### PR TITLE
refactor(web): let the group chip be the GitLab profile link

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -1542,12 +1542,14 @@ administers — the shape the GitHub card already has. It shows:
 - connected GitLab username and GitLab.com host;
 - OAuth state: connected, reconnect required, or disconnected;
 - the organization's bots, one row per AGENT — its icon and name linking to
-  it, then a pair for each top-level group it reaches: the group, the
-  `@username` there linking to that GitLab profile, and that account's health.
-  An account cannot cross a top-level group, so an agent spanning two owns two
-  accounts; that is one bot with two faces, not two bots, and the row reads
-  that way. A healthy account is named and not badged — only trouble and
-  departure are worth saying;
+  that agent's page, then a chip for each top-level group it reaches, which is
+  itself the link to the account's GitLab profile there, followed by that
+  account's health. The generated username is not shown: it is long, and
+  unreadable beside a name people actually read, so it lives in the chip's
+  tooltip and accessible label instead. An account cannot cross a top-level
+  group, so an agent spanning two owns two accounts; that is one bot with two
+  faces, not two bots, and the row reads that way. A healthy account is named
+  and not badged — only trouble and departure are worth saying;
 - per-bot actions in the same compact controls the messaging rows use: repair,
   which re-runs convergence on each project the bot holds, and taking that
   administration over, offered only where it has actually been lost — the

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -297,7 +297,8 @@ describe('GitlabCard', () => {
     expect(row.textContent).toContain('GitLab pilot')
     expect(row.querySelector('[data-agent-icon-glyph]')).toBeTruthy()
     const toAgent = row.querySelector('a[href^="/agents/"]') as HTMLAnchorElement
-    expect(toAgent.getAttribute('href')).toBe('/agents/agent-1?tab=config')
+    // The agent's own page, not one of its tabs.
+    expect(toAgent.getAttribute('href')).toBe('/agents/agent-1')
     expect(host.textContent).not.toContain('Connect GitLab')
   })
 
@@ -314,9 +315,10 @@ describe('GitlabCard', () => {
     const pairs = [...row.querySelectorAll('[data-gitlab-account]')]
     expect(pairs).toHaveLength(2)
     expect(pairs[0]!.textContent).toContain('example-group')
-    expect(pairs[0]!.textContent).toContain('@gitlab-pilot-5b350c0aeba7-2bivoj')
     expect(pairs[1]!.textContent).toContain('other-group')
-    expect(pairs[1]!.textContent).toContain('@gitlab-pilot-5b350c0aeba7-rwzj7')
+    // The generated handle is not shown: it is long, and unreadable beside a name people read.
+    expect(row.textContent).not.toContain('gitlab-pilot-5b350c0aeba7-2bivoj')
+    expect(row.textContent).not.toContain('gitlab-pilot-5b350c0aeba7-rwzj7')
     // One agent, so its name appears once rather than once per account.
     expect(row.querySelectorAll('a[href^="/agents/"]')).toHaveLength(1)
   })
@@ -343,7 +345,7 @@ describe('GitlabCard', () => {
     expect(botRow('agent-2')).toBeTruthy()
   })
 
