### PR TITLE
refactor(control-plane): key the session integration filter by code-host provider

### DIFF
--- a/packages/control-plane/src/http/routes/sessions.code-host-facets.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.code-host-facets.test.ts
@@ -10,7 +10,7 @@
  */
 import Fastify, { type FastifyInstance } from 'fastify'
 import { describe, expect, it, vi } from 'vitest'
-import { HOOK_KINDS, isCodeHostHookKind } from '@agentconnect.md/protocol'
+import { CODE_HOST_PROVIDERS, HOOK_KINDS, isCodeHostHookKind } from '@agentconnect.md/protocol'
 import type { HttpDeps } from '../deps.js'
 import type { SessionPageQuery, SessionPageRecord } from '../../persistence/ports.js'
 import { installZod } from '../plugins/zod.js'
@@ -98,6 +98,11 @@ function fakeDeps(pageSessions: ReturnType<typeof pageRow>[] = []) {
   return { deps, listFacets, listPage, listIdsForOrgKind }
 }
 
+/** The filter query the route handed the repository, as these assertions read it. */
+function filterQueryOf(listPage: { mock: { calls: unknown[][] } }) {
+  return listPage.mock.calls[0]?.[0] as { integration?: string; codeHostHookIds: Record<string, string[]> }
+}
+
 async function app(deps: HttpDeps): Promise<FastifyInstance> {
   const instance = Fastify()
   installZod(instance)
@@ -131,26 +136,33 @@ describe('session integration facets across code hosts', () => {
     expect(body.triggers.find((t) => t.hookKind === 'gitlab')?.githubRepoId).toBeNull()
   })
 
-  it('accepts gitlab as a filter value and hands the repository its own hook ids', async () => {
-    const { deps, listPage } = fakeDeps()
-    const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions?view=flat&integration=gitlab' })
+  // The read path is what the facet projection promises: a host it can EMIT must also
+  // be selectable. Walking the provider list pins both halves for every host at once —
+  // the query vocabulary accepting the value, and the filter resolving that host's ids.
+  it('accepts every code host as a filter value and hands each one its own hook ids', async () => {
+    const hookByProvider = new Map(hookRows.map((hook) => [hook.kind, hook.id]))
+    for (const provider of CODE_HOST_PROVIDERS) {
+      const { deps, listPage } = fakeDeps()
+      const res = await (await app(deps)).inject({ method: 'GET', url: `/sessions?view=flat&integration=${provider}` })
 
-    expect(res.statusCode).toBe(200)
-    expect(listPage.mock.calls[0]?.[0]).toMatchObject({ integration: 'gitlab', gitlabHookIds: [GITLAB_HOOK] })
-    // GitHub's ids are irrelevant to a gitlab filter, so they are never read.
-    expect(listPage.mock.calls[0]?.[0]).not.toHaveProperty('githubHookIds')
+      expect(res.statusCode).toBe(200)
+      const passed = filterQueryOf(listPage)
+      expect(passed.integration).toBe(provider)
+      // Exact, so another host's ids are never read for this filter.
+      expect(passed.codeHostHookIds).toEqual({ [provider]: [hookByProvider.get(provider)] })
+    }
   })
 
-  it('gives the generic hook filter both hosts to exclude', async () => {
+  it('gives the generic hook filter every host to exclude', async () => {
     const { deps, listPage } = fakeDeps()
     const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions?view=flat&integration=hook' })
 
     expect(res.statusCode).toBe(200)
-    expect(listPage.mock.calls[0]?.[0]).toMatchObject({
-      integration: 'hook',
-      githubHookIds: [GITHUB_HOOK],
-      gitlabHookIds: [GITLAB_HOOK]
-    })
+    const passed = filterQueryOf(listPage)
+    expect(passed.integration).toBe('hook')
+    // A promoted host missing here would be counted twice: once as its own, once as a webhook.
+    expect(Object.keys(passed.codeHostHookIds).sort()).toEqual([...CODE_HOST_PROVIDERS].sort())
+    expect(passed.codeHostHookIds).toMatchObject({ github: [GITHUB_HOOK], gitlab: [GITLAB_HOOK] })
   })
 
   it('resolves no code-host definitions for a filter that needs none', async () => {

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -20,7 +20,13 @@ import { AgentId, HookId, OrgId, SessionId } from '../../domain/ids.js'
 import { orgOf, ctxOf, denyNonOwner } from '../rbac.js'
 import { decodeConversationKey, encodeConversationKey } from '../conversation-key.js'
 import { canChangeSessionVisibility, canContinueSession, canView, canViewSession } from '../../authorization/policy.js'
-import { isCodeHostHookKind, originKindOf, type HookKind } from '@agentconnect.md/protocol'
+import {
+  CODE_HOST_PROVIDERS,
+  isCodeHostHookKind,
+  originKindOf,
+  type CodeHostProvider,
+  type HookKind
+} from '@agentconnect.md/protocol'
 import { makeSessionAccessResolver } from '../session-access.js'
 import { resolveContinuationHost } from '../session-continuation.js'
 import { Tag } from '../plugins/openapi.js'
@@ -53,16 +59,19 @@ import {
   SessionExternalAccessDto
 } from '../dto/index.js'
 
+const SESSION_PLATFORM_IDS = ['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'dream'] as const
+
 const SessionFilterQueryDto = z.object({
   // Repeatable: `?agentId=a` scopes to one agent's rows (unchanged), while
   // `?agentId=a&agentId=b` asks for the CONVERSATIONS both took part in and
   // returns each of their sessions in those threads. Fastify's querystring
   // parser hands repeated keys over as an array.
   agentId: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
-  platform: z.enum(['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'dream']).optional(),
-  integration: z
-    .enum(['slack', 'telegram', 'webchat', 'discord', 'feishu', 'hook', 'github', 'gitlab', 'dream'])
-    .optional(),
+  platform: z.enum(SESSION_PLATFORM_IDS).optional(),
+  // The integration axis is every routing platform plus each code host, which the facet
+  // projection promotes out of the generic hook bucket. Derived from the shared provider
+  // list, so a promoted host is selectable the moment it can be emitted.
+  integration: z.enum([...SESSION_PLATFORM_IDS, ...CODE_HOST_PROVIDERS]).optional(),
   channel: z.string().optional(),
   triggeredBy: z.string().optional(),
   githubRepoId: z
@@ -105,31 +114,34 @@ function requestedAgentIds(query: z.infer<typeof SessionFilterQueryDto>): string
 const HOOK_TRIGGER_PREFIX = 'hook:'
 const HookIdString = z.string().uuid()
 
-/** Which code-host hook definitions this request has to resolve. A repository
- *  filter is GitHub-only (the numeric repo id is GitHub's); otherwise each host's
- *  ids are read when the facet projection classifies everything, when that host is
- *  the requested integration, or when `hook` needs to exclude it. */
+/** Which code-host hook definitions this request has to resolve, keyed by provider. A
+ *  repository filter stays GitHub-only — the numeric repo id is GitHub's alone; otherwise
+ *  each host's ids are read when the facet projection classifies everything, when that
+ *  host is the requested integration, or when `hook` needs to exclude it. Iterating the
+ *  shared provider list is what keeps this seam level with the facet projection: a host
+ *  that can be emitted as a facet is resolved here too, so it can also be selected. */
 async function codeHostHookFilters(
   deps: HttpDeps,
   orgId: OrgId,
   query: z.infer<typeof SessionFilterQueryDto>,
   classifyAll: boolean
-): Promise<{ githubHookIds: HookId[]; gitlabHookIds: HookId[]; repoHookIds?: HookId[] }> {
+): Promise<{ codeHostHookIds: Partial<Record<CodeHostProvider, HookId[]>>; repoHookIds?: HookId[] }> {
   if (query.githubRepoId) {
     const githubHooks = await deps.repos.hook.listForOrgKind(orgId, 'github')
     return {
-      githubHookIds: githubHooks.map((hook) => hook.id),
-      gitlabHookIds: [],
+      codeHostHookIds: { github: githubHooks.map((hook) => hook.id) },
       repoHookIds: githubHooks.filter((hook) => hook.repoId?.toString() === query.githubRepoId).map((hook) => hook.id)
     }
   }
-  const wanted = (kind: 'github' | 'gitlab') =>
-    classifyAll || query.integration === kind || query.integration === 'hook'
-  const [githubHookIds, gitlabHookIds] = await Promise.all([
-    wanted('github') ? deps.repos.hook.listIdsForOrgKind(orgId, 'github') : Promise.resolve([]),
-    wanted('gitlab') ? deps.repos.hook.listIdsForOrgKind(orgId, 'gitlab') : Promise.resolve([])
-  ])
-  return { githubHookIds, gitlabHookIds }
+  const wanted = (provider: CodeHostProvider) =>
+    classifyAll || query.integration === provider || query.integration === 'hook'
+  const codeHostHookIds: Partial<Record<CodeHostProvider, HookId[]>> = {}
+  await Promise.all(
+    CODE_HOST_PROVIDERS.filter(wanted).map(async (provider) => {
+      codeHostHookIds[provider] = await deps.repos.hook.listIdsForOrgKind(orgId, provider)
+    })
+  )
+  return { codeHostHookIds }
 }
 
 function hookIdForSession(s: HookSessionRow): string | null {
@@ -606,12 +618,7 @@ export function sessionRoutes(deps: HttpDeps) {
         if (requested.some((id) => !new Set<string>(orgAgentIds).has(id))) {
           return { agents: [], agentNames: {}, integrations: [], channels: [], triggers: [] }
         }
-        const { githubHookIds, gitlabHookIds, repoHookIds } = await codeHostHookFilters(
-          deps,
-          orgOf(req),
-          req.query,
-          true
-        )
+        const { codeHostHookIds, repoHookIds } = await codeHostHookFilters(deps, orgOf(req), req.query, true)
         // A multi-agent request narrows to the qualifying CONVERSATIONS and then
         // reads facets off every member row the caller can see, rather than only
         // the selected agents' rows: a facet answers "what else can I narrow by",
@@ -624,8 +631,7 @@ export function sessionRoutes(deps: HttpDeps) {
           ...(req.query.integration ? { integration: req.query.integration } : {}),
           ...(req.query.channel ? { channel: req.query.channel } : {}),
           ...(req.query.triggeredBy ? { triggeredBy: req.query.triggeredBy } : {}),
-          githubHookIds,
-          gitlabHookIds,
+          codeHostHookIds,
           ...(repoHookIds ? { hookTriggerIds: repoHookIds } : {})
         }
         // Each facet drops its own active filter, so its external-audience
@@ -698,12 +704,7 @@ export function sessionRoutes(deps: HttpDeps) {
 
         // Each code host is a semantic subtype of hook sessions. Resolve definitions
         // only when integration classification or a repository-wide trigger filter needs them.
-        const { githubHookIds, gitlabHookIds, repoHookIds } = await codeHostHookFilters(
-          deps,
-          orgOf(req),
-          req.query,
-          false
-        )
+        const { codeHostHookIds, repoHookIds } = await codeHostHookFilters(deps, orgOf(req), req.query, false)
         // Two or more selected agents ask for the threads they SHARE. The rows stay
         // scoped to those agents (`agentIds`), so `?agentId=a` keeps returning
         // exactly what it always did. Every branch below reads this one binding —
@@ -723,8 +724,7 @@ export function sessionRoutes(deps: HttpDeps) {
           ...(req.query.integration ? { integration: req.query.integration } : {}),
           ...(req.query.channel ? { channel: req.query.channel } : {}),
           ...(req.query.triggeredBy ? { triggeredBy: req.query.triggeredBy } : {}),
-          ...(githubHookIds.length > 0 ? { githubHookIds } : {}),
-          ...(gitlabHookIds.length > 0 ? { gitlabHookIds } : {}),
+          ...(Object.keys(codeHostHookIds).length > 0 ? { codeHostHookIds } : {}),
           ...(repoHookIds ? { hookTriggerIds: repoHookIds } : {}),
           ...(cursor ? { cursor } : {}),
           limit: req.query.limit,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -34,6 +34,7 @@ import type {
   CodeHostReviewOpOutcome,
   CodeHostReviewOpState,
   CodeHostReviewState,
+  CodeHostProvider,
   HookKind
 } from '@agentconnect.md/protocol'
 import type {
@@ -1212,12 +1213,12 @@ export interface SessionQuery {
 }
 
 export interface SessionFilterQuery extends SessionQuery {
-  integration?: Platform | 'github' | 'gitlab'
+  integration?: Platform | CodeHostProvider
   triggeredBy?: string
-  /** Code-host hook ids, per host: each one is promoted out of the generic hook
-   *  bucket into its own integration, and `integration: 'hook'` excludes them all. */
-  githubHookIds?: HookId[]
-  gitlabHookIds?: HookId[]
+  /** Code-host hook ids keyed by provider: each provider is promoted out of the generic
+   *  hook bucket into its own integration, and `integration: 'hook'` excludes them all.
+   *  Keyed rather than one field per host, so a new provider needs no new field here. */
+  codeHostHookIds?: Partial<Record<CodeHostProvider, HookId[]>>
   hookTriggerIds?: HookId[]
   /** Agents whose sessions count as conversation MEMBERS, when the caller may see
    *  more than the filter returns. Absent ⇒ `agentIds`, i.e. membership and row

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -5,7 +5,12 @@
  * `sessionId`, advancing `phase` and keeping the latest `link`/`summary`; the
  * `end` phase stamps `endedAt`. The launch tie (`launchId`) is set on create.
  */
-import type { Platform } from '@agentconnect.md/protocol'
+import {
+  CODE_HOST_PROVIDERS,
+  isCodeHostProvider,
+  type CodeHostProvider,
+  type Platform
+} from '@agentconnect.md/protocol'
 import {
   Prisma,
   type ExternalScope,
@@ -244,15 +249,16 @@ function genericHookSql(codeHostHookIds: string[], a: Prisma.Sql = S): Prisma.Sq
 }
 
 /** Every promoted code-host hook id, in one list, for the generic-hook exclusion. */
-function codeHostHookIds(q: Pick<SessionFilterQuery, 'githubHookIds' | 'gitlabHookIds'>): string[] {
-  return [...(q.githubHookIds ?? []), ...(q.gitlabHookIds ?? [])]
+function allCodeHostHookIds(q: Pick<SessionFilterQuery, 'codeHostHookIds'>): string[] {
+  return CODE_HOST_PROVIDERS.flatMap((provider) => q.codeHostHookIds?.[provider] ?? [])
 }
 
 function integrationSql(q: SessionFilterQuery, a: Prisma.Sql = S): Prisma.Sql | null {
   if (!q.integration) return null
-  if (q.integration === 'github') return codeHostHookSql(q.githubHookIds ?? [], a)
-  if (q.integration === 'gitlab') return codeHostHookSql(q.gitlabHookIds ?? [], a)
-  if (q.integration === 'hook') return genericHookSql(codeHostHookIds(q), a)
+  // Each code host reads its own promoted ids; asking the shared provider list means a
+  // new host is filterable here without an arm of its own.
+  if (isCodeHostProvider(q.integration)) return codeHostHookSql(q.codeHostHookIds?.[q.integration] ?? [], a)
+  if (q.integration === 'hook') return genericHookSql(allCodeHostHookIds(q), a)
   return platformSql(q.integration, a)
 }
 
@@ -315,12 +321,14 @@ function pageWhereSql(
   return Prisma.sql`WHERE ${Prisma.join(filters, ' AND ')}`
 }
 
-function integrationFacetSql(githubHookIds: string[], gitlabHookIds: string[]): Prisma.Sql {
-  if (githubHookIds.length === 0 && gitlabHookIds.length === 0) return Prisma.sql`COALESCE(s."platform", 'slack')`
-  const arms = [
-    ...(githubHookIds.length > 0 ? [Prisma.sql`WHEN ${codeHostHookSql(githubHookIds)} THEN 'github'`] : []),
-    ...(gitlabHookIds.length > 0 ? [Prisma.sql`WHEN ${codeHostHookSql(gitlabHookIds)} THEN 'gitlab'`] : [])
-  ]
+/** One CASE arm per code host that has promoted ids, built from the shared provider
+ *  list so a new host projects its own facet value without an arm written by hand. */
+function integrationFacetSql(codeHostHookIds: Partial<Record<CodeHostProvider, string[]>>): Prisma.Sql {
+  const arms = CODE_HOST_PROVIDERS.flatMap((provider) => {
+    const ids = codeHostHookIds[provider] ?? []
+    return ids.length > 0 ? [Prisma.sql`WHEN ${codeHostHookSql(ids)} THEN ${provider}`] : []
+  })
+  if (arms.length === 0) return Prisma.sql`COALESCE(s."platform", 'slack')`
   return Prisma.sql`
     CASE
       ${Prisma.join(arms, ' ')}
@@ -1191,7 +1199,7 @@ export class PgSessionRepo implements SessionRepo {
     delete triggerQuery.triggeredBy
     delete triggerQuery.hookTriggerIds
 
-    const integrationFacet = integrationFacetSql(q.githubHookIds ?? [], q.gitlabHookIds ?? [])
+    const integrationFacet = integrationFacetSql(q.codeHostHookIds ?? {})
     const [agents, integrations, channels, triggers] = await Promise.all([
       this.db.$queryRaw<SessionAgentFacetDbRow[]>(Prisma.sql`
         SELECT DISTINCT s."agentId"


### PR DESCRIPTION
Follow-up to #1440, closing the asymmetry a reviewer caught there.

## The gap

#1440 made the session source taxonomy derive from `CODE_HOST_PROVIDERS`, and the facet projection now promotes **any** code host out of the generic hook bucket automatically. The filter **read** path did not keep up — it still named the two hosts by hand in four places. So a third provider would be *emitted* as a facet and offered in the console's integration dropdown, and then rejected by the very query that selecting it produces, or silently treated as a routing platform.

Put simply: the write side could describe a host the read side could not serve.

## The change

The read path iterates the shared provider list end to end:

| Seam | Before | After |
| --- | --- | --- |
| `SessionFilterQueryDto.integration` | nine string literals | routing platforms `+ ...CODE_HOST_PROVIDERS` |
| `codeHostHookFilters` | `wanted('github')` / `wanted('gitlab')`, two return fields | iterates providers, returns one keyed map |
| `SessionFilterQuery` | `githubHookIds` / `gitlabHookIds` | `codeHostHookIds?: Partial<Record<CodeHostProvider, HookId[]>>` |
| `integrationSql` | one `===` arm per host | `isCodeHostProvider(q.integration)` |
| `integrationFacetSql` | one hand-written CASE arm per host | one arm per provider that has ids |

`githubRepoId` deliberately stays GitHub-specific — the numeric repository-id collapse really is GitHub's alone, so a repository filter still resolves that one host.

**This is a shape change, not a behavior change.** GitHub and GitLab resolve, filter, exclude, and project exactly as before.

## Proving the gate

Temporarily adding a third provider to `CODE_HOST_PROVIDERS`:

- the filter read path **compiles and serves it with no edit** — query vocabulary, hook resolution, `WHERE` predicate, and facet CASE arm all pick it up;
- the only errors left are the two places a human must act anyway: the display label map in the session projection (`sessions.ts`), and the Prisma enum in `hook.repo.ts`, which is really "this kind needs a migration";
- the console's five presentation maps from #1440 still fail too, as intended.

Nothing degrades silently, which was the requirement. Experiment reverted before commit.

## Tests

The two route tests that asserted on the old field names now walk the provider list, so they cover every host at once rather than the two that exist today:

- every code host is accepted as a filter value and handed exactly its own ids (exact match, so another host's ids are never read for that filter);
- the generic `hook` filter receives every promoted host to exclude — a host missing there would be counted twice, once as itself and once as a webhook.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint`, `pnpm format:check` — clean
- control-plane `test:unit` — 175 files, 2009 tests
- control-plane `test:int` — 111 files, 1721 tests, run against the exact committed tree
- `pnpm --filter @agentconnect.md/web test` — 174 files, 1942 tests

One note for the record: an earlier integration run showed 7 failures that were entirely an artifact of running the third-provider experiment concurrently, which made Postgres reject an enum value that has no migration. Re-run on a clean tree, everything passes; the numbers above are from clean runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
