### PR TITLE
feat(daemon): clone from the code host the deployment already named

### DIFF
--- a/docs/self-managed-gitlab.md
+++ b/docs/self-managed-gitlab.md
@@ -116,20 +116,16 @@ supported yet.
 
 ## Allow the daemon to clone your instance
 
-A daemon serves a workspace only from an origin its **operator** allowed — a policy
-no tenant can widen, and one that ships allowing GitHub and GitLab.com alone. Until
-your instance is on that list, attaching a project answers:
+Nothing to do for the instance you configured: a daemon adopts the code host its
+control plane names — the same address it already uses to decide where an agent's
+git credential may go — so a workspace on your instance clones with no local
+configuration anywhere.
 
-```text
-workspace preparation failed: git clone origin is not allowed by this daemon
-```
-
-Add the exact origin — scheme, host, and port, no path — wherever that daemon is
-configured. On a host daemon that is `security.workspaceGitAllowedOrigins` in its
-config file; in Kubernetes the members have no config file, so the deployment states
-it instead (`daemonPool.workspaceGitAllowedOrigins` in the chart's values). Naming any
-origin replaces the default list rather than adding to it, so an install that also uses
-the public hosts names them alongside yours.
+The operator policy behind that is `security.workspaceGitAllowedOrigins` in a
+daemon's config file (`daemonPool.workspaceGitAllowedOrigins` in the Helm chart,
+where members have no config file). Reach for it only to allow something _else_ —
+a second host, an SSH remote — or to restrict: an explicit empty list turns remote
+Git workspaces off entirely, and nothing is adopted past that.
 
 ## Let GitLab reach the webhook endpoint
 

--- a/docs/self-managed-gitlab.md
+++ b/docs/self-managed-gitlab.md
@@ -118,8 +118,8 @@ supported yet.
 
 Nothing to do for the instance you configured: a daemon adopts the code host its
 control plane names — the same address it already uses to decide where an agent's
-git credential may go — so a workspace on your instance clones with no local
-configuration anywhere.
+git credential may go — so a workspace on your instance, or an additional
+repository on it, clones with no local configuration anywhere.
 
 The operator policy behind that is `security.workspaceGitAllowedOrigins` in a
 daemon's config file (`daemonPool.workspaceGitAllowedOrigins` in the Helm chart,

--- a/docs/self-managed-gitlab.md
+++ b/docs/self-managed-gitlab.md
@@ -116,10 +116,11 @@ supported yet.
 
 ## Allow the daemon to clone your instance
 
