### PR TITLE
feat(web): drop the daemon step from onboarding and the getting-started list

### DIFF
--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -65,7 +65,7 @@ export function openGettingStarted() {
 }
 
 export default function GettingStarted() {
-  const { agents, daemons, integrations, allSessions, orgHasSessions, members, loading } = useConsoleData()
+  const { agents, integrations, allSessions, orgHasSessions, members, loading } = useConsoleData()
   const { runAction, firstAgent } = useGsActions()
   const pathname = usePathname()
   const authOn = isAuthConfigured()
@@ -100,7 +100,6 @@ export default function GettingStarted() {
     () =>
       computeGettingStarted({
         agents,
-        daemons,
         integrations,
         sessions: allSessions,
         members,
@@ -112,7 +111,6 @@ export default function GettingStarted() {
       }),
     [
       agents,
-      daemons,
       integrations,
       allSessions,
       members,
@@ -125,7 +123,7 @@ export default function GettingStarted() {
   )
 
   // Show on every console page while the checklist is incomplete — including a
-  // brand-new org, where "Connect a daemon" is the first open step. The full-screen
+  // brand-new org, where setting up the built-in agent is the first open step. The full-screen
   // /onboarding wizard is a separate route (AgentsView redirects an empty org there);
   // the pill only steps aside for that route, not for the empty-org state itself.
   const onOnboardingRoute = pathname?.includes('/onboarding')
@@ -172,18 +170,30 @@ export default function GettingStarted() {
       {/* 1a — floating pill. On mobile it floats above the bottom-tab chrome (the
           drawer below is already full-width there). */}
       {showPill && !drawerOpen && (
-        <button
-          type="button"
-          onClick={() => setDrawerOpen(true)}
-          title="Getting started — open checklist"
-          className="fixed right-[26px] bottom-[22px] z-[60] inline-flex h-10 cursor-pointer items-center gap-[9px] rounded-full border border-(--border-default) bg-(--surface-card) pr-[15px] pl-[9px] shadow-(--shadow-lg) hover:border-(--border-strong) hover:shadow-(--shadow-xl) max-desktop:right-4 max-desktop:bottom-[96px]"
-        >
-          <Ring ring={gs.ring} size={22} track={3.4} />
-          <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
-            Getting started
-          </span>
-          <span className="font-mono text-[12px] leading-normal text-(--text-tertiary)">{shortLabel}</span>
-        </button>
+        <div className="fixed right-[26px] bottom-[22px] z-[60] inline-flex h-10 items-center rounded-full border border-(--border-default) bg-(--surface-card) pr-[5px] pl-[9px] shadow-(--shadow-lg) hover:border-(--border-strong) hover:shadow-(--shadow-xl) max-desktop:right-4 max-desktop:bottom-[96px]">
+          <button
+            type="button"
+            onClick={() => setDrawerOpen(true)}
+            title="Getting started — open checklist"
+            className="inline-flex cursor-pointer items-center gap-[9px] border-0 bg-transparent pr-[9px]"
+          >
+            <Ring ring={gs.ring} size={22} track={3.4} />
+            <span className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
+              Getting started
+            </span>
+            <span className="font-mono text-[12px] leading-normal text-(--text-tertiary)">{shortLabel}</span>
+          </button>
+          {/* Same "Skip for now" the drawer offers — dismissible without opening it first. */}
+          <button
+            type="button"
+            onClick={skip}
+            title="Hide the checklist — reopen it from the account menu"
+            aria-label="Hide the getting-started checklist"
+            className="flex h-[26px] w-[26px] flex-none cursor-pointer items-center justify-center rounded-full border-0 bg-transparent text-(--text-tertiary) hover:bg-(--surface-hover) hover:text-(--text-primary)"
+          >
+            <Icon name="x" size={14} />
+          </button>
+        </div>
       )}
 
       {/* 1b — slide-over drawer */}

--- a/packages/web/src/components/console/GettingStartedChecklist.test.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  agents: [] as Array<Record<string, unknown>>,
+  daemons: [] as Array<Record<string, unknown>>,
+  openModal: vi.fn(),
+  push: vi.fn()
+}))
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mocks.push }) }))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({ agents: mocks.agents, daemons: mocks.daemons })
+}))
+vi.mock('@/lib/org-context', () => ({ useOrgs: () => ({ orgPath: (path: string) => `/acme${path}` }) }))
+vi.mock('./ModalProvider', () => ({ useModal: () => ({ openModal: mocks.openModal }) }))
+
+import { useGsActions } from './GettingStartedChecklist'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root
+let run: (action: Parameters<ReturnType<typeof useGsActions>['runAction']>[0]) => void
+
+function Probe() {
+  const { runAction } = useGsActions()
+  run = runAction
+  return null
+}
+
+const render = async () => {
+  root = createRoot(document.createElement('div'))
+  await act(async () => root.render(<Probe />))
+}
+
+beforeEach(() => {
+  mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
+  mocks.daemons = []
+  mocks.openModal.mockReset()
+  mocks.push.mockReset()
+})
+
+afterEach(() => act(() => root.unmount()))
+
+// The checklist no longer carries a "Connect a daemon" step, so the agent step must
+// supply the missing route itself — same chain as the Agents / Agent detail "Add
+// daemon" chips (AddDaemonModal chains back into the edit dialog on Continue).
+describe('useGsActions — the agent step', () => {
+  it('mints a daemon first when the org has none, chaining into the agent editor', async () => {
+    await render()
+    act(() => run({ kind: 'agent' }))
+    expect(mocks.openModal).toHaveBeenCalledWith('daemon', mocks.agents[0], { focusSection: 'basics' })
+  })
+
+  it('edits the built-in agent directly once a daemon exists', async () => {
+    mocks.daemons = [{ daemonId: 'dmn_1', status: 'online' }]
+    await render()
+    act(() => run({ kind: 'agent' }))
+    expect(mocks.openModal).toHaveBeenCalledWith('editAgent', mocks.agents[0], { focusSection: 'basics' })
+  })
+
+  it('falls back to the create dialog for an org with no agent row at all', async () => {
+    mocks.agents = []
+    await render()
+    act(() => run({ kind: 'agent' }))
+    expect(mocks.openModal).toHaveBeenCalledWith('agent')
+  })
+})

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -47,8 +47,6 @@ export function useGsActions() {
   const runAction = useCallback(
     (action: GsAction) => {
       switch (action.kind) {
-        case 'daemon':
-          return openModal('daemon')
         case 'agent':
           return builtinAgent ? openModal('editAgent', builtinAgent, { focusSection: 'basics' }) : openModal('agent')
         case 'slack': {

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -34,7 +34,7 @@ import { PlatformMark } from '@/components/marks'
 
 /** The action-runner + the agent the agent-scoped steps act on, wired to the live console. */
 export function useGsActions() {
-  const { agents } = useConsoleData()
+  const { agents, daemons } = useConsoleData()
   const { orgPath } = useOrgs()
   const { openModal } = useModal()
   const router = useRouter()
@@ -48,7 +48,14 @@ export function useGsActions() {
     (action: GsAction) => {
       switch (action.kind) {
         case 'agent':
-          return builtinAgent ? openModal('editAgent', builtinAgent, { focusSection: 'basics' }) : openModal('agent')
+          if (!builtinAgent) return openModal('agent')
+          // Same chain the Agents / Agent detail "Add daemon" chips use (preset-agents.md
+          // §3.4): with no daemon in the org the edit modal's picker would offer only "No
+          // daemon", so mint one first and chain back into the edit dialog, where the
+          // fresh (and only) daemon is auto-preselected.
+          return daemons.length === 0
+            ? openModal('daemon', builtinAgent, { focusSection: 'basics' })
+            : openModal('editAgent', builtinAgent, { focusSection: 'basics' })
         case 'slack': {
           // The action targets the built-in preset; honor it — agents[0] is commonly an
           // older custom agent in backfilled orgs, and the manual fallback must not
@@ -79,7 +86,7 @@ export function useGsActions() {
           return router.push(orgPath('/settings#session-access'))
       }
     },
-    [openModal, router, orgPath, firstAgent, builtinAgent, agents]
+    [openModal, router, orgPath, firstAgent, builtinAgent, agents, daemons]
   )
 
   return { runAction, firstAgent }

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -12,13 +12,9 @@ const mocks = vi.hoisted(() => ({
   members: [] as Array<Record<string, unknown>>,
   agentsLoading: false,
   daemonsLoading: false,
-  provisionDaemon: vi.fn(),
-  reconnectDaemon: vi.fn(),
-  deleteDaemon: vi.fn(),
   updateAgent: vi.fn(),
   moveAgent: vi.fn(),
   refresh: vi.fn(),
-  refreshDaemons: vi.fn(),
   push: vi.fn(),
   skipOnboarding: vi.fn()
 }))
@@ -36,13 +32,9 @@ vi.mock('@/lib/data-context', () => ({
     members: mocks.members,
     agentsLoading: mocks.agentsLoading,
     daemonsLoading: mocks.daemonsLoading,
-    provisionDaemon: mocks.provisionDaemon,
-    reconnectDaemon: mocks.reconnectDaemon,
-    deleteDaemon: mocks.deleteDaemon,
     updateAgent: mocks.updateAgent,
     moveAgent: mocks.moveAgent,
-    refresh: mocks.refresh,
-    refreshDaemons: mocks.refreshDaemons
+    refresh: mocks.refresh
   })
 }))
 // RuntimeSelect pulls the ACP registry context + AgentMark; stub it to the picked value.
@@ -56,7 +48,6 @@ vi.mock('@/lib/onboarding', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/onboarding')>()
   return { ...actual, skipOnboarding: mocks.skipOnboarding }
 })
-vi.mock('@/lib/daemon-commands', () => ({ daemonCommands: (command: string) => ({ run: command, login: command }) }))
 vi.mock('@/components/console/GettingStartedChecklist', () => ({
   useGsActions: () => ({ runAction: vi.fn(), firstAgent: mocks.agents[0] }),
   useGithubProfileLinked: () => undefined,
@@ -66,7 +57,9 @@ vi.mock('@/components/console/GettingStartedChecklist', () => ({
   // drops the session-access row on a definitive false).
   useSessionAccessCardAvailable: () => undefined,
   useSlackPlatformAppAvailable: () => true,
-  GsRows: () => <div>rows</div>
+  GsRows: ({ items }: { items: Array<{ key: string; label: string }> }) => (
+    <div>rows {items.map((i) => i.key).join(',')}</div>
+  )
 }))
 vi.mock('@/components/marks', () => ({
   LogoMark: () => <span>logo</span>,
@@ -113,11 +106,7 @@ beforeEach(() => {
   mocks.members = []
   mocks.agentsLoading = false
   mocks.daemonsLoading = false
-  mocks.provisionDaemon.mockReset()
-  mocks.reconnectDaemon.mockReset()
-  mocks.deleteDaemon.mockReset().mockResolvedValue(undefined)
   mocks.refresh.mockReset()
-  mocks.refreshDaemons.mockReset().mockResolvedValue(undefined)
   mocks.updateAgent.mockReset().mockResolvedValue(undefined)
   mocks.moveAgent.mockReset().mockResolvedValue(undefined)
   mocks.push.mockReset()
@@ -132,104 +121,22 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-describe('onboarding — connect step', () => {
-  it('mints a join command on mount when no daemon is online', async () => {
-    mocks.provisionDaemon.mockResolvedValue({ daemonId: 'dmn_new', command: 'agentconnect run' })
+describe('onboarding — checklist reveal', () => {
+  it('reveals the checklist with no daemon step and never provisions one', async () => {
     await render()
-    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
-    expect(host.textContent).toContain('Connect your daemon')
-    expect(host.textContent).toContain('agentconnect run')
-    expect(host.textContent).toContain('Listening for dmn_new')
-  })
-
-  it('reconnects an existing offline daemon instead of provisioning a new one', async () => {
-    mocks.daemons = [{ daemonId: 'offline-1', status: 'offline' }]
-    mocks.reconnectDaemon.mockResolvedValue({ command: 'agentconnect run --resume' })
-    await render()
-    expect(mocks.reconnectDaemon).toHaveBeenCalledWith('offline-1')
-    expect(mocks.provisionDaemon).not.toHaveBeenCalled()
-  })
-
-  it('deletes an unclaimed provisioned daemon when exploring the console instead', async () => {
-    mocks.provisionDaemon.mockResolvedValue({ daemonId: 'dmn_new', command: 'agentconnect run' })
-    await render()
-    await click('Explore the console first')
-    expect(mocks.deleteDaemon).toHaveBeenCalledWith('dmn_new')
-    expect(mocks.skipOnboarding).toHaveBeenCalledWith('acme')
-    expect(mocks.push).toHaveBeenCalledWith('/acme/home')
-  })
-
-  // Partial-load regression: agents resolving first (every org ships the builtin
-  // preset) must NOT trigger a mint while the fleet list is still loading — the
-  // pending response may already contain a connected daemon.
-  it('does not mint while the daemon list is still loading, even with agents loaded', async () => {
-    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
-    mocks.daemonsLoading = true
-    await render()
-    expect(mocks.provisionDaemon).not.toHaveBeenCalled()
-    expect(mocks.reconnectDaemon).not.toHaveBeenCalled()
-  })
-
-  it('offers Retry after a mint failure and re-drives the request', async () => {
-    mocks.provisionDaemon
-      .mockRejectedValueOnce(new Error('cp unreachable'))
-      .mockResolvedValue({ daemonId: 'dmn_new', command: 'agentconnect run' })
-    await render()
-    expect(host.textContent).toContain('cp unreachable')
-    await click('Retry')
-    expect(mocks.refreshDaemons).toHaveBeenCalled()
-    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(2)
-    expect(host.textContent).toContain('agentconnect run')
-  })
-
-  // A failed refresh leaves the stale snapshot — re-arming against it could duplicate
-  // an ambiguously-successful provision. Stay latched, show the error, keep Retry.
-  it('does not re-arm provisioning when the fleet refresh itself fails', async () => {
-    mocks.provisionDaemon.mockRejectedValueOnce(new Error('cp unreachable'))
-    mocks.refreshDaemons.mockRejectedValue(new Error('network down'))
-    await render()
-    await click('Retry')
-    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1) // no second mint
-    expect(host.textContent).toContain('Could not refresh the daemon list')
-  })
-
-  // Ambiguous success: the failed provision actually landed server-side. Retry must
-  // observe the refreshed fleet (the new offline row) and reconnect it — never mint
-  // a second daemon against the stale empty list.
-  it('retries via reconnect when the failed provision succeeded server-side', async () => {
-    mocks.provisionDaemon.mockRejectedValueOnce(new Error('response lost'))
-    mocks.refreshDaemons.mockImplementation(async () => {
-      mocks.daemons = [{ daemonId: 'dmn_ghost', status: 'offline' }]
-    })
-    mocks.reconnectDaemon.mockResolvedValue({ command: 'agentconnect run --resume' })
-    await render()
-    expect(host.textContent).toContain('response lost')
-    await click('Retry')
-    expect(mocks.reconnectDaemon).toHaveBeenCalledWith('dmn_ghost')
-    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('onboarding — daemon online reveal', () => {
-  beforeEach(() => {
-    mocks.daemons = [{ daemonId: 'dmn_new', status: 'online', name: 'edge-1' }]
-  })
-
-  it('reveals the checklist and never provisions a daemon', async () => {
-    await render()
-    expect(mocks.provisionDaemon).not.toHaveBeenCalled()
-    expect(host.textContent).toContain('Your daemon is online')
+    expect(host.textContent).not.toContain('Connect your daemon')
+    expect(host.textContent).toContain('Welcome to AgentConnect')
     expect(host.textContent).toContain('Getting started')
     expect(host.textContent).toContain('rows') // <GsRows/> stub
+    expect(host.textContent).not.toContain('daemon') // no connect-a-daemon row
   })
 
   it('finish stays disabled until every step is done; skip always exits to the console', async () => {
-    await render() // only the daemon step is done → finish disabled
+    await render()
     expect(button('Finish onboarding').disabled).toBe(true)
     await click('Skip for now')
+    expect(mocks.skipOnboarding).toHaveBeenCalledWith('acme')
     expect(mocks.push).toHaveBeenCalledWith('/acme/home')
-    // an online daemon that has connected is never deleted on the way out
-    expect(mocks.deleteDaemon).not.toHaveBeenCalled()
   })
 })
 
@@ -251,10 +158,23 @@ describe('onboarding — configure the built-in agent', () => {
     await render()
     expect(host.textContent).toContain('Configure')
     expect(host.textContent).toContain('runtime-claude') // RuntimeSelect stub, seeded from the daemon
-    expect(host.textContent).not.toContain('Your daemon is online')
+    expect(host.textContent).not.toContain('Welcome to AgentConnect')
+    // the daemon is never shown or chosen here
+    expect(host.textContent).not.toContain('edge-1')
   })
 
-  it('sets the runtime BEFORE moving the agent onto the connected daemon, then reveals', async () => {
+  // No daemon yet (the connect step is gone): runtime/model still save, placement is
+  // simply skipped and waits for the checklist's daemon step.
+  it('saves runtime and model with no daemon, without a placement move', async () => {
+    mocks.daemons = []
+    await render()
+    await click('Save and continue')
+    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude' })
+    expect(mocks.moveAgent).not.toHaveBeenCalled()
+    expect(host.textContent).toContain('Welcome to AgentConnect')
+  })
+
+  it('sets the runtime BEFORE moving the agent onto the org daemon, then reveals', async () => {
     await render()
     await click('Save and continue')
     expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude', model: 'claude-sonnet-4-5' })
@@ -270,6 +190,6 @@ describe('onboarding — configure the built-in agent', () => {
     await render()
     await click('Skip for now')
     expect(mocks.updateAgent).not.toHaveBeenCalled()
-    expect(host.textContent).toContain('Your daemon is online')
+    expect(host.textContent).toContain('Welcome to AgentConnect')
   })
 })

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -1,14 +1,13 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
 import { isAuthConfigured } from '@/lib/auth'
-import { daemonCompletesOnboarding, firstReconnectableDaemonId, skipOnboarding } from '@/lib/onboarding'
-import { daemonCommands } from '@/lib/daemon-commands'
+import { daemonCompletesOnboarding, skipOnboarding } from '@/lib/onboarding'
 import { computeGettingStarted } from '@/lib/getting-started'
 import {
   AddToSlackRow,
@@ -30,22 +29,13 @@ import {
   loginRequiredRuntimeIds
 } from '@/lib/data'
 import type { Agent, DaemonRow } from '@/lib/data'
-import type { DaemonConnectDto } from '@/lib/api'
 
-// Onboarding (design: "AgentConnect Onboarding"). Connecting a daemon is the ONLY
-// blocking step; when one comes online the screen transitions in place and reveals the
-// SAME getting-started checklist the console shows (lib/getting-started.ts). No more
-// 3-step wizard — the remaining steps live in the checklist and follow the user into
-// the console (the corner pill in GettingStarted.tsx). Rendered full-screen (no rail)
-// by the shell on the /onboarding route.
-//
-// The daemon step is inline and functional: it mints a real join command and polls for
-// the daemon to come online (like AddDaemonModal). Not shipped yet, so not shown as
-// "done for you": preset agents + the one-click built-in Bot connect (preset-agents.md
-// §3/§5) — the revealed checklist derives from real state, so "Create your first agent"
-// etc. appear as ordinary open steps until those land.
-
-type DaemonCommand = Pick<DaemonConnectDto, 'daemonId' | 'command'>
+// Onboarding (design: "AgentConnect Onboarding"). Nothing here blocks: the screen
+// configures the org's built-in agent (runtime + model) and then reveals the SAME
+// getting-started checklist the console shows (lib/getting-started.ts). Connecting a
+// daemon is no longer an onboarding step — it lives in the checklist and follows the
+// user into the console (the corner pill in GettingStarted.tsx). Rendered full-screen
+// (no rail) by the shell on the /onboarding route.
 
 export default function OnboardingView() {
   const router = useRouter()
@@ -59,13 +49,9 @@ export default function OnboardingView() {
     members,
     agentsLoading,
     daemonsLoading,
-    provisionDaemon,
-    reconnectDaemon,
-    deleteDaemon,
     updateAgent,
     moveAgent,
-    refresh,
-    refreshDaemons
+    refresh
   } = useConsoleData()
   const { orgPath } = useOrgs()
   const { runAction } = useGsActions()
@@ -78,37 +64,32 @@ export default function OnboardingView() {
   const orgKey = typeof params.slug === 'string' ? params.slug : '-'
   const authOn = isAuthConfigured()
 
-  // A live daemon or a planned relaunch reveals the checklist. Only an unexpected offline
-  // row is eligible for a replacement connect token — it may be a provisioned daemon whose
-  // one-time command was lost on reload; the mint below reconnects it.
-  const daemonReady = daemons.some(daemonCompletesOnboarding)
-  const offlineDaemonId = firstReconnectableDaemonId(daemons)
   const loading = (agentsLoading || daemonsLoading) && daemons.length === 0 && agents.length === 0
 
-  // Once a daemon is serving, configure the org's built-in `agentconnect` preset before
-  // the checklist reveal: auto-assign it to that daemon and let the user pick a runtime +
-  // model (design: the built-in agent replaces "create your first agent"). The preset
-  // ships unplaced (daemon '—', deferred runtime); it's ready once both are set. Older
-  // orgs without the preset just skip straight to the reveal.
+  // First screen: configure the org's built-in `agentconnect` preset — the user picks a
+  // runtime + model (design: the built-in agent replaces "create your first agent"). The
+  // preset ships unplaced with a deferred runtime. If the org already runs a daemon we
+  // place the agent onto it behind the scenes; otherwise placement waits for the
+  // checklist's daemon step. Older orgs without the preset skip straight to the reveal.
   const builtinAgent = agents.find((a) => a.builtin)
   const placementDaemon = daemons.find((d) => d.status === 'online') ?? daemons.find(daemonCompletesOnboarding)
-  const needsAgentSetup = !!builtinAgent && !!placementDaemon && !agentIsPlaced(builtinAgent)
-  const [skipSetup, setSkipSetup] = useState(false)
+  const [setupDone, setSetupDone] = useState(false)
+  const needsAgentSetup = !!builtinAgent && !agentIsPlaced(builtinAgent) && !setupDone
   const [saving, setSaving] = useState(false)
   const [saveErr, setSaveErr] = useState<string | null>(null)
 
   // Runtime becomes mandatory at placement, so set it FIRST, then move onto the daemon
-  // (the CP rejects a move on a runtime-less agent). refresh() flips needsAgentSetup off,
-  // advancing the screen to the reveal on its own.
+  // (the CP rejects a move on a runtime-less agent).
   const saveAgentSetup = async (runtime: string, model: string) => {
-    if (!builtinAgent || !placementDaemon) return
+    if (!builtinAgent) return
     setSaving(true)
     setSaveErr(null)
     try {
       await updateAgent(builtinAgent.id, { runtime, ...(model ? { model } : {}) })
       // Onboarding places onto a concrete machine; the pool is chosen from the agent editor.
-      await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: placementDaemon.daemonId })
+      if (placementDaemon) await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: placementDaemon.daemonId })
       await refresh()
+      setSetupDone(true)
     } catch (e) {
       setSaveErr(e instanceof Error ? e.message : String(e))
     } finally {
@@ -116,103 +97,10 @@ export default function OnboardingView() {
     }
   }
 
-  // --- Daemon provisioning (mirrors AddDaemonModal / the old wizard step 0) ----------
-  const [connect, setConnect] = useState<DaemonCommand | null>(null)
-  const [mintErr, setMintErr] = useState<string | null>(null)
-  const [elapsed, setElapsed] = useState(0)
-  const [copied, setCopied] = useState(false)
-  // Bumped by the error state's Retry — re-arms the mint effect after a failure.
-  const [mintAttempt, setMintAttempt] = useState(0)
-  const provisioned = useRef(false)
-  const commandPending = useRef<Promise<DaemonCommand> | null>(null)
-  const createdByWizard = useRef(false)
-  const connectedOnce = useRef(false)
-
-  // Mint only once BOTH lists have settled: agents can resolve first (every org ships
-  // the builtin preset, so `loading` clears on partial data) while the pending fleet
-  // response still contains a connected daemon — minting against the empty snapshot
-  // would provision a duplicate. Duplicate-safe on retry too: a provision that
-  // succeeded server-side surfaces as an offline row on the next refresh, which routes
-  // the retry through reconnect instead of a second provision.
-  useEffect(() => {
-    if (agentsLoading || daemonsLoading || daemonReady || provisioned.current) return
-    provisioned.current = true
-    setMintErr(null)
-    createdByWizard.current = !offlineDaemonId
-    const command: Promise<DaemonCommand> = offlineDaemonId
-      ? reconnectDaemon(offlineDaemonId).then((minted) => ({ daemonId: offlineDaemonId, command: minted.command }))
-      : provisionDaemon()
-    commandPending.current = command
-    command.then(setConnect).catch((e) => setMintErr(e instanceof Error ? e.message : String(e)))
-  }, [agentsLoading, daemonsLoading, daemonReady, offlineDaemonId, provisionDaemon, reconnectDaemon, mintAttempt])
-
-  // A transient mint failure must not strand the single blocking step. AWAIT the fleet
-  // refresh before re-arming: if the failed provision actually succeeded server-side
-  // (response lost), the refreshed list contains that daemon as an offline row, so the
-  // re-run reconnects it via `offlineDaemonId` instead of minting a duplicate. A FAILED
-  // refresh must NOT re-arm — the stale snapshot is exactly what could duplicate an
-  // ambiguously-successful provision; stay latched and keep the Retry on screen.
-  const retryMint = async () => {
-    setMintErr(null)
-    try {
-      await refreshDaemons()
-    } catch {
-      setMintErr('Could not refresh the daemon list — check your connection and retry.')
-      return
-    }
-    provisioned.current = false
-    commandPending.current = null
-    setMintAttempt((n) => n + 1)
-  }
-
-  // Poll until the daemon connects; tick the elapsed timer while waiting.
-  useEffect(() => {
-    if (daemonReady) {
-      connectedOnce.current = true
-      return
-    }
-    if (!connect) return
-    const poll = setInterval(refresh, 3000)
-    const tick = setInterval(() => setElapsed((s) => s + 1), 1000)
-    return () => {
-      clearInterval(poll)
-      clearInterval(tick)
-    }
-  }, [connect, daemonReady, refresh])
-
-  // Drop only a wizard-created row that was never claimed. Once it has connected or
-  // hosts an agent, leaving onboarding must never turn into a deletion.
-  const cleanupPending = async () => {
-    const pending = connect ?? (await commandPending.current?.catch(() => null))
-    const row = pending ? daemons.find((d) => d.daemonId === pending.daemonId) : undefined
-    const hostsAgent = pending ? agents.some((a) => a.daemon === pending.daemonId) : false
-    const shouldDelete =
-      pending && createdByWizard.current && !connectedOnce.current && !hostsAgent && row?.status !== 'online'
-    try {
-      if (shouldDelete) await deleteDaemon(pending.daemonId)
-    } catch {
-      /* best-effort — an unclaimed provisioned row is harmless */
-    }
-  }
   const goConsole = () => {
-    void cleanupPending()
     skipOnboarding(orgKey)
     router.push(orgPath('/home'))
   }
-
-  const cmd = connect ? daemonCommands(connect.command).run : null
-  const copy = async () => {
-    if (!cmd) return
-    try {
-      await navigator.clipboard.writeText(cmd)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1700)
-    } catch {
-      /* clipboard unavailable */
-    }
-  }
-  const listeningId = connect?.daemonId ?? offlineDaemonId ?? ''
-  const elapsedLabel = `${Math.floor(elapsed / 60)}:${String(elapsed % 60).padStart(2, '0')}`
 
   // The shell renders the full-screen frame + slim top bar (logo · theme · user menu)
   // for the /onboarding route; this is just the centered content.
@@ -220,31 +108,19 @@ export default function OnboardingView() {
     <div className="flex min-h-full items-center justify-center px-5 py-10">
       {loading ? (
         <LoadingState fill />
-      ) : !daemonReady ? (
-        <ConnectDaemon
-          cmd={cmd}
-          mintErr={mintErr}
-          copied={copied}
-          onCopy={copy}
-          onRetry={() => void retryMint()}
-          listeningId={listeningId}
-          elapsedLabel={elapsedLabel}
-          onExplore={goConsole}
-        />
-      ) : needsAgentSetup && !skipSetup ? (
+      ) : needsAgentSetup ? (
         <ConfigureAgent
           agent={builtinAgent!}
-          daemon={placementDaemon!}
+          daemon={placementDaemon}
           saving={saving}
           err={saveErr}
           onSave={saveAgentSetup}
-          onSkip={() => setSkipSetup(true)}
+          onSkip={() => setSetupDone(true)}
         />
       ) : (
         <RevealChecklist
           gs={computeGettingStarted({
             agents,
-            daemons,
             integrations,
             sessions: allSessions,
             members,
@@ -263,122 +139,10 @@ export default function OnboardingView() {
   )
 }
 
-// --- Phase 1: connect your daemon (the one blocking step) ----------------------------
-function ConnectDaemon({
-  cmd,
-  mintErr,
-  copied,
-  onCopy,
-  onRetry,
-  listeningId,
-  elapsedLabel,
-  onExplore
-}: {
-  cmd: string | null
-  mintErr: string | null
-  copied: boolean
-  onCopy: () => void
-  onRetry: () => void
-  listeningId: string
-  elapsedLabel: string
-  onExplore: () => void
-}) {
-  return (
-    <div className="flex w-full max-w-[560px] flex-col gap-[22px]">
-      <div className="flex flex-col items-center gap-[11px] text-center">
-        <span className="flex h-11 w-11 items-center justify-center rounded-[11px] border border-(--border-default) bg-(--surface-card) text-(--brand) shadow-(--shadow-xs)">
-          <Icon name="server" size={21} />
-        </span>
-        <div className="font-mono text-[11px] font-semibold uppercase leading-none tracking-[.12em] text-(--brand)">
-          Setup
-        </div>
-        <h1 className="font-sans text-[28px] font-semibold leading-[1.2] tracking-[-.02em] text-(--text-primary)">
-          Connect your daemon
-        </h1>
-        <p className="max-w-[450px] font-sans text-[14.5px] font-normal leading-[1.55] text-(--text-secondary)">
-          A daemon runs your agents on your own hardware. Run this one command wherever you want them to run — it
-          connects to AgentConnect and keeps running.
-        </p>
-      </div>
-
-      {/* Dark terminal block — the real minted join command */}
-      <div className="overflow-hidden rounded-[10px] border border-(--gray-800) bg-(--gray-1000) shadow-(--shadow-xs)">
-        <div className="flex items-center gap-2 border-b border-(--gray-800) py-[9px] pr-[10px] pl-[13px]">
-          <Icon name="terminal" size={13} color="var(--text-inverse-dim)" />
-          <span className="font-mono text-[11px] font-medium leading-normal tracking-[.02em] text-(--text-inverse-dim)">
-            one command · macOS, Linux, WSL
-          </span>
-          <button
-            type="button"
-            onClick={onCopy}
-            disabled={!cmd}
-            className="ml-auto inline-flex h-[26px] cursor-pointer items-center gap-[6px] rounded-md border border-white/15 bg-white/5 px-[9px] font-mono text-[11px] font-medium text-[#e6ebf1] hover:border-white/25 hover:bg-white/10 disabled:cursor-default disabled:opacity-50"
-          >
-            <Icon name={copied ? 'check' : 'copy'} size={12} />
-            {copied ? 'Copied' : 'Copy'}
-          </button>
-        </div>
-        <div className="flex gap-[9px] break-all p-[15px] font-mono text-[13px] leading-[1.6] text-[#cdd6e0]">
-          {cmd ? (
-            <>
-              <span className="text-(--magenta-300)">$</span>
-              <span>{cmd}</span>
-            </>
-          ) : mintErr ? (
-            <span className="flex flex-wrap items-center gap-2">
-              <span className="text-(--status-error)">Could not provision a key — {mintErr}</span>
-              <button
-                type="button"
-                onClick={onRetry}
-                className="inline-flex h-[24px] cursor-pointer items-center gap-[5px] rounded-md border border-white/15 bg-white/5 px-2 font-mono text-[11px] font-medium text-[#e6ebf1] hover:border-white/25 hover:bg-white/10"
-              >
-                <Icon name="refresh-cw" size={11} />
-                Retry
-              </button>
-            </span>
-          ) : (
-            <span className="text-(--text-inverse-dim)">Minting key…</span>
-          )}
-        </div>
-      </div>
-
-      {/* Waiting card — auto-continues when the daemon comes online */}
-      <div className="flex items-center gap-[13px] rounded-[10px] border border-(--border-default) bg-(--surface-card) px-4 py-[14px] shadow-(--shadow-xs)">
-        <span className="h-[18px] w-[18px] flex-none animate-spin rounded-full border-2 border-(--gray-200) border-t-(--brand)" />
-        <div className="min-w-0 flex-1">
-          <div className="font-sans text-[13.5px] font-medium leading-normal text-(--text-primary)">
-            Waiting for your daemon to come online…
-          </div>
-          <div className="mt-[2px] font-mono text-[11.5px] leading-normal text-(--text-tertiary)">
-            {listeningId ? `Listening for ${listeningId} · ` : ''}this page continues on its own
-          </div>
-        </div>
-        <span className="flex-none font-mono text-[12px] tabular-nums text-(--text-tertiary)">{elapsedLabel}</span>
-      </div>
-
-      <div className="flex flex-col items-center gap-3">
-        <a
-          href="https://docs.agentconnect.md/docs/install-the-daemon"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-[6px] font-sans text-[12.5px] text-(--text-tertiary) no-underline hover:text-(--brand)"
-        >
-          Daemon not showing up? Read the setup guide
-          <Icon name="arrow-up-right" size={13} />
-        </a>
-        <Button variant="secondary" size="sm" onClick={onExplore}>
-          Explore the console first
-          <Icon name="arrow-right" size={14} />
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-// --- Phase 1.5: place + configure the built-in agent on the just-connected daemon ----
-// Daemon is fixed (the one we just brought online); the user only picks runtime + model.
-// Mirrors AddAgentModal's Daemon/Runtime/Model row: runtime ids come from the daemon's
-// reported profiles (else the static fallback), models from the chosen runtime's profile.
+// --- Phase 1: configure the built-in agent -------------------------------------------
+// The user only picks runtime + model. Mirrors AddAgentModal's Runtime/Model row:
+// runtime ids come from the org's daemon when there is one (else the static fallback),
+// models from the chosen runtime's profile.
 function ConfigureAgent({
   agent,
   daemon,
@@ -388,23 +152,23 @@ function ConfigureAgent({
   onSkip
 }: {
   agent: Agent
-  daemon: DaemonRow
+  daemon?: DaemonRow
   saving: boolean
   err: string | null
   onSave: (runtime: string, model: string) => void
   onSkip: () => void
 }) {
-  const runtimeIds = daemon.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
+  const runtimeIds = daemon?.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
   // Logged-out runtimes are marked, not blocked; the default just prefers a signed-in
   // one so a first agent starts answerable where the daemon allows it.
-  const runtimesNeedingLogin = loginRequiredRuntimeIds(daemon)
+  const runtimesNeedingLogin = daemon ? loginRequiredRuntimeIds(daemon) : []
   const defaultRuntime = runtimeIds.find((id) => !runtimesNeedingLogin.includes(id)) ?? runtimeIds[0] ?? ''
   const [runtime, setRuntime] = useState('') // '' = untouched
   const effectiveRuntime = runtime && runtimeIds.includes(runtime) ? runtime : defaultRuntime
-  const models = daemon.runtimeModels.find((r) => r.runtime === effectiveRuntime)?.models ?? []
+  const models = daemon?.runtimeModels.find((r) => r.runtime === effectiveRuntime)?.models ?? []
   const [model, setModel] = useState('')
   // Keep the selection valid as the runtime (and so the model set) changes.
-  const selectedModel = models.includes(model) ? model : preferredModelFor(daemon, effectiveRuntime)
+  const selectedModel = models.includes(model) ? model : daemon ? preferredModelFor(daemon, effectiveRuntime) : ''
 
   return (
     <div className="flex w-full max-w-[520px] flex-col gap-[22px]">
@@ -419,21 +183,11 @@ function ConfigureAgent({
           Configure {agentLabel(agent)}
         </h1>
         <p className="max-w-[430px] font-sans text-[14.5px] font-normal leading-[1.55] text-(--text-secondary)">
-          Your org&rsquo;s built-in agent runs on the daemon you just connected. Pick a runtime and model, and
-          it&rsquo;s ready to work.
+          Every org ships with a built-in agent. Pick the runtime and model it should use, and it&rsquo;s ready to work.
         </p>
       </div>
 
       <div className="flex flex-col gap-[14px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-xs)">
-        <div className="fld">
-          <span className="fldlbl">Runs on</span>
-          <div className="inp cursor-not-allowed" title="Set to the daemon you just connected">
-            <span className="truncate text-(--text-primary)">{daemon.name}</span>
-            <span className="ml-auto flex-none font-sans text-[11.5px] leading-none text-(--text-tertiary)">
-              just connected
-            </span>
-          </div>
-        </div>
         <div className="grid grid-cols-1 gap-[14px] desktop:grid-cols-2">
           <div className="fld">
             <span className="fldlbl">Runtime</span>
@@ -511,7 +265,7 @@ function ConfigureAgent({
   )
 }
 
-// --- Phase 2: daemon online → the same checklist the console shows -------------------
+// --- Phase 2: the same checklist the console shows -----------------------------------
 function RevealChecklist({
   gs,
   slackOneClick,
@@ -523,7 +277,7 @@ function RevealChecklist({
   runAction: (action: import('@/lib/getting-started').GsAction) => void
   onFinish: () => void
 }) {
-  const [expanded, setExpanded] = useState<string | null>('daemon')
+  const [expanded, setExpanded] = useState<string | null>('agent')
   return (
     <div className="ac-rise flex w-full max-w-[580px] flex-col gap-4">
       <div className="flex flex-col items-center gap-[10px] text-center">
@@ -531,11 +285,10 @@ function RevealChecklist({
           <Icon name="check" size={23} />
         </span>
         <h1 className="font-sans text-[24px] font-semibold leading-[1.2] tracking-[-.02em] text-(--text-primary)">
-          Your daemon is online
+          Welcome to AgentConnect
         </h1>
         <p className="max-w-[440px] font-sans text-[14px] font-normal leading-[1.55] text-(--text-secondary)">
-          Connected and ready — here&rsquo;s your getting-started checklist. Work through the rest any time; it follows
-          you into the console.
+          Here&rsquo;s your getting-started checklist. Work through the rest any time; it follows you into the console.
         </p>
       </div>
 

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { computeGettingStarted } from './getting-started'
-import type { Agent, DaemonRow, IntegrationRow, Session } from '@/lib/data'
+import type { Agent, IntegrationRow, Session } from '@/lib/data'
 import type { MemberDto } from '@/lib/api'
 
 const agent = (over: Partial<Agent> = {}): Agent =>
@@ -13,8 +13,7 @@ const agent = (over: Partial<Agent> = {}): Agent =>
     workspace: { mode: 'scratch' },
     ...over
   }) as Agent
-const daemon = (status: DaemonRow['status']): DaemonRow => ({ daemonId: 'd1', status }) as DaemonRow
-const empty = { agents: [], daemons: [], integrations: [], sessions: [], members: [], authOn: true }
+const empty = { agents: [], integrations: [], sessions: [], members: [], authOn: true }
 
 describe('computeGettingStarted', () => {
   it('starts all-incomplete for a fresh org and reports progress', () => {
@@ -23,16 +22,15 @@ describe('computeGettingStarted', () => {
     // see its `optional` comment in getting-started.ts), so it contributes to both
     // done and total and never moves the fraction.
     expect(gs.done).toBe(1)
-    expect(gs.total).toBe(7) // 5 core + session-access + invite (auth mode)
-    expect(gs.fraction).toBe(1 / 7)
+    expect(gs.total).toBe(6) // 4 core + session-access + invite (auth mode)
+    expect(gs.fraction).toBe(1 / 6)
     expect(gs.allDone).toBe(false)
   })
 
-  it('orders the steps per the design: daemon, agent, slack, github, conversation, session-access, invite', () => {
+  it('orders the steps per the design: agent, slack, github, conversation, session-access, invite', () => {
     // The "Runtime signed in" step is deferred until the explicit probe-status
     // signal ships (neither authRequired nor advertised models encode readiness).
     expect(computeGettingStarted(empty).items.map((i) => i.key)).toEqual([
-      'daemon',
       'agent',
       'slack',
       'github',
@@ -43,7 +41,7 @@ describe('computeGettingStarted', () => {
   })
 
   it('drops the invite AND session-access items in no-auth mode (no /settings there)', () => {
-    expect(computeGettingStarted({ ...empty, authOn: false }).total).toBe(5)
+    expect(computeGettingStarted({ ...empty, authOn: false }).total).toBe(4)
     expect(computeGettingStarted({ ...empty, authOn: false }).items.some((i) => i.key === 'invite')).toBe(false)
     expect(computeGettingStarted({ ...empty, authOn: false }).items.some((i) => i.key === 'session-access')).toBe(false)
   })
@@ -62,14 +60,6 @@ describe('computeGettingStarted', () => {
     // undefined (probe in flight / failed) keeps the step — same convention as githubEnabled
     expect(has(undefined)).toBe(true)
     expect(has(true)).toBe(true)
-  })
-
-  it('marks daemon done for any registered daemon, connected or not', () => {
-    const done = (rows: DaemonRow[]) =>
-      computeGettingStarted({ ...empty, daemons: rows }).items.find((i) => i.key === 'daemon')!.done
-    expect(done([])).toBe(false)
-    expect(done([daemon('offline')])).toBe(true)
-    expect(done([daemon('online')])).toBe(true)
   })
 
   it('marks agent done only once some agent is placed (daemon + runtime)', () => {
@@ -168,7 +158,6 @@ describe('computeGettingStarted', () => {
   it('reaches allDone with a full ring when every signal is satisfied', () => {
     const gs = computeGettingStarted({
       agents: [agent({ workspace: { mode: 'github', repo: 'acme/x' } as Agent['workspace'], hookKinds: ['github'] })],
-      daemons: [daemon('online')],
       integrations: [{ platform: 'slack', name: 's' } as IntegrationRow],
       sessions: [{ id: 's1', statusLabel: 'completed' } as Session],
       members: [{ userId: 'u1' } as MemberDto, { userId: 'u2' } as MemberDto],

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -4,8 +4,9 @@
 // item is incomplete and vanishes for good once the list is complete — there is no
 // manual dismiss, so the only state this module owns is the pure derivation.
 //
-// Steps in the design's order: daemon → meet your agent → Slack → GitHub+repo (one
-// merged step) → first conversation → invite. Still not derivable client-side (left
+// Steps in the design's order: meet your agent → Slack → GitHub+repo (one merged
+// step) → first conversation → invite. Connecting a daemon is no longer a step —
+// agents are placed from the agent editor and onboarding never asks for one. Still not derivable client-side (left
 // out rather than faked, preset-agents.md §6.2): the "Runtime signed in"
 // needs-attention item — neither `authRequired` (absence also means probe
 // pending/failed) nor advertised models (a usable runtime may legitimately have no
@@ -14,13 +15,12 @@
 // "Ask agentconnect" automation (§6.3/§6.4 delegated writes).
 
 import { agentIsPlaced } from './data'
-import type { Agent, DaemonRow, IntegrationRow, Session } from './data'
+import type { Agent, IntegrationRow, Session } from './data'
 import type { MemberDto } from './api'
 
 // What the item's primary CTA drives. The component maps kind → a real handler
 // (open a modal, route to a page) so this stays pure and testable.
 export type GsAction =
-  | { kind: 'daemon' }
   | { kind: 'agent' }
   | { kind: 'slack'; agentId: string | null }
   | { kind: 'github'; agentId: string | null }
@@ -62,7 +62,6 @@ const RING_CIRCUMFERENCE = 2 * Math.PI * 10.5
 
 export function computeGettingStarted(input: {
   agents: Agent[]
-  daemons: DaemonRow[]
   integrations: IntegrationRow[]
   sessions: Session[]
   members: MemberDto[]
@@ -90,7 +89,6 @@ export function computeGettingStarted(input: {
 }): GettingStarted {
   const {
     agents,
-    daemons,
     integrations,
     sessions,
     members,
@@ -111,16 +109,6 @@ export function computeGettingStarted(input: {
   const placedAgent = builtin ? agentIsPlaced(builtin) : agents.some(agentIsPlaced)
 
   const items: GsItem[] = [
-    {
-      key: 'daemon',
-      label: 'Connect a daemon',
-      expl: 'Run one command on the host where your agents should live. It stays connected and runs agents locally over ACP.',
-      // Registered is enough — an offline daemon has still been set up, and a laptop
-      // that's merely asleep shouldn't un-tick a step the user already completed.
-      done: daemons.length > 0,
-      ctaLabel: 'Add a daemon',
-      action: { kind: 'daemon' }
-    },
     {
       key: 'agent',
       label: 'Set up your agent',

--- a/packages/web/src/lib/onboarding.test.ts
+++ b/packages/web/src/lib/onboarding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { daemonCompletesOnboarding, firstReconnectableDaemonId, needsOnboarding } from './onboarding'
+import { daemonCompletesOnboarding, needsOnboarding } from './onboarding'
 
 describe('needsOnboarding', () => {
   it('recovers a fresh org (only the unplaced built-in preset, daemon offline)', () => {
@@ -20,7 +20,6 @@ describe('needsOnboarding', () => {
   it('keeps a fresh org initialized during a planned daemon relaunch', () => {
     const restarting = { daemonId: 'edge-1', status: 'offline' as const, lifecycleStatus: 'restarting' as const }
     expect(daemonCompletesOnboarding(restarting)).toBe(true)
-    expect(firstReconnectableDaemonId([restarting])).toBeUndefined()
     expect(needsOnboarding(false, false, false, daemonCompletesOnboarding(restarting), false)).toBe(false)
   })
 })

--- a/packages/web/src/lib/onboarding.ts
+++ b/packages/web/src/lib/onboarding.ts
@@ -14,11 +14,6 @@ export function daemonCompletesOnboarding(daemon: OnboardingDaemon): boolean {
   return daemon.status === 'online' || daemon.lifecycleStatus != null
 }
 
-/** Only an unexpectedly non-serving daemon is eligible for a replacement connect token. */
-export function firstReconnectableDaemonId(daemons: readonly OnboardingDaemon[]): string | undefined {
-  return daemons.find((daemon) => !daemonCompletesOnboarding(daemon))?.daemonId
-}
-
 // Every org now ships the built-in `agentconnect` preset UNPLACED, so "no agents" no
 // longer marks a fresh org. Initialized = a serving daemon OR a placed/configured agent
 // (agentIsPlaced) exists; otherwise the org is fresh and gets the full-screen wizard.


### PR DESCRIPTION
## What changed

**Onboarding no longer asks for a daemon.** The full-screen wizard's blocking "Connect your daemon" phase is removed, and with it the join-command mint, the copy/retry affordances, the come-online polling, and the unclaimed-daemon cleanup on exit. The wizard now opens directly on the built-in agent's configuration and then reveals the getting-started checklist.

**The configure-agent step lost its daemon field.** Only Runtime + Model remain — the read-only "Runs on · just connected" row is gone. If the org already runs a daemon the agent is still placed onto it behind the scenes (runtime first, then the move — the CP rejects a move on a runtime-less agent); with no daemon, runtime/model still save and placement waits for the agent editor.

**"Connect a daemon" is removed from the checklist itself**, not just from onboarding: the item, the `{ kind: 'daemon' }` `GsAction` variant, its `openModal('daemon')` case, and the now-unused `daemons` input to `computeGettingStarted`. The list is agent → Slack → GitHub → first conversation (→ session access / invite).

**The corner pill can be dismissed directly.** It becomes a container with the existing label button plus an `x` that runs the same per-device skip the drawer offers (`ac.gs-skipped`), so the checklist can be hidden without opening the drawer first. `openGettingStarted()` from the account menu still brings it back.

## Why

Connecting a daemon is no longer something a new org should be blocked on, or nudged about, during first-run setup — so it stops being an onboarding phase, stops being a checklist row, and the passive nudge itself becomes dismissible in one click.

## Notes for the reviewer

- `firstReconnectableDaemonId` in `lib/onboarding.ts` had no remaining caller and was deleted; `daemonCompletesOnboarding` stays (still used by `use-onboarding-redirect.ts` and for picking the placement daemon).
- `use-onboarding-redirect.ts` is unchanged: it still treats "a daemon exists in any of the caller's orgs" as an initialized org, so an org that already has a daemon but an unconfigured built-in agent will not route to onboarding. Happy to narrow that to `hasPlacedAgent` in a follow-up if that is the intent.
- Verification: `pnpm --filter @agentconnect.md/web test` (177 files / 1958 tests), `typecheck`, and `lint` all pass. The pill's visual change was not screenshotted against a running stack — it needs a CP plus an org with data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)