### PR TITLE
fix(daemon): await duty trigger connection readiness

### DIFF
--- a/packages/daemon/src/cp/duty-coordinator.ts
+++ b/packages/daemon/src/cp/duty-coordinator.ts
@@ -598,15 +598,11 @@ export class DutyCoordinator {
       try {
         await this.host.flushReconcile()
       } catch (err) {
-        this.log.warn(`duty: claimed ${grant.groupId} but its connections did not converge: ${formatErr(err)}`)
-        await this.applyDutyRevoke([{ groupId: grant.groupId, reason: 'superseded' }]).finally(() =>
-          this.host
-            .cpClient()
-            ?.releaseDuties([grant.groupId])
-            .catch((releaseErr) =>
-              this.log.warn(`duty: handing back ${grant.groupId} failed: ${formatErr(releaseErr)}`)
-            )
+        this.log.warn(
+          `duty: claimed ${grant.groupId} but its connections did not converge — withdrawing locally and ` +
+            `letting the lease lapse: ${formatErr(err)}`
         )
+        await this.applyDutyRevoke([{ groupId: grant.groupId, reason: 'superseded' }])
         return { granted: false }
       }
       return { granted: true }

--- a/packages/daemon/src/cp/duty-coordinator.ts
+++ b/packages/daemon/src/cp/duty-coordinator.ts
@@ -595,7 +595,20 @@ export class DutyCoordinator {
         this.log.warn(`duty: claimed ${grant.groupId} but could not install ${agentId} — handing the trigger back`)
         return { granted: false }
       }
-      await this.host.flushReconcile()
+      try {
+        await this.host.flushReconcile()
+      } catch (err) {
+        this.log.warn(`duty: claimed ${grant.groupId} but its connections did not converge: ${formatErr(err)}`)
+        await this.applyDutyRevoke([{ groupId: grant.groupId, reason: 'superseded' }]).finally(() =>
+          this.host
+            .cpClient()
+            ?.releaseDuties([grant.groupId])
+            .catch((releaseErr) =>
+              this.log.warn(`duty: handing back ${grant.groupId} failed: ${formatErr(releaseErr)}`)
+            )
+        )
+        return { granted: false }
+      }
       return { granted: true }
     } catch (err) {
       // A CP blip must not look like "someone else holds it" — answering with no

--- a/packages/daemon/src/cp/duty-coordinator.ts
+++ b/packages/daemon/src/cp/duty-coordinator.ts
@@ -588,19 +588,14 @@ export class DutyCoordinator {
           .catch((err) => this.log.warn(`duty: handing back ${grant.groupId} failed (it will lapse): ${err}`))
         return { granted: false }
       }
-      // Load-bearing await: the rendezvous claim exists BECAUSE a trigger arrived
-      // for an agent this member does not serve, and the turn is dispatched right
-      // after. Install, then hold, then answer — answering `granted` before the
-      // agent is there reproduces the "no agent on this daemon" drop the claim is
-      // meant to prevent.
+      // Dispatch follows immediately, so install, hold, and connect the agent before answering `granted`.
       const failed = await this.admitDutyGrants([grant])
-      // Never applied, so the answer and the local state agree — a member that
-      // says "not me" while still holding the lease is the split brain this whole
-      // mechanism exists to avoid.
+      // Never applied, so the answer and local duty state agree.
       if (failed.has(grant.groupId)) {
         this.log.warn(`duty: claimed ${grant.groupId} but could not install ${agentId} — handing the trigger back`)
         return { granted: false }
       }
+      await this.host.flushReconcile()
       return { granted: true }
     } catch (err) {
       // A CP blip must not look like "someone else holds it" — answering with no

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -597,7 +597,7 @@ describe('the rendezvous claim ordering', () => {
     await daemon.stop()
   })
 
-  it('releases a won duty when its platform connections fail to converge', async () => {
+  it('withdraws a won duty without releasing it before teardown is confirmed', async () => {
     const releaseDuties = vi.fn(async () => {})
     const daemon = await boot({
       claimDuty: vi.fn(async () => ({ granted: true, grant: grant() })),
@@ -613,7 +613,7 @@ describe('the rendezvous claim ordering', () => {
     await expect((daemon as any).dutyCoordinator.claimDutyForTrigger(AGENT)).resolves.toEqual({ granted: false })
 
     expect(duties(daemon).digest()).toEqual([])
-    expect(releaseDuties).toHaveBeenCalledWith([GROUP])
+    expect(releaseDuties).not.toHaveBeenCalled()
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -597,6 +597,26 @@ describe('the rendezvous claim ordering', () => {
     await daemon.stop()
   })
 
+  it('releases a won duty when its platform connections fail to converge', async () => {
+    const releaseDuties = vi.fn(async () => {})
+    const daemon = await boot({
+      claimDuty: vi.fn(async () => ({ granted: true, grant: grant() })),
+      fetchDutyAgent: vi.fn(async () => ({ bundle: bundle() })),
+      releaseDuties
+    })
+    const flush = (daemon as any).flushReconcile.bind(daemon)
+    ;(daemon as any).flushReconcile = async () => {
+      await flush()
+      if (duties(daemon).holdsAgent(AGENT)) throw new Error('platform connection failed')
+    }
+
+    await expect((daemon as any).dutyCoordinator.claimDutyForTrigger(AGENT)).resolves.toEqual({ granted: false })
+
+    expect(duties(daemon).digest()).toEqual([])
+    expect(releaseDuties).toHaveBeenCalledWith([GROUP])
+    await daemon.stop()
+  })
+
   it('answers granted:false on an empty reply, without ever holding the group', async () => {
     const daemon = await boot({
       claimDuty: vi.fn(async () => ({ granted: true, grant: grant() })),

--- a/packages/daemon/test/daemon-duty-install.test.ts
+++ b/packages/daemon/test/daemon-duty-install.test.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path'
 import type { DutyGrantEntry } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import type { DutyRegistry } from '../src/cp/duty-registry.js'
+import type { SlackAppFactory } from '../src/slack/connection.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 
 const AGENT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
@@ -114,8 +115,8 @@ const bundleWithDefinitions = (grantKey?: string, issuedAt?: number) => ({
 })
 
 /** A daemon started with a stub CP client — only the duty surface is exercised. */
-async function boot(client: Record<string, unknown>) {
-  const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold() })
+async function boot(client: Record<string, unknown>, slackAppFactory: SlackAppFactory = fakeSlackAppFactory()) {
+  const daemon = new Daemon({ slackAppFactory, root: scaffold() })
   await daemon.start()
   ;(daemon as any).cpClient = {
     organizationScope: () => 'frame',
@@ -528,19 +529,29 @@ describe('a group is not held until it is servable', () => {
 })
 
 describe('the rendezvous claim ordering', () => {
-  it('resolves granted only AFTER the granted agent is installed', async () => {
+  it('resolves granted only AFTER the granted agent is installed and connected', async () => {
     let releaseFetch!: () => void
     const fetched = new Promise<void>((resolve) => {
       releaseFetch = resolve
     })
+    let releaseSlack!: () => void
+    const slackReady = new Promise<void>((resolve) => {
+      releaseSlack = resolve
+    })
+    const baseSlackAppFactory = fakeSlackAppFactory()
+    const startSlack = vi.fn(async () => slackReady)
+    const slackAppFactory: SlackAppFactory = (opts) => ({ ...baseSlackAppFactory(opts), start: startSlack })
     const fetchDutyAgent = vi.fn(async () => {
       await fetched
       return { bundle: bundle() }
     })
-    const daemon = await boot({
-      claimDuty: vi.fn(async () => ({ granted: true, grant: grant() })),
-      fetchDutyAgent
-    })
+    const daemon = await boot(
+      {
+        claimDuty: vi.fn(async () => ({ granted: true, grant: grant() })),
+        fetchDutyAgent
+      },
+      slackAppFactory
+    )
     const cp = registries(daemon)
 
     let settled = false
@@ -557,9 +568,13 @@ describe('the rendezvous claim ordering', () => {
     expect(settled).toBe(false)
 
     releaseFetch()
-    await expect(claim).resolves.toEqual({ granted: true })
+    await vi.waitFor(() => expect(startSlack).toHaveBeenCalled())
     expect(cp.agents.has(AGENT)).toBe(true)
     expect(duties(daemon).holdsAgent(AGENT)).toBe(true)
+    expect(settled).toBe(false)
+
+    releaseSlack()
+    await expect(claim).resolves.toEqual({ granted: true })
     await daemon.stop()
   })
 


### PR DESCRIPTION
## Summary

- wait for duty-triggered platform connection convergence before acknowledging a rendezvous claim
- withdraw the local grant and let its lease lapse if connection convergence cannot be confirmed
- extend the rendezvous ordering tests to cover delayed Slack readiness and failed convergence

## Why

After a daemon restart, relay ingress can arrive after the daemon reacquires duty but before the agent's platform connection is ready. The daemon previously acknowledged the trigger first, then rejected dispatch because the conversation source was unavailable, so the relay could not retry the message.

The readiness barrier must also preserve the claim/local-state invariant: a failed barrier cannot report `{ granted: false }` while the daemon still serves the duty. It deliberately does not release that lease early, because physical host and platform teardown may still be settling; the normal lease-expiry handoff remains the safe path.

## Verification

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/daemon-duty-install.test.ts` (27 tests)
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec eslint packages/daemon/src/cp/duty-coordinator.ts packages/daemon/test/daemon-duty-install.test.ts`
- `pnpm exec prettier --check packages/daemon/src/cp/duty-coordinator.ts packages/daemon/test/daemon-duty-install.test.ts`
- `git diff --check`
- pre-push `eslint .`

Created by Codex . GPT-5.6
