### PR TITLE
fix(daemon): never let the file share's identity decoration cost the delivery

### DIFF
--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -37,6 +37,7 @@ const EXEMPT: Record<string, string> = {
   postChatMessage: 'private shared post boundary behind postMessage/postBlocks',
   putUploadBytes: 'private step 2 of the external upload, behind uploadFile',
   completeUpload: 'private step 3 of the external upload, behind uploadFile',
+  completeShare: 'private one-shot completion boundary, behind completeUpload',
   // Interactive Slack surfaces (Block Kit actions / modals) are driven by
   // Bolt callbacks the virtual transport never receives; the daemon only
   // invokes them from those callbacks.

--- a/packages/daemon/src/mcp/ops/context.ts
+++ b/packages/daemon/src/mcp/ops/context.ts
@@ -48,7 +48,12 @@ export interface UploadAnchor {
 export type UploadFailReason =
   'missing_scope' | 'too_large' | 'not_found' | 'forbidden' | 'indeterminate' | 'platform_error'
 
-export type UploadOutcome = { ok: true; messageId?: string; warning?: string } | { ok: false; reason: UploadFailReason }
+export type UploadOutcome =
+  | { ok: true; messageId?: string; warning?: string }
+  /** `detail` is the PROVIDER's own error code, carried because a category alone is not
+   *  diagnosable: `platform_error` is the catch-all every unclassified refusal lands in, and
+   *  a report that omits what the platform actually said cannot be acted on. */
+  | { ok: false; reason: UploadFailReason; detail?: string }
 
 export interface MessageGateway {
   /** Layer-1 `openDirectMessage`: resolve one platform user to the app's real

--- a/packages/daemon/src/mcp/ops/messaging.ts
+++ b/packages/daemon/src/mcp/ops/messaging.ts
@@ -607,9 +607,10 @@ export async function sendMessage(
               'MAY still have been delivered — do NOT retry; say the send may have gone through instead.'
           )
         }
+        const detail = shared && !shared.ok && shared.detail ? `: ${shared.detail}` : ''
         throw new Error(
           `sendMessage: ${platformLabel(wantPlatform)} rejected the file "${attachment.name}" ` +
-            `(${reason.replace('_', ' ')}) — nothing was sent.`
+            `(${reason.replace('_', ' ')}${detail}) — nothing was sent.`
         )
       }
       providerPostId = shared.messageId

--- a/packages/daemon/src/mcp/ops/share-file.ts
+++ b/packages/daemon/src/mcp/ops/share-file.ts
@@ -172,7 +172,8 @@ export async function shareFile(
         'shareFile: the upload timed out and MAY still have been delivered — do NOT retry; say the image may have gone through instead.'
       )
     }
-    throw new Error(UPLOAD_REFUSALS[outcome.reason](platformLabel(target.platform)))
+    const refusal = UPLOAD_REFUSALS[outcome.reason](platformLabel(target.platform))
+    throw new Error(outcome.detail ? `${refusal} (${outcome.detail})` : refusal)
   }
 
   // Provenance (docs §4): the model-chosen path plus what was ACTUALLY published — sniffed

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -1390,7 +1390,14 @@ export class SlackConnection implements PlatformConnection {
       } catch (err) {
         this.rememberMissingScopes(err)
         this.deps.log?.debug(`slack: uploadFile ${file.name} → ch=${channel} failed: ${(err as Error).message}`)
-        return { ok: false, reason: classifySlackUploadError(err), ...slackErrorDetail(err) }
+        // A share whose outcome Slack never confirmed must say "may have landed", never
+        // "nothing was sent" — the same rule the send queue's abandonment already follows.
+        const ambiguous = (err as { shareMayHaveLanded?: unknown } | null)?.shareMayHaveLanded === true
+        return {
+          ok: false,
+          reason: ambiguous ? 'indeterminate' : classifySlackUploadError(err),
+          ...slackErrorDetail(err)
+        }
       }
     })
     // The queue abandons a task at 30 s but the task KEEPS RUNNING — the share may still
@@ -1453,6 +1460,21 @@ export class SlackConnection implements PlatformConnection {
    * would have done for the one cause it knew about. The file lands either way; the agent's
    * name on it is the part we are willing to lose.
    */
+  /**
+   * `files.completeUploadExternal` is ONE-SHOT: it cannot be safely repeated, because a
+   * second call after a lost response would double-post. So a failure that is not a DEFINITE
+   * platform refusal (Slack answering `{ok:false, error}`) is ambiguous — the share may
+   * already be visible — and is marked as such rather than treated as "nothing happened".
+   */
+  private async completeShare(payload: Record<string, unknown>): Promise<void> {
+    try {
+      await this.app.client.files.completeUploadExternal(payload)
+    } catch (err) {
+      if (slackApiErrorCode(err) === undefined) throw Object.assign(err as Error, { shareMayHaveLanded: true })
+      throw err
+    }
+  }
+
   private async completeUpload(share: Record<string, unknown>, options?: SlackPostOptions): Promise<void> {
     const customize: Record<string, unknown> = {}
     const username = options?.username?.trim()
@@ -1460,21 +1482,25 @@ export class SlackConnection implements PlatformConnection {
     if (username) customize.username = username
     if (iconUrl) customize.icon_url = iconUrl
     if (Object.keys(customize).length === 0 || Date.now() < this.customUsernameRetryAt) {
-      await this.app.client.files.completeUploadExternal(share)
+      await this.completeShare(share)
       return
     }
     try {
-      await this.app.client.files.completeUploadExternal({ ...share, ...customize })
+      await this.completeShare({ ...share, ...customize })
       this.customUsernameRetryAt = 0
     } catch (err) {
       this.rememberMissingScopes(err)
+      // A second completion is only safe when Slack DEFINITELY refused the first: an
+      // ambiguous transport failure may have been accepted, and retrying it would either
+      // double-post or report "nothing was sent" for a file the channel already shows.
+      if (slackApiErrorCode(err) === undefined) throw err
       // Only a genuine missing scope arms the shared backoff — anything else is this
       // method's own argument handling and says nothing about the text path.
       if (isMissingCustomizeScope(err)) this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
       this.deps.log?.debug(
-        `slack: decorated file share refused (${slackApiErrorCode(err) ?? (err as Error).message}) — retrying under the app identity`
+        `slack: decorated file share refused (${slackApiErrorCode(err)}) — retrying under the app identity`
       )
-      await this.app.client.files.completeUploadExternal(share)
+      await this.completeShare(share)
     }
   }
 

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -527,6 +527,14 @@ const SLACK_API_TIMEOUT_MS = 30_000
 
 /** Map a Slack API error to the port's typed failure vocabulary — every arm already had the
  *  raw material (`missing_scope` payloads, stable error codes); this only names them. */
+/** The provider's own words, for the arm that has no category: without this a refusal
+ *  reports only `platform error`, which no operator can act on. */
+function slackErrorDetail(err: unknown): { detail?: string } {
+  const code = slackApiErrorCode(err)
+  const text = code ?? (err as Error | undefined)?.message
+  return text ? { detail: text.slice(0, 120) } : {}
+}
+
 function classifySlackUploadError(err: unknown): UploadFailReason {
   if (missingScopesFrom(err).length > 0) return 'missing_scope'
   const code = slackApiErrorCode(err)
@@ -1382,7 +1390,7 @@ export class SlackConnection implements PlatformConnection {
       } catch (err) {
         this.rememberMissingScopes(err)
         this.deps.log?.debug(`slack: uploadFile ${file.name} → ch=${channel} failed: ${(err as Error).message}`)
-        return { ok: false, reason: classifySlackUploadError(err) }
+        return { ok: false, reason: classifySlackUploadError(err), ...slackErrorDetail(err) }
       }
     })
     // The queue abandons a task at 30 s but the task KEEPS RUNNING — the share may still
@@ -1399,7 +1407,7 @@ export class SlackConnection implements PlatformConnection {
   private async putUploadBytes(
     uploadUrl: string,
     file: { bytes: Buffer; name: string }
-  ): Promise<{ ok: true } | { ok: false; reason: UploadFailReason }> {
+  ): Promise<{ ok: true } | { ok: false; reason: UploadFailReason; detail?: string }> {
     const form = new FormData()
     form.append('file', new Blob([new Uint8Array(file.bytes)]), file.name)
     // This runs inside the serial send queue, so it carries the same bound the WebClient
@@ -1422,7 +1430,11 @@ export class SlackConnection implements PlatformConnection {
       await res.body?.cancel().catch(() => {})
       if (!res.ok) {
         this.deps.log?.debug(`slack: uploadFile byte POST for ${file.name} → HTTP ${res.status}`)
-        return { ok: false, reason: res.status === 413 ? 'too_large' : 'platform_error' }
+        return {
+          ok: false,
+          reason: res.status === 413 ? 'too_large' : 'platform_error',
+          detail: `byte upload HTTP ${res.status}`
+        }
       }
       return { ok: true }
     } finally {
@@ -1432,8 +1444,15 @@ export class SlackConnection implements PlatformConnection {
     }
   }
 
-  /** Step 3 of the upload, with the same `chat:write.customize` fallback the text send has:
-   *  an installation without the scope still shares the file, under the app's own identity. */
+  /**
+   * Step 3 of the upload. The identity decoration is BEST-EFFORT and must never cost the
+   * delivery: `username`/`icon_url` are documented for this method but absent from the SDK's
+   * own argument type, so a rejection here is not necessarily the `chat:write.customize`
+   * scope — it can be the arguments themselves. Any failure of the decorated call is
+   * therefore retried once undecorated, which is what the text path's narrower fallback
+   * would have done for the one cause it knew about. The file lands either way; the agent's
+   * name on it is the part we are willing to lose.
+   */
   private async completeUpload(share: Record<string, unknown>, options?: SlackPostOptions): Promise<void> {
     const customize: Record<string, unknown> = {}
     const username = options?.username?.trim()
@@ -1449,9 +1468,12 @@ export class SlackConnection implements PlatformConnection {
       this.customUsernameRetryAt = 0
     } catch (err) {
       this.rememberMissingScopes(err)
-      if (!isMissingCustomizeScope(err)) throw err
-      this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
-      this.deps.log?.debug('slack: chat:write.customize missing — sharing the file with the app default identity')
+      // Only a genuine missing scope arms the shared backoff — anything else is this
+      // method's own argument handling and says nothing about the text path.
+      if (isMissingCustomizeScope(err)) this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
+      this.deps.log?.debug(
+        `slack: decorated file share refused (${slackApiErrorCode(err) ?? (err as Error).message}) — retrying under the app identity`
+      )
       await this.app.client.files.completeUploadExternal(share)
     }
   }

--- a/packages/daemon/test/slack-upload-file.test.ts
+++ b/packages/daemon/test/slack-upload-file.test.ts
@@ -107,6 +107,23 @@ describe('SlackConnection.uploadFile', () => {
     expect(completeUploadExternal.mock.calls[1]![0]).not.toHaveProperty('username')
   })
 
+  it('does NOT retry a completion whose outcome Slack never confirmed, and calls it indeterminate', async () => {
+    // completeUploadExternal is one-shot: a transport failure may have been ACCEPTED with its
+    // response lost, so a second call could double-post and "nothing was sent" could be a lie
+    // about a file the channel already shows.
+    const completeUploadExternal = vi.fn(async () => {
+      throw new Error('socket hang up')
+    })
+    const conn = connWith({
+      getUploadURLExternal: async () => ({ upload_url: 'https://files.slack.com/upload/v1/x', file_id: 'F1' }),
+      completeUploadExternal
+    })
+    await expect(
+      conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi', undefined, { username: 'Scout' })
+    ).resolves.toEqual({ ok: false, reason: 'indeterminate', detail: 'socket hang up' })
+    expect(completeUploadExternal).toHaveBeenCalledOnce()
+  })
+
   it('reports the provider’s own error code, since `platform error` alone is not actionable', async () => {
     const conn = connWith({
       getUploadURLExternal: async () => {

--- a/packages/daemon/test/slack-upload-file.test.ts
+++ b/packages/daemon/test/slack-upload-file.test.ts
@@ -88,6 +88,39 @@ describe('SlackConnection.uploadFile', () => {
     })
   })
 
+  it('shares under the app identity when ANY decorated attempt is refused, not only a missing scope', async () => {
+    // username/icon_url are documented for this method but absent from the SDK's argument
+    // type, so a rejection is not necessarily the scope — it can be the arguments. The file
+    // must land either way; the agent's name on it is the part we are willing to lose.
+    const completeUploadExternal = vi.fn(async (a: Record<string, unknown>) => {
+      if (a.username) throw Object.assign(new Error('invalid_arguments'), { data: { error: 'invalid_arguments' } })
+      return { files: [{ id: 'F1' }] }
+    })
+    const conn = connWith({
+      getUploadURLExternal: async () => ({ upload_url: 'https://files.slack.com/upload/v1/x', file_id: 'F1' }),
+      completeUploadExternal
+    })
+    await expect(
+      conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi', undefined, { username: 'Scout' })
+    ).resolves.toEqual({ ok: true })
+    expect(completeUploadExternal).toHaveBeenCalledTimes(2)
+    expect(completeUploadExternal.mock.calls[1]![0]).not.toHaveProperty('username')
+  })
+
+  it('reports the provider’s own error code, since `platform error` alone is not actionable', async () => {
+    const conn = connWith({
+      getUploadURLExternal: async () => {
+        throw Object.assign(new Error('nope'), { data: { error: 'method_not_supported_for_channel_type' } })
+      },
+      completeUploadExternal: async () => ({ files: [] })
+    })
+    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
+      ok: false,
+      reason: 'platform_error',
+      detail: 'method_not_supported_for_channel_type'
+    })
+  })
+
   it('shares under the app identity when chat:write.customize is missing', async () => {
     const completeUploadExternal = vi.fn(async (a: Record<string, unknown>) => {
       if (a.username)
@@ -142,7 +175,8 @@ describe('SlackConnection.uploadFile', () => {
     })
     await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
       ok: false,
-      reason: 'platform_error'
+      reason: 'platform_error',
+      detail: 'slack down'
     })
   })
 
@@ -156,7 +190,8 @@ describe('SlackConnection.uploadFile', () => {
     })
     await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
       ok: false,
-      reason: 'missing_scope'
+      reason: 'missing_scope',
+      detail: 'missing_scope'
     })
   })
 })


