### PR TITLE
fix(control-plane): let an asynchronous GitLab account deletion finish

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1715,11 +1715,18 @@ transaction as the detach that creates it, before any provider write — so the
 claim releases only when no retirement still names that removal, never when
 merely the first of several has finished.
 
-A retirement awaiting deletion is not a retirement that ended: a consumer
-arriving in that window waits rather than reviving the row, which would adopt a
-user id GitLab is about to remove and mint credentials that die with it. The
-sweep deletes the row once the user is gone, and the next attempt provisions a
-genuinely fresh account.
+A retirement in progress is not a retirement that ended: a consumer arriving
+while one is still `retiring` waits rather than reviving that row, which could
+adopt a user id GitLab is about to remove and mint credentials that die with it.
+The lifecycle itself is the signal — never the latest failure reason, which a
+later attempt overwrites — and a finished retirement deletes its row, so any
+surviving one is by definition still owed work. The sweep removes it once the
+user is gone, and the next attempt provisions a genuinely fresh account, which
+is what the generation fence means by re-provisioning after the wait.
+
+The `active`→`retiring` transition happens in the same transaction that detaches
+the last membership and records the obligation, before any provider call, so a
+crash anywhere after it still leaves a row both worklists select.
 
 If external cleanup cannot complete, retain a sealed, access-restricted
 tombstone only for bounded cleanup retries and mark `cleanup_pending`. Local

--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1708,7 +1708,11 @@ retirement rather than only observing it, so a run that failed part-way — an
 unconfirmed revocation, a refused delete — is finished rather than stranded,
 and a row never leaves the sweep's worklist by failing differently. A project
 removal that stopped on a pending deletion keeps its claim and completes once
-the sweep proves the account gone.
+the sweep proves the account gone. Because that removal detaches every
+membership before any deletion settles, and a project may have one account per
+agent, the obligation is recorded on the account rows themselves: the claim
+releases only when no retirement still names that removal, never when merely the
+first of several has finished.
 
 If external cleanup cannot complete, retain a sealed, access-restricted
 tombstone only for bounded cleanup retries and mark `cleanup_pending`. Local

--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1698,6 +1698,18 @@ verified-external-cleanup discipline; lost administration authority degrades
 the account rows to `cleanup_pending` with the same reconnect-or-transfer
 exits.
 
+GitLab removes a user asynchronously, so the run that asks for the deletion
+cannot witness it: an account still listed immediately after an accepted delete
+is a deletion in flight, not a refusal. That run records `deletion_pending` and
+returns; a background retirement sweep re-reads the top-level group's
+service-account listing on a bounded cadence and closes the retirement out on
+the absence the paragraph above requires. The sweep re-drives the whole
+retirement rather than only observing it, so a run that failed part-way — an
+unconfirmed revocation, a refused delete — is finished rather than stranded,
+and a row never leaves the sweep's worklist by failing differently. A project
+removal that stopped on a pending deletion keeps its claim and completes once
+the sweep proves the account gone.
+
 If external cleanup cannot complete, retain a sealed, access-restricted
 tombstone only for bounded cleanup retries and mark `cleanup_pending`. Local
 authority remains disabled. The Console provides the exact GitLab resources

--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1710,9 +1710,16 @@ and a row never leaves the sweep's worklist by failing differently. A project
 removal that stopped on a pending deletion keeps its claim and completes once
 the sweep proves the account gone. Because that removal detaches every
 membership before any deletion settles, and a project may have one account per
-agent, the obligation is recorded on the account rows themselves: the claim
-releases only when no retirement still names that removal, never when merely the
-first of several has finished.
+agent, the obligation is recorded on the account rows themselves — in the same
+transaction as the detach that creates it, before any provider write — so the
+claim releases only when no retirement still names that removal, never when
+merely the first of several has finished.
+
+A retirement awaiting deletion is not a retirement that ended: a consumer
+arriving in that window waits rather than reviving the row, which would adopt a
+user id GitLab is about to remove and mint credentials that die with it. The
+sweep deletes the row once the user is gone, and the next attempt provisions a
+genuinely fresh account.
 
 If external cleanup cannot complete, retain a sealed, access-restricted
 tombstone only for bounded cleanup retries and mark `cleanup_pending`. Local

--- a/packages/control-plane/prisma/migrations/20260909000000_gitlab_account_retirement_obligation/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260909000000_gitlab_account_retirement_obligation/migration.sql
@@ -1,0 +1,8 @@
+-- A project removal detaches every membership before the accounts it emptied
+-- finish deleting at GitLab, which is asynchronous (gitlab-com-integration.md
+-- §19.4). Without a durable record of what it is still owed, a removal resumed
+-- after the FIRST account disappears would see no memberships left and release
+-- the deployment-global claim while another account is still listed.
+ALTER TABLE "gitlab_agent_account" ADD COLUMN "retiringForBindingId" UUID;
+
+CREATE INDEX "gitlab_agent_account_retiringForBindingId_idx" ON "gitlab_agent_account"("retiringForBindingId");

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2778,6 +2778,11 @@ model GitlabAgentAccount {
   leaseUntil                DateTime? @db.Timestamptz(6)
   generation                BigInt    @default(1) // lifecycle generation a membership insert fences on
   lifecycle                 String    @default("active") // active | retiring
+  // The binding removal, if any, that is waiting on this retirement. Memberships
+  // are detached before a deletion settles, so without this the removal would
+  // lose track of what it still owes evidence for. No relation: the row must
+  // outlive a binding that is removed once every obligation clears.
+  retiringForBindingId      String?   @db.Uuid
   state                     String
   stateReason               String? // bounded repair category, e.g. service_account_quota
   createdAt                 DateTime  @default(now()) @db.Timestamptz(6)
@@ -2791,6 +2796,7 @@ model GitlabAgentAccount {
   @@unique([orgId, agentId, rootGroupId])
   @@index([orgId])
   @@index([agentId])
+  @@index([retiringForBindingId])
   @@map("gitlab_agent_account")
 }
 

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -25,10 +25,11 @@ import { resolveGithubAppConfig } from './github/config.js'
 import { resolveGitlabAppConfig } from './gitlab/config.js'
 import type { FetchLike as GitlabFetchLike } from './gitlab/api.js'
 import { GitlabOauthService } from './gitlab/oauth.service.js'
-import { GitlabAccountService } from './gitlab/account.service.js'
+import { DELETION_PENDING_REASON, GitlabAccountService } from './gitlab/account.service.js'
 import { GitlabProvisioner } from './gitlab/provisioner.js'
 import { GitlabGitcredService } from './gitlab/gitcred.service.js'
 import { GitlabCredentialRotator } from './gitlab/rotator.js'
+import { GitlabRetirementSweeper } from './gitlab/retirement-sweeper.js'
 import { GitlabMembershipAuthzService } from './gitlab/membership-authz.service.js'
 import { GitlabHookRerunService } from './gitlab/hook-rerun.service.js'
 import { CodeHostReviewBrokerService } from './codehost/review-lease.service.js'
@@ -978,6 +979,9 @@ export function buildContainer(
           log: { warn: (obj, msg) => http.log.warn(obj, msg) }
         })
       : undefined
+  // Late-bound, like the other orchestrator refs here: the account service is
+  // built before the provisioner that owns the removal saga it resumes.
+  const gitlabRef: { current?: { provisioner: GitlabProvisioner } } = {}
   // §7.2 identity: per-agent accounts, their PATs, and their memberships. Its
   // mutation lease is the account row's, never a binding's.
   const gitlabAccountService = gitlabOauthService
@@ -990,6 +994,16 @@ export function buildContainer(
         cipher: secretCipher,
         clock,
         avatarPng: createGitlabAccountAvatarRenderer(iconStore),
+        // A removal that stopped at a pending deletion finishes once the sweep
+        // proves the account gone; nothing else would revisit that binding.
+        onRetired: (orgId) => {
+          void (async () => {
+            for (const binding of await repos.gitlabProjectBinding.listForOrg(orgId)) {
+              if (binding.state !== 'cleanup_pending' || binding.stateReason !== DELETION_PENDING_REASON) continue
+              await gitlabRef.current?.provisioner.disconnect(orgId, binding.id)
+            }
+          })().catch((err) => http.log.warn({ err, orgId }, 'gitlab removal resume after retirement failed'))
+        },
         ...(opts.gitlabFetch ? { fetchImpl: opts.gitlabFetch } : {}),
         log: { warn: (obj, msg) => http.log.warn(obj, msg) }
       })
