### PR TITLE
fix(web): align the GitLab hook form with the GitHub trigger model

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
 /**
- * The GitLab trigger kind in the Add-integration wizard. Two things are worth a
- * regression test: the tile is absent — and the project list unrequested — while
- * the flag is off, and the create body carries exactly the stored vocabulary the
- * CP validates (`family:*` patterns, note families, labels, mention-only) keyed
- * by the project's numeric id rather than its renameable path.
+ * The GitLab trigger kind in the Add-integration wizard. Three things are worth
+ * a regression test: the tile is absent — and the project list unrequested —
+ * while the flag is off; each "Trigger when" choice compiles to exactly the
+ * stored vocabulary the CP validates (`family:*` patterns, note families,
+ * labels, mention-only) keyed by the project's numeric id rather than its
+ * renameable path; and pushes stay a per-push subscription across the cadence.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -57,6 +58,19 @@ const agent = {
   workspace: { mode: 'scratch' }
 } as unknown as Agent
 
+const project = {
+  id: 'binding-1',
+  projectId: '4210',
+  projectPath: 'acme/platform',
+  defaultBranch: 'main',
+  state: 'ready',
+  stateReason: null,
+  serviceAccountUsername: 'project_4210_bot',
+  webhookInstalled: true,
+  credentialEpoch: '1',
+  createdAt: '2026-08-01T00:00:00.000Z'
+}
+
 const setFlags = (value?: string) => {
   ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
     value === undefined ? {} : { FEATURE_FLAGS: value }
@@ -78,11 +92,18 @@ const tileNamed = (label: string) =>
   Array.from(document.querySelectorAll<HTMLDivElement>('.ptile')).find((tile) => tile.textContent === label)
 const clickText = (text: string) =>
   Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.includes(text))
-const checkbox = (label: string) => document.querySelector<HTMLInputElement>(`input[aria-label="${label}"]`)
+const family = (fam: string) => document.querySelector<HTMLDivElement>(`[data-gitlab-family="${fam}"]`)
+const trigger = (mode: string) => document.querySelector<HTMLDivElement>(`[data-gitlab-trigger="${mode}"]`)
 // React tracks the DOM value itself, so a plain assignment is invisible to onChange.
 function typeInto(input: HTMLInputElement, value: string) {
   Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(input, value)
   input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+async function pickProject() {
+  await act(async () => tileNamed('GitLab')?.click())
+  await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
+  await act(async () => clickText('acme/platform')?.click())
 }
 
 afterEach(async () => {
@@ -107,34 +128,55 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     expect(mocks.fetchGitlabProjects).not.toHaveBeenCalled()
   })
 
-  it('creates a gitlab hook from the chosen families, labels and mention mode', async () => {
+  it('defaults to the updated trigger, scoping replies to the selected subjects', async () => {
     setFlags('gitlab')
-    mocks.fetchGitlabProjects.mockResolvedValue([
-      {
-        id: 'binding-1',
-        projectId: '4210',
-        projectPath: 'acme/platform',
-        defaultBranch: 'main',
-        state: 'ready',
-        stateReason: null,
-        serviceAccountUsername: 'project_4210_bot',
-        webhookInstalled: true,
-        credentialEpoch: '1',
-        createdAt: '2026-08-01T00:00:00.000Z'
-      }
-    ])
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
-    await act(async () => tileNamed('GitLab')?.click())
-    await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
-    await act(async () => clickText('acme/platform')?.click())
+    await pickProject()
 
-    // Merge requests ride the default; add issues and drop the issue note family.
-    await act(async () => document.querySelector<HTMLDivElement>('[data-gitlab-family="issues"]')?.click())
-    await act(async () => checkbox('Comments in issues')?.click())
+    // No cadence click: the form opens on "updated", merge requests only.
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGitlabHook).toHaveBeenCalledWith({
+      agentId: 'agent-a',
+      name: 'acme/platform',
+      projectId: '4210',
+      events: ['merge_request:*'],
+      commentFamilies: ['merge_request'],
+      labelFilter: [],
+      mentionOnly: false
+    })
+  })
+
+  it('compiles the created trigger to openings with no note subscription', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    await render()
+    await pickProject()
+    await act(async () => family('issues')?.click())
+    await act(async () => trigger('first')?.click())
+
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGitlabHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: ['issues:opened', 'merge_request:opened'],
+        commentFamilies: [],
+        mentionOnly: false
+      })
+    )
+  })
+
+  it('compiles the mention-only trigger to the updated event set plus the flag', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    await render()
+    await pickProject()
+    await act(async () => family('issues')?.click())
+    await act(async () => trigger('mention')?.click())
     await act(async () =>
       typeInto(document.querySelector<HTMLInputElement>('input[aria-label="Label filter"]')!, 'needs-review, agent')
     )
-    await act(async () => checkbox('Mention only')?.click())
 
     await act(async () => clickText('Connect')?.click())
 
@@ -143,10 +185,40 @@ describe('AddIntegrationModal, GitLab trigger', () => {
       name: 'acme/platform',
       projectId: '4210',
       events: ['issues:*', 'merge_request:*'],
-      commentFamilies: ['merge_request'],
+      commentFamilies: ['issues', 'merge_request'],
       labelFilter: ['needs-review', 'agent'],
       mentionOnly: true
     })
+  })
+
+  it('keeps pushes a per-push subscription across the cadence, and says so', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    await render()
+    await pickProject()
+    await act(async () => family('merge_request')?.click())
+    await act(async () => family('push')?.click())
+
+    expect(document.body.textContent).toContain('created and updated behave the same')
+
+    await act(async () => trigger('first')?.click())
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGitlabHook).toHaveBeenCalledWith(
+      expect.objectContaining({ events: ['push:*'], commentFamilies: [], mentionOnly: false })
+    )
+  })
+
+  it('drops the separate comments row and mention checkbox the form used to expose', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    await render()
+    await pickProject()
+
+    expect(document.body.textContent).toContain('Listen for')
+    expect(document.body.textContent).toContain('Trigger when')
+    expect(document.body.textContent).not.toContain('Also run on comments in')
+    expect(document.querySelector('input[aria-label="Mention only"]')).toBeNull()
   })
 
   it('keeps the GitLab tile enabled on a placed daemon that advertises no such adapter', async () => {

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -59,7 +59,6 @@ import {
   type CreatedHookDto,
   type GithubInstallationDto,
   type GithubRepoDto,
-  type GitlabCommentFamily,
   type GitlabProjectBindingDto,
   type RepoAccess
 } from '@/lib/api'
@@ -76,12 +75,17 @@ import {
   type GhTriggerMode
 } from '@/lib/github-events'
 import {
-  GL_COMMENT_FAMILIES,
   GL_DEFAULT_FAMILIES,
+  GL_DEFAULT_TRIGGER_MODE,
   GL_FAMILIES,
+  GL_TRIGGER_LABEL,
+  commentFamiliesForGitlabFamilies,
   eventsForGitlabFamilies,
+  gitlabMentionUsage,
+  gitlabPushCadenceNote,
   parseLabelFilter,
-  type GlFamily
+  type GlFamily,
+  type GlTriggerMode
 } from '@/lib/gitlab-events'
 import { gitlabProjectSelectable, matchGitlabProjects } from '@/lib/gitlab-projects'
 import {
@@ -150,6 +154,21 @@ const GH_TRIGGER_TILES: { mode: GhTriggerMode; label: string; desc: string }[] =
   {
     mode: 'mention',
     label: GH_TRIGGER_LABEL.mention,
+    desc: 'Only when @-mentioned.'
+  }
+]
+
+/** The GitLab cadences — the same three choices, worded like GitHub's. */
+const GL_TRIGGER_TILES: { mode: GlTriggerMode; label: string; desc: string }[] = [
+  { mode: 'first', label: GL_TRIGGER_LABEL.first, desc: 'When opened, plus later @mentions.' },
+  {
+    mode: 'every',
+    label: GL_TRIGGER_LABEL.every,
+    desc: 'Updates, plus replies for selected issues and MRs.'
+  },
+  {
+    mode: 'mention',
+    label: GL_TRIGGER_LABEL.mention,
     desc: 'Only when @-mentioned.'
   }
 ]