### PR DESCRIPTION
## The observed failure

A Slack→Slack forward in test, read from the session's tool call. Everything upstream was right — #1410's marker fix worked, the agent had the name, and the handle resolved:

```json
{ "channel": "C0BLVB0TYPR", "attachment": "image.png", "message": "<caption>" }
```
```
"sendMessage: Slack rejected the file \"image.png\" (platform error) — nothing was sent."
```

`platform_error` is the catch-all, and the provider's own error code had been thrown away — so the report said nothing anyone could act on.

## Cause

The share sends `username`/`icon_url`. The Slack reference documents them for `files.completeUploadExternal`; the SDK's own argument type does not have them:

```ts
FilesCompleteUploadExternalArguments = FileDestinationArgument & TokenOverridable & {
  files; initial_comment?; blocks?
}
```

So a rejection there is **not necessarily** the `chat:write.customize` scope — it can be the arguments. The fallback only caught `missing_scope`, so anything else threw straight out of the upload.

## The fix

**Identity is best-effort; delivery is not.** Any refusal of the decorated call retries once undecorated. The file lands either way, and the agent's name on it is the part we are willing to lose — a degradation the design already documents. Only a genuine missing scope still arms the shared `customUsernameRetryAt` backoff, since nothing else says anything about the text path.

**The refusal carries the provider's error code.** `UploadOutcome`'s failure gains `detail`, populated from Slack's `error` field (or the byte POST's HTTP status), and both callers include it. `platform error` becomes `platform error: method_not_supported_for_channel_type` — the difference between a dead end and a next step.

## Testing

- Any decorated refusal (not just `missing_scope`) retries undecorated and succeeds, with the second call asserted to carry no `username`.
- The provider's code survives into the outcome; the two existing classification tests now pin it too.
- Full daemon `test:unit` clean apart from this machine's pre-existing `sandbox-exec` failures (shim-*, verified identical on a clean tree).

Honest caveat: this is still the first code in this path that has met real Slack. If the retry also fails, the refusal will now name Slack's actual error, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

