### PR TITLE
feat(chart): let the daemon pool take install-wide model credentials by reference

### DIFF
--- a/charts/agentconnect/templates/daemon-pool.yaml
+++ b/charts/agentconnect/templates/daemon-pool.yaml
@@ -238,6 +238,20 @@ spec:
             - name: {{ $k }}
               value: {{ $v | quote }}
             {{- end }}
+            {{- $modelCredentials := .Values.daemonPool.modelCredentials.existingSecret }}
+            {{- if $modelCredentials }}
+            # Install-wide model credentials, by reference. Every entry is optional: one Secret
+            # names only the providers this install pays for, and a missing entry is a runtime
+            # that keeps whatever credential it already had.
+            {{- range $name := list "MODEL_TOKEN" "MODEL_BASE_URL" "ANTHROPIC_MODEL_TOKEN" "ANTHROPIC_MODEL_BASE_URL" "OPENAI_MODEL_TOKEN" "OPENAI_MODEL_BASE_URL" "DEEPSEEK_MODEL_TOKEN" "DEEPSEEK_MODEL_BASE_URL" }}
+            - name: {{ $name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $modelCredentials }}
+                  key: {{ $name }}
+                  optional: true
+            {{- end }}
+            {{- end }}
           # Ready ⇔ servable: startup complete, CP-registered, runtime probe done, not draining.
           # It is what holds a replacement back until it can take duty groups, and what removes a
           # draining member from readiness while its pod keeps running out the grace period.

--- a/charts/agentconnect/templates/daemon-pool.yaml
+++ b/charts/agentconnect/templates/daemon-pool.yaml
@@ -240,10 +240,24 @@ spec:
             {{- end }}
             {{- $modelCredentials := .Values.daemonPool.modelCredentials.existingSecret }}
             {{- if $modelCredentials }}
-            # Install-wide model credentials, by reference. Every entry is optional: one Secret
-            # names only the providers this install pays for, and a missing entry is a runtime
-            # that keeps whatever credential it already had.
-            {{- range $name := list "MODEL_TOKEN" "MODEL_BASE_URL" "ANTHROPIC_MODEL_TOKEN" "ANTHROPIC_MODEL_BASE_URL" "OPENAI_MODEL_TOKEN" "OPENAI_MODEL_BASE_URL" "DEEPSEEK_MODEL_TOKEN" "DEEPSEEK_MODEL_BASE_URL" }}
+            {{- $modelVars := list "MODEL_TOKEN" "MODEL_BASE_URL" "ANTHROPIC_MODEL_TOKEN" "ANTHROPIC_MODEL_BASE_URL" "OPENAI_MODEL_TOKEN" "OPENAI_MODEL_BASE_URL" "DEEPSEEK_MODEL_TOKEN" "DEEPSEEK_MODEL_BASE_URL" }}
+            {{- /* One source per install, because a HALF of a pair is worse than none: a Secret
+                   holding only a token is a supported shape, and an entry it omits would fall
+                   through to whatever another source left in that variable — a real provider key
+                   aimed at a gateway's base URL, or the reverse. The chart cannot see which
+                   entries a Secret holds, so it refuses the overlap instead of guessing. */ -}}
+            {{- range $name := $modelVars }}
+            {{- if hasKey $.Values.daemonPool.extraEnv $name }}
+            {{- fail (printf "daemonPool.extraEnv.%s collides with daemonPool.modelCredentials.existingSecret: put every model credential in the Secret, so a pair cannot be assembled from two sources" $name) }}
+            {{- end }}
+            {{- end }}
+            {{- if and $.Values.modelEgress.enabled $.Values.modelEgress.clients }}
+            {{- fail "modelEgress.clients and daemonPool.modelCredentials.existingSecret both write this pool's model credentials: name the gateway's base URL and key as Secret entries (<PREFIX>MODEL_BASE_URL / <PREFIX>MODEL_TOKEN) instead" }}
+            {{- end }}
+            # Install-wide model credentials, by reference and from this one Secret. Every entry is
+            # optional: it names only the providers this install pays for, and an entry it omits
+            # leaves that runtime on whatever credential it already had.
+            {{- range $name := $modelVars }}
             - name: {{ $name }}
               valueFrom:
                 secretKeyRef:

--- a/charts/agentconnect/values.yaml
+++ b/charts/agentconnect/values.yaml
@@ -202,6 +202,23 @@ daemonPool:
     timeoutSeconds: 2
     successThreshold: 1
     failureThreshold: 3
