### PR TITLE
feat(control-plane): snapshot the hook kind on the session row

### DIFF
--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -22,8 +22,19 @@ the per-kind marks and labels — stops type-checking until it is extended:
 Only `webhook` is generic. Every code-host kind is promoted out of the generic
 bucket wherever a session is classified, so a code-host session is never
 filtered, marked, or labelled as a plain webhook. `webhook` is the mapping for
-the generic kind and for a hook whose definition can no longer be resolved — it
-is never the fallback for a kind nobody mapped.
+the generic kind and for a hook whose source cannot be determined at all — it is
+never the fallback for a kind nobody mapped.
+
+A session's kind is **snapshotted onto the session row at creation**
+(`session_meta."hookKind"`), beside the trigger id and display names it already
+records. A hook definition can be deleted and recreated, which leaves past
+sessions pointing at an id that resolves to nothing; reading the kind live would
+then rewrite their history as generic webhooks. Every read — display label,
+integration facet, and the filter predicate — prefers the snapshot and consults
+the live definition only when a row has none. Rows written before the column
+have no snapshot and keep resolving through the live hook exactly as before;
+they are deliberately **not** backfilled, so a code-host session that predates
+the column still degrades to the generic rendering once its hook is gone.
 
 For a numbered GitHub thread, `GithubPoster` owns the ordinary reply comment and
 publishes only the completed ACP final answer. A formal pull-request review is a

