### PR TITLE
feat(relay): veto every bound service account with the rule-owned review exception

### DIFF
--- a/packages/control-plane/src/hooks/hook.service.test.ts
+++ b/packages/control-plane/src/hooks/hook.service.test.ts
@@ -8,6 +8,8 @@ import { HookService, type HookAgentReads } from './hook.service.js'
 import type {
   AgentRecord,
   GithubInstallationRecord,
+  GitlabProjectBindingRecord,
+  GitlabWebhookSecretStore,
   HookRecord,
   HookRepo,
   HookSecretStore
@@ -69,6 +71,27 @@ function installation(id: bigint, over: Partial<GithubInstallationRecord> = {}):
   }
 }
 
+/** A ready gitlab binding — the gitlab-compile source (§11.3). */
+function binding(over: Partial<GitlabProjectBindingRecord> = {}): GitlabProjectBindingRecord {
+  return {
+    id: 'binding-1',
+    orgId: 'org',
+    projectId: 4455667n,
+    projectPath: 'example-group/example-project',
+    defaultBranch: 'main',
+    installerConnectionId: null,
+    serviceAccountUserId: 9042n,
+    serviceAccountUsername: 'agentconnect-p4455667',
+    webhookId: 12n,
+    desiredEventsHash: null,
+    credentialEpoch: 1n,
+    state: 'ready',
+    stateReason: null,
+    createdAt: new Date(),
+    ...over
+  }
+}
+
 /** A HookService with faked deps + a spy RelayControlSender capturing pushes. */
 function make(
   opts: {
@@ -78,6 +101,7 @@ function make(
     appSlug?: string
     hooks?: Partial<HookRepo>
     pause?: boolean | null
+    gitlabBinding?: Partial<GitlabProjectBindingRecord> | null
   } = {}
 ) {
   const agents: HookAgentReads = {
@@ -101,8 +125,24 @@ function make(
     hookRemove: (id: string) => removes.push(id)
   } as unknown as RelayControlSender
   const installations = opts.installations ? { listForOrg: vi.fn(async () => opts.installations!) } : undefined
+  const gitlabBindings =
+    opts.gitlabBinding === undefined
+      ? undefined
+      : { byProject: vi.fn(async () => (opts.gitlabBinding ? binding(opts.gitlabBinding) : null)) }
+  const gitlabWebhookSecrets = { get: vi.fn(async () => 'whsec_example') } as unknown as GitlabWebhookSecretStore
   return {
-    svc: new HookService(hooks, secrets, agents, relayControl, undefined, installations, opts.appSlug),
+    svc: new HookService(
+      hooks,
+      secrets,
+      agents,
+      relayControl,
+      undefined,
+      installations,
+      opts.appSlug,
+      undefined,
+      gitlabBindings,
+      gitlabWebhookSecrets
+    ),
     assigns,
     removes
   }
@@ -316,5 +356,16 @@ describe('HookService.broadcast', () => {
     await off.svc.broadcast(hook({ enabled: false }))
     expect(off.assigns).toHaveLength(0)
     expect(off.removes).toEqual([HOOK])
+  })
+})
+
+describe('HookService.compile — gitlab', () => {
+  it('projects the §12.1 veto set: every account bound to the project, the binding account today', async () => {
+    const { svc } = make({ gitlabBinding: {} })
+    const rule = await svc.compile(
+      hook({ kind: 'gitlab', sessionMode: 'perThread', urlToken: null, repoId: 4455667n, events: ['issues:*'] })
+    )
+    expect(rule?.gitlab?.serviceAccountUserId).toBe('9042')
+    expect(rule?.gitlab?.boundServiceAccountUserIds).toEqual(['9042'])
   })
 })

--- a/packages/control-plane/src/hooks/hook.service.ts
+++ b/packages/control-plane/src/hooks/hook.service.ts
@@ -162,6 +162,8 @@ export class HookService {
           agentName: agent.name,
           serviceAccountUserId: binding.serviceAccountUserId.toString(),
           serviceAccountUsername: binding.serviceAccountUsername,
+          // §12.1 veto set — per-agent accounts (§7.2) append here without another wire change.
+          boundServiceAccountUserIds: [...new Set([binding.serviceAccountUserId.toString()])],
           signingToken
         }
       }

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -196,6 +196,8 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
         expect(rule.gitlab?.projectId).toBe(PROJECT.toString())
         expect(rule.gitlab?.sessionKeyPrefix).toBe(`gitlab:${PROJECT}`)
         expect(rule.gitlab?.serviceAccountUsername).toBe(`agentconnect-p${PROJECT}`)
