### PR TITLE
fix(setup): carry the target origin's port when re-hosting a discovered URL

### DIFF
--- a/packages/setup/src/server/auth.ts
+++ b/packages/setup/src/server/auth.ts
@@ -49,6 +49,9 @@ export function urlAtOrigin(value: string, origin: string): URL {
   const target = new URL(origin)
   url.protocol = target.protocol
   url.host = target.host
+  // The host setter keeps the port the value already carried when the assigned host names none, so
+  // a URL discovered on a management endpoint's :3001 would keep it at a public origin serving 443.
+  url.port = target.port
   return url
 }
 

--- a/packages/setup/test/server-auth.test.ts
+++ b/packages/setup/test/server-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { SetupAuthenticator } from '../src/server/auth.js'
+import { SetupAuthenticator, urlAtOrigin } from '../src/server/auth.js'
 
 const oidc = { issuer: 'https://login.example.test/oidc', audience: 'agentconnect' }
 
@@ -28,5 +28,23 @@ describe('setup-server auth boundary', () => {
       statusCode: 503,
       code: 'ADMIN_OIDC_NOT_CONFIGURED'
     })
+  })
+})
+
+describe('urlAtOrigin', () => {
+  it('takes the target origin whole, including a port the value carried and the origin does not', () => {
+    // Self-hosted Logto is reached in-cluster on :3001 and answers discovery with that port; the
+    // browser-facing origin serves 443, and a surviving :3001 is a URL nothing answers on.
+    expect(urlAtOrigin('http://logto.internal:3001/oidc/auth', 'https://auth.example.test').toString()).toBe(
+      'https://auth.example.test/oidc/auth'
+    )
+    // The other direction still works: a target that names a port applies it.
+    expect(urlAtOrigin('https://auth.example.test/oidc', 'http://logto.internal:3001').toString()).toBe(
+      'http://logto.internal:3001/oidc'
+    )
+    // Neither side ported, and query/path survive.
+    expect(urlAtOrigin('https://a.example.test/oidc/auth?x=1', 'https://b.example.test').toString()).toBe(
+      'https://b.example.test/oidc/auth?x=1'
+    )
   })
 })


### PR DESCRIPTION
Sign-in through Setup ended in `ERR_CONNECTION_CLOSED` on a self-hosted Logto, with every other
part of the configuration correct — the browser was sent to `https://<public auth host>:3001/oidc/auth`.

Setup runs OIDC discovery through the **management** endpoint, deliberately, so the process needs
no public egress. Self-hosted Logto answers that request with URLs built from it:

```
http://logto.internal:3001/oidc/auth
```

which `urlAtOrigin` then re-hosts onto the public issuer origin before it reaches a browser. It did
that by assigning `protocol` and `host` — and the WHATWG `host` setter **leaves an existing port in
place when the assigned value names none**, so the port survived the move:

```js
const url = new URL('http://logto.internal:3001/oidc/auth')
url.protocol = 'https:'
url.host = 'auth.example.test'
url.toString() // https://auth.example.test:3001/oidc/auth
```

Nothing listens on that port at the public origin, so the authorization request dies at connect.

A hosted Logto tenant is reached at a port-less origin, so the rewrite has no port to keep and the
bug is invisible there — it only appears when the management endpoint is an in-cluster address with
an explicit port, which is the self-hosted shape.

Assigning `port` from the target as well makes the rewrite take the origin **whole**. The other
direction is unchanged and covered: rewriting the public issuer onto a management origin that names
a port still applies it, which is what the JWKS path depends on.

Test added beside the existing auth-boundary suite, asserting both directions and that path/query
survive.
