### PR TITLE
feat(web): bind GitLab projects at the point of use

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1389,26 +1389,29 @@ spec in a snapshot sent to one.
 
 ### 18.1 Console
 
-The Connections page shows:
+The Connections page manages the connection and the health of what it
+administers — the shape the GitHub card already has. It shows:
 
 - connected GitLab username and GitLab.com host;
 - OAuth state: connected, reconnect required, or disconnected;
-- project search with current path and role;
 - project binding state and service-account username;
 - webhook state: not needed, installed, repairing, or failed;
 - credential expiry and rotation warning without token values; and
-- actions to refresh projects, reconnect, repair, transfer administration, or
-  disconnect.
+- actions to reconnect, repair, remove a project, transfer administration,
+  disconnect, or remove a released connection.
 
 Webhook setup is automatic. The UI may show the desired endpoint and last
 verification result for diagnosis, but v1 does not make a manually copied
 secret a second source of truth.
 
-Agent workspace and additional-repository pickers use the same provider-aware
-project list. Hook configuration retains the existing family, cadence, label,
-review, reporting, and output controls. Premium-only effective behavior is
-described where relevant; the UI does not imply that Free request changes
-block merges.
+Choosing a project happens where the project is used, not on that page: the
+hook wizard and the agent workspace and additional-repository pickers list the
+connection's Maintainer-or-Owner projects merged with the ones already added,
+and picking one that is not added yet runs the Section 10.2 provisioning saga
+inline before the selection lands. Hook configuration retains the existing
+family, cadence, label, review, reporting, and output controls. Premium-only
+effective behavior is described where relevant; the UI does not imply that
+Free request changes block merges.
 
 User-facing copy says GitLab, connection, project, webhook, and bot. It does
 not expose internal Control Plane or relay terminology.

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
 /**
- * The GitLab card is the console's whole GitLab surface, so what it renders IS
- * the connection state: an unconnected organization gets one entry point, a
- * connected one gets its projects and their lifecycle. The write actions are
- * asserted against the endpoint they call — a repair that silently posted to
- * the wrong binding would still look right on screen.
+ * The GitLab card is the console's GitLab MANAGEMENT surface: an unconnected
+ * organization gets one entry point, a connected one gets its connection
+ * lifecycle and the health of the projects already set up. Picking a project is
+ * deliberately not here — that happens where the project is used. The write
+ * actions are asserted against the endpoint they call: a repair that silently
+ * posted to the wrong binding would still look right on screen.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -14,8 +15,6 @@ import type { GitlabConnectionDto, GitlabProjectBindingDto } from '@/lib/api'
 const mocks = vi.hoisted(() => ({
   fetchConnections: vi.fn(),
   fetchProjects: vi.fn(),
-  searchProjects: vi.fn(),
-  createProject: vi.fn(),
   repairProject: vi.fn(),
   deleteProject: vi.fn(),
   disconnect: vi.fn(),
@@ -32,8 +31,6 @@ vi.mock('@/lib/api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/api')>()),
   fetchGitlabConnections: mocks.fetchConnections,
   fetchGitlabProjects: mocks.fetchProjects,
-  searchGitlabProjects: mocks.searchProjects,
-  createGitlabProject: mocks.createProject,
   repairGitlabProject: mocks.repairProject,
   deleteGitlabProject: mocks.deleteProject,
   disconnectGitlabConnection: mocks.disconnect,
@@ -92,13 +89,6 @@ async function click(label: string, scope: ParentNode = host): Promise<void> {
   })
 }
 
-/** The picker searches server-side behind a debounce; let it elapse for real. */
-async function settleSearch(): Promise<void> {
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 400))
-  })
-}
-
 /** One connection row and everything the card renders under it. */
 function connectionRow(id: string): HTMLElement {
   const found = host.querySelector(`[data-gitlab-connection="${id}"]`)
@@ -116,7 +106,6 @@ beforeEach(() => {
   vi.clearAllMocks()
   document.body.innerHTML = ''
   mocks.fetchProjects.mockResolvedValue([])
-  mocks.searchProjects.mockResolvedValue({ projects: [], nextPage: null })
 })
 
 describe('GitlabCard', () => {
@@ -246,7 +235,7 @@ describe('GitlabCard', () => {
     expect(host.querySelectorAll('[data-gitlab-project]')).toHaveLength(0)
   })
 
-  it('picks the connected account for the picker, not the oldest row', async () => {
+  it('lists every retained connection, stale ones included', async () => {
     // The repository orders by createdAt ASC and retains stale rows, so the first is often unusable.
     mocks.fetchConnections.mockResolvedValue({
       enabled: true,
@@ -256,13 +245,29 @@ describe('GitlabCard', () => {
       ]
     })
     await render()
-    // Both rows still render; only the usable one drives the picker.
     expect(host.textContent).toContain('former-admin')
     expect(host.textContent).toContain('current-admin')
+    expect(host.querySelectorAll('[data-gitlab-connection]')).toHaveLength(2)
+  })
 
-    await click('Add project')
-    await settleSearch()
-    expect(mocks.searchProjects).toHaveBeenCalledWith('conn-new', {})
+  it('manages bindings but never picks a project: no add-project surface', async () => {
+    // Authorization lives at the point of use; the card is the health list, like GitHub's.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    await render()
+
+    expect(() => buttonIn(host, 'Add project')).toThrow()
+    expect(host.querySelector('input[aria-label="Search GitLab projects"]')).toBeNull()
+    // The health list itself is untouched: the project, its state, and its repairs.
+    expect(host.querySelectorAll('[data-gitlab-project]')).toHaveLength(1)
+    expect(buttonIn(host, 'Repair')).toBeTruthy()
+  })
+
+  it('says where projects come from when a connection has none', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    await render()
+    expect(host.textContent).toContain('No projects are set up yet')
+    expect(host.textContent).toContain('agent workspace')
   })
 
   it('translates known binding reasons and hides unmapped machine categories', async () => {
@@ -302,29 +307,5 @@ describe('GitlabCard', () => {
     expect(host.textContent).not.toContain('rotation_gitlab_503')
     expect(host.textContent).not.toContain('project_not_accessible')
     expect(host.textContent).toContain('bot access degraded')
-  })
-
-  it('binds a searched project through the connection that found it', async () => {
-    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
-    mocks.searchProjects.mockResolvedValue({
-      projects: [
-        { projectId: '90210', path: 'example-group/example-project', defaultBranch: 'main', lastActivityAt: null }
-      ],
-      nextPage: null
-    })
-    mocks.createProject.mockResolvedValue(BINDING)
-    await render()
-
-    await click('Add project')
-    await settleSearch()
-    expect(mocks.searchProjects).toHaveBeenCalledWith('conn-1', {})
-
-    const row = [...host.querySelectorAll('button')].find(
-      (candidate) => candidate.getAttribute('aria-label') === 'Add example-group/example-project'
-    )
-    await act(async () => {
-      row!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
-    expect(mocks.createProject).toHaveBeenCalledWith({ connectionId: 'conn-1', projectId: '90210' })
   })
 })

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -1,26 +1,26 @@
 // No 'use client' here: rendered only inside a client boundary (IntegrationsView).
 
-// The org's GitLab.com connection and the projects it manages (gitlab-com-integration.md §18.1).
+// The org's GitLab.com connection and the health of the projects it manages
+// (gitlab-com-integration.md §18.1). Like the GitHub card this is the management
+// surface only: a project joins the organization where it is used — the hook and
+// workspace flows — not from a picker here.
 // Deployment-config opt-in: with no GitLab application configured these routes 404 and the card says so.
 // Connections and projects are org-level infrastructure — visible to all, writable by non-viewers.
 
-import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { Button, Icon } from '@/components/ui'
 import { GitlabMark, LoadingState } from '@/components/marks'
 import { useOrgs } from '@/lib/org-context'
 import { GITLAB_PROJECT_STATE } from '@/lib/gitlab-projects'
 import {
-  createGitlabProject,
   deleteGitlabProject,
   disconnectGitlabConnection,
   fetchGitlabConnections,
   fetchGitlabProjects,
   repairGitlabProject,
-  searchGitlabProjects,
   startGitlabOauth,
   type GitlabConnectionDto,
-  type GitlabProjectBindingDto,
-  type GitlabProjectDto
+  type GitlabProjectBindingDto
 } from '@/lib/api'
 
 // The CP records a machine category in `stateReason`; these are the ones a user can act on, in GitLab
@@ -60,7 +60,6 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
   // One pending connection action: releasing a live row, or removing a released one.
   const [pending, setPending] = useState<{ target: GitlabConnectionDto; remove: boolean } | null>(null)
   const [removing, setRemoving] = useState<GitlabProjectBindingDto | null>(null)
-  const [adding, setAdding] = useState(false)
 
   useEffect(() => {
     if (!activeOrg) return
@@ -80,10 +79,6 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
       alive = false
     }
   }, [activeOrg])
-
-  // Every row is listed, but the picker installs through one that can still talk to GitLab: disconnected
-  // and reauth-required rows are retained, so the oldest connection is often not a usable one.
-  const live = connections.find((c) => c.state === 'connected') ?? null
 
   // The authorization URL carries a one-shot state — mint a fresh one per click.
   const connect = async () => {
@@ -160,11 +155,6 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     }
   }
 
-  const onBound = useCallback((binding: GitlabProjectBindingDto) => {
-    setProjects((current) => [...current.filter((p) => p.id !== binding.id), binding])
-    setAdding(false)
-  }, [])
-
   return (
     <div className="card">
       <div className="cardhead justify-between">
@@ -174,21 +164,11 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
           </span>
           GitLab
         </span>
-        {enabled === true && canWrite && (
-          <span className="flex items-center gap-2">
-            {live && (
-              <Button variant="ghost" onClick={() => setAdding((open) => !open)}>
-                <Icon name="plus" size={13} />
-                Add project
-              </Button>
-            )}
-            {connections.length === 0 && (
-              <Button onClick={connect}>
-                <Icon name="external-link" size={13} />
-                Connect GitLab
-              </Button>
-            )}
-          </span>
+        {enabled === true && canWrite && connections.length === 0 && (
+          <Button onClick={connect}>
+            <Icon name="external-link" size={13} />
+            Connect GitLab
+          </Button>
         )}
       </div>
 
@@ -203,8 +183,8 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
         <div className="px-4 py-7 text-center">
           <div className="font-sans text-[13px] font-semibold leading-normal">Not connected</div>
           <div className="mt-1 font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-            Connect a GitLab account with Maintainer or Owner access to your projects. AgentConnect then sets up a
-            project bot and a webhook per project you add, and agents answer merge requests and issues there.
+            Connect a GitLab account with Maintainer or Owner access to your projects. You then pick a project when you
+            add a trigger or an agent workspace, and AgentConnect sets up its project bot and webhook there.
           </div>
         </div>
       )}
@@ -287,8 +267,11 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
           </div>
         ))}
 
-      {enabled === true && live && adding && canWrite && (
-        <AddGitlabProject connectionId={live.id} bound={projects} onBound={onBound} onError={setErr} />
+      {enabled === true && connections.length > 0 && projects.length === 0 && (
+        <div className="px-4 py-5 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+          No projects are set up yet. Pick one when you add a GitLab trigger or an agent workspace — it is set up there,
+          and shows up here for repairs.
+        </div>
       )}
 
       {/* Desktop only: below the breakpoint the row stacks, where a two-track header would label nothing. */}
@@ -451,101 +434,5 @@ function ConfirmGitlab({
         </Button>
       </div>
     </>
-  )
-}
-
-// The picker: GitLab searches server-side, so keystrokes settle through a debounce, not a local roster.
-const SEARCH_DEBOUNCE_MS = 300
-
-function AddGitlabProject({
-  connectionId,
-  bound,
-  onBound,
-  onError
-}: {
-  connectionId: string
-  bound: GitlabProjectBindingDto[]
-  onBound: (binding: GitlabProjectBindingDto) => void
-  onError: (message: string | null) => void
-}) {
-  const [query, setQuery] = useState('')
-  const [results, setResults] = useState<GitlabProjectDto[]>([])
-  const [loading, setLoading] = useState(false)
-  const [bindingId, setBindingId] = useState<string | null>(null)
-
-  useEffect(() => {
-    let alive = true
-    setLoading(true)
-    const timer = setTimeout(() => {
-      searchGitlabProjects(connectionId, query.trim() ? { search: query.trim() } : {})
-        .then((page) => alive && setResults(page.projects))
-        .catch((e) => alive && onError(errorText(e)))
-        .finally(() => alive && setLoading(false))
-    }, SEARCH_DEBOUNCE_MS)
-    return () => {
-      alive = false
-      clearTimeout(timer)
-    }
-  }, [connectionId, query, onError])
-
-  const bind = async (project: GitlabProjectDto) => {
-    if (bindingId) return
-    setBindingId(project.projectId)
-    onError(null)
-    try {
-      onBound(await createGitlabProject({ connectionId, projectId: project.projectId }))
-    } catch (e) {
-      onError(errorText(e))
-    } finally {
-      setBindingId(null)
-    }
-  }
-
-  const boundIds = new Set(bound.map((b) => b.projectId))
-
-  return (
-    <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 py-3">
-      <label className="relative flex items-center">
-        <Icon
-          name="search"
-          size={15}
-          color="var(--text-tertiary)"
-          className="pointer-events-none absolute left-[11px]"
-        />
-        <input
-          className="inp mn pl-[34px]"
-          placeholder="Search your GitLab projects…"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          aria-label="Search GitLab projects"
-        />
-      </label>
-      {loading && <LoadingState size={18} padding={12} />}
-      {!loading && results.length === 0 && (
-        <div className="py-3 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-          No projects matched.
-        </div>
-      )}
-      {!loading &&
-        results.map((p) => (
-          <div key={p.projectId} className="flex items-center gap-3 py-[7px]">
-            <span className="mono min-w-0 flex-1 truncate text-[12.5px]">{p.path}</span>
-            {boundIds.has(p.projectId) ? (
-              <span className="badge bg-(--surface-active) text-(--text-tertiary)">added</span>
-            ) : (
-              <Button
-                variant="ghost"
-                size="xs"
-                disabled={bindingId !== null}
-                onClick={() => bind(p)}
-                ariaLabel={`Add ${p.path}`}
-              >
-                <Icon name="plus" size={13} />
-                {bindingId === p.projectId ? 'Adding…' : 'Add'}
-              </Button>
-            )}
-          </div>
-        ))}
-    </div>
   )
 }

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -4,8 +4,8 @@ import type { KeyboardEvent, ReactNode } from 'react'
 import { GithubMark, GitlabMark } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
 import { featureFlagEnabled } from '@/lib/feature-flags'
-import { GITLAB_PROJECT_STATE, gitlabProjectSelectable } from '@/lib/gitlab-projects'
-import type { GitlabProjectBindingDto, RepoAccess } from '@/lib/api'
+import { GITLAB_PROJECT_STATE, gitlabChoiceSelectable, type GitlabProjectChoice } from '@/lib/gitlab-projects'
+import type { RepoAccess } from '@/lib/api'
 
 export type WorkspaceMode = 'scratch' | 'github' | 'gitlab'
 export type WorkspaceRepoAccess = 'read' | 'write'
@@ -359,24 +359,29 @@ export function GitlabProjectField(props: RepositoryPickerProps) {
       mark={<GitlabMark />}
       emptyLabel="Pick a project"
       loadingLabel="Loading projects…"
-      searchPlaceholder="Search your added projects…"
+      searchPlaceholder="Search your GitLab projects…"
     />
   )
 }
 
-/** One added project. Transient states are listed and disabled, not hidden — a project
- *  the user just added reads as on its way rather than mysteriously absent. */
+/** One pickable project — already added, or one this connection can add. Picking
+ *  an unadded one sets up its bot and webhook, which is why it says so before the
+ *  click. Transient states are listed and disabled, not hidden: a project that is
+ *  mid-setup reads as on its way rather than mysteriously absent. */
 export function GitlabProjectOption({
-  project,
+  choice,
   selected = false,
+  busy = false,
   onSelect
 }: {
-  project: GitlabProjectBindingDto
+  choice: GitlabProjectChoice
   selected?: boolean
+  busy?: boolean
   onSelect: () => void
 }) {
-  const selectable = gitlabProjectSelectable(project.state)
-  const state = GITLAB_PROJECT_STATE[project.state]
+  const selectable = gitlabChoiceSelectable(choice) && !busy
+  const state = choice.binding ? GITLAB_PROJECT_STATE[choice.binding.state] : null
+  const branch = choice.defaultBranch ? `default branch ${choice.defaultBranch}` : 'no default branch reported'
   return (
     <button
       type="button"
@@ -385,7 +390,7 @@ export function GitlabProjectOption({
           ? 'fopt min-h-[46px] items-center gap-3 px-2 py-2'
           : 'fopt min-h-[46px] cursor-not-allowed items-center gap-3 px-2 py-2 opacity-60'
       }
-      title={project.projectPath}
+      title={choice.projectPath}
       aria-disabled={!selectable}
       disabled={!selectable}
       onClick={() => selectable && onSelect()}
@@ -396,34 +401,48 @@ export function GitlabProjectOption({
       <span className="flex min-w-0 flex-1 flex-col items-start gap-[2px] overflow-hidden">
         <span
           className="block w-full min-w-0 truncate font-mono text-[12.5px] font-semibold leading-normal text-(--text-primary)"
-          title={project.projectPath}
+          title={choice.projectPath}
         >
-          {project.projectPath}
+          {choice.projectPath}
         </span>
         <span className="block w-full min-w-0 truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-          {project.defaultBranch ? `default branch ${project.defaultBranch}` : 'no default branch reported'}
+          {busy ? 'Setting up the project bot and webhook…' : choice.binding ? branch : `${branch} · sets up on pick`}
         </span>
       </span>
-      {project.state !== 'ready' && <span className={`badge flex-none ${state.badge}`}>{state.label}</span>}
+      {state && state.label !== 'ready' && <span className={`badge flex-none ${state.badge}`}>{state.label}</span>}
       {selected && <Icon name="check" size={17} color="var(--brand)" />}
     </button>
   )
 }
 
-/** Nothing to pick yet: projects come from the organization's GitLab connection. */
-export function GitlabNoProjectsNotice({ integrationsHref }: { integrationsHref: string }) {
+/** Nothing to pick: either no GitLab account is connected, or the connected one
+ *  administers nothing this organization may set up. */
+export function GitlabNoProjectsNotice({
+  integrationsHref,
+  connected
+}: {
+  integrationsHref: string
+  connected: boolean
+}) {
   return (
     <div className="flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">
       <span className="mt-[1px] flex h-[14px] w-[14px] flex-none items-center justify-center">
         <GitlabMark fillPct={100} />
       </span>
-      <span>
-        No GitLab projects have been added yet. Connect GitLab and add a project under{' '}
-        <a className="lnk font-medium" href={integrationsHref}>
-          Integrations
-        </a>
-        , then pick it here.
-      </span>
+      {connected ? (
+        <span>
+          The connected GitLab account has no project to offer. You need Maintainer or Owner access to a project before
+          it can be set up here.
+        </span>
+      ) : (
+        <span>
+          No GitLab account is connected yet. Connect GitLab under{' '}
+          <a className="lnk font-medium" href={integrationsHref}>
+            Integrations
+          </a>
+          , then pick a project here.
+        </span>
+      )}
     </div>
   )
 }

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -43,13 +43,11 @@ import {
   fetchGithubInstallUrl,
   fetchGithubRepoRoster,
   fetchGithubRepoAccess,
-  fetchGitlabProjects,
   invalidateGithubRepoRosterCache,
   type AgentWorkspaceDto,
   type GithubInstallationDto,
   type GithubRepoAccess,
-  type GithubRepoDto,
-  type GitlabProjectBindingDto
+  type GithubRepoDto
 } from '@/lib/api'
 import { GithubMark, LoadingState } from '@/components/marks'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
@@ -95,7 +93,8 @@ import {
   WorkspaceModeField,
   type WorkspaceMode
 } from '@/components/console/WorkspaceFormFields'
-import { gitlabProjectSelectable, matchGitlabProjects } from '@/lib/gitlab-projects'
+import { matchGitlabProjects, type GitlabProjectChoice } from '@/lib/gitlab-projects'
+import { useGitlabProjects } from '@/lib/use-gitlab-projects'
 
 type WsMode = WorkspaceMode
 type RepoCheckState = 'idle' | 'checking' | 'missing' | 'found'
@@ -272,10 +271,8 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const [ghPublicExactRepo, setGhPublicExactRepo] = useState<GithubRepoDto | null>(null)
   const [ghExactRepoState, setGhExactRepoState] = useState<RepoCheckState>('idle')
   const [ghManualPublicRepo, setGhManualPublicRepo] = useState<GithubRepoDto | null>(null)
-  // GitLab path: the organization's added projects, picked by their numeric id.
-  // Null while the list is still loading; the picker never adds a project itself.
-  const [glProjects, setGlProjects] = useState<GitlabProjectBindingDto[] | null>(null)
-  const [glProjectsError, setGlProjectsError] = useState<string | null>(null)
+  // GitLab path: projects picked by their numeric id. One this organization has
+  // not added yet is set up as part of picking it (§18.1).
   const [glProject, setGlProject] = useState('')
   const [glOpen, setGlOpen] = useState(false)
   const [glQ, setGlQ] = useState('')
@@ -501,22 +498,19 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
 
   // Only the GitLab pane asks for projects, so a deployment without the flag
   // never issues the request — the mode tile it would come from is not offered.
-  useEffect(() => {
-    if (wsMode !== 'gitlab' || glProjects !== null) return
-    let alive = true
-    setGlProjectsError(null)
-    fetchGitlabProjects().then(
-      (bindings) => alive && setGlProjects(bindings),
-      (e) => alive && setGlProjectsError(e instanceof Error ? e.message : String(e))
-    )
-    return () => {
-      alive = false
-    }
-  }, [glProjects, wsMode])
+  const gl = useGitlabProjects(wsMode === 'gitlab', glQ)
+  const glNoProjects = wsMode === 'gitlab' && gl.empty
+  const glPicked = gl.choices.find((choice) => choice.projectId === glProject)
+  const glMatches = matchGitlabProjects(gl.choices, glQ)
 
-  const glSelectable = (glProjects ?? []).filter((project) => gitlabProjectSelectable(project.state))
-  const glNoProjects = wsMode === 'gitlab' && glProjects !== null && glSelectable.length === 0
-  const glPicked = (glProjects ?? []).find((project) => project.projectId === glProject)
+  // Picking an unadded project provisions it first; a failed setup picks nothing.
+  const pickGlProject = async (choice: GitlabProjectChoice) => {
+    if (!choice.binding && !(await gl.provision(choice.projectId))) return
+    setGlProject(choice.projectId)
+    setGlOpen(false)
+    setBranch(choice.defaultBranch ?? '')
+    setErr(null)
+  }
 
   // Installations loaded or refreshed → merge repository pages as they arrive.
   // GitHub has no server-side search here, so the dropdown filters locally.
@@ -1473,16 +1467,16 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
               )}
 
               {wsMode === 'gitlab' &&
-                (glProjectsError ? (
+                (gl.error ? (
                   <div className="font-sans text-[12px] font-normal leading-[1.5] text-(--status-error) desktop:col-span-2">
-                    Couldn&rsquo;t load your GitLab projects — {glProjectsError}
+                    Couldn&rsquo;t load your GitLab projects — {gl.error}
                   </div>
-                ) : glProjects === null ? (
+                ) : gl.loading ? (
                   <div className="desktop:col-span-2">
                     <LoadingState size={20} padding={16} />
                   </div>
                 ) : glNoProjects ? (
-                  <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} />
+                  <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} connected={gl.connected} />
                 ) : (
                   <div className="grid grid-cols-1 gap-[14px] desktop:col-span-2 desktop:grid-cols-2 desktop:gap-x-7">
                     <GitlabProjectField
@@ -1498,23 +1492,18 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                       }}
                       onClose={() => setGlOpen(false)}
                       onQueryChange={setGlQ}
+                      error={gl.provisionError ? `Couldn’t set up that project — ${gl.provisionError}` : undefined}
                     >
-                      {matchGitlabProjects(glProjects, glQ).map((project) => (
+                      {glMatches.map((choice) => (
                         <GitlabProjectOption
-                          key={project.id}
-                          project={project}
-                          selected={glProject === project.projectId}
-                          onSelect={() => {
-                            setGlProject(project.projectId)
-                            setGlOpen(false)
-                            setBranch(project.defaultBranch ?? '')
-                            setErr(null)
-                          }}
+                          key={choice.projectId}
+                          choice={choice}
+                          selected={glProject === choice.projectId}
+                          busy={gl.provisioning === choice.projectId}
+                          onSelect={() => void pickGlProject(choice)}
                         />
                       ))}
-                      {matchGitlabProjects(glProjects, glQ).length === 0 && (
-                        <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>
-                      )}
+                      {glMatches.length === 0 && <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>}
                     </GitlabProjectField>
 
                     <RepositoryAccessField

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -6,10 +6,13 @@
  * stored vocabulary the CP validates (`family:*` patterns, note families,
  * labels, mention-only) keyed by the project's numeric id rather than its
  * renameable path; and pushes stay a per-push subscription across the cadence.
+ *
+ * The picker also offers projects the organization has not added yet, because
+ * this wizard is now where a project joins the organization.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Agent } from '@/lib/data'
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
@@ -17,6 +20,9 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 const mocks = vi.hoisted(() => ({
   createGitlabHook: vi.fn(async () => ({ id: 'hook-1', agentId: 'agent-a', kind: 'gitlab' })),
   fetchGitlabProjects: vi.fn(),
+  fetchGitlabConnections: vi.fn(),
+  searchGitlabProjects: vi.fn(),
+  createGitlabProject: vi.fn(),
   daemons: [] as unknown[]
 }))
 
@@ -45,7 +51,10 @@ vi.mock('@/lib/api', async (importOriginal) => ({
   fetchGithubInstallUrl: vi.fn(async () => null),
   fetchGithubRepoRoster: vi.fn(async () => ({ repos: [], privateReposHidden: false, failed: false })),
   syncGithubInstallations: vi.fn(async () => []),
-  fetchGitlabProjects: mocks.fetchGitlabProjects
+  fetchGitlabProjects: mocks.fetchGitlabProjects,
+  fetchGitlabConnections: mocks.fetchGitlabConnections,
+  searchGitlabProjects: mocks.searchGitlabProjects,
+  createGitlabProject: mocks.createGitlabProject
 }))
 
 const AddIntegrationModal = (await import('./AddIntegrationModal')).default
@@ -68,6 +77,18 @@ const project = {
   serviceAccountUsername: 'project_4210_bot',
   webhookInstalled: true,
   credentialEpoch: '1',
+  createdAt: '2026-08-01T00:00:00.000Z'
+}
+
+const connection = {
+  id: 'conn-1',
+  gitlabUserId: '4711',
+  gitlabUsername: 'octo-maintainer',
+  state: 'connected',
+  scopes: ['api'],
+  connectedBy: 'user-1',
+  accessExpiresAt: null,
+  assignedProjects: 0,
   createdAt: '2026-08-01T00:00:00.000Z'
 }
 
@@ -106,6 +127,19 @@ async function pickProject() {
   await act(async () => clickText('acme/platform')?.click())
 }
 
+/** One usable connection with nothing else on offer; a test that needs another shape overrides it. */
+beforeEach(() => {
+  mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [connection] })
+  mocks.searchGitlabProjects.mockResolvedValue({ projects: [], nextPage: null })
+})
+
+/** Candidates are searched on GitLab behind a debounce; let it elapse for real. */
+async function settleSearch() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 400))
+  })
+}
+
 afterEach(async () => {
   setFlags()
   if (root) await act(async () => root?.unmount())
@@ -114,6 +148,9 @@ afterEach(async () => {
   host = undefined
   mocks.createGitlabHook.mockClear()
   mocks.fetchGitlabProjects.mockReset()
+  mocks.fetchGitlabConnections.mockReset()
+  mocks.searchGitlabProjects.mockReset()
+  mocks.createGitlabProject.mockReset()
   mocks.daemons = []
 })
 
@@ -126,6 +163,7 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     expect(tileNamed('GitHub')).toBeDefined()
     expect(tileNamed('GitLab')).toBeUndefined()
     expect(mocks.fetchGitlabProjects).not.toHaveBeenCalled()
+    expect(mocks.fetchGitlabConnections).not.toHaveBeenCalled()
   })
 
   it('defaults to the updated trigger, scoping replies to the selected subjects', async () => {
@@ -236,13 +274,52 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     expect(tileNamed('Discord')?.getAttribute('aria-disabled')).toBe('true')
   })
 
-  it('points at the connection surface when no project has been added', async () => {
+  it('points at the connection surface when no GitLab account is connected', async () => {
     setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([])
+    mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [] })
     await render()
     await act(async () => tileNamed('GitLab')?.click())
 
-    expect(document.body.textContent).toContain('No GitLab projects have been added yet')
+    expect(document.body.textContent).toContain('No GitLab account is connected yet')
     expect(document.querySelector('a[href="/acme/integrations"]')).not.toBeNull()
+    // Nothing to search through: an unusable connection never reaches the picker.
+    expect(mocks.searchGitlabProjects).not.toHaveBeenCalled()
+  })
+
+  it('sets up a project the organization has not added, then picks it', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([])
+    mocks.searchGitlabProjects.mockResolvedValue({
+      projects: [{ projectId: '4210', path: 'acme/platform', defaultBranch: 'main', lastActivityAt: null }],
+      nextPage: null
+    })
+    let settle: (binding: typeof project) => void = () => undefined
+    mocks.createGitlabProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settle = resolve
+        })
+    )
+    await render()
+    await act(async () => tileNamed('GitLab')?.click())
+    await settleSearch()
+    expect(mocks.searchGitlabProjects).toHaveBeenCalledWith('conn-1', {})
+
+    await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
+    // The candidate says what picking it will do before the click.
+    expect(document.body.textContent).toContain('sets up on pick')
+    await act(async () => clickText('acme/platform')?.click())
+    expect(mocks.createGitlabProject).toHaveBeenCalledWith({ connectionId: 'conn-1', projectId: '4210' })
+    // The saga takes seconds; the option says so while it runs.
+    expect(document.body.textContent).toContain('Setting up the project bot and webhook')
+
+    await act(async () => {
+      settle(project)
+    })
+    await act(async () => clickText('Connect')?.click())
+    expect(mocks.createGitlabHook).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'agent-a', name: 'acme/platform', projectId: '4210' })
+    )
   })
 })

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -52,14 +52,12 @@ import {
   fetchGithubInstallations,
   fetchGithubInstallUrl,
   fetchGithubRepoRoster,
-  fetchGitlabProjects,
   invalidateGithubRepoRosterCache,
   syncGithubInstallations,
   updateAgentRepo,
   type CreatedHookDto,
   type GithubInstallationDto,
   type GithubRepoDto,
-  type GitlabProjectBindingDto,
   type RepoAccess
 } from '@/lib/api'
 import EditWorkspaceModal from './EditWorkspaceModal'
