### PR TITLE
fix(daemon): name the trigger's own attachment in the prompt, not only the transcript

### DIFF
--- a/packages/daemon/src/mcp/ops/messaging.ts
+++ b/packages/daemon/src/mcp/ops/messaging.ts
@@ -522,11 +522,15 @@ export async function sendMessage(
       // message, while only the one retained image is forwardable. Saying "no such name"
       // would send the agent back to retry a name it read correctly.
       if (!attachment) {
+        // Wording matters here: an earlier phrasing listed the unforwardable kinds and an agent
+        // read the list backwards, asking the user to RE-SEND the picture as a document. State
+        // what can be forwarded, then close the loop on the retries that cannot work.
         throw new Error(
-          `sendMessage: "${attachmentName}" is not forwardable from this conversation. Only a shared ` +
-            'IMAGE is retained for forwarding — a document, a second image on the same message, or an ' +
-            'image too large to retain is not, even though the `[attached: …]` marker still lists it. ' +
-            'Check the spelling once; if it matches, this file cannot be forwarded and retrying will not help.'
+          `sendMessage: "${attachmentName}" cannot be forwarded. Only ONE shared image per message is ` +
+            'retained, and only PNG, JPEG or WEBP. Do NOT ask anyone to re-send it in another format ' +
+            '— a document or a second image on the same message can never be forwarded, and re-sending ' +
+            'will not change that. Check the spelling once against the `[attached: …]` marker; if it ' +
+            'matches, describe the image in your reply instead.'
         )
       }
     }

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -13,7 +13,7 @@ import type { Agent } from '../agents/agent-schema.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import { stableTurnId, type Attachment, type NormalizedMessage } from '../messages/normalized.js'
 import { messageOrderingFor } from '../platforms/message-ordering.js'
-import { buildAttachmentBlocks } from './attachment-block.js'
+import { attachmentMention, buildAttachmentBlocks } from './attachment-block.js'
 import { DIRECT_AGENT_CALL_REMINDER, EXPLICIT_MENTION_REMINDER, NO_RESPONSE_REMINDER } from './no-response.js'
 import { planReplay, renderReplayContext } from './turn/replay-plan.js'
 import { AGENT_META_OPENING, buildStandingContext, type StandingContext } from './turn/standing-context.js'