@@ -1061,9 +1075,21 @@ export function buildContainer(
         })
       }
     : undefined
+  if (gitlab) gitlabRef.current = gitlab
+
   // §7.4 PAT-rotation sweep; armed only by startBackground().
   const gitlabRotator = gitlab
     ? new GitlabCredentialRotator({
+        accounts: gitlab.accounts,
+        clock,
+        log: { warn: (obj, msg) => http.log.warn(obj, msg) }
+      })
+    : undefined
+
+  // §19.4 retirement sweep: GitLab deletes a user asynchronously, so the run
+  // that asked cannot witness it — this loop does. Armed by startBackground().
+  const gitlabRetirementSweeper = gitlab
+    ? new GitlabRetirementSweeper({
         accounts: gitlab.accounts,
         clock,
         log: { warn: (obj, msg) => http.log.warn(obj, msg) }
@@ -2102,6 +2128,7 @@ export function buildContainer(
       githubRunReporter?.start()
       hookRedeliveryReconciler?.start()
       gitlabRotator?.start()
+      gitlabRetirementSweeper?.start()
       for (const reaper of pendingInstallReapers) reaper.start()
       relaySweeper.start()
       dutyRecompute.start()
@@ -2119,6 +2146,7 @@ export function buildContainer(
       githubRunReporter?.stop()
       hookRedeliveryReconciler?.stop()
       gitlabRotator?.stop()
+      gitlabRetirementSweeper?.stop()
       installationDoorbell?.stop()
       for (const reaper of pendingInstallReapers) reaper.stop()
       relaySweeper.stop()

--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -71,6 +71,11 @@ const PURPOSES: readonly GitlabCredentialPurpose[] = ['read', 'git_write', 'effe
 /** The account was deleted at GitLab but is still listed: deletion is in flight. */
 export const DELETION_PENDING_REASON = 'deletion_pending'
 
+/** A consumer asked for an account whose retirement has not finished. Distinct
+ *  from `deletion_pending`, which is the retirement's own state, because a
+ *  retirement can also be waiting on repair rather than on GitLab. */
+export const ACCOUNT_RETIRING_REASON = 'account_retiring'
+
 /** How one retirement attempt settled. `deletion_pending` is in progress, not failed. */
 export type RetirementOutcome = 'retired' | 'deletion_pending' | 'failed'
 
@@ -115,8 +120,8 @@ export function gitlabAccountUnavailableMessage(reason: string): string {
   if (reason === 'service_account_create_forbidden') {
     return 'the connected GitLab account must be an Owner of the top-level group to create bot accounts'
   }
-  if (reason === DELETION_PENDING_REASON) {
-    return 'GitLab is still deleting this agent’s previous bot account — try again in a moment'
+  if (reason === ACCOUNT_RETIRING_REASON || reason === DELETION_PENDING_REASON) {
+    return 'This agent’s previous GitLab bot account is still being removed — try again in a moment'
   }
   if (reason === 'provisioning_or_cleanup_in_progress' || reason === 'account_busy') {
     return 'GitLab project setup is already running — try again shortly'
@@ -272,7 +277,7 @@ export class GitlabAccountService {
     if (!outcome.ok) {
       // Both resolve themselves: a peer finishes its account mutation, and a
       // pending deletion is closed out by the sweep.
-      const retryable = outcome.reason === 'account_busy' || outcome.reason === DELETION_PENDING_REASON
+      const retryable = outcome.reason === 'account_busy' || outcome.reason === ACCOUNT_RETIRING_REASON
       return { ok: false, reason: outcome.reason, retryable }
     }
     if (!(await this.bindMembership(input, outcome.account, consumer.accessLevel))) {
@@ -310,17 +315,13 @@ export class GitlabAccountService {
       return { ok: false, reason: 'account_busy', retryable: true }
     }
     try {
-      if (account.lifecycle === 'retiring' && account.stateReason === DELETION_PENDING_REASON) {
-        // GitLab accepted this account's deletion and has not finished it yet.
-        // Reviving the row would adopt a user id about to vanish and mint PATs
-        // that die with it, on a row the sweep no longer watches. Wait instead:
-        // the sweep removes the row and the next attempt creates a fresh one.
-        return { ok: false, reason: DELETION_PENDING_REASON, retryable: true }
-      }
       if (account.lifecycle === 'retiring') {
-        // The retirement released its lease and is not deleting, so it is over —
-        // re-provision a fresh generation rather than reviving what it tore down.
-        account = (await this.deps.accounts.reactivate(account.id)) ?? account
+        // A retirement in progress is never revived, whatever its latest reason
+        // says: GitLab may already have accepted the deletion, and adopting that
+        // user would mint PATs that die with it. The row is a work item until
+        // the retirement deletes it, and the next attempt then provisions a
+        // genuinely fresh account — the §7.2 "wait, then re-provision".
+        return { ok: false, reason: ACCOUNT_RETIRING_REASON, retryable: true }
       }
       // This top-level group's OWN accounts — never a global user search (§7.2).
       let listing = await gitlabListServiceAccounts(input.token, input.rootGroupId, this.deps.fetchImpl)

--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -568,7 +568,11 @@ export class GitlabAccountService {
       await gitlabRemoveMember(token, projectId, account.serviceAccountUserId, this.deps.fetchImpl).catch(swallow404)
     }
     await this.deps.accounts.detachMembership(account.id, bindingId)
-    return this.retireIfEmpty(orgId, account.id, token)
+    const outcome = await this.retireIfEmpty(orgId, account.id, token)
+    // The membership is gone, so nothing else links this retirement to the
+    // removal that caused it — record the obligation before that link is lost.
+    if (outcome !== 'retired') await this.deps.accounts.markRetiringFor(account.id, bindingId)
+    return outcome
   }
 
   /**
@@ -777,15 +781,32 @@ export class GitlabAccountService {
    *  positive evidence for releasing the deployment-global claim. */
   async unbindBinding(orgId: string, bindingId: string, projectId: bigint, token: string): Promise<RetirementOutcome> {
     let worst: RetirementOutcome = 'retired'
+    // A real failure outranks a pending deletion: only one of them is repair work.
+    const record = (outcome: RetirementOutcome): void => {
+      if (outcome === 'failed' || (outcome === 'deletion_pending' && worst === 'retired')) worst = outcome
+    }
+    const handled = new Set<string>()
     for (const membership of await this.deps.accounts.membershipsForBinding(bindingId)) {
       const account = await this.deps.accounts.get(membership.accountId)
       if (!account) continue
-      const outcome = await this.unbindOne(orgId, account, bindingId, projectId, token)
-      // A real failure outranks a pending deletion: only one of them is repair work.
-      if (outcome === 'failed' || (outcome === 'deletion_pending' && worst === 'retired')) worst = outcome
+      handled.add(account.id)
+      record(await this.unbindOne(orgId, account, bindingId, projectId, token))
+    }
+    // Finish what an earlier pass already owes. Its memberships are long gone,
+    // so these rows are the only record of them — and a retried removal has to
+    // be able to complete on its own rather than wait for the sweep.
+    for (const account of await this.deps.accounts.listRetiringForBinding(bindingId)) {
+      if (handled.has(account.id)) continue
+      record(await this.retireIfEmpty(orgId, account.id, token))
     }
     if (worst === 'retired' && (await this.deps.accounts.membershipsForBinding(bindingId)).length > 0) {
       return 'failed'
+    }
+    // The durable invariant, re-read: the claim may release only when no
+    // retirement still names this removal, never when merely the first of
+    // several has finished.
+    if (worst === 'retired' && (await this.deps.accounts.listRetiringForBinding(bindingId)).length > 0) {
+      return 'deletion_pending'
     }
     return worst
   }

--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -68,11 +68,30 @@ const PURPOSE_SCOPES: Record<GitlabCredentialPurpose, string[]> = {
 
 const PURPOSES: readonly GitlabCredentialPurpose[] = ['read', 'git_write', 'effect']
 
+/** The account was deleted at GitLab but is still listed: deletion is in flight. */
+export const DELETION_PENDING_REASON = 'deletion_pending'
+
+/** How one retirement attempt settled. `deletion_pending` is in progress, not failed. */
+export type RetirementOutcome = 'retired' | 'deletion_pending' | 'failed'
+
 /** §7.3: the provider returned a token outside the requested policy. */
 export class GitlabTokenPolicyViolation extends Error {
   constructor(readonly purpose: GitlabCredentialPurpose) {
     super(`gitlab returned an out-of-policy ${purpose} token`)
     this.name = 'GitlabTokenPolicyViolation'
+  }
+}
+
+/**
+ * The positive evidence a cleanup step needs could not be established. A LOCAL
+ * verdict about provider state, never a transport failure — so it carries its
+ * own reason instead of borrowing the `gitlab_<status>` family, whose status-0
+ * member means "we could not reach GitLab at all".
+ */
+export class GitlabCleanupUnverified extends Error {
+  constructor(readonly reason: string) {
+    super(`gitlab cleanup unverified: ${reason}`)
+    this.name = 'GitlabCleanupUnverified'
   }
 }
 
@@ -100,6 +119,14 @@ export function gitlabAccountUnavailableMessage(reason: string): string {
     return 'GitLab project setup is already running — try again shortly'
   }
   return `the agent’s GitLab bot account could not be provisioned (${reason})`
+}
+
+/** A cleanup failure's honest category: `gitlab_unreachable` is reserved for a
+ *  transport failure, the only thing `gitlabRequest` reports as status 0. */
+function retirementReason(e: unknown): string {
+  if (e instanceof GitlabCleanupUnverified) return e.reason
+  if (e instanceof GitlabApiError) return `gitlab_${e.status || 'unreachable'}`
+  return 'cleanup_failed'
 }
 
 function expiresAtDate(nowMs: number): string {
@@ -131,6 +158,9 @@ export interface GitlabAccountServiceDeps {
   /** Renders the agent's icon as the PNG its account wears (§7.2). Absent ⇒ the
    *  avatar is simply never converged; nothing else changes. */
   avatarPng?: (agent: Pick<AgentRecord, 'id' | 'icon' | 'runtime'>) => Promise<Uint8Array>
+  /** Fired when the sweep retires an account, so a removal that was waiting on
+   *  it can finish; absent in tests, which drive the sweep directly. */
+  onRetired?: (orgId: string) => void
   fetchImpl?: FetchLike
   log?: { warn(obj: object, msg: string): void }
 }
@@ -533,7 +563,7 @@ export class GitlabAccountService {
     bindingId: string,
     projectId: bigint,
     token: string
-  ): Promise<boolean> {
+  ): Promise<RetirementOutcome> {
     if (account.serviceAccountUserId !== null) {
       await gitlabRemoveMember(token, projectId, account.serviceAccountUserId, this.deps.fetchImpl).catch(swallow404)
     }
@@ -617,21 +647,29 @@ export class GitlabAccountService {
     }
   }
 
-  /** §19.4: an account with no membership left in its root is retired — PATs
-   *  revoked, account deleted — never kept warm. */
-  async retireIfEmpty(orgId: string, accountId: string, token: string): Promise<boolean> {
+  /**
+   * §19.4: an account with no membership left in its root is retired — PATs
+   *  revoked, account deleted — never kept warm.
+   *
+   * `deletion_pending` is the normal path, not a failure: GitLab deletes a user
+   * ASYNCHRONOUSLY, so the account is still listed for a while after the delete
+   * is accepted. The row records that and the retirement sweep closes it out on
+   * the positive evidence the design asks for — absence from the root's
+   * service-account listing — rather than this run pretending to see it early.
+   */
+  async retireIfEmpty(orgId: string, accountId: string, token: string): Promise<RetirementOutcome> {
     const account = await this.deps.accounts.get(accountId)
-    if (!account) return true
-    if ((await this.deps.accounts.countMemberships(accountId)) > 0) return true
+    if (!account) return 'retired'
+    if ((await this.deps.accounts.countMemberships(accountId)) > 0) return 'retired'
     const owner = randomBytes(9).toString('base64url')
     const nowMs = this.deps.clock.now()
     if (!(await this.deps.accounts.claimLease(accountId, owner, new Date(nowMs + ACCOUNT_LEASE_MS), new Date(nowMs)))) {
-      return false
+      return 'failed'
     }
     try {
       // The CAS and the emptiness check are one transaction: a bind that landed
       // first keeps the account alive and this run withdraws (§7.2).
-      if (!(await this.deps.accounts.beginRetirement(accountId))) return true
+      if (!(await this.deps.accounts.beginRetirement(accountId))) return 'retired'
       if (account.serviceAccountUserId !== null) {
         const rootGroupId = Number(account.rootGroupId)
         for (const credential of await this.deps.credentials.listForAccount(accountId)) {
@@ -646,20 +684,57 @@ export class GitlabAccountService {
         await gitlabDeleteServiceAccount(token, rootGroupId, account.serviceAccountUserId, this.deps.fetchImpl).catch(
           swallow404
         )
-        // Release only on positive evidence: the deterministic marker is absent.
+        // The delete was accepted, but GitLab removes the user asynchronously:
+        // still being listed here means the deletion is in flight, not refused.
         if (await gitlabFindServiceAccount(token, rootGroupId, account.username, this.deps.fetchImpl)) {
-          throw new GitlabApiError('marked service account still present after retirement', 0, 'INTERNAL', true)
+          await this.deps.accounts.update(accountId, {
+            state: 'cleanup_pending',
+            stateReason: DELETION_PENDING_REASON
+          })
+          return 'deletion_pending'
         }
       }
       await this.deps.accounts.finishRetirement(accountId)
-      return true
+      return 'retired'
     } catch (e) {
-      const reason = e instanceof GitlabApiError ? `gitlab_${e.status || 'unreachable'}` : 'cleanup_failed'
+      const reason = retirementReason(e)
       this.deps.log?.warn({ accountId, reason }, 'gitlab account retirement failed')
       await this.deps.accounts.update(accountId, { state: 'cleanup_pending', stateReason: reason })
-      return false
+      return 'failed'
     } finally {
       await this.deps.accounts.releaseLease(accountId, owner).catch(() => {})
+    }
+  }
+
+  /**
+   * §19.4 retirement sweep: close out the accounts whose GitLab deletion was
+   * accepted but not yet observable. GitLab removes a user asynchronously, so
+   * absence from the root's service-account listing is evidence that only a
+   * later read can produce — this is the read, on a bounded cadence.
+   *
+   * An account still listed stays pending and is picked up again; a transport
+   * failure records its own reason and the next pass retries.
+   */
+  async sweepPendingRetirements(quietMs: number, limit = 50): Promise<void> {
+    const before = new Date(this.deps.clock.now() - quietMs)
+    for (const account of await this.deps.accounts.listUnfinishedRetirements(before, limit)) {
+      if (!account.administeringConnectionId) {
+        await this.deps.accounts.update(account.id, { state: 'cleanup_pending', stateReason: 'no_admin_connection' })
+        continue
+      }
+      try {
+        const token = await this.deps.oauth.withAccessToken(account.orgId, account.administeringConnectionId)
+        // Re-drive the whole retirement, not just the observation: a run that
+        // failed part-way — an unconfirmed revocation, a refused delete — has to
+        // be finished, and one that only lacked evidence closes on this read.
+        if ((await this.retireIfEmpty(account.orgId, account.id, token)) === 'retired') {
+          this.deps.onRetired?.(account.orgId)
+        }
+      } catch (e) {
+        const reason = retirementReason(e)
+        this.deps.log?.warn({ accountId: account.id, reason }, 'gitlab retirement sweep failed')
+        await this.deps.accounts.update(account.id, { state: 'cleanup_pending', stateReason: reason })
+      }
     }
   }
 
@@ -700,13 +775,19 @@ export class GitlabAccountService {
    *  an account left with nothing bound in its root retires. True only when no
    *  membership survives AND every emptied account retired — the caller's
    *  positive evidence for releasing the deployment-global claim. */
-  async unbindBinding(orgId: string, bindingId: string, projectId: bigint, token: string): Promise<boolean> {
-    let clean = true
+  async unbindBinding(orgId: string, bindingId: string, projectId: bigint, token: string): Promise<RetirementOutcome> {
+    let worst: RetirementOutcome = 'retired'
     for (const membership of await this.deps.accounts.membershipsForBinding(bindingId)) {
       const account = await this.deps.accounts.get(membership.accountId)
-      if (account && !(await this.unbindOne(orgId, account, bindingId, projectId, token))) clean = false
+      if (!account) continue
+      const outcome = await this.unbindOne(orgId, account, bindingId, projectId, token)
+      // A real failure outranks a pending deletion: only one of them is repair work.
+      if (outcome === 'failed' || (outcome === 'deletion_pending' && worst === 'retired')) worst = outcome
     }
-    return clean && (await this.deps.accounts.membershipsForBinding(bindingId)).length === 0
+    if (worst === 'retired' && (await this.deps.accounts.membershipsForBinding(bindingId)).length > 0) {
+      return 'failed'
+    }
+    return worst
   }
 
   /**

--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -115,6 +115,9 @@ export function gitlabAccountUnavailableMessage(reason: string): string {
   if (reason === 'service_account_create_forbidden') {
     return 'the connected GitLab account must be an Owner of the top-level group to create bot accounts'
   }
+  if (reason === DELETION_PENDING_REASON) {
+    return 'GitLab is still deleting this agent’s previous bot account — try again in a moment'
+  }
   if (reason === 'provisioning_or_cleanup_in_progress' || reason === 'account_busy') {
     return 'GitLab project setup is already running — try again shortly'
   }
@@ -266,7 +269,12 @@ export class GitlabAccountService {
     const outcome = await this.ensureAccount(input, consumer)
     // A contended account lease resolves itself; every other refusal is the
     // account's own recorded state and needs a repair, not another attempt.
-    if (!outcome.ok) return { ok: false, reason: outcome.reason, retryable: outcome.reason === 'account_busy' }
+    if (!outcome.ok) {
+      // Both resolve themselves: a peer finishes its account mutation, and a
+      // pending deletion is closed out by the sweep.
+      const retryable = outcome.reason === 'account_busy' || outcome.reason === DELETION_PENDING_REASON
+      return { ok: false, reason: outcome.reason, retryable }
+    }
     if (!(await this.bindMembership(input, outcome.account, consumer.accessLevel))) {
       return { ok: false, reason: 'account_membership_contended', retryable: true }
     }
@@ -302,9 +310,16 @@ export class GitlabAccountService {
       return { ok: false, reason: 'account_busy', retryable: true }
     }
     try {
+      if (account.lifecycle === 'retiring' && account.stateReason === DELETION_PENDING_REASON) {
+        // GitLab accepted this account's deletion and has not finished it yet.
+        // Reviving the row would adopt a user id about to vanish and mint PATs
+        // that die with it, on a row the sweep no longer watches. Wait instead:
+        // the sweep removes the row and the next attempt creates a fresh one.
+        return { ok: false, reason: DELETION_PENDING_REASON, retryable: true }
+      }
       if (account.lifecycle === 'retiring') {
-        // The retirement released its lease, so it is over — re-provision a
-        // fresh generation rather than reviving the one it was tearing down.
+        // The retirement released its lease and is not deleting, so it is over —
+        // re-provision a fresh generation rather than reviving what it tore down.
         account = (await this.deps.accounts.reactivate(account.id)) ?? account
       }
       // This top-level group's OWN accounts — never a global user search (§7.2).
@@ -567,12 +582,11 @@ export class GitlabAccountService {
     if (account.serviceAccountUserId !== null) {
       await gitlabRemoveMember(token, projectId, account.serviceAccountUserId, this.deps.fetchImpl).catch(swallow404)
     }
-    await this.deps.accounts.detachMembership(account.id, bindingId)
-    const outcome = await this.retireIfEmpty(orgId, account.id, token)
-    // The membership is gone, so nothing else links this retirement to the
-    // removal that caused it — record the obligation before that link is lost.
-    if (outcome !== 'retired') await this.deps.accounts.markRetiringFor(account.id, bindingId)
-    return outcome
+    // The detach and the obligation commit together, BEFORE the provider work:
+    // once the membership is gone nothing else links this retirement to the
+    // removal that caused it, so a crash in between must not lose the link.
+    await this.deps.accounts.detachMembershipForRemoval(account.id, bindingId)
+    return this.retireIfEmpty(orgId, account.id, token)
   }
 
   /**

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -42,7 +42,12 @@ import {
   type GitlabProjectWithNamespace,
   type GitlabWebhookEvents
 } from './api.js'
-import { GitlabTokenPolicyViolation, type GitlabAccountService } from './account.service.js'
+import {
+  DELETION_PENDING_REASON,
+  GitlabCleanupUnverified,
+  GitlabTokenPolicyViolation,
+  type GitlabAccountService
+} from './account.service.js'
 import type { GitlabOauthService } from './oauth.service.js'
 
 /** The exclusive provisioning lease a run holds across its provider writes. */
@@ -615,12 +620,23 @@ export class GitlabProvisioner {
       // §19.4: this project's memberships go, but PATs are per account, not per
       // membership — an account still serving another bound project in its root
       // keeps them. Only an account left with nothing bound retires.
-      // Release only on positive evidence: no managed membership survives here.
-      if (!(await this.deps.accounts.unbindBinding(orgId, bindingId, binding.projectId, token))) {
-        throw new GitlabApiError('managed account memberships remain after cleanup', 0, 'INTERNAL', true)
+      // Release only on positive evidence: no managed membership survives here,
+      // and every emptied account is provably gone from its root.
+      const unbound = await this.deps.accounts.unbindBinding(orgId, bindingId, binding.projectId, token)
+      if (unbound !== 'retired') {
+        // A pending deletion is in flight, not refused: the retirement sweep
+        // closes it out and this removal finishes on the next attempt.
+        throw new GitlabCleanupUnverified(
+          unbound === 'deletion_pending' ? DELETION_PENDING_REASON : 'account_cleanup_incomplete'
+        )
       }
     } catch (e) {
-      const reason = e instanceof GitlabApiError ? `gitlab_${e.status || 'unreachable'}` : 'cleanup_failed'
+      const reason =
+        e instanceof GitlabCleanupUnverified
+          ? e.reason
+          : e instanceof GitlabApiError
+            ? `gitlab_${e.status || 'unreachable'}`
+            : 'cleanup_failed'
       await this.deps.bindings.update(orgId, bindingId, { state: 'cleanup_pending', stateReason: reason })
       return { removed: false, reason }
     }

--- a/packages/control-plane/src/gitlab/retirement-sweeper.ts
+++ b/packages/control-plane/src/gitlab/retirement-sweeper.ts
@@ -1,0 +1,53 @@
+/**
+ * Background retirement sweep (gitlab-com-integration.md §19.4): re-reads the
+ * accounts whose GitLab deletion was accepted but not yet observable and closes
+ * each one out on positive evidence of absence.
+ *
+ * GitLab deletes a user ASYNCHRONOUSLY, so the run that asked for the deletion
+ * cannot see it land; without this loop those rows would sit in
+ * `cleanup_pending` forever with nothing revisiting them. Built in the graph,
+ * armed only by `startBackground()` — never in tests, which drive
+ * `sweepPendingRetirements` directly.
+ */
+import type { Clock, TimerHandle } from '../domain/clock.js'
+import type { GitlabAccountService } from './account.service.js'
+
+/** Leave a row alone this long after its last write, so a sweep never races the
+ *  run that recorded it and GitLab gets a moment to finish. */
+export const RETIREMENT_QUIET_MS = 60 * 1000
+const FIRST_SWEEP_DELAY_MS = 60 * 1000
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000
+
+export class GitlabRetirementSweeper {
+  private timer: TimerHandle | null = null
+  private stopped = false
+
+  constructor(
+    private readonly deps: {
+      accounts: GitlabAccountService
+      clock: Clock
+      log?: { warn(obj: object, msg: string): void }
+    }
+  ) {}
+
+  start(): void {
+    this.stopped = false
+    this.arm(FIRST_SWEEP_DELAY_MS)
+  }
+
+  stop(): void {
+    this.stopped = true
+    if (this.timer !== null) this.deps.clock.clearTimeout(this.timer)
+    this.timer = null
+  }
+
+  private arm(delayMs: number): void {
+    if (this.stopped) return
+    this.timer = this.deps.clock.setTimeout(() => {
+      void this.deps.accounts
+        .sweepPendingRetirements(RETIREMENT_QUIET_MS)
+        .catch((err) => this.deps.log?.warn({ err }, 'gitlab retirement sweep failed'))
+        .finally(() => this.arm(SWEEP_INTERVAL_MS))
+    }, delayMs)
+  }
+}

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3459,9 +3459,11 @@ export interface GitlabAgentAccountRepo {
    *  owed external cleanup, untouched since `before`. Keyed on the lifecycle, not
    *  on a reason — a row must not fall out of the sweep by failing differently. */
   listUnfinishedRetirements(before: Date, limit: number): Promise<GitlabAgentAccountRecord[]>
-  /** Record that a binding's removal is waiting on this retirement — memberships
-   *  are detached before the deletion settles, so the obligation must be durable. */
-  markRetiringFor(accountId: string, bindingId: string): Promise<void>
+  /** Detach a membership as part of a binding's removal, recording in the SAME
+   *  transaction that the removal now owes this account's retirement when the
+   *  detach empties it. Durable before any provider write: a crash after the
+   *  detach would otherwise lose the only link between the two. */
+  detachMembershipForRemoval(accountId: string, bindingId: string): Promise<void>
   /** The retirements that removal is still owed evidence for. */
   listRetiringForBinding(bindingId: string): Promise<GitlabAgentAccountRecord[]>
   update(

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3521,8 +3521,6 @@ export interface GitlabAgentAccountRepo {
   beginRetirement(accountId: string): Promise<boolean>
   /** Verified-complete retirement: the row and its cascaded credentials go. */
   finishRetirement(accountId: string): Promise<void>
-  /** A bind that lost the race re-provisions a FRESH generation off `retiring`. */
-  reactivate(accountId: string): Promise<GitlabAgentAccountRecord | null>
   /** The agents consuming a project: gitlab-workspace agents and enabled gitlab
    *  hooks, each with the access level its authorization derives (§7.2). */
   consumers(orgId: string, projectId: bigint): Promise<GitlabAccountConsumer[]>

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3459,6 +3459,11 @@ export interface GitlabAgentAccountRepo {
    *  owed external cleanup, untouched since `before`. Keyed on the lifecycle, not
    *  on a reason — a row must not fall out of the sweep by failing differently. */
   listUnfinishedRetirements(before: Date, limit: number): Promise<GitlabAgentAccountRecord[]>
+  /** Record that a binding's removal is waiting on this retirement — memberships
+   *  are detached before the deletion settles, so the obligation must be durable. */
+  markRetiringFor(accountId: string, bindingId: string): Promise<void>
+  /** The retirements that removal is still owed evidence for. */
+  listRetiringForBinding(bindingId: string): Promise<GitlabAgentAccountRecord[]>
   update(
     accountId: string,
     patch: Partial<{

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3455,6 +3455,10 @@ export interface GitlabAgentAccountRepo {
   /** Every account holding a membership on the binding (§12.1 veto set, DTO). */
   listForBinding(bindingId: string): Promise<GitlabAgentAccountRecord[]>
   listForAgent(orgId: string, agentId: string): Promise<GitlabAgentAccountRecord[]>
+  /** Retirement sweep worklist (§19.4): every account whose retirement is still
+   *  owed external cleanup, untouched since `before`. Keyed on the lifecycle, not
+   *  on a reason — a row must not fall out of the sweep by failing differently. */
+  listUnfinishedRetirements(before: Date, limit: number): Promise<GitlabAgentAccountRecord[]>
   update(
     accountId: string,
     patch: Partial<{

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -622,7 +622,10 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
   async listUnfinishedRetirements(before: Date, limit: number): Promise<GitlabAgentAccountRecord[]> {
     const rows = await this.prisma.gitlabAgentAccount.findMany({
       orderBy: { updatedAt: 'asc' },
-      where: { lifecycle: 'retiring', state: 'cleanup_pending', updatedAt: { lt: before } },
+      // Every surviving `retiring` row is unfinished by definition — a finished
+      // retirement deletes its row — so the worklist keys on the lifecycle and
+      // never on a reason or state a later failure may have overwritten.
+      where: { lifecycle: 'retiring', updatedAt: { lt: before } },
       take: limit
     })
     return rows.map(toAccountRecord)
@@ -632,9 +635,15 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
     await this.prisma.$transaction(async (tx) => {
       await tx.gitlabAccountMembership.deleteMany({ where: { accountId, bindingId } })
       // Emptied by this detach ⇒ the removal owes this account's retirement.
-      // Recorded here, not after the provider work, so a crash cannot lose it.
+      // This transaction is the §7.2 `active`→`retiring` CAS: it has just
+      // verified the membership set is empty, and committing the lifecycle with
+      // the marker is what makes the row a durable work item — a crash before
+      // the provider work would otherwise leave it in no worklist at all.
       if ((await tx.gitlabAccountMembership.count({ where: { accountId } })) > 0) return
-      await tx.gitlabAgentAccount.updateMany({ where: { id: accountId }, data: { retiringForBindingId: bindingId } })
+      await tx.gitlabAgentAccount.updateMany({
+        where: { id: accountId, lifecycle: 'active' },
+        data: { lifecycle: 'retiring', retiringForBindingId: bindingId }
+      })
     })
   }
 
@@ -810,35 +819,6 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
 
   async finishRetirement(accountId: string): Promise<void> {
     await this.prisma.gitlabAgentAccount.deleteMany({ where: { id: accountId, lifecycle: 'retiring' } })
-  }
-
-  async reactivate(accountId: string): Promise<GitlabAgentAccountRecord | null> {
-    // A fresh generation: whatever the abandoned retirement did externally, the
-    // next converge re-provisions and re-binds. The credential rows go with the
-    // identity they were issued to — an interrupted retirement may have revoked
-    // them, or deleted the very user they name, so keeping them would let the
-    // account read `ready` holding tokens that authenticate nothing. The numeric
-    // user id STAYS: it is the durable key (§7.2), and dropping it would leave
-    // the next converge unable to tell its own surviving account from a foreign
-    // one holding the same username. A deleted account simply misses the lookup.
-    return this.prisma.$transaction(async (tx) => {
-      const res = await tx.gitlabAgentAccount.updateMany({
-        where: { id: accountId, lifecycle: 'retiring' },
-        data: {
-          lifecycle: 'active',
-          generation: { increment: 1n },
-          createAttemptId: null,
-          createAttemptAt: null,
-          createAttemptKnownIds: [],
-          state: 'provisioning',
-          stateReason: null
-        }
-      })
-      if (res.count !== 1) return null
-      await tx.gitlabProjectCredential.deleteMany({ where: { accountId } })
-      const row = await tx.gitlabAgentAccount.findUnique({ where: { id: accountId } })
-      return row ? toAccountRecord(row) : null
-    })
   }
 
   async consumers(orgId: string, projectId: bigint): Promise<GitlabAccountConsumer[]> {

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -628,10 +628,13 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
     return rows.map(toAccountRecord)
   }
 
-  async markRetiringFor(accountId: string, bindingId: string): Promise<void> {
-    await this.prisma.gitlabAgentAccount.updateMany({
-      where: { id: accountId, lifecycle: 'retiring' },
-      data: { retiringForBindingId: bindingId }
+  async detachMembershipForRemoval(accountId: string, bindingId: string): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      await tx.gitlabAccountMembership.deleteMany({ where: { accountId, bindingId } })
+      // Emptied by this detach ⇒ the removal owes this account's retirement.
+      // Recorded here, not after the provider work, so a crash cannot lose it.
+      if ((await tx.gitlabAccountMembership.count({ where: { accountId } })) > 0) return
+      await tx.gitlabAgentAccount.updateMany({ where: { id: accountId }, data: { retiringForBindingId: bindingId } })
     })
   }
 
@@ -744,6 +747,8 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
          WHERE "id" = ${input.accountId}::uuid FOR UPDATE`
       const row = locked[0]
       if (!row || row.lifecycle !== 'active' || row.generation !== input.generation) return false
+      // Bound again ⇒ no removal is owed this account's retirement any more.
+      await tx.gitlabAgentAccount.updateMany({ where: { id: input.accountId }, data: { retiringForBindingId: null } })
       await tx.gitlabAccountMembership.upsert({
         where: { accountId_bindingId: { accountId: input.accountId, bindingId: input.bindingId } },
         create: {

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -619,6 +619,15 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
     return rows.map(toAccountRecord)
   }
 
+  async listUnfinishedRetirements(before: Date, limit: number): Promise<GitlabAgentAccountRecord[]> {
+    const rows = await this.prisma.gitlabAgentAccount.findMany({
+      orderBy: { updatedAt: 'asc' },
+      where: { lifecycle: 'retiring', state: 'cleanup_pending', updatedAt: { lt: before } },
+      take: limit
+    })
+    return rows.map(toAccountRecord)
+  }
+
   async update(
     accountId: string,
     patch: Partial<{

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -628,6 +628,21 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
     return rows.map(toAccountRecord)
   }
 
+  async markRetiringFor(accountId: string, bindingId: string): Promise<void> {
+    await this.prisma.gitlabAgentAccount.updateMany({
+      where: { id: accountId, lifecycle: 'retiring' },
+      data: { retiringForBindingId: bindingId }
+    })
+  }
+
+  async listRetiringForBinding(bindingId: string): Promise<GitlabAgentAccountRecord[]> {
+    const rows = await this.prisma.gitlabAgentAccount.findMany({
+      orderBy: { createdAt: 'asc' },
+      where: { lifecycle: 'retiring', retiringForBindingId: bindingId }
+    })
+    return rows.map(toAccountRecord)
+  }
+
   async update(
     accountId: string,
     patch: Partial<{

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -633,6 +633,11 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
 
   async detachMembershipForRemoval(accountId: string, bindingId: string): Promise<void> {
     await this.prisma.$transaction(async (tx) => {
+      // Lock the account row FIRST, exactly as attachMembership and
+      // beginRetirement do. Counting before taking it would let a concurrent
+      // attach hold the lock with an uncommitted membership this count cannot
+      // see, and the CAS below would then retire a row that has one.
+      await tx.$queryRaw`SELECT "id" FROM "gitlab_agent_account" WHERE "id" = ${accountId}::uuid FOR UPDATE`
       await tx.gitlabAccountMembership.deleteMany({ where: { accountId, bindingId } })
       // Emptied by this detach ⇒ the removal owes this account's retirement.
       // This transaction is the §7.2 `active`→`retiring` CAS: it has just

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -21,6 +21,9 @@ export interface FakeGitlabOptions {
   patExpiryOverride?: string | null
   /** Fail PAT revocations with a 500 (ambiguous cleanup). */
   failTokenRevoke?: boolean
+  /** GitLab deletes a user asynchronously: accept the DELETE but keep listing
+   *  the account until `settleServiceAccountDeletions()` runs. */
+  deferServiceAccountDeletion?: boolean
   /** Refuse the display-name rename (older provider, or a locked account). */
   refuseServiceAccountRename?: boolean
   /** Create the account, then fail the response — the ambiguous create (§7.2). */
@@ -66,6 +69,11 @@ export class FakeGitlab {
       namespaceKind: options.namespaceKind ?? 'group',
       ...options
     }
+  }
+
+  /** The asynchronous half of a deferred deletion finally landing. */
+  settleServiceAccountDeletions(): void {
+    this.serviceAccounts = this.serviceAccounts.filter((account) => !this.deletedServiceAccounts.includes(account.id))
   }
 
   fetch(): FetchLike {
@@ -278,7 +286,11 @@ export class FakeGitlab {
       if (/\/api\/v4\/groups\/\d+\/service_accounts\/\d+$/.test(url) && method === 'DELETE') {
         const id = Number(/service_accounts\/(\d+)$/.exec(url)![1])
         this.deletedServiceAccounts.push(id)
-        this.serviceAccounts = this.serviceAccounts.filter((account) => account.id !== id)
+        // Real GitLab accepts the delete and removes the user later; a deferred
+        // fake keeps it listed until the test says the deletion landed.
+        if (!this.opts.deferServiceAccountDeletion) {
+          this.serviceAccounts = this.serviceAccounts.filter((account) => account.id !== id)
+        }
         return Response.json({})
       }
       if (/\/api\/v4\/groups\/\d+\/service_accounts\/\d+\/personal_access_tokens$/.test(url) && method === 'POST') {

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -661,6 +661,54 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({ removed: true })
   })
 
+  it('a bind racing the removal detach never leaves a retiring account holding a membership', async () => {
+    // The bind is for a DIFFERENT project in the same root, so it is a genuine
+    // "someone still needs this account" against "this account is being freed".
+    // Both take the account row lock, so they serialize: either the bind commits
+    // first and the detach sees its membership, or the detach retires first and
+    // the bind loses the generation fence. The state this rules out is a
+    // `retiring` row holding a membership — nothing could use the account then,
+    // and nothing could retire it either.
+    for (let round = 0; round < 8; round++) {
+      const h = await harness()
+      await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+      const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+      const second = await h.bindings.createWithClaim({
+        orgId: DEFAULT_ORG_ID,
+        projectId: SECOND_PROJECT,
+        projectPath: 'example-group/example-second',
+        installerConnectionId: h.connection.id
+      })
+
+      const [, bound] = await Promise.all([
+        h.accounts.detachMembershipForRemoval(account.id, h.binding.id),
+        h.accounts.attachMembership({
+          accountId: account.id,
+          generation: account.generation,
+          bindingId: second.id,
+          accessLevel: 30
+        })
+      ])
+
+      const after = await prisma.gitlabAgentAccount.findUniqueOrThrow({ where: { id: account.id } })
+      const memberships = await h.accounts.countMemberships(account.id)
+      // The invariant, whichever order won.
+      expect(after.lifecycle === 'retiring' && memberships > 0).toBe(false)
+      if (after.lifecycle === 'retiring') {
+        expect(bound).toBe(false)
+        expect(after.retiringForBindingId).toBe(h.binding.id)
+      } else {
+        expect(bound).toBe(true)
+        expect(memberships).toBe(1)
+        expect(after.retiringForBindingId).toBeNull()
+      }
+      await prisma.gitlabAgentAccount.deleteMany({})
+      await prisma.gitlabProjectBinding.deleteMany({})
+      await prisma.codeHostRepositoryClaim.deleteMany({})
+      await prisma.agent.deleteMany({ where: { id: AGENT } })
+    }
+  })
+
   it('a removal waits for EVERY emptied account, not just the first to disappear', async () => {
     // Two agents on one project means two bot accounts; the removal detaches
     // both memberships up front, so nothing but the recorded obligation still

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -494,6 +494,90 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     expect(account).toMatchObject({ state: 'cleanup_pending', lifecycle: 'retiring' })
   })
 
+  it('records an accepted-but-unobserved deletion as pending, then the sweep closes it (§19.4)', async () => {
+    // GitLab deletes a user asynchronously: the DELETE is accepted and the
+    // account is still listed for a while afterwards.
+    const h = await harness({ deferServiceAccountDeletion: true })
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    await prisma.agent.delete({ where: { id: AGENT } })
+    await h.accountService.retireAgentAccounts(DEFAULT_ORG_ID, AGENT)
+
+    // In flight, not failed — and never mislabelled as an unreachable GitLab.
+    expect(await h.accounts.get(account.id)).toMatchObject({
+      lifecycle: 'retiring',
+      state: 'cleanup_pending',
+      stateReason: 'deletion_pending'
+    })
+    expect(h.fake.deletedServiceAccounts).toEqual([Number(account.serviceAccountUserId)])
+
+    // A sweep before the deletion lands leaves the row exactly as it is.
+    await h.accountService.sweepPendingRetirements(0)
+    expect((await h.accounts.get(account.id))?.stateReason).toBe('deletion_pending')
+
+    // Once GitLab has actually removed the user, absence is the positive
+    // evidence the retirement was waiting for.
+    h.fake.settleServiceAccountDeletions()
+    await h.accountService.sweepPendingRetirements(0)
+    expect(await h.accounts.get(account.id)).toBeNull()
+  })
+
+  it('the sweep leaves rows alone until they have been quiet, and reserves gitlab_unreachable', async () => {
+    const h = await harness({ deferServiceAccountDeletion: true })
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    await prisma.agent.delete({ where: { id: AGENT } })
+    await h.accountService.retireAgentAccounts(DEFAULT_ORG_ID, AGENT)
+    h.fake.settleServiceAccountDeletions()
+
+    // A row written moments ago is not swept: the quiet window keeps the sweep
+    // from racing the run that recorded it.
+    await h.accountService.sweepPendingRetirements(60_000)
+    expect(await h.accounts.get(account.id)).not.toBeNull()
+
+    // A real transport failure — fetch itself throwing — is the ONLY thing that
+    // may be reported as an unreachable GitLab.
+    const offline = new GitlabAccountService({
+      oauth: h.oauth,
+      accounts: h.accounts,
+      credentials: h.credentials,
+      credentialSecrets: h.credentialSecrets,
+      agents: new PgAgentRepo(prisma),
+      cipher,
+      clock: systemClock,
+      fetchImpl: async () => {
+        throw new Error('connect ECONNREFUSED')
+      }
+    })
+    await offline.sweepPendingRetirements(0)
+    expect((await h.accounts.get(account.id))?.stateReason).toBe('gitlab_unreachable')
+
+    // …and the next healthy sweep still finishes the retirement.
+    await h.accountService.sweepPendingRetirements(0)
+    expect(await h.accounts.get(account.id)).toBeNull()
+  })
+
+  it('a project removal blocked by a pending deletion finishes once the account is gone', async () => {
+    const h = await harness({ deferServiceAccountDeletion: true }, EVENTS)
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+
+    // The removal cannot prove the account is gone yet, so it keeps the claim.
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      removed: false,
+      reason: 'deletion_pending'
+    })
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.stateReason).toBe('deletion_pending')
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(1)
+
+    // Deletion lands, the sweep observes it, and the removal completes.
+    h.fake.settleServiceAccountDeletions()
+    await h.accountService.sweepPendingRetirements(0)
+    expect(await h.accounts.get(account.id)).toBeNull()
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({ removed: true })
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(0)
+  })
+
   it('disconnect retires webhook, memberships, tokens, and accounts, then releases the claim (§19.4)', async () => {
     const h = await harness({}, EVENTS)
     await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -418,24 +418,34 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     expect((await h.accounts.membershipsForBinding(second.id)).map((m) => m.accountId)).toEqual([account.id])
   })
 
-  it('reactivating a generation drops the credentials the interrupted retirement left', async () => {
+  it('a retirement in flight is finished, never revived, and its credentials go with it', async () => {
     const h = await harness()
     await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
     const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
     const before = (await h.credentials.get(account.id, 'read'))!
-    await h.accounts.detachMembership(account.id, h.binding.id)
-    expect(await h.accounts.beginRetirement(account.id)).toBe(true)
+    await h.accounts.detachMembershipForRemoval(account.id, h.binding.id)
+    // The detach that empties the account IS the active→retiring CAS, so the
+    // row is a durable work item before any provider call runs (§7.2).
+    expect(await h.accounts.get(account.id)).toMatchObject({ lifecycle: 'retiring' })
 
-    // Those PATs belong to the identity the retirement was tearing down: keeping
-    // them would let the fresh generation read `ready` holding dead tokens.
-    expect(await h.accounts.reactivate(account.id)).not.toBeNull()
-    expect(await h.credentials.listForAccount(account.id)).toHaveLength(0)
+    // A consumer arriving now waits: reviving the row would keep credentials
+    // whose account the retirement is tearing down.
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      state: 'admin_degraded',
+      reason: 'account_retiring',
+      retryable: true
+    })
+
+    // The sweep finishes the retirement; the row and its credentials go together.
+    await h.accountService.sweepPendingRetirements(0)
+    expect(await h.accounts.get(account.id)).toBeNull()
     expect(await prisma.gitlabProjectCredentialSecret.count({ where: { credentialId: before.id } })).toBe(0)
 
-    // The next converge re-provisions the identity from scratch.
+    // Only then does the next converge provision a genuinely fresh identity.
     expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
-    const fresh = (await h.credentials.get(account.id, 'read'))!
-    expect(fresh.externalTokenId).not.toBe(before.externalTokenId)
+    const fresh = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect(fresh.id).not.toBe(account.id)
+    expect((await h.credentials.get(fresh.id, 'read'))!.externalTokenId).not.toBe(before.externalTokenId)
   })
 
   it('the lifecycle-generation fence decides a bind racing a retirement (§7.2)', async () => {
@@ -458,18 +468,14 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
       })
     ).toBe(false)
 
-    // The loser waits out the retirement and re-provisions a fresh generation.
-    const revived = (await h.accounts.reactivate(account.id))!
-    expect(revived.generation).toBe(account.generation + 1n)
-    expect(revived.lifecycle).toBe('active')
-    expect(
-      await h.accounts.attachMembership({
-        accountId: account.id,
-        generation: revived.generation,
-        bindingId: h.binding.id,
-        accessLevel: 30
-      })
-    ).toBe(true)
+    // The loser waits out the retirement rather than reviving the row: once the
+    // sweep has finished it, the next converge provisions a fresh account.
+    await h.accountService.sweepPendingRetirements(0)
+    expect(await h.accounts.get(account.id)).toBeNull()
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    const fresh = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect(fresh.id).not.toBe(account.id)
+    expect((await h.accounts.membershipsForBinding(h.binding.id)).map((m) => m.accountId)).toEqual([fresh.id])
   })
 
   it('deleting an agent retires every account it earned (§19.4)', async () => {
@@ -600,7 +606,7 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     })
     expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
       state: 'admin_degraded',
-      reason: 'deletion_pending',
+      reason: 'account_retiring',
       retryable: true
     })
     expect(await h.accounts.get(doomed.id)).toMatchObject({
@@ -627,21 +633,32 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
 
     // Detaching the last membership IS the moment the removal takes on the
-    // retirement, so the link is durable even if nothing else runs afterwards.
+    // retirement: the same transaction performs the active→retiring CAS and
+    // records the obligation, so a crash right here still leaves a work item.
     await h.accounts.detachMembershipForRemoval(account.id, h.binding.id)
     const row = await prisma.gitlabAgentAccount.findUniqueOrThrow({ where: { id: account.id } })
     expect(row.retiringForBindingId).toBe(h.binding.id)
+    expect(row.lifecycle).toBe('retiring')
 
-    // Binding the account again is the inverse: no removal is owed it any more.
-    await h.accounts.attachMembership({
-      accountId: account.id,
-      generation: account.generation,
-      bindingId: h.binding.id,
-      accessLevel: 30
+    // Crash simulated: nothing else ran after that transaction. Both worklists
+    // still select the row, so the retirement resumes rather than stranding.
+    expect((await h.accounts.listUnfinishedRetirements(new Date(Date.now() + 1_000), 50)).map((a) => a.id)).toEqual([
+      account.id
+    ])
+    expect((await h.accounts.listRetiringForBinding(h.binding.id)).map((a) => a.id)).toEqual([account.id])
+
+    // A removal retried after that crash cannot release the claim…
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      removed: false,
+      reason: 'deletion_pending'
     })
-    expect(
-      (await prisma.gitlabAgentAccount.findUniqueOrThrow({ where: { id: account.id } })).retiringForBindingId
-    ).toBeNull()
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(1)
+
+    // …until the deletion lands and the sweep discharges the obligation.
+    h.fake.settleServiceAccountDeletions()
+    await h.accountService.sweepPendingRetirements(0)
+    expect(await h.accounts.get(account.id)).toBeNull()
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({ removed: true })
   })
 
   it('a removal waits for EVERY emptied account, not just the first to disappear', async () => {

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -578,6 +578,72 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(0)
   })
 
+  it('never revives an account whose deletion GitLab already accepted', async () => {
+    const h = await harness({ deferServiceAccountDeletion: true })
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const doomed = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    // The agent stops consuming the project, so its account retires; GitLab
+    // accepts the deletion but has not carried it out yet.
+    await prisma.agent.update({ where: { id: AGENT }, data: { workspaceMode: 'scratch', workspaceRepoId: null } })
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    expect((await h.accounts.get(doomed.id))?.stateReason).toBe('deletion_pending')
+
+    // A consumer arriving before the deletion lands must NOT adopt that user:
+    // its PATs would die with it, on a row the sweep no longer watches.
+    await prisma.agent.update({
+      where: { id: AGENT },
+      data: {
+        workspaceMode: 'gitlab',
+        workspaceRepoId: PROJECT,
+        gitRepo: 'https://gitlab.com/example-group/example-project'
+      }
+    })
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      state: 'admin_degraded',
+      reason: 'deletion_pending',
+      retryable: true
+    })
+    expect(await h.accounts.get(doomed.id)).toMatchObject({
+      lifecycle: 'retiring',
+      serviceAccountUserId: doomed.serviceAccountUserId
+    })
+    expect(await h.accounts.membershipsForBinding(h.binding.id)).toHaveLength(0)
+
+    // Once the deletion lands the sweep clears the row, and the next attempt
+    // provisions a genuinely fresh account.
+    h.fake.settleServiceAccountDeletions()
+    await h.accountService.sweepPendingRetirements(0)
+    expect(await h.accounts.get(doomed.id)).toBeNull()
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    const fresh = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect(fresh.id).not.toBe(doomed.id)
+    expect(fresh.state).toBe('ready')
+    expect(await h.credentials.listForAccount(fresh.id)).toHaveLength(3)
+  })
+
+  it('records the removal’s obligation with the detach, before any provider write', async () => {
+    const h = await harness({ deferServiceAccountDeletion: true }, EVENTS)
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+
+    // Detaching the last membership IS the moment the removal takes on the
+    // retirement, so the link is durable even if nothing else runs afterwards.
+    await h.accounts.detachMembershipForRemoval(account.id, h.binding.id)
+    const row = await prisma.gitlabAgentAccount.findUniqueOrThrow({ where: { id: account.id } })
+    expect(row.retiringForBindingId).toBe(h.binding.id)
+
+    // Binding the account again is the inverse: no removal is owed it any more.
+    await h.accounts.attachMembership({
+      accountId: account.id,
+      generation: account.generation,
+      bindingId: h.binding.id,
+      accessLevel: 30
+    })
+    expect(
+      (await prisma.gitlabAgentAccount.findUniqueOrThrow({ where: { id: account.id } })).retiringForBindingId
+    ).toBeNull()
+  })
+
   it('a removal waits for EVERY emptied account, not just the first to disappear', async () => {
     // Two agents on one project means two bot accounts; the removal detaches
     // both memberships up front, so nothing but the recorded obligation still

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -578,6 +578,48 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(0)
   })
 
+  it('a removal waits for EVERY emptied account, not just the first to disappear', async () => {
+    // Two agents on one project means two bot accounts; the removal detaches
+    // both memberships up front, so nothing but the recorded obligation still
+    // links the second retirement to the removal that caused it.
+    const h = await harness({ deferServiceAccountDeletion: true }, EVENTS, [
+      { id: AGENT, name: 'reviewer' },
+      { id: SIBLING, name: 'builder' }
+    ])
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const first = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    const second = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, SIBLING, ROOT_GROUP))!
+
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      removed: false,
+      reason: 'deletion_pending'
+    })
+    expect(await h.accounts.membershipsForBinding(h.binding.id)).toHaveLength(0)
+
+    // Only the FIRST account's deletion lands. Its retirement completing must
+    // not let the removal release the claim while the second is still listed.
+    h.fake.serviceAccounts = h.fake.serviceAccounts.filter(
+      (candidate) => candidate.id !== Number(first.serviceAccountUserId)
+    )
+    await h.accountService.sweepPendingRetirements(0)
+    expect(await h.accounts.get(first.id)).toBeNull()
+    expect(await h.accounts.get(second.id)).not.toBeNull()
+
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      removed: false,
+      reason: 'deletion_pending'
+    })
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(1)
+    expect(await prisma.gitlabProjectBinding.count()).toBe(1)
+
+    // The second lands too: now every obligation is discharged and the claim goes.
+    h.fake.settleServiceAccountDeletions()
+    await h.accountService.sweepPendingRetirements(0)
+    expect(await h.accounts.get(second.id)).toBeNull()
+    expect(await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).toEqual({ removed: true })
+    expect(await prisma.codeHostRepositoryClaim.count({ where: { provider: 'gitlab' } })).toBe(0)
+  })
+
   it('disconnect retires webhook, memberships, tokens, and accounts, then releases the claim (§19.4)', async () => {
     const h = await harness({}, EVENTS)
     await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)

--- a/packages/web/src/lib/gitlab-projects.ts
+++ b/packages/web/src/lib/gitlab-projects.ts
@@ -46,6 +46,8 @@ export const GITLAB_STATE_REASON: Record<string, string> = {
     'Removal did not finish because no connected GitLab account could reach the project — reconnect it or transfer the project, then remove again',
   claim_fence_lost: 'Setup was interrupted — run Repair again',
   relay_url_unconfigured: 'This deployment has no public webhook address configured',
+  deletion_pending: 'GitLab is still deleting the bot account — this finishes on its own',
+  account_cleanup_incomplete: 'Removal did not finish cleaning up the bot accounts — remove the project again',
   provisioning_in_progress: 'Setup is already running',
   provisioning_or_cleanup_in_progress: 'Setup or removal is already running'
 }

--- a/packages/web/src/lib/gitlab-projects.ts
+++ b/packages/web/src/lib/gitlab-projects.ts
@@ -47,6 +47,7 @@ export const GITLAB_STATE_REASON: Record<string, string> = {
   claim_fence_lost: 'Setup was interrupted — run Repair again',
   relay_url_unconfigured: 'This deployment has no public webhook address configured',
   deletion_pending: 'GitLab is still deleting the bot account — this finishes on its own',
+  account_retiring: 'The previous bot account for this agent is still being removed — this finishes on its own',
   account_cleanup_incomplete: 'Removal did not finish cleaning up the bot accounts — remove the project again',
   provisioning_in_progress: 'Setup is already running',
   provisioning_or_cleanup_in_progress: 'Setup or removal is already running'


### PR DESCRIPTION
Found in live testing: an agent account whose last project was unbound entered
retirement and GitLab did delete it — the user 404s and the top-level group's
service-account listing is empty minutes later — yet the row sat at
`lifecycle=retiring, state=cleanup_pending, stateReason=gitlab_unreachable`
indefinitely, with nothing revisiting it.

## Why

GitLab removes a user **asynchronously**: the delete call returns before the
account disappears. The retirement asked for the deletion and then immediately
re-read the group's service-account listing as its positive evidence, so on the
normal path it found the account still listed and treated a deletion in flight
as a refusal.

Two defects compounded:

1. the immediate re-check read "still listed right after an accepted delete" as
   failure rather than as deletion pending; and
2. it threw an internal error carrying `status 0`, which the reason mapping
   renders as `gitlab_unreachable` — false, and it hid the real state.

Because the failure path only marked the row and returned, nothing ever came
back to it.

## The fix

- An account still listed after an **accepted** delete (2xx, or a 404 meaning it
  was already gone) records `deletion_pending` and returns, instead of throwing.
- A new background retirement sweep re-reads the listing on a bounded cadence
  and closes the retirement out on absence — the positive evidence §19.4 asks
  for, produced by the only read that can produce it.
- The sweep **re-drives the whole retirement** rather than only observing it, so
  a run that failed part-way (an unconfirmed revocation, a refused delete) is
  finished rather than stranded. Its worklist is keyed on the lifecycle, not on
  a reason, so a row cannot fall out of the sweep by failing differently — which
  is the same "nothing revisits it" shape as the original bug.
- `gitlab_unreachable` is now reserved for a real transport failure, the only
  thing the request wrapper reports as status 0. Positive-evidence failures
  carry their own category.

## Audit of the binding removal saga

Its webhook deletion is synchronous at GitLab and has no immediate re-check to
defeat, and its remaining evidence check is local state rather than a provider
read — so there is no second instance of the immediate-recheck pattern. It did
share the wrong status-0 reason, and it blocked on the account retirement it
triggers, so a project removal inherited the same stuck state. It now reports
`deletion_pending` honestly, keeps its deployment-global claim while the
deletion is in flight (the claim must not release before the account is provably
gone), and completes once the sweep proves it. A removal left waiting is resumed
by the sweep rather than needing an operator to click Remove again.

## Console

`deletion_pending` reads as in-progress — "GitLab is still deleting the bot
account — this finishes on its own" — not as an error.

## Tests

- delete accepted but the account still listed → `deletion_pending`, and the
  delete really was issued;
- a sweep before the deletion lands leaves the row untouched; once GitLab has
  removed the user, the next sweep retires it;
- the quiet window keeps a sweep from racing the run that recorded the row;
- a real transport failure (fetch throwing) is the only thing reported as
  `gitlab_unreachable`, and a later healthy sweep still finishes the retirement
  — proving the row stays in the worklist across a differently-shaped failure;
- a project removal blocked by a pending deletion keeps its claim and completes
  after the sweep.

The first of these fails against the previous behavior with exactly the reported
symptom.

## Verification

- root `pnpm typecheck`
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 1996 passed
- `pnpm --filter @agentconnect.md/control-plane test:int` — 1701 passed
- `pnpm --filter @agentconnect.md/web test` — 1911 passed (translations touched)
- `pnpm lint`, `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
