### PR TITLE
feat(control-plane): give GitLab hooks the review and reporting axes

### DIFF
--- a/packages/control-plane/src/codehost/note-projection.service.test.ts
+++ b/packages/control-plane/src/codehost/note-projection.service.test.ts
@@ -32,14 +32,14 @@ const orgId = OrgId('org_1')
 const OTHER_HOOK = '00000000-0000-4000-8000-00000000000f'
 const HEAD = 'a'.repeat(40)
 
-// The tuple a gitlab rule actually compiles to today (hook.service.ts): the Checks-axis knobs are
-// forced off and the note projection is its own transport.
+// The tuple a gitlab hook that opted into run reporting compiles to. `reportingMode` is the
+// axis that owns this surface — the §16 note IS the run report — so the fixture must carry it.
 const snapshot = {
   configRevision: '3',
   dispatchRevision: '5',
   dispatchDaemonId: daemonId,
   reviewPolicy: 'off' as const,
-  reportingMode: 'off' as const,
+  reportingMode: 'check' as const,
   gateMode: 'informational' as const
 }
 
@@ -97,7 +97,7 @@ function projection(overrides: Partial<CodeHostRunProjectionRecord> = {}): CodeH
     dispatchRevision: 5n,
     dispatchDaemonId: daemonId,
     reviewPolicySnapshot: 'off',
-    reportingModeSnapshot: 'off',
+    reportingModeSnapshot: 'check',
     gateModeSnapshot: 'informational',
     leaseOwner: null,
     leaseUntil: null,
