### PR TITLE
feat(daemon): stream Slack turn output natively

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -1,0 +1,527 @@
+# Slack Native Streaming Turn Output
+
+**Status:** Implemented — ships with the PR that adds this document (Layer 1 of the
+Slack-native agent experience; Layer 0 is merged). One carve-out is deliberately still
+closed: turns on a shareable (multi-agent) bot keep the legacy pipeline until §10 Q1 is
+verified live (§7.1).
+
+Layer 0 ([#1462](https://github.com/agentconnect-md/agentconnect/pull/1462),
+[#1471](https://github.com/agentconnect-md/agentconnect/pull/1471)) adopted Slack's Agent
+Sessions control surface: `agents.sessions.setStatus` (`processing` / `active`, deduped per
+`channel:thread`), `agents.sessions.rename`, and the native stop button — `agent_session_stopped`
+resolved by (channel, thread) into the existing cancel seam, on Socket Mode directly and on HTTP
+through a conversation-addressed `RdSlackAction` member.
+
+This document designs the delivery half: replacing the daemon's `chat.postMessage` +
+`chat.update` converger cadence with Slack's streaming methods.
+
+## 1. Context: one status slot, last writer wins
+
+Layer 0 left Slack driving **two** status APIs against **one** UI slot:
+
+- `assistant.threads.setStatus` — free text plus `loading_messages`, plus per-message
+  `username` / `icon_url`. This is how a shared bot shows _which agent_ is working.
+- `agents.sessions.setStatus` — a bare `processing` / `active` enum. No custom text, no
+  `loading_messages`. This is what renders the native "Working…" UI and, because the app
+  subscribes to `agent_session_stopped`, the native stop button.
+
+Slack bridges the legacy call onto the session (non-empty `status` → `processing`, empty →
+`active`), so the two land on the same slot and the **last writer controls the whole
+presentation**. There is no partial merge: you get the legacy rendering (custom text, per-agent
+authorship, no native UI, no stop button) or the session rendering (native UI and stop button, no
+text, no per-agent identity).
+
+`SlackConnection.setStatus` today writes text first, then the enum. But `setSessionLifecycle`
+dedupes on `channel:thread`, so only the **first** status write of a turn reaches the enum at all;
+every later one is text-only. Net effect in production: text wins, and Layer 0's stop button is
+largely invisible.
+
+[#1478](https://github.com/agentconnect-md/agentconnect/pull/1478) (`fix(daemon): set the Slack
+session lifecycle before the free-text status`) makes that ordering consistent rather than
+accidental. It is a correct fix for the _legacy_ path and does not resolve the tradeoff — nothing
+can, while both APIs share one slot. Streaming is the path that yields native UI, native stop, and
+per-agent authorship simultaneously, so **#1478 is expected to close as superseded** when this
+lands. §7 Q5 covers the fallback-path ordering it would have fixed.
+
+### 1.1 What the API research changed about this design
+
+Two premises from the original framing did not survive the documentation:
+
+- **There is no `message_stream_stopped` to subscribe to.** `docs.slack.dev` has no page for it;
+  across the whole platform corpus the name appears only inside one `chat.startStream` error
+  string (`not_subscribed_to_message_stream_stopped`), and `is_stoppable` appears only in that
+  same sentence. The documented mechanism is
+  [`agent_session_stopped`](https://docs.slack.dev/reference/events/agent_session_stopped) — the
+  event **Layer 0 already subscribes to and already routes on both transports**. Its payload
+  carries `streaming_message_ts`, "the timestamps of your app's in-progress streaming messages
+  that Slack stopped in response to the click… an empty array when no stream was active." One
+  event, both scopes.
+- **The streaming methods own the session lifecycle themselves.**
+  [`chat.startStream` creates the session and sets it to `processing`](https://docs.slack.dev/ai/agent-sessions);
+  `chat.stopStream` transitions it via `session_status` (default `active`). A streaming turn
+  therefore makes **zero** status calls of either kind.
+
+Together these mean Layer 1 needs no new Slack event, no new scope, no manifest change, and no new
+wire frame. It is a daemon-local change with a built-in degrade path.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+1. Agent output appears in Slack as a native streaming message, with the native processing UI and
+   the native in-message stop control, **without** losing custom progress narration or per-agent
+   authorship on a shared bot.
+2. Retire the daemon's post-once/`chat.update`-thereafter cadence for the agent's answer.
+3. Degrade to today's pipeline, byte-identically, wherever streaming is unavailable — detected
+   from Slack's own errors, with no configuration knob.
+4. Change nothing about Layer 0's stop seam, the transcript, §5.5 response routing, the session
+   status bar, permission/elicitation cards, or attachments.
+
+**Non-goals**
+
+- Other platforms. Telegram, Discord and Feishu convergers and appliers are untouched. (Feishu's
+  CardKit streaming is the structural precedent this design copies, not a thing it changes.)
+- Webchat, the Control Plane, and message normalization. Streaming is egress only.
+- Slack's feedback-buttons block. `chat.stopStream` accepts one, but AgentConnect has no feedback
+  sink; adding one is a separate product decision.
+- `agent_session_title_changed` handling. Still subscribed-but-inert, as Layer 0 left it.
+
+## 3. Pipeline
+
+### 3.1 Where the seam is
+
+The seam is the one Feishu already established for CardKit, reused verbatim:
+
+| Layer             | Feishu (shipped)                                                     | Slack (this design)                                                       |
+| ----------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Converger IR      | `card-start` / `card-stream` / `card-final` / `card-cancel`          | `stream-start` / `stream-append` / `stream-stop`                          |
+| Converger members | `onStart()`, `hasStreamingUpdate()`, `streamUpdate()`, `onFailure()` | same three plus the existing `flushTerminal()`                            |
+| Daemon timer      | `armFeishuStream(p)`                                                 | `armSlackStream(p)`                                                       |
+| Applier           | `applyFeishuAction` resolves against `startStreamingCard` / …        | `applySlackAction` resolves against `startTurnStream` / …                 |
+| Connection        | `FeishuConnection.startStreamingCard` etc.                           | `SlackConnection.startTurnStream` / `appendTurnStream` / `stopTurnStream` |
+
+No new mechanism is introduced. `OutputConverger` gains a `streaming` axis alongside the existing
+`mode` axis, and emits the `stream-*` actions instead of `post` / `live-reply` /
+`final-live-reply` / `progress` when it is set. Every other action it emits is unchanged.
+
+**Deciding the axis.** `createConverger(ctx)` runs before `openTurnChrome`, and `startTurnStream`
+is async, so the converger is built **optimistically** from a synchronous latch read
+(`conn.streamingLikely()`, §6) and `openTurnChrome` either records the opened stream on
+`SlackTurnState` or calls a one-way `conv.disableStreaming()`. That is safe because
+`openTurnChrome` is already documented to run before `host.prompt` can emit its first chunk — the
+demotion happens while there is provably no output yet.
+
+### 3.2 What stays
+
+Everything that is _chrome around the answer_ rather than the answer:
+
+- **Session status bar** (`status-bar` / `clear-status-bar`) — still its own message, still posted
+  before the stream opens so it stays above.
+- **Permission and elicitation cards**, and their resolved replacements — separate messages,
+  unchanged.
+- **Tool-output code blocks** (`high` mode) — separate messages. A `task_update` chunk caps at 256
+  characters; verbatim command output does not belong there.
+- **Attachments** (`uploadFile` / `shareFile`) — unchanged.
+- **Notices** and the `⚠️ Agent failed to respond` line — see §5.
+- **Transcript.** The paired `recordOnly` posts and `appendTranscript` rows are emitted exactly as
+  today. The stream is display; the transcript is the record.
+- **Permalinks** (`workspaceUrl`), thread coordinates, `protectedAddresses` splitting.
+- **§5.5 response finalization.** `finalizeResponse` still issues its closing `chat.update` on the
+  streamed message's `ts`, carrying `delivery_state: 'final'` and the recipient set resolved from
+  the complete response. This is load-bearing: relay and Socket Mode ingress recognise an agent's
+  finished answer by _that edit_, so replacing it with stop-time metadata would silently break
+  agent-to-agent routing over Slack. §7 Q1 makes verifying it a merge gate.
+
+### 3.3 The attribution footer gets simpler
+
+`chat.stopStream` accepts a `blocks` array "rendered at the bottom of the finalized message", and
+[unfurling is disabled in streaming messages](https://docs.slack.dev/ai/developing-agents) — which
+is exactly what the current path spends a `unfurl_links: false` post boundary to achieve.
+
+So a stream is **born without a footer and gains it exactly once, at stop**. The
+`staleReplyFooters` retry machinery is not needed on the streaming path: there is never a moment
+where two messages carry a footer. It stays for the fallback path, and `onSettle` keeps its retry.
+
+This satisfies
+[`product-conventions.md` §"Slack message attribution footer"](../product-conventions.md) — the
+footer is attached to the final message of the response and is never a separate message.
+
+### 3.4 Length and continuation
+
+`markdown_text` is documented as ≤ 12,000 characters **per call**; no total per-message cap is
+documented. Rather than guess, the design **preserves today's observable behavior**: cap the
+accumulated stream at `SLACK_MARKDOWN_BLOCK_LIMIT` (12,000, the constant the current splitter
+already uses) and roll over.
+
+A rollover is `stopTurnStream` then `startTurnStream`, two separate `PlatformSendQueue` enqueues
+from the applier — never one nested pair. Section boundaries come from the existing
+`splitIntoSections(text, undefined, protectedAddresses)`, so a compound shared-bot mention is
+never cut in half (§5.3).
+
+Two rules on a rollover stop:
+
+- it carries **no footer blocks** (only the last stop does), and
+- it must not release the session. `session_status` defaults to `active`, which would drop the
+  processing UI mid-turn, so the rollover stop passes `session_status: 'processing'`. If Slack
+  rejects that value, the immediately-following `startTurnStream` restores `processing` anyway,
+  at the cost of a sub-second flicker. See §7 Q2.
+
+**A stopped stream is unrecoverable, and a rollover is a new message by construction.**
+`chat.appendStream` against a settled message fails `message_not_in_streaming_state` (or
+`stopped_by_user` when the person ended it), and `chat.startStream` takes no existing `ts` —
+it only ever mints a message. There is therefore no "resume" to attempt and no code path may
+imply one: once a stream ends, for any reason, its handle is dropped, nothing appends to it,
+and no second stop is issued against it. Continuation happens the only way the API allows —
+by opening the next message — and that is exactly what makes the 12k rollover safe.
+
+### 3.5 Cadence and the send queue
+
+All streaming calls go through the connection's single `PlatformSendQueue` (350 ms spacing, FIFO,
+30 s per-task timeout), like every other Slack write. Two consequences:
+
+- **No nested enqueue.** `startTurnStream` / `appendTurnStream` / `stopTurnStream` each enqueue
+  once and never call each other from inside a queued task. Layer 0's
+  `setStatus` → `setSessionLifecycle` comment (_"Already inside the send queue — must not enqueue
+  again"_) is the precedent for the trap.
+- **Appends must not starve real posts.** `chat.appendStream` is Tier 4 (100+/min) against
+  `chat.startStream` / `chat.stopStream` at Tier 2 (20+/min), and Slack's own SDK buffers 256
+  characters before calling. `armSlackStream(p)` therefore coalesces: one append per tick carrying
+  everything buffered since the last, fired when either ~256 characters have accumulated or a
+  ~750 ms timer expires. This mirrors `armFeishuStream` exactly — _"a single timer survives token
+  bursts, so at most one write is queued per interval while still flushing the newest full
+  snapshot when it fires."_
+
+`armIdle` / `IDLE_FLUSH_MS` is untouched; it continues to drive the fallback path.
+
+## 4. ACP → stream mapping
+
+Slack's streaming chunk vocabulary — as the resolved SDK declares it, see §10 Q3 — is
+`{ type: 'markdown_text', text }`, `{ type: 'task_update', id, title, status, details? }`
+(256 chars, status `pending` | `in_progress` | `complete` | `error`),
+`{ type: 'plan_update', title }` and `{ type: 'blocks', blocks }`.
+
+| ACP `session/update`             | today                                                  | streaming                                                                                                                                                                                                               |
+| -------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_message_chunk`            | buffered → `post` / `live-reply`                       | appended as `markdown_text` (coalesced, §3.5)                                                                                                                                                                           |
+| `tool_call` / `tool_call_update` | in-place `progress` message + rotating status text     | `medium`/`high`: `task_update` keyed by `toolCallId`; ACP `pending`/`in_progress` → `in_progress`, `completed` → `complete`, `failed` → `error`. `minimal`/`low`: nothing, as today                                     |
+| `agent_thought_chunk`            | `high`: in-place Thinking message; others: status text | `medium`/`high`: one `task_update` per thinking run (`title: "Thinking"`, `details` = newest clamped line). `high` additionally keeps its full in-place Thinking message — 2,800 characters do not fit a 256-char chunk |
+| `plan`                           | in-place `plan` message                                | unchanged (see below)                                                                                                                                                                                                   |
+| tool output, terminal (`high`)   | separate code-block message                            | unchanged                                                                                                                                                                                                               |
+| `usage_update`                   | dropped                                                | dropped                                                                                                                                                                                                                 |
+
+**`task_display_mode`.** `timeline` (the default) "renders task updates as individual task cards
+interleaved with streamed text" — that is precisely a stream of ACP tool calls, which arrive
+interleaved with the answer and are append-only. `plan` renders the updates together as one
+checklist block — that is precisely an ACP `plan`, which resends the full entry list with
+per-entry statuses on every update.
+
+The catch is that `task_display_mode` is a `chat.startStream` argument, and a turn does not know
+at start whether the runtime will ever emit a plan. So: **open every stream in `timeline`, and
+leave the ACP plan on its existing separate in-place message.** Moving it into `plan_update`
+chunks is a follow-up gated on §7 Q4, not a prerequisite.
+
+**Output modes.** `none` never streams (transcript only, unchanged). `minimal` and `low` stream
+body text only. `medium` and `high` add task chunks. This is the same ladder the modes already
+express — streaming changes the _transport_ of each rung, not which rung shows what.
+
+## 5. Status choreography
+
+On a streaming turn the daemon makes **no status call of either kind**. The stream is the
+lifecycle:
+
+| Moment                               | Today                                                                                 | Streaming                                                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `dispatch`, before the session opens | `showActivity(…, plan.startupActivityLabel)` → legacy text (+ enum, first write only) | nothing                                                                         |
+| `openTurnChrome`                     | `showActivity(…, 'is thinking…')`                                                     | `chat.startStream` — creates the session, sets `processing`                     |
+| each activity change                 | `set-status` → legacy text, enum deduped away                                         | `task_update` chunk on the stream                                               |
+| turn end (`onFinal`)                 | `set-status ''` → legacy clear + enum `active`                                        | `chat.stopStream` with the footer blocks; `session_status` defaults to `active` |
+
+The legacy free-text path is **retired where streaming works and kept verbatim as the fallback**.
+Concretely: `showActivity` and the applier's `set-status` case each grow one guard — _is a stream
+open for this turn?_ — and skip the write if so. Nothing about `setStatus`,
+`setSessionLifecycle`, or their dedup map changes; on a non-streaming turn they run exactly as
+they do today.
+
+Per-agent authorship moves to where it belongs. `username` / `icon_url` / `icon_emoji` are
+per-message arguments on `chat.startStream`, populated from the same
+`slackAgentPostOptions(plan)` values a post uses today, under the same `chat:write.customize`
+dependency — so the existing `customUsernameRetryAt` cooldown covers a workspace that has not
+granted it (retry the start undecorated, re-probe in five minutes). Note that on
+`agents.sessions.setStatus` the equivalent overrides
+[apply only to the loading UX, not to messages](https://docs.slack.dev/ai/agent-sessions), which
+is the other half of why the two APIs could never both win.
+
+**Error flush.** `flushTerminal()` exists because some runtimes narrate a terminal error into the
+message stream and then reject the prompt, so the buffer holds text no later flush will take. On a
+streaming turn it drains into the open stream, and the `⚠️ Agent failed to respond: <reason>`
+notice — still suppressed when the flushed text already carries the same reason — is appended to
+the same stream rather than posted as a separate message. Then `chat.stopStream`.
+
+**…except after a user stop.** The error flush runs from the turn's catch, and a cancelled turn
+reaches it too. When the person pressed Stop, the stream is already dead (§3.4) and the daemon
+must do **neither** of the two things that would look like recovery: it must not append the
+notice to the settled message, and it must not open a replacement message to carry it. The
+existing `outputSuppressed` gate is what enforces this — it is set before the cancel reaches the
+prompt, the catch returns early on it, and `enqueueApply` drops anything already queued — so the
+streaming error flush inherits the rule rather than restating it. The failure is still reported
+through the turn's own outcome; it is simply not narrated into a conversation the person ended.
+
+**A stream must never be left open.** A turn that dies without stopping leaves Slack rendering a
+permanently-streaming message and a session stuck in `processing` for an hour. So the stop is
+idempotent per stream `ts` and is also issued from:
+
+- `onSettle` — the terminal settlement hook, as a last resort;
+- `onSuppress` — loop protection and shutdown, with `allowWhenSuppressed`, exactly as Feishu
+  cancels its card today.
+
+Both benign post-stop errors (`message_not_in_streaming_state`, `stopped_by_user`) are swallowed
+by the same best-effort pattern the other edits use.
+
+## 6. Stop
+
+**There is one stop event, and Layer 0 already handles it.** `agent_session_stopped` fires for
+the native session stop _and_ for the in-message stream stop; its `streaming_message_ts` array
+names the streams Slack ended (empty when none was active). Slack does **not** transition the
+session on a stop click — _"Your app is responsible for transitioning the status"_ — which is
+exactly what Layer 0's `agentSessionStopped` already does.
+
+So the entire stop story for Layer 1 is: **nothing changes.** Specifically:
+
+- No manifest event. `agent_session_stopped` is already in `SLACK_BOT_EVENTS`.
+- No new `RdSlackAction` member. The relay's existing `agent-session-stopped` member already
+  carries (channel, thread, user) to the owning daemon over the conversation-ownership ladder.
+- `streaming_message_ts` is deliberately **not** forwarded. The daemon already knows the stream
+  it opened for that conversation's turn, so forwarding the array would widen the wire contract to
+  restate something the receiver has. If a future case needs it, it is an optional field on the
+  existing member, not a new one.
+
+What the daemon does when the cancel lands: mark the turn's stream closed, so the turn-end path
+skips its own `chat.stopStream` and the applier stops appending. The existing `outputSuppressed`
+gate on `enqueueApply` already prevents queued actions from publishing after an interrupt; the
+stream flag is the same idea one level down.
+
+Both halves of that are prohibitions, not best-effort cleanups. After a stop the daemon may
+**neither append to the dead stream nor open a replacement message** — not for the remaining
+body, not for the error notice, not for the attribution footer. A person who pressed Stop asked
+for the answer to end where it ended; a fresh message appearing underneath would be the daemon
+overruling that. The closed flag lives on the connection (keyed by the conversation, because
+that is what `agent_session_stopped` carries) so that `appendTurnStream` and `stopTurnStream`
+both become no-ops for that message without every caller having to remember.
+
+**Dedupe.** Two stop clicks, or a stop click racing turn-end, collapse harmlessly: the cancel seam
+is idempotent (`cancelSessionByKey` on an already-cancelled turn is a no-op), the relay's
+`slack-action:` digest dedupes redeliveries, and `setSessionLifecycle` dedupes the `active`
+transition per `channel:thread`. The one ordering rule is that `chat.stopStream` precedes the
+lifecycle release, so the message settles before the session says idle.
+
+The status bar's "Cancel run" overflow option and the modal's "Cancel turn" button reach the same
+seam and are unaffected.
+
+## 7. Fallback and detection
+
+No configuration knob. Streaming is unavailable in real workspaces for reasons the daemon cannot
+know in advance —
+[some AI features require a paid plan](https://docs.slack.dev/ai/developing-agents),
+workspace guests cannot access Agents-enabled apps, and `recipient_user_id` /
+`recipient_team_id` are required outside DMs — so the answer has to come from Slack's own errors.
+
+**Turn-start decision, one branch point.** `openTurnChrome` attempts `chat.startStream`. Success
+⇒ the turn streams; failure or no returned `ts` ⇒ `conv.disableStreaming()` and the turn runs
+today's pipeline unchanged. A turn is never half-streamed.
+
+**Two error classes, following `customUsernameRetryAt` precedent** (the only prior art here for a
+TTL-bounded re-probe; `missingScopes` is the only prior art for a permanent latch, and a permanent
+latch is wrong for a capability a workspace can gain by upgrading a plan):
+
+- **Capability refusals** — `unknown_method`, `missing_scope`, `channel_type_not_supported`,
+  `messages_tab_disabled`, or any failure while the SDK exposes no such method — latch
+  `streamingUnavailableUntil = Date.now() + STREAM_REPROBE_MS` (5 minutes, the
+  `CUSTOM_USERNAME_REPROBE_MS` value). `streamingLikely()` reads this latch.
+- **Contextual refusals** — `channel_not_found`, `not_in_channel`, `missing_recipient_user_id`,
+  rate limits, send-queue timeouts — degrade **this turn only**. A per-channel or per-turn error
+  must never latch a per-connection capability off; that is how one bad channel silently kills
+  streaming workspace-wide.
+
+**Structural carve-outs** decided before the call is even attempted, because they cannot succeed:
+
+- No `thread_ts`. Streamed messages must be replies.
+- A channel turn with no human initiator — agent-to-agent, cron, hook, dream — because
+  `recipient_user_id` / `recipient_team_id` are required outside DMs and there is no honest value
+  to supply. DMs are unaffected.
+- Output mode `none`.
+
+A fifth carve-out is not structural but a staged rollout — see §7.1.
+
+**Mid-turn failure.** If an append fails, stop the stream best-effort and finish the remaining
+body through the ordinary `post` path — the same shape Feishu already ships (_"A final CardKit
+update failure must not lose the answer"_: cancel the card, fall back to `postMessage`).
+
+### 7.1 The shareable-bot carve-out, and why it is temporary
+
+One more carve-out ships with the first version, and unlike the four above it is not structural
+— it is a **staged rollout expressed as a predicate**. Turns on a **shareable** (multi-agent)
+Slack bot take the legacy pipeline; dedicated bots stream.
+
+The reason is §10 Q1. Whether the §5.5 closing `chat.update` still works on a _stopped stream_,
+and whether it still emits the `message_changed` event ingress recognises, is undocumented in
+both directions. Agent-to-agent routing over Slack depends on exactly that edit being seen — and
+**agent-to-agent conversation only happens on a shareable bot**, because that is the only bot
+that hosts more than one agent to address. So the population where a wrong answer to Q1 costs
+real behavior is precisely the population this predicate excludes.
+
+That converts Q1 from a merge gate into a **post-deploy verification**: streaming ships now for
+the large majority of installs (dedicated bots), and one live check on a shareable bot decides
+whether the carve-out is lifted. Until then the risk is bounded to _no change_ — a shareable bot
+behaves exactly as it does today.
+
+Two properties make this honest rather than a permanent hedge:
+
+- It gates on the codebase's **existing** shareable predicate — the same
+  `platformIntegrationConfig('slack', …).shareable` fact that decides whether the status bar
+  offers "Switch agent" — not on a new flag invented for this change. Nothing new becomes
+  configurable, so nothing new can acquire callers and become permanent.
+- The closing edit is **still issued on every streaming turn**. Skipping it on the streamed path
+  would leave nothing to verify; issuing it is what makes the follow-up a measurement rather
+  than another round of speculation.
+
+The follow-up is one line plus its test: delete the predicate from the eligibility check once a
+live shareable-bot turn is observed to route. If instead the edit turns out to be rejected or
+invisible, the carve-out stops being temporary and this section becomes its permanent
+justification — which is the same outcome §10 Q1 already recommended, reached without blocking
+the rest.
+
+**SDK note.** `@slack/web-api` resolves to 8.0.0 in this workspace, and — checked against the
+resolved package, not assumed — it **does** type all three methods (`chat.startStream`,
+`chat.appendStream`, `chat.stopStream`) plus the chunk union, through `@slack/types` 3.0.0. So
+`apiCall` is not needed here, unlike Layer 0's `agents.sessions.*`. The connection still declares
+the three members as OPTIONAL on its `AppLike` surface: their absence is one of the capability
+refusals §7 latches on, which is also what keeps every existing inert test app on the legacy path
+without edits.
+
+## 8. Blast radius
+
+**Manifest: no change.** `chat:write` is held, `agent_view` is already the declared feature (not
+the `assistant_view` that deprecates in February 2027), `assistant:write` is present, and
+`agent_session_stopped` was subscribed by Layer 0. There is nothing to add and therefore no
+manifest refresh for installed apps — which is the payoff of #1471's decision to pre-provision
+inert events.
+
+**Protocol and relay: no change.** No new frame member, no new `SlackHttpIngest` branch, no new
+`forwardSession*`. Both transports get streaming for free because it is pure egress: a shared
+bot's send-only `SlackConnection` posts through the same Web API client as a Socket Mode one, and
+the Socket Mode arm needs no new `app.event` handler.
+
+**Eval connection-surface guard** (`evals/test/connection-surface.test.ts`) — the guard reflects
+over `SlackConnection.prototype` and fails on any name that is neither implemented by
+`VirtualSlackConnection` nor listed in `EXEMPT` (TypeScript `private` is erased, so private
+helpers need entries too). New members and their disposition:
+
+| Member                               | Disposition                                                                                                                                                                                                   |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `startTurnStream`                    | **Implement** on `VirtualSlackConnection`, returning "unsupported" — the arena has no Slack API, so every turn deterministically takes the legacy path and every existing arena baseline stays byte-identical |
+| `appendTurnStream`, `stopTurnStream` | No-op stubs, as `setStatus` / `setTitle` already are                                                                                                                                                          |
+| `streamingLikely`                    | No-op stub returning `false` — consistent with the above                                                                                                                                                      |
+| `noteStreamFailure`, `closeStream`   | `EXEMPT` — private error classification / stop bookkeeping, reached only from the three members above (TypeScript `private` is erased, so they need entries)                                                  |
+
+`collaboration-arena-baseline.md` pins this file's test count and needs the same edit if tests are
+added.
+
+**Unchanged:** Telegram / Discord / Feishu convergers and appliers; webchat (its own sink; the
+applier's headless no-`conn` path is untouched); the Control Plane (no route, no schema, no DTO);
+`@agentconnect.md/message` normalization (egress only); the transcript contract; the session
+status bar; permission and elicitation cards; attachments; §5.5 routing semantics.
+
+## 9. Rollout
+
+**One PR — this one.** The two-PR split that would normally apply here — manifest additions ahead
+of the code that needs them, so installed apps take a single refresh — has nothing to carry: §8
+establishes that the manifest already declares everything streaming needs. The principle stands
+for the next change that does add an event; it simply does not bite this one. The design doc
+travels with the implementation, which is why this document ships in that PR rather than ahead of
+it.
+
+**Decided, so the sequence has no branches left in it:**
+
+1. **This PR** lands the whole pipeline — connection members, converger axis, applier, daemon
+   hooks, the status-choreography guards, the eval guard, and this document.
+2. **A follow-up PR lifts the §7.1 shareable carve-out** once a live shareable-bot turn confirms
+   §10 Q1. It is a predicate deletion plus its test; it is not a prerequisite for anything here.
+3. **[#1478](https://github.com/agentconnect-md/agentconnect/pull/1478) closes as superseded when
+   this merges** — not merged first, not rebased. Its ordering fix applies to a path streaming
+   retires wherever it works, and §10 Q5 explains why its order is the wrong one for the
+   remaining fallback turns. Its regression test survives, retargeted at the stronger assertion
+   (a streaming turn writes _neither_ status API).
+4. **No environment kill switch.** The three reasons below stand, and the degrade path is
+   exercised on every arena turn and every carved-out turn, so an unexercised second off-switch
+   would add a failure mode rather than remove one. If review disagrees, the maximal acceptable
+   form is still the single variable described below — but it is not being added pre-emptively.
+
+**Should the pipeline sit behind a code flag, so production keeps the stable legacy path?**
+Recommended: **no.**
+
+- The **promotion gate already provides the temporal separation** a flag would buy. A change
+  reaches a prerelease environment first, soaks, becomes stable, and only reaches production
+  through a manual promote. A flag would add a fourth, hand-operated gate on top of three
+  automatic ones.
+- The **degrade path is not hypothetical, it is the design**. §7's feature detection keeps the
+  legacy pipeline compiled, reachable, and exercised on every turn that cannot stream — including
+  every arena turn (§8). A flag would gate a fallback that already exists, and its "off" state
+  would be indistinguishable from the state a workspace on the wrong plan already reaches.
+- The **test matrix doubles**. Converger and applier assertions already need streaming and
+  fallback variants across five output modes. A flag multiplies that by two for behavior no test
+  can distinguish from `streamingUnavailableUntil` being set.
+
+If extra insurance is wanted, the **maximal acceptable form is a single daemon environment
+variable** (`AC_SLACK_STREAMING=0`) that forces `streamingLikely()` false, documented in the PR as
+temporary and removed after one stable cycle. Not a product-config field, not per-org, not a
+console toggle — those acquire callers and become permanent.
+
+**Sequencing within the PR** is the natural dependency order: connection members and their error
+classification → converger `streaming` axis → applier actions → `armSlackStream` and the
+`openTurnChrome` / `onSettle` / `onSuppress` hooks → the `showActivity` and `set-status` guards →
+eval guard.
+
+## 10. Open questions
+
+**Q1. Does `chat.update` work on a stopped stream, and does it emit the `message_changed` event
+ingress needs?** §5.5 routing depends on the closing edit being _seen_: relay and Socket Mode both
+recognise a finished agent answer by `normalizeSlackResponseFinalization` on that edit, and
+without it agent-to-agent mentions over Slack stop resolving. Undocumented either way.
+_Resolved as a rollout decision, not a merge gate:_ §7.1 ships the shareable-bot carve-out up
+front, so the only population a wrong answer could hurt never streams. The closing edit is still
+issued on every streaming turn, so the live check has something to observe. Verify post-deploy;
+lift the carve-out in a follow-up if it routes, keep it permanently if it does not.
+
+**Q2. What is the accumulated-length cap of a streamed message, and does `chat.stopStream` accept
+`session_status: "processing"`?** The 12,000 figure is documented per call, not per message;
+`session_status` is documented only in the Agent sessions guide, with `suspended` shown by example
+and `active` named as the default. _Recommended:_ cap the accumulated stream at 12,000 and roll
+over (§3.4) — that preserves today's split behavior whatever the real limit is — and pass
+`session_status: "processing"` on a rollover stop, accepting the sub-second flicker if Slack
+rejects it.
+
+**Q3. Which `task_update` chunk shape is real?** The docs carry three mutually inconsistent
+versions: a flat `{ id, title, status }` on the method reference pages, a nested
+`{ task: { task_id, title, status, output } }` in the developing-agents guide, and
+`{ type: "task", id, text, status }` in the design guide — with the status vocabulary differing
+(`complete` vs `completed`) between them. _Resolved from the resolved SDK, which outranks all
+three prose versions:_ `@slack/types` 3.0.0 (what `@slack/web-api` 8.0.0 depends on) declares the
+chunk union outright — `TaskUpdateChunk` is the **flat** shape **with an explicit `type`
+discriminator** the method reference omits:
+`{ type: 'task_update', id, title, status: 'pending' | 'in_progress' | 'complete' | 'error',
+details?, output?, sources? }`, alongside `{ type: 'markdown_text', text }`. So the status word is
+`complete`, the text field is `title` (not `text`), and there is no `task` wrapper. Task chunks
+still ride the same per-error degrade as everything else, so a shape Slack later rejects costs the
+task cards, not the answer.
+
+**Q4. Can `task_display_mode` change mid-stream?** It is a `chat.startStream` argument, and a turn
+cannot know at start whether its runtime will emit an ACP plan. _Recommended:_ open every stream in
+`timeline`, leave the ACP plan on its existing separate in-place message, and revisit moving it to
+`plan_update` chunks only if a mid-stream switch turns out to be supported.
+
+**Q5. On the fallback path, keep main's current enum-last order, or land #1478's reorder?** Once
+streaming ships, the legacy path runs only where streaming is impossible — and #1478's order means
+the enum is written first and then immediately overwritten by text, so the native stop button never
+appears there at all. _Resolved:_ close #1478 as superseded without merging, and leave main's order alone (§9 step 3).
+Its regression test is kept, retargeted at the stronger assertion that a **streaming** turn writes
+neither status API.

--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -166,6 +166,15 @@ Two rules on a rollover stop:
   rejects that value, the immediately-following `startTurnStream` restores `processing` anyway,
   at the cost of a sub-second flicker. See §7 Q2.
 
+**A rollover is also how the stream re-anchors.** The daemon already marks live chrome to
+continue below a newly posted chronological boundary — a permission/elicitation card, or
+visible agent-authored text — via `liveReplyReanchor`, because an in-place message that keeps
+being edited above a card makes the conversation read out of order. A streamed message has
+that problem in its strongest form: it can only ever grow at its own timestamp. So a boundary
+triggers the same rollover, on ORDER instead of on size — settle the current message, open the
+next, tail continues below the card — and, exactly like the live reply, it is **lazy**: an
+empty tail keeps the current message and its footer rather than opening one to say nothing.
+
 **A stopped stream is unrecoverable, and a rollover is a new message by construction.**
 `chat.appendStream` against a settled message fails `message_not_in_streaming_state` (or
 `stopped_by_user` when the person ended it), and `chat.startStream` takes no existing `ts` —
@@ -355,6 +364,38 @@ A fifth carve-out is not structural but a staged rollout — see §7.1.
 **Mid-turn failure.** If an append fails, stop the stream best-effort and finish the remaining
 body through the ordinary `post` path — the same shape Feishu already ships (_"A final CardKit
 update failure must not lose the answer"_: cancel the card, fall back to `postMessage`).
+
+**The APPLIER changes sink; the converger's axis does not flip.** This is the one place where
+the obvious implementation is wrong, so it is worth stating as a rule. Production and
+application are separated by the apply chain, so when a refusal lands, later appends — and
+often `onFinal` itself — are already converged and queued. Flipping the axis then affects only
+_future_ convergence, which leaves two holes: the queued actions no-op and the text they
+carried is never shown, and text already drained as `recordOnly` can never take the post
+boundary. Worse, the axis owns the _display_ cursor while the transcript cursor advances on
+its own slower clock, so resuming ordinary `post` output from the transcript buffer re-posts
+the overlap between them. Truncation and duplication, from the same one-line change.
+
+So the converger keeps streaming and keeps its cursors — they are the only exact record of
+what Slack has been shown — and the applier redirects. From the refusal on, every stream
+action feeds a fallback buffer instead of a message: the refused append first (its text is the
+only remaining copy, the converger having already advanced past it), then every later one,
+including the terminal stop. The buffer is delivered at the closing stop through the ordinary
+reply boundary, so it arrives with the attribution footer, the response metadata and the §5.5
+anchor. Task chunks are dropped — chrome with no legacy form, and a task card rendered as
+prose is worse than an omitted one. Net effect: the answer lands exactly once, and no queued
+action silently discards the content it carried.
+
+**A stop is retryable until Slack accepts it.** `chat.stopStream` failing transiently — a rate
+limit, a dropped connection, the send queue's own timeout — is precisely the case the §5
+settlement backstop exists for, so neither the turn's handle nor the connection's is retired
+on it; doing so would leave the message streaming and the session in `processing` with nothing
+to retry, the exact terminal state that backstop prevents. Only a definite answer retires a
+handle: success, or `message_not_in_streaming_state` / `stopped_by_user`, which prove the
+message is already settled. The unaccepted stop is remembered verbatim so settlement reissues
+_that_ stop rather than a bare abort — otherwise the retry would settle the message but
+silently drop its attribution footer. The same rule governs an append refusal: it retires the
+handle only when the error proves the message stopped, so a transient one still leaves
+something for the stop to land on.
 
 ### 7.1 The shareable-bot carve-out, and why it is temporary
 

--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -36,6 +36,8 @@ const EXEMPT: Record<string, string> = {
   postIfThreadExists: 'private Slack root-existence guard',
   postChatMessage: 'private shared post boundary behind postMessage/postBlocks',
   setSessionLifecycle: 'private agent-session lifecycle call, behind setStatus',
+  noteStreamFailure: 'private streaming error classification, behind the startTurnStream trio',
+  closeStream: 'private streaming handle bookkeeping, behind the startTurnStream trio',
   agentSessionStopped: 'native stop button (Bolt event / relay-forwarded), no arena equivalent',
   shareWithIdentity: 'private identity-carrying upload path, behind uploadFile',
   putUploadBytes: 'private step 2 of the external upload, behind uploadFile',

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -155,6 +155,7 @@ import {
   isSlackStatusBarText,
   slackAgentPostOptions,
   slackPostOptions,
+  slackStreamRecipient,
   type SlackTurnState
 } from './platforms/slack/turn-output.js'
 import { ChannelNameResolver } from './messages/channel-name-resolver.js'
@@ -473,6 +474,7 @@ import {
   type TurnInterruptReason,
   type TurnLifecycleCleanupOutcome,
   type TurnPromptOutcome,
+  type ReplyConnection,
   type TurnRun,
   type TurnSettlement
 } from './daemon/turn-types.js'
@@ -497,6 +499,7 @@ import {
   CANCEL_FORCE_MS,
   DEFAULT_WEB_APP_URL,
   FEISHU_STREAM_FLUSH_MS,
+  SLACK_STREAM_FLUSH_MS,
   IDLE_FLUSH_MS,
   MAX_BG_TASK_WAKE_REARMS,
   MAX_BG_TASK_WAKES_PER_SESSION,
@@ -780,13 +783,26 @@ export class Daemon {
       const registry = new TurnOutputRegistry<Pending, DaemonRenderAction, DaemonConverger, NormalizedMessage>({
         platform: 'slack',
         createConverger: (ctx) => new OutputConverger(ctx.mode as never, ctx.protectedAddresses ?? []),
-        initialTurnState: (): SlackTurnState => ({}),
+        initialTurnState: (ctx): SlackTurnState => {
+          const recipient = slackStreamRecipient(ctx.message)
+          return recipient ? { recipient } : {}
+        },
         apply: (p, action) => this.applySlackAction(p, action as SlackAction),
         // §5.5: re-stamp the delivered answer as this response's one `final` event.
         closeResponse: (p) => this.closeSlackResponse(p),
-        // Terminal settlement: retry stale footer removals the final attribution
-        // action may have bypassed on failure/suppression.
+        // Suppression teardown: stop the append timer and settle the stream mid-flight
+        // (loop protection, shutdown). Idempotent — after the person's own Stop the
+        // connection has already dropped the handle, so this makes no API call.
+        onSuppress: (p) => {
+          this.clearSlackStream(p)
+          if (turnState<SlackTurnState>(p).stream)
+            this.enqueueApply(p, { kind: 'stream-stop', settle: 'abort' }, { allowWhenSuppressed: true })
+        },
+        // Terminal settlement: a stream must never be left open (§5), and stale footer
+        // removals the final attribution action may have bypassed still need retrying.
         onSettle: async (p) => {
+          if (p.conn && turnState<SlackTurnState>(p).stream)
+            await this.applySlackAction(p, { kind: 'stream-stop', settle: 'abort' })
           if (p.conn && turnState<SlackTurnState>(p).staleReplyFooters?.length) {
             await clearStaleSlackReplyFootersExternal(
               { debug: (message) => this.log.debug(message) },
@@ -9238,8 +9254,16 @@ export class Daemon {
     // applies from the next turn on, not mid-turn (see `mode`, resolved inside the plan).
     const conv = plan.turnSurface.createConverger(plan.turnCtx)
     const replyConn = plan.suppressReplyConn ? undefined : this.replyConnFor(agentId, integrationId)
-    const run: TurnRun = { entry, key, plan, agent, replyConn, evaluation }
-    this.showActivity(replyConn, msg.channel, plan.statusThread, plan.startupActivityLabel, plan.statusOptions)
+    // slack-streaming-turn-output.md §3.1: decided optimistically here, from a synchronous
+    // capability read, because the converger is built before chat.startStream can be tried.
+    // openTurnChrome either records the opened stream or demotes this — while there is
+    // provably no output yet.
+    if (conv instanceof OutputConverger && this.slackStreamingEligible(plan, entry, replyConn)) conv.enableStreaming()
+    const run: TurnRun = { entry, key, plan, agent, replyConn, evaluation, conv }
+    // A streaming turn makes no status call of either kind (§5) — including this one: the
+    // stream itself creates the session and sets it processing.
+    if (!this.streamsTurnStatus(conv))
+      this.showActivity(replyConn, msg.channel, plan.statusThread, plan.startupActivityLabel, plan.statusOptions)
     const releaseReplyConn = this.holdReplyConnection(replyConn)
     const opened = await this.openSession(run, releaseReplyConn)
     if (opened.kind === 'cancelled') return null
@@ -9339,7 +9363,36 @@ export class Daemon {
 
   /** Clear this turn's transient platform activity indicator ("is thinking…"). */
   private clearTurnActivity(run: TurnRun): void {
+    if (this.streamsTurnStatus(run.conv)) return
     this.showActivity(run.replyConn, run.plan.channel, run.plan.statusThread, '')
+  }
+
+  /** Does this turn own the platform's status slot through a native stream? Slack's two
+   *  status APIs write the same slot the stream renders into, so a streaming turn writes
+   *  neither (slack-streaming-turn-output.md §5). */
+  private streamsTurnStatus(conv: DaemonConverger | undefined): boolean {
+    return conv instanceof OutputConverger && conv.isStreaming()
+  }
+
+  /**
+   * May this Slack turn take the native streaming pipeline? Every §7 carve-out that can be
+   * decided before the call is attempted, plus §7.1's staged one:
+   *
+   *  - a streamed message must be a thread reply, so a channel-root turn cannot stream;
+   *  - `recipient_user_id` is required outside a DM and only a human initiator supplies one;
+   *  - `none` delivers nothing to the channel at all;
+   *  - a SHAREABLE (multi-agent) bot keeps the legacy pipeline until §10 Q1 is verified live,
+   *    because agent-to-agent routing — the thing Q1 puts at risk — happens only there.
+   *
+   * The remaining answer is Slack's own: `streamingLikely()` reads the capability latch, and
+   * `chat.startStream` decides for real.
+   */
+  private slackStreamingEligible(plan: TurnPlan, entry: QueueEntry, conn: ReplyConnection | undefined): boolean {
+    if (plan.platform !== 'slack' || plan.mode === 'none' || !plan.thread) return false
+    if (!plan.isDm && !slackStreamRecipient(entry.msg)) return false
+    if (this.isShareableSlackIntegration(plan.agentId, plan.integrationId)) return false
+    const likely = (conn as Partial<SlackConnection> | undefined)?.streamingLikely
+    return typeof likely === 'function' && likely.call(conn)
   }
 
   /** §3.3 source gate: bind this session to the inbound envelope's external audience, then — only
@@ -9913,15 +9966,34 @@ export class Daemon {
     if (p.conv instanceof FeishuConverger) {
       for (const action of p.conv.onStart()) this.enqueueApply(p, action)
     }
-    if (!plan.hostAlreadyRunning)
-      this.showActivity(replyConn, plan.channel, plan.statusThread, 'is thinking…', plan.statusOptions)
     // Post/refresh the session status bar up front — with the model now known (session
     // created) plus any usage carried over from prior turns — so it sits at the top of
-    // the thread before the reply streams in.
+    // the thread before the reply streams in, and above the stream opened next.
     await this.emitStatusBar(p)
+    const intended = this.streamsTurnStatus(p.conv)
+    const streaming = intended && (await this.openSlackTurnStream(p))
+    // A turn that meant to stream and could not shows the indicator even on a warm host:
+    // dispatch skipped its own write on the strength of that intent (§7 degrade).
+    if (!streaming && (!plan.hostAlreadyRunning || intended))
+      this.showActivity(replyConn, plan.channel, plan.statusThread, 'is thinking…', plan.statusOptions)
     // Config-file secrets deleted by the idle sweep come back BEFORE the turn
     // reaches the child — synchronous, so the guarantee is ordering, not timing.
     this.rematerializeConfigFiles(entry.agentId)
+  }
+
+  /**
+   * Open this turn's Slack stream and answer whether it took (slack-streaming-turn-output.md
+   * §3.1). The action rides the ordinary apply chain so it lands AFTER the status bar and on
+   * the one send queue; the chain is then awaited because this is the turn's single branch
+   * point — success streams, anything else runs today's pipeline unchanged.
+   */
+  private async openSlackTurnStream(p: Pending): Promise<boolean> {
+    if (!(p.conv instanceof OutputConverger) || !p.conv.isStreaming()) return false
+    for (const action of p.conv.onStart()) this.enqueueApply(p, action)
+    await p.signals.applyChain.catch(() => {})
+    if (turnState<SlackTurnState>(p).stream) return true
+    p.conv.disableStreaming()
+    return false
   }
 
   /** Recheck the observations that landed while attachments, memory recall, or runtime ready
@@ -10296,6 +10368,7 @@ export class Daemon {
     // the relay reply sink — and closes that `rd/chat` stream with a done event.
     this.clearIdle(p)
     this.clearFeishuStream(p)
+    this.clearSlackStream(p)
   }
 
   /** Commit a webchat turn's reply: record it as a transcript row, fan it out as the canonical
@@ -10510,6 +10583,7 @@ export class Daemon {
     const { agentId, msg, webchat, hookContext } = entry
     this.clearIdle(p)
     this.clearFeishuStream(p)
+    this.clearSlackStream(p)
     // A live turn can reveal a login problem the probe sweep can't see
     // (claude-agent-acp initializes and opens sessions fine while logged out):
     // ACP -32000 = fresh logged-out credential; a provider_auth_required
@@ -10605,6 +10679,12 @@ export class Daemon {
       if (p.conv instanceof FeishuConverger) {
         const attribution = plan.showFooter ? await currentAttributionInfo() : undefined
         for (const action of p.conv.onFailure(reason, attribution)) this.enqueueApply(p, action)
+      } else if (p.conv instanceof OutputConverger && p.conv.isStreaming()) {
+        // Streaming: the notice joins the open stream instead of becoming a separate message,
+        // then the stream settles. A turn the person STOPPED never gets here — the suppression
+        // check above already returned, so nothing appends to a dead stream and no replacement
+        // message is opened (slack-streaming-turn-output.md §5/§6).
+        for (const action of p.conv.onStreamingFailure(reason)) this.enqueueApply(p, action)
       } else {
         let covered = false
         for (const action of p.conv.flushTerminal()) {
@@ -10675,6 +10755,7 @@ export class Daemon {
     releaseReplyConn()
     this.clearIdle(p)
     this.clearFeishuStream(p)
+    this.clearSlackStream(p)
     // Backstop: settle any permission / elicitation card still awaiting a tap.
     await this.permissions.releaseElicits(agentId, sessionId)
     await this.permissions.releaseChatPermissions(agentId, sessionId)
@@ -10923,7 +11004,10 @@ export class Daemon {
       // Platform suppression teardown (§7.3): Feishu stops its stream timer and
       // cancels the CardKit entity. Exact lookup — no core fallback.
       this.turnSurfaces.exact(live.plan.platform)?.onSuppress?.(live)
-      this.showActivity(live.conn, live.plan.channel, live.plan.statusThread, '')
+      // A streaming turn's stop settles the message and releases the session by itself; a
+      // status write here would be the one call §5 says a streaming turn never makes.
+      if (!this.streamsTurnStatus(live.conv))
+        this.showActivity(live.conn, live.plan.channel, live.plan.statusThread, '')
       if (live.webchat && !live.webchat.doneSent) {
         live.webchat.doneSent = true
         live.webchat.sink.done({
@@ -11166,7 +11250,13 @@ export class Daemon {
         setStatusBarTs: async (sessionKey, ts) => await this.store.setStatusBarTs(sessionKey, ts),
         clearStatusBarTs: async (sessionKey) => await this.store.clearStatusBarTs(sessionKey),
         monotonicTs: () => monotonicTs(),
-        debug: (message) => this.log.debug(message)
+        debug: (message) => this.log.debug(message),
+        // The applier saw the append refused; only core can flip the converger's axis so the
+        // rest of the answer posts the ordinary way (slack-streaming-turn-output.md §7).
+        degradeStreaming: (turn) => {
+          const pending = turn as Pending
+          if (pending.conv instanceof OutputConverger) pending.conv.disableStreaming()
+        }
       },
       p,
       turnState<SlackTurnState>(p),
@@ -11631,6 +11721,35 @@ export class Daemon {
 
   private clearFeishuStream(p: Pending): void {
     const state = turnState<FeishuTurnState>(p)
+    if (state.streamTimer) clearTimeout(state.streamTimer)
+    state.streamTimer = undefined
+  }
+
+  /**
+   * Coalesce Slack stream appends (slack-streaming-turn-output.md §3.5). `chat.appendStream`
+   * is Tier 4 against Tier 2 for start/stop, and Slack's own SDK buffers 256 characters, so:
+   * flush immediately once that much body is pending or a task card is waiting, otherwise let
+   * ONE timer absorb the token burst — the same shape as `armFeishuStream`.
+   */
+  private armSlackStream(p: Pending): void {
+    // Only a streaming Slack turn carries an OutputConverger with the axis set, so the
+    // instanceof plus the axis IS the platform gate.
+    if (!(p.conv instanceof OutputConverger) || !p.conv.hasStreamingUpdate()) return
+    if (p.conv.streamReady()) {
+      this.clearSlackStream(p)
+      for (const action of p.conv.streamUpdate()) this.enqueueApply(p, action)
+      return
+    }
+    const state = turnState<SlackTurnState>(p)
+    if (state.streamTimer) return
+    state.streamTimer = setTimeout(() => {
+      state.streamTimer = undefined
+      if (p.conv instanceof OutputConverger) for (const action of p.conv.streamUpdate()) this.enqueueApply(p, action)
+    }, SLACK_STREAM_FLUSH_MS)
+  }
+
+  private clearSlackStream(p: Pending): void {
+    const state = turnState<SlackTurnState>(p)
     if (state.streamTimer) clearTimeout(state.streamTimer)
     state.streamTimer = undefined
   }
@@ -12117,6 +12236,7 @@ export class Daemon {
       for (const action of p.conv.onUpdate(update)) this.enqueueApply(p, action)
       this.armIdle(p)
       this.armFeishuStream(p)
+      this.armSlackStream(p)
     }
     // Full activity log (tool/reasoning), recorded regardless of output mode.
     for (const ev of p.rec.onUpdate(update))

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -798,11 +798,19 @@ export class Daemon {
           if (turnState<SlackTurnState>(p).stream)
             this.enqueueApply(p, { kind: 'stream-stop', settle: 'abort' }, { allowWhenSuppressed: true })
         },
-        // Terminal settlement: a stream must never be left open (§5), and stale footer
-        // removals the final attribution action may have bypassed still need retrying.
+        // Terminal settlement: a stream must never be left open (§5), a degraded turn's
+        // buffered tail must still reach the channel (§7), and stale footer removals the
+        // final attribution action may have bypassed still need retrying.
         onSettle: async (p) => {
-          if (p.conn && turnState<SlackTurnState>(p).stream)
-            await this.applySlackAction(p, { kind: 'stream-stop', settle: 'abort' })
+          const state = turnState<SlackTurnState>(p)
+          // Reissue the exact stop Slack refused, so the retry keeps its footer; a stream
+          // still open for any other reason gets a plain settling stop.
+          const owed =
+            state.streamStopOwed ??
+            (state.stream || state.streamFallback
+              ? ({ kind: 'stream-stop', settle: state.streamFallback !== undefined ? 'final' : 'abort' } as const)
+              : undefined)
+          if (p.conn && owed) await this.applySlackAction(p, owed)
           if (p.conn && turnState<SlackTurnState>(p).staleReplyFooters?.length) {
             await clearStaleSlackReplyFootersExternal(
               { debug: (message) => this.log.debug(message) },
@@ -11250,13 +11258,7 @@ export class Daemon {
         setStatusBarTs: async (sessionKey, ts) => await this.store.setStatusBarTs(sessionKey, ts),
         clearStatusBarTs: async (sessionKey) => await this.store.clearStatusBarTs(sessionKey),
         monotonicTs: () => monotonicTs(),
-        debug: (message) => this.log.debug(message),
-        // The applier saw the append refused; only core can flip the converger's axis so the
-        // rest of the answer posts the ordinary way (slack-streaming-turn-output.md §7).
-        degradeStreaming: (turn) => {
-          const pending = turn as Pending
-          if (pending.conv instanceof OutputConverger) pending.conv.disableStreaming()
-        }
+        debug: (message) => this.log.debug(message)
       },
       p,
       turnState<SlackTurnState>(p),
@@ -11860,6 +11862,10 @@ export class Daemon {
     p.chrome.planAttempted = false
     p.chrome.reasoningTs = undefined
     p.chrome.reasoningAttempted = false
+    // A native stream is in-place chrome too, and the only one that cannot simply re-post:
+    // it grows at its own timestamp. Moving its tail to a fresh message is the same lazy
+    // re-anchor the live reply does (slack-streaming-turn-output.md §3.4).
+    if (p.conv instanceof OutputConverger) p.conv.reanchorStream()
   }
 
   /** Copy-on-write mask of an agent's write-only secret values over any JSON-ish

--- a/packages/daemon/src/daemon/constants.ts
+++ b/packages/daemon/src/daemon/constants.ts
@@ -41,6 +41,9 @@ export const IDLE_FLUSH_MS = 2000
 /** CardKit updates are cumulative and rate-limited. Sampling the converger at this
  * cadence streams visibly without queuing one HTTP request per model token. */
 export const FEISHU_STREAM_FLUSH_MS = 350
+/** Slack's analogue. chat.appendStream is Tier 4, so the timer only has to absorb a token
+ * burst — the ~256-character threshold flushes a fast stream well before it expires. */
+export const SLACK_STREAM_FLUSH_MS = 750
 
 /** Local Web App console origin used for session deep links when neither a local
  *  `webAppUrl` config nor a CP-provided one is set. */

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -326,6 +326,9 @@ export interface TurnRun {
   readonly agent: LoadedAgent
   readonly replyConn: ReplyConnection | undefined
   readonly evaluation: TurnEvaluationReporter
+  /** This turn's converger. Carried here so the pre-`Pending` phases can ask it whether the
+   *  turn owns its platform status slot — a Slack streaming turn writes no status API. */
+  readonly conv: DaemonConverger
 }
 
 /** A turn whose answer may be committed: the prompt loop settled on one accepted generation. */

--- a/packages/daemon/src/evaluation/virtual-connections.ts
+++ b/packages/daemon/src/evaluation/virtual-connections.ts
@@ -409,6 +409,28 @@ export class VirtualSlackConnection implements PlatformConnection {
 
   async setTitle(): Promise<void> {}
 
+  /**
+   * Native streaming turn output is UNSUPPORTED here, deliberately and deterministically.
+   * The arena has no Slack API to stream into, and a half-modelled stream would change what
+   * the arena counts; answering "cannot stream" sends every arena turn down the legacy
+   * pipeline, which is the path every existing baseline was recorded against.
+   */
+  async startTurnStream(): Promise<undefined> {
+    return undefined
+  }
+
+  async appendTurnStream(): Promise<boolean> {
+    return false
+  }
+
+  async stopTurnStream(): Promise<boolean> {
+    return false
+  }
+
+  streamingLikely(): boolean {
+    return false
+  }
+
   async openDirectMessage(user: string): Promise<string> {
     return `D-${user}`
   }

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -39,16 +39,26 @@
  * option builders are what make that safe: a non-Slack origin gets `undefined`
  * options and posts without Slack identity decoration.
  */
-import type { SlackConnection, SlackPostOptions, SlackStatusOptions } from '../../slack/connection.js'
+import type { SlackConnection, SlackPostOptions, SlackStatusOptions, SlackTurnStream } from '../../slack/connection.js'
 import { splitIntoSections } from '../../slack/formatter.js'
 import type { SlackAction } from '../../slack/render.js'
 
-/** Slack's opaque per-turn state (§7.3) — the footer edits still owed. */
+/** Slack's opaque per-turn state (§7.3) — the footer edits still owed, plus the turn's
+ *  native stream (slack-streaming-turn-output.md §3). */
 export interface SlackTurnState {
   /** Older reply sections whose footer-removal update failed. Retried on the next
    *  body section and once more at finalization, so a transient Slack error cannot
    *  leave two footers standing. */
   staleReplyFooters?: { ts: string; text: string }[]
+  /** The turn's OPEN streaming message. Dropped the moment it settles — a stopped stream
+   *  is unrecoverable, so a rollover opens a new one rather than reviving this. */
+  stream?: SlackTurnStream
+  /** Coalescing timer for stream appends (§3.5), the Slack analogue of Feishu's. */
+  streamTimer?: NodeJS.Timeout
+  /** The human a streamed message is addressed to (`recipient_user_id`, required outside
+   *  DMs). Absent on a cron / hook / dream / agent-to-agent turn, which is exactly why
+   *  those cannot stream in a channel (§7). */
+  recipient?: string
 }
 
 /** The core turn, as Slack's applier sees it. `Pending` satisfies it structurally.
@@ -140,6 +150,10 @@ export interface SlackTurnHost<TTurn> {
   /** Monotonic transcript timestamp — core owns ordering across surfaces. */
   monotonicTs(): string
   debug(message: string): void
+  /** Demote this turn to the legacy pipeline after a mid-turn streaming failure (§7). The
+   *  converger is core's, so only core can flip its axis; the applier only knows the append
+   *  was refused. Optional so a non-streaming host need not supply it. */
+  degradeStreaming?(turn: TTurn): void
 }
 
 /** Conversational authorship for Slack rows: the agent's name and icon, applied
@@ -193,6 +207,21 @@ export function slackAgentPostOptions(
         }
       : {})
   }
+}
+
+/**
+ * The human a streamed message is addressed to (`recipient_user_id`, which Slack requires
+ * outside a DM). A cron fire, a webhook, a dream, or an agent→agent delivery has no honest
+ * value to supply — which is precisely why those turns cannot stream in a channel (§7).
+ *
+ * Structural in its parameter so this module stays free of core message types.
+ */
+export function slackStreamRecipient(msg: {
+  source: string
+  headless?: boolean
+  sender: { id: string; isBot?: boolean }
+}): string | undefined {
+  return msg.source === 'user' && !msg.headless && !msg.sender.isBot ? msg.sender.id : undefined
 }
 
 /** Keep Slack's transient loading state visually owned by the same agent as its reply. */
@@ -433,6 +462,9 @@ export async function applySlackAction<TTurn extends SlackTurn>(
   const chromeOptions: SlackPostOptions = { ...(postOptions ?? {}), chrome: true }
   switch (action.kind) {
     case 'set-status':
+      // A streaming turn owns the whole status slot through its stream: the two status APIs
+      // share that slot, so writing either would replace the native UI with free text (§5).
+      if (state.stream) return
       if (p.plan.statusThread)
         await conn.setStatus(
           p.plan.channel,
@@ -572,6 +604,65 @@ export async function applySlackAction<TTurn extends SlackTurn>(
         if (ts) {
           p.chrome.liveReplyTs = ts
           p.chrome.liveReplyText = section
+        }
+      }
+      return
+    }
+    case 'stream-start': {
+      // Streamed messages must be thread replies (§7), and a rollover only ever opens the
+      // NEXT message — never a second stream beside a live one.
+      if (state.stream || !p.plan.thread) return
+      state.stream = await conn.startTurnStream(p.plan.channel, p.plan.thread, {
+        ...(state.recipient ? { recipientUserId: state.recipient } : {}),
+        // Per-agent authorship moves here from the status text: same username/icon a reply
+        // carries today, under the same chat:write.customize cooldown (§5).
+        ...(statusBarPostOptions ? { identity: statusBarPostOptions } : {})
+      })
+      return
+    }
+    case 'stream-append': {
+      if (!state.stream || action.chunks.length === 0) return
+      if (await conn.appendTurnStream(state.stream, action.chunks)) return
+      // §7: a mid-turn append failure must not lose the answer. Settle the stream and let
+      // the rest of the turn reach the channel through the ordinary post path.
+      const dead = state.stream
+      state.stream = undefined
+      await conn.stopTurnStream(dead)
+      host.degradeStreaming?.(p)
+      return
+    }
+    case 'stream-stop': {
+      const stream = state.stream
+      if (!stream) return
+      state.stream = undefined
+      const final = action.settle === 'final'
+      const agentOptions = final
+        ? slackAgentPostOptions({ ...p.plan, ...(p.reply.responseId ? { responseId: p.reply.responseId } : {}) })
+        : undefined
+      // The footer is attached exactly once, on the LAST stop — a rollover carries none, and
+      // teardown after suppression carries none either (§3.3).
+      const footer = final && p.attribution ? p.attribution.blocks : undefined
+      await conn.stopTurnStream(stream, {
+        ...(footer ? { blocks: footer } : {}),
+        // A rollover must not release the session mid-turn: `active` is the default (§3.4).
+        ...(action.settle === 'rollover' ? { sessionStatus: 'processing' as const } : {}),
+        ...(agentOptions?.agentAuthorId ? { agentAuthorId: agentOptions.agentAuthorId } : {}),
+        ...(agentOptions?.response ? { response: agentOptions.response } : {})
+      })
+      if (!final) return
+      if (action.discard) {
+        // Nothing ever reached this message — a suppressed reply must not leave an empty
+        // bubble where the agent deliberately stayed silent.
+        await conn.deleteMessage(p.plan.channel, stream.ts)
+        return
+      }
+      if (action.text !== undefined) {
+        // §5.5 closes the response by editing THIS message, so record what it displays.
+        p.reply.lastResponse = { ts: stream.ts, text: action.text }
+        p.reply.lastReply = {
+          ts: stream.ts,
+          text: action.text,
+          ...(footer && p.attribution ? { footerKey: p.attribution.key } : {})
         }
       }
       return

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -41,7 +41,7 @@
  */
 import type { SlackConnection, SlackPostOptions, SlackStatusOptions, SlackTurnStream } from '../../slack/connection.js'
 import { splitIntoSections } from '../../slack/formatter.js'
-import type { SlackAction } from '../../slack/render.js'
+import type { SlackAction, SlackStreamChunk } from '../../slack/render.js'
 
 /** Slack's opaque per-turn state (§7.3) — the footer edits still owed, plus the turn's
  *  native stream (slack-streaming-turn-output.md §3). */
@@ -50,11 +50,21 @@ export interface SlackTurnState {
    *  body section and once more at finalization, so a transient Slack error cannot
    *  leave two footers standing. */
   staleReplyFooters?: { ts: string; text: string }[]
-  /** The turn's OPEN streaming message. Dropped the moment it settles — a stopped stream
-   *  is unrecoverable, so a rollover opens a new one rather than reviving this. */
+  /** The turn's streaming message, until Slack confirms it is settled. Retired only on a
+   *  definite answer — success, or already-stopped — so a transient stop failure still has a
+   *  handle for the settlement retry. A rollover opens a NEW one; a stopped stream is
+   *  unrecoverable and is never revived. */
   stream?: SlackTurnStream
   /** Coalescing timer for stream appends (§3.5), the Slack analogue of Feishu's. */
   streamTimer?: NodeJS.Timeout
+  /** Display body a dead stream never delivered, awaiting the ordinary post boundary (§7).
+   *  Defined (even empty) IS the "this turn has degraded" flag: from that point every stream
+   *  action feeds this buffer instead of a message, so nothing the converger already
+   *  converged — or already queued — is silently dropped. */
+  streamFallback?: string
+  /** A stop Slack has not accepted yet, kept verbatim so settlement reissues THAT stop: a
+   *  bare abort retry would settle the message but drop its attribution footer. */
+  streamStopOwed?: Extract<SlackAction, { kind: 'stream-stop' }>
   /** The human a streamed message is addressed to (`recipient_user_id`, required outside
    *  DMs). Absent on a cron / hook / dream / agent-to-agent turn, which is exactly why
    *  those cannot stream in a channel (§7). */
@@ -150,10 +160,6 @@ export interface SlackTurnHost<TTurn> {
   /** Monotonic transcript timestamp — core owns ordering across surfaces. */
   monotonicTs(): string
   debug(message: string): void
-  /** Demote this turn to the legacy pipeline after a mid-turn streaming failure (§7). The
-   *  converger is core's, so only core can flip its axis; the applier only knows the append
-   *  was refused. Optional so a non-streaming host need not supply it. */
-  degradeStreaming?(turn: TTurn): void
 }
 
 /** Conversational authorship for Slack rows: the agent's name and icon, applied
@@ -390,6 +396,56 @@ async function postSlackReply<TTurn extends SlackTurn>(
   return ts
 }
 
+/** The DISPLAY text a set of stream chunks carries. Task cards are chrome with no legacy
+ *  equivalent — a fallback post would render them as prose — so only body text survives. */
+function streamChunkText(chunks: SlackStreamChunk[]): string {
+  return chunks.map((chunk) => (chunk.type === 'markdown_text' ? chunk.text : '')).join('')
+}
+
+/**
+ * Issue one stop and decide whether the handle may be retired. Slack answering "not settled"
+ * (a rate limit, a dropped connection, a send-queue timeout) is the one case that must NOT
+ * clear it: the message is still streaming and the session still `processing`, so the exact
+ * stop is remembered for the settlement backstop to reissue — reissuing a bare abort instead
+ * would settle the message but silently drop its attribution footer.
+ */
+async function settleTurnStream(
+  conn: SlackConnection,
+  p: SlackTurn,
+  state: SlackTurnState,
+  action: Extract<SlackAction, { kind: 'stream-stop' }>,
+  options: Parameters<SlackConnection['stopTurnStream']>[1] = {}
+): Promise<boolean> {
+  const stream = state.stream
+  if (!stream) return true
+  const settled = await conn.stopTurnStream(stream, options)
+  if (!settled) {
+    state.streamStopOwed = action
+    return false
+  }
+  state.stream = undefined
+  state.streamStopOwed = undefined
+  return true
+}
+
+/** Post the display body a dead stream never delivered, through the ordinary reply boundary
+ *  so it arrives with the attribution footer, the response metadata, and the §5.5 anchor —
+ *  the answer must land exactly once, and this is the copy that has not landed (§7). The
+ *  transcript is untouched: its `recordOnly` copies were written on their own cadence. */
+async function flushStreamFallback<TTurn extends SlackTurn>(
+  host: SlackTurnHost<TTurn>,
+  conn: SlackConnection,
+  p: TTurn,
+  state: SlackTurnState
+): Promise<void> {
+  const pending = state.streamFallback
+  state.streamFallback = ''
+  if (!pending) return
+  for (const section of splitIntoSections(pending, undefined, p.plan.protectedAddresses)) {
+    await postSlackReply(host, conn, p, state, section)
+  }
+}
+
 /** Update minimal mode's live body without dropping its born-in footer. Only record a
  *  footer-key transition after Slack accepts the edit so finalization can retry a failed
  *  metadata refresh. */
@@ -610,8 +666,9 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     }
     case 'stream-start': {
       // Streamed messages must be thread replies (§7), and a rollover only ever opens the
-      // NEXT message — never a second stream beside a live one.
-      if (state.stream || !p.plan.thread) return
+      // NEXT message — never a second stream beside a live one. Once the turn has degraded,
+      // a fresh message would be a second answer bubble rather than a continuation.
+      if (state.streamFallback !== undefined || state.stream || !p.plan.thread) return
       state.stream = await conn.startTurnStream(p.plan.channel, p.plan.thread, {
         ...(state.recipient ? { recipientUserId: state.recipient } : {}),
         // Per-agent authorship moves here from the status text: same username/icon a reply
@@ -621,50 +678,63 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       return
     }
     case 'stream-append': {
-      if (!state.stream || action.chunks.length === 0) return
+      if (action.chunks.length === 0) return
+      const body = streamChunkText(action.chunks)
+      // Already degraded. Application is asynchronous, so appends the converger produced
+      // BEFORE the refusal — and the terminal ones after it — are still arriving; they carry
+      // display text Slack never took, so they feed the buffer instead of no-opping (§7).
+      if (state.streamFallback !== undefined) {
+        state.streamFallback += body
+        return
+      }
+      if (!state.stream) return
       if (await conn.appendTurnStream(state.stream, action.chunks)) return
-      // §7: a mid-turn append failure must not lose the answer. Settle the stream and let
-      // the rest of the turn reach the channel through the ordinary post path.
-      const dead = state.stream
-      state.stream = undefined
-      await conn.stopTurnStream(dead)
-      host.degradeStreaming?.(p)
+      // A mid-turn append failure must not lose the answer. Open the buffer with exactly the
+      // text this append carried — the converger has already advanced its cursor past it, so
+      // this is the only remaining copy — and settle the message.
+      state.streamFallback = body
+      await settleTurnStream(conn, p, state, { kind: 'stream-stop', settle: 'abort' })
       return
     }
     case 'stream-stop': {
-      const stream = state.stream
-      if (!stream) return
-      state.stream = undefined
-      const final = action.settle === 'final'
-      const agentOptions = final
-        ? slackAgentPostOptions({ ...p.plan, ...(p.reply.responseId ? { responseId: p.reply.responseId } : {}) })
-        : undefined
-      // The footer is attached exactly once, on the LAST stop — a rollover carries none, and
-      // teardown after suppression carries none either (§3.3).
-      const footer = final && p.attribution ? p.attribution.blocks : undefined
-      await conn.stopTurnStream(stream, {
-        ...(footer ? { blocks: footer } : {}),
-        // A rollover must not release the session mid-turn: `active` is the default (§3.4).
-        ...(action.settle === 'rollover' ? { sessionStatus: 'processing' as const } : {}),
-        ...(agentOptions?.agentAuthorId ? { agentAuthorId: agentOptions.agentAuthorId } : {}),
-        ...(agentOptions?.response ? { response: agentOptions.response } : {})
-      })
-      if (!final) return
-      if (action.discard) {
-        // Nothing ever reached this message — a suppressed reply must not leave an empty
-        // bubble where the agent deliberately stayed silent.
-        await conn.deleteMessage(p.plan.channel, stream.ts)
-        return
-      }
-      if (action.text !== undefined) {
-        // §5.5 closes the response by editing THIS message, so record what it displays.
-        p.reply.lastResponse = { ts: stream.ts, text: action.text }
-        p.reply.lastReply = {
-          ts: stream.ts,
-          text: action.text,
-          ...(footer && p.attribution ? { footerKey: p.attribution.key } : {})
+      // A degraded turn's tail owns the footer and the §5.5 anchor, so the stop that follows
+      // is never the "final" one: it settles the dead message and nothing more.
+      const degraded = state.streamFallback !== undefined
+      const final = action.settle === 'final' && !degraded
+      if (state.stream) {
+        const agentOptions = final
+          ? slackAgentPostOptions({ ...p.plan, ...(p.reply.responseId ? { responseId: p.reply.responseId } : {}) })
+          : undefined
+        // The footer is attached exactly once, on the LAST stop — a rollover carries none, and
+        // teardown after suppression carries none either (§3.3).
+        const footer = final && p.attribution ? p.attribution.blocks : undefined
+        const stream = state.stream
+        const settled = await settleTurnStream(conn, p, state, action, {
+          ...(footer ? { blocks: footer } : {}),
+          // A rollover must not release the session mid-turn: `active` is the default (§3.4).
+          ...(action.settle === 'rollover' && !degraded ? { sessionStatus: 'processing' as const } : {}),
+          ...(agentOptions?.agentAuthorId ? { agentAuthorId: agentOptions.agentAuthorId } : {}),
+          ...(agentOptions?.response ? { response: agentOptions.response } : {})
+        })
+        if (settled && final) {
+          if (action.discard) {
+            // Nothing ever reached this message — a suppressed reply must not leave an empty
+            // bubble where the agent deliberately stayed silent.
+            await conn.deleteMessage(p.plan.channel, stream.ts)
+          } else if (action.text !== undefined) {
+            // §5.5 closes the response by editing THIS message, so record what it displays.
+            p.reply.lastResponse = { ts: stream.ts, text: action.text }
+            p.reply.lastReply = {
+              ts: stream.ts,
+              text: action.text,
+              ...(footer && p.attribution ? { footerKey: p.attribution.key } : {})
+            }
+          }
         }
       }
+      // Suppression drops the buffer with the rest of the turn's output; every other stop is
+      // where the tail Slack never showed reaches the channel.
+      if (degraded && action.settle !== 'abort') await flushStreamFallback(host, conn, p, state)
       return
     }
     case 'clear-status-bar': {

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -24,6 +24,7 @@ import {
   buildStatusModal,
   buildStatusUnavailableModal,
   decodePermValue,
+  type SlackStreamChunk,
   type StatusBarInfo,
   type StatusModalIdentity
 } from './render.js'
@@ -103,6 +104,15 @@ export interface SlackResponseMetadata {
   /** Only on the visible half of a paired `toAgent + channel` send (§3.2); it correlates
    *  this post with the internal wake that carries the authoritative call envelope. */
   agentCallDeliveryId?: string
+}
+
+/** A handle to ONE open Slack streaming message (`chat.startStream` → `chat.appendStream` →
+ *  `chat.stopStream`). Carries the conversation as well as the message, because the native
+ *  Stop arrives addressed by conversation and must be able to close this stream. */
+export interface SlackTurnStream {
+  readonly channel: string
+  readonly threadTs: string
+  readonly ts: string
 }
 
 /** Optional per-status identity overrides supported by assistant.threads.setStatus.
@@ -355,6 +365,12 @@ export type AppLike = {
       getPermalink: (a: unknown) => Promise<{ permalink?: string }>
       update: (a: unknown) => Promise<{ ts?: string }>
       delete: (a: unknown) => Promise<unknown>
+      // Native streaming turn output (slack-streaming-turn-output.md §3). Optional because
+      // absence IS one of the capability refusals §7 latches on — which is also what keeps
+      // every inert test app on the legacy path without edits.
+      startStream?: (a: unknown) => Promise<{ ts?: string }>
+      appendStream?: (a: unknown) => Promise<unknown>
+      stopStream?: (a: unknown) => Promise<unknown>
     }
     // The external upload flow (`files:write`). chat.postMessage cannot carry bytes at all,
     // so this is the ONLY way to put a file in a conversation.
@@ -525,6 +541,22 @@ function slackApiErrorCode(err: unknown): string | undefined {
 // call per message for installations that have not been upgraded yet.
 const CUSTOM_USERNAME_REPROBE_MS = 5 * 60_000
 
+/** Streaming re-probes on the same cadence: a workspace can GAIN the capability (plan
+ *  change, app upgrade), so a permanent latch would be wrong. */
+const STREAM_REPROBE_MS = CUSTOM_USERNAME_REPROBE_MS
+
+/** Refusals that say this INSTALLATION cannot stream at all — latch and re-probe (§7). */
+const STREAM_CAPABILITY_REFUSALS = new Set([
+  'unknown_method',
+  'missing_scope',
+  'channel_type_not_supported',
+  'messages_tab_disabled'
+])
+
+/** Not failures: the message is already settled, by our own stop or by the person's Stop.
+ *  A stopped stream is unrecoverable (§3.4), so there is nothing to retry or report. */
+const STREAM_ALREADY_STOPPED = new Set(['message_not_in_streaming_state', 'stopped_by_user'])
+
 /** Per-request bound on every Slack egress call. Shared with the byte upload, which rides the
  *  same serial queue and would otherwise block all delivery on undici's 300 s defaults. */
 const SLACK_API_TIMEOUT_MS = 30_000
@@ -656,6 +688,11 @@ export class SlackConnection implements PlatformConnection {
   private assistantDmThreads = new Map<string, string>()
   /** Last agent-session lifecycle state per `channel:thread`, so an unchanged one refires nothing. */
   private sessionLifecycle = new Map<string, 'processing' | 'active'>()
+  /** Cooldown after Slack proves this installation cannot stream (§7 capability refusal). */
+  private streamingUnavailableUntil = 0
+  /** Streaming messages still open, `channel:thread` → message ts. An entry disappears the
+   *  moment the stream settles — by our stop, by a refused append, or by the person's Stop. */
+  private openStreams = new Map<string, string>()
   botUserId = ''
   /** The appToken this socket is keyed by (one socket per unique appToken). */
   readonly appToken: string
@@ -1214,6 +1251,151 @@ export class SlackConnection implements PlatformConnection {
       this.deps.log?.debug(`slack: chat.delete failed (ch=${channel} ts=${ts}): ${(err as Error).message}`)
       return false
     }
+  }
+
+  // ── Native streaming turn output (slack-streaming-turn-output.md §3) ────────
+  // One message per stream, opened at turn start and settled at turn end. All three
+  // calls ride the same send queue as every other write, one enqueue each, and none
+  // of them calls another from inside a queued task.
+
+  /** Cheap synchronous capability read the daemon builds a turn's converger from (§3.1).
+   *  Optimistic by design — `chat.startStream` itself is the authoritative answer. */
+  streamingLikely(): boolean {
+    return typeof this.app.client.chat.startStream === 'function' && Date.now() >= this.streamingUnavailableUntil
+  }
+
+  /** Open this turn's streaming message. `undefined` means "run the legacy pipeline":
+   *  the SDK, the workspace, or this channel cannot stream, and §7 has already decided
+   *  whether that latches the capability off or degrades only this turn. */
+  async startTurnStream(
+    channel: string,
+    threadTs: string,
+    options: { recipientUserId?: string; identity?: SlackPostOptions } = {}
+  ): Promise<SlackTurnStream | undefined> {
+    const start = this.app.client.chat.startStream
+    if (typeof start !== 'function') {
+      this.streamingUnavailableUntil = Date.now() + STREAM_REPROBE_MS
+      return undefined
+    }
+    return this.queue.enqueue(async () => {
+      // `timeline` interleaves task cards with streamed text, which is exactly how ACP
+      // tool calls arrive; the ACP plan keeps its own message instead (§4).
+      const payload: Record<string, unknown> = {
+        channel,
+        thread_ts: threadTs,
+        task_display_mode: 'timeline',
+        ...(options.recipientUserId ? { recipient_user_id: options.recipientUserId } : {}),
+        ...(options.recipientUserId && this.teamId ? { recipient_team_id: this.teamId } : {})
+      }
+      const username = Date.now() < this.customUsernameRetryAt ? undefined : options.identity?.username?.trim()
+      const iconUrl = Date.now() < this.customUsernameRetryAt ? undefined : options.identity?.icon_url?.trim()
+      const customize = { ...(username ? { username } : {}), ...(iconUrl ? { icon_url: iconUrl } : {}) }
+      try {
+        let res: { ts?: string } | undefined
+        try {
+          res = await start({ ...payload, ...customize })
+          if (Object.keys(customize).length > 0) this.customUsernameRetryAt = 0
+        } catch (err) {
+          // Same cooldown the post boundary uses: retry undecorated, re-probe in 5 minutes.
+          if (Object.keys(customize).length === 0 || !isMissingCustomizeScope(err)) throw err
+          this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
+          this.deps.log?.debug('slack: chat:write.customize missing — streaming with the app default identity')
+          res = await start(payload)
+        }
+        const ts = res?.ts
+        if (!ts) {
+          this.deps.log?.debug(`slack: chat.startStream returned no ts (ch=${channel} thread=${threadTs})`)
+          return undefined
+        }
+        this.streamingUnavailableUntil = 0
+        this.openStreams.set(`${channel}:${threadTs}`, ts)
+        return { channel, threadTs, ts }
+      } catch (err) {
+        this.rememberMissingScopes(err)
+        this.noteStreamFailure(err, 'chat.startStream', channel)
+        return undefined
+      }
+    })
+  }
+
+  /** Append chunks to an open stream. `false` means the stream is finished — the caller
+   *  settles it and delivers the rest of the answer the ordinary way (§7). */
+  async appendTurnStream(stream: SlackTurnStream, chunks: SlackStreamChunk[]): Promise<boolean> {
+    const append = this.app.client.chat.appendStream
+    if (chunks.length === 0) return true
+    if (typeof append !== 'function' || this.openStreams.get(`${stream.channel}:${stream.threadTs}`) !== stream.ts)
+      return false
+    return this.queue.enqueue(async () => {
+      try {
+        await append({ channel: stream.channel, ts: stream.ts, chunks })
+        return true
+      } catch (err) {
+        this.rememberMissingScopes(err)
+        this.noteStreamFailure(err, 'chat.appendStream', stream.channel)
+        // A stream that refused an append is over: nothing may append to it again.
+        this.closeStream(stream.channel, stream.threadTs)
+        return false
+      }
+    })
+  }
+
+  /** Settle a stream. Idempotent per message — a turn-end stop that follows the person's
+   *  Stop makes no API call at all, because the handle is already gone. `blocks` are the
+   *  attribution footer (last stop only); `sessionStatus` keeps a rollover in `processing`. */
+  async stopTurnStream(
+    stream: SlackTurnStream,
+    options: {
+      blocks?: unknown[]
+      sessionStatus?: 'processing' | 'active'
+      agentAuthorId?: string
+      response?: SlackResponseMetadata
+    } = {}
+  ): Promise<boolean> {
+    const stop = this.app.client.chat.stopStream
+    if (typeof stop !== 'function' || this.openStreams.get(`${stream.channel}:${stream.threadTs}`) !== stream.ts)
+      return false
+    this.closeStream(stream.channel, stream.threadTs)
+    return this.queue.enqueue(async () => {
+      try {
+        await stop({
+          channel: stream.channel,
+          ts: stream.ts,
+          ...(options.blocks?.length ? { blocks: options.blocks } : {}),
+          ...(options.sessionStatus ? { session_status: options.sessionStatus } : {}),
+          // chat.startStream carries no metadata, so authorship is stamped here — otherwise a
+          // peer's thread backfill would read a streamed answer as an anonymous bot message.
+          ...slackMessageMetadata({
+            ...(options.agentAuthorId ? { agentAuthorId: options.agentAuthorId } : {}),
+            ...(options.response ? { response: options.response } : {})
+          })
+        })
+        return true
+      } catch (err) {
+        this.rememberMissingScopes(err)
+        this.noteStreamFailure(err, 'chat.stopStream', stream.channel)
+        return false
+      }
+    })
+  }
+
+  /** A stopped stream is unrecoverable (§3.4): drop the handle so nothing appends to it and
+   *  no second stop is attempted, whoever ended it. */
+  private closeStream(channel: string, threadTs: string): void {
+    this.openStreams.delete(`${channel}:${threadTs}`)
+  }
+
+  /** §7's two error classes. A capability refusal latches streaming off for a re-probe
+   *  window; everything else — a bad channel, a rate limit, a queue timeout — degrades only
+   *  the turn that hit it, because a per-channel error must never kill streaming workspace-wide. */
+  private noteStreamFailure(err: unknown, method: string, channel: string): void {
+    const code = slackApiErrorCode(err)
+    if (code && STREAM_ALREADY_STOPPED.has(code)) return
+    if (code && STREAM_CAPABILITY_REFUSALS.has(code)) {
+      this.streamingUnavailableUntil = Date.now() + STREAM_REPROBE_MS
+      this.deps.log?.info(`slack: streaming unavailable (${code}) — using the legacy pipeline, re-probing in 5m`)
+      return
+    }
+    this.deps.log?.debug(`slack: ${method} failed (ch=${channel}): ${(err as Error).message}`)
   }
 
   /**
@@ -1805,6 +1987,11 @@ export class SlackConnection implements PlatformConnection {
    *  its turn, then transition the session — Slack leaves it in `processing` on its own. */
   async agentSessionStopped(channel: string, threadTs: string, userId?: string): Promise<void> {
     this.deps.log?.debug(`slack: agent session stopped ch=${channel} thread=${threadTs} user=${userId ?? '?'}`)
+    // Slack already ended any stream this conversation had open before firing the event, and
+    // a stopped stream is unrecoverable (§3.4/§6). Drop the handle FIRST so the cancel below
+    // can neither append to the dead message nor issue a second stop against it — the message
+    // is settled before the session is told it is idle.
+    this.closeStream(channel, threadTs)
     const sessionKey = await this.deps.onMessageShortcut?.({ channel, thread: threadTs, ...(userId ? { userId } : {}) })
     if (sessionKey) this.deps.onStatusAction?.({ kind: 'cancel', sessionKey, ...(userId ? { actor: { userId } } : {}) })
     await this.queue.enqueue(() => this.setSessionLifecycle(channel, threadTs, 'active'))

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -557,6 +557,13 @@ const STREAM_CAPABILITY_REFUSALS = new Set([
  *  A stopped stream is unrecoverable (§3.4), so there is nothing to retry or report. */
 const STREAM_ALREADY_STOPPED = new Set(['message_not_in_streaming_state', 'stopped_by_user'])
 
+/** Does this error PROVE the message is no longer streaming? Only a definite answer retires a
+ *  handle — a rate limit or a dropped connection leaves the message live and must stay retryable. */
+function isStreamAlreadyStopped(err: unknown): boolean {
+  const code = slackApiErrorCode(err)
+  return code !== undefined && STREAM_ALREADY_STOPPED.has(code)
+}
+
 /** Per-request bound on every Slack egress call. Shared with the byte upload, which rides the
  *  same serial queue and would otherwise block all delivery on undici's 300 s defaults. */
 const SLACK_API_TIMEOUT_MS = 30_000
@@ -1277,71 +1284,83 @@ export class SlackConnection implements PlatformConnection {
       this.streamingUnavailableUntil = Date.now() + STREAM_REPROBE_MS
       return undefined
     }
-    return this.queue.enqueue(async () => {
-      // `timeline` interleaves task cards with streamed text, which is exactly how ACP
-      // tool calls arrive; the ACP plan keeps its own message instead (§4).
-      const payload: Record<string, unknown> = {
-        channel,
-        thread_ts: threadTs,
-        task_display_mode: 'timeline',
-        ...(options.recipientUserId ? { recipient_user_id: options.recipientUserId } : {}),
-        ...(options.recipientUserId && this.teamId ? { recipient_team_id: this.teamId } : {})
-      }
-      const username = Date.now() < this.customUsernameRetryAt ? undefined : options.identity?.username?.trim()
-      const iconUrl = Date.now() < this.customUsernameRetryAt ? undefined : options.identity?.icon_url?.trim()
-      const customize = { ...(username ? { username } : {}), ...(iconUrl ? { icon_url: iconUrl } : {}) }
-      try {
-        let res: { ts?: string } | undefined
-        try {
-          res = await start({ ...payload, ...customize })
-          if (Object.keys(customize).length > 0) this.customUsernameRetryAt = 0
-        } catch (err) {
-          // Same cooldown the post boundary uses: retry undecorated, re-probe in 5 minutes.
-          if (Object.keys(customize).length === 0 || !isMissingCustomizeScope(err)) throw err
-          this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
-          this.deps.log?.debug('slack: chat:write.customize missing — streaming with the app default identity')
-          res = await start(payload)
+    return this.queue
+      .enqueue(async () => {
+        // `timeline` interleaves task cards with streamed text, which is exactly how ACP
+        // tool calls arrive; the ACP plan keeps its own message instead (§4).
+        const payload: Record<string, unknown> = {
+          channel,
+          thread_ts: threadTs,
+          task_display_mode: 'timeline',
+          ...(options.recipientUserId ? { recipient_user_id: options.recipientUserId } : {}),
+          ...(options.recipientUserId && this.teamId ? { recipient_team_id: this.teamId } : {})
         }
-        const ts = res?.ts
-        if (!ts) {
-          this.deps.log?.debug(`slack: chat.startStream returned no ts (ch=${channel} thread=${threadTs})`)
+        const username = Date.now() < this.customUsernameRetryAt ? undefined : options.identity?.username?.trim()
+        const iconUrl = Date.now() < this.customUsernameRetryAt ? undefined : options.identity?.icon_url?.trim()
+        const customize = { ...(username ? { username } : {}), ...(iconUrl ? { icon_url: iconUrl } : {}) }
+        try {
+          let res: { ts?: string } | undefined
+          try {
+            res = await start({ ...payload, ...customize })
+            if (Object.keys(customize).length > 0) this.customUsernameRetryAt = 0
+          } catch (err) {
+            // Same cooldown the post boundary uses: retry undecorated, re-probe in 5 minutes.
+            if (Object.keys(customize).length === 0 || !isMissingCustomizeScope(err)) throw err
+            this.customUsernameRetryAt = Date.now() + CUSTOM_USERNAME_REPROBE_MS
+            this.deps.log?.debug('slack: chat:write.customize missing — streaming with the app default identity')
+            res = await start(payload)
+          }
+          const ts = res?.ts
+          if (!ts) {
+            this.deps.log?.debug(`slack: chat.startStream returned no ts (ch=${channel} thread=${threadTs})`)
+            return undefined
+          }
+          this.streamingUnavailableUntil = 0
+          this.openStreams.set(`${channel}:${threadTs}`, ts)
+          return { channel, threadTs, ts }
+        } catch (err) {
+          this.rememberMissingScopes(err)
+          this.noteStreamFailure(err, 'chat.startStream', channel)
           return undefined
         }
-        this.streamingUnavailableUntil = 0
-        this.openStreams.set(`${channel}:${threadTs}`, ts)
-        return { channel, threadTs, ts }
-      } catch (err) {
-        this.rememberMissingScopes(err)
-        this.noteStreamFailure(err, 'chat.startStream', channel)
-        return undefined
-      }
-    })
+        // The send queue's own timeout rejects outside the task; a turn that cannot open a
+        // stream degrades, it does not throw into dispatch.
+      })
+      .catch(() => undefined)
   }
 
-  /** Append chunks to an open stream. `false` means the stream is finished — the caller
-   *  settles it and delivers the rest of the answer the ordinary way (§7). */
+  /** Append chunks to an open stream. `false` means this content did NOT reach Slack, so the
+   *  caller owes it to the channel some other way (§7) — it never means "silently dropped". */
   async appendTurnStream(stream: SlackTurnStream, chunks: SlackStreamChunk[]): Promise<boolean> {
     const append = this.app.client.chat.appendStream
     if (chunks.length === 0) return true
     if (typeof append !== 'function' || this.openStreams.get(`${stream.channel}:${stream.threadTs}`) !== stream.ts)
       return false
-    return this.queue.enqueue(async () => {
-      try {
+    try {
+      return await this.queue.enqueue(async () => {
         await append({ channel: stream.channel, ts: stream.ts, chunks })
         return true
-      } catch (err) {
-        this.rememberMissingScopes(err)
-        this.noteStreamFailure(err, 'chat.appendStream', stream.channel)
-        // A stream that refused an append is over: nothing may append to it again.
-        this.closeStream(stream.channel, stream.threadTs)
-        return false
-      }
-    })
+      })
+    } catch (err) {
+      this.rememberMissingScopes(err)
+      this.noteStreamFailure(err, 'chat.appendStream', stream.channel)
+      // Only a DEFINITE already-stopped answer proves the message is settled. A transient
+      // failure leaves it streaming, so the handle stays and the stop that must still land
+      // has something to land on.
+      if (isStreamAlreadyStopped(err)) this.closeStream(stream.channel, stream.threadTs)
+      return false
+    }
   }
 
-  /** Settle a stream. Idempotent per message — a turn-end stop that follows the person's
-   *  Stop makes no API call at all, because the handle is already gone. `blocks` are the
-   *  attribution footer (last stop only); `sessionStatus` keeps a rollover in `processing`. */
+  /**
+   * Settle a stream. Answers whether the message is now DEFINITELY not streaming: true on
+   * success, and true when it was already settled — by our own earlier stop, or by the person
+   * pressing Stop. `false` means Slack left it unresolved, which is the caller's cue to keep
+   * the handle and let the settlement backstop retry; dropping it there would strand the
+   * message streaming and the session in `processing`, the one state that backstop exists to
+   * prevent. `blocks` are the attribution footer (last stop only); `sessionStatus` keeps a
+   * rollover in `processing`.
+   */
   async stopTurnStream(
     stream: SlackTurnStream,
     options: {
@@ -1352,11 +1371,12 @@ export class SlackConnection implements PlatformConnection {
     } = {}
   ): Promise<boolean> {
     const stop = this.app.client.chat.stopStream
+    // Nothing left to settle: no such method (so no stream was ever opened here) or the handle
+    // is already retired. Idempotent by construction — a stopped stream is unrecoverable.
     if (typeof stop !== 'function' || this.openStreams.get(`${stream.channel}:${stream.threadTs}`) !== stream.ts)
-      return false
-    this.closeStream(stream.channel, stream.threadTs)
-    return this.queue.enqueue(async () => {
-      try {
+      return true
+    try {
+      return await this.queue.enqueue(async () => {
         await stop({
           channel: stream.channel,
           ts: stream.ts,
@@ -1369,13 +1389,17 @@ export class SlackConnection implements PlatformConnection {
             ...(options.response ? { response: options.response } : {})
           })
         })
+        // Retired only now that Slack has accepted it.
+        this.closeStream(stream.channel, stream.threadTs)
         return true
-      } catch (err) {
-        this.rememberMissingScopes(err)
-        this.noteStreamFailure(err, 'chat.stopStream', stream.channel)
-        return false
-      }
-    })
+      })
+    } catch (err) {
+      this.rememberMissingScopes(err)
+      this.noteStreamFailure(err, 'chat.stopStream', stream.channel)
+      if (!isStreamAlreadyStopped(err)) return false
+      this.closeStream(stream.channel, stream.threadTs)
+      return true
+    }
   }
 
   /** A stopped stream is unrecoverable (§3.4): drop the handle so nothing appends to it and
@@ -1388,8 +1412,8 @@ export class SlackConnection implements PlatformConnection {
    *  window; everything else — a bad channel, a rate limit, a queue timeout — degrades only
    *  the turn that hit it, because a per-channel error must never kill streaming workspace-wide. */
   private noteStreamFailure(err: unknown, method: string, channel: string): void {
+    if (isStreamAlreadyStopped(err)) return
     const code = slackApiErrorCode(err)
-    if (code && STREAM_ALREADY_STOPPED.has(code)) return
     if (code && STREAM_CAPABILITY_REFUSALS.has(code)) {
       this.streamingUnavailableUntil = Date.now() + STREAM_REPROBE_MS
       this.deps.log?.info(`slack: streaming unavailable (${code}) — using the legacy pipeline, re-probing in 5m`)

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -880,6 +880,9 @@ export class OutputConverger {
   private streamSent = 0
   private streamMessageText = ''
   private streamEmitted = false
+  /** A chronological boundary was posted below the open message, so the next thing the stream
+   *  shows must move to a new one (see `reanchorStream`). */
+  private streamReanchor = false
   // Task cards awaiting the next append, keyed by tool call id so a burst of updates for
   // one call collapses to its newest state; `emittedTasks` suppresses an unchanged repeat.
   private pendingTasks = new Map<string, Extract<SlackStreamChunk, { type: 'task_update' }>>()
@@ -923,9 +926,17 @@ export class OutputConverger {
     if (this.mode !== 'none' && !this.streamEmitted) this.streaming = true
   }
 
-  /** One-way demotion to today's pipeline: the stream never opened, or an append failed
-   *  mid-turn (§7). A turn is never half-streamed, so this only ever runs before the first
-   *  chunk or after the stream has been settled. */
+  /**
+   * One-way demotion to today's pipeline, for the TURN-START branch point only: the stream
+   * never opened, so nothing has been shown and the whole turn runs unchanged (§7).
+   *
+   * A mid-turn failure deliberately does NOT come here. The axis owns the display cursor —
+   * how much of the answer Slack has already been shown — and the transcript cursor advances
+   * on its own, slower clock; flipping the axis mid-answer would post the overlap between
+   * them a second time and lose whatever the refused append carried. There the APPLIER
+   * changes sink instead, replaying the exact uncommitted tail through the post boundary,
+   * and this converger keeps producing the same stream actions it always would.
+   */
   disableStreaming(): void {
     this.streaming = false
   }
@@ -968,8 +979,22 @@ export class OutputConverger {
     return this.streamText.length - this.streamSent
   }
 
+  /**
+   * A chronological boundary — a human-input card, or visible agent-authored text — was
+   * posted below this stream. Everything the stream shows from here belongs BELOW it, and a
+   * streamed message can only grow at its own timestamp, so the tail has to move to a new
+   * message: the §3.4 rollover, triggered by ORDER instead of by size.
+   *
+   * Lazy on purpose, exactly like the legacy live reply's `liveReplyReanchor`: an empty tail
+   * keeps the current message and its footer rather than opening one to say nothing.
+   */
+  reanchorStream(): void {
+    if (this.streaming && this.streamMessageText) this.streamReanchor = true
+  }
+
   /** Drain the pending body and task cards into appends, settling and reopening the message
-   *  when it would pass Slack's 12,000-character block limit (§3.4). */
+   *  when it would pass Slack's 12,000-character block limit — or when a boundary was posted
+   *  below it (§3.4). */
   streamUpdate(): SlackAction[] {
     if (!this.streaming) return []
     const out: SlackAction[] = []
@@ -978,22 +1003,29 @@ export class OutputConverger {
       if (chunks.length > 0) out.push({ kind: 'stream-append', chunks })
       chunks = []
     }
+    // Settle the current message and open the next. Never releases the session: `active` is
+    // the default, and the turn is still working.
+    const rollover = () => {
+      flush()
+      out.push({ kind: 'stream-stop', settle: 'rollover', text: this.streamMessageText }, { kind: 'stream-start' })
+      this.streamMessageText = ''
+      this.streamReanchor = false
+    }
+    let parts: string[] = []
     if (this.releasableLength() > 0) {
       const body = this.streamText.slice(this.streamSent)
       this.streamSent = this.streamText.length
       // One flush is normally far under the cap; only a huge one needs the splitter, which
       // is also what keeps a compound shared-bot address from being cut in half (§5.3).
-      const parts =
+      parts =
         body.length > SLACK_MARKDOWN_BLOCK_LIMIT ? splitIntoSections(body, undefined, this.protectedAddresses) : [body]
-      for (const part of parts) {
-        if (this.streamMessageText && this.streamMessageText.length + part.length > SLACK_MARKDOWN_BLOCK_LIMIT) {
-          flush()
-          out.push({ kind: 'stream-stop', settle: 'rollover', text: this.streamMessageText }, { kind: 'stream-start' })
-          this.streamMessageText = ''
-        }
-        chunks.push({ type: 'markdown_text', text: part })
-        this.streamMessageText += part
-      }
+    }
+    // Order first, then size: anything at all to show after a boundary goes below it.
+    if (this.streamReanchor && this.streamMessageText && (parts.length > 0 || this.pendingTasks.size > 0)) rollover()
+    for (const part of parts) {
+      if (this.streamMessageText && this.streamMessageText.length + part.length > SLACK_MARKDOWN_BLOCK_LIMIT) rollover()
+      chunks.push({ type: 'markdown_text', text: part })
+      this.streamMessageText += part
     }
     for (const task of this.pendingTasks.values()) chunks.push(task)
     this.pendingTasks.clear()

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -17,7 +17,7 @@ export {
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
-import { splitIntoSections } from './formatter.js'
+import { splitIntoSections, SLACK_MARKDOWN_BLOCK_LIMIT } from './formatter.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
 
 /**
@@ -84,6 +84,33 @@ export type SlackAction =
   // final metadata that changed during the prompt. Not transcript content.
   // `standalone` (minimal mode only): finalize the footer kept on the live reply.
   | { kind: 'attribution'; text: string; blocks: unknown[]; standalone?: boolean }
+  // ── Native streaming (slack-streaming-turn-output.md §3) ─────────────────────
+  // The `streaming` axis emits these INSTEAD of `post` / `live-reply` /
+  // `final-live-reply` / `progress`: the answer rides one `chat.startStream` message
+  // whose native UI carries the processing state and the in-message stop control.
+  // Everything else the converger emits is unchanged, and the body still reaches the
+  // transcript through the paired `recordOnly` posts.
+  | { kind: 'stream-start' }
+  | { kind: 'stream-append'; chunks: SlackStreamChunk[] }
+  // `final` attaches the attribution footer and hands §5.5 the message it closes;
+  // `rollover` settles a full 12k message mid-turn (no footer, session stays
+  // `processing`); `abort` is teardown after suppression or settlement. `discard`
+  // removes a message that never received a chunk — a suppressed reply must not leave
+  // an empty bubble behind.
+  | { kind: 'stream-stop'; settle: 'final' | 'rollover' | 'abort'; text?: string; discard?: boolean }
+
+/** The chunk vocabulary `chat.appendStream` accepts, as `@slack/types` declares it (§10 Q3).
+ *  `plan_update` and `blocks` are unused: an ACP plan keeps its own in-place message, and the
+ *  attribution footer rides `chat.stopStream`'s own `blocks` argument. */
+export type SlackStreamChunk =
+  | { type: 'markdown_text'; text: string }
+  | {
+      type: 'task_update'
+      id: string
+      title: string
+      status: 'in_progress' | 'complete' | 'error'
+      details?: string
+    }
 
 /** Dynamic identity shown under the last reply section. All Slack integration modes use
  *  the same compact `context` footer so shared-bot attribution never looks like body text
@@ -104,6 +131,13 @@ const MAX_STATUS = 50
 // newest tail and mark a drop with a leading ellipsis. The raw buffer is soft-capped at
 // 2× so it can't grow unbounded across a long turn.
 const MAX_REASONING = 2800
+// A streaming task card caps title/details at 256 characters.
+const MAX_STREAM_TASK = 256
+// Slack's own SDK buffers this much before calling chat.appendStream; matching it keeps a
+// Tier-4 append from being queued per model token while still feeling live (§3.5).
+export const STREAM_APPEND_CHARS = 256
+/** Newest thinking line shown on the streamed Thinking card — a tail, not a transcript. */
+const STREAM_THINKING_TAIL = 400
 
 function clampTo(s: string, max: number): string {
   const t = s.trim()
@@ -836,6 +870,25 @@ export class OutputConverger {
   // isn't re-pushed to chat.update every idle window).
   private segmentReset = false
   private recordDirty = false
+  // ── Native streaming (slack-streaming-turn-output.md §3) ────────────────────
+  // The axis itself, plus the open message's bookkeeping. `streamText` is everything the
+  // agent has written this turn and `streamSent` how much of it Slack already has;
+  // `streamMessageText` is only the CURRENT message's share, because a 12k rollover starts
+  // a new one and §5.5 re-sends what that last message actually shows.
+  private streaming = false
+  private streamText = ''
+  private streamSent = 0
+  private streamMessageText = ''
+  private streamEmitted = false
+  // Task cards awaiting the next append, keyed by tool call id so a burst of updates for
+  // one call collapses to its newest state; `emittedTasks` suppresses an unchanged repeat.
+  private pendingTasks = new Map<string, Extract<SlackStreamChunk, { type: 'task_update' }>>()
+  private emittedTasks = new Map<string, string>()
+  private taskTitles = new Map<string, string>()
+  private openTasks = new Set<string>()
+  // The current thinking run: its newest tail, and a counter so each run gets its own card.
+  private thinkingTail = ''
+  private thinkingRun = 0
 
   /**
    * `protectedAddresses` are the COMPOUND mention addresses in this conversation — a
@@ -853,14 +906,155 @@ export class OutputConverger {
     private protectedAddresses: readonly string[] = []
   ) {}
 
+  /**
+   * The rung this turn occupies for CHANNEL chrome. Identical to `mode` except that a
+   * streaming turn has no segmented `minimal`: that mode works by replacing the visible
+   * message with the newest answer segment, and a stream is append-only. §4 puts minimal
+   * on "body text only", which is exactly the `low` rung — so it rides that one, and the
+   * transcript still receives every segment through `recordOnly` posts.
+   */
+  private get rung(): 'none' | 'minimal' | 'low' | 'medium' | 'high' {
+    return this.streaming && this.mode === 'minimal' ? 'low' : this.mode
+  }
+
+  /** Take the native streaming pipeline (§3.1). Called once at turn start from a synchronous
+   *  capability read, while there is provably no output yet. */
+  enableStreaming(): void {
+    if (this.mode !== 'none' && !this.streamEmitted) this.streaming = true
+  }
+
+  /** One-way demotion to today's pipeline: the stream never opened, or an append failed
+   *  mid-turn (§7). A turn is never half-streamed, so this only ever runs before the first
+   *  chunk or after the stream has been settled. */
+  disableStreaming(): void {
+    this.streaming = false
+  }
+
+  isStreaming(): boolean {
+    return this.streaming
+  }
+
+  /** Open this turn's stream, the way Feishu's converger opens its card. */
+  onStart(): SlackAction[] {
+    return this.streaming ? [{ kind: 'stream-start' }] : []
+  }
+
   /** True while body text OR reasoning is pending — the daemon uses this to (re)arm
    *  the ~2s idle-flush timer (§9.1 text-buffer) so a long pure-text stream posts in
    *  steps and streamed thinking updates its in-place block at most once per window. */
   hasBuffered(): boolean {
     // minimal: only the current (unrecorded) segment matters — arm the idle timer while
     // there is fresh streamed text to reflect into the single live message.
-    if (this.mode === 'minimal') return this.recordDirty
+    if (this.rung === 'minimal') return this.recordDirty
     return this.buf.trim().length > 0 || this.reasoningDirty
+  }
+
+  /** Whether a newer snapshot is ready for the append timer (§3.5). */
+  hasStreamingUpdate(): boolean {
+    return this.streaming && (this.pendingTasks.size > 0 || this.releasableLength() > 0)
+  }
+
+  /** Flush now instead of waiting out the timer: Slack's own SDK buffers 256 characters,
+   *  and a task card is a semantic event worth showing immediately. */
+  streamReady(): boolean {
+    return this.streaming && (this.pendingTasks.size > 0 || this.releasableLength() >= STREAM_APPEND_CHARS)
+  }
+
+  /** Characters of body the stream may take right now. Zero while the answer could still
+   *  turn out to be the bare response-control marker — a suppressed turn must never flash. */
+  private releasableLength(): number {
+    const trimmed = this.streamText.trim()
+    if (!trimmed || isNoResponsePrefix(trimmed)) return 0
+    return this.streamText.length - this.streamSent
+  }
+
+  /** Drain the pending body and task cards into appends, settling and reopening the message
+   *  when it would pass Slack's 12,000-character block limit (§3.4). */
+  streamUpdate(): SlackAction[] {
+    if (!this.streaming) return []
+    const out: SlackAction[] = []
+    let chunks: SlackStreamChunk[] = []
+    const flush = () => {
+      if (chunks.length > 0) out.push({ kind: 'stream-append', chunks })
+      chunks = []
+    }
+    if (this.releasableLength() > 0) {
+      const body = this.streamText.slice(this.streamSent)
+      this.streamSent = this.streamText.length
+      // One flush is normally far under the cap; only a huge one needs the splitter, which
+      // is also what keeps a compound shared-bot address from being cut in half (§5.3).
+      const parts =
+        body.length > SLACK_MARKDOWN_BLOCK_LIMIT ? splitIntoSections(body, undefined, this.protectedAddresses) : [body]
+      for (const part of parts) {
+        if (this.streamMessageText && this.streamMessageText.length + part.length > SLACK_MARKDOWN_BLOCK_LIMIT) {
+          flush()
+          out.push({ kind: 'stream-stop', settle: 'rollover', text: this.streamMessageText }, { kind: 'stream-start' })
+          this.streamMessageText = ''
+        }
+        chunks.push({ type: 'markdown_text', text: part })
+        this.streamMessageText += part
+      }
+    }
+    for (const task of this.pendingTasks.values()) chunks.push(task)
+    this.pendingTasks.clear()
+    flush()
+    if (out.length > 0) this.streamEmitted = true
+    return out
+  }
+
+  /** Queue one task card. Keyed by id so streamed updates edit the same card, and an
+   *  unchanged repeat emits nothing. */
+  private queueTask(id: string, title: string, status: 'in_progress' | 'complete' | 'error', details?: string): void {
+    const clamped = clampTo(title, MAX_STREAM_TASK) || 'tool'
+    const chunk: Extract<SlackStreamChunk, { type: 'task_update' }> = {
+      type: 'task_update',
+      id,
+      title: clamped,
+      status,
+      ...(details ? { details: clampTo(details, MAX_STREAM_TASK) } : {})
+    }
+    const signature = `${chunk.title} ${chunk.status} ${chunk.details ?? ''}`
+    if (this.emittedTasks.get(id) === signature) return
+    this.emittedTasks.set(id, signature)
+    this.taskTitles.set(id, clamped)
+    if (status === 'in_progress') this.openTasks.add(id)
+    else this.openTasks.delete(id)
+    this.pendingTasks.set(id, chunk)
+  }
+
+  /** A thinking run ends at the next tool call or at turn end — settle its card rather
+   *  than leaving a spinner behind (§4). */
+  private closeThinkingRun(): void {
+    if (!this.thinkingTail) return
+    this.queueTask(`thinking-${this.thinkingRun}`, 'Thinking', 'complete', this.newestThinkingLine())
+    this.thinkingTail = ''
+    this.thinkingRun += 1
+  }
+
+  private newestThinkingLine(): string {
+    return (
+      this.thinkingTail
+        .split('\n')
+        .filter((line) => line.trim())
+        .pop() ?? ''
+    )
+  }
+
+  /** Turn end: no card may stay in progress once the turn is over. */
+  private settleTasks(): void {
+    this.closeThinkingRun()
+    for (const id of [...this.openTasks]) this.queueTask(id, this.taskTitles.get(id) ?? 'tool', 'complete')
+  }
+
+  /** The one closing stop: it carries the footer (via the applier's `p.attribution`) and the
+   *  text §5.5 re-sends. A stream nothing ever reached is removed instead of left empty. */
+  private finalStop(): SlackAction {
+    return {
+      kind: 'stream-stop',
+      settle: 'final',
+      ...(this.streamMessageText ? { text: this.streamMessageText } : {}),
+      ...(this.streamEmitted ? {} : { discard: true })
+    }
   }
 
   /** Flush pending output for the idle timer: in high mode one in-place `reasoning` update
@@ -872,7 +1066,7 @@ export class OutputConverger {
    *
    *  minimal: no per-window `post`s — just the `live-reply` refresh. */
   flushBuffered(): SlackAction[] {
-    if (this.mode === 'minimal') return this.liveRefresh()
+    if (this.rung === 'minimal') return this.liveRefresh()
     return [...this.drainReasoning(), ...this.flushStreaming()]
   }
 
@@ -882,8 +1076,30 @@ export class OutputConverger {
    *  the whole buffer, paragraph break or not — otherwise the runtime's own error text is
    *  dropped and replaced by the generic failure notice. */
   flushTerminal(): SlackAction[] {
-    if (this.mode === 'minimal') return this.liveRefresh()
+    if (this.rung === 'minimal') return this.liveRefresh()
     return [...this.drainReasoning(), ...this.flush()]
+  }
+
+  /**
+   * Terminal failure on a STREAMING turn (§5 error flush). Same contract as the legacy
+   * path — drain whatever the runtime narrated before rejecting, and add the failure line
+   * only when that text does not already say it — except that both land on the open stream
+   * instead of becoming separate messages, and the stream is settled here.
+   *
+   * A turn the person STOPPED never reaches this: the cancel sets `outputSuppressed`, the
+   * turn's catch returns on it, and `enqueueApply` drops anything already queued. Nothing
+   * appends to the dead stream and no replacement message is opened (§5/§6).
+   */
+  onStreamingFailure(reason: string): SlackAction[] {
+    const drained = [...this.drainReasoning(), ...this.flush()]
+    if (!this.streamText.includes(reason)) {
+      const notice = `⚠️ Agent failed to respond: ${reason}`
+      this.streamText += this.streamText.trim() ? `\n\n${notice}` : notice
+      drained.push({ kind: 'post', text: notice, attributed: false, recordOnly: true })
+    }
+    this.settleTasks()
+    const appends = this.streamUpdate()
+    return [...drained, ...appends, this.finalStop()]
   }
 
   /** minimal: refresh the single in-place `live-reply` with the current segment (display only;
@@ -966,7 +1182,9 @@ export class OutputConverger {
   private emitBody(text: string): SlackAction[] {
     // none: record the reply into the transcript WITHOUT sending it — `recordOnly` is handled
     // before the connection check on every platform, so it lands even though replyConn is unset.
-    const recordOnly = this.mode === 'none'
+    // streaming: the channel already has the body on the stream, so these posts are the
+    // transcript half only — the stream is display, the transcript is the record (§3.2).
+    const recordOnly = this.mode === 'none' || this.streaming
     return splitIntoSections(text, undefined, this.protectedAddresses).map(
       (t) => ({ kind: 'post', text: t, ...(recordOnly ? { recordOnly: true } : {}) }) as SlackAction
     )
@@ -979,7 +1197,9 @@ export class OutputConverger {
    */
   private pushActivity(raw: string): SlackAction[] {
     // none: nothing reaches the channel, not even the transient loading status.
-    if (this.mode === 'none') return []
+    // streaming: the stream IS the lifecycle, and the two status APIs share one slot with
+    // it — writing either would replace the native UI with free text (§5).
+    if (this.rung === 'none' || this.streaming) return []
     const label = clampTo(raw, MAX_STATUS)
     if (this.activity[this.activity.length - 1] === label) return []
     this.activity.push(label)
@@ -1036,12 +1256,15 @@ export class OutputConverger {
         const text = content?.type === 'text' ? (content.text ?? '') : ''
         // minimal: a chunk arriving after a tool boundary opens a new segment that REPLACES
         // the previous one in the single live message (the previous was already recorded).
-        if (this.mode === 'minimal' && this.segmentReset && text) {
+        if (this.rung === 'minimal' && this.segmentReset && text) {
           this.buf = ''
           this.segmentReset = false
         }
         this.buf += text
-        if (this.mode === 'minimal' && text.trim()) this.recordDirty = true
+        // The stream keeps its own cursor: appends are deltas, and the idle flush that
+        // drains `buf` into the transcript runs on a different clock (§3.5).
+        if (this.streaming) this.streamText += text
+        if (this.rung === 'minimal' && text.trim()) this.recordDirty = true
         return []
       }
       case 'agent_thought_chunk': {
@@ -1049,10 +1272,10 @@ export class OutputConverger {
         // dirty; the actual in-place `reasoning` update is deferred to flushBuffered()
         // (idle timer) / onFinal so a token-by-token stream doesn't flood chat.update.
         // low + medium keep only the transient status — no reasoning in the channel.
-        if (this.mode === 'high') {
-          const text = (update as { content?: { text?: string } }).content?.text ?? ''
-          if (text) {
-            this.reasoningBuf += text
+        const thought = (update as { content?: { text?: string } }).content?.text ?? ''
+        if (this.rung === 'high') {
+          if (thought) {
+            this.reasoningBuf += thought
             // Soft-cap the raw buffer so a very long turn can't grow it unbounded;
             // renderReasoning tail-clamps again for the message body.
             if (this.reasoningBuf.length > MAX_REASONING * 2) {
@@ -1061,9 +1284,17 @@ export class OutputConverger {
             this.reasoningDirty = true
           }
         }
+        // streaming medium/high: one card per thinking RUN, refreshed with the newest line
+        // on the append timer. `high` still keeps its full in-place Thinking message —
+        // 2,800 characters do not fit a 256-character chunk (§4).
+        if (this.streaming && (this.rung === 'medium' || this.rung === 'high') && thought) {
+          this.thinkingTail = (this.thinkingTail + thought).slice(-STREAM_THINKING_TAIL)
+          const line = this.newestThinkingLine()
+          if (line) this.queueTask(`thinking-${this.thinkingRun}`, 'Thinking', 'in_progress', line)
+        }
         // minimal: keep the streamed reply intact (thinking mid-reply doesn't close a
         // segment) — only surface the transient status.
-        if (this.mode === 'minimal') return this.pushActivity(THINKING)
+        if (this.rung === 'minimal') return this.pushActivity(THINKING)
         // Flush any buffered body, then surface the live "is thinking…" status.
         return [...this.flush(), ...this.pushActivity(THINKING)]
       }
@@ -1079,14 +1310,29 @@ export class OutputConverger {
         // Minimal deliberately hides the concrete tool label as well as tool cards/output:
         // keep Slack's transient working indicator generic so commands and tool names do
         // not leak into the channel chrome. Thinking remains a distinct thought-chunk state.
-        const label = this.mode === 'minimal' ? WORKING : this.toolLabel(u)
+        const label = this.rung === 'minimal' ? WORKING : this.toolLabel(u)
         const status = this.pushActivity(label)
+        // streaming: the in-place progress message becomes a task card on the stream —
+        // keyed by toolCallId, so streamed updates edit one card instead of stacking (§4).
+        if (this.streaming) {
+          this.closeThinkingRun()
+          const id = u.toolCallId
+          if (id && (this.rung === 'medium' || this.rung === 'high'))
+            this.queueTask(
+              id,
+              this.toolLabel(u),
+              u.status === 'completed' ? 'complete' : u.status === 'failed' ? 'error' : 'in_progress'
+            )
+          const streamed: SlackAction[] = [...this.flush()]
+          if (this.rung === 'high') streamed.push(...this.drainToolOutput(u))
+          return streamed
+        }
         // minimal: a tool boundary closes the current reply segment (record it + settle the
         // live message); closeSegment marks the next chunk as a fresh segment. No progress/
         // tool-output message — activity lives in the transient status only.
-        if (this.mode === 'minimal') return [...status, ...this.closeSegment()]
+        if (this.rung === 'minimal') return [...status, ...this.closeSegment()]
         // none/low: just record the buffered body — no tool card, no status (none emits none).
-        if (this.mode === 'low' || this.mode === 'none') return [...this.flush(), ...status]
+        if (this.rung === 'low' || this.rung === 'none') return [...this.flush(), ...status]
         // medium/high: reflect the current tool on the in-place progress message. The
         // label (a command line / tool title) is wrapped in a code span so it renders
         // verbatim in the `markdown` block instead of being parsed as emphasis.
@@ -1096,14 +1342,16 @@ export class OutputConverger {
           { kind: 'progress', text: `:hammer_and_wrench: ${codeSpan(label)}` }
         ]
         // high only: once the tool finishes, post its output as a code block.
-        if (this.mode === 'high') actions.push(...this.drainToolOutput(u))
+        if (this.rung === 'high') actions.push(...this.drainToolOutput(u))
         return actions
       }
       case 'plan': {
         const entries = (update as { entries?: PlanEntry[] }).entries ?? []
         // minimal keeps the reply intact and shows planning only as transient status.
-        if (this.mode === 'minimal') return this.pushActivity('planning…')
-        if (this.mode === 'low' || this.mode === 'none') return [...this.flush(), ...this.pushActivity('planning…')]
+        if (this.rung === 'minimal') return this.pushActivity('planning…')
+        if (this.rung === 'low' || this.rung === 'none') return [...this.flush(), ...this.pushActivity('planning…')]
+        // Unchanged under streaming: an ACP plan resends the whole entry list with per-entry
+        // statuses, which is a checklist, not a timeline of append-only cards (§4).
         return [...this.flush(), { kind: 'plan', text: renderPlan(entries) }]
       }
       case 'usage_update':
@@ -1126,22 +1374,33 @@ export class OutputConverger {
     if (isNoResponseBody(this.buf.trim())) {
       this.buf = ''
       this.recordDirty = false
-      return [clear]
+      // Streaming opened a visible message before the body proved to be the control marker.
+      // Nothing was ever appended (releasableLength holds a sentinel prefix), so settle and
+      // remove it rather than leaving an empty bubble where silence was intended.
+      return this.streaming ? [{ kind: 'stream-stop', settle: 'final', discard: true }] : [clear]
     }
     // none: settle the final body into the transcript (recordOnly via flush) and stop — no
     // status clear, no attribution footer; nothing is delivered to the channel this turn.
     if (this.mode === 'none') return this.flush()
+    // streaming: the footer rides the ONE closing stop (§3.3) and no status call of either
+    // kind is made (§5), so neither the `attribution` action nor the status clear appears.
+    if (this.streaming) {
+      const record = [...this.drainReasoning(), ...this.flush()]
+      this.settleTasks()
+      const appends = this.streamUpdate()
+      return [...record, ...appends, this.finalStop()]
+    }
     const attribution: SlackAction[] = info ? [{ kind: 'attribution', ...buildAttributionBlocks(info) }] : []
     // minimal: settle the complete final segment (the daemon splits it only when Slack's
     // per-block limit requires multiple messages), record it, clear the status, then attach
     // the attribution footer to the last delivered response message.
-    if (this.mode === 'minimal') {
+    if (this.rung === 'minimal') {
       const footer: SlackAction[] = info
         ? [{ kind: 'attribution', standalone: true, ...buildAttributionBlocks(info) }]
         : []
       return [...this.closeSegment(true), clear, ...footer]
     }
-    if (this.mode === 'low') return [...this.flush(), clear, ...attribution]
+    if (this.rung === 'low') return [...this.flush(), clear, ...attribution]
     // The daemon cancels the idle-flush timer before onFinal, so drain any reasoning
     // buffered since the last flush here. It goes BEFORE the body flush so the Thinking
     // block posts above the reply — thinking precedes the answer (§9.1), so it must sit

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -8,6 +8,7 @@ import { OutputConverger, type SlackAction, type SlackStreamChunk } from '../src
 import {
   applySlackAction,
   slackStreamRecipient,
+  type SlackTurn,
   type SlackTurnHost,
   type SlackTurnState
 } from '../src/platforms/slack/turn-output.js'
@@ -194,6 +195,58 @@ describe('OutputConverger streaming axis', () => {
     })
   })
 
+  it('re-anchors the tail below a chronological boundary, reusing the rollover', () => {
+    const converger = streaming('low')
+    converger.onUpdate(chunk('before the card'))
+    converger.streamUpdate()
+    // A human-input card (or visible agent-authored text) was posted below the stream.
+    converger.reanchorStream()
+    converger.onUpdate(chunk('after the card'))
+    const rolled = converger.streamUpdate()
+    expect(rolled).toEqual([
+      { kind: 'stream-stop', settle: 'rollover', text: 'before the card' },
+      { kind: 'stream-start' },
+      { kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'after the card' }] }
+    ])
+    // The closing stop names only the NEW message's text, so §5.5 re-sends what it shows.
+    expect(converger.onFinal(attribution()).at(-1)).toEqual({
+      kind: 'stream-stop',
+      settle: 'final',
+      text: 'after the card'
+    })
+  })
+
+  it('keeps the current message and its footer when the post-boundary tail is empty', () => {
+    const converger = streaming('low')
+    converger.onUpdate(chunk('all of it'))
+    converger.streamUpdate()
+    converger.reanchorStream()
+    expect(converger.streamUpdate()).toEqual([])
+    const finals = converger.onFinal(attribution())
+    expect(finals.some((a) => a.kind === 'stream-start')).toBe(false)
+    expect(finals.at(-1)).toEqual({ kind: 'stream-stop', settle: 'final', text: 'all of it' })
+  })
+
+  it('moves a post-boundary task card below the boundary too', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(chunk('before'))
+    converger.streamUpdate()
+    converger.reanchorStream()
+    converger.onUpdate(tool('t1', 'Read file'))
+    const rolled = converger.streamUpdate()
+    expect(rolled[0]).toMatchObject({ kind: 'stream-stop', settle: 'rollover' })
+    expect(rolled[1]).toEqual({ kind: 'stream-start' })
+  })
+
+  it('ignores a boundary before the stream has shown anything', () => {
+    const converger = streaming('low')
+    converger.reanchorStream()
+    converger.onUpdate(chunk('first words'))
+    expect(converger.streamUpdate()).toEqual([
+      { kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'first words' }] }
+    ])
+  })
+
   it('never cuts a compound shared-bot address across a rollover', () => {
     const address = '<@U09SHARED> reviewer'
     const converger = streaming('low', [address])
@@ -264,10 +317,10 @@ describe('applySlackAction — streaming actions', () => {
       stopTurnStream: vi.fn(async (_stream: SlackTurnStream, _options?: Record<string, unknown>) => true),
       deleteMessage: vi.fn(async (_channel: string, _ts: string) => true),
       setStatus: vi.fn(async () => {}),
-      postMessage: vi.fn(async () => 'p1'),
+      postMessage: vi.fn(async (_channel: string, _text: string, _thread?: string, _options?: unknown) => 'p1'),
       ...over
     }
-    const turn = {
+    const turn: SlackTurn = {
       conn,
       plan: {
         channel: 'C1',
@@ -293,8 +346,7 @@ describe('applySlackAction — streaming actions', () => {
       setStatusBarTs: vi.fn(),
       clearStatusBarTs: vi.fn(),
       monotonicTs: () => '1',
-      debug: vi.fn(),
-      degradeStreaming: vi.fn()
+      debug: vi.fn()
     }
     return {
       conn,
@@ -329,14 +381,120 @@ describe('applySlackAction — streaming actions', () => {
     expect(conn.startTurnStream).not.toHaveBeenCalled()
   })
 
-  it('settles the stream and demotes the turn when an append is refused', async () => {
-    const { apply, conn, state, host } = fixture({ appendTurnStream: vi.fn(async () => false) })
+  it('settles the stream and degrades the turn when an append is refused', async () => {
+    const { apply, conn, state } = fixture({
+      appendTurnStream: vi.fn(async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => false)
+    })
     await apply({ kind: 'stream-start' })
     await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'hi' }] })
     expect(conn.stopTurnStream).toHaveBeenCalledOnce()
     expect(state.stream).toBeUndefined()
-    // The rest of the answer must reach the channel the ordinary way (§7).
-    expect(host.degradeStreaming).toHaveBeenCalledOnce()
+    // The refused text is the only remaining copy of that display body — the converger has
+    // already advanced past it — so it must be held for the ordinary post boundary (§7).
+    expect(state.streamFallback).toBe('hi')
+  })
+
+  it('replays the whole uncommitted tail exactly once through the legacy post boundary', async () => {
+    // Application is asynchronous: appends the converger produced before the refusal, and the
+    // terminal ones after it, are already queued when the refusal lands. None may be dropped,
+    // and none may be shown twice.
+    let accept = true
+    const { apply, conn, turn } = fixture({
+      appendTurnStream: vi.fn(async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => accept)
+    })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'accepted. ' }] })
+    accept = false
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'refused. ' }] })
+    // Queued before the refusal was known — a task card is chrome and has no legacy form.
+    await apply({
+      kind: 'stream-append',
+      chunks: [
+        { type: 'task_update', id: 't1', title: 'Read file', status: 'complete' },
+        { type: 'markdown_text', text: 'and the tail.' }
+      ]
+    })
+    await apply({ kind: 'stream-stop', settle: 'final', text: 'accepted. refused. and the tail.' })
+
+    // Exactly one legacy post, carrying exactly what Slack never displayed.
+    expect(conn.postMessage).toHaveBeenCalledOnce()
+    expect(conn.postMessage.mock.calls[0]![1]).toBe('refused. and the tail.')
+    // …with the footer and the §5.5 anchor on the message that actually holds the answer,
+    // never on the dead stream.
+    expect(conn.postMessage.mock.calls[0]![3]).toMatchObject({ trailingBlocks: [{ type: 'context' }] })
+    expect(turn.reply.lastResponse).toEqual({ ts: 'p1', text: 'refused. and the tail.' })
+  })
+
+  it('a degraded turn opens no replacement stream, and its cleanup stop carries no footer', async () => {
+    const { apply, conn } = fixture({
+      appendTurnStream: vi.fn(async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => false)
+    })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'tail' }] })
+    // The converger keeps producing rollovers; a second bubble is not a continuation.
+    await apply({ kind: 'stream-stop', settle: 'rollover', text: 'tail' })
+    await apply({ kind: 'stream-start' })
+    expect(conn.startTurnStream).toHaveBeenCalledOnce()
+    expect(conn.stopTurnStream.mock.calls[0]![1]).toEqual({})
+  })
+
+  it('drops the buffered tail when suppression tears the turn down', async () => {
+    const { apply, conn, state } = fixture({
+      appendTurnStream: vi.fn(async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => false)
+    })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'never shown' }] })
+    await apply({ kind: 'stream-stop', settle: 'abort' })
+    expect(conn.postMessage).not.toHaveBeenCalled()
+    expect(state.streamFallback).toBe('never shown')
+  })
+
+  it('keeps the handle and the exact stop when Slack leaves the message streaming', async () => {
+    let settled = false
+    const { apply, conn, state } = fixture({
+      stopTurnStream: vi.fn(async (_s: SlackTurnStream, _o?: Record<string, unknown>) => settled)
+    })
+    await apply({ kind: 'stream-start' })
+    const closing = { kind: 'stream-stop', settle: 'final', text: 'the answer' } as const
+    await apply(closing)
+    // Nothing may be retired while the message might still be streaming.
+    expect(state.stream).toEqual({ channel: 'C1', threadTs: 'T1', ts: '900.1' })
+    expect(state.streamStopOwed).toEqual(closing)
+
+    // The settlement backstop reissues THAT stop, so the retry keeps its footer.
+    settled = true
+    await apply(state.streamStopOwed!)
+    expect(state.stream).toBeUndefined()
+    expect(state.streamStopOwed).toBeUndefined()
+    expect(conn.stopTurnStream).toHaveBeenCalledTimes(2)
+    expect(conn.stopTurnStream.mock.calls[1]![1]).toMatchObject({ blocks: [{ type: 'context' }] })
+  })
+
+  it('does not claim the response, or delete the message, until Slack accepts the stop', async () => {
+    const { apply, conn, turn } = fixture({
+      stopTurnStream: vi.fn(async (_s: SlackTurnStream, _o?: Record<string, unknown>) => false)
+    })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-stop', settle: 'final', text: 'the answer', discard: true })
+    expect(conn.deleteMessage).not.toHaveBeenCalled()
+    expect(turn.reply).not.toHaveProperty('lastResponse')
+  })
+
+  it('re-anchors below a chronological boundary: settle, reopen, then append the tail', async () => {
+    const { apply, conn, state } = fixture()
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'before the card' }] })
+    // What the converger emits once a boundary was posted below the open message.
+    conn.startTurnStream.mockResolvedValueOnce({ channel: 'C1', threadTs: 'T1', ts: '900.2' })
+    await apply({ kind: 'stream-stop', settle: 'rollover', text: 'before the card' })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'after the card' }] })
+
+    // A fresh message below the boundary, and the session was never released mid-turn.
+    expect(state.stream).toEqual({ channel: 'C1', threadTs: 'T1', ts: '900.2' })
+    expect(conn.stopTurnStream.mock.calls[0]![1]).toMatchObject({ sessionStatus: 'processing' })
+    expect(conn.stopTurnStream.mock.calls[0]![1]).not.toHaveProperty('blocks')
+    expect(conn.appendTurnStream.mock.calls[1]![0]).toMatchObject({ ts: '900.2' })
   })
 
   it('attaches the attribution footer to the final stop only, and hands §5.5 the message it closes', async () => {
@@ -518,7 +676,56 @@ describe('SlackConnection streaming', () => {
     const { conn, app } = await connect()
     const stream = (await conn.startTurnStream('C1', 'T1'))!
     expect(await conn.stopTurnStream(stream)).toBe(true)
+    // Still "settled" — the caller's question is whether the message is streaming, and it
+    // is not; only an unresolved answer asks for a retry.
+    expect(await conn.stopTurnStream(stream)).toBe(true)
+    expect(app.client.chat.stopStream).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a stop retryable while Slack leaves the message streaming', async () => {
+    let attempts = 0
+    const stopStream = vi.fn(async () => {
+      if (++attempts === 1) throw slackError('ratelimited')
+      return {}
+    })
+    const { conn } = await connect({ chat: { stopStream } })
+    const stream = (await conn.startTurnStream('C1', 'T1'))!
+    // A transient failure must NOT retire the handle: the message is still streaming and the
+    // session still processing, which is exactly what the settlement backstop exists to fix.
     expect(await conn.stopTurnStream(stream)).toBe(false)
+    expect(await conn.stopTurnStream(stream)).toBe(true)
+    expect(stopStream).toHaveBeenCalledTimes(2)
+    // …and once accepted, it is retired for good.
+    expect(await conn.stopTurnStream(stream)).toBe(true)
+    expect(stopStream).toHaveBeenCalledTimes(2)
+  })
+
+  it('retires the handle on a DEFINITE already-stopped answer, without retrying', async () => {
+    for (const code of ['message_not_in_streaming_state', 'stopped_by_user']) {
+      const stopStream = vi.fn(async () => {
+        throw slackError(code)
+      })
+      const { conn } = await connect({ chat: { stopStream } })
+      const stream = (await conn.startTurnStream('C1', 'T1'))!
+      expect(await conn.stopTurnStream(stream)).toBe(true)
+      expect(await conn.stopTurnStream(stream)).toBe(true)
+      expect(stopStream).toHaveBeenCalledOnce()
+      // A settled message is not a lost capability.
+      expect(conn.streamingLikely()).toBe(true)
+    }
+  })
+
+  it('keeps the handle after a TRANSIENT append failure, so the stop can still land', async () => {
+    const { conn, app } = await connect({
+      chat: {
+        appendStream: vi.fn(async () => {
+          throw slackError('ratelimited')
+        })
+      }
+    })
+    const stream = (await conn.startTurnStream('C1', 'T1'))!
+    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'x' }])).toBe(false)
+    expect(await conn.stopTurnStream(stream)).toBe(true)
     expect(app.client.chat.stopStream).toHaveBeenCalledOnce()
   })
 
@@ -535,7 +742,8 @@ describe('SlackConnection streaming', () => {
     await conn.agentSessionStopped('C1', 'T1', 'U1')
 
     expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'more' }])).toBe(false)
-    expect(await conn.stopTurnStream(stream)).toBe(false)
+    // Settled, and settled by the person — so nothing is retried against it either.
+    expect(await conn.stopTurnStream(stream)).toBe(true)
     expect(app.client.chat.appendStream).not.toHaveBeenCalled()
     expect(app.client.chat.stopStream).not.toHaveBeenCalled()
     // The turn is still cancelled and the session still transitions exactly once.
@@ -546,7 +754,7 @@ describe('SlackConnection streaming', () => {
   })
 
   it('treats a post-stop append refusal as benign rather than a capability loss', async () => {
-    const { conn } = await connect({
+    const { conn, app } = await connect({
       chat: {
         appendStream: vi.fn(async () => {
           throw slackError('message_not_in_streaming_state')
@@ -556,6 +764,9 @@ describe('SlackConnection streaming', () => {
     const stream = (await conn.startTurnStream('C1', 'T1'))!
     expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'x' }])).toBe(false)
     expect(conn.streamingLikely()).toBe(true)
+    // A DEFINITE already-stopped answer proves the message is settled, so no stop is owed.
+    expect(await conn.stopTurnStream(stream)).toBe(true)
+    expect(app.client.chat.stopStream).not.toHaveBeenCalled()
   })
 })
 
@@ -724,6 +935,46 @@ describe('Daemon Slack streaming turn', () => {
     expect(conn.appendTurnStream).not.toHaveBeenCalled()
     expect(conn.setStatus).toHaveBeenCalled()
     expect(conn.postMessage).toHaveBeenCalledWith('C1', 'streamed answer', 'T1', expect.anything())
+    await daemon.stop()
+  }, 15_000)
+
+  it('settlement retries a stop Slack left unresolved, so no message is stranded streaming', async () => {
+    const { daemon } = booted(scaffold())
+    await daemon.start()
+    let attempts = 0
+    const conn = connect(daemon, {
+      stopTurnStream: vi.fn(async (_s: SlackTurnStream, _o?: Record<string, unknown>) => ++attempts > 1)
+    })
+
+    await (daemon as never as { dispatch: (a: string, m: NormalizedMessage, i: string) => Promise<unknown> }).dispatch(
+      'bot-a',
+      inbound(),
+      'int-a'
+    )
+
+    // Turn end could not settle the message; the settlement backstop reissued the same stop.
+    expect(conn.stopTurnStream).toHaveBeenCalledTimes(2)
+    expect(conn.stopTurnStream.mock.calls[1]![1]).toMatchObject({ agentAuthorId: 'bot-a' })
+    await daemon.stop()
+  }, 15_000)
+
+  it('moves the stream below a chronological boundary the turn posts under it', async () => {
+    const { daemon } = booted(scaffold())
+    await daemon.start()
+    connect(daemon)
+    const converger = new OutputConverger('low')
+    converger.enableStreaming()
+    converger.onUpdate(chunk('before the card'))
+    converger.streamUpdate()
+
+    // The one place the daemon marks live chrome to continue below a new boundary message.
+    ;(daemon as never as { markInPlaceChromeForReanchor: (p: unknown) => void }).markInPlaceChromeForReanchor({
+      chrome: {},
+      conv: converger
+    })
+
+    converger.onUpdate(chunk('after the card'))
+    expect(converger.streamUpdate()[0]).toMatchObject({ kind: 'stream-stop', settle: 'rollover' })
     await daemon.stop()
   }, 15_000)
 })

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -1,0 +1,729 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Daemon } from '../src/daemon.js'
+import { SlackConnection, type SlackTurnStream } from '../src/slack/connection.js'
+import { OutputConverger, type SlackAction, type SlackStreamChunk } from '../src/slack/render.js'
+import {
+  applySlackAction,
+  slackStreamRecipient,
+  type SlackTurnHost,
+  type SlackTurnState
+} from '../src/platforms/slack/turn-output.js'
+import type { NormalizedMessage } from '../src/messages/normalized.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+
+/**
+ * slack-streaming-turn-output.md (Layer 1). The invariants worth pinning are the ones the
+ * design argues from rather than the plumbing: the answer rides ONE streaming message while
+ * the transcript keeps its own copy, a streaming turn writes NEITHER status API (they share
+ * one slot with the stream), a stopped stream is never revived, and every path that cannot
+ * stream degrades to today's pipeline unchanged.
+ */
+
+const chunk = (text: string) => ({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } }) as never
+const tool = (id: string, title: string, status = 'pending') =>
+  ({ sessionUpdate: 'tool_call', toolCallId: id, title, status }) as never
+const think = (text: string) => ({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text } }) as never
+
+const attribution = () => ({
+  botName: 'Bot A',
+  botUrl: 'https://console.example.test/agents/bot-a',
+  runtime: 'Claude',
+  model: 'opus',
+  sessionUrl: 'https://console.example.test/sessions/1'
+})
+
+function streaming(mode: 'none' | 'minimal' | 'low' | 'medium' | 'high', addresses: string[] = []): OutputConverger {
+  const converger = new OutputConverger(mode, addresses)
+  converger.enableStreaming()
+  return converger
+}
+
+const appends = (actions: SlackAction[]): SlackStreamChunk[] =>
+  actions.flatMap((action) => (action.kind === 'stream-append' ? action.chunks : []))
+
+const streamedText = (actions: SlackAction[]): string =>
+  appends(actions)
+    .map((c) => (c.type === 'markdown_text' ? c.text : ''))
+    .join('')
+
+describe('OutputConverger streaming axis', () => {
+  it('never streams in `none` mode — the axis cannot be enabled at all', () => {
+    const converger = streaming('none')
+    expect(converger.isStreaming()).toBe(false)
+    expect(converger.onStart()).toEqual([])
+  })
+
+  for (const mode of ['minimal', 'low', 'medium', 'high'] as const) {
+    it(`${mode}: the body rides the stream and the transcript keeps its own recordOnly copy`, () => {
+      const converger = streaming(mode)
+      expect(converger.onStart()).toEqual([{ kind: 'stream-start' }])
+      converger.onUpdate(chunk('Hello world'))
+      const finals = converger.onFinal(attribution())
+
+      expect(streamedText(finals)).toBe('Hello world')
+      // Every post on a streaming turn is transcript-only: the stream is display, the
+      // transcript is the record.
+      const posts = finals.filter((a) => a.kind === 'post')
+      expect(posts.length).toBeGreaterThan(0)
+      expect(posts.every((a) => a.kind === 'post' && a.recordOnly === true)).toBe(true)
+      // The retired cadence: nothing posts, edits in place, or narrates progress.
+      expect(finals.some((a) => ['live-reply', 'final-live-reply', 'progress'].includes(a.kind))).toBe(false)
+      // §5: no status call of either kind — the two APIs share one slot with the stream.
+      expect(finals.some((a) => a.kind === 'set-status')).toBe(false)
+      // The footer rides the ONE closing stop, so there is no separate attribution action.
+      expect(finals.some((a) => a.kind === 'attribution')).toBe(false)
+      expect(finals.at(-1)).toMatchObject({ kind: 'stream-stop', settle: 'final', text: 'Hello world' })
+    })
+  }
+
+  it('medium/high turn tool calls into task cards keyed by toolCallId', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(tool('t1', 'Read file'))
+    converger.onUpdate(tool('t1', 'Read file', 'completed'))
+    converger.onUpdate(tool('t2', 'Run tests', 'failed'))
+    const cards = appends(converger.streamUpdate()).filter((c) => c.type === 'task_update')
+    expect(cards).toEqual([
+      { type: 'task_update', id: 't1', title: 'Read file', status: 'complete' },
+      { type: 'task_update', id: 't2', title: 'Run tests', status: 'error' }
+    ])
+  })
+
+  it('collapses a burst of updates for one tool into its newest state', () => {
+    const converger = streaming('high')
+    converger.onUpdate(tool('t1', 'Read file'))
+    converger.onUpdate(tool('t1', 'Read file', 'in_progress'))
+    const cards = appends(converger.streamUpdate()).filter((c) => c.type === 'task_update')
+    expect(cards).toEqual([{ type: 'task_update', id: 't1', title: 'Read file', status: 'in_progress' }])
+  })
+
+  it('minimal and low stream body text only — no task cards on either rung', () => {
+    for (const mode of ['minimal', 'low'] as const) {
+      const converger = streaming(mode)
+      converger.onUpdate(tool('t1', 'Read file'))
+      expect(appends(converger.streamUpdate()).filter((c) => c.type === 'task_update')).toEqual([])
+    }
+  })
+
+  it('gives a thinking run one card and settles it at the next tool call', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(think('weighing the options'))
+    expect(appends(converger.streamUpdate())).toEqual([
+      {
+        type: 'task_update',
+        id: 'thinking-0',
+        title: 'Thinking',
+        status: 'in_progress',
+        details: 'weighing the options'
+      }
+    ])
+    converger.onUpdate(tool('t1', 'Read file'))
+    const next = appends(converger.streamUpdate())
+    expect(next).toContainEqual({
+      type: 'task_update',
+      id: 'thinking-0',
+      title: 'Thinking',
+      status: 'complete',
+      details: 'weighing the options'
+    })
+  })
+
+  it('leaves no card spinning once the turn is over', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(tool('t1', 'Read file'))
+    converger.streamUpdate()
+    const cards = appends(converger.onFinal(attribution())).filter((c) => c.type === 'task_update')
+    expect(cards).toEqual([{ type: 'task_update', id: 't1', title: 'Read file', status: 'complete' }])
+  })
+
+  it('keeps the ACP plan on its own message — a checklist is not a timeline of cards', () => {
+    const converger = streaming('medium')
+    const actions = converger.onUpdate({
+      sessionUpdate: 'plan',
+      entries: [{ content: 'step one', status: 'pending' }]
+    } as never)
+    expect(actions.some((a) => a.kind === 'plan')).toBe(true)
+  })
+
+  it('flushes at ~256 characters and otherwise waits for the timer', () => {
+    const converger = streaming('low')
+    converger.onUpdate(chunk('a'.repeat(100)))
+    expect(converger.hasStreamingUpdate()).toBe(true)
+    expect(converger.streamReady()).toBe(false)
+    converger.onUpdate(chunk('a'.repeat(200)))
+    expect(converger.streamReady()).toBe(true)
+  })
+
+  it('holds the response-control marker back, so a suppressed turn never flashes a prefix', () => {
+    const converger = streaming('low')
+    converger.onUpdate(chunk('AC_NO_'))
+    expect(converger.hasStreamingUpdate()).toBe(false)
+    expect(converger.streamUpdate()).toEqual([])
+  })
+
+  it('removes the stream a suppressed reply never wrote to, instead of leaving an empty bubble', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(chunk('AC_NO_RESPONSE'))
+    expect(converger.onFinal(attribution())).toEqual([{ kind: 'stream-stop', settle: 'final', discard: true }])
+  })
+
+  it('discards the stream when the turn produced no body at all', () => {
+    expect(streaming('low').onFinal(attribution())).toEqual([{ kind: 'stream-stop', settle: 'final', discard: true }])
+  })
+
+  it('rolls over at the 12k block limit: no footer, session stays processing, a fresh message', () => {
+    const converger = streaming('low')
+    converger.onUpdate(chunk('a'.repeat(8_000)))
+    expect(converger.streamUpdate()).toEqual([
+      { kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'a'.repeat(8_000) }] }
+    ])
+    converger.onUpdate(chunk('b'.repeat(6_000)))
+    const rolled = converger.streamUpdate()
+    // Settle the full message, then open the NEXT one — a stopped stream is unrecoverable,
+    // so continuation is a new message by construction (§3.4).
+    expect(rolled[0]).toEqual({ kind: 'stream-stop', settle: 'rollover', text: 'a'.repeat(8_000) })
+    expect(rolled[1]).toEqual({ kind: 'stream-start' })
+    expect(rolled[2]).toEqual({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'b'.repeat(6_000) }] })
+    // Only the LAST stop closes the response, and it names the second message's own text.
+    expect(converger.onFinal(attribution()).at(-1)).toEqual({
+      kind: 'stream-stop',
+      settle: 'final',
+      text: 'b'.repeat(6_000)
+    })
+  })
+
+  it('never cuts a compound shared-bot address across a rollover', () => {
+    const address = '<@U09SHARED> reviewer'
+    const converger = streaming('low', [address])
+    // One flush larger than a whole message, with the natural cut landing inside the slug.
+    converger.onUpdate(chunk(`${'x'.repeat(12_000 - 16)}${address} please verify`))
+    const parts = appends(converger.streamUpdate())
+      .map((c) => (c.type === 'markdown_text' ? c.text : ''))
+      .filter(Boolean)
+    expect(parts.length).toBeGreaterThan(1)
+    expect(parts.join('')).toBe(`${'x'.repeat(12_000 - 16)}${address} please verify`)
+    expect(parts.some((part) => part.startsWith(address))).toBe(true)
+  })
+
+  it('appends the terminal failure notice to the open stream rather than posting it', () => {
+    const converger = streaming('low')
+    converger.onUpdate(chunk('partial answer'))
+    const actions = converger.onStreamingFailure('quota exhausted')
+    expect(streamedText(actions)).toBe('partial answer\n\n⚠️ Agent failed to respond: quota exhausted')
+    expect(actions.filter((a) => a.kind === 'post').every((a) => a.kind === 'post' && a.recordOnly === true)).toBe(true)
+    expect(actions.some((a) => a.kind === 'notice')).toBe(false)
+    expect(actions.at(-1)).toMatchObject({ kind: 'stream-stop', settle: 'final' })
+  })
+
+  it('does not repeat a reason the runtime already narrated into the stream', () => {
+    const converger = streaming('low')
+    converger.onUpdate(chunk('Error: quota exhausted'))
+    const actions = converger.onStreamingFailure('quota exhausted')
+    expect(streamedText(actions)).toBe('Error: quota exhausted')
+  })
+
+  it('demotion before the first chunk reproduces the legacy pipeline exactly', () => {
+    const demoted = streaming('medium')
+    demoted.disableStreaming()
+    const legacy = new OutputConverger('medium')
+    for (const converger of [demoted, legacy]) {
+      converger.onUpdate(chunk('hello'))
+      converger.onUpdate(tool('t1', 'Read file'))
+    }
+    expect(demoted.onFinal(attribution())).toEqual(legacy.onFinal(attribution()))
+  })
+})
+
+describe('slackStreamRecipient', () => {
+  const sender = (over: Record<string, unknown> = {}) => ({ id: 'U1', ...over })
+
+  it('names the human a streamed message is for', () => {
+    expect(slackStreamRecipient({ source: 'user', sender: sender() })).toBe('U1')
+  })
+
+  it('has no honest value for a cron / hook / headless / agent-to-agent turn', () => {
+    expect(slackStreamRecipient({ source: 'cron', sender: sender() })).toBeUndefined()
+    expect(slackStreamRecipient({ source: 'hook', sender: sender() })).toBeUndefined()
+    expect(slackStreamRecipient({ source: 'agent', sender: sender() })).toBeUndefined()
+    expect(slackStreamRecipient({ source: 'user', headless: true, sender: sender() })).toBeUndefined()
+    expect(slackStreamRecipient({ source: 'user', sender: sender({ isBot: true }) })).toBeUndefined()
+  })
+})
+
+describe('applySlackAction — streaming actions', () => {
+  function fixture(over: Record<string, unknown> = {}) {
+    const conn = {
+      startTurnStream: vi.fn(async (channel: string, threadTs: string, _o?: unknown) => ({
+        channel,
+        threadTs,
+        ts: '900.1'
+      })),
+      appendTurnStream: vi.fn(async (_stream: SlackTurnStream, _chunks: SlackStreamChunk[]) => true),
+      stopTurnStream: vi.fn(async (_stream: SlackTurnStream, _options?: Record<string, unknown>) => true),
+      deleteMessage: vi.fn(async (_channel: string, _ts: string) => true),
+      setStatus: vi.fn(async () => {}),
+      postMessage: vi.fn(async () => 'p1'),
+      ...over
+    }
+    const turn = {
+      conn,
+      plan: {
+        channel: 'C1',
+        thread: 'T1',
+        statusThread: 'T1',
+        transcriptChannel: 'C1',
+        agentId: 'bot-a',
+        agentName: 'Bot A',
+        iconUrl: 'https://icons.example.test/a.png',
+        sessionKey: 'k',
+        platform: 'slack',
+        isDm: true
+      },
+      chrome: {},
+      reply: { responseId: 'resp-1' },
+      attribution: { blocks: [{ type: 'context' }], key: 'footer-1' }
+    }
+    const state: SlackTurnState = { recipient: 'U1' }
+    const host: SlackTurnHost<typeof turn> = {
+      recordReplySegment: vi.fn(),
+      appendTranscript: vi.fn(),
+      getStatusBarTs: vi.fn(async () => undefined),
+      setStatusBarTs: vi.fn(),
+      clearStatusBarTs: vi.fn(),
+      monotonicTs: () => '1',
+      debug: vi.fn(),
+      degradeStreaming: vi.fn()
+    }
+    return {
+      conn,
+      turn,
+      state,
+      host,
+      apply: (action: SlackAction) => applySlackAction(host, turn as never, state, action)
+    }
+  }
+
+  it('opens the stream with the recipient and the agent identity, and records the handle', async () => {
+    const { apply, conn, state } = fixture()
+    await apply({ kind: 'stream-start' })
+    expect(conn.startTurnStream).toHaveBeenCalledWith('C1', 'T1', {
+      recipientUserId: 'U1',
+      identity: { username: 'Bot A', icon_url: 'https://icons.example.test/a.png' }
+    })
+    expect(state.stream).toEqual({ channel: 'C1', threadTs: 'T1', ts: '900.1' })
+  })
+
+  it('refuses to open a second stream beside a live one', async () => {
+    const { apply, conn } = fixture()
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-start' })
+    expect(conn.startTurnStream).toHaveBeenCalledOnce()
+  })
+
+  it('cannot stream without a thread — a streamed message must be a reply', async () => {
+    const { apply, conn, turn } = fixture()
+    delete (turn.plan as { thread?: string }).thread
+    await apply({ kind: 'stream-start' })
+    expect(conn.startTurnStream).not.toHaveBeenCalled()
+  })
+
+  it('settles the stream and demotes the turn when an append is refused', async () => {
+    const { apply, conn, state, host } = fixture({ appendTurnStream: vi.fn(async () => false) })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'hi' }] })
+    expect(conn.stopTurnStream).toHaveBeenCalledOnce()
+    expect(state.stream).toBeUndefined()
+    // The rest of the answer must reach the channel the ordinary way (§7).
+    expect(host.degradeStreaming).toHaveBeenCalledOnce()
+  })
+
+  it('attaches the attribution footer to the final stop only, and hands §5.5 the message it closes', async () => {
+    const { apply, conn, turn } = fixture()
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-stop', settle: 'final', text: 'the answer' })
+    expect(conn.stopTurnStream).toHaveBeenCalledWith(
+      { channel: 'C1', threadTs: 'T1', ts: '900.1' },
+      expect.objectContaining({ blocks: [{ type: 'context' }], agentAuthorId: 'bot-a' })
+    )
+    expect(conn.stopTurnStream.mock.calls[0]![1]).not.toHaveProperty('sessionStatus')
+    expect(turn.reply).toMatchObject({
+      lastResponse: { ts: '900.1', text: 'the answer' },
+      lastReply: { ts: '900.1', text: 'the answer', footerKey: 'footer-1' }
+    })
+  })
+
+  it('keeps a rollover stop footerless and the session processing', async () => {
+    const { apply, conn, turn } = fixture()
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-stop', settle: 'rollover', text: 'first half' })
+    const options = conn.stopTurnStream.mock.calls[0]![1] as Record<string, unknown>
+    expect(options.sessionStatus).toBe('processing')
+    expect(options.blocks).toBeUndefined()
+    // A rollover closes no response — only the last stop does.
+    expect(turn.reply).not.toHaveProperty('lastResponse')
+  })
+
+  it('carries no footer when suppression tears the stream down', async () => {
+    const { apply, conn } = fixture()
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-stop', settle: 'abort' })
+    expect(conn.stopTurnStream.mock.calls[0]![1]).toEqual({})
+  })
+
+  it('removes a message nothing ever reached', async () => {
+    const { apply, conn } = fixture()
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-stop', settle: 'final', discard: true })
+    expect(conn.deleteMessage).toHaveBeenCalledWith('C1', '900.1')
+  })
+
+  it('skips the status write while a stream is open — the two share one slot', async () => {
+    const { apply, conn } = fixture()
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'set-status', text: 'is thinking…' })
+    expect(conn.setStatus).not.toHaveBeenCalled()
+    // …and resumes the moment the stream is gone.
+    await apply({ kind: 'stream-stop', settle: 'abort' })
+    await apply({ kind: 'set-status', text: 'is thinking…' })
+    expect(conn.setStatus).toHaveBeenCalledOnce()
+  })
+})
+
+describe('SlackConnection streaming', () => {
+  const deps = (over: Record<string, unknown> = {}) => ({
+    group: { appToken: 'xapp-1', botToken: 'xoxb-a', integrations: [] },
+    onMessage: () => {},
+    newTraceId: () => 't',
+    sendIntervalMs: 0,
+    ...over
+  })
+
+  function streamApp(over: Record<string, unknown> = {}) {
+    return {
+      message() {},
+      event(type: string, handler: (a: { event: unknown }) => unknown) {
+        ;(this as unknown as { handlers: Map<string, unknown> }).handlers.set(type, handler)
+      },
+      handlers: new Map<string, (a: { event: unknown }) => unknown>(),
+      action() {},
+      shortcut() {},
+      client: {
+        auth: { test: async () => ({ user_id: 'U1', bot_id: 'B1', team_id: 'T123' }) },
+        views: { open: async () => ({}), update: async () => ({}) },
+        chat: {
+          postMessage: async () => ({ ts: '1.1' }),
+          getPermalink: async () => ({ permalink: 'https://example.test/t' }),
+          update: async () => ({}),
+          delete: async () => ({}),
+          startStream: vi.fn(async () => ({ ts: '900.1' })),
+          appendStream: vi.fn(async () => ({})),
+          stopStream: vi.fn(async () => ({})),
+          ...(over.chat ?? {})
+        },
+        assistant: { threads: { setStatus: async () => ({}) } },
+        apiCall: vi.fn(async (_method: string, _args?: Record<string, unknown>) => ({}))
+      },
+      start: async () => {},
+      stop: async () => {}
+    }
+  }
+
+  const slackError = (code: string) =>
+    Object.assign(new Error(`An API error occurred: ${code}`), { data: { error: code } })
+
+  async function connect(over: Record<string, unknown> = {}, depsOver: Record<string, unknown> = {}) {
+    const app = streamApp(over)
+    const conn = new SlackConnection(deps(depsOver) as never, () => app as never)
+    await conn.start()
+    return { conn, app }
+  }
+
+  it('opens, appends and settles one message through the typed SDK methods', async () => {
+    const { conn, app } = await connect()
+    expect(conn.streamingLikely()).toBe(true)
+    const stream = await conn.startTurnStream('C1', 'T1', { recipientUserId: 'U9', identity: { username: 'Bot A' } })
+    expect(stream).toEqual({ channel: 'C1', threadTs: 'T1', ts: '900.1' })
+    expect(app.client.chat.startStream).toHaveBeenCalledWith({
+      channel: 'C1',
+      thread_ts: 'T1',
+      task_display_mode: 'timeline',
+      recipient_user_id: 'U9',
+      recipient_team_id: 'T123',
+      username: 'Bot A'
+    })
+    await conn.appendTurnStream(stream!, [{ type: 'markdown_text', text: 'hi' }])
+    expect(app.client.chat.appendStream).toHaveBeenCalledWith({
+      channel: 'C1',
+      ts: '900.1',
+      chunks: [{ type: 'markdown_text', text: 'hi' }]
+    })
+    await conn.stopTurnStream(stream!, { sessionStatus: 'processing', agentAuthorId: 'bot-a' })
+    expect(app.client.chat.stopStream).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C1', ts: '900.1', session_status: 'processing' })
+    )
+  })
+
+  it('answers "cannot stream" when the SDK has no such method, and latches it', async () => {
+    const { conn } = await connect({ chat: { startStream: undefined } })
+    expect(await conn.startTurnStream('C1', 'T1')).toBeUndefined()
+    expect(conn.streamingLikely()).toBe(false)
+  })
+
+  it('latches a CAPABILITY refusal off for the whole connection', async () => {
+    for (const code of ['unknown_method', 'missing_scope', 'channel_type_not_supported', 'messages_tab_disabled']) {
+      const { conn } = await connect({
+        chat: {
+          startStream: vi.fn(async () => {
+            throw slackError(code)
+          })
+        }
+      })
+      expect(await conn.startTurnStream('C1', 'T1')).toBeUndefined()
+      expect(conn.streamingLikely()).toBe(false)
+    }
+  })
+
+  it('degrades only the turn on a CONTEXTUAL refusal — one bad channel must not kill streaming', async () => {
+    for (const code of ['channel_not_found', 'not_in_channel', 'missing_recipient_user_id', 'ratelimited']) {
+      const { conn } = await connect({
+        chat: {
+          startStream: vi.fn(async () => {
+            throw slackError(code)
+          })
+        }
+      })
+      expect(await conn.startTurnStream('C1', 'T1')).toBeUndefined()
+      expect(conn.streamingLikely()).toBe(true)
+    }
+  })
+
+  it('retries the open undecorated when the workspace lacks chat:write.customize', async () => {
+    const startStream = vi.fn(async (args: Record<string, unknown>) => {
+      if (args.username !== undefined)
+        throw Object.assign(new Error('An API error occurred: missing_scope'), {
+          data: { error: 'missing_scope', needed: 'chat:write.customize' }
+        })
+      return { ts: '900.1' }
+    })
+    const { conn } = await connect({ chat: { startStream } })
+    expect(await conn.startTurnStream('C1', 'T1', { identity: { username: 'Bot A' } })).toMatchObject({ ts: '900.1' })
+    expect(startStream).toHaveBeenCalledTimes(2)
+    // The decoration cooldown absorbed it; streaming itself is untouched.
+    expect(conn.streamingLikely()).toBe(true)
+  })
+
+  it('stops exactly once per message, however many times the turn asks', async () => {
+    const { conn, app } = await connect()
+    const stream = (await conn.startTurnStream('C1', 'T1'))!
+    expect(await conn.stopTurnStream(stream)).toBe(true)
+    expect(await conn.stopTurnStream(stream)).toBe(false)
+    expect(app.client.chat.stopStream).toHaveBeenCalledOnce()
+  })
+
+  it('after the native Stop, nothing appends to the dead stream and no second stop is issued', async () => {
+    const actions: unknown[] = []
+    const { conn, app } = await connect(
+      {},
+      {
+        onMessageShortcut: async () => 'slack:C1:T1:bot-a',
+        onStatusAction: (a: unknown) => void actions.push(a)
+      }
+    )
+    const stream = (await conn.startTurnStream('C1', 'T1'))!
+    await conn.agentSessionStopped('C1', 'T1', 'U1')
+
+    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'more' }])).toBe(false)
+    expect(await conn.stopTurnStream(stream)).toBe(false)
+    expect(app.client.chat.appendStream).not.toHaveBeenCalled()
+    expect(app.client.chat.stopStream).not.toHaveBeenCalled()
+    // The turn is still cancelled and the session still transitions exactly once.
+    expect(actions).toEqual([{ kind: 'cancel', sessionKey: 'slack:C1:T1:bot-a', actor: { userId: 'U1' } }])
+    const lifecycle = app.client.apiCall.mock.calls.filter((call) => call[0] === 'agents.sessions.setStatus')
+    expect(lifecycle).toHaveLength(1)
+    expect(lifecycle[0]![1]).toMatchObject({ status: 'active' })
+  })
+
+  it('treats a post-stop append refusal as benign rather than a capability loss', async () => {
+    const { conn } = await connect({
+      chat: {
+        appendStream: vi.fn(async () => {
+          throw slackError('message_not_in_streaming_state')
+        })
+      }
+    })
+    const stream = (await conn.startTurnStream('C1', 'T1'))!
+    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'x' }])).toBe(false)
+    expect(conn.streamingLikely()).toBe(true)
+  })
+})
+
+describe('Daemon Slack streaming turn', () => {
+  function scaffold(): string {
+    const root = mkdtempSync(join(tmpdir(), 'ac-slack-stream-'))
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        runtimes: { claude: { command: 'node', args: ['unused'] } }
+      })
+    )
+    const agentDir = join(root, 'agents', 'bot-a')
+    mkdirSync(agentDir, { recursive: true })
+    writeFileSync(
+      join(agentDir, 'agent.json'),
+      JSON.stringify({
+        id: 'bot-a',
+        name: 'bot-a',
+        status: 'active',
+        runtime: 'claude',
+        workspace: { mode: 'from-scratch', path: join(agentDir, 'workspace') },
+        integrations: [],
+        output: { mode: 'low' }
+      })
+    )
+    return root
+  }
+
+  const inbound = (): NormalizedMessage =>
+    ({
+      msgId: 'slack:C1:100.1',
+      traceId: '100.1',
+      source: 'user',
+      platform: 'slack',
+      channel: 'C1',
+      thread: 'T1',
+      sender: { id: 'U1', isBot: false },
+      text: 'hello',
+      mentionedBots: [],
+      isDm: true,
+      trigger: 'dm'
+    }) as NormalizedMessage
+
+  /** A duck-typed reply connection. `setStatus` is the ONLY route the daemon has to either
+   *  Slack status API — the free text and the session enum are both behind it — so asserting
+   *  on it covers both halves of §5. */
+  function connect(daemon: Daemon, over: Record<string, unknown> = {}, shareable = false) {
+    const agent = (daemon as unknown as { agents: Map<string, { integrations: unknown[] }> }).agents.get('bot-a')!
+    agent.integrations = [
+      {
+        id: 'int-a',
+        platform: 'slack',
+        core: { mode: shareable ? 'shared' : 'direct', bindRules: [{ match: { kind: 'dm' } }] },
+        config: { botToken: 'b', appToken: 'p', ...(shareable ? { shareable: true } : {}) }
+      }
+    ]
+    const conn = {
+      workspaceId: vi.fn(() => 'T1'),
+      setStatus: vi.fn(async () => {}),
+      postMessage: vi.fn(async () => 'reply-1'),
+      postBlocks: vi.fn(async () => 'status-bar'),
+      updateBlocks: vi.fn(async () => true),
+      streamingLikely: vi.fn(() => true),
+      startTurnStream: vi.fn(async (channel: string, threadTs: string, _o?: unknown) => ({
+        channel,
+        threadTs,
+        ts: '900.1'
+      })),
+      appendTurnStream: vi.fn(async (_stream: SlackTurnStream, _chunks: SlackStreamChunk[]) => true),
+      stopTurnStream: vi.fn(async (_stream: SlackTurnStream, _options?: Record<string, unknown>) => true),
+      deleteMessage: vi.fn(async (_channel: string, _ts: string) => true),
+      ...over
+    }
+    ;(daemon as unknown as { connByIntegration: Map<string, unknown> }).connByIntegration.set('int-a', conn)
+    return conn
+  }
+
+  function booted(root: string) {
+    let onUpdate!: (sessionId: string, update: unknown) => void
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-1'),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sessionId: string) => {
+        onUpdate(sessionId, {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'streamed answer' }
+        })
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      hostFactory: (_agent: unknown, update: (sessionId: string, u: unknown) => void) => {
+        onUpdate = update
+        return host as never
+      }
+    } as never)
+    return { daemon, host }
+  }
+
+  it('writes NEITHER status API, and delivers the answer on the stream', async () => {
+    const { daemon } = booted(scaffold())
+    await daemon.start()
+    const conn = connect(daemon)
+
+    await (daemon as never as { dispatch: (a: string, m: NormalizedMessage, i: string) => Promise<unknown> }).dispatch(
+      'bot-a',
+      inbound(),
+      'int-a'
+    )
+
+    expect(conn.setStatus).not.toHaveBeenCalled()
+    expect(conn.startTurnStream).toHaveBeenCalledOnce()
+    expect(conn.stopTurnStream).toHaveBeenCalledOnce()
+    const streamed = conn.appendTurnStream.mock.calls
+      .flatMap((call) => call[1] ?? [])
+      .map((c) => (c.type === 'markdown_text' ? c.text : ''))
+      .join('')
+    expect(streamed).toContain('streamed answer')
+    // The answer never takes the post boundary on a streaming turn.
+    expect(conn.postMessage).not.toHaveBeenCalledWith(
+      'C1',
+      expect.stringContaining('streamed answer'),
+      expect.anything(),
+      expect.anything()
+    )
+    await daemon.stop()
+  }, 15_000)
+
+  it('keeps a SHAREABLE bot on the legacy pipeline until §10 Q1 is verified live', async () => {
+    const { daemon } = booted(scaffold())
+    await daemon.start()
+    const conn = connect(daemon, {}, true)
+
+    await (daemon as never as { dispatch: (a: string, m: NormalizedMessage, i: string) => Promise<unknown> }).dispatch(
+      'bot-a',
+      inbound(),
+      'int-a'
+    )
+
+    expect(conn.startTurnStream).not.toHaveBeenCalled()
+    expect(conn.setStatus).toHaveBeenCalled()
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', 'streamed answer', 'T1', expect.anything())
+    await daemon.stop()
+  }, 15_000)
+
+  it('degrades to the legacy pipeline when the stream cannot be opened', async () => {
+    const { daemon } = booted(scaffold())
+    await daemon.start()
+    const conn = connect(daemon, { startTurnStream: vi.fn(async () => undefined) })
+
+    await (daemon as never as { dispatch: (a: string, m: NormalizedMessage, i: string) => Promise<unknown> }).dispatch(
+      'bot-a',
+      inbound(),
+      'int-a'
+    )
+
+    expect(conn.startTurnStream).toHaveBeenCalledOnce()
+    expect(conn.appendTurnStream).not.toHaveBeenCalled()
+    expect(conn.setStatus).toHaveBeenCalled()
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', 'streamed answer', 'T1', expect.anything())
+    await daemon.stop()
+  }, 15_000)
+})