@@ -755,7 +755,18 @@ export class SessionManager {
             ? matchSkillInvocation(msg.text, this.deps.advertisedCommandsFor(agentId))
             : null
         const triggerText = invocation ? renderSkillInvocation(invocation) : msg.text
-        blocks.push({ type: 'text', text: msg.source === 'user' ? `[${msg.sender.id}] ${triggerText}` : msg.text })
+        // The trigger's OWN attachments are named here, not only on its transcript row. A
+        // shared image reaches the model as pixels (an `image` block below), which is enough
+        // to look at and not enough to ACT on: `sendMessage`'s `attachment` takes the name
+        // from this marker, so without it an agent asked to forward the picture it can
+        // plainly see has no string to forward it by. Replayed context already carries the
+        // marker (it renders transcript rows), which is why only this arm was missing it.
+        const triggerMarker = attachmentMention(ingested.attachments)
+        const withMarker = (text: string): string => (triggerMarker ? `${text}\n${triggerMarker}` : text)
+        blocks.push({
+          type: 'text',
+          text: withMarker(msg.source === 'user' ? `[${msg.sender.id}] ${triggerText}` : msg.text)
+        })
         contextEvents = [...context.map((entry) => ({ ts: entry.ts, text: entry.text })), { ts, text: msg.text }]
       }
       rec.lastDeliveredTs = plan.deliveredThrough ?? ts

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -1674,9 +1674,11 @@ describe('Daemon handleRelayMsg (rd/msg op dispatch — the relay data plane)', 
     expect(ack).toMatchObject({ accepted: true })
     await vi.waitFor(() => expect(events.some((event) => event.kind === 'done')).toBe(true), WAIT)
 
+    // The trigger names its own attachment beside the pixels: the image block is what the
+    // model looks at, the marker is what `sendMessage`'s `attachment` forwards it BY.
     expect(host.prompt.mock.calls[0]?.[1]).toEqual(
       expect.arrayContaining([
-        { type: 'text', text: '[ada] What is shown?' },
+        { type: 'text', text: '[ada] What is shown?\n[attached: screen.webp (image/webp)]' },
         { type: 'image', data: bytes.toString('base64'), mimeType: 'image/webp' }
       ])
     )

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -292,15 +292,20 @@ describe('executeTool: sendMessage (channel post)', () => {
       expect(recorded).toEqual([])
     })
 
-    it('refuses an unforwardable name without blaming the spelling, posting nothing', async () => {
+    it('refuses an unforwardable name without blaming the spelling or inviting a re-send', async () => {
       const gw = anchorless()
       const { deps: d } = deps(gw)
       Object.assign(d, resolves())
       await expect(
         executeTool(ctx, 'sendMessage', { channel: 'C_OTHER', attachment: 'nope.png', message: 'hi' }, d)
-      ).rejects.toThrow(/"nope.png" is not forwardable/)
+      ).rejects.toThrow(/"nope.png" cannot be forwarded/)
       expect(gw.uploadFile).not.toHaveBeenCalled()
       expect(gw.postMessage).not.toHaveBeenCalled()
+      // An agent read an earlier phrasing backwards and asked the user to re-send the picture
+      // AS a document — the one move that cannot help. The refusal now forecloses it.
+      await expect(
+        executeTool(ctx, 'sendMessage', { channel: 'C_OTHER', attachment: 'nope.png', message: 'hi' }, d)
+      ).rejects.toThrow(/Do NOT ask anyone to re-send it/)
     })
 
     it('refuses a target platform with no upload port rather than sending the caption alone', async () => {

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -1438,6 +1438,41 @@ describe('SessionManager', () => {
     const img = blocks.find((b: any) => b.type === 'image') as any
     expect(img).toMatchObject({ type: 'image', mimeType: 'image/png', data: png.toString('base64') })
     expect(img).not.toHaveProperty('uri')
+    // The pixels are not enough: `sendMessage`'s `attachment` takes the NAME from this marker,
+    // so an agent asked to forward the picture it can see needs the marker on the trigger too.
+    const prompt = blocks
+      .filter((b: any) => b.type === 'text')
+      .map((b: any) => b.text)
+      .join('\n')
+    expect(prompt).toContain('see this')
+    expect(prompt).toContain('[attached: a.png (image/png)]')
+    await (await store).close()
+  })
+
+  it('names the trigger’s attachment even when the agent cannot take images at all', async () => {
+    // The resource_link arm carries a uri, but the forward path is keyed on the marker name —
+    // it must not depend on the runtime's image capability.
+    const store = await newStore()
+    const sm = new SessionManager({
+      store,
+      hostFor: async () => fakeHost(),
+      agentById: () => agent,
+      memory,
+      downloadAttachment: async () => null
+    })
+    const { blocks } = await sm.handle(
+      'bot-a',
+      msg({
+        ts: '100.1',
+        text: 'forward this',
+        attachments: [{ id: 'F1', name: 'shot.jpg', mimeType: 'image/jpeg', sourceUrl: 'tg-file-id' }]
+      })
+    )
+    const prompt = blocks
+      .filter((b: any) => b.type === 'text')
+      .map((b: any) => b.text)
+      .join('\n')
+    expect(prompt).toContain('[attached: shot.jpg (image/jpeg)]')
     await (await store).close()
   })
 


### PR DESCRIPTION
## The bug, from a real failure

A user sent a screenshot on Telegram **with** `@bot forward it to dev team on slack` as its caption. The agent replied:

> I'll forward the attached image and request to the dev team in Slack. Forwarded to the Slack dev/support channel. **The image couldn't transfer; please resend it as a file/document so I can attach it.**

The text reached Slack. The image did not — and the agent never reached the tool at all.

## Why

`sendMessage`'s `attachment` is keyed on the **name** in the `[attached: …]` marker. That marker was written to the **transcript row** only; the trigger's own prompt text is the raw message text (`session-manager.ts`, the non-batch arm). So the agent had:

| | in the prompt |
| --- | --- |
| the image's pixels | ✅ inline `image` block |
| the image's **name** | ❌ nowhere |

Pixels it can look at, and no string it can act on. Replayed context already carried the marker — it renders transcript rows — which is why forwarding an image from an **earlier** message worked while the obvious case (image + mention in one message) could not.

## The fix

The trigger's attachments are named in the prompt too, beside the text — the same `attachmentMention` the transcript uses, so the console's marker parsing is untouched.

Also reworded the refusal that produced the invented workaround. It listed the unforwardable kinds (`… a document … is not`) and an agent read it backwards, asking the user to re-send the picture **as** a document — the one move that cannot help. It now states what *can* be forwarded and forecloses the re-send explicitly.

## Testing

- The trigger's marker is in the prompt, with and without the runtime's image capability (the forward path must not depend on it — the `resource_link` arm has a uri, but the name is what `attachment` takes).
- The refusal's anti-re-send clause is pinned, since that exact sentence is what a model got wrong in production.
- Workspace `typecheck`, `lint`, `format:check`, `eval:gates` (193) and the touched suites (287) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
