### PR TITLE
feat(web): attach MCP servers and skills from the agent page

### DIFF
--- a/packages/web/src/components/console/AgentSkillsCard.test.tsx
+++ b/packages/web/src/components/console/AgentSkillsCard.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  // The org registry the caller can see.
+  skillSources: [
+    { id: 's1', name: 'example-ai-kit', source: 'github.com/acme/ai-kit', subDir: null, visibility: 'org' },
+    { id: 's2', name: 'internal-runbooks', source: 'github.com/acme/runbooks', subDir: null, visibility: 'org' }
+  ] as unknown[],
+  managed: [
+    { id: 'm1', name: 'safe-deploy', currentRevision: 3, fileCount: 2, archivedAt: null, canManage: true }
+  ] as unknown[],
+  savedSkills: [] as string[],
+  savedManaged: [] as string[]
+}))
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    updateAgent: vi.fn(async () => undefined),
+    skillSources: mocks.skillSources,
+    skillSourcesLoading: false,
+    createSkillSource: vi.fn(),
+    members: []
+  })
+}))
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ activeOrg: { id: 'o1' } }) }))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: { id: 'u1' } }) }))
+vi.mock('@/lib/api', () => ({
+  fetchAgentDto: vi.fn(async () => ({ skills: mocks.savedSkills, managedSkills: mocks.savedManaged })),
+  fetchAgentSkillSources: vi.fn(async () => []),
+  fetchSkillSourceSkills: vi.fn(async () => ({ resolvable: true, skills: [] })),
+  listManagedSkills: vi.fn(async () => mocks.managed),
+  listManagedSkillRevisions: vi.fn(async () => []),
+  setManagedSkillArchived: vi.fn(async () => undefined),
+  searchSkillRegistry: vi.fn(async () => ({ reachable: true, skills: [] })),
+  fetchConnectorCatalog: vi.fn(async () => ({ providers: [] })),
+  memberDisplayName: (m: { id: string }) => m.id,
+  fmtDate: (d: unknown) => String(d),
+  repoLabel: (r: unknown) => String(r),
+  repoWebUrl: () => undefined
+}))
+vi.mock('@/components/marks', () => ({ GithubMark: () => null, LoadingState: () => null }))
+
+import { AgentSkillsCard } from './AgentSkillsCard'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let host: HTMLDivElement | undefined
+let root: Root | undefined
+
+async function render(): Promise<string> {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root!.render(<AgentSkillsCard agentId="a1" canEdit />)
+  })
+  return host.textContent ?? ''
+}
+
+/** Open the header's Add menu — it portals to the body, so what it offers is
+ *  never in the card's own subtree. */
+async function openAddMenu(): Promise<string> {
+  const trigger = [...document.querySelectorAll('button')].find((b) => b.textContent?.includes('Add'))
+  expect(trigger).toBeTruthy()
+  await act(async () => {
+    trigger!.click()
+  })
+  return document.querySelector('[data-anchored-flyout]')?.textContent ?? ''
+}
+
+afterEach(() => {
+  act(() => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  mocks.savedSkills = []
+  mocks.savedManaged = []
+})
+
+describe('AgentSkillsCard', () => {
+  it('shows the empty state and offers both libraries when nothing is enabled', async () => {
+    expect(await render()).toContain('No skills')
+    const menu = await openAddMenu()
+    expect(menu).toContain('Managed skills')
+    expect(menu).toContain('safe-deploy')
+    expect(menu).toContain('Git skill sources')
+    expect(menu).toContain('example-ai-kit')
+    // The quick-add items that open the library's own dialogs.
+    expect(menu).toContain('Search skills.sh')
+    expect(menu).toContain('Add custom skill source')
+  })
+
+  // The rows ARE the saved refs, so an enabled source leaves the Add menu.
+  it('rows the enabled source and drops it from the Add menu', async () => {
+    mocks.savedSkills = ['example-ai-kit/*']
+    const text = await render()
+    expect(text).toContain('example-ai-kit')
+    expect(text).toContain('all skills')
+    expect(text).not.toContain('internal-runbooks')
+    const menu = await openAddMenu()
+    expect(menu).toContain('internal-runbooks')
+    expect(menu).not.toContain('example-ai-kit')
+  })
+
+  it('rows an enabled managed bundle with its pinned revision', async () => {
+    mocks.savedManaged = ['m1']
+    const text = await render()
+    expect(text).toContain('safe-deploy')
+    expect(text).toContain('rev 3')
+    expect(text).toContain('managed')
+    expect(await openAddMenu()).toContain('No further approved managed skills')
+  })
+
+  // A partial selection reads as a count, not as the whole source.
+  it('badges a picked subset with how many skills are selected', async () => {
+    mocks.savedSkills = ['internal-runbooks/safe-deploy']
+    const text = await render()
+    expect(text).toContain('internal-runbooks')
+    expect(text).toContain('1 selected')
+  })
+})

--- a/packages/web/src/components/console/AgentSkillsCard.tsx
+++ b/packages/web/src/components/console/AgentSkillsCard.tsx
@@ -124,7 +124,7 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
     if (managedEnabled === null || saving) return
     const prev = managedEnabled
     const activeIds = new Set((managedLibrary ?? []).filter((skill) => !skill.archivedAt).map((skill) => skill.id))
-    const valid = next.filter((id) => activeIds.has(id))
+    const valid = [...new Set(next)].filter((id) => activeIds.has(id))
     setManagedEnabled(valid)
     setSaving(true)
     setErr(null)

--- a/packages/web/src/components/console/AgentSkillsCard.tsx
+++ b/packages/web/src/components/console/AgentSkillsCard.tsx
@@ -6,30 +6,40 @@ import {
   fetchAgentSkillSources,
   fetchSkillSourceSkills,
   listManagedSkills,
+  repoLabel,
   type AgentSkillSourceDto,
   type ManagedSkillDto,
+  type SkillSourceDto,
   type SkillSourceSkillsDto
 } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
 import { MOCK_MODE } from '@/lib/data'
-import { SkillMark, SkillSourceLine, ToolTile, ToolTileGrid } from '@/components/console/ToolTile'
-import { VisibilityValue } from '@/components/console/VisibilityField'
+import { AttachedEmpty, AttachedNote, AttachedRow, AttachMenu } from '@/components/console/AttachedList'
+import { InstallRegistrySkillModal } from '@/components/console/InstallRegistrySkillModal'
+import { CreateSkillSourceModal } from '@/components/console/SkillSourcesCard'
+import { SkillMark, SkillSourceLine } from '@/components/console/ToolTile'
 import { Icon, Toggle } from '@/components/ui'
 
 /**
- * The agent's shared-skills enable-list (docs/designs/shared-skills.md). Lists the
- * org's visible skill sources; each can be enabled whole (`<source>/*`) or, when the
- * source's SKILL.md manifest is scannable, expanded to toggle individual skills
+ * The agent's shared-skills enable-list (docs/designs/shared-skills.md), rendered
+ * as the design's attached-roster: one row per skill this agent installs, with the
+ * header's Add menu offering the org's managed bundles and Git sources it hasn't
+ * attached yet. A Git source can be enabled whole (`<source>/*`) or, when its
+ * SKILL.md manifest is scannable, expanded to toggle individual skills
  * (`<source>/<skill>`). The agent stores the explicit ref list and the CP resolves
  * it into installable entries.
  *
- * The tiles are the org registry the caller can see, PLUS whatever this agent
- * already enables — `GET /agents/:id/skill-sources` resolves the agent's refs
- * regardless of the source's own sharing, so a source restricted away from the
- * caller still shows its name and repo rather than a bare, unexplained row. A ref
- * whose source is genuinely gone resolves to nothing and is not rendered: it
- * installs nothing (the CP resolver drops it) and there is nothing truthful to say
- * about it.
+ * The attached rows are the agent's own refs — `GET /agents/:id/skill-sources`
+ * resolves them regardless of the source's own sharing, so a source restricted away
+ * from the caller still shows its name and repo rather than a bare, unexplained row,
+ * and can be removed. A ref whose source is genuinely gone resolves to nothing and
+ * is not rendered: it installs nothing (the CP resolver drops it) and there is
+ * nothing truthful to say about it. Only sources the caller can SEE are offered in
+ * the Add menu — the CP rejects enabling an unseen one (`enablingUnseenSkillDenied`).
+ *
+ * The menu's quick-add items open the skills library's OWN dialogs
+ * (`InstallRegistrySkillModal`, `CreateSkillSourceModal`), and a source registered
+ * through either is enabled on this agent immediately.
  */
 
 const sourceOf = (ref: string) => (ref.includes('/') ? ref.slice(0, ref.indexOf('/')) : ref)
@@ -52,12 +62,14 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
   const [err, setErr] = useState<string | null>(null)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [manifests, setManifests] = useState<Record<string, SkillSourceSkillsDto | 'loading'>>({})
+  const [creating, setCreating] = useState(false)
+  const [browsing, setBrowsing] = useState(false)
   const fetched = useRef(false)
 
   useEffect(() => {
     if (fetched.current) return
     // Demo agents (canEdit false) have no spec to fetch — mock mode seeds a selection
-    // so both tile states (whole source vs a picked subset) are visible.
+    // so both row states (whole source vs a picked subset) are visible.
     if (!canEdit) {
       if (MOCK_MODE) {
         setEnabled(['example-ai-kit/*', 'internal-runbooks/safe-deploy'])
@@ -81,9 +93,9 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
         setErr(e instanceof Error ? e.message : String(e))
       }
     )
-    // Resolving the agent's own refs is best-effort decoration: it only ADDS tiles
+    // Resolving the agent's own refs is best-effort decoration: it only ADDS rows
     // for sources missing from the registry list, so a failure degrades to the
-    // registry view rather than blocking the toggles.
+    // registry view rather than blocking the card.
     if (canEdit) {
       fetchAgentSkillSources(agentId).then(
         (rows) => setOwn(rows),
@@ -101,7 +113,7 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
     try {
       await updateAgent(agentId, { skills: next })
     } catch (e) {
-      setEnabled(prev) // revert so the toggles never lie about what's saved
+      setEnabled(prev) // revert so the rows never lie about what's saved
       setErr(e instanceof Error ? e.message : String(e))
     } finally {
       setSaving(false)
@@ -148,6 +160,10 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
     void save([...base, ...[...set].map((s) => `${name}/${s}`)])
   }
 
+  // A source registered from this card is what the operator wanted on THIS agent,
+  // so it is enabled whole as soon as the library accepts it.
+  const enableCreated = (created: SkillSourceDto) => toggleSource(created.name, true)
+
   const expand = (id: string) => {
     setExpanded((cur) => {
       const next = new Set(cur)
@@ -165,14 +181,13 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
   }
 
   // Registry rows the caller can see, then the agent's own sources that sharing keeps
-  // out of that list. The second group is `registry: false` — the CP still gates
-  // ADDING a ref on seeing the source (`enablingUnseenSkillDenied`), so those tiles
-  // are off-only and offer no per-skill picker; they exist to say what the agent
-  // installs and to let it be turned off, like the MCP card's ineligible names.
-  const tiles = useMemo(() => {
+  // out of that list. The second group is `registry: false` — off-only, with no
+  // per-skill picker, because the CP gates ADDING a ref on seeing the source; they
+  // exist to say what the agent installs and to let it be removed.
+  const sources = useMemo(() => {
     const known = new Set(skillSources.map((s) => s.name))
     // `registry` is a literal so it discriminates the union: only the registry arm
-    // carries the sharing fields the footer reads.
+    // carries the fields the menu's repo hint reads.
     return [
       ...skillSources.map((s) => ({ ...s, registry: true as const })),
       ...(own ?? []).filter((s) => !known.has(s.name)).map((s) => ({ ...s, registry: false as const }))
@@ -180,162 +195,151 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
   }, [skillSources, own])
 
   // Nothing is known yet while either list is in flight; rendering the empty state
-  // then would claim the org has no sources when we simply haven't asked.
-  const loading = skillSourcesLoading || (canEdit && own === null)
-
+  // then would claim the agent has nothing when we simply haven't asked.
+  const loading = skillSourcesLoading || (canEdit && own === null) || managedLibrary === null || enabled === null
   const interactive = canEdit && enabled !== null && !saving
+
+  const library = managedLibrary ?? []
+  const managedIds = managedEnabled ?? []
+  const attachedManaged = library.filter((skill) => managedIds.includes(skill.id))
+  const attachedSources = sources.filter((s) => {
+    const sel = enabled ? selectionFor(enabled, s.name) : null
+    return !!sel && (sel.all || sel.skills.size > 0)
+  })
+  const empty = attachedManaged.length === 0 && attachedSources.length === 0
+
+  const menu = canEdit ? (
+    <AttachMenu
+      ariaLabel="Add a skill to this agent"
+      disabled={!interactive || managedEnabled === null}
+      groups={[
+        {
+          heading: 'Managed skills',
+          icon: 'package',
+          options: library
+            .filter((skill) => !skill.archivedAt && !managedIds.includes(skill.id))
+            .map((skill) => ({
+              key: skill.id,
+              name: skill.name,
+              meta: `rev ${skill.currentRevision}`,
+              onPick: () => void saveManaged([...managedIds, skill.id])
+            })),
+          emptyLabel: 'No further approved managed skills to add.'
+        },
+        {
+          heading: 'Git skill sources',
+          icon: 'book-open',
+          // Only registry sources are offerable — the CP rejects enabling a ref to a
+          // source this caller can't see.
+          options: sources
+            .filter((s) => s.registry && !attachedSources.some((a) => a.name === s.name))
+            .map((s) => ({
+              key: s.id,
+              name: s.name,
+              meta: repoLabel(s.source),
+              onPick: () => toggleSource(s.name, true)
+            })),
+          emptyLabel: 'Every source in your organization is already enabled.'
+        }
+      ]}
+      actions={[
+        { key: 'registry', label: 'Search skills.sh…', icon: 'search', onPick: () => setBrowsing(true) },
+        { key: 'custom', label: 'Add custom skill source…', icon: 'plus', onPick: () => setCreating(true) }
+      ]}
+    />
+  ) : undefined
 
   return (
     <div className="card overflow-hidden max-desktop:rounded-lg desktop:max-w-[760px]">
-      <div className="border-b border-(--border-subtle) px-4 py-3 font-sans text-[14px] font-semibold leading-normal desktop:py-[13px]">
-        Skills
+      <div className="cardhead flex-wrap gap-2">
+        <span className="cardtitle">Skills</span>
+        <span className="mono ml-auto text-[11px] text-(--text-tertiary)">managed bundles · Git sources</span>
+        {menu}
       </div>
 
-      <div className="border-b border-(--border-subtle)">
-        <div className="flex items-baseline justify-between px-4 pt-3 pb-2">
-          <span className="font-sans text-[12.5px] font-semibold text-(--text-secondary)">
-            Managed organization skills
-          </span>
-          <span className="font-sans text-[10.5px] text-(--text-tertiary)">owner-approved · pinned revision</span>
-        </div>
-        {managedLibrary === null || managedEnabled === null ? (
-          <div className="px-4 pb-3 font-sans text-[12px] text-(--text-tertiary)">Loading managed skills…</div>
-        ) : managedLibrary.length === 0 ? (
-          <div className="px-4 pb-3 font-sans text-[12px] text-(--text-tertiary)">
-            No approved managed skills are available yet.
-          </div>
-        ) : (
-          <ToolTileGrid columns={2}>
-            {managedLibrary.map((skill) => {
-              const checked = managedEnabled.includes(skill.id) && !skill.archivedAt
-              return (
-                <ToolTile
-                  key={skill.id}
-                  mark={<SkillMark />}
-                  name={skill.name}
-                  badge={
-                    <span
-                      className={`badge flex-none text-[9.5px] ${skill.archivedAt ? 'bg-(--surface-sunken) text-(--text-disabled)' : 'bg-(--status-online-soft) text-(--status-online)'}`}
-                    >
-                      {skill.archivedAt ? 'archived' : `rev ${skill.currentRevision}`}
-                    </span>
-                  }
-                  subtitle={skill.description}
-                  footer={
-                    <span className="mono text-[10.5px] text-(--text-disabled)">
-                      {skill.fileCount} file{skill.fileCount === 1 ? '' : 's'} · immutable bundle
-                    </span>
-                  }
-                  action={
-                    <Toggle
-                      checked={checked}
-                      disabled={!canEdit || saving || !!skill.archivedAt}
-                      onChange={(next) =>
-                        void saveManaged(
-                          next
-                            ? [...managedEnabled.filter((id) => id !== skill.id), skill.id]
-                            : managedEnabled.filter((id) => id !== skill.id)
-                        )
-                      }
-                    />
-                  }
-                />
-              )
-            })}
-          </ToolTileGrid>
-        )}
-      </div>
-
-      <div className="px-4 pt-3 pb-2 font-sans text-[12.5px] font-semibold text-(--text-secondary)">
-        Git skill sources
-      </div>
-
-      {tiles.length === 0 ? (
-        <div className="flex items-center gap-2 px-4 py-[13px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) desktop:py-3">
-          {loading ? (
-            'Loading skill sources…'
-          ) : (
-            <>
-              <Icon name="book-open" size={14} />
-              No skill sources in your organization yet.
-            </>
-          )}
-        </div>
+      {empty ? (
+        <AttachedEmpty
+          title={loading ? 'Loading skills…' : 'No skills'}
+          hint={
+            loading
+              ? 'Reading this agent’s enabled skills.'
+              : canEdit
+                ? 'Enable a managed bundle or a Git source from your organization, or register a new one.'
+                : 'This agent has no skills enabled.'
+          }
+          action={loading ? undefined : menu}
+        />
       ) : (
-        <ToolTileGrid columns={2}>
-          {tiles.map((s) => {
-            const sel = enabled ? selectionFor(enabled, s.name) : { all: false, skills: new Set<string>() }
-            const on = sel.all || sel.skills.size > 0
-            const manifest = manifests[s.id]
-            const isOpen = expanded.has(s.id)
-            return (
-              <ToolTile
-                key={s.id}
+        <>
+          <div>
+            {attachedManaged.map((skill) => (
+              <AttachedRow
+                key={skill.id}
                 mark={<SkillMark />}
-                name={s.name}
-                // What's selected rides as a badge so the second line can stay the repo,
-                // matching the registry card's tile.
+                name={skill.name}
+                meta={`rev ${skill.currentRevision} · ${skill.fileCount} file${skill.fileCount === 1 ? '' : 's'} · immutable bundle`}
+                dimmed={!!skill.archivedAt}
                 badge={
-                  on ? (
-                    <span className="badge flex-none bg-(--status-info-soft) text-[9.5px] text-(--status-info)">
+                  <span
+                    className={`badge flex-none ${skill.archivedAt ? 'bg-(--surface-sunken) text-(--text-disabled)' : 'bg-(--status-online-soft) text-(--status-online)'}`}
+                  >
+                    {skill.archivedAt ? 'archived' : 'managed'}
+                  </span>
+                }
+                onRemove={
+                  canEdit && !saving ? () => void saveManaged(managedIds.filter((id) => id !== skill.id)) : undefined
+                }
+                removeTitle="Remove from this agent"
+              />
+            ))}
+            {attachedSources.map((s) => {
+              const sel = enabled ? selectionFor(enabled, s.name) : { all: false, skills: new Set<string>() }
+              const manifest = manifests[s.id]
+              const isOpen = expanded.has(s.id)
+              return (
+                <AttachedRow
+                  key={s.id}
+                  mark={<SkillMark />}
+                  name={s.name}
+                  meta={<SkillSourceLine source={s.source} subDir={s.subDir} />}
+                  badge={
+                    <span className="badge flex-none bg-(--status-info-soft) text-(--status-info)">
                       {sel.all ? 'all skills' : `${sel.skills.size} selected`}
                     </span>
-                  ) : undefined
-                }
-                subtitle={<SkillSourceLine source={s.source} subDir={s.subDir} />}
-                // Who the source belongs to, worded exactly as its registry tile words it.
-                // Only the registry rows carry a share set — the agent-scoped resolution
-                // deliberately omits it (seeing an agent isn't seeing the source).
-                footer={
-                  s.registry ? <VisibilityValue visibility={s.visibility} sharedWith={s.sharedWith} /> : undefined
-                }
-                action={
-                  <>
-                    {/* Expanding is a secondary move, so the chevron only surfaces on
-                        hover/keyboard focus (and stays put once open). Its box is always
-                        reserved, so revealing it never shifts the toggle. Touch has no
-                        hover, so below the desktop breakpoint it stays visible. */}
-                    {s.registry && (
+                  }
+                  // Picking individual skills is a secondary move, so the chevron only
+                  // surfaces on hover/keyboard focus (and stays put once open). An
+                  // agent-scoped source has no picker: the CP would reject re-adding a
+                  // ref to a source this caller can't see.
+                  actions={
+                    s.registry ? (
                       <button
                         type="button"
-                        className={`iconbtn h-6 w-6 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 max-desktop:opacity-100 ${isOpen ? 'opacity-100' : 'opacity-0'}`}
+                        className="iconbtn h-[26px] w-[26px] flex-none"
                         onClick={() => expand(s.id)}
-                        aria-label="Show skills"
+                        aria-label="Choose individual skills"
                         aria-expanded={isOpen}
-                        title="Show skills"
+                        title="Choose individual skills"
                       >
                         <Icon name={isOpen ? 'chevron-down' : 'chevron-right'} size={13} />
                       </button>
-                    )}
-                    {/* No picker for an agent-scoped source, but keep its slot so the
-                        toggles line up with the registry tiles beside it. */}
-                    {!s.registry && <span className="block h-6 w-6" />}
-                    <span className="ml-[6px]">
-                      <Toggle
-                        checked={on}
-                        // Off-only for a non-registry source: the CP would reject
-                        // re-adding a ref to a source this caller can't see.
-                        disabled={!interactive || (!s.registry && !on)}
-                        onChange={(next) => toggleSource(s.name, next)}
-                      />
-                    </span>
-                  </>
-                }
-              >
-                {isOpen && s.registry && (
-                  <div className="border-t border-(--border-subtle) bg-(--surface-sunken) px-[14px] py-2">
-                    {manifest === 'loading' || manifest === undefined ? (
-                      <div className="py-1 font-sans text-[12px] text-(--text-tertiary)">Loading skills…</div>
-                    ) : !manifest.resolvable || manifest.skills.length === 0 ? (
-                      <div className="py-1 font-sans text-[12px] leading-[1.5] text-(--text-tertiary)">
-                        {manifest.resolvable
-                          ? 'No SKILL.md found in this source.'
-                          : 'Can’t list individual skills for this source — enable the whole source above.'}
-                      </div>
-                    ) : (
-                      manifest.skills.map((sk) => {
-                        const checked = sel.all || sel.skills.has(sk.name)
-                        return (
+                    ) : undefined
+                  }
+                  onRemove={canEdit && !saving ? () => toggleSource(s.name, false) : undefined}
+                  removeTitle="Remove from this agent"
+                >
+                  {isOpen && s.registry && (
+                    <div className="border-t border-(--border-subtle) bg-(--surface-sunken) px-[14px] py-2">
+                      {manifest === 'loading' || manifest === undefined ? (
+                        <div className="py-1 font-sans text-[12px] text-(--text-tertiary)">Loading skills…</div>
+                      ) : !manifest.resolvable || manifest.skills.length === 0 ? (
+                        <div className="py-1 font-sans text-[12px] leading-[1.5] text-(--text-tertiary)">
+                          {manifest.resolvable
+                            ? 'No SKILL.md found in this source.'
+                            : 'Can’t list individual skills for this source — the whole source is enabled.'}
+                        </div>
+                      ) : (
+                        manifest.skills.map((sk) => (
                           <div key={sk.name} className="flex items-center gap-[11px] py-[7px]">
                             <div className="min-w-0 flex-1">
                               <div className="truncate font-mono text-[12px] font-medium leading-normal text-(--text-primary)">
@@ -346,7 +350,7 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
                               </div>
                             </div>
                             <Toggle
-                              checked={checked}
+                              checked={sel.all || sel.skills.has(sk.name)}
                               disabled={!interactive}
                               onChange={() =>
                                 toggleSkill(
@@ -357,20 +361,44 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
                               }
                             />
                           </div>
-                        )
-                      })
-                    )}
-                  </div>
-                )}
-              </ToolTile>
-            )
-          })}
-        </ToolTileGrid>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </AttachedRow>
+              )
+            })}
+          </div>
+          <AttachedNote>
+            Managed bundles install from their pinned revision; Git sources install with{' '}
+            <span className="mono text-[11.5px]">npx skills</span> on session start. Removing one stops installing it
+            for this agent.
+          </AttachedNote>
+        </>
       )}
 
       {err && (
         <div className="border-t border-(--border-subtle) px-4 py-[11px] font-sans text-[12px] font-normal leading-normal text-(--red-600)">
           {err}
+        </div>
+      )}
+
+      {browsing && (
+        <div className="scrim">
+          <div className="modal">
+            <InstallRegistrySkillModal
+              existing={skillSources}
+              onClose={() => setBrowsing(false)}
+              onCreated={enableCreated}
+            />
+          </div>
+        </div>
+      )}
+      {creating && (
+        <div className="scrim">
+          <div className="modal">
+            <CreateSkillSourceModal onClose={() => setCreating(false)} onCreated={enableCreated} />
+          </div>
         </div>
       )}
     </div>

--- a/packages/web/src/components/console/AgentSkillsCard.tsx
+++ b/packages/web/src/components/console/AgentSkillsCard.tsx
@@ -307,10 +307,8 @@ export function AgentSkillsCard({ agentId, canEdit }: { agentId: string; canEdit
                       {sel.all ? 'all skills' : `${sel.skills.size} selected`}
                     </span>
                   }
-                  // Picking individual skills is a secondary move, so the chevron only
-                  // surfaces on hover/keyboard focus (and stays put once open). An
-                  // agent-scoped source has no picker: the CP would reject re-adding a
-                  // ref to a source this caller can't see.
+                  // An agent-scoped source has no per-skill picker: the CP would reject
+                  // re-adding a ref to a source this caller can't see.
                   actions={
                     s.registry ? (
                       <button

--- a/packages/web/src/components/console/AgentToolsCard.test.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.test.tsx
@@ -35,12 +35,12 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 let host: HTMLDivElement | undefined
 let root: Root | undefined
 
-async function render(daemon: DaemonRow | undefined): Promise<string> {
+async function render(daemon: DaemonRow | undefined, canEdit = true): Promise<string> {
   host = document.createElement('div')
   document.body.appendChild(host)
   root = createRoot(host)
   await act(async () => {
-    root!.render(<AgentToolsCard agentId="a1" runtime="claude" daemon={daemon} canEdit />)
+    root!.render(<AgentToolsCard agentId="a1" runtime="claude" daemon={daemon} canEdit={canEdit} />)
   })
   return host.textContent ?? ''
 }
@@ -101,6 +101,15 @@ describe('AgentToolsCard', () => {
 
   it('shows the empty state when the agent has nothing attached', async () => {
     expect(await render(undefined)).toContain('No MCP servers')
+  })
+
+  // A read-only agent is never asked for its spec, so the card must settle on the
+  // empty state instead of sitting on its loading line forever.
+  it('does not hang on the loading line for an agent the caller cannot edit', async () => {
+    const text = await render(undefined, false)
+    expect(text).toContain('No MCP servers')
+    expect(text).not.toContain('Loading tools')
+    expect(text).not.toContain('Add')
   })
 
   it('says so in the menu when the org registry is empty too', async () => {

--- a/packages/web/src/components/console/AgentToolsCard.test.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.test.tsx
@@ -9,7 +9,8 @@ const mocks = vi.hoisted(() => ({
   mcpProviders: [
     { name: 'grafana', visibility: 'org' },
     { name: 'linear', visibility: 'org' }
-  ] as unknown[]
+  ] as unknown[],
+  saved: [] as string[]
 }))
 
 vi.mock('@/lib/data-context', () => ({
@@ -20,7 +21,7 @@ vi.mock('@/lib/data-context', () => ({
   })
 }))
 vi.mock('@/lib/api', () => ({
-  fetchAgentDto: vi.fn(async () => ({ mcpServers: [] })),
+  fetchAgentDto: vi.fn(async () => ({ mcpServers: mocks.saved })),
   fetchConnectorCatalog: vi.fn(async () => ({ providers: [] })),
   repoLabel: (r: unknown) => String(r),
   repoWebUrl: () => undefined
@@ -44,11 +45,23 @@ async function render(daemon: DaemonRow | undefined): Promise<string> {
   return host.textContent ?? ''
 }
 
+/** Open the header's Add menu and read what it offers. It portals to the body,
+ *  so the attachable names are never in the card's own subtree. */
+async function openAddMenu(): Promise<string> {
+  const trigger = [...document.querySelectorAll('button')].find((b) => b.textContent?.includes('Add'))
+  expect(trigger).toBeTruthy()
+  await act(async () => {
+    trigger!.click()
+  })
+  return document.querySelector('[data-anchored-flyout]')?.textContent ?? ''
+}
+
 afterEach(() => {
   act(() => root?.unmount())
   host?.remove()
   root = undefined
   host = undefined
+  mocks.saved = []
 })
 
 describe('AgentToolsCard', () => {
@@ -56,27 +69,46 @@ describe('AgentToolsCard', () => {
   // console resolves no owning daemon for it. Gating the whole candidate list on that lookup hid
   // every org-registry server such an agent could attach — and those are http-proxied, so they
   // never needed a daemon in the first place.
-  it('lists the org registry servers for an agent with no resolved daemon', async () => {
-    const text = await render(undefined)
-    expect(text).toContain('grafana')
-    expect(text).toContain('linear')
+  it('offers the org registry servers for an agent with no resolved daemon', async () => {
+    await render(undefined)
+    const menu = await openAddMenu()
+    expect(menu).toContain('grafana')
+    expect(menu).toContain('linear')
   })
 
   it('unions the daemon-reported servers with the registry when a daemon does resolve', async () => {
     const daemon = {
+      name: 'mac-studio',
       mcpServers: [{ name: 'daemon-local', transport: 'stdio' }],
       runtimeModels: []
     } as unknown as DaemonRow
-    const text = await render(daemon)
-    expect(text).toContain('daemon-local')
-    expect(text).toContain('grafana')
+    await render(daemon)
+    const menu = await openAddMenu()
+    expect(menu).toContain('daemon-local')
+    expect(menu).toContain('grafana')
   })
 
-  it('still shows the empty state when the org registry is empty too', async () => {
+  // The rows are the saved allow-list, so an attached server leaves the Add menu.
+  it('rows the attached servers and drops them from the Add menu', async () => {
+    mocks.saved = ['grafana']
+    const text = await render(undefined)
+    expect(text).toContain('grafana')
+    expect(text).not.toContain('linear')
+    const menu = await openAddMenu()
+    expect(menu).toContain('linear')
+    expect(menu).not.toContain('grafana')
+  })
+
+  it('shows the empty state when the agent has nothing attached', async () => {
+    expect(await render(undefined)).toContain('No MCP servers')
+  })
+
+  it('says so in the menu when the org registry is empty too', async () => {
     const saved = mocks.mcpProviders
     mocks.mcpProviders = []
     try {
-      expect(await render(undefined)).toContain('No MCP servers available to this agent.')
+      await render(undefined)
+      expect(await openAddMenu()).toContain('already attached')
     } finally {
       mocks.mcpProviders = saved
     }

--- a/packages/web/src/components/console/AgentToolsCard.test.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.test.tsx
@@ -103,13 +103,19 @@ describe('AgentToolsCard', () => {
     expect(await render(undefined)).toContain('No MCP servers')
   })
 
-  // A read-only agent is never asked for its spec, so the card must settle on the
-  // empty state instead of sitting on its loading line forever.
-  it('does not hang on the loading line for an agent the caller cannot edit', async () => {
+  // `canEdit` is false for a real agent the caller may see but not change, and
+  // `GET /agents/:id` is view-gated — so the saved roster must still be fetched and
+  // shown, just without the mutation controls. Short-circuiting to [] would claim an
+  // empty roster the card never checked.
+  it('shows the saved roster read-only for an agent the caller cannot edit', async () => {
+    mocks.saved = ['grafana']
     const text = await render(undefined, false)
-    expect(text).toContain('No MCP servers')
+    expect(text).toContain('grafana')
     expect(text).not.toContain('Loading tools')
+    expect(text).not.toContain('No MCP servers')
+    // No Add menu, and no per-row remove.
     expect(text).not.toContain('Add')
+    expect(host?.querySelector('button[title="Remove from this agent"]')).toBeNull()
   })
 
   it('says so in the menu when the org registry is empty too', async () => {

--- a/packages/web/src/components/console/AgentToolsCard.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.tsx
@@ -79,16 +79,15 @@ export function AgentToolsCard({
   // Always fetch the saved allow-list (even with no eligible servers) so saved
   // names the daemon no longer reports — or whose transport the current runtime
   // can't attach — can still be shown and removed; without it a consolidated
-  // Tools card offers no way to clear a stale name. Mock agents (canEdit false)
-  // have no spec to fetch.
+  // Tools card offers no way to clear a stale name.
   useEffect(() => {
     if (fetched.current) return
-    // Demo agents (canEdit false) have no spec to fetch — mock mode seeds a plausible
-    // saved set instead so the card isn't uniformly empty. A read-only agent settles
-    // on the empty list rather than null: null means "still asking", and nobody is
-    // going to ask, so the card would sit on its loading line forever.
-    if (!canEdit) {
-      setEnabled(MOCK_MODE ? ['grafana', 'linear'] : [])
+    // Only DEMO agents lack a spec to fetch — `canEdit` is also false for a real
+    // agent the caller may see but not change, and `GET /agents/:id` is view-gated,
+    // so that case fetches like any other and just renders without the mutation
+    // controls. Short-circuiting it would claim an empty roster it never checked.
+    if (!canEdit && MOCK_MODE) {
+      setEnabled(['grafana', 'linear'])
       return
     }
     fetched.current = true
@@ -117,9 +116,10 @@ export function AgentToolsCard({
     }
   }
 
-  // A server registered from this card is what the operator wanted on THIS agent,
-  // so it is attached as soon as the registry accepts it — no second trip through
-  // the Add menu. Its name is the allow-list key, exactly as a registry candidate's is.
+  // A server registered from this card — by URL, or as a connector connection — is
+  // what the operator wanted on THIS agent, so it is attached as soon as the registry
+  // accepts it, with no second trip through the Add menu. Its name is the allow-list
+  // key, exactly as a registry candidate's is.
   const attachCreated = (created: McpProviderCreatedDto) => void attach(created.name, true)
 
   const attached = enabled ?? []
@@ -240,7 +240,7 @@ export function AgentToolsCard({
       {browsing && (
         <div className="scrim">
           <div className="modal max-w-[920px]">
-            <ConnectorsModal onClose={() => setBrowsing(false)} />
+            <ConnectorsModal onClose={() => setBrowsing(false)} onCreated={attachCreated} />
           </div>
         </div>
       )}

--- a/packages/web/src/components/console/AgentToolsCard.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.tsx
@@ -84,9 +84,11 @@ export function AgentToolsCard({
   useEffect(() => {
     if (fetched.current) return
     // Demo agents (canEdit false) have no spec to fetch — mock mode seeds a plausible
-    // saved set instead so the card isn't uniformly empty.
+    // saved set instead so the card isn't uniformly empty. A read-only agent settles
+    // on the empty list rather than null: null means "still asking", and nobody is
+    // going to ask, so the card would sit on its loading line forever.
     if (!canEdit) {
-      if (MOCK_MODE) setEnabled(['grafana', 'linear'])
+      setEnabled(MOCK_MODE ? ['grafana', 'linear'] : [])
       return
     }
     fetched.current = true

--- a/packages/web/src/components/console/AgentToolsCard.tsx
+++ b/packages/web/src/components/console/AgentToolsCard.tsx
@@ -1,29 +1,32 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { fetchAgentDto } from '@/lib/api'
+import { fetchAgentDto, type McpProviderCreatedDto } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
 import { MOCK_MODE, type DaemonRow } from '@/lib/data'
 import { mcpCandidates, mcpCapsFor, mcpKindLabel, mcpServersForRuntime } from '@/components/console/McpServersField'
-import { ProviderMark, ToolTile, ToolTileGrid, useConnectorIcons } from '@/components/console/ToolTile'
-import { VisibilityValue } from '@/components/console/VisibilityField'
-import { Icon, Toggle } from '@/components/ui'
+import { AttachedEmpty, AttachedNote, AttachedRow, AttachMenu } from '@/components/console/AttachedList'
+import { ConnectorsModal } from '@/components/console/ConnectorsModal'
+import { CreateMcpProviderModal } from '@/components/console/McpServersCard'
+import { ProviderMark, useConnectorIcons } from '@/components/console/ToolTile'
 
 /**
- * Leads the agent's Tools & Skills tab: the MCP servers the owning daemon's
- * runtime can attach (via `mcpServersForRuntime`/`mcpKindLabel`), each with an
- * enable/disable toggle. MCP is agent-scoped — this is the surface where it's
- * picked; the daemon detail view no longer lists MCP servers.
+ * Leads the agent's Tools & Skills tab: the MCP servers this agent has attached,
+ * one row each, plus the header's Add menu offering the ones it hasn't (via
+ * `mcpServersForRuntime`/`mcpKindLabel`). MCP is agent-scoped — this is the
+ * surface where it's picked; the daemon detail view no longer lists MCP servers.
  *
  * The agent model stores an explicit allow-list (`mcpServers`) and the daemon
- * attaches ONLY the names in it (an empty list ⇒ no servers), so the toggles
- * mirror the saved list 1:1 — a server is on iff its name is saved, and a brand
- * new agent (empty list) starts with every server OFF. Each toggle persists the
- * explicit set via `updateAgent`, so what's shown is exactly what a session
- * attaches. Saved names the daemon no longer reports — or whose transport the
- * current runtime can't attach — still render as rows so they can be turned OFF
- * (they can't be turned back on here); this is the only place to clear a stale
- * name now that the create/edit picker is gone.
+ * attaches ONLY the names in it (an empty list ⇒ no servers), so the rows ARE the
+ * saved list — attaching appends a name, the row's × removes it, and both persist
+ * through `updateAgent`. Saved names the daemon no longer reports — or whose
+ * transport the current runtime can't attach — still render as dimmed rows so they
+ * can be removed (they are never offered in the Add menu); this is the only place
+ * to clear a stale name.
+ *
+ * The Add menu's quick-add items open the org registry's OWN dialogs
+ * (`CreateMcpProviderModal`, `ConnectorsModal`) rather than a second create form,
+ * and a server created through the first is attached to this agent immediately.
  *
  * Daemons are live-only, so an agent with no resolved daemon — a mock one, one
  * out of the fleet, or one placed on a pool or a group rather than a member —
@@ -41,6 +44,8 @@ export function AgentToolsCard({
   canEdit: boolean
 }) {
   const { updateAgent, mcpProviders, connectorsEnabled } = useConsoleData()
+  const [creating, setCreating] = useState(false)
+  const [browsing, setBrowsing] = useState(false)
   // Candidate list = daemon-configured servers ∪ org-registry provider names, gated
   // by the runtime's transport support (registry providers are http-proxied).
   const registryNames = useMemo(() => mcpProviders.map((p) => p.name), [mcpProviders])
@@ -50,9 +55,9 @@ export function AgentToolsCard({
     () => new Map(mcpProviders.flatMap((p) => (p.service ? [[p.name, p.service] as const] : []))),
     [mcpProviders]
   )
-  // The registry row behind a candidate name (when there is one) — it carries both the
-  // kind wording and the access footer, so an agent tile says the same thing about a
-  // server as its registry tile does.
+  // The registry row behind a candidate name (when there is one) — it carries the
+  // kind wording, so an agent row says the same thing about a server as its
+  // registry tile does.
   const providerByName = useMemo(() => new Map(mcpProviders.map((p) => [p.name, p] as const)), [mcpProviders])
   const iconByService = useConnectorIcons(connectorsEnabled && serviceByName.size > 0)
   const iconFor = (name: string) => {
@@ -73,13 +78,13 @@ export function AgentToolsCard({
 
   // Always fetch the saved allow-list (even with no eligible servers) so saved
   // names the daemon no longer reports — or whose transport the current runtime
-  // can't attach — can still be shown and turned OFF; without it a consolidated
+  // can't attach — can still be shown and removed; without it a consolidated
   // Tools card offers no way to clear a stale name. Mock agents (canEdit false)
   // have no spec to fetch.
   useEffect(() => {
     if (fetched.current) return
     // Demo agents (canEdit false) have no spec to fetch — mock mode seeds a plausible
-    // saved set instead so the toggles aren't uniformly off.
+    // saved set instead so the card isn't uniformly empty.
     if (!canEdit) {
       if (MOCK_MODE) setEnabled(['grafana', 'linear'])
       return
@@ -87,81 +92,154 @@ export function AgentToolsCard({
     fetched.current = true
     fetchAgentDto(agentId).then(
       // The saved allow-list IS the effective set (empty ⇒ no servers), so the
-      // toggles mirror it 1:1 rather than defaulting an empty list to all-on.
+      // rows mirror it 1:1 rather than defaulting an empty list to all-on.
       (dto) => setEnabled(dto.mcpServers ?? []),
       (e) => setErr(e instanceof Error ? e.message : String(e))
     )
   }, [agentId, canEdit])
 
-  const toggle = async (name: string, next: boolean) => {
+  const attach = async (name: string, next: boolean) => {
     if (!canEdit || enabled === null || saving) return
     const prev = enabled
-    const nextEnabled = next ? [...enabled, name] : enabled.filter((n) => n !== name)
+    const nextEnabled = next ? [...enabled.filter((n) => n !== name), name] : enabled.filter((n) => n !== name)
     setEnabled(nextEnabled)
     setSaving(true)
     setErr(null)
     try {
       await updateAgent(agentId, { mcpServers: nextEnabled })
     } catch (e) {
-      setEnabled(prev) // revert on failure so the toggle never lies about what's saved
+      setEnabled(prev) // revert on failure so the card never lies about what's saved
       setErr(e instanceof Error ? e.message : String(e))
     } finally {
       setSaving(false)
     }
   }
 
-  // Saved names not in the eligible set: reported-but-transport-ineligible, or no
-  // longer reported at all. Shown so they can be turned off (never back on here).
-  const eligibleNames = new Set(servers.map((s) => s.name))
+  // A server registered from this card is what the operator wanted on THIS agent,
+  // so it is attached as soon as the registry accepts it — no second trip through
+  // the Add menu. Its name is the allow-list key, exactly as a registry candidate's is.
+  const attachCreated = (created: McpProviderCreatedDto) => void attach(created.name, true)
+
+  const attached = enabled ?? []
+  const eligible = new Map(servers.map((s) => [s.name, s] as const))
   const candidateNames = new Set(candidates.map((c) => c.name))
-  const unknown = (enabled ?? []).filter((n) => !eligibleNames.has(n))
-  const unknownMeta = (n: string) =>
+  const options = servers
+    .filter((s) => !attached.includes(s.name))
+    .map((s) => ({
+      key: s.name,
+      name: s.name,
+      meta: mcpKindLabel(providerByName.get(s.name)?.kind),
+      onPick: () => void attach(s.name, true)
+    }))
+  // Why a saved name isn't attachable any more: reported but transport-ineligible,
+  // or no longer reported at all.
+  const staleMeta = (n: string) =>
     candidateNames.has(n) ? 'Not supported by this runtime' : 'Not available to this agent'
 
-  // One MCP tile — the same ToolTile the registry card renders, with the enable toggle
-  // in place of its edit/delete action. Eligible servers toggle freely; an ineligible
-  // saved name stays interactive only while ON, so it can be turned off but not
-  // re-enabled here.
-  const tile = (name: string, meta: string, eligible: boolean) => {
-    const on = enabled ? enabled.includes(name) : false // mirror the saved set; off until it loads
-    const interactive = canEdit && enabled !== null && !saving && (eligible || on)
-    const provider = providerByName.get(name)
-    return (
-      <ToolTile
-        key={name}
-        mark={<ProviderMark iconUrl={iconFor(name)} />}
-        name={name}
-        subtitle={meta}
-        dimmed={!eligible}
-        action={<Toggle checked={on} disabled={!interactive} onChange={(next) => toggle(name, next)} />}
-        // Who the server belongs to, same as its registry tile. A daemon-local server
-        // has no registry row, so it has no access line to show.
-        footer={
-          provider ? <VisibilityValue visibility={provider.visibility} sharedWith={provider.sharedWith} /> : undefined
+  const menu = canEdit ? (
+    <AttachMenu
+      ariaLabel="Add an MCP server to this agent"
+      disabled={enabled === null || saving}
+      groups={[
+        {
+          heading: 'Add existing',
+          icon: 'plug',
+          options,
+          emptyLabel: 'Every server available to this agent is already attached.'
         }
-      />
-    )
-  }
+      ]}
+      actions={[
+        ...(connectorsEnabled
+          ? [{ key: 'connectors', label: 'Browse connectors…', icon: 'blocks', onPick: () => setBrowsing(true) }]
+          : []),
+        { key: 'custom', label: 'Add custom MCP server…', icon: 'plus', onPick: () => setCreating(true) }
+      ]}
+    />
+  ) : undefined
 
   return (
     <div className="card overflow-hidden max-desktop:rounded-lg desktop:max-w-[760px]">
-      <div className="border-b border-(--border-subtle) px-4 py-3 font-sans text-[14px] font-semibold leading-normal desktop:py-[13px]">
-        Tools
+      <div className="cardhead flex-wrap gap-2">
+        <span className="cardtitle">Tools</span>
+        <span className="mono ml-auto text-[11px] text-(--text-tertiary)">
+          MCP servers{daemon ? ` · ${runtime} on ${daemon.name}` : ` · ${runtime}`}
+        </span>
+        {menu}
       </div>
-      {servers.length > 0 || unknown.length > 0 ? (
-        <ToolTileGrid columns={2}>
-          {servers.map((s) => tile(s.name, mcpKindLabel(providerByName.get(s.name)?.kind), true))}
-          {unknown.map((n) => tile(n, unknownMeta(n), false))}
-        </ToolTileGrid>
+
+      {attached.length > 0 ? (
+        <>
+          <div>
+            {attached.map((name) => {
+              const server = eligible.get(name)
+              const provider = providerByName.get(name)
+              return (
+                <AttachedRow
+                  key={name}
+                  mark={<ProviderMark iconUrl={iconFor(name)} />}
+                  name={name}
+                  meta={
+                    server
+                      ? `${server.transport} · ${mcpKindLabel(provider?.kind)}`
+                      : `${mcpKindLabel(provider?.kind)} · ${staleMeta(name)}`
+                  }
+                  dimmed={!server}
+                  badge={
+                    <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">
+                      {provider ? 'workspace' : 'daemon'}
+                    </span>
+                  }
+                  onRemove={canEdit && !saving ? () => void attach(name, false) : undefined}
+                  removeTitle="Remove from this agent"
+                />
+              )
+            })}
+          </div>
+          <AttachedNote>
+            Served by the {runtime} runtime
+            {daemon ? (
+              <>
+                {' '}
+                on <span className="mono text-[11.5px]">{daemon.name}</span>
+              </>
+            ) : null}
+            . Removing a server hides its tools from this agent.
+          </AttachedNote>
+        </>
       ) : (
-        <div className="flex items-center gap-2 px-4 py-[13px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary) desktop:py-3">
-          <Icon name="plug" size={14} />
-          No MCP servers available to this agent.
-        </div>
+        <AttachedEmpty
+          // `enabled` null ⇒ the saved allow-list is still in flight; claiming
+          // "no servers" then would be a guess, not a fact.
+          title={enabled === null ? 'Loading tools…' : 'No MCP servers'}
+          hint={
+            enabled === null
+              ? 'Reading the servers this agent attaches.'
+              : canEdit
+                ? 'Attach one from your workspace, or register a new server.'
+                : 'This agent has no MCP servers attached.'
+          }
+          action={enabled === null ? undefined : menu}
+        />
       )}
+
       {err && (
         <div className="border-t border-(--border-subtle) px-4 py-[11px] font-sans text-[12px] font-normal leading-normal text-(--red-600)">
           {err}
+        </div>
+      )}
+
+      {creating && (
+        <div className="scrim">
+          <div className="modal">
+            <CreateMcpProviderModal onClose={() => setCreating(false)} onCreated={attachCreated} />
+          </div>
+        </div>
+      )}
+      {browsing && (
+        <div className="scrim">
+          <div className="modal max-w-[920px]">
+            <ConnectorsModal onClose={() => setBrowsing(false)} />
+          </div>
         </div>
       )}
     </div>

--- a/packages/web/src/components/console/AttachedList.tsx
+++ b/packages/web/src/components/console/AttachedList.tsx
@@ -138,10 +138,17 @@ export function AttachMenu({
       {({ close }) => (
         <>
           {groups.map((group) => (
-            <div key={group.heading}>
-              <div className="fhdr">{group.heading}</div>
+            // `role="group"` keeps the heading from putting a bare div between the
+            // flyout's role="menu" and its menuitems, which invalidates both.
+            <div key={group.heading} role="group" aria-label={group.heading}>
+              <div className="fhdr" aria-hidden="true">
+                {group.heading}
+              </div>
               {group.options.length === 0 ? (
-                <div className="px-[10px] py-[9px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+                <div
+                  role="none"
+                  className="px-[10px] py-[9px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)"
+                >
                   {group.emptyLabel}
                 </div>
               ) : (
@@ -165,7 +172,7 @@ export function AttachMenu({
               )}
             </div>
           ))}
-          {actions.length > 0 && <div className="dmsep" />}
+          {actions.length > 0 && <div className="dmsep" role="separator" />}
           {actions.map((action) => (
             <button
               key={action.key}

--- a/packages/web/src/components/console/AttachedList.tsx
+++ b/packages/web/src/components/console/AttachedList.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+// The two shapes the agent detail view's Tools & Skills tab is built from: one
+// attached row, and the card header's "Add" menu (AgentConnect Console v2 design,
+// agent page → Tools & Skills). Both cards list only what the agent HAS attached
+// and offer everything else behind the menu, so the tab reads as a roster rather
+// than a switchboard over the whole org registry.
+//
+// Kept here — not in ToolTile.tsx — because these are LIST rows: the registry
+// pages still render the tile grid, and the two shapes should stay independently
+// tweakable.
+
+import type { ReactNode } from 'react'
+import { AnchoredFlyout } from '@/components/ui/AnchoredFlyout'
+import { Button, Icon } from '@/components/ui'
+
+/** One attached MCP server / skill: mark, name + meta line, origin badge, remove. */
+export function AttachedRow({
+  mark,
+  name,
+  meta,
+  badge,
+  actions,
+  onRemove,
+  removeTitle,
+  dimmed,
+  children
+}: {
+  mark: ReactNode
+  name: string
+  /** The muted second line — transport · kind, or a skill source's repo. */
+  meta: ReactNode
+  /** Where it comes from (registry / daemon-local / managed), right of the meta. */
+  badge?: ReactNode
+  /** Extra controls left of the remove button (the skills card's expand chevron). */
+  actions?: ReactNode
+  onRemove?: () => void
+  removeTitle?: string
+  /** A saved name this agent can no longer attach — shown only so it can be removed. */
+  dimmed?: boolean
+  /** Full-bleed panel below the row (the skills card's per-skill list). */
+  children?: ReactNode
+}) {
+  return (
+    <div className={`border-b border-(--border-subtle) last:border-b-0 ${dimmed ? 'opacity-60' : ''}`}>
+      <div className="flex items-center gap-[11px] px-4 py-3">
+        {mark}
+        <div className="min-w-0 flex-1">
+          <div className="mono truncate text-[12.5px] text-(--text-primary)">{name}</div>
+          <div className="mono truncate text-[11px] text-(--text-tertiary)">{meta}</div>
+        </div>
+        {badge}
+        {actions}
+        {onRemove && (
+          <button type="button" className="iconbtn flex-none" title={removeTitle} onClick={onRemove}>
+            <Icon name="x" size={15} />
+          </button>
+        )}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+/** The card footer's info strip — what serves these, and what removing one means. */
+export function AttachedNote({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 border-t border-(--border-subtle) px-4 py-[13px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+      <Icon name="info" size={14} className="flex-none" />
+      <span>{children}</span>
+    </div>
+  )
+}
+
+/** One already-known thing the agent can attach, offered under a menu heading. */
+export interface AttachOption {
+  key: string
+  name: string
+  /** Right-aligned hint — the kind of server, the repo a source installs from. */
+  meta?: string
+  onPick: () => void
+}
+
+/** A heading plus the options under it; `emptyLabel` shows when nothing is left. */
+export interface AttachGroup {
+  heading: string
+  icon: string
+  options: AttachOption[]
+  emptyLabel: string
+}
+
+/** A "create one now" item below the separator — opens the registry's own dialog. */
+export interface AttachAction {
+  key: string
+  label: string
+  icon: string
+  onPick: () => void
+}
+
+/**
+ * The card header's Add menu: "add existing" groups first, then the custom
+ * quick-add actions. Groups with no options left say so rather than vanishing,
+ * so the menu never looks broken when everything is already attached.
+ */
+export function AttachMenu({
+  ariaLabel,
+  groups,
+  actions,
+  disabled
+}: {
+  ariaLabel: string
+  groups: AttachGroup[]
+  actions: AttachAction[]
+  disabled?: boolean
+}) {
+  const rows = groups.reduce((n, g) => n + Math.max(1, Math.min(g.options.length, 6)), 0)
+  return (
+    <AnchoredFlyout
+      ariaLabel={ariaLabel}
+      width={330}
+      estimatedHeight={36 * (rows + actions.length) + 24 * groups.length}
+      trigger={({ open, menuId, toggle }) => (
+        <Button
+          variant="secondary"
+          size="xs"
+          disabled={disabled}
+          onClick={toggle}
+          ariaExpanded={open}
+          ariaHasPopup="menu"
+          ariaControls={open ? menuId : undefined}
+        >
+          <Icon name="plus" size={14} />
+          Add
+          <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
+        </Button>
+      )}
+    >
+      {({ close }) => (
+        <>
+          {groups.map((group) => (
+            <div key={group.heading}>
+              <div className="fhdr">{group.heading}</div>
+              {group.options.length === 0 ? (
+                <div className="px-[10px] py-[9px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+                  {group.emptyLabel}
+                </div>
+              ) : (
+                group.options.map((option) => (
+                  <button
+                    key={option.key}
+                    role="menuitem"
+                    className="dmi"
+                    onClick={() => {
+                      close()
+                      option.onPick()
+                    }}
+                  >
+                    <Icon name={group.icon} size={15} />
+                    <span className="mono min-w-0 flex-1 truncate text-left text-[12.5px]">{option.name}</span>
+                    {option.meta && (
+                      <span className="mono flex-none text-[11px] text-(--text-tertiary)">{option.meta}</span>
+                    )}
+                  </button>
+                ))
+              )}
+            </div>
+          ))}
+          {actions.length > 0 && <div className="dmsep" />}
+          {actions.map((action) => (
+            <button
+              key={action.key}
+              role="menuitem"
+              className="dmi"
+              onClick={() => {
+                close()
+                action.onPick()
+              }}
+            >
+              <Icon name={action.icon} size={15} />
+              <span className="flex-1 text-left">{action.label}</span>
+            </button>
+          ))}
+        </>
+      )}
+    </AnchoredFlyout>
+  )
+}
+
+/** The empty state both cards show when the agent has nothing attached yet. */
+export function AttachedEmpty({ title, hint, action }: { title: string; hint: string; action?: ReactNode }) {
+  return (
+    <div className="px-4 py-[26px] text-center">
+      <div className="font-sans text-[13px] font-medium leading-normal text-(--text-secondary)">{title}</div>
+      <div className="mx-auto mt-[3px] mb-[13px] max-w-[430px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+        {hint}
+      </div>
+      {action}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/ConnectorsModal.tsx
+++ b/packages/web/src/components/console/ConnectorsModal.tsx
@@ -9,7 +9,12 @@
 // connections — it never shows or manages existing ones.
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { fetchConnectorCatalog, type ConnectorAuthDefinition, type ConnectorProviderDto } from '@/lib/api'
+import {
+  fetchConnectorCatalog,
+  type ConnectorAuthDefinition,
+  type ConnectorConnectionCreatedDto,
+  type ConnectorProviderDto
+} from '@/lib/api'
 import {
   credentialFieldsFor,
   filterByCategory,
@@ -29,7 +34,14 @@ import { Button, Icon } from '@/components/ui'
 // Must match the CP's CreateConnectorConnectionBody rule (≤32, alphanumeric-led).
 const CONNECTION_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$/
 
-export function ConnectorsModal({ onClose }: { onClose: () => void }) {
+export function ConnectorsModal({
+  onClose,
+  onCreated
+}: {
+  onClose: () => void
+  /** Fired with the connection's provider row, so a caller can attach it to an agent. */
+  onCreated?: (created: ConnectorConnectionCreatedDto) => void
+}) {
   const [providers, setProviders] = useState<ConnectorProviderDto[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [selected, setSelected] = useState<string | null>(null)
@@ -83,7 +95,7 @@ export function ConnectorsModal({ onClose }: { onClose: () => void }) {
         ) : !providers ? (
           <LoadingState size={22} padding={24} />
         ) : provider ? (
-          <ProviderDetail provider={provider} onDone={onClose} />
+          <ProviderDetail provider={provider} onDone={onClose} onCreated={onCreated} />
         ) : (
           <ProviderBrowser providers={providers} onSelect={setSelected} />
         )}
@@ -257,7 +269,15 @@ function ProviderIcon({ provider, large }: { provider: ConnectorProviderDto; lar
 }
 
 // ── detail / new connection ───────────────────────────────────────────────────
-function ProviderDetail({ provider, onDone }: { provider: ConnectorProviderDto; onDone: () => void }) {
+function ProviderDetail({
+  provider,
+  onDone,
+  onCreated
+}: {
+  provider: ConnectorProviderDto
+  onDone: () => void
+  onCreated?: (created: ConnectorConnectionCreatedDto) => void
+}) {
   const [authType, setAuthType] = useState<ConnectorAuthDefinition['type'] | undefined>(() => initialAuthType(provider))
   const auth = provider.auth.find((a) => a.type === authType) ?? provider.auth[0]
   const hasMultiple = provider.auth.length > 1
@@ -308,7 +328,13 @@ function ProviderDetail({ provider, onDone }: { provider: ConnectorProviderDto; 
       )}
 
       {auth ? (
-        <ConnectionForm key={`${provider.service}:${auth.type}`} provider={provider} auth={auth} onDone={onDone} />
+        <ConnectionForm
+          key={`${provider.service}:${auth.type}`}
+          provider={provider}
+          auth={auth}
+          onDone={onDone}
+          onCreated={onCreated}
+        />
       ) : (
         <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
           This connector has no supported connection method.
@@ -321,11 +347,13 @@ function ProviderDetail({ provider, onDone }: { provider: ConnectorProviderDto; 
 function ConnectionForm({
   provider,
   auth,
-  onDone
+  onDone,
+  onCreated
 }: {
   provider: ConnectorProviderDto
   auth: ConnectorAuthDefinition
   onDone: () => void
+  onCreated?: (created: ConnectorConnectionCreatedDto) => void
 }) {
   const { createConnectorConnection } = useConsoleData()
   const { me } = useProfile()
@@ -352,6 +380,10 @@ function ConnectionForm({
           ? { visibility: 'restricted' as const, sharedWith: sharing.sharedWith }
           : {})
       })
+      // The provider row exists the moment the CP accepts the connection — including
+      // on the oauth2 path, where the popup finishes independently — so a caller
+      // attaching it to an agent hears about it here, not after the sign-in lands.
+      onCreated?.(created)
       if (auth.type === 'oauth2') {
         if (created.authorizationUrl) {
           window.open(created.authorizationUrl, 'connectors_oauth', oauthPopupFeatures())

--- a/packages/web/src/components/console/InstallRegistrySkillModal.tsx
+++ b/packages/web/src/components/console/InstallRegistrySkillModal.tsx
@@ -51,11 +51,14 @@ export function registrySourceName(skill: string, taken: Iterable<string>): stri
 
 export function InstallRegistrySkillModal({
   existing,
-  onClose
+  onClose,
+  onCreated
 }: {
   /** The org's current sources — for the "already in your library" state. */
   existing: SkillSourceDto[]
   onClose: () => void
+  /** Fired with the registered source, so a caller can enable it on an agent. */
+  onCreated?: (created: SkillSourceDto) => void
 }) {
   const { createSkillSource } = useConsoleData()
   const { me } = useProfile()
@@ -124,7 +127,7 @@ export function InstallRegistrySkillModal({
     setBusy(true)
     setErr(null)
     try {
-      await createSkillSource({
+      const created = await createSkillSource({
         name: name.trim(),
         source: picked.source,
         skills: [picked.name],
@@ -132,6 +135,7 @@ export function InstallRegistrySkillModal({
           ? { visibility: 'restricted' as const, sharedWith: sharing.sharedWith }
           : {})
       })
+      onCreated?.(created)
       onClose()
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))

--- a/packages/web/src/components/console/McpServersCard.tsx
+++ b/packages/web/src/components/console/McpServersCard.tsx
@@ -22,6 +22,7 @@ import {
   fetchConnectorCatalog,
   fmtDate,
   type McpProviderDto,
+  type McpProviderCreatedDto,
   type McpHeaderInput,
   type ConnectorAuthDefinition
 } from '@/lib/api'
@@ -307,7 +308,15 @@ function cleanHeaders(rows: HeaderRow[]): McpHeaderInput[] {
 
 // ── create dialog (form → mint; the grant key is minted server-side and pushed to
 // the relay, but never surfaced here — agents enable the provider by name) ────────
-function CreateMcpProviderModal({ onClose }: { onClose: () => void }) {
+/** Register an upstream MCP server. Reused by the agent detail view's Tools card,
+ *  which passes `onCreated` to attach the new provider to that agent right away. */
+export function CreateMcpProviderModal({
+  onClose,
+  onCreated
+}: {
+  onClose: () => void
+  onCreated?: (created: McpProviderCreatedDto) => void
+}) {
   const { createMcpProvider } = useConsoleData()
   const { me } = useProfile()
   const [name, setName] = useState('')
@@ -324,7 +333,7 @@ function CreateMcpProviderModal({ onClose }: { onClose: () => void }) {
     setBusy(true)
     setErr(null)
     try {
-      await createMcpProvider({
+      const created = await createMcpProvider({
         name: name.trim(),
         url: url.trim(),
         headers: cleanHeaders(headers),
@@ -333,6 +342,7 @@ function CreateMcpProviderModal({ onClose }: { onClose: () => void }) {
           ? { visibility: 'restricted' as const, sharedWith: sharing.sharedWith }
           : {})
       })
+      onCreated?.(created)
       onClose()
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))

--- a/packages/web/src/components/console/SkillSourcesCard.tsx
+++ b/packages/web/src/components/console/SkillSourcesCard.tsx
@@ -270,7 +270,15 @@ function SourceTile({
   )
 }
 
-function CreateSkillSourceModal({ onClose }: { onClose: () => void }) {
+/** Register a Git skill source. Reused by the agent detail view's Skills card,
+ *  which passes `onCreated` to enable the new source on that agent right away. */
+export function CreateSkillSourceModal({
+  onClose,
+  onCreated
+}: {
+  onClose: () => void
+  onCreated?: (created: SkillSourceDto) => void
+}) {
   const { createSkillSource } = useConsoleData()
   const { me } = useProfile()
   const [name, setName] = useState('')
@@ -299,7 +307,7 @@ function CreateSkillSourceModal({ onClose }: { onClose: () => void }) {
     setBusy(true)
     setErr(null)
     try {
-      await createSkillSource({
+      const created = await createSkillSource({
         name: derivedName,
         source: source.trim(),
         ...(ref.trim() ? { ref: ref.trim() } : {}),
@@ -309,6 +317,7 @@ function CreateSkillSourceModal({ onClose }: { onClose: () => void }) {
           ? { visibility: 'restricted' as const, sharedWith: sharing.sharedWith }
           : {})
       })
+      onCreated?.(created)
       onClose()
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))


### PR DESCRIPTION
Closes #1212 ("be able to add mcp/connector directly from agents").

Implements the agent page → **Tools & Skills** tab from the Console v2 design
([`AgentConnect Console v2.dc.html`](https://claude.ai/design/p/dc5868f1-6c3f-4315-bac2-b983274e3192?file=AgentConnect+Console+v2.dc.html),
Knowledge & Tools tab).

## Why

The tab listed **every** candidate the org registry knew about and made the agent's
choice a column of toggles. The design draws it as a roster instead: the agent's own
attached servers and skills, one row each, with everything else behind an `Add ⌄` menu
in the card header — and that menu is also where you register something new, so adding
an MCP server no longer means leaving the agent for the Tools & Skills page.

## What

**`AttachedList.tsx` (new)** — the two shapes from the design, shared by both cards:

| | |
|---|---|
| `AttachedRow` | 30px mark well, mono name + muted meta line, origin badge, `×` remove (`iconbtn`), full-bleed slot for the expandable per-skill panel |
| `AttachMenu` | the header's `Add ⌄` (secondary `xs` Button) opening the design's `fhdr` / `dmi` / `dmsep` menu — "add existing" groups first, then the quick-add actions |
| `AttachedNote` / `AttachedEmpty` | the design's footer info strip and centered empty state |

Built on the existing `AnchoredFlyout`, so the menu escapes the card's
`overflow-hidden` and gets collision handling, Escape, and backdrop dismissal for free.

**`AgentToolsCard`** — rows are the saved `mcpServers` allow-list. Meta reads
`{transport} · {kind}`, badge is `workspace`/`daemon`, `×` detaches. The menu offers the
eligible-but-unattached servers, then `Browse connectors…` (when connectors are on) and
`Add custom MCP server…`. Stale saved names — no longer reported, or transport-ineligible
for the current runtime — still render dimmed **with the reason** so they can be cleared,
and are never offered for re-attach.

**`AgentSkillsCard`** — one row per enabled managed bundle (`rev N · M files`,
`managed`/`archived` badge) and per enabled Git source (repo line, `all skills` /
`N selected` badge, hover chevron for the per-skill picker). The menu groups
`Managed skills` and `Git skill sources`, then `Search skills.sh…` and
`Add custom skill source…`.

## Reuse over new UI

The quick-add items open the registry's **own** dialogs — `CreateMcpProviderModal`,
`ConnectorsModal`, `InstallRegistrySkillModal`, `CreateSkillSourceModal` — rather than a
second create form. The two module-local ones are now exported, and all three create
dialogs gained an optional `onCreated`, so a thing registered from the agent page is
attached to that agent immediately instead of making you re-open the menu.

## Notes on judgment calls

- The design puts the Add button in each **card** header, so Tools and Skills each got
  their own (Tools → MCP servers, Skills → skills) rather than one page-level button with
  a combined dropdown.
- The design's row shows `{transport} · {tools}`; there is no per-server tool count in the
  data, so the second line is `{transport} · {kind}`, worded exactly as the registry tile
  words it.

## Verification

- `tsc --noEmit` clean, `eslint` clean on all touched files.
- Full web suite green: **178 files / 1972 tests**.
- `AgentToolsCard.test.tsx` updated for the new model — unattached servers now live in the
  portaled menu, so the tests open the menu and read from `document.body`.
- `AgentSkillsCard.test.tsx` is **new**: empty state + both libraries offered,
  attach-drops-from-menu, managed-bundle row with its pinned revision, and the
  partial-selection badge.

No browser screenshot: no Playwright/Puppeteer in this checkout, so fidelity was checked
against the design markup rather than a render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
