### PR TITLE
fix(daemon): join a workspace mutation on host start instead of failing the turn

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12056,9 +12056,6 @@ export class Daemon {
   private async ensureHostAsync(agentId: string, opts: { allowAgentDrain?: boolean } = {}): Promise<AcpHost> {
     const assertStartAllowed = (): void => {
       if (this.draining) throw new Error(`host start blocked while daemon is draining (${agentId})`)
-      if (this.workspaceDispatchFences.has(agentId)) {
-        throw new Error(`host start blocked while a workspace mutation is in progress (${agentId})`)
-      }
       // Already-admitted work in another logical session may keep using the warm
       // host while a conversation-scoped interrupt drains. It may not allocate a
       // replacement after that host/start generation has been evicted.
@@ -12069,10 +12066,21 @@ export class Daemon {
         throw new Error(`host start blocked while agent is draining (${agentId})`)
       }
     }
+    // A workspace mutation is a transient exclusion, not a refusal: join the fence and re-read the
+    // hard gates. The spawn queues behind the same per-agent tail one call deeper anyway, so waiting
+    // costs the same as failing did — and a cleanup for an unrelated session's worktree no longer
+    // kills an already-admitted cold turn.
+    const admitStart = async (): Promise<void> => {
+      assertStartAllowed()
+      while (this.workspaceDispatchFences.has(agentId)) {
+        await this.waitForWorkspaceDispatchFence(agentId)
+        assertStartAllowed()
+      }
+    }
     // The ordinary dispatch gates are the primary admission boundary; repeat them at
     // the lifecycle resource boundary so an already-admitted cold turn cannot spawn a
     // replacement child after reconcile/stop has begun.
-    assertStartAllowed()
+    await admitStart()
     // If this agent's previous host is mid-teardown, wait it out before (re)spawning
     // — otherwise we'd boot a second child while the first is still SIGTERM-ing.
     const stopping = this.hostStopping.get(agentId)
@@ -12080,7 +12088,7 @@ export class Daemon {
       await stopping
       // A reconcile gate may have been installed while this call waited. Re-check at
       // the exact promise boundary before allocating a new start generation.
-      assertStartAllowed()
+      await admitStart()
     }
     let p = this.hostStarts.get(agentId)
     if (!p) {

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -582,6 +582,55 @@ describe('Daemon session lifecycle (#118)', () => {
     await daemon.stop()
   }, 20_000)
 
+  it('waits out a workspace mutation instead of failing an admitted cold host start', async () => {
+    const host = quietHost()
+    const factory = vi.fn(() => host as any)
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
+    await daemon.start()
+
+    // A per-session worktree cleanup fences the WHOLE agent, so a cold turn admitted just
+    // before it used to die on an unrelated session's cleanup rather than wait the seconds out.
+    let releaseMutation!: () => void
+    const mutationBlocked = new Promise<void>((resolve) => (releaseMutation = resolve))
+    const mutating = (daemon as any).withWorkspaceAdmissionFence('bot-a', () => mutationBlocked) as Promise<void>
+    expect((daemon as any).workspaceDispatchFences.has('bot-a')).toBe(true)
+
+    const starting = (daemon as any).ensureHostAsync('bot-a') as Promise<unknown>
+    const settled = vi.fn()
+    void starting.then(settled, settled)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    // Still the old invariant: no child is constructed while the mutation holds the tree.
+    expect(settled).not.toHaveBeenCalled()
+    expect(factory).not.toHaveBeenCalled()
+
+    releaseMutation()
+    await mutating
+    await expect(starting).resolves.toBe(host)
+    expect(host.start).toHaveBeenCalledOnce()
+    await daemon.stop()
+  }, 20_000)
+
+  it('still refuses a host start when a hard gate closes while the mutation drains', async () => {
+    const factory = vi.fn(() => quietHost() as any)
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(), hostFactory: factory })
+    await daemon.start()
+
+    let releaseMutation!: () => void
+    const mutationBlocked = new Promise<void>((resolve) => (releaseMutation = resolve))
+    const mutating = (daemon as any).withWorkspaceAdmissionFence('bot-a', () => mutationBlocked) as Promise<void>
+    const starting = (daemon as any).ensureHostAsync('bot-a') as Promise<unknown>
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    // Joining the fence must not launder a real refusal: the gates are re-read on the far side.
+    ;(daemon as any).drainingAgents.add('bot-a')
+    releaseMutation()
+    await mutating
+    await expect(starting).rejects.toThrow(/agent is draining/)
+    expect(factory).not.toHaveBeenCalled()
+    ;(daemon as any).drainingAgents.delete('bot-a')
+    await daemon.stop()
+  }, 20_000)
+
   it('serializes workspace preparation and file publication in both admission orders', async () => {
     const daemon = new Daemon({
       slackAppFactory: fakeSlackAppFactory(),


### PR DESCRIPTION
A review turn for a newly opened PR died eight seconds in with `host start
blocked while a workspace mutation is in progress`, and the PR got a skipped
check titled "Review could not be completed". Nothing about the trigger chain
was wrong: the hook fired, dispatch happened, the turn was admitted. What killed
it was **another PR merging onto the same agent** while it was still preparing
its workspace.

## What the fence actually is

`cleanupSessionWorktree` — the post-merge / post-close removal of one session's
isolated worktree — publishes an **agent-wide** admission fence. That is on
purpose for admission: `admitActiveDispatch` waits on it, so a dispatch accepted
after the cleanup starts cannot begin against a tree that is being rewritten.

`ensureHostAsync` read the same fence and **threw**. So a turn that cleared
admission seconds earlier, then spent those seconds on workspace preparation,
would find a fence published in the meantime and lose the whole turn — over a
cleanup for a *different* session's worktree.

## Why the refusal was never load-bearing

It was not the thing keeping a spawn off a mutating tree. One frame deeper,
`startHostWithRetry` calls `prepareAgentWorkspace`, which queues on the **same
per-agent mutation tail** the fenced operation runs on. The child already could
not be constructed while the mutation held the tree; the fence check only
converted that unavoidable wait into a dead turn. For a hook turn, a dead turn
is a review that never runs.

That also bounds the change's risk: waiting here adds no new stall, because the
very next thing the start does is block on that same queue.

## The change

`ensureHostAsync` joins the fence and re-reads the hard gates on the far side of
it, at both existing gate points. Daemon drain, agent drain, and safety drain
still refuse outright — the transient exclusion is the only one that became a
wait — and no host is constructed while a mutation is in flight.

## Verification

- `waits out a workspace mutation instead of failing an admitted cold host start`
  — asserts the start neither settles nor constructs a host while the fence is
  held, then resolves once the mutation is released. Fails on the old code with
  the exact production error.
- `still refuses a host start when a hard gate closes while the mutation drains`
  — closes the agent-drain gate while the start is parked on the fence and
  requires the refusal to survive. Joining a fence must not launder a real
  refusal.
- `daemon-lifecycle` 70/70; `daemon-hook`, `daemon-serial-gate`,
  `daemon-interrupt-safety`, `cluster-cold-start`, `cluster-workspace-prepare`,
  `reconcile-watch` 212/212 together; daemon typecheck, eslint, prettier clean.

## Not in this PR

`cleanupSessionWorktree` fences the whole agent to remove **one** session's
worktree. Narrowing that fence to the worktree it actually touches is the deeper
fix, but it is a larger change and it would still want this PR's semantics —
an in-flight start should wait out an exclusion, not die on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
