### PR TITLE
feat(web): key the GitLab card by bot

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1541,20 +1541,30 @@ administers — the shape the GitHub card already has. It shows:
 
 - connected GitLab username and GitLab.com host;
 - OAuth state: connected, reconnect required, or disconnected;
-- the organization's bots, one row per agent account — avatar, display
-  name, `@username` linking to its GitLab profile, top-level group, and
-  account health — mirroring the chat-platform cards, where the bot is the
-  row;
+- the organization's bots, one row per agent account — the agent's icon and
+  name linking to it, `@username` linking to its GitLab profile, top-level
+  group, and account health — mirroring the chat-platform cards, where the
+  bot is the row;
 - under each bot, the projects it is a member of: path, role, binding state,
-  and webhook state (not needed, installed, repairing, or failed), with the
-  project-level actions — repair, remove, transfer administration — on that
-  project line;
-- a final "projects without a bot" group for every managed binding no
-  account is currently a member of — a binding outlives its last consumer
-  until it is removed, and it keeps its state and the same project-level
-  actions there;
+  and why the bot holds it — its workspace access, the enabled trigger
+  families, or both. Naming the reason is what keeps a bot whose triggers
+  were deleted, but whose workspace still uses the project, from reading as
+  a leftover. The project-level actions sit on that project line, and a
+  project two bots hold appears under both. An account with no project left
+  still shows, with its health: a retiring one says it is being removed, a
+  refused one says it is not a member of anything yet and waits for repair.
+  A managed project no bot is a member of keeps its own group at the end,
+  since the binding still owns the webhook and the claim;
+- webhook state only where it needs attention — repairing or failed. A
+  healthy webhook, and one that a project with no trigger never needed, show
+  nothing at all: not wanting ingress is a resting state, not a condition to
+  report;
 - credential expiry and rotation warning without token values; and
-- actions to reconnect, disconnect, or remove a released connection.
+- actions to reconnect, repair, remove a project, disconnect, or remove a
+  released connection. Taking a project's administration over is offered only
+  where administration has lost its authority — the administering connection
+  is disconnected or removed, or the binding is awaiting cleanup and needs an
+  account to finish it — never on a healthy row.
 
 The agent detail page gives GitLab no surface of its own: the bot identity
 appears where every platform's does — inside the integration row, the way a

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1835,7 +1835,9 @@ export const GitlabProjectBindingDto = z.object({
       stateReason: z.string().nullable()
     })
   ),
-  webhookInstalled: z.boolean(),
+  /** The managed webhook's state (§11.1). `not_needed` is NORMAL — a project with no enabled
+   *  trigger wants no ingress — so the console badges only the two that need attention. */
+  webhookState: z.enum(['not_needed', 'installed', 'repairing', 'failed']),
   credentialEpoch: z.string(),
   createdAt: z.string()
 })
