### PR TITLE
feat(web): drop the daemon step only where the cloud pool is offered

### DIFF
--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -17,6 +17,7 @@ import { usePathname } from 'next/navigation'
 import { useConsoleData } from '@/lib/data-context'
 import { isAuthConfigured } from '@/lib/auth'
 import { computeGettingStarted, type GsAction } from '@/lib/getting-started'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import {
   AddToSlackRow,
   GsRows,
@@ -65,7 +66,7 @@ export function openGettingStarted() {
 }
 
 export default function GettingStarted() {
-  const { agents, integrations, allSessions, orgHasSessions, members, loading } = useConsoleData()
+  const { agents, daemons, integrations, allSessions, orgHasSessions, members, loading } = useConsoleData()
   const { runAction, firstAgent } = useGsActions()
   const pathname = usePathname()
   const authOn = isAuthConfigured()
@@ -100,6 +101,7 @@ export default function GettingStarted() {
     () =>
       computeGettingStarted({
         agents,
+        daemons,
         integrations,
         sessions: allSessions,
         members,
@@ -107,10 +109,13 @@ export default function GettingStarted() {
         orgHasSessions,
         githubLinked,
         githubEnabled,
-        sessionAccessAvailable
+        sessionAccessAvailable,
+        // Cloud pool on ⇒ the "Connect a daemon" step is dropped (lib/getting-started.ts).
+        poolEnabled: featureFlagEnabled('daemon-pool')
       }),
     [
       agents,
+      daemons,
       integrations,
       allSessions,
       members,
@@ -123,7 +128,8 @@ export default function GettingStarted() {
   )
 
   // Show on every console page while the checklist is incomplete — including a
-  // brand-new org, where setting up the built-in agent is the first open step. The full-screen
+  // brand-new org, where the first open step is "Connect a daemon" (or, on the cloud
+  // pool, setting up the built-in agent). The full-screen
   // /onboarding wizard is a separate route (AgentsView redirects an empty org there);
   // the pill only steps aside for that route, not for the empty-org state itself.
   const onOnboardingRoute = pathname?.includes('/onboarding')

--- a/packages/web/src/components/console/GettingStartedChecklist.test.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.test.tsx
@@ -35,7 +35,13 @@ const render = async () => {
   await act(async () => root.render(<Probe />))
 }
 
+/** Whether this deployment offers the cloud pool (lib/feature-flags.ts). */
+const setFlags = (value: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: value }
+}
+
 beforeEach(() => {
+  setFlags('')
   mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
   mocks.daemons = []
   mocks.openModal.mockReset()
@@ -56,6 +62,24 @@ describe('useGsActions — the agent step', () => {
 
   it('edits the built-in agent directly once a daemon exists', async () => {
     mocks.daemons = [{ daemonId: 'dmn_1', status: 'online' }]
+    await render()
+    act(() => run({ kind: 'agent' }))
+    expect(mocks.openModal).toHaveBeenCalledWith('editAgent', mocks.agents[0], { focusSection: 'basics' })
+  })
+
+  // A fleet of pool Pods with the pool hidden is nothing to place onto: EditAgentModal filters
+  // them out and would offer only "No daemon", so the step still needs the Add-daemon chain.
+  it('still mints a daemon when the only fleet rows are hidden pool Pods', async () => {
+    mocks.daemons = [{ daemonId: 'pool-pod-1', pool: true, status: 'online' }]
+    await render()
+    act(() => run({ kind: 'agent' }))
+    expect(mocks.openModal).toHaveBeenCalledWith('daemon', mocks.agents[0], { focusSection: 'basics' })
+  })
+
+  // With the pool offered, Cloud IS a placement target — the editor owns that choice.
+  it('edits directly when the deployment offers the pool those Pods belong to', async () => {
+    setFlags('daemon-pool')
+    mocks.daemons = [{ daemonId: 'pool-pod-1', pool: true, status: 'online' }]
     await render()
     act(() => run({ kind: 'agent' }))
     expect(mocks.openModal).toHaveBeenCalledWith('editAgent', mocks.agents[0], { focusSection: 'basics' })

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -47,6 +47,8 @@ export function useGsActions() {
   const runAction = useCallback(
     (action: GsAction) => {
       switch (action.kind) {
+        case 'daemon':
+          return openModal('daemon')
         case 'agent':
           if (!builtinAgent) return openModal('agent')
           // Same chain the Agents / Agent detail "Add daemon" chips use (preset-agents.md

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -17,8 +17,9 @@ import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
 import { useModal } from './ModalProvider'
 import type { GsAction, GsItem } from '@/lib/getting-started'
-import { agentIsPlaced, agentLabel, modelLabel, runtimeLabel } from '@/lib/data'
+import { agentIsPlaced, agentLabel, localDaemons, modelLabel, runtimeLabel } from '@/lib/data'
 import { isAuthConfigured } from '@/lib/auth'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import {
   fetchGithubInstallations,
   fetchMySocialAccount,
@@ -43,6 +44,7 @@ export function useGsActions() {
   // (placement + runtime/model) rather than creating a new one — only a truly empty org
   // (no preset row) falls back to the create modal.
   const builtinAgent = agents.find((a) => a.builtin) ?? firstAgent
+  const placeableDaemons = featureFlagEnabled('daemon-pool') ? daemons : localDaemons(daemons)
 
   const runAction = useCallback(
     (action: GsAction) => {
@@ -52,10 +54,11 @@ export function useGsActions() {
         case 'agent':
           if (!builtinAgent) return openModal('agent')
           // Same chain the Agents / Agent detail "Add daemon" chips use (preset-agents.md
-          // §3.4): with no daemon in the org the edit modal's picker would offer only "No
+          // §3.4): with nothing to place onto the edit modal's picker would offer only "No
           // daemon", so mint one first and chain back into the edit dialog, where the
-          // fresh (and only) daemon is auto-preselected.
-          return daemons.length === 0
+          // fresh (and only) daemon is auto-preselected. Cloud counts only where the
+          // deployment offers it — the picker hides pool Pods otherwise.
+          return placeableDaemons.length === 0
             ? openModal('daemon', builtinAgent, { focusSection: 'basics' })
             : openModal('editAgent', builtinAgent, { focusSection: 'basics' })
         case 'slack': {
@@ -88,7 +91,7 @@ export function useGsActions() {
           return router.push(orgPath('/settings#session-access'))
       }
     },
-    [openModal, router, orgPath, firstAgent, builtinAgent, agents, daemons]
+    [openModal, router, orgPath, firstAgent, builtinAgent, agents, placeableDaemons]
   )
 
   return { runAction, firstAgent }

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -12,9 +12,13 @@ const mocks = vi.hoisted(() => ({
   members: [] as Array<Record<string, unknown>>,
   agentsLoading: false,
   daemonsLoading: false,
+  provisionDaemon: vi.fn(),
+  reconnectDaemon: vi.fn(),
+  deleteDaemon: vi.fn(),
   updateAgent: vi.fn(),
   moveAgent: vi.fn(),
   refresh: vi.fn(),
+  refreshDaemons: vi.fn(),
   push: vi.fn(),
   skipOnboarding: vi.fn()
 }))
@@ -32,9 +36,13 @@ vi.mock('@/lib/data-context', () => ({
     members: mocks.members,
     agentsLoading: mocks.agentsLoading,
     daemonsLoading: mocks.daemonsLoading,
+    provisionDaemon: mocks.provisionDaemon,
+    reconnectDaemon: mocks.reconnectDaemon,
+    deleteDaemon: mocks.deleteDaemon,
     updateAgent: mocks.updateAgent,
     moveAgent: mocks.moveAgent,
-    refresh: mocks.refresh
+    refresh: mocks.refresh,
+    refreshDaemons: mocks.refreshDaemons
   })
 }))
 // RuntimeSelect pulls the ACP registry context + AgentMark; stub it to the picked value.
@@ -48,6 +56,7 @@ vi.mock('@/lib/onboarding', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/onboarding')>()
   return { ...actual, skipOnboarding: mocks.skipOnboarding }
 })
+vi.mock('@/lib/daemon-commands', () => ({ daemonCommands: (command: string) => ({ run: command, login: command }) }))
 vi.mock('@/components/console/GettingStartedChecklist', () => ({
   useGsActions: () => ({ runAction: vi.fn(), firstAgent: mocks.agents[0] }),
   useGithubProfileLinked: () => undefined,
@@ -57,9 +66,7 @@ vi.mock('@/components/console/GettingStartedChecklist', () => ({
   // drops the session-access row on a definitive false).
   useSessionAccessCardAvailable: () => undefined,
   useSlackPlatformAppAvailable: () => true,
-  GsRows: ({ items }: { items: Array<{ key: string; label: string }> }) => (
-    <div>rows {items.map((i) => i.key).join(',')}</div>
-  )
+  GsRows: () => <div>rows</div>
 }))
 vi.mock('@/components/marks', () => ({
   LogoMark: () => <span>logo</span>,
@@ -76,6 +83,7 @@ vi.mock('@/components/ui', () => ({
 }))
 
 import OnboardingView from './OnboardingView'
+import { FALLBACK_RUNTIME_IDS } from '@/lib/data'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -98,7 +106,13 @@ const render = async () => {
   await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
 }
 
+/** Cloud pool on ⇒ onboarding skips the daemon phase entirely (lib/feature-flags.ts). */
+const setFlags = (value: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: value }
+}
+
 beforeEach(() => {
+  setFlags('') // self-hosted by default: the daemon phase is the blocking first step
   mocks.agents = []
   mocks.daemons = []
   mocks.integrations = []
@@ -106,7 +120,11 @@ beforeEach(() => {
   mocks.members = []
   mocks.agentsLoading = false
   mocks.daemonsLoading = false
+  mocks.provisionDaemon.mockReset()
+  mocks.reconnectDaemon.mockReset()
+  mocks.deleteDaemon.mockReset().mockResolvedValue(undefined)
   mocks.refresh.mockReset()
+  mocks.refreshDaemons.mockReset().mockResolvedValue(undefined)
   mocks.updateAgent.mockReset().mockResolvedValue(undefined)
   mocks.moveAgent.mockReset().mockResolvedValue(undefined)
   mocks.push.mockReset()
@@ -121,22 +139,104 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-describe('onboarding — checklist reveal', () => {
-  it('reveals the checklist with no daemon step and never provisions one', async () => {
+describe('onboarding — connect step', () => {
+  it('mints a join command on mount when no daemon is online', async () => {
+    mocks.provisionDaemon.mockResolvedValue({ daemonId: 'dmn_new', command: 'agentconnect run' })
     await render()
-    expect(host.textContent).not.toContain('Connect your daemon')
-    expect(host.textContent).toContain('Welcome to AgentConnect')
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
+    expect(host.textContent).toContain('Connect your daemon')
+    expect(host.textContent).toContain('agentconnect run')
+    expect(host.textContent).toContain('Listening for dmn_new')
+  })
+
+  it('reconnects an existing offline daemon instead of provisioning a new one', async () => {
+    mocks.daemons = [{ daemonId: 'offline-1', status: 'offline' }]
+    mocks.reconnectDaemon.mockResolvedValue({ command: 'agentconnect run --resume' })
+    await render()
+    expect(mocks.reconnectDaemon).toHaveBeenCalledWith('offline-1')
+    expect(mocks.provisionDaemon).not.toHaveBeenCalled()
+  })
+
+  it('deletes an unclaimed provisioned daemon when exploring the console instead', async () => {
+    mocks.provisionDaemon.mockResolvedValue({ daemonId: 'dmn_new', command: 'agentconnect run' })
+    await render()
+    await click('Explore the console first')
+    expect(mocks.deleteDaemon).toHaveBeenCalledWith('dmn_new')
+    expect(mocks.skipOnboarding).toHaveBeenCalledWith('acme')
+    expect(mocks.push).toHaveBeenCalledWith('/acme/home')
+  })
+
+  // Partial-load regression: agents resolving first (every org ships the builtin
+  // preset) must NOT trigger a mint while the fleet list is still loading — the
+  // pending response may already contain a connected daemon.
+  it('does not mint while the daemon list is still loading, even with agents loaded', async () => {
+    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
+    mocks.daemonsLoading = true
+    await render()
+    expect(mocks.provisionDaemon).not.toHaveBeenCalled()
+    expect(mocks.reconnectDaemon).not.toHaveBeenCalled()
+  })
+
+  it('offers Retry after a mint failure and re-drives the request', async () => {
+    mocks.provisionDaemon
+      .mockRejectedValueOnce(new Error('cp unreachable'))
+      .mockResolvedValue({ daemonId: 'dmn_new', command: 'agentconnect run' })
+    await render()
+    expect(host.textContent).toContain('cp unreachable')
+    await click('Retry')
+    expect(mocks.refreshDaemons).toHaveBeenCalled()
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(2)
+    expect(host.textContent).toContain('agentconnect run')
+  })
+
+  // A failed refresh leaves the stale snapshot — re-arming against it could duplicate
+  // an ambiguously-successful provision. Stay latched, show the error, keep Retry.
+  it('does not re-arm provisioning when the fleet refresh itself fails', async () => {
+    mocks.provisionDaemon.mockRejectedValueOnce(new Error('cp unreachable'))
+    mocks.refreshDaemons.mockRejectedValue(new Error('network down'))
+    await render()
+    await click('Retry')
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1) // no second mint
+    expect(host.textContent).toContain('Could not refresh the daemon list')
+  })
+
+  // Ambiguous success: the failed provision actually landed server-side. Retry must
+  // observe the refreshed fleet (the new offline row) and reconnect it — never mint
+  // a second daemon against the stale empty list.
+  it('retries via reconnect when the failed provision succeeded server-side', async () => {
+    mocks.provisionDaemon.mockRejectedValueOnce(new Error('response lost'))
+    mocks.refreshDaemons.mockImplementation(async () => {
+      mocks.daemons = [{ daemonId: 'dmn_ghost', status: 'offline' }]
+    })
+    mocks.reconnectDaemon.mockResolvedValue({ command: 'agentconnect run --resume' })
+    await render()
+    expect(host.textContent).toContain('response lost')
+    await click('Retry')
+    expect(mocks.reconnectDaemon).toHaveBeenCalledWith('dmn_ghost')
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('onboarding — daemon online reveal', () => {
+  beforeEach(() => {
+    mocks.daemons = [{ daemonId: 'dmn_new', status: 'online', name: 'edge-1' }]
+  })
+
+  it('reveals the checklist and never provisions a daemon', async () => {
+    await render()
+    expect(mocks.provisionDaemon).not.toHaveBeenCalled()
+    expect(host.textContent).toContain('Your daemon is online')
     expect(host.textContent).toContain('Getting started')
     expect(host.textContent).toContain('rows') // <GsRows/> stub
-    expect(host.textContent).not.toContain('daemon') // no connect-a-daemon row
   })
 
   it('finish stays disabled until every step is done; skip always exits to the console', async () => {
-    await render()
+    await render() // only the daemon step is done → finish disabled
     expect(button('Finish onboarding').disabled).toBe(true)
     await click('Skip for now')
-    expect(mocks.skipOnboarding).toHaveBeenCalledWith('acme')
     expect(mocks.push).toHaveBeenCalledWith('/acme/home')
+    // an online daemon that has connected is never deleted on the way out
+    expect(mocks.deleteDaemon).not.toHaveBeenCalled()
   })
 })
 
@@ -158,23 +258,10 @@ describe('onboarding — configure the built-in agent', () => {
     await render()
     expect(host.textContent).toContain('Configure')
     expect(host.textContent).toContain('runtime-claude') // RuntimeSelect stub, seeded from the daemon
-    expect(host.textContent).not.toContain('Welcome to AgentConnect')
-    // the daemon is never shown or chosen here
-    expect(host.textContent).not.toContain('edge-1')
+    expect(host.textContent).not.toContain('Your daemon is online')
   })
 
-  // No daemon yet (the connect step is gone): runtime/model still save, placement is
-  // simply skipped and waits for the checklist's daemon step.
-  it('saves runtime and model with no daemon, without a placement move', async () => {
-    mocks.daemons = []
-    await render()
-    await click('Save and continue')
-    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude' })
-    expect(mocks.moveAgent).not.toHaveBeenCalled()
-    expect(host.textContent).toContain('Welcome to AgentConnect')
-  })
-
-  it('sets the runtime BEFORE moving the agent onto the org daemon, then reveals', async () => {
+  it('sets the runtime BEFORE moving the agent onto the connected daemon, then reveals', async () => {
     await render()
     await click('Save and continue')
     expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude', model: 'claude-sonnet-4-5' })
@@ -190,6 +277,32 @@ describe('onboarding — configure the built-in agent', () => {
     await render()
     await click('Skip for now')
     expect(mocks.updateAgent).not.toHaveBeenCalled()
+    expect(host.textContent).toContain('Your daemon is online')
+  })
+})
+
+// The cloud pool hosts the agents, so there is nothing to connect: no mint, no waiting
+// card, and the built-in agent is configured without a placement move.
+describe('onboarding — cloud pool', () => {
+  beforeEach(() => setFlags('daemon-pool'))
+
+  it('skips the daemon phase and never provisions one', async () => {
+    await render()
+    expect(mocks.provisionDaemon).not.toHaveBeenCalled()
+    expect(mocks.reconnectDaemon).not.toHaveBeenCalled()
+    expect(host.textContent).not.toContain('Connect your daemon')
+    expect(host.textContent).toContain('Welcome to AgentConnect')
+  })
+
+  it('configures the built-in agent with no daemon row and no placement move', async () => {
+    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
+    await render()
+    expect(host.textContent).toContain('Configure')
+    expect(host.textContent).not.toContain('just connected') // no "Runs on" row
+    await click('Save and continue')
+    // No daemon reports runtimes on the pool, so the static fallback seeds the picker.
+    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: FALLBACK_RUNTIME_IDS[0] })
+    expect(mocks.moveAgent).not.toHaveBeenCalled()
     expect(host.textContent).toContain('Welcome to AgentConnect')
   })
 })

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -311,16 +311,17 @@ describe('onboarding — cloud pool', () => {
     expect(host.textContent).toContain('Configure')
     expect(host.textContent).not.toContain('just connected') // no "Runs on" row
     await click('Save and continue')
-    // No daemon reports runtimes on the pool, so the static fallback seeds the picker.
+    // No daemon reports runtimes on the pool, so the static fallback seeds the picker. With no
+    // pool member either there is nothing to place onto — the agent editor owns that choice.
     expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: FALLBACK_RUNTIME_IDS[0] })
     expect(mocks.moveAgent).not.toHaveBeenCalled()
     expect(host.textContent).toContain('Welcome to AgentConnect')
   })
 
   // GET /daemons carries the install-wide pool's member Pods in every org's fleet. They are
-  // replaceable identities: one may seed the runtime/model pickers, but pinning the preset
-  // to a Pod (or calling it "just connected") is never right — Cloud is picked in the editor.
-  it('reads runtimes from a pool member without placing the agent onto it', async () => {
+  // replaceable identities: one may seed the runtime/model pickers, but the placement names
+  // the POOL, never a Pod, and nothing here "just connected".
+  it('reads runtimes from a pool member but places on the pool, not the Pod', async () => {
     mocks.daemons = [
       {
         daemonId: 'pool-pod-1',
@@ -337,6 +338,6 @@ describe('onboarding — cloud pool', () => {
     expect(host.textContent).not.toContain('ac-cloud-7f9')
     await click('Save and continue')
     expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude', model: 'claude-sonnet-4-5' })
-    expect(mocks.moveAgent).not.toHaveBeenCalled()
+    expect(mocks.moveAgent).toHaveBeenCalledWith('ag_ac', { kind: 'pool' })
   })
 })

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -149,6 +149,17 @@ describe('onboarding — connect step', () => {
     expect(host.textContent).toContain('Listening for dmn_new')
   })
 
+  // With the pool flag off the console hides pool Pods, so an org whose fleet carries them
+  // is still daemon-less here: mint a real join command, never a reconnect token for a Pod.
+  it('ignores pool member Pods when the deployment does not offer the pool', async () => {
+    mocks.daemons = [{ daemonId: 'pool-pod-1', pool: true, status: 'online', name: 'ac-cloud-7f9' }]
+    mocks.provisionDaemon.mockResolvedValue({ daemonId: 'dmn_new', command: 'agentconnect run' })
+    await render()
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
+    expect(mocks.reconnectDaemon).not.toHaveBeenCalled()
+    expect(host.textContent).toContain('Connect your daemon')
+  })
+
   it('reconnects an existing offline daemon instead of provisioning a new one', async () => {
     mocks.daemons = [{ daemonId: 'offline-1', status: 'offline' }]
     mocks.reconnectDaemon.mockResolvedValue({ command: 'agentconnect run --resume' })
@@ -304,5 +315,28 @@ describe('onboarding — cloud pool', () => {
     expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: FALLBACK_RUNTIME_IDS[0] })
     expect(mocks.moveAgent).not.toHaveBeenCalled()
     expect(host.textContent).toContain('Welcome to AgentConnect')
+  })
+
+  // GET /daemons carries the install-wide pool's member Pods in every org's fleet. They are
+  // replaceable identities: one may seed the runtime/model pickers, but pinning the preset
+  // to a Pod (or calling it "just connected") is never right — Cloud is picked in the editor.
+  it('reads runtimes from a pool member without placing the agent onto it', async () => {
+    mocks.daemons = [
+      {
+        daemonId: 'pool-pod-1',
+        pool: true,
+        status: 'online',
+        name: 'ac-cloud-7f9',
+        runtimeModels: [{ runtime: 'claude', models: ['claude-sonnet-4-5'] }]
+      }
+    ]
+    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
+    await render()
+    expect(host.textContent).toContain('runtime-claude') // seeded from the pool member
+    expect(host.textContent).not.toContain('just connected')
+    expect(host.textContent).not.toContain('ac-cloud-7f9')
+    await click('Save and continue')
+    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude', model: 'claude-sonnet-4-5' })
+    expect(mocks.moveAgent).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -26,7 +26,9 @@ import {
   FALLBACK_RUNTIME_IDS,
   agentIsPlaced,
   agentLabel,
+  localDaemons,
   modelLabel,
+  poolLabel,
   preferredModelFor,
   loginRequiredRuntimeIds
 } from '@/lib/data'
@@ -90,9 +92,9 @@ export default function OnboardingView() {
   const cloudDaemon = featureFlagEnabled('daemon-pool')
   // Pool Pods are never a machine the user connected, so the connect step ignores them —
   // off the pool the console hides them entirely, and a reconnect token for one is nonsense.
-  const localDaemons = daemons.filter((d) => !d.pool)
-  const daemonReady = cloudDaemon || localDaemons.some(daemonCompletesOnboarding)
-  const offlineDaemonId = firstReconnectableDaemonId(localDaemons)
+  const machines = localDaemons(daemons)
+  const daemonReady = cloudDaemon || machines.some(daemonCompletesOnboarding)
+  const offlineDaemonId = firstReconnectableDaemonId(machines)
   const loading = (agentsLoading || daemonsLoading) && daemons.length === 0 && agents.length === 0
 
   // Once a daemon is serving, configure the org's built-in `agentconnect` preset before
@@ -101,7 +103,7 @@ export default function OnboardingView() {
   // ships unplaced (daemon '—', deferred runtime); it's ready once both are set. Older
   // orgs without the preset just skip straight to the reveal.
   const builtinAgent = agents.find((a) => a.builtin)
-  const servingDaemon = localDaemons.find((d) => d.status === 'online') ?? localDaemons.find(daemonCompletesOnboarding)
+  const servingDaemon = machines.find((d) => d.status === 'online') ?? machines.find(daemonCompletesOnboarding)
   // The fleet list includes the install-wide pool's member Pods, which are replaceable
   // identities — pinning the preset to one is never right. So pool mode has NO concrete
   // placement target here (the agent editor owns the Cloud choice); one live member still
@@ -111,6 +113,8 @@ export default function OnboardingView() {
   const capabilityDaemon = cloudDaemon
     ? (daemons.find((d) => d.pool && d.status === 'online') ?? daemons.find((d) => d.pool))
     : servingDaemon
+  // Placing on the pool needs a pool that exists; without one the agent editor owns the choice.
+  const poolTarget = cloudDaemon && capabilityDaemon !== undefined
   const needsAgentSetup = !!builtinAgent && (cloudDaemon || !!placementDaemon) && !agentIsPlaced(builtinAgent)
   const [skipSetup, setSkipSetup] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -125,8 +129,10 @@ export default function OnboardingView() {
     setSaveErr(null)
     try {
       await updateAgent(builtinAgent.id, { runtime, ...(model ? { model } : {}) })
-      // Onboarding places onto a concrete machine; Cloud is chosen from the agent editor.
+      // Onto the machine just connected, or — on the pool — onto the POOL itself. A pool
+      // placement names the pool, never the member Pod whose capabilities seeded the form.
       if (placementDaemon) await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: placementDaemon.daemonId })
+      else if (poolTarget) await moveAgent(builtinAgent.id, { kind: 'pool' })
       await refresh()
       setSkipSetup(true)
     } catch (e) {
@@ -256,6 +262,7 @@ export default function OnboardingView() {
           agent={builtinAgent!}
           daemon={capabilityDaemon}
           runsOn={placementDaemon}
+          poolTarget={poolTarget}
           saving={saving}
           err={saveErr}
           onSave={saveAgentSetup}
@@ -406,6 +413,7 @@ function ConfigureAgent({
   agent,
   daemon,
   runsOn,
+  poolTarget,
   saving,
   err,
   onSave,
@@ -415,9 +423,11 @@ function ConfigureAgent({
   /** Whose reported runtimes/models seed the pickers — a pool member on the pool, else the
    *  just-connected daemon. Absent ⇒ the static fallback list. Never a placement. */
   daemon?: DaemonRow
-  /** The daemon this agent is being placed onto — absent on the pool, where nothing was
-   *  connected and Cloud is picked from the agent editor. */
+  /** The machine this agent is being placed onto — absent on the pool, which has no member
+   *  identity to pin to. */
   runsOn?: DaemonRow
+  /** Pool mode with a live pool: the agent lands on the pool itself. */
+  poolTarget: boolean
   saving: boolean
   err: string | null
   onSave: (runtime: string, model: string) => void
@@ -450,19 +460,28 @@ function ConfigureAgent({
         <p className="max-w-[430px] font-sans text-[14.5px] font-normal leading-[1.55] text-(--text-secondary)">
           {runsOn
             ? 'Your org’s built-in agent runs on the daemon you just connected. Pick a runtime and model, and it’s ready to work.'
-            : 'Every org ships with a built-in agent. Pick the runtime and model it should use, and it’s ready to work.'}
+            : `Your org’s built-in agent runs on ${poolTarget ? poolLabel() : 'your infrastructure'}. Pick a runtime and model, and it’s ready to work.`}
         </p>
       </div>
 
       <div className="flex flex-col gap-[14px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-xs)">
-        {runsOn && (
+        {(runsOn || poolTarget) && (
           <div className="fld">
             <span className="fldlbl">Runs on</span>
-            <div className="inp cursor-not-allowed" title="Set to the daemon you just connected">
-              <span className="truncate text-(--text-primary)">{runsOn.name}</span>
-              <span className="ml-auto flex-none font-sans text-[11.5px] leading-none text-(--text-tertiary)">
-                just connected
-              </span>
+            <div
+              className="inp cursor-not-allowed"
+              title={
+                runsOn
+                  ? 'Set to the daemon you just connected'
+                  : 'Move it to a machine any time from the agent’s settings'
+              }
+            >
+              <span className="truncate text-(--text-primary)">{runsOn ? runsOn.name : poolLabel()}</span>
+              {runsOn && (
+                <span className="ml-auto flex-none font-sans text-[11.5px] leading-none text-(--text-tertiary)">
+                  just connected
+                </span>
+              )}
             </div>
           </div>
         )}

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -88,8 +88,11 @@ export default function OnboardingView() {
   // Cloud pool on ⇒ agents run there, so onboarding never asks for a daemon: treat the
   // blocking step as already satisfied, which also latches off the mint/poll effects below.
   const cloudDaemon = featureFlagEnabled('daemon-pool')
-  const daemonReady = cloudDaemon || daemons.some(daemonCompletesOnboarding)
-  const offlineDaemonId = firstReconnectableDaemonId(daemons)
+  // Pool Pods are never a machine the user connected, so the connect step ignores them —
+  // off the pool the console hides them entirely, and a reconnect token for one is nonsense.
+  const localDaemons = daemons.filter((d) => !d.pool)
+  const daemonReady = cloudDaemon || localDaemons.some(daemonCompletesOnboarding)
+  const offlineDaemonId = firstReconnectableDaemonId(localDaemons)
   const loading = (agentsLoading || daemonsLoading) && daemons.length === 0 && agents.length === 0
 
   // Once a daemon is serving, configure the org's built-in `agentconnect` preset before
@@ -98,9 +101,16 @@ export default function OnboardingView() {
   // ships unplaced (daemon '—', deferred runtime); it's ready once both are set. Older
   // orgs without the preset just skip straight to the reveal.
   const builtinAgent = agents.find((a) => a.builtin)
-  const placementDaemon = daemons.find((d) => d.status === 'online') ?? daemons.find(daemonCompletesOnboarding)
-  // Off the pool the daemon we just brought online is the placement target; on the pool
-  // there may be no daemon row to place onto, and the agent editor owns that choice.
+  const servingDaemon = localDaemons.find((d) => d.status === 'online') ?? localDaemons.find(daemonCompletesOnboarding)
+  // The fleet list includes the install-wide pool's member Pods, which are replaceable
+  // identities — pinning the preset to one is never right. So pool mode has NO concrete
+  // placement target here (the agent editor owns the Cloud choice); one live member still
+  // stands in for the pool's REPORTED runtimes/models, the same seam the edit form's
+  // capability source uses. Off the pool both are the daemon we just brought online.
+  const placementDaemon = cloudDaemon ? undefined : servingDaemon
+  const capabilityDaemon = cloudDaemon
+    ? (daemons.find((d) => d.pool && d.status === 'online') ?? daemons.find((d) => d.pool))
+    : servingDaemon
   const needsAgentSetup = !!builtinAgent && (cloudDaemon || !!placementDaemon) && !agentIsPlaced(builtinAgent)
   const [skipSetup, setSkipSetup] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -115,7 +125,7 @@ export default function OnboardingView() {
     setSaveErr(null)
     try {
       await updateAgent(builtinAgent.id, { runtime, ...(model ? { model } : {}) })
-      // Onboarding places onto a concrete machine; the pool is chosen from the agent editor.
+      // Onboarding places onto a concrete machine; Cloud is chosen from the agent editor.
       if (placementDaemon) await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: placementDaemon.daemonId })
       await refresh()
       setSkipSetup(true)
@@ -244,7 +254,8 @@ export default function OnboardingView() {
       ) : needsAgentSetup && !skipSetup ? (
         <ConfigureAgent
           agent={builtinAgent!}
-          daemon={placementDaemon}
+          daemon={capabilityDaemon}
+          runsOn={placementDaemon}
           saving={saving}
           err={saveErr}
           onSave={saveAgentSetup}
@@ -394,14 +405,19 @@ function ConnectDaemon({
 function ConfigureAgent({
   agent,
   daemon,
+  runsOn,
   saving,
   err,
   onSave,
   onSkip
 }: {
   agent: Agent
-  /** The just-connected daemon — absent on the cloud pool, where nothing was connected. */
+  /** Whose reported runtimes/models seed the pickers — a pool member on the pool, else the
+   *  just-connected daemon. Absent ⇒ the static fallback list. Never a placement. */
   daemon?: DaemonRow
+  /** The daemon this agent is being placed onto — absent on the pool, where nothing was
+   *  connected and Cloud is picked from the agent editor. */
+  runsOn?: DaemonRow
   saving: boolean
   err: string | null
   onSave: (runtime: string, model: string) => void
@@ -432,18 +448,18 @@ function ConfigureAgent({
           Configure {agentLabel(agent)}
         </h1>
         <p className="max-w-[430px] font-sans text-[14.5px] font-normal leading-[1.55] text-(--text-secondary)">
-          {daemon
+          {runsOn
             ? 'Your org’s built-in agent runs on the daemon you just connected. Pick a runtime and model, and it’s ready to work.'
             : 'Every org ships with a built-in agent. Pick the runtime and model it should use, and it’s ready to work.'}
         </p>
       </div>
 
       <div className="flex flex-col gap-[14px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-xs)">
-        {daemon && (
+        {runsOn && (
           <div className="fld">
             <span className="fldlbl">Runs on</span>
             <div className="inp cursor-not-allowed" title="Set to the daemon you just connected">
-              <span className="truncate text-(--text-primary)">{daemon.name}</span>
+              <span className="truncate text-(--text-primary)">{runsOn.name}</span>
               <span className="ml-auto flex-none font-sans text-[11.5px] leading-none text-(--text-tertiary)">
                 just connected
               </span>

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -1,14 +1,16 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
 import { isAuthConfigured } from '@/lib/auth'
-import { daemonCompletesOnboarding, skipOnboarding } from '@/lib/onboarding'
+import { daemonCompletesOnboarding, firstReconnectableDaemonId, skipOnboarding } from '@/lib/onboarding'
+import { daemonCommands } from '@/lib/daemon-commands'
 import { computeGettingStarted } from '@/lib/getting-started'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import {
   AddToSlackRow,
   GsRows,
@@ -29,13 +31,25 @@ import {
   loginRequiredRuntimeIds
 } from '@/lib/data'
 import type { Agent, DaemonRow } from '@/lib/data'
+import type { DaemonConnectDto } from '@/lib/api'
 
-// Onboarding (design: "AgentConnect Onboarding"). Nothing here blocks: the screen
-// configures the org's built-in agent (runtime + model) and then reveals the SAME
-// getting-started checklist the console shows (lib/getting-started.ts). Connecting a
-// daemon is no longer an onboarding step — it lives in the checklist and follows the
-// user into the console (the corner pill in GettingStarted.tsx). Rendered full-screen
-// (no rail) by the shell on the /onboarding route.
+// Onboarding (design: "AgentConnect Onboarding"). Where the deployment offers the cloud
+// pool (`daemon-pool`) there is nothing to connect, so the daemon phase is skipped
+// entirely and onboarding opens on the built-in agent's configuration. Self-hosted
+// (flag off) keeps the flow below unchanged: connecting a daemon is the ONLY
+// blocking step; when one comes online the screen transitions in place and reveals the
+// SAME getting-started checklist the console shows (lib/getting-started.ts). No more
+// 3-step wizard — the remaining steps live in the checklist and follow the user into
+// the console (the corner pill in GettingStarted.tsx). Rendered full-screen (no rail)
+// by the shell on the /onboarding route.
+//
+// The daemon step is inline and functional: it mints a real join command and polls for
+// the daemon to come online (like AddDaemonModal). Not shipped yet, so not shown as
+// "done for you": preset agents + the one-click built-in Bot connect (preset-agents.md
+// §3/§5) — the revealed checklist derives from real state, so "Create your first agent"
+// etc. appear as ordinary open steps until those land.
+
+type DaemonCommand = Pick<DaemonConnectDto, 'daemonId' | 'command'>
 
 export default function OnboardingView() {
   const router = useRouter()
@@ -49,9 +63,13 @@ export default function OnboardingView() {
     members,
     agentsLoading,
     daemonsLoading,
+    provisionDaemon,
+    reconnectDaemon,
+    deleteDaemon,
     updateAgent,
     moveAgent,
-    refresh
+    refresh,
+    refreshDaemons
   } = useConsoleData()
   const { orgPath } = useOrgs()
   const { runAction } = useGsActions()
@@ -64,22 +82,33 @@ export default function OnboardingView() {
   const orgKey = typeof params.slug === 'string' ? params.slug : '-'
   const authOn = isAuthConfigured()
 
+  // A live daemon or a planned relaunch reveals the checklist. Only an unexpected offline
+  // row is eligible for a replacement connect token — it may be a provisioned daemon whose
+  // one-time command was lost on reload; the mint below reconnects it.
+  // Cloud pool on ⇒ agents run there, so onboarding never asks for a daemon: treat the
+  // blocking step as already satisfied, which also latches off the mint/poll effects below.
+  const cloudDaemon = featureFlagEnabled('daemon-pool')
+  const daemonReady = cloudDaemon || daemons.some(daemonCompletesOnboarding)
+  const offlineDaemonId = firstReconnectableDaemonId(daemons)
   const loading = (agentsLoading || daemonsLoading) && daemons.length === 0 && agents.length === 0
 
-  // First screen: configure the org's built-in `agentconnect` preset — the user picks a
-  // runtime + model (design: the built-in agent replaces "create your first agent"). The
-  // preset ships unplaced with a deferred runtime. If the org already runs a daemon we
-  // place the agent onto it behind the scenes; otherwise placement waits for the
-  // checklist's daemon step. Older orgs without the preset skip straight to the reveal.
+  // Once a daemon is serving, configure the org's built-in `agentconnect` preset before
+  // the checklist reveal: auto-assign it to that daemon and let the user pick a runtime +
+  // model (design: the built-in agent replaces "create your first agent"). The preset
+  // ships unplaced (daemon '—', deferred runtime); it's ready once both are set. Older
+  // orgs without the preset just skip straight to the reveal.
   const builtinAgent = agents.find((a) => a.builtin)
   const placementDaemon = daemons.find((d) => d.status === 'online') ?? daemons.find(daemonCompletesOnboarding)
-  const [setupDone, setSetupDone] = useState(false)
-  const needsAgentSetup = !!builtinAgent && !agentIsPlaced(builtinAgent) && !setupDone
+  // Off the pool the daemon we just brought online is the placement target; on the pool
+  // there may be no daemon row to place onto, and the agent editor owns that choice.
+  const needsAgentSetup = !!builtinAgent && (cloudDaemon || !!placementDaemon) && !agentIsPlaced(builtinAgent)
+  const [skipSetup, setSkipSetup] = useState(false)
   const [saving, setSaving] = useState(false)
   const [saveErr, setSaveErr] = useState<string | null>(null)
 
   // Runtime becomes mandatory at placement, so set it FIRST, then move onto the daemon
-  // (the CP rejects a move on a runtime-less agent).
+  // (the CP rejects a move on a runtime-less agent). A placed agent flips needsAgentSetup
+  // off by itself; latching `skipSetup` also advances the pool case, where nothing moved.
   const saveAgentSetup = async (runtime: string, model: string) => {
     if (!builtinAgent) return
     setSaving(true)
@@ -89,7 +118,7 @@ export default function OnboardingView() {
       // Onboarding places onto a concrete machine; the pool is chosen from the agent editor.
       if (placementDaemon) await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: placementDaemon.daemonId })
       await refresh()
-      setSetupDone(true)
+      setSkipSetup(true)
     } catch (e) {
       setSaveErr(e instanceof Error ? e.message : String(e))
     } finally {
@@ -97,10 +126,103 @@ export default function OnboardingView() {
     }
   }
 
+  // --- Daemon provisioning (mirrors AddDaemonModal / the old wizard step 0) ----------
+  const [connect, setConnect] = useState<DaemonCommand | null>(null)
+  const [mintErr, setMintErr] = useState<string | null>(null)
+  const [elapsed, setElapsed] = useState(0)
+  const [copied, setCopied] = useState(false)
+  // Bumped by the error state's Retry — re-arms the mint effect after a failure.
+  const [mintAttempt, setMintAttempt] = useState(0)
+  const provisioned = useRef(false)
+  const commandPending = useRef<Promise<DaemonCommand> | null>(null)
+  const createdByWizard = useRef(false)
+  const connectedOnce = useRef(false)
+
+  // Mint only once BOTH lists have settled: agents can resolve first (every org ships
+  // the builtin preset, so `loading` clears on partial data) while the pending fleet
+  // response still contains a connected daemon — minting against the empty snapshot
+  // would provision a duplicate. Duplicate-safe on retry too: a provision that
+  // succeeded server-side surfaces as an offline row on the next refresh, which routes
+  // the retry through reconnect instead of a second provision.
+  useEffect(() => {
+    if (agentsLoading || daemonsLoading || daemonReady || provisioned.current) return
+    provisioned.current = true
+    setMintErr(null)
+    createdByWizard.current = !offlineDaemonId
+    const command: Promise<DaemonCommand> = offlineDaemonId
+      ? reconnectDaemon(offlineDaemonId).then((minted) => ({ daemonId: offlineDaemonId, command: minted.command }))
+      : provisionDaemon()
+    commandPending.current = command
+    command.then(setConnect).catch((e) => setMintErr(e instanceof Error ? e.message : String(e)))
+  }, [agentsLoading, daemonsLoading, daemonReady, offlineDaemonId, provisionDaemon, reconnectDaemon, mintAttempt])
+
+  // A transient mint failure must not strand the single blocking step. AWAIT the fleet
+  // refresh before re-arming: if the failed provision actually succeeded server-side
+  // (response lost), the refreshed list contains that daemon as an offline row, so the
+  // re-run reconnects it via `offlineDaemonId` instead of minting a duplicate. A FAILED
+  // refresh must NOT re-arm — the stale snapshot is exactly what could duplicate an
+  // ambiguously-successful provision; stay latched and keep the Retry on screen.
+  const retryMint = async () => {
+    setMintErr(null)
+    try {
+      await refreshDaemons()
+    } catch {
+      setMintErr('Could not refresh the daemon list — check your connection and retry.')
+      return
+    }
+    provisioned.current = false
+    commandPending.current = null
+    setMintAttempt((n) => n + 1)
+  }
+
+  // Poll until the daemon connects; tick the elapsed timer while waiting.
+  useEffect(() => {
+    if (daemonReady) {
+      connectedOnce.current = true
+      return
+    }
+    if (!connect) return
+    const poll = setInterval(refresh, 3000)
+    const tick = setInterval(() => setElapsed((s) => s + 1), 1000)
+    return () => {
+      clearInterval(poll)
+      clearInterval(tick)
+    }
+  }, [connect, daemonReady, refresh])
+
+  // Drop only a wizard-created row that was never claimed. Once it has connected or
+  // hosts an agent, leaving onboarding must never turn into a deletion.
+  const cleanupPending = async () => {
+    const pending = connect ?? (await commandPending.current?.catch(() => null))
+    const row = pending ? daemons.find((d) => d.daemonId === pending.daemonId) : undefined
+    const hostsAgent = pending ? agents.some((a) => a.daemon === pending.daemonId) : false
+    const shouldDelete =
+      pending && createdByWizard.current && !connectedOnce.current && !hostsAgent && row?.status !== 'online'
+    try {
+      if (shouldDelete) await deleteDaemon(pending.daemonId)
+    } catch {
+      /* best-effort — an unclaimed provisioned row is harmless */
+    }
+  }
   const goConsole = () => {
+    void cleanupPending()
     skipOnboarding(orgKey)
     router.push(orgPath('/home'))
   }
+
+  const cmd = connect ? daemonCommands(connect.command).run : null
+  const copy = async () => {
+    if (!cmd) return
+    try {
+      await navigator.clipboard.writeText(cmd)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1700)
+    } catch {
+      /* clipboard unavailable */
+    }
+  }
+  const listeningId = connect?.daemonId ?? offlineDaemonId ?? ''
+  const elapsedLabel = `${Math.floor(elapsed / 60)}:${String(elapsed % 60).padStart(2, '0')}`
 
   // The shell renders the full-screen frame + slim top bar (logo · theme · user menu)
   // for the /onboarding route; this is just the centered content.
@@ -108,19 +230,31 @@ export default function OnboardingView() {
     <div className="flex min-h-full items-center justify-center px-5 py-10">
       {loading ? (
         <LoadingState fill />
-      ) : needsAgentSetup ? (
+      ) : !daemonReady ? (
+        <ConnectDaemon
+          cmd={cmd}
+          mintErr={mintErr}
+          copied={copied}
+          onCopy={copy}
+          onRetry={() => void retryMint()}
+          listeningId={listeningId}
+          elapsedLabel={elapsedLabel}
+          onExplore={goConsole}
+        />
+      ) : needsAgentSetup && !skipSetup ? (
         <ConfigureAgent
           agent={builtinAgent!}
           daemon={placementDaemon}
           saving={saving}
           err={saveErr}
           onSave={saveAgentSetup}
-          onSkip={() => setSetupDone(true)}
+          onSkip={() => setSkipSetup(true)}
         />
       ) : (
         <RevealChecklist
           gs={computeGettingStarted({
             agents,
+            daemons,
             integrations,
             sessions: allSessions,
             members,
@@ -128,10 +262,12 @@ export default function OnboardingView() {
             orgHasSessions,
             githubLinked,
             githubEnabled,
-            sessionAccessAvailable
+            sessionAccessAvailable,
+            poolEnabled: cloudDaemon
           })}
           slackOneClick={slackOneClick}
           runAction={runAction}
+          cloudDaemon={cloudDaemon}
           onFinish={goConsole}
         />
       )}
@@ -139,10 +275,122 @@ export default function OnboardingView() {
   )
 }
 
-// --- Phase 1: configure the built-in agent -------------------------------------------
-// The user only picks runtime + model. Mirrors AddAgentModal's Runtime/Model row:
-// runtime ids come from the org's daemon when there is one (else the static fallback),
-// models from the chosen runtime's profile.
+// --- Phase 1: connect your daemon (the one blocking step) ----------------------------
+function ConnectDaemon({
+  cmd,
+  mintErr,
+  copied,
+  onCopy,
+  onRetry,
+  listeningId,
+  elapsedLabel,
+  onExplore
+}: {
+  cmd: string | null
+  mintErr: string | null
+  copied: boolean
+  onCopy: () => void
+  onRetry: () => void
+  listeningId: string
+  elapsedLabel: string
+  onExplore: () => void
+}) {
+  return (
+    <div className="flex w-full max-w-[560px] flex-col gap-[22px]">
+      <div className="flex flex-col items-center gap-[11px] text-center">
+        <span className="flex h-11 w-11 items-center justify-center rounded-[11px] border border-(--border-default) bg-(--surface-card) text-(--brand) shadow-(--shadow-xs)">
+          <Icon name="server" size={21} />
+        </span>
+        <div className="font-mono text-[11px] font-semibold uppercase leading-none tracking-[.12em] text-(--brand)">
+          Setup
+        </div>
+        <h1 className="font-sans text-[28px] font-semibold leading-[1.2] tracking-[-.02em] text-(--text-primary)">
+          Connect your daemon
+        </h1>
+        <p className="max-w-[450px] font-sans text-[14.5px] font-normal leading-[1.55] text-(--text-secondary)">
+          A daemon runs your agents on your own hardware. Run this one command wherever you want them to run — it
+          connects to AgentConnect and keeps running.
+        </p>
+      </div>
+
+      {/* Dark terminal block — the real minted join command */}
+      <div className="overflow-hidden rounded-[10px] border border-(--gray-800) bg-(--gray-1000) shadow-(--shadow-xs)">
+        <div className="flex items-center gap-2 border-b border-(--gray-800) py-[9px] pr-[10px] pl-[13px]">
+          <Icon name="terminal" size={13} color="var(--text-inverse-dim)" />
+          <span className="font-mono text-[11px] font-medium leading-normal tracking-[.02em] text-(--text-inverse-dim)">
+            one command · macOS, Linux, WSL
+          </span>
+          <button
+            type="button"
+            onClick={onCopy}
+            disabled={!cmd}
+            className="ml-auto inline-flex h-[26px] cursor-pointer items-center gap-[6px] rounded-md border border-white/15 bg-white/5 px-[9px] font-mono text-[11px] font-medium text-[#e6ebf1] hover:border-white/25 hover:bg-white/10 disabled:cursor-default disabled:opacity-50"
+          >
+            <Icon name={copied ? 'check' : 'copy'} size={12} />
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+        <div className="flex gap-[9px] break-all p-[15px] font-mono text-[13px] leading-[1.6] text-[#cdd6e0]">
+          {cmd ? (
+            <>
+              <span className="text-(--magenta-300)">$</span>
+              <span>{cmd}</span>
+            </>
+          ) : mintErr ? (
+            <span className="flex flex-wrap items-center gap-2">
+              <span className="text-(--status-error)">Could not provision a key — {mintErr}</span>
+              <button
+                type="button"
+                onClick={onRetry}
+                className="inline-flex h-[24px] cursor-pointer items-center gap-[5px] rounded-md border border-white/15 bg-white/5 px-2 font-mono text-[11px] font-medium text-[#e6ebf1] hover:border-white/25 hover:bg-white/10"
+              >
+                <Icon name="refresh-cw" size={11} />
+                Retry
+              </button>
+            </span>
+          ) : (
+            <span className="text-(--text-inverse-dim)">Minting key…</span>
+          )}
+        </div>
+      </div>
+
+      {/* Waiting card — auto-continues when the daemon comes online */}
+      <div className="flex items-center gap-[13px] rounded-[10px] border border-(--border-default) bg-(--surface-card) px-4 py-[14px] shadow-(--shadow-xs)">
+        <span className="h-[18px] w-[18px] flex-none animate-spin rounded-full border-2 border-(--gray-200) border-t-(--brand)" />
+        <div className="min-w-0 flex-1">
+          <div className="font-sans text-[13.5px] font-medium leading-normal text-(--text-primary)">
+            Waiting for your daemon to come online…
+          </div>
+          <div className="mt-[2px] font-mono text-[11.5px] leading-normal text-(--text-tertiary)">
+            {listeningId ? `Listening for ${listeningId} · ` : ''}this page continues on its own
+          </div>
+        </div>
+        <span className="flex-none font-mono text-[12px] tabular-nums text-(--text-tertiary)">{elapsedLabel}</span>
+      </div>
+
+      <div className="flex flex-col items-center gap-3">
+        <a
+          href="https://docs.agentconnect.md/docs/install-the-daemon"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-[6px] font-sans text-[12.5px] text-(--text-tertiary) no-underline hover:text-(--brand)"
+        >
+          Daemon not showing up? Read the setup guide
+          <Icon name="arrow-up-right" size={13} />
+        </a>
+        <Button variant="secondary" size="sm" onClick={onExplore}>
+          Explore the console first
+          <Icon name="arrow-right" size={14} />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// --- Phase 1.5: place + configure the built-in agent on the just-connected daemon ----
+// Daemon is fixed (the one we just brought online); the user only picks runtime + model.
+// Mirrors AddAgentModal's Daemon/Runtime/Model row: runtime ids come from the daemon's
+// reported profiles (else the static fallback), models from the chosen runtime's profile.
 function ConfigureAgent({
   agent,
   daemon,
@@ -152,6 +400,7 @@ function ConfigureAgent({
   onSkip
 }: {
   agent: Agent
+  /** The just-connected daemon — absent on the cloud pool, where nothing was connected. */
   daemon?: DaemonRow
   saving: boolean
   err: string | null
@@ -183,11 +432,24 @@ function ConfigureAgent({
           Configure {agentLabel(agent)}
         </h1>
         <p className="max-w-[430px] font-sans text-[14.5px] font-normal leading-[1.55] text-(--text-secondary)">
-          Every org ships with a built-in agent. Pick the runtime and model it should use, and it&rsquo;s ready to work.
+          {daemon
+            ? 'Your org’s built-in agent runs on the daemon you just connected. Pick a runtime and model, and it’s ready to work.'
+            : 'Every org ships with a built-in agent. Pick the runtime and model it should use, and it’s ready to work.'}
         </p>
       </div>
 
       <div className="flex flex-col gap-[14px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-xs)">
+        {daemon && (
+          <div className="fld">
+            <span className="fldlbl">Runs on</span>
+            <div className="inp cursor-not-allowed" title="Set to the daemon you just connected">
+              <span className="truncate text-(--text-primary)">{daemon.name}</span>
+              <span className="ml-auto flex-none font-sans text-[11.5px] leading-none text-(--text-tertiary)">
+                just connected
+              </span>
+            </div>
+          </div>
+        )}
         <div className="grid grid-cols-1 gap-[14px] desktop:grid-cols-2">
           <div className="fld">
             <span className="fldlbl">Runtime</span>
@@ -265,19 +527,22 @@ function ConfigureAgent({
   )
 }
 
-// --- Phase 2: the same checklist the console shows -----------------------------------
+// --- Phase 2: daemon online → the same checklist the console shows -------------------
 function RevealChecklist({
   gs,
   slackOneClick,
   runAction,
+  cloudDaemon,
   onFinish
 }: {
   gs: ReturnType<typeof computeGettingStarted>
   slackOneClick: boolean
   runAction: (action: import('@/lib/getting-started').GsAction) => void
+  /** Cloud pool: no daemon was connected, so the reveal cannot claim one came online. */
+  cloudDaemon: boolean
   onFinish: () => void
 }) {
-  const [expanded, setExpanded] = useState<string | null>('agent')
+  const [expanded, setExpanded] = useState<string | null>(cloudDaemon ? 'agent' : 'daemon')
   return (
     <div className="ac-rise flex w-full max-w-[580px] flex-col gap-4">
       <div className="flex flex-col items-center gap-[10px] text-center">
@@ -285,10 +550,12 @@ function RevealChecklist({
           <Icon name="check" size={23} />
         </span>
         <h1 className="font-sans text-[24px] font-semibold leading-[1.2] tracking-[-.02em] text-(--text-primary)">
-          Welcome to AgentConnect
+          {cloudDaemon ? 'Welcome to AgentConnect' : 'Your daemon is online'}
         </h1>
         <p className="max-w-[440px] font-sans text-[14px] font-normal leading-[1.55] text-(--text-secondary)">
-          Here&rsquo;s your getting-started checklist. Work through the rest any time; it follows you into the console.
+          {cloudDaemon
+            ? 'Here’s your getting-started checklist. Work through the rest any time; it follows you into the console.'
+            : 'Connected and ready — here’s your getting-started checklist. Work through the rest any time; it follows you into the console.'}
         </p>
       </div>
 

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -173,6 +173,13 @@ export function groupFleetStatus(
   return daemons.some((d) => members.has(d.daemonId) && d.status === 'online') ? 'online' : 'offline'
 }
 
+/** The daemons that are MACHINES this org connected. Pool members are install-wide, replaceable
+ *  Pods carried in every org's fleet and hidden wherever the deployment does not offer the pool —
+ *  so every "does this org have a daemon to run on?" decision projects them out first. */
+export function localDaemons<T extends { pool?: boolean }>(daemons: readonly T[]): T[] {
+  return daemons.filter((daemon) => !daemon.pool)
+}
+
 /** One status for the whole pool: online while any member is serving. */
 export function poolFleetStatus(members: Pick<DaemonRow, 'status'>[]): ConnectionStatusKey {
   return members.some((m) => m.status === 'online') ? 'online' : 'offline'

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -42,6 +42,15 @@ describe('computeGettingStarted', () => {
     ])
   })
 
+  // A pool Pod is install-wide infrastructure, not a machine this org connected — and with the
+  // pool hidden the console does not show it at all. It must not tick "Connect a daemon".
+  it('does not tick the daemon step from a pool member Pod', () => {
+    const done = (rows: DaemonRow[]) =>
+      computeGettingStarted({ ...empty, daemons: rows }).items.find((i) => i.key === 'daemon')!.done
+    expect(done([{ daemonId: 'pool-1', status: 'online', pool: true } as DaemonRow])).toBe(false)
+    expect(done([{ daemonId: 'd1', status: 'online' } as DaemonRow])).toBe(true)
+  })
+
   // Cloud pool on: agents run there, so there is no daemon to connect and the step goes.
   it('drops the daemon step where the deployment offers the cloud pool', () => {
     const pooled = computeGettingStarted({ ...empty, poolEnabled: true })

--- a/packages/web/src/lib/getting-started.test.ts
+++ b/packages/web/src/lib/getting-started.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { computeGettingStarted } from './getting-started'
-import type { Agent, IntegrationRow, Session } from '@/lib/data'
+import type { Agent, DaemonRow, IntegrationRow, Session } from '@/lib/data'
 import type { MemberDto } from '@/lib/api'
 
 const agent = (over: Partial<Agent> = {}): Agent =>
@@ -13,7 +13,8 @@ const agent = (over: Partial<Agent> = {}): Agent =>
     workspace: { mode: 'scratch' },
     ...over
   }) as Agent
-const empty = { agents: [], integrations: [], sessions: [], members: [], authOn: true }
+const daemon = (status: DaemonRow['status']): DaemonRow => ({ daemonId: 'd1', status }) as DaemonRow
+const empty = { agents: [], daemons: [], integrations: [], sessions: [], members: [], authOn: true }
 
 describe('computeGettingStarted', () => {
   it('starts all-incomplete for a fresh org and reports progress', () => {
@@ -22,15 +23,16 @@ describe('computeGettingStarted', () => {
     // see its `optional` comment in getting-started.ts), so it contributes to both
     // done and total and never moves the fraction.
     expect(gs.done).toBe(1)
-    expect(gs.total).toBe(6) // 4 core + session-access + invite (auth mode)
-    expect(gs.fraction).toBe(1 / 6)
+    expect(gs.total).toBe(7) // 5 core + session-access + invite (auth mode)
+    expect(gs.fraction).toBe(1 / 7)
     expect(gs.allDone).toBe(false)
   })
 
-  it('orders the steps per the design: agent, slack, github, conversation, session-access, invite', () => {
+  it('orders the steps per the design: daemon, agent, slack, github, conversation, session-access, invite', () => {
     // The "Runtime signed in" step is deferred until the explicit probe-status
     // signal ships (neither authRequired nor advertised models encode readiness).
     expect(computeGettingStarted(empty).items.map((i) => i.key)).toEqual([
+      'daemon',
       'agent',
       'slack',
       'github',
@@ -40,8 +42,17 @@ describe('computeGettingStarted', () => {
     ])
   })
 
+  // Cloud pool on: agents run there, so there is no daemon to connect and the step goes.
+  it('drops the daemon step where the deployment offers the cloud pool', () => {
+    const pooled = computeGettingStarted({ ...empty, poolEnabled: true })
+    expect(pooled.items.map((i) => i.key)).not.toContain('daemon')
+    expect(pooled.total).toBe(6)
+    // off (a self-hosted install) it is still the first step
+    expect(computeGettingStarted(empty).items[0]!.key).toBe('daemon')
+  })
+
   it('drops the invite AND session-access items in no-auth mode (no /settings there)', () => {
-    expect(computeGettingStarted({ ...empty, authOn: false }).total).toBe(4)
+    expect(computeGettingStarted({ ...empty, authOn: false }).total).toBe(5)
     expect(computeGettingStarted({ ...empty, authOn: false }).items.some((i) => i.key === 'invite')).toBe(false)
     expect(computeGettingStarted({ ...empty, authOn: false }).items.some((i) => i.key === 'session-access')).toBe(false)
   })
@@ -60,6 +71,14 @@ describe('computeGettingStarted', () => {
     // undefined (probe in flight / failed) keeps the step — same convention as githubEnabled
     expect(has(undefined)).toBe(true)
     expect(has(true)).toBe(true)
+  })
+
+  it('marks daemon done for any registered daemon, connected or not', () => {
+    const done = (rows: DaemonRow[]) =>
+      computeGettingStarted({ ...empty, daemons: rows }).items.find((i) => i.key === 'daemon')!.done
+    expect(done([])).toBe(false)
+    expect(done([daemon('offline')])).toBe(true)
+    expect(done([daemon('online')])).toBe(true)
   })
 
   it('marks agent done only once some agent is placed (daemon + runtime)', () => {
@@ -158,6 +177,7 @@ describe('computeGettingStarted', () => {
   it('reaches allDone with a full ring when every signal is satisfied', () => {
     const gs = computeGettingStarted({
       agents: [agent({ workspace: { mode: 'github', repo: 'acme/x' } as Agent['workspace'], hookKinds: ['github'] })],
+      daemons: [daemon('online')],
       integrations: [{ platform: 'slack', name: 's' } as IntegrationRow],
       sessions: [{ id: 's1', statusLabel: 'completed' } as Session],
       members: [{ userId: 'u1' } as MemberDto, { userId: 'u2' } as MemberDto],

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -4,9 +4,9 @@
 // item is incomplete and vanishes for good once the list is complete — there is no
 // manual dismiss, so the only state this module owns is the pure derivation.
 //
-// Steps in the design's order: meet your agent → Slack → GitHub+repo (one merged
-// step) → first conversation → invite. Connecting a daemon is no longer a step —
-// agents are placed from the agent editor and onboarding never asks for one. Still not derivable client-side (left
+// Steps in the design's order: daemon → meet your agent → Slack → GitHub+repo (one
+// merged step) → first conversation → invite. The daemon step is dropped where the
+// deployment offers the cloud pool (`poolEnabled`) — there is nothing to connect. Still not derivable client-side (left
 // out rather than faked, preset-agents.md §6.2): the "Runtime signed in"
 // needs-attention item — neither `authRequired` (absence also means probe
 // pending/failed) nor advertised models (a usable runtime may legitimately have no
@@ -15,12 +15,13 @@
 // "Ask agentconnect" automation (§6.3/§6.4 delegated writes).
 
 import { agentIsPlaced } from './data'
-import type { Agent, IntegrationRow, Session } from './data'
+import type { Agent, DaemonRow, IntegrationRow, Session } from './data'
 import type { MemberDto } from './api'
 
 // What the item's primary CTA drives. The component maps kind → a real handler
 // (open a modal, route to a page) so this stays pure and testable.
 export type GsAction =
+  | { kind: 'daemon' }
   | { kind: 'agent' }
   | { kind: 'slack'; agentId: string | null }
   | { kind: 'github'; agentId: string | null }
@@ -62,6 +63,7 @@ const RING_CIRCUMFERENCE = 2 * Math.PI * 10.5
 
 export function computeGettingStarted(input: {
   agents: Agent[]
+  daemons: DaemonRow[]
   integrations: IntegrationRow[]
   sessions: Session[]
   members: MemberDto[]
@@ -86,9 +88,14 @@ export function computeGettingStarted(input: {
    *  its CTA would land on a page with no card to scroll to. Undefined (probe in
    *  flight) keeps the step. */
   sessionAccessAvailable?: boolean
+  /** Is the `daemon-pool` flag on for this deployment? On, agents run on the cloud pool, so
+   *  "Connect a daemon" is dropped — the console offers no daemon to connect. Off (a self-hosted
+   *  install) keeps it as the first step. */
+  poolEnabled?: boolean
 }): GettingStarted {
   const {
     agents,
+    daemons,
     integrations,
     sessions,
     members,
@@ -96,7 +103,8 @@ export function computeGettingStarted(input: {
     orgHasSessions,
     githubLinked,
     githubEnabled,
-    sessionAccessAvailable
+    sessionAccessAvailable,
+    poolEnabled
   } = input
   // Pick a chat-capable / bindable agent for the agent-scoped CTAs. Prefer the built-in
   // `agentconnect` preset — the canonical agent every org gets — else the first agent.
@@ -109,6 +117,21 @@ export function computeGettingStarted(input: {
   const placedAgent = builtin ? agentIsPlaced(builtin) : agents.some(agentIsPlaced)
 
   const items: GsItem[] = [
+    // Cloud pool on ⇒ no daemon to connect; the pool hosts the agents.
+    ...(poolEnabled
+      ? []
+      : [
+          {
+            key: 'daemon',
+            label: 'Connect a daemon',
+            expl: 'Run one command on the host where your agents should live. It stays connected and runs agents locally over ACP.',
+            // Registered is enough — an offline daemon has still been set up, and a laptop
+            // that's merely asleep shouldn't un-tick a step the user already completed.
+            done: daemons.length > 0,
+            ctaLabel: 'Add a daemon',
+            action: { kind: 'daemon' } as const
+          }
+        ]),
     {
       key: 'agent',
       label: 'Set up your agent',

--- a/packages/web/src/lib/getting-started.ts
+++ b/packages/web/src/lib/getting-started.ts
@@ -14,7 +14,7 @@
 // pending|ready|auth_required|failed probe status ships. Same for the per-item
 // "Ask agentconnect" automation (§6.3/§6.4 delegated writes).
 
-import { agentIsPlaced } from './data'
+import { agentIsPlaced, localDaemons } from './data'
 import type { Agent, DaemonRow, IntegrationRow, Session } from './data'
 import type { MemberDto } from './api'
 
@@ -126,8 +126,9 @@ export function computeGettingStarted(input: {
             label: 'Connect a daemon',
             expl: 'Run one command on the host where your agents should live. It stays connected and runs agents locally over ACP.',
             // Registered is enough — an offline daemon has still been set up, and a laptop
-            // that's merely asleep shouldn't un-tick a step the user already completed.
-            done: daemons.length > 0,
+            // that's merely asleep shouldn't un-tick a step the user already completed. Pool
+            // Pods don't count: this step is about a machine, and they are hidden here anyway.
+            done: localDaemons(daemons).length > 0,
             ctaLabel: 'Add a daemon',
             action: { kind: 'daemon' } as const
           }

--- a/packages/web/src/lib/onboarding.test.ts
+++ b/packages/web/src/lib/onboarding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { daemonCompletesOnboarding, needsOnboarding } from './onboarding'
+import { daemonCompletesOnboarding, firstReconnectableDaemonId, needsOnboarding } from './onboarding'
 
 describe('needsOnboarding', () => {
   it('recovers a fresh org (only the unplaced built-in preset, daemon offline)', () => {
@@ -20,6 +20,7 @@ describe('needsOnboarding', () => {
   it('keeps a fresh org initialized during a planned daemon relaunch', () => {
     const restarting = { daemonId: 'edge-1', status: 'offline' as const, lifecycleStatus: 'restarting' as const }
     expect(daemonCompletesOnboarding(restarting)).toBe(true)
+    expect(firstReconnectableDaemonId([restarting])).toBeUndefined()
     expect(needsOnboarding(false, false, false, daemonCompletesOnboarding(restarting), false)).toBe(false)
   })
 })

--- a/packages/web/src/lib/onboarding.test.ts
+++ b/packages/web/src/lib/onboarding.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { daemonCompletesOnboarding, firstReconnectableDaemonId, needsOnboarding } from './onboarding'
+import { localDaemons } from './data'
+import type { DaemonRow } from './data'
 
 describe('needsOnboarding', () => {
   it('recovers a fresh org (only the unplaced built-in preset, daemon offline)', () => {
@@ -22,5 +24,20 @@ describe('needsOnboarding', () => {
     expect(daemonCompletesOnboarding(restarting)).toBe(true)
     expect(firstReconnectableDaemonId([restarting])).toBeUndefined()
     expect(needsOnboarding(false, false, false, daemonCompletesOnboarding(restarting), false)).toBe(false)
+  })
+})
+
+// The redirect, the checklist and the connect step all ask "does this org have a daemon?" —
+// an install-wide pool Pod is never the answer, so they share this projection.
+describe('localDaemons', () => {
+  it('drops pool member Pods and keeps the org own machines', () => {
+    const rows = [
+      { daemonId: 'pool-1', status: 'online', pool: true },
+      { daemonId: 'edge-1', status: 'online', pool: false },
+      { daemonId: 'edge-2', status: 'offline' } // older CP: no `pool` field at all
+    ] as DaemonRow[]
+    expect(localDaemons(rows).map((d) => d.daemonId)).toEqual(['edge-1', 'edge-2'])
+    // a pool-only fleet reads as daemon-less, so onboarding still runs
+    expect(localDaemons(rows.slice(0, 1)).some(daemonCompletesOnboarding)).toBe(false)
   })
 })

--- a/packages/web/src/lib/onboarding.ts
+++ b/packages/web/src/lib/onboarding.ts
@@ -14,6 +14,11 @@ export function daemonCompletesOnboarding(daemon: OnboardingDaemon): boolean {
   return daemon.status === 'online' || daemon.lifecycleStatus != null
 }
 
+/** Only an unexpectedly non-serving daemon is eligible for a replacement connect token. */
+export function firstReconnectableDaemonId(daemons: readonly OnboardingDaemon[]): string | undefined {
+  return daemons.find((daemon) => !daemonCompletesOnboarding(daemon))?.daemonId
+}
+
 // Every org now ships the built-in `agentconnect` preset UNPLACED, so "no agents" no
 // longer marks a fresh org. Initialized = a serving daemon OR a placed/configured agent
 // (agentIsPlaced) exists; otherwise the org is fresh and gets the full-screen wizard.

--- a/packages/web/src/lib/use-onboarding-redirect.ts
+++ b/packages/web/src/lib/use-onboarding-redirect.ts
@@ -2,8 +2,9 @@
 
 // Fresh-workspace redirect to the full-screen /onboarding route, shared by every
 // console landing surface (Home is the default landing, Agents keeps it for deep
-// links). A fresh org = no placed agent AND no serving daemon AND no daemon in ANY
-// of the caller's orgs (needsOnboarding); the per-tab "Explore the console first"
+// links). A fresh org = no placed agent AND no serving daemon of its OWN (pool Pods
+// are install-wide, not this org's machine) AND no daemon in ANY of the caller's orgs
+// (needsOnboarding); the per-tab "Explore the console first"
 // skip flag suppresses the bounce-back.
 //
 // Returns true while the caller should hold a spinner instead of rendering: either
@@ -14,7 +15,7 @@ import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
-import { agentIsPlaced } from '@/lib/data'
+import { agentIsPlaced, localDaemons } from '@/lib/data'
 import { daemonCompletesOnboarding, isOnboardingSkipped, needsOnboarding } from '@/lib/onboarding'
 
 export function useOnboardingRedirect(): boolean {
@@ -39,7 +40,9 @@ export function useOnboardingRedirect(): boolean {
       agentsLoading,
       daemonsLoading,
       agents.some(agentIsPlaced),
-      daemons.some(daemonCompletesOnboarding),
+      // Pool Pods are not a machine this org connected, and on the pool the wizard is where
+      // the built-in agent is configured — a hidden Pod must not mark the org initialized.
+      localDaemons(daemons).some(daemonCompletesOnboarding),
       orgs.some((org) => (org.daemonCount ?? 0) > 0)
     )
   const redirect = notInitialized && skipped === false


### PR DESCRIPTION
Follow-up to #1470, which removed the daemon step unconditionally. That strands a self-hosted install: with no cloud pool there is nothing for agents to run on, so "Connect a daemon" is exactly the step that has to stay there.

## What changed

Both removals are now gated on the existing `daemon-pool` console flag (`lib/feature-flags.ts` — "the install-wide daemon pool: its fleet entry and the Cloud placement option").

**Pool on** — onboarding skips the connect phase entirely (no mint, no waiting card, no unclaimed-daemon cleanup: `daemonReady` starts true, which latches those effects off), opens on the built-in agent's configuration **without** the read-only "Runs on · just connected" row, saves runtime/model with no placement move, and the reveal heading reads "Welcome to AgentConnect". The checklist omits "Connect a daemon".

**Pool off** — the flow is the one that shipped before #1470, unchanged: the connect phase with the minted join command and come-online polling, the just-connected daemon fixed as the placement target, "Your daemon is online" on reveal, and daemon as the checklist's first step.

`computeGettingStarted` takes the flag as a `poolEnabled` input rather than reading it itself — same shape as `edit-agent-daemon-choice.ts`, so the derivation stays pure and both call sites pass what they see.

## Kept from #1470

- The corner pill's own dismiss: an `x` beside the label running the drawer's per-device skip, so the checklist can be hidden without opening it first. Unconditional.
- The agent step's Add daemon → Edit agent chain when the org has no daemon row at all (review-bot's finding on #1470), plus its tests.

## Notes for the reviewer

- The onboarding daemon phase is restored byte-for-byte from `b86f4be13` and then gated, so a flag-off diff against pre-#1470 is limited to the gates themselves.
- `OnboardingView.test.tsx` defaults to `FEATURE_FLAGS=''` (self-hosted) and keeps every original connect-step test; a new `onboarding — cloud pool` describe sets `daemon-pool` and covers the skipped phase and the placement-free save. `getting-started.test.ts` covers `poolEnabled` dropping the row while the default keeps it first.
- The pool-on save asserts `FALLBACK_RUNTIME_IDS[0]` rather than a literal id — the static fallback seeds the picker when no daemon reports runtimes.
- Verification: `pnpm --filter @agentconnect.md/web test` (179 files / 1979 tests), `typecheck`, `lint` all pass. The pill and the two onboarding variants were not screenshotted against a running stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)