### PR TITLE
test(control-plane): settle kicked GitLab convergence before asserting on it

### DIFF
--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -53,7 +53,11 @@ const RELAY_URL = 'https://relay.example.test'
 const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
 
 let running: HttpApp | undefined
+let settleConvergence: (() => Promise<void>) | undefined
 afterEach(async () => {
+  // Own the routes' fire-and-forget convergence: a run outliving its test writes into the next one's swept database.
+  await settleConvergence?.()
+  settleConvergence = undefined
   await running?.close()
   running = undefined
 })
@@ -105,6 +109,22 @@ async function harness(options: FakeGitlabOptions = {}) {
     },
     fetchImpl: fake.fetch()
   })
+  // Hook writes kick §11.1 convergence fire-and-forget, and that run provisions accounts and re-writes project
+  // facts — so a test asserting on either has to outwait the run instead of racing it.
+  const inFlightConvergence = new Set<Promise<void>>()
+  const convergeProject = provisioner.convergeProject.bind(provisioner)
+  provisioner.convergeProject = (orgId: string, projectId: bigint): Promise<void> => {
+    const run = convergeProject(orgId, projectId)
+    inFlightConvergence.add(run)
+    return run.finally(() => inFlightConvergence.delete(run))
+  }
+  const settled = async (): Promise<void> => {
+    while (inFlightConvergence.size > 0) {
+      await Promise.allSettled([...inFlightConvergence])
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+  }
+  settleConvergence = settled
   running = buildHttpApp(
     prisma,
     { PUBLIC_CP_URL: 'https://api.example.test', PUBLIC_RELAY_URL: RELAY_URL },
@@ -166,7 +186,8 @@ async function harness(options: FakeGitlabOptions = {}) {
     agentId,
     secondAgentId,
     daemonId,
-    authorize
+    authorize,
+    settled
   }
 }
 
@@ -356,9 +377,13 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
       url: `${ORG}/hooks`,
       payload: glBody(h.agentId, { enabled: false })
     })
+    // The 200 is the claim: a write that tried to provision would have hit the refused quota and 409'd, exactly as
+    // the enabled-hook case below does. Convergence separately serves the agent's pre-existing authorization, so
+    // read the SETTLED state rather than racing that run — the group still holds no bot for this agent.
     expect(created.statusCode).toBe(200)
-    expect(await h.accounts.listForAgent(DEFAULT_ORG_ID, h.agentId)).toHaveLength(0)
+    await h.settled()
     expect(h.fake.serviceAccounts).toHaveLength(0)
+    expect((await h.accounts.listForAgent(DEFAULT_ORG_ID, h.agentId)).filter((a) => a.state === 'ready')).toEqual([])
 
     // Disabling an enabled hook is likewise not blocked by the outage.
     await h.authorize(h.secondAgentId)
@@ -369,6 +394,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
       payload: glBody(h.secondAgentId)
     })
     expect(enabled.statusCode).toBe(200)
+    await h.settled()
     h.fake.opts.refuseServiceAccountQuota = true
     const disabled = await h.a.app.inject({
       method: 'PUT',
@@ -1100,6 +1126,8 @@ describe('gitlab run projection — the fence follows the agent account (§7.2/�
     const h = await harness()
     const created = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
     const hookId = (created.json() as { id: string }).id
+    // Outwait the write's kick: a run landing later would converge the account back to ready over the drift below.
+    await h.settled()
     const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, h.agentId, 900n))!
     // Runtime drift: the account is being repaired, so its lease would be refused.
     await h.accounts.update(account.id, { state: 'runtime_degraded', stateReason: 'drift' })

--- a/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
@@ -45,7 +45,11 @@ const AGENT = '11111111-1111-4111-8111-111111111111'
 const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
 
 let running: HttpApp | undefined
+let settleConvergence: (() => Promise<void>) | undefined
 afterEach(async () => {
+  // Own the routes' fire-and-forget convergence: a run outliving its test writes into the next one's swept database.
+  await settleConvergence?.()
+  settleConvergence = undefined
   await running?.close()
   running = undefined
 })
@@ -93,6 +97,23 @@ async function harness(liveness?: DaemonLiveness) {
     },
     fetchImpl: fake.fetch()
   })
