### PR TITLE
feat(console): connect GitLab where the project is picked, as GitHub installs

### DIFF
--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -411,14 +411,56 @@ export function GitlabProjectOption({
  *  account is connected, or the connected one administers nothing this
  *  organization may set up. */
 export function GitlabNoProjectsNotice({
-  integrationsHref,
   connected,
-  enabled = true
+  enabled = true,
+  onConnect,
+  onSync,
+  syncing = false
 }: {
-  integrationsHref: string
   connected: boolean
   enabled?: boolean
+  onConnect: () => void
+  onSync?: () => void
+  syncing?: boolean
 }) {
+  // Connecting belongs where the project is picked, exactly as installing the GitHub app does.
+  if (enabled && !connected) {
+    return (
+      <div className="rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px] desktop:col-span-2">
+        <div className="font-sans text-[13.5px] font-semibold leading-normal text-(--text-primary)">
+          Connect GitLab to watch projects
+        </div>
+        <div className="mt-[3px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+          Authorize AgentConnect on GitLab to subscribe this agent to issue and merge-request events. You pick the
+          project it watches here — you need Maintainer or Owner access to it.
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <Button size="sm" onClick={onConnect}>
+            <Icon name="external-link" size={13} />
+            Connect GitLab
+          </Button>
+          {onSync && (
+            <button
+              type="button"
+              className="lnk inline-flex items-center gap-[6px]"
+              onClick={onSync}
+              disabled={syncing}
+            >
+              <Icon
+                name={syncing ? 'loader' : 'refresh-cw'}
+                size={13}
+                className={syncing ? 'animate-spin' : undefined}
+              />
+              I&rsquo;ve connected it — sync
+            </button>
+          )}
+          <span className="font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+            Opens GitLab in a new tab
+          </span>
+        </div>
+      </div>
+    )
+  }
   return (
     <div className="flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">
       <span className="mt-[1px] flex h-[14px] w-[14px] flex-none items-center justify-center">
@@ -426,18 +468,10 @@ export function GitlabNoProjectsNotice({
       </span>
       {!enabled ? (
         <span>GitLab is not enabled on this deployment — no GitLab application is configured.</span>
-      ) : connected ? (
+      ) : (
         <span>
           The connected GitLab account has no project to offer. You need Maintainer or Owner access to a project before
           it can be set up here.
-        </span>
-      ) : (
-        <span>
-          No GitLab account is connected yet. Connect GitLab under{' '}
-          <a className="lnk font-medium" href={integrationsHref}>
-            Integrations
-          </a>
-          , then pick a project here.
         </span>
       )}
     </div>

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -1476,9 +1476,11 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                   </div>
                 ) : glNoProjects ? (
                   <GitlabNoProjectsNotice
-                    integrationsHref={orgPath('/integrations')}
                     connected={gl.connected}
                     enabled={gl.enabled}
+                    onConnect={() => void gl.connect()}
+                    onSync={gl.reload}
+                    syncing={gl.reloading}
                   />
                 ) : (
                   <div className="grid grid-cols-1 gap-[14px] desktop:col-span-2 desktop:grid-cols-2 desktop:gap-x-7">

--- a/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentRepoModal.tsx
@@ -415,9 +415,11 @@ export default function AddAgentRepoModal({
             ) : glNoProjects ? (
               <div className="mb-4">
                 <GitlabNoProjectsNotice
-                  integrationsHref={orgPath('/integrations')}
                   connected={gl.connected}
                   enabled={gl.enabled}
+                  onConnect={() => void gl.connect()}
+                  onSync={gl.reload}
+                  syncing={gl.reloading}
                 />
               </div>
             ) : (

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -27,8 +27,16 @@ const mocks = vi.hoisted(() => ({
   searchGitlabProjects: vi.fn(),
   createGitlabProject: vi.fn(),
   fetchAgentRepos: vi.fn(),
+  startGitlabOauth: vi.fn(),
   daemons: [] as unknown[]
 }))
+
+/** `window.open` is the connect flow's only visible effect — record it rather than navigate. */
+const opened: unknown[][] = []
+window.open = ((...args: unknown[]) => {
+  opened.push(args)
+  return null
+}) as typeof window.open
 
 vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
 vi.mock('@/lib/org-context', () => ({
@@ -58,7 +66,8 @@ vi.mock('@/lib/api', async (importOriginal) => ({
   fetchGitlabProjects: mocks.fetchGitlabProjects,
   fetchGitlabConnections: mocks.fetchGitlabConnections,
   searchGitlabProjects: mocks.searchGitlabProjects,
-  createGitlabProject: mocks.createGitlabProject
+  createGitlabProject: mocks.createGitlabProject,
+  startGitlabOauth: mocks.startGitlabOauth
 }))
 
 const AddIntegrationModal = (await import('./AddIntegrationModal')).default
@@ -158,6 +167,8 @@ afterEach(async () => {
   mocks.searchGitlabProjects.mockReset()
   mocks.createGitlabProject.mockReset()
   mocks.fetchAgentRepos.mockReset()
+  mocks.startGitlabOauth.mockReset()
+  opened.length = 0
   mocks.daemons = []
 })
 
@@ -320,16 +331,35 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     expect(tileNamed('Discord')?.getAttribute('aria-disabled')).toBe('true')
   })
 
-  it('points at the connection surface when no GitLab account is connected', async () => {
+  it('connects GitLab in place instead of sending the user to another surface', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([])
+    mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [] })
+    mocks.startGitlabOauth.mockResolvedValue('https://gitlab.example.test/oauth/authorize?state=one-shot')
+    await render()
+    await act(async () => tileNamed('GitLab')?.click())
+
+    expect(document.querySelector('a[href="/acme/integrations"]')).toBeNull()
+    // Nothing to search through: an unusable connection never reaches the picker.
+    expect(mocks.searchGitlabProjects).not.toHaveBeenCalled()
+
+    await act(async () => clickText('Connect GitLab')?.click())
+    expect(mocks.startGitlabOauth).toHaveBeenCalled()
+    expect(opened).toEqual([['https://gitlab.example.test/oauth/authorize?state=one-shot', '_blank', 'noopener']])
+  })
+
+  it('re-reads the picker when the user reports having connected', async () => {
     mocks.fetchGitlabProjects.mockResolvedValue([])
     mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [] })
     await render()
     await act(async () => tileNamed('GitLab')?.click())
+    expect(mocks.fetchGitlabConnections).toHaveBeenCalledTimes(1)
 
-    expect(document.body.textContent).toContain('No GitLab account is connected yet')
-    expect(document.querySelector('a[href="/acme/integrations"]')).not.toBeNull()
-    // Nothing to search through: an unusable connection never reaches the picker.
-    expect(mocks.searchGitlabProjects).not.toHaveBeenCalled()
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [connection] })
+    await act(async () => clickText('I’ve connected it — sync')?.click())
+
+    expect(mocks.fetchGitlabConnections).toHaveBeenCalledTimes(2)
+    expect(document.body.textContent).not.toContain('Connect GitLab to watch projects')
   })
 
   it('sets up a project the organization has not added, then picks it', async () => {

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -1667,9 +1667,11 @@ export default function AddIntegrationModal({
             ) : gl.empty ? (
               <div className="mb-4">
                 <GitlabNoProjectsNotice
-                  integrationsHref={orgPath('/integrations')}
                   connected={gl.connected}
                   enabled={gl.enabled}
+                  onConnect={() => void gl.connect()}
+                  onSync={gl.reload}
+                  syncing={gl.reloading}
                 />
               </div>
             ) : (

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.gitlab.test.tsx
@@ -173,14 +173,14 @@ describe('EditWorkspaceModal, GitLab workspace', () => {
     })
   })
 
-  it('points at the connection surface when no GitLab account is connected', async () => {
+  it('offers the connect action in place when no GitLab account is connected', async () => {
     mocks.fetchGitlabProjects.mockResolvedValue([])
     mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [] })
     await render()
     await act(async () => buttonsNamed('From GitLab')[0]?.click())
 
-    expect(document.body.textContent).toContain('No GitLab account is connected yet')
-    expect(document.querySelector('a[href="/acme/integrations"]')).not.toBeNull()
+    expect(buttonsNamed('Connect GitLab').length).toBe(1)
+    expect(document.querySelector('a[href="/acme/integrations"]')).toBeNull()
     expect(mocks.searchGitlabProjects).not.toHaveBeenCalled()
   })
 

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -506,9 +506,11 @@ export default function EditWorkspaceModal({
                 </div>
               ) : noProjects ? (
                 <GitlabNoProjectsNotice
-                  integrationsHref={orgPath('/integrations')}
                   connected={gl.connected}
                   enabled={gl.enabled}
+                  onConnect={() => void gl.connect()}
+                  onSync={gl.reload}
+                  syncing={gl.reloading}
                 />
               ) : (
                 <>

--- a/packages/web/src/lib/use-gitlab-projects.ts
+++ b/packages/web/src/lib/use-gitlab-projects.ts
@@ -19,6 +19,7 @@ import {
   fetchGitlabConnections,
   fetchGitlabProjects,
   searchGitlabProjects,
+  startGitlabOauth,
   type GitlabProjectBindingDto,
   type GitlabProjectDto
 } from './api'
@@ -53,6 +54,14 @@ export interface GitlabProjectPicker {
   error: string | null
   /** A connection that can still talk to GitLab exists. */
   connected: boolean
+  /** Authorize a GitLab account in a new tab. The grant lands on the connection,
+   *  so the picker learns about it through `reload`, not through this call. */
+  connect: () => Promise<void>
+  /** Re-read the added projects and the connections — what a caller offers after
+   *  sending someone off to connect. */
+  reload: () => void
+  /** A `reload` is in flight. */
+  reloading: boolean
   /** Project id whose setup saga is running right now. */
   provisioning: string | null
   /** The last failed setup, in GitLab words. */
@@ -70,6 +79,8 @@ export function useGitlabProjects(active: boolean, query: string): GitlabProject
   const [error, setError] = useState<string | null>(null)
   const [provisioning, setProvisioning] = useState<string | null>(null)
   const [provisionError, setProvisionError] = useState<string | null>(null)
+  const [reloadToken, setReloadToken] = useState(0)
+  const [reloading, setReloading] = useState(false)
   const busy = useRef(false)
 
   // One request per active lifecycle, and no one-shot guard: the guard would
@@ -87,17 +98,19 @@ export function useGitlabProjects(active: boolean, query: string): GitlabProject
         setBindings(bound)
         // Only a connection GitLab still accepts can add a project (§10.1).
         setConnectionId(connections.find((c) => c.state === 'connected')?.id ?? null)
+        setReloading(false)
       },
       (e) => {
         if (!alive) return
         setBindings([])
         setError(errorText(e))
+        setReloading(false)
       }
     )
     return () => {
       alive = false
     }
-  }, [active])
+  }, [active, reloadToken])
 
   // Candidates are searched on GitLab, so keystrokes settle through a debounce.
   // A failed search leaves the added projects pickable rather than emptying the list.
@@ -139,6 +152,22 @@ export function useGitlabProjects(active: boolean, query: string): GitlabProject
     [connectionId]
   )
 
+  // The authorization URL carries a one-shot state, so it is minted per click.
+  const connect = useCallback(async (): Promise<void> => {
+    setError(null)
+    try {
+      const url = await startGitlabOauth(typeof window === 'undefined' ? undefined : window.location.pathname)
+      window.open(url, '_blank', 'noopener')
+    } catch (e) {
+      setError(errorText(e))
+    }
+  }, [])
+
+  const reload = useCallback((): void => {
+    setReloading(true)
+    setReloadToken((token) => token + 1)
+  }, [])
+
   const choices = useMemo(() => mergeGitlabProjectChoices(bindings ?? [], candidates), [bindings, candidates])
 
   // Sticky: once the picker has offered something, a search that matches nothing
@@ -156,6 +185,9 @@ export function useGitlabProjects(active: boolean, query: string): GitlabProject
     empty: !loading && !everOffered && choices.length === 0,
     error,
     connected: connectionId !== null,
+    connect,
+    reload,
+    reloading,
     provisioning,
     provisionError,
     provision


### PR DESCRIPTION
## Summary

The GitLab arm of the Add-integration wizard said *"No GitLab account is connected yet. Connect GitLab under **Integrations**, then pick a project here"* — sending the user away mid-flow. The GitHub arm of the very same modal offers **Install GitHub app** plus **I've installed it — sync** in place. GitLab now matches.

**Before:** a link out to another page, and the user has to find their way back.
**After:** `Connect GitLab` opens the authorization in a new tab, `I've connected it — sync` re-reads the picker, and the same "opens in a new tab" hint GitHub carries.

## Where it lives

`useGitlabProjects` owns both actions, since it already owns the connection read:

- `connect()` — mints the authorize URL per click (the state is one-shot, so it cannot be cached) and opens it in a new tab.
- `reload()` / `reloading` — re-runs the added-projects and connections reads, which is what the sync link drives.

`GitlabNoProjectsNotice` renders the prompt shape for the not-connected case; its other two branches — *no project to offer* and *GitLab is not enabled on this deployment* — are unchanged, because neither is fixed by connecting another account.

All four forms that show the notice get the action: add integration, add agent, add repository, edit workspace. That is the same set where the GitHub install already sits in the same position, so the parity is uniform rather than one-modal-deep.

## Tests

- `AddIntegrationModal.gitlab.test.tsx` gains two cases: clicking `Connect GitLab` mints and opens the authorize URL and no link to the Integrations page remains; and the sync link re-reads, after which the prompt is gone.
- `EditWorkspaceModal.gitlab.test.tsx`'s existing case now asserts the in-place action instead of the link-out.
- Web suite 1966 passing, `pnpm typecheck`, `pnpm lint`, prettier all green.

Not verified in a running console: the dev server 500s on every route in this tree on a Turbopack module-resolution failure inside `packages/protocol` that predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
