### PR TITLE
feat(daemon): resolve the GitLab instance from the spec instead of two literals

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -2432,12 +2432,28 @@ Merge order, GitLab.com green at every step:
   Exit: mixed-version tests in both directions,
   including a self-managed additional repository on a scratch workspace and
   a hook targeting a non-GitLab-workspace agent on an old daemon.
-- **N3 — daemon plumbing.** The managed host resolved from the spec's
+- **N3 — daemon plumbing. Landed.** The managed host resolved from the spec's
   `gitlabHost`, the injected helper table with prefix stripping, the
   spec-admission origin refusal, per-turn client bases, the `glab` export at
   spawn. Exit additionally covers a warm session receiving a hook whose
   fence host disagrees with the spec. Daemons carrying N3 advertise the
-  feature.
+  feature, on the control connection and on `rd/hello` alike — the relay's
+  dispatch fence reads the latter. The two-literal classifier is replaced by a
+  resolved `{provider, baseUrl}` pair threaded through the workspace roots, so
+  the trusted-origin check, the `.git`-suffix canonicalization (now keyed on
+  provider) and the materialization key all take the spec's answer instead of
+  re-deriving one from the clone URL. The helper table travels on
+  `AC_GITCRED_HOSTS` beside the capability it is minted with, carries GitHub
+  plus the one GitLab instance the spec names — a GitLab consumer is not always
+  the workspace — and is stripped from the daemon's own inherited environment so
+  an ambient value can never be read as a hint. The `glab` token entry reads the
+  instance off that same table rather than off the `GITLAB_HOST` it exports,
+  which it only compares against. The spec-admission refusal rides the
+  `agent/upsert` ack, which is the control plane's own record of why the daemon
+  will not serve the agent; the reconnect snapshot deliberately still stores a
+  spec it cannot clone, because one unservable roster entry must not fail
+  registration, and the clone boundary refuses it as it always did. The boot
+  warning survives only as "no https origin is permitted at all".
 - **N4 — authority and surfaces.** `service_account_creation_forbidden`
   with tier-aware copy, the expiry clamp with the re-derived horizon, Setup
   and Console surfaces, operator documentation (authority bundle, egress for

--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -2303,10 +2303,17 @@ convention, and each entry carries the **full normalized base including any
 path prefix**: with `useHttpPath`, Git hands the helper
 `gitlab/group/project.git` on a prefixed install, and `glab` remotes carry
 the same prefix, so both strip the entry's prefix on an exact segment
-boundary before parsing the project path. The `.git`-suffix
-canonicalization keys on provider; the four daemon API clients resolve their
-base per turn; the `glab` shim exports `GITLAB_HOST` so the real CLI targets
-the instance, deferring only on a genuine mismatch.
+boundary before parsing the project path. The session config pins the
+helper for the instance whenever the spec carries a **repo-bearing** GitLab
+consumer — a GitLab workspace or an authorized GitLab additional repository,
+never a hook alone, because such an agent already accepts that the managed
+identity owns that host's credential path while a hook authorizes a turn and
+no repository, so pinning for it would cut ambient access with nothing to
+serve. The `.git`-suffix canonicalization keys on provider, falling back for
+an anonymous remote to the instance its address is checked against; the four
+daemon API clients resolve their base per turn; the `glab` shim exports
+`GITLAB_HOST` so the real CLI targets the instance, deferring only on a
+genuine mismatch.
 
 One feature string, `gitlab-instance-v1`, gates on the configured value.
 When the host is GitLab.com nothing is gated and a mixed fleet is today's
@@ -2446,7 +2453,9 @@ Merge order, GitLab.com green at every step:
   `AC_GITCRED_HOSTS` beside the capability it is minted with, carries GitHub
   plus the one GitLab instance the spec names — a GitLab consumer is not always
   the workspace — and is stripped from the daemon's own inherited environment so
-  an ambient value can never be read as a hint. The `glab` token entry reads the
+  an ambient value can never be read as a hint. The table only classifies, so the
+  session config additionally pins the helper for the instance on a repo-bearing
+  spec: git has to select a configured helper before any table can route the ask. The `glab` token entry reads the
   instance off that same table rather than off the `GITLAB_HOST` it exports,
   which it only compares against. The spec-admission refusal rides the
   `agent/upsert` ack, which is the control plane's own record of why the daemon

--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -200,6 +200,8 @@ export const AgentSchema = z.object({
   // managed (the default). External keeps only connection id + bounded policy on
   // disk; endpoint/grant/config live in the daemon-private CP registry.
   memory: AgentMemoryBinding.optional(),
+  // The instance every GitLab consumer here addresses (§24.4); absent ⇒ GitLab.com, the axis default.
+  gitlabHost: z.string().optional(),
   workspace: z.object({
     mode: z.enum(['git-repo', 'from-scratch']),
     // Internal isolation policy. Product surfaces call the session mode

--- a/packages/daemon/src/agents/write-agent.ts
+++ b/packages/daemon/src/agents/write-agent.ts
@@ -793,6 +793,9 @@ export function applySpecFields(
   // field), so a flip replicates; absent (older CP) ⇒ leave the on-disk value alone.
   if (spec.builtin !== undefined) raw.builtin = spec.builtin
   if (spec.memory !== undefined) raw.memory = spec.memory
+  // §24.4: absent means GitLab.com, so an absent value CLEARS a stale one rather than preserving it.
+  if (spec.gitlabHost !== undefined) raw.gitlabHost = spec.gitlabHost
+  else delete raw.gitlabHost
 
   // Output settings preserve sibling/future keys while applying CP-owned values.
   if (spec.outputMode !== undefined || spec.showFooter !== undefined || spec.showStatusBar !== undefined) {

--- a/packages/daemon/src/config/tls-trust-env.ts
+++ b/packages/daemon/src/config/tls-trust-env.ts
@@ -1,0 +1,18 @@
+/**
+ * The customer authority bundle, as process configuration (gitlab-com-integration.md §24.5).
+ *
+ * A self-managed instance is commonly fronted by a private certificate authority, so Node, git and
+ * the tools the daemon spawns each need to be pointed at the operator's bundle. That is the ONLY
+ * mechanism: there is no skip-verify flag at any layer. These names are an addition to the daemon's
+ * existing deliberately narrow forwarding allowlists, not a new channel.
+ */
+export const TLS_TRUST_ENV = ['NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE', 'SSL_CERT_DIR', 'GIT_SSL_CAINFO'] as const
+
+export function tlsTrustEnv(source: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const name of TLS_TRUST_ENV) {
+    const value = source[name]
+    if (value !== undefined && value !== '') env[name] = value
+  }
+  return env
+}

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -53,6 +53,7 @@ import {
 import type { LocalStore } from '../store/local-store.js'
 import type { AcpHost } from '../acp/acp-host.js'
 import type { WorkspaceManager, PrepareSessionWorkspaceRequest } from '../workspace/workspace-manager.js'
+import { unauthorizedWorkspaceGitOrigin } from '../workspace/git-origin-policy.js'
 import type { KeyServerClient } from '../key-server/client.js'
 import type { GitCredentialCache } from './git-credential.js'
 import type { GitCredServer } from './gitcred-server.js'
@@ -326,9 +327,29 @@ export async function applyReconcileSnapshot(host: ConfigApplyHost, snap: Regist
   await host.flushReconcile()
 }
 
+/**
+ * §24.4 spec admission: the operator's `workspaceGitAllowedOrigins` stays authoritative, and the
+ * managed GitLab feature never widens it. A GitLab workspace whose instance the policy excludes is
+ * refused HERE, naming the origin an operator has to add, and the refusal travels back on the
+ * upsert ack — the control plane's own record of why this daemon will not serve the agent.
+ */
+function gitlabOriginRefusal(spec: AgentUpsert['spec']): string | undefined {
+  const workspace = spec.workspace
+  if (workspace?.mode !== 'gitlab') return undefined
+  const origin = unauthorizedWorkspaceGitOrigin(workspace.gitRepo)
+  return origin === undefined
+    ? undefined
+    : `workspace refused: security.workspaceGitAllowedOrigins on this daemon excludes ${origin} — add that origin to serve this GitLab instance`
+}
+
 export function applyAgentUpsert(host: ConfigApplyHost, { agentId, spec }: AgentUpsert): Promise<Ack> {
   return host.queueAgentLifecycle(agentId, async () => {
     if (host.moveStagedAgents().has(agentId)) return { ok: false, reason: 'agent is staged for a move' }
+    const originRefusal = gitlabOriginRefusal(spec)
+    if (originRefusal !== undefined) {
+      host.log().warn(`cp: agent "${agentId}" ${originRefusal}`)
+      return { ok: false, reason: originRefusal }
+    }
     if (host.agentRemovalPending(agentId)) return { ok: false, reason: 'agent is pending removal' }
     const cpAgents = host.cpAgents()
     if (!cpAgents) return { ok: false, reason: 'agent registry is not ready' }

--- a/packages/daemon/src/cp/git-credential.ts
+++ b/packages/daemon/src/cp/git-credential.ts
@@ -31,7 +31,7 @@
  * and an UNEXPIRED cached token keeps serving — CP downtime only breaks remote
  * git once the hour runs out.
  */
-import type { GitCredCapability, GitCredGrant } from '@agentconnect.md/protocol'
+import { GITLAB_DEFAULT_BASE_URL, type GitCredCapability, type GitCredGrant } from '@agentconnect.md/protocol'
 
 /** Hand out only while more than this remains (nests under the CP's 15min floor). */
 const HANDOUT_MIN_MS = 10 * 60 * 1000
@@ -125,6 +125,10 @@ export interface GitCredentialCacheDeps {
   /** §17.3 negotiation: `purpose: 'gitlab_effect'` is a NEW ENUM VALUE, so naming it to an
    *  older CP is frame-fatal rather than silently stripped — ask only after gitlab-effect-v1. */
   gitlabEffectSupported?: () => boolean
+  /** §24.4: the GitLab instance this agent's spec names, absent ⇒ GitLab.com. Every gitlab grant's
+   *  echoed host is verified against it exactly as provider and project id are — a mismatch means
+   *  the credential authenticates against a different instance and is never served. */
+  gitlabHostFor?: (agentId: string) => string | undefined
   /** Monotonic ms; injectable for tests. */
   monoNow?: () => number
 }
@@ -422,6 +426,17 @@ export class GitCredentialCache {
         `control plane answered project ${grant.externalRepoId ?? 'unknown'} for project ${payload.externalRepoId}`,
         false
       )
+    }
+    // …and the instance it authenticates against (§24.4); absent means GitLab.com on both sides.
+    if (payload.provider === 'gitlab') {
+      const expected = this.deps.gitlabHostFor?.(payload.agentId) ?? GITLAB_DEFAULT_BASE_URL
+      const echoed = grant.host ?? GITLAB_DEFAULT_BASE_URL
+      if (echoed !== expected) {
+        throw new GitCredUnavailableError(
+          `control plane answered a credential for gitlab instance ${echoed} for an agent bound to ${expected}`,
+          false
+        )
+      }
     }
     const entry: Entry = {
       username: grant.username,

--- a/packages/daemon/src/cp/glab-shim.ts
+++ b/packages/daemon/src/cp/glab-shim.ts
@@ -68,6 +68,17 @@ export function glabShimDir(root: string): string {
   return join(root, 'run', 'bin')
 }
 
+/**
+ * The session export that points the real glab at this deployment's instance (§24.4).
+ *
+ * It rides the per-AGENT session environment rather than the wrapper text, because the wrapper is
+ * generated once per boot while the host comes off each agent's replicated spec. A user-configured
+ * `GITLAB_TOKEN` still wins in the wrapper; this only decides which instance glab talks to.
+ */
+export function glabSessionEnv(gitlabBaseUrl: string): Record<string, string> {
+  return { GITLAB_HOST: gitlabBaseUrl }
+}
+
 /** (Re)write `run/bin/glab` and return the bin dir to prepend to agent PATHs. */
 export function writeGlabShim(root: string, cliEntry: string): string {
   const dir = glabShimDir(root)

--- a/packages/daemon/src/cp/glab-target.ts
+++ b/packages/daemon/src/cp/glab-target.ts
@@ -2,10 +2,15 @@
  * Target-project resolution for the `glab` wrapper (gitlab-com-integration.md
  * §13.3): explicit `-R/--repo` argument, then the `GITLAB_REPO` environment,
  * then the cwd origin remote — provider-defined precedence, resolved on the
- * Node side so sh never parses argv. gitlab.com only: any other host defers
- * (exit 2 — the wrapper runs the real glab untouched), matching the gh
- * wrapper's non-github deferral.
+ * Node side so sh never parses argv.
+ *
+ * The instance is passed in, never assumed (§24.4): the expected host is the deployment's own
+ * normalized base URL, carried on the injected credential table. A target on some OTHER host defers
+ * (exit 2 — the wrapper runs the real glab untouched), matching the gh wrapper's non-github
+ * deferral, and a prefixed install's path prefix is stripped before the project path is read,
+ * because the API takes the project path relative to the instance root.
  */
+import { GITLAB_COM_BASE_URL, parseManagedBaseUrl, stripHostPathPrefix } from '../gitcred/managed-hosts.js'
 
 function nonEmpty(value?: string): string | undefined {
   const trimmed = value?.trim()
@@ -27,47 +32,84 @@ function flagRepo(argv: readonly string[]): string | undefined {
   return nonEmpty(found)
 }
 
+interface ExpectedInstance {
+  /** Lower-cased host including a non-default port. */
+  host: string
+  /** Lower-cased host without its port — the form a bare `HOST/path` argument can carry. */
+  hostname: string
+  pathPrefix: string
+}
+
+function expectedInstance(expectedHost: string): ExpectedInstance {
+  const parts = parseManagedBaseUrl(expectedHost) ?? parseManagedBaseUrl(GITLAB_COM_BASE_URL)!
+  return { host: parts.host, hostname: parts.host.replace(/:\d+$/, ''), pathPrefix: parts.pathPrefix }
+}
+
+/** The project path relative to the instance root, or undefined when the prefix does not apply. */
+function projectPath(path: string, instance: ExpectedInstance): string | undefined {
+  const stripped = stripHostPathPrefix(path.replace(/\.git$/i, '').replace(/\/+$/, ''), instance.pathPrefix)
+  return stripped !== undefined && stripped.includes('/') ? stripped.toLowerCase() : undefined
+}
+
 /**
  * Normalize a raw project candidate. glab accepts `group/…/project` full paths,
  * `HOST/group/…/project`, and full/scp URLs for `-R`/`GITLAB_REPO`; the cwd
  * fallback hands us whatever `git remote get-url origin` prints. Unparseable ⇒
- * workspace token (project undefined); a non-gitlab.com host ⇒ defer.
+ * workspace token (project undefined); another host ⇒ defer.
  */
-export function normalizeProjectArg(raw?: string): { project?: string; defer?: boolean } {
+export function normalizeProjectArg(
+  raw?: string,
+  expectedHost: string = GITLAB_COM_BASE_URL
+): { project?: string; defer?: boolean } {
   const s = raw?.trim()
   if (!s) return {}
+  const instance = expectedInstance(expectedHost)
   // Bare namespaced path (no scheme, no scp colon) — arbitrary subgroup depth.
   if (/^[^/\s:@]+(\/[^/\s:@]+)+$/.test(s)) {
     const segs = s.replace(/\.git$/i, '').split('/')
-    // `gitlab.com/group/project` — the HOST/path form.
-    if (segs[0]!.toLowerCase() === 'gitlab.com') {
-      return segs.length >= 3 ? { project: segs.slice(1).join('/').toLowerCase() } : {}
+    // `gitlab.example.test/group/project` — the HOST/path form.
+    if (segs[0]!.toLowerCase() === instance.hostname) {
+      const project = projectPath(segs.slice(1).join('/'), instance)
+      return project ? { project } : {}
     }
     if (segs[0]!.includes('.')) return { defer: true } // some other HOST/path form
+    // A bare path is already relative to the instance root, prefix included.
     return { project: segs.join('/').toLowerCase() }
   }
-  const host = /^[a-z][a-z0-9+.-]*:\/\/(?:[^/@]+@)?([^/:]+)/i.exec(s)?.[1] ?? /^[\w.-]+@([\w.-]+):/.exec(s)?.[1]
+  const host =
+    /^[a-z][a-z0-9+.-]*:\/\/(?:[^/@]+@)?([^/:]+(?::\d+)?)/i.exec(s)?.[1] ?? /^[\w.-]+@([\w.-]+):/.exec(s)?.[1]
   if (host) {
-    if (host.toLowerCase() !== 'gitlab.com') return { defer: true }
+    const lowered = host.toLowerCase()
+    if (lowered !== instance.host && lowered !== instance.hostname) return { defer: true }
     const path = s
       .replace(/^[a-z][a-z0-9+.-]*:\/\/(?:[^/@]+@)?[^/]+\//i, '')
       .replace(/^[\w.-]+@[\w.-]+:/, '')
       .replace(/\.git$/i, '')
       .replace(/\/+$/, '')
-    return path.includes('/') ? { project: path.toLowerCase() } : {}
+    const project = projectPath(path, instance)
+    return project ? { project } : {}
   }
   return {}
+}
+
+/** Whether an operator- or agent-supplied `GITLAB_HOST` still names the deployment's instance. */
+function namesExpectedInstance(value: string, instance: ExpectedInstance): boolean {
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(value) ? value : `https://${value}`
+  const parts = parseManagedBaseUrl(withScheme)
+  if (!parts) return false
+  return parts.host === instance.host && parts.pathPrefix === instance.pathPrefix
 }
 
 export function resolveGlabTargetProject(
   argv: readonly string[],
   env: { GITLAB_REPO?: string; GITLAB_HOST?: string },
-  cwdOrigin: () => string | undefined
+  cwdOrigin: () => string | undefined,
+  expectedHost: string = GITLAB_COM_BASE_URL
 ): { project?: string; defer?: boolean } {
-  // An explicit non-gitlab.com GITLAB_HOST retargets the whole CLI — ours only
-  // answers for gitlab.com, so everything defers to the real glab.
+  // A GITLAB_HOST naming another instance retargets the whole CLI, so everything defers.
+  const instance = expectedInstance(expectedHost)
   const host = nonEmpty(env.GITLAB_HOST)
-  if (host && host.toLowerCase() !== 'gitlab.com') return { defer: true }
+  if (host && !namesExpectedInstance(host, instance)) return { defer: true }
   const candidate = flagRepo(argv) ?? nonEmpty(env.GITLAB_REPO) ?? cwdOrigin()
-  return normalizeProjectArg(candidate)
+  return normalizeProjectArg(candidate, expectedHost)
 }

--- a/packages/daemon/src/cp/relay-client.ts
+++ b/packages/daemon/src/cp/relay-client.ts
@@ -26,7 +26,8 @@ import {
   type RdAgentMsgAck,
   type RdChatEvent,
   type RdWebchatPost,
-  GITLAB_COM_V1_FEATURE
+  GITLAB_COM_V1_FEATURE,
+  GITLAB_INSTANCE_V1_FEATURE
 } from '@agentconnect.md/protocol'
 import { Backoff, ReqRep, WireError, type Clock, type TimerHandle, type Transport } from '@agentconnect.md/connection'
 import type { Logger } from '../log.js'
@@ -46,7 +47,9 @@ const DAEMON_RD_CAPABILITIES: readonly string[] = [
   RD_AGENT_IMPLICIT_ROUTING_V1,
   RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2,
   // The relay gates gitlab rd/msg dispatch on this capability.
-  GITLAB_COM_V1_FEATURE
+  GITLAB_COM_V1_FEATURE,
+  // §24.4: and gates a SELF-MANAGED gitlab delivery on this one, per delivery attempt.
+  GITLAB_INSTANCE_V1_FEATURE
 ]
 
 export type RelayClientState = 'CONNECTING' | 'HELLO' | 'READY' | 'CLOSED' | 'DEGRADED'

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -59,10 +59,11 @@ import {
   assertSafeWorkspaceGitConfig,
   canonicalWorkspaceGitUrl,
   gitCommitIdentityEnv,
-  managedCredentialHostOf,
+  GITHUB_CREDENTIAL_SCOPE,
   pullWorkspaceRef,
   workspaceGitLocalEnv,
-  workspaceGitRemoteTarget
+  workspaceGitRemoteTarget,
+  type ManagedCredentialScope
 } from '../workspace/git-injection.js'
 import { WorkspaceManager } from '../workspace/workspace-manager.js'
 import { GitTransportError, type GitRunner } from '../workspace/git-runner.js'
@@ -207,6 +208,8 @@ export interface WorkspaceGitTarget {
   repo: string
   branch: string
   githubApp: boolean
+  /** The managed host this scope's credential channel pins, resolved from the spec (§24.4). */
+  managed?: ManagedCredentialScope
 }
 
 export function createWorkspaceGit(
@@ -284,18 +287,18 @@ export function createWorkspaceGit(
     agentId: string,
     git: GitRunner,
     repo?: string
-  ): Promise<{ origin: string; branch: string } | undefined> {
+  ): Promise<{ origin: string; branch: string; managed: ManagedCredentialScope } | undefined> {
     const target = await workspaceTargetByAgent(agentId, repo)
     let currentOrigin: string | undefined
     let expectedOrigin: string
     try {
       currentOrigin = safeExplicitOrigin(await git.raw(['remote', 'get-url', 'origin']))
       if (!target) throw new Error('workspace target is unavailable')
-      // Canonicalization follows the PROVIDER HOST, never the managed flag: a github grant is tied
-      // to exactly owner/repo, while a gitlab project keeps its full subgroup namespace.
-      const github = target.githubApp && managedCredentialHostOf(target.repo) !== 'gitlab.com'
+      // Canonicalization follows the spec's PROVIDER: only a gitlab project keeps its subgroups.
+      const provider = target.managed?.host.provider ?? 'github'
+      const github = target.githubApp && provider === 'github'
       expectedOrigin = authorizeWorkspaceGitUrl(
-        canonicalWorkspaceGitUrl(github ? normalizeGithubRepoUrl(target.repo) : target.repo)
+        canonicalWorkspaceGitUrl(github ? normalizeGithubRepoUrl(target.repo) : target.repo, provider)
       )
     } catch {
       return undefined
@@ -303,7 +306,7 @@ export function createWorkspaceGit(
     if (!currentOrigin || (target.githubApp === true && currentOrigin.toLowerCase() !== expectedOrigin.toLowerCase())) {
       return undefined
     }
-    return { origin: expectedOrigin, branch: target.branch }
+    return { origin: expectedOrigin, branch: target.branch, managed: target.managed ?? GITHUB_CREDENTIAL_SCOPE }
   }
 
   /** Shared by `status` and by both index writes, which answer with the fresh status. */
@@ -561,7 +564,11 @@ export function createWorkspaceGit(
         }
         await assertSafeWorkspaceGitConfig(base)
         const pullBranch = authorized.branch
-        const pullTarget = workspaceGitRemoteTarget(authorized.origin, credentialAgentIdFor(agentId, repo))
+        const pullTarget = workspaceGitRemoteTarget(
+          authorized.origin,
+          credentialAgentIdFor(agentId, repo),
+          authorized.managed
+        )
         timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
         const res = await pullWorkspaceRef(
           git.withEnv({
@@ -730,7 +737,11 @@ export function createWorkspaceGit(
         }
         // check-ref-format so a checkout-chosen branch cannot read as an option or a second refspec.
         await git.raw(['check-ref-format', '--branch', branch])
-        const pushTarget = workspaceGitRemoteTarget(authorized.origin, credentialAgentIdFor(agentId, req.repo))
+        const pushTarget = workspaceGitRemoteTarget(
+          authorized.origin,
+          credentialAgentIdFor(agentId, req.repo),
+          authorized.managed
+        )
         timer = setTimeout(() => abort.abort(), PUSH_TIMEOUT_MS)
         // NEVER --force / --force-with-lease: a console push must not drop a commit the remote has
         // and this checkout does not — divergence is data that says "pull first". Both refspec sides

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -210,6 +210,8 @@ export interface WorkspaceGitTarget {
   githubApp: boolean
   /** The managed host this scope's credential channel pins, resolved from the spec (§24.4). */
   managed?: ManagedCredentialScope
+  /** Whose URL conventions this remote follows; absent ⇒ neither provider's (§24.4). */
+  remoteProvider?: 'github' | 'gitlab'
 }
 
 export function createWorkspaceGit(
@@ -294,9 +296,9 @@ export function createWorkspaceGit(
     try {
       currentOrigin = safeExplicitOrigin(await git.raw(['remote', 'get-url', 'origin']))
       if (!target) throw new Error('workspace target is unavailable')
-      // Canonicalization follows the spec's PROVIDER: only a gitlab project keeps its subgroups.
-      const provider = target.managed?.host.provider ?? 'github'
-      const github = target.githubApp && provider === 'github'
+      // Canonicalization follows the remote's PROVIDER: only a gitlab project keeps its subgroups.
+      const provider = target.remoteProvider
+      const github = target.githubApp && provider !== 'gitlab'
       expectedOrigin = authorizeWorkspaceGitUrl(
         canonicalWorkspaceGitUrl(github ? normalizeGithubRepoUrl(target.repo) : target.repo, provider)
       )

--- a/packages/daemon/src/cp/workspace-scope.ts
+++ b/packages/daemon/src/cp/workspace-scope.ts
@@ -121,20 +121,22 @@ export function createWorkspaceScope(deps: WorkspaceScopeDeps): WorkspaceScope {
               repo: root.cloneUrl,
               branch: root.branch,
               githubApp: true,
+              remoteProvider: 'github',
               ...(root.managed ? { managed: root.managed } : {})
             }
           : undefined
       }
       const workspace = agent.workspace
+      if (workspace.mode !== 'git-repo' || !workspace.gitRepo) return undefined
+      const remoteProvider = deps.workspaces.remoteProviderOf(agent, workspace.gitRepo)
       // The flag's name is historical: it means MANAGED credential, gitlab as much as github-app.
-      return workspace.mode === 'git-repo' && workspace.gitRepo
-        ? {
-            repo: workspace.gitRepo,
-            branch: workspace.gitBranch,
-            githubApp: deps.workspaces.usesManagedCredential(agent),
-            managed: deps.workspaces.managedScopeOf(agent)
-          }
-        : undefined
+      return {
+        repo: workspace.gitRepo,
+        branch: workspace.gitBranch,
+        githubApp: deps.workspaces.usesManagedCredential(agent),
+        managed: deps.workspaces.managedScopeOf(agent),
+        ...(remoteProvider !== undefined ? { remoteProvider } : {})
+      }
     },
     usesGithubApp: (agentId, repo) => {
       const agent = deps.agentOf(agentId)

--- a/packages/daemon/src/cp/workspace-scope.ts
+++ b/packages/daemon/src/cp/workspace-scope.ts
@@ -116,7 +116,14 @@ export function createWorkspaceScope(deps: WorkspaceScopeDeps): WorkspaceScope {
         const root = await deps.workspaces.consoleSecondaryRoot(agent, repo)
         // Rows exist only for App-covered repositories, so a secondary root always rides the helper;
         // the branch is the one its `.materialization.json` attests, never the primary's.
-        return root ? { repo: root.cloneUrl, branch: root.branch, githubApp: true } : undefined
+        return root
+          ? {
+              repo: root.cloneUrl,
+              branch: root.branch,
+              githubApp: true,
+              ...(root.managed ? { managed: root.managed } : {})
+            }
+          : undefined
       }
       const workspace = agent.workspace
       // The flag's name is historical: it means MANAGED credential, gitlab as much as github-app.
@@ -124,7 +131,8 @@ export function createWorkspaceScope(deps: WorkspaceScopeDeps): WorkspaceScope {
         ? {
             repo: workspace.gitRepo,
             branch: workspace.gitBranch,
-            githubApp: deps.workspaces.usesManagedCredential(agent)
+            githubApp: deps.workspaces.usesManagedCredential(agent),
+            managed: deps.workspaces.managedScopeOf(agent)
           }
         : undefined
     },

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -56,6 +56,7 @@ import { RemoteWebchatGrantManager } from './mcp/remote-webchat-grant.js'
 import type { CodeHostEffectReq, SetSessionTitleReq } from './mcp/ops.js'
 import { GitCredentialCache } from './cp/git-credential.js'
 import { GitlabBroker } from './gitlab/broker.js'
+import { gitlabApiBaseUrl } from './gitlab/api-base.js'
 import { CodeHostNoteProjector } from './gitlab/note-projection.js'
 import {
   CONFIG_FILE_CONVENTIONS,
@@ -64,18 +65,19 @@ import {
   materializeConfigFiles
 } from './shim/config-file-env.js'
 import { writeGhShim } from './cp/gh-shim.js'
-import { writeGlabShim } from './cp/glab-shim.js'
+import { glabSessionEnv, writeGlabShim } from './cp/glab-shim.js'
 import { GitCredServer, gitcredShimPath, gitcredSocketPath, writeGitcredShim } from './cp/gitcred-server.js'
 import {
   daemonGitCredentialTarget,
   initGitInjection,
+  managedCredentialScope,
   probeGitVersion,
   sandboxGitCredentialTarget,
   sessionGitConfig,
   sessionGitEnv,
   sessionGitPolicyEnv
 } from './workspace/git-injection.js'
-import { configureWorkspaceGitOrigins } from './workspace/git-origin-policy.js'
+import { configureWorkspaceGitOrigins, permitsNoHttpsOrigin } from './workspace/git-origin-policy.js'
 import { buildMcpServers, buildSandboxMcpServers, type McpStdioServer } from './mcp/inject.js'
 import { resolveAgentMcpServers, RESERVED_MCP_SERVER_NAME } from './mcp/resolve-servers.js'
 import { toolsForIntegrations, CODE_HOST_EFFECT_TOOLS, GITHUB_REVIEW_TOOLS, KNOWLEDGE_TOOLS } from './mcp/tools.js'
@@ -266,6 +268,7 @@ import {
   CODEHOST_NOTE_PROJECTION_V1_FEATURE,
   CODEHOST_REVIEW_V1_FEATURE,
   GITLAB_COM_V1_FEATURE,
+  GITLAB_INSTANCE_V1_FEATURE,
   encodeSharedSlackStatusTarget,
   HOOK_REPORT_REASON_AGENT_HANDOVER,
   HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED,
@@ -1582,11 +1585,10 @@ export class Daemon {
     })
     this.cfg = cfg
     configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
-    // §13.2 readiness: an explicit operator policy stays authoritative — but say
-    // plainly when it excludes managed GitLab rather than silently widening it.
-    if (!cfg.security.workspaceGitAllowedOrigins.some((origin) => origin.toLowerCase() === 'https://gitlab.com')) {
+    // §24.4: an excluded origin is named at SPEC admission; only the degenerate case is known here.
+    if (permitsNoHttpsOrigin()) {
       this.log.warn(
-        'workspace policy: workspaceGitAllowedOrigins excludes https://gitlab.com — managed GitLab workspaces will refuse to clone on this daemon'
+        'workspace policy: workspaceGitAllowedOrigins permits no https origin — no managed GitLab workspace can clone on this daemon'
       )
     }
     return { root, cfg }
@@ -1696,10 +1698,12 @@ export class Daemon {
       actionsSupported: () => this.cpClient?.supportsServerFeature?.('gitcred-actions-v1') ?? false,
       providerV2Supported: () => this.cpClient?.supportsServerFeature?.('gitcred-provider-v2') ?? false,
       githubV2Supported: () => this.cpClient?.supportsServerFeature?.(GITCRED_GITHUB_V2_FEATURE) ?? false,
-      gitlabEffectSupported: () => this.cpClient?.supportsServerFeature?.(GITLAB_EFFECT_V1_FEATURE) ?? false
+      gitlabEffectSupported: () => this.cpClient?.supportsServerFeature?.(GITLAB_EFFECT_V1_FEATURE) ?? false,
+      gitlabHostFor: (agentId) => this.agents.get(agentId)?.gitlabHost
     })
     // §14.2: the broker holds the effect lease; the agent environment never sees the token.
     this.gitlabBroker = new GitlabBroker({
+      apiBaseUrl: (target) => this.gitlabApiBase(target.agentId),
       lease: async (target) => {
         const entry = await this.gitCreds.getGitlabEffectToken(target.agentId, target.projectId, target.hookId)
         return { token: entry.token, access: entry.access }
@@ -1709,6 +1713,7 @@ export class Daemon {
     // §16: the same hook-authorized effect lease, on a writer the model never sees or influences.
     this.noteProjector = new CodeHostNoteProjector({
       daemonId: () => this.cfg.daemonId,
+      apiBaseUrl: (row) => this.gitlabApiBase(row.agentId),
       store: {
         getNoteProjection: (daemonId, key) => this.store.getNoteProjection(daemonId, key),
         beginNoteProjectionWrite: (row, now) => this.store.beginNoteProjectionWrite(row, now),
@@ -3503,7 +3508,11 @@ export class Daemon {
     const githubAppCredentials = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'github-app'
     const gitlabCredentials = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'gitlab'
     const managedCredentials = githubAppCredentials || gitlabCredentials
-    const managedCredentialHost = gitlabCredentials ? ('gitlab.com' as const) : ('github.com' as const)
+    // §24.4: the pinned host comes from the SPEC; a non-workspace consumer rides the table beside it.
+    const managedScope = managedCredentialScope(
+      gitlabCredentials ? 'gitlab' : githubAppCredentials ? 'github' : undefined,
+      agent.gitlabHost
+    )
     // The Git session policy runs for every configured repository, not only
     // GitHub review: repository hooks/fsmonitor stay disabled without rewriting
     // checkout config. sessionGitEnv additionally supplies GitHub App identity.
@@ -3524,7 +3533,7 @@ export class Daemon {
     // The daemon-local write (sessionGitEnv) would land the file on this daemon's disk instead.
     const sandboxSessionGit =
       this.k8sPlane && managedCredentials
-        ? sessionGitConfig(agent.id, this.gitCommitIdentity, sandboxGitCredentialTarget(), managedCredentialHost)
+        ? sessionGitConfig(agent.id, this.gitCommitIdentity, sandboxGitCredentialTarget(), managedScope)
         : undefined
     const env: Record<string, string> = {
       ...baseEnv,
@@ -3536,7 +3545,7 @@ export class Daemon {
       // App identity rides with the CREDENTIAL mode, not the workspace mode: a scratch workspace with
       // authorized repositories needs the capability for its git and gh exactly like a clone does.
       ...(managedCredentials
-        ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, this.gitCommitIdentity, managedCredentialHost))
+        ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, this.gitCommitIdentity, managedScope))
         : agent.workspace.mode === 'git-repo'
           ? sessionGitPolicyEnv()
           : {})
@@ -3584,6 +3593,8 @@ export class Daemon {
     if (gitlabCredentials && this.glabBinDir && !this.k8sPlane) {
       // glab wrapper (§13.3): read-only project tokens for the managed workspace.
       env.AC_AGENT_ID = agent.id
+      // §24.4: point the real CLI at the deployment's instance, prefix and port included.
+      Object.assign(env, glabSessionEnv(managedScope.host.baseUrl))
       shimDirs.add(this.glabBinDir)
     }
     if (shimDirs.size > 0) {
@@ -3787,6 +3798,8 @@ export class Daemon {
       ...(this.remoteWebchatGrants ? [WEBCHAT_REMOTE_MCP_FEATURE] : []),
       // The CP withholds gitlab-workspace specs and gitlab hook assignments until this is advertised.
       GITLAB_COM_V1_FEATURE,
+      // §24.4: the instance is resolved from the spec, not assumed; no self-managed work without this.
+      GITLAB_INSTANCE_V1_FEATURE,
       // §16: this daemon renders and updates the run-projection note. The CP leaves the desired
       // generation pending rather than opening a second provider egress path without this bit.
       CODEHOST_NOTE_PROJECTION_V1_FEATURE,
@@ -6640,6 +6653,12 @@ export class Daemon {
     return projectId === undefined ? undefined : { projectId }
   }
 
+  /** The instance every GitLab client on this turn addresses (§24.4). Resolved per turn off the
+   *  agent's replicated spec; the turn-time hook fence is what keeps hook metadata agreeing with it. */
+  private gitlabApiBase(agentId: string): string {
+    return gitlabApiBaseUrl(this.agents.get(agentId)?.gitlabHost)
+  }
+
   /** The agent's managed GitLab workspace project from the REPLICATED SPEC — never a tool argument. */
   private gitlabWorkspaceProject(agentId: string): string | undefined {
     const agent = this.agents.get(agentId)
@@ -6663,6 +6682,7 @@ export class Daemon {
         }
       },
       orgForAgent: (agentId) => this.cpAgents?.orgForAgent(agentId) ?? this.cpCollab.orgForAgent(agentId),
+      apiBaseUrl: (turn) => this.gitlabApiBase(turn.agentId),
       daemonId: () => this.cfg.daemonId,
       store: {
         recordReviewIntent: (row, now) => this.store.recordReviewIntent(row, now),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3508,10 +3508,12 @@ export class Daemon {
     const githubAppCredentials = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'github-app'
     const gitlabCredentials = !excludeAgentToolCredentials && agent.workspace.gitCredential === 'gitlab'
     const managedCredentials = githubAppCredentials || gitlabCredentials
-    // §24.4: the pinned host comes from the SPEC; a non-workspace consumer rides the table beside it.
+    // §24.4: the pinned host comes from the SPEC, and a repo-bearing GitLab consumer that is not
+    // the workspace pins its instance beside it. A dream host gets no tool credentials at all.
     const managedScope = managedCredentialScope(
       gitlabCredentials ? 'gitlab' : githubAppCredentials ? 'github' : undefined,
-      agent.gitlabHost
+      agent.gitlabHost,
+      !excludeAgentToolCredentials && this.workspaces.gitlabRepoBearing(agent)
     )
     // The Git session policy runs for every configured repository, not only
     // GitHub review: repository hooks/fsmonitor stay disabled without rewriting

--- a/packages/daemon/src/gitcred/glab-token-client.ts
+++ b/packages/daemon/src/gitcred/glab-token-client.ts
@@ -7,10 +7,16 @@ import { execFileSync } from 'node:child_process'
 import { createConnection } from 'node:net'
 import { resolveGlabTargetProject } from '../cp/glab-target.js'
 import { GITCRED_CAPABILITY_ENV } from './env.js'
+import { decodeManagedHostTable, GITCRED_HOSTS_ENV, gitlabManagedHost } from './managed-hosts.js'
 
 /** Fetch the read token for this glab invocation and print it — nothing else ever reaches stdout. */
 export async function emitGlabToken(agentId: string, glabArgv: readonly string[], socketPath: string): Promise<void> {
-  const target = resolveGlabTargetProject(glabArgv, process.env, cwdOriginRemote)
+  // The instance comes off the INJECTED table (§24.4), never off an agent-set GITLAB_HOST.
+  const expectedHost = (
+    decodeManagedHostTable(process.env[GITCRED_HOSTS_ENV]).find((entry) => entry.provider === 'gitlab') ??
+    gitlabManagedHost()
+  ).baseUrl
+  const target = resolveGlabTargetProject(glabArgv, process.env, cwdOriginRemote, expectedHost)
   if (target.defer) {
     process.exitCode = 2
     return

--- a/packages/daemon/src/gitcred/helper.ts
+++ b/packages/daemon/src/gitcred/helper.ts
@@ -15,6 +15,11 @@
  * is routing, not authorization — the CP gate decides; token scope enforces
  * the real boundary at GitHub either way.
  *
+ * WHICH hosts are ours comes from the injected table (§24.4), never from two literals and never
+ * from the agent's own environment as a hint: the daemon writes it beside the capability at
+ * injection time, each entry carrying the full base URL, so a prefixed install's path prefix is
+ * stripped before the project path is parsed.
+ *
  * Exit style: on ANY failure print a human-actionable line to stderr and exit 1
  * — since #251 surfaces turn failures to end users, this text is user-facing.
  * NEVER print or log the token outside the protocol response.
@@ -26,6 +31,7 @@
  */
 import { createConnection } from 'node:net'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from './env.js'
+import { decodeManagedHostTable, GITCRED_HOSTS_ENV, matchManagedHost } from './managed-hosts.js'
 
 interface HelperInput {
   protocol?: string
@@ -52,11 +58,13 @@ export async function runGitCredential(action: string, agentId: string, socketPa
   agentId = effectiveAgentId(agentId)
 
   const input = parseStdin(await readStdin())
-  const host = input.host?.toLowerCase()
-  // gitlab.com paths keep their FULL namespaced depth (subgroups, §13.2);
-  // github stays at owner/repo.
-  const gitlab = host === 'gitlab.com'
-  const repo = input.path !== undefined ? (gitlab ? projectFromPath(input.path) : repoFromPath(input.path)) : undefined
+  const match = matchManagedHost(decodeManagedHostTable(process.env[GITCRED_HOSTS_ENV]), input)
+  // GitLab keeps full subgroup depth from the instance's path prefix (§13.2); github stays owner/repo.
+  const gitlab = match?.entry.provider === 'gitlab'
+  const repo = match?.path === undefined ? undefined : gitlab ? projectFromPath(match.path) : repoFromPath(match.path)
+
+  // Not ours — stay silent so git can try other helpers; an absent host still means the workspace.
+  if (input.host !== undefined && match === undefined) return
 
   if (action === 'erase') {
     // Route the invalidation to the same (agent, repo) key the get used.
@@ -71,11 +79,6 @@ export async function runGitCredential(action: string, agentId: string, socketPa
     return
   }
   if (action !== 'get') return // unknown actions are ignored per the helper contract
-
-  if (host !== undefined && host !== 'github.com' && host !== 'gitlab.com') {
-    // Not ours — stay silent so git can try other helpers / fail cleanly.
-    return
-  }
 
   const res = await ipc(socketPath, {
     op: 'get',

--- a/packages/daemon/src/gitcred/managed-hosts.ts
+++ b/packages/daemon/src/gitcred/managed-hosts.ts
@@ -1,0 +1,151 @@
+/**
+ * The injected host→provider table (gitlab-com-integration.md §24.4) and the parsing both ends of
+ * the credential channel share.
+ *
+ * A leaf with NO imports on purpose: the credential helper and the `glab` token entry are bundled
+ * for the sandbox image and may pull in nothing but node builtins, while the daemon writes the same
+ * table at injection time. Each entry carries the FULL normalized base URL — scheme, host,
+ * non-default port, and any path prefix — because with `useHttpPath` a prefixed install hands git a
+ * credential `path` that starts with that prefix, and a bare hostname could not strip it.
+ */
+
+export type ManagedCredentialProvider = 'github' | 'gitlab'
+
+/** One managed code host: the provider plus the normalized base URL its consumers address. */
+export interface ManagedCredentialHost {
+  provider: ManagedCredentialProvider
+  /** Scheme, lower-cased host, non-default port, and any path prefix; never a trailing slash. */
+  baseUrl: string
+}
+
+/** The env name the table travels on, minted beside the capability and agent identity. */
+export const GITCRED_HOSTS_ENV = 'AC_GITCRED_HOSTS'
+
+export const GITHUB_MANAGED_HOST: ManagedCredentialHost = { provider: 'github', baseUrl: 'https://github.com' }
+
+/** The default value of the GitLab host axis (§24.1) — absent is GitLab.com, never a second mode. */
+export const GITLAB_COM_BASE_URL = 'https://gitlab.com'
+
+function trimTrailingSlashes(value: string): string {
+  let end = value.length
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1
+  return value.slice(0, end)
+}
+
+function trimSurroundingSlashes(value: string): string {
+  let start = 0
+  while (start < value.length && value.charCodeAt(start) === 47) start += 1
+  return trimTrailingSlashes(value.slice(start))
+}
+
+/** The GitLab instance a spec's GitLab consumers address; an absent host means GitLab.com (§24.1). */
+export function gitlabManagedHost(gitlabHost?: string): ManagedCredentialHost {
+  const trimmed = trimTrailingSlashes((gitlabHost ?? '').trim())
+  return { provider: 'gitlab', baseUrl: trimmed === '' ? GITLAB_COM_BASE_URL : trimmed }
+}
+
+/** The table one agent's git classifies against: GitHub plus the one GitLab instance its spec names. */
+export function managedHostTableFor(gitlabHost?: string): ManagedCredentialHost[] {
+  return [GITHUB_MANAGED_HOST, gitlabManagedHost(gitlabHost)]
+}
+
+/** `github=https://github.com gitlab=https://gitlab.example.test:8443/gitlab` — space separated,
+ *  which no absolute URL may contain. */
+export function encodeManagedHostTable(hosts: readonly ManagedCredentialHost[]): string {
+  return hosts.map((entry) => `${entry.provider}=${entry.baseUrl}`).join(' ')
+}
+
+/** Absent or unparseable ⇒ the default table, which is what a deployment on GitLab.com means. */
+export function decodeManagedHostTable(raw: string | undefined): ManagedCredentialHost[] {
+  const entries: ManagedCredentialHost[] = []
+  for (const token of (raw ?? '').split(/\s+/)) {
+    const eq = token.indexOf('=')
+    if (eq <= 0) continue
+    const provider = token.slice(0, eq)
+    const baseUrl = trimTrailingSlashes(token.slice(eq + 1))
+    if (provider !== 'github' && provider !== 'gitlab') continue
+    if (parseManagedBaseUrl(baseUrl) === undefined) continue
+    entries.push({ provider, baseUrl })
+  }
+  return entries.length > 0 ? entries : managedHostTableFor()
+}
+
+export interface ManagedBaseUrlParts {
+  /** Lower-cased scheme without the colon, as git spells it on the credential `protocol` line. */
+  protocol: string
+  /** Lower-cased host including a non-default port, as git spells it on the `host` line. */
+  host: string
+  /** Path prefix without surrounding slashes; empty for an instance at the URL root. */
+  pathPrefix: string
+}
+
+export function parseManagedBaseUrl(baseUrl: string): ManagedBaseUrlParts | undefined {
+  const match = /^([a-z][a-z0-9+.-]*):\/\/([^/?#\s]+)(\/[^?#\s]*)?$/i.exec(baseUrl.trim())
+  if (!match) return undefined
+  return {
+    protocol: match[1]!.toLowerCase(),
+    host: match[2]!.toLowerCase(),
+    pathPrefix: trimSurroundingSlashes(match[3] ?? '')
+  }
+}
+
+/**
+ * The request path with the entry's prefix removed on an EXACT segment boundary, or undefined when
+ * the prefix does not apply — a second GitLab at another prefix on the same host is not ours.
+ */
+export function stripHostPathPrefix(path: string, pathPrefix: string): string | undefined {
+  const cleaned = path.replace(/^\/+/, '')
+  if (pathPrefix === '') return cleaned
+  if (!cleaned.startsWith(pathPrefix)) return undefined
+  const rest = cleaned.slice(pathPrefix.length)
+  if (rest === '') return ''
+  if (!rest.startsWith('/')) return undefined
+  return rest.replace(/^\/+/, '')
+}
+
+/** What git hands a credential helper on stdin, as far as routing cares. */
+export interface ManagedHostQuery {
+  protocol?: string
+  host?: string
+  path?: string
+}
+
+export interface ManagedHostMatch {
+  entry: ManagedCredentialHost
+  /** The request path with the entry's prefix stripped; absent when git sent no path. */
+  path?: string
+}
+
+/**
+ * The table entry a credential request belongs to — undefined means "not ours", and the caller must
+ * stay silent rather than guess. Host comparison is exact, so a host that is a prefix or a suffix of
+ * a managed one never matches; among matches the longest applicable path prefix wins.
+ */
+export function matchManagedHost(
+  table: readonly ManagedCredentialHost[],
+  query: ManagedHostQuery
+): ManagedHostMatch | undefined {
+  const protocol = query.protocol?.toLowerCase()
+  const host = query.host?.toLowerCase()
+  if (host === undefined) return undefined
+  let best: ManagedHostMatch | undefined
+  let bestPrefixLength = -1
+  for (const entry of table) {
+    const parts = parseManagedBaseUrl(entry.baseUrl)
+    if (!parts) continue
+    if (parts.host !== host) continue
+    if (protocol !== undefined && protocol !== parts.protocol) continue
+    let path: string | undefined
+    if (query.path !== undefined) {
+      path = stripHostPathPrefix(query.path, parts.pathPrefix)
+      if (path === undefined) continue
+    } else if (parts.pathPrefix !== '') {
+      // A prefixed install cannot be recognized without the path git was asked for.
+      continue
+    }
+    if (parts.pathPrefix.length <= bestPrefixLength) continue
+    bestPrefixLength = parts.pathPrefix.length
+    best = { entry, ...(path !== undefined ? { path } : {}) }
+  }
+  return best
+}

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -10,6 +10,7 @@
  */
 import { randomUUID } from 'node:crypto'
 import {
+  GITLAB_DEFAULT_BASE_URL,
   normalizeGitCloneUrl,
   normalizeGithubRepoUrl,
   type GithubHookMetadata,
@@ -18,6 +19,7 @@ import {
   type RdMsgHook
 } from '@agentconnect.md/protocol'
 import type { Agent } from '../agents/agent-schema.js'
+import { gitlabApiBaseUrl } from '../gitlab/api-base.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import type { AcpHost } from '../acp/acp-host.js'
 import type { CpClient } from '../cp/client.js'
@@ -53,6 +55,7 @@ import { initiatorLabel } from '../workspace/session-branch.js'
 import type { PrepareSessionWorkspaceRequest } from '../workspace/workspace-manager.js'
 import { GithubFinalPoster, GithubReplyCollector, type GithubCommentAttribution } from './poster.js'
 import { GitlabFinalPoster } from '../gitlab/poster.js'
+import { GITLAB_HOST_MISMATCH_REASON } from '../gitlab/host-fence.js'
 import { GithubReviewClient, type GithubReviewEffect } from './review.js'
 
 /** Dispatch options this seam needs; a subset of the daemon's own. */
@@ -172,9 +175,21 @@ export class GithubReviewOrchestrator {
   async dispatchRelayHook(msg: RdMsgHook): Promise<RdAck> {
     const cleanup = githubThreadWorktreeCleanup(msg)
     const maintenance = cleanup !== undefined || githubDeletedHookEvent(msg)
-    if (!this.agents.has(msg.agentId)) {
+    const agent = this.agents.get(msg.agentId)
+    if (!agent) {
       this.log.warn(`hook: no agent "${msg.agentId}" on this daemon — rejecting fire ${msg.msgId}`)
       return { msgId: msg.msgId, accepted: false, reason: 'no_agent' }
+    }
+    // §24.4: a delivery naming another instance than the spec is REFUSED, never re-targeted.
+    if (msg.gitlab !== undefined) {
+      const expected = agent.gitlabHost ?? GITLAB_DEFAULT_BASE_URL
+      const delivered = msg.gitlab.host ?? GITLAB_DEFAULT_BASE_URL
+      if (delivered !== expected) {
+        this.log.warn(
+          `hook: fire ${msg.msgId} for agent "${msg.agentId}" names gitlab instance ${delivered} but its spec is bound to ${expected} — refusing`
+        )
+        return { msgId: msg.msgId, accepted: false, reason: GITLAB_HOST_MISMATCH_REASON }
+      }
     }
     if (!maintenance && this.host.paused(msg.agentId)) {
       this.log.info(`hook: agent "${msg.agentId}" is paused — rejecting fire ${msg.msgId}`)
@@ -938,6 +953,8 @@ export class GithubReviewOrchestrator {
           {
             token: async () => (await this.host.getGitlabPostToken(agentId, ref.repo, ref.hookId)).token,
             invalidateToken: (token) => this.host.invalidateGitlabPost(agentId, ref.repo, token),
+            // §24.4: the instance this agent's spec names, read when the note is actually posted.
+            apiBaseUrl: () => gitlabApiBaseUrl(this.agents.get(agentId)?.gitlabHost),
             log: { warn: (m: string) => this.log.warn(m) }
           },
           ref.repo,

--- a/packages/daemon/src/gitlab/api-base.ts
+++ b/packages/daemon/src/gitlab/api-base.ts
@@ -1,0 +1,16 @@
+/**
+ * The `/api/v4` root of the one GitLab instance a deployment talks to (gitlab-com-integration.md
+ * §24.1, §24.4).
+ *
+ * Composed by CONCATENATION onto the normalized base, never by URL resolution against an absolute
+ * path, which silently discards a path prefix. Every daemon client resolves this PER TURN from the
+ * host its spec or its trusted hook metadata carries: a deployment has exactly one instance, so the
+ * value is constant, but reading it per turn is what keeps the host a data dependency rather than a
+ * boot-time constant nothing can re-target.
+ */
+import { GITLAB_DEFAULT_BASE_URL } from '@agentconnect.md/protocol'
+
+export function gitlabApiBaseUrl(host?: string): string {
+  const trimmed = host?.trim()
+  return `${trimmed ? trimmed.replace(/\/+$/, '') : GITLAB_DEFAULT_BASE_URL}/api/v4`
+}

--- a/packages/daemon/src/gitlab/broker.ts
+++ b/packages/daemon/src/gitlab/broker.ts
@@ -123,7 +123,8 @@ export interface GitlabBrokerDeps {
   lease: (target: GitlabBrokerTarget) => Promise<GitlabBrokerLease>
   /** Drop a cached lease GitLab just rejected (401/403) so the single retry re-mints. */
   invalidateLease?: (target: GitlabBrokerTarget, token: string) => void
-  baseUrl?: string
+  /** The instance's `/api/v4` root for THIS target's agent, resolved per turn (§24.4). */
+  apiBaseUrl: (target: GitlabBrokerTarget) => string
   fetchImpl?: typeof fetch
 }
 
@@ -398,7 +399,7 @@ export class GitlabBroker {
     const doFetch = this.deps.fetchImpl ?? fetch
     const search = new URLSearchParams(plan.query ?? {}).toString()
     const path = renderPath(endpoint.path, plan.params)
-    const url = `${this.deps.baseUrl ?? 'https://gitlab.com/api/v4'}${path}${search ? `?${search}` : ''}`
+    const url = `${this.deps.apiBaseUrl(target)}${path}${search ? `?${search}` : ''}`
     let current = lease
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const res = await doFetch(url, {

--- a/packages/daemon/src/gitlab/host-fence.ts
+++ b/packages/daemon/src/gitlab/host-fence.ts
@@ -1,0 +1,9 @@
+/**
+ * The named refusal a turn-time GitLab host disagreement takes (gitlab-com-integration.md §24.4).
+ *
+ * A hook may reach an ALREADY-RUNNING session whose environment cannot be retroactively edited: its
+ * credential git-config block, injected helper table and `GITLAB_HOST` export were all established
+ * at spawn for the instance the spec named. So a delivery whose trusted metadata names another
+ * instance is refused under this reason and never re-targeted.
+ */
+export const GITLAB_HOST_MISMATCH_REASON = 'gitlab_host_mismatch'

--- a/packages/daemon/src/gitlab/note-projection.ts
+++ b/packages/daemon/src/gitlab/note-projection.ts
@@ -39,7 +39,6 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 /** Unsettled rows retry on the projector's own clock: a healthy control socket never triggers a sweep. */
 const DEFAULT_RESWEEP_BASE_MS = 30_000
 const DEFAULT_RESWEEP_CAP_MS = 300_000
-const DEFAULT_BASE_URL = 'https://gitlab.com/api/v4'
 /** The projection is a comment-class effect, so the hook-authorized lease must clamp at least here. */
 const REQUIRED_CAPABILITY: BrokerCapability = 'comment'
 const CAPABILITY_RANK: Record<BrokerCapability, number> = { read: 0, comment: 1, write: 2 }
@@ -168,7 +167,8 @@ export interface CodeHostNoteProjectorDeps {
   scheduler?: PosterScheduler
   resweepBaseMs?: number
   resweepCapMs?: number
-  baseUrl?: string
+  /** The instance's `/api/v4` root for THIS projection's agent, resolved per turn (§24.4). */
+  apiBaseUrl: (input: { agentId: string; projectId: string }) => string
   fetchImpl?: typeof fetch
   requestTimeoutMs?: number
 }
@@ -512,7 +512,9 @@ export class CodeHostNoteProjector {
     let readopted = false
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const path = target === undefined ? this.notesPath(row) : `${this.notesPath(row)}/${encodeURIComponent(target)}`
-      const res = await this.call(target === undefined ? 'POST' : 'PUT', path, current.token, { body: row.body })
+      const res = await this.call(row, target === undefined ? 'POST' : 'PUT', path, current.token, {
+        body: row.body
+      })
       if (res.kind === 'unavailable') return { kind: 'ambiguous', code: res.code }
       if (res.status >= 200 && res.status < 300) {
         const id = noteIdOf(idFromBody(res.body))
@@ -555,7 +557,7 @@ export class CodeHostNoteProjector {
   ): Promise<{ kind: 'resolved'; noteId?: string } | { kind: 'unavailable' }> {
     const marker = projectionMarker(row.projectionKey)
     for (let page = 1; page <= MAX_LIST_PAGES; page += 1) {
-      const res = await this.call('GET', `${this.notesPath(row)}?per_page=${LIST_PAGE_SIZE}&page=${page}`, token)
+      const res = await this.call(row, 'GET', `${this.notesPath(row)}?per_page=${LIST_PAGE_SIZE}&page=${page}`, token)
       if (res.kind === 'unavailable' || res.status < 200 || res.status >= 300) return { kind: 'unavailable' }
       let notes: unknown
       try {
@@ -581,6 +583,7 @@ export class CodeHostNoteProjector {
 
   /** One bounded provider call. A timeout or transport error is UNAVAILABLE, never a no-effect answer. */
   private async call(
+    row: NoteProjectionRow,
     method: 'GET' | 'POST' | 'PUT',
     path: string,
     token: string,
@@ -590,7 +593,7 @@ export class CodeHostNoteProjector {
     const abort = new AbortController()
     const timer = setTimeout(() => abort.abort(), this.deps.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS)
     try {
-      const res = await doFetch(`${this.deps.baseUrl ?? DEFAULT_BASE_URL}${path}`, {
+      const res = await doFetch(`${this.deps.apiBaseUrl(row)}${path}`, {
         method,
         headers: {
           'private-token': token,

--- a/packages/daemon/src/gitlab/poster.ts
+++ b/packages/daemon/src/gitlab/poster.ts
@@ -23,7 +23,8 @@ export interface GitlabFinalPosterDeps {
   /** Drop a cached token GitLab just rejected (401/403) so the retry re-mints. */
   invalidateToken?: (token: string) => void
   log: { warn: (message: string) => void }
-  baseUrl?: string
+  /** The instance's `/api/v4` root, resolved per turn from the spec or hook metadata (§24.4). */
+  apiBaseUrl: () => string
   fetchImpl?: typeof fetch
   scheduler?: PosterScheduler
   finalizeTimeoutMs?: number
@@ -121,7 +122,7 @@ export class GitlabFinalPoster {
         this.abandonTimedOut()
         return
       }
-      const res = await doFetch(`${this.deps.baseUrl ?? 'https://gitlab.com/api/v4'}${notePath}`, {
+      const res = await doFetch(`${this.deps.apiBaseUrl()}${notePath}`, {
         method: 'POST',
         headers: {
           'private-token': token,

--- a/packages/daemon/src/gitlab/review-adapter.ts
+++ b/packages/daemon/src/gitlab/review-adapter.ts
@@ -109,7 +109,8 @@ export interface GitlabReviewAdapterDeps {
   invalidateToken: (turn: GitlabReviewTurn, token: string) => void
   attribution?: (turn: GitlabReviewTurn) => Promise<GithubCommentAttribution | undefined>
   log: { warn: (message: string) => void }
-  baseUrl?: string
+  /** The instance's `/api/v4` root for THIS turn's agent, resolved per turn (§24.4). */
+  apiBaseUrl: (turn: GitlabReviewTurn) => string
   fetchImpl?: typeof fetch
   newAttemptId?: () => string
   newStartToken?: () => string
@@ -136,7 +137,6 @@ export interface GitlabReviewOutcome {
   externalIds?: CodeHostReviewExternalRef[]
 }
 
-const DEFAULT_BASE_URL = 'https://gitlab.com/api/v4'
 const DEFAULT_TIMEOUT_MS = 20_000
 const DEFAULT_AMBIGUOUS_WINDOW_MS = 30_000
 const DEFAULT_MERGE_STATUS_WINDOW_MS = 30_000
@@ -1108,7 +1108,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
       await this.markOperationStarted(attempt, issued.recordId)
       let result: SendResult
       try {
-        result = await this.send(method, target, undefined, body, attempt.token)
+        result = await this.send(method, target, undefined, body, attempt.token, attempt.turn)
       } catch (err) {
         if (err instanceof AmbiguousSend) {
           await this.settleAndClear(cp, attempt, issued.recordId, { kind: 'ambiguous', code: err.code }, true)
@@ -1555,7 +1555,7 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     for (let tries = 0; tries < 2; tries += 1) {
       let result: SendResult
       try {
-        result = await this.send('GET', path, query, undefined, session.token)
+        result = await this.send('GET', path, query, undefined, session.token, session.turn)
       } catch {
         throw new Error(`GitLab GET ${path} did not complete`)
       }
@@ -1574,10 +1574,11 @@ export class GitlabReviewAdapter implements CodeHostReviewAdapter {
     path: string,
     query: string | undefined,
     body: Record<string, unknown> | undefined,
-    token: string
+    token: string,
+    turn: GitlabReviewTurn
   ): Promise<SendResult> {
     const doFetch = this.deps.fetchImpl ?? fetch
-    const url = `${this.deps.baseUrl ?? DEFAULT_BASE_URL}${path}${query ? `?${query}` : ''}`
+    const url = `${this.deps.apiBaseUrl(turn)}${path}${query ? `?${query}` : ''}`
     let response: Response
     try {
       response = await doFetch(url, {

--- a/packages/daemon/src/runtimes/runtime-install-repair.ts
+++ b/packages/daemon/src/runtimes/runtime-install-repair.ts
@@ -80,6 +80,8 @@ const NPM_ENV_ALLOWLIST = [
   'NODE_EXTRA_CA_CERTS',
   'SSL_CERT_DIR',
   'SSL_CERT_FILE',
+  // A git-backed dependency reaches its remote through git's own bundle (§24.5).
+  'GIT_SSL_CAINFO',
   'SystemRoot',
   'ComSpec',
   'PATHEXT',

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -30,7 +30,9 @@ const CERTIFICATE_ENV_KEYS = new Set([
   'SSL_CERT_DIR',
   'NODE_EXTRA_CA_CERTS',
   'REQUESTS_CA_BUNDLE',
-  'CURL_CA_BUNDLE'
+  'CURL_CA_BUNDLE',
+  // A probe may fetch through git; the same operator bundle has to reach it (§24.5).
+  'GIT_SSL_CAINFO'
 ])
 const PROVIDER_ENV_KEYS = new Set([
   'OPENAI_API_KEY',

--- a/packages/daemon/src/skills/skill-git-source.ts
+++ b/packages/daemon/src/skills/skill-git-source.ts
@@ -8,6 +8,7 @@ import { workspaceGitOriginOf, type AgentSkillEntry } from '@agentconnect.md/pro
 import { extract as extractTar, list as listTar, type ReadEntry } from 'tar'
 import { authorizeWorkspaceGitUrl } from '../workspace/git-origin-policy.js'
 import { cloneGitEnv, workspaceGitEnvBase } from '../workspace/git-injection.js'
+import { TLS_TRUST_ENV } from '../config/tls-trust-env.js'
 
 const GITHUB_SHORTHAND = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/
 const GITHUB_TREE = /^\/([^/]+)\/([^/]+)\/tree\/([^/]+)(?:\/(.*))?$/
@@ -185,8 +186,7 @@ export function buildSkillGitAcquisitionEnv(opts: {
     if (
       upper.startsWith('GIT_') ||
       upper.startsWith('AC_GITCRED_') ||
-      upper === 'SSL_CERT_FILE' ||
-      upper === 'SSL_CERT_DIR' ||
+      TLS_TRUST_ENV.includes(upper as (typeof TLS_TRUST_ENV)[number]) ||
       upper === 'LANG' ||
       upper === 'LC_ALL'
     ) {

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -356,6 +356,14 @@ export interface ManagedCredentialScope {
   host: ManagedCredentialHost
   /** The GitLab instance this spec's GitLab consumers address, for the injected classifier table. */
   gitlabHost?: string
+  /**
+   * The spec carries a REPO-BEARING GitLab consumer — a gitlab workspace, or at least one gitlab
+   * additional-repository authorization (§24.4). Such an agent already accepts that the managed
+   * identity owns that instance's credential path, so the session config pins the helper there too.
+   * A hook-only host does NOT set this: a hook holds no repository authorization, so pinning would
+   * cut the agent's ambient credentials with nothing to serve in their place.
+   */
+  gitlabRepoBearing?: boolean
 }
 
 /** Anonymous and github-app operations both pin github.com; only a gitlab consumer moves the axis. */
@@ -371,10 +379,29 @@ function scopeHostTable(scope: ManagedCredentialScope): ManagedCredentialHost[] 
 
 export function managedCredentialScope(
   provider: 'github' | 'gitlab' | undefined,
-  gitlabHost?: string
+  gitlabHost?: string,
+  gitlabRepoBearing = false
 ): ManagedCredentialScope {
   const host = provider === 'gitlab' ? gitlabManagedHost(gitlabHost) : GITHUB_MANAGED_HOST
-  return { host, ...(gitlabHost !== undefined ? { gitlabHost } : {}) }
+  return {
+    host,
+    ...(gitlabHost !== undefined ? { gitlabHost } : {}),
+    // A gitlab workspace is repo-bearing by construction; the flag only adds the other consumer.
+    ...(gitlabRepoBearing || provider === 'gitlab' ? { gitlabRepoBearing: true } : {})
+  }
+}
+
+/**
+ * The hosts the SESSION config pins the helper for: the operation's own host, plus the GitLab
+ * instance when the spec carries a repo-bearing consumer that is not the workspace (§24.4). Only
+ * the session channel widens — a daemon-run clone, fetch or push always knows its exact target.
+ */
+function sessionCredentialBases(scope: ManagedCredentialScope): string[] {
+  const bases = [scope.host.baseUrl]
+  if (scope.gitlabRepoBearing !== true || scope.host.provider === 'gitlab') return bases
+  const instance = gitlabManagedHost(scope.gitlabHost).baseUrl
+  if (instance !== scope.host.baseUrl) bases.push(instance)
+  return bases
 }
 
 /**
@@ -558,15 +585,17 @@ export function sessionGitConfig(
   scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE
 ): { path: string; content: string; env: Record<string, string> } {
   const file = join(target.configDir, `${agentId}.gitconfig`)
-  const base = scope.host.baseUrl
+  const bases = sessionCredentialBases(scope)
   const lines = [
     '# agentconnect session git config — regenerated on agent start; NO secrets.',
-    `# Keeps non-identity host config, then pins ${base} credentials to the daemon helper.`,
+    `# Keeps non-identity host config, then pins ${bases.join(' + ')} credentials to the daemon helper.`,
     ...(target.hostConfig ? ['[include]', `\tpath = ${target.hostConfig}`] : []),
-    `[credential "${base}"]`,
-    '\thelper = ', // reset the accumulated helper list for this host
-    `\thelper = ${quotedHelper(agentId, target)}`,
-    '\tuseHttpPath = true',
+    ...bases.flatMap((base) => [
+      `[credential "${base}"]`,
+      '\thelper = ', // reset the accumulated helper list for this host
+      `\thelper = ${quotedHelper(agentId, target)}`,
+      '\tuseHttpPath = true'
+    ]),
     ''
   ]
   return {

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -31,10 +31,21 @@ import { randomUUID } from 'node:crypto'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { tlsTrustEnv } from '../config/tls-trust-env.js'
 import type { GitPullSummary, GitRunner } from './git-runner.js'
 import { simpleGit, type SimpleGit } from 'simple-git'
 import { normalizeGitCloneUrl, type GitCommitIdentity } from '@agentconnect.md/protocol'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV, GITCRED_SOCKET_ENV } from '../cp/gitcred-server.js'
+import {
+  encodeManagedHostTable,
+  gitlabManagedHost,
+  GITCRED_HOSTS_ENV,
+  GITHUB_MANAGED_HOST,
+  managedHostTableFor,
+  parseManagedBaseUrl,
+  stripHostPathPrefix,
+  type ManagedCredentialHost
+} from '../gitcred/managed-hosts.js'
 import { SANDBOX_GIT_CONFIG_DIR, SANDBOX_GIT_CREDENTIAL_HELPER } from '../shim/sandbox-paths.js'
 import { SANDBOX_TUNNEL_PATHS } from '../shim/tunnel.js'
 
@@ -87,6 +98,8 @@ const HOST_ENV_STRIP = new Set([
   GITCRED_CAPABILITY_ENV,
   GITCRED_AGENT_ENV,
   GITCRED_SOCKET_ENV,
+  // The managed-host table is WRITTEN at injection time; an inherited value is never a hint.
+  GITCRED_HOSTS_ENV,
   'EDITOR',
   'VISUAL',
   'PAGER',
@@ -172,6 +185,8 @@ function workspaceGitProcessEnv(): Record<string, string> {
   env.GIT_GRAFT_FILE = EMPTY_GIT_CONFIG
   env.GIT_LFS_SKIP_SMUDGE = '1'
   env.GIT_NO_LAZY_FETCH = '1'
+  // §24.5: re-assert the operator's authority bundle so a later narrowing cannot break TLS trust.
+  Object.assign(env, tlsTrustEnv())
   return env
 }
 
@@ -250,15 +265,14 @@ export function workspaceGitEnvBase(repository?: string): Record<string, string>
  */
 export function workspaceGitRemoteTarget(
   repository: string,
-  credentialAgentId?: string
+  credentialAgentId?: string,
+  scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE
 ): { remote: string; env: Record<string, string> } {
   const normalized = normalizeGitCloneUrl(repository)
   const remote = `agentconnect-${randomUUID()}`
   const pairs = [
     ...workspaceGitConfigPairs(normalized),
-    ...(credentialAgentId
-      ? credentialConfigPairs(credentialAgentId, managedCredentialHostOf(normalized) ?? 'github.com')
-      : []),
+    ...(credentialAgentId ? credentialConfigPairs(credentialAgentId, scope) : []),
     // Never an empty value first: Git reads it as the first fetch URL and fails before the authorized target.
     [`remote.${remote}.url`, normalized] as const,
     [`remote.${remote}.proxy`, ''] as const
@@ -270,7 +284,7 @@ export function workspaceGitRemoteTarget(
     env: {
       ...env,
       ...gitConfigEnv(pairs),
-      ...(credentialAgentId ? gitCredentialEnv(credentialAgentId) : {}),
+      ...(credentialAgentId ? gitCredentialEnv(credentialAgentId, targetOf(credentialAgentId), scope) : {}),
       // A missing credential must fail immediately rather than block on a prompt nobody answers.
       GIT_TERMINAL_PROMPT: '0'
     }
@@ -332,24 +346,65 @@ export async function pullWorkspaceRef(git: GitRunner, remote: string, branch: s
   return git.pull(remote, refspec, ['--ff-only', '--no-recurse-submodules'])
 }
 
-/** The managed-credential hosts the helper may answer for (§13.2: exact origins). */
-export type ManagedCredentialHost = 'github.com' | 'gitlab.com'
+/**
+ * How one agent's git reaches its managed hosts (§13.2, §24.4). Resolved from the REPLICATED SPEC —
+ * the provider decides which host the credential config block pins, and `gitlabHost` decides that
+ * host's address. A clone URL is checked against the result, never the source of it.
+ */
+export interface ManagedCredentialScope {
+  /** The host the `credential.<base>` block pins for this operation. */
+  host: ManagedCredentialHost
+  /** The GitLab instance this spec's GitLab consumers address, for the injected classifier table. */
+  gitlabHost?: string
+}
 
-/** Which managed host a workspace repository URL belongs to; undefined ⇒ neither. */
-export function managedCredentialHostOf(repository: string | undefined): ManagedCredentialHost | undefined {
-  if (!repository) return undefined
+/** Anonymous and github-app operations both pin github.com; only a gitlab consumer moves the axis. */
+export const GITHUB_CREDENTIAL_SCOPE: ManagedCredentialScope = { host: GITHUB_MANAGED_HOST }
+
+export { GITHUB_MANAGED_HOST, gitlabManagedHost }
+export type { ManagedCredentialHost }
+
+/** The classifier table an injection carries: GitHub plus the one GitLab instance the scope names. */
+function scopeHostTable(scope: ManagedCredentialScope): ManagedCredentialHost[] {
+  return managedHostTableFor(scope.gitlabHost ?? (scope.host.provider === 'gitlab' ? scope.host.baseUrl : undefined))
+}
+
+export function managedCredentialScope(
+  provider: 'github' | 'gitlab' | undefined,
+  gitlabHost?: string
+): ManagedCredentialScope {
+  const host = provider === 'gitlab' ? gitlabManagedHost(gitlabHost) : GITHUB_MANAGED_HOST
+  return { host, ...(gitlabHost !== undefined ? { gitlabHost } : {}) }
+}
+
+/**
+ * Whether a remote address sits on the scope's managed host — the address is CHECKED against the
+ * resolved host, never the source of it. A prefixed instance matches only on an exact segment
+ * boundary, so a neighbouring path root on the same host does not. Transport-agnostic, like the
+ * host comparison it replaces: an `scp` or `ssh` remote of the same host is still that host's.
+ */
+export function originOnManagedHost(input: string, host: ManagedCredentialHost): boolean {
+  const base = parseManagedBaseUrl(host.baseUrl)
+  if (!base) return false
+  const raw = input.trim()
+  if (raw.includes('\\')) return false
+  const scp = /^[\w.-]+@([\w.-]+):(.*)$/.exec(raw)
+  if (scp) return scp[1]!.toLowerCase() === base.host && stripHostPathPrefix(scp[2]!, base.pathPrefix) !== undefined
+  if (!/^(?:https|ssh):\/\//i.test(raw)) return false
   try {
-    const host = new URL(normalizeGitCloneUrl(repository)).host.toLowerCase()
-    return host === 'github.com' ? 'github.com' : host === 'gitlab.com' ? 'gitlab.com' : undefined
+    const parsed = new URL(normalizeGitCloneUrl(raw))
+    return (
+      parsed.host.toLowerCase() === base.host && stripHostPathPrefix(parsed.pathname, base.pathPrefix) !== undefined
+    )
   } catch {
-    return undefined
+    return false
   }
 }
 
-// The address daemon Git may dial: gitlab.com 301s the suffix-less HTTPS probe and we refuse redirects, so its remote carries `.git`.
-export function canonicalWorkspaceGitUrl(repository: string): string {
+// GitLab 301s the suffix-less HTTPS probe and we refuse redirects, so a gitlab remote carries `.git`.
+export function canonicalWorkspaceGitUrl(repository: string, provider?: 'github' | 'gitlab'): string {
   const normalized = normalizeGitCloneUrl(repository)
-  if (managedCredentialHostOf(normalized) !== 'gitlab.com') return normalized
+  if (provider !== 'gitlab') return normalized
   if (!/^https:/i.test(normalized) || /\.git$/i.test(normalized)) return normalized
   return `${normalized}.git`
 }
@@ -433,12 +488,15 @@ function targetOf(agentId: string): GitCredentialTarget {
  *  derive a daemon root it does not have. */
 export function gitCredentialEnv(
   agentId: string,
-  target: GitCredentialTarget = targetOf(agentId)
+  target: GitCredentialTarget = targetOf(agentId),
+  scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE
 ): Record<string, string> {
   if (!capabilityFor) throw new Error('git credential injection is not initialized')
   return {
     [GITCRED_CAPABILITY_ENV]: capabilityFor(agentId),
     [GITCRED_AGENT_ENV]: agentId,
+    // §24.4: which hosts are ours is injected, never sniffed by the helper from two literals.
+    [GITCRED_HOSTS_ENV]: encodeManagedHostTable(scopeHostTable(scope)),
     ...(target.socketPath ? { [GITCRED_SOCKET_ENV]: target.socketPath } : {})
   }
 }
@@ -449,13 +507,17 @@ function quotedHelper(agentId: string, target: GitCredentialTarget = targetOf(ag
 }
 
 /** The three host-scoped config pairs both channels share. The host defaults to
- *  github.com; a gitlab workspace pins gitlab.com instead (§13.2) — never both,
+ *  github.com; a gitlab workspace pins its instance base instead (§13.2, §24.4) — never both,
  *  so a non-gitlab agent keeps whatever machine gitlab credentials exist. */
-function credentialConfigPairs(agentId: string, host: ManagedCredentialHost = 'github.com'): Array<[string, string]> {
+function credentialConfigPairs(
+  agentId: string,
+  scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE
+): Array<[string, string]> {
+  const base = scope.host.baseUrl
   return [
-    [`credential.https://${host}.helper`, ''], // reset: machine helpers must never answer for this host
-    [`credential.https://${host}.helper`, quotedHelper(agentId)],
-    [`credential.https://${host}.useHttpPath`, 'true'] // git strips `path` otherwise — the helper wants it
+    [`credential.${base}.helper`, ''], // reset: machine helpers must never answer for this host
+    [`credential.${base}.helper`, quotedHelper(agentId)],
+    [`credential.${base}.useHttpPath`, 'true'] // git strips `path` otherwise — the helper wants it
   ]
 }
 
@@ -464,13 +526,14 @@ function credentialConfigPairs(agentId: string, host: ManagedCredentialHost = 'g
  * Spread over `process.env` by the caller: simple-git's `.env()` REPLACES the
  * child environment (v3.36 verified), a bare object would strip PATH/HOME.
  */
-export function cloneGitEnv(agentId: string, repository?: string): Record<string, string> {
-  const pairs = [
-    ...workspaceGitConfigPairs(repository),
-    ...credentialConfigPairs(agentId, managedCredentialHostOf(repository) ?? 'github.com')
-  ]
+export function cloneGitEnv(
+  agentId: string,
+  repository?: string,
+  scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE
+): Record<string, string> {
+  const pairs = [...workspaceGitConfigPairs(repository), ...credentialConfigPairs(agentId, scope)]
   const env: Record<string, string> = {
-    ...gitCredentialEnv(agentId),
+    ...gitCredentialEnv(agentId, targetOf(agentId), scope),
     GIT_TERMINAL_PROMPT: '0',
     ...gitConfigEnv(pairs)
   }
@@ -492,14 +555,15 @@ export function sessionGitConfig(
   // Explicit for a spawn that KNOWS where the runtime will run (a --k8s launch always lands in the
   // pod), so the env cannot depend on whether the shim channel happens to be attached right now.
   target: GitCredentialTarget = targetOf(agentId),
-  host: ManagedCredentialHost = 'github.com'
+  scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE
 ): { path: string; content: string; env: Record<string, string> } {
   const file = join(target.configDir, `${agentId}.gitconfig`)
+  const base = scope.host.baseUrl
   const lines = [
     '# agentconnect session git config — regenerated on agent start; NO secrets.',
-    `# Keeps non-identity host config, then pins ${host} credentials to the daemon helper.`,
+    `# Keeps non-identity host config, then pins ${base} credentials to the daemon helper.`,
     ...(target.hostConfig ? ['[include]', `\tpath = ${target.hostConfig}`] : []),
-    `[credential "https://${host}"]`,
+    `[credential "${base}"]`,
     '\thelper = ', // reset the accumulated helper list for this host
     `\thelper = ${quotedHelper(agentId, target)}`,
     '\tuseHttpPath = true',
@@ -509,7 +573,7 @@ export function sessionGitConfig(
     path: file,
     content: lines.join('\n'),
     env: {
-      ...gitCredentialEnv(agentId, target),
+      ...gitCredentialEnv(agentId, target, scope),
       ...sessionGitPolicyEnv(),
       GIT_CONFIG_GLOBAL: file,
       GIT_TERMINAL_PROMPT: '0',
@@ -529,12 +593,12 @@ export function sessionGitConfig(
 export function sessionGitEnv(
   agentId: string,
   commitIdentity?: GitCommitIdentity,
-  host: ManagedCredentialHost = 'github.com'
+  scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE
 ): Record<string, string> {
   if (targetOf(agentId).kind !== 'daemon') {
     throw new Error(`agent ${agentId} runs its git in a sandbox — materialize its gitconfig instead of writing it`)
   }
-  const { path: file, content, env } = sessionGitConfig(agentId, commitIdentity, targetOf(agentId), host)
+  const { path: file, content, env } = sessionGitConfig(agentId, commitIdentity, targetOf(agentId), scope)
   mkdirSync(dirname(file), { recursive: true, mode: 0o700 })
   writeFileSync(file, content, { mode: 0o644 })
   return env
@@ -557,14 +621,15 @@ export function gitCommitIdentityEnv(identity: GitCommitIdentity): Record<string
 export async function writeRepoHelperConfig(
   runner: GitRunner,
   agentId: string,
-  host: ManagedCredentialHost = 'github.com'
+  scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE
 ): Promise<void> {
   const git = runner.withEnv(workspaceGitLocalEnv())
+  const base = scope.host.baseUrl
   // `--replace-all` on the first write resets any stale helper list from a
   // previous agent generation; addConfig(append=true) accumulates the rest.
-  await git.raw(['config', '--replace-all', `credential.https://${host}.helper`, ''])
-  await git.raw(['config', '--add', `credential.https://${host}.helper`, quotedHelper(agentId)])
-  await git.raw(['config', `credential.https://${host}.useHttpPath`, 'true'])
+  await git.raw(['config', '--replace-all', `credential.${base}.helper`, ''])
+  await git.raw(['config', '--add', `credential.${base}.helper`, quotedHelper(agentId)])
+  await git.raw(['config', `credential.${base}.useHttpPath`, 'true'])
 }
 
 /** Pre-warm hook for workspace-manager (no-op until initialized). */

--- a/packages/daemon/src/workspace/git-origin-policy.ts
+++ b/packages/daemon/src/workspace/git-origin-policy.ts
@@ -1,7 +1,8 @@
 import {
   DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
   normalizeAllowedWorkspaceGitUrl,
-  normalizeWorkspaceGitOrigin
+  normalizeWorkspaceGitOrigin,
+  workspaceGitOriginOf
 } from '@agentconnect.md/protocol'
 
 // One daemon runs per process. Keep the operator-owned policy beside the
@@ -15,4 +16,29 @@ export function configureWorkspaceGitOrigins(origins: readonly string[]): void {
 /** Final daemon boundary for every tenant-selected workspace network target. */
 export function authorizeWorkspaceGitUrl(input: string): string {
   return normalizeAllowedWorkspaceGitUrl(input, allowedOrigins)
+}
+
+/**
+ * The origin a workspace repository needs but the operator policy excludes; undefined when the
+ * policy admits it (§24.4). The operator allowlist stays authoritative — the managed GitLab feature
+ * allows exactly the configured origin and never widens the list — so a spec naming an excluded
+ * instance is refused by NAMING the origin an operator has to add.
+ */
+export function unauthorizedWorkspaceGitOrigin(repository: string): string | undefined {
+  try {
+    authorizeWorkspaceGitUrl(repository)
+    return undefined
+  } catch {
+    try {
+      return workspaceGitOriginOf(repository)
+    } catch {
+      return undefined // not a clone address at all; the clone boundary reports that on its own
+    }
+  }
+}
+
+/** True when no HTTPS origin is permitted at all: managed GitLab is HTTPS-only (§13.2), so on such
+ *  a daemon no GitLab instance — GitLab.com or self-managed — can ever be cloned. */
+export function permitsNoHttpsOrigin(): boolean {
+  return !allowedOrigins.some((origin) => origin.toLowerCase().startsWith('https://'))
 }

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -36,6 +36,7 @@ import {
   workspaceGitRemoteTarget,
   writeRepoHelperConfig,
   GITHUB_CREDENTIAL_SCOPE,
+  gitlabManagedHost,
   managedCredentialScope,
   originOnManagedHost,
   type ManagedCredentialScope
@@ -293,6 +294,18 @@ export class WorkspaceManager {
     return managedCredentialScope(this.managedCredentialProvider(agent), agent.gitlabHost)
   }
 
+  /**
+   * Whose URL conventions a remote follows. The spec's credential provider answers for a managed
+   * workspace; an ANONYMOUS remote has no provider on the spec, so its address is CHECKED against
+   * the deployment's GitLab instance (§24.4) — a public clone from that instance still needs
+   * GitLab's `.git` suffix rule, and checking is not the same as sniffing a host out of the URL.
+   */
+  remoteProviderOf(agent: Agent, repository: string): 'github' | 'gitlab' | undefined {
+    const managed = this.managedCredentialProvider(agent)
+    if (managed !== undefined) return managed
+    return originOnManagedHost(repository, gitlabManagedHost(agent.gitlabHost)) ? 'gitlab' : undefined
+  }
+
   gitRepoOf(agent: Agent): string {
     if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) {
       throw new Error(`workspace clone: agent "${agent.id}" has git-repo mode but no gitRepo configured`)
@@ -300,7 +313,7 @@ export class WorkspaceManager {
     return authorizeWorkspaceGitUrl(
       canonicalWorkspaceGitUrl(
         this.usesGithubApp(agent) ? normalizeGithubRepoUrl(agent.workspace.gitRepo) : agent.workspace.gitRepo,
-        this.managedCredentialProvider(agent)
+        this.remoteProviderOf(agent, agent.workspace.gitRepo)
       )
     )
   }
@@ -860,7 +873,7 @@ export class WorkspaceManager {
     if (agent.workspace.mode === 'from-scratch') return JSON.stringify({ mode: 'scratch' })
     const repo = this.gitRepoOf(agent)
     // Both providers treat `.git` as the same repository, so neither canonicalization may replace a checkout over an access-only edit.
-    const suffixInsensitive = this.managedCredentialProvider(agent) !== undefined
+    const suffixInsensitive = this.remoteProviderOf(agent, agent.workspace.gitRepo ?? '') !== undefined
     return JSON.stringify({
       mode: 'github',
       repo: (suffixInsensitive ? repo.replace(/\.git$/i, '') : repo).toLowerCase(),

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -35,7 +35,10 @@ import {
   workspaceGitLocalEnv,
   workspaceGitRemoteTarget,
   writeRepoHelperConfig,
-  managedCredentialHostOf
+  GITHUB_CREDENTIAL_SCOPE,
+  managedCredentialScope,
+  originOnManagedHost,
+  type ManagedCredentialScope
 } from './git-injection.js'
 import { LocalGitRunner, type GitRunner } from './git-runner.js'
 import { localWorkspaceFs, type WorkspaceFs, type WorkspacePlacement } from './workspace-fs.js'
@@ -91,6 +94,8 @@ export interface WorkspaceRoot {
   worktreesPath: string
   /** Credentials ride the github-app helper (vs anonymous). */
   githubApp: boolean
+  /** The managed host this root's credential channel pins, resolved from the spec (§24.4). */
+  managed?: ManagedCredentialScope
 }
 
 /** One authorized additional repository as a root beside the primary (design decision 1). */
@@ -282,13 +287,20 @@ export class WorkspaceManager {
     return this.managedCredentialProvider(agent) !== undefined
   }
 
+  /** The credential scope this agent's primary workspace pins: its provider plus the spec's
+   *  GitLab instance (§24.4). Anonymous workspaces resolve to github.com, as they always did. */
+  managedScopeOf(agent: Agent): ManagedCredentialScope {
+    return managedCredentialScope(this.managedCredentialProvider(agent), agent.gitlabHost)
+  }
+
   gitRepoOf(agent: Agent): string {
     if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) {
       throw new Error(`workspace clone: agent "${agent.id}" has git-repo mode but no gitRepo configured`)
     }
     return authorizeWorkspaceGitUrl(
       canonicalWorkspaceGitUrl(
-        this.usesGithubApp(agent) ? normalizeGithubRepoUrl(agent.workspace.gitRepo) : agent.workspace.gitRepo
+        this.usesGithubApp(agent) ? normalizeGithubRepoUrl(agent.workspace.gitRepo) : agent.workspace.gitRepo,
+        this.managedCredentialProvider(agent)
       )
     )
   }
@@ -309,8 +321,9 @@ export class WorkspaceManager {
       path: mount === undefined ? agent.workspace.path : this.clusterWorkspaceCheckout(agent, mount),
       worktreesPath: this.worktreesPathAt(agent, mount),
       // The MANAGED-credential flag (name is historical): a gitlab workspace
-      // rides the same helper pin/pre-warm/clone-env paths, host-derived.
-      githubApp: this.usesManagedCredential(agent)
+      // rides the same helper pin/pre-warm/clone-env paths, spec-derived.
+      githubApp: this.usesManagedCredential(agent),
+      managed: this.managedScopeOf(agent)
     }
   }
 
@@ -375,7 +388,8 @@ export class WorkspaceManager {
           branch: '',
           path: join(base, 'checkout'),
           worktreesPath: join(base, 'worktrees'),
-          githubApp: true
+          githubApp: true,
+          managed: GITHUB_CREDENTIAL_SCOPE
         })
       } catch (err) {
         workspaceLog.warn(
@@ -715,7 +729,7 @@ export class WorkspaceManager {
   async resolveRemoteDefaultBranch(agentId: string, root: SecondaryWorkspaceRoot): Promise<string> {
     if (root.githubApp) await preWarmGitCred(agentId, 'clone')
     const env = root.githubApp
-      ? { ...workspaceGitEnvBase(root.cloneUrl), ...cloneGitEnv(agentId, root.cloneUrl) }
+      ? { ...workspaceGitEnvBase(root.cloneUrl), ...cloneGitEnv(agentId, root.cloneUrl, root.managed) }
       : { ...workspaceGitEnvBase(root.cloneUrl), GIT_TERMINAL_PROMPT: '0' }
     const abort = new AbortController()
     const timer = setTimeout(() => abort.abort(), LS_REMOTE_TIMEOUT_MS)
@@ -731,20 +745,10 @@ export class WorkspaceManager {
     }
   }
 
-  /** A managed root's origin must stay on ITS provider host, derived from the
-   *  authorized clone URL (github.com unless the root is a gitlab.com one). */
-  isTrustedManagedOrigin(input: string, cloneUrl: string): boolean {
-    const host = managedCredentialHostOf(cloneUrl) ?? 'github.com'
-    const raw = input.trim()
-    if (raw.includes('\\')) return false
-    const scp = /^[\w.-]+@([\w.-]+):/.exec(raw)
-    if (scp) return scp[1]!.toLowerCase() === host
-    if (!/^(?:https|ssh):\/\//i.test(raw)) return false
-    try {
-      return new URL(normalizeGitCloneUrl(redactGitUrlSecrets(raw))).hostname.toLowerCase() === host
-    } catch {
-      return false
-    }
+  /** A managed root's origin must stay on the host its SPEC resolved (§24.4), never on a host
+   *  read back out of the checkout. A prefixed instance additionally pins the path prefix. */
+  isTrustedManagedOrigin(input: string, scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE): boolean {
+    return originOnManagedHost(redactGitUrlSecrets(input), scope.host)
   }
 
   isTrustedGithubOrigin(input: string): boolean {
@@ -833,9 +837,8 @@ export class WorkspaceManager {
       if (root.githubApp) throw new UntrustedGithubWorkspaceOriginError({ cause })
       return
     }
-    // Managed roots trust exactly their provider's host: a gitlab root's
-    // origin must be gitlab.com, a github one github.com (§13.2).
-    if (root.githubApp && !this.isTrustedManagedOrigin(current, root.cloneUrl)) {
+    // Managed roots trust exactly the host their spec resolved (§13.2, §24.4).
+    if (root.githubApp && !this.isTrustedManagedOrigin(current, root.managed)) {
       throw new UntrustedGithubWorkspaceOriginError()
     }
     const normalizedCurrent = normalizeGitUrl(current)
@@ -856,8 +859,8 @@ export class WorkspaceManager {
   materializationKey(agent: Agent): string {
     if (agent.workspace.mode === 'from-scratch') return JSON.stringify({ mode: 'scratch' })
     const repo = this.gitRepoOf(agent)
-    // Both hosts treat `.git` as the same repository, so neither canonicalization may replace a checkout over an access-only edit.
-    const suffixInsensitive = this.usesGithubApp(agent) || managedCredentialHostOf(repo) === 'gitlab.com'
+    // Both providers treat `.git` as the same repository, so neither canonicalization may replace a checkout over an access-only edit.
+    const suffixInsensitive = this.managedCredentialProvider(agent) !== undefined
     return JSON.stringify({
       mode: 'github',
       repo: (suffixInsensitive ? repo.replace(/\.git$/i, '') : repo).toLowerCase(),
@@ -977,7 +980,7 @@ export class WorkspaceManager {
     const timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
     try {
       await assertSafeWorkspaceGitConfig(this.runnerFor(agentId, cwd))
-      const pullTarget = workspaceGitRemoteTarget(root.cloneUrl, root.githubApp ? agentId : undefined)
+      const pullTarget = workspaceGitRemoteTarget(root.cloneUrl, root.githubApp ? agentId : undefined, root.managed)
       const git = this.runnerFor(agentId, cwd, abort.signal).withEnv({
         ...workspaceGitLocalEnv(),
         ...pullTarget.env
@@ -1028,11 +1031,7 @@ export class WorkspaceManager {
       // The CP follows repository renames by numeric repo id. Repoint the existing
       // checkout instead of treating that canonical URL refresh as a new workspace.
       await this.convergeWorkspaceOrigin(agent, cwd)
-      await writeRepoHelperConfig(
-        this.runnerFor(agent.id, cwd),
-        agent.id,
-        managedCredentialHostOf(root.cloneUrl) ?? 'github.com'
-      ).catch(() => undefined)
+      await writeRepoHelperConfig(this.runnerFor(agent.id, cwd), agent.id, root.managed).catch(() => undefined)
     } else {
       // Historical anonymous checkouts may still have credential-bearing or
       // disallowed origins even after their CP row has been sanitized.
@@ -1410,7 +1409,7 @@ export class WorkspaceManager {
     const mergeRef = `${refRoot}/merge`
     await assertSafeWorkspaceGitConfig(this.runnerFor(agentId, root.path))
     if (root.githubApp) await preWarmGitCred(agentId, 'pull')
-    const pullTarget = workspaceGitRemoteTarget(root.cloneUrl, root.githubApp ? agentId : undefined)
+    const pullTarget = workspaceGitRemoteTarget(root.cloneUrl, root.githubApp ? agentId : undefined, root.managed)
     const abort = new AbortController()
     const timer = setTimeout(() => abort.abort(), REVIEW_FETCH_TIMEOUT_MS)
     try {
@@ -1809,11 +1808,9 @@ export class WorkspaceManager {
       // `.git/config`, whose agent id goes stale when an agent is recreated over a surviving volume.
       await this.convergeOriginInPlace(agent, checkout)
       if (githubApp) {
-        await writeRepoHelperConfig(
-          this.runnerFor(agent.id, checkout),
-          agent.id,
-          managedCredentialHostOf(repository) ?? 'github.com'
-        ).catch(() => undefined)
+        await writeRepoHelperConfig(this.runnerFor(agent.id, checkout), agent.id, this.managedScopeOf(agent)).catch(
+          () => undefined
+        )
       }
     }
 
@@ -1824,7 +1821,11 @@ export class WorkspaceManager {
       const timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
       try {
         await assertSafeWorkspaceGitConfig(this.runnerFor(agent.id, checkout))
-        const pullTarget = workspaceGitRemoteTarget(repository, githubApp ? agent.id : undefined)
+        const pullTarget = workspaceGitRemoteTarget(
+          repository,
+          githubApp ? agent.id : undefined,
+          this.managedScopeOf(agent)
+        )
         const git = this.runnerFor(agent.id, checkout, abort.signal).withEnv({
           ...workspaceGitLocalEnv(),
           ...pullTarget.env
@@ -1959,7 +1960,7 @@ export class WorkspaceManager {
     const githubApp = this.usesManagedCredential(agent)
     if (githubApp) await preWarmGitCred(agent.id, 'clone')
     const env = githubApp
-      ? { ...workspaceGitEnvBase(repository), ...cloneGitEnv(agent.id, repository) }
+      ? { ...workspaceGitEnvBase(repository), ...cloneGitEnv(agent.id, repository, this.managedScopeOf(agent)) }
       : { ...workspaceGitEnvBase(repository), GIT_TERMINAL_PROMPT: '0' }
     try {
       await this.runnerFor(agent.id, root)
@@ -1972,11 +1973,7 @@ export class WorkspaceManager {
       throw err
     }
     if (githubApp) {
-      await writeRepoHelperConfig(
-        this.runnerFor(agent.id, checkout),
-        agent.id,
-        managedCredentialHostOf(repository) ?? 'github.com'
-      )
+      await writeRepoHelperConfig(this.runnerFor(agent.id, checkout), agent.id, this.managedScopeOf(agent))
     }
   }
 
@@ -2259,14 +2256,17 @@ export class WorkspaceManager {
     const inflight = this.cloneInFlight.get(key)
     if (inflight) return inflight
 
-    const { cloneUrl, branch, githubApp } = root
+    const { cloneUrl, branch, githubApp, managed } = root
 
     const p = (async () => {
       // github-app: credentials ride the env-injected helper (no repo config exists
       // yet). SPREAD over process.env — withEnv REPLACES the child env, as .env() did.
       if (githubApp) await preWarmGitCred(agentId, 'clone')
       const git = githubApp
-        ? this.runnerFor(agentId).withEnv({ ...workspaceGitEnvBase(cloneUrl), ...cloneGitEnv(agentId, cloneUrl) })
+        ? this.runnerFor(agentId).withEnv({
+            ...workspaceGitEnvBase(cloneUrl),
+            ...cloneGitEnv(agentId, cloneUrl, managed)
+          })
         : this.runnerFor(agentId).withEnv({ ...workspaceGitEnvBase(cloneUrl), GIT_TERMINAL_PROMPT: '0' })
       try {
         await git.clone(cloneUrl, cwd, ['--branch', branch, '--single-branch'])
@@ -2280,11 +2280,7 @@ export class WorkspaceManager {
       // through the daemon too — the "no credentials on the machine, but the agent
       // can still push" half of the design.
       if (githubApp) {
-        await writeRepoHelperConfig(
-          this.runnerFor(agentId, cwd),
-          agentId,
-          managedCredentialHostOf(cloneUrl) ?? 'github.com'
-        )
+        await writeRepoHelperConfig(this.runnerFor(agentId, cwd), agentId, managed)
       }
     })().finally(() => {
       this.cloneInFlight.delete(key)

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -288,10 +288,24 @@ export class WorkspaceManager {
     return this.managedCredentialProvider(agent) !== undefined
   }
 
+  /**
+   * Whether the spec carries a REPO-BEARING GitLab consumer (§24.4): a gitlab workspace, or an
+   * authorized gitlab additional repository. A hook is deliberately not one — it authorizes a turn,
+   * not a repository, so it must not take over the instance's credential path.
+   */
+  gitlabRepoBearing(agent: Agent): boolean {
+    if (this.managedCredentialProvider(agent) === 'gitlab') return true
+    return (agent.workspace.additionalRepos ?? []).some((row) => (row.provider ?? 'github') === 'gitlab')
+  }
+
   /** The credential scope this agent's primary workspace pins: its provider plus the spec's
    *  GitLab instance (§24.4). Anonymous workspaces resolve to github.com, as they always did. */
   managedScopeOf(agent: Agent): ManagedCredentialScope {
-    return managedCredentialScope(this.managedCredentialProvider(agent), agent.gitlabHost)
+    return managedCredentialScope(
+      this.managedCredentialProvider(agent),
+      agent.gitlabHost,
+      this.gitlabRepoBearing(agent)
+    )
   }
 
   /**

--- a/packages/daemon/test/codehost-note-projection.test.ts
+++ b/packages/daemon/test/codehost-note-projection.test.ts
@@ -217,7 +217,7 @@ function projector(
     scheduler: clock.sched,
     resweepBaseMs: RESWEEP_BASE_MS,
     resweepCapMs: RESWEEP_CAP_MS,
-    baseUrl: 'https://gitlab.example.test/api/v4',
+    apiBaseUrl: () => 'https://gitlab.example.test/api/v4',
     fetchImpl
   })
   return { projector, results, invalidated, clock, mints: () => mint }

--- a/packages/daemon/test/cp/gitlab-gitcred.test.ts
+++ b/packages/daemon/test/cp/gitlab-gitcred.test.ts
@@ -9,7 +9,12 @@ import { describe, it, expect } from 'vitest'
 import type { GitCredGrant } from '@agentconnect.md/protocol'
 import { GitCredentialCache, GitCredUnavailableError } from '../../src/cp/git-credential.js'
 import { projectFromPath, repoFromPath } from '../../src/gitcred/helper.js'
-import { initGitInjection, managedCredentialHostOf, sessionGitConfig } from '../../src/workspace/git-injection.js'
+import {
+  GITHUB_CREDENTIAL_SCOPE,
+  initGitInjection,
+  managedCredentialScope,
+  sessionGitConfig
+} from '../../src/workspace/git-injection.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const HOOK = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
@@ -128,27 +133,28 @@ describe('helper path parsing (§13.2)', () => {
       'https://gitlab.com/example-group/example-project',
       'https://gitlab.com/example-group/example-project.git'
     ]) {
-      const path = new URL(canonicalWorkspaceGitUrl(configured)).pathname
+      const path = new URL(canonicalWorkspaceGitUrl(configured, 'gitlab')).pathname
       expect(path).toBe('/example-group/example-project.git')
       expect(projectFromPath(path)).toBe('example-group/example-project')
     }
-    const subgroup = new URL(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/sub/deeper/proj')).pathname
+    const subgroup = new URL(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/sub/deeper/proj', 'gitlab'))
+      .pathname
     expect(projectFromPath(subgroup)).toBe('example-group/sub/deeper/proj')
     expect(projectFromPath(`${subgroup}/info/lfs`)).toBe('example-group/sub/deeper/proj')
   })
 })
 
 describe('managed origin convergence trust (round 2)', () => {
-  it('a managed root trusts exactly ITS provider host', async () => {
+  it('a managed root trusts exactly the host its SPEC resolved', async () => {
     const { WorkspaceManager } = await import('../../src/workspace/workspace-manager.js')
     const wm = new WorkspaceManager()
-    const gitlabRoot = 'https://gitlab.com/example-group/example-project'
-    expect(wm.isTrustedManagedOrigin('https://gitlab.com/example-group/example-project.git', gitlabRoot)).toBe(true)
-    expect(wm.isTrustedManagedOrigin('git@gitlab.com:example-group/example-project.git', gitlabRoot)).toBe(true)
-    expect(wm.isTrustedManagedOrigin('https://github.com/acme/infra.git', gitlabRoot)).toBe(false)
-    const githubRoot = 'https://github.com/acme/infra'
-    expect(wm.isTrustedManagedOrigin('https://github.com/acme/infra.git', githubRoot)).toBe(true)
-    expect(wm.isTrustedManagedOrigin('https://gitlab.com/g/p.git', githubRoot)).toBe(false)
+    const gitlab = managedCredentialScope('gitlab')
+    expect(wm.isTrustedManagedOrigin('https://gitlab.com/example-group/example-project.git', gitlab)).toBe(true)
+    expect(wm.isTrustedManagedOrigin('git@gitlab.com:example-group/example-project.git', gitlab)).toBe(true)
+    expect(wm.isTrustedManagedOrigin('https://github.com/acme/infra.git', gitlab)).toBe(false)
+    const github = managedCredentialScope('github')
+    expect(wm.isTrustedManagedOrigin('https://github.com/acme/infra.git', github)).toBe(true)
+    expect(wm.isTrustedManagedOrigin('https://gitlab.com/g/p.git', github)).toBe(false)
   })
 })
 
@@ -160,15 +166,17 @@ describe('injection host selection (§13.2)', () => {
     capabilityFor: () => 'cap-test'
   })
 
-  it('derives the managed host from the workspace URL, exactly one per workspace', () => {
-    expect(managedCredentialHostOf('https://gitlab.com/example-group/example-project')).toBe('gitlab.com')
-    expect(managedCredentialHostOf('https://github.com/acme/infra')).toBe('github.com')
-    expect(managedCredentialHostOf('https://code.example.test/x/y')).toBeUndefined()
-    expect(managedCredentialHostOf(undefined)).toBeUndefined()
+  it('derives the managed host from the SPEC provider and host, not from the clone URL', () => {
+    expect(managedCredentialScope('gitlab').host.baseUrl).toBe('https://gitlab.com')
+    expect(managedCredentialScope('github').host.baseUrl).toBe('https://github.com')
+    expect(managedCredentialScope('gitlab', 'https://gitlab.example.test:8443/gitlab').host.baseUrl).toBe(
+      'https://gitlab.example.test:8443/gitlab'
+    )
+    expect(managedCredentialScope(undefined)).toEqual(GITHUB_CREDENTIAL_SCOPE)
   })
 
   it('pins the session gitconfig to the workspace host only', () => {
-    const gitlab = sessionGitConfig(AGENT, undefined, target, 'gitlab.com')
+    const gitlab = sessionGitConfig(AGENT, undefined, target, managedCredentialScope('gitlab'))
     expect(gitlab.content).toContain('[credential "https://gitlab.com"]')
     expect(gitlab.content).not.toContain('github.com')
     const github = sessionGitConfig(AGENT, undefined, target)

--- a/packages/daemon/test/cp/relay-client.test.ts
+++ b/packages/daemon/test/cp/relay-client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   buildRelayDaemonFrame,
   GITLAB_COM_V1_FEATURE,
+  GITLAB_INSTANCE_V1_FEATURE,
   RD_HEADLESS_AGENT_DELIVERY_V1,
   RD_AGENT_IMPLICIT_ROUTING_V1,
   RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2,
@@ -113,7 +114,8 @@ describe('RelayClient (daemon → one relay)', () => {
         RD_HEADLESS_AGENT_DELIVERY_V1,
         RD_AGENT_IMPLICIT_ROUTING_V1,
         RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2,
-        GITLAB_COM_V1_FEATURE
+        GITLAB_COM_V1_FEATURE,
+        GITLAB_INSTANCE_V1_FEATURE
       ]
     })
     expect(client.state).toBe('READY')

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -29,6 +29,7 @@ import {
   UNTRUSTED_CONTENT_END
 } from '../src/messages/hook-message.js'
 import { GithubReplyCollector } from '../src/github/poster.js'
+import { GITLAB_HOST_MISMATCH_REASON } from '../src/gitlab/host-fence.js'
 import { NO_ACTIVE_REVIEW_TURN } from '../src/codehost/review-adapter.js'
 import { transcriptCoords } from '../src/session/session-manager.js'
 import { DatabaseSync } from 'node:sqlite'
@@ -3451,6 +3452,74 @@ describe('Daemon rd/msg hook fires', () => {
     expect(secondAnchor.postMessage).not.toHaveBeenCalled()
     await second.stop()
   }, 15_000)
+
+  // §24.4: the host is established at spawn — the credential git-config block, the injected helper
+  // table and the `GITLAB_HOST` export — so a hook reaching an already-running session may not
+  // re-target it. A disagreement between the spec and the delivery is refused under its own reason.
+  describe('the turn-time gitlab host fence (§24.4)', () => {
+    const INSTANCE = 'https://gitlab.example.test:8443/gitlab'
+    const hostedFire = (host?: string): RdMsgHook => {
+      const base = gitlabFire()
+      return { ...base, gitlab: { ...base.gitlab!, ...(host !== undefined ? { host } : {}) } }
+    }
+
+    it.each([
+      { name: 'the delivery means GitLab.com but the spec names an instance', spec: INSTANCE, delivered: undefined },
+      { name: 'the delivery names an instance but the spec means GitLab.com', spec: undefined, delivered: INSTANCE },
+      {
+        name: 'the two name different instances',
+        spec: INSTANCE,
+        delivered: 'https://gitlab.other.test'
+      }
+    ])(
+      'refuses a warm session when $name',
+      async ({ spec, delivered }) => {
+        const { factory } = streamingHost()
+        const daemon = new Daemon({
+          slackAppFactory: fakeSlackAppFactory(),
+          root: scaffold(spec === undefined ? undefined : { gitlabHost: spec }),
+          hostFactory: factory
+        })
+        await daemon.start()
+        const cp = fakeCpClient()
+        ;(daemon as never as { cpClient: unknown }).cpClient = cp
+
+        const ack = await (daemon as any).handleRelayMsg(hostedFire(delivered), () => {})
+
+        expect(ack).toEqual({
+          msgId: `${HOOK_ID}:d-1`,
+          accepted: false,
+          reason: GITLAB_HOST_MISMATCH_REASON
+        })
+        expect(cp.hookReports).toHaveLength(0)
+        await daemon.stop()
+      },
+      15_000
+    )
+
+    it('accepts the delivery whose host the spec agrees with, prefix and port included', async () => {
+      const { factory } = streamingHost()
+      const daemon = new Daemon({
+        slackAppFactory: fakeSlackAppFactory(),
+        root: scaffold({ gitlabHost: INSTANCE }),
+        hostFactory: factory
+      })
+      await daemon.start()
+      const cp = fakeCpClient()
+      ;(daemon as never as { cpClient: unknown }).cpClient = cp
+      ;(daemon as any).githubReviews.makeGithubReply = vi.fn(() => ({
+        poster: { publish: vi.fn(async () => ({ provider: 'gitlab', kind: 'note', externalId: '9001' })) },
+        collector: new GithubReplyCollector()
+      }))
+
+      const ack = await (daemon as any).handleRelayMsg(hostedFire(INSTANCE), () => {})
+
+      expect(ack).toEqual({ msgId: `${HOOK_ID}:d-1`, accepted: true })
+      await vi.waitFor(() => expect(cp.hookReports).toHaveLength(1), WAIT)
+      expect(cp.hookReports[0]).toMatchObject({ status: 'success' })
+      await daemon.stop()
+    }, 15_000)
+  })
 })
 
 describe('buildHookMessage', () => {

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -598,43 +598,53 @@ describe('cloneGitEnv', () => {
 })
 
 describe('canonicalWorkspaceGitUrl', () => {
-  // gitlab.com 301s the suffix-less ref probe to the `.git` form and daemon Git pins http.followRedirects=false.
-  it('gives a gitlab.com HTTPS remote its `.git` form, at any subgroup depth', () => {
-    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project')).toBe(
+  // GitLab 301s the suffix-less ref probe to the `.git` form and daemon Git pins http.followRedirects=false.
+  it('gives a gitlab HTTPS remote its `.git` form, at any subgroup depth and on any host', () => {
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project', 'gitlab')).toBe(
       'https://gitlab.com/example-group/example-project.git'
     )
-    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/sub/deeper/example-project')).toBe(
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/sub/deeper/example-project', 'gitlab')).toBe(
       'https://gitlab.com/example-group/sub/deeper/example-project.git'
     )
     // A trailing slash is the same repository, so it must not produce `…/.git`.
-    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project/')).toBe(
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project/', 'gitlab')).toBe(
       'https://gitlab.com/example-group/example-project.git'
     )
+    // §24.4: the suffix rule keys on the PROVIDER, so a self-managed instance gets it too.
+    expect(
+      canonicalWorkspaceGitUrl('https://gitlab.example.test:8443/gitlab/example-group/example-project', 'gitlab')
+    ).toBe('https://gitlab.example.test:8443/gitlab/example-group/example-project.git')
   })
 
   it('is idempotent: a remote that already carries the suffix is left exactly as configured', () => {
-    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project.git')).toBe(
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project.git', 'gitlab')).toBe(
       'https://gitlab.com/example-group/example-project.git'
     )
     // Git matches the suffix case-insensitively; appending a second one would name a different path.
-    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project.GIT')).toBe(
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project.GIT', 'gitlab')).toBe(
       'https://gitlab.com/example-group/example-project.GIT'
     )
   })
 
-  it('leaves github and every non-gitlab HTTPS remote byte-identical', () => {
-    expect(canonicalWorkspaceGitUrl('https://github.com/acme/infra')).toBe('https://github.com/acme/infra')
-    expect(canonicalWorkspaceGitUrl('https://github.com/acme/infra.git')).toBe('https://github.com/acme/infra.git')
+  it('leaves every non-gitlab provider byte-identical, whatever host the URL names', () => {
+    expect(canonicalWorkspaceGitUrl('https://github.com/acme/infra', 'github')).toBe('https://github.com/acme/infra')
+    expect(canonicalWorkspaceGitUrl('https://github.com/acme/infra.git', 'github')).toBe(
+      'https://github.com/acme/infra.git'
+    )
     expect(canonicalWorkspaceGitUrl('https://code.example.test/acme/infra')).toBe(
       'https://code.example.test/acme/infra'
+    )
+    // An anonymous workspace on a gitlab-looking host is not a gitlab CONSUMER, so no suffix.
+    expect(canonicalWorkspaceGitUrl('https://gitlab.com/example-group/example-project')).toBe(
+      'https://gitlab.com/example-group/example-project'
     )
   })
 
   it('leaves gitlab SSH alone — only the HTTPS ref probe redirects', () => {
-    expect(canonicalWorkspaceGitUrl('ssh://git@gitlab.com/example-group/example-project')).toBe(
+    expect(canonicalWorkspaceGitUrl('ssh://git@gitlab.com/example-group/example-project', 'gitlab')).toBe(
       'ssh://git@gitlab.com/example-group/example-project'
     )
-    expect(canonicalWorkspaceGitUrl('git@gitlab.com:example-group/example-project')).toBe(
+    expect(canonicalWorkspaceGitUrl('git@gitlab.com:example-group/example-project', 'gitlab')).toBe(
       'git@gitlab.com:example-group/example-project'
     )
   })

--- a/packages/daemon/test/gitlab-broker.test.ts
+++ b/packages/daemon/test/gitlab-broker.test.ts
@@ -57,7 +57,7 @@ function broker(
   const instance = new GitlabBroker({
     lease: async () => ({ token: tokens[Math.min(minted++, tokens.length - 1)]!, access: opts.access ?? 'write' }),
     invalidateLease: (_target, token) => opts.invalidate?.(token),
-    baseUrl: BASE,
+    apiBaseUrl: () => BASE,
     fetchImpl
   })
   return { instance, minted: () => minted }

--- a/packages/daemon/test/gitlab-poster.test.ts
+++ b/packages/daemon/test/gitlab-poster.test.ts
@@ -71,6 +71,7 @@ function poster(
       token: deps.token ?? (async () => 'glpat-effect'),
       ...(deps.invalidateToken ? { invalidateToken: deps.invalidateToken } : {}),
       log,
+      apiBaseUrl: () => 'https://gitlab.com/api/v4',
       fetchImpl: deps.fetchImpl,
       scheduler: fakeScheduler({ ...(deps.fireDeadline ? { fireDeadline: true } : {}) }).sched
     },

--- a/packages/daemon/test/gitlab-review-adapter.test.ts
+++ b/packages/daemon/test/gitlab-review-adapter.test.ts
@@ -463,7 +463,7 @@ function harness(
     },
     invalidateToken: (_turn, token) => void invalidated.push(token),
     log: { warn: () => {} },
-    baseUrl: BASE,
+    apiBaseUrl: () => BASE,
     fetchImpl: gitlab.fetchImpl,
     newAttemptId: () => attemptIds[Math.min(mintedAttempts++, attemptIds.length - 1)]!,
     newStartToken: () => `start-${control.ops.filter((op) => op.op === 'issue').length}`,

--- a/packages/daemon/test/gitlab-self-managed-git.test.ts
+++ b/packages/daemon/test/gitlab-self-managed-git.test.ts
@@ -165,13 +165,18 @@ function serveGitcred(path: string): { server: Server; requests: Record<string, 
   return { server, requests }
 }
 
+// A CI runner has no global git identity, so every commit here supplies its own — both halves,
+// since git refuses on the committer as readily as on the author.
+const COMMIT_IDENTITY = {
+  GIT_AUTHOR_NAME: 'a',
+  GIT_AUTHOR_EMAIL: 'a@example.test',
+  GIT_COMMITTER_NAME: 'a',
+  GIT_COMMITTER_EMAIL: 'a@example.test'
+}
+
 /** Local-only git: nothing here reaches the instance, so a blocking call is safe. */
 function git(cwd: string, args: string[]): string {
-  return execFileSync('git', args, {
-    cwd,
-    encoding: 'utf8',
-    env: { ...process.env, GIT_AUTHOR_NAME: 'a', GIT_AUTHOR_EMAIL: 'a@example.test' }
-  })
+  return execFileSync('git', args, { cwd, encoding: 'utf8', env: { ...process.env, ...COMMIT_IDENTITY } })
 }
 
 // The instance, the gitcred socket and the test all live in ONE process, so every command that has

--- a/packages/daemon/test/gitlab-self-managed-git.test.ts
+++ b/packages/daemon/test/gitlab-self-managed-git.test.ts
@@ -1,0 +1,318 @@
+/**
+ * The self-managed GitLab slice end to end (gitlab-com-integration.md §24.4/§24.5): a REAL git
+ * clone and push, and a REAL `glab` invocation, against an instance served on a non-default port
+ * behind a path prefix — through the shim, the injected host table, and the operator's TLS bundle.
+ *
+ * Nothing here is stubbed on the git side: git dials TLS with `GIT_SSL_CAINFO`, `git-http-backend`
+ * serves the pack protocol, and the credential helper runs as its own process exactly as git spawns
+ * it. That is the point: the config key, `useHttpPath`, the prefix stripping and the project path
+ * only agree in real git, and every earlier version of this seam agreed with itself instead.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { execFile, execFileSync, spawn } from 'node:child_process'
+import { promisify } from 'node:util'
+import { createServer, type Server } from 'node:net'
+import { createServer as createTlsServer } from 'node:https'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS } from '@agentconnect.md/protocol'
+import { createRequire } from 'node:module'
+import { gitcredSocketPath } from '../src/cp/gitcred-server.js'
+import { writeGlabShim } from '../src/cp/glab-shim.js'
+import {
+  cloneGitEnv,
+  gitFor,
+  initGitInjection,
+  managedCredentialScope,
+  workspaceGitEnvBase,
+  workspaceGitRemoteTarget
+} from '../src/workspace/git-injection.js'
+import { configureWorkspaceGitOrigins } from '../src/workspace/git-origin-policy.js'
+
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const PROJECT = 'example-group/example-project'
+/** The instance's relative URL root — a first-class install shape, and the one that breaks classifiers. */
+const PREFIX = 'gitlab'
+const TOKEN = 'glpat-effect-token'
+const SERVICE_ACCOUNT = 'agent-service-account'
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const daemonEntry = join(packageRoot, 'src', 'index.ts')
+/** The in-sandbox credential entry: the same helper source, on a graph of three leaf modules. */
+const helperEntry = join(packageRoot, 'src', 'shim', 'git-credential.ts')
+const tsxCli = createRequire(import.meta.url).resolve('tsx/cli')
+// Each shim runs in a fresh node, which resolves workspace siblings from their published `dist`.
+// Tests build nothing, so hand the subprocess the same source condition vitest itself uses.
+const SOURCE_CONDITION_ENV = { NODE_OPTIONS: '--conditions=development' }
+
+/** `#!/bin/sh` in front of one entry, the way both production shims are shaped. */
+function writeEntryShim(path: string, entry: string): string {
+  writeFileSync(
+    path,
+    `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(tsxCli)} ${JSON.stringify(entry)} "$@"\n`,
+    {
+      mode: 0o755
+    }
+  )
+  chmodSync(path, 0o755)
+  return path
+}
+const gitExecPath = execFileSync('git', ['--exec-path'], { encoding: 'utf8' }).trim()
+
+/** A throwaway self-signed authority for 127.0.0.1 — the operator's bundle, in one file. */
+function selfSignedTls(dir: string): { key: string; cert: string; certPath: string } | undefined {
+  const keyPath = join(dir, 'instance.key')
+  const certPath = join(dir, 'instance.crt')
+  try {
+    execFileSync(
+      'openssl',
+      // prettier-ignore
+      [
+        'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+        '-keyout', keyPath, '-out', certPath, '-days', '2',
+        '-subj', '/CN=127.0.0.1', '-addext', 'subjectAltName=IP:127.0.0.1'
+      ],
+      { stdio: 'ignore', timeout: 60_000 }
+    )
+  } catch {
+    return undefined
+  }
+  return { key: readFileSync(keyPath, 'utf8'), cert: readFileSync(certPath, 'utf8'), certPath }
+}
+
+/** `git-http-backend` behind Basic auth, mounted under `/<PREFIX>/` — the fake instance. */
+function serveInstance(tls: { key: string; cert: string }, projectRoot: string): Promise<Server & { port: number }> {
+  const server = createTlsServer({ key: tls.key, cert: tls.cert }, (req, res) => {
+    const expected = `Basic ${Buffer.from(`${SERVICE_ACCOUNT}:${TOKEN}`).toString('base64')}`
+    if (req.headers.authorization !== expected) {
+      res.writeHead(401, { 'www-authenticate': 'Basic realm="gitlab"' }).end('unauthorized')
+      return
+    }
+    const [rawPath = '', query = ''] = (req.url ?? '').split('?')
+    if (!rawPath.startsWith(`/${PREFIX}/`)) {
+      res.writeHead(404).end('not this instance')
+      return
+    }
+    const child = spawn(join(gitExecPath, 'git-http-backend'), {
+      env: {
+        PATH: process.env.PATH ?? '',
+        GIT_PROJECT_ROOT: projectRoot,
+        GIT_HTTP_EXPORT_ALL: '1',
+        REMOTE_USER: SERVICE_ACCOUNT,
+        REQUEST_METHOD: req.method ?? 'GET',
+        PATH_INFO: rawPath.slice(PREFIX.length + 1),
+        QUERY_STRING: query,
+        ...(req.headers['content-type'] ? { CONTENT_TYPE: req.headers['content-type'] } : {}),
+        ...(req.headers['content-length'] ? { CONTENT_LENGTH: req.headers['content-length'] } : {}),
+        ...(req.headers['content-encoding'] ? { HTTP_CONTENT_ENCODING: req.headers['content-encoding'] } : {})
+      }
+    })
+    req.pipe(child.stdin)
+    // CGI answers with its own headers, so buffer until the blank line and replay them verbatim.
+    const chunks: Buffer[] = []
+    let headersSent = false
+    child.stdout.on('data', (chunk: Buffer) => {
+      if (headersSent) {
+        res.write(chunk)
+        return
+      }
+      chunks.push(chunk)
+      const buffered = Buffer.concat(chunks)
+      const split = buffered.indexOf('\r\n\r\n')
+      if (split === -1) return
+      headersSent = true
+      for (const line of buffered.subarray(0, split).toString('utf8').split('\r\n')) {
+        const colon = line.indexOf(':')
+        if (colon > 0) res.setHeader(line.slice(0, colon).trim(), line.slice(colon + 1).trim())
+      }
+      res.write(buffered.subarray(split + 4))
+    })
+    child.on('close', () => res.end())
+  })
+  return new Promise((done) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      done(Object.assign(server, { port: typeof address === 'object' && address ? address.port : 0 }))
+    })
+  })
+}
+
+/** The gitcred socket, answering the binding's service-account credential and recording every ask. */
+function serveGitcred(path: string): { server: Server; requests: Record<string, unknown>[] } {
+  const requests: Record<string, unknown>[] = []
+  const server = createServer((conn) => {
+    let buf = ''
+    conn.on('data', (chunk) => {
+      buf += chunk.toString('utf8')
+      const nl = buf.indexOf('\n')
+      if (nl === -1) return
+      const request = JSON.parse(buf.slice(0, nl)) as Record<string, unknown>
+      requests.push(request)
+      conn.end(
+        JSON.stringify({
+          ok: true,
+          username: SERVICE_ACCOUNT,
+          password: TOKEN,
+          repoFullName: request.repoFullName ?? PROJECT
+        }) + '\n'
+      )
+    })
+  })
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
+  server.listen(path)
+  return { server, requests }
+}
+
+/** Local-only git: nothing here reaches the instance, so a blocking call is safe. */
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, GIT_AUTHOR_NAME: 'a', GIT_AUTHOR_EMAIL: 'a@example.test' }
+  })
+}
+
+// The instance, the gitcred socket and the test all live in ONE process, so every command that has
+// to reach one of them must be ASYNC: a synchronous spawn blocks the loop those servers accept on,
+// and git then fails with a connection timeout against a server that was never asleep.
+const run = promisify(execFile)
+
+const tlsDir = mkdtempSync(join(tmpdir(), 'ac-gl-tls-'))
+const tls = selfSignedTls(tlsDir)
+
+describe.skipIf(tls === undefined)('a prefixed, non-default-port instance, end to end (§24.4)', () => {
+  let root: string
+  let projectRoot: string
+  let server: Server & { port: number }
+  let gitcred: { server: Server; requests: Record<string, unknown>[] }
+  let instance: string
+  let cloneUrl: string
+  let previousCaInfo: string | undefined
+
+  beforeAll(async () => {
+    root = mkdtempSync(join(tmpdir(), 'ac-gl-daemon-'))
+    projectRoot = mkdtempSync(join(tmpdir(), 'ac-gl-projects-'))
+    const bare = join(projectRoot, `${PROJECT}.git`)
+    mkdirSync(dirname(bare), { recursive: true })
+    git(projectRoot, ['init', '--bare', '--initial-branch=main', bare])
+    git(projectRoot, ['-C', bare, 'config', 'http.receivepack', 'true'])
+    const seed = mkdtempSync(join(tmpdir(), 'ac-gl-seed-'))
+    git(seed, ['init', '--initial-branch=main'])
+    writeFileSync(join(seed, 'README.md'), 'seeded\n')
+    git(seed, ['add', 'README.md'])
+    git(seed, ['commit', '-m', 'seed'])
+    git(seed, ['push', bare, 'main'])
+    rmSync(seed, { recursive: true, force: true })
+
+    server = await serveInstance(tls!, projectRoot)
+    instance = `https://127.0.0.1:${server.port}/${PREFIX}`
+    cloneUrl = `${instance}/${PROJECT}.git`
+    // §24.5: TLS trust is process configuration. Real git verifies the chain through this bundle.
+    previousCaInfo = process.env.GIT_SSL_CAINFO
+    process.env.GIT_SSL_CAINFO = tls!.certPath
+    // The operator's allowlist stays authoritative — the managed feature never widens it.
+    configureWorkspaceGitOrigins([`https://127.0.0.1:${server.port}`])
+    gitcred = serveGitcred(gitcredSocketPath(root))
+    mkdirSync(join(root, 'run'), { recursive: true, mode: 0o700 })
+    const helperShim = writeEntryShim(join(root, 'run', 'git-credential'), helperEntry)
+    initGitInjection({
+      // The daemon's own filesystem, but pointed at the leaf entry and an explicit socket: the same
+      // helper source git spawns in production, without the whole daemon graph behind it.
+      targetFor: () => ({
+        kind: 'daemon',
+        helper: helperShim,
+        configDir: join(root, 'run', 'gitcred'),
+        socketPath: gitcredSocketPath(root)
+      }),
+      preWarm: async () => undefined,
+      capabilityFor: () => 'cap-test'
+    })
+  }, 120_000)
+
+  afterAll(() => {
+    server?.close()
+    gitcred?.server.close()
+    if (previousCaInfo === undefined) delete process.env.GIT_SSL_CAINFO
+    else process.env.GIT_SSL_CAINFO = previousCaInfo
+    configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS])
+    for (const dir of [root, projectRoot, tlsDir]) if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  const scope = () => managedCredentialScope('gitlab', instance)
+
+  it('clones and pushes through the injected helper table, on the instance path prefix', async () => {
+    const checkout = join(root, 'checkout')
+    const env = { ...workspaceGitEnvBase(cloneUrl), ...cloneGitEnv(AGENT, cloneUrl, scope()), ...SOURCE_CONDITION_ENV }
+    // No `process.env` spread: `workspaceGitEnvBase` already IS the sanitized process env, and a
+    // raw spread reintroduces exactly the host-shell names simple-git refuses (a login-shell EDITOR).
+    await gitFor(root).env(env).clone(cloneUrl, checkout, ['--branch', 'main', '--single-branch'])
+    expect(readFileSync(join(checkout, 'README.md'), 'utf8')).toBe('seeded\n')
+
+    writeFileSync(join(checkout, 'agent.txt'), 'written by the agent\n')
+    git(checkout, ['add', 'agent.txt'])
+    git(checkout, ['commit', '-m', 'agent change'])
+    const target = workspaceGitRemoteTarget(cloneUrl, AGENT, scope())
+    await run('git', ['push', '--porcelain', target.remote, 'refs/heads/main:refs/heads/main'], {
+      cwd: checkout,
+      env: { ...target.env, ...SOURCE_CONDITION_ENV }
+    })
+    const remoteHead = git(projectRoot, ['-C', join(projectRoot, `${PROJECT}.git`), 'log', '-1', '--pretty=%s', 'main'])
+    expect(remoteHead.trim()).toBe('agent change')
+
+    // Every credential the helper served was asked for as a gitlab project path measured from the
+    // instance root: the `gitlab/` prefix git sent under useHttpPath never reaches the project id.
+    expect(gitcred.requests.length).toBeGreaterThan(0)
+    for (const request of gitcred.requests) {
+      expect(request).toMatchObject({ agentId: AGENT, provider: 'gitlab', repoFullName: PROJECT })
+    }
+  }, 120_000)
+
+  it('runs the real glab against the instance, with a read token and the host export', async () => {
+    const binDir = writeGlabShim(root, daemonEntry)
+    const fakeGlab = join(mkdtempSync(join(tmpdir(), 'ac-gl-realglab-')), 'glab')
+    const observed = join(root, 'glab-env.json')
+    writeFileSync(
+      fakeGlab,
+      [
+        '#!/bin/sh',
+        `cat > ${JSON.stringify(observed)} <<EOF`,
+        '{"token":"$GITLAB_TOKEN","host":"$GITLAB_HOST","argv":"$*"}',
+        'EOF',
+        ''
+      ].join('\n'),
+      { mode: 0o755 }
+    )
+    chmodSync(fakeGlab, 0o755)
+
+    const before = gitcred.requests.length
+    const glab = await run(join(binDir, 'glab'), ['mr', 'view', '1'], {
+      cwd: join(root, 'checkout'),
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        PATH: `${dirname(fakeGlab)}:${process.env.PATH ?? ''}`,
+        AC_AGENT_ID: AGENT,
+        AC_GITCRED_CAPABILITY: 'cap-test',
+        // Exactly what the daemon injects at spawn: the table plus the host export.
+        AC_GITCRED_HOSTS: `github=https://github.com gitlab=${instance}`,
+        GITLAB_HOST: instance,
+        GITLAB_TOKEN: '',
+        ...SOURCE_CONDITION_ENV
+      }
+    })
+    // The wrapper passes the token command's stderr straight through, so a refusal is visible here.
+    expect(glab.stderr).toBe('')
+
+    expect(JSON.parse(readFileSync(observed, 'utf8'))).toEqual({
+      token: TOKEN,
+      host: instance,
+      argv: 'mr view 1'
+    })
+    // The token was minted for THIS project, resolved from the prefixed origin of the cwd checkout.
+    expect(gitcred.requests.slice(before)).toEqual([
+      { op: 'get', agentId: AGENT, capability: 'cap-test', plane: 'glab', provider: 'gitlab', repoFullName: PROJECT }
+    ])
+  }, 120_000)
+})

--- a/packages/daemon/test/gitlab-self-managed-host.test.ts
+++ b/packages/daemon/test/gitlab-self-managed-host.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Self-managed GitLab, daemon side (gitlab-com-integration.md §24.4/§24.5): the injected
+ * host→provider table that replaced the two-literal classifier, the prefix stripping a relative URL
+ * root forces, the grant host echo, the `glab` target resolver, and the spec-admission origin
+ * refusal. GitLab.com is the default value of the axis, so every case here also pins that nothing
+ * changes for a deployment that names no host.
+ */
+import { afterAll, describe, expect, it, vi } from 'vitest'
+import { createServer } from 'node:net'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+import {
+  DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
+  GITLAB_DEFAULT_BASE_URL,
+  type AgentSpec,
+  type GitCredGrant
+} from '@agentconnect.md/protocol'
+import { Daemon } from '../src/daemon.js'
+import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import {
+  decodeManagedHostTable,
+  encodeManagedHostTable,
+  GITCRED_HOSTS_ENV,
+  gitlabManagedHost,
+  managedHostTableFor,
+  matchManagedHost,
+  stripHostPathPrefix
+} from '../src/gitcred/managed-hosts.js'
+import { runGitCredential } from '../src/gitcred/helper.js'
+import { GITCRED_CAPABILITY_ENV } from '../src/gitcred/env.js'
+import { GitCredentialCache, GitCredUnavailableError } from '../src/cp/git-credential.js'
+import { normalizeProjectArg, resolveGlabTargetProject } from '../src/cp/glab-target.js'
+import {
+  gitCredentialEnv,
+  initGitInjection,
+  managedCredentialScope,
+  originOnManagedHost,
+  sessionGitConfig,
+  daemonGitCredentialTarget
+} from '../src/workspace/git-injection.js'
+import { configureWorkspaceGitOrigins, unauthorizedWorkspaceGitOrigin } from '../src/workspace/git-origin-policy.js'
+
+// A prefixed, non-default-port install: the shape a relative URL root produces, and the one every
+// bare-hostname classifier gets wrong.
+const INSTANCE = 'https://gitlab.example.test:8443/gitlab'
+const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+describe('the injected host→provider table (§24.4)', () => {
+  it('round-trips, and an absent table means the default axis value: GitHub plus GitLab.com', () => {
+    const table = managedHostTableFor(INSTANCE)
+    expect(encodeManagedHostTable(table)).toBe(`github=https://github.com gitlab=${INSTANCE}`)
+    expect(decodeManagedHostTable(encodeManagedHostTable(table))).toEqual(table)
+    expect(decodeManagedHostTable(undefined)).toEqual([
+      { provider: 'github', baseUrl: 'https://github.com' },
+      { provider: 'gitlab', baseUrl: GITLAB_DEFAULT_BASE_URL }
+    ])
+    expect(gitlabManagedHost().baseUrl).toBe(GITLAB_DEFAULT_BASE_URL)
+    expect(gitlabManagedHost(`${INSTANCE}/`).baseUrl).toBe(INSTANCE)
+  })
+
+  it('classifies GitHub, GitLab.com, and a prefixed non-default-port instance', () => {
+    const table = managedHostTableFor(INSTANCE)
+    expect(matchManagedHost(table, { protocol: 'https', host: 'github.com', path: 'acme/infra.git' })).toEqual({
+      entry: { provider: 'github', baseUrl: 'https://github.com' },
+      path: 'acme/infra.git'
+    })
+    expect(
+      matchManagedHost(table, { protocol: 'https', host: 'gitlab.example.test:8443', path: 'gitlab/group/proj.git' })
+    ).toEqual({ entry: { provider: 'gitlab', baseUrl: INSTANCE }, path: 'group/proj.git' })
+    // The same host WITHOUT the port is a different address and is not ours.
+    expect(
+      matchManagedHost(table, { protocol: 'https', host: 'gitlab.example.test', path: 'gitlab/group/proj.git' })
+    ).toBeUndefined()
+    // GitLab.com stays classified when the axis is unset.
+    expect(
+      matchManagedHost(managedHostTableFor(), { protocol: 'https', host: 'gitlab.com', path: 'group/sub/proj.git' })
+    ).toEqual({ entry: { provider: 'gitlab', baseUrl: GITLAB_DEFAULT_BASE_URL }, path: 'group/sub/proj.git' })
+  })
+
+  it('refuses a near-miss host and an unknown one — the comparison is exact, never a substring', () => {
+    const table = managedHostTableFor(INSTANCE)
+    for (const host of [
+      'gitlab.example.test:8443.evil.test', // managed host as a PREFIX of the asked one
+      'evil.gitlab.example.test:8443', // managed host as a SUFFIX of the asked one
+      'notgitlab.example.test:8443',
+      'code.example.test'
+    ]) {
+      expect(matchManagedHost(table, { protocol: 'https', host, path: 'gitlab/group/proj.git' })).toBeUndefined()
+    }
+    // Right host, wrong transport, and right host under a NEIGHBOURING path root: neither is ours.
+    expect(
+      matchManagedHost(table, { protocol: 'ssh', host: 'gitlab.example.test:8443', path: 'gitlab/group/proj.git' })
+    ).toBeUndefined()
+    expect(
+      matchManagedHost(table, { protocol: 'https', host: 'gitlab.example.test:8443', path: 'gitlab-staging/g/p.git' })
+    ).toBeUndefined()
+  })
+
+  it('strips a path prefix only on an exact segment boundary', () => {
+    expect(stripHostPathPrefix('gitlab/group/proj.git', 'gitlab')).toBe('group/proj.git')
+    expect(stripHostPathPrefix('/gitlab/group/proj.git', 'gitlab')).toBe('group/proj.git')
+    expect(stripHostPathPrefix('gitlab', 'gitlab')).toBe('')
+    expect(stripHostPathPrefix('gitlabextra/group/proj.git', 'gitlab')).toBeUndefined()
+    expect(stripHostPathPrefix('group/proj.git', '')).toBe('group/proj.git')
+  })
+
+  it('is checked against a clone URL, never sniffed from one', () => {
+    const scope = managedCredentialScope('gitlab', INSTANCE)
+    expect(originOnManagedHost('https://gitlab.example.test:8443/gitlab/group/proj.git', scope.host)).toBe(true)
+    expect(originOnManagedHost('https://gitlab.example.test:8443/other/group/proj.git', scope.host)).toBe(false)
+    expect(originOnManagedHost('https://gitlab.com/group/proj.git', scope.host)).toBe(false)
+    // …and GitLab.com keeps trusting exactly GitLab.com when the axis is unset.
+    expect(originOnManagedHost('https://gitlab.com/group/proj.git', managedCredentialScope('gitlab').host)).toBe(true)
+  })
+})
+
+describe('the credential helper on a prefixed instance (§24.4)', () => {
+  const runDir = mkdtempSync(join(tmpdir(), 'ac-selfmanaged-'))
+  initGitInjection({
+    targetFor: () => daemonGitCredentialTarget({ shimPath: join(runDir, 'helper.sh'), runDir }),
+    preWarm: async () => undefined,
+    capabilityFor: () => 'cap-test'
+  })
+
+  /** A one-shot gitcred socket that records the request and answers a fixed grant. */
+  async function socket(reply: Record<string, unknown>): Promise<{
+    path: string
+    requests: Record<string, unknown>[]
+    close: () => void
+  }> {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-gitcred-sock-')), 's')
+    const requests: Record<string, unknown>[] = []
+    const server = createServer((conn) => {
+      let buf = ''
+      conn.on('data', (chunk) => {
+        buf += chunk.toString('utf8')
+        const nl = buf.indexOf('\n')
+        if (nl === -1) return
+        requests.push(JSON.parse(buf.slice(0, nl)) as Record<string, unknown>)
+        conn.end(JSON.stringify(reply) + '\n')
+      })
+    })
+    await new Promise<void>((resolve) => server.listen(path, resolve))
+    return { path, requests, close: () => server.close() }
+  }
+
+  /** Run the real helper against `stdin`, with the table injected exactly as the daemon writes it. */
+  async function helper(
+    stdin: string,
+    socketPath: string,
+    table: string | undefined
+  ): Promise<{ stdout: string; stderr: string }> {
+    const input = new PassThrough()
+    input.end(stdin)
+    const stdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin')!
+    Object.defineProperty(process, 'stdin', { value: input, configurable: true })
+    const out: string[] = []
+    const err: string[] = []
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      out.push(String(chunk))
+      return true
+    })
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      err.push(String(chunk))
+      return true
+    })
+    const previous = process.env[GITCRED_HOSTS_ENV]
+    const previousCapability = process.env[GITCRED_CAPABILITY_ENV]
+    if (table === undefined) delete process.env[GITCRED_HOSTS_ENV]
+    else process.env[GITCRED_HOSTS_ENV] = table
+    process.env[GITCRED_CAPABILITY_ENV] = 'cap-test'
+    try {
+      await runGitCredential('get', AGENT, socketPath)
+    } finally {
+      Object.defineProperty(process, 'stdin', stdinDescriptor)
+      stdout.mockRestore()
+      stderr.mockRestore()
+      if (previous === undefined) delete process.env[GITCRED_HOSTS_ENV]
+      else process.env[GITCRED_HOSTS_ENV] = previous
+      if (previousCapability === undefined) delete process.env[GITCRED_CAPABILITY_ENV]
+      else process.env[GITCRED_CAPABILITY_ENV] = previousCapability
+      process.exitCode = 0
+    }
+    return { stdout: out.join(''), stderr: err.join('') }
+  }
+
+  const table = encodeManagedHostTable(managedHostTableFor(INSTANCE))
+
+  it('routes a prefixed request to the gitlab provider on the project path minus the prefix', async () => {
+    const server = await socket({ ok: true, username: 'agent-sa', password: 'glpat-x', repoFullName: 'group/proj' })
+    try {
+      const { stdout } = await helper(
+        'protocol=https\nhost=gitlab.example.test:8443\npath=gitlab/group/sub/proj.git\n',
+        server.path,
+        table
+      )
+      expect(server.requests).toEqual([
+        {
+          op: 'get',
+          agentId: AGENT,
+          capability: 'cap-test',
+          repoFullName: 'group/sub/proj',
+          provider: 'gitlab'
+        }
+      ])
+      expect(stdout).toBe('username=agent-sa\npassword=glpat-x\n')
+    } finally {
+      server.close()
+    }
+  })
+
+  it('stays silent for a near-miss host, so git can try its own helpers', async () => {
+    const server = await socket({ ok: true, username: 'agent-sa', password: 'glpat-x' })
+    try {
+      const { stdout, stderr } = await helper(
+        'protocol=https\nhost=evil.gitlab.example.test:8443\npath=gitlab/group/proj.git\n',
+        server.path,
+        table
+      )
+      expect(server.requests).toEqual([])
+      expect(stdout).toBe('')
+      expect(stderr).toBe('')
+    } finally {
+      server.close()
+    }
+  })
+
+  it('keeps GitHub unqualified and full-depth GitLab.com routing when the axis is unset', async () => {
+    const server = await socket({ ok: true, username: 'x-access-token', password: 'ghs_x' })
+    try {
+      await helper('protocol=https\nhost=github.com\npath=acme/infra.git\n', server.path, undefined)
+      expect(server.requests[0]).toEqual({
+        op: 'get',
+        agentId: AGENT,
+        capability: 'cap-test',
+        repoFullName: 'acme/infra'
+      })
+      await helper('protocol=https\nhost=gitlab.com\npath=group/sub/proj.git\n', server.path, undefined)
+      expect(server.requests[1]).toEqual({
+        op: 'get',
+        agentId: AGENT,
+        capability: 'cap-test',
+        repoFullName: 'group/sub/proj',
+        provider: 'gitlab'
+      })
+    } finally {
+      server.close()
+    }
+  })
+
+  it('pins the git-config block and the injected table to the resolved instance', () => {
+    const target = daemonGitCredentialTarget({ shimPath: join(runDir, 'helper.sh'), runDir })
+    const scope = managedCredentialScope('gitlab', INSTANCE)
+    const config = sessionGitConfig(AGENT, undefined, target, scope)
+    expect(config.content).toContain(`[credential "${INSTANCE}"]`)
+    expect(config.content).toContain('useHttpPath = true')
+    expect(config.env[GITCRED_HOSTS_ENV]).toBe(table)
+    // A github workspace on the same deployment still carries the instance in its table: an
+    // additional-repository authorization is a GitLab consumer that is not the workspace.
+    expect(gitCredentialEnv(AGENT, target, managedCredentialScope('github', INSTANCE))[GITCRED_HOSTS_ENV]).toBe(table)
+  })
+
+  rmSync(runDir, { recursive: true, force: true })
+})
+
+describe('the grant host echo (§24.4)', () => {
+  function cache(grant: Partial<GitCredGrant>, gitlabHost?: string) {
+    return new GitCredentialCache({
+      request: async () =>
+        ({
+          username: 'agent-sa',
+          token: 'glpat-x',
+          ttlSec: 3600,
+          expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+          repoFullName: 'group/proj',
+          access: 'write',
+          provider: 'gitlab',
+          externalRepoId: '4455667',
+          ...grant
+        }) as GitCredGrant,
+      log: { warn: () => undefined },
+      providerV2Supported: () => true,
+      gitlabHostFor: () => gitlabHost
+    })
+  }
+
+  const ask = (instance: GitCredentialCache) =>
+    instance.get(AGENT, 'clone', { provider: 'gitlab', externalRepoId: '4455667' })
+
+  it('accepts the instance the spec names, prefix and port included', async () => {
+    await expect(ask(cache({ host: INSTANCE }, INSTANCE))).resolves.toMatchObject({ token: 'glpat-x' })
+  })
+
+  it('refuses a grant echoing another instance', async () => {
+    await expect(ask(cache({ host: 'https://gitlab.other.test' }, INSTANCE))).rejects.toThrow(
+      /gitlab instance https:\/\/gitlab\.other\.test for an agent bound to https:\/\/gitlab\.example\.test:8443\/gitlab/
+    )
+    await expect(ask(cache({ host: 'https://gitlab.other.test' }, INSTANCE))).rejects.toBeInstanceOf(
+      GitCredUnavailableError
+    )
+  })
+
+  it('reads an absent host on either side as GitLab.com', async () => {
+    // Neither side names one: today's GitLab.com wire, byte-identical.
+    await expect(ask(cache({}))).resolves.toMatchObject({ token: 'glpat-x' })
+    // Absent echo against a self-managed spec is a GitLab.com credential — refused.
+    await expect(ask(cache({}, INSTANCE))).rejects.toThrow(/gitlab instance https:\/\/gitlab\.com/)
+    // …and an echoed GitLab.com against an unset axis is the same host, so it passes.
+    await expect(ask(cache({ host: GITLAB_DEFAULT_BASE_URL }))).resolves.toMatchObject({ token: 'glpat-x' })
+  })
+})
+
+describe('glab target resolution against the configured instance (§13.3, §24.4)', () => {
+  const none = () => undefined
+
+  it('strips the instance prefix from every candidate form', () => {
+    expect(normalizeProjectArg('https://gitlab.example.test:8443/gitlab/group/sub/proj.git', INSTANCE)).toEqual({
+      project: 'group/sub/proj'
+    })
+    expect(normalizeProjectArg('gitlab.example.test/gitlab/group/proj', INSTANCE)).toEqual({ project: 'group/proj' })
+    // A bare path is already relative to the instance root.
+    expect(normalizeProjectArg('group/proj', INSTANCE)).toEqual({ project: 'group/proj' })
+    // A neighbouring path root on the same host names no project of this instance.
+    expect(normalizeProjectArg('https://gitlab.example.test:8443/other/group/proj.git', INSTANCE)).toEqual({})
+  })
+
+  it('defers only on a genuine mismatch, and honours the export the shim makes', () => {
+    expect(
+      resolveGlabTargetProject([], { GITLAB_HOST: INSTANCE }, () => `${INSTANCE}/group/proj.git`, INSTANCE)
+    ).toEqual({ project: 'group/proj' })
+    // glab also accepts a scheme-less host; the same instance is still the same instance.
+    expect(resolveGlabTargetProject([], { GITLAB_HOST: 'gitlab.example.test:8443/gitlab' }, none, INSTANCE)).toEqual({})
+    expect(resolveGlabTargetProject([], { GITLAB_HOST: 'gitlab.com' }, none, INSTANCE)).toEqual({ defer: true })
+    expect(resolveGlabTargetProject(['mr', 'view', '-R', 'gitlab.com/g/p'], {}, none, INSTANCE)).toEqual({
+      defer: true
+    })
+    // Unset axis: GitLab.com is the expected instance and nothing defers.
+    expect(resolveGlabTargetProject([], {}, () => 'https://gitlab.com/g/p.git')).toEqual({ project: 'g/p' })
+  })
+})
+
+describe('spec-admission origin refusal (§24.4)', () => {
+  afterAll(() => configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS]))
+
+  it('names the origin the operator policy excludes, and admits a permitted one', () => {
+    configureWorkspaceGitOrigins(['https://github.com', 'https://gitlab.com'])
+    expect(unauthorizedWorkspaceGitOrigin('https://gitlab.example.test:8443/gitlab/group/proj.git')).toBe(
+      'https://gitlab.example.test:8443'
+    )
+    expect(unauthorizedWorkspaceGitOrigin('https://gitlab.com/group/proj.git')).toBeUndefined()
+    // The managed feature never widens the list; the operator adding the origin is what admits it.
+    configureWorkspaceGitOrigins(['https://github.com', 'https://gitlab.example.test:8443'])
+    expect(unauthorizedWorkspaceGitOrigin('https://gitlab.example.test:8443/gitlab/group/proj.git')).toBeUndefined()
+    expect(unauthorizedWorkspaceGitOrigin('https://gitlab.com/group/proj.git')).toBe('https://gitlab.com')
+  })
+
+  /** A daemon whose only interesting configuration is the operator's origin policy. */
+  async function daemonWithOrigins(origins: string[]): Promise<{ daemon: Daemon; root: string }> {
+    const root = mkdtempSync(join(tmpdir(), 'ac-gl-admission-'))
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        runtimes: { claude: { command: 'node', args: [] } },
+        security: { workspaceGitAllowedOrigins: origins }
+      })
+    )
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root })
+    await daemon.start()
+    return { daemon, root }
+  }
+
+  const gitlabSpec = () =>
+    ({
+      name: 'gl',
+      gitlabHost: INSTANCE,
+      workspace: {
+        mode: 'gitlab',
+        isolation: 'shared',
+        gitRepo: `${INSTANCE}/example-group/example-project.git`,
+        branch: 'main',
+        projectId: '4455667',
+        additionalRepos: []
+      }
+    }) as unknown as AgentSpec
+
+  it('refuses the workspace and reports the required origin on the upsert ack', async () => {
+    const { daemon, root } = await daemonWithOrigins(['https://github.com', 'https://gitlab.com'])
+    try {
+      const ack = await (daemon as any).cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec: gitlabSpec() })
+      expect(ack.ok).toBe(false)
+      expect(ack.reason).toContain('https://gitlab.example.test:8443')
+      expect(ack.reason).toContain('workspaceGitAllowedOrigins')
+      expect((daemon as any).agents.has(AGENT)).toBe(false)
+    } finally {
+      await daemon.stop()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('admits the same spec once the operator permits the origin, and resolves the clone target on it', async () => {
+    const { daemon, root } = await daemonWithOrigins(['https://github.com', 'https://gitlab.example.test:8443'])
+    try {
+      const ack = await (daemon as any).cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec: gitlabSpec() })
+      expect(ack).toEqual({ ok: true })
+      const agent = (daemon as any).agents.get(AGENT)
+      expect(agent.gitlabHost).toBe(INSTANCE)
+      const workspaces = new WorkspaceManager()
+      expect(workspaces.managedScopeOf(agent).host.baseUrl).toBe(INSTANCE)
+      expect(workspaces.gitRepoOf(agent)).toBe(`${INSTANCE}/example-group/example-project.git`)
+    } finally {
+      await daemon.stop()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/daemon/test/gitlab-self-managed-host.test.ts
+++ b/packages/daemon/test/gitlab-self-managed-host.test.ts
@@ -171,7 +171,7 @@ describe('the credential helper on a prefixed instance (§24.4)', () => {
     stdin: string,
     socketPath: string,
     table: string | undefined
-  ): Promise<{ stdout: string; stderr: string }> {
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
     const input = new PassThrough()
     input.end(stdin)
     const stdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin')!
@@ -191,8 +191,11 @@ describe('the credential helper on a prefixed instance (§24.4)', () => {
     if (table === undefined) delete process.env[GITCRED_HOSTS_ENV]
     else process.env[GITCRED_HOSTS_ENV] = table
     process.env[GITCRED_CAPABILITY_ENV] = 'cap-test'
+    let exitCode = 0
     try {
       await runGitCredential('get', AGENT, socketPath)
+      // The helper reports a refusal by SETTING exitCode; git reads that as a failed helper.
+      exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0
     } finally {
       Object.defineProperty(process, 'stdin', stdinDescriptor)
       stdout.mockRestore()
@@ -203,7 +206,7 @@ describe('the credential helper on a prefixed instance (§24.4)', () => {
       else process.env[GITCRED_CAPABILITY_ENV] = previousCapability
       process.exitCode = 0
     }
-    return { stdout: out.join(''), stderr: err.join('') }
+    return { stdout: out.join(''), stderr: err.join(''), exitCode }
   }
 
   const table = encodeManagedHostTable(managedHostTableFor(INSTANCE))
@@ -280,6 +283,98 @@ describe('the credential helper on a prefixed instance (§24.4)', () => {
     // A github workspace on the same deployment still carries the instance in its table: an
     // additional-repository authorization is a GitLab consumer that is not the workspace.
     expect(gitCredentialEnv(AGENT, target, managedCredentialScope('github', INSTANCE))[GITCRED_HOSTS_ENV]).toBe(table)
+  })
+
+  // §24.4: the session config pins the instance for a REPO-BEARING consumer — a gitlab workspace or
+  // an authorized gitlab additional repository. A hook-only host does not, because a hook holds no
+  // repository authorization and pinning would only cut the agent's ambient credentials.
+  describe('the second credential block for a repo-bearing consumer', () => {
+    const workspaces = new WorkspaceManager()
+    const target = daemonGitCredentialTarget({ shimPath: join(runDir, 'helper.sh'), runDir })
+    const agentWith = (workspace: Record<string, unknown>) =>
+      ({
+        id: AGENT,
+        gitlabHost: INSTANCE,
+        workspace: { gitBranch: 'main', path: '/tmp/ws', additionalRepos: [], ...workspace }
+      }) as unknown as Parameters<WorkspaceManager['managedScopeOf']>[0]
+    const githubWorkspace = { mode: 'git-repo', gitRepo: 'https://github.com/acme/infra', gitCredential: 'github-app' }
+    const gitlabRepoRow = { repoFullName: 'example-group/example-project', repoId: '4455667', provider: 'gitlab' }
+    const configFor = (workspace: Record<string, unknown>) =>
+      sessionGitConfig(AGENT, undefined, target, workspaces.managedScopeOf(agentWith(workspace))).content
+
+    it('pins both hosts for a github workspace holding a gitlab additional-repository grant', () => {
+      const content = configFor({ ...githubWorkspace, additionalRepos: [gitlabRepoRow] })
+      expect(content).toContain('[credential "https://github.com"]')
+      expect(content).toContain(`[credential "${INSTANCE}"]`)
+      // Both blocks reset the accumulated helper list and keep the path the helper routes on.
+      expect(content.match(/\thelper = $/gm)).toHaveLength(2)
+      expect(content.match(/\tuseHttpPath = true/g)).toHaveLength(2)
+    })
+
+    it('pins a scratch workspace the same way — the grant, not the workspace, is what bears the repo', () => {
+      const content = configFor({ mode: 'from-scratch', gitCredential: 'github-app', additionalRepos: [gitlabRepoRow] })
+      expect(content).toContain(`[credential "${INSTANCE}"]`)
+      expect(workspaces.gitlabRepoBearing(agentWith({ mode: 'from-scratch', additionalRepos: [gitlabRepoRow] }))).toBe(
+        true
+      )
+    })
+
+    it('leaves a HOOK-ONLY agent unpinned, so its ambient gitlab credentials still answer', () => {
+      const content = configFor(githubWorkspace)
+      expect(content).toContain('[credential "https://github.com"]')
+      expect(content).not.toContain(INSTANCE)
+      expect(workspaces.gitlabRepoBearing(agentWith(githubWorkspace))).toBe(false)
+      // A github additional repository is not a gitlab consumer either.
+      const githubRow = { repoFullName: 'acme/other', repoId: '77', provider: 'github' }
+      expect(workspaces.gitlabRepoBearing(agentWith({ ...githubWorkspace, additionalRepos: [githubRow] }))).toBe(false)
+    })
+
+    it('still pins exactly one block for a gitlab workspace — the instance is already its own host', () => {
+      const content = configFor({ mode: 'git-repo', gitRepo: `${INSTANCE}/g/p.git`, gitCredential: 'gitlab' })
+      expect(content.match(/\[credential /g)).toHaveLength(1)
+      expect(content).toContain(`[credential "${INSTANCE}"]`)
+    })
+  })
+
+  it('serves an authorized additional repository on the instance, and DECLINES an unauthorized one', async () => {
+    // The block above is what makes git ask at all; the injected table is what routes the ask.
+    const authorized = await socket({
+      ok: true,
+      username: 'agent-sa',
+      password: 'glpat-x',
+      repoFullName: 'example-group/example-project'
+    })
+    try {
+      const served = await helper(
+        'protocol=https\nhost=gitlab.example.test:8443\npath=gitlab/example-group/example-project.git\n',
+        authorized.path,
+        table
+      )
+      expect(served.stdout).toBe('username=agent-sa\npassword=glpat-x\n')
+      expect(served.exitCode).toBe(0)
+      expect(authorized.requests[0]).toMatchObject({
+        provider: 'gitlab',
+        repoFullName: 'example-group/example-project'
+      })
+    } finally {
+      authorized.close()
+    }
+    // The new failure mode the second block introduces: our helper now OWNS this host's credential
+    // path, so an unauthorized project on it fails closed instead of falling through to ambient auth.
+    const refused = await socket({ ok: false, error: 'repository is not authorized for this agent' })
+    try {
+      const denied = await helper(
+        'protocol=https\nhost=gitlab.example.test:8443\npath=gitlab/example-group/not-authorized.git\n',
+        refused.path,
+        table
+      )
+      expect(denied.stdout).toBe('')
+      expect(denied.exitCode).toBe(1)
+      expect(denied.stderr).toContain('no git credentials')
+      expect(denied.stderr).toContain('example-group/not-authorized')
+    } finally {
+      refused.close()
+    }
   })
 
   rmSync(runDir, { recursive: true, force: true })

--- a/packages/daemon/test/gitlab-self-managed-host.test.ts
+++ b/packages/daemon/test/gitlab-self-managed-host.test.ts
@@ -115,6 +115,25 @@ describe('the injected host→provider table (§24.4)', () => {
     // …and GitLab.com keeps trusting exactly GitLab.com when the axis is unset.
     expect(originOnManagedHost('https://gitlab.com/group/proj.git', managedCredentialScope('gitlab').host)).toBe(true)
   })
+
+  it('gives an ANONYMOUS gitlab remote the provider whose `.git` rule it needs, checked not sniffed', () => {
+    const workspaces = new WorkspaceManager()
+    const anonymous = (gitRepo: string, gitlabHost?: string) =>
+      ({
+        id: AGENT,
+        workspace: { mode: 'git-repo', gitRepo, gitBranch: 'main', path: '/tmp/ws', additionalRepos: [] },
+        ...(gitlabHost !== undefined ? { gitlabHost } : {})
+      }) as unknown as Parameters<WorkspaceManager['remoteProviderOf']>[0]
+    // A public GitLab.com clone has no credential provider on the spec, and still needs the suffix
+    // rule: GitLab 301s the suffix-less probe and daemon git refuses redirects.
+    const repo = 'https://gitlab.com/example-group/example-project'
+    expect(workspaces.remoteProviderOf(anonymous(repo), repo)).toBe('gitlab')
+    expect(workspaces.gitRepoOf(anonymous(repo))).toBe(`${repo}.git`)
+    // Another host is nobody's provider, so nothing is appended.
+    const other = 'https://github.com/acme/infra'
+    expect(workspaces.remoteProviderOf(anonymous(other), other)).toBeUndefined()
+    expect(workspaces.gitRepoOf(anonymous(other))).toBe(other)
+  })
 })
 
 describe('the credential helper on a prefixed instance (§24.4)', () => {


### PR DESCRIPTION
Milestone **N3** of `docs/designs/gitlab-com-integration.md` §24 — the daemon side of self-managed GitLab. Builds on N0 (#1450), N1 (#1451) and N2 (#1452). GitLab.com stays green: absent is the default value of one axis, not a second mode, so a deployment that names no host composes byte-identical config, URLs and wire frames.

## Managed host resolution

The two-literal `'github.com' | 'gitlab.com'` classifier in `workspace/git-injection.ts` is gone. In its place a resolved `ManagedCredentialScope` — the spec's provider plus the instance base URL its `gitlabHost` names — travels on each `WorkspaceRoot` and through every injection entry point (`cloneGitEnv`, `workspaceGitRemoteTarget`, `sessionGitConfig`/`sessionGitEnv`, `writeRepoHelperConfig`). A clone URL is now **checked against** that host (`originOnManagedHost`) instead of being the source of it, and the `.git`-suffix canonicalization, the trusted-origin convergence check and the workspace materialization key all key on the provider rather than re-deriving one from the URL. `agent.json` gains `gitlabHost`, mirrored from `AgentSpec.gitlabHost` including the clear.

## The injected helper table

`gitcred/managed-hosts.ts` is a new leaf — no imports, so the sandbox-bundled helper can use it — holding the table plus its parsing. It travels on `AC_GITCRED_HOSTS` beside the capability and agent identity, is written at injection time, and is **stripped from the daemon's own inherited environment** so an ambient value can never be read as a hint. Each entry carries the full normalized base including any path prefix, because with `useHttpPath` git hands the helper `gitlab/group/project.git` on a prefixed install: the prefix is stripped on an exact segment boundary before `projectFromPath` runs, and a host that is a prefix or a suffix of a managed one does not match. The table always carries GitHub plus the one GitLab instance the spec names, because a GitLab consumer is not always the workspace — an additional-repository authorization rides on a scratch or GitHub workspace.

## Fences

- **Grant echo.** `GitCredentialCache` verifies a gitlab grant's echoed `host` against the spec's, exactly as it verifies provider and numeric project id. Absent means GitLab.com on both sides.
- **Turn time.** A hook delivery whose trusted metadata names another instance than the session's spec is refused as `gitlab_host_mismatch`, never re-targeted: a warm session's credential block, helper table and CLI export were all established at spawn.
- **Spec admission.** The boot warning keyed on the GitLab.com literal becomes a refusal on the `agent/upsert` ack, naming the origin `security.workspaceGitAllowedOrigins` has to admit. The operator list stays authoritative and the managed feature never widens it. Only the degenerate case — no https origin permitted at all — survives as a boot warning. The reconnect snapshot deliberately still stores a spec it cannot clone, because one unservable roster entry must not fail registration, and the clone boundary refuses it as it always did.

## `glab` and per-turn API bases

`cp/glab-shim.ts` exports `GITLAB_HOST` into the agent session so the real CLI targets the instance, prefix and port included. `cp/glab-target.ts` takes the expected host explicitly — read off the same injected table, never off the exported value, which it only compares against — applies the same prefix stripping to every candidate form, and defers only on a genuine mismatch. The "user-supplied `GITLAB_TOKEN` wins" rule is unchanged. The four GitLab API clients (poster, broker, note projection, review adapter) resolve their base per turn from the carried host instead of falling back to a literal.

## TLS trust

`NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `SSL_CERT_DIR` and `GIT_SSL_CAINFO` join the existing narrow forwarding allowlists (skill git acquisition, runtime probe, install repair) and are re-asserted on the workspace clone environment. No skip-verify flag at any layer.

## Advertisement

The slice is complete, so the daemon advertises `gitlab-instance-v1` on the control connection **and** on `rd/hello` — the relay's dispatch fence reads the latter.

## Tests

- Table unit coverage: GitHub, GitLab.com, a self-managed host with a path prefix and a non-default port, near-miss hosts (managed host as prefix and as suffix), a neighbouring path root, an unknown host, and segment-boundary prefix stripping.
- The real helper driven over a real socket for the prefixed, the near-miss and the unset-axis cases.
- Grant-host mismatch rejection, with absent-means-GitLab.com asserted on both sides.
- Warm-session fence: three disagreement shapes refused under the named reason, and the agreeing delivery accepted.
- Spec-admission refusal reported on the ack, then admitted once the operator permits the origin.
- End to end: a real `git clone`, a real `git push` and a real `glab` invocation against `git-http-backend` behind TLS on an ephemeral port under a `/gitlab` path prefix, through the shim and the injected table, with `GIT_SSL_CAINFO` as the only trust channel. It skips itself when `openssl` cannot mint a throwaway certificate.

`pnpm --filter @agentconnect.md/daemon test`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, plus the protocol and relay suites. The only daemon failures are the known environment-sensitive ones — `acp-matrix` (live models), `shim-cancellation` / `shim-workspace-files` / `shim-exec-handler` (BSD `pgrep`, the Linux-only fd descent, and the `/var` → `/private/var` tmpdir symlink) — each verified to reproduce identically on a clean checkout of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
