### PR TITLE
fix(daemon): let the Slack SDK own the file upload transport

### DIFF
--- a/docs/designs/agent-authored-attachments.md
+++ b/docs/designs/agent-authored-attachments.md
@@ -303,14 +303,17 @@ shim boundary, and generalizes to none of the other three platforms.
    30 s queue bound — decides whether the default cap drops, the byte transfer gets its
    own lane, or `indeterminate` carries the weight.
 3. **Slack transport (settled):** the external upload's middle step is a POST to a reserved
-   URL that is not a Slack API endpoint and has no published wire contract. Driving the
-   three steps by hand cost two live failures — a multipart part the URL answers with HTTP
-   500 unless it is named `body`, and at least one more the same code never got past — so
-   `uploadFile` now calls `files.uploadV2`, which owns all three steps and inherits the
-   `WebClient` agent/proxy/timeout configuration. `uploadV2` builds its completion
-   arguments from an explicit key list, which is what removed the identity decoration
-   above. It also hides _which_ step threw, so only a Slack `{ok:false}` and the SDK's own
-   byte-POST rejection count as proof that nothing was published; every other failure is
+   URL that is not a Slack API endpoint and has no published wire contract. Driving it by
+   hand was refused with HTTP 500 on every live attempt. Matching the SDK's multipart shape
+   — one part named `body`, an untyped `Blob` — did not lift the 500; the one divergence
+   left was that the SDK sends `Authorization: Bearer <token>` to the reserved URL, which
+   the hand-written POST asserted in a comment was unnecessary. Rather than test that guess
+   in production, `uploadFile` now calls `files.uploadV2`, which owns all three steps and
+   inherits the `WebClient` agent/proxy/timeout configuration. Two consequences: it builds
+   its completion arguments from an explicit key list, which is what removed the identity
+   decoration above; and it raises one `WebAPIHTTPError` for every non-200 across all three
+   steps, so an HTTP failure can never prove which step it came from. Only Slack answering
+   `{ok:false}` counts as proof that nothing was published — everything else is
    `indeterminate`.
 4. **Demand:** is there a concrete request behind "produced file → different
    conversation", or only the table's symmetry? Decides whether `attachFile` leaves §7.

--- a/docs/designs/agent-authored-attachments.md
+++ b/docs/designs/agent-authored-attachments.md
@@ -115,12 +115,13 @@ Three refusal classes, and only the first is port-probeable — the doc'd earlie
 
 ### 3.3 Identity, caption, and the result
 
-**The file post is _not_ identity-stamped today, on any platform** — three `uploadFile`
-implementations do not even declare the identity parameter, Telegram ignores identity by
-platform design, and Slack's share carries `username`/`icon_url` but not the
-`agentAuthorId` metadata every other agent post carries. On a shared Slack app that makes
-a shared file invisible to peer backfill and mis-attributable to whichever agent looks at
-it. Phase 1 states this degradation per platform rather than claiming otherwise; if
+**The file post is _not_ identity-stamped today, on any platform** — no `uploadFile`
+implementation declares the identity parameter, and Telegram ignores identity by platform
+design. Slack briefly passed `username`/`icon_url` to the share step: documented for that
+method, absent from the SDK's argument type, and never confirmed against live Slack before
+it was dropped along with the hand-written transport it lived in (§9.4). On a shared Slack
+app the gap makes a shared file invisible to peer backfill and mis-attributable to
+whichever agent looks at it. Phase 1 states this degradation per platform rather than claiming otherwise; if
 attribution matters on shared bots, the fix is a paired zero-content anchor post stamped
 with `agentAuthorId` — which would also supply Slack's missing message id — and it is
 deferred until shared-bot usage demands it.
@@ -298,8 +299,18 @@ shim boundary, and generalizes to none of the other three platforms.
 
 1. **Telegram:** does `sendPhoto` re-encode a ≤8 MB PNG chart badly enough to blur axis
    labels? Decides whether the `preview | file` hint is deferrable.
-2. **Slack:** wall time of an 8 MB three-step share on a typical self-hosted uplink vs the
+2. **Slack:** wall time of an 8 MB external upload on a typical self-hosted uplink vs the
    30 s queue bound — decides whether the default cap drops, the byte transfer gets its
    own lane, or `indeterminate` carries the weight.
-3. **Demand:** is there a concrete request behind "produced file → different
+3. **Slack transport (settled):** the external upload's middle step is a POST to a reserved
+   URL that is not a Slack API endpoint and has no published wire contract. Driving the
+   three steps by hand cost two live failures — a multipart part the URL answers with HTTP
+   500 unless it is named `body`, and at least one more the same code never got past — so
+   `uploadFile` now calls `files.uploadV2`, which owns all three steps and inherits the
+   `WebClient` agent/proxy/timeout configuration. `uploadV2` builds its completion
+   arguments from an explicit key list, which is what removed the identity decoration
+   above. It also hides _which_ step threw, so only a Slack `{ok:false}` and the SDK's own
+   byte-POST rejection count as proof that nothing was published; every other failure is
+   `indeterminate`.
+4. **Demand:** is there a concrete request behind "produced file → different
    conversation", or only the table's symmetry? Decides whether `attachFile` leaves §7.

