### PR TITLE
fix(web): tighten the Lark/Feishu tile label

### DIFF
--- a/packages/web/src/components/LarkFeishuSwitcher.tsx
+++ b/packages/web/src/components/LarkFeishuSwitcher.tsx
@@ -37,8 +37,8 @@ export default function LarkFeishuSwitcher({
       : 'font-sans text-[13px] font-semibold leading-normal text-(--text-primary)'
   const alternateClassName =
     variant === 'login'
-      ? 'pointer-events-auto ml-[5px] cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[12px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
-      : 'ml-1 cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
+      ? 'pointer-events-auto cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[12px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
+      : 'cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
 
   return (
     <span className="inline-flex items-baseline whitespace-nowrap">
@@ -46,9 +46,10 @@ export default function LarkFeishuSwitcher({
         {prefix}
         {BRAND_LABEL[value]}
       </span>
+      {/* The slash hugs both words: spaced out, the label reached the install tile's edge. */}
       <span
         aria-hidden="true"
-        className="ml-[6px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)"
+        className="mx-[1px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)"
       >
         /
       </span>

--- a/packages/web/src/components/console/SessionVisibilityControl.tsx
+++ b/packages/web/src/components/console/SessionVisibilityControl.tsx
@@ -130,7 +130,7 @@ export function SessionVisibilityControl({
             ? 'Lark'
             : feishuRegion === 'feishu'
               ? 'Feishu'
-              : 'Feishu / Lark'
+              : 'Feishu/Lark'
           : 'External'
     const title =
       externalResolution === 'settled'

--- a/packages/web/src/components/console/platforms/platform-set.test.tsx
+++ b/packages/web/src/components/console/platforms/platform-set.test.tsx
@@ -55,7 +55,7 @@ describe('platform set', () => {
   it('keeps the prose name and the picker label distinct only where they must be', () => {
     // One platform id, two clouds: prose picks the international brand, the
     // picker names both so a Feishu user recognizes their own tile.
-    expect(platformLabel('feishu')).toEqual({ name: 'Lark', picker: 'Lark / Feishu' })
+    expect(platformLabel('feishu')).toEqual({ name: 'Lark', picker: 'Lark/Feishu' })
     expect(platformLabel('lark')).toEqual(platformLabel('feishu'))
     for (const id of ['slack', 'telegram', 'discord']) {
       const label = platformLabel(id)!

--- a/packages/web/src/components/console/views/SettingsView.test.tsx
+++ b/packages/web/src/components/console/views/SettingsView.test.tsx
@@ -66,7 +66,7 @@ async function render() {
 }
 
 function rowNames(): string[] {
-  return ['Slack', 'GitHub', 'Feishu / Lark'].filter((name) =>
+  return ['Slack', 'GitHub', 'Feishu/Lark'].filter((name) =>
     [...host.querySelectorAll('span')].some((span) => span.textContent === name)
   )
 }
@@ -94,7 +94,7 @@ describe('session access card', () => {
 
     await render()
 
-    expect(rowNames()).toEqual(['Slack', 'GitHub', 'Feishu / Lark'])
+    expect(rowNames()).toEqual(['Slack', 'GitHub', 'Feishu/Lark'])
     expect(host.querySelectorAll('[role="switch"]')).toHaveLength(3)
   })
 

--- a/packages/web/src/components/console/views/SettingsView.tsx
+++ b/packages/web/src/components/console/views/SettingsView.tsx
@@ -112,8 +112,8 @@ const SESSION_ACCESS_COPY: Record<
     degraded: 'Repository scopes stopped resolving — new sessions are being hidden.'
   },
   feishu: {
-    name: 'Feishu / Lark',
-    label: 'Follow Feishu / Lark access',
+    name: 'Feishu/Lark',
+    label: 'Follow Feishu/Lark access',
     details: [
       'Group sessions created through the matching AgentConnect app follow current chat membership.',
       'DMs stay private, and agent memory learned earlier is not erased.',
@@ -121,9 +121,9 @@ const SESSION_ACCESS_COPY: Record<
       'Turning this off hides the sessions synced while it was on — they are not deleted, and turning it back on restores them.'
     ].join('\n'),
     unavailable:
-      'Unavailable until console sign-in is configured for this deployment — without it a viewer has no linked Feishu / Lark profile to check.',
+      'Unavailable until console sign-in is configured for this deployment — without it a viewer has no linked Feishu/Lark profile to check.',
     unresolved: (count) => `${count} session${count === 1 ? '' : 's'} hidden — no trusted chat scope.`,
-    degraded: 'Feishu / Lark scopes stopped resolving — new sessions are being hidden.'
+    degraded: 'Feishu/Lark scopes stopped resolving — new sessions are being hidden.'
   }
 }
 

--- a/packages/web/src/lib/platform-labels.ts
+++ b/packages/web/src/lib/platform-labels.ts
@@ -40,10 +40,10 @@ const LABELS = new Map<string, PlatformLabel>([
   ['discord', { name: 'Discord', picker: 'Discord' }],
   // One platform id, two clouds. Prose picks the international brand; the picker
   // names both so a Feishu user recognizes their own tile.
-  ['feishu', { name: 'Lark', picker: 'Lark / Feishu' }],
+  ['feishu', { name: 'Lark', picker: 'Lark/Feishu' }],
   // Nothing routes a bare 'lark' id today (the cloud rides on its own `region`
   // field), but the substring chains this replaces accepted it.
-  ['lark', { name: 'Lark', picker: 'Lark / Feishu' }]
+  ['lark', { name: 'Lark', picker: 'Lark/Feishu' }]
 ])
 
 /** This platform's labels, or undefined when no chat platform claims the id. */


### PR DESCRIPTION
## What

User feedback: the "Lark / Feishu" tile label ran to the tile's edge in the integration picker. The label is the live `LarkFeishuSwitcher` control, and the gap came from three stacked margins around the slash (two of which differed between the platform and login variants for no reason).

- The separator now hugs both words (`Lark/Feishu` with hairline air), one shared treatment for both variants; the alternate word stays a real button with its smaller size, tertiary color, and brand hover. Tile, padding, and grid untouched.
- Measured at real geometry with the production font: text-to-border clearance in the seven-tile row (the screenshot's case) goes from 3px to 7px; six-tile row 11px → 15px; mobile was never tight and improves too.
- The combined label was spelled three different ways across the console; the user-visible ones now use the compact form the control plane's own session label already uses, with word order unchanged per surface.

## Tests

Two string assertions updated (picker label, settings row names); no spacing assertions added — they would be brittle for what they carry. Full web suite, typecheck, lint, format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