-  it('links each pair’s handle to its GitLab profile, in a tab that cannot reach back', async () => {
+  it('makes each group chip the link to that account’s profile, in a tab that cannot reach back', async () => {
     mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
     mocks.fetchProjects.mockResolvedValue([BINDING, BINDING_TWO])
     roster = [BOT, BOT_OTHER_GROUP]
@@ -354,8 +356,23 @@ describe('GitlabCard', () => {
       'https://gitlab.com/gitlab-pilot-5b350c0aeba7-2bivoj',
       'https://gitlab.com/gitlab-pilot-5b350c0aeba7-rwzj7'
     ])
+    // The chip carries the group as its text, and the handle where it can still be read or copied.
+    expect(links[0]!.textContent).toBe('example-group')
+    expect(links[0]!.getAttribute('title')).toBe('@gitlab-pilot-5b350c0aeba7-2bivoj')
+    expect(links[0]!.getAttribute('aria-label')).toContain('@gitlab-pilot-5b350c0aeba7-2bivoj')
     expect(links.every((link) => link.getAttribute('target') === '_blank')).toBe(true)
     expect(links.every((link) => link.getAttribute('rel') === 'noopener noreferrer')).toBe(true)
+  })
+
+  it('leaves the chip unlinked, but still named, before the account exists on GitLab', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    roster = [{ ...BOT, userId: null, bindingIds: [] }]
+    await render()
+
+    const row = botRow('agent-1')
+    expect(row.querySelector('a[href^="https://gitlab.com/"]')).toBeNull()
+    expect(row.textContent).toContain('example-group')
+    expect(row.querySelector('[title="@gitlab-pilot-5b350c0aeba7-2bivoj"]')).toBeTruthy()
   })
 
   it('names no project under a bot: projects are managed where they are used', async () => {

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -587,7 +587,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                 <div className="flex min-w-0 items-center gap-[10px]">
                   {/* The bot IS an agent: its face and its name lead back to that agent's page. */}
                   <Link
-                    href={orgPath(`/agents/${encodeURIComponent(row.agentId)}?tab=config`)}
+                    href={orgPath(`/agents/${encodeURIComponent(row.agentId)}`)}
                     title={`Open ${name}`}
                     className="flex min-w-0 flex-none items-center gap-[10px] no-underline"
                   >
@@ -601,28 +601,33 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                   {/* One pair per top-level group the agent reaches: where, who it is there, how it is. */}
                   <div className="flex min-w-0 flex-wrap items-center gap-x-[10px] gap-y-[4px]">
                     {row.accounts.map((account) => {
+                      const group = account.rootGroupPath ?? `group ${account.rootGroupId}`
                       return (
                         <span
                           key={account.id}
                           data-gitlab-account={account.username}
                           className="inline-flex min-w-0 items-center gap-[6px]"
                         >
-                          <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">
-                            {account.rootGroupPath ?? `group ${account.rootGroupId}`}
-                          </span>
-                          {/* The username is deterministic, so the profile links only once the account exists. */}
+                          {/* The group IS the link: a generated handle is long, and unreadable next to
+                              a name people do read. It stays reachable by tooltip and to a screen reader.
+                              The handle is deterministic, so it links only once the account exists. */}
                           {account.userId ? (
                             <a
                               href={gitlabProfileUrl(account.username)}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="mono min-w-0 truncate text-[11.5px] text-(--text-tertiary) hover:underline"
+                              title={`@${account.username}`}
+                              aria-label={`${group} — @${account.username} on GitLab`}
+                              className="badge flex-none bg-(--surface-active) text-(--text-tertiary) no-underline hover:underline"
                             >
-                              @{account.username}
+                              {group}
                             </a>
                           ) : (
-                            <span className="mono min-w-0 truncate text-[11.5px] text-(--text-tertiary)">
-                              @{account.username}
+                            <span
+                              title={`@${account.username}`}
+                              className="badge flex-none bg-(--surface-active) text-(--text-tertiary)"
+                            >
+                              {group}
                             </span>
                           )}
                           {/* A healthy bot says nothing; only trouble and departure are worth a badge. */}


### PR DESCRIPTION
## What

Two things about the bot row after living with it.

**The group chip is the link now.** Each pair printed the whole generated username beside its group. That name is long by construction — agent slug, agent suffix, group suffix — and it sat right next to the agent name people actually read, so a row spanning two groups was mostly machine text. The chip that says *where* the account lives is now the link that goes *to* it. The username has not been thrown away: it is the chip's `title` and part of its `aria-label`, so it can still be read, copied, or spoken, just not occupying the row. A chip whose account does not exist on GitLab yet stays unlinked and still names its group.

**The row opens the agent, not a tab of it.** The face and name pointed at `?tab=config`. They now open `/agents/:id` and let the agent page decide what to show.

## Tests

The chip's `href` is the GitLab profile URL, its text is the group, and the handle is present as tooltip and accessible label while absent from the row's visible text; the unlinked-but-named case before the account exists; the bot link's `href` carries no `?tab=`.

Verified: root `pnpm typecheck`; web 1932 passed (42 in the card suite); `pnpm lint`; `pnpm format:check`.

Section 18.1 described the pair as carrying a linked `@username`, so it is updated in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
