### PR TITLE
fix(control-plane): exhaust the GitLab listings a recovery predicate reads

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1792,12 +1792,7 @@ external credentials by deleting only local metadata.
 > `running` edge waits on its GitLab arm
 > (`packages/control-plane/src/codehost/note-projection.service.ts`); that arm
 > is being finished as follow-up work. The session merge-request dock panel
-> stays out of scope per Section 18.1. One defect is open rather than
-> deliberate: the service-account listing behind Section 7.2 reads a single
-> hundred-account page instead of following the pagination, so the recorded
-> window and its `username_taken` refusal hold only while a top-level group's
-> service accounts fit that first page — always true on Free, not guaranteed
-> on Premium.
+> stays out of scope per Section 18.1.
 
 Milestones are merge order, not calendar. Each milestone is several small,
 independently mergeable PRs; GitHub behavior stays green at every merge; each

--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -279,6 +279,9 @@ export class GitlabAccountService {
       }
       // This top-level group's OWN accounts — never a global user search (§7.2).
       let listing = await gitlabListServiceAccounts(input.token, input.rootGroupId, this.deps.fetchImpl)
+      // The listing is exhaustive, so a large root spends real time in it: prove
+      // the fence still holds before any write this listing decides.
+      await this.renew(account.id, owner)
       // The durable key first: an account we already recorded needs no marker.
       let external =
         (account.serviceAccountUserId === null
@@ -314,6 +317,7 @@ export class GitlabAccountService {
         } catch (e) {
           // Ambiguous create: re-read, then apply that same persisted window.
           listing = await gitlabListServiceAccounts(input.token, input.rootGroupId, this.deps.fetchImpl)
+          await this.renew(account.id, owner)
           external = this.claimFromAttempt(account, listing)
           if (!external) {
             const reason = listing.some((candidate) => candidate.username === account.username)

--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -655,6 +655,8 @@ export class GitlabAccountService {
           throw new GitlabApiError('marked service account still present after retirement', 0, 'INTERNAL', true)
         }
       }
+      // No lease renewal guards this one: the delete is CAS-fenced on `retiring`,
+      // so a peer that reclaimed an expired lease and reactivated the row wins it.
       await this.deps.accounts.finishRetirement(accountId)
       return true
     } catch (e) {
@@ -822,6 +824,9 @@ export class GitlabAccountService {
     const strays = (
       await gitlabListServiceAccountTokens(token, rootGroupId, serviceAccountUserId, this.deps.fetchImpl)
     ).filter((t) => t.name === name && t.active !== false && t.revoked !== true)
+    // That listing is exhaustive too: re-prove the fence before the revokes it
+    // decides, not only before the create further down.
+    await this.renew(account.id, owner)
     for (const stray of strays) {
       if (recorded && BigInt(stray.id) === recorded.externalTokenId) continue
       await gitlabRevokeServiceAccountToken(

--- a/packages/control-plane/src/gitlab/api-pagination.test.ts
+++ b/packages/control-plane/src/gitlab/api-pagination.test.ts
@@ -5,7 +5,7 @@
  * sweep, the exact-URL webhook adoption — so each must follow `x-next-page` and
  * must refuse rather than hand back a partial page.
  */
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { FetchLike } from './api.js'
 import { GitlabApiError, gitlabListServiceAccountTokens, gitlabListServiceAccounts, gitlabListWebhooks } from './api.js'
 
@@ -26,6 +26,10 @@ function pagedFetch(pages: unknown[][]): { fetch: FetchLike; urls: string[] } {
 }
 
 const account = (id: number) => ({ id, username: `bot-${id}`, name: `bot ${id}` })
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 describe('gitlabListServiceAccounts', () => {
   it('follows x-next-page and returns every page, in order', async () => {
@@ -91,6 +95,24 @@ describe('gitlabListServiceAccounts', () => {
     }
     await expect(gitlabListServiceAccounts(TOKEN, 77, fetch)).rejects.toBeInstanceOf(GitlabApiError)
     expect(calls).toBe(1)
+  })
+
+  it('raises retryably once the walk outruns its time budget, so it cannot outlive a caller lease', async () => {
+    // Only Date is faked: AbortSignal.timeout keeps its real timer.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    let calls = 0
+    const fetch: FetchLike = async (url) => {
+      calls++
+      // Each page answers slowly enough that a few of them spend the budget.
+      vi.setSystemTime(Date.now() + 25_000)
+      const page = Number(new URL(url).searchParams.get('page') ?? '1')
+      return Response.json([account(page)], { headers: { 'x-next-page': String(page + 1) } })
+    }
+    const error = await gitlabListServiceAccounts(TOKEN, 77, fetch).catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(GitlabApiError)
+    expect((error as GitlabApiError).retryable).toBe(true)
+    // Three pages spend 75s of a 60s budget; the fourth is never attempted.
+    expect(calls).toBe(3)
   })
 
   it('raises retryably past the page bound rather than truncating the listing', async () => {

--- a/packages/control-plane/src/gitlab/api-pagination.test.ts
+++ b/packages/control-plane/src/gitlab/api-pagination.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Paginated GitLab listings (gitlab-com-integration.md §7.2). These three reads
+ * back predicates that are sound only over a COMPLETE listing — the create
+ * window's snapshot, the `username_taken` foreign-account check, the stray-PAT
+ * sweep, the exact-URL webhook adoption — so each must follow `x-next-page` and
+ * must refuse rather than hand back a partial page.
+ */
+import { describe, expect, it } from 'vitest'
+import type { FetchLike } from './api.js'
+import { GitlabApiError, gitlabListServiceAccountTokens, gitlabListServiceAccounts, gitlabListWebhooks } from './api.js'
+
+const TOKEN = 'at-1'
+
+/** A GitLab-shaped paged edge: `pages` are served in order, and `x-next-page`
+ *  carries the next index, empty on the last — exactly what gitlab.com sends. */
+function pagedFetch(pages: unknown[][]): { fetch: FetchLike; urls: string[] } {
+  const urls: string[] = []
+  const fetch: FetchLike = async (url) => {
+    urls.push(url)
+    const page = Number(new URL(url).searchParams.get('page') ?? '1')
+    const body = pages[page - 1] ?? []
+    const next = page < pages.length ? String(page + 1) : ''
+    return Response.json(body, { headers: { 'x-next-page': next } })
+  }
+  return { fetch, urls }
+}
+
+const account = (id: number) => ({ id, username: `bot-${id}`, name: `bot ${id}` })
+
+describe('gitlabListServiceAccounts', () => {
+  it('follows x-next-page and returns every page, in order', async () => {
+    const first = Array.from({ length: 100 }, (_, i) => account(1000 + i))
+    const second = [account(2000), account(2001)]
+    const { fetch, urls } = pagedFetch([first, second])
+
+    const accounts = await gitlabListServiceAccounts(TOKEN, 77, fetch)
+
+    expect(accounts).toHaveLength(102)
+    expect(accounts.map((a) => a.id)).toEqual([...first, ...second].map((a) => a.id))
+    expect(urls).toEqual([
+      'https://gitlab.com/api/v4/groups/77/service_accounts?per_page=100&page=1',
+      'https://gitlab.com/api/v4/groups/77/service_accounts?per_page=100&page=2'
+    ])
+  })
+
+  it('is one request when the header says there is no next page', async () => {
+    const { fetch, urls } = pagedFetch([[account(1)]])
+    await expect(gitlabListServiceAccounts(TOKEN, 77, fetch)).resolves.toHaveLength(1)
+    expect(urls).toHaveLength(1)
+  })
+
+  it('stops at a provider that sends no pagination header at all', async () => {
+    let calls = 0
+    const fetch: FetchLike = async () => {
+      calls++
+      return Response.json([account(1)])
+    }
+    await expect(gitlabListServiceAccounts(TOKEN, 77, fetch)).resolves.toHaveLength(1)
+    expect(calls).toBe(1)
+  })
+
+  it('presents the bearer on every page', async () => {
+    const seen: (string | undefined)[] = []
+    const fetch: FetchLike = async (url, init) => {
+      seen.push((init?.headers as Record<string, string> | undefined)?.authorization)
+      const page = Number(new URL(url).searchParams.get('page') ?? '1')
+      return Response.json([account(page)], { headers: { 'x-next-page': page < 3 ? String(page + 1) : '' } })
+    }
+    await gitlabListServiceAccounts(TOKEN, 77, fetch)
+    expect(seen).toEqual([`Bearer ${TOKEN}`, `Bearer ${TOKEN}`, `Bearer ${TOKEN}`])
+  })
+
+  it('refuses a mid-listing failure rather than returning the pages it already read', async () => {
+    const fetch: FetchLike = async (url) => {
+      const page = Number(new URL(url).searchParams.get('page') ?? '1')
+      if (page === 2) return Response.json({ message: 'upstream' }, { status: 502 })
+      return Response.json([account(1)], { headers: { 'x-next-page': '2' } })
+    }
+    await expect(gitlabListServiceAccounts(TOKEN, 77, fetch)).rejects.toMatchObject({
+      name: 'GitlabApiError',
+      status: 502,
+      retryable: true
+    })
+  })
+
+  it('refuses a header that does not advance instead of spinning or truncating', async () => {
+    let calls = 0
+    const fetch: FetchLike = async () => {
+      calls++
+      return Response.json([account(1)], { headers: { 'x-next-page': '1' } })
+    }
+    await expect(gitlabListServiceAccounts(TOKEN, 77, fetch)).rejects.toBeInstanceOf(GitlabApiError)
+    expect(calls).toBe(1)
+  })
+
+  it('raises retryably past the page bound rather than truncating the listing', async () => {
+    let calls = 0
+    const fetch: FetchLike = async (url) => {
+      calls++
+      const page = Number(new URL(url).searchParams.get('page') ?? '1')
+      return Response.json([account(page)], { headers: { 'x-next-page': String(page + 1) } })
+    }
+    const error = await gitlabListServiceAccounts(TOKEN, 77, fetch).catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(GitlabApiError)
+    expect((error as GitlabApiError).retryable).toBe(true)
+    expect(calls).toBe(50)
+  })
+})
+
+describe('gitlabListServiceAccountTokens', () => {
+  it('follows x-next-page so a stray on a later page is still swept', async () => {
+    const grant = (id: number) => ({ id, name: 'ac-api', scopes: ['api'], active: true, expires_at: null })
+    const { fetch, urls } = pagedFetch([[grant(1)], [grant(2)]])
+
+    const grants = await gitlabListServiceAccountTokens(TOKEN, 77, 5001n, fetch)
+
+    expect(grants.map((g) => g.id)).toEqual([1, 2])
+    expect(urls[0]).toBe(
+      'https://gitlab.com/api/v4/groups/77/service_accounts/5001/personal_access_tokens?per_page=100&page=1'
+    )
+    expect(urls[1]).toContain('page=2')
+  })
+})
+
+describe('gitlabListWebhooks', () => {
+  it('follows x-next-page so an existing hook on a later page is still adopted', async () => {
+    const managed = { id: 9, url: 'https://relay.example.test/webhooks/gitlab' }
+    const { fetch, urls } = pagedFetch([[{ id: 8, url: 'https://other.example.test/hook' }], [managed]])
+
+    const hooks = await gitlabListWebhooks(TOKEN, 4455667n, fetch)
+
+    expect(hooks.map((h) => h.id)).toEqual([8, 9])
+    expect(urls[0]).toBe('https://gitlab.com/api/v4/projects/4455667/hooks?per_page=100&page=1')
+    expect(urls[1]).toContain('page=2')
+  })
+})

--- a/packages/control-plane/src/gitlab/api.ts
+++ b/packages/control-plane/src/gitlab/api.ts
@@ -86,23 +86,29 @@ async function gitlabError(res: Response): Promise<GitlabApiError> {
 
 /** GitLab's own per-page ceiling for these listings. */
 const PAGE_SIZE = 100
-/** Runaway backstop on `gitlabPagedGet`; exceeding it refuses, never truncates. */
+/** Runaway backstops on `gitlabPagedGet`; exceeding either refuses, never truncates.
+ *  The wall-clock one is what keeps a paged read inside a caller's mutual-exclusion
+ *  lease: an unbounded walk could otherwise outlive the lease it reads under. */
 const MAX_PAGES = 50
+const LISTING_BUDGET_MS = 60_000
 
 /** EVERY row of a paginated GET, following GitLab's `x-next-page` header.
  *  A caller's predicate is sound only over a complete listing (§7.2), so this
  *  never returns a partial one: a bound or a stuck header raises instead. */
 async function gitlabPagedGet<T>(path: string, opts: { auth: string; fetchImpl?: FetchLike }): Promise<T[]> {
   const fetchImpl = opts.fetchImpl ?? (fetch as FetchLike)
+  const deadline = Date.now() + LISTING_BUDGET_MS
   const rows: T[] = []
   let page = 1
   for (let requests = 0; requests < MAX_PAGES; requests++) {
+    const budget = deadline - Date.now()
+    if (budget <= 0) throw new GitlabApiError('gitlab listing exceeded its time budget', 0, 'INTERNAL', true)
     const url = `${API_BASE}${path}${path.includes('?') ? '&' : '?'}per_page=${PAGE_SIZE}&page=${page}`
     let res: Response
     try {
       res = await fetchImpl(url, {
         headers: { accept: 'application/json', authorization: `Bearer ${opts.auth}` },
-        signal: AbortSignal.timeout(TIMEOUT_MS)
+        signal: AbortSignal.timeout(Math.min(TIMEOUT_MS, budget))
       })
     } catch (e) {
       throw new GitlabApiError(`gitlab unreachable: ${(e as Error).message}`, 0, 'INTERNAL', true)

--- a/packages/control-plane/src/gitlab/api.ts
+++ b/packages/control-plane/src/gitlab/api.ts
@@ -66,7 +66,12 @@ export async function gitlabRequest<T>(path: string, opts: GitlabRequestOpts): P
     if (!text) return undefined as T
     return JSON.parse(text) as T
   }
-  // Read the message for diagnostics only; NEVER include token material.
+  throw await gitlabError(res)
+}
+
+/** A non-2xx response as the typed error. Reads the body for diagnostics only;
+ *  NEVER include token material. */
+async function gitlabError(res: Response): Promise<GitlabApiError> {
   let detail = ''
   try {
     const body = (await res.json()) as { message?: unknown; error?: unknown; error_description?: unknown }
@@ -76,7 +81,43 @@ export async function gitlabRequest<T>(path: string, opts: GitlabRequestOpts): P
   } catch {
     // non-JSON error body — status alone
   }
-  throw new GitlabApiError(`gitlab ${res.status}${detail}`, res.status, codeFor(res.status), res.status >= 500)
+  return new GitlabApiError(`gitlab ${res.status}${detail}`, res.status, codeFor(res.status), res.status >= 500)
+}
+
+/** GitLab's own per-page ceiling for these listings. */
+const PAGE_SIZE = 100
+/** Runaway backstop on `gitlabPagedGet`; exceeding it refuses, never truncates. */
+const MAX_PAGES = 50
+
+/** EVERY row of a paginated GET, following GitLab's `x-next-page` header.
+ *  A caller's predicate is sound only over a complete listing (§7.2), so this
+ *  never returns a partial one: a bound or a stuck header raises instead. */
+async function gitlabPagedGet<T>(path: string, opts: { auth: string; fetchImpl?: FetchLike }): Promise<T[]> {
+  const fetchImpl = opts.fetchImpl ?? (fetch as FetchLike)
+  const rows: T[] = []
+  let page = 1
+  for (let requests = 0; requests < MAX_PAGES; requests++) {
+    const url = `${API_BASE}${path}${path.includes('?') ? '&' : '?'}per_page=${PAGE_SIZE}&page=${page}`
+    let res: Response
+    try {
+      res = await fetchImpl(url, {
+        headers: { accept: 'application/json', authorization: `Bearer ${opts.auth}` },
+        signal: AbortSignal.timeout(TIMEOUT_MS)
+      })
+    } catch (e) {
+      throw new GitlabApiError(`gitlab unreachable: ${(e as Error).message}`, 0, 'INTERNAL', true)
+    }
+    if (!res.ok) throw await gitlabError(res)
+    const batch = (await res.json()) as T[]
+    if (!Array.isArray(batch)) throw new GitlabApiError('gitlab listing is not an array', 0, 'INTERNAL', false)
+    rows.push(...batch)
+    const next = res.headers.get('x-next-page')
+    if (!next || !/^\d+$/.test(next)) return rows
+    // A header that does not advance would spin or silently truncate: refuse.
+    if (Number(next) <= page) throw new GitlabApiError('gitlab pagination did not advance', 0, 'INTERNAL', true)
+    page = Number(next)
+  }
+  throw new GitlabApiError(`gitlab listing exceeds ${MAX_PAGES} pages`, 0, 'INTERNAL', true)
 }
 
 /** The token grant GitLab's `/oauth/token` returns for code exchange and refresh. */
@@ -366,18 +407,17 @@ export function gitlabAgentAccountDisplayName(agentName: string, username: strin
   return folded || username
 }
 
-/** The top-level group's OWN service accounts. Deliberately the only listing
- *  the recovery path reads: a global user search would let an account outside
- *  this root answer for one of ours (§7.2). */
+/** The top-level group's OWN service accounts, ALL pages. Deliberately the only
+ *  listing the recovery path reads: a global user search would let an account
+ *  outside this root answer for one of ours (§7.2). It is also the snapshot the
+ *  create window is dated against, so a partial page would read an account that
+ *  merely sits further down as new — hence the exhaustive read. */
 export async function gitlabListServiceAccounts(
   accessToken: string,
   groupId: number,
   fetchImpl?: FetchLike
 ): Promise<GitlabServiceAccount[]> {
-  return gitlabRequest<GitlabServiceAccount[]>(`/groups/${groupId}/service_accounts?per_page=100`, {
-    auth: accessToken,
-    fetchImpl
-  })
+  return gitlabPagedGet<GitlabServiceAccount>(`/groups/${groupId}/service_accounts`, { auth: accessToken, fetchImpl })
 }
 
 /** Find the marked account among the top-level group's service accounts. */
@@ -574,17 +614,18 @@ export async function gitlabCreateServiceAccountToken(
   )
 }
 
-/** List the account's PATs (marker recovery); values are never returned here.
- *  Group-scoped on purpose: the installer OAuth identity is not an instance
- *  admin on GitLab.com and can manage ONLY the group's service-account tokens. */
+/** ALL pages of the account's PATs (marker recovery); values are never returned
+ *  here. Group-scoped on purpose: the installer OAuth identity is not an instance
+ *  admin on GitLab.com and can manage ONLY the group's service-account tokens.
+ *  Exhaustive because a stray this misses keeps a token whose plaintext is lost. */
 export async function gitlabListServiceAccountTokens(
   accessToken: string,
   groupId: number,
   serviceAccountUserId: bigint,
   fetchImpl?: FetchLike
 ): Promise<GitlabPatGrant[]> {
-  return gitlabRequest<GitlabPatGrant[]>(
-    `/groups/${groupId}/service_accounts/${serviceAccountUserId}/personal_access_tokens?per_page=100`,
+  return gitlabPagedGet<GitlabPatGrant>(
+    `/groups/${groupId}/service_accounts/${serviceAccountUserId}/personal_access_tokens`,
     { auth: accessToken, fetchImpl }
   )
 }
@@ -646,13 +687,15 @@ export async function gitlabUpdateWebhook(
   })
 }
 
-/** The project's webhooks — crash-left create reconciliation (exact-URL adoption). */
+/** ALL pages of the project's webhooks — crash-left create reconciliation
+ *  (exact-URL adoption). Exhaustive because a hook this misses is read as
+ *  absent: the converge creates a duplicate, and cleanup orphans it. */
 export async function gitlabListWebhooks(
   accessToken: string,
   projectId: bigint,
   fetchImpl?: FetchLike
 ): Promise<GitlabWebhook[]> {
-  return gitlabRequest<GitlabWebhook[]>(`/projects/${projectId}/hooks?per_page=100`, { auth: accessToken, fetchImpl })
+  return gitlabPagedGet<GitlabWebhook>(`/projects/${projectId}/hooks`, { auth: accessToken, fetchImpl })
 }
 
 export async function gitlabDeleteWebhook(

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -29,6 +29,9 @@ export interface FakeGitlabOptions {
   refuseServiceAccountUsernameChange?: boolean
   /** Observe the row the moment the provider sees a service-account PATCH. */
   onServiceAccountPatch?: () => Promise<void>
+  /** Act between the pages of a service-account listing — a peer that moves
+   *  while an exhaustive read is in flight (§7.2). */
+  onServiceAccountListPage?: (page: number) => Promise<void>
   /** Answer the avatar endpoint 404 — a provider that does not offer it. */
   avatarEndpointUnsupported?: boolean
   /** Refuse the avatar upload with a definitive 400. */
@@ -245,6 +248,7 @@ export class FakeGitlab {
       }
 
       if (/\/api\/v4\/groups\/\d+\/service_accounts\?/.test(url)) {
+        await this.opts.onServiceAccountListPage?.(Number(new URL(url).searchParams.get('page') ?? '1'))
         return page(url, this.serviceAccounts)
       }
       if (/\/api\/v4\/groups\/\d+\/service_accounts$/.test(url) && method === 'POST') {

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -29,9 +29,9 @@ export interface FakeGitlabOptions {
   refuseServiceAccountUsernameChange?: boolean
   /** Observe the row the moment the provider sees a service-account PATCH. */
   onServiceAccountPatch?: () => Promise<void>
-  /** Act between the pages of a service-account listing — a peer that moves
-   *  while an exhaustive read is in flight (§7.2). */
-  onServiceAccountListPage?: (page: number) => Promise<void>
+  /** Act between the pages of a paginated listing — a peer that moves while an
+   *  exhaustive read is in flight (§7.2). */
+  onListPage?: (resource: 'service_accounts' | 'personal_access_tokens' | 'hooks', page: number) => Promise<void>
   /** Answer the avatar endpoint 404 — a provider that does not offer it. */
   avatarEndpointUnsupported?: boolean
   /** Refuse the avatar upload with a definitive 400. */
@@ -40,6 +40,8 @@ export interface FakeGitlabOptions {
 
 /** GitLab-shaped paging: one `per_page` slice plus `x-next-page`, empty on the
  *  last page. Listings the recovery predicates read must follow it (§7.2). */
+const pageOf = (url: string): number => Number(new URL(url).searchParams.get('page') ?? '1')
+
 function page<T>(url: string, rows: readonly T[]): Response {
   const params = new URL(url).searchParams
   const perPage = Number(params.get('per_page') ?? '20')
@@ -248,7 +250,7 @@ export class FakeGitlab {
       }
 
       if (/\/api\/v4\/groups\/\d+\/service_accounts\?/.test(url)) {
-        await this.opts.onServiceAccountListPage?.(Number(new URL(url).searchParams.get('page') ?? '1'))
+        await this.opts.onListPage?.('service_accounts', pageOf(url))
         return page(url, this.serviceAccounts)
       }
       if (/\/api\/v4\/groups\/\d+\/service_accounts$/.test(url) && method === 'POST') {
@@ -324,6 +326,7 @@ export class FakeGitlab {
       }
       if (/\/api\/v4\/groups\/\d+\/service_accounts\/\d+\/personal_access_tokens\?/.test(url)) {
         const userId = Number(/service_accounts\/(\d+)\//.exec(url)![1])
+        await this.opts.onListPage?.('personal_access_tokens', pageOf(url))
         return page(
           url,
           [...this.tokens.entries()]

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -35,6 +35,16 @@ export interface FakeGitlabOptions {
   refuseAvatarUpload?: boolean
 }
 
+/** GitLab-shaped paging: one `per_page` slice plus `x-next-page`, empty on the
+ *  last page. Listings the recovery predicates read must follow it (§7.2). */
+function page<T>(url: string, rows: readonly T[]): Response {
+  const params = new URL(url).searchParams
+  const perPage = Number(params.get('per_page') ?? '20')
+  const index = Number(params.get('page') ?? '1')
+  const next = index * perPage < rows.length ? String(index + 1) : ''
+  return Response.json(rows.slice((index - 1) * perPage, index * perPage), { headers: { 'x-next-page': next } })
+}
+
 export class FakeGitlab {
   readonly opts: Required<Pick<FakeGitlabOptions, 'projectId' | 'path' | 'accessLevel' | 'namespaceKind'>> &
     FakeGitlabOptions
@@ -128,7 +138,8 @@ export class FakeGitlab {
       if (/\/api\/v4\/projects\/\d+\/hooks\?/.test(url) && method === 'GET') {
         const projectId = Number(/projects\/(\d+)\//.exec(url)![1])
         // Real GitLab scopes the listing to the addressed project.
-        return Response.json(
+        return page(
+          url,
           [...this.webhooks.entries()]
             .filter(([, hook]) => hook.projectId === projectId)
             .map(([id, hook]) => ({ id, url: hook.url }))
@@ -234,7 +245,7 @@ export class FakeGitlab {
       }
 
       if (/\/api\/v4\/groups\/\d+\/service_accounts\?/.test(url)) {
-        return Response.json(this.serviceAccounts)
+        return page(url, this.serviceAccounts)
       }
       if (/\/api\/v4\/groups\/\d+\/service_accounts$/.test(url) && method === 'POST') {
         if (this.opts.refuseServiceAccountQuota) {
@@ -309,7 +320,8 @@ export class FakeGitlab {
       }
       if (/\/api\/v4\/groups\/\d+\/service_accounts\/\d+\/personal_access_tokens\?/.test(url)) {
         const userId = Number(/service_accounts\/(\d+)\//.exec(url)![1])
-        return Response.json(
+        return page(
+          url,
           [...this.tokens.entries()]
             .filter(([, t]) => t.user_id === userId)
             .map(([id, t]) => ({ id, ...t, active: !t.revoked }))

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -806,6 +806,31 @@ describe('GitlabAccountService listing pagination (§7.2)', () => {
     expect(accountListings(h).some((r) => r.url.includes('page=2'))).toBe(true)
   })
 
+  it('re-proves the account fence after the read, so a peer that took it mid-listing wins', async () => {
+    const h = await harness()
+    h.fake.serviceAccounts = others(120)
+    // A peer claims the account the moment our exhaustive read reaches page 2 —
+    // the shape a lease that expires under a slow multi-page listing produces.
+    h.fake.opts.onServiceAccountListPage = async (page) => {
+      if (page !== 2) return
+      const row = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+      const later = new Date(Date.now() + 600_000)
+      expect(await h.accounts.claimLease(row.id, 'peer', later, later)).toBe(true)
+    }
+
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      state: 'admin_degraded',
+      reason: 'account_lease_lost'
+    })
+    // Nothing the stale listing decided was written at the provider.
+    expect(h.fake.serviceAccounts).toHaveLength(120)
+    expect(h.fake.tokens.size).toBe(0)
+    expect(await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP)).toMatchObject({
+      serviceAccountUserId: null,
+      createAttempt: null
+    })
+  })
+
   it('sees a foreign account holding the username on a later page, and refuses it', async () => {
     const h = await harness()
     const foreign = { id: 7000, username: usernameOf(AGENT), name: 'somebody-else' }

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -779,6 +779,83 @@ describe('GitlabAccountService create recovery (§7.2)', () => {
   })
 })
 
+describe('GitlabAccountService listing pagination (§7.2)', () => {
+  /** A root already holding this many other service accounts — Premium puts no
+   *  bound on the quantity (§5), so a first page is not the whole set. */
+  const others = (count: number, from = 6000) =>
+    Array.from({ length: count }, (_, i) => ({ id: from + i, username: `other-${from + i}`, name: `other ${i}` }))
+
+  const accountListings = (h: Awaited<ReturnType<typeof harness>>) =>
+    h.fake.requests.filter((r) => r.method === 'GET' && /\/service_accounts\?/.test(r.url))
+
+  it('claims the account an ambiguous create landed past the first page', async () => {
+    const h = await harness({ ambiguousServiceAccountCreate: true })
+    h.fake.serviceAccounts = others(120)
+
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    const created = h.fake.serviceAccounts.find((a) => a.username === usernameOf(AGENT))!
+    // It landed at index 120, so only an exhausted listing ever sees it.
+    expect(h.fake.serviceAccounts.indexOf(created)).toBeGreaterThan(99)
+    expect(await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP)).toMatchObject({
+      serviceAccountUserId: BigInt(created.id),
+      createAttempt: null,
+      state: 'ready'
+    })
+    // One account, not a second one created because the first looked absent.
+    expect(h.fake.serviceAccounts.filter((a) => a.username === usernameOf(AGENT))).toHaveLength(1)
+    expect(accountListings(h).some((r) => r.url.includes('page=2'))).toBe(true)
+  })
+
+  it('sees a foreign account holding the username on a later page, and refuses it', async () => {
+    const h = await harness()
+    const foreign = { id: 7000, username: usernameOf(AGENT), name: 'somebody-else' }
+    h.fake.serviceAccounts = [...others(100), foreign]
+
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      state: 'admin_degraded',
+      reason: 'username_taken'
+    })
+    const [account] = await h.accounts.listForAgent(DEFAULT_ORG_ID, AGENT)
+    expect(account).toMatchObject({ serviceAccountUserId: null, stateReason: 'username_taken' })
+    // Nothing was created behind its back, and the foreign account is untouched.
+    expect(h.fake.serviceAccounts).toHaveLength(101)
+    expect(h.fake.serviceAccounts.at(-1)).toEqual(foreign)
+    expect(h.fake.tokens.size).toBe(0)
+  })
+
+  it('sweeps a stray PAT that a long revocation history pushed past the first page', async () => {
+    const h = await harness()
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    const userId = Number(account.serviceAccountUserId)
+    // Re-lay the account's tokens behind a hundred revoked ones, so the live
+    // PATs answer on page 2 — what years of rotation leave on a real account.
+    const live = [...h.fake.tokens.entries()]
+    h.fake.tokens.clear()
+    for (let i = 0; i < 100; i++) {
+      const stale = {
+        name: `spent-${i}`,
+        scopes: ['read_api'],
+        expires_at: '2027-01-01',
+        revoked: true,
+        user_id: userId
+      }
+      h.fake.tokens.set(9000 + i, stale)
+    }
+    for (const [id, grant] of live) h.fake.tokens.set(id, grant)
+    // The crash shape: the provider token exists but our record of it is gone,
+    // so the next mint must find it as a stray and revoke it before re-minting.
+    const read = (await h.credentials.get(account.id, 'read'))!
+    await prisma.gitlabProjectCredential.delete({ where: { id: read.id } })
+
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    const listings = h.fake.requests.filter((r) => r.method === 'GET' && /personal_access_tokens\?/.test(r.url))
+    expect(listings.some((r) => r.url.includes('page=2'))).toBe(true)
+    // A first-page-only read would have left this token live with no plaintext.
+    expect(h.fake.tokens.get(Number(read.externalTokenId))!.revoked).toBe(true)
+  })
+})
+
 describe('GitlabAccountService avatar sync (§7.2)', () => {
   it('dresses the account in the agent icon on provisioning, through its OWN api token', async () => {
     const h = await harness()

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -788,6 +788,14 @@ describe('GitlabAccountService listing pagination (§7.2)', () => {
   const accountListings = (h: Awaited<ReturnType<typeof harness>>) =>
     h.fake.requests.filter((r) => r.method === 'GET' && /\/service_accounts\?/.test(r.url))
 
+  /** A peer takes the account the way it legitimately can: the run's lease has
+   *  expired, so the CAS lets the next worker claim it. */
+  const stealLease = async (h: Awaited<ReturnType<typeof harness>>) => {
+    const row = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    const later = new Date(Date.now() + 600_000)
+    expect(await h.accounts.claimLease(row.id, 'peer', later, later)).toBe(true)
+  }
+
   it('claims the account an ambiguous create landed past the first page', async () => {
     const h = await harness({ ambiguousServiceAccountCreate: true })
     h.fake.serviceAccounts = others(120)
@@ -811,11 +819,9 @@ describe('GitlabAccountService listing pagination (§7.2)', () => {
     h.fake.serviceAccounts = others(120)
     // A peer claims the account the moment our exhaustive read reaches page 2 —
     // the shape a lease that expires under a slow multi-page listing produces.
-    h.fake.opts.onServiceAccountListPage = async (page) => {
-      if (page !== 2) return
-      const row = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
-      const later = new Date(Date.now() + 600_000)
-      expect(await h.accounts.claimLease(row.id, 'peer', later, later)).toBe(true)
+    h.fake.opts.onListPage = async (resource, page) => {
+      if (resource !== 'service_accounts' || page !== 2) return
+      await stealLease(h)
     }
 
     expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
@@ -846,6 +852,27 @@ describe('GitlabAccountService listing pagination (§7.2)', () => {
     expect(h.fake.serviceAccounts).toHaveLength(101)
     expect(h.fake.serviceAccounts.at(-1)).toEqual(foreign)
     expect(h.fake.tokens.size).toBe(0)
+  })
+
+  it('re-proves the fence after the token listing, so a stolen lease revokes nothing', async () => {
+    const h = await harness()
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    const read = (await h.credentials.get(account.id, 'read'))!
+    // The crash shape again: the PAT is live at the provider, our record is gone,
+    // so the next mint would sweep it as a stray.
+    await prisma.gitlabProjectCredential.delete({ where: { id: read.id } })
+    h.fake.opts.onListPage = async (resource) => {
+      if (resource !== 'personal_access_tokens') return
+      await stealLease(h)
+    }
+
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      state: 'admin_degraded',
+      reason: 'account_lease_lost'
+    })
+    // The revokes the stale listing decided never reached the provider.
+    expect(h.fake.tokens.get(Number(read.externalTokenId))!.revoked).toBe(false)
   })
 
   it('sweeps a stray PAT that a long revocation history pushed past the first page', async () => {


### PR DESCRIPTION
`gitlabListServiceAccounts` requested a single `per_page=100` page and never followed GitLab's `x-next-page` header — yet that listing is the only read behind the Section 7.2 per-agent service-account convergence. It supplies the `createAttemptKnownIds` snapshot recorded by `openCreateAttempt`, the candidate search in `claimFromAttempt`, the durable-key lookup by `serviceAccountUserId`, and the `username_taken` foreign-account check. All four treat an account that merely sits further down the pages as absent.

Section 5 puts Premium service-account quantity at unlimited (only Free is capped at 100 per top-level group) and Section 1 scopes this integration to GitLab.com Free *and* Premium, so a root group past one page is inside the supported scope.

## What went wrong there

- **Liveness.** An account GitLab had created was not on page 1, so `claimFromAttempt` could not claim it and the username check did not see it either. The code opened a fresh window, re-created, was refused for the taken username, and surfaced a generic retryable `gitlab_409` instead of the promised `username_taken`. The added test reproduces exactly that reason before the fix.
- **Safety.** Depending on the endpoint's undocumented ordering, an incomplete snapshot could let the claim predicate adopt a pre-existing *foreign* account — handing somebody else's account this agent's credentials.

## The fix

A shared `gitlabPagedGet` follows `x-next-page` to exhaustion. It never returns a partial listing, because a partial listing is precisely what breaks the predicate's soundness:

- a mid-listing non-2xx raises the typed error rather than returning the pages already read;
- a header that does not advance raises instead of spinning or silently truncating;
- the page bound and the wall-clock budget both raise a **retryable** `GitlabApiError` rather than truncating.

The non-2xx mapping moves out of `gitlabRequest` into `gitlabError` so both paths share it.

## Keeping the read inside its caller's fence

Review caught a real consequence of going exhaustive, fixed in `c176a7ac5`. A single page could never outlive `ACCOUNT_LEASE_MS` (300s); a walk of up to 50 pages at the 10s per-request timeout can. The convergence reads under that lease and then writes on what it read, and `openCreateAttempt` is keyed by account id rather than by lease owner — so a lease that lapsed inside a slow read let two runs both create at the provider.

Bounded at both ends:

- **The read.** `gitlabPagedGet` carries a wall-clock budget (60s, well under the 300s lease) and caps each request's timeout by what is left of it, so no paged read can consume a caller's lease whatever the page count or per-page latency.
- **The callers.** Every stretch that goes from an exhaustive listing into a dependent mutation now re-proves the fence first: `ensureAccount` after both of its account listings, and `mintCredential` after the token listing — before the stray revokes, not only before the create. A lost lease surfaces as the existing `account_lease_lost` and retries instead of writing.

Retirement is the one stretch that needs no renewal and did not get one: `finishRetirement` deletes under a CAS on `lifecycle = 'retiring'`, so a peer that reclaimed an expired lease and reactivated the row already wins and the delete no-ops. That reasoning is now a comment where it happens.

## The sibling listings

Both get the same treatment, for the same class of reason:

- **service-account PATs** — a stray the sweep misses stays live with its plaintext lost;
- **project webhooks** — a hook the exact-URL adoption misses is read as absent, so the converge creates a duplicate and cleanup orphans it.

`gitlabListProjects` is deliberately untouched: its paging is the picker's own, driven by the client.

## Tests

The fake gitlab.com edge now pages GitLab-shaped (`per_page` slice plus `x-next-page`, empty on the last page), so the integration suite exercises the real header rather than a listing that always fits. It also gained an `onServiceAccountListPage` hook so a test can act between pages.

- 10 unit tests in `api-pagination.test.ts`: multi-page assembly and request URLs, the bearer on every page, the no-header and empty-header stops, the mid-listing failure, the non-advancing header, the page bound, and the time budget.
- 5 provisioning integration tests: claiming an ambiguous create that landed past page 1, refusing a foreign account holding the username on a later page, sweeping a stray PAT a long revocation history pushed past page 1, and re-proving the fence when a peer takes the account mid-listing — at page 2 of the account read, and during the token read.

Every one of those integration tests fails without its corresponding fix and passes with it. No existing test asserted on the single-page URL.

## Docs

Section 22's implementation status no longer records this as an open defect. Section 7.2's requirement that both reads exhaust the paginated listing stays.

Gates: `lint`, `typecheck`, control-plane `test:unit` (2006) and `test:int` (1703) all green.
