### PR TITLE
feat(gitlab): self-managed creation authority, the PAT expiry clamp, and its surfaces

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -2156,12 +2156,14 @@ IDs, tokens, and signing secrets.
 
 ## 24. Self-Managed Instances
 
-> Status: **Proposed.** Everything above is implemented and pinned to
-> GitLab.com; this section removes the pin. Scope: **GitLab Self-Managed
-> 18.11 or later, one instance per deployment** — a deployment connects to
-> GitLab.com or to one self-managed instance, never both. GitLab Dedicated,
-> plain HTTP, mTLS, SSH remotes, and instances below the floor stay outside
-> the contract. Platform assumptions verified 2026-08-23.
+> Status: **Implemented** — the N0–N4 sequence in §24.6 is merged. Everything
+> above was pinned to GitLab.com; this section removes the pin. Scope:
+> **GitLab Self-Managed 18.11 or later, one instance per deployment** — a
+> deployment connects to GitLab.com or to one self-managed instance, never
+> both. GitLab Dedicated, plain HTTP, mTLS, SSH remotes, and instances below
+> the floor stay outside the contract. Platform assumptions verified
+> 2026-08-23. Operator-facing setup is
+> [`docs/self-managed-gitlab.md`](../self-managed-gitlab.md).
 
 A self-managed instance is the same product against a different origin. The
 identity model, credential purposes, webhook verification, event mapping,
@@ -2248,10 +2250,14 @@ external state. The truth arrives at the inline pre-activation ensure, where
 a `403` is classified `service_account_creation_forbidden` on the account
 row, with tier-aware remedy copy naming the setting, the Admin Area path,
 and the Admin Mode caveat. Existing accounts, webhooks, sessions, and
-reviews are unaffected by authority being withdrawn; whether the instance
-gates PAT rotation the same way is verified during implementation, and if it
-does, the rotation-horizon warning carries this reason so an operator learns
-from a warning rather than from a bot going silent.
+reviews are unaffected by authority being withdrawn, which is why the
+classification is the account row's own state rather than an `admin_degraded`
+reason: the credential port refuses on `admin_degraded`, so filing it there
+would cut exactly the runtime leases this sentence promises. An instance that
+gates PAT minting the same way is classified the same way under a
+`rotation_`-prefixed reason, so the rotation-horizon warning names the
+withdrawn authority and an operator learns from a warning rather than from a
+bot going silent.
 
 A deployment-wide instance-administrator credential (a PAT with `api` +
 `admin_mode`, confined to a service-account lifecycle port) was designed and
@@ -2463,11 +2469,34 @@ Merge order, GitLab.com green at every step:
   spec it cannot clone, because one unservable roster entry must not fail
   registration, and the clone boundary refuses it as it always did. The boot
   warning survives only as "no https origin is permitted at all".
-- **N4 — authority and surfaces.** `service_account_creation_forbidden`
+- **N4 — authority and surfaces. Landed.** `service_account_creation_forbidden`
   with tier-aware copy, the expiry clamp with the re-derived horizon, Setup
   and Console surfaces, operator documentation (authority bundle, egress for
   Control Plane / daemon / sandbox, webhook allowlist, delegation setting
-  and Admin Mode caveat, instance quota).
+  and Admin Mode caveat, instance quota). The classification is the account
+  row's OWN state, not an `admin_degraded` reason, and that distinction is
+  load-bearing rather than cosmetic: `admin_degraded` is what the credential
+  port refuses on, so filing withdrawn authority there would cut the very
+  runtime leases §24.3 says survive it. The credential port therefore serves
+  a `service_account_creation_forbidden` account exactly as it serves a ready
+  one, and the PAT's own expiry — already checked on every grant — is the
+  bound. It is also a settled verdict rather than a fault, so the inline
+  pre-activation ensure reports it instead of spending its retry budget on an
+  answer that cannot change without a human; the ordinary Repair path
+  re-attempts. A `403` from minting or rotating a PAT on an existing account
+  classifies the same way under a `rotation_`-prefixed reason, which keeps it
+  inside the namespace a later successful sweep clears — and that heal now
+  keys on the reason's namespace alone, since the state it has to clear is no
+  longer only `admin_degraded`. Both surfaces read a NAMED reason before its
+  family, so the specific remedy is not buried under the generic rotation
+  line. The clamp is one predicate at the §7.3 validation: a `YYYY-MM-DD`
+  expiry at or below the request is accepted and RECORDED, which is the whole
+  re-derivation, because the rotation sweep reads that column; null, later,
+  or unparseable stays out of policy and fails closed. A create the instance
+  rejects for its lifetime cap gets its own reason rather than the bare
+  status. The console's floor status is answered BY the Control Plane
+  (`instanceVersionSupported` plus the enforced floor on the connection DTO)
+  rather than by a second version parser in a browser.
 
 The integration fake gains a path-prefixed non-default-port mode, an
 admin-only mode returning `403` from creation, an expiry-clamping mode, and

--- a/docs/self-managed-gitlab.md
+++ b/docs/self-managed-gitlab.md
@@ -1,0 +1,140 @@
+# Connect AgentConnect to a self-managed GitLab
+
+AgentConnect talks to **one** GitLab instance per deployment: either GitLab.com
+or one self-managed instance, never both. Everything else about the integration
+— identities, credentials, webhooks, reviews — is the same on either.
+
+This guide uses the RFC 2606 documentation name `https://gitlab.example.test`.
+Replace it with your own instance URL.
+
+## What the instance must provide
+
+| Requirement               | Why                                                                                                                                                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| GitLab **18.11 or later** | Group service accounts reached every tier, Community Edition included, at 18.11. Below that the Free-tier answer sits behind instance feature flags the API does not report, so AgentConnect refuses to provision rather than guess. |
+| **HTTPS**, one address    | Clone URLs, OAuth redirects, and GitLab's own `web_url` values only agree if there is a single address. Split internal and external addressing belongs in DNS.                                                                       |
+| A trusted certificate     | There is no skip-verify option at any layer. A private authority is supported by installing its bundle — see below.                                                                                                                  |
+
+An instance that drops below the floor after projects are already set up keeps
+serving them: existing sessions and credentials work until they expire, and
+only new setup is refused. The Control Plane records the version it observes,
+and the console shows it on the GitLab connection.
+
+## Register the OAuth application
+
+AgentConnect uses one OAuth application per deployment as its **administration**
+identity. Register it on your instance, then enter the Application ID and Secret
+in Setup.
+
+- Your own applications: `https://gitlab.example.test/-/user_settings/applications`
+- An instance-wide one, as an administrator: `https://gitlab.example.test/admin/applications`
+
+Keep **Confidential** selected, request the `api` scope, and set the redirect URI
+to exactly the value Setup publishes. GitLab shows the secret only once.
+
+Setup's GitLab card takes the instance base URL beside that pair. A path prefix
+(`https://gitlab.example.test/gitlab`) and a non-default port are both supported
+and are preserved everywhere. When the URL is saved, Setup probes the instance:
+only an invalid URL blocks the save — an unreachable host, an untrusted
+certificate chain, or a response that is not a GitLab API root are reported as
+warnings, because Setup and the Control Plane need not share a network position.
+
+**The base URL cannot be changed while GitLab state exists.** Connections,
+tokens, numeric project IDs, and cleanup obligations carry no instance
+provenance, so retargeting would send one instance's credentials to another.
+Disconnect every GitLab project and connection first.
+
+## Who may create the agent bot accounts
+
+Each agent acts on GitLab as its own group service account. Creating one needs
+authority that **no GitLab API reports**, so AgentConnect cannot check it in
+advance and cannot probe for it — a probe would leave half-created accounts
+behind. The truth arrives the first time a project is set up, and a refusal is
+reported on the agent's bot in the console with the remedy.
+
+Any one of these is enough:
+
+- **Premium or Ultimate:** turn on **Allow top-level group Owners to create
+  service accounts** under **Admin → Settings → General → Account and limit**.
+  The installing user then provisions exactly as on GitLab.com. The setting
+  itself is Premium/Ultimate-only.
+- **Any tier, including Community Edition:** connect a GitLab account that is an
+  **instance administrator**. No special handling — it is the same code path.
+
+  One caveat: when **Admin Mode** is enabled, administrator API actions require
+  the `admin_mode` token scope, which AgentConnect's OAuth application does not
+  and will not request. On an Admin-Mode instance the delegation setting above
+  is the only path.
+
+**Free and Community Edition allow 100 service accounts per instance** (on
+GitLab.com Free the same limit is per top-level group). The population is
+agents-with-projects, so plan against the tighter ceiling; a refused creation is
+reported as a quota failure and leaves existing credentials untouched.
+
+If an instance also caps **maximum allowable access token lifetime**, an expiry
+shorter than AgentConnect requests is accepted as your policy and credential
+rotation simply runs on that shorter cycle. An instance that rejects the request
+outright instead of shortening it is reported with a message naming the cap.
+
+## Certificate authority bundle
+
+If your instance presents a certificate from a private authority, the bundle
+must be readable **at a file path that exists inside each process**, including
+the agent sandbox. Point every runtime at it:
+
+| Variable              | Reached by                                         |
+| --------------------- | -------------------------------------------------- |
+| `NODE_EXTRA_CA_CERTS` | The orchestration service and the daemon (Node.js) |
+| `SSL_CERT_FILE`       | Tools that read the OpenSSL default bundle         |
+| `SSL_CERT_DIR`        | The hashed-directory form of the same              |
+| `GIT_SSL_CAINFO`      | Git itself, for clone, fetch, and push             |
+
+A path that exists only on the host is not enough: an agent runs in a sandbox
+with its own filesystem view, so the bundle has to be mounted there too, and the
+variables have to survive into the sandbox environment. Set them where the
+sandbox image and its environment are configured, not only on the host.
+
+## Network access
+
+Three components need to reach the instance, and one does not:
+
+- **The orchestration service** calls the GitLab API outbound over HTTPS for
+  every administrative action: version checks, project reads, service accounts,
+  tokens, and webhook management.
+- **The daemon** calls the API for turn-time reads and effects, and clones,
+  fetches, and pushes over HTTPS.
+- **The agent sandbox** clones and pushes over HTTPS, and runs `glab` against
+  the instance.
+- **The public ingress endpoint that terminates GitLab webhooks never dials
+  GitLab.** It only receives. It needs no certificate bundle and no outbound
+  access to the instance.
+
+Traffic runs to the one base URL you configured. SSH remotes and mutual TLS are
+outside the contract, and there is no HTTP option. An outbound HTTP proxy is not
+supported yet.
+
+## Let GitLab reach the webhook endpoint
+
+GitLab blocks webhook requests to the local network by default. If your
+AgentConnect ingress endpoint resolves to a private address, GitLab silently
+refuses to deliver — the integration looks installed and stays quiet.
+
+Add that one host to **Admin → Settings → Network → Outbound requests →
+Local network endpoints allowed for webhooks**. Prefer this per-host allowlist
+over the instance-wide "Allow requests to the local network from webhooks and
+integrations" toggle: it grants exactly what is needed. A webhook GitLab refuses
+for this reason is reported with its own message rather than a generic failure.
+
+## Checklist
+
+1. Instance is 18.11 or later, on HTTPS, at one address.
+2. OAuth application registered, `api` scope, Confidential, exact redirect URI.
+3. Instance base URL saved in Setup; probe warnings understood.
+4. Bot-creation authority granted — delegation setting or administrator
+   connection — with the Admin Mode caveat considered.
+5. Private authority bundle mounted and exported to the orchestration service,
+   the daemon, and the sandbox.
+6. Webhook endpoint host on the outbound allowlist if it is on a private
+   network.
+7. Connect a GitLab account in the console, add a project, and confirm the bot
+   appears and a webhook is installed.

