### PR TITLE
fix(control-plane): fence cross-bot thread fallback

### DIFF
--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -424,6 +424,33 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(res.participants).toEqual([])
     })
 
+    it('keeps Feishu and Lark apps in distinct thread fallback realms', async () => {
+      botRow = bot({
+        platform: 'feishu',
+        externalAppId: 'cli_cn',
+        externalTenantId: '-',
+        feishuAppId: 'cli_cn',
+        feishuRegion: null
+      })
+      siblingBots = [
+        bot({
+          id: OTHER_BOT,
+          platform: 'feishu',
+          externalAppId: 'cli_global',
+          externalTenantId: '-',
+          feishuAppId: 'cli_global',
+          feishuRegion: 'lark',
+          shareable: false,
+          agentIds: [ALICE]
+        })
+      ]
+      threadOwner = { agentId: ALICE }
+
+      const res = await makeOrch().lookupThread({ botId: BOT, sessionKey: SK })
+
+      expect(res.target).toEqual({ agentId: ALICE, daemonId: D1 })
+    })
+
     it('persists and broadcasts participant joins independently of the compatibility owner', async () => {
       const orch = makeOrch()
       await orch.recordThreadParticipant({ botId: BOT, sessionKey: SK, agentId: BOB, daemonId: D2 })

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -451,6 +451,34 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(res.target).toEqual({ agentId: ALICE, daemonId: D1 })
     })
 
