### PR TITLE
feat(control-plane): open a private agent's DM to the people it is shared with

### DIFF
--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -1002,6 +1002,14 @@ reverse index from a platform member id to a console account. Every unresolvable
 case fails CLOSED to §14.2: no sign-in configured, no workspace on the bot, an
 oversized audience, or an upstream that cannot answer all leave the row Off.
 
+This report is also the one place where a CP write turns a daemon's own report
+into an ENABLED conversation, so it is the one that has to push: the reporting
+daemon still holds the `bindRules` it was given before the row existed, and it
+has already cached the conversation, so nothing re-reports and repairs it.
+Opening a row therefore re-converges the agent's integrations, the same push a
+visibility flip performs. (The shared-bot path already did this — `syncRoutes`
+recompiles the relay routes _and_ re-pushes the send-only specs.)
+
 **Order independence.** A seed decided at discovery would fire only for people
 whose link and audience seat both predate their first DM — which is the opposite
 of what happens, since people link _because_ they were refused. So the two
@@ -1009,10 +1017,20 @@ writes that can make the answer true later — a landed identity link, a widened
 audience — re-ask it for the Off DM rows already on record. The rule that
 results does not depend on the order the three events arrive in.
 
-This catch-up is **one-way**: it opens rows and never closes them. A stored
-trigger is indistinguishable from an operator's own choice — §14.2 lets an
-editor enable a DM for anyone — so re-deriving a CLOSE would silently revert
-decisions §14.8 never made.
+**The catch-up asks about the pair that just became eligible, never about the
+current state.** A widened audience reconciles the members it GAINED, not
+everyone in it; a link reconciles only when the Slack identity actually changed,
+compared against what the account carried when the request started. This is not
+an optimization. A stored Off is indistinguishable from an operator's own choice
+— §14.2 lets an editor close a DM §14.8 opened — so re-deriving from "everyone
+currently in the audience who is currently linked" would reopen that DM on the
+next unrelated sharing edit or profile refresh, turning a DEFAULT into a
+standing rule that overrides the per-conversation control. Neither call site
+means "a Slack link appeared" on its own: the console's refresh is also used
+after a reauthorization, and the link route links providers other than Slack.
+
+For the same reason the catch-up is **one-way**: it opens rows and never closes
+them, because re-deriving a CLOSE would revert decisions §14.8 never made.
 
 **Consequence, stated plainly: an opened DM stays open.** A gated bind rule is
 conversation-scoped (`{channel, match:'dm'}`), with no user dimension, so losing

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -1020,7 +1020,11 @@ results does not depend on the order the three events arrive in.
 **A catch-up only ever touches a row still at its DEFAULT.** That is what
 `integration_channel.triggerChosen` exists for: it is set the moment a human
 picks a conversation's trigger, in the Console or the in-Slack modal, and never
-cleared. Without it a stored Off is indistinguishable from an operator's own
+cleared. It has to be as complete as the trigger it accompanies — a shared bot's
+convergence writes the chosen trigger across every sibling row, so under a human
+decision a row that already carries the value, or one the same call backfills
+with it, is marked too. Skipping those as no-ops is what would leave a
+deliberate Off indistinguishable from an untouched default. Without it a stored Off is indistinguishable from an operator's own
 choice — §14.2 lets an editor close a DM §14.8 opened — and a catch-up would
 reopen that DM on the next sharing edit or profile refresh, turning a DEFAULT
 into a standing rule that overrides the per-conversation control.

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -1031,7 +1031,14 @@ conversation and carries it onto siblings it backfills later. That last part is
 what survives the owner-removal lifecycle — the row that RECORDED the decision
 is deleted with its integration while siblings live on, and reading provenance
 from the owner row alone would lose the decision on precisely the path the
-backfill exists for. For the same reason **a decided conversation is never
+backfill exists for. `dmUserId` replicates for the same reason and is the more
+brittle of the two: it IS §14.8's input, so a sibling that inherits `kind:'im'`
+without it is a DM whose counterpart is unknown, and once owner removal leaves
+that sibling as the only surviving row a linked audience member re-derives to
+Off with no way back — the later report that finally supplies the id cannot
+reopen a row that already exists. The backfill therefore takes the
+conversation's metadata PER FIELD from whichever sibling knows it, rather than
+from one template row that may not know all of it. For the same reason **a decided conversation is never
 re-derived**: a gated agent inheriting one keeps its trigger instead of
 recomputing the §14.2/§14.8 default over it. Without it a stored Off is indistinguishable from an operator's own
 choice — §14.2 lets an editor close a DM §14.8 opened — and a catch-up would

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -1017,30 +1017,41 @@ writes that can make the answer true later — a landed identity link, a widened
 audience — re-ask it for the Off DM rows already on record. The rule that
 results does not depend on the order the three events arrive in.
 
-**The catch-up asks about the pair that just became eligible, never about the
-current state.** A widened audience reconciles the members it GAINED, not
-everyone in it; a link reconciles only when the Slack identity actually changed,
-compared against what the account carried when the request started. This is not
-an optimization. A stored Off is indistinguishable from an operator's own choice
-— §14.2 lets an editor close a DM §14.8 opened — so re-deriving from "everyone
-currently in the audience who is currently linked" would reopen that DM on the
-next unrelated sharing edit or profile refresh, turning a DEFAULT into a
-standing rule that overrides the per-conversation control. Neither call site
-means "a Slack link appeared" on its own: the console's refresh is also used
-after a reauthorization, and the link route links providers other than Slack.
+**A catch-up only ever touches a row still at its DEFAULT.** That is what
+`integration_channel.triggerChosen` exists for: it is set the moment a human
+picks a conversation's trigger, in the Console or the in-Slack modal, and never
+cleared. Without it a stored Off is indistinguishable from an operator's own
+choice — §14.2 lets an editor close a DM §14.8 opened — and a catch-up would
+reopen that DM on the next sharing edit or profile refresh, turning a DEFAULT
+into a standing rule that overrides the per-conversation control.
 
-For the same reason the catch-up is **one-way**: it opens rows and never closes
-them, because re-deriving a CLOSE would revert decisions §14.8 never made.
+The marker is load-bearing rather than an optimization, because **neither call
+site can prove it is the moment a link appeared.** The browser-driven Account
+API flow writes the link at the provider BEFORE calling the Console's refresh
+route, so a "was it linked before?" read on this side is only pre-link when a
+cache entry happens to survive the round trip — cold cache, a CP restart, or a
+link slower than the identity lease all make it read the already-linked
+identity and conclude nothing changed. Inferring novelty after an external
+mutation is not available here, so the catch-up runs unconditionally and leans
+on `triggerChosen` to be idempotent. (A widened audience still reconciles only
+the members it GAINED — there the diff IS available, and it bounds the work.)
 
-**Consequence, stated plainly: an opened DM stays open.** A gated bind rule is
-conversation-scoped (`{channel, match:'dm'}`), with no user dimension, so losing
-the audience seat or unlinking the identity does NOT close the conversation the
-seat opened; an editor turning the row Off in the Console does. That is the same
-durability §14.2 already gives an editor-enabled conversation — "enabling
-entrusts the conversation" — but the grant now originates from an audience
-membership that can later change, which an editor-made one does not. Making it
-revocable needs the rows §14.8 opened to be told apart from the rows an editor
-chose, which is a marker this deliberately does not add yet.
+Rows that predate the marker are left at `false`: for a gated agent Off is the
+universal default, so before §14.8 a deliberately-closed DM required an editor
+to turn one On and then Off again. Marking the whole backlog "chosen" would be
+safer on paper and would keep the feature from ever reaching the DMs that
+already exist, which are exactly the ones it is for.
+
+**One-way even so: a catch-up never closes a row.** A close cannot be derived
+from absence — an audience seat lost, an unlink, and an editor's own Off all
+present the same way to the reconciler. So an opened DM stays open: a gated bind
+rule is conversation-scoped (`{channel, match:'dm'}`) with no user dimension, and
+losing the seat does not close the conversation the seat opened; an editor
+turning the row Off does, and that Off is now sticky. This is the same durability
+§14.2 already gives an editor-enabled conversation, with the difference that the
+grant originated from a membership that can later change. Revoking on seat loss
+is now expressible — `triggerChosen` tells the two apart — and is left to a
+change that can decide what should happen to the session history behind it.
 
 **Known edge.** The daemon and relay decide admission before the CP has the row,
 so the very first message of a brand-new DM is still refused with the §14.3

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -1020,11 +1020,20 @@ results does not depend on the order the three events arrive in.
 **A catch-up only ever touches a row still at its DEFAULT.** That is what
 `integration_channel.triggerChosen` exists for: it is set the moment a human
 picks a conversation's trigger, in the Console or the in-Slack modal, and never
-cleared. It has to be as complete as the trigger it accompanies — a shared bot's
-convergence writes the chosen trigger across every sibling row, so under a human
-decision a row that already carries the value, or one the same call backfills
-with it, is marked too. Skipping those as no-ops is what would leave a
-deliberate Off indistinguishable from an untouched default. Without it a stored Off is indistinguishable from an operator's own
+cleared.
+
+It has to be as complete as the trigger it accompanies, because on a shared bot
+the trigger is CONVERSATION-level state repeated across one row per install. So
+the marker replicates exactly the same way: a human decision marks every sibling
+row, including one that already carries the value and one the same call
+backfills with it; ownership convergence reads the flag from ANY row of the
+conversation and carries it onto siblings it backfills later. That last part is
+what survives the owner-removal lifecycle — the row that RECORDED the decision
+is deleted with its integration while siblings live on, and reading provenance
+from the owner row alone would lose the decision on precisely the path the
+backfill exists for. For the same reason **a decided conversation is never
+re-derived**: a gated agent inheriting one keeps its trigger instead of
+recomputing the §14.2/§14.8 default over it. Without it a stored Off is indistinguishable from an operator's own
 choice — §14.2 lets an editor close a DM §14.8 opened — and a catch-up would
 reopen that DM on the next sharing edit or profile refresh, turning a DEFAULT
 into a standing rule that overrides the per-conversation control.

--- a/docs/designs/resource-visibility.md
+++ b/docs/designs/resource-visibility.md
@@ -8,8 +8,8 @@
 > is the complete human audience; immutable creation attribution grants no
 > access. Normal member removal prunes all five visibility carriers atomically
 > and repairs only audiences that would otherwise become empty.
-> Section 14 (platform conversation gating) is a **proposed** addendum, not yet
-> implemented.
+> Section 14 (platform conversation gating) extends the same model to platform
+> ingress and is implemented.
 >
 > **Scope:** control-plane + web. The daemon execution data plane is unaffected
 > except for §14, which extends restricted visibility to platform ingress via a
@@ -677,9 +677,9 @@ while `visibilityWhere(undefined)` equals `{}`.
    `agentId -> canView` per envelope and send nothing when false. A restricted
    agent remains completely invisible, matching list/get 404 semantics.
 
-## 14. Platform conversation gating (private agents) — proposed
+## 14. Platform conversation gating (private agents)
 
-> **Status:** Proposed — product design agreed, implementation not started.
+> **Status:** Implemented.
 > Scope: protocol + daemon + control-plane + web. Slack is the driving case;
 > the mechanism is platform-generic (Telegram / Discord / Lark / Feishu integrations
 > share the same bind-rule shape).
@@ -938,11 +938,12 @@ Mention.
 
 ### 14.6 Out of scope / future overlays
 
-- **Identity mapping.** Resolving platform senders to AgentConnect users
-  (e.g. Slack `users.info` email ↔ OIDC email, with a manual link fallback)
-  would let ingress enforce agent visibility itself, making "private" mean the
-  same set of people on every surface. Conversation gating neither depends on
-  nor conflicts with this.
+- **Identity mapping at ingress.** Resolving platform senders to AgentConnect
+  users so ingress could enforce agent visibility itself — making "private" mean
+  the same set of people on every surface — remains out of scope as a general
+  mechanism. §14.8 takes the one case where the mapping is an identity
+  ASSERTION rather than an inference, and applies it to a default rather than to
+  admission. Conversation gating neither depends on nor conflicts with the rest.
 - **Auto-leave policy** (bot automatically leaves channels it is not enabled
   in), **user-group-based grants**, and webchat/GitHub surfaces (already gated
   by Console auth / repo authorization respectively).
@@ -956,3 +957,75 @@ Mention.
    (e.g. after 24 h) or be strictly once per conversation per daemon lifetime.
 3. Whether the DM boot-sweep ships in v1 or first-message reporting alone is
    enough.
+
+### 14.8 A private agent's DM follows its audience's linked identity
+
+**Status:** Implemented.
+
+**Problem.** §14.2 makes every conversation of a restricted agent default Off,
+including a DM. That is right for a channel and wrong for the person the agent
+was shared with: they can already see, edit and run it in the Console, yet their
+own DM with it answers a "not enabled" notice until an editor — often the same
+person — goes and enables it. The gate protects nobody there; it just makes a
+private agent feel broken to its own audience.
+
+**Rule.** A 1:1 DM row of a gated agent seeds to the ordinary DM default (On)
+instead of Off when its counterpart is BOTH:
+
+1. in the agent's own `sharedWith` audience, and
+2. carrying a linked Slack identity in that bot's workspace.
+
+Both arms are load-bearing. An unlinked audience member and a linked
+non-member each keep §14.2's Off. The link is Logto's — a Slack sign-in, or an
+Account API link driven by the user's own authenticated session — never an email
+guess, which is what keeps this an assertion rather than the inference §14.6
+parks.
+
+**Why only a 1:1 DM.** It is the one conversation whose entire human membership
+is known at discovery: one bot, one person. A channel's membership is a place
+and may change after the fact, which is exactly why §14.2 sends it to an editor;
+a group DM is a room by the same argument. Neither is seeded.
+
+**Why only Slack.** It is the driving case, and the one platform whose linked
+identity names the same id space a DM report carries. A Feishu link asserts a
+cross-app `union_id` while its messages carry an app-scoped `open_id`; matching
+there needs a resolution step that does not exist yet, and guessing would
+silently widen a private agent.
+
+**Mechanism.** The reporter adds the counterpart's platform member id to the
+conversation report (`IntegrationChannel.dmUserId`, persisted on the row as
+control metadata of the same class as `name`); both report paths — the daemon's
+`integration/channels` and the relay's `rc/bot-conversation` — carry it. The CP
+resolves the audience's own linked identities (one cached per-subject read each)
+and matches the reported counterpart against them; there is deliberately no
+reverse index from a platform member id to a console account. Every unresolvable
+case fails CLOSED to §14.2: no sign-in configured, no workspace on the bot, an
+oversized audience, or an upstream that cannot answer all leave the row Off.
+
+**Order independence.** A seed decided at discovery would fire only for people
+whose link and audience seat both predate their first DM — which is the opposite
+of what happens, since people link _because_ they were refused. So the two
+writes that can make the answer true later — a landed identity link, a widened
+audience — re-ask it for the Off DM rows already on record. The rule that
+results does not depend on the order the three events arrive in.
+
+This catch-up is **one-way**: it opens rows and never closes them. A stored
+trigger is indistinguishable from an operator's own choice — §14.2 lets an
+editor enable a DM for anyone — so re-deriving a CLOSE would silently revert
+decisions §14.8 never made.
+
+**Consequence, stated plainly: an opened DM stays open.** A gated bind rule is
+conversation-scoped (`{channel, match:'dm'}`), with no user dimension, so losing
+the audience seat or unlinking the identity does NOT close the conversation the
+seat opened; an editor turning the row Off in the Console does. That is the same
+durability §14.2 already gives an editor-enabled conversation — "enabling
+entrusts the conversation" — but the grant now originates from an audience
+membership that can later change, which an editor-made one does not. Making it
+revocable needs the rows §14.8 opened to be told apart from the rows an editor
+chose, which is a marker this deliberately does not add yet.
+
+**Known edge.** The daemon and relay decide admission before the CP has the row,
+so the very first message of a brand-new DM is still refused with the §14.3
+notice; the conversation is open from the next message on. Closing that gap
+means shipping the authorized member ids to the edge in the integration spec,
+which is a separate change with its own recompute-and-push triggers.

--- a/packages/control-plane/prisma/migrations/20260909000000_integration_channel_dm_user/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260909000000_integration_channel_dm_user/migration.sql
@@ -1,0 +1,5 @@
+-- The 1:1 DM counterpart's platform member id (resource-visibility.md §14.8).
+-- Additive and nullable: rows discovered before this migration keep whatever
+-- trigger an operator already chose, and are re-stamped by the reporter's next
+-- conversation report.
+ALTER TABLE "integration_channel" ADD COLUMN "dmUserId" TEXT;

