### PR TITLE
feat(control-plane): friendly display names and profile links for project bots

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -329,6 +329,11 @@ eligibility, author/committer restrictions, and protected-resource rules still
 apply. AgentConnect never raises the role automatically to bypass project
 policy.
 
+Its username is the rename-stable machine marker; its display name is the
+project's own last path segment plus `-bot`, sanitized and capped, which
+reconciliation backfills onto an account still carrying a default name and never
+onto one an administrator renamed.
+
 The account is shared by all AgentConnect agents connected to that project.
 Agent identity is recorded in the generated note/review marker and
 AgentConnect audit metadata, not represented as another GitLab user.

--- a/packages/control-plane/src/gitlab/api.ts
+++ b/packages/control-plane/src/gitlab/api.ts
@@ -35,7 +35,7 @@ function codeFor(status: number): GitlabErrorCode {
 }
 
 export interface GitlabRequestOpts {
-  method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
   /** OAuth or PAT bearer. Pass null only for the token endpoint itself. */
   auth: string | null
   body?: unknown
@@ -309,6 +309,24 @@ export function gitlabServiceAccountUsername(projectId: bigint): string {
   return `agentconnect-p${projectId}`
 }
 
+/** The account's human display name: the project's own last path segment plus
+ *  `-bot`, folded to a conservative ASCII set and capped so no name we write can
+ *  be refused. Falls back to the machine username when nothing survives (§7.2). */
+export function gitlabServiceAccountDisplayName(projectPath: string, username: string): string {
+  const segment = (projectPath.split('/').pop() ?? '')
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^[-._]+|[-._]+$/g, '')
+    .slice(0, 48)
+  return segment ? `${segment}-bot` : username
+}
+
+/** "Still the default": empty, the machine username itself, or the `AgentConnect
+ *  (<path>)` form earlier versions wrote — never a name a person chose. */
+export function gitlabServiceAccountNameIsDefault(name: string | undefined, username: string): boolean {
+  const trimmed = (name ?? '').trim()
+  return trimmed === '' || trimmed === username || /^AgentConnect \(.*\)$/.test(trimmed)
+}
+
 /** Find the marked account among the top-level group's service accounts. */
 export async function gitlabFindServiceAccount(
   accessToken: string,
@@ -333,6 +351,22 @@ export async function gitlabCreateServiceAccount(
     method: 'POST',
     auth: accessToken,
     body: { username: input.username, name: input.name },
+    fetchImpl
+  })
+}
+
+/** Rename an existing account (display name only — the username is the §7.2 identity). */
+export async function gitlabUpdateServiceAccount(
+  accessToken: string,
+  groupId: number,
+  userId: bigint,
+  input: { name: string },
+  fetchImpl?: FetchLike
+): Promise<GitlabServiceAccount> {
+  return gitlabRequest<GitlabServiceAccount>(`/groups/${groupId}/service_accounts/${userId}`, {
+    method: 'PATCH',
+    auth: accessToken,
+    body: { name: input.name },
     fetchImpl
   })
 }

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -51,8 +51,11 @@ import {
   gitlabListWebhooks,
   gitlabRevokeServiceAccountToken,
   gitlabRootNamespace,
+  gitlabServiceAccountDisplayName,
+  gitlabServiceAccountNameIsDefault,
   gitlabServiceAccountUsername,
   gitlabTestWebhook,
+  gitlabUpdateServiceAccount,
   gitlabUpdateWebhook,
   membershipSatisfies,
   type FetchLike,
@@ -326,6 +329,7 @@ export class GitlabProvisioner {
 
     // 2–3. Find-or-create the marked service account; ensure Developer membership.
     const username = gitlabServiceAccountUsername(binding.projectId)
+    const displayName = gitlabServiceAccountDisplayName(project.path_with_namespace, username)
     let account = await gitlabFindServiceAccount(token, root.id, username, fetchImpl)
     if (!account) {
       // §10.2 per-step atomic renewal: the run must still own the lease.
@@ -333,12 +337,7 @@ export class GitlabProvisioner {
         return { state: 'admin_degraded', reason: 'claim_fence_lost' }
       }
       try {
-        account = await gitlabCreateServiceAccount(
-          token,
-          root.id,
-          { username, name: `AgentConnect (${project.path_with_namespace})` },
-          fetchImpl
-        )
+        account = await gitlabCreateServiceAccount(token, root.id, { username, name: displayName }, fetchImpl)
       } catch (e) {
         // Ambiguous create (§10.2): list by the deterministic marker before failing.
         account = await gitlabFindServiceAccount(token, root.id, username, fetchImpl)
@@ -349,6 +348,22 @@ export class GitlabProvisioner {
           }
           throw e
         }
+      }
+    }
+    // Repair backfills the friendly name onto an account still carrying a default
+    // one; a name a person chose is left alone, and a refused rename never fails
+    // the run — the account and its credentials matter, its label does not.
+    if (account.name !== displayName && gitlabServiceAccountNameIsDefault(account.name, username)) {
+      if (!(await this.renewLease(orgId, binding, owner))) {
+        return { state: 'admin_degraded', reason: 'claim_fence_lost' }
+      }
+      try {
+        account = await gitlabUpdateServiceAccount(token, root.id, BigInt(account.id), { name: displayName }, fetchImpl)
+      } catch (e) {
+        this.deps.log?.warn(
+          { bindingId: binding.id, status: e instanceof GitlabApiError ? e.status : undefined },
+          'gitlab service account rename failed'
+        )
       }
     }
     const accountUserId = BigInt(account.id)

--- a/packages/control-plane/src/gitlab/service-account-name.test.ts
+++ b/packages/control-plane/src/gitlab/service-account-name.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Project Service Account naming (gitlab-com-integration.md §7.2): the username
+ * is the rename-stable machine identity, the display name is the friendly label.
+ */
+import { describe, expect, it } from 'vitest'
+import { gitlabServiceAccountDisplayName, gitlabServiceAccountNameIsDefault } from './api.js'
+
+const USERNAME = 'agentconnect-p4455667'
+
+describe('gitlabServiceAccountDisplayName', () => {
+  it('names the account after the project’s own last path segment', () => {
+    expect(gitlabServiceAccountDisplayName('example-group/example-project', USERNAME)).toBe('example-project-bot')
+    // Nested subgroups still resolve to the project itself.
+    expect(gitlabServiceAccountDisplayName('example-group/team/api.service', USERNAME)).toBe('api.service-bot')
+  })
+
+  it('folds anything outside the safe set and caps the segment', () => {
+    expect(gitlabServiceAccountDisplayName('group/prêt <à> porter', USERNAME)).toBe('pr-t-porter-bot')
+    const long = gitlabServiceAccountDisplayName(`group/${'a'.repeat(120)}`, USERNAME)
+    expect(long).toBe(`${'a'.repeat(48)}-bot`)
+  })
+
+  it('falls back to the machine username when nothing survives', () => {
+    expect(gitlabServiceAccountDisplayName('group/***', USERNAME)).toBe(USERNAME)
+    expect(gitlabServiceAccountDisplayName('', USERNAME)).toBe(USERNAME)
+  })
+})
+
+describe('gitlabServiceAccountNameIsDefault', () => {
+  it('accepts every default form the account can carry', () => {
+    expect(gitlabServiceAccountNameIsDefault('', USERNAME)).toBe(true)
+    expect(gitlabServiceAccountNameIsDefault(undefined, USERNAME)).toBe(true)
+    expect(gitlabServiceAccountNameIsDefault(USERNAME, USERNAME)).toBe(true)
+    expect(gitlabServiceAccountNameIsDefault('AgentConnect (example-group/example-project)', USERNAME)).toBe(true)
+  })
+
+  it('never claims a name a person chose', () => {
+    expect(gitlabServiceAccountNameIsDefault('Release Robot', USERNAME)).toBe(false)
+    expect(gitlabServiceAccountNameIsDefault('example-project-bot', USERNAME)).toBe(false)
+    // Near-miss on the retired form: only the exact shape counts as ours.
+    expect(gitlabServiceAccountNameIsDefault('AgentConnect helper', USERNAME)).toBe(false)
+  })
+})

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -19,6 +19,8 @@ export interface FakeGitlabOptions {
   patExpiryOverride?: string | null
   /** Fail PAT revocations with a 500 (ambiguous cleanup). */
   failTokenRevoke?: boolean
+  /** Refuse the display-name rename (older provider, or a locked account). */
+  refuseServiceAccountRename?: boolean
 }
 
 export class FakeGitlab {
@@ -213,6 +215,14 @@ export class FakeGitlab {
         const account = { id: ++this.nextId, username: String(payload.username), name: String(payload.name) }
         this.serviceAccounts.push(account)
         return Response.json(account, { status: 201 })
+      }
+      if (/\/api\/v4\/groups\/\d+\/service_accounts\/\d+$/.test(url) && method === 'PATCH') {
+        const id = Number(/service_accounts\/(\d+)$/.exec(url)![1])
+        const account = this.serviceAccounts.find((candidate) => candidate.id === id)
+        if (!account) return Response.json({ message: 'Not Found' }, { status: 404 })
+        if (this.opts.refuseServiceAccountRename) return Response.json({ message: 'forbidden' }, { status: 403 })
+        account.name = String(json().name)
+        return Response.json(account)
       }
       if (/\/api\/v4\/groups\/\d+\/service_accounts\/\d+$/.test(url) && method === 'DELETE') {
         const id = Number(/service_accounts\/(\d+)$/.exec(url)![1])

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -87,6 +87,11 @@ describe('GitlabProvisioner (§10.2)', () => {
     const binding = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
     expect(binding.state).toBe('ready')
     expect(binding.serviceAccountUsername).toBe(gitlabServiceAccountUsernameForTests(PROJECT))
+    // The rename-stable username stays machine; only the human label reads as the project.
+    expect(h.fake.serviceAccounts[0]).toMatchObject({
+      username: gitlabServiceAccountUsernameForTests(PROJECT),
+      name: 'example-project-bot'
+    })
     expect(binding.credentialEpoch).toBe(h.binding.credentialEpoch + 3n)
     // Developer, never higher (§7.2).
     expect(h.fake.members.get(Number(binding.serviceAccountUserId))).toBe(30)
@@ -223,6 +228,38 @@ describe('GitlabProvisioner (§10.2)', () => {
       await h.bindings.markProviderMutationStarted(DEFAULT_ORG_ID, h.binding.id, PROJECT, 'dead2', expired, now)
     ).toBe(true)
     expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT, now)).toBe(true)
+  })
+
+  it('repair backfills a default display name onto an account that already exists', async () => {
+    const h = await harness()
+    const username = gitlabServiceAccountUsernameForTests(PROJECT)
+    // Both default forms an account can carry: the retired label and the bare username.
+    for (const stale of [`AgentConnect (example-group/example-project)`, username]) {
+      h.fake.serviceAccounts = [{ id: 7000, username, name: stale }]
+      expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+      expect(h.fake.serviceAccounts[0]).toMatchObject({ id: 7000, username, name: 'example-project-bot' })
+    }
+    // The identity itself never moved: one account, same username, same id.
+    expect(h.fake.serviceAccounts).toHaveLength(1)
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.serviceAccountUsername).toBe(username)
+  })
+
+  it('leaves a display name a person chose alone', async () => {
+    const h = await harness()
+    const username = gitlabServiceAccountUsernameForTests(PROJECT)
+    h.fake.serviceAccounts = [{ id: 7001, username, name: 'Release Robot' }]
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    expect(h.fake.serviceAccounts[0]).toMatchObject({ name: 'Release Robot' })
+  })
+
+  it('a refused rename is cosmetic: the run still converges to ready', async () => {
+    const h = await harness({ refuseServiceAccountRename: true })
+    const username = gitlabServiceAccountUsernameForTests(PROJECT)
+    h.fake.serviceAccounts = [{ id: 7002, username, name: username }]
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    expect(h.fake.serviceAccounts[0]).toMatchObject({ name: username })
+    // The credentials the run exists for landed anyway.
+    expect(await new PgGitlabProjectCredentialRepo(prisma).listForBinding(h.binding.id)).toHaveLength(3)
   })
 
   it('two concurrent provisions: exactly one runs, the other observes busy', async () => {

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -358,6 +358,19 @@ describe('GitlabCard', () => {
     expect(buttonIn(host, 'Repair')).toBeTruthy()
   })
 
+  it('links the bot chip to the service account’s GitLab profile', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    await render()
+
+    const chip = host.querySelector('[data-gitlab-project] a') as HTMLAnchorElement
+    expect(chip.textContent).toBe('bot @project_4711_bot')
+    expect(chip.getAttribute('href')).toBe('https://gitlab.com/project_4711_bot')
+    // A new tab, and never one that can reach back into the console.
+    expect(chip.getAttribute('target')).toBe('_blank')
+    expect(chip.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
   it('says where projects come from when a connection has none', async () => {
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     await render()

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -347,10 +347,16 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
               <span className={`badge ${GITLAB_PROJECT_STATE[p.state].badge}`}>
                 {GITLAB_PROJECT_STATE[p.state].label}
               </span>
+              {/* The bot is a real GitLab account: its chip opens that profile. */}
               {p.serviceAccountUsername && (
-                <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                <a
+                  href={`https://gitlab.com/${p.serviceAccountUsername}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary) hover:underline"
+                >
                   bot @{p.serviceAccountUsername}
-                </span>
+                </a>
               )}
               {!p.webhookInstalled && (
                 <span className="badge bg-(--surface-active) text-(--text-tertiary)">no webhook</span>


### PR DESCRIPTION
## What

User feedback on the pilot: the project service account read as machine noise in the console and notes, and nothing linked to it.

- New accounts get a friendly display name derived from the project path's last segment — `<project>-bot`, sanitized to GitLab's name charset with a length cap and a machine-username fallback so a write can never be refused. The username stays the rename-stable `agentconnect-p<projectId>` identity.
- Repair backfills the friendly name onto accounts still carrying a default form (the machine username or the earlier `AgentConnect (…)` shape), under the provisioner's mutation lease; a person-chosen name is left alone, and a refused rename is cosmetic — logged, never degrading the run.
- The console's bot chip links to the account's GitLab profile in a new tab.
- Design section 7.2 records the convention.

## Tests

Five unit tests for the sanitizer and default-name predicate; provisioning integration tests assert the created name, both backfill forms, the person-chosen name staying put, and a 403 rename still converging to ready; a card test pins the anchor. Full CP unit + touched integration, web suite, typecheck, lint, format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
