### PR TITLE
fix(control-plane): fence the GitLab run projection on the acting agent's account epoch

### DIFF
--- a/packages/control-plane/src/codehost/note-projection.service.test.ts
+++ b/packages/control-plane/src/codehost/note-projection.service.test.ts
@@ -123,19 +123,28 @@ function harness(
     setDesired?: boolean
     retiredOwner?: boolean
     runEpoch?: bigint | null
+    /** The acting agent's §7.2 account on the project; null ⇒ it has none. */
+    account?: { credentialEpoch: bigint; state?: string; serviceAccountUserId?: bigint | null } | null
   } = {}
 ) {
   const row = options.row ?? projection()
+  // The stored row carries whatever converge computed, as the real repository
+  // does — the dispatched frame is then read back from it.
+  let stored = row
   const sent: Array<{ daemonId: string; desired: CodeHostNoteDesired; orgId: string }> = []
   const projections = {
-    upsert: vi.fn(async () => (options.retiredOwner ? null : row)),
+    upsert: vi.fn(async (input: { credentialEpoch: bigint }) => {
+      if (options.retiredOwner) return null
+      stored = { ...row, credentialEpoch: input.credentialEpoch }
+      return stored
+    }),
     setDesired: vi.fn(async () => options.setDesired ?? true),
     supersede: vi.fn(async () => 0),
     beginWrite: vi.fn(async () => options.beginWrite ?? true),
     completeWrite: vi.fn(async () => true),
     failWrite: vi.fn(async () => true),
     advancePending: vi.fn(async () => null),
-    get: vi.fn(async () => row)
+    get: vi.fn(async () => stored)
   } satisfies Record<keyof CodeHostRunProjectionRepo, unknown> as unknown as CodeHostRunProjectionRepo & {
     upsert: ReturnType<typeof vi.fn>
     setDesired: ReturnType<typeof vi.fn>
@@ -149,11 +158,19 @@ function harness(
   const runs = {
     getRun: vi.fn(async () => ({ projectionEpoch: options.runEpoch === undefined ? 1n : options.runEpoch }))
   }
+  // The account's own epoch, deliberately DIFFERENT from the binding's: the two
+  // counters advance independently and the daemon fences on the account's.
+  const account =
+    options.account === undefined
+      ? { credentialEpoch: 7n, state: 'ready', serviceAccountUserId: 9042n }
+      : options.account
+  const accounts = { forAgentBinding: vi.fn(async () => account) }
   const service = new CodeHostNoteProjectionService({
     projections,
     runs: runs as never,
     agents: { getUnscoped: vi.fn(async () => agent) },
-    bindings: { byProject: vi.fn(async () => ({ credentialEpoch: 2n })) } as never,
+    bindings: { byProject: vi.fn(async () => ({ id: 'binding-1', credentialEpoch: 2n })) } as never,
+    accounts: accounts as never,
     orgs: { slugById: vi.fn(async () => 'acme') },
     webAppUrl: 'https://console.example.test',
     clock: new FakeClock(NOW),
@@ -162,7 +179,7 @@ function harness(
       send: (id, desired, org) => sent.push({ daemonId: id, desired, orgId: org })
     }
   })
-  return { service, projections, sent, row, runs }
+  return { service, projections, sent, row, runs, accounts }
 }
 
 describe('reportedNoteState (gitlab-com-integration.md §16)', () => {
@@ -208,10 +225,35 @@ describe('CodeHostNoteProjectionService', () => {
     expect(desired.projectId).toBe('4455667')
     expect(desired.mergeRequestIid).toBe(42)
     expect(desired.headSha).toBe(HEAD)
-    expect(desired.credentialEpoch).toBe('2')
+    // §7.2: the ACTING AGENT's account epoch, never the binding's (2n here) —
+    // the daemon mints its effect lease against that account and fences on it.
+    expect(desired.credentialEpoch).toBe('7')
     // The fence echoes the ACCEPTED tuple verbatim, never a value the projection invented.
     expect(desired.snapshot).toEqual(snapshot)
     expect(desired.writeMarker).not.toBe(desired.projectionKey)
+  })
+
+  it('follows the account epoch across a rotation, and asks for the ACTING agent’s account', async () => {
+    const rotated = harness({ account: { credentialEpoch: 8n, state: 'ready', serviceAccountUserId: 9042n } })
+    await rotated.service.afterAccepted(edge())
+    expect(rotated.sent[0]!.desired.credentialEpoch).toBe('8')
+    // Resolved for this agent on this project's binding — the same identity the
+    // effect lease is minted against, so the two counters cannot diverge.
+    expect(rotated.accounts.forAgentBinding).toHaveBeenCalledWith(orgId, agentId, 'binding-1')
+  })
+
+  it('opens no projection when the agent has no usable account on the project (§7.2)', async () => {
+    for (const account of [
+      null,
+      { credentialEpoch: 7n, state: 'provisioning', serviceAccountUserId: 9042n },
+      { credentialEpoch: 7n, state: 'ready', serviceAccountUserId: null }
+    ]) {
+      const { service, projections, sent } = harness({ account })
+      await service.afterAccepted(edge())
+      // Fail closed: the note could never be written, so no row and no frame.
+      expect(projections.upsert).not.toHaveBeenCalled()
+      expect(sent).toHaveLength(0)
+    }
   })
 
   it('advances the generation to running when the start barrier is crossed', async () => {
@@ -259,7 +301,10 @@ describe('CodeHostNoteProjectionService', () => {
       projections,
       runs: runs as never,
       agents: { getUnscoped: vi.fn(async () => agent) },
-      bindings: { byProject: vi.fn(async () => ({ credentialEpoch: 2n })) } as never,
+      bindings: { byProject: vi.fn(async () => ({ id: 'binding-1', credentialEpoch: 2n })) } as never,
+      accounts: {
+        forAgentBinding: vi.fn(async () => ({ credentialEpoch: 7n, state: 'ready', serviceAccountUserId: 9042n }))
+      } as never,
       clock: new FakeClock(NOW),
       sender: { daemonFeatures: () => undefined, send: () => sent.push(undefined as never) }
     })

--- a/packages/control-plane/src/codehost/note-projection.service.ts
+++ b/packages/control-plane/src/codehost/note-projection.service.ts
@@ -30,6 +30,7 @@ import type { Clock } from '../domain/clock.js'
 import { AgentId, HookId, type OrgId } from '../domain/ids.js'
 import type {
   AgentRepo,
+  GitlabAgentAccountRepo,
   CodeHostRunProjectionRecord,
   CodeHostRunProjectionRepo,
   GitlabProjectBindingRepo,
@@ -119,6 +120,9 @@ export interface CodeHostNoteProjectionDeps {
   runs: Pick<HookRepo, 'getRun'>
   agents: Pick<AgentRepo, 'getUnscoped'>
   bindings: Pick<GitlabProjectBindingRepo, 'byProject'>
+  /** §7.2: the acting agent's own account on the project — the identity the
+   *  effect lease is minted against, and so the epoch the daemon fences on. */
+  accounts: Pick<GitlabAgentAccountRepo, 'forAgentBinding'>
   orgs?: Pick<OrgRepo, 'slugById'>
   sender: NoteProjectionSender
   clock: Clock
@@ -224,6 +228,12 @@ export class CodeHostNoteProjectionService {
     if (!agent || agent.orgId !== edge.orgId) return
     const binding = await this.deps.bindings.byProject(edge.orgId, subject.projectId)
     if (!binding) return
+    // The daemon fences the write on the epoch of the lease it mints, and that
+    // lease is the ACTING AGENT's account (§7.2) — never the binding's counter,
+    // which advances on its own schedule and would refuse every write. An agent
+    // with no ready account there cannot write the note, so no projection opens.
+    const account = await this.deps.accounts.forAgentBinding(edge.orgId, edge.agentId, binding.id)
+    if (!account || account.serviceAccountUserId === null || account.state !== 'ready') return
 
     // A newer head preempts every older generation on the same merge request before the new one
     // opens, so exactly one note per head reads current.
@@ -246,7 +256,7 @@ export class CodeHostNoteProjectionService {
       desiredState: edge.state,
       currentDeliveryKey: edge.deliveryKey,
       currentRunAt: edge.at,
-      credentialEpoch: binding.credentialEpoch,
+      credentialEpoch: account.credentialEpoch,
       configRevision: BigInt(snapshot.configRevision),
       dispatchRevision: BigInt(snapshot.dispatchRevision),
       dispatchDaemonId: snapshot.dispatchDaemonId,

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1070,13 +1070,14 @@ export function buildContainer(
 
   // §16 informational run projection: the CP records the desired generation, the OWNING DAEMON
   // writes the note. Assembled with the GitLab administration surface, since the ledger's
-  // credential fence comes from a project binding.
+  // credential fence comes from the acting agent's account on a project binding.
   const codeHostNoteProjection = gitlab
     ? new CodeHostNoteProjectionService({
         projections: new PgCodeHostRunProjectionRepo(prisma),
         runs: repos.hook,
         agents: repos.agent,
         bindings: repos.gitlabProjectBinding,
+        accounts: repos.gitlabAgentAccount,
         orgs: repos.org,
         clock,
         ...(gitlabWebAppUrl ? { webAppUrl: gitlabWebAppUrl } : {}),

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -14,12 +14,14 @@ import { FakeGitlab, type FakeGitlabOptions } from '../fakes/gitlab-api.js'
 import { GitlabOauthService } from '../../src/gitlab/oauth.service.js'
 import { GitlabProvisioner } from '../../src/gitlab/provisioner.js'
 import { GitlabAccountService } from '../../src/gitlab/account.service.js'
+import { CodeHostNoteProjectionService } from '../../src/codehost/note-projection.service.js'
 import { gitlabAgentAccountUsername } from '../../src/gitlab/api.js'
 import { GitlabMembershipAuthzService } from '../../src/gitlab/membership-authz.service.js'
 import { unionGitlabWebhookEvents } from '../../src/gitlab/webhook-events.js'
 import {
   PgAgentRepo,
   PgCodeHostRepositoryRepo,
+  PgCodeHostRunProjectionRepo,
   PgGitlabAgentAccountRepo,
   PgGitlabConnectionRepo,
   PgGitlabConnectionSecretStore,
@@ -34,8 +36,10 @@ import { makeSecretCipher } from '../../src/secrets/cipher.js'
 import { systemClock } from '../../src/domain/clock.js'
 import { AgentId, HookId, OrgId } from '../../src/domain/ids.js'
 import {
+  CODEHOST_NOTE_PROJECTION_V1_FEATURE,
   GITLAB_COM_V1_FEATURE,
   GITLAB_RERUN_V1_FEATURE,
+  type CodeHostNoteDesired,
   type RcHookAssign,
   type RcHookRerun,
   type RcHookRerunResult
@@ -141,7 +145,7 @@ async function harness(options: FakeGitlabOptions = {}) {
   // A second agent, so a test needing two hooks on one project clears the per-agent fence.
   const secondAgentId = randomUUID()
   await seedAgent(prisma, secondAgentId, { daemonId })
-  return { fake, a: running, hookRepo, bindings, accounts, provisioner, binding, agentId, secondAgentId }
+  return { fake, a: running, hookRepo, bindings, accounts, provisioner, binding, agentId, secondAgentId, daemonId }
 }
 
 /** A stand-in relay socket. `answer` decides how it replies to a correlated
@@ -881,5 +885,103 @@ describe('gitlab hook rerun — the Console "Run again" route (§16.1/§18.2)', 
     const none = await rerun(h.a, hookId, { kind: 'merge_request', iid: MR_IID })
     expect(none.statusCode).toBe(503)
     expect((none.json() as { code: string }).code).toBe('RELAY_UNAVAILABLE')
+  })
+})
+
+/**
+ * §16 run-projection credential fence, against real rows: the daemon mints its
+ * effect lease from the ACTING AGENT's account (§7.2) and refuses the write when
+ * the frame's epoch disagrees, so the projection must carry that account's
+ * counter — not the binding's, which advances independently.
+ */
+describe('gitlab run projection — the fence follows the agent account (§7.2/§16)', () => {
+  const PROJECTION_HEAD = 'a'.repeat(40)
+
+  function projectionService(sent: CodeHostNoteDesired[]) {
+    return new CodeHostNoteProjectionService({
+      projections: new PgCodeHostRunProjectionRepo(prisma),
+      runs: { getRun: async () => ({ projectionEpoch: 1n }) } as never,
+      agents: new PgAgentRepo(prisma),
+      bindings: new PgGitlabProjectBindingRepo(prisma),
+      accounts: new PgGitlabAgentAccountRepo(prisma),
+      clock: systemClock,
+      sender: {
+        daemonFeatures: () => [CODEHOST_NOTE_PROJECTION_V1_FEATURE],
+        send: (_daemonId: string, desired: CodeHostNoteDesired) => sent.push(desired)
+      }
+    })
+  }
+
+  function edge(agentId: string, hookId: string, daemonId: string, headSha = PROJECTION_HEAD) {
+    return {
+      hookId,
+      agentId,
+      deliveryKey: `delivery-${randomUUID().slice(0, 8)}`,
+      orgId: OrgId(DEFAULT_ORG_ID),
+      state: 'queued' as const,
+      gitlab: {
+        projectId: PROJECT.toString(),
+        projectPath: 'example-group/example-project',
+        target: { kind: 'merge_request' as const, iid: 42, headSha }
+      },
+      snapshot: {
+        configRevision: '1',
+        dispatchRevision: '1',
+        dispatchDaemonId: daemonId,
+        reviewPolicy: 'off' as const,
+        reportingMode: 'check' as const,
+        gateMode: 'informational' as const
+      },
+      at: new Date()
+    }
+  }
+
+  it('carries the agent account’s epoch, and follows it across a rotation', async () => {
+    const h = await harness()
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(created.statusCode).toBe(200)
+    const hookId = (created.json() as { id: string }).id
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, h.agentId, 900n))!
+    const binding = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
+    // The two counters really do differ, which is what made the mismatch bite.
+    expect(account.credentialEpoch).not.toBe(binding.credentialEpoch)
+
+    const sent: CodeHostNoteDesired[] = []
+    await projectionService(sent).afterAccepted(edge(h.agentId, hookId, h.daemonId) as never)
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.credentialEpoch).toBe(account.credentialEpoch.toString())
+    const row = await prisma.codeHostRunProjection.findFirstOrThrow({ where: { hookId } })
+    expect(row.credentialEpoch).toBe(account.credentialEpoch)
+
+    // A PAT rotation bumps the account's epoch; the next generation follows it.
+    await new PgGitlabProjectCredentialRepo(prisma).commitRotation({
+      accountId: account.id,
+      purpose: 'effect',
+      externalTokenId: 4242n,
+      scopes: ['api'],
+      providerExpiresAt: new Date(Date.now() + 86_400_000),
+      sealedToken: 'glpat-rotated'
+    })
+    const rotated = (await h.accounts.get(account.id))!
+    expect(rotated.credentialEpoch).toBe(account.credentialEpoch + 1n)
+
+    const after: CodeHostNoteDesired[] = []
+    await projectionService(after).afterAccepted(edge(h.agentId, hookId, h.daemonId, 'b'.repeat(40)) as never)
+    expect(after[0]!.credentialEpoch).toBe(rotated.credentialEpoch.toString())
+  })
+
+  it('opens no projection while the agent has no ready account on the project', async () => {
+    const h = await harness()
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    const hookId = (created.json() as { id: string }).id
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, h.agentId, 900n))!
+    // Runtime drift: the account is being repaired, so its lease would be refused.
+    await h.accounts.update(account.id, { state: 'runtime_degraded', stateReason: 'drift' })
+
+    const sent: CodeHostNoteDesired[] = []
+    await projectionService(sent).afterAccepted(edge(h.agentId, hookId, h.daemonId) as never)
+    // Fail closed, like every other missing-authority early return.
+    expect(sent).toHaveLength(0)
+    expect(await prisma.codeHostRunProjection.count({ where: { hookId } })).toBe(0)
   })
 })


### PR DESCRIPTION
Found in live testing of the per-agent GitLab identity rollout: **every**
merge-request status-note write was refused with `stale_credential_epoch`. The
projection rows sat at `desiredState=completed, observedState=NULL,
lastErrorCode=stale_credential_epoch, attempts=3` with no note ever posted, while
formal reviews and ordinary replies from the same agents worked normally.

## Why

The daemon fences the note write by comparing two epochs for equality: the one
on the effect lease it just minted, and the one the projection frame carries.

- Since per-agent identity, the effect lease is minted against the **acting
  agent's own account** (§7.2), so `lease.credentialEpoch` is
  `GitlabAgentAccount.credentialEpoch`.
- The projection frame was still filled from `GitlabProjectBinding.credentialEpoch`.

Those two counters advance on entirely separate schedules — the account's on its
own PAT rotations, the binding's on binding-level events — so after the identity
change they agree only by coincidence. Compared for equality, the fence refused
every write, and no retry could ever make them match. Reviews and replies were
unaffected because they take the lease without comparing it to a stored
projection epoch.

## The fix

The projection resolves the agent's account on the project exactly the way the
effect lease does — `forAgentBinding(orgId, agentId, binding.id)` — and carries
that account's epoch, so both sides of the daemon's comparison now come from the
same identity.

An agent with no ready account on the project cannot write the note at all, so
no projection opens: that joins the other missing-authority early returns and
fails closed, rather than recording a row whose write could never pass.

**The daemon is unchanged** — the fence is correct, it was being handed the
wrong counter.

## Audit

The instruction was to check the other places per-agent identity left a
binding-level counter feeding a fence the daemon now compares against a
per-account grant, without churning unrelated fields. Sweeping every
`credentialEpoch` producer and consumer:

- the compiled rule and the review lease carry account **identity** but no
  epoch, so there is nothing to align there;
- gitcred grants already carry the account's epoch;
- the daemon's only other epoch comparison is monotonic, between a stored
  desired generation and an incoming one — both from this same source, so it
  stays consistent once the source is right;
- the binding's own counter now feeds only the console DTO, where nothing
  compares it.

So this is the single site, and nothing else was touched.

One transition note: an in-flight projection row written before this change
holds a binding-derived value, and the daemon's monotonic check could read a
lower account-derived value as stale. Those rows are exactly the ones already
failing today, and any new head or delivery opens a fresh generation, so they
resolve on the next run rather than needing a migration.

## Tests

- Unit: the dispatched frame's `credentialEpoch` is the account's, not the
  binding's — the harness deliberately gives the two different values — and it
  follows the account across a rotation; the account is resolved for the acting
  agent on that project's binding; and no projection opens for a missing,
  unprovisioned, or not-yet-ready account. Both epoch assertions fail against
  the previous behavior.
- Integration, against real Postgres: a hook created through the route, then a
  converge asserting the persisted row and the dispatched frame both carry the
  account's epoch — through the real `forAgentBinding` join — that a real PAT
  rotation moves it, and that a `runtime_degraded` account opens nothing.

## Verification

- root `pnpm typecheck`
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 1969 passed
- `pnpm --filter @agentconnect.md/control-plane test:int` — 1676 passed
- `pnpm lint`, `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
