### PR TITLE
fix(web): one row action, and triggers on a dropdown

### DIFF
--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -317,7 +317,7 @@ describe('rowLabel', () => {
 })
 
 describe('IntegrationChannelList direct rows', () => {
-  it('renders an Everyone DM with its Off/On control', () => {
+  it('renders an Everyone DM with its on/off trigger dropdown', () => {
     const html = renderToStaticMarkup(
       createElement(IntegrationChannelList, {
         platform: 'discord',
@@ -326,8 +326,9 @@ describe('IntegrationChannelList direct rows', () => {
       })
     )
     expect(html).toContain('Direct messages')
-    expect(html).toContain('>off</button>')
-    expect(html).toContain('>on</button>')
+    // The closed control READS the current choice; "off" is one menu item away.
+    expect(html).toContain('aria-label="Trigger for Alice"')
+    expect(html).toContain('>on</span>')
   })
 
   it('renders shared-bot default dispatch for a DM', () => {
@@ -342,5 +343,32 @@ describe('IntegrationChannelList direct rows', () => {
       })
     )
     expect(html).toContain('Default dispatch — Bob')
+  })
+})
+
+// A row offers exactly one way out, so it spends it directly — the same × the repository
+// rows carry — rather than hiding a single item behind an overflow menu.
+describe('IntegrationChannelList row action', () => {
+  const render = (platform: string) =>
+    renderToStaticMarkup(
+      createElement(IntegrationChannelList, {
+        integrationId: 'int_alice',
+        platform,
+        channels: [{ channelId: 'C1', name: 'deploys', kind: 'channel', trigger: 'mention' }]
+      })
+    )
+
+  it('delists with an × where the bot cannot leave', () => {
+    const html = render('slack')
+    expect(html).toContain('aria-label="Remove from this list: deploys"')
+    expect(html).toContain('lucide-x')
+    expect(html).not.toContain('lucide-ellipsis')
+  })
+
+  it('leaves, and says so, where the platform can leave one conversation', () => {
+    const html = render('telegram')
+    expect(html).toContain('aria-label="Leave group: deploys"')
+    expect(html).toContain('lucide-log-out')
+    expect(html).not.toContain('lucide-ellipsis')
   })
 })

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -7,13 +7,13 @@ import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
 import { AgentIconView } from '@/components/marks'
 import { channelListSemantics } from '@/components/console/platforms/registry'
+import { TriggerSelect, type TriggerOption } from '@/components/console/TriggerSelect'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { chatPlatformName } from '@/lib/platform-labels'
 
-/** The per-conversation trigger toggle: a ⚡ marker followed by the segmented
- *  bar. Channels: "off" / "any message" / "@-mention" (the default, so it sits
- *  last). DM rows are binary off/on; shared bots project that state across every
- *  membership row. Every segment carries hover copy. */
+/** The per-conversation trigger dropdown: channels take "off" / "any message" / "@-mention" (the
+ *  default, so it sits last), DM rows are binary off/on, and shared bots project that state across
+ *  every membership row. Every choice carries hover copy. */
 function TriggerToggle({
   channel,
   platform,
@@ -33,62 +33,38 @@ function TriggerToggle({
     setSaving(true)
     Promise.resolve(onChange(trigger)).finally(() => setSaving(false))
   }
-  const seg = (trigger: IntegrationChannelRow['trigger'], label: string, hint: string) => {
-    const active = channel.trigger === trigger
-    return (
-      <button
-        key={trigger}
-        onClick={() => pick(trigger)}
-        disabled={disabled || saving}
-        title={hint}
-        className={`rounded-[7px] border-0 px-3 py-[5px] font-sans text-[12.5px] leading-normal max-desktop:w-full ${
-          disabled ? 'cursor-default' : 'cursor-pointer'
-        } ${
-          active
-            ? 'bg-(--surface-card) font-semibold text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]'
-            : 'bg-transparent font-normal text-(--text-tertiary)'
-        } ${saving ? 'opacity-60' : ''}`}
-      >
-        {label}
-      </button>
-    )
-  }
   // A DM conversation activates on any message once enabled — binary off/on. A
   // channel takes the full three-way choice for EVERY agent, gated or not: an operator
   // who wants the bot silent here but still in the channel on the platform has nowhere
   // else to say so. A GROUP DM takes the channel's choice, not the DM's: several people
   // share it, so "every message" must stay opt-in.
   const here = `this ${rowNoun(channel.kind, platform)}`
-  const segs: [IntegrationChannelRow['trigger'], string, string][] =
+  const options: TriggerOption<IntegrationChannelRow['trigger']>[] =
     channel.kind === 'im'
       ? [
-          ['off', 'off', "The agent doesn't respond in this conversation."],
-          ['any', 'on', 'The agent responds to messages in this conversation.']
+          { value: 'off', label: 'off', hint: "The agent doesn't respond in this conversation." },
+          { value: 'any', label: 'on', hint: 'The agent responds to messages in this conversation.' }
         ]
       : [
-          ['off', 'off', `The agent doesn't respond in ${here}, even when @-mentioned.`],
-          ['any', 'any message', `The agent responds to every message in ${here}.`],
-          [
-            'mention',
-            '@-mention',
-            "The agent responds when @-mentioned. Follow-ups in a thread it has joined don't need another mention."
-          ]
+          { value: 'off', label: 'off', hint: `The agent doesn't respond in ${here}, even when @-mentioned.` },
+          { value: 'any', label: 'any message', hint: `The agent responds to every message in ${here}.` },
+          {
+            value: 'mention',
+            label: '@-mention',
+            hint: "The agent responds when @-mentioned. Follow-ups in a thread it has joined don't need another mention."
+          }
         ]
   return (
-    <span className="inline-flex items-center gap-[7px] max-desktop:w-full">
-      <span title="Trigger — when the agent responds here" className="flex-none leading-none">
-        <Icon name="zap" size={14} color="var(--text-tertiary)" />
-      </span>
-      <div
-        className={
-          segs.length === 3
-            ? 'inline-flex flex-1 gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px] max-desktop:grid max-desktop:grid-cols-3'
-            : 'inline-flex flex-1 gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px] max-desktop:grid max-desktop:grid-cols-2'
-        }
-      >
-        {segs.map(([trigger, label, hint]) => seg(trigger, label, hint))}
-      </div>
-    </span>
+    <TriggerSelect
+      options={options}
+      value={channel.trigger}
+      onChange={pick}
+      ariaLabel={`Trigger for ${rowLabel(channel)}`}
+      hint="Trigger — when the agent responds here"
+      disabled={disabled}
+      busy={saving}
+      className="max-desktop:w-full"
+    />
   )
 }
 
@@ -253,10 +229,9 @@ export const canLeaveRow = (kind: IntegrationChannelRow['kind'], platform?: stri
   canLeaveConversation(platform) && !isDirectConversation(kind)
 
 /**
- * The ONE action a row's menu offers, fully worded. Exported and pure because the rule
- * it encodes — one action, the strongest the platform allows, and the copy carries
- * whatever that leaves undone — is the whole design and belongs in a test rather than
- * only in a rendered popover.
+ * The ONE action a row offers, fully worded. Exported and pure because the rule it encodes —
+ * one action, the strongest the platform allows, and the copy carries whatever that leaves
+ * undone — is the whole design and belongs in a test rather than only in a rendered button.
  *
  * Three cases hide behind "cannot leave", and they call for different sentences:
  * a Discord bot belongs to a SERVER, so the way out is the band heading above the row,
@@ -289,7 +264,7 @@ export function rowMenuAction(
     leave: false,
     name,
     label: 'Remove from this list',
-    icon: 'trash-2',
+    icon: 'x',
     hint: `Only stops showing it here. ${rest}`,
     confirm: `Remove ${name} from this list? ${rest}`
   }
@@ -320,22 +295,22 @@ export function placePopover(
 }
 
 /**
- * The per-row overflow menu, which offers exactly ONE action — the strongest the
- * platform allows, worded by `rowMenuAction`. Where the bot can leave, leaving is the
- * only choice: it does everything the weaker one does and more, so offering both would
- * ask the operator to distinguish two outcomes that differ only in how far they reach.
- * Where it cannot, removing the row is the only choice and its copy carries the rest.
+ * The row's ONE way out, worded by `rowMenuAction` — a bare icon button, not a menu: a
+ * single-item overflow menu is two clicks and a popover to reach one control, and the repository
+ * rows next to it already spend their × directly. Where the bot can leave, leaving is the only
+ * choice: it does everything the weaker one does and more, so offering both would ask the operator
+ * to distinguish two outcomes that differ only in how far they reach. Where it cannot, removing the
+ * row is the only choice and its copy carries the rest.
  *
- * That collapse is what makes the "already gone" case load-bearing: on a leave-capable
- * platform a stale row has no second escape hatch, so Leave must also succeed when the
- * bot has already been removed there (`isAlreadyOutOfChat`, daemon side).
+ * That collapse is what makes the "already gone" case load-bearing: on a leave-capable platform a
+ * stale row has no second escape hatch, so Leave must also succeed when the bot has already been
+ * removed there (`isAlreadyOutOfChat`, daemon side).
  *
- * Each label names its OUTCOME. Neither says "forget", the earlier wording: it
- * describes our bookkeeping, not the user's outcome, and in a product that gives agents
- * a MEMORY it reads like erasing what was said. Both confirm, since neither is undoable
- * from here.
+ * The label names the OUTCOME. Neither says "forget", the earlier wording: it describes our
+ * bookkeeping, not the user's outcome, and in a product that gives agents a MEMORY it reads like
+ * erasing what was said. Both confirm, since neither is undoable from here.
  */
-function RowActions({
+function RowAction({
   channel,
   platform,
   onForget,
@@ -346,88 +321,25 @@ function RowActions({
   onForget: () => Promise<void>
   onLeave: () => Promise<void>
 }) {
-  const [box, setBox] = useState<PopoverBox | null>(null)
   const [busy, setBusy] = useState(false)
-  const btnRef = useRef<HTMLButtonElement>(null)
-  const open = box !== null
-  const close = useCallback(() => setBox(null), [])
-  // Same portal + dismissal contract as the default-dispatch popover: the host cards
-  // clip their rows, so an in-flow menu is cut off on the last one.
-  useEffect(() => {
-    if (!open) return
-    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && close()
-    document.addEventListener('keydown', onKey, true)
-    window.addEventListener('scroll', close, true)
-    window.addEventListener('resize', close)
-    return () => {
-      document.removeEventListener('keydown', onKey, true)
-      window.removeEventListener('scroll', close, true)
-      window.removeEventListener('resize', close)
-    }
-  }, [open, close])
-  const toggle = () => {
-    const el = btnRef.current
-    if (open || !el) return close()
-    setBox(placePopover(el.getBoundingClientRect(), window.innerWidth, window.innerHeight))
-  }
-  const run = (action: () => Promise<void>) => {
-    close()
-    if (busy) return
-    setBusy(true)
-    void action().finally(() => setBusy(false))
-  }
   const action = rowMenuAction(channel, platform)
-  const item = (label: string, icon: string, hint: string, onClick: () => void) => (
-    <button
-      onClick={onClick}
-      disabled={busy}
-      title={hint}
-      className={`flex w-full items-start gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[7px] text-left hover:bg-(--surface-hover) ${
-        busy ? 'cursor-default opacity-60' : 'cursor-pointer'
-      }`}
-    >
-      <Icon name={icon} size={13} color="var(--text-tertiary)" className="mt-[2px] flex-none" />
-      <span className="min-w-0">
-        <span className="block font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)">
-          {label}
-        </span>
-        <span className="block font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-tertiary)">{hint}</span>
-      </span>
-    </button>
-  )
+  const run = () => {
+    if (busy || !window.confirm(action.confirm)) return
+    setBusy(true)
+    void (action.leave ? onLeave() : onForget()).finally(() => setBusy(false))
+  }
   return (
     // The row's controls stack on mobile, where a left-aligned lone button reads as
     // stray; pinning it to the row's end keeps it looking like the row's own control.
-    <span className="flex-none max-desktop:self-end">
-      <button
-        ref={btnRef}
-        onClick={toggle}
-        title={`More actions for ${action.name}`}
-        aria-label={`More actions for ${action.name}`}
-        aria-expanded={open}
-        className={`iconbtn h-7 w-7 ${busy ? 'opacity-60' : ''}`}
-      >
-        <Icon name="ellipsis" size={15} color="var(--text-tertiary)" />
-      </button>
-      {box &&
-        createPortal(
-          <>
-            <span className="fixed inset-0 z-[1090]" onClick={close} />
-            <div
-              className="fixed z-[1100] w-[264px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
-              style={box.style}
-            >
-              {item(action.label, action.icon, action.hint, () =>
-                run(async () => {
-                  if (!window.confirm(action.confirm)) return
-                  await (action.leave ? onLeave() : onForget())
-                })
-              )}
-            </div>
-          </>,
-          document.body
-        )}
-    </span>
+    <button
+      onClick={run}
+      disabled={busy}
+      title={`${action.label} — ${action.hint}`}
+      aria-label={`${action.label}: ${action.name}`}
+      className={`iconbtn h-7 w-7 flex-none max-desktop:self-end ${busy ? 'opacity-60' : ''}`}
+    >
+      <Icon name={action.icon} size={14} color="var(--text-tertiary)" />
+    </button>
   )
 }
 
@@ -721,11 +633,11 @@ export function IntegrationChannelList({
             disabled={!integrationId}
             onChange={(trigger) => setChannelTrigger(integrationId!, c.channelId, trigger)}
           />
-          {/* Demo rows have no integration to act on, so they carry no menu at all
-              rather than an inert one. Both callbacks below are always wired; which ONE
-              the menu offers is `rowMenuAction`'s call, so that rule lives in one place. */}
+          {/* Demo rows have no integration to act on, so they carry no button at all rather than an
+              inert one. Both callbacks are always wired; which ONE the row spends is `rowMenuAction`'s
+              call, so that rule lives in one place. */}
           {integrationId && (
-            <RowActions
+            <RowAction
               channel={c}
               platform={platform}
               onForget={() => act(() => forgetChannel(integrationId, c.channelId))}

--- a/packages/web/src/components/console/TriggerSelect.tsx
+++ b/packages/web/src/components/console/TriggerSelect.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { Icon } from '@/components/ui'
+import { AnchoredFlyout } from '@/components/ui/AnchoredFlyout'
+
+/** One choice: the stored value, the word the closed control shows, and the hover copy for what it does. */
+export interface TriggerOption<T extends string> {
+  value: T
+  label: string
+  hint: string
+}
+
+/**
+ * The ⚡ + dropdown that says when an agent runs here — one control for every trigger surface
+ * (conversations, watched repositories, watched projects), because they are one decision worded
+ * per platform. It states the current choice and keeps the rest behind a menu, so a row that also
+ * carries event pills doesn't read as one long bar of segments.
+ *
+ * The menu is an {@link AnchoredFlyout}: every host card clips its rows, so a menu drawn in flow
+ * would be cut off on the last one.
+ */
+export function TriggerSelect<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  hint,
+  disabled = false,
+  busy = false,
+  className = ''
+}: {
+  options: readonly TriggerOption<T>[]
+  value: T
+  onChange: (value: T) => void
+  /** Names the control for assistive tech — "Trigger for #deploys". */
+  ariaLabel: string
+  /** What ⚡ means on this surface, in this platform's nouns. */
+  hint: string
+  /** Demo rows (no live integration) render the control inert. */
+  disabled?: boolean
+  /** A write is in flight: the control holds its reading and stops taking picks. */
+  busy?: boolean
+  /** Host layout only — the channel rows stretch the control at ≤768px. */
+  className?: string
+}) {
+  const current = options.find((o) => o.value === value)
+  const inert = disabled || busy
+  return (
+    <span className={`inline-flex items-center gap-[7px] ${className}`}>
+      <span title={hint} className="flex-none leading-none">
+        <Icon name="zap" size={14} color="var(--text-tertiary)" />
+      </span>
+      <AnchoredFlyout
+        ariaLabel={ariaLabel}
+        align="start"
+        width={220}
+        estimatedHeight={10 + options.length * 34}
+        triggerClassName="flex min-w-0 flex-1"
+        trigger={({ open, menuId, toggle }) => (
+          <button
+            type="button"
+            disabled={inert}
+            aria-label={ariaLabel}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            aria-controls={open ? menuId : undefined}
+            title={current?.hint ?? hint}
+            onClick={toggle}
+            className={
+              inert
+                ? 'selbtn h-[30px] w-full cursor-default opacity-60'
+                : open
+                  ? 'selbtn on h-[30px] w-full'
+                  : 'selbtn h-[30px] w-full'
+            }
+          >
+            <span className="lbl">{current?.label ?? value}</span>
+          </button>
+        )}
+      >
+        {({ close }) => (
+          <>
+            {options.map((o) => (
+              <button
+                key={o.value}
+                type="button"
+                role="menuitemradio"
+                aria-checked={o.value === value}
+                title={o.hint}
+                className="fopt"
+                onClick={() => {
+                  close(true)
+                  if (o.value !== value) onChange(o.value)
+                }}
+              >
+                <span className="min-w-0 flex-1 truncate">{o.label}</span>
+                {o.value === value && <Icon name="check" size={14} color="var(--brand)" className="flex-none" />}
+              </button>
+            ))}
+          </>
+        )}
+      </AnchoredFlyout>
+    </span>
+  )
+}

--- a/packages/web/src/components/console/TriggerSelect.tsx
+++ b/packages/web/src/components/console/TriggerSelect.tsx
@@ -88,9 +88,12 @@ export function TriggerSelect<T extends string>({
                 aria-checked={o.value === value}
                 title={o.hint}
                 className="fopt"
+                // Every pick reaches the host, the displayed one included: a code-host row whose stored
+                // rule the menu cannot express normalizes by re-picking what it already shows. True
+                // no-ops are suppressed by the hosts, which know which of their picks are no-ops.
                 onClick={() => {
                   close(true)
-                  if (o.value !== value) onChange(o.value)
+                  onChange(o.value)
                 }}
               >
                 <span className="min-w-0 flex-1 truncate">{o.label}</span>

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -52,6 +52,7 @@ import { AgentCallVisibility } from '@/components/console/AgentCallVisibility'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { IntegrationChannelList, roomGlyph, rowLabel } from '@/components/console/IntegrationChannelList'
 import { RecentSessionsCard } from '@/components/console/RecentSessionsCard'
+import { TriggerSelect } from '@/components/console/TriggerSelect'
 import { discordBotInviteUrl } from '@/components/console/platforms/discord/invite'
 import { WorkspaceCard, type WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
 import { WorkspaceFiles, workspaceReadModelKey } from '@/components/console/WorkspaceFiles'
@@ -1564,33 +1565,20 @@ export default function AgentDetailView() {
                                   )
                                 })}
                               </div>
-                              {/* Trigger bar — same ⚡ + segmented control as the IM
-                                    channel rows, mention last, hover copy per segment. */}
-                              <span className="inline-flex flex-none items-center gap-[7px]">
-                                <span title="Trigger — when this agent runs" className="flex-none leading-none">
-                                  <Icon name="zap" size={14} color="var(--text-tertiary)" />
-                                </span>
-                                <div className="inline-flex gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px]">
-                                  {GH_TRIGGER_MODES.map((mode) => {
-                                    const active = triggerModeOf(h) === mode
-                                    return (
-                                      <button
-                                        key={mode}
-                                        onClick={() => void setHookCadence(h, mode)}
-                                        disabled={hookBusy === h.id}
-                                        title={githubTriggerTooltip(mode, da.name)}
-                                        className={`cursor-pointer rounded-[7px] border-0 px-3 py-[5px] font-sans text-[12.5px] leading-normal ${
-                                          active
-                                            ? 'bg-(--surface-card) font-semibold text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]'
-                                            : 'bg-transparent font-normal text-(--text-tertiary)'
-                                        } ${hookBusy === h.id ? 'opacity-60' : ''}`}
-                                      >
-                                        {GH_TRIGGER_PILL[mode]}
-                                      </button>
-                                    )
-                                  })}
-                                </div>
-                              </span>
+                              {/* Trigger — the same ⚡ dropdown the IM channel rows carry, mention last. */}
+                              <TriggerSelect
+                                className="flex-none"
+                                options={GH_TRIGGER_MODES.map((mode) => ({
+                                  value: mode,
+                                  label: GH_TRIGGER_PILL[mode],
+                                  hint: githubTriggerTooltip(mode, da.name)
+                                }))}
+                                value={triggerModeOf(h)}
+                                onChange={(mode) => void setHookCadence(h, mode)}
+                                ariaLabel={`Trigger for ${h.repoFullName ?? h.name}`}
+                                hint="Trigger — when this agent runs"
+                                busy={hookBusy === h.id}
+                              />
                               <span className="inline-flex flex-none gap-[2px]">
                                 <button
                                   className="iconbtn h-[26px] w-[26px] flex-none"
@@ -1697,32 +1685,20 @@ export default function AgentDetailView() {
                                   )
                                 })}
                               </div>
-                              {/* Trigger bar — the same segmented control the GitHub rows carry. */}
-                              <span className="inline-flex flex-none items-center gap-[7px]">
-                                <span title="Trigger — when this agent runs" className="flex-none leading-none">
-                                  <Icon name="zap" size={14} color="var(--text-tertiary)" />
-                                </span>
-                                <div className="inline-flex gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[2px]">
-                                  {GL_TRIGGER_MODES.map((mode) => {
-                                    const active = gitlabTriggerModeOf(h) === mode
-                                    return (
-                                      <button
-                                        key={mode}
-                                        onClick={() => void setGitlabHookCadence(h, mode)}
-                                        disabled={hookBusy === h.id}
-                                        title={gitlabTriggerTooltip(mode, da.name)}
-                                        className={`cursor-pointer rounded-[7px] border-0 px-3 py-[5px] font-sans text-[12.5px] leading-normal ${
-                                          active
-                                            ? 'bg-(--surface-card) font-semibold text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]'
-                                            : 'bg-transparent font-normal text-(--text-tertiary)'
-                                        } ${hookBusy === h.id ? 'opacity-60' : ''}`}
-                                      >
-                                        {GL_TRIGGER_PILL[mode]}
-                                      </button>
-                                    )
-                                  })}
-                                </div>
-                              </span>
+                              {/* Trigger — the same ⚡ dropdown the GitHub rows carry. */}
+                              <TriggerSelect
+                                className="flex-none"
+                                options={GL_TRIGGER_MODES.map((mode) => ({
+                                  value: mode,
+                                  label: GL_TRIGGER_PILL[mode],
+                                  hint: gitlabTriggerTooltip(mode, da.name)
+                                }))}
+                                value={gitlabTriggerModeOf(h)}
+                                onChange={(mode) => void setGitlabHookCadence(h, mode)}
+                                ariaLabel={`Trigger for ${h.repoFullName ?? h.name}`}
+                                hint="Trigger — when this agent runs"
+                                busy={hookBusy === h.id}
+                              />
                               <span className="inline-flex flex-none gap-[2px]">
                                 <button
                                   className="iconbtn h-[26px] w-[26px] flex-none"


### PR DESCRIPTION
## What changed

**A row with one action spends it directly.** A conversation row's overflow menu only ever
held a single item — `rowMenuAction` collapses the choice to the strongest thing the platform
allows — so reaching it cost a click, a portalled popover and a second click. The row now
carries that action as a bare icon button, the way the repository rows beside it already carry
theirs: `×` where the bot can only be delisted (the same button GitHub and GitLab rows use for
"Remove repository"), `log-out` where the platform can actually leave the conversation, since
those are different outcomes. The full wording moved into the tooltip and both actions still
confirm, so nothing the popover explained is lost.

**Every trigger control is one shared dropdown.** New `TriggerSelect` — ⚡ plus a `selbtn` that
reads the current choice, with the options in an `AnchoredFlyout` menu (portalled, because every
host card clips its rows) and a check on the active one. All three surfaces use it:

- conversation rows: `off` / `any message` / `@-mention`, and the binary `off` / `on` for direct
  conversations;
- watched GitHub repositories and watched GitLab projects: `create` / `update` / `@-mention`.

Each option keeps the hover copy its segment carried, so the per-choice explanations are
unchanged — only the shape is.

## Why

Two segmented bars on one row (event families + trigger) read as a single long bar of segments,
and the trigger's three choices were spending row width to show two that aren't in effect. A
dropdown states the current choice and keeps the rest one click away. Hiding a single action
behind an overflow menu had the opposite problem: chrome around a control that needed none.

## Notes for a reviewer

- `rowMenuAction` is unchanged apart from the delist icon (`trash-2` → `x`); the rule about which
  action a row offers, and all its copy, still lives in that one pure function with its tests.
- The Add-integration wizard's trigger step is deliberately left as 3-up tiles with descriptions:
  it is a first-run choice where seeing all three helps, not a row control.
- Mobile is unchanged in layout — the dropdown stretches and the action button sits where the
  overflow button did.
- Verified in mock mode at 1500/1000/375px in both themes; `tsc`, eslint, prettier and the full
  web suite (1878 tests) pass. The direct-conversation render test now asserts the dropdown reads
  its current choice, and two new tests pin the row's direct button per platform.