--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -25,11 +25,13 @@ import type {
   GitlabAccountConsumer,
   GitlabAgentAccountRecord,
   GitlabAgentAccountRepo,
+  GitlabAccountState,
   GitlabCredentialPurpose,
   GitlabInstanceStateRepo,
   GitlabProjectCredentialRepo,
   GitlabProjectCredentialSecretStore
 } from '../persistence/ports.js'
+import { GITLAB_CREATION_FORBIDDEN_STATE } from '../persistence/ports.js'
 import {
   GitlabApiError,
   gitlabAccountUsernameMatchesScheme,
@@ -120,8 +122,11 @@ export function gitlabAccountUnavailableMessage(reason: string): string {
   if (reason === 'username_taken') {
     return 'another GitLab account already holds the bot username — remove or rename it, then try again'
   }
-  if (reason === 'service_account_create_forbidden') {
-    return 'the connected GitLab account must be an Owner of the top-level group to create bot accounts'
+  if (reason === CREATION_FORBIDDEN_REASON) {
+    return 'this GitLab instance does not allow the connected account to create bot accounts — allow top-level group Owners to create service accounts, or connect an instance administrator, then try again'
+  }
+  if (reason === PAT_LIFETIME_CAPPED_REASON) {
+    return `this GitLab instance refuses a ${PAT_LIFETIME_DAYS}-day bot credential — raise the instance maximum access-token lifetime, then try again`
   }
   if (reason === ACCOUNT_RETIRING_REASON || reason === DELETION_PENDING_REASON) {
     return 'This agent’s previous GitLab bot account is still being removed — try again in a moment'
@@ -132,6 +137,18 @@ export function gitlabAccountUnavailableMessage(reason: string): string {
   return `the agent’s GitLab bot account could not be provisioned (${reason})`
 }
 
+/**
+ * §24.3: the instance refused to create a service account or one of its tokens.
+ * Authority is not probeable, so this refusal IS the answer — and it is a
+ * settled one: nothing retries it until an operator changes the instance
+ * setting, connects an administrator, and re-attempts through Repair.
+ */
+export const CREATION_FORBIDDEN_REASON = 'service_account_creation_forbidden'
+
+/** §24.3: the instance capped personal-access-token lifetime below what this
+ *  policy asks for and rejected the create outright instead of clamping it. */
+export const PAT_LIFETIME_CAPPED_REASON = 'pat_lifetime_exceeds_instance_maximum'
+
 /** A cleanup failure's honest category: `gitlab_unreachable` is reserved for a
  *  transport failure, the only thing `gitlabRequest` reports as status 0. */
 function retirementReason(e: unknown): string {
@@ -139,6 +156,9 @@ function retirementReason(e: unknown): string {
   if (e instanceof GitlabApiError) return `gitlab_${e.status || 'unreachable'}`
   return 'cleanup_failed'
 }
+
+/** GitLab's PAT expiry shape. An unparseable answer is not a clamp (§24.3). */
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
 
 function expiresAtDate(nowMs: number): string {
   return new Date(nowMs + PAT_LIFETIME_DAYS * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
@@ -153,9 +173,27 @@ function patName(username: string, purpose: GitlabCredentialPurpose): string {
 function refusalReason(e: unknown): string {
   if (!(e instanceof GitlabApiError)) return 'service_account_create_failed'
   if (/quota|limit|maximum/i.test(e.message)) return 'service_account_quota'
-  return e.status === 403 || e.status === 401
-    ? 'service_account_create_forbidden'
-    : `gitlab_${e.status || 'unreachable'}`
+  // 403 is the §24.3 authority answer; a 401 is our own admin token, whose repair
+  // is the `gitlab_<status>` family's "reconnect the account that manages this".
+  return e.status === 403 ? CREATION_FORBIDDEN_REASON : `gitlab_${e.status || 'unreachable'}`
+}
+
+/**
+ * §24.3: an instance POLICY refusal, which is a settled verdict rather than a
+ * transport fault — the authority to create service accounts or their tokens was
+ * withdrawn, or the requested token lifetime exceeds an instance cap. Null when
+ * the failure is not one of those, so the caller keeps its own mapping.
+ */
+function policyRefusal(e: unknown): string | null {
+  if (!(e instanceof GitlabApiError)) return null
+  if (e.status === 403) return CREATION_FORBIDDEN_REASON
+  return e.status === 400 && /expir|lifetime/i.test(e.message) ? PAT_LIFETIME_CAPPED_REASON : null
+}
+
+/** Which state a refusal earns: only withdrawn authority gets its own, because
+ *  only it must leave an already-provisioned account serving (§24.3). */
+function refusalState(reason: string): GitlabAccountState {
+  return reason.endsWith(CREATION_FORBIDDEN_REASON) ? GITLAB_CREATION_FORBIDDEN_STATE : 'admin_degraded'
 }
 
 export interface GitlabAccountServiceDeps {
@@ -375,7 +413,7 @@ export class GitlabAccountService {
             const reason = listing.some((candidate) => candidate.username === account.username)
               ? 'username_taken'
               : refusalReason(e)
-            await this.deps.accounts.update(account.id, { state: 'admin_degraded', stateReason: reason })
+            await this.deps.accounts.update(account.id, { state: refusalState(reason), stateReason: reason })
             return { ok: false, reason, retryable: reason !== 'username_taken' }
           }
         }
@@ -459,17 +497,21 @@ export class GitlabAccountService {
       account = (await this.deps.accounts.update(account.id, { state: 'ready', stateReason: null })) ?? account
       return { ok: true, account }
     } catch (e) {
+      // §24.3: a token create the instance refused on authority or lifetime policy
+      // is a settled verdict, so it outranks the transport mapping and never retries.
+      const policy = policyRefusal(e)
       const reason =
-        e instanceof GitlabTokenPolicyViolation
+        policy ??
+        (e instanceof GitlabTokenPolicyViolation
           ? 'out_of_policy_token'
           : e instanceof GitlabAccountLeaseLost
             ? 'account_lease_lost'
             : e instanceof GitlabApiError
               ? `gitlab_${e.status || 'unreachable'}`
-              : 'admin_unavailable'
+              : 'admin_unavailable')
       this.deps.log?.warn({ accountId: account.id, reason }, 'gitlab account provisioning failed')
-      await this.deps.accounts.update(account.id, { state: 'admin_degraded', stateReason: reason })
-      return { ok: false, reason, retryable: true }
+      await this.deps.accounts.update(account.id, { state: refusalState(reason), stateReason: reason })
+      return { ok: false, reason, retryable: policy === null }
     } finally {
       await this.deps.accounts.releaseLease(account.id, owner).catch(() => {})
     }
@@ -910,16 +952,22 @@ export class GitlabAccountService {
             'gitlab rotation could not revoke the previous token (it still expires on schedule)'
           )
         })
-        // A rotation-owned degradation heals on the first successful rotation.
-        if (account.state === 'admin_degraded' && account.stateReason?.startsWith('rotation_')) {
+        // A rotation-owned degradation heals on the first successful rotation. The
+        // reason's namespace decides, not the state: §24.3 authority refusals get
+        // their own state and must heal from it the moment authority is back.
+        if (account.stateReason?.startsWith('rotation_')) {
           await this.deps.accounts.update(account.id, { state: 'ready', stateReason: null })
         }
       } catch (e) {
         failed.add(account.id)
         // Every rotation-set reason is rotation_-prefixed: that namespace is
-        // exactly what a later successful sweep may clear.
-        const reason =
-          e instanceof GitlabTokenPolicyViolation
+        // exactly what a later successful sweep may clear. §24.3: an instance
+        // policy refusal is named specifically, so the horizon warning says the
+        // authority was withdrawn instead of reporting a bare upstream status.
+        const policy = policyRefusal(e)
+        const reason = policy
+          ? `rotation_${policy}`
+          : e instanceof GitlabTokenPolicyViolation
             ? 'rotation_out_of_policy_token'
             : e instanceof GitlabAccountLeaseLost
               ? 'rotation_lease_lost'
@@ -927,7 +975,7 @@ export class GitlabAccountService {
                 ? `rotation_gitlab_${e.status || 'unreachable'}`
                 : 'rotation_admin_unavailable'
         this.deps.log?.warn({ accountId: account.id, reason }, 'gitlab credential rotation failed')
-        await this.deps.accounts.update(account.id, { state: 'admin_degraded', stateReason: reason })
+        await this.deps.accounts.update(account.id, { state: refusalState(reason), stateReason: reason })
       } finally {
         await this.deps.accounts.releaseLease(account.id, owner).catch(() => {})
       }
@@ -980,13 +1028,20 @@ export class GitlabAccountService {
       { name, scopes, expiresAt },
       this.deps.api
     )
-    // §7.3 validation before sealing: identity, scopes, active, EXACT expiry.
+    // §24.3: an instance token-lifetime cap makes an EARLIER expiry legitimate
+    // operator policy, so it is accepted and becomes the recorded one — the
+    // rotation horizon reads that column, so a 30-day cap warns on a 30-day
+    // cycle. Null or LATER stays out of policy and fails closed as §7.3 requires.
+    // `YYYY-MM-DD` compares lexicographically exactly as it compares in time.
+    const granted = typeof grant.expires_at === 'string' ? grant.expires_at : ''
+    const withinPolicy = ISO_DATE.test(granted) && granted <= expiresAt
+    // §7.3 validation before sealing: identity, scopes, active, bounded expiry.
     const valid =
       typeof grant.token === 'string' &&
       grant.token.length > 0 &&
       grant.active !== false &&
       grant.revoked !== true &&
-      grant.expires_at === expiresAt &&
+      withinPolicy &&
       (grant.user_id === undefined || BigInt(grant.user_id) === serviceAccountUserId) &&
       scopes.every((scope) => grant.scopes?.includes(scope)) &&
       grant.scopes?.length === scopes.length
@@ -1017,7 +1072,7 @@ export class GitlabAccountService {
       purpose,
       externalTokenId: BigInt(grant.id),
       scopes,
-      providerExpiresAt: new Date(`${expiresAt}T00:00:00.000Z`),
+      providerExpiresAt: new Date(`${granted}T00:00:00.000Z`),
       sealedToken: await this.deps.cipher.seal(grant.token!, orgScope(OrgId(orgId)))
     })
   }

--- a/packages/control-plane/src/gitlab/account.service.ts
+++ b/packages/control-plane/src/gitlab/account.service.ts
@@ -113,6 +113,18 @@ export class GitlabAccountLeaseLost extends Error {
   }
 }
 
+/**
+ * §24.3: the instance refused to create a service account or one of its tokens.
+ * Authority is not probeable, so this refusal IS the answer — and it is a
+ * settled one: nothing retries it until an operator changes the instance
+ * setting, connects an administrator, and re-attempts through Repair.
+ */
+export const CREATION_FORBIDDEN_REASON = 'service_account_creation_forbidden'
+
+/** §24.3: the instance capped personal-access-token lifetime below what this
+ *  policy asks for and rejected the create outright instead of clamping it. */
+export const PAT_LIFETIME_CAPPED_REASON = 'pat_lifetime_exceeds_instance_maximum'
+
 /** An account the write could not provision, said the way a console can act on
  *  it. The reasons are this module's own repair categories (§8.2). */
 export function gitlabAccountUnavailableMessage(reason: string): string {
@@ -136,18 +148,6 @@ export function gitlabAccountUnavailableMessage(reason: string): string {
   }
   return `the agent’s GitLab bot account could not be provisioned (${reason})`
 }
-
-/**
- * §24.3: the instance refused to create a service account or one of its tokens.
- * Authority is not probeable, so this refusal IS the answer — and it is a
- * settled one: nothing retries it until an operator changes the instance
- * setting, connects an administrator, and re-attempts through Repair.
- */
-export const CREATION_FORBIDDEN_REASON = 'service_account_creation_forbidden'
-
-/** §24.3: the instance capped personal-access-token lifetime below what this
- *  policy asks for and rejected the create outright instead of clamping it. */
-export const PAT_LIFETIME_CAPPED_REASON = 'pat_lifetime_exceeds_instance_maximum'
 
 /** A cleanup failure's honest category: `gitlab_unreachable` is reserved for a
  *  transport failure, the only thing `gitlabRequest` reports as status 0. */

--- a/packages/control-plane/src/gitlab/gitcred.service.ts
+++ b/packages/control-plane/src/gitlab/gitcred.service.ts
@@ -1,6 +1,7 @@
 import type { GitCredGrant } from '@agentconnect.md/protocol'
 import type { Clock } from '../domain/clock.js'
 import { GitCredDeniedError } from '../github/service.js'
+import { GITLAB_CREATION_FORBIDDEN_STATE } from '../persistence/ports.js'
 import type {
   AgentRecord,
   AgentRepoAuthorizationRepo,
@@ -128,7 +129,11 @@ export class GitlabGitcredService {
    *  authorization, so an unbound or unprovisioned agent gets nothing. */
   private async agentAccount(orgId: string, agentId: string, bindingId: string): Promise<GitlabAgentAccountRecord> {
     const account = await this.deps.accounts.forAgentBinding(orgId, agentId, bindingId)
-    if (!account || account.serviceAccountUserId === null || account.state !== 'ready') {
+    // §24.3: withdrawn creation authority is the one non-ready state that still
+    // serves. It cannot mint or rotate, so the credential's own expiry — checked
+    // by every caller below — is the bound, exactly the §19.1 degradation.
+    const servable = account?.state === 'ready' || account?.state === GITLAB_CREATION_FORBIDDEN_STATE
+    if (!account || account.serviceAccountUserId === null || !servable) {
       throw new GitCredDeniedError(
         'the agent has no ready GitLab account on that project — repair it',
         'LEASE_DENIED',

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1768,7 +1768,18 @@ export const SlackBotRefreshDto = z.object({
 
 // ── github app (github-app workspaces) ────────────────────────────────────
 /** Deployment GitHub App status + the org-bound install deep link. NEVER key material. */
-/** One organization GitLab.com OAuth connection — administration identity, no token material. */
+/** An agent account's own health: the §8.2 binding vocabulary plus §24.3's
+ *  withdrawn-authority state, which a binding has no equivalent of. */
+export const GitlabAccountStateSchema = z.enum([
+  'provisioning',
+  'ready',
+  'admin_degraded',
+  'runtime_degraded',
+  'cleanup_pending',
+  'service_account_creation_forbidden'
+])
+
+/** One organization GitLab OAuth connection — administration identity, no token material. */
 export const GitlabConnectionDto = z.object({
   id: z.string(),
   gitlabUserId: z.string(), // numeric GitLab.com user id, losslessly as a string
@@ -1788,6 +1799,11 @@ export const GitlabConnectionDto = z.object({
   instanceUrl: z.string(),
   /** The version last observed on that instance (§24.2); null until first contact. */
   instanceVersion: z.string().nullable(),
+  /** Whether that observation clears the floor (§24.2). Null until first contact;
+   *  the Control Plane answers so no second version parser lives in a browser. */
+  instanceVersionSupported: z.boolean().nullable(),
+  /** The `MAJOR.MINOR` floor this deployment enforces, so the console names it. */
+  instanceVersionFloor: z.string(),
   createdAt: z.string()
 })
 export type GitlabConnectionDtoT = z.infer<typeof GitlabConnectionDto>
@@ -1836,8 +1852,10 @@ export const GitlabProjectBindingDto = z.object({
       username: z.string(),
       displayName: z.string().nullable(),
       userId: z.string().nullable(),
-      /** The account's OWN health: an agent's identity can be broken on a project whose binding is ready. */
-      state: z.enum(['provisioning', 'ready', 'admin_degraded', 'runtime_degraded', 'cleanup_pending']),
+      /** The account's OWN health: an agent's identity can be broken on a project
+       *  whose binding is ready. Carries the one authority state a binding has no
+       *  equivalent of (§24.3), which still serves until its credentials expire. */
+      state: GitlabAccountStateSchema,
       stateReason: z.string().nullable()
     })
   ),
@@ -1869,8 +1887,9 @@ export const GitlabOrgAccountDto = z.object({
   username: z.string(),
   displayName: z.string().nullable(),
   userId: z.string().nullable(), // numeric GitLab user id; null until the account exists
-  /** The §8.2 lifecycle vocabulary the binding uses, so the console translates one set. */
-  state: z.enum(['provisioning', 'ready', 'admin_degraded', 'runtime_degraded', 'cleanup_pending']),
+  /** The §8.2 lifecycle vocabulary the binding uses plus the §24.3 authority
+   *  state, so the console translates one set. */
+  state: GitlabAccountStateSchema,
   stateReason: z.string().nullable(),
   /** `retiring` once the agent's last project in the group went away (§7.2). */
   lifecycle: z.enum(['active', 'retiring']),

--- a/packages/control-plane/src/http/routes/gitlab.ts
+++ b/packages/control-plane/src/http/routes/gitlab.ts
@@ -35,6 +35,7 @@ import { GitlabProjectClaimConflict } from '../../persistence/errors.js'
  *  scheduled follow-up finish the job rather than holding the connection. */
 const REPAIR_CONTENTION_ATTEMPTS = 6
 import { unionGitlabWebhookEvents } from '../../gitlab/webhook-events.js'
+import { GITLAB_MINIMUM_VERSION_LABEL, parseGitlabVersion } from '../../gitlab/version.js'
 import {
   CreateGitlabProjectBody,
   ErrorDto,
@@ -60,6 +61,9 @@ type GitlabWebhookState = 'not_needed' | 'installed' | 'repairing' | 'failed'
 interface GitlabInstanceFacts {
   instanceUrl: string
   instanceVersion: string | null
+  /** Null until first credentialed contact — unobserved is not "unsupported". */
+  instanceVersionSupported: boolean | null
+  instanceVersionFloor: string
 }
 
 function toDto(
@@ -214,7 +218,12 @@ export function gitlabRoutes(deps: HttpDeps) {
     // stamped on every connection row rather than joined per row.
     const instanceFacts = async (): Promise<GitlabInstanceFacts> => {
       const observed = await deps.repos.gitlabInstanceState.get(gitlab.api.baseUrl)
-      return { instanceUrl: gitlab.api.baseUrl, instanceVersion: observed?.version ?? null }
+      return {
+        instanceUrl: gitlab.api.baseUrl,
+        instanceVersion: observed?.version ?? null,
+        instanceVersionSupported: observed ? parseGitlabVersion(observed.version).supported : null,
+        instanceVersionFloor: GITLAB_MINIMUM_VERSION_LABEL
+      }
     }
 
     // Whether a project wants ingress, from the same authority the provisioner converges against:

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -3435,8 +3435,14 @@ export interface GitlabProjectBindingRepo {
 // under the binding's provisioning lease.
 // ───────────────────────────────────────────────────────────────────────────
 
-/** Account rows reuse the binding lifecycle vocabulary and Console translations (§8.2). */
-export type GitlabAccountState = GitlabBindingState
+/** §24.3: the instance withdrew the authority to create service accounts or their
+ *  tokens. Its OWN state, never `admin_degraded`, because an account already
+ *  provisioned keeps serving its unexpired credentials while authority is away. */
+export const GITLAB_CREATION_FORBIDDEN_STATE = 'service_account_creation_forbidden'
+
+/** Account rows reuse the binding lifecycle vocabulary and Console translations
+ *  (§8.2), plus the one authority state a binding has no equivalent of (§24.3). */
+export type GitlabAccountState = GitlabBindingState | typeof GITLAB_CREATION_FORBIDDEN_STATE
 
 /** The generation fence a membership insert commits against (§7.2). */
 export type GitlabAccountLifecycle = 'active' | 'retiring'

--- a/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/gitlab.repo.ts
@@ -16,6 +16,7 @@ import type {
 import { Prisma } from '../../generated/prisma/client.js'
 import type { PrismaLike } from '../prisma.js'
 import { GitlabMembershipGone, GitlabProjectClaimConflict } from '../errors.js'
+import { GITLAB_CREATION_FORBIDDEN_STATE } from '../ports.js'
 import type {
   GitlabAccountConsumer,
   GitlabProjectConsumer,
@@ -600,7 +601,7 @@ export class PgGitlabProjectBindingRepo implements GitlabProjectBindingRepo {
 
 // ── §7.2/§8.2 per-agent accounts, their memberships, and their PATs ──────────
 
-const ACCOUNT_STATES: readonly GitlabAccountState[] = BINDING_STATES
+const ACCOUNT_STATES: readonly GitlabAccountState[] = [...BINDING_STATES, GITLAB_CREATION_FORBIDDEN_STATE]
 
 function toAccountRecord(r: GitlabAgentAccount): GitlabAgentAccountRecord {
   return {

--- a/packages/control-plane/test/fakes/gitlab-api.ts
+++ b/packages/control-plane/test/fakes/gitlab-api.ts
@@ -26,10 +26,19 @@ export interface FakeGitlabOptions {
   namespaceKind?: 'group' | 'user'
   /** Refuse service-account creation (Owner verification, §5). */
   refuseServiceAccountCreate?: boolean
+  /** §24.3 admin-only instance: creating a service account or one of its tokens
+   *  is reserved for an instance administrator, so both answer 403. */
+  adminOnly?: boolean
   /** Refuse service-account creation for the root's 100-account quota (§7.2). */
   refuseServiceAccountQuota?: boolean
   /** Return this expires_at instead of echoing the request (out-of-policy). */
   patExpiryOverride?: string | null
+  /** §24.3 instance token-lifetime cap: grant an EARLIER expiry than requested. */
+  patLifetimeCapDays?: number
+  /** §24.3: reject the create outright for exceeding that cap instead of clamping. */
+  refusePatLifetime?: boolean
+  /** The clock the lifetime cap measures from; defaults to the wall clock. */
+  now?: () => number
   /** Fail PAT revocations with a 500 (ambiguous cleanup). */
   failTokenRevoke?: boolean
   /** GitLab deletes a user asynchronously: accept the DELETE but keep listing
@@ -110,6 +119,15 @@ export class FakeGitlab {
   /** One project's namespaced path — per-id when a test holds several bindings. */
   private pathOf(projectId: number): string {
     return this.opts.pathById?.[String(projectId)] ?? this.opts.path
+  }
+
+  /** §24.3: an instance maximum token lifetime clamps the requested expiry down;
+   *  anything at or under the cap is granted exactly as asked. */
+  private grantedExpiry(requested: unknown): unknown {
+    const capDays = this.opts.patLifetimeCapDays
+    if (capDays === undefined) return requested
+    const cap = new Date((this.opts.now?.() ?? Date.now()) + capDays * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+    return typeof requested === 'string' && requested <= cap ? requested : cap
   }
 
   /** The asynchronous half of a deferred deletion finally landing. */
@@ -295,7 +313,7 @@ export class FakeGitlab {
         if (this.opts.refuseServiceAccountQuota) {
           return Response.json({ message: 'Maximum number of service accounts reached' }, { status: 400 })
         }
-        if (this.opts.refuseServiceAccountCreate) {
+        if (this.opts.refuseServiceAccountCreate || this.opts.adminOnly) {
           return Response.json({ message: 'forbidden' }, { status: 403 })
         }
         const payload = json()
@@ -342,9 +360,16 @@ export class FakeGitlab {
       }
       if (/\/api\/v4\/groups\/\d+\/service_accounts\/\d+\/personal_access_tokens$/.test(url) && method === 'POST') {
         const userId = Number(/service_accounts\/(\d+)\//.exec(url)![1])
+        if (this.opts.adminOnly) return Response.json({ message: 'forbidden' }, { status: 403 })
+        if (this.opts.refusePatLifetime) {
+          return Response.json({ message: 'expires_at exceeds the maximum allowable lifetime' }, { status: 400 })
+        }
         const payload = json()
         const id = ++this.nextId
-        const expires = this.opts.patExpiryOverride !== undefined ? this.opts.patExpiryOverride : payload.expires_at
+        const expires =
+          this.opts.patExpiryOverride !== undefined
+            ? this.opts.patExpiryOverride
+            : this.grantedExpiry(payload.expires_at)
         this.tokens.set(id, {
           name: String(payload.name),
           scopes: payload.scopes as string[],

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -59,6 +59,8 @@ async function harness(
 ) {
   const fake = new FakeGitlab(options)
   const avatarRenders: string[] = []
+  /** What an operator reads: every account-service warning, with its reason. */
+  const warnings: { obj: Record<string, unknown>; msg: string }[] = []
   const connections = new PgGitlabConnectionRepo(prisma)
   const bindings = new PgGitlabProjectBindingRepo(prisma)
   const accounts = new PgGitlabAgentAccountRepo(prisma)
@@ -88,6 +90,7 @@ async function harness(
       avatarRenders.push(agent.id)
       return AVATAR_PNG
     },
+    log: { warn: (obj, msg) => warnings.push({ obj: obj as Record<string, unknown>, msg }) },
     api: fake.api
   })
   const buildProvisioner = (): GitlabProvisioner =>
@@ -131,6 +134,7 @@ async function harness(
   return {
     fake,
     avatarRenders,
+    warnings,
     bindings,
     accounts,
     credentials,
@@ -270,10 +274,91 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
     const h = await harness({ refuseServiceAccountCreate: true })
     expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
       state: 'admin_degraded',
-      reason: 'service_account_create_forbidden'
+      reason: 'service_account_creation_forbidden'
     })
     h.fake.opts.refuseServiceAccountCreate = false
     expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+  })
+
+  it('an admin-only instance lands the account in its own authority state, and Repair clears it (§24.3)', async () => {
+    const h = await harness({ adminOnly: true })
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      state: 'admin_degraded',
+      reason: 'service_account_creation_forbidden'
+    })
+    const [account] = await h.accounts.listForAgent(DEFAULT_ORG_ID, AGENT)
+    // Its OWN state, never admin_degraded: authority is what is missing, and an
+    // account that already exists elsewhere must keep serving through it.
+    expect(account).toMatchObject({
+      state: 'service_account_creation_forbidden',
+      stateReason: 'service_account_creation_forbidden'
+    })
+    // A settled verdict owes nothing: no sweep re-attempts it until a human acts.
+    expect((await h.bindings.get(DEFAULT_ORG_ID, h.binding.id))!.convergeOwedAt).toBeNull()
+
+    // The operator grants the authority; the ordinary Repair path re-attempts.
+    h.fake.opts.adminOnly = false
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    expect(await h.accounts.get(account!.id)).toMatchObject({ state: 'ready', stateReason: null })
+  })
+
+  it('the inline pre-activation ensure refuses an admin-only instance without retrying it (§24.3)', async () => {
+    const h = await harness({ adminOnly: true })
+    const committed: string[] = []
+    const outcome = await h.provisioner.provisionAgentAccount(
+      DEFAULT_ORG_ID,
+      PROJECT,
+      { agentId: AGENT, accessLevel: 30 },
+      async () => {
+        committed.push('commit')
+        return 'ok'
+      }
+    )
+    expect(outcome).toEqual({ ok: false, reason: 'service_account_creation_forbidden', retryable: false })
+    // The write never happened, and the budget loop never spun: exactly one
+    // create was attempted, because authority cannot resolve itself.
+    expect(committed).toHaveLength(0)
+    const creates = h.fake.requests.filter((r) => r.method === 'POST' && /\/service_accounts$/.test(r.url))
+    expect(creates).toHaveLength(1)
+    expect(await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP)).toMatchObject({
+      state: 'service_account_creation_forbidden'
+    })
+  })
+
+  it('names the instance token-lifetime cap when the create is rejected for it (§24.3)', async () => {
+    const h = await harness({ refusePatLifetime: true })
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      state: 'admin_degraded',
+      reason: 'pat_lifetime_exceeds_instance_maximum'
+    })
+    const [account] = await h.accounts.listForAgent(DEFAULT_ORG_ID, AGENT)
+    expect(account).toMatchObject({
+      state: 'admin_degraded',
+      stateReason: 'pat_lifetime_exceeds_instance_maximum'
+    })
+    expect(gitlabAccountUnavailableMessage(account!.stateReason!)).toContain('maximum access-token lifetime')
+  })
+
+  it('accepts an expiry the instance clamped below the request and records the granted one (§24.3)', async () => {
+    const h = await harness({ patLifetimeCapDays: 30 })
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({ state: 'ready' })
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    const read = (await h.credentials.get(account.id, 'read'))!
+    // The 90-day request was answered with 30 days, and the ROW carries what the
+    // instance granted — nothing was revoked and nothing failed closed.
+    expect(read.providerExpiresAt.getTime()).toBeLessThan(Date.now() + 31 * 86_400_000)
+    expect(read.providerExpiresAt.getTime()).toBeGreaterThan(Date.now() + 29 * 86_400_000)
+    expect(h.fake.tokens.get(Number(read.externalTokenId))!.revoked).toBe(false)
+  })
+
+  it('revokes an expiry LATER than requested and fails closed (§7.3)', async () => {
+    const h = await harness({ patExpiryOverride: '2099-01-01' })
+    expect(await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)).toEqual({
+      state: 'admin_degraded',
+      reason: 'out_of_policy_token'
+    })
+    expect([...h.fake.tokens.values()].every((token) => token.revoked)).toBe(true)
+    expect(await prisma.gitlabProjectCredential.count()).toBe(0)
   })
 
   it('revokes an out-of-policy token and fails closed (§7.3)', async () => {
@@ -1549,6 +1634,51 @@ describe('GitlabAccountService rotation (§7.4)', () => {
     await h.accounts.update(account.id, { state: 'admin_degraded', stateReason: 'rotation_gitlab_503' })
     await h.accountService.rotateDueCredentials(14 * 86_400_000)
     expect(await h.accounts.get(account.id)).toMatchObject({ state: 'ready', stateReason: null })
+  })
+
+  it('a rotation the instance forbids is named as withdrawn authority and keeps serving (§24.3)', async () => {
+    const h = await harness()
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    const before = (await h.credentials.get(account.id, 'read'))!
+    await prisma.gitlabProjectCredential.update({
+      where: { id: before.id },
+      data: { providerExpiresAt: new Date(Date.now() + 3 * 86_400_000) }
+    })
+    // The instance takes the delegation away under a live account.
+    h.fake.opts.adminOnly = true
+    await h.accountService.rotateDueCredentials(14 * 86_400_000)
+
+    expect(await h.accounts.get(account.id)).toMatchObject({
+      state: 'service_account_creation_forbidden',
+      stateReason: 'rotation_service_account_creation_forbidden'
+    })
+    // The horizon warning names the authority, not a bare upstream status: an
+    // operator learns this from the warning rather than from a silent bot.
+    expect(h.warnings.at(-1)).toMatchObject({
+      obj: { reason: 'rotation_service_account_creation_forbidden' },
+      msg: 'gitlab credential rotation failed'
+    })
+    // The existing credential is untouched and still serves to its own expiry.
+    expect((await h.credentials.get(account.id, 'read'))!.externalTokenId).toBe(before.externalTokenId)
+    expect(h.fake.tokens.get(Number(before.externalTokenId))!.revoked).toBe(false)
+
+    h.fake.opts.adminOnly = false
+    await h.accountService.rotateDueCredentials(14 * 86_400_000)
+    expect(await h.accounts.get(account.id)).toMatchObject({ state: 'ready', stateReason: null })
+  })
+
+  it('re-derives the rotation horizon from a clamped expiry, not from the requested one (§24.3)', async () => {
+    const h = await harness({ patLifetimeCapDays: 30 })
+    await h.provisioner.provision(DEFAULT_ORG_ID, h.binding.id)
+    const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, AGENT, ROOT_GROUP))!
+    // The ordinary horizon does not reach a credential 30 days out.
+    await h.accountService.rotateDueCredentials(14 * 86_400_000)
+    expect((await h.credentials.get(account.id, 'read'))!.generation).toBe(1n)
+    // A horizon inside the 30-day cap does — which it could not if the row still
+    // carried the 90-day expiry that was ASKED for rather than the granted one.
+    await h.accountService.rotateDueCredentials(35 * 86_400_000)
+    expect((await h.credentials.get(account.id, 'read'))!.generation).toBe(2n)
   })
 
   it('a live foreign account lease defers rotation to the next sweep', async () => {

--- a/packages/setup/src/gitlab-app.ts
+++ b/packages/setup/src/gitlab-app.ts
@@ -1,22 +1,45 @@
-import { GITLAB_OAUTH_CALLBACK_PATH } from '@agentconnect.md/control-plane/gitlab-config'
+import { GITLAB_DEFAULT_BASE_URL, GITLAB_OAUTH_CALLBACK_PATH } from '@agentconnect.md/control-plane/gitlab-config'
 import type { ProviderAppConfig } from './provider-app.js'
 
 /** Exactly the scope set the Control Plane asks GitLab for (gitlab-com-integration.md §9.1). */
 export const GITLAB_OAUTH_SCOPES = ['api'] as const
 
+/** Where a user registers their own OAuth application on any instance. */
+const USER_APPLICATIONS_PATH = '/-/user_settings/applications'
+/** Where an administrator registers an instance-wide one instead. */
+const ADMIN_APPLICATIONS_PATH = '/admin/applications'
+
 export interface GitlabConfiguredUrls {
   callbackUrl: string
   scopes: string[]
+  /** The instance these links target (§24.1) — GitLab.com when the axis is unset. */
+  instanceUrl: string
+  applicationsUrl: string
+  adminApplicationsUrl: string
 }
 
-/** GitLab has no OAuth-application creation API, so setup only publishes what to register by hand. */
-export function gitlabConfiguredUrls(config: ProviderAppConfig): GitlabConfiguredUrls {
+/**
+ * GitLab has no OAuth-application creation API, so setup only publishes what to
+ * register by hand — on whichever instance this deployment is bound to.
+ *
+ * Instance links are composed by CONCATENATION onto the normalized base (§24.1):
+ * resolving `/-/user_settings/applications` against a prefixed install root would
+ * silently discard the prefix.
+ */
+export function gitlabConfiguredUrls(
+  config: ProviderAppConfig,
+  baseUrl: string = GITLAB_DEFAULT_BASE_URL
+): GitlabConfiguredUrls {
   const controlPlane = config.services.controlPlane
   if (!controlPlane || new URL(controlPlane).protocol !== 'https:') {
     throw new Error('the GitLab OAuth application requires a saved HTTPS Control Plane public URL')
   }
+  const instanceUrl = baseUrl.replace(/\/+$/, '')
   return {
     callbackUrl: `${controlPlane.replace(/\/$/, '')}${GITLAB_OAUTH_CALLBACK_PATH}`,
-    scopes: [...GITLAB_OAUTH_SCOPES]
+    scopes: [...GITLAB_OAUTH_SCOPES],
+    instanceUrl,
+    applicationsUrl: `${instanceUrl}${USER_APPLICATIONS_PATH}`,
+    adminApplicationsUrl: `${instanceUrl}${ADMIN_APPLICATIONS_PATH}`
   }
 }

--- a/packages/setup/src/server/html.ts
+++ b/packages/setup/src/server/html.ts
@@ -244,7 +244,7 @@ export const SETUP_HTML = String.raw`<!doctype html>
 
       <section id="gitlab-section" class="panel setup-section" aria-labelledby="gitlab-heading">
         <div class="provider-head">
-          <div><h3 id="gitlab-heading">GitLab</h3><p class="muted">OAuth application used to administer GitLab.com projects.</p></div>
+          <div><h3 id="gitlab-heading">GitLab</h3><p class="muted">OAuth application used to administer projects on this deployment's GitLab instance.</p></div>
           <span id="gitlab-match" class="badge">Not configured</span>
         </div>
         <dl class="credentials">
@@ -258,7 +258,9 @@ export const SETUP_HTML = String.raw`<!doctype html>
         <p>Redirect URI:</p><ul id="gitlab-callbacks" class="uris"></ul>
         <p>Scopes:</p><ul id="gitlab-scopes" class="uris"></ul>
         <p class="muted">GitLab does not expose OAuth application creation through an API. In User settings &rarr; Applications, or a group's Settings &rarr; Applications, add an application whose redirect URI is exactly the value above, keep Confidential selected, grant the scopes above, then save the generated Application ID and Secret here. GitLab shows the secret only once.</p>
-        <div class="row"><a class="button" href="https://gitlab.com/-/user_settings/applications" target="_blank" rel="noopener">Open GitLab applications</a></div>
+        <p class="muted">Use your own user applications unless you are an instance administrator registering one application for everyone; an instance-wide application lives in the Admin area instead.</p>
+        <p class="muted">Creating each agent's bot account later needs authority this page cannot verify — no GitLab API reports it: either connect an instance administrator (whose API token cannot act as one while Admin Mode is enabled), or, on Premium and Ultimate, turn on Admin &rarr; Settings &rarr; General &rarr; Account and limit &rarr; &ldquo;Allow top-level group Owners to create service accounts&rdquo;.</p>
+        <div class="row"><a id="gitlab-applications" class="button" href="https://gitlab.com/-/user_settings/applications" target="_blank" rel="noopener">Open GitLab applications</a><a id="gitlab-admin-applications" class="button" href="https://gitlab.com/admin/applications" target="_blank" rel="noopener">Open admin applications</a></div>
         <div id="gitlab-config-controls" class="subsection">
           <label class="field">Instance base URL<input id="gitlab-base-url" autocomplete="off" placeholder="Leave empty for https://gitlab.com"></label>
           <label class="field">Application ID<input id="gitlab-id" autocomplete="off"></label>
@@ -643,13 +645,19 @@ export const SETUP_HTML = String.raw`<!doctype html>
       showIdentityEditors('gitlab', Boolean(gitlab));
       el('gitlab-id').value = gitlab ? gitlab.clientId : '';
       text('gitlab-instance', (gitlab && gitlab.baseUrl) || 'https://gitlab.com');
+      // Host-aware application links (§24.1): composed by the server against the
+      // configured base, so a path-prefixed install keeps its prefix here too.
+      if (expectedGitlab) {
+        el('gitlab-applications').href = expectedGitlab.applicationsUrl;
+        el('gitlab-admin-applications').href = expectedGitlab.adminApplicationsUrl;
+      }
       el('gitlab-base-url').value = (gitlab && gitlab.baseUrl) || '';
       // A probe verdict belongs to the save that produced it, never to a reload.
       el('gitlab-probe').hidden = true;
       el('gitlab-status').textContent = gitlab
         ? gitlab.clientId + ' is configured.'
         : expectedGitlab
-          ? 'Register the OAuth application on GitLab.com, then save its Application ID and Secret here.'
+          ? 'Register the OAuth application on the configured GitLab instance, then save its Application ID and Secret here.'
           : 'Publishing the redirect URI needs an HTTPS API public URL.';
       showDiff('gitlab-drift', gitlab && !expectedGitlab
         ? [{ field: 'Startup public URLs', current: 'Unavailable', expected: 'An HTTPS API URL' }]

--- a/packages/setup/src/server/index.ts
+++ b/packages/setup/src/server/index.ts
@@ -521,7 +521,8 @@ export function buildSetupServer(deps: SetupServerDeps, options: SetupServerOpti
     }
     let gitlab: ReturnType<typeof gitlabConfiguredUrls> | null = null
     try {
-      gitlab = gitlabConfiguredUrls(providerAppConfig(localAuthBootstrap.services))
+      // The instance the card's links must target (§24.1); absent ⇒ GitLab.com.
+      gitlab = gitlabConfiguredUrls(providerAppConfig(localAuthBootstrap.services), values.gitlab?.baseUrl ?? undefined)
     } catch {
       // GitLab needs an HTTPS Control Plane URL before its redirect URI is publishable.
     }

--- a/packages/setup/test/provider-base-paths.test.ts
+++ b/packages/setup/test/provider-base-paths.test.ts
@@ -83,8 +83,27 @@ describe('provider service base paths', () => {
 
     expect(gitlabConfiguredUrls(config)).toEqual({
       callbackUrl: 'https://gateway.example.test/cp/v1/gitlab/oauth/callback',
-      scopes: ['api']
+      scopes: ['api'],
+      instanceUrl: 'https://gitlab.com',
+      applicationsUrl: 'https://gitlab.com/-/user_settings/applications',
+      adminApplicationsUrl: 'https://gitlab.com/admin/applications'
     })
     expect(() => gitlabConfiguredUrls({ services: { controlPlane: 'http://localhost:8080' } })).toThrow(/HTTPS/)
+  })
+
+  it('targets the application links at a self-managed instance, prefix and port intact (§24.1)', () => {
+    const config = { services: loadDeploymentEnvironment(PREFIXED_ENVIRONMENT).services }
+
+    // Concatenation, never resolution: resolving an absolute path against this
+    // base would drop `/gitlab` and send the operator to the wrong page.
+    expect(gitlabConfiguredUrls(config, 'https://gitlab.example.test:8443/gitlab')).toMatchObject({
+      instanceUrl: 'https://gitlab.example.test:8443/gitlab',
+      applicationsUrl: 'https://gitlab.example.test:8443/gitlab/-/user_settings/applications',
+      adminApplicationsUrl: 'https://gitlab.example.test:8443/gitlab/admin/applications'
+    })
+    // The redirect URI is the Control Plane's own, unchanged by the instance.
+    expect(gitlabConfiguredUrls(config, 'https://gitlab.example.test/gitlab').callbackUrl).toBe(
+      'https://gateway.example.test/cp/v1/gitlab/oauth/callback'
+    )
   })
 })

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -105,6 +105,10 @@ const CONNECTION: GitlabConnectionDto = {
   mine: true,
   accessExpiresAt: null,
   assignedProjects: 0,
+  instanceUrl: 'https://gitlab.com',
+  instanceVersion: '18.11.0-ee',
+  instanceVersionSupported: true,
+  instanceVersionFloor: '18.11',
   createdAt: '2026-08-01T00:00:00.000Z'
 }
 
@@ -413,6 +417,100 @@ describe('GitlabCard', () => {
     expect(refused.querySelector('a[href^="https://gitlab.com/"]')).toBeNull()
     // The group falls back to its number rather than borrowing another project's path.
     expect(refused.textContent).toContain('group 900')
+  })
+
+  it('names the configured instance, not a gitlab.com literal, and links the bots there (\u00a724.1)', async () => {
+    const SELF_MANAGED = {
+      ...CONNECTION,
+      instanceUrl: 'https://gitlab.example.test:8443/gitlab',
+      instanceVersion: '18.11.4-ee'
+    }
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [SELF_MANAGED] })
+    mocks.fetchProjects.mockResolvedValue([BINDING])
+    roster = [BOT]
+    await render()
+
+    const row = connectionRow('conn-1')
+    // Host and port, without the scheme or the install prefix — it is a badge.
+    expect(row.textContent).toContain('gitlab.example.test:8443')
+    expect(row.textContent).not.toContain('gitlab.com')
+    // The chip link keeps the prefix: every path on that instance lives under it.
+    const link = botRow('agent-1').querySelector('a[href*="gitlab-pilot"]')
+    expect(link!.getAttribute('href')).toBe('https://gitlab.example.test:8443/gitlab/gitlab-pilot-5b350c0aeba7-2bivoj')
+  })
+
+  it('reports the instance version, and says what a below-floor one still serves (\u00a724.2)', async () => {
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [{ ...CONNECTION, instanceVersion: '18.11.4-ee', instanceVersionSupported: true }]
+    })
+    await render()
+    const healthy = connectionRow('conn-1')
+    expect(healthy.textContent).toContain('GitLab 18.11.4-ee')
+    expect(healthy.textContent).not.toContain('below 18.11')
+
+    document.body.innerHTML = ''
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [{ ...CONNECTION, instanceVersion: '18.4.1', instanceVersionSupported: false }]
+    })
+    await render()
+    const old = connectionRow('conn-1')
+    expect(old.textContent).toContain('GitLab 18.4.1')
+    expect(old.textContent).toContain('below 18.11')
+    // Bounded degradation, said plainly: what is already set up keeps working.
+    expect(old.textContent).toContain('keep working until their credentials expire')
+  })
+
+  it('says nothing about a version the deployment has not observed yet', async () => {
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [{ ...CONNECTION, instanceVersion: null, instanceVersionSupported: null }]
+    })
+    await render()
+    expect(connectionRow('conn-1').textContent).not.toContain('GitLab 1')
+  })
+
+  it('tells an operator how to grant withdrawn bot-creation authority (\u00a724.3)', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    roster = [
+      {
+        ...BOT,
+        userId: null,
+        state: 'service_account_creation_forbidden',
+        stateReason: 'service_account_creation_forbidden',
+        bindingIds: []
+      }
+    ]
+    await render()
+
+    const row = botRow('agent-1')
+    // Its own badge: this is not "setup incomplete", it is a missing permission.
+    expect(row.textContent).toContain('not allowed on GitLab')
+    expect(row.textContent).not.toContain('service_account_creation_forbidden')
+    // Every way to grant it: the administrator, the tier-gated setting, the caveat.
+    expect(row.textContent).toContain('Connect an instance administrator')
+    expect(row.textContent).toContain('Admin Mode')
+    expect(row.textContent).toContain('Allow top-level group Owners to create service accounts')
+    expect(row.textContent).toContain('Premium and Ultimate')
+  })
+
+  it('keeps a bot serving while a refused rotation asks for the same authority (\u00a724.3)', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [CONNECTION] })
+    roster = [
+      {
+        ...BOT,
+        state: 'service_account_creation_forbidden',
+        stateReason: 'rotation_service_account_creation_forbidden'
+      }
+    ]
+    await render()
+
+    const row = botRow('agent-1')
+    // The named reason wins over the generic rotation line, which would bury it.
+    expect(row.textContent).toContain('it keeps working until they expire')
+    expect(row.textContent).toContain('Connect an instance administrator')
+    expect(row.textContent).not.toContain('The project bot credential needs repair')
   })
 
   it('marks a retiring account as leaving', async () => {

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -19,8 +19,11 @@ import { agentLabel } from '@/lib/data'
 import { useOrgs } from '@/lib/org-context'
 import { consoleKeys } from '@/lib/swr-keys'
 import {
+  GITLAB_ACCOUNT_STATE,
   GITLAB_CONVERGENCE_POLL_MS,
+  GITLAB_DEFAULT_INSTANCE_URL,
   GITLAB_PROJECT_STATE,
+  gitlabInstanceHost,
   gitlabProfileUrl,
   gitlabStateReasonText,
   gitlabWebhookBadge
@@ -437,6 +440,9 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     }
   }
 
+  // One deployment, one instance (§24.1), so any connection answers for all of
+  // them; before the first one there is nothing to link to anyway.
+  const instanceUrl = connections[0]?.instanceUrl ?? GITLAB_DEFAULT_INSTANCE_URL
   const accounts = bots?.accounts ?? []
   const rows = botRows(accounts)
   const orphans = orphanBindings(accounts, projects)
@@ -496,7 +502,10 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                   </span>
                 </span>
                 <span className="mono min-w-0 truncate text-[12.5px]">{c.gitlabUsername}</span>
-                <span className="badge bg-(--surface-active) text-(--text-tertiary)">gitlab.com</span>
+                {/* The instance, not a literal: one deployment talks to exactly one. */}
+                <span className="badge bg-(--surface-active) text-(--text-tertiary)" title={c.instanceUrl}>
+                  {gitlabInstanceHost(c.instanceUrl)}
+                </span>
                 {c.state === 'reauth_required' && (
                   <span className="badge bg-(--status-paused-soft) text-(--amber-500)">reconnect needed</span>
                 )}
@@ -546,6 +555,24 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                 {c.assignedProjects === 1
                   ? 'This account still administers 1 project below. Transfer that project to your own GitLab account, or reconnect this one to keep managing it, before this row can go.'
                   : `This account still administers ${c.assignedProjects} projects below. Transfer those projects to your own GitLab account, or reconnect this one to keep managing them, before this row can go.`}
+              </div>
+            )}
+            {/* What the instance reports, and whether it clears the floor project
+                setup needs. Silent until the first credentialed contact answers. */}
+            {c.instanceVersion !== null && (
+              <div className="flex flex-wrap items-center gap-2 border-b border-(--border-subtle) px-4 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+                <span>GitLab {c.instanceVersion}</span>
+                {c.instanceVersionSupported === false && (
+                  <>
+                    <span className="badge bg-(--status-paused-soft) text-(--amber-500)">
+                      below {c.instanceVersionFloor}
+                    </span>
+                    <span>
+                      Setting up new projects and bots needs {c.instanceVersionFloor} or later. Projects already set up
+                      keep working until their credentials expire.
+                    </span>
+                  </>
+                )}
               </div>
             )}
             {c.state === 'reauth_required' && (
@@ -623,7 +650,7 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                               The handle is deterministic, so it links only once the account exists. */}
                           {account.userId ? (
                             <a
-                              href={gitlabProfileUrl(account.username)}
+                              href={gitlabProfileUrl(instanceUrl, account.username)}
                               target="_blank"
                               rel="noopener noreferrer"
                               title={`@${account.username}`}
@@ -642,8 +669,8 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                           )}
                           {/* A healthy bot says nothing; only trouble and departure are worth a badge. */}
                           {account.state !== 'ready' && (
-                            <span className={`badge flex-none ${GITLAB_PROJECT_STATE[account.state].badge}`}>
-                              {GITLAB_PROJECT_STATE[account.state].label}
+                            <span className={`badge flex-none ${GITLAB_ACCOUNT_STATE[account.state].badge}`}>
+                              {GITLAB_ACCOUNT_STATE[account.state].label}
                             </span>
                           )}
                           {account.lifecycle === 'retiring' && (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -5272,6 +5272,14 @@ export interface GitlabConnectionDto {
   mine: boolean
   accessExpiresAt: string | null
   assignedProjects: number // managed projects this connection still administers
+  /** The instance this deployment talks to — the same on every connection, because
+   *  one deployment has exactly one host axis. Never secret. */
+  instanceUrl: string
+  /** What that instance last reported, and whether it clears the floor the CP
+   *  enforces. Both null until the first credentialed contact. */
+  instanceVersion: string | null
+  instanceVersionSupported: boolean | null
+  instanceVersionFloor: string
   createdAt: string
 }
 
@@ -5298,6 +5306,10 @@ export type GitlabProjectBindingState =
   'provisioning' | 'ready' | 'admin_degraded' | 'runtime_degraded' | 'cleanup_pending'
 
 /** One managed project — its lifecycle state and non-secret external identity. */
+/** A bot account's own health: the binding vocabulary plus the one state only an
+ *  account can be in — the instance withdrew authority to create service accounts. */
+export type GitlabAgentAccountState = GitlabProjectBindingState | 'service_account_creation_forbidden'
+
 /** One agent's GitLab identity on a managed project. */
 export interface GitlabProjectAccountDto {
   agentId: string
@@ -5305,7 +5317,7 @@ export interface GitlabProjectAccountDto {
   displayName: string | null
   userId: string | null
   /** The account's OWN health: an agent's identity can be broken on a ready project. */
-  state: GitlabProjectBindingState
+  state: GitlabAgentAccountState
   stateReason: string | null
 }
 
@@ -5420,7 +5432,7 @@ export interface GitlabOrgAccountDto {
   username: string
   displayName: string | null
   userId: string | null // numeric GitLab user id; null until the account exists
-  state: GitlabProjectBindingState
+  state: GitlabAgentAccountState
   stateReason: string | null
   lifecycle: 'active' | 'retiring'
   /** The bound projects this account is a member of — which, not how: a project is managed

--- a/packages/web/src/lib/gitlab-projects.ts
+++ b/packages/web/src/lib/gitlab-projects.ts
@@ -13,7 +13,13 @@
  * project that is about to change underneath it.
  */
 
-import type { GitlabProjectBindingDto, GitlabProjectBindingState, GitlabProjectDto, GitlabWebhookState } from './api'
+import type {
+  GitlabAgentAccountState,
+  GitlabProjectBindingDto,
+  GitlabProjectBindingState,
+  GitlabProjectDto,
+  GitlabWebhookState
+} from './api'
 
 export const GITLAB_PROJECT_STATE: Record<GitlabProjectBindingState, { label: string; badge: string }> = {
   provisioning: { label: 'setting up', badge: 'bg-(--status-info-soft) text-(--status-info)' },
@@ -21,6 +27,17 @@ export const GITLAB_PROJECT_STATE: Record<GitlabProjectBindingState, { label: st
   admin_degraded: { label: 'setup incomplete', badge: 'bg-(--status-paused-soft) text-(--amber-500)' },
   runtime_degraded: { label: 'bot access degraded', badge: 'bg-(--status-paused-soft) text-(--amber-500)' },
   cleanup_pending: { label: 'removal incomplete', badge: 'bg-(--status-error-soft) text-(--status-error)' }
+}
+
+/** An agent's own bot account carries one state a project binding cannot: §24.3's
+ *  withdrawn creation authority, which is not "setup incomplete" — the bot that
+ *  exists keeps working, and what is missing is a permission on the instance. */
+export const GITLAB_ACCOUNT_STATE: Record<GitlabAgentAccountState, { label: string; badge: string }> = {
+  ...GITLAB_PROJECT_STATE,
+  service_account_creation_forbidden: {
+    label: 'not allowed on GitLab',
+    badge: 'bg-(--status-paused-soft) text-(--amber-500)'
+  }
 }
 
 // Only the two webhook states a person can act on are worth saying. A webhook that is not
@@ -39,10 +56,30 @@ export function gitlabWebhookBadge(state: GitlabWebhookState): { label: string; 
 /** Account convergence runs behind hook and workspace CRUD; this is how often we ask whether it landed. */
 export const GITLAB_CONVERGENCE_POLL_MS = 5_000
 
-/** gitlab.com is pinned in v1 — no host override exists to thread through here. */
-export function gitlabProfileUrl(username: string): string {
-  return `https://gitlab.com/${username}`
+/** The default value of the host axis (§24.1) — what an unset base URL means. */
+export const GITLAB_DEFAULT_INSTANCE_URL = 'https://gitlab.com'
+
+/** The instance this deployment talks to, as a badge reads it: host and any
+ *  non-default port, without the scheme or an install path prefix (§24.1). */
+export function gitlabInstanceHost(instanceUrl: string): string {
+  try {
+    return new URL(instanceUrl).host
+  } catch {
+    return instanceUrl
+  }
 }
+
+/** A bot account's page on the configured instance. Composed by CONCATENATION
+ *  onto the base (§24.1): a prefixed install root is part of every path under it. */
+export function gitlabProfileUrl(instanceUrl: string, username: string): string {
+  return `${instanceUrl.replace(/\/+$/, '')}/${username}`
+}
+
+/** §24.3: authority to create service accounts is not API-readable, so the copy
+ *  has to name every way an operator can grant it — the tier-gated delegation
+ *  setting, the administrator connection, and why Admin Mode defeats the latter. */
+const CREATION_AUTHORITY_REMEDY =
+  'Connect an instance administrator — whose API token cannot act as one while Admin Mode is enabled — or, on Premium and Ultimate, turn on “Allow top-level group Owners to create service accounts” in Admin → Settings → General → Account and limit. Then run Repair.'
 
 // The CP records a machine category in `stateReason`; these are the ones a user can act on, in GitLab
 // vocabulary. Every rotation_* variant collapses to one line — the tail (rotation_gitlab_<status>) is open-ended.
@@ -51,7 +88,10 @@ export const GITLAB_STATE_REASON: Record<string, string> = {
   project_not_accessible: 'GitLab project is no longer accessible',
   personal_namespace_unsupported: 'Projects in a personal namespace are not supported',
   project_namespace_unknown: 'GitLab did not report the group this project belongs to',
-  service_account_create_forbidden: 'Not allowed to create a project bot on GitLab',
+  service_account_creation_forbidden: `This GitLab instance does not let the connected account create bot accounts. ${CREATION_AUTHORITY_REMEDY}`,
+  rotation_service_account_creation_forbidden: `This GitLab instance stopped letting AgentConnect renew this bot's credentials — it keeps working until they expire. ${CREATION_AUTHORITY_REMEDY}`,
+  pat_lifetime_exceeds_instance_maximum:
+    'This GitLab instance refuses a credential as long-lived as AgentConnect asks for — raise the maximum allowable access token lifetime in Admin → Settings → General → Account and limit, then run Repair',
   service_account_quota:
     'This GitLab group has reached its limit of bot accounts — remove one that is no longer used, then run Repair',
   service_account_create_failed: 'GitLab refused to create the bot account — run Repair to try again',
@@ -75,12 +115,16 @@ export const GITLAB_STATE_REASON: Record<string, string> = {
  *  unmapped category is an implementation identifier and never belongs on this surface. */
 export function gitlabStateReasonText(reason: string | null): string | null {
   if (!reason) return null
+  // A named category wins over its family: `rotation_service_account_creation_forbidden`
+  // is the one reason an operator can act on, and the family line would bury it.
+  const named = GITLAB_STATE_REASON[reason]
+  if (named) return named
   if (reason.startsWith('rotation_')) return 'The project bot credential needs repair'
   // The gitlab_<status> family is open-ended; the actionable part is the same for all of it.
   if (reason.startsWith('gitlab_')) {
     return 'GitLab refused the last administration request — reconnect the account that manages this project, or transfer it to your own'
   }
-  return GITLAB_STATE_REASON[reason] ?? null
+  return null
 }
 
 /** One pickable project: `binding` null means picking it sets it up first. */

--- a/packages/web/src/lib/use-gitlab-projects.test.tsx
+++ b/packages/web/src/lib/use-gitlab-projects.test.tsx
@@ -41,6 +41,10 @@ const CONNECTION: GitlabConnectionDto = {
   mine: true,
   accessExpiresAt: null,
   assignedProjects: 0,
+  instanceUrl: 'https://gitlab.com',
+  instanceVersion: '18.11.0-ee',
+  instanceVersionSupported: true,
+  instanceVersionFloor: '18.11',
   createdAt: '2026-08-01T00:00:00.000Z'
 }
 


### PR DESCRIPTION
Final milestone of `docs/designs/gitlab-com-integration.md` Section 24 (N4), after N0 the host axis, N1 the version floor, N2 protocol carriage, N3 daemon plumbing. Section 24 is marked implemented here.

## Creation authority

A self-managed instance may simply refuse to create a group service account, and there is no API that reports whether it will — probing by attempting a create would leave half-provisioned external state behind. So the refusal itself is the answer, and it now has a name.

A `403` from service-account creation, or from minting or rotating a PAT on an account that already exists, lands the account row in `service_account_creation_forbidden`. That is the row's own **state**, not an `admin_degraded` reason, and the distinction is load-bearing: `admin_degraded` is what the credential port refuses on, so filing withdrawn authority there would cut exactly the runtime leases §24.3 promises survive it. The credential port serves a `service_account_creation_forbidden` account as it serves a ready one, and the token's own expiry — already checked on every grant — is the bound.

It is also a settled verdict rather than a fault, so the inline pre-activation ensure reports it instead of spending its retry budget on an answer that cannot change without a human. Repair re-attempts once the operator has acted. The rotation case is named under a `rotation_`-prefixed reason, keeping it in the namespace a later successful sweep clears; that heal now keys on the reason's namespace alone, since the state it clears is no longer only `admin_degraded`. Both surfaces read a named reason before its family, so the specific remedy is not buried under the generic rotation line.

## The expiry clamp

The PAT policy revoked any token whose expiry did not match the request exactly. An instance token-lifetime cap is legitimate operator policy, so an expiry **earlier** than requested is now accepted and **recorded** — which is the whole re-derivation, because the rotation sweep reads that column. A 30-day cap rotates on a 30-day cycle. Null, later, or unparseable stays out of policy: revoked by id and failed closed, exactly as before. A create the instance rejects outright for its cap gets its own reason naming it.

## Surfaces

**Setup** composes the application links onto the configured base by concatenation — resolving an absolute path against a prefixed install root discards the prefix — and offers the admin applications path beside the user one with a line saying which to use. The prose stops saying GitLab.com where it means the configured instance, and one line states the authority project setup will need, honest that this page cannot verify it. The redirect URI and scopes are unchanged.

**Console** reads `instanceUrl` for the host badge and the bot rows' profile links, adds a version row with floor status, and gives withdrawn authority its own badge with copy naming every way to grant it: an instance administrator, the Premium/Ultimate delegation setting with its Admin Area path, and why Admin Mode defeats the first. Floor status is answered by the Control Plane (`instanceVersionSupported` plus the enforced floor on the connection DTO) rather than by a second version parser in a browser.

**Operator documentation** is a new `docs/self-managed-gitlab.md`: the floor, the certificate-authority bundle and the fact that its path must exist inside the sandbox too, which components dial the instance and which one never does, the webhook local-network allowlist, the delegation setting and Admin Mode caveat, and the Free/CE quota of 100 service accounts per instance.

## Tests

The integration fake gains an admin-only mode and a token-lifetime-cap mode. New integration coverage: the account row's state and the settled-verdict binding under admin-only; the inline ensure refusing with exactly one create attempted and no retry; Repair clearing it once authority is granted; the rotation `403` classification, the warning that carries it, the credential left serving, and the heal; the cap-rejection reason; a clamped expiry recorded and reaching rotation at 35 days but not at 14; a later-than-requested expiry revoked and failed closed. Setup gets link composition on a prefixed non-default-port instance. The console tests cover the badge, the links, both version rows, the unobserved case, and both authority remedies.

`pnpm typecheck`, `pnpm lint`, `pnpm format:check`, control-plane 1775 tests, web 1945 tests, setup 36 tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