@@ -1846,6 +1848,50 @@ export const GitlabProjectBindingListDto = z.object({ bindings: z.array(GitlabPr
 export const CreateGitlabProjectBody = z.object({
   connectionId: z.string().uuid(),
   projectId: z.string().regex(/^[1-9]\d*$/) // numeric id as a string; the server re-fetches and validates
+})
+
+/** One organization bot for the Integrations card (§18.1): the service account an agent acts as,
+ *  one per top-level group it has a bound project in, plus the projects it is a member of.
+ *  No token material. */
+export const GitlabOrgAccountDto = z.object({
+  id: z.string(),
+  /** The agent whose identity this is; the console joins it to that agent's own name, icon, and page. */
+  agentId: z.string(),
+  rootGroupId: z.string(), // numeric top-level group id, losslessly as a string
+  /** Current path of that top-level group, read off a bound project; null while none is bound. */
+  rootGroupPath: z.string().nullable(),
+  username: z.string(),
+  displayName: z.string().nullable(),
+  userId: z.string().nullable(), // numeric GitLab user id; null until the account exists
+  /** The §8.2 lifecycle vocabulary the binding uses, so the console translates one set. */
+  state: z.enum(['provisioning', 'ready', 'admin_degraded', 'runtime_degraded', 'cleanup_pending']),
+  stateReason: z.string().nullable(),
+  /** `retiring` once the agent's last project in the group went away (§7.2). */
+  lifecycle: z.enum(['active', 'retiring']),
+  /** The bound projects this account is a member of, each with the role its authorization derives
+   *  and WHY it holds it — a workspace, triggers, or both. Dropping one reason while the other
+   *  stands must read as a change, never as a bot with no purpose left. */
+  memberships: z.array(
+    z.object({
+      bindingId: z.string(),
+      accessLevel: z.number().int(),
+      /** The agent's workspace on the project and the access it grants; null when it has none. */
+      workspace: z.enum(['read', 'write']).nullable(),
+      /** Comment families the agent's enabled triggers cover here; may be empty. */
+      triggerFamilies: z.array(z.string()),
+      /** How many enabled triggers the agent has on the project. */
+      triggerCount: z.number().int()
+    })
+  )
+})
+export type GitlabOrgAccountDtoT = z.infer<typeof GitlabOrgAccountDto>
+
+export const GitlabOrgAccountListDto = z.object({
+  accounts: z.array(GitlabOrgAccountDto),
+  /** Whether account convergence still owes this organization work: an account mid-flight, a
+   *  membership no consumer justifies, or a consumer with none yet. The console cannot judge
+   *  this — it cannot see an agent's hooks or workspace — so it polls on this answer. */
+  converging: z.boolean()
 })
 
 export const GithubAppDto = z.object({

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -74,7 +74,10 @@ function toDto(r: GitlabConnectionRecord, assignedProjects: number, callerUserId
 function webhookStateOf(r: GitlabProjectBindingRecord, wanted: boolean): GitlabWebhookState {
   if (!wanted) return 'not_needed'
   if (r.webhookId !== null) return 'installed'
-  return r.state === 'provisioning' ? 'repairing' : 'failed'
+  // Wanted but absent. Enabling a trigger commits before the convergence it fires, so a binding
+  // still reporting healthy simply has not been converged for this desire yet — that is transient,
+  // not a fault. Only a run that actually completed and left the binding degraded means failed.
+  return r.state === 'ready' || r.state === 'provisioning' ? 'repairing' : 'failed'
 }
 
 /** One binding with its member accounts (§7.2) — the project's bot identities. */
@@ -136,8 +139,14 @@ function stillConverging(
   accounts: readonly GitlabAgentAccountRecord[],
   bindings: readonly GitlabProjectBindingRecord[],
   consumers: readonly GitlabProjectConsumer[],
-  memberLevels: ReadonlyMap<string, ReadonlyMap<string, number>>
+  memberLevels: ReadonlyMap<string, ReadonlyMap<string, number>>,
+  webhookWanted: (projectId: bigint) => boolean
 ): boolean {
+  // A webhook still being installed is convergence the console must outwait, or a badge that
+  // is only transient would sit there until a reload. A failed one has settled and does not.
+  if (bindings.some((binding) => webhookStateOf(binding, webhookWanted(binding.projectId)) === 'repairing')) {
+    return true
+  }
   if (accounts.some((account) => account.lifecycle !== 'active' || account.state === 'provisioning')) return true
   // Past that guard every account is active and settled, so anything but ready is stuck awaiting Repair.
   const refused = new Set(accounts.filter((account) => account.state !== 'ready').map((account) => account.agentId))
@@ -158,7 +167,9 @@ function stillConverging(
     for (const [agentId, accessLevel] of desired) {
       if (!refused.has(agentId) && actual.get(agentId) !== accessLevel) return true
     }
-    for (const agentId of actual.keys()) if (!desired.has(agentId) && !refused.has(agentId)) return true
+    // A membership no consumer justifies is a detach the saga still owes, whatever shape the
+    // account is in — the refusal exemption covers creation that cannot proceed, never removal.
+    for (const agentId of actual.keys()) if (!desired.has(agentId)) return true
   }
   return false
 }
@@ -363,7 +374,7 @@ export function gitlabRoutes(deps: HttpDeps) {
                 memberships
               }
             }),
-          converging: stillConverging(accounts, bindings, consumers, memberLevels)
+          converging: stillConverging(accounts, bindings, consumers, memberLevels, await webhookWanted(orgId))
         }
       }
     )

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -18,7 +18,8 @@ import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
-import { orgOf, denyViewerWrite } from '../rbac.js'
+import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
+import { OrgId } from '../../domain/ids.js'
 import { Tag } from '../plugins/openapi.js'
 import { GitlabOauthDenied, OAUTH_BROWSER_COOKIE } from '../../gitlab/oauth.service.js'
 import {
@@ -30,12 +31,15 @@ import {
   membershipSatisfies
 } from '../../gitlab/api.js'
 import { GitlabProjectClaimConflict } from '../../persistence/errors.js'
+import { unionGitlabWebhookEvents } from '../../gitlab/webhook-events.js'
 import {
   CreateGitlabProjectBody,
   ErrorDto,
   GitlabConnectionDeleteDto,
   GitlabConnectionListDto,
   GitlabOauthStartDto,
+  GitlabOrgAccountListDto,
+  type GitlabOrgAccountDtoT,
   GitlabProjectBindingDto,
   GitlabProjectBindingListDto,
   GitlabProjectPageDto,
@@ -44,8 +48,11 @@ import {
 import type {
   GitlabAgentAccountRecord,
   GitlabConnectionRecord,
-  GitlabProjectBindingRecord
+  GitlabProjectBindingRecord,
+  GitlabProjectConsumer
 } from '../../persistence/ports.js'
+
+type GitlabWebhookState = 'not_needed' | 'installed' | 'repairing' | 'failed'
 
 function toDto(r: GitlabConnectionRecord, assignedProjects: number, callerUserId: string) {
   return {
@@ -62,8 +69,16 @@ function toDto(r: GitlabConnectionRecord, assignedProjects: number, callerUserId
   }
 }
 
+/** The managed webhook's state (§11.1). A project no enabled trigger points at wants no ingress
+ *  at all, which is normal — never the same fact as one that was wanted and is missing. */
+function webhookStateOf(r: GitlabProjectBindingRecord, wanted: boolean): GitlabWebhookState {
+  if (!wanted) return 'not_needed'
+  if (r.webhookId !== null) return 'installed'
+  return r.state === 'provisioning' ? 'repairing' : 'failed'
+}
+
 /** One binding with its member accounts (§7.2) — the project's bot identities. */
-function bindingToDto(r: GitlabProjectBindingRecord, accounts: GitlabAgentAccountRecord[]) {
+function bindingToDto(r: GitlabProjectBindingRecord, accounts: GitlabAgentAccountRecord[], webhookWanted: boolean) {
   return {
     id: r.id,
     projectId: r.projectId.toString(),
@@ -80,10 +95,72 @@ function bindingToDto(r: GitlabProjectBindingRecord, accounts: GitlabAgentAccoun
       state: account.state,
       stateReason: account.stateReason
     })),
-    webhookInstalled: r.webhookId !== null,
+    webhookState: webhookStateOf(r, webhookWanted),
     credentialEpoch: r.credentialEpoch.toString(),
     createdAt: r.createdAt.toISOString()
   }
+}
+
+/** One agent account (§7.2) — the group is a bare number on the row, so the readable heading comes off a bound project. */
+function accountToDto(
+  r: GitlabAgentAccountRecord,
+  bindingIds: readonly string[],
+  projectPaths: ReadonlyMap<string, string>
+) {
+  let rootGroupPath: string | null = null
+  for (const bindingId of bindingIds) {
+    const segment = projectPaths.get(bindingId)?.split('/')[0]
+    if (segment) {
+      rootGroupPath = segment
+      break
+    }
+  }
+  return {
+    id: r.id,
+    rootGroupId: r.rootGroupId.toString(),
+    rootGroupPath,
+    username: r.username,
+    displayName: r.displayName,
+    userId: r.serviceAccountUserId?.toString() ?? null,
+    state: r.state,
+    stateReason: r.stateReason,
+    lifecycle: r.lifecycle
+  }
+}
+
+/** Whether account convergence still owes the organization work (§18.1). True while an account is
+ *  mid-flight, or a binding's memberships differ from what its consumers want — the ROLE included,
+ *  since dropping one authorization downgrades a surviving membership rather than removing it.
+ *  A refused account is EXCLUDED: it waits for a human to run Repair, and counting it would ask forever. */
+function stillConverging(
+  accounts: readonly GitlabAgentAccountRecord[],
+  bindings: readonly GitlabProjectBindingRecord[],
+  consumers: readonly GitlabProjectConsumer[],
+  memberLevels: ReadonlyMap<string, ReadonlyMap<string, number>>
+): boolean {
+  if (accounts.some((account) => account.lifecycle !== 'active' || account.state === 'provisioning')) return true
+  // Past that guard every account is active and settled, so anything but ready is stuck awaiting Repair.
+  const refused = new Set(accounts.filter((account) => account.state !== 'ready').map((account) => account.agentId))
+  const byProject = new Map<string, string>(bindings.map((binding) => [binding.projectId.toString(), binding.id]))
+  const wanted = new Map<string, Map<string, number>>()
+  for (const consumer of consumers) {
+    const bindingId = byProject.get(consumer.projectId.toString())
+    // A consumer of a project this organization does not manage owes nothing here.
+    if (!bindingId) continue
+    const holders = wanted.get(bindingId) ?? new Map<string, number>()
+    holders.set(consumer.agentId, consumer.accessLevel)
+    wanted.set(bindingId, holders)
+  }
+  for (const binding of bindings) {
+    const desired = wanted.get(binding.id) ?? new Map<string, number>()
+    const actual = memberLevels.get(binding.id) ?? new Map<string, number>()
+    // Absent and held-at-the-wrong-role are the same debt: the level the saga would write differs.
+    for (const [agentId, accessLevel] of desired) {
+      if (!refused.has(agentId) && actual.get(agentId) !== accessLevel) return true
+    }
+    for (const agentId of actual.keys()) if (!desired.has(agentId) && !refused.has(agentId)) return true
+  }
+  return false
 }
 
 /** Upstream trouble is upstream trouble, not policy: 429 stays 429, the rest 502. */
@@ -107,6 +184,13 @@ export function gitlabRoutes(deps: HttpDeps) {
     const gitlab = deps.gitlab
     if (!gitlab) return
     const r = app.withTypeProvider<ZodTypeProvider>()
+
+    // Whether a project wants ingress, from the same authority the provisioner converges against:
+    // one org-wide hook read, unioned per project, so a route never re-derives the rule.
+    const webhookWanted = async (orgId: string): Promise<(projectId: bigint) => boolean> => {
+      const hooks = await deps.repos.hook.listForOrgKind(OrgId(orgId), 'gitlab')
+      return (projectId) => unionGitlabWebhookEvents(hooks, projectId) !== null
+    }
 
     r.post(
       '/gitlab/oauth/start',
@@ -212,6 +296,79 @@ export function gitlabRoutes(deps: HttpDeps) {
     )
 
     r.get(
+      '/gitlab/accounts',
+      {
+        schema: {
+          tags: [Tag.GitLab],
+          summary: 'List the organization’s GitLab bot accounts',
+          description:
+            'Every service account this organization owns on GitLab.com (§7.2), with the agent it acts for, its top-level group, its health, and the bound projects it is a member of. The Integrations card keys its rows by this (§18.1). `converging` reports whether membership convergence still owes the organization work, so the console can stop asking once it does not. Visibility-gated: a bot belonging to an agent the caller cannot see is absent, exactly as that agent is. Never token material.',
+          operationId: 'listGitlabAccounts',
+          response: { 200: GitlabOrgAccountListDto }
+        }
+      },
+      async (req) => {
+        const orgId = orgOf(req)
+        const accounts = await deps.repos.gitlabAgentAccount.listForOrg(orgId)
+        const bindings = await deps.repos.gitlabProjectBinding.listForOrg(orgId)
+        if (accounts.length === 0 && bindings.length === 0) return { accounts: [], converging: false }
+        const visible = new Set<string>((await deps.repos.agent.list(orgId, ctxOf(req))).map((agent) => agent.id))
+        const projectPaths = new Map(bindings.map((binding) => [binding.id, binding.projectPath]))
+        // Walking the bindings — not the accounts — is one query per project and carries the access level with it.
+        const byAccount = new Map<string, GitlabOrgAccountDtoT['memberships']>()
+        const consumers = await deps.repos.gitlabAgentAccount.consumersForOrg(orgId)
+        const byProject = new Map<string, string>(bindings.map((b) => [b.projectId.toString(), b.id]))
+        // Why each agent consumes each project, keyed the way a membership is.
+        const reasons = new Map<string, GitlabProjectConsumer>()
+        for (const consumer of consumers) {
+          const bindingId = byProject.get(consumer.projectId.toString())
+          if (bindingId) reasons.set(`${bindingId}:${consumer.agentId}`, consumer)
+        }
+        const memberLevels = new Map<string, Map<string, number>>()
+        const agentOfAccount = new Map(accounts.map((account) => [account.id, account.agentId]))
+        for (const rows of await Promise.all(
+          bindings.map(async (binding) => deps.repos.gitlabAgentAccount.membershipsForBinding(binding.id))
+        )) {
+          for (const row of rows) {
+            const held = byAccount.get(row.accountId) ?? []
+            const why = reasons.get(`${row.bindingId}:${agentOfAccount.get(row.accountId) ?? ''}`)
+            held.push({
+              bindingId: row.bindingId,
+              accessLevel: row.accessLevel,
+              workspace: why?.workspace ?? null,
+              triggerFamilies: why?.triggerFamilies ?? [],
+              triggerCount: why?.triggerCount ?? 0
+            })
+            byAccount.set(row.accountId, held)
+            const agentId = agentOfAccount.get(row.accountId)
+            if (agentId) {
+              const holders = memberLevels.get(row.bindingId) ?? new Map<string, number>()
+              holders.set(agentId, row.accessLevel)
+              memberLevels.set(row.bindingId, holders)
+            }
+          }
+        }
+        return {
+          accounts: accounts
+            .filter((account) => visible.has(account.agentId))
+            .map((account) => {
+              const memberships = byAccount.get(account.id) ?? []
+              return {
+                ...accountToDto(
+                  account,
+                  memberships.map((membership) => membership.bindingId),
+                  projectPaths
+                ),
+                agentId: account.agentId,
+                memberships
+              }
+            }),
+          converging: stillConverging(accounts, bindings, consumers, memberLevels)
+        }
+      }
+    )
+
+    r.get(
       '/gitlab/projects',
       {
         schema: {
@@ -223,10 +380,14 @@ export function gitlabRoutes(deps: HttpDeps) {
         }
       },
       async (req) => {
-        const rows = await deps.repos.gitlabProjectBinding.listForOrg(orgOf(req))
+        const orgId = orgOf(req)
+        const rows = await deps.repos.gitlabProjectBinding.listForOrg(orgId)
+        const wanted = await webhookWanted(orgId)
         return {
           bindings: await Promise.all(
-            rows.map(async (row) => bindingToDto(row, await deps.repos.gitlabAgentAccount.listForBinding(row.id)))
+            rows.map(async (row) =>
+              bindingToDto(row, await deps.repos.gitlabAgentAccount.listForBinding(row.id), wanted(row.projectId))
+            )
           )
         }
       }
@@ -290,7 +451,12 @@ export function gitlabRoutes(deps: HttpDeps) {
           // the outcome state either way and repair re-runs it.
           await gitlab.provisioner.provision(orgId, binding.id)
           const converged = await deps.repos.gitlabProjectBinding.get(orgId, binding.id)
-          return bindingToDto(converged ?? binding, await deps.repos.gitlabAgentAccount.listForBinding(binding.id))
+          const wanted = await webhookWanted(orgId)
+          return bindingToDto(
+            converged ?? binding,
+            await deps.repos.gitlabAgentAccount.listForBinding(binding.id),
+            wanted(binding.projectId)
+          )
         } catch (e) {
           if (e instanceof GitlabProjectClaimConflict) {
             // The deployment-global claim (§7.2): one managing organization per
@@ -333,7 +499,12 @@ export function gitlabRoutes(deps: HttpDeps) {
         if (!binding) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab project not found' })
         }
-        return bindingToDto(binding, await deps.repos.gitlabAgentAccount.listForBinding(binding.id))
+        const wanted = await webhookWanted(orgId)
+        return bindingToDto(
+          binding,
+          await deps.repos.gitlabAgentAccount.listForBinding(binding.id),
+          wanted(binding.projectId)
+        )
       }
     )
 
@@ -409,7 +580,12 @@ export function gitlabRoutes(deps: HttpDeps) {
           }
           const converged = await deps.repos.gitlabProjectBinding.get(orgId, binding.id)
           if (!converged) return notFound()
-          return bindingToDto(converged, await deps.repos.gitlabAgentAccount.listForBinding(binding.id))
+          const wanted = await webhookWanted(orgId)
+          return bindingToDto(
+            converged,
+            await deps.repos.gitlabAgentAccount.listForBinding(binding.id),
+            wanted(converged.projectId)
+          )
         } catch (e) {
           if (e instanceof GitlabOauthDenied) {
             return reply.code(e.status).send({ error: 'Conflict', statusCode: e.status, message: e.message })

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3439,6 +3439,18 @@ export interface GitlabAccountConsumer {
   accessLevel: number
 }
 
+/** A consumer with WHY it consumes the project: the console names the reason on the row, so
+ *  dropping an agent's triggers cannot leave its still-working workspace looking like a ghost. */
+export interface GitlabProjectConsumer extends GitlabAccountConsumer {
+  projectId: bigint
+  /** The agent's gitlab workspace on this project and the access it grants; null when it has none. */
+  workspace: 'read' | 'write' | null
+  /** Comment families the agent's enabled triggers cover here, sorted; may be empty. */
+  triggerFamilies: string[]
+  /** How many enabled triggers the agent has on the project. */
+  triggerCount: number
+}
+
 export interface GitlabAgentAccountRepo {
   /** Find-or-create the (org, agent, root) row; an existing row keeps its state. */
   ensure(input: {
@@ -3466,6 +3478,8 @@ export interface GitlabAgentAccountRepo {
   detachMembershipForRemoval(accountId: string, bindingId: string): Promise<void>
   /** The retirements that removal is still owed evidence for. */
   listRetiringForBinding(bindingId: string): Promise<GitlabAgentAccountRecord[]>
+  /** Every account the organization owns — the console's bot roster (§18.1). */
+  listForOrg(orgId: string): Promise<GitlabAgentAccountRecord[]>
   update(
     accountId: string,
     patch: Partial<{
@@ -3524,6 +3538,9 @@ export interface GitlabAgentAccountRepo {
   /** The agents consuming a project: gitlab-workspace agents and enabled gitlab
    *  hooks, each with the access level its authorization derives (§7.2). */
   consumers(orgId: string, projectId: bigint): Promise<GitlabAccountConsumer[]>
+  /** Every consumer in the organization, in two queries — the desired membership set the
+   *  console's convergence signal is judged against, and the reasons it names on a row (§18.1). */
+  consumersForOrg(orgId: string): Promise<GitlabProjectConsumer[]>
 }
 
 export type GitlabCredentialPurpose = 'read' | 'git_write' | 'effect'

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -18,6 +18,7 @@ import type { PrismaLike } from '../prisma.js'
 import { GitlabMembershipGone, GitlabProjectClaimConflict } from '../errors.js'
 import type {
   GitlabAccountConsumer,
+  GitlabProjectConsumer,
   GitlabAccountMembershipRecord,
   GitlabAccountState,
   GitlabAgentAccountRecord,
@@ -660,6 +661,11 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
     return rows.map(toAccountRecord)
   }
 
+  async listForOrg(orgId: string): Promise<GitlabAgentAccountRecord[]> {
+    const rows = await this.prisma.gitlabAgentAccount.findMany({ orderBy: { createdAt: 'asc' }, where: { orgId } })
+    return rows.map(toAccountRecord)
+  }
+
   async update(
     accountId: string,
     patch: Partial<{
@@ -846,6 +852,54 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
     // A hook consumer posts notes and may run the configured review policy.
     for (const row of hooks) if (row.agentId) raise(row.agentId, ACCESS_DEVELOPER)
     return [...levels].map(([agentId, accessLevel]) => ({ agentId, accessLevel }))
+  }
+
+  async consumersForOrg(orgId: string): Promise<GitlabProjectConsumer[]> {
+    const [workspaces, hooks] = await Promise.all([
+      this.prisma.agent.findMany({
+        where: { orgId, workspaceMode: 'gitlab', workspaceRepoId: { not: null } },
+        select: { id: true, gitAccess: true, workspaceRepoId: true }
+      }),
+      this.prisma.hookDef.findMany({
+        where: { orgId, kind: 'gitlab', enabled: true, repoId: { not: null }, agentId: { not: null } },
+        select: { agentId: true, repoId: true, commentFamilies: true }
+      })
+    ])
+    const found = new Map<string, GitlabProjectConsumer & { families: Set<string> }>()
+    const at = (projectId: bigint, agentId: string): GitlabProjectConsumer & { families: Set<string> } => {
+      const key = `${projectId}:${agentId}`
+      const held = found.get(key)
+      if (held) return held
+      const fresh = {
+        projectId,
+        agentId,
+        accessLevel: 0,
+        workspace: null,
+        triggerFamilies: [],
+        triggerCount: 0,
+        families: new Set<string>()
+      }
+      found.set(key, fresh)
+      return fresh
+    }
+    // The workspace gitAccess clamp derives the role (§7.2, §13.1).
+    for (const row of workspaces) {
+      const entry = at(row.workspaceRepoId!, row.id)
+      entry.workspace = row.gitAccess === 'read' ? 'read' : 'write'
+      entry.accessLevel = Math.max(entry.accessLevel, gitlabWorkspaceAccessLevel(row.gitAccess))
+    }
+    // A hook consumer posts notes and may run the configured review policy.
+    for (const row of hooks) {
+      if (!row.agentId || !row.repoId) continue
+      const entry = at(row.repoId, row.agentId)
+      entry.triggerCount += 1
+      entry.accessLevel = Math.max(entry.accessLevel, ACCESS_DEVELOPER)
+      for (const family of row.commentFamilies) entry.families.add(family)
+    }
+    return [...found.values()].map(({ families, ...consumer }) => ({
+      ...consumer,
+      triggerFamilies: [...families].sort()
+    }))
   }
 }
 

--- a/packages/control-plane/test/integration/gitlab.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab.route.test.ts
@@ -11,6 +11,10 @@ import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { GitlabOauthService } from '../../src/gitlab/oauth.service.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
+import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
+import { OrgId } from '../../src/domain/ids.js'
+import { unionGitlabWebhookEvents } from '../../src/gitlab/webhook-events.js'
 import {
   PgGitlabAgentAccountRepo,
   PgGitlabConnectionRepo,
@@ -71,7 +75,9 @@ function gitlabApp(options: FakeGitlabOptions = {}, callerUserId?: string): Http
     catalog: new PgCodeHostRepositoryRepo(prisma),
     clock: systemClock,
     publicRelayUrl: 'https://relay.example.test',
-    desiredWebhookEvents: async () => null,
+    // The same authority container.ts wires: an enabled gitlab hook on the project wants ingress.
+    desiredWebhookEvents: async (orgId, projectId) =>
+      unionGitlabWebhookEvents(await new PgHookRepo(prisma).listForOrgKind(OrgId(orgId), 'gitlab'), projectId),
     fetchImpl: fake.fetch()
   })
   running = buildHttpApp(
@@ -484,7 +490,8 @@ describe('gitlab oauth routes', () => {
       state: 'ready',
       // No agent consumes this project yet, so it has no member accounts (§7.2).
       accounts: [],
-      webhookInstalled: false
+      // No enabled trigger points at it either, so no ingress is wanted — a normal resting state.
+      webhookState: 'not_needed'
     })
     // The claim and the provider-qualified catalog row were acquired atomically.
     const claim = await prisma.codeHostRepositoryClaim.findUniqueOrThrow({
@@ -570,5 +577,283 @@ describe('gitlab oauth routes', () => {
     running = buildHttpApp(prisma, { PUBLIC_CP_URL: PUBLIC_CP })
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/gitlab/connections` })
     expect(res.statusCode).toBe(404)
+  })
+})
+/**
+ * The Integrations card's bot roster (§18.1): every account the organization owns,
+ * with the agent it acts for and the projects it is a member of, in one read.
+ */
+describe('gitlab organization bot roster (§7.2, §18.1)', () => {
+  const rosterUrl = (org = ORG) => `${org}/gitlab/accounts`
+
+  type RosterAccount = Record<string, unknown> & {
+    memberships: Array<{ bindingId: string; accessLevel: number; workspace: string | null }>
+  }
+
+  async function rosterRead(a: HttpApp): Promise<{ accounts: RosterAccount[]; converging: boolean }> {
+    const res = await a.app.inject({ method: 'GET', url: rosterUrl() })
+    expect(res.statusCode).toBe(200)
+    return res.json() as { accounts: RosterAccount[]; converging: boolean }
+  }
+
+  async function roster(a: HttpApp): Promise<RosterAccount[]> {
+    return (await rosterRead(a)).accounts
+  }
+
+  async function bind(a: HttpApp, connectionId: string, projectId: string): Promise<string> {
+    const bound = await a.app.inject({
+      method: 'POST',
+      url: `${ORG}/gitlab/projects`,
+      payload: { connectionId, projectId }
+    })
+    expect(bound.statusCode).toBe(200)
+    return (bound.json() as { id: string }).id
+  }
+
+  it('reports each bot with its agent, group, health, and the project it is a member of', async () => {
+    const a = gitlabApp()
+    const { connectionId } = await connect(a)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { name: 'reviewer', gitlabProjectId: 4455667n, gitAccess: 'write' })
+    const bindingId = await bind(a, connectionId, '4455667')
+
+    const accounts = await roster(a)
+    expect(accounts).toHaveLength(1)
+    expect(accounts[0]).toMatchObject({
+      agentId,
+      rootGroupId: '900',
+      rootGroupPath: 'example-group',
+      username: gitlabAgentAccountUsername(agentId, 'reviewer', 900n),
+      displayName: 'reviewer',
+      state: 'ready',
+      stateReason: null,
+      lifecycle: 'active'
+    })
+    // The membership carries the role GitLab enforces, so the card can name it.
+    expect(accounts[0]!.memberships).toMatchObject([{ bindingId, accessLevel: 30 }])
+    expect(accounts[0]!.userId).toMatch(/^\d+$/)
+    expect(JSON.stringify(accounts)).not.toContain('glpat')
+  })
+
+  it('reports why each bot holds its project: workspace access and enabled trigger families', async () => {
+    // The role alone cannot say this, and it is what stops a workspace-only bot reading as
+    // a leftover once someone deletes the triggers that used to justify it too.
+    const a = gitlabApp()
+    const { connectionId } = await connect(a)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { name: 'reviewer', gitlabProjectId: 4455667n, gitAccess: 'read' })
+    await prisma.hookDef.create({
+      data: {
+        id: randomUUID(),
+        orgId: DEFAULT_ORG_ID,
+        agentId,
+        kind: 'gitlab',
+        name: 'reviews',
+        sessionMode: 'perDelivery',
+        repoId: 4455667n,
+        commentFamilies: ['merge_request', 'issues']
+      }
+    })
+    await bind(a, connectionId, '4455667')
+
+    const accounts = await roster(a)
+    expect(accounts[0]!.memberships[0]).toMatchObject({
+      workspace: 'read',
+      // Sorted, so the console never has to care what order the rows came back in.
+      triggerFamilies: ['issues', 'merge_request'],
+      triggerCount: 1
+    })
+  })
+
+  it('gives a project consumed by two agents one bot each, with the role each derives', async () => {
+    const a = gitlabApp()
+    const { connectionId } = await connect(a)
+    const writer = randomUUID()
+    const reader = randomUUID()
+    await seedAgent(prisma, writer, { name: 'reviewer', gitlabProjectId: 4455667n, gitAccess: 'write' })
+    await seedAgent(prisma, reader, { name: 'triager', gitlabProjectId: 4455667n, gitAccess: 'read' })
+    const bindingId = await bind(a, connectionId, '4455667')
+
+    const accounts = await roster(a)
+    expect(accounts).toHaveLength(2)
+    // One account per AGENT, not per project: the binding appears under both.
+    expect(accounts.every((account) => account.memberships[0]!.bindingId === bindingId)).toBe(true)
+    const byAgent = new Map(accounts.map((account) => [account.agentId as string, account]))
+    expect(byAgent.get(writer)!.memberships[0]!.accessLevel).toBe(30)
+    expect(byAgent.get(reader)!.memberships[0]!.accessLevel).toBe(20)
+  })
+
+  it('omits a bot whose agent the caller cannot see, and keeps the visible one', async () => {
+    const a = gitlabApp()
+    const { connectionId } = await connect(a)
+    const visible = randomUUID()
+    const hidden = randomUUID()
+    await seedAgent(prisma, visible, { name: 'reviewer', gitlabProjectId: 4455667n })
+    await seedAgent(prisma, hidden, {
+      name: 'private-reviewer',
+      gitlabProjectId: 4455667n,
+      visibility: 'restricted',
+      sharedWith: [DEFAULT_OWNER_ID]
+    })
+    await bind(a, connectionId, '4455667')
+    // The owner sees both bots on the project.
+    expect(await roster(a)).toHaveLength(2)
+    await a.close()
+
+    const users = new PgUserRepo(prisma)
+    const email = `outsider-${randomUUID().slice(0, 8)}@example.test`
+    const { userId: outsider } = await users.provisionOidcUser({ oidcSubject: email, email, emailVerified: true })
+    await users.addMemberByEmail(DEFAULT_ORG_ID, email, 'collaborator')
+    const asOutsider = gitlabApp({}, outsider)
+
+    const seen = await roster(asOutsider)
+    expect(seen.map((account) => account.agentId)).toEqual([visible])
+    // The restricted agent's bot is absent, not redacted — nothing names it.
+    expect(JSON.stringify(seen)).not.toContain('private-reviewer')
+  })
+
+  it('is empty for an organization with no bot accounts, and another organization reads as absent', async () => {
+    const a = gitlabApp()
+    await connect(a)
+    expect(await roster(a)).toEqual([])
+
+    // Cross-org is 404 at the tenancy boundary, never someone else's roster.
+    const foreign = await a.app.inject({ method: 'GET', url: rosterUrl(`/api/v1/orgs/${randomUUID()}`) })
+    expect(foreign.statusCode).toBe(404)
+  })
+
+  it('404s with the rest of the surface when the deployment has no gitlab oauth app', async () => {
+    running = buildHttpApp(prisma, { PUBLIC_CP_URL: PUBLIC_CP })
+    expect((await running.app.inject({ method: 'GET', url: rosterUrl() })).statusCode).toBe(404)
+  })
+
+  it('reports a wanted webhook as installed, and an unwanted one as not needed', async () => {
+    // The two are the same absence of trouble, but only one of them is an absence of a webhook —
+    // reporting a project with no trigger as lacking one turns a resting state into an alarm.
+    const a = gitlabApp()
+    const { connectionId } = await connect(a)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { name: 'reviewer', gitlabProjectId: 4455667n })
+    await bind(a, connectionId, '4455667')
+
+    const listed = await a.app.inject({ method: 'GET', url: `${ORG}/gitlab/projects` })
+    expect((listed.json() as { bindings: Array<{ webhookState: string }> }).bindings[0]!.webhookState).toBe(
+      'not_needed'
+    )
+
+    // An enabled trigger on the project is what wants ingress; repair installs it.
+    await prisma.hookDef.create({
+      data: {
+        id: randomUUID(),
+        orgId: DEFAULT_ORG_ID,
+        agentId,
+        kind: 'gitlab',
+        name: 'reviews',
+        sessionMode: 'perDelivery',
+        repoId: 4455667n
+      }
+    })
+    const bindingId = (
+      (await (await a.app.inject({ method: 'GET', url: `${ORG}/gitlab/projects` })).json()) as {
+        bindings: Array<{ id: string }>
+      }
+    ).bindings[0]!.id
+    const repaired = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/repair` })
+    expect(repaired.statusCode).toBe(200)
+    expect((repaired.json() as { webhookState: string }).webhookState).toBe('installed')
+  })
+
+  /**
+   * The console cannot see an agent's hooks or workspace, so it cannot tell a converged
+   * roster from one read mid-flight. `converging` is that answer, and it has to terminate.
+   */
+  describe('convergence signal', () => {
+    it('is settled once every consumer holds the membership it wants', async () => {
+      const a = gitlabApp()
+      const { connectionId } = await connect(a)
+      await seedAgent(prisma, randomUUID(), { name: 'reviewer', gitlabProjectId: 4455667n })
+      await bind(a, connectionId, '4455667')
+
+      expect((await rosterRead(a)).converging).toBe(false)
+    })
+
+    it('is unsettled while a consumer added after the project still owes a membership', async () => {
+      // Exactly the shape a hook created on another page has before its saga runs: the
+      // project set is unchanged, so nothing about the roster's key would move.
+      const a = gitlabApp()
+      const { connectionId } = await connect(a)
+      await bind(a, connectionId, '4455667')
+      expect((await rosterRead(a)).converging).toBe(false)
+
+      await seedAgent(prisma, randomUUID(), { name: 'late-arrival', gitlabProjectId: 4455667n })
+      expect((await rosterRead(a)).converging).toBe(true)
+    })
+
+    it('is unsettled while a membership no consumer justifies still awaits detach', async () => {
+      const a = gitlabApp()
+      const { connectionId } = await connect(a)
+      const agentId = randomUUID()
+      await seedAgent(prisma, agentId, { name: 'reviewer', gitlabProjectId: 4455667n })
+      await bind(a, connectionId, '4455667')
+      expect((await rosterRead(a)).converging).toBe(false)
+
+      // The consumer goes away; its membership is removed asynchronously.
+      await prisma.agent.update({ where: { id: agentId }, data: { workspaceRepoId: null } })
+      expect((await rosterRead(a)).converging).toBe(true)
+    })
+
+    it('is unsettled while a surviving membership still holds the role a dropped hook raised it to', async () => {
+      // A read-only workspace earns Reporter; an enabled hook raises the same agent to Developer.
+      // Dropping the hook does not remove the membership, it downgrades it — a change no set of
+      // agent ids can see, and the one the card would otherwise show as Developer forever.
+      const a = gitlabApp()
+      const { connectionId } = await connect(a)
+      const agentId = randomUUID()
+      await seedAgent(prisma, agentId, { name: 'reviewer', gitlabProjectId: 4455667n, gitAccess: 'read' })
+      const hookId = randomUUID()
+      await prisma.hookDef.create({
+        data: {
+          id: hookId,
+          orgId: DEFAULT_ORG_ID,
+          agentId,
+          kind: 'gitlab',
+          name: 'reviews',
+          sessionMode: 'perDelivery',
+          repoId: 4455667n
+        }
+      })
+      const bindingId = await bind(a, connectionId, '4455667')
+
+      const raised = await rosterRead(a)
+      expect(raised.accounts[0]!.memberships).toMatchObject([{ bindingId, accessLevel: 30 }])
+      expect(raised.converging).toBe(false)
+
+      // The hook goes; the membership survives at the role only the hook justified.
+      await prisma.hookDef.delete({ where: { id: hookId } })
+      const pending = await rosterRead(a)
+      expect(pending.accounts[0]!.memberships).toMatchObject([{ bindingId, accessLevel: 30 }])
+      expect(pending.converging).toBe(true)
+
+      // Convergence writes the workspace's own role, and the answer settles on it.
+      const repaired = await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${bindingId}/repair` })
+      expect(repaired.statusCode).toBe(200)
+      const settled = await rosterRead(a)
+      expect(settled.accounts[0]!.memberships).toMatchObject([{ bindingId, accessLevel: 20 }])
+      expect(settled.converging).toBe(false)
+    })
+
+    it('settles on a refused account rather than asking forever about one that needs Repair', async () => {
+      // The group hit its bot ceiling: the account row exists, no membership can attach, and
+      // nothing will change until a human acts. Reporting that as convergence would never end.
+      const a = gitlabApp({ refuseServiceAccountQuota: true })
+      const { connectionId } = await connect(a)
+      await seedAgent(prisma, randomUUID(), { name: 'reviewer', gitlabProjectId: 4455667n })
+      await bind(a, connectionId, '4455667')
+
+      const read = await rosterRead(a)
+      expect(read.accounts[0]).toMatchObject({ state: 'admin_degraded', stateReason: 'service_account_quota' })
+      expect(read.accounts[0]!.memberships).toEqual([])
+      expect(read.converging).toBe(false)
+    })
   })
 })

--- a/packages/control-plane/test/integration/gitlab.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab.route.test.ts
@@ -44,7 +44,12 @@ afterEach(async () => {
   running = undefined
 })
 
-function gitlabApp(options: FakeGitlabOptions = {}, callerUserId?: string): HttpApp & { fake: FakeGitlab } {
+function gitlabApp(
+  options: FakeGitlabOptions = {},
+  callerUserId?: string,
+  /** A deployment with no public webhook address makes the webhook step fail for real. */
+  deployment: { publicRelayUrl?: string } = {}
+): HttpApp & { fake: FakeGitlab } {
   const fake = new FakeGitlab(options)
   const oauth = new GitlabOauthService({
     cfg: { clientId: 'client-1', clientSecret: 'secret-1' },
@@ -74,7 +79,7 @@ function gitlabApp(options: FakeGitlabOptions = {}, callerUserId?: string): Http
     webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
     catalog: new PgCodeHostRepositoryRepo(prisma),
     clock: systemClock,
-    publicRelayUrl: 'https://relay.example.test',
+    publicRelayUrl: deployment.publicRelayUrl ?? 'https://relay.example.test',
     // The same authority container.ts wires: an enabled gitlab hook on the project wants ingress.
     desiredWebhookEvents: async (orgId, projectId) =>
       unionGitlabWebhookEvents(await new PgHookRepo(prisma).listForOrgKind(OrgId(orgId), 'gitlab'), projectId),
@@ -764,6 +769,79 @@ describe('gitlab organization bot roster (§7.2, §18.1)', () => {
   })
 
   /**
+   * Enabling a trigger commits before the convergence it fires, so the window between the two
+   * must not look like a broken webhook — and the console has to be told to wait it out.
+   */
+  describe('webhook state', () => {
+    async function hookOn(agentId: string): Promise<string> {
+      const hookId = randomUUID()
+      await prisma.hookDef.create({
+        data: {
+          id: hookId,
+          orgId: DEFAULT_ORG_ID,
+          agentId,
+          kind: 'gitlab',
+          name: 'reviews',
+          sessionMode: 'perDelivery',
+          repoId: 4455667n
+        }
+      })
+      return hookId
+    }
+
+    async function onlyBinding(a: HttpApp): Promise<{ id: string; webhookState: string }> {
+      const res = await a.app.inject({ method: 'GET', url: `${ORG}/gitlab/projects` })
+      return (res.json() as { bindings: Array<{ id: string; webhookState: string }> }).bindings[0]!
+    }
+
+    it('calls a webhook wanted but not yet installed transient, and keeps the roster asking', async () => {
+      const a = gitlabApp()
+      const { connectionId } = await connect(a)
+      const agentId = randomUUID()
+      await seedAgent(prisma, agentId, { name: 'reviewer', gitlabProjectId: 4455667n })
+      await bind(a, connectionId, '4455667')
+      expect((await onlyBinding(a)).webhookState).toBe('not_needed')
+
+      // The hook write lands; its convergence has not run yet. That is not a failure.
+      await hookOn(agentId)
+      expect((await onlyBinding(a)).webhookState).toBe('repairing')
+      // And the console is told to keep asking, so the badge cannot get stuck.
+      expect((await rosterRead(a)).converging).toBe(true)
+    })
+
+    it('clears once the install completes, and stops asking', async () => {
+      const a = gitlabApp()
+      const { connectionId } = await connect(a)
+      const agentId = randomUUID()
+      await seedAgent(prisma, agentId, { name: 'reviewer', gitlabProjectId: 4455667n })
+      await bind(a, connectionId, '4455667')
+      await hookOn(agentId)
+
+      const { id } = await onlyBinding(a)
+      expect((await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${id}/repair` })).statusCode).toBe(200)
+      expect((await onlyBinding(a)).webhookState).toBe('installed')
+      expect((await rosterRead(a)).converging).toBe(false)
+    })
+
+    it('reports failed only once a run actually tried and could not, and then rests', async () => {
+      // No public webhook address configured: the webhook step runs and refuses (§10.2).
+      const a = gitlabApp({}, undefined, { publicRelayUrl: '' })
+      const { connectionId } = await connect(a)
+      const agentId = randomUUID()
+      await seedAgent(prisma, agentId, { name: 'reviewer', gitlabProjectId: 4455667n })
+      await bind(a, connectionId, '4455667')
+      await hookOn(agentId)
+
+      const { id } = await onlyBinding(a)
+      await a.app.inject({ method: 'POST', url: `${ORG}/gitlab/projects/${id}/repair` })
+      const settled = await onlyBinding(a)
+      expect(settled.webhookState).toBe('failed')
+      // Settled: a failure waits for a person, so the console stops polling on it.
+      expect((await rosterRead(a)).converging).toBe(false)
+    })
+  })
+
+  /**
    * The console cannot see an agent's hooks or workspace, so it cannot tell a converged
    * roster from one read mid-flight. `converging` is that answer, and it has to terminate.
    */
@@ -840,6 +918,29 @@ describe('gitlab organization bot roster (§7.2, §18.1)', () => {
       const settled = await rosterRead(a)
       expect(settled.accounts[0]!.memberships).toMatchObject([{ bindingId, accessLevel: 20 }])
       expect(settled.converging).toBe(false)
+    })
+
+    it('is unsettled by a membership whose consumer went away, even on a degraded account', async () => {
+      // The refusal exemption exists for a membership that cannot be CREATED without repair. A
+      // membership already recorded and no longer justified is a detach the saga owes regardless,
+      // and exempting it left the project sitting under that bot for good.
+      const a = gitlabApp()
+      const { connectionId } = await connect(a)
+      const agentId = randomUUID()
+      await seedAgent(prisma, agentId, { name: 'reviewer', gitlabProjectId: 4455667n })
+      await bind(a, connectionId, '4455667')
+      expect((await rosterRead(a)).converging).toBe(false)
+
+      // Rotation trouble degrades the account while it keeps its membership.
+      await prisma.gitlabAgentAccount.updateMany({
+        where: { orgId: DEFAULT_ORG_ID, agentId },
+        data: { state: 'admin_degraded', stateReason: 'rotation_gitlab_503' }
+      })
+      expect((await rosterRead(a)).converging).toBe(false)
+
+      // Now its last consumer goes; the detach is still owed and must be reported.
+      await prisma.agent.update({ where: { id: agentId }, data: { workspaceRepoId: null } })
+      expect((await rosterRead(a)).converging).toBe(true)
     })
 
     it('settles on a refused account rather than asking forever about one that needs Repair', async () => {

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -596,6 +596,34 @@ describe('GitlabCard', () => {
     expect(mocks.fetchProjects.mock.calls.length).toBe(settling + 1)
   })
 
+  it('lets the newest project read win when an older one resolves after it', async () => {
+    // Each roster answer launches its own project read, so two are in flight at once and the
+    // network decides the order they land in. Unfenced, a slow read of the transient state
+    // paints over the finished one that already arrived — after polling has stopped for good.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([{ ...BINDING, webhookState: 'repairing' as const }])
+    roster = [BOT]
+    converging = true
+    await render()
+    const row = () => projectRow(botRow('acct-1'), 'bind-1')
+
+    let older!: (rows: GitlabProjectBindingDto[]) => void
+    let newer!: (rows: GitlabProjectBindingDto[]) => void
+    mocks.fetchProjects.mockReturnValueOnce(new Promise((resolve) => (older = resolve)))
+    mocks.fetchProjects.mockReturnValueOnce(new Promise((resolve) => (newer = resolve)))
+    await revalidate()
+    converging = false
+    await revalidate()
+
+    // The newer read lands first and shows the install finished.
+    await act(async () => newer([BINDING]))
+    expect(row().textContent).not.toContain('webhook')
+
+    // The older one answers last, still describing the install as running, and is discarded.
+    await act(async () => older([{ ...BINDING, webhookState: 'repairing' as const }]))
+    expect(row().textContent).not.toContain('webhook')
+  })
+
   it('leaves the projects alone once nothing is converging', async () => {
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     mocks.fetchProjects.mockResolvedValue([BINDING])

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -2,24 +2,33 @@
 /**
  * The GitLab card is the console's GitLab MANAGEMENT surface: an unconnected
  * organization gets one entry point, a connected one gets its connection
- * lifecycle and the health of the projects already set up. Picking a project is
- * deliberately not here — that happens where the project is used. The write
- * actions are asserted against the endpoint they call: a repair that silently
- * posted to the wrong binding would still look right on screen.
+ * lifecycle, its bots, and the health of the projects each bot is a member of.
+ * The BOT is the row (§18.1), mirroring the chat-platform cards; picking a
+ * project is deliberately not here — that happens where the project is used.
+ * The write actions are asserted against the endpoint they call: a repair that
+ * silently posted to the wrong binding would still look right on screen.
  */
-import { act } from 'react'
+import { act, type ReactElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ApiError, type GitlabConnectionDto, type GitlabProjectBindingDto } from '@/lib/api'
+import {
+  ApiError,
+  type GitlabConnectionDto,
+  type GitlabMembershipDto,
+  type GitlabOrgAccountDto,
+  type GitlabProjectBindingDto
+} from '@/lib/api'
 
 const mocks = vi.hoisted(() => ({
   fetchConnections: vi.fn(),
   fetchProjects: vi.fn(),
+  fetchAccounts: vi.fn(),
   repairProject: vi.fn(),
   deleteProject: vi.fn(),
   transferProject: vi.fn(),
   disconnect: vi.fn(),
-  startOauth: vi.fn()
+  startOauth: vi.fn(),
+  reread: vi.fn()
 }))
 
 // One stable org object: the card keys its fetch effect on `activeOrg`, so a
@@ -28,16 +37,56 @@ vi.mock('@/lib/org-context', () => {
   const orgs = { activeOrg: { id: 'org-gitlab' }, myRole: 'owner', orgPath: (path: string) => path }
   return { useOrgs: () => orgs }
 })
+vi.mock('next/link', () => ({
+  default: ({ children, href, className }: { children: ReactElement; href: string; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  )
+}))
+// The bot's face and name come from the agent the console already loaded, so the
+// card joins on the agent id rather than having the API repeat the agent's identity.
+const AGENT = {
+  id: 'agent-1',
+  name: 'gitlab-pilot',
+  displayName: 'GitLab pilot',
+  runtime: 'claude',
+  model: 'sonnet',
+  icon: { kind: 'glyph' as const, glyph: 'bot', color: '#c62a78' }
+}
+vi.mock('@/lib/data-context', () => {
+  const data = { getAgent: (id: string) => (id === AGENT.id ? AGENT : undefined) }
+  return { useConsoleData: () => data }
+})
 vi.mock('@/lib/api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/api')>()),
   fetchGitlabConnections: mocks.fetchConnections,
   fetchGitlabProjects: mocks.fetchProjects,
+  fetchGitlabAccounts: mocks.fetchAccounts,
   repairGitlabProject: mocks.repairProject,
   deleteGitlabProject: mocks.deleteProject,
   transferGitlabProject: mocks.transferProject,
   disconnectGitlabConnection: mocks.disconnect,
   startGitlabOauth: mocks.startOauth
 }))
+// The mock records the key and options so the freshness contract is assertable, and
+// serves the roster the test set — the card's own reads stay the effect's business.
+vi.mock('swr', () => ({
+  default: (key: unknown, fetcher: ((k: unknown) => Promise<unknown>) | null, options: SwrOptions) => {
+    lastSwr = { key, options }
+    if (!key || !fetcher) return { data: undefined, mutate: mocks.reread }
+    return { data: read(), mutate: mocks.reread }
+  }
+}))
+
+interface SwrOptions {
+  refreshInterval?: (latest: unknown) => number
+}
+
+/** What the roster read answers with right now, or undefined before it has answered. */
+function read(): { enabled: boolean; accounts: GitlabOrgAccountDto[]; converging: boolean } | undefined {
+  return roster === undefined ? undefined : { enabled: true, accounts: roster, converging }
+}
 
 const GitlabCard = (await import('./GitlabCard')).default
 
@@ -66,17 +115,53 @@ const BINDING: GitlabProjectBindingDto = {
     {
       agentId: 'agent-1',
       username: 'agentconnect-a1-g900',
-      displayName: 'reviewer',
+      displayName: 'GitLab pilot',
       userId: '9042',
       state: 'ready',
       stateReason: null
     }
   ],
-  webhookInstalled: true,
+  webhookState: 'installed',
   credentialEpoch: '1',
   createdAt: '2026-08-02T00:00:00.000Z'
 }
 
+/** One hold on a project: a read & write workspace, no triggers. */
+const MEMBER: GitlabMembershipDto = {
+  bindingId: 'bind-1',
+  accessLevel: 30,
+  workspace: 'write',
+  triggerFamilies: [],
+  triggerCount: 0
+}
+
+const BOT: GitlabOrgAccountDto = {
+  id: 'acct-1',
+  agentId: 'agent-1',
+  rootGroupId: '900',
+  rootGroupPath: 'example-group',
+  username: 'agentconnect-a1-g900',
+  displayName: 'GitLab pilot',
+  userId: '9042',
+  state: 'ready',
+  stateReason: null,
+  lifecycle: 'active',
+  memberships: [MEMBER]
+}
+
+/** A second agent's bot in the same top-level group — one account per agent, not per project. */
+const OTHER_BOT: GitlabOrgAccountDto = {
+  ...BOT,
+  id: 'acct-2',
+  agentId: 'agent-2',
+  username: 'agentconnect-a2-g900',
+  displayName: 'triager'
+}
+
+let roster: GitlabOrgAccountDto[] | undefined
+/** The server's answer to "does convergence still owe this organization work". */
+let converging = false
+let lastSwr: { key: unknown; options: SwrOptions } | undefined
 let host: HTMLDivElement
 let root: Root
 
@@ -109,16 +194,43 @@ function connectionRow(id: string): HTMLElement {
   return found as HTMLElement
 }
 
+/** One bot row and the project rows underneath it. */
+function botRow(accountId: string): HTMLElement {
+  const found = host.querySelector(`[data-gitlab-bot="${accountId}"]`)
+  if (!found) throw new Error(`no bot row: ${accountId}`)
+  return found as HTMLElement
+}
+
+/** The projects no bot is a member of — they keep their state and their actions. */
+function orphanSection(): HTMLElement | null {
+  return host.querySelector('[data-gitlab-orphans]')
+}
+
+function projectRow(scope: ParentNode, bindingId: string): HTMLElement {
+  const found = scope.querySelector(`[data-gitlab-project="${bindingId}"]`)
+  if (!found) throw new Error(`no project row: ${bindingId}`)
+  return found as HTMLElement
+}
+
 function modal(): HTMLElement {
   const found = host.querySelector('.modal')
   if (!found) throw new Error('no confirmation modal is open')
   return found as HTMLElement
 }
 
+/** What SWR would wait before asking again — 0 means the card has stopped polling. */
+function pollInterval(): number {
+  const refresh = lastSwr?.options.refreshInterval
+  if (!refresh) throw new Error('the card declared no refresh interval')
+  return refresh(read())
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   document.body.innerHTML = ''
   mocks.fetchProjects.mockResolvedValue([])
+  roster = []
+  converging = false
 })
 
 describe('GitlabCard', () => {
@@ -130,6 +242,8 @@ describe('GitlabCard', () => {
     await render()
     expect(host.textContent).toContain('Not enabled on this deployment')
     expect(mocks.fetchProjects).not.toHaveBeenCalled()
+    // The bot roster is not asked for either: a disabled surface has no key.
+    expect(lastSwr?.key).toBeNull()
     expect([...host.querySelectorAll('button')]).toHaveLength(0)
   })
 
@@ -141,15 +255,368 @@ describe('GitlabCard', () => {
     expect(host.querySelectorAll('[data-gitlab-project]')).toHaveLength(0)
   })
 
-  it('shows the connected identity, its projects, and no connect button', async () => {
+  it('shows the connected identity, its bots, and no connect button', async () => {
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
     await render()
     expect(host.textContent).toContain('octo-maintainer')
     expect(host.textContent).toContain('example-group/example-project')
     expect(host.textContent).toContain('ready')
     expect(host.textContent).toContain('agentconnect-a1-g900')
     expect(host.textContent).not.toContain('Connect GitLab')
+  })
+
+  it('keys a row by bot: the agent’s face and name, its handle, its group, and its health', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    await render()
+
+    const row = botRow('acct-1')
+    // The agent's own name, not the derived GitLab display name — the bot IS that agent.
+    expect(row.textContent).toContain('GitLab pilot')
+    expect(row.textContent).toContain('@agentconnect-a1-g900')
+    expect(row.textContent).toContain('example-group')
+    expect(row.querySelector('[data-agent-icon-glyph]')).toBeTruthy()
+    // And the row leads back to that agent's page.
+    const toAgent = row.querySelector('a[href^="/agents/"]') as HTMLAnchorElement
+    expect(toAgent.getAttribute('href')).toBe('/agents/agent-1?tab=config')
+  })
+
+  it('links the bot handle to its GitLab profile, in a tab that cannot reach back', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    await render()
+
+    const handle = host.querySelector('[data-gitlab-account]') as HTMLAnchorElement
+    expect(handle.textContent).toBe('@agentconnect-a1-g900')
+    expect(handle.getAttribute('href')).toBe('https://gitlab.com/agentconnect-a1-g900')
+    expect(handle.getAttribute('target')).toBe('_blank')
+    expect(handle.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('puts the bot’s projects underneath it, with role and state', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    await render()
+
+    const project = projectRow(botRow('acct-1'), 'bind-1')
+    expect(project.textContent).toContain('example-group/example-project')
+    // The role is GitLab's word for the access level the membership carries.
+    expect(project.textContent).toContain('Developer')
+    expect(project.textContent).toContain('ready')
+    // The project-level actions live on the project line, not on the bot.
+    expect(buttonIn(project, 'Repair')).toBeTruthy()
+    expect(buttonIn(project, 'Remove')).toBeTruthy()
+  })
+
+  it('says nothing about a webhook that is healthy or simply not needed', async () => {
+    // A workspace-only project has no trigger pointing at it, so it wants no ingress at all.
+    // That is a resting state, not a condition — badging it reads as a fault that is not there.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([
+      { ...BINDING, webhookState: 'not_needed' as const },
+      { ...BINDING, id: 'bind-hooked', projectPath: 'example-group/hooked', webhookState: 'installed' as const }
+    ])
+    roster = [{ ...BOT, memberships: [...BOT.memberships, { ...MEMBER, bindingId: 'bind-hooked' }] }]
+    await render()
+
+    const bot = botRow('acct-1')
+    expect(bot.textContent).not.toContain('webhook')
+    // The rest of the row is untouched: the project, its role, and its state still read.
+    expect(projectRow(bot, 'bind-1').textContent).toContain('ready')
+  })
+
+  it('badges a webhook only while it needs attention, and keeps Repair on the failed one', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([
+      { ...BINDING, webhookState: 'repairing' as const },
+      {
+        ...BINDING,
+        id: 'bind-failed',
+        projectPath: 'example-group/broken',
+        state: 'admin_degraded' as const,
+        webhookState: 'failed' as const
+      }
+    ])
+    roster = [{ ...BOT, memberships: [...BOT.memberships, { ...MEMBER, bindingId: 'bind-failed' }] }]
+    await render()
+
+    const bot = botRow('acct-1')
+    expect(projectRow(bot, 'bind-1').textContent).toContain('webhook repairing')
+    const failed = projectRow(bot, 'bind-failed')
+    expect(failed.textContent).toContain('webhook failed')
+    expect(buttonIn(failed, 'Repair')).toBeTruthy()
+  })
+
+  it('names why the bot is on the project: its workspace, its triggers, or both', async () => {
+    // Removing an agent's triggers leaves its workspace using the project. Without the reason on
+    // the line the surviving bot reads as a leftover, and people go looking for something to delete.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([
+      BINDING,
+      { ...BINDING, id: 'bind-both', projectPath: 'example-group/both' },
+      { ...BINDING, id: 'bind-triggers', projectPath: 'example-group/triggers-only' }
+    ])
+    roster = [
+      {
+        ...BOT,
+        memberships: [
+          { ...MEMBER, workspace: 'read' },
+          {
+            ...MEMBER,
+            bindingId: 'bind-both',
+            triggerFamilies: ['issues', 'merge_request'],
+            triggerCount: 2
+          },
+          { ...MEMBER, bindingId: 'bind-triggers', workspace: null, triggerFamilies: ['issues'], triggerCount: 1 }
+        ]
+      }
+    ]
+    await render()
+
+    const bot = botRow('acct-1')
+    expect(projectRow(bot, 'bind-1').textContent).toContain('workspace (read)')
+    // Both reasons, in GitLab's own words for the families.
+    expect(projectRow(bot, 'bind-both').textContent).toContain('workspace (read & write) · triggers: Issues, MRs')
+    // Triggers alone, with no workspace clause invented for it.
+    const triggersOnly = projectRow(bot, 'bind-triggers').textContent ?? ''
+    expect(triggersOnly).toContain('triggers: Issues')
+    expect(triggersOnly).not.toContain('workspace')
+  })
+
+  it('says nothing about a reason when a membership no authorization justifies is on its way out', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [{ ...BOT, memberships: [{ ...MEMBER, workspace: null, triggerFamilies: [], triggerCount: 0 }] }]
+    await render()
+
+    const project = projectRow(botRow('acct-1'), 'bind-1')
+    expect(project.textContent).not.toContain('workspace')
+    expect(project.textContent).not.toContain('triggers')
+    // The project itself still reads, and is still actionable.
+    expect(project.textContent).toContain('example-group/example-project')
+    expect(buttonIn(project, 'Repair')).toBeTruthy()
+  })
+
+  it('lists a project shared by two bots under both, once each', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT, OTHER_BOT]
+    await render()
+
+    expect(host.querySelectorAll('[data-gitlab-bot]')).toHaveLength(2)
+    expect(projectRow(botRow('acct-1'), 'bind-1')).toBeTruthy()
+    expect(projectRow(botRow('acct-2'), 'bind-1')).toBeTruthy()
+    // Shared, not orphaned: every bot on it accounts for it.
+    expect(orphanSection()).toBeNull()
+
+    // Removing it from either line removes the project itself, and the copy says so.
+    await click('Remove', projectRow(botRow('acct-2'), 'bind-1'))
+    expect(modal().textContent).toContain('from this organization')
+    expect(modal().textContent).toContain('all 2 bots')
+    mocks.deleteProject.mockResolvedValue({ removed: true })
+    await click('Remove', modal())
+    expect(mocks.deleteProject).toHaveBeenCalledWith('bind-1')
+    expect(host.querySelectorAll('[data-gitlab-project]')).toHaveLength(0)
+  })
+
+  it('keeps a bot whose last project went away, with its health', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([])
+    roster = [{ ...BOT, lifecycle: 'retiring', memberships: [] }]
+    await render()
+
+    const row = botRow('acct-1')
+    expect(row.textContent).toContain('removing')
+    expect(row.textContent).toContain('Removing…')
+    expect(row.querySelectorAll('[data-gitlab-project]')).toHaveLength(0)
+    // The bot is on screen, so the "nothing set up yet" notice is not.
+    expect(host.textContent).not.toContain('No projects are set up yet')
+  })
+
+  it('says what a refused bot account needs, in GitLab terms and with no machine code', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    // The group hit its bot-account ceiling: the account has no GitLab user and no group to name.
+    roster = [
+      {
+        ...BOT,
+        userId: null,
+        rootGroupPath: null,
+        state: 'admin_degraded',
+        stateReason: 'service_account_quota'
+      }
+    ]
+    await render()
+
+    const row = botRow('acct-1')
+    expect(row.textContent).toContain('setup incomplete')
+    expect(row.textContent).toContain('limit of bot accounts')
+    expect(row.textContent).not.toContain('service_account_quota')
+    // No account on GitLab yet, so the handle names it without offering a dead profile link.
+    const handle = row.querySelector('[data-gitlab-account]')!
+    expect(handle.tagName).toBe('SPAN')
+    // The group falls back to its number rather than borrowing another project's path.
+    expect(row.textContent).toContain('group 900')
+  })
+
+  it('does not call a refused account retiring: it is waiting for Repair, not leaving', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    // Refused creation leaves an ACTIVE account row that never got a membership.
+    roster = [{ ...BOT, userId: null, state: 'admin_degraded', stateReason: 'service_account_quota', memberships: [] }]
+    await render()
+
+    const row = botRow('acct-1')
+    expect(row.textContent).toContain('Not a member of any project yet')
+    expect(row.textContent).not.toContain('on its way out')
+    expect(row.textContent).not.toContain('removing')
+    // And the health line still says what to do about it.
+    expect(row.textContent).toContain('limit of bot accounts')
+  })
+
+  it('gives a project no bot is a member of its own group, with its actions', async () => {
+    // A binding outlives its last consumer: it still owns the webhook and the claim,
+    // so it must keep somewhere to be repaired, transferred, or removed from.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([{ ...BINDING, state: 'admin_degraded' as const }])
+    mocks.repairProject.mockResolvedValue({ ...BINDING, state: 'provisioning' as const })
+    roster = []
+    await render()
+
+    const orphans = orphanSection()!
+    expect(orphans.textContent).toContain('Projects without a bot')
+    const project = projectRow(orphans, 'bind-1')
+    expect(project.textContent).toContain('example-group/example-project')
+    expect(project.textContent).toContain('setup incomplete')
+    expect(buttonIn(project, 'Repair')).toBeTruthy()
+    expect(buttonIn(project, 'Remove')).toBeTruthy()
+    // Its administering account is still connected, so there is no authority to take over.
+    expect(() => buttonIn(project, 'Take over')).toThrow()
+
+    await click('Repair', project)
+    expect(mocks.repairProject).toHaveBeenCalledWith('bind-1')
+  })
+
+  it('moves a project out of that group as soon as a bot becomes a member', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = []
+    await render()
+    expect(projectRow(orphanSection()!, 'bind-1')).toBeTruthy()
+    expect(host.querySelectorAll('[data-gitlab-bot]')).toHaveLength(0)
+
+    // The provisioning saga lands the membership; the next roster read carries it.
+    await act(async () => root.unmount())
+    roster = [BOT]
+    await render()
+    expect(orphanSection()).toBeNull()
+    expect(projectRow(botRow('acct-1'), 'bind-1')).toBeTruthy()
+  })
+
+  it('polls on the server’s convergence answer, not on how the roster happens to look', async () => {
+    // A membership can change while this project set does not — a hook disabled elsewhere
+    // converges asynchronously — so a roster that merely looks settled proves nothing.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    converging = true
+    await render()
+    expect(pollInterval()).toBeGreaterThan(0)
+
+    await act(async () => root.unmount())
+    converging = false
+    await render()
+    expect(pollInterval()).toBe(0)
+  })
+
+  it('keeps polling through a role-only downgrade, then shows the settled role', async () => {
+    // Dropping one of an agent's two authorizations downgrades its surviving membership
+    // instead of removing it: the bot and the project both stay, only the role moves.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    converging = true
+    await render()
+    expect(projectRow(botRow('acct-1'), 'bind-1').textContent).toContain('Developer')
+    expect(pollInterval()).toBeGreaterThan(0)
+
+    await act(async () => root.unmount())
+    roster = [{ ...BOT, memberships: [{ ...MEMBER, accessLevel: 20 }] }]
+    converging = false
+    await render()
+    expect(projectRow(botRow('acct-1'), 'bind-1').textContent).toContain('Reporter')
+    expect(pollInterval()).toBe(0)
+  })
+
+  it('keeps asking before the read has answered at all', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = undefined
+    await render()
+    expect(pollInterval()).toBeGreaterThan(0)
+  })
+
+  it('re-reads the roster after Repair, whose account changes leave the project set alone', async () => {
+    // Repair can create or heal an account and its membership without touching the bound
+    // projects, so nothing about the key would change and the cached roster would stay stale.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    mocks.repairProject.mockResolvedValue({ ...BINDING, state: 'ready' as const })
+    await render()
+
+    await click('Repair', projectRow(botRow('acct-1'), 'bind-1'))
+    expect(mocks.repairProject).toHaveBeenCalledWith('bind-1')
+    expect(mocks.reread).toHaveBeenCalled()
+  })
+
+  it('re-reads the roster after a takeover, which re-runs convergence under the new account', async () => {
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [{ ...CONNECTION, state: 'disconnected' as const, assignedProjects: 1 }]
+    })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    mocks.transferProject.mockResolvedValue({ ...BINDING, installerConnectionId: 'conn-1' })
+    await render()
+
+    await click('Take over', projectRow(botRow('acct-1'), 'bind-1'))
+    await click('Take over', modal())
+    expect(mocks.reread).toHaveBeenCalled()
+  })
+
+  it('re-reads the roster when a removal did not finish and the project set stayed put', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    mocks.deleteProject.mockResolvedValue({ removed: false, state: 'cleanup_pending', stateReason: 'cleanup_failed' })
+    await render()
+
+    await click('Remove', projectRow(botRow('acct-1'), 'bind-1'))
+    await click('Remove', modal())
+    expect(mocks.reread).toHaveBeenCalled()
+    // The project is still listed, in the state GitLab left it in.
+    expect(host.textContent).toContain('removal incomplete')
+  })
+
+  it('keys the roster read on the bound projects, so a removal cannot serve a stale one', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    mocks.deleteProject.mockResolvedValue({ removed: true })
+    await render()
+    const before = lastSwr?.key
+
+    await click('Remove', projectRow(botRow('acct-1'), 'bind-1'))
+    await click('Remove', modal())
+    expect(mocks.deleteProject).toHaveBeenCalledWith('bind-1')
+    // The key carries the binding set, so the entry recorded under the old one is unreachable.
+    expect(lastSwr?.key).not.toEqual(before)
   })
 
   it('surfaces the reconnect hint when GitLab stopped accepting the connection', async () => {
@@ -222,14 +689,16 @@ describe('GitlabCard', () => {
     const mine = { ...CONNECTION, id: 'conn-2', gitlabUsername: 'current-admin', assignedProjects: 0 }
     mocks.fetchConnections.mockResolvedValueOnce({ enabled: true, connections: [stale, mine] })
     mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
     await render()
 
     expect(connectionRow('conn-1').textContent).toContain('still administers 1 project')
     expect(connectionRow('conn-1').textContent).toContain('Transfer that project')
     expect(() => buttonIn(connectionRow('conn-1'), 'Remove')).toThrow()
 
+    const project = () => projectRow(botRow('acct-1'), 'bind-1')
     // Remove is explained, not attempted: the saga would fail halfway at GitLab.
-    await click('Remove', host.querySelector('[data-gitlab-project]')!)
+    await click('Remove', project())
     expect(modal().textContent).toContain('no longer connected')
     expect(() => buttonIn(modal(), 'Remove')).toThrow()
     expect(mocks.deleteProject).not.toHaveBeenCalled()
@@ -244,34 +713,59 @@ describe('GitlabCard', () => {
         { ...mine, assignedProjects: 1 }
       ]
     })
-    await click('Transfer', host.querySelector('[data-gitlab-project]')!)
+    await click('Take over', project())
     expect(mocks.transferProject).not.toHaveBeenCalled()
-    await click('Transfer', modal())
+    await click('Take over', modal())
     expect(mocks.transferProject).toHaveBeenCalledWith('bind-1')
     expect(connectionRow('conn-1').textContent).not.toContain('still administers')
     expect(buttonIn(connectionRow('conn-1'), 'Remove')).toBeTruthy()
 
     // And removal now runs for real, under the account that took it over.
     mocks.deleteProject.mockResolvedValue({ removed: true })
-    await click('Remove', host.querySelector('[data-gitlab-project]')!)
+    await click('Remove', project())
     await click('Remove', modal())
     expect(mocks.deleteProject).toHaveBeenCalledWith('bind-1')
     expect(host.querySelectorAll('[data-gitlab-project]')).toHaveLength(0)
   })
 
-  it('offers Transfer only where administration is stuck', async () => {
+  it('offers Take over only where administration lost its authority, never on a healthy row', async () => {
+    // Taking a project over swaps the account that administers it. That is only meaningful when
+    // the current one cannot act — a degraded project under a CONNECTED account is a Repair.
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     mocks.fetchProjects.mockResolvedValue([
       BINDING,
-      { ...BINDING, id: 'bind-degraded', projectPath: 'example-group/degraded', state: 'admin_degraded' as const }
+      { ...BINDING, id: 'bind-degraded', projectPath: 'example-group/degraded', state: 'admin_degraded' as const },
+      { ...BINDING, id: 'bind-cleanup', projectPath: 'example-group/going', state: 'cleanup_pending' as const }
     ])
+    roster = [
+      {
+        ...BOT,
+        memberships: [
+          ...BOT.memberships,
+          { ...MEMBER, bindingId: 'bind-degraded' },
+          { ...MEMBER, bindingId: 'bind-cleanup' }
+        ]
+      }
+    ]
     await render()
 
-    const healthy = host.querySelector('[data-gitlab-project="bind-1"]')!
-    const degraded = host.querySelector('[data-gitlab-project="bind-degraded"]')!
-    // A ready project its own connected account manages has nothing to take over.
-    expect(() => buttonIn(healthy, 'Transfer')).toThrow()
-    expect(buttonIn(degraded, 'Transfer')).toBeTruthy()
+    const bot = botRow('acct-1')
+    expect(() => buttonIn(projectRow(bot, 'bind-1'), 'Take over')).toThrow()
+    // Degraded, but its own account is still connected and can repair it.
+    expect(() => buttonIn(projectRow(bot, 'bind-degraded'), 'Take over')).toThrow()
+    // A removal waiting for authority is the one state that always needs one.
+    expect(buttonIn(projectRow(bot, 'bind-cleanup'), 'Take over')).toBeTruthy()
+  })
+
+  it('offers Take over once the account administering a project is no longer connected', async () => {
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [{ ...CONNECTION, state: 'disconnected' as const, assignedProjects: 1 }]
+    })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    await render()
+    expect(buttonIn(projectRow(botRow('acct-1'), 'bind-1'), 'Take over')).toBeTruthy()
   })
 
   it('offers Transfer on a project awaiting cleanup, connected installer and all', async () => {
@@ -279,8 +773,9 @@ describe('GitlabCard', () => {
     // the takeover is what lets someone else finish it.
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     mocks.fetchProjects.mockResolvedValue([{ ...BINDING, state: 'cleanup_pending' as const }])
+    roster = [BOT]
     await render()
-    expect(buttonIn(host.querySelector('[data-gitlab-project]')!, 'Transfer')).toBeTruthy()
+    expect(buttonIn(projectRow(botRow('acct-1'), 'bind-1'), 'Take over')).toBeTruthy()
   })
 
   it('keeps a connect action reachable for a caller who owns none of the connections', async () => {
@@ -305,11 +800,12 @@ describe('GitlabCard', () => {
       connections: [{ ...CONNECTION, mine: false, state: 'disconnected' as const, assignedProjects: 1 }]
     })
     mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
     mocks.transferProject.mockRejectedValue(new ApiError('no own connection', 409, 'GITLAB_NO_OWN_CONNECTION'))
     await render()
 
-    await click('Transfer', host.querySelector('[data-gitlab-project]')!)
-    await click('Transfer', modal())
+    await click('Take over', projectRow(botRow('acct-1'), 'bind-1'))
+    await click('Take over', modal())
     // The refusal names the affordance, and that affordance is on screen.
     expect(host.textContent).toContain('Connect my account')
     expect(buttonIn(host, 'Connect my account')).toBeTruthy()
@@ -321,11 +817,12 @@ describe('GitlabCard', () => {
       connections: [{ ...CONNECTION, state: 'disconnected' as const, assignedProjects: 1 }]
     })
     mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
     mocks.transferProject.mockRejectedValue(new ApiError('gitlab: nope', 403, 'GITLAB_NOT_MAINTAINER'))
     await render()
 
-    await click('Transfer', host.querySelector('[data-gitlab-project]')!)
-    await click('Transfer', modal())
+    await click('Take over', projectRow(botRow('acct-1'), 'bind-1'))
+    await click('Take over', modal())
     expect(host.textContent).toContain('Maintainer or Owner access')
     // The refusal is readable: the dialog is gone and no machine code is shown.
     expect(host.querySelector('.modal')).toBeNull()
@@ -335,6 +832,7 @@ describe('GitlabCard', () => {
   it('repairs and removes the project it was invoked on', async () => {
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
     mocks.repairProject.mockResolvedValue({ ...BINDING, state: 'provisioning' as const })
     mocks.deleteProject.mockResolvedValue({ removed: true })
     await render()
@@ -369,6 +867,7 @@ describe('GitlabCard', () => {
     // Authorization lives at the point of use; the card is the health list, like GitHub's.
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
     await render()
 
     expect(() => buttonIn(host, 'Add project')).toThrow()
@@ -376,50 +875,6 @@ describe('GitlabCard', () => {
     // The health list itself is untouched: the project, its state, and its repairs.
     expect(host.querySelectorAll('[data-gitlab-project]')).toHaveLength(1)
     expect(buttonIn(host, 'Repair')).toBeTruthy()
-  })
-
-  it('links each member account chip to its GitLab profile', async () => {
-    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
-    mocks.fetchProjects.mockResolvedValue([BINDING])
-    await render()
-
-    const chip = host.querySelector('[data-gitlab-account]') as HTMLAnchorElement
-    expect(chip.textContent).toBe('bot @agentconnect-a1-g900')
-    expect(chip.getAttribute('href')).toBe('https://gitlab.com/agentconnect-a1-g900')
-    // A new tab, and never one that can reach back into the console.
-    expect(chip.getAttribute('target')).toBe('_blank')
-    expect(chip.getAttribute('rel')).toBe('noopener noreferrer')
-  })
-
-  it('gives a project one chip per member account, each with its own health', async () => {
-    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
-    mocks.fetchProjects.mockResolvedValue([
-      {
-        ...BINDING,
-        accounts: [
-          ...BINDING.accounts,
-          {
-            agentId: 'agent-2',
-            username: 'agentconnect-a2-g900',
-            displayName: 'triager',
-            userId: null,
-            state: 'admin_degraded' as const,
-            stateReason: 'service_account_quota'
-          }
-        ]
-      }
-    ])
-    await render()
-
-    const chips = [...host.querySelectorAll('[data-gitlab-account]')] as HTMLAnchorElement[]
-    expect(chips.map((c) => c.getAttribute('href'))).toEqual([
-      'https://gitlab.com/agentconnect-a1-g900',
-      'https://gitlab.com/agentconnect-a2-g900'
-    ])
-    // The binding is ready; only the refused account is marked, and its tooltip says why.
-    expect(chips[0]!.className).toContain('text-(--text-tertiary)')
-    expect(chips[1]!.className).toContain('text-(--amber-500)')
-    expect(chips[1]!.getAttribute('title')).toContain('limit of bot accounts')
   })
 
   it('says where projects come from when a connection has none', async () => {
@@ -455,6 +910,7 @@ describe('GitlabCard', () => {
         stateReason: 'some_future_category'
       }
     ])
+    roster = []
     await render()
     expect(host.textContent).toContain('GitLab project is no longer accessible')
     expect(host.textContent).toContain('The project bot credential needs repair')

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -624,6 +624,29 @@ describe('GitlabCard', () => {
     expect(row().textContent).not.toContain('webhook')
   })
 
+  it('discards the read taken at mount when a newer one has already answered', async () => {
+    // The mount read is launched before the roster surface is even enabled, so it races every
+    // fenced read that follows. Left unfenced it answers last and paints its own snapshot back.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    let initial!: (rows: GitlabProjectBindingDto[]) => void
+    mocks.fetchProjects.mockReturnValueOnce(new Promise((resolve) => (initial = resolve)))
+    roster = [BOT]
+    converging = true
+    await render()
+
+    // A fenced poll answers first, with the install finished.
+    let newer!: (rows: GitlabProjectBindingDto[]) => void
+    mocks.fetchProjects.mockReturnValueOnce(new Promise((resolve) => (newer = resolve)))
+    await revalidate()
+    await act(async () => newer([BINDING]))
+    const row = () => projectRow(botRow('acct-1'), 'bind-1')
+    expect(row().textContent).not.toContain('webhook')
+
+    // The mount read finally lands, still describing the install as running, and is dropped.
+    await act(async () => initial([{ ...BINDING, webhookState: 'repairing' as const }]))
+    expect(row().textContent).not.toContain('webhook')
+  })
+
   it('leaves the projects alone once nothing is converging', async () => {
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     mocks.fetchProjects.mockResolvedValue([BINDING])

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -81,6 +81,16 @@ vi.mock('swr', () => ({
 
 interface SwrOptions {
   refreshInterval?: (latest: unknown) => number
+  onSuccess?: (latest: unknown) => void
+}
+
+/** Drive one successful revalidation of the roster read, the way SWR's poll would. */
+async function revalidate(): Promise<void> {
+  const onSuccess = lastSwr?.options.onSuccess
+  if (!onSuccess) throw new Error('the card handles no roster revalidation')
+  await act(async () => {
+    onSuccess(read())
+  })
 }
 
 /** What the roster read answers with right now, or undefined before it has answered. */
@@ -551,6 +561,36 @@ describe('GitlabCard', () => {
     await render()
     expect(projectRow(botRow('acct-1'), 'bind-1').textContent).toContain('Reporter')
     expect(pollInterval()).toBe(0)
+  })
+
+  it('re-reads the projects on every roster poll while convergence is pending', async () => {
+    // A webhook still installing lives on the project row, not the roster, and the projects were
+    // read once at mount — so without this the transient badge would sit there until a reload.
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([{ ...BINDING, webhookState: 'repairing' as const }])
+    roster = [BOT]
+    converging = true
+    await render()
+    expect(projectRow(botRow('acct-1'), 'bind-1').textContent).toContain('webhook repairing')
+    const reads = mocks.fetchProjects.mock.calls.length
+
+    // The install lands; the next poll picks the projects up with it.
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    await revalidate()
+    expect(mocks.fetchProjects.mock.calls.length).toBeGreaterThan(reads)
+    expect(projectRow(botRow('acct-1'), 'bind-1').textContent).not.toContain('webhook')
+  })
+
+  it('leaves the projects alone once nothing is converging', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    converging = false
+    await render()
+    const reads = mocks.fetchProjects.mock.calls.length
+
+    await revalidate()
+    expect(mocks.fetchProjects.mock.calls.length).toBe(reads)
   })
 
   it('keeps asking before the read has answered at all', async () => {

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -563,22 +563,37 @@ describe('GitlabCard', () => {
     expect(pollInterval()).toBe(0)
   })
 
-  it('re-reads the projects on every roster poll while convergence is pending', async () => {
+  it('re-reads the projects while convergence is pending, and once more when it settles', async () => {
     // A webhook still installing lives on the project row, not the roster, and the projects were
     // read once at mount — so without this the transient badge would sit there until a reload.
+    // The response that reports settled is the one carrying the finished state AND the one that
+    // stops the poll, so skipping the read there would strand the badge for good.
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     mocks.fetchProjects.mockResolvedValue([{ ...BINDING, webhookState: 'repairing' as const }])
     roster = [BOT]
     converging = true
     await render()
-    expect(projectRow(botRow('acct-1'), 'bind-1').textContent).toContain('webhook repairing')
-    const reads = mocks.fetchProjects.mock.calls.length
+    const row = () => projectRow(botRow('acct-1'), 'bind-1')
+    expect(row().textContent).toContain('webhook repairing')
 
-    // The install lands; the next poll picks the projects up with it.
-    mocks.fetchProjects.mockResolvedValue([BINDING])
+    // A poll taken while it is still installing re-reads, and the badge honestly stays.
+    const pending = mocks.fetchProjects.mock.calls.length
     await revalidate()
-    expect(mocks.fetchProjects.mock.calls.length).toBeGreaterThan(reads)
-    expect(projectRow(botRow('acct-1'), 'bind-1').textContent).not.toContain('webhook')
+    expect(mocks.fetchProjects.mock.calls.length).toBeGreaterThan(pending)
+    expect(row().textContent).toContain('webhook repairing')
+
+    // The install completes, and the roster settles in the same breath.
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    converging = false
+    const settling = mocks.fetchProjects.mock.calls.length
+    await revalidate()
+    expect(mocks.fetchProjects.mock.calls.length).toBe(settling + 1)
+    expect(row().textContent).not.toContain('webhook')
+    expect(pollInterval()).toBe(0)
+
+    // Exactly one: a settled answer following a settled one reads nothing more.
+    await revalidate()
+    expect(mocks.fetchProjects.mock.calls.length).toBe(settling + 1)
   })
 
   it('leaves the projects alone once nothing is converging', async () => {

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -209,8 +209,11 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
         setEnabled(enabled)
         setConnections(connections)
         if (!enabled) return
+        // This read races the roster's own the moment the surface is enabled, so it takes a
+        // generation like every other one: `alive` answers unmount, not which answer is newest.
+        const seq = supersedeReads()
         const bindings = await fetchGitlabProjects()
-        if (alive) setProjects(bindings)
+        if (alive && seq === readSeq.current) setProjects(bindings)
       })
       .catch(() => alive && setEnabled(false))
     return () => {

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -200,6 +200,8 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
   useEffect(() => {
     if (!activeOrg) return
     let alive = true
+    // A different organization: nothing already in flight may speak for this one.
+    supersedeReads()
     setEnabled(null)
     fetchGitlabConnections()
       .then(async ({ enabled, connections }) => {
@@ -218,6 +220,19 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
 
   // Whether the last roster answer still owed convergence, so the settling one can be recognized.
   const wasConverging = useRef(false)
+  // Roster answers launch project reads independently, so two can be in flight at once and the
+  // slower one may land last. Only the newest generation may commit; a write or an organization
+  // switch supersedes every read still out there, since both know better than any of them.
+  const readSeq = useRef(0)
+  const supersedeReads = (): number => ++readSeq.current
+  const refreshProjects = (): void => {
+    const seq = supersedeReads()
+    void fetchGitlabProjects()
+      .then((rows) => {
+        if (seq === readSeq.current) setProjects(rows)
+      })
+      .catch(() => undefined)
+  }
   // The bound-project set is part of the key, so adding or removing a project makes the
   // entry recorded under the old set unreachable and no action site has to invalidate it.
   const signature = [...projects.map((project) => project.id)].sort().join(',')
@@ -236,9 +251,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
       const settling = wasConverging.current && !latest.converging
       wasConverging.current = latest.converging
       if (!latest.converging && !settling) return
-      void fetchGitlabProjects()
-        .then((rows) => setProjects(rows))
-        .catch(() => undefined)
+      refreshProjects()
     },
     shouldRetryOnError: false
   })
@@ -289,6 +302,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     setErr(null)
     try {
       const updated = await transferGitlabProject(binding.id)
+      supersedeReads()
       setProjects((current) => current.map((p) => (p.id === updated.id ? updated : p)))
       // The takeover re-runs convergence under the new account, so the roster moves with it.
       await rereadBots()
@@ -310,6 +324,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     setErr(null)
     try {
       const updated = await repairGitlabProject(binding.id)
+      supersedeReads()
       setProjects((current) => current.map((p) => (p.id === updated.id ? updated : p)))
       // Repair can create or heal an account and its membership while the project set stays put,
       // so the roster under this unchanged key is stale until it is re-read.
@@ -327,6 +342,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     setErr(null)
     try {
       const outcome = await deleteGitlabProject(binding.id)
+      supersedeReads()
       // Incomplete external cleanup keeps the row, in its reported state — GitLab still holds something.
       if (outcome.removed) {
         setProjects((current) => current.filter((p) => p.id !== binding.id))

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -9,7 +9,7 @@
 // Deployment-config opt-in: with no GitLab application configured these routes 404 and the card says so.
 // Connections and projects are org-level infrastructure — visible to all, writable by non-viewers.
 
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import Link from 'next/link'
 import useSWR from 'swr'
 import { Button, Icon } from '@/components/ui'
@@ -216,6 +216,8 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     }
   }, [activeOrg])
 
+  // Whether the last roster answer still owed convergence, so the settling one can be recognized.
+  const wasConverging = useRef(false)
   // The bound-project set is part of the key, so adding or removing a project makes the
   // entry recorded under the old set unreachable and no action site has to invalidate it.
   const signature = [...projects.map((project) => project.id)].sort().join(',')
@@ -225,9 +227,15 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     // while this project set does not — so only the server can say whether to ask again.
     refreshInterval: (latest) => (latest && !latest.converging ? 0 : GITLAB_CONVERGENCE_POLL_MS),
     // The projects carry state the same saga moves — a webhook still installing among it — so they
-    // ride this poll rather than resting on the read taken at mount. A write in flight owns them.
+    // ride this poll rather than resting on the read taken at mount. A write in flight owns them,
+    // and leaves the edge below unconsumed so the settling read still happens afterwards.
     onSuccess: (latest) => {
-      if (!latest.converging || busyId !== null) return
+      if (busyId !== null) return
+      // The response that reports settled is the one carrying the finished state, and polling
+      // stops right after it — so the pending→settled edge earns one last read of its own.
+      const settling = wasConverging.current && !latest.converging
+      wasConverging.current = latest.converging
+      if (!latest.converging && !settling) return
       void fetchGitlabProjects()
         .then((rows) => setProjects(rows))
         .catch(() => undefined)

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -1,27 +1,45 @@
 // No 'use client' here: rendered only inside a client boundary (IntegrationsView).
 
-// The org's GitLab.com connection and the health of the projects it manages
-// (gitlab-com-integration.md §18.1). Like the GitHub card this is the management
-// surface only: a project joins the organization where it is used — the hook and
-// workspace flows — not from a picker here.
+// The org's GitLab.com connection and the bots that act on it
+// (gitlab-com-integration.md §18.1). Like the chat-platform cards the BOT is the row:
+// one per agent service account, with the projects it is a member of underneath and
+// the project-level actions on the project line. Like the GitHub card this is the
+// management surface only: a project joins the organization where it is used — the hook
+// and workspace flows — not from a picker here.
 // Deployment-config opt-in: with no GitLab application configured these routes 404 and the card says so.
 // Connections and projects are org-level infrastructure — visible to all, writable by non-viewers.
 
 import { useEffect, useState, type ReactNode } from 'react'
+import Link from 'next/link'
+import useSWR from 'swr'
 import { Button, Icon } from '@/components/ui'
-import { GitlabMark, LoadingState } from '@/components/marks'
+import { AgentIconView, GitlabMark, LoadingState } from '@/components/marks'
+import { useConsoleData } from '@/lib/data-context'
+import { agentLabel } from '@/lib/data'
 import { useOrgs } from '@/lib/org-context'
-import { GITLAB_PROJECT_STATE, gitlabProfileUrl, gitlabStateReasonText } from '@/lib/gitlab-projects'
+import { consoleKeys } from '@/lib/swr-keys'
+import {
+  GITLAB_CONVERGENCE_POLL_MS,
+  GITLAB_PROJECT_STATE,
+  gitlabMembershipReason,
+  gitlabProfileUrl,
+  gitlabRoleLabel,
+  gitlabStateReasonText,
+  gitlabWebhookBadge
+} from '@/lib/gitlab-projects'
 import {
   ApiError,
   deleteGitlabProject,
   disconnectGitlabConnection,
+  fetchGitlabAccounts,
   fetchGitlabConnections,
   fetchGitlabProjects,
   repairGitlabProject,
   startGitlabOauth,
   transferGitlabProject,
   type GitlabConnectionDto,
+  type GitlabMembershipDto,
+  type GitlabOrgAccountDto,
   type GitlabProjectBindingDto
 } from '@/lib/api'
 
@@ -40,9 +58,133 @@ function errorText(e: unknown): string {
   return e instanceof Error ? e.message : String(e)
 }
 
+/** One bot row: the account, and the bindings it is a member of, in path order. */
+interface BotRow {
+  account: GitlabOrgAccountDto
+  projects: Array<{ binding: GitlabProjectBindingDto; membership: GitlabMembershipDto }>
+}
+
+/** Bots in the order the server returns them, each with its member projects. A binding
+ *  two bots share appears under both — the membership is what the row is keyed by. */
+function botRows(accounts: readonly GitlabOrgAccountDto[], bindings: readonly GitlabProjectBindingDto[]): BotRow[] {
+  const byId = new Map(bindings.map((binding) => [binding.id, binding]))
+  return accounts.map((account) => ({
+    account,
+    projects: account.memberships
+      .flatMap((membership) => {
+        const binding = byId.get(membership.bindingId)
+        return binding ? [{ binding, membership }] : []
+      })
+      .sort((a, b) => a.binding.projectPath.localeCompare(b.binding.projectPath))
+  }))
+}
+
+/** Managed projects no listed bot is a member of. A binding outlives its last consumer —
+ *  it still owns the webhook and the deployment-global claim — so it keeps its own row. */
+function orphanBindings(
+  accounts: readonly GitlabOrgAccountDto[],
+  bindings: readonly GitlabProjectBindingDto[]
+): GitlabProjectBindingDto[] {
+  const claimed = new Set(accounts.flatMap((account) => account.memberships.map((m) => m.bindingId)))
+  return bindings.filter((binding) => !claimed.has(binding.id))
+}
+
+/** One managed project: its state, its webhook, and the actions that act on the binding. */
+function ProjectRow({
+  binding,
+  membership,
+  indented,
+  canWrite,
+  busy,
+  stuck,
+  onRepair,
+  onRemove,
+  onTransfer
+}: {
+  binding: GitlabProjectBindingDto
+  /** The bot's hold on it; absent on a project no bot is a member of. */
+  membership?: GitlabMembershipDto
+  indented: boolean
+  canWrite: boolean
+  busy: boolean
+  stuck: boolean
+  onRepair: () => void
+  onRemove: () => void
+  onTransfer: () => void
+}) {
+  const reason = gitlabStateReasonText(binding.stateReason)
+  const webhook = gitlabWebhookBadge(binding.webhookState)
+  const why = membership ? gitlabMembershipReason(membership) : null
+  // Taking a project over is only meaningful where administration has actually lost its
+  // authority: a connection that is gone, or a removal waiting for one. Never on a healthy row.
+  const takeable = stuck || binding.state === 'cleanup_pending'
+  return (
+    <div
+      className={`row grid-cols-1 gap-2 desktop:grid-cols-[minmax(0,1fr)_auto] desktop:gap-[11px] ${
+        indented ? 'pl-[34px] desktop:pl-[50px]' : ''
+      }`}
+      data-gitlab-project={binding.id}
+    >
+      <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
+        <span className="mono min-w-0 truncate text-[12.5px]">{binding.projectPath}</span>
+        {membership && (
+          <span className="badge bg-(--surface-active) text-(--text-tertiary)">
+            {gitlabRoleLabel(membership.accessLevel)}
+          </span>
+        )}
+        <span className={`badge ${GITLAB_PROJECT_STATE[binding.state].badge}`}>
+          {GITLAB_PROJECT_STATE[binding.state].label}
+        </span>
+        {/* Silent unless the webhook needs attention: not needing one is a normal state. */}
+        {webhook && <span className={`badge ${webhook.badge}`}>{webhook.label}</span>}
+      </div>
+      <span className="flex items-center justify-end gap-3">
+        {/* Only a project whose administration is stuck can be taken over — and one
+            awaiting cleanup always can, since that is what unblocks its removal. */}
+        {canWrite && takeable && (
+          <Button variant="ghost" size="xs" disabled={busy} onClick={onTransfer}>
+            <Icon name="key-round" size={13} />
+            Take over
+          </Button>
+        )}
+        {canWrite && (
+          <Button variant="ghost" size="xs" disabled={busy} onClick={onRepair}>
+            <Icon name="wrench" size={13} />
+            {busy ? 'Working…' : 'Repair'}
+          </Button>
+        )}
+        {canWrite && (
+          <Button
+            variant="ghost"
+            size="xs"
+            className="text-(--status-error) hover:text-(--status-error)"
+            disabled={busy}
+            onClick={onRemove}
+          >
+            <Icon name="trash-2" size={13} />
+            Remove
+          </Button>
+        )}
+      </span>
+      {/* Why this bot is here at all: dropping one authorization while another stands is a change to read, not a ghost. */}
+      {why && (
+        <span className="font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">
+          {why}
+        </span>
+      )}
+      {reason && (
+        <span className="font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">
+          {reason}
+        </span>
+      )}
+    </div>
+  )
+}
+
 export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
   // Gate on the active org like the GitHub card: before it resolves `orgBase()` throws and reads "not enabled".
-  const { activeOrg } = useOrgs()
+  const { activeOrg, orgPath } = useOrgs()
+  const { getAgent } = useConsoleData()
   const [enabled, setEnabled] = useState<boolean | null>(null)
   const [connections, setConnections] = useState<GitlabConnectionDto[]>([])
   const [projects, setProjects] = useState<GitlabProjectBindingDto[]>([])
@@ -73,6 +215,17 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
       alive = false
     }
   }, [activeOrg])
+
+  // The bound-project set is part of the key, so adding or removing a project makes the
+  // entry recorded under the old set unreachable and no action site has to invalidate it.
+  const signature = [...projects.map((project) => project.id)].sort().join(',')
+  const botsKey = enabled === true ? consoleKeys.gitlabAccounts(activeOrg?.id, signature) : null
+  const { data: bots, mutate: rereadBots } = useSWR(botsKey, ([, orgId]) => fetchGitlabAccounts(orgId as string), {
+    // Convergence runs behind hook and workspace CRUD elsewhere, and a membership can change
+    // while this project set does not — so only the server can say whether to ask again.
+    refreshInterval: (latest) => (latest && !latest.converging ? 0 : GITLAB_CONVERGENCE_POLL_MS),
+    shouldRetryOnError: false
+  })
 
   // The authorization URL carries a one-shot state — mint a fresh one per click.
   const connect = async () => {
@@ -121,6 +274,8 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     try {
       const updated = await transferGitlabProject(binding.id)
       setProjects((current) => current.map((p) => (p.id === updated.id ? updated : p)))
+      // The takeover re-runs convergence under the new account, so the roster moves with it.
+      await rereadBots()
       // The takeover moves a project between connections, and both counts gate their Remove.
       const fresh = await fetchGitlabConnections().catch(() => null)
       if (fresh) setConnections(fresh.connections)
@@ -140,6 +295,9 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     try {
       const updated = await repairGitlabProject(binding.id)
       setProjects((current) => current.map((p) => (p.id === updated.id ? updated : p)))
+      // Repair can create or heal an account and its membership while the project set stays put,
+      // so the roster under this unchanged key is stale until it is re-read.
+      await rereadBots()
     } catch (e) {
       setErr(errorText(e))
     } finally {
@@ -160,7 +318,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
         // freeing the last project has to be read back before Remove can appear.
         const fresh = await fetchGitlabConnections().catch(() => null)
         if (fresh) setConnections(fresh.connections)
-      } else
+      } else {
         setProjects((current) =>
           current.map((p) =>
             p.id === binding.id
@@ -168,6 +326,9 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
               : p
           )
         )
+        // An incomplete removal keeps the project set, so the roster it detached from does not re-key.
+        await rereadBots()
+      }
       setRemoving(null)
     } catch (e) {
       setErr(errorText(e))
@@ -175,6 +336,22 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
       setBusyId(null)
     }
   }
+
+  const accounts = bots?.accounts ?? []
+  const rows = botRows(accounts, projects)
+  const orphans = orphanBindings(accounts, projects)
+  // How many bots a removal would take off the project — the confirmation says so plainly.
+  const membersOf = (binding: GitlabProjectBindingDto): number =>
+    accounts.filter((account) => account.memberships.some((m) => m.bindingId === binding.id)).length
+
+  const projectActions = (binding: GitlabProjectBindingDto) => ({
+    canWrite,
+    busy: busyId === binding.id,
+    stuck: stuck(binding),
+    onRepair: () => repair(binding),
+    onRemove: () => (stuck(binding) ? setBlocked(binding) : setRemoving(binding)),
+    onTransfer: () => setTaking(binding)
+  })
 
   return (
     <div className="card">
@@ -291,7 +468,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
           </div>
         ))}
 
-      {enabled === true && connections.length > 0 && projects.length === 0 && (
+      {enabled === true && connections.length > 0 && rows.length === 0 && projects.length === 0 && (
         <div className="px-4 py-5 text-center font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
           No projects are set up yet. Pick one when you add a GitLab trigger or an agent workspace — it is set up there,
           and shows up here for repairs.
@@ -299,84 +476,105 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
       )}
 
       {/* Desktop only: below the breakpoint the row stacks, where a two-track header would label nothing. */}
-      {enabled === true && projects.length > 0 && (
+      {enabled === true && rows.length > 0 && (
         <div className="row h hidden grid-cols-[minmax(0,1fr)_auto] gap-[11px] desktop:grid">
-          <span>Project</span>
+          <span>Bot</span>
           <span>State</span>
         </div>
       )}
       {enabled === true &&
-        projects.map((p) => (
-          <div
-            key={p.id}
-            className="row grid-cols-1 gap-2 desktop:grid-cols-[minmax(0,1fr)_auto] desktop:gap-[11px]"
-            data-gitlab-project={p.id}
-          >
-            <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
-              <span className="mono min-w-0 truncate text-[12.5px]">{p.projectPath}</span>
-              <span className={`badge ${GITLAB_PROJECT_STATE[p.state].badge}`}>
-                {GITLAB_PROJECT_STATE[p.state].label}
-              </span>
-              {/* Each member account is a real GitLab user: its chip opens that profile.
-                  An account can be broken on a project whose own binding is ready, so
-                  the chip carries its own state rather than borrowing the row's. */}
-              {p.accounts.map((account) => (
-                <a
-                  key={account.username}
-                  href={gitlabProfileUrl(account.username)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  title={gitlabStateReasonText(account.stateReason) ?? account.displayName ?? account.username}
-                  data-gitlab-account={account.username}
-                  className={`font-sans text-[12px] font-normal leading-normal hover:underline ${
-                    account.state === 'ready' ? 'text-(--text-tertiary)' : 'text-(--amber-500)'
-                  }`}
-                >
-                  {account.state !== 'ready' && (
-                    <Icon name="triangle-alert" size={12} className="mr-[3px] inline-block align-[-1px]" />
+        rows.map(({ account, projects: members }) => {
+          const agent = getAgent(account.agentId)
+          const name = agent ? agentLabel(agent) : (account.displayName ?? account.username)
+          const reason = gitlabStateReasonText(account.stateReason)
+          return (
+            <div key={account.id} data-gitlab-bot={account.id}>
+              <div className="row grid-cols-1 gap-2">
+                <div className="flex min-w-0 flex-wrap items-center gap-[10px]">
+                  {/* The bot IS an agent: its face and its name lead back to that agent's page. */}
+                  <Link
+                    href={orgPath(`/agents/${encodeURIComponent(account.agentId)}?tab=config`)}
+                    title={`Open ${name}`}
+                    className="flex min-w-0 items-center gap-[10px] no-underline"
+                  >
+                    <span className="av h-7 w-7 flex-none rounded-[7px]">
+                      <AgentIconView icon={agent?.icon} runtime={agent?.runtime || agent?.model || ''} size={28} />
+                    </span>
+                    <span className="min-w-0 truncate font-sans text-[13px] font-semibold leading-normal text-(--text-primary) hover:underline">
+                      {name}
+                    </span>
+                  </Link>
+                  {/* The username is deterministic, so the profile links only once the account exists. */}
+                  {account.userId ? (
+                    <a
+                      href={gitlabProfileUrl(account.username)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      data-gitlab-account={account.username}
+                      className="mono min-w-0 truncate text-[12px] text-(--text-tertiary) hover:underline"
+                    >
+                      @{account.username}
+                    </a>
+                  ) : (
+                    <span
+                      data-gitlab-account={account.username}
+                      className="mono min-w-0 truncate text-[12px] text-(--text-tertiary)"
+                    >
+                      @{account.username}
+                    </span>
                   )}
-                  bot @{account.username}
-                </a>
+                  <span className="badge bg-(--surface-active) text-(--text-tertiary)">
+                    {account.rootGroupPath ?? `group ${account.rootGroupId}`}
+                  </span>
+                  <span className={`badge ${GITLAB_PROJECT_STATE[account.state].badge}`}>
+                    {GITLAB_PROJECT_STATE[account.state].label}
+                  </span>
+                  {account.lifecycle === 'retiring' && (
+                    <span className="badge bg-(--surface-active) text-(--text-tertiary)">removing</span>
+                  )}
+                </div>
+                {reason && (
+                  <span className="font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+                    {reason}
+                  </span>
+                )}
+              </div>
+              {/* An account with no project still shows, so its health can be acted on. Only a
+                  retiring one is leaving: an active one was refused and is waiting for Repair. */}
+              {members.length === 0 && (
+                <div className="row grid-cols-1 pl-[34px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:pl-[50px]">
+                  {account.lifecycle === 'retiring' || account.state === 'cleanup_pending'
+                    ? 'Removing…'
+                    : 'Not a member of any project yet.'}
+                </div>
+              )}
+              {members.map(({ binding, membership }) => (
+                <ProjectRow
+                  key={binding.id}
+                  binding={binding}
+                  membership={membership}
+                  indented
+                  {...projectActions(binding)}
+                />
               ))}
-              {!p.webhookInstalled && (
-                <span className="badge bg-(--surface-active) text-(--text-tertiary)">no webhook</span>
-              )}
             </div>
-            <span className="flex items-center justify-end gap-3">
-              {/* Only a project whose administration is stuck can be taken over — and one
-                  awaiting cleanup always can, since that is what unblocks its removal. */}
-              {canWrite && (stuck(p) || p.state === 'admin_degraded' || p.state === 'cleanup_pending') && (
-                <Button variant="ghost" size="xs" disabled={busyId === p.id} onClick={() => setTaking(p)}>
-                  <Icon name="key-round" size={13} />
-                  Transfer
-                </Button>
-              )}
-              {canWrite && (
-                <Button variant="ghost" size="xs" disabled={busyId === p.id} onClick={() => repair(p)}>
-                  <Icon name="wrench" size={13} />
-                  {busyId === p.id ? 'Working…' : 'Repair'}
-                </Button>
-              )}
-              {canWrite && (
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  className="text-(--status-error) hover:text-(--status-error)"
-                  disabled={busyId === p.id}
-                  onClick={() => (stuck(p) ? setBlocked(p) : setRemoving(p))}
-                >
-                  <Icon name="trash-2" size={13} />
-                  Remove
-                </Button>
-              )}
+          )
+        })}
+
+      {/* A binding outlives its last consumer — it still owns the webhook and the claim —
+          so it keeps its state and its actions here rather than dropping off the card. */}
+      {enabled === true && orphans.length > 0 && (
+        <div data-gitlab-orphans="true">
+          <div className="border-b border-(--border-subtle) bg-(--surface-app) px-4 py-[6px]">
+            <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+              Projects without a bot — no agent is a member yet, and the webhook stays until the project is removed.
             </span>
-            {gitlabStateReasonText(p.stateReason) && (
-              <span className="font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">
-                {gitlabStateReasonText(p.stateReason)}
-              </span>
-            )}
           </div>
-        ))}
+          {orphans.map((binding) => (
+            <ProjectRow key={binding.id} binding={binding} indented={false} {...projectActions(binding)} />
+          ))}
+        </div>
+      )}
 
       {err && (
         <div className="px-4 py-2 font-sans text-[12px] font-normal leading-normal text-(--status-error)">{err}</div>
@@ -416,7 +614,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
         <div className="scrim" onClick={() => setTaking(null)}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
             <ConfirmGitlab
-              title="Transfer administration"
+              title="Take over project"
               body={
                 <>
                   Take over <span className="mono text-(--text-primary)">{taking.projectPath}</span>? GitLab is asked
@@ -424,7 +622,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                   account becomes the one AgentConnect uses to set up and repair it.
                 </>
               }
-              verb="Transfer"
+              verb="Take over"
               icon="key-round"
               busy={busyId === taking.id}
               danger={false}
@@ -461,9 +659,12 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
               title="Remove project"
               body={
                 <>
-                  Remove <span className="mono text-(--text-primary)">{removing.projectPath}</span>? The webhook and the
-                  project bot are deleted on GitLab, and agents stop answering there. Nothing in the project&rsquo;s
-                  code or history changes.
+                  Remove <span className="mono text-(--text-primary)">{removing.projectPath}</span> from this
+                  organization? The webhook and every project bot on it are deleted on GitLab, and
+                  {membersOf(removing) > 1
+                    ? ` all ${membersOf(removing)} bots listed on it stop answering there.`
+                    : ' agents stop answering there.'}{' '}
+                  Nothing in the project&rsquo;s code or history changes.
                 </>
               }
               verb="Remove"

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -224,6 +224,14 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     // Convergence runs behind hook and workspace CRUD elsewhere, and a membership can change
     // while this project set does not — so only the server can say whether to ask again.
     refreshInterval: (latest) => (latest && !latest.converging ? 0 : GITLAB_CONVERGENCE_POLL_MS),
+    // The projects carry state the same saga moves — a webhook still installing among it — so they
+    // ride this poll rather than resting on the read taken at mount. A write in flight owns them.
+    onSuccess: (latest) => {
+      if (!latest.converging || busyId !== null) return
+      void fetchGitlabProjects()
+        .then((rows) => setProjects(rows))
+        .catch(() => undefined)
+    },
     shouldRetryOnError: false
   })
 

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -78,7 +78,7 @@ const project = {
   state: 'ready',
   stateReason: null,
   accounts: [],
-  webhookInstalled: true,
+  webhookState: 'installed',
   credentialEpoch: '1',
   createdAt: '2026-08-01T00:00:00.000Z'
 }

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
@@ -45,7 +45,7 @@ const binding = (over: Record<string, unknown>) => ({
   state: 'ready',
   stateReason: null,
   accounts: [],
-  webhookInstalled: true,
+  webhookState: 'installed',
   credentialEpoch: '1',
   createdAt: '2026-08-01T00:00:00.000Z',
   ...over

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -5276,6 +5276,10 @@ export interface GitlabProjectDto {
   lastActivityAt: string | null
 }
 
+/** The managed webhook's state. `not_needed` is a normal resting state — a project with no
+ *  enabled trigger wants no ingress — not a condition anyone has to act on. */
+export type GitlabWebhookState = 'not_needed' | 'installed' | 'repairing' | 'failed'
+
 export type GitlabProjectBindingState =
   'provisioning' | 'ready' | 'admin_degraded' | 'runtime_degraded' | 'cleanup_pending'
 
@@ -5305,7 +5309,7 @@ export interface GitlabProjectBindingDto {
   /** The per-agent service accounts bound to this project: each agent acts on
    *  GitLab as its own user, so a project has a member list, not one bot. */
   accounts: GitlabProjectAccountDto[]
-  webhookInstalled: boolean
+  webhookState: GitlabWebhookState
   credentialEpoch: string
   createdAt: string
 }
@@ -5389,6 +5393,52 @@ export function transferGitlabProject(id: string): Promise<GitlabProjectBindingD
 
 export function deleteGitlabProject(id: string): Promise<GitlabProjectRemovalDto> {
   return apiDelete<GitlabProjectRemovalDto>(`${orgBase()}/gitlab/projects/${encodeURIComponent(id)}`)
+}
+
+/** Why one bot holds one project: the role, plus the authorizations that earned it. Dropping
+ *  an agent's triggers while its workspace stands must read as a change, not as a purposeless bot. */
+export interface GitlabMembershipDto {
+  bindingId: string
+  accessLevel: number
+  /** The agent's workspace on the project and the access it grants; null when it has none. */
+  workspace: 'read' | 'write' | null
+  /** Comment families the agent's enabled triggers cover here; may be empty. */
+  triggerFamilies: string[]
+  triggerCount: number
+}
+
+/** One organization bot for the Integrations card: the service account an agent acts as, one per
+ *  top-level group it has a bound project in, with the projects it is a member of. A project bound
+ *  to two agents therefore appears under both bots, once per membership. */
+export interface GitlabOrgAccountDto {
+  id: string
+  agentId: string
+  rootGroupId: string // numeric top-level group id, losslessly as a string
+  rootGroupPath: string | null // that group's current path, read off a bound project
+  username: string
+  displayName: string | null
+  userId: string | null // numeric GitLab user id; null until the account exists
+  state: GitlabProjectBindingState
+  stateReason: string | null
+  lifecycle: 'active' | 'retiring'
+  memberships: GitlabMembershipDto[]
+}
+
+/** The organization's bots, plus whether account convergence still owes it work — the console
+ *  cannot judge that itself, so it asks again only while the answer is yes.
+ *  Same enabled-probe shape as the connection list: 404 ⇒ no GitLab app. */
+export async function fetchGitlabAccounts(
+  orgId?: string
+): Promise<{ enabled: boolean; accounts: GitlabOrgAccountDto[]; converging: boolean }> {
+  try {
+    const body = await apiGet<{ accounts: GitlabOrgAccountDto[]; converging: boolean }>(
+      `${orgBase(orgId)}/gitlab/accounts`
+    )
+    return { enabled: true, accounts: body.accounts, converging: body.converging }
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) return { enabled: false, accounts: [], converging: false }
+    throw e
+  }
 }
 
 // ── agent repository authorizations (agent-multi-repo-authorization.md) ──────

--- a/packages/web/src/lib/gitlab-projects.test.ts
+++ b/packages/web/src/lib/gitlab-projects.test.ts
@@ -29,7 +29,7 @@ const binding = (
   stateReason: null,
   installerConnectionId: 'conn-1',
   accounts,
-  webhookInstalled: true,
+  webhookState: 'installed',
   credentialEpoch: '1',
   createdAt: '2026-08-20T00:00:00.000Z'
 })

--- a/packages/web/src/lib/gitlab-projects.ts
+++ b/packages/web/src/lib/gitlab-projects.ts
@@ -17,7 +17,8 @@ import type {
   GitlabProjectAccountDto,
   GitlabProjectBindingDto,
   GitlabProjectBindingState,
-  GitlabProjectDto
+  GitlabProjectDto,
+  GitlabWebhookState
 } from './api'
 
 export const GITLAB_PROJECT_STATE: Record<GitlabProjectBindingState, { label: string; badge: string }> = {
@@ -26,6 +27,58 @@ export const GITLAB_PROJECT_STATE: Record<GitlabProjectBindingState, { label: st
   admin_degraded: { label: 'setup incomplete', badge: 'bg-(--status-paused-soft) text-(--amber-500)' },
   runtime_degraded: { label: 'bot access degraded', badge: 'bg-(--status-paused-soft) text-(--amber-500)' },
   cleanup_pending: { label: 'removal incomplete', badge: 'bg-(--status-error-soft) text-(--status-error)' }
+}
+
+// Only the two webhook states a person can act on are worth saying. A webhook that is not
+// needed — the project has no trigger — and a healthy one are both silence: badging either
+// turns a normal resting state into an alarm.
+const GITLAB_WEBHOOK_ATTENTION: Partial<Record<GitlabWebhookState, { label: string; badge: string }>> = {
+  repairing: { label: 'webhook repairing', badge: 'bg-(--status-info-soft) text-(--status-info)' },
+  failed: { label: 'webhook failed', badge: 'bg-(--status-error-soft) text-(--status-error)' }
+}
+
+/** GitLab's own words for the comment families a trigger covers. */
+const GITLAB_TRIGGER_FAMILY: Record<string, string> = { issues: 'Issues', merge_request: 'MRs' }
+
+/** Why a bot is on a project, in one phrase: its workspace, its triggers, or both. Null when the
+ *  membership is on its way out and no authorization justifies it any more. */
+export function gitlabMembershipReason(membership: {
+  workspace: 'read' | 'write' | null
+  triggerFamilies: string[]
+  triggerCount: number
+}): string | null {
+  const parts: string[] = []
+  if (membership.workspace) {
+    parts.push(membership.workspace === 'write' ? 'workspace (read & write)' : 'workspace (read)')
+  }
+  if (membership.triggerCount > 0) {
+    const named = membership.triggerFamilies.map((family) => GITLAB_TRIGGER_FAMILY[family] ?? family)
+    parts.push(named.length > 0 ? `triggers: ${named.join(', ')}` : 'triggers')
+  }
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
+/** The webhook badge for a project row, or null when there is nothing worth saying. */
+export function gitlabWebhookBadge(state: GitlabWebhookState): { label: string; badge: string } | null {
+  return GITLAB_WEBHOOK_ATTENTION[state] ?? null
+}
+
+/** Account convergence runs behind hook and workspace CRUD; this is how often we ask whether it landed. */
+export const GITLAB_CONVERGENCE_POLL_MS = 5_000
+
+const GITLAB_ROLE: Record<number, string> = {
+  10: 'Guest',
+  15: 'Planner',
+  20: 'Reporter',
+  30: 'Developer',
+  40: 'Maintainer',
+  50: 'Owner'
+}
+
+/** GitLab's own word for an access level. An unknown level is shown as the bare number
+ *  rather than guessed at — the role is what GitLab enforces, not what we hoped for. */
+export function gitlabRoleLabel(accessLevel: number): string {
+  return GITLAB_ROLE[accessLevel] ?? `level ${accessLevel}`
 }
 
 /** gitlab.com is pinned in v1 — no host override exists to thread through here. */

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -90,6 +90,10 @@ export const consoleKeys = {
     agentId ? consoleKey(orgId, 'agent-repos', agentId) : null,
   /** The org's managed GitLab project bindings — one read, shared by every surface that names a project's bots. */
   gitlabProjects: (orgId: string | null | undefined) => consoleKey(orgId, 'gitlab-projects'),
+  /** The Integrations card's bot roster. The bound-project signature is part of the key, so
+   *  binding or removing a project makes the entry recorded under the old set unreachable. */
+  gitlabAccounts: (orgId: string | null | undefined, bindings: string) =>
+    consoleKey(orgId, 'gitlab-accounts', bindings),
   agentPermissionRequests: (orgId: string | null | undefined, agentId: string | null | undefined) =>
     agentId ? consoleKey(orgId, 'agent-permission-requests', agentId) : null,
   hookRuns: (orgId: string | null | undefined, hookId: string) => consoleKey(orgId, 'hook-runs', hookId)

--- a/packages/web/src/lib/use-gitlab-projects.test.tsx
+++ b/packages/web/src/lib/use-gitlab-projects.test.tsx
@@ -53,7 +53,7 @@ const BINDING: GitlabProjectBindingDto = {
   stateReason: null,
   installerConnectionId: 'conn-1',
   accounts: [],
-  webhookInstalled: true,
+  webhookState: 'installed',
   credentialEpoch: '1',
   createdAt: '2026-08-02T00:00:00.000Z'
 }


### PR DESCRIPTION
## What

The Integrations page's GitLab card listed **projects** with their bot accounts as chips inside. That inverts how every chat-platform card reads — there the bot is the row — and it leaves an account whose last project went away with nowhere to appear at all.

The card is now keyed by bot, per the Section 18.1 amendment (#1427):

- **Connection header** unchanged: GitLab user, host, OAuth state, Reconnect / Disconnect / Remove a released connection.
- **One row per bot** — the agent's own icon and name (linking to that agent), its `@handle` linking to its GitLab profile once the account exists, its top-level group, and its account health with the existing state translations (`service_account_quota`, `cleanup_pending`, the rotation family…).
- **Its projects underneath** — path, the role the membership derives, binding state, webhook state, with Repair, Remove and Transfer administration on the project line. Their semantics are untouched; they still act on the binding.
- A project two agents consume appears under **both** bots. Removing it from either line removes the project itself — that is what the route does — so the confirmation now says how many bots stop with it rather than implying a per-bot detach.
- An account with **no project left** still renders with its health, so a retiring or refused one can be acted on.
- A **project no bot is a member of** keeps its own group at the end of the card. A binding outlives its last consumer — it still owns the webhook and the project claim — so it keeps its state display and the same three actions instead of dropping off the surface.

No token material or expiry values are added anywhere.

## Control plane

Serving a bot-keyed card needs the whole roster in one read, and none existed: `GET /orgs/:orgId/gitlab/agents/:id/accounts` answers for one agent, and the binding DTO's member list cannot show an account that has no binding left. So:

```
GET /api/v1/orgs/:orgId/gitlab/accounts   → listGitlabAccounts
```

Every account the organization owns, each with its `agentId`, top-level group, health, lifecycle, and the bindings it is a member of with the access level each membership carries. Org-scoped and visibility-gated like the per-agent read: a bot whose agent the caller cannot see is **absent**, not redacted — and its project then shows up in the no-bot group, still actionable, naming nobody. Tagged, summarized, described, uniquely operation-id'd; every response field is declared. `GitlabAgentAccountRepo` gains a one-query `listForOrg`.

The console joins `agentId` against the agent list it already has for the name and icon, so the API does not repeat an agent's identity.

## Freshness

The read reuses the rule the agent detail page's identity card established rather than re-deriving it — `GITLAB_CONVERGENCE_POLL_MS`, `gitlabRootGroupsOf` and `gitlabAccountPending` moved into `lib/gitlab-projects.ts` and both cards import them. The card's key carries the bound-project set, so an added or removed project makes the entry recorded under the old set unreachable and no action site has to invalidate anything; it polls only while an account is mid-flight or a project is still being set up, then rests.

## Tests

Component tests cover the bot row (face, name, handle, group, health, link to the agent), the project sub-rows with role and webhook, a project shared by two bots, a bot with no project left, the quota-refused account, the no-bot group rendering with its actions, a project moving out of that group once a bot becomes a member, the poll-then-rest contract, and the key changing on removal. The existing connection-lifecycle, takeover and refusal tests are kept and re-pointed at the new layout. Route tests cover the roster shape, two agents on one project with the role each derives, the visibility gate, the empty organization, and the whole-surface 404 on a deployment with no GitLab application.

Verified: root `pnpm typecheck`; `pnpm --filter @agentconnect.md/web test` (1919 passed); control-plane `test:unit` (1967 passed) and `test:int` (`gitlab.route.test.ts` 32 passed, full suite green); `pnpm lint`; `pnpm format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
