### PR TITLE
feat: drop the GitLab hook label filter

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -123,7 +123,6 @@ GitHub modes.
 | Controlled comments and mutations      | Daemon-owned effect broker                                                     | Equivalent                                                      |
 | Managed event ingress                  | Automatically reconciled project webhook                                       | Equivalent                                                      |
 | Created, updated, mention-only cadence | GitLab issue, merge-request, note, and push event mapping                      | Equivalent                                                      |
-| Label filter                           | Current issue or merge-request labels from the verified event/API              | Equivalent                                                      |
 | Collaborator gate                      | Live target-project membership check; Developer or higher                      | Stricter than GitHub, whose gate now accepts the triage role    |
 | External merge-request gate            | Target-project membership or explicit Developer-or-higher request              | Stricter than GitHub; no workflow-approval start path           |
 | Bot-authored merge requests            | Same-project service-account MR revisions enter review                         | Equivalent to GitHub's internal-CI lane                         |
@@ -210,7 +209,7 @@ The relay owns public webhook ingress. It:
 - verifies the signing-token HMAC and timestamp before full decoding;
 - maps `webhook-id` to the stable downstream delivery identity without owning
   authoritative deduplication;
-- applies provider-specific event, bot, mention, label, and collaborator gates;
+- applies provider-specific event, bot, mention, and collaborator gates;
 - routes the bounded, explicitly untrusted context directly to the owning
   daemon; and
 - reports only delivery metadata to the Control Plane.
@@ -720,7 +719,7 @@ The Control Plane sends each relay the compiled rule, extending the existing
 - provider `gitlab` with the numeric project ID as the match key;
 - current project path for display only;
 - service-account numeric user ID and username;
-- event patterns, label filter, comment families, and mention mode; and
+- event patterns, comment families, and mention mode; and
 - the project signing token inline in the rule, exactly as the generic
   webhook's HMAC secret rides today, fetched from the hook secret store at
   compile time.
@@ -1409,7 +1408,7 @@ hook wizard and the agent workspace and additional-repository pickers list the
 connection's Maintainer-or-Owner projects merged with the ones already added,
 and picking one that is not added yet runs the Section 10.2 provisioning saga
 inline before the selection lands. Hook configuration retains the existing
-family, cadence, label, review, reporting, and output controls. Premium-only
+family, cadence, review, reporting, and output controls. Premium-only
 effective behavior is described where relevant; the UI does not imply that
 Free request changes block merges.
 
@@ -1727,9 +1726,9 @@ Use focused unit tests for pure boundaries only:
 
 - OAuth state/PKCE binding and refresh single-writer transitions;
 - Standard Webhooks signature, timestamp, and multi-signature verification;
-- event normalization, mention targeting, bot veto, labels, and membership
-  gates, including effective direct, inherited, invited-group, expired, and
-  awaiting membership;
+- event normalization, mention targeting, bot veto, and membership gates,
+  including effective direct, inherited, invited-group, expired, and awaiting
+  membership;
 - disjoint issue, merge-request, and push session-key derivation with missing
   target/ref rejection, plus daemon normalization that keeps one MR/ref on one
   channel/thread pair across different delivery IDs;

--- a/packages/control-plane/src/hooks/hook.service.ts
+++ b/packages/control-plane/src/hooks/hook.service.ts
@@ -155,7 +155,9 @@ export class HookService {
                 )
               }
             : {}),
