### PR TITLE
fix(control-plane): stop a lost GitLab convergence fence becoming a degraded binding

### DIFF
--- a/packages/control-plane/prisma/migrations/20260912000000_gitlab_binding_converge_owed/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260912000000_gitlab_binding_converge_owed/migration.sql
@@ -1,0 +1,8 @@
+-- A GitLab convergence that loses a lease fence writes nothing: the binding
+-- keeps the state it had, because a race is not a verdict about it. Something
+-- must still come back for it, and an in-process timer does not survive a
+-- restart — so the obligation is recorded here, neutrally, and a sweep
+-- rediscovers it (gitlab-com-integration.md §10.2).
+ALTER TABLE "gitlab_project_binding" ADD COLUMN "convergeOwedAt" TIMESTAMPTZ(6);
+
+CREATE INDEX "gitlab_project_binding_convergeOwedAt_idx" ON "gitlab_project_binding"("convergeOwedAt");

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2748,6 +2748,10 @@ model GitlabProjectBinding {
   webhookId              BigInt? // the one AgentConnect-managed project webhook (§10.3)
   desiredEventsHash      String? // hash of the enabled-hook event union the webhook was last converged to
   credentialEpoch        BigInt    @default(1) // purge fence: bumped on rotation/revocation/disconnect
+  // A convergence that lost a fence wrote nothing, so this is the only record
+  // that one is still owed. Neutral, not a degraded state: the binding keeps
+  // whatever it was, and a sweep re-drives it — including after a restart.
+  convergeOwedAt         DateTime? @db.Timestamptz(6)
   state                  String
   stateReason            String? // bounded normalized repair category for degraded states
   createdAt              DateTime  @default(now()) @db.Timestamptz(6)
@@ -2760,6 +2764,7 @@ model GitlabProjectBinding {
 
   @@unique([orgId, projectId])
   @@index([orgId])
+  @@index([convergeOwedAt])
   @@map("gitlab_project_binding")
 }
 

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -30,6 +30,7 @@ import { GitlabProvisioner } from './gitlab/provisioner.js'
 import { GitlabGitcredService } from './gitlab/gitcred.service.js'
 import { GitlabCredentialRotator } from './gitlab/rotator.js'
 import { GitlabRetirementSweeper } from './gitlab/retirement-sweeper.js'
+import { GitlabConvergeSweeper } from './gitlab/converge-sweeper.js'
 import { GitlabMembershipAuthzService } from './gitlab/membership-authz.service.js'
 import { GitlabHookRerunService } from './gitlab/hook-rerun.service.js'
 import { CodeHostReviewBrokerService } from './codehost/review-lease.service.js'
@@ -1092,6 +1093,16 @@ export function buildContainer(
       })
     : undefined
 
+  // §10.2 convergence sweep: re-drives what a contended pass still owes, the
+  // half of that obligation which survives a restart. Armed by startBackground().
+  const gitlabConvergeSweeper = gitlab
+    ? new GitlabConvergeSweeper({
+        provisioner: gitlab.provisioner,
+        clock,
+        log: { warn: (obj, msg) => http.log.warn(obj, msg) }
+      })
+    : undefined
+
   // The GitLab arm of rc/codehost-membership-authz (§12.2): live effective
   // membership through the binding's read PAT. Absent configuration fails closed.
   const gitlabMembershipAuthz = gitlab
