### PR TITLE
fix(daemon): put the agent's identity back on a Slack file share

### DIFF
--- a/docs/designs/agent-authored-attachments.md
+++ b/docs/designs/agent-authored-attachments.md
@@ -131,7 +131,11 @@ the message — which is why the file path and the text path diverge in the firs
 why every consequence of that divergence lands here. `files.completeUploadExternal`
 documents `username`/`icon_url`/`icon_emoji` for the share message (behind
 `chat:write.customize`), so `uploadFile` passes the turn's identity there and falls back to
-the undecorated call on a definite refusal, exactly as the text path does. The other three
+the undecorated call when — and only when — Slack refused the DECORATION itself
+(`missing_scope`, `invalid_arguments`). The completion is one-shot, and Slack documents
+`internal_error`/`fatal_error` as possibly raised after part of it succeeded, so those join
+"no provider code at all" as outcomes that forfeit the proof of refusal and stay
+`indeterminate` rather than being retried into a second share. The other three
 implementations do not declare the parameter, and Telegram ignores identity by platform
 design. A file post still carries no `agentAuthorId`, so on a shared bot it stays invisible
 to peer backfill; the fix for that remains a paired anchor post, deferred until shared-bot

--- a/docs/designs/agent-authored-attachments.md
+++ b/docs/designs/agent-authored-attachments.md
@@ -125,13 +125,17 @@ always worked. `uploadFile` therefore reads `files.info` after the share and ret
 best-effort by construction: the file is already in the conversation, so a failure degrades
 to an unanchored share, never to a failed one.
 
-**The file post is _not_ identity-stamped today, on any platform** — no `uploadFile`
-implementation declares the identity parameter, and Telegram ignores identity by platform
-design. Slack briefly passed `username`/`icon_url` to the share step: documented for that
-method, absent from the SDK's argument type, and never confirmed against live Slack before
-it was dropped along with the hand-written transport it lived in (§9.4). On a shared Slack
-app the gap makes a shared file invisible to peer backfill and mis-attributable to
-whichever agent looks at it. Phase 1 states this degradation per platform rather than claiming otherwise; if
+**Only Slack can identity-stamp a file post, and the API's own arguments are the only way
+to do it.** `chat.postMessage` cannot attach a file at all, so the upload's completion IS
+the message — which is why the file path and the text path diverge in the first place, and
+why every consequence of that divergence lands here. `files.completeUploadExternal`
+documents `username`/`icon_url`/`icon_emoji` for the share message (behind
+`chat:write.customize`), so `uploadFile` passes the turn's identity there and falls back to
+the undecorated call on a definite refusal, exactly as the text path does. The other three
+implementations do not declare the parameter, and Telegram ignores identity by platform
+design. A file post still carries no `agentAuthorId`, so on a shared bot it stays invisible
+to peer backfill; the fix for that remains a paired anchor post, deferred until shared-bot
+usage demands it. Phase 1 states this degradation per platform rather than claiming otherwise; if
 attribution matters on shared bots, the fix is a paired zero-content anchor post stamped
 with `agentAuthorId` — which would also supply Slack's missing message id — and it is
 deferred until shared-bot usage demands it.
@@ -325,13 +329,13 @@ shim boundary, and generalizes to none of the other three platforms.
    steps, so an HTTP failure can never prove which step it came from. Only Slack answering
    `{ok:false}` counts as proof that nothing was published — everything else is
    `indeterminate`.
-4. **Slack file identity is an app setting, not an argument (settled).** A bot binds to ONE
-   agent, so the app's own name is already the agent's; what a file post shows for an avatar
-   is the app's ICON. No file method takes `username`/`icon_url`, and the app manifest has
-   no icon field — Slack exposes no way to set one programmatically. Text posts sidestep
-   this with `icon_url` on `chat.postMessage`; file posts cannot, so an installation whose
-   Slack app has no icon shows the placeholder on shared files and the agent's icon on its
-   replies. The fix is to upload the agent's icon once in the app's settings, not to change
-   this code.
+4. **Why the two paths differ at all (settled).** Slack has no way to attach a file to a
+   message: `chat.postMessage` takes no file, and the upload's completion creates its own
+   message instead. So a caption rides as `initial_comment` on a message the UPLOAD endpoint
+   built, and everything `chat.postMessage` returns for free — a `ts`, per-message identity —
+   has to be recovered separately here. `blocks` + `slack_file` would collapse the two paths
+   into one, but a file uploaded without `channel_id` is documented as private, and whether a
+   block reference makes it visible to anyone else is not documented either way; that is the
+   open question standing between this design and one code path.
 5. **Demand:** is there a concrete request behind "produced file → different
    conversation", or only the table's symmetry? Decides whether `attachFile` leaves §7.