+  // Route writes kick §10.2 convergence fire-and-forget, and the run re-writes every replicated project path from
+  // what the provider answers with — so a test writing those paths itself has to outwait the run, not race it.
+  const inFlightConvergence = new Set<Promise<void>>()
+  const convergeProject = provisioner.convergeProject.bind(provisioner)
+  provisioner.convergeProject = (orgId: string, projectId: bigint): Promise<void> => {
+    const run = convergeProject(orgId, projectId)
+    inFlightConvergence.add(run)
+    return run.finally(() => inFlightConvergence.delete(run))
+  }
+  // A retarget converges two projects SEQUENTIALLY, so drain until nothing new is enqueued.
+  const settled = async (): Promise<void> => {
+    while (inFlightConvergence.size > 0) {
+      await Promise.allSettled([...inFlightConvergence])
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+  }
+  settleConvergence = settled
   running = buildHttpApp(prisma, { PUBLIC_CP_URL: 'https://api.example.test' }, liveness, undefined, {
     gitlab: { oauth, provisioner, accounts: accountService, fetchImpl: fake.fetch() }
   })
@@ -116,7 +137,7 @@ async function harness(liveness?: DaemonLiveness) {
   await seedAgent(prisma, AGENT, { name: 'workspace-agent', gitlabProjectId: PROJECT })
   expect(await provisioner.provision(DEFAULT_ORG_ID, binding.id)).toEqual({ state: 'ready' })
   const account = (await accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
-  return { fake, a: running, bindings, accounts, binding, account, provisioner, connection }
+  return { fake, a: running, bindings, accounts, binding, account, provisioner, connection, settled }
 }
 
 function credService(bindings: PgGitlabProjectBindingRepo) {
@@ -299,6 +320,9 @@ describe('gitlab workspaces — agent create/edit (§8.3)', () => {
     })
     expect(created.statusCode).toBe(201)
     const agentId = (created.json() as { id: string }).id
+    // Outwait the create's kick: the rename below is a provider-side fact this fake never learns, so a run landing
+    // after it would legitimately converge the clone URL back to the path the provider still answers with.
+    await h.settled()
     const before = await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })
     const agents = new PgAgentRepo(prisma)
     const refreshed = await agents.refreshGitlabProjectPath(
@@ -803,6 +827,8 @@ describe('additional GitLab project authorizations (§8.3/§13.1)', () => {
     await secondBinding(h)
     const created = await h.a.app.inject(authorize({ provider: 'gitlab', projectId: SECOND_PROJECT.toString() }))
     expect(created.statusCode).toBe(200)
+    // Same as the workspace half: outwait the authorization's kick, which re-writes the grant path from the provider.
+    await h.settled()
     const before = await prisma.agent.findUniqueOrThrow({ where: { id: AGENT } })
 
     const agents = new PgAgentRepo(prisma)


### PR DESCRIPTION
## The flake

`a binding path refresh converges affected agent clone URLs with a revision bump`
(`packages/control-plane/test/integration/gitlab-workspace.route.test.ts`) fails
intermittently under the parallel integration pool with
`expected [ …(2) ] to deeply equal []`, while passing on isolated and repeated runs.

## Root cause: the test, not the product

Two writers of the same replicated project paths, with nothing ordering them.

1. The test writes them directly through `PgAgentRepo.refreshGitlabProjectPath`, standing
   in for a provider-side rename the fake GitLab never learns about.
2. The agent create it made one line earlier kicked project convergence fire-and-forget.
   That run re-reads the project and re-writes the same paths from what the provider
   answers with — still the original path.

Whichever lands last wins. Landing before the rename, the usual ordering on an idle
machine, is invisible. Landing between the rename and the idempotency assertion converges
both gitlab agents back to the provider's path, so the follow-up refresh finds two drifted
agents instead of none. That is the reported failure, and the two is the two
gitlab-workspace agents the test holds.

**The product is not racing.** Every production write of these paths happens inside the
leased convergence run, so two runs never overlap; the direct repository write is a second
writer that exists only in the test. No product code changes here.

## The fix

The harness keeps a handle on the runs the routes kick and exposes `settled()`. Tests that
write or assert state those runs also write await it first, and `afterEach` drains it so a
run never outlives its test into the next one's freshly swept database. It awaits the
actual work rather than polling a proxy for it, so there is no sleep and no timeout.

Applied to both suites that were exposed:

- **`gitlab-workspace.route.test.ts`** — the reported flake, plus `carries a project rename
  into the grant path and the replicated spec`, which has the same shape one route over.
- **`gitlab-hooks.route.test.ts`** — its `afterEach` only closed the app, so runs leaked
  into the next test against a constant (org, project). Two assertions there outwait the
  kick now, and the mid-test quota flip no longer changes provider behaviour under a run
  that is still reading it.

One assertion needed more than a wait. `a hook that will not be enabled needs no account,
even out of quota` counted the agent's accounts and expected none — true only before
convergence runs, because the agent's pre-existing authorization makes it a consumer that
convergence serves for its own reasons. The test's actual claim is already carried by the
`200`: a write that tried to provision would have hit the refused quota and answered `409`,
exactly as the enabled-hook case does. It now asserts what the claim is about — no bot
minted in the group, and no account reaching `ready`.

## Evidence

Reproduced deterministically before fixing: with the kick scheduled 21 ms late and the gap
between the two assertions widened to 30 ms — the interleaving a loaded four-worker pool
produces — the test fails with the exact CI message. The same instrumentation on top of
this change passes, and with every kick delayed 1.5 s the whole file still passes 27/27.
The hooks suite likewise stays green with every kick delayed 800 ms.

In fairness to the record: the hooks projection assertion is hardened rather than proven —
its window is real but I could not force it across kick delays from 12 ms to 70 ms.

Repeat runs on this branch, default four workers (`INTEGRATION_TEST_WORKERS` unset):
**10 consecutive full control-plane `test:int` runs, 111 files / 1734 tests each, all green.**

## Noted, not fixed

Adjacent and separate: the inline agent-account provisioning gives up after a short bounded
retry, while a background convergence run can hold the binding lease through a far longer
one. Back-to-back route writes on one project can therefore answer `409` where waiting
would have succeeded. That is a product tuning question about the two retry budgets, not a
test defect, so it is recorded here rather than changed.

## Verification

- root `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
- `@agentconnect.md/control-plane` `test:unit` (175 files / 2013 tests) and `test:int`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
