### PR TITLE
feat(control-plane): a released GitLab connection can be removed

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -554,6 +554,11 @@ and removes the sealed token pair. Project bindings are not deleted
 implicitly. Bindings assigned to that connection become `admin_degraded` and
 can be taken over by another current Maintainer or Owner.
 
+The retained row is history, not a permanent fixture: once a disconnected
+connection administers no project binding at all, deleting it again removes
+the row, and that removal is refused while any binding is still assigned to
+it.
+
 Removing the AgentConnect user from the organization follows the same rule.
 Their OAuth authority must not survive organization membership.
 

--- a/packages/control-plane/src/gitlab/oauth.service.test.ts
+++ b/packages/control-plane/src/gitlab/oauth.service.test.ts
@@ -96,6 +96,12 @@ class MemConnections implements GitlabConnectionRepo {
     this.secrets.rows.delete(id)
     return true
   }
+  async remove(orgId: string, id: string): Promise<boolean> {
+    const row = this.rows.get(id)
+    if (!row || row.orgId !== orgId || row.state !== 'disconnected') return false
+    this.rows.delete(id)
+    return true
+  }
   leases = new Map<string, { owner: string; until: Date }>()
   async claimRefreshLease(id: string, owner: string, until: Date, now: Date): Promise<boolean> {
     const lease = this.leases.get(id)

--- a/packages/control-plane/src/gitlab/oauth.service.test.ts
+++ b/packages/control-plane/src/gitlab/oauth.service.test.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { describe, expect, it } from 'vitest'
 import type {
   GitlabConnectionRecord,
+  GitlabConnectionRemoval,
   GitlabConnectionRepo,
   GitlabConnectionSecretStore,
   GitlabOauthStateRecord,
@@ -96,11 +97,12 @@ class MemConnections implements GitlabConnectionRepo {
     this.secrets.rows.delete(id)
     return true
   }
-  async remove(orgId: string, id: string): Promise<boolean> {
+  async remove(orgId: string, id: string): Promise<GitlabConnectionRemoval> {
     const row = this.rows.get(id)
-    if (!row || row.orgId !== orgId || row.state !== 'disconnected') return false
+    if (!row || row.orgId !== orgId) return { outcome: 'missing' }
+    if (row.state !== 'disconnected') return { outcome: 'not_disconnected' }
     this.rows.delete(id)
-    return true
+    return { outcome: 'removed' }
   }
   leases = new Map<string, { owner: string; until: Date }>()
   async claimRefreshLease(id: string, owner: string, until: Date, now: Date): Promise<boolean> {

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1776,11 +1776,21 @@ export const GitlabConnectionDto = z.object({
   scopes: z.array(z.string()),
   connectedBy: z.string().nullable(), // AgentConnect user id; null after user deletion
   accessExpiresAt: z.string().nullable(),
+  /** Managed projects this connection still administers (§7.1). A released
+   *  connection with none can be removed; with any, removal is refused. */
+  assignedProjects: z.number().int(),
   createdAt: z.string()
 })
 export type GitlabConnectionDtoT = z.infer<typeof GitlabConnectionDto>
 
 export const GitlabConnectionListDto = z.object({ connections: z.array(GitlabConnectionDto) })
+
+/** Deleting a connection twice means two things (§9.4): the first call releases
+ *  it and returns the retained row, the second removes the row entirely. */
+export const GitlabConnectionDeleteDto = z.object({
+  removed: z.boolean(),
+  connection: GitlabConnectionDto.nullable()
+})
 
 /** The begin URL the browser must visit to continue the OAuth flow on GitLab.com. */
 export const GitlabOauthStartDto = z.object({ url: z.string() })

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -361,7 +361,7 @@ export function gitlabRoutes(deps: HttpDeps) {
           tags: [Tag.GitLab],
           summary: 'Disconnect or remove a GitLab.com connection',
           description:
-            'On a live connection: revokes the OAuth grant when possible, removes the stored token pair, and keeps the row so its projects can still be listed — project bindings are never deleted implicitly (§9.4). On an already-disconnected connection that administers no projects: removes the row. Removal is refused with 409 while any project is still assigned to it.',
+            'On a live connection: revokes the OAuth grant when possible, removes the stored token pair, and keeps the row so its projects can still be listed — project bindings are never deleted implicitly (§9.4). On an already-disconnected connection that administers no projects: removes the row, under a lock that makes a racing project create meet the refusal rather than be detached. Removal is refused with 409 while any project is still assigned to it.',
           operationId: 'disconnectGitlabConnection',
           params: IdParam,
           response: { 200: GitlabConnectionDeleteDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
@@ -372,24 +372,26 @@ export function gitlabRoutes(deps: HttpDeps) {
         const orgId = orgOf(req)
         const notFound = () =>
           reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab connection not found' })
+        const conflict = (message: string) => reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
         const existing = await deps.repos.gitlabConnection.get(orgId, req.params.id)
         if (!existing) return notFound()
-        const assigned = (await deps.repos.gitlabProjectBinding.countByInstaller(orgId))[existing.id] ?? 0
         // Second delete on a released row finishes the job the first one started.
+        // The repository re-checks state and count under its own lock; this read
+        // only decides which of the two meanings the request has.
         if (existing.state === 'disconnected') {
-          if (assigned > 0) {
-            return reply.code(409).send({
-              error: 'Conflict',
-              statusCode: 409,
-              message: `connection still administers ${assigned} managed project${assigned === 1 ? '' : 's'}`
-            })
+          const removal = await deps.repos.gitlabConnection.remove(orgId, existing.id)
+          if (removal.outcome === 'removed') return { removed: true, connection: null }
+          if (removal.outcome === 'missing') return notFound()
+          if (removal.outcome === 'blocked') {
+            const n = removal.assignedProjects
+            return conflict(`connection still administers ${n} managed project${n === 1 ? '' : 's'}`)
           }
-          if (!(await deps.repos.gitlabConnection.remove(orgId, existing.id))) return notFound()
-          return { removed: true, connection: null }
+          return conflict('gitlab connection is connected again — reload and try once more')
         }
         if (!(await gitlab.oauth.disconnect(orgId, existing.id))) return notFound()
         const record = await deps.repos.gitlabConnection.get(orgId, existing.id)
         if (!record) return notFound()
+        const assigned = (await deps.repos.gitlabProjectBinding.countByInstaller(orgId))[existing.id] ?? 0
         return { removed: false, connection: toDto(record, assigned) }
       }
     )

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -4,7 +4,7 @@
  *
  * TWO plugins, mirroring `github.ts`:
  *  - `gitlabRoutes` mounts inside the `/orgs/:orgId` subtree: oauth start,
- *    connection list, disconnect. Connections are infrastructure-class
+ *    connection list, disconnect and removal. Connections are infrastructure-class
  *    (org-visible, never canView-filtered), like GitHub installations.
  *  - `gitlabOauthRoutes` mounts at the API version root, UNAUTHENTICATED
  *    (GitLab redirects a browser): the begin hop that stamps the
@@ -33,7 +33,7 @@ import { GitlabProjectClaimConflict } from '../../persistence/errors.js'
 import {
   CreateGitlabProjectBody,
   ErrorDto,
-  GitlabConnectionDto,
+  GitlabConnectionDeleteDto,
   GitlabConnectionListDto,
   GitlabOauthStartDto,
   GitlabProjectBindingDto,
@@ -43,7 +43,7 @@ import {
 } from '../dto/index.js'
 import type { GitlabConnectionRecord, GitlabProjectBindingRecord } from '../../persistence/ports.js'
 
-function toDto(r: GitlabConnectionRecord) {
+function toDto(r: GitlabConnectionRecord, assignedProjects: number) {
   return {
     id: r.id,
     gitlabUserId: r.gitlabUserId.toString(),
@@ -52,6 +52,7 @@ function toDto(r: GitlabConnectionRecord) {
     scopes: r.scopes,
     connectedBy: r.userId,
     accessExpiresAt: r.accessExpiresAt ? r.accessExpiresAt.toISOString() : null,
+    assignedProjects,
     createdAt: r.createdAt.toISOString()
   }
 }
@@ -133,8 +134,10 @@ export function gitlabRoutes(deps: HttpDeps) {
         }
       },
       async (req) => {
-        const rows = await deps.repos.gitlabConnection.listForOrg(orgOf(req))
-        return { connections: rows.map(toDto) }
+        const orgId = orgOf(req)
+        const rows = await deps.repos.gitlabConnection.listForOrg(orgId)
+        const assigned = await deps.repos.gitlabProjectBinding.countByInstaller(orgId)
+        return { connections: rows.map((row) => toDto(row, assigned[row.id] ?? 0)) }
       }
     )
 
@@ -356,23 +359,38 @@ export function gitlabRoutes(deps: HttpDeps) {
       {
         schema: {
           tags: [Tag.GitLab],
-          summary: 'Disconnect a GitLab.com connection',
+          summary: 'Disconnect or remove a GitLab.com connection',
           description:
-            'Revokes the OAuth grant when possible and removes the stored token pair. Project bindings are not deleted implicitly.',
+            'On a live connection: revokes the OAuth grant when possible, removes the stored token pair, and keeps the row so its projects can still be listed — project bindings are never deleted implicitly (§9.4). On an already-disconnected connection that administers no projects: removes the row. Removal is refused with 409 while any project is still assigned to it.',
           operationId: 'disconnectGitlabConnection',
           params: IdParam,
-          response: { 200: GitlabConnectionDto, 404: ErrorDto }
+          response: { 200: GitlabConnectionDeleteDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
         }
       },
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
         const orgId = orgOf(req)
-        const removed = await gitlab.oauth.disconnect(orgId, req.params.id)
-        const record = removed ? await deps.repos.gitlabConnection.get(orgId, req.params.id) : null
-        if (!record) {
-          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab connection not found' })
+        const notFound = () =>
+          reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab connection not found' })
+        const existing = await deps.repos.gitlabConnection.get(orgId, req.params.id)
+        if (!existing) return notFound()
+        const assigned = (await deps.repos.gitlabProjectBinding.countByInstaller(orgId))[existing.id] ?? 0
+        // Second delete on a released row finishes the job the first one started.
+        if (existing.state === 'disconnected') {
+          if (assigned > 0) {
+            return reply.code(409).send({
+              error: 'Conflict',
+              statusCode: 409,
+              message: `connection still administers ${assigned} managed project${assigned === 1 ? '' : 's'}`
+            })
+          }
+          if (!(await deps.repos.gitlabConnection.remove(orgId, existing.id))) return notFound()
+          return { removed: true, connection: null }
         }
-        return toDto(record)
+        if (!(await gitlab.oauth.disconnect(orgId, existing.id))) return notFound()
+        const record = await deps.repos.gitlabConnection.get(orgId, existing.id)
+        if (!record) return notFound()
+        return { removed: false, connection: toDto(record, assigned) }
       }
     )
   }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3275,10 +3275,19 @@ export interface GitlabConnectionRepo {
   /** Atomic disconnect: state flip, version bump (defeats in-flight refresh CAS),
    *  and sealed-pair deletion in one transaction. The row stays as history. */
   disconnect(orgId: string, connectionId: string): Promise<boolean>
-  /** Drop an already-released row (§9.4): state-fenced to `disconnected`, so a
-   *  reconnect that raced this call keeps its live connection. */
-  remove(orgId: string, connectionId: string): Promise<boolean>
+  /** Drop an already-released row (§9.4). Locks the row, re-checks the state and
+   *  the assigned-binding count, and deletes — all in one transaction, because
+   *  `installerConnectionId` is ON DELETE SET NULL: an unfenced delete would
+   *  silently DETACH a binding a racing create had just attached. */
+  remove(orgId: string, connectionId: string): Promise<GitlabConnectionRemoval>
 }
+
+/** Why a connection removal did or did not happen — the route maps it to a status. */
+export type GitlabConnectionRemoval =
+  | { outcome: 'removed' }
+  | { outcome: 'blocked'; assignedProjects: number }
+  | { outcome: 'not_disconnected' }
+  | { outcome: 'missing' }
 
 /** Sealed OAuth pair reads (per-org key scope). Writes ride the connection
  *  repo's atomic transitions; never joined by DTO queries. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3275,6 +3275,9 @@ export interface GitlabConnectionRepo {
   /** Atomic disconnect: state flip, version bump (defeats in-flight refresh CAS),
    *  and sealed-pair deletion in one transaction. The row stays as history. */
   disconnect(orgId: string, connectionId: string): Promise<boolean>
+  /** Drop an already-released row (§9.4): state-fenced to `disconnected`, so a
+   *  reconnect that raced this call keeps its live connection. */
+  remove(orgId: string, connectionId: string): Promise<boolean>
 }
 
 /** Sealed OAuth pair reads (per-org key scope). Writes ride the connection
@@ -3327,6 +3330,9 @@ export interface GitlabProjectBindingRepo {
   get(orgId: string, bindingId: string): Promise<GitlabProjectBindingRecord | null>
   byProject(orgId: string, projectId: bigint): Promise<GitlabProjectBindingRecord | null>
   listForOrg(orgId: string): Promise<GitlabProjectBindingRecord[]>
+  /** How many bindings each connection still administers, keyed by connection id
+   *  (§7.1): a connection with any is not released and cannot be removed. */
+  countByInstaller(orgId: string): Promise<Record<string, number>>
   /** Saga/reconciler facts (service account, webhook, path refresh, lifecycle). */
   update(
     orgId: string,

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -19,6 +19,7 @@ import type {
   GitlabBindingState,
   GitlabConnectionRecord,
   GitlabConnectionRepo,
+  GitlabConnectionRemoval,
   GitlabConnectionSecretStore,
   GitlabConnectionState,
   GitlabCredentialPurpose,
@@ -138,13 +139,24 @@ export class PgGitlabConnectionRepo implements GitlabConnectionRepo {
     })
   }
 
-  async remove(orgId: string, connectionId: string): Promise<boolean> {
-    // State-fenced (§9.4): only an already-released row goes, so a reconnect that
-    // landed between the read and this call keeps its live connection.
-    const res = await this.prisma.gitlabConnection.deleteMany({
-      where: { id: connectionId, orgId, state: 'disconnected' }
+  async remove(orgId: string, connectionId: string): Promise<GitlabConnectionRemoval> {
+    // Lock, check, delete in ONE transaction (§9.4). FOR UPDATE conflicts with the
+    // FOR KEY SHARE that inserting a binding takes on its installer, so a racing
+    // project create either commits first and is counted, or waits and then fails
+    // its foreign key — it can never be silently detached by ON DELETE SET NULL.
+    return this.prisma.$transaction(async (tx) => {
+      const locked = await tx.$queryRaw<{ state: string }[]>`
+        SELECT "state" FROM "gitlab_connection"
+         WHERE "id" = ${connectionId}::uuid AND "orgId" = ${orgId} FOR UPDATE`
+      if (locked.length === 0) return { outcome: 'missing' }
+      if (locked[0]!.state !== 'disconnected') return { outcome: 'not_disconnected' }
+      const assignedProjects = await tx.gitlabProjectBinding.count({
+        where: { orgId, installerConnectionId: connectionId }
+      })
+      if (assignedProjects > 0) return { outcome: 'blocked', assignedProjects }
+      await tx.gitlabConnection.delete({ where: { id: connectionId } })
+      return { outcome: 'removed' }
     })
-    return res.count === 1
   }
 
   async claimRefreshLease(connectionId: string, owner: string, until: Date, now: Date): Promise<boolean> {

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -138,6 +138,15 @@ export class PgGitlabConnectionRepo implements GitlabConnectionRepo {
     })
   }
 
+  async remove(orgId: string, connectionId: string): Promise<boolean> {
+    // State-fenced (§9.4): only an already-released row goes, so a reconnect that
+    // landed between the read and this call keeps its live connection.
+    const res = await this.prisma.gitlabConnection.deleteMany({
+      where: { id: connectionId, orgId, state: 'disconnected' }
+    })
+    return res.count === 1
+  }
+
   async claimRefreshLease(connectionId: string, owner: string, until: Date, now: Date): Promise<boolean> {
     const res = await this.prisma.gitlabConnection.updateMany({
       where: {
@@ -352,6 +361,19 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
       where: { orgId }
     })
     return rows.map(toBindingRecord)
+  }
+
+  async countByInstaller(orgId: string): Promise<Record<string, number>> {
+    const groups = await this.prisma.gitlabProjectBinding.groupBy({
+      by: ['installerConnectionId'],
+      where: { orgId, installerConnectionId: { not: null } },
+      _count: { _all: true }
+    })
+    const counts: Record<string, number> = {}
+    for (const group of groups) {
+      if (group.installerConnectionId) counts[group.installerConnectionId] = group._count._all
+    }
+    return counts
   }
 
   async update(

--- a/packages/control-plane/test/integration/gitlab.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab.route.test.ts
@@ -154,8 +154,44 @@ describe('gitlab oauth routes', () => {
     const { connectionId } = await connect(a)
     const res = await a.app.inject({ method: 'DELETE', url: `${ORG}/gitlab/connections/${connectionId}` })
     expect(res.statusCode).toBe(200)
-    expect((res.json() as { state: string }).state).toBe('disconnected')
+    // A live connection is released, never removed: the row survives for takeover.
+    expect(res.json()).toMatchObject({ removed: false, connection: { state: 'disconnected' } })
     expect(await prisma.gitlabConnectionSecret.findUnique({ where: { connectionId } })).toBeNull()
+    expect(await prisma.gitlabConnection.count({ where: { id: connectionId } })).toBe(1)
+  })
+
+  it('removes a released connection that administers no project (§9.4)', async () => {
+    const a = gitlabApp()
+    const { connectionId } = await connect(a)
+    await a.app.inject({ method: 'DELETE', url: `${ORG}/gitlab/connections/${connectionId}` })
+    const res = await a.app.inject({ method: 'DELETE', url: `${ORG}/gitlab/connections/${connectionId}` })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ removed: true, connection: null })
+    expect(await prisma.gitlabConnection.count({ where: { id: connectionId } })).toBe(0)
+    const list = await a.app.inject({ method: 'GET', url: `${ORG}/gitlab/connections` })
+    expect((list.json() as { connections: unknown[] }).connections).toHaveLength(0)
+  })
+
+  it('refuses to remove a released connection while it still administers projects', async () => {
+    const a = gitlabApp()
+    const { connectionId } = await connect(a)
+    const bound = await a.app.inject({
+      method: 'POST',
+      url: `${ORG}/gitlab/projects`,
+      payload: { connectionId, projectId: '4455667' }
+    })
+    expect(bound.statusCode).toBe(200)
+    // The list states the blocking count before the user reaches for removal.
+    const listed = await a.app.inject({ method: 'GET', url: `${ORG}/gitlab/connections` })
+    expect((listed.json() as { connections: { assignedProjects: number }[] }).connections[0]).toMatchObject({
+      assignedProjects: 1
+    })
+
+    await a.app.inject({ method: 'DELETE', url: `${ORG}/gitlab/connections/${connectionId}` })
+    const res = await a.app.inject({ method: 'DELETE', url: `${ORG}/gitlab/connections/${connectionId}` })
+    expect(res.statusCode).toBe(409)
+    expect((res.json() as { message: string }).message).toContain('1 managed project')
+    expect(await prisma.gitlabConnection.count({ where: { id: connectionId } })).toBe(1)
   })
 
   it('searches accessible projects through the connection', async () => {

--- a/packages/control-plane/test/repo/gitlab-connection.repo.test.ts
+++ b/packages/control-plane/test/repo/gitlab-connection.repo.test.ts
@@ -21,6 +21,18 @@ const store = () => new PgGitlabConnectionSecretStore(prisma, cipher)
 
 const pair = (tag: string) => ({ accessToken: `at-${tag}`, refreshToken: `rt-${tag}` })
 
+/** One provisioning binding administered by `installerConnectionId`. */
+const binding = (installerConnectionId: string) => ({
+  orgId: DEFAULT_ORG_ID,
+  projectId: 4455667n,
+  projectPath: 'example-group/example-project',
+  installerConnectionId,
+  state: 'provisioning'
+})
+
+/** Let the other transaction reach its lock before this one asks for it. */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 150))
+
 async function connected() {
   return repo().upsertOnCallback({
     orgId: DEFAULT_ORG_ID,
@@ -71,11 +83,52 @@ describe('PgGitlabConnectionRepo transitions', () => {
 
   it('remove is state-fenced: only an already-released row goes (§9.4)', async () => {
     const record = await connected()
-    expect(await repo().remove(DEFAULT_ORG_ID, record.id)).toBe(false)
+    expect(await repo().remove(DEFAULT_ORG_ID, record.id)).toEqual({ outcome: 'not_disconnected' })
     expect((await repo().get(DEFAULT_ORG_ID, record.id))!.state).toBe('connected')
     await repo().disconnect(DEFAULT_ORG_ID, record.id)
-    expect(await repo().remove(DEFAULT_ORG_ID, record.id)).toBe(true)
+    expect(await repo().remove(DEFAULT_ORG_ID, record.id)).toEqual({ outcome: 'removed' })
     expect(await repo().get(DEFAULT_ORG_ID, record.id)).toBeNull()
+    expect(await repo().remove(DEFAULT_ORG_ID, record.id)).toEqual({ outcome: 'missing' })
+  })
+
+  it('a binding attached mid-removal meets the refusal, not a silent detach (§9.4)', async () => {
+    const record = await connected()
+    await repo().disconnect(DEFAULT_ORG_ID, record.id)
+
+    // Transaction A inserts a binding and holds its installer FK lock open.
+    let release = () => {}
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const inserting = prisma.$transaction(
+      async (tx) => {
+        await tx.gitlabProjectBinding.create({ data: binding(record.id) })
+        await held
+      },
+      { timeout: 20_000 }
+    )
+    await tick()
+
+    // Transaction B wants the row: FOR UPDATE waits for A, then counts what A added.
+    const removing = repo().remove(DEFAULT_ORG_ID, record.id)
+    await tick()
+    release()
+    await inserting
+
+    expect(await removing).toEqual({ outcome: 'blocked', assignedProjects: 1 })
+    const row = await prisma.gitlabProjectBinding.findFirstOrThrow({ where: { orgId: DEFAULT_ORG_ID } })
+    expect(row.installerConnectionId).toBe(record.id)
+  })
+
+  it('negative control: the unfenced state-only delete detaches that binding instead', async () => {
+    const record = await connected()
+    await repo().disconnect(DEFAULT_ORG_ID, record.id)
+    await prisma.gitlabProjectBinding.create({ data: binding(record.id) })
+    // The shape `remove` deliberately is not: no lock, no count, so ON DELETE SET
+    // NULL quietly orphans an administered project.
+    await prisma.gitlabConnection.deleteMany({ where: { id: record.id, state: 'disconnected' } })
+    const row = await prisma.gitlabProjectBinding.findFirstOrThrow({ where: { orgId: DEFAULT_ORG_ID } })
+    expect(row.installerConnectionId).toBeNull()
   })
 
   it('markReauthRequired is version-fenced: a stale outcome keeps newer state', async () => {

--- a/packages/control-plane/test/repo/gitlab-connection.repo.test.ts
+++ b/packages/control-plane/test/repo/gitlab-connection.repo.test.ts
@@ -69,6 +69,15 @@ describe('PgGitlabConnectionRepo transitions', () => {
     expect((await repo().get(DEFAULT_ORG_ID, record.id))!.state).toBe('disconnected')
   })
 
+  it('remove is state-fenced: only an already-released row goes (§9.4)', async () => {
+    const record = await connected()
+    expect(await repo().remove(DEFAULT_ORG_ID, record.id)).toBe(false)
+    expect((await repo().get(DEFAULT_ORG_ID, record.id))!.state).toBe('connected')
+    await repo().disconnect(DEFAULT_ORG_ID, record.id)
+    expect(await repo().remove(DEFAULT_ORG_ID, record.id)).toBe(true)
+    expect(await repo().get(DEFAULT_ORG_ID, record.id)).toBeNull()
+  })
+
   it('markReauthRequired is version-fenced: a stale outcome keeps newer state', async () => {
     const record = await connected()
     expect(await repo().markReauthRequired(record.id, record.tokenVersion - 1n)).toBe(false)

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -50,6 +50,7 @@ const CONNECTION: GitlabConnectionDto = {
   scopes: ['api'],
   connectedBy: 'user-1',
   accessExpiresAt: null,
+  assignedProjects: 0,
   createdAt: '2026-08-01T00:00:00.000Z'
 }
 
@@ -98,6 +99,13 @@ async function settleSearch(): Promise<void> {
   })
 }
 
+/** One connection row and everything the card renders under it. */
+function connectionRow(id: string): HTMLElement {
+  const found = host.querySelector(`[data-gitlab-connection="${id}"]`)
+  if (!found) throw new Error(`no connection row: ${id}`)
+  return found as HTMLElement
+}
+
 function modal(): HTMLElement {
   const found = host.querySelector('.modal')
   if (!found) throw new Error('no confirmation modal is open')
@@ -139,6 +147,59 @@ describe('GitlabCard', () => {
     await render()
     expect(host.textContent).toContain('reconnect needed')
     expect(buttonIn(host, 'Reconnect')).toBeTruthy()
+  })
+
+  it('offers Disconnect, not Remove, while the connection is still live', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.disconnect.mockResolvedValue({
+      removed: false,
+      connection: { ...CONNECTION, state: 'disconnected' as const }
+    })
+    await render()
+    const row = connectionRow('conn-1')
+    expect(buttonIn(row, 'Disconnect')).toBeTruthy()
+    expect(() => buttonIn(row, 'Remove')).toThrow()
+
+    // Disconnect is confirmed, and the row survives it — in its released state.
+    await click('Disconnect')
+    expect(mocks.disconnect).not.toHaveBeenCalled()
+    await click('Disconnect', modal())
+    expect(mocks.disconnect).toHaveBeenCalledWith('conn-1')
+    expect(host.textContent).toContain('disconnected')
+    expect(host.querySelectorAll('[data-gitlab-connection]')).toHaveLength(1)
+  })
+
+  it('finishes a released connection that administers nothing: Remove instead of Disconnect', async () => {
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [{ ...CONNECTION, state: 'disconnected' as const, assignedProjects: 0 }]
+    })
+    mocks.disconnect.mockResolvedValue({ removed: true, connection: null })
+    await render()
+    const row = connectionRow('conn-1')
+    expect(buttonIn(row, 'Reconnect')).toBeTruthy()
+    expect(() => buttonIn(row, 'Disconnect')).toThrow()
+
+    await click('Remove')
+    expect(mocks.disconnect).not.toHaveBeenCalled()
+    await click('Remove', modal())
+    expect(mocks.disconnect).toHaveBeenCalledWith('conn-1')
+    expect(host.querySelectorAll('[data-gitlab-connection]')).toHaveLength(0)
+  })
+
+  it('explains why a released connection with projects still assigned cannot go', async () => {
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [{ ...CONNECTION, state: 'disconnected' as const, assignedProjects: 2 }]
+    })
+    await render()
+    const row = connectionRow('conn-1')
+    expect(row.textContent).toContain('still administers 2 projects')
+    expect(buttonIn(row, 'Reconnect')).toBeTruthy()
+    expect(() => buttonIn(row, 'Remove')).toThrow()
+    expect(() => buttonIn(row, 'Disconnect')).toThrow()
+    // The blocking count is stated in words, never as a machine code.
+    expect(row.textContent).not.toContain('assignedProjects')
   })
 
   it('repairs and removes the project it was invoked on', async () => {

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -202,6 +202,32 @@ describe('GitlabCard', () => {
     expect(row.textContent).not.toContain('assignedProjects')
   })
 
+  it('completes the guided removal: the blocked line clears when the last project goes', async () => {
+    const blocked = { ...CONNECTION, state: 'disconnected' as const, assignedProjects: 1 }
+    mocks.fetchConnections.mockResolvedValueOnce({ enabled: true, connections: [blocked] })
+    // The removal frees the connection, and the card reads the new count back.
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [{ ...blocked, assignedProjects: 0 }]
+    })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    mocks.deleteProject.mockResolvedValue({ removed: true })
+    await render()
+
+    expect(connectionRow('conn-1').textContent).toContain('still administers 1 project')
+    expect(() => buttonIn(connectionRow('conn-1'), 'Remove')).toThrow()
+
+    // Remove the one project that blocks it — the project row's button, then the modal's.
+    await click('Remove', host.querySelector('[data-gitlab-project]')!)
+    await click('Remove', modal())
+    expect(mocks.deleteProject).toHaveBeenCalledWith('bind-1')
+
+    // No reload: the connection now offers its own removal.
+    expect(host.querySelectorAll('[data-gitlab-project]')).toHaveLength(0)
+    expect(connectionRow('conn-1').textContent).not.toContain('still administers')
+    expect(buttonIn(connectionRow('conn-1'), 'Remove')).toBeTruthy()
+  })
+
   it('repairs and removes the project it was invoked on', async () => {
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     mocks.fetchProjects.mockResolvedValue([BINDING])

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -57,7 +57,8 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
   const [projects, setProjects] = useState<GitlabProjectBindingDto[]>([])
   const [busyId, setBusyId] = useState<string | null>(null)
   const [err, setErr] = useState<string | null>(null)
-  const [disconnecting, setDisconnecting] = useState<GitlabConnectionDto | null>(null)
+  // One pending connection action: releasing a live row, or removing a released one.
+  const [pending, setPending] = useState<{ target: GitlabConnectionDto; remove: boolean } | null>(null)
   const [removing, setRemoving] = useState<GitlabProjectBindingDto | null>(null)
   const [adding, setAdding] = useState(false)
 
@@ -95,14 +96,20 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     }
   }
 
-  const disconnect = async (target: GitlabConnectionDto) => {
+  // Disconnect releases the row and keeps it; a second delete on a released row
+  // with nothing left assigned to it removes the row for good.
+  const release = async (target: GitlabConnectionDto) => {
     if (busyId) return
     setBusyId(target.id)
     setErr(null)
     try {
-      await disconnectGitlabConnection(target.id)
-      setConnections((current) => current.filter((c) => c.id !== target.id))
-      setDisconnecting(null)
+      const outcome = await disconnectGitlabConnection(target.id)
+      setConnections((current) =>
+        outcome.removed || !outcome.connection
+          ? current.filter((c) => c.id !== target.id)
+          : current.map((c) => (c.id === target.id ? outcome.connection! : c))
+      )
+      setPending(null)
     } catch (e) {
       setErr(errorText(e))
     } finally {
@@ -199,7 +206,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
 
       {enabled === true &&
         connections.map((c) => (
-          <div key={c.id}>
+          <div key={c.id} data-gitlab-connection={c.id}>
             <div className="row grid-cols-1 gap-2 desktop:grid-cols-[minmax(0,1fr)_auto] desktop:gap-[11px]">
               <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
                 <span className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
@@ -224,18 +231,41 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                       Reconnect
                     </Button>
                   )}
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    className="text-(--status-error) hover:text-(--status-error)"
-                    onClick={() => setDisconnecting(c)}
-                  >
-                    <Icon name="unplug" size={13} />
-                    Disconnect
-                  </Button>
+                  {/* A released row has nothing left to disconnect: it offers the finish instead. */}
+                  {c.state !== 'disconnected' && (
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      className="text-(--status-error) hover:text-(--status-error)"
+                      disabled={busyId === c.id}
+                      onClick={() => setPending({ target: c, remove: false })}
+                    >
+                      <Icon name="unplug" size={13} />
+                      Disconnect
+                    </Button>
+                  )}
+                  {c.state === 'disconnected' && c.assignedProjects === 0 && (
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      className="text-(--status-error) hover:text-(--status-error)"
+                      disabled={busyId === c.id}
+                      onClick={() => setPending({ target: c, remove: true })}
+                    >
+                      <Icon name="trash-2" size={13} />
+                      Remove
+                    </Button>
+                  )}
                 </span>
               )}
             </div>
+            {c.state === 'disconnected' && c.assignedProjects > 0 && (
+              <div className="border-b border-(--border-subtle) px-4 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+                {c.assignedProjects === 1
+                  ? 'This account still administers 1 project below. Remove that project, or reconnect the account to keep managing it, before this row can go.'
+                  : `This account still administers ${c.assignedProjects} projects below. Remove those projects, or reconnect the account to keep managing them, before this row can go.`}
+              </div>
+            )}
             {c.state === 'reauth_required' && (
               <div
                 role="status"
@@ -316,23 +346,31 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
         <div className="px-4 py-2 font-sans text-[12px] font-normal leading-normal text-(--status-error)">{err}</div>
       )}
 
-      {disconnecting && (
-        <div className="scrim" onClick={() => setDisconnecting(null)}>
+      {pending && (
+        <div className="scrim" onClick={() => setPending(null)}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
             <ConfirmGitlab
-              title="Disconnect GitLab"
+              title={pending.remove ? 'Remove connection' : 'Disconnect GitLab'}
               body={
-                <>
-                  Disconnect <span className="mono text-(--text-primary)">{disconnecting.gitlabUsername}</span>? GitLab
-                  stops accepting this account for project setup and repairs. Projects you already added keep running
-                  until you remove them.
-                </>
+                pending.remove ? (
+                  <>
+                    Remove <span className="mono text-(--text-primary)">{pending.target.gitlabUsername}</span> from the
+                    list? It has already been disconnected and administers no projects, so this only clears the row.
+                    Connect GitLab again whenever you need it.
+                  </>
+                ) : (
+                  <>
+                    Disconnect <span className="mono text-(--text-primary)">{pending.target.gitlabUsername}</span>?
+                    GitLab stops accepting this account for project setup and repairs. Projects you already added keep
+                    running until you remove them.
+                  </>
+                )
               }
-              verb="Disconnect"
-              icon="unplug"
-              busy={busyId === disconnecting.id}
-              onClose={() => setDisconnecting(null)}
-              onConfirm={() => disconnect(disconnecting)}
+              verb={pending.remove ? 'Remove' : 'Disconnect'}
+              icon={pending.remove ? 'trash-2' : 'unplug'}
+              busy={busyId === pending.target.id}
+              onClose={() => setPending(null)}
+              onConfirm={() => release(pending.target)}
             />
           </div>
         </div>

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -138,8 +138,13 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     try {
       const outcome = await deleteGitlabProject(binding.id)
       // Incomplete external cleanup keeps the row, in its reported state — GitLab still holds something.
-      if (outcome.removed) setProjects((current) => current.filter((p) => p.id !== binding.id))
-      else
+      if (outcome.removed) {
+        setProjects((current) => current.filter((p) => p.id !== binding.id))
+        // The count that gates connection removal lives on the connection row, so
+        // freeing the last project has to be read back before Remove can appear.
+        const fresh = await fetchGitlabConnections().catch(() => null)
+        if (fresh) setConnections(fresh.connections)
+      } else
         setProjects((current) =>
           current.map((p) =>
             p.id === binding.id

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -5252,7 +5252,15 @@ export interface GitlabConnectionDto {
   scopes: string[]
   connectedBy: string | null // AgentConnect user id; null after user deletion
   accessExpiresAt: string | null
+  assignedProjects: number // managed projects this connection still administers
   createdAt: string
+}
+
+/** Deleting a connection twice means two things: the first call releases it and
+ *  returns the retained row, the second removes the row entirely. */
+export interface GitlabConnectionDeleteDto {
+  removed: boolean
+  connection: GitlabConnectionDto | null
 }
 
 /** One accessible project in the picker — metadata only, never installability. */
@@ -5309,10 +5317,12 @@ export function startGitlabOauth(returnPath?: string): Promise<string> {
   )
 }
 
-/** Revoke the OAuth grant and drop the stored tokens. Bound projects survive —
- *  removing them is a separate, explicitly destructive action. */
-export function disconnectGitlabConnection(id: string): Promise<GitlabConnectionDto> {
-  return apiDelete<GitlabConnectionDto>(`${orgBase()}/gitlab/connections/${encodeURIComponent(id)}`)
+/** Two-step release. On a live connection this revokes the OAuth grant, drops the
+ *  stored tokens, and keeps the row so its projects can still be listed; on an
+ *  already-disconnected one that administers nothing it removes the row. Removal
+ *  is refused (409) while any project is still assigned to the connection. */
+export function disconnectGitlabConnection(id: string): Promise<GitlabConnectionDeleteDto> {
+  return apiDelete<GitlabConnectionDeleteDto>(`${orgBase()}/gitlab/connections/${encodeURIComponent(id)}`)
 }
 
 /** Server-side paginated project search. `nextPage` is null on the last page. */


### PR DESCRIPTION
## What

User feedback: Disconnect on the GitLab card appeared to do nothing. Two causes — the design keeps the released row (bindings are not deleted implicitly, section 9.4) but nothing could ever remove it, and the card dropped the row from local state so it reappeared on reload.

- `DELETE /gitlab/connections/:id` becomes two-step: a live connection releases as today (revoke, drop the token pair, keep the row); a second delete on an already-disconnected row removes it when no bindings remain assigned, and answers a typed 409 naming the count when they do. The response reports `{ removed, connection }` and the connection DTO now carries its assigned-project count so the console can present the right actions without probing.
- Card presentations: live → Reconnect/Disconnect; released with nothing assigned → Reconnect/Remove; released with projects → Reconnect plus a translated line explaining what blocks removal. The local-state bug is fixed by writing back the returned row.
- Design section 9.4 records that a fully released connection can be removed.

## Tests

CP integration: release keeps the row, the second delete removes it, the blocked removal names the count and keeps the row, and removal is state-fenced at the repository (a connected row refuses). Web: the three presentations and confirm-before-call on both destructive paths. Full CP unit suite, touched integration files, web suite, typecheck (tests included), lint, format all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
