### PR TITLE
fix(daemon): bind a self-post channel root to the channel it landed in

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -349,6 +349,14 @@ Notes:
   same recheck `inherited_pending` rows get. Its own `explicit`
   re-classification survives the convergence; only a human tighten of the parent
   overrides that.
+- **The lineage fence.** Both halves of that convergence read rows that may not
+  exist yet, and a row lock cannot serialize two rows that are both still
+  uncommitted — each transaction would see no counterpart and commit its own
+  view. Ingest, §4.3 reclassification, and the post-commit recheck therefore
+  take a transaction-scoped advisory lock keyed on the session id
+  (`persistence/session-lineage-lock.ts`) before any row lock, so one side waits
+  and observes the other's committed state. Taken lock-first, never while
+  holding rows, which is what keeps a blocking lock deadlock-free.
 
 ### 4.3 Changing visibility after the fact
 

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -344,8 +344,11 @@ Notes:
   shared destination re-binds its own trusted candidate, which outranks both.
   Classifying itself does not exempt it from privacy travelling DOWN the
   lineage: a settled-private parent tightens it exactly as §4.3 would, whichever
-  of the two rows arrives first, and its own `explicit` re-classification
-  survives that convergence (only a human tighten of the parent overrides it).
+  of the two rows arrives first — and if the parent landed inside the child's own
+  classification window, the child re-runs that tightening after it commits, the
+  same recheck `inherited_pending` rows get. Its own `explicit`
+  re-classification survives the convergence; only a human tighten of the parent
+  overrides that.
 
 ### 4.3 Changing visibility after the fact
 

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -342,6 +342,10 @@ Notes:
   binds no audience by design) becomes `private`, any other conversation `org`,
   and both are unowned — the reporting trigger is the agent, not a person. A
   shared destination re-binds its own trusted candidate, which outranks both.
+  Classifying itself does not exempt it from privacy travelling DOWN the
+  lineage: a settled-private parent tightens it exactly as §4.3 would, whichever
+  of the two rows arrives first, and its own `explicit` re-classification
+  survives that convergence (only a human tighten of the parent overrides it).
 
 ### 4.3 Changing visibility after the fact
 

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -330,6 +330,12 @@ Notes:
   agent. The child takes the parent's `visibility` + `ownerIdentity` at
   ingest; §4.5 defines the durable reconciliation semantics for out-of-order
   arrival and later parent changes.
+- **A self-post channel root binds where it landed, not where it came from.**
+  An agent's channel-ROOT post seeds a new session for the thread it just
+  created, so that thread's own conversation is its external source scope. The
+  origin session travels as lineage only: inheriting its scope would bind the
+  seed to a conversation it does not live in — readable by that channel's
+  audience, and rejecting the first human reply as a cross-source turn.
 
 ### 4.3 Changing visibility after the fact
 

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -205,7 +205,7 @@ hidden unresolved candidate after GitHub sync is enabled.
 
 ### 4.1 Protocol: new telemetry fields
 
-`EventSession` (`packages/protocol/src/frames/telemetry.ts`) gains four
+`EventSession` (`packages/protocol/src/frames/telemetry.ts`) gains five
 optional fields:
 
 ```ts
@@ -213,6 +213,7 @@ conversationKind?: 'dm' | 'group_dm' | 'channel'
 transportScope?: string // trusted workspace/tenant scope for ownerIdentity, §2
 launchCorrelationId?: string // Web API launch provenance, §4.4
 sourceBindingKind?: 'local' | 'external' // daemon-pinned source provenance
+directDestination?: true // this row's coordinates are its own conversation, §4.2
 ```
 
 Shared-source sessions additionally report a provider-specific
@@ -336,6 +337,11 @@ Notes:
   origin session travels as lineage only: inheriting its scope would bind the
   seed to a conversation it does not live in — readable by that channel's
   audience, and rejecting the first human reply as a cross-source turn.
+  Such a row reports `directDestination` and is classified here rather than by
+  inheritance, even though it keeps `parentSessionId`: a DM destination (which
+  binds no audience by design) becomes `private`, any other conversation `org`,
+  and both are unowned — the reporting trigger is the agent, not a person. A
+  shared destination re-binds its own trusted candidate, which outranks both.
 
 ### 4.3 Changing visibility after the fact
 

--- a/packages/control-plane/src/domain/session-visibility.test.ts
+++ b/packages/control-plane/src/domain/session-visibility.test.ts
@@ -9,6 +9,45 @@ describe('classifySession — the §4.2 default rules', () => {
     })
   })
 