--- a/packages/control-plane/prisma/migrations/20260911000000_session_meta_hook_kind/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260911000000_session_meta_hook_kind/migration.sql
@@ -1,0 +1,4 @@
+-- Trigger-identity snapshot: the hook kind a session fired from, frozen at creation.
+-- Additive and nullable, with no backfill: existing rows keep resolving through the
+-- live hook definition, so this changes nothing until new sessions are written.
+ALTER TABLE "session_meta" ADD COLUMN "hookKind" "HookKind";

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1095,6 +1095,11 @@ model SessionMeta {
   triggeredBy         String?
   channelName         String?
   triggeredByName     String?
+  // Trigger-identity snapshot, frozen at creation beside triggeredBy/triggeredByName: the
+  // KIND of hook this session fired from. The hook row can be deleted and recreated, and
+  // without this the session would silently degrade to the generic webhook rendering.
+  // Null on rows written before this column — those still resolve through the live hook.
+  hookKind            HookKind?
   threadUrl           String?             @db.Text
   // ── execution-config snapshot (what the session actually ran with) ──
   // Daemon-reported via event/session (session override ?? agent config at run

--- a/packages/control-plane/src/http/routes/sessions.code-host-facets.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.code-host-facets.test.ts
@@ -61,8 +61,14 @@ const hookRows = [
 ]
 
 /** A hook session as the LIST projection reads it — the visibility trio the row DTO requires. */
-function pageRow(hookId: string, id: string) {
-  return { ...hookSession(hookId, id), visibility: 'org', externalProvider: null, externalResolution: null }
+function pageRow(hookId: string, id: string, hookKind: string | null = null) {
+  return {
+    ...hookSession(hookId, id),
+    hookKind,
+    visibility: 'org',
+    externalProvider: null,
+    externalResolution: null
+  }
 }
 
 function fakeDeps(pageSessions: ReturnType<typeof pageRow>[] = []) {
@@ -202,6 +208,26 @@ describe('session integration facets across code hosts', () => {
     const [session] = (res.json() as { sessions: Array<{ hookKind: string; triggeredByName: string }> }).sessions
     expect(session?.hookKind).toBe('gitlab')
     expect(session?.triggeredByName).toBe('acme/platform')
+  })
+
+  it('lets the row own snapshot outrank the hook definition it points at', async () => {
+    // A hook can be deleted and recreated, so the definition a session points at is not
+    // evidence about what fired it. The creation-time snapshot is, and it wins.
+    const { deps } = fakeDeps([pageRow(WEBHOOK, 'sess-snapshot', 'gitlab')])
+    const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions?view=flat' })
+
+    expect(res.statusCode).toBe(200)
+    const [session] = (res.json() as { sessions: Array<{ hookKind: string }> }).sessions
+    expect(session?.hookKind).toBe('gitlab')
+  })
+
+  it('falls back to the live hook only for a row with no snapshot', async () => {
+    const { deps } = fakeDeps([pageRow(GITLAB_HOOK, 'sess-legacy', null)])
+    const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions?view=flat' })
+
+    expect(res.statusCode).toBe(200)
+    const [session] = (res.json() as { sessions: Array<{ hookKind: string }> }).sessions
+    expect(session?.hookKind).toBe('gitlab')
   })
 
   it('names the source of an unnamed hook instead of calling every kind a webhook', async () => {

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -94,7 +94,7 @@ const SessionQueryDto = SessionFilterQueryDto.extend({
 type SessionCursor = { activityMs: number; startedMs: number; id: string }
 type SessionPageRow = Awaited<ReturnType<HttpDeps['repos']['session']['listPage']>>['sessions'][number]
 type SessionFacetIndex = Awaited<ReturnType<HttpDeps['repos']['session']['listFacets']>>
-type HookSessionRow = Pick<SessionPageRow, 'agentId' | 'platform' | 'channel' | 'triggeredBy'>
+type HookSessionRow = Pick<SessionPageRow, 'agentId' | 'platform' | 'channel' | 'triggeredBy' | 'hookKind'>
 type HookSessionMetadata = {
   agentId: string | null
   kind: HookKind
@@ -221,6 +221,14 @@ function decodeSessionCursor(raw: string): SessionCursor | null {
   }
 }
 
+/** A hook session's own source kind. The creation-time snapshot is authoritative — the
+ *  definition it fired from may have been deleted since, and a session's history must not
+ *  change when that happens. Only rows written before the snapshot existed read the live
+ *  hook, and a hook that no longer resolves leaves them with no kind at all. */
+function sessionHookKind(s: HookSessionRow, hook: HookSessionMetadata | undefined): HookKind | null {
+  return s.hookKind ?? hook?.kind ?? null
+}
+
 /** A hook session's integration facet. EVERY code host is promoted out of the generic
  *  hook bucket so each gets a first-class entry the console can filter by; only the
  *  generic kind keeps the raw `hook` platform. The predicate is derived from the shared
@@ -229,7 +237,8 @@ function decodeSessionCursor(raw: string): SessionCursor | null {
 function sessionIntegration(s: HookSessionRow, hook: HookSessionMetadata | undefined): string {
   const platform = s.platform ?? 'slack'
   if (platform !== 'hook') return platform
-  return hook && isCodeHostHookKind(hook.kind) ? hook.kind : platform
+  const kind = sessionHookKind(s, hook)
+  return kind && isCodeHostHookKind(kind) ? kind : platform
 }
 
 /** Display name for a hook source with no name of its own. TOTAL over the hook-kind
@@ -244,8 +253,9 @@ function sessionDisplayMetadata(
   // Hook kind remains valid after reassignment, but the current name only
   // describes historical rows while the hook still belongs to the same agent.
   const hookName = hook?.agentId === s.agentId ? hook.name : undefined
-  // An unresolvable hook has no kind to name, so it stays generic.
-  const sourceLabel = hook ? HOOK_KIND_LABEL[hook.kind] : HOOK_KIND_LABEL.webhook
+  // A row with neither a snapshot nor a resolvable hook has no kind to name, so it stays generic.
+  const kind = sessionHookKind(s, hook)
+  const sourceLabel = HOOK_KIND_LABEL[kind ?? 'webhook']
   return {
     channelName: s.platform === 'hook' ? (hookName ?? s.channelName ?? null) : (s.channelName ?? null),
     triggeredByName: s.triggeredBy?.startsWith(HOOK_TRIGGER_PREFIX)
@@ -311,7 +321,7 @@ function sessionFacets(
       value: triggeredBy,
       integration: sessionIntegration(session, hook),
       name: display.triggeredByName,
-      hookKind: hook?.kind ?? null,
+      hookKind: sessionHookKind(session, hook),
       githubRepoId
     })
   }
@@ -346,7 +356,7 @@ function sessionDto(
     lastActivityAt: s.lastActivityAt.toISOString(),
     usage: s.usage ?? null,
     triggeredBy: s.triggeredBy ?? null,
-    hookKind: hook?.kind ?? null,
+    hookKind: sessionHookKind(s, hook),
     channelName: display.channelName,
     triggeredByName: display.triggeredByName,
     threadUrl: s.threadUrl ?? null,
@@ -916,7 +926,7 @@ export function sessionRoutes(deps: HttpDeps) {
           lastActivityAt: s.lastActivityAt.toISOString(),
           usage,
           triggeredBy: s.triggeredBy,
-          hookKind: hook?.kind ?? null,
+          hookKind: sessionHookKind(s, hook),
           channelName: display.channelName,
           triggeredByName: display.triggeredByName,
           threadUrl: s.threadUrl,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1160,6 +1160,9 @@ export interface SessionMetaRecord {
   triggeredBy: string | null
   channelName: string | null
   triggeredByName: string | null
+  /** Creation-time hook-kind snapshot, so a deleted hook cannot rewrite this session's
+   *  source. Null on rows written before the column; those resolve through the live hook. */
+  hookKind: HookKind | null
   threadUrl: string | null
   runtime: string | null
   model: string | null
@@ -1301,6 +1304,8 @@ export interface SessionFacetRecord {
   triggeredBy: string | null
   channelName: string | null
   triggeredByName: string | null
+  /** Creation-time hook-kind snapshot; null on rows written before it existed. */
+  hookKind: HookKind | null
   lastActivityAt: Date
   startedAt: Date
 }

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -8,7 +8,9 @@
 import {
   CODE_HOST_PROVIDERS,
   isCodeHostProvider,
+  GENERIC_HOOK_KIND,
   type CodeHostProvider,
+  type HookKind,
   type Platform
 } from '@agentconnect.md/protocol'
 import {
@@ -71,6 +73,7 @@ function toRecord(s: SessionMeta): SessionMetaRecord {
     triggeredBy: s.triggeredBy,
     channelName: s.channelName,
     triggeredByName: s.triggeredByName,
+    hookKind: (s.hookKind as HookKind | null) ?? null,
     threadUrl: s.threadUrl,
     runtime: s.runtime,
     model: s.model,
@@ -226,24 +229,51 @@ function hookTriggerSql(hookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
   `
 }
 
-/** One code host's hook sessions — the same predicate for either host, told apart
- *  only by which hook ids it is given. */
-function codeHostHookSql(hookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
-  return Prisma.sql`${a}."platform" = 'hook' AND ${hookTriggerSql(hookIds, a)}`
+/** The hook definition a reported session fires from. `triggeredBy` is authoritative;
+ *  the channel fallback covers legacy headless hook rows that predate that identity. */
+function hookIdOfEvent(ev: EventSessionInput): string | null {
+  const fromTrigger = ev.triggeredBy?.startsWith(HOOK_TRIGGER_PREFIX)
+    ? ev.triggeredBy.slice(HOOK_TRIGGER_PREFIX.length)
+    : ''
+  const id = fromTrigger || (ev.platform === 'hook' ? (ev.channel ?? '') : '')
+  return UUID_RE.test(id) ? id : null
 }
 
-/** Hook sessions that belong to NO code host — every promoted id is excluded here,
- *  or a GitLab session would be counted twice: once as gitlab, once as a webhook. */
-function genericHookSql(codeHostHookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
-  if (codeHostHookIds.length === 0) return Prisma.sql`${a}."platform" = 'hook'`
-  const triggers = codeHostHookIds.map((id) => `${HOOK_TRIGGER_PREFIX}${id}`)
+/** One code host's hook sessions. The row's own snapshot decides when it has one — that
+ *  survives the definition being deleted — and only rows written before the column fall
+ *  back to matching the live hook ids. */
+function codeHostHookSql(provider: CodeHostProvider, hookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
   return Prisma.sql`
     ${a}."platform" = 'hook'
-    AND (${a}."triggeredBy" IS NULL OR ${a}."triggeredBy" NOT IN (${Prisma.join(triggers)}))
     AND (
-      (${a}."triggeredBy" LIKE ${`${HOOK_TRIGGER_PREFIX}%`} AND ${a}."triggeredBy" <> ${HOOK_TRIGGER_PREFIX})
-      OR ${a}."channel" IS NULL
-      OR ${a}."channel" NOT IN (${Prisma.join(codeHostHookIds)})
+      ${a}."hookKind" = ${provider}::"HookKind"
+      OR (${a}."hookKind" IS NULL AND ${hookTriggerSql(hookIds, a)})
+    )
+  `
+}
+
+/** Hook sessions that belong to NO code host — a snapshot naming one is excluded on its
+ *  own, and pre-snapshot rows are excluded by promoted id, or a GitLab session would be
+ *  counted twice: once as gitlab, once as a webhook. */
+function genericHookSql(codeHostHookIds: string[], a: Prisma.Sql = S): Prisma.Sql {
+  const byId =
+    codeHostHookIds.length === 0
+      ? Prisma.sql`TRUE`
+      : Prisma.sql`
+          (${a}."triggeredBy" IS NULL OR ${a}."triggeredBy" NOT IN (${Prisma.join(
+            codeHostHookIds.map((id) => `${HOOK_TRIGGER_PREFIX}${id}`)
+          )}))
+          AND (
+            (${a}."triggeredBy" LIKE ${`${HOOK_TRIGGER_PREFIX}%`} AND ${a}."triggeredBy" <> ${HOOK_TRIGGER_PREFIX})
+            OR ${a}."channel" IS NULL
+            OR ${a}."channel" NOT IN (${Prisma.join(codeHostHookIds)})
+          )
+        `
+  return Prisma.sql`
+    ${a}."platform" = 'hook'
+    AND (
+      ${a}."hookKind" = ${GENERIC_HOOK_KIND}::"HookKind"
+      OR (${a}."hookKind" IS NULL AND ${byId})
     )
   `
 }
@@ -257,7 +287,8 @@ function integrationSql(q: SessionFilterQuery, a: Prisma.Sql = S): Prisma.Sql | 
   if (!q.integration) return null
   // Each code host reads its own promoted ids; asking the shared provider list means a
   // new host is filterable here without an arm of its own.
-  if (isCodeHostProvider(q.integration)) return codeHostHookSql(q.codeHostHookIds?.[q.integration] ?? [], a)
+  if (isCodeHostProvider(q.integration))
+    return codeHostHookSql(q.integration, q.codeHostHookIds?.[q.integration] ?? [], a)
   if (q.integration === 'hook') return genericHookSql(allCodeHostHookIds(q), a)
   return platformSql(q.integration, a)
 }
@@ -321,14 +352,13 @@ function pageWhereSql(
   return Prisma.sql`WHERE ${Prisma.join(filters, ' AND ')}`
 }
 
-/** One CASE arm per code host that has promoted ids, built from the shared provider
- *  list so a new host projects its own facet value without an arm written by hand. */
+/** One CASE arm per code host, built from the shared provider list so a new host projects
+ *  its own facet value without an arm written by hand. Every provider gets an arm whether
+ *  or not it still has live hooks: a snapshot alone is enough to classify a row. */
 function integrationFacetSql(codeHostHookIds: Partial<Record<CodeHostProvider, string[]>>): Prisma.Sql {
-  const arms = CODE_HOST_PROVIDERS.flatMap((provider) => {
-    const ids = codeHostHookIds[provider] ?? []
-    return ids.length > 0 ? [Prisma.sql`WHEN ${codeHostHookSql(ids)} THEN ${provider}`] : []
-  })
-  if (arms.length === 0) return Prisma.sql`COALESCE(s."platform", 'slack')`
+  const arms = CODE_HOST_PROVIDERS.map(
+    (provider) => Prisma.sql`WHEN ${codeHostHookSql(provider, codeHostHookIds[provider] ?? [])} THEN ${provider}`
+  )
   return Prisma.sql`
     CASE
       ${Prisma.join(arms, ' ')}
@@ -372,6 +402,7 @@ type SessionFacetDbRow = {
   triggeredBy: string | null
   channelName: string | null
   triggeredByName: string | null
+  hookKind: HookKind | null
   lastActivityAt: Date
   startedAt: Date
 }
@@ -802,7 +833,7 @@ export class PgSessionRepo implements SessionRepo {
       INSERT INTO "session_meta" (
         "id", "parentSessionId", "agentId", "launchId", "platform", "channel",
         "thread", "tenantScope", "phase", "link", "summary", "title", "status",
-        "lastActivityAt", "triggeredBy", "channelName", "triggeredByName",
+        "lastActivityAt", "triggeredBy", "channelName", "triggeredByName", "hookKind",
         "threadUrl", "runtime", "model", "effort", "fastMode",
         "permissionMode", "outputMode", "daemonId", "contentSetId", "workspaceIsolation", "orgId", "visibility",
         "ownerIdentity", "visibilitySource", "externalProvider",
@@ -814,7 +845,11 @@ export class PgSessionRepo implements SessionRepo {
         ${ev.thread ?? null}, ${ev.transportScope ?? null}, ${ev.phase}::"SessionPhase", ${ev.link ?? null},
         ${ev.summary ?? null}, ${ev.title ?? null}, ${ev.status ?? null},
         ${lastActivityAt}, ${ev.triggeredBy ?? null}, ${ev.channelName ?? null},
-        ${ev.triggeredByName ?? null}, ${ev.threadUrl ?? null},
+        ${ev.triggeredByName ?? null},
+        -- Snapshot the hook KIND beside the trigger id, resolved in this same statement.
+        -- The definition can be deleted and recreated; the session's own source cannot.
+        (SELECT h."kind" FROM "hook_def" h WHERE h."id" = ${hookIdOfEvent(ev)}::uuid),
+        ${ev.threadUrl ?? null},
         ${ev.runtime ?? null}, ${ev.model ?? null}, ${ev.effort ?? null},
         ${ev.fastMode ?? null}, ${ev.permissionMode ?? null},
         ${ev.outputMode ?? null}, ${ev.daemonId ?? null},
@@ -864,6 +899,9 @@ export class PgSessionRepo implements SessionRepo {
           EXCLUDED."triggeredByName",
           "session_meta"."triggeredByName"
         ),
+        -- First non-null wins: a snapshot is a record of what fired the session, so a
+        -- later report can fill it in but never rewrite it.
+        "hookKind" = COALESCE("session_meta"."hookKind", EXCLUDED."hookKind"),
         "threadUrl" = COALESCE(EXCLUDED."threadUrl", "session_meta"."threadUrl"),
         "runtime" = COALESCE(EXCLUDED."runtime", "session_meta"."runtime"),
         "model" = CASE
@@ -1210,15 +1248,15 @@ export class PgSessionRepo implements SessionRepo {
       this.db.$queryRaw<SessionFacetDbRow[]>(Prisma.sql`
         SELECT
           "id", "agentId", "platform", "channel", "triggeredBy",
-          "channelName", "triggeredByName", "lastActivityAt", "startedAt"
+          "channelName", "triggeredByName", "hookKind", "lastActivityAt", "startedAt"
         FROM (
           SELECT DISTINCT ON ("facetValue")
             "id", "agentId", "platform", "channel", "triggeredBy",
-            "channelName", "triggeredByName", "lastActivityAt", "startedAt"
+            "channelName", "triggeredByName", "hookKind", "lastActivityAt", "startedAt"
           FROM (
             SELECT
               s."id", s."agentId", s."platform", s."channel", s."triggeredBy",
-              s."channelName", s."triggeredByName", s."lastActivityAt", s."startedAt",
+              s."channelName", s."triggeredByName", s."hookKind", s."lastActivityAt", s."startedAt",
               ${integrationFacet} AS "facetValue"
             FROM "session_meta" AS s
             ${pageWhereSql(integrationQuery, false)}
@@ -1230,11 +1268,11 @@ export class PgSessionRepo implements SessionRepo {
       this.db.$queryRaw<SessionFacetDbRow[]>(Prisma.sql`
         SELECT
           "id", "agentId", "platform", "channel", "triggeredBy",
-          "channelName", "triggeredByName", "lastActivityAt", "startedAt"
+          "channelName", "triggeredByName", "hookKind", "lastActivityAt", "startedAt"
         FROM (
           SELECT DISTINCT ON (s."channel")
             s."id", s."agentId", s."platform", s."channel", s."triggeredBy",
-            s."channelName", s."triggeredByName", s."lastActivityAt", s."startedAt"
+            s."channelName", s."triggeredByName", s."hookKind", s."lastActivityAt", s."startedAt"
           FROM "session_meta" AS s
           ${pageWhereSql(channelQuery, false)}
             AND s."channel" IS NOT NULL
@@ -1246,11 +1284,11 @@ export class PgSessionRepo implements SessionRepo {
       this.db.$queryRaw<SessionFacetDbRow[]>(Prisma.sql`
         SELECT
           "id", "agentId", "platform", "channel", "triggeredBy",
-          "channelName", "triggeredByName", "lastActivityAt", "startedAt"
+          "channelName", "triggeredByName", "hookKind", "lastActivityAt", "startedAt"
         FROM (
           SELECT DISTINCT ON (s."triggeredBy")
             s."id", s."agentId", s."platform", s."channel", s."triggeredBy",
-            s."channelName", s."triggeredByName", s."lastActivityAt", s."startedAt"
+            s."channelName", s."triggeredByName", s."hookKind", s."lastActivityAt", s."startedAt"
           FROM "session_meta" AS s
           ${pageWhereSql(triggerQuery, false)}
             AND s."triggeredBy" IS NOT NULL

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -580,6 +580,93 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     )
   })
 
+  it('keeps a code-host session on its own source after the hook is deleted and recreated', async () => {
+    // Found in live testing: a hook can be deleted and recreated, which leaves its past
+    // sessions pointing at an id that resolves to nothing. Reading the kind live then
+    // rewrote their history as generic webhooks. The kind is snapshotted at creation, so
+    // the source of a session that already ran cannot change afterwards.
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    const gitlabId = randomUUID()
+    await prisma.hookDef.create({
+      data: {
+        id: gitlabId,
+        orgId: DEFAULT_ORG_ID,
+        agentId: AGENT,
+        kind: 'gitlab',
+        name: 'acme/platform',
+        sessionMode: 'perThread',
+        repoId: 4210n,
+        repoFullName: 'acme/platform',
+        events: ['merge_request:*'],
+        targetPlatform: 'slack'
+      }
+    })
+    running = buildHttpApp(prisma)
+
+    // No triggeredByName: the unnamed case is exactly where the label used to read "Webhook".
+    await reportSession({
+      sessionId: 'acp-gitlab-orphan',
+      agentId: AGENT,
+      phase: 'start',
+      platform: 'hook',
+      channel: gitlabId,
+      title: 'Answer the merge request',
+      triggeredBy: `hook:${gitlabId}`,
+      ts: '2026-08-22T00:00:00.000Z'
+    })
+    // A legacy row: written before the snapshot column existed, so it has no kind of its own.
+    await reportSession({
+      sessionId: 'acp-gitlab-legacy',
+      agentId: AGENT,
+      phase: 'start',
+      platform: 'hook',
+      channel: gitlabId,
+      title: 'An older merge request',
+      triggeredBy: `hook:${gitlabId}`,
+      ts: '2026-08-22T00:01:00.000Z'
+    })
+    await prisma.sessionMeta.update({ where: { id: 'acp-gitlab-legacy' }, data: { hookKind: null } })
+
+    expect((await prisma.sessionMeta.findUnique({ where: { id: 'acp-gitlab-orphan' } }))?.hookKind).toBe('gitlab')
+
+    await prisma.hookDef.delete({ where: { id: gitlabId } })
+
+    const rows = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })
+    expect(rows.statusCode).toBe(200)
+    const byId = new Map(
+      (
+        rows.json() as { sessions: Array<{ sessionId: string; hookKind: string | null; triggeredByName: string }> }
+      ).sessions.map((session) => [session.sessionId, session])
+    )
+    // The snapshot survives the definition; the pre-snapshot row degrades as it always did.
+    expect(byId.get('acp-gitlab-orphan')?.hookKind).toBe('gitlab')
+    expect(byId.get('acp-gitlab-orphan')?.triggeredByName).toBe('GitLab')
+    expect(byId.get('acp-gitlab-legacy')?.hookKind).toBeNull()
+    expect(byId.get('acp-gitlab-legacy')?.triggeredByName).toBe('Webhook')
+
+    // The facet list still promotes it out of the generic bucket with no hook to read.
+    const facets = await running.app.inject({ method: 'GET', url: `${ORG}/sessions/facets` })
+    expect(facets.statusCode).toBe(200)
+    expect((facets.json() as { integrations: string[] }).integrations).toEqual(expect.arrayContaining(['gitlab']))
+
+    const gitlabOnly = await running.app.inject({
+      method: 'GET',
+      url: `${ORG}/sessions?view=flat&integration=gitlab`
+    })
+    expect(gitlabOnly.statusCode).toBe(200)
+    expect((gitlabOnly.json() as { sessions: Array<{ sessionId: string }> }).sessions.map((s) => s.sessionId)).toEqual([
+      'acp-gitlab-orphan'
+    ])
+
+    // And it is no longer double-counted: the generic filter returns only the legacy row.
+    const genericOnly = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat&integration=hook` })
+    expect(genericOnly.statusCode).toBe(200)
+    expect((genericOnly.json() as { sessions: Array<{ sessionId: string }> }).sessions.map((s) => s.sessionId)).toEqual(
+      ['acp-gitlab-legacy']
+    )
+  })
+
   it('serves the multi-agent webchat roster on the detail route; single-agent stays null', async () => {
     // An adopted/refreshed webchat session has no relay socket to deliver the
     // verified roster — the composer/header read it from this DTO field instead.


### PR DESCRIPTION
Found in live testing, and the last read-time dependency in the session source taxonomy after #1440 and #1441.

## The bug

A GitLab-triggered session rendered as a generic **Webhook** once its hook had been deleted and recreated. The source kind was read from the hook definition at display time, so a session pointing at an id that no longer resolves lost its identity everywhere at once: the row, its label, its integration facet, and the filter that should have found it all fell back to the generic bucket.

`session_meta` already snapshots the rest of a session's trigger identity at creation — `platform`, `channel`, `triggeredBy`, `channelName`, `triggeredByName`. The kind was the one piece still read live, which made a session's history a function of data someone else could delete.

## The fix

`session_meta."hookKind"` snapshots it at creation, resolved from `hook_def` **inside the same INSERT**, so the write stays atomic and costs no extra round trip:

```sql
(SELECT h."kind" FROM "hook_def" h WHERE h."id" = $n::uuid)
```

It is frozen once set — `COALESCE("session_meta"."hookKind", EXCLUDED."hookKind")` — so a later report can fill a null in but can never rewrite a recorded source.

Every read prefers the snapshot and consults the live hook only when a row has none:

- the display label and all four DTO sites, through one `sessionHookKind(s, hook)` helper;
- the integration facet CASE, which now emits an arm per provider whether or not that host still has live hooks — a snapshot alone is enough to classify a row;
- the filter predicate: a code host matches by snapshot first and by live hook id only for pre-snapshot rows, and the generic `hook` filter excludes a snapshot naming a code host on its own, so a session is never counted twice.

## No backfill

Existing rows are deliberately **not** backfilled. They keep resolving through the live hook exactly as they do today, which means a code-host session older than this column still degrades to the generic rendering once its hook is gone. That is the documented trade, not an oversight — and the integration test asserts it, so the boundary is pinned rather than assumed.

The column is additive and nullable, so the migration is safe to apply ahead of the code.

## Totality is unchanged

The column is the Prisma `HookKind` enum, which already mirrors the protocol union member for member, so the `Record<HookKind, …>` gates from #1440/#1441 still fail type-check for a new code host until every mapping is given an entry.

## Tests

- **Integration (real Postgres):** a GitLab session is created, the hook is deleted, and the session still reports `hookKind: gitlab`, labels as "GitLab", appears under the `gitlab` integration facet with no hook left to read, is returned by `integration=gitlab`, and is absent from `integration=hook`. A deliberately null-snapshot row alongside it degrades to "Webhook" exactly as before — the pre-snapshot boundary, asserted.
- **Route unit:** the row's snapshot outranks the definition it points at, and the live hook is consulted only for a row without one.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint`, `pnpm format:check` — clean
- control-plane `test:unit` — 175 files, 2011 tests
- control-plane `test:int` — 111 files, 1721 tests, including the migration applying cleanly
- `pnpm --filter @agentconnect.md/web test` — 173 files, 1932 tests

Design note added to `docs/designs/webhook-triggers-and-github-events.md` covering the snapshot, the read precedence, and the no-backfill boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