--- a/packages/control-plane/prisma/migrations/20260910000000_integration_channel_trigger_chosen/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260910000000_integration_channel_trigger_chosen/migration.sql
@@ -1,0 +1,12 @@
+-- Whether a human chose this conversation's trigger (resource-visibility.md §14.8).
+--
+-- No backfill, deliberately. Rows already on record are left at `false` — "still at
+-- their default" — because for a gated agent Off IS the universal default: before
+-- §14.8 a DM could only be On if an editor turned it On, so a stored Off that an
+-- editor deliberately chose required two opposite actions and is close to nonexistent.
+-- Marking the whole backlog `true` instead would be safer on paper and would keep the
+-- feature from ever reaching the DMs that already exist, which are exactly the ones it
+-- is for. The blast radius of the choice is bounded by the rest of the rule: a
+-- catch-up only ever opens a DM whose counterpart is a linked member of the agent's
+-- own audience, and the first close after this ships is sticky.
+ALTER TABLE "integration_channel" ADD COLUMN "triggerChosen" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2402,6 +2402,11 @@ model IntegrationChannel {
   // integration so deleting the canonical owner does not discard conversation state.
   // Classic integrations keep their trigger per integration.
   trigger       ChannelTrigger   @default(mention)
+  // True once a HUMAN chose this conversation's trigger (resource-visibility.md §14.8).
+  // A stored Off is otherwise indistinguishable from a default nobody has decided yet,
+  // and the two need opposite treatment: §14.8's catch-up may open a defaulted row and
+  // must never reopen one an editor deliberately closed.
+  triggerChosen Boolean          @default(false)
   // Per-conversation default/owning agent for a SHARED bot (shared-bot-relay.md §10.1
   // conversation ownership — the primary disambiguation path). Exactly one active
   // integration row per shared conversation carries the owner; sibling rows are null.

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2393,6 +2393,11 @@ model IntegrationChannel {
   space         String?
   isPrivate     Boolean          @default(false)
   kind          ConversationKind @default(channel)
+  // The 1:1 DM counterpart's platform member id (resource-visibility.md §14.8). Control
+  // metadata of the same class as `name` — it says WHO the row is with, which is what
+  // lets a private agent's DM follow that person's linked console identity instead of
+  // defaulting Off. Null on channels, on group DMs, and on rows reported before §14.8.
+  dmUserId      String?
   // Relay-backed shared-bot rows repeat the effective trigger across each active
   // integration so deleting the canonical owner does not discard conversation state.
   // Classic integrations keep their trigger per integration.

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -143,6 +143,7 @@ import { RelayRoster } from './orchestrator/relayRoster.js'
 import { WebchatMcpOperationReaper } from './orchestrator/webchatMcpOperationReaper.js'
 import { HttpBotOrchestrator } from './orchestrator/httpBot.js'
 import { gatedDmSeeds, type GatedDmSeedResolver } from './orchestrator/linkedDm.js'
+import { convergeIntegrationGating } from './orchestrator/integrationPush.js'
 import { SlackBotIdentityReconciler } from './orchestrator/slackBotIdentityReconciler.js'
 import { slackConfigApi } from './http/slack-config-api.js'
 import { findTool } from './http/mcp/tools.js'
@@ -1725,6 +1726,12 @@ export function buildContainer(
     integrationChannel: repos.integrationChannel,
     slackSessionAccess,
     gatedDmSeeds: gatedDmSeedResolver,
+    // §14.8: the report path can now create an ENABLED row, so it needs the same
+    // re-converge a visibility flip performs — the reporter's own bindRules predate it.
+    integrationConverge: (agent) =>
+      convergeIntegrationGating({ repos, agentDelivery, httpBot, platforms }, agent, {
+        warn: (o, m) => http.log.warn(o as Record<string, unknown>, m)
+      }),
     sessionAccessWarmer,
     agentMutations,
     recoverStagedAgent: (agentId, daemonId, moveId) => stagedAgentMoves.recoverStaged(agentId, daemonId, moveId),

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -142,6 +142,7 @@ import { RelaySweeper } from './orchestrator/relaySweeper.js'
 import { RelayRoster } from './orchestrator/relayRoster.js'
 import { WebchatMcpOperationReaper } from './orchestrator/webchatMcpOperationReaper.js'
 import { HttpBotOrchestrator } from './orchestrator/httpBot.js'
+import { gatedDmSeeds, type GatedDmSeedResolver } from './orchestrator/linkedDm.js'
 import { SlackBotIdentityReconciler } from './orchestrator/slackBotIdentityReconciler.js'
 import { slackConfigApi } from './http/slack-config-api.js'
 import { findTool } from './http/mcp/tools.js'
@@ -797,6 +798,17 @@ export function buildContainer(
   // daemons on register/sweep via the `relay/roster` EVT (sender is the broadcaster).
   const relayRoster = new RelayRoster(repos.relay, sender, clock, relayStaleMs)
 
+  // §14.8 (resource-visibility.md): which of a gated install's reported DMs open to the
+  // ordinary DM default because their counterpart is already in the agent's audience.
+  // Lazy over `logtoIdentity` and `http.log` for the same reason as the logger below —
+  // both are assigned further down and this only runs at report time.
+  const gatedDmSeedResolver: GatedDmSeedResolver = (channels, agent, bot) =>
+    gatedDmSeeds(channels, agent, bot, {
+      users: repos.user,
+      ...(logtoIdentity ? { identity: logtoIdentity } : {}),
+      log: { debug: (o, m) => http.log.debug(o, m), warn: (o, m) => http.log.warn(o, m) }
+    })
+
   // HTTP-bot assignment + attributed-route compilation (shared-bot-relay.md §4.2/§10).
   // Its logger is lazy (a wrapper over `http.log`, which is created below) — only ever
   // invoked at request/sweep time, well after `http` is assigned, so no TDZ hazard.
@@ -818,7 +830,8 @@ export function buildContainer(
     },
     platforms,
     agentDelivery,
-    placementResolver
+    placementResolver,
+    gatedDmSeedResolver
   )
   const stagedAgentMoves = new AgentMoveService({
     agents: repos.agent,
@@ -1711,6 +1724,7 @@ export function buildContainer(
     githubInstallation: repos.githubInstallation,
     integrationChannel: repos.integrationChannel,
     slackSessionAccess,
+    gatedDmSeeds: gatedDmSeedResolver,
     sessionAccessWarmer,
     agentMutations,
     recoverStagedAgent: (agentId, daemonId, moveId) => stagedAgentMoves.recoverStaged(agentId, daemonId, moveId),

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -3011,10 +3011,13 @@ export function agentRoutes(deps: HttpDeps) {
           if (agent.visibility !== existing.visibility) {
             await convergeIntegrationGating(deps, agent, req.log)
           }
-          // §14.8: a widened audience may authorize DMs its new members already have
-          // open with this agent. Best-effort — the sharing write itself has landed,
-          // and a failure leaves those rows Off, which is where they already were.
-          await reconcileAgentLinkedDms(agent, {
+          // §14.8: an audience that GAINED members may authorize DMs those members
+          // already have open with this agent. The diff, never the whole audience — a
+          // later edit must not reassert the default over an editor's own Off.
+          // Best-effort: the sharing write has landed, and a failure leaves those rows
+          // Off, which is where they already were.
+          const gained = agent.sharedWith.filter((id) => !existing.sharedWith.includes(id))
+          await reconcileAgentLinkedDms(agent, gained, {
             users: deps.repos.user,
             orgs: deps.repos.org,
             agents: deps.repos.agent,

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -95,6 +95,7 @@ import { NoConnection } from '../../orchestrator/outbound.js'
 import { AgentMoveConflict, AgentMoveFailed } from '../../orchestrator/agentMove.js'
 import { AgentWakeCoordinator } from '../../orchestrator/agentWake.js'
 import { convergeIntegrationGating } from '../../orchestrator/integrationPush.js'
+import { reconcileAgentLinkedDms } from '../../orchestrator/linkedDmReconcile.js'
 import { ProtocolError } from '../../domain/errors.js'
 import {
   AGENT_WORKSPACE_INTEGRATION_CONFLICT_MESSAGE,
@@ -3010,6 +3011,20 @@ export function agentRoutes(deps: HttpDeps) {
           if (agent.visibility !== existing.visibility) {
             await convergeIntegrationGating(deps, agent, req.log)
           }
+          // §14.8: a widened audience may authorize DMs its new members already have
+          // open with this agent. Best-effort — the sharing write itself has landed,
+          // and a failure leaves those rows Off, which is where they already were.
+          await reconcileAgentLinkedDms(agent, {
+            users: deps.repos.user,
+            orgs: deps.repos.org,
+            agents: deps.repos.agent,
+            integrations: deps.repos.integration,
+            bots: deps.repos.bot,
+            channels: deps.repos.integrationChannel,
+            ...(deps.logtoIdentity ? { identity: deps.logtoIdentity } : {}),
+            push: (target) => convergeIntegrationGating(deps, target, req.log),
+            log: req.log
+          }).catch((err: unknown) => req.log.warn({ err, agentId: agent.id }, 'gated DM: sharing catch-up failed'))
           return toDto(
             agent,
             ctxOf(req),

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -873,10 +873,12 @@ export function integrationRoutes(deps: HttpDeps) {
                 message: 'default agent applies only to shared bot conversations'
               })
             }
+            // A human picked this, so it outranks every later default (§14.8).
             updated = await deps.repos.integrationChannel.setTrigger(
               integration.id,
               req.params.channelId,
-              req.body.trigger!
+              req.body.trigger!,
+              { chosen: true }
             )
           }
           if (!updated)

--- a/packages/control-plane/src/http/routes/me-social-identities.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.ts
@@ -21,7 +21,7 @@
 import type { FastifyInstance, FastifyReply } from 'fastify'
 import { z } from 'zod'
 import { resolveWebAppUrl } from '../../config/env.js'
-import { LogtoApiError, type SlackIdentity } from '../../github/logto-identity.js'
+import { LogtoApiError } from '../../github/logto-identity.js'
 import { convergeIntegrationGating } from '../../orchestrator/integrationPush.js'
 import { reconcileLinkedDms } from '../../orchestrator/linkedDmReconcile.js'
 import type { HttpDeps } from '../deps.js'
@@ -187,44 +187,29 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
       message: 'social sign-in management is not configured'
     } as const
 
-    type LinkedReq = {
-      principal?: { userId: string }
-      oidcSubject?: string
-      log: { debug(obj: object, msg: string): void; warn(obj: object, msg?: string): void }
-    }
-
-    /** The Slack identity this account carries right now, or null. Cheap and cached —
-     *  the point of reading it is to have a BEFORE to compare an AFTER against. */
-    const slackIdentityOf = async (sub: string): Promise<SlackIdentity | null> => {
-      try {
-        return (await deps.logtoIdentity?.slackIdentityFor(sub)) ?? null
-      } catch {
-        // Unknown reads as "unchanged": the catch-up below is an optimization, and
-        // refusing it costs a DM that stays Off, which is where it already was.
-        return null
-      }
-    }
-
     /**
-     * §14.8 catch-up (resource-visibility.md): a link that JUST landed may authorize
-     * DMs this person already has open with a private agent they are shared with.
+     * §14.8 catch-up (resource-visibility.md): a link may have just authorized DMs this
+     * person already has open with a private agent they are shared with.
      *
-     * `before` is what the account carried when the request started. Only a genuine
-     * change fires the catch-up — neither of these routes means "a Slack link
-     * appeared": the refresh is also used after a reauthorization, and the link route
-     * also links providers other than Slack. Re-deriving on every call would let the
-     * default reassert itself over an editor's per-conversation Off.
+     * Runs on every call rather than trying to detect "a Slack link appeared", because
+     * nothing observable here can: the browser writes the link at the provider BEFORE
+     * calling the refresh route, so a pre-link read is only pre-link when a cache entry
+     * happens to survive the round trip. Running unconditionally is safe because the
+     * catch-up only touches rows still at their default (`triggerChosen`), so a
+     * reauthorization or a link to another provider changes nothing.
      *
      * Awaited so the Console read that follows already shows the opened rows, and
      * swallowed — the link itself succeeded, and a failure leaves the rows put.
      */
-    const openLinkedDms = async (req: LinkedReq, before: SlackIdentity | null): Promise<void> => {
+    const openLinkedDms = async (req: {
+      principal?: { userId: string }
+      oidcSubject?: string
+      log: { debug(obj: object, msg: string): void; warn(obj: object, msg?: string): void }
+    }): Promise<void> => {
       const userId = req.principal?.userId
       if (!userId || !req.oidcSubject || !deps.logtoIdentity) return
-      const after = await slackIdentityOf(req.oidcSubject)
-      if (!after || (before?.teamId === after.teamId && before?.userId === after.userId)) return
       try {
-        await reconcileLinkedDms(userId, after, {
+        await reconcileLinkedDms(userId, req.oidcSubject, {
           users: deps.repos.user,
           orgs: deps.repos.org,
           agents: deps.repos.agent,
@@ -259,11 +244,8 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
       async (req, reply) => {
         const identity = deps.logtoIdentity
         if (!identity) return reply.code(503).send(unavailable)
-        // Read the pre-change identity BEFORE dropping the cache, so the comparison
-        // has something to be a comparison against.
-        const before = await slackIdentityOf(req.oidcSubject!)
         identity.forgetUser(req.oidcSubject!)
-        await openLinkedDms(req, before)
+        await openLinkedDms(req)
         return reply.code(204).send(null)
       }
     )
@@ -325,9 +307,6 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
         const identity = deps.logtoIdentity
         const redirectUri = socialCallbackUrl(deps)
         if (!identity || !redirectUri) return reply.code(503).send(unavailable)
-        // Before the link invalidates the cache — this route links any provider, so
-        // only a comparison can say whether the SLACK identity is what changed.
-        const before = await slackIdentityOf(req.oidcSubject!)
         try {
           // redirectUri last: Logto exchanges the code against the URI it
           // authorized with, and only the server knows that one.
@@ -335,7 +314,7 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
             ...req.body.connectorData,
             redirectUri
           })
-          await openLinkedDms(req, before)
+          await openLinkedDms(req)
           return { linked: true as const }
         } catch (error) {
           return logtoFailure(reply, error, 'link')

--- a/packages/control-plane/src/http/routes/me-social-identities.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.ts
@@ -21,7 +21,7 @@
 import type { FastifyInstance, FastifyReply } from 'fastify'
 import { z } from 'zod'
 import { resolveWebAppUrl } from '../../config/env.js'
-import { LogtoApiError } from '../../github/logto-identity.js'
+import { LogtoApiError, type SlackIdentity } from '../../github/logto-identity.js'
 import { convergeIntegrationGating } from '../../orchestrator/integrationPush.js'
 import { reconcileLinkedDms } from '../../orchestrator/linkedDmReconcile.js'
 import type { HttpDeps } from '../deps.js'
@@ -187,19 +187,44 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
       message: 'social sign-in management is not configured'
     } as const
 
-    // §14.8 catch-up (resource-visibility.md): a landed link may authorize DMs this
-    // person already has open with a private agent they are shared with. Awaited so
-    // the Console read that follows the link already shows them, and swallowed — the
-    // link itself succeeded, and a failure leaves the rows exactly where they were.
-    const openLinkedDms = async (req: {
+    type LinkedReq = {
       principal?: { userId: string }
       oidcSubject?: string
       log: { debug(obj: object, msg: string): void; warn(obj: object, msg?: string): void }
-    }): Promise<void> => {
+    }
+
+    /** The Slack identity this account carries right now, or null. Cheap and cached —
+     *  the point of reading it is to have a BEFORE to compare an AFTER against. */
+    const slackIdentityOf = async (sub: string): Promise<SlackIdentity | null> => {
+      try {
+        return (await deps.logtoIdentity?.slackIdentityFor(sub)) ?? null
+      } catch {
+        // Unknown reads as "unchanged": the catch-up below is an optimization, and
+        // refusing it costs a DM that stays Off, which is where it already was.
+        return null
+      }
+    }
+
+    /**
+     * §14.8 catch-up (resource-visibility.md): a link that JUST landed may authorize
+     * DMs this person already has open with a private agent they are shared with.
+     *
+     * `before` is what the account carried when the request started. Only a genuine
+     * change fires the catch-up — neither of these routes means "a Slack link
+     * appeared": the refresh is also used after a reauthorization, and the link route
+     * also links providers other than Slack. Re-deriving on every call would let the
+     * default reassert itself over an editor's per-conversation Off.
+     *
+     * Awaited so the Console read that follows already shows the opened rows, and
+     * swallowed — the link itself succeeded, and a failure leaves the rows put.
+     */
+    const openLinkedDms = async (req: LinkedReq, before: SlackIdentity | null): Promise<void> => {
       const userId = req.principal?.userId
       if (!userId || !req.oidcSubject || !deps.logtoIdentity) return
+      const after = await slackIdentityOf(req.oidcSubject)
+      if (!after || (before?.teamId === after.teamId && before?.userId === after.userId)) return
       try {
-        await reconcileLinkedDms(userId, req.oidcSubject, {
+        await reconcileLinkedDms(userId, after, {
           users: deps.repos.user,
           orgs: deps.repos.org,
           agents: deps.repos.agent,
@@ -234,8 +259,11 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
       async (req, reply) => {
         const identity = deps.logtoIdentity
         if (!identity) return reply.code(503).send(unavailable)
+        // Read the pre-change identity BEFORE dropping the cache, so the comparison
+        // has something to be a comparison against.
+        const before = await slackIdentityOf(req.oidcSubject!)
         identity.forgetUser(req.oidcSubject!)
-        await openLinkedDms(req)
+        await openLinkedDms(req, before)
         return reply.code(204).send(null)
       }
     )
@@ -297,6 +325,9 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
         const identity = deps.logtoIdentity
         const redirectUri = socialCallbackUrl(deps)
         if (!identity || !redirectUri) return reply.code(503).send(unavailable)
+        // Before the link invalidates the cache — this route links any provider, so
+        // only a comparison can say whether the SLACK identity is what changed.
+        const before = await slackIdentityOf(req.oidcSubject!)
         try {
           // redirectUri last: Logto exchanges the code against the URI it
           // authorized with, and only the server knows that one.
@@ -304,7 +335,7 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
             ...req.body.connectorData,
             redirectUri
           })
-          await openLinkedDms(req)
+          await openLinkedDms(req, before)
           return { linked: true as const }
         } catch (error) {
           return logtoFailure(reply, error, 'link')

--- a/packages/control-plane/src/http/routes/me-social-identities.ts
+++ b/packages/control-plane/src/http/routes/me-social-identities.ts
@@ -22,6 +22,8 @@ import type { FastifyInstance, FastifyReply } from 'fastify'
 import { z } from 'zod'
 import { resolveWebAppUrl } from '../../config/env.js'
 import { LogtoApiError } from '../../github/logto-identity.js'
+import { convergeIntegrationGating } from '../../orchestrator/integrationPush.js'
+import { reconcileLinkedDms } from '../../orchestrator/linkedDmReconcile.js'
 import type { HttpDeps } from '../deps.js'
 import { ErrorDto } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
@@ -185,6 +187,34 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
       message: 'social sign-in management is not configured'
     } as const
 
+    // §14.8 catch-up (resource-visibility.md): a landed link may authorize DMs this
+    // person already has open with a private agent they are shared with. Awaited so
+    // the Console read that follows the link already shows them, and swallowed — the
+    // link itself succeeded, and a failure leaves the rows exactly where they were.
+    const openLinkedDms = async (req: {
+      principal?: { userId: string }
+      oidcSubject?: string
+      log: { debug(obj: object, msg: string): void; warn(obj: object, msg?: string): void }
+    }): Promise<void> => {
+      const userId = req.principal?.userId
+      if (!userId || !req.oidcSubject || !deps.logtoIdentity) return
+      try {
+        await reconcileLinkedDms(userId, req.oidcSubject, {
+          users: deps.repos.user,
+          orgs: deps.repos.org,
+          agents: deps.repos.agent,
+          integrations: deps.repos.integration,
+          bots: deps.repos.bot,
+          channels: deps.repos.integrationChannel,
+          identity: deps.logtoIdentity,
+          push: (agent) => convergeIntegrationGating(deps, agent, req.log),
+          log: req.log
+        })
+      } catch (err) {
+        req.log.warn({ err, userId }, 'gated DM: opening conversations after an identity link failed')
+      }
+    }
+
     // The counterpart to linking happening in the browser: that write never
     // passes through the CP, so the console has to say when one landed or the
     // cached read would hide the new identity for its full TTL.
@@ -205,6 +235,7 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
         const identity = deps.logtoIdentity
         if (!identity) return reply.code(503).send(unavailable)
         identity.forgetUser(req.oidcSubject!)
+        await openLinkedDms(req)
         return reply.code(204).send(null)
       }
     )
@@ -273,6 +304,7 @@ export function meSocialIdentityRoutes(deps: HttpDeps) {
             ...req.body.connectorData,
             redirectUri
           })
+          await openLinkedDms(req)
           return { linked: true as const }
         } catch (error) {
           return logtoFailure(reply, error, 'link')

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -238,10 +238,12 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         row.agentId = agentId
         return row
       },
-      setTrigger: async (integrationId, channelId, trigger) => {
+      setTrigger: async (integrationId, channelId, trigger, opts) => {
         const row = channels.find((c) => c.integrationId === integrationId && c.channelId === channelId)
         if (!row) return null
         row.trigger = trigger
+        // Set-only, exactly like the repo: a decision does not expire.
+        if (opts?.chosen) row.triggerChosen = true
         return row
       },
       upsertConversation: async (integrationId, conversation, opts) => {
@@ -829,6 +831,35 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     // ownership convergence that immediately follows the report — that pass re-derives
     // a gated owner's trigger, and forcing Off there would undo the seed on the very
     // syncRoutes the report itself triggers.
+    // §14.8: `triggerChosen` is only useful if it is as complete as the trigger it
+    // accompanies. The shared-bot convergence has two ways to skip the write — a row
+    // that already carries the value, and one it backfills with that value — and both
+    // would leave a deliberate Off looking like an untouched default to a later
+    // catch-up.
+    it('records the human choice on every sibling row, including the ones needing no change (§14.8)', async () => {
+      gatedAgents = new Set([ALICE])
+      channels = [
+        // The owner row §14.8 opened, and a sibling that is already Off.
+        channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', trigger: 'any', agentId: ALICE }),
+        channel({ integrationId: INT_B, channelId: 'D42', kind: 'im', trigger: 'off' })
+      ]
+      const orch = makeOrch()
+      await orch.updateConversation(BOT, 'D42', { trigger: 'off' }, { source: 'console' })
+      for (const integrationId of [INT_A, INT_B]) {
+        const row = channels.find((c) => c.integrationId === integrationId && c.channelId === 'D42')
+        expect(row).toMatchObject({ trigger: 'off', triggerChosen: true })
+      }
+    })
+
+    it('records the human choice on a sibling row the update itself backfills (§14.8)', async () => {
+      gatedAgents = new Set([ALICE])
+      channels = [channel({ integrationId: INT_A, channelId: 'D42', kind: 'im', trigger: 'any', agentId: ALICE })]
+      const orch = makeOrch()
+      await orch.updateConversation(BOT, 'D42', { trigger: 'off' }, { source: 'console' })
+      const backfilled = channels.find((c) => c.integrationId === INT_B && c.channelId === 'D42')
+      expect(backfilled).toMatchObject({ trigger: 'off', triggerChosen: true })
+    })
+
     it('reportConversation opens a gated DM with a member of the agent’s own audience (§14.8)', async () => {
       gatedAgents = new Set([ALICE])
       channels = []

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -894,6 +894,44 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       })
     })
 
+    // §14.8's input is the counterpart id, so it is conversation-level metadata like the
+    // name: a sibling that inherits kind:'im' without it is a DM whose counterpart is
+    // unknown, and when owner removal leaves it as the only surviving row a linked
+    // audience member re-derives to Off with no way back — the later report that
+    // supplies the id cannot reopen a row that already exists.
+    it('carries the DM counterpart onto a backfilled sibling, so owner removal keeps it open (§14.8)', async () => {
+      gatedAgents = new Set([ALICE, BOB])
+      channels = [
+        channel({
+          integrationId: INT_A,
+          channelId: 'D42',
+          name: '@Alice',
+          kind: 'im',
+          dmUserId: 'U_ALICE',
+          trigger: 'any',
+          agentId: ALICE
+        })
+      ]
+      const orch = makeOrch(PLATFORMS, undefined, async (reported) =>
+        reported.some((c) => c.dmUserId === 'U_ALICE') ? new Map([['D42', 'any' as const]]) : new Map()
+      )
+
+      await orch.prepareIntegrationRemoval(BOT)
+      expect(channels.find((c) => c.integrationId === INT_B && c.channelId === 'D42')).toMatchObject({
+        kind: 'im',
+        dmUserId: 'U_ALICE'
+      })
+
+      // The owner integration and its row are gone; the survivor inherits the
+      // conversation and must still be able to answer the §14.8 question.
+      channels = channels.filter((c) => c.integrationId !== INT_A)
+      integrations = integrations.filter((i) => i.id !== INT_A)
+      await orch.syncBot(BOT)
+      expect(channels.find((c) => c.integrationId === INT_B && c.channelId === 'D42')).toMatchObject({
+        trigger: 'any'
+      })
+    })
+
     it('reportConversation opens a gated DM with a member of the agent’s own audience (§14.8)', async () => {
       gatedAgents = new Set([ALICE])
       channels = []

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -111,6 +111,7 @@ function channel(over: Partial<IntegrationChannelRecord>): IntegrationChannelRec
     kind: 'channel',
     trigger: 'mention',
     dmUserId: null,
+    triggerChosen: false,
     agentId: null,
     ...over
   } as IntegrationChannelRecord

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -860,6 +860,40 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(backfilled).toMatchObject({ trigger: 'off', triggerChosen: true })
     })
 
+    // §14.8 provenance is conversation-level, so it has to survive the owner-removal
+    // lifecycle the backfill exists for: the row that RECORDED the decision goes away
+    // with its integration, and a surviving sibling must not read the value it inherited
+    // as an undecided default.
+    it('carries the human decision onto a sibling backfilled long after it (§14.8)', async () => {
+      gatedAgents = new Set([ALICE, BOB])
+      channels = [
+        channel({
+          integrationId: INT_A,
+          channelId: 'D42',
+          kind: 'im',
+          trigger: 'off',
+          triggerChosen: true,
+          agentId: ALICE
+        })
+      ]
+      const orch = makeOrch(PLATFORMS, undefined, async () => new Map([['D42', 'any' as const]]))
+
+      // The sibling install arrives after the decision and is backfilled by ordinary
+      // convergence, which never passes `chosen` of its own.
+      await orch.prepareIntegrationRemoval(BOT)
+      const sibling = channels.find((c) => c.integrationId === INT_B && c.channelId === 'D42')
+      expect(sibling).toMatchObject({ trigger: 'off', triggerChosen: true })
+
+      // The owner integration is now gone with the row that recorded the decision.
+      channels = channels.filter((c) => c.integrationId !== INT_A)
+      integrations = integrations.filter((i) => i.id !== INT_A)
+      await orch.syncBot(BOT)
+      expect(channels.find((c) => c.integrationId === INT_B && c.channelId === 'D42')).toMatchObject({
+        trigger: 'off',
+        triggerChosen: true
+      })
+    })
+
     it('reportConversation opens a gated DM with a member of the agent’s own audience (§14.8)', async () => {
       gatedAgents = new Set([ALICE])
       channels = []

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { HttpBotOrchestrator } from './httpBot.js'
 import { AgentDelivery } from './agentDelivery.js'
 import type { PlacementResolver } from './placementResolver.js'
+import type { GatedDmSeedResolver } from './linkedDm.js'
 import { RelayRegistry, type RelayChannel } from '../ws/relay-registry.js'
 import type { RcBotAssign, RelayCpFrameType } from '@agentconnect.md/protocol'
 import { AgentId, BotId, DaemonId, IntegrationId, OrgId } from '../domain/ids.js'
@@ -109,6 +110,7 @@ function channel(over: Partial<IntegrationChannelRecord>): IntegrationChannelRec
     isPrivate: false,
     kind: 'channel',
     trigger: 'mention',
+    dmUserId: null,
     agentId: null,
     ...over
   } as IntegrationChannelRecord
@@ -151,7 +153,11 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
 
   /** `placement` stands in for the duty ledger: absent ⇒ placement alone, which is what every
    *  expectation predating the pool was written against. */
-  function makeOrch(platforms = PLATFORMS, placement?: Pick<PlacementResolver, 'routableDaemon'>): HttpBotOrchestrator {
+  function makeOrch(
+    platforms = PLATFORMS,
+    placement?: Pick<PlacementResolver, 'routableDaemon'>,
+    gatedDmSeeds?: GatedDmSeedResolver
+  ): HttpBotOrchestrator {
     const agents: Record<string, AgentRecord> = {
       [ALICE]: agent(ALICE, 'alice', unplacedAgents.has(ALICE) ? null : D1),
       [BOB]: agent(BOB, 'bob', unplacedAgents.has(BOB) ? null : D2)
@@ -245,11 +251,13 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
             channelId: conversation.id,
             name: conversation.name ?? null,
             kind: conversation.kind ?? 'channel',
+            dmUserId: conversation.dmUserId ?? null,
             trigger: opts?.defaultTrigger ?? 'mention'
           })
           channels.push(row)
         } else {
           if (conversation.name) row.name = conversation.name
+          if (conversation.dmUserId) row.dmUserId = conversation.dmUserId
         }
         return row
       },
@@ -320,7 +328,8 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       // No duty ledger wired ⇒ the delivery set is the placement alone, which is
       // exactly what every expectation in this file was written against.
       new AgentDelivery({ control: control as never, specs: undefined as never }),
-      ...(placement ? [placement] : [])
+      placement ?? undefined,
+      gatedDmSeeds
     )
   }
 
@@ -813,6 +822,37 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(assign.routes.filter((route) => route.scope?.channel === 'D42')).toEqual([
         expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } })
       ])
+    })
+
+    // §14.8: the shared-bot mirror of the direct path. The seed has to survive the
+    // ownership convergence that immediately follows the report — that pass re-derives
+    // a gated owner's trigger, and forcing Off there would undo the seed on the very
+    // syncRoutes the report itself triggers.
+    it('reportConversation opens a gated DM with a member of the agent’s own audience (§14.8)', async () => {
+      gatedAgents = new Set([ALICE])
+      channels = []
+      // Stands in for the real resolver, whose own policy is pinned in linkedDm.test.ts.
+      const orch = makeOrch(PLATFORMS, undefined, async (reported) =>
+        reported.some((c) => c.dmUserId === 'U_ALICE') ? new Map([['D42', 'any' as const]]) : new Map()
+      )
+      await orch.reportConversation(BOT, { id: 'D42', name: '@Alice', dmUserId: 'U_ALICE' })
+      const aliceRow = channels.find((c) => c.integrationId === INT_A && c.channelId === 'D42')
+      expect(aliceRow).toMatchObject({ kind: 'im', trigger: 'any', agentId: ALICE })
+
+      // And it routes: an open DM compiles the same channel-scoped auto rung an
+      // editor-enabled conversation gets.
+      const assign = ch.sends.filter((s) => s.type === 'rc/routes').at(-1)!.payload as RcBotAssign
+      expect(assign.routes.filter((route) => route.scope?.channel === 'D42')).toEqual([
+        expect.objectContaining({ agentId: ALICE, match: { kind: 'auto' } })
+      ])
+    })
+
+    it('reportConversation keeps a gated DM Off when its counterpart is outside the audience (§14.8)', async () => {
+      gatedAgents = new Set([ALICE])
+      channels = []
+      const orch = makeOrch(PLATFORMS, undefined, async () => new Map())
+      await orch.reportConversation(BOT, { id: 'D42', name: '@Dave', dmUserId: 'U_DAVE' })
+      expect(channels.find((c) => c.integrationId === INT_A && c.channelId === 'D42')).toMatchObject({ trigger: 'off' })
     })
 
     it('reportConversation preserves a group DM and converges it like a channel', async () => {

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -782,8 +782,17 @@ export class HttpBotOrchestrator {
       if (!owner) continue
       const persistedOwner = conversationRows.some((row) => row.agentId === owner.agentId)
       const ownerRow = conversationOwnerRow(owner, conversationRows)
+      // Provenance is CONVERSATION-level, exactly like the trigger it qualifies, and is
+      // read from ANY row: a human decides a conversation once, but the decision is
+      // repeated per install, and the row that recorded it can be deleted with its
+      // integration while siblings survive. Reading it from the owner row alone would
+      // lose the decision on precisely the owner-removal path this method exists for.
+      const chosen = conversationRows.some((row) => row.triggerChosen)
       let trigger = ownerRow?.trigger
-      if (!persistedOwner) {
+      // A decision outranks every default: a conversation a human has ruled on is not
+      // re-derived, whoever ends up owning it. Only an undecided one falls through to
+      // the gated rule below.
+      if (!persistedOwner && !chosen) {
         const ownerAgent = await this.agents.getUnscoped(owner.agentId)
         // A gated agent inheriting a conversation it never owned fails closed — with
         // §14.8's one exception, re-derived here rather than trusted from the row: the
@@ -807,7 +816,11 @@ export class HttpBotOrchestrator {
       )
       if (!canonical || conflicting)
         await this.persistConversationOwner(installs, channelId, owner, conversationRows[0])
-      if (trigger !== undefined) await this.syncConversationTrigger(installs, channelId, trigger, conversationRows)
+      // Replicating, not introducing: `chosen` came from the rows themselves, so a
+      // sibling backfilled here — including one added long after the decision — carries
+      // the same provenance as the value it is given.
+      if (trigger !== undefined)
+        await this.syncConversationTrigger(installs, channelId, trigger, conversationRows, { chosen })
     }
   }
 

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -663,7 +663,9 @@ export class HttpBotOrchestrator {
         targetAgent && isGatedAgent(targetAgent)
           ? ('off' as const)
           : (patch.trigger ?? currentRow?.trigger ?? rows[0]?.trigger ?? updated.trigger)
-      await this.syncConversationTrigger(installs, channelId, trigger, rows)
+      // This call IS the human's action (console patch or the in-Slack modal), so the
+      // resulting trigger is a decision on every sibling row, not a default (§14.8).
+      await this.syncConversationTrigger(installs, channelId, trigger, rows, { chosen: true })
       updated = { ...updated, trigger }
       await this.syncRoutes(botId)
       return updated
@@ -734,7 +736,8 @@ export class HttpBotOrchestrator {
     installs: IntegrationRecord[],
     channelId: string,
     trigger: ChannelTrigger,
-    knownRows: IntegrationChannelRecord[]
+    knownRows: IntegrationChannelRecord[],
+    opts?: { chosen?: boolean }
   ): Promise<void> {
     const known = new Map(knownRows.map((row) => [row.integrationId, row]))
     const template = knownRows.find((row) => row.name !== null) ?? knownRows[0]
@@ -754,7 +757,7 @@ export class HttpBotOrchestrator {
         )
         if (backfilled.trigger === trigger) continue
       }
-      await this.channels.setTrigger(integration.id, channelId, trigger)
+      await this.channels.setTrigger(integration.id, channelId, trigger, opts)
     }
   }
 

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -743,7 +743,14 @@ export class HttpBotOrchestrator {
     const template = knownRows.find((row) => row.name !== null) ?? knownRows[0]
     for (const integration of installs) {
       const row = known.get(integration.id)
-      if (row?.trigger === trigger) continue
+      // A human decision has to reach EVERY sibling row, including one that already
+      // carries the value and one this call is about to create. `triggerChosen` is what
+      // tells a decision from an untouched default later (§14.8), so under `chosen` a
+      // trigger that needs no change is still a write — otherwise the marker would be
+      // missing on exactly the rows the shared-bot paths converge, and a later catch-up
+      // would read a deliberate Off as pending and reopen it.
+      const marked = opts?.chosen !== true || row?.triggerChosen === true
+      if (row?.trigger === trigger && marked) continue
       if (!row) {
         const backfilled = await this.channels.upsertConversation(
           integration.id,
@@ -755,7 +762,7 @@ export class HttpBotOrchestrator {
           },
           { defaultTrigger: trigger }
         )
-        if (backfilled.trigger === trigger) continue
+        if (backfilled.trigger === trigger && opts?.chosen !== true) continue
       }
       await this.channels.setTrigger(integration.id, channelId, trigger, opts)
     }

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -740,7 +740,26 @@ export class HttpBotOrchestrator {
     opts?: { chosen?: boolean }
   ): Promise<void> {
     const known = new Map(knownRows.map((row) => [row.integrationId, row]))
-    const template = knownRows.find((row) => row.name !== null) ?? knownRows[0]
+    // Conversation-level metadata, taken PER FIELD from whichever sibling knows it: one
+    // row may carry the name while another carries the DM counterpart, and picking a
+    // single template row would silently drop whatever that row happens not to know. A
+    // committed direct kind wins over 'channel' for the same reason `replaceSnapshot`
+    // never downgrades one.
+    const first = <T>(get: (row: IntegrationChannelRecord) => T | null | undefined): T | undefined => {
+      for (const row of knownRows) {
+        const value = get(row)
+        if (value !== null && value !== undefined) return value
+      }
+      return undefined
+    }
+    const template = {
+      name: first((row) => row.name),
+      spaceId: first((row) => row.spaceId),
+      space: first((row) => row.space),
+      dmUserId: first((row) => row.dmUserId),
+      isPrivate: first((row) => row.isPrivate) ?? false,
+      kind: knownRows.find((row) => row.kind !== 'channel')?.kind ?? knownRows[0]?.kind ?? 'channel'
+    }
     for (const integration of installs) {
       const row = known.get(integration.id)
       // A human decision has to reach EVERY sibling row, including one that already
@@ -752,13 +771,23 @@ export class HttpBotOrchestrator {
       const marked = opts?.chosen !== true || row?.triggerChosen === true
       if (row?.trigger === trigger && marked) continue
       if (!row) {
+        // The template carries the CONVERSATION's own metadata, so a sibling gets all
+        // of it rather than a subset. `dmUserId` is the load-bearing one: it is the
+        // whole §14.8 input, and a sibling that inherits `kind:'im'` without it becomes
+        // a DM whose counterpart is unknown — so when owner removal leaves that sibling
+        // as the only surviving row, a linked audience member re-derives to Off, and
+        // the later report that finally supplies the id cannot reopen a row that
+        // already exists.
         const backfilled = await this.channels.upsertConversation(
           integration.id,
           {
             id: channelId,
-            ...(template?.name ? { name: template.name } : {}),
-            isPrivate: template?.isPrivate ?? false,
-            kind: template?.kind ?? 'channel'
+            ...(template.name ? { name: template.name } : {}),
+            ...(template.spaceId ? { spaceId: template.spaceId } : {}),
+            ...(template.space ? { space: template.space } : {}),
+            ...(template.dmUserId ? { dmUserId: template.dmUserId } : {}),
+            isPrivate: template.isPrivate,
+            kind: template.kind
           },
           { defaultTrigger: trigger }
         )

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -36,6 +36,7 @@ import type {
   IntegrationChannelRepo,
   IntegrationChannelRecord,
   ChannelTrigger,
+  ConversationKind,
   ReportedChannel,
   AgentRepo,
   AgentRecord,
@@ -45,6 +46,7 @@ import type {
 import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 import { ControlSender, NoConnection } from './outbound.js'
 import { isGatedAgent, httpIntegrationToSpec } from './placement.js'
+import type { GatedDmSeedResolver } from './linkedDm.js'
 import type { AgentDelivery } from './agentDelivery.js'
 import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
 import type { CpPlatformRegistry } from '../platforms/provider.js'
@@ -139,7 +141,11 @@ export class HttpBotOrchestrator {
     private readonly agentDelivery: AgentDelivery,
     /** Names the one member the relay addresses ingress to. Placement when it names a machine;
      *  for a pool agent, the member currently holding its duty — placement names none. */
-    private readonly placement: Pick<PlacementResolver, 'routableDaemon'> = PLACEMENT_ONLY
+    private readonly placement: Pick<PlacementResolver, 'routableDaemon'> = PLACEMENT_ONLY,
+    /** §14.8: which of a gated install's reported DMs seed to the ordinary DM default
+     *  because their counterpart is in the agent's own audience. Late-bound in the
+     *  composition root; absent ⇒ every gated conversation keeps the §14.2 Off default. */
+    private readonly gatedDmSeeds?: GatedDmSeedResolver
   ) {}
 
   /**
@@ -558,6 +564,28 @@ export class HttpBotOrchestrator {
   }
 
   /**
+   * What a GATED owner's conversation defaults to. Off is §14.2's answer for a room —
+   * its membership is a place, and only an editor can vouch for it. A 1:1 DM with a
+   * member of the agent's own `sharedWith` audience is §14.8's exception: that person
+   * can already see, edit and run the agent in the Console, so closing their DM hides
+   * it from someone it was explicitly shared with. Everything else, including every
+   * unresolvable case, stays Off.
+   */
+  private async gatedConversationTrigger(
+    agent: AgentRecord,
+    bot: Pick<BotRecord, 'platform' | 'teamId'>,
+    conversation: { id: string; kind?: ConversationKind; dmUserId?: string | null }
+  ): Promise<ChannelTrigger> {
+    if (!this.gatedDmSeeds || conversation.kind !== 'im' || !conversation.dmUserId) return 'off'
+    const seeds = await this.gatedDmSeeds(
+      [{ id: conversation.id, kind: 'im', dmUserId: conversation.dmUserId }],
+      agent,
+      bot
+    )
+    return seeds.get(conversation.id) ?? 'off'
+  }
+
+  /**
    * Fan an INCREMENTAL direct-conversation report across every install as a
    * `kind:'im'` / `kind:'mpim'` membership row. The shared bot converges the rows to
    * one owner and trigger, just like an enumerated channel; restricted installs still
@@ -578,13 +606,15 @@ export class HttpBotOrchestrator {
       const agent = await this.agents.getUnscoped(install.agentId)
       if (!agent) continue
       const kind = conversation.kind === 'mpim' ? ('mpim' as const) : ('im' as const)
-      await this.channels.upsertConversation(
-        install.id,
-        { ...conversation, kind },
-        {
-          defaultTrigger: isGatedAgent(agent) ? 'off' : kind === 'im' ? 'any' : 'mention'
-        }
-      )
+      const reported = { ...conversation, kind }
+      // Resolved per install, because a shared bot's installs are different agents with
+      // different audiences — the same DM may be open for one and Off for the next.
+      const defaultTrigger = isGatedAgent(agent)
+        ? await this.gatedConversationTrigger(agent, bot, reported)
+        : kind === 'im'
+          ? ('any' as const)
+          : ('mention' as const)
+      await this.channels.upsertConversation(install.id, reported, { defaultTrigger })
     }
     await this.syncRoutes(botId)
   }
@@ -733,6 +763,9 @@ export class HttpBotOrchestrator {
     if (installs.length === 0) return
     const rows = await this.channels.listForBot(botId)
     const conversationIds = [...new Set(rows.map((row) => row.channelId))]
+    // Only the gated arm below reads it, and only for a conversation whose owner is
+    // not yet persisted — so it is fetched once and lazily rather than per row.
+    let bot: BotRecord | null | undefined
     for (const channelId of conversationIds) {
       const conversationRows = rows.filter((row) => row.channelId === channelId)
       const owner = pickConversationOwner(installs, conversationRows)
@@ -742,7 +775,21 @@ export class HttpBotOrchestrator {
       let trigger = ownerRow?.trigger
       if (!persistedOwner) {
         const ownerAgent = await this.agents.getUnscoped(owner.agentId)
-        if (ownerAgent && isGatedAgent(ownerAgent)) trigger = 'off'
+        // A gated agent inheriting a conversation it never owned fails closed — with
+        // §14.8's one exception, re-derived here rather than trusted from the row: the
+        // audience may have changed since the row was seeded, and this is the write
+        // that would otherwise freeze a stale answer in as the owner's trigger.
+        if (ownerAgent && isGatedAgent(ownerAgent)) {
+          if (bot === undefined) bot = await this.bots.getUnscoped(botId)
+          const direct = conversationRows.find((row) => row.kind === 'im' && row.dmUserId)
+          trigger = bot
+            ? await this.gatedConversationTrigger(ownerAgent, bot, {
+                id: channelId,
+                kind: direct?.kind,
+                dmUserId: direct?.dmUserId
+              })
+            : 'off'
+        }
       }
       const canonical = conversationRows.some((row) => row.integrationId === owner.id && row.agentId === owner.agentId)
       const conflicting = conversationRows.some(

--- a/packages/control-plane/src/orchestrator/linkedDm.test.ts
+++ b/packages/control-plane/src/orchestrator/linkedDm.test.ts
@@ -1,0 +1,158 @@
+/**
+ * §14.8 seeding policy (resource-visibility.md): which of a private agent's reported
+ * conversations open to the ordinary DM default because their counterpart is already
+ * in the agent's audience. Both arms of the rule are load-bearing — an unlinked
+ * audience member and a linked non-member must BOTH keep §14.2's Off — and every
+ * unresolvable case has to fail to Off rather than to open.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentRecord, BotRecord, ReportedChannel } from '../persistence/ports.js'
+import type { SlackIdentity } from '../github/logto-identity.js'
+import { gatedDmSeeds, linkedAudienceMemberIds, type LinkedDmDeps } from './linkedDm.js'
+
+const TEAM = 'T024BE7LD'
+
+const agent = (over: Partial<Pick<AgentRecord, 'visibility' | 'sharedWith'>> = {}) => ({
+  visibility: 'restricted' as const,
+  sharedWith: ['user-a'],
+  ...over
+})
+
+const bot = (over: Partial<Pick<BotRecord, 'platform' | 'teamId'>> = {}) => ({
+  platform: 'slack',
+  teamId: TEAM,
+  ...over
+})
+
+/** `links` maps a user id to the Slack identity their console account carries. */
+function deps(links: Record<string, SlackIdentity | null>, over: Partial<LinkedDmDeps> = {}): LinkedDmDeps {
+  return {
+    users: { getOidcSubject: async (userId) => (userId in links ? `sub-${userId}` : null) },
+    identity: {
+      slackIdentityFor: async (sub) => links[sub.replace(/^sub-/, '')] ?? null
+    },
+    ...over
+  }
+}
+
+const slack = (userId: string, teamId = TEAM): SlackIdentity => ({ teamId, userId })
+
+describe('linkedAudienceMemberIds', () => {
+  it('resolves every audience member who linked this workspace', async () => {
+    const ids = await linkedAudienceMemberIds(
+      agent({ sharedWith: ['user-a', 'user-b', 'user-c'] }),
+      bot(),
+      deps({ 'user-a': slack('U_A'), 'user-b': slack('U_B'), 'user-c': slack('U_C') })
+    )
+    expect([...ids].sort()).toEqual(['U_A', 'U_B', 'U_C'])
+  })
+
+  it('leaves out an audience member who never linked', async () => {
+    const ids = await linkedAudienceMemberIds(
+      agent({ sharedWith: ['user-a', 'user-b'] }),
+      bot(),
+      deps({ 'user-a': slack('U_A'), 'user-b': null })
+    )
+    expect([...ids]).toEqual(['U_A'])
+  })
+
+  it('fences on the workspace — the same member id in another team is another person', async () => {
+    const ids = await linkedAudienceMemberIds(agent(), bot(), deps({ 'user-a': slack('U_A', 'T_OTHER') }))
+    expect(ids.size).toBe(0)
+  })
+
+  it('resolves nothing for a public agent, an unknown workspace, or a deployment without sign-in', async () => {
+    const links = { 'user-a': slack('U_A') }
+    expect((await linkedAudienceMemberIds(agent({ visibility: 'org' }), bot(), deps(links))).size).toBe(0)
+    expect((await linkedAudienceMemberIds(agent(), bot({ teamId: null }), deps(links))).size).toBe(0)
+    expect((await linkedAudienceMemberIds(agent(), bot({ platform: 'telegram' }), deps(links))).size).toBe(0)
+    expect((await linkedAudienceMemberIds(agent(), bot(), { users: deps(links).users })).size).toBe(0)
+  })
+
+  it('keeps the Off default when one member’s lookup throws, without losing the others', async () => {
+    const warn = vi.fn()
+    const ids = await linkedAudienceMemberIds(agent({ sharedWith: ['user-a', 'user-b'] }), bot(), {
+      users: { getOidcSubject: async (userId) => `sub-${userId}` },
+      identity: {
+        slackIdentityFor: async (sub) => {
+          if (sub === 'sub-user-a') throw new Error('logto unreachable')
+          return slack('U_B')
+        }
+      },
+      log: { debug: vi.fn(), warn }
+    })
+    expect([...ids]).toEqual(['U_B'])
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('refuses an audience too large to resolve rather than fanning it out upstream', async () => {
+    const slackIdentityFor = vi.fn(async () => slack('U_A'))
+    const ids = await linkedAudienceMemberIds(
+      agent({ sharedWith: Array.from({ length: 201 }, (_, i) => `user-${i}`) }),
+      bot(),
+      {
+        users: { getOidcSubject: async (userId) => `sub-${userId}` },
+        identity: { slackIdentityFor },
+        log: { debug: vi.fn(), warn: vi.fn() }
+      }
+    )
+    expect(ids.size).toBe(0)
+    expect(slackIdentityFor).not.toHaveBeenCalled()
+  })
+})
+
+describe('gatedDmSeeds', () => {
+  const dm = (id: string, dmUserId: string): ReportedChannel => ({ id, kind: 'im', dmUserId })
+
+  it('opens the DM of an audience member and leaves everyone else Off', async () => {
+    const seeds = await gatedDmSeeds(
+      [dm('D_A', 'U_A'), dm('D_STRANGER', 'U_STRANGER')],
+      agent({ sharedWith: ['user-a'] }),
+      bot(),
+      deps({ 'user-a': slack('U_A') })
+    )
+    expect([...seeds]).toEqual([['D_A', 'any']])
+  })
+
+  it('opens one row per audience member of the same agent', async () => {
+    const seeds = await gatedDmSeeds(
+      [dm('D_A', 'U_A'), dm('D_B', 'U_B'), dm('D_C', 'U_C')],
+      agent({ sharedWith: ['user-a', 'user-b', 'user-c'] }),
+      bot(),
+      deps({ 'user-a': slack('U_A'), 'user-b': slack('U_B'), 'user-c': slack('U_C') })
+    )
+    expect([...seeds].sort()).toEqual([
+      ['D_A', 'any'],
+      ['D_B', 'any'],
+      ['D_C', 'any']
+    ])
+  })
+
+  it('never seeds a channel or a group DM — their membership is a room, not a person', async () => {
+    const seeds = await gatedDmSeeds(
+      [
+        { id: 'C_DEPLOYS', kind: 'channel' },
+        { id: 'G_ROOM', kind: 'mpim', dmUserId: 'U_A' }
+      ],
+      agent(),
+      bot(),
+      deps({ 'user-a': slack('U_A') })
+    )
+    expect(seeds.size).toBe(0)
+  })
+
+  it('costs no identity lookup when the report carries no DM to seed', async () => {
+    const getOidcSubject = vi.fn(async () => 'sub-user-a')
+    const seeds = await gatedDmSeeds([{ id: 'C_DEPLOYS', kind: 'channel' }], agent(), bot(), {
+      users: { getOidcSubject },
+      identity: { slackIdentityFor: async () => slack('U_A') }
+    })
+    expect(seeds.size).toBe(0)
+    expect(getOidcSubject).not.toHaveBeenCalled()
+  })
+
+  it('leaves a DM reported without its counterpart Off', async () => {
+    const seeds = await gatedDmSeeds([{ id: 'D_A', kind: 'im' }], agent(), bot(), deps({ 'user-a': slack('U_A') }))
+    expect(seeds.size).toBe(0)
+  })
+})

--- a/packages/control-plane/src/orchestrator/linkedDm.ts
+++ b/packages/control-plane/src/orchestrator/linkedDm.ts
@@ -60,12 +60,16 @@ async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value:
 }
 
 /**
- * The platform member ids of `agent`'s audience who have linked THIS bot's workspace.
- * Empty for a public agent (nothing is gated), a platform without a linked-identity
- * assertion, a bot whose workspace is unknown, or a deployment without sign-in.
+ * The platform member ids, among `userIds`, that have linked THIS bot's workspace.
+ * Empty for a platform without a linked-identity assertion, a bot whose workspace is
+ * unknown, or a deployment without sign-in.
+ *
+ * Takes an explicit user list rather than reading the audience, because the catch-up
+ * paths must ask about the members that just BECAME eligible, not the whole current
+ * audience — re-asking for everyone would reopen a DM an editor had since closed.
  */
-export async function linkedAudienceMemberIds(
-  agent: Pick<AgentRecord, 'visibility' | 'sharedWith'>,
+export async function linkedMemberIds(
+  userIds: readonly string[],
   bot: Pick<BotRecord, 'platform' | 'teamId'>,
   deps: LinkedDmDeps
 ): Promise<ReadonlySet<string>> {
@@ -74,14 +78,13 @@ export async function linkedAudienceMemberIds(
   // cross-app `union_id` while its messages carry an app-scoped `open_id`, so
   // matching there needs a resolution step this does not have — and guessing would
   // silently widen a private agent.
-  if (!deps.identity || !isGatedAgent(agent) || bot.platform !== 'slack' || !bot.teamId) return new Set()
-  const audience = agent.sharedWith
-  if (audience.length === 0) return new Set()
-  if (audience.length > MAX_AUDIENCE) {
-    deps.log?.debug({ audience: audience.length }, 'gated DM: audience too large to resolve — keeping the Off default')
+  if (!deps.identity || bot.platform !== 'slack' || !bot.teamId) return new Set()
+  if (userIds.length === 0) return new Set()
+  if (userIds.length > MAX_AUDIENCE) {
+    deps.log?.debug({ audience: userIds.length }, 'gated DM: audience too large to resolve — keeping the Off default')
     return new Set()
   }
-  const identities = await mapLimited(audience, AUDIENCE_CONCURRENCY, async (userId) => {
+  const identities = await mapLimited(userIds, AUDIENCE_CONCURRENCY, async (userId) => {
     try {
       const sub = await deps.users.getOidcSubject(userId)
       if (!sub) return null
@@ -94,6 +97,16 @@ export async function linkedAudienceMemberIds(
     }
   })
   return new Set(identities.filter((id): id is string => id !== null))
+}
+
+/** {@link linkedMemberIds} over a gated agent's whole audience — the seed path, where
+ *  every row under consideration is new and there is no operator choice to preserve. */
+export async function linkedAudienceMemberIds(
+  agent: Pick<AgentRecord, 'visibility' | 'sharedWith'>,
+  bot: Pick<BotRecord, 'platform' | 'teamId'>,
+  deps: LinkedDmDeps
+): Promise<ReadonlySet<string>> {
+  return isGatedAgent(agent) ? linkedMemberIds(agent.sharedWith, bot, deps) : new Set()
 }
 
 /**

--- a/packages/control-plane/src/orchestrator/linkedDm.ts
+++ b/packages/control-plane/src/orchestrator/linkedDm.ts
@@ -1,0 +1,128 @@
+/**
+ * §14.8 — a private agent's DM follows its audience's linked identity.
+ *
+ * §14.2 gates every conversation of a restricted agent Off because the platform has no
+ * per-user ACL: a channel's membership is a room, so the Console (already protected by
+ * this design's predicates) has to say who is trusted inside it. A 1:1 DM is the one
+ * conversation whose entire human membership is known the moment it is discovered —
+ * one bot, one person. When that person's console account is in the agent's OWN
+ * `sharedWith` audience, defaulting the row Off protects nobody: it hides the agent
+ * from someone already authorized to see, edit, and run it. So that row seeds to the
+ * ordinary DM default instead, and "private" starts meaning the same set of people on
+ * both surfaces (§14.6's identity-mapping overlay, narrowed to the case where the
+ * mapping is an assertion rather than an inference).
+ *
+ * The link is Logto's — a Slack sign-in, or an Account API link driven by the user's
+ * own authenticated session — never an email guess. Both arms must hold: an unlinked
+ * member of the audience and a linked non-member both keep today's Off.
+ *
+ * There is no reverse index from a Slack member id to a console account, and this
+ * deliberately does not build one. The audience of a restricted agent is small by
+ * construction, so the scan runs the other way: resolve the audience's own linked
+ * identities (each a cached per-subject read) and match the reported counterpart
+ * against them. Everything here fails CLOSED to the §14.2 default — no sign-in
+ * configured, no workspace on the bot, an audience past {@link MAX_AUDIENCE}, or an
+ * upstream that cannot answer all leave the row Off, which is exactly today's
+ * behavior.
+ */
+import type { SlackIdentity } from '../github/logto-identity.js'
+import type { AgentRecord, BotRecord, ChannelTrigger, ReportedChannel } from '../persistence/ports.js'
+import { isGatedAgent } from './placement.js'
+
+/** Concurrent identity reads per resolve — the audience is small and every lookup is
+ *  cached per subject, so this only bounds a cold burst. */
+const AUDIENCE_CONCURRENCY = 8
+
+/** Audience size past which the scan is refused rather than fanned out upstream. An
+ *  agent shared this widely is not the case §14.8 serves, and refusing keeps the
+ *  §14.2 default. */
+const MAX_AUDIENCE = 200
+
+export interface LinkedDmDeps {
+  users: { getOidcSubject(userId: string): Promise<string | null> }
+  /** Absent when the deployment has no sign-in configured — then nothing is linked. */
+  identity?: { slackIdentityFor(sub: string): Promise<SlackIdentity | null> }
+  log?: { debug(obj: object, msg: string): void; warn(obj: object, msg: string): void }
+}
+
+/** Run `fn` over `values` with at most `limit` in flight, preserving order. */
+async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value: T) => Promise<R>): Promise<R[]> {
+  const out = new Array<R>(values.length)
+  let next = 0
+  const worker = async (): Promise<void> => {
+    while (next < values.length) {
+      const i = next++
+      out[i] = await fn(values[i]!)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, values.length) }, worker))
+  return out
+}
+
+/**
+ * The platform member ids of `agent`'s audience who have linked THIS bot's workspace.
+ * Empty for a public agent (nothing is gated), a platform without a linked-identity
+ * assertion, a bot whose workspace is unknown, or a deployment without sign-in.
+ */
+export async function linkedAudienceMemberIds(
+  agent: Pick<AgentRecord, 'visibility' | 'sharedWith'>,
+  bot: Pick<BotRecord, 'platform' | 'teamId'>,
+  deps: LinkedDmDeps
+): Promise<ReadonlySet<string>> {
+  // Slack only for now: it is the driving case AND the one platform whose linked
+  // identity names the same id space a DM report carries. A Feishu link asserts a
+  // cross-app `union_id` while its messages carry an app-scoped `open_id`, so
+  // matching there needs a resolution step this does not have — and guessing would
+  // silently widen a private agent.
+  if (!deps.identity || !isGatedAgent(agent) || bot.platform !== 'slack' || !bot.teamId) return new Set()
+  const audience = agent.sharedWith
+  if (audience.length === 0) return new Set()
+  if (audience.length > MAX_AUDIENCE) {
+    deps.log?.debug({ audience: audience.length }, 'gated DM: audience too large to resolve — keeping the Off default')
+    return new Set()
+  }
+  const identities = await mapLimited(audience, AUDIENCE_CONCURRENCY, async (userId) => {
+    try {
+      const sub = await deps.users.getOidcSubject(userId)
+      if (!sub) return null
+      const identity = await deps.identity!.slackIdentityFor(sub)
+      return identity?.teamId === bot.teamId ? identity.userId : null
+    } catch (err) {
+      // One member's lookup failing costs that member the default, never the report.
+      deps.log?.warn({ err, userId }, 'gated DM: linked-identity lookup failed — keeping the Off default')
+      return null
+    }
+  })
+  return new Set(identities.filter((id): id is string => id !== null))
+}
+
+/**
+ * The per-conversation seeds a gated install's report deserves: the ordinary DM
+ * default for every reported 1:1 DM whose counterpart is in {@link
+ * linkedAudienceMemberIds}, and nothing for anything else (which leaves the caller's
+ * install-wide Off). Empty when no reported row qualifies, so a caller can skip the
+ * identity scan's cost entirely on the common report.
+ */
+export async function gatedDmSeeds(
+  channels: readonly ReportedChannel[],
+  agent: Pick<AgentRecord, 'visibility' | 'sharedWith'>,
+  bot: Pick<BotRecord, 'platform' | 'teamId'>,
+  deps: LinkedDmDeps
+): Promise<ReadonlyMap<string, ChannelTrigger>> {
+  const seeds = new Map<string, ChannelTrigger>()
+  const dms = channels.filter((c) => c.kind === 'im' && c.dmUserId)
+  if (dms.length === 0) return seeds
+  const linked = await linkedAudienceMemberIds(agent, bot, deps)
+  if (linked.size === 0) return seeds
+  for (const dm of dms) if (linked.has(dm.dmUserId!)) seeds.set(dm.id, 'any')
+  return seeds
+}
+
+/** The seam both report paths hold: the daemon WS handler and the shared-bot
+ *  orchestrator take this, and the composition root is the only place that knows it
+ *  is backed by Logto. Absent ⇒ every gated conversation keeps the §14.2 Off default. */
+export type GatedDmSeedResolver = (
+  channels: readonly ReportedChannel[],
+  agent: Pick<AgentRecord, 'visibility' | 'sharedWith'>,
+  bot: Pick<BotRecord, 'platform' | 'teamId'>
+) => Promise<ReadonlyMap<string, ChannelTrigger>>

--- a/packages/control-plane/src/orchestrator/linkedDmReconcile.ts
+++ b/packages/control-plane/src/orchestrator/linkedDmReconcile.ts
@@ -13,10 +13,16 @@
  * results is order-independent: an audience member with a linked identity has an open
  * DM, however the two arrived.
  *
- * Deliberately ONE-WAY: it opens rows and never closes them. A stored trigger is
- * indistinguishable from an operator's own choice — §14.2 lets an editor enable a DM
- * for anyone — so re-deriving a CLOSE would silently revert decisions §14.8 never
- * made. The consequence is that an opened DM stays open: a gated bind rule is
+ * Scoped to the pair that JUST became eligible, never to the current state. A stored
+ * Off is indistinguishable from an operator's own choice — §14.2 lets an editor close
+ * a DM §14.8 opened — so re-deriving from "everyone currently in the audience who is
+ * currently linked" would reopen that DM on the next unrelated sharing edit or profile
+ * refresh, turning a DEFAULT into a standing rule that overrides the per-conversation
+ * control. Hence the callers pass the members just added, and the link path fires only
+ * when the identity actually changed.
+ *
+ * Deliberately ONE-WAY: it opens rows and never closes them, for the same reason. The
+ * consequence is that an opened DM stays open — a gated bind rule is
  * conversation-scoped, with no user dimension, so losing the audience seat does not
  * close the conversation the seat opened, and only an editor's Off does. §14.8 records
  * why, and what telling the two apart would cost.
@@ -35,7 +41,7 @@ import type {
 } from '../persistence/ports.js'
 import { AgentId, IntegrationId, OrgId } from '../domain/ids.js'
 import type { SlackIdentity } from '../github/logto-identity.js'
-import { linkedAudienceMemberIds, type LinkedDmDeps } from './linkedDm.js'
+import { linkedMemberIds, type LinkedDmDeps } from './linkedDm.js'
 import { isGatedAgent } from './placement.js'
 
 export interface LinkedDmReconcileDeps extends LinkedDmDeps {
@@ -85,16 +91,17 @@ async function openDirectRows(
 /**
  * A link just landed on this account: open this person's Off DMs with every private
  * agent they are already in the audience of, across every org they belong to.
- * Returns how many rows were opened, for the caller's log line.
+ *
+ * `identity` is the one that just became true — the caller establishes that by
+ * comparing what it read before the change with what it reads after, so a profile
+ * refresh that changed nothing (a reauthorization, a link to some other provider)
+ * reconciles nothing. Returns how many rows were opened, for the caller's log line.
  */
 export async function reconcileLinkedDms(
   userId: string,
-  oidcSubject: string,
+  identity: SlackIdentity,
   deps: LinkedDmReconcileDeps
 ): Promise<number> {
-  if (!deps.identity) return 0
-  const identity = await deps.identity.slackIdentityFor(oidcSubject)
-  if (!identity) return 0
   // The workspace fence: a Slack member id is scoped to its team, so the same `U…` in
   // another workspace is a different person entirely.
   const admits = async (bot: BotRecord): Promise<ReadonlySet<string>> =>
@@ -113,11 +120,19 @@ export async function reconcileLinkedDms(
 }
 
 /**
- * An audience just widened: open the Off DMs of everyone now in it who has a linked
- * identity. The mirror of {@link reconcileLinkedDms} — same rule, other input.
+ * An audience just widened: open the Off DMs of the members it GAINED who have a
+ * linked identity. The mirror of {@link reconcileLinkedDms} — same rule, other input.
+ *
+ * `addedUserIds` is the diff, not the audience. Passing the whole current audience
+ * would make every later sharing edit reassert the default over an editor's Off.
  */
-export async function reconcileAgentLinkedDms(agent: AgentRecord, deps: LinkedDmReconcileDeps): Promise<number> {
-  const opened = await openDirectRows(agent, (bot) => linkedAudienceMemberIds(agent, bot, deps), deps)
+export async function reconcileAgentLinkedDms(
+  agent: AgentRecord,
+  addedUserIds: readonly string[],
+  deps: LinkedDmReconcileDeps
+): Promise<number> {
+  if (addedUserIds.length === 0) return 0
+  const opened = await openDirectRows(agent, (bot) => linkedMemberIds(addedUserIds, bot, deps), deps)
   if (opened > 0)
     deps.log?.debug({ agentId: agent.id, opened }, 'gated DM: opened conversations after a sharing change')
   return opened

--- a/packages/control-plane/src/orchestrator/linkedDmReconcile.ts
+++ b/packages/control-plane/src/orchestrator/linkedDmReconcile.ts
@@ -13,19 +13,19 @@
  * results is order-independent: an audience member with a linked identity has an open
  * DM, however the two arrived.
  *
- * Scoped to the pair that JUST became eligible, never to the current state. A stored
- * Off is indistinguishable from an operator's own choice — §14.2 lets an editor close
- * a DM §14.8 opened — so re-deriving from "everyone currently in the audience who is
- * currently linked" would reopen that DM on the next unrelated sharing edit or profile
- * refresh, turning a DEFAULT into a standing rule that overrides the per-conversation
- * control. Hence the callers pass the members just added, and the link path fires only
- * when the identity actually changed.
+ * Only ever opens rows still at their DEFAULT. `triggerChosen` is what makes that
+ * expressible: without it a stored Off is indistinguishable from an operator's own
+ * choice — §14.2 lets an editor close a DM §14.8 opened — and a catch-up would reopen
+ * that DM on the next sharing edit or profile refresh, turning a default into a
+ * standing rule that overrides the per-conversation control. With it, running the
+ * catch-up more often than strictly necessary is harmless, which matters because
+ * neither caller can prove it is the moment a link appeared: the console's refresh
+ * lands AFTER the browser already wrote the link, so nothing observable on this side
+ * separates a new link from a reauthorization.
  *
- * Deliberately ONE-WAY: it opens rows and never closes them, for the same reason. The
- * consequence is that an opened DM stays open — a gated bind rule is
- * conversation-scoped, with no user dimension, so losing the audience seat does not
- * close the conversation the seat opened, and only an editor's Off does. §14.8 records
- * why, and what telling the two apart would cost.
+ * Deliberately ONE-WAY even so: it never closes a row, because a close cannot be
+ * derived from absence — an audience seat lost, an unlink, and an editor's own Off all
+ * present the same way. §14.8 records the consequence.
  *
  * Best-effort at every call site: a failure leaves the rows Off, which is where they
  * already were.
@@ -74,7 +74,11 @@ async function openDirectRows(
     const bot = await deps.bots.getUnscoped(integration.botId)
     if (!bot) continue
     const rows = await deps.channels.listForIntegration(IntegrationId(integration.id))
-    const candidates = rows.filter((row) => row.kind === 'im' && row.trigger === 'off' && row.dmUserId)
+    // `!triggerChosen` is the whole safety property: a row an editor closed is not a
+    // pending authorization, it is a decision, and this must not relitigate it.
+    const candidates = rows.filter(
+      (row) => row.kind === 'im' && row.trigger === 'off' && !row.triggerChosen && row.dmUserId
+    )
     if (candidates.length === 0) continue
     const allowed = await admits(bot)
     if (allowed.size === 0) continue
@@ -92,16 +96,18 @@ async function openDirectRows(
  * A link just landed on this account: open this person's Off DMs with every private
  * agent they are already in the audience of, across every org they belong to.
  *
- * `identity` is the one that just became true — the caller establishes that by
- * comparing what it read before the change with what it reads after, so a profile
- * refresh that changed nothing (a reauthorization, a link to some other provider)
- * reconciles nothing. Returns how many rows were opened, for the caller's log line.
+ * Safe to run whenever a link MIGHT have landed — the caller does not have to prove
+ * one did, because `openDirectRows` only touches rows still at their default. Returns
+ * how many rows were opened, for the caller's log line.
  */
 export async function reconcileLinkedDms(
   userId: string,
-  identity: SlackIdentity,
+  oidcSubject: string,
   deps: LinkedDmReconcileDeps
 ): Promise<number> {
+  if (!deps.identity) return 0
+  const identity = await deps.identity.slackIdentityFor(oidcSubject)
+  if (!identity) return 0
   // The workspace fence: a Slack member id is scoped to its team, so the same `U…` in
   // another workspace is a different person entirely.
   const admits = async (bot: BotRecord): Promise<ReadonlySet<string>> =>

--- a/packages/control-plane/src/orchestrator/linkedDmReconcile.ts
+++ b/packages/control-plane/src/orchestrator/linkedDmReconcile.ts
@@ -1,0 +1,124 @@
+/**
+ * §14.8 catch-up: open the DM rows that became authorized after the row was created.
+ *
+ * The seed in `linkedDm.ts` decides at DISCOVERY time, which is the wrong moment for
+ * the flow that actually happens. Someone DMs a private agent, is refused, reads the
+ * notice, and only THEN links their Slack account — or is only then added to the
+ * agent's audience. Either way the row already exists and is Off, and no reporter
+ * re-reports an unchanged conversation. Without this, §14.8 would fire only for people
+ * whose link and audience seat both predate their first DM.
+ *
+ * So both writes that can make the §14.8 answer true — a landed identity link, a
+ * widened audience — re-ask it for the Off DMs already on record. The rule that
+ * results is order-independent: an audience member with a linked identity has an open
+ * DM, however the two arrived.
+ *
+ * Deliberately ONE-WAY: it opens rows and never closes them. A stored trigger is
+ * indistinguishable from an operator's own choice — §14.2 lets an editor enable a DM
+ * for anyone — so re-deriving a CLOSE would silently revert decisions §14.8 never
+ * made. The consequence is that an opened DM stays open: a gated bind rule is
+ * conversation-scoped, with no user dimension, so losing the audience seat does not
+ * close the conversation the seat opened, and only an editor's Off does. §14.8 records
+ * why, and what telling the two apart would cost.
+ *
+ * Best-effort at every call site: a failure leaves the rows Off, which is where they
+ * already were.
+ */
+import type {
+  AgentRecord,
+  AgentRepo,
+  BotRecord,
+  BotRepo,
+  IntegrationChannelRepo,
+  IntegrationRepo,
+  OrgRepo
+} from '../persistence/ports.js'
+import { AgentId, IntegrationId, OrgId } from '../domain/ids.js'
+import type { SlackIdentity } from '../github/logto-identity.js'
+import { linkedAudienceMemberIds, type LinkedDmDeps } from './linkedDm.js'
+import { isGatedAgent } from './placement.js'
+
+export interface LinkedDmReconcileDeps extends LinkedDmDeps {
+  orgs: Pick<OrgRepo, 'listForUser'>
+  agents: Pick<AgentRepo, 'list'>
+  integrations: Pick<IntegrationRepo, 'listForAgent'>
+  bots: Pick<BotRepo, 'getUnscoped'>
+  channels: Pick<IntegrationChannelRepo, 'listForIntegration' | 'setTrigger'>
+  identity?: { slackIdentityFor(sub: string): Promise<SlackIdentity | null> }
+  /** Re-converge every integration of an agent whose rows changed — the same push a
+   *  visibility flip performs, so an HTTP bot recompiles its relay routes and a direct
+   *  install receives a fresh spec. */
+  push: (agent: AgentRecord) => Promise<void>
+}
+
+/**
+ * Open every Off 1:1 DM of `agent` whose counterpart `admits` allows, and push once if
+ * anything changed. `admits` is asked per bot because a platform member id means
+ * nothing outside its own workspace.
+ */
+async function openDirectRows(
+  agent: AgentRecord,
+  admits: (bot: BotRecord) => Promise<ReadonlySet<string>>,
+  deps: LinkedDmReconcileDeps
+): Promise<number> {
+  if (!isGatedAgent(agent)) return 0
+  let opened = 0
+  for (const integration of await deps.integrations.listForAgent(AgentId(agent.id))) {
+    if (integration.status !== 'active') continue
+    const bot = await deps.bots.getUnscoped(integration.botId)
+    if (!bot) continue
+    const rows = await deps.channels.listForIntegration(IntegrationId(integration.id))
+    const candidates = rows.filter((row) => row.kind === 'im' && row.trigger === 'off' && row.dmUserId)
+    if (candidates.length === 0) continue
+    const allowed = await admits(bot)
+    if (allowed.size === 0) continue
+    for (const row of candidates) {
+      if (!allowed.has(row.dmUserId!)) continue
+      await deps.channels.setTrigger(IntegrationId(integration.id), row.channelId, 'any')
+      opened += 1
+    }
+  }
+  if (opened > 0) await deps.push(agent)
+  return opened
+}
+
+/**
+ * A link just landed on this account: open this person's Off DMs with every private
+ * agent they are already in the audience of, across every org they belong to.
+ * Returns how many rows were opened, for the caller's log line.
+ */
+export async function reconcileLinkedDms(
+  userId: string,
+  oidcSubject: string,
+  deps: LinkedDmReconcileDeps
+): Promise<number> {
+  if (!deps.identity) return 0
+  const identity = await deps.identity.slackIdentityFor(oidcSubject)
+  if (!identity) return 0
+  // The workspace fence: a Slack member id is scoped to its team, so the same `U…` in
+  // another workspace is a different person entirely.
+  const admits = async (bot: BotRecord): Promise<ReadonlySet<string>> =>
+    bot.platform === 'slack' && bot.teamId === identity.teamId ? new Set([identity.userId]) : new Set()
+  let opened = 0
+  for (const org of await deps.orgs.listForUser(userId)) {
+    // Unfiltered on purpose: the audience test below IS the visibility predicate, so a
+    // viewer projection would hide nothing it does not already hide.
+    for (const agent of await deps.agents.list(OrgId(org.id))) {
+      if (!agent.sharedWith.includes(userId)) continue
+      opened += await openDirectRows(agent, admits, deps)
+    }
+  }
+  if (opened > 0) deps.log?.debug({ userId, opened }, 'gated DM: opened conversations after an identity link')
+  return opened
+}
+
+/**
+ * An audience just widened: open the Off DMs of everyone now in it who has a linked
+ * identity. The mirror of {@link reconcileLinkedDms} — same rule, other input.
+ */
+export async function reconcileAgentLinkedDms(agent: AgentRecord, deps: LinkedDmReconcileDeps): Promise<number> {
+  const opened = await openDirectRows(agent, (bot) => linkedAudienceMemberIds(agent, bot, deps), deps)
+  if (opened > 0)
+    deps.log?.debug({ agentId: agent.id, opened }, 'gated DM: opened conversations after a sharing change')
+  return opened
+}

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -91,6 +91,7 @@ const channel = (
   kind,
   trigger,
   dmUserId: null,
+  triggerChosen: false,
   agentId: null
 })
 

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -90,6 +90,7 @@ const channel = (
   isPrivate: false,
   kind,
   trigger,
+  dmUserId: null,
   agentId: null
 })
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4329,6 +4329,9 @@ export interface IntegrationChannelRecord {
   /** The 1:1 DM counterpart's platform member id (§14.8); null on rooms and on rows
    *  discovered before the reporter carried it. */
   dmUserId: string | null
+  /** True once a HUMAN chose this trigger — the one thing that tells an operator's Off
+   *  apart from a default nobody has decided yet (§14.8). */
+  triggerChosen: boolean
   /** Per-conversation owner for a shared bot (§10.1); null on sibling non-owner rows. */
   agentId: AgentId | null
 }
@@ -4404,11 +4407,14 @@ export interface IntegrationChannelRepo {
   /** Conversations across EVERY integration of a shared bot — the route compiler's
    *  ownership source. */
   listForBot(botId: BotId): Promise<IntegrationChannelRecord[]>
-  /** Per-conversation trigger choice; returns null when the row doesn't exist. */
+  /** Per-conversation trigger choice; returns null when the row doesn't exist.
+   *  `chosen` records that a HUMAN picked this value (§14.8) — omitted leaves the flag
+   *  as it was, so orchestration mirroring a trigger never fabricates a decision. */
   setTrigger(
     integrationId: IntegrationId,
     channelId: string,
-    trigger: ChannelTrigger
+    trigger: ChannelTrigger,
+    opts?: { chosen?: boolean }
   ): Promise<IntegrationChannelRecord | null>
   /** Set or clear this integration row's owner marker. The orchestrator keeps
    *  exactly one row marked per shared conversation. Returns null when missing. */

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4326,6 +4326,9 @@ export interface IntegrationChannelRecord {
   kind: ConversationKind
   /** Repeated across shared-bot sibling rows; per-integration for non-shared bots. */
   trigger: ChannelTrigger
+  /** The 1:1 DM counterpart's platform member id (§14.8); null on rooms and on rows
+   *  discovered before the reporter carried it. */
+  dmUserId: string | null
   /** Per-conversation owner for a shared bot (§10.1); null on sibling non-owner rows. */
   agentId: AgentId | null
 }
@@ -4341,6 +4344,8 @@ export interface ReportedChannel {
   isPrivate?: boolean
   /** Absent = 'channel' (wire compatibility). */
   kind?: ConversationKind
+  /** The 1:1 DM counterpart's platform member id — reported for `kind:'im'` only. */
+  dmUserId?: string
 }
 
 /**
@@ -4374,7 +4379,14 @@ export interface IntegrationChannelRepo {
   replaceSnapshot(
     integrationId: IntegrationId,
     channels: ReportedChannel[],
-    opts?: { defaultTrigger?: ChannelTrigger; authoritative?: boolean; removed?: string[] }
+    opts?: {
+      defaultTrigger?: ChannelTrigger
+      /** Per-conversation seed overriding `defaultTrigger` on a NEW row (§14.8: a gated
+       *  agent's DM with a member of its own audience). Existing rows are unaffected. */
+      defaultTriggerByChannel?: ReadonlyMap<string, ChannelTrigger>
+      authoritative?: boolean
+      removed?: string[]
+    }
   ): Promise<void>
   /** Forget one conversation row. Console-driven cleanup for a conversation the bot
    *  is no longer in on a platform that cannot say so itself; returns whether a row

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -701,6 +701,7 @@ function toChannelRecord(c: IntegrationChannel): IntegrationChannelRecord {
     kind: c.kind as ConversationKind,
     trigger: c.trigger as ChannelTrigger,
     dmUserId: c.dmUserId,
+    triggerChosen: c.triggerChosen,
     agentId: c.agentId ? AgentId(c.agentId) : null
   }
 }
@@ -907,12 +908,15 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
   async setTrigger(
     integrationId: IntegrationId,
     channelId: string,
-    trigger: ChannelTrigger
+    trigger: ChannelTrigger,
+    opts?: { chosen?: boolean }
   ): Promise<IntegrationChannelRecord | null> {
     // updateMany → no throw on a missing row (the bot may have just left the channel).
+    // `triggerChosen` is only ever set, never cleared: a decision does not expire, and
+    // orchestration mirroring an owner's trigger must not unmark one either.
     const res = await this.db.integrationChannel.updateMany({
       where: { integrationId, channelId },
-      data: { trigger }
+      data: { trigger, ...(opts?.chosen ? { triggerChosen: true } : {}) }
     })
     if (res.count === 0) return null
     const row = await this.db.integrationChannel.findUnique({

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -700,6 +700,7 @@ function toChannelRecord(c: IntegrationChannel): IntegrationChannelRecord {
     isPrivate: c.isPrivate,
     kind: c.kind as ConversationKind,
     trigger: c.trigger as ChannelTrigger,
+    dmUserId: c.dmUserId,
     agentId: c.agentId ? AgentId(c.agentId) : null
   }
 }
@@ -725,7 +726,12 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
   async replaceSnapshot(
     integrationId: IntegrationId,
     channels: ReportedChannel[],
-    opts?: { defaultTrigger?: ChannelTrigger; authoritative?: boolean; removed?: string[] }
+    opts?: {
+      defaultTrigger?: ChannelTrigger
+      defaultTriggerByChannel?: ReadonlyMap<string, ChannelTrigger>
+      authoritative?: boolean
+      removed?: string[]
+    }
   ): Promise<void> {
     if (opts?.authoritative !== false) {
       await this.db.integrationChannel.deleteMany({
@@ -748,15 +754,18 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
       // pass `defaultTrigger:'off'`; Everyone installs default a 1:1 DM On and a group
       // DM to Mention. An authoritative channel snapshot cannot delete either kind.
       const direct = c.kind === 'im' || c.kind === 'mpim'
-      const createTrigger: ChannelTrigger = opts?.defaultTrigger ?? (c.kind === 'im' ? 'any' : 'mention')
+      // A per-conversation seed (§14.8) outranks the install-wide default; both seed a
+      // NEW row only, and a late channel→direct conversion re-applies whichever won.
+      const createTrigger: ChannelTrigger =
+        opts?.defaultTriggerByChannel?.get(c.id) ?? opts?.defaultTrigger ?? (c.kind === 'im' ? 'any' : 'mention')
       await this.db.$executeRaw`
         INSERT INTO "integration_channel"
           ("integrationId", "channelId", "name", "spaceId", "space", "isPrivate", "kind", "trigger",
-           "firstSeenAt", "updatedAt")
+           "dmUserId", "firstSeenAt", "updatedAt")
         VALUES (
           ${integrationId}::uuid, ${c.id}, ${c.name ?? null}, ${c.spaceId ?? null}, ${c.space ?? null},
           ${c.isPrivate ?? false}, ${c.kind ?? 'channel'}::"ConversationKind",
-          ${createTrigger}::"ChannelTrigger", NOW(), NOW()
+          ${createTrigger}::"ChannelTrigger", ${c.dmUserId ?? null}, NOW(), NOW()
         )
         ON CONFLICT ("integrationId", "channelId") DO UPDATE SET
           "name" = CASE WHEN ${setName}::boolean THEN EXCLUDED."name" ELSE "integration_channel"."name" END,
@@ -766,6 +775,10 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
                          ELSE "integration_channel"."space" END,
           "isPrivate" = CASE WHEN ${setPrivate}::boolean THEN EXCLUDED."isPrivate"
                              ELSE "integration_channel"."isPrivate" END,
+          -- Learned once and never unlearned: an omitting report (a channel snapshot, an
+          -- older reporter) must not blank the member a DM row is with.
+          "dmUserId" = CASE WHEN ${c.dmUserId !== undefined}::boolean THEN EXCLUDED."dmUserId"
+                            ELSE "integration_channel"."dmUserId" END,
           -- A committed direct kind is never downgraded back to 'channel'. Slack
           -- classifies a group DM late, so a daemon that has lost its cache (a restart,
           -- a snapshot refresh) re-reports the conversation as a provisional 'channel'
@@ -822,6 +835,7 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         space: conversation.space ?? null,
         isPrivate: conversation.isPrivate ?? false,
         kind: conversation.kind ?? 'channel',
+        dmUserId: conversation.dmUserId ?? null,
         // Restricted installs supply Off. Otherwise 1:1 DMs start On and rooms use
         // Mention, matching replaceSnapshot and the controls shown in the Console.
         trigger: opts?.defaultTrigger ?? (conversation.kind === 'im' ? 'any' : 'mention')
@@ -830,7 +844,8 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
       update: {
         ...(conversation.name ? { name: conversation.name } : {}),
         ...(conversation.spaceId ? { spaceId: conversation.spaceId } : {}),
-        ...(conversation.space ? { space: conversation.space } : {})
+        ...(conversation.space ? { space: conversation.space } : {}),
+        ...(conversation.dmUserId ? { dmUserId: conversation.dmUserId } : {})
       }
     })
     return toChannelRecord(row)

--- a/packages/control-plane/src/platforms/discord/provider.test.ts
+++ b/packages/control-plane/src/platforms/discord/provider.test.ts
@@ -87,6 +87,7 @@ const channel = (
   kind,
   trigger,
   dmUserId: null,
+  triggerChosen: false,
   agentId: null
 })
 

--- a/packages/control-plane/src/platforms/discord/provider.test.ts
+++ b/packages/control-plane/src/platforms/discord/provider.test.ts
@@ -86,6 +86,7 @@ const channel = (
   isPrivate: false,
   kind,
   trigger,
+  dmUserId: null,
   agentId: null
 })
 

--- a/packages/control-plane/src/platforms/feishu/provider.test.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.test.ts
@@ -146,6 +146,7 @@ const channel = (
   kind,
   trigger,
   dmUserId: null,
+  triggerChosen: false,
   agentId: null
 })
 

--- a/packages/control-plane/src/platforms/feishu/provider.test.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.test.ts
@@ -145,6 +145,7 @@ const channel = (
   isPrivate: false,
   kind,
   trigger,
+  dmUserId: null,
   agentId: null
 })
 

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -137,6 +137,7 @@ const channel = (
   kind,
   trigger,
   dmUserId: null,
+  triggerChosen: false,
   agentId: null
 })
 

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -136,6 +136,7 @@ const channel = (
   isPrivate: false,
   kind,
   trigger,
+  dmUserId: null,
   agentId: null
 })
 

--- a/packages/control-plane/src/platforms/telegram/provider.test.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.test.ts
@@ -83,6 +83,7 @@ const channel = (
   kind,
   trigger,
   dmUserId: null,
+  triggerChosen: false,
   agentId: null
 })
 

--- a/packages/control-plane/src/platforms/telegram/provider.test.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.test.ts
@@ -82,6 +82,7 @@ const channel = (
   isPrivate: false,
   kind,
   trigger,
+  dmUserId: null,
   agentId: null
 })
 

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -100,6 +100,11 @@ export interface DaemonWsDeps {
   /** §14.8: which of a gated install's reported DMs seed to the ordinary DM default
    *  because their counterpart is in the agent's own audience; absent ⇒ all stay Off. */
   gatedDmSeeds?: GatedDmSeedResolver
+  /** Republish the agent's integrations. Needed because §14.8 is the one path where a
+   *  daemon REPORT creates an ENABLED row: the reporter is still holding bindRules that
+   *  predate it, and it has already cached the conversation, so nothing re-reports and
+   *  the DM stays refused until an unrelated push or reconnect. Absent ⇒ exactly that. */
+  integrationConverge?: (agent: AgentRecord) => Promise<void>
   /** §4.1 activity poke (session-access-cold-visit.md): a committed live `event/session`
    *  milestone marks its external scope active so the warmer keeps its resource facts
    *  leased. Replayed `event/session-sync` frames never poke (§4.2(6)). */

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -43,6 +43,7 @@ import type { SessionEventSink } from '../events/sink.js'
 import type { AgentMutationGate } from '../orchestrator/agentMutationGate.js'
 import type { PlacementResolver } from '../orchestrator/placementResolver.js'
 import type { CollabRoutesService } from '../orchestrator/collabRoutes.service.js'
+import type { GatedDmSeedResolver } from '../orchestrator/linkedDm.js'
 import type { DutyLeaseService } from '../orchestrator/dutyLease.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
 import type { WebchatRemoteMcpService } from '../registry/webchatRemoteMcpService.js'
@@ -96,6 +97,9 @@ export interface DaemonWsDeps {
   /** §4.2(4) `isPrivate` cross-check (session-access-cold-visit.md): a snapshot observing a
    *  channel private drops its cached `public` audience verdict — invalidation only. */
   slackSessionAccess?: Pick<SlackSessionAccessService, 'dropPublicAudiences'>
+  /** §14.8: which of a gated install's reported DMs seed to the ordinary DM default
+   *  because their counterpart is in the agent's own audience; absent ⇒ all stay Off. */
+  gatedDmSeeds?: GatedDmSeedResolver
   /** §4.1 activity poke (session-access-cold-visit.md): a committed live `event/session`
    *  milestone marks its external scope active so the warmer keeps its resource facts
    *  leased. Replayed `event/session-sync` frames never poke (§4.2(6)). */

--- a/packages/control-plane/src/ws/handlers/integration-channels.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.ts
@@ -23,7 +23,7 @@ import { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
 import { isGatedAgent } from '../../orchestrator/placement.js'
 import { servedAgents } from '../../orchestrator/servedAgents.js'
 import type { DaemonWsDeps } from '../deps.js'
-import type { IntegrationRecord } from '../../persistence/ports.js'
+import type { AgentRecord, ChannelTrigger, IntegrationRecord } from '../../persistence/ports.js'
 import type { Handler } from './index.js'
 
 /** Active integrations of the agents this daemon serves — a pool member is the placement of
@@ -53,6 +53,9 @@ export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
   }
   const release = deps.agentMutations.tryBeginMutation(integration.agentId)
   if (!release) return // a placement move owns this agent; its authoritative bundle wins
+  // Read after the lease releases, to decide whether the report opened anything (§14.8).
+  let owner: AgentRecord | null = null
+  let seeded: ReadonlyMap<string, ChannelTrigger> | undefined
   try {
     // Ownership may have changed while the first repository read was in flight.
     // Re-check under the shared mutation lease before accepting this daemon's
@@ -66,21 +69,20 @@ export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
     // integration's fresh conversations start Off — an editor must enable them in
     // the console. Known rows keep their operator-chosen trigger either way.
     // Fenced on the org of the integration row this daemon just proved it owns.
-    const owner = await deps.agent.get(OrgId(integration.orgId), AgentId(integration.agentId))
+    owner = await deps.agent.get(OrgId(integration.orgId), AgentId(integration.agentId))
     const defaultTrigger = owner && isGatedAgent(owner) ? ('off' as const) : undefined
     // §14.8: a gated DM whose counterpart is already in the agent's audience seeds to
     // the ordinary DM default instead. Only the gated arm asks — a public install has
     // no Off to override — and a resolver that answers nothing leaves §14.2 intact.
     const bot = defaultTrigger && deps.bot ? await deps.bot.get(OrgId(integration.orgId), integration.botId) : null
-    const defaultTriggerByChannel =
-      owner && bot && deps.gatedDmSeeds ? await deps.gatedDmSeeds(p.channels, owner, bot) : undefined
+    seeded = owner && bot && deps.gatedDmSeeds ? await deps.gatedDmSeeds(p.channels, owner, bot) : undefined
     await deps.integrationChannel.replaceSnapshot(
       integration.id,
       p.channels,
       defaultTrigger || p.authoritative === false || p.removed?.length
         ? {
             ...(defaultTrigger ? { defaultTrigger } : {}),
-            ...(defaultTriggerByChannel?.size ? { defaultTriggerByChannel } : {}),
+            ...(seeded?.size ? { defaultTriggerByChannel: seeded } : {}),
             ...(p.authoritative === false ? { authoritative: false } : {}),
             ...(p.removed?.length ? { removed: p.removed } : {})
           }
@@ -88,6 +90,19 @@ export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
     )
   } finally {
     release()
+  }
+
+  // §14.8 is the one path where a REPORT can create an ENABLED row, so it is also the
+  // only one that has to push: the reporting daemon still holds bindRules assembled
+  // before this write, and it has already cached the conversation, so no later message
+  // re-reports and repairs it. Outside the mutation lease and best-effort — the
+  // register snapshot remains the durable backstop.
+  if (seeded?.size && owner && deps.integrationConverge) {
+    try {
+      await deps.integrationConverge(owner)
+    } catch {
+      // The daemon converges on its next register snapshot.
+    }
   }
 
   // Conversation availability is part of the effective agent-call edge. Refresh

--- a/packages/control-plane/src/ws/handlers/integration-channels.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.ts
@@ -68,12 +68,19 @@ export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
     // Fenced on the org of the integration row this daemon just proved it owns.
     const owner = await deps.agent.get(OrgId(integration.orgId), AgentId(integration.agentId))
     const defaultTrigger = owner && isGatedAgent(owner) ? ('off' as const) : undefined
+    // §14.8: a gated DM whose counterpart is already in the agent's audience seeds to
+    // the ordinary DM default instead. Only the gated arm asks — a public install has
+    // no Off to override — and a resolver that answers nothing leaves §14.2 intact.
+    const bot = defaultTrigger && deps.bot ? await deps.bot.get(OrgId(integration.orgId), integration.botId) : null
+    const defaultTriggerByChannel =
+      owner && bot && deps.gatedDmSeeds ? await deps.gatedDmSeeds(p.channels, owner, bot) : undefined
     await deps.integrationChannel.replaceSnapshot(
       integration.id,
       p.channels,
       defaultTrigger || p.authoritative === false || p.removed?.length
         ? {
             ...(defaultTrigger ? { defaultTrigger } : {}),
+            ...(defaultTriggerByChannel?.size ? { defaultTriggerByChannel } : {}),
             ...(p.authoritative === false ? { authoritative: false } : {}),
             ...(p.removed?.length ? { removed: p.removed } : {})
           }

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -152,7 +152,9 @@ async function report(
   removed?: string[],
   /** §14.8: OIDC subject → the Slack identity that console account carries. Given, the
    *  report runs the REAL seed resolver over these links instead of none. */
-  links?: Record<string, SlackIdentity>
+  links?: Record<string, SlackIdentity>,
+  /** §14.8: records the re-converge a report that opened a DM has to trigger. */
+  integrationConverge?: (agent: unknown) => Promise<void>
 ): Promise<void> {
   const frame = {
     v: 1,
@@ -185,7 +187,8 @@ async function report(
               identity: { slackIdentityFor: async (sub: string) => links[sub] ?? null }
             })) satisfies GatedDmSeedResolver
         }
-      : {})
+      : {}),
+    ...(integrationConverge ? { integrationConverge } : {})
   } as unknown as DaemonWsDeps
   await handleIntegrationChannels(frame, { daemonId } as DaemonConnection, deps)
 }
@@ -356,6 +359,18 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     return userId
   }
 
+  /** Real repos + a stubbed identity service keyed by OIDC subject. */
+  const reconcileDeps = (links: Record<string, SlackIdentity>) => ({
+    users: new PgUserRepo(prisma),
+    orgs: new PgOrgRepo(prisma),
+    agents: new PgAgentRepo(prisma),
+    integrations: new PgIntegrationRepo(prisma),
+    bots: new PgBotRepo(prisma),
+    channels: new PgIntegrationChannelRepo(prisma),
+    identity: { slackIdentityFor: async (sub: string) => links[sub] ?? null },
+    push: async () => {}
+  })
+
   const triggersOf = async (id: string): Promise<Map<string, string>> =>
     new Map(
       (await new PgIntegrationChannelRepo(prisma).listForIntegration(IntegrationId(id))).map((row) => [
@@ -404,6 +419,49 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(triggers.get('D_DAVE')).toBe('off')
   })
 
+  // The other regression the review caught. On a direct/socket integration this handler
+  // is the ONLY path where a REPORT creates an enabled row: the reporting daemon still
+  // holds bindRules with no scoped rule for that DM, and it has already cached the
+  // conversation, so nothing re-reports and the DM stays refused until an unrelated
+  // reconnect. Opening a row therefore has to push.
+  it('re-converges the reporting daemon when a report opens a gated DM (§14.8)', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    const id = await privateAgentInWorkspace(running, [DEFAULT_OWNER_ID])
+    const links = { [ALICE_SUB]: { teamId: 'T_ACME', userId: 'U_ALICE' } }
+    const converged: unknown[] = []
+    const converge = async (agent: unknown) => void converged.push(agent)
+
+    // A channel-only report changes no gating, so it must NOT push.
+    await report(
+      DAEMON,
+      id,
+      [{ id: 'C1', name: 'deploys' }],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      links,
+      converge
+    )
+    expect(converged).toHaveLength(0)
+
+    // The DM that opens does.
+    await report(
+      DAEMON,
+      id,
+      [{ id: 'D_ALICE', name: '@alice', kind: 'im', dmUserId: 'U_ALICE' }],
+      undefined,
+      undefined,
+      false,
+      undefined,
+      links,
+      converge
+    )
+    expect((await triggersOf(id)).get('D_ALICE')).toBe('any')
+    expect(converged).toHaveLength(1)
+  })
+
   it('keeps the Off default for an audience member who linked a DIFFERENT workspace (§14.8)', async () => {
     await seedDaemon(prisma, DAEMON)
     running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
@@ -430,18 +488,21 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect((await triggersOf(id)).get('D_ALICE')).toBe('off')
 
     const pushed: string[] = []
-    const opened = await reconcileLinkedDms(DEFAULT_OWNER_ID, ALICE_SUB, {
-      users: new PgUserRepo(prisma),
-      orgs: new PgOrgRepo(prisma),
-      agents: new PgAgentRepo(prisma),
-      integrations: new PgIntegrationRepo(prisma),
-      bots: new PgBotRepo(prisma),
-      channels: new PgIntegrationChannelRepo(prisma),
-      identity: { slackIdentityFor: async () => ({ teamId: 'T_ACME', userId: 'U_ALICE' }) },
-      push: async (agent) => {
-        pushed.push(agent.id)
+    const opened = await reconcileLinkedDms(
+      DEFAULT_OWNER_ID,
+      { teamId: 'T_ACME', userId: 'U_ALICE' },
+      {
+        users: new PgUserRepo(prisma),
+        orgs: new PgOrgRepo(prisma),
+        agents: new PgAgentRepo(prisma),
+        integrations: new PgIntegrationRepo(prisma),
+        bots: new PgBotRepo(prisma),
+        channels: new PgIntegrationChannelRepo(prisma),
+        push: async (agent) => {
+          pushed.push(agent.id)
+        }
       }
-    })
+    )
     expect(opened).toBe(1)
     expect(pushed).toHaveLength(1)
     expect((await triggersOf(id)).get('D_ALICE')).toBe('any')
@@ -461,22 +522,59 @@ describe('integration/channels EVT → integration_channel convergence', () => {
       data: { sharedWith: [DEFAULT_OWNER_ID, bob] }
     })
     const opened = await reconcileAgentLinkedDms(
-      { ...agent, sharedWith: agent.sharedWith } as unknown as Parameters<typeof reconcileAgentLinkedDms>[0],
-      {
-        users: new PgUserRepo(prisma),
-        orgs: new PgOrgRepo(prisma),
-        agents: new PgAgentRepo(prisma),
-        integrations: new PgIntegrationRepo(prisma),
-        bots: new PgBotRepo(prisma),
-        channels: new PgIntegrationChannelRepo(prisma),
-        identity: {
-          slackIdentityFor: async (sub) => (sub === BOB_SUB ? { teamId: 'T_ACME', userId: 'U_BOB' } : null)
-        },
-        push: async () => {}
-      }
+      agent as unknown as Parameters<typeof reconcileAgentLinkedDms>[0],
+      [bob],
+      reconcileDeps({ [BOB_SUB]: { teamId: 'T_ACME', userId: 'U_BOB' } })
     )
     expect(opened).toBe(1)
     expect((await triggersOf(id)).get('D_BOB')).toBe('any')
+  })
+
+  // The regression the review caught: the catch-up is a DEFAULT for a pair that just
+  // became eligible, not a standing rule. Re-deriving it from the whole current
+  // audience on every later sharing edit would silently revert an editor's own Off.
+  it('a later sharing edit never reopens a DM the editor closed (§14.8)', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    const bob = await seedMember(BOB_SUB)
+    const carol = await seedMember(CAROL_SUB)
+    const id = await privateAgentInWorkspace(running, [DEFAULT_OWNER_ID, bob])
+    const links = {
+      [BOB_SUB]: { teamId: 'T_ACME', userId: 'U_BOB' },
+      [CAROL_SUB]: { teamId: 'T_ACME', userId: 'U_CAROL' }
+    }
+    await report(
+      DAEMON,
+      id,
+      [
+        { id: 'D_BOB', name: '@bob', kind: 'im', dmUserId: 'U_BOB' },
+        { id: 'D_CAROL', name: '@carol', kind: 'im', dmUserId: 'U_CAROL' }
+      ],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      links
+    )
+    expect((await triggersOf(id)).get('D_BOB')).toBe('any')
+
+    // The editor reconsiders and closes Bob's DM.
+    await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'D_BOB', 'off')
+
+    // Carol is added later. Only Carol's DM opens; Bob's stays where the editor put it.
+    const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
+    const agent = await prisma.agent.update({
+      where: { id: integration.agentId },
+      data: { sharedWith: [DEFAULT_OWNER_ID, bob, carol] }
+    })
+    await reconcileAgentLinkedDms(
+      agent as unknown as Parameters<typeof reconcileAgentLinkedDms>[0],
+      [carol],
+      reconcileDeps(links)
+    )
+    const triggers = await triggersOf(id)
+    expect(triggers.get('D_CAROL')).toBe('any')
+    expect(triggers.get('D_BOB')).toBe('off')
   })
 
   it('never re-closes a DM an operator turned Off after §14.8 opened it', async () => {

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -488,21 +488,18 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect((await triggersOf(id)).get('D_ALICE')).toBe('off')
 
     const pushed: string[] = []
-    const opened = await reconcileLinkedDms(
-      DEFAULT_OWNER_ID,
-      { teamId: 'T_ACME', userId: 'U_ALICE' },
-      {
-        users: new PgUserRepo(prisma),
-        orgs: new PgOrgRepo(prisma),
-        agents: new PgAgentRepo(prisma),
-        integrations: new PgIntegrationRepo(prisma),
-        bots: new PgBotRepo(prisma),
-        channels: new PgIntegrationChannelRepo(prisma),
-        push: async (agent) => {
-          pushed.push(agent.id)
-        }
+    const opened = await reconcileLinkedDms(DEFAULT_OWNER_ID, ALICE_SUB, {
+      users: new PgUserRepo(prisma),
+      orgs: new PgOrgRepo(prisma),
+      agents: new PgAgentRepo(prisma),
+      integrations: new PgIntegrationRepo(prisma),
+      bots: new PgBotRepo(prisma),
+      channels: new PgIntegrationChannelRepo(prisma),
+      identity: { slackIdentityFor: async () => ({ teamId: 'T_ACME', userId: 'U_ALICE' }) },
+      push: async (agent) => {
+        pushed.push(agent.id)
       }
-    )
+    })
     expect(opened).toBe(1)
     expect(pushed).toHaveLength(1)
     expect((await triggersOf(id)).get('D_ALICE')).toBe('any')
@@ -575,6 +572,41 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     const triggers = await triggersOf(id)
     expect(triggers.get('D_CAROL')).toBe('any')
     expect(triggers.get('D_BOB')).toBe('off')
+  })
+
+  // The link path cannot prove a link just landed — the browser writes it at the
+  // provider BEFORE calling refresh — so it runs on every call. `triggerChosen` is what
+  // makes that safe: an editor's Off is a decision, not a pending authorization.
+  it('a repeated identity refresh never reopens a DM the editor closed (§14.8)', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    const id = await privateAgentInWorkspace(running, [DEFAULT_OWNER_ID])
+    const links = { [ALICE_SUB]: { teamId: 'T_ACME', userId: 'U_ALICE' } }
+    await report(
+      DAEMON,
+      id,
+      [{ id: 'D_ALICE', name: '@alice', kind: 'im', dmUserId: 'U_ALICE' }],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      links
+    )
+    expect((await triggersOf(id)).get('D_ALICE')).toBe('any')
+
+    // The editor closes it through the console route, which records the choice.
+    const closed = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${id}/channels/D_ALICE`,
+      payload: { trigger: 'off' }
+    })
+    expect(closed.statusCode).toBe(200)
+
+    // Any number of later refreshes leave it closed.
+    for (let i = 0; i < 3; i += 1) {
+      expect(await reconcileLinkedDms(DEFAULT_OWNER_ID, ALICE_SUB, reconcileDeps(links))).toBe(0)
+    }
+    expect((await triggersOf(id)).get('D_ALICE')).toBe('off')
   })
 
   it('never re-closes a DM an operator turned Off after §14.8 opened it', async () => {

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -17,7 +17,17 @@ import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
 import { seedPoolMember } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
-import { PgAgentRepo, PgDaemonRepo, PgIntegrationRepo, PgIntegrationChannelRepo } from '../../src/persistence/index.js'
+import {
+  PgAgentRepo,
+  PgBotRepo,
+  PgDaemonRepo,
+  PgIntegrationRepo,
+  PgIntegrationChannelRepo
+} from '../../src/persistence/index.js'
+import { PgOrgRepo } from '../../src/persistence/repositories/org.repo.js'
+import { gatedDmSeeds, type GatedDmSeedResolver } from '../../src/orchestrator/linkedDm.js'
+import { reconcileAgentLinkedDms, reconcileLinkedDms } from '../../src/orchestrator/linkedDmReconcile.js'
+import type { SlackIdentity } from '../../src/github/logto-identity.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
 import { systemClock } from '../../src/domain/clock.js'
@@ -42,6 +52,11 @@ afterEach(async () => {
   await running?.close()
   running = undefined
 })
+
+// §14.8 OIDC subjects — the key a linked Slack identity is resolved by.
+const ALICE_SUB = 'oidc-alice'
+const BOB_SUB = 'oidc-bob'
+const CAROL_SUB = 'oidc-carol'
 
 const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const OTHER_DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
@@ -134,7 +149,10 @@ async function report(
   agentMutations = new AgentMutationGate(),
   collabRoutes = { broadcast: async () => undefined } as unknown as CollabRoutesService,
   authoritative?: boolean,
-  removed?: string[]
+  removed?: string[],
+  /** §14.8: OIDC subject → the Slack identity that console account carries. Given, the
+   *  report runs the REAL seed resolver over these links instead of none. */
+  links?: Record<string, SlackIdentity>
 ): Promise<void> {
   const frame = {
     v: 1,
@@ -148,15 +166,26 @@ async function report(
       ...(removed === undefined ? {} : { removed })
     }
   } as AnyFrame
+  const users = new PgUserRepo(prisma)
   const deps = {
     integration: new PgIntegrationRepo(prisma),
     integrationChannel: new PgIntegrationChannelRepo(prisma),
     agent: new PgAgentRepo(prisma),
+    bot: new PgBotRepo(prisma),
     // Admission is the served set now — placement ∪ the duties this member holds.
     dutyLease: new PgDutyGroupRepo(prisma),
     clock: systemClock,
     agentMutations,
-    collabRoutes
+    collabRoutes,
+    ...(links
+      ? {
+          gatedDmSeeds: ((reported, agent, bot) =>
+            gatedDmSeeds(reported, agent, bot, {
+              users,
+              identity: { slackIdentityFor: async (sub: string) => links[sub] ?? null }
+            })) satisfies GatedDmSeedResolver
+        }
+      : {})
   } as unknown as DaemonWsDeps
   await handleIntegrationChannels(frame, { daemonId } as DaemonConnection, deps)
 }
@@ -302,6 +331,168 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     ;[dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
     expect(dto!.channels.find((c) => c.channelId === 'D1')).toMatchObject({ kind: 'im' })
+  })
+
+  /** §14.8 fixture: a private agent shared with `audience`, on a bot in workspace T_ACME.
+   *  The seeded owner gets an OIDC subject so their own link can be resolved. */
+  async function privateAgentInWorkspace(app: HttpApp, audience: string[]): Promise<string> {
+    const id = await install(app)
+    const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
+    await prisma.agent.update({
+      where: { id: integration.agentId },
+      data: { visibility: 'restricted', sharedWith: audience }
+    })
+    await prisma.bot.update({ where: { id: integration.botId }, data: { teamId: 'T_ACME' } })
+    await prisma.user.update({ where: { id: DEFAULT_OWNER_ID }, data: { oidcSubject: ALICE_SUB } })
+    return id
+  }
+
+  /** A second console account in the default org, for the multi-member audience. */
+  async function seedMember(sub: string): Promise<string> {
+    const users = new PgUserRepo(prisma)
+    const email = `${sub}@example.test`
+    const { userId } = await users.provisionOidcUser({ oidcSubject: sub, email, emailVerified: true })
+    await users.addMemberByEmail(DEFAULT_ORG_ID, email, 'collaborator')
+    return userId
+  }
+
+  const triggersOf = async (id: string): Promise<Map<string, string>> =>
+    new Map(
+      (await new PgIntegrationChannelRepo(prisma).listForIntegration(IntegrationId(id))).map((row) => [
+        row.channelId,
+        row.trigger
+      ])
+    )
+
+  it("opens a private agent's DM with every audience member who linked their Slack identity (§14.8)", async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    const bob = await seedMember(BOB_SUB)
+    const carol = await seedMember(CAROL_SUB)
+    const id = await privateAgentInWorkspace(running, [DEFAULT_OWNER_ID, bob, carol])
+
+    // Alice (the owner), Bob and Carol are the audience and all three linked; Dave is a
+    // workspace member who is not, and Erin is in the audience but never linked.
+    await report(
+      DAEMON,
+      id,
+      [
+        { id: 'C1', name: 'deploys' },
+        { id: 'D_ALICE', name: '@alice', kind: 'im', dmUserId: 'U_ALICE' },
+        { id: 'D_BOB', name: '@bob', kind: 'im', dmUserId: 'U_BOB' },
+        { id: 'D_CAROL', name: '@carol', kind: 'im', dmUserId: 'U_CAROL' },
+        { id: 'D_DAVE', name: '@dave', kind: 'im', dmUserId: 'U_DAVE' }
+      ],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        [ALICE_SUB]: { teamId: 'T_ACME', userId: 'U_ALICE' },
+        [BOB_SUB]: { teamId: 'T_ACME', userId: 'U_BOB' },
+        [CAROL_SUB]: { teamId: 'T_ACME', userId: 'U_CAROL' }
+      }
+    )
+
+    const triggers = await triggersOf(id)
+    expect(triggers.get('D_ALICE')).toBe('any')
+    expect(triggers.get('D_BOB')).toBe('any')
+    expect(triggers.get('D_CAROL')).toBe('any')
+    // The two arms that must NOT open: a channel (its membership is a room, not a
+    // person) and a DM from someone outside the audience.
+    expect(triggers.get('C1')).toBe('off')
+    expect(triggers.get('D_DAVE')).toBe('off')
+  })
+
+  it('keeps the Off default for an audience member who linked a DIFFERENT workspace (§14.8)', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    const id = await privateAgentInWorkspace(running, [DEFAULT_OWNER_ID])
+    await report(
+      DAEMON,
+      id,
+      [{ id: 'D_ALICE', name: '@alice', kind: 'im', dmUserId: 'U_ALICE' }],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { [ALICE_SUB]: { teamId: 'T_OTHER', userId: 'U_ALICE' } }
+    )
+    expect((await triggersOf(id)).get('D_ALICE')).toBe('off')
+  })
+
+  it('opens an already-Off DM when its counterpart links afterwards, and pushes (§14.8)', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    const id = await privateAgentInWorkspace(running, [DEFAULT_OWNER_ID])
+    // The real order of events: the DM is discovered and refused BEFORE the link.
+    await report(DAEMON, id, [{ id: 'D_ALICE', name: '@alice', kind: 'im', dmUserId: 'U_ALICE' }])
+    expect((await triggersOf(id)).get('D_ALICE')).toBe('off')
+
+    const pushed: string[] = []
+    const opened = await reconcileLinkedDms(DEFAULT_OWNER_ID, ALICE_SUB, {
+      users: new PgUserRepo(prisma),
+      orgs: new PgOrgRepo(prisma),
+      agents: new PgAgentRepo(prisma),
+      integrations: new PgIntegrationRepo(prisma),
+      bots: new PgBotRepo(prisma),
+      channels: new PgIntegrationChannelRepo(prisma),
+      identity: { slackIdentityFor: async () => ({ teamId: 'T_ACME', userId: 'U_ALICE' }) },
+      push: async (agent) => {
+        pushed.push(agent.id)
+      }
+    })
+    expect(opened).toBe(1)
+    expect(pushed).toHaveLength(1)
+    expect((await triggersOf(id)).get('D_ALICE')).toBe('any')
+  })
+
+  it('opens an already-Off DM when its counterpart JOINS the audience afterwards (§14.8)', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    const bob = await seedMember(BOB_SUB)
+    const id = await privateAgentInWorkspace(running, [DEFAULT_OWNER_ID])
+    await report(DAEMON, id, [{ id: 'D_BOB', name: '@bob', kind: 'im', dmUserId: 'U_BOB' }])
+    expect((await triggersOf(id)).get('D_BOB')).toBe('off')
+
+    const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
+    const agent = await prisma.agent.update({
+      where: { id: integration.agentId },
+      data: { sharedWith: [DEFAULT_OWNER_ID, bob] }
+    })
+    const opened = await reconcileAgentLinkedDms(
+      { ...agent, sharedWith: agent.sharedWith } as unknown as Parameters<typeof reconcileAgentLinkedDms>[0],
+      {
+        users: new PgUserRepo(prisma),
+        orgs: new PgOrgRepo(prisma),
+        agents: new PgAgentRepo(prisma),
+        integrations: new PgIntegrationRepo(prisma),
+        bots: new PgBotRepo(prisma),
+        channels: new PgIntegrationChannelRepo(prisma),
+        identity: {
+          slackIdentityFor: async (sub) => (sub === BOB_SUB ? { teamId: 'T_ACME', userId: 'U_BOB' } : null)
+        },
+        push: async () => {}
+      }
+    )
+    expect(opened).toBe(1)
+    expect((await triggersOf(id)).get('D_BOB')).toBe('any')
+  })
+
+  it('never re-closes a DM an operator turned Off after §14.8 opened it', async () => {
+    await seedDaemon(prisma, DAEMON)
+    running = buildHttpApp(prisma, undefined, undefined, new SpyControl() as unknown as ControlSender)
+    const id = await privateAgentInWorkspace(running, [DEFAULT_OWNER_ID])
+    const links = { [ALICE_SUB]: { teamId: 'T_ACME', userId: 'U_ALICE' } }
+    const dm = { id: 'D_ALICE', name: '@alice', kind: 'im' as const, dmUserId: 'U_ALICE' }
+    await report(DAEMON, id, [dm], undefined, undefined, undefined, undefined, links)
+    expect((await triggersOf(id)).get('D_ALICE')).toBe('any')
+
+    // The seed is a DEFAULT, not a standing rule: once a row exists, its trigger is
+    // the operator's, and a re-report must not reassert the open state.
+    await new PgIntegrationChannelRepo(prisma).setTrigger(IntegrationId(id), 'D_ALICE', 'off')
+    await report(DAEMON, id, [dm], undefined, undefined, undefined, undefined, links)
+    expect((await triggersOf(id)).get('D_ALICE')).toBe('off')
   })
 
   it('stores a public DM as On, then atomically closes it when the agent becomes restricted (§14.3)', async () => {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12744,19 +12744,22 @@ export class Daemon {
     // otherwise the two classifications would fight and re-emit on every message.
     const observed = isDm ? ('im' as const) : msg.isGroupDm ? ('mpim' as const) : ('channel' as const)
     const kind = observed === 'channel' && current?.kind === 'mpim' ? ('mpim' as const) : observed
+    // Who the row is with (§14.8), reported for a 1:1 DM only — the CP seeds a gated
+    // agent's DM to its ordinary default when this member is one of the agent's own.
+    const dmUserId = kind === 'im' ? { dmUserId: msg.sender.id } : undefined
     const known = (await this.store.getDisplayNames([channel])).get(channel)
     // Which Discord server the channel belongs to — see spaceFor. Direct rows have none.
     const found = kind === 'channel' ? await this.observedChannelsSync.spaceFor(msg.platform, channel) : undefined
     const space = found ? { spaceId: found.id, ...(found.name ? { space: found.name } : {}) } : undefined
     // Compare against what a write would actually change — a partially resolved space
     // (id known, name not yet) must not re-emit the snapshot on every message.
-    const merged = current ? { ...current, ...(known ? { name: known } : {}), ...space, kind } : undefined
+    const merged = current ? { ...current, ...(known ? { name: known } : {}), ...space, ...dmUserId, kind } : undefined
     if (merged && JSON.stringify(merged) === JSON.stringify(current)) return
     // A previously-observed DM (Telegram/Discord session snapshots are kind-less)
     // is upgraded to 'im' rather than skipped after an org→restricted flip.
     const next = merged
       ? existing.map((c) => (c.id === channel ? merged : c))
-      : [...existing, { id: channel, ...(known ? { name: known } : {}), ...space, kind }]
+      : [...existing, { id: channel, ...(known ? { name: known } : {}), ...space, ...dmUserId, kind }]
     this.channelSnapshots.set(integrationId, {
       channels: next,
       authoritative: cached?.authoritative ?? false

--- a/packages/daemon/test/telegram-threading.test.ts
+++ b/packages/daemon/test/telegram-threading.test.ts
@@ -122,9 +122,11 @@ describe('Telegram conversation discovery', () => {
 
     await (daemon as any).onInboundOutcome(tg(91, { channel: '424242', isDm: true }), ['i-tg'])
 
+    // `dmUserId` rides a 1:1 DM row (§14.8) — who the conversation is with, which is
+    // what lets the CP match it against a private agent's own audience.
     expect(emitIntegrationChannels).toHaveBeenCalledWith({
       integrationId: 'i-tg',
-      channels: [{ id: '424242', kind: 'im' }],
+      channels: [{ id: '424242', dmUserId: 'U1', kind: 'im' }],
       authoritative: false
     })
     await daemon.stop()

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -208,7 +208,11 @@ export const IntegrationChannel = z.object({
   spaceId: z.string().optional(), // enclosing Discord guild snowflake — the space's IDENTITY
   space: z.string().optional(), // that guild's display name; absent until resolved
   isPrivate: z.boolean().optional(),
-  kind: z.enum(['channel', 'im', 'mpim']).optional() // absent = 'channel'
+  kind: z.enum(['channel', 'im', 'mpim']).optional(), // absent = 'channel'
+  // The 1:1 DM counterpart's platform member id (§14.8) — control metadata of the same
+  // class as `name`, and the only thing that identifies WHO a private agent's DM row is
+  // with. Absent on channels and group DMs, whose membership is a room, not a person.
+  dmUserId: z.string().optional()
 })
 export type IntegrationChannel = z.infer<typeof IntegrationChannel>
 

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -1420,9 +1420,11 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     internals.slackPool.set(BOT_ID, ingest)
 
     await internals.forward(BOT_ID, dm())
+    // `dmUserId` rides the report (§14.8): a 1:1 DM's whole human membership, and the
+    // only thing that lets the CP match it against a private agent's own audience.
     expect(reportBotConversation).toHaveBeenCalledWith({
       botId: BOT_ID,
-      conversation: { id: 'D42', name: '@Alice', kind: 'im' }
+      conversation: { id: 'D42', name: '@Alice', dmUserId: 'U1', kind: 'im' }
     })
     expect(ingest.postText).toHaveBeenCalledTimes(1)
     expect(ingest.postText.mock.calls[0]![0]).toBe('D42')
@@ -1538,7 +1540,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     // pending Off row, but nothing was unrouted so there is NO notice.
     expect(reportBotConversation).toHaveBeenCalledWith({
       botId: BOT_ID,
-      conversation: { id: 'D42', name: '@Alice', kind: 'im' }
+      conversation: { id: 'D42', name: '@Alice', dmUserId: 'U1', kind: 'im' }
     })
     expect(ingest.postText).not.toHaveBeenCalled()
   })
@@ -1832,7 +1834,7 @@ describe('RelayIngressManager conversation gating (resource-visibility §14.3)',
     await internals.forward(BOT_ID, dm())
     expect(reportBotConversation).toHaveBeenCalledWith({
       botId: BOT_ID,
-      conversation: { id: 'D42', name: '@Alice', kind: 'im' }
+      conversation: { id: 'D42', name: '@Alice', dmUserId: 'U1', kind: 'im' }
     })
     expect(ingest.postText).not.toHaveBeenCalled()
   })

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -1041,7 +1041,14 @@ export class RelayIngressManager {
     const name = msg.isDm ? await this.ingestFor(botId)?.egress?.lookupUserName(msg.sender.id) : undefined
     const sent = this.deps.reportBotConversation({
       botId,
-      conversation: { id: msg.channel, ...(name ? { name } : {}), kind: msg.isDm ? 'im' : 'mpim' }
+      conversation: {
+        id: msg.channel,
+        ...(name ? { name } : {}),
+        // Who the row is with (§14.8) — a 1:1 DM's whole human membership, and what lets
+        // the CP seed a gated install's row On for a member the agent is already shared with.
+        ...(msg.isDm ? { dmUserId: msg.sender.id } : {}),
+        kind: msg.isDm ? 'im' : 'mpim'
+      }
     })
     // Latch only a delivered report — a CP-link-down drop retries on the next DM.
     if (sent) this.observedConversationsReported.add(latch)


### PR DESCRIPTION
Closes #558.

## The problem

Conversation gating (`docs/designs/resource-visibility.md` §14.2) defaults **every**
conversation of a restricted agent to Off, DMs included, because the platform has no
per-user ACL and only an editor can vouch for a channel's membership.

That is right for a room and wrong for the person the agent was shared with. Today,
share a private agent with a, b and c, and each of them who DMs it gets a "this agent
isn't enabled in this conversation" notice — until an editor, often one of the same
three, goes to the Console and enables that DM row by hand. The gate protects nobody
there; it just makes a private agent feel broken to its own audience.

## The rule

A 1:1 DM row of a gated agent now seeds to the ordinary DM default (On) instead of Off
when its counterpart is **both**:

1. in the agent's own `sharedWith` audience, and
2. carrying a linked Slack identity in that bot's workspace.

Both arms are load-bearing — an unlinked audience member and a linked non-member each
keep today's Off. Share an agent with a, b and c and all three have linked: all three
DMs are open, each on its own row.

The link is Logto's (a Slack sign-in, or an Account API link driven by the user's own
authenticated session), never an email guess. That is what keeps this an identity
**assertion** rather than the general ingress identity-mapping §14.6 parks.

**Only a 1:1 DM is seeded.** It is the one conversation whose entire human membership
is known at discovery: one bot, one person. A channel is a place and a group DM is a
room, so both still go to an editor. **Only Slack**, because it is the one platform
whose linked identity names the same id space a DM report carries — a Feishu link
asserts a cross-app `union_id` while its messages carry an app-scoped `open_id`, and
guessing there would silently widen a private agent.

## Mechanism

The reporter adds the counterpart's platform member id to the conversation report
(`IntegrationChannel.dmUserId`, persisted on the row as control metadata of the same
class as its `name`). Both report paths carry it: the daemon's `integration/channels`
and the relay's `rc/bot-conversation`.

The CP resolves the **audience's own** linked identities — each a cached per-subject
read through the existing `slackIdentityFor` — and matches the reported counterpart
against them. There is deliberately no reverse index from a platform member id to a
console account; the scan runs from the small side.

Everything fails **closed** to §14.2: no sign-in configured, no workspace on the bot,
an oversized audience, or an upstream that cannot answer all leave the row Off.

## Order independence

Deciding only at discovery would fire only for people whose link and audience seat both
predate their first DM — the opposite of what happens, since people link *because* they
were refused. So the two writes that can make the answer true later re-ask it for the
Off DM rows already on record:

- a landed identity link (`POST /me/social-identities`, and the console's `…/refresh`)
- a widened audience (`PUT /agents/:id/sharing`)

The catch-up is **one-way**: it opens rows and never closes them. A stored trigger is
indistinguishable from an operator's own choice — §14.2 lets an editor enable a DM for
anyone — so re-deriving a close would revert decisions this never made.

## Two limits, both recorded in §14.8

- **The first message of a brand-new DM still gets the one-time notice.** The edge
  decides admission before the CP has the row; the conversation is open from the next
  message on. Closing that gap means shipping the authorized member ids to the edge in
  the integration spec, with its own recompute-and-push triggers.
- **An opened DM stays open.** A gated bind rule is conversation-scoped
  (`{channel, match:'dm'}`) with no user dimension, so losing the audience seat or
  unlinking does not close the conversation the seat opened — an editor's Off does.
  That is the same durability §14.2 already gives an editor-enabled conversation, but
  the grant now originates from a membership that can later change. Making it revocable
  needs a marker telling §14.8-opened rows from editor-chosen ones, which this
  deliberately does not add yet.

## Migration

One additive nullable column (`integration_channel.dmUserId`). No backfill: existing
rows keep whatever trigger an operator already chose and are re-stamped by the
reporter's next conversation report.

## Tests

- `orchestrator/linkedDm.test.ts` (new, 11) — the policy: both arms, the workspace
  fence, channels and group DMs never seeded, a failed lookup costing only that member,
  the oversized-audience refusal, and no identity lookup at all when a report carries
  no DM.
- `orchestrator/httpBot.test.ts` (+2) — the shared-bot path, including that the seed
  survives the ownership convergence that immediately follows the report, and compiles
  a scoped `auto` route.
- `test/integration/integration-channels.test.ts` (+5, real Postgres) — a three-member
  audience opening three DMs while a channel and an outsider's DM stay Off; the
  wrong-workspace case; both catch-ups; and that a re-report never reasserts a DM an
  operator turned Off.

Control-plane (1978 unit + 1679 integration) and relay (535) suites pass. The daemon
suite's only failures are pre-existing and environmental on this machine (live provider
quotas in the ACP matrix, and `sandbox-exec` being unavailable to the shim tests) —
verified to reproduce unchanged on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