### PR DESCRIPTION
Layer 1 of the Slack-native agent experience: the agent's answer now rides one native
streaming message instead of the post-once / `chat.update`-thereafter cadence.

## Why this, and not more status-call ordering

Slack's two status APIs — `assistant.threads.setStatus` (free text, `loading_messages`,
per-agent `username`/`icon_url`) and `agents.sessions.setStatus` (a bare
`processing`/`active` enum) — write **one UI slot**, and the last writer controls the whole
presentation. You get custom progress narration and per-agent authorship, or the native
processing UI and its in-message stop button. Never both, and no ordering of the two calls
changes that.

`chat.startStream` does. It creates the agent session and sets it `processing` itself, and
`chat.stopStream` releases it — so a streaming turn makes **zero** status calls of either
kind and gets native UI, the native stop control, and per-agent authorship simultaneously.

## What streams, what stays

`OutputConverger` gains a `streaming` axis beside `mode` and emits `stream-start` /
`stream-append` / `stream-stop` instead of `post` / `live-reply` / `final-live-reply` /
`progress`. The structural template is Feishu's CardKit seam, reused verbatim: converger IR
→ applier → connection, plus one coalescing timer (`armSlackStream`, ~256 chars / ~750 ms,
matching Slack's own SDK buffer against a Tier-4 `chat.appendStream`).

Streams: the answer body (`markdown_text`), and on `medium`/`high` the tool calls and
thinking runs as `task_update` cards keyed by `toolCallId`.

Unchanged: the session status bar (still its own message, still posted before the stream so
it stays above), permission and elicitation cards, `high`-mode tool-output code blocks, the
ACP plan message, attachments, and — importantly — the **transcript**. The body reaches it
through the same paired `recordOnly` posts `none` mode already uses. The stream is display;
the transcript is the record.

The attribution footer got simpler: a stream is born without one and gains it exactly once,
on the closing `chat.stopStream` (which takes `blocks`, and disables unfurls itself). The
`staleReplyFooters` retry machinery is not needed on this path and stays for the fallback.

## Choreography: no status calls

`showActivity` and the applier's `set-status` case each grow one guard — is this turn
streaming? — and skip the write if so. Nothing about `setStatus`, `setSessionLifecycle`, or
their dedup map changes; a non-streaming turn runs exactly as it does today. The regression
test is retargeted at the stronger assertion: a streaming turn calls **neither**
`assistant.threads.setStatus` nor `agents.sessions.setStatus`.

`chat.startStream` is issued from `openTurnChrome`, after the status bar and on the same
send queue, and the apply chain is awaited there because it is the turn's single branch
point: success streams, anything else runs today's pipeline. A turn is never half-streamed.

## Carve-outs

Structural, decided before the call is attempted because they cannot succeed:

- no `thread_ts` — a streamed message must be a reply, so a channel-root turn cannot stream;
- a channel turn with no human initiator (agent-to-agent, cron, hook, dream), because
  `recipient_user_id` / `recipient_team_id` are required outside DMs and there is no honest
  value to supply — DMs are unaffected;
- output mode `none`.

And one deliberately temporary carve-out: **turns on a shareable (multi-agent) bot keep the
legacy pipeline.** Whether the response-finalization `chat.update` still works on a *stopped
stream*, and still emits the `message_changed` event ingress recognises, is undocumented in
both directions — and agent-to-agent routing over Slack depends on exactly that edit being
seen. A2A conversation only happens on a shareable bot, so excluding that population bounds
the risk of a wrong answer to *no change at all*, and turns a merge gate into a post-deploy
verification. The closing edit is still issued on every streaming turn, so there is
something to observe. The gate is the codebase's existing `shareable` predicate (the same
fact that decides whether the status bar offers "Switch agent"), not a new flag. A small
follow-up PR deletes the predicate once a live shareable-bot turn is seen to route.