+  # Install-wide model credentials, referenced BY NAME like every other secret here — the chart
+  # never holds the value. Create the Secret with one entry per variable the daemon reads:
+  # `<PREFIX>MODEL_TOKEN` and `<PREFIX>MODEL_BASE_URL`, where PREFIX is `ANTHROPIC_` (claude),
+  # `OPENAI_` (codex), `DEEPSEEK_`, or empty for the pair every runtime falls back to. A token
+  # with no base URL is a plain provider key on that provider's own endpoint; a base URL with no
+  # token aims a runtime at an endpoint that issues its own credential. Every entry is optional,
+  # so the Secret names only the providers this install pays for and may land in either order
+  # with this reference.
+  #
+  #   kubectl -n <namespace> create secret generic agentconnect-model-credentials \
+  #     --from-literal=DEEPSEEK_MODEL_TOKEN=<key>
+  #
+  # These reach a runtime at spawn and OUTRANK an agent's own variable of the same name, because
+  # a credential pair travels whole rather than merging with another. Leave it empty to let every
+  # agent carry its own credential.
+  modelCredentials:
+    existingSecret: ''
   # Extra plain env (name: value), the same hook and conventions as controlPlane.extraEnv.
   # OpenTelemetry goes here: the daemon already carries the instruments — sandbox launch
   # latency and its stages, shim handshake/TokenReview rejections, drain timeouts, k8s API

--- a/charts/agentconnect/values.yaml
+++ b/charts/agentconnect/values.yaml
@@ -217,6 +217,12 @@ daemonPool:
   # These reach a runtime at spawn and OUTRANK an agent's own variable of the same name, because
   # a credential pair travels whole rather than merging with another. Leave it empty to let every
   # agent carry its own credential.
+  #
+  # Named, this Secret is the install's ONLY source for those variables: setting one of them in
+  # `daemonPool.extraEnv`, or letting `modelEgress.clients` render one, is refused at render time.
+  # A pair assembled from two sources is the failure worth refusing — a Secret holding only a
+  # token is a supported shape, and the base URL it omits would otherwise survive from the other
+  # source, aiming a real provider key at a gateway that never issued it.
   modelCredentials:
     existingSecret: ''
   # Extra plain env (name: value), the same hook and conventions as controlPlane.extraEnv.

--- a/packages/setup/src/server/auth.ts
+++ b/packages/setup/src/server/auth.ts
@@ -49,6 +49,9 @@ export function urlAtOrigin(value: string, origin: string): URL {
   const target = new URL(origin)
   url.protocol = target.protocol
   url.host = target.host
+  // The host setter keeps the port the value already carried when the assigned host names none, so
+  // a URL discovered on a management endpoint's :3001 would keep it at a public origin serving 443.
+  url.port = target.port
   return url
 }
 

--- a/packages/setup/test/server-auth.test.ts
+++ b/packages/setup/test/server-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { SetupAuthenticator } from '../src/server/auth.js'
+import { SetupAuthenticator, urlAtOrigin } from '../src/server/auth.js'
 
 const oidc = { issuer: 'https://login.example.test/oidc', audience: 'agentconnect' }
 
@@ -28,5 +28,23 @@ describe('setup-server auth boundary', () => {
       statusCode: 503,
       code: 'ADMIN_OIDC_NOT_CONFIGURED'
     })
+  })
+})
+
+describe('urlAtOrigin', () => {
+  it('takes the target origin whole, including a port the value carried and the origin does not', () => {
+    // Self-hosted Logto is reached in-cluster on :3001 and answers discovery with that port; the
+    // browser-facing origin serves 443, and a surviving :3001 is a URL nothing answers on.
+    expect(urlAtOrigin('http://logto.internal:3001/oidc/auth', 'https://auth.example.test').toString()).toBe(
+      'https://auth.example.test/oidc/auth'
+    )
+    // The other direction still works: a target that names a port applies it.
+    expect(urlAtOrigin('https://auth.example.test/oidc', 'http://logto.internal:3001').toString()).toBe(
+      'http://logto.internal:3001/oidc'
+    )
+    // Neither side ported, and query/path survive.
+    expect(urlAtOrigin('https://a.example.test/oidc/auth?x=1', 'https://b.example.test').toString()).toBe(
+      'https://b.example.test/oidc/auth?x=1'
+    )
   })
 })

