### PR TITLE
fix(control-plane): provision an agent's GitLab account before the write that acts as it

### DIFF
--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -360,6 +360,54 @@ export class GitlabAccountService {
     return this.retireIfEmpty(orgId, account.id, token)
   }
 
+  /**
+   * Undo a speculative bind whose write never landed. `ensureForConsumer` runs
+   * BEFORE the row that makes the agent a consumer exists, so a failure after it
+   * can leave an account — and possibly a membership — that no convergence would
+   * ever visit: the unbind pass discovers stale members through the binding's
+   * membership rows, and an account with none is invisible to it. Left alone it
+   * would sit in the root consuming one of its 100 service-account slots for a
+   * hook or workspace that does not exist.
+   *
+   * An account still bound to another project keeps its membership and its PATs
+   * (§19.4) — only the binding this write was for is undone.
+   */
+  async rollbackSpeculativeBind(
+    input: { orgId: string; bindingId: string; projectId: bigint; rootGroupId: bigint; token: string },
+    agentId: string
+  ): Promise<void> {
+    const account = await this.deps.accounts.byAgentRoot(input.orgId, agentId, input.rootGroupId)
+    if (!account) return
+    // Another authorization may already earn this membership — a workspace on
+    // the project, or an enabled hook that is not the one being rolled back.
+    // The consumer set is the same authority the unbind pass uses, so asking it
+    // keeps this from revoking access the write never granted.
+    const consumers = await this.deps.accounts.consumers(input.orgId, input.projectId)
+    if (consumers.some((consumer) => consumer.agentId === agentId)) return
+    try {
+      const bound = await this.deps.accounts.membershipsForBinding(input.bindingId)
+      if (bound.some((membership) => membership.accountId === account.id)) {
+        if (account.serviceAccountUserId !== null) {
+          await gitlabRemoveMember(
+            input.token,
+            input.projectId,
+            account.serviceAccountUserId,
+            this.deps.fetchImpl
+          ).catch(swallow404)
+        }
+        await this.deps.accounts.detachMembership(account.id, input.bindingId)
+      }
+      await this.retireIfEmpty(input.orgId, account.id, input.token)
+    } catch (e) {
+      // Best effort: the account row keeps its own cleanup state, and the next
+      // convergence of any project in this root reconciles what is left.
+      this.deps.log?.warn(
+        { accountId: account.id, status: e instanceof GitlabApiError ? e.status : undefined },
+        'gitlab speculative bind rollback failed'
+      )
+    }
+  }
+
   /** §19.4: an account with no membership left in its root is retired — PATs
    *  revoked, account deleted — never kept warm. */
   async retireIfEmpty(orgId: string, accountId: string, token: string): Promise<boolean> {

--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -381,9 +381,37 @@ export class GitlabAccountService {
     // Another authorization may already earn this membership — a workspace on
     // the project, or an enabled hook that is not the one being rolled back.
     // The consumer set is the same authority the unbind pass uses, so asking it
-    // keeps this from revoking access the write never granted.
+    // keeps this from revoking access the write never granted. It does not
+    // justify the ROLE the write installed, though: a read-only workspace earns
+    // Reporter, so a failed hook that raised the account to Developer must give
+    // that back rather than leave write access behind indefinitely.
     const consumers = await this.deps.accounts.consumers(input.orgId, input.projectId)
-    if (consumers.some((consumer) => consumer.agentId === agentId)) return
+    const surviving = consumers.find((consumer) => consumer.agentId === agentId)
+    if (surviving) {
+      try {
+        if (account.serviceAccountUserId !== null) {
+          await gitlabEnsureMember(
+            input.token,
+            input.projectId,
+            account.serviceAccountUserId,
+            surviving.accessLevel,
+            this.deps.fetchImpl
+          )
+        }
+        await this.deps.accounts.attachMembership({
+          accountId: account.id,
+          generation: account.generation,
+          bindingId: input.bindingId,
+          accessLevel: surviving.accessLevel
+        })
+      } catch (e) {
+        this.deps.log?.warn(
+          { accountId: account.id, status: e instanceof GitlabApiError ? e.status : undefined },
+          'gitlab speculative role rollback failed'
+        )
+      }
+      return
+    }
     try {
       const bound = await this.deps.accounts.membershipsForBinding(input.bindingId)
       if (bound.some((membership) => membership.accountId === account.id)) {

--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -75,6 +75,21 @@ export class GitlabAccountLeaseLost extends Error {
   }
 }
 
+/** An account the write could not provision, said the way a console can act on
+ *  it. The reasons are this module's own repair categories (§8.2). */
+export function gitlabAccountUnavailableMessage(reason: string): string {
+  if (reason === 'service_account_quota') {
+    return 'the GitLab group has no service-account slots left — free one, then try again'
+  }
+  if (reason === 'service_account_create_forbidden') {
+    return 'the connected GitLab account must be an Owner of the top-level group to create bot accounts'
+  }
+  if (reason === 'provisioning_or_cleanup_in_progress' || reason === 'account_busy') {
+    return 'GitLab project setup is already running — try again shortly'
+  }
+  return `the agent’s GitLab bot account could not be provisioned (${reason})`
+}
+
 function expiresAtDate(nowMs: number): string {
   return new Date(nowMs + PAT_LIFETIME_DAYS * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
 }
@@ -141,13 +156,8 @@ export class GitlabAccountService {
     // who may stay bound, so a transient convergence failure never revokes one.
     const authorized = new Set(consumers.map((consumer) => consumer.agentId))
     for (const consumer of consumers) {
-      const outcome = await this.ensureAccount(input, consumer)
-      if (!outcome.ok) {
-        fail(outcome.reason, outcome.reason === 'account_busy')
-        continue
-      }
-      const bound = await this.bindMembership(input, outcome.account, consumer.accessLevel)
-      if (!bound) fail('account_membership_contended', true)
+      const outcome = await this.ensureForConsumer(input, consumer)
+      if (!outcome.ok) fail(outcome.reason, outcome.retryable)
     }
     // Authorization removed ⇒ membership removed (§7.2). The account itself
     // survives while it still serves another project in its root.
@@ -165,6 +175,37 @@ export class GitlabAccountService {
       }
     }
     return { reason, retryable }
+  }
+
+  /**
+   * ONE consuming agent's identity on one project: its account, its three PATs,
+   * and its project membership at the derived role.
+   *
+   * Public because a write that will immediately act as that agent — a gitlab
+   * workspace edit whose activation mints credentials, a hook whose rule must
+   * carry an account — has to run this to completion BEFORE it dispatches,
+   * while the row that would make the agent a consumer does not exist yet.
+   * The binding converge is the same call per consumer it already has.
+   */
+  async ensureForConsumer(
+    input: {
+      orgId: string
+      bindingId: string
+      projectId: bigint
+      rootGroupId: number
+      installerConnectionId: string
+      token: string
+    },
+    consumer: GitlabAccountConsumer
+  ): Promise<{ ok: true } | { ok: false; reason: string; retryable: boolean }> {
+    const outcome = await this.ensureAccount(input, consumer)
+    // A contended account lease resolves itself; every other refusal is the
+    // account's own recorded state and needs a repair, not another attempt.
+    if (!outcome.ok) return { ok: false, reason: outcome.reason, retryable: outcome.reason === 'account_busy' }
+    if (!(await this.bindMembership(input, outcome.account, consumer.accessLevel))) {
+      return { ok: false, reason: 'account_membership_contended', retryable: true }
+    }
+    return { ok: true }
   }
 
   /** One consumer's account: created or recovered in the root, named after the

--- a/packages/control-plane/src/gitlab/api.ts
+++ b/packages/control-plane/src/gitlab/api.ts
@@ -226,6 +226,13 @@ export const GITLAB_ACCESS_REPORTER = 20
 export const GITLAB_ACCESS_DEVELOPER = 30
 export const GITLAB_ACCESS_MAINTAINER = 40
 
+/** The project role a workspace authorization derives (§7.2): push needs
+ *  Developer, a read-only workspace needs no more than Reporter. One definition,
+ *  because the consumer query and the write paths must not disagree. */
+export function gitlabWorkspaceAccessLevel(gitAccess: 'read' | 'write' | undefined): number {
+  return gitAccess === 'read' ? GITLAB_ACCESS_REPORTER : GITLAB_ACCESS_DEVELOPER
+}
+
 export interface GitlabEffectiveMembership {
   access_level: number
   state: string

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -21,6 +21,7 @@ import { randomBytes } from 'node:crypto'
 import type { Clock } from '../domain/clock.js'
 import type {
   CodeHostRepositoryRepo,
+  GitlabAccountConsumer,
   GitlabProjectBindingRecord,
   GitlabProjectBindingRepo,
   GitlabWebhookSecretStore
@@ -63,6 +64,13 @@ export type ProvisionOutcome =
   // A live peer owns the claim (provisioning or cleanup in progress): nothing
   // was written and no binding state was overwritten; the caller observes.
   | { state: 'busy'; reason: string }
+
+/** One agent's identity provisioned ahead of a write that will act as it. The
+ *  reason is the account's own repair category (`service_account_quota`, …). */
+export type AgentAccountOutcome = { ok: true } | { ok: false; reason: string; retryable: boolean }
+
+/** Inline in a request: retry a contended attempt on a short bound, then report. */
+const AGENT_ACCOUNT_ATTEMPTS = 5
 
 /** §9.4 takeover result; every refusal leaves the binding exactly as it was.
  *  The binding row carries the convergence outcome, so the caller re-reads it. */
@@ -156,6 +164,89 @@ export class GitlabProvisioner {
     }
     if (contended(outcome)) {
       this.deps.log?.warn({ projectId: projectId.toString() }, 'gitlab converge still contended — gave up')
+    }
+  }
+
+  /**
+   * Provision ONE agent's identity on a project ahead of the write that will act
+   * as that agent (§7.2). A workspace edit activates through the daemon, and
+   * activation mints credentials from the agent's own account: without this the
+   * activation is refused, the edit rolls back, and the post-write convergence
+   * that would have created the account never runs — the agent never became a
+   * consumer, so nothing else has a reason to create it either.
+   *
+   * Runs under the SAME binding lease as a full converge, so the two cannot
+   * interleave, and the account mutation lease plus the generation fence stay
+   * where `ensureForConsumer` puts them. Inline in a request, so a contended
+   * attempt is retried on a short bound and then reported, never outwaited for
+   * the minutes `convergeProject` can afford.
+   */
+  async provisionAgentAccount(
+    orgId: string,
+    projectId: bigint,
+    consumer: GitlabAccountConsumer
+  ): Promise<AgentAccountOutcome> {
+    let outcome = await this.agentAccountAttempt(orgId, projectId, consumer)
+    for (let attempt = 0; !outcome.ok && outcome.retryable && attempt < AGENT_ACCOUNT_ATTEMPTS; attempt++) {
+      const delayMs = Math.min(1_000, 200 * 2 ** attempt)
+      await new Promise<void>((resolve) => this.deps.clock.setTimeout(() => resolve(), delayMs))
+      outcome = await this.agentAccountAttempt(orgId, projectId, consumer)
+    }
+    return outcome
+  }
+
+  private async agentAccountAttempt(
+    orgId: string,
+    projectId: bigint,
+    consumer: GitlabAccountConsumer
+  ): Promise<AgentAccountOutcome> {
+    const binding = await this.deps.bindings.byProject(orgId, projectId)
+    if (!binding || binding.state === 'cleanup_pending') {
+      return { ok: false, reason: 'binding_unavailable', retryable: false }
+    }
+    if (!binding.installerConnectionId) return { ok: false, reason: 'no_admin_connection', retryable: false }
+    const owner = randomBytes(9).toString('base64url')
+    const nowMs = this.deps.clock.now()
+    if (
+      !(await this.deps.bindings.markProviderMutationStarted(
+        orgId,
+        binding.id,
+        binding.projectId,
+        owner,
+        new Date(nowMs + PROVISION_LEASE_MS),
+        new Date(nowMs)
+      ))
+    ) {
+      return { ok: false, reason: 'provisioning_or_cleanup_in_progress', retryable: true }
+    }
+    try {
+      const token = await this.deps.oauth.withAccessToken(orgId, binding.installerConnectionId)
+      const project = (await gitlabProject(
+        token,
+        binding.projectId,
+        this.deps.fetchImpl
+      )) as GitlabProjectWithNamespace | null
+      if (!project?.namespace) return { ok: false, reason: 'project_not_accessible', retryable: false }
+      const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
+      // Service accounts hang off a top-level GROUP; a personal namespace has none (§5).
+      if (root.kind !== 'group') return { ok: false, reason: 'personal_namespace_unsupported', retryable: false }
+      return await this.deps.accounts.ensureForConsumer(
+        {
+          orgId,
+          bindingId: binding.id,
+          projectId: binding.projectId,
+          rootGroupId: root.id,
+          installerConnectionId: binding.installerConnectionId,
+          token
+        },
+        consumer
+      )
+    } catch (e) {
+      const reason = e instanceof GitlabApiError ? `gitlab_${e.status || 'unreachable'}` : 'admin_unavailable'
+      this.deps.log?.warn({ bindingId: binding.id, reason }, 'gitlab agent account provisioning failed')
+      return { ok: false, reason, retryable: e instanceof GitlabApiError && e.retryable }
+    } finally {
+      await this.deps.bindings.endProviderMutation(orgId, binding.id, binding.projectId, owner).catch(() => {})
     }
   }
 

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -225,6 +225,9 @@ export class GitlabProvisioner {
     ) {
       return { ok: false, reason: 'provisioning_or_cleanup_in_progress', retryable: true }
     }
+    // Set once the run knows where it is working, so a failure can undo exactly
+    // what it speculatively created.
+    let scope: { orgId: string; bindingId: string; projectId: bigint; rootGroupId: bigint; token: string } | undefined
     try {
       let ensured: { ok: true } | { ok: false; reason: string; retryable: boolean }
       try {
@@ -238,27 +241,39 @@ export class GitlabProvisioner {
         const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
         // Service accounts hang off a top-level GROUP; a personal namespace has none (§5).
         if (root.kind !== 'group') return { ok: false, reason: 'personal_namespace_unsupported', retryable: false }
+        scope = {
+          orgId,
+          bindingId: binding.id,
+          projectId: binding.projectId,
+          rootGroupId: BigInt(root.id),
+          token
+        }
         ensured = await this.deps.accounts.ensureForConsumer(
-          {
-            orgId,
-            bindingId: binding.id,
-            projectId: binding.projectId,
-            rootGroupId: root.id,
-            installerConnectionId: binding.installerConnectionId,
-            token
-          },
+          { ...scope, rootGroupId: root.id, installerConnectionId: binding.installerConnectionId },
           consumer
         )
       } catch (e) {
         // Only the provisioning half maps its failures; `commit` owns its own.
         const reason = e instanceof GitlabApiError ? `gitlab_${e.status || 'unreachable'}` : 'admin_unavailable'
         this.deps.log?.warn({ bindingId: binding.id, reason }, 'gitlab agent account provisioning failed')
+        if (scope) await this.deps.accounts.rollbackSpeculativeBind(scope, consumer.agentId)
         return { ok: false, reason, retryable: e instanceof GitlabApiError && e.retryable }
       }
-      if (!ensured.ok) return ensured
+      if (!ensured.ok) {
+        // A retryable loser did not create anything of its own — the account it
+        // lost to belongs to a live peer, so only a final failure rolls back.
+        if (!ensured.retryable && scope) await this.deps.accounts.rollbackSpeculativeBind(scope, consumer.agentId)
+        return ensured
+      }
       // STILL under the binding lease: the authorization row and the membership
       // become visible to convergence together, never one without the other.
-      return { ok: true, result: await commit() }
+      try {
+        return { ok: true, result: await commit() }
+      } catch (e) {
+        // The write never landed, so the bind it was for must not outlive it.
+        if (scope) await this.deps.accounts.rollbackSpeculativeBind(scope, consumer.agentId)
+        throw e
+      }
     } finally {
       await this.deps.bindings.endProviderMutation(orgId, binding.id, binding.projectId, owner).catch(() => {})
     }

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -65,9 +65,10 @@ export type ProvisionOutcome =
   // was written and no binding state was overwritten; the caller observes.
   | { state: 'busy'; reason: string }
 
-/** One agent's identity provisioned ahead of a write that will act as it. The
- *  reason is the account's own repair category (`service_account_quota`, …). */
-export type AgentAccountOutcome = { ok: true } | { ok: false; reason: string; retryable: boolean }
+/** One agent's identity provisioned ahead of a write that will act as it, and
+ *  that write's own result. The reason is the account's own repair category
+ *  (`service_account_quota`, …); nothing was committed when it is present. */
+export type AgentAccountOutcome<T> = { ok: true; result: T } | { ok: false; reason: string; retryable: boolean }
 
 /** Inline in a request: retry a contended attempt on a short bound, then report. */
 const AGENT_ACCOUNT_ATTEMPTS = 5
@@ -177,29 +178,34 @@ export class GitlabProvisioner {
    *
    * Runs under the SAME binding lease as a full converge, so the two cannot
    * interleave, and the account mutation lease plus the generation fence stay
-   * where `ensureForConsumer` puts them. Inline in a request, so a contended
+   * where `ensureForConsumer` puts them. `commit` — the write that makes the
+   * agent a consumer — runs while that lease is still HELD, because a membership
+   * whose authorization row is not visible yet is exactly what a concurrent
+   * convergence would unbind and retire. Inline in a request, so a contended
    * attempt is retried on a short bound and then reported, never outwaited for
-   * the minutes `convergeProject` can afford.
+   * the minutes `convergeProject` can afford. A throw from `commit` propagates.
    */
-  async provisionAgentAccount(
+  async provisionAgentAccount<T>(
     orgId: string,
     projectId: bigint,
-    consumer: GitlabAccountConsumer
-  ): Promise<AgentAccountOutcome> {
-    let outcome = await this.agentAccountAttempt(orgId, projectId, consumer)
+    consumer: GitlabAccountConsumer,
+    commit: () => Promise<T>
+  ): Promise<AgentAccountOutcome<T>> {
+    let outcome = await this.agentAccountAttempt(orgId, projectId, consumer, commit)
     for (let attempt = 0; !outcome.ok && outcome.retryable && attempt < AGENT_ACCOUNT_ATTEMPTS; attempt++) {
       const delayMs = Math.min(1_000, 200 * 2 ** attempt)
       await new Promise<void>((resolve) => this.deps.clock.setTimeout(() => resolve(), delayMs))
-      outcome = await this.agentAccountAttempt(orgId, projectId, consumer)
+      outcome = await this.agentAccountAttempt(orgId, projectId, consumer, commit)
     }
     return outcome
   }
 
-  private async agentAccountAttempt(
+  private async agentAccountAttempt<T>(
     orgId: string,
     projectId: bigint,
-    consumer: GitlabAccountConsumer
-  ): Promise<AgentAccountOutcome> {
+    consumer: GitlabAccountConsumer,
+    commit: () => Promise<T>
+  ): Promise<AgentAccountOutcome<T>> {
     const binding = await this.deps.bindings.byProject(orgId, projectId)
     if (!binding || binding.state === 'cleanup_pending') {
       return { ok: false, reason: 'binding_unavailable', retryable: false }
@@ -220,31 +226,39 @@ export class GitlabProvisioner {
       return { ok: false, reason: 'provisioning_or_cleanup_in_progress', retryable: true }
     }
     try {
-      const token = await this.deps.oauth.withAccessToken(orgId, binding.installerConnectionId)
-      const project = (await gitlabProject(
-        token,
-        binding.projectId,
-        this.deps.fetchImpl
-      )) as GitlabProjectWithNamespace | null
-      if (!project?.namespace) return { ok: false, reason: 'project_not_accessible', retryable: false }
-      const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
-      // Service accounts hang off a top-level GROUP; a personal namespace has none (§5).
-      if (root.kind !== 'group') return { ok: false, reason: 'personal_namespace_unsupported', retryable: false }
-      return await this.deps.accounts.ensureForConsumer(
-        {
-          orgId,
-          bindingId: binding.id,
-          projectId: binding.projectId,
-          rootGroupId: root.id,
-          installerConnectionId: binding.installerConnectionId,
-          token
-        },
-        consumer
-      )
-    } catch (e) {
-      const reason = e instanceof GitlabApiError ? `gitlab_${e.status || 'unreachable'}` : 'admin_unavailable'
-      this.deps.log?.warn({ bindingId: binding.id, reason }, 'gitlab agent account provisioning failed')
-      return { ok: false, reason, retryable: e instanceof GitlabApiError && e.retryable }
+      let ensured: { ok: true } | { ok: false; reason: string; retryable: boolean }
+      try {
+        const token = await this.deps.oauth.withAccessToken(orgId, binding.installerConnectionId)
+        const project = (await gitlabProject(
+          token,
+          binding.projectId,
+          this.deps.fetchImpl
+        )) as GitlabProjectWithNamespace | null
+        if (!project?.namespace) return { ok: false, reason: 'project_not_accessible', retryable: false }
+        const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
+        // Service accounts hang off a top-level GROUP; a personal namespace has none (§5).
+        if (root.kind !== 'group') return { ok: false, reason: 'personal_namespace_unsupported', retryable: false }
+        ensured = await this.deps.accounts.ensureForConsumer(
+          {
+            orgId,
+            bindingId: binding.id,
+            projectId: binding.projectId,
+            rootGroupId: root.id,
+            installerConnectionId: binding.installerConnectionId,
+            token
+          },
+          consumer
+        )
+      } catch (e) {
+        // Only the provisioning half maps its failures; `commit` owns its own.
+        const reason = e instanceof GitlabApiError ? `gitlab_${e.status || 'unreachable'}` : 'admin_unavailable'
+        this.deps.log?.warn({ bindingId: binding.id, reason }, 'gitlab agent account provisioning failed')
+        return { ok: false, reason, retryable: e instanceof GitlabApiError && e.retryable }
+      }
+      if (!ensured.ok) return ensured
+      // STILL under the binding lease: the authorization row and the membership
+      // become visible to convergence together, never one without the other.
+      return { ok: true, result: await commit() }
     } finally {
       await this.deps.bindings.endProviderMutation(orgId, binding.id, binding.projectId, owner).catch(() => {})
     }

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -1761,16 +1761,27 @@ export function agentRoutes(deps: HttpDeps) {
           // convergence adopts as a consumer, where the reverse order would
           // leave an account no agent owns.
           if (agent.workspace.mode === 'gitlab' && agent.workspaceRepoId !== undefined && deps.gitlab) {
-            const ensured = await deps.gitlab.provisioner.provisionAgentAccount(agent.orgId, agent.workspaceRepoId, {
-              agentId: agent.id,
-              accessLevel: gitlabWorkspaceAccessLevel(agent.workspace.gitAccess)
-            })
+            const gitlab = deps.gitlab
+            // The agent row IS the authorization here and is already committed,
+            // so nothing has to run inside the lease alongside the ensure.
+            const ensured = await gitlab.provisioner.provisionAgentAccount(
+              agent.orgId,
+              agent.workspaceRepoId,
+              { agentId: agent.id, accessLevel: gitlabWorkspaceAccessLevel(agent.workspace.gitAccess) },
+              async () => undefined
+            )
             if (!ensured.ok) {
               // Nothing was pushed yet, so the create can still be withdrawn
               // whole rather than leaving an agent whose workspace cannot start.
+              // The account rows go with it: they carry no agent foreign key on
+              // purpose, so a dropped agent would otherwise orphan whatever the
+              // failed provisioning already created at GitLab (§19.4).
               await deps.repos.agent
                 .delete(agent.orgId, agent.id)
                 .catch((err) => app.log.warn({ err, agentId: agent.id }, 'agent rollback after gitlab account failure'))
+              await gitlab.accounts
+                .retireAgentAccounts(agent.orgId, agent.id)
+                .catch((err) => app.log.warn({ err, agentId: agent.id }, 'gitlab account rollback failed'))
               return conflict(gitlabAccountUnavailableMessage(ensured.reason))
             }
           }
@@ -2473,22 +2484,31 @@ export function agentRoutes(deps: HttpDeps) {
           // cannot serve this — activation would be refused, the edit would roll
           // back, and the agent would never become the consumer that convergence
           // needs a reason to provision for.
-          if (workspace.mode === 'gitlab' && workspaceRepoId !== undefined && deps.gitlab) {
-            const ensured = await deps.gitlab.provisioner.provisionAgentAccount(existing.orgId, workspaceRepoId, {
-              agentId: existing.id,
-              accessLevel: gitlabWorkspaceAccessLevel(workspace.gitAccess)
-            })
-            if (!ensured.ok) return conflict(gitlabAccountUnavailableMessage(ensured.reason))
-          }
-
+          const applyWorkspace = (): Promise<AgentRecord> =>
+            agentMoves.setWorkspace(existing, workspace, workspaceRepoId, req.principal?.userId)
           let converted: AgentRecord
-          try {
-            converted = await agentMoves.setWorkspace(existing, workspace, workspaceRepoId, req.principal?.userId)
-          } catch (err) {
-            // The edit rolled back, so the membership just bound belongs to an
-            // agent that no longer consumes the project: converge it away.
-            if (workspace.mode === 'gitlab') convergeGitlabProjects(existing.orgId, [workspaceRepoId])
-            throw err
+          if (workspace.mode === 'gitlab' && workspaceRepoId !== undefined && deps.gitlab) {
+            let applied
+            try {
+              // The edit itself runs under the binding lease this takes, so the
+              // membership and the workspace row that authorizes it commit
+              // together as far as convergence can see.
+              applied = await deps.gitlab.provisioner.provisionAgentAccount(
+                existing.orgId,
+                workspaceRepoId,
+                { agentId: existing.id, accessLevel: gitlabWorkspaceAccessLevel(workspace.gitAccess) },
+                applyWorkspace
+              )
+            } catch (err) {
+              // The edit rolled back, so the membership just bound belongs to an
+              // agent that does not consume the project: converge it away.
+              convergeGitlabProjects(existing.orgId, [workspaceRepoId])
+              throw err
+            }
+            if (!applied.ok) return conflict(gitlabAccountUnavailableMessage(applied.reason))
+            converted = applied.result
+          } else {
+            converted = await applyWorkspace()
           }
           // Joining, leaving, or re-clamping a gitlab project moves its §7.2
           // membership set. DESTINATION FIRST, and the order is load-bearing: an

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -34,6 +34,8 @@ import type {
   DreamFilesPage,
   DreamFileReadContent
 } from '@agentconnect.md/protocol'
+import { gitlabWorkspaceAccessLevel } from '../../gitlab/api.js'
+import { gitlabAccountUnavailableMessage } from '../../gitlab/account.service.js'
 import {
   GITLAB_COM_V1_FEATURE,
   MAX_WORKSPACE_EDIT_BYTES,
@@ -1753,6 +1755,25 @@ export function agentRoutes(deps: HttpDeps) {
           const connect = req.query.connect
             ? await provisionDaemonConnect(deps.apiKeys, deps.config, req.orgCtx!.orgId, req.principal?.userId)
             : undefined
+          // §7.2 BEFORE the spec push: the daemon prepares a gitlab workspace by
+          // minting credentials from this agent's OWN account. The row is
+          // created first on purpose — a crash here leaves an agent the next
+          // convergence adopts as a consumer, where the reverse order would
+          // leave an account no agent owns.
+          if (agent.workspace.mode === 'gitlab' && agent.workspaceRepoId !== undefined && deps.gitlab) {
+            const ensured = await deps.gitlab.provisioner.provisionAgentAccount(agent.orgId, agent.workspaceRepoId, {
+              agentId: agent.id,
+              accessLevel: gitlabWorkspaceAccessLevel(agent.workspace.gitAccess)
+            })
+            if (!ensured.ok) {
+              // Nothing was pushed yet, so the create can still be withdrawn
+              // whole rather than leaving an agent whose workspace cannot start.
+              await deps.repos.agent
+                .delete(agent.orgId, agent.id)
+                .catch((err) => app.log.warn({ err, agentId: agent.id }, 'agent rollback after gitlab account failure'))
+              return conflict(gitlabAccountUnavailableMessage(ensured.reason))
+            }
+          }
           // Issue the private definition first. Even if its probe ACK is lost,
           // the WebSocket preserves frame order and daemon admission remains
           // closed until the registry validates it.
@@ -2446,7 +2467,29 @@ export function agentRoutes(deps: HttpDeps) {
             return conflict(AGENT_WORKSPACE_INTEGRATION_CONFLICT_MESSAGE)
           }
 
-          const converted = await agentMoves.setWorkspace(existing, workspace, workspaceRepoId, req.principal?.userId)
+          // §7.2 BEFORE activation: the daemon prepares the workspace by minting
+          // credentials from this agent's OWN GitLab account, so the account,
+          // its membership, and its PATs must already exist. A post-write kick
+          // cannot serve this — activation would be refused, the edit would roll
+          // back, and the agent would never become the consumer that convergence
+          // needs a reason to provision for.
+          if (workspace.mode === 'gitlab' && workspaceRepoId !== undefined && deps.gitlab) {
+            const ensured = await deps.gitlab.provisioner.provisionAgentAccount(existing.orgId, workspaceRepoId, {
+              agentId: existing.id,
+              accessLevel: gitlabWorkspaceAccessLevel(workspace.gitAccess)
+            })
+            if (!ensured.ok) return conflict(gitlabAccountUnavailableMessage(ensured.reason))
+          }
+
+          let converted: AgentRecord
+          try {
+            converted = await agentMoves.setWorkspace(existing, workspace, workspaceRepoId, req.principal?.userId)
+          } catch (err) {
+            // The edit rolled back, so the membership just bound belongs to an
+            // agent that no longer consumes the project: converge it away.
+            if (workspace.mode === 'gitlab') convergeGitlabProjects(existing.orgId, [workspaceRepoId])
+            throw err
+          }
           // Joining, leaving, or re-clamping a gitlab project moves its §7.2
           // membership set. DESTINATION FIRST, and the order is load-bearing: an
           // account with no membership left in its root retires, so converging

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -24,6 +24,8 @@ import {
   type UpsertHookInput
 } from '../../persistence/ports.js'
 import { GithubApiError } from '../../github/api.js'
+import { GITLAB_ACCESS_DEVELOPER } from '../../gitlab/api.js'
+import { gitlabAccountUnavailableMessage } from '../../gitlab/account.service.js'
 import { GitCredDeniedError, type ResolvedAgentRepoAuthorization } from '../../github/service.js'
 import { AgentId, HookId, IntegrationId, OrgId } from '../../domain/ids.js'
 import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
@@ -127,6 +129,25 @@ export function hookRoutes(deps: HttpDeps) {
     // never fails the CRUD (a relay converges via its register replay).
     const converge = (hook: HookRecord): void => {
       void deps.hooks.broadcast(hook).catch((err) => app.log.warn({ hookId: hook.id, err }, 'hook broadcast failed'))
+    }
+
+    // §7.2 identity for the hook's own agent, run to completion BEFORE the write
+    // that will act as it. Returns a refusal to send, or null when the agent has
+    // its account, membership, and credentials on the project.
+    const ensureGitlabAgentAccount = async (
+      orgId: OrgId,
+      projectId: bigint,
+      agentId: string
+    ): Promise<{ status: 409; message: string } | null> => {
+      const gitlab = deps.gitlab
+      if (!gitlab) return null
+      const ensured = await gitlab.provisioner.provisionAgentAccount(orgId, projectId, {
+        agentId,
+        // A hook consumer posts notes and may run the configured review policy.
+        accessLevel: GITLAB_ACCESS_DEVELOPER
+      })
+      if (ensured.ok) return null
+      return { status: 409, message: gitlabAccountUnavailableMessage(ensured.reason) }
     }
 
     // gitlab-kind writes also (re)converge the project (§11.1): the saga
@@ -434,6 +455,13 @@ export function hookRoutes(deps: HttpDeps) {
                     reportingMode: req.body.kind === 'gitlab' ? req.body.reportingMode : 'off'
                   })
                   if (effectError) return { ok: false as const, ...effectError }
+                  // §7.2 BEFORE the write: the compiled rule names this agent's
+                  // own account and its poster mints credentials from it, so the
+                  // account must exist by the time the rule reaches a relay. The
+                  // hook row is what would make the agent a consumer, so no
+                  // post-write convergence can get here first.
+                  const identity = await ensureGitlabAgentAccount(orgId, projectId, agent.id)
+                  if (identity) return { ok: false as const, ...identity }
                   return {
                     // gitlab is perThread by definition, like github (§12.3).
                     sessionMode: 'perThread' as const,
@@ -774,6 +802,14 @@ export function hookRoutes(deps: HttpDeps) {
               statusCode: effectError.status,
               message: effectError.message
             })
+          }
+          // §7.2: retargeting onto a project the agent does not consume yet needs
+          // its account there before the recompiled rule can name one.
+          const identity = await ensureGitlabAgentAccount(orgId, projectId, agent.id)
+          if (identity) {
+            return reply
+              .code(identity.status)
+              .send({ error: ERROR_NAMES[identity.status], statusCode: identity.status, message: identity.message })
           }
           kindFields = {
             sessionMode: 'perThread',

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -131,23 +131,31 @@ export function hookRoutes(deps: HttpDeps) {
       void deps.hooks.broadcast(hook).catch((err) => app.log.warn({ hookId: hook.id, err }, 'hook broadcast failed'))
     }
 
-    // §7.2 identity for the hook's own agent, run to completion BEFORE the write
-    // that will act as it. Returns a refusal to send, or null when the agent has
-    // its account, membership, and credentials on the project.
-    const ensureGitlabAgentAccount = async (
+    // §7.2 identity bracket for a gitlab hook write: the hook agent's own account
+    // is provisioned FIRST — the compiled rule names it and its poster mints
+    // credentials from it — and the write commits while the binding lease is
+    // still held, so convergence never sees the membership without the hook row
+    // that authorizes it. A hook that will not be enabled needs no identity: it
+    // can never fire, and provisioning one would churn an account the next
+    // convergence retires, and would block disabling during an account outage.
+    const withGitlabHookIdentity = async <T>(
       orgId: OrgId,
       projectId: bigint,
-      agentId: string
-    ): Promise<{ status: 409; message: string } | null> => {
+      agentId: string,
+      enabled: boolean,
+      commit: () => Promise<T>
+    ): Promise<{ ok: true; result: T } | { ok: false; status: 409; message: string }> => {
       const gitlab = deps.gitlab
-      if (!gitlab) return null
-      const ensured = await gitlab.provisioner.provisionAgentAccount(orgId, projectId, {
-        agentId,
+      if (!gitlab || !enabled) return { ok: true, result: await commit() }
+      const done = await gitlab.provisioner.provisionAgentAccount(
+        orgId,
+        projectId,
         // A hook consumer posts notes and may run the configured review policy.
-        accessLevel: GITLAB_ACCESS_DEVELOPER
-      })
-      if (ensured.ok) return null
-      return { status: 409, message: gitlabAccountUnavailableMessage(ensured.reason) }
+        { agentId, accessLevel: GITLAB_ACCESS_DEVELOPER },
+        commit
+      )
+      if (!done.ok) return { ok: false, status: 409, message: gitlabAccountUnavailableMessage(done.reason) }
+      return { ok: true, result: done.result }
     }
 
     // gitlab-kind writes also (re)converge the project (§11.1): the saga
@@ -455,13 +463,6 @@ export function hookRoutes(deps: HttpDeps) {
                     reportingMode: req.body.kind === 'gitlab' ? req.body.reportingMode : 'off'
                   })
                   if (effectError) return { ok: false as const, ...effectError }
-                  // §7.2 BEFORE the write: the compiled rule names this agent's
-                  // own account and its poster mints credentials from it, so the
-                  // account must exist by the time the rule reaches a relay. The
-                  // hook row is what would make the agent a consumer, so no
-                  // post-write convergence can get here first.
-                  const identity = await ensureGitlabAgentAccount(orgId, projectId, agent.id)
-                  if (identity) return { ok: false as const, ...identity }
                   return {
                     // gitlab is perThread by definition, like github (§12.3).
                     sessionMode: 'perThread' as const,
@@ -510,42 +511,53 @@ export function hookRoutes(deps: HttpDeps) {
           return reply.code(status).send({ error: ERROR_NAMES[status], statusCode: status, message })
         }
         const { hmacSecret, ...upsertFields } = kindFields
-        const hook = await persistHook({
-          hookId,
-          orgId,
-          agentId: agent.id,
-          kind: req.body.kind,
-          name: req.body.name,
-          enabled: req.body.enabled,
-          ...upsertFields,
-          ...(req.body.kind === 'github'
-            ? {
-                events: req.body.events,
-                commentFamilies: req.body.commentFamilies,
-                labelFilter: req.body.labelFilter,
-                mentionOnly: req.body.mentionOnly,
-                reviewPolicy: req.body.reviewPolicy,
-                reportingMode: req.body.reportingMode,
-                gateMode: req.body.gateMode
-              }
-            : {}),
-          ...(req.body.kind === 'gitlab'
-            ? {
-                events: req.body.events,
-                commentFamilies: req.body.commentFamilies,
-                mentionOnly: req.body.mentionOnly,
-                reviewPolicy: req.body.reviewPolicy,
-                reportingMode: req.body.reportingMode
-                // No gateMode: GitLab has no required-gate surface, so the row stays informational.
-              }
-            : {}),
-          targetPlatform: target.targetPlatform,
-          ...(req.body.targetChannel ? { targetChannel: req.body.targetChannel } : {}),
-          ...(target.targetIntegrationId ? { targetIntegrationId: target.targetIntegrationId } : {}),
-          ...(req.principal
-            ? { createdByUserId: req.principal.userId, lastModifiedByUserId: req.principal.userId }
-            : {})
-        })
+        const writeHook = (): Promise<HookRecord | AgentWorkspaceIntegrationConflict> =>
+          persistHook({
+            hookId,
+            orgId,
+            agentId: agent.id,
+            kind: req.body.kind,
+            name: req.body.name,
+            enabled: req.body.enabled,
+            ...upsertFields,
+            ...(req.body.kind === 'github'
+              ? {
+                  events: req.body.events,
+                  commentFamilies: req.body.commentFamilies,
+                  labelFilter: req.body.labelFilter,
+                  mentionOnly: req.body.mentionOnly,
+                  reviewPolicy: req.body.reviewPolicy,
+                  reportingMode: req.body.reportingMode,
+                  gateMode: req.body.gateMode
+                }
+              : {}),
+            ...(req.body.kind === 'gitlab'
+              ? {
+                  events: req.body.events,
+                  commentFamilies: req.body.commentFamilies,
+                  mentionOnly: req.body.mentionOnly,
+                  reviewPolicy: req.body.reviewPolicy,
+                  reportingMode: req.body.reportingMode
+                  // No gateMode: GitLab has no required-gate surface, so the row stays informational.
+                }
+              : {}),
+            targetPlatform: target.targetPlatform,
+            ...(req.body.targetChannel ? { targetChannel: req.body.targetChannel } : {}),
+            ...(target.targetIntegrationId ? { targetIntegrationId: target.targetIntegrationId } : {}),
+            ...(req.principal
+              ? { createdByUserId: req.principal.userId, lastModifiedByUserId: req.principal.userId }
+              : {})
+          })
+        const written =
+          req.body.kind === 'gitlab'
+            ? await withGitlabHookIdentity(orgId, BigInt(req.body.projectId), agent.id, req.body.enabled, writeHook)
+            : { ok: true as const, result: await writeHook() }
+        if (!written.ok) {
+          return reply
+            .code(written.status)
+            .send({ error: ERROR_NAMES[written.status], statusCode: written.status, message: written.message })
+        }
+        const hook = written.result
         if (hook instanceof AgentWorkspaceIntegrationConflict) {
           return reply.code(409).send({ error: ERROR_NAMES[409], statusCode: 409, message: hook.message })
         }
@@ -803,14 +815,6 @@ export function hookRoutes(deps: HttpDeps) {
               message: effectError.message
             })
           }
-          // §7.2: retargeting onto a project the agent does not consume yet needs
-          // its account there before the recompiled rule can name one.
-          const identity = await ensureGitlabAgentAccount(orgId, projectId, agent.id)
-          if (identity) {
-            return reply
-              .code(identity.status)
-              .send({ error: ERROR_NAMES[identity.status], statusCode: identity.status, message: identity.message })
-          }
           kindFields = {
             sessionMode: 'perThread',
             repoId: projectId,
@@ -826,20 +830,32 @@ export function hookRoutes(deps: HttpDeps) {
         // PgHookRepo owns the hook-level lifecycle transaction: binding/mode/
         // enablement changes tombstone the old projection epoch before this
         // definition advances to its new epoch.
-        const hook = await persistHook({
-          hookId: existing.id,
-          expectedAgentId: existing.agentId!,
-          orgId,
-          agentId: agent.id,
-          kind: existing.kind,
-          name: req.body.name,
-          enabled: req.body.enabled ?? existing.enabled,
-          ...kindFields,
-          targetPlatform: target.targetPlatform,
-          ...(req.body.targetChannel ? { targetChannel: req.body.targetChannel } : {}),
-          ...(target.targetIntegrationId ? { targetIntegrationId: target.targetIntegrationId } : {}),
-          ...(req.principal ? { lastModifiedByUserId: req.principal.userId } : {})
-        })
+        const nowEnabled = req.body.enabled ?? existing.enabled
+        const writeHook = (): Promise<HookRecord | AgentWorkspaceIntegrationConflict> =>
+          persistHook({
+            hookId: existing.id,
+            expectedAgentId: existing.agentId!,
+            orgId,
+            agentId: agent.id,
+            kind: existing.kind,
+            name: req.body.name,
+            enabled: nowEnabled,
+            ...kindFields,
+            targetPlatform: target.targetPlatform,
+            ...(req.body.targetChannel ? { targetChannel: req.body.targetChannel } : {}),
+            ...(target.targetIntegrationId ? { targetIntegrationId: target.targetIntegrationId } : {}),
+            ...(req.principal ? { lastModifiedByUserId: req.principal.userId } : {})
+          })
+        const written =
+          req.body.kind === 'gitlab'
+            ? await withGitlabHookIdentity(orgId, BigInt(req.body.projectId), agent.id, nowEnabled, writeHook)
+            : { ok: true as const, result: await writeHook() }
+        if (!written.ok) {
+          return reply
+            .code(written.status)
+            .send({ error: ERROR_NAMES[written.status], statusCode: written.status, message: written.message })
+        }
+        const hook = written.result
         if (hook instanceof AgentWorkspaceIntegrationConflict) {
           return reply.code(409).send({ error: ERROR_NAMES[409], statusCode: 409, message: hook.message })
         }

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -42,10 +42,7 @@ import type {
 import type { SecretCipher } from '../../secrets/cipher.js'
 import { orgScope } from '../../secrets/scope.js'
 import { OrgId } from '../../domain/ids.js'
-import {
-  GITLAB_ACCESS_DEVELOPER as ACCESS_DEVELOPER,
-  GITLAB_ACCESS_REPORTER as ACCESS_REPORTER
-} from '../../gitlab/api.js'
+import { GITLAB_ACCESS_DEVELOPER as ACCESS_DEVELOPER, gitlabWorkspaceAccessLevel } from '../../gitlab/api.js'
 
 const CONNECTION_STATES: readonly GitlabConnectionState[] = ['connected', 'reauth_required', 'disconnected']
 
@@ -773,9 +770,8 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
     const raise = (agentId: string, accessLevel: number): void => {
       levels.set(agentId, Math.max(levels.get(agentId) ?? 0, accessLevel))
     }
-    // The workspace gitAccess clamp derives the role: push needs Developer, a
-    // read-only workspace needs no more than Reporter (§7.2, §13.1).
-    for (const row of workspaces) raise(row.id, row.gitAccess === 'read' ? ACCESS_REPORTER : ACCESS_DEVELOPER)
+    // The workspace gitAccess clamp derives the role (§7.2, §13.1).
+    for (const row of workspaces) raise(row.id, gitlabWorkspaceAccessLevel(row.gitAccess))
     // A hook consumer posts notes and may run the configured review policy.
     for (const row of hooks) if (row.agentId) raise(row.agentId, ACCESS_DEVELOPER)
     return [...levels].map(([agentId, accessLevel]) => ({ agentId, accessLevel }))

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -241,6 +241,52 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(30)
   })
 
+  it('rolls back the account a refused hook write speculatively created', async () => {
+    // The account is created, then its PATs come back out of policy: the ensure
+    // fails with real provider state already behind it, and the hook row that
+    // would have made the agent a consumer is never written. Nothing would ever
+    // visit that account again, so the write has to undo it (§7.2).
+    const h = await harness({ patExpiryOverride: null })
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(created.statusCode).toBe(409)
+    expect(await h.hookRepo.listForAgent(AgentId(h.agentId))).toHaveLength(0)
+
+    // No account row, no service account left in the group, no live token.
+    expect(await h.accounts.listForAgent(DEFAULT_ORG_ID, h.agentId)).toHaveLength(0)
+    expect(h.fake.serviceAccounts).toHaveLength(0)
+    expect([...h.fake.tokens.values()].every((token) => token.revoked)).toBe(true)
+  })
+
+  it('keeps a membership another authorization still earns when a hook write is refused', async () => {
+    const h = await harness()
+    // The agent already consumes the project through its workspace, so the
+    // account and membership are not this write's to undo.
+    await prisma.agent.update({
+      where: { id: h.agentId },
+      data: {
+        workspaceMode: 'gitlab',
+        workspaceRepoId: PROJECT,
+        gitRepo: 'https://gitlab.com/example-group/example-project'
+      }
+    })
+    await h.provisioner.convergeProject(DEFAULT_ORG_ID, PROJECT)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, h.agentId, 900n))!
+
+    // Force a re-mint that the provider then answers out of policy, so the
+    // hook's own ensure fails with the account already in place.
+    await prisma.gitlabProjectCredential.updateMany({
+      where: { accountId: account.id },
+      data: { providerExpiresAt: new Date(Date.now() - 1_000) }
+    })
+    h.fake.opts.patExpiryOverride = null
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(created.statusCode).toBe(409)
+    // The workspace's own authorization survives the refused hook write.
+    expect(await h.accounts.get(account.id)).not.toBeNull()
+    expect((await h.accounts.membershipsForBinding(h.binding.id)).map((m) => m.accountId)).toEqual([account.id])
+    expect(h.fake.deletedServiceAccounts).toEqual([])
+  })
+
   it('a hook that will not be enabled needs no account, even out of quota', async () => {
     const h = await harness({ refuseServiceAccountQuota: true })
     // A disabled hook can never fire, so provisioning an identity for it would

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -241,6 +241,38 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(30)
   })
 
+  it('a hook that will not be enabled needs no account, even out of quota', async () => {
+    const h = await harness({ refuseServiceAccountQuota: true })
+    // A disabled hook can never fire, so provisioning an identity for it would
+    // churn an account the next convergence retires — and would make disabling
+    // impossible while the group is out of slots.
+    const created = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: glBody(h.agentId, { enabled: false })
+    })
+    expect(created.statusCode).toBe(200)
+    expect(await h.accounts.listForAgent(DEFAULT_ORG_ID, h.agentId)).toHaveLength(0)
+    expect(h.fake.serviceAccounts).toHaveLength(0)
+
+    // Disabling an enabled hook is likewise not blocked by the outage.
+    h.fake.opts.refuseServiceAccountQuota = false
+    const enabled = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: glBody(h.secondAgentId)
+    })
+    expect(enabled.statusCode).toBe(200)
+    h.fake.opts.refuseServiceAccountQuota = true
+    const disabled = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/hooks/${(enabled.json() as { id: string }).id}`,
+      payload: { ...glBody(h.secondAgentId), enabled: false }
+    })
+    expect(disabled.statusCode).toBe(200)
+    expect((disabled.json() as { enabled: boolean }).enabled).toBe(false)
+  })
+
   it('refuses the hook with the account’s own repair reason, writing no hook', async () => {
     const h = await harness({ refuseServiceAccountQuota: true })
     const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -32,7 +32,7 @@ import {
 } from '../../src/persistence/index.js'
 import { makeSecretCipher } from '../../src/secrets/cipher.js'
 import { systemClock } from '../../src/domain/clock.js'
-import { HookId, OrgId } from '../../src/domain/ids.js'
+import { AgentId, HookId, OrgId } from '../../src/domain/ids.js'
 import {
   GITLAB_COM_V1_FEATURE,
   GITLAB_RERUN_V1_FEATURE,
@@ -222,6 +222,32 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
       { timeout: 20_000 }
     )
     expect(legacy.sent.filter((frame) => frame.type === 'rc/hook-assign')).toHaveLength(0)
+  })
+
+  it('provisions the hook agent’s account inline, before the write (§7.2)', async () => {
+    const h = await harness()
+    // The binding converged with no consumers, so it has no accounts at all.
+    expect(await h.accounts.listForBinding(h.binding.id)).toHaveLength(0)
+
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(created.statusCode).toBe(200)
+
+    // Asserted with NO polling: the rule this write compiles names the agent's
+    // own account, so the account has to exist by the time the write happens.
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, h.agentId, 900n))!
+    expect(account.state).toBe('ready')
+    expect(account.username).toBe(gitlabAgentAccountUsername(h.agentId, 900n))
+    expect((await h.accounts.membershipsForBinding(h.binding.id)).map((m) => m.accountId)).toEqual([account.id])
+    expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(30)
+  })
+
+  it('refuses the hook with the account’s own repair reason, writing no hook', async () => {
+    const h = await harness({ refuseServiceAccountQuota: true })
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(created.statusCode).toBe(409)
+    expect((created.json() as { message: string }).message).toContain('no service-account slots left')
+    expect(await h.hookRepo.listForAgent(AgentId(h.agentId))).toHaveLength(0)
+    expect(await h.accounts.membershipsForBinding(h.binding.id)).toHaveLength(0)
   })
 
   it('create is fenced on a managed binding; a second hook on the same project+agent is a 409', async () => {

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -298,6 +298,32 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     ).toBe(true)
   })
 
+  it('a failed write gives back the role it raised, keeping what survives it', async () => {
+    // A read-only workspace earns Reporter. An enabled hook would earn
+    // Developer, so its pre-write provisioning raises the membership — and if
+    // that write then fails, the raise must not outlive it.
+    const h = await harness({}, null, [{ id: AGENT, name: 'reader', gitAccess: 'read' }])
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(20)
+
+    await expect(
+      h.provisioner.provisionAgentAccount(DEFAULT_ORG_ID, PROJECT, { agentId: AGENT, accessLevel: 30 }, async () => {
+        throw new Error('the hook write failed')
+      })
+    ).rejects.toThrow('the hook write failed')
+
+    // The workspace's own authorization survives, at its own role — not the
+    // hook's — and the account is untouched.
+    expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(20)
+    expect((await h.accounts.membershipsForBinding(h.binding.id))[0]).toMatchObject({
+      accountId: account.id,
+      accessLevel: 20
+    })
+    expect(await h.accounts.get(account.id)).not.toBeNull()
+    expect(h.fake.deletedServiceAccounts).toEqual([])
+  })
+
   it('a transient convergence failure never revokes an existing membership', async () => {
     const h = await harness({}, null, [
       { id: AGENT, name: 'reviewer' },

--- a/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
@@ -368,6 +368,81 @@ describe('gitlab workspaces — agent create/edit (§8.3)', () => {
     expect(row.gitAccess).toBe('read')
   })
 
+  it('provisions the agent’s account inline, before the workspace edit activates (§7.2)', async () => {
+    const h = await harness()
+    // The live-testing shape: a project picked and provisioned moments ago, so
+    // it has no consumers and therefore no accounts at all.
+    const fresh = await h.bindings.createWithClaim({
+      orgId: DEFAULT_ORG_ID,
+      projectId: SECOND_PROJECT,
+      projectPath: 'example-group/example-second',
+      installerConnectionId: h.connection.id
+    })
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, fresh.id)).toEqual({ state: 'ready' })
+    expect(await h.accounts.listForBinding(fresh.id)).toHaveLength(0)
+
+    const created = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'gl-picker', runtime: 'claude' }
+    })
+    expect(created.statusCode).toBe(201)
+    const agentId = (created.json() as { id: string }).id
+
+    const res = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/workspace`,
+      payload: { mode: 'gitlab', projectId: SECOND_PROJECT.toString(), gitAccess: 'write' }
+    })
+    expect(res.statusCode).toBe(200)
+
+    // Asserted with NO polling on purpose: the identity has to exist by the time
+    // the response is written, because activation runs inside this request and
+    // mints its credentials from it.
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, agentId, ROOT_GROUP))!
+    expect(account.state).toBe('ready')
+    expect((await h.accounts.membershipsForBinding(fresh.id)).map((m) => m.accountId)).toEqual([account.id])
+    expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(30)
+    expect(await new PgGitlabProjectCredentialRepo(prisma).listForAccount(account.id)).toHaveLength(3)
+
+    // …and the grant the daemon asks for while preparing the workspace resolves.
+    const grant = await credService(h.bindings).grantForAgent(
+      gitlabAgent({ id: agentId, workspaceRepoId: SECOND_PROJECT } as Partial<AgentRecord>)
+    )
+    expect(grant.username).toBe(account.username)
+    expect(grant.access).toBe('write')
+  })
+
+  it('refuses the workspace edit with the account’s own repair reason, writing nothing', async () => {
+    const h = await harness()
+    const fresh = await h.bindings.createWithClaim({
+      orgId: DEFAULT_ORG_ID,
+      projectId: SECOND_PROJECT,
+      projectPath: 'example-group/example-second',
+      installerConnectionId: h.connection.id
+    })
+    await h.provisioner.provision(DEFAULT_ORG_ID, fresh.id)
+    const created = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents`,
+      payload: { name: 'gl-refused', runtime: 'claude' }
+    })
+    const agentId = (created.json() as { id: string }).id
+
+    // The top-level group is out of service-account slots (§7.2).
+    h.fake.opts.refuseServiceAccountQuota = true
+    const res = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/agents/${agentId}/workspace`,
+      payload: { mode: 'gitlab', projectId: SECOND_PROJECT.toString() }
+    })
+    expect(res.statusCode).toBe(409)
+    expect((res.json() as { message: string }).message).toContain('no service-account slots left')
+    // The workspace was never written, so the agent is untouched.
+    expect((await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).workspaceMode).toBe('scratch')
+    expect(await h.accounts.membershipsForBinding(fresh.id)).toHaveLength(0)
+  })
+
   it('a retarget within one top-level group keeps the agent’s account alive (§7.2)', async () => {
     const h = await harness()
     // A second managed project under the SAME root, so both share one account.


### PR DESCRIPTION
Found in live testing of the per-agent GitLab identity (#1418): picking a GitLab
project in the workspace editor and then replacing the workspace **always**
failed, on a clean deployment, with

> workspace edit rejected: agent/activate: workspace preparation failed: the agent has no ready GitLab account on that project — repair it

and `gitlab_agent_account` / `gitlab_account_membership` still empty afterwards.

## Why it could never succeed

The workspace write activates through the daemon, and activation mints
credentials from the agent's **own** service account (§7.2). The account was
provisioned by a fire-and-forget kick placed *after* the write, so:

1. activation ran before any account existed and was refused;
2. the refusal rolled the edit back, so the post-write kick never ran;
3. repair did not help either — the rollback meant the agent never became a
   consumer of the project, so binding convergence had no reason to provision an
   account for it.

Every path out of the deadlock depended on the one thing the deadlock prevented.
The same ordering applies to gitlab hooks: the rule a hook write compiles names
the hook agent's account, and the hook row is what would make the agent a
consumer.

## The fix

The identity is provisioned **inline, to completion, before** the write that
will act as it — in both gitlab workspace arms (create and the workspace edit)
and both gitlab hook arms (create and update).

- `GitlabAccountService.ensureForConsumer` is the one-consumer step the binding
  converge already ran per consumer, now public: account, PATs, and project
  membership at the derived role. The binding converge calls the same method, so
  there is no second provisioning path.
- `GitlabProvisioner.provisionAgentAccount` resolves the binding, the
  administering token, and the top-level group, and runs that step under the
  **same binding lease** a full converge takes, so the two cannot interleave.
  The account mutation lease and the lifecycle-generation fence stay exactly
  where the account service puts them.
- Contention is retried on a short, request-appropriate bound (5 attempts,
  backoff capped at 1s) rather than the minutes `convergeProject` can afford in
  the background.
- A definite refusal becomes a **409 carrying the account's own repair
  category**, so a top-level group that is out of service-account slots says so
  at the point of the edit instead of failing later at activation.

Two ordering details worth calling out:

- **Create** provisions after the agent row exists and withdraws that row if the
  account cannot be provisioned. The reverse order would leave an account no
  agent owns; this order leaves, at worst, an agent the next convergence adopts
  as a consumer and provisions normally.
- A workspace edit that **rolls back** for any other reason converges the
  project it had just bound, so a membership never outlives the edit that
  created it. The post-write kick stays for the retarget's leave-side cleanup.

Also folded in: the role a workspace authorization derives
(`gitlabWorkspaceAccessLevel`) now has one definition shared by the consumer
query and the write paths, instead of the same rule spelled twice.

## Tests

Integration tests reproduce the reported flow exactly — a freshly picked binding
with no accounts at all, then the workspace PUT — and assert the account,
membership, credentials, and provider role **without any polling**, because the
identity has to exist by the time the response is written. A grant is then
resolved through the new account, which is what activation asks for. The
hook-create equivalent asserts the same. Two more assert the 409 path: a group
out of service-account slots refuses the write, and neither the workspace nor
the hook is written.

## Verification

- root `pnpm typecheck`
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 1967 passed
- `pnpm --filter @agentconnect.md/control-plane test:int` — 1664 passed
- `pnpm lint`, `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
