### PR TITLE
fix(web): GitLab sessions are GitLab, not generic webhooks

### DIFF
--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -5,13 +5,25 @@ one inbound delivery to one agent turn. The relay is the public ingress and data
 plane, the daemon runs the turn, and the Control Plane (CP) stores definitions
 and body-free run metadata.
 
-Two hook kinds share this execution path:
+The hook kinds sharing this execution path are the generic endpoint plus one per
+code host. The vocabulary is `HOOK_KINDS` in `packages/protocol/src/code-host.ts`,
+derived from `CODE_HOST_PROVIDERS`, so a new host widens it in one place and every
+mapping over it — the session integration facet, the console's trigger taxonomy,
+the per-kind marks and labels — stops type-checking until it is extended:
 
 - `webhook`: an unguessable capability URL accepts a caller-supplied
   instruction.
 - `github`: a GitHub App webhook accepts signed repository events, applies
   subscription and authorization rules, and preserves issue or pull-request
   session continuity.
+- `gitlab`: the GitLab counterpart, described in
+  [gitlab-com-integration.md](gitlab-com-integration.md).
+
+Only `webhook` is generic. Every code-host kind is promoted out of the generic
+bucket wherever a session is classified, so a code-host session is never
+filtered, marked, or labelled as a plain webhook. `webhook` is the mapping for
+the generic kind and for a hook whose definition can no longer be resolved — it
+is never the fallback for a kind nobody mapped.
 
 For a numbered GitHub thread, `GithubPoster` owns the ordinary reply comment and
 publishes only the completed ACP final answer. A formal pull-request review is a
@@ -582,7 +594,7 @@ The implementation does not provide:
 
 - synchronous webhook responses containing agent output;
 - arbitrary payload transformation or filter programs;
