### PR TITLE
feat(web): make the GitLab console surface generally available

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1592,6 +1592,11 @@ Residual risks are explicit:
 7. Enable project creation generally; keep Ultimate-specific and self-managed
    options absent.
 
+Step 7 is done: the console flag that held the surface back during the pilot is
+removed, so every GitLab view is gated on deployment availability alone — a
+control plane with no GitLab application shows the same absence a deployment
+without a GitHub App does (Section 18.3).
+
 Contract extraction rides these phases rather than preceding them: each
 code-host contract member (Section 6.5) is extracted from the working GitHub
 implementation in the same change that adds its GitLab implementer, so there

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -113,6 +113,17 @@ beforeEach(() => {
 })
 
 describe('GitlabCard', () => {
+  it('states the absence, and asks for no projects, on a deployment with no GitLab application', async () => {
+    // The card mounts everywhere and learns availability from the API (§18.3):
+    // an unconfigured control plane 404s the whole surface, which is an absence
+    // to state — never a load error, and never a second request.
+    mocks.fetchConnections.mockResolvedValue({ enabled: false, connections: [] })
+    await render()
+    expect(host.textContent).toContain('Not enabled on this deployment')
+    expect(mocks.fetchProjects).not.toHaveBeenCalled()
+    expect([...host.querySelectorAll('button')]).toHaveLength(0)
+  })
+
   it('offers a single connect entry point when nothing is connected', async () => {
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [] })
     await render()

--- a/packages/web/src/components/console/GitlabRerunButton.test.tsx
+++ b/packages/web/src/components/console/GitlabRerunButton.test.tsx
@@ -31,11 +31,6 @@ vi.mock('@/lib/api', async (importOriginal) => ({
 
 const { GitlabRerunButton } = await import('./GitlabRerunButton')
 
-const setFlags = (value?: string) => {
-  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
-    value === undefined ? {} : { FEATURE_FLAGS: value }
-}
-
 let root: Root | undefined
 let host: HTMLDivElement | undefined
 
@@ -84,7 +79,6 @@ const startedText = () => document.querySelector('[data-gitlab-rerun-started]')?
 
 afterEach(async () => {
   await unmount()
-  setFlags(undefined)
   mocks.rerunGitlabHook.mockClear()
   mocks.rerunGitlabHook.mockResolvedValue({
     accepted: true,
@@ -97,19 +91,12 @@ afterEach(async () => {
 describe('GitlabRerunButton', () => {
   const gitlabSession = { hookKind: 'gitlab', hookId: 'hook-1', thread: 'gitlab:4455667:merge_request:42' }
 
-  it('renders for a GitLab merge-request hook session under the flag', async () => {
-    setFlags('gitlab')
+  it('renders for a GitLab merge-request hook session', async () => {
     await render(gitlabSession)
     expect(button()?.textContent).toContain('Run again')
   })
 
-  it('is absent without the flag, off a GitLab hook, and on a push or webchat thread', async () => {
-    setFlags(undefined)
-    await render(gitlabSession)
-    expect(button()).toBeNull()
-    await unmount()
-
-    setFlags('gitlab')
+  it('is absent off a GitLab hook, and on a push or webchat thread', async () => {
     for (const props of [
       { ...gitlabSession, hookKind: 'github' },
       { ...gitlabSession, hookKind: null },
@@ -126,7 +113,6 @@ describe('GitlabRerunButton', () => {
   })
 
   it('sends the thread SUBJECT — never a revision the console guessed', async () => {
-    setFlags('gitlab')
     await render({ ...gitlabSession, thread: 'gitlab:4455667:issue:7' })
     await act(async () => {
       button()?.click()
@@ -137,7 +123,6 @@ describe('GitlabRerunButton', () => {
   })
 
   it('translates a refusal code instead of showing the wire category', async () => {
-    setFlags('gitlab')
     mocks.rerunGitlabHook.mockRejectedValueOnce(
       new ApiError('this merge request is merged', 409, 'SUBJECT_CLOSED') as never
     )
@@ -158,7 +143,6 @@ describe('GitlabRerunButton', () => {
   })
 
   it('tells the three relay refusals apart, including the spent per-hook budget', async () => {
-    setFlags('gitlab')
     await render(gitlabSession)
     for (const [relayCode, copy] of [
       ['replay_pending', 'This trigger is still loading — try again shortly'],
@@ -185,7 +169,6 @@ describe('GitlabRerunButton', () => {
   })
 
   it('renders pristine for the next session and drops the previous one’s late reply', async () => {
-    setFlags('gitlab')
     type Reply = Awaited<ReturnType<typeof mocks.rerunGitlabHook>>
     let settleA: ((value: Reply) => void) | undefined
     mocks.rerunGitlabHook.mockImplementationOnce(() => new Promise<Reply>((resolve) => (settleA = resolve)))
@@ -212,7 +195,6 @@ describe('GitlabRerunButton', () => {
   })
 
   it('keeps an error on its own subject when the reader switches away', async () => {
-    setFlags('gitlab')
     mocks.rerunGitlabHook.mockRejectedValueOnce(new ApiError('gone', 409, 'SUBJECT_NOT_FOUND') as never)
     await render(gitlabSession)
     await act(async () => {

--- a/packages/web/src/components/console/GitlabRerunButton.tsx
+++ b/packages/web/src/components/console/GitlabRerunButton.tsx
@@ -8,8 +8,7 @@
  * It names only the thread's subject: the Control Plane reads the merge
  * request's current head itself, so the console can never re-run a stale
  * revision. Absent — never disabled — for anything that is not a GitLab hook
- * session on a merge-request or issue thread, and behind the `gitlab` flag with
- * the rest of the GitLab console surface.
+ * session on a merge-request or issue thread.
  *
  * State is SUBJECT-SCOPED. The session detail view stays mounted across
  * `/sessions/a` → `/sessions/b`, so busy/started/error belong to the subject
@@ -19,7 +18,6 @@
 import { useState } from 'react'
 import { Icon } from '@/components/ui'
 import { ApiError, rerunGitlabHook } from '@/lib/api'
-import { featureFlagEnabled } from '@/lib/feature-flags'
 import { parseGitlabHookThread } from '@/lib/gitlab-events'
 import type { HookKind } from '@/lib/api'
 
@@ -83,7 +81,7 @@ export function GitlabRerunButton({
   const [state, setState] = useState<RerunState>({ key: '', ...PRISTINE })
   const subject = parseGitlabHookThread(thread)
   const subjectKey = `${hookId ?? ''}:${thread ?? ''}`
-  if (!featureFlagEnabled('gitlab') || hookKind !== 'gitlab' || !hookId || !subject) return null
+  if (hookKind !== 'gitlab' || !hookId || !subject) return null
 
   // State belongs to the subject it was produced for; every other subject is pristine.
   const view = state.key === subjectKey ? state : PRISTINE

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -33,7 +33,6 @@ import { useOrgs } from '@/lib/org-context'
 import { useProfile } from '@/lib/profile'
 import { consoleKeys } from '@/lib/swr-keys'
 import { useConsoleData } from '@/lib/data-context'
-import { featureFlagEnabled } from '@/lib/feature-flags'
 import EditWorkspaceModal from '@/components/console/modals/EditWorkspaceModal'
 import { REPOSITORY_ACCESS_BADGE, type WorkspaceMode } from '@/components/console/WorkspaceFormFields'
 
@@ -107,7 +106,6 @@ export function WorkspaceCard({
     router.replace(`${pathname}${sp.size ? `?${sp}` : ''}`, { scroll: false })
   }, [searchParams, agent.canEdit, pathname, router])
 
-  const gitlabOffered = featureFlagEnabled('gitlab')
   const isGithub = ws.mode === 'github'
   const isGitlab = ws.mode === 'gitlab'
   const isGit = ws.mode !== 'scratch'
@@ -162,16 +160,14 @@ export function WorkspaceCard({
             <Icon name="git-branch" size={12} />
             GitHub repo
           </button>
-          {gitlabOffered && (
-            <button
-              className={segClass('gitlab')}
-              onClick={() => pickMode('gitlab')}
-              title={isGitlab ? 'The workspace is a GitLab clone' : 'Convert this workspace to a GitLab project'}
-            >
-              <Icon name="git-branch" size={12} />
-              GitLab project
-            </button>
-          )}
+          <button
+            className={segClass('gitlab')}
+            onClick={() => pickMode('gitlab')}
+            title={isGitlab ? 'The workspace is a GitLab clone' : 'Convert this workspace to a GitLab project'}
+          >
+            <Icon name="git-branch" size={12} />
+            GitLab project
+          </button>
           <button
             className={segClass('scratch')}
             onClick={() => pickMode('scratch')}

--- a/packages/web/src/components/console/WorkspaceFormFields.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.test.tsx
@@ -14,11 +14,6 @@ import {
 let root: Root | undefined
 let container: HTMLDivElement | undefined
 
-const setFlags = (value?: string) => {
-  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
-    value === undefined ? {} : { FEATURE_FLAGS: value }
-}
-
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
 async function render(element: ReactNode) {
@@ -29,7 +24,6 @@ async function render(element: ReactNode) {
 }
 
 afterEach(async () => {
-  setFlags()
   if (root) await act(async () => root?.unmount())
   container?.remove()
   root = undefined
@@ -51,21 +45,8 @@ describe('WorkspaceFormFields', () => {
     const onChange = vi.fn()
     await render(<WorkspaceModeField value="scratch" onChange={onChange} />)
 
-    const buttons = Array.from(container?.querySelectorAll('button') ?? [])
-    expect(buttons.map((button) => button.textContent)).toEqual([
-      'From scratchFresh empty directory.',
-      'From GitHubClone a repo on a branch.'
-    ])
-
-    await act(async () => buttons[1]?.click())
-    expect(onChange).toHaveBeenCalledWith('github')
-  })
-
-  it('offers the GitLab source only where the flag is on', async () => {
-    const onChange = vi.fn()
-    setFlags('gitlab')
-    await render(<WorkspaceModeField value="scratch" onChange={onChange} />)
-
+    // Both code hosts are always offered; a deployment that configures neither
+    // says so in the pane the tile opens, never by dropping the tile.
     const buttons = Array.from(container?.querySelectorAll('button') ?? [])
     expect(buttons.map((button) => button.textContent)).toEqual([
       'From scratchFresh empty directory.',
@@ -73,6 +54,8 @@ describe('WorkspaceFormFields', () => {
       'From GitLabClone a project on a branch.'
     ])
 
+    await act(async () => buttons[1]?.click())
+    expect(onChange).toHaveBeenCalledWith('github')
     await act(async () => buttons[2]?.click())
     expect(onChange).toHaveBeenCalledWith('gitlab')
   })

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom'
 import type { KeyboardEvent, ReactNode } from 'react'
 import { GithubMark, GitlabMark } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
-import { featureFlagEnabled } from '@/lib/feature-flags'
 import { GITLAB_PROJECT_STATE, gitlabChoiceSelectable, type GitlabProjectChoice } from '@/lib/gitlab-projects'
 import type { RepoAccess } from '@/lib/api'
 
@@ -33,7 +32,6 @@ export function WorkspaceModeField({
   label?: string
 }) {
   const fieldClassName = className ? `fld ${className}` : 'fld'
-  const gitlab = featureFlagEnabled('gitlab')
   const radio = (selected: boolean) => (
     <span
       className={
@@ -54,11 +52,7 @@ export function WorkspaceModeField({
   return (
     <div className={fieldClassName}>
       <span className="fldlbl">{label}</span>
-      <div
-        className={
-          gitlab ? 'grid grid-cols-1 gap-[10px] desktop:grid-cols-3' : 'grid grid-cols-1 gap-[10px] desktop:grid-cols-2'
-        }
-      >
+      <div className="grid grid-cols-1 gap-[10px] desktop:grid-cols-3">
         <button
           type="button"
           className={value === 'scratch' ? 'ptile on items-start text-left' : 'ptile items-start text-left'}
@@ -89,22 +83,20 @@ export function WorkspaceModeField({
           </span>
           {radio(value === 'github')}
         </button>
-        {gitlab && (
-          <button
-            type="button"
-            className={value === 'gitlab' ? 'ptile on items-start text-left' : 'ptile items-start text-left'}
-            onClick={() => onChange('gitlab')}
-          >
-            {tileIcon(<GitlabMark />)}
-            <span className="min-w-0 flex-1">
-              <span className="block font-sans text-[13px] font-semibold leading-normal">From GitLab</span>
-              <span className="mt-[2px] block truncate font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-                Clone a project on a branch.
-              </span>
+        <button
+          type="button"
+          className={value === 'gitlab' ? 'ptile on items-start text-left' : 'ptile items-start text-left'}
+          onClick={() => onChange('gitlab')}
+        >
+          {tileIcon(<GitlabMark />)}
+          <span className="min-w-0 flex-1">
+            <span className="block font-sans text-[13px] font-semibold leading-normal">From GitLab</span>
+            <span className="mt-[2px] block truncate font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+              Clone a project on a branch.
             </span>
-            {radio(value === 'gitlab')}
-          </button>
-        )}
+          </span>
+          {radio(value === 'gitlab')}
+        </button>
       </div>
     </div>
   )
@@ -415,21 +407,26 @@ export function GitlabProjectOption({
   )
 }
 
-/** Nothing to pick: either no GitLab account is connected, or the connected one
- *  administers nothing this organization may set up. */
+/** Nothing to pick: this deployment configures no GitLab application, no GitLab
+ *  account is connected, or the connected one administers nothing this
+ *  organization may set up. */
 export function GitlabNoProjectsNotice({
   integrationsHref,
-  connected
+  connected,
+  enabled = true
 }: {
   integrationsHref: string
   connected: boolean
+  enabled?: boolean
 }) {
   return (
     <div className="flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">
       <span className="mt-[1px] flex h-[14px] w-[14px] flex-none items-center justify-center">
         <GitlabMark fillPct={100} />
       </span>
-      {connected ? (
+      {!enabled ? (
+        <span>GitLab is not enabled on this deployment — the control plane has no GitLab application configured.</span>
+      ) : connected ? (
         <span>
           The connected GitLab account has no project to offer. You need Maintainer or Owner access to a project before
           it can be set up here.

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -425,7 +425,7 @@ export function GitlabNoProjectsNotice({
         <GitlabMark fillPct={100} />
       </span>
       {!enabled ? (
-        <span>GitLab is not enabled on this deployment — the control plane has no GitLab application configured.</span>
+        <span>GitLab is not enabled on this deployment — no GitLab application is configured.</span>
       ) : connected ? (
         <span>
           The connected GitLab account has no project to offer. You need Maintainer or Owner access to a project before

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -496,8 +496,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
 
   const usingPicker = wsMode === 'github' && ghEnabled === true && ghInstalls.length > 0
 
-  // Only the GitLab pane asks for projects, so a deployment without the flag
-  // never issues the request — the mode tile it would come from is not offered.
+  // Only the GitLab pane asks for projects; every other source issues no request.
   const gl = useGitlabProjects(wsMode === 'gitlab', glQ)
   const glNoProjects = wsMode === 'gitlab' && gl.empty
   const glPicked = gl.choices.find((choice) => choice.projectId === glProject)
@@ -1476,7 +1475,11 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                     <LoadingState size={20} padding={16} />
                   </div>
                 ) : glNoProjects ? (
-                  <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} connected={gl.connected} />
+                  <GitlabNoProjectsNotice
+                    integrationsHref={orgPath('/integrations')}
+                    connected={gl.connected}
+                    enabled={gl.enabled}
+                  />
                 ) : (
                   <div className="grid grid-cols-1 gap-[14px] desktop:col-span-2 desktop:grid-cols-2 desktop:gap-x-7">
                     <GitlabProjectField

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -160,7 +160,9 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     expect(mocks.fetchGitlabProjects).not.toHaveBeenCalled()
 
     await act(async () => tileNamed('GitLab')?.click())
-    expect(document.body.textContent).toContain('GitLab is not enabled on this deployment')
+    expect(document.body.textContent).toContain(
+      'GitLab is not enabled on this deployment — no GitLab application is configured.'
+    )
     expect(document.body.textContent).not.toContain('Couldn’t load your GitLab projects')
   })
 

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment happy-dom
 /**
  * The GitLab trigger kind in the Add-integration wizard. Three things are worth
- * a regression test: the tile is absent — and the project list unrequested —
- * while the flag is off; each "Trigger when" choice compiles to exactly the
- * stored vocabulary the CP validates (`family:*` patterns, note families,
- * mention-only) keyed by the project's numeric id rather than its renameable
- * path; and the form offers exactly the two subjects GitHub does, so no
- * reachable selection compiles a push event.
+ * a regression test: a deployment with no GitLab application still offers the
+ * tile and states the absence in the pane rather than failing a load; each
+ * "Trigger when" choice compiles to exactly the stored vocabulary the CP
+ * validates (`family:*` patterns, note families, mention-only) keyed by the
+ * project's numeric id rather than its renameable path; and the form offers
+ * exactly the two subjects GitHub does, so no reachable selection compiles a
+ * push event.
  *
  * The picker also offers projects the organization has not added yet, because
  * this wizard is now where a project joins the organization.
@@ -14,6 +15,7 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError } from '@/lib/api'
 import type { Agent } from '@/lib/data'
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
@@ -93,11 +95,6 @@ const connection = {
   createdAt: '2026-08-01T00:00:00.000Z'
 }
 
-const setFlags = (value?: string) => {
-  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
-    value === undefined ? {} : { FEATURE_FLAGS: value }
-}
-
 let root: Root | undefined
 let host: HTMLDivElement | undefined
 
@@ -137,7 +134,6 @@ async function settleSearch() {
 }
 
 afterEach(async () => {
-  setFlags()
   if (root) await act(async () => root?.unmount())
   host?.remove()
   root = undefined
@@ -151,19 +147,24 @@ afterEach(async () => {
 })
 
 describe('AddIntegrationModal, GitLab trigger', () => {
-  it('offers no GitLab tile and asks for no projects while the flag is off', async () => {
-    setFlags()
-    mocks.fetchGitlabProjects.mockResolvedValue([])
+  it('offers the GitLab tile beside GitHub and states the absence on an unconfigured deployment', async () => {
+    // Availability is the API's answer, not the picker's: the tile is always
+    // offered and the pane it opens says why there is nothing to pick.
+    mocks.fetchGitlabProjects.mockRejectedValue(new ApiError('GET /gitlab/projects → 404', 404))
+    mocks.fetchGitlabConnections.mockResolvedValue({ enabled: false, connections: [] })
     await render()
 
     expect(tileNamed('GitHub')).toBeDefined()
-    expect(tileNamed('GitLab')).toBeUndefined()
+    expect(tileNamed('GitLab')).toBeDefined()
+    // Nothing is asked before the pane is opened.
     expect(mocks.fetchGitlabProjects).not.toHaveBeenCalled()
-    expect(mocks.fetchGitlabConnections).not.toHaveBeenCalled()
+
+    await act(async () => tileNamed('GitLab')?.click())
+    expect(document.body.textContent).toContain('GitLab is not enabled on this deployment')
+    expect(document.body.textContent).not.toContain('Couldn’t load your GitLab projects')
   })
 
   it('defaults to the updated trigger, scoping replies to the selected subjects', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
     await pickProject()
@@ -182,7 +183,6 @@ describe('AddIntegrationModal, GitLab trigger', () => {
   })
 
   it('compiles the created trigger to openings with no note subscription', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
     await pickProject()
@@ -201,7 +201,6 @@ describe('AddIntegrationModal, GitLab trigger', () => {
   })
 
   it('compiles the mention-only trigger to the updated event set plus the flag', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
     await pickProject()
@@ -221,7 +220,6 @@ describe('AddIntegrationModal, GitLab trigger', () => {
   })
 
   it('offers exactly the two subjects GitHub offers, and never emits a push event', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
     await pickProject()
@@ -242,7 +240,6 @@ describe('AddIntegrationModal, GitLab trigger', () => {
   })
 
   it('drops the separate comments row and mention checkbox the form used to expose', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
     await pickProject()
@@ -257,7 +254,6 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     // GitLab is a relay-backed trigger kind, not a chat platform: the owning daemon's
     // adapter list has no say over it. Naming only webhook and github in that set left
     // this tile — and the agent page's empty-state twin — disabled for a placed agent.
-    setFlags('gitlab')
     mocks.daemons = [{ daemonId: 'daemon-1', caps: { platforms: ['slack'] } }]
     mocks.fetchGitlabProjects.mockResolvedValue([])
     await render()
@@ -269,7 +265,6 @@ describe('AddIntegrationModal, GitLab trigger', () => {
   })
 
   it('points at the connection surface when no GitLab account is connected', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([])
     mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [] })
     await render()
@@ -282,7 +277,6 @@ describe('AddIntegrationModal, GitLab trigger', () => {
   })
 
   it('sets up a project the organization has not added, then picks it', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([])
     mocks.searchGitlabProjects.mockResolvedValue({
       projects: [{ projectId: '4210', path: 'acme/platform', defaultBranch: 'main', lastActivityAt: null }],

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -38,7 +38,7 @@ import {
   type IdentityChromeView
 } from '@/components/console/platforms/publish'
 import { platformRegistry, platformSupportsSharing } from '@/components/console/platforms/registry'
-import { BOT_PLATFORMS, isCoreTriggerKind, offeredPlatforms } from '@/components/console/platforms/host-projections'
+import { BOT_PLATFORMS, PLATFORMS, isCoreTriggerKind } from '@/components/console/platforms/host-projections'
 import { agentLabel, MOCK_MODE, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
@@ -421,7 +421,7 @@ export default function AddIntegrationModal({
     isCoreTriggerKind(candidate) || supportedBotPlatforms.some((supported) => supported.key === candidate)
   const selectedBotPlatformSupported = isPlatformAvailable(platform)
 
-  const platformTiles = offeredPlatforms()
+  const platformTiles = PLATFORMS
 
   // The active platform module — undefined for the core trigger sections.
   const activeModule = platformRegistry.get(platform)
@@ -1646,7 +1646,11 @@ export default function AddIntegrationModal({
               <LoadingState size={20} padding={16} />
             ) : gl.empty ? (
               <div className="mb-4">
-                <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} connected={gl.connected} />
+                <GitlabNoProjectsNotice
+                  integrationsHref={orgPath('/integrations')}
+                  connected={gl.connected}
+                  enabled={gl.enabled}
+                />
               </div>
             ) : (
               <>

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
@@ -1,15 +1,16 @@
 // @vitest-environment happy-dom
 /**
- * The GitLab workspace choice is a standing switch: with the flag off the mode
- * tile must not exist AND the project list must never be requested, because a
- * deployment without a GitLab application does not serve that route. With it on,
- * the picker offers the organization's added projects — every state except the
- * transient ones — alongside the ones the connected account can still set up,
- * and the save sends the numeric project id, never the path.
+ * The GitLab workspace choice is offered on every deployment; a control plane
+ * with no GitLab application 404s the routes behind it, which the pane states as
+ * an absence instead of a failed load. Where it is configured, the picker offers
+ * the organization's added projects — every state except the transient ones —
+ * alongside the ones the connected account can still set up, and the save sends
+ * the numeric project id, never the path.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiError } from '@/lib/api'
 import type { Agent } from '@/lib/data'
 
 const mocks = vi.hoisted(() => ({
@@ -57,11 +58,6 @@ const agent = {
   workspace: { mode: 'scratch' }
 } as unknown as Agent
 
-const setFlags = (value?: string) => {
-  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
-    value === undefined ? {} : { FEATURE_FLAGS: value }
-}
-
 let root: Root | undefined
 let host: HTMLDivElement | undefined
 
@@ -80,7 +76,6 @@ const buttonsNamed = (text: string) =>
   Array.from(document.querySelectorAll('button')).filter((button) => button.textContent?.includes(text))
 
 afterEach(async () => {
-  setFlags()
   if (root) await act(async () => root?.unmount())
   host?.remove()
   root = undefined
@@ -118,18 +113,22 @@ async function settleSearch() {
 }
 
 describe('EditWorkspaceModal, GitLab workspace', () => {
-  it('offers no GitLab source and asks for no projects while the flag is off', async () => {
-    setFlags()
-    mocks.fetchGitlabProjects.mockResolvedValue([binding({ projectId: '1' })])
+  it('offers the GitLab source and states the absence on an unconfigured deployment', async () => {
+    mocks.fetchGitlabProjects.mockRejectedValue(new ApiError('GET /gitlab/projects → 404', 404))
+    mocks.fetchGitlabConnections.mockResolvedValue({ enabled: false, connections: [] })
     await render()
 
-    expect(document.body.textContent).not.toContain('From GitLab')
+    expect(document.body.textContent).toContain('From GitLab')
+    // Nothing is asked until the source is picked.
     expect(mocks.fetchGitlabProjects).not.toHaveBeenCalled()
-    expect(mocks.fetchGitlabConnections).not.toHaveBeenCalled()
+
+    await act(async () => buttonsNamed('From GitLab')[0]?.click())
+    expect(document.body.textContent).toContain('GitLab is not enabled on this deployment')
+    expect(document.body.textContent).not.toContain('Couldn’t load your GitLab projects')
+    expect(mocks.searchGitlabProjects).not.toHaveBeenCalled()
   })
 
   it('lists the added projects and disables the ones still setting up', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([
       binding({ projectId: '1', projectPath: 'acme/platform', state: 'ready' }),
       binding({ projectId: '2', projectPath: 'acme/runtime', state: 'runtime_degraded' }),
@@ -152,7 +151,6 @@ describe('EditWorkspaceModal, GitLab workspace', () => {
   })
 
   it('saves the picked project by its numeric id', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([binding({ projectId: '4210', projectPath: 'acme/platform' })])
     connected()
     await render()
@@ -174,7 +172,6 @@ describe('EditWorkspaceModal, GitLab workspace', () => {
   })
 
   it('points at the connection surface when no GitLab account is connected', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([])
     mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [] })
     await render()
@@ -186,7 +183,6 @@ describe('EditWorkspaceModal, GitLab workspace', () => {
   })
 
   it('sets up a project the organization has not added, then saves it', async () => {
-    setFlags('gitlab')
     mocks.fetchGitlabProjects.mockResolvedValue([])
     connected([{ projectId: '4210', path: 'acme/platform', defaultBranch: 'main', lastActivityAt: null }])
     let settle: (value: unknown) => void = () => undefined

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
@@ -123,7 +123,9 @@ describe('EditWorkspaceModal, GitLab workspace', () => {
     expect(mocks.fetchGitlabProjects).not.toHaveBeenCalled()
 
     await act(async () => buttonsNamed('From GitLab')[0]?.click())
-    expect(document.body.textContent).toContain('GitLab is not enabled on this deployment')
+    expect(document.body.textContent).toContain(
+      'GitLab is not enabled on this deployment — no GitLab application is configured.'
+    )
     expect(document.body.textContent).not.toContain('Couldn’t load your GitLab projects')
     expect(mocks.searchGitlabProjects).not.toHaveBeenCalled()
   })

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -11,7 +11,6 @@ import { Button, Icon } from '@/components/ui'
 import { agentLabel, isPoolPlacementKind, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
-import { featureFlagEnabled } from '@/lib/feature-flags'
 import { matchGitlabProjects, type GitlabProjectChoice } from '@/lib/gitlab-projects'
 import { useGitlabProjects } from '@/lib/use-gitlab-projects'
 import {
@@ -94,7 +93,6 @@ export default function EditWorkspaceModal({
       ? gitlabWorkspace.gitAccess !== 'read'
       : null
   const currentAgentDir = agentDirInputValue(gitWorkspace?.agentDir)
-  const gitlabOffered = featureFlagEnabled('gitlab')
   const [mode, setMode] = useState<WorkspaceMode>(initialMode ?? agent.workspace.mode)
   const [gh, setGh] = useState<{ enabled: boolean; installations: GithubInstallationDto[] } | null>(null)
   const [ghSyncing, setGhSyncing] = useState(false)
@@ -191,7 +189,7 @@ export default function EditWorkspaceModal({
 
   // The projects this organization added, plus the ones the connected account can
   // still add — picking one of those sets it up here (§18.1).
-  const gl = useGitlabProjects(repositoryEditor === null && gitlabOffered && mode === 'gitlab', glQ)
+  const gl = useGitlabProjects(repositoryEditor === null && mode === 'gitlab', glQ)
 
   const openGhInstall = async () => {
     const url = await fetchGithubInstallUrl().catch(() => null)
@@ -499,7 +497,11 @@ export default function EditWorkspaceModal({
                   <LoadingState size={20} padding={16} />
                 </div>
               ) : noProjects ? (
-                <GitlabNoProjectsNotice integrationsHref={orgPath('/integrations')} connected={gl.connected} />
+                <GitlabNoProjectsNotice
+                  integrationsHref={orgPath('/integrations')}
+                  connected={gl.connected}
+                  enabled={gl.enabled}
+                />
               ) : (
                 <>
                   <GitlabProjectField

--- a/packages/web/src/components/console/platforms/host-projections.ts
+++ b/packages/web/src/components/console/platforms/host-projections.ts
@@ -3,7 +3,6 @@
 
 import { larkFeishuBrand, type LarkFeishuTarget } from '@/components/LarkFeishuSwitcher'
 import type { BotDto } from '@/lib/api'
-import { featureFlagEnabled } from '@/lib/feature-flags'
 import { platformLabel } from '@/lib/platform-labels'
 import { platformRegistry } from './registry'
 
@@ -57,8 +56,8 @@ export function platformTiles(ids: readonly string[]): PlatformTile[] {
 export const BOT_PLATFORMS: readonly PlatformTile[] = platformTiles(platformRegistry.ids())
 
 /** Every picker choice: the chat platforms plus the core trigger kinds. None of
- *  the triggers is gated by daemon adapters — all live on the relay pool. The
- *  GitLab tile is additionally gated on its feature flag at the call site. */
+ *  the triggers is gated by daemon adapters — all live on the relay pool, and a
+ *  code host the deployment has not configured says so in its own pane. */
 export const PLATFORMS: readonly PlatformTile[] = [
   ...BOT_PLATFORMS,
   { key: 'webhook', label: 'Webhook' },
@@ -72,13 +71,6 @@ export const PLATFORMS: readonly PlatformTile[] = [
  *  capabilities gate them; every picker must treat them as always available. */
 export function isCoreTriggerKind(key: string): boolean {
   return !BOT_PLATFORMS.some((tile) => tile.key === key) && PLATFORMS.some((tile) => tile.key === key)
-}
-
-/** The picker choices this deployment actually offers — {@link PLATFORMS} minus
- *  the tiles a feature flag holds back. Every picker reads this, so a flagged
- *  trigger kind can never appear on one surface and not the other. */
-export function offeredPlatforms(): readonly PlatformTile[] {
-  return PLATFORMS.filter((tile) => tile.key !== 'gitlab' || featureFlagEnabled('gitlab'))
 }
 
 /**

--- a/packages/web/src/components/console/platforms/platform-set.test.tsx
+++ b/packages/web/src/components/console/platforms/platform-set.test.tsx
@@ -10,7 +10,6 @@ import {
   PLATFORMS,
   botMatchesPlatformTab,
   isCoreTriggerKind,
-  offeredPlatforms,
   platformTiles
 } from './host-projections'
 import { PLATFORM_MARK_IDS, platformMark } from './marks'
@@ -87,26 +86,9 @@ describe('platform set', () => {
     // and must NEVER gate a trigger kind that way — GitLab's empty-state tile
     // rendered disabled for a normally placed agent while this set named only two.
     expect(PLATFORMS.map((tile) => tile.key).filter(isCoreTriggerKind)).toEqual(CORE_TRIGGER_KINDS)
+    expect(isCoreTriggerKind('gitlab')).toBe(true)
     for (const id of platformRegistry.ids()) expect(isCoreTriggerKind(id), id).toBe(false)
     expect(isCoreTriggerKind('zulip')).toBe(false)
-  })
-
-  it('offers the flagged GitLab tile only where its flag is on', () => {
-    const flags = (value?: string) => {
-      ;(globalThis as { window?: { __AC_ENV?: Record<string, string> } }).window = {
-        __AC_ENV: value === undefined ? {} : { FEATURE_FLAGS: value }
-      }
-    }
-    try {
-      flags()
-      expect(offeredPlatforms().map((tile) => tile.key)).not.toContain('gitlab')
-      flags('gitlab')
-      expect(offeredPlatforms().map((tile) => tile.key)).toContain('gitlab')
-      // Still a trigger kind, so nothing about the daemon can disable its tile.
-      expect(isCoreTriggerKind('gitlab')).toBe(true)
-    } finally {
-      delete (globalThis as { window?: unknown }).window
-    }
   })
 
   it('passes an id no module claims straight through the tile projection', () => {

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -68,7 +68,7 @@ import LarkFeishuSwitcher from '@/components/LarkFeishuSwitcher'
 import { AgentMark, GithubMark, GitlabMark, LoadingState, PlatformMark } from '@/components/marks'
 import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import type { Platform } from '@/components/console/modals/AddIntegrationModal'
-import { INTEGRATION_BLURB, isCoreTriggerKind, offeredPlatforms } from '@/components/console/platforms/host-projections'
+import { INTEGRATION_BLURB, PLATFORMS, isCoreTriggerKind } from '@/components/console/platforms/host-projections'
 import {
   GL_TRIGGER_MODES,
   GL_TRIGGER_PILL,
@@ -1764,7 +1764,7 @@ export default function AgentDetailView() {
                 {/* Identical grid to the Add-integration modal's platform picker —
                     same list, order, tile size and disabled treatment. */}
                 <div className="mt-4 grid grid-cols-2 gap-[10px] desktop:flex desktop:flex-wrap desktop:justify-center">
-                  {offeredPlatforms().map((p) => {
+                  {PLATFORMS.map((p) => {
                     const available = integrationPlatformAvailable(p.key)
                     return (
                       <div

--- a/packages/web/src/components/console/views/IntegrationsView.gitlab.test.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.gitlab.test.tsx
@@ -1,10 +1,9 @@
 // @vitest-environment happy-dom
 /**
- * GitLab is a standing switch, not an experiment: a deployment with no GitLab
- * application must not merely hide the card, it must never mount it — mounting
- * runs the connection probe, and a console that probes a route this deployment
- * does not serve is asking a question it has no business asking. The gate is
- * therefore on the element, not inside the card, and this is its regression test.
+ * The GitLab card sits under Code hosts beside the GitHub one, on every
+ * deployment: availability is the card's own answer, read from the authenticated
+ * API (gitlab-com-integration.md §18.3), not a console-side gate that would
+ * decide before asking. This pins the mount.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -41,11 +40,6 @@ vi.mock('@/lib/api', async (importOriginal) => ({
 
 const IntegrationsView = (await import('./IntegrationsView')).default
 
-const setFlags = (value?: string) => {
-  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV =
-    value === undefined ? {} : { FEATURE_FLAGS: value }
-}
-
 async function render(): Promise<string> {
   const host = document.createElement('div')
   document.body.appendChild(host)
@@ -60,17 +54,11 @@ async function render(): Promise<string> {
 }
 
 afterEach(() => {
-  setFlags()
   mocks.gitlabCard.mockClear()
 })
 
-describe('IntegrationsView, GitLab flag', () => {
-  it('mounts the GitLab card only where the flag is on', async () => {
-    setFlags()
-    expect(await render()).not.toContain('data-gitlab-card')
-    expect(mocks.gitlabCard).not.toHaveBeenCalled()
-
-    setFlags('gitlab')
+describe('IntegrationsView, GitLab card', () => {
+  it('mounts the GitLab card on every deployment, GitHub App or not', async () => {
     expect(await render()).toContain('data-gitlab-card')
     expect(mocks.gitlabCard).toHaveBeenCalled()
   })

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -34,7 +34,6 @@ import { BOT_PLATFORM_TABS, botMatchesPlatformTab } from '@/components/console/p
 import DeleteBotModal from '@/components/console/modals/DeleteBotModal'
 import UninstallGithubInstallationModal from '@/components/console/modals/UninstallGithubInstallationModal'
 import GitlabCard from '@/components/console/GitlabCard'
-import { featureFlagEnabled } from '@/lib/feature-flags'
 
 // The free-bot sub-line shows where the bot came from without repeating
 // historical usage metadata in the list row.
@@ -255,11 +254,9 @@ export default function IntegrationsView() {
       <Section label="Code hosts">
         <GithubCard canWrite={canWrite} isOwner={isOwner} />
         {/* Cards own no margin here (see Section) — the second one supplies its own gap. */}
-        {featureFlagEnabled('gitlab') && (
-          <div className="mt-4">
-            <GitlabCard canWrite={canWrite} />
-          </div>
-        )}
+        <div className="mt-4">
+          <GitlabCard canWrite={canWrite} />
+        </div>
       </Section>
 
       {deletingBot && (

--- a/packages/web/src/lib/feature-flags.ts
+++ b/packages/web/src/lib/feature-flags.ts
@@ -32,10 +32,6 @@ export type FeatureFlagId =
    *  nothing to point it at. `BILLING_URL` then says WHERE that service is; this says WHETHER to
    *  offer the page, so a missing endpoint is a misconfiguration rather than a silent opt-out. */
   | 'billing'
-  /** GitLab.com integration surfaces: the Connections card, its project bindings, and the gitlab
-   *  workspace and hook options as they land. A standing switch — the connection needs a GitLab
-   *  OAuth application only some deployments register (gitlab-com-integration.md §18.1, §18.3). */
-  | 'gitlab'
 
 function enabledIds(): ReadonlySet<string> {
   // The server must read the SAME value `PublicEnvScript` injects, in the same precedence, or a

--- a/packages/web/src/lib/use-gitlab-projects.test.tsx
+++ b/packages/web/src/lib/use-gitlab-projects.test.tsx
@@ -10,7 +10,7 @@
 import { StrictMode, act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { GitlabConnectionDto, GitlabProjectBindingDto } from '@/lib/api'
+import { ApiError, type GitlabConnectionDto, type GitlabProjectBindingDto } from '@/lib/api'
 
 ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -64,6 +64,12 @@ function Probe({ active }: { active: boolean }) {
   return <span>{gl.loading ? 'loading' : gl.choices.map((choice) => choice.projectPath).join(',')}</span>
 }
 
+/** Renders the availability answer the panes branch on. */
+function AvailabilityProbe() {
+  const gl = useGitlabProjects(true, '')
+  return <span>{`${gl.enabled}|${gl.empty}|${gl.error ?? 'none'}`}</span>
+}
+
 let host: HTMLDivElement
 let root: Root
 
@@ -100,6 +106,25 @@ describe('useGitlabProjects lifecycle', () => {
     )
 
     expect(host.textContent).toBe('example-group/example-project')
+  })
+
+  it('reads a deployment with no GitLab application as absence, not a load failure', async () => {
+    // The whole surface 404s there; the panes must say so rather than render an error.
+    mocks.fetchProjects.mockRejectedValue(new ApiError('GET /gitlab/projects → 404', 404))
+    mocks.fetchConnections.mockResolvedValue({ enabled: false, connections: [] })
+
+    await mount(<AvailabilityProbe />)
+
+    expect(host.textContent).toBe('false|true|none')
+  })
+
+  it('still reports a real read failure', async () => {
+    mocks.fetchProjects.mockRejectedValue(new ApiError('GET /gitlab/projects → 503', 503))
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+
+    await mount(<AvailabilityProbe />)
+
+    expect(host.textContent).toBe('true|true|GET /gitlab/projects → 503')
   })
 
   it('a visit that leaves mid-load and returns loads on the second visit', async () => {

--- a/packages/web/src/lib/use-gitlab-projects.ts
+++ b/packages/web/src/lib/use-gitlab-projects.ts
@@ -14,6 +14,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  ApiError,
   createGitlabProject,
   fetchGitlabConnections,
   fetchGitlabProjects,
@@ -29,7 +30,15 @@ function errorText(e: unknown): string {
   return e instanceof Error ? e.message : String(e)
 }
 
+// A deployment with no GitLab application serves none of these routes: 404 is absence, not failure.
+function absentAsEmpty(e: unknown): GitlabProjectBindingDto[] {
+  if (e instanceof ApiError && e.status === 404) return []
+  throw e
+}
+
 export interface GitlabProjectPicker {
+  /** This deployment has a GitLab application configured at all. */
+  enabled: boolean
   /** Added projects merged with what the live connection could still add. */
   choices: GitlabProjectChoice[]
   /** True until the added projects and the connections have both answered. */
@@ -49,10 +58,10 @@ export interface GitlabProjectPicker {
   provision: (projectId: string) => Promise<GitlabProjectBindingDto | null>
 }
 
-/** `active` keeps a pane that is not showing from issuing any request at all —
- *  a deployment without a GitLab application does not serve these routes. */
+/** `active` keeps a pane that is not showing from issuing any request at all. */
 export function useGitlabProjects(active: boolean, query: string): GitlabProjectPicker {
   const [bindings, setBindings] = useState<GitlabProjectBindingDto[] | null>(null)
+  const [enabled, setEnabled] = useState(true)
   const [connectionId, setConnectionId] = useState<string | null>(null)
   const [candidates, setCandidates] = useState<GitlabProjectDto[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -68,9 +77,10 @@ export function useGitlabProjects(active: boolean, query: string): GitlabProject
     if (!active) return
     let alive = true
     setError(null)
-    Promise.all([fetchGitlabProjects(), fetchGitlabConnections()]).then(
-      ([bound, { connections }]) => {
+    Promise.all([fetchGitlabProjects().catch(absentAsEmpty), fetchGitlabConnections()]).then(
+      ([bound, { enabled: configured, connections }]) => {
         if (!alive) return
+        setEnabled(configured)
         setBindings(bound)
         // Only a connection GitLab still accepts can add a project (§10.1).
         setConnectionId(connections.find((c) => c.state === 'connected')?.id ?? null)
@@ -137,6 +147,7 @@ export function useGitlabProjects(active: boolean, query: string): GitlabProject
 
   const loading = active && bindings === null
   return {
+    enabled,
     choices,
     loading,
     empty: !loading && !everOffered && choices.length === 0,


### PR DESCRIPTION
## What

The `gitlab` console feature flag gated the surface while the integration hardened; the pilot completed, so the flag is removed and the GitLab surface follows deployment availability alone — the same rule the GitHub surface already uses (a control plane without a configured application answers 404 on its routes, and the console renders the absence).

- Flag and every gate removed: the Integrations card mounts beside GitHub's, the workspace source picker offers three tiles, the integration tiles come straight from the platform table (`offeredPlatforms` deleted), and the rerun button is data-gated only.
- Unconfigured-deployment behavior verified per surface. One real gap fixed on the way: the shared project loader swallowed a 404 on connections but not on projects, so every picker pane would have shown a red load error on a deployment without a GitLab application — it now treats that 404 as absence and the panes state it plainly, while a genuine failure (e.g. 503) still surfaces as an error.
- Design section 21 records general enablement.

## Tests

Flag-gating tests became availability tests; new cases cover the card's not-enabled presentation, the loader's 404-as-absence and 503-as-error split, and every picker pane's unconfigured copy. Full web suite (171 files / 1886 tests), typecheck, lint, format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
