### PR TITLE
fix(daemon): adopt gpt-5.6-sol promotional public pricing

### DIFF
--- a/packages/daemon/src/usage/openai-public-pricing.ts
+++ b/packages/daemon/src/usage/openai-public-pricing.ts
@@ -6,10 +6,10 @@
  * `$update-model-pricing` skill and keep the focused tests in sync.
  *
  * Source: https://developers.openai.com/api/docs/pricing
- * Verified: 2026-08-02
+ * Verified: 2026-08-24
  */
 
-export const OPENAI_PUBLIC_PRICING_AS_OF = '2026-08-02'
+export const OPENAI_PUBLIC_PRICING_AS_OF = '2026-08-24'
 export const OPENAI_PUBLIC_PRICING_SOURCE = 'https://developers.openai.com/api/docs/pricing'
 
 const TOKENS_PER_MILLION = 1_000_000
@@ -34,9 +34,10 @@ interface ModelPricing {
 
 /** Exact public model ids only. Never prefix-match an unknown future model. */
 const MODEL_PRICING: Readonly<Record<string, ModelPricing>> = {
+  // Promotional list price ("available at least through November 21, 2026"); re-verify when the promo ends.
   'gpt-5.6-sol': {
-    standard: { input: 5, cachedInput: 0.5, cacheWrite: 6.25, output: 30 },
-    longContext: { input: 10, cachedInput: 1, cacheWrite: 12.5, output: 45 }
+    standard: { input: 4, cachedInput: 0.4, cacheWrite: 5, output: 20 },
+    longContext: { input: 8, cachedInput: 0.8, cacheWrite: 10, output: 30 }
   },
   'gpt-5.6-terra': {
     standard: { input: 2, cachedInput: 0.2, cacheWrite: 2.5, output: 12 },

--- a/packages/daemon/test/openai-public-pricing.test.ts
+++ b/packages/daemon/test/openai-public-pricing.test.ts
@@ -47,7 +47,19 @@ describe('estimateOpenAiTurnCost', () => {
       outputTokens: 19_000
     })
     expect(estimate).toMatchObject({ ok: true, longContext: false })
-    if (estimate.ok) expect(estimate.amount).toBeCloseTo(4.945)
+    if (estimate.ok) expect(estimate.amount).toBeCloseTo(3.88)
+  })
+
+  it('prices GPT-5.6 Sol long context at the promotional 2x-input/1.5x-output tier', () => {
+    const estimate = estimateOpenAiTurnCost('gpt-5.6-sol', {
+      inputTokens: 280_000,
+      cachedReadTokens: 20_000,
+      cachedWriteTokens: 10_000,
+      outputTokens: 5_000,
+      tierInputTokens: 300_000
+    })
+    expect(estimate).toMatchObject({ ok: true, longContext: true })
+    if (estimate.ok) expect(estimate.amount).toBeCloseTo(0.28 * 8 + 0.02 * 0.8 + 0.01 * 10 + 0.005 * 30)
   })
 
   it('uses GPT-5.6 public cache-write pricing when the adapter supplies that bucket', () => {


### PR DESCRIPTION
## Summary

Ran the repo-local `update-model-pricing` skill: re-verified every row of the daemon's offline OpenAI Standard-API pricing manifest against the official pricing page and model pages on 2026-08-24.

- **gpt-5.6-sol** moved to promotional rates — standard $4 input / $0.40 cached read / $5 cache write / $20 output, long-context $8 / $0.80 / $10 / $30. The page states the promotion is available at least through 2026-11-21.
- The promo rate **is** the published Standard list price, so the static manifest carries it directly (no wall-clock branching — the daemon stays deterministic, and the post-promo rate is unpublished). A dated one-line comment on the row records the bound for the next refresh.
- Every other row is unchanged, including the older codex models that have moved off the main pricing table but still publish their existing rates on their model pages. New models the runtime does not advertise (gpt-5.6-cyber, gpt-5.4-nano, `daybreak-*-latest`) stay out of the manifest per the skill's scope rule.
- Confirmed the managed codex-acp channel's usage mapping still matches the formula's assumptions (disjoint input/cached-read buckets, output includes reasoning, no cache-write bucket, per-prompt aggregate) — no formula change.
- `OPENAI_PUBLIC_PRICING_AS_OF` → 2026-08-24; updated the sol aggregate expectation and added a test locking the promotional long-context tier.

## Validation

- `vitest run test/openai-public-pricing.test.ts test/local-store.test.ts test/daemon-webchat.test.ts test/acp-host.test.ts` — 217 passed
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)