### PR TITLE
feat(daemon): add Discord and Feishu channel history

### DIFF
--- a/packages/control-plane/src/http/feishu-app-template.ts
+++ b/packages/control-plane/src/http/feishu-app-template.ts
@@ -17,6 +17,7 @@ export const AGENTCONNECT_FEISHU_SCOPES = [
   'im:chat.members:bot_access',
   'im:chat.members:read',
   'im:message',
+  'im:message.group_msg',
   'im:message.group_at_msg:readonly',
   'im:message.p2p_msg:readonly',
   'im:message:send_as_bot',

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2576,7 +2576,8 @@ export class Daemon {
       mcpServersFor: ({ agent, platform, channel, thread, integrationId, transportScope, isDm }) => {
         const servers: McpServer[] = []
         let tools = toolsForIntegrations(agent.integrations, {
-          organizationKnowledge: this.cpClient?.supportsServerFeature?.(ORGANIZATION_KNOWLEDGE_FEATURE) === true
+          organizationKnowledge: this.cpClient?.supportsServerFeature?.(ORGANIZATION_KNOWLEDGE_FEATURE) === true,
+          currentPlatform: platform
         })
         // Static descriptor, dynamic authority: a per-thread ACP session can
         // outlive many hook deliveries. The call resolves the CURRENT daemon-

--- a/packages/daemon/src/discord/connection.ts
+++ b/packages/daemon/src/discord/connection.ts
@@ -14,7 +14,7 @@ import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
 import { isSendQueueTimeout, PlatformSendQueue } from '../platforms/send-queue.js'
 import type { UploadAnchor, UploadFailReason, UploadOutcome } from '../mcp/ops/context.js'
-import { normalizeDiscordMessage, type DiscordMessageLike } from './normalize.js'
+import { humanizeDiscordText, normalizeDiscordMessage, type DiscordMessageLike } from './normalize.js'
 import { DISCORD_APP_COMMANDS } from './app-commands.js'
 import {
   buildPermissionUpdateNotice,
@@ -24,7 +24,12 @@ import {
   type DiscordComponents,
   type DiscordSelectKind
 } from './render.js'
-import type { InteractionActor, PlatformConnection } from '../platforms/contract.js'
+import type {
+  InteractionActor,
+  PlatformChannelHistoryOptions,
+  PlatformChannelHistoryPage,
+  PlatformConnection
+} from '../platforms/contract.js'
 
 /**
  * §Discord edge unit. Mirrors slack/connection.ts + telegram/connection.ts but over
@@ -105,6 +110,8 @@ export interface DiscordDeps {
 const DEFAULT_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024
 /** Cap on channels enumerated per listChannels call (bounds the response). */
 const CHANNEL_CAP = 200
+const DISCORD_CHANNEL_HISTORY_DEFAULT_LIMIT = 100
+const DISCORD_CHANNEL_HISTORY_MAX_LIMIT = 100
 const PERMISSION_NOTICE_RETRY_MS = 5 * 60_000
 
 // Keep this permission set in lock-step with packages/web/src/components/console/platforms/discord/invite.ts.
@@ -153,6 +160,13 @@ function discordPermissionIssueFrom(err: unknown): DiscordPermissionIssue | null
   if (/\bmissing permissions?\b/i.test(message)) return 'missing-permissions'
   if (/\bmissing required oauth2 scope\b/i.test(message)) return 'missing-oauth-scope'
   return null
+}
+
+function discordErrorCode(err: unknown): number | undefined {
+  const e = err && typeof err === 'object' ? (err as DiscordErrorLike) : undefined
+  const candidate = e?.code ?? e?.rawError?.code ?? e?.data?.code
+  const code = typeof candidate === 'number' ? candidate : Number(candidate)
+  return Number.isSafeInteger(code) && code >= 0 ? code : undefined
 }
 
 /** The discord.js message-send payload we use (content + optional components). */
@@ -697,6 +711,64 @@ export class DiscordConnection implements PlatformConnection {
   }
 
   // ── MCP MessageGateway: read helpers backing the injected channel tools ──
+
+  /** Fetch one bounded page of channel messages using Discord's `before` cursor. */
+  async getChannelHistory(
+    channel: string,
+    options: PlatformChannelHistoryOptions = {}
+  ): Promise<PlatformChannelHistoryPage> {
+    const limit = Math.min(
+      Math.max(options.limit ?? DISCORD_CHANNEL_HISTORY_DEFAULT_LIMIT, 1),
+      DISCORD_CHANNEL_HISTORY_MAX_LIMIT
+    )
+    try {
+      const oldest = options.oldest === undefined ? undefined : Number(options.oldest)
+      const latest = options.latest === undefined ? undefined : Number(options.latest)
+      if ((oldest !== undefined && !Number.isFinite(oldest)) || (latest !== undefined && !Number.isFinite(latest))) {
+        throw new Error('invalid timestamp bound')
+      }
+
+      const ch = await this.client.channels.fetch(channel)
+      if (!ch?.isTextBased()) throw new Error('channel does not expose message history')
+      const fetched = await ch.messages.fetch({ limit, ...(options.cursor ? { before: options.cursor } : {}) })
+      const raw = [...fetched.values()].sort((a, b) => b.createdTimestamp - a.createdTimestamp)
+      const messages = raw
+        .filter(
+          (message) =>
+            (oldest === undefined || message.createdTimestamp >= oldest) &&
+            (latest === undefined || message.createdTimestamp <= latest)
+        )
+        .map((message) => {
+          const replyCount = message.thread?.messageCount
+          return {
+            sender: message.author.id,
+            ts: String(message.createdTimestamp),
+            text: humanizeDiscordText(
+              message.content,
+              Object.fromEntries(
+                [...message.mentions.users.values()].map((user) => [user.id, user.globalName ?? user.username])
+              )
+            ),
+            isBot: message.author.bot,
+            ...(message.thread ? { threadTs: message.thread.id } : {}),
+            ...(typeof replyCount === 'number' && replyCount > 0 ? { replyCount } : {})
+          }
+        })
+
+      const reachedOldest = oldest !== undefined && raw.some((message) => message.createdTimestamp <= oldest)
+      const nextCursor = raw.length === limit && !reachedOldest ? raw.at(-1)?.id : undefined
+      return {
+        messages,
+        hasMore: nextCursor !== undefined,
+        ...(nextCursor ? { nextCursor } : {})
+      }
+    } catch (err) {
+      this.rememberPermissionIssue(err, channel)
+      const code = discordErrorCode(err)
+      this.deps.log?.debug(`discord: channel history failed (ch=${channel}): ${code ?? 'unknown'}`)
+      throw new Error(code === undefined ? 'Discord channel history failed' : `Discord channel history failed: ${code}`)
+    }
+  }
 
   async getChannelInfo(channel: string): Promise<{
     id: string

--- a/packages/daemon/src/evaluation/virtual-connections.ts
+++ b/packages/daemon/src/evaluation/virtual-connections.ts
@@ -176,6 +176,37 @@ function identityOf(options?: VirtualPostOptions): SendIdentity | undefined {
   return Object.keys(identity).length > 0 ? identity : undefined
 }
 
+function virtualChannelHistory(
+  world: VirtualConnectionWorldPort,
+  channel: string,
+  options: PlatformChannelHistoryOptions,
+  maxLimit: number
+): PlatformChannelHistoryPage {
+  const limit = Math.min(Math.max(options.limit ?? 100, 1), maxLimit)
+  const offset = Math.max(Number.parseInt(options.cursor ?? '0', 10) || 0, 0)
+  const oldest = options.oldest || undefined
+  const latest = options.latest || undefined
+  const messages = [...(world.channelHistory?.(channel) ?? [])]
+    .filter(
+      (message) => (oldest === undefined || message.ts >= oldest) && (latest === undefined || message.ts <= latest)
+    )
+    .sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0))
+  const page = messages.slice(offset, offset + limit)
+  const nextOffset = offset + page.length
+  const nextCursor = nextOffset < messages.length ? String(nextOffset) : undefined
+  const result: PlatformChannelHistoryMessage[] = page.map((message) => ({
+    sender: message.sender,
+    ts: message.ts,
+    text: message.text,
+    isBot: message.isBot
+  }))
+  return {
+    messages: result,
+    hasMore: nextCursor !== undefined,
+    ...(nextCursor !== undefined ? { nextCursor } : {})
+  }
+}
+
 /**
  * Implements the `SlackConnection` surface the daemon uses: the ordinary reply
  * path, Slack tenant identity for session/audience classification, delivery
@@ -370,29 +401,7 @@ export class VirtualSlackConnection implements PlatformConnection {
     channel: string,
     options: PlatformChannelHistoryOptions = {}
   ): Promise<PlatformChannelHistoryPage> {
-    const limit = Math.min(Math.max(options.limit ?? 100, 1), 200)
-    const offset = Math.max(Number.parseInt(options.cursor ?? '0', 10) || 0, 0)
-    const oldest = options.oldest || undefined
-    const latest = options.latest || undefined
-    const messages = [...(this.world.channelHistory?.(channel) ?? [])]
-      .filter(
-        (message) => (oldest === undefined || message.ts >= oldest) && (latest === undefined || message.ts <= latest)
-      )
-      .sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0))
-    const page = messages.slice(offset, offset + limit)
-    const nextOffset = offset + page.length
-    const nextCursor = nextOffset < messages.length ? String(nextOffset) : undefined
-    const result: PlatformChannelHistoryMessage[] = page.map((message) => ({
-      sender: message.sender,
-      ts: message.ts,
-      text: message.text,
-      isBot: message.isBot
-    }))
-    return {
-      messages: result,
-      hasMore: nextCursor !== undefined,
-      ...(nextCursor !== undefined ? { nextCursor } : {})
-    }
+    return virtualChannelHistory(this.world, channel, options, 200)
   }
 
   /** Ephemeral presence (assistant status) — not a message; not recorded. */
@@ -510,6 +519,13 @@ export class VirtualDiscordConnection implements PlatformConnection {
 
   async listChannels(): Promise<{ id: string; name?: string; isPrivate?: boolean }[]> {
     return [...this.world.channels(this.integrationId)]
+  }
+
+  async getChannelHistory(
+    channel: string,
+    options: PlatformChannelHistoryOptions = {}
+  ): Promise<PlatformChannelHistoryPage> {
+    return virtualChannelHistory(this.world, channel, options, 100)
   }
 
   async getUserProfile(user: string): Promise<{ id: string; name?: string; realName?: string; isBot?: boolean }> {

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -16,7 +16,13 @@ import type { NormalizedMessage } from '../messages/normalized.js'
 import type { Logger } from '../log.js'
 import { isSendQueueTimeout, PlatformSendQueue } from '../platforms/send-queue.js'
 import type { UploadAnchor, UploadFailReason, UploadOutcome } from '../mcp/ops/context.js'
-import { feishuEventToMessageLike, normalizeFeishuMessage, type FeishuRawEvent } from './normalize.js'
+import {
+  extractFeishuMessageText,
+  feishuEventToMessageLike,
+  normalizeFeishuMessage,
+  type FeishuMention,
+  type FeishuRawEvent
+} from './normalize.js'
 import {
   buildCompletedReplyCard,
   buildPermissionUpdateCard,
@@ -26,7 +32,12 @@ import {
   FEISHU_REPLY_CANCEL_OPTION,
   FEISHU_STREAMING_ELEMENT_ID
 } from './render.js'
-import type { InteractionActor, PlatformConnection } from '../platforms/contract.js'
+import type {
+  InteractionActor,
+  PlatformChannelHistoryOptions,
+  PlatformChannelHistoryPage,
+  PlatformConnection
+} from '../platforms/contract.js'
 
 /**
  * §Feishu / Lark edge unit. Mirrors discord/connection.ts but over the official
@@ -111,6 +122,30 @@ export interface FeishuDeps {
  * nests message/chat ids under `context`; root-level fallbacks cover older payloads. */
 export type FeishuRawCardActionEvent = WireFeishuCardActionEvent
 export type FeishuCardActionResponse = WireFeishuCardActionResponse
+
+export interface FeishuHistoryItem {
+  message_id?: string
+  thread_id?: string
+  msg_type?: string
+  create_time?: string
+  sender?: { id: string; sender_type: string; open_bot_id?: string }
+  body?: { content: string }
+  mentions?: { key: string; id: string; name: string }[]
+}
+
+export interface FeishuHistoryPage {
+  items: FeishuHistoryItem[]
+  hasMore: boolean
+  nextCursor?: string
+}
+
+export interface FeishuHistoryRequest {
+  cursor?: string
+  limit: number
+  startTime?: string
+  endTime?: string
+}
+
 /**
  * The slice of the Lark SDK the connection drives — hand-declared (like Telegram's
  * `TelegramApi` / Slack's `AppLike`) so the connection is testable with a fake and
@@ -127,6 +162,8 @@ export interface FeishuApi {
   replyText(messageId: string, text: string): Promise<{ messageId?: string }>
   /** im.message.reply (msg_type 'interactive', reply_in_thread). */
   replyCard(messageId: string, card: Record<string, unknown>): Promise<{ messageId?: string }>
+  /** im.message.list, newest-first and limited to chat/thread roots. */
+  listMessages(chatId: string, request: FeishuHistoryRequest): Promise<FeishuHistoryPage>
   /** cardkit.card.create. */
   createCardEntity(card: Record<string, unknown>): Promise<{ cardId?: string }>
   /** im.message.create/reply with an interactive CardKit `card_id` reference. */
@@ -252,6 +289,30 @@ function defaultFactory(appId: string, appSecret: string, region: FeishuRegion):
     createCard: (chatId, card) => createMessage(chatId, 'interactive', card),
     replyText: (messageId, text) => replyMessage(messageId, 'text', { text }),
     replyCard: (messageId, card) => replyMessage(messageId, 'interactive', card),
+    async listMessages(chatId, request) {
+      const res = assertApiSuccess(
+        await client.im.message.list({
+          params: {
+            container_id_type: 'chat',
+            container_id: chatId,
+            sort_type: 'ByCreateTimeDesc',
+            page_size: request.limit,
+            only_thread_root_messages: true,
+            ...(request.cursor ? { page_token: request.cursor } : {}),
+            ...(request.startTime ? { start_time: request.startTime } : {}),
+            ...(request.endTime ? { end_time: request.endTime } : {})
+          }
+        }),
+        'im.message.list'
+      )
+      const data = res.data ?? {}
+      const nextCursor = data.page_token?.trim() || undefined
+      return {
+        items: data.items ?? [],
+        hasMore: Boolean(data.has_more || nextCursor),
+        ...(nextCursor ? { nextCursor } : {})
+      }
+    },
     createImage: (chatId, imageKey) => createMessage(chatId, 'image', { image_key: imageKey }),
     replyImage: (messageId, imageKey) => replyMessage(messageId, 'image', { image_key: imageKey }),
     async uploadImage(bytes) {
@@ -413,6 +474,8 @@ const DEFAULT_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024
 /** Cap on channels/members enumerated per read call (bounds the response). */
 const CHANNEL_CAP = 200
 const MEMBER_CAP = 50
+const FEISHU_CHANNEL_HISTORY_DEFAULT_LIMIT = 50
+const FEISHU_CHANNEL_HISTORY_MAX_LIMIT = 50
 const PERMISSION_NOTICE_RETRY_MS = 5 * 60_000
 
 type FeishuPermissionIssue = 'app-permissions' | 'bot-capability' | 'app-availability' | 'chat-access'
@@ -1134,6 +1197,59 @@ export class FeishuConnection implements PlatformConnection {
   }
 
   // ── MCP MessageGateway: read helpers backing the injected channel tools ──
+
+  /** Fetch one bounded, provider-paginated page of Feishu/Lark chat roots. */
+  async getChannelHistory(
+    channel: string,
+    options: PlatformChannelHistoryOptions = {}
+  ): Promise<PlatformChannelHistoryPage> {
+    const limit = Math.min(
+      Math.max(options.limit ?? FEISHU_CHANNEL_HISTORY_DEFAULT_LIMIT, 1),
+      FEISHU_CHANNEL_HISTORY_MAX_LIMIT
+    )
+    try {
+      const oldest = options.oldest === undefined ? undefined : Number(options.oldest)
+      const latest = options.latest === undefined ? undefined : Number(options.latest)
+      if ((oldest !== undefined && !Number.isFinite(oldest)) || (latest !== undefined && !Number.isFinite(latest))) {
+        throw new Error('invalid timestamp bound')
+      }
+      const page = await this.handle.api.listMessages(channel, {
+        limit,
+        ...(options.cursor ? { cursor: options.cursor } : {}),
+        ...(oldest !== undefined ? { startTime: String(Math.floor(oldest / 1000)) } : {}),
+        ...(latest !== undefined ? { endTime: String(Math.ceil(latest / 1000)) } : {})
+      })
+      const messages = page.items.flatMap((message) => {
+        if (!message.create_time || !/^\d+$/.test(message.create_time)) return []
+        const timestamp = Number(message.create_time)
+        if ((oldest !== undefined && timestamp < oldest) || (latest !== undefined && timestamp > latest)) return []
+        const mentions: FeishuMention[] = (message.mentions ?? []).map((mention) => ({
+          key: mention.key,
+          id: { open_id: mention.id },
+          name: mention.name
+        }))
+        return [
+          {
+            sender: message.sender?.id || message.sender?.open_bot_id || 'unknown',
+            ts: message.create_time,
+            text: extractFeishuMessageText(message.msg_type ?? 'text', message.body?.content ?? '', mentions),
+            isBot: message.sender?.sender_type === 'app',
+            ...(message.thread_id ? { threadTs: message.thread_id } : {})
+          }
+        ]
+      })
+      return {
+        messages,
+        hasMore: page.hasMore,
+        ...(page.nextCursor ? { nextCursor: page.nextCursor } : {})
+      }
+    } catch (err) {
+      this.rememberPermissionIssue(err, channel)
+      const code = feishuErrorCode(err)
+      this.deps.log?.debug(`feishu: channel history failed (ch=${channel}): ${code ?? 'unknown'}`)
+      throw new Error(code === undefined ? 'Feishu channel history failed' : `Feishu channel history failed: ${code}`)
+    }
+  }
 
   async getChannelInfo(channel: string): Promise<{ id: string; name?: string; isIm?: boolean; isPrivate?: boolean }> {
     try {

--- a/packages/daemon/src/feishu/connection.ts
+++ b/packages/daemon/src/feishu/connection.ts
@@ -171,9 +171,10 @@ export interface FeishuApi {
   replyCardEntityMessage(messageId: string, cardId: string): Promise<{ messageId?: string }>
   /** cardkit.cardElement.content (native typewriter update). */
   updateCardEntityElement(cardId: string, elementId: string, text: string, sequence: number): Promise<void>
-  /** cardkit.card.settings + card.update terminal lifecycle. */
+  /** cardkit.card.settings closes the native stream before the final message patch. */
   setCardEntityStreaming(cardId: string, streaming: boolean, sequence: number): Promise<void>
-  updateCardEntity(cardId: string, card: Record<string, unknown>, sequence: number): Promise<void>
+  /** im.message.patch materializes the final card JSON so message history can read it. */
+  patchCardMessage(messageId: string, card: Record<string, unknown>): Promise<void>
   /** im.message.delete (retract an unfinished/no-response card). */
   deleteMessage(messageId: string): Promise<void>
   /** im.message.update (in-place text edit). */
@@ -297,6 +298,7 @@ function defaultFactory(appId: string, appSecret: string, region: FeishuRegion):
             container_id: chatId,
             sort_type: 'ByCreateTimeDesc',
             page_size: request.limit,
+            card_msg_content_type: 'user_card_content',
             only_thread_root_messages: true,
             ...(request.cursor ? { page_token: request.cursor } : {}),
             ...(request.startTime ? { start_time: request.startTime } : {}),
@@ -360,17 +362,13 @@ function defaultFactory(appId: string, appSecret: string, region: FeishuRegion):
         'cardkit.card.settings'
       )
     },
-    async updateCardEntity(cardId, card, sequence) {
+    async patchCardMessage(messageId, card) {
       assertApiSuccess(
-        await client.cardkit.v1.card.update({
-          path: { card_id: cardId },
-          data: {
-            card: { type: 'card_json', data: JSON.stringify(card) },
-            sequence,
-            uuid: `u_${cardId}_${sequence}`
-          }
+        await client.im.message.patch({
+          path: { message_id: messageId },
+          data: { content: JSON.stringify(card) }
         }),
-        'cardkit.card.update'
+        'im.message.patch'
       )
     },
     async deleteMessage(messageId) {
@@ -649,8 +647,7 @@ export class FeishuConnection implements PlatformConnection {
   // All outbound writes funnel through one queue so streamed edits are FIFO-ordered
   // per connection (keeps a post-then-edit pair from racing on the same progress msg).
   private queue: PlatformSendQueue
-  /** CardKit sequence numbers are scoped to a card entity and must increase across
-   * element, settings, and full-card updates. */
+  /** CardKit sequence numbers are scoped to a card entity and increase across element and settings updates. */
   private streamingCards = new Map<
     string,
     { sequence: number; lastText: string; messageId: string; sessionUrl?: string }
@@ -983,13 +980,11 @@ export class FeishuConnection implements PlatformConnection {
         this.deps.log?.debug(`feishu: streaming card close failed (${card.cardId}): ${(err as Error).message}`)
       }
 
-      state.sequence += 1
       let updated = false
       try {
-        await this.handle.api.updateCardEntity(
-          card.cardId,
-          buildCompletedReplyCard(text, attribution, state.sessionUrl),
-          state.sequence
+        await this.handle.api.patchCardMessage(
+          state.messageId,
+          buildCompletedReplyCard(text, attribution, state.sessionUrl)
         )
         updated = true
       } catch (err) {

--- a/packages/daemon/src/feishu/normalize.ts
+++ b/packages/daemon/src/feishu/normalize.ts
@@ -1,5 +1,6 @@
 export {
   deriveFeishuAttachments,
+  extractFeishuMessageText,
   feishuEventToMessageLike,
   humanizeFeishuText,
   normalizeFeishuMessage,

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -351,7 +351,7 @@ function buildShareFileTool(): ToolDescriptor {
   }
 }
 
-function buildReadTools(platforms: string[]): ToolDescriptor[] {
+function buildReadTools(platforms: string[], currentPlatform?: string): ToolDescriptor[] {
   const platform = {
     type: 'string',
     enum: platforms,
@@ -365,7 +365,9 @@ function buildReadTools(platforms: string[]): ToolDescriptor[] {
     type: 'string',
     description: 'Optional. Pick a specific bot when the agent has multiple integrations on the target platform.'
   }
-  const historyPlatforms = channelHistoryPlatformsFor(platforms)
+  // History has no target selector, so only the current session platform may enable it.
+  const historyPlatform = currentPlatform ?? (platforms.length === 1 ? platforms[0] : undefined)
+  const hasChannelHistory = historyPlatform !== undefined && channelHistoryPlatformsFor([historyPlatform]).length > 0
   return [
     {
       name: 'getCurrentChannel',
@@ -384,7 +386,7 @@ function buildReadTools(platforms: string[]): ToolDescriptor[] {
         'has multiple bots on the platform (history is not attributable to one bot).',
       inputSchema: obj({ platform, integrationId })
     },
-    ...(historyPlatforms.length > 0
+    ...(hasChannelHistory
       ? [
           {
             name: 'getChannelHistory',
@@ -399,7 +401,7 @@ function buildReadTools(platforms: string[]): ToolDescriptor[] {
                 type: 'integer',
                 minimum: 1,
                 maximum: 200,
-                description: 'Number of messages to request, capped at 200 per page.'
+                description: 'Number of messages to request (max 200; the provider may return a smaller page).'
               },
               oldest: { type: 'string', description: 'Inclusive oldest message timestamp bound.' },
               latest: { type: 'string', description: 'Inclusive latest message timestamp bound.' }
@@ -889,7 +891,7 @@ export const ALL_TOOL_NAMES = [
       // are stable and belong in the permission auto-allow set.
       buildSendMessageTool([]),
       buildShareFileTool(),
-      ...buildReadTools(allChannelHistoryPlatforms()),
+      ...buildReadTools(allChannelHistoryPlatforms(), allChannelHistoryPlatforms().at(0)),
       // Every platform's credentialed attachment tool, whatever this agent has:
       // the auto-allow set is about NAMES, and a name a platform can inject must
       // be listed even for an agent that will never see it.
@@ -922,7 +924,7 @@ export const ALL_TOOL_NAMES = [
  */
 export function toolsForIntegrations(
   integrations: Integration[],
-  options: { sessionTitle?: boolean; organizationKnowledge?: boolean } = {}
+  options: { sessionTitle?: boolean; organizationKnowledge?: boolean; currentPlatform?: string } = {}
 ): ToolDescriptor[] {
   const tools: ToolDescriptor[] = []
   const seen = new Set<string>()
@@ -945,7 +947,7 @@ export function toolsForIntegrations(
   add([buildSendMessageTool(platforms)])
   // Platform read helpers only make sense once the agent has at least one integration.
   if (platforms.length > 0) {
-    add(buildReadTools(platforms))
+    add(buildReadTools(platforms, options.currentPlatform))
     // The current-conversation file share (docs/designs/agent-authored-attachments.md §3):
     // platform-gated like the read tools; sessions without a file-hosting gateway get a
     // clean refusal at call time (port probe / coordinate gates).

--- a/packages/daemon/src/platforms/read-ports.ts
+++ b/packages/daemon/src/platforms/read-ports.ts
@@ -112,6 +112,22 @@ const READ_PORTS = new Map<string, PlatformReadPorts>([
       label: 'Telegram',
       attachmentReadTool: TELEGRAM_ATTACHMENT_TOOL
     }
+  ],
+  [
+    'discord',
+    {
+      platform: 'discord',
+      label: 'Discord',
+      channelHistory: true
+    }
+  ],
+  [
+    'feishu',
+    {
+      platform: 'feishu',
+      label: 'Lark / Feishu',
+      channelHistory: true
+    }
   ]
 ])
 

--- a/packages/daemon/test/discord-connection.test.ts
+++ b/packages/daemon/test/discord-connection.test.ts
@@ -39,4 +39,57 @@ describe('DiscordConnection gateway options', () => {
     expect(fetch.mock.calls.map(([id]) => id)).toEqual(['THREAD', 'THREAD', 'THREAD', 'THREAD'])
     expect(edit).toHaveBeenCalledOnce()
   })
+
+  it('reads a newest-first page from the current channel with Discord pagination', async () => {
+    const connection = new DiscordConnection({
+      group: { botToken: 'token', integrations: [] },
+      onMessage: () => {},
+      newTraceId: () => 'trace'
+    })
+    const messages = [
+      {
+        id: '300',
+        createdTimestamp: 3_000,
+        content: 'hello <@42>',
+        author: { id: '7', bot: false },
+        mentions: { users: new Map([['42', { id: '42', username: 'alice', globalName: 'Alice' }]]) },
+        thread: { id: 'thread-300', messageCount: 2 }
+      },
+      {
+        id: '200',
+        createdTimestamp: 2_000,
+        content: 'from bot',
+        author: { id: '8', bot: true },
+        mentions: { users: new Map() },
+        thread: null
+      }
+    ]
+    const fetchMessages = vi.fn(async () => new Map(messages.map((message) => [message.id, message])))
+    const fetchChannel = vi.fn(async () => ({ isTextBased: () => true, messages: { fetch: fetchMessages } }))
+    ;(connection as unknown as { client: unknown }).client = { channels: { fetch: fetchChannel } }
+
+    await expect(
+      connection.getChannelHistory('channel-1', {
+        cursor: 'before-400',
+        limit: 2,
+        oldest: '1000',
+        latest: '3000'
+      })
+    ).resolves.toEqual({
+      messages: [
+        {
+          sender: '7',
+          ts: '3000',
+          text: 'hello @Alice',
+          isBot: false,
+          threadTs: 'thread-300',
+          replyCount: 2
+        },
+        { sender: '8', ts: '2000', text: 'from bot', isBot: true }
+      ],
+      hasMore: true,
+      nextCursor: '200'
+    })
+    expect(fetchMessages).toHaveBeenCalledWith({ limit: 2, before: 'before-400' })
+  })
 })

--- a/packages/daemon/test/feishu-channel-history.test.ts
+++ b/packages/daemon/test/feishu-channel-history.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FeishuConnection, type FeishuClientHandle } from '../src/feishu/connection.js'
+
+describe('FeishuConnection.getChannelHistory', () => {
+  it('converts bounds, maps messages, and preserves the provider cursor', async () => {
+    const listMessages = vi.fn(async () => ({
+      items: [
+        {
+          message_id: 'om_3',
+          thread_id: 'omt_3',
+          msg_type: 'text',
+          create_time: '3000',
+          sender: { id: 'ou_user', sender_type: 'user' },
+          body: { content: '{"text":"hello @_user_1"}' },
+          mentions: [{ key: '@_user_1', id: 'ou_alice', name: 'Alice' }]
+        },
+        {
+          message_id: 'om_2',
+          msg_type: 'text',
+          create_time: '2000',
+          sender: { id: 'cli_bot', sender_type: 'app' },
+          body: { content: '{"text":"bot reply"}' }
+        },
+        {
+          message_id: 'om_1',
+          msg_type: 'text',
+          create_time: '1000',
+          sender: { id: 'ou_old', sender_type: 'user' },
+          body: { content: '{"text":"outside bound"}' }
+        }
+      ],
+      hasMore: true,
+      nextCursor: 'page-2'
+    }))
+    const handle = {
+      api: { listMessages },
+      startWs: async () => {},
+      close: () => {}
+    } as unknown as FeishuClientHandle
+    const connection = new FeishuConnection(
+      {
+        group: {
+          appId: 'cli_history',
+          appSecret: 'secret',
+          mode: 'direct',
+          region: 'feishu',
+          integrations: []
+        },
+        onMessage: () => {},
+        newTraceId: () => 'trace'
+      },
+      () => handle
+    )
+
+    await expect(
+      connection.getChannelHistory('oc_current', {
+        cursor: 'page-1',
+        limit: 200,
+        oldest: '2000',
+        latest: '3999'
+      })
+    ).resolves.toEqual({
+      messages: [
+        {
+          sender: 'ou_user',
+          ts: '3000',
+          text: 'hello @Alice',
+          isBot: false,
+          threadTs: 'omt_3'
+        },
+        { sender: 'cli_bot', ts: '2000', text: 'bot reply', isBot: true }
+      ],
+      hasMore: true,
+      nextCursor: 'page-2'
+    })
+    expect(listMessages).toHaveBeenCalledWith('oc_current', {
+      cursor: 'page-1',
+      limit: 50,
+      startTime: '2',
+      endTime: '4'
+    })
+  })
+})

--- a/packages/daemon/test/feishu-channel-history.test.ts
+++ b/packages/daemon/test/feishu-channel-history.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { FeishuConnection, type FeishuClientHandle } from '../src/feishu/connection.js'
+import { buildCompletedReplyCard } from '../src/feishu/render.js'
 
 describe('FeishuConnection.getChannelHistory', () => {
   it('converts bounds, maps messages, and preserves the provider cursor', async () => {
@@ -13,6 +14,13 @@ describe('FeishuConnection.getChannelHistory', () => {
           sender: { id: 'ou_user', sender_type: 'user' },
           body: { content: '{"text":"hello @_user_1"}' },
           mentions: [{ key: '@_user_1', id: 'ou_alice', name: 'Alice' }]
+        },
+        {
+          message_id: 'om_card',
+          msg_type: 'interactive',
+          create_time: '2500',
+          sender: { id: 'cli_bot', sender_type: 'app' },
+          body: { content: JSON.stringify(buildCompletedReplyCard('CardKit answer')) }
         },
         {
           message_id: 'om_2',
@@ -68,6 +76,7 @@ describe('FeishuConnection.getChannelHistory', () => {
           isBot: false,
           threadTs: 'omt_3'
         },
+        { sender: 'cli_bot', ts: '2500', text: 'CardKit answer', isBot: true },
         { sender: 'cli_bot', ts: '2000', text: 'bot reply', isBot: true }
       ],
       hasMore: true,

--- a/packages/daemon/test/feishu-permission-notice.test.ts
+++ b/packages/daemon/test/feishu-permission-notice.test.ts
@@ -32,6 +32,7 @@ function connectionFor(
       createCard,
       replyText: async () => ({}),
       replyCard,
+      listMessages: async () => ({ items: [], hasMore: false }),
       createCardEntity: async () => ({ cardId: 'card-1' }),
       createCardEntityMessage: async () => ({ messageId: 'message-1' }),
       replyCardEntityMessage: async () => ({ messageId: 'message-2' }),

--- a/packages/daemon/test/feishu-permission-notice.test.ts
+++ b/packages/daemon/test/feishu-permission-notice.test.ts
@@ -38,7 +38,7 @@ function connectionFor(
       replyCardEntityMessage: async () => ({ messageId: 'message-2' }),
       updateCardEntityElement: async () => {},
       setCardEntityStreaming: async () => {},
-      updateCardEntity: async () => {},
+      patchCardMessage: async () => {},
       deleteMessage: async () => {},
       uploadImage: async () => ({}),
       createImage: async () => ({}),

--- a/packages/daemon/test/feishu-region-reconcile.test.ts
+++ b/packages/daemon/test/feishu-region-reconcile.test.ts
@@ -38,7 +38,7 @@ function fakeFeishuConn(appId: string, region: 'feishu' | 'lark', botOpenId: str
       replyCardEntityMessage: async () => ({ messageId: 'message-2' }),
       updateCardEntityElement: async () => {},
       setCardEntityStreaming: async () => {},
-      updateCardEntity: async () => {},
+      patchCardMessage: async () => {},
       deleteMessage: async () => {},
       updateText: async () => {},
       downloadResource: async () => {},

--- a/packages/daemon/test/feishu-region-reconcile.test.ts
+++ b/packages/daemon/test/feishu-region-reconcile.test.ts
@@ -29,6 +29,7 @@ function fakeFeishuConn(appId: string, region: 'feishu' | 'lark', botOpenId: str
       createCard: async () => ({}),
       replyText: async () => ({}),
       replyCard: async () => ({}),
+      listMessages: async () => ({ items: [], hasMore: false }),
       uploadImage: async () => ({ imageKey: 'img_1' }),
       createImage: async () => ({}),
       replyImage: async () => ({}),

--- a/packages/daemon/test/feishu-region.test.ts
+++ b/packages/daemon/test/feishu-region.test.ts
@@ -39,7 +39,7 @@ function fakeHandle(): FeishuClientHandle {
     replyCardEntityMessage: async () => ({ messageId: 'message-2' }),
     updateCardEntityElement: async () => {},
     setCardEntityStreaming: async () => {},
-    updateCardEntity: async () => {},
+    patchCardMessage: async () => {},
     deleteMessage: async () => {},
     updateText: async () => {},
     downloadResource: async () => {},

--- a/packages/daemon/test/feishu-region.test.ts
+++ b/packages/daemon/test/feishu-region.test.ts
@@ -30,6 +30,7 @@ function fakeHandle(): FeishuClientHandle {
     createCard: async () => ({}),
     replyText: async () => ({}),
     replyCard: async () => ({}),
+    listMessages: async () => ({ items: [], hasMore: false }),
     uploadImage: async () => ({ imageKey: 'img_1' }),
     createImage: async () => ({}),
     replyImage: async () => ({}),

--- a/packages/daemon/test/feishu-streaming-card.test.ts
+++ b/packages/daemon/test/feishu-streaming-card.test.ts
@@ -33,7 +33,7 @@ function connection() {
   const replyCardEntityMessage = vi.fn(async (): Promise<{ messageId?: string }> => ({ messageId: 'message-1' }))
   const updateCardEntityElement = vi.fn(async () => {})
   const setCardEntityStreaming = vi.fn(async () => {})
-  const updateCardEntity = vi.fn<FeishuApi['updateCardEntity']>(async () => {})
+  const patchCardMessage = vi.fn<FeishuApi['patchCardMessage']>(async () => {})
   const deleteMessage = vi.fn(async () => {})
   const onStatusAction = vi.fn()
   let cardActionHandler: ((event: FeishuRawCardActionEvent) => FeishuCardActionResponse | undefined) | undefined
@@ -52,7 +52,7 @@ function connection() {
       replyCardEntityMessage,
       updateCardEntityElement,
       setCardEntityStreaming,
-      updateCardEntity,
+      patchCardMessage,
       deleteMessage,
       updateText: async () => {},
       downloadResource: async () => {},
@@ -83,7 +83,7 @@ function connection() {
     replyCardEntityMessage,
     updateCardEntityElement,
     setCardEntityStreaming,
-    updateCardEntity,
+    patchCardMessage,
     deleteMessage,
     onStatusAction,
     triggerCardAction: (event: FeishuRawCardActionEvent) => cardActionHandler?.(event)
@@ -98,7 +98,7 @@ describe('Lark CardKit transport', () => {
       replyCardEntityMessage,
       updateCardEntityElement,
       setCardEntityStreaming,
-      updateCardEntity
+      patchCardMessage
     } = connection()
 
     const card = await conn.startStreamingCard('oc_chat', 'om_root', {
@@ -142,9 +142,8 @@ describe('Lark CardKit transport', () => {
 
     expect(updateCardEntityElement).toHaveBeenCalledWith('card-1', FEISHU_STREAMING_ELEMENT_ID, 'Hello', 1)
     expect(setCardEntityStreaming).toHaveBeenCalledWith('card-1', false, 2)
-    expect(updateCardEntity.mock.calls[0]![0]).toBe('card-1')
-    expect(updateCardEntity.mock.calls[0]![2]).toBe(3)
-    expect(updateCardEntity.mock.calls[0]![1]).toMatchObject({
+    expect(patchCardMessage.mock.calls[0]![0]).toBe('message-1')
+    expect(patchCardMessage.mock.calls[0]![1]).toMatchObject({
       body: {
         elements: [
           { tag: 'markdown', content: 'Hello world' },
@@ -214,12 +213,12 @@ describe('Lark CardKit transport', () => {
   })
 
   it('falls back when the IM send response has no message id', async () => {
-    const { conn, replyCardEntityMessage, updateCardEntity } = connection()
+    const { conn, replyCardEntityMessage, patchCardMessage } = connection()
     replyCardEntityMessage.mockResolvedValueOnce({})
 
     const card = await conn.startStreamingCard('oc_chat', 'om_root')
 
     expect(card).toBeUndefined()
-    expect(updateCardEntity).not.toHaveBeenCalled()
+    expect(patchCardMessage).not.toHaveBeenCalled()
   })
 })

--- a/packages/daemon/test/feishu-streaming-card.test.ts
+++ b/packages/daemon/test/feishu-streaming-card.test.ts
@@ -43,6 +43,7 @@ function connection() {
       createCard: async () => ({}),
       replyText: async () => ({}),
       replyCard: async () => ({}),
+      listMessages: async () => ({ items: [], hasMore: false }),
       uploadImage: async () => ({ imageKey: 'img_1' }),
       createImage: async () => ({}),
       replyImage: async () => ({}),

--- a/packages/daemon/test/mcp-tool-args.test.ts
+++ b/packages/daemon/test/mcp-tool-args.test.ts
@@ -33,7 +33,11 @@ const telegramInt: Integration = {
 const ALL_CAPABILITIES = new Set(['recall', 'create', 'get', 'update', 'delete'] as const)
 
 const advertised: ToolDescriptor[] = [
-  ...toolsForIntegrations([slackInt, telegramInt], { sessionTitle: true, organizationKnowledge: true }),
+  ...toolsForIntegrations([slackInt, telegramInt], {
+    sessionTitle: true,
+    organizationKnowledge: true,
+    currentPlatform: 'slack'
+  }),
   ...externalMemoryTools(ALL_CAPABILITIES),
   ...RETIRED_ORCHESTRATION_TOOLS,
   ...GITHUB_REVIEW_TOOLS,

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -88,7 +88,19 @@ describe('toolsForIntegrations', () => {
       ])
     )
     expect(names).not.toContain('readSlackFile') // the Slack file tool is still platform-gated
+    expect(names).not.toContain('getChannelHistory')
     expect(sendPlatformEnum([telegramInt])).toEqual(['telegram'])
+  })
+
+  it('injects channel history only for the current session platform when its adapter is registered', () => {
+    const integrations = [slackInt, telegramInt, discordInt, feishuInt]
+    const namesFor = (currentPlatform: string) =>
+      toolsForIntegrations(integrations, { currentPlatform }).map((tool) => tool.name)
+
+    for (const platform of ['slack', 'discord', 'feishu']) {
+      expect(namesFor(platform)).toContain('getChannelHistory')
+    }
+    expect(namesFor('telegram')).not.toContain('getChannelHistory')
   })
 
   it('narrows the read tools’ platform enum to the agent’s platforms and routes cross-platform', () => {
@@ -107,7 +119,10 @@ describe('toolsForIntegrations', () => {
     for (const n of ['listChannels', 'listChannelMembers', 'getUserProfile']) {
       expect(props(readTool([slackInt, telegramInt], n))).toHaveProperty('integrationId')
     }
-    const historyProps = props(readTool([slackInt, telegramInt], 'getChannelHistory'))
+    const historyTool = toolsForIntegrations([slackInt, telegramInt], { currentPlatform: 'slack' }).find(
+      (tool) => tool.name === 'getChannelHistory'
+    )!
+    const historyProps = props(historyTool)
     expect(Object.keys(historyProps).sort()).toEqual(['cursor', 'latest', 'limit', 'oldest'])
     expect(props(readTool([slackInt, telegramInt], 'listKnownUsers'))).not.toHaveProperty('integrationId')
   })

--- a/packages/daemon/test/platform-contract.test.ts
+++ b/packages/daemon/test/platform-contract.test.ts
@@ -68,6 +68,9 @@ describe('Layer-1 platform contract (§7.1)', () => {
       expect(has(ctor, 'listBotChannels')).toBe(false)
       expect(has(ctor, 'getThreadReplies')).toBe(false)
     }
+    expect(has(DiscordConnection, 'getChannelHistory')).toBe(true)
+    expect(has(FeishuConnection, 'getChannelHistory')).toBe(true)
+    expect(has(TelegramConnection, 'getChannelHistory')).toBe(false)
 
     // leaveGranularity: Slack/Telegram leave a CONVERSATION, Discord leaves the
     // enclosing SPACE (a bot joins servers, not channels), Feishu leaves neither.
@@ -84,6 +87,8 @@ describe('Layer-1 platform contract (§7.1)', () => {
     // eval suite's ability to substitute for a real platform.
     expect(has(VirtualSlackConnection, 'getThreadReplies')).toBe(true)
     expect(has(VirtualSlackConnection, 'getChannelHistory')).toBe(true)
+    expect(has(VirtualDiscordConnection, 'getChannelHistory')).toBe(true)
+    expect(has(VirtualTelegramConnection, 'getChannelHistory')).toBe(false)
     expect(has(VirtualSlackConnection, 'listBotChannels')).toBe(true)
     expect(has(VirtualSlackConnection, 'openDirectMessage')).toBe(true)
     expect(has(VirtualSlackConnection, 'leaveChannel')).toBe(true)

--- a/packages/message/src/feishu-message.ts
+++ b/packages/message/src/feishu-message.ts
@@ -131,6 +131,11 @@ function extractText(messageType: string, content: string): string {
   return messageType === 'post' ? flattenPost(parsed) : ''
 }
 
+/** Extract the readable text carried by one Feishu message body. */
+export function extractFeishuMessageText(messageType: string, content: string, mentions?: FeishuMention[]): string {
+  return humanizeFeishuText(extractText(messageType, content), mentions)
+}
+
 export function deriveFeishuAttachments(messageType: string, content: string): FeishuAttachmentLike[] {
   try {
     const parsed = JSON.parse(content || '{}') as Record<string, unknown>
@@ -192,7 +197,7 @@ export function normalizeFeishuMessage(
     channel: message.chatId,
     thread: isDm ? message.chatId : (message.rootId ?? message.messageId),
     sender: { id: message.senderUnionId, isBot: message.senderIsBot ?? false },
-    text: humanizeFeishuText(extractText(message.messageType, message.content), message.mentions),
+    text: extractFeishuMessageText(message.messageType, message.content, message.mentions),
     mentionedBots: (message.mentions ?? [])
       .map((mention) => mention?.id?.open_id)
       .filter((id): id is string => typeof id === 'string' && id.length > 0),

--- a/packages/message/src/feishu-message.ts
+++ b/packages/message/src/feishu-message.ts
@@ -117,6 +117,45 @@ function flattenPost(parsed: unknown): string {
   return [title, body].filter(Boolean).join('\n')
 }
 
+function flattenCard(parsed: unknown): string {
+  const parts: string[] = []
+  const add = (value: unknown, prefix = '') => {
+    if (typeof value !== 'string') return
+    const text = value.trim()
+    if (text) parts.push(prefix + text)
+  }
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item)
+      return
+    }
+    if (!value || typeof value !== 'object') return
+    const node = value as Record<string, unknown>
+    const tag = typeof node.tag === 'string' ? node.tag : undefined
+    if (tag === 'button' || tag === 'overflow') return
+    if (tag === 'at') {
+      const user = node.user_name || node.user_id
+      add(user, typeof user === 'string' && user.startsWith('@') ? '' : '@')
+      return
+    }
+    if (tag === 'markdown' || tag === 'lark_md' || tag === 'plain_text' || tag === 'md') {
+      add(node.content ?? node.text)
+      return
+    }
+    if (tag === 'text' || tag === 'a') {
+      add(node.text ?? node.content)
+      return
+    }
+    for (const key of ['title', 'header', 'body', 'elements', 'columns', 'fields', 'text', 'content']) {
+      const child = node[key]
+      if (typeof child === 'string') add(child)
+      else visit(child)
+    }
+  }
+  visit(parsed)
+  return parts.join('\n')
+}
+
 function extractText(messageType: string, content: string): string {
   let parsed: unknown
   try {
@@ -128,7 +167,8 @@ function extractText(messageType: string, content: string): string {
     const text = (parsed as Record<string, unknown>)?.text
     return typeof text === 'string' ? text : ''
   }
-  return messageType === 'post' ? flattenPost(parsed) : ''
+  if (messageType === 'post') return flattenPost(parsed)
+  return messageType === 'interactive' ? flattenCard(parsed) : ''
 }
 
 /** Extract the readable text carried by one Feishu message body. */


### PR DESCRIPTION
## Summary

- add provider-paginated current-channel history adapters for Discord and Feishu/Lark
- register channel-history capabilities and gate tool injection by the active session platform
- keep Telegram fail-closed, add the Feishu group-history scope, and preserve virtual Discord parity

## Testing

- focused daemon channel-history, platform-contract, MCP-tool, and Feishu Vitest suites
- virtual connection Vitest suite (5 tests)
- daemon, message, and control-plane typechecks
- repository pre-push ESLint gate

Created by Codex . GPT-5
