### PR TITLE
fix(daemon): anchor a Slack file share on the ts it actually landed on

### DIFF
--- a/docs/designs/agent-authored-attachments.md
+++ b/docs/designs/agent-authored-attachments.md
@@ -115,6 +115,16 @@ Three refusal classes, and only the first is port-probeable — the doc'd earlie
 
 ### 3.3 Identity, caption, and the result
 
+**The file post carries no message id of its own, and Slack needs a second read to get
+one.** `files.completeUploadExternal` answers with the FILE, not the message it became — and
+an unnamed post is not an ANCHOR: a human replying under a shared image lands in a thread
+whose root the daemon does not recognize as its own, so the reply wakes nobody, while the
+same reply under a forwarded TEXT message (a `chat.postMessage`, which returns its `ts`)
+always worked. `uploadFile` therefore reads `files.info` after the share and returns
+`shares.public|private[channel][0].ts` as the outcome's `messageId`. The read is
+best-effort by construction: the file is already in the conversation, so a failure degrades
+to an unanchored share, never to a failed one.
+
 **The file post is _not_ identity-stamped today, on any platform** — no `uploadFile`
 implementation declares the identity parameter, and Telegram ignores identity by platform
 design. Slack briefly passed `username`/`icon_url` to the share step: documented for that
@@ -315,5 +325,13 @@ shim boundary, and generalizes to none of the other three platforms.
    steps, so an HTTP failure can never prove which step it came from. Only Slack answering
    `{ok:false}` counts as proof that nothing was published — everything else is
    `indeterminate`.
-4. **Demand:** is there a concrete request behind "produced file → different
+4. **Slack file identity is an app setting, not an argument (settled).** A bot binds to ONE
+   agent, so the app's own name is already the agent's; what a file post shows for an avatar
+   is the app's ICON. No file method takes `username`/`icon_url`, and the app manifest has
+   no icon field — Slack exposes no way to set one programmatically. Text posts sidestep
+   this with `icon_url` on `chat.postMessage`; file posts cannot, so an installation whose
+   Slack app has no icon shows the placeholder on shared files and the agent's icon on its
+   replies. The fix is to upload the agent's icon once in the app's settings, not to change
+   this code.
+5. **Demand:** is there a concrete request behind "produced file → different
    conversation", or only the table's symmetry? Decides whether `attachFile` leaves §7.