## Fallback and latching

No configuration knob — the answer comes from Slack's own errors, in two classes:

- **capability refusals** (`unknown_method`, `missing_scope`, `channel_type_not_supported`,
  `messages_tab_disabled`, or the SDK exposing no such method) latch
  `streamingUnavailableUntil` for five minutes, the `customUsernameRetryAt` precedent — a
  permanent latch would be wrong for a capability a workspace can gain by changing plan;
- **contextual refusals** (`channel_not_found`, `not_in_channel`, rate limits, send-queue
  timeouts) degrade only that turn. A per-channel error must never kill streaming
  workspace-wide.

A mid-turn append failure settles the stream best-effort and finishes the remaining body
through the ordinary post path, the shape Feishu already ships.

**A stopped stream is unrecoverable**, and the code says so structurally: `chat.appendStream`
on a settled message fails, `chat.startStream` never takes an existing `ts`. The handle is
dropped the moment the stream ends — by our own stop, by a refused append, or by the
person's Stop — so nothing appends to it and no second stop is issued. Continuation past the
12,000-character block limit is therefore a new message by construction (rollover stop
carries no footer and `session_status: processing`; only the last stop carries the footer).
After a user Stop the daemon opens no replacement message either: `outputSuppressed` covers
the queued actions and the error-flush path returns before it can narrate into a
conversation the person ended.