+        // §12.1 veto set: every account bound to the project, one per-project account today.
+        expect(rule.gitlab?.boundServiceAccountUserIds).toEqual([rule.gitlab!.serviceAccountUserId])
         expect(rule.gitlab?.signingToken).toBe(webhook.token)
         expect(rule.gitlab?.events).toEqual(['issues:*', 'merge_request:opened'])
         // The value never reaches the rule; the empty array only keeps an older relay decoding.

--- a/packages/protocol/src/frames/relay-cp.test.ts
+++ b/packages/protocol/src/frames/relay-cp.test.ts
@@ -786,6 +786,40 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
     if (decoded.success) expect(decoded.data.gitlab?.labelFilter).toEqual(['bug'])
   })
 
+  it('the §12.1 veto set is an additive optional member on a gitlab rule (§17.3)', () => {
+    const gitlab = {
+      hookId: '88888888-8888-4888-8888-888888888888',
+      agentId: AGENT_ID,
+      daemonId: DAEMON_ID,
+      kind: 'gitlab' as const,
+      sessionMode: 'perThread' as const,
+      gitlab: {
+        projectId: '4210',
+        projectPath: 'example-group/example-project',
+        sessionKeyPrefix: 'gitlab:4210',
+        events: ['merge_request:*'],
+        mentionOnly: false,
+        serviceAccountUserId: '99',
+        serviceAccountUsername: 'agentconnect-p4210',
+        signingToken: 'whsec_example'
+      }
+    }
+    // Absent: the shape a Control Plane predating the field sends; the relay vetoes one ID.
+    const without = RcHookAssign.safeParse(gitlab)
+    expect(without.success).toBe(true)
+    if (without.success) expect(without.data.gitlab?.boundServiceAccountUserIds).toBeUndefined()
+    // Present: every managed account bound to the project, including the named one.
+    const withSet = RcHookAssign.safeParse({
+      ...gitlab,
+      gitlab: { ...gitlab.gitlab, boundServiceAccountUserIds: ['99', '100'] }
+    })
+    expect(withSet.success).toBe(true)
+    if (withSet.success) expect(withSet.data.gitlab?.boundServiceAccountUserIds).toEqual(['99', '100'])
+    // Every member is a positive numeric provider ID, exactly like the named account.
+    const bad = { ...gitlab, gitlab: { ...gitlab.gitlab, boundServiceAccountUserIds: ['0'] } }
+    expect(RcHookAssign.safeParse(bad).success).toBe(false)
+  })
+
   it('rc/hook-rerun carries the Console rerun fence and its live subject (§16.1)', () => {
     const HOOK_ID = '99999999-9999-4999-8999-999999999999'
     const base = {

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -378,6 +378,9 @@ export const RcHookAssign = z
         // mention/reviewer targets.
         serviceAccountUserId: z.string().regex(/^[1-9]\d*$/),
         serviceAccountUsername: z.string().min(1),
+        // §12.1 veto set: every managed account bound to the project, including the one above.
+        // Additive optional (§17.3) — a rule without it vetoes only the account it names.
+        boundServiceAccountUserIds: z.array(z.string().regex(/^[1-9]\d*$/)).optional(),
         // whsec_ Standard Webhooks signing key for §11.2 verification.
         signingToken: z.string().min(1)
       })

--- a/packages/relay/src/hooks/gitlab-ingress.test.ts
+++ b/packages/relay/src/hooks/gitlab-ingress.test.ts
@@ -29,6 +29,7 @@ const AGENT = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
 const DAEMON = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
 const PROJECT = 4455667
 const SA_USER = 9042
+const SIBLING_SA_USER = 9043
 const KEY = randomBytes(32)
 const TOKEN = `whsec_${KEY.toString('base64')}`
 
@@ -309,6 +310,37 @@ describe('gitlab ingress', () => {
     expect((h.sent[0] as RdMsgHook).event).toBe('merge_request:synchronize')
   })
 
+  it('§12.1: a SIBLING bound account is vetoed even for a same-project MR revision', async () => {
+    const vetoSet = { boundServiceAccountUserIds: [String(SA_USER), String(SIBLING_SA_USER)] }
+    h.table.upsert(rule({}, { events: ['merge_request:*'], commentFamilies: ['merge_request'], ...vetoSet }))
+    const siblingNote = notePayload({
+      user: { id: SIBLING_SA_USER, username: 'agentconnect-a2-g7' },
+      issue: undefined,
+      merge_request: { iid: 77, author_id: 7001 },
+      object_attributes: { noteable_type: 'MergeRequest' }
+    })
+    expect((await post(h, siblingNote)).statusCode).toBe(202)
+    const siblingRevision = mrPayload({
+      object_attributes: { action: 'update', oldrev: 'c'.repeat(40), author_id: SIBLING_SA_USER },
+      user: { id: SIBLING_SA_USER, username: 'agentconnect-a2-g7' }
+    })
+    expect((await post(h, siblingRevision, { 'webhook-id': 'msg_delivery_2' })).statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toHaveLength(0)
+    expect(h.sent).toHaveLength(0)
+
+    // The rule's OWN account keeps the internal-CI exception under the same veto set.
+    const ownRevision = mrPayload({
+      object_attributes: { action: 'update', oldrev: 'c'.repeat(40), author_id: SA_USER },
+      user: { id: SA_USER, username: `agentconnect-p${PROJECT}` }
+    })
+    expect((await post(h, ownRevision, { 'webhook-id': 'msg_delivery_3' })).statusCode).toBe(202)
+    await flush()
+    expect(h.authzRequests).toHaveLength(0)
+    expect(h.sent).toHaveLength(1)
+    expect((h.sent[0] as RdMsgHook).event).toBe('merge_request:synchronize')
+  })
+
   it('assigning the service account as reviewer is the explicit start path', async () => {
     h.table.upsert(rule({}, { events: ['merge_request:opened'] }))
     const assigned = mrPayload({
@@ -473,6 +505,24 @@ describe('gitlab ingress', () => {
     expect(gitlabRuleVerdict(rule({}, { labelFilter: undefined }), ctx)).toBe('needs-authz')
     expect(gitlabRuleVerdict(rule({}, { events: ['merge_request:*'] }), ctx)).toBe('no-match')
     expect(gitlabRuleVerdict(rule({ kind: 'github' }), ctx)).toBe('no-match')
+  })
+
+  it('§12.1: the veto set widens the author veto; a rule without one vetoes exactly its own account', () => {
+    const siblingIssue = normalizeGitlabEvent(
+      issuePayload({ user: { id: SIBLING_SA_USER, username: 'agentconnect-a2-g7' } }) as never
+    )!
+    const vetoSet = { boundServiceAccountUserIds: [String(SA_USER), String(SIBLING_SA_USER)] }
+    expect(gitlabRuleVerdict(rule({}, vetoSet), siblingIssue)).toBe('no-match')
+    // A rule the Control Plane compiled before the field vetoes only the ID it names.
+    expect(gitlabRuleVerdict(rule(), siblingIssue)).toBe('needs-authz')
+    expect(gitlabRuleVerdict(rule({}, { boundServiceAccountUserIds: [String(SA_USER)] }), siblingIssue)).toBe(
+      'needs-authz'
+    )
+    const ownIssue = normalizeGitlabEvent(
+      issuePayload({ user: { id: SA_USER, username: `agentconnect-p${PROJECT}` } }) as never
+    )!
+    expect(gitlabRuleVerdict(rule(), ownIssue)).toBe('no-match')
+    expect(gitlabRuleVerdict(rule({}, vetoSet), ownIssue)).toBe('no-match')
   })
 })
 

--- a/packages/relay/src/hooks/gitlab-ingress.ts
+++ b/packages/relay/src/hooks/gitlab-ingress.ts
@@ -276,8 +276,14 @@ export function gitlabMentionCandidates(rules: RcHookAssign[], body: string | un
 
 export type GitlabRuleVerdict = 'no-match' | 'trusted' | 'needs-authz'
 
-/** The §12.1 internal lane: a same-project MR revision authored by the managed
- *  service account still enters review; everything else it authors is vetoed. */
+/** §12.1 veto set: every account bound to the project; an older rule names only one. */
+function gitlabVetoedAuthor(rule: RcHookAssign, actorId: string | undefined): boolean {
+  const gitlab = rule.gitlab
+  if (!gitlab || actorId === undefined) return false
+  return actorId === gitlab.serviceAccountUserId || (gitlab.boundServiceAccountUserIds ?? []).includes(actorId)
+}
+
+/** §12.1 internal lane: only a same-project MR revision by the account THIS rule names enters review. */
 function isInternalServiceAccountRevision(rule: RcHookAssign, ctx: GitlabMatchCtx): boolean {
   return (
     (ctx.eventAction === 'merge_request:opened' || ctx.eventAction === 'merge_request:synchronize') &&
@@ -295,12 +301,13 @@ function isInternalServiceAccountRevision(rule: RcHookAssign, ctx: GitlabMatchCt
  */
 export function gitlabRuleVerdict(rule: RcHookAssign, ctx: GitlabMatchCtx): GitlabRuleVerdict {
   if (rule.kind !== 'gitlab' || !rule.gitlab) return 'no-match'
-  // §12.1: events authored BY the managed service account never re-trigger,
-  // except its own same-project MR revisions (the internal CI lane). Notes it
-  // authors are always rejected (the note author IS the actor).
-  const actorIsServiceAccount = ctx.actorId !== undefined && ctx.actorId === rule.gitlab.serviceAccountUserId
-  if (actorIsServiceAccount && !isInternalServiceAccountRevision(rule, ctx)) return 'no-match'
-  if (ctx.family === 'note' && actorIsServiceAccount) return 'no-match'
+  // §12.1: any bound account's events never re-trigger, except this rule's own same-project MR revisions.
+  // A note a bound account authors is always rejected (the note author IS the actor).
+  const actorIsBoundAccount = gitlabVetoedAuthor(rule, ctx.actorId)
+  const internalRevision =
+    ctx.actorId === rule.gitlab.serviceAccountUserId && isInternalServiceAccountRevision(rule, ctx)
+  if (actorIsBoundAccount && !internalRevision) return 'no-match'
+  if (ctx.family === 'note' && actorIsBoundAccount) return 'no-match'
   // §12.2 explicit start path: assigning the SA as reviewer bypasses cadence,
   // label, and mention filters — but only for this rule's SA, and only after
   // the live membership gate authorizes the assigning actor.
@@ -339,7 +346,7 @@ export function gitlabRuleVerdict(rule: RcHookAssign, ctx: GitlabMatchCtx): Gitl
   // §12.2: pushes and the SA's own same-project revisions stay relay-trusted;
   // every issue/MR lifecycle event and comment resolves live membership.
   if (ctx.family === 'push') return 'trusted'
-  if (isInternalServiceAccountRevision(rule, ctx) && actorIsServiceAccount) return 'trusted'
+  if (internalRevision) return 'trusted'
   return 'needs-authz'
 }
 


### PR DESCRIPTION
First slice of M8 (per-agent runtime identity) from `docs/designs/gitlab-com-integration.md`: protocol, relay, and Control Plane rule projection. No daemon code, account tables, credentials, or console in this change.

## Why

The compiled GitLab rule names one service-account user ID, so the §12.1 loop guard can only reject events authored by that single account. §7.2 gives each agent its own GitLab account, which puts several managed accounts on one project — one agent's note or merge request must never wake a sibling agent's hook. §7.2 requires the widened veto to ship *before* anything posts as an agent account, so this slice lands first.

## What

**Protocol** — `RcHookAssign.gitlab` gains `boundServiceAccountUserIds`, an optional array of positive numeric user IDs: the veto set of every managed account bound to the project, including the one `serviceAccountUserId` names. It is an additive optional member under §17.3. The rule schema is not `.strict()`, so a relay that predates the field decodes a widened rule and keeps vetoing only the ID it knows; no enum or union value changes, so no feature string is added.

**Relay** (`packages/relay/src/hooks/gitlab-ingress.ts`) — the author veto now rejects an event whose actor is any member of the set. The §12.1 exception narrows to the rule's own identity: a same-project merge-request revision authored by `serviceAccountUserId` still enters review as the internal lane, while every other member stays vetoed even for revisions. Notes authored by any member are always rejected; system notes are already dropped at normalization. A rule without the field behaves exactly as before.

**Control Plane** (`HookService.compile`) — the projector fills the set from the binding's account. Only per-project accounts exist today, so it holds exactly one ID, but it is built as a set so per-agent accounts append without another wire change.

## Tests

- Relay: a sibling account's note and its same-project merge-request revision are both vetoed, while the rule's own revision is still admitted under the same veto set; a pure-verdict case pins that a rule carrying no veto set vetoes exactly the ID it names.
- Control Plane: a `compile` unit test asserts the projected set contains the binding account, plus an assertion on the compiled rule in the gitlab hooks route integration test.
- Protocol: round-trip with the field absent, with a multi-member set, and a rejection for a non-positive member.

Verified with `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm --filter @agentconnect.md/protocol test`, `pnpm --filter @agentconnect.md/relay test`, `pnpm --filter @agentconnect.md/control-plane test:unit`, and `test:int` (111 files, 1647 tests) — all green. Both new relay tests were confirmed to fail against the pre-change veto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
