### PR TITLE
feat(web): chart the billing ledger, and scope spend by metering source

### DIFF
--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -378,7 +378,11 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // lets billing ask for gateway spend alone through the console's own route.
     const sourceScope = (alias: string) =>
       source ? Prisma.sql`AND ${Prisma.raw(`${alias}."source"`)} = ${source}::"UsageSource"` : Prisma.empty
-    const sessionScope = sessionViewerSql(sessionViewer)
+    // A gateway-metered row's sessionId (a hash minted for the model credential) matches no
+    // session_meta, so the viewer predicate's equality arms would silently drop it; an unlinked
+    // row has no per-session content to protect, so it falls back to agent visibility alone.
+    const viewerScope = sessionViewerSql(sessionViewer)
+    const sessionScope = viewerScope ? Prisma.sql`(s."id" IS NULL OR ${viewerScope})` : null
 
     // EVERY figure in this answer comes from the spend timeline inside `[from, to)`,
     // diffed against each session's last checkpoint before the window. Tokens too, not

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -728,6 +728,39 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     }
   })
 
+  it('keeps a gateway row whose sessionId matches no session_meta (hashed credential id)', async () => {
+    await seedAgent(prisma, AGENT_A)
+    const repo = new PgSessionUsageRepo(prisma)
+    const at = new Date(Date.now() - 60_000)
+    // The hub reports the model credential's hashed session id — no session_meta row exists
+    // for it, so the row must fall back to agent visibility instead of being filtered out.
+    await repo.record({
+      agentId: AgentId(AGENT_A),
+      sessionId: 'a'.repeat(64),
+      source: 'gateway',
+      lastActivityAt: at,
+      usage: { totalTokens: 100, costAmount: '12.75', costCurrency: 'USD' }
+    })
+
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as {
+        totals: { sessions: number; totalTokens: number; costAmount: string; costCurrency: string | null }
+        sources: { source: string; costAmount: string }[]
+      }
+      expect(body.totals.sessions).toBe(1)
+      expect(body.totals.totalTokens).toBe(100)
+      expect(body.totals.costAmount).toBe('12.75')
+      // The currency read shares the viewer predicate, so it must see the unlinked row too.
+      expect(body.totals.costCurrency).toBe('USD')
+      expect(body.sources).toEqual([expect.objectContaining({ source: 'gateway', costAmount: '12.75' })])
+    } finally {
+      await close()
+    }
+  })
+
   it('keeps a session that spent in the window but reported again after it', async () => {
     await seedAgent(prisma, AGENT_A)
     const repo = new PgSessionUsageRepo(prisma)

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -10,6 +10,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR from 'swr'
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
 import {
   BillingError,
   BillingShapeError,
@@ -19,15 +20,25 @@ import {
   fetchBillingAccount,
   fetchBillingPurchase,
   fetchBillingTransactions,
+  fetchBillingTransactionsSince,
   fmtDecimalUsd,
   fmtMicroUsd,
   type BillingAccount,
   type BillingPurchase,
   type BillingTransaction
 } from '@/lib/billing-api'
+import {
+  ACTIVITY_RANGES,
+  activityRange,
+  activityWindowStart,
+  bucketActivity,
+  type ActivityMode,
+  type ActivityRange
+} from '@/lib/billing-activity'
 import { balanceBanner, ledgerHistory } from '@/lib/billing-banner'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { useOrgs } from '@/lib/org-context'
+import { SEG_FILL, tickInterval } from '@/lib/spend-chart'
 import { consoleKeys } from '@/lib/swr-keys'
 import { LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
@@ -402,6 +413,152 @@ function AddCreditsCard({ orgId, returnPath }: { orgId: string; returnPath: stri
   )
 }
 
+// ── Activity: the ledger, bucketed ──────────────────────────────────────────
+// Both series come out of the SAME feed the transactions table reads — this page has no
+// other source, and the service exposes no time series of its own. So the chart states
+// what the ledger says and nothing more: no burn rate, no projection, no "days left".
+//
+// SVG `fill` can't take a `var()` presentation attribute, so the hues are descendant rules
+// on the wrapper — the trick `SEG_FILL` uses. Usage is the brand hue (money leaving),
+// top-ups green (money arriving), the same pairing as the Cluster page's credits chart.
+const ACTIVITY_FILL = '[&_.bar-usage_path]:fill-(--brand) [&_.bar-topup_path]:fill-(--green-500)'
+
+function ActivityCard({ orgId }: { orgId: string }) {
+  const [range, setRange] = useState<ActivityRange>('d7')
+  const [mode, setMode] = useState<ActivityMode>('usage')
+  const cfg = activityRange(range)
+
+  const rows = useSWR(consoleKeys.billingActivity(orgId, range), () =>
+    fetchBillingTransactionsSince(orgId, activityWindowStart(range))
+  )
+  const buckets = bucketActivity(rows.data ?? [], range, mode)
+  const total = buckets.reduce((sum, b) => sum + b.amount, 0)
+
+  const Tip = ({ active, payload }: { active?: boolean; payload?: { payload: (typeof buckets)[number] }[] }) => {
+    const row = active ? payload?.[0]?.payload : undefined
+    if (!row) return null
+    return (
+      <div className="rounded-md border border-(--border-subtle) bg-(--surface-card) px-2.5 py-2 shadow-(--shadow-md)">
+        <div className="mono text-[11px] font-semibold">{row.label}</div>
+        <div className="mt-1 flex items-center gap-1.5 font-sans text-[11px] leading-normal text-(--text-secondary)">
+          <span
+            className={`h-[9px] w-[9px] flex-none rounded-[2px] ${mode === 'usage' ? 'bg-(--brand)' : 'bg-(--green-500)'}`}
+          />
+          {mode === 'usage' ? 'usage' : 'topped up'}{' '}
+          <span className="mono text-(--text-primary)">{fmtMicroUsd(Math.round(row.amount * 1_000_000))}</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    // `min-w-0`: recharts measures this box, and an auto min-width would let the plot
+    // widen its own container.
+    <div className="card mb-[18px] min-w-0">
+      <div className="cardhead flex-wrap justify-between gap-2">
+        <span className="inline-flex items-baseline gap-2">
+          <span className="cardtitle">Activity</span>
+          <span className="mono text-[11.5px] text-(--text-tertiary)">{cfg.note}</span>
+        </span>
+        <span className="flex items-center gap-2">
+          <span className="pillbar">
+            {ACTIVITY_RANGES.map((r) => (
+              <button key={r.key} className={range === r.key ? 'pill on' : 'pill'} onClick={() => setRange(r.key)}>
+                {r.label}
+              </button>
+            ))}
+          </span>
+          <span className="pillbar">
+            <button className={mode === 'usage' ? 'pill on' : 'pill'} onClick={() => setMode('usage')}>
+              Usage
+            </button>
+            <button className={mode === 'topups' ? 'pill on' : 'pill'} onClick={() => setMode('topups')}>
+              Top-ups
+            </button>
+          </span>
+        </span>
+      </div>
+      {rows.error ? (
+        <div className="flex items-center gap-3 px-4 py-3">
+          <Icon name="triangle-alert" size={18} color="var(--status-error)" />
+          <span className="flex-1 font-sans text-[13px] font-normal leading-[1.55]">
+            Could not load activity: {(rows.error as Error).message}
+          </span>
+          <Button size="sm" variant="secondary" onClick={() => void rows.mutate()}>
+            Retry
+          </Button>
+        </div>
+      ) : !rows.data ? (
+        // Bar count is the range's real bucket count, so the placeholder has the plot's own
+        // rhythm and switching range doesn't reflow the card's height. Each bar is an equal
+        // flex SLOT with the bar 88% wide inside it, which is `barCategoryGap="12%"` below —
+        // a fixed px gap would leave 7 wide bars glued together and 90 narrow ones as gap.
+        <div className="p-4">
+          <div className="flex h-[124px] animate-pulse items-end pb-[22px]">
+            {Array.from({ length: cfg.buckets }, (_, i) => (
+              <span
+                key={i}
+                className="flex min-w-0 flex-1 justify-center"
+                style={{ height: `${24 + ((i * 23 + 13) % 60)}%` }}
+              >
+                <span className="w-[88%] rounded-t-[3px] bg-(--surface-active)" />
+              </span>
+            ))}
+          </div>
+          <div className="mt-2 flex justify-center">
+            <span className="h-[11px] w-[160px] animate-pulse rounded-[3px] bg-(--surface-active)" />
+          </div>
+        </div>
+      ) : (
+        <div className="p-4">
+          {/* An all-zero plot reads as broken rather than as empty, so an empty range says so
+              in words and keeps the chart out of it. */}
+          {total > 0 ? (
+            <div className={`h-[124px] text-(--text-tertiary) ${SEG_FILL} ${ACTIVITY_FILL}`}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={buckets} margin={{ top: 4, right: 4, bottom: 0, left: 4 }} barCategoryGap="12%">
+                  <XAxis
+                    dataKey="label"
+                    interval={tickInterval(buckets.length)}
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={6}
+                    tick={{ fill: 'currentColor', fontSize: 10.5 }}
+                    className="mono"
+                  />
+                  <Tooltip content={<Tip />} cursor={{ fill: 'var(--surface-hover)' }} />
+                  {/* A pixel floor under any nonzero bucket, so a cent beside a $50 top-up is
+                      still visible — and 0 for a bucket with nothing, so an idle day draws
+                      nothing at all. */}
+                  <Bar
+                    dataKey="amount"
+                    name={mode === 'usage' ? 'usage' : 'top-up'}
+                    className={mode === 'usage' ? 'bar-usage' : 'bar-topup'}
+                    radius={[3, 3, 0, 0]}
+                    minPointSize={(_: number | null | undefined, i: number) => ((buckets[i]?.amount ?? 0) > 0 ? 3 : 0)}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <div className="py-8 text-center font-sans text-[12.5px] font-normal leading-[1.55] text-(--text-tertiary)">
+              {mode === 'usage'
+                ? `Nothing was deducted in the ${cfg.note.replace('last ', '')}.`
+                : `No credits were added in the ${cfg.note.replace('last ', '')}.`}
+            </div>
+          )}
+          <div className="mt-2 text-center font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+            {mode === 'usage' ? 'usage' : 'top-ups'} · {cfg.note.replace('last ', '')}{' '}
+            <span className="mono text-[11px] text-(--text-secondary)">
+              {fmtMicroUsd(Math.round(total * 1_000_000))}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
 function MembersDontPayCard() {
   return (
     <div className="card flex flex-col">
@@ -666,6 +823,10 @@ export default function BillingView() {
             ) : null}
           </div>
 
+          {/* Design: the chart only appears once the ledger has something to draw — an
+              unfunded org gets the banner and the empty table, not an empty plot. */}
+          {txItems.length > 0 && <ActivityCard orgId={orgId} />}
+
           <div className="card">
             <div className="cardhead justify-between">
               <span className="inline-flex items-baseline gap-2">
@@ -692,8 +853,28 @@ export default function BillingView() {
                 </Button>
               </div>
             ) : !transactions.data ? (
-              <div className="px-4 py-8 text-center font-sans text-[13px] font-normal leading-[1.55] text-(--text-tertiary)">
-                Loading…
+              // Placeholder rows on the real column template, so the header the loaded table
+              // will carry lines up with them instead of arriving over a centred word.
+              <div className="animate-pulse">
+                <div className={`row h rounded-none ${TX_GRID}`}>
+                  <span />
+                  <span>Description</span>
+                  <span className="text-right">Amount</span>
+                  <span />
+                  <span className="truncate">Posted ({LOCAL_TZ})</span>
+                </div>
+                {Array.from({ length: 5 }, (_, i) => (
+                  <div key={i} className={`row ${TX_GRID}`}>
+                    <span className="h-[26px] w-[26px] rounded-[7px] bg-(--surface-active)" />
+                    <span
+                      className="h-[13px] rounded-[3px] bg-(--surface-active)"
+                      style={{ width: `${44 + i * 9}%` }}
+                    />
+                    <span className="ml-auto h-[13px] w-[68px] rounded-[3px] bg-(--surface-active)" />
+                    <span />
+                    <span className="h-[13px] w-[112px] rounded-[3px] bg-(--surface-active)" />
+                  </div>
+                ))}
               </div>
             ) : txItems.length === 0 ? (
               <div className="flex flex-col items-center px-4 py-10 text-center">

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -9,7 +9,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import useSWR from 'swr'
+import useSWR, { useSWRConfig } from 'swr'
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
 import {
   BillingError,
@@ -621,10 +621,16 @@ export default function BillingView() {
 
   // Poll until the service reports a terminal status. Each poll also makes the
   // service reconcile against Stripe directly, so a lost webhook delays nothing.
+  const { mutate: mutateKey } = useSWRConfig()
   const refreshMoney = useCallback(() => {
     void account.mutate()
     void transactions.mutate()
-  }, [account.mutate, transactions.mutate])
+    // The Activity chart reads the same ledger through its OWN key, one per range, and its
+    // fetch usually landed while the purchase was still pending. Settlement has to reach
+    // every range it can show — leaving the cached ones alone had the Top-ups chart disagree
+    // with the table right beside it until a refocus or a reload.
+    if (orgId) for (const r of ACTIVITY_RANGES) void mutateKey(consoleKeys.billingActivity(orgId, r.key))
+  }, [account.mutate, transactions.mutate, mutateKey, orgId])
   useEffect(() => {
     if (!orgId || checkout?.phase !== 'confirming') return
     const { purchaseId, attempt } = checkout

--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   balance: { data: { orgId: 'org-pool', balanceMicro: 38_740_000 } } as Record<string, unknown>,
   usage: {} as Record<string, unknown>,
   topUps: {} as Record<string, unknown>,
+  keys: [] as unknown[][],
   push: vi.fn()
 }))
 
@@ -43,6 +44,7 @@ vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: (
 // the stub answers per KEY — one shared response would hide a card that wired the wrong one.
 vi.mock('swr', () => ({
   default: (key: unknown) => {
+    if (Array.isArray(key)) mocks.keys.push(key)
     const resource = Array.isArray(key) ? key[2] : null
     if (resource === 'billing-account') return mocks.balance
     if (resource === 'usage') return mocks.usage
@@ -108,9 +110,10 @@ const onPool = (id: string, over: Partial<Agent> = {}): Agent =>
     ...over
   }) as Agent
 
-/** A 30-day spend series where only SOME of the cost is the pool's — the other agent is the
- *  whole point: a card that summed the org's total would pass against a single-agent series. */
-function usageOverPool(pool: Record<number, string> = { 3: '1.50', 10: '4.00', 29: '2.50' }) {
+/** The 30-day series a `source=gateway` request answers with: already scoped, so a bucket's
+ *  `costAmount` IS the Cloud figure for that day. `byAgent` carries a deliberately different
+ *  number — a card that still scoped the split itself would quote that instead. */
+function gatewayUsage(daily: Record<number, string> = { 3: '1.50', 10: '4.00', 29: '2.50' }) {
   return {
     from: '',
     to: '',
@@ -122,8 +125,8 @@ function usageOverPool(pool: Record<number, string> = { 3: '1.50', 10: '4.00', 2
       bucket: 'day' as const,
       points: Array.from({ length: 30 }, (_, day) => ({
         start: new Date(Date.UTC(2026, 6, 22 + day)).toISOString(),
-        costAmount: '9.99',
-        byAgent: { ...(pool[day] ? { a1: pool[day] } : {}), 'not-on-pool': '7.00' }
+        costAmount: daily[day] ?? '0',
+        byAgent: { a1: '99.00' }
       }))
     }
   }
@@ -162,8 +165,9 @@ beforeEach(() => {
   mocks.agentsLoading = false
   mocks.memberSetsLoading = false
   mocks.balance = { data: { orgId: 'org-pool', balanceMicro: 38_740_000 } }
-  mocks.usage = { data: usageOverPool() }
+  mocks.usage = { data: gatewayUsage() }
   mocks.topUps = { data: [] }
+  mocks.keys = []
   mocks.push.mockClear()
   setFlags('daemon-pool')
 })
@@ -340,19 +344,20 @@ describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
     expect(html).not.toContain('pool-member-p1')
   })
 
-  it('bills the org for what ran on the POOL, not for what the org spent', () => {
+  it('asks the CP for the gateway-metered slice rather than scoping the org total itself', () => {
     // The footnote right below this card promises agents on your own daemons are never billed
-    // here, so the spend is the `byAgent` split filtered to the pool — never the bucket total.
+    // here. Scope is now the REQUEST — `source=gateway`, the ingress the pool meters through —
+    // so the bucket total is already the Cloud figure and the per-agent split is not read.
     mocks.daemons = [member('p1')]
     mocks.agents = [onPool('a1')]
 
     const html = render()
 
+    expect(mocks.keys.find((k) => k[2] === 'usage')).toEqual(['console', 'org-pool', 'usage', 'd30', 'gateway'])
     expect(html).toContain('Credits')
     expect(html).toContain('$8.00')
-    // 30 buckets × $7.00 belonging to an agent that does not run here.
-    expect(html).not.toContain('$218.00')
-    expect(html).not.toContain('$210.00')
+    // 30 buckets × $99.00 is what scoping the split by placement would have quoted.
+    expect(html).not.toContain('$297.00')
   })
 
   it('shows the REAL balance beside them', () => {
@@ -378,18 +383,17 @@ describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
     expect(html).toContain('2 top-ups')
   })
 
-  it('claims nothing while placement is still loading, even with the series in hand', () => {
-    // `hosted` is empty while agents load — and group-placed agents classify as pool-placed
-    // while the set ids load — so a figure rendered now would be a confident wrong number.
+  it('quotes the spend while placement is still loading — placement no longer scopes it', () => {
+    // It used to: the figure was the per-agent split filtered by current placement, so it had
+    // to wait for the agent list AND the set ids. A server-scoped series needs neither.
     mocks.daemons = [member('p1')]
-    mocks.agents = [onPool('a1')]
+    mocks.agents = []
     mocks.agentsLoading = true
+    mocks.memberSetsLoading = true
 
     const html = render()
 
-    expect(html).toContain('animate-pulse')
-    expect(html).not.toContain('$8.00')
-    expect(html).not.toContain('$0.00 / day')
+    expect(html).toContain('$8.00')
   })
 
   it('keeps the stale figure through a failed revalidation instead of contradicting the chart', () => {
@@ -397,7 +401,7 @@ describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
     // so the header must not flip to "unavailable" beside it.
     mocks.daemons = [member('p1')]
     mocks.agents = [onPool('a1')]
-    mocks.usage = { data: usageOverPool(), error: new Error('fetch failed') }
+    mocks.usage = { data: gatewayUsage(), error: new Error('fetch failed') }
     mocks.topUps = { data: [credit(4, 20_000_000)], error: new Error('fetch failed') }
     mocks.balance = { data: { orgId: 'org-pool', balanceMicro: 38_740_000 }, error: new Error('fetch failed') }
 
@@ -440,21 +444,18 @@ describe('ClusterDetailView — managed (AgentConnect Cloud)', () => {
     expect(html).not.toContain('$0.00')
   })
 
-  it('refuses to quote a spend it cannot scope to the pool', () => {
-    // A CP predating the `byAgent` split can only answer for the whole org, and answering with
-    // that number is the one thing this card must not do.
+  it('quotes a series that carries no per-agent split at all', () => {
+    // The split used to BE the scope, so a CP without it left the figure unavailable. Now the
+    // scope is the request and the split is not read — an older CP answers this card fine.
     mocks.daemons = [member('p1')]
     mocks.agents = [onPool('a1')]
-    // The split absent on every point — the shape an older CP actually sends (a current CP
-    // never returns an empty series; its bucket count is floored at 1).
-    const noSplit = usageOverPool().series.points.map(({ byAgent: _, ...p }) => p)
-    mocks.usage = { data: { ...usageOverPool(), series: { bucket: 'day' as const, points: noSplit } } }
+    const noSplit = gatewayUsage().series.points.map(({ byAgent: _, ...p }) => p)
+    mocks.usage = { data: { ...gatewayUsage(), series: { bucket: 'day' as const, points: noSplit } } }
 
     const html = render()
 
-    expect(html).toContain('unavailable')
-    expect(html).toContain('does not split spend per agent')
-    // The balance is a different source and still answers.
+    expect(html).toContain('$8.00')
+    expect(html).not.toContain('unavailable')
     expect(html).toContain('$38.74')
   })
 

--- a/packages/web/src/components/console/views/ClusterDetailView.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.tsx
@@ -24,7 +24,7 @@ import { useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import useSWR from 'swr'
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
-import { isPoolPlacementKind, poolFleetStatus, poolLabel, status, type Agent, type DaemonRow } from '@/lib/data'
+import { isPoolPlacementKind, poolFleetStatus, poolLabel, status, type DaemonRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { consoleKeys } from '@/lib/swr-keys'
 import { fetchUsage } from '@/lib/api'
@@ -32,7 +32,7 @@ import { amountToNumber, sumAmounts } from '@/lib/amount'
 import { SEG_FILL, bucketLabel, tickInterval } from '@/lib/spend-chart'
 import {
   fetchBillingAccount,
-  fetchBillingTransactions,
+  fetchBillingTransactionsSince,
   fmtDecimalUsd,
   fmtMicroUsd,
   type BillingCredit
@@ -217,7 +217,7 @@ export default function ClusterDetailView() {
             report. Neither borrows the other's figure — a plan's included usage cannot be
             derived from load telemetry, and a self-hoster is billed nothing here. */}
         {managed ? (
-          billingOffered && <CloudCreditsCard hosted={hosted} placementLoading={agentsLoading || memberSetsLoading} />
+          billingOffered && <CloudCreditsCard />
         ) : (
           <ClusterCapacityCard {...{ capacityLabel, capacityPct, unbounded, cpu, mem }} />
         )}
@@ -304,78 +304,45 @@ function MetaItem({ icon, text, mono = false }: { icon: string; text: string; mo
 // The spend is NOT read off the billing debits, and scope is the whole reason. A debit's
 // `period` is `YYYY-MM`, so it is a monthly aggregate of the org's ENTIRE usage — quoting it
 // here would contradict this page's own footnote about agents on daemons you connected
-// yourself. `fetchUsage('d30')` buckets cost per day with a `byAgent` split, so the pool's
-// agents can be summed out of it and nothing else is counted. A CP predating that split can
-// only answer for the whole org, so the card reports the figure as unavailable rather than
-// quoting a number this page has just promised it is not.
+// yourself. `fetchUsage('d30', …, 'gateway')` buckets cost per day already scoped to the
+// gateway collector — the ingress the hosted pool meters through, and the same figure the
+// billing service bills — so the series total IS the Cloud figure and this card sums nothing.
 //
-// One approximation remains, and it is the axis the rollup does not have: placement is
-// CURRENT-state while the series is historical, so an agent moved onto the pool brings its
-// whole 30 days along (spend it incurred on a self-connected daemon), and one moved off drops
-// its real Cloud spend. Exact scoping needs a placement dimension in the CP's rollup.
+// Scoping by metering source rather than by current placement is also what makes the number
+// historically true: placement is CURRENT-state, so filtering the per-agent split by it made
+// an agent moved onto the pool bring along 30 days of spend it incurred on a self-connected
+// daemon, and one moved off drop its real Cloud spend.
 const CREDITS_WINDOW_DAYS = 30
 const DAY_MS = 24 * 60 * 60 * 1000
 // Two series, one shared axis: both are USD, and a second axis scaled to make a $0.40 day
 // look like a $50 top-up would be the misleading chart. SVG `fill` can't take a `var()`
 // attribute, so the hues are descendant rules on the wrapper — the trick `SEG_FILL` uses.
 const SERIES_FILL = '[&_.bar-spend_path]:fill-(--brand) [&_.bar-topup_path]:fill-(--green-500)'
-// The window goes to the service as `from`, so a long ledger costs one page here instead of
-// however many it takes to walk back 30 days. The client-side cut stays: a billing image that
-// predates the parameter ignores it and answers with everything, and this console deploys
-// ahead of that image — summing what came back would then quote the wrong figure, silently.
-//
-// The page cap is a runaway guard, not a policy: an org that tops up more times than this in
-// 30 days under-reports rather than paging its whole ledger for one total.
-const TOPUP_MAX_PAGES = 10
+// Only the credit side of the window: this card charts top-ups against the CP's own usage
+// series, so the ledger's debit rows would double-count what `usage` already carries.
+const fetchTopUps = async (orgId: string, sinceMs: number): Promise<BillingCredit[]> =>
+  (await fetchBillingTransactionsSince(orgId, sinceMs)).filter((t): t is BillingCredit => t.type === 'credit')
 
-async function fetchTopUps(orgId: string, sinceMs: number): Promise<BillingCredit[]> {
-  const from = new Date(sinceMs).toISOString()
-  const credits: BillingCredit[] = []
-  let cursor: string | undefined
-  for (let page = 0; page < TOPUP_MAX_PAGES; page++) {
-    const { items, nextCursor } = await fetchBillingTransactions(orgId, cursor, { from })
-    // Rows are newest-first, so the window ends at the first row older than it. An unparseable
-    // `at` compares false and stays — a row this side cannot date must not silently truncate
-    // the ones behind it.
-    const older = items.findIndex((t) => Date.parse(t.at) < sinceMs)
-    for (const row of older < 0 ? items : items.slice(0, older)) if (row.type === 'credit') credits.push(row)
-    if (older >= 0 || !nextCursor) break
-    cursor = nextCursor
-  }
-  return credits
-}
-
-function CloudCreditsCard({ hosted, placementLoading }: { hosted: readonly Agent[]; placementLoading: boolean }) {
+function CloudCreditsCard() {
   const { activeOrg } = useOrgs()
   const orgId = activeOrg?.id ?? null
   // Same `billingAccount` key the Billing page reads, so the two pages cannot disagree.
   const account = useSWR(consoleKeys.billingAccount(orgId), () => fetchBillingAccount(orgId!))
-  const usage = useSWR(consoleKeys.usage(orgId, 'd30'), () => fetchUsage('d30', orgId!))
+  // `source=gateway` is the scope, as a request parameter: the CP answers with the
+  // gateway-metered aggregate only, so nothing here filters or re-sums it.
+  const usage = useSWR(consoleKeys.usage(orgId, 'd30', 'gateway'), () => fetchUsage('d30', orgId!, 'gateway'))
   const topUps = useSWR(consoleKeys.billingTopUps(orgId), () =>
     fetchTopUps(orgId!, Date.now() - CREDITS_WINDOW_DAYS * DAY_MS)
   )
 
   const points = usage.data?.series?.points ?? []
-  const poolIds = new Set(hosted.map((a) => a.id))
-  // `byAgent` is optional on the wire; without it there is no Cloud-only figure to quote.
-  const scoped = points.some((p) => p.byAgent)
-  const daily = scoped
-    ? points.map((p) => sumAmounts(Object.entries(p.byAgent ?? {}).flatMap(([id, c]) => (poolIds.has(id) ? [c] : []))))
-    : []
+  const daily = points.map((p) => p.costAmount)
   const spent = sumAmounts(daily)
-  // The spend figure needs BOTH sides settled: the series, and the placement that scopes it.
-  // `hosted` is empty while agents load, and worse, group-placed agents classify as pool-placed
-  // while `orgSetIds` is empty — either would render a confident wrong figure for a round trip.
-  const spendLoading = usage.isLoading || placementLoading
+  const spendLoading = usage.isLoading
   // An error is the figure's state only while there is nothing to show: SWR keeps `data` across
   // a failed revalidation, and flipping the header to "unavailable" beside a chart still drawn
   // from that same retained series would have the card disagree with itself.
-  const spendError =
-    usage.error && !usage.data
-      ? (usage.error as Error).message
-      : usage.data && !scoped
-        ? 'this control plane does not split spend per agent, so the Cloud-only figure cannot be separated from the org total'
-        : undefined
+  const spendError = usage.error && !usage.data ? (usage.error as Error).message : undefined
 
   const credits = topUps.data ?? []
   // The NET of the credit side — a negative adjustment subtracts, which is what the balance
@@ -458,12 +425,12 @@ function CloudCreditsCard({ hosted, placementLoading }: { hosted: readonly Agent
         <span className="w-px flex-none self-stretch bg-(--border-subtle)" />
         <Figure
           label={`Spent · ${CREDITS_WINDOW_DAYS}d`}
-          value={scoped ? fmtDecimalUsd(spent) : '—'}
+          value={usage.data ? fmtDecimalUsd(spent) : '—'}
           // Divided by the labelled window, not `daily.length`: the CP floors the window's
           // start to a local day boundary, so a 30-day span is 31 buckets whenever "now" is
           // not midnight, and the edge two are partial days.
           note={
-            scoped
+            usage.data
               ? `avg ${fmtMicroUsd(Math.round((amountToNumber(spent) / CREDITS_WINDOW_DAYS) * 1_000_000))} / day`
               : ' '
           }

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -7,7 +7,7 @@ import { SEG_FILL, bucketLabel, tickInterval } from '@/lib/spend-chart'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { fetchUsage, fmtCost, fmtCountCompact as fmtCompact, type UsageRange } from '@/lib/api'
 import { amountToNumber, sumAmounts } from '@/lib/amount'
-import { agentLabel, isPoolPlacementKind, modelLabel, runtimeLabel } from '@/lib/data'
+import { agentLabel, modelLabel, runtimeLabel } from '@/lib/data'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { useConsoleData } from '@/lib/data-context'
 import { AgentIconView, ModelMark, Spinner } from '@/components/marks'
@@ -32,11 +32,12 @@ const MOBILE_RANGES: { key: UsageRange; label: string }[] = [
 
 const GRID = 'grid-cols-[2fr_1fr_1fr_1fr_1.4fr]'
 
-// Placement filter: Cloud = agents on the install-wide pool, Daemons = everything else.
-// Client-side over the per-agent aggregate — the API's `source` param means metering
-// ingress (daemon EVT vs gateway collector), NOT where the agent runs, so it can't
-// answer this. Only offered where the pool exists (`daemon-pool` flag).
-type SourceFilter = 'all' | 'cloud' | 'daemons'
+// Metering-source filter, answered by the API's own `source` param: which authenticated
+// ingress metered the session — the gateway collector (Cloud) or a daemon's EVT. The CP
+// scopes the WHOLE aggregate to it, totals and rollups and the spend series alike, so this
+// view does no filtering of its own and every figure on the page agrees by construction.
+// Only offered where the pool exists (`daemon-pool` flag).
+type SourceFilter = 'all' | 'gateway' | 'daemon'
 
 // How the usage table is broken down. Runtime is derived from the per-agent
 // aggregate; model comes from the server's per-session execution snapshots so
@@ -75,24 +76,21 @@ export default function UsageView() {
   const showSourceFilter = featureFlagEnabled('daemon-pool')
   const sourceOptions: { key: SourceFilter; label: string }[] = [
     { key: 'all', label: 'All' },
-    // Same split the placement picker uses: the pool is the product on managed,
-    // the operator's own cluster elsewhere.
-    { key: 'cloud', label: featureFlagEnabled('managed') ? 'Cloud' : 'Cluster' },
-    { key: 'daemons', label: 'Daemons' }
+    // Gateway-metered IS the hosted product: named as the placement picker names it —
+    // the pool is the product on managed, the operator's own cluster elsewhere.
+    { key: 'gateway', label: featureFlagEnabled('managed') ? 'Cloud' : 'Cluster' },
+    { key: 'daemon', label: 'Daemons' }
   ]
-  // The model rollup comes pre-aggregated across ALL agents, so it can't follow a
-  // client-side placement filter — fall back to the agent rollup while filtered.
   const selectSource = (k: SourceFilter) => {
     setSourceFilter(k)
     setHiddenKeys([])
-    if (k !== 'all' && groupBy === 'model') setGroupBy('agent')
   }
 
-  const { agents, orgSetIds } = useConsoleData()
+  const { agents } = useConsoleData()
   const waitingForOrg = orgLoading || (!activeOrg && orgs.length > 0)
-  const usageKey = consoleKeys.usage(waitingForOrg ? null : activeOrg?.id, range)
-  const { data, error, isLoading } = useSWR(usageKey, ([, orgId, , requestedRange]) =>
-    fetchUsage(requestedRange, orgId)
+  const usageKey = consoleKeys.usage(waitingForOrg ? null : activeOrg?.id, range, sourceFilter)
+  const { data, error, isLoading } = useSWR(usageKey, ([, orgId, , requestedRange, requestedSource]) =>
+    fetchUsage(requestedRange, orgId, requestedSource === 'all' ? undefined : requestedSource)
   )
   const loading = waitingForOrg || isLoading
   const err = orgError ?? (error ? (error instanceof Error ? error.message : String(error)) : null)
@@ -112,26 +110,20 @@ export default function UsageView() {
       name: meta ? agentLabel(meta) : a.agentId.length > 12 ? a.agentId.slice(0, 8) : a.agentId,
       icon: meta?.icon,
       runtime: meta?.runtime || meta?.model || '',
-      // Pool-placed = Cloud. An agent no longer in the console list reads as daemon-side.
-      cloud: meta ? isPoolPlacementKind(meta.placementKind, meta.setId, orgSetIds) : false,
       totalTokens: a.totalTokens,
       sessions: a.sessions,
       costAmount: a.costAmount
     }
   })
-  const filtered = sourceFilter === 'all' ? enriched : enriched.filter((e) => e.cloud === (sourceFilter === 'cloud'))
 
-  // Unfiltered, the server totals are authoritative; filtered, re-sum the visible
-  // agents (a session belongs to one agent, so session counts add cleanly).
-  const totalTokens =
-    sourceFilter === 'all' ? (data?.totals.totalTokens ?? 0) : filtered.reduce((s, e) => s + e.totalTokens, 0)
-  const totalSessions =
-    sourceFilter === 'all' ? (data?.totals.sessions ?? 0) : filtered.reduce((s, e) => s + e.sessions, 0)
+  // The server totals are authoritative in every mode — the source filter is a request
+  // parameter, so what came back IS the filtered aggregate and re-summing rows here could
+  // only disagree with it.
+  const totalTokens = data?.totals.totalTokens ?? 0
+  const totalSessions = data?.totals.sessions ?? 0
   // Amounts arrive as exact decimal strings; a number appears only where the value is
   // being formatted or turned into pixels, never where two amounts are added.
-  const totalSpend = amountToNumber(
-    sourceFilter === 'all' ? (data?.totals.costAmount ?? '0') : sumAmounts(filtered.map((e) => e.costAmount))
-  )
+  const totalSpend = amountToNumber(data?.totals.costAmount ?? '0')
   // Currency reported for this workspace's sessions (null when none/mixed → the
   // formatter falls back to USD). Amounts are summed as-is, so a mixed-currency
   // workspace shows an unlabeled total — acceptable until per-currency rollups.
@@ -166,7 +158,7 @@ export default function UsageView() {
     }))
   } else if (groupBy === 'runtime') {
     const byRuntime = new Map<string, Entry>()
-    for (const e of filtered) {
+    for (const e of enriched) {
       const rt = e.runtime || 'unknown'
       const g = byRuntime.get(rt) ?? {
         key: `runtime:${rt}`,
@@ -185,7 +177,7 @@ export default function UsageView() {
     }
     entries = [...byRuntime.values()].sort((a, b) => b.totalTokens - a.totalTokens)
   } else {
-    entries = filtered.map((e) => ({ ...e, key: e.agentId, kind: 'agent', navId: e.agentId, model: '' }))
+    entries = enriched.map((e) => ({ ...e, key: e.agentId, kind: 'agent', navId: e.agentId, model: '' }))
   }
 
   // Two bar geometries from one map: `pct` is the desktop share (percent of the
@@ -366,21 +358,12 @@ export default function UsageView() {
           // place in this view where a cost is allowed to be a float.
           const plot = (by: Record<string, string>): Record<string, number> =>
             Object.fromEntries(Object.entries(by).map(([k, v]) => [k, amountToNumber(v)]))
-          // Placement filter applied per bucket: keep only the visible agents' deltas.
-          const allowed = sourceFilter === 'all' ? null : new Set(filtered.map((e) => e.agentId))
-          const scopedByAgent = (p: (typeof pts)[number]): Record<string, number> => {
-            const rec = plot(p.byAgent ?? {})
-            if (!allowed) return rec
-            return Object.fromEntries(Object.entries(rec).filter(([id]) => allowed.has(id)))
-          }
           const recs = pts.map((p) => {
             if (!hasBreakdown) return { '': amountToNumber(p.costAmount) }
-            // The model split can't be placement-filtered; selectSource forces the
-            // rollup off 'model' whenever the filter is active.
             if (groupBy === 'model') return plot(p.byModel ?? {})
-            if (groupBy === 'agent') return scopedByAgent(p)
+            if (groupBy === 'agent') return plot(p.byAgent ?? {})
             const rec: Record<string, number> = {}
-            for (const [id, v] of Object.entries(scopedByAgent(p))) {
+            for (const [id, v] of Object.entries(plot(p.byAgent ?? {}))) {
               const rt = agentMeta.get(id)?.runtime || 'unknown'
               rec[rt] = (rec[rt] ?? 0) + v
             }
@@ -416,9 +399,7 @@ export default function UsageView() {
           const chartData = recs.map((rec, i) => {
             const row: Record<string, number | string> = {
               label: bucketLabel(pts[i]!.start, data.series!.bucket),
-              // Filtered, the bucket's server total covers hidden agents too — report
-              // the visible agents' net sum instead (signed, before the clamp below).
-              __total: allowed ? Object.values(rec).reduce((s, v) => s + v, 0) : amountToNumber(pts[i]!.costAmount)
+              __total: amountToNumber(pts[i]!.costAmount)
             }
             stackKeys.forEach((k, si) => {
               row[`s${si}`] =
@@ -474,8 +455,8 @@ export default function UsageView() {
           const Tip = ({ active, payload, label }: { active?: boolean; payload?: TipSeg[]; label?: string }) => {
             if (!active || !payload?.length) return null
             const segs = [...payload].reverse().filter((s) => s.value > 0)
-            // Unfiltered, report the bucket's true net cost (`__total` keeps negative
-            // corrections the clamped segments drop); filtered, report what's shown.
+            // With nothing hidden, report the bucket's true net cost (`__total` keeps the
+            // negative corrections the clamped segments drop); legend-hidden, report what's shown.
             const total = hidden.size
               ? payload.reduce((s, x) => s + (x.value || 0), 0)
               : (payload[0]!.payload.__total ?? 0)
@@ -559,22 +540,11 @@ export default function UsageView() {
         {/* Group-by toolbar (both form factors): switch the rollup dimension. */}
         <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3 desktop:px-[18px] desktop:py-[10px]">
           <div className="pillbar">
-            {GROUPS.map((g) => {
-              const off = g.key === 'model' && sourceFilter !== 'all'
-              return (
-                <button
-                  key={g.key}
-                  className={`${groupBy === g.key ? 'pill on' : 'pill'} disabled:cursor-not-allowed disabled:opacity-45`}
-                  disabled={off}
-                  title={
-                    off ? 'The model breakdown spans all agents, so it can’t follow the placement filter' : undefined
-                  }
-                  onClick={() => selectGroup(g.key)}
-                >
-                  {g.label}
-                </button>
-              )
-            })}
+            {GROUPS.map((g) => (
+              <button key={g.key} className={groupBy === g.key ? 'pill on' : 'pill'} onClick={() => selectGroup(g.key)}>
+                {g.label}
+              </button>
+            ))}
           </div>
         </div>
 

--- a/packages/web/src/lib/billing-activity.test.ts
+++ b/packages/web/src/lib/billing-activity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { activityWindowStart, bucketActivity } from '@/lib/billing-activity'
 import type { BillingTransaction } from '@/lib/billing-api'
 
@@ -53,5 +53,46 @@ describe('bucketActivity', () => {
     expect(buckets).toHaveLength(24)
     expect(buckets[0]!.start).toBe(activityWindowStart('h24', now))
     expect(buckets[23]!.start - buckets[22]!.start).toBe(3_600_000)
+  })
+})
+
+// The 24-hour range is walked in elapsed hours, not wall-clock hours, so it survives a DST
+// transition. Pinned in a zone that HAS one: in UTC the two implementations agree.
+describe('bucketActivity across a spring-forward', () => {
+  const realTz = process.env.TZ
+  beforeAll(() => {
+    process.env.TZ = 'America/New_York'
+  })
+  afterAll(() => {
+    process.env.TZ = realTz
+  })
+
+  // 2026-03-08 skips local 02:00 in New York, so setting the wall-clock hour lands twice on
+  // the same instant — 23 distinct buckets and a window start an hour late, which silently
+  // drops an hour of the ledger from the request.
+  const noon = new Date('2026-03-08T12:00:00-05:00').getTime()
+
+  it('keeps 24 distinct, strictly ascending, one-hour-apart starts', () => {
+    const buckets = bucketActivity([], 'h24', 'usage', noon)
+    expect(new Set(buckets.map((b) => b.start)).size).toBe(24)
+    for (let i = 1; i < buckets.length; i++) expect(buckets[i]!.start - buckets[i - 1]!.start).toBe(3_600_000)
+    expect(activityWindowStart('h24', noon)).toBe(buckets[0]!.start)
+  })
+
+  it('still counts a row that posted in the skipped hour', () => {
+    // 02:30 EST does not exist locally; the instant does, and it belongs to a bucket.
+    const at = new Date('2026-03-08T07:30:00Z').toISOString()
+    const buckets = bucketActivity([debit(at, '2.50')], 'h24', 'usage', noon)
+    expect(buckets.reduce((a, b) => a + b.amount, 0)).toBeCloseTo(2.5)
+  })
+
+  it('keeps the 23-hour DST day exactly one bucket wide', () => {
+    // Daily buckets stay calendar arithmetic on purpose: every start is a local midnight, and
+    // the short day is still one bucket. Fixed-ms stepping would drift them off midnight here.
+    const buckets = bucketActivity([], 'd7', 'usage', new Date('2026-03-09T12:00:00-04:00').getTime())
+    expect(new Set(buckets.map((b) => b.start)).size).toBe(7)
+    expect(buckets.every((b) => new Date(b.start).getHours() === 0)).toBe(true)
+    const mar9 = buckets.findIndex((b) => new Date(b.start).getDate() === 9)
+    expect(buckets[mar9]!.start - buckets[mar9 - 1]!.start).toBe(23 * 3_600_000)
   })
 })

--- a/packages/web/src/lib/billing-activity.test.ts
+++ b/packages/web/src/lib/billing-activity.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { activityWindowStart, bucketActivity } from '@/lib/billing-activity'
+import type { BillingTransaction } from '@/lib/billing-api'
+
+const credit = (at: string, amountMicro: number, kind: 'purchase' | 'refund' = 'purchase'): BillingTransaction => ({
+  type: 'credit',
+  id: `c-${at}-${amountMicro}`,
+  kind,
+  amountMicro,
+  at
+})
+const debit = (at: string, amount: string): BillingTransaction => ({
+  type: 'debit',
+  id: `d-${at}`,
+  period: at.slice(0, 7),
+  amount,
+  at
+})
+
+// A local-midnight instant, so the assertions below don't depend on the runner's timezone.
+const dayStart = (daysAgo: number, hour = 12) => {
+  const d = new Date()
+  d.setHours(hour, 0, 0, 0)
+  d.setDate(d.getDate() - daysAgo)
+  return d.toISOString()
+}
+const now = Date.now()
+
+describe('bucketActivity', () => {
+  it('sums debits into their local day and leaves credits out of usage mode', () => {
+    const rows = [debit(dayStart(1), '1.5'), debit(dayStart(1, 20), '0.25'), credit(dayStart(1), 50_000_000)]
+    const buckets = bucketActivity(rows, 'd7', 'usage', now)
+    expect(buckets).toHaveLength(7)
+    expect(buckets[5]!.amount).toBeCloseTo(1.75)
+    expect(buckets.reduce((a, b) => a + b.amount, 0)).toBeCloseTo(1.75)
+  })
+
+  it('counts positive credits in top-ups mode and ignores refunds', () => {
+    const rows = [credit(dayStart(0), 10_000_000), credit(dayStart(0), -4_000_000, 'refund'), debit(dayStart(0), '3')]
+    const buckets = bucketActivity(rows, 'd7', 'topups', now)
+    expect(buckets[6]!.amount).toBeCloseTo(10)
+    expect(buckets.reduce((a, b) => a + b.amount, 0)).toBeCloseTo(10)
+  })
+
+  it('drops rows older than the window and rows it cannot date', () => {
+    const rows = [debit(dayStart(30), '9'), debit('not-a-date', '9'), debit(dayStart(2), '1')]
+    const buckets = bucketActivity(rows, 'd7', 'usage', now)
+    expect(buckets.reduce((a, b) => a + b.amount, 0)).toBeCloseTo(1)
+  })
+
+  it('spans exactly the range it will request, hourly for 24h', () => {
+    const buckets = bucketActivity([], 'h24', 'usage', now)
+    expect(buckets).toHaveLength(24)
+    expect(buckets[0]!.start).toBe(activityWindowStart('h24', now))
+    expect(buckets[23]!.start - buckets[22]!.start).toBe(3_600_000)
+  })
+})

--- a/packages/web/src/lib/billing-activity.ts
+++ b/packages/web/src/lib/billing-activity.ts
@@ -1,0 +1,95 @@
+// Bucketing for the Billing page's Activity chart. Pure — the fetch is
+// `fetchBillingTransactionsSince` and the drawing is recharts; this only decides which
+// bucket a ledger row lands in and how much it adds.
+//
+// Buckets are LOCAL calendar hours/days, matching the transactions table below the chart
+// (which posts in the viewer's own timezone) and `bucketLabel`, which reads a bucket start
+// as local time. Walking the boundaries with setHours/setDate rather than adding a fixed
+// 3_600_000/86_400_000 is what keeps a DST day one day wide.
+
+import type { BillingTransaction } from '@/lib/billing-api'
+import { bucketLabel } from '@/lib/spend-chart'
+
+export type ActivityRange = 'h24' | 'd7' | 'd30' | 'd90'
+export type ActivityMode = 'usage' | 'topups'
+
+export const ACTIVITY_RANGES = [
+  { key: 'h24', label: '24h', note: 'last 24 hours', buckets: 24, unit: 'hour' },
+  { key: 'd7', label: '7d', note: 'last 7 days', buckets: 7, unit: 'day' },
+  { key: 'd30', label: '30d', note: 'last 30 days', buckets: 30, unit: 'day' },
+  { key: 'd90', label: '90d', note: 'last 90 days', buckets: 90, unit: 'day' }
+] as const satisfies readonly {
+  key: ActivityRange
+  label: string
+  note: string
+  buckets: number
+  unit: 'hour' | 'day'
+}[]
+
+export const activityRange = (key: ActivityRange) => ACTIVITY_RANGES.find((r) => r.key === key)!
+
+/** UTC ms of every bucket start in the range, oldest first, the last one holding `nowMs`. */
+function bucketStarts(range: ActivityRange, nowMs: number): number[] {
+  const { buckets, unit } = activityRange(range)
+  const last = new Date(nowMs)
+  if (unit === 'hour') last.setMinutes(0, 0, 0)
+  else last.setHours(0, 0, 0, 0)
+  const starts: number[] = []
+  for (let back = buckets - 1; back >= 0; back--) {
+    const d = new Date(last)
+    if (unit === 'hour') d.setHours(d.getHours() - back)
+    else d.setDate(d.getDate() - back)
+    starts.push(d.getTime())
+  }
+  return starts
+}
+
+/** Start of the window a range covers — what goes to the service as `from`. */
+export function activityWindowStart(range: ActivityRange, nowMs: number = Date.now()): number {
+  return bucketStarts(range, nowMs)[0]!
+}
+
+export interface ActivityBucket {
+  start: number
+  label: string
+  amount: number
+}
+
+/** One row per bucket, oldest first. `amount` is USD as a NUMBER because it is chart
+ *  geometry and a total under it — the exact decimal string a debit carries stays in the
+ *  transactions table, which is the reconciliation surface. Rows outside the window, and
+ *  rows the other mode owns, add nothing. */
+export function bucketActivity(
+  rows: readonly BillingTransaction[],
+  range: ActivityRange,
+  mode: ActivityMode,
+  nowMs: number = Date.now()
+): ActivityBucket[] {
+  const starts = bucketStarts(range, nowMs)
+  const { unit } = activityRange(range)
+  const amounts = new Array<number>(starts.length).fill(0)
+  for (const row of rows) {
+    const at = Date.parse(row.at)
+    if (!Number.isFinite(at) || at < starts[0]!) continue
+    const amount =
+      mode === 'usage'
+        ? row.type === 'debit'
+          ? Number(row.amount)
+          : 0
+        : // Positive credits only: a refund is a negative credit, and a bar that eats into
+          // the day beside it reads as usage rather than as money coming back.
+          row.type === 'credit' && row.amountMicro > 0
+          ? row.amountMicro / 1_000_000
+          : 0
+    if (!Number.isFinite(amount) || amount <= 0) continue
+    // Last bucket that had already started when the row posted.
+    let i = starts.length - 1
+    while (i > 0 && starts[i]! > at) i--
+    amounts[i] = amounts[i]! + amount
+  }
+  return starts.map((start, i) => ({
+    start,
+    label: bucketLabel(new Date(start).toISOString(), unit),
+    amount: amounts[i]!
+  }))
+}

--- a/packages/web/src/lib/billing-activity.ts
+++ b/packages/web/src/lib/billing-activity.ts
@@ -2,13 +2,23 @@
 // `fetchBillingTransactionsSince` and the drawing is recharts; this only decides which
 // bucket a ledger row lands in and how much it adds.
 //
-// Buckets are LOCAL calendar hours/days, matching the transactions table below the chart
-// (which posts in the viewer's own timezone) and `bucketLabel`, which reads a bucket start
-// as local time. Walking the boundaries with setHours/setDate rather than adding a fixed
-// 3_600_000/86_400_000 is what keeps a DST day one day wide.
+// Buckets are the viewer's own local hours/days, matching the transactions table below the
+// chart (which posts in local time) and `bucketLabel`, which reads a bucket start as local.
+//
+// The two units are walked DIFFERENTLY, and DST is the whole reason:
+//
+//   day  → local calendar arithmetic (`setDate`), because a local day is a calendar fact and
+//          a DST day must stay one bucket wide even though it is 23 or 25 hours long.
+//   hour → elapsed milliseconds, because an hour is a fixed duration and the local clock is
+//          not. Setting the wall-clock hour would land twice on the same instant across a
+//          spring-forward — the skipped local hour normalises onto the next one — so `h24`
+//          would carry a duplicate start, 23 distinct buckets, and a window beginning late
+//          enough that an hour of the ledger was never requested at all.
 
 import type { BillingTransaction } from '@/lib/billing-api'
 import { bucketLabel } from '@/lib/spend-chart'
+
+const HOUR_MS = 60 * 60 * 1000
 
 export type ActivityRange = 'h24' | 'd7' | 'd30' | 'd90'
 export type ActivityMode = 'usage' | 'topups'
@@ -28,7 +38,8 @@ export const ACTIVITY_RANGES = [
 
 export const activityRange = (key: ActivityRange) => ACTIVITY_RANGES.find((r) => r.key === key)!
 
-/** UTC ms of every bucket start in the range, oldest first, the last one holding `nowMs`. */
+/** UTC ms of every bucket start in the range, strictly ascending and distinct, the last one
+ *  holding `nowMs`. */
 function bucketStarts(range: ActivityRange, nowMs: number): number[] {
   const { buckets, unit } = activityRange(range)
   const last = new Date(nowMs)
@@ -36,9 +47,12 @@ function bucketStarts(range: ActivityRange, nowMs: number): number[] {
   else last.setHours(0, 0, 0, 0)
   const starts: number[] = []
   for (let back = buckets - 1; back >= 0; back--) {
+    if (unit === 'hour') {
+      starts.push(last.getTime() - back * HOUR_MS)
+      continue
+    }
     const d = new Date(last)
-    if (unit === 'hour') d.setHours(d.getHours() - back)
-    else d.setDate(d.getDate() - back)
+    d.setDate(d.getDate() - back)
     starts.push(d.getTime())
   }
   return starts

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -341,3 +341,31 @@ export function fmtMicroUsd(micro: number): string {
   const sign = micro < 0 ? '-' : ''
   return `${sign}$${(Math.abs(micro) / MICRO_PER_USD).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
 }
+
+/** Every transaction posted at or after `sinceMs`, newest first. The window goes to the
+ *  service as `from`, so a long ledger costs one page instead of however many it takes to
+ *  walk back; the client-side cut stays because a billing image that predates the parameter
+ *  ignores it and answers with everything, and this console deploys ahead of that image.
+ *
+ *  `maxPages` is a runaway guard, not a policy: a ledger busier than that under-reports
+ *  rather than paging all of it for one total. */
+export async function fetchBillingTransactionsSince(
+  orgId: string,
+  sinceMs: number,
+  maxPages = 10
+): Promise<BillingTransaction[]> {
+  const from = new Date(sinceMs).toISOString()
+  const out: BillingTransaction[] = []
+  let cursor: string | undefined
+  for (let page = 0; page < maxPages; page++) {
+    const { items, nextCursor } = await fetchBillingTransactions(orgId, cursor, { from })
+    // Rows are newest-first, so the window ends at the first row older than it. An unparseable
+    // `at` compares false and stays — a row this side cannot date must not silently truncate
+    // the ones behind it.
+    const older = items.findIndex((t) => Date.parse(t.at) < sinceMs)
+    out.push(...(older < 0 ? items : items.slice(0, older)))
+    if (older >= 0 || !nextCursor) break
+    cursor = nextCursor
+  }
+  return out
+}

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -38,8 +38,13 @@ export const consoleKeys = {
     orgId: string | null | undefined,
     provider: Provider
   ) => consoleKey(orgId, 'session-access', provider),
-  usage: <const Range extends string>(orgId: string | null | undefined, range: Range) =>
-    consoleKey(orgId, 'usage', range),
+  /** `source` is a REQUEST parameter (the CP scopes the whole aggregate to one metering
+   *  ingress), so it keys apart from the unscoped read rather than being filtered out of it. */
+  usage: <const Range extends string, const Source extends string = 'all'>(
+    orgId: string | null | undefined,
+    range: Range,
+    source: Source = 'all' as Source
+  ) => consoleKey(orgId, 'usage', range, source),
   /** Billing rows come from the separate billing service (lib/billing-api), but they
    *  are org-scoped like everything else here, so they key the same way. */
   billingAccount: (orgId: string | null | undefined) => consoleKey(orgId, 'billing-account'),
@@ -47,6 +52,11 @@ export const consoleKeys = {
   /** The credit rows of the last 30 days — paged out of the same feed, so it keys apart
    *  from the first page `billingTransactions` serves the Billing table. */
   billingTopUps: (orgId: string | null | undefined) => consoleKey(orgId, 'billing-top-ups'),
+  /** The Activity chart's window, keyed per range: a wider range is not a superset it can
+   *  slice, because the page cap truncates a long ledger and a 90-day answer may already
+   *  have lost days a 24-hour answer carries in full. */
+  billingActivity: <const Range extends string>(orgId: string | null | undefined, range: Range) =>
+    consoleKey(orgId, 'billing-activity', range),
   sessions: (
     orgId: string | null | undefined,
     cursor: string,


### PR DESCRIPTION
Two changes to the console's money surfaces, plus the CP-side commit they need (see the note at the bottom).

## Billing — Activity card

Implements the design's `Activity` card between the balance grid and the transactions table: the ledger bucketed into local calendar hours/days over 24h / 7d / 30d / 90d, drawn with recharts, one series at a time (Usage or Top-ups).

Both series come out of the **same feed the transactions table reads** — the billing service exposes no time series of its own. So the card states what the ledger says and nothing more: no burn rate, no projection, no "days left". It renders only once the ledger has rows, and an empty range says so in words rather than drawing an all-zero plot.

- `lib/billing-activity.ts` — pure bucketing (range table, window start, `bucketActivity`), with a test. Boundaries are walked with `setHours`/`setDate` rather than by adding a fixed `3_600_000`/`86_400_000`, which is what keeps a DST day one day wide.
- Usage takes debit rows' exact decimal string; Top-ups takes positive credits only — a refund is a negative credit, and a bar eating into the day beside it reads as usage rather than as money coming back.
- `fetchBillingTransactionsSince` in `lib/billing-api.ts` is now the one paging-over-a-window helper, replacing the loop the Cluster page had inline (same `from` parameter, same client-side cut for a billing image that predates it, same page cap).
- The Activity fetch keys per range: a wider range is not a superset it can slice, because the page cap truncates a long ledger, so a 90-day answer may already have lost days a 24-hour answer carries in full.

## Loading skeletons

The Activity chart and the transactions table get skeletons on their real geometry — bar count = the range's bucket count, bars sized as equal flex slots at 88% width (the chart's own `barCategoryGap="12%"`), and the table's placeholder rows on the real column template with the header kept — so data landing shifts nothing.

## Spend charts: scope by metering source, not by agent placement

Both spend charts stop deriving "Cloud" by filtering the per-agent split on current placement, and ask the CP for `source=gateway` instead.

**Analytics ("Spend over time")** — the source segments ARE the API's `source` values now (`all` / `gateway` / `daemon`; segment labels unchanged). The CP scopes the whole aggregate — totals, rollups and the series alike — so the view filters nothing and every figure on the page agrees by construction. Removed with it: the `isPoolPlacementKind`-derived `cloud` flag, the client-side row filter, the per-bucket `byAgent` intersection, and the re-summed totals. **"By model" is no longer disabled while filtered** — the model rollup is scoped the same way, so it no longer has to fall back to By agent.

**Cluster → Credits card** — sums the scoped series' bucket totals and no longer reads `byAgent` at all. That drops two failure modes with it: the *"this control plane does not split spend per agent"* unavailable state, and having to wait for the agent list **plus** the org set ids before quoting a figure.

### Why this is more correct, not just simpler

Placement is CURRENT-state while the series is historical, so filtering a historical series by it made an agent moved onto the pool bring along 30 days of spend it incurred on a self-connected daemon, and one moved off drop its real Cloud spend. The old code carried that approximation as a comment; scoping by metering ingress removes it. Gateway-metered is also exactly what the billing service bills, so the Cluster card's `Spent` figure and the billing ledger now share one definition.

`source` joins the usage SWR key — it is a request parameter, so it keys apart from the unscoped read rather than being filtered out of it.

## For the reviewer

- **`ClusterDetailView.test.tsx` rewrites 5 tests** that pinned the old contract. The fixture (`usageOverPool` → `gatewayUsage`) puts a deliberately different number in `byAgent` (`$99.00`) than in `costAmount`, so an implementation that still scoped the split itself fails visibly. Two assertions are inverted on purpose — the card now quotes the figure while placement is loading, and quotes a series carrying no per-agent split at all.
- **This branch's first commit is `fix(control-plane): show gateway-metered usage to console viewers` (0b220cf2), which was PR #1353 and is currently CLOSED.** The web change here depends on it: a console viewer asking for `source=gateway` needs the CP to answer. Decide whether to revive #1353 or land it as part of this PR.
- The branch's base predates a lot of `main`; a rebase may be wanted before merge.
- `pnpm typecheck`, `eslint`, `prettier` clean; 1800 web tests pass.
- **Not visually verified** — the billing and analytics pages are behind Logto sign-in, which I could not complete. The chart reuses the Cluster card's already-shipped recharts configuration (same `SEG_FILL`, same fixed-height `ResponsiveContainer`, same `var()`-fill descendant-rule trick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