-Nothing to do for the instance you configured: a daemon adopts the code host its
-control plane names — the same address it already uses to decide where an agent's
-git credential may go — so a workspace on your instance, or an additional
-repository on it, clones with no local configuration anywhere.
+Nothing to do for the instance you configured: a daemon authorizes a clone against
+the code host the agent's own specification names — the same address it already
+uses to decide where that agent's git credential may go — so a workspace on your
+instance, or an additional repository on it, clones with no local configuration
+anywhere.
 
 The operator policy behind that is `security.workspaceGitAllowedOrigins` in a
 daemon's config file (`daemonPool.workspaceGitAllowedOrigins` in the Helm chart,

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -53,7 +53,7 @@ import {
 import type { LocalStore } from '../store/local-store.js'
 import type { AcpHost } from '../acp/acp-host.js'
 import type { WorkspaceManager, PrepareSessionWorkspaceRequest } from '../workspace/workspace-manager.js'
-import { unauthorizedWorkspaceGitOrigin } from '../workspace/git-origin-policy.js'
+import { adoptDeploymentCodeHost, unauthorizedWorkspaceGitOrigin } from '../workspace/git-origin-policy.js'
 import type { KeyServerClient } from '../key-server/client.js'
 import type { GitCredentialCache } from './git-credential.js'
 import type { GitCredServer } from './gitcred-server.js'
@@ -328,18 +328,23 @@ export async function applyReconcileSnapshot(host: ConfigApplyHost, snap: Regist
 }
 
 /**
- * §24.4 spec admission: the operator's `workspaceGitAllowedOrigins` stays authoritative, and the
- * managed GitLab feature never widens it. A GitLab workspace whose instance the policy excludes is
- * refused HERE, naming the origin an operator has to add, and the refusal travels back on the
- * upsert ack — the control plane's own record of why this daemon will not serve the agent.
+ * §24.4 spec admission. The deployment's own code host is ADOPTED from the spec that names it —
+ * it is deployment configuration, not tenant input, and this daemon already trusts it to decide
+ * where an agent's git credential may go, so refusing to clone the same host protected nothing and
+ * made every self-managed install restate an address the control plane had already sent. What is
+ * still refused HERE is a repository somewhere else entirely: the refusal names the origin and
+ * travels back on the upsert ack, the control plane's own record of why this daemon will not serve
+ * the agent. An operator who set `workspaceGitAllowedOrigins: []` turned remote workspaces off, and
+ * nothing adopts past that.
  */
 function gitlabOriginRefusal(spec: AgentUpsert['spec']): string | undefined {
   const workspace = spec.workspace
   if (workspace?.mode !== 'gitlab') return undefined
+  adoptDeploymentCodeHost(spec.gitlabHost)
   const origin = unauthorizedWorkspaceGitOrigin(workspace.gitRepo)
   return origin === undefined
     ? undefined
-    : `workspace refused: security.workspaceGitAllowedOrigins on this daemon excludes ${origin} — add that origin to serve this GitLab instance`
+    : `workspace refused: ${origin} is neither this deployment's code host nor in security.workspaceGitAllowedOrigins on this daemon`
 }
 
 export function applyAgentUpsert(host: ConfigApplyHost, { agentId, spec }: AgentUpsert): Promise<Ack> {

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -340,7 +340,6 @@ export async function applyReconcileSnapshot(host: ConfigApplyHost, snap: Regist
 function gitlabOriginRefusal(spec: AgentUpsert['spec']): string | undefined {
   const workspace = spec.workspace
   if (workspace?.mode !== 'gitlab') return undefined
-  adoptDeploymentCodeHost(spec.gitlabHost)
   const origin = unauthorizedWorkspaceGitOrigin(workspace.gitRepo)
   return origin === undefined
     ? undefined
@@ -350,6 +349,11 @@ function gitlabOriginRefusal(spec: AgentUpsert['spec']): string | undefined {
 export function applyAgentUpsert(host: ConfigApplyHost, { agentId, spec }: AgentUpsert): Promise<Ack> {
   return host.queueAgentLifecycle(agentId, async () => {
     if (host.moveStagedAgents().has(agentId)) return { ok: false, reason: 'agent is staged for a move' }
+    // Keyed on the instance itself, not on the primary workspace: a github or scratch workspace
+    // holding a GitLab additional-repository grant carries `gitlabHost` too, and adopting only for
+    // a gitlab-mode workspace would leave that agent's clone waiting on whichever OTHER agent
+    // happened to upsert first.
+    adoptDeploymentCodeHost(spec.gitlabHost)
     const originRefusal = gitlabOriginRefusal(spec)
     if (originRefusal !== undefined) {
       host.log().warn(`cp: agent "${agentId}" ${originRefusal}`)

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -53,7 +53,7 @@ import {
 import type { LocalStore } from '../store/local-store.js'
 import type { AcpHost } from '../acp/acp-host.js'
 import type { WorkspaceManager, PrepareSessionWorkspaceRequest } from '../workspace/workspace-manager.js'
-import { adoptDeploymentCodeHost, unauthorizedWorkspaceGitOrigin } from '../workspace/git-origin-policy.js'
+import { unauthorizedWorkspaceGitOrigin } from '../workspace/git-origin-policy.js'
 import type { KeyServerClient } from '../key-server/client.js'
 import type { GitCredentialCache } from './git-credential.js'
 import type { GitCredServer } from './gitcred-server.js'
@@ -340,7 +340,7 @@ export async function applyReconcileSnapshot(host: ConfigApplyHost, snap: Regist
 function gitlabOriginRefusal(spec: AgentUpsert['spec']): string | undefined {
   const workspace = spec.workspace
   if (workspace?.mode !== 'gitlab') return undefined
-  const origin = unauthorizedWorkspaceGitOrigin(workspace.gitRepo)
+  const origin = unauthorizedWorkspaceGitOrigin(workspace.gitRepo, spec.gitlabHost)
   return origin === undefined
     ? undefined
     : `workspace refused: ${origin} is neither this deployment's code host nor in security.workspaceGitAllowedOrigins on this daemon`
@@ -349,11 +349,6 @@ function gitlabOriginRefusal(spec: AgentUpsert['spec']): string | undefined {
 export function applyAgentUpsert(host: ConfigApplyHost, { agentId, spec }: AgentUpsert): Promise<Ack> {
   return host.queueAgentLifecycle(agentId, async () => {
     if (host.moveStagedAgents().has(agentId)) return { ok: false, reason: 'agent is staged for a move' }
-    // Keyed on the instance itself, not on the primary workspace: a github or scratch workspace
-    // holding a GitLab additional-repository grant carries `gitlabHost` too, and adopting only for
-    // a gitlab-mode workspace would leave that agent's clone waiting on whichever OTHER agent
-    // happened to upsert first.
-    adoptDeploymentCodeHost(spec.gitlabHost)
     const originRefusal = gitlabOriginRefusal(spec)
     if (originRefusal !== undefined) {
       host.log().warn(`cp: agent "${agentId}" ${originRefusal}`)

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -272,11 +272,11 @@ export function createWorkspaceGit(
     return msg.split(root).join('<workspace>').trim()
   }
 
-  function safeExplicitOrigin(input: string): string | undefined {
+  function safeExplicitOrigin(input: string, deploymentCodeHost?: string): string | undefined {
     const raw = input.trim()
     if (!/^(?:https|ssh):\/\//i.test(raw) && !/^[\w.-]+@[\w.-]+:/.test(raw)) return undefined
     try {
-      return authorizeWorkspaceGitUrl(raw)
+      return authorizeWorkspaceGitUrl(raw, deploymentCodeHost)
     } catch {
       return undefined
     }
@@ -294,13 +294,14 @@ export function createWorkspaceGit(
     let currentOrigin: string | undefined
     let expectedOrigin: string
     try {
-      currentOrigin = safeExplicitOrigin(await git.raw(['remote', 'get-url', 'origin']))
       if (!target) throw new Error('workspace target is unavailable')
+      currentOrigin = safeExplicitOrigin(await git.raw(['remote', 'get-url', 'origin']), target.managed?.gitlabHost)
       // Canonicalization follows the remote's PROVIDER: only a gitlab project keeps its subgroups.
       const provider = target.remoteProvider
       const github = target.githubApp && provider !== 'gitlab'
       expectedOrigin = authorizeWorkspaceGitUrl(
-        canonicalWorkspaceGitUrl(github ? normalizeGithubRepoUrl(target.repo) : target.repo, provider)
+        canonicalWorkspaceGitUrl(github ? normalizeGithubRepoUrl(target.repo) : target.repo, provider),
+        target.managed?.gitlabHost
       )
     } catch {
       return undefined
@@ -720,7 +721,9 @@ export function createWorkspaceGit(
         // itself answers (a push with nothing to send is cheap and honest).
         const upstreamRemote = upstream.includes('/') ? upstream.slice(0, upstream.indexOf('/')) : null
         const upstreamBranch = upstreamRemote ? upstream.slice(upstreamRemote.length + 1) : null
-        const upstreamOrigin = upstreamRemote ? await remoteUrl(git, upstreamRemote) : null
+        const upstreamOrigin = upstreamRemote
+          ? await remoteUrl(git, upstreamRemote, authorized.managed?.gitlabHost)
+          : null
         const upstreamIsDestination =
           upstreamOrigin !== null &&
           upstreamOrigin.toLowerCase() === authorized.origin.toLowerCase() &&
@@ -980,11 +983,11 @@ async function pathExists(git: GitRunner, rel: string): Promise<boolean> {
 
 /** One remote's fetch URL, authorized through the same policy the origin goes through, or null
  *  when it does not exist or is not a URL this daemon may talk to. */
-async function remoteUrl(git: GitRunner, remote: string): Promise<string | null> {
+async function remoteUrl(git: GitRunner, remote: string, deploymentCodeHost?: string): Promise<string | null> {
   try {
     const raw = (await git.readBounded(['remote', 'get-url', remote], 4096)).out.toString('utf8').trim()
     if (raw === '') return null
-    return authorizeWorkspaceGitUrl(raw)
+    return authorizeWorkspaceGitUrl(raw, deploymentCodeHost)
   } catch {
     return null
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1623,7 +1623,7 @@ export class Daemon {
     // whether a spec names an instance of its own, which stays cloneable either way, is per-agent.
     if (permitsNoHttpsOrigin()) {
       this.log.warn(
-        'workspace policy: workspaceGitAllowedOrigins permits no https origin — only the instance a spec names can clone here, and an empty list not even that'
+        'workspace policy: workspaceGitAllowedOrigins lists no https origin — the only https clone left is the instance a spec names, and an empty list permits nothing at all'
       )
     }
     return { root, cfg }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1619,10 +1619,11 @@ export class Daemon {
     })
     this.cfg = cfg
     configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
-    // §24.4: an excluded origin is named at SPEC admission; only the degenerate case is known here.
+    // §24.4: an excluded origin is named at SPEC admission. All this knows is the operator list —
+    // whether a spec names an instance of its own, which stays cloneable either way, is per-agent.
     if (permitsNoHttpsOrigin()) {
       this.log.warn(
-        'workspace policy: workspaceGitAllowedOrigins permits no https origin — no managed GitLab workspace can clone on this daemon'
+        'workspace policy: workspaceGitAllowedOrigins permits no https origin — only the instance a spec names can clone here, and an empty list not even that'
       )
     }
     return { root, cfg }

--- a/packages/daemon/src/workspace/git-origin-policy.ts
+++ b/packages/daemon/src/workspace/git-origin-policy.ts
@@ -14,40 +14,41 @@ export function configureWorkspaceGitOrigins(origins: readonly string[]): void {
   allowedOrigins = origins.map(normalizeWorkspaceGitOrigin)
 }
 
-// The one code host this deployment's control plane names — deployment configuration, not tenant
-// input, and the same value that already decides which host this daemon hands an agent's git
-// credential to. Adopting it is what keeps a self-managed instance from having to be restated here.
-let deploymentCodeHostOrigin: string | undefined
-
-/** Adopt the code host a spec names, so cloning from it needs no second statement anywhere. A
- *  deployment addresses ONE GitLab instance, so the latest spec is the current answer. */
-export function adoptDeploymentCodeHost(gitlabHost: string | undefined): void {
+/** The origin form of a GitLab base URL, which may carry a path prefix (§24.1) an origin may not. */
+function codeHostOrigin(gitlabHost: string | undefined): string | undefined {
   const host = gitlabHost?.trim()
-  // Absent means this AGENT addresses GitLab.com or no GitLab at all (§24.1) — never that the
-  // deployment stopped having an instance. Leave the answer alone: with several agents on one
-  // daemon, clearing here would make the policy depend on whose spec arrived last. A disconnected
-  // instance is forgotten at restart, when nothing names it again.
-  if (!host) return
+  if (!host) return undefined
   try {
-    // The base URL may carry a path prefix (§24.1), which an origin may not: keep scheme, host, port.
     const url = new URL(gitlabManagedHost(host).baseUrl)
-    deploymentCodeHostOrigin = normalizeWorkspaceGitOrigin(`${url.protocol}//${url.host}`)
+    return normalizeWorkspaceGitOrigin(`${url.protocol}//${url.host}`)
   } catch {
-    // Not addressable as a clone origin: leave the previous answer rather than a broken one.
+    return undefined // not addressable as a clone origin; the caller's own boundary reports that
   }
 }
 
-/** The operator's list plus the deployment's own host — except when the operator turned remote
- *  workspaces off entirely, which is a decision about this daemon and not about one host. */
-function effectiveOrigins(): readonly string[] {
+/**
+ * The operator's list plus the code host THIS agent's spec names. Deployment configuration, not
+ * tenant input — the same value that already decides which host the daemon hands this agent's git
+ * credential to, so refusing to clone it protected nothing and made every self-managed install
+ * restate an address the control plane had already sent.
+ *
+ * Derived per call from the spec in hand rather than remembered: a daemon installs specs through
+ * four paths (live upsert, the register/ok snapshot, activate, a move), and a policy carried in
+ * process state is only as correct as whichever path last happened to run.
+ *
+ * An explicit empty list is a decision about this daemon — no remote Git workspaces at all — and
+ * nothing widens past it.
+ */
+function effectiveOrigins(deploymentCodeHost?: string): readonly string[] {
   if (allowedOrigins.length === 0) return allowedOrigins
-  if (!deploymentCodeHostOrigin || allowedOrigins.includes(deploymentCodeHostOrigin)) return allowedOrigins
-  return [...allowedOrigins, deploymentCodeHostOrigin]
+  const origin = codeHostOrigin(deploymentCodeHost)
+  if (!origin || allowedOrigins.includes(origin)) return allowedOrigins
+  return [...allowedOrigins, origin]
 }
 
 /** Final daemon boundary for every tenant-selected workspace network target. */
-export function authorizeWorkspaceGitUrl(input: string): string {
-  return normalizeAllowedWorkspaceGitUrl(input, effectiveOrigins())
+export function authorizeWorkspaceGitUrl(input: string, deploymentCodeHost?: string): string {
+  return normalizeAllowedWorkspaceGitUrl(input, effectiveOrigins(deploymentCodeHost))
 }
 
 /**
@@ -55,9 +56,9 @@ export function authorizeWorkspaceGitUrl(input: string): string {
  * policy admits it (§24.4). The policy is the operator's list plus the deployment's own code host,
  * so what this reports is a repository somewhere neither of them names.
  */
-export function unauthorizedWorkspaceGitOrigin(repository: string): string | undefined {
+export function unauthorizedWorkspaceGitOrigin(repository: string, deploymentCodeHost?: string): string | undefined {
   try {
-    authorizeWorkspaceGitUrl(repository)
+    authorizeWorkspaceGitUrl(repository, deploymentCodeHost)
     return undefined
   } catch {
     try {
@@ -68,8 +69,9 @@ export function unauthorizedWorkspaceGitOrigin(repository: string): string | und
   }
 }
 
-/** True when no HTTPS origin is permitted at all: managed GitLab is HTTPS-only (§13.2), so on such
- *  a daemon no GitLab instance — GitLab.com or self-managed — can ever be cloned. */
+/** True when the OPERATOR list carries no HTTPS origin. Managed GitLab is HTTPS-only (§13.2), so
+ *  such a daemon serves no GitLab instance beyond the one its own deployment names — which is a
+ *  per-agent answer this startup-time check cannot have. */
 export function permitsNoHttpsOrigin(): boolean {
-  return !effectiveOrigins().some((origin) => origin.toLowerCase().startsWith('https://'))
+  return !allowedOrigins.some((origin) => origin.toLowerCase().startsWith('https://'))
 }

--- a/packages/daemon/src/workspace/git-origin-policy.ts
+++ b/packages/daemon/src/workspace/git-origin-policy.ts
@@ -4,6 +4,7 @@ import {
   normalizeWorkspaceGitOrigin,
   workspaceGitOriginOf
 } from '@agentconnect.md/protocol'
+import { gitlabManagedHost } from '../gitcred/managed-hosts.js'
 
 // One daemon runs per process. Keep the operator-owned policy beside the
 // functional workspace helpers, like git-injection's process-local state.
@@ -13,9 +14,41 @@ export function configureWorkspaceGitOrigins(origins: readonly string[]): void {
   allowedOrigins = origins.map(normalizeWorkspaceGitOrigin)
 }
 
+// The one code host this deployment's control plane names — deployment configuration, not tenant
+// input, and the same value that already decides which host this daemon hands an agent's git
+// credential to. Adopting it is what keeps a self-managed instance from having to be restated here.
+let deploymentCodeHostOrigin: string | undefined
+
+/** Adopt the code host a spec names, so cloning from it needs no second statement anywhere. A
+ *  deployment addresses ONE GitLab instance, so the latest spec is the current answer. */
+export function adoptDeploymentCodeHost(gitlabHost: string | undefined): void {
+  const host = gitlabHost?.trim()
+  // Absent means GitLab.com (§24.1), which needs no adoption — and stops adopting whatever
+  // self-managed instance a previous spec named, so disconnecting one narrows the policy back.
+  if (!host) {
+    deploymentCodeHostOrigin = undefined
+    return
+  }
+  try {
+    // The base URL may carry a path prefix (§24.1), which an origin may not: keep scheme, host, port.
+    const url = new URL(gitlabManagedHost(host).baseUrl)
+    deploymentCodeHostOrigin = normalizeWorkspaceGitOrigin(`${url.protocol}//${url.host}`)
+  } catch {
+    // Not addressable as a clone origin: leave the previous answer rather than a broken one.
+  }
+}
+
+/** The operator's list plus the deployment's own host — except when the operator turned remote
+ *  workspaces off entirely, which is a decision about this daemon and not about one host. */
+function effectiveOrigins(): readonly string[] {
+  if (allowedOrigins.length === 0) return allowedOrigins
+  if (!deploymentCodeHostOrigin || allowedOrigins.includes(deploymentCodeHostOrigin)) return allowedOrigins
+  return [...allowedOrigins, deploymentCodeHostOrigin]
+}
+
 /** Final daemon boundary for every tenant-selected workspace network target. */
 export function authorizeWorkspaceGitUrl(input: string): string {
-  return normalizeAllowedWorkspaceGitUrl(input, allowedOrigins)
+  return normalizeAllowedWorkspaceGitUrl(input, effectiveOrigins())
 }
 
 /**
@@ -40,5 +73,5 @@ export function unauthorizedWorkspaceGitOrigin(repository: string): string | und
 /** True when no HTTPS origin is permitted at all: managed GitLab is HTTPS-only (§13.2), so on such
  *  a daemon no GitLab instance — GitLab.com or self-managed — can ever be cloned. */
 export function permitsNoHttpsOrigin(): boolean {
-  return !allowedOrigins.some((origin) => origin.toLowerCase().startsWith('https://'))
+  return !effectiveOrigins().some((origin) => origin.toLowerCase().startsWith('https://'))
 }

--- a/packages/daemon/src/workspace/git-origin-policy.ts
+++ b/packages/daemon/src/workspace/git-origin-policy.ts
@@ -23,12 +23,11 @@ let deploymentCodeHostOrigin: string | undefined
  *  deployment addresses ONE GitLab instance, so the latest spec is the current answer. */
 export function adoptDeploymentCodeHost(gitlabHost: string | undefined): void {
   const host = gitlabHost?.trim()
-  // Absent means GitLab.com (§24.1), which needs no adoption — and stops adopting whatever
-  // self-managed instance a previous spec named, so disconnecting one narrows the policy back.
-  if (!host) {
-    deploymentCodeHostOrigin = undefined
-    return
-  }
+  // Absent means this AGENT addresses GitLab.com or no GitLab at all (§24.1) — never that the
+  // deployment stopped having an instance. Leave the answer alone: with several agents on one
+  // daemon, clearing here would make the policy depend on whose spec arrived last. A disconnected
+  // instance is forgotten at restart, when nothing names it again.
+  if (!host) return
   try {
     // The base URL may carry a path prefix (§24.1), which an origin may not: keep scheme, host, port.
     const url = new URL(gitlabManagedHost(host).baseUrl)
@@ -52,10 +51,9 @@ export function authorizeWorkspaceGitUrl(input: string): string {
 }
 
 /**
- * The origin a workspace repository needs but the operator policy excludes; undefined when the
- * policy admits it (§24.4). The operator allowlist stays authoritative — the managed GitLab feature
- * allows exactly the configured origin and never widens the list — so a spec naming an excluded
- * instance is refused by NAMING the origin an operator has to add.
+ * The origin a workspace repository needs but this daemon's policy excludes; undefined when the
+ * policy admits it (§24.4). The policy is the operator's list plus the deployment's own code host,
+ * so what this reports is a repository somewhere neither of them names.
  */
 export function unauthorizedWorkspaceGitOrigin(repository: string): string | undefined {
   try {

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -328,7 +328,8 @@ export class WorkspaceManager {
       canonicalWorkspaceGitUrl(
         this.usesGithubApp(agent) ? normalizeGithubRepoUrl(agent.workspace.gitRepo) : agent.workspace.gitRepo,
         this.remoteProviderOf(agent, agent.workspace.gitRepo)
-      )
+      ),
+      agent.gitlabHost
     )
   }
 
@@ -871,7 +872,7 @@ export class WorkspaceManager {
     const normalizedCurrent = normalizeGitUrl(current)
     let unsafeCurrent = redactGitUrlSecrets(current) !== normalizedCurrent
     try {
-      authorizeWorkspaceGitUrl(current)
+      authorizeWorkspaceGitUrl(current, root.managed?.gitlabHost)
       if (!/^(?:https|ssh):\/\//i.test(current) && !/^[\w.-]+@[\w.-]+:/.test(current)) unsafeCurrent = true
     } catch {
       unsafeCurrent = true

--- a/packages/daemon/test/git-origin-policy.test.ts
+++ b/packages/daemon/test/git-origin-policy.test.ts
@@ -1,18 +1,12 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS } from '@agentconnect.md/protocol'
 import {
-  adoptDeploymentCodeHost,
   authorizeWorkspaceGitUrl,
   configureWorkspaceGitOrigins,
   permitsNoHttpsOrigin
 } from '../src/workspace/git-origin-policy.js'
 
-afterEach(() => {
-  configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
-  // Adoption is process state that only a named instance moves: park it on a host no case names,
-  // so one test's instance cannot widen the next one's.
-  adoptDeploymentCodeHost('https://adoption-parked.example.test')
-})
+afterEach(() => configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS))
 
 describe('workspace Git origin policy', () => {
   it('denies an unconfigured host at the daemon boundary', () => {
@@ -48,64 +42,45 @@ describe('workspace Git origin policy', () => {
 })
 
 describe("the deployment's own code host", () => {
+  const INSTANCE = 'https://gitlab.example.test'
+
   // It is deployment configuration, and this daemon already trusts it to decide where an agent's
   // git credential may go. Making an operator restate it bought nothing and drifted.
-  it('is cloneable once a spec names it, with nothing configured locally', () => {
-    adoptDeploymentCodeHost('https://gitlab.example.test')
-    expect(authorizeWorkspaceGitUrl('https://gitlab.example.test/team/repo.git')).toBe(
-      'https://gitlab.example.test/team/repo.git'
-    )
+  it('is cloneable when the spec in hand names it, with nothing configured locally', () => {
+    expect(authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`, INSTANCE)).toBe(`${INSTANCE}/team/repo.git`)
+    // ...and only for the spec that names it: no process state leaks to the next caller.
+    expect(() => authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`)).toThrow('git clone origin is not allowed')
   })
 
   it('admits that origin only, never anywhere else', () => {
-    adoptDeploymentCodeHost('https://gitlab.example.test/gitlab')
-    expect(authorizeWorkspaceGitUrl('https://gitlab.example.test/gitlab/team/repo.git')).toBe(
-      'https://gitlab.example.test/gitlab/team/repo.git'
+    const prefixed = 'https://gitlab.example.test/gitlab'
+    expect(authorizeWorkspaceGitUrl(`${INSTANCE}/gitlab/team/repo.git`, prefixed)).toBe(
+      `${INSTANCE}/gitlab/team/repo.git`
     )
-    expect(() => authorizeWorkspaceGitUrl('https://elsewhere.example.test/team/repo.git')).toThrow(
+    expect(() => authorizeWorkspaceGitUrl('https://elsewhere.example.test/team/repo.git', prefixed)).toThrow(
       'git clone origin is not allowed'
-    )
-  })
-
-  it('replaces the previous answer, because a deployment addresses one instance', () => {
-    adoptDeploymentCodeHost('https://first.example.test')
-    adoptDeploymentCodeHost('https://second.example.test')
-    expect(() => authorizeWorkspaceGitUrl('https://first.example.test/team/repo.git')).toThrow(
-      'git clone origin is not allowed'
-    )
-    expect(authorizeWorkspaceGitUrl('https://second.example.test/team/repo.git')).toBe(
-      'https://second.example.test/team/repo.git'
     )
   })
 
   // `[]` is a decision about this daemon — no remote workspaces at all — not about one host.
-  it('does not adopt past an explicit deny-all', () => {
+  it('does not widen past an explicit deny-all', () => {
     configureWorkspaceGitOrigins([])
-    adoptDeploymentCodeHost('https://gitlab.example.test')
-    expect(() => authorizeWorkspaceGitUrl('https://gitlab.example.test/team/repo.git')).toThrow(
+    expect(() => authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`, INSTANCE)).toThrow(
       'git clone origin is not allowed'
     )
     expect(permitsNoHttpsOrigin()).toBe(true)
   })
 
-  // Managed GitLab is HTTPS-only (§13.2), and the adopted instance counts for that check — an
-  // operator list with no https origin no longer means no GitLab workspace can ever clone here.
-  it('counts toward the https check the managed-GitLab warning reads', () => {
+  // The startup warning reads the operator list alone: whether an instance is named is per-agent.
+  it('leaves the https-only warning to the operator list', () => {
     configureWorkspaceGitOrigins(['ssh://github.com'])
-    adoptDeploymentCodeHost('https://gitlab.example.test')
-    expect(permitsNoHttpsOrigin()).toBe(false)
-    expect(authorizeWorkspaceGitUrl('https://gitlab.example.test/team/repo.git')).toBe(
-      'https://gitlab.example.test/team/repo.git'
-    )
+    expect(permitsNoHttpsOrigin()).toBe(true)
+    expect(authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`, INSTANCE)).toBe(`${INSTANCE}/team/repo.git`)
   })
 
-  // An agent without GitLab is not a statement about the deployment. Clearing here would make the
-  // policy depend on whose spec arrived last; a disconnected instance is forgotten at restart.
-  it('is left alone by a spec that names no instance', () => {
-    adoptDeploymentCodeHost('https://gitlab.example.test')
-    adoptDeploymentCodeHost(undefined)
-    expect(authorizeWorkspaceGitUrl('https://gitlab.example.test/team/repo.git')).toBe(
-      'https://gitlab.example.test/team/repo.git'
+  it('ignores a host that is not addressable as an origin', () => {
+    expect(() => authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`, 'not a url')).toThrow(
+      'git clone origin is not allowed'
     )
   })
 })

--- a/packages/daemon/test/git-origin-policy.test.ts
+++ b/packages/daemon/test/git-origin-policy.test.ts
@@ -9,7 +9,9 @@ import {
 
 afterEach(() => {
   configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
-  adoptDeploymentCodeHost(undefined)
+  // Adoption is process state that only a named instance moves: park it on a host no case names,
+  // so one test's instance cannot widen the next one's.
+  adoptDeploymentCodeHost('https://adoption-parked.example.test')
 })
 
 describe('workspace Git origin policy', () => {
@@ -86,18 +88,24 @@ describe("the deployment's own code host", () => {
     expect(permitsNoHttpsOrigin()).toBe(true)
   })
 
-  it('makes an ssh-only operator list serve managed GitLab again', () => {
+  // Managed GitLab is HTTPS-only (§13.2), and the adopted instance counts for that check — an
+  // operator list with no https origin no longer means no GitLab workspace can ever clone here.
+  it('counts toward the https check the managed-GitLab warning reads', () => {
     configureWorkspaceGitOrigins(['ssh://github.com'])
-    expect(permitsNoHttpsOrigin()).toBe(true)
     adoptDeploymentCodeHost('https://gitlab.example.test')
     expect(permitsNoHttpsOrigin()).toBe(false)
+    expect(authorizeWorkspaceGitUrl('https://gitlab.example.test/team/repo.git')).toBe(
+      'https://gitlab.example.test/team/repo.git'
+    )
   })
 
-  it('stops adopting when the deployment no longer names an instance', () => {
+  // An agent without GitLab is not a statement about the deployment. Clearing here would make the
+  // policy depend on whose spec arrived last; a disconnected instance is forgotten at restart.
+  it('is left alone by a spec that names no instance', () => {
     adoptDeploymentCodeHost('https://gitlab.example.test')
     adoptDeploymentCodeHost(undefined)
-    expect(() => authorizeWorkspaceGitUrl('https://gitlab.example.test/team/repo.git')).toThrow(
-      'git clone origin is not allowed'
+    expect(authorizeWorkspaceGitUrl('https://gitlab.example.test/team/repo.git')).toBe(
+      'https://gitlab.example.test/team/repo.git'
     )
   })
 })

--- a/packages/daemon/test/git-origin-policy.test.ts
+++ b/packages/daemon/test/git-origin-policy.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS } from '@agentconnect.md/protocol'
-import { authorizeWorkspaceGitUrl, configureWorkspaceGitOrigins } from '../src/workspace/git-origin-policy.js'
+import {
+  adoptDeploymentCodeHost,
+  authorizeWorkspaceGitUrl,
+  configureWorkspaceGitOrigins,
+  permitsNoHttpsOrigin
+} from '../src/workspace/git-origin-policy.js'
 
-afterEach(() => configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS))
+afterEach(() => {
+  configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
+  adoptDeploymentCodeHost(undefined)
+})
 
 describe('workspace Git origin policy', () => {
   it('denies an unconfigured host at the daemon boundary', () => {
@@ -32,6 +40,63 @@ describe('workspace Git origin policy', () => {
       'https://git.example:8443/acme/repo.git'
     )
     expect(() => authorizeWorkspaceGitUrl('https://git.example/acme/repo.git')).toThrow(
+      'git clone origin is not allowed'
+    )
+  })
+})
+
+describe("the deployment's own code host", () => {
+  // It is deployment configuration, and this daemon already trusts it to decide where an agent's
+  // git credential may go. Making an operator restate it bought nothing and drifted.
+  it('is cloneable once a spec names it, with nothing configured locally', () => {
+    adoptDeploymentCodeHost('https://gitlab.example.test')
+    expect(authorizeWorkspaceGitUrl('https://gitlab.example.test/team/repo.git')).toBe(
+      'https://gitlab.example.test/team/repo.git'
+    )
+  })
+
+  it('admits that origin only, never anywhere else', () => {
+    adoptDeploymentCodeHost('https://gitlab.example.test/gitlab')
+    expect(authorizeWorkspaceGitUrl('https://gitlab.example.test/gitlab/team/repo.git')).toBe(
+      'https://gitlab.example.test/gitlab/team/repo.git'
+    )
+    expect(() => authorizeWorkspaceGitUrl('https://elsewhere.example.test/team/repo.git')).toThrow(
+      'git clone origin is not allowed'
+    )
+  })
+
+  it('replaces the previous answer, because a deployment addresses one instance', () => {
+    adoptDeploymentCodeHost('https://first.example.test')
+    adoptDeploymentCodeHost('https://second.example.test')
+    expect(() => authorizeWorkspaceGitUrl('https://first.example.test/team/repo.git')).toThrow(
+      'git clone origin is not allowed'
+    )
+    expect(authorizeWorkspaceGitUrl('https://second.example.test/team/repo.git')).toBe(
+      'https://second.example.test/team/repo.git'
+    )
+  })
+
+  // `[]` is a decision about this daemon — no remote workspaces at all — not about one host.
+  it('does not adopt past an explicit deny-all', () => {
+    configureWorkspaceGitOrigins([])
+    adoptDeploymentCodeHost('https://gitlab.example.test')
+    expect(() => authorizeWorkspaceGitUrl('https://gitlab.example.test/team/repo.git')).toThrow(
+      'git clone origin is not allowed'
+    )
+    expect(permitsNoHttpsOrigin()).toBe(true)
+  })
+
+  it('makes an ssh-only operator list serve managed GitLab again', () => {
+    configureWorkspaceGitOrigins(['ssh://github.com'])
+    expect(permitsNoHttpsOrigin()).toBe(true)
+    adoptDeploymentCodeHost('https://gitlab.example.test')
+    expect(permitsNoHttpsOrigin()).toBe(false)
+  })
+
+  it('stops adopting when the deployment no longer names an instance', () => {
+    adoptDeploymentCodeHost('https://gitlab.example.test')
+    adoptDeploymentCodeHost(undefined)
+    expect(() => authorizeWorkspaceGitUrl('https://gitlab.example.test/team/repo.git')).toThrow(
       'git clone origin is not allowed'
     )
   })

--- a/packages/daemon/test/gitlab-self-managed-host.test.ts
+++ b/packages/daemon/test/gitlab-self-managed-host.test.ts
@@ -41,7 +41,11 @@ import {
   sessionGitConfig,
   daemonGitCredentialTarget
 } from '../src/workspace/git-injection.js'
-import { configureWorkspaceGitOrigins, unauthorizedWorkspaceGitOrigin } from '../src/workspace/git-origin-policy.js'
+import {
+  adoptDeploymentCodeHost,
+  configureWorkspaceGitOrigins,
+  unauthorizedWorkspaceGitOrigin
+} from '../src/workspace/git-origin-policy.js'
 
 // A prefixed, non-default-port install: the shape a relative URL root produces, and the one every
 // bare-hostname classifier gets wrong.
@@ -457,9 +461,14 @@ describe('glab target resolution against the configured instance (§13.3, §24.4
 })
 
 describe('spec-admission origin refusal (§24.4)', () => {
-  afterAll(() => configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS]))
+  afterAll(() => {
+    configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS])
+    adoptDeploymentCodeHost(undefined)
+  })
 
   it('names the origin the operator policy excludes, and admits a permitted one', () => {
+    // No instance adopted here: this is the operator list on its own.
+    adoptDeploymentCodeHost(undefined)
     configureWorkspaceGitOrigins(['https://github.com', 'https://gitlab.com'])
     expect(unauthorizedWorkspaceGitOrigin('https://gitlab.example.test:8443/gitlab/group/proj.git')).toBe(
       'https://gitlab.example.test:8443'
@@ -502,13 +511,30 @@ describe('spec-admission origin refusal (§24.4)', () => {
       }
     }) as unknown as AgentSpec
 
-  it('refuses the workspace and reports the required origin on the upsert ack', async () => {
+  // The instance is the deployment's own configuration, and this daemon already trusts it to decide
+  // where an agent's git credential may go — so admission adopts it rather than asking an operator
+  // to restate an address the control plane just sent.
+  it('admits the deployment instance with nothing configured for it', async () => {
     const { daemon, root } = await daemonWithOrigins(['https://github.com', 'https://gitlab.com'])
     try {
       const ack = await (daemon as any).cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec: gitlabSpec() })
+      expect(ack).toEqual({ ok: true })
+      expect((daemon as any).agents.get(AGENT).gitlabHost).toBe(INSTANCE)
+    } finally {
+      await daemon.stop()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  // What admission still refuses: a repository somewhere the deployment never named.
+  it('refuses a repository off the deployment instance, and names that origin on the ack', async () => {
+    const { daemon, root } = await daemonWithOrigins(['https://github.com', 'https://gitlab.com'])
+    try {
+      const spec = gitlabSpec() as unknown as { workspace: { gitRepo: string } }
+      spec.workspace.gitRepo = 'https://elsewhere.example.test/group/proj.git'
+      const ack = await (daemon as any).cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec })
       expect(ack.ok).toBe(false)
-      expect(ack.reason).toContain('https://gitlab.example.test:8443')
-      expect(ack.reason).toContain('workspaceGitAllowedOrigins')
+      expect(ack.reason).toContain('https://elsewhere.example.test')
       expect((daemon as any).agents.has(AGENT)).toBe(false)
     } finally {
       await daemon.stop()

--- a/packages/daemon/test/gitlab-self-managed-host.test.ts
+++ b/packages/daemon/test/gitlab-self-managed-host.test.ts
@@ -463,12 +463,12 @@ describe('glab target resolution against the configured instance (§13.3, §24.4
 describe('spec-admission origin refusal (§24.4)', () => {
   afterAll(() => {
     configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS])
-    adoptDeploymentCodeHost(undefined)
+    adoptDeploymentCodeHost('https://adoption-parked.example.test')
   })
 
   it('names the origin the operator policy excludes, and admits a permitted one', () => {
-    // No instance adopted here: this is the operator list on its own.
-    adoptDeploymentCodeHost(undefined)
+    // Park adoption on a host no case names: this one is about the operator list on its own.
+    adoptDeploymentCodeHost('https://adoption-parked.example.test')
     configureWorkspaceGitOrigins(['https://github.com', 'https://gitlab.com'])
     expect(unauthorizedWorkspaceGitOrigin('https://gitlab.example.test:8443/gitlab/group/proj.git')).toBe(
       'https://gitlab.example.test:8443'
@@ -520,6 +520,24 @@ describe('spec-admission origin refusal (§24.4)', () => {
       const ack = await (daemon as any).cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec: gitlabSpec() })
       expect(ack).toEqual({ ok: true })
       expect((daemon as any).agents.get(AGENT).gitlabHost).toBe(INSTANCE)
+    } finally {
+      await daemon.stop()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  // The bot's case: the instance rides `gitlabHost`, not the primary workspace mode.
+  it('adopts from a non-gitlab workspace that still names the instance', async () => {
+    const { daemon, root } = await daemonWithOrigins(['https://github.com', 'https://gitlab.com'])
+    try {
+      const spec = {
+        name: 'gh-with-gitlab-grant',
+        gitlabHost: INSTANCE,
+        workspace: { mode: 'scratch', isolation: 'shared', additionalRepos: [] }
+      } as unknown as AgentSpec
+      const ack = await (daemon as any).cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec })
+      expect(ack).toEqual({ ok: true })
+      expect(unauthorizedWorkspaceGitOrigin(`${INSTANCE}/example-group/example-project.git`)).toBeUndefined()
     } finally {
       await daemon.stop()
       rmSync(root, { recursive: true, force: true })

--- a/packages/daemon/test/gitlab-self-managed-host.test.ts
+++ b/packages/daemon/test/gitlab-self-managed-host.test.ts
@@ -41,11 +41,7 @@ import {
   sessionGitConfig,
   daemonGitCredentialTarget
 } from '../src/workspace/git-injection.js'
-import {
-  adoptDeploymentCodeHost,
-  configureWorkspaceGitOrigins,
-  unauthorizedWorkspaceGitOrigin
-} from '../src/workspace/git-origin-policy.js'
+import { configureWorkspaceGitOrigins, unauthorizedWorkspaceGitOrigin } from '../src/workspace/git-origin-policy.js'
 
 // A prefixed, non-default-port install: the shape a relative URL root produces, and the one every
 // bare-hostname classifier gets wrong.
@@ -461,14 +457,9 @@ describe('glab target resolution against the configured instance (§13.3, §24.4
 })
 
 describe('spec-admission origin refusal (§24.4)', () => {
-  afterAll(() => {
-    configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS])
-    adoptDeploymentCodeHost('https://adoption-parked.example.test')
-  })
+  afterAll(() => configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS]))
 
   it('names the origin the operator policy excludes, and admits a permitted one', () => {
-    // Park adoption on a host no case names: this one is about the operator list on its own.
-    adoptDeploymentCodeHost('https://adoption-parked.example.test')
     configureWorkspaceGitOrigins(['https://github.com', 'https://gitlab.com'])
     expect(unauthorizedWorkspaceGitOrigin('https://gitlab.example.test:8443/gitlab/group/proj.git')).toBe(
       'https://gitlab.example.test:8443'
@@ -537,7 +528,7 @@ describe('spec-admission origin refusal (§24.4)', () => {
       } as unknown as AgentSpec
       const ack = await (daemon as any).cpConfigApply().applyAgentUpsert({ agentId: AGENT, spec })
       expect(ack).toEqual({ ok: true })
-      expect(unauthorizedWorkspaceGitOrigin(`${INSTANCE}/example-group/example-project.git`)).toBeUndefined()
+      expect(unauthorizedWorkspaceGitOrigin(`${INSTANCE}/example-group/example-project.git`, INSTANCE)).toBeUndefined()
     } finally {
       await daemon.stop()
       rmSync(root, { recursive: true, force: true })


### PR DESCRIPTION
Connecting a self-managed GitLab required restating its origin on every daemon — in a config file, or in Helm values for a pool member — before a workspace on it would clone. That was redundant configuration, and it drifted: change the instance in Setup and workspaces break until someone edits a second place.

The information was already there. The control plane sends the instance in the agent spec (`gitlabHost`), and the daemon already trusts that value for something stronger — `managedHostTableFor` derives from it which host may receive an agent's **git credential**, and `git-credential.ts` serves only that host. Refusing to *clone* the one host we hand credentials to protected nothing.

The rule's own wording is what permits this: *"tenant input can never add to it."* `gitlabHost` is **deployment configuration** — written through Setup Server, stored in `deployment_config`, unreachable by a tenant. Authorizing against it is not authorizing tenant input. Per-agent repository choice stays tenant input and is still checked against the resulting host set.

## How it works

The clone policy is computed **per call, from the spec in hand** — the operator's `workspaceGitAllowedOrigins` plus the code host that agent's own specification names. Nothing is remembered between calls:

- primary repository → `agent.gitlabHost`;
- origin convergence, push/pull targets, upstream remotes → the `managed.gitlabHost` a `WorkspaceRoot` / `WorkspaceGitTarget` already carries;
- spec admission → `spec.gitlabHost`.

That makes the four paths a spec reaches a daemon through — live `agent/upsert`, the `register/ok` snapshot that installs the whole roster on every start and reconnect, `agent/activate` for a pool member's duty bundle, and a move's activation — agree without any of them having to write policy first. A spec that admission refuses changes nothing for anyone. A workspace on the deployment's instance clones with **nothing configured anywhere**, host daemon and pool member alike.

What is still refused is a repository somewhere the deployment never named:

```
workspace refused: https://elsewhere.example.test is neither this deployment's code host
nor in security.workspaceGitAllowedOrigins on this daemon
```

`workspaceGitAllowedOrigins: []` stays a decision about the daemon — no remote Git workspaces at all — and nothing widens past it. `permitsNoHttpsOrigin()` reads the operator list alone, since whether an instance is named is a per-agent fact a startup-time check cannot have.

`workspaceGitAllowedOrigins` keeps its real job — allowing something *else* (a second host, an SSH remote) or restricting — and stops being a step in connecting a self-managed instance. The env and chart value from #1484 stay as the way to set that list in a cluster.

Tests: the policy cases (admitted from the spec in hand, no leak to the next caller, origin-only, deny-all, unparseable host, the https warning) plus the spec-admission set — the old "refuses until the operator adds the origin" case became "admits the deployment instance", with new cases for a non-gitlab workspace that still names the instance and for a repository off it. Docs updated in the same change.

**Follow-up once this ships:** the four origins in this environment's overlay and the corresponding lines on the public Kubernetes page become unnecessary — I'll remove both.