--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -35,9 +35,6 @@ const EXEMPT: Record<string, string> = {
   postPermissionUpdateCard: 'private permission-card helper',
   postIfThreadExists: 'private Slack root-existence guard',
   postChatMessage: 'private shared post boundary behind postMessage/postBlocks',
-  putUploadBytes: 'private step 2 of the external upload, behind uploadFile',
-  completeUpload: 'private step 3 of the external upload, behind uploadFile',
-  completeShare: 'private one-shot completion boundary, behind completeUpload',
   // Interactive Slack surfaces (Block Kit actions / modals) are driven by
   // Bolt callbacks the virtual transport never receives; the daemon only
   // invokes them from those callbacks.

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -357,11 +357,10 @@ export type AppLike = {
       update: (a: unknown) => Promise<{ ts?: string }>
       delete: (a: unknown) => Promise<unknown>
     }
-    // The external upload flow (`files:write`). chat.postMessage cannot carry bytes at
-    // all, so this three-step dance is the ONLY way to put a file in a conversation.
+    // The external upload flow (`files:write`). chat.postMessage cannot carry bytes at all,
+    // so this is the ONLY way to put a file in a conversation.
     files: {
-      getUploadURLExternal: (a: unknown) => Promise<{ upload_url?: string; file_id?: string }>
-      completeUploadExternal: (a: unknown) => Promise<{ files?: { id?: string }[] }>
+      uploadV2: (a: unknown) => Promise<unknown>
     }
     conversations: {
       open: (a: unknown) => Promise<{ channel?: { id?: string } }>
@@ -527,6 +526,19 @@ const SLACK_API_TIMEOUT_MS = 30_000
 
 /** Map a Slack API error to the port's typed failure vocabulary — every arm already had the
  *  raw material (`missing_scope` payloads, stable error codes); this only names them. */
+/**
+ * `uploadV2` runs all three steps, so a failure's MEANING depends on which one raised it.
+ * Slack answering `{ok:false}` (either the reservation or the share) and the SDK's own
+ * byte-POST rejection both prove nothing was published; any other throw may have happened
+ * after the share was already accepted, and the caller must not be told to retry it.
+ * Matching the SDK's rejection text is deliberately the only brittle part — if that string
+ * ever changes, this degrades to "may have landed", which is the safe direction.
+ */
+function isDefiniteUploadRefusal(err: unknown): boolean {
+  if (slackApiErrorCode(err) !== undefined) return true
+  return /^Failed to upload file\b/.test((err as Error | undefined)?.message ?? '')
+}
+
 /** The provider's own words, for the arm that has no category: without this a refusal
  *  reports only `platform error`, which no operator can act on. */
 function slackErrorDetail(err: unknown): { detail?: string } {
@@ -1353,51 +1365,50 @@ export class SlackConnection implements PlatformConnection {
     channel: string,
     file: { bytes: Buffer; name: string; mimeType?: string },
     comment?: string,
-    anchor?: UploadAnchor,
-    options?: SlackPostOptions
+    anchor?: UploadAnchor
   ): Promise<UploadOutcome> {
     const threadTs = anchor?.thread
     const task: Promise<UploadOutcome> = this.queue.enqueue(async () => {
       try {
-        const reserved = await this.app.client.files.getUploadURLExternal({
-          filename: file.name,
-          length: file.bytes.byteLength
-        })
-        const uploadUrl = reserved.upload_url
-        const fileId = reserved.file_id
-        if (!uploadUrl || !fileId) {
-          this.deps.log?.debug(`slack: uploadFile got no upload url for ${file.name}`)
-          return { ok: false, reason: 'platform_error' }
-        }
-        const put = await this.putUploadBytes(uploadUrl, file)
-        if (!put.ok) return put
+        // `uploadV2` IS the three-step external upload — reserve a URL, POST the bytes, share
+        // the file — and we call it instead of driving those steps ourselves because the
+        // middle one is not a Slack API request and its exact wire shape is undocumented.
+        // Two live failures came out of reimplementing it (a multipart part Slack answers
+        // with HTTP 500 unless it is named `body`, and at least one more), so the transport
+        // now belongs to the SDK that Slack maintains, along with the agent/proxy/timeout
+        // configuration the rest of this client already got from `WebClient`.
+        //
+        // The cost is the file share's identity decoration: `completeUploadExternal` accepts
+        // `username`/`icon_url` per the docs but not per the SDK's types, and `uploadV2`
+        // builds its completion arguments from an explicit key list that omits both. So a
+        // shared file posts under the app's identity while the agent's text reply posts under
+        // the agent's. That decoration was never verified against live Slack anyway — it was
+        // already being dropped on any rejection — so this gives up nothing that worked.
+        //
         // Sharing is what makes the file a message; without `channel_id` it stays a private
         // upload nobody can see. `thread_ts` must be the PARENT's ts, never a reply's.
-        // A CAPTION IS MRKDWN HERE, unlike every other send in this file. `postMessage` renders
-        // through a Block Kit `markdown` block, but this method documents `blocks` as IGNORED
-        // whenever `initial_comment` is set — and it has no separate `text` argument, so
-        // blocks-only would buy CommonMark at the price of the notification preview for every
-        // forwarded file. Keeping the comment is the better half of that trade; the cost is
-        // that `**bold**` and `[label](url)` read literally on a forward.
-        const share: Record<string, unknown> = {
-          files: [{ id: fileId, title: file.name }],
+        // A CAPTION IS MRKDWN HERE, unlike every other send in this file. `postMessage`
+        // renders through a Block Kit `markdown` block, but the completion step documents
+        // `blocks` as IGNORED whenever `initial_comment` is set — and it has no separate
+        // `text` argument, so blocks-only would buy CommonMark at the price of the
+        // notification preview for every forwarded file. Keeping the comment is the better
+        // half of that trade; the cost is that `**bold**` and `[label](url)` read literally.
+        await this.app.client.files.uploadV2({
+          file: file.bytes,
+          filename: file.name,
           channel_id: channel,
           ...(threadTs ? { thread_ts: threadTs } : {}),
           ...(comment ? { initial_comment: comment } : {})
-        }
-        await this.completeUpload(share, options)
+        })
         return { ok: true }
       } catch (err) {
         this.rememberMissingScopes(err)
         this.deps.log?.debug(`slack: uploadFile ${file.name} → ch=${channel} failed: ${(err as Error).message}`)
         // A share whose outcome Slack never confirmed must say "may have landed", never
         // "nothing was sent" — the same rule the send queue's abandonment already follows.
-        const ambiguous = (err as { shareMayHaveLanded?: unknown } | null)?.shareMayHaveLanded === true
-        return {
-          ok: false,
-          reason: ambiguous ? 'indeterminate' : classifySlackUploadError(err),
-          ...slackErrorDetail(err)
-        }
+        return isDefiniteUploadRefusal(err)
+          ? { ok: false, reason: classifySlackUploadError(err), ...slackErrorDetail(err) }
+          : { ok: false, reason: 'indeterminate', ...slackErrorDetail(err) }
       }
     })
     // The queue abandons a task at 30 s but the task KEEPS RUNNING — the share may still
@@ -1406,107 +1417,6 @@ export class SlackConnection implements PlatformConnection {
       ok: false,
       reason: isSendQueueTimeout(err) ? 'indeterminate' : 'platform_error'
     }))
-  }
-
-  /** Step 2 of the upload: POST the bytes to the reserved URL. It is NOT a Slack API
-   *  endpoint (no token, no JSON envelope), so it goes out through undici with the same
-   *  proxy dispatcher the Web API client uses rather than through `this.app.client`. */
-  private async putUploadBytes(
-    uploadUrl: string,
-    file: { bytes: Buffer; name: string }
-  ): Promise<{ ok: true } | { ok: false; reason: UploadFailReason; detail?: string }> {
-    // FIELD NAME `body`, NOT `file`: this shape is not ours to choose — it is what Slack's
-    // own SDK sends (`postFileUploadsToExternalURL` posts `{ body: data }`, which its
-    // form serializer turns into one multipart part named `body`). A part named anything
-    // else is answered with HTTP 500 by the reserved upload URL, which is what a live
-    // Slack→Slack forward hit.
-    const form = new FormData()
-    form.append('body', new Blob([new Uint8Array(file.bytes)]), file.name)
-    // This runs inside the serial send queue, so it carries the same bound the WebClient
-    // does: a stuck upload must not wedge every other message on this connection.
-    const dispatcher = proxyDispatcher()
-    try {
-      // Same cast seam as `fetchWithDispatcher`: undici's own FormData/RequestInit types and
-      // the Node globals are structurally identical but nominally distinct.
-      const init = {
-        method: 'POST',
-        body: form,
-        signal: AbortSignal.timeout(SLACK_API_TIMEOUT_MS),
-        ...(dispatcher ? { dispatcher } : {})
-      }
-      const res = await undiciFetch(uploadUrl, init as Parameters<typeof undiciFetch>[1])
-      // Only `ok` is read, so the body is never drained — and an unread body leaves the
-      // request in flight, which is exactly what the graceful `close()` below waits for. That
-      // wait sits inside the send queue and outside the signal's reach, so it would trade the
-      // socket-pool leak for the wedge the timeout was added to prevent.
-      await res.body?.cancel().catch(() => {})
-      if (!res.ok) {
-        this.deps.log?.debug(`slack: uploadFile byte POST for ${file.name} → HTTP ${res.status}`)
-        return {
-          ok: false,
-          reason: res.status === 413 ? 'too_large' : 'platform_error',
-          detail: `byte upload HTTP ${res.status}`
-        }
-      }
-      return { ok: true }
-    } finally {
-      // Unlike the two long-lived clients, this agent serves one request — closing it keeps
-      // a proxied deployment from leaking a keep-alive socket pool per forward.
-      await dispatcher?.close()
-    }
-  }
-
-  /**
-   * Step 3 of the upload. The identity decoration is BEST-EFFORT and must never cost the
-   * delivery: `username`/`icon_url` are documented for this method but absent from the SDK's
-   * own argument type, so a rejection here is not necessarily the `chat:write.customize`
-   * scope — it can be the arguments themselves. Any failure of the decorated call is
-   * therefore retried once undecorated, which is what the text path's narrower fallback
-   * would have done for the one cause it knew about. The file lands either way; the agent's
-   * name on it is the part we are willing to lose.
-   */
-  /**
-   * `files.completeUploadExternal` is ONE-SHOT: it cannot be safely repeated, because a
-   * second call after a lost response would double-post. So a failure that is not a DEFINITE
-   * platform refusal (Slack answering `{ok:false, error}`) is ambiguous — the share may
-   * already be visible — and is marked as such rather than treated as "nothing happened".
-   */
-  private async completeShare(payload: Record<string, unknown>): Promise<void> {
-    try {
-      await this.app.client.files.completeUploadExternal(payload)
-    } catch (err) {
-      if (slackApiErrorCode(err) === undefined) throw Object.assign(err as Error, { shareMayHaveLanded: true })
-      throw err
-    }
-  }
-
-  private async completeUpload(share: Record<string, unknown>, options?: SlackPostOptions): Promise<void> {
-    const customize: Record<string, unknown> = {}
-    const username = options?.username?.trim()
-    const iconUrl = options?.icon_url?.trim()
-    if (username) customize.username = username
-    if (iconUrl) customize.icon_url = iconUrl
-    if (Object.keys(customize).length === 0 || Date.now() < this.customUsernameRetryAt) {
-      await this.completeShare(share)
-      return
-    }
-    try {
-      await this.completeShare({ ...share, ...customize })
-      this.customUsernameRetryAt = 0
-    } catch (err) {
-      this.rememberMissingScopes(err)
-      // A second completion is only safe when Slack DEFINITELY refused the first: an
-      // ambiguous transport failure may have been accepted, and retrying it would either
-      // double-post or report "nothing was sent" for a file the channel already shows.
-      if (slackApiErrorCode(err) === undefined) throw err
-      // Only a genuine missing scope arms the shared backoff — anything else is this
-      // method's own argument handling and says nothing about the text path.
-      if (isMissingCustomizeScope(err)) this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
-      this.deps.log?.debug(
-        `slack: decorated file share refused (${slackApiErrorCode(err)}) — retrying under the app identity`
-      )
-      await this.completeShare(share)
-    }
   }
 
   /**

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -526,19 +526,6 @@ const SLACK_API_TIMEOUT_MS = 30_000
 
 /** Map a Slack API error to the port's typed failure vocabulary — every arm already had the
  *  raw material (`missing_scope` payloads, stable error codes); this only names them. */
-/**
- * `uploadV2` runs all three steps, so a failure's MEANING depends on which one raised it.
- * Slack answering `{ok:false}` (either the reservation or the share) and the SDK's own
- * byte-POST rejection both prove nothing was published; any other throw may have happened
- * after the share was already accepted, and the caller must not be told to retry it.
- * Matching the SDK's rejection text is deliberately the only brittle part — if that string
- * ever changes, this degrades to "may have landed", which is the safe direction.
- */
-function isDefiniteUploadRefusal(err: unknown): boolean {
-  if (slackApiErrorCode(err) !== undefined) return true
-  return /^Failed to upload file\b/.test((err as Error | undefined)?.message ?? '')
-}
-
 /** The provider's own words, for the arm that has no category: without this a refusal
  *  reports only `platform error`, which no operator can act on. */
 function slackErrorDetail(err: unknown): { detail?: string } {
@@ -1406,7 +1393,11 @@ export class SlackConnection implements PlatformConnection {
         this.deps.log?.debug(`slack: uploadFile ${file.name} → ch=${channel} failed: ${(err as Error).message}`)
         // A share whose outcome Slack never confirmed must say "may have landed", never
         // "nothing was sent" — the same rule the send queue's abandonment already follows.
-        return isDefiniteUploadRefusal(err)
+        // Only Slack answering `{ok:false}` proves nothing was published. An HTTP failure
+        // cannot: the SDK raises the same `WebAPIHTTPError` for every non-200 in all three
+        // steps, so a rejected byte POST and a lost response from the already-accepted share
+        // are indistinguishable here, and the ambiguous reading is the safe one.
+        return slackApiErrorCode(err) !== undefined
           ? { ok: false, reason: classifySlackUploadError(err), ...slackErrorDetail(err) }
           : { ok: false, reason: 'indeterminate', ...slackErrorDetail(err) }
       }

--- a/packages/daemon/test/fakes/slack-app.ts
+++ b/packages/daemon/test/fakes/slack-app.ts
@@ -44,11 +44,7 @@ export function fakeSlackAppFactory(identity: FakeSlackIdentity = {}): SlackAppF
           delete: ok
         },
         files: {
-          getUploadURLExternal: async () => ({
-            upload_url: 'https://files.slack.com/upload/v1/fake',
-            file_id: 'F_FAKE'
-          }),
-          completeUploadExternal: async () => ({ files: [{ id: 'F_FAKE' }] })
+          uploadV2: async () => ({ ok: true, files: [{ id: 'F_FAKE' }] })
         },
         conversations: {
           open: async () => ({ channel: { id: 'D_FAKE' } }),

--- a/packages/daemon/test/slack-upload-file.test.ts
+++ b/packages/daemon/test/slack-upload-file.test.ts
@@ -83,20 +83,7 @@ describe('SlackConnection.uploadFile', () => {
     })
   })
 