-          labelFilter: hook.labelFilter,
+          // Removed feature: a stored value is read tolerantly and ignored. The empty
+          // array still rides the wire because a relay predating this release requires it.
+          labelFilter: [],
           mentionOnly: hook.mentionOnly,
           agentName: agent.name,
           serviceAccountUserId: binding.serviceAccountUserId.toString(),

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2416,7 +2416,6 @@ export const CreateGitlabHookBody = HookBodyBase.extend({
   events: z.array(z.string().regex(GitlabHookEventPattern)).min(1).max(20),
   // Note events for the selected subject families (§12); empty = no comments.
   commentFamilies: z.array(GitlabCommentFamily).max(2).default([]),
-  labelFilter: z.array(z.string().trim().min(1).max(100)).max(20).default([]),
   mentionOnly: z.boolean().default(false)
   // No review/reporting knobs yet: the M6 review slice adds them; rows default off.
 })

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -486,7 +486,6 @@ export function hookRoutes(deps: HttpDeps) {
             ? {
                 events: req.body.events,
                 commentFamilies: req.body.commentFamilies,
-                labelFilter: req.body.labelFilter,
                 mentionOnly: req.body.mentionOnly
                 // Review/reporting stay at their off defaults until the M6 slice.
               }
@@ -749,7 +748,6 @@ export function hookRoutes(deps: HttpDeps) {
             repoFullName: binding.projectPath,
             events: req.body.events,
             commentFamilies: req.body.commentFamilies ?? existing.commentFamilies,
-            labelFilter: req.body.labelFilter,
             mentionOnly: req.body.mentionOnly ?? existing.mentionOnly
           }
         } else {

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -167,7 +167,12 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     h.a.relayReg.add(glab.ch)
     h.a.relayReg.add(legacy.ch)
 
-    const res = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    // The removed label filter is read tolerantly: an old client may still send it.
+    const res = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: glBody(h.agentId, { labelFilter: ['bug'] })
+    })
     expect(res.statusCode).toBe(200)
     const dto = res.json() as { id: string; kind: string; url: string | null }
     expect(dto.kind).toBe('gitlab')
@@ -193,6 +198,8 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
         expect(rule.gitlab?.serviceAccountUsername).toBe(`agentconnect-p${PROJECT}`)
         expect(rule.gitlab?.signingToken).toBe(webhook.token)
         expect(rule.gitlab?.events).toEqual(['issues:*', 'merge_request:opened'])
+        // The value never reaches the rule; the empty array only keeps an older relay decoding.
+        expect(rule.gitlab?.labelFilter).toEqual([])
       },
       { timeout: 20_000 }
     )

--- a/packages/protocol/src/frames/relay-cp.test.ts
+++ b/packages/protocol/src/frames/relay-cp.test.ts
@@ -757,6 +757,35 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
     expect(rm.ok).toBe(true)
   })
 
