### PR TITLE
test(daemon): follow the runtime-commands reader's two-argument contract

### DIFF
--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -951,11 +951,7 @@ describe('CpClient dispatch', () => {
       Date.parse('2026-06-26T00:00:00.000Z')
     )
     const { t } = await readyClient({
-      runtimeCommandsReader: createRuntimeCommandsReader(
-        commands,
-        (id) => id === 'a1',
-        async (_a, acp) => acp
-      )
+      runtimeCommandsReader: createRuntimeCommandsReader(commands, (id) => id === 'a1')
     })
     const f = JSON.parse(frame('runtime/commands', { agentId: 'a1' }, { epoch: 5 }))
     t.pushInbound(JSON.stringify(f))
@@ -973,11 +969,7 @@ describe('CpClient dispatch', () => {
 
   it('replies runtime/commands/list with reported:false before any advertisement', async () => {
     const { t } = await readyClient({
-      runtimeCommandsReader: createRuntimeCommandsReader(
-        new RuntimeCommandsCache(),
-        () => true,
-        async (_a, acp) => acp
-      )
+      runtimeCommandsReader: createRuntimeCommandsReader(new RuntimeCommandsCache(), () => true)
     })
     t.pushInbound(frame('runtime/commands', { agentId: 'a1' }, { epoch: 5 }))
     await tick()


### PR DESCRIPTION
## What

Main's Check job is red after #1354: the squash shipped an intermediate commit's test edits — two call sites in the daemon's dispatch tests still pass the read-time resolver argument that a later commit in the same PR removed from `createRuntimeCommandsReader` (the reader returned to a pure two-argument cache read when advertisements moved to write-time session naming). The stray argument was the identity function, so the assertions never depended on it; test files only became type-checked with #1386, which is why it surfaced now.

Both call sites return to the two-argument form; the resulting file is byte-identical to its pre-#1354 state. Whole-repo `typecheck:ci` is clean after this — it was the only error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
