### PR TITLE
feat(daemon): adopt the Slack agent-session lifecycle and native stop

### DIFF
--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -35,6 +35,7 @@ const EXEMPT: Record<string, string> = {
   postPermissionUpdateCard: 'private permission-card helper',
   postIfThreadExists: 'private Slack root-existence guard',
   postChatMessage: 'private shared post boundary behind postMessage/postBlocks',
+  setSessionLifecycle: 'private agent-session lifecycle call, behind setStatus',
   shareWithIdentity: 'private identity-carrying upload path, behind uploadFile',
   putUploadBytes: 'private step 2 of the external upload, behind uploadFile',
   completeUpload: 'private step 3 of the external upload, behind uploadFile',

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -106,6 +106,7 @@ describe('buildInstallManifest', () => {
 
   it('pins the exact bot events (drift guard)', () => {
     expect([...SLACK_BOT_EVENTS]).toEqual([
+      'agent_session_stopped',
       'app_mention',
       'app_uninstalled',
       'assistant_thread_started',

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -6,6 +6,7 @@ import {
   slackOAuthRedirectUri,
   SLACK_BOT_SCOPES,
   SLACK_BOT_EVENTS,
+  SLACK_SOCKET_ONLY_BOT_EVENTS,
   DEFAULT_SLACK_APP_NAME
 } from './slack-manifest.js'
 import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
@@ -51,8 +52,12 @@ describe('buildInstallManifest', () => {
     expect(m.settings.event_subscriptions.request_url).toBe('https://relay.example/slack/events')
     expect(m.settings.interactivity.request_url).toBe('https://relay.example/slack/interactions')
     expect(m.settings.interactivity.message_menu_options_url).toBe('https://relay.example/slack/interactions')
-    // still carries the same scopes + events (only the transport differs).
-    expect(m.settings.event_subscriptions.bot_events).toEqual([...SLACK_BOT_EVENTS])
+    // Same events MINUS the socket-only ones: the relay's ingress never forwards those, so
+    // advertising one here would render a control this transport cannot answer.
+    expect(m.settings.event_subscriptions.bot_events).toEqual(
+      [...SLACK_BOT_EVENTS].filter((event) => !SLACK_SOCKET_ONLY_BOT_EVENTS.includes(event))
+    )
+    expect(m.settings.event_subscriptions.bot_events).not.toContain('agent_session_stopped')
   })
 
   it('falls back to the default app name when blank', () => {

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -18,16 +18,20 @@ import {
   PLATFORM_APP_DESCRIPTION,
   SLACK_BOT_EVENTS,
   SLACK_BOT_SCOPES,
+  slackBotEvents,
   slackEventsRequestUrl,
-  slackInteractionsRequestUrl
+  slackInteractionsRequestUrl,
+  SLACK_SOCKET_ONLY_BOT_EVENTS
 } from '@agentconnect.md/protocol/slack-app-manifest'
 
 export {
   DEFAULT_SLACK_APP_NAME,
   SLACK_BOT_EVENTS,
   SLACK_BOT_SCOPES,
+  slackBotEvents,
   slackEventsRequestUrl,
-  slackInteractionsRequestUrl
+  slackInteractionsRequestUrl,
+  SLACK_SOCKET_ONLY_BOT_EVENTS
 }
 
 /**
@@ -207,7 +211,7 @@ export function mergeManagedSlackManifest(
       event_subscriptions: {
         ...managedEvents,
         ...currentEvents,
-        bot_events: unionStrings(currentEvents.bot_events, SLACK_BOT_EVENTS),
+        bot_events: unionStrings(currentEvents.bot_events, slackBotEvents(http)),
         // HTTP mode: force the relay pool's Events API request_url (a socket refresh
         // leaves the exported value — there is none — untouched).
         ...(http ? { request_url: slackEventsRequestUrl(httpRelayBase!) } : {})

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -263,9 +263,8 @@ export interface SlackDeps {
   onStatusInfo?: (
     sessionKey: string
   ) => Promise<{ info: StatusBarInfo; identity?: StatusModalIdentity; link?: string; cancellable: boolean } | undefined>
-  /** Resolve the exact local session owned by the selected Slack conversation, awaited
-   *  before the one-shot shortcut trigger opens its modal. */
-  onMessageShortcut?: (a: { channel: string; thread: string; userId: string }) => Promise<string | undefined>
+  /** Resolve the local session a Slack conversation owns — for the shortcut modal, and for the stop button. */
+  onMessageShortcut?: (a: { channel: string; thread: string; userId?: string }) => Promise<string | undefined>
   /** Fired when a user taps a button on an interactive permission card
    *  (render.buildPermissionCard). The decoded `requestId` ties the click back to the
    *  pending ACP `session/request_permission`; `optionId` is the chosen option. */
@@ -430,9 +429,10 @@ export type AppLike = {
     assistant: {
       threads: {
         setStatus: (a: unknown) => Promise<unknown>
-        setTitle: (a: unknown) => Promise<unknown>
       }
     }
+    // The generic Web-API escape hatch: @slack/web-api 8 has no typed `agents.sessions.*`.
+    apiCall: (method: string, a?: Record<string, unknown>) => Promise<unknown>
   }
   init?: () => Promise<void>
   start: () => Promise<void>
@@ -654,6 +654,8 @@ export class SlackConnection implements PlatformConnection {
   // assistant_thread_started, while later message.im payloads may arrive without
   // thread_ts. Keep the active DM thread root so replies stay inside that thread.
   private assistantDmThreads = new Map<string, string>()
+  /** Last agent-session lifecycle state per `channel:thread`, so an unchanged one refires nothing. */
+  private sessionLifecycle = new Map<string, 'processing' | 'active'>()
   botUserId = ''
   /** The appToken this socket is keyed by (one socket per unique appToken). */
   readonly appToken: string
@@ -760,6 +762,22 @@ export class SlackConnection implements PlatformConnection {
     this.app.event('assistant_thread_started', async ({ event }) => {
       const thread = this.rememberAssistantThread(event as AssistantThreadStartedEvent)
       if (thread) log?.debug(`slack: assistant thread started ch=${thread.channel} thread=${thread.threadTs}`)
+    })
+    // Native stop button. Slack leaves the session in `processing`, so interrupt the turn then transition it.
+    this.app.event('agent_session_stopped', async ({ event }) => {
+      const ev = event as { channel?: string; thread_ts?: string; user?: string }
+      const channel = ev.channel
+      const thread = ev.thread_ts
+      if (!channel || !thread) return
+      log?.debug(`slack: agent session stopped ch=${channel} thread=${thread} user=${ev.user ?? '?'}`)
+      const sessionKey = await this.deps.onMessageShortcut?.({ channel, thread, userId: ev.user })
+      if (sessionKey)
+        this.deps.onStatusAction?.({
+          kind: 'cancel',
+          sessionKey,
+          ...(ev.user ? { actor: { userId: ev.user } } : {})
+        })
+      await this.queue.enqueue(() => this.setSessionLifecycle(channel, thread, 'active'))
     })
     // Membership changes: the bot was invited to (member_joined_channel, filtered
     // to our own user id) or removed from (channel_left / group_left) a channel.
@@ -1761,11 +1779,7 @@ export class SlackConnection implements PlatformConnection {
     }
   }
 
-  /**
-   * Best-effort assistant loading status (assistant.threads.setStatus).
-   * Works in channels/DMs/assistant panel under chat:write (post Mar 2026).
-   * Pass status='' to clear. Never throws into dispatch.
-   */
+  /** Best-effort loading status: the legacy free text plus the lifecycle enum. Pass '' to clear; never throws. */
   async setStatus(
     channel: string,
     threadTs: string,
@@ -1791,20 +1805,37 @@ export class SlackConnection implements PlatformConnection {
         this.rememberMissingScopes(err)
         this.deps.log?.debug(`slack: setStatus failed (ch=${channel} thread=${threadTs}): ${(err as Error).message}`)
       }
+      // Already inside the send queue — setSessionLifecycle must not enqueue again.
+      await this.setSessionLifecycle(channel, threadTs, status ? 'processing' : 'active')
       await this.postPermissionUpdateCard(channel, threadTs)
     })
   }
 
-  /**
-   * Best-effort assistant thread title (assistant.threads.setTitle). This API is
-   * only valid for Slack app threads created by the Agents feature; the daemon
-   * gates calls to DM sessions before reaching this boundary. Never throws into
-   * dispatch, including when the shared send queue itself times out.
-   */
+  // The lifecycle half of setStatus. Posting a message does NOT end the loading UX — only `active` does.
+  // Deduped per (channel, thread); no username/icon, because Slack keeps those sticky until cleared.
+  private async setSessionLifecycle(channel: string, threadTs: string, status: 'processing' | 'active'): Promise<void> {
+    const key = `${channel}:${threadTs}`
+    if (this.sessionLifecycle.get(key) === status) return
+    try {
+      await this.app.client.apiCall('agents.sessions.setStatus', {
+        channel_id: channel,
+        thread_ts: threadTs,
+        status
+      })
+      this.sessionLifecycle.set(key, status)
+    } catch (err) {
+      // Left unrecorded so the next status update retries instead of deduping a failure.
+      this.deps.log?.debug(
+        `slack: session lifecycle ${status} failed (ch=${channel} thread=${threadTs}): ${(err as Error).message}`
+      )
+    }
+  }
+
+  /** Best-effort agent-session title; only valid for Agents-feature threads, so the daemon gates it to DMs. */
   async setTitle(channel: string, threadTs: string, title: string): Promise<void> {
     try {
       await this.queue.enqueue(() =>
-        this.app.client.assistant.threads.setTitle({
+        this.app.client.apiCall('agents.sessions.rename', {
           channel_id: channel,
           thread_ts: threadTs,
           title

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -1814,6 +1814,9 @@ export class SlackConnection implements PlatformConnection {
   // The lifecycle half of setStatus. Posting a message does NOT end the loading UX — only `active` does.
   // Deduped per (channel, thread); no username/icon, because Slack keeps those sticky until cleared.
   private async setSessionLifecycle(channel: string, threadTs: string, status: 'processing' | 'active'): Promise<void> {
+    // Send-only (HTTP) bots take inbound from the relay, which does not forward the stop event —
+    // so `processing` here would render a Stop button nothing on this side could ever answer.
+    if (this.deps.sendOnly) return
     const key = `${channel}:${threadTs}`
     if (this.sessionLifecycle.get(key) === status) return
     try {

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -26,7 +26,7 @@ import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
  *  - `post`        a finalized body/result section → chat.postMessage in the thread.
  *  - `notice`      a system line (e.g. the done footer) posted to the thread but not recorded.
  *  - `set-status`  the transient assistant status bar (assistant.threads.setStatus).
- *  - `set-title`   the native Slack app-thread title (assistant.threads.setTitle).
+ *  - `set-title`   the native Slack app-thread title (agents.sessions.rename).
  *  - `progress`    the SINGLE in-place "main progress" message (medium/high) — posted
  *                  once then chat.update-ed in place as tool activity changes (in-place update).
  *  - `reasoning`   the SINGLE in-place reasoning "context block" (high only) — the

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -34,9 +34,10 @@ describe('consolidate', () => {
   })
 })
 
+// `apiCall` is the generic Web-API entry the untyped `agents.sessions.*` methods go through.
 function fakeAppWith(
   setStatus: (a: any) => Promise<unknown>,
-  setTitle: (a: any) => Promise<unknown> = async () => undefined,
+  apiCall: (method: string, a: any) => Promise<unknown> = async () => ({}),
   postMessage: (a: any) => Promise<unknown> = async () => ({})
 ) {
   return {
@@ -47,7 +48,8 @@ function fakeAppWith(
     client: {
       auth: { test: async () => ({ user_id: 'U1', team_id: 'T123' }) },
       chat: { postMessage, getPermalink: async () => ({ permalink: 'https://example.slack.com/thread' }) },
-      assistant: { threads: { setStatus, setTitle } }
+      assistant: { threads: { setStatus } },
+      apiCall
     },
     start: async () => {},
     stop: async () => {}
@@ -968,6 +970,90 @@ describe('SlackConnection.setStatus', () => {
     await expect(conn.setStatus('C1', '123.45', 'is thinking…')).resolves.toBeUndefined()
   })
 
+  // The free-text call and the lifecycle enum are two halves of one status: the enum drives
+  // the native loading UX (and the stop button), the free text is what the user reads.
+  const lifecycleConn = (record: (a: any) => void, setStatus: (a: any) => Promise<unknown> = async () => undefined) =>
+    new SlackConnection(
+      { ...deps(), sendIntervalMs: 0 } as any,
+      () =>
+        fakeAppWith(setStatus, async (method, a) => {
+          if (method === 'agents.sessions.setStatus') record(a)
+          return {}
+        }) as any
+    )
+
+  it('mirrors the free-text status with the agent-session lifecycle enum', async () => {
+    const lifecycle: any[] = []
+    const conn = lifecycleConn((a) => lifecycle.push(a))
+
+    await conn.setStatus('C1', '123.45', 'is thinking…', ['Working on it…'], {
+      username: 'Release Captain',
+      icon_url: 'https://console.example.test/icons/bot-a'
+    })
+    await conn.setStatus('C1', '123.45', '')
+
+    // No username/icon here on purpose: Slack keeps those sticky on an agent session until
+    // cleared, so the per-agent identity stays on the free-text call.
+    expect(lifecycle).toEqual([
+      { channel_id: 'C1', thread_ts: '123.45', status: 'processing' },
+      { channel_id: 'C1', thread_ts: '123.45', status: 'active' }
+    ])
+  })
+
+  it('refires nothing for an unchanged lifecycle state, per channel and thread', async () => {
+    const lifecycle: any[] = []
+    const conn = lifecycleConn((a) => lifecycle.push(a))
+
+    await conn.setStatus('C1', '123.45', 'is thinking…')
+    await conn.setStatus('C1', '123.45', 'Searching…')
+    await conn.setStatus('C1', '999.99', 'is thinking…')
+    await conn.setStatus('C1', '123.45', '')
+    await conn.setStatus('C1', '123.45', '')
+
+    expect(lifecycle).toEqual([
+      { channel_id: 'C1', thread_ts: '123.45', status: 'processing' },
+      { channel_id: 'C1', thread_ts: '999.99', status: 'processing' },
+      { channel_id: 'C1', thread_ts: '123.45', status: 'active' }
+    ])
+  })
+
+  it('retries a lifecycle state the last call failed on rather than deduping the failure', async () => {
+    const lifecycle: any[] = []
+    let attempts = 0
+    const conn = new SlackConnection(
+      { ...deps(), sendIntervalMs: 0 } as any,
+      () =>
+        fakeAppWith(
+          async () => undefined,
+          async (method, a) => {
+            if (method !== 'agents.sessions.setStatus') return {}
+            if (++attempts === 1) throw new Error('ratelimited')
+            lifecycle.push(a)
+            return {}
+          }
+        ) as any
+    )
+
+    await conn.setStatus('C1', '123.45', 'is thinking…')
+    await conn.setStatus('C1', '123.45', 'Searching…')
+
+    expect(lifecycle).toEqual([{ channel_id: 'C1', thread_ts: '123.45', status: 'processing' }])
+  })
+
+  it('keeps a failing lifecycle call out of dispatch', async () => {
+    const conn = new SlackConnection(
+      { ...deps(), sendIntervalMs: 0 } as any,
+      () =>
+        fakeAppWith(
+          async () => undefined,
+          async () => {
+            throw new Error('not_an_agent_session')
+          }
+        ) as any
+    )
+    await expect(conn.setStatus('C1', '123.45', 'is thinking…')).resolves.toBeUndefined()
+  })
+
   it('posts one permission-update card when Slack reports a missing scope', async () => {
     const missingScope = Object.assign(new Error('An API error occurred: missing_scope'), {
       data: { error: 'missing_scope', needed: 'assistant:write', provided: 'chat:write' }
@@ -1013,19 +1099,121 @@ describe('SlackConnection.setStatus', () => {
   })
 })
 
+describe('SlackConnection agent_session_stopped', () => {
+  // The native stop button. Slack leaves the session in `processing` after it fires, so the
+  // app owes both halves: interrupt the running turn, then transition the session itself.
+  const stopApp = (
+    handlers: Map<string, (a: { event: unknown }) => unknown>,
+    apiCall: (method: string, a: any) => Promise<unknown>
+  ) => ({
+    message() {},
+    event(type: string, h: (a: { event: unknown }) => unknown) {
+      handlers.set(type, h)
+    },
+    action() {},
+    shortcut() {},
+    client: {
+      auth: { test: async () => ({ user_id: 'UBOT' }) },
+      views: { open: async () => {}, update: async () => {} },
+      chat: { postMessage: async () => ({}), getPermalink: async () => ({ permalink: 'https://example.slack.com/t' }) },
+      assistant: { threads: { setStatus: async () => undefined } },
+      apiCall
+    },
+    start: async () => {},
+    stop: async () => {}
+  })
+
+  const stopped = (over: Record<string, unknown> = {}) => ({
+    event: {
+      type: 'agent_session_stopped',
+      channel: 'C1',
+      thread_ts: '200.1',
+      streaming_message_ts: [],
+      user: 'U1',
+      event_ts: '200.9',
+      ...over
+    }
+  })
+
+  const started = async (sessionKey: string | undefined) => {
+    const handlers = new Map<string, (a: { event: unknown }) => unknown>()
+    const lifecycle: any[] = []
+    const actions: any[] = []
+    const resolved: any[] = []
+    const conn = new SlackConnection(
+      {
+        ...deps(),
+        sendIntervalMs: 0,
+        onMessageShortcut: async (a: unknown) => {
+          resolved.push(a)
+          return sessionKey
+        },
+        onStatusAction: (a: unknown) => void actions.push(a)
+      } as any,
+      () =>
+        stopApp(handlers, async (method, a) => {
+          if (method === 'agents.sessions.setStatus') lifecycle.push(a)
+          return {}
+        }) as any
+    )
+    await conn.start()
+    return { conn, handlers, lifecycle, actions, resolved }
+  }
+
+  it('cancels the turn the stopped session owns and transitions the session itself', async () => {
+    const { handlers, lifecycle, actions, resolved } = await started('slack:C1:200.1:bot-a')
+
+    await handlers.get('agent_session_stopped')!(stopped())
+
+    expect(resolved).toEqual([{ channel: 'C1', thread: '200.1', userId: 'U1' }])
+    expect(actions).toEqual([{ kind: 'cancel', sessionKey: 'slack:C1:200.1:bot-a', actor: { userId: 'U1' } }])
+    expect(lifecycle).toEqual([{ channel_id: 'C1', thread_ts: '200.1', status: 'active' }])
+  })
+
+  it('still transitions the session when no local session owns the thread', async () => {
+    const { handlers, lifecycle, actions } = await started(undefined)
+
+    await handlers.get('agent_session_stopped')!(stopped())
+
+    expect(actions).toEqual([])
+    expect(lifecycle).toEqual([{ channel_id: 'C1', thread_ts: '200.1', status: 'active' }])
+  })
+
+  it('makes the turn-end status clear that follows a stop a no-op', async () => {
+    const { conn, handlers, lifecycle } = await started('slack:C1:200.1:bot-a')
+
+    await handlers.get('agent_session_stopped')!(stopped())
+    await conn.setStatus('C1', '200.1', '')
+
+    expect(lifecycle).toEqual([{ channel_id: 'C1', thread_ts: '200.1', status: 'active' }])
+  })
+
+  it('ignores a payload without session coordinates', async () => {
+    const { handlers, lifecycle, actions } = await started('slack:C1:200.1:bot-a')
+
+    await handlers.get('agent_session_stopped')!(stopped({ thread_ts: undefined }))
+
+    expect(actions).toEqual([])
+    expect(lifecycle).toEqual([])
+  })
+})
+
 describe('SlackConnection.setTitle', () => {
-  it('maps args to assistant.threads.setTitle', async () => {
+  it('maps args to agents.sessions.rename', async () => {
     const calls: any[] = []
     const conn = new SlackConnection(
       deps() as any,
       () =>
         fakeAppWith(
           async () => undefined,
-          async (a) => void calls.push(a)
+          async (method, a) => void calls.push([method, a])
         ) as any
     )
     await conn.setTitle('D1', '123.45', 'Runtime summary')
-    expect(calls[0]).toEqual({ channel_id: 'D1', thread_ts: '123.45', title: 'Runtime summary' })
+    expect(calls[0]).toEqual([
+      'agents.sessions.rename',
+      { channel_id: 'D1', thread_ts: '123.45', title: 'Runtime summary' }
+    ])
   })
 
   it('swallows errors and never rejects (best-effort)', async () => {
@@ -1053,18 +1241,18 @@ describe('SlackConnection.setTitle', () => {
           resolveCard = resolve
         })
     )
-    const setTitle = vi.fn(async () => {
+    const rename = vi.fn(async () => {
       throw missingScope
     })
     const conn = new SlackConnection(
       { ...deps(), group: { ...deps().group, appId: 'A123' }, sendIntervalMs: 0 } as any,
-      () => fakeAppWith(async () => undefined, setTitle, postMessage) as any
+      () => fakeAppWith(async () => undefined, rename, postMessage) as any
     )
 
     const first = conn.setTitle('D1', '123.45', 'First title')
     await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce())
     const second = conn.setTitle('D1', '123.45', 'Second title')
-    await vi.waitFor(() => expect(setTitle).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(rename).toHaveBeenCalledTimes(2))
     expect(postMessage).toHaveBeenCalledOnce()
 
     resolveCard({ ts: 'card-1' })

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -1040,6 +1040,31 @@ describe('SlackConnection.setStatus', () => {
     expect(lifecycle).toEqual([{ channel_id: 'C1', thread_ts: '123.45', status: 'processing' }])
   })
 
+  // HTTP bots take inbound from the relay, which does not forward the stop event. Setting
+  // `processing` there would render a Stop button this side could never answer.
+  it('makes no lifecycle call on a send-only (HTTP) connection', async () => {
+    const calls: any[] = []
+    const legacy: any[] = []
+    const conn = new SlackConnection(
+      { ...deps(), sendOnly: true, sendIntervalMs: 0 } as any,
+      () =>
+        fakeAppWith(
+          async (a) => void legacy.push(a),
+          async (method, a) => {
+            calls.push([method, a])
+            return {}
+          }
+        ) as any
+    )
+
+    await conn.setStatus('C1', '123.45', 'is thinking…')
+    await conn.setStatus('C1', '123.45', '')
+
+    // The legacy free-text status still runs — only the lifecycle enum is withheld.
+    expect(legacy).toHaveLength(2)
+    expect(calls).toEqual([])
+  })
+
   it('keeps a failing lifecycle call out of dispatch', async () => {
     const conn = new SlackConnection(
       { ...deps(), sendIntervalMs: 0 } as any,

--- a/packages/daemon/test/fakes/slack-app.ts
+++ b/packages/daemon/test/fakes/slack-app.ts
@@ -65,7 +65,8 @@ export function fakeSlackAppFactory(identity: FakeSlackIdentity = {}): SlackAppF
           info: async () => ({}),
           conversations: async () => ({ channels: [] })
         },
-        assistant: { threads: { setStatus: ok, setTitle: ok } }
+        assistant: { threads: { setStatus: ok } },
+        apiCall: ok
       },
       start: async () => {},
       stop: async () => {}

--- a/packages/protocol/src/slack-app-manifest.ts
+++ b/packages/protocol/src/slack-app-manifest.ts
@@ -46,6 +46,8 @@ export const SLACK_BOT_SCOPES = [
 ] as const
 
 export const SLACK_BOT_EVENTS = [
+  // The native stop button on an agent session; without the subscription Slack never shows it.
+  'agent_session_stopped',
   'app_mention',
   'app_uninstalled',
   'assistant_thread_started',

--- a/packages/protocol/src/slack-app-manifest.ts
+++ b/packages/protocol/src/slack-app-manifest.ts
@@ -61,6 +61,15 @@ export const SLACK_BOT_EVENTS = [
   'tokens_revoked'
 ] as const
 
+// Bot events only a Socket Mode app can act on. The relay's HTTP ingress forwards chat and
+// finalization events only, so advertising one over HTTP renders a control that goes nowhere.
+export const SLACK_SOCKET_ONLY_BOT_EVENTS: readonly string[] = ['agent_session_stopped']
+
+/** The bot events one transport's manifest advertises: the full list, minus what only a socket can serve. */
+export function slackBotEvents(http: boolean): string[] {
+  return SLACK_BOT_EVENTS.filter((event) => !http || !SLACK_SOCKET_ONLY_BOT_EVENTS.includes(event))
+}
+
 export const DEFAULT_SLACK_APP_NAME = 'agentconnect'
 
 export interface SlackAppManifest extends Record<string, unknown> {
@@ -142,7 +151,7 @@ export function buildSlackAppManifest(name: string, options: SlackAppManifestOpt
     },
     settings: {
       event_subscriptions: {
-        bot_events: [...SLACK_BOT_EVENTS],
+        bot_events: slackBotEvents(http),
         ...(relayUrl ? { request_url: slackEventsRequestUrl(relayUrl) } : {})
       },
       interactivity: {

--- a/packages/web/src/components/console/platforms/slack/manifest.test.ts
+++ b/packages/web/src/components/console/platforms/slack/manifest.test.ts
@@ -4,6 +4,7 @@ import {
   slackCreateAppUrl,
   SLACK_BOT_SCOPES,
   SLACK_BOT_EVENTS,
+  SLACK_SOCKET_ONLY_BOT_EVENTS,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
   PLATFORM_APP_DESCRIPTION
 } from './manifest'
@@ -61,6 +62,25 @@ describe('buildSlackManifest', () => {
     // A color (from the owning agent's icon) ⇒ display_information.background_color.
     const branded = buildSlackManifest({ name: 'acme' }, { backgroundColor: '#c62a78' })
     expect(branded.display_information.background_color).toBe('#c62a78')
+  })
+
+  // The stop button is a Socket Mode capability: the relay's HTTP ingress forwards chat and
+  // finalization events only, so an http app advertising it would show a control that goes nowhere.
+  it('advertises the socket-only events on socket, and withholds them over http', () => {
+    const socket = buildSlackManifest({ name: 'acme' })
+    const http = buildSlackManifest({ name: 'acme' }, { mode: 'http', relayUrl: 'https://relay.example' })
+
+    expect(socket.settings.socket_mode_enabled).toBe(true)
+    expect(socket.settings.event_subscriptions.bot_events).toEqual([...SLACK_BOT_EVENTS])
+    expect(http.settings.socket_mode_enabled).toBe(false)
+    expect(http.settings.event_subscriptions.bot_events).toEqual(
+      [...SLACK_BOT_EVENTS].filter((event) => !SLACK_SOCKET_ONLY_BOT_EVENTS.includes(event))
+    )
+    expect(http.settings.event_subscriptions.bot_events).not.toContain('agent_session_stopped')
+  })
+
+  it('pins the socket-only event list (drift guard)', () => {
+    expect([...SLACK_SOCKET_ONLY_BOT_EVENTS]).toEqual(['agent_session_stopped'])
   })
 
   it('uses the generic public app description', () => {

--- a/packages/web/src/components/console/platforms/slack/manifest.test.ts
+++ b/packages/web/src/components/console/platforms/slack/manifest.test.ts
@@ -38,6 +38,7 @@ describe('manifest parity with the Control Plane', () => {
 
   it('pins the exact bot events (drift guard)', () => {
     expect([...SLACK_BOT_EVENTS]).toEqual([
+      'agent_session_stopped',
       'app_mention',
       'app_uninstalled',
       'assistant_thread_started',

--- a/packages/web/src/components/console/platforms/slack/manifest.ts
+++ b/packages/web/src/components/console/platforms/slack/manifest.ts
@@ -32,6 +32,7 @@ import {
   SLACK_BOT_EVENTS,
   SLACK_BOT_SCOPES,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+  SLACK_SOCKET_ONLY_BOT_EVENTS,
   type SlackAppManifest
 } from '@agentconnect.md/protocol/slack-app-manifest'
 
@@ -41,6 +42,7 @@ export {
   SLACK_BOT_EVENTS,
   SLACK_BOT_SCOPES,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
+  SLACK_SOCKET_ONLY_BOT_EVENTS,
   type SlackAppManifest
 }
 


### PR DESCRIPTION
Slack is replacing the legacy assistant surface with the Agent Sessions API (the two are bridged today). This adopts the parts that change what a user actually sees, without dropping anything the legacy surface still renders.

## What changed

**Manifest** — `SLACK_BOT_EVENTS` gains `agent_session_stopped`. Without that subscription Slack never renders the native stop button at all. Scopes are untouched: both new methods run on `chat:write`, which we already request.

**Lifecycle mirror** — `SlackConnection.setStatus` now makes the new call alongside the legacy one, so every existing caller and branch inherits it for free:

| free-text status | `agents.sessions.setStatus` |
| --- | --- |
| non-empty (`"is thinking…"`, `"Searching…"`) | `status: 'processing'` |
| `''` (the turn-end clear) | `status: 'active'` |

The legacy `assistant.threads.setStatus` call is unchanged — same free text, same `loading_messages`, same per-agent identity overrides. The new call is best-effort exactly like the old one: a failure is logged at debug and never thrown into dispatch.

Two semantics worth calling out:

- **Enum, not prose.** The new API takes `active | processing | suspended | closed`. The human-readable status a user reads stays on the legacy call; the enum is what drives the native loading UX and the stop button. We only ever move between `processing` and `active`.
- **`active` on turn end is required, not cosmetic.** Under the legacy surface the loading state disappeared when the app posted a message. It does not under the new one — the app has to send `active` explicitly, or the session sits in `processing` forever after a reply lands. The existing turn-end clear (`status: ''`) is what carries that, which is why mirroring inside `setStatus` rather than adding a new call site is the right seam.

Consecutive identical lifecycle states are deduped per (channel, thread), so the several free-text updates a single turn emits produce one `processing`, not one per update. A failed call is deliberately left unrecorded so the next status update retries rather than deduping the failure.

**No identity on the new call.** `username` / `icon_url` are accepted there (under `chat:write.customize`) but Slack keeps them **sticky until explicitly cleared** — setting them once would pin that agent's name and avatar to the session for every later status, including one set by a different agent. Per-agent authorship therefore stays on the free-text call, which applies it per status and drops it on a clear.

**Rename** — `setTitle` now calls `agents.sessions.rename` instead of `assistant.threads.setTitle`. Same argument shape, same best-effort error handling, and the daemon's existing DM-only gating is left exactly where it is (deliberately not widened to channels in this change).

**Native stop** — a Bolt handler for `agent_session_stopped` resolves the session owning `(channel, thread_ts)` and cancels the in-flight turn through the path the status-bar Cancel button already uses (`onMessageShortcut` to resolve, then `onStatusAction {kind:'cancel'}` → `cancelSessionByKey`), so the operator behind the stop is recorded the same way a Cancel tap is. It then sets the session `active`, since Slack does not transition it on stop. If the normal turn-end clear also fires, the dedupe above makes it a no-op. A payload missing channel or thread coordinates is ignored; a thread with no local session still gets the lifecycle transition.

`@slack/web-api` 8.0.0 exposes no typed `agents.sessions.*` methods, so both new calls go through the generic `client.apiCall(...)` entry point, added to the `AppLike` client surface.

## Socket Mode only, enforced on both halves

The stop button is only answerable where the daemon owns the socket: relay-backed HTTP ingress forwards chat and finalization events and never the stop callback. An HTTP bot that advertised the subscription and set `processing` would render a native Stop control nothing on our side could answer, and Slack does not transition the session on its own. Both halves are gated on the transport axis each layer already has:

- `slackBotEvents(http)` filters `SLACK_SOCKET_ONLY_BOT_EVENTS` out of the manifest's `bot_events` when a relay URL is present — applied to the install manifest and the refresh merge alike, so neither funnel adds it to an HTTP app.
- `setSessionLifecycle` returns early on a send-only connection, which is exactly how HTTP bots are constructed, so they never reach `processing`. The handler registration was already socket-only: send-only connections return from `start()` before any handler is registered.

The legacy free-text status keeps working identically on both transports.

## Scope

No streaming, no suggested prompts, no protocol frame changes, and the legacy free-text status and `loading_messages` stay exactly as they are. `packages/relay` has zero diff — routing the stop callback through HTTP ingress is deliberately not attempted here.

## Verified

- `pnpm --filter @agentconnect.md/protocol test` — 451 passed / 27 files.
- `pnpm --filter @agentconnect.md/daemon test` — the four Slack-touching files (`connection`, `daemon-smoke`, `slack-upload-file`, `slack-status-actor`) pass, 107 tests. Four files in the full daemon run fail (`shim-workspace-files`, `shim-exec-handler`, `shim-cancellation`, `acp-matrix`) — confirmed pre-existing by stashing this change and re-running them on a clean tree, where they fail identically. They are local-environment failures (`sandbox-exec` refusing `execvp` of the local bash, and real-provider quota/auth errors), unrelated to this diff, and green on CI.
- `pnpm --filter @agentconnect.md/web test` — 1964 passed / 177 files.
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 2041 passed / 177 files; `test:int` — 1793 passed / 113 files.
- `pnpm eval:gates` — 193 passed / 28 files.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean.

New tests cover the lifecycle mirror (processing on the first status, active on the clear, identity-free args), the dedupe (including per-thread keying and the retry-after-failure case), the send-only connection making no lifecycle call, the rename call, the socket-vs-http manifest split, and the stop event (cancel routed with the actor, lifecycle transitioned, unknown session, missing coordinates, and the follow-on turn-end clear collapsing to a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