@@ -2126,6 +2137,7 @@ export function buildContainer(
       hookRedeliveryReconciler?.start()
       gitlabRotator?.start()
       gitlabRetirementSweeper?.start()
+      gitlabConvergeSweeper?.start()
       for (const reaper of pendingInstallReapers) reaper.start()
       relaySweeper.start()
       dutyRecompute.start()
@@ -2144,6 +2156,7 @@ export function buildContainer(
       hookRedeliveryReconciler?.stop()
       gitlabRotator?.stop()
       gitlabRetirementSweeper?.stop()
+      gitlabConvergeSweeper?.stop()
       installationDoorbell?.stop()
       for (const reaper of pendingInstallReapers) reaper.stop()
       relaySweeper.stop()

--- a/packages/control-plane/src/gitlab/converge-sweeper.ts
+++ b/packages/control-plane/src/gitlab/converge-sweeper.ts
@@ -1,0 +1,53 @@
+/**
+ * Background convergence sweep (gitlab-com-integration.md §10.2): re-drives the
+ * bindings a contended pass still owes work.
+ *
+ * A convergence that loses a lease fence writes no state — a race is not a
+ * verdict about the binding — so there is no degraded row to rediscover it by,
+ * and the in-process follow-up it arms does not survive a restart. The neutral
+ * obligation on the binding is what does, and this is what reads it. Built in
+ * the graph, armed only by `startBackground()` — never in tests, which drive
+ * `sweepOwedConvergences` directly.
+ */
+import type { Clock, TimerHandle } from '../domain/clock.js'
+import type { GitlabProvisioner } from './provisioner.js'
+
+/** Leave an obligation alone this long, so the sweep never races the follow-up
+ *  the same process already armed for it. */
+export const CONVERGE_OWED_QUIET_MS = 2 * 60 * 1000
+const FIRST_SWEEP_DELAY_MS = 90 * 1000
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000
+
+export class GitlabConvergeSweeper {
+  private timer: TimerHandle | null = null
+  private stopped = false
+
+  constructor(
+    private readonly deps: {
+      provisioner: GitlabProvisioner
+      clock: Clock
+      log?: { warn(obj: object, msg: string): void }
+    }
+  ) {}
+
+  start(): void {
+    this.stopped = false
+    this.arm(FIRST_SWEEP_DELAY_MS)
+  }
+
+  stop(): void {
+    this.stopped = true
+    if (this.timer !== null) this.deps.clock.clearTimeout(this.timer)
+    this.timer = null
+  }
+
+  private arm(delayMs: number): void {
+    if (this.stopped) return
+    this.timer = this.deps.clock.setTimeout(() => {
+      void this.deps.provisioner
+        .sweepOwedConvergences(CONVERGE_OWED_QUIET_MS)
+        .catch((err) => this.deps.log?.warn({ err }, 'gitlab convergence sweep failed'))
+        .finally(() => this.arm(SWEEP_INTERVAL_MS))
+    }, delayMs)
+  }
+}

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -75,6 +75,25 @@ export type ProvisionOutcome =
  *  (`service_account_quota`, …); nothing was committed when it is present. */
 export type AgentAccountOutcome<T> = { ok: true; result: T } | { ok: false; reason: string; retryable: boolean }
 
+/** How a joined convergence run is shared, and whether it owes a trailing pass. */
+interface ConvergeRun {
+  done: Promise<void>
+  again: boolean
+}
+
+export interface ConvergeProjectOpts {
+  /** Contention retries before giving up on this pass; a request-inline caller
+   *  passes a small number rather than blocking for the background bound. */
+  attempts?: number
+  /** False ⇒ this IS the follow-up; it does not schedule another. */
+  followUp?: boolean
+}
+
+/** Background convergence outwaits a full 10-minute peer lease plus slack. */
+const BACKGROUND_CONVERGE_ATTEMPTS = 92
+/** A contended pass re-drives itself after this, so nothing needs a second Repair. */
+const FOLLOW_UP_DELAY_MS = 30 * 1000
+
 /** Inline in a request: retry a contended attempt on a short bound, then report. */
 const AGENT_ACCOUNT_ATTEMPTS = 5
 
@@ -108,6 +127,10 @@ export interface GitlabProvisionerDeps {
 }
 
 export class GitlabProvisioner {
+  /** One convergence per project at a time, keyed `<org>:<project>`; late
+   *  callers join it and ask for a trailing pass instead of racing its leases. */
+  private readonly convergeRuns = new Map<string, ConvergeRun>()
+
   constructor(private readonly deps: GitlabProvisionerDeps) {}
 
   /** Converge one binding to ready; persists the outcome state on the binding. */
@@ -159,18 +182,53 @@ export class GitlabProvisioner {
    * attempts, which outlasts a full 10-minute lease plus slack while
    * back-to-back writes converge in seconds.
    */
-  async convergeProject(orgId: string, projectId: bigint): Promise<void> {
+  async convergeProject(orgId: string, projectId: bigint, opts: ConvergeProjectOpts = {}): Promise<void> {
+    const key = `${orgId}:${projectId}`
+    const running = this.convergeRuns.get(key)
+    if (running) {
+      // Someone is already converging this project. Join them rather than race
+      // for the same leases — but ask for one more pass, because their reads may
+      // predate whatever this caller just wrote.
+      running.again = true
+      await running.done
+      return
+    }
+    const entry: ConvergeRun = { again: false, done: Promise.resolve() }
+    this.convergeRuns.set(key, entry)
+    entry.done = (async () => {
+      try {
+        do {
+          entry.again = false
+          await this.convergeProjectOnce(orgId, projectId, opts)
+        } while (entry.again)
+      } finally {
+        this.convergeRuns.delete(key)
+      }
+    })()
+    await entry.done
+  }
+
+  private async convergeProjectOnce(orgId: string, projectId: bigint, opts: ConvergeProjectOpts): Promise<void> {
     const binding = await this.deps.bindings.byProject(orgId, projectId)
     if (!binding) return
+    const attempts = opts.attempts ?? BACKGROUND_CONVERGE_ATTEMPTS
     let outcome = await this.provision(orgId, binding.id)
-    for (let attempt = 0; contended(outcome) && attempt < 92; attempt++) {
+    for (let attempt = 0; contended(outcome) && attempt < attempts; attempt++) {
       const delayMs = Math.min(8_000, 1_000 * 2 ** attempt)
       await new Promise<void>((resolve) => this.deps.clock.setTimeout(() => resolve(), delayMs))
       outcome = await this.provision(orgId, binding.id)
     }
-    if (contended(outcome)) {
-      this.deps.log?.warn({ projectId: projectId.toString() }, 'gitlab converge still contended — gave up')
-    }
+    if (!contended(outcome)) return
+    // Still contended: the binding keeps its previous state, so nothing settles
+    // as degraded on account of a race. A follow-up re-drives it so it heals
+    // without anyone pressing Repair again.
+    this.deps.log?.warn({ projectId: projectId.toString() }, 'gitlab converge still contended — retrying later')
+    if (opts.followUp === false) return
+    this.deps.clock.setTimeout(() => {
+      void this.convergeProject(orgId, projectId, { followUp: false }).catch((err) =>
+        this.deps.log?.warn({ err, projectId: projectId.toString() }, 'gitlab converge follow-up failed')
+      )
+    }, FOLLOW_UP_DELAY_MS)
   }
 
   /**
@@ -407,7 +465,10 @@ export class GitlabProvisioner {
       const outcome = await this.converge(orgId, binding, token, owner)
       if (outcome.state === 'ready') {
         await this.deps.bindings.update(orgId, binding.id, { state: 'ready', stateReason: null })
-      } else if (outcome.state !== 'busy') {
+      } else if (outcome.state !== 'busy' && !contended(outcome)) {
+        // A contended outcome is a lost fence, not a verdict on this binding:
+        // persisting it would turn "someone else is converging right now" into a
+        // sticky degraded state that only a racing repair could ever clear.
         await this.deps.bindings.update(orgId, binding.id, { state: outcome.state, stateReason: outcome.reason })
       }
       this.deps.onConverged?.(orgId, binding.projectId)

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -568,7 +568,10 @@ export class GitlabProvisioner {
     state: 'admin_degraded' | 'runtime_degraded',
     reason: string
   ): Promise<ProvisionOutcome> {
-    await this.deps.bindings.update(orgId, bindingId, { state, stateReason: reason })
+    // A degrade is a settled verdict asking for human repair, so nothing is owed
+    // automatically any more: leaving the marker would have every sweep repeat
+    // an outcome that has already settled, and report `converging` forever.
+    await this.deps.bindings.update(orgId, bindingId, { state, stateReason: reason, convergeOwedAt: null })
     return { state, reason }
   }
 
@@ -759,6 +762,9 @@ export class GitlabProvisioner {
       return { removed: false, reason: 'provisioning_in_progress' }
     }
     await this.deps.bindings.bumpCredentialEpoch(orgId, bindingId)
+    // Cleanup owns the claim from here, so provisioning can never acquire it:
+    // any convergence obligation on this binding is void (§19.4).
+    await this.deps.bindings.update(orgId, bindingId, { convergeOwedAt: null })
     // The binding just left the servable states — pull the project's compiled
     // rules off the relay pool now, not when cleanup eventually completes.
     this.deps.onConverged?.(orgId, binding.projectId)

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -94,8 +94,10 @@ const BACKGROUND_CONVERGE_ATTEMPTS = 92
 /** A contended pass re-drives itself after this, so nothing needs a second Repair. */
 const FOLLOW_UP_DELAY_MS = 30 * 1000
 
-/** Inline in a request: retry a contended attempt on a short bound, then report. */
-const AGENT_ACCOUNT_ATTEMPTS = 5
+/** Inline in a request: keep retrying a contended attempt for this long — long
+ *  enough to outlast a peer route write or to join a convergence already
+ *  running, short enough to answer the request — then report it as transient. */
+const AGENT_ACCOUNT_BUDGET_MS = 15_000
 
 /** §9.4 takeover result; every refusal leaves the binding exactly as it was.
  *  The binding row carries the convergence outcome, so the caller re-reads it. */
@@ -163,7 +165,7 @@ export class GitlabProvisioner {
     ) {
       // Held by a live peer, or the claim is gone/detached/in-cleanup: no
       // provider writes, and no state overwrite of whatever is in progress.
-      if (followUp) this.scheduleFollowUp(orgId, binding.projectId)
+      if (followUp) await this.scheduleFollowUp(orgId, bindingId, binding.projectId)
       return { state: 'busy', reason: 'provisioning_or_cleanup_in_progress' }
     }
     try {
@@ -196,14 +198,28 @@ export class GitlabProvisioner {
     return [...this.convergeRuns.keys()].some(mine) || [...this.pendingFollowUps].some(mine)
   }
 
-  /** Arm one follow-up for a contended pass; a project already owing one keeps it. */
-  private scheduleFollowUp(orgId: string, projectId: bigint): void {
+  /** Arm one follow-up for a contended pass; a project already owing one keeps it.
+   *  The obligation is ALSO written to the binding, because this timer does not
+   *  survive a restart and the contended pass wrote no state to rediscover. */
+  private async scheduleFollowUp(orgId: string, bindingId: string, projectId: bigint): Promise<void> {
+    // AWAITED: an obligation nobody waited for is not durable, and this write is
+    // the whole reason a restart can still find the work.
+    await this.deps.bindings
+      .update(orgId, bindingId, { convergeOwedAt: new Date(this.deps.clock.now()) })
+      .catch((err) => this.deps.log?.warn({ err, bindingId }, 'gitlab converge obligation not recorded'))
     const key = `${orgId}:${projectId}`
     if (this.pendingFollowUps.has(key)) return
     this.pendingFollowUps.add(key)
     this.deps.clock.setTimeout(() => {
       this.pendingFollowUps.delete(key)
-      void this.convergeProject(orgId, projectId, { followUp: false }).catch((err) =>
+      void (async () => {
+        // Re-read the obligation: anything that converged in the meantime — a
+        // later write, the sweep, another follow-up — has already discharged it,
+        // and re-running would only take the lease from whoever needs it next.
+        const owed = await this.deps.bindings.byProject(orgId, projectId)
+        if (!owed || owed.convergeOwedAt === null) return
+        await this.convergeProject(orgId, projectId, { followUp: false })
+      })().catch((err) =>
         this.deps.log?.warn({ err, projectId: projectId.toString() }, 'gitlab converge follow-up failed')
       )
     }, FOLLOW_UP_DELAY_MS)
@@ -235,6 +251,19 @@ export class GitlabProvisioner {
     await entry.done
   }
 
+  /**
+   * §10.2 convergence sweep: re-drive the bindings a contended pass still owes.
+   * The in-process follow-up handles the common case; this is what survives a
+   * restart, because a contended pass deliberately writes no state a degraded
+   * binding could be rediscovered by — only this neutral marker.
+   */
+  async sweepOwedConvergences(quietMs: number, limit = 50): Promise<void> {
+    const before = new Date(this.deps.clock.now() - quietMs)
+    for (const binding of await this.deps.bindings.listConvergeOwed(before, limit)) {
+      await this.convergeProject(binding.orgId, binding.projectId, { followUp: false })
+    }
+  }
+
   private async convergeProjectOnce(orgId: string, projectId: bigint, opts: ConvergeProjectOpts): Promise<void> {
     const binding = await this.deps.bindings.byProject(orgId, projectId)
     if (!binding) return
@@ -251,7 +280,7 @@ export class GitlabProvisioner {
     // as degraded on account of a race. A follow-up re-drives it so it heals
     // without anyone pressing Repair again.
     this.deps.log?.warn({ projectId: projectId.toString() }, 'gitlab converge still contended — retrying later')
-    if (opts.followUp !== false) this.scheduleFollowUp(orgId, projectId)
+    if (opts.followUp !== false) await this.scheduleFollowUp(orgId, binding.id, projectId)
   }
 
   /**
@@ -277,10 +306,18 @@ export class GitlabProvisioner {
     consumer: GitlabAccountConsumer,
     commit: (live: { projectPath: string }) => Promise<T>
   ): Promise<AgentAccountOutcome<T>> {
+    const deadline = this.deps.clock.now() + AGENT_ACCOUNT_BUDGET_MS
     let outcome = await this.agentAccountAttempt(orgId, projectId, consumer, commit)
-    for (let attempt = 0; !outcome.ok && outcome.retryable && attempt < AGENT_ACCOUNT_ATTEMPTS; attempt++) {
-      const delayMs = Math.min(1_000, 200 * 2 ** attempt)
-      await new Promise<void>((resolve) => this.deps.clock.setTimeout(() => resolve(), delayMs))
+    for (let attempt = 0; !outcome.ok && outcome.retryable && this.deps.clock.now() < deadline; attempt++) {
+      // A background convergence of this project can hold the binding lease for
+      // minutes, and out-waiting it attempt by attempt would spend this budget
+      // losing the same race. JOIN it instead: when it finishes, the account it
+      // was provisioning is usually the very one this write needs.
+      const running = this.convergeRuns.get(`${orgId}:${projectId}`)
+      const backoff = new Promise<void>((resolve) =>
+        this.deps.clock.setTimeout(() => resolve(), Math.min(1_000, 200 * 2 ** attempt))
+      )
+      await (running ? Promise.race([running.done, backoff]) : backoff)
       outcome = await this.agentAccountAttempt(orgId, projectId, consumer, commit)
     }
     return outcome
@@ -487,17 +524,24 @@ export class GitlabProvisioner {
   ): Promise<ProvisionOutcome> {
     try {
       const outcome = await this.converge(orgId, binding, token, owner)
+      // Settled either way ⇒ nothing is owed any more; only a contended pass
+      // leaves the marker standing for the sweep.
+      const settled = !contended(outcome) && binding.convergeOwedAt !== null ? { convergeOwedAt: null } : {}
       if (outcome.state === 'ready') {
-        await this.deps.bindings.update(orgId, binding.id, { state: 'ready', stateReason: null })
+        await this.deps.bindings.update(orgId, binding.id, { state: 'ready', stateReason: null, ...settled })
       } else if (outcome.state !== 'busy' && !contended(outcome)) {
         // A contended outcome is a lost fence, not a verdict on this binding:
         // persisting it would turn "someone else is converging right now" into a
         // sticky degraded state that only a racing repair could ever clear.
-        await this.deps.bindings.update(orgId, binding.id, { state: outcome.state, stateReason: outcome.reason })
+        await this.deps.bindings.update(orgId, binding.id, {
+          state: outcome.state,
+          stateReason: outcome.reason,
+          ...settled
+        })
       }
       // Nothing was written for a contended pass, so something must come back
       // for it: a create, a takeover, or a single repair has no loop of its own.
-      if (contended(outcome) && followUp) this.scheduleFollowUp(orgId, binding.projectId)
+      if (contended(outcome) && followUp) await this.scheduleFollowUp(orgId, binding.id, binding.projectId)
       this.deps.onConverged?.(orgId, binding.projectId)
       return outcome
     } catch (e) {

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -762,9 +762,6 @@ export class GitlabProvisioner {
       return { removed: false, reason: 'provisioning_in_progress' }
     }
     await this.deps.bindings.bumpCredentialEpoch(orgId, bindingId)
-    // Cleanup owns the claim from here, so provisioning can never acquire it:
-    // any convergence obligation on this binding is void (§19.4).
-    await this.deps.bindings.update(orgId, bindingId, { convergeOwedAt: null })
     // The binding just left the servable states — pull the project's compiled
     // rules off the relay pool now, not when cleanup eventually completes.
     this.deps.onConverged?.(orgId, binding.projectId)

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -130,11 +130,18 @@ export class GitlabProvisioner {
   /** One convergence per project at a time, keyed `<org>:<project>`; late
    *  callers join it and ask for a trailing pass instead of racing its leases. */
   private readonly convergeRuns = new Map<string, ConvergeRun>()
+  /** Projects whose contended pass has a follow-up armed. Together with the runs
+   *  above this is "work this process still owes", which the console asks for so
+   *  it keeps watching until the binding really has settled. */
+  private readonly pendingFollowUps = new Set<string>()
 
   constructor(private readonly deps: GitlabProvisionerDeps) {}
 
   /** Converge one binding to ready; persists the outcome state on the binding. */
-  async provision(orgId: string, bindingId: string): Promise<ProvisionOutcome> {
+  async provision(orgId: string, bindingId: string, opts: { followUp?: boolean } = {}): Promise<ProvisionOutcome> {
+    // A caller with its own retry loop owns coming back; every other one — a
+    // create, a takeover, a single repair — leaves a contended pass owing it.
+    const followUp = opts.followUp !== false
     const binding = await this.deps.bindings.get(orgId, bindingId)
     if (!binding) return { state: 'admin_degraded', reason: 'binding_missing' }
     if (!binding.installerConnectionId) {
@@ -156,11 +163,12 @@ export class GitlabProvisioner {
     ) {
       // Held by a live peer, or the claim is gone/detached/in-cleanup: no
       // provider writes, and no state overwrite of whatever is in progress.
+      if (followUp) this.scheduleFollowUp(orgId, binding.projectId)
       return { state: 'busy', reason: 'provisioning_or_cleanup_in_progress' }
     }
     try {
       const token = await this.deps.oauth.withAccessToken(orgId, binding.installerConnectionId)
-      return await this.convergeAndPersist(orgId, binding, token, owner)
+      return await this.convergeAndPersist(orgId, binding, token, owner, followUp)
     } catch (e) {
       // Only the administration-token acquisition reaches here; convergence maps its own failures.
       return this.failed(orgId, bindingId, e)
@@ -182,6 +190,25 @@ export class GitlabProvisioner {
    * attempts, which outlasts a full 10-minute lease plus slack while
    * back-to-back writes converge in seconds.
    */
+  /** Does this process still owe convergence work in the organization? */
+  hasPendingWork(orgId: string): boolean {
+    const mine = (key: string): boolean => key.startsWith(`${orgId}:`)
+    return [...this.convergeRuns.keys()].some(mine) || [...this.pendingFollowUps].some(mine)
+  }
+
+  /** Arm one follow-up for a contended pass; a project already owing one keeps it. */
+  private scheduleFollowUp(orgId: string, projectId: bigint): void {
+    const key = `${orgId}:${projectId}`
+    if (this.pendingFollowUps.has(key)) return
+    this.pendingFollowUps.add(key)
+    this.deps.clock.setTimeout(() => {
+      this.pendingFollowUps.delete(key)
+      void this.convergeProject(orgId, projectId, { followUp: false }).catch((err) =>
+        this.deps.log?.warn({ err, projectId: projectId.toString() }, 'gitlab converge follow-up failed')
+      )
+    }, FOLLOW_UP_DELAY_MS)
+  }
+
   async convergeProject(orgId: string, projectId: bigint, opts: ConvergeProjectOpts = {}): Promise<void> {
     const key = `${orgId}:${projectId}`
     const running = this.convergeRuns.get(key)
@@ -212,23 +239,19 @@ export class GitlabProvisioner {
     const binding = await this.deps.bindings.byProject(orgId, projectId)
     if (!binding) return
     const attempts = opts.attempts ?? BACKGROUND_CONVERGE_ATTEMPTS
-    let outcome = await this.provision(orgId, binding.id)
+    // This loop owns the retrying, so no attempt arms a follow-up of its own.
+    let outcome = await this.provision(orgId, binding.id, { followUp: false })
     for (let attempt = 0; contended(outcome) && attempt < attempts; attempt++) {
       const delayMs = Math.min(8_000, 1_000 * 2 ** attempt)
       await new Promise<void>((resolve) => this.deps.clock.setTimeout(() => resolve(), delayMs))
-      outcome = await this.provision(orgId, binding.id)
+      outcome = await this.provision(orgId, binding.id, { followUp: false })
     }
     if (!contended(outcome)) return
     // Still contended: the binding keeps its previous state, so nothing settles
     // as degraded on account of a race. A follow-up re-drives it so it heals
     // without anyone pressing Repair again.
     this.deps.log?.warn({ projectId: projectId.toString() }, 'gitlab converge still contended — retrying later')
-    if (opts.followUp === false) return
-    this.deps.clock.setTimeout(() => {
-      void this.convergeProject(orgId, projectId, { followUp: false }).catch((err) =>
-        this.deps.log?.warn({ err, projectId: projectId.toString() }, 'gitlab converge follow-up failed')
-      )
-    }, FOLLOW_UP_DELAY_MS)
+    if (opts.followUp !== false) this.scheduleFollowUp(orgId, projectId)
   }
 
   /**
@@ -459,7 +482,8 @@ export class GitlabProvisioner {
     orgId: string,
     binding: GitlabProjectBindingRecord,
     token: string,
-    owner: string
+    owner: string,
+    followUp = true
   ): Promise<ProvisionOutcome> {
     try {
       const outcome = await this.converge(orgId, binding, token, owner)
@@ -471,6 +495,9 @@ export class GitlabProvisioner {
         // sticky degraded state that only a racing repair could ever clear.
         await this.deps.bindings.update(orgId, binding.id, { state: outcome.state, stateReason: outcome.reason })
       }
+      // Nothing was written for a contended pass, so something must come back
+      // for it: a create, a takeover, or a single repair has no loop of its own.
+      if (contended(outcome) && followUp) this.scheduleFollowUp(orgId, binding.projectId)
       this.deps.onConverged?.(orgId, binding.projectId)
       return outcome
     } catch (e) {

--- a/packages/control-plane/src/gitlab/provisioner.ts
+++ b/packages/control-plane/src/gitlab/provisioner.ts
@@ -205,7 +205,7 @@ export class GitlabProvisioner {
     // AWAITED: an obligation nobody waited for is not durable, and this write is
     // the whole reason a restart can still find the work.
     await this.deps.bindings
-      .update(orgId, bindingId, { convergeOwedAt: new Date(this.deps.clock.now()) })
+      .markConvergeOwed(orgId, bindingId, new Date(this.deps.clock.now()))
       .catch((err) => this.deps.log?.warn({ err, bindingId }, 'gitlab converge obligation not recorded'))
     const key = `${orgId}:${projectId}`
     if (this.pendingFollowUps.has(key)) return

--- a/packages/control-plane/src/hooks/hook.service.test.ts
+++ b/packages/control-plane/src/hooks/hook.service.test.ts
@@ -105,6 +105,7 @@ function binding(over: Partial<GitlabProjectBindingRecord> = {}): GitlabProjectB
     webhookId: 12n,
     desiredEventsHash: null,
     credentialEpoch: 1n,
+    convergeOwedAt: null,
     state: 'ready',
     stateReason: null,
     createdAt: new Date(),

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -357,7 +357,10 @@ export function gitlabRoutes(deps: HttpDeps) {
           // Database state alone can read settled while a contended pass still
           // owes a follow-up, and the console would stop watching one refresh
           // before the binding actually heals — so ask what is still in flight.
+          // The durable half first: an obligation recorded on a binding outlives
+          // the process that armed the follow-up, so a restart still reports work.
           converging:
+            bindings.some((binding) => binding.convergeOwedAt !== null) ||
             gitlab.provisioner.hasPendingWork(orgId) ||
             stillConverging(accounts, bindings, consumers, memberLevels, await webhookWanted(orgId))
         }

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -354,7 +354,12 @@ export function gitlabRoutes(deps: HttpDeps) {
               const bindingIds = byAccount.get(account.id) ?? []
               return { ...accountToDto(account, bindingIds, projectPaths), agentId: account.agentId, bindingIds }
             }),
-          converging: stillConverging(accounts, bindings, consumers, memberLevels, await webhookWanted(orgId))
+          // Database state alone can read settled while a contended pass still
+          // owes a follow-up, and the console would stop watching one refresh
+          // before the binding actually heals — so ask what is still in flight.
+          converging:
+            gitlab.provisioner.hasPendingWork(orgId) ||
+            stillConverging(accounts, bindings, consumers, memberLevels, await webhookWanted(orgId))
         }
       }
     )

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -31,6 +31,9 @@ import {
   membershipSatisfies
 } from '../../gitlab/api.js'
 import { GitlabProjectClaimConflict } from '../../persistence/errors.js'
+/** A repair is an HTTP request: outwait a brief contention, then let the
+ *  scheduled follow-up finish the job rather than holding the connection. */
+const REPAIR_CONTENTION_ATTEMPTS = 6
 import { unionGitlabWebhookEvents } from '../../gitlab/webhook-events.js'
 import {
   CreateGitlabProjectBody,
@@ -479,10 +482,15 @@ export function gitlabRoutes(deps: HttpDeps) {
       async (req, reply) => {
         if (denyViewerWrite(req, reply)) return
         const orgId = orgOf(req)
-        if (!(await deps.repos.gitlabProjectBinding.get(orgId, req.params.id))) {
+        const target = await deps.repos.gitlabProjectBinding.get(orgId, req.params.id)
+        if (!target) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab project not found' })
         }
-        await gitlab.provisioner.provision(orgId, req.params.id)
+        // Repairing a bot re-runs this per project it holds, so several requests
+        // arrive at once. Converge through the project-keyed path: concurrent
+        // repairs JOIN one run instead of racing it for the same leases, and a
+        // request waits only a request-sized bound before the follow-up takes over.
+        await gitlab.provisioner.convergeProject(orgId, target.projectId, { attempts: REPAIR_CONTENTION_ATTEMPTS })
         const binding = await deps.repos.gitlabProjectBinding.get(orgId, req.params.id)
         if (!binding) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'gitlab project not found' })

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3327,6 +3327,8 @@ export interface GitlabProjectBindingRecord {
   webhookId: bigint | null
   desiredEventsHash: string | null
   credentialEpoch: bigint
+  /** Set when a convergence lost a fence and wrote nothing; a sweep re-drives it. */
+  convergeOwedAt: Date | null
   state: GitlabBindingState
   stateReason: string | null
   createdAt: Date
@@ -3360,10 +3362,13 @@ export interface GitlabProjectBindingRepo {
       installerConnectionId: string | null
       webhookId: bigint | null
       desiredEventsHash: string | null
+      convergeOwedAt: Date | null
       state: GitlabBindingState
       stateReason: string | null
     }>
   ): Promise<GitlabProjectBindingRecord | null>
+  /** Bindings a contended convergence still owes work, oldest first (§10.2). */
+  listConvergeOwed(before: Date, limit: number): Promise<GitlabProjectBindingRecord[]>
   /** Purge fence: every rotation/revocation/disconnect bumps it (§7.4/§19.4). */
   bumpCredentialEpoch(orgId: string, bindingId: string): Promise<bigint | null>
   /** §10.2 EXCLUSIVE run-owned provisioning lease, CAS-acquired before the

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3367,6 +3367,10 @@ export interface GitlabProjectBindingRepo {
       stateReason: string | null
     }>
   ): Promise<GitlabProjectBindingRecord | null>
+  /** Record that a contended pass still owes convergence — but ONLY while the
+   *  claim is still provisionable. A repair that loses to cleanup must not arm
+   *  an obligation nothing can satisfy; one statement, so either order is safe. */
+  markConvergeOwed(orgId: string, bindingId: string, at: Date): Promise<void>
   /** Bindings a contended convergence still owes work, oldest first (§10.2). */
   listConvergeOwed(before: Date, limit: number): Promise<GitlabProjectBindingRecord[]>
   /** Purge fence: every rotation/revocation/disconnect bumps it (§7.4/§19.4). */

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -513,7 +513,10 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
   async listConvergeOwed(before: Date, limit: number): Promise<GitlabProjectBindingRecord[]> {
     const rows = await this.prisma.gitlabProjectBinding.findMany({
       orderBy: { convergeOwedAt: 'asc' },
-      where: { convergeOwedAt: { not: null, lt: before } },
+      // A binding in cleanup can never acquire its claim again, so its
+      // obligation is void — selecting it would burn the sweep's budget and
+      // hold it "converging" forever.
+      where: { convergeOwedAt: { not: null, lt: before }, state: { not: 'cleanup_pending' } },
       take: limit
     })
     return rows.map(toBindingRecord)

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -525,18 +525,21 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
   }
 
   async markConvergeOwed(orgId: string, bindingId: string, at: Date): Promise<void> {
-    // One statement: the EXISTS is evaluated with the write, so a cleanup that
-    // commits first simply leaves nothing to mark, and one that commits after
-    // clears the marker in its own transaction.
-    await this.prisma.$executeRaw`
-      UPDATE "gitlab_project_binding" AS b
-         SET "convergeOwedAt" = ${at}
-       WHERE b."id" = ${bindingId}::uuid AND b."orgId" = ${orgId}
-         AND EXISTS (
-           SELECT 1 FROM "code_host_repository_claim" AS c
-            WHERE c."provider" = 'gitlab' AND c."externalId" = b."projectId"
-              AND c."bindingRef" = b."id" AND c."state" IN ('provisioning', 'active')
-         )`
+    // Lock the CLAIM first, the same order cleanup takes, then decide. A single
+    // statement would not do: under read-committed its subquery is evaluated on
+    // the statement snapshot, so a cleanup committing while this waits on the
+    // binding row would not be seen, and the marker would land unsatisfiable.
+    await this.prisma.$transaction(async (tx) => {
+      const claim = await tx.$queryRaw<{ state: string }[]>`
+        SELECT c."state" FROM "code_host_repository_claim" AS c
+          JOIN "gitlab_project_binding" AS b
+            ON c."externalId" = b."projectId" AND c."bindingRef" = b."id"
+         WHERE c."provider" = 'gitlab' AND b."id" = ${bindingId}::uuid AND b."orgId" = ${orgId}
+           FOR UPDATE OF c`
+      const state = claim[0]?.state
+      if (state !== 'provisioning' && state !== 'active') return
+      await tx.gitlabProjectBinding.updateMany({ where: { id: bindingId, orgId }, data: { convergeOwedAt: at } })
+    })
   }
 
   async listConvergeOwed(before: Date, limit: number): Promise<GitlabProjectBindingRecord[]> {

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -481,18 +481,32 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
     const attached = await this.prisma.codeHostRepositoryClaim.count({
       where: { provider: 'gitlab', externalId: projectId, orgId, bindingRef: bindingId }
     })
-    if (attached === 0) return true
-    const res = await this.prisma.codeHostRepositoryClaim.updateMany({
-      where: {
-        provider: 'gitlab',
-        externalId: projectId,
-        orgId,
-        bindingRef: bindingId,
-        OR: [{ opOwner: null }, { opLeaseUntil: { lt: now } }]
-      },
-      data: { state: 'cleanup_pending', opOwner: null, opLeaseUntil: null }
+    if (attached === 0) {
+      await this.prisma.gitlabProjectBinding.updateMany({
+        where: { id: bindingId, orgId },
+        data: { convergeOwedAt: null }
+      })
+      return true
+    }
+    // The claim flip and the convergence discharge are ONE transaction: past
+    // this point provisioning can never acquire the claim, so an obligation
+    // surviving the flip is one nothing could ever satisfy — and it would hold
+    // the console at "converging" forever.
+    return this.prisma.$transaction(async (tx) => {
+      const res = await tx.codeHostRepositoryClaim.updateMany({
+        where: {
+          provider: 'gitlab',
+          externalId: projectId,
+          orgId,
+          bindingRef: bindingId,
+          OR: [{ opOwner: null }, { opLeaseUntil: { lt: now } }]
+        },
+        data: { state: 'cleanup_pending', opOwner: null, opLeaseUntil: null }
+      })
+      if (res.count !== 1) return false
+      await tx.gitlabProjectBinding.updateMany({ where: { id: bindingId, orgId }, data: { convergeOwedAt: null } })
+      return true
     })
-    return res.count === 1
   }
 
   async removeWithClaim(orgId: string, bindingId: string, projectId: bigint): Promise<boolean> {

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -301,6 +301,7 @@ function toBindingRecord(r: GitlabProjectBinding): GitlabProjectBindingRecord {
     webhookId: r.webhookId,
     desiredEventsHash: r.desiredEventsHash,
     credentialEpoch: r.credentialEpoch,
+    convergeOwedAt: r.convergeOwedAt,
     state: toBindingState(r.state),
     stateReason: r.stateReason,
     createdAt: r.createdAt
@@ -507,6 +508,15 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
       await tx.gitlabProjectBinding.deleteMany({ where: { id: bindingId, orgId } })
       return true
     })
+  }
+
+  async listConvergeOwed(before: Date, limit: number): Promise<GitlabProjectBindingRecord[]> {
+    const rows = await this.prisma.gitlabProjectBinding.findMany({
+      orderBy: { convergeOwedAt: 'asc' },
+      where: { convergeOwedAt: { not: null, lt: before } },
+      take: limit
+    })
+    return rows.map(toBindingRecord)
   }
 
   async bumpCredentialEpoch(orgId: string, bindingId: string): Promise<bigint | null> {

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -524,6 +524,21 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
     })
   }
 
+  async markConvergeOwed(orgId: string, bindingId: string, at: Date): Promise<void> {
+    // One statement: the EXISTS is evaluated with the write, so a cleanup that
+    // commits first simply leaves nothing to mark, and one that commits after
+    // clears the marker in its own transaction.
+    await this.prisma.$executeRaw`
+      UPDATE "gitlab_project_binding" AS b
+         SET "convergeOwedAt" = ${at}
+       WHERE b."id" = ${bindingId}::uuid AND b."orgId" = ${orgId}
+         AND EXISTS (
+           SELECT 1 FROM "code_host_repository_claim" AS c
+            WHERE c."provider" = 'gitlab' AND c."externalId" = b."projectId"
+              AND c."bindingRef" = b."id" AND c."state" IN ('provisioning', 'active')
+         )`
+  }
+
   async listConvergeOwed(before: Date, limit: number): Promise<GitlabProjectBindingRecord[]> {
     const rows = await this.prisma.gitlabProjectBinding.findMany({
       orderBy: { convergeOwedAt: 'asc' },

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -1037,6 +1037,42 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     expect(await h.bindings.get(DEFAULT_ORG_ID, h.binding.id)).toMatchObject({ state: 'ready', stateReason: null })
   }, 30_000)
 
+  it('a settled degrade discharges the obligation instead of sweeping forever', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect(await h.accounts.claimLease(account.id, 'peer', new Date(Date.now() + 300_000), new Date())).toBe(true)
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.convergeOwedAt).not.toBeNull()
+
+    // The administering connection goes away: the next pass is a verdict asking
+    // for human repair, not something a sweep should keep repeating.
+    await h.bindings.update(DEFAULT_ORG_ID, h.binding.id, { installerConnectionId: null })
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      state: 'admin_degraded',
+      reason: 'no_admin_connection'
+    })
+    const settled = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
+    expect(settled.convergeOwedAt).toBeNull()
+    expect(await h.bindings.listConvergeOwed(new Date(Date.now() + 1_000), 50)).toHaveLength(0)
+  })
+
+  it('a binding entering cleanup owes no more convergence', async () => {
+    const h = await harness({ failTokenRevoke: true })
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect(await h.accounts.claimLease(account.id, 'peer', new Date(Date.now() + 300_000), new Date())).toBe(true)
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.convergeOwedAt).not.toBeNull()
+    await h.accounts.releaseLease(account.id, 'peer')
+
+    // Removal takes the claim; convergence can never acquire it again, so the
+    // obligation is void whether or not the removal itself completes.
+    expect((await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).removed).toBe(false)
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('cleanup_pending')
+    expect(await h.bindings.listConvergeOwed(new Date(Date.now() + 1_000), 50)).toHaveLength(0)
+  })
+
   it('two concurrent provisions: exactly one runs, the other observes busy', async () => {
     const h = await harness()
     const [a, b] = await Promise.all([

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -131,7 +131,8 @@ async function harness(
     accountService,
     provisioner,
     binding,
-    connection
+    connection,
+    connections
   }
 }
 
@@ -897,6 +898,51 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     await h.accounts.releaseLease(account.id, 'peer')
     await h.provisioner.convergeProject(DEFAULT_ORG_ID, PROJECT, { attempts: 0, followUp: false })
     expect(await h.bindings.get(DEFAULT_ORG_ID, h.binding.id)).toMatchObject({ state: 'ready', stateReason: null })
+  })
+
+  it('a contended pass owes a follow-up, and the console keeps watching until it lands', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect(h.provisioner.hasPendingWork(DEFAULT_ORG_ID)).toBe(false)
+
+    // A peer holds the account lease, so a single pass — a create, a takeover,
+    // a repair — cannot converge and must leave the binding alone.
+    expect(await h.accounts.claimLease(account.id, 'peer', new Date(Date.now() + 300_000), new Date())).toBe(true)
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toMatchObject({ retryable: true })
+    expect(await h.bindings.get(DEFAULT_ORG_ID, h.binding.id)).toMatchObject({ state: 'ready', stateReason: null })
+
+    // The work is owed and visible: the console is told to keep watching rather
+    // than reading a settled database one refresh too early.
+    expect(h.provisioner.hasPendingWork(DEFAULT_ORG_ID)).toBe(true)
+    expect(h.provisioner.hasPendingWork('another-org')).toBe(false)
+  })
+
+  it('a takeover that loses the account fence still gets converged later', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    // A bot-wide takeover launches one transfer per project, so projects sharing
+    // an account contend exactly as repairs do.
+    expect(await h.accounts.claimLease(account.id, 'peer', new Date(Date.now() + 300_000), new Date())).toBe(true)
+
+    const taker = await h.connections.upsertOnCallback({
+      orgId: DEFAULT_ORG_ID,
+      userId: DEFAULT_OWNER_ID,
+      gitlabUserId: 7007n,
+      gitlabUsername: 'example-taker',
+      scopes: ['api'],
+      accessExpiresAt: new Date(Date.now() + 3600_000),
+      sealedPair: { accessToken: 'at-taker', refreshToken: 'rt-taker' }
+    })
+    h.fake.members.set(7007, 50)
+    expect(await h.provisioner.transfer(DEFAULT_ORG_ID, h.binding.id, { id: taker.id, gitlabUserId: 7007n })).toEqual({
+      outcome: 'transferred'
+    })
+
+    // The binding is not falsely degraded, and the convergence it never got is owed.
+    expect(await h.bindings.get(DEFAULT_ORG_ID, h.binding.id)).toMatchObject({ state: 'ready', stateReason: null })
+    expect(h.provisioner.hasPendingWork(DEFAULT_ORG_ID)).toBe(true)
   })
 
   it('two concurrent provisions: exactly one runs, the other observes busy', async () => {

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -1066,8 +1066,13 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.convergeOwedAt).not.toBeNull()
     await h.accounts.releaseLease(account.id, 'peer')
 
-    // Removal takes the claim; convergence can never acquire it again, so the
-    // obligation is void whether or not the removal itself completes.
+    // Taking the claim for cleanup discharges the obligation in the SAME
+    // transaction: past that point convergence can never acquire the claim, so
+    // an obligation surviving the flip is one nothing could satisfy.
+    expect(await h.bindings.beginCleanup(DEFAULT_ORG_ID, h.binding.id, PROJECT, new Date())).toBe(true)
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.convergeOwedAt).toBeNull()
+    expect(await h.bindings.listConvergeOwed(new Date(Date.now() + 1_000), 50)).toHaveLength(0)
+
     expect((await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).removed).toBe(false)
     expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('cleanup_pending')
     expect(await h.bindings.listConvergeOwed(new Date(Date.now() + 1_000), 50)).toHaveLength(0)

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -1076,6 +1076,13 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     expect((await h.provisioner.disconnect(DEFAULT_ORG_ID, h.binding.id)).removed).toBe(false)
     expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.state).toBe('cleanup_pending')
     expect(await h.bindings.listConvergeOwed(new Date(Date.now() + 1_000), 50)).toHaveLength(0)
+
+    // The inverse order too: a repair that loses to cleanup must not arm an
+    // obligation afterwards, or the console would report converging forever.
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.convergeOwedAt).toBeNull()
+    await h.bindings.markConvergeOwed(DEFAULT_ORG_ID, h.binding.id, new Date())
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.convergeOwedAt).toBeNull()
   })
 
   it('two concurrent provisions: exactly one runs, the other observes busy', async () => {

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -407,10 +407,12 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
       true
     )
     const converging = h.provisioner.convergeProject(DEFAULT_ORG_ID, SECOND_PROJECT)
-    await vi.waitFor(
-      async () => expect((await h.bindings.get(DEFAULT_ORG_ID, second.id))!.stateReason).toBe('account_busy'),
-      { timeout: 20_000 }
-    )
+    // Losing the fence leaves the binding exactly as it was — a race is not a
+    // verdict — so the peer's grip is what this waits on, not a degraded state.
+    await vi.waitFor(() => expect(h.fake.requests.some((r) => r.url.includes('service_accounts'))).toBe(true), {
+      timeout: 20_000
+    })
+    expect((await h.bindings.get(DEFAULT_ORG_ID, second.id))!.stateReason).toBeNull()
     await h.accounts.releaseLease(account.id, 'old-project-run')
 
     await converging
@@ -824,6 +826,77 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     expect(await h.accounts.claimLease(account.id, 'C', until, now)).toBe(true)
     await h.accounts.releaseLease(account.id, 'A')
     expect(await h.accounts.claimLease(account.id, 'D', until, now)).toBe(false)
+  })
+
+  it('concurrent convergences of one project join instead of racing, and settle ready', async () => {
+    const h = await harness()
+    // Four callers at once — a repair, a hook write, and two background kicks.
+    await Promise.all([
+      h.provisioner.convergeProject(DEFAULT_ORG_ID, PROJECT),
+      h.provisioner.convergeProject(DEFAULT_ORG_ID, PROJECT),
+      h.provisioner.convergeProject(DEFAULT_ORG_ID, PROJECT),
+      h.provisioner.convergeProject(DEFAULT_ORG_ID, PROJECT)
+    ])
+    const binding = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
+    expect(binding).toMatchObject({ state: 'ready', stateReason: null })
+    // One account and one set of PATs: the joined callers did not each provision.
+    expect(h.fake.serviceAccounts).toHaveLength(1)
+    expect(h.fake.tokens.size).toBe(3)
+  })
+
+  it('a bot repair across two projects sharing one account settles both clean', async () => {
+    const h = await harness()
+    const second = await h.bindings.createWithClaim({
+      orgId: DEFAULT_ORG_ID,
+      projectId: SECOND_PROJECT,
+      projectPath: 'example-group/example-second',
+      installerConnectionId: h.connection.id
+    })
+    // One agent consuming both projects in the same root: both convergences want
+    // the SAME account mutation lease, which is what a bot-level repair triggers.
+    await prisma.hookDef.create({
+      data: {
+        orgId: DEFAULT_ORG_ID,
+        agentId: AGENT,
+        kind: 'gitlab',
+        name: 'second-hook',
+        sessionMode: 'perThread',
+        repoId: SECOND_PROJECT,
+        events: ['issues:*']
+      }
+    })
+
+    await Promise.all([
+      h.provisioner.convergeProject(DEFAULT_ORG_ID, PROJECT),
+      h.provisioner.convergeProject(DEFAULT_ORG_ID, SECOND_PROJECT)
+    ])
+
+    // Neither binding settled degraded on account of the other holding the lease.
+    expect(await h.bindings.get(DEFAULT_ORG_ID, h.binding.id)).toMatchObject({ state: 'ready', stateReason: null })
+    expect(await h.bindings.get(DEFAULT_ORG_ID, second.id)).toMatchObject({ state: 'ready', stateReason: null })
+    // One account, bound to both.
+    const accounts = await h.accounts.listForAgent(DEFAULT_ORG_ID, AGENT)
+    expect(accounts).toHaveLength(1)
+    expect(await h.accounts.countMemberships(accounts[0]!.id)).toBe(2)
+  })
+
+  it('exhausted contention leaves the binding alone and re-drives itself', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    // A peer holds the account lease for longer than this pass will wait.
+    expect(await h.accounts.claimLease(account.id, 'peer', new Date(Date.now() + 300_000), new Date())).toBe(true)
+
+    await h.provisioner.convergeProject(DEFAULT_ORG_ID, PROJECT, { attempts: 0, followUp: false })
+
+    // A lost fence is not a verdict: the binding keeps the state it had, so the
+    // console never shows "setup incomplete" because two repairs overlapped.
+    expect(await h.bindings.get(DEFAULT_ORG_ID, h.binding.id)).toMatchObject({ state: 'ready', stateReason: null })
+
+    // Once the peer is done, the next pass converges normally — no user action.
+    await h.accounts.releaseLease(account.id, 'peer')
+    await h.provisioner.convergeProject(DEFAULT_ORG_ID, PROJECT, { attempts: 0, followUp: false })
+    expect(await h.bindings.get(DEFAULT_ORG_ID, h.binding.id)).toMatchObject({ state: 'ready', stateReason: null })
   })
 
   it('two concurrent provisions: exactly one runs, the other observes busy', async () => {

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -87,17 +87,19 @@ async function harness(
     },
     fetchImpl: fake.fetch()
   })
-  const provisioner = new GitlabProvisioner({
-    oauth,
-    bindings,
-    accounts: accountService,
-    webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
-    catalog: new PgCodeHostRepositoryRepo(prisma),
-    clock: systemClock,
-    publicRelayUrl: 'https://relay.example.test',
-    desiredWebhookEvents: async () => webhookEvents,
-    fetchImpl: fake.fetch()
-  })
+  const buildProvisioner = (): GitlabProvisioner =>
+    new GitlabProvisioner({
+      oauth,
+      bindings,
+      accounts: accountService,
+      webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
+      catalog: new PgCodeHostRepositoryRepo(prisma),
+      clock: systemClock,
+      publicRelayUrl: 'https://relay.example.test',
+      desiredWebhookEvents: async () => webhookEvents,
+      fetchImpl: fake.fetch()
+    })
+  const provisioner = buildProvisioner()
   const connection = await connections.upsertOnCallback({
     orgId: DEFAULT_ORG_ID,
     userId: DEFAULT_OWNER_ID,
@@ -130,6 +132,9 @@ async function harness(
     oauth,
     accountService,
     provisioner,
+    /** A second instance over the same rows — what survives a restart is only
+     *  what the database holds, never this process's timers. */
+    restarted: buildProvisioner,
     binding,
     connection,
     connections
@@ -944,6 +949,93 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     expect(await h.bindings.get(DEFAULT_ORG_ID, h.binding.id)).toMatchObject({ state: 'ready', stateReason: null })
     expect(h.provisioner.hasPendingWork(DEFAULT_ORG_ID)).toBe(true)
   })
+
+  it('records the contended obligation durably, and a sweep re-drives it after a restart', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.convergeOwedAt).toBeNull()
+
+    // A peer holds the account lease, so this pass writes no binding state.
+    expect(await h.accounts.claimLease(account.id, 'peer', new Date(Date.now() + 300_000), new Date())).toBe(true)
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+
+    // The obligation is on the row, not only in this process's timer — which is
+    // what a restart would otherwise erase along with the console's signal.
+    const owed = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
+    expect(owed.convergeOwedAt).not.toBeNull()
+    expect(owed).toMatchObject({ state: 'ready', stateReason: null })
+    expect((await h.bindings.listConvergeOwed(new Date(Date.now() + 1_000), 50)).map((b) => b.id)).toEqual([
+      h.binding.id
+    ])
+
+    // A fresh provisioner — the restart — rediscovers and discharges it.
+    await h.accounts.releaseLease(account.id, 'peer')
+    await h.restarted().sweepOwedConvergences(0)
+    const settled = (await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!
+    expect(settled.convergeOwedAt).toBeNull()
+    expect(settled).toMatchObject({ state: 'ready', stateReason: null })
+    expect(await h.bindings.listConvergeOwed(new Date(Date.now() + 1_000), 50)).toHaveLength(0)
+  })
+
+  it('a route write waits out a background convergence instead of refusing it', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+
+    // A background convergence holds the binding lease. The pre-activation
+    // ensure a route write runs must outlast that rather than 409 on a race
+    // with a perfectly healthy convergence.
+    const held = 'background-converge'
+    expect(
+      await h.bindings.markProviderMutationStarted(
+        DEFAULT_ORG_ID,
+        h.binding.id,
+        PROJECT,
+        held,
+        new Date(Date.now() + 600_000),
+        new Date()
+      )
+    ).toBe(true)
+    setTimeout(() => {
+      void h.bindings.endProviderMutation(DEFAULT_ORG_ID, h.binding.id, PROJECT, held)
+    }, 5_000)
+
+    const committed = await h.provisioner.provisionAgentAccount(
+      DEFAULT_ORG_ID,
+      PROJECT,
+      { agentId: AGENT, accessLevel: 30 },
+      async () => 'written'
+    )
+    expect(committed).toEqual({ ok: true, result: 'written' })
+    expect((await h.accounts.membershipsForBinding(h.binding.id)).map((m) => m.accessLevel)).toEqual([30])
+  }, 30_000)
+
+  it('reports a still-contended route write as transient, never as a degraded binding', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    // Held for longer than any request should wait.
+    expect(
+      await h.bindings.markProviderMutationStarted(
+        DEFAULT_ORG_ID,
+        h.binding.id,
+        PROJECT,
+        'stuck',
+        new Date(Date.now() + 600_000),
+        new Date()
+      )
+    ).toBe(true)
+
+    const refused = await h.provisioner.provisionAgentAccount(
+      DEFAULT_ORG_ID,
+      PROJECT,
+      { agentId: AGENT, accessLevel: 30 },
+      async () => 'written'
+    )
+    expect(refused).toMatchObject({ ok: false, retryable: true, reason: 'provisioning_or_cleanup_in_progress' })
+    // Transient wording, and the binding is untouched — a race is not a verdict.
+    expect(gitlabAccountUnavailableMessage('provisioning_or_cleanup_in_progress')).toContain('try again')
+    expect(await h.bindings.get(DEFAULT_ORG_ID, h.binding.id)).toMatchObject({ state: 'ready', stateReason: null })
+  }, 30_000)
 
   it('two concurrent provisions: exactly one runs, the other observes busy', async () => {
     const h = await harness()

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -350,13 +350,23 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     `${verb} ${done} of ${done + failures.length} projects. ${errorText(failures[0]!.reason)}`
 
   // Convergence for an account runs per project, so repairing a bot re-runs it on each project the
-  // bot holds — including the one whose group its refused account belongs to.
+  // bot holds — including the one whose group its refused account belongs to. SEQUENTIAL: those
+  // projects share one bot account, so firing them together only makes them queue on its lease.
+  // The server coalesces regardless; this just keeps the common case from contending at all.
   const repairBot = async (agentId: string, bindingIds: readonly string[]) => {
     if (busyId) return
     setBusyId(agentId)
     setErr(null)
     try {
-      const results = await Promise.allSettled(bindingIds.map(async (id) => repairGitlabProject(id)))
+      const results: PromiseSettledResult<GitlabProjectBindingDto>[] = []
+      for (const id of bindingIds) {
+        results.push(
+          await repairGitlabProject(id).then(
+            (value): PromiseSettledResult<GitlabProjectBindingDto> => ({ status: 'fulfilled', value }),
+            (reason: unknown): PromiseSettledResult<GitlabProjectBindingDto> => ({ status: 'rejected', reason })
+          )
+        )
+      }
       const failures = results.filter((r) => r.status === 'rejected')
       // Whatever each request did, the authoritative state is the answer — never the batch's.
       const reconciled = await refreshAfterBatch()

--- a/packages/web/src/lib/gitlab-projects.ts
+++ b/packages/web/src/lib/gitlab-projects.ts
@@ -66,7 +66,9 @@ export const GITLAB_STATE_REASON: Record<string, string> = {
   account_retiring: 'The previous bot account for this agent is still being removed — this finishes on its own',
   account_cleanup_incomplete: 'Removal did not finish cleaning up the bot accounts — remove the project again',
   provisioning_in_progress: 'Setup is already running',
-  provisioning_or_cleanup_in_progress: 'Setup or removal is already running'
+  provisioning_or_cleanup_in_progress: 'Setup or removal is already running',
+  account_busy: 'Another setup for this bot account is already running — this finishes on its own',
+  account_membership_contended: 'Another setup for this bot account is already running — this finishes on its own'
 }
 
 /** User-facing copy for a state reason, or null to show nothing but the state badge — an


### PR DESCRIPTION
Found in live testing: clicking the bot-level Repair reliably left a project at
`state=admin_degraded, stateReason=account_busy` — the console showing "setup
incomplete" and the attention badge — and it never healed, because the next
Repair raced exactly the same way.

## Why

Repairing a bot re-runs convergence for **each project that bot holds**, and two
bots sharing a project double that again. Those convergences all want the same
account mutation lease, so the losers came back with the retryable
`account_busy` — and `convergeAndPersist` wrote that outcome to the binding
verbatim. A lost fence, which says nothing about the binding itself, became a
sticky degraded verdict that only another race could clear.

The repair route compounded it: it ran a single `provision` with no contention
retry at all, so the very first collision stuck.

## The fix

- **Coalesce convergence per (organization, project).** A caller that finds one
  already in flight joins it and asks for a trailing pass, instead of racing it
  for the same leases. Concurrent repairs of one project become one run, and a
  joiner's own write is still converged by the trailing pass — the reason this
  is a join-and-rerun rather than a plain join.
- **Never persist a contended outcome.** The binding keeps the state it had.
- **Schedule a follow-up when the contention budget is exhausted**, so the
  binding settles on its own rather than waiting for a user to press Repair
  again — the durable re-drive pattern the retirement sweep already uses.
- The repair route now converges through that path with a request-sized bound
  and hands off to the follow-up, rather than holding the connection.

Any contention reason still reachable reads as in-progress in the console
instead of as a setup failure. The card's per-bot Repair also issues its
per-project requests sequentially — they share one bot account, so firing them
together only made them queue on its lease. That is a mitigation; the server is
correct whatever the client does.

## Tests

- four concurrent convergences of one project settle it `ready` with no degraded
  state, and provision exactly one account and one set of PATs — proving they
  joined rather than each ran;
- a bot repair across two projects sharing one account settles both `ready`,
  with one account bound to both;
- an exhausted contention budget leaves the binding exactly as it was, and the
  next pass converges normally once the peer releases.

The third fails against the previous behavior with the reported symptom. One
existing test asserted the old sticky `account_busy` as its synchronisation
signal; it now waits on the peer's grip instead and additionally asserts the
binding is *not* degraded while contended.

## Verification

- root `pnpm typecheck`
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 2013 passed
- `pnpm --filter @agentconnect.md/control-plane test:int` — 1737 passed
- `pnpm --filter @agentconnect.md/web test` — 1940 passed (translations touched)
- `pnpm lint`, `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
