### PR TITLE
fix(daemon): reach the directDestination migration by bumping SCHEMA_VERSION

### DIFF
--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -830,9 +830,12 @@ function restrictPath(path: string, mode: number): void {
 /**
  * Schema version a freshly created database is stamped with. Bump it in the same
  * change that edits a `CREATE TABLE` below, and append the matching step to
- * {@link SCHEMA_MIGRATIONS}.
+ * {@link SCHEMA_MIGRATIONS}. Appending a step WITHOUT bumping this leaves the step
+ * unreachable — `upgradeSchema` stops at this number — so the column exists only on
+ * fresh databases and every established one fails at query time. `SCHEMA_MIGRATIONS`
+ * asserts the two stay in lockstep for exactly that reason.
  */
-const SCHEMA_VERSION = 12
+const SCHEMA_VERSION = 13
 
 /**
  * Ordered in-place upgrades for a store created by an EARLIER daemon.
@@ -968,6 +971,16 @@ const SCHEMA_MIGRATIONS: ((db: StoreTx, store: { shared: boolean }) => Promise<v
   // existing rows: absent keeps the CP's ordinary child inheritance, which is what they got.
   async (db) => await db.exec('ALTER TABLE sessions ADD COLUMN directDestination INTEGER')
 ]
+
+// The list and the version are two halves of one fact: step `i` moves a database from
+// `user_version === i + 1` to `i + 2`, so the last step must land exactly on SCHEMA_VERSION.
+// A step appended without the bump is silently dead code — the failure mode that shipped
+// `directDestination` to fresh databases only, and broke every established one at query time.
+if (SCHEMA_MIGRATIONS.length !== SCHEMA_VERSION - 1) {
+  throw new Error(
+    `local store schema is inconsistent: ${SCHEMA_MIGRATIONS.length} migration step(s) cannot reach v${SCHEMA_VERSION}`
+  )
+}
 
 export class LocalStore {
   /** The backend as given. Only the tool-write flush uses it directly; everything else goes

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -103,6 +103,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN claimedAt')
     dropTranscriptOrg(old)
     old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
+    old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
     old.exec('PRAGMA user_version = 1')
     old.close()
 
@@ -130,7 +131,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     expect(cronColumns).toContain('definition')
     // Purge receipts are leased per pool member (#1032).
     expect(purgeColumns).toEqual(expect.arrayContaining(['ownerId', 'claimedAt']))
-    expect(userVersion(path)).toBe(12)
+    expect(userVersion(path)).toBe(13)
   })
 
   it.skipIf(pg)('never persists the CP routing map on a shared store, and still does on an owned one', async () => {
@@ -178,6 +179,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN claimedAt')
     dropTranscriptOrg(old)
     old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
+    old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
     old.exec('PRAGMA user_version = 5')
     old.close()
 
@@ -193,7 +195,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     expect(await upgraded.isCaptureExcluded('bot-c', 'acp-2')).toBe(true)
     await upgraded.close()
 
-    expect(userVersion(path)).toBe(12)
+    expect(userVersion(path)).toBe(13)
   })
 
   it('re-keys the runtime catalog cache on its owning member when upgrading a v7 store', async () => {
@@ -223,6 +225,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN claimedAt')
     dropTranscriptOrg(old)
     old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
+    old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
     old.exec('PRAGMA user_version = 7')
     old.close()
 
@@ -244,7 +247,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
         .map((column) => column.name)
     expect(primaryKey(metaColumns)).toEqual(['ownerId', 'runtimeId'])
     expect(primaryKey(capColumns)).toEqual(['ownerId', 'runtimeId', 'modelId'])
-    expect(userVersion(path)).toBe(12)
+    expect(userVersion(path)).toBe(13)
   })
 
   it('backfills a v11 store with the outward id its sessions were already reported under', async () => {
@@ -257,6 +260,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     // A session that never launched has no id to inherit — it gets one when it next needs one.
     old.exec(`INSERT INTO sessions (key, agentId, platform, channel, thread, acpSessionId, state, updatedAt)
       VALUES ('k2', 'bot-a', 'slack', 'C1', 'T2', NULL, 'idle', 100)`)
+    old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
     old.exec('PRAGMA user_version = 11')
     old.close()
 
@@ -267,7 +271,29 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     expect((await upgraded.getSession('k2'))?.sessionId).toBeNull()
     expect(await upgraded.ensureOutwardSessionId('k2', 'bot-a')).toMatch(/^[0-9a-f-]{36}$/)
     await upgraded.close()
-    expect(userVersion(path)).toBe(12)
+    expect(userVersion(path)).toBe(13)
+  })
+
+  // The regression that made `directDestination` reachable on fresh databases only: the step was
+  // appended to SCHEMA_MIGRATIONS without bumping SCHEMA_VERSION, so `upgradeSchema` stopped short
+  // of it and every established store failed at query time instead of at boot.
+  it('adds directDestination to a v12 store', async () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'ac-schema-v12-')), 'local.sqlite')
+    await (await LocalStore.open(path)).close()
+    const old = new DatabaseSync(path)
+    old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
+    old.exec(`INSERT INTO sessions (key, agentId, platform, channel, thread, acpSessionId, state, updatedAt)
+      VALUES ('k1', 'bot-a', 'slack', 'C1', 'T1', 'acp-1', 'idle', 100)`)
+    old.exec('PRAGMA user_version = 12')
+    old.close()
+
+    const upgraded = await LocalStore.open(path)
+    // The read path that broke: every dispatch resolves a session's classification.
+    expect(await upgraded.getSessionClassification('bot-a', 'acp-1')).toEqual({})
+    await upgraded.setSessionClassification('k1', { sourceBindingKind: 'external', directDestination: true })
+    expect(await upgraded.getSessionClassification('bot-a', 'acp-1')).toMatchObject({ directDestination: true })
+    await upgraded.close()
+    expect(userVersion(path)).toBe(13)
   })
 
   it('refuses a store written by a newer daemon WITHOUT touching it first', async () => {
@@ -2489,6 +2515,7 @@ describe.skipIf(pg)('transcript org migration from a v10 store', () => {
       VALUES ('C1', 'T1', '1', 'U', 'text', 'kept', 'agent-a', 1000000, 1)`)
     old.exec("INSERT INTO transcript_recipient (channel, thread, ts, agentId) VALUES ('C1', 'T1', '1', 'agent-b')")
     old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
+    old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
     old.exec('PRAGMA user_version = 10')
     old.close()
     return path


### PR DESCRIPTION
## The break

#1456 added `sessions.directDestination` and appended the matching step to `SCHEMA_MIGRATIONS` —
but left `SCHEMA_VERSION` at `12`. `upgradeSchema` loops `while (version < SCHEMA_VERSION)`, so it
stopped one step short and the new step never ran.

Fresh databases were fine: they take the whole schema from the `CREATE` block, which has the
column. Every **established** store stayed at v12 *without* it, so `getSessionClassification` —
one call per dispatch, plus every `event/session` re-emit — failed:

```
ERROR relay im dispatch failed for agent "…": Error: no such column: directDestination
WARN  session visibility: classification failed for 01a03297-… (Error: no such column: directDestination
```

Observed live on the test CP: an agent mentioned in Slack at 07:05:47 UTC started its ACP host two
seconds later and then answered nothing, no session row anywhere — the dispatch threw before the
session was created, and the mention was lost. Any daemon that had run before this shipped was
dead for IM on every message.

## The fix

- `SCHEMA_VERSION = 13`, which makes the appended step reachable.
- The list and the version are asserted to stay in lockstep at module load. Step `i` moves a
  database from `user_version === i + 1` to `i + 2`, so the last step must land exactly on
  `SCHEMA_VERSION`; a step that cannot be reached is dead code. This assert is the part that
  actually prevents a recurrence — the failure is invisible to a suite whose stores are all
  created fresh, which is why 4700 green tests said nothing.
- The upgrade fixtures drop the column before replaying, the way each already drops the one its
  own step adds, plus a v12 case that walks the read and the write path the missing column broke
  (`getSessionClassification` → `setSessionClassification` → read back).

## Rollout

Existing stores are still at v12 with no column; the migration adds it on the next daemon start,
so nothing needs a manual repair. A store hand-patched during the window should be left at
`user_version = 12` with the column dropped, so this step applies normally.

`local-store` + permissions + portability + dialect + round-trips + retention + concurrency +
`daemon-transcript`: 211 passed. Typecheck, lint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
