### PR TITLE
feat(control-plane): authorize additional GitLab projects and enforce the hook precondition

### DIFF
--- a/docs/designs/agent-multi-repo-authorization.md
+++ b/docs/designs/agent-multi-repo-authorization.md
@@ -191,16 +191,24 @@ spec replication or restart.
 
 ## Prisma data model
 
+GitLab's arrival made this row a two-host one
+([gitlab-com-integration.md](gitlab-com-integration.md) §8.3): it carries the
+provider beside its numeric id, and identity is the pair. Everything below that
+says GitHub is now that host's arm of a shared shape.
+
 ```prisma
-/// Explicit agent access to a GitHub repository outside the workspace.
-/// Authorization belongs to the agent, not a hook. repoId is the rename-immune
-/// match key; repoFullName is for display. Installation is resolved dynamically
-/// by owner at mint time. Rows are detachable and do not change workspace identity.
+/// Explicit agent access to one code-host repository outside the workspace.
+/// Authorization belongs to the agent, not a hook. (provider, repoId) is the
+/// rename-immune match key — the hosts number their repositories independently;
+/// repoFullName is for display. A GitHub installation is resolved dynamically by
+/// owner at mint time, a GitLab project through its managed binding. Rows are
+/// detachable and do not change workspace identity.
 model AgentRepoAuthorization {
   id              String   @id @default(uuid()) @db.Uuid
   agentId         String   @db.Uuid
-  repoId          BigInt            // Numeric GitHub repository ID; match key
-  repoFullName    String            // "owner/repo"; display and fast-path match
+  provider        String   @default("github")  // 'github' | 'gitlab'
+  repoId          BigInt            // Numeric repository/project ID; match key
+  repoFullName    String            // "owner/repo" or "group/subgroup/project"; display and fast-path match
   access          RepoAccess        // read | comment | write
   createdByUserId String?           // Audit: who granted it and was attested
   createdAt       DateTime @default(now()) @db.Timestamptz(6)
@@ -208,7 +216,7 @@ model AgentRepoAuthorization {
   agent     Agent @relation(fields: [agentId], references: [id], onDelete: Cascade)
   createdBy User? @relation(fields: [createdByUserId], references: [id], onDelete: SetNull)
 
-  @@unique([agentId, repoId])
+  @@unique([agentId, provider, repoId])
   @@index([agentId])
   @@map("agent_repo_authorization")
 }

--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -594,7 +594,25 @@ the top-level group's account quota refuses a creation.
 
 - An agent workspace and each `AgentRepoAuthorization` reference a
   `CodeHostRepository`.
-- `RepoAccess` remains `read | comment | write`.
+- `AgentRepoAuthorization` carries the provider beside its numeric id, and its
+  uniqueness is `(agent, provider, repository)`. The reference converged on the
+  catalog through a provider column rather than a foreign key, for the same
+  readers-first reason `HookDef` did: the two hosts number their repositories
+  independently, so a bare numeric id stopped being an identity the moment
+  GitLab grants existed, and every reader that matched on it — the mint gates,
+  the workspace-collision checks, the Checks ledger — is qualified by provider.
+  An absent provider means `github`, which is what every row predating GitLab
+  is.
+- `RepoAccess` remains `read | comment | write`. On GitLab the tier derives the
+  account's project role exactly as a workspace does: `write` earns Developer,
+  and `read` and `comment` both earn Reporter, since a note is a read-level
+  action there.
+- Authorizing a project makes the agent a **consumer** of it (§7.2), so the
+  write runs the same inline account/membership ensure the workspace and hook
+  writes run, under the same binding lease, and revoking converges the
+  membership away. The consumer query that computes the desired membership set
+  counts grants alongside workspaces and enabled hooks; without that, the next
+  convergence would unbind the membership the grant had just bound.
 - A code-host hook references a `CodeHostRepository` and a provider
   discriminator. Common cadence, labels, session, review, reporting, revision,
   placement, and output-target fields stay on `HookDef`.
@@ -603,7 +621,11 @@ the top-level group's account quota refuses a creation.
   `HookDef`.
 - Creating a hook never creates a general repository grant. The watched project
   must already be the workspace repository or an explicit additional
-  authorization.
+  authorization, enforced on create and on a binding-changing edit with a 409
+  that names the fix; hooks predating the check keep firing, exactly as the
+  GitHub precedent grandfathers its own. Without the check the trigger plane
+  outruns the credential plane: the hook fires, the review's exact checkout can
+  obtain no credential, and the agent posts a note saying it could not review.
 
 ## 9. OAuth Flow and Correctness
 
@@ -1029,6 +1051,22 @@ Workspace `gitAccess` remains `read | write`. The daemon-owned ordinary hook
 poster is authorized by the enabled hook, not by an agent-visible general
 grant. This preserves the existing behavior where a read-only workspace can
 return one final comment without receiving a write credential.
+
+An agent therefore has **two** credential authorities on GitLab, as it does on
+GitHub: its workspace project, and any project it holds an explicit additional
+authorization on. The grant's own tier is that project's ceiling — a write
+workspace does not widen it — and a project that is neither is a denial, never
+a fallback onto the workspace. A named project is asked for by its numeric id,
+because the grant echo the consumer verifies is keyed on that identity: an ask
+carrying only a display path would be answered with the workspace grant and
+then correctly rejected by the daemon.
+
+One half is deliberately not built yet: an authorized additional GitLab project
+receives credentials but is not materialized as a secondary workspace root. The
+existing root layout is `owner/repo` and clones from github.com, which a
+namespaced GitLab path cannot express and a GitLab project must not be fetched
+from. Until that layout is provider-aware, GitLab entries are skipped when
+roots are built rather than cloned from the wrong host.
 
 Every broker request is re-resolved by:
 
@@ -1590,8 +1628,18 @@ Choosing a project happens where the project is used, not on that page: the
 hook wizard and the agent workspace and additional-repository pickers list the
 connection's Maintainer-or-Owner projects merged with the ones already added,
 and picking one that is not added yet runs the Section 10.2 provisioning saga
-inline before the selection lands. Hook configuration retains the existing
-family, cadence, review, reporting, and output controls. Premium-only
+inline before the selection lands. The additional-repository picker chooses the
+code host first and then a repository or a project, because a grant is
+provider-qualified; it offers the same tiers on both hosts and says project,
+merge request, and pipeline on the GitLab side. A project the agent already
+holds — as its workspace, or through an existing grant — is named as taken
+rather than offered again.
+
+Because a trigger may only watch a project the agent already holds (§8.3), the
+trigger wizard says so where the pick is rather than letting the create reach
+the same refusal from the server, and names the two ways to satisfy it. Hook
+configuration retains the existing family, cadence, review, reporting, and
+output controls. Premium-only
 effective behavior is described where relevant; the UI does not imply that
 Free request changes block merges.
 
@@ -1634,7 +1682,12 @@ provisioning state and non-secret external identifiers. They never return OAuth
 tokens, PAT values, signing tokens, or token hashes.
 
 Existing agent repository-authorization and hook routes gain a provider-aware
-repository reference rather than GitLab-only copies. Every new or changed route
+repository reference rather than GitLab-only copies. On
+`POST /orgs/:orgId/agents/:agentId/repos` that reference is a `provider` field
+whose GitHub arm names `owner/repo` and whose GitLab arm names the numeric
+project id, since a namespaced project path is not `owner/repo` shaped and the
+client supplies no facts (§10.1). The field is optional and means `github` when
+absent, so the published body stays valid. Every new or changed route
 must include OpenAPI tags, summary, description, and a unique operation ID.
 
 ### 18.3 Deployment Configuration

--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -603,6 +603,11 @@ the top-level group's account quota refuses a creation.
   the workspace-collision checks, the Checks ledger — is qualified by provider.
   An absent provider means `github`, which is what every row predating GitLab
   is.
+  A pre-GitLab daemon strips the unknown provider key, so a two-segment project
+  path would read there as an `owner/repo` GitHub entry; the §17.3 projection
+  gate therefore reads the assembled additional-repository list as well as the
+  workspace arm, and withholds such a spec from a daemon that has not advertised
+  `gitlab-com-v1`.
 - `RepoAccess` remains `read | comment | write`. On GitLab the tier derives the
   account's project role exactly as a workspace does: `write` earns Developer,
   and `read` and `comment` both earn Reporter, since a note is a read-level
@@ -1060,6 +1065,15 @@ a fallback onto the workspace. A named project is asked for by its numeric id,
 because the grant echo the consumer verifies is keyed on that identity: an ask
 carrying only a display path would be answered with the workspace grant and
 then correctly rejected by the daemon.
+
+A rename reaches both places the project's path is replicated into. The binding
+and the catalog converge on the numeric id, and so must every gitlab workspace's
+clone URL AND every explicit authorization's display path — the latter is what
+the daemon maps a named project back to its numeric id with. Leaving a grant
+stale orphans the new path, and an ask under the old one is answered with the
+binding's new path and then correctly rejected by the consumer's echo check.
+Both writes join one configuration-ordering domain and bump each affected
+agent's revision exactly once, so a spec never carries half a rename.
 
 One half is deliberately not built yet: an authorized additional GitLab project
 receives credentials but is not materialized as a secondary workspace root. The

--- a/packages/control-plane/prisma/migrations/20260911000000_agent_repo_authorization_provider/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260911000000_agent_repo_authorization_provider/migration.sql
@@ -1,0 +1,11 @@
+-- Provider-qualify an agent's explicit repository grants (gitlab-com-integration.md §8.3).
+--
+-- GitHub and GitLab number their repositories independently, so a bare `repoId` is not an
+-- identity once GitLab grants exist: one agent could legitimately hold a grant on GitHub
+-- repository 4455667 and on GitLab project 4455667. Every row on record predates GitLab
+-- grants and is a GitHub grant, so the column default IS the backfill.
+ALTER TABLE "agent_repo_authorization" ADD COLUMN "provider" TEXT NOT NULL DEFAULT 'github';
+
+DROP INDEX "agent_repo_authorization_agentId_repoId_key";
+
+CREATE UNIQUE INDEX "agent_repo_authorization_agentId_provider_repoId_key" ON "agent_repo_authorization" ("agentId", "provider", "repoId");

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -891,27 +891,32 @@ enum RepoAccess {
   write // all write — secondary working repo
 }
 
-/// Explicit grant of a GitHub repo to an agent (issue #457,
-/// agent-multi-repo-authorization.md). Anchored on the agent, NOT on hooks —
-/// creating a hook must never silently widen credentials. `repoId` (numeric,
-/// rename-immune) is the match key; `repoFullName` is display + the request
-/// fast-path. The covering installation is deliberately NOT bound here: minting
-/// re-resolves the live installation by repo owner (gitcred decision 7), so an
-/// uninstall→reinstall self-heals. Rows are mutable (add/remove) — the
-/// workspace-immutability convention is untouched.
+/// Explicit grant of one code-host repository to an agent (issue #457,
+/// agent-multi-repo-authorization.md; gitlab-com-integration.md §8.3). Anchored on
+/// the agent, NOT on hooks — creating a hook must never silently widen
+/// credentials. `repoId` (numeric, rename-immune) is the match key WITHIN a
+/// provider; `repoFullName` is display + the request fast-path. The covering
+/// installation is deliberately NOT bound here: minting re-resolves the live
+/// installation by repo owner (gitcred decision 7), so an uninstall→reinstall
+/// self-heals. Rows are mutable (add/remove) — the workspace-immutability
+/// convention is untouched.
 model AgentRepoAuthorization {
-  id              String     @id @default(uuid()) @db.Uuid
-  agentId         String     @db.Uuid
-  repoId          BigInt // GitHub numeric repo id — the match key
-  repoFullName    String // "owner/repo" — display + case-insensitive fast-path; refreshed on rename detection
-  access          RepoAccess
+  id String @id @default(uuid()) @db.Uuid
+  agentId String @db.Uuid
+  /// 'github' | 'gitlab' — TEXT with the closed-set guard at the application layer,
+  /// matching CodeHostRepository. The two hosts number their repositories
+  /// independently, so identity is (provider, repoId), never repoId alone.
+  provider String @default("github")
+  repoId BigInt // numeric repository/project id — the match key
+  repoFullName String // "owner/repo" or "group/subgroup/project" — display + case-insensitive fast-path; refreshed on rename detection
+  access RepoAccess
   createdByUserId String? // audit: who authorized (the identity-assertion subject)
-  createdAt       DateTime   @default(now()) @db.Timestamptz(6)
+  createdAt DateTime @default(now()) @db.Timestamptz(6)
 
   agent     Agent @relation(fields: [agentId], references: [id], onDelete: Cascade)
   createdBy User? @relation("AgentRepoAuthCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
 
-  @@unique([agentId, repoId])
+  @@unique([agentId, provider, repoId])
   @@index([agentId])
   @@map("agent_repo_authorization")
 }

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1782,6 +1782,7 @@ export function buildContainer(
             accounts: repos.gitlabAgentAccount,
             credentials: new PgGitlabProjectCredentialRepo(prisma),
             credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, secretCipher),
+            repoAuths: repos.agentRepoAuth,
             clock
           })
         }

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1039,11 +1039,7 @@ export function buildContainer(
           // Awaited under the run lease (§17.3 round 3): the durable clone-URL
           // convergence rides the saga; only the daemon fan-out stays async.
           syncWorkspacePaths: async (orgId, projectId, projectPath) => {
-            const agentIds = await repos.agent.refreshGitlabWorkspacePath(
-              OrgId(orgId),
-              projectId,
-              `https://gitlab.com/${projectPath}`
-            )
+            const agentIds = await repos.agent.refreshGitlabProjectPath(OrgId(orgId), projectId, projectPath)
             for (const agentId of agentIds) {
               void repos.agent
                 .getUnscoped(agentId)

--- a/packages/control-plane/src/domain/daemon-features.test.ts
+++ b/packages/control-plane/src/domain/daemon-features.test.ts
@@ -15,6 +15,21 @@ describe('§17.3 snapshot projection gate predicate', () => {
     expect(requiredDaemonFeatures(workspace('gitlab'))).toEqual([GITLAB_COM_V1_FEATURE])
   })
 
+  it('gates a gitlab ADDITIONAL repository, whatever the workspace is', () => {
+    // The quieter half: an older daemon strips the unknown `provider` key, so a
+    // two-segment project path would read as an owner/repo GitHub entry and be
+    // cloned from github.com. Only the assembled spec carries this, which is why
+    // the predicate takes it structurally.
+    const withGrant = (mode: string, provider: string) => ({
+      workspace: { mode, additionalRepos: [{ repoFullName: 'a/b', repoId: '1', provider }] } as never
+    })
+    expect(requiredDaemonFeatures(withGrant('scratch', 'gitlab'))).toEqual([GITLAB_COM_V1_FEATURE])
+    expect(requiredDaemonFeatures(withGrant('github', 'gitlab'))).toEqual([GITLAB_COM_V1_FEATURE])
+    expect(requiredDaemonFeatures(withGrant('scratch', 'github'))).toEqual([])
+    expect(daemonSupportsAgent(withGrant('scratch', 'gitlab'), [])).toBe(false)
+    expect(daemonSupportsAgent(withGrant('scratch', 'gitlab'), [GITLAB_COM_V1_FEATURE])).toBe(true)
+  })
+
   it('fails closed: absent or feature-less advertisements support only ungated agents', () => {
     expect(daemonSupportsAgent(workspace('github'), undefined)).toBe(true)
     expect(daemonSupportsAgent(workspace('gitlab'), undefined)).toBe(false)

--- a/packages/control-plane/src/domain/daemon-features.ts
+++ b/packages/control-plane/src/domain/daemon-features.ts
@@ -12,17 +12,27 @@
  */
 import { GITLAB_COM_V1_FEATURE } from '@agentconnect.md/protocol'
 
-// Structural on purpose: the predicate reads only the workspace-mode
-// discriminant, so DOMAIN records and WIRE AgentSpec bundles both fit — the
-// sender-level activation gate checks the exact spec it is about to transmit.
-type WorkspaceShapedAgent = { workspace: { mode: string } }
+// Structural on purpose: the predicate reads the workspace-mode discriminant and,
+// when the caller holds one, the assembled additional-repository list — so DOMAIN
+// records and WIRE AgentSpec bundles both fit. The sender-level activation gate
+// checks the exact spec it is about to transmit, which is the only place the
+// second source is visible: grants live in their own table, not on the agent row.
+type WorkspaceShapedAgent = {
+  workspace: { mode: string; additionalRepos?: readonly { provider?: string }[] }
+}
 
 /** Features a daemon must advertise before this agent's spec can decode there. */
 export function requiredDaemonFeatures(agent: WorkspaceShapedAgent): readonly string[] {
-  // The workspace union's 'gitlab' arm arrives with the M4 daemon slice; until a
-  // row can carry it this returns [] for every agent, and the comparison stays a
-  // string so the arm lights the gate up without touching this file again.
-  return agent.workspace.mode === 'gitlab' ? [GITLAB_COM_V1_FEATURE] : []
+  // Two sources, not one. The workspace union's 'gitlab' arm is frame-fatal on a
+  // pre-GitLab daemon; a gitlab ADDITIONAL repository is quieter and worse — the
+  // old schema strips the unknown `provider` key, so a two-segment project path
+  // reads as an `owner/repo` GitHub entry and would be cloned from github.com.
+  // Comparisons stay strings so a new host lights the gate up without touching
+  // this file again.
+  const gitlab =
+    agent.workspace.mode === 'gitlab' ||
+    (agent.workspace.additionalRepos ?? []).some((repo) => repo.provider === 'gitlab')
+  return gitlab ? [GITLAB_COM_V1_FEATURE] : []
 }
 
 /** Fail-closed: unknown/absent advertised features support only feature-free agents. */

--- a/packages/control-plane/src/github/github.test.ts
+++ b/packages/control-plane/src/github/github.test.ts
@@ -1007,6 +1007,7 @@ describe('GithubService.mintForAgent — additional repos (issue #457)', () => {
     return {
       id: 'ra-1',
       agentId: 'agent-1' as never,
+      provider: 'github',
       repoId: 111n,
       repoFullName: 'Acme/Tools', // stored as GitHub cases it — may differ from the request
       access: 'comment',

--- a/packages/control-plane/src/github/service.ts
+++ b/packages/control-plane/src/github/service.ts
@@ -804,7 +804,10 @@ export class GithubService {
       }
     }
 
-    const auth = (await this.deps.repoAuths?.listForAgent(agent.id))?.find((row) => row.repoId === repoId)
+    // Grants are provider-qualified: a GitLab project sharing this numeric id is a different repository.
+    const auth = (await this.deps.repoAuths?.listForAgent(agent.id))?.find(
+      (row) => row.provider === 'github' && row.repoId === repoId
+    )
     if (!auth) {
       throw new GitCredDeniedError(
         `${repoFullName} is not authorized for this agent — add it under the agent's Repositories settings`,
@@ -1037,7 +1040,9 @@ export class GithubService {
       }
     }
 
-    const grants = (await this.deps.repoAuths?.listForAgent(agent.id)) ?? []
+    const grants = ((await this.deps.repoAuths?.listForAgent(agent.id)) ?? []).filter(
+      (row) => row.provider === 'github'
+    )
     const exact = grants.find((row) => row.repoFullName.toLowerCase() === repoFullName.toLowerCase())
     // Never probe an unrelated owner merely because the daemon named it. A
     // same-owner grant is enough to justify the slow rename lookup below.

--- a/packages/control-plane/src/gitlab/api.ts
+++ b/packages/control-plane/src/gitlab/api.ts
@@ -280,6 +280,13 @@ export function gitlabWorkspaceAccessLevel(gitAccess: 'read' | 'write' | undefin
   return gitAccess === 'read' ? GITLAB_ACCESS_REPORTER : GITLAB_ACCESS_DEVELOPER
 }
 
+/** The project role an additional-repository authorization derives (§8.3, §13.1).
+ *  `comment` sits with `read` at Reporter — on GitLab a note is a read-level social
+ *  action — and only `write` earns the push role, matching the workspace mapping. */
+export function gitlabAuthorizationAccessLevel(access: 'read' | 'comment' | 'write'): number {
+  return access === 'write' ? GITLAB_ACCESS_DEVELOPER : GITLAB_ACCESS_REPORTER
+}
+
 export interface GitlabEffectiveMembership {
   access_level: number
   state: string

--- a/packages/control-plane/src/gitlab/gitcred.service.ts
+++ b/packages/control-plane/src/gitlab/gitcred.service.ts
@@ -3,6 +3,7 @@ import type { Clock } from '../domain/clock.js'
 import { GitCredDeniedError } from '../github/service.js'
 import type {
   AgentRecord,
+  AgentRepoAuthorizationRepo,
   GitlabAgentAccountRecord,
   GitlabAgentAccountRepo,
   GitlabProjectBindingRecord,
@@ -23,12 +24,16 @@ export interface GitlabGitcredDeps {
   accounts: Pick<GitlabAgentAccountRepo, 'forAgentBinding'>
   credentials: Pick<GitlabProjectCredentialRepo, 'get'>
   credentialSecrets: Pick<GitlabProjectCredentialSecretStore, 'get'>
+  /** The §8.3 additional-project allowlist — the second authority beside the workspace. */
+  repoAuths: Pick<AgentRepoAuthorizationRepo, 'listForAgent'>
   clock: Clock
 }
 
 /**
  * gitcred v2 GitLab grants (gitlab-com-integration.md §13.1/§17.1): serve the
- * workspace binding's purpose-separated PAT under the agent's access clamp.
+ * authorized binding's purpose-separated PAT under the agent's access clamp —
+ * the workspace project, or a project the agent holds an explicit additional
+ * authorization on (§8.3).
  * The grant carries TOKEN MATERIAL — never log it. Every request re-resolves
  * the live binding, the AGENT's own account in that project's root (§7.2), and
  * the credential epoch; the token is the agent account's, never a human's.
@@ -129,28 +134,49 @@ export class GitlabGitcredService {
     return account
   }
 
+  /**
+   * The project this request may be served for, and the ceiling it carries (§13.1
+   * step 3, §8.3). Two authorities, exactly as GitHub has: the agent's workspace
+   * project, and an explicit additional authorization. A project that is neither is
+   * a denial, never a fallback onto the workspace.
+   */
+  private async authority(
+    agent: AgentRecord,
+    requestedExternalRepoId?: bigint
+  ): Promise<{ projectId: bigint; clamp: 'read' | 'write' }> {
+    const workspaceProject = agent.workspace.mode === 'gitlab' ? agent.workspaceRepoId : undefined
+    if (requestedExternalRepoId === undefined || requestedExternalRepoId === workspaceProject) {
+      if (agent.workspace.mode !== 'gitlab' || workspaceProject === undefined) {
+        throw new GitCredDeniedError('agent workspace is not a managed GitLab project', 'SCOPE_DENIED', false)
+      }
+      return { projectId: workspaceProject, clamp: agent.workspace.gitAccess === 'read' ? 'read' : 'write' }
+    }
+    const grants = await this.deps.repoAuths.listForAgent(agent.id)
+    const grant = grants.find((row) => row.provider === 'gitlab' && row.repoId === requestedExternalRepoId)
+    if (!grant) {
+      throw new GitCredDeniedError(
+        'requested project is neither this agent’s workspace nor an authorized additional project',
+        'SCOPE_DENIED',
+        false
+      )
+    }
+    // `comment` earns no push: on Git it is contents-read, the same as `read` (§13.1).
+    return { projectId: requestedExternalRepoId, clamp: grant.access === 'write' ? 'write' : 'read' }
+  }
+
   async grantForAgent(
     agent: AgentRecord,
     requestedExternalRepoId?: bigint,
     requestedAccess?: 'read' | 'write'
   ): Promise<GitCredGrant> {
-    if (agent.workspace.mode !== 'gitlab' || agent.workspaceRepoId === undefined) {
-      throw new GitCredDeniedError('agent workspace is not a managed GitLab project', 'SCOPE_DENIED', false)
-    }
-    const projectId = agent.workspaceRepoId
-    // v1 scope: the workspace project only. Additional-repo authorization rows
-    // are GitHub-shaped today; a foreign id is a denial, not a fallback.
-    if (requestedExternalRepoId !== undefined && requestedExternalRepoId !== projectId) {
-      throw new GitCredDeniedError('requested project is not this agent workspace', 'SCOPE_DENIED', false)
-    }
+    const { projectId, clamp } = await this.authority(agent, requestedExternalRepoId)
     const binding = await this.servableBinding(agent.orgId, projectId)
     const account = await this.agentAccount(agent.orgId, agent.id, binding.id)
-    // Access clamp (§13.1): the workspace gitAccess ceiling picks the purpose —
-    // read → the read PAT, write → the git_write PAT. The effect PAT is never
-    // served through this path (it backs daemon-owned effects, M5). A v2
-    // `requestedAccess` may only NARROW the clamp (§17.1): the read-only CLI
-    // wrapper asks for read even on a write workspace.
-    const clamp: 'read' | 'write' = agent.workspace.gitAccess === 'read' ? 'read' : 'write'
+    // Access clamp (§13.1): the authority's ceiling picks the purpose — read → the
+    // read PAT, write → the git_write PAT. The effect PAT is never served through
+    // this path (it backs daemon-owned effects, M5). A v2 `requestedAccess` may only
+    // NARROW the clamp (§17.1): the read-only CLI wrapper asks for read even on a
+    // write workspace.
     const access: 'read' | 'write' = requestedAccess === 'read' ? 'read' : clamp
     const purpose = access === 'read' ? 'read' : 'git_write'
     const credential = await this.deps.credentials.get(account.id, purpose)

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -194,7 +194,7 @@ export class GitlabProvisioner {
     orgId: string,
     projectId: bigint,
     consumer: GitlabAccountConsumer,
-    commit: () => Promise<T>
+    commit: (live: { projectPath: string }) => Promise<T>
   ): Promise<AgentAccountOutcome<T>> {
     let outcome = await this.agentAccountAttempt(orgId, projectId, consumer, commit)
     for (let attempt = 0; !outcome.ok && outcome.retryable && attempt < AGENT_ACCOUNT_ATTEMPTS; attempt++) {
@@ -205,11 +205,42 @@ export class GitlabProvisioner {
     return outcome
   }
 
+  /**
+   * §10.2 step 1: the project's mutable facts, keyed by its immutable numeric id,
+   * converged onto every durable replica — the binding, the catalog, and every
+   * projected path (workspace clone URLs and authorization display paths).
+   *
+   * AWAITED under the caller's lease: those paths are hints keyed by the numeric
+   * id, and a fire-and-forget refresh can be skipped by a crash or reordered by an
+   * overlapping callback. Runs never overlap, so converging here is both durable
+   * and ordered; the daemon fan-out stays best-effort on the container side.
+   */
+  private async syncProjectFacts(
+    orgId: string,
+    bindingId: string,
+    projectId: bigint,
+    project: GitlabProjectWithNamespace
+  ): Promise<void> {
+    await this.deps.bindings.update(orgId, bindingId, {
+      projectPath: project.path_with_namespace,
+      defaultBranch: project.default_branch ?? null
+    })
+    await this.deps.catalog.upsert({
+      orgId,
+      provider: 'gitlab',
+      externalId: projectId,
+      displayPath: project.path_with_namespace,
+      ...(project.http_url_to_repo ? { cloneUrl: project.http_url_to_repo } : {}),
+      ...(project.default_branch ? { defaultBranch: project.default_branch } : {})
+    })
+    await this.deps.syncWorkspacePaths?.(orgId, projectId, project.path_with_namespace)
+  }
+
   private async agentAccountAttempt<T>(
     orgId: string,
     projectId: bigint,
     consumer: GitlabAccountConsumer,
-    commit: () => Promise<T>
+    commit: (live: { projectPath: string }) => Promise<T>
   ): Promise<AgentAccountOutcome<T>> {
     const binding = await this.deps.bindings.byProject(orgId, projectId)
     if (!binding || binding.state === 'cleanup_pending') {
@@ -233,6 +264,9 @@ export class GitlabProvisioner {
     // Set once the run knows where it is working, so a failure can undo exactly
     // what it speculatively created.
     let scope: { orgId: string; bindingId: string; projectId: bigint; rootGroupId: bigint; token: string } | undefined
+    // The provider's own current answer, handed to `commit` so the row it writes
+    // carries the live path rather than the caller's pre-lease capture.
+    let livePath = binding.projectPath
     try {
       let ensured: { ok: true } | { ok: false; reason: string; retryable: boolean }
       try {
@@ -243,6 +277,12 @@ export class GitlabProvisioner {
           this.deps.fetchImpl
         )) as GitlabProjectWithNamespace | null
         if (!project?.namespace) return { ok: false, reason: 'project_not_accessible', retryable: false }
+        // The path this read answers with is the CURRENT one; a caller committing a
+        // path it captured before the lease would persist a rename's losing side.
+        // Converging the replicas here first means the binding, the catalog, the
+        // projected paths, and the row `commit` writes all agree on one answer.
+        await this.syncProjectFacts(orgId, binding.id, binding.projectId, project)
+        livePath = project.path_with_namespace
         const root = await gitlabRootNamespace(token, project.namespace, this.deps.fetchImpl)
         // Service accounts hang off a top-level GROUP; a personal namespace has none (§5).
         if (root.kind !== 'group') return { ok: false, reason: 'personal_namespace_unsupported', retryable: false }
@@ -273,7 +313,7 @@ export class GitlabProvisioner {
       // STILL under the binding lease: the authorization row and the membership
       // become visible to convergence together, never one without the other.
       try {
-        return { ok: true, result: await commit() }
+        return { ok: true, result: await commit({ projectPath: livePath }) }
       } catch (e) {
         // The write never landed, so the bind it was for must not outlive it.
         if (scope) await this.deps.accounts.rollbackSpeculativeBind(scope, consumer.agentId)
@@ -410,24 +450,7 @@ export class GitlabProvisioner {
     // 1. Refresh the mutable facts by numeric id (rename-proof, §10.2 step 1).
     const project = (await gitlabProject(token, binding.projectId, fetchImpl)) as GitlabProjectWithNamespace | null
     if (!project) return { state: 'admin_degraded', reason: 'project_not_accessible' }
-    await this.deps.bindings.update(orgId, binding.id, {
-      projectPath: project.path_with_namespace,
-      defaultBranch: project.default_branch ?? null
-    })
-    await this.deps.catalog.upsert({
-      orgId,
-      provider: 'gitlab',
-      externalId: binding.projectId,
-      displayPath: project.path_with_namespace,
-      ...(project.http_url_to_repo ? { cloneUrl: project.http_url_to_repo } : {}),
-      ...(project.default_branch ? { defaultBranch: project.default_branch } : {})
-    })
-    // AWAITED under the run lease (round 3): the projected agent clone URLs are
-    // a mutable hint keyed by the numeric id, and a fire-and-forget refresh can
-    // be skipped by a crash or reordered by an overlapping callback. Runs never
-    // overlap, so converging here is both durable and ordered; the daemon
-    // fan-out stays best-effort on the container side.
-    await this.deps.syncWorkspacePaths?.(orgId, binding.projectId, project.path_with_namespace)
+    await this.syncProjectFacts(orgId, binding.id, binding.projectId, project)
     if (!project.namespace) return { state: 'admin_degraded', reason: 'project_namespace_unknown' }
     const root = await gitlabRootNamespace(token, project.namespace, fetchImpl)
     // Service accounts hang off a top-level GROUP; a personal namespace has none (§5).

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -313,7 +313,19 @@ export class GitlabProvisioner {
       // STILL under the binding lease: the authorization row and the membership
       // become visible to convergence together, never one without the other.
       try {
-        return { ok: true, result: await commit({ projectPath: livePath }) }
+        const result = await commit({ projectPath: livePath })
+        // The commit just made a new account and membership visible — and, after a
+        // rename, a new path. Compiled rules bake the project's bound
+        // service-account ids into their §12.1 veto set, and push events are
+        // relay-trusted once past it, so a rule left compiled from the old set
+        // would let this bot's own pushes trigger its siblings' hooks.
+        this.deps.onConverged?.(orgId, binding.projectId)
+        // The commit just made a new account and membership visible — and, after a
+        // rename, a new path. Compiled rules bake the project's bound
+        // service-account ids into their §12.1 veto set, and push events are
+        // relay-trusted once past it, so a rule left compiled from the old set
+        // would let this bot's own pushes trigger its siblings' hooks.
+        return { ok: true, result }
       } catch (e) {
         // The write never landed, so the bind it was for must not outlive it.
         if (scope) await this.deps.accounts.rollbackSpeculativeBind(scope, consumer.agentId)

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -20,6 +20,7 @@ import {
   RESERVED_MCP_SERVER_NAME,
   SESSION_RETENTION_RE,
   GitCloneUrlError,
+  CODE_HOST_PROVIDERS,
   HOOK_KINDS,
   RepoSubdirError,
   SessionImageAttachment,
@@ -1959,11 +1960,13 @@ export const GithubOwnerRepoParam = z.object({ id: z.string(), owner: z.string()
  *  hook write-back shape); `read`/`write` are uniform across capabilities. */
 export const RepoAccessDto = z.enum(['read', 'comment', 'write'])
 
-/** One explicit repo grant on an agent (the Repositories card). */
+/** One explicit repository grant on an agent (the Repositories card). */
 export const AgentRepoAuthDto = z.object({
   id: z.string(),
-  repoId: z.string(), // rename-proof GitHub numeric id
-  repoFullName: z.string(), // owner/repo as GitHub cases it (refreshed on rename)
+  /** The host that numbers `repoId` — identity is the pair, never the id alone (§8.1). */
+  provider: z.enum(CODE_HOST_PROVIDERS),
+  repoId: z.string(), // rename-proof numeric repository/project id
+  repoFullName: z.string(), // owner/repo as GitHub cases it, or the GitLab project path (refreshed on rename)
   access: RepoAccessDto,
   createdBy: z.string().nullable(), // app_user id (member directory resolves display)
   createdAt: z.string() // ISO-8601
@@ -1971,15 +1974,30 @@ export const AgentRepoAuthDto = z.object({
 export const AgentRepoAuthListDto = z.array(AgentRepoAuthDto)
 export type AgentRepoAuthDtoT = z.infer<typeof AgentRepoAuthDto>
 
-/** `POST /agents/:agentId/repos` — repo named by full name; the server resolves
- *  the numeric id through an org installation (never client-supplied). */
-export const CreateAgentRepoAuthBody = z.strictObject({
-  repoFullName: z
-    .string()
-    .trim()
-    .regex(/^[^/\s]+\/[^/\s]+$/, 'expected "owner/repo"'),
-  access: RepoAccessDto.default('read')
-})
+/** `POST /agents/:agentId/repos` — one arm per code host, keyed by `provider`.
+ *  A github repository is named by full name and the server resolves its numeric id
+ *  through an org installation; a gitlab project is named by the numeric project id
+ *  alone (§10.1 — the client never supplies facts, and a namespaced project path is
+ *  not `owner/repo` shaped).
+ *
+ *  Plain `z.union`, not `discriminatedUnion`: `provider` STAYS OPTIONAL on the github
+ *  arm because the published body never carried it, and a versioned surface must not
+ *  400 yesterday's valid body — a defaulted discriminator does not match an absent key. */
+export const CreateAgentRepoAuthBody = z.union([
+  z.strictObject({
+    provider: z.literal('gitlab'),
+    projectId: z.string().regex(/^[1-9]\d*$/),
+    access: RepoAccessDto.default('read')
+  }),
+  z.strictObject({
+    provider: z.literal('github').default('github'),
+    repoFullName: z
+      .string()
+      .trim()
+      .regex(/^[^/\s]+\/[^/\s]+$/, 'expected "owner/repo"'),
+    access: RepoAccessDto.default('read')
+  })
+])
 
 /** `PATCH /agents/:agentId/repos/:repoAuthId` — raise an existing grant's tier. */
 export const UpdateAgentRepoAuthBody = z.strictObject({ access: RepoAccessDto })

--- a/packages/control-plane/src/http/routes/agent-repos.ts
+++ b/packages/control-plane/src/http/routes/agent-repos.ts
@@ -1,23 +1,37 @@
 /**
- * `http/routes/agent-repos.ts` — explicit repo grants per agent
- * (issue #457, agent-multi-repo-authorization.md).
+ * `http/routes/agent-repos.ts` — explicit repository grants per agent
+ * (issue #457, agent-multi-repo-authorization.md; gitlab-com-integration.md §8.3).
  *
  * Authorization is anchored on the AGENT (a grant is subordinate to it, like a
  * hook): reads gate on the owning agent's visibility, writes on
  * `denyViewerWrite` — the hook-route precedent for agent-subordinate resources.
- * The numeric repo id is resolved server-side through an org installation
- * (create-time attribution proof, same as github-hook creation); with the
- * identity-assertion gate configured, the CALLER must hold the corresponding
- * GitHub permission on the repo (read/comment ⇒ ≥read, write ⇒ ≥write).
+ * The numeric repository id is resolved server-side, never client-supplied: github
+ * resolves it through an org installation (create-time attribution proof, same as
+ * github-hook creation) and gitlab through the org's own managed project binding.
+ * With the identity-assertion gate configured, a github CALLER must hold the
+ * corresponding permission on the repo (read/comment ⇒ ≥read, write ⇒ ≥write); the
+ * gitlab arm's proof is the binding, whose creation already required the installing
+ * user's Maintainer-or-Owner membership (§10.1).
+ *
+ * Authorizing a gitlab project makes the agent a CONSUMER of it (§7.2), so the arm
+ * runs the same inline account/membership ensure the workspace and hook arms run,
+ * and revoking converges the membership away.
  */
 import { gitRepoLabel } from '@agentconnect.md/protocol'
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
-import { isSyntheticEmail, type AgentRecord, type AgentRepoAuthorizationRecord } from '../../persistence/ports.js'
+import {
+  isSyntheticEmail,
+  type AgentRecord,
+  type AgentRepoAuthorizationRecord,
+  type RepoAccess
+} from '../../persistence/ports.js'
 import { AgentWorkspaceRepoConflict } from '../../persistence/errors.js'
 import { GithubApiError } from '../../github/api.js'
+import { gitlabAuthorizationAccessLevel } from '../../gitlab/api.js'
+import { gitlabAccountUnavailableMessage } from '../../gitlab/account.service.js'
 import { UserAuthzDeniedError } from '../../github/user-authz.js'
 import { LogtoApiError } from '../../github/logto-identity.js'
 import { AgentId, OrgId } from '../../domain/ids.js'
@@ -38,6 +52,7 @@ import {
 function toDto(r: AgentRepoAuthorizationRecord): AgentRepoAuthDtoT {
   return {
     id: r.id,
+    provider: r.provider,
     repoId: r.repoId.toString(),
     repoFullName: r.repoFullName,
     access: r.access,
@@ -110,6 +125,150 @@ export function agentRepoRoutes(deps: HttpDeps) {
       })
     }
 
+    // Authorization changed who consumes the project, so the §7.2 accounts and
+    // memberships must reconverge — the same kick a gitlab workspace or hook write
+    // does. Fire-and-forget: the saga outwaits a peer's lease on its own.
+    const convergeGitlabProject = (orgId: string, projectId: bigint): void => {
+      const gitlab = deps.gitlab
+      if (!gitlab) return
+      void gitlab.provisioner
+        .convergeProject(OrgId(orgId), projectId)
+        .catch((err) => app.log.warn({ err, projectId: projectId.toString() }, 'gitlab authorization converge failed'))
+    }
+
+    /** The gitlab arm of `POST /agents/:agentId/repos` (§8.3). */
+    const authorizeGitlabProject = async (
+      req: FastifyRequest,
+      reply: FastifyReply,
+      agent: AgentRecord,
+      body: { projectId: string; access: RepoAccess }
+    ): Promise<AgentRepoAuthDtoT | undefined> => {
+      const conflict = (message: string): undefined => {
+        void reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
+      }
+      const gitlab = deps.gitlab
+      if (!gitlab) return conflict('GitLab is not configured on this deployment')
+      const orgId = orgOf(req)
+      const projectId = BigInt(body.projectId)
+      // A grant never creates a binding, exactly as a hook never does (§8.3): the
+      // numeric id is validated against the organization's own row, never trusted.
+      const binding = await deps.repos.gitlabProjectBinding.byProject(orgId, projectId)
+      if (!binding || binding.state === 'cleanup_pending') {
+        return conflict('the project is not a managed GitLab project in this organization')
+      }
+      if (agent.workspace.mode === 'gitlab' && agent.workspaceRepoId === projectId) {
+        return conflict('this is already the agent’s workspace project')
+      }
+      const held = await deps.repos.agentRepoAuth.listForAgent(agent.id)
+      if (held.some((row) => row.provider === 'gitlab' && row.repoId === projectId)) {
+        return conflict(
+          `${binding.projectPath} is already authorized for this agent — upgrade that grant or remove it to lower the tier`
+        )
+      }
+      // Readers-first catalog convergence (gitlab-com-integration.md §8.1).
+      await deps.repos.codeHostRepository.upsert({
+        orgId,
+        provider: 'gitlab',
+        externalId: projectId,
+        displayPath: binding.projectPath,
+        cloneUrl: `https://gitlab.com/${binding.projectPath}`,
+        ...(binding.defaultBranch ? { defaultBranch: binding.defaultBranch } : {})
+      })
+      const create = (): Promise<AgentRepoAuthorizationRecord> =>
+        deps.repos.agentRepoAuth.create({
+          agentId: agent.id,
+          provider: 'gitlab',
+          repoId: projectId,
+          repoFullName: binding.projectPath,
+          access: body.access,
+          ...(req.principal ? { createdByUserId: req.principal.userId } : {})
+        })
+      // §7.2 identity bracket, exactly as the workspace and hook arms take it: the
+      // agent's own account and membership are provisioned FIRST and the grant row
+      // commits while the binding lease is still HELD, so convergence never sees a
+      // membership without the authorization that justifies it.
+      let applied
+      try {
+        applied = await gitlab.provisioner.provisionAgentAccount(
+          orgId,
+          projectId,
+          { agentId: agent.id, accessLevel: gitlabAuthorizationAccessLevel(body.access) },
+          create
+        )
+      } catch (err) {
+        // The grant rolled back, so the membership just bound belongs to an agent
+        // that does not consume the project: converge it away.
+        convergeGitlabProject(orgId, projectId)
+        throw err
+      }
+      if (!applied.ok) return conflict(gitlabAccountUnavailableMessage(applied.reason))
+      const row = applied.result
+      void deps.repos.audit
+        .append({
+          kind: 'agent_repo_change',
+          orgId,
+          agentId: agent.id,
+          ...(req.principal ? { actorUserId: req.principal.userId } : {}),
+          frameType: 'gitcred/grant',
+          message: `gitlab project ${row.repoFullName} authorized (${row.access})`,
+          details: { repoAuthId: row.id, provider: 'gitlab', repoFullName: row.repoFullName, access: row.access }
+        })
+        .catch(() => {})
+      await replicateUpsert(agent)
+      return toDto(row)
+    }
+
+    /** The gitlab arm of `PATCH /agents/:agentId/repos/:repoAuthId`: raising the tier
+     *  raises the account's project role, so it re-runs the same ensure the grant took. */
+    const upgradeGitlabAuthorization = async (
+      req: FastifyRequest,
+      reply: FastifyReply,
+      agent: AgentRecord,
+      row: AgentRepoAuthorizationRecord,
+      access: RepoAccess
+    ): Promise<AgentRepoAuthDtoT | undefined> => {
+      const conflict = (message: string): undefined => {
+        void reply.code(409).send({ error: 'Conflict', statusCode: 409, message })
+      }
+      const gitlab = deps.gitlab
+      if (!gitlab) return conflict('GitLab is not configured on this deployment')
+      const orgId = orgOf(req)
+      const binding = await deps.repos.gitlabProjectBinding.byProject(orgId, row.repoId)
+      if (!binding || binding.state === 'cleanup_pending') {
+        return conflict('the project is not a managed GitLab project in this organization')
+      }
+      const applied = await gitlab.provisioner.provisionAgentAccount(
+        orgId,
+        row.repoId,
+        { agentId: agent.id, accessLevel: gitlabAuthorizationAccessLevel(access) },
+        () => deps.repos.agentRepoAuth.updateAccess(row.id, access)
+      )
+      if (!applied.ok) return conflict(gitlabAccountUnavailableMessage(applied.reason))
+      const updated = applied.result
+      if (!updated) {
+        void reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'authorization not found' })
+        return undefined
+      }
+      void deps.repos.audit
+        .append({
+          kind: 'agent_repo_change',
+          orgId,
+          agentId: agent.id,
+          ...(req.principal ? { actorUserId: req.principal.userId } : {}),
+          frameType: 'gitcred/grant',
+          message: `gitlab project ${updated.repoFullName} authorization upgraded (${row.access} → ${updated.access})`,
+          details: {
+            repoAuthId: updated.id,
+            provider: 'gitlab',
+            repoFullName: updated.repoFullName,
+            previousAccess: row.access,
+            access: updated.access
+          }
+        })
+        .catch(() => {})
+      return toDto(updated)
+    }
+
     r.get(
       '/agents/:agentId/repos',
       {
@@ -138,7 +297,7 @@ export function agentRepoRoutes(deps: HttpDeps) {
           tags: [Tag.Agents],
           summary: 'Authorize a repository for an agent',
           description:
-            'Grant the agent access to a GitHub repository. App-backed workspaces may add repositories beyond their implicit workspace grant, scratch workspaces may add any covered repository, and a manual GitHub workspace may explicitly authorize only its own repository for control-plane review/check effects. The repository must be covered by one of the organization’s GitHub App installations; with the per-user gate configured, the caller must hold the matching GitHub permission (`read`/`comment` tiers need read, `write` needs write).',
+            'Grant the agent access to one code-host repository. With `provider: github` (the default) the repository is named `owner/repo` and must be covered by one of the organization’s GitHub App installations; App-backed workspaces may add repositories beyond their implicit workspace grant, scratch workspaces may add any covered repository, and a manual GitHub workspace may explicitly authorize only its own repository for control-plane review/check effects. With the per-user gate configured, the caller must hold the matching GitHub permission (`read`/`comment` tiers need read, `write` needs write). With `provider: gitlab` the project is named by its numeric id and must already be a managed GitLab project in this organization; authorizing it provisions the agent’s own GitLab bot account and project membership before the grant lands.',
           operationId: 'createAgentRepoAuthorization',
           params: z.object({ agentId: z.string() }),
           body: CreateAgentRepoAuthBody,
@@ -157,6 +316,7 @@ export function agentRepoRoutes(deps: HttpDeps) {
         if (denyViewerWrite(req, reply)) return
         const agent = await getViewableAgent(req, req.params.agentId)
         if (!agent) return agentNotFound(reply)
+        if (req.body.provider === 'gitlab') return authorizeGitlabProject(req, reply, agent, req.body)
         if (!deps.github) {
           return reply.code(409).send({
             error: 'Conflict',
@@ -235,6 +395,7 @@ export function agentRepoRoutes(deps: HttpDeps) {
           }
           const row = await deps.repos.agentRepoAuth.create({
             agentId: agent.id,
+            provider: 'github',
             repoId: ref.repoId,
             repoFullName: ref.fullName,
             access: req.body.access,
@@ -319,6 +480,7 @@ export function agentRepoRoutes(deps: HttpDeps) {
           })
         }
         if (req.body.access === row.access) return toDto(row)
+        if (row.provider === 'gitlab') return upgradeGitlabAuthorization(req, reply, agent, row, req.body.access)
 
         const [owner, repo] = row.repoFullName.split('/')
         const installation = owner
@@ -417,12 +579,21 @@ export function agentRepoRoutes(deps: HttpDeps) {
           }
           throw e
         }
-        const redundantWorkspaceGrant = workspaceRepoId === row.repoId
+        // The workspace is redundant with this grant only when it is the SAME host's
+        // repository: the two number theirs independently (§8.1).
+        const redundantWorkspaceGrant = workspaceRepoId === row.repoId && agent.workspace.mode === row.provider
         const now = new Date()
         // Persist one-way cleanup authority and drop the grant atomically under
         // the projection lifecycle lock. Deleting first could leave a passing
         // Check that the normal reporter is no longer authorized to clean up.
-        await deps.repos.agentRepoAuth.removeWithReviewProjectionCleanup(row.id, agent.id, row.repoId, now, 'failure')
+        await deps.repos.agentRepoAuth.removeWithReviewProjectionCleanup(
+          row.id,
+          agent.id,
+          row.provider,
+          row.repoId,
+          now,
+          'failure'
+        )
         void deps.repos.audit
           .append({
             kind: 'agent_repo_change',
@@ -433,9 +604,17 @@ export function agentRepoRoutes(deps: HttpDeps) {
             message: redundantWorkspaceGrant
               ? `redundant workspace repo ${row.repoFullName} authorization removed`
               : `repo ${row.repoFullName} authorization revoked`,
-            details: { repoAuthId: row.id, repoFullName: row.repoFullName, redundantWorkspaceGrant }
+            details: {
+              repoAuthId: row.id,
+              provider: row.provider,
+              repoFullName: row.repoFullName,
+              redundantWorkspaceGrant
+            }
           })
           .catch(() => {})
+        // Revoked authorization ⇒ the agent is no longer a consumer, so the §7.2
+        // membership must go — and with nothing left in its root, the account retires.
+        if (row.provider === 'gitlab' && !redundantWorkspaceGrant) convergeGitlabProject(orgOf(req), row.repoId)
         await replicateUpsert(agent)
         return reply.code(204).send(null)
       }

--- a/packages/control-plane/src/http/routes/agent-repos.ts
+++ b/packages/control-plane/src/http/routes/agent-repos.ts
@@ -165,21 +165,15 @@ export function agentRepoRoutes(deps: HttpDeps) {
           `${binding.projectPath} is already authorized for this agent — upgrade that grant or remove it to lower the tier`
         )
       }
-      // Readers-first catalog convergence (gitlab-com-integration.md §8.1).
-      await deps.repos.codeHostRepository.upsert({
-        orgId,
-        provider: 'gitlab',
-        externalId: projectId,
-        displayPath: binding.projectPath,
-        cloneUrl: `https://gitlab.com/${binding.projectPath}`,
-        ...(binding.defaultBranch ? { defaultBranch: binding.defaultBranch } : {})
-      })
-      const create = (): Promise<AgentRepoAuthorizationRecord> =>
+      // The path comes from the provider's answer INSIDE the lease, never from the
+      // binding read above: a rename between the two would otherwise persist and
+      // replicate the losing side, leaving the daemon unable to map the checkout.
+      const create = (live: { projectPath: string }): Promise<AgentRepoAuthorizationRecord> =>
         deps.repos.agentRepoAuth.create({
           agentId: agent.id,
           provider: 'gitlab',
           repoId: projectId,
-          repoFullName: binding.projectPath,
+          repoFullName: live.projectPath,
           access: body.access,
           ...(req.principal ? { createdByUserId: req.principal.userId } : {})
         })
@@ -241,6 +235,7 @@ export function agentRepoRoutes(deps: HttpDeps) {
         orgId,
         row.repoId,
         { agentId: agent.id, accessLevel: gitlabAuthorizationAccessLevel(access) },
+        // Access-only: the row's path is converged by the same lease's fact sync.
         () => deps.repos.agentRepoAuth.updateAccess(row.id, access)
       )
       if (!applied.ok) return conflict(gitlabAccountUnavailableMessage(applied.reason))

--- a/packages/control-plane/src/http/routes/agent-repos.ts
+++ b/packages/control-plane/src/http/routes/agent-repos.ts
@@ -373,7 +373,13 @@ export function agentRepoRoutes(deps: HttpDeps) {
               message: 'this is already the agent’s workspace repository'
             })
           }
-          if ((await deps.repos.agentRepoAuth.listForAgent(agent.id)).some((row) => row.repoId === ref.repoId)) {
+          // Provider-qualified: a GitLab project numbered the same is a different
+          // repository, and the unique key permits both (§8.1).
+          if (
+            (await deps.repos.agentRepoAuth.listForAgent(agent.id)).some(
+              (row) => row.provider === 'github' && row.repoId === ref.repoId
+            )
+          ) {
             return reply.code(409).send({
               error: 'Conflict',
               statusCode: 409,

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -2488,8 +2488,18 @@ export function agentRoutes(deps: HttpDeps) {
           // cannot serve this — activation would be refused, the edit would roll
           // back, and the agent would never become the consumer that convergence
           // needs a reason to provision for.
-          const applyWorkspace = (): Promise<AgentRecord> =>
-            agentMoves.setWorkspace(existing, workspace, workspaceRepoId, req.principal?.userId)
+          // A gitlab clone URL is built from the binding read BEFORE the lease, and
+          // the lease's own project read converges every replicated path. Rebuilding
+          // from the live answer keeps this write from putting the stale one back.
+          const applyWorkspace = (live?: { projectPath: string }): Promise<AgentRecord> =>
+            agentMoves.setWorkspace(
+              existing,
+              live && workspace.mode === 'gitlab'
+                ? { ...workspace, gitRepo: `https://gitlab.com/${live.projectPath}` }
+                : workspace,
+              workspaceRepoId,
+              req.principal?.userId
+            )
           let converted: AgentRecord
           if (workspace.mode === 'gitlab' && workspaceRepoId !== undefined && deps.gitlab) {
             let applied

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -11,7 +11,7 @@
  * echoed EXACTLY ONCE in the create response and never retrievable after.
  */
 import { randomBytes, randomUUID } from 'node:crypto'
-import { gitRepoLabel } from '@agentconnect.md/protocol'
+import { gitRepoLabel, type CodeHostProvider } from '@agentconnect.md/protocol'
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
@@ -239,29 +239,36 @@ export function hookRoutes(deps: HttpDeps) {
     } as const
 
     // The trigger plane must not outrun the credential plane (issue #457,
-    // multi-repo design decision 6): a github hook may only watch the agent's
-    // workspace repo or an explicitly authorized one — otherwise the agent's
-    // `gh` write-back on the watched repo is credential-less by construction.
-    // Enforced on create and on a repo-CHANGING edit; pre-existing rows are
-    // grandfathered (the console badges them instead).
+    // multi-repo design decision 6; gitlab-com-integration.md §8.3): a code-host
+    // hook may only watch the agent's workspace repository or an explicitly
+    // authorized one — otherwise the agent's write-back on the watched repository
+    // is credential-less by construction, which is exactly the "could not review"
+    // note both agents post. Enforced on create and on a binding-CHANGING edit;
+    // pre-existing rows are grandfathered (the console badges them instead).
     type WatchRepoAuthz = { ok: true } | { ok: false; status: 409 | 429 | 502; message: string }
     const watchRepoAuthorized = async (
       agent: AgentRecord,
+      provider: CodeHostProvider,
       repoId: bigint,
       repoFullName: string
     ): Promise<WatchRepoAuthz> => {
+      const subject = provider === 'gitlab' ? 'project' : 'repository'
       const denied = {
         ok: false,
         status: 409,
-        message: `${repoFullName} is not authorized for this agent — add it under the agent's Repositories settings first`
+        message: `${repoFullName} is not authorized for this agent — authorize the ${subject} for it, or make it the agent's workspace ${subject}, then create the trigger`
       } as const
       const explicitlyGranted = async () =>
-        (await deps.repos.agentRepoAuth.listForAgent(agent.id)).some((row) => row.repoId === repoId)
-      if (agent.workspaceRepoId === repoId) return { ok: true }
+        (await deps.repos.agentRepoAuth.listForAgent(agent.id)).some(
+          (row) => row.provider === provider && row.repoId === repoId
+        )
+      // The workspace is this repository only when it is the SAME host's: the two
+      // number theirs independently, so `workspaceMode` qualifies the id (§8.1).
+      if (agent.workspaceRepoId === repoId && agent.workspace.mode === provider) return { ok: true }
       // Legacy workspace rows acquire their rename-proof id lazily. The stored
       // name is only an endpoint hint: after a GitHub rename the requested
       // canonical name differs, so always resolve and compare numeric identity.
-      if (agent.workspace.mode === 'github' && deps.github) {
+      if (provider === 'github' && agent.workspace.mode === 'github' && deps.github) {
         const workspaceLabel = gitRepoLabel(agent.workspace.gitRepo)
         const [owner, repo] = workspaceLabel.split('/')
         const ins = owner ? await deps.repos.githubInstallation.liveByOrgAndAccount(agent.orgId, owner) : null
@@ -458,6 +465,10 @@ export function hookRoutes(deps: HttpDeps) {
                       message: `this agent already watches ${binding.projectPath}`
                     }
                   }
+                  // §8.3: creating a hook never creates a grant, so the project must
+                  // ALREADY be the workspace or an explicit additional authorization.
+                  const authz = await watchRepoAuthorized(agent, 'gitlab', projectId, binding.projectPath)
+                  if (!authz.ok) return authz
                   const effectError = validateGitlabEffects(binding, {
                     reviewPolicy: req.body.kind === 'gitlab' ? req.body.reviewPolicy : 'off',
                     reportingMode: req.body.kind === 'gitlab' ? req.body.reportingMode : 'off'
@@ -487,7 +498,7 @@ export function hookRoutes(deps: HttpDeps) {
                       message: `this agent already watches ${repo.repoFullName}`
                     }
                   }
-                  const authz = await watchRepoAuthorized(agent, repo.repoId, repo.repoFullName)
+                  const authz = await watchRepoAuthorized(agent, 'github', repo.repoId, repo.repoFullName)
                   if (!authz.ok) return authz
                   const configError = await validateGithubEffects(agent, repo.repoId, repo.repoFullName, {
                     reviewPolicy: req.body.kind === 'github' ? req.body.reviewPolicy : 'off',
@@ -753,7 +764,7 @@ export function hookRoutes(deps: HttpDeps) {
           // not brick an existing hook.
           const bindingChanged = repo.repoId !== existing.repoId || agent.id !== existing.agentId
           if (bindingChanged) {
-            const authz = await watchRepoAuthorized(agent, repo.repoId, repo.repoFullName)
+            const authz = await watchRepoAuthorized(agent, 'github', repo.repoId, repo.repoFullName)
             if (!authz.ok) {
               return reply.code(authz.status).send({
                 error: ERROR_NAMES[authz.status],
@@ -802,6 +813,19 @@ export function hookRoutes(deps: HttpDeps) {
               statusCode: 409,
               message: `this agent already watches ${binding.projectPath}`
             })
+          }
+          // Binding-CHANGING edits go through the §8.3 gate — a new project, or the
+          // same project moved onto a different agent. An edit that keeps the
+          // (grandfathered) pair must not brick an existing hook, exactly as github.
+          if (projectId !== existing.repoId || agent.id !== existing.agentId) {
+            const authz = await watchRepoAuthorized(agent, 'gitlab', projectId, binding.projectPath)
+            if (!authz.ok) {
+              return reply.code(authz.status).send({
+                error: ERROR_NAMES[authz.status],
+                statusCode: authz.status,
+                message: authz.message
+              })
+            }
           }
           const effectConfig = {
             reviewPolicy: req.body.reviewPolicy ?? existing.reviewPolicy,

--- a/packages/control-plane/src/orchestrator/agentDelivery.ts
+++ b/packages/control-plane/src/orchestrator/agentDelivery.ts
@@ -95,13 +95,16 @@ export class AgentDelivery {
   /** Push an edited spec to every delivery target. The spec is assembled ONCE:
    *  the targets replicate the same agent, and two assemblies could disagree. */
   async upsert(agent: AgentRecord, onError: DeliveryErrorHandler): Promise<void> {
-    // §17.3 projection gate: a target that has not advertised the agent's required
-    // features is skipped rather than sent a frame it cannot decode.
-    const targets = (await this.daemonsFor(agent)).filter((daemonId) =>
-      daemonSupportsAgent(agent, this.deps.daemonFeatures?.(daemonId))
-    )
-    if (targets.length === 0) return
+    const candidates = await this.daemonsFor(agent)
+    if (candidates.length === 0) return
     const spec = await this.deps.specs.assemble(agent)
+    // §17.3 projection gate, judged on the ASSEMBLED spec: a gitlab additional
+    // repository is only visible there (grants are their own table), and a target
+    // that has not advertised the required features is skipped rather than sent a
+    // frame it would decode into the wrong host.
+    const shaped = spec.workspace ? { workspace: spec.workspace } : agent
+    const targets = candidates.filter((daemonId) => daemonSupportsAgent(shaped, this.deps.daemonFeatures?.(daemonId)))
+    if (targets.length === 0) return
     await this.fanOut(targets, onError, (daemonId) =>
       this.deps.control.agentUpsert(daemonId, { agentId: agent.id, spec }, agent.orgId)
     )

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.test.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.test.ts
@@ -71,6 +71,7 @@ function repoAuthWith(rows: Array<[fullName: string, repoId: bigint]>): AgentRep
       rows.map(([repoFullName, repoId], index) => ({
         id: `auth-${index}`,
         agentId,
+        provider: 'github' as const,
         repoId,
         repoFullName,
         access: 'read' as const,
@@ -239,7 +240,7 @@ describe('AgentSpecAssembler', () => {
 
   it('project trusts the caller-snapshotted allowlist (the move bundle pins it)', () => {
     const specs = assemblerWith(repoAuthWith([['acme/infra', 4711n]]))
-    const pinned = [{ repoFullName: 'example-co/shared-library', repoId: '815' }]
+    const pinned = [{ repoFullName: 'example-co/shared-library', repoId: '815', provider: 'github' }]
 
     const spec = specs.project(AGENT, {}, [], [], undefined, pinned)
 

--- a/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
+++ b/packages/control-plane/src/orchestrator/agentSpecAssembler.ts
@@ -43,6 +43,9 @@ import {
 /** The wire spec plus the id it is keyed by on `agent/upsert` / the roster. */
 export type AssembledAgentSpec = AgentSpec & { agentId: string }
 
+/** Byte-order string compare — deliberately not `localeCompare`, whose order is host-dependent. */
+const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0)
+
 export class AgentSpecAssembler {
   constructor(
     private readonly secrets: AgentSecretStore,
@@ -114,14 +117,15 @@ export class AgentSpecAssembler {
     return this.secrets.get(a.orgId, a.id)
   }
 
-  /** The agent's authorized additional repositories, sorted by full name so the
-   *  projection is stable (a reordered read must not change the spec digest).
+  /** The agent's authorized additional repositories, sorted by provider then full name
+   *  so the projection is stable (a reordered read must not change the spec digest) —
+   *  two hosts can display the same path, so the name alone is not a total order.
    *  Pinned into the move {@link MoveBundle} for the same reason as skills. */
   async additionalReposOf(a: Pick<AgentRecord, 'id'>): Promise<AgentAdditionalRepo[]> {
     const rows = (await this.agentRepoAuth?.listForAgent(a.id)) ?? []
     return rows
-      .map((row) => ({ repoFullName: row.repoFullName, repoId: row.repoId.toString() }))
-      .sort((x, y) => (x.repoFullName < y.repoFullName ? -1 : x.repoFullName > y.repoFullName ? 1 : 0))
+      .map((row) => ({ repoFullName: row.repoFullName, repoId: row.repoId.toString(), provider: row.provider }))
+      .sort((x, y) => cmp(x.provider, y.provider) || cmp(x.repoFullName, y.repoFullName))
   }
 
   /** Resolve the agent's skill entries — pinned into the move {@link MoveBundle} so

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -878,10 +878,12 @@ export interface AgentRepo {
    *  numeric repo without tombstoning projections: workspace authority remains
    *  live. A concurrently deleted or differently repaired agent is a no-op. */
   setWorkspaceRepoId(agentId: AgentId, repoId: bigint): Promise<boolean>
-  /** Converge gitlab-workspace clone URLs after a binding path refresh (rename)
-   *  — bumps configRevision so the fenced spec push replicates. Returns the
-   *  affected agent ids. */
-  refreshGitlabWorkspacePath(orgId: OrgId, projectId: bigint, cloneUrl: string): Promise<AgentId[]>
+  /** Converge everything a gitlab project path is replicated into after a binding
+   *  path refresh (rename): gitlab-workspace clone URLs AND every explicit
+   *  authorization's display path, which is how the daemon maps a named project
+   *  back to its numeric id. Bumps configRevision once per agent so the fenced
+   *  spec push replicates. Returns the affected agent ids. */
+  refreshGitlabProjectPath(orgId: OrgId, projectId: bigint, projectPath: string): Promise<AgentId[]>
   /** Set the visibility + share set (the dedicated `/sharing` write path, kept
    *  separate from content `update`). An org→restricted transition atomically
    *  closes known direct-conversation rows. Stamps the last-modified audit;

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3761,8 +3761,9 @@ export type RepoAccess = 'read' | 'comment' | 'write'
 export interface AgentRepoAuthorizationRecord {
   id: string
   agentId: AgentId
+  provider: CodeHostProvider // the host that numbers `repoId` — identity is (provider, repoId)
   repoId: bigint
-  repoFullName: string // "owner/repo" as GitHub cases it; refreshed on rename detection
+  repoFullName: string // "owner/repo" as GitHub cases it, or a GitLab namespaced project path; refreshed on rename detection
   access: RepoAccess
   createdAt: Date
   createdBy: AgentCreator | null // audit: who authorized (identity-assertion subject)
@@ -3775,6 +3776,7 @@ export interface AgentRepoAuthorizationRepo {
    *  may grant any covered repo. */
   create(input: {
     agentId: AgentId
+    provider: CodeHostProvider
     repoId: bigint
     repoFullName: string
     access: RepoAccess
@@ -3796,6 +3798,7 @@ export interface AgentRepoAuthorizationRepo {
   removeWithReviewProjectionCleanup(
     id: string,
     agentId: AgentId,
+    provider: CodeHostProvider,
     repoId: bigint,
     at: Date,
     desiredState: string

--- a/packages/control-plane/src/persistence/repositories/agent-repo-auth.repo.test.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-repo-auth.repo.test.ts
@@ -33,7 +33,9 @@ describe('workspace repository identity and additional grants', () => {
       where: { id: AGENT },
       data: { workspaceRepoId: REPO, configRevision: { increment: 1 } }
     })
-    expect(tx.agentRepoAuthorization.deleteMany).toHaveBeenCalledWith({ where: { agentId: AGENT, repoId: REPO } })
+    expect(tx.agentRepoAuthorization.deleteMany).toHaveBeenCalledWith({
+      where: { agentId: AGENT, provider: 'github', repoId: REPO }
+    })
     // No HookReviewProjection operation is part of redundant-grant repair.
     expect(Object.hasOwn(tx, 'hookReviewProjection')).toBe(false)
   })
@@ -42,21 +44,52 @@ describe('workspace repository identity and additional grants', () => {
     const create = vi.fn()
     const tx = {
       $queryRaw: vi.fn(async () => []),
-      agent: { findUnique: vi.fn(async () => ({ workspaceRepoId: REPO })) },
+      agent: { findUnique: vi.fn(async () => ({ workspaceMode: 'github', workspaceRepoId: REPO })) },
       agentRepoAuthorization: { create }
     }
     const repo = new PgAgentRepoAuthorizationRepo(transactionalDb(tx) as never)
 
     await expect(
-      repo.create({ agentId: AGENT, repoId: REPO, repoFullName: 'acme/infra', access: 'write' })
+      repo.create({ agentId: AGENT, provider: 'github', repoId: REPO, repoFullName: 'acme/infra', access: 'write' })
     ).rejects.toBeInstanceOf(AgentWorkspaceRepoConflict)
     expect(create).not.toHaveBeenCalled()
+  })
+
+  it('lets a gitlab grant name the numeric id a github workspace already holds', async () => {
+    const create = vi.fn(async () => ({
+      id: 'ra-1',
+      agentId: AGENT,
+      provider: 'gitlab',
+      repoId: REPO,
+      repoFullName: 'example-group/example-project',
+      access: 'read',
+      createdAt: new Date(0),
+      createdBy: null
+    }))
+    const tx = {
+      $queryRaw: vi.fn(async () => [{ id: AGENT }]),
+      agent: {
+        findUnique: vi.fn(async () => ({ workspaceMode: 'github', workspaceRepoId: REPO })),
+        updateMany: vi.fn(async () => ({ count: 1 }))
+      },
+      agentRepoAuthorization: { create }
+    }
+    const repo = new PgAgentRepoAuthorizationRepo(transactionalDb(tx) as never)
+
+    await repo.create({
+      agentId: AGENT,
+      provider: 'gitlab',
+      repoId: REPO,
+      repoFullName: 'example-group/example-project',
+      access: 'read'
+    })
+    expect(create).toHaveBeenCalledOnce()
   })
 
   it('deletes a redundant workspace grant without tombstoning live projections', async () => {
     const tx = {
       $queryRaw: vi.fn(async () => []),
-      agent: { findUnique: vi.fn(async () => ({ workspaceRepoId: REPO })) },
+      agent: { findUnique: vi.fn(async () => ({ workspaceMode: 'github', workspaceRepoId: REPO })) },
       agentRepoAuthorization: { deleteMany: vi.fn(async () => ({ count: 1 })) }
     }
     const repo = new PgAgentRepoAuthorizationRepo(transactionalDb(tx) as never)
@@ -64,6 +97,7 @@ describe('workspace repository identity and additional grants', () => {
     await repo.removeWithReviewProjectionCleanup(
       '22222222-2222-4222-8222-222222222222',
       AGENT,
+      'github',
       REPO,
       new Date('2026-07-11T00:00:00.000Z'),
       'failure'

--- a/packages/control-plane/src/persistence/repositories/agent-repo-auth.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent-repo-auth.repo.ts
@@ -1,6 +1,6 @@
 /**
- * PgAgentRepoAuthorizationRepo — explicit repo grants per agent
- * (issue #457, agent-multi-repo-authorization.md).
+ * PgAgentRepoAuthorizationRepo — explicit repository grants per agent
+ * (issue #457, agent-multi-repo-authorization.md; gitlab-com-integration.md §8.3).
  *
  * Metadata only (repo identity + access tier); no token material ever lands
  * here. Rows are hard-deleted on revoke — unlike installations there is no
@@ -16,6 +16,7 @@
 import type { AgentRepoAuthorization, PrismaClient, User } from '../../generated/prisma/client.js'
 import { Prisma } from '../../generated/prisma/client.js'
 import type { PrismaLike } from '../prisma.js'
+import type { CodeHostProvider } from '@agentconnect.md/protocol'
 import type { AgentRepoAuthorizationRecord, AgentRepoAuthorizationRepo, RepoAccess } from '../ports.js'
 import { AgentId } from '../../domain/ids.js'
 import { PgHookRepo } from './hook.repo.js'
@@ -31,6 +32,7 @@ function toRecord(r: Row): AgentRepoAuthorizationRecord {
   return {
     id: r.id,
     agentId: AgentId(r.agentId),
+    provider: r.provider as CodeHostProvider,
     repoId: r.repoId,
     repoFullName: r.repoFullName,
     access: r.access as RepoAccess,
@@ -51,6 +53,7 @@ export class PgAgentRepoAuthorizationRepo implements AgentRepoAuthorizationRepo 
 
   async create(input: {
     agentId: AgentId
+    provider: CodeHostProvider
     repoId: bigint
     repoFullName: string
     access: RepoAccess
@@ -61,11 +64,19 @@ export class PgAgentRepoAuthorizationRepo implements AgentRepoAuthorizationRepo 
       // deletes the now-redundant row; if repair wins, create observes the
       // numeric workspace identity and refuses to recreate it.
       await lockHookReviewAgentRepoScope(tx, input.agentId, input.repoId)
-      const agent = await tx.agent.findUnique({ where: { id: input.agentId }, select: { workspaceRepoId: true } })
-      if (agent?.workspaceRepoId === input.repoId) throw new AgentWorkspaceRepoConflict(input.repoId)
+      const agent = await tx.agent.findUnique({
+        where: { id: input.agentId },
+        select: { workspaceRepoId: true, workspaceMode: true }
+      })
+      // The hosts number repositories independently, so the workspace collides only
+      // when the grant names ITS provider — `workspaceMode` doubles as that provider.
+      if (agent?.workspaceRepoId === input.repoId && agent.workspaceMode === input.provider) {
+        throw new AgentWorkspaceRepoConflict(input.repoId)
+      }
       const row = await tx.agentRepoAuthorization.create({
         data: {
           agentId: input.agentId,
+          provider: input.provider,
           repoId: input.repoId,
           repoFullName: input.repoFullName,
           access: input.access,
@@ -122,23 +133,31 @@ export class PgAgentRepoAuthorizationRepo implements AgentRepoAuthorizationRepo 
   async removeWithReviewProjectionCleanup(
     id: string,
     agentId: AgentId,
+    provider: CodeHostProvider,
     repoId: bigint,
     at: Date,
     desiredState: string
   ): Promise<void> {
     await this.transaction(async (tx) => {
       await lockHookReviewAgentRepoScope(tx, agentId, repoId)
-      const agent = await tx.agent.findUnique({ where: { id: agentId }, select: { workspaceRepoId: true } })
+      const agent = await tx.agent.findUnique({
+        where: { id: agentId },
+        select: { workspaceRepoId: true, workspaceMode: true }
+      })
+      const workspaceIsThisRepo = agent?.workspaceRepoId === repoId && agent.workspaceMode === provider
+      // HookReviewProjection is the GitHub Checks ledger — GitLab publishes notes and
+      // has no durable projection to retire, so only a github grant reaches it.
+      //
       // A lazy workspace repair may have classified this legacy grant while
       // the delete request was in flight. Deleting the duplicate is harmless;
       // tombstoning would incorrectly revoke still-valid workspace Checks.
-      if (agent?.workspaceRepoId !== repoId) {
+      if (provider === 'github' && !workspaceIsThisRepo) {
         // PgHookRepo re-enters the same xact advisory lock before its candidate
         // scan. PostgreSQL transaction advisory locks are re-entrant, keeping
         // the shared lock order without opening a no-row race.
         await new PgHookRepo(tx).tombstoneReviewProjectionsForAgentRepo(agentId, repoId, at, desiredState)
       }
-      const removed = await tx.agentRepoAuthorization.deleteMany({ where: { id, agentId, repoId } })
+      const removed = await tx.agentRepoAuthorization.deleteMany({ where: { id, agentId, provider, repoId } })
       if (removed.count > 0) await bumpAgentConfigRevisions(tx, [agentId])
     })
   }

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -770,7 +770,9 @@ export class PgAgentRepo implements AgentRepo {
         where: { id: agentId },
         data: { workspaceRepoId: repoId, configRevision: { increment: 1 } }
       })
-      await tx.agentRepoAuthorization.deleteMany({ where: { agentId, repoId } })
+      // Only the github grant is redundant with a github workspace: a gitlab project
+      // that happens to carry the same number is a different repository (§8.1).
+      await tx.agentRepoAuthorization.deleteMany({ where: { agentId, provider: 'github', repoId } })
       return true
     })
   }

--- a/packages/control-plane/src/persistence/repositories/agent.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/agent.repo.ts
@@ -53,7 +53,12 @@ function placementCreateColumns(input: { placementKind?: PlacementKind; daemonId
     return { placementKind: 'set', setId: input.setId, status: 'active' }
   return input.daemonId ? { daemonId: input.daemonId, status: 'active' } : {}
 }
-import { fenceAgentLocalConfigWrite, lockOrgForConfigWrite, orgIdOfAgent } from './organization-environment-fence.js'
+import {
+  bumpAgentConfigRevisions,
+  fenceAgentLocalConfigWrite,
+  lockOrgForConfigWrite,
+  orgIdOfAgent
+} from './organization-environment-fence.js'
 import {
   AgentMissing,
   AgentWorkspaceIntegrationConflict,
@@ -728,21 +733,46 @@ export class PgAgentRepo implements AgentRepo {
     }
   }
 
-  async refreshGitlabWorkspacePath(orgId: OrgId, projectId: bigint, cloneUrl: string): Promise<AgentId[]> {
-    // The clone URL is a mutable display/transport hint keyed by the immutable
-    // project id (§8.1); a rename refresh must reach every replicated spec, so
-    // the write joins the configRevision ordering domain the daemon fences on.
-    const drifted = await this.db.agent.findMany({
-      where: { orgId, workspaceMode: 'gitlab', workspaceRepoId: projectId, NOT: { gitRepo: cloneUrl } },
-      select: { id: true }
+  async refreshGitlabProjectPath(orgId: OrgId, projectId: bigint, projectPath: string): Promise<AgentId[]> {
+    // The path is a mutable display/transport hint keyed by the immutable project
+    // id (§8.1). Both places that replicate it drift on a rename: a gitlab
+    // workspace's clone URL, and every explicit authorization's display path,
+    // which is what the daemon maps a NAMED project back to its numeric id with
+    // (§13.1). Leaving a grant stale orphans the new path and makes an ask under
+    // the old one fail the daemon's echo check against the binding's new path.
+    // Both writes join the configRevision ordering domain the daemon fences on,
+    // in one transaction, so a spec never carries one half of the rename.
+    const cloneUrl = `https://gitlab.com/${projectPath}`
+    return this.transaction(async (tx) => {
+      const workspaces = await tx.agent.findMany({
+        where: { orgId, workspaceMode: 'gitlab', workspaceRepoId: projectId, NOT: { gitRepo: cloneUrl } },
+        select: { id: true }
+      })
+      const workspaceIds = workspaces.map((row: { id: string }) => row.id)
+      if (workspaceIds.length > 0) {
+        await tx.agent.updateMany({
+          where: { id: { in: workspaceIds }, orgId, workspaceMode: 'gitlab', workspaceRepoId: projectId },
+          data: { gitRepo: cloneUrl }
+        })
+      }
+      const staleGrants = {
+        provider: 'gitlab',
+        repoId: projectId,
+        agent: { orgId },
+        repoFullName: { not: projectPath }
+      }
+      const grantAgentIds = (
+        await tx.agentRepoAuthorization.findMany({ where: staleGrants, select: { agentId: true } })
+      ).map((row: { agentId: string }) => row.agentId)
+      if (grantAgentIds.length > 0) {
+        await tx.agentRepoAuthorization.updateMany({ where: staleGrants, data: { repoFullName: projectPath } })
+      }
+      const ids = [...new Set([...workspaceIds, ...grantAgentIds])].sort()
+      // One bump per agent, after both writes: an agent holding the workspace AND
+      // a grant on the same project must not advance two revisions for one rename.
+      await bumpAgentConfigRevisions(tx, ids)
+      return ids.map((id: string) => AgentId(id))
     })
-    if (drifted.length === 0) return []
-    const ids = drifted.map((row: { id: string }) => row.id)
-    await this.db.agent.updateMany({
-      where: { id: { in: ids }, orgId, workspaceMode: 'gitlab', workspaceRepoId: projectId },
-      data: { gitRepo: cloneUrl, configRevision: { increment: 1 } }
-    })
-    return ids.map((id: string) => AgentId(id))
   }
 
   async setWorkspaceRepoId(agentId: AgentId, repoId: bigint): Promise<boolean> {

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -43,7 +43,11 @@ import type {
 import type { SecretCipher } from '../../secrets/cipher.js'
 import { orgScope } from '../../secrets/scope.js'
 import { OrgId } from '../../domain/ids.js'
-import { GITLAB_ACCESS_DEVELOPER as ACCESS_DEVELOPER, gitlabWorkspaceAccessLevel } from '../../gitlab/api.js'
+import {
+  GITLAB_ACCESS_DEVELOPER as ACCESS_DEVELOPER,
+  gitlabAuthorizationAccessLevel,
+  gitlabWorkspaceAccessLevel
+} from '../../gitlab/api.js'
 
 const CONNECTION_STATES: readonly GitlabConnectionState[] = ['connected', 'reauth_required', 'disconnected']
 
@@ -833,7 +837,7 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
   }
 
   async consumers(orgId: string, projectId: bigint): Promise<GitlabAccountConsumer[]> {
-    const [workspaces, hooks] = await Promise.all([
+    const [workspaces, hooks, grants] = await Promise.all([
       this.prisma.agent.findMany({
         where: { orgId, workspaceMode: 'gitlab', workspaceRepoId: projectId },
         select: { id: true, gitAccess: true }
@@ -841,6 +845,10 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
       this.prisma.hookDef.findMany({
         where: { orgId, kind: 'gitlab', enabled: true, repoId: projectId, agentId: { not: null } },
         select: { agentId: true }
+      }),
+      this.prisma.agentRepoAuthorization.findMany({
+        where: { provider: 'gitlab', repoId: projectId, agent: { orgId } },
+        select: { agentId: true, access: true }
       })
     ])
     const levels = new Map<string, number>()
@@ -851,11 +859,14 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
     for (const row of workspaces) raise(row.id, gitlabWorkspaceAccessLevel(row.gitAccess))
     // A hook consumer posts notes and may run the configured review policy.
     for (const row of hooks) if (row.agentId) raise(row.agentId, ACCESS_DEVELOPER)
+    // An explicit additional-project authorization is a consumer too (§8.3): without
+    // it, the membership such a grant binds would be unbound by the next converge.
+    for (const row of grants) raise(row.agentId, gitlabAuthorizationAccessLevel(row.access))
     return [...levels].map(([agentId, accessLevel]) => ({ agentId, accessLevel }))
   }
 
   async consumersForOrg(orgId: string): Promise<GitlabProjectConsumer[]> {
-    const [workspaces, hooks] = await Promise.all([
+    const [workspaces, hooks, grants] = await Promise.all([
       this.prisma.agent.findMany({
         where: { orgId, workspaceMode: 'gitlab', workspaceRepoId: { not: null } },
         select: { id: true, gitAccess: true, workspaceRepoId: true }
@@ -863,6 +874,10 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
       this.prisma.hookDef.findMany({
         where: { orgId, kind: 'gitlab', enabled: true, repoId: { not: null }, agentId: { not: null } },
         select: { agentId: true, repoId: true }
+      }),
+      this.prisma.agentRepoAuthorization.findMany({
+        where: { provider: 'gitlab', agent: { orgId } },
+        select: { agentId: true, repoId: true, access: true }
       })
     ])
     const levels = new Map<string, GitlabProjectConsumer>()
@@ -876,6 +891,8 @@ export class PgGitlabAgentAccountRepo implements GitlabAgentAccountRepo {
     for (const row of workspaces) raise(row.workspaceRepoId!, row.id, gitlabWorkspaceAccessLevel(row.gitAccess))
     // A hook consumer posts notes and may run the configured review policy.
     for (const row of hooks) if (row.agentId && row.repoId) raise(row.repoId, row.agentId, ACCESS_DEVELOPER)
+    // An explicit additional-project authorization is a consumer too (§8.3).
+    for (const row of grants) raise(row.repoId, row.agentId, gitlabAuthorizationAccessLevel(row.access))
     return [...levels.values()]
   }
 }

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -2326,19 +2326,22 @@ export class PgHookRepo implements HookRepo {
         })
         const agent = await tx.agent.findUnique({
           where: { id: input.agentId },
-          select: { orgId: true, workspaceRepoId: true, gitAccess: true }
+          select: { orgId: true, workspaceRepoId: true, workspaceMode: true, gitAccess: true }
         })
-        const additionalGrant =
-          agent?.workspaceRepoId === input.repoId
-            ? null
-            : await tx.agentRepoAuthorization.findUnique({
-                where: { agentId_repoId: { agentId: input.agentId, repoId: input.repoId } },
-                select: { access: true }
-              })
+        // HookReviewProjection is the GitHub Checks ledger, so both authorities read
+        // github here — the hosts number their repositories independently (§8.1).
+        const workspaceIsThisRepo = agent?.workspaceRepoId === input.repoId && agent.workspaceMode === 'github'
+        const additionalGrant = workspaceIsThisRepo
+          ? null
+          : await tx.agentRepoAuthorization.findUnique({
+              where: {
+                agentId_provider_repoId: { agentId: input.agentId, provider: 'github', repoId: input.repoId }
+              },
+              select: { access: true }
+            })
         const currentRepoAuthority =
           agent?.orgId === input.orgId &&
-          ((agent.workspaceRepoId === input.repoId && agent.gitAccess === 'write') ||
-            additionalGrant?.access === 'write')
+          ((workspaceIsThisRepo && agent.gitAccess === 'write') || additionalGrant?.access === 'write')
         const currentLifecycle =
           hook?.kind === 'github' &&
           hook.enabled &&

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -1031,20 +1031,17 @@ export class PgHookRepo implements HookRepo {
       // The grants carry the renamed display name into `workspace.additionalRepos`, so their
       // owners join the same configuration-ordering domain — and the same convergence fan-out —
       // as the workspace agents below. Read the owners BEFORE the write erases the predicate.
+      // Provider-qualified: a GitLab project carrying this same number is a different
+      // repository, and a GitHub rename must never overwrite its path (§8.1).
+      const renamedGrants = { provider: 'github', repoId, agent: { orgId }, repoFullName: { not: repoFullName } }
       const renamedGrantAgentIds = [
         ...new Set(
-          (
-            await tx.agentRepoAuthorization.findMany({
-              where: { repoId, agent: { orgId }, repoFullName: { not: repoFullName } },
-              select: { agentId: true }
-            })
-          ).map((row) => row.agentId)
+          (await tx.agentRepoAuthorization.findMany({ where: renamedGrants, select: { agentId: true } })).map(
+            (row) => row.agentId
+          )
         )
       ]
-      await tx.agentRepoAuthorization.updateMany({
-        where: { repoId, agent: { orgId }, repoFullName: { not: repoFullName } },
-        data: { repoFullName }
-      })
+      await tx.agentRepoAuthorization.updateMany({ where: renamedGrants, data: { repoFullName } })
       await bumpAgentConfigRevisions(tx, renamedGrantAgentIds)
       const gitRepo = normalizeGitUrl(repoFullName)
       const workspaceWhere = {

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -11,6 +11,8 @@ import type { FetchLike } from '../../src/gitlab/api.js'
 export interface FakeGitlabOptions {
   projectId?: number
   path?: string
+  /** Per-project paths, for a test holding more than one binding; `path` is the fallback. */
+  pathById?: Record<string, string>
   accessLevel?: number
   namespaceKind?: 'group' | 'user'
   /** Refuse service-account creation (Owner verification, §5). */
@@ -84,6 +86,11 @@ export class FakeGitlab {
       namespaceKind: options.namespaceKind ?? 'group',
       ...options
     }
+  }
+
+  /** One project's namespaced path — per-id when a test holds several bindings. */
+  private pathOf(projectId: number): string {
+    return this.opts.pathById?.[String(projectId)] ?? this.opts.path
   }
 
   /** The asynchronous half of a deferred deletion finally landing. */
@@ -233,16 +240,17 @@ export class FakeGitlab {
 
       if (/\/api\/v4\/projects\/\d+$/.test(url)) {
         const id = Number(/projects\/(\d+)$/.exec(url)![1])
+        const path = this.pathOf(id)
         return Response.json({
           id,
-          path_with_namespace: this.opts.path,
+          path_with_namespace: path,
           default_branch: 'main',
-          http_url_to_repo: `https://gitlab.com/${this.opts.path}.git`,
+          http_url_to_repo: `https://gitlab.com/${path}.git`,
           namespace: {
             id: 900,
             parent_id: null,
             kind: this.opts.namespaceKind,
-            full_path: this.opts.path.split('/')[0]!
+            full_path: path.split('/')[0]!
           }
         })
       }

--- a/packages/control-plane/test/integration/agent-repos.route.test.ts
+++ b/packages/control-plane/test/integration/agent-repos.route.test.ts
@@ -730,6 +730,37 @@ describe('agent repo authorizations REST — grant, list, revoke, gates', () => 
     expect((await post(a, other, { repoFullName: 'acme/tools' })).statusCode).toBe(200)
   })
 
+  it('POST does not read a same-numbered GitLab project as a duplicate GitHub repository', async () => {
+    // The hosts number their repositories independently and the unique key permits
+    // both, so the duplicate preflight has to qualify by provider (§8.1). Before it
+    // did, holding GitLab project 111 blocked authorizing GitHub repository 111.
+    await seedDaemon(prisma, DAEMON)
+    const agentId = await workspaceAgent()
+    await seedInstallation()
+    const a = app()
+    await prisma.agentRepoAuthorization.create({
+      data: {
+        agentId,
+        provider: 'gitlab',
+        repoId: 111n,
+        repoFullName: 'example-group/example-project',
+        access: 'read'
+      }
+    })
+
+    expect((await post(a, agentId, { repoFullName: 'acme/tools' })).statusCode).toBe(200)
+    expect(
+      await prisma.agentRepoAuthorization.findMany({
+        where: { agentId, repoId: 111n },
+        orderBy: { provider: 'asc' },
+        select: { provider: true, repoFullName: true }
+      })
+    ).toEqual([
+      { provider: 'github', repoFullName: 'acme/tools' },
+      { provider: 'gitlab', repoFullName: 'example-group/example-project' }
+    ])
+  })
+
   it('lets a manual GitHub workspace explicitly authorize only its own repo', async () => {
     await seedDaemon(prisma, DAEMON)
     const agentId = await manualWorkspaceAgent()

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -274,6 +274,48 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
   // membership survives it either way. The full undo is reachable where the write
   // really is what makes the agent a consumer — see the authorize route's own suite.
 
+  it('recompiles the project rules when an authorization adds or drops a bot (§12.1)', async () => {
+    // The veto set is baked into the compiled rule, and push events are
+    // relay-trusted once past it. A rule left compiled from the pre-grant account
+    // set would let the newly authorized bot's own pushes trigger sibling hooks.
+    const h = await harness()
+    const glab = channel([GITLAB_COM_V1_FEATURE])
+    h.a.relayReg.add(glab.ch)
+    expect((await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })).statusCode).toBe(
+      200
+    )
+    const first = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, h.agentId, 900n))!
+    const boundIds = () => {
+      const assigns = glab.sent.filter((frame) => frame.type === 'rc/hook-assign')
+      return [
+        ...((assigns.at(-1)?.payload as RcHookAssign | undefined)?.gitlab?.boundServiceAccountUserIds ?? [])
+      ].sort()
+    }
+    await vi.waitFor(() => expect(boundIds()).toEqual([first.serviceAccountUserId!.toString()]), { timeout: 20_000 })
+
+    // A SECOND agent is authorized on the same project — a new bot joins it.
+    const authorized = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/agents/${h.secondAgentId}/repos`,
+      payload: { provider: 'gitlab', projectId: PROJECT.toString(), access: 'write' }
+    })
+    expect(authorized.statusCode).toBe(200)
+    const second = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, h.secondAgentId, 900n))!
+    const both = [first.serviceAccountUserId!.toString(), second.serviceAccountUserId!.toString()].sort()
+    await vi.waitFor(() => expect(boundIds()).toEqual(both), { timeout: 20_000 })
+
+    // …and drops back out of the veto set when the authorization is revoked.
+    expect(
+      (
+        await h.a.app.inject({
+          method: 'DELETE',
+          url: `${ORG}/agents/${h.secondAgentId}/repos/${(authorized.json() as { id: string }).id}`
+        })
+      ).statusCode
+    ).toBe(204)
+    await vi.waitFor(() => expect(boundIds()).toEqual([first.serviceAccountUserId!.toString()]), { timeout: 20_000 })
+  })
+
   it('keeps a membership another authorization still earns when a hook write is refused', async () => {
     const h = await harness()
     // The agent already consumes the project through its workspace, so the

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -145,7 +145,29 @@ async function harness(options: FakeGitlabOptions = {}) {
   // A second agent, so a test needing two hooks on one project clears the per-agent fence.
   const secondAgentId = randomUUID()
   await seedAgent(prisma, secondAgentId, { daemonId })
-  return { fake, a: running, hookRepo, bindings, accounts, provisioner, binding, agentId, secondAgentId, daemonId }
+  // §8.3: a trigger never creates a grant, so the agent must already hold the
+  // project. Written straight to the row, not through the authorize route, so the
+  // account these tests watch the hook write provision is still absent. Only the
+  // first agent holds one by default — a grant is an authorization, so granting an
+  // agent no test needs would make it a consumer convergence has to serve.
+  const authorize = (id: string, projectId = PROJECT, path = 'example-group/example-project') =>
+    prisma.agentRepoAuthorization.create({
+      data: { agentId: id, provider: 'gitlab', repoId: projectId, repoFullName: path, access: 'write' }
+    })
+  await authorize(agentId)
+  return {
+    fake,
+    a: running,
+    hookRepo,
+    bindings,
+    accounts,
+    provisioner,
+    binding,
+    agentId,
+    secondAgentId,
+    daemonId,
+    authorize
+  }
 }
 
 /** A stand-in relay socket. `answer` decides how it replies to a correlated
@@ -247,21 +269,10 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(30)
   })
 
-  it('rolls back the account a refused hook write speculatively created', async () => {
-    // The account is created, then its PATs come back out of policy: the ensure
-    // fails with real provider state already behind it, and the hook row that
-    // would have made the agent a consumer is never written. Nothing would ever
-    // visit that account again, so the write has to undo it (§7.2).
-    const h = await harness({ patExpiryOverride: null })
-    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
-    expect(created.statusCode).toBe(409)
-    expect(await h.hookRepo.listForAgent(AgentId(h.agentId))).toHaveLength(0)
-
-    // No account row, no service account left in the group, no live token.
-    expect(await h.accounts.listForAgent(DEFAULT_ORG_ID, h.agentId)).toHaveLength(0)
-    expect(h.fake.serviceAccounts).toHaveLength(0)
-    expect([...h.fake.tokens.values()].every((token) => token.revoked)).toBe(true)
-  })
+  // The account a refused hook write speculatively created is NOT rolled back here:
+  // §8.3 makes the hook agent an authorized consumer before the write, so the
+  // membership survives it either way. The full undo is reachable where the write
+  // really is what makes the agent a consumer — see the authorize route's own suite.
 
   it('keeps a membership another authorization still earns when a hook write is refused', async () => {
     const h = await harness()
@@ -308,6 +319,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect(h.fake.serviceAccounts).toHaveLength(0)
 
     // Disabling an enabled hook is likewise not blocked by the outage.
+    await h.authorize(h.secondAgentId)
     h.fake.opts.refuseServiceAccountQuota = false
     const enabled = await h.a.app.inject({
       method: 'POST',
@@ -331,7 +343,74 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect(created.statusCode).toBe(409)
     expect((created.json() as { message: string }).message).toContain('no service-account slots left')
     expect(await h.hookRepo.listForAgent(AgentId(h.agentId))).toHaveLength(0)
-    expect(await h.accounts.membershipsForBinding(h.binding.id)).toHaveLength(0)
+    // The group refused the slot, so no bot exists there to carry the membership.
+    expect(h.fake.serviceAccounts).toHaveLength(0)
+  })
+
+  it('refuses a project the agent does not hold, and accepts it once authorized (§8.3)', async () => {
+    // Creating a hook never creates a grant. Without one the trigger would fire
+    // into a review whose exact checkout can get no credential, so the route
+    // refuses rather than leaving the agent to post a "could not review" note.
+    const h = await harness()
+    const unauthorized = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: glBody(h.secondAgentId)
+    })
+    expect(unauthorized.statusCode).toBe(409)
+    const message = (unauthorized.json() as { message: string }).message
+    expect(message).toContain('example-group/example-project is not authorized for this agent')
+    // Actionable, and in GitLab's own nouns.
+    expect(message).toContain('authorize the project')
+    expect(message).toContain('workspace project')
+    expect(await h.hookRepo.listForAgent(AgentId(h.secondAgentId))).toHaveLength(0)
+
+    await h.authorize(h.secondAgentId)
+    const authorized = await h.a.app.inject({
+      method: 'POST',
+      url: `${ORG}/hooks`,
+      payload: glBody(h.secondAgentId)
+    })
+    expect(authorized.statusCode).toBe(200)
+  })
+
+  it('accepts the agent’s own workspace project with no separate grant (§8.3)', async () => {
+    const h = await harness()
+    await prisma.agent.update({
+      where: { id: h.secondAgentId },
+      data: {
+        workspaceMode: 'gitlab',
+        workspaceRepoId: PROJECT,
+        gitRepo: 'https://gitlab.com/example-group/example-project'
+      }
+    })
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.secondAgentId) })
+    expect(created.statusCode).toBe(200)
+  })
+
+  it('grandfathers an existing hook through edits that do not change its binding (§8.3)', async () => {
+    const h = await harness()
+    const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
+    expect(created.statusCode).toBe(200)
+    const hookId = (created.json() as { id: string }).id
+    // The grant goes away underneath it; the definition itself may still be edited.
+    await prisma.agentRepoAuthorization.deleteMany({ where: { agentId: h.agentId } })
+
+    const edited = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/hooks/${hookId}`,
+      payload: { ...glBody(h.agentId), name: 'renamed' }
+    })
+    expect(edited.statusCode).toBe(200)
+    expect((edited.json() as { name: string }).name).toBe('renamed')
+
+    // Moving it onto another agent IS a binding change, and that is refused.
+    const moved = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/hooks/${hookId}`,
+      payload: glBody(h.secondAgentId)
+    })
+    expect(moved.statusCode).toBe(409)
   })
 
   it('create is fenced on a managed binding; a second hook on the same project+agent is a 409', async () => {
@@ -383,6 +462,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect((plain.json() as { reviewPolicy: string }).reviewPolicy).toBe('off')
 
     // A second agent so the one-hook-per-(agent, project) fence does not fire.
+    await h.authorize(h.secondAgentId)
     const second = await h.a.app.inject({
       method: 'POST',
       url: `${ORG}/hooks`,
@@ -493,6 +573,8 @@ describe('gitlab hooks — binding lifecycle rebroadcast (§11.1/§11.3 round 2)
       installerConnectionId: connection.id
     })
     expect(await h.provisioner.provision(DEFAULT_ORG_ID, other.id)).toEqual({ state: 'ready' })
+    // Retargeting is a binding change, so the destination needs its own grant (§8.3).
+    await h.authorize(h.agentId, OTHER, 'example-group/other-project')
 
     const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
     expect(created.statusCode).toBe(200)

--- a/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
@@ -89,11 +89,7 @@ async function harness(liveness?: DaemonLiveness) {
     // Mirrors the container: the durable clone-URL convergence is AWAITED
     // inside the run, under the saga lease.
     syncWorkspacePaths: async (orgId, projectId, projectPath) => {
-      await new PgAgentRepo(prisma).refreshGitlabWorkspacePath(
-        OrgId(orgId),
-        projectId,
-        `https://gitlab.com/${projectPath}`
-      )
+      await new PgAgentRepo(prisma).refreshGitlabProjectPath(OrgId(orgId), projectId, projectPath)
     },
     fetchImpl: fake.fetch()
   })
@@ -305,10 +301,10 @@ describe('gitlab workspaces — agent create/edit (§8.3)', () => {
     const agentId = (created.json() as { id: string }).id
     const before = await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })
     const agents = new PgAgentRepo(prisma)
-    const refreshed = await agents.refreshGitlabWorkspacePath(
+    const refreshed = await agents.refreshGitlabProjectPath(
       OrgId(DEFAULT_ORG_ID),
       PROJECT,
-      'https://gitlab.com/example-group/renamed-project'
+      'example-group/renamed-project'
     )
     // Every gitlab-workspace agent on the project drifts, the harness's included.
     expect(refreshed).toContain(agentId)
@@ -317,11 +313,7 @@ describe('gitlab workspaces — agent create/edit (§8.3)', () => {
     expect(after.configRevision).toBe(before.configRevision + 1n)
     // Idempotent: an unchanged path touches nothing.
     expect(
-      await agents.refreshGitlabWorkspacePath(
-        OrgId(DEFAULT_ORG_ID),
-        PROJECT,
-        'https://gitlab.com/example-group/renamed-project'
-      )
+      await agents.refreshGitlabProjectPath(OrgId(DEFAULT_ORG_ID), PROJECT, 'example-group/renamed-project')
     ).toEqual([])
   })
 
@@ -772,6 +764,64 @@ describe('additional GitLab project authorizations (§8.3/§13.1)', () => {
     const again = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
     expect(again.statusCode).toBe(409)
     expect((again.json() as { message: string }).message).toContain('already authorized')
+  })
+
+  it('carries a project rename into the grant path and the replicated spec', async () => {
+    // The daemon maps a NAMED gitlab project back to its numeric id through this
+    // path in the replicated spec. A rename that refreshed only the binding and
+    // the workspace would orphan the new path, and an ask under the old one is
+    // answered with the binding's new path and then rejected by the echo check.
+    const h = await harness()
+    await secondBinding(h)
+    const created = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
+    expect(created.statusCode).toBe(200)
+    const before = await prisma.agent.findUniqueOrThrow({ where: { id: AGENT } })
+
+    const agents = new PgAgentRepo(prisma)
+    const refreshed = await agents.refreshGitlabProjectPath(
+      OrgId(DEFAULT_ORG_ID),
+      SECOND_PROJECT,
+      'example-group/renamed-second'
+    )
+
+    // The grant's owner joins the rename's configuration-ordering domain, so the
+    // spec push replicates the new path.
+    expect(refreshed).toContain(AGENT)
+    expect(await grants()).toMatchObject([{ repoFullName: 'example-group/renamed-second' }])
+    const after = await prisma.agent.findUniqueOrThrow({ where: { id: AGENT } })
+    expect(after.configRevision).toBe(before.configRevision + 1n)
+    // The workspace project is a different project: its own path is untouched.
+    expect(after.gitRepo).toBe('https://gitlab.com/example-group/example-project')
+    // Idempotent, exactly as the workspace half is.
+    expect(
+      await agents.refreshGitlabProjectPath(OrgId(DEFAULT_ORG_ID), SECOND_PROJECT, 'example-group/renamed-second')
+    ).toEqual([])
+  })
+
+  it('bumps one revision when a rename moves an agent’s workspace AND its grant', async () => {
+    // The same agent may hold the workspace on one project and a grant on it too
+    // only transiently, but a rename touching both halves must still advance the
+    // revision once: two bumps for one rename would be a spec the daemon refuses.
+    const h = await harness()
+    await prisma.agentRepoAuthorization.create({
+      data: {
+        agentId: AGENT,
+        provider: 'gitlab',
+        repoId: PROJECT,
+        repoFullName: 'example-group/example-project',
+        access: 'read'
+      }
+    })
+    const before = await prisma.agent.findUniqueOrThrow({ where: { id: AGENT } })
+    const agents = new PgAgentRepo(prisma)
+
+    expect(
+      await agents.refreshGitlabProjectPath(OrgId(DEFAULT_ORG_ID), PROJECT, 'example-group/renamed-project')
+    ).toEqual([AGENT])
+    const after = await prisma.agent.findUniqueOrThrow({ where: { id: AGENT } })
+    expect(after.configRevision).toBe(before.configRevision + 1n)
+    expect(after.gitRepo).toBe('https://gitlab.com/example-group/renamed-project')
+    expect(await grants()).toMatchObject([{ repoFullName: 'example-group/renamed-project' }])
   })
 
   it('undoes the account a refused authorization speculatively created (§7.2)', async () => {

--- a/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
@@ -700,6 +700,34 @@ describe('additional GitLab project authorizations (§8.3/§13.1)', () => {
     await expect(service.grantForAgent(gitlabAgent(), 999n)).rejects.toThrowError(GitCredDeniedError)
   })
 
+  it('commits the path the provider answers with inside the lease, not the pre-lease capture', async () => {
+    // A rename between the binding read and the write is exactly when a captured
+    // path becomes the losing side. The grant is what the daemon maps a NAMED
+    // project back to its numeric id with, so persisting the stale one would
+    // replicate a path the checkout can never be found under.
+    const h = await harness()
+    const fresh = await secondBinding(h)
+    expect(fresh.projectPath).toBe('example-group/example-second')
+
+    // The project is renamed at GitLab; no convergence has run since.
+    h.fake.opts.pathById = { [String(SECOND_PROJECT)]: 'example-group/renamed-second' }
+
+    const res = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ repoFullName: 'example-group/renamed-second' })
+    expect(await grants()).toMatchObject([{ repoFullName: 'example-group/renamed-second' }])
+
+    // The same read converged the durable replicas, so nothing disagrees.
+    expect((await h.bindings.get(DEFAULT_ORG_ID, fresh.id))?.projectPath).toBe('example-group/renamed-second')
+    expect(
+      await prisma.codeHostRepository.findUnique({
+        where: {
+          orgId_provider_externalId: { orgId: DEFAULT_ORG_ID, provider: 'gitlab', externalId: SECOND_PROJECT }
+        }
+      })
+    ).toMatchObject({ displayPath: 'example-group/renamed-second' })
+  })
+
   it('raises the account’s project role when the tier is raised', async () => {
     const h = await harness()
     const fresh = await secondBinding(h)

--- a/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
@@ -17,6 +17,7 @@ import { GitlabGitcredService } from '../../src/gitlab/gitcred.service.js'
 import { GitCredDeniedError } from '../../src/github/service.js'
 import {
   PgAgentRepo,
+  PgAgentRepoAuthorizationRepo,
   PgCodeHostRepositoryRepo,
   PgGitlabAgentAccountRepo,
   PgGitlabConnectionRepo,
@@ -126,6 +127,7 @@ function credService(bindings: PgGitlabProjectBindingRepo) {
     accounts: new PgGitlabAgentAccountRepo(prisma),
     credentials: new PgGitlabProjectCredentialRepo(prisma),
     credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, cipher),
+    repoAuths: new PgAgentRepoAuthorizationRepo(prisma),
     clock: systemClock
   })
 }

--- a/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
@@ -51,7 +51,9 @@ afterEach(async () => {
 })
 
 async function harness(liveness?: DaemonLiveness) {
-  const fake = new FakeGitlab()
+  // The second project answers with its own path, so a test holding both can tell
+  // which one a grant or a credential resolved to.
+  const fake = new FakeGitlab({ pathById: { [String(SECOND_PROJECT)]: 'example-group/example-second' } })
   const bindings = new PgGitlabProjectBindingRepo(prisma)
   const connections = new PgGitlabConnectionRepo(prisma)
   const oauth = new GitlabOauthService({
@@ -624,5 +626,172 @@ describe('gitcred v2 GitLab grants (§13.1/§17.1)', () => {
       .catch((e: GitCredDeniedError) => e)
     expect((degraded as GitCredDeniedError).code).toBe('LEASE_DENIED')
     expect((degraded as GitCredDeniedError).retryable).toBe(true)
+  })
+})
+
+describe('additional GitLab project authorizations (§8.3/§13.1)', () => {
+  /** A second managed binding under the same top-level group, with no consumer yet. */
+  async function secondBinding(h: Awaited<ReturnType<typeof harness>>) {
+    const fresh = await h.bindings.createWithClaim({
+      orgId: DEFAULT_ORG_ID,
+      projectId: SECOND_PROJECT,
+      projectPath: 'example-group/example-second',
+      installerConnectionId: h.connection.id
+    })
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, fresh.id)).toEqual({ state: 'ready' })
+    expect(await h.accounts.listForBinding(fresh.id)).toHaveLength(0)
+    return fresh
+  }
+
+  const authorize = (payload: Record<string, unknown>) => ({
+    method: 'POST' as const,
+    url: `${ORG}/agents/${AGENT}/repos`,
+    payload
+  })
+
+  const grants = () => running!.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/repos` }).then((r) => r.json())
+
+  it('authorizes a project, provisioning the agent’s account and membership inline (§7.2)', async () => {
+    const h = await harness()
+    const fresh = await secondBinding(h)
+
+    const res = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      provider: 'gitlab',
+      repoId: SECOND_PROJECT.toString(),
+      repoFullName: 'example-group/example-second',
+      access: 'read'
+    })
+
+    // Asserted with NO polling: the account is the write's own precondition, so it
+    // exists by the time the response is written — the grant row and the membership
+    // become visible to convergence together.
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect((await h.accounts.membershipsForBinding(fresh.id)).map((m) => m.accountId)).toEqual([account.id])
+    // read ⇒ Reporter, the same clamp a read workspace derives (§13.1).
+    expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(20)
+
+    // The catalog converged on the project too (§8.1).
+    expect(
+      await prisma.codeHostRepository.findUnique({
+        where: {
+          orgId_provider_externalId: { orgId: DEFAULT_ORG_ID, provider: 'gitlab', externalId: SECOND_PROJECT }
+        }
+      })
+    ).toMatchObject({ displayPath: 'example-group/example-second' })
+
+    expect(await grants()).toMatchObject([{ provider: 'gitlab', repoId: SECOND_PROJECT.toString() }])
+  })
+
+  it('serves a read credential for the authorized project, not the workspace one (§13.1)', async () => {
+    const h = await harness()
+    await secondBinding(h)
+    const created = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
+    expect(created.statusCode).toBe(200)
+    const service = credService(h.bindings)
+    const creds = new PgGitlabProjectCredentialRepo(prisma)
+    const store = new PgGitlabProjectCredentialSecretStore(prisma, cipher)
+
+    const grant = await service.grantForAgent(gitlabAgent(), SECOND_PROJECT)
+    expect(grant.provider).toBe('gitlab')
+    expect(grant.externalRepoId).toBe(SECOND_PROJECT.toString())
+    expect(grant.repoFullName).toBe('example-group/example-second')
+    // The grant's own tier is the ceiling — a write WORKSPACE does not widen it.
+    expect(grant.access).toBe('read')
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect(grant.token).toBe(await store.get(DEFAULT_ORG_ID, (await creds.get(account.id, 'read'))!.id))
+
+    // The workspace ask still resolves to the workspace project.
+    expect((await service.grantForAgent(gitlabAgent())).externalRepoId).toBe(PROJECT.toString())
+    // A project that is neither remains a denial, never a fallback onto the workspace.
+    await expect(service.grantForAgent(gitlabAgent(), 999n)).rejects.toThrowError(GitCredDeniedError)
+  })
+
+  it('raises the account’s project role when the tier is raised', async () => {
+    const h = await harness()
+    const fresh = await secondBinding(h)
+    const created = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
+    expect(created.statusCode).toBe(200)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(20)
+
+    const raised = await h.a.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/agents/${AGENT}/repos/${(created.json() as { id: string }).id}`,
+      payload: { access: 'write' }
+    })
+    expect(raised.statusCode).toBe(200)
+    expect(raised.json()).toMatchObject({ provider: 'gitlab', access: 'write' })
+    // write ⇒ Developer, the push role.
+    expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(30)
+    expect(await h.accounts.membershipsForBinding(fresh.id)).toHaveLength(1)
+
+    const service = credService(h.bindings)
+    expect((await service.grantForAgent(gitlabAgent(), SECOND_PROJECT)).access).toBe('write')
+  })
+
+  it('drops the consumer when the authorization is revoked', async () => {
+    const h = await harness()
+    const fresh = await secondBinding(h)
+    const created = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
+    expect(created.statusCode).toBe(200)
+    expect(await h.accounts.membershipsForBinding(fresh.id)).toHaveLength(1)
+
+    const removed = await h.a.app.inject({
+      method: 'DELETE',
+      url: `${ORG}/agents/${AGENT}/repos/${(created.json() as { id: string }).id}`
+    })
+    expect(removed.statusCode).toBe(204)
+    expect(await grants()).toEqual([])
+    // Membership detach is the converge kick's, so it settles just after the reply.
+    await vi.waitFor(async () => expect(await h.accounts.membershipsForBinding(fresh.id)).toHaveLength(0), {
+      timeout: 20_000
+    })
+    // The workspace project keeps the account alive in this root.
+    expect((await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))?.state).toBe('ready')
+
+    const service = credService(h.bindings)
+    await expect(service.grantForAgent(gitlabAgent(), SECOND_PROJECT)).rejects.toThrowError(GitCredDeniedError)
+  })
+
+  it('refuses an unmanaged project, the workspace project, and a duplicate', async () => {
+    const h = await harness()
+    await secondBinding(h)
+
+    const unmanaged = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: '999' }))
+    expect(unmanaged.statusCode).toBe(409)
+    expect((unmanaged.json() as { message: string }).message).toContain('not a managed GitLab project')
+
+    const workspace = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: PROJECT.toString() }))
+    expect(workspace.statusCode).toBe(409)
+    expect((workspace.json() as { message: string }).message).toContain('workspace project')
+
+    const first = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
+    expect(first.statusCode).toBe(200)
+    const again = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
+    expect(again.statusCode).toBe(409)
+    expect((again.json() as { message: string }).message).toContain('already authorized')
+  })
+
+  it('undoes the account a refused authorization speculatively created (§7.2)', async () => {
+    const h = await harness()
+    // Nothing else makes the agent a consumer once its workspace account is gone,
+    // so this write is the only thing that would — and its PATs come back out of
+    // policy, failing the ensure with real provider state already behind it.
+    const fresh = await secondBinding(h)
+    await prisma.agent.update({
+      where: { id: AGENT },
+      data: { workspaceMode: 'scratch', workspaceRepoId: null, gitRepo: null }
+    })
+    await prisma.gitlabAccountMembership.deleteMany({})
+    await prisma.gitlabAgentAccount.deleteMany({})
+    h.fake.opts.patExpiryOverride = null
+
+    const res = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
+    expect(res.statusCode).toBe(409)
+    expect(await grants()).toEqual([])
+    expect(await h.accounts.listForAgent(DEFAULT_ORG_ID, AGENT)).toHaveLength(0)
+    expect(await h.accounts.membershipsForBinding(fresh.id)).toHaveLength(0)
   })
 })

--- a/packages/control-plane/test/integration/hook-report.test.ts
+++ b/packages/control-plane/test/integration/hook-report.test.ts
@@ -574,7 +574,10 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     expect(
       await repo().claimRetryableDeliveryRedelivery('projection-before-recovery', [HookId(hookId)], firedAt, [30_000])
     ).toBe(true)
-    await prisma.agent.update({ where: { id: agentId }, data: { workspaceRepoId: hook.repoId, gitAccess: 'write' } })
+    await prisma.agent.update({
+      where: { id: agentId },
+      data: { workspaceMode: 'github', workspaceRepoId: hook.repoId, gitAccess: 'write' }
+    })
     const failed = (await repo().getRun(HookId(hookId), 'projection-before-recovery'))!
     const projection = await repo().upsertReviewProjection({
       hookId: HookId(hookId),

--- a/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
+++ b/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
@@ -364,6 +364,7 @@ describe('R1/R2a persistence foundation', () => {
     })
     const duplicate = await grants.create({
       agentId: legacyAgent,
+      provider: 'github',
       repoId,
       repoFullName: 'acme/infra',
       access: 'write'
@@ -404,7 +405,7 @@ describe('R1/R2a persistence foundation', () => {
         installationId: 'legacy-installation'
       })
       await Promise.allSettled([
-        grants.create({ agentId, repoId, repoFullName: 'acme/infra', access: 'write' }),
+        grants.create({ agentId, provider: 'github', repoId, repoFullName: 'acme/infra', access: 'write' }),
         agents.setWorkspaceRepoId(agentId, repoId)
       ])
       expect(await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })).toMatchObject({
@@ -1681,7 +1682,7 @@ describe('R1/R2a persistence foundation', () => {
     )
     expect(
       await prisma.agentRepoAuthorization.findUniqueOrThrow({
-        where: { agentId_repoId: { agentId, repoId: 44n } },
+        where: { agentId_provider_repoId: { agentId, provider: 'github', repoId: 44n } },
         select: { repoFullName: true }
       })
     ).toEqual({ repoFullName: 'acme/new-name' })

--- a/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
+++ b/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
@@ -426,7 +426,7 @@ describe('R1/R2a persistence foundation', () => {
       installationId: 'workspace-installation',
       gitAccess: 'write'
     })
-    await prisma.agent.update({ where: { id: agentId }, data: { workspaceRepoId: repoId } })
+    await prisma.agent.update({ where: { id: agentId }, data: { workspaceMode: 'github', workspaceRepoId: repoId } })
     const original = await agents.get(OrgId(DEFAULT_ORG_ID), agentId)
     if (!original || original.workspace.mode !== 'github') throw new Error('expected GitHub workspace fixture')
 
@@ -701,7 +701,7 @@ describe('R1/R2a persistence foundation', () => {
     const repoId = 777n
     const reportSha = 'c'.repeat(40)
     await seedAgent(prisma, agentId, { daemonId: D1, gitAccess: 'write', name: 'concurrent-agent' })
-    await prisma.agent.update({ where: { id: agentId }, data: { workspaceRepoId: repoId } })
+    await prisma.agent.update({ where: { id: agentId }, data: { workspaceMode: 'github', workspaceRepoId: repoId } })
     const hook = await repo.upsert({
       hookId,
       orgId: OrgId(DEFAULT_ORG_ID),
@@ -1757,7 +1757,10 @@ describe('R1/R2a persistence foundation', () => {
     await seedDaemon(prisma, D1)
     const agentId = AgentId(randomUUID())
     await seedAgent(prisma, agentId, { daemonId: D1, name: 'review-agent' })
-    await prisma.agent.update({ where: { id: agentId }, data: { workspaceRepoId: 22n, gitAccess: 'write' } })
+    await prisma.agent.update({
+      where: { id: agentId },
+      data: { workspaceMode: 'github', workspaceRepoId: 22n, gitAccess: 'write' }
+    })
     const repo = new PgHookRepo(prisma)
     const hookId = HookId(randomUUID())
     const hook = await repo.upsert({
@@ -2198,7 +2201,10 @@ describe('R1/R2a persistence foundation', () => {
     await seedDaemon(prisma, D1)
     const agentId = AgentId(randomUUID())
     await seedAgent(prisma, agentId, { daemonId: D1, name: 'review-agent' })
-    await prisma.agent.update({ where: { id: agentId }, data: { workspaceRepoId: 24n, gitAccess: 'write' } })
+    await prisma.agent.update({
+      where: { id: agentId },
+      data: { workspaceMode: 'github', workspaceRepoId: 24n, gitAccess: 'write' }
+    })
     const repo = new PgHookRepo(prisma)
     const hookId = HookId(randomUUID())
     const hook = await repo.upsert({
@@ -2352,7 +2358,7 @@ describe('R1/R2a persistence foundation', () => {
     await seedAgent(prisma, agentId, { daemonId: D1, name: 'quota-agent' })
     await prisma.agent.update({
       where: { id: agentId },
-      data: { status: 'active', workspaceRepoId: 23n, gitAccess: 'write' }
+      data: { status: 'active', workspaceMode: 'github', workspaceRepoId: 23n, gitAccess: 'write' }
     })
     const repo = new PgHookRepo(prisma)
     const hookId = HookId(randomUUID())

--- a/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
+++ b/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
@@ -1609,8 +1609,21 @@ describe('R1/R2a persistence foundation', () => {
     await prisma.agentRepoAuthorization.create({
       data: {
         agentId,
+        provider: 'github',
         repoId: 44n,
         repoFullName: 'acme/old-name',
+        access: 'read'
+      }
+    })
+    // The SAME agent may hold GitLab project 44 — the hosts number their
+    // repositories independently, so the unique key permits both. A GitHub rename
+    // must not reach across and rewrite this one's path (§8.1).
+    await prisma.agentRepoAuthorization.create({
+      data: {
+        agentId,
+        provider: 'gitlab',
+        repoId: 44n,
+        repoFullName: 'example-group/example-project',
         access: 'read'
       }
     })
@@ -1686,6 +1699,13 @@ describe('R1/R2a persistence foundation', () => {
         select: { repoFullName: true }
       })
     ).toEqual({ repoFullName: 'acme/new-name' })
+    // The same-numbered GitLab grant kept its own path and its owner was counted once.
+    expect(
+      await prisma.agentRepoAuthorization.findUniqueOrThrow({
+        where: { agentId_provider_repoId: { agentId, provider: 'gitlab', repoId: 44n } },
+        select: { repoFullName: true }
+      })
+    ).toEqual({ repoFullName: 'example-group/example-project' })
     expect(await agents.get(OrgId(DEFAULT_ORG_ID), workspaceAgentId)).toMatchObject({
       workspace: { mode: 'github', gitRepo: 'https://github.com/acme/new-name' },
       workspaceRepoId: 44n,

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -222,10 +222,20 @@ export const AgentSchema = z.object({
       .regex(/^[1-9]\d*$/)
       .optional(),
     // The agent's additional-repository allowlist, replicated from the CP
-    // (multi-repository-workspaces.md decision 2). A later phase materializes these
-    // as secondary workspace roots; nothing reads the list yet. `repoId` is GitHub's
-    // numeric repository id as a decimal string, so a rename cannot orphan an entry.
-    additionalRepos: z.array(z.object({ repoFullName: z.string(), repoId: z.string() })).default([]),
+    // (multi-repository-workspaces.md decision 2). `repoId` is the host's numeric
+    // repository/project id as a decimal string, so a rename cannot orphan an entry,
+    // and `provider` qualifies it — the hosts number theirs independently
+    // (gitlab-com-integration.md §8.1). Absent ⇒ github, what every entry a
+    // pre-GitLab control plane replicated means.
+    additionalRepos: z
+      .array(
+        z.object({
+          repoFullName: z.string(),
+          repoId: z.string(),
+          provider: z.string().min(1).default('github')
+        })
+      )
+      .default([]),
     pullOnNewSession: z.boolean().default(true),
     // DEPRECATED: superseded by the top-level `skills` field (AgentSkillEntry[]).
     // Kept so historical agent.json files still parse; nothing consumes it.

--- a/packages/daemon/src/cp/gitcred-server.ts
+++ b/packages/daemon/src/cp/gitcred-server.ts
@@ -81,6 +81,10 @@ export interface GitCredServerDeps {
   /** The gitlab workspace's numeric project id from the REPLICATED SPEC — the
    *  §17.1 request identity the grant echo is verified against. */
   projectIdOf?: (agentId: string) => string | undefined
+  /** The numeric project id of a NAMED gitlab project the spec lists as an additional
+   *  authorization (§8.3), or undefined when the path is not one. Also from the
+   *  replicated spec, so a named project never introduces a provider the spec lacks. */
+  gitlabProjectOf?: (agentId: string, repoFullName: string) => string | undefined
 }
 
 export class GitCredServer {
@@ -90,6 +94,7 @@ export class GitCredServer {
   private readonly workspaceRepoOf?: (agentId: string) => string | undefined
   private readonly providerOf?: (agentId: string) => 'github' | 'gitlab' | undefined
   private readonly projectIdOf?: (agentId: string) => string | undefined
+  private readonly gitlabProjectOf?: (agentId: string, repoFullName: string) => string | undefined
 
   constructor(
     private readonly cache: GitCredentialCache,
@@ -100,6 +105,7 @@ export class GitCredServer {
     if (deps.workspaceRepoOf) this.workspaceRepoOf = deps.workspaceRepoOf
     if (deps.providerOf) this.providerOf = deps.providerOf
     if (deps.projectIdOf) this.projectIdOf = deps.projectIdOf
+    if (deps.gitlabProjectOf) this.gitlabProjectOf = deps.gitlabProjectOf
   }
 
   start(): void {
@@ -200,7 +206,15 @@ export class GitCredServer {
     }
     // The SPEC decides the provider; a helper whose host hint disagrees is
     // asking for another host's credential and gets a clean denial (§13.2).
-    const provider = this.providerOf?.(req.agentId) ?? 'github'
+    // A named project the spec lists as a gitlab additional authorization (§8.3) is
+    // the second spec-derived gitlab authority; the host hint only disambiguates
+    // between authorities the spec already carries, it never introduces one.
+    const workspaceProvider = this.providerOf?.(req.agentId) ?? 'github'
+    const gitlabProject = repo !== undefined ? this.gitlabProjectOf?.(req.agentId, repo) : undefined
+    const provider: 'github' | 'gitlab' =
+      gitlabProject !== undefined && (req.provider === 'gitlab' || workspaceProvider === 'gitlab')
+        ? 'gitlab'
+        : workspaceProvider
     if (req.provider !== undefined && req.provider !== provider) {
       this.audit('denied', req.agentId, plane, repo)
       return reply({ ok: false, error: `this workspace has no managed ${req.provider} credential` })
@@ -210,14 +224,19 @@ export class GitCredServer {
       return reply({ ok: false, error: 'glab credentials require a managed GitLab workspace' })
     }
     try {
-      const projectId = provider === 'gitlab' ? this.projectIdOf?.(req.agentId) : undefined
+      // §17.1: every gitlab ask names the rename-stable numeric identity so the
+      // consumer can reject a wrong-project grant echo — the workspace project for
+      // the repo-less ask, the authorized project for a named one. Without it a
+      // named project resolves to the workspace grant and the echo check rejects it.
+      const projectId =
+        provider !== 'gitlab'
+          ? undefined
+          : (gitlabProject ?? (repo === undefined ? this.projectIdOf?.(req.agentId) : undefined))
       const cred = await this.cache.get(req.agentId, 'helper', {
         plane,
         ...(repo !== undefined ? { repo } : {}),
         ...(provider === 'gitlab' ? { provider: 'gitlab' as const } : {}),
-        // §17.1: the workspace ask names the rename-stable numeric identity so
-        // the consumer can reject a wrong-project grant echo.
-        ...(projectId !== undefined && repo === undefined ? { externalRepoId: projectId } : {}),
+        ...(projectId !== undefined ? { externalRepoId: projectId } : {}),
         // §13.3: the CLI wrapper is read-only BY DESIGN — a mutating glab
         // command never receives effect authority and fails at GitLab.
         ...(plane === 'glab' ? { requestedAccess: 'read' as const } : {})

--- a/packages/daemon/src/cp/gitcred-server.ts
+++ b/packages/daemon/src/cp/gitcred-server.ts
@@ -188,15 +188,29 @@ export class GitCredServer {
       const workspace = this.workspaceRepoOf?.(req.agentId)
       if (workspace && workspace.toLowerCase() === repo.toLowerCase()) repo = undefined
     }
+    // The SPEC decides the provider; a helper whose host hint disagrees is
+    // asking for another host's credential and gets a clean denial (§13.2).
+    // A named project the spec lists as a gitlab additional authorization (§8.3) is
+    // the second spec-derived gitlab authority; the host hint only disambiguates
+    // between authorities the spec already carries, it never introduces one.
+    //
+    // Resolved BEFORE the op split: erase has to reach the key get stored, and a
+    // gitlab additional project on a scratch or github workspace is keyed gitlab
+    // while the workspace alone says github. Deriving erase from the workspace
+    // would invalidate the wrong entry and leave the rejected token live to TTL.
+    const workspaceProvider = this.providerOf?.(req.agentId) ?? 'github'
+    const gitlabProject = repo !== undefined ? this.gitlabProjectOf?.(req.agentId, repo) : undefined
+    const provider: 'github' | 'gitlab' =
+      gitlabProject !== undefined && (req.provider === 'gitlab' || workspaceProvider === 'gitlab')
+        ? 'gitlab'
+        : workspaceProvider
     if (req.op === 'erase') {
       // Git presents the rejected credential — the provider revokes instantly on
-      // uninstall/suspend/rotation, and this is how the daemon cache learns. The
-      // SPEC-derived provider keys the entry, exactly as the get stored it.
-      const eraseProvider = this.providerOf?.(req.agentId) ?? 'github'
+      // uninstall/suspend/rotation, and this is how the daemon cache learns.
       this.cache.invalidate(req.agentId, req.password, {
         plane,
         ...(repo !== undefined ? { repo } : {}),
-        ...(eraseProvider === 'gitlab' ? { provider: 'gitlab' as const } : {})
+        ...(provider === 'gitlab' ? { provider: 'gitlab' as const } : {})
       })
       this.audit('erased', req.agentId, plane, repo)
       return reply({ ok: true })
@@ -204,17 +218,6 @@ export class GitCredServer {
     if (req.op !== 'get') {
       return reply({ ok: false, error: 'unsupported op' })
     }
-    // The SPEC decides the provider; a helper whose host hint disagrees is
-    // asking for another host's credential and gets a clean denial (§13.2).
-    // A named project the spec lists as a gitlab additional authorization (§8.3) is
-    // the second spec-derived gitlab authority; the host hint only disambiguates
-    // between authorities the spec already carries, it never introduces one.
-    const workspaceProvider = this.providerOf?.(req.agentId) ?? 'github'
-    const gitlabProject = repo !== undefined ? this.gitlabProjectOf?.(req.agentId, repo) : undefined
-    const provider: 'github' | 'gitlab' =
-      gitlabProject !== undefined && (req.provider === 'gitlab' || workspaceProvider === 'gitlab')
-        ? 'gitlab'
-        : workspaceProvider
     if (req.provider !== undefined && req.provider !== provider) {
       this.audit('denied', req.agentId, plane, repo)
       return reply({ ok: false, error: `this workspace has no managed ${req.provider} credential` })

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1753,6 +1753,13 @@ export class Daemon {
       projectIdOf: (agentId: string) => {
         const ws = this.agents.get(agentId)?.workspace
         return ws?.mode === 'git-repo' ? ws.gitlabProjectId : undefined
+      },
+      // The §8.3 allowlist, matched case-insensitively on the project path.
+      gitlabProjectOf: (agentId: string, repoFullName: string) => {
+        const wanted = repoFullName.toLowerCase()
+        return (this.agents.get(agentId)?.workspace.additionalRepos ?? []).find(
+          (row) => row.provider === 'gitlab' && row.repoFullName.toLowerCase() === wanted
+        )?.repoId
       }
     })
     const daemonCredentialTarget = daemonGitCredentialTarget({

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -350,6 +350,11 @@ export class WorkspaceManager {
     const parent = this.secondaryRootsDirAt(agent, mount)
     const roots: SecondaryWorkspaceRoot[] = []
     for (const row of agent.workspace.additionalRepos ?? []) {
+      // Secondary roots are GitHub-only: the clone URL below is github.com, so a
+      // GitLab project would be fetched from the wrong host entirely. Its grant
+      // still serves credentials — only the materialized root is not built yet
+      // (gitlab-com-integration.md §13.1; multi-repository-workspaces.md).
+      if ((row.provider ?? 'github') !== 'github') continue
       const [owner, repo, ...rest] = row.repoFullName.split('/')
       // A row that is not two plain segments would place its subtree by its own text; refuse it here.
       if (rest.length > 0 || !isRepoSegment(owner) || !isRepoSegment(repo)) {

--- a/packages/daemon/test/agents.test.ts
+++ b/packages/daemon/test/agents.test.ts
@@ -230,7 +230,12 @@ describe('AgentSchema defaults', () => {
 
   it('round-trips the CP-replicated additional-repository allowlist, defaulting to none', () => {
     const base = { id: 'x', name: 'x', status: 'active', runtime: 'claude', integrations: [] }
-    const additionalRepos = [{ repoFullName: 'example-co/shared-library', repoId: '815' }]
+    // A provider-less entry is what a pre-GitLab control plane replicates, and it
+    // means github; a gitlab project keeps its own qualifier.
+    const additionalRepos = [
+      { repoFullName: 'example-co/shared-library', repoId: '815' },
+      { repoFullName: 'example-group/example-project', repoId: '4455667', provider: 'gitlab' }
+    ]
 
     expect(
       AgentSchema.parse({ ...base, workspace: { mode: 'from-scratch', path: './workspace' } }).workspace.additionalRepos
@@ -238,6 +243,9 @@ describe('AgentSchema defaults', () => {
     expect(
       AgentSchema.parse({ ...base, workspace: { mode: 'from-scratch', path: './workspace', additionalRepos } })
         .workspace.additionalRepos
-    ).toEqual(additionalRepos)
+    ).toEqual([
+      { repoFullName: 'example-co/shared-library', repoId: '815', provider: 'github' },
+      { repoFullName: 'example-group/example-project', repoId: '4455667', provider: 'gitlab' }
+    ])
   })
 })

--- a/packages/daemon/test/cp/gitcred-routing.test.ts
+++ b/packages/daemon/test/cp/gitcred-routing.test.ts
@@ -211,6 +211,34 @@ describe('GitCredServer routing (gitcred.sock)', () => {
     expect(gets).toEqual([{ agentId: 'a1', opts: { plane: 'git' } }]) // no repo → workspace key
   })
 
+  it('erases the provider-qualified key a named gitlab project was served under', async () => {
+    // A scratch or github-workspace agent holding a gitlab additional project has a
+    // cache entry keyed gitlab, while its WORKSPACE says github. Deriving erase from
+    // the workspace alone would invalidate the github key and leave the rejected
+    // GitLab token live until its TTL.
+    const { sockPath, erases, capability } = boot(undefined, {
+      providerOf: () => 'github',
+      gitlabProjectOf: (_agentId, repoFullName) =>
+        repoFullName === 'example-group/example-second' ? '4455668' : undefined
+    })
+    const res = await roundtrip(sockPath, {
+      op: 'erase',
+      agentId: 'a1',
+      capability,
+      password: 'glpat_dead',
+      repoFullName: 'example-group/example-second',
+      provider: 'gitlab'
+    })
+    expect(res.ok).toBe(true)
+    expect(erases).toEqual([
+      {
+        agentId: 'a1',
+        password: 'glpat_dead',
+        opts: { plane: 'git', repo: 'example-group/example-second', provider: 'gitlab' }
+      }
+    ])
+  })
+
   it('routes erase to the same key the get used', async () => {
     const { sockPath, erases, capability } = boot()
     const res = await roundtrip(sockPath, {

--- a/packages/daemon/test/cp/gitcred-routing.test.ts
+++ b/packages/daemon/test/cp/gitcred-routing.test.ts
@@ -10,7 +10,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { effectiveAgentId, repoFromPath } from '../../src/cli/git-credential.js'
 import { normalizeRepoArg } from '../../src/cp/gh-target.js'
-import { GITCRED_AGENT_ENV, GitCredServer } from '../../src/cp/gitcred-server.js'
+import { GITCRED_AGENT_ENV, GitCredServer, type GitCredServerDeps } from '../../src/cp/gitcred-server.js'
 import type { GitCredentialCache } from '../../src/cp/git-credential.js'
 
 describe('repoFromPath (git credential path → owner/repo)', () => {
@@ -70,9 +70,16 @@ describe('normalizeRepoArg (gh wrapper repo argument)', () => {
 })
 
 describe('GitCredServer routing (gitcred.sock)', () => {
+  interface GetOpts {
+    plane?: string
+    repo?: string
+    provider?: string
+    externalRepoId?: string
+    requestedAccess?: string
+  }
   interface GetCall {
     agentId: string
-    opts?: { plane?: string; repo?: string }
+    opts?: GetOpts
   }
   interface EraseCall {
     agentId: string
@@ -87,7 +94,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
     if (dir) rmSync(dir, { recursive: true, force: true })
   })
 
-  function boot(workspace?: string) {
+  function boot(workspace?: string, spec?: Partial<GitCredServerDeps>) {
     dir = mkdtempSync(join(tmpdir(), 'gitcred-routing-'))
     const sockPath = join(dir, 'gitcred.sock')
     const gets: GetCall[] = []
@@ -95,7 +102,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
     const logs: string[] = []
     const warnings: string[] = []
     const fakeCache = {
-      get: async (agentId: string, _reason: string, opts?: { plane?: string; repo?: string }) => {
+      get: async (agentId: string, _reason: string, opts?: GetOpts) => {
         gets.push({ agentId, ...(opts ? { opts } : {}) })
         return {
           username: 'x-access-token',
@@ -105,13 +112,14 @@ describe('GitCredServer routing (gitcred.sock)', () => {
           expiresAtMono: 0
         }
       },
-      invalidate: (agentId: string, password?: string, opts?: { plane?: string; repo?: string }) => {
+      invalidate: (agentId: string, password?: string, opts?: GetOpts) => {
         erases.push({ agentId, ...(password !== undefined ? { password } : {}), ...(opts ? { opts } : {}) })
       }
     }
     server = new GitCredServer(fakeCache as unknown as GitCredentialCache, sockPath, {
       log: { info: (message) => logs.push(message), warn: (message) => warnings.push(message) },
-      ...(workspace ? { workspaceRepoOf: () => workspace } : {})
+      ...(workspace ? { workspaceRepoOf: () => workspace } : {}),
+      ...spec
     })
     const capability = server.capabilityFor('a1')
     server.start()
@@ -148,6 +156,47 @@ describe('GitCredServer routing (gitcred.sock)', () => {
     expect(gets).toEqual([{ agentId: 'a1', opts: { plane: 'gh', repo: 'other/tools' } }])
     expect(logs.join('\n')).toContain('outcome=served')
     expect(logs.join('\n')).not.toContain('ghs_test')
+  })
+
+  it('names the numeric project id for an authorized additional gitlab project (§8.3)', async () => {
+    // Without the id the ask travels as a display path only, the control plane
+    // answers with the WORKSPACE grant, and the echo check rejects it — which is
+    // what leaves an exact checkout of an authorized project credential-less.
+    const { sockPath, gets, capability } = boot('example-group/example-project', {
+      providerOf: () => 'gitlab',
+      gitlabProjectOf: (_agentId, repoFullName) =>
+        repoFullName === 'example-group/example-second' ? '4455668' : undefined
+    })
+    const res = await roundtrip(sockPath, {
+      op: 'get',
+      agentId: 'a1',
+      capability,
+      repoFullName: 'example-group/example-second',
+      provider: 'gitlab'
+    })
+    expect(res.ok).toBe(true)
+    expect(gets).toEqual([
+      {
+        agentId: 'a1',
+        opts: { plane: 'git', repo: 'example-group/example-second', provider: 'gitlab', externalRepoId: '4455668' }
+      }
+    ])
+  })
+
+  it('denies a gitlab project the replicated spec does not authorize', async () => {
+    const { sockPath, gets, capability } = boot(undefined, {
+      providerOf: () => 'github',
+      gitlabProjectOf: () => undefined
+    })
+    const res = await roundtrip(sockPath, {
+      op: 'get',
+      agentId: 'a1',
+      capability,
+      repoFullName: 'example-group/unauthorized',
+      provider: 'gitlab'
+    })
+    expect(res.ok).toBe(false)
+    expect(gets).toEqual([]) // refused locally; the control plane is never asked
   })
 
   it('folds a request naming the workspace repo onto the repo-less key', async () => {

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -422,9 +422,15 @@ describe('agent spec / CRUD frames (CP→daemon spec sync)', () => {
   })
 
   it('spec.workspace round-trips the additional-repository allowlist on both modes', () => {
+    // A provider-less entry is what a pre-GitLab control plane sends, and it means
+    // github — the tolerant-reader default the two hosts' independent numbering needs.
     const additionalRepos = [
       { repoFullName: 'acme/infra', repoId: '4711' },
-      { repoFullName: 'example-co/shared-library', repoId: '815' }
+      { repoFullName: 'example-group/example-project', repoId: '815', provider: 'gitlab' }
+    ]
+    const qualified = [
+      { repoFullName: 'acme/infra', repoId: '4711', provider: 'github' },
+      { repoFullName: 'example-group/example-project', repoId: '815', provider: 'gitlab' }
     ]
     const scratch = decodeEnvelope(
       envelope('agent/upsert', {
@@ -433,7 +439,7 @@ describe('agent spec / CRUD frames (CP→daemon spec sync)', () => {
       })
     )
     if (!scratch.ok || !isFrame('agent/upsert')(scratch.frame)) throw new Error('expected agent/upsert')
-    expect(scratch.frame.payload.spec.workspace?.additionalRepos).toEqual(additionalRepos)
+    expect(scratch.frame.payload.spec.workspace?.additionalRepos).toEqual(qualified)
 
     const github = decodeEnvelope(
       envelope('agent/upsert', {
@@ -445,7 +451,7 @@ describe('agent spec / CRUD frames (CP→daemon spec sync)', () => {
       })
     )
     if (!github.ok || !isFrame('agent/upsert')(github.frame)) throw new Error('expected agent/upsert')
-    expect(github.frame.payload.spec.workspace?.additionalRepos).toEqual(additionalRepos)
+    expect(github.frame.payload.spec.workspace?.additionalRepos).toEqual(qualified)
   })
 
   it('agent/upsert and agent/remove decode for live CRUD', () => {

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { CodeHostProviderString } from '../code-host.js'
 import { AgentMemoryBinding } from './memory-connection.js'
 import { IntegrationSpec } from './integration.js'
 import { CronUpsert } from './cron.js'
@@ -14,8 +15,15 @@ import { normalizeGitHubSkillSource } from '../git-url.js'
  */
 
 // One repository of the agent's additional-repository allowlist (multi-repository-workspaces.md decision 2).
-// `repoId` is GitHub's numeric repository id as a decimal string — rename-immune, the identity minting matches on.
-export const AgentAdditionalRepo = z.object({ repoFullName: z.string(), repoId: z.string() })
+// `repoId` is the host's numeric repository/project id as a decimal string — rename-immune, the identity
+// minting matches on. `provider` qualifies it (gitlab-com-integration.md §8.1): the hosts number their
+// repositories independently, so the pair is the identity. Absent ⇒ `github`, which is what every row a
+// pre-GitLab control plane projects means, so an older peer's list still decodes.
+export const AgentAdditionalRepo = z.object({
+  repoFullName: z.string(),
+  repoId: z.string(),
+  provider: CodeHostProviderString.default('github')
+})
 export type AgentAdditionalRepo = z.infer<typeof AgentAdditionalRepo>
 
 /**

--- a/packages/web/src/components/console/WorkspaceCard.test.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.test.tsx
@@ -8,7 +8,8 @@ vi.mock('swr', () => ({
 }))
 vi.mock('@/lib/api', () => ({
   creatorLabel: () => 'Dana Reyes',
-  fetchAgentRepos: vi.fn()
+  fetchAgentRepos: vi.fn(),
+  repoAuthProvider: (row: { provider?: string }) => row.provider ?? 'github'
 }))
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: vi.fn() }),

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -28,7 +28,7 @@ import useSWR from 'swr'
 import { GithubMark, GitlabMark, LoadingState } from '@/components/marks'
 import { Icon } from '@/components/ui'
 import { isPoolPlacementKind, type Agent, type WorkspaceStatusInfo } from '@/lib/data'
-import { creatorLabel, fetchAgentRepos } from '@/lib/api'
+import { creatorLabel, fetchAgentRepos, repoAuthProvider } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import { useProfile } from '@/lib/profile'
 import { consoleKeys } from '@/lib/swr-keys'
@@ -123,7 +123,11 @@ export function WorkspaceCard({
   const manualWorkspaceAuthorized =
     ws.mode === 'github' &&
     !isGithubApp &&
-    repos.some((authorization) => authorization.repoFullName.toLowerCase() === ws.repo.toLowerCase())
+    repos.some(
+      (authorization) =>
+        repoAuthProvider(authorization) === 'github' &&
+        authorization.repoFullName.toLowerCase() === ws.repo.toLowerCase()
+    )
   // A manual checkout has no App installation to mint a write token from, so its
   // effective workspace access is read regardless of the stored preference.
   const workspaceAccess =
@@ -285,7 +289,7 @@ export function WorkspaceCard({
                 title={`${r.repoFullName} — ${r.access} access${poolPlaced ? '' : ', checked out alongside the workspace'}; added by ${creatorLabel(r.createdBy, me)}`}
               >
                 <span className="imark h-[14px] w-[14px] border-0 bg-transparent">
-                  <GithubMark />
+                  {repoAuthProvider(r) === 'gitlab' ? <GitlabMark /> : <GithubMark />}
                 </span>
                 <span className="mono text-[11.5px] text-(--text-primary)">{r.repoFullName}</span>
                 <span className={REPOSITORY_ACCESS_BADGE[r.access]}>{r.access}</span>

--- a/packages/web/src/components/console/modals/AddAgentRepoModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddAgentRepoModal.gitlab.test.tsx
@@ -1,0 +1,244 @@
+// @vitest-environment happy-dom
+/**
+ * Authorizing an additional repository is a choice of code host first
+ * (gitlab-com-integration.md §18.1). The GitLab arm offers the connection's
+ * Maintainer-or-Owner projects merged with the ones already added, sets up a
+ * project that is not added yet before the selection lands, and submits the
+ * numeric project id — never the namespaced path, which is not a match key.
+ * Projects the agent already holds are named as taken rather than offered again.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentRepoAuthDto } from '@/lib/api'
+import type { Agent } from '@/lib/data'
+
+const mocks = vi.hoisted(() => ({
+  fetchGitlabProjects: vi.fn(),
+  fetchGitlabConnections: vi.fn(),
+  searchGitlabProjects: vi.fn(),
+  createGitlabProject: vi.fn(),
+  createAgentRepo: vi.fn()
+}))
+
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (path: string) => `/acme${path}` }) }))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
+  fetchGithubInstallUrl: vi.fn(async () => null),
+  fetchGithubRepoRoster: vi.fn(async () => ({ repos: [], privateReposHidden: false, failed: false })),
+  fetchGitlabProjects: mocks.fetchGitlabProjects,
+  fetchGitlabConnections: mocks.fetchGitlabConnections,
+  searchGitlabProjects: mocks.searchGitlabProjects,
+  createGitlabProject: mocks.createGitlabProject,
+  createAgentRepo: mocks.createAgentRepo
+}))
+
+const AddAgentRepoModal = (await import('./AddAgentRepoModal')).default
+
+const binding = (over: Record<string, unknown>) => ({
+  id: `binding-${over.projectId}`,
+  projectPath: 'example-group/example-project',
+  defaultBranch: 'main',
+  state: 'ready',
+  stateReason: null,
+  accounts: [],
+  webhookState: 'installed',
+  credentialEpoch: '1',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  ...over
+})
+
+const CONNECTION = {
+  id: 'conn-1',
+  gitlabUserId: '4711',
+  gitlabUsername: 'example-maintainer',
+  state: 'connected' as const,
+  scopes: ['api'],
+  connectedBy: 'user-1',
+  accessExpiresAt: null,
+  assignedProjects: 0,
+  createdAt: '2026-08-01T00:00:00.000Z'
+}
+
+const grant = (over: Partial<AgentRepoAuthDto>): AgentRepoAuthDto => ({
+  id: 'ra-1',
+  provider: 'gitlab',
+  repoId: '4455667',
+  repoFullName: 'example-group/example-project',
+  access: 'read',
+  createdBy: null,
+  createdAt: '2026-08-01T00:00:00.000Z',
+  ...over
+})
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+const created: AgentRepoAuthDto[] = []
+
+async function render(options: { agent?: Agent; authorized?: AgentRepoAuthDto[] } = {}) {
+  const agent =
+    options.agent ??
+    ({ id: 'agent-a', name: 'build-agent', canEdit: true, workspace: { mode: 'scratch' } } as unknown as Agent)
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(
+      <AddAgentRepoModal
+        agent={agent}
+        workspaceRepo={null}
+        authorized={options.authorized ?? []}
+        onClose={() => undefined}
+        onCreated={(row) => created.push(row)}
+      />
+    )
+  })
+}
+
+const buttonsNamed = (text: string) =>
+  Array.from(document.querySelectorAll('button')).filter((button) => button.textContent?.includes(text))
+
+/** Candidates are searched on GitLab behind a debounce; let it elapse for real. */
+async function settleSearch() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 400))
+  })
+}
+
+/** One connected account with nothing else to offer, unless a test says otherwise. */
+function connected(projects: unknown[] = []) {
+  mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+  mocks.searchGitlabProjects.mockResolvedValue({ projects, nextPage: null })
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  created.length = 0
+  mocks.fetchGitlabProjects.mockReset()
+  mocks.fetchGitlabConnections.mockReset()
+  mocks.searchGitlabProjects.mockReset()
+  mocks.createGitlabProject.mockReset()
+  mocks.createAgentRepo.mockReset()
+})
+
+describe('AddAgentRepoModal, GitLab projects', () => {
+  it('offers GitLab beside GitHub and asks nothing until it is picked', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([])
+    connected()
+    await render()
+
+    expect(document.body.textContent).toContain('GitHub')
+    expect(document.body.textContent).toContain('GitLab')
+    expect(mocks.fetchGitlabProjects).not.toHaveBeenCalled()
+
+    await act(async () => buttonsNamed('GitLab')[0]?.click())
+    await settleSearch()
+    expect(mocks.fetchGitlabProjects).toHaveBeenCalled()
+  })
+
+  it('names the project in GitLab’s vocabulary, not the repository one', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([binding({ projectId: '4455667' })])
+    connected()
+    await render()
+    await act(async () => buttonsNamed('GitLab')[0]?.click())
+    await settleSearch()
+
+    expect(document.body.textContent).toContain('GitLab project')
+    expect(document.body.textContent).toContain('Push, open merge requests & run pipelines')
+    expect(document.body.textContent).toContain('Access applies only to this project')
+    expect(document.body.textContent).not.toContain('run GitHub Actions')
+  })
+
+  it('authorizes the picked project by its numeric id', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([binding({ projectId: '4455667' })])
+    connected()
+    mocks.createAgentRepo.mockResolvedValue(grant({}))
+    await render()
+    await act(async () => buttonsNamed('GitLab')[0]?.click())
+    await settleSearch()
+    await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
+    const option = Array.from(document.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('example-group/example-project')
+    )
+    await act(async () => option?.click())
+    await act(async () => buttonsNamed('Add')[0]?.click())
+
+    expect(mocks.createAgentRepo).toHaveBeenCalledWith('agent-a', {
+      provider: 'gitlab',
+      projectId: '4455667',
+      access: 'read'
+    })
+    expect(created).toHaveLength(1)
+  })
+
+  it('sets a project up before the selection lands, then authorizes it', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([])
+    connected([
+      { projectId: '4455668', path: 'example-group/example-second', defaultBranch: 'main', lastActivityAt: null }
+    ])
+    mocks.createGitlabProject.mockResolvedValue(
+      binding({ projectId: '4455668', projectPath: 'example-group/example-second' })
+    )
+    mocks.createAgentRepo.mockResolvedValue(grant({ repoId: '4455668' }))
+    await render()
+    await act(async () => buttonsNamed('GitLab')[0]?.click())
+    await settleSearch()
+    await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
+    expect(document.body.textContent).toContain('sets up on pick')
+
+    const option = Array.from(document.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('example-group/example-second')
+    )
+    await act(async () => option?.click())
+    expect(mocks.createGitlabProject).toHaveBeenCalledWith({ connectionId: 'conn-1', projectId: '4455668' })
+
+    await act(async () => buttonsNamed('Add')[0]?.click())
+    expect(mocks.createAgentRepo).toHaveBeenCalledWith('agent-a', {
+      provider: 'gitlab',
+      projectId: '4455668',
+      access: 'read'
+    })
+  })
+
+  it('says a project is taken by the workspace or an existing grant instead of offering it', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([
+      binding({ projectId: '4455667', projectPath: 'example-group/example-project' }),
+      binding({ projectId: '4455668', projectPath: 'example-group/example-second' })
+    ])
+    connected()
+    await render({
+      agent: {
+        id: 'agent-a',
+        name: 'build-agent',
+        canEdit: true,
+        workspace: { mode: 'gitlab', projectId: '4455667' }
+      } as unknown as Agent,
+      authorized: [grant({ repoId: '4455668', repoFullName: 'example-group/example-second' })]
+    })
+    await act(async () => buttonsNamed('GitLab')[0]?.click())
+    await settleSearch()
+    await act(async () => document.querySelector<HTMLDivElement>('.inp')?.click())
+
+    expect(document.body.textContent).toContain('is the agent’s workspace project')
+    expect(document.body.textContent).toContain('is already authorized for this agent')
+    // Neither is selectable, so Add stays inert.
+    expect(mocks.createAgentRepo).not.toHaveBeenCalled()
+  })
+
+  it('states the absence when the deployment configures no GitLab application', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([])
+    mocks.fetchGitlabConnections.mockResolvedValue({ enabled: false, connections: [] })
+    await render()
+    await act(async () => buttonsNamed('GitLab')[0]?.click())
+    await settleSearch()
+
+    expect(document.body.textContent).toContain(
+      'GitLab is not enabled on this deployment — no GitLab application is configured.'
+    )
+    expect(mocks.searchGitlabProjects).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
@@ -1,9 +1,13 @@
 'use client'
 
 // Authorize a repository for one agent (issue #457,
-// agent-multi-repo-authorization.md §web 1): repo picker over the org's GitHub
-// App installations + an access choice, preflighted against the
-// per-user identity-assertion gate when the deployment has one.
+// agent-multi-repo-authorization.md §web 1; gitlab-com-integration.md §18.1):
+// one picker per code host — GitHub repositories across the org's App
+// installations, GitLab projects the connection administers — plus an access
+// choice, preflighted against the per-user identity-assertion gate when the
+// deployment has one. Picking a GitLab project that is not set up yet runs the
+// §10.2 provisioning saga inline before the selection lands, exactly as the
+// workspace and trigger pickers do.
 //
 // This renders its own scrim/modal overlay because Edit workspace can expose it
 // as a preserved-state subview while another editor (such as GitHub hook setup)
@@ -11,11 +15,18 @@
 // so a nested open never tears down the caller.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { GithubMark } from '@/components/marks'
+import { GithubMark, GitlabMark, LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { agentLabel, type Agent } from '@/lib/data'
 import { useOrgs } from '@/lib/org-context'
-import { GithubPrivateReposNotice } from '@/components/console/WorkspaceFormFields'
+import {
+  GithubPrivateReposNotice,
+  GitlabNoProjectsNotice,
+  GitlabProjectField,
+  GitlabProjectOption
+} from '@/components/console/WorkspaceFormFields'
+import { matchGitlabProjects, type GitlabProjectChoice } from '@/lib/gitlab-projects'
+import { useGitlabProjects } from '@/lib/use-gitlab-projects'
 import {
   ApiError,
   createAgentRepo,
@@ -24,6 +35,7 @@ import {
   fetchGithubRepoRoster,
   fetchGithubRepoAccess,
   invalidateGithubRepoRosterCache,
+  repoAuthProvider,
   syncGithubInstallations,
   type AgentRepoAuthDto,
   type GithubInstallationDto,
@@ -31,6 +43,9 @@ import {
   type GithubRepoDto,
   type RepoAccess
 } from '@/lib/api'
+
+/** Which host the picker is offering. Grants are provider-qualified (§8.1). */
+type GrantProvider = 'github' | 'gitlab'
 
 // The two grant tiers. Read is a clone/read scope; write additionally grants
 // push access, pull_requests:write for formal reviews, and actions:write for
@@ -44,6 +59,18 @@ const TIERS: { v: RepoAccess; label: string; icon: string; desc: string }[] = [
     label: 'Read & write',
     icon: 'git-branch',
     desc: 'Push, open PRs & run GitHub Actions'
+  }
+]
+
+// The same two tiers in GitLab's vocabulary — merge requests and pipelines, and a
+// project rather than a repository.
+const GITLAB_TIERS: { v: RepoAccess; label: string; icon: string; desc: string }[] = [
+  { v: 'read', label: 'Read only', icon: 'eye', desc: 'Clone & read files only' },
+  {
+    v: 'write',
+    label: 'Read & write',
+    icon: 'git-branch',
+    desc: 'Push, open merge requests & run pipelines'
   }
 ]
 
@@ -81,6 +108,9 @@ export default function AddAgentRepoModal({
   onCreated: (row: AgentRepoAuthDto) => void
 }) {
   const { orgPath } = useOrgs()
+  // A repository locked by a manual GitHub workspace pins the host too — that arm
+  // may authorize only its own repository, so the choice would be a dead end.
+  const [provider, setProvider] = useState<GrantProvider>('github')
   const [gh, setGh] = useState<{ enabled: boolean; installations: GithubInstallationDto[] } | null>(null)
   const [ghSyncing, setGhSyncing] = useState(false)
   // Repos merged across every installation; partial pages render immediately
@@ -101,6 +131,13 @@ export default function AddAgentRepoModal({
   const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const busyRef = useRef(false)
+  // GitLab arm: the connection's Maintainer-or-Owner projects merged with the ones
+  // already added. Inert until the GitLab tile is picked, so a GitHub-only
+  // deployment issues no GitLab request at all.
+  const [glQ, setGlQ] = useState('')
+  const [glPick, setGlPick] = useState('')
+  const [glPickOpen, setGlPickOpen] = useState(false)
+  const gl = useGitlabProjects(provider === 'gitlab', glQ)
 
   // Escape closes THIS layer only: capture-phase + stopPropagation beats the
   // ModalProvider's bubble-phase window listener when we're nested in a dialog.
@@ -175,9 +212,34 @@ export default function AddAgentRepoModal({
     }
   }
 
-  const authorizedByName = useMemo(() => new Set(authorized.map((r) => r.repoFullName.toLowerCase())), [authorized])
+  const authorizedByName = useMemo(
+    () => new Set(authorized.filter((r) => repoAuthProvider(r) === 'github').map((r) => r.repoFullName.toLowerCase())),
+    [authorized]
+  )
   const isWorkspace = (fullName: string) => !!workspaceRepo && workspaceRepo.toLowerCase() === fullName.toLowerCase()
   const isAuthorized = (fullName: string) => authorizedByName.has(fullName.toLowerCase())
+
+  // GitLab identity is the numeric project id, never the namespaced path.
+  const authorizedProjects = useMemo(
+    () =>
+      new Set(authorized.filter((r) => repoAuthProvider(r) === 'gitlab' && r.repoId).map((r) => r.repoId as string)),
+    [authorized]
+  )
+  const workspaceProject = agent.workspace.mode === 'gitlab' ? agent.workspace.projectId : undefined
+  const glMatches = matchGitlabProjects(gl.choices, glQ)
+  const glPicked = gl.choices.find((c) => c.projectId === glPick)
+  const glTakenBy = (projectId: string): 'workspace' | 'authorized' | null =>
+    workspaceProject === projectId ? 'workspace' : authorizedProjects.has(projectId) ? 'authorized' : null
+  const glNoProjects = gl.empty || !gl.enabled || !gl.connected
+
+  // Picking a project that is not set up yet runs the provisioning saga first; a
+  // failed setup selects nothing, so the footer stays inert (§18.1).
+  const selectProject = async (choice: GitlabProjectChoice) => {
+    if (!choice.binding && !(await gl.provision(choice.projectId))) return
+    setGlPick(choice.projectId)
+    setGlPickOpen(false)
+    setErr(null)
+  }
 
   const picked = repos?.find((r) => r.fullName.toLowerCase() === pick.toLowerCase())
   const pickOwner = pick.split('/')[0] ?? ''
@@ -223,7 +285,10 @@ export default function AddAgentRepoModal({
   const typedIsListed = !!typedRepo && matches.some((r) => r.fullName.toLowerCase() === typedRepo.toLowerCase())
   const typedTaken = !!typedRepo && (isWorkspace(typedRepo) || isAuthorized(typedRepo))
 
-  const canSubmit = !!pick && !isWorkspace(pick) && !isAuthorized(pick) && !uncovered && !probeDenies
+  const canSubmit =
+    provider === 'gitlab'
+      ? !!glPick && glTakenBy(glPick) === null && gl.provisioning === null
+      : !!pick && !isWorkspace(pick) && !isAuthorized(pick) && !uncovered && !probeDenies
 
   const submit = async () => {
     if (busyRef.current || !canSubmit) return
@@ -231,7 +296,10 @@ export default function AddAgentRepoModal({
     setSaving(true)
     setErr(null)
     try {
-      const row = await createAgentRepo(agent.id, { repoFullName: pick, access })
+      const row = await createAgentRepo(
+        agent.id,
+        provider === 'gitlab' ? { provider: 'gitlab', projectId: glPick, access } : { repoFullName: pick, access }
+      )
       onCreated(row)
     } catch (e) {
       if (e instanceof ApiError && e.code === 'GITHUB_IDENTITY_REQUIRED') {
@@ -272,7 +340,13 @@ export default function AddAgentRepoModal({
               {workspaceContext ? 'Edit workspace' : 'Add repository'}
             </div>
             <div className="mt-[1px] truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-              {workspaceContext ? 'authorize an additional repository for ' : 'authorize a GitHub repository for '}
+              {workspaceContext
+                ? provider === 'gitlab'
+                  ? 'authorize an additional project for '
+                  : 'authorize an additional repository for '
+                : provider === 'gitlab'
+                  ? 'authorize a GitLab project for '
+                  : 'authorize a GitHub repository for '}
               <span className="mono">{agentLabel(agent)}</span>
             </div>
           </div>
@@ -281,7 +355,149 @@ export default function AddAgentRepoModal({
           </button>
         </div>
         <div className="modalbody">
-          {gh === null ? (
+          {/* A repository fixed by a manual GitHub workspace pins the host too. */}
+          {!fixedRepo && (
+            <div className="fld mb-[18px]">
+              <span className="fldlbl">Code host</span>
+              <div className="grid grid-cols-2 gap-[10px]">
+                {(
+                  [
+                    {
+                      v: 'github',
+                      label: 'GitHub',
+                      hint: 'Authorize a repository.',
+                      mark: <GithubMark color="var(--text-primary)" />
+                    },
+                    { v: 'gitlab', label: 'GitLab', hint: 'Authorize a project.', mark: <GitlabMark /> }
+                  ] as const
+                ).map((host) => (
+                  <button
+                    key={host.v}
+                    type="button"
+                    className={provider === host.v ? 'ptile on items-start text-left' : 'ptile items-start text-left'}
+                    onClick={() => {
+                      setProvider(host.v)
+                      setErr(null)
+                    }}
+                  >
+                    <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
+                      <span className="flex h-4 w-4 items-center justify-center">{host.mark}</span>
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block font-sans text-[13px] font-semibold leading-normal">{host.label}</span>
+                      <span className="mt-[2px] block truncate font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                        {host.hint}
+                      </span>
+                    </span>
+                    <span
+                      className={
+                        provider === host.v
+                          ? 'ml-auto flex h-4 w-4 flex-none items-center justify-center self-center rounded-full border-[1.5px] border-(--brand)'
+                          : 'ml-auto flex h-4 w-4 flex-none items-center justify-center self-center rounded-full border-[1.5px] border-(--border-strong)'
+                      }
+                    >
+                      {provider === host.v && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          {provider === 'gitlab' ? (
+            gl.error ? (
+              <div className="mb-4 font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
+                Couldn&rsquo;t load your GitLab projects — {gl.error}
+              </div>
+            ) : gl.loading ? (
+              <div className="mb-4">
+                <LoadingState size={20} padding={16} />
+              </div>
+            ) : glNoProjects ? (
+              <div className="mb-4">
+                <GitlabNoProjectsNotice
+                  integrationsHref={orgPath('/integrations')}
+                  connected={gl.connected}
+                  enabled={gl.enabled}
+                />
+              </div>
+            ) : (
+              <>
+                <div className="mb-[18px]">
+                  <GitlabProjectField
+                    value={glPicked?.projectPath ?? ''}
+                    icon="book-marked"
+                    loading={false}
+                    open={glPickOpen}
+                    query={glQ}
+                    onToggle={() => {
+                      setGlQ('')
+                      setGlPickOpen((value) => !value)
+                    }}
+                    onClose={() => setGlPickOpen(false)}
+                    onQueryChange={setGlQ}
+                    error={gl.provisionError ? `Couldn’t set up that project — ${gl.provisionError}` : undefined}
+                  >
+                    {glMatches.map((choice) => {
+                      const taken = glTakenBy(choice.projectId)
+                      if (taken !== null) {
+                        return (
+                          <div key={choice.projectId} className="fnohit">
+                            {choice.projectPath}
+                            {taken === 'workspace'
+                              ? ' is the agent’s workspace project'
+                              : ' is already authorized for this agent'}
+                          </div>
+                        )
+                      }
+                      return (
+                        <GitlabProjectOption
+                          key={choice.projectId}
+                          choice={choice}
+                          selected={glPick === choice.projectId}
+                          busy={gl.provisioning === choice.projectId}
+                          onSelect={() => void selectProject(choice)}
+                        />
+                      )
+                    })}
+                    {glMatches.length === 0 && <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>}
+                  </GitlabProjectField>
+                </div>
+
+                <div className="fldlbl mb-2">Access</div>
+                <div className="mb-4 flex flex-col gap-[9px]">
+                  {GITLAB_TIERS.map((t) => {
+                    const on = access === t.v
+                    return (
+                      <div
+                        key={t.v}
+                        className={`flex cursor-pointer items-center gap-[11px] rounded-[9px] border px-[13px] py-[11px] ${
+                          on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-subtle) bg-(--surface-card)'
+                        }`}
+                        onClick={() => setAccess(t.v)}
+                      >
+                        <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
+                          <Icon name={t.icon} size={16} color={on ? 'var(--brand)' : 'var(--text-tertiary)'} />
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <div className="font-sans text-[13px] font-semibold leading-normal">{t.label}</div>
+                          <div className="mt-[2px] font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                            {t.desc}
+                          </div>
+                        </div>
+                        <span
+                          className={`flex h-4 w-4 flex-none items-center justify-center rounded-full border-[1.5px] ${
+                            on ? 'border-(--brand)' : 'border-(--border-strong)'
+                          }`}
+                        >
+                          {on && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
+                        </span>
+                      </div>
+                    )
+                  })}
+                </div>
+              </>
+            )
+          ) : gh === null ? (
             <div className="mb-4 flex items-center gap-[10px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
               <Icon name="loader" size={15} className="flex-none animate-spin" />
               Checking your GitHub setup…
@@ -537,7 +753,9 @@ export default function AddAgentRepoModal({
         </div>
         <div className="modalfoot">
           <span className="flex-1 font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-            Access applies only to this repository and can be revoked at any time.
+            {provider === 'gitlab'
+              ? 'Access applies only to this project and can be revoked at any time.'
+              : 'Access applies only to this repository and can be revoked at any time.'}
           </span>
           <Button variant="ghost" onClick={onClose}>
             Cancel

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   fetchGitlabConnections: vi.fn(),
   searchGitlabProjects: vi.fn(),
   createGitlabProject: vi.fn(),
+  fetchAgentRepos: vi.fn(),
   daemons: [] as unknown[]
 }))
 
@@ -49,7 +50,7 @@ vi.mock('@/lib/data-context', () => ({
 vi.mock('@/lib/api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/api')>()),
   fetchAgentHooks: vi.fn(async () => []),
-  fetchAgentRepos: vi.fn(async () => []),
+  fetchAgentRepos: mocks.fetchAgentRepos,
   fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
   fetchGithubInstallUrl: vi.fn(async () => null),
   fetchGithubRepoRoster: vi.fn(async () => ({ repos: [], privateReposHidden: false, failed: false })),
@@ -120,10 +121,23 @@ async function pickProject() {
   await act(async () => clickText('acme/platform')?.click())
 }
 
+/** The agent already holds the project a trigger may watch (§8.3) — the precondition
+ *  every compilation test is about something else than. */
+const authorization = {
+  id: 'ra-1',
+  provider: 'gitlab' as const,
+  repoId: '4210',
+  repoFullName: 'acme/platform',
+  access: 'read' as const,
+  createdBy: null,
+  createdAt: '2026-08-01T00:00:00.000Z'
+}
+
 /** One usable connection with nothing else on offer; a test that needs another shape overrides it. */
 beforeEach(() => {
   mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [connection] })
   mocks.searchGitlabProjects.mockResolvedValue({ projects: [], nextPage: null })
+  mocks.fetchAgentRepos.mockResolvedValue([authorization])
 })
 
 /** Candidates are searched on GitLab behind a debounce; let it elapse for real. */
@@ -143,6 +157,7 @@ afterEach(async () => {
   mocks.fetchGitlabConnections.mockReset()
   mocks.searchGitlabProjects.mockReset()
   mocks.createGitlabProject.mockReset()
+  mocks.fetchAgentRepos.mockReset()
   mocks.daemons = []
 })
 
@@ -350,5 +365,45 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     expect(mocks.createGitlabHook).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: 'agent-a', name: 'acme/platform', projectId: '4210' })
     )
+  })
+
+  // Each case renders a DISTINCT agent id: the grant read is cached per agent, so
+  // reusing one would serve the previous case's authorization set.
+  async function renderAgent(over: Record<string, unknown>) {
+    host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+    await act(async () => {
+      root?.render(<AddIntegrationModal agent={{ ...agent, ...over } as unknown as Agent} onClose={() => undefined} />)
+    })
+  }
+
+  it('refuses a project the agent is not authorized for, and names the fix', async () => {
+    // A trigger never creates a grant (§8.3): the project must already be the
+    // workspace project or an authorized additional one, so the wizard says so
+    // rather than letting the create reach the same refusal from the server.
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    mocks.fetchAgentRepos.mockResolvedValue([])
+    await renderAgent({ id: 'agent-unauthorized' })
+    await pickProject()
+    await settleSearch()
+
+    expect(document.body.textContent).toContain('isn’t authorized for')
+    expect(document.body.textContent).toContain('Workspace tab')
+
+    await act(async () => clickText('Connect')?.click())
+    expect(mocks.createGitlabHook).not.toHaveBeenCalled()
+  })
+
+  it('accepts the agent’s own workspace project without a separate grant', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    mocks.fetchAgentRepos.mockResolvedValue([])
+    await renderAgent({ id: 'agent-workspace', workspace: { mode: 'gitlab', projectId: '4210' } })
+    await pickProject()
+    await settleSearch()
+
+    expect(document.body.textContent).not.toContain('isn’t authorized for')
+    await act(async () => clickText('Connect')?.click())
+    expect(mocks.createGitlabHook).toHaveBeenCalledWith(expect.objectContaining({ projectId: '4210' }))
   })
 })

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -49,6 +49,7 @@ import {
   creatorLabel,
   fetchAgentHooks,
   fetchAgentRepos,
+  repoAuthProvider,
   fetchGithubInstallationRepo,
   fetchGithubInstallations,
   fetchGithubInstallUrl,
@@ -821,6 +822,13 @@ export default function AddIntegrationModal({
     [agentHooksData]
   )
   const glAlreadyWatched = !!glProject && glWatchedProjects.has(glProject)
+  // §8.3: a trigger never creates a grant, so the watched project must already be the
+  // agent's workspace project or an authorized additional one — the CP 409s anything
+  // else, and saying so here beats letting the user reach a refusal at the last click.
+  const glProjectAuthorized =
+    !glProject ||
+    (agent.workspace.mode === 'gitlab' && agent.workspace.projectId === glProject) ||
+    authorizedRepos.some((r) => repoAuthProvider(r) === 'gitlab' && r.repoId === glProject)
 
   // One subscription = one hook row on this agent, named after the project.
   const submitGitlab = async () => {
@@ -828,6 +836,13 @@ export default function AddIntegrationModal({
     if (glAlreadyWatched) {
       setErr(
         `This agent already watches ${glPicked?.projectPath ?? 'this project'} — edit its events on the agent page instead.`
+      )
+      return
+    }
+    // §8.3, the same refusal the CP would return — said here instead of after a round trip.
+    if (!glProjectAuthorized) {
+      setErr(
+        `This agent isn’t authorized for ${glPicked?.projectPath ?? 'this project'} — authorize the project on the agent’s Workspace tab, or make it the agent’s workspace project, then create the trigger.`
       )
       return
     }
@@ -955,7 +970,7 @@ export default function AddIntegrationModal({
           ? {
               label: 'Connect',
               act: () => void submitGitlab(),
-              enabled: !!glProject && !glAlreadyWatched && glFams.size > 0,
+              enabled: !!glProject && !glAlreadyWatched && glProjectAuthorized && glFams.size > 0,
               hidden: false
             }
           : mode === 'existing'
@@ -1692,6 +1707,18 @@ export default function AddIntegrationModal({
                     {glMatches.length === 0 && <div className="fnohit">No projects match &ldquo;{glQ}&rdquo;</div>}
                   </GitlabProjectField>
                 </div>
+                {/* §8.3 — stated where the pick is, not only inside the closed dropdown. */}
+                {!glProjectAuthorized && (
+                  <div className="mb-4 flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">
+                    <Icon name="shield-alert" size={14} className="mt-[1px] flex-none" />
+                    <span>
+                      This agent isn&rsquo;t authorized for{' '}
+                      <span className="mono">{glPicked?.projectPath ?? 'this project'}</span>. Authorize the project on
+                      the agent&rsquo;s Workspace tab, or make it the agent&rsquo;s workspace project, then create the
+                      trigger.
+                    </span>
+                  </div>
+                )}
                 <div className="fldlbl mb-2">Listen for</div>
                 <div className="mb-4 grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-2">
                   {GL_FAMILIES.map((r) => {

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -6,7 +6,7 @@
 // rejects edits that conflict with enabled GitHub review or Check actions.
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { GithubMark, LoadingState } from '@/components/marks'
+import { GithubMark, GitlabMark, LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { agentLabel, isPoolPlacementKind, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
@@ -23,6 +23,7 @@ import {
   fetchGithubRepoRoster,
   fetchGithubRepoAccess,
   invalidateGithubRepoRosterCache,
+  repoAuthProvider,
   syncGithubInstallations,
   type AgentRepoAuthDto,
   type GithubInstallationDto,
@@ -213,8 +214,15 @@ export default function EditWorkspaceModal({
     }
   }
 
+  // Keyed by github name only: `grantOf` answers questions about the GitHub arm,
+  // and a GitLab project path shares no namespace with `owner/repo`.
   const authorizedByName = useMemo(
-    () => new Map(authorizations.map((r) => [r.repoFullName.toLowerCase(), r])),
+    () =>
+      new Map(
+        authorizations
+          .filter((r) => repoAuthProvider(r) === 'github')
+          .map((r) => [r.repoFullName.toLowerCase(), r] as const)
+      ),
     [authorizations]
   )
   const grantOf = (fullName: string) => authorizedByName.get(fullName.toLowerCase())
@@ -789,7 +797,7 @@ export default function EditWorkspaceModal({
                     className="flex min-w-0 items-center gap-[10px] rounded-md border border-(--border-subtle) bg-(--surface-card) px-3 py-[9px]"
                   >
                     <span className="imark h-4 w-4 flex-none border-0 bg-transparent">
-                      <GithubMark />
+                      {repoAuthProvider(authorization) === 'gitlab' ? <GitlabMark /> : <GithubMark />}
                     </span>
                     <span
                       className="mono min-w-0 flex-1 truncate text-[12.5px] font-semibold text-(--text-primary)"

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -5457,11 +5457,18 @@ export type RepoAccess = 'read' | 'comment' | 'write'
 
 export interface AgentRepoAuthDto {
   id: string
-  repoId?: string // rename-proof GitHub numeric id (absent on an older CP)
-  repoFullName: string // owner/repo as GitHub cases it (refreshed on rename)
+  /** Which host numbers `repoId`. Absent on an older CP, where every grant is GitHub. */
+  provider?: 'github' | 'gitlab'
+  repoId?: string // rename-proof numeric repository/project id (absent on an older CP)
+  repoFullName: string // owner/repo as GitHub cases it, or the GitLab project path (refreshed on rename)
   access: RepoAccess
   createdBy: string | null // authorizer's userId (resolved to a name / "You" in the UI); null for key-created
   createdAt: string // ISO-8601
+}
+
+/** Which host a grant row names — an older CP omits the field and means GitHub. */
+export function repoAuthProvider(row: AgentRepoAuthDto): 'github' | 'gitlab' {
+  return row.provider ?? 'github'
 }
 
 // Gated by the agent's visibility server-side (404 for an agent you can't see) —
@@ -5476,7 +5483,9 @@ export async function fetchAgentRepos(agentId: string, orgId?: string): Promise<
 // USER_NO_ACCESS) that the add-repo modal words inline.
 export async function createAgentRepo(
   agentId: string,
-  input: { repoFullName: string; access: RepoAccess }
+  // One arm per host: a GitHub repository by full name, a GitLab project by its
+  // numeric id (the namespaced path is never a match key).
+  input: { repoFullName: string; access: RepoAccess } | { provider: 'gitlab'; projectId: string; access: RepoAccess }
 ): Promise<AgentRepoAuthDto> {
   const path = `${orgBase()}/agents/${encodeURIComponent(agentId)}/repos`
   const res = await authenticatedFetch(


### PR DESCRIPTION
Section 8.3 of the GitLab design states that creating a hook never creates a repository grant, and that the watched project must already be the workspace project or an explicit additional authorization. Neither half held for GitLab.

Found in live testing: a review-enabled GitLab trigger was created on a project that was neither. It fires, the review's exact checkout can obtain no credential, and both agents gracefully post a "could not review" note. The requirement was also unsatisfiable from the console — the additional-repository picker searched GitHub repositories only, with no GitLab arm at all.

## Did GitHub have the same gap?

**No.** GitHub already enforced it: `watchRepoAuthorized` in `http/routes/hooks.ts` gated hook create and binding-changing edits. Only the GitLab arms skipped it — their own comment cited §8.3 while implementing just the binding half, not the grant half. The check is now provider-aware and both hosts share it.

## Provider-qualifying the grant

`AgentRepoAuthorization` was GitHub-only: a bare numeric `repoId` unique per agent. The two hosts number their repositories independently, so that stopped being an identity the moment GitLab grants existed — one agent may legitimately hold GitHub repository 4455667 and GitLab project 4455667. The row gains a `provider` column and its unique key becomes `(agentId, provider, repoId)`. Every row on record is a GitHub grant, so the column default *is* the backfill.

Every reader that matched on `repoId` alone is qualified the same way: the mint gates, the Checks ledger, and the workspace-collision checks, which now read `workspaceMode` as the workspace's own provider. A migration in the same change adjusts the index.

## Authorizing a project

`POST/PATCH/DELETE /agents/:agentId/repos` gain a gitlab arm. The body is a plain union rather than a discriminated one, because `provider` stays optional on the GitHub arm and a defaulted discriminator does not match an absent key — a published body must keep validating. GitHub names `owner/repo`; GitLab names the numeric project id, since a namespaced path is not `owner/repo` shaped and the client supplies no facts (§10.1). The project is validated against the organization's own binding: a grant never creates a binding, exactly as a hook never does.

Authorizing makes the agent a **consumer** of the project (§7.2), so the arm takes the same identity bracket the workspace and hook arms take — the account and membership are provisioned first, and the grant row commits while the binding lease is still held, so convergence never sees a membership without the authorization that justifies it. Revoking converges the membership away. The query that computes the desired membership set now unions grant rows alongside workspaces and enabled hooks; without that, the next convergence would unbind the membership the grant had just bound.

## Serving the credential

The GitLab grant resolution accepted only the workspace project — its comment said additional-repo rows were "GitHub-shaped today". It now resolves either authority and clamps to the grant's own tier: a write workspace does not widen a read grant, and a project that is neither remains a denial rather than a fallback onto the workspace.

**The daemon needed one change.** An additional-repository entry now carries its provider (absent means github, so an older control plane's list still decodes), and a named GitLab project is asked for with its numeric id. Without it the ask travelled as a display path only, the control plane answered with the workspace grant, and the daemon's own echo check correctly rejected it — no usable credential and a misleading error. Secondary workspace roots stay GitHub-only and now skip GitLab entries rather than cloning them from github.com, which is what the existing `owner/repo` layout would have done.

## Console

The additional-repository picker chooses the code host first, then a repository or a project. The GitLab arm lists the connection's Maintainer-or-Owner projects merged with the ones already added, runs the §10.2 provisioning saga inline when a project is not set up yet, and offers the same two tiers in GitLab's vocabulary — project, merge request, pipeline. A project the agent already holds is named as taken rather than offered again, and grant rows carry their host's mark wherever they are listed. The trigger wizard states the §8.3 refusal where the pick is and names the two ways to satisfy it, instead of letting the create reach the identical message from the server.

## Tests

Control plane integration: the authorize arm (create, list, upgrade, revoke, and its refusals), the inline account/membership ensure and its role mapping, the rollback of an account a refused authorization speculatively created, a grant resolving a read credential for an additional-authorized project rather than the workspace one, the hook 409 and its success after authorization, workspace-project acceptance, and grandfathering of existing hooks through non-binding edits. Web: the merged picker, its GitLab vocabulary, inline provisioning, taken-project handling, and the surfaced refusal. Daemon: the numeric project id on a named GitLab ask, and the local denial of a project the spec does not authorize.

Four GitLab hook tests encoded "the trigger is the sole authority", a premise §8.3 abolishes; they now state the new truth, and the full-undo rollback case moved to the authorize route, where the write really is what makes the agent a consumer. Several fixtures set `workspaceRepoId` while leaving the mode `scratch` — a state production never produces — and are now consistent.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean. Control plane 2010 unit + 1728 integration, web 1940, protocol 441, and the daemon's credential, workspace, and schema suites all pass. Remaining daemon failures in this environment are pre-existing and unrelated (sandbox-exec denied, real-runtime quota); they reproduce with these changes stashed.

## Not in this change

An authorized additional GitLab project receives credentials but is not materialized as a secondary workspace root: that layout is `owner/repo` on github.com, which a namespaced GitLab path cannot express. Section 13.1 records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