+  // A self-post channel ROOT (or a peer woken by a mention there) keeps its parent for lineage
+  // but lives in its own conversation, so inheriting would hand it that conversation's readers.
+  it('classifies a direct-destination child by its own conversation, unowned', () => {
+    expect(
+      classifySession({
+        parentSessionId: 'parent-1',
+        directDestination: true,
+        platform: 'slack',
+        conversationKind: 'dm',
+        transportScope: 'T1',
+        triggeredBy: 'agent-uuid'
+      })
+    ).toEqual({ visibility: 'private', ownerIdentity: null, source: 'default' })
+    expect(
+      classifySession({
+        parentSessionId: 'parent-1',
+        directDestination: true,
+        platform: 'slack',
+        conversationKind: 'channel',
+        transportScope: 'T1',
+        triggeredBy: 'agent-uuid'
+      })
+    ).toEqual({ visibility: 'org', ownerIdentity: null, source: 'default' })
+    // Without the flag the same row still inherits — the ordinary A2A path is untouched.
+    expect(classifySession({ parentSessionId: 'parent-1', platform: 'slack', conversationKind: 'dm' })).toEqual({
+      inherit: true
+    })
+    // And the flag never widens a ROOT session: with no parent the ordinary IM rules own it.
+    expect(
+      classifySession({
+        directDestination: true,
+        platform: 'slack',
+        conversationKind: 'dm',
+        transportScope: 'T1',
+        triggeredBy: 'U1'
+      })
+    ).toEqual({ visibility: 'private', ownerIdentity: 'slack:T1:U1', source: 'default' })
+  })
+
   it('classifies webchat private and owns it via the resolved binding', () => {
     expect(classifySession({ platform: 'webchat', triggeredBy: 'dev@example.com', webchatOwnerUserId: 'u1' })).toEqual({
       visibility: 'private',

--- a/packages/control-plane/src/domain/session-visibility.ts
+++ b/packages/control-plane/src/domain/session-visibility.ts
@@ -39,6 +39,9 @@ export interface SessionClassificationInput {
   triggeredBy?: string
   /** Present ⇒ an A2A child: it inherits from its parent under a row lock (§4.5). */
   parentSessionId?: string
+  /** Daemon-reported: this row's coordinates ARE its own conversation (an agent's channel-ROOT
+   *  post, or a peer woken by a platform mention there), so a parent link is lineage only. */
+  directDestination?: boolean
   /** Resolved `WebchatConversation.userId`, or null when the lookup missed. */
   webchatOwnerUserId?: string | null
   /** Present ⇒ a Web API launch (§4.4); the value is its resolved principal or null. */
@@ -71,6 +74,7 @@ function imOwnerIdentity(input: SessionClassificationInput): string | null {
  * | origin                        | visibility      | ownerIdentity                    |
  * | ----------------------------- | --------------- | -------------------------------- |
  * | A2A child (`parentSessionId`) | inherits parent | inherits parent                  |
+ * | …that child's own conversation| `private` (DM) / `org` | null (the trigger is the agent) |
  * | webchat / Playground          | `private`       | `user:<WebchatConversation.userId>` |
  * | Web API launch (§4.4)         | `private`       | `user:<launch principal>`        |
  * | cron / hook / dream           | `org`           | null                             |
@@ -82,7 +86,19 @@ export function classifySession(input: SessionClassificationInput): SessionClass
   // DM or Playground session copies the delegated prompt into the child
   // transcript, so classifying children `org` would expose it to every viewer
   // of the target agent. Resolution needs the parent row under a lock (§4.5).
-  if (input.parentSessionId) return { inherit: true }
+  if (input.parentSessionId) {
+    // …unless the child IS its own conversation: an agent's channel-ROOT post, or a peer woken
+    // by a mention observed there. Nothing of the parent's is copied into such a row — its
+    // content is what the agent published in that conversation and what people reply there — so
+    // inheriting would give it the readers of a conversation it does not live in (§4.2). It
+    // classifies by its own shape, unowned: the reporting trigger is the agent, not a person,
+    // and a shared external destination is re-bound from the row's own trusted candidate.
+    if (input.directDestination) {
+      const visibility: SessionVisibility = input.conversationKind === 'dm' ? 'private' : 'org'
+      return { visibility, ownerIdentity: null, source: 'default' }
+    }
+    return { inherit: true }
+  }
 
   // Webchat/Playground. `triggeredBy` here is the console user's email, which
   // degrades under devAuth and is not a stable key — the binding lookup is the

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -473,6 +473,18 @@ export class PgSessionRepo implements SessionRepo {
             legacyUnresolved: false,
             classifiedPolicyRev: null
           }
+    // A row that keeps a parent link but classifies ITSELF (a direct destination, or a
+    // trusted candidate of its own) still serializes against a concurrent §4.3 tightening
+    // cascade: that cascade re-scans each level only after locking it `FOR UPDATE`, so a
+    // child committing without `FOR SHARE` on its parent could slip past the scan. The
+    // inheriting path below takes the same lock, for the values too.
+    if (ev.parentSessionId && (direct || ev.externalCandidate)) {
+      await tx.$queryRaw(Prisma.sql`
+        SELECT 1 FROM "session_meta"
+        WHERE "id" = ${ev.parentSessionId} AND "orgId" = ${orgId}
+        FOR SHARE
+      `)
+    }
     if (ev.externalCandidate) {
       const candidate = ev.externalCandidate
       await tx.sessionExternalAccessPolicy.upsert({

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -413,6 +413,11 @@ type ResolvedSessionClassification = {
   visibility: SessionVisibility
   ownerIdentity: string | null
   source: VisibilitySource
+  /** Internal, never a column: this row classified ITSELF while its parent was absent or still
+   *  `inherited_pending`, so no parent state could be consumed under the lock. Such a row owes a
+   *  post-commit recheck — the parent may have inserted and finished its own descendant scan
+   *  while this one was invisible to it. */
+  parentUnsettled?: boolean
   externalProvider: string | null
   externalScopeId: string | null
   externalResolution: ExternalResolution | null
@@ -507,8 +512,11 @@ export class PgSessionRepo implements SessionRepo {
     // applies the same rewrite now. Tightening only — it never widens a row, and a parent
     // still holding the `inherited_pending` placeholder is NOT evidence of privacy (copying
     // it would strand this row private when the real ancestor settles `org`).
-    const parentTightened =
-      parent.length === 1 && parent[0]!.visibility === 'private' && parent[0]!.visibilitySource !== 'inherited_pending'
+    const parentSettled = parent.length === 1 && parent[0]!.visibilitySource !== 'inherited_pending'
+    const parentTightened = parentSettled && parent[0]!.visibility === 'private'
+    // Only meaningful for a row that classifies itself; the inheriting path below marks the same
+    // situation `inherited_pending` and is rechecked by `settleFromParent`.
+    const parentUnsettled = ev.parentSessionId !== undefined && !parentSettled
     const applyParentTightening = (row: ResolvedSessionClassification): ResolvedSessionClassification =>
       !parentTightened
         ? row
@@ -569,6 +577,7 @@ export class PgSessionRepo implements SessionRepo {
       const base = direct ?? { visibility: 'org' as const, ownerIdentity: null, source: 'default' as const }
       return applyParentTightening({
         ...base,
+        ...(parentUnsettled ? { parentUnsettled } : {}),
         // A Feishu/Lark p2p conversation is both a private direct session and a
         // provider-bound candidate. Keep its owner-only baseline while sync is
         // disabled; enabling the policy atomically switches every candidate to
@@ -581,7 +590,7 @@ export class PgSessionRepo implements SessionRepo {
         classifiedPolicyRev: policy.currentRev
       })
     }
-    if (direct) return applyParentTightening(direct)
+    if (direct) return applyParentTightening({ ...direct, ...(parentUnsettled ? { parentUnsettled } : {}) })
     if (!classification) {
       return {
         visibility: 'org',
@@ -770,7 +779,7 @@ export class PgSessionRepo implements SessionRepo {
   }
 
   async recordMilestone(ev: EventSessionInput): Promise<SessionMilestoneResult> {
-    const result = await withAmbientTx(this.db, async (tx) => this.upsertMilestone(tx, ev))
+    const { parentUnsettled, ...result } = await withAmbientTx(this.db, async (tx) => this.upsertMilestone(tx, ev))
     if (!result.recorded || !result.session) return result
     // Out-of-order arrival: our parent may have landed while we were writing.
     // Settling ourselves can in turn settle descendants that were waiting on us,
@@ -782,11 +791,59 @@ export class PgSessionRepo implements SessionRepo {
         result.session.parentSessionId
       )
       if (self) return { ...result, session: self, settled: [...result.settled, ...descendants] }
+      return result
+    }
+    // The same window for a row that classified ITSELF: our parent could have inserted AND
+    // finished its descendant scan while this row was still invisible to it, so neither side
+    // would revisit us. Re-run the parent's tightening now that we are committed — it is
+    // idempotent, and a non-private parent leaves this row's own classification alone.
+    if (parentUnsettled && result.session.parentSessionId) {
+      const converged = await this.convergeFromParent(result.session.orgId, result.session.parentSessionId)
+      if (converged.length > 0) {
+        const self = converged.find((row) => row.id === result.session!.id)
+        return {
+          ...result,
+          ...(self ? { session: self } : {}),
+          settled: [...result.settled, ...converged.filter((row) => row.id !== result.session!.id)]
+        }
+      }
     }
     return result
   }
 
-  private async upsertMilestone(tx: PrismaLike, ev: EventSessionInput): Promise<SessionMilestoneResult> {
+  /**
+   * Post-commit half of §4.2 direct-destination convergence, mirroring `settleFromParent` for
+   * rows that classify themselves: tightening only, never inheritance. Runs the parent's own
+   * descendant rewrite, so it also catches siblings that raced through the same window.
+   */
+  private async convergeFromParent(orgId: OrgId, parentSessionId: SessionId): Promise<SessionMetaRecord[]> {
+    return withAmbientTx(this.db, async (tx) => {
+      const parent = await tx.$queryRaw<
+        Array<{ visibility: string; ownerIdentity: string | null; visibilitySource: string }>
+      >(
+        Prisma.sql`
+          SELECT "visibility", "ownerIdentity", "visibilitySource"
+          FROM "session_meta"
+          WHERE "id" = ${parentSessionId} AND "orgId" = ${orgId}
+          FOR SHARE
+        `
+      )
+      // Still absent, still a placeholder, or not private: nothing to converge — and when it
+      // settles later, its own milestone runs this rewrite from the other side.
+      if (parent.length !== 1 || parent[0]!.visibilitySource === 'inherited_pending') return []
+      if (parent[0]!.visibility !== 'private') return []
+      return await this.tightenDescendants(
+        tx,
+        { id: parentSessionId, orgId, ownerIdentity: parent[0]!.ownerIdentity },
+        { includeExplicit: false }
+      )
+    })
+  }
+
+  private async upsertMilestone(
+    tx: PrismaLike,
+    ev: EventSessionInput
+  ): Promise<SessionMilestoneResult & { parentUnsettled?: boolean }> {
     const endedAt = ev.phase === 'end' ? ev.at : undefined
     const lastActivityAt = ev.lastActivityAt ?? ev.at
     // Webchat current-session fence: lock the durable conversation row BEFORE
@@ -1050,7 +1107,7 @@ export class PgSessionRepo implements SessionRepo {
           AND p."state" <> 'disabled'::"ExternalAccessPolicyState"
       `)
     }
-    return { recorded: true, session, settled }
+    return { recorded: true, session, settled, ...(cls.parentUnsettled ? { parentUnsettled: true } : {}) }
   }
 
   async listPage(q: SessionPageQuery): Promise<SessionPageRecord> {

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -20,6 +20,7 @@ import {
   type SessionMeta
 } from '../../generated/prisma/client.js'
 import { withAmbientTx, type PrismaLike } from '../prisma.js'
+import { lockSessionLineage } from '../session-lineage-lock.js'
 import type {
   SessionRepo,
   SessionMilestoneResult,
@@ -818,6 +819,8 @@ export class PgSessionRepo implements SessionRepo {
    */
   private async convergeFromParent(orgId: OrgId, parentSessionId: SessionId): Promise<SessionMetaRecord[]> {
     return withAmbientTx(this.db, async (tx) => {
+      // The parent may still be committing; the fence makes this recheck observe it.
+      await lockSessionLineage(tx, [parentSessionId])
       const parent = await tx.$queryRaw<
         Array<{ visibility: string; ownerIdentity: string | null; visibilitySource: string }>
       >(
@@ -846,6 +849,10 @@ export class PgSessionRepo implements SessionRepo {
   ): Promise<SessionMilestoneResult & { parentUnsettled?: boolean }> {
     const endedAt = ev.phase === 'end' ? ev.at : undefined
     const lastActivityAt = ev.lastActivityAt ?? ev.at
+    // §4.2/§4.5 lineage fence, ahead of every row lock in this transaction: this row and its
+    // parent may both be uncommitted, and no row lock can serialize two rows that do not exist
+    // yet (`lockSessionLineage`). Own id included because this row may itself be a parent.
+    await lockSessionLineage(tx, [ev.sessionId, ev.parentSessionId])
     // Webchat current-session fence: lock the durable conversation row BEFORE
     // the session upsert. Pointer maintenance (below), authorization reads
     // (which lock the same conversation row FOR UPDATE), and any concurrent
@@ -1671,6 +1678,9 @@ export class PgSessionRepo implements SessionRepo {
     }) => boolean
   ): Promise<SessionVisibilityChange> {
     return withAmbientTx(this.db, async (tx) => {
+      // Same fence as ingest, before this transaction's first row lock: the cascade below scans
+      // for children, and a child whose row is still uncommitted is invisible to that scan.
+      await lockSessionLineage(tx, [sessionId])
       const locked = await tx.$queryRaw<
         Array<{ visibility: string; ownerIdentity: string | null; externalProvider: string | null }>
       >(Prisma.sql`

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -473,18 +473,50 @@ export class PgSessionRepo implements SessionRepo {
             legacyUnresolved: false,
             classifiedPolicyRev: null
           }
-    // A row that keeps a parent link but classifies ITSELF (a direct destination, or a
-    // trusted candidate of its own) still serializes against a concurrent §4.3 tightening
-    // cascade: that cascade re-scans each level only after locking it `FOR UPDATE`, so a
-    // child committing without `FOR SHARE` on its parent could slip past the scan. The
-    // inheriting path below takes the same lock, for the values too.
-    if (ev.parentSessionId && (direct || ev.externalCandidate)) {
-      await tx.$queryRaw(Prisma.sql`
-        SELECT 1 FROM "session_meta"
-        WHERE "id" = ${ev.parentSessionId} AND "orgId" = ${orgId}
-        FOR SHARE
-      `)
-    }
+    // The parent under `FOR SHARE`, read for EVERY row that keeps a parent link — not only
+    // the inheriting ones. A row that classifies itself must still land in the state a §4.3
+    // tightening would have left it in: the cascade re-scans each level only after locking
+    // it, so a child that merely waited on the lock and then ignored what it read would
+    // commit `org` after the cascade finished, and the outcome would depend on which
+    // committed first. `applyParentTightening` below is that convergence.
+    const parent = ev.parentSessionId
+      ? await tx.$queryRaw<
+          Array<{
+            visibility: string
+            ownerIdentity: string | null
+            visibilitySource: string
+            externalProvider: string | null
+            externalScopeId: string | null
+            externalResolution: string | null
+            legacyUnresolved: boolean
+            classifiedPolicyRev: bigint | null
+          }>
+        >(
+          Prisma.sql`
+            SELECT "visibility", "ownerIdentity", "visibilitySource",
+                   "externalProvider", "externalScopeId", "externalResolution",
+                   "legacyUnresolved", "classifiedPolicyRev"
+            FROM "session_meta"
+            WHERE "id" = ${ev.parentSessionId} AND "orgId" = ${orgId}
+            FOR SHARE
+          `
+        )
+      : []
+    // A parent that is settled-private has either been tightened (§4.3) or was private from
+    // birth; either way the cascade rewrites this row's level the moment it runs, so ingest
+    // applies the same rewrite now. Tightening only — it never widens a row, and a parent
+    // still holding the `inherited_pending` placeholder is NOT evidence of privacy (copying
+    // it would strand this row private when the real ancestor settles `org`).
+    const parentTightened =
+      parent.length === 1 && parent[0]!.visibility === 'private' && parent[0]!.visibilitySource !== 'inherited_pending'
+    const applyParentTightening = (row: ResolvedSessionClassification): ResolvedSessionClassification =>
+      !parentTightened
+        ? row
+        : row.externalProvider !== null
+          ? // The cascade quarantines a shared descendant instead of hiding it: the audience is
+            // immutable, so its resolution is invalidated and it reads to nobody.
+            { ...row, visibility: 'external', ownerIdentity: null, externalResolution: 'invalid', source: 'inherited' }
+          : { ...row, visibility: 'private', ownerIdentity: parent[0]!.ownerIdentity, source: 'inherited' }
     if (ev.externalCandidate) {
       const candidate = ev.externalCandidate
       await tx.sessionExternalAccessPolicy.upsert({
@@ -535,7 +567,7 @@ export class PgSessionRepo implements SessionRepo {
         resolution = 'invalid'
       }
       const base = direct ?? { visibility: 'org' as const, ownerIdentity: null, source: 'default' as const }
-      return {
+      return applyParentTightening({
         ...base,
         // A Feishu/Lark p2p conversation is both a private direct session and a
         // provider-bound candidate. Keep its owner-only baseline while sync is
@@ -547,9 +579,9 @@ export class PgSessionRepo implements SessionRepo {
         externalResolution: resolution,
         legacyUnresolved: false,
         classifiedPolicyRev: policy.currentRev
-      }
+      })
     }
-    if (direct) return direct
+    if (direct) return applyParentTightening(direct)
     if (!classification) {
       return {
         visibility: 'org',
@@ -562,29 +594,6 @@ export class PgSessionRepo implements SessionRepo {
         classifiedPolicyRev: null
       }
     }
-    const parent = ev.parentSessionId
-      ? await tx.$queryRaw<
-          Array<{
-            visibility: string
-            ownerIdentity: string | null
-            visibilitySource: string
-            externalProvider: string | null
-            externalScopeId: string | null
-            externalResolution: string | null
-            legacyUnresolved: boolean
-            classifiedPolicyRev: bigint | null
-          }>
-        >(
-          Prisma.sql`
-            SELECT "visibility", "ownerIdentity", "visibilitySource",
-                   "externalProvider", "externalScopeId", "externalResolution",
-                   "legacyUnresolved", "classifiedPolicyRev"
-            FROM "session_meta"
-            WHERE "id" = ${ev.parentSessionId} AND "orgId" = ${orgId}
-            FOR SHARE
-          `
-        )
-      : []
     // Parent not here yet (it may live on another daemon, or simply arrive
     // later): start private + unowned and mark the row for one-time settlement.
     //

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -759,8 +759,13 @@ export class PgSessionRepo implements SessionRepo {
       `)
       if (rows.length !== 1) return []
       const self = toRecord(rows[0]!)
-      // We just settled — anything that was waiting on US can settle now too.
-      return [self, ...(await this.settlePendingChildren(tx, self))]
+      // We just settled — anything that was waiting on US can settle now too, and a private
+      // outcome converges the descendants that classified themselves (see `upsertMilestone`).
+      const settled = await this.settlePendingChildren(tx, self)
+      if (self.visibility === 'private') {
+        settled.push(...(await this.tightenDescendants(tx, self, { includeExplicit: false })))
+      }
+      return [self, ...settled]
     })
   }
 
@@ -998,6 +1003,13 @@ export class PgSessionRepo implements SessionRepo {
     // would drop it out of the scan when the real ancestor finally lands.
     const settled =
       session.visibilitySource === 'inherited_pending' ? [] : await this.settlePendingChildren(tx, session)
+    // Settlement alone only rewrites `inherited_pending` descendants, so a descendant that
+    // classified ITSELF (a direct destination, §4.2) would stay org-visible under a private
+    // parent purely because it arrived first. Converge it the way a §4.3 tighten would — its
+    // own explicit re-classification survives, and a non-private parent changes nothing.
+    if (session.visibility === 'private' && session.visibilitySource !== 'inherited_pending') {
+      settled.push(...(await this.tightenDescendants(tx, session, { includeExplicit: false })))
+    }
     if (rebound) settled.push(...(await this.settleExternalDescendants(tx, session)))
     // Keep the durable policy state aligned with the actual unresolved set.
     // A trusted retry may settle the final historical candidate after enable;
@@ -1640,63 +1652,90 @@ export class PgSessionRepo implements SessionRepo {
       `)
       const affected = target.map(toRecord)
       if (visibility === 'org') return { affected }
-
-      const seen = new Set<string>([sessionId])
-      let frontier: string[] = [sessionId]
-      while (frontier.length > 0) {
-        // Lock this level's children BEFORE reading them as a set to update: a
-        // concurrent child insert either waits here or is caught by the re-scan.
-        // `parentSessionId` is a daemon-reported free string with NO foreign key,
-        // so a session in another organization can name this one as its parent.
-        // Every lineage hop is therefore confined to the root's org: without it a
-        // tighten here would lock, rewrite, and push another tenant's row
-        // (org-scoped-data-layer.md §3 — the fence is per-hop, not just per-root).
-        const children = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
-          SELECT "id" FROM "session_meta"
-          WHERE "parentSessionId" = ANY(${frontier}::text[]) AND "orgId" = ${orgId}
-          ORDER BY "id"
-          FOR UPDATE
-        `)
-        const next = children.map((c) => c.id).filter((id) => !seen.has(id))
-        if (next.length === 0) break
-        for (const id of next) seen.add(id)
-        // Every descendant is rewritten, including ones ALREADY private: their
-        // transcripts hold text copied from this session, so they must inherit
-        // ITS owner. Leaving a private-but-differently-owned child alone would
-        // keep that other owner's access to the tightened session's content.
-        const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
-          UPDATE "session_meta" SET
-            "visibility" = CASE
-              WHEN "externalProvider" IS NULL THEN 'private'::"SessionVisibility"
-              ELSE 'external'::"SessionVisibility"
-            END,
-            "ownerIdentity" = CASE
-              WHEN "externalProvider" IS NULL THEN ${ownerIdentity}
-              ELSE NULL
-            END,
-            "externalResolution" = CASE
-              WHEN "externalProvider" IS NULL THEN "externalResolution"
-              ELSE 'invalid'::"ExternalResolution"
-            END,
-            "visibilitySource" = 'inherited'::"VisibilitySource",
-            "visibilityRev" = "visibilityRev" + 1,
-            "updatedAt" = CURRENT_TIMESTAMP
-          WHERE "id" = ANY(${next}::text[])
-            AND "orgId" = ${orgId}
-            AND (
-              ("externalProvider" IS NULL AND "visibility" <> 'private'::"SessionVisibility")
-              OR ("externalProvider" IS NULL AND "ownerIdentity" IS DISTINCT FROM ${ownerIdentity})
-              OR ("externalProvider" IS NOT NULL AND "visibility" <> 'external'::"SessionVisibility")
-              OR ("externalProvider" IS NOT NULL AND "externalResolution" <> 'invalid'::"ExternalResolution")
-              OR "visibilitySource" <> 'inherited'::"VisibilitySource"
-            )
-          RETURNING *
-        `)
-        affected.push(...rows.map(toRecord))
-        frontier = next
-      }
+      // A human tightening overrides a descendant's own re-classification — privacy wins.
+      affected.push(
+        ...(await this.tightenDescendants(
+          tx,
+          { id: sessionId, orgId, ownerIdentity: current.ownerIdentity },
+          { includeExplicit: true }
+        ))
+      )
       return { affected }
     })
+  }
+
+  /**
+   * The §4.3 descendant rewrite, shared with §4.5 settlement: privacy travels DOWN a lineage.
+   * A plain descendant takes the root's owner — including one already private, whose transcript
+   * holds text copied from the root and must not keep a different owner's access. A shared
+   * descendant's audience is immutable, so it is quarantined (`invalid`) rather than hidden.
+   *
+   * Lock-then-scan per level: a concurrent child insert either waits on the level's lock or is
+   * caught by the next scan. `parentSessionId` is a daemon-reported free string with NO foreign
+   * key, so a session in another organization can name this one as its parent — every hop is
+   * confined to the root's org, or a tighten here would rewrite and push another tenant's row
+   * (org-scoped-data-layer.md §3: the fence is per-hop, not just per-root).
+   *
+   * `includeExplicit` separates the callers. A human tightening (§4.3) overrides a descendant's
+   * own decision; convergence on data ARRIVAL must not, because widening a child stays its
+   * owner's own decision (§4.5) and would otherwise be undone by the parent's next milestone.
+   * Idempotent either way — the predicate matches only rows that still differ.
+   */
+  private async tightenDescendants(
+    tx: PrismaLike,
+    root: { id: string; orgId: string; ownerIdentity: string | null },
+    { includeExplicit }: { includeExplicit: boolean }
+  ): Promise<SessionMetaRecord[]> {
+    const { id, orgId, ownerIdentity } = root
+    const keepExplicit = includeExplicit
+      ? Prisma.empty
+      : Prisma.sql`AND "visibilitySource" <> 'explicit'::"VisibilitySource"`
+    const affected: SessionMetaRecord[] = []
+    const seen = new Set<string>([id])
+    let frontier: string[] = [id]
+    while (frontier.length > 0) {
+      const children = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+        SELECT "id" FROM "session_meta"
+        WHERE "parentSessionId" = ANY(${frontier}::text[]) AND "orgId" = ${orgId}
+        ORDER BY "id"
+        FOR UPDATE
+      `)
+      const next = children.map((c) => c.id).filter((childId) => !seen.has(childId))
+      if (next.length === 0) break
+      for (const childId of next) seen.add(childId)
+      const rows = await tx.$queryRaw<SessionMeta[]>(Prisma.sql`
+        UPDATE "session_meta" SET
+          "visibility" = CASE
+            WHEN "externalProvider" IS NULL THEN 'private'::"SessionVisibility"
+            ELSE 'external'::"SessionVisibility"
+          END,
+          "ownerIdentity" = CASE
+            WHEN "externalProvider" IS NULL THEN ${ownerIdentity}
+            ELSE NULL
+          END,
+          "externalResolution" = CASE
+            WHEN "externalProvider" IS NULL THEN "externalResolution"
+            ELSE 'invalid'::"ExternalResolution"
+          END,
+          "visibilitySource" = 'inherited'::"VisibilitySource",
+          "visibilityRev" = "visibilityRev" + 1,
+          "updatedAt" = CURRENT_TIMESTAMP
+        WHERE "id" = ANY(${next}::text[])
+          AND "orgId" = ${orgId}
+          AND (
+            ("externalProvider" IS NULL AND "visibility" <> 'private'::"SessionVisibility")
+            OR ("externalProvider" IS NULL AND "ownerIdentity" IS DISTINCT FROM ${ownerIdentity})
+            OR ("externalProvider" IS NOT NULL AND "visibility" <> 'external'::"SessionVisibility")
+            OR ("externalProvider" IS NOT NULL AND "externalResolution" <> 'invalid'::"ExternalResolution")
+            OR "visibilitySource" <> 'inherited'::"VisibilitySource"
+          )
+          ${keepExplicit}
+        RETURNING *
+      `)
+      affected.push(...rows.map(toRecord))
+      frontier = next
+    }
+    return affected
   }
 
   async recordVisibilityAck(sessionId: SessionId, visibilityRev: number): Promise<void> {

--- a/packages/control-plane/src/persistence/session-lineage-lock.ts
+++ b/packages/control-plane/src/persistence/session-lineage-lock.ts
@@ -1,0 +1,41 @@
+/**
+ * Mutual fence for one session lineage (session-visibility.md §4.2 / §4.5).
+ *
+ * Both halves of visibility convergence read rows that MAY NOT EXIST YET: a child classifies
+ * against its parent, and a parent's tightening scan walks its children. A row lock cannot
+ * serialize two rows that are both still uncommitted — each transaction sees no counterpart and
+ * commits its own view, which leaves a self-classifying child at its own wider tier underneath a
+ * private parent. An advisory lock keyed on the session ID exists BEFORE either row, so one of
+ * the two waits and then observes the other's committed state.
+ *
+ * Taken FIRST in every participating transaction, ahead of any row lock. A transaction may then
+ * wait on rows while holding the fence, but never waits for the fence while holding rows — that
+ * ordering is what keeps a BLOCKING advisory lock deadlock-free here (unlike the try-lock scopes
+ * in `memory-connection-lock.ts`, whose callers answer 409 instead of waiting). Multi-id
+ * acquisition sorts, so two transactions sharing both keys — a child that is itself a parent —
+ * contend deterministically rather than deadlocking.
+ *
+ * Advisory locks are cluster-wide, not per database, and `hashtextextended` can collide: both
+ * only ever cost extra serialization, never correctness.
+ */
+import { Prisma } from '../generated/prisma/client.js'
+
+/** The lock key for one session's lineage. Exported so a test can hold it. */
+export function sessionLineageLockKey(sessionId: string): string {
+  return JSON.stringify(['session-lineage', sessionId])
+}
+
+/** Fence this transaction against concurrent writers of the same lineage (ids may be absent). */
+export async function lockSessionLineage(
+  tx: Prisma.TransactionClient,
+  ids: ReadonlyArray<string | null | undefined>
+): Promise<void> {
+  const present = ids.filter((id): id is string => typeof id === 'string' && id.length > 0)
+  for (const id of [...new Set(present)].sort()) {
+    // `$executeRaw`, not `$queryRaw`: the lock function returns `void`, which Prisma's row
+    // deserializer rejects as a column type.
+    await tx.$executeRaw(Prisma.sql`
+      SELECT pg_advisory_xact_lock(hashtextextended(${sessionLineageLockKey(id)}, 0))
+    `)
+  }
+}

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -53,6 +53,7 @@ async function classifyMilestone(p: EventSession, agentId: AgentId, deps: Daemon
     ...(p.transportScope !== undefined ? { transportScope: p.transportScope } : {}),
     ...(p.triggeredBy !== undefined ? { triggeredBy: p.triggeredBy } : {}),
     ...(p.parentSessionId !== undefined ? { parentSessionId: p.parentSessionId } : {}),
+    ...(p.directDestination !== undefined ? { directDestination: p.directDestination } : {}),
     ...(p.launchCorrelationId !== undefined ? { launchCorrelationId: p.launchCorrelationId } : {}),
     webchatOwnerUserId,
     launchOwnerUserId

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -14,6 +14,8 @@ import { seedPoolMember } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { PgSessionRepo } from '../../src/persistence/repositories/session.repo.js'
+import { sessionLineageLockKey } from '../../src/persistence/session-lineage-lock.js'
+import { Prisma } from '../../src/generated/prisma/client.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { PgDutyGroupRepo } from '../../src/persistence/repositories/duty-group.repo.js'
 import { PlacementResolver } from '../../src/orchestrator/placementResolver.js'
@@ -663,6 +665,64 @@ describe('session visibility — external conversation audiences', () => {
       ownerIdentity: 'user:origin-owner',
       visibilitySource: 'inherited'
     })
+  })
+
+  // …and the fence that removes the window itself: two rows of one lineage can BOTH be
+  // uncommitted, which no row lock can serialize. Ingest takes the lineage's advisory lock ahead
+  // of every row lock, so a child's classification cannot run beside an uncommitted parent.
+  it('fences a child ingest behind a concurrent writer of the same lineage', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const parentId = `s-fence-parent-${randomUUID()}`
+    const childId = `s-fence-child-${randomUUID()}`
+
+    // Stand in for the parent's in-flight transaction: hold its lineage lock and nothing else,
+    // so what the ingest waits on can only be the fence.
+    let release!: () => void
+    const held = new Promise<void>((resolve) => (release = resolve))
+    let acquired!: () => void
+    const holding = new Promise<void>((resolve) => (acquired = resolve))
+    const holder = prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${sessionLineageLockKey(parentId)}, 0))`
+      acquired()
+      await held
+    })
+    await holding
+
+    const ingest = repo.recordMilestone({
+      sessionId: SessionId(childId),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      platform: 'slack',
+      channel: 'C_POSTED',
+      at: new Date(),
+      classification: { visibility: 'org', ownerIdentity: null, source: 'default' }
+    })
+    // The waiter itself is the assertion: an unfenced ingest commits instead of queueing, and
+    // no ungranted advisory lock ever appears. Polled, not slept — a slow runner cannot make a
+    // correct run fail, and the loop ends the moment the waiter shows up.
+    for (let attempt = 0; ; attempt++) {
+      const [row] = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+        SELECT COUNT(*)::int AS "count"
+        FROM pg_locks
+        WHERE locktype = 'advisory'
+          AND granted = false
+          AND database = (SELECT oid FROM pg_database WHERE datname = current_database())
+      `)
+      if ((row?.count ?? 0) > 0) break
+      expect(attempt, 'the child ingest never waited on the lineage fence').toBeLessThan(500)
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    // …and it is waiting BEFORE it wrote anything. Without the fence in ingest the row is already
+    // committed by now (only the post-commit recheck would be queueing), which is the whole point:
+    // a classification that has already landed cannot observe the parent this fence is waiting for.
+    expect(await prisma.sessionMeta.findUnique({ where: { id: childId } })).toBeNull()
+
+    release()
+    await holder
+    expect((await ingest).recorded).toBe(true)
   })
 
   // The post-commit settlement path (§4.5) inherits the parent's audience after

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -479,6 +479,46 @@ describe('session visibility — external conversation audiences', () => {
     expect((await repo.getExternalAccessPolicy(OrgId(DEFAULT_ORG_ID), 'slack'))?.state).toBe('degraded')
   })
 
+  // §4.2 direct destination: a child whose coordinates are its OWN conversation (an agent's
+  // channel-ROOT post) reports a settled classification instead of `inherit`. It keeps the
+  // parent for lineage, but must not take the parent's audience — a DM seeded from a public
+  // channel session would otherwise be readable by that channel's audience.
+  it('keeps a direct-destination child out of its parent audience while keeping the lineage', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const parentId = `s-dd-parent-${randomUUID()}`
+    const childId = `s-dd-child-${randomUUID()}`
+
+    // The origin turn: an org-visible Slack channel session with a human owner.
+    await seedSessionMeta(prisma, parentId, agentId, {
+      daemonId,
+      channel: 'C_ORIGIN',
+      ownerIdentity: 'slack:T1:U1'
+    })
+
+    const child = await repo.recordMilestone({
+      sessionId: SessionId(childId),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      platform: 'slack',
+      channel: 'D_PEER',
+      at: new Date(),
+      classification: { visibility: 'private', ownerIdentity: null, source: 'default' }
+    })
+    expect(child.session).toMatchObject({
+      parentSessionId: parentId,
+      visibility: 'private',
+      ownerIdentity: null,
+      // Not `inherited`/`inherited_pending`: this row classified itself, so no settlement
+      // scan will ever hand it the parent's audience either.
+      visibilitySource: 'default',
+      externalProvider: null,
+      externalScopeId: null
+    })
+  })
+
   // The post-commit settlement path (§4.5) inherits the parent's audience after
   // the child's own transaction closed — including the interleaving where the
   // parent lands and is stamped legacy in between. Provenance must ride along, or

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -617,6 +617,54 @@ describe('session visibility — external conversation audiences', () => {
     })
   })
 
+  // The concurrent window between those two orders: the child reads no parent (there is no row to
+  // lock), the parent then inserts and finishes its own descendant scan before the child is
+  // visible to it, and the child commits its own classification. Neither side would revisit the
+  // row, so a committed self-classifying child re-runs the parent's tightening. Straddling that
+  // window is not reachable through the public API without a concurrency hook, so the post-commit
+  // half is driven directly here; the two fully ordered paths are covered above.
+  it('converges a direct-destination child whose parent landed inside its classification window', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const parentId = `s-dd-race-parent-${randomUUID()}`
+    const childId = `s-dd-race-child-${randomUUID()}`
+
+    // The child commits with no parent row in sight, keeping its own classification.
+    const child = await repo.recordMilestone({
+      sessionId: SessionId(childId),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      platform: 'slack',
+      channel: 'C_POSTED',
+      at: new Date(),
+      classification: { visibility: 'org', ownerIdentity: null, source: 'default' }
+    })
+    expect(child.session).toMatchObject({ visibility: 'org', visibilitySource: 'default' })
+
+    // The parent is now present, private, and its descendant scan already ran without seeing
+    // this child (seeded raw, exactly like a cascade that finished a moment too early).
+    await seedSessionMeta(prisma, parentId, agentId, {
+      daemonId,
+      visibility: 'private',
+      ownerIdentity: 'user:origin-owner'
+    })
+    const converged = await (
+      repo as unknown as {
+        convergeFromParent(orgId: string, parentSessionId: string): Promise<Array<{ id: string }>>
+      }
+    ).convergeFromParent(DEFAULT_ORG_ID, parentId)
+
+    // Reported back so the caller owes this row a §5.1 gate push at its new tier.
+    expect(converged.map((row) => row.id)).toContain(childId)
+    expect(await prisma.sessionMeta.findUnique({ where: { id: childId } })).toMatchObject({
+      visibility: 'private',
+      ownerIdentity: 'user:origin-owner',
+      visibilitySource: 'inherited'
+    })
+  })
+
   // The post-commit settlement path (§4.5) inherits the parent's audience after
   // the child's own transaction closed — including the interleaving where the
   // parent lands and is stamped legacy in between. Provenance must ride along, or

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -566,6 +566,57 @@ describe('session visibility — external conversation audiences', () => {
     expect(after.session).toMatchObject(expected)
   })
 
+  // The inverse arrival order: the self-classifying child lands FIRST, so there is no parent to
+  // read. Settlement alone only rewrites `inherited_pending` rows, so without convergence on the
+  // parent's own milestone this row would stay org-visible under a private parent — the same
+  // lineage, a different outcome, decided by which telemetry arrived first.
+  it('converges a direct-destination child that arrived before its private parent', async () => {
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const parentId = `s-dd-first-parent-${randomUUID()}`
+    const childId = `s-dd-first-child-${randomUUID()}`
+    const widened = `s-dd-first-widened-${randomUUID()}`
+
+    // Two self-classifying children of a parent that has not been reported yet.
+    for (const id of [childId, widened]) {
+      await repo.recordMilestone({
+        sessionId: SessionId(id),
+        parentSessionId: SessionId(parentId),
+        agentId,
+        phase: 'start',
+        platform: 'slack',
+        channel: 'C_POSTED',
+        at: new Date(),
+        classification: { visibility: 'org', ownerIdentity: null, source: 'default' }
+      })
+    }
+    // …one of which its owner then deliberately widened. A human decision on the CHILD is not
+    // reconciliation's to undo (§4.5): only an explicit tighten of the parent may override it.
+    await prisma.sessionMeta.update({ where: { id: widened }, data: { visibilitySource: 'explicit' } })
+
+    // The parent finally arrives, private from birth (a webchat/DM origin).
+    await repo.recordMilestone({
+      sessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      platform: 'webchat',
+      channel: randomUUID(),
+      at: new Date(),
+      classification: { visibility: 'private', ownerIdentity: 'user:someone', source: 'default' }
+    })
+
+    expect(await prisma.sessionMeta.findUnique({ where: { id: childId } })).toMatchObject({
+      visibility: 'private',
+      ownerIdentity: 'user:someone',
+      visibilitySource: 'inherited'
+    })
+    expect(await prisma.sessionMeta.findUnique({ where: { id: widened } })).toMatchObject({
+      visibility: 'org',
+      visibilitySource: 'explicit'
+    })
+  })
+
   // The post-commit settlement path (§4.5) inherits the parent's audience after
   // the child's own transaction closed — including the interleaving where the
   // parent lands and is stamped legacy in between. Provenance must ride along, or

--- a/packages/control-plane/test/integration/session-visibility.route.test.ts
+++ b/packages/control-plane/test/integration/session-visibility.route.test.ts
@@ -519,6 +519,53 @@ describe('session visibility — external conversation audiences', () => {
     })
   })
 
+  // …but a TIGHTENED parent still reaches it: the §4.3 cascade rewrites every descendant it
+  // can see, so a row that classifies itself must land in the same state whether it arrives
+  // before the tightening (cascade catches it) or after (this path applies it). Otherwise the
+  // outcome is commit-order dependent.
+  it('applies a tightened parent to a direct-destination child that arrives after the cascade', async () => {
+    const owner = await makeUser('sv-dd-tighten', 'owner')
+    const daemonId = await seedDaemon(prisma, randomUUID())
+    const agentId = await seedAgent(prisma, randomUUID(), { daemonId })
+    const repo = new PgSessionRepo(prisma)
+    const parentId = `s-dd-tight-parent-${randomUUID()}`
+    const early = `s-dd-tight-early-${randomUUID()}`
+    const late = `s-dd-tight-late-${randomUUID()}`
+
+    await seedSessionMeta(prisma, parentId, agentId, { daemonId, ownerIdentity: `user:${owner}` })
+    const settled = { visibility: 'org' as const, ownerIdentity: null, source: 'default' as const }
+    // One child arrives BEFORE the tightening and is swept by the cascade…
+    await repo.recordMilestone({
+      sessionId: SessionId(early),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      platform: 'slack',
+      channel: 'C_POSTED',
+      at: new Date(),
+      classification: settled
+    })
+    await appAs(owner).app.inject({
+      method: 'PUT',
+      url: `${ORG}/sessions/${parentId}/visibility`,
+      payload: { visibility: 'private' }
+    })
+    // …the other arrives after it, and must not read as the wider row the cascade already removed.
+    const after = await repo.recordMilestone({
+      sessionId: SessionId(late),
+      parentSessionId: SessionId(parentId),
+      agentId,
+      phase: 'start',
+      platform: 'slack',
+      channel: 'C_POSTED',
+      at: new Date(),
+      classification: settled
+    })
+    const expected = { visibility: 'private', ownerIdentity: `user:${owner}`, visibilitySource: 'inherited' }
+    expect(await prisma.sessionMeta.findUnique({ where: { id: early } })).toMatchObject(expected)
+    expect(after.session).toMatchObject(expected)
+  })
+
   // The post-commit settlement path (§4.5) inherits the parent's audience after
   // the child's own transaction closed — including the interleaving where the
   // parent lands and is stamped legacy in between. Provenance must ride along, or

--- a/packages/daemon/src/collab/coordinator.ts
+++ b/packages/daemon/src/collab/coordinator.ts
@@ -1327,6 +1327,12 @@ export class CollabCoordinator {
    * with `Parent session` = the origin session. This is initialization only: the root is recorded
    * for replay with the first real reply, but no model turn runs. `headless` remains a transport
    * backstop, and the hop count remains a defense for replay from an older durable inbox row.
+   *
+   * Lineage travels; the AUDIENCE does not. The seed classifies against the conversation the post
+   * landed in (`platformOrigin`), because a cross-conversation post that inherited the origin's
+   * external binding would leave the new thread bound to a channel it does not live in — every
+   * later human reply there then rejects as a cross-source turn, and the session claims the
+   * origin channel's readers (§3.3, `session-visibility.md` §4.2).
    */
   async spawnChannelRootSession(req: {
     agentId: string
@@ -1340,6 +1346,8 @@ export class CollabCoordinator {
     thread: string
     /** The post's RAW platform ts, which on Telegram differs from `thread`. */
     postTs: string
+    /** Whether the DESTINATION is a direct message, as the platform reports it. */
+    isDm?: boolean
     text: string
     originPlatform?: string
     originTransportScope?: string
@@ -1370,7 +1378,6 @@ export class CollabCoordinator {
     const originSessionId = originRec
       ? await this.host.store().ensureOutwardSessionId(originKey, req.agentId, this.host.clock().now())
       : undefined
-    const externalOrigin = await this.host.externalOriginForSession(req.agentId, originAcpSessionId)
     const originCoordPlatform = originPlatform
     const deliveryId = randomUUID()
     const callMeta: CallMeta = {
@@ -1378,8 +1385,11 @@ export class CollabCoordinator {
       hopCount,
       deliveryId,
       initializeOnly: true,
+      // The seed's audience is the conversation the post LANDED in, never the origin's: it is
+      // keyed by a thread this post just created there, and inheriting the origin conversation
+      // would claim an audience this content was never posted to (§3.3).
+      platformOrigin: true,
       ...(originSessionId ? { originSessionId } : {}),
-      ...(externalOrigin ? { externalOrigin } : {}),
       originCoords: {
         platform: originCoordPlatform,
         channel: req.originChannel,
@@ -1410,7 +1420,9 @@ export class CollabCoordinator {
       sender: { id: req.agentId, isBot: true },
       text: req.text,
       mentionedBots: [],
-      isDm: false,
+      // Load-bearing for classification, not cosmetic: the audience strategy asks whether the
+      // DESTINATION is a DM, and a Slack DM binds no conversation audience (§7.4).
+      isDm: req.isDm === true,
       // No model turn runs for this seed; headless is retained as a transport backstop.
       headless: true
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12611,6 +12611,11 @@ export class Daemon {
       ...(tenantScope ? { tenantScope } : {}),
       ...(launchCorrelationId ? { launchCorrelationId } : {}),
       sourceBindingKind: externalSource ? 'external' : 'local',
+      // A platform-observed child (a self-post channel root, or a peer woken by a mention in
+      // that very conversation) lives in a conversation of its own, so its parent link is
+      // lineage: the CP must classify it here rather than inherit an audience it was never
+      // posted to. Only the true case is written — absent keeps ordinary inheritance.
+      ...(callMeta?.platformOrigin === true ? { directDestination: true } : {}),
       ...(externalSource ?? {})
     })
     // An external-source binding (Slack/Feishu channel) no longer marks the

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -123,6 +123,11 @@ export interface CallMeta {
    * thread — so it must bind, or it can never wake an agent that already holds an
    * externally-bound session there, which is every agent already talking in the thread.
    *
+   * A channel-ROOT self-post seed carries it for the same reason: the post landed, so its
+   * channel and thread are the provider's own coordinates for a thread that did not exist
+   * before — there is no shared conversation to claim, and the alternative (inheriting the
+   * origin session's audience) binds the seed to a channel it does not live in.
+   *
    * Persisted with the inbox row alongside the rest of CallMeta, so a replayed turn makes
    * the same classification it would have made live.
    */

--- a/packages/daemon/src/mcp/ops/messaging.ts
+++ b/packages/daemon/src/mcp/ops/messaging.ts
@@ -326,6 +326,9 @@ export interface MessagingDeps extends GatewayDeps {
      *  platform ts (see the dedup note in `spawnChannelRootSession`), which on Telegram is
      *  NOT the same string as `thread`. */
     postTs: string
+    /** Whether the destination is a DM, as the platform reports it — it decides the new
+     *  session's audience the same way it decides the thread key. */
+    isDm?: boolean
     text: string
     /** Current (origin) session coords, for the new session's origin lineage. The origin
      *  may be on a DIFFERENT platform than the post (e.g. a Telegram turn posting to Slack),
@@ -659,6 +662,7 @@ export async function sendMessage(
         channel: postChannel,
         thread: postedThread,
         postTs: ts,
+        isDm: isDmTarget || directMessage,
         text: body,
         originPlatform: ctx.platform,
         ...(ctx.transportScope !== undefined ? { originTransportScope: ctx.transportScope } : {}),

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -250,6 +250,9 @@ export interface SessionRecord {
   // Null is legacy/unknown. New rows pin either an external shared input or a
   // non-external origin so a later turn cannot silently change audiences.
   sourceBindingKind?: 'local' | 'external' | null
+  /** 1 when this session's coordinates are its own conversation, so a parent link is
+   *  lineage only and the CP must not inherit the parent's audience (§4.2). */
+  directDestination?: number | null
   // session-concept §5.3: the origin (parent) session's stable acpSessionId, when this session
   // was spawned by another session's `sendMessage` (case 2a / A2A). DURABLE parent link (first-wins):
   // it authorizes this session's SessionTarget replies back to the parent on EVERY turn, not just
@@ -960,7 +963,10 @@ const SCHEMA_MIGRATIONS: ((db: StoreTx, store: { shared: boolean }) => Promise<v
         sessionId TEXT NOT NULL,
         mintedAt INTEGER NOT NULL
       );
-    `)
+    `),
+  // Whether a child session's coordinates are its OWN conversation (§4.2). Left null on
+  // existing rows: absent keeps the CP's ordinary child inheritance, which is what they got.
+  async (db) => await db.exec('ALTER TABLE sessions ADD COLUMN directDestination INTEGER')
 ]
 
 export class LocalStore {
@@ -1059,7 +1065,7 @@ export class LocalStore {
         originSessionId TEXT, lastTurnOutcome TEXT, needsParentReply INTEGER,
         externalProvider TEXT, externalRealmKey TEXT, externalResourceKind TEXT,
         externalResourceKey TEXT, externalIntegrationId TEXT, externalOriginJson TEXT,
-        sourceBindingKind TEXT,
+        sourceBindingKind TEXT, directDestination INTEGER,
         -- session-visibility.md §4.1: persisted so EVERY event/session re-emit
         -- carries them, not just the one dispatch that knew the message.
         conversationKind TEXT, tenantScope TEXT, launchCorrelationId TEXT
@@ -2443,6 +2449,7 @@ export class LocalStore {
       externalIntegrationId?: string
       externalOrigin?: ExternalSessionOrigin
       sourceBindingKind?: 'local' | 'external'
+      directDestination?: boolean
     }
   ): Promise<void> {
     await this.db
@@ -2458,7 +2465,8 @@ export class LocalStore {
            -- Unlike the source tuple, the credential locator is replaceable.
            externalIntegrationId = COALESCE(?, externalIntegrationId),
            externalOriginJson = COALESCE(externalOriginJson, ?),
-           sourceBindingKind = COALESCE(sourceBindingKind, ?)
+           sourceBindingKind = COALESCE(sourceBindingKind, ?),
+           directDestination = COALESCE(directDestination, ?)
          WHERE key = ?`
       )
       .run(
@@ -2472,6 +2480,7 @@ export class LocalStore {
         c.externalIntegrationId ?? null,
         c.externalOrigin ? JSON.stringify(c.externalOrigin) : null,
         c.sourceBindingKind ?? null,
+        c.directDestination === undefined ? null : c.directDestination ? 1 : 0,
         key
       )
   }
@@ -2492,6 +2501,7 @@ export class LocalStore {
         externalIntegrationId?: string
         externalOrigin?: ExternalSessionOrigin
         sourceBindingKind?: 'local' | 'external'
+        directDestination?: boolean
       }
     | undefined
   > {
@@ -2500,7 +2510,7 @@ export class LocalStore {
         `SELECT conversationKind, tenantScope, launchCorrelationId,
                 externalProvider, externalRealmKey, externalResourceKind,
                 externalResourceKey, externalIntegrationId, externalOriginJson,
-                sourceBindingKind
+                sourceBindingKind, directDestination
          FROM sessions WHERE agentId = ? AND acpSessionId = ?`
       )
       .get(agentId, acpSessionId)) as
@@ -2515,6 +2525,7 @@ export class LocalStore {
           externalIntegrationId: string | null
           externalOriginJson: string | null
           sourceBindingKind: 'local' | 'external' | null
+          directDestination: number | null
         }
       | undefined
     if (!row) return undefined
@@ -2530,7 +2541,8 @@ export class LocalStore {
       ...(row.externalOriginJson
         ? { externalOrigin: JSON.parse(row.externalOriginJson) as ExternalSessionOrigin }
         : {}),
-      ...(row.sourceBindingKind ? { sourceBindingKind: row.sourceBindingKind } : {})
+      ...(row.sourceBindingKind ? { sourceBindingKind: row.sourceBindingKind } : {}),
+      ...(row.directDestination ? { directDestination: true } : {})
     }
   }
 

--- a/packages/daemon/src/store/postgres-dialect.ts
+++ b/packages/daemon/src/store/postgres-dialect.ts
@@ -52,6 +52,7 @@ export const canonicalColumns = [
   'defaultModel',
   'defaultPermissionMode',
   'deliveryReason',
+  'directDestination',
   'dispatchId',
   'dreamId',
   'dueAt',

--- a/packages/daemon/src/store/session-metadata-outbox.ts
+++ b/packages/daemon/src/store/session-metadata-outbox.ts
@@ -133,6 +133,9 @@ export class SessionMetadataOutbox {
     if (classification?.sourceBindingKind !== undefined) {
       event.sourceBindingKind = classification.sourceBindingKind
     }
+    // §4.2: this row's coordinates are its own conversation, so `parentSessionId` below is
+    // lineage and the CP classifies the row instead of inheriting the parent's audience.
+    if (classification?.directDestination) event.directDestination = true
     // Only a direct trusted ingress reports a credential locator. A2A children
     // persist the same source tuple for the local gate but let the CP inherit
     // the already-validated parent scope instead of presenting the parent's bot

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
-import { transcriptChannelKey, type TranscriptEntry } from '../src/store/local-store.js'
+import { sessionKey, transcriptChannelKey, type TranscriptEntry } from '../src/store/local-store.js'
 import { stableTurnId } from '../src/messages/normalized.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import type { SlackPostOptions } from '../src/slack/connection.js'
@@ -331,6 +331,59 @@ describe('Daemon transcript records the agent reply', () => {
       expect.stringContaining('already belongs to a session created from another source'),
       'T1'
     )
+    await daemon.stop()
+  }, 15_000)
+
+  // A cross-channel root post used to seed its new thread with the ORIGIN conversation's audience,
+  // so the first human reply there rejected as a cross-source turn — and the session claimed the
+  // readers of a channel it does not live in. The seed binds where the post LANDED.
+  it('binds an agent root post in another channel to that channel, not the origin', async () => {
+    const { factory, host } = replyingHost('here is my answer')
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
+    await daemon.start()
+    const conn = makeRoutable(daemon)
+
+    // The origin turn runs in C1 and binds that channel's audience.
+    await (daemon as any).dispatch('bot-a', channelMsg('100', 'say hi in C2'), 'int-a')
+    // …then the agent posts a channel ROOT into C2, which seeds C2's new thread.
+    await (daemon as any).collab.spawnChannelRootSession({
+      agentId: 'bot-a',
+      platform: 'slack',
+      integrationId: 'int-a',
+      channel: 'C2',
+      thread: '300.1',
+      postTs: '300.1',
+      text: 'Hi! 👋',
+      originTransportScope: TRANSPORT_SCOPE,
+      originChannel: 'C1',
+      originThread: 'T1'
+    })
+    const seededKey = sessionKey('slack', 'C2', '300.1', 'bot-a', TRANSPORT_SCOPE)
+    await vi.waitFor(async () => {
+      expect(await (daemon as any).store.getSession(seededKey)).toBeTruthy()
+    }, WAIT)
+    expect(await (daemon as any).store.getSession(seededKey)).toMatchObject({
+      sourceBindingKind: 'external',
+      externalProvider: 'slack',
+      externalRealmKey: 'T1',
+      externalResourceKind: 'conversation',
+      // Pre-fix: 'C1', inherited from the origin session — the reply below then rejected.
+      externalResourceKey: 'C2'
+    })
+
+    const reply = { ...channelMsg('400', 'hello'), msgId: 'slack:C2:400', channel: 'C2', thread: '300.1' }
+    await (daemon as any).dispatch('bot-a', reply, 'int-a')
+
+    expect(conn.postMessage).not.toHaveBeenCalledWith(
+      'C2',
+      expect.stringContaining('already belongs to a session created from another source'),
+      '300.1'
+    )
+    expect(host.prompt).toHaveBeenCalledTimes(2)
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -368,6 +368,9 @@ describe('Daemon transcript records the agent reply', () => {
     }, WAIT)
     expect(await (daemon as any).store.getSession(seededKey)).toMatchObject({
       sourceBindingKind: 'external',
+      // Reported to the CP so the row is classified by THIS conversation instead of
+      // inheriting the parent's audience (session-visibility.md §4.2).
+      directDestination: 1,
       externalProvider: 'slack',
       externalRealmKey: 'T1',
       externalResourceKind: 'conversation',

--- a/packages/protocol/src/frames/session-visibility.test.ts
+++ b/packages/protocol/src/frames/session-visibility.test.ts
@@ -112,6 +112,7 @@ describe('EventSession visibility-classification fields (session-visibility.md ย
     expect(parsed.transportScope).toBeUndefined()
     expect(parsed.launchCorrelationId).toBeUndefined()
     expect(parsed.sourceBindingKind).toBeUndefined()
+    expect(parsed.directDestination).toBeUndefined()
   })
 
   it('carries conversationKind + durable transportScope + launchCorrelationId + source provenance', () => {
@@ -129,6 +130,15 @@ describe('EventSession visibility-classification fields (session-visibility.md ย
     expect(EventSession.safeParse({ ...legacyMilestone, conversationKind: 'group_dm' }).success).toBe(true)
     expect(EventSession.safeParse({ ...legacyMilestone, conversationKind: 'channel' }).success).toBe(true)
     expect(EventSession.safeParse({ ...legacyMilestone, sourceBindingKind: 'external' }).success).toBe(true)
+  })
+
+  // ยง4.2: the row's coordinates ARE its own conversation, so its parent is lineage only. Only the
+  // true case is on the wire โ€” `false` would be a claim the classifier has no use for.
+  it('carries directDestination beside the parent link, true-only', () => {
+    const parsed = EventSession.parse({ ...legacyMilestone, parentSessionId: 'acp-parent-1', directDestination: true })
+    expect(parsed.directDestination).toBe(true)
+    expect(parsed.parentSessionId).toBe('acp-parent-1')
+    expect(EventSession.safeParse({ ...legacyMilestone, directDestination: false }).success).toBe(false)
   })
 
   it('carries the exact accepted GitHub delivery as repository-scope proof', () => {

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -119,6 +119,12 @@ export const EventSession = z.object({
   // for session-key compatibility. Absent keeps mixed-version ingest on the
   // conservative legacy path.
   sourceBindingKind: z.enum(['local', 'external']).optional(),
+  // This session's coordinates ARE its own conversation — an agent's channel-ROOT
+  // post, or a peer woken by a platform-observed mention there. Its `parentSessionId`
+  // is lineage, not an audience ancestor: the row classifies by the conversation it
+  // lives in instead of inheriting one it was never posted to (§4.2). Absent keeps
+  // the ordinary child-inheritance path.
+  directDestination: z.literal(true).optional(),
   // Immutable audience candidate for a supported shared input. This is
   // metadata-only: the CP validates the integration before binding a scope and
   // resolves current provider membership only on authorized read paths.


### PR DESCRIPTION
## The bug

An agent's channel-**ROOT** post seeds a new session for the thread it just created
(`spawnChannelRootSession`, session-concept case 2a). That seed inherited the **origin**
session's external audience — `externalOriginForSession(origin)`, whose `resourceKey` is the
*origin channel*. Nothing in the seed path ever looked at where the post actually landed:
`classifyNewSessionOrThrow` skips `conversationExternalSource` for any A2A-shaped delivery
without `platformOrigin`.

So a cross-channel post — "@bot say hi in #other-channel" — bound the new thread in
`#other-channel` to `#origin-channel`. Two consequences:

1. **The first human reply there is rejected.** Slack ingress resolves the real conversation,
   `bindSessionSource`'s `sameScope` fails on `resourceKey`, and the reply gets
   *"This thread already belongs to a session created from another source. Start a new Slack
   thread and mention the agent there."* — no turn ever runs.
2. **The session claims the wrong readers.** A seed living in a *private* channel was bound to
   the *public* channel it was triggered from, so the public channel's audience could read it
   in the console (`session-visibility.md` §4.2).

Cross-*platform* posts had the same shape: a Slack-bound origin posting into Telegram stamped
the Slack scope onto the Telegram thread, and every later reply there — which resolves no
external source at all — hit `!source && existing.externalProvider ⇒ mismatch`.

### Observed in the test workspace

| | |
|---|---|
| origin session (`#ai-playground`) | bound `slack/T038…/conversation/**C0AAR1W849K**` ✅ |
| seed session (`#ai-playground-private`, root `Hi! 👋`) | channel `C0BLVB0TYPR`, scope `resourceKey = **C0AAR1W849K**` ❌ |
| the human's `hello` in that thread | rejected; the row's `model` stayed `null` |

(The agent still answered ten seconds later only because that workspace has a *second* Slack
app for the same agent: its delivery had a different `transportScope`, so it opened a second,
correctly-bound session for the same Slack thread. Unrelated config smell, not addressed here.)

## The fix

- The seed dispatch carries `platformOrigin: true` and **no** inherited `externalOrigin`, so it
  classifies against the conversation the post landed in. The post already happened, so its
  channel/thread are provider-confirmed coordinates of a thread that did not exist before —
  there is no shared conversation for a model-chosen target to claim. Origin travels as lineage
  (`originSessionId` / `originCoords` / `parentPrivate`) exactly as before.
- The destination's **DM-ness** now travels with the seed. The audience strategy asks whether
  the conversation is a DM (a Slack DM binds no conversation audience, §7.4) and the seed
  hardcoded `isDm: false`; `sendMessage` passes what it already resolved. Hand-passed DM channel
  ids on DM-insensitive platforms stay unclassified, same as for the thread key today.
- If the destination is unattributable (no integration / no live workspace id) the seed
  fails closed to a `local` binding, as any other unattributable system turn does.

## Tests

`daemon-transcript.test.ts` — "binds an agent root post in another channel to that channel, not
the origin": origin turn in `C1` → root post seeds `C2`'s thread → asserts the seed row's scope
is `C2` (pre-fix: `C1`), and that a human reply in that thread runs a turn instead of getting the
cross-source rejection. Verified failing on the pre-fix code.

`daemon-transcript` + `daemon-message-agent` + `mcp-ops`: 270 passed. Full daemon suite run
locally too (the one failure, `daemon-smoke › hands a scratch workspace with App credentials`, is
a pre-existing host-env artifact — it fails identically on a clean tree here).

## Follow-up: the destination that binds no audience (review round 1)

Binding the seed to its destination closes the reply rejection, but a destination that
*deliberately* binds no audience — a Slack DM from `sendMessage({toUser})` — still reached the CP
as an ordinary child: no external candidate plus a `parentSessionId` means `classifySession`
returned `{inherit: true}`, and the row copied the parent's visibility **and** external scope. A DM
seeded from a public-channel session therefore stayed readable by that channel's audience.

`EventSession` now carries `directDestination` — this row's coordinates ARE its own conversation.
The daemon persists it with the rest of the §4.1 classification (new `sessions.directDestination`
column, so every re-emit carries it) from the same `platformOrigin` bit that decides destination
binding. The CP classifies such a row instead of inheriting: DM ⇒ `private`, any other conversation
⇒ `org`, both unowned (the reporting trigger is the agent, not a person). A shared destination
still outranks both through its own trusted candidate, and `parentSessionId` is untouched, so
lineage and the §4.3 cascade keep working.

Also: a row that keeps a parent link but classifies itself never took the parent's `FOR SHARE`
lock, so it could commit past a concurrent §4.3 tightening cascade's re-scan. Those rows now take
it too.

Added coverage: `classifySession` unit cases for all four arms (including "without the flag it
still inherits"), a `session-visibility.route.test.ts` integration case (child lands
`private`/unowned/`visibilitySource: 'default'`, no external scope, parent kept), a protocol case
pinning the field true-only, and the daemon regression test now asserts the seeded row persists it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
