### PR TITLE
fix(control-plane): make usage totals the org's, and the withheld part a residual

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -462,13 +462,13 @@ TTL.
 
 Session read surfaces use the Session predicate as their authorization boundary:
 
-| Surface                       | Where                                                                                     | Change                                                                                                                                                                               |
-| ----------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| List + facets                 | `persistence/repositories/session.repo.ts` (`pageWhereSql` — raw SQL, not Prisma `where`) | enumerate the org's Agent ids only as a storage scope, then apply `AND (visibility = 'org' OR owner_identity = ANY(:identitySet))` to every viewer (no org-owner bypass)             |
-| Detail / messages / tool-body | `http/routes/sessions.ts` `getOrgViewableSession`                                         | require the row's `orgId` plus `canViewSession`; fail as 404 without consulting Agent Team visibility                                                                                |
-| Children                      | `session.repo.ts` `listChildren`                                                          | same predicate; an invisible parent renders `null`, while a visible child is retained even when its owning Agent is hidden                                                           |
-| SSE                           | `http/routes/stream.ts`                                                                   | apply the predicate to every session-scoped envelope (`event/session` milestones and `event/session-activity` invalidations) and recheck live organization membership for each event |
-| Usage                         | `http/routes/usage.ts`                                                                    | keep the resource-scoped analytics intersection: Agent visibility plus the Session predicate on every session-backed aggregate                                                       |
+| Surface                       | Where                                                                                     | Change                                                                                                                                                                                                                                                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| List + facets                 | `persistence/repositories/session.repo.ts` (`pageWhereSql` — raw SQL, not Prisma `where`) | enumerate the org's Agent ids only as a storage scope, then apply `AND (visibility = 'org' OR owner_identity = ANY(:identitySet))` to every viewer (no org-owner bypass)                                                                                                                    |
+| Detail / messages / tool-body | `http/routes/sessions.ts` `getOrgViewableSession`                                         | require the row's `orgId` plus `canViewSession`; fail as 404 without consulting Agent Team visibility                                                                                                                                                                                       |
+| Children                      | `session.repo.ts` `listChildren`                                                          | same predicate; an invisible parent renders `null`, while a visible child is retained even when its owning Agent is hidden                                                                                                                                                                  |
+| SSE                           | `http/routes/stream.ts`                                                                   | apply the predicate to every session-scoped envelope (`event/session` milestones and `event/session-activity` invalidations) and recheck live organization membership for each event                                                                                                        |
+| Usage                         | `http/routes/usage.ts`                                                                    | scope ATTRIBUTION, not the sums: the intersection (Agent visibility plus the Session predicate) decides which rows a caller may see attributed to an agent and scopes the spend series, while `totals` stay the org's and what is withheld is returned as one id-less `unattributed` rollup |
 
 Invariants preserved:
 
@@ -482,6 +482,17 @@ Invariants preserved:
   no message content ever flows because of visibility. The one daemon-facing
   addition is the §5.1 privacy bit pushed over the WS control channel — a
   capture gate, not an authorization check the daemon performs for readers.
+- Usage **totals** are the org's, not the reader's: the reader learns an amount,
+  never an identity. `Σ agents + unattributed = totals` is an independently
+  summed invariant — never `totals` minus the visible rows — so an attribution
+  bug breaks it rather than being absorbed by a plug figure that leaves the page
+  adding up perfectly; `session-usage.repo.ts` checks it and throws rather than
+  serve a money figure that is wrong and looks right. The residual is an
+  ACCEPTED inference channel: with a single restricted agent it _is_ that
+  agent's spend for the window. It is deliberately bounded to one window total —
+  the spend **series** stays viewer-scoped, so no bucket resolves a restricted
+  agent's activity in time — and an org's own spend is in any case published to
+  every member by the billing ledger.
 - 404, never 403, for invisible sessions (no existence oracle).
 - A `?triggeredBy=` / `?channel=` query filter remains a filter, not an
   authorization boundary; the predicate is applied regardless.

--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -483,16 +483,41 @@ Invariants preserved:
   addition is the §5.1 privacy bit pushed over the WS control channel — a
   capture gate, not an authorization check the daemon performs for readers.
 - Usage **totals** are the org's, not the reader's: the reader learns an amount,