@@ -87,7 +85,8 @@ import {
   type GlFamily,
   type GlTriggerMode
 } from '@/lib/gitlab-events'
-import { gitlabProjectSelectable, matchGitlabProjects } from '@/lib/gitlab-projects'
+import { matchGitlabProjects, type GitlabProjectChoice } from '@/lib/gitlab-projects'
+import { useGitlabProjects } from '@/lib/use-gitlab-projects'
 import {
   effectiveRepoAccess,
   hasChecksWritePermission,
@@ -361,13 +360,12 @@ export default function AddIntegrationModal({
       (ghReportingMode === 'check' &&
         (!hasChecksWritePermission(ghSelectedInstallation) || !hasPullRequestsReadPermission(ghSelectedInstallation))))
 
-  // GitLab path: the organization's added projects, one hook per project. The
-  // wizard never adds a project — that stays on the connection card.
-  const [glProjects, setGlProjects] = useState<GitlabProjectBindingDto[] | null>(null)
-  const [glProjectsError, setGlProjectsError] = useState<string | null>(null)
+  // GitLab path: one hook per project, picked here. A project the organization
+  // has not added yet is set up as part of picking it (§18.1).
   const [glProject, setGlProject] = useState<string | null>(null)
   const [glOpen, setGlOpen] = useState(false)
   const [glQ, setGlQ] = useState('')
+  const gl = useGitlabProjects(platform === 'gitlab', glQ)
   const [glFams, setGlFams] = useState<Set<GlFamily>>(new Set(GL_DEFAULT_FAMILIES))
   const [glMode, setGlMode] = useState<GlTriggerMode>(GL_DEFAULT_TRIGGER_MODE)
   const [glLabels, setGlLabels] = useState('')
@@ -805,24 +803,17 @@ export default function AddIntegrationModal({
     }
   }
 
-  // Only the GitLab pane asks for projects; the flag already decides whether the
-  // tile that reaches this pane exists at all.
-  useEffect(() => {
-    if (platform !== 'gitlab' || glProjects !== null) return
-    let alive = true
-    setGlProjectsError(null)
-    fetchGitlabProjects().then(
-      (bindings) => alive && setGlProjects(bindings),
-      (e) => alive && setGlProjectsError(e instanceof Error ? e.message : String(e))
-    )
-    return () => {
-      alive = false
-    }
-  }, [glProjects, platform])
+  const glPicked = gl.choices.find((choice) => choice.projectId === glProject)
+  const glMatches = matchGitlabProjects(gl.choices, glQ)
 
-  const glSelectable = (glProjects ?? []).filter((project) => gitlabProjectSelectable(project.state))
-  const glNoProjects = glProjects !== null && glSelectable.length === 0
-  const glPicked = (glProjects ?? []).find((project) => project.projectId === glProject)
+  // Picking an unadded project provisions it first; the pick lands on the
+  // binding the saga produced, so a failed setup selects nothing.
+  const pickGlProject = async (choice: GitlabProjectChoice) => {
+    if (!choice.binding && !(await gl.provision(choice.projectId))) return
+    setGlProject(choice.projectId)
+    setGlOpen(false)
+    setErr(null)
+  }
   // One hook per (agent, project) — the CP 409s a second one, so the picker says so first.
   const glWatchedProjects = useMemo(
     () =>
@@ -1651,15 +1642,15 @@ export default function AddIntegrationModal({
         )}
         {platform === 'gitlab' && (
           <>
-            {glProjectsError ? (
+            {gl.error ? (
               <div className="mb-4 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
-                Couldn&rsquo;t load your GitLab projects — {glProjectsError}
+                Couldn&rsquo;t load your GitLab projects — {gl.error}
               </div>
-            ) : glProjects === null ? (
+            ) : gl.loading ? (
               <LoadingState size={20} padding={16} />
-            ) : glNoProjects ? (
+            ) : gl.empty ? (
               <div className="mb-4">
-                <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} />
+                <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} connected={gl.connected} />
               </div>
             ) : (
               <>
@@ -1677,26 +1668,23 @@ export default function AddIntegrationModal({
                     onClose={() => setGlOpen(false)}
                     onQueryChange={setGlQ}
                     error={
-                      glAlreadyWatched
-                        ? `This agent already watches ${glPicked?.projectPath ?? 'this project'}.`
-                        : undefined
+                      gl.provisionError
+                        ? `Couldn’t set up that project — ${gl.provisionError}`
+                        : glAlreadyWatched
+                          ? `This agent already watches ${glPicked?.projectPath ?? 'this project'}.`
+                          : undefined
                     }
                   >
-                    {matchGitlabProjects(glProjects, glQ).map((project) => (
+                    {glMatches.map((choice) => (
                       <GitlabProjectOption
-                        key={project.id}
-                        project={project}
-                        selected={glProject === project.projectId}
-                        onSelect={() => {
-                          setGlProject(project.projectId)
-                          setGlOpen(false)
-                          setErr(null)
-                        }}
+                        key={choice.projectId}
+                        choice={choice}
+                        selected={glProject === choice.projectId}
+                        busy={gl.provisioning === choice.projectId}
+                        onSelect={() => void pickGlProject(choice)}
                       />
                     ))}
-                    {matchGitlabProjects(glProjects, glQ).length === 0 && (
-                      <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>
-                    )}
+                    {glMatches.length === 0 && <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>}
                   </GitlabProjectField>
                 </div>
                 <div className="fldlbl mb-2">Listen for</div>

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
@@ -4,7 +4,8 @@
  * tile must not exist AND the project list must never be requested, because a
  * deployment without a GitLab application does not serve that route. With it on,
  * the picker offers the organization's added projects — every state except the
- * transient ones — and the save sends the numeric project id, never the path.
+ * transient ones — alongside the ones the connected account can still set up,
+ * and the save sends the numeric project id, never the path.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -13,6 +14,9 @@ import type { Agent } from '@/lib/data'
 
 const mocks = vi.hoisted(() => ({
   fetchGitlabProjects: vi.fn(),
+  fetchGitlabConnections: vi.fn(),
+  searchGitlabProjects: vi.fn(),
+  createGitlabProject: vi.fn(),
   setAgentWorkspace: vi.fn(async () => ({}) as Agent)
 }))
 
@@ -25,6 +29,9 @@ vi.mock('@/lib/api', async (importOriginal) => ({
   fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
   fetchGithubInstallUrl: vi.fn(async () => null),
   fetchGitlabProjects: mocks.fetchGitlabProjects,
+  fetchGitlabConnections: mocks.fetchGitlabConnections,
+  searchGitlabProjects: mocks.searchGitlabProjects,
+  createGitlabProject: mocks.createGitlabProject,
   setAgentWorkspace: mocks.setAgentWorkspace
 }))
 
@@ -79,8 +86,36 @@ afterEach(async () => {
   root = undefined
   host = undefined
   mocks.fetchGitlabProjects.mockReset()
+  mocks.fetchGitlabConnections.mockReset()
+  mocks.searchGitlabProjects.mockReset()
+  mocks.createGitlabProject.mockReset()
   mocks.setAgentWorkspace.mockClear()
 })
+
+const CONNECTION = {
+  id: 'conn-1',
+  gitlabUserId: '4711',
+  gitlabUsername: 'octo-maintainer',
+  state: 'connected' as const,
+  scopes: ['api'],
+  connectedBy: 'user-1',
+  accessExpiresAt: null,
+  assignedProjects: 0,
+  createdAt: '2026-08-01T00:00:00.000Z'
+}
+
+/** One connected account with nothing else to offer, unless a test says otherwise. */
+function connected(projects: unknown[] = []) {
+  mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+  mocks.searchGitlabProjects.mockResolvedValue({ projects, nextPage: null })
+}
+
+/** Candidates are searched on GitLab behind a debounce; let it elapse for real. */
+async function settleSearch() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 400))
+  })
+}
 
 describe('EditWorkspaceModal, GitLab workspace', () => {
   it('offers no GitLab source and asks for no projects while the flag is off', async () => {
@@ -90,6 +125,7 @@ describe('EditWorkspaceModal, GitLab workspace', () => {
 
     expect(document.body.textContent).not.toContain('From GitLab')
     expect(mocks.fetchGitlabProjects).not.toHaveBeenCalled()
+    expect(mocks.fetchGitlabConnections).not.toHaveBeenCalled()
   })
 
   it('lists the added projects and disables the ones still setting up', async () => {
@@ -99,14 +135,17 @@ describe('EditWorkspaceModal, GitLab workspace', () => {
       binding({ projectId: '2', projectPath: 'acme/runtime', state: 'runtime_degraded' }),
       binding({ projectId: '3', projectPath: 'acme/fresh', state: 'provisioning' })
     ])
+    // GitLab lists an added project among the account's projects too — it stays one row.
+    connected([{ projectId: '1', path: 'acme/platform', defaultBranch: 'main', lastActivityAt: null }])
     await render()
     await act(async () => buttonsNamed('From GitLab')[0]?.click())
+    await settleSearch()
     await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
 
     const options = Array.from(document.querySelectorAll('button')).filter((button) =>
       button.textContent?.includes('acme/')
     )
-    expect(options.map((option) => option.textContent?.includes('acme/platform'))).toContain(true)
+    expect(options.filter((option) => option.textContent?.includes('acme/platform'))).toHaveLength(1)
     expect(options.find((option) => option.textContent?.includes('acme/fresh'))?.disabled).toBe(true)
     expect(options.find((option) => option.textContent?.includes('acme/runtime'))?.disabled).toBe(false)
     expect(document.body.textContent).toContain('bot access degraded')
@@ -115,6 +154,7 @@ describe('EditWorkspaceModal, GitLab workspace', () => {
   it('saves the picked project by its numeric id', async () => {
     setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([binding({ projectId: '4210', projectPath: 'acme/platform' })])
+    connected()
     await render()
     await act(async () => buttonsNamed('From GitLab')[0]?.click())
     await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
@@ -133,13 +173,54 @@ describe('EditWorkspaceModal, GitLab workspace', () => {
     })
   })
 
-  it('points at the connection surface when no project has been added', async () => {
+  it('points at the connection surface when no GitLab account is connected', async () => {
     setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([])
+    mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [] })
     await render()
     await act(async () => buttonsNamed('From GitLab')[0]?.click())
 
-    expect(document.body.textContent).toContain('No GitLab projects have been added yet')
+    expect(document.body.textContent).toContain('No GitLab account is connected yet')
     expect(document.querySelector('a[href="/acme/integrations"]')).not.toBeNull()
+    expect(mocks.searchGitlabProjects).not.toHaveBeenCalled()
+  })
+
+  it('sets up a project the organization has not added, then saves it', async () => {
+    setFlags('gitlab')
+    mocks.fetchGitlabProjects.mockResolvedValue([])
+    connected([{ projectId: '4210', path: 'acme/platform', defaultBranch: 'main', lastActivityAt: null }])
+    let settle: (value: unknown) => void = () => undefined
+    mocks.createGitlabProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settle = resolve
+        })
+    )
+    await render()
+    await act(async () => buttonsNamed('From GitLab')[0]?.click())
+    await settleSearch()
+    expect(mocks.searchGitlabProjects).toHaveBeenCalledWith('conn-1', {})
+
+    await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
+    expect(document.body.textContent).toContain('sets up on pick')
+    const option = Array.from(document.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('acme/platform')
+    )
+    await act(async () => option?.click())
+    expect(mocks.createGitlabProject).toHaveBeenCalledWith({ connectionId: 'conn-1', projectId: '4210' })
+    // The saga takes seconds, and the picker says so instead of looking stuck.
+    expect(document.body.textContent).toContain('Setting up the project bot and webhook')
+
+    await act(async () => {
+      settle(binding({ projectId: '4210', projectPath: 'acme/platform' }))
+    })
+    await act(async () => buttonsNamed('Replace workspace')[0]?.click())
+    expect(mocks.setAgentWorkspace).toHaveBeenCalledWith('agent-a', {
+      mode: 'gitlab',
+      worktree: true,
+      projectId: '4210',
+      gitBranch: 'main',
+      gitAccess: 'write'
+    })
   })
 })

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -12,7 +12,8 @@ import { agentLabel, isPoolPlacementKind, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
 import { featureFlagEnabled } from '@/lib/feature-flags'
-import { gitlabProjectSelectable, matchGitlabProjects } from '@/lib/gitlab-projects'
+import { matchGitlabProjects, type GitlabProjectChoice } from '@/lib/gitlab-projects'
+import { useGitlabProjects } from '@/lib/use-gitlab-projects'
 import {
   ApiError,
   deleteAgentRepo,
@@ -22,14 +23,12 @@ import {
   fetchGithubInstallUrl,
   fetchGithubRepoRoster,
   fetchGithubRepoAccess,
-  fetchGitlabProjects,
   invalidateGithubRepoRosterCache,
   syncGithubInstallations,
   type AgentRepoAuthDto,
   type GithubInstallationDto,
   type GithubRepoAccess,
   type GithubRepoDto,
-  type GitlabProjectBindingDto,
   type RepoAccess
 } from '@/lib/api'
 import { agentDirInputValue, normalizeAgentDir } from '@/lib/repo-subdir'
@@ -113,9 +112,6 @@ export default function EditWorkspaceModal({
   const [branchQ, setBranchQ] = useState('')
   const [agentDir, setAgentDir] = useState(currentAgentDir)
   const [worktree, setWorktree] = useState(gitWorkspace ? gitWorkspace.worktree === true : true)
-  // The organization's added GitLab projects; null while the list is still loading.
-  const [glProjects, setGlProjects] = useState<GitlabProjectBindingDto[] | null>(null)
-  const [glProjectsError, setGlProjectsError] = useState<string | null>(null)
   const [glPick, setGlPick] = useState(gitlabWorkspace?.projectId ?? '')
   const [glPickOpen, setGlPickOpen] = useState(false)
   const [glQ, setGlQ] = useState('')
@@ -193,20 +189,9 @@ export default function EditWorkspaceModal({
     }
   }, [gh, repositoryEditor, reposNonce])
 
-  // Added projects only — the picker never installs one, so the connection card
-  // stays the single place a project joins the organization.
-  useEffect(() => {
-    if (repositoryEditor !== null || !gitlabOffered || mode !== 'gitlab' || glProjects !== null) return
-    let alive = true
-    setGlProjectsError(null)
-    fetchGitlabProjects().then(
-      (bindings) => alive && setGlProjects(bindings),
-      (e) => alive && setGlProjectsError(e instanceof Error ? e.message : String(e))
-    )
-    return () => {
-      alive = false
-    }
-  }, [gitlabOffered, glProjects, mode, repositoryEditor])
+  // The projects this organization added, plus the ones the connected account can
+  // still add — picking one of those sets it up here (§18.1).
+  const gl = useGitlabProjects(repositoryEditor === null && gitlabOffered && mode === 'gitlab', glQ)
 
   const openGhInstall = async () => {
     const url = await fetchGithubInstallUrl().catch(() => null)
@@ -304,9 +289,9 @@ export default function EditWorkspaceModal({
   }
 
   const noInstall = mode === 'github' && gh !== null && (!gh.enabled || gh.installations.length === 0)
-  const glSelectable = (glProjects ?? []).filter((project) => gitlabProjectSelectable(project.state))
-  const noProjects = mode === 'gitlab' && glProjects !== null && glSelectable.length === 0
-  const glPicked = (glProjects ?? []).find((project) => project.projectId === glPick)
+  const noProjects = mode === 'gitlab' && gl.empty
+  const glPicked = gl.choices.find((choice) => choice.projectId === glPick)
+  const glMatches = matchGitlabProjects(gl.choices, glQ)
   // Falls back to the stored path so the current project reads correctly before the list lands.
   const glPickLabel =
     glPicked?.projectPath ?? (glPick && glPick === gitlabWorkspace?.projectId ? gitlabWorkspace.repo : '')
@@ -354,11 +339,13 @@ export default function EditWorkspaceModal({
     setErr(null)
   }
 
-  const selectProject = (project: GitlabProjectBindingDto) => {
-    setGlPick(project.projectId)
+  // Picking an unadded project provisions it first; a failed setup picks nothing.
+  const selectProject = async (choice: GitlabProjectChoice) => {
+    if (!choice.binding && !(await gl.provision(choice.projectId))) return
+    setGlPick(choice.projectId)
     setGlPickOpen(false)
     setAccessOpen(false)
-    setBranch(project.defaultBranch ?? '')
+    setBranch(choice.defaultBranch ?? '')
     setAgentDir('')
     setErr(null)
   }
@@ -503,16 +490,16 @@ export default function EditWorkspaceModal({
 
           {mode === 'gitlab' && (
             <div className="mb-4 grid grid-cols-1 gap-[14px] desktop:grid-cols-2 desktop:gap-x-7">
-              {glProjectsError ? (
+              {gl.error ? (
                 <div className="font-sans text-[12px] font-normal leading-[1.5] text-(--status-error) desktop:col-span-2">
-                  Couldn&rsquo;t load your GitLab projects — {glProjectsError}
+                  Couldn&rsquo;t load your GitLab projects — {gl.error}
                 </div>
-              ) : glProjects === null ? (
+              ) : gl.loading ? (
                 <div className="desktop:col-span-2">
                   <LoadingState size={20} padding={16} />
                 </div>
               ) : noProjects ? (
-                <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} />
+                <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} connected={gl.connected} />
               ) : (
                 <>
                   <GitlabProjectField
@@ -528,18 +515,18 @@ export default function EditWorkspaceModal({
                     }}
                     onClose={() => setGlPickOpen(false)}
                     onQueryChange={setGlQ}
+                    error={gl.provisionError ? `Couldn’t set up that project — ${gl.provisionError}` : undefined}
                   >
-                    {matchGitlabProjects(glProjects, glQ).map((project) => (
+                    {glMatches.map((choice) => (
                       <GitlabProjectOption
-                        key={project.id}
-                        project={project}
-                        selected={glPick === project.projectId}
-                        onSelect={() => selectProject(project)}
+                        key={choice.projectId}
+                        choice={choice}
+                        selected={glPick === choice.projectId}
+                        busy={gl.provisioning === choice.projectId}
+                        onSelect={() => void selectProject(choice)}
                       />
                     ))}
-                    {matchGitlabProjects(glProjects, glQ).length === 0 && (
-                      <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>
-                    )}
+                    {glMatches.length === 0 && <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>}
                   </GitlabProjectField>
 
                   <RepositoryAccessField

--- a/packages/web/src/lib/gitlab-projects.ts
+++ b/packages/web/src/lib/gitlab-projects.ts
@@ -1,7 +1,11 @@
 /**
- * How the console words a managed GitLab project binding, shared by the
- * Connections card and the pickers that pick one (a workspace, a hook).
+ * How the console words a GitLab project at the point where one is picked — a
+ * hook subscription, an agent workspace — plus the shared vocabulary the
+ * Integrations card uses for the projects it already manages.
  *
+ * A picker offers two kinds of row: a project this organization already added,
+ * and a project the connected account could add. They are one `choice` list so
+ * the flow reads as "pick a project", never "go set one up elsewhere first".
  * The vocabulary names the broken half in GitLab terms, never the internal
  * state id, and the selectability rule is the one product answer: a project is
  * pickable once it exists on GitLab, even when its setup finished only partly.
@@ -9,7 +13,7 @@
  * project that is about to change underneath it.
  */
 
-import type { GitlabProjectBindingDto, GitlabProjectBindingState } from './api'
+import type { GitlabProjectBindingDto, GitlabProjectBindingState, GitlabProjectDto } from './api'
 
 export const GITLAB_PROJECT_STATE: Record<GitlabProjectBindingState, { label: string; badge: string }> = {
   provisioning: { label: 'setting up', badge: 'bg-(--status-info-soft) text-(--status-info)' },
@@ -19,16 +23,51 @@ export const GITLAB_PROJECT_STATE: Record<GitlabProjectBindingState, { label: st
   cleanup_pending: { label: 'removal incomplete', badge: 'bg-(--status-error-soft) text-(--status-error)' }
 }
 
+/** One pickable project: `binding` null means picking it sets it up first. */
+export interface GitlabProjectChoice {
+  projectId: string
+  projectPath: string
+  defaultBranch: string | null
+  binding: GitlabProjectBindingDto | null
+}
+
 /** Whether a binding may be attached to an agent workspace or a hook. */
 export function gitlabProjectSelectable(state: GitlabProjectBindingState): boolean {
   return state === 'ready' || state === 'admin_degraded' || state === 'runtime_degraded'
 }
 
-/** Filter a project list by the picker's search box — path substring, case-insensitive. */
-export function matchGitlabProjects(
-  projects: readonly GitlabProjectBindingDto[],
-  query: string
-): GitlabProjectBindingDto[] {
+/** An unadded project is always selectable — setup is what picking it does. */
+export function gitlabChoiceSelectable(choice: GitlabProjectChoice): boolean {
+  return choice.binding === null || gitlabProjectSelectable(choice.binding.state)
+}
+
+/** Added projects first, then what the connection could still add. A candidate
+ *  that is already added stays the binding's row, never a second one. */
+export function mergeGitlabProjectChoices(
+  bindings: readonly GitlabProjectBindingDto[],
+  candidates: readonly GitlabProjectDto[]
+): GitlabProjectChoice[] {
+  const added = new Set(bindings.map((binding) => binding.projectId))
+  return [
+    ...bindings.map((binding) => ({
+      projectId: binding.projectId,
+      projectPath: binding.projectPath,
+      defaultBranch: binding.defaultBranch,
+      binding
+    })),
+    ...candidates
+      .filter((candidate) => !added.has(candidate.projectId))
+      .map((candidate) => ({
+        projectId: candidate.projectId,
+        projectPath: candidate.path,
+        defaultBranch: candidate.defaultBranch,
+        binding: null
+      }))
+  ]
+}
+
+/** Filter a choice list by the picker's search box — path substring, case-insensitive. */
+export function matchGitlabProjects(choices: readonly GitlabProjectChoice[], query: string): GitlabProjectChoice[] {
   const wanted = query.trim().toLowerCase()
-  return projects.filter((project) => !wanted || project.projectPath.toLowerCase().includes(wanted))
+  return choices.filter((choice) => !wanted || choice.projectPath.toLowerCase().includes(wanted))
 }

--- a/packages/web/src/lib/use-gitlab-projects.test.tsx
+++ b/packages/web/src/lib/use-gitlab-projects.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+/**
+ * The picker's load must survive a lifecycle that starts twice. React Strict
+ * Mode deliberately runs setup → cleanup → setup on mount, and a user can leave
+ * the GitLab pane mid-request and come back; both abandon the first request. A
+ * one-shot "already started" flag made the second lifecycle skip its own fetch
+ * and wait forever on an answer nobody was listening for — a spinner that never
+ * ends. Each active lifecycle owns a fresh request.
+ */
+import { StrictMode, act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitlabConnectionDto, GitlabProjectBindingDto } from '@/lib/api'
+
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const mocks = vi.hoisted(() => ({
+  fetchProjects: vi.fn(),
+  fetchConnections: vi.fn(),
+  searchProjects: vi.fn(),
+  createProject: vi.fn()
+}))
+
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchGitlabProjects: mocks.fetchProjects,
+  fetchGitlabConnections: mocks.fetchConnections,
+  searchGitlabProjects: mocks.searchProjects,
+  createGitlabProject: mocks.createProject
+}))
+
+const { useGitlabProjects } = await import('./use-gitlab-projects')
+
+const CONNECTION: GitlabConnectionDto = {
+  id: 'conn-1',
+  gitlabUserId: '4711',
+  gitlabUsername: 'octo-maintainer',
+  state: 'connected',
+  scopes: ['api'],
+  connectedBy: 'user-1',
+  accessExpiresAt: null,
+  assignedProjects: 0,
+  createdAt: '2026-08-01T00:00:00.000Z'
+}
+
+const BINDING: GitlabProjectBindingDto = {
+  id: 'bind-1',
+  projectId: '90210',
+  projectPath: 'example-group/example-project',
+  defaultBranch: 'main',
+  state: 'ready',
+  stateReason: null,
+  serviceAccountUsername: 'project_4711_bot',
+  webhookInstalled: true,
+  credentialEpoch: '1',
+  createdAt: '2026-08-02T00:00:00.000Z'
+}
+
+/** Renders the hook's visible outcome: the spinner, or the paths it offers. */
+function Probe({ active }: { active: boolean }) {
+  const gl = useGitlabProjects(active, '')
+  return <span>{gl.loading ? 'loading' : gl.choices.map((choice) => choice.projectPath).join(',')}</span>
+}
+
+let host: HTMLDivElement
+let root: Root
+
+async function mount(node: React.ReactNode): Promise<void> {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root.render(node)
+  })
+}
+
+async function rerender(node: React.ReactNode): Promise<void> {
+  await act(async () => {
+    root.render(node)
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  document.body.innerHTML = ''
+  mocks.searchProjects.mockResolvedValue({ projects: [], nextPage: null })
+})
+
+describe('useGitlabProjects lifecycle', () => {
+  it('loads under Strict Mode, whose mount runs setup, cleanup, then setup again', async () => {
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+
+    await mount(
+      <StrictMode>
+        <Probe active />
+      </StrictMode>
+    )
+
+    expect(host.textContent).toBe('example-group/example-project')
+  })
+
+  it('a visit that leaves mid-load and returns loads on the second visit', async () => {
+    let settle: (bindings: GitlabProjectBindingDto[]) => void = () => undefined
+    mocks.fetchProjects.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          settle = resolve
+        })
+    )
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+
+    await mount(<Probe active />)
+    expect(host.textContent).toBe('loading')
+
+    // Leave the pane, then let the abandoned first answer arrive with nobody listening.
+    await rerender(<Probe active={false} />)
+    await act(async () => {
+      settle([])
+    })
+
+    await rerender(<Probe active />)
+    expect(host.textContent).toBe('example-group/example-project')
+  })
+})

--- a/packages/web/src/lib/use-gitlab-projects.ts
+++ b/packages/web/src/lib/use-gitlab-projects.ts
@@ -59,13 +59,13 @@ export function useGitlabProjects(active: boolean, query: string): GitlabProject
   const [provisioning, setProvisioning] = useState<string | null>(null)
   const [provisionError, setProvisionError] = useState<string | null>(null)
   const busy = useRef(false)
-  // A ref, not state: a "already started" flag that re-rendered would re-run this
-  // effect and its own cleanup would then discard the answer it was waiting for.
-  const started = useRef(false)
 
+  // One request per active lifecycle, and no one-shot guard: the guard would
+  // survive the cleanup that abandons its own request, so Strict Mode's
+  // setup/cleanup/setup — or leaving the pane mid-load — would strand the
+  // spinner on an answer nobody is listening for.
   useEffect(() => {
-    if (!active || started.current) return
-    started.current = true
+    if (!active) return
     let alive = true
     setError(null)
     Promise.all([fetchGitlabProjects(), fetchGitlabConnections()]).then(

--- a/packages/web/src/lib/use-gitlab-projects.ts
+++ b/packages/web/src/lib/use-gitlab-projects.ts
@@ -1,0 +1,149 @@
+'use client'
+
+/**
+ * The GitLab project picker's data, shared by every flow that picks a project:
+ * the Add-integration wizard's GitLab trigger and the agent-workspace forms.
+ *
+ * Authorization happens where the project is used, mirroring the GitHub card:
+ * the Integrations card manages the connection and the health of what is
+ * already bound, and picking a project that is not bound yet provisions it
+ * here. The added projects come from one org-wide list; the candidates come
+ * from the connection that can still talk to GitLab, searched server-side
+ * behind a debounce because a Maintainer's project list is not a local roster.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  createGitlabProject,
+  fetchGitlabConnections,
+  fetchGitlabProjects,
+  searchGitlabProjects,
+  type GitlabProjectBindingDto,
+  type GitlabProjectDto
+} from './api'
+import { mergeGitlabProjectChoices, type GitlabProjectChoice } from './gitlab-projects'
+
+const SEARCH_DEBOUNCE_MS = 300
+
+function errorText(e: unknown): string {
+  return e instanceof Error ? e.message : String(e)
+}
+
+export interface GitlabProjectPicker {
+  /** Added projects merged with what the live connection could still add. */
+  choices: GitlabProjectChoice[]
+  /** True until the added projects and the connections have both answered. */
+  loading: boolean
+  /** This picker has never had a project to offer — the notice case, as opposed
+   *  to a search that happens to match nothing right now. */
+  empty: boolean
+  /** Fatal: neither list could be read. The picker has nothing to offer. */
+  error: string | null
+  /** A connection that can still talk to GitLab exists. */
+  connected: boolean
+  /** Project id whose setup saga is running right now. */
+  provisioning: string | null
+  /** The last failed setup, in GitLab words. */
+  provisionError: string | null
+  /** Bind an unadded project. Resolves to null when setup failed. */
+  provision: (projectId: string) => Promise<GitlabProjectBindingDto | null>
+}
+
+/** `active` keeps a pane that is not showing from issuing any request at all —
+ *  a deployment without a GitLab application does not serve these routes. */
+export function useGitlabProjects(active: boolean, query: string): GitlabProjectPicker {
+  const [bindings, setBindings] = useState<GitlabProjectBindingDto[] | null>(null)
+  const [connectionId, setConnectionId] = useState<string | null>(null)
+  const [candidates, setCandidates] = useState<GitlabProjectDto[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [provisioning, setProvisioning] = useState<string | null>(null)
+  const [provisionError, setProvisionError] = useState<string | null>(null)
+  const busy = useRef(false)
+  // A ref, not state: a "already started" flag that re-rendered would re-run this
+  // effect and its own cleanup would then discard the answer it was waiting for.
+  const started = useRef(false)
+
+  useEffect(() => {
+    if (!active || started.current) return
+    started.current = true
+    let alive = true
+    setError(null)
+    Promise.all([fetchGitlabProjects(), fetchGitlabConnections()]).then(
+      ([bound, { connections }]) => {
+        if (!alive) return
+        setBindings(bound)
+        // Only a connection GitLab still accepts can add a project (§10.1).
+        setConnectionId(connections.find((c) => c.state === 'connected')?.id ?? null)
+      },
+      (e) => {
+        if (!alive) return
+        setBindings([])
+        setError(errorText(e))
+      }
+    )
+    return () => {
+      alive = false
+    }
+  }, [active])
+
+  // Candidates are searched on GitLab, so keystrokes settle through a debounce.
+  // A failed search leaves the added projects pickable rather than emptying the list.
+  useEffect(() => {
+    if (!active || !connectionId) return
+    let alive = true
+    const timer = setTimeout(() => {
+      searchGitlabProjects(connectionId, query.trim() ? { search: query.trim() } : {}).then(
+        (page) => alive && setCandidates(page.projects),
+        () => alive && setCandidates([])
+      )
+    }, SEARCH_DEBOUNCE_MS)
+    return () => {
+      alive = false
+      clearTimeout(timer)
+    }
+  }, [active, connectionId, query])
+
+  const provision = useCallback(
+    async (projectId: string): Promise<GitlabProjectBindingDto | null> => {
+      if (busy.current || !connectionId) return null
+      busy.current = true
+      setProvisioning(projectId)
+      setProvisionError(null)
+      try {
+        // The saga runs server-side and answers with the converged binding, so
+        // its outcome state — ready or partly set up — is what the picker shows.
+        const binding = await createGitlabProject({ connectionId, projectId })
+        setBindings((current) => [...(current ?? []).filter((b) => b.id !== binding.id), binding])
+        return binding
+      } catch (e) {
+        setProvisionError(errorText(e))
+        return null
+      } finally {
+        busy.current = false
+        setProvisioning(null)
+      }
+    },
+    [connectionId]
+  )
+
+  const choices = useMemo(() => mergeGitlabProjectChoices(bindings ?? [], candidates), [bindings, candidates])
+
+  // Sticky: once the picker has offered something, a search that matches nothing
+  // is a search result, not an empty integration.
+  const [everOffered, setEverOffered] = useState(false)
+  useEffect(() => {
+    if (choices.length > 0) setEverOffered(true)
+  }, [choices.length])
+
+  const loading = active && bindings === null
+  return {
+    choices,
+    loading,
+    empty: !loading && !everOffered && choices.length === 0,
+    error,
+    connected: connectionId !== null,
+    provisioning,
+    provisionError,
+    provision
+  }
+}


### PR DESCRIPTION
## What

User feedback: the GitLab integrations card embedded a global add-project picker, mixing the management surface with the authorization flow — GitHub's card only manages the connection while repositories are chosen where they are used. Stacked on #1393.

- The card loses the embedded search/add picker and keeps what GitHub's card keeps: connection rows and the bound-project health list (state, bot, webhook, Repair, Remove), plus an empty-state line saying where projects now come from.
- The hook flow and both workspace pickers share one hook that merges already-bound projects with the live connection's Maintainer+ candidates (server-searched, debounced, deduplicated). Picking an unbound project provisions it inline — the existing create saga runs synchronously, so the option shows a setting-up line while in flight and the returned binding state after — and a bound project behaves as before. Only connections that can still talk to GitLab are offered, reusing #1393's rule.
- Design section 18.1 updated to match.

Also fixes a real loader bug the new tests caught: the project loader effect depended on its own loaded flag, re-ran on completion, and the cleanup discarded the in-flight answer, leaving the pane on its spinner forever.

## Tests

Modal and picker tests: an unbound candidate advertises that picking sets it up, the pick calls the create route and completes into the selection for both the hook and workspace paths, and a project that is both bound and listed by GitLab stays one row. Card tests assert the picker is gone while the health list and Repair remain. Full web suite, CP suites, typecheck, lint, format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