--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -35,6 +35,7 @@ const EXEMPT: Record<string, string> = {
   postPermissionUpdateCard: 'private permission-card helper',
   postIfThreadExists: 'private Slack root-existence guard',
   postChatMessage: 'private shared post boundary behind postMessage/postBlocks',
+  shareMessageTs: 'private share-ts read behind uploadFile',
   // Interactive Slack surfaces (Block Kit actions / modals) are driven by
   // Bolt callbacks the virtual transport never receives; the daemon only
   // invokes them from those callbacks.

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -361,6 +361,9 @@ export type AppLike = {
     // so this is the ONLY way to put a file in a conversation.
     files: {
       uploadV2: (a: unknown) => Promise<unknown>
+      info: (a: unknown) => Promise<{
+        file?: { shares?: { public?: SlackFileShares; private?: SlackFileShares } }
+      }>
     }
     conversations: {
       open: (a: unknown) => Promise<{ channel?: { id?: string } }>
@@ -526,6 +529,12 @@ const SLACK_API_TIMEOUT_MS = 30_000
 
 /** Map a Slack API error to the port's typed failure vocabulary — every arm already had the
  *  raw material (`missing_scope` payloads, stable error codes); this only names them. */
+/** The `files.info` share record, keyed by channel id (docs: `shares.public|private`). */
+type SlackFileShares = Record<string, { ts?: string }[] | undefined>
+
+/** `uploadV2` answers with one `completeUploadExternal` response per file. */
+type SlackUploadV2Result = { files?: { files?: { id?: string }[] }[] } | undefined
+
 /** The provider's own words, for the arm that has no category: without this a refusal
  *  reports only `platform error`, which no operator can act on. */
 function slackErrorDetail(err: unknown): { detail?: string } {
@@ -1380,14 +1389,16 @@ export class SlackConnection implements PlatformConnection {
         // `text` argument, so blocks-only would buy CommonMark at the price of the
         // notification preview for every forwarded file. Keeping the comment is the better
         // half of that trade; the cost is that `**bold**` and `[label](url)` read literally.
-        await this.app.client.files.uploadV2({
+        const done = (await this.app.client.files.uploadV2({
           file: file.bytes,
           filename: file.name,
           channel_id: channel,
           ...(threadTs ? { thread_ts: threadTs } : {}),
           ...(comment ? { initial_comment: comment } : {})
-        })
-        return { ok: true }
+        })) as SlackUploadV2Result
+        // `uploadV2` answers with one completion response per file, each carrying the FILE.
+        const fileId = done?.files?.[0]?.files?.[0]?.id
+        return { ok: true, ...(await this.shareMessageTs(fileId, channel)) }
       } catch (err) {
         this.rememberMissingScopes(err)
         this.deps.log?.debug(`slack: uploadFile ${file.name} → ch=${channel} failed: ${(err as Error).message}`)
@@ -1408,6 +1419,31 @@ export class SlackConnection implements PlatformConnection {
       ok: false,
       reason: isSendQueueTimeout(err) ? 'indeterminate' : 'platform_error'
     }))
+  }
+
+  /**
+   * The ts of the message a shared file became. Slack's completion answers with the FILE, not
+   * the message, so a share has no timestamp of its own — and a post the daemon cannot name is
+   * not an ANCHOR: replying under it lands in a thread whose root the daemon does not
+   * recognize as its own, so the reply wakes nobody. `files.info` publishes the share record
+   * that does carry the ts, which is why the file post costs one extra read.
+   *
+   * Best-effort by construction: the file is already in the conversation by the time this
+   * runs, so a failure here must degrade to an unanchored share, never to a failed one.
+   */
+  private async shareMessageTs(fileId: string | undefined, channel: string): Promise<{ messageId?: string }> {
+    if (!fileId) return {}
+    try {
+      const info = await this.app.client.files.info({ file: fileId })
+      const shares = info.file?.shares
+      // A share is filed under the channel's own visibility, so read both arms by channel id.
+      const ts = (shares?.public?.[channel] ?? shares?.private?.[channel])?.[0]?.ts
+      if (!ts) this.deps.log?.debug(`slack: uploadFile share of ${fileId} carried no ts for ${channel}`)
+      return ts ? { messageId: ts } : {}
+    } catch (err) {
+      this.deps.log?.debug(`slack: uploadFile could not read the share ts of ${fileId}: ${(err as Error).message}`)
+      return {}
+    }
   }
 
   /**

--- a/packages/daemon/test/fakes/slack-app.ts
+++ b/packages/daemon/test/fakes/slack-app.ts
@@ -44,7 +44,8 @@ export function fakeSlackAppFactory(identity: FakeSlackIdentity = {}): SlackAppF
           delete: ok
         },
         files: {
-          uploadV2: async () => ({ ok: true, files: [{ id: 'F_FAKE' }] })
+          uploadV2: async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F_FAKE' }] }] }),
+          info: async () => ({ file: { shares: { public: { C1: [{ ts: '1700000000.000100' }] } } } })
         },
         conversations: {
           open: async () => ({ channel: { id: 'D_FAKE' } }),

--- a/packages/daemon/test/slack-upload-file.test.ts
+++ b/packages/daemon/test/slack-upload-file.test.ts
@@ -7,7 +7,13 @@ const deps = () => ({
   newTraceId: () => 't'
 })
 
-function connWith(uploadV2: unknown) {
+const sharedAt =
+  (ts: string, channel = 'C1', visibility = 'public') =>
+  async () => ({
+    file: { shares: { [visibility]: { [channel]: [{ ts }] } } }
+  })
+
+function connWith(uploadV2: unknown, info: unknown = sharedAt('1700000000.000100')) {
   const app = {
     message() {},
     event() {},
@@ -16,7 +22,7 @@ function connWith(uploadV2: unknown) {
     client: {
       auth: { test: async () => ({ user_id: 'U1', team_id: 'T123' }) },
       chat: { postMessage: async () => ({}), getPermalink: async () => ({ permalink: 'https://x/y' }) },
-      files: { uploadV2 },
+      files: { uploadV2, info },
       assistant: { threads: { setStatus: async () => undefined, setTitle: async () => undefined } }
     },
     start: async () => {},
@@ -34,13 +40,14 @@ describe('SlackConnection.uploadFile', () => {
   it('hands the whole external upload to the SDK, with the coordinates that make it a message', async () => {
     // The byte POST is not a Slack API request and its wire shape is undocumented; two live
     // failures came out of reimplementing it, so the transport belongs to `uploadV2` now.
-    const uploadV2 = vi.fn(async () => ({ ok: true, files: [{ id: 'F1' }] }))
+    const uploadV2 = vi.fn(async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }))
     const conn = connWith(uploadV2)
 
     const bytes = Buffer.from('PNGBYTES')
     await expect(
       conn.uploadFile('C1', { bytes, name: 'shot.png' }, 'from telegram', { thread: '111.1' })
-    ).resolves.toEqual({ ok: true })
+      // The share's own ts, read back from files.info — see the anchoring test below.
+    ).resolves.toEqual({ ok: true, messageId: '1700000000.000100' })
 
     // channel_id is what turns a hosted file into a message; without it the upload stays
     // private. No `blocks`: the completion step ignores them whenever `initial_comment` is
@@ -55,7 +62,7 @@ describe('SlackConnection.uploadFile', () => {
   })
 
   it('omits the anchor and the caption rather than sending them empty', async () => {
-    const uploadV2 = vi.fn(async () => ({ ok: true }))
+    const uploadV2 = vi.fn(async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }))
     await connWith(uploadV2).uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })
     expect(uploadV2).toHaveBeenCalledWith({ file: expect.any(Buffer), filename: 'a.png', channel_id: 'C1' })
   })
@@ -81,6 +88,45 @@ describe('SlackConnection.uploadFile', () => {
       reason: 'missing_scope',
       detail: 'missing_scope'
     })
+  })
+
+  it('anchors the file post on the share’s real ts, so a reply under it wakes the agent', async () => {
+    // Slack's completion answers with the FILE, not the message, so without this read the
+    // share has no timestamp — and a post the daemon cannot name is not a thread root it
+    // recognizes, which is why replying under a shared image used to wake nobody while
+    // replying under a forwarded TEXT message (a chat.postMessage, which returns its ts)
+    // always worked.
+    const info = vi.fn(sharedAt('1700000000.000200', 'C9'))
+    const conn = connWith(async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F7' }] }] }), info)
+    await expect(conn.uploadFile('C9', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
+      ok: true,
+      messageId: '1700000000.000200'
+    })
+    expect(info).toHaveBeenCalledWith({ file: 'F7' })
+  })
+
+  it('reads the share ts out of the private arm too, since a DM files it there', async () => {
+    const conn = connWith(
+      async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F7' }] }] }),
+      sharedAt('1700000000.000300', 'D2', 'private')
+    )
+    await expect(conn.uploadFile('D2', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
+      ok: true,
+      messageId: '1700000000.000300'
+    })
+  })
+
+  it('still reports success when the ts cannot be read, since the file already landed', async () => {
+    // Anchoring is bookkeeping ON TOP of a delivery that already happened. Failing the share
+    // here would report "nothing was sent" about a file the channel is displaying, and invite
+    // the retry that double-posts it.
+    const conn = connWith(
+      async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F7' }] }] }),
+      async () => {
+        throw new Error('ratelimited')
+      }
+    )
+    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({ ok: true })
   })
 
   it('calls every non-API failure indeterminate, because the share step is one-shot', async () => {


### PR DESCRIPTION
Replying under a shared image woke nobody. The same reply under a **forwarded
text** message always worked.

The difference is where the two messages come from. A text reply goes out
through `chat.postMessage`, which returns its `ts`. A file share goes out
through the external upload, and `files.completeUploadExternal` answers with the
**file** — no message timestamp at all. The share was therefore recorded under a
synthetic local id, so when a human replied under it the daemon saw a thread
whose root it did not recognize as its own, and had nothing to wake.

## The fix

`uploadFile` reads `files.info` after the share and returns
`shares.public|private[channel][0].ts` as the outcome's `messageId` — the
documented place that record lives. One extra read per file post.

It is best-effort by construction: the file is already in the conversation by
the time it runs, so a failure degrades to an unanchored share, never to a
failed one. Reporting "nothing was sent" about a file the channel is displaying
would invite exactly the retry that double-posts it — the rule the rest of this
outcome vocabulary exists to keep.

## The other half, which is not a code change

The same investigation started from a shared image showing a placeholder avatar,
and that one has no fix in this repository:

- A bot binds to **one** agent (`botId` unique), so a file post already shows the
  agent's name — that part was never broken.
- The avatar is the Slack **app's icon**. No file method accepts
  `username`/`icon_url`, and the app manifest has no icon field, so Slack exposes
  no way to set one programmatically.
- Text posts sidestep this by passing `icon_url` to `chat.postMessage`. File
  posts cannot, which is why an installation whose app has no icon shows the
  placeholder on shared files and the agent's icon on its replies.

An installation fixes it by uploading the agent's icon once in the app's
settings. Recorded in the design so it is not rediscovered as a bug.

## Verification

- Three new cases: the share ts becomes the anchor and `files.info` is asked for
  the right file; the private arm is read too, since a DM files the share there;
  and a failed lookup still reports success, because the file already landed.
- Existing cases updated for the nested completion shape `uploadV2` actually
  returns (one `completeUploadExternal` response per file).
- Daemon typecheck, lint, the neighbouring upload/ops/session suites (283
  passing), and the arena connection-surface guard all pass.