-  it('treats the SDK’s own byte-POST rejection as proof that nothing was published', async () => {
-    // That step runs before the share, so its failure is one of the few non-API errors that
-    // definitely left the conversation untouched — the agent may say so and move on.
-    const conn = connWith(async () => {
-      throw new Error('Failed to upload file (id:F1, filename: a.png)')
-    })
-    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
-      ok: false,
-      reason: 'platform_error',
-      detail: 'Failed to upload file (id:F1, filename: a.png)'
-    })
-  })
-
-  it('calls any other failure indeterminate, because the share step is one-shot', async () => {
+  it('calls every non-API failure indeterminate, because the share step is one-shot', async () => {
     // `uploadV2` hides WHICH step threw, and a lost response from the completion step may
     // have been accepted. "Nothing was sent" would then be a lie about a file the channel
     // already shows, and would invite the retry that double-posts it.
@@ -107,6 +94,23 @@ describe('SlackConnection.uploadFile', () => {
       ok: false,
       reason: 'indeterminate',
       detail: 'socket hang up'
+    })
+  })
+
+  it('will not call an HTTP failure definite, however early in the upload it happened', async () => {
+    // Tempting, since a rejected byte POST runs BEFORE the share and so proves nothing was
+    // published — but the SDK raises one `WebAPIHTTPError` for every non-200 across all three
+    // steps, so that case is indistinguishable from a lost response to an accepted share.
+    const httpError = Object.assign(new Error('An HTTP protocol error occurred: statusCode = 500'), {
+      code: 'slack_webapi_http_error',
+      statusCode: 500
+    })
+    const conn = connWith(async () => {
+      throw httpError
+    })
+    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toMatchObject({
+      ok: false,
+      reason: 'indeterminate'
     })
   })
 })