-- structured GitLab or Bitbucket event semantics;
+- structured Bitbucket event semantics;
 - per-repository webhook registration managed by AgentConnect;
 - daemon polling as an alternative public ingress;
 - queueing arbitrary generic deliveries while a daemon is offline;

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -20,6 +20,7 @@ import {
   RESERVED_MCP_SERVER_NAME,
   SESSION_RETENTION_RE,
   GitCloneUrlError,
+  HOOK_KINDS,
   RepoSubdirError,
   SessionImageAttachment,
   MAX_WORKSPACE_COMMIT_MESSAGE,
@@ -801,10 +802,9 @@ export const AgentDto = z.object({
   sandboxSupported: z.boolean(),
   // #642: daemon policy forces the effective value true and makes it immutable.
   sandboxRequired: z.boolean(),
-  // Distinct kinds of ENABLED inbound triggers (hooks) on this agent — the list
-  // view's integrations cell renders a mark per kind (github repo subscriptions,
-  // generic webhooks) without an org-wide hook list existing anywhere.
-  hookKinds: z.array(z.enum(['webhook', 'github', 'gitlab']))
+  // Distinct kinds of ENABLED inbound triggers on this agent — one mark per kind in the
+  // list's integrations cell, without an org-wide hook list existing anywhere.
+  hookKinds: z.array(z.enum(HOOK_KINDS))
 })
 export const AgentListDto = z.array(AgentDto)
 
@@ -2535,7 +2535,7 @@ export const HookDto = z.object({
   id: z.string(),
   orgId: z.string(),
   agentId: z.string().nullable(), // null ⇒ legacy inert row
-  kind: z.enum(['webhook', 'github', 'gitlab']),
+  kind: z.enum(HOOK_KINDS),
   name: z.string(),
   sessionMode: HookSessionModeEnum,
   enabled: z.boolean(),
@@ -2646,7 +2646,7 @@ export const SessionDto = z.object({
   triggeredBy: z.string().nullable(),
   // Stable source kind for hook-triggered sessions. null for non-hook or a
   // deleted/legacy hook whose definition can no longer be resolved.
-  hookKind: z.enum(['webhook', 'github', 'gitlab']).nullable(),
+  hookKind: z.enum(HOOK_KINDS).nullable(),
   // Daemon-resolved display names (pure passthrough — the raw ids above stay
   // canonical; null when the daemon hasn't resolved them).
   channelName: z.string().nullable(),
@@ -2698,7 +2698,7 @@ export const SessionFacetsDto = z.object({
       value: z.string(),
       integration: z.string(),
       name: z.string().nullable(),
-      hookKind: z.enum(['webhook', 'github', 'gitlab']).nullable(),
+      hookKind: z.enum(HOOK_KINDS).nullable(),
       githubRepoId: z.string().nullable()
     })
   )
@@ -2782,7 +2782,7 @@ export const SessionDetailDto = z.object({
   lastActivityAt: z.string(),
   usage: SessionUsageDto.nullable(),
   triggeredBy: z.string().nullable(),
-  hookKind: z.enum(['webhook', 'github', 'gitlab']).nullable(),
+  hookKind: z.enum(HOOK_KINDS).nullable(),
   channelName: z.string().nullable(),
   triggeredByName: z.string().nullable(),
   threadUrl: z.string().nullable(),

--- a/packages/control-plane/src/http/routes/sessions.code-host-facets.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.code-host-facets.test.ts
@@ -10,6 +10,7 @@
  */
 import Fastify, { type FastifyInstance } from 'fastify'
 import { describe, expect, it, vi } from 'vitest'
+import { HOOK_KINDS, isCodeHostHookKind } from '@agentconnect.md/protocol'
 import type { HttpDeps } from '../deps.js'
 import type { SessionPageQuery, SessionPageRecord } from '../../persistence/ports.js'
 import { installZod } from '../plugins/zod.js'
@@ -59,11 +60,16 @@ const hookRows = [
   { id: WEBHOOK, agentId: AGENT_ID, kind: 'webhook', name: 'acme/build', repoId: null }
 ]
 
-function fakeDeps() {
+/** A hook session as the LIST projection reads it — the visibility trio the row DTO requires. */
+function pageRow(hookId: string, id: string) {
+  return { ...hookSession(hookId, id), visibility: 'org', externalProvider: null, externalResolution: null }
+}
+
+function fakeDeps(pageSessions: ReturnType<typeof pageRow>[] = []) {
   const listFacets = vi.fn(async () => facetIndex)
   const listPage = vi.fn<(q: SessionPageQuery) => Promise<SessionPageRecord>>(async () => ({
-    sessions: [],
-    total: 0,
+    sessions: pageSessions as unknown as SessionPageRecord['sessions'],
+    total: pageSessions.length,
     hasMore: false
   }))
   const listIdsForOrgKind = vi.fn(async (_orgId: string, kind: string) =>
@@ -153,5 +159,49 @@ describe('session integration facets across code hosts', () => {
 
     expect(res.statusCode).toBe(200)
     expect(listIdsForOrgKind).not.toHaveBeenCalled()
+  })
+
+  // The taxonomy is derived from the shared hook-kind vocabulary, so this walks the
+  // whole vocabulary rather than the two hosts that happen to exist today: every code
+  // host must project a facet of its own, and only the generic kind may say 'hook'.
+  it('gives every code-host kind a distinct, non-generic facet', async () => {
+    const hookById = new Map(hookRows.map((hook) => [hook.kind, hook.id]))
+    const { deps } = fakeDeps()
+    const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions/facets' })
+    const triggers = (res.json() as { triggers: Array<{ value: string; integration: string; hookKind: string }> })
+      .triggers
+    const facetOf = (kind: string) => triggers.find((t) => t.value === `hook:${hookById.get(kind)}`)
+
+    const projected = HOOK_KINDS.map((kind) => [kind, facetOf(kind)?.integration] as const)
+    for (const [kind, integration] of projected) {
+      expect(facetOf(kind)?.hookKind).toBe(kind)
+      expect(integration).toBe(isCodeHostHookKind(kind) ? kind : 'hook')
+    }
+    // Distinctness is the property that failed in live testing: GitLab shared the
+    // generic bucket, so its sessions were unreachable from the integration filter.
+    expect(new Set(projected.map(([, integration]) => integration)).size).toBe(HOOK_KINDS.length)
+  })
+
+  it('carries the hook kind on the session row so the console never has to guess', async () => {
+    const { deps } = fakeDeps([pageRow(GITLAB_HOOK, 'sess-gitlab')])
+    const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions?view=flat' })
+
+    expect(res.statusCode).toBe(200)
+    const [session] = (res.json() as { sessions: Array<{ hookKind: string; triggeredByName: string }> }).sessions
+    expect(session?.hookKind).toBe('gitlab')
+    expect(session?.triggeredByName).toBe('acme/platform')
+  })
+
+  it('names the source of an unnamed hook instead of calling every kind a webhook', async () => {
+    // A hook reassigned to another agent keeps its kind but loses its name for these
+    // historical rows, which is exactly when the generic label used to take over.
+    const { deps } = fakeDeps([pageRow(GITLAB_HOOK, 'sess-gitlab')])
+    deps.repos.hook.getMany = vi.fn(async () => [
+      { id: GITLAB_HOOK, agentId: 'agent-2', kind: 'gitlab', name: 'acme/platform', repoId: 4210n }
+    ]) as unknown as typeof deps.repos.hook.getMany
+    const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions?view=flat' })
+
+    const [session] = (res.json() as { sessions: Array<{ hookKind: string; triggeredByName: string }> }).sessions
+    expect(session?.triggeredByName).toBe('GitLab')
   })
 })

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -20,7 +20,7 @@ import { AgentId, HookId, OrgId, SessionId } from '../../domain/ids.js'
 import { orgOf, ctxOf, denyNonOwner } from '../rbac.js'
 import { decodeConversationKey, encodeConversationKey } from '../conversation-key.js'
 import { canChangeSessionVisibility, canContinueSession, canView, canViewSession } from '../../authorization/policy.js'
-import { originKindOf } from '@agentconnect.md/protocol'
+import { isCodeHostHookKind, originKindOf, type HookKind } from '@agentconnect.md/protocol'
 import { makeSessionAccessResolver } from '../session-access.js'
 import { resolveContinuationHost } from '../session-continuation.js'
 import { Tag } from '../plugins/openapi.js'
@@ -88,7 +88,7 @@ type SessionFacetIndex = Awaited<ReturnType<HttpDeps['repos']['session']['listFa
 type HookSessionRow = Pick<SessionPageRow, 'agentId' | 'platform' | 'channel' | 'triggeredBy'>
 type HookSessionMetadata = {
   agentId: string | null
-  kind: 'webhook' | 'github' | 'gitlab'
+  kind: HookKind
   name: string
   repoId: bigint | null
 }
@@ -209,14 +209,21 @@ function decodeSessionCursor(raw: string): SessionCursor | null {
   }
 }
 
-/** A hook session's integration facet. Both code hosts are promoted out of the
- *  generic hook bucket so each gets a first-class entry the console can filter by;
- *  the value matches the client's own `sessionPlatform` classification. */
+/** A hook session's integration facet. EVERY code host is promoted out of the generic
+ *  hook bucket so each gets a first-class entry the console can filter by; only the
+ *  generic kind keeps the raw `hook` platform. The predicate is derived from the shared
+ *  hook-kind vocabulary, so a new host is promoted here without a code change, and the
+ *  value matches the client's own `sessionPlatform` classification. */
 function sessionIntegration(s: HookSessionRow, hook: HookSessionMetadata | undefined): string {
   const platform = s.platform ?? 'slack'
   if (platform !== 'hook') return platform
-  return hook?.kind === 'github' || hook?.kind === 'gitlab' ? hook.kind : platform
+  return hook && isCodeHostHookKind(hook.kind) ? hook.kind : platform
 }
+
+/** Display name for a hook source with no name of its own. TOTAL over the hook-kind
+ *  vocabulary, so a new code host cannot inherit the generic "Webhook" label the way
+ *  GitLab did — adding one to the shared union fails this file's type-check first. */
+const HOOK_KIND_LABEL: Record<HookKind, string> = { webhook: 'Webhook', github: 'GitHub', gitlab: 'GitLab' }
 
 function sessionDisplayMetadata(
   s: HookSessionRow & { channelName: string | null; triggeredByName: string | null },
@@ -225,10 +232,12 @@ function sessionDisplayMetadata(
   // Hook kind remains valid after reassignment, but the current name only
   // describes historical rows while the hook still belongs to the same agent.
   const hookName = hook?.agentId === s.agentId ? hook.name : undefined
+  // An unresolvable hook has no kind to name, so it stays generic.
+  const sourceLabel = hook ? HOOK_KIND_LABEL[hook.kind] : HOOK_KIND_LABEL.webhook
   return {
     channelName: s.platform === 'hook' ? (hookName ?? s.channelName ?? null) : (s.channelName ?? null),
     triggeredByName: s.triggeredBy?.startsWith(HOOK_TRIGGER_PREFIX)
-      ? (hookName ?? s.triggeredByName ?? 'Webhook')
+      ? (hookName ?? s.triggeredByName ?? sourceLabel)
       : (s.triggeredByName ?? null)
   }
 }
@@ -250,7 +259,7 @@ function sessionFacets(
       value: string
       integration: string
       name: string | null
-      hookKind: 'webhook' | 'github' | 'gitlab' | null
+      hookKind: HookKind | null
       githubRepoId: string | null
     }
   >()

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -33,7 +33,8 @@ import type {
   CodeHostReviewOpMethod,
   CodeHostReviewOpOutcome,
   CodeHostReviewOpState,
-  CodeHostReviewState
+  CodeHostReviewState,
+  HookKind
 } from '@agentconnect.md/protocol'
 import type {
   CodeHostReviewLockReason,
@@ -2096,7 +2097,8 @@ export interface CronRepo {
 //   HookDef rows into rc/hook-assign rules; event payloads never land here.
 // ───────────────────────────────────────────────────────────────────────────
 
-export type HookKind = 'webhook' | 'github' | 'gitlab'
+/** Re-exported so the repository layer keeps one hook-kind vocabulary with the wire contract. */
+export type { HookKind }
 export type HookSessionMode = 'perDelivery' | 'perThread' | 'shared'
 export type GithubCommentFamily = 'issues' | 'pull_request'
 /** The stored comment-family vocabulary across code hosts; rows carry one host's subset. */

--- a/packages/protocol/src/code-host.ts
+++ b/packages/protocol/src/code-host.ts
@@ -16,6 +16,24 @@ export function isCodeHostProvider(value: unknown): value is CodeHostProvider {
   return typeof value === 'string' && (CODE_HOST_PROVIDERS as readonly string[]).includes(value)
 }
 
+/** The generic inbound endpoint — the one hook kind that is not a code host. */
+export const GENERIC_HOOK_KIND = 'webhook'
+
+/**
+ * Inbound-trigger source vocabulary: the generic endpoint plus one entry per code
+ * host. Deriving it from `CODE_HOST_PROVIDERS` is what makes a new host a
+ * compile-time event — every `Record<HookKind, …>` mapping over this union stops
+ * type-checking until it is given an entry, so no host can silently inherit the
+ * generic webhook rendering the way GitLab once did.
+ */
+export const HOOK_KINDS = [GENERIC_HOOK_KIND, ...CODE_HOST_PROVIDERS] as const
+export type HookKind = (typeof HOOK_KINDS)[number]
+
+/** A hook kind that identifies a code host, as opposed to the generic endpoint. */
+export function isCodeHostHookKind(kind: HookKind): kind is CodeHostProvider {
+  return kind !== GENERIC_HOOK_KIND
+}
+
 /**
  * Wire form for provider fields — an OPEN string, mirroring the KNOWN_PLATFORMS
  * precedent (frames/route.ts): zod rejects unknown enum values wholesale, and an

--- a/packages/protocol/src/frames/hook.ts
+++ b/packages/protocol/src/frames/hook.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { CodeHostExternalId, CodeHostProviderString } from '../code-host.js'
+import { CodeHostExternalId, CodeHostProviderString, HOOK_KINDS } from '../code-host.js'
 
 /** Decimal wire form for Prisma/GitHub bigint values. */
 export const HookBigIntString = z.string().regex(/^(?:0|[1-9]\d*)$/)
@@ -190,7 +190,7 @@ export type PublishedHookOutput = z.infer<typeof PublishedHookOutput>
  * (P2) are untrusted third-party content the daemon fences in the prompt.
  */
 export const HookContext = z.object({
-  source: z.enum(['webhook', 'github', 'gitlab']),
+  source: z.enum(HOOK_KINDS),
   // ── github (P2) ──
   event: z.string().optional(), // 'issues' | 'pull_request' | 'issue_comment'
   action: z.string().optional(), // 'opened' | 'synchronize' | 'created' | …

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { frameSchema } from '../envelope.js'
+import { HOOK_KINDS } from '../code-host.js'
 import { ErrorFrame } from './error.js'
 import { BindMatch, IntegrationChannel } from './integration.js'
 import { CronTarget } from './cron.js'
@@ -311,7 +312,7 @@ export type RcGithubRerequestResult = z.infer<typeof RcGithubRerequestResult>
 export const RcHookAssign = z
   .object({
     hookId: z.string().uuid(),
-    kind: z.enum(['webhook', 'github', 'gitlab']),
+    kind: z.enum(HOOK_KINDS),
     agentId: z.string().uuid(),
     daemonId: z.string().uuid(), // the agent's CURRENT placement; re-sent on moves
     // R1/R2a rolling fields. Partial/absent remains decodable, but the relay

--- a/packages/web/src/components/console/IntegrationMarks.test.tsx
+++ b/packages/web/src/components/console/IntegrationMarks.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+/**
+ * The Agents list integration cluster.
+ *
+ * Two properties, both found wanting in live testing. The hook-kind marks carried a
+ * hover title ("GitLab events") that no other mark in this cluster has, so one icon in
+ * a row of otherwise silent icons popped a tooltip. And the mark itself was picked by a
+ * chain of equality tests ending in the generic webhook glyph, so an unmapped code host
+ * would render as a webhook — the same shape of bug that hid GitLab elsewhere.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { HOOK_KINDS } from '@agentconnect.md/protocol'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+// Real marks are anonymous <svg> paths; these stubs name which one rendered.
+vi.mock('@/components/marks', () => ({
+  GithubMark: () => <span data-mark="github" />,
+  GitlabMark: () => <span data-mark="gitlab" />,
+  PlatformMark: ({ platform }: { platform: string }) => <span data-mark={platform} />
+}))
+
+const { IntegrationMarks } = await import('./IntegrationMarks')
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+async function render(node: React.ReactNode) {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(node)
+  })
+  return host
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+})
+
+describe('IntegrationMarks', () => {
+  it('gives every hook kind its own mark', async () => {
+    // Walk the whole vocabulary: a new code host must not reuse the webhook glyph.
+    for (const kind of HOOK_KINDS) {
+      const node = await render(<IntegrationMarks integrations={[]} hookKinds={[kind]} />)
+      expect(node.querySelector(`[data-mark="${kind}"]`)).not.toBeNull()
+      if (root) await act(async () => root?.unmount())
+      host?.remove()
+    }
+  })
+
+  it('shows no hover title on any mark, hook kinds included', async () => {
+    const node = await render(
+      <IntegrationMarks integrations={[{ id: 'i1', platform: 'slack' }]} hookKinds={[...HOOK_KINDS]} />
+    )
+
+    expect(node.querySelectorAll('[title]')).toHaveLength(0)
+    // The cluster still rendered — an empty tree would pass the assertion above.
+    // Three marks fit; the platform sits first and the hook kinds fill the rest.
+    expect(node.querySelector('[data-mark="slack"]')).not.toBeNull()
+    expect(node.querySelectorAll('[data-mark]')).toHaveLength(3)
+  })
+})

--- a/packages/web/src/components/console/IntegrationMarks.tsx
+++ b/packages/web/src/components/console/IntegrationMarks.tsx
@@ -1,10 +1,22 @@
+import type { ReactNode } from 'react'
 import { GithubMark, GitlabMark, PlatformMark } from '@/components/marks'
 import type { HookKind } from '@/lib/api'
 
-const HOOK_KIND_TITLE: Record<HookKind, string> = {
-  github: 'GitHub events',
-  gitlab: 'GitLab events',
-  webhook: 'Inbound webhook'
+// Total over the hook-kind vocabulary, so a new code host is given its own mark here
+// instead of inheriting the generic webhook glyph. The webhook mark is the brand-pink
+// plate rather than a white glyph, which had nothing to sit on when unplated on dark.
+const HOOK_KIND_MARK: Record<HookKind, ReactNode> = {
+  github: (
+    <span className="flex h-[13px] w-[13px] items-center justify-center">
+      <GithubMark fillPct={90} />
+    </span>
+  ),
+  gitlab: (
+    <span className="flex h-[13px] w-[13px] items-center justify-center">
+      <GitlabMark fillPct={90} />
+    </span>
+  ),
+  webhook: <PlatformMark platform="webhook" />
 }
 
 interface IntegrationMarkSource {
@@ -37,25 +49,13 @@ export function IntegrationMarks({
             <PlatformMark platform={integration.platform} />
           </span>
         ))}
+        {/* No hover title: these sit beside platform marks, which carry none either. */}
         {visibleHookKinds.map((kind, index) => (
           <span
             key={kind}
             className={`imark h-[21px] w-[21px] ${visibleIntegrations.length + index === 0 ? '' : 'imark-overlap -ml-[7px]'}`}
-            title={HOOK_KIND_TITLE[kind]}
           >
-            {kind === 'github' ? (
-              <span className="flex h-[13px] w-[13px] items-center justify-center">
-                <GithubMark fillPct={90} />
-              </span>
-            ) : kind === 'gitlab' ? (
-              <span className="flex h-[13px] w-[13px] items-center justify-center">
-                <GitlabMark fillPct={90} />
-              </span>
-            ) : (
-              // The brand-pink webhook mark, not a white glyph on an inverted plate:
-              // unplated on dark, that glyph had nothing left to sit on.
-              <PlatformMark platform="webhook" />
-            )}
+            {HOOK_KIND_MARK[kind]}
           </span>
         ))}
       </span>

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import {
   agentDaemonLabel,
   agentLabel,
@@ -12,7 +12,8 @@ import {
   status,
   type Agent
 } from '@/lib/data'
-import { creatorLabel, fmtCost, fmtCountCompact, memberDisplayName } from '@/lib/api'
+import { creatorLabel, fmtCost, fmtCountCompact, memberDisplayName, type HookKind } from '@/lib/api'
+import { primaryHookKind } from '@/lib/session-trigger'
 import { amountToNumber } from '@/lib/amount'
 import { useConsoleData } from '@/lib/data-context'
 import { IntegrationMarks } from '@/components/console/IntegrationMarks'
@@ -27,6 +28,15 @@ import { useIsMobile } from '@/lib/use-is-mobile'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { AgentReachabilityOverview } from '@/components/console/AgentReachabilityOverview'
 import { useOnboardingRedirect } from '@/lib/use-onboarding-redirect'
+
+// The single mark a compact agent row shows for its inbound triggers. Total over the
+// hook-kind vocabulary, so a new code host is given a mark instead of falling through
+// to the generic webhook glyph the way an unmapped kind used to.
+const AGENT_HOOK_MARK: Record<HookKind, ReactNode> = {
+  github: <GithubMark />,
+  gitlab: <GitlabMark />,
+  webhook: <Icon name="webhook" size={14} color="var(--text-secondary)" />
+}
 
 // Two-letter avatar initials for a creator name — first letters of the first two
 // words, or the first two chars of a single token.
@@ -392,6 +402,7 @@ export default function AgentsView() {
               const s = status(effectiveAgentStatus(a, owning))
               const agentInts = integrations.filter((int) => int.agentId === a.id)
               const first = agentInts[0]
+              const primaryKind = primaryHookKind(a.hookKinds ?? [])
               const n24 = sessions24h(a.id)
               return (
                 <Link
@@ -433,15 +444,9 @@ export default function AgentsView() {
                     <span className="flex h-4 w-4 flex-none items-center justify-center">
                       <PlatformMark platform={first.platform} fillPct={100} />
                     </span>
-                  ) : (a.hookKinds ?? []).length > 0 ? (
+                  ) : primaryKind ? (
                     <span className="flex h-4 w-4 flex-none items-center justify-center">
-                      {(a.hookKinds ?? []).includes('github') ? (
-                        <GithubMark />
-                      ) : (a.hookKinds ?? []).includes('gitlab') ? (
-                        <GitlabMark />
-                      ) : (
-                        <Icon name="webhook" size={14} color="var(--text-secondary)" />
-                      )}
+                      {AGENT_HOOK_MARK[primaryKind]}
                     </span>
                   ) : null}
                   <span className="flex-none font-mono text-[14px] font-medium leading-normal text-(--text-primary) tabular-nums">

--- a/packages/web/src/components/console/views/SessionsView.gitlab.test.tsx
+++ b/packages/web/src/components/console/views/SessionsView.gitlab.test.tsx
@@ -13,6 +13,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Session } from '@/lib/data'
+import { HOOK_KIND_GROUP_LABEL, HOOK_TRIGGER_KINDS } from '@/lib/session-trigger'
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
@@ -188,5 +189,37 @@ describe('SessionsView, GitLab triggers', () => {
     )!
     await act(async () => option.click())
     expect(mocks.replace).toHaveBeenCalledWith('/acme/sessions?trigger=hook%3Agl-1')
+  })
+})
+
+/**
+ * The trigger menu is built by walking the hook-kind vocabulary, not by listing the
+ * hosts that exist today — the bug was a `switch` whose arms were written by hand, so a
+ * kind nobody had added an arm for was collected nowhere and vanished from the menu.
+ */
+describe('SessionsView, trigger groups per hook kind', () => {
+  it('offers one group per hook kind, code hosts before generic webhooks', async () => {
+    mocks.sessions = [gitlabSession]
+    mocks.triggers = HOOK_TRIGGER_KINDS.map((kind) => ({
+      value: `hook:${kind}-1`,
+      integration: 'hook',
+      name: `acme/${kind}`,
+      hookKind: kind,
+      githubRepoId: null
+    }))
+    await render()
+    await openFilterMenu('triggers')
+
+    const headers = Array.from(document.querySelectorAll('.fhdr')).map((node) => node.textContent)
+    // Every kind earns its own heading, in the vocabulary's display order.
+    expect(headers).toEqual(HOOK_TRIGGER_KINDS.map((kind) => HOOK_KIND_GROUP_LABEL[kind]))
+    // Each group holds exactly its own subscription — nothing pooled into one bucket.
+    for (const kind of HOOK_TRIGGER_KINDS) {
+      const group = Array.from(document.querySelectorAll('.fhdr')).find(
+        (node) => node.textContent === HOOK_KIND_GROUP_LABEL[kind]
+      )!.parentElement!
+      const labels = Array.from(group.querySelectorAll('button')).map((button) => button.textContent)
+      expect(labels).toEqual([`acme/${kind}`])
+    }
   })
 })

--- a/packages/web/src/components/console/views/SessionsView.tsx
+++ b/packages/web/src/components/console/views/SessionsView.tsx
@@ -20,12 +20,14 @@ import {
   type Agent,
   type Session
 } from '@/lib/data'
-import { fmtDate, memberDisplayName, type MemberDto, type SessionListFilters } from '@/lib/api'
+import { fmtDate, memberDisplayName, type HookKind, type MemberDto, type SessionListFilters } from '@/lib/api'
 import {
   githubRepoIdFromSessionTriggerFilter,
   sessionSenderLabel,
   sessionTriggerFilterValue,
   sessionTriggerKind,
+  HOOK_KIND_GROUP_LABEL,
+  HOOK_TRIGGER_KINDS,
   type SessionTriggerKind
 } from '@/lib/session-trigger'
 import { useConsoleData } from '@/lib/data-context'
@@ -284,29 +286,22 @@ export default function SessionsView() {
   // their CP-enriched source kind to keep each code host distinct from generic webhooks.
   const triggerAgentSet = new Map<string, Agent>()
   const peopleSet = new Map<string, { label: string; platform: string; member?: MemberDto }>()
-  const githubSet = new Map<string, string>()
-  const gitlabSet = new Map<string, string>()
-  const webhookSet = new Map<string, string>()
+  // One bucket per hook kind, keyed by the shared vocabulary rather than by hand — a
+  // hook trigger can no longer land in a bucket nobody collects, which is how GitLab
+  // sessions used to disappear from this menu instead of getting their own group.
+  const hookSets = new Map<HookKind, Map<string, string>>(HOOK_TRIGGER_KINDS.map((kind) => [kind, new Map()]))
   const cronSet = new Map<string, string>()
   for (const [triggeredBy, source] of triggerSources) {
     const label = sessionSenderLabel(triggeredBy, source.name, agentNameById, memberNameByIdentity, me)
-    switch (sessionTriggerKind({ triggeredBy, hookKind: source.hookKind }, agentById)) {
+    const kind = sessionTriggerKind({ triggeredBy, hookKind: source.hookKind }, agentById)
+    switch (kind) {
+      case null:
+        break
       case 'schedule': {
         const id = triggeredBy.slice(5)
         cronSet.set(triggeredBy, cronById.get(id)?.name?.trim() || `Schedule ${id.slice(0, 8)}`)
         break
       }
-      case 'github':
-        if (!githubSet.has(source.filterValue)) githubSet.set(source.filterValue, label)
-        break
-      // No per-project collapse: the CP indexes a numeric repo id for GitHub only,
-      // so a GitLab subscription filters by its own trigger value like a webhook.
-      case 'gitlab':
-        gitlabSet.set(triggeredBy, label)
-        break
-      case 'webhook':
-        webhookSet.set(triggeredBy, label)
-        break
       case 'agent': {
         const agent = agentById.get(triggeredBy)
         if (agent) triggerAgentSet.set(triggeredBy, agent)
@@ -318,6 +313,15 @@ export default function SessionsView() {
           platform: source.platform,
           member: memberByIdentity.get(triggeredBy)
         })
+        break
+      // Everything left is a hook kind — the arms above narrow it, so a new NON-hook
+      // trigger kind fails to compile here rather than being silently dropped.
+      default: {
+        // GitHub subscriptions collapse per repository through `filterValue`; every
+        // other kind, GitLab included, filters by its own raw trigger value.
+        const bucket = hookSets.get(kind)!
+        if (!bucket.has(source.filterValue)) bucket.set(source.filterValue, label)
+      }
     }
   }
   const catFace = (name: string) => <Icon name={name} size={15} color="var(--text-tertiary)" />
@@ -422,51 +426,41 @@ export default function SessionsView() {
       rightFace: <PlatformMark platform={p.platform} fillPct={100} />
     }))
     .sort(byLabel)
-  const triggerGithub: FilterOption[] = [...githubSet]
-    .map(([v, label]) => ({
-      v,
-      label,
-      kind: 'github' as const,
-      face: (
-        <span className="flex h-[15px] w-[15px] items-center justify-center">
-          <GithubMark color="var(--text-tertiary)" />
-        </span>
-      )
-    }))
-    .sort(byLabel)
-  const triggerGitlab: FilterOption[] = [...gitlabSet]
-    .map(([v, label]) => ({
-      v,
-      label,
-      kind: 'gitlab' as const,
-      face: (
-        <span className="flex h-[15px] w-[15px] items-center justify-center">
-          <GitlabMark />
-        </span>
-      )
-    }))
-    .sort(byLabel)
-  const triggerWebhooks: FilterOption[] = [...webhookSet]
-    .map(([v, label]) => ({ v, label, kind: 'webhook' as const, face: catFace('webhook') }))
-    .sort(byLabel)
+  // Total over the hook-kind vocabulary: a new code host has to be given a face here.
+  const hookTriggerFace: Record<HookKind, ReactNode> = {
+    github: (
+      <span className="flex h-[15px] w-[15px] items-center justify-center">
+        <GithubMark color="var(--text-tertiary)" />
+      </span>
+    ),
+    gitlab: (
+      <span className="flex h-[15px] w-[15px] items-center justify-center">
+        <GitlabMark />
+      </span>
+    ),
+    webhook: catFace('webhook')
+  }
+  // One group per hook kind in display order, code hosts before generic webhooks.
+  const hookTriggerGroups: FilterGroup[] = HOOK_TRIGGER_KINDS.map((kind) => ({
+    label: HOOK_KIND_GROUP_LABEL[kind],
+    options: [...hookSets.get(kind)!]
+      .map(([v, label]) => ({ v, label, kind, face: hookTriggerFace[kind] }))
+      .sort(byLabel)
+  }))
   const triggerScheds: FilterOption[] = [...cronSet]
     .map(([v, label]) => ({ v, label, kind: 'schedule' as const, face: catFace('timer') }))
     .sort(byLabel)
   const triggerGroups: FilterGroup[] = [
     { label: 'Agents', options: triggerAgents },
     { label: 'People', options: triggerPeople },
-    { label: 'GitHub', options: triggerGithub },
-    { label: 'GitLab', options: triggerGitlab },
-    { label: 'Webhooks', options: triggerWebhooks },
+    ...hookTriggerGroups,
     { label: 'Schedules', options: triggerScheds }
   ]
   const triggerFlat: FilterOption[] = [
     triggerAll,
     ...triggerAgents,
     ...triggerPeople,
-    ...triggerGithub,
-    ...triggerGitlab,
-    ...triggerWebhooks,
+    ...hookTriggerGroups.flatMap((group) => group.options),
     ...triggerScheds
   ]
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -17,6 +17,8 @@ import type {
   PlacementKindValue
 } from '@/lib/data'
 import { isSelfSender, lifecycleStatus, MOCK_MODE, placementValueOf, poolLabel } from '@/lib/data'
+import type { HookKind } from '@agentconnect.md/protocol'
+import { hookKindFromIntegration, hookSourceLabel } from '@/lib/session-trigger'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { withIconUrl } from '@/lib/agent-icon'
 import {
@@ -1926,7 +1928,8 @@ function sessionChannelLabel(
   platform: string,
   rawChannel: string,
   channelName: string | null,
-  triggeredByName: string | null
+  triggeredByName: string | null,
+  hookKind: HookKind | null | undefined
 ): string {
   // webchat's `channel` is the conversationId (a UUID) — never a human channel. Show the
   // "Playground" label (matching platName + the live playground session), and keep the raw
@@ -1936,7 +1939,8 @@ function sessionChannelLabel(
   // A headless webhook's `channel` is the hook id (and `thread` may be the delivery key),
   // so render the CP-enriched hook name when present and otherwise hide the raw UUID.
   const isHook = platform === 'hook'
-  const hookLabel = channelName?.trim() || 'Webhook'
+  // An unnamed hook still names its SOURCE — a GitLab delivery is "GitLab", not "Webhook".
+  const hookLabel = channelName?.trim() || hookSourceLabel(hookKind)
   // Name-first display: "#general" when the daemon resolved a channel name, or the
   // DM counterpart verbatim ("@Dana Reyes" — already @-prefixed by the daemon). A
   // Slack DM ("D…" im id) the daemon hasn't labeled yet falls back to the
@@ -1963,7 +1967,7 @@ export function sessionFromDto(d: SessionDto): Session {
   const isWebchat = platform === 'webchat'
   const isHook = platform === 'hook'
   const isDream = platform === 'dream'
-  const channel = sessionChannelLabel(platform, rawChannel, d.channelName, d.triggeredByName)
+  const channel = sessionChannelLabel(platform, rawChannel, d.channelName, d.triggeredByName, d.hookKind)
   const isSlackDm = platform === 'slack' && /^D/.test(rawChannel)
   const dmFallback = isSlackDm ? (d.triggeredByName ? `@${d.triggeredByName}` : 'DM') : null
   const user = isDream
@@ -1972,7 +1976,9 @@ export function sessionFromDto(d: SessionDto): Session {
       : d.triggeredBy === 'auto'
         ? 'Automatic'
         : 'Manual'
-    : d.triggeredByName || (isHook && d.triggeredBy?.startsWith('hook:') ? 'Webhook' : d.triggeredBy) || PLACEHOLDER
+    : d.triggeredByName ||
+      (isHook && d.triggeredBy?.startsWith('hook:') ? hookSourceLabel(d.hookKind) : d.triggeredBy) ||
+      PLACEHOLDER
   return {
     id: d.sessionId,
     title: d.title || `Session ${d.sessionId.slice(0, 8)}`,
@@ -2316,7 +2322,13 @@ export async function fetchSessionFacets(orgId?: string, filters: SessionListFil
     integrations: facets.integrations,
     channels: facets.channels.map((channel) => ({
       value: channel.value,
-      label: sessionChannelLabel(channel.platform, channel.value, channel.name, channel.triggeredByName),
+      label: sessionChannelLabel(
+        channel.platform,
+        channel.value,
+        channel.name,
+        channel.triggeredByName,
+        hookKindFromIntegration(channel.integration)
+      ),
       platform: channel.integration
     })),
     triggers: facets.triggers.map((trigger) => ({
@@ -3823,7 +3835,9 @@ export async function deleteIntegration(id: string): Promise<void> {
 
 // A hook definition row. `url` is the full public ingress URL (relay-pool based),
 // a capability URL the CP surfaces only to callers with edit rights.
-export type HookKind = 'webhook' | 'github' | 'gitlab'
+// The hook-kind vocabulary is the shared wire contract's, not a copy: a new code
+// host widens it there and every mapping over it in the console must be extended.
+export type { HookKind }
 export type GithubCommentFamily = 'issues' | 'pull_request'
 /** GitLab's own note families — the merge-request counterpart of a pull request. */
 export type GitlabCommentFamily = 'issues' | 'merge_request'

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -2,7 +2,8 @@
 // Ported from the AgentConnect design (static demo content for the console UI).
 
 import type { AgentIcon } from '@/lib/agent-icon'
-import type { DaemonSessionRetention, HookKind, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
+import { isCodeHostHookKind, type HookKind } from '@agentconnect.md/protocol'
+import type { DaemonSessionRetention, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { platformLabel } from '@/lib/platform-labels'
 import { randomUuid } from '@/lib/random-uuid'
@@ -2168,13 +2169,14 @@ export function platName(p: string): string {
   return p.charAt(0).toUpperCase() + p.slice(1)
 }
 
-/** A session's display integration. The code hosts are hook sources rather than
- * routing Platforms, so the CP supplies the stable hook kind explicitly — without
- * it a GitLab session would render as a generic webhook. */
+/** A session's display integration. Code hosts are hook sources rather than routing
+ * Platforms, so the CP supplies the stable hook kind explicitly — without it a GitLab
+ * session renders as a generic webhook. The promotion asks the shared vocabulary which
+ * kinds are code hosts instead of listing them, so no future host can miss it. */
 export function sessionPlatform(s: { platform: string; hookKind?: HookKind }): string {
   if (s.platform === 'playground') return 'webchat'
   if (s.platform !== 'hook') return s.platform
-  return s.hookKind === 'github' || s.hookKind === 'gitlab' ? s.hookKind : s.platform
+  return s.hookKind && isCodeHostHookKind(s.hookKind) ? s.hookKind : s.platform
 }
 
 /** Channel-cell identity (mark + label) for a session row. A headless schedule

--- a/packages/web/src/lib/session-trigger.test.ts
+++ b/packages/web/src/lib/session-trigger.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { CODE_HOST_PROVIDERS, GENERIC_HOOK_KIND, HOOK_KINDS, isCodeHostHookKind } from '@agentconnect.md/protocol'
 import {
   mergeSessionDetailUsage,
   sessionFromDetailDto,
@@ -14,7 +15,13 @@ import {
   sessionSenderLabel,
   sessionTranscriptAgentIds,
   sessionTriggerFilterValue,
-  sessionTriggerKind
+  sessionTriggerKind,
+  hookKindFromIntegration,
+  hookSourceLabel,
+  primaryHookKind,
+  HOOK_KIND_GROUP_LABEL,
+  HOOK_KIND_LABEL,
+  HOOK_TRIGGER_KINDS
 } from './session-trigger'
 
 const sessionDto = (overrides: Partial<SessionDto>): SessionDto => ({
@@ -408,5 +415,84 @@ describe('retention-GC purge mark (#485)', () => {
     } satisfies SessionDetailDto
 
     expect(sessionFromDetailDto(detail).contentPurgedAt).toBe('2026-08-04T09:00:00.000Z')
+  })
+})
+
+/**
+ * The session source taxonomy, walked over the WHOLE hook-kind vocabulary rather than
+ * the hosts that exist today. GitLab regressed because the console kept its own copy of
+ * the union and a code host could be left out of it: the row then folded into the
+ * generic webhook rendering and dropped out of the trigger filter entirely. Every
+ * assertion here is derived, so a new code host has to earn its own mapping.
+ */
+describe('hook-kind taxonomy', () => {
+  const agents = { has: () => false }
+
+  it('makes every hook kind its own trigger kind', () => {
+    for (const kind of HOOK_KINDS) {
+      expect(sessionTriggerKind({ triggeredBy: 'hook:h1', hookKind: kind }, agents)).toBe(kind)
+    }
+    // The generic kind is the mapping for an UNRESOLVED hook, not a catch-all for
+    // kinds nobody mapped — that distinction is the whole fix.
+    expect(sessionTriggerKind({ triggeredBy: 'hook:h1' }, agents)).toBe(GENERIC_HOOK_KIND)
+  })
+
+  it('gives every code-host kind a distinct, non-generic label, group and platform', () => {
+    for (const provider of CODE_HOST_PROVIDERS) {
+      expect(isCodeHostHookKind(provider)).toBe(true)
+      expect(HOOK_KIND_LABEL[provider]).not.toBe(HOOK_KIND_LABEL[GENERIC_HOOK_KIND])
+      expect(HOOK_KIND_GROUP_LABEL[provider]).not.toBe(HOOK_KIND_GROUP_LABEL[GENERIC_HOOK_KIND])
+      expect(sessionPlatform({ platform: 'hook', hookKind: provider })).toBe(provider)
+    }
+    // Only the generic kind keeps the raw routing platform.
+    expect(sessionPlatform({ platform: 'hook', hookKind: GENERIC_HOOK_KIND })).toBe('hook')
+    expect(new Set(HOOK_KINDS.map((kind) => HOOK_KIND_LABEL[kind])).size).toBe(HOOK_KINDS.length)
+    expect(new Set(HOOK_KINDS.map((kind) => HOOK_KIND_GROUP_LABEL[kind])).size).toBe(HOOK_KINDS.length)
+  })
+
+  it('keeps the hook-kind labels in step with the platform label chain', () => {
+    for (const kind of HOOK_KINDS) expect(HOOK_KIND_LABEL[kind]).toBe(platName(kind))
+  })
+
+  it('names an unnamed hook by its source', () => {
+    expect(hookSourceLabel('gitlab')).toBe('GitLab')
+    expect(hookSourceLabel('github')).toBe('GitHub')
+    // A hook the CP could not resolve carries no kind, so generic is all it can say.
+    expect(hookSourceLabel(null)).toBe('Webhook')
+  })
+
+  it('orders the trigger groups code hosts first and covers the vocabulary exactly', () => {
+    expect([...HOOK_TRIGGER_KINDS]).toEqual([...CODE_HOST_PROVIDERS, GENERIC_HOOK_KIND])
+    expect([...HOOK_TRIGGER_KINDS].sort()).toEqual([...HOOK_KINDS].sort())
+  })
+
+  it('reads a hook kind back off the integration facet the server promoted', () => {
+    for (const provider of CODE_HOST_PROVIDERS) expect(hookKindFromIntegration(provider)).toBe(provider)
+    expect(hookKindFromIntegration('hook')).toBe(GENERIC_HOOK_KIND)
+    expect(hookKindFromIntegration('slack')).toBeUndefined()
+  })
+
+  it('represents a mixed trigger set by its code host, never by the generic mark', () => {
+    for (const provider of CODE_HOST_PROVIDERS) {
+      expect(primaryHookKind([GENERIC_HOOK_KIND, provider])).toBe(provider)
+    }
+    expect(primaryHookKind([GENERIC_HOOK_KIND])).toBe(GENERIC_HOOK_KIND)
+    expect(primaryHookKind([])).toBeUndefined()
+  })
+
+  it('carries the kind onto the session row so a GitLab delivery never reads as a webhook', () => {
+    const row = sessionFromDto(
+      sessionDto({
+        sessionKey: { platform: 'hook', channel: 'gitlab-hook-1' },
+        triggeredBy: 'hook:gitlab-hook-1',
+        hookKind: 'gitlab'
+      })
+    )
+
+    expect(row.hookKind).toBe('gitlab')
+    expect(sessionPlatform(row)).toBe('gitlab')
+    // Negative control: both cells named the generic endpoint before the fix.
+    expect(row.channel).toBe('GitLab')
+    expect(row.user).toBe('GitLab')
   })
 })

--- a/packages/web/src/lib/session-trigger.ts
+++ b/packages/web/src/lib/session-trigger.ts
@@ -1,7 +1,50 @@
+import { CODE_HOST_PROVIDERS, GENERIC_HOOK_KIND, isCodeHostProvider, type HookKind } from '@agentconnect.md/protocol'
 import { isSelfSender } from './data'
-import type { HookKind } from './api'
 
-export type SessionTriggerKind = 'agent' | 'person' | 'github' | 'gitlab' | 'webhook' | 'schedule'
+/**
+ * Session source taxonomy. A hook kind IS a trigger kind, so the union is the three
+ * non-hook origins plus the shared hook-kind vocabulary rather than a hand-copied
+ * list — a new code host widens it here and every total mapping below (and every
+ * `Record<HookKind, …>` in the views) stops compiling until it is given an entry.
+ * That is the constraint GitLab was missing: it could be typed out of the union and
+ * silently inherit the generic webhook rendering.
+ */
+export type SessionTriggerKind = 'agent' | 'person' | 'schedule' | HookKind
+
+/** Hook kinds in console display order — every code host first, the generic endpoint last. */
+export const HOOK_TRIGGER_KINDS = [...CODE_HOST_PROVIDERS, GENERIC_HOOK_KIND] as const
+
+/** Trigger filter-group heading per hook kind. Total: a new kind gets its own group. */
+export const HOOK_KIND_GROUP_LABEL: Record<HookKind, string> = {
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  webhook: 'Webhooks'
+}
+
+/** Display name for a hook source the daemon left unnamed. Total, so no code host reads as "Webhook". */
+export const HOOK_KIND_LABEL: Record<HookKind, string> = {
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  webhook: 'Webhook'
+}
+
+/** The name to show for an unnamed hook source; an unresolvable hook is generic by definition. */
+export function hookSourceLabel(kind: HookKind | null | undefined): string {
+  return HOOK_KIND_LABEL[kind ?? GENERIC_HOOK_KIND]
+}
+
+/** The kind that stands for a set of them where only one mark fits — code hosts first,
+ *  so an agent's GitLab subscription is never represented by the generic webhook glyph. */
+export function primaryHookKind(kinds: readonly HookKind[]): HookKind | undefined {
+  return HOOK_TRIGGER_KINDS.find((kind) => kinds.includes(kind))
+}
+
+/** The hook kind an integration facet value names — the CP promotes each code host
+ *  out of the generic `hook` bucket, so only that one value needs translating. */
+export function hookKindFromIntegration(integration: string): HookKind | undefined {
+  if (integration === 'hook') return GENERIC_HOOK_KIND
+  return isCodeHostProvider(integration) ? integration : undefined
+}
 
 type IdLookup = { has(id: string): boolean }
 const GITHUB_REPO_TRIGGER_PREFIX = 'github-repo:'
@@ -90,7 +133,10 @@ export function sessionTriggerKind(
   const trigger = session.triggeredBy
   if (!trigger) return null
   if (trigger.startsWith('cron:')) return 'schedule'
-  if (trigger.startsWith('hook:')) return session.hookKind ?? 'webhook'
+  // A hook kind IS its own trigger kind. The generic kind is a mapping, never a
+  // fallback: only a hook the CP could not resolve (deleted definition, local row)
+  // arrives without one, and an unidentified hook source is generic by definition.
+  if (trigger.startsWith('hook:')) return session.hookKind ?? GENERIC_HOOK_KIND
   return agentIds.has(trigger) ? 'agent' : 'person'
 }
 
@@ -103,6 +149,6 @@ export function sessionSenderLabel(
 ): string {
   if (!sender) return fallback ?? '—'
   if (isSelfSender(sender, me)) return 'You'
-  if (sender.startsWith('hook:')) return fallback ?? 'Webhook'
+  if (sender.startsWith('hook:')) return fallback ?? HOOK_KIND_LABEL[GENERIC_HOOK_KIND]
   return agentNames.get(sender) ?? memberNames.get(sender) ?? fallback ?? sender
 }


### PR DESCRIPTION
## What was wrong

Found in live testing on a GitLab-connected org:

1. A GitLab-hook-triggered session showed its source as the generic **"Webhook"** whenever the hook had no name of its own to show (a hook reassigned to another agent loses its name for those historical rows).
2. The Agents list popped a **"GitLab events"** tooltip when hovering the integration mark — the only mark in that cluster with a hover title. Platform marks beside it carry none.

Chasing (1) turned up the real problem. The hook-kind vocabulary (`webhook | github | gitlab`) was hand-copied into every consumer — the wire frames, five DTO schemas, the repository port, and the console's own union — and each consumer classified a hook by writing the hosts out by hand. Nothing failed when a host was left out of a mapping: it just inherited the generic webhook arm. That is exactly how GitLab lost its trigger-filter group and its session mark earlier, and it is why GitHub needed the same set of fixes by hand months ago.

## The constraint

One source of truth, in the shared wire contract:

```ts
// packages/protocol/src/code-host.ts
export const GENERIC_HOOK_KIND = 'webhook'
export const HOOK_KINDS = [GENERIC_HOOK_KIND, ...CODE_HOST_PROVIDERS] as const
export type HookKind = (typeof HOOK_KINDS)[number]
export function isCodeHostHookKind(kind: HookKind): kind is CodeHostProvider
```

Every hand-written classification now reads it:

- **Promotion out of the generic bucket** — the session integration facet and the console's `sessionPlatform` ask `isCodeHostHookKind` instead of listing hosts, so a new host is promoted with no edit.
- **Per-kind values** — source label, trigger filter-group heading, filter face, agent-row mark and integration-cluster mark are `Record<HookKind, …>` mappings. A new host cannot compile until it has each one.
- **Bucketing** — the Sessions trigger menu builds one bucket per hook kind from the vocabulary and routes hook kinds through a narrowed `default` arm, rather than hand-written `case` arms that silently collected nothing.
- **Schemas** — `HookContext.source`, `RcHookAssign.kind`, and the four session/agent DTO fields build their `z.enum` from the same tuple. Member order is unchanged, so the wire and the generated OpenAPI document are identical.

`webhook` is now the mapping for the generic kind, and for a hook whose definition can no longer be resolved. It is never the fallback for an unmapped code-host kind.

**Verified by construction:** temporarily adding a third provider to `CODE_HOST_PROVIDERS` produced six type errors — the session projection's label map, the console's four mapping tables, and the persistence enum — and none anywhere else. Reverted before commit.

**Scope of the guarantee.** It covers the *presentation* taxonomy: nothing can render, label, mark, or group a code-host session as a generic webhook without failing type-check first. It does not yet cover the session *filter reader* — `SessionFilterQueryDto.integration`, `codeHostHookFilters`, `SessionFilterQuery`, and the facet SQL still name the two hosts by hand, so a third provider would be promoted into a facet the query would reject until those are extended. Making that side derived means reshaping the repository port and its SQL around a per-provider map, which is a change of its own rather than a rider on this one. No current hook kind is affected. Thanks to the reviewer for catching that the original wording claimed more than the diff delivers.

## Also fixed on the same taxonomy

- The Sessions channel and trigger cells name an unnamed hook by its **source** ("GitLab") instead of calling every kind a webhook. This is symptom (1).
- The hook-kind tooltip is gone, so the cluster is silent on hover like the platform marks next to it. This is symptom (2).
- The compact agent row picked its single mark with a chain of `includes()` tests ending in the webhook glyph; it now uses the vocabulary's display order.

Symptom (3) from the report — GitLab missing from the integration filter dropdown — is **already fixed on `main`** (#1375). The dropdown is derived from the server's facet list, which promotes each code host correctly, and the existing tests pin it. The live deployment predates that change. No code was needed here; the new tests cover the property from the other direction.

## Tests

Both sides walk the **whole** vocabulary rather than the two hosts that exist today, so they keep their value when a third arrives:

- Session projection: every code-host kind gets a distinct, non-generic facet; only the generic kind keeps the raw `hook` platform; a GitLab session carries `hookKind` on the row; an unnamed GitLab hook is labelled "GitLab", not "Webhook".
- Console: every hook kind is its own trigger kind; distinct labels, groups and platforms per code host; label parity with the platform-label chain; one filter group per kind in code-hosts-first order; the integration cluster renders a mark per kind and no hover title anywhere.
- Each carries a negative control for the pre-fix behaviour.

## Docs

`docs/designs/webhook-triggers-and-github-events.md` still said "Two hook kinds share this execution path" and listed structured GitLab event semantics as unsupported. Both now describe the derived vocabulary and the three kinds.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint`, `pnpm format:check` — clean
- `pnpm --filter @agentconnect.md/web test` — 174 files, 1942 tests
- control-plane `test:unit` — 175 files, 2009 tests
- control-plane `test:int` — 111 files, 1721 tests
- `pnpm --filter @agentconnect.md/protocol test` — 26 files, 441 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
