### PR TITLE
feat(web): show each agent's own GitLab bot identity

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1829,7 +1829,10 @@ export const GitlabProjectBindingDto = z.object({
       agentId: z.string(),
       username: z.string(),
       displayName: z.string().nullable(),
-      userId: z.string().nullable()
+      userId: z.string().nullable(),
+      /** The account's OWN health: an agent's identity can be broken on a project whose binding is ready. */
+      state: z.enum(['provisioning', 'ready', 'admin_degraded', 'runtime_degraded', 'cleanup_pending']),
+      stateReason: z.string().nullable()
     })
   ),
   webhookInstalled: z.boolean(),
@@ -1844,6 +1847,26 @@ export const CreateGitlabProjectBody = z.object({
   connectionId: z.string().uuid(),
   projectId: z.string().regex(/^[1-9]\d*$/) // numeric id as a string; the server re-fetches and validates
 })
+
+/** One agent's own GitLab identity (§7.2): the group service account it acts as,
+ *  one per top-level group it has a bound project in. No token material. */
+export const GitlabAgentAccountDto = z.object({
+  id: z.string(),
+  rootGroupId: z.string(), // numeric top-level group id, losslessly as a string
+  /** Current path of that top-level group, read off a bound project; null while none is bound. */
+  rootGroupPath: z.string().nullable(),
+  username: z.string(),
+  displayName: z.string().nullable(),
+  userId: z.string().nullable(), // numeric GitLab user id; null until the account exists
+  /** The §8.2 lifecycle vocabulary the binding uses, so the console translates one set. */
+  state: z.enum(['provisioning', 'ready', 'admin_degraded', 'runtime_degraded', 'cleanup_pending']),
+  stateReason: z.string().nullable(),
+  /** `retiring` once the agent's last project in the group went away (§7.2). */
+  lifecycle: z.enum(['active', 'retiring'])
+})
+export type GitlabAgentAccountDtoT = z.infer<typeof GitlabAgentAccountDto>
+
+export const GitlabAgentAccountListDto = z.object({ accounts: z.array(GitlabAgentAccountDto) })
 
 export const GithubAppDto = z.object({
   enabled: z.boolean(),

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -18,7 +18,9 @@ import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
-import { orgOf, denyViewerWrite } from '../rbac.js'
+import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
+import { canView } from '../../authorization/policy.js'
+import { AgentId } from '../../domain/ids.js'
 import { Tag } from '../plugins/openapi.js'
 import { GitlabOauthDenied, OAUTH_BROWSER_COOKIE } from '../../gitlab/oauth.service.js'
 import {
@@ -33,6 +35,7 @@ import { GitlabProjectClaimConflict } from '../../persistence/errors.js'
 import {
   CreateGitlabProjectBody,
   ErrorDto,
+  GitlabAgentAccountListDto,
   GitlabConnectionDeleteDto,
   GitlabConnectionListDto,
   GitlabOauthStartDto,
@@ -76,11 +79,40 @@ function bindingToDto(r: GitlabProjectBindingRecord, accounts: GitlabAgentAccoun
       agentId: account.agentId,
       username: account.username,
       displayName: account.displayName,
-      userId: account.serviceAccountUserId?.toString() ?? null
+      userId: account.serviceAccountUserId?.toString() ?? null,
+      state: account.state,
+      stateReason: account.stateReason
     })),
     webhookInstalled: r.webhookId !== null,
     credentialEpoch: r.credentialEpoch.toString(),
     createdAt: r.createdAt.toISOString()
+  }
+}
+
+/** One agent account (§7.2) — the group is a bare number on the row, so the readable heading comes off a bound project. */
+function accountToDto(
+  r: GitlabAgentAccountRecord,
+  bindingIds: readonly string[],
+  projectPaths: ReadonlyMap<string, string>
+) {
+  let rootGroupPath: string | null = null
+  for (const bindingId of bindingIds) {
+    const segment = projectPaths.get(bindingId)?.split('/')[0]
+    if (segment) {
+      rootGroupPath = segment
+      break
+    }
+  }
+  return {
+    id: r.id,
+    rootGroupId: r.rootGroupId.toString(),
+    rootGroupPath,
+    username: r.username,
+    displayName: r.displayName,
+    userId: r.serviceAccountUserId?.toString() ?? null,
+    state: r.state,
+    stateReason: r.stateReason,
+    lifecycle: r.lifecycle
   }
 }
 
@@ -205,6 +237,46 @@ export function gitlabRoutes(deps: HttpDeps) {
             return reply.code(up.status).send({ error: 'Bad Gateway', statusCode: up.status, message: up.message })
           }
           throw e
+        }
+      }
+    )
+
+    r.get(
+      '/gitlab/agents/:id/accounts',
+      {
+        schema: {
+          tags: [Tag.GitLab],
+          summary: 'List an agent’s GitLab accounts',
+          description:
+            'The service accounts this agent acts as on GitLab.com — one per top-level group it has a bound project in (§7.2) — with the account username, display name, numeric user id, and lifecycle state. Never token material.',
+          operationId: 'listGitlabAgentAccounts',
+          params: IdParam,
+          response: { 200: GitlabAgentAccountListDto, 404: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const orgId = orgOf(req)
+        // Org boundary + canView: a cross-org or restricted agent reads as absent, never as someone else's bot.
+        const agent = await deps.repos.agent.get(orgId, AgentId(req.params.id))
+        if (!agent || !canView(agent, ctxOf(req))) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'agent not found' })
+        }
+        const accounts = await deps.repos.gitlabAgentAccount.listForAgent(orgId, agent.id)
+        if (accounts.length === 0) return { accounts: [] }
+        const projectPaths = new Map(
+          (await deps.repos.gitlabProjectBinding.listForOrg(orgId)).map((b) => [b.id, b.projectPath])
+        )
+        const memberships = await Promise.all(
+          accounts.map(async (account) => deps.repos.gitlabAgentAccount.membershipsOfAccount(account.id))
+        )
+        return {
+          accounts: accounts.map((account, i) =>
+            accountToDto(
+              account,
+              memberships[i]!.map((m) => m.bindingId),
+              projectPaths
+            )
+          )
         }
       }
     )

--- a/packages/control-plane/test/integration/gitlab.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab.route.test.ts
@@ -11,6 +11,7 @@ import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { GitlabOauthService } from '../../src/gitlab/oauth.service.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import {
   PgGitlabAgentAccountRepo,
   PgGitlabConnectionRepo,
