### PR TITLE
fix(control-plane): read a restarted token counter as a reset, not a negative delta

### DIFF
--- a/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session-usage.repo.ts
@@ -110,7 +110,15 @@ function countersOf(row: Omit<SpendRow, 'visible'>): Counters {
   }
 }
 
+/** This interval's consumption. A LOWER token total at a LATER instant is a counter RESET,
+ *  not a correction: a runtime reporting live context occupancy as the session total shrinks
+ *  on compaction, and diffing through that made "Tokens 24h" negative — so on a reset the
+ *  whole of `current` is what the interval consumed. The token total alone decides and the
+ *  whole checkpoint resets with it, because cost DOES fall legitimately later (a late
+ *  `usage_update` replacing a fallback estimate with a smaller native price) without
+ *  lowering tokens — deciding per field would read every such correction as a reset. */
 function subtractCounters(current: Counters, previous: Counters): Counters {
+  if (current.totalTokens < previous.totalTokens) return current
   return {
     totalTokens: current.totalTokens - previous.totalTokens,
     inputTokens: current.inputTokens - previous.inputTokens,
@@ -521,9 +529,9 @@ export class PgSessionUsageRepo implements SessionUsageRepo {
 
     // Per-session running state, seeded from the pre-window checkpoint. `inRange` is
     // globally at-ascending, so each session's rows are visited chronologically —
-    // exactly what the running diff needs. A replay contributes 0 (nothing changed) and
-    // a downward correction contributes a negative delta that nets out, so the cards and
-    // the chart always show the same numbers.
+    // exactly what the running diff needs. A replay contributes 0, a downward cost
+    // correction a negative delta that nets out, a restarted token counter its whole
+    // checkpoint (`subtractCounters`) — cards and chart always show the same numbers.
     const SEP = '\0'
     const key = (row: Omit<SpendRow, 'visible'>) => row.agentId + SEP + row.sessionId + SEP + row.source
     const previous = new Map<string, Counters>(baselineRows.map((row) => [key(row), countersOf(row)]))

--- a/packages/control-plane/test/integration/usage.route.test.ts
+++ b/packages/control-plane/test/integration/usage.route.test.ts
@@ -545,6 +545,49 @@ describe('GET /usage — aggregates the persisted usage store by agent over a ra
     }
   })
 
+  it('reads a token counter that restarted as a reset, not as a negative delta', async () => {
+    await seedAgent(prisma, AGENT_A)
+    const repo = new PgSessionUsageRepo(prisma)
+    const min = (m: number) => new Date(Date.now() - m * 60_000)
+    await seedVisibleSession(AGENT_A, 'compacted', min(10))
+    // A runtime reporting live context occupancy as the session total: the third
+    // checkpoint is SMALLER than the second because the context was compacted. Shape and
+    // magnitudes taken from a real claude-acp session that made this column go negative.
+    for (const [m, totalTokens, cachedReadTokens, cost] of [
+      [40, 358828, 317889, '0.6389545'],
+      [30, 154615, 130954, '0.329797'],
+      [20, 124906, 121259, '0.1112345'],
+      [10, 126082, 122436, '0.1512345']
+    ] as const) {
+      await repo.record({
+        agentId: AgentId(AGENT_A),
+        sessionId: 'compacted',
+        source: 'daemon',
+        lastActivityAt: min(m),
+        usage: { totalTokens, cachedReadTokens, costAmount: cost, costCurrency: 'USD' }
+      })
+    }
+
+    const { app, close } = buildHttpApp(prisma)
+    try {
+      const res = await app.inject({ method: 'GET', url: `${ORG}/usage?${preset('d1')}` })
+      const body = res.json() as {
+        totals: { totalTokens: number; costAmount: string }
+        agents: { agentId: string; totalTokens: number; cachedReadTokens: number }[]
+      }
+      // Each restart contributes its whole checkpoint, the one advance contributes its
+      // diff: 358828 + 154615 + 124906 + (126082 − 124906).
+      expect(body.totals.totalTokens).toBe(358828 + 154615 + 124906 + 1176)
+      const agent = body.agents.find((a) => a.agentId === AGENT_A)!
+      expect(agent.totalTokens).toBe(body.totals.totalTokens)
+      expect(agent.cachedReadTokens).toBe(317889 + 130954 + 121259 + 1177)
+      // Cost resets with the token total it belongs to, so it cannot go negative either.
+      expect(body.totals.costAmount).toBe('1.119986')
+    } finally {
+      await close()
+    }
+  })
+
   it('serves an amount at the column’s full precision without rounding a digit', async () => {
     await seedAgent(prisma, AGENT_A)
     const repo = new PgSessionUsageRepo(prisma)


### PR DESCRIPTION
## What went wrong

The Agents table's **Tokens 24h** column served negative numbers. On test, one agent read:

```json
{ "sessions": 3, "totalTokens": -182828, "inputTokens": -14,
  "cachedReadTokens": -146851, "cachedWriteTokens": -32328, "costAmount": "0.1664754999999999" }
```

Not an aggregation bug — the stored data moves backwards. That agent's `session_spend`
checkpoints, from the test database:

| sessionId | at | cumulativeTotalTokens |
| --- | --- | --- |
| `2a06800e…` | 2026-08-23 06:38:14 | 358828 |
| `2a06800e…` | 2026-08-23 09:52:00 | 154615 |
| `2a06800e…` | 2026-08-23 09:56:50 | 124906 |
| `a9553dfb…` | 2026-08-23 12:44:13 | 260592 |
| `a9553dfb…` | 2026-08-23 13:06:03 | 162300 |
| `a9553dfb…` | 2026-08-23 13:07:21 | 48953 |

The window whose baseline is `358828` reproduces every field of that response exactly:
`2a06800e` contributes `124906 − 358828 = −233922` and `a9553dfb` contributes `+51094`,
summing to `−182828`, `−14`, `−146851`, `−32328`, `0.1664755`.

Three things compose into it:

1. **The daemon stores a gauge as a counter.** Non-codex runtimes fold turn-end usage
   through `setTokenUsage` (latest-wins), and claude-acp's `PromptResponse.usage` is the
   live context occupancy — it SHRINKS after a compaction. `cachedRead` 317889 → 121259
   and `cachedWrite` 36203 → 2698 are that shape.
2. **The write fence does not cover it.** `advancesSql` sits in `ON CONFLICT (agentId,
   sessionId, at) DO UPDATE … WHERE`, so it only stops a replay or a straggler at the
   *same* instant. A new `at` carrying lower counters inserts freely, and
   `countCheckpointRegression` never fires for it.
3. **The read side diffs straight through.** `subtractCounters` had no reset handling.

Not isolated — regressing consecutive checkpoint pairs across the test database:
claude-acp 130/1568, codex-acp 98/4230, dsh-acp 14/74, opencode 1/5.

## The fix

`subtractCounters` treats a lower token total as a counter reset and counts the whole of
`current` as the interval's consumption (Prometheus' rule).

**The token total alone decides, and the whole checkpoint resets with it.** Cost falls
legitimately at a later instant — the `late = true` report path replaces a fallback
estimate with a smaller native price — and that correction must keep netting out. Such a
report never lowers the token total, so it stays on the subtracting path; deciding per
field would misread every one of those corrections as a reset. The existing
`nets a downward correction against a later increase` test pins that and still passes.

## Known cost of this shape

A gauge reported as a counter cannot be recovered on the read side. For the session
above, 24h goes from `−182828` to `+753507` — the pre-compaction context is counted once
per compaction. Over-counting is the deliberate choice: for a *genuine* reset (a session
id reused, a runtime restart) counting `current` is correct, whereas clamping to 0 is
never correct for one. Metering the two quantities separately in the daemon — keeping
claude-acp's context occupancy out of `setTokenUsage` — is the actual fix, and is not in
this PR.

## Verification

New integration case `reads a token counter that restarted as a reset, not as a negative
delta`, with the magnitudes taken from the real session above.

- `test/integration/usage.route.test.ts` 22/22, plus `usage-report-ingress` and
  `usage-service-read` — 48/48
- `test:unit` 2041/2041, `typecheck`, eslint, prettier clean

Draft: not for merge yet.