## Eval guard

`VirtualSlackConnection` **implements** `startTurnStream` returning "unsupported", with no-op
stubs for append/stop and `streamingLikely() → false`. Arena turns therefore take the legacy
path deterministically and every existing baseline stays byte-identical. The two new private
helpers get `EXEMPT` entries with justifications. `connection-surface.test.ts` keeps its
pinned test count (5), so `collaboration-arena-baseline.md` needs no edit.

## Notes

- The design's open question on the `task_update` chunk shape is resolved from the resolved
  SDK rather than the three inconsistent prose versions: `@slack/types` 3.0.0 declares the
  flat shape **with** an explicit `type` discriminator, `title` (not `text`), and `complete`
  (not `completed`). The same package types all three methods, so `apiCall` was not needed
  here — they are declared as optional members on the connection's `AppLike` surface, which
  also keeps every inert test app on the legacy path with no edits.
- Supersedes #1478 (`fix(daemon): set the Slack session lifecycle before the free-text
  status`): it fixes ordering on a path streaming retires wherever it works, and on the
  remaining fallback turns its order writes the enum first and then immediately overwrites
  it with text. Its regression test is kept here, retargeted. Not closing it from this PR.

## Verified

- `pnpm --filter @agentconnect.md/daemon test` — 4840 passed, 82 skipped. The only failures
  are the four pre-existing local-environment suites (`shim-workspace-files`,
  `shim-exec-handler`, `shim-cancellation`, `acp-matrix`), unchanged by this PR.
- `pnpm eval:gates` — 28 files, 193 passed.
- `pnpm --filter @agentconnect.md/protocol test` — 27 files, 452 passed.
- `pnpm typecheck` (all packages, tests included), `pnpm lint`, `pnpm format:check` — clean.
- 42 new tests in `packages/daemon/test/slack-streaming.test.ts`: the converger axis across
  all five output modes, task-card mapping and collapse, the 256-char/timer cadence, the 12k
  rollover (footerless, `processing`, new message, no cut mention), suppressed-reply discard,
  the streaming error flush, byte-identical demotion, the applier's three action cases, both
  connection error classes, stop idempotency, the post-Stop no-append/no-second-stop rule,
  and three full daemon turns (neither status API; shareable carve-out; degrade when the
  stream cannot open).

Design: `docs/designs/slack-streaming-turn-output.md`, added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