@@ -24,6 +25,7 @@ import {
 import { PgCodeHostRepositoryRepo } from '../../src/persistence/repositories/code-host-repository.repo.js'
 import { GitlabProvisioner } from '../../src/gitlab/provisioner.js'
 import { GitlabAccountService } from '../../src/gitlab/account.service.js'
+import { gitlabAgentAccountUsername } from '../../src/gitlab/api.js'
 import { FakeGitlab, type FakeGitlabOptions } from '../fakes/gitlab-api.js'
 import { makeSecretCipher } from '../../src/secrets/cipher.js'
 import { systemClock } from '../../src/domain/clock.js'
@@ -39,7 +41,7 @@ afterEach(async () => {
   running = undefined
 })
 
-function gitlabApp(options: FakeGitlabOptions = {}): HttpApp & { fake: FakeGitlab } {
+function gitlabApp(options: FakeGitlabOptions = {}, callerUserId?: string): HttpApp & { fake: FakeGitlab } {
   const fake = new FakeGitlab(options)
   const oauth = new GitlabOauthService({
     cfg: { clientId: 'client-1', clientSecret: 'secret-1' },
@@ -73,9 +75,13 @@ function gitlabApp(options: FakeGitlabOptions = {}): HttpApp & { fake: FakeGitla
     desiredWebhookEvents: async () => null,
     fetchImpl: fake.fetch()
   })
-  running = buildHttpApp(prisma, { PUBLIC_CP_URL: PUBLIC_CP }, undefined, undefined, {
-    gitlab: { oauth, provisioner, accounts: accountService, fetchImpl: fake.fetch() }
-  })
+  running = buildHttpApp(
+    prisma,
+    { PUBLIC_CP_URL: PUBLIC_CP, ...(callerUserId ? { DEFAULT_OWNER_ID: callerUserId } : {}) },
+    undefined,
+    undefined,
+    { gitlab: { oauth, provisioner, accounts: accountService, fetchImpl: fake.fetch() } }
+  )
   return { ...running, fake }
 }
 
@@ -535,6 +541,125 @@ describe('gitlab oauth routes', () => {
   it('404s the whole surface when the deployment has no gitlab oauth app', async () => {
     running = buildHttpApp(prisma, { PUBLIC_CP_URL: PUBLIC_CP })
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/gitlab/connections` })
+    expect(res.statusCode).toBe(404)
+  })
+})
+
+/**
+ * The agent detail page's identity read (§18.1): an agent's OWN bot accounts,
+ * one per top-level group, org-scoped and visibility-gated like every agent read.
+ */
+describe('gitlab agent accounts (§7.2, §18.1)', () => {
+  const accountsUrl = (agentId: string, org = ORG) => `${org}/gitlab/agents/${agentId}/accounts`
+
+  /** A bound project WITH a consuming agent, so provisioning earns that agent an account. */
+  async function boundWithAgent(
+    a: HttpApp & { fake: FakeGitlab },
+    opts: { visibility?: 'org' | 'restricted' } = {}
+  ): Promise<string> {
+    const { connectionId } = await connect(a)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { name: 'reviewer', gitlabProjectId: 4455667n, ...opts })
+    const bound = await a.app.inject({
+      method: 'POST',
+      url: `${ORG}/gitlab/projects`,
+      payload: { connectionId, projectId: '4455667' }
+    })
+    expect(bound.statusCode).toBe(200)
+    return agentId
+  }
+
+  it('reports the account username, display name, group, and health', async () => {
+    const a = gitlabApp()
+    const agentId = await boundWithAgent(a)
+
+    const res = await a.app.inject({ method: 'GET', url: accountsUrl(agentId) })
+    expect(res.statusCode).toBe(200)
+    const { accounts } = res.json() as { accounts: Array<Record<string, unknown>> }
+    expect(accounts).toHaveLength(1)
+    expect(accounts[0]).toMatchObject({
+      rootGroupId: '900',
+      // The readable heading comes off a bound project — the row itself holds only the number.
+      rootGroupPath: 'example-group',
+      username: gitlabAgentAccountUsername(agentId, 900n),
+      displayName: 'reviewer',
+      state: 'ready',
+      stateReason: null,
+      lifecycle: 'active'
+    })
+    // The account exists on GitLab, so the console may link its profile.
+    expect(accounts[0]!.userId).toMatch(/^\d+$/)
+  })
+
+  it('translates a quota refusal into an actionable reason, naming no token material', async () => {
+    const a = gitlabApp({ refuseServiceAccountQuota: true })
+    const agentId = await boundWithAgent(a)
+
+    const res = await a.app.inject({ method: 'GET', url: accountsUrl(agentId) })
+    expect(res.statusCode).toBe(200)
+    const { accounts } = res.json() as { accounts: Array<Record<string, unknown>> }
+    expect(accounts[0]).toMatchObject({ state: 'admin_degraded', stateReason: 'service_account_quota' })
+    // Refused creation means no GitLab user and no project to read a group path from.
+    expect(accounts[0]!.userId).toBeNull()
+    expect(accounts[0]!.rootGroupPath).toBeNull()
+    expect(JSON.stringify(accounts)).not.toContain('glpat')
+  })
+
+  it('is empty for an agent with no GitLab project', async () => {
+    const a = gitlabApp()
+    await connect(a)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { name: 'no-gitlab' })
+
+    const res = await a.app.inject({ method: 'GET', url: accountsUrl(agentId) })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ accounts: [] })
+  })
+
+  it('404s an unknown agent and another organization’s agent', async () => {
+    const a = gitlabApp()
+    const agentId = await boundWithAgent(a)
+
+    expect((await a.app.inject({ method: 'GET', url: accountsUrl(randomUUID()) })).statusCode).toBe(404)
+    // Cross-org reads as absent, never as someone else's resource.
+    const foreign = await a.app.inject({ method: 'GET', url: accountsUrl(agentId, '/api/v1/orgs/some-other-org') })
+    expect(foreign.statusCode).toBe(404)
+  })
+
+  it('404s a restricted agent the caller cannot see, with no oracle', async () => {
+    const a = gitlabApp()
+    const { connectionId } = await connect(a)
+    const visible = randomUUID()
+    const hidden = randomUUID()
+    await seedAgent(prisma, visible, { name: 'reviewer', gitlabProjectId: 4455667n })
+    await seedAgent(prisma, hidden, {
+      name: 'private-reviewer',
+      gitlabProjectId: 4455667n,
+      visibility: 'restricted',
+      sharedWith: [DEFAULT_OWNER_ID]
+    })
+    const bound = await a.app.inject({
+      method: 'POST',
+      url: `${ORG}/gitlab/projects`,
+      payload: { connectionId, projectId: '4455667' }
+    })
+    expect(bound.statusCode).toBe(200)
+    await a.close()
+
+    const users = new PgUserRepo(prisma)
+    const email = `outsider-${randomUUID().slice(0, 8)}@example.test`
+    const { userId: outsider } = await users.provisionOidcUser({ oidcSubject: email, email, emailVerified: true })
+    await users.addMemberByEmail(DEFAULT_ORG_ID, email, 'collaborator')
+    const asOutsider = gitlabApp({}, outsider)
+
+    expect((await asOutsider.app.inject({ method: 'GET', url: accountsUrl(hidden) })).statusCode).toBe(404)
+    // The same caller reads the org-visible agent fine, so the 404 is visibility, not the route.
+    expect((await asOutsider.app.inject({ method: 'GET', url: accountsUrl(visible) })).statusCode).toBe(200)
+  })
+
+  it('404s with the rest of the surface when the deployment has no gitlab oauth app', async () => {
+    running = buildHttpApp(prisma, { PUBLIC_CP_URL: PUBLIC_CP })
+    const res = await running.app.inject({ method: 'GET', url: accountsUrl(randomUUID()) })
     expect(res.statusCode).toBe(404)
   })
 })

--- a/packages/web/src/components/console/AgentGitlabIdentity.test.tsx
+++ b/packages/web/src/components/console/AgentGitlabIdentity.test.tsx
@@ -51,6 +51,15 @@ const ACCOUNT: GitlabAgentAccountDto = {
 
 type Read = { enabled: boolean; accounts: GitlabAgentAccountDto[] } | undefined
 
+/** The same agent's account in a SECOND top-level group — accounts cannot cross that boundary. */
+const OTHER_GROUP_ACCOUNT: GitlabAgentAccountDto = {
+  ...ACCOUNT,
+  id: 'acct-2',
+  rootGroupId: '901',
+  rootGroupPath: 'other-group',
+  username: 'agentconnect-a1-g901'
+}
+
 let swrData: Read
 let lastCall: { key: unknown; options: SwrOptions } | undefined
 let host: HTMLDivElement
@@ -225,24 +234,49 @@ describe('AgentGitlabIdentity', () => {
     await render({ enabled: true, accounts: [ACCOUNT] }, consumers)
     expect(pollInterval()).toBeGreaterThan(0)
 
-    await render({ enabled: true, accounts: [ACCOUNT, { ...ACCOUNT, id: 'acct-2', rootGroupId: '901' }] }, consumers)
+    await render({ enabled: true, accounts: [ACCOUNT, OTHER_GROUP_ACCOUNT] }, consumers)
     expect(pollInterval()).toBe(0)
   })
 
   it('keeps polling while ONE of several accounts is still retiring', async () => {
     // Dropping to one group: the surviving account alone is the settled shape.
-    await render({ enabled: true, accounts: [ACCOUNT, { ...ACCOUNT, id: 'acct-2', rootGroupId: '901' }] })
+    await render({
+      enabled: true,
+      accounts: [ACCOUNT, OTHER_GROUP_ACCOUNT]
+    })
     expect(pollInterval()).toBeGreaterThan(0)
 
     await render({ enabled: true, accounts: [ACCOUNT] })
     expect(pollInterval()).toBe(0)
   })
 
-  it('stops polling on a refused account: a quota refusal rests until someone repairs it', async () => {
+  it('keeps polling a retarget to another group, which leaves the COUNT unchanged', async () => {
+    const retargeted = ['other-group/example-project']
+    // The CP commits the new consumer and returns before convergence runs, so the first read can
+    // still be the old group's account: one expected group, one account, and nothing transient.
+    await render({ enabled: true, accounts: [ACCOUNT] }, retargeted)
+    expect(pollInterval()).toBeGreaterThan(0)
+
+    await render({ enabled: true, accounts: [{ ...OTHER_GROUP_ACCOUNT, id: ACCOUNT.id }] }, retargeted)
+    expect(pollInterval()).toBe(0)
+  })
+
+  it('keeps polling a refused account, which cannot yet name the group it serves', async () => {
+    // Creation was refused, so no project is bound and the group is unknown — asking again is what
+    // heals the card once someone frees up the group's bot accounts.
     await render({
       enabled: true,
-      accounts: [{ ...ACCOUNT, state: 'admin_degraded', stateReason: 'service_account_quota' }]
+      accounts: [
+        {
+          ...ACCOUNT,
+          userId: null,
+          rootGroupPath: null,
+          state: 'admin_degraded',
+          stateReason: 'service_account_quota'
+        }
+      ]
     })
-    expect(pollInterval()).toBe(0)
+    expect(pollInterval()).toBeGreaterThan(0)
+    expect(host.textContent).toContain('limit of bot accounts')
   })
 })

--- a/packages/web/src/components/console/AgentGitlabIdentity.test.tsx
+++ b/packages/web/src/components/console/AgentGitlabIdentity.test.tsx
@@ -22,13 +22,18 @@ vi.mock('@/lib/api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/api')>()),
   fetchGitlabAgentAccounts: mocks.fetchAccounts
 }))
-// SWR resolves through the mocked fetcher directly — the card has no revalidation behaviour to test.
+// The mock records the key and options so the freshness contract is assertable.
 vi.mock('swr', () => ({
-  default: (key: unknown, fetcher: ((k: unknown) => Promise<unknown>) | null) => {
+  default: (key: unknown, fetcher: ((k: unknown) => Promise<unknown>) | null, options: SwrOptions) => {
+    lastCall = { key, options }
     if (!key || !fetcher) return { data: undefined }
     return { data: swrData }
   }
 }))
+
+interface SwrOptions {
+  refreshInterval?: (latest: unknown) => number
+}
 
 const AgentGitlabIdentity = (await import('./AgentGitlabIdentity')).AgentGitlabIdentity
 
@@ -44,19 +49,27 @@ const ACCOUNT: GitlabAgentAccountDto = {
   lifecycle: 'active'
 }
 
-let swrData: { enabled: boolean; accounts: GitlabAgentAccountDto[] } | undefined
+type Read = { enabled: boolean; accounts: GitlabAgentAccountDto[] } | undefined
+
+let swrData: Read
+let lastCall: { key: unknown; options: SwrOptions } | undefined
 let host: HTMLDivElement
 let root: Root
 
 // No default argument: "SWR has no data yet" IS one of the cases, and a default would swallow it.
-async function render(data: { enabled: boolean; accounts: GitlabAgentAccountDto[] } | undefined): Promise<void> {
+async function render(data: Read, consumerCount = 1): Promise<void> {
   swrData = data
   host = document.createElement('div')
   document.body.appendChild(host)
   root = createRoot(host)
   await act(async () => {
-    root.render(<AgentGitlabIdentity agentId="agent-1" />)
+    root.render(<AgentGitlabIdentity agentId="agent-1" consumerCount={consumerCount} />)
   })
+}
+
+/** What SWR would wait before asking again — 0 means the card has stopped polling. */
+function pollInterval(): number {
+  return lastCall!.options.refreshInterval!(swrData)
 }
 
 function chips(): HTMLElement[] {
@@ -65,6 +78,7 @@ function chips(): HTMLElement[] {
 
 beforeEach(() => {
   mocks.fetchAccounts.mockReset()
+  lastCall = undefined
   document.body.innerHTML = ''
 })
 
@@ -157,5 +171,46 @@ describe('AgentGitlabIdentity', () => {
 
     expect(host.textContent).toContain('bot access degraded')
     expect(host.textContent).not.toContain('some_internal_category')
+  })
+  it('keys the read by the consumer set, so binding a project cannot read the pre-bind entry', async () => {
+    await render({ enabled: true, accounts: [] }, 0)
+    const beforeBind = JSON.stringify(lastCall!.key)
+
+    await render({ enabled: true, accounts: [] }, 1)
+    const afterBind = JSON.stringify(lastCall!.key)
+
+    // The CP creates the account behind hook CRUD, so the old entry must be unreachable.
+    expect(afterBind).not.toBe(beforeBind)
+    expect(afterBind).toContain('agent-1')
+  })
+
+  it('polls while convergence is still in flight and rests once it has landed', async () => {
+    // A consumer exists but its account does not yet — the saga runs after hook CRUD returned.
+    await render({ enabled: true, accounts: [] }, 1)
+    expect(pollInterval()).toBeGreaterThan(0)
+
+    // Still provisioning is equally in flight.
+    await render({ enabled: true, accounts: [{ ...ACCOUNT, state: 'provisioning' }] }, 1)
+    expect(pollInterval()).toBeGreaterThan(0)
+
+    // The last consumer went away but the identity is still listed: retirement in flight.
+    await render({ enabled: true, accounts: [ACCOUNT] }, 0)
+    expect(pollInterval()).toBeGreaterThan(0)
+
+    // Agreed: an account for the consumer that has one, and nothing transient left.
+    await render({ enabled: true, accounts: [ACCOUNT] }, 1)
+    expect(pollInterval()).toBe(0)
+
+    // No consumer and no account is equally settled — the common agent must not poll at all.
+    await render({ enabled: true, accounts: [] }, 0)
+    expect(pollInterval()).toBe(0)
+  })
+
+  it('stops polling on a refused account: a quota refusal rests until someone repairs it', async () => {
+    await render(
+      { enabled: true, accounts: [{ ...ACCOUNT, state: 'admin_degraded', stateReason: 'service_account_quota' }] },
+      1
+    )
+    expect(pollInterval()).toBe(0)
   })
 })

--- a/packages/web/src/components/console/AgentGitlabIdentity.test.tsx
+++ b/packages/web/src/components/console/AgentGitlabIdentity.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment happy-dom
+/**
+ * The agent detail page's own GitLab identity card (gitlab-com-integration.md
+ * §18.1): the bot account the agent acts as, one per top-level group, with the
+ * profile link and the account's own health.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitlabAgentAccountDto } from '@/lib/api'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const mocks = vi.hoisted(() => ({ fetchAccounts: vi.fn() }))
+
+// One stable org object: a fresh literal per render would re-key the fetch forever.
+vi.mock('@/lib/org-context', () => {
+  const orgs = { activeOrg: { id: 'org-gitlab' }, myRole: 'owner', orgPath: (path: string) => path }
+  return { useOrgs: () => orgs }
+})
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchGitlabAgentAccounts: mocks.fetchAccounts
+}))
+// SWR resolves through the mocked fetcher directly — the card has no revalidation behaviour to test.
+vi.mock('swr', () => ({
+  default: (key: unknown, fetcher: ((k: unknown) => Promise<unknown>) | null) => {
+    if (!key || !fetcher) return { data: undefined }
+    return { data: swrData }
+  }
+}))
+
+const AgentGitlabIdentity = (await import('./AgentGitlabIdentity')).AgentGitlabIdentity
+
+const ACCOUNT: GitlabAgentAccountDto = {
+  id: 'acct-1',
+  rootGroupId: '900',
+  rootGroupPath: 'example-group',
+  username: 'agentconnect-a1-g900',
+  displayName: 'reviewer',
+  userId: '9042',
+  state: 'ready',
+  stateReason: null,
+  lifecycle: 'active'
+}
+
+let swrData: { enabled: boolean; accounts: GitlabAgentAccountDto[] } | undefined
+let host: HTMLDivElement
+let root: Root
+
+// No default argument: "SWR has no data yet" IS one of the cases, and a default would swallow it.
+async function render(data: { enabled: boolean; accounts: GitlabAgentAccountDto[] } | undefined): Promise<void> {
+  swrData = data
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root.render(<AgentGitlabIdentity agentId="agent-1" />)
+  })
+}
+
+function chips(): HTMLElement[] {
+  return [...host.querySelectorAll('[data-gitlab-account]')] as HTMLElement[]
+}
+
+beforeEach(() => {
+  mocks.fetchAccounts.mockReset()
+  document.body.innerHTML = ''
+})
+
+describe('AgentGitlabIdentity', () => {
+  it('shows the account username, display name, health, and profile link for one group', async () => {
+    await render({ enabled: true, accounts: [ACCOUNT] })
+
+    expect(chips()).toHaveLength(1)
+    expect(host.textContent).toContain('GitLab identity')
+    expect(host.textContent).toContain('bot @agentconnect-a1-g900')
+    expect(host.textContent).toContain('Shown on GitLab as reviewer')
+    expect(host.textContent).toContain('ready')
+    const link = host.querySelector('[data-gitlab-account] a') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('https://gitlab.com/agentconnect-a1-g900')
+    // A new tab, and never one that can reach back into the console.
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+    // A single group needs no heading — the grouping only earns one when it disambiguates.
+    expect(host.querySelectorAll('[data-gitlab-group]')).toHaveLength(1)
+    expect(host.textContent).not.toContain('example-group')
+  })
+
+  it('renders nothing when the agent has no account, and nothing when GitLab is not configured', async () => {
+    await render({ enabled: true, accounts: [] })
+    expect(host.textContent).toBe('')
+
+    await render({ enabled: false, accounts: [] })
+    expect(host.textContent).toBe('')
+
+    await render(undefined)
+    expect(host.textContent).toBe('')
+  })
+
+  it('groups by top-level group, labelled by path, when the agent spans several', async () => {
+    await render({
+      enabled: true,
+      accounts: [
+        ACCOUNT,
+        {
+          ...ACCOUNT,
+          id: 'acct-2',
+          rootGroupId: '901',
+          rootGroupPath: 'other-group',
+          username: 'agentconnect-a1-g901'
+        },
+        // No bound project has reported a path yet: the numeric group still labels its own bucket.
+        {
+          ...ACCOUNT,
+          id: 'acct-3',
+          rootGroupId: '902',
+          rootGroupPath: null,
+          username: 'agentconnect-a1-g902'
+        }
+      ]
+    })
+
+    const groups = [...host.querySelectorAll('[data-gitlab-group]')]
+    expect(groups.map((g) => g.getAttribute('data-gitlab-group'))).toEqual(['900', '901', '902'])
+    expect(host.textContent).toContain('example-group')
+    expect(host.textContent).toContain('other-group')
+    expect(host.textContent).toContain('group 902')
+    expect(chips()).toHaveLength(3)
+  })
+
+  it('translates a refused account: the group is out of bot accounts', async () => {
+    await render({
+      enabled: true,
+      accounts: [
+        { ...ACCOUNT, userId: null, state: 'admin_degraded', stateReason: 'service_account_quota', displayName: null }
+      ]
+    })
+
+    expect(host.textContent).toContain('setup incomplete')
+    expect(host.textContent).toContain('limit of bot accounts')
+    // The account does not exist on GitLab yet, so its deterministic name links nowhere.
+    expect(host.querySelector('[data-gitlab-account] a')).toBeNull()
+    expect(host.textContent).toContain('bot @agentconnect-a1-g900')
+  })
+
+  it('marks an account whose last project went away as being removed', async () => {
+    await render({ enabled: true, accounts: [{ ...ACCOUNT, lifecycle: 'retiring' }] })
+    expect(host.textContent).toContain('removing')
+  })
+
+  it('hides an unmapped machine reason but keeps the state badge', async () => {
+    await render({
+      enabled: true,
+      accounts: [{ ...ACCOUNT, state: 'runtime_degraded', stateReason: 'some_internal_category' }]
+    })
+
+    expect(host.textContent).toContain('bot access degraded')
+    expect(host.textContent).not.toContain('some_internal_category')
+  })
+})

--- a/packages/web/src/components/console/AgentGitlabIdentity.test.tsx
+++ b/packages/web/src/components/console/AgentGitlabIdentity.test.tsx
@@ -57,13 +57,13 @@ let host: HTMLDivElement
 let root: Root
 
 // No default argument: "SWR has no data yet" IS one of the cases, and a default would swallow it.
-async function render(data: Read, consumerCount = 1): Promise<void> {
+async function render(data: Read, consumers: readonly string[] = ['example-group/example-project']): Promise<void> {
   swrData = data
   host = document.createElement('div')
   document.body.appendChild(host)
   root = createRoot(host)
   await act(async () => {
-    root.render(<AgentGitlabIdentity agentId="agent-1" consumerCount={consumerCount} />)
+    root.render(<AgentGitlabIdentity agentId="agent-1" consumerProjectPaths={consumers} />)
   })
 }
 
@@ -173,44 +173,76 @@ describe('AgentGitlabIdentity', () => {
     expect(host.textContent).not.toContain('some_internal_category')
   })
   it('keys the read by the consumer set, so binding a project cannot read the pre-bind entry', async () => {
-    await render({ enabled: true, accounts: [] }, 0)
+    await render({ enabled: true, accounts: [] }, [])
     const beforeBind = JSON.stringify(lastCall!.key)
 
-    await render({ enabled: true, accounts: [] }, 1)
+    await render({ enabled: true, accounts: [] }, ['example-group/example-project'])
     const afterBind = JSON.stringify(lastCall!.key)
 
     // The CP creates the account behind hook CRUD, so the old entry must be unreachable.
     expect(afterBind).not.toBe(beforeBind)
     expect(afterBind).toContain('agent-1')
+
+    // Swapping one project for another in a different group is also a change, at equal count.
+    await render({ enabled: true, accounts: [] }, ['other-group/example-project'])
+    expect(JSON.stringify(lastCall!.key)).not.toBe(afterBind)
   })
 
   it('polls while convergence is still in flight and rests once it has landed', async () => {
     // A consumer exists but its account does not yet — the saga runs after hook CRUD returned.
-    await render({ enabled: true, accounts: [] }, 1)
+    await render({ enabled: true, accounts: [] })
     expect(pollInterval()).toBeGreaterThan(0)
 
     // Still provisioning is equally in flight.
-    await render({ enabled: true, accounts: [{ ...ACCOUNT, state: 'provisioning' }] }, 1)
+    await render({ enabled: true, accounts: [{ ...ACCOUNT, state: 'provisioning' }] })
     expect(pollInterval()).toBeGreaterThan(0)
 
     // The last consumer went away but the identity is still listed: retirement in flight.
-    await render({ enabled: true, accounts: [ACCOUNT] }, 0)
+    await render({ enabled: true, accounts: [ACCOUNT] }, [])
     expect(pollInterval()).toBeGreaterThan(0)
 
-    // Agreed: an account for the consumer that has one, and nothing transient left.
-    await render({ enabled: true, accounts: [ACCOUNT] }, 1)
+    // Agreed: an account for the group that has one, and nothing transient left.
+    await render({ enabled: true, accounts: [ACCOUNT] })
     expect(pollInterval()).toBe(0)
 
     // No consumer and no account is equally settled — the common agent must not poll at all.
-    await render({ enabled: true, accounts: [] }, 0)
+    await render({ enabled: true, accounts: [] }, [])
+    expect(pollInterval()).toBe(0)
+  })
+
+  it('counts top-level groups, not consumers: two projects in one group settle at one account', async () => {
+    // A second project under the SAME group shares the one account — already settled.
+    await render({ enabled: true, accounts: [ACCOUNT] }, [
+      'example-group/example-project',
+      'example-group/another-project'
+    ])
+    expect(pollInterval()).toBe(0)
+  })
+
+  it('keeps polling until the SECOND group’s account arrives', async () => {
+    const consumers = ['example-group/example-project', 'other-group/example-project']
+    // One of two groups has landed: stopping here would hide the second identity until a reload.
+    await render({ enabled: true, accounts: [ACCOUNT] }, consumers)
+    expect(pollInterval()).toBeGreaterThan(0)
+
+    await render({ enabled: true, accounts: [ACCOUNT, { ...ACCOUNT, id: 'acct-2', rootGroupId: '901' }] }, consumers)
+    expect(pollInterval()).toBe(0)
+  })
+
+  it('keeps polling while ONE of several accounts is still retiring', async () => {
+    // Dropping to one group: the surviving account alone is the settled shape.
+    await render({ enabled: true, accounts: [ACCOUNT, { ...ACCOUNT, id: 'acct-2', rootGroupId: '901' }] })
+    expect(pollInterval()).toBeGreaterThan(0)
+
+    await render({ enabled: true, accounts: [ACCOUNT] })
     expect(pollInterval()).toBe(0)
   })
 
   it('stops polling on a refused account: a quota refusal rests until someone repairs it', async () => {
-    await render(
-      { enabled: true, accounts: [{ ...ACCOUNT, state: 'admin_degraded', stateReason: 'service_account_quota' }] },
-      1
-    )
+    await render({
+      enabled: true,
+      accounts: [{ ...ACCOUNT, state: 'admin_degraded', stateReason: 'service_account_quota' }]
+    })
     expect(pollInterval()).toBe(0)
   })
 })

--- a/packages/web/src/components/console/AgentGitlabIdentity.tsx
+++ b/packages/web/src/components/console/AgentGitlabIdentity.tsx
@@ -14,6 +14,11 @@ import { consoleKeys } from '@/lib/swr-keys'
 import { GITLAB_PROJECT_STATE, gitlabProfileUrl, gitlabStateReasonText } from '@/lib/gitlab-projects'
 import { fetchGitlabAgentAccounts, type GitlabAgentAccountDto } from '@/lib/api'
 
+type AccountsRead = Awaited<ReturnType<typeof fetchGitlabAgentAccounts>>
+
+/** Account convergence runs behind hook CRUD; this is how often we ask whether it landed. */
+const CONVERGENCE_POLL_MS = 5_000
+
 /** Accounts in row order, one bucket per group — the readable path labels it whenever we have one. */
 function groupByRoot(accounts: readonly GitlabAgentAccountDto[]): Array<{
   rootGroupId: string
@@ -76,10 +81,32 @@ function AccountChip({ account }: { account: GitlabAgentAccountDto }) {
   )
 }
 
-export function AgentGitlabIdentity({ agentId, className = '' }: { agentId: string; className?: string }) {
+/** Whether what we fetched already agrees with what the agent's consumers imply.
+ *  Convergence is transient; a refused account is a resting state we stop polling. */
+function settled(data: AccountsRead | undefined, hasConsumer: boolean): boolean {
+  if (!data) return false
+  if (data.accounts.length > 0 !== hasConsumer) return false
+  return data.accounts.every((a) => a.lifecycle === 'active' && a.state !== 'provisioning')
+}
+
+export function AgentGitlabIdentity({
+  agentId,
+  consumerCount,
+  className = ''
+}: {
+  agentId: string
+  /** Enabled GitLab hooks plus a GitLab workspace — what the CP counts as consumers. */
+  consumerCount: number
+  className?: string
+}) {
   const { activeOrg } = useOrgs()
-  const accountsKey = MOCK_MODE ? null : consoleKeys.agentGitlabAccounts(activeOrg?.id, agentId)
+  // The consumer count is part of the key: binding or unbinding a project makes the
+  // stale entry unreachable, so no mutation site has to remember to invalidate it.
+  const accountsKey = MOCK_MODE ? null : consoleKeys.agentGitlabAccounts(activeOrg?.id, agentId, consumerCount)
   const { data } = useSWR(accountsKey, ([, , , id]) => fetchGitlabAgentAccounts(id as string), {
+    // The CP returns from hook CRUD BEFORE the saga creates or retires the account,
+    // so one immediate read would race it. Poll until the two agree, then rest.
+    refreshInterval: (latest) => (settled(latest, consumerCount > 0) ? 0 : CONVERGENCE_POLL_MS),
     shouldRetryOnError: false
   })
 

--- a/packages/web/src/components/console/AgentGitlabIdentity.tsx
+++ b/packages/web/src/components/console/AgentGitlabIdentity.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+// The agent's OWN GitLab face (gitlab-com-integration.md §18.1): the bot account
+// it posts, reviews, and pushes as. One account per top-level group the agent has
+// a bound project in — GitLab bot accounts cannot be invited across that boundary
+// — so an agent spanning two groups shows two, grouped. Nothing here is an input:
+// the name derives from the agent, and the card is absent until a project is bound.
+
+import useSWR from 'swr'
+import { GitlabMark } from '@/components/marks'
+import { MOCK_MODE } from '@/lib/data'
+import { useOrgs } from '@/lib/org-context'
+import { consoleKeys } from '@/lib/swr-keys'
+import { GITLAB_PROJECT_STATE, gitlabProfileUrl, gitlabStateReasonText } from '@/lib/gitlab-projects'
+import { fetchGitlabAgentAccounts, type GitlabAgentAccountDto } from '@/lib/api'
+
+/** Accounts in row order, one bucket per group — the readable path labels it whenever we have one. */
+function groupByRoot(accounts: readonly GitlabAgentAccountDto[]): Array<{
+  rootGroupId: string
+  label: string
+  accounts: GitlabAgentAccountDto[]
+}> {
+  const groups: Array<{ rootGroupId: string; label: string; accounts: GitlabAgentAccountDto[] }> = []
+  for (const account of accounts) {
+    const found = groups.find((g) => g.rootGroupId === account.rootGroupId)
+    if (found) {
+      found.accounts.push(account)
+      if (account.rootGroupPath) found.label = account.rootGroupPath
+      continue
+    }
+    groups.push({
+      rootGroupId: account.rootGroupId,
+      label: account.rootGroupPath ?? `group ${account.rootGroupId}`,
+      accounts: [account]
+    })
+  }
+  return groups
+}
+
+/** One account chip. The username is deterministic, so the profile links only once the account exists. */
+function AccountChip({ account }: { account: GitlabAgentAccountDto }) {
+  const state = GITLAB_PROJECT_STATE[account.state]
+  const reason = gitlabStateReasonText(account.stateReason)
+  const handle = `bot @${account.username}`
+  return (
+    <div data-gitlab-account={account.id} className="px-4 py-3 desktop:px-[14px]">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-[6px]">
+        {account.userId ? (
+          <a
+            href={gitlabProfileUrl(account.username)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mono min-w-0 truncate text-[12.5px] text-(--text-primary) hover:underline"
+          >
+            {handle}
+          </a>
+        ) : (
+          <span className="mono min-w-0 truncate text-[12.5px] text-(--text-tertiary)">{handle}</span>
+        )}
+        <span className={`badge flex-none ${state.badge}`}>{state.label}</span>
+        {account.lifecycle === 'retiring' && (
+          <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">removing</span>
+        )}
+      </div>
+      {account.displayName && (
+        <div className="mt-[3px] font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+          Shown on GitLab as {account.displayName}
+        </div>
+      )}
+      {reason && (
+        <div className="mt-[3px] font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-secondary)">
+          {reason}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function AgentGitlabIdentity({ agentId, className = '' }: { agentId: string; className?: string }) {
+  const { activeOrg } = useOrgs()
+  const accountsKey = MOCK_MODE ? null : consoleKeys.agentGitlabAccounts(activeOrg?.id, agentId)
+  const { data } = useSWR(accountsKey, ([, , , id]) => fetchGitlabAgentAccounts(id as string), {
+    shouldRetryOnError: false
+  })
+
+  // Absent, not empty: most agents have no GitLab project, and a deployment without GitLab reports `enabled: false`.
+  if (!data?.enabled || data.accounts.length === 0) return null
+  const groups = groupByRoot(data.accounts)
+
+  return (
+    <div className={`card overflow-hidden ${className}`}>
+      <div className="flex min-h-[53px] items-center gap-[10px] border-b border-(--border-subtle) px-4 py-3 desktop:min-h-[55px] desktop:px-[14px] desktop:py-[13px]">
+        <span className="flex h-[22px] w-[22px] flex-none items-center justify-center">
+          <GitlabMark fillPct={100} />
+        </span>
+        <span className="min-w-0 flex-1 font-sans text-[14px] font-semibold leading-normal">GitLab identity</span>
+      </div>
+      <div className="px-4 pt-3 font-sans text-[11.5px] font-normal leading-[1.45] text-(--text-tertiary) desktop:px-[14px]">
+        The bot account this agent acts as on GitLab — its notes, reviews, and pushes are authored by it.
+      </div>
+      {groups.map((group, index) => (
+        <div
+          key={group.rootGroupId}
+          data-gitlab-group={group.rootGroupId}
+          className={index > 0 ? 'border-t border-(--border-subtle)' : undefined}
+        >
+          {/* One group needs no heading; several do — the account is per top-level group. */}
+          {groups.length > 1 && (
+            <div className="border-b border-(--border-subtle) bg-(--surface-app) px-4 py-[6px] desktop:px-[14px]">
+              <span className="mono truncate text-[11.5px] text-(--text-tertiary)">{group.label}</span>
+            </div>
+          )}
+          {group.accounts.map((account) => (
+            <AccountChip key={account.id} account={account} />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/AgentGitlabIdentity.tsx
+++ b/packages/web/src/components/console/AgentGitlabIdentity.tsx
@@ -81,32 +81,41 @@ function AccountChip({ account }: { account: GitlabAgentAccountDto }) {
   )
 }
 
-/** Whether what we fetched already agrees with what the agent's consumers imply.
- *  Convergence is transient; a refused account is a resting state we stop polling. */
-function settled(data: AccountsRead | undefined, hasConsumer: boolean): boolean {
+/** The top-level groups a set of consumed project paths implies — one bot account each (§7.2).
+ *  A GitLab project always sits under a group, so the leading path segment IS that group. */
+function rootGroupsOf(projectPaths: readonly string[]): string[] {
+  return [...new Set(projectPaths.map((path) => path.split('/')[0]).filter((seg): seg is string => !!seg))].sort()
+}
+
+/** Whether the fetched accounts already match what the consumers imply, with nothing transient left.
+ *  Counting GROUPS, not consumers: two projects in one group share one account, two groups earn two. */
+function settled(data: AccountsRead | undefined, expectedGroups: number): boolean {
   if (!data) return false
-  if (data.accounts.length > 0 !== hasConsumer) return false
+  if (data.accounts.length !== expectedGroups) return false
+  // A refused account rests here on purpose: a group out of service accounts needs a repair, not a poll.
   return data.accounts.every((a) => a.lifecycle === 'active' && a.state !== 'provisioning')
 }
 
 export function AgentGitlabIdentity({
   agentId,
-  consumerCount,
+  consumerProjectPaths,
   className = ''
 }: {
   agentId: string
-  /** Enabled GitLab hooks plus a GitLab workspace — what the CP counts as consumers. */
-  consumerCount: number
+  /** Paths of the projects this agent consumes: its enabled GitLab hooks plus a GitLab workspace. */
+  consumerProjectPaths: readonly string[]
   className?: string
 }) {
   const { activeOrg } = useOrgs()
-  // The consumer count is part of the key: binding or unbinding a project makes the
-  // stale entry unreachable, so no mutation site has to remember to invalidate it.
-  const accountsKey = MOCK_MODE ? null : consoleKeys.agentGitlabAccounts(activeOrg?.id, agentId, consumerCount)
+  const rootGroups = rootGroupsOf(consumerProjectPaths)
+  // The consumer set is part of the key, so binding or unbinding a project makes the entry
+  // recorded under the old set unreachable and no mutation site has to invalidate it.
+  const signature = `${consumerProjectPaths.length}:${rootGroups.join(',')}`
+  const accountsKey = MOCK_MODE ? null : consoleKeys.agentGitlabAccounts(activeOrg?.id, agentId, signature)
   const { data } = useSWR(accountsKey, ([, , , id]) => fetchGitlabAgentAccounts(id as string), {
-    // The CP returns from hook CRUD BEFORE the saga creates or retires the account,
-    // so one immediate read would race it. Poll until the two agree, then rest.
-    refreshInterval: (latest) => (settled(latest, consumerCount > 0) ? 0 : CONVERGENCE_POLL_MS),
+    // The CP returns from hook CRUD BEFORE the saga creates or retires an account, so one
+    // immediate read would race it. Poll until the accounts match the groups, then rest.
+    refreshInterval: (latest) => (settled(latest, rootGroups.length) ? 0 : CONVERGENCE_POLL_MS),
     shouldRetryOnError: false
   })
 

--- a/packages/web/src/components/console/AgentGitlabIdentity.tsx
+++ b/packages/web/src/components/console/AgentGitlabIdentity.tsx
@@ -87,13 +87,17 @@ function rootGroupsOf(projectPaths: readonly string[]): string[] {
   return [...new Set(projectPaths.map((path) => path.split('/')[0]).filter((seg): seg is string => !!seg))].sort()
 }
 
-/** Whether the fetched accounts already match what the consumers imply, with nothing transient left.
- *  Counting GROUPS, not consumers: two projects in one group share one account, two groups earn two. */
-function settled(data: AccountsRead | undefined, expectedGroups: number): boolean {
+/** Whether the fetched accounts already serve exactly the groups the consumers imply, with nothing
+ *  transient left. Compares WHICH groups, not how many: a retarget from one group to another keeps
+ *  the count equal, and a stale read of the old group's account would otherwise look finished. */
+function settled(data: AccountsRead | undefined, expectedGroups: readonly string[]): boolean {
   if (!data) return false
-  if (data.accounts.length !== expectedGroups) return false
-  // A refused account rests here on purpose: a group out of service accounts needs a repair, not a poll.
-  return data.accounts.every((a) => a.lifecycle === 'active' && a.state !== 'provisioning')
+  if (data.accounts.some((a) => a.lifecycle !== 'active' || a.state === 'provisioning')) return false
+  // An account with no bound project cannot name its group, so it can never be matched against an
+  // expected one — a refused account keeps us asking, and repairing its group heals the card live.
+  if (data.accounts.some((a) => a.rootGroupPath === null)) return false
+  const served = [...new Set(data.accounts.map((a) => a.rootGroupPath as string))].sort()
+  return served.length === expectedGroups.length && served.every((group, i) => group === expectedGroups[i])
 }
 
 export function AgentGitlabIdentity({
@@ -115,7 +119,7 @@ export function AgentGitlabIdentity({
   const { data } = useSWR(accountsKey, ([, , , id]) => fetchGitlabAgentAccounts(id as string), {
     // The CP returns from hook CRUD BEFORE the saga creates or retires an account, so one
     // immediate read would race it. Poll until the accounts match the groups, then rest.
-    refreshInterval: (latest) => (settled(latest, rootGroups.length) ? 0 : CONVERGENCE_POLL_MS),
+    refreshInterval: (latest) => (settled(latest, rootGroups) ? 0 : CONVERGENCE_POLL_MS),
     shouldRetryOnError: false
   })
 

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -62,7 +62,16 @@ const BINDING: GitlabProjectBindingDto = {
   state: 'ready',
   stateReason: null,
   installerConnectionId: 'conn-1',
-  accounts: [{ agentId: 'agent-1', username: 'agentconnect-a1-g900', displayName: 'reviewer', userId: '9042' }],
+  accounts: [
+    {
+      agentId: 'agent-1',
+      username: 'agentconnect-a1-g900',
+      displayName: 'reviewer',
+      userId: '9042',
+      state: 'ready',
+      stateReason: null
+    }
+  ],
   webhookInstalled: true,
   credentialEpoch: '1',
   createdAt: '2026-08-02T00:00:00.000Z'
@@ -374,12 +383,43 @@ describe('GitlabCard', () => {
     mocks.fetchProjects.mockResolvedValue([BINDING])
     await render()
 
-    const chip = host.querySelector('[data-gitlab-project] a') as HTMLAnchorElement
+    const chip = host.querySelector('[data-gitlab-account]') as HTMLAnchorElement
     expect(chip.textContent).toBe('bot @agentconnect-a1-g900')
     expect(chip.getAttribute('href')).toBe('https://gitlab.com/agentconnect-a1-g900')
     // A new tab, and never one that can reach back into the console.
     expect(chip.getAttribute('target')).toBe('_blank')
     expect(chip.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('gives a project one chip per member account, each with its own health', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([
+      {
+        ...BINDING,
+        accounts: [
+          ...BINDING.accounts,
+          {
+            agentId: 'agent-2',
+            username: 'agentconnect-a2-g900',
+            displayName: 'triager',
+            userId: null,
+            state: 'admin_degraded' as const,
+            stateReason: 'service_account_quota'
+          }
+        ]
+      }
+    ])
+    await render()
+
+    const chips = [...host.querySelectorAll('[data-gitlab-account]')] as HTMLAnchorElement[]
+    expect(chips.map((c) => c.getAttribute('href'))).toEqual([
+      'https://gitlab.com/agentconnect-a1-g900',
+      'https://gitlab.com/agentconnect-a2-g900'
+    ])
+    // The binding is ready; only the refused account is marked, and its tooltip says why.
+    expect(chips[0]!.className).toContain('text-(--text-tertiary)')
+    expect(chips[1]!.className).toContain('text-(--amber-500)')
+    expect(chips[1]!.getAttribute('title')).toContain('limit of bot accounts')
   })
 
   it('says where projects come from when a connection has none', async () => {

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState, type ReactNode } from 'react'
 import { Button, Icon } from '@/components/ui'
 import { GitlabMark, LoadingState } from '@/components/marks'
 import { useOrgs } from '@/lib/org-context'
-import { GITLAB_PROJECT_STATE } from '@/lib/gitlab-projects'
+import { GITLAB_PROJECT_STATE, gitlabProfileUrl, gitlabStateReasonText } from '@/lib/gitlab-projects'
 import {
   ApiError,
   deleteGitlabProject,
@@ -25,24 +25,6 @@ import {
   type GitlabProjectBindingDto
 } from '@/lib/api'
 
-// The CP records a machine category in `stateReason`; these are the ones a user can act on, in GitLab
-// vocabulary. Every rotation_* variant collapses to one line — the tail (rotation_gitlab_<status>) is open-ended.
-const STATE_REASON: Record<string, string> = {
-  project_not_accessible: 'GitLab project is no longer accessible',
-  personal_namespace_unsupported: 'Projects in a personal namespace are not supported',
-  project_namespace_unknown: 'GitLab did not report the group this project belongs to',
-  service_account_create_forbidden: 'Not allowed to create a project bot on GitLab',
-  no_admin_connection: 'No connected GitLab account can manage this project — transfer it to your own account',
-  admin_unavailable:
-    'The GitLab account that set this project up can no longer manage it — reconnect that account, or transfer the project to your own',
-  cleanup_failed:
-    'Removal did not finish because no connected GitLab account could reach the project — reconnect it or transfer the project, then remove again',
-  claim_fence_lost: 'Setup was interrupted — run Repair again',
-  relay_url_unconfigured: 'This deployment has no public webhook address configured',
-  provisioning_in_progress: 'Setup is already running',
-  provisioning_or_cleanup_in_progress: 'Setup or removal is already running'
-}
-
 /** Machine-readable CP refusals the card says better itself (all takeover, today). */
 const REFUSAL: Record<string, string> = {
   GITLAB_NO_OWN_CONNECTION:
@@ -51,18 +33,6 @@ const REFUSAL: Record<string, string> = {
   GITLAB_NOT_MAINTAINER: 'Your GitLab account needs Maintainer or Owner access to this project to take it over.',
   GITLAB_INSTALLER_CONNECTED: 'A connected GitLab account already manages this project.',
   GITLAB_BINDING_BUSY: 'Setup or removal is already running for this project — try again shortly.'
-}
-
-/** User-facing copy for a binding's reason, or null to show nothing but the state badge — an
- *  unmapped category is an implementation identifier and never belongs on this surface. */
-function stateReasonText(reason: string | null): string | null {
-  if (!reason) return null
-  if (reason.startsWith('rotation_')) return 'The project bot credential needs repair'
-  // The gitlab_<status> family is open-ended; the actionable part is the same for all of it.
-  if (reason.startsWith('gitlab_')) {
-    return 'GitLab refused the last administration request — reconnect the account that manages this project, or transfer it to your own'
-  }
-  return STATE_REASON[reason] ?? null
 }
 
 function errorText(e: unknown): string {
@@ -347,16 +317,24 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
               <span className={`badge ${GITLAB_PROJECT_STATE[p.state].badge}`}>
                 {GITLAB_PROJECT_STATE[p.state].label}
               </span>
-              {/* Each member account is a real GitLab user: its chip opens that profile. */}
+              {/* Each member account is a real GitLab user: its chip opens that profile.
+                  An account can be broken on a project whose own binding is ready, so
+                  the chip carries its own state rather than borrowing the row's. */}
               {p.accounts.map((account) => (
                 <a
                   key={account.username}
-                  href={`https://gitlab.com/${account.username}`}
+                  href={gitlabProfileUrl(account.username)}
                   target="_blank"
                   rel="noopener noreferrer"
-                  title={account.displayName ?? account.username}
-                  className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary) hover:underline"
+                  title={gitlabStateReasonText(account.stateReason) ?? account.displayName ?? account.username}
+                  data-gitlab-account={account.username}
+                  className={`font-sans text-[12px] font-normal leading-normal hover:underline ${
+                    account.state === 'ready' ? 'text-(--text-tertiary)' : 'text-(--amber-500)'
+                  }`}
                 >
+                  {account.state !== 'ready' && (
+                    <Icon name="triangle-alert" size={12} className="mr-[3px] inline-block align-[-1px]" />
+                  )}
                   bot @{account.username}
                 </a>
               ))}
@@ -392,9 +370,9 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                 </Button>
               )}
             </span>
-            {stateReasonText(p.stateReason) && (
+            {gitlabStateReasonText(p.stateReason) && (
               <span className="font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">
-                {stateReasonText(p.stateReason)}
+                {gitlabStateReasonText(p.stateReason)}
               </span>
             )}
           </div>

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -237,6 +237,9 @@ export default function AgentDetailView() {
   const webhookHooks = agentHooks.filter((h) => h.kind === 'webhook')
   const githubHooks = agentHooks.filter((h) => h.kind === 'github')
   const gitlabHooks = agentHooks.filter((h) => h.kind === 'gitlab')
+  // What earns this agent a GitLab bot account (§7.2): its enabled GitLab hooks plus a GitLab workspace.
+  const gitlabConsumerCount =
+    gitlabHooks.filter((h) => h.enabled).length + (getAgent(id)?.workspace?.mode === 'gitlab' ? 1 : 0)
   const githubInstallationsKey =
     activeOrg && githubHooks.length > 0 ? (['github-review-installations', activeOrg.id] as const) : null
   const { data: githubInstallationsData } = useSWR<GithubInstallationDto[]>(githubInstallationsKey, () =>
@@ -1848,7 +1851,11 @@ export default function AgentDetailView() {
 
           <div className="flex min-w-0 flex-col gap-4 desktop:gap-[18px]">
             {/* Absent unless this agent has a GitLab project bound — it renders its own nothing. */}
-            <AgentGitlabIdentity agentId={da.id} className="max-desktop:rounded-lg" />
+            <AgentGitlabIdentity
+              agentId={da.id}
+              consumerCount={gitlabConsumerCount}
+              className="max-desktop:rounded-lg"
+            />
             {da.canEdit && !da.name.startsWith(MOCK_PREFIX) && (
               <ApprovalRequestsCard agentId={da.id} className="max-desktop:rounded-lg" />
             )}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -237,9 +237,13 @@ export default function AgentDetailView() {
   const webhookHooks = agentHooks.filter((h) => h.kind === 'webhook')
   const githubHooks = agentHooks.filter((h) => h.kind === 'github')
   const gitlabHooks = agentHooks.filter((h) => h.kind === 'gitlab')
-  // What earns this agent a GitLab bot account (§7.2): its enabled GitLab hooks plus a GitLab workspace.
-  const gitlabConsumerCount =
-    gitlabHooks.filter((h) => h.enabled).length + (getAgent(id)?.workspace?.mode === 'gitlab' ? 1 : 0)
+  // What earns this agent a GitLab bot account (§7.2): its enabled GitLab hooks plus a GitLab
+  // workspace. Paths, not a count — the account is per TOP-LEVEL GROUP, which the path names.
+  const gitlabWorkspace = getAgent(id)?.workspace
+  const gitlabConsumerPaths = [
+    ...gitlabHooks.filter((h) => h.enabled).map((h) => h.repoFullName),
+    gitlabWorkspace?.mode === 'gitlab' && isGitWorkspace(gitlabWorkspace) ? gitlabWorkspace.repo : null
+  ].filter((path): path is string => typeof path === 'string' && path.length > 0)
   const githubInstallationsKey =
     activeOrg && githubHooks.length > 0 ? (['github-review-installations', activeOrg.id] as const) : null
   const { data: githubInstallationsData } = useSWR<GithubInstallationDto[]>(githubInstallationsKey, () =>
@@ -1853,7 +1857,7 @@ export default function AgentDetailView() {
             {/* Absent unless this agent has a GitLab project bound — it renders its own nothing. */}
             <AgentGitlabIdentity
               agentId={da.id}
-              consumerCount={gitlabConsumerCount}
+              consumerProjectPaths={gitlabConsumerPaths}
               className="max-desktop:rounded-lg"
             />
             {da.canEdit && !da.name.startsWith(MOCK_PREFIX) && (

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -49,6 +49,7 @@ import { AgentSecretsCard } from '@/components/console/AgentSecretsCard'
 import { AgentToolsCard } from '@/components/console/AgentToolsCard'
 import { AgentSkillsCard } from '@/components/console/AgentSkillsCard'
 import { AgentCallVisibility } from '@/components/console/AgentCallVisibility'
+import { AgentGitlabIdentity } from '@/components/console/AgentGitlabIdentity'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { IntegrationChannelList, roomGlyph, rowLabel } from '@/components/console/IntegrationChannelList'
 import { RecentSessionsCard } from '@/components/console/RecentSessionsCard'
@@ -1846,6 +1847,8 @@ export default function AgentDetailView() {
           </div>
 
           <div className="flex min-w-0 flex-col gap-4 desktop:gap-[18px]">
+            {/* Absent unless this agent has a GitLab project bound — it renders its own nothing. */}
+            <AgentGitlabIdentity agentId={da.id} className="max-desktop:rounded-lg" />
             {da.canEdit && !da.name.startsWith(MOCK_PREFIX) && (
               <ApprovalRequestsCard agentId={da.id} className="max-desktop:rounded-lg" />
             )}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -5286,6 +5286,9 @@ export interface GitlabProjectAccountDto {
   username: string
   displayName: string | null
   userId: string | null
+  /** The account's OWN health: an agent's identity can be broken on a ready project. */
+  state: GitlabProjectBindingState
+  stateReason: string | null
 }
 
 export interface GitlabProjectBindingDto {
@@ -5386,6 +5389,37 @@ export function transferGitlabProject(id: string): Promise<GitlabProjectBindingD
 
 export function deleteGitlabProject(id: string): Promise<GitlabProjectRemovalDto> {
   return apiDelete<GitlabProjectRemovalDto>(`${orgBase()}/gitlab/projects/${encodeURIComponent(id)}`)
+}
+
+/** One agent's own GitLab identity: the group service account it acts as. An
+ *  agent holds one per top-level group it has a bound project in, so an agent
+ *  spanning two groups has two — GitLab bot accounts cannot cross that boundary. */
+export interface GitlabAgentAccountDto {
+  id: string
+  rootGroupId: string // numeric top-level group id, losslessly as a string
+  rootGroupPath: string | null // that group's current path, read off a bound project
+  username: string
+  displayName: string | null
+  userId: string | null // numeric GitLab user id; null until the account exists
+  state: GitlabProjectBindingState
+  stateReason: string | null
+  lifecycle: 'active' | 'retiring'
+}
+
+/** The agent's GitLab accounts. Like the connection list this doubles as the enabled-probe: 404 ⇒ no GitLab app. */
+export async function fetchGitlabAgentAccounts(
+  agentId: string,
+  orgId?: string
+): Promise<{ enabled: boolean; accounts: GitlabAgentAccountDto[] }> {
+  try {
+    const body = await apiGet<{ accounts: GitlabAgentAccountDto[] }>(
+      `${orgBase(orgId)}/gitlab/agents/${encodeURIComponent(agentId)}/accounts`
+    )
+    return { enabled: true, accounts: body.accounts }
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) return { enabled: false, accounts: [] }
+    throw e
+  }
 }
 
 // ── agent repository authorizations (agent-multi-repo-authorization.md) ──────

--- a/packages/web/src/lib/gitlab-projects.ts
+++ b/packages/web/src/lib/gitlab-projects.ts
@@ -23,6 +23,45 @@ export const GITLAB_PROJECT_STATE: Record<GitlabProjectBindingState, { label: st
   cleanup_pending: { label: 'removal incomplete', badge: 'bg-(--status-error-soft) text-(--status-error)' }
 }
 
+/** gitlab.com is pinned in v1 — no host override exists to thread through here. */
+export function gitlabProfileUrl(username: string): string {
+  return `https://gitlab.com/${username}`
+}
+
+// The CP records a machine category in `stateReason`; these are the ones a user can act on, in GitLab
+// vocabulary. Every rotation_* variant collapses to one line — the tail (rotation_gitlab_<status>) is open-ended.
+// A project binding and an agent's own bot account share this vocabulary, so both translate one set.
+export const GITLAB_STATE_REASON: Record<string, string> = {
+  project_not_accessible: 'GitLab project is no longer accessible',
+  personal_namespace_unsupported: 'Projects in a personal namespace are not supported',
+  project_namespace_unknown: 'GitLab did not report the group this project belongs to',
+  service_account_create_forbidden: 'Not allowed to create a project bot on GitLab',
+  service_account_quota:
+    'This GitLab group has reached its limit of bot accounts — remove one that is no longer used, then run Repair',
+  service_account_create_failed: 'GitLab refused to create the bot account — run Repair to try again',
+  no_admin_connection: 'No connected GitLab account can manage this project — transfer it to your own account',
+  admin_unavailable:
+    'The GitLab account that set this project up can no longer manage it — reconnect that account, or transfer the project to your own',
+  cleanup_failed:
+    'Removal did not finish because no connected GitLab account could reach the project — reconnect it or transfer the project, then remove again',
+  claim_fence_lost: 'Setup was interrupted — run Repair again',
+  relay_url_unconfigured: 'This deployment has no public webhook address configured',
+  provisioning_in_progress: 'Setup is already running',
+  provisioning_or_cleanup_in_progress: 'Setup or removal is already running'
+}
+
+/** User-facing copy for a state reason, or null to show nothing but the state badge — an
+ *  unmapped category is an implementation identifier and never belongs on this surface. */
+export function gitlabStateReasonText(reason: string | null): string | null {
+  if (!reason) return null
+  if (reason.startsWith('rotation_')) return 'The project bot credential needs repair'
+  // The gitlab_<status> family is open-ended; the actionable part is the same for all of it.
+  if (reason.startsWith('gitlab_')) {
+    return 'GitLab refused the last administration request — reconnect the account that manages this project, or transfer it to your own'
+  }
+  return GITLAB_STATE_REASON[reason] ?? null
+}
+
 /** One pickable project: `binding` null means picking it sets it up first. */
 export interface GitlabProjectChoice {
   projectId: string

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -91,8 +91,8 @@ export const consoleKeys = {
   /** `consumers` is not a request parameter but a freshness discriminator: the CP creates and
    *  retires these accounts behind hook CRUD, so binding or unbinding a project must not read a
    *  cache entry recorded under the old consumer set. */
-  agentGitlabAccounts: (orgId: string | null | undefined, agentId: string | null | undefined, consumers: number) =>
-    agentId ? consoleKey(orgId, 'agent-gitlab-accounts', agentId, String(consumers)) : null,
+  agentGitlabAccounts: (orgId: string | null | undefined, agentId: string | null | undefined, consumers: string) =>
+    agentId ? consoleKey(orgId, 'agent-gitlab-accounts', agentId, consumers) : null,
   agentPermissionRequests: (orgId: string | null | undefined, agentId: string | null | undefined) =>
     agentId ? consoleKey(orgId, 'agent-permission-requests', agentId) : null,
   hookRuns: (orgId: string | null | undefined, hookId: string) => consoleKey(orgId, 'hook-runs', hookId)

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -88,8 +88,11 @@ export const consoleKeys = {
     agentId ? consoleKey(orgId, 'agent-hooks', agentId) : null,
   agentRepos: (orgId: string | null | undefined, agentId: string | null | undefined) =>
     agentId ? consoleKey(orgId, 'agent-repos', agentId) : null,
-  agentGitlabAccounts: (orgId: string | null | undefined, agentId: string | null | undefined) =>
-    agentId ? consoleKey(orgId, 'agent-gitlab-accounts', agentId) : null,
+  /** `consumers` is not a request parameter but a freshness discriminator: the CP creates and
+   *  retires these accounts behind hook CRUD, so binding or unbinding a project must not read a
+   *  cache entry recorded under the old consumer set. */
+  agentGitlabAccounts: (orgId: string | null | undefined, agentId: string | null | undefined, consumers: number) =>
+    agentId ? consoleKey(orgId, 'agent-gitlab-accounts', agentId, String(consumers)) : null,
   agentPermissionRequests: (orgId: string | null | undefined, agentId: string | null | undefined) =>
     agentId ? consoleKey(orgId, 'agent-permission-requests', agentId) : null,
   hookRuns: (orgId: string | null | undefined, hookId: string) => consoleKey(orgId, 'hook-runs', hookId)

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -88,6 +88,8 @@ export const consoleKeys = {
     agentId ? consoleKey(orgId, 'agent-hooks', agentId) : null,
   agentRepos: (orgId: string | null | undefined, agentId: string | null | undefined) =>
     agentId ? consoleKey(orgId, 'agent-repos', agentId) : null,
+  agentGitlabAccounts: (orgId: string | null | undefined, agentId: string | null | undefined) =>
+    agentId ? consoleKey(orgId, 'agent-gitlab-accounts', agentId) : null,
   agentPermissionRequests: (orgId: string | null | undefined, agentId: string | null | undefined) =>
     agentId ? consoleKey(orgId, 'agent-permission-requests', agentId) : null,
   hookRuns: (orgId: string | null | undefined, hookId: string) => consoleKey(orgId, 'hook-runs', hookId)


### PR DESCRIPTION
Console half of M8 (gitlab-com-integration.md §7.2, §18.1). #1418 gave every agent its own GitLab service account; this makes that identity visible where the user manages the agent.

## Agent detail page owns the agent's GitLab identity

A new `AgentGitlabIdentity` card lists the bot accounts the agent acts as — username, display name, GitLab profile link, and account health — grouped by top-level group when the agent holds one in several, since a GitLab group service account cannot be invited across that boundary.

Three deliberate details:

- **Absent, not empty.** Most agents have no GitLab project, and a deployment with no GitLab application at all answers 404 on the whole surface — both render nothing rather than an empty-state card.
- **The profile link waits for the account.** The username is deterministic from the agent, so linking before the account exists on GitLab would point at nothing; until then the handle is plain text.
- **No new input.** Names derive from the agent, exactly as §7.2 specifies.

## Project rows show each bot's own health

The member-account chips a project row already renders now carry the account's own state. An agent's identity can be refused — a top-level group out of service accounts — on a project whose binding is otherwise `ready`, and that was previously invisible on the row that owns Repair.

## One vocabulary, two surfaces

The binding state-reason translations move from `GitlabCard` into `lib/gitlab-projects`, so the Integrations card and the new chip translate the same set, and gain the account reasons. `service_account_quota` now reads as "This GitLab group has reached its limit of bot accounts — remove one that is no longer used, then run Repair" instead of rendering nothing.

## New route

`GET /orgs/:orgId/gitlab/agents/:id/accounts` — org-scoped and visibility-gated like the other agent reads, with OpenAPI tag, summary, description, and `listGitlabAgentAccounts` as its operation ID. It returns no token material, and a cross-org or restricted agent reads as absent rather than as someone else's bot. The response declares every field it returns.

`rootGroupPath` is derived server-side from a bound project's namespaced path: the account row holds only a numeric group id, which makes a poor heading.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean
- `pnpm --filter @agentconnect.md/web test` — 1904 passed
- control-plane `test:unit` — 1967 passed; `test:int` — 1665 passed

New tests: the chip's single-root, multi-root grouping, quota-refused, retiring, and unmapped-reason cases; the project row's per-account health; and five integration cases on the new route (fields and derived group path, quota refusal, empty, 404s for unknown/cross-org/restricted, and 404 with the rest of the surface when GitLab is unconfigured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