+  it('a gitlab rule decodes with or without the removed label filter (§17.3)', () => {
+    const gitlab = {
+      hookId: '88888888-8888-4888-8888-888888888888',
+      agentId: AGENT_ID,
+      daemonId: DAEMON_ID,
+      kind: 'gitlab' as const,
+      sessionMode: 'perThread' as const,
+      gitlab: {
+        projectId: '4210',
+        projectPath: 'example-group/example-project',
+        sessionKeyPrefix: 'gitlab:4210',
+        events: ['merge_request:*'],
+        commentFamilies: ['merge_request' as const],
+        mentionOnly: false,
+        serviceAccountUserId: '99',
+        serviceAccountUsername: 'agentconnect-p4210',
+        signingToken: 'whsec_example'
+      }
+    }
+    // Absence is the shape a later release sends once no older relay is deployed.
+    expect(RcHookAssign.safeParse(gitlab).success).toBe(true)
+    // Presence is what a Control Plane predating the removal still sends; it decodes
+    // and the relay's matcher ignores the value.
+    const withFilter = { ...gitlab, gitlab: { ...gitlab.gitlab, labelFilter: ['bug'] } }
+    const decoded = RcHookAssign.safeParse(withFilter)
+    expect(decoded.success).toBe(true)
+    if (decoded.success) expect(decoded.data.gitlab?.labelFilter).toEqual(['bug'])
+  })
+
   it('rc/hook-rerun carries the Console rerun fence and its live subject (§16.1)', () => {
     const HOOK_ID = '99999999-9999-4999-8999-999999999999'
     const base = {

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -368,7 +368,9 @@ export const RcHookAssign = z
         projectPath: z.string().min(1), // display/logs only; never matched on
         sessionKeyPrefix: z.string().min(1), // rename-stable per-thread namespace: gitlab:<projectId>
         events: z.array(z.string()), // 'issues:*' / 'merge_request:*' / 'push:*' …
-        labelFilter: z.array(z.string()),
+        // Removed feature, accepted and ignored for one release: a relay predating
+        // this one still REQUIRES the member, so the CP keeps sending an empty array.
+        labelFilter: z.array(z.string()).optional(),
         commentFamilies: z.array(z.enum(['issues', 'merge_request'])).optional(),
         mentionOnly: z.boolean(),
         agentName: z.string().optional(),

--- a/packages/relay/src/hooks/gitlab-ingress.test.ts
+++ b/packages/relay/src/hooks/gitlab-ingress.test.ts
@@ -463,10 +463,14 @@ describe('gitlab ingress', () => {
     expect(h.sent).toHaveLength(0)
   })
 
-  it('verdict is pure: label filter and event patterns gate before authz', async () => {
+  it('verdict is pure: event patterns gate before authz, and a stored label filter is ignored', async () => {
     const ctx = normalizeGitlabEvent(issuePayload() as never)!
+    // The label filter is a removed feature. A rule compiled from a stored config
+    // that still carries one matches exactly as if it carried none — matching or
+    // non-matching labels make no difference to the verdict.
     expect(gitlabRuleVerdict(rule({}, { labelFilter: ['bug'] }), ctx)).toBe('needs-authz')
-    expect(gitlabRuleVerdict(rule({}, { labelFilter: ['ops'] }), ctx)).toBe('no-match')
+    expect(gitlabRuleVerdict(rule({}, { labelFilter: ['ops'] }), ctx)).toBe('needs-authz')
+    expect(gitlabRuleVerdict(rule({}, { labelFilter: undefined }), ctx)).toBe('needs-authz')
     expect(gitlabRuleVerdict(rule({}, { events: ['merge_request:*'] }), ctx)).toBe('no-match')
     expect(gitlabRuleVerdict(rule({ kind: 'github' }), ctx)).toBe('no-match')
   })

--- a/packages/relay/src/hooks/gitlab-ingress.ts
+++ b/packages/relay/src/hooks/gitlab-ingress.ts
@@ -291,7 +291,7 @@ function isInternalServiceAccountRevision(rule: RcHookAssign, ctx: GitlabMatchCt
 /**
  * One rule's verdict for one verified delivery (pure; exported for unit tests).
  * Order: loop-prevention veto → reviewer-request path → cadence/additive summon
- * match → comment scope → mention-only gate → labels → live-authz classification.
+ * match → comment scope → mention-only gate → live-authz classification.
  */
 export function gitlabRuleVerdict(rule: RcHookAssign, ctx: GitlabMatchCtx): GitlabRuleVerdict {
   if (rule.kind !== 'gitlab' || !rule.gitlab) return 'no-match'
@@ -336,8 +336,6 @@ export function gitlabRuleVerdict(rule: RcHookAssign, ctx: GitlabMatchCtx): Gitl
   }
   if (!eventMatched) return 'no-match'
   if (rule.gitlab.mentionOnly && !summoned) return 'no-match'
-  if (rule.gitlab.labelFilter.length > 0 && !ctx.labels.some((label) => rule.gitlab!.labelFilter.includes(label)))
-    return 'no-match'
   // §12.2: pushes and the SA's own same-project revisions stay relay-trusted;
   // every issue/MR lifecycle event and comment resolves live membership.
   if (ctx.family === 'push') return 'trusted'

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -4,9 +4,9 @@
  * a regression test: the tile is absent — and the project list unrequested —
  * while the flag is off; each "Trigger when" choice compiles to exactly the
  * stored vocabulary the CP validates (`family:*` patterns, note families,
- * labels, mention-only) keyed by the project's numeric id rather than its
- * renameable path; and the form offers exactly the two subjects GitHub does, so
- * no reachable selection compiles a push event.
+ * mention-only) keyed by the project's numeric id rather than its renameable
+ * path; and the form offers exactly the two subjects GitHub does, so no
+ * reachable selection compiles a push event.
  *
  * The picker also offers projects the organization has not added yet, because
  * this wizard is now where a project joins the organization.
@@ -116,11 +116,6 @@ const clickText = (text: string) =>
   Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.includes(text))
 const family = (fam: string) => document.querySelector<HTMLDivElement>(`[data-gitlab-family="${fam}"]`)
 const trigger = (mode: string) => document.querySelector<HTMLDivElement>(`[data-gitlab-trigger="${mode}"]`)
-// React tracks the DOM value itself, so a plain assignment is invisible to onChange.
-function typeInto(input: HTMLInputElement, value: string) {
-  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(input, value)
-  input.dispatchEvent(new Event('input', { bubbles: true }))
-}
 
 async function pickProject() {
   await act(async () => tileNamed('GitLab')?.click())
@@ -182,7 +177,6 @@ describe('AddIntegrationModal, GitLab trigger', () => {
       projectId: '4210',
       events: ['merge_request:*'],
       commentFamilies: ['merge_request'],
-      labelFilter: [],
       mentionOnly: false
     })
   })
@@ -213,9 +207,6 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     await pickProject()
     await act(async () => family('issues')?.click())
     await act(async () => trigger('mention')?.click())
-    await act(async () =>
-      typeInto(document.querySelector<HTMLInputElement>('input[aria-label="Label filter"]')!, 'needs-review, agent')
-    )
 
     await act(async () => clickText('Connect')?.click())
 
@@ -225,7 +216,6 @@ describe('AddIntegrationModal, GitLab trigger', () => {
       projectId: '4210',
       events: ['issues:*', 'merge_request:*'],
       commentFamilies: ['issues', 'merge_request'],
-      labelFilter: ['needs-review', 'agent'],
       mentionOnly: true
     })
   })

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -80,7 +80,6 @@ import {
   commentFamiliesForGitlabFamilies,
   eventsForGitlabFamilies,
   gitlabMentionUsage,
-  parseLabelFilter,
   type GlFamily,
   type GlTriggerMode
 } from '@/lib/gitlab-events'
@@ -367,7 +366,6 @@ export default function AddIntegrationModal({
   const gl = useGitlabProjects(platform === 'gitlab', glQ)
   const [glFams, setGlFams] = useState<Set<GlFamily>>(new Set(GL_DEFAULT_FAMILIES))
   const [glMode, setGlMode] = useState<GlTriggerMode>(GL_DEFAULT_TRIGGER_MODE)
-  const [glLabels, setGlLabels] = useState('')
 
   // Reusing a bot is an advanced path; every platform opens on the create flow
   // until the user explicitly chooses an existing identity.
@@ -840,7 +838,6 @@ export default function AddIntegrationModal({
         projectId: glProject,
         events: eventsForGitlabFamilies(glFams, glMode),
         commentFamilies: commentFamiliesForGitlabFamilies(glFams, glMode),
-        labelFilter: parseLabelFilter(glLabels),
         mentionOnly: glMode === 'mention'
       })
       onClose()
@@ -1752,19 +1749,6 @@ export default function AddIntegrationModal({
                       </div>
                     )
                   })}
-                </div>
-                <div className="fld mb-4">
-                  <span className="fldlbl">Only these labels (optional)</span>
-                  <input
-                    className="inp mn"
-                    placeholder="needs-review, agent"
-                    value={glLabels}
-                    onChange={(e) => setGlLabels(e.target.value)}
-                    aria-label="Label filter"
-                  />
-                  <span className="mt-[6px] block font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-tertiary)">
-                    Comma separated. Empty means every issue and merge request.
-                  </span>
                 </div>
               </>
             )}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -407,7 +407,6 @@ export default function AgentDetailView() {
         projectId: h.repoId,
         events: eventsForGitlabFamilies(families, mode),
         commentFamilies: commentFamiliesForGitlabFamilies(families, mode),
-        labelFilter: h.labelFilter,
         mentionOnly: mode === 'mention'
       })
       void mutateHooks((rows) => rows?.map((r) => (r.id === h.id ? updated : r)), { revalidate: false })

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3912,7 +3912,6 @@ export interface CreateGitlabHookInput {
   projectId: string // numeric GitLab project id
   events: string[] // 'issues:*' / 'merge_request:*' / 'push:*' — at least one
   commentFamilies?: GitlabCommentFamily[]
-  labelFilter?: string[]
   mentionOnly?: boolean
 }
 