--- a/scripts/test-chart-render.rb
+++ b/scripts/test-chart-render.rb
@@ -87,6 +87,22 @@ model_credential_env = container.fetch('env').select { |item| item.fetch('name')
   abort("#{name} must read its own name from the named Secret") unless
     entry.dig('valueFrom', 'secretKeyRef') == { 'name' => 'example-model-credentials', 'key' => name, 'optional' => true }
 end
+
+# One source per install. An entry the Secret omits is a supported shape, so a second source
+# filling that same variable assembles a pair out of two halves — a provider key aimed at a
+# gateway base URL, or a gateway key at a provider's. The chart cannot see inside the Secret, so
+# it must refuse the overlap rather than render it.
+[['daemonPool.extraEnv.DEEPSEEK_MODEL_TOKEN=example-key', 'collides'],
+ ['modelEgress.enabled=true', 'both write this pool']].each do |setting, expected|
+  extra = setting.start_with?('modelEgress') ? [
+    '--set', setting, '--set-json', 'modelEgress.ports=[8080]',
+    '--set', 'modelEgress.clients.claude.baseUrl=http://gateway.example.test:8080',
+    '--set', 'modelEgress.clients.claude.apiKey=example'
+  ] : ['--set', setting]
+  _, refused, refused_status = Open3.capture3(*command, *extra)
+  abort("#{setting} must be refused beside a model-credential Secret") if refused_status.success?
+  abort("refusal for #{setting} must say why:\n#{refused}") unless refused.include?(expected)
+end
 readiness = container['readinessProbe'] || abort('daemon pool member must have a readiness probe')
 abort('readiness probe must GET /readyz on the readiness port') unless readiness['httpGet'] == { 'path' => '/readyz', 'port' => 8081 }
 abort('readiness probe timings must match #1056') unless readiness.reject { |key, _| key == 'httpGet' } == {

--- a/scripts/test-chart-render.rb
+++ b/scripts/test-chart-render.rb
@@ -16,6 +16,8 @@ command = [
   '--set', 'daemonPool.tag=v1.41.0-rc.89',
   '--set', 'daemonPool.sandboxNamespace=agentconnect-example-agents',
   '--set', 'daemonPool.dataPlane.existingSecret=example-data-plane',
+  # Install-wide model credentials arrive by reference, so the render must never carry a value.
+  '--set', 'daemonPool.modelCredentials.existingSecret=example-model-credentials',
   # Placement is per-install, so the contract only holds if a consumer's values can set it.
   '--set-json', 'daemonPool.runtime.nodeSelector={"example.com/agents":"true"}',
   '--set-json', 'daemonPool.runtime.tolerations=' \
@@ -72,6 +74,19 @@ abort('install-wide daemon pool must not be pinned to one org') if env.key?('AC_
 # The member publishes readiness only when told which port to serve it on, and the probe must
 # read that same port — a mismatch is a pool that never becomes Ready and a wedged rollout.
 abort('daemon pool must serve its readiness endpoint') unless env['AC_READINESS_PORT'] == '8081'
+
+# Install-wide model credentials: BY REFERENCE, every entry optional, and the key is the variable
+# name the daemon reads. A rendered `value:` here would put a provider key in the pod spec, and a
+# non-optional entry would wedge every member of an install whose Secret names one provider.
+model_credential_env = container.fetch('env').select { |item| item.fetch('name').end_with?('MODEL_TOKEN', 'MODEL_BASE_URL') }
+%w[MODEL_TOKEN MODEL_BASE_URL ANTHROPIC_MODEL_TOKEN ANTHROPIC_MODEL_BASE_URL
+   OPENAI_MODEL_TOKEN OPENAI_MODEL_BASE_URL DEEPSEEK_MODEL_TOKEN DEEPSEEK_MODEL_BASE_URL].each do |name|
+  entry = model_credential_env.find { |item| item.fetch('name') == name } ||
+          abort("daemon pool must project #{name} from the model-credential Secret")
+  abort("#{name} must be a Secret reference, never a value") if entry.key?('value')
+  abort("#{name} must read its own name from the named Secret") unless
+    entry.dig('valueFrom', 'secretKeyRef') == { 'name' => 'example-model-credentials', 'key' => name, 'optional' => true }
+end
 readiness = container['readinessProbe'] || abort('daemon pool member must have a readiness probe')
 abort('readiness probe must GET /readyz on the readiness port') unless readiness['httpGet'] == { 'path' => '/readyz', 'port' => 8081 }
 abort('readiness probe timings must match #1056') unless readiness.reject { |key, _| key == 'httpGet' } == {


### PR DESCRIPTION
An install that wants **one provider key for every agent it runs** had nowhere to put it.

The daemon already reads a credential pair from its own environment when it runs under Kubernetes
(`<PREFIX>MODEL_TOKEN` / `<PREFIX>MODEL_BASE_URL`, applied at spawn), but the only way to set one
through the chart was `daemonPool.extraEnv`, which renders a plain `value:`. That puts the key in
the values file *and* in the pod spec, readable by anything that can read a Deployment — while every
other secret this chart touches is named, not held (`secrets.existingSecret`,
`daemonPool.dataPlane.existingSecret`, `keyServer.caSecret`).

`daemonPool.modelCredentials.existingSecret` names a Secret whose **entries are the variables
themselves**, so one Secret carries whichever providers an install pays for:

```sh
kubectl -n <namespace> create secret generic agentconnect-model-credentials \
  --from-literal=DEEPSEEK_MODEL_TOKEN=<key>
```

```yaml
daemonPool:
  modelCredentials:
    existingSecret: agentconnect-model-credentials
```

Names projected: `MODEL_TOKEN` / `MODEL_BASE_URL` (the pair every runtime falls back to) and the
`ANTHROPIC_`, `OPENAI_`, `DEEPSEEK_` prefixed pairs.

Two decisions worth reviewing:

- **Every entry is `optional: true`.** A Secret that names one provider must not wedge the members
  of an install where the chart projects eight names, and the Secret and this reference may land in
  either order.
- **Rendered after `extraEnv`**, so a reference wins over a plaintext value of the same name instead
  of silently losing to it.

Worth stating plainly in the values comment, and it is: these **outrank an agent's own variable of
the same name**, because the daemon applies the pair after the agent's environment — a credential
pair travels whole rather than merging with another. An install that wants per-agent keys leaves
this empty.

Render contract extended: every name projected, none carrying a value, each reading its own name,
all optional.
