### PR TITLE
feat(control-plane): a degraded GitLab binding can be taken over

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -554,6 +554,11 @@ and removes the sealed token pair. Project bindings are not deleted
 implicitly. Bindings assigned to that connection become `admin_degraded` and
 can be taken over by another current Maintainer or Owner.
 
+Takeover is offered wherever administration is actually stuck — a released,
+reauth-required, or removed connection, or a binding degraded under its current
+one — and a `cleanup_pending` binding is reassigned without being reprovisioned,
+so its interrupted removal can finish under the new account (Section 19.4).
+
 The retained row is history, not a permanent fixture: once a disconnected
 connection administers no project binding at all, deleting it again removes
 the row, and that removal is refused while any binding is still assigned to

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -36,12 +36,14 @@ import type {
   GitlabWebhookSecretStore
 } from '../persistence/ports.js'
 import {
+  GITLAB_ACCESS_MAINTAINER,
   GitlabApiError,
   gitlabCreateServiceAccount,
   gitlabCreateServiceAccountToken,
   gitlabCreateWebhook,
   gitlabDeleteServiceAccount,
   gitlabDeleteWebhook,
+  gitlabEffectiveMembership,
   gitlabEnsureDeveloperMember,
   gitlabFindServiceAccount,
   gitlabProject,
@@ -52,6 +54,7 @@ import {
   gitlabServiceAccountUsername,
   gitlabTestWebhook,
   gitlabUpdateWebhook,
+  membershipSatisfies,
   type FetchLike,
   type GitlabProjectWithNamespace,
   type GitlabWebhookEvents
@@ -92,6 +95,11 @@ export type ProvisionOutcome =
   // A live peer owns the claim (provisioning or cleanup in progress): nothing
   // was written and no binding state was overwritten; the caller observes.
   | { state: 'busy'; reason: string }
+
+/** §9.4 takeover result; every refusal leaves the binding exactly as it was.
+ *  The binding row carries the convergence outcome, so the caller re-reads it. */
+export type GitlabTransferOutcome =
+  { outcome: 'transferred' } | { outcome: 'binding_missing' } | { outcome: 'busy' } | { outcome: 'not_maintainer' }
 
 export interface GitlabProvisionerDeps {
   oauth: GitlabOauthService
@@ -156,30 +164,109 @@ export class GitlabProvisioner {
     }
     try {
       const token = await this.deps.oauth.withAccessToken(orgId, binding.installerConnectionId)
-      const outcome = await this.converge(orgId, binding, token, owner)
-      if (outcome.state === 'ready') {
-        await this.deps.bindings.update(orgId, bindingId, { state: 'ready', stateReason: null })
-      } else if (outcome.state !== 'busy') {
-        await this.deps.bindings.update(orgId, bindingId, { state: outcome.state, stateReason: outcome.reason })
-      }
-      this.deps.onConverged?.(orgId, binding.projectId)
-      return outcome
+      return await this.convergeAndPersist(orgId, binding, token, owner)
     } catch (e) {
-      const reason =
-        e instanceof GitlabClaimFenceLost
-          ? 'claim_fence_lost'
-          : e instanceof GitlabTokenPolicyViolation
-            ? 'out_of_policy_token'
-            : e instanceof GitlabApiError
-              ? `gitlab_${e.status || 'unreachable'}`
-              : 'admin_unavailable'
-      this.deps.log?.warn({ bindingId, reason }, 'gitlab provisioning failed')
-      return this.degrade(orgId, bindingId, 'admin_degraded', reason)
+      // Only the administration-token acquisition reaches here; convergence maps its own failures.
+      return this.failed(orgId, bindingId, e)
     } finally {
       // Release THIS run's lease whatever happened: every external resource is
       // deterministically marked, so the next run reconciles it.
       await this.deps.bindings.endProviderMutation(orgId, bindingId, binding.projectId, owner).catch(() => {})
     }
+  }
+
+  /**
+   * §9.4 takeover: another current Maintainer or Owner becomes the administering
+   * account of a binding whose own administration is stuck. It proves the
+   * caller's CURRENT membership with the CALLER's own token before any write.
+   *
+   * A binding still in provisioning/ready/degraded is then re-converged under the
+   * new authority, so the takeover is an admin mutation and runs under the SAME
+   * exclusive lease as provision. A `cleanup_pending` one is only reassigned so
+   * its interrupted removal can finish (§19.4) — it writes nothing at the
+   * provider, holds no provisioning lease, and is never re-provisioned.
+   */
+  async transfer(
+    orgId: string,
+    bindingId: string,
+    connection: { id: string; gitlabUserId: bigint }
+  ): Promise<GitlabTransferOutcome> {
+    const binding = await this.deps.bindings.get(orgId, bindingId)
+    if (!binding) return { outcome: 'binding_missing' }
+    const reprovision = binding.state !== 'cleanup_pending'
+    const owner = randomBytes(9).toString('base64url')
+    const nowMs = this.deps.clock.now()
+    if (
+      reprovision &&
+      !(await this.deps.bindings.markProviderMutationStarted(
+        orgId,
+        bindingId,
+        binding.projectId,
+        owner,
+        new Date(nowMs + PROVISION_LEASE_MS),
+        new Date(nowMs)
+      ))
+    ) {
+      return { outcome: 'busy' }
+    }
+    try {
+      // Read-only prelude through the CALLER's own connection: an auth or upstream
+      // failure here reaches the caller and degrades nothing, because nothing moved.
+      const token = await this.deps.oauth.withAccessToken(orgId, connection.id)
+      const membership = await gitlabEffectiveMembership(
+        token,
+        binding.projectId,
+        connection.gitlabUserId,
+        this.deps.fetchImpl
+      )
+      if (!membershipSatisfies(membership, GITLAB_ACCESS_MAINTAINER, this.deps.clock.now())) {
+        return { outcome: 'not_maintainer' }
+      }
+      // §10.2 per-step atomic renewal: the fence must still be ours before the first write.
+      if (reprovision && !(await this.renewLease(orgId, binding, owner))) return { outcome: 'busy' }
+      const moved = await this.deps.bindings.update(orgId, bindingId, { installerConnectionId: connection.id })
+      if (!moved) return { outcome: 'binding_missing' }
+      if (reprovision) await this.convergeAndPersist(orgId, moved, token, owner)
+      return { outcome: 'transferred' }
+    } finally {
+      if (reprovision) {
+        await this.deps.bindings.endProviderMutation(orgId, bindingId, binding.projectId, owner).catch(() => {})
+      }
+    }
+  }
+
+  /** Converge under an already-held lease and persist the outcome on the binding. */
+  private async convergeAndPersist(
+    orgId: string,
+    binding: GitlabProjectBindingRecord,
+    token: string,
+    owner: string
+  ): Promise<ProvisionOutcome> {
+    try {
+      const outcome = await this.converge(orgId, binding, token, owner)
+      if (outcome.state === 'ready') {
+        await this.deps.bindings.update(orgId, binding.id, { state: 'ready', stateReason: null })
+      } else if (outcome.state !== 'busy') {
+        await this.deps.bindings.update(orgId, binding.id, { state: outcome.state, stateReason: outcome.reason })
+      }
+      this.deps.onConverged?.(orgId, binding.projectId)
+      return outcome
+    } catch (e) {
+      return this.failed(orgId, binding.id, e)
+    }
+  }
+
+  private failed(orgId: string, bindingId: string, e: unknown): Promise<ProvisionOutcome> {
+    const reason =
+      e instanceof GitlabClaimFenceLost
+        ? 'claim_fence_lost'
+        : e instanceof GitlabTokenPolicyViolation
+          ? 'out_of_policy_token'
+          : e instanceof GitlabApiError
+            ? `gitlab_${e.status || 'unreachable'}`
+            : 'admin_unavailable'
+    this.deps.log?.warn({ bindingId, reason }, 'gitlab provisioning failed')
+    return this.degrade(orgId, bindingId, 'admin_degraded', reason)
   }
 
   private async degrade(

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1816,6 +1816,9 @@ export const GitlabProjectBindingDto = z.object({
   defaultBranch: z.string().nullable(),
   state: z.enum(['provisioning', 'ready', 'admin_degraded', 'runtime_degraded', 'cleanup_pending']),
   stateReason: z.string().nullable(),
+  /** The OAuth connection administering this project (§7.1); null once it was
+   *  removed. Its state decides whether repair, removal, or takeover can run. */
+  installerConnectionId: z.string().nullable(),
   serviceAccountUsername: z.string().nullable(),
   webhookInstalled: z.boolean(),
   credentialEpoch: z.string(),

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1775,6 +1775,9 @@ export const GitlabConnectionDto = z.object({
   state: z.enum(['connected', 'reauth_required', 'disconnected']),
   scopes: z.array(z.string()),
   connectedBy: z.string().nullable(), // AgentConnect user id; null after user deletion
+  /** Whether the CALLER owns this connection: takeover and reconnect are their
+   *  own account's actions, so the console needs the answer without comparing ids. */
+  mine: z.boolean(),
   accessExpiresAt: z.string().nullable(),
   /** Managed projects this connection still administers (§7.1). A released
    *  connection with none can be removed; with any, removal is refused. */

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -66,6 +66,7 @@ function bindingToDto(r: GitlabProjectBindingRecord) {
     defaultBranch: r.defaultBranch,
     state: r.state,
     stateReason: r.stateReason,
+    installerConnectionId: r.installerConnectionId,
     serviceAccountUsername: r.serviceAccountUsername,
     webhookInstalled: r.webhookId !== null,
     credentialEpoch: r.credentialEpoch.toString(),
@@ -317,6 +318,89 @@ export function gitlabRoutes(deps: HttpDeps) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab project not found' })
         }
         return bindingToDto(binding)
+      }
+    )
+
+    r.post(
+      '/gitlab/projects/:id/transfer',
+      {
+        schema: {
+          tags: [Tag.GitLab],
+          summary: 'Take over administration of a GitLab project',
+          description:
+            "Moves administration of a project whose administering account can no longer act to the caller's own connected GitLab account (§9.4). The Control Plane re-verifies the caller's CURRENT Maintainer-or-Owner membership live, through the caller's own connection, then re-runs the §10.2 convergence under the new account. Eligible in any binding state — including a `cleanup_pending` one, whose interrupted removal can then finish under the new account (§19.4); that state is only reassigned, never re-provisioned. A project whose administering account is still connected and is not degraded is refused. Every refusal carries a machine-readable `code`.",
+          operationId: 'transferGitlabProject',
+          params: IdParam,
+          response: {
+            200: GitlabProjectBindingDto,
+            400: ErrorDto,
+            403: ErrorDto,
+            404: ErrorDto,
+            409: ErrorDto,
+            429: ErrorDto,
+            502: ErrorDto
+          }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return
+        const orgId = orgOf(req)
+        const notFound = () =>
+          reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab project not found' })
+        const conflict = (code: string, message: string) =>
+          reply.code(409).send({ error: 'Conflict', statusCode: 409, message, code })
+        const binding = await deps.repos.gitlabProjectBinding.get(orgId, req.params.id)
+        if (!binding) return notFound()
+        // Takeover authority is the CALLER's own connection, never the org's (§7.1).
+        const own = (await deps.repos.gitlabConnection.listForOrg(orgId)).filter(
+          (candidate) => candidate.userId === req.principal!.userId
+        )
+        if (own.length === 0) {
+          return conflict('GITLAB_NO_OWN_CONNECTION', 'connect your own GitLab account before taking over a project')
+        }
+        // Newest wins when one user connected two GitLab identities to this organization.
+        const mine = own.filter((candidate) => candidate.state === 'connected').at(-1)
+        if (!mine) {
+          return conflict('GITLAB_CONNECTION_NOT_CONNECTED', 'reconnect your own GitLab account first')
+        }
+        const installer = binding.installerConnectionId
+          ? await deps.repos.gitlabConnection.get(orgId, binding.installerConnectionId)
+          : null
+        // §9.4 offers takeover for administration that is actually stuck: a released
+        // or removed installer, or a binding degraded under the current one.
+        if (installer?.state === 'connected' && binding.state !== 'admin_degraded') {
+          return conflict('GITLAB_INSTALLER_CONNECTED', 'a connected GitLab account already administers this project')
+        }
+        try {
+          const outcome = await gitlab.provisioner.transfer(orgId, binding.id, {
+            id: mine.id,
+            gitlabUserId: mine.gitlabUserId
+          })
+          if (outcome.outcome === 'binding_missing') return notFound()
+          if (outcome.outcome === 'busy') {
+            return conflict('GITLAB_BINDING_BUSY', 'project setup or removal is already running — try again shortly')
+          }
+          if (outcome.outcome === 'not_maintainer') {
+            return reply.code(403).send({
+              error: 'Forbidden',
+              statusCode: 403,
+              message: 'Maintainer or Owner access to the project is required to take it over',
+              code: 'GITLAB_NOT_MAINTAINER'
+            })
+          }
+          const converged = await deps.repos.gitlabProjectBinding.get(orgId, binding.id)
+          if (!converged) return notFound()
+          return bindingToDto(converged)
+        } catch (e) {
+          if (e instanceof GitlabOauthDenied) {
+            return reply.code(e.status).send({ error: 'Conflict', statusCode: e.status, message: e.message })
+          }
+          if (e instanceof GitlabApiError) {
+            const up = gitlabUpstream(e)
+            return reply.code(up.status).send({ error: 'Bad Gateway', statusCode: up.status, message: up.message })
+          }
+          throw e
+        }
       }
     )
 

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -43,7 +43,7 @@ import {
 } from '../dto/index.js'
 import type { GitlabConnectionRecord, GitlabProjectBindingRecord } from '../../persistence/ports.js'
 
-function toDto(r: GitlabConnectionRecord, assignedProjects: number) {
+function toDto(r: GitlabConnectionRecord, assignedProjects: number, callerUserId: string) {
   return {
     id: r.id,
     gitlabUserId: r.gitlabUserId.toString(),
@@ -51,6 +51,7 @@ function toDto(r: GitlabConnectionRecord, assignedProjects: number) {
     state: r.state,
     scopes: r.scopes,
     connectedBy: r.userId,
+    mine: r.userId !== null && r.userId === callerUserId,
     accessExpiresAt: r.accessExpiresAt ? r.accessExpiresAt.toISOString() : null,
     assignedProjects,
     createdAt: r.createdAt.toISOString()
@@ -138,7 +139,7 @@ export function gitlabRoutes(deps: HttpDeps) {
         const orgId = orgOf(req)
         const rows = await deps.repos.gitlabConnection.listForOrg(orgId)
         const assigned = await deps.repos.gitlabProjectBinding.countByInstaller(orgId)
-        return { connections: rows.map((row) => toDto(row, assigned[row.id] ?? 0)) }
+        return { connections: rows.map((row) => toDto(row, assigned[row.id] ?? 0, req.principal!.userId)) }
       }
     )
 
@@ -367,8 +368,11 @@ export function gitlabRoutes(deps: HttpDeps) {
           ? await deps.repos.gitlabConnection.get(orgId, binding.installerConnectionId)
           : null
         // §9.4 offers takeover for administration that is actually stuck: a released
-        // or removed installer, or a binding degraded under the current one.
-        if (installer?.state === 'connected' && binding.state !== 'admin_degraded') {
+        // or removed installer, or a binding degraded under the current one. A binding
+        // awaiting cleanup qualifies whatever its installer row reports — the takeover
+        // only reassigns it, and that is what unblocks the interrupted removal (§19.4).
+        const stuck = installer?.state !== 'connected'
+        if (!stuck && binding.state !== 'admin_degraded' && binding.state !== 'cleanup_pending') {
           return conflict('GITLAB_INSTALLER_CONNECTED', 'a connected GitLab account already administers this project')
         }
         try {
@@ -476,7 +480,7 @@ export function gitlabRoutes(deps: HttpDeps) {
         const record = await deps.repos.gitlabConnection.get(orgId, existing.id)
         if (!record) return notFound()
         const assigned = (await deps.repos.gitlabProjectBinding.countByInstaller(orgId))[existing.id] ?? 0
-        return { removed: false, connection: toDto(record, assigned) }
+        return { removed: false, connection: toDto(record, assigned, req.principal!.userId) }
       }
     )
   }

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -35,6 +35,9 @@ export class FakeGitlab {
   mergeRequests = new Map<number, { state: string; headSha: string; baseSha?: string; draft?: boolean }>()
   issues = new Map<number, { state: string }>()
   deletedServiceAccounts: number[] = []
+  /** Every call the CP made, with the bearer it presented — WHICH token a check
+   *  used is part of the contract (§9.4 takeover proves the caller's own access). */
+  requests: { method: string; url: string; token: string | null }[] = []
   private nextId = 5000
 
   constructor(options: FakeGitlabOptions = {}) {
@@ -51,6 +54,8 @@ export class FakeGitlab {
     return async (url, init) => {
       const method = init?.method ?? 'GET'
       const body = typeof init?.body === 'string' ? init.body : ''
+      const authorization = (init?.headers as Record<string, string> | undefined)?.authorization
+      this.requests.push({ method, url, token: authorization?.replace(/^Bearer /, '') ?? null })
       const json = (): Record<string, unknown> => {
         try {
           return JSON.parse(body) as Record<string, unknown>

--- a/packages/control-plane/test/integration/gitlab.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab.route.test.ts
@@ -274,6 +274,34 @@ describe('gitlab project takeover (§9.4)', () => {
     expect(await prisma.codeHostRepositoryClaim.count({ where: { externalId: 4455667n } })).toBe(0)
   })
 
+  it('takes over a project awaiting cleanup even while its installer still reads connected', async () => {
+    // A revoke that fails leaves cleanup_pending under a perfectly connected account:
+    // gating on the installer's state alone would answer GITLAB_INSTALLER_CONNECTED here.
+    const a = gitlabApp({ failTokenRevoke: true })
+    const { connectionId } = await connect(a)
+    const bound = await a.app.inject({
+      method: 'POST',
+      url: `${ORG}/gitlab/projects`,
+      payload: { connectionId, projectId: '4455667' }
+    })
+    const bindingId = (bound.json() as { id: string }).id
+    const stuck = await a.app.inject({ method: 'DELETE', url: `${ORG}/gitlab/projects/${bindingId}` })
+    expect(stuck.json()).toMatchObject({ removed: false, state: 'cleanup_pending' })
+    const installer = await prisma.gitlabConnection.findUniqueOrThrow({ where: { id: connectionId } })
+    expect(installer.state).toBe('connected')
+
+    const taker = await ownConnection(a.fake, 50)
+    const moved = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/transfer` })
+    expect(moved.statusCode).toBe(200)
+    expect(moved.json()).toMatchObject({ state: 'cleanup_pending', installerConnectionId: taker.id })
+
+    // Under the account that took it over — and a provider that answers — removal finishes.
+    a.fake.opts.failTokenRevoke = false
+    const removed = await a.app.inject({ method: 'DELETE', url: `${ORG}/gitlab/projects/${bindingId}` })
+    expect(removed.json()).toEqual({ removed: true })
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { externalId: 4455667n } })).toBe(0)
+  })
+
   it('refuses a project a connected account still administers', async () => {
     const a = gitlabApp()
     const { connectionId } = await connect(a)
@@ -309,7 +337,8 @@ describe('gitlab oauth routes', () => {
       gitlabUserId: '4242',
       gitlabUsername: 'example-admin',
       state: 'connected',
-      scopes: ['api']
+      scopes: ['api'],
+      mine: true
     })
     // Metadata only: no token-shaped field leaves the DTO.
     expect(JSON.stringify(body)).not.toContain('at-1')
@@ -317,6 +346,15 @@ describe('gitlab oauth routes', () => {
     // The pair itself landed sealed in the side-table.
     const secret = await prisma.gitlabConnectionSecret.findUniqueOrThrow({ where: { connectionId } })
     expect(secret.accessToken).toBeTruthy()
+  })
+
+  it('reports a connection whose user left the organization as nobody’s own', async () => {
+    const a = gitlabApp()
+    const { connectionId } = await connect(a)
+    await prisma.gitlabConnection.update({ where: { id: connectionId }, data: { userId: null } })
+    const list = await a.app.inject({ method: 'GET', url: `${ORG}/gitlab/connections` })
+    // `mine` is what the console keys its own-account connect affordance on.
+    expect((list.json() as { connections: { mine: boolean }[] }).connections[0]).toMatchObject({ mine: false })
   })
 
   it('requires the begin-hop browser cookie on the callback', async () => {

--- a/packages/control-plane/test/integration/gitlab.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab.route.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, expect, it, afterEach } from 'vitest'
 import { prisma } from '../setup.db.js'
-import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { GitlabOauthService } from '../../src/gitlab/oauth.service.js'
 import {
@@ -34,7 +34,7 @@ afterEach(async () => {
   running = undefined
 })
 
-function gitlabApp(options: FakeGitlabOptions = {}): HttpApp {
+function gitlabApp(options: FakeGitlabOptions = {}): HttpApp & { fake: FakeGitlab } {
   const fake = new FakeGitlab(options)
   const oauth = new GitlabOauthService({
     cfg: { clientId: 'client-1', clientSecret: 'secret-1' },
@@ -63,7 +63,7 @@ function gitlabApp(options: FakeGitlabOptions = {}): HttpApp {
   running = buildHttpApp(prisma, { PUBLIC_CP_URL: PUBLIC_CP }, undefined, undefined, {
     gitlab: { oauth, provisioner, fetchImpl: fake.fetch() }
   })
-  return running
+  return { ...running, fake }
 }
 
 async function connect(a: HttpApp): Promise<{ connectionId: string }> {
@@ -103,6 +103,197 @@ async function connect(a: HttpApp): Promise<{ connectionId: string }> {
   const row = await prisma.gitlabConnection.findFirstOrThrow({ where: { orgId: DEFAULT_ORG_ID } })
   return { connectionId: row.id }
 }
+
+/** The §9.4 starting point: the installing user left, so the binding degrades. */
+async function degradedBinding(a: HttpApp & { fake: FakeGitlab }): Promise<{ bindingId: string; installer: string }> {
+  const { connectionId } = await connect(a)
+  const bound = await a.app.inject({
+    method: 'POST',
+    url: `${ORG}/gitlab/projects`,
+    payload: { connectionId, projectId: '4455667' }
+  })
+  expect(bound.statusCode).toBe(200)
+  const bindingId = (bound.json() as { id: string }).id
+  await a.app.inject({ method: 'DELETE', url: `${ORG}/gitlab/connections/${connectionId}` })
+  // The installing user is no longer an organization member: their OAuth authority does not survive it.
+  await prisma.gitlabConnection.update({ where: { id: connectionId }, data: { userId: null } })
+  const repaired = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/repair` })
+  expect((repaired.json() as { state: string }).state).toBe('admin_degraded')
+  return { bindingId, installer: connectionId }
+}
+
+/** A second GitLab identity connected by the CALLER, at the given project access level. */
+async function ownConnection(fake: FakeGitlab, accessLevel: number): Promise<{ id: string }> {
+  fake.members.set(7007, accessLevel)
+  return new PgGitlabConnectionRepo(prisma).upsertOnCallback({
+    orgId: DEFAULT_ORG_ID,
+    userId: DEFAULT_OWNER_ID,
+    gitlabUserId: 7007n,
+    gitlabUsername: 'example-successor',
+    scopes: ['api'],
+    accessExpiresAt: new Date(Date.now() + 3_600_000),
+    sealedPair: { accessToken: 'at-taker', refreshToken: 'rt-taker' }
+  })
+}
+
+const membershipRead = (userId: number, token: string) => ({
+  method: 'GET',
+  url: `https://gitlab.com/api/v4/projects/4455667/members/all/${userId}`,
+  token
+})
+
+describe('gitlab project takeover (§9.4)', () => {
+  it('moves administration to the caller, verified through the caller’s own token', async () => {
+    const a = gitlabApp()
+    const { bindingId } = await degradedBinding(a)
+    const taker = await ownConnection(a.fake, 50)
+    a.fake.requests.length = 0
+
+    const res = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/transfer` })
+    expect(res.statusCode).toBe(200)
+    // Provider truth was re-verified under the new administering account.
+    expect(res.json()).toMatchObject({
+      id: bindingId,
+      state: 'ready',
+      stateReason: null,
+      installerConnectionId: taker.id
+    })
+    const row = await prisma.gitlabProjectBinding.findUniqueOrThrow({ where: { id: bindingId } })
+    expect(row.installerConnectionId).toBe(taker.id)
+
+    // The Maintainer proof is the CALLER's identity read with the CALLER's token…
+    expect(a.fake.requests).toContainEqual(membershipRead(7007, 'at-taker'))
+    // …and the released installer's own token is never spent on this route.
+    expect(a.fake.requests.every((request) => request.token === 'at-taker')).toBe(true)
+    // The claim is left free for the next run: the takeover held it, it did not keep it.
+    const claim = await prisma.codeHostRepositoryClaim.findUniqueOrThrow({
+      where: { provider_externalId: { provider: 'gitlab', externalId: 4455667n } }
+    })
+    expect(claim.opOwner).toBeNull()
+  })
+
+  it('404s a binding of another organization', async () => {
+    const a = gitlabApp()
+    await connect(a)
+    await ownConnection(a.fake, 50)
+    const foreignOrg = await prisma.org.create({ data: { name: 'Foreign', slug: 'foreign-gitlab' } })
+    const foreign = await prisma.gitlabProjectBinding.create({
+      data: {
+        orgId: foreignOrg.id,
+        projectId: 991122n,
+        projectPath: 'example-group/foreign-project',
+        state: 'admin_degraded'
+      }
+    })
+    const res = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${foreign.id}/transfer` })
+    expect(res.statusCode).toBe(404)
+    // A cross-organization takeover never even reaches gitlab.com.
+    expect(a.fake.requests.some((request) => request.url.includes('991122'))).toBe(false)
+    const untouched = await prisma.gitlabProjectBinding.findUniqueOrThrow({ where: { id: foreign.id } })
+    expect(untouched.installerConnectionId).toBeNull()
+  })
+
+  it('refuses a caller with no GitLab connection of their own', async () => {
+    const a = gitlabApp()
+    const { bindingId, installer } = await degradedBinding(a)
+    const res = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/transfer` })
+    expect(res.statusCode).toBe(409)
+    expect(res.json()).toMatchObject({ code: 'GITLAB_NO_OWN_CONNECTION' })
+    const row = await prisma.gitlabProjectBinding.findUniqueOrThrow({ where: { id: bindingId } })
+    expect(row.installerConnectionId).toBe(installer)
+  })
+
+  it('refuses a caller whose own connection needs reconnecting', async () => {
+    const a = gitlabApp()
+    const { bindingId } = await degradedBinding(a)
+    const taker = await ownConnection(a.fake, 50)
+    await prisma.gitlabConnection.update({ where: { id: taker.id }, data: { state: 'reauth_required' } })
+    const res = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/transfer` })
+    expect(res.statusCode).toBe(409)
+    expect(res.json()).toMatchObject({ code: 'GITLAB_CONNECTION_NOT_CONNECTED' })
+  })
+
+  it('refuses a caller who is only a Developer on the project (§10.1)', async () => {
+    const a = gitlabApp()
+    const { bindingId, installer } = await degradedBinding(a)
+    await ownConnection(a.fake, 30)
+    a.fake.requests.length = 0
+
+    const res = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/transfer` })
+    expect(res.statusCode).toBe(403)
+    expect(res.json()).toMatchObject({ code: 'GITLAB_NOT_MAINTAINER' })
+    // The live read happened; the write did not.
+    expect(a.fake.requests).toContainEqual(membershipRead(7007, 'at-taker'))
+    const row = await prisma.gitlabProjectBinding.findUniqueOrThrow({ where: { id: bindingId } })
+    expect(row.installerConnectionId).toBe(installer)
+    expect(row.state).toBe('admin_degraded')
+  })
+
+  it('refuses while a peer holds the provisioning lease, spending no gitlab call', async () => {
+    const a = gitlabApp()
+    const { bindingId, installer } = await degradedBinding(a)
+    await ownConnection(a.fake, 50)
+    await prisma.codeHostRepositoryClaim.updateMany({
+      where: { provider: 'gitlab', externalId: 4455667n },
+      data: { opOwner: 'peer-run', opLeaseUntil: new Date(Date.now() + 60_000) }
+    })
+    a.fake.requests.length = 0
+
+    const res = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/transfer` })
+    expect(res.statusCode).toBe(409)
+    expect(res.json()).toMatchObject({ code: 'GITLAB_BINDING_BUSY' })
+    expect(a.fake.requests).toEqual([])
+    const row = await prisma.gitlabProjectBinding.findUniqueOrThrow({ where: { id: bindingId } })
+    expect(row.installerConnectionId).toBe(installer)
+    // The peer's lease is intact: a refused takeover never releases someone else's fence.
+    const claim = await prisma.codeHostRepositoryClaim.findUniqueOrThrow({
+      where: { provider_externalId: { provider: 'gitlab', externalId: 4455667n } }
+    })
+    expect(claim.opOwner).toBe('peer-run')
+  })
+
+  it('breaks the removal deadlock: cleanup_pending transfers, then removal completes', async () => {
+    const a = gitlabApp()
+    const { bindingId } = await degradedBinding(a)
+    // Removal with a released installer cannot reach GitLab: the binding half-leaves.
+    const stuck = await a.app.inject({ method: 'DELETE', url: `${ORG}/gitlab/projects/${bindingId}` })
+    expect(stuck.json()).toMatchObject({ removed: false, state: 'cleanup_pending', stateReason: 'cleanup_failed' })
+    expect(a.fake.serviceAccounts).toHaveLength(1)
+
+    const taker = await ownConnection(a.fake, 50)
+    const moved = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/transfer` })
+    expect(moved.statusCode).toBe(200)
+    // A binding on its way out is reassigned, never re-provisioned back to ready.
+    expect(moved.json()).toMatchObject({ state: 'cleanup_pending', installerConnectionId: taker.id })
+
+    const removed = await a.app.inject({ method: 'DELETE', url: `${ORG}/gitlab/projects/${bindingId}` })
+    expect(removed.json()).toEqual({ removed: true })
+    expect(a.fake.serviceAccounts).toHaveLength(0)
+    expect(await prisma.gitlabProjectBinding.count({ where: { id: bindingId } })).toBe(0)
+    // Verified-complete cleanup frees the project for another organization.
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { externalId: 4455667n } })).toBe(0)
+  })
+
+  it('refuses a project a connected account still administers', async () => {
+    const a = gitlabApp()
+    const { connectionId } = await connect(a)
+    const bound = await a.app.inject({
+      method: 'POST',
+      url: `${ORG}/gitlab/projects`,
+      payload: { connectionId, projectId: '4455667' }
+    })
+    const bindingId = (bound.json() as { id: string }).id
+    await ownConnection(a.fake, 50)
+    a.fake.requests.length = 0
+
+    const res = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/transfer` })
+    expect(res.statusCode).toBe(409)
+    expect(res.json()).toMatchObject({ code: 'GITLAB_INSTALLER_CONNECTED' })
+    expect(a.fake.requests).toEqual([])
+    const row = await prisma.gitlabProjectBinding.findUniqueOrThrow({ where: { id: bindingId } })
+    expect(row.installerConnectionId).toBe(connectionId)
+  })
+})
 
 describe('gitlab oauth routes', () => {
   it('runs start → begin → callback and lists metadata-only connections', async () => {

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -10,13 +10,14 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { GitlabConnectionDto, GitlabProjectBindingDto } from '@/lib/api'
+import { ApiError, type GitlabConnectionDto, type GitlabProjectBindingDto } from '@/lib/api'
 
 const mocks = vi.hoisted(() => ({
   fetchConnections: vi.fn(),
   fetchProjects: vi.fn(),
   repairProject: vi.fn(),
   deleteProject: vi.fn(),
+  transferProject: vi.fn(),
   disconnect: vi.fn(),
   startOauth: vi.fn()
 }))
@@ -33,6 +34,7 @@ vi.mock('@/lib/api', async (importOriginal) => ({
   fetchGitlabProjects: mocks.fetchProjects,
   repairGitlabProject: mocks.repairProject,
   deleteGitlabProject: mocks.deleteProject,
+  transferGitlabProject: mocks.transferProject,
   disconnectGitlabConnection: mocks.disconnect,
   startGitlabOauth: mocks.startOauth
 }))
@@ -58,6 +60,7 @@ const BINDING: GitlabProjectBindingDto = {
   defaultBranch: 'main',
   state: 'ready',
   stateReason: null,
+  installerConnectionId: 'conn-1',
   serviceAccountUsername: 'project_4711_bot',
   webhookInstalled: true,
   credentialEpoch: '1',
@@ -191,30 +194,80 @@ describe('GitlabCard', () => {
     expect(row.textContent).not.toContain('assignedProjects')
   })
 
-  it('completes the guided removal: the blocked line clears when the last project goes', async () => {
-    const blocked = { ...CONNECTION, state: 'disconnected' as const, assignedProjects: 1 }
-    mocks.fetchConnections.mockResolvedValueOnce({ enabled: true, connections: [blocked] })
-    // The removal frees the connection, and the card reads the new count back.
-    mocks.fetchConnections.mockResolvedValue({
-      enabled: true,
-      connections: [{ ...blocked, assignedProjects: 0 }]
-    })
+  it('breaks the removal deadlock: transfer first, then the blocked line clears', async () => {
+    // The account that set the project up is gone, so removing the project would
+    // need an administering account it no longer has: takeover is the way out.
+    const stale = { ...CONNECTION, state: 'disconnected' as const, assignedProjects: 1 }
+    const mine = { ...CONNECTION, id: 'conn-2', gitlabUsername: 'current-admin', assignedProjects: 0 }
+    mocks.fetchConnections.mockResolvedValueOnce({ enabled: true, connections: [stale, mine] })
     mocks.fetchProjects.mockResolvedValue([BINDING])
-    mocks.deleteProject.mockResolvedValue({ removed: true })
     await render()
 
     expect(connectionRow('conn-1').textContent).toContain('still administers 1 project')
+    expect(connectionRow('conn-1').textContent).toContain('Transfer that project')
     expect(() => buttonIn(connectionRow('conn-1'), 'Remove')).toThrow()
 
-    // Remove the one project that blocks it — the project row's button, then the modal's.
+    // Remove is explained, not attempted: the saga would fail halfway at GitLab.
+    await click('Remove', host.querySelector('[data-gitlab-project]')!)
+    expect(modal().textContent).toContain('no longer connected')
+    expect(() => buttonIn(modal(), 'Remove')).toThrow()
+    expect(mocks.deleteProject).not.toHaveBeenCalled()
+    await click('Close', modal())
+
+    // Take it over, and the counts both sides show move with it.
+    mocks.transferProject.mockResolvedValue({ ...BINDING, installerConnectionId: 'conn-2' })
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [
+        { ...stale, assignedProjects: 0 },
+        { ...mine, assignedProjects: 1 }
+      ]
+    })
+    await click('Transfer', host.querySelector('[data-gitlab-project]')!)
+    expect(mocks.transferProject).not.toHaveBeenCalled()
+    await click('Transfer', modal())
+    expect(mocks.transferProject).toHaveBeenCalledWith('bind-1')
+    expect(connectionRow('conn-1').textContent).not.toContain('still administers')
+    expect(buttonIn(connectionRow('conn-1'), 'Remove')).toBeTruthy()
+
+    // And removal now runs for real, under the account that took it over.
+    mocks.deleteProject.mockResolvedValue({ removed: true })
     await click('Remove', host.querySelector('[data-gitlab-project]')!)
     await click('Remove', modal())
     expect(mocks.deleteProject).toHaveBeenCalledWith('bind-1')
-
-    // No reload: the connection now offers its own removal.
     expect(host.querySelectorAll('[data-gitlab-project]')).toHaveLength(0)
-    expect(connectionRow('conn-1').textContent).not.toContain('still administers')
-    expect(buttonIn(connectionRow('conn-1'), 'Remove')).toBeTruthy()
+  })
+
+  it('offers Transfer only where administration is stuck', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([
+      BINDING,
+      { ...BINDING, id: 'bind-degraded', projectPath: 'example-group/degraded', state: 'admin_degraded' as const }
+    ])
+    await render()
+
+    const healthy = host.querySelector('[data-gitlab-project="bind-1"]')!
+    const degraded = host.querySelector('[data-gitlab-project="bind-degraded"]')!
+    // A ready project its own connected account manages has nothing to take over.
+    expect(() => buttonIn(healthy, 'Transfer')).toThrow()
+    expect(buttonIn(degraded, 'Transfer')).toBeTruthy()
+  })
+
+  it('says why a takeover was refused, in GitLab terms', async () => {
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [{ ...CONNECTION, state: 'disconnected' as const, assignedProjects: 1 }]
+    })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    mocks.transferProject.mockRejectedValue(new ApiError('gitlab: nope', 403, 'GITLAB_NOT_MAINTAINER'))
+    await render()
+
+    await click('Transfer', host.querySelector('[data-gitlab-project]')!)
+    await click('Transfer', modal())
+    expect(host.textContent).toContain('Maintainer or Owner access')
+    // The refusal is readable: the dialog is gone and no machine code is shown.
+    expect(host.querySelector('.modal')).toBeNull()
+    expect(host.textContent).not.toContain('GITLAB_NOT_MAINTAINER')
   })
 
   it('repairs and removes the project it was invoked on', async () => {

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -48,6 +48,7 @@ const CONNECTION: GitlabConnectionDto = {
   state: 'connected',
   scopes: ['api'],
   connectedBy: 'user-1',
+  mine: true,
   accessExpiresAt: null,
   assignedProjects: 0,
   createdAt: '2026-08-01T00:00:00.000Z'
@@ -251,6 +252,47 @@ describe('GitlabCard', () => {
     // A ready project its own connected account manages has nothing to take over.
     expect(() => buttonIn(healthy, 'Transfer')).toThrow()
     expect(buttonIn(degraded, 'Transfer')).toBeTruthy()
+  })
+
+  it('offers Transfer on a project awaiting cleanup, connected installer and all', async () => {
+    // A removal that failed halfway leaves cleanup_pending under a connected account:
+    // the takeover is what lets someone else finish it.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([{ ...BINDING, state: 'cleanup_pending' as const }])
+    await render()
+    expect(buttonIn(host.querySelector('[data-gitlab-project]')!, 'Transfer')).toBeTruthy()
+  })
+
+  it('keeps a connect action reachable for a caller who owns none of the connections', async () => {
+    const theirs = { ...CONNECTION, id: 'conn-theirs', gitlabUsername: 'someone-else', mine: false }
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [theirs] })
+    await render()
+    // Every listed account belongs to someone else, so the caller can still start their own.
+    expect(buttonIn(host, 'Connect my account')).toBeTruthy()
+  })
+
+  it('drops that action once the caller has an own connected account', async () => {
+    const theirs = { ...CONNECTION, id: 'conn-theirs', gitlabUsername: 'someone-else', mine: false }
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [theirs, CONNECTION] })
+    await render()
+    expect(() => buttonIn(host, 'Connect my account')).toThrow()
+    expect(() => buttonIn(host, 'Connect GitLab')).toThrow()
+  })
+
+  it('points a takeover refused for want of an own account at that action', async () => {
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [{ ...CONNECTION, mine: false, state: 'disconnected' as const, assignedProjects: 1 }]
+    })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    mocks.transferProject.mockRejectedValue(new ApiError('no own connection', 409, 'GITLAB_NO_OWN_CONNECTION'))
+    await render()
+
+    await click('Transfer', host.querySelector('[data-gitlab-project]')!)
+    await click('Transfer', modal())
+    // The refusal names the affordance, and that affordance is on screen.
+    expect(host.textContent).toContain('Connect my account')
+    expect(buttonIn(host, 'Connect my account')).toBeTruthy()
   })
 
   it('says why a takeover was refused, in GitLab terms', async () => {

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -45,7 +45,8 @@ const STATE_REASON: Record<string, string> = {
 
 /** Machine-readable CP refusals the card says better itself (all takeover, today). */
 const REFUSAL: Record<string, string> = {
-  GITLAB_NO_OWN_CONNECTION: 'Connect your own GitLab account first — a project is taken over with your own access.',
+  GITLAB_NO_OWN_CONNECTION:
+    'Connect your own GitLab account first, with Connect my account above — a project is taken over with your own access.',
   GITLAB_CONNECTION_NOT_CONNECTED: 'Reconnect your own GitLab account first, then take the project over.',
   GITLAB_NOT_MAINTAINER: 'Your GitLab account needs Maintainer or Owner access to this project to take it over.',
   GITLAB_INSTALLER_CONNECTED: 'A connected GitLab account already manages this project.',
@@ -135,6 +136,9 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     }
   }
 
+  // The caller's own connected account — the only one a takeover can run on (§7.1).
+  const ownConnection = connections.some((c) => c.mine && c.state === 'connected')
+
   // One connection administers a project; a released or removed one can neither
   // repair nor remove it, and §9.4 lets another Maintainer take it over instead.
   const stuck = (binding: GitlabProjectBindingDto): boolean =>
@@ -211,10 +215,12 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
           </span>
           GitLab
         </span>
-        {enabled === true && canWrite && connections.length === 0 && (
+        {/* A takeover runs on the caller's OWN account, so connecting one stays reachable
+            even when the organization already lists other people's connections. */}
+        {enabled === true && canWrite && !ownConnection && (
           <Button onClick={connect}>
             <Icon name="external-link" size={13} />
-            Connect GitLab
+            {connections.length === 0 ? 'Connect GitLab' : 'Connect my account'}
           </Button>
         )}
       </div>
@@ -351,8 +357,9 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
               )}
             </div>
             <span className="flex items-center justify-end gap-3">
-              {/* Only a project whose administration is stuck can be taken over (§9.4). */}
-              {canWrite && (stuck(p) || p.state === 'admin_degraded') && (
+              {/* Only a project whose administration is stuck can be taken over — and one
+                  awaiting cleanup always can, since that is what unblocks its removal. */}
+              {canWrite && (stuck(p) || p.state === 'admin_degraded' || p.state === 'cleanup_pending') && (
                 <Button variant="ghost" size="xs" disabled={busyId === p.id} onClick={() => setTaking(p)}>
                   <Icon name="key-round" size={13} />
                   Transfer

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -13,12 +13,14 @@ import { GitlabMark, LoadingState } from '@/components/marks'
 import { useOrgs } from '@/lib/org-context'
 import { GITLAB_PROJECT_STATE } from '@/lib/gitlab-projects'
 import {
+  ApiError,
   deleteGitlabProject,
   disconnectGitlabConnection,
   fetchGitlabConnections,
   fetchGitlabProjects,
   repairGitlabProject,
   startGitlabOauth,
+  transferGitlabProject,
   type GitlabConnectionDto,
   type GitlabProjectBindingDto
 } from '@/lib/api'
@@ -30,11 +32,24 @@ const STATE_REASON: Record<string, string> = {
   personal_namespace_unsupported: 'Projects in a personal namespace are not supported',
   project_namespace_unknown: 'GitLab did not report the group this project belongs to',
   service_account_create_forbidden: 'Not allowed to create a project bot on GitLab',
-  no_admin_connection: 'No connected GitLab account can manage this project',
+  no_admin_connection: 'No connected GitLab account can manage this project — transfer it to your own account',
+  admin_unavailable:
+    'The GitLab account that set this project up can no longer manage it — reconnect that account, or transfer the project to your own',
+  cleanup_failed:
+    'Removal did not finish because no connected GitLab account could reach the project — reconnect it or transfer the project, then remove again',
   claim_fence_lost: 'Setup was interrupted — run Repair again',
   relay_url_unconfigured: 'This deployment has no public webhook address configured',
   provisioning_in_progress: 'Setup is already running',
   provisioning_or_cleanup_in_progress: 'Setup or removal is already running'
+}
+
+/** Machine-readable CP refusals the card says better itself (all takeover, today). */
+const REFUSAL: Record<string, string> = {
+  GITLAB_NO_OWN_CONNECTION: 'Connect your own GitLab account first — a project is taken over with your own access.',
+  GITLAB_CONNECTION_NOT_CONNECTED: 'Reconnect your own GitLab account first, then take the project over.',
+  GITLAB_NOT_MAINTAINER: 'Your GitLab account needs Maintainer or Owner access to this project to take it over.',
+  GITLAB_INSTALLER_CONNECTED: 'A connected GitLab account already manages this project.',
+  GITLAB_BINDING_BUSY: 'Setup or removal is already running for this project — try again shortly.'
 }
 
 /** User-facing copy for a binding's reason, or null to show nothing but the state badge — an
@@ -42,10 +57,15 @@ const STATE_REASON: Record<string, string> = {
 function stateReasonText(reason: string | null): string | null {
   if (!reason) return null
   if (reason.startsWith('rotation_')) return 'The project bot credential needs repair'
+  // The gitlab_<status> family is open-ended; the actionable part is the same for all of it.
+  if (reason.startsWith('gitlab_')) {
+    return 'GitLab refused the last administration request — reconnect the account that manages this project, or transfer it to your own'
+  }
   return STATE_REASON[reason] ?? null
 }
 
 function errorText(e: unknown): string {
+  if (e instanceof ApiError && e.code && REFUSAL[e.code]) return REFUSAL[e.code]!
   return e instanceof Error ? e.message : String(e)
 }
 
@@ -60,6 +80,9 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
   // One pending connection action: releasing a live row, or removing a released one.
   const [pending, setPending] = useState<{ target: GitlabConnectionDto; remove: boolean } | null>(null)
   const [removing, setRemoving] = useState<GitlabProjectBindingDto | null>(null)
+  const [taking, setTaking] = useState<GitlabProjectBindingDto | null>(null)
+  // Removal needs an administering account: without one the saga cannot finish, so it is explained, not run.
+  const [blocked, setBlocked] = useState<GitlabProjectBindingDto | null>(null)
 
   useEffect(() => {
     if (!activeOrg) return
@@ -108,6 +131,30 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     } catch (e) {
       setErr(errorText(e))
     } finally {
+      setBusyId(null)
+    }
+  }
+
+  // One connection administers a project; a released or removed one can neither
+  // repair nor remove it, and §9.4 lets another Maintainer take it over instead.
+  const stuck = (binding: GitlabProjectBindingDto): boolean =>
+    connections.find((c) => c.id === binding.installerConnectionId)?.state !== 'connected'
+
+  const takeOver = async (binding: GitlabProjectBindingDto) => {
+    if (busyId) return
+    setBusyId(binding.id)
+    setErr(null)
+    try {
+      const updated = await transferGitlabProject(binding.id)
+      setProjects((current) => current.map((p) => (p.id === updated.id ? updated : p)))
+      // The takeover moves a project between connections, and both counts gate their Remove.
+      const fresh = await fetchGitlabConnections().catch(() => null)
+      if (fresh) setConnections(fresh.connections)
+    } catch (e) {
+      setErr(errorText(e))
+    } finally {
+      // The refusal is a sentence under the card, so the dialog closes either way.
+      setTaking(null)
       setBusyId(null)
     }
   }
@@ -246,9 +293,10 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
             </div>
             {c.state === 'disconnected' && c.assignedProjects > 0 && (
               <div className="border-b border-(--border-subtle) px-4 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+                {/* Removing those projects needs an administering account too, so it is not a way out from here. */}
                 {c.assignedProjects === 1
-                  ? 'This account still administers 1 project below. Remove that project, or reconnect the account to keep managing it, before this row can go.'
-                  : `This account still administers ${c.assignedProjects} projects below. Remove those projects, or reconnect the account to keep managing them, before this row can go.`}
+                  ? 'This account still administers 1 project below. Transfer that project to your own GitLab account, or reconnect this one to keep managing it, before this row can go.'
+                  : `This account still administers ${c.assignedProjects} projects below. Transfer those projects to your own GitLab account, or reconnect this one to keep managing them, before this row can go.`}
               </div>
             )}
             {c.state === 'reauth_required' && (
@@ -303,6 +351,13 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
               )}
             </div>
             <span className="flex items-center justify-end gap-3">
+              {/* Only a project whose administration is stuck can be taken over (§9.4). */}
+              {canWrite && (stuck(p) || p.state === 'admin_degraded') && (
+                <Button variant="ghost" size="xs" disabled={busyId === p.id} onClick={() => setTaking(p)}>
+                  <Icon name="key-round" size={13} />
+                  Transfer
+                </Button>
+              )}
               {canWrite && (
                 <Button variant="ghost" size="xs" disabled={busyId === p.id} onClick={() => repair(p)}>
                   <Icon name="wrench" size={13} />
@@ -315,7 +370,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                   size="xs"
                   className="text-(--status-error) hover:text-(--status-error)"
                   disabled={busyId === p.id}
-                  onClick={() => setRemoving(p)}
+                  onClick={() => (stuck(p) ? setBlocked(p) : setRemoving(p))}
                 >
                   <Icon name="trash-2" size={13} />
                   Remove
@@ -364,6 +419,48 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
         </div>
       )}
 
+      {taking && (
+        <div className="scrim" onClick={() => setTaking(null)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <ConfirmGitlab
+              title="Transfer administration"
+              body={
+                <>
+                  Take over <span className="mono text-(--text-primary)">{taking.projectPath}</span>? GitLab is asked
+                  whether your own account has Maintainer or Owner access to the project right now, and if it does, your
+                  account becomes the one AgentConnect uses to set up and repair it.
+                </>
+              }
+              verb="Transfer"
+              icon="key-round"
+              busy={busyId === taking.id}
+              danger={false}
+              onClose={() => setTaking(null)}
+              onConfirm={() => takeOver(taking)}
+            />
+          </div>
+        </div>
+      )}
+
+      {blocked && (
+        <div className="scrim" onClick={() => setBlocked(null)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <ConfirmGitlab
+              title="Remove project"
+              body={
+                <>
+                  <span className="mono text-(--text-primary)">{blocked.projectPath}</span> cannot be removed yet: the
+                  GitLab account that manages it is no longer connected, and removing the webhook and the project bot
+                  needs one. Reconnect that account, or transfer the project to your own, then remove it.
+                </>
+              }
+              busy={false}
+              onClose={() => setBlocked(null)}
+            />
+          </div>
+        </div>
+      )}
+
       {removing && (
         <div className="scrim" onClick={() => setRemoving(null)}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
@@ -389,28 +486,33 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
   )
 }
 
-// One confirmation body for both destructive actions: bare-verb primary, noun in the title.
+// One confirmation body for every dialog here: bare-verb primary, noun in the title.
+// Without `onConfirm` it is guidance for an action that cannot run yet, and only closes.
 function ConfirmGitlab({
   title,
   body,
   verb,
   icon,
   busy,
+  danger = true,
   onClose,
   onConfirm
 }: {
   title: string
   body: ReactNode
-  verb: string
-  icon: string
+  verb?: string
+  icon?: string
   busy: boolean
+  danger?: boolean
   onClose: () => void
-  onConfirm: () => void
+  onConfirm?: () => void
 }) {
   return (
     <>
       <div className="modalhead">
-        <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
+        <span
+          className={`flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] ${danger ? 'bg-(--status-error-soft)' : 'bg-(--surface-active)'}`}
+        >
           <span className="flex h-4 w-4 items-center justify-center">
             <GitlabMark />
           </span>
@@ -426,12 +528,18 @@ function ConfirmGitlab({
       <div className="modalfoot">
         <div className="flex-1" />
         <Button variant="ghost" onClick={onClose}>
-          Cancel
+          {onConfirm ? 'Cancel' : 'Close'}
         </Button>
-        <Button variant="danger" onClick={onConfirm} className={busy ? 'pointer-events-none opacity-50' : undefined}>
-          <Icon name={icon} size={15} />
-          {busy ? 'Working…' : verb}
-        </Button>
+        {onConfirm && verb && (
+          <Button
+            variant={danger ? 'danger' : 'primary'}
+            onClick={onConfirm}
+            className={busy ? 'pointer-events-none opacity-50' : undefined}
+          >
+            {icon && <Icon name={icon} size={15} />}
+            {busy ? 'Working…' : verb}
+          </Button>
+        )}
       </div>
     </>
   )

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -5282,6 +5282,10 @@ export interface GitlabProjectBindingDto {
   defaultBranch: string | null
   state: GitlabProjectBindingState
   stateReason: string | null
+  /** The connection administering this project; null once it was removed. A
+   *  project whose administering connection is not connected can neither be
+   *  repaired nor removed — it is reconnected or transferred first. */
+  installerConnectionId: string | null
   serviceAccountUsername: string | null
   webhookInstalled: boolean
   credentialEpoch: string
@@ -5355,6 +5359,14 @@ export function createGitlabProject(input: {
 /** Re-run provisioning: identity, service account, credentials, and webhook. */
 export function repairGitlabProject(id: string): Promise<GitlabProjectBindingDto> {
   return apiPost<GitlabProjectBindingDto>(`${orgBase()}/gitlab/projects/${encodeURIComponent(id)}/repair`, {})
+}
+
+/** Take over a project whose administering account can no longer act: the CP
+ *  re-verifies the caller's own Maintainer-or-Owner access live, through the
+ *  caller's own connection, and re-runs provisioning under it. Refusals carry a
+ *  `GITLAB_*` code on the ApiError. */
+export function transferGitlabProject(id: string): Promise<GitlabProjectBindingDto> {
+  return apiPost<GitlabProjectBindingDto>(`${orgBase()}/gitlab/projects/${encodeURIComponent(id)}/transfer`, {})
 }
 
 export function deleteGitlabProject(id: string): Promise<GitlabProjectRemovalDto> {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -5251,6 +5251,9 @@ export interface GitlabConnectionDto {
   state: 'connected' | 'reauth_required' | 'disconnected'
   scopes: string[]
   connectedBy: string | null // AgentConnect user id; null after user deletion
+  /** Whether this connection is the CALLER's own: takeover and reconnect act on
+   *  their own GitLab account, and the CP answers so the console compares no ids. */
+  mine: boolean
   accessExpiresAt: string | null
   assignedProjects: number // managed projects this connection still administers
   createdAt: string

--- a/packages/web/src/lib/use-gitlab-projects.test.tsx
+++ b/packages/web/src/lib/use-gitlab-projects.test.tsx
@@ -50,6 +50,7 @@ const BINDING: GitlabProjectBindingDto = {
   defaultBranch: 'main',
   state: 'ready',
   stateReason: null,
+  installerConnectionId: 'conn-1',
   serviceAccountUsername: 'project_4711_bot',
   webhookInstalled: true,
   credentialEpoch: '1',

--- a/packages/web/src/lib/use-gitlab-projects.test.tsx
+++ b/packages/web/src/lib/use-gitlab-projects.test.tsx
@@ -38,6 +38,7 @@ const CONNECTION: GitlabConnectionDto = {
   state: 'connected',
   scopes: ['api'],
   connectedBy: 'user-1',
+  mine: true,
   accessExpiresAt: null,
   assignedProjects: 0,
   createdAt: '2026-08-01T00:00:00.000Z'


### PR DESCRIPTION
## What

The design promises (section 9.4) that a binding whose installing connection was disconnected can be taken over by another current Maintainer or Owner, and section 18.2 lists the transfer route — but nothing implemented it. Live testing showed the consequence: external cleanup runs under the installer's OAuth authority, so once that account disconnects, Remove lands the binding in `cleanup_pending` and the user is deadlocked between a connection that cannot be removed and a project that cannot be cleaned up.

- `POST /gitlab/projects/:id/transfer`: offered wherever administration is actually stuck — installer missing or not connected, or the binding `admin_degraded` — and also for `cleanup_pending` bindings, which are reassigned only (never re-provisioned) so the interrupted removal can finish under the new account. The caller must hold their own connected GitLab connection; Maintainer+ membership is verified live through the caller's own token inside the provisioner's mutation lease (a busy peer lease refuses rather than queues), then the installer moves and provider truth re-converges. Typed refusals for every other case; full OpenAPI metadata; `installerConnectionId` exposed on the binding DTO.
- Card: Transfer on stuck or degraded rows with a confirm; Remove on a stuck binding opens guidance instead of running a saga that cannot succeed; the cleanup and admin state reasons translate to actionable copy; the blocked-removal line from #1393 now names transfer or reconnect.
- Design section 9.4 records the cleanup-pending takeover rule.

## Tests

Seven new integration tests including the successful takeover (membership read asserted on the caller's token only, lease released), the refusal matrix (foreign org, no own connection, caller's connection not connected, Developer-only caller, busy lease, connected installer), and the end-to-end deadlock exit: Remove → cleanup pending → transfer → Remove completes and the claim releases. Card tests walk the same deadlock. Full CP unit + integration suites, web suite, typecheck, lint, format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
