### PR TITLE
fix(daemon): render Slack streaming as a collapsed plan and keep it after the turn

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -7,8 +7,8 @@ finalization first (§7.1).
 
 Presentation was revised once after seeing it live: streams open in `plan` display mode rather
 than `timeline`, the §5.5 finalization rides `chat.stopStream` instead of a closing `chat.update`
-that was erasing the task cards, and the documented loading state was restored for the window
-before the stream has anything to show. §4, §3.3 and §5 carry those decisions.
+that was erasing the task cards, and the legacy loading row was restored and re-issued so it
+coexists with the stream that would otherwise displace it. §4, §3.3 and §5 carry those decisions.
 
 Layer 0 ([#1462](https://github.com/agentconnect-md/agentconnect/pull/1462),
 [#1471](https://github.com/agentconnect-md/agentconnect/pull/1471)) adopted Slack's Agent
@@ -275,17 +275,21 @@ express — streaming changes the _transport_ of each rung, not which rung shows
 
 ## 5. Status choreography
 
-On a streaming turn the daemon never writes the **session enum**. It does write the **loading
-text**, for exactly one window. The stream is the lifecycle; the loading state is what covers the
-gap before the stream has anything in it:
+On a streaming turn the daemon never writes the **session enum**. It writes only the **legacy
+loading text**, and it keeps that row alive for the whole turn. Live testing settled two facts a
+channel thread makes plain: the enum's loading UX and the native stop button are **DM /
+assistant-container surfaces only** — neither renders in a channel thread — and `chat.startStream`
+(and every append after it) **displaces** the legacy `assistant.threads.setStatus` row. So a
+streaming turn drives only the legacy status, with no enum and no `is_stoppable`, and it re-issues
+that status to make it coexist with the stream:
 
-| Moment                               | Today                                                                                 | Streaming                                                                       |
-| ------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `dispatch`, before the session opens | `showActivity(…, plan.startupActivityLabel)` → legacy text (+ enum, first write only) | the same legacy text and `loading_messages`, **text only** — never the enum     |
-| `openTurnChrome`                     | `showActivity(…, 'is thinking…')`                                                     | `chat.startStream` — creates the session, sets `processing`. No second write    |
-| pre-stream loading                   | (the status simply persists)                                                          | the loading text stands until the stream's first visible chunk, then one clear  |
-| each activity change                 | `set-status` → legacy text, enum deduped away                                         | `task_update` chunk on the stream; the plan card's `in_progress` is the signal  |
-| turn end (`onFinal`)                 | `set-status ''` → legacy clear + enum `active`                                        | `chat.stopStream` with the footer blocks; `session_status` defaults to `active` |
+| Moment                               | Today                                                                                 | Streaming                                                                                                                                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dispatch`, before the session opens | `showActivity(…, plan.startupActivityLabel)` → legacy text (+ enum, first write only) | the same legacy text and `loading_messages`, **text only** — never the enum                                                                                               |
+| `openTurnChrome`                     | `showActivity(…, 'is thinking…')`                                                     | `chat.startStream` — creates the session, sets `processing`. No second write                                                                                              |
+| loading, while streaming             | (the status simply persists)                                                          | startStream and each append displace the row, so it is re-issued after the stream opens and on each visible append — it then coexists with the message and its plan cards |
+| each activity change                 | `set-status` → legacy text, enum deduped away                                         | `task_update` chunk on the stream; the loading row is re-issued on the same append seam                                                                                   |
+| turn end (`onFinal`)                 | `set-status ''` → legacy clear + enum `active`                                        | `chat.stopStream` with the footer blocks; the loading text is cleared once                                                                                                |
 
 **Why the loading state came back.** The first version wrote no status of either kind and read
 well on paper — the stream is the lifecycle, so why narrate it? In practice a cold start opens a
@@ -298,20 +302,20 @@ official assistant templates both do the obvious thing instead: set the free-tex
 Three rules keep it from re-opening the one-slot conflict of §1:
 
 - **Text only, never the enum.** `chat.startStream` already set the session `processing`, and the
-  enum cannot carry custom text anyway — writing it would replace the native rendering with the
-  legacy one for nothing. The connection therefore exposes a `setLoadingStatus` that writes the
-  free text alone, and a streaming turn uses only that.
-- **One window, closed explicitly.** The status is written once, before the stream, and cleared
-  the moment the stream first shows a body chunk or a task card — not when the stream _opens_,
-  because the gap between opening and first content is the whole point. The clear has to be
-  explicit now: Slack's bridge cleared the legacy status when the app posted a message, and a
-  streaming turn no longer posts one. A turn that ends without ever showing anything clears it at
-  the terminal stop, so it cannot be left hanging.
-- **Nothing mid-turn.** After the clear, the plan card's `in_progress` state is the activity
-  signal. The applier's `set-status` case still skips while a stream is open.
+  enum's loading UX renders nothing in a channel thread anyway — writing it would only overwrite
+  the native rendering with the legacy one for nothing. The connection therefore exposes a
+  `setLoadingStatus` that writes the free text alone, and a streaming turn uses only that.
+- **Kept alive, cleared at the end.** The row is written once before the stream, then re-issued —
+  right after `chat.startStream`, and on each visible append — because both displace it. The
+  re-issue is what makes it coexist with the message and plan cards rather than vanishing on first
+  content. The clear is explicit and happens once at the terminal stop: Slack's bridge used to
+  clear the legacy status when the app posted a message, and a streaming turn no longer posts one.
+- **Uniform across rungs.** `minimal`/`low` (body-only stream) and `medium`/`high` (stream + plan
+  cards) all carry the same persistent loading row as the working signal. The applier's
+  `set-status` case still skips the enum-driving path while a stream is open.
 
-This covers the pre-stream window only, so it is independent of the separate, deferred question
-of whether `minimal`/`low` should keep a rotating status _during_ a streaming turn.
+The re-issue rides the existing send queue and activity seam — no extra timer — so the row simply
+tracks the stream it sits beside.
 
 The legacy free-text path is otherwise **retired where streaming works and kept verbatim as the
 fallback**. Nothing about `setStatus`, `setSessionLifecycle`, or their dedup map changes; on a

--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -1,9 +1,14 @@
 # Slack Native Streaming Turn Output
 
-**Status:** Implemented — ships with the PR that adds this document (Layer 1 of the
-Slack-native agent experience; Layer 0 is merged). One carve-out is deliberately still
-closed: turns on a shareable (multi-agent) bot keep the legacy pipeline until §10 Q1 is
-verified live (§7.1).
+**Status:** Implemented and shipped (Layer 1 of the Slack-native agent experience; Layer 0 is
+merged). One carve-out is deliberately still closed: turns on a shareable (multi-agent) bot keep
+the legacy pipeline, and lifting it now requires teaching ingress to read a stop-time
+finalization first (§7.1).
+
+Presentation was revised once after seeing it live: streams open in `plan` display mode rather
+than `timeline`, the §5.5 finalization rides `chat.stopStream` instead of a closing `chat.update`
+that was erasing the task cards, and the documented loading state was restored for the window
+before the stream has anything to show. §4, §3.3 and §5 carry those decisions.
 
 Layer 0 ([#1462](https://github.com/agentconnect-md/agentconnect/pull/1462),
 [#1471](https://github.com/agentconnect-md/agentconnect/pull/1471)) adopted Slack's Agent
@@ -126,11 +131,8 @@ Everything that is _chrome around the answer_ rather than the answer:
 - **Transcript.** The paired `recordOnly` posts and `appendTranscript` rows are emitted exactly as
   today. The stream is display; the transcript is the record.
 - **Permalinks** (`workspaceUrl`), thread coordinates, `protectedAddresses` splitting.
-- **§5.5 response finalization.** `finalizeResponse` still issues its closing `chat.update` on the
-  streamed message's `ts`, carrying `delivery_state: 'final'` and the recipient set resolved from
-  the complete response. This is load-bearing: relay and Socket Mode ingress recognise an agent's
-  finished answer by _that edit_, so replacing it with stop-time metadata would silently break
-  agent-to-agent routing over Slack. §7 Q1 makes verifying it a merge gate.
+- **§5.5 response finalization** — but **carried by the stop, not by a follow-up edit.** See
+  below; this is the one item in this list that streaming genuinely changes.
 
 ### 3.3 The attribution footer gets simpler
 
@@ -145,6 +147,24 @@ where two messages carry a footer. It stays for the fallback path, and `onSettle
 This satisfies
 [`product-conventions.md` §"Slack message attribution footer"](../product-conventions.md) — the
 footer is attached to the final message of the response and is never a separate message.
+
+**And §5.5's finalization rides the same stop.** The original plan kept the closing `chat.update`
+on the streamed message, carrying `delivery_state: 'final'` and the resolved recipient set. That
+turned out to be the single most destructive call in the pipeline: `chat.update` **replaces** a
+message's whole content, so it wiped every task card the turn had rendered and left the answer
+marked "(edited)". `chat.stopStream` takes both of the things that edit was for — `blocks`, which
+are appended below everything already streamed rather than replacing it, and `metadata` — so the
+final delivery state is stamped at stop time and no edit is issued at all. The samples corroborate
+the shape: none of them calls `chat.update` on a streamed message.
+
+**Why that is safe to do now, and what the carve-out lift owes.** Nothing reads the finalization
+event except agent-to-agent routing, and A2A happens only on shareable bots — which §7.1 keeps
+off the streaming path entirely. So today no consumer can miss it. That makes it a **prerequisite
+of lifting the carve-out**, not an afterthought: before a shareable bot may stream, relay and
+Socket Mode ingress must first learn to recognise the finalization from stop-time metadata, since
+the `message_changed` edit they key on today will no longer be emitted. Until then the two facts
+hold each other up — the carve-out is what makes stop-carried finalization safe, and teaching
+ingress is what makes the carve-out liftable.
 
 ### 3.4 Length and continuation
 
@@ -205,29 +225,49 @@ All streaming calls go through the connection's single `PlatformSendQueue` (350 
 ## 4. ACP → stream mapping
 
 Slack's streaming chunk vocabulary — as the resolved SDK declares it, see §10 Q3 — is
-`{ type: 'markdown_text', text }`, `{ type: 'task_update', id, title, status, details? }`
+`{ type: 'markdown_text', text }`, `{ type: 'task_update', id, title, status, details?, output? }`
 (256 chars, status `pending` | `in_progress` | `complete` | `error`),
 `{ type: 'plan_update', title }` and `{ type: 'blocks', blocks }`.
 
-| ACP `session/update`             | today                                                  | streaming                                                                                                                                                                                                               |
-| -------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent_message_chunk`            | buffered → `post` / `live-reply`                       | appended as `markdown_text` (coalesced, §3.5)                                                                                                                                                                           |
-| `tool_call` / `tool_call_update` | in-place `progress` message + rotating status text     | `medium`/`high`: `task_update` keyed by `toolCallId`; ACP `pending`/`in_progress` → `in_progress`, `completed` → `complete`, `failed` → `error`. `minimal`/`low`: nothing, as today                                     |
-| `agent_thought_chunk`            | `high`: in-place Thinking message; others: status text | `medium`/`high`: one `task_update` per thinking run (`title: "Thinking"`, `details` = newest clamped line). `high` additionally keeps its full in-place Thinking message — 2,800 characters do not fit a 256-char chunk |
-| `plan`                           | in-place `plan` message                                | unchanged (see below)                                                                                                                                                                                                   |
-| tool output, terminal (`high`)   | separate code-block message                            | unchanged                                                                                                                                                                                                               |
-| `usage_update`                   | dropped                                                | dropped                                                                                                                                                                                                                 |
+**The fields do not all behave the same way, and that is the single most load-bearing fact
+here.** `title` and `status` REPLACE per card id — re-send them as often as you like. `details`
+**appends** server-side, and `output` is written once at completion. Refreshing an appending
+field per update therefore concatenates on Slack's side instead of replacing it: streaming a
+thinking line into `details` on every chunk is what ran repeated `**bold**` fragments together
+into literal `****`, since card fields render as plain text and never interpret emphasis. The
+rule this design follows is **write-once for anything that appends**: `output` at completion,
+`details` at most once per card, and everything else expressed through `title`/`status`.
 
-**`task_display_mode`.** `timeline` (the default) "renders task updates as individual task cards
-interleaved with streamed text" — that is precisely a stream of ACP tool calls, which arrive
-interleaved with the answer and are append-only. `plan` renders the updates together as one
-checklist block — that is precisely an ACP `plan`, which resends the full entry list with
-per-entry statuses on every update.
+| ACP `session/update`             | today                                                  | streaming                                                                                                                                                                                                                                     |
+| -------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_message_chunk`            | buffered → `post` / `live-reply`                       | appended as `markdown_text` (coalesced, §3.5)                                                                                                                                                                                                 |
+| `tool_call` / `tool_call_update` | in-place `progress` message + rotating status text     | `medium`/`high`: `task_update` keyed by `toolCallId`; ACP `pending`/`in_progress` → `in_progress`, `completed` → `complete`, `failed` → `error`; the tool's result written ONCE as `output` at completion. `minimal`/`low`: nothing, as today |
+| `agent_thought_chunk`            | `high`: in-place Thinking message; others: status text | `medium`/`high`: one `task_update` per thinking run, `title: "Thinking"` and status only — no per-line detail, because that field appends. `high` keeps its full in-place Thinking message, which is where 2,800 characters belong anyway     |
+| `plan`                           | in-place `plan` message                                | unchanged (see below)                                                                                                                                                                                                                         |
+| tool output, terminal (`high`)   | separate code-block message                            | unchanged                                                                                                                                                                                                                                     |
+| `usage_update`                   | dropped                                                | dropped                                                                                                                                                                                                                                       |
 
-The catch is that `task_display_mode` is a `chat.startStream` argument, and a turn does not know
-at start whether the runtime will ever emit a plan. So: **open every stream in `timeline`, and
-leave the ACP plan on its existing separate in-place message.** Moving it into `plan_update`
-chunks is a follow-up gated on §7 Q4, not a prerequisite.
+**`task_display_mode`: `plan`, not `timeline`.** The first version reasoned from the names —
+`timeline` "renders task updates as individual task cards interleaved with streamed text", which
+sounded like a stream of ACP tool calls — and shipped that. Seeing it rendered settled the
+question the other way: flat, separate cards bury the answer under a column of tool chrome, and
+what a reader wants is the answer with the activity folded away.
+
+`plan` is that shape. Every task card is collected into ONE collapsed-by-default container, and
+`{ type: 'plan_update', title }` is the line printed on it. So the container gets a small arc of
+its own:
+
+- **while working** — a generic honest label (`Working…`), written once when the stream opens;
+- **at the terminal stop** — a counted summary: `Completed 3 steps`, `Completed 3 steps · 1
+failed`, or `Done` when the turn ran no steps at all.
+
+Counted rather than narrated, deliberately: it is derived from the cards the turn actually
+emitted, so it needs no second model call and cannot disagree with what is inside the container.
+`minimal` and `low` open no container and get no label — they stream body text alone.
+
+The ACP `plan` keeps its existing separate in-place message. That is now a stronger decision than
+it was: the container's label is one plain-text line, and an ACP plan is a full entry list with
+per-entry statuses that it resends on every update, which is a checklist, not a label.
 
 **Output modes.** `none` never streams (transcript only, unchanged). `minimal` and `low` stream
 body text only. `medium` and `high` add task chunks. This is the same ladder the modes already
@@ -235,21 +275,47 @@ express — streaming changes the _transport_ of each rung, not which rung shows
 
 ## 5. Status choreography
 
-On a streaming turn the daemon makes **no status call of either kind**. The stream is the
-lifecycle:
+On a streaming turn the daemon never writes the **session enum**. It does write the **loading
+text**, for exactly one window. The stream is the lifecycle; the loading state is what covers the
+gap before the stream has anything in it:
 
 | Moment                               | Today                                                                                 | Streaming                                                                       |
 | ------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `dispatch`, before the session opens | `showActivity(…, plan.startupActivityLabel)` → legacy text (+ enum, first write only) | nothing                                                                         |
-| `openTurnChrome`                     | `showActivity(…, 'is thinking…')`                                                     | `chat.startStream` — creates the session, sets `processing`                     |
-| each activity change                 | `set-status` → legacy text, enum deduped away                                         | `task_update` chunk on the stream                                               |
+| `dispatch`, before the session opens | `showActivity(…, plan.startupActivityLabel)` → legacy text (+ enum, first write only) | the same legacy text and `loading_messages`, **text only** — never the enum     |
+| `openTurnChrome`                     | `showActivity(…, 'is thinking…')`                                                     | `chat.startStream` — creates the session, sets `processing`. No second write    |
+| pre-stream loading                   | (the status simply persists)                                                          | the loading text stands until the stream's first visible chunk, then one clear  |
+| each activity change                 | `set-status` → legacy text, enum deduped away                                         | `task_update` chunk on the stream; the plan card's `in_progress` is the signal  |
 | turn end (`onFinal`)                 | `set-status ''` → legacy clear + enum `active`                                        | `chat.stopStream` with the footer blocks; `session_status` defaults to `active` |
 
-The legacy free-text path is **retired where streaming works and kept verbatim as the fallback**.
-Concretely: `showActivity` and the applier's `set-status` case each grow one guard — _is a stream
-open for this turn?_ — and skip the write if so. Nothing about `setStatus`,
-`setSessionLifecycle`, or their dedup map changes; on a non-streaming turn they run exactly as
-they do today.
+**Why the loading state came back.** The first version wrote no status of either kind and read
+well on paper — the stream is the lifecycle, so why narrate it? In practice a cold start opens a
+visible empty bubble and then shows nothing until the first token, which is a blank wait exactly
+where a user most wants a sign of life.
+[Slack's own loading-state guidance](https://docs.slack.dev/ai/developing-agents) and the
+official assistant templates both do the obvious thing instead: set the free-text status with
+`loading_messages` while working, and let the message carry the content. So does this design now.
+
+Three rules keep it from re-opening the one-slot conflict of §1:
+
+- **Text only, never the enum.** `chat.startStream` already set the session `processing`, and the
+  enum cannot carry custom text anyway — writing it would replace the native rendering with the
+  legacy one for nothing. The connection therefore exposes a `setLoadingStatus` that writes the
+  free text alone, and a streaming turn uses only that.
+- **One window, closed explicitly.** The status is written once, before the stream, and cleared
+  the moment the stream first shows a body chunk or a task card — not when the stream _opens_,
+  because the gap between opening and first content is the whole point. The clear has to be
+  explicit now: Slack's bridge cleared the legacy status when the app posted a message, and a
+  streaming turn no longer posts one. A turn that ends without ever showing anything clears it at
+  the terminal stop, so it cannot be left hanging.
+- **Nothing mid-turn.** After the clear, the plan card's `in_progress` state is the activity
+  signal. The applier's `set-status` case still skips while a stream is open.
+
+This covers the pre-stream window only, so it is independent of the separate, deferred question
+of whether `minimal`/`low` should keep a rotating status _during_ a streaming turn.
+
+The legacy free-text path is otherwise **retired where streaming works and kept verbatim as the
+fallback**. Nothing about `setStatus`, `setSessionLifecycle`, or their dedup map changes; on a
+non-streaming turn they run exactly as they do today.
 
 Per-agent authorship moves to where it belongs. `username` / `icon_url` / `icon_emoji` are
 per-message arguments on `chat.startStream`, populated from the same
@@ -450,21 +516,26 @@ the large majority of installs (dedicated bots), and one live check on a shareab
 whether the carve-out is lifted. Until then the risk is bounded to _no change_ — a shareable bot
 behaves exactly as it does today.
 
-Two properties make this honest rather than a permanent hedge:
+It gates on the codebase's **existing** shareable predicate — the same
+`platformIntegrationConfig('slack', …).shareable` fact that decides whether the status bar offers
+"Switch agent" — not on a new flag invented for this change. Nothing new becomes configurable, so
+nothing new can acquire callers and become permanent.
 
-- It gates on the codebase's **existing** shareable predicate — the same
-  `platformIntegrationConfig('slack', …).shareable` fact that decides whether the status bar
-  offers "Switch agent" — not on a new flag invented for this change. Nothing new becomes
-  configurable, so nothing new can acquire callers and become permanent.
-- The closing edit is **still issued on every streaming turn**. Skipping it on the streamed path
-  would leave nothing to verify; issuing it is what makes the follow-up a measurement rather
-  than another round of speculation.
+**The carve-out has since become load-bearing for a second reason, and that raised its lift
+price.** §3.3 moved the §5.5 finalization onto `chat.stopStream`, because the closing
+`chat.update` it replaced was erasing the task cards. That means a streamed turn no longer emits
+the `message_changed` event ingress keys on. Harmless today — the only consumer is A2A routing,
+which happens only on shareable bots, which do not stream — but it makes the lift a two-part
+change, in order:
 
-The follow-up is one line plus its test: delete the predicate from the eligibility check once a
-live shareable-bot turn is observed to route. If instead the edit turns out to be rejected or
-invisible, the carve-out stops being temporary and this section becomes its permanent
-justification — which is the same outcome §10 Q1 already recommended, reached without blocking
-the rest.
+1. **Teach relay and Socket Mode ingress to recognise a finalization from stop-time metadata**,
+   alongside the edit they read today.
+2. **Then** delete the predicate from the eligibility check.
+
+Doing (2) without (1) would silently stop agent-to-agent routing on exactly the bots that use it.
+So the lift is no longer "one line plus its test" — the line is still one line, but it is the
+second of two changes, and the first belongs to the ingress seam this design otherwise leaves
+alone.
 
 **SDK note.** `@slack/web-api` resolves to 8.0.0 in this workspace, and — checked against the
 resolved package, not assumed — it **does** type all three methods (`chat.startStream`,
@@ -563,10 +634,13 @@ eval guard.
 ingress needs?** §5.5 routing depends on the closing edit being _seen_: relay and Socket Mode both
 recognise a finished agent answer by `normalizeSlackResponseFinalization` on that edit, and
 without it agent-to-agent mentions over Slack stop resolving. Undocumented either way.
-_Resolved as a rollout decision, not a merge gate:_ §7.1 ships the shareable-bot carve-out up
-front, so the only population a wrong answer could hurt never streams. The closing edit is still
-issued on every streaming turn, so the live check has something to observe. Verify post-deploy;
-lift the carve-out in a follow-up if it routes, keep it permanently if it does not.
+_Resolved, and then made moot._ §7.1 ships the shareable-bot carve-out up front, so the only
+population a wrong answer could hurt never streams. Seeing the edit run in a real workspace then
+answered the question in the worst way available: it works, and it is destructive — `chat.update`
+replaces the message wholesale, erasing every task card and marking the answer "(edited)". So the
+edit is gone from the streamed path entirely (§3.3), and what replaces it is stop-time metadata.
+The open question is no longer "does the edit survive" but "can ingress read a finalization that
+never arrives as an edit" — see §7.1, where it is now the first half of the carve-out lift.
 
 **Q2. What is the accumulated-length cap of a streamed message, and does `chat.stopStream` accept
 `session_status: "processing"`?** The 12,000 figure is documented per call, not per message;
@@ -590,10 +664,11 @@ details?, output?, sources? }`, alongside `{ type: 'markdown_text', text }`. So 
 still ride the same per-error degrade as everything else, so a shape Slack later rejects costs the
 task cards, not the answer.
 
-**Q4. Can `task_display_mode` change mid-stream?** It is a `chat.startStream` argument, and a turn
-cannot know at start whether its runtime will emit an ACP plan. _Recommended:_ open every stream in
-`timeline`, leave the ACP plan on its existing separate in-place message, and revisit moving it to
-`plan_update` chunks only if a mid-stream switch turns out to be supported.
+**Q4. Can `task_display_mode` change mid-stream?** _Answered, and the question turned out not to
+matter._ Every stream now opens in `plan` (§4), which is the mode we want for the whole turn, so
+nothing needs to switch. `plan_update` is used for the container's own label, not for the ACP
+plan, which keeps its separate in-place message — a full entry list with per-entry statuses is a
+checklist, and the container's label is one plain-text line.
 
 **Q5. On the fallback path, keep main's current enum-last order, or land #1478's reorder?** Once
 streaming ships, the legacy path runs only where streaming is impossible — and #1478's order means

--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -36,6 +36,7 @@ const EXEMPT: Record<string, string> = {
   postIfThreadExists: 'private Slack root-existence guard',
   postChatMessage: 'private shared post boundary behind postMessage/postBlocks',
   setSessionLifecycle: 'private agent-session lifecycle call, behind setStatus',
+  writeLoadingStatus: 'private free-text status write, behind setStatus/setLoadingStatus',
   noteStreamFailure: 'private streaming error classification, behind the startTurnStream trio',
   closeStream: 'private streaming handle bookkeeping, behind the startTurnStream trio',
   agentSessionStopped: 'native stop button (Bolt event / relay-forwarded), no arena equivalent',

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9998,9 +9998,17 @@ export class Daemon {
     // created) plus any usage carried over from prior turns — so it sits at the top of
     // the thread before the reply streams in, and above the stream opened next.
     await this.emitStatusBar(p)
+    // Stash the loading snapshot the applier re-issues to keep the legacy row alive beside the
+    // stream (startStream and every append displace it, §5) — before the stream opens, so the
+    // stream-start re-issue can read it.
+    if (this.streamsTurnStatus(p.conv))
+      turnState<SlackTurnState>(p).loadingStatus = {
+        text: plan.startupActivityLabel,
+        ...(plan.statusOptions ? { options: plan.statusOptions } : {})
+      }
     const streaming = this.streamsTurnStatus(p.conv) && (await this.openSlackTurnStream(p))
-    // A streaming turn already wrote its loading state at dispatch and keeps it until the
-    // stream has something to show, so it takes no second write here.
+    // A streaming turn already wrote its loading state at dispatch and re-issues it beside the
+    // stream, so it takes no second write here.
     if (!streaming && !plan.hostAlreadyRunning)
       this.showActivity(replyConn, plan.channel, plan.statusThread, 'is thinking…', plan.statusOptions)
     // Config-file secrets deleted by the idle sweep come back BEFORE the turn

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9273,10 +9273,17 @@ export class Daemon {
     // provably no output yet.
     if (conv instanceof OutputConverger && this.slackStreamingEligible(plan, entry, replyConn)) conv.enableStreaming()
     const run: TurnRun = { entry, key, plan, agent, replyConn, evaluation, conv }
-    // A streaming turn makes no status call of either kind (§5) — including this one: the
-    // stream itself creates the session and sets it processing.
-    if (!this.streamsTurnStatus(conv))
-      this.showActivity(replyConn, msg.channel, plan.statusThread, plan.startupActivityLabel, plan.statusOptions)
+    // The documented loading state, on every turn including a streaming one: it covers the
+    // window before the stream has anything to show, which is otherwise a blank wait (§5).
+    // On a streaming turn it is TEXT only — the enum belongs to `chat.startStream`.
+    this.showActivity(
+      replyConn,
+      msg.channel,
+      plan.statusThread,
+      plan.startupActivityLabel,
+      plan.statusOptions,
+      this.streamsTurnStatus(conv)
+    )
     const releaseReplyConn = this.holdReplyConnection(replyConn)
     const opened = await this.openSession(run, releaseReplyConn)
     if (opened.kind === 'cancelled') return null
@@ -9376,8 +9383,16 @@ export class Daemon {
 
   /** Clear this turn's transient platform activity indicator ("is thinking…"). */
   private clearTurnActivity(run: TurnRun): void {
-    if (this.streamsTurnStatus(run.conv)) return
-    this.showActivity(run.replyConn, run.plan.channel, run.plan.statusThread, '')
+    // A streaming turn clears the TEXT — its loading state does not expire on its own now that
+    // the answer no longer arrives through chat.postMessage — but never the session enum.
+    this.showActivity(
+      run.replyConn,
+      run.plan.channel,
+      run.plan.statusThread,
+      '',
+      undefined,
+      this.streamsTurnStatus(run.conv)
+    )
   }
 
   /** Does this turn own the platform's status slot through a native stream? Slack's two
@@ -9983,11 +9998,10 @@ export class Daemon {
     // created) plus any usage carried over from prior turns — so it sits at the top of
     // the thread before the reply streams in, and above the stream opened next.
     await this.emitStatusBar(p)
-    const intended = this.streamsTurnStatus(p.conv)
-    const streaming = intended && (await this.openSlackTurnStream(p))
-    // A turn that meant to stream and could not shows the indicator even on a warm host:
-    // dispatch skipped its own write on the strength of that intent (§7 degrade).
-    if (!streaming && (!plan.hostAlreadyRunning || intended))
+    const streaming = this.streamsTurnStatus(p.conv) && (await this.openSlackTurnStream(p))
+    // A streaming turn already wrote its loading state at dispatch and keeps it until the
+    // stream has something to show, so it takes no second write here.
+    if (!streaming && !plan.hostAlreadyRunning)
       this.showActivity(replyConn, plan.channel, plan.statusThread, 'is thinking…', plan.statusOptions)
     // Config-file secrets deleted by the idle sweep come back BEFORE the turn
     // reaches the child — synchronous, so the guarantee is ordering, not timing.
@@ -11017,10 +11031,16 @@ export class Daemon {
       // Platform suppression teardown (§7.3): Feishu stops its stream timer and
       // cancels the CardKit entity. Exact lookup — no core fallback.
       this.turnSurfaces.exact(live.plan.platform)?.onSuppress?.(live)
-      // A streaming turn's stop settles the message and releases the session by itself; a
-      // status write here would be the one call §5 says a streaming turn never makes.
-      if (!this.streamsTurnStatus(live.conv))
-        this.showActivity(live.conn, live.plan.channel, live.plan.statusThread, '')
+      // Clear the loading text; on a streaming turn the stop owns the session enum, so this
+      // must not drive it (§5).
+      this.showActivity(
+        live.conn,
+        live.plan.channel,
+        live.plan.statusThread,
+        '',
+        undefined,
+        this.streamsTurnStatus(live.conv)
+      )
       if (live.webchat && !live.webchat.doneSent) {
         live.webchat.doneSent = true
         live.webchat.sink.done({
@@ -11219,21 +11239,17 @@ export class Daemon {
    * Recipients come from the COMPLETE response and are resolved against the
    * CONVERSATION's directory — the same bidirectional mapping the target will use — so
    * author and target cannot disagree about who was addressed.
+   *
+   * Runs only for a turn whose answer took the ordinary post boundary. A streamed turn closes
+   * its own response on `chat.stopStream` instead (see {@link resolveSlackFinalization}).
    */
   private async closeSlackResponse(p: Pending): Promise<void> {
     if (!p.conn) return
+    // A streamed answer was finalized in place by its own `chat.stopStream`. Editing it again
+    // would replace the whole message — losing every task card and marking it "(edited)".
+    if (turnState<SlackTurnState>(p).streamFinalized) return
     const orgId = this.cpCollab.orgForAgent(p.plan.agentId)
-    const recipients = orgId
-      ? resolveSlackMentionedAgents(
-          p.reply.text,
-          this.cpCollab.mentionDirectory(orgId, p.plan.platform, p.plan.channel)
-        ).filter((id) => id !== p.plan.agentId)
-      : []
-    // Whether the answer addressed ANYONE is read from the complete reply text, not
-    // from the final section: §2.3 makes any address binding, and the splitter may
-    // have put the only mention in section one. Without this the same answer would
-    // wake a peer or not depending on where the cut landed.
-    const addressedAnyone = slackTextAddressesAnyone(p.reply.text)
+    const { mentionedAgentIds: recipients, addressedAnyone } = this.resolveSlackFinalization(p)
     // What this response RESOLVED to, at the one place the author still knows it.
     // Everything downstream (relay arbitration, the target's ladder) sees only the
     // outcome, so without this a response that addressed a peer but resolved to no
@@ -11250,6 +11266,26 @@ export class Daemon {
     await finalizeSlackResponse(p.conn as SlackConnection, p, recipients, addressedAnyone, (m) => this.log.debug(m))
   }
 
+  /**
+   * Who this turn's COMPLETE response addressed (send-message-routing-rework.md §5.5).
+   *
+   * Shared by both ways a response can be closed: the legacy follow-up edit, and a streamed
+   * turn's own `chat.stopStream`. `addressedAnyone` is read from the whole reply text, not the
+   * final section — §2.3 makes any address binding, and the splitter may have put the only
+   * mention in section one, so reading the tail alone would make the same answer wake a peer
+   * or not depending on where the cut landed.
+   */
+  private resolveSlackFinalization(p: Pending): { mentionedAgentIds: string[]; addressedAnyone: boolean } {
+    const orgId = this.cpCollab.orgForAgent(p.plan.agentId)
+    const mentionedAgentIds = orgId
+      ? resolveSlackMentionedAgents(
+          p.reply.text,
+          this.cpCollab.mentionDirectory(orgId, p.plan.platform, p.plan.channel)
+        ).filter((id) => id !== p.plan.agentId)
+      : []
+    return { mentionedAgentIds, addressedAnyone: slackTextAddressesAnyone(p.reply.text) }
+  }
+
   /** Slack's turn output lives in its platform module (§7.3) — and doubles as the
    *  CORE surface every non-platform origin (webchat / hook / dream) renders through.
    *  Core supplies the transcript + status-bar-anchor capabilities and the opaque
@@ -11263,7 +11299,8 @@ export class Daemon {
         setStatusBarTs: async (sessionKey, ts) => await this.store.setStatusBarTs(sessionKey, ts),
         clearStatusBarTs: async (sessionKey) => await this.store.clearStatusBarTs(sessionKey),
         monotonicTs: () => monotonicTs(),
-        debug: (message) => this.log.debug(message)
+        debug: (message) => this.log.debug(message),
+        resolveFinalization: (turn) => this.resolveSlackFinalization(turn as Pending)
       },
       p,
       turnState<SlackTurnState>(p),
@@ -11664,15 +11701,23 @@ export class Daemon {
     channel: string,
     thread: string,
     text: string,
-    slackStatusOptions?: SlackStatusOptions
+    slackStatusOptions?: SlackStatusOptions,
+    streaming = false
   ): void {
     if (!conn) return
     // Duck-type by method (so test fakes work): Slack has setStatus ('' clears the bar);
     // Telegram/Discord have sendChatAction (a self-expiring "typing…", so a clear is a no-op).
     const slack = conn as Partial<SlackConnection>
     if (typeof slack.setStatus === 'function') {
-      if (text && slackStatusOptions) void slack.setStatus(channel, thread, text, undefined, slackStatusOptions)
-      else void slack.setStatus(channel, thread, text)
+      // A streaming turn writes the loading TEXT but never the session enum: `chat.startStream`
+      // already set the session processing, and the enum would replace the native rendering
+      // with the legacy one (§5). Everything else keeps both halves.
+      const write =
+        streaming && typeof slack.setLoadingStatus === 'function'
+          ? slack.setLoadingStatus.bind(slack)
+          : slack.setStatus.bind(slack)
+      if (text && slackStatusOptions) void write(channel, thread, text, undefined, slackStatusOptions)
+      else void write(channel, thread, text)
     } else if (text && typeof (conn as Partial<TelegramConnection>).sendChatAction === 'function')
       void (conn as TelegramConnection).sendChatAction(channel)
   }

--- a/packages/daemon/src/evaluation/virtual-connections.ts
+++ b/packages/daemon/src/evaluation/virtual-connections.ts
@@ -407,6 +407,9 @@ export class VirtualSlackConnection implements PlatformConnection {
   /** Ephemeral presence (assistant status) — not a message; not recorded. */
   async setStatus(): Promise<void> {}
 
+  /** The loading-state half of the same presence, for streaming turns. Equally ephemeral. */
+  async setLoadingStatus(): Promise<void> {}
+
   async setTitle(): Promise<void> {}
 
   /**

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -74,6 +74,11 @@ export interface SlackTurnState {
   /** Whether this turn's loading state has been cleared. A streaming turn owes exactly one
    *  clear: nothing expires it now that the answer no longer arrives through chat.postMessage. */
   streamLoadingCleared?: boolean
+  /** The legacy free-text loading row re-issued to keep it visible beside the stream.
+   *  `chat.startStream` and every append DISPLACE the row (confirmed live), so a streaming turn
+   *  re-writes this snapshot after the stream opens and on each visible append, clearing it only
+   *  at turn end (§5). Text only — the enum belongs to the stream. */
+  loadingStatus?: { text: string; loadingMessages?: string[]; options?: SlackStatusOptions }
   /** A stop Slack has not accepted yet, kept verbatim so settlement reissues THAT stop: a
    *  bare abort retry would settle the message but drop its attribution footer. */
   streamStopOwed?: Extract<SlackAction, { kind: 'stream-stop' }>
@@ -426,14 +431,34 @@ function streamChunkText(chunks: SlackStreamChunk[]): string {
 
 /**
  * Clear the turn's loading state, once. Text only — the session enum belongs to the stream
- * (§5) — and idempotent, because the seams that can end the pre-stream window (first visible
- * append, terminal stop, teardown) all reach this and only the first one owes Slack a call.
+ * (§5) — and idempotent, because the seams that end the streaming turn (terminal stop, teardown)
+ * all reach this and only the first one owes Slack a call.
  */
 async function clearStreamLoading(conn: SlackConnection, p: SlackTurn, state: SlackTurnState): Promise<void> {
   if (state.streamLoadingCleared || !p.plan.statusThread) return
   state.streamLoadingCleared = true
   if (typeof conn.setLoadingStatus !== 'function') return
   await conn.setLoadingStatus(p.plan.channel, p.plan.statusThread, '')
+}
+
+/**
+ * Re-issue the legacy loading row so it survives beside the stream. `chat.startStream` and every
+ * append DISPLACE the row (confirmed live), so a streaming turn re-writes the stashed snapshot
+ * right after the stream opens and on each visible append; it coexists with the streamed message
+ * and its plan cards. Best-effort, text only (never the enum, §5), and a no-op once the terminal
+ * clear has run so a late append cannot resurrect the row.
+ */
+async function reissueStreamLoading(conn: SlackConnection, p: SlackTurn, state: SlackTurnState): Promise<void> {
+  const loading = state.loadingStatus
+  if (!loading || state.streamLoadingCleared || !p.plan.statusThread) return
+  if (typeof conn.setLoadingStatus !== 'function') return
+  await conn.setLoadingStatus(
+    p.plan.channel,
+    p.plan.statusThread,
+    loading.text,
+    loading.loadingMessages,
+    loading.options
+  )
 }
 
 /** Route display text to the fallback buffer, opening it if needed, and record ownership the
@@ -718,6 +743,8 @@ export async function applySlackAction<TTurn extends SlackTurn>(
         // carries today, under the same chat:write.customize cooldown (§5).
         ...(statusBarPostOptions ? { identity: statusBarPostOptions } : {})
       })
+      // startStream displaces the legacy loading row — re-issue it so it stays visible (§5).
+      if (state.stream) await reissueStreamLoading(conn, p, state)
       return
     }
     case 'stream-append': {
@@ -735,10 +762,10 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       if (!state.stream) return
       const outcome = await conn.appendTurnStream(state.stream, action.chunks)
       if (outcome === 'ok') {
-        // The stream now has something to look at, so the loading state has done its job (§5).
-        // Cleared here rather than at stream open: the gap between the two is the blank wait
-        // the loading state exists to cover.
-        if (action.chunks.some((c) => c.type !== 'plan_update')) await clearStreamLoading(conn, p, state)
+        // The append displaces the legacy loading row, so re-issue it on this activity seam to
+        // keep it beside the stream (§5) — the plan container's own label is not content, so a
+        // plan-only append never re-issues. Cleared only at turn end / stop, not on first content.
+        if (action.chunks.some((c) => c.type !== 'plan_update')) await reissueStreamLoading(conn, p, state)
         return
       }
       if (outcome === 'stopped') {

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -68,6 +68,12 @@ export interface SlackTurnState {
    *  attributed message. One-way for the turn — once the fallback owns the response, nothing
    *  hands it back. */
   streamResponseMoved?: boolean
+  /** The closing `chat.stopStream` carried the footer and the §5.5 `final` delivery state, so
+   *  the response is already closed and no follow-up edit is owed — see the stop's own note. */
+  streamFinalized?: boolean
+  /** Whether this turn's loading state has been cleared. A streaming turn owes exactly one
+   *  clear: nothing expires it now that the answer no longer arrives through chat.postMessage. */
+  streamLoadingCleared?: boolean
   /** A stop Slack has not accepted yet, kept verbatim so settlement reissues THAT stop: a
    *  bare abort retry would settle the message but drop its attribution footer. */
   streamStopOwed?: Extract<SlackAction, { kind: 'stream-stop' }>
@@ -171,6 +177,11 @@ export interface SlackTurnHost<TTurn> {
   /** Monotonic transcript timestamp — core owns ordering across surfaces. */
   monotonicTs(): string
   debug(message: string): void
+  /** Who the COMPLETE response addressed (send-message-routing-rework.md §5.5). A streamed
+   *  turn carries this on its closing `chat.stopStream` instead of a follow-up edit, so the
+   *  applier needs it at stop time rather than after the apply chain drains. Plain core data
+   *  — agent ids and a flag — so this stays a port and not a Slack shape. */
+  resolveFinalization?(turn: TTurn): { mentionedAgentIds: string[]; addressedAnyone: boolean }
 }
 
 /** Conversational authorship for Slack rows: the agent's name and icon, applied
@@ -411,6 +422,18 @@ async function postSlackReply<TTurn extends SlackTurn>(
  *  equivalent — a fallback post would render them as prose — so only body text survives. */
 function streamChunkText(chunks: SlackStreamChunk[]): string {
   return chunks.map((chunk) => (chunk.type === 'markdown_text' ? chunk.text : '')).join('')
+}
+
+/**
+ * Clear the turn's loading state, once. Text only — the session enum belongs to the stream
+ * (§5) — and idempotent, because the seams that can end the pre-stream window (first visible
+ * append, terminal stop, teardown) all reach this and only the first one owes Slack a call.
+ */
+async function clearStreamLoading(conn: SlackConnection, p: SlackTurn, state: SlackTurnState): Promise<void> {
+  if (state.streamLoadingCleared || !p.plan.statusThread) return
+  state.streamLoadingCleared = true
+  if (typeof conn.setLoadingStatus !== 'function') return
+  await conn.setLoadingStatus(p.plan.channel, p.plan.statusThread, '')
 }
 
 /** Route display text to the fallback buffer, opening it if needed, and record ownership the
@@ -711,7 +734,13 @@ export async function applySlackAction<TTurn extends SlackTurn>(
       }
       if (!state.stream) return
       const outcome = await conn.appendTurnStream(state.stream, action.chunks)
-      if (outcome === 'ok') return
+      if (outcome === 'ok') {
+        // The stream now has something to look at, so the loading state has done its job (§5).
+        // Cleared here rather than at stream open: the gap between the two is the blank wait
+        // the loading state exists to cover.
+        if (action.chunks.some((c) => c.type !== 'plan_update')) await clearStreamLoading(conn, p, state)
+        return
+      }
       if (outcome === 'stopped') {
         // Not a failure to make good on — a decision by the person. Anything still queued for
         // this turn stops here, and no fallback post may follow it (§6).
@@ -732,6 +761,9 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     }
     case 'stream-stop': {
       if (state.streamStopped) return
+      // Backstop for a turn whose stream never showed anything — a suppressed reply, or one
+      // that failed before its first append. Its loading state would otherwise sit there.
+      if (action.settle === 'final' || action.settle === 'abort') await clearStreamLoading(conn, p, state)
       // Degradation moves the RESPONSE off the stream only once real body text has landed in
       // the fallback. A refusal that dropped nothing but task chrome leaves the accepted
       // stream holding the whole visible answer, so it must still be closed as the attributed
@@ -745,31 +777,46 @@ export async function applySlackAction<TTurn extends SlackTurn>(
           ? slackAgentPostOptions({ ...p.plan, ...(p.reply.responseId ? { responseId: p.reply.responseId } : {}) })
           : undefined
         // The footer is attached exactly once, on the LAST stop — a rollover carries none, and
-        // teardown after suppression carries none either (§3.3).
+        // teardown after suppression carries none either (§3.3). `chat.stopStream` renders
+        // these blocks BELOW everything the stream already showed, so the cards survive.
         const footer = final && p.attribution ? p.attribution.blocks : undefined
+        // §5.5's `final` delivery state rides the stop too. It used to ride a follow-up
+        // `chat.update`, but that call REPLACES the whole message — which erased every task
+        // card and stamped the answer "(edited)". Safe today only because agent-to-agent
+        // routing consumers read that event on shareable bots, and shareable bots do not
+        // stream (§7.1); the carve-out lift must first teach ingress to read stop-time
+        // metadata.
+        const finalization = final ? host.resolveFinalization?.(p) : undefined
         const stream = state.stream
         const settled = await settleTurnStream(conn, p, state, action, {
           ...(footer ? { blocks: footer } : {}),
           // A rollover must not release the session mid-turn: `active` is the default (§3.4).
           ...(action.settle === 'rollover' && !degraded ? { sessionStatus: 'processing' as const } : {}),
           ...(agentOptions?.agentAuthorId ? { agentAuthorId: agentOptions.agentAuthorId } : {}),
-          ...(agentOptions?.response ? { response: agentOptions.response } : {})
+          ...(agentOptions?.response
+            ? {
+                response: {
+                  ...agentOptions.response,
+                  ...(finalization
+                    ? {
+                        deliveryState: 'final' as const,
+                        mentionedAgentIds: finalization.mentionedAgentIds,
+                        ...(finalization.addressedAnyone ? { addressedAnyone: true } : {})
+                      }
+                    : {})
+                }
+              }
+            : {})
         })
-        if (settled && final) {
-          if (action.discard) {
-            // Nothing ever reached this message — a suppressed reply must not leave an empty
-            // bubble where the agent deliberately stayed silent.
-            await conn.deleteMessage(p.plan.channel, stream.ts)
-          } else if (action.text !== undefined) {
-            // §5.5 closes the response by editing THIS message, so record what it displays.
-            p.reply.lastResponse = { ts: stream.ts, text: action.text }
-            p.reply.lastReply = {
-              ts: stream.ts,
-              text: action.text,
-              ...(footer && p.attribution ? { footerKey: p.attribution.key } : {})
-            }
-          }
+        if (settled && final && action.discard) {
+          // Nothing ever reached this message — a suppressed reply must not leave an empty
+          // bubble where the agent deliberately stayed silent.
+          await conn.deleteMessage(p.plan.channel, stream.ts)
         }
+        // `lastResponse` is deliberately NOT set for a streamed answer: it is the handle the
+        // closing edit works on, and this message has already been finalized in place. Leaving
+        // it unset is what keeps §5.5 from re-editing — and re-flattening — the finished card.
+        if (settled && final && !action.discard) state.streamFinalized = true
         // A ROLLOVER whose stop Slack would not accept owes a replacement message, and the
         // retained handle is emphatically not it: appending the tail there would put
         // post-boundary output back above the boundary, defeat the size cap, and — because

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -1300,12 +1300,14 @@ export class SlackConnection implements PlatformConnection {
     }
     return this.queue
       .enqueue(async () => {
-        // `timeline` interleaves task cards with streamed text, which is exactly how ACP
-        // tool calls arrive; the ACP plan keeps its own message instead (§4).
+        // `plan` collects every task card into ONE collapsed-by-default container labelled by
+        // the `plan_update` title, which is the compact shape the reader wants: the answer,
+        // with the tool activity folded behind a single chevron. `timeline` — the default —
+        // renders each card flat and separate, which buries the answer under them (§4).
         const payload: Record<string, unknown> = {
           channel,
           thread_ts: threadTs,
-          task_display_mode: 'timeline',
+          task_display_mode: 'plan',
           ...(options.recipientUserId ? { recipient_user_id: options.recipientUserId } : {}),
           ...(options.recipientUserId && this.teamId ? { recipient_team_id: this.teamId } : {})
         }
@@ -2008,27 +2010,61 @@ export class SlackConnection implements PlatformConnection {
     options?: SlackStatusOptions
   ): Promise<void> {
     await this.queue.enqueue(async () => {
-      try {
-        // A clear only needs the status coordinates. Keeping authorship off that request
-        // also makes the identity override specific to the visible loading state.
-        const username = status ? options?.username?.trim() : undefined
-        const iconUrl = status ? options?.icon_url?.trim() : undefined
-        await this.app.client.assistant.threads.setStatus({
-          channel_id: channel,
-          thread_ts: threadTs,
-          status,
-          ...(loadingMessages ? { loading_messages: loadingMessages } : {}),
-          ...(username ? { username } : {}),
-          ...(iconUrl ? { icon_url: iconUrl } : {})
-        })
-      } catch (err) {
-        this.rememberMissingScopes(err)
-        this.deps.log?.debug(`slack: setStatus failed (ch=${channel} thread=${threadTs}): ${(err as Error).message}`)
-      }
+      await this.writeLoadingStatus(channel, threadTs, status, loadingMessages, options)
       // Already inside the send queue — setSessionLifecycle must not enqueue again.
       await this.setSessionLifecycle(channel, threadTs, status ? 'processing' : 'active')
       await this.postPermissionUpdateCard(channel, threadTs)
     })
+  }
+
+  /**
+   * The loading state ALONE — free text plus `loading_messages`, no session enum.
+   *
+   * This is what a streaming turn writes. `chat.startStream` already put the session in
+   * `processing`, and the enum cannot carry text anyway, so driving it here would only
+   * overwrite the native rendering with the legacy one (§1). Pass `''` to clear, which a
+   * streaming turn must do explicitly: nothing auto-clears it once the answer stops arriving
+   * through `chat.postMessage`.
+   */
+  async setLoadingStatus(
+    channel: string,
+    threadTs: string,
+    status: string,
+    loadingMessages?: string[],
+    options?: SlackStatusOptions
+  ): Promise<void> {
+    await this.queue.enqueue(async () => {
+      await this.writeLoadingStatus(channel, threadTs, status, loadingMessages, options)
+      await this.postPermissionUpdateCard(channel, threadTs)
+    })
+  }
+
+  /** The legacy free-text status write itself. Callers own the send-queue enqueue, so this
+   *  never adds one — the §3.5 no-nested-enqueue rule. */
+  private async writeLoadingStatus(
+    channel: string,
+    threadTs: string,
+    status: string,
+    loadingMessages?: string[],
+    options?: SlackStatusOptions
+  ): Promise<void> {
+    try {
+      // A clear only needs the status coordinates. Keeping authorship off that request
+      // also makes the identity override specific to the visible loading state.
+      const username = status ? options?.username?.trim() : undefined
+      const iconUrl = status ? options?.icon_url?.trim() : undefined
+      await this.app.client.assistant.threads.setStatus({
+        channel_id: channel,
+        thread_ts: threadTs,
+        status,
+        ...(loadingMessages ? { loading_messages: loadingMessages } : {}),
+        ...(username ? { username } : {}),
+        ...(iconUrl ? { icon_url: iconUrl } : {})
+      })
+    } catch (err) {
+      this.rememberMissingScopes(err)
+      this.deps.log?.debug(`slack: setStatus failed (ch=${channel} thread=${threadTs}): ${(err as Error).message}`)
+    }
   }
 
   /** The native Stop, from either transport: resolve the session this conversation owns, interrupt

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -1420,9 +1420,10 @@ export class OutputConverger {
           const id = u.toolCallId
           if (id && (this.rung === 'medium' || this.rung === 'high')) {
             const terminal = u.status === 'completed' || u.status === 'failed'
-            // The tool's own result goes on the card ONCE, when the call finishes — `output`
-            // is a write-once field, so a per-update summary would accumulate on Slack's side.
-            const result = terminal ? extractToolOutput(u) : ''
+            // The tool's own result is HIGH only — medium keeps the card's title + status, high
+            // adds the output (§4). Written once at completion — `output` is a write-once field,
+            // so a per-update summary would accumulate on Slack's side.
+            const result = terminal && this.rung === 'high' ? extractToolOutput(u) : ''
             this.queueTask(
               id,
               this.toolLabel(u),

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -99,9 +99,16 @@ export type SlackAction =
   // an empty bubble behind.
   | { kind: 'stream-stop'; settle: 'final' | 'rollover' | 'abort'; text?: string; discard?: boolean }
 
-/** The chunk vocabulary `chat.appendStream` accepts, as `@slack/types` declares it (§10 Q3).
- *  `plan_update` and `blocks` are unused: an ACP plan keeps its own in-place message, and the
- *  attribution footer rides `chat.stopStream`'s own `blocks` argument. */
+/**
+ * The chunk vocabulary `chat.appendStream` accepts, as `@slack/types` declares it (§10 Q3).
+ * `blocks` is unused — the attribution footer rides `chat.stopStream`'s own `blocks` argument.
+ *
+ * The FIELD SEMANTICS are not uniform, and this is the whole reason the cards render the way
+ * they do: `title` and `status` REPLACE per id, but `details` APPENDS server-side. Re-sending
+ * a detail line per update therefore concatenates on Slack's side rather than refreshing —
+ * which is how repeated `**bold**` fragments ran together into literal `****`. Write-once
+ * fields only: `output` at completion, `details` never more than once per card.
+ */
 export type SlackStreamChunk =
   | { type: 'markdown_text'; text: string }
   | {
@@ -110,7 +117,11 @@ export type SlackStreamChunk =
       title: string
       status: 'in_progress' | 'complete' | 'error'
       details?: string
+      output?: string
     }
+  // The collapsed container's own label. `plan` display mode renders every task card inside
+  // one collapsed-by-default block, and this is the line the reader sees on it (§4).
+  | { type: 'plan_update'; title: string }
 
 /** Dynamic identity shown under the last reply section. All Slack integration modes use
  *  the same compact `context` footer so shared-bot attribution never looks like body text
@@ -131,17 +142,30 @@ const MAX_STATUS = 50
 // newest tail and mark a drop with a leading ellipsis. The raw buffer is soft-capped at
 // 2× so it can't grow unbounded across a long turn.
 const MAX_REASONING = 2800
-// A streaming task card caps title/details at 256 characters.
+// Every streaming card field caps at 256 characters ON THE WIRE, per chunk. Because the
+// write-once rule above removes the only appending field's repetition, a clamped field is
+// also the card's final size — no card can grow past this across a turn.
 const MAX_STREAM_TASK = 256
+/** The collapsed container's label while the turn is still working (§4). */
+const STREAM_PLAN_WORKING = 'Working…'
 // Slack's own SDK buffers this much before calling chat.appendStream; matching it keeps a
 // Tier-4 append from being queued per model token while still feeling live (§3.5).
 export const STREAM_APPEND_CHARS = 256
-/** Newest thinking line shown on the streamed Thinking card — a tail, not a transcript. */
-const STREAM_THINKING_TAIL = 400
 
 function clampTo(s: string, max: number): string {
   const t = s.trim()
   return t.length > max ? `${t.slice(0, max - 1)}…` : t
+}
+
+/** Flatten markdown emphasis for a card field. Task titles and plan labels render as PLAIN
+ *  text, so `**bold**` and friends would arrive as literal punctuation rather than styling. */
+function plainCardText(s: string): string {
+  return s
+    .replace(/```[\s\S]*?```|`([^`]*)`/g, '$1')
+    .replace(/[*_~]{1,3}(?=\S)([\s\S]*?\S)[*_~]{1,3}/g, '$1')
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 function clampLabel(s: string): string {
@@ -889,9 +913,19 @@ export class OutputConverger {
   private emittedTasks = new Map<string, string>()
   private taskTitles = new Map<string, string>()
   private openTasks = new Set<string>()
-  // The current thinking run: its newest tail, and a counter so each run gets its own card.
-  private thinkingTail = ''
+  /** Cards whose write-once `output` has been sent, so a later update cannot append a second. */
+  private outputWritten = new Set<string>()
+  /** Every card id this turn opened, and how many ended in error — the closing plan label is
+   *  counted from these, so it is deterministic and needs no model call. */
+  private taskCount = 0
+  private taskFailures = 0
+  // The current thinking run: whether one is open, and a counter so each gets its own card.
+  private thinkingActive = false
   private thinkingRun = 0
+  /** The collapsed container's label, so an unchanged one is never re-sent, plus the one
+   *  awaiting the next append. */
+  private planTitle = ''
+  private pendingPlanTitle = ''
 
   /**
    * `protectedAddresses` are the COMPOUND mention addresses in this conversation — a
@@ -945,9 +979,12 @@ export class OutputConverger {
     return this.streaming
   }
 
-  /** Open this turn's stream, the way Feishu's converger opens its card. */
+  /** Open this turn's stream, the way Feishu's converger opens its card. The container starts
+   *  with a working label; `settleTasks` replaces it with what actually happened (§4). */
   onStart(): SlackAction[] {
-    return this.streaming ? [{ kind: 'stream-start' }] : []
+    if (!this.streaming) return []
+    if (this.rung === 'medium' || this.rung === 'high') this.queuePlanTitle(STREAM_PLAN_WORKING)
+    return [{ kind: 'stream-start' }]
   }
 
   /** True while body text OR reasoning is pending — the daemon uses this to (re)arm
@@ -1029,24 +1066,42 @@ export class OutputConverger {
     }
     for (const task of this.pendingTasks.values()) chunks.push(task)
     this.pendingTasks.clear()
+    // A card or body text means the reader has something to look at; the container's own label
+    // does not, so it must never be what keeps an otherwise empty message from being discarded.
+    if (chunks.length > 0 || out.length > 0) this.streamEmitted = true
+    // The container label rides the same append, after the cards it describes.
+    if (this.pendingPlanTitle) {
+      chunks.push({ type: 'plan_update', title: this.pendingPlanTitle })
+      this.pendingPlanTitle = ''
+    }
     flush()
-    if (out.length > 0) this.streamEmitted = true
     return out
   }
 
-  /** Queue one task card. Keyed by id so streamed updates edit the same card, and an
-   *  unchanged repeat emits nothing. */
-  private queueTask(id: string, title: string, status: 'in_progress' | 'complete' | 'error', details?: string): void {
-    const clamped = clampTo(title, MAX_STREAM_TASK) || 'tool'
+  /**
+   * Queue one task card. Keyed by id so streamed updates edit the same card, and an unchanged
+   * repeat emits nothing.
+   *
+   * `title` and `status` may be re-sent freely — Slack REPLACES them per id. `output` may not:
+   * it is written exactly once, at completion, because the appending fields concatenate on
+   * Slack's side rather than refreshing.
+   */
+  private queueTask(id: string, title: string, status: 'in_progress' | 'complete' | 'error', output?: string): void {
+    const clamped = clampTo(plainCardText(title), MAX_STREAM_TASK) || 'tool'
+    const writeOutput = output && !this.outputWritten.has(id) ? clampTo(plainCardText(output), MAX_STREAM_TASK) : ''
     const chunk: Extract<SlackStreamChunk, { type: 'task_update' }> = {
       type: 'task_update',
       id,
       title: clamped,
       status,
-      ...(details ? { details: clampTo(details, MAX_STREAM_TASK) } : {})
+      ...(writeOutput ? { output: writeOutput } : {})
     }
-    const signature = `${chunk.title} ${chunk.status} ${chunk.details ?? ''}`
-    if (this.emittedTasks.get(id) === signature) return
+    const signature = `${chunk.title} ${chunk.status}`
+    // An unchanged card is skipped — unless this update is the one carrying its output.
+    if (!writeOutput && this.emittedTasks.get(id) === signature) return
+    if (!this.emittedTasks.has(id)) this.taskCount += 1
+    if (status === 'error') this.taskFailures += 1
+    if (writeOutput) this.outputWritten.add(id)
     this.emittedTasks.set(id, signature)
     this.taskTitles.set(id, clamped)
     if (status === 'in_progress') this.openTasks.add(id)
@@ -1054,28 +1109,41 @@ export class OutputConverger {
     this.pendingTasks.set(id, chunk)
   }
 
+  /** Retitle the collapsed container, skipping an unchanged label (§4). */
+  private queuePlanTitle(title: string): void {
+    const clamped = clampTo(plainCardText(title), MAX_STREAM_TASK)
+    if (!clamped || clamped === this.planTitle) return
+    this.planTitle = clamped
+    this.pendingPlanTitle = clamped
+  }
+
+  /** What the container says once the turn is over. Counted, not narrated: no model call, and
+   *  a failed step is named rather than folded into a success. */
+  private planSummary(): string {
+    if (this.taskCount === 0) return 'Done'
+    const steps = `${this.taskCount} step${this.taskCount === 1 ? '' : 's'}`
+    if (this.taskFailures === 0) return `Completed ${steps}`
+    return `Completed ${steps} · ${this.taskFailures} failed`
+  }
+
   /** A thinking run ends at the next tool call or at turn end — settle its card rather
-   *  than leaving a spinner behind (§4). */
+   *  than leaving a spinner behind (§4). Title and status only: the thought text would have
+   *  to ride `details`, which appends, so streaming it per line is what produced `****`. */
   private closeThinkingRun(): void {
-    if (!this.thinkingTail) return
-    this.queueTask(`thinking-${this.thinkingRun}`, 'Thinking', 'complete', this.newestThinkingLine())
-    this.thinkingTail = ''
+    if (!this.thinkingActive) return
+    this.queueTask(`thinking-${this.thinkingRun}`, 'Thinking', 'complete')
+    this.thinkingActive = false
     this.thinkingRun += 1
   }
 
-  private newestThinkingLine(): string {
-    return (
-      this.thinkingTail
-        .split('\n')
-        .filter((line) => line.trim())
-        .pop() ?? ''
-    )
-  }
-
-  /** Turn end: no card may stay in progress once the turn is over. */
+  /** Turn end: no card may stay in progress once the turn is over, and the container settles
+   *  from its working label to what actually happened. */
   private settleTasks(): void {
     this.closeThinkingRun()
     for (const id of [...this.openTasks]) this.queueTask(id, this.taskTitles.get(id) ?? 'tool', 'complete')
+    // Only where a container was actually opened — `minimal`/`low` stream body text alone and
+    // have no cards to collect, so they get no label either.
+    if (this.planTitle) this.queuePlanTitle(this.planSummary())
   }
 
   /** The one closing stop: it carries the footer (via the applier's `p.attribution`) and the
@@ -1316,13 +1384,14 @@ export class OutputConverger {
             this.reasoningDirty = true
           }
         }
-        // streaming medium/high: one card per thinking RUN, refreshed with the newest line
-        // on the append timer. `high` still keeps its full in-place Thinking message —
-        // 2,800 characters do not fit a 256-character chunk (§4).
-        if (this.streaming && (this.rung === 'medium' || this.rung === 'high') && thought) {
-          this.thinkingTail = (this.thinkingTail + thought).slice(-STREAM_THINKING_TAIL)
-          const line = this.newestThinkingLine()
-          if (line) this.queueTask(`thinking-${this.thinkingRun}`, 'Thinking', 'in_progress', line)
+        // streaming medium/high: ONE card per thinking run, opened once and settled once —
+        // title and status only. The thought text would have to ride `details`, which appends
+        // server-side, so refreshing it per line concatenated instead of replacing. `high`
+        // still carries the full thinking in its own in-place message, which is where the
+        // 2,800 characters belong anyway (§4).
+        if (this.streaming && (this.rung === 'medium' || this.rung === 'high') && thought && !this.thinkingActive) {
+          this.thinkingActive = true
+          this.queueTask(`thinking-${this.thinkingRun}`, 'Thinking', 'in_progress')
         }
         // minimal: keep the streamed reply intact (thinking mid-reply doesn't close a
         // segment) — only surface the transient status.
@@ -1349,12 +1418,18 @@ export class OutputConverger {
         if (this.streaming) {
           this.closeThinkingRun()
           const id = u.toolCallId
-          if (id && (this.rung === 'medium' || this.rung === 'high'))
+          if (id && (this.rung === 'medium' || this.rung === 'high')) {
+            const terminal = u.status === 'completed' || u.status === 'failed'
+            // The tool's own result goes on the card ONCE, when the call finishes — `output`
+            // is a write-once field, so a per-update summary would accumulate on Slack's side.
+            const result = terminal ? extractToolOutput(u) : ''
             this.queueTask(
               id,
               this.toolLabel(u),
-              u.status === 'completed' ? 'complete' : u.status === 'failed' ? 'error' : 'in_progress'
+              u.status === 'completed' ? 'complete' : u.status === 'failed' ? 'error' : 'in_progress',
+              result
             )
+          }
           const streamed: SlackAction[] = [...this.flush()]
           if (this.rung === 'high') streamed.push(...this.drainToolOutput(u))
           return streamed

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -171,6 +171,23 @@ describe('OutputConverger streaming axis', () => {
     expect(appends(converger.streamUpdate())).toEqual([])
   })
 
+  it('medium cards carry title + status but no output — the result is a high-only rung', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(tool('t1', 'Read file'))
+    converger.streamUpdate()
+    converger.onUpdate({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 't1',
+      title: 'Read file',
+      status: 'completed',
+      content: [{ type: 'content', content: { type: 'text', text: 'read 42 lines' } }]
+    } as never)
+    const cards = appends(converger.streamUpdate()).filter((c) => c.type === 'task_update')
+    // The completed card has no `output` key — medium shows only that the step finished.
+    expect(cards).toEqual([{ type: 'task_update', id: 't1', title: 'Read file', status: 'complete' }])
+    expect(cards[0] && 'output' in cards[0]).toBe(false)
+  })
+
   it('flattens markdown emphasis out of card labels, which render as plain text', () => {
     const converger = streaming('medium')
     converger.onUpdate(tool('t1', '**Read** `src/a.ts`'))
@@ -792,20 +809,28 @@ describe('applySlackAction — streaming actions', () => {
     expect(conn.deleteMessage).toHaveBeenCalledWith('C1', '900.1')
   })
 
-  it('clears the loading state once the stream first has something to show', async () => {
+  it('re-issues the loading row beside the stream and clears it only at the stop', async () => {
     const { apply, conn, state } = fixture()
+    // The daemon stashes the snapshot the applier re-issues (§5).
+    state.loadingStatus = { text: 'is thinking…', options: { username: 'Bot A' } }
     await apply({ kind: 'stream-start' })
-    // The container label alone is not content — the reader is still waiting.
+    // startStream displaces the row, so it is re-issued right after the stream opens.
+    expect(conn.setLoadingStatus).toHaveBeenLastCalledWith('C1', 'T1', 'is thinking…', undefined, { username: 'Bot A' })
+    const afterStart = conn.setLoadingStatus.mock.calls.length
+    // The container label alone is not content, so a plan-only append does not re-issue.
     await apply({ kind: 'stream-append', chunks: [{ type: 'plan_update', title: 'Working…' }] })
-    expect(conn.setLoadingStatus).not.toHaveBeenCalled()
-    // A card or body text is.
+    expect(conn.setLoadingStatus.mock.calls.length).toBe(afterStart)
+    // A card or body text re-issues the row so it survives the append that would displace it.
     await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'the answer' }] })
-    expect(conn.setLoadingStatus).toHaveBeenCalledWith('C1', 'T1', '')
-    expect(state.streamLoadingCleared).toBe(true)
-    // Exactly one clear, however much else the turn streams.
+    expect(conn.setLoadingStatus.mock.calls.length).toBe(afterStart + 1)
+    // Never a clear until the turn ends.
+    expect(conn.setLoadingStatus.mock.calls.every((call) => call[2] !== '')).toBe(true)
     await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: ' and more' }] })
+    // …then exactly one clear at the terminal stop, and no more re-issues after it.
     await apply({ kind: 'stream-stop', settle: 'final', text: 'the answer and more' })
-    expect(conn.setLoadingStatus).toHaveBeenCalledOnce()
+    expect(conn.setLoadingStatus).toHaveBeenLastCalledWith('C1', 'T1', '')
+    expect(conn.setLoadingStatus.mock.calls.filter((call) => call[2] === '')).toHaveLength(1)
+    expect(state.streamLoadingCleared).toBe(true)
     // The enum is never driven from here — chat.startStream owns it.
     expect(conn.setStatus).not.toHaveBeenCalled()
   })
@@ -1197,7 +1222,7 @@ describe('Daemon Slack streaming turn', () => {
     return { daemon, host }
   }
 
-  it('writes the loading state once before the stream, clears it once, and never the enum', async () => {
+  it('keeps the loading row alive beside the stream, clears it once at the end, never the enum', async () => {
     const { daemon } = booted(scaffold())
     await daemon.start()
     const conn = connect(daemon)
@@ -1208,15 +1233,18 @@ describe('Daemon Slack streaming turn', () => {
       'int-a'
     )
 
-    // `setStatus` is the call that ALSO drives agents.sessions.setStatus. A streaming turn
-    // never makes it: chat.startStream owns the session, and the enum cannot carry text.
+    // (a) `setStatus` is the call that ALSO drives agents.sessions.setStatus. A streaming turn
+    // never makes it: chat.startStream owns the session, and the enum renders nothing in a
+    // channel thread anyway (confirmed live).
     expect(conn.setStatus).not.toHaveBeenCalled()
-    // The loading state itself is written — the documented shape, and what covers the wait
-    // before the stream has anything to show — then cleared exactly once.
     const loading = conn.setLoadingStatus.mock.calls.map((call) => call[2])
-    expect(loading.filter((text) => text !== '')).toHaveLength(1)
-    expect(loading.filter((text) => text === '')).toHaveLength(1)
+    // (b) the row is set at the start and RE-ISSUED (startStream and each append displace it),
+    // so there is more than one non-empty write and it is never cleared on first content.
+    expect(loading.filter((text) => text !== '').length).toBeGreaterThan(1)
     expect(loading.at(0)).not.toBe('')
+    expect(loading.slice(0, -1)).not.toContain('')
+    // (c) cleared exactly once, at turn end.
+    expect(loading.filter((text) => text === '')).toHaveLength(1)
     expect(loading.at(-1)).toBe('')
     expect(conn.startTurnStream).toHaveBeenCalledOnce()
     expect(conn.stopTurnStream).toHaveBeenCalledOnce()

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -18,9 +18,9 @@ import { fakeSlackAppFactory } from './fakes/slack-app.js'
 /**
  * slack-streaming-turn-output.md (Layer 1). The invariants worth pinning are the ones the
  * design argues from rather than the plumbing: the answer rides ONE streaming message while
- * the transcript keeps its own copy, a streaming turn writes NEITHER status API (they share
- * one slot with the stream), a stopped stream is never revived, and every path that cannot
- * stream degrades to today's pipeline unchanged.
+ * the transcript keeps its own copy, a streaming turn writes the loading TEXT but never the
+ * session enum (the stream owns that), a stopped stream is never revived, and every path that
+ * cannot stream degrades to today's pipeline unchanged.
  */
 
 const chunk = (text: string) => ({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } }) as never
@@ -100,6 +100,92 @@ describe('OutputConverger streaming axis', () => {
     expect(cards).toEqual([{ type: 'task_update', id: 't1', title: 'Read file', status: 'in_progress' }])
   })
 
+  it('labels the collapsed container while working and settles it to what happened', () => {
+    const converger = streaming('medium')
+    // The container opens with an honest working label…
+    expect(converger.onStart()).toEqual([{ kind: 'stream-start' }])
+    expect(appends(converger.streamUpdate())).toEqual([{ type: 'plan_update', title: 'Working…' }])
+    converger.onUpdate(tool('t1', 'Read file', 'completed'))
+    converger.onUpdate(tool('t2', 'Run tests', 'completed'))
+    converger.streamUpdate()
+    // …and settles to a counted summary — deterministic, no model call.
+    const plans = appends(converger.onFinal(attribution())).filter((c) => c.type === 'plan_update')
+    expect(plans).toEqual([{ type: 'plan_update', title: 'Completed 2 steps' }])
+  })
+
+  it('names a failed step in the closing label rather than folding it into a success', () => {
+    const converger = streaming('medium')
+    converger.onStart()
+    converger.onUpdate(tool('t1', 'Read file', 'completed'))
+    converger.onUpdate(tool('t2', 'Run tests', 'failed'))
+    converger.streamUpdate()
+    const plans = appends(converger.onFinal(attribution())).filter((c) => c.type === 'plan_update')
+    expect(plans).toEqual([{ type: 'plan_update', title: 'Completed 2 steps · 1 failed' }])
+  })
+
+  it('says Done when the turn ran no steps at all', () => {
+    const converger = streaming('medium')
+    converger.onStart()
+    converger.onUpdate(chunk('just an answer'))
+    const plans = appends(converger.onFinal(attribution())).filter((c) => c.type === 'plan_update')
+    expect(plans).toEqual([{ type: 'plan_update', title: 'Done' }])
+  })
+
+  it('gives minimal and low no container label — they stream body text alone', () => {
+    for (const mode of ['minimal', 'low'] as const) {
+      const converger = streaming(mode)
+      converger.onStart()
+      converger.onUpdate(chunk('an answer'))
+      const chunksOut = appends(converger.onFinal(attribution()))
+      expect(chunksOut.filter((c) => c.type === 'plan_update')).toEqual([])
+    }
+  })
+
+  it('never lets the container label alone keep an empty message alive', () => {
+    // A medium turn that produced nothing still opened a container; the label is not content,
+    // so the message is still removed rather than left as an empty bubble.
+    const converger = streaming('medium')
+    converger.onStart()
+    expect(converger.onFinal(attribution()).at(-1)).toMatchObject({ settle: 'final', discard: true })
+  })
+
+  it('writes a completed tool card its output exactly once', () => {
+    const converger = streaming('high')
+    converger.onUpdate(tool('t1', 'Read file'))
+    expect(appends(converger.streamUpdate()).filter((c) => c.type === 'task_update')).toEqual([
+      { type: 'task_update', id: 't1', title: 'Read file', status: 'in_progress' }
+    ])
+    const done = {
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 't1',
+      title: 'Read file',
+      status: 'completed',
+      content: [{ type: 'content', content: { type: 'text', text: 'read 42 lines' } }]
+    } as never
+    converger.onUpdate(done)
+    expect(appends(converger.streamUpdate()).filter((c) => c.type === 'task_update')).toEqual([
+      { type: 'task_update', id: 't1', title: 'Read file', status: 'complete', output: 'read 42 lines' }
+    ])
+    // A repeat of the terminal update must not append a second copy — `output` accumulates.
+    converger.onUpdate(done)
+    expect(appends(converger.streamUpdate())).toEqual([])
+  })
+
+  it('flattens markdown emphasis out of card labels, which render as plain text', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(tool('t1', '**Read** `src/a.ts`'))
+    expect(appends(converger.streamUpdate()).filter((c) => c.type === 'task_update')).toEqual([
+      { type: 'task_update', id: 't1', title: 'Read src/a.ts', status: 'in_progress' }
+    ])
+  })
+
+  it('clamps a card label to the wire limit', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(tool('t1', 'x'.repeat(400)))
+    const card = appends(converger.streamUpdate()).find((c) => c.type === 'task_update')
+    expect(card?.type === 'task_update' && card.title.length).toBe(256)
+  })
+
   it('minimal and low stream body text only — no task cards on either rung', () => {
     for (const mode of ['minimal', 'low'] as const) {
       const converger = streaming(mode)
@@ -111,23 +197,22 @@ describe('OutputConverger streaming axis', () => {
   it('gives a thinking run one card and settles it at the next tool call', () => {
     const converger = streaming('medium')
     converger.onUpdate(think('weighing the options'))
+    // Title and status only. `details` appends server-side, so a per-line refresh concatenates
+    // instead of replacing — which is how repeated emphasis ran together into literal `****`.
     expect(appends(converger.streamUpdate())).toEqual([
-      {
-        type: 'task_update',
-        id: 'thinking-0',
-        title: 'Thinking',
-        status: 'in_progress',
-        details: 'weighing the options'
-      }
+      { type: 'task_update', id: 'thinking-0', title: 'Thinking', status: 'in_progress' }
     ])
+    // More thinking must not re-send the card at all.
+    converger.onUpdate(think('\nand another line'))
+    converger.onUpdate(think('\nand a third'))
+    expect(appends(converger.streamUpdate())).toEqual([])
     converger.onUpdate(tool('t1', 'Read file'))
     const next = appends(converger.streamUpdate())
     expect(next).toContainEqual({
       type: 'task_update',
       id: 'thinking-0',
       title: 'Thinking',
-      status: 'complete',
-      details: 'weighing the options'
+      status: 'complete'
     })
   })
 
@@ -319,6 +404,7 @@ describe('applySlackAction — streaming actions', () => {
       stopTurnStream: vi.fn(async (_stream: SlackTurnStream, _options?: Record<string, unknown>) => true),
       deleteMessage: vi.fn(async (_channel: string, _ts: string) => true),
       setStatus: vi.fn(async () => {}),
+      setLoadingStatus: vi.fn(async (_c: string, _t: string, _s: string) => {}),
       postMessage: vi.fn(async (_channel: string, _text: string, _thread?: string, _options?: unknown) => 'p1'),
       ...over
     }
@@ -348,7 +434,8 @@ describe('applySlackAction — streaming actions', () => {
       setStatusBarTs: vi.fn(),
       clearStatusBarTs: vi.fn(),
       monotonicTs: () => '1',
-      debug: vi.fn()
+      debug: vi.fn(),
+      resolveFinalization: vi.fn(() => ({ mentionedAgentIds: ['agent-2'], addressedAnyone: true }))
     }
     return {
       conn,
@@ -483,9 +570,13 @@ describe('applySlackAction — streaming actions', () => {
     // Exactly one attributed close, on the message that actually shows the answer.
     expect(conn.postMessage).not.toHaveBeenCalled()
     const closing = conn.stopTurnStream.mock.calls.at(-1)![1] as Record<string, unknown>
-    expect(closing).toMatchObject({ blocks: [{ type: 'context' }], agentAuthorId: 'bot-a' })
-    expect(turn.reply.lastResponse).toEqual({ ts: '900.1', text: 'the whole answer' })
-    expect(turn.reply.lastReply).toMatchObject({ ts: '900.1', footerKey: 'footer-1' })
+    expect(closing).toMatchObject({
+      blocks: [{ type: 'context' }],
+      agentAuthorId: 'bot-a',
+      response: expect.objectContaining({ deliveryState: 'final' })
+    })
+    expect(state.streamFinalized).toBe(true)
+    expect(turn.reply).not.toHaveProperty('lastResponse')
   })
 
   it('defers the replacement message when a ROLLOVER stop is left unsettled', async () => {
@@ -621,19 +712,59 @@ describe('applySlackAction — streaming actions', () => {
     expect(conn.appendTurnStream.mock.calls[1]![0]).toMatchObject({ ts: '900.2' })
   })
 
-  it('attaches the attribution footer to the final stop only, and hands §5.5 the message it closes', async () => {
-    const { apply, conn, turn } = fixture()
+  it('closes the response ON the final stop — footer and §5.5 metadata, no follow-up edit', async () => {
+    const { apply, conn, turn, state } = fixture()
     await apply({ kind: 'stream-start' })
     await apply({ kind: 'stream-stop', settle: 'final', text: 'the answer' })
     expect(conn.stopTurnStream).toHaveBeenCalledWith(
       { channel: 'C1', threadTs: 'T1', ts: '900.1' },
-      expect.objectContaining({ blocks: [{ type: 'context' }], agentAuthorId: 'bot-a' })
+      expect.objectContaining({
+        blocks: [{ type: 'context' }],
+        agentAuthorId: 'bot-a',
+        response: expect.objectContaining({
+          responseId: 'resp-1',
+          deliveryState: 'final',
+          mentionedAgentIds: ['agent-2'],
+          addressedAnyone: true
+        })
+      })
     )
     expect(conn.stopTurnStream.mock.calls[0]![1]).not.toHaveProperty('sessionStatus')
-    expect(turn.reply).toMatchObject({
-      lastResponse: { ts: '900.1', text: 'the answer' },
-      lastReply: { ts: '900.1', text: 'the answer', footerKey: 'footer-1' }
+    // No handle is left for a closing edit: chat.update replaces the whole message, which
+    // would erase every task card and stamp the answer "(edited)".
+    expect(state.streamFinalized).toBe(true)
+    expect(turn.reply).not.toHaveProperty('lastResponse')
+    expect(turn.reply).not.toHaveProperty('lastReply')
+  })
+
+  it('a retried closing stop still carries the footer and the §5.5 metadata', async () => {
+    let settled = false
+    const { apply, conn, state } = fixture({
+      stopTurnStream: vi.fn(async (_s: SlackTurnStream, _o?: Record<string, unknown>) => settled)
     })
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-stop', settle: 'final', text: 'the answer' })
+    expect(state.streamFinalized).toBeUndefined()
+
+    // Settlement replays the owed stop; the finals are rebuilt, not lost with the first try.
+    settled = true
+    await apply(state.streamStopOwed!)
+    expect(conn.stopTurnStream.mock.calls.at(-1)![1]).toMatchObject({
+      blocks: [{ type: 'context' }],
+      agentAuthorId: 'bot-a',
+      response: expect.objectContaining({ deliveryState: 'final', mentionedAgentIds: ['agent-2'] })
+    })
+    expect(state.streamFinalized).toBe(true)
+  })
+
+  it('leaves a rollover stop with no footer and no finalization metadata', async () => {
+    const { apply, conn, host } = fixture()
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-stop', settle: 'rollover', text: 'first half' })
+    const options = conn.stopTurnStream.mock.calls[0]![1] as Record<string, unknown>
+    expect(options.blocks).toBeUndefined()
+    expect(options.response).toBeUndefined()
+    expect(host.resolveFinalization).not.toHaveBeenCalled()
   })
 
   it('keeps a rollover stop footerless and the session processing', async () => {
@@ -659,6 +790,32 @@ describe('applySlackAction — streaming actions', () => {
     await apply({ kind: 'stream-start' })
     await apply({ kind: 'stream-stop', settle: 'final', discard: true })
     expect(conn.deleteMessage).toHaveBeenCalledWith('C1', '900.1')
+  })
+
+  it('clears the loading state once the stream first has something to show', async () => {
+    const { apply, conn, state } = fixture()
+    await apply({ kind: 'stream-start' })
+    // The container label alone is not content — the reader is still waiting.
+    await apply({ kind: 'stream-append', chunks: [{ type: 'plan_update', title: 'Working…' }] })
+    expect(conn.setLoadingStatus).not.toHaveBeenCalled()
+    // A card or body text is.
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: 'the answer' }] })
+    expect(conn.setLoadingStatus).toHaveBeenCalledWith('C1', 'T1', '')
+    expect(state.streamLoadingCleared).toBe(true)
+    // Exactly one clear, however much else the turn streams.
+    await apply({ kind: 'stream-append', chunks: [{ type: 'markdown_text', text: ' and more' }] })
+    await apply({ kind: 'stream-stop', settle: 'final', text: 'the answer and more' })
+    expect(conn.setLoadingStatus).toHaveBeenCalledOnce()
+    // The enum is never driven from here — chat.startStream owns it.
+    expect(conn.setStatus).not.toHaveBeenCalled()
+  })
+
+  it('still clears the loading state when the stream never showed anything', async () => {
+    const { apply, conn } = fixture()
+    await apply({ kind: 'stream-start' })
+    await apply({ kind: 'stream-stop', settle: 'final', discard: true })
+    expect(conn.setLoadingStatus).toHaveBeenCalledWith('C1', 'T1', '')
+    expect(conn.setStatus).not.toHaveBeenCalled()
   })
 
   it('skips the status write while a stream is open — the two share one slot', async () => {
@@ -730,7 +887,8 @@ describe('SlackConnection streaming', () => {
     expect(app.client.chat.startStream).toHaveBeenCalledWith({
       channel: 'C1',
       thread_ts: 'T1',
-      task_display_mode: 'timeline',
+      // The collapsed container: every task card folded behind one chevron (§4).
+      task_display_mode: 'plan',
       recipient_user_id: 'U9',
       recipient_team_id: 'T123',
       username: 'Bot A'
@@ -991,6 +1149,7 @@ describe('Daemon Slack streaming turn', () => {
       postMessage: vi.fn(async () => 'reply-1'),
       postBlocks: vi.fn(async () => 'status-bar'),
       updateBlocks: vi.fn(async () => true),
+      setLoadingStatus: vi.fn(async (_c: string, _t: string, _s: string) => {}),
       streamingLikely: vi.fn(() => true),
       startTurnStream: vi.fn(async (channel: string, threadTs: string, _o?: unknown) => ({
         channel,
@@ -1002,6 +1161,9 @@ describe('Daemon Slack streaming turn', () => {
       ),
       stopTurnStream: vi.fn(async (_stream: SlackTurnStream, _options?: Record<string, unknown>) => true),
       deleteMessage: vi.fn(async (_channel: string, _ts: string) => true),
+      // The §5.5 closing edit. On a streamed turn it must never fire: it replaces the whole
+      // message, taking the task cards with it and marking the answer "(edited)".
+      finalizeResponse: vi.fn(async () => true),
       ...over
     }
     ;(daemon as unknown as { connByIntegration: Map<string, unknown> }).connByIntegration.set('int-a', conn)
@@ -1035,7 +1197,7 @@ describe('Daemon Slack streaming turn', () => {
     return { daemon, host }
   }
 
-  it('writes NEITHER status API, and delivers the answer on the stream', async () => {
+  it('writes the loading state once before the stream, clears it once, and never the enum', async () => {
     const { daemon } = booted(scaffold())
     await daemon.start()
     const conn = connect(daemon)
@@ -1046,7 +1208,16 @@ describe('Daemon Slack streaming turn', () => {
       'int-a'
     )
 
+    // `setStatus` is the call that ALSO drives agents.sessions.setStatus. A streaming turn
+    // never makes it: chat.startStream owns the session, and the enum cannot carry text.
     expect(conn.setStatus).not.toHaveBeenCalled()
+    // The loading state itself is written — the documented shape, and what covers the wait
+    // before the stream has anything to show — then cleared exactly once.
+    const loading = conn.setLoadingStatus.mock.calls.map((call) => call[2])
+    expect(loading.filter((text) => text !== '')).toHaveLength(1)
+    expect(loading.filter((text) => text === '')).toHaveLength(1)
+    expect(loading.at(0)).not.toBe('')
+    expect(loading.at(-1)).toBe('')
     expect(conn.startTurnStream).toHaveBeenCalledOnce()
     expect(conn.stopTurnStream).toHaveBeenCalledOnce()
     const streamed = conn.appendTurnStream.mock.calls
@@ -1061,6 +1232,42 @@ describe('Daemon Slack streaming turn', () => {
       expect.anything(),
       expect.anything()
     )
+    await daemon.stop()
+  }, 15_000)
+
+  it('issues NO closing edit on a streamed turn — the stop already finalized it', async () => {
+    const { daemon } = booted(scaffold())
+    await daemon.start()
+    const conn = connect(daemon)
+
+    await (daemon as never as { dispatch: (a: string, m: NormalizedMessage, i: string) => Promise<unknown> }).dispatch(
+      'bot-a',
+      inbound(),
+      'int-a'
+    )
+
+    expect(conn.stopTurnStream).toHaveBeenCalledOnce()
+    expect(conn.stopTurnStream.mock.calls[0]![1]).toMatchObject({
+      response: expect.objectContaining({ deliveryState: 'final' })
+    })
+    expect(conn.finalizeResponse).not.toHaveBeenCalled()
+    await daemon.stop()
+  }, 15_000)
+
+  it('still issues the closing edit when the turn took the legacy pipeline', async () => {
+    const { daemon } = booted(scaffold())
+    await daemon.start()
+    const conn = connect(daemon, { streamingLikely: vi.fn(() => false) })
+
+    await (daemon as never as { dispatch: (a: string, m: NormalizedMessage, i: string) => Promise<unknown> }).dispatch(
+      'bot-a',
+      inbound(),
+      'int-a'
+    )
+
+    expect(conn.startTurnStream).not.toHaveBeenCalled()
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', 'streamed answer', 'T1', expect.anything())
+    expect(conn.finalizeResponse).toHaveBeenCalledOnce()
     await daemon.stop()
   }, 15_000)
 


### PR DESCRIPTION
Follow-up to #1483 / #1487. Seeing streaming render in a real workspace exposed several
presentation faults — most of them from reasoning about the API by the names of its fields
rather than by what they do.

## 1. Collapsed plan, not a flat timeline

Streams now open in `task_display_mode: 'plan'`. `timeline` — which the first version chose
because "task cards interleaved with streamed text" sounded like a stream of ACP tool calls —
renders each card flat and separate, so the answer ends up buried under a column of tool chrome.
`plan` collects them into **one collapsed-by-default container**, which is the shape a reader
actually wants: the answer, with the activity folded behind a single chevron.

The container's own label is a `plan_update` title, so it gets a small arc:

- **while working** — `Working…`, written once when the stream opens;
- **at the terminal stop** — a counted summary: `Completed 3 steps`, `Completed 3 steps · 1
  failed`, or `Done` when the turn ran no steps.

Counted rather than narrated on purpose: derived from the cards the turn actually emitted, so it
needs no second model call and cannot disagree with what is inside the container. `minimal` and
`low` open no container and get no label. A label alone never counts as visible content — an
otherwise-empty message is still discarded.

## 2. The `****` bug: write-once for anything that appends

The task-card fields do not behave alike, and this is the load-bearing fact the first version
missed. `title` and `status` **replace** per card id; `details` **appends** server-side. Sending
the newest thinking line into `details` on every chunk therefore concatenated on Slack's side
instead of refreshing — and because card fields render as plain text, repeated `**bold**`
fragments ran together into literal `****`.

Every appending field is now write-once:

- the **thinking card** carries `title: "Thinking"` and status only, opened once per run and
  settled once — no per-line detail at all;
- a **tool card** gets its result as `output`, written exactly once at completion — and **only on
  the High rung**. Medium keeps the card's title and status; the output text is High only, matching
  the product ladder (Medium = tool activity/plans, High = Medium plus reasoning and tool outputs)
  and the legacy pipeline, which already gated tool output to High;
- markdown emphasis is flattened out of every card label and output before it goes on the wire.

## 3. Footer and finalization ride `chat.stopStream`; no closing edit

The closing `chat.update` was the most destructive call in the pipeline. `chat.update` replaces a
message's **whole content**, so it erased every task card the turn had rendered and left the
answer marked "(edited)" — the second half of the "cards disappear at the end" symptom.

`chat.stopStream` accepts both things that edit existed for: `blocks`, which are appended *below*
everything already streamed rather than replacing it, and `metadata`. So a streamed turn now
stamps the §5.5 `final` delivery state and the resolved recipient set at stop time and issues **no
edit at all**. (None of the official samples calls `chat.update` on a streamed message either.)

**This is safe today because the only consumer of that event is agent-to-agent routing, and A2A
happens only on shareable bots — which are still carved out from streaming.** It does raise the
price of lifting that carve-out, which the design doc now states explicitly: ingress must first
learn to recognise a finalization from stop-time metadata, *then* the predicate can be deleted.
Doing it the other way round would silently stop A2A routing on exactly the bots that use it.

Legacy and fallback turns keep the closing edit unchanged. A retried stop (the #1487 owed-stop
machinery) rebuilds the same blocks and metadata, so a transient failure still finalizes
correctly.

## 4. The loading row is kept alive beside the stream

"A streaming turn writes neither status API" read well on paper and was wrong in practice: a cold
start opened a visible empty bubble and then showed nothing until the first token.
[Slack's loading-state guidance](https://docs.slack.dev/ai/developing-agents) and the official
assistant templates both set the free-text status with `loading_messages` while working and let
the message carry the content.

The first fix wrote that text once and cleared it on the stream's first visible chunk. A real
channel thread showed why that is not enough: `chat.startStream` — and every append after it —
**displaces** the legacy `assistant.threads.setStatus` row, so a single write vanishes the moment
the stream opens. Re-issuing the legacy status *after* the stream has started brings the row back,
and it then coexists with the streamed message and its plan cards.

So a streaming turn now keeps the row alive: it writes the text before the stream, re-issues it
right after `chat.startStream` and on each visible append, and clears it once at the terminal stop
— never on first content. This is uniform across rungs: `minimal`/`low` (body-only stream) and
`medium`/`high` (stream + cards) all carry the same persistent working row. The re-issue rides the
existing send queue and the same append seam, so there is no extra timer.

The **session enum is still never written** on a streaming turn. Live testing settled two facts a
channel thread makes plain: the enum's loading UX and the native stop button are DM /
assistant-container surfaces only — neither renders in a channel thread — so a streaming turn
drives only the legacy status, with no enum and no `is_stoppable`. The connection's
`setLoadingStatus` writes the free text alone so the two halves stay separate.

## Clamp audit

`MAX_STREAM_TASK` (256) is a per-chunk wire limit. With the write-once rule the only appending
field is written at most once per card, so a clamped field is also the card's final size — no card
can grow across a turn. Covered by a test.

## Not touched

`minimal`/`low` status behaviour during a turn is no longer deferred — they now carry the same
persistent loading row as the other rungs (§4). Still untouched: the shareable carve-out itself,
`is_stoppable` (not a usable API in a channel thread today), and relay/ingress code.

## Verified

- `pnpm --filter @agentconnect.md/daemon test` — 4891 passed, 82 skipped. The only failures are
  the four pre-existing local-environment suites (14 tests across `shim-workspace-files`,
  `shim-exec-handler`, `shim-cancellation`, `acp-matrix`), unchanged by this PR.
- `pnpm eval:gates` — 28 files, 193 passed.
- `pnpm --filter @agentconnect.md/protocol test`, `pnpm typecheck` (all packages, tests
  included), `pnpm lint`, `pnpm format:check` — clean.
- `slack-streaming.test.ts` 64 → 79. New/updated: plan display mode on the wire; the plan-title arc
  (working → counted summary, failures named, `Done`, none on minimal/low, label alone never keeps
  an empty message); thinking card sends no repeated details; tool `output` written exactly once
  and only on High, with Medium keeping title/status and no output; emphasis flattened; label
  clamped; terminal stop carries footer + `final` metadata with no `finalizeResponse` call; legacy
  turn still issues the closing edit; owed-stop retry preserves blocks and metadata; rollover stop
  stays bare; the loading row is set at the start, re-issued beside the stream rather than cleared
  on first content, and cleared exactly once at turn end.

Design doc updated: §4 (plan mode and field semantics), §3.3 (stop-carried footer and
finalization), §5 (the loading row re-issued to coexist with the stream, the channel-thread
findings, and the three rules that keep it out of the §1 one-slot conflict), §7.1 (the two-part
carve-out lift), and Q1/Q4 answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