@@ -295,6 +295,30 @@ describe('CodeHostNoteProjectionService', () => {
     expect(projections.upsert).not.toHaveBeenCalled()
     await service.afterDeliveryFailed(edge({ reason: 'review_request_required' }))
     expect(projections.upsert.mock.calls[0]![0].desiredState).toBe('skipped')
+  })
+
+  it('opens no projection at all while the hook reports nothing', async () => {
+    // `reportingMode` gates this surface exactly as it gates a GitHub Check: the note IS the
+    // run report, so `off` means no generation, no ledger row, and no daemon frame.
+    const { service, projections, sent } = harness()
+    const silent = { ...snapshot, reportingMode: 'off' as const }
+    await service.afterAccepted(edge({ snapshot: silent }))
+    await service.afterStart(edge({ snapshot: silent }))
+    await service.afterReport(edge({ snapshot: silent, state: 'completed' }))
+    await service.afterDeliveryFailed(edge({ snapshot: silent, reason: 'review_request_required' }))
+    expect(projections.upsert).not.toHaveBeenCalled()
+    expect(projections.supersede).not.toHaveBeenCalled()
+    expect(sent).toEqual([])
+  })
+
+  it('still settles a terminal edge whose accepted snapshot reports, so the gate strands nothing', async () => {
+    // The gate reads the edge's ACCEPTED tuple, never the live hook, so an open generation keeps
+    // converging to its terminal state even while the hook is being edited underneath it.
+    const { service, projections } = harness()
+    await service.afterAccepted(edge())
+    expect(projections.upsert).toHaveBeenCalledTimes(1)
+    await service.afterReport(edge({ state: 'completed' }))
+    expect(projections.upsert).toHaveBeenCalledTimes(2)
   })
 
   it('settles a written result on the reporting daemon and persists the note id', async () => {

--- a/packages/control-plane/src/codehost/note-projection.service.test.ts
+++ b/packages/control-plane/src/codehost/note-projection.service.test.ts
@@ -60,7 +60,6 @@ function edge(overrides: Partial<NoteProjectionEdge> = {}): NoteProjectionEdge {
     state: 'queued',
     gitlab: gitlab(),
     snapshot,
-    projectionEpoch: 1n,
     at: new Date(NOW),
     ...overrides
   }
@@ -123,6 +122,7 @@ function harness(
     beginWrite?: boolean
     setDesired?: boolean
     retiredOwner?: boolean
+    runEpoch?: bigint | null
   } = {}
 ) {
   const row = options.row ?? projection()
@@ -145,8 +145,13 @@ function harness(
     failWrite: ReturnType<typeof vi.fn>
     get: ReturnType<typeof vi.fn>
   }
+  // The accepted run, whose epoch the projection must spend even after the live hook moves on.
+  const runs = {
+    getRun: vi.fn(async () => ({ projectionEpoch: options.runEpoch === undefined ? 1n : options.runEpoch }))
+  }
   const service = new CodeHostNoteProjectionService({
     projections,
+    runs: runs as never,
     agents: { getUnscoped: vi.fn(async () => agent) },
     bindings: { byProject: vi.fn(async () => ({ credentialEpoch: 2n })) } as never,
     orgs: { slugById: vi.fn(async () => 'acme') },
@@ -157,7 +162,7 @@ function harness(
       send: (id, desired, org) => sent.push({ daemonId: id, desired, orgId: org })
     }
   })
-  return { service, projections, sent, row }
+  return { service, projections, sent, row, runs }
 }
 
 describe('reportedNoteState (gitlab-com-integration.md §16)', () => {
@@ -249,9 +254,10 @@ describe('CodeHostNoteProjectionService', () => {
   })
 
   it('leaves the row pending when the owning daemon is offline', async () => {
-    const { service, projections, sent } = harness({ features: undefined })
+    const { projections, sent, runs } = harness({ features: undefined })
     const offline = new CodeHostNoteProjectionService({
       projections,
+      runs: runs as never,
       agents: { getUnscoped: vi.fn(async () => agent) },
       bindings: { byProject: vi.fn(async () => ({ credentialEpoch: 2n })) } as never,
       clock: new FakeClock(NOW),
@@ -311,14 +317,29 @@ describe('CodeHostNoteProjectionService', () => {
     expect(sent).toEqual([])
   })
 
-  it('still settles a terminal edge whose accepted snapshot reports, so the gate strands nothing', async () => {
-    // The gate reads the edge's ACCEPTED tuple, never the live hook, so an open generation keeps
-    // converging to its terminal state even while the hook is being edited underneath it.
-    const { service, projections } = harness()
+  it('settles the row acceptance opened when the hook is edited mid-run, instead of forking a new one', async () => {
+    // A check → off PUT mid-run advances the LIVE hook's epoch while the accepted run keeps its own.
+    // Spending the live one would strand the queued note and post a second terminal one.
+    const ACCEPTED_EPOCH = 1n
+    const EDITED_HOOK_EPOCH = 2n
+    const { service, projections, runs } = harness({ runEpoch: ACCEPTED_EPOCH })
     await service.afterAccepted(edge())
-    expect(projections.upsert).toHaveBeenCalledTimes(1)
+    // The edit lands here: it moves the hook definition, never the accepted run.
     await service.afterReport(edge({ state: 'completed' }))
-    expect(projections.upsert).toHaveBeenCalledTimes(2)
+
+    const epochs = projections.upsert.mock.calls.map(([input]) => input.projectionEpoch)
+    expect(epochs).toEqual([ACCEPTED_EPOCH, ACCEPTED_EPOCH])
+    expect(epochs).not.toContain(EDITED_HOOK_EPOCH)
+    // Both edges resolved that epoch from the accepted run, keyed by the delivery they belong to.
+    expect(runs.getRun).toHaveBeenCalledTimes(2)
+    expect(runs.getRun).toHaveBeenLastCalledWith(hookId, 'delivery-1')
+  })
+
+  it('opens nothing when the accepted run carries no epoch, so a retired key is never revived', async () => {
+    const { service, projections } = harness({ runEpoch: null })
+    await service.afterAccepted(edge())
+    expect(projections.upsert).not.toHaveBeenCalled()
+    expect(projections.supersede).not.toHaveBeenCalled()
   })
 
   it('settles a written result on the reporting daemon and persists the note id', async () => {

--- a/packages/control-plane/src/codehost/note-projection.service.ts
+++ b/packages/control-plane/src/codehost/note-projection.service.ts
@@ -211,9 +211,10 @@ export class CodeHostNoteProjectionService {
     if (!subject) return
     const snapshot = completeSnapshot(edge.snapshot)
     // A partially rolled-out dispatch tuple cannot authorize an effect, so it cannot open a
-    // projection either — absence fails closed rather than being filled with a revision. The
-    // Checks-axis members are carried as fence, not evaluated: a gitlab rule forces them off.
+    // projection either — absence fails closed rather than being filled with a revision.
     if (!snapshot) return
+    // The §16 note IS the run report, so reporting `off` opens nothing — judged from the ACCEPTED snapshot.
+    if (snapshot.reportingMode === 'off') return
     const agent = await this.deps.agents.getUnscoped(AgentId(edge.agentId))
     if (!agent || agent.orgId !== edge.orgId) return
     const binding = await this.deps.bindings.byProject(edge.orgId, subject.projectId)

--- a/packages/control-plane/src/codehost/note-projection.service.ts
+++ b/packages/control-plane/src/codehost/note-projection.service.ts
@@ -33,6 +33,7 @@ import type {
   CodeHostRunProjectionRecord,
   CodeHostRunProjectionRepo,
   GitlabProjectBindingRepo,
+  HookRepo,
   OrgRepo
 } from '../persistence/ports.js'
 
@@ -94,8 +95,6 @@ export interface NoteProjectionEdge {
   sessionId?: string
   gitlab: GitlabHookMetadata | undefined
   snapshot: OptionalHookConfigSnapshot
-  /** Hook-definition epoch: retarget / disable / re-enable retires the old projection key. */
-  projectionEpoch: bigint
   at: Date
 }
 
@@ -116,6 +115,8 @@ export interface CodeHostNoteProjectionLog {
 
 export interface CodeHostNoteProjectionDeps {
   projections: CodeHostRunProjectionRepo
+  /** The ACCEPTED run behind an edge — the only authority for its projection epoch. */
+  runs: Pick<HookRepo, 'getRun'>
   agents: Pick<AgentRepo, 'getUnscoped'>
   bindings: Pick<GitlabProjectBindingRepo, 'byProject'>
   orgs?: Pick<OrgRepo, 'slugById'>
@@ -215,6 +216,10 @@ export class CodeHostNoteProjectionService {
     if (!snapshot) return
     // The §16 note IS the run report, so reporting `off` opens nothing — judged from the ACCEPTED snapshot.
     if (snapshot.reportingMode === 'off') return
+    // The ACCEPTED run's epoch, never the live hook's: an edit mid-run would otherwise fork a new row.
+    const run = await this.deps.runs.getRun(HookId(edge.hookId), edge.deliveryKey)
+    // No epoch means the run's fence missed at delivery and its key is retired — fail closed.
+    if (!run || run.projectionEpoch === null) return
     const agent = await this.deps.agents.getUnscoped(AgentId(edge.agentId))
     if (!agent || agent.orgId !== edge.orgId) return
     const binding = await this.deps.bindings.byProject(edge.orgId, subject.projectId)
@@ -237,7 +242,7 @@ export class CodeHostNoteProjectionService {
       orgId: edge.orgId,
       agentId: AgentId(edge.agentId),
       agentName: agent.name,
-      projectionEpoch: edge.projectionEpoch,
+      projectionEpoch: run.projectionEpoch,
       desiredState: edge.state,
       currentDeliveryKey: edge.deliveryKey,
       currentRunAt: edge.at,

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1054,6 +1054,7 @@ export function buildContainer(
   const codeHostNoteProjection = gitlab
     ? new CodeHostNoteProjectionService({
         projections: new PgCodeHostRunProjectionRepo(prisma),
+        runs: repos.hook,
         agents: repos.agent,
         bindings: repos.gitlabProjectBinding,
         orgs: repos.org,
@@ -1936,7 +1937,6 @@ export function buildContainer(
             reason: report.reason ?? null,
             gitlab: report.gitlab,
             snapshot: report,
-            projectionEpoch: hook.projectionEpoch,
             at: firedAt
           }
           if (report.status === 'accepted') await codeHostNoteProjection.afterAccepted(edge)

--- a/packages/control-plane/src/hooks/hook.service.ts
+++ b/packages/control-plane/src/hooks/hook.service.ts
@@ -92,8 +92,10 @@ export class HookService {
             configRevision: hook.configRevision.toString(),
             dispatchRevision: hook.dispatchRevision.toString(),
             dispatchDaemonId: agentDaemonId,
-            reviewPolicy: hook.kind === 'github' ? hook.reviewPolicy : ('off' as const),
-            reportingMode: hook.kind === 'github' ? hook.reportingMode : ('off' as const),
+            // Both code hosts carry their own effect axes; a generic webhook has none.
+            reviewPolicy: hook.kind === 'webhook' ? ('off' as const) : hook.reviewPolicy,
+            reportingMode: hook.kind === 'webhook' ? ('off' as const) : hook.reportingMode,
+            // Only github has a gate axis; GitLab has no required-gate surface and webhooks none at all.
             gateMode: hook.kind === 'github' ? hook.gateMode : ('informational' as const)
           }
         : ({ reviewPolicy: 'off', reportingMode: 'off', gateMode: 'informational' } as const)

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2422,8 +2422,10 @@ export const CreateGitlabHookBody = HookBodyBase.extend({
   events: z.array(z.string().regex(GitlabHookEventPattern)).min(1).max(20),
   // Note events for the selected subject families (§12); empty = no comments.
   commentFamilies: z.array(GitlabCommentFamily).max(2).default([]),
-  mentionOnly: z.boolean().default(false)
-  // No review/reporting knobs yet: the M6 review slice adds them; rows default off.
+  mentionOnly: z.boolean().default(false),
+  // The two effect axes github carries; `check` is the §16 run note. No gateMode — GitLab has no required gate.
+  reviewPolicy: HookReviewPolicyEnum.default('off'),
+  reportingMode: HookReportingModeEnum.default('off')
 })
 
 export const CreateHookBody = z.discriminatedUnion('kind', [
@@ -2445,7 +2447,10 @@ export const UpdateHookBody = z.union([
   CreateGitlabHookBody.extend({
     enabled: z.boolean().optional(),
     commentFamilies: z.array(GitlabCommentFamily).max(2).optional(),
-    mentionOnly: z.boolean().optional()
+    mentionOnly: z.boolean().optional(),
+    // Optional on whole-definition PUT so a client predating these axes preserves the stored policy.
+    reviewPolicy: HookReviewPolicyEnum.optional(),
+    reportingMode: HookReportingModeEnum.optional()
   }),
   // mentionOnly OPTIONAL on update (unlike create's default-false): a pre-P3
   // client echoing a hook back must not silently downgrade mention mode — the

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -266,13 +266,15 @@ export function hookRoutes(deps: HttpDeps) {
       return (await explicitlyGranted()) ? { ok: true } : denied
     }
 
-    type GithubEffectConfig = {
+    // The two effect axes both code hosts carry; github adds its own gate axis on top.
+    type CodeHostEffectConfig = {
       reviewPolicy: HookRecord['reviewPolicy']
       reportingMode: HookRecord['reportingMode']
-      gateMode: HookRecord['gateMode']
     }
 
-    type GithubEffectDenial = { status: 409 | 429 | 502; message: string }
+    type GithubEffectConfig = CodeHostEffectConfig & { gateMode: HookRecord['gateMode'] }
+
+    type CodeHostEffectDenial = { status: 409 | 429 | 502; message: string }
 
     /** R1/R2a action-time rules are also enforced at configuration time so the
      * editor cannot save a mode that is guaranteed to fail. Runtime still
@@ -282,8 +284,8 @@ export function hookRoutes(deps: HttpDeps) {
       repoId: bigint,
       repoFullName: string,
       cfg: GithubEffectConfig
-    ): Promise<GithubEffectDenial | null> => {
-      const misconfigured = (message: string): GithubEffectDenial => ({ status: 409, message })
+    ): Promise<CodeHostEffectDenial | null> => {
+      const misconfigured = (message: string): CodeHostEffectDenial => ({ status: 409, message })
       if (cfg.gateMode === 'required') return misconfigured('required review gates are not available until R2b')
       if (cfg.reportingMode === 'status') return misconfigured('commit status reporting is not available until R3')
       if (cfg.reviewPolicy === 'off' && cfg.reportingMode === 'off') return null
@@ -322,6 +324,27 @@ export function hookRoutes(deps: HttpDeps) {
         const pullRequests = resolved.installation.permissions?.pull_requests
         if (pullRequests !== 'read' && pullRequests !== 'write') {
           return misconfigured('this GitHub App installation has not accepted the Pull requests read permission')
+        }
+      }
+      return null
+    }
+
+    // The GitLab counterpart. No repository-access clamp: the writer for BOTH effects is the
+    // project's service account under its provisioned role, not the agent's git grant, so the
+    // only configuration-time fact to check is that the binding actually has that writer.
+    const validateGitlabEffects = (
+      binding: { serviceAccountUserId: bigint | null; projectPath: string },
+      cfg: CodeHostEffectConfig
+    ): CodeHostEffectDenial | null => {
+      // §16.2: GitLab commit statuses are external CI jobs, deliberately not this transport.
+      if (cfg.reportingMode === 'status') {
+        return { status: 409, message: 'commit status reporting is not available for GitLab projects' }
+      }
+      if (cfg.reviewPolicy === 'off' && cfg.reportingMode === 'off') return null
+      if (binding.serviceAccountUserId === null) {
+        return {
+          status: 409,
+          message: `${binding.projectPath} has no project bot yet — reviews and run reporting need one`
         }
       }
       return null
@@ -415,6 +438,11 @@ export function hookRoutes(deps: HttpDeps) {
                       message: `this agent already watches ${binding.projectPath}`
                     }
                   }
+                  const effectError = validateGitlabEffects(binding, {
+                    reviewPolicy: req.body.kind === 'gitlab' ? req.body.reviewPolicy : 'off',
+                    reportingMode: req.body.kind === 'gitlab' ? req.body.reportingMode : 'off'
+                  })
+                  if (effectError) return { ok: false as const, ...effectError }
                   return {
                     // gitlab is perThread by definition, like github (§12.3).
                     sessionMode: 'perThread' as const,
@@ -486,8 +514,10 @@ export function hookRoutes(deps: HttpDeps) {
             ? {
                 events: req.body.events,
                 commentFamilies: req.body.commentFamilies,
-                mentionOnly: req.body.mentionOnly
-                // Review/reporting stay at their off defaults until the M6 slice.
+                mentionOnly: req.body.mentionOnly,
+                reviewPolicy: req.body.reviewPolicy,
+                reportingMode: req.body.reportingMode
+                // No gateMode: GitLab has no required-gate surface, so the row stays informational.
               }
             : {}),
           targetPlatform: target.targetPlatform,
@@ -742,13 +772,26 @@ export function hookRoutes(deps: HttpDeps) {
               message: `this agent already watches ${binding.projectPath}`
             })
           }
+          const effectConfig = {
+            reviewPolicy: req.body.reviewPolicy ?? existing.reviewPolicy,
+            reportingMode: req.body.reportingMode ?? existing.reportingMode
+          }
+          const effectError = validateGitlabEffects(binding, effectConfig)
+          if (effectError) {
+            return reply.code(effectError.status).send({
+              error: ERROR_NAMES[effectError.status],
+              statusCode: effectError.status,
+              message: effectError.message
+            })
+          }
           kindFields = {
             sessionMode: 'perThread',
             repoId: projectId,
             repoFullName: binding.projectPath,
             events: req.body.events,
             commentFamilies: req.body.commentFamilies ?? existing.commentFamilies,
-            mentionOnly: req.body.mentionOnly ?? existing.mentionOnly
+            mentionOnly: req.body.mentionOnly ?? existing.mentionOnly,
+            ...effectConfig
           }
         } else {
           kindFields = { sessionMode: req.body.sessionMode }

--- a/packages/control-plane/src/ws/handlers/hook-report.ts
+++ b/packages/control-plane/src/ws/handlers/hook-report.ts
@@ -118,7 +118,6 @@ export const handleHookReport: Handler = async (frame, conn, deps) => {
         ...(p.sessionId ? { sessionId: p.sessionId } : {}),
         gitlab: p.gitlab,
         snapshot: p,
-        projectionEpoch: hook.projectionEpoch,
         at: completedAt
       })
     }

--- a/packages/control-plane/src/ws/handlers/hook-start.test.ts
+++ b/packages/control-plane/src/ws/handlers/hook-start.test.ts
@@ -90,7 +90,6 @@ describe('hook/start provider one-of (gitlab-com-integration.md §17.2)', () => 
       sessionId: 'acp-gitlab-1',
       gitlab,
       snapshot: frame.payload,
-      projectionEpoch: 3n,
       at: new Date(NOW)
     })
     expect(conn.replyTo).toHaveBeenCalledWith(frame, 'hook/start/ok', { accepted: true })

--- a/packages/control-plane/src/ws/handlers/hook-start.ts
+++ b/packages/control-plane/src/ws/handlers/hook-start.ts
@@ -38,7 +38,6 @@ export const handleHookStart: Handler = async (frame, conn, deps) => {
         ...(frame.payload.sessionId ? { sessionId: frame.payload.sessionId } : {}),
         gitlab: frame.payload.gitlab,
         snapshot: frame.payload,
-        projectionEpoch: hook.projectionEpoch,
         at: new Date(deps.clock.now())
       })
       conn.replyTo(frame, 'hook/start/ok', { accepted: true })

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -125,7 +125,10 @@ async function harness(options: FakeGitlabOptions = {}) {
   await seedDaemon(prisma, daemonId)
   const agentId = randomUUID()
   await seedAgent(prisma, agentId, { daemonId })
-  return { fake, a: running, hookRepo, bindings, provisioner, binding, agentId }
+  // A second agent, so a test needing two hooks on one project clears the per-agent fence.
+  const secondAgentId = randomUUID()
+  await seedAgent(prisma, secondAgentId, { daemonId })
+  return { fake, a: running, hookRepo, bindings, provisioner, binding, agentId, secondAgentId }
 }
 
 /** A stand-in relay socket. `answer` decides how it replies to a correlated
@@ -238,6 +241,83 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
         expect(h.fake.webhooks.size).toBe(0)
         // The binding record trails the provider delete inside the same kick.
         expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))?.webhookId).toBeNull()
+      },
+      { timeout: 20_000 }
+    )
+  })
+
+  it('round-trips the review and reporting axes, defaulting both off', async () => {
+    const h = await harness()
+    // Default: a body that names neither axis stores the off pair, exactly like github's.
+    const plain = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(plain.statusCode).toBe(200)
+    const plainRow = (await h.hookRepo.get(OrgId(DEFAULT_ORG_ID), HookId((plain.json() as { id: string }).id)))!
+    expect(plainRow.reviewPolicy).toBe('off')
+    expect(plainRow.reportingMode).toBe('off')
+    expect(plainRow.gateMode).toBe('informational')
+    expect((plain.json() as { reviewPolicy: string }).reviewPolicy).toBe('off')
+
+    // A second agent so the one-hook-per-(agent, project) fence does not fire.
+    const second = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: glBody(h.secondAgentId, { reviewPolicy: 'full', reportingMode: 'check' })
+    })
+    expect(second.statusCode).toBe(200)
+    const hookId = (second.json() as { id: string }).id
+    const row = (await h.hookRepo.get(OrgId(DEFAULT_ORG_ID), HookId(hookId)))!
+    expect(row.reviewPolicy).toBe('full')
+    expect(row.reportingMode).toBe('check')
+    expect(second.json()).toMatchObject({ reviewPolicy: 'full', reportingMode: 'check' })
+
+    // PUT moves one axis and preserves the other; omitting both keeps the stored pair.
+    const lowered = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/hooks/${hookId}`,
+      payload: glBody(h.secondAgentId, { reviewPolicy: 'comment', reportingMode: 'check' })
+    })
+    expect(lowered.statusCode).toBe(200)
+    expect((await h.hookRepo.get(OrgId(DEFAULT_ORG_ID), HookId(hookId)))!.reviewPolicy).toBe('comment')
+
+    const echoed = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/hooks/${hookId}`,
+      payload: glBody(h.secondAgentId)
+    })
+    expect(echoed.statusCode).toBe(200)
+    const preserved = (await h.hookRepo.get(OrgId(DEFAULT_ORG_ID), HookId(hookId)))!
+    expect(preserved.reviewPolicy).toBe('comment')
+    expect(preserved.reportingMode).toBe('check')
+  })
+
+  it('refuses commit status reporting, which GitLab does not serve (§16.2)', async () => {
+    const h = await harness()
+    const res = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: glBody(h.agentId, { reportingMode: 'status' })
+    })
+    expect(res.statusCode).toBe(409)
+    expect((res.json() as { message: string }).message).toContain('commit status')
+  })
+
+  it('carries the effect axes into the compiled rule fence', async () => {
+    const h = await harness()
+    const glab = channel([GITLAB_COM_V1_FEATURE])
+    h.a.relayReg.add(glab.ch)
+    const res = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: glBody(h.agentId, { reviewPolicy: 'request_changes', reportingMode: 'check' })
+    })
+    expect(res.statusCode).toBe(200)
+    await vi.waitFor(
+      () => {
+        const assigns = glab.sent.filter((frame) => frame.type === 'rc/hook-assign')
+        expect(assigns.length).toBeGreaterThan(0)
+        const rule = assigns.at(-1)!.payload as RcHookAssign
+        expect(rule.reviewPolicy).toBe('request_changes')
+        expect(rule.reportingMode).toBe('check')
       },
       { timeout: 20_000 }
     )

--- a/packages/control-plane/test/integration/hook-report.test.ts
+++ b/packages/control-plane/test/integration/hook-report.test.ts
@@ -1156,9 +1156,8 @@ describe('gitlab hook/start records the started head', () => {
     const started = (await repo().getRun(HookId(hookId), 'gl-1'))!
     expect(started).toMatchObject({ headSha: HEAD, baseSha: 'b'.repeat(40), sessionId: 'ses_gitlab' })
     expect(started.turnStartedAt).not.toBeNull()
-    expect(first.afterStart).toHaveBeenCalledWith(
-      expect.objectContaining({ state: 'running', projectionEpoch: hook.projectionEpoch })
-    )
+    // The edge names the delivery, not an epoch — the projection resolves that from the accepted run.
+    expect(first.afterStart).toHaveBeenCalledWith(expect.objectContaining({ state: 'running', deliveryKey: 'gl-1' }))
 
     // A retried barrier re-asserts the same row rather than moving the recorded head.
     const retry = await start(hookId, agentId, 'gl-1')

--- a/packages/web/src/components/console/CodeHostReviewSettings.tsx
+++ b/packages/web/src/components/console/CodeHostReviewSettings.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+import { Icon } from '@/components/ui'
+import {
+  codeHostReviewCapabilities,
+  codeHostReviewSettingsFromCapabilities,
+  REVIEW_PRESETS,
+  reviewPresetOf,
+  withCapability,
+  type CodeHostReviewCapabilities,
+  type CodeHostReviewSettingsValue,
+  type HookReportingMode,
+  type HookReviewPolicy
+} from '@/lib/code-host-review-settings'
+
+/** The four capability labels are shared; only the hover copy differs per host. */
+export interface ReviewCapabilityHelp {
+  inlineComments: string
+  requestChanges: string
+  approve: string
+  statusCheck: string
+}
+
+// The disclosure both code hosts render: preset row, capability checkboxes, and a notice slot.
+// It holds no authorization opinion — each host computes its own blockers and passes them in.
+export function CodeHostReviewSettings({
+  title,
+  value,
+  onReviewPolicyChange,
+  onReportingModeChange,
+  help,
+  statusCheckLabel,
+  defaultExpanded = false,
+  notices
+}: {
+  title: string
+  value: CodeHostReviewSettingsValue
+  onReviewPolicyChange: (policy: HookReviewPolicy) => void
+  onReportingModeChange: (mode: HookReportingMode) => void
+  help: ReviewCapabilityHelp
+  statusCheckLabel: string
+  defaultExpanded?: boolean
+  notices?: ReactNode
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const preset = reviewPresetOf(value)
+  const capabilities = codeHostReviewCapabilities(value)
+
+  const applyValue = (next: CodeHostReviewSettingsValue) => {
+    if (next.reviewPolicy !== value.reviewPolicy) onReviewPolicyChange(next.reviewPolicy)
+    if (next.reportingMode !== value.reportingMode) onReportingModeChange(next.reportingMode)
+  }
+
+  const setCapability = (key: keyof CodeHostReviewCapabilities, enabled: boolean) => {
+    applyValue(codeHostReviewSettingsFromCapabilities(withCapability(capabilities, key, enabled)))
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((open) => !open)}
+        className="flex min-h-10 w-full items-center justify-between gap-3 rounded-md border border-(--border-default) bg-(--surface-card) px-3 py-[9px] text-left font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)"
+      >
+        <span>{title}</span>
+        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={15} className="flex-none" />
+      </button>
+
+      {expanded && (
+        <div className="flex flex-col gap-3">
+          <div className="grid grid-cols-3 gap-2">
+            {REVIEW_PRESETS.map((option) => {
+              const active = preset === option.id
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => applyValue(option.value)}
+                  className={
+                    active
+                      ? 'h-10 rounded-md border border-(--brand) bg-(--brand-soft) font-sans text-[12.5px] font-semibold leading-normal text-(--brand-soft-text)'
+                      : 'h-10 rounded-md border border-(--border-default) bg-(--surface-card) font-sans text-[12.5px] font-semibold leading-normal text-(--text-secondary)'
+                  }
+                >
+                  {option.label}
+                </button>
+              )
+            })}
+          </div>
+
+          {preset === 'details' && (
+            <div className="grid grid-cols-2 gap-x-3 gap-y-2 desktop:grid-cols-4">
+              <Capability
+                label="Inline comments"
+                help={help.inlineComments}
+                checked={capabilities.inlineComments}
+                onChange={(checked) => setCapability('inlineComments', checked)}
+              />
+              <Capability
+                label="Request changes"
+                help={help.requestChanges}
+                checked={capabilities.requestChanges}
+                onChange={(checked) => setCapability('requestChanges', checked)}
+              />
+              <Capability
+                label="Approve"
+                help={help.approve}
+                checked={capabilities.approve}
+                onChange={(checked) => setCapability('approve', checked)}
+              />
+              <Capability
+                label={statusCheckLabel}
+                help={help.statusCheck}
+                checked={capabilities.statusCheck}
+                onChange={(checked) => setCapability('statusCheck', checked)}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {notices}
+    </div>
+  )
+}
+
+function Capability({
+  label,
+  help,
+  checked,
+  onChange
+}: {
+  label: string
+  help: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+}) {
+  return (
+    <label className="flex min-w-0 cursor-help items-center gap-[7px]" title={help}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="accent-(--brand)"
+      />
+      <span className="truncate font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)">
+        {label}
+      </span>
+      <Icon name="info" size={12} color="var(--text-tertiary)" className="flex-none" />
+    </label>
+  )
+}
+
+/** The host-specific warning row; both wrappers render their blockers through it. */
+export function ReviewNotice({
+  icon,
+  tone,
+  action,
+  children
+}: {
+  icon: string
+  tone: 'warning' | 'error'
+  action?: ReactNode
+  children: ReactNode
+}) {
+  const error = tone === 'error'
+  return (
+    <div
+      className={
+        error
+          ? 'flex items-start gap-2 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)'
+          : 'flex items-start gap-2 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--amber-500)'
+      }
+    >
+      <Icon
+        name={icon}
+        size={14}
+        color={error ? 'var(--status-error)' : 'var(--amber-500)'}
+        className="mt-[2px] flex-none"
+      />
+      <span className="min-w-0 flex-1">{children}</span>
+      {action}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/GithubReviewSettings.tsx
+++ b/packages/web/src/components/console/GithubReviewSettings.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { useState, type ReactNode } from 'react'
 import { Icon } from '@/components/ui'
+import { CodeHostReviewSettings, ReviewNotice } from '@/components/console/CodeHostReviewSettings'
 import {
-  githubReviewCapabilities,
-  githubReviewSettingsFromCapabilities,
   hasChecksWritePermission,
   hasPullRequestsReadPermission,
   hasPullRequestsWritePermission,
@@ -22,16 +20,6 @@ interface InstallationPermissionView {
   checksPermission: 'write' | 'missing' | 'unknown'
   settingsUrl: string
 }
-
-const REVIEW_MODES = [
-  { id: 'none', label: 'None', value: { reviewPolicy: 'off', reportingMode: 'off' } },
-  { id: 'brief', label: 'Brief', value: { reviewPolicy: 'comment', reportingMode: 'off' } },
-  { id: 'details', label: 'Details', value: { reviewPolicy: 'full', reportingMode: 'check' } }
-] as const satisfies ReadonlyArray<{
-  id: string
-  label: string
-  value: GithubReviewSettingsValue
-}>
 
 export function GithubReviewSettings({
   value,
@@ -58,7 +46,6 @@ export function GithubReviewSettings({
   authorizingRepo?: boolean
   onAuthorizeRepo?: () => void
 }) {
-  const [expanded, setExpanded] = useState(defaultExpanded)
   const needed = requiredRepoAccess(value)
   const accessBlocked = repoSelected && !repoAccessSatisfies(repoAccess, needed)
   const hasExactChecksWritePermission = hasChecksWritePermission(installation)
@@ -72,234 +59,112 @@ export function GithubReviewSettings({
     (!hasExactChecksWritePermission || !hasExactPullRequestsReadPermission)
   const hasPendingPermissionUpgrade = installation?.permissionsStatus === 'outdated'
   const blocked = accessBlocked || reviewPermissionBlocked || checkPermissionBlocked
-  const mode =
-    value.reviewPolicy === 'off' && value.reportingMode === 'off'
-      ? 'none'
-      : value.reviewPolicy === 'comment' && value.reportingMode === 'off'
-        ? 'brief'
-        : 'details'
-  const capabilities = githubReviewCapabilities(value)
-
-  const applyValue = (next: GithubReviewSettingsValue) => {
-    if (next.reviewPolicy !== value.reviewPolicy) onReviewPolicyChange(next.reviewPolicy)
-    if (next.reportingMode !== value.reportingMode) onReportingModeChange(next.reportingMode)
-  }
-
-  const setCapability = (key: keyof typeof capabilities, enabled: boolean) => {
-    const next = { ...capabilities, [key]: enabled }
-    if (key === 'inlineComments' && !enabled) {
-      next.requestChanges = false
-      next.approve = false
-    } else if (key === 'requestChanges') {
-      if (enabled) next.inlineComments = true
-      else next.approve = false
-    } else if (key === 'approve' && enabled) {
-      next.inlineComments = true
-      next.requestChanges = true
-    }
-    applyValue(githubReviewSettingsFromCapabilities(next))
-  }
 
   const approveHelp = `Allows a formal APPROVE review. The App cannot approve its own PR or guarantee CODEOWNERS coverage${
     publicRepo ? '; public PR content is untrusted input' : ''
   }.`
 
   return (
-    <div className="flex flex-col gap-3">
-      <button
-        type="button"
-        aria-expanded={expanded}
-        onClick={() => setExpanded((open) => !open)}
-        className="flex min-h-10 w-full items-center justify-between gap-3 rounded-md border border-(--border-default) bg-(--surface-card) px-3 py-[9px] text-left font-sans text-[12.5px] font-semibold leading-normal text-(--text-primary)"
-      >
-        <span>PR review</span>
-        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={15} className="flex-none" />
-      </button>
-
-      {expanded && (
-        <div className="flex flex-col gap-3">
-          <div className="grid grid-cols-3 gap-2">
-            {REVIEW_MODES.map((option) => {
-              const active = mode === option.id
-              return (
-                <button
-                  key={option.id}
-                  type="button"
-                  aria-pressed={active}
-                  onClick={() => applyValue(option.value)}
-                  className={
-                    active
-                      ? 'h-10 rounded-md border border-(--brand) bg-(--brand-soft) font-sans text-[12.5px] font-semibold leading-normal text-(--brand-soft-text)'
-                      : 'h-10 rounded-md border border-(--border-default) bg-(--surface-card) font-sans text-[12.5px] font-semibold leading-normal text-(--text-secondary)'
-                  }
-                >
-                  {option.label}
-                </button>
-              )
-            })}
-          </div>
-
-          {mode === 'details' && (
-            <div className="grid grid-cols-2 gap-x-3 gap-y-2 desktop:grid-cols-4">
-              <Capability
-                label="Inline comments"
-                help="Submit formal COMMENT reviews with optional comments on specific changed lines."
-                checked={capabilities.inlineComments}
-                onChange={(checked) => setCapability('inlineComments', checked)}
-              />
-              <Capability
-                label="Request changes"
-                help="Allow formal REQUEST_CHANGES reviews for blocking findings. This also enables inline comments."
-                checked={capabilities.requestChanges}
-                onChange={(checked) => setCapability('requestChanges', checked)}
-              />
-              <Capability
-                label="Approve"
-                help={approveHelp}
-                checked={capabilities.approve}
-                onChange={(checked) => setCapability('approve', checked)}
-              />
-              <Capability
-                label="Status check"
-                help="Publish an informational GitHub Check Run for queued, in-progress, and final results. It does not block merging."
-                checked={capabilities.statusCheck}
-                onChange={(checked) => setCapability('statusCheck', checked)}
-              />
-            </div>
+    <CodeHostReviewSettings
+      title="PR review"
+      value={value}
+      onReviewPolicyChange={onReviewPolicyChange}
+      onReportingModeChange={onReportingModeChange}
+      defaultExpanded={defaultExpanded}
+      statusCheckLabel="Status check"
+      help={{
+        inlineComments: 'Submit formal COMMENT reviews with optional comments on specific changed lines.',
+        requestChanges:
+          'Allow formal REQUEST_CHANGES reviews for blocking findings. This also enables inline comments.',
+        approve: approveHelp,
+        statusCheck:
+          'Publish an informational GitHub Check Run for queued, in-progress, and final results. It does not block merging.'
+      }}
+      notices={
+        <>
+          {accessBlocked && (
+            <ReviewNotice
+              icon="lock"
+              tone="error"
+              action={
+                canAuthorizeRepo && onAuthorizeRepo ? (
+                  <button
+                    type="button"
+                    onClick={onAuthorizeRepo}
+                    disabled={authorizingRepo}
+                    className="flex-none rounded-sm border border-(--status-error) px-2 py-[5px] font-sans text-[11.5px] font-semibold leading-normal disabled:cursor-default disabled:opacity-60"
+                  >
+                    {authorizingRepo ? 'Authorizing…' : repoAccess === 'none' ? 'Authorize repo' : 'Upgrade access'}
+                  </button>
+                ) : undefined
+              }
+            >
+              This configuration needs {needed} repository access; the agent currently has {repoAccess}.
+            </ReviewNotice>
           )}
-        </div>
-      )}
+          {reviewPermissionBlocked && (
+            <ReviewNotice icon="triangle-alert" tone="error">
+              {installation?.pullRequestsPermission === 'missing'
+                ? 'This installation must grant the App Pull requests write permission for formal reviews.'
+                : installation?.pullRequestsPermission === 'read'
+                  ? 'This installation must upgrade Pull requests permission from read to write for formal reviews.'
+                  : 'Pull requests write permission could not be confirmed for this installation.'}
+              {installation?.settingsUrl && (
+                <>
+                  {' '}
+                  <a
+                    href={installation.settingsUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="lnk text-[12px]"
+                  >
+                    Review permissions
+                    <Icon name="external-link" size={12} />
+                  </a>
+                </>
+              )}
+            </ReviewNotice>
+          )}
 
-      {accessBlocked && (
-        <Notice
-          icon="lock"
-          tone="error"
-          action={
-            canAuthorizeRepo && onAuthorizeRepo ? (
-              <button
-                type="button"
-                onClick={onAuthorizeRepo}
-                disabled={authorizingRepo}
-                className="flex-none rounded-sm border border-(--status-error) px-2 py-[5px] font-sans text-[11.5px] font-semibold leading-normal disabled:cursor-default disabled:opacity-60"
-              >
-                {authorizingRepo ? 'Authorizing…' : repoAccess === 'none' ? 'Authorize repo' : 'Upgrade access'}
-              </button>
-            ) : undefined
-          }
-        >
-          This configuration needs {needed} repository access; the agent currently has {repoAccess}.
-        </Notice>
-      )}
-      {reviewPermissionBlocked && (
-        <Notice icon="triangle-alert" tone="error">
-          {installation?.pullRequestsPermission === 'missing'
-            ? 'This installation must grant the App Pull requests write permission for formal reviews.'
-            : installation?.pullRequestsPermission === 'read'
-              ? 'This installation must upgrade Pull requests permission from read to write for formal reviews.'
-              : 'Pull requests write permission could not be confirmed for this installation.'}
-          {installation?.settingsUrl && (
-            <>
-              {' '}
+          {checkPermissionBlocked && (
+            <ReviewNotice icon="triangle-alert" tone="error">
+              {!hasExactChecksWritePermission
+                ? installation?.checksPermission === 'missing'
+                  ? 'This installation must accept the App’s updated Checks permission.'
+                  : 'Checks permission could not be confirmed for this installation.'
+                : installation?.pullRequestsPermission === 'missing'
+                  ? 'This installation must grant the App Pull requests read permission for live PR association.'
+                  : 'Pull requests read permission could not be confirmed for live PR association.'}
+              {installation?.settingsUrl && (
+                <>
+                  {' '}
+                  <a
+                    href={installation.settingsUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="lnk text-[12px]"
+                  >
+                    Update permissions
+                    <Icon name="external-link" size={12} />
+                  </a>
+                </>
+              )}
+            </ReviewNotice>
+          )}
+
+          {repoSelected && hasPendingPermissionUpgrade && !blocked && (
+            <ReviewNotice icon="triangle-alert" tone="warning">
+              {hasExactChecksWritePermission
+                ? 'This installation has other GitHub App permission updates waiting for approval. Its current Checks write permission remains available.'
+                : 'This installation has GitHub App permission updates waiting for approval.'}{' '}
               <a href={installation.settingsUrl} target="_blank" rel="noopener noreferrer" className="lnk text-[12px]">
                 Review permissions
                 <Icon name="external-link" size={12} />
               </a>
-            </>
+            </ReviewNotice>
           )}
-        </Notice>
-      )}
-
-      {checkPermissionBlocked && (
-        <Notice icon="triangle-alert" tone="error">
-          {!hasExactChecksWritePermission
-            ? installation?.checksPermission === 'missing'
-              ? 'This installation must accept the App’s updated Checks permission.'
-              : 'Checks permission could not be confirmed for this installation.'
-            : installation?.pullRequestsPermission === 'missing'
-              ? 'This installation must grant the App Pull requests read permission for live PR association.'
-              : 'Pull requests read permission could not be confirmed for live PR association.'}
-          {installation?.settingsUrl && (
-            <>
-              {' '}
-              <a href={installation.settingsUrl} target="_blank" rel="noopener noreferrer" className="lnk text-[12px]">
-                Update permissions
-                <Icon name="external-link" size={12} />
-              </a>
-            </>
-          )}
-        </Notice>
-      )}
-
-      {repoSelected && hasPendingPermissionUpgrade && !blocked && (
-        <Notice icon="triangle-alert" tone="warning">
-          {hasExactChecksWritePermission
-            ? 'This installation has other GitHub App permission updates waiting for approval. Its current Checks write permission remains available.'
-            : 'This installation has GitHub App permission updates waiting for approval.'}{' '}
-          <a href={installation.settingsUrl} target="_blank" rel="noopener noreferrer" className="lnk text-[12px]">
-            Review permissions
-            <Icon name="external-link" size={12} />
-          </a>
-        </Notice>
-      )}
-    </div>
-  )
-}
-
-function Capability({
-  label,
-  help,
-  checked,
-  onChange
-}: {
-  label: string
-  help: string
-  checked: boolean
-  onChange: (checked: boolean) => void
-}) {
-  return (
-    <label className="flex min-w-0 cursor-help items-center gap-[7px]" title={help}>
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(event) => onChange(event.target.checked)}
-        className="accent-(--brand)"
-      />
-      <span className="truncate font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)">
-        {label}
-      </span>
-      <Icon name="info" size={12} color="var(--text-tertiary)" className="flex-none" />
-    </label>
-  )
-}
-
-function Notice({
-  icon,
-  tone,
-  action,
-  children
-}: {
-  icon: string
-  tone: 'warning' | 'error'
-  action?: ReactNode
-  children: ReactNode
-}) {
-  const error = tone === 'error'
-  return (
-    <div
-      className={
-        error
-          ? 'flex items-start gap-2 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)'
-          : 'flex items-start gap-2 rounded-md border border-(--status-paused) bg-(--status-paused-soft) px-3 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--amber-500)'
+        </>
       }
-    >
-      <Icon
-        name={icon}
-        size={14}
-        color={error ? 'var(--status-error)' : 'var(--amber-500)'}
-        className="mt-[2px] flex-none"
-      />
-      <span className="min-w-0 flex-1">{children}</span>
-      {action}
-    </div>
+    />
   )
 }

--- a/packages/web/src/components/console/GitlabReviewSettings.tsx
+++ b/packages/web/src/components/console/GitlabReviewSettings.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { CodeHostReviewSettings, ReviewNotice } from '@/components/console/CodeHostReviewSettings'
+import type { CodeHostReviewSettingsValue, HookReportingMode, HookReviewPolicy } from '@/lib/code-host-review-settings'
+
+// GitLab's half of the review disclosure. No access clamp on purpose: the project bot writes both
+// effects under its provisioned role, so the only precondition is that the project has a bot.
+export function GitlabReviewSettings({
+  value,
+  onReviewPolicyChange,
+  onReportingModeChange,
+  projectBotReady = true,
+  defaultExpanded = false
+}: {
+  value: CodeHostReviewSettingsValue
+  onReviewPolicyChange: (policy: HookReviewPolicy) => void
+  onReportingModeChange: (mode: HookReportingMode) => void
+  projectBotReady?: boolean
+  defaultExpanded?: boolean
+}) {
+  const botMissing = !projectBotReady && (value.reviewPolicy !== 'off' || value.reportingMode === 'check')
+  return (
+    <CodeHostReviewSettings
+      title="MR review"
+      value={value}
+      onReviewPolicyChange={onReviewPolicyChange}
+      onReportingModeChange={onReportingModeChange}
+      defaultExpanded={defaultExpanded}
+      statusCheckLabel="Run note"
+      help={{
+        inlineComments: 'Submit formal COMMENT reviews with optional comments on specific changed lines.',
+        requestChanges:
+          'Allow formal REQUEST_CHANGES reviews. GitLab records them only while the project bot is a current reviewer — otherwise the finding is recorded as a COMMENT that does not pass.',
+        approve:
+          'Allow the project bot to record an approval. That is a separate act from a review, and project rules may still refuse it.',
+        statusCheck:
+          'Post one status note on the merge request for queued, running, and final results. It does not block merging.'
+      }}
+      notices={
+        botMissing ? (
+          <ReviewNotice icon="triangle-alert" tone="error">
+            This project has no bot yet. Reviews and run notes are posted by it, so finish connecting the project first.
+          </ReviewNotice>
+        ) : undefined
+      }
+    />
+  )
+}

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -180,7 +180,10 @@ describe('AddIntegrationModal, GitLab trigger', () => {
       projectId: '4210',
       events: ['merge_request:*'],
       commentFamilies: ['merge_request'],
-      mentionOnly: false
+      mentionOnly: false,
+      // The review disclosure opens on the full preset, exactly like the github pane.
+      reviewPolicy: 'full',
+      reportingMode: 'check'
     })
   })
 
@@ -217,8 +220,44 @@ describe('AddIntegrationModal, GitLab trigger', () => {
       projectId: '4210',
       events: ['issues:*', 'merge_request:*'],
       commentFamilies: ['issues', 'merge_request'],
-      mentionOnly: true
+      mentionOnly: true,
+      reviewPolicy: 'full',
+      reportingMode: 'check'
     })
+  })
+
+  it('offers the review disclosure and sends whichever preset is chosen', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    await render()
+    await pickProject()
+
+    // The section exists on the GitLab pane, worded for merge requests.
+    const disclosure = clickText('MR review')
+    expect(disclosure).toBeDefined()
+    await act(async () => disclosure?.click())
+    expect(document.body.textContent).toContain('Run note')
+
+    // "None" turns both axes off in one click.
+    await act(async () => clickText('None')?.click())
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGitlabHook).toHaveBeenCalledWith(
+      expect.objectContaining({ reviewPolicy: 'off', reportingMode: 'off' })
+    )
+  })
+
+  it('names GitLab tier semantics in the review copy, not GitHub ones', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    await render()
+    await pickProject()
+    await act(async () => clickText('MR review')?.click())
+
+    const help = Array.from(document.querySelectorAll('label[title]')).map((row) => row.getAttribute('title') ?? '')
+    // §15.3: request-changes needs the bot to be a current reviewer; approval is its own act.
+    expect(help.some((text) => text.includes('current reviewer'))).toBe(true)
+    expect(help.some((text) => text.includes('separate act from a review'))).toBe(true)
+    expect(help.join(' ')).not.toContain('Check Run')
+    expect(help.join(' ')).not.toContain('CODEOWNERS')
   })
 
   it('offers exactly the two subjects GitHub offers, and never emits a push event', async () => {

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -14,6 +14,7 @@ import LarkFeishuSwitcher, { type LarkFeishuTarget } from '@/components/LarkFeis
 import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { GithubReviewSettings } from '@/components/console/GithubReviewSettings'
+import { GitlabReviewSettings } from '@/components/console/GitlabReviewSettings'
 import {
   GithubPrivateReposNotice,
   GitlabNoProjectsNotice,
@@ -366,6 +367,8 @@ export default function AddIntegrationModal({
   const gl = useGitlabProjects(platform === 'gitlab', glQ)
   const [glFams, setGlFams] = useState<Set<GlFamily>>(new Set(GL_DEFAULT_FAMILIES))
   const [glMode, setGlMode] = useState<GlTriggerMode>(GL_DEFAULT_TRIGGER_MODE)
+  const [glReviewPolicy, setGlReviewPolicy] = useState<HookReviewPolicy>('full')
+  const [glReportingMode, setGlReportingMode] = useState<HookReportingMode>('check')
 
   // Reusing a bot is an advanced path; every platform opens on the create flow
   // until the user explicitly chooses an existing identity.
@@ -838,7 +841,9 @@ export default function AddIntegrationModal({
         projectId: glProject,
         events: eventsForGitlabFamilies(glFams, glMode),
         commentFamilies: commentFamiliesForGitlabFamilies(glFams, glMode),
-        mentionOnly: glMode === 'mention'
+        mentionOnly: glMode === 'mention',
+        reviewPolicy: glReviewPolicy,
+        reportingMode: glReportingMode
       })
       onClose()
     } catch (e) {
@@ -1753,6 +1758,20 @@ export default function AddIntegrationModal({
                       </div>
                     )
                   })}
+                </div>
+                <div className="mb-4">
+                  <GitlabReviewSettings
+                    value={{ reviewPolicy: glReviewPolicy, reportingMode: glReportingMode }}
+                    onReviewPolicyChange={(policy) => {
+                      setGlReviewPolicy(policy)
+                      setErr(null)
+                    }}
+                    onReportingModeChange={(mode) => {
+                      setGlReportingMode(mode)
+                      setErr(null)
+                    }}
+                    projectBotReady={!glPicked?.binding || !!glPicked.binding.serviceAccountUsername}
+                  />
                 </div>
               </>
             )}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -63,6 +63,7 @@ import { FileBrowserShell } from '@/components/console/FileBrowser'
 import { MemoryPanel } from '@/components/console/MemoryPanel'
 import { LocalSkillsList } from '@/components/console/LocalSkillsList'
 import { GithubReviewSettings } from '@/components/console/GithubReviewSettings'
+import { GitlabReviewSettings } from '@/components/console/GitlabReviewSettings'
 import { VisibilityValue } from '@/components/console/VisibilityField'
 import LarkFeishuSwitcher from '@/components/LarkFeishuSwitcher'
 import { AgentMark, GithubMark, GitlabMark, LoadingState, PlatformMark } from '@/components/marks'
@@ -75,6 +76,7 @@ import {
   commentFamiliesForGitlabFamilies,
   eventsForGitlabFamilies,
   gitlabCadencePick,
+  gitlabCommentFamilies,
   gitlabFamCovered,
   gitlabFamilyToggle,
   gitlabHookNeedsNormalization,
@@ -138,8 +140,9 @@ function FeishuRegionBadge({ integration }: { integration: Pick<IntegrationRow, 
   )
 }
 
-interface GithubReviewSettingsDraft {
+interface CodeHostReviewSettingsDraft {
   hookId: string
+  kind: 'github' | 'gitlab'
   reviewPolicy: HookReviewPolicy
   reportingMode: HookReportingMode
 }
@@ -292,11 +295,12 @@ export default function AgentDetailView() {
     return owners.length === 1 ? owners[0]! : 'GitHub'
   }, [githubHooks])
 
-  const [reviewSettingsDraft, setReviewSettingsDraft] = useState<GithubReviewSettingsDraft | null>(null)
+  const [reviewSettingsDraft, setReviewSettingsDraft] = useState<CodeHostReviewSettingsDraft | null>(null)
   const [reviewSettingsSaving, setReviewSettingsSaving] = useState(false)
   const [reviewSettingsError, setReviewSettingsError] = useState<string | null>(null)
+  const isGitlabReviewDraft = reviewSettingsDraft?.kind === 'gitlab'
   const reviewSettingsHook = reviewSettingsDraft
-    ? githubHooks.find((hook) => hook.id === reviewSettingsDraft.hookId)
+    ? (isGitlabReviewDraft ? gitlabHooks : githubHooks).find((hook) => hook.id === reviewSettingsDraft.hookId)
     : undefined
   const reviewSettingsRepoAccess = effectiveRepoAccess({
     repoId: reviewSettingsHook?.repoId,
@@ -306,19 +310,23 @@ export default function AgentDetailView() {
   })
   const reviewSettingsInstallation = installationForRepo(reviewSettingsHook?.repoFullName, githubInstallations)
   const reviewSettingsNeededAccess = reviewSettingsDraft ? requiredRepoAccess(reviewSettingsDraft) : 'none'
+  // Only the github surface has a config-time blocker; GitLab's writer is the
+  // project bot, which carries no per-agent access tier to satisfy first.
   const reviewSettingsBlocked =
-    !repoAccessSatisfies(reviewSettingsRepoAccess, reviewSettingsNeededAccess) ||
-    (reviewSettingsDraft?.reviewPolicy !== undefined &&
-      reviewSettingsDraft.reviewPolicy !== 'off' &&
-      !hasPullRequestsWritePermission(reviewSettingsInstallation)) ||
-    (reviewSettingsDraft?.reportingMode === 'check' &&
-      (!hasChecksWritePermission(reviewSettingsInstallation) ||
-        !hasPullRequestsReadPermission(reviewSettingsInstallation)))
+    !isGitlabReviewDraft &&
+    (!repoAccessSatisfies(reviewSettingsRepoAccess, reviewSettingsNeededAccess) ||
+      (reviewSettingsDraft?.reviewPolicy !== undefined &&
+        reviewSettingsDraft.reviewPolicy !== 'off' &&
+        !hasPullRequestsWritePermission(reviewSettingsInstallation)) ||
+      (reviewSettingsDraft?.reportingMode === 'check' &&
+        (!hasChecksWritePermission(reviewSettingsInstallation) ||
+          !hasPullRequestsReadPermission(reviewSettingsInstallation))))
 
   const openReviewSettings = (hook: HookDto) => {
     setReviewSettingsError(null)
     setReviewSettingsDraft({
       hookId: hook.id,
+      kind: hook.kind === 'gitlab' ? 'gitlab' : 'github',
       reviewPolicy: hook.reviewPolicy,
       reportingMode: hook.reportingMode
     })
@@ -331,32 +339,46 @@ export default function AgentDetailView() {
   }
 
   const saveReviewSettings = async () => {
-    if (
-      reviewSettingsSaving ||
-      reviewSettingsBlocked ||
-      !reviewSettingsDraft ||
-      !reviewSettingsHook?.agentId ||
-      !reviewSettingsHook.repoFullName
-    ) {
+    if (reviewSettingsSaving || reviewSettingsBlocked || !reviewSettingsDraft || !reviewSettingsHook?.agentId) {
       return
     }
+    const agentId = reviewSettingsHook.agentId
+    const hook = reviewSettingsHook
+    const { reviewPolicy, reportingMode } = reviewSettingsDraft
+    const common = { agentId, name: hook.name, enabled: hook.enabled, events: hook.events }
+    // Each host's PUT re-sends its own whole block; only the two effect axes move.
+    const save =
+      hook.kind === 'gitlab'
+        ? hook.repoId
+          ? () =>
+              updateGitlabHook(hook.id, {
+                ...common,
+                projectId: hook.repoId!,
+                commentFamilies: gitlabCommentFamilies(hook.commentFamilies),
+                mentionOnly: hook.mentionOnly,
+                reviewPolicy,
+                reportingMode
+              })
+          : null
+        : hook.repoFullName
+          ? () =>
+              updateGithubHook(hook.id, {
+                ...common,
+                repoFullName: hook.repoFullName!,
+                commentFamilies: githubCommentFamilies(hook.commentFamilies),
+                labelFilter: hook.labelFilter,
+                mentionOnly: hook.mentionOnly,
+                reviewPolicy,
+                reportingMode,
+                gateMode: 'informational'
+              })
+          : null
+    if (!save) return
     setReviewSettingsSaving(true)
     setReviewSettingsError(null)
     try {
-      const updated = await updateGithubHook(reviewSettingsHook.id, {
-        agentId: reviewSettingsHook.agentId,
-        name: reviewSettingsHook.name,
-        enabled: reviewSettingsHook.enabled,
-        repoFullName: reviewSettingsHook.repoFullName,
-        events: reviewSettingsHook.events,
-        commentFamilies: githubCommentFamilies(reviewSettingsHook.commentFamilies),
-        labelFilter: reviewSettingsHook.labelFilter,
-        mentionOnly: reviewSettingsHook.mentionOnly,
-        reviewPolicy: reviewSettingsDraft.reviewPolicy,
-        reportingMode: reviewSettingsDraft.reportingMode,
-        gateMode: 'informational'
-      })
-      void mutateHooks((rows) => rows?.map((row) => (row.id === reviewSettingsHook.id ? updated : row)), {
+      const updated = await save()
+      void mutateHooks((rows) => rows?.map((row) => (row.id === hook.id ? updated : row)), {
         revalidate: false
       })
       setReviewSettingsDraft(null)
@@ -408,7 +430,9 @@ export default function AgentDetailView() {
         projectId: h.repoId,
         events: eventsForGitlabFamilies(families, mode),
         commentFamilies: commentFamiliesForGitlabFamilies(families, mode),
-        mentionOnly: mode === 'mention'
+        mentionOnly: mode === 'mention',
+        reviewPolicy: h.reviewPolicy,
+        reportingMode: h.reportingMode
       })
       void mutateHooks((rows) => rows?.map((r) => (r.id === h.id ? updated : r)), { revalidate: false })
     } catch {
@@ -1399,10 +1423,20 @@ export default function AgentDetailView() {
                             .join(' · ') || 'no events'}
                           {` · ${GL_TRIGGER_PILL[gitlabTriggerModeOf(h)]}`}
                         </span>
+                        {(h.reviewPolicy !== 'off' || h.reportingMode === 'check') && (
+                          <span className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                            {reviewPolicyLabel(h.reviewPolicy)} review
+                            {h.reportingMode === 'check' ? ' · run note' : ''}
+                          </span>
+                        )}
                       </span>
-                      <span className="inline-flex flex-none items-center gap-[5px] rounded-full bg-(--surface-active) px-[10px] py-[3px] font-sans text-[12px] font-semibold leading-normal text-(--text-tertiary)">
-                        GitLab
-                      </span>
+                      <button
+                        className="iconbtn flex-none"
+                        title="MR review and run note settings"
+                        onClick={() => openReviewSettings(h)}
+                      >
+                        <Icon name="settings-2" size={15} />
+                      </button>
                     </div>
                   ))}
                 </div>
@@ -1703,6 +1737,13 @@ export default function AgentDetailView() {
                               <span className="inline-flex flex-none gap-[2px]">
                                 <button
                                   className="iconbtn h-[26px] w-[26px] flex-none"
+                                  title="MR review and run note settings"
+                                  onClick={() => openReviewSettings(h)}
+                                >
+                                  <Icon name="settings-2" size={13} />
+                                </button>
+                                <button
+                                  className="iconbtn h-[26px] w-[26px] flex-none"
                                   title="Recent deliveries"
                                   onClick={() => setHookRunsFor(hookRunsFor === h.id ? null : h.id)}
                                 >
@@ -1994,22 +2035,22 @@ export default function AgentDetailView() {
           <div
             role="dialog"
             aria-modal="true"
-            aria-labelledby="github-review-settings-title"
+            aria-labelledby="code-host-review-settings-title"
             onClick={(event) => event.stopPropagation()}
             className="flex max-h-[88vh] w-full flex-col rounded-t-xl bg-(--surface-card) shadow-[0_-8px_32px_rgba(0,0,0,.18)] desktop:max-w-[620px] desktop:rounded-xl desktop:shadow-(--shadow-xl)"
           >
             <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-[13px] desktop:px-5">
               <span className="flex h-8 w-8 flex-none items-center justify-center rounded-md bg-(--surface-inverse)">
                 <span className="flex h-[17px] w-[17px] items-center justify-center">
-                  <GithubMark color="#fff" />
+                  {isGitlabReviewDraft ? <GitlabMark fillPct={100} /> : <GithubMark color="#fff" />}
                 </span>
               </span>
               <div className="min-w-0 flex-1">
                 <div
-                  id="github-review-settings-title"
+                  id="code-host-review-settings-title"
                   className="font-sans text-[14px] font-semibold leading-normal text-(--text-primary)"
                 >
-                  PR review &amp; Checks
+                  {isGitlabReviewDraft ? 'MR review & run note' : 'PR review & Checks'}
                 </div>
                 <div className="mono mt-[2px] truncate text-[11.5px] text-(--text-tertiary)">
                   {reviewSettingsHook.repoFullName ?? reviewSettingsHook.name}
@@ -2020,20 +2061,35 @@ export default function AgentDetailView() {
               </button>
             </div>
             <div className="overflow-y-auto px-4 py-4 desktop:px-5">
-              <GithubReviewSettings
-                value={reviewSettingsDraft}
-                onReviewPolicyChange={(reviewPolicy) => {
-                  setReviewSettingsError(null)
-                  setReviewSettingsDraft((draft) => (draft ? { ...draft, reviewPolicy } : draft))
-                }}
-                onReportingModeChange={(reportingMode) => {
-                  setReviewSettingsError(null)
-                  setReviewSettingsDraft((draft) => (draft ? { ...draft, reportingMode } : draft))
-                }}
-                repoAccess={reviewSettingsRepoAccess}
-                installation={reviewSettingsInstallation}
-                defaultExpanded
-              />
+              {isGitlabReviewDraft ? (
+                <GitlabReviewSettings
+                  value={reviewSettingsDraft}
+                  onReviewPolicyChange={(reviewPolicy) => {
+                    setReviewSettingsError(null)
+                    setReviewSettingsDraft((draft) => (draft ? { ...draft, reviewPolicy } : draft))
+                  }}
+                  onReportingModeChange={(reportingMode) => {
+                    setReviewSettingsError(null)
+                    setReviewSettingsDraft((draft) => (draft ? { ...draft, reportingMode } : draft))
+                  }}
+                  defaultExpanded
+                />
+              ) : (
+                <GithubReviewSettings
+                  value={reviewSettingsDraft}
+                  onReviewPolicyChange={(reviewPolicy) => {
+                    setReviewSettingsError(null)
+                    setReviewSettingsDraft((draft) => (draft ? { ...draft, reviewPolicy } : draft))
+                  }}
+                  onReportingModeChange={(reportingMode) => {
+                    setReviewSettingsError(null)
+                    setReviewSettingsDraft((draft) => (draft ? { ...draft, reportingMode } : draft))
+                  }}
+                  repoAccess={reviewSettingsRepoAccess}
+                  installation={reviewSettingsInstallation}
+                  defaultExpanded
+                />
+              )}
               {reviewSettingsError && (
                 <div className="mt-3 flex items-start gap-2 rounded-md border border-(--status-error) bg-(--status-error-soft) px-3 py-[10px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
                   <Icon name="triangle-alert" size={14} className="mt-[2px] flex-none" />

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3913,6 +3913,9 @@ export interface CreateGitlabHookInput {
   events: string[] // 'issues:*' / 'merge_request:*' / 'push:*' — at least one
   commentFamilies?: GitlabCommentFamily[]
   mentionOnly?: boolean
+  reviewPolicy?: HookReviewPolicy
+  // 'check' publishes the merge-request run note; no gateMode — GitLab has no required gate.
+  reportingMode?: HookReportingMode
 }
 
 // A hook is subordinate to its agent (like an Integration), so there is no

--- a/packages/web/src/lib/code-host-review-settings.test.ts
+++ b/packages/web/src/lib/code-host-review-settings.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  codeHostReviewCapabilities,
+  codeHostReviewSettingsFromCapabilities,
+  REVIEW_PRESETS,
+  reviewPolicyLabel,
+  reviewPresetOf,
+  withCapability,
+  type CodeHostReviewSettingsValue
+} from './code-host-review-settings'
+
+describe('codeHostReviewCapabilities', () => {
+  it('projects the hierarchical policy onto the four checkboxes', () => {
+    expect(codeHostReviewCapabilities({ reviewPolicy: 'off', reportingMode: 'off' })).toEqual({
+      inlineComments: false,
+      requestChanges: false,
+      approve: false,
+      statusCheck: false
+    })
+    expect(codeHostReviewCapabilities({ reviewPolicy: 'full', reportingMode: 'check' })).toEqual({
+      inlineComments: true,
+      requestChanges: true,
+      approve: true,
+      statusCheck: true
+    })
+  })
+
+  it('round-trips every reachable value', () => {
+    const values: CodeHostReviewSettingsValue[] = [
+      { reviewPolicy: 'off', reportingMode: 'off' },
+      { reviewPolicy: 'off', reportingMode: 'check' },
+      { reviewPolicy: 'comment', reportingMode: 'off' },
+      { reviewPolicy: 'request_changes', reportingMode: 'check' },
+      { reviewPolicy: 'full', reportingMode: 'check' }
+    ]
+    for (const value of values) {
+      expect(codeHostReviewSettingsFromCapabilities(codeHostReviewCapabilities(value))).toEqual(value)
+    }
+  })
+})
+
+describe('withCapability', () => {
+  it('drops the dependants when the base capability is turned off', () => {
+    const full = codeHostReviewCapabilities({ reviewPolicy: 'full', reportingMode: 'check' })
+    expect(withCapability(full, 'inlineComments', false)).toMatchObject({
+      inlineComments: false,
+      requestChanges: false,
+      approve: false
+    })
+    expect(withCapability(full, 'requestChanges', false)).toMatchObject({ requestChanges: false, approve: false })
+  })
+
+  it('raises the prerequisites when a stronger capability is turned on', () => {
+    const none = codeHostReviewCapabilities({ reviewPolicy: 'off', reportingMode: 'off' })
+    expect(withCapability(none, 'approve', true)).toMatchObject({
+      inlineComments: true,
+      requestChanges: true,
+      approve: true
+    })
+    expect(withCapability(none, 'requestChanges', true)).toMatchObject({ inlineComments: true, requestChanges: true })
+  })
+
+  it('keeps the reporting axis independent of the review ladder', () => {
+    const none = codeHostReviewCapabilities({ reviewPolicy: 'off', reportingMode: 'off' })
+    expect(codeHostReviewSettingsFromCapabilities(withCapability(none, 'statusCheck', true))).toEqual({
+      reviewPolicy: 'off',
+      reportingMode: 'check'
+    })
+  })
+})
+
+describe('reviewPresetOf', () => {
+  it('reads each preset back from the value it writes', () => {
+    for (const preset of REVIEW_PRESETS) expect(reviewPresetOf(preset.value)).toBe(preset.id)
+  })
+
+  it('reads anything richer than brief as details', () => {
+    expect(reviewPresetOf({ reviewPolicy: 'comment', reportingMode: 'check' })).toBe('details')
+    expect(reviewPresetOf({ reviewPolicy: 'request_changes', reportingMode: 'off' })).toBe('details')
+  })
+})
+
+describe('reviewPolicyLabel', () => {
+  it('names each policy without naming a host', () => {
+    expect(reviewPolicyLabel('off')).toBe('Off')
+    expect(reviewPolicyLabel('request_changes')).toBe('Request changes')
+    expect(REVIEW_PRESETS.map(({ label }) => label)).toEqual(['None', 'Brief', 'Details'])
+  })
+})

--- a/packages/web/src/lib/code-host-review-settings.ts
+++ b/packages/web/src/lib/code-host-review-settings.ts
@@ -1,0 +1,98 @@
+// The review/reporting vocabulary both code hosts share: the two effect enums, the capability
+// projection, and the preset row. Whatever only one host has stays in that host's own module.
+
+export type HookReviewPolicy = 'off' | 'comment' | 'request_changes' | 'full'
+export type HookReportingMode = 'off' | 'check'
+export type HookGateMode = 'informational'
+
+export interface CodeHostReviewSettingsValue {
+  reviewPolicy: HookReviewPolicy
+  reportingMode: HookReportingMode
+}
+
+export interface CodeHostReviewCapabilities {
+  inlineComments: boolean
+  requestChanges: boolean
+  approve: boolean
+  statusCheck: boolean
+}
+
+/** Present the hierarchical reviewPolicy enum as capability checkboxes. */
+export function codeHostReviewCapabilities(value: CodeHostReviewSettingsValue): CodeHostReviewCapabilities {
+  return {
+    inlineComments: value.reviewPolicy !== 'off',
+    requestChanges: value.reviewPolicy === 'request_changes' || value.reviewPolicy === 'full',
+    approve: value.reviewPolicy === 'full',
+    statusCheck: value.reportingMode === 'check'
+  }
+}
+
+/** Collapse capability checkboxes back to the strongest enabled policy. */
+export function codeHostReviewSettingsFromCapabilities(
+  capabilities: CodeHostReviewCapabilities
+): CodeHostReviewSettingsValue {
+  return {
+    reviewPolicy: capabilities.approve
+      ? 'full'
+      : capabilities.requestChanges
+        ? 'request_changes'
+        : capabilities.inlineComments
+          ? 'comment'
+          : 'off',
+    reportingMode: capabilities.statusCheck ? 'check' : 'off'
+  }
+}
+
+/** The three presets the disclosure opens on, in display order. */
+export const REVIEW_PRESETS = [
+  { id: 'none', label: 'None', value: { reviewPolicy: 'off', reportingMode: 'off' } },
+  { id: 'brief', label: 'Brief', value: { reviewPolicy: 'comment', reportingMode: 'off' } },
+  { id: 'details', label: 'Details', value: { reviewPolicy: 'full', reportingMode: 'check' } }
+] as const satisfies ReadonlyArray<{ id: string; label: string; value: CodeHostReviewSettingsValue }>
+
+export type ReviewPresetId = (typeof REVIEW_PRESETS)[number]['id']
+
+/** Which preset a stored value reads as; anything richer than "brief" is details. */
+export function reviewPresetOf(value: CodeHostReviewSettingsValue): ReviewPresetId {
+  if (value.reviewPolicy === 'off' && value.reportingMode === 'off') return 'none'
+  return value.reviewPolicy === 'comment' && value.reportingMode === 'off' ? 'brief' : 'details'
+}
+
+/** Apply one capability checkbox with its dependants, so a click never leaves an impossible tuple. */
+export function withCapability(
+  capabilities: CodeHostReviewCapabilities,
+  key: keyof CodeHostReviewCapabilities,
+  enabled: boolean
+): CodeHostReviewCapabilities {
+  const next = { ...capabilities, [key]: enabled }
+  if (key === 'inlineComments' && !enabled) {
+    next.requestChanges = false
+    next.approve = false
+  } else if (key === 'requestChanges') {
+    if (enabled) next.inlineComments = true
+    else next.approve = false
+  } else if (key === 'approve' && enabled) {
+    next.inlineComments = true
+    next.requestChanges = true
+  }
+  return next
+}
+
+export const REVIEW_POLICY_OPTIONS: ReadonlyArray<{
+  value: HookReviewPolicy
+  label: string
+  description: string
+}> = [
+  { value: 'off', label: 'Off', description: 'Do not submit a formal review.' },
+  { value: 'comment', label: 'Comment', description: 'Submit a formal COMMENT review.' },
+  {
+    value: 'request_changes',
+    label: 'Request changes',
+    description: 'Allow COMMENT or REQUEST_CHANGES.'
+  },
+  { value: 'full', label: 'Full', description: 'Also allow an approval.' }
+]
+
+export function reviewPolicyLabel(policy: HookReviewPolicy): string {
+  return REVIEW_POLICY_OPTIONS.find((option) => option.value === policy)?.label ?? 'Off'
+}

--- a/packages/web/src/lib/github-review-settings.ts
+++ b/packages/web/src/lib/github-review-settings.ts
@@ -1,70 +1,33 @@
-/**
- * R1/R2a GitHub review settings shared by the create and edit surfaces.
- *
- * Keep the release boundary explicit here: the console only offers formal
- * reviews plus informational Checks. Required gates and legacy commit statuses
- * are later milestones and therefore have no option in this module.
- */
+// R1/R2a GitHub review settings shared by the create and edit surfaces.
+// The release boundary is explicit: only formal reviews plus informational Checks have options here.
+// The host-neutral half lives in `code-host-review-settings.ts`; what stays is GitHub's own
+// App-installation permissions and the per-repository access tier an effect is clamped against.
 
-export type HookReviewPolicy = 'off' | 'comment' | 'request_changes' | 'full'
-export type HookReportingMode = 'off' | 'check'
-export type HookGateMode = 'informational'
+import {
+  codeHostReviewCapabilities,
+  codeHostReviewSettingsFromCapabilities,
+  type CodeHostReviewCapabilities,
+  type CodeHostReviewSettingsValue,
+  type HookReportingMode
+} from './code-host-review-settings'
+
+export {
+  REVIEW_POLICY_OPTIONS,
+  reviewPolicyLabel,
+  type HookGateMode,
+  type HookReportingMode,
+  type HookReviewPolicy
+} from './code-host-review-settings'
+
 export type EffectiveRepoAccess = 'none' | 'read' | 'comment' | 'write'
 export type GithubChecksPermission = 'write' | 'missing' | 'unknown'
 export type GithubPullRequestsPermission = 'read' | 'write' | 'missing' | 'unknown'
 
-export interface GithubReviewSettingsValue {
-  reviewPolicy: HookReviewPolicy
-  reportingMode: HookReportingMode
-}
+export type GithubReviewSettingsValue = CodeHostReviewSettingsValue
+export type GithubReviewCapabilities = CodeHostReviewCapabilities
 
-export interface GithubReviewCapabilities {
-  inlineComments: boolean
-  requestChanges: boolean
-  approve: boolean
-  statusCheck: boolean
-}
-
-/** Present the hierarchical reviewPolicy enum as capability checkboxes. */
-export function githubReviewCapabilities(value: GithubReviewSettingsValue): GithubReviewCapabilities {
-  return {
-    inlineComments: value.reviewPolicy !== 'off',
-    requestChanges: value.reviewPolicy === 'request_changes' || value.reviewPolicy === 'full',
-    approve: value.reviewPolicy === 'full',
-    statusCheck: value.reportingMode === 'check'
-  }
-}
-
-/** Collapse capability checkboxes back to the strongest enabled R1 policy. */
-export function githubReviewSettingsFromCapabilities(
-  capabilities: GithubReviewCapabilities
-): GithubReviewSettingsValue {
-  return {
-    reviewPolicy: capabilities.approve
-      ? 'full'
-      : capabilities.requestChanges
-        ? 'request_changes'
-        : capabilities.inlineComments
-          ? 'comment'
-          : 'off',
-    reportingMode: capabilities.statusCheck ? 'check' : 'off'
-  }
-}
-
-export const REVIEW_POLICY_OPTIONS: ReadonlyArray<{
-  value: HookReviewPolicy
-  label: string
-  description: string
-}> = [
-  { value: 'off', label: 'Off', description: 'Do not submit a formal review.' },
-  { value: 'comment', label: 'Comment', description: 'Submit a formal COMMENT review.' },
-  {
-    value: 'request_changes',
-    label: 'Request changes',
-    description: 'Allow COMMENT or REQUEST_CHANGES.'
-  },
-  { value: 'full', label: 'Full', description: 'Also allow the shared App bot to approve.' }
-]
+export const githubReviewCapabilities = codeHostReviewCapabilities
+export const githubReviewSettingsFromCapabilities = codeHostReviewSettingsFromCapabilities
 
 export const REPORTING_MODE_OPTIONS: ReadonlyArray<{
   value: HookReportingMode
@@ -82,13 +45,8 @@ const ACCESS_RANK: Record<EffectiveRepoAccess, number> = {
   write: 3
 }
 
-/**
- * The additional capability a selected R1/R2a configuration needs. Any formal
- * review — even a COMMENT-type one — is submitted through the Reviews API, which
- * requires the App's pull_requests:write scope; the console now grants that only
- * via the `write` tier (the standalone `comment` grant tier was retired from the
- * UI). Informational Checks need checks:write, likewise the `write` tier.
- */
+/** The tier a configuration needs: every formal review and every Check goes through an API the
+ *  App holds only at `write`, so anything but the off pair demands the `write` grant tier. */
 export function requiredRepoAccess({ reviewPolicy, reportingMode }: GithubReviewSettingsValue): 'none' | 'write' {
   return reviewPolicy !== 'off' || reportingMode === 'check' ? 'write' : 'none'
 }
@@ -97,12 +55,8 @@ export function repoAccessSatisfies(actual: EffectiveRepoAccess, required: 'none
   return ACCESS_RANK[actual] >= ACCESS_RANK[required]
 }
 
-/**
- * Checks are authorized from the installation-effective permission snapshot,
- * not GitHub's coarse "new App permissions are waiting" status. The latter
- * can include unrelated permissions, while a legacy/unknown snapshot must
- * still fail closed.
- */
+/** Checks are authorized from the installation-effective snapshot, not the coarse
+ *  "permissions waiting" status; a legacy or unknown snapshot still fails closed. */
 export function hasChecksWritePermission(
   installation: { checksPermission: GithubChecksPermission } | null | undefined
 ): boolean {
@@ -149,11 +103,8 @@ export function isWorkspaceRepo(input: WorkspaceRepoMatchInput): boolean {
   )
 }
 
-/**
- * Resolve the hook repo against the agent's implicit App-backed workspace
- * grant first, then its explicit repo grants. Scratch has no implicit repo,
- * while a manual GitHub workspace can carry an explicit grant for its own repo.
- */
+/** Resolve the hook repo against the agent's implicit App-backed workspace grant first, then its
+ *  explicit repo grants — scratch has no implicit repo, a manual workspace may grant its own. */
 export function effectiveRepoAccess(input: {
   repoId?: string | null
   repoFullName: string | null | undefined
@@ -197,8 +148,4 @@ export function installationForRepo<T extends { accountLogin: string }>(
 ): T | undefined {
   const owner = repoFullName?.split('/')[0]?.toLowerCase()
   return owner ? installations.find((installation) => installation.accountLogin.toLowerCase() === owner) : undefined
-}
-
-export function reviewPolicyLabel(policy: HookReviewPolicy): string {
-  return REVIEW_POLICY_OPTIONS.find((option) => option.value === policy)?.label ?? 'Off'
 }


### PR DESCRIPTION
## Why

A GitLab hook could never run a formal merge-request review. The create route
hardcoded `reviewPolicy: req.body.kind === 'github' ? req.body.reviewPolicy : 'off'`
and the gitlab update arm omitted both effect fields, so every GitLab row stored
the off pair. The daemon's review gate is already provider-neutral — the GitLab
adapter and the GitHub orchestrator call the same `reviewPolicyAllows`, and
`gitlabOpensReviewGeneration` refuses to open a turn while the policy reads `off`
— so the stored value alone made §15 unreachable. The relay is neutral too: it
passes the snapshot through without looking at `kind`.

So the gap was entirely configuration: the axes had nowhere to be set.

## What

**Control plane.** `CreateGitlabHookBody` takes `reviewPolicy` and `reportingMode`
with the same defaults github uses; the whole-definition PUT keeps them optional so
a client that omits them preserves the stored pair instead of silently turning
reviews off. `compile()` stops forcing both to `off` for anything that is not a
generic webhook, so the compiled rule fence carries the real tuple.

`reportingMode` becomes load-bearing rather than a stored-but-inert knob: the §16
status note IS the run report, so `off` opens no projection at all. The gate reads
the accepted snapshot, never the live hook, so an edit mid-flight cannot strand an
open generation.

Configuration-time validation mirrors github's shape without inventing a clamp
GitLab does not have. There is no repository-access tier or app permission to
satisfy, because the project bot writes both effects under its provisioned role,
not the agent's git grant — the one precondition is that the binding has that bot.
`reportingMode: 'status'` is refused: §16.2 rules commit statuses out of this
transport, and GitLab keeps no `gateMode` because it has no required-gate surface.

**Console.** The review disclosure is now shared. The preset row, the four
capability checkboxes and the notice frame moved into `CodeHostReviewSettings`,
leaving each host only what is genuinely its own — github's installation
permissions and access tier, GitLab's project-bot readiness. GitLab hook rows gain
the settings button and summary line the github rows already carry, worded for
merge requests and run notes.

Per §18.1 the copy never implies that requesting changes blocks a merge: the hint
says GitLab records a change request only while the bot is a current reviewer, and
that approval is a separate act which project rules may still refuse.

## Behavior change worth a reviewer's attention

An existing GitLab hook stores `reportingMode: 'off'`, so it stops posting run
notes until the axis is turned on. That is the opt-in github has always had, and
the design lists reporting as a hook control rather than an implicit default. New
hooks created through the console open on the same "Details" preset the github
wizard does, so the wizard path is unchanged.

## Verification

- `pnpm typecheck` — all 13 packages, clean.
- `pnpm lint` — clean.
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 1963 passed.
- `pnpm --filter @agentconnect.md/control-plane test:int` — 1650 passed, including
  the new route tests: the axes round-trip and default off, PUT moves one axis and
  preserves the other, `status` is refused, and the pair reaches the compiled rule.
- `pnpm --filter @agentconnect.md/web test` — 1897 passed, including the new
  capability/preset unit tests and the modal tests asserting the GitLab pane offers
  the disclosure and uses GitLab tier wording rather than GitHub's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
