### PR TITLE
fix(daemon): canonicalize the seam test's worktree fixture root

### DIFF
--- a/packages/daemon/test/workspace-git-runner-seam.test.ts
+++ b/packages/daemon/test/workspace-git-runner-seam.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { WorkspaceManager, type WorkspaceGitRunnerResolver } from '../src/workspace/workspace-manager.js'
@@ -40,7 +40,8 @@ function git(cwd: string, args: string[]): string {
 
 /** A real agent whose workspace is a real repository with a real session worktree. */
 function agentWithWorktree(sessionKey: string): { agent: Agent; worktree: string } {
-  const home = mkdtempSync(join(tmpdir(), 'ac-seam-'))
+  // CANONICAL: removal re-derives cwd from the realpath'd root, so a symlinked tmpdir (macOS) renames the argv.
+  const home = realpathSync(mkdtempSync(join(tmpdir(), 'ac-seam-')))
   roots.push(home)
   const path = join(home, 'checkout')
   mkdirSync(path, { recursive: true })


### PR DESCRIPTION
## What

`workspace-git-runner-seam.test.ts` had one case failing off Linux — "routes worktree removal through the resolver, with the agent it belongs to", at the `worktree remove <path>` assertion. The other 13 cases in the file passed.

## Why it failed

The production side is correct and the routing was never broken. `removeRootSessionWorktree` re-derives its cwd from `validateWorktreesRoot`, which realpaths the worktrees parent so that a symlinked root (or symlinked ancestor) cannot redirect the destructive branches below it outside the agent directory. So the argv that reaches the seam names the **canonical** worktree path.

The test built its expectation from the raw `mkdtempSync(join(tmpdir(), …))` path instead. Those two strings are equal only where the platform's tmpdir is already canonical — true on Linux CI (`/tmp`), false on macOS, where `os.tmpdir()` returns `/var/folders/…`, a symlink to `/private/var/folders/…`. The assertion therefore compared against a string the removal path never emits.

Recording the argv under a symlinked `TMPDIR` shows removal was routed through the seam the whole time, just under the canonical name:

```
status --porcelain
symbolic-ref --quiet --short HEAD
rev-list --count HEAD --not --remotes --glob=refs/agentconnect/reviews/<id>
worktree remove <realpath>/worktrees/<id>      <- fixture expected <symlink>/worktrees/<id>
worktree prune
update-ref -d refs/agentconnect/reviews/<id>/{base,head,merge}
```

## Change

Canonicalize the fixture's temp home in `agentWithWorktree`, matching how the neighbouring workspace tests (`workspace.test.ts`, `workspace-secondary-roots.test.ts`) already canonicalize before comparing against manager-emitted paths.

The assertion itself is untouched and stays byte-exact, so it still proves worktree removal goes through the per-agent runner seam rather than around it — and it would still catch a shape change such as `worktree remove --force`. Canonicalizing the fixture root rather than just the one expected string keeps every path the fixture derives (agent dir, checkout, worktree) in the same coordinates the manager uses.

## Testing

- `test/workspace-git-runner-seam.test.ts`: 14/14 pass on a plain tmpdir, and 14/14 under a symlinked `TMPDIR` that reproduces the macOS layout (1 failed / 13 passed there before the change, matching the report).
- `pnpm --filter @agentconnect.md/daemon typecheck` passes; prettier and eslint clean on the changed file.
- Unrelated pre-existing failures in this sandbox: `workspace.test.ts`, `workspace-secondary-roots.test.ts`, and `daemon-hook.test.ts` fail with `SkillLedgerSafetyError: workspace skill lock database is unavailable`. The container runs Node v22.22.2 while the repo requires >= 24.12.0, and the skill install ledger uses `node:sqlite`, which is experimental with a different API on 22. Those files are unmodified by this commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Tec2EHWsMrBbRwqsd1VHy)_