### PR TITLE
chore(sandbox): drop OpenCode from the runtime image

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -91,7 +91,6 @@ FROM node:24-bookworm-slim AS runtime-sandbox
 # Exact pins keep the published runtime table truthful.
 ARG CLAUDE_ACP_VERSION=0.70.0
 ARG CODEX_ACP_VERSION=1.6.2-agentconnect.1
-ARG OPENCODE_VERSION=1.18.20
 ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.16
 
 # git and ca-certificates are load-bearing — the workspace surface runs git IN here over the
@@ -107,13 +106,10 @@ RUN apt-get update \
 RUN ln -sf /usr/bin/python3 /usr/local/bin/python
 
 # Global installs give `--k8s` fixed PATH binaries without registry egress at spawn time.
-# Keep scripts enabled because opencode-ai copies its platform binary during postinstall.
 RUN npm install --global --no-fund --no-audit \
   "@agentclientprotocol/claude-agent-acp@${CLAUDE_ACP_VERSION}" \
   "@agentconnect.md/codex-acp@${CODEX_ACP_VERSION}" \
-  "opencode-ai@${OPENCODE_VERSION}" \
   "@openma/deepseek-harness-acp@${DEEPSEEK_HARNESS_ACP_VERSION}" \
-  && opencode --version \
   && npm cache clean --force
 
 # Root-owned and read-only: the runtime is the untrusted party in this image, and a shim it can

--- a/docker/runtime-sandbox/generate-runtime-table.mjs
+++ b/docker/runtime-sandbox/generate-runtime-table.mjs
@@ -20,7 +20,6 @@ import { pathToFileURL } from 'node:url'
 const PROVIDED = [
   { id: 'claude-acp', bin: 'claude-agent-acp' },
   { id: 'codex-acp', bin: 'codex-acp' },
-  { id: 'opencode', bin: 'opencode', args: ['acp'] },
   // The curated catalog launches this one through npx; here it is the image's own executable,
   // which is what makes it admissible at all under --k8s (runtimes/k8s-runtimes.ts).
   { id: 'dsh-acp', bin: 'dsh-acp' }

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -12,10 +12,9 @@ shared Sandbox namespace are the only isolation boundaries, and a provider key i
 the sandbox, so this shape suits internal dogfooding and self-hosted
 bring-your-own-key. A cloud daemon accepts the shared `MODEL_BASE_URL`/`MODEL_TOKEN` pair,
 or a runtime-scoped one that replaces it whole (`ANTHROPIC_MODEL_*` for Claude,
-`OPENAI_MODEL_*` for Codex, `DEEPSEEK_MODEL_*` for the DeepSeek Harness — OpenCode takes the
-shared pair, having no single base of its own), and translates it for that runtime at spawn;
-a configured key server replaces the static token with a session-scoped pair. The runtime
-image still accepts the legacy deployment-owned `AC_CLAUDE_BASE_URL`/`AC_CLAUDE_API_KEY`,
+`OPENAI_MODEL_*` for Codex, `DEEPSEEK_MODEL_*` for the DeepSeek Harness), and translates it for
+that runtime at spawn; a configured key server replaces the static token with a session-scoped
+pair. The runtime image still accepts the legacy deployment-owned `AC_CLAUDE_BASE_URL`/`AC_CLAUDE_API_KEY`,
 `AC_CODEX_BASE_URL`/`AC_CODEX_API_KEY` and `AC_DEEPSEEK_BASE_URL`/`AC_DEEPSEEK_API_KEY` pod
 variables as fill-ins, but a daemon-sent value wins — including for DeepSeek Harness, whose
 `DEEPSEEK_BASE_URL`/`DEEPSEEK_API_KEY` the daemon now writes itself; the pod variables remain

--- a/scripts/verify-runtime-image.mjs
+++ b/scripts/verify-runtime-image.mjs
@@ -236,7 +236,7 @@ check('the published runtime table matches a fresh ACP probe of this image', () 
 // The workspace surface runs git INSIDE the sandbox over the shim's exec channel, so a missing
 // git is not a degraded feature — it is every workspace operation failing at the far end.
 check('provides the executables the shim must resolve', () => {
-  const required = ['git', 'gh', 'node', 'claude-agent-acp', 'codex-acp', 'opencode', 'dsh-acp']
+  const required = ['git', 'gh', 'node', 'claude-agent-acp', 'codex-acp', 'dsh-acp']
   const missing = required.filter((bin) => inImage(`command -v ${bin} >/dev/null && echo y || echo n`) === 'n')
   if (missing.length > 0) throw new Error(`missing: ${missing.join(', ')}`)
   return required.join(' ')


### PR DESCRIPTION
## What

The runtime sandbox image no longer ships `opencode-ai`.

- `docker/runtime-sandbox.Dockerfile` — removed the `OPENCODE_VERSION` pin, the global install, and the `opencode --version` build-time smoke test. The comment justifying npm scripts (opencode-ai copies its platform binary at postinstall) went with it; `--ignore-scripts` stays off, since flipping it is a separate hardening call.
- `docker/runtime-sandbox/generate-runtime-table.mjs` — dropped the `opencode` entry from `PROVIDED`, so the published runtime table now declares `claude-acp`, `codex-acp`, `dsh-acp`.
- `scripts/verify-runtime-image.mjs` — dropped `opencode` from the executables the shim must resolve, which would otherwise fail the verify run against the new image.
- `docs/designs/cluster-spawn-and-shim.md` — the cloud-daemon env-translation paragraph loses its "OpenCode takes the shared pair" clause.

## What is deliberately untouched

Host-mode OpenCode. A daemon that finds a local install still probes it (`runtimes/probe.ts`), builds its model catalog (`model-catalog.ts`) and translates `OPENCODE_CONFIG_CONTENT` (`model-provider-config.ts`); `key-server.md` and the README badge still describe that path. Only the cluster sandbox stops offering the runtime.

`scripts/runtime-table-diff.test.mjs` keeps `opencode` as a synthetic fixture id — arbitrary test data for the diff logic, not an image reference.

## Verification

Prettier passes on the edited files. Not run locally: a Docker build of the sandbox image plus `verify-runtime-image.mjs` — that is what actually proves the table and the executable list agree, and it is CI's job here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)