+    it('treats different Feishu apps in one region as sibling tenant routes', async () => {
+      botRow = bot({
+        platform: 'feishu',
+        externalAppId: 'cli_a',
+        externalTenantId: '-',
+        feishuAppId: 'cli_a',
+        feishuRegion: null
+      })
+      siblingBots = [
+        bot({
+          id: OTHER_BOT,
+          platform: 'feishu',
+          externalAppId: 'cli_b',
+          externalTenantId: '-',
+          feishuAppId: 'cli_b',
+          feishuRegion: 'feishu',
+          shareable: false,
+          agentIds: [ALICE]
+        })
+      ]
+      threadOwner = { agentId: ALICE }
+
+      const res = await makeOrch().lookupThread({ botId: BOT, sessionKey: SK })
+
+      expect(res.target).toBeNull()
+      expect(res.participants).toEqual([])
+    })
+
     it('persists and broadcasts participant joins independently of the compatibility owner', async () => {
       const orch = makeOrch()
       await orch.recordThreadParticipant({ botId: BOT, sessionKey: SK, agentId: BOB, daemonId: D2 })

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -40,6 +40,7 @@ const PLATFORMS = buildCpPlatformRegistry([
 // ── ids ──────────────────────────────────────────────────────────────────────
 const ORG = OrgId('11111111-1111-4111-8111-111111111111')
 const BOT = BotId('22222222-2222-4222-8222-222222222222')
+const OTHER_BOT = BotId('22222222-2222-4222-8222-222222222223')
 const RELAY = '55555555-5555-4555-8555-555555555555'
 const D1 = '33333333-3333-4333-8333-333333333331'
 const D2 = '33333333-3333-4333-8333-333333333332'
@@ -121,6 +122,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
   let relayReg: RelayRegistry
   let ch: FakeChannel
   let botRow: BotRecord
+  let siblingBots: BotRecord[]
   let integrations: IntegrationRecord[]
   let channels: IntegrationChannelRecord[]
   let upserts: {
@@ -164,7 +166,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       [BOB]: agent(BOB, 'bob', unplacedAgents.has(BOB) ? null : D2)
     }
     let getCalls = 0
-    const bots: Pick<BotRepo, 'getUnscoped' | 'listHttpActive' | 'revokeIfCurrent'> = {
+    const bots: Pick<BotRepo, 'getUnscoped' | 'listForOrg' | 'listHttpActive' | 'revokeIfCurrent'> = {
       getUnscoped: async () => {
         getCalls += 1
         if (bumpRevisionAfterFirstGet && getCalls > 1) {
@@ -172,6 +174,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         }
         return botRow
       },
+      listForOrg: async () => [botRow, ...siblingBots],
       listHttpActive: async () => [botRow],
       // Mirrors the SQL CAS: both arms conjunctive, each skipped when the report
       // didn't carry it, and `credentialInstalledAt: null` passes the time arm.
@@ -341,6 +344,7 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     ch = new FakeChannel(RELAY)
     relayReg.add(ch)
     botRow = bot()
+    siblingBots = []
     integrations = [integration(INT_A, ALICE), integration(INT_B, BOB)]
     channels = [channel({ integrationId: INT_B, channelId: 'C1', agentId: BOB, trigger: 'mention' })]
     upserts = []
@@ -405,6 +409,19 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       threadOwner = null
       const res = await orch.lookupThread({ botId: BOT, sessionKey: SK })
       expect(res.target).toBeNull()
+    })
+
+    it('does not let SessionMeta create a second owner across sibling Slack bots', async () => {
+      botRow = bot({ externalTenantId: 'T1', workspaceId: 'T1' })
+      siblingBots = [
+        bot({ id: OTHER_BOT, externalTenantId: null, workspaceId: 'T1', shareable: false, agentIds: [ALICE] })
+      ]
+      threadOwner = { agentId: ALICE }
+
+      const res = await makeOrch().lookupThread({ botId: BOT, sessionKey: SK })
+
+      expect(res.target).toBeNull()
+      expect(res.participants).toEqual([])
     })
 
     it('persists and broadcasts participant joins independently of the compatibility owner', async () => {

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -470,15 +470,19 @@ export class HttpBotOrchestrator {
   private async sessionOwnerHasSiblingBot(botId: string, agentId: string): Promise<boolean> {
     const bot = await this.bots.getUnscoped(BotId(botId))
     if (!bot) return false
-    const tenant = bot.externalTenantId ?? bot.workspaceId ?? bot.teamId
-    if (!tenant) return false
+    const provider = this.platforms.get(bot.platform)
+    const realmOf = (candidate: BotRecord): string | null =>
+      provider?.threadFallbackRealm
+        ? provider.threadFallbackRealm(candidate)
+        : (candidate.externalTenantId ?? candidate.workspaceId ?? candidate.teamId)
+    const realm = realmOf(bot)
+    if (!realm) return false
     return (await this.bots.listForOrg(bot.orgId)).some((candidate) => {
-      const candidateTenant = candidate.externalTenantId ?? candidate.workspaceId ?? candidate.teamId
       return (
         candidate.id !== bot.id &&
         candidate.revokedAt === null &&
         candidate.platform === bot.platform &&
-        candidateTenant === tenant &&
+        realmOf(candidate) === realm &&
         candidate.agentIds.some((id) => id === agentId)
       )
     })

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -443,7 +443,7 @@ export class HttpBotOrchestrator {
       const thread = m.sessionKey.slice(slash + 1)
       const owner = await this.sessions.findThreadOwner(BotId(m.botId), channel, thread)
       const ambiguous = owner ? await this.sessionOwnerHasSiblingBot(m.botId, owner.agentId) : false
-      if (ambiguous) {
+      if (ambiguous && owner) {
         this.log.debug?.(
           { botId: m.botId, agentId: owner.agentId, channel },
           'http-bot: SessionMeta thread owner is ambiguous across bots — leaving the thread unowned'

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -442,9 +442,16 @@ export class HttpBotOrchestrator {
       const channel = m.sessionKey.slice(0, slash)
       const thread = m.sessionKey.slice(slash + 1)
       const owner = await this.sessions.findThreadOwner(BotId(m.botId), channel, thread)
+      const ambiguous = owner ? await this.sessionOwnerHasSiblingBot(m.botId, owner.agentId) : false
+      if (ambiguous) {
+        this.log.debug?.(
+          { botId: m.botId, agentId: owner.agentId, channel },
+          'http-bot: SessionMeta thread owner is ambiguous across bots — leaving the thread unowned'
+        )
+      }
       // The session names the agent; the member serving it is resolved live, so this fallback
       // covers a pool agent — whose row names no machine — as well as a machine-placed one.
-      const target = owner ? await this.threadOwnerTarget(m.botId, channel, owner.agentId) : null
+      const target = owner && !ambiguous ? await this.threadOwnerTarget(m.botId, channel, owner.agentId) : null
       if (target) {
         return {
           botId: m.botId,
@@ -457,6 +464,24 @@ export class HttpBotOrchestrator {
       }
     }
     return { botId: m.botId, sessionKey: m.sessionKey, target: null, participants }
+  }
+
+  /** Refuse a bot-agnostic SessionMeta fallback when another live bot can route the same agent in this tenant. */
+  private async sessionOwnerHasSiblingBot(botId: string, agentId: string): Promise<boolean> {
+    const bot = await this.bots.getUnscoped(BotId(botId))
+    if (!bot) return false
+    const tenant = bot.externalTenantId ?? bot.workspaceId ?? bot.teamId
+    if (!tenant) return false
+    return (await this.bots.listForOrg(bot.orgId)).some((candidate) => {
+      const candidateTenant = candidate.externalTenantId ?? candidate.workspaceId ?? candidate.teamId
+      return (
+        candidate.id !== bot.id &&
+        candidate.revokedAt === null &&
+        candidate.platform === bot.platform &&
+        candidateTenant === tenant &&
+        candidate.agentIds.some((id) => id === agentId)
+      )
+    })
   }
 
   /** The addressable target for a thread owner, or null when the gate refuses it or nothing is

--- a/packages/control-plane/src/platforms/feishu/provider.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.ts
@@ -375,10 +375,8 @@ export function createFeishuCpProvider(deps: FeishuCpProviderDeps): CpPlatformPr
       }
     },
 
-    threadFallbackRealm: (bot) => {
-      const appId = bot.feishuAppId ?? bot.externalAppId
-      return appId ? `${bot.feishuRegion ?? 'feishu'}:${appId}` : null
-    },
+    // Every Bot App admitted in a region was verified against that region's one configured Login App tenant.
+    threadFallbackRealm: (bot) => bot.feishuRegion ?? 'feishu',
 
     // Feishu reuses the established two-slot shape (`install-feishu.ts`):
     // botToken = app SECRET (the credential), appToken = app ID (the

--- a/packages/control-plane/src/platforms/feishu/provider.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.ts
@@ -375,6 +375,11 @@ export function createFeishuCpProvider(deps: FeishuCpProviderDeps): CpPlatformPr
       }
     },
 
+    threadFallbackRealm: (bot) => {
+      const appId = bot.feishuAppId ?? bot.externalAppId
+      return appId ? `${bot.feishuRegion ?? 'feishu'}:${appId}` : null
+    },
+
     // Feishu reuses the established two-slot shape (`install-feishu.ts`):
     // botToken = app SECRET (the credential), appToken = app ID (the
     // identifier) — the overloading the audit found spelled only in comments,

--- a/packages/control-plane/src/platforms/provider.ts
+++ b/packages/control-plane/src/platforms/provider.ts
@@ -493,6 +493,9 @@ export interface CpPlatformProvider<TCredentials = unknown> {
    */
   projectBotIdentity?(input: CreateBotInput): BotIdentityColumns
 
+  /** Normalize the provider realm used to fence bot-agnostic SessionMeta thread fallback. */
+  threadFallbackRealm?(bot: BotRecord): string | null
+
   /** Pending-install funnel state models + their TTL reapers. Absent ⇒ the
    *  platform has no funnel (Telegram/Discord). */
   pendingInstalls?: readonly CpPendingInstallDecl[]


### PR DESCRIPTION
## Summary

- make the SessionMeta thread fallback fail closed when the same agent is reachable through another active bot in the same provider realm
- let each platform normalize that realm; Feishu/Lark use the region-scoped configured Login App tenant while Slack uses workspace tenant metadata
- preserve explicit per-bot thread affinity as the authoritative path
- cover mixed current and legacy Slack tenant metadata, distinct Feishu/Lark realms, and sibling Feishu apps in one tenant

## Why

SessionMeta records the agent and external conversation but does not durably identify the originating bot. On a per-bot affinity miss, an HTTP bot could therefore adopt a thread that another app had already routed to the same agent. Both integrations then created and resumed separate sessions for the same conversation.

The ambiguity fence must be provider-realm aware: Feishu and Lark share one wire platform and use a tenantless sentinel. Each region admits Bot Apps only after checking them against that region's configured Login App tenant, so normalized region separates Feishu from Lark while grouping different apps in the same provider tenant.

## Verification

- `pnpm --filter @agentconnect.md/control-plane exec vitest run --project unit src/orchestrator/httpBot.test.ts` (73 tests)
- `pnpm --filter @agentconnect.md/control-plane test:unit` (177 files, 2044 tests)
- `pnpm --filter @agentconnect.md/control-plane typecheck`
- `pnpm exec eslint packages/control-plane/src/orchestrator/httpBot.ts packages/control-plane/src/orchestrator/httpBot.test.ts packages/control-plane/src/platforms/provider.ts packages/control-plane/src/platforms/feishu/provider.ts`
- `pnpm exec prettier --check packages/control-plane/src/orchestrator/httpBot.ts packages/control-plane/src/orchestrator/httpBot.test.ts packages/control-plane/src/platforms/provider.ts packages/control-plane/src/platforms/feishu/provider.ts`
- `git diff --check`
- pre-push `eslint .`

Created by Codex . GPT-5.6
