### PR TITLE
fix(daemon): set the Slack session lifecycle before the free-text status

### DIFF
--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -1778,6 +1778,10 @@ export class SlackConnection implements PlatformConnection {
     options?: SlackStatusOptions
   ): Promise<void> {
     await this.queue.enqueue(async () => {
+      // Slack bridges both calls onto one status slot, last writer wins — so the enum goes
+      // first and the free text second, or the enum blanks the text just written.
+      // Already inside the send queue — setSessionLifecycle must not enqueue again.
+      await this.setSessionLifecycle(channel, threadTs, status ? 'processing' : 'active')
       try {
         // A clear only needs the status coordinates. Keeping authorship off that request
         // also makes the identity override specific to the visible loading state.
@@ -1795,8 +1799,6 @@ export class SlackConnection implements PlatformConnection {
         this.rememberMissingScopes(err)
         this.deps.log?.debug(`slack: setStatus failed (ch=${channel} thread=${threadTs}): ${(err as Error).message}`)
       }
-      // Already inside the send queue — setSessionLifecycle must not enqueue again.
-      await this.setSessionLifecycle(channel, threadTs, status ? 'processing' : 'active')
       await this.postPermissionUpdateCard(channel, threadTs)
     })
   }

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -1000,6 +1000,36 @@ describe('SlackConnection.setStatus', () => {
     ])
   })
 
+  // Slack bridges both calls onto ONE status slot, last writer wins. The enum therefore has to
+  // land first: written second it blanks the free text it just displayed, and the dedupe means
+  // that happens exactly once — on the turn's first status, which is the flash users saw.
+  it('writes the lifecycle enum before the free text, and never again mid-turn', async () => {
+    const order: string[] = []
+    const conn = new SlackConnection(
+      { ...deps(), sendIntervalMs: 0 } as any,
+      () =>
+        fakeAppWith(
+          async (a) => void order.push(`text:${a.status || '(clear)'}`),
+          async (method, a) => {
+            if (method === 'agents.sessions.setStatus') order.push(`lifecycle:${a.status}`)
+            return {}
+          }
+        ) as any
+    )
+
+    await conn.setStatus('C1', '123.45', 'is thinking…')
+    await conn.setStatus('C1', '123.45', 'Searching…')
+    await conn.setStatus('C1', '123.45', '')
+
+    expect(order).toEqual([
+      'lifecycle:processing',
+      'text:is thinking…',
+      'text:Searching…',
+      'lifecycle:active',
+      'text:(clear)'
+    ])
+  })
+
   it('refires nothing for an unchanged lifecycle state, per channel and thread', async () => {
     const lifecycle: any[] = []
     const conn = lifecycleConn((a) => lifecycle.push(a))


### PR DESCRIPTION
## The regression

On an HTTP-mode bot, the free-text loading status ("checking…" and its `loading_messages`) appears, immediately vanishes, and only comes back at the next status update — sometimes much later, sometimes not at all for the rest of the turn.

Slack bridges `assistant.threads.setStatus` and `agents.sessions.setStatus` onto the **same session status slot**: last writer wins. `SlackConnection.setStatus` runs both inside one queued task, and it wrote the free text first and the lifecycle enum second — so the `processing` write blanked the text it had just displayed.

The per-(channel, thread) dedupe on the enum is what shaped the symptom. Only the turn's **first** status changes the lifecycle state, so only that one call reaches Slack and stomps its own text; every later free-text update in the same turn dedupes the enum away and renders fine. Appear → blank → nothing until the next update is exactly that.

It surfaced on HTTP because #1471 un-gated the lifecycle call for send-only connections, but the ordering bug is transport-neutral — it was equally live on Socket Mode since #1462, just less noticed.

## The fix

Swap the two calls inside the same queued task: lifecycle enum first, free text second. Uniformly for both paths — on a clear the end state is identical either way, so one order beats a conditional. The dedupe, the best-effort error handling, the permission-update card, and the stop handler are all untouched, and no call is added or removed.

A one-line comment records the constraint, since the last-writer-wins bridge is not something the code can show.

## Test

`writes the lifecycle enum before the free text, and never again mid-turn` records both calls into one ordered list and pins the full turn:

```
lifecycle:processing, text:is thinking…, text:Searching…, lifecycle:active, text:(clear)
```

That locks both halves of the invariant: the enum lands before the turn's first free text, and the mid-turn update fires no second enum, so nothing can stomp the text later. Verified to fail on the pre-fix order (the `processing` write lands after the first text). No existing test asserted cross-call ordering — they recorded the two calls into separate arrays — so none needed updating.

## Verified

- daemon `test/connection.test.ts` — 55 passed (54 + the new one)
- daemon `daemon-smoke`, `daemon-commands`, `daemon-transcript`, `durable-inbox`, `daemon-runtime-auth`, `turn-output-workflow`, `daemon-lifecycle`, `daemon-hook`, `daemon-interrupt-safety`, `render` — 450 passed; `slack-upload-file` (mocked project) — 12 passed
- `pnpm eval:gates` — 193 passed
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
