### PR TITLE
fix(web): switching org from a detail view lands on home, not a 404

### DIFF
--- a/packages/web/src/components/console/views/BillingView.checkout.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.checkout.test.tsx
@@ -11,14 +11,24 @@
  * 2. A transient poll failure must not abandon confirmation. The return params
  *    are cleaned from the URL on claim, so the purchase id lives only in state;
  *    a single network blip or 5xx must retry, not become a dead end.
+ *
+ * 3. Settlement reaches the UNFILTERED ledger read, not only the table's current side. That
+ *    read is what "last deduction", the banner's history and the Activity card's visibility
+ *    use, and its key sits outside the side table the pills iterate.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import { SWRConfig } from 'swr'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { BillingError } from '@/lib/billing-api'
 
 const mocks = vi.hoisted(() => ({
-  fetchPurchase: vi.fn<() => Promise<unknown>>()
+  fetchPurchase: vi.fn<() => Promise<unknown>>(),
+  // Typed with the real parameters so a test can read the FILTER off a recorded call.
+  fetchTransactions: vi.fn(async (_orgId: string, _cursor?: string, _filter?: { type?: string }) => ({
+    items: [] as unknown[],
+    nextCursor: null as string | null
+  }))
 }))
 
 vi.mock('@/lib/org-context', () => ({
@@ -36,7 +46,7 @@ vi.mock('@/lib/billing-api', async () => {
     createBillingPurchase: vi.fn(),
     fetchBillingPurchase: mocks.fetchPurchase,
     fetchBillingAccount: async () => ({ orgId: 'org-1', balanceMicro: 0 }),
-    fetchBillingTransactions: async () => ({ items: [], nextCursor: null })
+    fetchBillingTransactions: mocks.fetchTransactions
   }
 })
 
@@ -49,8 +59,14 @@ async function render() {
   host = document.createElement('div')
   document.body.appendChild(host)
   root = createRoot(host)
+  // A FRESH SWR cache per render. On the global one a later test inherits an earlier test's
+  // page one and its fetcher is never called, so a test that counts fetches reads zero.
   await act(async () => {
-    root.render(<BillingView />)
+    root.render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <BillingView />
+      </SWRConfig>
+    )
   })
 }
 
@@ -65,6 +81,7 @@ beforeEach(() => {
   vi.useFakeTimers()
   ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: 'billing' }
   mocks.fetchPurchase.mockReset()
+  mocks.fetchTransactions.mockClear()
 })
 afterEach(async () => {
   await act(async () => root.unmount())
@@ -98,6 +115,24 @@ describe('checkout return: expired is not terminal', () => {
     for (let i = 0; i < 120; i++) await tick(2_500) // exhaust the poll budget
     expect(host.innerHTML).toContain('Checkout session expired')
     expect(host.innerHTML).not.toContain('Nothing was charged')
+  })
+})
+
+describe('checkout return: what settlement invalidates', () => {
+  it('refetches the unfiltered ledger, not only the table’s current side', async () => {
+    // The pills are the two ledger SIDES, so the unfiltered key is not among them and no loop
+    // over that table reaches it. A first top-up settling into a stale unfiltered read left the
+    // page still saying the org had never been funded.
+    const unfiltered = () => mocks.fetchTransactions.mock.calls.filter((c) => c[2] === undefined).length
+
+    mocks.fetchPurchase.mockResolvedValue(purchase('completed'))
+    await render()
+    const before = unfiltered()
+    expect(before).toBeGreaterThan(0)
+
+    await tick(0)
+    expect(host.innerHTML).toContain('$50.00 added')
+    expect(unfiltered()).toBeGreaterThan(before)
   })
 })
 

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -56,7 +56,7 @@ const TX_GRID = 'grid-cols-[34px_minmax(0,1fr)_132px_24px_190px] gap-2'
 // it here rather than on a page already fetched is what keeps the cursor, the loaded count
 // and "end of ledger" describing the rows actually on screen.
 const TX_SIDES = [
-  { key: 'all', label: 'All', type: undefined },
+  // { key: 'all', label: 'All', type: undefined },
   { key: 'debit', label: 'Usage', type: 'debit' },
   { key: 'credit', label: 'Top-ups', type: 'credit' }
 ] as const
