### PR TITLE
fix(daemon): drop the stale third argument from two reader test call sites

### DIFF
--- a/packages/daemon/test/cp/client-dispatch.test.ts
+++ b/packages/daemon/test/cp/client-dispatch.test.ts
@@ -951,11 +951,7 @@ describe('CpClient dispatch', () => {
       Date.parse('2026-06-26T00:00:00.000Z')
     )
     const { t } = await readyClient({
-      runtimeCommandsReader: createRuntimeCommandsReader(
-        commands,
-        (id) => id === 'a1',
-        async (_a, acp) => acp
-      )
+      runtimeCommandsReader: createRuntimeCommandsReader(commands, (id) => id === 'a1')
     })
     const f = JSON.parse(frame('runtime/commands', { agentId: 'a1' }, { epoch: 5 }))
     t.pushInbound(JSON.stringify(f))
@@ -973,11 +969,7 @@ describe('CpClient dispatch', () => {
 
   it('replies runtime/commands/list with reported:false before any advertisement', async () => {
     const { t } = await readyClient({
-      runtimeCommandsReader: createRuntimeCommandsReader(
-        new RuntimeCommandsCache(),
-        () => true,
-        async (_a, acp) => acp
-      )
+      runtimeCommandsReader: createRuntimeCommandsReader(new RuntimeCommandsCache(), () => true)
     })
     t.pushInbound(frame('runtime/commands', { agentId: 'a1' }, { epoch: 5 }))
     await tick()


### PR DESCRIPTION
Unbreaks main's release build ([failed run](https://github.com/agentconnect-md/agentconnect/actions/runs/32571775084)).

#1354 removed `createRuntimeCommandsReader`'s outward-id resolver parameter when runtime-command advertisements moved to write-time naming, but two call sites in `client-dispatch.test.ts` kept passing it. The branch predated #1379's typecheck widening to `test/`, so neither the branch's local typecheck nor its PR CI compiled these files — the first build to hold both changes was main's release run.

Runtime behavior was never wrong (the extra argument was ignored), so this is exactly the two call sites, brought to the 2-parameter signature. `pnpm typecheck:ci` is clean and the file's 53 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)