### PR TITLE
fix(daemon): clone managed GitLab workspaces through the canonical git URL

### DIFF
--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -57,6 +57,7 @@ import {
 } from '@agentconnect.md/protocol'
 import {
   assertSafeWorkspaceGitConfig,
+  canonicalWorkspaceGitUrl,
   gitCommitIdentityEnv,
   managedCredentialHostOf,
   pullWorkspaceRef,
@@ -293,7 +294,9 @@ export function createWorkspaceGit(
       // Canonicalization follows the PROVIDER HOST, never the managed flag: a github grant is tied
       // to exactly owner/repo, while a gitlab project keeps its full subgroup namespace.
       const github = target.githubApp && managedCredentialHostOf(target.repo) !== 'gitlab.com'
-      expectedOrigin = authorizeWorkspaceGitUrl(github ? normalizeGithubRepoUrl(target.repo) : target.repo)
+      expectedOrigin = authorizeWorkspaceGitUrl(
+        canonicalWorkspaceGitUrl(github ? normalizeGithubRepoUrl(target.repo) : target.repo)
+      )
     } catch {
       return undefined
     }

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -346,6 +346,14 @@ export function managedCredentialHostOf(repository: string | undefined): Managed
   }
 }
 
+// The address daemon Git may dial: gitlab.com 301s the suffix-less HTTPS probe and we refuse redirects, so its remote carries `.git`.
+export function canonicalWorkspaceGitUrl(repository: string): string {
+  const normalized = normalizeGitCloneUrl(repository)
+  if (managedCredentialHostOf(normalized) !== 'gitlab.com') return normalized
+  if (!/^https:/i.test(normalized) || /\.git$/i.test(normalized)) return normalized
+  return `${normalized}.git`
+}
+
 /**
  * Where the git that will READ these pointers runs.
  *

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -26,6 +26,7 @@ import { installSkills, type LocalSkillSource } from '../skills/install-skills.j
 import { acceptedDreamSkillSources } from '../skills/dream-skills.js'
 import {
   assertSafeWorkspaceGitConfig,
+  canonicalWorkspaceGitUrl,
   cloneGitEnv,
   gitFor,
   preWarmGitCred,
@@ -286,7 +287,9 @@ export class WorkspaceManager {
       throw new Error(`workspace clone: agent "${agent.id}" has git-repo mode but no gitRepo configured`)
     }
     return authorizeWorkspaceGitUrl(
-      this.usesGithubApp(agent) ? normalizeGithubRepoUrl(agent.workspace.gitRepo) : agent.workspace.gitRepo
+      canonicalWorkspaceGitUrl(
+        this.usesGithubApp(agent) ? normalizeGithubRepoUrl(agent.workspace.gitRepo) : agent.workspace.gitRepo
+      )
     )
   }
 
@@ -848,12 +851,11 @@ export class WorkspaceManager {
   materializationKey(agent: Agent): string {
     if (agent.workspace.mode === 'from-scratch') return JSON.stringify({ mode: 'scratch' })
     const repo = this.gitRepoOf(agent)
+    // Both hosts treat `.git` as the same repository, so neither canonicalization may replace a checkout over an access-only edit.
+    const suffixInsensitive = this.usesGithubApp(agent) || managedCredentialHostOf(repo) === 'gitlab.com'
     return JSON.stringify({
       mode: 'github',
-      // GitHub treats the conventional `.git` suffix as the same repository.
-      // Ignoring it here prevents a harmless CP canonicalization from replacing
-      // an existing checkout during an access/agentDir-only edit.
-      repo: (this.usesGithubApp(agent) ? repo.replace(/\.git$/i, '') : repo).toLowerCase(),
+      repo: (suffixInsensitive ? repo.replace(/\.git$/i, '') : repo).toLowerCase(),
       branch: agent.workspace.gitBranch
     })
   }

--- a/packages/daemon/test/cp/gitlab-gitcred.test.ts
+++ b/packages/daemon/test/cp/gitlab-gitcred.test.ts
@@ -120,6 +120,22 @@ describe('helper path parsing (§13.2)', () => {
     expect(projectFromPath('just-a-name')).toBeUndefined()
     expect(repoFromPath('owner/repo.git/info/lfs')).toBe('owner/repo')
   })
+
+  it('resolves the same project from the canonical `.git` remote git now dials (useHttpPath)', async () => {
+    const { canonicalWorkspaceGitUrl } = await import('../../src/workspace/git-injection.js')
+    // useHttpPath=true sends the remote's own path, so the helper routes on the canonical form: suffix and depth survive.
+    for (const configured of [
+      'https://gitlab.com/example-group/example-project',
+      'https://gitlab.com/example-group/example-project.git'
+    ]) {
+      const path = new URL(canonicalWorkspaceGitUrl(configured)).pathname
+      expect(path).toBe('/example-group/example-project.git')
+      expect(projectFromPath(path)).toBe('example-group/example-project')
+    }
+    const subgroup = new URL(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/sub/deeper/proj')).pathname
+    expect(projectFromPath(subgroup)).toBe('example-group/sub/deeper/proj')
+    expect(projectFromPath(`${subgroup}/info/lfs`)).toBe('example-group/sub/deeper/proj')
+  })
 })
 
 describe('managed origin convergence trust (round 2)', () => {

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -8,6 +8,7 @@ import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV, GITCRED_SOCKET_ENV } from '.
 import { LocalGitRunner, type GitRunner } from '../src/workspace/git-runner.js'
 import {
   assertSafeWorkspaceGitConfig,
+  canonicalWorkspaceGitUrl,
   cloneGitEnv,
   gitEnvBase,
   gitFor,
@@ -593,6 +594,54 @@ describe('cloneGitEnv', () => {
       'core.sshCommand',
       'ssh -F none -o ProxyCommand=none -o ProxyJump=none -o PermitLocalCommand=no -o ClearAllForwardings=yes'
     ])
+  })
+})
+
+describe('canonicalWorkspaceGitUrl', () => {
+  // gitlab.com 301s the suffix-less ref probe to the `.git` form and daemon Git pins http.followRedirects=false.
+  it('gives a gitlab.com HTTPS remote its `.git` form, at any subgroup depth', () => {
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project')).toBe(
+      'https://gitlab.com/example-group/example-project.git'
+    )
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/sub/deeper/example-project')).toBe(
+      'https://gitlab.com/example-group/sub/deeper/example-project.git'
+    )
+    // A trailing slash is the same repository, so it must not produce `…/.git`.
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project/')).toBe(
+      'https://gitlab.com/example-group/example-project.git'
+    )
+  })
+
+  it('is idempotent: a remote that already carries the suffix is left exactly as configured', () => {
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project.git')).toBe(
+      'https://gitlab.com/example-group/example-project.git'
+    )
+    // Git matches the suffix case-insensitively; appending a second one would name a different path.
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project.GIT')).toBe(
+      'https://gitlab.com/example-group/example-project.GIT'
+    )
+  })
+
+  it('leaves github and every non-gitlab HTTPS remote byte-identical', () => {
+    expect(canonicalWorkspaceGitUrl('https://github.com/acme/infra')).toBe('https://github.com/acme/infra')
+    expect(canonicalWorkspaceGitUrl('https://github.com/acme/infra.git')).toBe('https://github.com/acme/infra.git')
+    expect(canonicalWorkspaceGitUrl('https://code.example.test/acme/infra')).toBe(
+      'https://code.example.test/acme/infra'
+    )
+  })
+
+  it('leaves gitlab SSH alone — only the HTTPS ref probe redirects', () => {
+    expect(canonicalWorkspaceGitUrl('ssh://git@gitlab.com/example-group/example-project')).toBe(
+      'ssh://git@gitlab.com/example-group/example-project'
+    )
+    expect(canonicalWorkspaceGitUrl('git@gitlab.com:example-group/example-project')).toBe(
+      'git@gitlab.com:example-group/example-project'
+    )
+  })
+
+  it('still refuses what the shared codec refuses, so canonicalization cannot admit a new target', () => {
+    expect(() => canonicalWorkspaceGitUrl('/srv/local/repo')).toThrow('local git paths are not supported')
+    expect(() => canonicalWorkspaceGitUrl('ext::payload')).toThrow('git clone url must use https or ssh')
   })
 })
 

--- a/packages/daemon/test/workspace-repo-scope.test.ts
+++ b/packages/daemon/test/workspace-repo-scope.test.ts
@@ -345,11 +345,52 @@ describe('the console git scope keys on the MANAGED credential, not the github-a
   })
 
   it('authorizes a gitlab SUBGROUP primary at its configured URL, which github canonicalization throws on', async () => {
-    // Three path segments: `normalizeGithubRepoUrl` demands exactly owner/repo and throws here, which
-    // used to refuse every console pull and push on a managed GitLab primary as an unsafe remote.
-    const origin = 'https://gitlab.com/example-group/sub/example-project'
-    const row = managed('bot-gitlab-push', checkoutOn('bot-gitlab-push', origin), origin, 'gitlab')
+    // Three path segments: `normalizeGithubRepoUrl` demands owner/repo and throws, which used to refuse every console push.
+    const configured = 'https://gitlab.com/example-group/sub/example-project'
+    // The checkout carries what the daemon clones through — the canonical `.git` remote.
+    const row = managed('bot-gitlab-push', checkoutOn('bot-gitlab-push', `${configured}.git`), configured, 'gitlab')
     expect(await seamOn(row).push({ agentId: row.id })).toMatchObject({ isRepo: true, ok: true, ahead: 0 })
+  })
+
+  it('dials a managed gitlab primary through the canonical `.git` remote, github byte-identically', () => {
+    // gitlab.com 301s the suffix-less ref probe and daemon Git refuses to follow one — the first real managed clone died on it.
+    const at = (id: string) => join(base, 'agents', id, 'workspace')
+    const bare = managed('bot-gl-bare', at('bot-gl-bare'), 'https://gitlab.com/example-group/example-project', 'gitlab')
+    expect(workspaces.gitRepoOf(bare)).toBe('https://gitlab.com/example-group/example-project.git')
+    expect(workspaces.primaryRoot(bare).cloneUrl).toBe('https://gitlab.com/example-group/example-project.git')
+
+    const subgroup = managed('bot-gl-sub', at('bot-gl-sub'), 'https://gitlab.com/example-group/sub/proj', 'gitlab')
+    expect(workspaces.primaryRoot(subgroup).cloneUrl).toBe('https://gitlab.com/example-group/sub/proj.git')
+
+    const suffixed = managed('bot-gl-suffixed', at('bot-gl-suffixed'), 'https://gitlab.com/g/p.git', 'gitlab')
+    expect(workspaces.primaryRoot(suffixed).cloneUrl).toBe('https://gitlab.com/g/p.git')
+
+    const github = managed('bot-gh-clone', at('bot-gh-clone'), 'https://github.com/acme/infra', 'github-app')
+    expect(workspaces.primaryRoot(github).cloneUrl).toBe('https://github.com/acme/infra')
+  })
+
+  it('converges a checkout left on the suffix-less origin, so the agent never sees a second form', async () => {
+    // The origin the AGENT's git reads must be the one the daemon dials; convergence at reconcile and prepare is that seam.
+    const configured = 'https://gitlab.com/example-group/example-project'
+    const dir = checkoutOn('bot-gl-converge', configured)
+    const row = managed('bot-gl-converge', dir, configured, 'gitlab')
+    await workspaces.convergeOriginInPlaceFor(row.id, workspaces.primaryRoot(row), dir)
+    const origin = execFileSync('git', ['-C', dir, 'remote', 'get-url', 'origin'], { env, encoding: 'utf8' }).trim()
+    expect(origin).toBe(`${configured}.git`)
+  })
+
+  it('keeps the materialization key suffix-insensitive, so canonicalizing does not re-clone a checkout', () => {
+    // The key decides whether a checkout still matches the config, so gaining `.git` must not empty a materialized volume.
+    const at = (id: string) => join(base, 'agents', id, 'workspace')
+    const bare = managed('bot-gl-key', at('bot-gl-key'), 'https://gitlab.com/example-group/example-project', 'gitlab')
+    const suffixed = managed(
+      'bot-gl-key2',
+      at('bot-gl-key'),
+      'https://gitlab.com/example-group/example-project.git',
+      'gitlab'
+    )
+    expect(workspaces.materializationKey(bare)).toBe(workspaces.materializationKey(suffixed))
+    expect(workspaces.materializationKey(bare)).toContain('https://gitlab.com/example-group/example-project"')
   })
 
   it('still collapses a github-app primary onto its canonical owner/repo origin', async () => {


### PR DESCRIPTION
## What

First live GitLab hook turn failed at the workspace clone: GitLab answers the suffix-less HTTP `info/refs` probe with a 301 to the `.git` form, and the managed credential path deliberately refuses redirects (a redirect could carry the credential elsewhere), so the clone exited 128. GitHub serves the bare path directly, which is why this never surfaced.

- `canonicalWorkspaceGitUrl` (beside `managedCredentialHostOf`) appends `.git` for HTTPS gitlab.com remotes that lack it — keyed on the host, not the credential, so an anonymous gitlab.com workspace is covered too; SSH and every other host are untouched.
- Both places that turn an agent's repository into a network remote use it: the workspace manager's single `cloneUrl` funnel (clone, sandbox clone, default-branch probe, pulls, review-ref fetch, in-place origin convergence) and the console pull/push target — so the origin the agent's own git sees is the canonical one everywhere, never half-and-half.
- The materialization key strips the suffix for gitlab.com as it already did for GitHub App checkouts, so existing checkouts are not re-cloned; a checkout still on the bare origin is converged at the next reconcile.
- Display paths stay bare: labels, the console remote parser, the glab target resolver, the credential helper's path match, and the origin allowlist all already normalize `.git`, verified rather than assumed.

## Tests

Nine new cases across the URL helper (with/without suffix, uppercase, trailing slash, subgroups, other hosts, SSH), the workspace scope (clone URL, origin convergence on a real checkout, key stability), and the credential helper's canonical-path match. Workspace/git/gitcred suites (745 tests across the two sweeps), typecheck with tests, lint, format all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