@@ -350,9 +369,8 @@ export default function AddIntegrationModal({
   const [glOpen, setGlOpen] = useState(false)
   const [glQ, setGlQ] = useState('')
   const [glFams, setGlFams] = useState<Set<GlFamily>>(new Set(GL_DEFAULT_FAMILIES))
-  const [glComments, setGlComments] = useState<Set<GitlabCommentFamily>>(new Set(['issues', 'merge_request']))
+  const [glMode, setGlMode] = useState<GlTriggerMode>(GL_DEFAULT_TRIGGER_MODE)
   const [glLabels, setGlLabels] = useState('')
-  const [glMentionOnly, setGlMentionOnly] = useState(false)
 
   // Reusing a bot is an advanced path; every platform opens on the create flow
   // until the user explicitly chooses an existing identity.
@@ -752,15 +770,6 @@ export default function AddIntegrationModal({
     })
   }
 
-  const toggleGlComment = (fam: GitlabCommentFamily) => {
-    setGlComments((prev) => {
-      const next = new Set(prev)
-      if (next.has(fam)) next.delete(fam)
-      else next.add(fam)
-      return next
-    })
-  }
-
   const authorizeSelectedRepo = async () => {
     if (!ghRepoPick || ghAccessSaving) return
     if (ghSelectedIsWorkspace) {
@@ -839,10 +848,10 @@ export default function AddIntegrationModal({
         agentId: agent.id,
         name: glPicked?.projectPath ?? glProject,
         projectId: glProject,
-        events: eventsForGitlabFamilies(glFams),
-        commentFamilies: [...glComments],
+        events: eventsForGitlabFamilies(glFams, glMode),
+        commentFamilies: commentFamiliesForGitlabFamilies(glFams, glMode),
         labelFilter: parseLabelFilter(glLabels),
-        mentionOnly: glMentionOnly
+        mentionOnly: glMode === 'mention'
       })
       onClose()
     } catch (e) {
@@ -1726,31 +1735,45 @@ export default function AddIntegrationModal({
                     )
                   })}
                 </div>
-                <div className="fldlbl mb-2">Also run on comments in</div>
-                <div className="mb-4 grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-2">
-                  {GL_COMMENT_FAMILIES.map((r) => {
-                    const on = glComments.has(r.fam)
+                <div className="fldlbl mb-2">Trigger when</div>
+                <div
+                  className={`grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-3 ${glFams.has('push') ? 'mb-2' : 'mb-4'}`}
+                >
+                  {GL_TRIGGER_TILES.map((m) => {
+                    const on = glMode === m.mode
                     return (
-                      <label
-                        key={r.fam}
-                        className={`flex min-w-0 cursor-pointer items-center gap-2.5 rounded-[9px] border px-3 py-[10px] ${
+                      <div
+                        key={m.mode}
+                        data-gitlab-trigger={m.mode}
+                        title={m.mode === 'mention' ? gitlabMentionUsage(agent.name) : undefined}
+                        className={`flex min-w-0 cursor-pointer items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
                           on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'
                         }`}
+                        onClick={() => setGlMode(m.mode)}
                       >
-                        <input
-                          type="checkbox"
-                          className="flex-none accent-(--brand)"
-                          checked={on}
-                          aria-label={`Comments in ${r.label.toLowerCase()}`}
-                          onChange={() => toggleGlComment(r.fam)}
-                        />
-                        <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-                          {r.label}
+                        <span
+                          className={`mt-[1px] flex h-4 w-4 flex-none items-center justify-center rounded-full border-[1.5px] bg-(--surface-card) ${
+                            on ? 'border-(--brand)' : 'border-(--border-default)'
+                          }`}
+                        >
+                          {on && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
                         </span>
-                      </label>
+                        <span className="min-w-0 flex-1">
+                          <span className="block font-sans text-[12.5px] font-semibold leading-normal">{m.label}</span>
+                          <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                            {m.desc}
+                          </span>
+                        </span>
+                      </div>
                     )
                   })}
                 </div>
+                {/* Pushes reach the cadence only through mention-only's commit-message gate. */}
+                {glFams.has('push') && (
+                  <div className="mb-4 font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-tertiary)">
+                    {gitlabPushCadenceNote(agent.name)}
+                  </div>
+                )}
                 <div className="fld mb-4">
                   <span className="fldlbl">Only these labels (optional)</span>
                   <input
@@ -1764,21 +1787,6 @@ export default function AddIntegrationModal({
                     Comma separated. Empty means every issue and merge request.
                   </span>
                 </div>
-                <label className="mb-4 flex cursor-pointer items-start gap-2.5 rounded-[9px] border border-(--border-default) bg-(--surface-card) px-3 py-[10px]">
-                  <input
-                    type="checkbox"
-                    className="mt-[2px] flex-none accent-(--brand)"
-                    checked={glMentionOnly}
-                    aria-label="Mention only"
-                    onChange={(e) => setGlMentionOnly(e.target.checked)}
-                  />
-                  <span className="min-w-0 flex-1">
-                    <span className="block font-sans text-[12.5px] font-semibold leading-normal">Mention only</span>
-                    <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-                      Run only when the text mentions @{agent.name}.
-                    </span>
-                  </span>
-                </label>
               </>
             )}
           </>

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -36,7 +36,6 @@ import {
   updateGitlabHook,
   uploadAgentIcon,
   type GithubInstallationDto,
-  type GitlabCommentFamily,
   type HookDto,
   type HookRunDto
 } from '@/lib/api'
@@ -69,7 +68,21 @@ import { AgentMark, GithubMark, GitlabMark, LoadingState, PlatformMark } from '@
 import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import type { Platform } from '@/components/console/modals/AddIntegrationModal'
 import { INTEGRATION_BLURB, isCoreTriggerKind, offeredPlatforms } from '@/components/console/platforms/host-projections'
-import { GL_FAMILIES, eventsForGitlabFamilies, gitlabFamCovered, type GlFamily } from '@/lib/gitlab-events'
+import {
+  GL_FAMILIES,
+  GL_TRIGGER_MODES,
+  GL_TRIGGER_PILL,
+  commentFamiliesForGitlabFamilies,
+  eventsForGitlabFamilies,
+  gitlabCadencePick,
+  gitlabFamCovered,
+  gitlabFamilyToggle,
+  gitlabHookNeedsNormalization,
+  gitlabTriggerModeOf,
+  gitlabTriggerTooltip,
+  type GlFamily,
+  type GlTriggerMode
+} from '@/lib/gitlab-events'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
 import { BuiltinBadge } from '@/components/console/BuiltinBadge'
 import { NotFound } from '@/components/console/NotFound'
@@ -381,14 +394,10 @@ export default function AgentDetailView() {
       setHookBusy(null)
     }
   }
-  // The GitLab counterpart: subject families only, no cadence axis and no review
-  // knobs — the M6 review slice adds those, and the row must not imply them yet.
-  const toggleGitlabHookFam = async (h: HookDto, fam: GlFamily) => {
+  // The GitLab counterpart of saveHookEvents — same two axes, no review knobs
+  // yet (the M6 slice adds those, and the row must not imply them).
+  const saveGitlabHookEvents = async (h: HookDto, families: GlFamily[], mode: GlTriggerMode) => {
     if (hookBusy || !h.agentId || !h.repoId) return
-    const families = GL_FAMILIES.map((f) => f.fam).filter((f) =>
-      f === fam ? !gitlabFamCovered(h.events, f) : gitlabFamCovered(h.events, f)
-    )
-    if (families.length === 0) return // at least one family must stay subscribed
     setHookBusy(h.id)
     try {
       const updated = await updateGitlabHook(h.id, {
@@ -396,12 +405,10 @@ export default function AgentDetailView() {
         name: h.name,
         enabled: h.enabled,
         projectId: h.repoId,
-        events: eventsForGitlabFamilies(families),
-        commentFamilies: h.commentFamilies.filter(
-          (family): family is GitlabCommentFamily => family === 'issues' || family === 'merge_request'
-        ),
+        events: eventsForGitlabFamilies(families, mode),
+        commentFamilies: commentFamiliesForGitlabFamilies(families, mode),
         labelFilter: h.labelFilter,
-        mentionOnly: h.mentionOnly
+        mentionOnly: mode === 'mention'
       })
       void mutateHooks((rows) => rows?.map((r) => (r.id === h.id ? updated : r)), { revalidate: false })
     } catch {
@@ -409,6 +416,15 @@ export default function AgentDetailView() {
     } finally {
       setHookBusy(null)
     }
+  }
+  // Pure helpers decide both edits: the toggle refuses to drop the last family, and the cadence pick refuses a no-op write, which is what leaves an inexpressible stored rule untouched.
+  const toggleGitlabHookFam = async (h: HookDto, fam: GlFamily) => {
+    const edit = gitlabFamilyToggle(h, fam)
+    if (edit) await saveGitlabHookEvents(h, edit.families, edit.mode)
+  }
+  const setGitlabHookCadence = async (h: HookDto, mode: GlTriggerMode) => {
+    const edit = gitlabCadencePick(h, mode)
+    if (edit) await saveGitlabHookEvents(h, edit.families, edit.mode)
   }
   const toggleHookFam = async (h: HookDto, fam: GhFamily) => {
     const fams = GH_FAMILIES.map((f) => f.fam).filter((f) =>
@@ -1380,7 +1396,7 @@ export default function AgentDetailView() {
                           {GL_FAMILIES.filter((f) => gitlabFamCovered(h.events, f.fam))
                             .map((f) => f.pill)
                             .join(' · ') || 'no events'}
-                          {h.mentionOnly ? ' · @-mention only' : ''}
+                          {` · ${GL_TRIGGER_PILL[gitlabTriggerModeOf(h)]}`}
                         </span>
                       </span>
                       <span className="inline-flex flex-none items-center gap-[5px] rounded-full bg-(--surface-active) px-[10px] py-[3px] font-sans text-[12px] font-semibold leading-normal text-(--text-tertiary)">
@@ -1653,9 +1669,12 @@ export default function AgentDetailView() {
                               <span className="mono min-w-[90px] flex-1 truncate text-[12px] text-(--text-primary)">
                                 {h.repoFullName ?? h.name}
                               </span>
-                              {h.mentionOnly && (
-                                <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">
-                                  @-mention only
+                              {gitlabHookNeedsNormalization(h) && (
+                                <span
+                                  className="badge flex-none bg-(--surface-active) text-(--text-tertiary)"
+                                  title="The stored subscription matches no trigger exactly — the nearest one is shown. Picking a trigger replaces it."
+                                >
+                                  custom rule
                                 </span>
                               )}
                               <div className="ml-auto inline-flex flex-none gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) p-[2px]">
@@ -1678,6 +1697,32 @@ export default function AgentDetailView() {
                                   )
                                 })}
                               </div>
+                              {/* Trigger bar — the same segmented control the GitHub rows carry. */}
+                              <span className="inline-flex flex-none items-center gap-[7px]">
+                                <span title="Trigger — when this agent runs" className="flex-none leading-none">
+                                  <Icon name="zap" size={14} color="var(--text-tertiary)" />
+                                </span>
+                                <div className="inline-flex gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px]">
+                                  {GL_TRIGGER_MODES.map((mode) => {
+                                    const active = gitlabTriggerModeOf(h) === mode
+                                    return (
+                                      <button
+                                        key={mode}
+                                        onClick={() => void setGitlabHookCadence(h, mode)}
+                                        disabled={hookBusy === h.id}
+                                        title={gitlabTriggerTooltip(mode, da.name)}
+                                        className={`cursor-pointer rounded-[7px] border-0 px-3 py-[5px] font-sans text-[12.5px] leading-normal ${
+                                          active
+                                            ? 'bg-(--surface-card) font-semibold text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]'
+                                            : 'bg-transparent font-normal text-(--text-tertiary)'
+                                        } ${hookBusy === h.id ? 'opacity-60' : ''}`}
+                                      >
+                                        {GL_TRIGGER_PILL[mode]}
+                                      </button>
+                                    )
+                                  })}
+                                </div>
+                              </span>
                               <span className="inline-flex flex-none gap-[2px]">
                                 <button
                                   className="iconbtn h-[26px] w-[26px] flex-none"

--- a/packages/web/src/lib/gitlab-events.test.ts
+++ b/packages/web/src/lib/gitlab-events.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GL_DEFAULT_TRIGGER_MODE,
+  GL_FAMILIES,
+  GL_TRIGGER_LABEL,
+  GL_TRIGGER_MODES,
+  GL_TRIGGER_PILL,
+  commentFamiliesForGitlabFamilies,
+  eventsForGitlabFamilies,
+  gitlabCadencePick,
+  gitlabFamilyToggle,
+  gitlabHookNeedsNormalization,
+  gitlabPushCadenceNote,
+  gitlabTriggerModeOf,
+  gitlabTriggerTooltip,
+  parseGitlabHookThread,
+  parseLabelFilter
+} from './gitlab-events'
+
+describe('GL_TRIGGER_LABEL', () => {
+  it('speaks the same vocabulary as the GitHub form', () => {
+    expect(GL_TRIGGER_LABEL.first).toBe('created')
+    expect(GL_TRIGGER_LABEL.every).toBe('updated')
+    expect(GL_TRIGGER_LABEL.mention).toBe('mention only')
+  })
+
+  it('defaults new subscriptions to updated mode', () => {
+    expect(GL_DEFAULT_TRIGGER_MODE).toBe('every')
+    expect(GL_TRIGGER_LABEL[GL_DEFAULT_TRIGGER_MODE]).toBe('updated')
+  })
+})
+
+describe('GL_TRIGGER_PILL', () => {
+  it('keeps mention as the last segment, worded like the IM bar', () => {
+    expect(GL_TRIGGER_MODES[GL_TRIGGER_MODES.length - 1]).toBe('mention')
+    expect(GL_TRIGGER_PILL.mention).toBe('@-mention')
+  })
+
+  it('names the agent in the per-segment hover copy', () => {
+    expect(gitlabTriggerTooltip('first', 'reviewer')).toContain('@reviewer')
+    expect(gitlabTriggerTooltip('mention', 'reviewer')).toContain('@reviewer')
+    expect(gitlabTriggerTooltip('every', 'reviewer')).not.toContain('@')
+  })
+
+  it('admits the service-account broadcast and reviewer requests, without an absolute "only"', () => {
+    const copy = gitlabTriggerTooltip('mention', 'reviewer')
+    expect(copy).toContain('service account')
+    expect(copy).toContain('reviewer request')
+    expect(copy).not.toMatch(/\bonly\b/)
+  })
+})
+
+describe('GL_FAMILIES', () => {
+  it('keeps the third GitLab subject and describes each like the GitHub tiles', () => {
+    expect(GL_FAMILIES.map(({ fam }) => fam)).toEqual(['issues', 'merge_request', 'push'])
+    expect(GL_FAMILIES.find(({ fam }) => fam === 'issues')?.desc).toBe('opened, labels, replies')
+    expect(GL_FAMILIES.find(({ fam }) => fam === 'merge_request')?.desc).toBe('opened, new commits, replies')
+    expect(GL_FAMILIES.find(({ fam }) => fam === 'push')?.desc).toBe('commits pushed to a branch')
+  })
+})
+
+describe('eventsForGitlabFamilies', () => {
+  it('subscribes created mode to thread openings while leaving push as a wildcard', () => {
+    expect(eventsForGitlabFamilies(['issues', 'merge_request', 'push'], 'first')).toEqual([
+      'issues:opened',
+      'merge_request:opened',
+      'push:*'
+    ])
+  })
+
+  it('widens updated mode to every supported action', () => {
+    expect(eventsForGitlabFamilies(['issues', 'merge_request', 'push'], 'every')).toEqual([
+      'issues:*',
+      'merge_request:*',
+      'push:*'
+    ])
+  })
+
+  it('uses the same event subscriptions for mention and updated modes', () => {
+    expect(eventsForGitlabFamilies(['issues', 'push'], 'mention')).toEqual(
+      eventsForGitlabFamilies(['issues', 'push'], 'every')
+    )
+  })
+
+  it('emits display order regardless of the order the boxes were ticked', () => {
+    expect(eventsForGitlabFamilies(['push', 'merge_request', 'issues'], 'every')).toEqual([
+      'issues:*',
+      'merge_request:*',
+      'push:*'
+    ])
+  })
+})
+
+describe('commentFamiliesForGitlabFamilies', () => {
+  it('clears the note subscription in created mode — a reply then needs a summon', () => {
+    expect(commentFamiliesForGitlabFamilies(['issues', 'merge_request'], 'first')).toEqual([])
+  })
+
+  it('scopes replies to the selected thread families in updated and mention modes', () => {
+    expect(commentFamiliesForGitlabFamilies(['merge_request', 'push'], 'every')).toEqual(['merge_request'])
+    expect(commentFamiliesForGitlabFamilies(['issues', 'merge_request'], 'mention')).toEqual([
+      'issues',
+      'merge_request'
+    ])
+  })
+
+  it('returns an empty scope for a push-only subscription', () => {
+    expect(commentFamiliesForGitlabFamilies(['push'], 'every')).toEqual([])
+  })
+})
+
+describe('gitlabTriggerModeOf', () => {
+  it('reads the stored encoding back into the displayed trigger', () => {
+    expect(gitlabTriggerModeOf({ events: ['merge_request:opened'], mentionOnly: false })).toBe('first')
+    expect(gitlabTriggerModeOf({ events: ['merge_request:*'], mentionOnly: false })).toBe('every')
+    expect(gitlabTriggerModeOf({ events: ['merge_request:*'], mentionOnly: true })).toBe('mention')
+  })
+
+  it('lets the mentionOnly flag win over an opened-cadence encoding', () => {
+    expect(gitlabTriggerModeOf({ events: ['issues:opened'], mentionOnly: true })).toBe('mention')
+  })
+
+  it('reads a push-only subscription as updated — pushes carry no opening', () => {
+    expect(gitlabTriggerModeOf({ events: ['push:*'], mentionOnly: false })).toBe('every')
+  })
+})
+
+describe('gitlabHookNeedsNormalization', () => {
+  it('accepts every canonical console encoding', () => {
+    expect(
+      gitlabHookNeedsNormalization({
+        events: ['merge_request:*'],
+        commentFamilies: ['merge_request'],
+        mentionOnly: false
+      })
+    ).toBe(false)
+    expect(
+      gitlabHookNeedsNormalization({ events: ['merge_request:opened'], commentFamilies: [], mentionOnly: false })
+    ).toBe(false)
+    expect(gitlabHookNeedsNormalization({ events: ['push:*'], commentFamilies: [], mentionOnly: false })).toBe(false)
+  })
+
+  it('flags a comment scope narrower than the subject selection', () => {
+    expect(
+      gitlabHookNeedsNormalization({
+        events: ['issues:*', 'merge_request:*'],
+        commentFamilies: ['issues'],
+        mentionOnly: false
+      })
+    ).toBe(true)
+  })
+
+  it('flags a created-cadence rule that still subscribes to replies', () => {
+    expect(
+      gitlabHookNeedsNormalization({
+        events: ['merge_request:opened'],
+        commentFamilies: ['merge_request'],
+        mentionOnly: false
+      })
+    ).toBe(true)
+  })
+
+  it('flags a finer family:action pattern no radio state emits', () => {
+    expect(
+      gitlabHookNeedsNormalization({
+        events: ['merge_request:synchronize'],
+        commentFamilies: ['merge_request'],
+        mentionOnly: false
+      })
+    ).toBe(true)
+  })
+
+  it('leaves a note-only rule outside the console normalization model', () => {
+    expect(gitlabHookNeedsNormalization({ events: [], commentFamilies: ['issues'], mentionOnly: false })).toBe(false)
+  })
+})
+
+describe('gitlabPushCadenceNote', () => {
+  it('says the cadence reaches pushes only through the mention gate', () => {
+    const note = gitlabPushCadenceNote('reviewer')
+    expect(note).toContain('created and updated behave the same')
+    expect(note).toContain('commit message')
+    expect(note).toContain('reviewer')
+  })
+})
+
+describe('parseLabelFilter', () => {
+  it('trims, drops blanks and de-duplicates', () => {
+    expect(parseLabelFilter(' needs-review , agent, ,needs-review ')).toEqual(['needs-review', 'agent'])
+  })
+})
+
+describe('parseGitlabHookThread', () => {
+  it('names a rerunnable subject but never a branch', () => {
+    expect(parseGitlabHookThread('gitlab:4210:merge_request:17')).toEqual({ kind: 'merge_request', iid: 17 })
+    expect(parseGitlabHookThread('gitlab:4210:push:refs/heads/main')).toBeNull()
+  })
+})
+
+describe('gitlabFamilyToggle', () => {
+  const updatedMr = { events: ['merge_request:*'], mentionOnly: false }
+
+  it('adds and removes a subject while carrying the stored cadence along', () => {
+    expect(gitlabFamilyToggle(updatedMr, 'issues')).toEqual({ families: ['issues', 'merge_request'], mode: 'every' })
+    expect(gitlabFamilyToggle({ events: ['issues:opened', 'push:*'], mentionOnly: false }, 'push')).toEqual({
+      families: ['issues'],
+      mode: 'first'
+    })
+  })
+
+  it('refuses to unsubscribe the last remaining subject', () => {
+    expect(gitlabFamilyToggle(updatedMr, 'merge_request')).toBeNull()
+  })
+})
+
+describe('gitlabCadencePick', () => {
+  const canonicalUpdated = {
+    events: ['merge_request:*'],
+    commentFamilies: ['merge_request'] as const,
+    mentionOnly: false
+  }
+  // Replies on issues but not merge requests: no radio state encodes it.
+  const nonCollapsing = {
+    events: ['issues:*', 'merge_request:*'],
+    commentFamilies: ['issues'] as const,
+    mentionOnly: false
+  }
+
+  it('writes nothing when the displayed cadence is picked on a canonical rule', () => {
+    expect(gitlabCadencePick(canonicalUpdated, 'every')).toBeNull()
+  })
+
+  it('rewrites the whole block when a different cadence is picked', () => {
+    expect(gitlabCadencePick(canonicalUpdated, 'first')).toEqual({ families: ['merge_request'], mode: 'first' })
+    expect(gitlabCadencePick(canonicalUpdated, 'mention')).toEqual({ families: ['merge_request'], mode: 'mention' })
+  })
+
+  it('leaves a rule the trigger cannot express alone until a cadence is picked', () => {
+    // Displaying it must not rewrite it — but the nearest state is still shown,
+    // and re-picking that same state is the explicit opt-in that normalizes.
+    expect(gitlabTriggerModeOf(nonCollapsing)).toBe('every')
+    expect(gitlabHookNeedsNormalization(nonCollapsing)).toBe(true)
+    expect(gitlabCadencePick(nonCollapsing, 'every')).toEqual({
+      families: ['issues', 'merge_request'],
+      mode: 'every'
+    })
+  })
+
+  it('never invents a subject the stored rule did not watch', () => {
+    expect(gitlabCadencePick({ events: ['push:*'], commentFamilies: [], mentionOnly: false }, 'mention')).toEqual({
+      families: ['push'],
+      mode: 'mention'
+    })
+  })
+})

--- a/packages/web/src/lib/gitlab-events.ts
+++ b/packages/web/src/lib/gitlab-events.ts
@@ -1,50 +1,198 @@
 /**
  * GitLab subscription vocabulary, the counterpart of `github-events.ts`.
  *
- * The console works in SUBJECT families (issues / merge requests / pushes) and,
- * independently, in NOTE families — which conversations a reply may fire the
- * agent from. Both are stored plainly: a subject family becomes a `family:*`
- * pattern, a note family stays in `commentFamilies`, and `mentionOnly` narrows
- * every one of them to authored text that @-mentions the agent.
+ * The console presents the same two axes GitHub does: SUBJECT families (issues
+ * / merge requests / pushes) plus one TRIGGER MODE. The stored `events`
+ * patterns, `commentFamilies` and the `mentionOnly` flag encode both:
+ *
+ *   created  → `family:opened` for the thread families and NO note family; the
+ *              relay additionally accepts a later explicit @mention in an
+ *              `:opened`-cadence thread family. Pushes have no "first" — a push
+ *              subscription is inherently per-push, so `push:*` rides along.
+ *   updated  → `family:*` plus the selected thread families as note families,
+ *              so replies fire too. Close, reopen, merge and draft toggles stay
+ *              inert; supported updates and replies run.
+ *   mention only → the same subscriptions as updated, with `mentionOnly: true` —
+ *              an event fires ONLY when its text (issue/MR description, note
+ *              body, commit message) @-mentions the agent or the project's
+ *              service account. The agent handle targets one rule; the service
+ *              account handle broadcasts. Assigning the service account as a
+ *              reviewer bypasses the gate entirely.
+ *
+ * One asymmetry with GitHub is deliberate: there, `commentFamilies` only
+ * NARROWS a shared `issue_comment` subscription, so it may stay populated in
+ * created mode. Here it is the note subscription itself, so created mode must
+ * clear it or every reply would fire.
  *
  * The wire accepts finer `family:action` patterns; these helpers never emit one.
  */
 
-import type { GitlabCommentFamily } from './api'
+import type { GitlabCommentFamily, HookCommentFamily } from './api'
 
 export type GlFamily = 'issues' | 'merge_request' | 'push'
+export type GlTriggerMode = 'first' | 'every' | 'mention'
 
+// `desc` is the Add-integration tile subtitle — keep it to a short fragment
+// naming signals the relay really forwards, on one or two 11.5px lines.
 export const GL_FAMILIES: { fam: GlFamily; pill: string; icon: string; label: string; desc: string }[] = [
-  { fam: 'issues', pill: 'Issues', icon: 'circle-dot', label: 'Issues', desc: 'opened, updated, labelled' },
+  { fam: 'issues', pill: 'Issues', icon: 'circle-dot', label: 'Issues', desc: 'opened, labels, replies' },
   {
     fam: 'merge_request',
     pill: 'MRs',
     icon: 'git-pull-request',
     label: 'Merge requests',
-    desc: 'opened, updated, merged'
+    desc: 'opened, new commits, replies'
   },
   { fam: 'push', pill: 'Pushes', icon: 'git-commit-horizontal', label: 'Pushes', desc: 'commits pushed to a branch' }
 ]
 
-/** The note families a reply can arrive on — pushes carry no conversation. */
-export const GL_COMMENT_FAMILIES: { fam: GitlabCommentFamily; label: string }[] = [
-  { fam: 'issues', label: 'Issues' },
-  { fam: 'merge_request', label: 'Merge requests' }
-]
+/** The trigger modes in display order — mention deliberately last. */
+export const GL_TRIGGER_MODES: readonly GlTriggerMode[] = ['first', 'every', 'mention']
+/** The Add-integration cadence tiles' vocabulary ("Trigger when …"). */
+export const GL_TRIGGER_LABEL: Record<GlTriggerMode, string> = {
+  first: 'created',
+  every: 'updated',
+  mention: 'mention only'
+}
+/** The agent-detail trigger bar's segment vocabulary, worded like the IM bar. */
+export const GL_TRIGGER_PILL: Record<GlTriggerMode, string> = {
+  first: 'create',
+  every: 'update',
+  mention: '@-mention'
+}
+
+/** Per-segment hover copy for the trigger bar. */
+export function gitlabTriggerTooltip(mode: GlTriggerMode, agentName: string): string {
+  switch (mode) {
+    case 'first':
+      return `Runs when an issue or merge request opens, plus later @${agentName} mentions.`
+    case 'every':
+      return 'Runs when an issue or merge request is opened and on supported updates and replies (close, reopen and merge are ignored).'
+    case 'mention':
+      // Not "only @agent": the service-account handle is the project-wide
+      // broadcast, and assigning it as a reviewer bypasses cadence and mention.
+      return `Runs when @${agentName} or the project's service account is mentioned, and on explicit reviewer requests.`
+  }
+}
+
+/** Concrete hover copy for the agent-targeted GitLab mention form. */
+export function gitlabMentionUsage(agentName: string): string {
+  return `Use @${agentName} to trigger only this agent.`
+}
+
+/** Pushes carry no conversation and no "first" — the cadence never narrows them. */
+export function gitlabPushCadenceNote(agentName: string): string {
+  return `Pushes run once per push, so created and updated behave the same for them; mention only still needs the commit message to @-mention ${agentName}.`
+}
 
 /** The default create-form selection: merge requests only. */
 export const GL_DEFAULT_FAMILIES: readonly GlFamily[] = ['merge_request']
 
-/** Compile the console's family choice into stored event patterns, in display
- *  order — a hook's stored events must not depend on the order boxes were ticked. */
-export function eventsForGitlabFamilies(families: Iterable<GlFamily>): string[] {
+/** The default create-form cadence: react to issue or merge-request updates. */
+export const GL_DEFAULT_TRIGGER_MODE: GlTriggerMode = 'every'
+
+/** Narrow a stored cross-host comment scope to the GitLab families a gitlab hook may carry. */
+export function gitlabCommentFamilies(families: readonly HookCommentFamily[]): GitlabCommentFamily[] {
+  return families.filter((family): family is GitlabCommentFamily => family === 'issues' || family === 'merge_request')
+}
+
+/** The note families replies may arrive on — empty in created mode, where a
+ *  reply fires only by summoning the agent in an already-opened thread. */
+export function commentFamiliesForGitlabFamilies(
+  families: Iterable<GlFamily>,
+  mode: GlTriggerMode
+): GitlabCommentFamily[] {
+  if (mode === 'first') return []
   const picked = new Set(families)
-  return GL_FAMILIES.filter((family) => picked.has(family.fam)).map((family) => `${family.fam}:*`)
+  return GL_FAMILIES.map((entry) => entry.fam).filter(
+    (family): family is GitlabCommentFamily => family !== 'push' && picked.has(family)
+  )
+}
+
+/** Compile the console's family+mode choice into stored event patterns, in
+ *  display order — a hook's stored events must not depend on the order boxes
+ *  were ticked. */
+export function eventsForGitlabFamilies(families: Iterable<GlFamily>, mode: GlTriggerMode): string[] {
+  const picked = new Set(families)
+  return GL_FAMILIES.filter((entry) => picked.has(entry.fam)).map((entry) =>
+    mode === 'first' && entry.fam !== 'push' ? `${entry.fam}:opened` : `${entry.fam}:*`
+  )
 }
 
 /** Whether a hook's stored events cover a family (any action pattern counts). */
 export function gitlabFamCovered(events: readonly string[], family: GlFamily): boolean {
   return events.some((event) => event.startsWith(`${family}:`))
+}
+
+/** Recover the trigger mode: the mentionOnly flag wins, `:opened` ⇒ created. */
+export function gitlabTriggerModeOf(hook: { events: readonly string[]; mentionOnly: boolean }): GlTriggerMode {
+  if (hook.mentionOnly) return 'mention'
+  return hook.events.some((event) => event.endsWith(':opened')) ? 'first' : 'every'
+}
+
+function sameMembers(actual: readonly string[], expected: readonly string[]): boolean {
+  const actualSet = new Set(actual)
+  const expectedSet = new Set(expected)
+  return actualSet.size === expectedSet.size && [...actualSet].every((value) => expectedSet.has(value))
+}
+
+/** Whether a persisted hook differs from the canonical console encoding — a
+ *  stored rule the three-way trigger cannot express (say, replies on issues but
+ *  not merge requests, or a finer `family:action` pattern an API caller wrote).
+ *  Such a rule is never rewritten implicitly: the console shows the nearest
+ *  trigger and flags the difference, and only an explicit cadence pick
+ *  normalizes it — including a pick of the cadence already displayed. */
+export function gitlabHookNeedsNormalization(hook: {
+  events: readonly string[]
+  commentFamilies: readonly HookCommentFamily[]
+  mentionOnly: boolean
+}): boolean {
+  const families = gitlabFamiliesOf(hook.events)
+  // A note-only rule has no console family to normalize into and must remain
+  // untouched even if the user reselects the displayed cadence.
+  if (families.length === 0) return false
+  const mode = gitlabTriggerModeOf(hook)
+  return (
+    !sameMembers(hook.events, eventsForGitlabFamilies(families, mode)) ||
+    !sameMembers(gitlabCommentFamilies(hook.commentFamilies), commentFamiliesForGitlabFamilies(families, mode))
+  )
+}
+
+/** One edit-path write: the whole subscription block the row must PUT. */
+export interface GitlabSubscriptionEdit {
+  families: GlFamily[]
+  mode: GlTriggerMode
+}
+
+/** The stored subject families, in display order. */
+function gitlabFamiliesOf(events: readonly string[]): GlFamily[] {
+  return GL_FAMILIES.map((entry) => entry.fam).filter((family) => gitlabFamCovered(events, family))
+}
+
+/** A subject toggle on an existing hook — null when it would leave the hook
+ *  watching nothing. The stored cadence rides along unchanged; a rule the radio
+ *  cannot express is normalized, because the toggle is an explicit edit. */
+export function gitlabFamilyToggle(
+  hook: { events: readonly string[]; mentionOnly: boolean },
+  fam: GlFamily
+): GitlabSubscriptionEdit | null {
+  const families = GL_FAMILIES.map((entry) => entry.fam).filter((family) =>
+    family === fam ? !gitlabFamCovered(hook.events, family) : gitlabFamCovered(hook.events, family)
+  )
+  if (families.length === 0) return null
+  return { families, mode: gitlabTriggerModeOf(hook) }
+}
+
+/** A cadence pick on an existing hook — null when nothing would change, which
+ *  is what keeps a stored rule the radio cannot express from being rewritten by
+ *  the mere act of displaying it. Re-picking the DISPLAYED cadence on such a
+ *  rule does write: that is the explicit opt-in that normalizes it. */
+export function gitlabCadencePick(
+  hook: { events: readonly string[]; commentFamilies: readonly HookCommentFamily[]; mentionOnly: boolean },
+  mode: GlTriggerMode
+): GitlabSubscriptionEdit | null {
+  if (mode === gitlabTriggerModeOf(hook) && !gitlabHookNeedsNormalization(hook)) return null
+  return { families: gitlabFamiliesOf(hook.events), mode }
 }
 
 /** Split a comma or whitespace separated label filter into the stored array. */


### PR DESCRIPTION
## What

User feedback: the GitLab hook form exposed its wire fields directly — a separate "Also run on comments in" row and a standalone "Mention only" checkbox — where GitHub presents one "Trigger when" choice. The form now shares GitHub's shape.

- **Add flow**: subject cards (Issues / Merge requests / Pushes, subtitles matching GitHub's wording where the relay semantics agree) plus GitHub's created / updated / mention-only radio tiles, mapped onto the same stored fields. The mapping was derived from the relay's actual matcher: `created` clears the comment families (on GitLab they ARE the note subscription, unlike GitHub where they only narrow one — the created-cadence @mention summon still works through the relay's opened-thread branch), `updated` subscribes the fuller set plus replies for the selected subjects, `mention only` is `updated` plus the flag.
- **Pushes** ride "Listen for" only, like GitHub's push special case; mention-only coherently gates on commit messages, and a hint line under the radio says so whenever Pushes is selected.
- **Edit flow** (agent detail): GitLab hook rows gain GitHub's segmented trigger bar, desktop and mobile. A stored config the radio cannot express is mapped to the nearest state without being rewritten — GitHub's normalization-on-explicit-pick pattern — and additionally surfaced with a "custom rule" badge whose tooltip explains that picking a trigger replaces it.
- The labels filter stays as the one extra row (the GitLab wire supports it; GitHub has no equivalent), repositioned below the radio.

One deliberate behavior change beyond presentation: a newly created hook's reply scope now derives from the subject selection (a merge-request-only hook stores merge-request comment families only), which is the point of the alignment.

## Tests

New `gitlab-events` unit suite (30 tests) for the mode mapping, round-trip classification, normalization predicate, and the pure edit helpers; the modal suite extended to eight tests pinning the exact payload per radio state, the push edge, and the removal of the old rows. Full web suite (170 files / 1865 tests) green — GitHub form tests untouched; typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
