### PR TITLE
fix(daemon): converge the GitLab run-projection note past its first write

### DIFF
--- a/packages/control-plane/test/repo/code-host-projection.repo.test.ts
+++ b/packages/control-plane/test/repo/code-host-projection.repo.test.ts
@@ -203,6 +203,51 @@ describe('code-host run projection ledger (gitlab-com-integration.md §16)', () 
     expect(advanced!.pendingIntent).toBeNull()
   })
 
+  it('lets the terminal edge of a run win after the daemon refused its non-terminal write', async () => {
+    const ledger = repo()
+    const base = input(await owner())
+    const opened = await upsert(base)
+    // The create lands: the note exists and reads queued.
+    const created = randomUUID()
+    expect(await ledger.beginWrite(opened.id, 1n, DAEMON, created, 'create', NOW, LATER)).toBe(true)
+    expect(
+      await ledger.completeWrite({
+        projectionId: opened.id,
+        generation: 1n,
+        leaseOwner: DAEMON,
+        writeMarker: created,
+        observedState: 'queued',
+        noteId: '987654321'
+      })
+    ).toBe(true)
+
+    // The running edge of the SAME run moves the state inside this generation, and the daemon
+    // refuses that write with a ledger code — a proved non-effect, so the mutex is released.
+    expect(await ledger.setDesired(opened.id, 1n, 'running', LATER)).toBe(true)
+    const refused = randomUUID()
+    expect(await ledger.beginWrite(opened.id, 1n, DAEMON, refused, 'update', NOW, LATER)).toBe(true)
+    expect(await ledger.failWrite(opened.id, 1n, DAEMON, refused, 'projection_key_conflict', LATER, false)).toBe(true)
+    const stuck = (await ledger.get(opened.id))!
+    expect(stuck.desiredState).toBe('running')
+    expect(stuck.observedState).toBe('queued')
+    expect(stuck.attempts).toBe(1)
+    expect(stuck.lastErrorCode).toBe('projection_key_conflict')
+
+    // Nothing re-dispatches a refused generation on its own, so the terminal edge is the only
+    // thing that can move this row — a refusal must never cost the run its final state.
+    const reported = await upsert({ ...base, desiredState: 'completed', currentRunAt: LATER, completedAt: LATER })
+    expect(reported.generation).toBe(1n)
+    expect(reported.pendingIntent).toBeNull()
+    expect(await ledger.setDesired(opened.id, 1n, 'completed', LATER)).toBe(true)
+    const terminal = (await ledger.get(opened.id))!
+    expect(terminal.desiredState).toBe('completed')
+    expect(terminal.sealedThrough).toBe(1n)
+    // And it is dispatchable: the refusal left no marker or lease behind to fence the write out.
+    expect(terminal.writeMarker).toBeNull()
+    expect(terminal.writePhase).toBeNull()
+    expect(await ledger.beginWrite(opened.id, 1n, DAEMON, randomUUID(), 'update', LATER, LATER)).toBe(true)
+  })
+
   it('keeps an ambiguous mutation on its writer and lets that writer reconcile it', async () => {
     const ledger = repo()
     const opened = await upsert(await owner())

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7883,6 +7883,9 @@ export class Daemon {
       ...(hook.snapshot ?? {}),
       ...(hook.event ? { event: hook.event } : {}),
       ...(hook.github ? { github: hook.github } : {}),
+      // The §16 terminal edge is keyed on this subject: without it the note never leaves its
+      // last non-terminal state, because nothing else re-dispatches the projection.
+      ...(hook.gitlab ? { gitlab: hook.gitlab } : {}),
       status,
       durationMs: Number.isFinite(start) ? Math.max(0, this.clock.now() - start) : 0,
       ...extra,

--- a/packages/daemon/src/store/postgres-dialect.ts
+++ b/packages/daemon/src/store/postgres-dialect.ts
@@ -14,7 +14,7 @@ export const POOL_STORE_SCHEMA = 'agentconnect_cloud_store'
 export const SCHEMA_LOCK_KEY = 'agentconnect-cloud-store-schema'
 export const TRANSCRIPT_REVISION_LOCK_KEY = 'agentconnect-cloud-transcript-revision'
 
-/** camelCase column names as `LocalStore` spells them; PostgreSQL folds unquoted ones to lower. */
+/** Every camelCase column and result alias `LocalStore` spells; an unlisted one reads back undefined. */
 export const canonicalColumns = [
   'acpSessionId',
   'activationKey',
@@ -25,6 +25,7 @@ export const canonicalColumns = [
   'agentId',
   'attachmentsJson',
   'attemptAt',
+  'attemptId',
   'authorityGeneration',
   'authorityId',
   'automaticCount',
@@ -46,6 +47,8 @@ export const canonicalColumns = [
   'cpPrivate',
   'cpRev',
   'createdAt',
+  'credentialEpoch',
+  'daemonId',
   'defaultModel',
   'defaultPermissionMode',
   'deliveryReason',
@@ -67,9 +70,12 @@ export const canonicalColumns = [
   'failedAttempts',
   'fastModeOverride',
   'globalRules',
+  'headSha',
   'hookContext',
+  'hookId',
   'integrationId',
   'imageRef',
+  'intentId',
   'introducedAt',
   'isIm',
   'isQueueCmd',
@@ -83,11 +89,14 @@ export const canonicalColumns = [
   'mainSessionKey',
   'manifestDigest',
   'memoryProvider',
+  'mergeRequestIid',
+  'mintedAt',
   'modelId',
   'modelOverride',
   'modelsHash',
   'needsParentReply',
   'nextAttemptAt',
+  'noteId',
   'observedAt',
   'observedModel',
   'observedModelSet',
@@ -110,6 +119,9 @@ export const canonicalColumns = [
   'posterPublishState',
   'profileId',
   'probedAt',
+  'projectId',
+  'projectionId',
+  'projectionKey',
   'providerCheckpoint',
   'purgedAt',
   'queuedAt',
@@ -154,7 +166,8 @@ export const canonicalColumns = [
   'turnId',
   'updatedAt',
   'windowStartedAt',
-  'workspaceIsolation'
+  'workspaceIsolation',
+  'writeMarker'
 ] as const
 
 /** Lower-cased column name → the camelCase spelling every row shape expects back. */

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -326,6 +326,11 @@ describe('Daemon rd/msg hook fires', () => {
         expect(payload.github).toBeUndefined()
         expect(payload.sessionId).toBeTruthy()
       }
+      // The terminal report carries the same subject, whatever the start barrier did: the control
+      // plane projects the §16 note's terminal edge only from a report that names its merge request.
+      const report = cp.hookReports[0]!
+      expect(report.gitlab).toEqual(gitlabReviewFire(dispatchDaemonId).gitlab)
+      expect(report.github).toBeUndefined()
       await daemon.stop()
     },
     15_000

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
+import type { NoteProjectionRow } from '../src/gitlab/note-projection.js'
 import { LocalStore, sessionKey, type StoreDatabase } from '../src/store/local-store.js'
 import { SqliteAsyncDatabase } from '../src/store/sqlite-async-database.js'
 import { memoryStoreDatabase, openTestStore, usingPostgresStore } from './store-support.js'
@@ -2426,6 +2427,55 @@ describe('transcript org fence on a shared store', () => {
     await a.appendTranscript({ channel: 'C1', thread: 'T9', ts: '1', sender: 'U', kind: 'text', text: 'observed' })
     expect((await a.threadTranscript('C1', 'T9', 'agent-a')).map((r) => r.text)).toEqual(['observed'])
     await a.close()
+  })
+})
+
+describe('code-host note projection ledger (gitlab-com-integration.md §16)', () => {
+  const DAEMON = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd1'
+  const ledgerRow = (overrides: Partial<NoteProjectionRow> = {}): NoteProjectionRow => ({
+    projectionKey: 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1',
+    projectionId: 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1',
+    hookId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1',
+    agentId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1',
+    orgId: 'org-1',
+    provider: 'gitlab',
+    projectId: '4455667',
+    mergeRequestIid: 42,
+    headSha: 'a'.repeat(40),
+    generation: '1',
+    writeMarker: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeee1',
+    state: 'queued',
+    body: 'AgentConnect run — Queued',
+    noteId: '9001',
+    credentialEpoch: '2',
+    daemonId: DAEMON,
+    phase: 'in_flight',
+    ...overrides
+  })
+
+  // The projector's key fence compares its stored row against the incoming desired frame with ===,
+  // so a field that does not survive the read refuses every update after the create.
+  it('reads every field back with the value and type it was written with', async () => {
+    const s = await store()
+    const row = ledgerRow()
+    await s.beginNoteProjectionWrite(row, 1000)
+    const stored = await s.getNoteProjection(DAEMON, row.projectionKey)
+    expect(stored).toEqual(row)
+    expect(typeof stored!.mergeRequestIid).toBe('number')
+    for (const field of ['hookId', 'projectId', 'mergeRequestIid', 'headSha'] as const) {
+      expect(stored![field]).toBe(row[field])
+    }
+    await s.close()
+  })
+
+  it('replays an unsettled write with the same fields the sweep compares', async () => {
+    const s = await store()
+    const row = ledgerRow()
+    await s.recordNoteProjectionOutcome(row, 'written', undefined, 1000)
+    expect(await s.listUnsettledNoteProjections(DAEMON)).toEqual([
+      { ...row, phase: 'settled_unreported', outcome: 'written' }
+    ])
+    await s.close()
   })
 })
 

--- a/packages/daemon/test/postgres-dialect.test.ts
+++ b/packages/daemon/test/postgres-dialect.test.ts
@@ -3,7 +3,10 @@
  * exact output — every rewrite rule, both binding forms, revision-slot detection, and the
  * PRAGMA / `sqlite_master` emulation `LocalStore` depends on.
  */
+import { DatabaseSync } from 'node:sqlite'
 import { describe, expect, it } from 'vitest'
+import { LocalStore } from '../src/store/local-store.js'
+import { tempStorePath } from './store-support.js'
 import {
   bind,
   changesOf,
@@ -185,6 +188,31 @@ describe('result shaping', () => {
 
   it('maps every canonical column back from its folded spelling', () => {
     expect(columnNames['transcriptcoordinates']).toBe('transcriptCoordinates')
+  })
+})
+
+describe('canonical column coverage', () => {
+  // The list is what restores a folded name, so a camelCase column missing from it reads back as
+  // undefined on PostgreSQL only — the store's row shapes silently lose that field. Enumerate the
+  // real schema and require every one of them, instead of trusting the list to be maintained.
+  it('names every camelCase column the store schema declares', async () => {
+    const path = tempStorePath('ac-dialect-')
+    await (await LocalStore.open(path)).close()
+    const db = new DatabaseSync(path)
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
+      .all() as Array<{ name: string }>
+    const unregistered: string[] = []
+    for (const { name } of tables) {
+      const columns = db.prepare(`PRAGMA table_info("${name}")`).all() as Array<{ name: string }>
+      for (const column of columns) {
+        if (!/[A-Z]/.test(column.name)) continue
+        if (columnNames[column.name.toLowerCase()] !== column.name) unregistered.push(`${name}.${column.name}`)
+      }
+    }
+    db.close()
+    expect(tables.length).toBeGreaterThan(0)
+    expect(unregistered).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Symptom

On a deployment running the Postgres data plane, the §16 GitLab merge-request status note was created correctly — "AgentConnect run — Queued", hidden marker, note id recorded back — and then never changed again. Every subsequent edge (`running` from the start barrier, the terminal edge, `superseded` on a newer head) was refused by the daemon with `projection_key_conflict`. The control-plane row settled at `desiredState=running, observedState=queued, lastErrorCode=projection_key_conflict, attempts=1` and never converged; the note read "Queued" even after the run succeeded.

Two independent defects, either of which alone strands the note.

## 1. Ten projection columns never survived a Postgres read

`canonicalColumns` in the store's dialect layer restores the camelCase column names PostgreSQL folds to lower case on the way back out. It is hand-maintained, and thirteen columns were never added to it — including all ten of `code_host_note_projection`.

So `getNoteProjection()` on Postgres returned a row whose `hookId`, `projectId`, `mergeRequestIid`, and `headSha` were `undefined`. Those are the exact four fields the projector's key fence compares with `===`, so the fence refused every update. This was not a widened integer or a string/number drift — the keys were simply absent. Creates were unaffected because the create path has no stored row to compare against, which is why the note appeared and then froze.

`code_host_review_intent` (intent replay) and `session_outward_ids` had the same gap.

The list now covers the schema. To keep it covered, a new test opens a real store, enumerates every table and column from the store's own DDL, and fails naming any camelCase column that is not registered — so the next table added cannot reintroduce this silently.

## 2. The terminal edge was never emitted

`buildHookReport` spread the GitHub subject but never the GitLab one, so `hook/report` always arrived with `gitlab` undefined. The control plane projects the §16 terminal edge only from a report that names its merge request, so `afterReport` was never called for GitLab at all: `desiredState` stayed on its last non-terminal value, and since nothing re-dispatches a settled generation on its own, the row had nothing left to move it.

The ledger itself was not at fault — a new integration case drives create → running → refused write → terminal edge against real Postgres and shows the terminal edge does take the row and leaves it dispatchable.

## Tests

- `postgres-dialect` — schema-derived coverage guard; fails naming `code_host_note_projection.mergeRequestIid` when that entry is removed.
- `local-store` — the note-projection ledger round-trips every field with its written value and type through **both** backends (this suite runs in the SQLite lane and the `store-postgres` lane). Without the fix the Postgres lane reports ten fields as `undefined`.
- `daemon-hook` — the terminal report carries the merge-request subject; fails with `expected undefined` without the fix.
- `code-host-projection.repo` — a terminal edge after a refused non-terminal write still becomes the desired state and stays dispatchable.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean. Daemon suite and the `store-postgres` lane (7 files, 134 tests) green; control-plane `test:unit` (1965) and `test:int` (1651) green. Pre-existing sandbox/shim and real-runtime matrix failures reproduce identically on an untouched tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
