### PR TITLE
fix(console): spell the no-profile runtime fallback as the ACP registry does

### DIFF
--- a/packages/web/src/lib/acp-registry.test.ts
+++ b/packages/web/src/lib/acp-registry.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { GET } from '@/app/api/acp-registry/route'
 import { acpRuntime } from './acp-registry'
-import { runtimeLabel } from './data'
+import { FALLBACK_RUNTIME_IDS, runtimeLabel } from './data'
 
 describe('ACP Registry metadata', () => {
   afterEach(() => vi.unstubAllGlobals())
@@ -48,6 +48,19 @@ describe('ACP Registry metadata', () => {
     expect(response.status).toBe(200)
     const { agents } = (await response.json()) as { agents: Record<string, unknown> }
     expect(agents['kiro-cli']).toBeDefined()
+  })
+
+  // The alias table above is DISPLAY-only: it gives `claude`/`codex` a name and a mark, and
+  // nothing rewrites them on the way to a daemon. So the ids the picker offers when a daemon
+  // reports no profiles must be the registry's own — a bare `claude` looked right in the menu
+  // and then failed activation with `runtime "claude" is unavailable`.
+  it('offers only real registry ids as the no-profile fallback, never a display alias', () => {
+    const registry = {
+      'claude-acp': { name: 'Claude Agent', icon: null },
+      'codex-acp': { name: 'Codex', icon: null },
+      opencode: { name: 'OpenCode', icon: null }
+    }
+    for (const id of FALLBACK_RUNTIME_IDS) expect(registry[id as keyof typeof registry]).toBeDefined()
   })
 
   it('resolves legacy runtime ids and applies the product-name exception', () => {

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -536,8 +536,11 @@ export function agentSlugFinalize(v: string): string {
 }
 
 // Runtime ids offered when no daemon is selected (or it reports no profiles). When a
-// daemon IS selected, the ids come from its reported runtime profiles instead.
-export const FALLBACK_RUNTIME_IDS = ['claude', 'codex', 'opencode']
+// daemon IS selected, the ids come from its reported runtime profiles instead. Spelled as
+// the public ACP registry spells them — Claude and Codex carry its `-acp` suffix and
+// opencode does not — because a chosen id that no daemon reports is one the daemon rejects
+// at activation ("runtime is unavailable"), and nothing between here and there rewrites it.
+export const FALLBACK_RUNTIME_IDS = ['claude-acp', 'codex-acp', 'opencode']
 
 const REGISTRY_RUNTIME_NAME_OVERRIDES: Record<string, string> = {
   'Claude Agent': 'Claude Code'


### PR DESCRIPTION
## The bug

A daemon that reports no runtime profiles makes the console fall back to `FALLBACK_RUNTIME_IDS`, and those ids were `claude` / `codex` — **display aliases, not runtime ids**. Nothing rewrites them on the way to a daemon, so picking one created an agent whose runtime no daemon has, and activation refused it:

```
agent/activate: runtime "claude" is unavailable
```

Nothing looked wrong at the point of choice. `RUNTIME_ID_ALIASES` (`lib/acp-registry.ts:13`) resolves both bare ids to a registry name and mark, so the menu rendered "Claude Code" with its own icon. The mismatch surfaced later, and twice over:

- **an empty model picker** — `models` comes from `daemon.runtimeModels.find(r => r.runtime === effectiveRuntime)`, which can never match an id the daemon does not report, so Model went inert (`—`);
- **two identically-labelled entries** — once the probe landed, `EditAgentModal.tsx:463` prepended the stale `claude` beside the real `claude-acp`, and `runtimeLabel()` strips `-acp`, so both read "Claude Code".

## Why the window is wide

Worst on a cluster member. `declaredPoolCatalog()` (`daemon/src/daemon.ts:15452`) advertises **nothing** until the sandbox probe reports what the image provides — the runtime table lives in the runtime-sandbox image, not the daemon pod, and nothing mounts it:

```
runtimes: --k8s advertises none until the sandbox probe reports what the image provides
```

That lasts up to `K8S_PROBE_SWEEP_CEILING_MS` (90s + 180s + 8×60s ≈ 12.5 min). The image's ids are `claude-acp` / `codex-acp` / `dsh-acp` (`docker/runtime-sandbox/generate-runtime-table.mjs:20`), so a fallback spelled the registry's way now round-trips for Claude and Codex. Host daemons have the same shape with a much shorter window.

`opencode` keeps no suffix — that is the public ACP registry's own spelling for it, so a blanket `-acp` would have turned the one correct id into a broken one.

## Once the id matches, it works

Verified the rest of the path tolerates a probe-window creation:

- the activation model gate (`daemon.ts:14531`) **fails open** for an empty model, and for an offered list that is empty or not yet live — so the `model: ''` these agents carry is not rejected, and the runtime resolves its own default;
- permission / effort read the static tables through `runtimeLabel()`, which strips `-acp`, so the vocabularies are unchanged.

## No visual change

`claude-acp` → registry name "Claude Agent" → `REGISTRY_RUNTIME_NAME_OVERRIDES` → "Claude Code"; `codex-acp` → "Codex"; `opencode` → "OpenCode". Identical to before. The alias table stays as-is: an agent created by the old fallback still needs a name and a mark.

## Scope

This narrows the mismatch rather than closing it. A fallback list is still a guess about what one machine installed — the cluster image ships no `opencode`, and a host with only Codex installed still rejects `claude-acp`. Closing it means not guessing at all: an explicit "probing runtimes" empty state while a live daemon reports no profiles, plus the missing `(unavailable)` marker on a stale runtime in Edit. Left for a follow-up.

## Test

`acp-registry.test.ts` gains the invariant: every fallback id must hit a table of real registry ids **directly**, no alias hop. Confirmed it fails when the constant is reverted to `'claude'`.

- `pnpm --filter @agentconnect.md/web typecheck` — clean
- `pnpm --filter @agentconnect.md/web test` — 177 files / 1962 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)