### PR TITLE
feat(web): the transaction feed's operator note, and a ledger-side filter

### DIFF
--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -808,7 +808,11 @@ export default function BillingView() {
         <>
           <BalanceBannerCard
             acct={acct}
-            hasHistory={ledgerHistory(transactions.data)}
+            // The UNFILTERED read, like "last deduction" below: whether this account has ever
+            // moved money is a fact about the account, and reading it off the table's current
+            // side told a suspended org with usage and no top-ups that it had never been
+            // funded the moment someone pressed Top-ups.
+            hasHistory={ledgerHistory(ledger.data)}
             canPay={myRole === 'owner'}
             // The banner's CTA leads INTO the inline form (the design's modal equivalent):
             // scroll to it, blink the card, and land focus in the amount field.

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -50,6 +50,18 @@ import { Button, Icon } from '@/components/ui'
 // Mobile scrolls the card sideways (globals' `.card:has(.row)`), so one template serves both.
 const TX_GRID = 'grid-cols-[34px_minmax(0,1fr)_132px_24px_190px] gap-2'
 
+// The Transactions filter, the same Usage / Top-ups split the Activity chart offers — plus
+// `all`, which is the table's own default and the whole ledger it always showed. `type` goes
+// to the service: the feed is keyset-paginated over both ledger sides at once, so narrowing
+// it here rather than on a page already fetched is what keeps the cursor, the loaded count
+// and "end of ledger" describing the rows actually on screen.
+const TX_SIDES = [
+  { key: 'all', label: 'All', type: undefined },
+  { key: 'debit', label: 'Usage', type: 'debit' },
+  { key: 'credit', label: 'Top-ups', type: 'credit' }
+] as const
+type TxSide = (typeof TX_SIDES)[number]['key']
+
 const KIND_LABEL: Record<string, string> = {
   purchase: 'Credit purchase',
   adjustment: 'Adjustment',
@@ -592,15 +604,33 @@ export default function BillingView() {
   const fetching = offered && orgId !== null
 
   const account = useSWR(fetching ? consoleKeys.billingAccount(orgId) : null, () => fetchBillingAccount(orgId!))
-  const transactions = useSWR(fetching ? consoleKeys.billingTransactions(orgId) : null, () =>
+
+  const [side, setSide] = useState<TxSide>('all')
+  const sideType = TX_SIDES.find((s) => s.key === side)!.type
+  // The table's own feed, one page one per side. `all` is the same key the unfiltered ledger
+  // below uses, so the default view still costs ONE request — SWR dedupes them.
+  const transactions = useSWR(fetching ? consoleKeys.billingTransactions(orgId, side) : null, () =>
+    // The unfiltered call on `all`, not `{ type: undefined }`: it shares its key with the
+    // ledger read below, and SWR runs ONE of the two fetchers for a shared key — so they
+    // have to be the same request, not two spellings of it.
+    sideType ? fetchBillingTransactions(orgId!, undefined, { type: sideType }) : fetchBillingTransactions(orgId!)
+  )
+  // The balance card's own read, deliberately NOT the table's: "last deduction" is a fact
+  // about the account, and reading it off whatever the table happens to have loaded made it
+  // vanish the moment someone filtered to Top-ups.
+  const ledger = useSWR(fetching ? consoleKeys.billingTransactions(orgId) : null, () =>
     fetchBillingTransactions(orgId!)
   )
 
-  // Pages past the first, keyed to their org so a switch drops them without an effect.
-  // SWR owns page one (and revalidates it); this only ever appends behind it.
-  const [tail, setTail] = useState<{ orgId: string; items: BillingTransaction[]; nextCursor: string | null } | null>(
-    null
-  )
+  // Pages past the first, keyed to their org AND side so a switch of either drops them
+  // without an effect — a cursor belongs to the feed it came from and means nothing in
+  // another. SWR owns page one (and revalidates it); this only ever appends behind it.
+  const [tail, setTail] = useState<{
+    orgId: string
+    side: TxSide
+    items: BillingTransaction[]
+    nextCursor: string | null
+  } | null>(null)
   const [loadingMore, setLoadingMore] = useState(false)
   const [tailError, setTailError] = useState<string | null>(null)
 
@@ -624,13 +654,16 @@ export default function BillingView() {
   const { mutate: mutateKey } = useSWRConfig()
   const refreshMoney = useCallback(() => {
     void account.mutate()
-    void transactions.mutate()
+    // Every side's page one, not only the visible one: a settled top-up belongs to the All
+    // and Top-ups feeds alike, and leaving the others cached had a filter switch show a
+    // ledger that predated the purchase.
+    if (orgId) for (const s of TX_SIDES) void mutateKey(consoleKeys.billingTransactions(orgId, s.key))
     // The Activity chart reads the same ledger through its OWN key, one per range, and its
     // fetch usually landed while the purchase was still pending. Settlement has to reach
     // every range it can show — leaving the cached ones alone had the Top-ups chart disagree
     // with the table right beside it until a refocus or a reload.
     if (orgId) for (const r of ACTIVITY_RANGES) void mutateKey(consoleKeys.billingActivity(orgId, r.key))
-  }, [account.mutate, transactions.mutate, mutateKey, orgId])
+  }, [account.mutate, mutateKey, orgId])
   useEffect(() => {
     if (!orgId || checkout?.phase !== 'confirming') return
     const { purchaseId, attempt } = checkout
@@ -702,18 +735,23 @@ export default function BillingView() {
 
   // Page one from SWR plus the appended tail, deduped: a revalidated page one can
   // grow into rows the tail already fetched.
-  const tailItems = tail && tail.orgId === orgId ? tail.items : []
+  const mine = tail && tail.orgId === orgId && tail.side === side ? tail : null
+  const tailItems = mine ? mine.items : []
   const firstIds = new Set(transactions.data?.items.map((t) => t.id))
-  const txItems = transactions.data ? [...transactions.data.items, ...tailItems.filter((t) => !firstIds.has(t.id))] : []
-  const nextCursor = tail && tail.orgId === orgId ? tail.nextCursor : (transactions.data?.nextCursor ?? null)
+  const loaded = transactions.data ? [...transactions.data.items, ...tailItems.filter((t) => !firstIds.has(t.id))] : []
+  // The side is a REQUEST: a billing image that predates `type` ignores it and answers with
+  // the whole ledger. Cutting again here is what stops that image from rendering top-ups
+  // under a pill that says Usage — a wrong answer is worse than a narrower one.
+  const txItems = sideType ? loaded.filter((t) => t.type === sideType) : loaded
+  const nextCursor = mine ? mine.nextCursor : (transactions.data?.nextCursor ?? null)
 
   const loadMore = async () => {
     if (!nextCursor || loadingMore) return
     setLoadingMore(true)
     setTailError(null)
     try {
-      const page = await fetchBillingTransactions(orgId, nextCursor)
-      setTail({ orgId, items: [...tailItems, ...page.items], nextCursor: page.nextCursor })
+      const page = await fetchBillingTransactions(orgId, nextCursor, { type: sideType })
+      setTail({ orgId, side, items: [...tailItems, ...page.items], nextCursor: page.nextCursor })
     } catch (e) {
       setTailError((e as Error).message)
     }
@@ -723,7 +761,8 @@ export default function BillingView() {
   // Design's balance-card stats, from what the wire actually carries: the latest debit
   // comes off the loaded ledger, the threshold off the account. The design's
   // "Billed this period" needs a service field that does not exist — still out.
-  const lastDebit = txItems.find((t) => t.type === 'debit')
+  const ledgerItems = ledger.data?.items ?? []
+  const lastDebit = ledgerItems.find((t) => t.type === 'debit')
   const thresholdMicro = acct?.lowBalanceMicro ?? 0
   const threshold = thresholdMicro > 0 ? fmtMicroUsd(thresholdMicro) : '—'
   // Design: still Serving below the threshold, but the pill turns amber with the banner.
@@ -831,18 +870,27 @@ export default function BillingView() {
 
           {/* Design: the chart only appears once the ledger has something to draw — an
               unfunded org gets the banner and the empty table, not an empty plot. */}
-          {txItems.length > 0 && <ActivityCard orgId={orgId} />}
+          {ledgerItems.length > 0 && <ActivityCard orgId={orgId} />}
 
           <div className="card">
-            <div className="cardhead justify-between">
+            <div className="cardhead flex-wrap justify-between gap-2">
               <span className="inline-flex items-baseline gap-2">
                 <span className="cardtitle">Transactions</span>
                 {transactions.data && (
                   <span className="mono text-[11.5px] text-(--text-tertiary)">{txItems.length} loaded</span>
                 )}
               </span>
-              <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                Newest first · amounts in USD
+              <span className="flex items-center gap-2">
+                <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                  Newest first · amounts in USD
+                </span>
+                <span className="pillbar">
+                  {TX_SIDES.map((s) => (
+                    <button key={s.key} className={side === s.key ? 'pill on' : 'pill'} onClick={() => setSide(s.key)}>
+                      {s.label}
+                    </button>
+                  ))}
+                </span>
               </span>
             </div>
             {/* The two requests fail independently, so this card carries its own
@@ -887,9 +935,17 @@ export default function BillingView() {
                 <span className="flex h-11 w-11 items-center justify-center rounded-[11px] border border-(--border-subtle) bg-(--surface-sunken) text-(--text-tertiary)">
                   <Icon name="receipt-text" size={20} />
                 </span>
-                <div className="mt-3 font-sans text-[14px] font-semibold leading-normal">No transactions yet</div>
+                <div className="mt-3 font-sans text-[14px] font-semibold leading-normal">
+                  {side === 'debit' ? 'No usage yet' : side === 'credit' ? 'No top-ups yet' : 'No transactions yet'}
+                </div>
+                {/* Under a filter this is "nothing on this side", not "nothing at all" — the
+                    unfiltered ledger may be full, and saying otherwise reads as data loss. */}
                 <div className="mt-1 max-w-[340px] font-sans text-[12.5px] font-normal leading-[1.6] text-(--text-tertiary)">
-                  Purchases and usage deductions will appear here once your org is funded.
+                  {side === 'debit'
+                    ? 'Usage deductions will appear here once your agents start spending.'
+                    : side === 'credit'
+                      ? 'Purchases and operator credits will appear here.'
+                      : 'Purchases and usage deductions will appear here once your org is funded.'}
                 </div>
               </div>
             ) : (
@@ -932,18 +988,24 @@ export default function BillingView() {
                         >
                           {credit ? t.kind : 'usage'}
                         </span>
-                        {t.agentId && (
+                        {/* Attribution, not a second amount: the lead agent named, the rest
+                            counted, and the split itself only in the tooltip — a per-agent
+                            figure printed beside the charge would read as proof of it. */}
+                        {!credit && t.agents && t.agents.length > 0 && (
                           <span
-                            className="mono inline-flex h-[19px] max-w-[160px] flex-none items-center gap-1 rounded-[4px] bg-(--surface-active) px-[7px] text-[10.5px] text-(--text-secondary)"
-                            title={t.agentId}
+                            className="mono inline-flex h-[19px] max-w-[190px] flex-none items-center gap-1 rounded-[4px] bg-(--surface-active) px-[7px] text-[10.5px] text-(--text-secondary)"
+                            title={t.agents.map((a) => `${a.agentId} — $${a.amount}`).join('\n')}
                           >
                             <Icon name="bot" size={11} />
-                            <span className="truncate">{t.agentId}</span>
+                            <span className="truncate">{t.agents[0]!.agentId}</span>
+                            {t.agents.length > 1 && (
+                              <span className="flex-none text-(--text-tertiary)">+{t.agents.length - 1}</span>
+                            )}
                           </span>
                         )}
-                        {/* Service-authored free text: truncated with the full value on hover,
-                            so a long note cannot push the amount column out of line. */}
-                        {t.note && (
+                        {/* Free operator text, rendered as TEXT — truncated, with the whole
+                            note on hover, so a long one cannot push the amount column out. */}
+                        {credit && t.note && (
                           <span
                             className="truncate font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)"
                             title={t.note}

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -988,21 +988,9 @@ export default function BillingView() {
                         >
                           {credit ? t.kind : 'usage'}
                         </span>
-                        {/* Attribution, not a second amount: the lead agent named, the rest
-                            counted, and the split itself only in the tooltip — a per-agent
-                            figure printed beside the charge would read as proof of it. */}
-                        {!credit && t.agents && t.agents.length > 0 && (
-                          <span
-                            className="mono inline-flex h-[19px] max-w-[190px] flex-none items-center gap-1 rounded-[4px] bg-(--surface-active) px-[7px] text-[10.5px] text-(--text-secondary)"
-                            title={t.agents.map((a) => `${a.agentId} — $${a.amount}`).join('\n')}
-                          >
-                            <Icon name="bot" size={11} />
-                            <span className="truncate">{t.agents[0]!.agentId}</span>
-                            {t.agents.length > 1 && (
-                              <span className="flex-none text-(--text-tertiary)">+{t.agents.length - 1}</span>
-                            )}
-                          </span>
-                        )}
+                        {/* No agent attribution here, deliberately: this feed is authorized on
+                            org membership alone, so naming the agent behind a charge would
+                            hand every member a resource-existence oracle. See billing-api.ts. */}
                         {/* Free operator text, rendered as TEXT — truncated, with the whole
                             note on hover, so a long one cannot push the amount column out. */}
                         {credit && t.note && (

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -932,6 +932,25 @@ export default function BillingView() {
                         >
                           {credit ? t.kind : 'usage'}
                         </span>
+                        {t.agentId && (
+                          <span
+                            className="mono inline-flex h-[19px] max-w-[160px] flex-none items-center gap-1 rounded-[4px] bg-(--surface-active) px-[7px] text-[10.5px] text-(--text-secondary)"
+                            title={t.agentId}
+                          >
+                            <Icon name="bot" size={11} />
+                            <span className="truncate">{t.agentId}</span>
+                          </span>
+                        )}
+                        {/* Service-authored free text: truncated with the full value on hover,
+                            so a long note cannot push the amount column out of line. */}
+                        {t.note && (
+                          <span
+                            className="truncate font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)"
+                            title={t.note}
+                          >
+                            {t.note}
+                          </span>
+                        )}
                         {credit && t.receiptUrl && (
                           <a
                             className="inline-flex flex-none items-center gap-0.5 font-sans text-[12px] font-medium text-(--text-brand) hover:underline"

--- a/packages/web/src/components/console/views/BillingView.txfilter.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.txfilter.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+/**
+ * The Transactions table's ledger-side filter. Two things are worth pinning: the side
+ * reaches the SERVICE (the feed is keyset-paginated over both sides at once, so filtering a
+ * page already fetched would leave the cursor and the loaded count describing other rows),
+ * and the rows are cut again on arrival — a billing image that predates `?type=` answers
+ * with the whole ledger, and showing top-ups under a pill that says Usage is a wrong answer,
+ * not a stale one.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetchAccount: vi.fn(async () => ({ orgId: 'org-1', balanceMicro: 5_000_000, state: 'active' })),
+  // The stale-service case on purpose: the whole ledger whatever was asked for.
+  fetchTransactions: vi.fn(async () => ({
+    items: [
+      { type: 'credit', id: 'c1', kind: 'promo', amountMicro: 5_000_000, at: '2026-08-24T15:09:00Z' },
+      { type: 'debit', id: 'd1', period: '2026-08', amount: '0.42', at: '2026-08-20T04:00:00Z' }
+    ],
+    nextCursor: null
+  })),
+  fetchSince: vi.fn(async () => [])
+}))
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, myRole: 'owner', orgPath: (p: string) => p, loading: false })
+}))
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/acme/billing',
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams()
+}))
+vi.mock('@/lib/billing-api', () => ({
+  PURCHASE_MIN_MICRO: 5_000_000,
+  PURCHASE_MAX_MICRO: 2_000_000_000,
+  createBillingPurchase: vi.fn(),
+  fetchBillingPurchase: vi.fn(),
+  fetchBillingAccount: mocks.fetchAccount,
+  fetchBillingTransactions: mocks.fetchTransactions,
+  fetchBillingTransactionsSince: mocks.fetchSince,
+  fmtMicroUsd: (micro: number) => `$${micro / 1_000_000}`,
+  fmtDecimalUsd: (amount: string) => `$${amount}`
+}))
+
+const BillingView = (await import('./BillingView')).default
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(async () => {
+  mocks.fetchTransactions.mockClear()
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: 'billing' }
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root.render(<BillingView />)
+  })
+})
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = {}
+})
+
+// Scoped to the Transactions card's own pillbar — the Activity chart's has a "Usage" pill
+// too, and it comes first in the document.
+async function clickPill(label: string) {
+  const bar = [...host.querySelectorAll('.pillbar')].find((b) =>
+    [...b.querySelectorAll('button')].some((x) => x.textContent === 'All')
+  )
+  const pill = [...(bar?.querySelectorAll('button') ?? [])].find((b) => b.textContent === label) as
+    HTMLButtonElement | undefined
+  expect(pill, `no "${label}" pill`).toBeTruthy()
+  await act(async () => {
+    pill!.click()
+  })
+}
+
+describe('Transactions — the ledger-side filter', () => {
+  it('asks the service for one side, and for the whole ledger by default', async () => {
+    // The default view shares its key with the balance card's own unfiltered read, so it must
+    // be the same request — one page one, not two spellings of it.
+    expect(mocks.fetchTransactions).toHaveBeenCalledWith('org-1')
+
+    await clickPill('Usage')
+    expect(mocks.fetchTransactions).toHaveBeenCalledWith('org-1', undefined, { type: 'debit' })
+
+    await clickPill('Top-ups')
+    expect(mocks.fetchTransactions).toHaveBeenCalledWith('org-1', undefined, { type: 'credit' })
+  })
+
+  it('cuts a stale service’s rows to the side that was asked for', async () => {
+    // The stub answers with both sides whatever the request said, which is exactly what a
+    // billing image predating `?type=` does.
+    expect(host.innerHTML).toContain('Promotional credit')
+    expect(host.innerHTML).toContain('Usage — 2026-08')
+
+    await clickPill('Usage')
+    expect(host.innerHTML).not.toContain('Promotional credit')
+    expect(host.innerHTML).toContain('Usage — 2026-08')
+
+    await clickPill('Top-ups')
+    expect(host.innerHTML).toContain('Promotional credit')
+    expect(host.innerHTML).not.toContain('Usage — 2026-08')
+  })
+
+  it('keeps “last deduction” off the table’s filter', async () => {
+    // It is a fact about the ACCOUNT, not about whichever side is on screen — reading it off
+    // the table's rows had it vanish the moment someone filtered to Top-ups.
+    const posted = /Last deduction<\/div><div class="[^"]*">([^<]*)</
+    const before = posted.exec(host.innerHTML)?.[1]
+    expect(before).not.toBe('—')
+
+    await clickPill('Top-ups')
+    expect(posted.exec(host.innerHTML)?.[1]).toBe(before)
+  })
+})

--- a/packages/web/src/components/console/views/BillingView.txfilter.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.txfilter.test.tsx
@@ -9,18 +9,14 @@
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import { SWRConfig } from 'swr'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+// `fetchTransactions` answers with the whole ledger whatever was asked for — the stale-service
+// case on purpose, since that is what a billing image predating `?type=` does.
 const mocks = vi.hoisted(() => ({
-  fetchAccount: vi.fn(async () => ({ orgId: 'org-1', balanceMicro: 5_000_000, state: 'active' })),
-  // The stale-service case on purpose: the whole ledger whatever was asked for.
-  fetchTransactions: vi.fn(async () => ({
-    items: [
-      { type: 'credit', id: 'c1', kind: 'promo', amountMicro: 5_000_000, at: '2026-08-24T15:09:00Z' },
-      { type: 'debit', id: 'd1', period: '2026-08', amount: '0.42', at: '2026-08-20T04:00:00Z' }
-    ],
-    nextCursor: null
-  })),
+  fetchAccount: vi.fn(),
+  fetchTransactions: vi.fn(),
   fetchSince: vi.fn(async () => [])
 }))
 
@@ -49,15 +45,31 @@ const BillingView = (await import('./BillingView')).default
 let host: HTMLDivElement
 let root: Root
 
-beforeEach(async () => {
+const ACCOUNT = { orgId: 'org-1', balanceMicro: 5_000_000, state: 'active' }
+const CREDIT = { type: 'credit', id: 'c1', kind: 'promo', amountMicro: 5_000_000, at: '2026-08-24T15:09:00Z' }
+const DEBIT = { type: 'debit', id: 'd1', period: '2026-08', amount: '0.42', at: '2026-08-20T04:00:00Z' }
+
+// A FRESH SWR cache per mount. Without it the global one carries a previous test's page one
+// into this one's key, and a test that asserts on an empty filtered page passes on cached rows
+// — which is how the never-funded regression below went green against the bug it exists for.
+async function mount() {
+  await act(async () => {
+    root.render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <BillingView />
+      </SWRConfig>
+    )
+  })
+}
+
+beforeEach(() => {
   mocks.fetchTransactions.mockClear()
+  mocks.fetchAccount.mockResolvedValue(ACCOUNT)
+  mocks.fetchTransactions.mockResolvedValue({ items: [CREDIT, DEBIT], nextCursor: null })
   ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: 'billing' }
   host = document.createElement('div')
   document.body.appendChild(host)
   root = createRoot(host)
-  await act(async () => {
-    root.render(<BillingView />)
-  })
 })
 afterEach(async () => {
   await act(async () => root.unmount())
@@ -81,6 +93,7 @@ async function clickPill(label: string) {
 
 describe('Transactions — the ledger-side filter', () => {
   it('asks the service for one side, and for the whole ledger by default', async () => {
+    await mount()
     // The default view shares its key with the balance card's own unfiltered read, so it must
     // be the same request — one page one, not two spellings of it.
     expect(mocks.fetchTransactions).toHaveBeenCalledWith('org-1')
@@ -93,6 +106,7 @@ describe('Transactions — the ledger-side filter', () => {
   })
 
   it('cuts a stale service’s rows to the side that was asked for', async () => {
+    await mount()
     // The stub answers with both sides whatever the request said, which is exactly what a
     // billing image predating `?type=` does.
     expect(host.innerHTML).toContain('Promotional credit')
@@ -107,7 +121,27 @@ describe('Transactions — the ledger-side filter', () => {
     expect(host.innerHTML).not.toContain('Usage — 2026-08')
   })
 
+  it('keeps the never-funded banner off the table’s filter', async () => {
+    // A suspended org with usage and no top-ups. Reading "has this account ever moved money"
+    // off the table's current side told it, on Top-ups alone, that it never had.
+    mocks.fetchAccount.mockResolvedValue({ orgId: 'org-1', balanceMicro: 0, state: 'suspended' })
+    // A service that HONOURS the side, so the Top-ups page is genuinely empty — the stub used
+    // elsewhere here answers with everything, which would hide this regression.
+    mocks.fetchTransactions.mockImplementation(
+      async (_orgId: string, _cursor?: string, filter?: { type?: string }) => ({
+        items: filter?.type === 'credit' ? [] : [DEBIT],
+        nextCursor: null
+      })
+    )
+    await mount()
+
+    await clickPill('Top-ups')
+    expect(host.innerHTML).not.toContain('Add credits to start serving traffic')
+  })
+
   it('keeps “last deduction” off the table’s filter', async () => {
+    await mount()
+
     // It is a fact about the ACCOUNT, not about whichever side is on screen — reading it off
     // the table's rows had it vanish the moment someone filtered to Top-ups.
     const posted = /Last deduction<\/div><div class="[^"]*">([^<]*)</

--- a/packages/web/src/lib/billing-api.test.ts
+++ b/packages/web/src/lib/billing-api.test.ts
@@ -102,33 +102,30 @@ describe('assertTransactionsPage', () => {
     expect(() => assertTransactionsPage({ items: [legacy], nextCursor: null })).not.toThrow()
   })
 
-  it("accepts a credit's note and a debit's agent split, each on its own arm", () => {
-    // Absent is the older contract; null is the service's "no note" / "no breakdown".
+  it("accepts an operator's note on a credit, and refuses one it cannot read", () => {
+    // Absent is the older contract; null is the service's "no note on this kind".
     expect(() =>
       assertTransactionsPage({
         items: [
           { ...tx, kind: 'adjustment', note: 'goodwill credit' },
-          { ...tx, note: null },
-          { ...debit, agents: [{ agentId: 'agt_1', amount: '0.4' }] },
-          // `[]` is "a breakdown arrived and named nobody" — a different claim from null,
-          // and neither is an error.
-          { ...debit, agents: [] },
-          { ...debit, agents: null }
+          { ...tx, note: null }
         ],
         nextCursor: null
       })
     ).not.toThrow()
+    expect(() => assertTransactionsPage({ items: [{ ...tx, note: 7 }], nextCursor: null })).toThrow(BillingShapeError)
   })
 
-  it('refuses an attribution it cannot read rather than rendering half of it', () => {
-    // A per-agent amount is a decimal string for the same reason the debit's is.
+  it('passes a debit’s agent split through UNREAD rather than refusing the page', () => {
+    // Deliberately unmirrored: this feed is authorized on org membership alone, so its agent
+    // ids are the org's and not the viewer's. Nothing declares the field, so nothing can
+    // render it — and a service that sends one must still not take the page down.
     expect(() =>
-      assertTransactionsPage({ items: [{ ...debit, agents: [{ agentId: 'agt_1', amount: 0.4 }] }], nextCursor: null })
-    ).toThrow(BillingShapeError)
-    expect(() => assertTransactionsPage({ items: [{ ...debit, agents: 'agt_1' }], nextCursor: null })).toThrow(
-      BillingShapeError
-    )
-    expect(() => assertTransactionsPage({ items: [{ ...tx, note: 7 }], nextCursor: null })).toThrow(BillingShapeError)
+      assertTransactionsPage({
+        items: [{ ...debit, agents: [{ agentId: 'agt_1', amount: '0.4' }] }],
+        nextCursor: null
+      })
+    ).not.toThrow()
   })
 
   it('refuses a row whose type this build cannot read', () => {

--- a/packages/web/src/lib/billing-api.test.ts
+++ b/packages/web/src/lib/billing-api.test.ts
@@ -102,20 +102,33 @@ describe('assertTransactionsPage', () => {
     expect(() => assertTransactionsPage({ items: [legacy], nextCursor: null })).not.toThrow()
   })
 
-  it('accepts agentId and note on either arm, and refuses an unusable one', () => {
-    // Absent is the older contract; null is the natural serialization of "not attributed".
+  it("accepts a credit's note and a debit's agent split, each on its own arm", () => {
+    // Absent is the older contract; null is the service's "no note" / "no breakdown".
     expect(() =>
       assertTransactionsPage({
         items: [
-          { ...tx, agentId: 'agt_1', note: 'manual top-up' },
-          { ...debit, agentId: null, note: null }
+          { ...tx, kind: 'adjustment', note: 'goodwill credit' },
+          { ...tx, note: null },
+          { ...debit, agents: [{ agentId: 'agt_1', amount: '0.4' }] },
+          // `[]` is "a breakdown arrived and named nobody" — a different claim from null,
+          // and neither is an error.
+          { ...debit, agents: [] },
+          { ...debit, agents: null }
         ],
         nextCursor: null
       })
     ).not.toThrow()
-    expect(() => assertTransactionsPage({ items: [{ ...debit, agentId: 7 }], nextCursor: null })).toThrow(
+  })
+
+  it('refuses an attribution it cannot read rather than rendering half of it', () => {
+    // A per-agent amount is a decimal string for the same reason the debit's is.
+    expect(() =>
+      assertTransactionsPage({ items: [{ ...debit, agents: [{ agentId: 'agt_1', amount: 0.4 }] }], nextCursor: null })
+    ).toThrow(BillingShapeError)
+    expect(() => assertTransactionsPage({ items: [{ ...debit, agents: 'agt_1' }], nextCursor: null })).toThrow(
       BillingShapeError
     )
+    expect(() => assertTransactionsPage({ items: [{ ...tx, note: 7 }], nextCursor: null })).toThrow(BillingShapeError)
   })
 
   it('refuses a row whose type this build cannot read', () => {

--- a/packages/web/src/lib/billing-api.test.ts
+++ b/packages/web/src/lib/billing-api.test.ts
@@ -102,6 +102,22 @@ describe('assertTransactionsPage', () => {
     expect(() => assertTransactionsPage({ items: [legacy], nextCursor: null })).not.toThrow()
   })
 
+  it('accepts agentId and note on either arm, and refuses an unusable one', () => {
+    // Absent is the older contract; null is the natural serialization of "not attributed".
+    expect(() =>
+      assertTransactionsPage({
+        items: [
+          { ...tx, agentId: 'agt_1', note: 'manual top-up' },
+          { ...debit, agentId: null, note: null }
+        ],
+        nextCursor: null
+      })
+    ).not.toThrow()
+    expect(() => assertTransactionsPage({ items: [{ ...debit, agentId: 7 }], nextCursor: null })).toThrow(
+      BillingShapeError
+    )
+  })
+
   it('refuses a row whose type this build cannot read', () => {
     // Unlike an unknown `kind`, an unknown `type` has no sensible fallback rendering.
     expect(() => assertTransactionsPage({ items: [{ ...tx, type: 'hold' }], nextCursor: null })).toThrow(

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -53,9 +53,9 @@ export interface BillingAccount {
 //            a statement line is a reconciliation fact. The service rounds in exactly
 //            two places and a history row is neither of them, so it hands the exact
 //            value over and formatting it for a human is this side's job.
-// `agentId` / `note` are optional on BOTH arms for the same reason `type` is: a service
-// that predates them omits them, and the console routinely runs ahead of that image.
-// Absent or null ⇒ the row simply renders without that detail.
+// `note` and `agents` are each on ONE arm, and each is optional for the same reason `type`
+// is: a service that predates it omits it, and the console routinely runs ahead of that
+// image. Absent or null ⇒ the row renders without that detail.
 export interface BillingCredit {
   type: 'credit'
   id: string
@@ -67,9 +67,8 @@ export interface BillingCredit {
   // `type` is: a service that predates it omits it, and the console runs ahead of that
   // image. Absent or null ⇒ the row renders with no receipt link, never a broken one.
   receiptUrl?: string | null
-  /** The agent the row is attributed to. */
-  agentId?: string | null
-  /** Free-text note from the service, shown verbatim. */
+  /** Why an operator moved this money, on an `adjustment` row only — null on every other
+   *  kind. Free operator text, so it renders as TEXT: never as markup, never as a link. */
   note?: string | null
 }
 
@@ -82,8 +81,20 @@ export interface BillingDebit {
   amount: string
   /** ISO 8601 instant. */
   at: string
-  agentId?: string | null
-  note?: string | null
+  /** Which agents the charge came from, descending by amount. ATTRIBUTION, not a second
+   *  amount: it is the control plane's split of the same observation `amount` was
+   *  differenced from, so this side must not present it as a proof of the total.
+   *
+   *  Absent or null ⇒ the row carries no attribution. `[]` is the different claim that a
+   *  breakdown arrived and named nobody; both render as no agents, and neither is an error.
+   *  A credit has no agent at all, which is why the field is on this arm only. */
+  agents?: BillingDebitAgent[] | null
+}
+
+/** One agent's share of a debit. `amount` is a decimal STRING, same reason as the debit's. */
+export interface BillingDebitAgent {
+  agentId: string
+  amount: string
 }
 
 export type BillingTransaction = BillingCredit | BillingDebit
@@ -205,11 +216,6 @@ export function assertTransactionsPage(
     // to `never`.
     const t = row as unknown as Record<string, unknown> | null
     if (!t || typeof t.id !== 'string' || typeof t.at !== 'string') throw new BillingShapeError('transaction')
-    // Both arms may carry them; a non-string, non-null value is a shape error, ABSENT is the
-    // older contract.
-    for (const k of ['agentId', 'note'] as const) {
-      if (!(t[k] === undefined || t[k] === null || typeof t[k] === 'string')) throw new BillingShapeError('transaction')
-    }
     // An ABSENT `type` is the shape this API had before the history merged both ledger
     // sides, and it is read as a credit — which is exactly what it was.
     //
@@ -232,10 +238,23 @@ export function assertTransactionsPage(
       // A non-string, non-null receipt is a shape error; ABSENT is the older contract.
       if (!(t.receiptUrl === undefined || t.receiptUrl === null || typeof t.receiptUrl === 'string'))
         throw new BillingShapeError('transaction')
+      // An operator's note, on `adjustment` only. ABSENT is the older contract.
+      if (!(t.note === undefined || t.note === null || typeof t.note === 'string'))
+        throw new BillingShapeError('transaction')
     } else if (t.type === 'debit') {
       // A string, and never coerced to a number here — the exact value is what the
       // service sent, and only the display rounds it.
       if (typeof t.amount !== 'string' || typeof t.period !== 'string') throw new BillingShapeError('transaction')
+      // Attribution. ABSENT is the older contract and `null` is "no breakdown"; a present
+      // list must be entirely readable, since a half-rendered split is worse than none.
+      if (!(t.agents === undefined || t.agents === null)) {
+        if (!Array.isArray(t.agents)) throw new BillingShapeError('transaction')
+        for (const a of t.agents as unknown[]) {
+          const agent = a as Record<string, unknown> | null
+          if (!agent || typeof agent.agentId !== 'string' || typeof agent.amount !== 'string')
+            throw new BillingShapeError('transaction')
+        }
+      }
     } else {
       throw new BillingShapeError('transaction')
     }
@@ -275,21 +294,24 @@ export async function fetchBillingAccount(orgId: string): Promise<BillingAccount
   return body
 }
 
-/** `window` narrows the feed to a half-open `[from, to)` on the row's own instant, the same
- *  shape the CP's usage query takes; both ends are optional and an omitted one is open.
+/** `filter` narrows the feed. `from`/`to` are a half-open `[from, to)` on the row's own
+ *  instant, the same shape the CP's usage query takes; both ends are optional and an omitted
+ *  one is open. `type` narrows it to one ledger side, and an omitted one is both.
  *
- *  It is a REQUEST, not a guarantee: a billing image that predates the parameters ignores
- *  them and answers with the whole ledger, and this console routinely runs ahead of that
- *  image. A caller that needs the window to hold must still check `at` on the rows it keeps. */
+ *  Every part is a REQUEST, not a guarantee: a billing image that predates a parameter
+ *  ignores it and answers with the whole ledger, and this console routinely runs ahead of
+ *  that image. A caller that needs a narrowing to hold must check the rows it keeps — `at`
+ *  for the window, `type` for the side. */
 export async function fetchBillingTransactions(
   orgId: string,
   cursor?: string,
-  window?: { from?: string; to?: string }
+  filter?: { from?: string; to?: string; type?: 'credit' | 'debit' }
 ): Promise<BillingTransactionsPage> {
   const params = new URLSearchParams()
   if (cursor) params.set('cursor', cursor)
-  if (window?.from) params.set('from', window.from)
-  if (window?.to) params.set('to', window.to)
+  if (filter?.from) params.set('from', filter.from)
+  if (filter?.to) params.set('to', filter.to)
+  if (filter?.type) params.set('type', filter.type)
   const query = params.size > 0 ? `?${params}` : ''
   const body = await request<unknown>(`${orgPath(orgId)}/transactions${query}`)
   assertTransactionsPage(body)

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -53,9 +53,16 @@ export interface BillingAccount {
 //            a statement line is a reconciliation fact. The service rounds in exactly
 //            two places and a history row is neither of them, so it hands the exact
 //            value over and formatting it for a human is this side's job.
-// `note` and `agents` are each on ONE arm, and each is optional for the same reason `type`
-// is: a service that predates it omits it, and the console routinely runs ahead of that
-// image. Absent or null ⇒ the row renders without that detail.
+// `note` is optional for the same reason `type` is: a service that predates it omits it, and
+// the console routinely runs ahead of that image. Absent or null ⇒ the row renders without it.
+//
+// The debit arm's `agents` — the control plane's per-agent split of a charge — is DELIBERATELY
+// not mirrored. The billing service authorizes on org membership alone; it holds no Agent or
+// Session visibility, so its `agentId`s are the org's, not the viewer's. Naming one to every
+// member is the discovery that `docs/designs/authorization-policy.md` §4 forbids and a second
+// attribution surface beside the viewer-scoped one in `session-visibility.md` §5, whose whole
+// rule is that withheld usage comes back id-less. An opaque id is still an existence
+// disclosure. Mirroring it needs a viewer-scoped response first — see #1480.
 export interface BillingCredit {
   type: 'credit'
   id: string
@@ -81,20 +88,6 @@ export interface BillingDebit {
   amount: string
   /** ISO 8601 instant. */
   at: string
-  /** Which agents the charge came from, descending by amount. ATTRIBUTION, not a second
-   *  amount: it is the control plane's split of the same observation `amount` was
-   *  differenced from, so this side must not present it as a proof of the total.
-   *
-   *  Absent or null ⇒ the row carries no attribution. `[]` is the different claim that a
-   *  breakdown arrived and named nobody; both render as no agents, and neither is an error.
-   *  A credit has no agent at all, which is why the field is on this arm only. */
-  agents?: BillingDebitAgent[] | null
-}
-
-/** One agent's share of a debit. `amount` is a decimal STRING, same reason as the debit's. */
-export interface BillingDebitAgent {
-  agentId: string
-  amount: string
 }
 
 export type BillingTransaction = BillingCredit | BillingDebit
@@ -245,16 +238,9 @@ export function assertTransactionsPage(
       // A string, and never coerced to a number here — the exact value is what the
       // service sent, and only the display rounds it.
       if (typeof t.amount !== 'string' || typeof t.period !== 'string') throw new BillingShapeError('transaction')
-      // Attribution. ABSENT is the older contract and `null` is "no breakdown"; a present
-      // list must be entirely readable, since a half-rendered split is worse than none.
-      if (!(t.agents === undefined || t.agents === null)) {
-        if (!Array.isArray(t.agents)) throw new BillingShapeError('transaction')
-        for (const a of t.agents as unknown[]) {
-          const agent = a as Record<string, unknown> | null
-          if (!agent || typeof agent.agentId !== 'string' || typeof agent.amount !== 'string')
-            throw new BillingShapeError('transaction')
-        }
-      }
+      // `agents` is checked by its ABSENCE from this list, not by a rule: an unmirrored field
+      // passes through unread, which is what keeps a service that sends one from failing the
+      // page. Nothing downstream can render what nothing here declares.
     } else {
       throw new BillingShapeError('transaction')
     }

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -53,6 +53,9 @@ export interface BillingAccount {
 //            a statement line is a reconciliation fact. The service rounds in exactly
 //            two places and a history row is neither of them, so it hands the exact
 //            value over and formatting it for a human is this side's job.
+// `agentId` / `note` are optional on BOTH arms for the same reason `type` is: a service
+// that predates them omits them, and the console routinely runs ahead of that image.
+// Absent or null ⇒ the row simply renders without that detail.
 export interface BillingCredit {
   type: 'credit'
   id: string
@@ -64,6 +67,10 @@ export interface BillingCredit {
   // `type` is: a service that predates it omits it, and the console runs ahead of that
   // image. Absent or null ⇒ the row renders with no receipt link, never a broken one.
   receiptUrl?: string | null
+  /** The agent the row is attributed to. */
+  agentId?: string | null
+  /** Free-text note from the service, shown verbatim. */
+  note?: string | null
 }
 
 export interface BillingDebit {
@@ -75,6 +82,8 @@ export interface BillingDebit {
   amount: string
   /** ISO 8601 instant. */
   at: string
+  agentId?: string | null
+  note?: string | null
 }
 
 export type BillingTransaction = BillingCredit | BillingDebit
@@ -196,6 +205,11 @@ export function assertTransactionsPage(
     // to `never`.
     const t = row as unknown as Record<string, unknown> | null
     if (!t || typeof t.id !== 'string' || typeof t.at !== 'string') throw new BillingShapeError('transaction')
+    // Both arms may carry them; a non-string, non-null value is a shape error, ABSENT is the
+    // older contract.
+    for (const k of ['agentId', 'note'] as const) {
+      if (!(t[k] === undefined || t[k] === null || typeof t[k] === 'string')) throw new BillingShapeError('transaction')
+    }
     // An ABSENT `type` is the shape this API had before the history merged both ledger
     // sides, and it is read as a credit — which is exactly what it was.
     //

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -48,7 +48,12 @@ export const consoleKeys = {
   /** Billing rows come from the separate billing service (lib/billing-api), but they
    *  are org-scoped like everything else here, so they key the same way. */
   billingAccount: (orgId: string | null | undefined) => consoleKey(orgId, 'billing-account'),
-  billingTransactions: (orgId: string | null | undefined) => consoleKey(orgId, 'billing-transactions'),
+  /** `side` is a REQUEST parameter — the service narrows the keyset feed to one ledger side —
+   *  so each side is its own page one with its own cursor, not a filter over a shared cache. */
+  billingTransactions: <const Side extends string = 'all'>(
+    orgId: string | null | undefined,
+    side: Side = 'all' as Side
+  ) => consoleKey(orgId, 'billing-transactions', side),
   /** The credit rows of the last 30 days — paged out of the same feed, so it keys apart
    *  from the first page `billingTransactions` serves the Billing table. */
   billingTopUps: (orgId: string | null | undefined) => consoleKey(orgId, 'billing-top-ups'),


### PR DESCRIPTION
Renders the operator note a credit row carries, and gives the Transactions table the same Usage / Top-ups split the Activity chart above it already has.

Paired billing-service change (the `?type=` parameter): https://github.com/agentconnect-md/extensions/pull/95 — merge that first.

## The mirror, as the service actually declares it

The first commit here mirrored `agentId` and `note` as sibling optionals on both arms. The billing service's zod schemas are the authority and say something different, corrected in `c47551b`: `note` is on the **credit** arm and means an operator's reason on an `adjustment` row (null on every other kind — the column behind it holds a Checkout Session id or a promo tag there, and neither is a note). Free operator text, so it renders as text: never markup, never a link.

Tolerance is unchanged and still the point: absent is the previous contract.

## No agent attribution — review caught a real hole

The debit arm also carries `agents`, the control plane's per-agent split of a charge, and an earlier commit rendered it. `b9965f8` removes it and does **not** mirror the field.

The billing service authorizes on **org membership alone** — it reads `org` / `membership` from the CP and holds no Agent or Session visibility — so those `agentId`s are the org's, not the viewer's. Naming one to every member is the discovery [`authorization-policy.md`](docs/designs/authorization-policy.md) §4 forbids, and a second attribution surface beside the viewer-scoped one in [`session-visibility.md`](docs/designs/session-visibility.md) §5, whose whole rule is that withheld usage comes back as one id-less rollup. An opaque id is still an existence disclosure.

The **amount** is not the problem and stays — an org's own spend is published to every member by this ledger already, and `session-visibility.md` says so in as many words.

The field is left **unread** rather than validated: an unmirrored field passes through untouched, so a service that sends one does not fail the page, and nothing downstream can render what nothing here declares. A test pins that.

Attribution can come back when the response is viewer-scoped, which needs visibility data the billing service does not have today. That is a design change, not a follow-up commit.

## The ledger-side filter

`All / Usage / Top-ups` in the Transactions cardhead. The side goes to the service as `?type=`, not applied to a page already fetched, because the feed is keyset-paginated over both sides at once — a client-side cut would leave the cursor, the loaded count and "end of ledger" describing the unfiltered ledger while the rows shown are a subset.

The rows are still cut again on arrival: a billing image that predates the parameter answers with everything, and this console deploys ahead of that image. Top-ups under a pill that says Usage is a wrong answer, not a stale one.

Also in this commit:

- the tail is keyed to its **side** as well as its org — a cursor means nothing in another feed
- a settled purchase revalidates **every** side's page one, not only the visible one
- **"Last deduction" moves off the table's rows** onto its own unfiltered read. It is a fact about the account, and reading it off whatever the table happened to hold made it vanish the moment someone filtered to Top-ups. On the default side that read shares the table's SWR key, so the common case is still one request.
- the empty state says "nothing on this side", not "nothing at all"

## Verification

- `typecheck` clean, 1989 tests pass, prettier + eslint clean
- new `BillingView.txfilter.test.tsx` renders the real component and drives the pills: the side reaches the fetcher, a stale service's rows get cut to the side asked for, and "Last deduction" survives a filter switch
- `assertTransactionsPage` cases for the note, and for an `agents` payload passing through unread
- **not** checked in a live browser — that needs the billing service, CP and Postgres up; the DOM tests assert against the real rendered markup instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