--- a/packages/daemon/test/slack-upload-file.test.ts
+++ b/packages/daemon/test/slack-upload-file.test.ts
@@ -1,20 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-
-// The byte POST of Slack's external upload goes to a reserved URL that is NOT a Slack API
-// endpoint, so it leaves through undici directly rather than through the Web API client.
-type FakeFetchResponse = { ok: boolean; status: number; body?: { cancel: () => Promise<void> } }
-const undici = vi.hoisted(() => ({
-  fetch: vi.fn<(url: string, init?: Record<string, unknown>) => Promise<FakeFetchResponse>>(async () => ({
-    ok: true,
-    status: 200
-  }))
-}))
-vi.mock('undici', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('undici')>()),
-  fetch: undici.fetch
-}))
-
-const { SlackConnection } = await import('../src/slack/connection.js')
+import { SlackConnection } from '../src/slack/connection.js'
 
 const deps = () => ({
   group: { appToken: 'xapp-1', botToken: 'xoxb-a', integrations: [] },
@@ -22,8 +7,8 @@ const deps = () => ({
   newTraceId: () => 't'
 })
 
-function fakeApp(files: Record<string, unknown>) {
-  return {
+function connWith(uploadV2: unknown) {
+  const app = {
     message() {},
     event() {},
     action() {},
@@ -31,110 +16,53 @@ function fakeApp(files: Record<string, unknown>) {
     client: {
       auth: { test: async () => ({ user_id: 'U1', team_id: 'T123' }) },
       chat: { postMessage: async () => ({}), getPermalink: async () => ({ permalink: 'https://x/y' }) },
-      files,
+      files: { uploadV2 },
       assistant: { threads: { setStatus: async () => undefined, setTitle: async () => undefined } }
     },
     start: async () => {},
     stop: async () => {}
   }
+  return new SlackConnection(deps() as never, (() => app) as never)
 }
 
-function connWith(files: Record<string, unknown>) {
-  return new SlackConnection(deps() as never, (() => fakeApp(files)) as never)
-}
+const slackError = (code: string, extra: Record<string, unknown> = {}) =>
+  Object.assign(new Error(code), { data: { error: code, ...extra } })
 
 describe('SlackConnection.uploadFile', () => {
   // Slack is the outlier: its share answers with the FILE, so success carries no messageId and
   // a forward there anchors nothing — see platform-upload-file.test.ts for the other three.
-  it('reserves a URL, POSTs the bytes, and shares the file as the message', async () => {
-    const getUploadURLExternal = vi.fn(async () => ({
-      upload_url: 'https://files.slack.com/upload/v1/x',
-      file_id: 'F1'
-    }))
-    const completeUploadExternal = vi.fn(async () => ({ files: [{ id: 'F1' }] }))
-    const conn = connWith({ getUploadURLExternal, completeUploadExternal })
+  it('hands the whole external upload to the SDK, with the coordinates that make it a message', async () => {
+    // The byte POST is not a Slack API request and its wire shape is undocumented; two live
+    // failures came out of reimplementing it, so the transport belongs to `uploadV2` now.
+    const uploadV2 = vi.fn(async () => ({ ok: true, files: [{ id: 'F1' }] }))
+    const conn = connWith(uploadV2)
 
     const bytes = Buffer.from('PNGBYTES')
     await expect(
-      conn.uploadFile(
-        'C1',
-        { bytes, name: 'shot.png' },
-        'from telegram',
-        { thread: '111.1' },
-        {
-          username: 'Scout',
-          icon_url: 'https://example.test/a.png'
-        }
-      )
+      conn.uploadFile('C1', { bytes, name: 'shot.png' }, 'from telegram', { thread: '111.1' })
     ).resolves.toEqual({ ok: true })
 
-    expect(getUploadURLExternal).toHaveBeenCalledWith({ filename: 'shot.png', length: bytes.byteLength })
-    expect(undici.fetch).toHaveBeenCalledWith(
-      'https://files.slack.com/upload/v1/x',
-      expect.objectContaining({ method: 'POST' })
-    )
-    // The multipart part must be named `body`, the name Slack's own SDK sends. Anything
-    // else — `file`, say — is answered with HTTP 500 by the reserved upload URL.
-    const posted = undici.fetch.mock.calls[0]![1] as { body: FormData }
-    expect(posted.body.has('body')).toBe(true)
-    expect(posted.body.has('file')).toBe(false)
     // channel_id is what turns a hosted file into a message; without it the upload stays
-    // private. The caption rides as initial_comment, and the agent keeps its own identity.
-    expect(completeUploadExternal).toHaveBeenCalledWith({
-      files: [{ id: 'F1', title: 'shot.png' }],
+    // private. No `blocks`: the completion step ignores them whenever `initial_comment` is
+    // set, so sending both would only look like the caption renders as CommonMark.
+    expect(uploadV2).toHaveBeenCalledWith({
+      file: bytes,
+      filename: 'shot.png',
       channel_id: 'C1',
       thread_ts: '111.1',
-      // No `blocks`: this method ignores them whenever `initial_comment` is set, so sending
-      // both would only look like the caption renders as CommonMark. It does not — see the
-      // note on the trade in `uploadFile`.
-      initial_comment: 'from telegram',
-      username: 'Scout',
-      icon_url: 'https://example.test/a.png'
+      initial_comment: 'from telegram'
     })
   })
 
-  it('shares under the app identity when ANY decorated attempt is refused, not only a missing scope', async () => {
-    // username/icon_url are documented for this method but absent from the SDK's argument
-    // type, so a rejection is not necessarily the scope — it can be the arguments. The file
-    // must land either way; the agent's name on it is the part we are willing to lose.
-    const completeUploadExternal = vi.fn(async (a: Record<string, unknown>) => {
-      if (a.username) throw Object.assign(new Error('invalid_arguments'), { data: { error: 'invalid_arguments' } })
-      return { files: [{ id: 'F1' }] }
-    })
-    const conn = connWith({
-      getUploadURLExternal: async () => ({ upload_url: 'https://files.slack.com/upload/v1/x', file_id: 'F1' }),
-      completeUploadExternal
-    })
-    await expect(
-      conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi', undefined, { username: 'Scout' })
-    ).resolves.toEqual({ ok: true })
-    expect(completeUploadExternal).toHaveBeenCalledTimes(2)
-    expect(completeUploadExternal.mock.calls[1]![0]).not.toHaveProperty('username')
-  })
-
-  it('does NOT retry a completion whose outcome Slack never confirmed, and calls it indeterminate', async () => {
-    // completeUploadExternal is one-shot: a transport failure may have been ACCEPTED with its
-    // response lost, so a second call could double-post and "nothing was sent" could be a lie
-    // about a file the channel already shows.
-    const completeUploadExternal = vi.fn(async () => {
-      throw new Error('socket hang up')
-    })
-    const conn = connWith({
-      getUploadURLExternal: async () => ({ upload_url: 'https://files.slack.com/upload/v1/x', file_id: 'F1' }),
-      completeUploadExternal
-    })
-    await expect(
-      conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi', undefined, { username: 'Scout' })
-    ).resolves.toEqual({ ok: false, reason: 'indeterminate', detail: 'socket hang up' })
-    expect(completeUploadExternal).toHaveBeenCalledOnce()
+  it('omits the anchor and the caption rather than sending them empty', async () => {
+    const uploadV2 = vi.fn(async () => ({ ok: true }))
+    await connWith(uploadV2).uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })
+    expect(uploadV2).toHaveBeenCalledWith({ file: expect.any(Buffer), filename: 'a.png', channel_id: 'C1' })
   })
 
   it('reports the provider’s own error code, since `platform error` alone is not actionable', async () => {
-    const conn = connWith({
-      getUploadURLExternal: async () => {
-        throw Object.assign(new Error('nope'), { data: { error: 'method_not_supported_for_channel_type' } })
-      },
-      completeUploadExternal: async () => ({ files: [] })
+    const conn = connWith(async () => {
+      throw slackError('method_not_supported_for_channel_type')
     })
     await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
       ok: false,
@@ -143,77 +71,42 @@ describe('SlackConnection.uploadFile', () => {
     })
   })
 
-  it('shares under the app identity when chat:write.customize is missing', async () => {
-    const completeUploadExternal = vi.fn(async (a: Record<string, unknown>) => {
-      if (a.username)
-        throw Object.assign(new Error('missing_scope'), {
-          data: { error: 'missing_scope', needed: 'chat:write.customize' }
-        })
-      return { files: [{ id: 'F1' }] }
-    })
-    const conn = connWith({
-      getUploadURLExternal: async () => ({ upload_url: 'https://files.slack.com/upload/v1/x', file_id: 'F1' }),
-      completeUploadExternal
-    })
-
-    await expect(
-      conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi', undefined, { username: 'Scout' })
-    ).resolves.toEqual({ ok: true })
-    expect(completeUploadExternal).toHaveBeenCalledTimes(2)
-    expect(completeUploadExternal.mock.calls[1]![0]).not.toHaveProperty('username')
-  })
-
-  it('bounds the byte POST and drains its body, so neither can wedge the send queue', async () => {
-    // The body matters as much as the signal: an unread one keeps the request in flight, and
-    // the graceful agent close waits for exactly that — outside the signal's reach.
-    const cancel = vi.fn(async () => {})
-    undici.fetch.mockResolvedValueOnce({ ok: true, status: 200, body: { cancel } })
-    const conn = connWith({
-      getUploadURLExternal: async () => ({ upload_url: 'https://files.slack.com/upload/v1/x', file_id: 'F1' }),
-      completeUploadExternal: async () => ({ files: [{ id: 'F1' }] })
-    })
-    await conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })
-    expect(undici.fetch.mock.calls[0]![1]).toMatchObject({ signal: expect.any(AbortSignal) })
-    expect(cancel).toHaveBeenCalledOnce()
-  })
-
-  it('gives up without sharing when the reservation returns no upload url', async () => {
-    const completeUploadExternal = vi.fn(async () => ({ files: [] }))
-    const conn = connWith({ getUploadURLExternal: async () => ({}), completeUploadExternal })
-
-    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
-      ok: false,
-      reason: 'platform_error'
-    })
-    expect(completeUploadExternal).not.toHaveBeenCalled()
-  })
-
-  it('classifies failures instead of throwing into the send path', async () => {
-    const conn = connWith({
-      getUploadURLExternal: async () => {
-        throw new Error('slack down')
-      },
-      completeUploadExternal: async () => ({ files: [] })
-    })
-    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
-      ok: false,
-      reason: 'platform_error',
-      detail: 'slack down'
-    })
-  })
-
   it('classifies a missing files:write scope, the likeliest first-run failure', async () => {
     // Operator-fixable, so the reason must be distinguishable from a deleted thread root.
-    const conn = connWith({
-      getUploadURLExternal: async () => {
-        throw Object.assign(new Error('missing_scope'), { data: { error: 'missing_scope', needed: 'files:write' } })
-      },
-      completeUploadExternal: async () => ({ files: [] })
+    const conn = connWith(async () => {
+      throw slackError('missing_scope', { needed: 'files:write' })
     })
     await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
       ok: false,
       reason: 'missing_scope',
       detail: 'missing_scope'
+    })
+  })
+
+  it('treats the SDK’s own byte-POST rejection as proof that nothing was published', async () => {
+    // That step runs before the share, so its failure is one of the few non-API errors that
+    // definitely left the conversation untouched — the agent may say so and move on.
+    const conn = connWith(async () => {
+      throw new Error('Failed to upload file (id:F1, filename: a.png)')
+    })
+    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
+      ok: false,
+      reason: 'platform_error',
+      detail: 'Failed to upload file (id:F1, filename: a.png)'
+    })
+  })
+
+  it('calls any other failure indeterminate, because the share step is one-shot', async () => {
+    // `uploadV2` hides WHICH step threw, and a lost response from the completion step may
+    // have been accepted. "Nothing was sent" would then be a lie about a file the channel
+    // already shows, and would invite the retry that double-posts it.
+    const conn = connWith(async () => {
+      throw new Error('socket hang up')
+    })
+    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
+      ok: false,
+      reason: 'indeterminate',
+      detail: 'socket hang up'
     })
   })
 })

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -12,7 +12,6 @@ export const MOCKING_TESTS = [
   'test/cp/cp-integration.test.ts',
   'test/daemon-cp-onboarding.test.ts',
   'test/runtime-install-repair-collapse.test.ts',
-  'test/slack-upload-file.test.ts',
   'test/telegram-connection.test.ts',
   'test/workspace-git.test.ts',
   'test/workspace.test.ts'


### PR DESCRIPTION
Agent image uploads to Slack failed against the live platform twice in a row, in
the same place both times: the middle step of the external upload, a POST of the
raw bytes to a reserved URL that is **not** a Slack API endpoint and has no
published wire contract. Both attempts came back **HTTP 500**.

The first fix (#1419) renamed the multipart part to `body`, matching the name the
SDK's serializer sends. Re-reading the SDK version actually pinned here — 8.0.0,
not the 7.19.0 copy also present in the tree — shows that after that rename the
hand-written POST already matched the SDK's multipart shape exactly: one part
named `body` carrying an untyped `Blob`. So the multipart shape was never what
the reserved URL refused, and #1419 fixed nothing observable.

The one divergence left is that the SDK sends `Authorization: Bearer <token>` to
the reserved URL, while the hand-written POST sends no headers at all and asserts
in a comment that the endpoint takes no token.

## What this does instead of testing that guess in production

Stops reimplementing the transport. `uploadFile` now calls `files.uploadV2`,
which owns all three steps and inherits the agent, proxy, and timeout
configuration the rest of this client already takes from `WebClient` — so the
byte POST stops being the one Slack request that routes differently from every
other one.

This ends a class of bug rather than one instance, and it makes the next live
result informative either way: if uploads work, the transport was the problem; if
they still fail, the transport never was.

## Two consequences, stated rather than discovered later

**The share loses its identity decoration.** `username`/`icon_url` are documented
for the completion step but absent from the SDK's argument type, and `uploadV2`
builds its completion arguments from an explicit key list that omits both. That
decoration was never confirmed against live Slack, and #1417 already made it
droppable on any rejection — so in practice files already posted under the app's
identity. The design doc had recorded file posts as not identity-stamped on any
platform; this removes the one partial exception and says why.

**An HTTP failure cannot name the step that raised it.** `uploadV2` raises the
same `WebAPIHTTPError` for every non-200 across all three steps, so a rejected
byte POST and a lost response to an already-accepted share are indistinguishable.
Only Slack answering `{ok:false}` counts as proof that nothing was published;
everything else is `indeterminate`, so a share whose outcome was never confirmed
still cannot be reported as "nothing was sent" or retried into a double post.

## Verification

- `slack-upload-file.test.ts` rewritten against `uploadV2`: the coordinates that
  make a hosted file a message, the omitted-anchor case, provider error codes,
  `missing_scope`, and both halves of the classification rule — including that an
  HTTP error stays indeterminate however early in the upload it happened.
- Full daemon unit suite, typecheck, lint, and the arena connection-surface guard
  pass. The four failing files on this machine (`shim-*`, the live ACP matrix)
  fail identically on a clean tree — they need a built shim bundle and locally
  installed runtimes.
- The three surface-guard exemptions for the removed private steps are gone along
  with the steps, and the test no longer mocks `undici`, so its registration in
  the mocking allowlist is dropped too.

Still unverified, and only a live run can settle it: whether a Slack share now
lands at all.
