### PR TITLE
fix(daemon): join the catch-up fires instead of sleeping for them

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -7709,6 +7709,21 @@ export class Daemon {
     if (dreamRun && dreamRun.definition !== dream) await this.store.setDreamLastRun(a.id, now, dream)
   }
 
+  // Catch-up fires in flight. A fire stays OFF the settle path — it is a whole turn, and duty
+  // convergence must never wait on one — but dropping the promise also erased when it finished.
+  private readonly catchUpFires = new Set<Promise<void>>()
+
+  // Joinable for its own lifetime; registering changes nothing about when the fire runs.
+  private trackCatchUpFire(fire: Promise<void>): void {
+    const tracked = fire.finally(() => this.catchUpFires.delete(tracked))
+    this.catchUpFires.add(tracked)
+  }
+
+  /** Settle the catch-up fires a duty handover launched — the completion signal a bare `void` loses. */
+  async joinCatchUpFires(): Promise<void> {
+    while (this.catchUpFires.size > 0) await Promise.allSettled([...this.catchUpFires])
+  }
+
   /**
    * Compensate the fires a duty handover swallowed (#1031). The old holder unregisters an agent's
    * schedules before the moment and the new holder arms a `Cron` that knows nothing of a moment
@@ -7732,8 +7747,10 @@ export class Daemon {
         if (due === undefined || !(await this.store.claimCronCatchUp(key, due, now, fingerprint))) continue
         this.log.info(`cron "${cron.id}" of agent "${agentId}": firing the occurrence a duty handover missed`)
         const { msg } = buildSyntheticMessage(agentId, cron, randomUUID())
-        void this.onCronFire(agentId, msg, cron).catch((err) =>
-          this.log.error(`cron catch-up dispatch failed for agent "${agentId}": ${formatErr(err)}`)
+        this.trackCatchUpFire(
+          this.onCronFire(agentId, msg, cron).catch((err) =>
+            this.log.error(`cron catch-up dispatch failed for agent "${agentId}": ${formatErr(err)}`)
+          )
         )
       }
       const dream = this.dreamDefinition(agent)

--- a/packages/daemon/test/schedule-catchup.test.ts
+++ b/packages/daemon/test/schedule-catchup.test.ts
@@ -131,8 +131,9 @@ const editSchedules = (root: string, members: { inner: any }[], over: { schedule
     for (const target of [agent.crons[0], agent.memory.dreaming]) Object.assign(target, over)
   })
 
-/** croner fires are async under the hood; let the stubbed dispatch settle. */
-const settle = () => new Promise((r) => setTimeout(r, 30))
+/** A cron fire leaves the settle path, so a returned `hold` proves only that the decision was made;
+ *  join the fires themselves, never a wall clock. The dream half is awaited inside the catch-up. */
+const settle = (...members: { inner: any }[]) => Promise.all(members.map((member) => member.inner.joinCatchUpFires()))
 
 describe('missed-fire compensation across a duty handover', () => {
   it('replays a cron and a dream that fell inside the handover, on the member that gained the duty', async () => {
@@ -144,7 +145,7 @@ describe('missed-fire compensation across a duty handover', () => {
     a.crons.length = 0
     a.dreams.length = 0
     await hold(b.inner)
-    await settle()
+    await settle(a, b)
     expect(b.crons).toEqual([AGENT])
     expect(b.dreams).toEqual([AGENT])
     // The released member neither fires nor holds anything to fire.
@@ -159,7 +160,7 @@ describe('missed-fire compensation across a duty handover', () => {
     await stampsBefore(a.inner, 0)
     await drop(a.inner)
     await hold(b.inner)
-    await settle()
+    await settle(b)
     expect(b.crons).toEqual([])
     expect(b.dreams).toEqual([])
     await stop()
@@ -170,7 +171,7 @@ describe('missed-fire compensation across a duty handover', () => {
     await hold(a.inner)
     await drop(a.inner)
     await hold(b.inner)
-    await settle()
+    await settle(b)
     expect(b.crons).toEqual([])
     expect(b.dreams).toEqual([])
     await stop()
@@ -182,7 +183,7 @@ describe('missed-fire compensation across a duty handover', () => {
     // Both claim the group — the overlap a handover leaves behind.
     await hold(a.inner)
     await hold(b.inner)
-    await settle()
+    await settle(a, b)
     expect(a.crons.length + b.crons.length).toBe(1)
     expect(a.dreams.length + b.dreams.length).toBe(1)
     await stop()
@@ -192,12 +193,12 @@ describe('missed-fire compensation across a duty handover', () => {
     const { a, stop } = await bootPool()
     await stampsBefore(a.inner, 2 * HOUR_MS)
     await hold(a.inner)
-    await settle()
+    await settle(a)
     expect(a.crons).toEqual([AGENT])
     a.crons.length = 0
     a.dreams.length = 0
     await hold(a.inner)
-    await settle()
+    await settle(a)
     expect(a.crons).toEqual([])
     expect(a.dreams).toEqual([])
     await stop()
@@ -206,8 +207,8 @@ describe('missed-fire compensation across a duty handover', () => {
   it('a real fire stamps the dream schedule, so the next handover sees the moment as served', async () => {
     const { a, stop } = await bootPool()
     expect(await a.inner.store.dreamRun(AGENT)).toBeUndefined()
+    // The fire stamps before its gates, so awaiting it is already proof the row is durable.
     await a.inner.onDreamScheduleFire(AGENT)
-    await settle()
     const run = await a.inner.store.dreamRun(AGENT)
     expect(run.lastRunAt).toBeGreaterThan(0)
     expect(run.definition).toBe(scheduleFingerprint(a.inner.dreamDefinition(agentOf(a.inner))))
@@ -223,7 +224,7 @@ describe('missed-fire compensation across a duty handover', () => {
     // evidence about the :00 schedule that no longer exists.
     await editSchedules(root, [a, b], { schedule: '30 * * * *' })
     await hold(b.inner)
-    await settle()
+    await settle(b)
     expect(b.crons).toEqual([])
     expect(b.dreams).toEqual([])
     await stop()
@@ -260,7 +261,7 @@ describe('missed-fire compensation across a duty handover', () => {
     })
     await drop(a.inner)
     await hold(b.inner)
-    await settle()
+    await settle(b)
     expect(b.crons).toEqual([])
     expect(b.dreams).toEqual([])
     await stop()
@@ -274,7 +275,7 @@ describe('missed-fire compensation across a duty handover', () => {
     await editSchedules(root, [a, b], { enabled: true })
     await drop(a.inner)
     await hold(b.inner)
-    await settle()
+    await settle(b)
     expect(b.crons).toEqual([])
     expect(b.dreams).toEqual([])
     await stop()


### PR DESCRIPTION
## What

`packages/daemon/test/schedule-catchup.test.ts` is intermittently flaky on CI, failing on this assertion:

```
AssertionError: expected [] to deeply equal [ 'bot-a' ]
  at test/schedule-catchup.test.ts:148:21
```

The catch-up compensates two schedules, and only one of them is observable once the duty change settles:

- The **dream** half is awaited inside `catchUpMissedSchedules`, so its recorder is already populated when `hold()` returns.
- The **cron** half is dispatched off that path with `void this.onCronFire(...)`, and the promise was dropped on the floor.

The test bridged that gap with a fixed 30 ms sleep — a wall clock racing an unbounded dispatch rather than a completion signal. That asymmetry is what makes the failure land on the cron assertion and not the dream one directly below it.

## Why the fire is not simply awaited in production

`onCronFire` runs a whole turn (`fireTrigger` → `dispatch`). Duty convergence must never block on one, so the fire deliberately stays off the settle path. **This PR does not change that**, and it does not change when the fire runs.

## What changed

The fire is no longer forgotten once launched: each one is registered so it stays joinable for its own lifetime, and the test awaits the fires themselves instead of sleeping. Registering a promise does not move when it executes.

The negative assertions get stronger too. Previously "nothing fired" could pass because a wrongly launched fire had not landed within the sleep; now such a fire is joined and observed.

## Verification

The flake does not reproduce on an idle machine, so the fix is demonstrated by A/B with a deliberately slow stubbed dispatch (500 ms):

| dispatch | synchronization | result |
| --- | --- | --- |
| slow | `joinCatchUpFires()` | 10/10 pass |
| slow | previous 30 ms sleep | reproduces the reported failure verbatim |

- 20/20 consecutive clean runs of the file afterwards
- `pnpm typecheck` — passes for every package
- `pnpm lint` and `pnpm format:check` — clean

`pnpm --filter @agentconnect.md/daemon test:unit` has pre-existing failures in the shim, k8s-mode, and live ACP matrix files (`sandbox-exec: execvp() ... Operation not permitted`, and an exhausted external quota). They reproduce on a clean tree with this change stashed, so they are unrelated to it.

## Reviewer note

`joinCatchUpFires()` has no production caller today — the test is its only consumer. It was deliberately not wired into `stop()`: joining there could block shutdown on a full turn, which is a worse trade than the small window it would close.

An earlier theory — that two members over one SQLite file hit `SQLITE_BUSY` on the swallowed catch-up write — was ruled out. Instrumenting the suite showed zero transactions in this test, and without a `BEGIN IMMEDIATE` held across an `await`, two synchronous connections in one process cannot collide.