@@ -605,7 +605,7 @@ export default function BillingView() {
 
   const account = useSWR(fetching ? consoleKeys.billingAccount(orgId) : null, () => fetchBillingAccount(orgId!))
 
-  const [side, setSide] = useState<TxSide>('all')
+  const [side, setSide] = useState<TxSide>('debit')
   const sideType = TX_SIDES.find((s) => s.key === side)!.type
   // The table's own feed, one page one per side. `all` is the same key the unfiltered ledger
   // below uses, so the default view still costs ONE request — SWR dedupes them.
@@ -878,11 +878,8 @@ export default function BillingView() {
 
           <div className="card">
             <div className="cardhead flex-wrap justify-between gap-2">
-              <span className="inline-flex items-baseline gap-2">
+              <span className="inline-flex items-center gap-2">
                 <span className="cardtitle">Transactions</span>
-                {transactions.data && (
-                  <span className="mono text-[11.5px] text-(--text-tertiary)">{txItems.length} loaded</span>
-                )}
                 {/* `self-center`: the group stays baseline-aligned so the title and the count
                     keep sitting on one line, while the pillbar — a control with its own box,
                     taller than both — centres in the line instead of hanging off its text. */}
@@ -893,6 +890,9 @@ export default function BillingView() {
                     </button>
                   ))}
                 </span>