--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -35,6 +35,10 @@ const EXEMPT: Record<string, string> = {
   postPermissionUpdateCard: 'private permission-card helper',
   postIfThreadExists: 'private Slack root-existence guard',
   postChatMessage: 'private shared post boundary behind postMessage/postBlocks',
+  shareWithIdentity: 'private identity-carrying upload path, behind uploadFile',
+  putUploadBytes: 'private step 2 of the external upload, behind uploadFile',
+  completeUpload: 'private step 3 of the external upload, behind uploadFile',
+  completeShare: 'private one-shot completion boundary, behind completeUpload',
   shareMessageTs: 'private share-ts read behind uploadFile',
   // Interactive Slack surfaces (Block Kit actions / modals) are driven by
   // Bolt callbacks the virtual transport never receives; the daemon only

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -534,6 +534,22 @@ const SLACK_API_TIMEOUT_MS = 30_000
 /** The `files.info` share record, keyed by channel id (docs: `shares.public|private`). */
 type SlackFileShares = Record<string, { ts?: string }[] | undefined>
 
+/**
+ * Completion outcomes that do NOT prove the share was refused. Slack documents both as
+ * possibly raised AFTER some aspect of the operation succeeded, so a one-shot completion that
+ * answers with either may already be visible in the channel.
+ */
+const COMPLETION_MAY_HAVE_LANDED = new Set(['internal_error', 'fatal_error'])
+
+/**
+ * The only completion refusals worth a second, undecorated attempt: pure request validation
+ * (so provably before publication) AND plausibly caused by `username`/`icon_url` themselves,
+ * which is the one thing the retry can change. A pre-publication refusal this set omits —
+ * `not_in_channel`, `channel_not_found` — would fail identically undecorated, so retrying it
+ * only spends a call and replaces the real error with its echo.
+ */
+const DECORATION_REFUSALS = new Set(['missing_scope', 'invalid_arguments', 'invalid_arg_name', 'invalid_array_arg'])
+
 /** `uploadV2` answers with one `completeUploadExternal` response per file. */
 type SlackUploadV2Result = { files?: { files?: { id?: string }[] }[] } | undefined
 
@@ -1417,11 +1433,12 @@ export class SlackConnection implements PlatformConnection {
         this.deps.log?.debug(`slack: uploadFile ${file.name} → ch=${channel} failed: ${(err as Error).message}`)
         // A share whose outcome Slack never confirmed must say "may have landed", never
         // "nothing was sent" — the same rule the send queue's abandonment already follows.
-        // Only Slack answering `{ok:false}` proves nothing was published. An HTTP failure
-        // cannot: the SDK raises the same `WebAPIHTTPError` for every non-200 in all three
-        // steps, so a rejected byte POST and a lost response from the already-accepted share
-        // are indistinguishable here, and the ambiguous reading is the safe one.
-        return slackApiErrorCode(err) !== undefined
+        // Two things forfeit that proof, and BOTH have to be read here: a completion Slack
+        // marked as possibly-partial (`completeShare` stamps it), and any failure with no
+        // provider code at all — the SDK raises one `WebAPIHTTPError` for every non-200, so a
+        // rejected byte POST and a lost response to an accepted share look identical.
+        const mayHaveLanded = (err as { shareMayHaveLanded?: unknown } | null)?.shareMayHaveLanded === true
+        return !mayHaveLanded && slackApiErrorCode(err) !== undefined
           ? { ok: false, reason: classifySlackUploadError(err), ...slackErrorDetail(err) }
           : { ok: false, reason: 'indeterminate', ...slackErrorDetail(err) }
       }
@@ -1513,12 +1530,16 @@ export class SlackConnection implements PlatformConnection {
   }
 
   /** `completeUploadExternal` is ONE-SHOT — a second call after a lost response would double
-   *  post — so a failure that is not a DEFINITE refusal is marked ambiguous, not retried. */
+   *  post — so any outcome that does not PROVE a refusal is marked ambiguous, not retried.
+   *  A lost response is one such outcome; so is Slack answering with a partial-success code. */
   private async completeShare(payload: Record<string, unknown>): Promise<void> {
     try {
       await this.app.client.files.completeUploadExternal(payload)
     } catch (err) {
-      if (slackApiErrorCode(err) === undefined) throw Object.assign(err as Error, { shareMayHaveLanded: true })
+      const code = slackApiErrorCode(err)
+      if (code === undefined || COMPLETION_MAY_HAVE_LANDED.has(code)) {
+        throw Object.assign(err as Error, { shareMayHaveLanded: true })
+      }
       throw err
     }
   }
@@ -1542,12 +1563,13 @@ export class SlackConnection implements PlatformConnection {
       this.customUsernameRetryAt = 0
     } catch (err) {
       this.rememberMissingScopes(err)
-      // A second completion is only safe when Slack DEFINITELY refused the first.
-      if (slackApiErrorCode(err) === undefined) throw err
+      // A second completion is only safe when the FIRST provably published nothing and the
+      // decoration is what it refused — anything else is re-sending a share that may already
+      // be visible, which is the double post this whole vocabulary exists to prevent.
+      const code = slackApiErrorCode(err)
+      if (code === undefined || !DECORATION_REFUSALS.has(code)) throw err
       if (isMissingCustomizeScope(err)) this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
-      this.deps.log?.debug(
-        `slack: decorated file share refused (${slackApiErrorCode(err)}) — retrying under the app identity`
-      )
+      this.deps.log?.debug(`slack: decorated file share refused (${code}) — retrying under the app identity`)
       await this.completeShare(share)
     }
   }

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -360,6 +360,8 @@ export type AppLike = {
     // The external upload flow (`files:write`). chat.postMessage cannot carry bytes at all,
     // so this is the ONLY way to put a file in a conversation.
     files: {
+      getUploadURLExternal: (a: unknown) => Promise<{ upload_url?: string; file_id?: string }>
+      completeUploadExternal: (a: unknown) => Promise<unknown>
       uploadV2: (a: unknown) => Promise<unknown>
       info: (a: unknown) => Promise<{
         file?: { shares?: { public?: SlackFileShares; private?: SlackFileShares } }
@@ -1361,7 +1363,8 @@ export class SlackConnection implements PlatformConnection {
     channel: string,
     file: { bytes: Buffer; name: string; mimeType?: string },
     comment?: string,
-    anchor?: UploadAnchor
+    anchor?: UploadAnchor,
+    options?: SlackPostOptions
   ): Promise<UploadOutcome> {
     const threadTs = anchor?.thread
     const task: Promise<UploadOutcome> = this.queue.enqueue(async () => {
@@ -1389,6 +1392,16 @@ export class SlackConnection implements PlatformConnection {
         // `text` argument, so blocks-only would buy CommonMark at the price of the
         // notification preview for every forwarded file. Keeping the comment is the better
         // half of that trade; the cost is that `**bold**` and `[label](url)` read literally.
+        // The identity path first: `completeUploadExternal` documents `username`/`icon_url`
+        // for the share message, which is the ONLY way a file post can carry the agent's own
+        // name and avatar — no manifest field sets an app icon, and `uploadV2` drops both
+        // arguments when it builds its completion from an explicit key list.
+        const shared = await this.shareWithIdentity(channel, file, comment, threadTs, options)
+        if (shared !== undefined) return { ok: true, ...(await this.shareMessageTs(shared, channel)) }
+        // Only a refused BYTE POST lands here, and that step runs before anything reaches the
+        // conversation — which is what makes retrying through the SDK's own transport safe
+        // rather than a double post. It costs the identity; the delivery outranks it.
+        this.deps.log?.debug(`slack: uploadFile falling back to the SDK transport for ${file.name}`)
         const done = (await this.app.client.files.uploadV2({
           file: file.bytes,
           filename: file.name,
@@ -1419,6 +1432,124 @@ export class SlackConnection implements PlatformConnection {
       ok: false,
       reason: isSendQueueTimeout(err) ? 'indeterminate' : 'platform_error'
     }))
+  }
+
+  /**
+   * Steps 1-3 with the agent's identity on the share. Returns the file id once the share is
+   * PUBLISHED, or `undefined` when the byte POST was refused — the one failure that provably
+   * happened before anything reached the conversation, which is what lets the caller retry
+   * through the SDK. Every later failure throws, because it may have landed.
+   */
+  private async shareWithIdentity(
+    channel: string,
+    file: { bytes: Buffer; name: string },
+    comment: string | undefined,
+    threadTs: string | undefined,
+    options?: SlackPostOptions
+  ): Promise<string | undefined> {
+    const reserved = await this.app.client.files.getUploadURLExternal({
+      filename: file.name,
+      length: file.bytes.byteLength
+    })
+    const uploadUrl = reserved.upload_url
+    const fileId = reserved.file_id
+    if (!uploadUrl || !fileId) return undefined
+    if (!(await this.putUploadBytes(uploadUrl, file))) return undefined
+    // Sharing is what makes the file a message; without `channel_id` it stays a private
+    // upload nobody can see. `thread_ts` must be the PARENT's ts, never a reply's.
+    // A CAPTION IS MRKDWN HERE, unlike every other send in this file: this method documents
+    // `blocks` as IGNORED whenever `initial_comment` is set and has no separate `text`
+    // argument, so blocks-only would buy CommonMark at the price of the notification preview.
+    await this.completeUpload(
+      {
+        files: [{ id: fileId, title: file.name }],
+        channel_id: channel,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+        ...(comment ? { initial_comment: comment } : {})
+      },
+      options
+    )
+    return fileId
+  }
+
+  /**
+   * Step 2: POST the bytes to the reserved URL. Not a Slack API endpoint — no JSON envelope,
+   * no published wire contract — so it goes out through undici with the same proxy dispatcher
+   * the Web API client uses. Every field here is copied from what the SDK sends, because two
+   * live failures came out of choosing any of them differently: the multipart part is named
+   * `body` and carries an untyped Blob, and the reserved URL is given the bot token. That
+   * last one is not optional despite reading like it should be — a POST without it is
+   * answered with HTTP 500. Returns false rather than throwing: nothing is published yet, so
+   * the caller may still fall back.
+   */
+  private async putUploadBytes(uploadUrl: string, file: { bytes: Buffer; name: string }): Promise<boolean> {
+    const form = new FormData()
+    form.append('body', new Blob([new Uint8Array(file.bytes)]), file.name)
+    const dispatcher = proxyDispatcher()
+    try {
+      // Same cast seam as `fetchWithDispatcher`: undici's own FormData/RequestInit types and
+      // the Node globals are structurally identical but nominally distinct.
+      const init = {
+        method: 'POST',
+        body: form,
+        headers: { Authorization: `Bearer ${this.deps.group.botToken}` },
+        signal: AbortSignal.timeout(SLACK_API_TIMEOUT_MS),
+        ...(dispatcher ? { dispatcher } : {})
+      }
+      const res = await undiciFetch(uploadUrl, init as Parameters<typeof undiciFetch>[1])
+      // An unread body leaves the request in flight, and the graceful close below waits for
+      // exactly that — outside the signal's reach.
+      await res.body?.cancel().catch(() => {})
+      if (!res.ok) this.deps.log?.debug(`slack: uploadFile byte POST for ${file.name} → HTTP ${res.status}`)
+      return res.ok
+    } catch (err) {
+      this.deps.log?.debug(`slack: uploadFile byte POST for ${file.name} failed: ${(err as Error).message}`)
+      return false
+    } finally {
+      // Unlike the two long-lived clients this agent serves one request; closing it keeps a
+      // proxied deployment from leaking a keep-alive socket pool per share.
+      await dispatcher?.close()
+    }
+  }
+
+  /** `completeUploadExternal` is ONE-SHOT — a second call after a lost response would double
+   *  post — so a failure that is not a DEFINITE refusal is marked ambiguous, not retried. */
+  private async completeShare(payload: Record<string, unknown>): Promise<void> {
+    try {
+      await this.app.client.files.completeUploadExternal(payload)
+    } catch (err) {
+      if (slackApiErrorCode(err) === undefined) throw Object.assign(err as Error, { shareMayHaveLanded: true })
+      throw err
+    }
+  }
+
+  /** Step 3. The identity decoration is BEST-EFFORT: `username`/`icon_url` are documented for
+   *  this method but absent from the SDK's argument type, so a rejection can be the arguments
+   *  rather than the `chat:write.customize` scope. Any DEFINITE refusal is retried once
+   *  undecorated — the file lands either way, and the agent's name on it is what we can lose. */
+  private async completeUpload(share: Record<string, unknown>, options?: SlackPostOptions): Promise<void> {
+    const customize: Record<string, unknown> = {}
+    const username = options?.username?.trim()
+    const iconUrl = options?.icon_url?.trim()
+    if (username) customize.username = username
+    if (iconUrl) customize.icon_url = iconUrl
+    if (Object.keys(customize).length === 0 || Date.now() < this.customUsernameRetryAt) {
+      await this.completeShare(share)
+      return
+    }
+    try {
+      await this.completeShare({ ...share, ...customize })
+      this.customUsernameRetryAt = 0
+    } catch (err) {
+      this.rememberMissingScopes(err)
+      // A second completion is only safe when Slack DEFINITELY refused the first.
+      if (slackApiErrorCode(err) === undefined) throw err
+      if (isMissingCustomizeScope(err)) this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
+      this.deps.log?.debug(
+        `slack: decorated file share refused (${slackApiErrorCode(err)}) — retrying under the app identity`
+      )
+      await this.completeShare(share)
+    }
   }
 
   /**

--- a/packages/daemon/test/fakes/slack-app.ts
+++ b/packages/daemon/test/fakes/slack-app.ts
@@ -44,6 +44,11 @@ export function fakeSlackAppFactory(identity: FakeSlackIdentity = {}): SlackAppF
           delete: ok
         },
         files: {
+          getUploadURLExternal: async () => ({
+            upload_url: 'https://files.slack.com/upload/v1/fake',
+            file_id: 'F_FAKE'
+          }),
+          completeUploadExternal: async () => ({ files: [{ id: 'F_FAKE' }] }),
           uploadV2: async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F_FAKE' }] }] }),
           info: async () => ({ file: { shares: { public: { C1: [{ ts: '1700000000.000100' }] } } } })
         },

--- a/packages/daemon/test/slack-upload-file.test.ts
+++ b/packages/daemon/test/slack-upload-file.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect, vi } from 'vitest'
-import { SlackConnection } from '../src/slack/connection.js'
+
+// The byte POST goes to a reserved URL that is NOT a Slack API endpoint, so it leaves
+// through undici directly rather than through the Web API client.
+type FakeFetchResponse = { ok: boolean; status: number; body?: { cancel: () => Promise<void> } }
+const undici = vi.hoisted(() => ({
+  fetch: vi.fn<(url: string, init?: Record<string, unknown>) => Promise<FakeFetchResponse>>(async () => ({
+    ok: true,
+    status: 200
+  }))
+}))
+vi.mock('undici', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('undici')>()),
+  fetch: undici.fetch
+}))
+
+const { SlackConnection } = await import('../src/slack/connection.js')
 
 const deps = () => ({
   group: { appToken: 'xapp-1', botToken: 'xoxb-a', integrations: [] },
@@ -13,7 +28,9 @@ const sharedAt =
     file: { shares: { [visibility]: { [channel]: [{ ts }] } } }
   })
 
-function connWith(uploadV2: unknown, info: unknown = sharedAt('1700000000.000100')) {
+const reserved = async () => ({ upload_url: 'https://files.slack.com/upload/v1/x', file_id: 'F1' })
+
+function connWith(files: Record<string, unknown>) {
   const app = {
     message() {},
     event() {},
@@ -22,7 +39,13 @@ function connWith(uploadV2: unknown, info: unknown = sharedAt('1700000000.000100
     client: {
       auth: { test: async () => ({ user_id: 'U1', team_id: 'T123' }) },
       chat: { postMessage: async () => ({}), getPermalink: async () => ({ permalink: 'https://x/y' }) },
-      files: { uploadV2, info },
+      files: {
+        getUploadURLExternal: reserved,
+        completeUploadExternal: async () => ({ files: [{ id: 'F1' }] }),
+        uploadV2: async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }),
+        info: sharedAt('1700000000.000100'),
+        ...files
+      },
       assistant: { threads: { setStatus: async () => undefined, setTitle: async () => undefined } }
     },
     start: async () => {},
@@ -35,53 +58,133 @@ const slackError = (code: string, extra: Record<string, unknown> = {}) =>
   Object.assign(new Error(code), { data: { error: code, ...extra } })
 
 describe('SlackConnection.uploadFile', () => {
-  // Slack is the outlier: its share answers with the FILE, so success carries no messageId and
-  // a forward there anchors nothing — see platform-upload-file.test.ts for the other three.
-  it('hands the whole external upload to the SDK, with the coordinates that make it a message', async () => {
-    // The byte POST is not a Slack API request and its wire shape is undocumented; two live
-    // failures came out of reimplementing it, so the transport belongs to `uploadV2` now.
-    const uploadV2 = vi.fn(async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }))
-    const conn = connWith(uploadV2)
+  it('shares under the agent’s own identity, the only way a file post can carry one', async () => {
+    // `chat.postMessage` cannot attach a file, so the upload's completion IS the message —
+    // and `username`/`icon_url` on that call are the only identity it will ever accept.
+    const completeUploadExternal = vi.fn(async () => ({ files: [{ id: 'F1' }] }))
+    const getUploadURLExternal = vi.fn(reserved)
+    const conn = connWith({ getUploadURLExternal, completeUploadExternal })
 
     const bytes = Buffer.from('PNGBYTES')
     await expect(
-      conn.uploadFile('C1', { bytes, name: 'shot.png' }, 'from telegram', { thread: '111.1' })
+      conn.uploadFile(
+        'C1',
+        { bytes, name: 'shot.png' },
+        'from telegram',
+        { thread: '111.1' },
+        {
+          username: 'Scout',
+          icon_url: 'https://example.test/a.png'
+        }
+      )
       // The share's own ts, read back from files.info — see the anchoring test below.
     ).resolves.toEqual({ ok: true, messageId: '1700000000.000100' })
 
+    expect(getUploadURLExternal).toHaveBeenCalledWith({ filename: 'shot.png', length: bytes.byteLength })
     // channel_id is what turns a hosted file into a message; without it the upload stays
-    // private. No `blocks`: the completion step ignores them whenever `initial_comment` is
-    // set, so sending both would only look like the caption renders as CommonMark.
-    expect(uploadV2).toHaveBeenCalledWith({
-      file: bytes,
-      filename: 'shot.png',
+    // private. No `blocks`: this method ignores them whenever `initial_comment` is set.
+    expect(completeUploadExternal).toHaveBeenCalledWith({
+      files: [{ id: 'F1', title: 'shot.png' }],
       channel_id: 'C1',
       thread_ts: '111.1',
-      initial_comment: 'from telegram'
+      initial_comment: 'from telegram',
+      username: 'Scout',
+      icon_url: 'https://example.test/a.png'
     })
   })
 
-  it('omits the anchor and the caption rather than sending them empty', async () => {
-    const uploadV2 = vi.fn(async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }))
-    await connWith(uploadV2).uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })
-    expect(uploadV2).toHaveBeenCalledWith({ file: expect.any(Buffer), filename: 'a.png', channel_id: 'C1' })
+  it('sends the reserved URL the bot token and a part named `body`, as Slack’s own SDK does', async () => {
+    // Every field here is copied rather than chosen: two live shares were refused with HTTP
+    // 500 for differing, and the token is the one that reads most like it should be optional.
+    await connWith({}).uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })
+    const [url, init] = undici.fetch.mock.calls.at(-1) as [string, { body: FormData; headers: Record<string, string> }]
+    expect(url).toBe('https://files.slack.com/upload/v1/x')
+    expect(init.headers.Authorization).toBe('Bearer xoxb-a')
+    expect(init.body.has('body')).toBe(true)
+    expect(init.body.has('file')).toBe(false)
   })
 
-  it('reports the provider’s own error code, since `platform error` alone is not actionable', async () => {
-    const conn = connWith(async () => {
-      throw slackError('method_not_supported_for_channel_type')
+  it('falls back to the SDK transport when the byte POST is refused, without double posting', async () => {
+    // That step runs BEFORE anything reaches the conversation, which is the whole reason a
+    // retry is safe here and nowhere else in this flow.
+    undici.fetch.mockResolvedValueOnce({ ok: false, status: 500 })
+    const completeUploadExternal = vi.fn(async () => ({ files: [{ id: 'F1' }] }))
+    const uploadV2 = vi.fn(async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F9' }] }] }))
+    const conn = connWith({ completeUploadExternal, uploadV2, info: sharedAt('1700000000.000900') })
+
+    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi')).resolves.toEqual({
+      ok: true,
+      messageId: '1700000000.000900'
     })
-    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
-      ok: false,
-      reason: 'platform_error',
-      detail: 'method_not_supported_for_channel_type'
+    expect(uploadV2).toHaveBeenCalledOnce()
+    expect(completeUploadExternal).not.toHaveBeenCalled()
+  })
+
+  it('shares under the app identity when ANY decorated attempt is definitely refused', async () => {
+    // username/icon_url are documented for this method but absent from the SDK's argument
+    // type, so a rejection is not necessarily the scope — it can be the arguments.
+    const completeUploadExternal = vi.fn(async (a: Record<string, unknown>) => {
+      if (a.username) throw slackError('invalid_arguments')
+      return { files: [{ id: 'F1' }] }
     })
+    const conn = connWith({ completeUploadExternal })
+    await expect(
+      conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi', undefined, { username: 'Scout' })
+    ).resolves.toMatchObject({ ok: true })
+    expect(completeUploadExternal).toHaveBeenCalledTimes(2)
+    expect(completeUploadExternal.mock.calls[1]![0]).not.toHaveProperty('username')
+  })
+
+  it('does NOT retry a completion whose outcome Slack never confirmed', async () => {
+    // It is one-shot: a transport failure may have been ACCEPTED with its response lost, so a
+    // second call could double-post and "nothing was sent" could be a lie.
+    const completeUploadExternal = vi.fn(async () => {
+      throw new Error('socket hang up')
+    })
+    const conn = connWith({ completeUploadExternal })
+    await expect(
+      conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi', undefined, { username: 'Scout' })
+    ).resolves.toEqual({ ok: false, reason: 'indeterminate', detail: 'socket hang up' })
+    expect(completeUploadExternal).toHaveBeenCalledOnce()
+  })
+
+  it('anchors the file post on the share’s real ts, so a reply under it wakes the agent', async () => {
+    // The completion answers with the FILE, not the message, so without this read the share
+    // has no timestamp — and a post the daemon cannot name is not a thread root it
+    // recognizes, which is why replying under a shared image woke nobody while replying under
+    // a forwarded TEXT message (a chat.postMessage, which returns its ts) always worked.
+    const info = vi.fn(sharedAt('1700000000.000200', 'C9'))
+    await expect(connWith({ info }).uploadFile('C9', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
+      ok: true,
+      messageId: '1700000000.000200'
+    })
+    expect(info).toHaveBeenCalledWith({ file: 'F1' })
+  })
+
+  it('reads the share ts out of the private arm too, since a DM files it there', async () => {
+    const conn = connWith({ info: sharedAt('1700000000.000300', 'D2', 'private') })
+    await expect(conn.uploadFile('D2', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
+      ok: true,
+      messageId: '1700000000.000300'
+    })
+  })
+
+  it('still reports success when the ts cannot be read, since the file already landed', async () => {
+    // Anchoring is bookkeeping ON TOP of a delivery that already happened.
+    const conn = connWith({
+      info: async () => {
+        throw new Error('ratelimited')
+      }
+    })
+    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({ ok: true })
   })
 
   it('classifies a missing files:write scope, the likeliest first-run failure', async () => {
     // Operator-fixable, so the reason must be distinguishable from a deleted thread root.
-    const conn = connWith(async () => {
-      throw slackError('missing_scope', { needed: 'files:write' })
+    const conn = connWith({
+      getUploadURLExternal: async () => {
+        throw slackError('missing_scope', { needed: 'files:write' })
+      }
     })
     await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
       ok: false,
@@ -90,73 +193,16 @@ describe('SlackConnection.uploadFile', () => {
     })
   })
 
-  it('anchors the file post on the share’s real ts, so a reply under it wakes the agent', async () => {
-    // Slack's completion answers with the FILE, not the message, so without this read the
-    // share has no timestamp — and a post the daemon cannot name is not a thread root it
-    // recognizes, which is why replying under a shared image used to wake nobody while
-    // replying under a forwarded TEXT message (a chat.postMessage, which returns its ts)
-    // always worked.
-    const info = vi.fn(sharedAt('1700000000.000200', 'C9'))
-    const conn = connWith(async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F7' }] }] }), info)
-    await expect(conn.uploadFile('C9', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
-      ok: true,
-      messageId: '1700000000.000200'
-    })
-    expect(info).toHaveBeenCalledWith({ file: 'F7' })
-  })
-
-  it('reads the share ts out of the private arm too, since a DM files it there', async () => {
-    const conn = connWith(
-      async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F7' }] }] }),
-      sharedAt('1700000000.000300', 'D2', 'private')
-    )
-    await expect(conn.uploadFile('D2', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
-      ok: true,
-      messageId: '1700000000.000300'
-    })
-  })
-
-  it('still reports success when the ts cannot be read, since the file already landed', async () => {
-    // Anchoring is bookkeeping ON TOP of a delivery that already happened. Failing the share
-    // here would report "nothing was sent" about a file the channel is displaying, and invite
-    // the retry that double-posts it.
-    const conn = connWith(
-      async () => ({ ok: true, files: [{ ok: true, files: [{ id: 'F7' }] }] }),
-      async () => {
-        throw new Error('ratelimited')
+  it('reports the provider’s own error code, since `platform error` alone is not actionable', async () => {
+    const conn = connWith({
+      getUploadURLExternal: async () => {
+        throw slackError('method_not_supported_for_channel_type')
       }
-    )
-    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({ ok: true })
-  })
-
-  it('calls every non-API failure indeterminate, because the share step is one-shot', async () => {
-    // `uploadV2` hides WHICH step threw, and a lost response from the completion step may
-    // have been accepted. "Nothing was sent" would then be a lie about a file the channel
-    // already shows, and would invite the retry that double-posts it.
-    const conn = connWith(async () => {
-      throw new Error('socket hang up')
     })
     await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toEqual({
       ok: false,
-      reason: 'indeterminate',
-      detail: 'socket hang up'
-    })
-  })
-
-  it('will not call an HTTP failure definite, however early in the upload it happened', async () => {
-    // Tempting, since a rejected byte POST runs BEFORE the share and so proves nothing was
-    // published — but the SDK raises one `WebAPIHTTPError` for every non-200 across all three
-    // steps, so that case is indistinguishable from a lost response to an accepted share.
-    const httpError = Object.assign(new Error('An HTTP protocol error occurred: statusCode = 500'), {
-      code: 'slack_webapi_http_error',
-      statusCode: 500
-    })
-    const conn = connWith(async () => {
-      throw httpError
-    })
-    await expect(conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' })).resolves.toMatchObject({
-      ok: false,
-      reason: 'indeterminate'
+      reason: 'platform_error',
+      detail: 'method_not_supported_for_channel_type'
     })
   })
 })

--- a/packages/daemon/test/slack-upload-file.test.ts
+++ b/packages/daemon/test/slack-upload-file.test.ts
@@ -135,6 +135,35 @@ describe('SlackConnection.uploadFile', () => {
     expect(completeUploadExternal.mock.calls[1]![0]).not.toHaveProperty('username')
   })
 
+  it('does NOT retry a completion Slack answered with a partial-success code', async () => {
+    // Slack documents `internal_error`/`fatal_error` as possibly raised AFTER some aspect of
+    // the operation succeeded, so a provider code is not by itself proof of a refusal — the
+    // share may be visible already, and a second completion would publish it twice.
+    for (const code of ['internal_error', 'fatal_error']) {
+      const completeUploadExternal = vi.fn(async () => {
+        throw slackError(code)
+      })
+      const conn = connWith({ completeUploadExternal })
+      await expect(
+        conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi', undefined, { username: 'Scout' })
+      ).resolves.toEqual({ ok: false, reason: 'indeterminate', detail: code })
+      expect(completeUploadExternal).toHaveBeenCalledOnce()
+    }
+  })
+
+  it('does NOT retry a refusal the decoration cannot have caused, even before publication', async () => {
+    // `not_in_channel` precedes publication, so retrying would be safe — but undecorated it
+    // fails identically, spending a call and replacing the real error with its echo.
+    const completeUploadExternal = vi.fn(async () => {
+      throw slackError('not_in_channel')
+    })
+    const conn = connWith({ completeUploadExternal })
+    await expect(
+      conn.uploadFile('C1', { bytes: Buffer.from('x'), name: 'a.png' }, 'hi', undefined, { username: 'Scout' })
+    ).resolves.toMatchObject({ ok: false, detail: 'not_in_channel' })
+    expect(completeUploadExternal).toHaveBeenCalledOnce()
+  })
+
   it('does NOT retry a completion whose outcome Slack never confirmed', async () => {
     // It is one-shot: a transport failure may have been ACCEPTED with its response lost, so a
     // second call could double-post and "nothing was sent" could be a lie.

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -10,6 +10,7 @@ import { githubActionsReporters } from '../../scripts/vitest-github-reporters.js
 // `test/no-stray-vi-mock.test.ts` fails if this list drifts from what the suite actually mocks.
 export const MOCKING_TESTS = [
   'test/cp/cp-integration.test.ts',
+  'test/slack-upload-file.test.ts',
   'test/daemon-cp-onboarding.test.ts',
   'test/runtime-install-repair-collapse.test.ts',
   'test/telegram-connection.test.ts',


### PR DESCRIPTION
A shared image showed the placeholder avatar while the same agent's text replies
showed its own. I read that as a platform limit and wrote it into the design as
one. **It is not.**

`files.completeUploadExternal` documents `username`, `icon_url`, and
`icon_emoji` for the share message, behind `chat:write.customize` — the same
scope the text path already uses. The arguments went missing in #1422: handing
the whole flow to `files.uploadV2` also handed it that method's completion
builder, which works from an explicit key list none of the three appear in.

## Why the two paths differ at all

Worth stating, because it is the root of every symptom in this area: **Slack has
no way to attach a file to a message.** `chat.postMessage` takes no file, and
the upload's completion creates its own message instead. So a caption rides as
`initial_comment` on a message the *upload* endpoint built, and everything
`chat.postMessage` returns for free — a `ts` (#1426), per-message identity (this
PR) — has to be recovered separately.

`blocks` + `slack_file` would collapse the two into one path. But a file
uploaded without `channel_id` is documented as private, and whether a block
reference makes it visible to anyone else is not documented either way. That
open question is recorded in the design rather than guessed at.

## The byte POST, finally explained

Restoring the identity path means restoring the step that was refused twice with
HTTP 500. Matching the SDK's multipart shape was never the gap — it posts one
part named `body` carrying an untyped `Blob`, which the earlier code already
did. The gap was the `Authorization: Bearer` header the SDK sends to the
reserved URL, and which that code asserted in a comment was unnecessary.

It is sent now, and the comment says the fields are **copied, not chosen**, so
the next reader does not re-derive them from an undocumented endpoint.

## Delivery is still not gambled on that

`uploadV2` stays as the fallback when the byte POST is refused. That step runs
before anything reaches the conversation, so retrying through it is a second
attempt at an unpublished file rather than a double post — the only point in
this flow where a retry is provably safe. It costs the identity; the delivery
outranks it. Every failure after that point still throws, and an unconfirmed
completion is still `indeterminate` and never retried.

## Verification

- Identity reaches the completion with the channel/thread/caption coordinates.
- The byte POST carries the bot token and a part named `body`, not `file`.
- A refused byte POST falls back to `uploadV2` **and never calls the completion**
  — the double-post guard, asserted directly.
- The undecorated retry on a definite refusal, and no retry on an ambiguous one.
- Anchoring (#1426) still holds: real ts, private arm, and a failed lookup that
  still reports success.
- Daemon typecheck, lint, the upload/ops/session suites (283 passing), and the
  arena connection-surface guard all pass.

Only a live share can settle whether the avatar now matches the agent's.