--- a/packages/web/src/lib/gitlab-events.test.ts
+++ b/packages/web/src/lib/gitlab-events.test.ts
@@ -13,8 +13,7 @@ import {
   gitlabRowFamilies,
   gitlabTriggerModeOf,
   gitlabTriggerTooltip,
-  parseGitlabHookThread,
-  parseLabelFilter
+  parseGitlabHookThread
 } from './gitlab-events'
 
 describe('GL_TRIGGER_LABEL', () => {
@@ -183,12 +182,6 @@ describe('gitlabHookNeedsNormalization', () => {
 
   it('leaves a note-only rule outside the console normalization model', () => {
     expect(gitlabHookNeedsNormalization({ events: [], commentFamilies: ['issues'], mentionOnly: false })).toBe(false)
-  })
-})
-
-describe('parseLabelFilter', () => {
-  it('trims, drops blanks and de-duplicates', () => {
-    expect(parseLabelFilter(' needs-review , agent, ,needs-review ')).toEqual(['needs-review', 'agent'])
   })
 })
 

--- a/packages/web/src/lib/gitlab-events.ts
+++ b/packages/web/src/lib/gitlab-events.ts
@@ -213,18 +213,6 @@ export function gitlabCadencePick(
   return { families: gitlabFamiliesOf(hook.events), mode }
 }
 
-/** Split a comma or whitespace separated label filter into the stored array. */
-export function parseLabelFilter(input: string): string[] {
-  return [
-    ...new Set(
-      input
-        .split(',')
-        .map((label) => label.trim())
-        .filter(Boolean)
-    )
-  ]
-}
-
 /**
  * The rename-stable thread key a GitLab hook session carries
  * (gitlab-com-integration.md §12.3): `gitlab:<project-id>:<kind>:<iid>`. A push


### PR DESCRIPTION
## What

User decision: the GitLab hook label filter is removed outright rather than hidden — the matching surface is not part of the v1 console. Stacked on #1398.

- Removed end to end for GitLab: the "Only these labels" row and its state/emission, the field on the GitLab hook create/update bodies, and the relay's label-matching arm in the GitLab rule verdict. The design's label-filter mentions (parity row, relay gate, rule contents, console control, test scope) are removed; event-level `labeled` mentions stay.
- **Rolling compatibility** (section 17.3): the `gitlab.labelFilter` wire member was REQUIRED on `RcHookAssign`, so omitting it would make every GitLab rule undecodable on a not-yet-upgraded relay. The member therefore becomes optional on the wire, the control plane keeps sending a constant empty list for one release, and the relay ignores whatever arrives; a later release can drop the member once no older peer remains.
- Deliberately unchanged: the shared `HookDef.labelFilter` column, DTO, and GitHub write paths — GitHub keeps the feature. Old GitLab rows keep their stored value; nothing reads it.

## Tests

Relay: matching, non-matching, and absent filters all proceed to authorization (tolerant read). Protocol: a GitLab rule decodes with and without the member. CP integration: a create body still carrying the field yields a broadcast rule with an empty filter, proving the value never reaches the relay. Web assertions removed with the row. All package suites (web, relay, protocol, CP unit + touched integration), repo-wide typecheck, lint, format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