+                {transactions.data && (
+                  <span className="mono text-[11.5px] text-(--text-tertiary)">{txItems.length} loaded</span>
+                )}
               </span>
               <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
                 Newest first · amounts in USD

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -654,16 +654,21 @@ export default function BillingView() {
   const { mutate: mutateKey } = useSWRConfig()
   const refreshMoney = useCallback(() => {
     void account.mutate()
-    // Every side's page one, not only the visible one: a settled top-up belongs to the All
-    // and Top-ups feeds alike, and leaving the others cached had a filter switch show a
-    // ledger that predated the purchase.
+    // The unfiltered read, by ITS OWN handle. Its key is deliberately outside `TX_SIDES` — the
+    // pills are the two ledger sides — so no loop over that table can reach it, and it is what
+    // "last deduction", the banner's history and the Activity card's visibility all read.
+    // Leaving it cached had a first top-up settle into a page still saying never funded.
+    void ledger.mutate()
+    // Then every side's page one, not only the visible one: a settled top-up belongs to the
+    // Top-ups feed whichever pill is pressed, and leaving the others cached had a filter switch
+    // show a ledger that predated the purchase.
     if (orgId) for (const s of TX_SIDES) void mutateKey(consoleKeys.billingTransactions(orgId, s.key))
     // The Activity chart reads the same ledger through its OWN key, one per range, and its
     // fetch usually landed while the purchase was still pending. Settlement has to reach
     // every range it can show — leaving the cached ones alone had the Top-ups chart disagree
     // with the table right beside it until a refocus or a reload.
     if (orgId) for (const r of ACTIVITY_RANGES) void mutateKey(consoleKeys.billingActivity(orgId, r.key))
-  }, [account.mutate, mutateKey, orgId])
+  }, [account.mutate, ledger.mutate, mutateKey, orgId])
   useEffect(() => {
     if (!orgId || checkout?.phase !== 'confirming') return
     const { purchaseId, attempt } = checkout

--- a/packages/web/src/components/console/views/BillingView.txfilter.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.txfilter.test.tsx
@@ -77,12 +77,13 @@ afterEach(async () => {
   ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = {}
 })
 
-// Scoped to the Transactions card's own pillbar — the Activity chart's has a "Usage" pill
-// too, and it comes first in the document.
+// Scoped to the Transactions CARD. The Activity chart's pillbar carries the same two labels
+// and comes first in the document, so the label alone cannot tell them apart.
 async function clickPill(label: string) {
-  const bar = [...host.querySelectorAll('.pillbar')].find((b) =>
-    [...b.querySelectorAll('button')].some((x) => x.textContent === 'All')
+  const card = [...host.querySelectorAll('.card')].find((c) =>
+    [...c.querySelectorAll('.cardtitle')].some((t) => t.textContent === 'Transactions')
   )
+  const bar = card?.querySelector('.pillbar')
   const pill = [...(bar?.querySelectorAll('button') ?? [])].find((b) => b.textContent === label) as
     HTMLButtonElement | undefined
   expect(pill, `no "${label}" pill`).toBeTruthy()
@@ -92,14 +93,12 @@ async function clickPill(label: string) {
 }
 
 describe('Transactions — the ledger-side filter', () => {
-  it('asks the service for one side, and for the whole ledger by default', async () => {
+  it('asks the service for one side, and reads the unfiltered ledger alongside it', async () => {
     await mount()
-    // The default view shares its key with the balance card's own unfiltered read, so it must
-    // be the same request — one page one, not two spellings of it.
-    expect(mocks.fetchTransactions).toHaveBeenCalledWith('org-1')
-
-    await clickPill('Usage')
+    // The table opens on Usage — the pills ARE the two ledger sides, so there is no unfiltered
+    // view of the table and the account-level read is its own request, not a shared key.
     expect(mocks.fetchTransactions).toHaveBeenCalledWith('org-1', undefined, { type: 'debit' })
+    expect(mocks.fetchTransactions).toHaveBeenCalledWith('org-1')
 
     await clickPill('Top-ups')
     expect(mocks.fetchTransactions).toHaveBeenCalledWith('org-1', undefined, { type: 'credit' })
@@ -108,13 +107,9 @@ describe('Transactions — the ledger-side filter', () => {
   it('cuts a stale service’s rows to the side that was asked for', async () => {
     await mount()
     // The stub answers with both sides whatever the request said, which is exactly what a
-    // billing image predating `?type=` does.
-    expect(host.innerHTML).toContain('Promotional credit')
+    // billing image predating `?type=` does. On Usage the credit must not survive that.
     expect(host.innerHTML).toContain('Usage — 2026-08')
-
-    await clickPill('Usage')
     expect(host.innerHTML).not.toContain('Promotional credit')
-    expect(host.innerHTML).toContain('Usage — 2026-08')
 
     await clickPill('Top-ups')
     expect(host.innerHTML).toContain('Promotional credit')

--- a/packages/web/src/lib/org-context.test.ts
+++ b/packages/web/src/lib/org-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveOrgTarget, switchOrgPath } from './org-context'
+import { resolveOrgTarget, switchOrgTarget } from './org-context'
 import type { OrgDto } from './api'
 
 const org = (id: string, slug: string) => ({ id, slug }) as OrgDto
@@ -19,7 +19,17 @@ describe('resolveOrgTarget', () => {
   })
 })
 
-describe('switchOrgPath', () => {
+describe('switchOrgTarget', () => {
+  const acme = org('acme-id', 'acme')
+  const other = org('other-id', 'other')
+
+  it('is a NO-OP for the org already active — both switchers make that row clickable', () => {
+    // Not merely harmless: the detail-path rule below would otherwise throw away the page the
+    // user is reading, on a click that switched nothing.
+    expect(switchOrgTarget(acme, acme.id, '/acme/sessions/s_123', 'acme')).toBeNull()
+    expect(switchOrgTarget(acme, acme.id, '/acme/billing', 'acme')).toBeNull()
+  })
+
   it('sends a detail view home — its id belongs to the org being left', () => {
     for (const path of [
       '/acme/sessions/s_123',
@@ -29,24 +39,28 @@ describe('switchOrgPath', () => {
       '/acme/daemons/groups/g_123',
       '/acme/conversations/slack:C123'
     ])
-      expect(switchOrgPath(path, 'acme')).toBe('/home')
+      expect(switchOrgTarget(other, acme.id, path, 'acme')).toBe('/other/home')
   })
 
   it('keeps an org-level page, so a switch stays where the user was working', () => {
-    expect(switchOrgPath('/acme/sessions', 'acme')).toBe('/sessions')
-    expect(switchOrgPath('/acme/billing', 'acme')).toBe('/billing')
-    expect(switchOrgPath('/acme/settings', 'acme')).toBe('/settings')
-    expect(switchOrgPath('/acme', 'acme')).toBe('/home')
+    expect(switchOrgTarget(other, acme.id, '/acme/sessions', 'acme')).toBe('/other/sessions')
+    expect(switchOrgTarget(other, acme.id, '/acme/billing', 'acme')).toBe('/other/billing')
+    expect(switchOrgTarget(other, acme.id, '/acme/settings', 'acme')).toBe('/other/settings')
+    expect(switchOrgTarget(other, acme.id, '/acme', 'acme')).toBe('/other/home')
   })
 
   it('keeps a deep path built from static segments only', () => {
-    expect(switchOrgPath('/acme/daemons/cluster', 'acme')).toBe('/daemons/cluster')
+    expect(switchOrgTarget(other, acme.id, '/acme/daemons/cluster', 'acme')).toBe('/other/daemons/cluster')
   })
 
   it('handles the bare path of the first-visit rewrite window', () => {
     // `subPath` leaves a path that does not start with the slug alone; the depth rule still
     // has to read it, or a bare detail URL would carry its id across the switch.
-    expect(switchOrgPath('/sessions/s_123', 'acme')).toBe('/home')
-    expect(switchOrgPath('/', 'acme')).toBe('/home')
+    expect(switchOrgTarget(other, acme.id, '/sessions/s_123', 'acme')).toBe('/other/home')
+    expect(switchOrgTarget(other, acme.id, '/', 'acme')).toBe('/other/home')
+  })
+
+  it('treats a brand-new org as a switch — nothing is active from its point of view', () => {
+    expect(switchOrgTarget(other, undefined, '/acme/sessions/s_123', 'acme')).toBe('/other/home')
   })
 })

--- a/packages/web/src/lib/org-context.test.ts
+++ b/packages/web/src/lib/org-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveOrgTarget } from './org-context'
+import { resolveOrgTarget, switchOrgPath } from './org-context'
 import type { OrgDto } from './api'
 
 const org = (id: string, slug: string) => ({ id, slug }) as OrgDto
@@ -16,5 +16,37 @@ describe('resolveOrgTarget', () => {
     expect(resolveOrgTarget([remembered, rewrittenDefault], rewrittenDefault, 'remembered', true)).toBe(
       rewrittenDefault
     )
+  })
+})
+
+describe('switchOrgPath', () => {
+  it('sends a detail view home — its id belongs to the org being left', () => {
+    for (const path of [
+      '/acme/sessions/s_123',
+      '/acme/agents/a_123',
+      '/acme/crons/c_123',
+      '/acme/daemons/d_123',
+      '/acme/daemons/groups/g_123',
+      '/acme/conversations/slack:C123'
+    ])
+      expect(switchOrgPath(path, 'acme')).toBe('/home')
+  })
+
+  it('keeps an org-level page, so a switch stays where the user was working', () => {
+    expect(switchOrgPath('/acme/sessions', 'acme')).toBe('/sessions')
+    expect(switchOrgPath('/acme/billing', 'acme')).toBe('/billing')
+    expect(switchOrgPath('/acme/settings', 'acme')).toBe('/settings')
+    expect(switchOrgPath('/acme', 'acme')).toBe('/home')
+  })
+
+  it('keeps a deep path built from static segments only', () => {
+    expect(switchOrgPath('/acme/daemons/cluster', 'acme')).toBe('/daemons/cluster')
+  })
+
+  it('handles the bare path of the first-visit rewrite window', () => {
+    // `subPath` leaves a path that does not start with the slug alone; the depth rule still
+    // has to read it, or a bare detail URL would carry its id across the switch.
+    expect(switchOrgPath('/sessions/s_123', 'acme')).toBe('/home')
+    expect(switchOrgPath('/', 'acme')).toBe('/home')
   })
 })

--- a/packages/web/src/lib/org-context.tsx
+++ b/packages/web/src/lib/org-context.tsx
@@ -55,6 +55,28 @@ export function subPath(pathname: string, slug: string): string {
   return pathname === '/' ? '/home' : pathname
 }
 
+/** Deep sub-paths built from STATIC segments only, so they still name something in another
+ *  org. Everything else deeper than one segment is a detail view of an id scoped to ONE org. */
+const PORTABLE_DEEP_PATHS = new Set(['/daemons/cluster'])
+
+/** Where a sub-path lands after an org SWITCH — the same path, or `/home`.
+ *
+ *  A session, agent, cron, daemon or conversation id belongs to one org, so carrying one
+ *  across a switch lands on the other org's not-found page — and sessions answer 404 rather
+ *  than 403, so it is not even a hint about what was there. Home is the honest destination.
+ *
+ *  Deny by default, allow the few static deep paths: a new `[id]` route is covered here
+ *  without a change, and forgetting to list a new static one only sends someone home.
+ *
+ *  This is NOT `subPath`'s job — that one also canonicalizes a bare URL inside the SAME org
+ *  (`/sessions/abc` → `/acme/sessions/abc`), where dropping the id would break every deep
+ *  link into the console. */
+export function switchOrgPath(pathname: string, slug: string): string {
+  const sub = subPath(pathname, slug)
+  const deep = sub.split('/').filter(Boolean).length > 1
+  return deep && !PORTABLE_DEEP_PATHS.has(sub) ? '/home' : sub
+}
+
 /** The URL prefix shown next to the org slug ("appears in the URL") — THIS
  *  deployment's host, not a hardcoded domain. Client-only components call it
  *  after mount, so `window` is present; SSR falls back to a bare slash. */
@@ -207,7 +229,7 @@ export function OrgProvider({ children }: { children: ReactNode }) {
       const org = orgs.find((o) => o.id === orgId)
       if (!org) return
       writeLastSlug(org.slug)
-      router.push(`/${org.slug}${subPath(pathname, slug)}`)
+      router.push(`/${org.slug}${switchOrgPath(pathname, slug)}`)
     },
     [orgs, pathname, slug, router]
   )
@@ -217,8 +239,9 @@ export function OrgProvider({ children }: { children: ReactNode }) {
       const org = await apiCreateOrg(input)
       // Append optimistically BEFORE switching so activeOrg never goes null.
       setOrgs((prev) => (prev.some((candidate) => candidate.id === org.id) ? prev : [...prev, org]))
+      // A brand-new org holds nothing at all, so the same rule applies even more plainly.
       writeLastSlug(org.slug)
-      router.push(`/${org.slug}${subPath(pathname, slug)}`)
+      router.push(`/${org.slug}${switchOrgPath(pathname, slug)}`)
       await refreshOrgs()
       return org
     },

--- a/packages/web/src/lib/org-context.tsx
+++ b/packages/web/src/lib/org-context.tsx
@@ -59,11 +59,17 @@ export function subPath(pathname: string, slug: string): string {
  *  org. Everything else deeper than one segment is a detail view of an id scoped to ONE org. */
 const PORTABLE_DEEP_PATHS = new Set(['/daemons/cluster'])
 
-/** Where a sub-path lands after an org SWITCH — the same path, or `/home`.
+/** Where selecting `org` should navigate — or NULL when selecting it is not a switch at all.
  *
- *  A session, agent, cron, daemon or conversation id belongs to one org, so carrying one
- *  across a switch lands on the other org's not-found page — and sessions answer 404 rather
- *  than 403, so it is not even a hint about what was there. Home is the honest destination.
+ *  Both switchers render the current org as a clickable row, so re-selecting the one you are
+ *  already in is a normal click. That is the null case, and it has to come first: the path
+ *  rule below sends a detail view home, which on the same org would throw away the page the
+ *  user is reading.
+ *
+ *  On a real switch the sub-path is kept, or replaced by `/home`. A session, agent, cron,
+ *  daemon or conversation id belongs to ONE org, so carrying one across lands on the other
+ *  org's not-found page — and sessions answer 404 rather than 403, so it is not even a hint
+ *  about what was there. Home is the honest destination.
  *
  *  Deny by default, allow the few static deep paths: a new `[id]` route is covered here
  *  without a change, and forgetting to list a new static one only sends someone home.
@@ -71,10 +77,16 @@ const PORTABLE_DEEP_PATHS = new Set(['/daemons/cluster'])
  *  This is NOT `subPath`'s job — that one also canonicalizes a bare URL inside the SAME org
  *  (`/sessions/abc` → `/acme/sessions/abc`), where dropping the id would break every deep
  *  link into the console. */
-export function switchOrgPath(pathname: string, slug: string): string {
+export function switchOrgTarget(
+  org: { id: string; slug: string },
+  activeOrgId: string | undefined,
+  pathname: string,
+  slug: string
+): string | null {
+  if (org.id === activeOrgId) return null
   const sub = subPath(pathname, slug)
   const deep = sub.split('/').filter(Boolean).length > 1
-  return deep && !PORTABLE_DEEP_PATHS.has(sub) ? '/home' : sub
+  return `/${org.slug}${deep && !PORTABLE_DEEP_PATHS.has(sub) ? '/home' : sub}`
 }
 
 /** The URL prefix shown next to the org slug ("appears in the URL") — THIS
@@ -228,10 +240,12 @@ export function OrgProvider({ children }: { children: ReactNode }) {
     (orgId: string) => {
       const org = orgs.find((o) => o.id === orgId)
       if (!org) return
+      const target = switchOrgTarget(org, activeOrg?.id, pathname, slug)
+      if (!target) return
       writeLastSlug(org.slug)
-      router.push(`/${org.slug}${switchOrgPath(pathname, slug)}`)
+      router.push(target)
     },
-    [orgs, pathname, slug, router]
+    [orgs, activeOrg, pathname, slug, router]
   )
 
   const createOrg = useCallback(
@@ -239,9 +253,10 @@ export function OrgProvider({ children }: { children: ReactNode }) {
       const org = await apiCreateOrg(input)
       // Append optimistically BEFORE switching so activeOrg never goes null.
       setOrgs((prev) => (prev.some((candidate) => candidate.id === org.id) ? prev : [...prev, org]))
-      // A brand-new org holds nothing at all, so the same rule applies even more plainly.
+      // A brand-new org holds nothing at all, so the same rule applies even more plainly —
+      // and it is never the active one, so the no-op arm cannot fire here.
       writeLastSlug(org.slug)
-      router.push(`/${org.slug}${switchOrgPath(pathname, slug)}`)
+      router.push(switchOrgTarget(org, undefined, pathname, slug)!)
       await refreshOrgs()
       return org
     },


### PR DESCRIPTION
A session, agent, cron, daemon or conversation id belongs to **one** org, and the switcher carried the whole sub-path across — so switching org from a detail view went straight to the other org's not-found page. Sessions answer 404 rather than 403, so it was not even a hint about what had been there; it just looked like the console had lost the page.

## The rule

`switchOrgPath(pathname, slug)` decides where a sub-path lands after a switch: the same path, or `/home`.

It **denies by default** — anything deeper than one segment is a detail view — and allows the few deep paths built from static segments only (`/daemons/cluster` today). Two properties worth having:

- a new `[id]` route is covered without touching this file
- forgetting to list a new *static* deep route only sends someone home, which is safe

Covers every dynamic console route: `agents/[id]`, `sessions/[id]`, `crons/[id]`, `daemons/[id]`, `daemons/groups/[id]`, `conversations/[key]`. Applied to `setActiveOrg` and to `createOrg` (a brand-new org holds nothing at all).

## What deliberately did NOT change

- **`subPath` itself.** It also canonicalizes a bare URL inside the *same* org (`/sessions/abc` → `/acme/sessions/abc`) during the first-visit rewrite window. Dropping the id there would break every deep link into the console.
- **A slug rename** (`updateOrg`) keeps its path — same org, same resources.

## Verification

`typecheck` clean, 1994 tests pass, prettier + eslint clean. New unit tests cover each dynamic route, the org-level pages that must stay put, the static deep path, and the bare-path rewrite window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
