### PR TITLE
fix(web): name authorization in the session-unavailable reasons, and count tokens to billions

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1358,22 +1358,17 @@ function SessionDetailFrame({ children, withDock = true }: { children: ReactNode
 }
 
 function sessionUnavailableReasons(providerName: string | undefined, profileLinked: boolean | undefined): string[] {
+  const base = ['The session doesn’t exist or has been removed.', 'You aren’t authorized to see this session.']
   if (!providerName) {
-    return ['The session doesn’t exist or has been removed.']
+    return base
   }
   if (profileLinked === false) {
-    return ['The session doesn’t exist or has been removed.', `Your ${providerName} profile isn’t linked.`]
+    return [...base, `Your ${providerName} profile isn’t linked.`]
   }
   if (profileLinked === true) {
-    return [
-      'The session doesn’t exist or has been removed.',
-      `Your linked ${providerName} profile belongs to a different workspace.`
-    ]
+    return [...base, `Your linked ${providerName} profile belongs to a different workspace.`]
   }
-  return [
-    'The session doesn’t exist or has been removed.',
-    `Your ${providerName} profile isn’t linked or belongs to a different workspace.`
-  ]
+  return [...base, `Your ${providerName} profile isn’t linked or belongs to a different workspace.`]
 }
 
 export default function SessionDetailView() {

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -79,6 +79,9 @@ describe('fmtCountCompact', () => {
     [101_817, '102K'],
     [2_316_000, '2.32M'],
     [2_463_144, '2.46M'],
+    [1_234_567_890, '1.23B'],
+    [45_600_000_000, '46B'],
+    [2_500_000_000_000, '2,500B'],
     [undefined, '—']
   ])('formats %s as %s', (value, expected) => {
     expect(fmtCountCompact(value)).toBe(expected)

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1908,9 +1908,13 @@ export function fmtCountCompact(n: number | null | undefined): string {
   // Strip trailing zeros only AFTER a decimal point — never the integer part.
   // A bare `/\.?0+$/` would turn "10" → "1", rendering 10M as "1M".
   const trim = (s: string) => (s.includes('.') ? s.replace(/\.?0+$/, '') : s)
-  if (n >= 1_000_000) return trim((n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 2)) + 'M'
-  if (n >= 1_000) return trim((n / 1_000).toFixed(n >= 10_000 ? 0 : 1)) + 'K'
-  return String(n)
+  // Group the integer part — "B" is the largest unit, so past 1000B the digits keep going.
+  const fmt = (v: number, digits: number) =>
+    trim(v.toFixed(digits)).replace(/^-?\d+/, (i) => Number(i).toLocaleString('en-US'))
+  if (n >= 1_000_000_000) return fmt(n / 1_000_000_000, n >= 10_000_000_000 ? 0 : 2) + 'B'
+  if (n >= 1_000_000) return fmt(n / 1_000_000, n >= 10_000_000 ? 0 : 2) + 'M'
+  if (n >= 1_000) return fmt(n / 1_000, n >= 10_000 ? 0 : 1) + 'K'
+  return n.toLocaleString('en-US')
 }
 
 // Format the daemon-metered session cost. Currency is an ISO code (e.g. "USD");


### PR DESCRIPTION
Two small console fixes.

## Session unavailable — "Possible reasons"

`SessionDetailView`'s not-found body listed only existence and profile-link reasons, so a session that exists but isn't yours read as "doesn't exist". The two shared reasons are now a `base` array and every branch carries **"You aren't authorized to see this session."**

## Token counts — billions and thousands separators

`fmtCountCompact` topped out at `M`, so a billion-token total rendered as `1234M`, and nothing grouped the digits.

- New `B` tier, on the same rule as `M`: ≥10 units → no decimals, otherwise two. `1_234_567_890` → `1.23B`, `45.6e9` → `46B`.
- The integer part is grouped: `2.5e12` → `2,500B` (`B` is the largest unit, so past 1000B the digits keep going), and sub-1000 counts go through `toLocaleString` instead of `String`.

## Reviewer notes

- `fmtCountCompact` is shared — Analytics (the requested surface), Agents, Session detail, Dream panel, and the context-window indicator all pick up `B` and the grouping. No Analytics-only formatter was added.
- Cases added to `api.test.ts`; `pnpm --filter @agentconnect.md/web test` passes (1965) and `typecheck` is clean.
- Negative and fractional inputs still fall through the old path — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)