### PR TITLE
fix(daemon): name the Slack upload part `body`, the name Slack's SDK sends

### DIFF
--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -1415,8 +1415,13 @@ export class SlackConnection implements PlatformConnection {
     uploadUrl: string,
     file: { bytes: Buffer; name: string }
   ): Promise<{ ok: true } | { ok: false; reason: UploadFailReason; detail?: string }> {
+    // FIELD NAME `body`, NOT `file`: this shape is not ours to choose — it is what Slack's
+    // own SDK sends (`postFileUploadsToExternalURL` posts `{ body: data }`, which its
+    // form serializer turns into one multipart part named `body`). A part named anything
+    // else is answered with HTTP 500 by the reserved upload URL, which is what a live
+    // Slack→Slack forward hit.
     const form = new FormData()
-    form.append('file', new Blob([new Uint8Array(file.bytes)]), file.name)
+    form.append('body', new Blob([new Uint8Array(file.bytes)]), file.name)
     // This runs inside the serial send queue, so it carries the same bound the WebClient
     // does: a stuck upload must not wedge every other message on this connection.
     const dispatcher = proxyDispatcher()

--- a/packages/daemon/test/slack-upload-file.test.ts
+++ b/packages/daemon/test/slack-upload-file.test.ts
@@ -73,6 +73,11 @@ describe('SlackConnection.uploadFile', () => {
       'https://files.slack.com/upload/v1/x',
       expect.objectContaining({ method: 'POST' })
     )
+    // The multipart part must be named `body`, the name Slack's own SDK sends. Anything
+    // else — `file`, say — is answered with HTTP 500 by the reserved upload URL.
+    const posted = undici.fetch.mock.calls[0]![1] as { body: FormData }
+    expect(posted.body.has('body')).toBe(true)
+    expect(posted.body.has('file')).toBe(false)
     // channel_id is what turns a hosted file into a message; without it the upload stays
     // private. The caption rides as initial_comment, and the agent keeps its own identity.
     expect(completeUploadExternal).toHaveBeenCalledWith({


### PR DESCRIPTION
## What the diagnostic bought us

#1417 made the refusal name the step and the provider's own words. One live Slack→Slack forward later, the agent reported the forward as failed with **`byte upload HTTP 500`** — not a bare `platform error`.

That points at exactly one step: the POST of the bytes to the reserved upload URL. It also retires the previous hypothesis — the `username`/`icon_url` identity arguments were never reached.

## The cause

The byte POST is multipart, and the part name is **not ours to choose**. Slack's own SDK does this:

```js
const body = data
await this.makeRequest(upload_url, { body }, headers)
```

…and its form serializer turns that object into a single multipart part named **`body`**. We were sending one named `file`. The reserved upload URL answers that with a 500.

One word. Matching the reference implementation is the whole fix.

## Why no test caught it

Every assertion in the Slack upload suite runs against a mocked upload URL that accepts any shape — which is precisely how a wrong shape shipped. The test now pins the part name (`body` present, `file` absent), so the one detail that only real Slack could reject is now checkable without it.

## Honest status

This is inferred from Slack's reference implementation rather than from a live send — the strongest evidence available short of running it. If it is still wrong, the refusal will again name the step and the status, which is what makes the next iteration one round instead of a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
