### PR TITLE
feat(relay): forward the Slack agent-session stop to the owning daemon

### DIFF
--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -36,6 +36,7 @@ const EXEMPT: Record<string, string> = {
   postIfThreadExists: 'private Slack root-existence guard',
   postChatMessage: 'private shared post boundary behind postMessage/postBlocks',
   setSessionLifecycle: 'private agent-session lifecycle call, behind setStatus',
+  agentSessionStopped: 'native stop button (Bolt event / relay-forwarded), no arena equivalent',
   shareWithIdentity: 'private identity-carrying upload path, behind uploadFile',
   putUploadBytes: 'private step 2 of the external upload, behind uploadFile',
   completeUpload: 'private step 3 of the external upload, behind uploadFile',

--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -6,7 +6,6 @@ import {
   slackOAuthRedirectUri,
   SLACK_BOT_SCOPES,
   SLACK_BOT_EVENTS,
-  SLACK_SOCKET_ONLY_BOT_EVENTS,
   DEFAULT_SLACK_APP_NAME
 } from './slack-manifest.js'
 import { SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
@@ -52,12 +51,10 @@ describe('buildInstallManifest', () => {
     expect(m.settings.event_subscriptions.request_url).toBe('https://relay.example/slack/events')
     expect(m.settings.interactivity.request_url).toBe('https://relay.example/slack/interactions')
     expect(m.settings.interactivity.message_menu_options_url).toBe('https://relay.example/slack/interactions')
-    // Same events MINUS the socket-only ones: the relay's ingress never forwards those, so
-    // advertising one here would render a control this transport cannot answer.
-    expect(m.settings.event_subscriptions.bot_events).toEqual(
-      [...SLACK_BOT_EVENTS].filter((event) => !SLACK_SOCKET_ONLY_BOT_EVENTS.includes(event))
-    )
-    expect(m.settings.event_subscriptions.bot_events).not.toContain('agent_session_stopped')
+    // Still carries the same scopes + events (only the transport differs) — the relay forwards
+    // the agent-session stop to the owning daemon, so the subscription is answerable here too.
+    expect(m.settings.event_subscriptions.bot_events).toEqual([...SLACK_BOT_EVENTS])
+    expect(m.settings.event_subscriptions.bot_events).toContain('agent_session_stopped')
   })
 
   it('falls back to the default app name when blank', () => {
@@ -112,9 +109,11 @@ describe('buildInstallManifest', () => {
   it('pins the exact bot events (drift guard)', () => {
     expect([...SLACK_BOT_EVENTS]).toEqual([
       'agent_session_stopped',
+      'agent_session_title_changed',
       'app_mention',
       'app_uninstalled',
       'assistant_thread_started',
+      'assistant_thread_context_changed',
       'message.channels',
       'message.groups',
       'message.im',

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -18,20 +18,16 @@ import {
   PLATFORM_APP_DESCRIPTION,
   SLACK_BOT_EVENTS,
   SLACK_BOT_SCOPES,
-  slackBotEvents,
   slackEventsRequestUrl,
-  slackInteractionsRequestUrl,
-  SLACK_SOCKET_ONLY_BOT_EVENTS
+  slackInteractionsRequestUrl
 } from '@agentconnect.md/protocol/slack-app-manifest'
 
 export {
   DEFAULT_SLACK_APP_NAME,
   SLACK_BOT_EVENTS,
   SLACK_BOT_SCOPES,
-  slackBotEvents,
   slackEventsRequestUrl,
-  slackInteractionsRequestUrl,
-  SLACK_SOCKET_ONLY_BOT_EVENTS
+  slackInteractionsRequestUrl
 }
 
 /**
@@ -211,7 +207,7 @@ export function mergeManagedSlackManifest(
       event_subscriptions: {
         ...managedEvents,
         ...currentEvents,
-        bot_events: unionStrings(currentEvents.bot_events, slackBotEvents(http)),
+        bot_events: unionStrings(currentEvents.bot_events, SLACK_BOT_EVENTS),
         // HTTP mode: force the relay pool's Events API request_url (a socket refresh
         // leaves the exported value — there is none — untouched).
         ...(http ? { request_url: slackEventsRequestUrl(httpRelayBase!) } : {})

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6261,6 +6261,12 @@ export class Daemon {
       void conn.openStatusModal(payload.triggerId, rec.key, privateMetadata)
       return { msgId: msg.msgId, accepted: true }
     }
+    // Conversation-addressed like the shortcut above: the Slack event names no session, so the
+    // connection resolves the one this thread owns and runs the same cancel + transition.
+    if (payload.kind === 'agent-session-stopped') {
+      await conn.agentSessionStopped(payload.channelId, payload.threadTs, msg.userId)
+      return { msgId: msg.msgId, accepted: true }
+    }
 
     const rec = await this.store.getSession(msg.sessionKey)
     if (!rec || rec.agentId !== msg.agentId || rec.platform !== 'slack') {

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -448,12 +448,17 @@ export class ConnectionReconciler {
       let conn = this.slackSharedPool.find(slackSharedKey(group))
       let bound = false
       if (!conn) {
-        conn = new SlackConnection(
+        // `created` (not `conn`) so the shortcut resolver reads this exact connection's bindings.
+        const created: SlackConnection = new SlackConnection(
           {
             group,
             sendOnly: true,
             newTraceId: () => randomUUID(),
             onMessage: () => {}, // never called (relay owns inbound)
+            // Registered on this transport too: the relay forwards the native Stop, which resolves
+            // the conversation's session the same way a Socket Mode stop does.
+            onMessageShortcut: (shortcut) =>
+              this.host.slackShortcutSession(shortcut, this.host.srcIntegrationIds(created)),
             onStatusAction: (a) => this.host.handleStatusAction(a),
             onStatusInfo: (key) => this.host.statusInfoForKey(key),
             onPermissionChoice: (a) => this.host.handlePermissionChoice(a),
@@ -462,6 +467,7 @@ export class ConnectionReconciler {
           },
           this.host.slackAppFactory()
         )
+        conn = created
         try {
           await conn.start()
           this.slackSharedPool.add(conn)

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -763,21 +763,11 @@ export class SlackConnection implements PlatformConnection {
       const thread = this.rememberAssistantThread(event as AssistantThreadStartedEvent)
       if (thread) log?.debug(`slack: assistant thread started ch=${thread.channel} thread=${thread.threadTs}`)
     })
-    // Native stop button. Slack leaves the session in `processing`, so interrupt the turn then transition it.
+    // Native stop button, Socket Mode arm. The HTTP arm reaches the same method through the relay.
     this.app.event('agent_session_stopped', async ({ event }) => {
       const ev = event as { channel?: string; thread_ts?: string; user?: string }
-      const channel = ev.channel
-      const thread = ev.thread_ts
-      if (!channel || !thread) return
-      log?.debug(`slack: agent session stopped ch=${channel} thread=${thread} user=${ev.user ?? '?'}`)
-      const sessionKey = await this.deps.onMessageShortcut?.({ channel, thread, userId: ev.user })
-      if (sessionKey)
-        this.deps.onStatusAction?.({
-          kind: 'cancel',
-          sessionKey,
-          ...(ev.user ? { actor: { userId: ev.user } } : {})
-        })
-      await this.queue.enqueue(() => this.setSessionLifecycle(channel, thread, 'active'))
+      if (!ev.channel || !ev.thread_ts) return
+      await this.agentSessionStopped(ev.channel, ev.thread_ts, ev.user)
     })
     // Membership changes: the bot was invited to (member_joined_channel, filtered
     // to our own user id) or removed from (channel_left / group_left) a channel.
@@ -1811,12 +1801,18 @@ export class SlackConnection implements PlatformConnection {
     })
   }
 
+  /** The native Stop, from either transport: resolve the session this conversation owns, interrupt
+   *  its turn, then transition the session — Slack leaves it in `processing` on its own. */
+  async agentSessionStopped(channel: string, threadTs: string, userId?: string): Promise<void> {
+    this.deps.log?.debug(`slack: agent session stopped ch=${channel} thread=${threadTs} user=${userId ?? '?'}`)
+    const sessionKey = await this.deps.onMessageShortcut?.({ channel, thread: threadTs, ...(userId ? { userId } : {}) })
+    if (sessionKey) this.deps.onStatusAction?.({ kind: 'cancel', sessionKey, ...(userId ? { actor: { userId } } : {}) })
+    await this.queue.enqueue(() => this.setSessionLifecycle(channel, threadTs, 'active'))
+  }
+
   // The lifecycle half of setStatus. Posting a message does NOT end the loading UX — only `active` does.
   // Deduped per (channel, thread); no username/icon, because Slack keeps those sticky until cleared.
   private async setSessionLifecycle(channel: string, threadTs: string, status: 'processing' | 'active'): Promise<void> {
-    // Send-only (HTTP) bots take inbound from the relay, which does not forward the stop event —
-    // so `processing` here would render a Stop button nothing on this side could ever answer.
-    if (this.deps.sendOnly) return
     const key = `${channel}:${threadTs}`
     if (this.sessionLifecycle.get(key) === status) return
     try {

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -1040,10 +1040,10 @@ describe('SlackConnection.setStatus', () => {
     expect(lifecycle).toEqual([{ channel_id: 'C1', thread_ts: '123.45', status: 'processing' }])
   })
 
-  // HTTP bots take inbound from the relay, which does not forward the stop event. Setting
-  // `processing` there would render a Stop button this side could never answer.
-  it('makes no lifecycle call on a send-only (HTTP) connection', async () => {
-    const calls: any[] = []
+  // The relay forwards the native stop to the owning daemon, so an HTTP bot can answer the
+  // Stop button too and both transports drive the same lifecycle enum.
+  it('drives the lifecycle enum on a send-only (HTTP) connection as well', async () => {
+    const lifecycle: any[] = []
     const legacy: any[] = []
     const conn = new SlackConnection(
       { ...deps(), sendOnly: true, sendIntervalMs: 0 } as any,
@@ -1051,7 +1051,7 @@ describe('SlackConnection.setStatus', () => {
         fakeAppWith(
           async (a) => void legacy.push(a),
           async (method, a) => {
-            calls.push([method, a])
+            if (method === 'agents.sessions.setStatus') lifecycle.push(a)
             return {}
           }
         ) as any
@@ -1060,9 +1060,11 @@ describe('SlackConnection.setStatus', () => {
     await conn.setStatus('C1', '123.45', 'is thinking…')
     await conn.setStatus('C1', '123.45', '')
 
-    // The legacy free-text status still runs — only the lifecycle enum is withheld.
     expect(legacy).toHaveLength(2)
-    expect(calls).toEqual([])
+    expect(lifecycle).toEqual([
+      { channel_id: 'C1', thread_ts: '123.45', status: 'processing' },
+      { channel_id: 'C1', thread_ts: '123.45', status: 'active' }
+    ])
   })
 
   it('keeps a failing lifecycle call out of dispatch', async () => {
@@ -1220,6 +1222,40 @@ describe('SlackConnection agent_session_stopped', () => {
 
     expect(actions).toEqual([])
     expect(lifecycle).toEqual([])
+  })
+
+  // The HTTP arm. A send-only connection registers no Bolt handler at all — the relay forwards
+  // the event and the daemon calls the same method, so both transports share one implementation.
+  it('runs the same resolve → cancel → transition when the relay forwards the stop', async () => {
+    const handlers = new Map<string, (a: { event: unknown }) => unknown>()
+    const lifecycle: any[] = []
+    const actions: any[] = []
+    const resolved: any[] = []
+    const conn = new SlackConnection(
+      {
+        ...deps(),
+        sendOnly: true,
+        sendIntervalMs: 0,
+        onMessageShortcut: async (a: unknown) => {
+          resolved.push(a)
+          return 'slack:C1:200.1:bot-a'
+        },
+        onStatusAction: (a: unknown) => void actions.push(a)
+      } as any,
+      () =>
+        stopApp(handlers, async (method, a) => {
+          if (method === 'agents.sessions.setStatus') lifecycle.push(a)
+          return {}
+        }) as any
+    )
+    await conn.start()
+    expect(handlers.has('agent_session_stopped')).toBe(false)
+
+    await conn.agentSessionStopped('C1', '200.1', 'U1')
+
+    expect(resolved).toEqual([{ channel: 'C1', thread: '200.1', userId: 'U1' }])
+    expect(actions).toEqual([{ kind: 'cancel', sessionKey: 'slack:C1:200.1:bot-a', actor: { userId: 'U1' } }])
+    expect(lifecycle).toEqual([{ channel_id: 'C1', thread_ts: '200.1', status: 'active' }])
   })
 })
 

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1757,7 +1757,8 @@ describe('Slack interactive status bar', () => {
       async () => {}
     )
     const updateBlocks = vi.fn(async () => true)
-    ;(daemon as any).connByIntegration.set('int-a', { openStatusModal, updateBlocks })
+    const agentSessionStopped = vi.fn(async () => {})
+    ;(daemon as any).connByIntegration.set('int-a', { openStatusModal, updateBlocks, agentSessionStopped })
     await (daemon as any).store.upsertSession({
       key: KEY,
       agentId: 'bot-a',
@@ -1822,6 +1823,21 @@ describe('Slack interactive status bar', () => {
       integrationId: 'int-a',
       sessionKey: KEY
     })
+
+    // The relay-forwarded native Stop is conversation-addressed like the shortcut above: the
+    // connection resolves the session itself, so the frame's sessionKey is not the target.
+    expect(
+      await (daemon as any).handleRelayMsg(
+        action({
+          sessionKey: 'C1/T1',
+          msgId: 'action-stop',
+          userId: 'U1',
+          payload: { kind: 'agent-session-stopped', channelId: 'C1', threadTs: 'T1' }
+        }),
+        () => {}
+      )
+    ).toEqual({ msgId: 'action-stop', accepted: true })
+    expect(agentSessionStopped).toHaveBeenCalledWith('C1', 'T1', 'U1')
 
     const permissionResolved = vi.fn()
     const permissionRequestId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -444,6 +444,7 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
         channelId: 'C123',
         threadTs: '1720000000.000100'
       },
+      { kind: 'agent-session-stopped', channelId: 'C123', threadTs: '1720000000.000100' },
       { kind: 'set-model', model: 'opus-4.8' },
       { kind: 'set-effort', effort: 'high' },
       { kind: 'set-permission-mode', permissionMode: 'plan' },
@@ -470,6 +471,7 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
         threadTs: ''
       }).success
     ).toBe(false)
+    expect(RdSlackAction.safeParse({ kind: 'agent-session-stopped', channelId: 'C123' }).success).toBe(false)
     // Envelope-level identity stays schema-enforced.
     expect(RdMsg.safeParse({ ...base, integrationId: 'not-a-uuid', payload: { kind: 'cancel' } }).success).toBe(false)
   })

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -289,6 +289,13 @@ export const RdSlackAction = z.discriminatedUnion('kind', [
     channelId: z.string().min(1),
     threadTs: z.string().min(1)
   }),
+  // Slack's native agent-session Stop, addressed by conversation: the relay never sees a session
+  // key on the event, so the daemon resolves the owning session exactly as Socket Mode does.
+  z.object({
+    kind: z.literal('agent-session-stopped'),
+    channelId: z.string().min(1),
+    threadTs: z.string().min(1)
+  }),
   z.object({ kind: z.literal('set-model'), model: z.string().min(1) }),
   z.object({ kind: z.literal('set-effort'), effort: z.string().min(1) }),
   z.object({ kind: z.literal('set-permission-mode'), permissionMode: z.string().min(1) }),

--- a/packages/protocol/src/slack-app-manifest.ts
+++ b/packages/protocol/src/slack-app-manifest.ts
@@ -45,12 +45,18 @@ export const SLACK_BOT_SCOPES = [
   'users:read'
 ] as const
 
+// Both transports advertise the same events: Socket Mode receives them directly, and the relay's
+// HTTP ingress forwards the ones this app acts on to the daemon that owns the conversation.
 export const SLACK_BOT_EVENTS = [
   // The native stop button on an agent session; without the subscription Slack never shows it.
   'agent_session_stopped',
+  // Subscribed but not handled yet, so title sync can land without a second manifest refresh.
+  'agent_session_title_changed',
   'app_mention',
   'app_uninstalled',
   'assistant_thread_started',
+  // Same: the shipping context signal for an assistant thread, pre-provisioned and inert today.
+  'assistant_thread_context_changed',
   'message.channels',
   'message.groups',
   'message.im',
@@ -60,15 +66,6 @@ export const SLACK_BOT_EVENTS = [
   'group_left',
   'tokens_revoked'
 ] as const
-
-// Bot events only a Socket Mode app can act on. The relay's HTTP ingress forwards chat and
-// finalization events only, so advertising one over HTTP renders a control that goes nowhere.
-export const SLACK_SOCKET_ONLY_BOT_EVENTS: readonly string[] = ['agent_session_stopped']
-
-/** The bot events one transport's manifest advertises: the full list, minus what only a socket can serve. */
-export function slackBotEvents(http: boolean): string[] {
-  return SLACK_BOT_EVENTS.filter((event) => !http || !SLACK_SOCKET_ONLY_BOT_EVENTS.includes(event))
-}
 
 export const DEFAULT_SLACK_APP_NAME = 'agentconnect'
 
@@ -151,7 +148,7 @@ export function buildSlackAppManifest(name: string, options: SlackAppManifestOpt
     },
     settings: {
       event_subscriptions: {
-        bot_events: slackBotEvents(http),
+        bot_events: [...SLACK_BOT_EVENTS],
         ...(relayUrl ? { request_url: slackEventsRequestUrl(relayUrl) } : {})
       },
       interactivity: {

--- a/packages/relay/src/platforms/slack/http-ingest.test.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.test.ts
@@ -333,6 +333,7 @@ describe('SlackHttpIngest.handleInteraction', () => {
     onSelectThreadAgent: vi.fn(),
     onSessionAction: vi.fn(),
     onSessionShortcut: vi.fn(() => false),
+    onSessionStopped: vi.fn(),
     log: silentLog,
     ...over
   })
@@ -403,6 +404,7 @@ describe('SlackHttpIngest channel membership events', () => {
     onSelectThreadAgent: vi.fn(),
     onSessionAction: vi.fn(),
     onSessionShortcut: vi.fn(() => false),
+    onSessionStopped: vi.fn(),
     webClientFactory: () => web as never,
     log: silentLog,
     ...over
@@ -457,6 +459,69 @@ describe('SlackHttpIngest channel membership events', () => {
 
     expect(onChannelsChanged).toHaveBeenCalledWith([{ id: 'C1', name: 'remaining' }])
   })
+
+  // The native Stop. Also not a chat event, and the event id is the receipt a Slack
+  // redelivery reuses, so the daemon-side dedup id it mints is stable.
+  it('forwards the agent-session stop with its conversation and the tapping user', async () => {
+    const web = { auth: { test: vi.fn(async () => ({ user_id: 'UBOT' })) } }
+    const onSessionStopped = vi.fn()
+    const onMessage = vi.fn(async () => {})
+    const ingest = new SlackHttpIngest(
+      'bot',
+      { botToken: 'xoxb', signingSecret: 's' },
+      deps(web, { onSessionStopped, onMessage })
+    )
+    await ingest.start()
+
+    await ingest.handleEvent(
+      { type: 'agent_session_stopped', channel: 'C1', thread_ts: '200.1', user: 'U-ALICE' },
+      1_700_000_000_000,
+      'Ev123'
+    )
+
+    expect(onSessionStopped).toHaveBeenCalledWith({
+      channelId: 'C1',
+      threadTs: '200.1',
+      interactionId: 'Ev123',
+      userId: 'U-ALICE'
+    })
+    expect(onMessage).not.toHaveBeenCalled()
+  })
+
+  it('omits the actor when the stop names none, and drops one without a thread', async () => {
+    const web = { auth: { test: vi.fn(async () => ({ user_id: 'UBOT' })) } }
+    const onSessionStopped = vi.fn()
+    const ingest = new SlackHttpIngest('bot', { botToken: 'xoxb', signingSecret: 's' }, deps(web, { onSessionStopped }))
+    await ingest.start()
+
+    await ingest.handleEvent({ type: 'agent_session_stopped', channel: 'C1', thread_ts: '200.1' }, undefined, 'Ev124')
+    await ingest.handleEvent({ type: 'agent_session_stopped', channel: 'C1' }, undefined, 'Ev125')
+
+    expect(onSessionStopped).toHaveBeenCalledTimes(1)
+    expect(onSessionStopped.mock.calls[0]![0]).not.toHaveProperty('userId')
+  })
+
+  // Subscribed so a future feature needs no manifest-refresh cycle, but nothing acts on them:
+  // they fall through to the same drop every unrecognized event takes.
+  it.each(['agent_session_title_changed', 'assistant_thread_context_changed'] as const)(
+    'drops the inert %s subscription',
+    async (type) => {
+      const web = { auth: { test: vi.fn(async () => ({ user_id: 'UBOT' })) } }
+      const onSessionStopped = vi.fn()
+      const onMessage = vi.fn(async () => {})
+      const ingest = new SlackHttpIngest(
+        'bot',
+        { botToken: 'xoxb', signingSecret: 's' },
+        deps(web, { onSessionStopped, onMessage })
+      )
+      await ingest.start()
+
+      await ingest.handleEvent({ type, channel: 'C1', thread_ts: '200.1', user: 'U-ALICE' })
+
+      expect(onSessionStopped).not.toHaveBeenCalled()
+      expect(onMessage).not.toHaveBeenCalled()
+    }
+  )
 
   // App lifecycle (preset-agents.md §5.3): the workspace pulled the app / revoked
   // its tokens. Not a chat event — it has no user/bot_id, so without the explicit
@@ -589,6 +654,7 @@ describe('SlackHttpIngest message events', () => {
         onSelectThreadAgent: vi.fn(),
         onSessionAction: vi.fn(),
         onSessionShortcut: vi.fn(() => false),
+        onSessionStopped: vi.fn(),
         webClientFactory: () => web as never,
         log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
       }

--- a/packages/relay/src/platforms/slack/http-ingest.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.ts
@@ -97,6 +97,14 @@ export interface HttpSlackSessionShortcut extends HttpSlackInteractionReceipt {
   userId?: string
 }
 
+/** Slack's native agent-session Stop, as the Events API delivers it. Conversation-addressed:
+ *  the event names no session, so the owning daemon resolves one from (channel, thread). */
+export interface HttpSlackSessionStop extends HttpSlackInteractionReceipt {
+  channelId: string
+  threadTs: string
+  userId?: string
+}
+
 type HttpSlackAgent = { agentId: string; name: string }
 
 function httpSlackAgentOption(agent: HttpSlackAgent) {
@@ -344,6 +352,8 @@ export interface SlackHttpIngestDeps {
   /** Resolve and forward the app-level message shortcut. False opens a local
    *  unavailable modal while the one-shot trigger id is still valid. */
   onSessionShortcut: (shortcut: HttpSlackSessionShortcut) => boolean
+  /** Forward the native agent-session Stop to the daemon owning that conversation. */
+  onSessionStopped: (stop: HttpSlackSessionStop) => void
   /** The workspace uninstalled the app / revoked its tokens — the bot's credential
    *  is dead; report upstream so the CP marks it revoked. */
   /** `eventAtMs` = Slack's envelope `event_time` (when the uninstall HAPPENED),
@@ -455,8 +465,11 @@ export class SlackHttpIngest {
 
   /** Handle one verified `/slack/events` envelope after demux + HMAC. Forwards
    *  top-level chat after removing this app's own echo. Never throws — HTTP 200 was
-   *  already sent; a forward miss is bounded loss at the forwarder. */
-  async handleEvent(event: SlackMessageEvent | undefined, eventAtMs?: number): Promise<void> {
+   *  already sent; a forward miss is bounded loss at the forwarder. `eventId` is the
+   *  envelope's `event_id`, the receipt a redelivery reuses. Every event this app
+   *  subscribes to but does not act on (agent-session title, assistant thread context)
+   *  falls through to the drop at the end. */
+  async handleEvent(event: SlackMessageEvent | undefined, eventAtMs?: number, eventId?: string): Promise<void> {
     try {
       // App lifecycle: the workspace pulled the app / revoked its tokens. Not a
       // chat event (no user/bot_id — isRoutableEvent would drop it), so branch
@@ -464,6 +477,20 @@ export class SlackHttpIngest {
       // the app has exactly one bot token, and Slack sends it when that dies.
       if (event?.type === 'app_uninstalled' || event?.type === 'tokens_revoked') {
         this.deps.onBotRevoked?.(event.type, eventAtMs)
+        return
+      }
+      // The native Stop button — not chat either, and the one non-chat event this transport
+      // forwards to a daemon, which cancels the turn its conversation owns.
+      if (event?.type === 'agent_session_stopped') {
+        if (event.channel && event.thread_ts)
+          this.deps.onSessionStopped({
+            channelId: event.channel,
+            threadTs: event.thread_ts,
+            // No event id ⇒ fall back to the thread + envelope time; a second stop within the
+            // same second then dedups, which is harmless — the turn is already cancelled.
+            interactionId: eventId ?? `${event.thread_ts}:${eventAtMs ?? ''}`,
+            ...(event.user ? { userId: event.user } : {})
+          })
         return
       }
       if (event && this.isOwnMembershipChange(event)) {

--- a/packages/relay/src/platforms/slack/ingress-plugin.test.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto'
 import { describe, it, expect, vi } from 'vitest'
 import { forwardSessionShortcut, slackIngressPlugin } from './ingress-plugin.js'
 import type { RelayIngressHost } from '../contract.js'
@@ -54,6 +55,58 @@ describe('slack ingress plugin — review-pinned regressions', () => {
     const h = host()
     expect(forwardSessionShortcut(h, 'bot-1', SHORTCUT)).toBe(true)
     expect(h.forwardAction).toHaveBeenCalledTimes(1)
+  })
+
+  // The whole plugin path for the native Stop: HMAC demux → handle → the daemon that owns the
+  // conversation, carrying the tapping user. A signature no assigned bot verifies stops at verify.
+  it('forwards a verified agent-session stop, and never an unverified one', async () => {
+    const h = host()
+    const assignment = {
+      botId: 'bot-1',
+      platform: 'slack',
+      secrets: { botToken: 'xoxb-1', signingSecret: 'sig' },
+      members: [],
+      agents: [],
+      routes: []
+    } as unknown as BotAssignment
+    const ingest = slackIngressPlugin.buildIngest(assignment, h)!
+    const envelope = {
+      type: 'event_callback',
+      api_app_id: 'A1',
+      team_id: 'T9',
+      event_id: 'Ev-stop',
+      event: { type: 'agent_session_stopped', channel: 'C1', thread_ts: 'T1', user: 'U-ALICE' }
+    }
+    const raw = Buffer.from(JSON.stringify(envelope))
+    const ts = '1720000000'
+    const now = 1_720_000_000_000
+    const sign = (secret: string) =>
+      `v0=${createHmac('sha256', secret)
+        .update(`v0:${ts}:${raw.toString('utf8')}`)
+        .digest('hex')}`
+    const headers = (signature: string) => ({
+      'x-slack-signature': signature,
+      'x-slack-request-timestamp': ts
+    })
+
+    expect(slackIngressPlugin.verify(ingest, raw, envelope, headers(sign('other-bots-secret')), now)).toBeUndefined()
+    expect(h.forwardAction).not.toHaveBeenCalled()
+
+    const verified = slackIngressPlugin.verify(ingest, raw, envelope, headers(sign('sig')), now)!
+    expect(verified).toMatchObject({ kind: 'event', eventId: 'Ev-stop' })
+    await slackIngressPlugin.handle(ingest, verified, h)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(h.forwardAction).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(h.forwardAction).mock.calls[0]![0]).toMatchObject({
+      source: 'platform_action',
+      platformId: 'slack',
+      agentId: ROUTE.agentId,
+      integrationId: ROUTE.integrationId,
+      botId: 'bot-1',
+      userId: 'U-ALICE',
+      payload: { kind: 'agent-session-stopped', channelId: 'C1', threadTs: 'T1' }
+    })
   })
 
   it('revocation reports carry the OBSERVING assignment revision, not the current one', () => {

--- a/packages/relay/src/platforms/slack/ingress-plugin.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.ts
@@ -24,6 +24,7 @@ import {
   SlackHttpIngest,
   type HttpSlackSessionAction,
   type HttpSlackSessionShortcut,
+  type HttpSlackSessionStop,
   type SlackInteractiveBody,
   type SlackMessageEvent
 } from './http-ingest.js'
@@ -89,6 +90,24 @@ export function httpSlackShortcutMsgId(botId: string, shortcut: HttpSlackSession
         channelId: shortcut.channelId,
         threadTs: shortcut.threadTs,
         interactionId: shortcut.interactionId
+      })
+    )
+    .digest('hex')
+  return `slack-action:${digest}`
+}
+
+/** Stable daemon-side dedup id for one native agent-session Stop. `kind` keeps it distinct
+ *  from a shortcut that happened to reuse the same conversation + receipt. */
+export function httpSlackStopMsgId(botId: string, stop: HttpSlackSessionStop): string {
+  const digest = createHash('sha256')
+    .update(
+      JSON.stringify({
+        v: 1,
+        botId,
+        kind: 'agent-session-stopped',
+        channelId: stop.channelId,
+        threadTs: stop.threadTs,
+        interactionId: stop.interactionId
       })
     )
     .digest('hex')
@@ -169,10 +188,42 @@ export function forwardSessionShortcut(
   return true
 }
 
+/** Forward the native Stop over the same seam a message shortcut takes: the event names no
+ *  session, so the conversation-ownership ladder picks the daemon and the daemon resolves the
+ *  session itself — exactly what Socket Mode does with the same event. Nothing is returned to
+ *  Slack, so an unroutable or offline target is bounded loss like any other forwarded event. */
+export function forwardSessionStop(host: RelayIngressHost, botId: string, stop: HttpSlackSessionStop): void {
+  const route = host.directory.resolveTarget(botId, { channelId: stop.channelId, threadTs: stop.threadTs })
+  if (!route) {
+    host.log.warn(`relay-ingress(${botId}): no owner for the agent-session stop in ${stop.channelId}`)
+    return
+  }
+  const rd: RdMsgPlatformAction = {
+    source: 'platform_action',
+    platformId: 'slack',
+    agentId: route.agentId,
+    integrationId: route.integrationId,
+    sessionKey: sessionKeyOf({ channel: stop.channelId, thread: stop.threadTs }),
+    msgId: httpSlackStopMsgId(botId, stop),
+    botId,
+    ...(stop.userId ? { userId: stop.userId } : {}),
+    payload: { kind: 'agent-session-stopped', channelId: stop.channelId, threadTs: stop.threadTs }
+  }
+  void host
+    .forwardAction(rd, route)
+    .then((ack) => {
+      if (!ack.accepted)
+        host.log.warn(`relay-ingress(${botId}): daemon rejected the agent-session stop (${ack.reason ?? 'unknown'})`)
+    })
+    .catch((err) =>
+      host.log.warn(`relay-ingress(${botId}): agent-session stop forward failed: ${(err as Error).message}`)
+    )
+}
+
 /** The plugin's typed verified product: one authenticated Slack delivery, as
  *  the two HTTP routes parse it. Opaque to core (§8). */
 export type SlackVerifiedDelivery =
-  | { kind: 'event'; event?: SlackMessageEvent; eventAtMs?: number; dedupKey?: string }
+  | { kind: 'event'; event?: SlackMessageEvent; eventAtMs?: number; dedupKey?: string; eventId?: string }
   | { kind: 'interaction'; body: SlackInteractiveBody }
 
 function headerString(v: string | string[] | undefined): string | undefined {
@@ -206,6 +257,7 @@ export const slackIngressPlugin: RelayPlatformIngressPlugin<SlackHttpIngest, Sla
           host.selectThreadAgent(botId, channelId, threadTs, agentId),
         onSessionAction: (action) => forwardSessionAction(host, botId, action),
         onSessionShortcut: (shortcut) => forwardSessionShortcut(host, botId, shortcut),
+        onSessionStopped: (stop) => forwardSessionStop(host, botId, stop),
         onBotRevoked: (reason, eventAtMs) => {
           host.log.warn(`relay-ingress(${botId}): workspace revoked the app (${reason})`)
           // Fence with the generation THIS ingest was built from — assignments
@@ -252,7 +304,10 @@ export const slackIngressPlugin: RelayPlatformIngressPlugin<SlackHttpIngest, Sla
       kind: 'event',
       ...(env?.event ? { event: env.event } : {}),
       ...(env?.event_time ? { eventAtMs: env.event_time * 1000 } : {}),
-      ...(dedupKey ? { dedupKey } : {})
+      ...(dedupKey ? { dedupKey } : {}),
+      // The per-delivery receipt a redelivery reuses — the daemon-side dedup id of a
+      // forwarded non-chat event is minted from it.
+      ...(env?.event_id ? { eventId: env.event_id } : {})
     }
   },
 
@@ -269,7 +324,7 @@ export const slackIngressPlugin: RelayPlatformIngressPlugin<SlackHttpIngest, Sla
     // and a forward miss is bounded loss. Failures log exactly as the live
     // route logs them today.
     void ingest
-      .handleEvent(verified.event, verified.eventAtMs)
+      .handleEvent(verified.event, verified.eventAtMs, verified.eventId)
       .catch((err) => host.log.warn(`slack ingress: event handler error: ${(err as Error).message}`))
     return {}
   }

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -20,14 +20,20 @@ import { RelayIngressManager, type RelayIngressManagerDeps } from './relay-ingre
 import {
   forwardSessionAction,
   forwardSessionShortcut,
+  forwardSessionStop,
   httpSlackActionMsgId,
-  httpSlackShortcutMsgId
+  httpSlackShortcutMsgId,
+  httpSlackStopMsgId
 } from './platforms/slack/ingress-plugin.js'
 import { forwardFeishuCardAction, httpFeishuActionMsgId } from './platforms/feishu/ingress-plugin.js'
 import { DemuxIndex, relayIngressPlugins } from './platforms/registry.js'
 import type { RelayBotIngress, RelayPlatformIngressPlugin } from './platforms/contract.js'
 import { BotArbitrationRouter, mapAgentDirectory, type BotAssignment } from './bot-arbitration.js'
-import type { HttpSlackSessionAction, HttpSlackSessionShortcut } from './platforms/slack/http-ingest.js'
+import type {
+  HttpSlackSessionAction,
+  HttpSlackSessionShortcut,
+  HttpSlackSessionStop
+} from './platforms/slack/http-ingest.js'
 import type { RelayDaemonConnection } from './relay-daemon-connection.js'
 import type { Logger } from './log.js'
 
@@ -266,6 +272,66 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
         threadTs: 'T1'
       }
     })
+  })
+
+  // The native Stop travels the shortcut's seam: it names no session, so ownership picks the
+  // daemon and the daemon resolves the session — exactly what Socket Mode does with the event.
+  it('forwards the agent-session stop through the current thread affinity, with attribution', () => {
+    const sendMsg = vi.fn(async (msg: RdMsgPlatformAction): Promise<RdAck> => ({ msgId: msg.msgId, accepted: true }))
+    const daemon = { sendMsg } as unknown as RelayDaemonConnection
+    const manager = new RelayIngressManager(
+      deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
+    )
+    const internals = internalsOf(manager)
+    internals.router.upsert(assignment())
+    internals.router.setAffinity(BOT_ID, 'C123/T1', {
+      agentId: AGENT_ID,
+      daemonId: DAEMON_ID,
+      integrationId: INTEGRATION_ID
+    })
+    const stop: HttpSlackSessionStop = {
+      channelId: 'C123',
+      threadTs: 'T1',
+      interactionId: 'Ev123',
+      userId: 'U-ALICE'
+    }
+
+    forwardSessionStop(internals.ingressHost, BOT_ID, stop)
+    forwardSessionStop(internals.ingressHost, BOT_ID, stop) // Slack redelivery
+
+    expect(sendMsg).toHaveBeenCalledTimes(2)
+    const first = sendMsg.mock.calls[0]![0]
+    expect(first).toEqual({
+      source: 'platform_action',
+      platformId: 'slack',
+      agentId: AGENT_ID,
+      integrationId: INTEGRATION_ID,
+      sessionKey: 'C123/T1',
+      msgId: httpSlackStopMsgId(BOT_ID, stop),
+      botId: BOT_ID,
+      userId: 'U-ALICE',
+      payload: { kind: 'agent-session-stopped', channelId: 'C123', threadTs: 'T1' }
+    })
+    // A redelivery carries the same event id, so the daemon dedups it.
+    expect(sendMsg.mock.calls[1]![0].msgId).toBe(first.msgId)
+    // …and a stop the shortcut seam would have hashed identically stays distinct.
+    expect(first.msgId).not.toBe(
+      httpSlackShortcutMsgId(BOT_ID, { channelId: 'C123', threadTs: 'T1', triggerId: 't', interactionId: 'Ev123' })
+    )
+  })
+
+  it('forwards no stop for a conversation this bot owns nowhere', () => {
+    const sendMsg = vi.fn()
+    const warn = vi.fn()
+    const manager = new RelayIngressManager(
+      deps({ getDaemon: () => ({ sendMsg }) as unknown as RelayDaemonConnection, log: { ...silentLog, warn } })
+    )
+    const internals = internalsOf(manager)
+
+    forwardSessionStop(internals.ingressHost, BOT_ID, { channelId: 'C123', threadTs: 'T1', interactionId: 'Ev123' })
+
+    expect(sendMsg).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no owner for the agent-session stop'))
   })
 
   it('forwards the tapping user, and omits it entirely when the interaction named none', () => {

--- a/packages/web/src/components/console/platforms/slack/manifest.test.ts
+++ b/packages/web/src/components/console/platforms/slack/manifest.test.ts
@@ -4,7 +4,6 @@ import {
   slackCreateAppUrl,
   SLACK_BOT_SCOPES,
   SLACK_BOT_EVENTS,
-  SLACK_SOCKET_ONLY_BOT_EVENTS,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
   PLATFORM_APP_DESCRIPTION
 } from './manifest'
@@ -40,9 +39,11 @@ describe('manifest parity with the Control Plane', () => {
   it('pins the exact bot events (drift guard)', () => {
     expect([...SLACK_BOT_EVENTS]).toEqual([
       'agent_session_stopped',
+      'agent_session_title_changed',
       'app_mention',
       'app_uninstalled',
       'assistant_thread_started',
+      'assistant_thread_context_changed',
       'message.channels',
       'message.groups',
       'message.im',
@@ -64,23 +65,24 @@ describe('buildSlackManifest', () => {
     expect(branded.display_information.background_color).toBe('#c62a78')
   })
 
-  // The stop button is a Socket Mode capability: the relay's HTTP ingress forwards chat and
-  // finalization events only, so an http app advertising it would show a control that goes nowhere.
-  it('advertises the socket-only events on socket, and withholds them over http', () => {
+  // One event list for both transports: Socket Mode receives the stop directly, and the relay
+  // forwards it to the daemon that owns the conversation, so neither variant withholds it.
+  it('advertises the same bot events on socket and over http', () => {
     const socket = buildSlackManifest({ name: 'acme' })
     const http = buildSlackManifest({ name: 'acme' }, { mode: 'http', relayUrl: 'https://relay.example' })
 
     expect(socket.settings.socket_mode_enabled).toBe(true)
     expect(socket.settings.event_subscriptions.bot_events).toEqual([...SLACK_BOT_EVENTS])
     expect(http.settings.socket_mode_enabled).toBe(false)
-    expect(http.settings.event_subscriptions.bot_events).toEqual(
-      [...SLACK_BOT_EVENTS].filter((event) => !SLACK_SOCKET_ONLY_BOT_EVENTS.includes(event))
-    )
-    expect(http.settings.event_subscriptions.bot_events).not.toContain('agent_session_stopped')
-  })
-
-  it('pins the socket-only event list (drift guard)', () => {
-    expect([...SLACK_SOCKET_ONLY_BOT_EVENTS]).toEqual(['agent_session_stopped'])
+    expect(http.settings.event_subscriptions.bot_events).toEqual([...SLACK_BOT_EVENTS])
+    for (const manifest of [socket, http])
+      expect(manifest.settings.event_subscriptions.bot_events).toEqual(
+        expect.arrayContaining([
+          'agent_session_stopped',
+          'agent_session_title_changed',
+          'assistant_thread_context_changed'
+        ])
+      )
   })
 
   it('uses the generic public app description', () => {

--- a/packages/web/src/components/console/platforms/slack/manifest.ts
+++ b/packages/web/src/components/console/platforms/slack/manifest.ts
@@ -32,7 +32,6 @@ import {
   SLACK_BOT_EVENTS,
   SLACK_BOT_SCOPES,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
-  SLACK_SOCKET_ONLY_BOT_EVENTS,
   type SlackAppManifest
 } from '@agentconnect.md/protocol/slack-app-manifest'
 
@@ -42,7 +41,6 @@ export {
   SLACK_BOT_EVENTS,
   SLACK_BOT_SCOPES,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
-  SLACK_SOCKET_ONLY_BOT_EVENTS,
   type SlackAppManifest
 }
 


### PR DESCRIPTION
Follow-up to #1462, which shipped Slack's native agent-session Stop on Socket Mode only because the relay's HTTP ingress had nowhere to send the event. This gives it somewhere, so the capability stops being transport-dependent.

## The relay to daemon path, and why it is the shortcut's

The Stop arrives as a bot event naming a conversation, not a session — the same shape the "Manage session" message shortcut has. So it takes the same seam rather than a new one:

- `SlackHttpIngest.handleEvent` gains an `agent_session_stopped` branch beside `app_uninstalled` / `tokens_revoked`, forwarding `channel`, `thread_ts` and the acting user through a new `onSessionStopped` dep.
- `forwardSessionStop` resolves the owner with `directory.resolveTarget` — the affinity → owner → default ladder `forwardSessionShortcut` already uses — and sends one §6.6 `platform_action` with a new conversation-addressed `RdSlackAction` member, `{ kind: 'agent-session-stopped', channelId, threadTs }`. Both `protocol` consumers were checked: the relay mints it, the daemon's existing per-platform decoder validates it, and an older daemon NAKs it as `unsupported_action` rather than mis-handling it.
- Slack is still acked inside the 3s window and the forward stays async, so a miss is the bounded loss the rest of that file declares. Nothing is returned to Slack, so unlike a shortcut there is no one-shot trigger id to protect and an offline daemon needs no local fallback.
- The envelope's `event_id` now rides from `verify` into `handleEvent` as the receipt a Slack redelivery reuses, so the daemon-side dedup id `httpSlackStopMsgId` mints stays stable. `kind` is inside that hash, so a stop can never collide with a shortcut on the same conversation and receipt.

On the daemon, the Bolt handler's body was extracted into `SlackConnection.agentSessionStopped`, and the forwarded frame calls exactly that — one resolve → cancel → set `active` for both transports, placed beside the `open-config-for-thread` branch because it is conversation-addressed the same way (the frame's `sessionKey` is not the target). Resolution keeps running through `onMessageShortcut` → `latestAdmittedSession`, so the conversation-routing gate applies unchanged.

## HTTP lifecycle calls are no longer withheld

`setSessionLifecycle` returned early on a send-only connection, because `processing` would have rendered a Stop button this side could not answer. That is no longer true, so the early return is gone and HTTP bots drive `processing`/`active` like sockets do. Send-only connections now register `onMessageShortcut` for the resolve step; the dedupe and best-effort error handling are untouched.

## Manifest

- `agent_session_stopped` returns to the HTTP variant. With nothing left to withhold, `SLACK_SOCKET_ONLY_BOT_EVENTS` and `slackBotEvents(http)` are deleted outright and both variants read one shared `SLACK_BOT_EVENTS` again — a split with an empty set is a mechanism with no reason to exist.
- `agent_session_title_changed` and `assistant_thread_context_changed` join that list, subscribed but deliberately inert. No handler is registered: Bolt 5 dispatches an event to matching listeners and returns silently when none match (no "unhandled event" warning anywhere in `App.processEvent` or the builtin middleware), and on the relay side the default drop branch at the end of `handleEvent` already swallows them. Pre-provisioning costs nothing today and means title sync and context handling can land without a second manifest-refresh cycle on installed apps. `assistant_thread_context_changed` belongs to the legacy assistant event family, adopted deliberately while it remains the shipping context signal for a thread.

## What the drift checker will flag on installed apps

An installed HTTP app is now three subscriptions short, and an installed socket app two. Both funnels converge: the install manifest emits the full list, and `mergeManagedSlackManifest` unions it into whatever the app already has, so a manifest refresh adds the missing `bot_events` and leaves everything else alone. Until an app is refreshed, an HTTP bot shows no Stop button — the same state it is in today, not a regression.

## Verified

- `pnpm --filter @agentconnect.md/protocol test` — 451 passed
- `pnpm --filter @agentconnect.md/relay test` — 544 passed
- `pnpm --filter @agentconnect.md/web test` — 1964 passed
- `pnpm --filter @agentconnect.md/control-plane test:unit` — 2041 passed
- `pnpm eval:gates` — 193 passed (the connection-surface guard takes an EXEMPT entry for the new member, as the private lifecycle helper did)
- daemon `test/connection.test.ts` (54) and `test/daemon-commands.test.ts` (54) — passed. The full daemon suite leaves 15 failures in `shim-*` and `acp-matrix`, all pre-existing on this machine (no local sandbox binary, no provider quota); `daemon-k8s-mode` timed out once under full-suite load and passes on its own.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean

New coverage: relay — a verified stop is demuxed and forwarded with attribution while an unverified one stops at `verify`, the ingest branch reads the conversation and omits an unnamed actor, the two inert subscriptions are dropped, and an unowned conversation forwards nothing; daemon — a forwarded stop cancels the resolved session and transitions it on a send-only connection that registers no Bolt handler, and send-only `setStatus` now emits both lifecycle states; manifest — both variants pin the same list, in all three drift guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