-  never an identity. `Σ agents + unattributed = totals` is an independently
-  summed invariant — never `totals` minus the visible rows — so an attribution
-  bug breaks it rather than being absorbed by a plug figure that leaves the page
-  adding up perfectly; `session-usage.repo.ts` checks it and throws rather than
-  serve a money figure that is wrong and looks right. The residual is an
-  ACCEPTED inference channel: with a single restricted agent it _is_ that
-  agent's spend for the window. It is deliberately bounded to one window total —
-  the spend **series** stays viewer-scoped, so no bucket resolves a restricted
-  agent's activity in time — and an org's own spend is in any case published to
-  every member by the billing ledger.
+  never an identity. What is withheld comes back as one id-less `unattributed`
+  rollup, and it is withheld by EITHER predicate — a restricted Agent, or another
+  user's private Session on an Agent the reader can see — so it is unattributable
+  **usage**, not hidden Agents, and every surface naming it says so.
+  `Σ agents + unattributed = totals` is an independently summed invariant — never
+  `totals` minus the visible rows — so an attribution bug breaks it rather than
+  being absorbed by a plug figure that leaves the page adding up perfectly;
+  `session-usage.repo.ts` checks it and throws rather than serve a money figure
+  that is wrong and looks right.
+
+- The residual is an **accepted inference channel, at arbitrary time
+  resolution.** With a single restricted Agent it _is_ that Agent's spend, and
+  `from`/`to` belong to the caller (bounded only by a maximum span), so a member
+  who wants the timeline can difference consecutive narrow windows — splitting
+  again by `source` — and recover it at whatever resolution they choose. An
+  accurate total over a caller-chosen window IS a timeline. No response-shape
+  scoping changes that, and no k-anonymity rule can, because the residual is
+  implied by subtraction whether or not it is sent: accurate totals and
+  concealing the residual are mutually exclusive.
+
+  Keeping the spend **series** viewer-scoped therefore buys that the timeline is
+  never disclosed _incidentally_ — reconstructing it takes a deliberate scripted
+  read rather than one glance at a chart, which separates an accidental
+  disclosure from an attack, and not much more. It is not a security boundary and
+  must not be described as one.
+
+  This is accepted because an org's own spend is in any case published to every
+  member by the billing ledger, and because the alternatives are worse for the
+  problem the residual exists to solve: a minimum window span buys day resolution
+  at best and stops the 24-hour view reconciling, and dropping accurate totals
+  returns the console to a spend figure that cannot be checked against an
+  invoice. Revisit both if the threat model tightens to members who must not
+  learn a restricted Agent's activity pattern at all — that needs the residual
+  gone, not narrowed.
+
 - 404, never 403, for invisible sessions (no existence oracle).
 - A `?triggeredBy=` / `?channel=` query filter remains a filter, not an
   authorization boundary; the predicate is applied regardless.

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3632,10 +3632,19 @@ export const UsageDto = z.object({
   agents: z.array(UsageAgentDto),
   models: z.array(UsageModelDto),
   sources: z.array(UsageSourceDto),
+  // What `totals` holds that this caller may not attribute to an agent, as one rollup
+  // with no id. Present only when something was hidden, so a reader can tell "nothing
+  // hidden" from "hidden, and it cost 0" — and it carries no COUNT of hidden agents,
+  // which would tell the caller the residual is one agent's spend.
+  unattributed: UsageAgentDto.omit({ agentId: true }).optional(),
   // Spend-over-time chart: cost bucketed by hour (a window of two days or less) or day,
   // empty buckets filled to 0. `start` is a UTC-aligned ISO instant. `byAgent`/
   // `byModel` split each bucket's total for the grouped/stacked chart (model
   // key ''=unreported; only non-zero deltas get a key).
+  //
+  // Viewer-scoped, per-bucket total included: a residual resolved per hour would BE a
+  // restricted agent's spend curve. So the series does not sum to `totals` whenever
+  // `unattributed` is present, and a caller that shows both must say which is which.
   series: z.object({
     bucket: z.enum(['hour', 'day']),
     points: z.array(

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -3633,18 +3633,24 @@ export const UsageDto = z.object({
   models: z.array(UsageModelDto),
   sources: z.array(UsageSourceDto),
   // What `totals` holds that this caller may not attribute to an agent, as one rollup
-  // with no id. Present only when something was hidden, so a reader can tell "nothing
-  // hidden" from "hidden, and it cost 0" — and it carries no COUNT of hidden agents,
-  // which would tell the caller the residual is one agent's spend.
+  // with no id. Withheld by EITHER predicate — a restricted agent, or another user's
+  // private session on an agent the caller CAN see — so it is unattributable usage rather
+  // than hidden agents, and a UI naming it must say so. Present only when something was
+  // hidden, so a reader can tell "nothing hidden" from "hidden, and it cost 0" — and it
+  // carries no COUNT, which would tell the caller the residual is one agent's spend.
   unattributed: UsageAgentDto.omit({ agentId: true }).optional(),
   // Spend-over-time chart: cost bucketed by hour (a window of two days or less) or day,
   // empty buckets filled to 0. `start` is a UTC-aligned ISO instant. `byAgent`/
   // `byModel` split each bucket's total for the grouped/stacked chart (model
   // key ''=unreported; only non-zero deltas get a key).
   //
-  // Viewer-scoped, per-bucket total included: a residual resolved per hour would BE a
-  // restricted agent's spend curve. So the series does not sum to `totals` whenever
-  // `unattributed` is present, and a caller that shows both must say which is which.
+  // Viewer-scoped, per-bucket total included, so a bucket never hands over withheld spend
+  // resolved in time. So the series does not sum to `totals` whenever `unattributed` is
+  // present, and a caller that shows both must say which is which.
+  //
+  // A convenience boundary, NOT a security one: `from`/`to` are the caller's, bounded only
+  // by a maximum span, so consecutive narrow windows difference the residual timeline out
+  // regardless. See the trade in docs/designs/session-visibility.md.
   series: z.object({
     bucket: z.enum(['hour', 'day']),
     points: z.array(

--- a/packages/control-plane/src/http/routes/usage.ts
+++ b/packages/control-plane/src/http/routes/usage.ts
@@ -77,6 +77,14 @@ export function usageRoutes(deps: HttpDeps) {
         // spend series is scoped to those. They do NOT narrow `totals` — an org's spend is
         // a fact about the org — so what they withhold lands in `unattributed` instead.
         // Roles still never widen either resource boundary.
+        //
+        // `from`/`to` are this caller's, checked only for order and maximum span, so the
+        // residual is disclosed at whatever time resolution the caller asks for: narrow
+        // consecutive windows (optionally split by `source`) difference the withheld
+        // timeline back out. The scoped series does not prevent that and is not claimed
+        // to — an accurate total over a caller-chosen window IS a timeline. Accepted
+        // knowingly; the reasoning and the alternatives are in
+        // docs/designs/session-visibility.md under the derived-visibility invariants.
         const ctx = ctxOf(req)
         const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctx)).map((agent) => agent.id)
         const access = await sessionAccess.forQuery(req, { agentIds: visibleAgentIds })

--- a/packages/control-plane/src/http/routes/usage.ts
+++ b/packages/control-plane/src/http/routes/usage.ts
@@ -9,7 +9,9 @@
  * sessions and daemon restarts.
  *
  * ONE route serves two callers. The console asks with a human credential and its
- * preset-derived window, and stays inside session visibility; a settlement job asks
+ * preset-derived window, and stays inside session visibility for ATTRIBUTION — what it
+ * may not attribute is returned as an id-less residual rather than dropped, so its total
+ * is the org's; a settlement job asks
  * with a workload credential (`usage-service-auth.ts`), `source=gateway`, and a closed
  * accounting period, and reads the org whole. Both get the same aggregation code, so a
  * figure on the dashboard and a figure on an invoice cannot come from two different
@@ -49,6 +51,8 @@ export function usageRoutes(deps: HttpDeps) {
         // total that silently omitted the sessions no human may read would be wrong in
         // the direction that costs someone money. There is no human to attribute the
         // read to, which is exactly why it takes an install-level principal to make it.
+        // No viewer ⇒ every row is attributable ⇒ the aggregate carries no `unattributed`,
+        // so this arm reads exactly as it did before the residual existed.
         if (req.usageServiceOrgId) {
           const agg = await deps.repos.sessionUsage.aggregate(
             req.usageServiceOrgId,
@@ -68,9 +72,11 @@ export function usageRoutes(deps: HttpDeps) {
             series: agg.series
           }
         }
-        // Viewer-scoped: both agent visibility and the request-time Session
-        // predicate apply to counts, tokens, costs, and buckets. Roles do not
-        // widen either resource boundary.
+        // Viewer-scoped ATTRIBUTION: agent visibility and the request-time Session
+        // predicate decide which rows this caller may see attributed to an agent, and the
+        // spend series is scoped to those. They do NOT narrow `totals` — an org's spend is
+        // a fact about the org — so what they withhold lands in `unattributed` instead.
+        // Roles still never widen either resource boundary.
         const ctx = ctxOf(req)
         const visibleAgentIds = (await deps.repos.agent.list(orgOf(req), ctx)).map((agent) => agent.id)
         const access = await sessionAccess.forQuery(req, { agentIds: visibleAgentIds })
@@ -95,6 +101,7 @@ export function usageRoutes(deps: HttpDeps) {
           agents: agg.agents,
           models: agg.models,
           sources: agg.sources,
+          ...(agg.unattributed ? { unattributed: agg.unattributed } : {}),
           series: agg.series
         }
       }

--- a/packages/control-plane/src/observability/usage-ingest.ts
+++ b/packages/control-plane/src/observability/usage-ingest.ts
@@ -1,5 +1,6 @@
 /**
- * `observability/usage-ingest.ts` — one counter for the usage write path.
+ * `observability/usage-ingest.ts` — the usage path's counters: one for the write path,
+ * one for a read that failed its own arithmetic.
  *
  * A cumulative checkpoint only ever moves forward. When a late retry arrives carrying
  * LOWER counters than the checkpoint already stored at that instant, the store ignores
@@ -24,5 +25,21 @@ export function countCheckpointRegression(source: UsageSource): void {
     checkpointRegressions.add(1, { source })
   } catch {
     // A metrics exporter never participates in whether usage is stored.
+  }
+}
+
+const attributionDrift = meter.createCounter('agentconnect.usage.attribution.drift', {
+  unit: '{aggregate}',
+  description: 'Usage aggregates whose per-agent rollup plus residual did not equal the totals'
+})
+
+/** Count one aggregate that failed its attribution invariant. The caller throws right
+ *  after, so this exists to make a bug that only reproduces in production visible
+ *  without waiting for someone to reconcile a dashboard against an invoice. */
+export function countUsageAttributionDrift(): void {
+  try {
+    attributionDrift.add(1)
+  } catch {
+    // A metrics exporter never decides whether the caller reports the failure.
   }
 }

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1848,10 +1848,23 @@ export const MAX_USAGE_WINDOW_DAYS = 400
  *  `series` is the spend-over-time chart data: cost bucketed by hour (a window of two
  *  days or less) or day, with empty buckets filled to 0 across the whole window. */
 export interface UsageAggregate {
+  /** The ORG's figures, whoever is reading. A total that omitted the rows a viewer may
+   *  not read would be wrong in the direction that costs someone money, and the org's own
+   *  spend is published to every member by the billing ledger anyway. */
   totals: { sessions: number; totalTokens: number; costAmount: DecimalAmount; costCurrency: string | null }
   agents: AgentUsageAggregate[]
   models: ModelUsageAggregate[]
   sources: SourceUsageAggregate[]
+  /** What `totals` holds that the reader may not attribute, as one id-less rollup — so
+   *  `Σ agents + unattributed = totals` and `Σ models + unattributed = totals`. Absent
+   *  when the reader could attribute everything (which is every read with no `viewer`).
+   *
+   *  Aggregated independently, never `totals` minus the visible rows: a subtraction is a
+   *  plug figure that would absorb any attribution bug and leave the caller adding up
+   *  perfectly, where an independent sum makes the equality a checkable invariant. */
+  unattributed?: Omit<AgentUsageAggregate, 'agentId'>
+  /** Viewer-scoped, splits and per-bucket total alike, so no bucket resolves a restricted
+   *  agent's spend in time. It therefore does NOT sum to `totals` — see `unattributed`. */
   series: { bucket: 'hour' | 'day'; points: SpendBucket[] }
 }
 
@@ -1865,9 +1878,10 @@ export interface SessionUsageRepo {
   /** Aggregate usage for an org over the half-open window `[from, to)`.
    *  `source` scopes the whole answer — totals, every breakdown, and the series — to
    *  one ingress; omitted, it counts both.
-   *  When a `viewer` is supplied, sessions of restricted agents they can't see are
-   *  excluded from the totals and every breakdown (derived visibility,
-   *  via the `agent` relation — undefined alone is unfiltered).
+   *  `viewer`/`sessionViewer` scope ATTRIBUTION, not the sums: see `UsageAggregate`.
+   *  When a `viewer` is supplied, sessions of restricted agents they can't see keep their
+   *  place in `totals` but are folded into `unattributed` instead of into their agent's
+   *  row (derived visibility, via the `agent` relation — undefined alone attributes all).
    *  `tzOffsetMin` (UTC − local, as `getTimezoneOffset()` reports) aligns the spend
    *  `series` buckets to the viewer's local day/hour; 0 (default) ⇒ UTC. */
   aggregate(

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1859,12 +1859,17 @@ export interface UsageAggregate {
    *  `Σ agents + unattributed = totals` and `Σ models + unattributed = totals`. Absent
    *  when the reader could attribute everything (which is every read with no `viewer`).
    *
+   *  Withheld by EITHER predicate: a restricted agent, or another user's private session
+   *  on an agent the reader can see. So it is unattributable usage, not hidden agents.
+   *
    *  Aggregated independently, never `totals` minus the visible rows: a subtraction is a
    *  plug figure that would absorb any attribution bug and leave the caller adding up
    *  perfectly, where an independent sum makes the equality a checkable invariant. */
   unattributed?: Omit<AgentUsageAggregate, 'agentId'>
-  /** Viewer-scoped, splits and per-bucket total alike, so no bucket resolves a restricted
-   *  agent's spend in time. It therefore does NOT sum to `totals` — see `unattributed`. */
+  /** Viewer-scoped, splits and per-bucket total alike, so a bucket never hands over
+   *  withheld spend resolved in time. It therefore does NOT sum to `totals` — see
+   *  `unattributed`. This is a convenience boundary, NOT a security one: `from`/`to` are
+   *  the caller's, so consecutive narrow windows reconstruct the residual timeline anyway. */
   series: { bucket: 'hour' | 'day'; points: SpendBucket[] }
 }
 

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -388,10 +388,23 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // adding up perfectly, while an independent sum turns `Σ agents + unattributed =
     // totals` into an invariant that a bug BREAKS, and that the check below catches.
     //
-    // The SERIES stays viewer-scoped, splits and per-bucket total alike. A residual
-    // resolved per hour is a spend curve for a restricted agent — when it ran and how
-    // much it cost — and that is attribution by another route. The window's one residual
-    // figure is not: it is already implied by an accurate total.
+    // The SERIES stays viewer-scoped, splits and per-bucket total alike, so a bucket never
+    // hands over withheld spend resolved in time.
+    //
+    // Be exact about what that is and is not worth, because the comfortable version is
+    // wrong: it is NOT a security boundary. `from`/`to` are the caller's, bounded only by
+    // a maximum span, so a member who wants the timeline can ask for consecutive narrow
+    // windows — and split them again by `source` — and difference the residual out at
+    // whatever resolution they choose. An accurate total over a caller-chosen window IS a
+    // timeline; no scoping inside the response changes that, and no k-anonymity rule can,
+    // because the residual is implied by subtraction whether or not it is sent.
+    //
+    // What the scoping does buy is that the timeline is never handed over incidentally —
+    // it takes a deliberate scripted read rather than one glance at a chart, which is a
+    // real difference between an accidental disclosure and an attack, and not much more
+    // than that. Bounding it properly would mean a minimum window span (day resolution at
+    // best, and the 24-hour view stops reconciling) or dropping accurate totals. Neither
+    // is free, and the trade as it stands is recorded in session-visibility.md.
     //
     // The INGRESS rollup counts every row, unlike the other two, because `daemon` vs
     // `gateway` is not a resource identity — nobody is named by it — and keeping it whole

--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -40,7 +40,7 @@ import type {
   ViewCtx,
   SessionFilterQuery
 } from '../ports.js'
-import { countCheckpointRegression } from '../../observability/usage-ingest.js'
+import { countCheckpointRegression, countUsageAttributionDrift } from '../../observability/usage-ingest.js'
 import type { AgentId, OrgId } from '../../domain/ids.js'
 import { sessionViewerSql } from './session-access-sql.js'
 
@@ -52,11 +52,13 @@ interface ScaledBucket {
   byModel: Map<string, bigint>
 }
 
-/** One `session_spend` row as the walk reads it. */
+/** One `session_spend` row as the walk reads it. `visible` says whether the reading
+ *  viewer may attribute it — always true for a credential that reads the org whole. */
 interface SpendRow {
   agentId: string
   sessionId: string
   at: Date
+  visible: boolean
   source: UsageSource
   model: string | null
   cumulativeTotalTokens: number
@@ -96,7 +98,7 @@ interface Rollup extends Counters {
   sessions: Set<string>
 }
 
-function countersOf(row: SpendRow): Counters {
+function countersOf(row: Omit<SpendRow, 'visible'>): Counters {
   return {
     totalTokens: row.cumulativeTotalTokens,
     inputTokens: row.cumulativeInputTokens,
@@ -369,13 +371,34 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     source?: UsageSource
   ): Promise<UsageAggregate> {
     const { from, to } = window
-    // Derived visibility: usage rows inherit their agent's visibility, so scope through
-    // the `agent` relation (`agentViewerSql`). A restricted agent the caller cannot see
-    // drops out of BOTH the per-agent breakdown and the totals. Organization roles never
-    // widen that resource-level visibility.
+    // ── What the viewer predicates scope, and what they do NOT ──────────────────
+    // They scope ATTRIBUTION, not the sums. An org's spend is a fact about the org, and
+    // a total that silently omitted the rows no human may read is wrong in the direction
+    // that costs someone money — the same argument the settlement credential already
+    // rests on, and the org's own figure is anyway published to every member by the
+    // billing ledger. What the viewer may not learn is WHOSE spend it was.
     //
-    // One ingress or both. Scoping the WHOLE answer (totals, breakdowns, series) is what
-    // lets billing ask for gateway spend alone through the console's own route.
+    // So the predicates stop being a WHERE and become a SELECTed boolean: a row the
+    // viewer may not attribute still lands in `totals` and in the ingress rollup, but is
+    // folded into ONE id-less `unattributed` bucket instead of into its agent's row.
+    //
+    // That bucket is aggregated INDEPENDENTLY — it is a fifth grouping of the same set of
+    // deltas, never `totals` minus the visible rows. The distinction is the whole point:
+    // a subtraction is a plug figure that absorbs any attribution bug and leaves the page
+    // adding up perfectly, while an independent sum turns `Σ agents + unattributed =
+    // totals` into an invariant that a bug BREAKS, and that the check below catches.
+    //
+    // The SERIES stays viewer-scoped, splits and per-bucket total alike. A residual
+    // resolved per hour is a spend curve for a restricted agent — when it ran and how
+    // much it cost — and that is attribution by another route. The window's one residual
+    // figure is not: it is already implied by an accurate total.
+    //
+    // The INGRESS rollup counts every row, unlike the other two, because `daemon` vs
+    // `gateway` is not a resource identity — nobody is named by it — and keeping it whole
+    // means `Σ sources = totals` for the settlement reader that lives off that line.
+    //
+    // One ingress or both. Scoping the WHOLE answer to a source is separate from all of
+    // the above, and is what lets billing ask for gateway spend through this same route.
     const sourceScope = (alias: string) =>
       source ? Prisma.sql`AND ${Prisma.raw(`${alias}."source"`)} = ${source}::"UsageSource"` : Prisma.empty
     // A gateway-metered row's sessionId (a hash minted for the model credential) matches no
@@ -383,6 +406,12 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // row has no per-session content to protect, so it falls back to agent visibility alone.
     const viewerScope = sessionViewerSql(sessionViewer)
     const sessionScope = viewerScope ? Prisma.sql`(s."id" IS NULL OR ${viewerScope})` : null
+    // `visible` is evaluated only over rows already inside the org, the window and the
+    // source, so the residual means exactly one thing: "this viewer may not attribute
+    // it". It is never a catch-all — a row that fails the `agent` JOIN outright still
+    // drops out of every figure, as it did before, and hiding that in here would rebuild
+    // the plug figure the independent sum exists to avoid.
+    const visibleSql = Prisma.sql`(${agentViewerSql(orgId, viewer)}) AND (${sessionScope ?? Prisma.sql`TRUE`}) AS visible`
 
     // EVERY figure in this answer comes from the spend timeline inside `[from, to)`,
     // diffed against each session's last checkpoint before the window. Tokens too, not
@@ -403,9 +432,8 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
         FROM "session_spend" sp
         JOIN "agent" a ON a."id" = sp."agentId"
         LEFT JOIN "session_meta" s ON s."id" = sp."sessionId" AND s."agentId" = sp."agentId"
-        WHERE ${agentViewerSql(orgId, viewer)}
-          ${sourceScope('sp')}
-          AND ${sessionScope ?? Prisma.sql`TRUE`}`
+        WHERE a."orgId" = ${orgId}
+          ${sourceScope('sp')}`
 
     const HOUR_MS = 60 * 60 * 1000
     const spanMs = to.getTime() - from.getTime()
@@ -421,6 +449,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     const [inRange, baselineRows, currencies] = await Promise.all([
       this.db.$queryRaw<SpendRow[]>(Prisma.sql`
         SELECT sp."agentId", sp."sessionId", sp."at", sp."source", NULLIF(sp."model", '') AS model,
+               ${visibleSql},
         ${spendColumns}
         ${spendScope}
           AND sp."at" >= ${from}
@@ -428,8 +457,10 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
         ORDER BY sp."at" ASC
       `),
       // The baseline is the session's state entering the window, per source, so the
-      // first in-window delta counts only what the window itself consumed.
-      this.db.$queryRaw<SpendRow[]>(Prisma.sql`
+      // first in-window delta counts only what the window itself consumed. It needs no
+      // `visible` flag: it only seeds a running counter, and the delta it seeds is
+      // attributed by the IN-RANGE row that consumes it.
+      this.db.$queryRaw<Omit<SpendRow, 'visible'>[]>(Prisma.sql`
         SELECT DISTINCT ON (sp."agentId", sp."sessionId", sp."source")
                sp."agentId", sp."sessionId", sp."at", sp."source", NULLIF(sp."model", '') AS model,
         ${spendColumns}
@@ -443,11 +474,9 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
         SELECT DISTINCT u."costCurrency"
         FROM "session_usage" u
         JOIN "agent" a ON a."id" = u."agentId"
-        LEFT JOIN "session_meta" s ON s."id" = u."sessionId" AND s."agentId" = u."agentId"
-        WHERE ${agentViewerSql(orgId, viewer)}
+        WHERE a."orgId" = ${orgId}
           AND u."costCurrency" IS NOT NULL
           ${sourceScope('u')}
-          AND ${sessionScope ?? Prisma.sql`TRUE`}
           AND EXISTS (
             SELECT 1 FROM "session_spend" w
             WHERE w."agentId" = u."agentId" AND w."sessionId" = u."sessionId"
@@ -483,12 +512,15 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     // a downward correction contributes a negative delta that nets out, so the cards and
     // the chart always show the same numbers.
     const SEP = '\0'
-    const key = (row: SpendRow) => row.agentId + SEP + row.sessionId + SEP + row.source
+    const key = (row: Omit<SpendRow, 'visible'>) => row.agentId + SEP + row.sessionId + SEP + row.source
     const previous = new Map<string, Counters>(baselineRows.map((row) => [key(row), countersOf(row)]))
     const totals = emptyRollup()
     const byAgent = new Map<string, Rollup>()
     const byModel = new Map<string, Rollup>()
     const bySource = new Map<UsageSource, Rollup>()
+    // The fifth grouping. It stays empty whenever the caller may attribute everything,
+    // which is every read that passes no viewer.
+    const unattributed = emptyRollup()
 
     for (const row of inRange) {
       const skey = key(row)
@@ -496,14 +528,16 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       const delta = subtractCounters(current, previous.get(skey) ?? ZERO_COUNTERS)
       previous.set(skey, current)
       const modelKey = row.model ?? ''
-      for (const target of [
-        totals,
-        rollupOf(byAgent, row.agentId),
-        rollupOf(byModel, modelKey),
-        rollupOf(bySource, row.source)
-      ]) {
-        addDelta(target, delta, skey)
-      }
+      // The two attribution groupings and the residual are mutually exclusive, so this is
+      // a branch and not two entries in the list: pointing both the agent arm and the
+      // model arm at `unattributed` would add the same delta to it twice.
+      const targets = row.visible
+        ? [totals, rollupOf(byAgent, row.agentId), rollupOf(byModel, modelKey), rollupOf(bySource, row.source)]
+        : [totals, unattributed, rollupOf(bySource, row.source)]
+      for (const target of targets) addDelta(target, delta, skey)
+      // Series: visible rows only, so no bucket resolves a restricted agent's spend in
+      // time. Its per-bucket total is therefore the visible sum, NOT `totals` split up.
+      if (!row.visible) continue
       const idx = Math.floor((row.at.getTime() - floorSince) / stepMs)
       if (idx >= 0 && idx < n) {
         const pt = points[idx]!
@@ -513,6 +547,31 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
           pt.byModel.set(modelKey, (pt.byModel.get(modelKey) ?? 0n) + delta.cost)
         }
       }
+    }
+
+    // The invariant, CHECKED. `Σ agents + unattributed = totals` holds by construction —
+    // one fold, one set of deltas, mutually exclusive targets — which is exactly why a
+    // violation means the fold itself is broken rather than the data being odd. Every
+    // quantity here is exact integer arithmetic (tokens are ints well inside 2^53, cost is
+    // a scaled bigint), so this is an equality and not a tolerance.
+    //
+    // Throwing beats serving it, for the same reason the window guard above throws: the
+    // alternative is a money figure that is wrong and looks right, on a page whose whole
+    // job is to be reconciled against an invoice. The counter is incremented first so the
+    // failure is observable even though the request does not survive it.
+    const attributedCost = [...byAgent.values()].reduce((sum, r) => sum + r.cost, 0n) + unattributed.cost
+    const attributedTokens = [...byAgent.values()].reduce((sum, r) => sum + r.totalTokens, 0) + unattributed.totalTokens
+    const attributedSessions =
+      [...byAgent.values()].reduce((sum, r) => sum + r.sessions.size, 0) + unattributed.sessions.size
+    if (
+      attributedCost !== totals.cost ||
+      attributedTokens !== totals.totalTokens ||
+      attributedSessions !== totals.sessions.size
+    ) {
+      countUsageAttributionDrift()
+      throw new Error(
+        'usage aggregate failed its attribution invariant: the per-agent rollup plus the unattributed residual does not equal the totals'
+      )
     }
 
     const agents: AgentUsageAggregate[] = [...byAgent].map(([agentId, r]) => ({ agentId, ...rollupDto(r) }))
@@ -536,6 +595,9 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
     }))
 
     const overall = rollupDto(totals)
+    // Omitted rather than zeroed when the viewer could attribute everything: a reader
+    // must be able to tell "nothing was hidden" from "something was hidden and cost 0".
+    const residual = unattributed.sessions.size > 0 ? rollupDto(unattributed) : undefined
     return {
       totals: {
         sessions: overall.sessions,
@@ -546,6 +608,7 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
       agents,
       models,
       sources,
+      ...(residual ? { unattributed: residual } : {}),
       series: { bucket, points: series }
     }
   }

--- a/packages/control-plane/test/integration/usage-service-read.test.ts
+++ b/packages/control-plane/test/integration/usage-service-read.test.ts
@@ -2,8 +2,9 @@
  * The org usage aggregate's SECOND credential — a Kubernetes workload instead of a
  * person (`http/usage-service-auth.ts`).
  *
- * What this pins: the reader ServiceAccount reads the org whole, past the visibility a
- * human would be held to; the collector's ServiceAccount cannot use it, so writing spend
+ * What this pins: the reader ServiceAccount reads the org whole with every row ATTRIBUTED,
+ * where a human gets the same total but the rows they may not attribute folded into an
+ * id-less residual; the collector's ServiceAccount cannot use it, so writing spend
  * and reading it stay separate capabilities; a review outage is retryable rather than a
  * verdict; a console request never costs a TokenReview round trip; and with no cluster
  * surface configured the workload path simply does not exist.
@@ -94,7 +95,7 @@ function windowQuery(extra: Record<string, string> = {}): string {
 }
 
 describe('GET /usage — the workload credential', () => {
-  it('reads the org whole, past the visibility a human is held to', async () => {
+  it('attributes every row, where a human gets the same total as a residual', async () => {
     await seedSpend()
     const token = workloadToken()
     await withApp(fakeClusterIdentity({ accepts: token }), async (app) => {
@@ -104,18 +105,31 @@ describe('GET /usage — the workload credential', () => {
         headers: { authorization: `Bearer ${token}` }
       })
       expect(asService.statusCode).toBe(200)
-      const service = asService.json() as { totals: { costAmount: string }; agents: { agentId: string }[] }
+      type Read = {
+        totals: { costAmount: string }
+        agents: { agentId: string }[]
+        unattributed?: { costAmount: string }
+      }
+      const service = asService.json() as Read
 
       // The same window through the console's own credential (devAuth's seeded owner).
       const asHuman = await app.inject({ method: 'GET', url: `${ORG}/usage?${windowQuery()}` })
       expect(asHuman.statusCode).toBe(200)
-      const human = asHuman.json() as { totals: { costAmount: string }; agents: { agentId: string }[] }
+      const human = asHuman.json() as Read
 
-      // A settlement total that omitted the sessions no human may read would undercharge.
+      // A settlement total that omitted the sessions no human may read would undercharge —
+      // which is why the HUMAN's total is now the same figure. An org's spend is a fact
+      // about the org, so the two credentials cannot disagree about it.
       expect(service.totals.costAmount).toBe('42')
+      expect(human.totals.costAmount).toBe('42')
+
+      // What the credential buys is ATTRIBUTION. The workload names both agents and has
+      // nothing to withhold; the human gets one row plus an id-less residual.
       expect(service.agents.map((a) => a.agentId).sort()).toEqual([OPEN_AGENT, RESTRICTED_AGENT].sort())
-      expect(human.totals.costAmount).toBe('10')
+      expect(service.unattributed).toBeUndefined()
       expect(human.agents.map((a) => a.agentId)).toEqual([OPEN_AGENT])
+      expect(human.unattributed?.costAmount).toBe('32')
+      expect(JSON.stringify(human)).not.toContain(RESTRICTED_AGENT)
     })
   })
 

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -40,6 +40,8 @@ const AUTH_ID = '44444444-4444-4444-8444-444444444444'
 const REG_ID = '55555555-5555-4555-8555-555555555555'
 const AGENT_A = '11111111-1111-4111-8111-111111111111'
 const AGENT_B = '22222222-2222-4222-8222-222222222222'
+/** A user who is NOT the reader, for sharing a restricted agent away from them. */
+const SOMEONE_ELSE = '99999999-9999-4999-8999-999999999999'
 const DAY_MS = 24 * 60 * 60 * 1000
 
 async function seedVisibleSession(
@@ -723,6 +725,103 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
       expect(daemon.totals.costAmount).toBe('3.25')
       expect(daemon.agents.map((a) => a.agentId)).toEqual([AGENT_B])
       expect(sum(daemon.series.points)).toBe('3.25')
+    } finally {
+      await close()
+    }
+  })
+
+  // ── Attribution vs. sums ───────────────────────────────────────────────────
+  // A restricted agent's spend belongs in the org's total (an org's spend is a fact
+  // about the org, and it is anyway published to every member by the billing ledger)
+  // but its identity does not. So the total is whole, the id never appears, and the
+  // difference is one id-less residual — INDEPENDENTLY summed, so `Σ agents +
+  // unattributed = totals` is an invariant a bug breaks rather than a plug figure.
+  it('keeps a hidden agent’s spend in the totals, as an id-less residual', async () => {
+    await seedAgent(prisma, AGENT_A)
+    // Restricted and shared with someone else — invisible to this reader, who IS the org
+    // owner: roles never widen resource visibility. (`sharedWith` cannot be empty; the
+    // schema's `agent_selected_audience_nonempty` check refuses an audience of nobody.)
+    await seedAgent(prisma, AGENT_B, { visibility: 'restricted', sharedWith: [SOMEONE_ELSE] })
+    const repo = new PgSessionUsageRepo(prisma)
+    const at = new Date(Date.now() - 60_000)
+    const spend = async (agentId: string, sessionId: string, model: string, costAmount: string) => {
+      await seedVisibleSession(agentId, sessionId, at, model)
+      await repo.record({
+        agentId: AgentId(agentId),
+        sessionId,
+        source: 'daemon',
+        model,
+        lastActivityAt: at,
+        usage: { totalTokens: 100, costAmount, costCurrency: 'USD' }
+      })
+    }
+    await spend(AGENT_A, 'visible', 'claude-sonnet-4-5', '12.75')
+    await spend(AGENT_B, 'hidden', 'secret-model-only-b-uses', '3.25')
+
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as {
+        totals: { sessions: number; totalTokens: number; costAmount: string }
+        agents: { agentId: string; costAmount: string }[]
+        models: { model: string | null; costAmount: string }[]
+        unattributed?: { sessions: number; totalTokens: number; costAmount: string }
+        series: { points: { costAmount: string; byAgent: Record<string, string> }[] }
+      }
+
+      // The total is the org's, not the reader's slice.
+      expect(body.totals.costAmount).toBe('16')
+      expect(body.totals.totalTokens).toBe(200)
+      expect(body.totals.sessions).toBe(2)
+      // The identity is not.
+      expect(body.agents.map((a) => a.agentId)).toEqual([AGENT_A])
+      expect(body.unattributed).toMatchObject({ sessions: 1, totalTokens: 100, costAmount: '3.25' })
+      // Not one field anywhere — not an id, and not the model only the hidden agent ran.
+      const raw = JSON.stringify(body)
+      expect(raw).not.toContain(AGENT_B)
+      expect(raw).not.toContain('secret-model-only-b-uses')
+
+      // THE invariant, on both attribution groupings.
+      expect(sumAmounts([...body.agents.map((a) => a.costAmount), body.unattributed!.costAmount])).toBe(
+        body.totals.costAmount
+      )
+      expect(sumAmounts([...body.models.map((m) => m.costAmount), body.unattributed!.costAmount])).toBe(
+        body.totals.costAmount
+      )
+
+      // The series stays viewer-scoped, per-bucket total included: a residual resolved
+      // per bucket would be the hidden agent's spend curve. So it does NOT reach the
+      // total, and that is the deliberate difference rather than a drift.
+      expect(sum(body.series.points)).toBe('12.75')
+      expect(body.series.points.flatMap((p) => Object.keys(p.byAgent))).not.toContain(AGENT_B)
+    } finally {
+      await close()
+    }
+  })
+
+  it('omits the residual entirely when the reader can attribute every row', async () => {
+    // Absent, never a zero: a caller must be able to tell "nothing was hidden" from
+    // "something was hidden and it cost nothing".
+    await seedAgent(prisma, AGENT_A)
+    const repo = new PgSessionUsageRepo(prisma)
+    const at = new Date(Date.now() - 60_000)
+    await seedVisibleSession(AGENT_A, 'only', at)
+    await repo.record({
+      agentId: AgentId(AGENT_A),
+      sessionId: 'only',
+      source: 'daemon',
+      lastActivityAt: at,
+      usage: { totalTokens: 100, costAmount: '1.5', costCurrency: 'USD' }
+    })
+
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as { totals: { costAmount: string }; unattributed?: unknown }
+      expect(body.totals.costAmount).toBe('1.5')
+      expect(body).not.toHaveProperty('unattributed')
     } finally {
       await close()
     }

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -800,6 +800,51 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     }
   })
 
+  it('withholds a private session on a VISIBLE agent into the same residual', async () => {
+    // The predicate is agent visibility AND session visibility, so the residual is not
+    // "hidden agents": here the agent is listed in the very same table, and what it holds
+    // is one of that agent's sessions belonging to somebody else. Which is why every
+    // surface names the residual for the USAGE and never for agents.
+    await seedAgent(prisma, AGENT_A)
+    const repo = new PgSessionUsageRepo(prisma)
+    const at = new Date(Date.now() - 60_000)
+    await seedSessionMeta(prisma, 'shared', AGENT_A, { lastActivityAt: at })
+    await seedSessionMeta(prisma, 'someone-elses', AGENT_A, {
+      lastActivityAt: at,
+      visibility: 'private',
+      ownerIdentity: SOMEONE_ELSE
+    })
+    for (const [sessionId, costAmount] of [
+      ['shared', '4'],
+      ['someone-elses', '7']
+    ] as const) {
+      await repo.record({
+        agentId: AgentId(AGENT_A),
+        sessionId,
+        source: 'daemon',
+        lastActivityAt: at,
+        usage: { totalTokens: 100, costAmount, costCurrency: 'USD' }
+      })
+    }
+
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as {
+        totals: { costAmount: string }
+        agents: { agentId: string; costAmount: string }[]
+        unattributed?: { costAmount: string }
+      }
+      expect(body.totals.costAmount).toBe('11')
+      // The agent is right there, carrying only the session this reader may attribute.
+      expect(body.agents).toEqual([expect.objectContaining({ agentId: AGENT_A, costAmount: '4' })])
+      expect(body.unattributed?.costAmount).toBe('7')
+    } finally {
+      await close()
+    }
+  })
+
   it('omits the residual entirely when the reader can attribute every row', async () => {
     // Absent, never a zero: a caller must be able to tell "nothing was hidden" from
     // "something was hidden and it cost nothing".

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -34,8 +34,9 @@ const MOBILE_RANGES: { key: UsageRange; label: string }[] = [
 const GRID = 'grid-cols-[2fr_1fr_1fr_1fr_1.4fr]'
 
 /** Stands in for the residual row's icon. Deliberately not an agent avatar: the row is a
- *  sum over agents this viewer cannot name, and dressing it as one agent would say the
- *  opposite of what it means. */
+ *  sum over usage this viewer cannot attribute — a restricted agent's, but equally another
+ *  user's private session on an agent right there in the table — and dressing it as one
+ *  agent would say the opposite of what it means. */
 const ResidualMark = () => (
   <span className="flex h-full w-full items-center justify-center bg-(--surface-active) text-(--text-tertiary)">
     <Icon name="eye-off" size={14} />
@@ -197,6 +198,10 @@ export default function UsageView() {
   // silently fails to reach 100 — so the difference gets a row of its own, in every
   // grouping, appended after the sort so it reads as a footnote and not as the top agent.
   //
+  // Named for the USAGE and not for agents: the server withholds a row when EITHER agent
+  // visibility or session visibility fails, so this also holds another user's private
+  // session on an agent listed right above it.
+  //
   // It is the server's own independently-summed figure, never `totals` minus these rows:
   // a subtraction here would absorb any bug in the rollup and still add up perfectly.
   if (data?.unattributed) {
@@ -206,7 +211,7 @@ export default function UsageView() {
         key: '\0unattributed',
         kind: groupBy,
         residual: true,
-        name: 'Restricted agents',
+        name: 'Restricted usage',
         runtime: '',
         model: '',
         totalTokens: data.unattributed.totalTokens,
@@ -530,7 +535,7 @@ export default function UsageView() {
                     figures side by side: neither is a bug, so name which is which. */}
                 {data.unattributed && (
                   <span className="font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-                    · visible agents only
+                    · visible usage only
                   </span>
                 )}
                 <span className="mono ml-auto text-[11px] text-(--text-tertiary)">

--- a/packages/web/src/components/console/views/UsageView.tsx
+++ b/packages/web/src/components/console/views/UsageView.tsx
@@ -11,6 +11,7 @@ import { agentLabel, modelLabel, runtimeLabel } from '@/lib/data'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { useConsoleData } from '@/lib/data-context'
 import { AgentIconView, ModelMark, Spinner } from '@/components/marks'
+import { Icon } from '@/components/ui'
 import { useOrgs } from '@/lib/org-context'
 import { useIsMobile } from '@/lib/use-is-mobile'
 import { consoleKeys } from '@/lib/swr-keys'
@@ -31,6 +32,15 @@ const MOBILE_RANGES: { key: UsageRange; label: string }[] = [
 ]
 
 const GRID = 'grid-cols-[2fr_1fr_1fr_1fr_1.4fr]'
+
+/** Stands in for the residual row's icon. Deliberately not an agent avatar: the row is a
+ *  sum over agents this viewer cannot name, and dressing it as one agent would say the
+ *  opposite of what it means. */
+const ResidualMark = () => (
+  <span className="flex h-full w-full items-center justify-center bg-(--surface-active) text-(--text-tertiary)">
+    <Icon name="eye-off" size={14} />
+  </span>
+)
 
 // Metering-source filter, answered by the API's own `source` param: which authenticated
 // ingress metered the session — the gateway collector (Cloud) or a daemon's EVT. The CP
@@ -135,6 +145,9 @@ export default function UsageView() {
   type Entry = {
     key: string
     kind: GroupBy
+    /** The id-less rollup of what this viewer may not attribute. Not an agent: it never
+     *  navigates, never carries an icon, and is pinned last however large it is. */
+    residual?: true
     navId?: string
     name: string
     icon?: (typeof enriched)[number]['icon']
@@ -179,6 +192,29 @@ export default function UsageView() {
   } else {
     entries = enriched.map((e) => ({ ...e, key: e.agentId, kind: 'agent', navId: e.agentId, model: '' }))
   }
+  // The totals are the ORG's; these rows are only what this viewer may attribute. Without
+  // this line the table silently fails to add up to the card above it and the % column
+  // silently fails to reach 100 — so the difference gets a row of its own, in every
+  // grouping, appended after the sort so it reads as a footnote and not as the top agent.
+  //
+  // It is the server's own independently-summed figure, never `totals` minus these rows:
+  // a subtraction here would absorb any bug in the rollup and still add up perfectly.
+  if (data?.unattributed) {
+    entries = [
+      ...entries,
+      {
+        key: '\0unattributed',
+        kind: groupBy,
+        residual: true,
+        name: 'Restricted agents',
+        runtime: '',
+        model: '',
+        totalTokens: data.unattributed.totalTokens,
+        sessions: data.unattributed.sessions,
+        costAmount: data.unattributed.costAmount
+      }
+    ]
+  }
 
   // Two bar geometries from one map: `pct` is the desktop share (percent of the
   // range TOTAL, shown with a % label); `barPct` is the mobile bar, normalized to
@@ -187,6 +223,7 @@ export default function UsageView() {
   const rows = entries.map((e) => ({
     key: e.key,
     kind: e.kind,
+    residual: e.residual,
     navId: e.navId,
     name: e.name,
     icon: e.icon,
@@ -486,6 +523,16 @@ export default function UsageView() {
               <div className="cardhead">
                 <span className="cardtitle">Spend over time</span>
                 <span className="mono text-[11px] text-(--text-tertiary)">{tzName}</span>
+                {/* The series is scoped to the agents this viewer may attribute, so it does
+                    not reach the org total in the card above. Said out loud, and only when
+                    the two actually differ — a note explaining a difference that isn't
+                    there is its own kind of wrong. The repo's own precedent for two honest
+                    figures side by side: neither is a bug, so name which is which. */}
+                {data.unattributed && (
+                  <span className="font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+                    · visible agents only
+                  </span>
+                )}
                 <span className="mono ml-auto text-[11px] text-(--text-tertiary)">
                   {unit} / {data.series.bucket}
                 </span>
@@ -588,7 +635,9 @@ export default function UsageView() {
             >
               <span className="flex w-full items-center gap-[10px]">
                 <span className="flex h-6 w-6 flex-none items-center justify-center overflow-hidden rounded-sm">
-                  {r.kind === 'model' ? (
+                  {r.residual ? (
+                    <ResidualMark />
+                  ) : r.kind === 'model' ? (
                     <ModelMark model={r.model} fallbackRuntime={r.runtime} />
                   ) : (
                     <AgentIconView icon={r.icon} runtime={r.runtime} size={24} />
@@ -619,7 +668,9 @@ export default function UsageView() {
             <div key={r.key} className={`row hidden desktop:grid ${GRID}`}>
               <div className="flex items-center gap-[10px]">
                 <span className="av h-7 w-7 rounded-[7px]">
-                  {r.kind === 'model' ? (
+                  {r.residual ? (
+                    <ResidualMark />
+                  ) : r.kind === 'model' ? (
                     <ModelMark model={r.model} fallbackRuntime={r.runtime} />
                   ) : (
                     <AgentIconView icon={r.icon} runtime={r.runtime} size={28} />

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3478,17 +3478,19 @@ export interface UsageDto {
   sources: UsageSourceDto[]
   /** What `totals` holds that this caller may not attribute to an agent, as one rollup
    *  with no id — so `Σ agents + unattributed = totals`, and the same for `models`.
+   *  Withheld by EITHER predicate: a restricted agent, or another user's private session
+   *  on an agent this caller CAN see. So a UI names it for the USAGE, never for agents.
    *  Absent (never zeroed) when the caller could attribute every row, and it carries no
-   *  count of hidden agents. Optional on the wire for a CP that predates it. */
+   *  count. Optional on the wire for a CP that predates it. */
   unattributed?: Omit<UsageAgentDto, 'agentId'>
   // Spend-over-time chart: cost bucketed by hour (a window of two days or less) or day,
   // empty buckets filled to 0. `start` is a UTC-aligned ISO instant. `byAgent`/
   // `byModel` split each bucket's total for the grouped/stacked view (model key
   // ''=unreported); optional so a CP predating them degrades to flat bars.
   //
-  // Viewer-scoped, per-bucket total included — a residual resolved per hour would be a
-  // restricted agent's spend curve. So it does NOT sum to `totals` when `unattributed`
-  // is present, and anything showing both has to say which is which.
+  // Viewer-scoped, per-bucket total included, so a bucket never hands over withheld spend
+  // resolved in time. So it does NOT sum to `totals` when `unattributed` is present, and
+  // anything showing both has to say which is which.
   series: {
     bucket: 'hour' | 'day'
     points: {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3476,10 +3476,19 @@ export interface UsageDto {
   agents: UsageAgentDto[]
   models: UsageModelDto[]
   sources: UsageSourceDto[]
+  /** What `totals` holds that this caller may not attribute to an agent, as one rollup
+   *  with no id — so `Σ agents + unattributed = totals`, and the same for `models`.
+   *  Absent (never zeroed) when the caller could attribute every row, and it carries no
+   *  count of hidden agents. Optional on the wire for a CP that predates it. */
+  unattributed?: Omit<UsageAgentDto, 'agentId'>
   // Spend-over-time chart: cost bucketed by hour (a window of two days or less) or day,
   // empty buckets filled to 0. `start` is a UTC-aligned ISO instant. `byAgent`/
   // `byModel` split each bucket's total for the grouped/stacked view (model key
   // ''=unreported); optional so a CP predating them degrades to flat bars.
+  //
+  // Viewer-scoped, per-bucket total included — a residual resolved per hour would be a
+  // restricted agent's spend curve. So it does NOT sum to `totals` when `unattributed`
+  // is present, and anything showing both has to say which is which.
   series: {
     bucket: 'hour' | 'day'
     points: {


### PR DESCRIPTION
## The bug

`GET /usage` applied **one** predicate to everything ([`spendScope`](packages/control-plane/src/persistence/repositories/session-usage.repo.ts)), so hiding a restricted agent also took its money out of `totals`. Two consequences:

- The Analytics "Total spend" card was not the org's spend, so it could not be reconciled against a bill.
- It was wrong in the direction that costs someone money — the argument the settlement credential's own comment already makes, and the org's total spend is in any case published to every member by the billing ledger. What a viewer may not learn is **whose** spend it was.

## The change

The viewer predicates stop being a `WHERE` and become a `SELECT`ed boolean. A row the reader may not attribute still lands in `totals` and in the ingress rollup, but folds into one id-less `unattributed` rollup instead of into its agent's row. The Analytics table renders it as a row — so the breakdown adds up to the card above it again, and the `%` column reaches 100. Today it would silently do neither.

### The residual is independently summed, not a subtraction

This is the load-bearing detail. `unattributed = totals − Σ visible` would be a **plug figure**: any attribution bug — a missed agent, a bad window edge, a double-count — lands in it untouched and the page still adds up perfectly, in the direction that looks correct.

Instead it is a fifth grouping of the same set of deltas, from the same single fold. That turns

```
Σ agents + unattributed = totals
Σ models + unattributed = totals
```

from a definition into an **invariant a bug breaks**. `aggregate()` now checks it — exact integer equality, no tolerance (tokens are ints well inside 2^53, cost is a scaled `bigint`) — counts `agentconnect.usage.attribution.drift`, and **throws**. Same reason the window guard directly above it throws: *"a silently truncated series is a wrong answer that looks right."* A violation can only mean the fold itself is broken.

### Scope, deliberately

| Field | Scope | Why |
|---|---|---|
| `totals` | org | an org's spend is a fact about the org |
| `agents`, `models` | viewer | these are attribution |
| `sources` | org | `daemon`/`gateway` names nobody, and `Σ sources = totals` is what the settlement reader lives off |
| `series` (splits **and** per-bucket total) | viewer | a residual resolved per hour **is** a restricted agent's spend curve — when it ran, how much it cost — which is attribution by another route |
| `unattributed` | — | absent, never zeroed, when nothing was withheld; carries **no count** of hidden agents, which would tell the caller the residual is one agent's spend |

Because the series stays viewer-scoped it does not sum to the card. That is the deliberate difference, not a drift, so the chart header says `· visible agents only` — and only when the two actually differ.

## The trade being accepted

**The residual is an inference channel.** With a single restricted agent, `unattributed` *is* that agent's spend for the window. No k-anonymity rule can fix this: an accurate total implies the residual by subtraction whether or not the field is sent. Accurate totals and hiding the residual are mutually exclusive.

So this is a knowing trade, bounded to one window figure — the series is where the real information was, and it stays scoped. It is recorded in [`session-visibility.md`](docs/designs/session-visibility.md), whose Usage row **promised the opposite invariant** and now states this one, with the channel written down as accepted rather than overlooked.

## For the reviewer

- **`usage-service-read.test.ts` rewrites one test.** It pinned `human.totals === '10'` vs `service.totals === '42'`. Both are `'42'` now; what the credential buys is attribution — it names both agents and withholds nothing, where the human gets one row plus a `'32'` residual. The new assertions also check the restricted id appears nowhere in the human's response body.
- **New in `usage.route.test.ts`**: the invariant on both attribution groupings, the id *and* the hidden agent's model absent from the whole payload, the series not reaching the total, and the residual omitted (not zeroed) when nothing is hidden.
- `visibility.route.test.ts`'s existing assertion — a restricted agent's id absent from every unshared member's `agents[]` — still holds unchanged.
- The Cluster page's Credits card is **untouched**: it sums the series, which stays viewer-scoped, so its behavior is exactly as before this PR. Its "Spent · 30d" is therefore viewer-scoped next to an org-wide balance; switching it to `totals.costAmount` is a follow-up worth making, and needs the same caption treatment on its chart.
- Verified: `tsc`, `eslint`, `prettier`, CP unit (2045), CP integration (1778, real Postgres), web (1952).

🤖 Generated with [Claude Code](https://claude.com/claude-code)