### PR TITLE
fix(daemon): settle the streaming state machine edges

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -309,6 +309,18 @@ skips its own `chat.stopStream` and the applier stops appending. The existing `o
 gate on `enqueueApply` already prevents queued actions from publishing after an interrupt; the
 stream flag is the same idea one level down.
 
+**A stop is not a delivery failure, and the two must not share a return value.** An append can
+come back unsuccessful for two unrelated reasons: Slack refused it (a rate limit, a dropped
+connection), or the person ended the stream. The first owes the content to the channel by
+another route; the second forbids exactly that. Collapsing them into one boolean is how a
+buffered tail gets posted as a fresh reply into a conversation somebody just stopped — the
+append response can beat `agent_session_stopped`, so the daemon cannot rely on the event
+having arrived. `appendTurnStream` therefore answers `ok` / `refused` / `stopped`, and
+`stopped` means the turn's output ends there: no buffer, no post, no replacement message, no
+closing edit. The connection also remembers WHICH conversations the person stopped, so a
+queued append arriving after the event is answered `stopped` rather than `refused`; the marker
+clears when a later turn opens its own stream there.
+
 Both halves of that are prohibitions, not best-effort cleanups. After a stop the daemon may
 **neither append to the dead stream nor open a replacement message** — not for the remaining
 body, not for the error notice, not for the attribution footer. A person who pressed Stop asked
@@ -384,6 +396,23 @@ reply boundary, so it arrives with the attribution footer, the response metadata
 anchor. Task chunks are dropped — chrome with no legacy form, and a task card rendered as
 prose is worse than an omitted one. Net effect: the answer lands exactly once, and no queued
 action silently discards the content it carried.
+
+Two consequences follow from "the answer lands exactly once", and both are easy to get wrong:
+
+- **Degradation moves the response only once the buffer holds body text.** A refusal that
+  dropped nothing but task chrome leaves the accepted stream holding the whole visible answer,
+  so that message must still be closed as the attributed final response — and must therefore
+  stay OPEN until the terminal stop rather than being settled at the refusal. Settling it
+  early, or treating "degraded" as "the fallback owns the response", ends a
+  `body → tool card → end` turn footerless and with nothing for §5.5 to finalize.
+- **A failed ROLLOVER stop degrades its tail instead of reusing the old handle.** The retained
+  handle (§3.4/§5 keep it for the settlement retry) is the message the rollover was trying to
+  leave. Appending the tail there would undo the whole point — post-boundary output back above
+  the boundary, or the size cap defeated — and, because the converger has already reset its
+  per-message text, the closing edit would then replace the combined message with just the
+  tail, deleting the prefix. So the tail goes to the fallback buffer and lands BELOW as an
+  ordinary reply, which is what the rollover wanted; the old message keeps its prefix and
+  settlement keeps retrying its stop.
 
 **A stop is retryable until Slack accepts it.** `chat.stopStream` failing transiently — a rate
 limit, a dropped connection, the send queue's own timeout — is precisely the case the §5

--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -405,6 +405,12 @@ Two consequences follow from "the answer lands exactly once", and both are easy 
   stay OPEN until the terminal stop rather than being settled at the refusal. Settling it
   early, or treating "degraded" as "the fallback owns the response", ends a
   `body → tool card → end` turn footerless and with nothing for §5.5 to finalize.
+  **That ownership is explicit state, not a length check on the buffer.** The buffer empties
+  on every flush, so a stop retried afterwards — the double-failure case, where the rollover
+  stop and then the terminal stop are both left unresolved — would read "no fallback body" and
+  re-anoint the retained old message as final, moving the footer and the §5.5 anchor onto it
+  and restamping it with the tail's text. Ownership is therefore one-way for the turn: once
+  the fallback has taken the response, no later retry hands it back.
 - **A failed ROLLOVER stop degrades its tail instead of reusing the old handle.** The retained
   handle (§3.4/§5 keep it for the settlement retry) is the message the rollover was trying to
   leave. Appending the tail there would undo the whole point — post-boundary output back above

--- a/packages/daemon/src/evaluation/virtual-connections.ts
+++ b/packages/daemon/src/evaluation/virtual-connections.ts
@@ -419,8 +419,8 @@ export class VirtualSlackConnection implements PlatformConnection {
     return undefined
   }
 
-  async appendTurnStream(): Promise<boolean> {
-    return false
+  async appendTurnStream(): Promise<'ok' | 'refused' | 'stopped'> {
+    return 'refused'
   }
 
   async stopTurnStream(): Promise<boolean> {

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -62,6 +62,12 @@ export interface SlackTurnState {
    *  action feeds this buffer instead of a message, so nothing the converger already
    *  converged — or already queued — is silently dropped. */
   streamFallback?: string
+  /** Whether the RESPONSE has moved off the stream to the fallback. Deliberately NOT derived
+   *  from the buffer's length: each flush empties the buffer, so a stop retried after one
+   *  would read "no fallback body" and re-anoint the retained old stream as the final,
+   *  attributed message. One-way for the turn — once the fallback owns the response, nothing
+   *  hands it back. */
+  streamResponseMoved?: boolean
   /** A stop Slack has not accepted yet, kept verbatim so settlement reissues THAT stop: a
    *  bare abort retry would settle the message but drop its attribution footer. */
   streamStopOwed?: Extract<SlackAction, { kind: 'stream-stop' }>
@@ -407,6 +413,14 @@ function streamChunkText(chunks: SlackStreamChunk[]): string {
   return chunks.map((chunk) => (chunk.type === 'markdown_text' ? chunk.text : '')).join('')
 }
 
+/** Route display text to the fallback buffer, opening it if needed, and record ownership the
+ *  moment real body text lands there. Ownership is tracked separately from the buffer BECAUSE
+ *  the buffer empties on every flush — see `streamResponseMoved`. */
+function bufferStreamFallback(state: SlackTurnState, body: string): void {
+  state.streamFallback = (state.streamFallback ?? '') + body
+  if (body) state.streamResponseMoved = true
+}
+
 /**
  * Issue one stop and decide whether the handle may be retired. Slack answering "not settled"
  * (a rate limit, a dropped connection, a send-queue timeout) is the one case that must NOT
@@ -692,7 +706,7 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       // BEFORE the refusal — and the terminal ones after it — are still arriving; they carry
       // display text Slack never took, so they feed the buffer instead of no-opping (§7).
       if (state.streamFallback !== undefined) {
-        state.streamFallback += body
+        bufferStreamFallback(state, body)
         return
       }
       if (!state.stream) return
@@ -708,7 +722,7 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       // A mid-turn append failure must not lose the answer. Open the buffer with exactly the
       // text this append carried — the converger has already advanced its cursor past it, so
       // this is the only remaining copy.
-      state.streamFallback = body
+      bufferStreamFallback(state, body)
       // Settle the message only when the answer has actually MOVED off it. A refusal that
       // dropped nothing but task chrome leaves the stream holding the whole visible answer,
       // so it stays open for its terminal attributed stop — aborting it here is what left a
@@ -718,14 +732,14 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     }
     case 'stream-stop': {
       if (state.streamStopped) return
-      // Degradation moves the RESPONSE off the stream only once the buffer actually holds
-      // body text. A refusal that dropped nothing but task chrome leaves the accepted stream
-      // holding the whole visible answer, so it must still be closed as the attributed final
-      // message — otherwise a "body → tool card → end" turn ends footerless and with nothing
-      // for §5.5 to finalize.
+      // Degradation moves the RESPONSE off the stream only once real body text has landed in
+      // the fallback. A refusal that dropped nothing but task chrome leaves the accepted
+      // stream holding the whole visible answer, so it must still be closed as the attributed
+      // final message — otherwise a "body → tool card → end" turn ends footerless and with
+      // nothing for §5.5 to finalize. Read from the one-way ownership flag, never from the
+      // buffer: a stop retried after the flush emptied it would re-anoint the old message.
       const degraded = state.streamFallback !== undefined
-      const fallbackOwnsResponse = (state.streamFallback ?? '').length > 0
-      const final = action.settle === 'final' && !fallbackOwnsResponse
+      const final = action.settle === 'final' && !state.streamResponseMoved
       if (state.stream) {
         const agentOptions = final
           ? slackAgentPostOptions({ ...p.plan, ...(p.reply.responseId ? { responseId: p.reply.responseId } : {}) })

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -65,6 +65,11 @@ export interface SlackTurnState {
   /** A stop Slack has not accepted yet, kept verbatim so settlement reissues THAT stop: a
    *  bare abort retry would settle the message but drop its attribution footer. */
   streamStopOwed?: Extract<SlackAction, { kind: 'stream-stop' }>
+  /** The PERSON ended this turn's stream. Terminal and absolute: nothing more is appended,
+   *  buffered, posted, or opened, and the cancellation already in flight settles the turn.
+   *  Distinct from `streamFallback` precisely because that one re-delivers and this one must
+   *  not — a fallback post here would be the replacement message §6 forbids. */
+  streamStopped?: boolean
   /** The human a streamed message is addressed to (`recipient_user_id`, required outside
    *  DMs). Absent on a cron / hook / dream / agent-to-agent turn, which is exactly why
    *  those cannot stream in a channel (§7). */
@@ -667,8 +672,9 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     case 'stream-start': {
       // Streamed messages must be thread replies (§7), and a rollover only ever opens the
       // NEXT message — never a second stream beside a live one. Once the turn has degraded,
-      // a fresh message would be a second answer bubble rather than a continuation.
-      if (state.streamFallback !== undefined || state.stream || !p.plan.thread) return
+      // a fresh message would be a second answer bubble rather than a continuation; once the
+      // person has stopped, opening one at all is what §6 forbids.
+      if (state.streamStopped || state.streamFallback !== undefined || state.stream || !p.plan.thread) return
       state.stream = await conn.startTurnStream(p.plan.channel, p.plan.thread, {
         ...(state.recipient ? { recipientUserId: state.recipient } : {}),
         // Per-agent authorship moves here from the status text: same username/icon a reply
@@ -678,7 +684,9 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       return
     }
     case 'stream-append': {
-      if (action.chunks.length === 0) return
+      // The person ended this conversation's stream: the remaining output is not re-routed,
+      // it is dropped, and the cancellation already in flight settles the turn (§6).
+      if (state.streamStopped || action.chunks.length === 0) return
       const body = streamChunkText(action.chunks)
       // Already degraded. Application is asynchronous, so appends the converger produced
       // BEFORE the refusal — and the terminal ones after it — are still arriving; they carry
@@ -688,19 +696,36 @@ export async function applySlackAction<TTurn extends SlackTurn>(
         return
       }
       if (!state.stream) return
-      if (await conn.appendTurnStream(state.stream, action.chunks)) return
+      const outcome = await conn.appendTurnStream(state.stream, action.chunks)
+      if (outcome === 'ok') return
+      if (outcome === 'stopped') {
+        // Not a failure to make good on — a decision by the person. Anything still queued for
+        // this turn stops here, and no fallback post may follow it (§6).
+        state.streamStopped = true
+        state.stream = undefined
+        return
+      }
       // A mid-turn append failure must not lose the answer. Open the buffer with exactly the
       // text this append carried — the converger has already advanced its cursor past it, so
-      // this is the only remaining copy — and settle the message.
+      // this is the only remaining copy.
       state.streamFallback = body
-      await settleTurnStream(conn, p, state, { kind: 'stream-stop', settle: 'abort' })
+      // Settle the message only when the answer has actually MOVED off it. A refusal that
+      // dropped nothing but task chrome leaves the stream holding the whole visible answer,
+      // so it stays open for its terminal attributed stop — aborting it here is what left a
+      // "body → tool card → end" turn footerless and with nothing for §5.5 to finalize.
+      if (body) await settleTurnStream(conn, p, state, { kind: 'stream-stop', settle: 'abort' })
       return
     }
     case 'stream-stop': {
-      // A degraded turn's tail owns the footer and the §5.5 anchor, so the stop that follows
-      // is never the "final" one: it settles the dead message and nothing more.
+      if (state.streamStopped) return
+      // Degradation moves the RESPONSE off the stream only once the buffer actually holds
+      // body text. A refusal that dropped nothing but task chrome leaves the accepted stream
+      // holding the whole visible answer, so it must still be closed as the attributed final
+      // message — otherwise a "body → tool card → end" turn ends footerless and with nothing
+      // for §5.5 to finalize.
       const degraded = state.streamFallback !== undefined
-      const final = action.settle === 'final' && !degraded
+      const fallbackOwnsResponse = (state.streamFallback ?? '').length > 0
+      const final = action.settle === 'final' && !fallbackOwnsResponse
       if (state.stream) {
         const agentOptions = final
           ? slackAgentPostOptions({ ...p.plan, ...(p.reply.responseId ? { responseId: p.reply.responseId } : {}) })
@@ -731,6 +756,14 @@ export async function applySlackAction<TTurn extends SlackTurn>(
             }
           }
         }
+        // A ROLLOVER whose stop Slack would not accept owes a replacement message, and the
+        // retained handle is emphatically not it: appending the tail there would put
+        // post-boundary output back above the boundary, defeat the size cap, and — because
+        // the converger has already reset its per-message text — let the closing edit replace
+        // the combined message with just the tail. Degrade the tail instead, so it lands
+        // BELOW as an ordinary reply (which is what the rollover wanted) while the old
+        // message keeps its prefix and settlement keeps retrying its stop.
+        if (!settled && action.settle === 'rollover') state.streamFallback ??= ''
       }
       // Suppression drops the buffer with the rest of the turn's output; every other stop is
       // where the tail Slack never showed reaches the channel.

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -115,6 +115,16 @@ export interface SlackTurnStream {
   readonly ts: string
 }
 
+/**
+ * What Slack did with an append — three outcomes, because two of them are not the same
+ * failure. `refused` means the content did not land and the caller still owes it to the
+ * channel some other way (§7). `stopped` means the PERSON ended the stream: the content must
+ * NOT be re-delivered by any route, because a fallback post would be exactly the replacement
+ * message §6 forbids after a Stop. Collapsing the two into one boolean is how a stopped
+ * conversation gets a new reply posted into it.
+ */
+export type SlackStreamAppendOutcome = 'ok' | 'refused' | 'stopped'
+
 /** Optional per-status identity overrides supported by assistant.threads.setStatus.
  * Unlike chat.postMessage customization, Slack accepts these with chat:write. */
 export interface SlackStatusOptions {
@@ -700,6 +710,10 @@ export class SlackConnection implements PlatformConnection {
   /** Streaming messages still open, `channel:thread` → message ts. An entry disappears the
    *  moment the stream settles — by our stop, by a refused append, or by the person's Stop. */
   private openStreams = new Map<string, string>()
+  /** Conversations whose stream the PERSON ended. A queued append arriving after the event is
+   *  answered `stopped` rather than `refused`, so it is never re-delivered by another route
+   *  (§6). Cleared when a later turn opens a stream in the same conversation. */
+  private userStoppedStreams = new Set<string>()
   botUserId = ''
   /** The appToken this socket is keyed by (one socket per unique appToken). */
   readonly appToken: string
@@ -1317,6 +1331,8 @@ export class SlackConnection implements PlatformConnection {
           }
           this.streamingUnavailableUntil = 0
           this.openStreams.set(`${channel}:${threadTs}`, ts)
+          // A new turn's stream: whatever the person stopped before was a different message.
+          this.userStoppedStreams.delete(`${channel}:${threadTs}`)
           return { channel, threadTs, ts }
         } catch (err) {
           this.rememberMissingScopes(err)
@@ -1329,26 +1345,34 @@ export class SlackConnection implements PlatformConnection {
       .catch(() => undefined)
   }
 
-  /** Append chunks to an open stream. `false` means this content did NOT reach Slack, so the
-   *  caller owes it to the channel some other way (§7) — it never means "silently dropped". */
-  async appendTurnStream(stream: SlackTurnStream, chunks: SlackStreamChunk[]): Promise<boolean> {
+  /** Append chunks to an open stream. See {@link SlackStreamAppendOutcome}: a refusal the
+   *  caller must make good on is NOT the same answer as the person having pressed Stop. */
+  async appendTurnStream(stream: SlackTurnStream, chunks: SlackStreamChunk[]): Promise<SlackStreamAppendOutcome> {
     const append = this.app.client.chat.appendStream
-    if (chunks.length === 0) return true
-    if (typeof append !== 'function' || this.openStreams.get(`${stream.channel}:${stream.threadTs}`) !== stream.ts)
-      return false
+    if (chunks.length === 0) return 'ok'
+    const key = `${stream.channel}:${stream.threadTs}`
+    // The stop event already landed. Whatever this append carried is not shown here and must
+    // not be shown anywhere else either — the cancellation is on its way (§6).
+    if (this.userStoppedStreams.has(key)) return 'stopped'
+    if (typeof append !== 'function') return 'refused'
+    // The handle is retired but the person did not do it, so we settled it ourselves and the
+    // caller is holding a stale one; the content is still owed to the channel.
+    if (this.openStreams.get(key) !== stream.ts) return 'refused'
     try {
       return await this.queue.enqueue(async () => {
         await append({ channel: stream.channel, ts: stream.ts, chunks })
-        return true
+        return 'ok' as const
       })
     } catch (err) {
       this.rememberMissingScopes(err)
       this.noteStreamFailure(err, 'chat.appendStream', stream.channel)
-      // Only a DEFINITE already-stopped answer proves the message is settled. A transient
-      // failure leaves it streaming, so the handle stays and the stop that must still land
-      // has something to land on.
-      if (isStreamAlreadyStopped(err)) this.closeStream(stream.channel, stream.threadTs)
-      return false
+      // Only a DEFINITE already-stopped answer proves the message is settled — and since our
+      // own stop would have been caught by the guard above, something else settled it, which
+      // in practice is the person's Stop racing its own event. A transient failure instead
+      // leaves the message streaming, so the handle stays and the stop still has a target.
+      if (!isStreamAlreadyStopped(err)) return 'refused'
+      this.closeStream(stream.channel, stream.threadTs)
+      return 'stopped'
     }
   }
 
@@ -2014,8 +2038,10 @@ export class SlackConnection implements PlatformConnection {
     // Slack already ended any stream this conversation had open before firing the event, and
     // a stopped stream is unrecoverable (§3.4/§6). Drop the handle FIRST so the cancel below
     // can neither append to the dead message nor issue a second stop against it — the message
-    // is settled before the session is told it is idle.
+    // is settled before the session is told it is idle. Remembering WHO ended it is what keeps
+    // a late append from being re-delivered as an ordinary post afterwards.
     this.closeStream(channel, threadTs)
+    this.userStoppedStreams.add(`${channel}:${threadTs}`)
     const sessionKey = await this.deps.onMessageShortcut?.({ channel, thread: threadTs, ...(userId ? { userId } : {}) })
     if (sessionKey) this.deps.onStatusAction?.({ kind: 'cancel', sessionKey, ...(userId ? { actor: { userId } } : {}) })
     await this.queue.enqueue(() => this.setSessionLifecycle(channel, threadTs, 'active'))

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -517,6 +517,39 @@ describe('applySlackAction — streaming actions', () => {
     expect(conn.stopTurnStream.mock.calls.at(-1)![1]).toEqual({})
   })
 
+  it('never re-anoints the old message when BOTH the rollover and the terminal stop fail', async () => {
+    // The flush empties the buffer, so ownership read from its length would flip back to "the
+    // stream owns the response" on the settlement retry — putting the footer and the §5.5
+    // anchor on the old message, with the tail's text under the old ts.
+    let acceptStops = false
+    const { apply, conn, turn, state } = fixture({
+      stopTurnStream: vi.fn(async (_s: SlackTurnStream, _o?: Record<string, unknown>) => acceptStops)
+    })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'the prefix' }] })
+    await apply({ kind: 'stream-stop', settle: 'rollover', text: 'the prefix' })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'the tail' }] })
+    // Terminal stop ALSO refused — the tail still posts, and the stop stays owed.
+    await apply({ kind: 'stream-stop', settle: 'final', text: 'the tail' })
+    expect(conn.postMessage).toHaveBeenCalledOnce()
+    expect(turn.reply.lastResponse).toEqual({ ts: 'p1', text: 'the tail' })
+    expect(state.streamFallback).toBe('')
+    expect(state.streamStopOwed).toMatchObject({ settle: 'final' })
+
+    // Settlement replays that owed stop against the still-open OLD message.
+    acceptStops = true
+    await apply(state.streamStopOwed!)
+
+    // It settles BARE: no footer, no response metadata…
+    expect(conn.stopTurnStream.mock.calls.at(-1)![1]).toEqual({})
+    // …and the response anchor still names the message that actually holds the answer.
+    expect(turn.reply.lastResponse).toEqual({ ts: 'p1', text: 'the tail' })
+    expect(turn.reply.lastReply).toMatchObject({ ts: 'p1' })
+    expect(conn.postMessage).toHaveBeenCalledOnce()
+    expect(state.stream).toBeUndefined()
+  })
+
   it('stops everything when the append reports the person pressed Stop', async () => {
     const { apply, conn, turn, state } = fixture({
       appendTurnStream: vi.fn(

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
-import { SlackConnection, type SlackTurnStream } from '../src/slack/connection.js'
+import { SlackConnection, type SlackStreamAppendOutcome, type SlackTurnStream } from '../src/slack/connection.js'
 import { OutputConverger, type SlackAction, type SlackStreamChunk } from '../src/slack/render.js'
 import {
   applySlackAction,
@@ -313,7 +313,9 @@ describe('applySlackAction — streaming actions', () => {
         threadTs,
         ts: '900.1'
       })),
-      appendTurnStream: vi.fn(async (_stream: SlackTurnStream, _chunks: SlackStreamChunk[]) => true),
+      appendTurnStream: vi.fn(
+        async (_stream: SlackTurnStream, _chunks: SlackStreamChunk[]) => 'ok' as SlackStreamAppendOutcome
+      ),
       stopTurnStream: vi.fn(async (_stream: SlackTurnStream, _options?: Record<string, unknown>) => true),
       deleteMessage: vi.fn(async (_channel: string, _ts: string) => true),
       setStatus: vi.fn(async () => {}),
@@ -383,7 +385,9 @@ describe('applySlackAction — streaming actions', () => {
 
   it('settles the stream and degrades the turn when an append is refused', async () => {
     const { apply, conn, state } = fixture({
-      appendTurnStream: vi.fn(async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => false)
+      appendTurnStream: vi.fn(
+        async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => 'refused' as SlackStreamAppendOutcome
+      )
     })
     await apply({ kind: 'stream-start' })
     await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'hi' }] })
@@ -400,7 +404,9 @@ describe('applySlackAction — streaming actions', () => {
     // and none may be shown twice.
     let accept = true
     const { apply, conn, turn } = fixture({
-      appendTurnStream: vi.fn(async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => accept)
+      appendTurnStream: vi.fn(
+        async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => (accept ? 'ok' : 'refused') as SlackStreamAppendOutcome
+      )
     })
     await apply({ kind: 'stream-start' })
     await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'accepted. ' }] })
@@ -427,7 +433,9 @@ describe('applySlackAction — streaming actions', () => {
 
   it('a degraded turn opens no replacement stream, and its cleanup stop carries no footer', async () => {
     const { apply, conn } = fixture({
-      appendTurnStream: vi.fn(async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => false)
+      appendTurnStream: vi.fn(
+        async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => 'refused' as SlackStreamAppendOutcome
+      )
     })
     await apply({ kind: 'stream-start' })
     await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'tail' }] })
@@ -440,13 +448,96 @@ describe('applySlackAction — streaming actions', () => {
 
   it('drops the buffered tail when suppression tears the turn down', async () => {
     const { apply, conn, state } = fixture({
-      appendTurnStream: vi.fn(async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => false)
+      appendTurnStream: vi.fn(
+        async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => 'refused' as SlackStreamAppendOutcome
+      )
     })
     await apply({ kind: 'stream-start' })
     await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'never shown' }] })
     await apply({ kind: 'stream-stop', settle: 'abort' })
     expect(conn.postMessage).not.toHaveBeenCalled()
     expect(state.streamFallback).toBe('never shown')
+  })
+
+  it('a task-only refusal still lets the accepted stream close as the attributed answer', async () => {
+    // "body → tool card → end": the body is already visible on the stream, and the refusal
+    // dropped nothing but chrome. The stream must still get the footer and the §5.5 anchor,
+    // or the answer ends footerless and unroutable.
+    let accept = true
+    const { apply, conn, turn, state } = fixture({
+      appendTurnStream: vi.fn(
+        async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => (accept ? 'ok' : 'refused') as SlackStreamAppendOutcome
+      )
+    })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'the whole answer' }] })
+    accept = false
+    await apply({
+      kind: 'stream-append',
+      chunks: [{ type: 'task_update', id: 't1', title: 'Read file', status: 'complete' }]
+    })
+    // Degraded for appends, but the buffer holds no body — so the response has not moved.
+    expect(state.streamFallback).toBe('')
+    await apply({ kind: 'stream-stop', settle: 'final', text: 'the whole answer' })
+
+    // Exactly one attributed close, on the message that actually shows the answer.
+    expect(conn.postMessage).not.toHaveBeenCalled()
+    const closing = conn.stopTurnStream.mock.calls.at(-1)![1] as Record<string, unknown>
+    expect(closing).toMatchObject({ blocks: [{ type: 'context' }], agentAuthorId: 'bot-a' })
+    expect(turn.reply.lastResponse).toEqual({ ts: '900.1', text: 'the whole answer' })
+    expect(turn.reply.lastReply).toMatchObject({ ts: '900.1', footerKey: 'footer-1' })
+  })
+
+  it('defers the replacement message when a ROLLOVER stop is left unsettled', async () => {
+    // The retained handle is the OLD message. Appending the post-rollover tail there would put
+    // it back above the boundary, defeat the size cap, and let finalization replace the
+    // combined message with just the tail.
+    const { apply, conn, turn, state } = fixture({
+      stopTurnStream: vi.fn(async (_s: SlackTurnStream, o?: Record<string, unknown>) => o?.sessionStatus === undefined)
+    })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'the prefix' }] })
+    // Rollover, refused — the converger has already reset its per-message text.
+    await apply({ kind: 'stream-stop', settle: 'rollover', text: 'the prefix' })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'the tail' }] })
+    await apply({ kind: 'stream-stop', settle: 'final', text: 'the tail' })
+
+    // The old handle was never reused: exactly one append, the accepted prefix.
+    expect(conn.appendTurnStream).toHaveBeenCalledOnce()
+    expect(conn.startTurnStream).toHaveBeenCalledOnce()
+    // The tail landed BELOW as an ordinary reply, which is what the rollover wanted…
+    expect(conn.postMessage).toHaveBeenCalledOnce()
+    expect(conn.postMessage.mock.calls[0]![1]).toBe('the tail')
+    // …and finalization names THAT message, so the prefix is never overwritten.
+    expect(turn.reply.lastResponse).toEqual({ ts: 'p1', text: 'the tail' })
+    // The old message keeps its prefix and was settled bare — no footer, no §5.5 claim.
+    expect(state.stream).toBeUndefined()
+    expect(state.streamStopOwed).toBeUndefined()
+    expect(conn.stopTurnStream.mock.calls.at(-1)![1]).toEqual({})
+  })
+
+  it('stops everything when the append reports the person pressed Stop', async () => {
+    const { apply, conn, turn, state } = fixture({
+      appendTurnStream: vi.fn(
+        async (_s: SlackTurnStream, _c: SlackStreamChunk[]) => 'stopped' as SlackStreamAppendOutcome
+      )
+    })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'never shown' }] })
+    expect(state.streamStopped).toBe(true)
+    // No buffer opened, so nothing can be re-delivered by another route.
+    expect(state.streamFallback).toBeUndefined()
+
+    // Everything still queued for this turn is inert — no post, no replacement message,
+    // no closing edit on a message the person ended (§6).
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'nor this' }] })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-stop', settle: 'final', text: 'nor this' })
+    expect(conn.postMessage).not.toHaveBeenCalled()
+    expect(conn.startTurnStream).toHaveBeenCalledOnce()
+    expect(conn.stopTurnStream).not.toHaveBeenCalled()
+    expect(turn.reply).not.toHaveProperty('lastResponse')
   })
 
   it('keeps the handle and the exact stop when Slack leaves the message streaming', async () => {
@@ -715,6 +806,39 @@ describe('SlackConnection streaming', () => {
     }
   })
 
+  it('answers `stopped`, not `refused`, once the person has ended the stream', async () => {
+    const { conn, app } = await connect(
+      {},
+      { onMessageShortcut: async () => 'slack:C1:T1:bot-a', onStatusAction: () => {} }
+    )
+    const stream = (await conn.startTurnStream('C1', 'T1'))!
+    await conn.agentSessionStopped('C1', 'T1', 'U1')
+    // Collapsing this into the same `false` a rate limit returns is what lets a buffered tail
+    // be posted as a new reply after a Stop.
+    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'more' }])).toBe('stopped')
+    expect(app.client.chat.appendStream).not.toHaveBeenCalled()
+  })
+
+  it('reads a stopped_by_user refusal as `stopped` even before the event arrives', async () => {
+    const { conn } = await connect({
+      chat: {
+        appendStream: vi.fn(async () => {
+          throw slackError('stopped_by_user')
+        })
+      }
+    })
+    const stream = (await conn.startTurnStream('C1', 'T1'))!
+    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'x' }])).toBe('stopped')
+  })
+
+  it('forgets a previous Stop when a later turn opens its own stream', async () => {
+    const { conn } = await connect({}, { onMessageShortcut: async () => 'slack:C1:T1:bot-a', onStatusAction: () => {} })
+    await conn.startTurnStream('C1', 'T1')
+    await conn.agentSessionStopped('C1', 'T1', 'U1')
+    const next = (await conn.startTurnStream('C1', 'T1'))!
+    expect(await conn.appendTurnStream(next, [{ type: 'markdown_text', text: 'a new turn' }])).toBe('ok')
+  })
+
   it('keeps the handle after a TRANSIENT append failure, so the stop can still land', async () => {
     const { conn, app } = await connect({
       chat: {
@@ -724,7 +848,7 @@ describe('SlackConnection streaming', () => {
       }
     })
     const stream = (await conn.startTurnStream('C1', 'T1'))!
-    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'x' }])).toBe(false)
+    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'x' }])).toBe('refused')
     expect(await conn.stopTurnStream(stream)).toBe(true)
     expect(app.client.chat.stopStream).toHaveBeenCalledOnce()
   })
@@ -741,7 +865,7 @@ describe('SlackConnection streaming', () => {
     const stream = (await conn.startTurnStream('C1', 'T1'))!
     await conn.agentSessionStopped('C1', 'T1', 'U1')
 
-    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'more' }])).toBe(false)
+    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'more' }])).toBe('stopped')
     // Settled, and settled by the person — so nothing is retried against it either.
     expect(await conn.stopTurnStream(stream)).toBe(true)
     expect(app.client.chat.appendStream).not.toHaveBeenCalled()
@@ -762,7 +886,9 @@ describe('SlackConnection streaming', () => {
       }
     })
     const stream = (await conn.startTurnStream('C1', 'T1'))!
-    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'x' }])).toBe(false)
+    // Settled by something other than us — in practice the person's Stop racing its event —
+    // so the content is dropped rather than re-delivered by another route (§6).
+    expect(await conn.appendTurnStream(stream, [{ type: 'markdown_text', text: 'x' }])).toBe('stopped')
     expect(conn.streamingLikely()).toBe(true)
     // A DEFINITE already-stopped answer proves the message is settled, so no stop is owed.
     expect(await conn.stopTurnStream(stream)).toBe(true)
@@ -838,7 +964,9 @@ describe('Daemon Slack streaming turn', () => {
         threadTs,
         ts: '900.1'
       })),
-      appendTurnStream: vi.fn(async (_stream: SlackTurnStream, _chunks: SlackStreamChunk[]) => true),
+      appendTurnStream: vi.fn(
+        async (_stream: SlackTurnStream, _chunks: SlackStreamChunk[]) => 'ok' as SlackStreamAppendOutcome
+      ),
       stopTurnStream: vi.fn(async (_stream: SlackTurnStream, _options?: Record<string, unknown>) => true),
       deleteMessage: vi.fn(async (_channel: string, _ts: string) => true),
       ...over


### PR DESCRIPTION
Follow-up to #1483 (merged). Three round-2 review findings, all on streaming failure paths.
Each is the same class of mistake: the state machine kept a handle it should not have reused,
or reused one outcome to mean two different things.

## 1. A failed rollover stop no longer reuses the old message

A rollover stop that Slack leaves unresolved retains its handle, by design, so settlement can
retry it. But the already-queued replacement `stream-start` then saw a live handle and skipped,
and the following `stream-append` sent the post-rollover tail straight back into the message
the rollover was trying to leave — above the boundary for a chronological rollover, past the
cap for a size one. Worse, the converger had already reset its per-message text, so the closing
edit would have replaced the combined message with just the tail, deleting the prefix.

The tail now degrades to the ordinary post boundary instead, so it lands *below* as a normal
reply — which is exactly what the rollover wanted — while the old message keeps its prefix and
settlement keeps retrying its stop. The retained handle is never treated as the replacement.

## 2. A chrome-only refusal no longer strands the answer

`streamChunkText` is empty for a `task_update`-only append. A refusal there opened an empty
fallback and aborted the accepted stream, so a very ordinary `body → tool card → end` turn
finished with no attribution footer and nothing for response finalization to close.

Degradation now moves the *response* only once the fallback buffer actually holds body text.
A refusal that dropped nothing but chrome leaves the stream holding the whole visible answer,
so it stays open for its terminal attributed stop rather than being settled at the refusal.
Dropping the task chrome itself is still fine.

## 3. An append refusal and a user Stop are no longer the same answer

`appendTurnStream` returned one boolean for two unrelated things: Slack refused the content
(owe it to the channel another way) and the person pressed Stop (delivering it anywhere is
forbidden). Because the append response can beat `agent_session_stopped`, that collapse let a
buffered tail be posted as a fresh reply into a conversation somebody had just stopped —
violating the native-Stop invariant that no replacement message may open after a stop.

It now answers `ok` / `refused` / `stopped`. `stopped` ends the turn's output: no buffer, no
post, no replacement message, no closing edit — the cancellation already in flight settles the
turn. The connection also remembers which conversations the person stopped, so a queued append
arriving *after* the event is answered `stopped` rather than `refused`; the marker clears when
a later turn opens its own stream there.

## Verified

- `pnpm --filter @agentconnect.md/daemon test` — 4867 passed, 82 skipped. The only failures are
  the four pre-existing local-environment suites (`shim-workspace-files`, `shim-exec-handler`,
  `shim-cancellation`, `acp-matrix`), unchanged by this PR.
- `pnpm eval:gates` — 28 files, 193 passed.
- `pnpm typecheck` (all packages, tests included), `pnpm lint`, `pnpm format:check` — clean.
- `slack-streaming.test.ts` grows 57 → 63. New: deferred replacement on an unsettled rollover
  (one append, one start, tail posted below, finalization names the new message, old message
  settled bare); accepted body + refused task-only append (footer and §5.5 anchor land on the
  stream exactly once, nothing posted); `stopped` on append (no buffer, no post, no replacement
  stream, no closing edit); and three connection-level cases — `stopped` after the event,
  `stopped_by_user` before it, and the marker clearing on a later turn's stream.

The design doc gains matching notes in §6 and §7, including the rule the third finding is
really about: a stop is not a delivery failure, and the two must not share a return value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
