### PR TITLE
feat(slack): stream shareable bots by reading stop-time finalization metadata

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -1,9 +1,9 @@
 # Slack Native Streaming Turn Output
 
 **Status:** Implemented and shipped (Layer 1 of the Slack-native agent experience; Layer 0 is
-merged). One carve-out is deliberately still closed: turns on a shareable (multi-agent) bot keep
-the legacy pipeline, and lifting it now requires teaching ingress to read a stop-time
-finalization first (§7.1).
+merged). The §7.1 shareable-bot carve-out has since been **lifted**: shareable (multi-agent) bots
+now stream like the rest, because ingress reads the finalization from `chat.stopStream`'s
+stop-time metadata instead of the closing edit it no longer emits (§7.1).
 
 Presentation was revised once after seeing it live: streams open in `plan` display mode rather
 than `timeline`, the §5.5 finalization rides `chat.stopStream` instead of a closing `chat.update`
@@ -157,14 +157,15 @@ are appended below everything already streamed rather than replacing it, and `me
 final delivery state is stamped at stop time and no edit is issued at all. The samples corroborate
 the shape: none of them calls `chat.update` on a streamed message.
 
-**Why that is safe to do now, and what the carve-out lift owes.** Nothing reads the finalization
-event except agent-to-agent routing, and A2A happens only on shareable bots — which §7.1 keeps
-off the streaming path entirely. So today no consumer can miss it. That makes it a **prerequisite
-of lifting the carve-out**, not an afterthought: before a shareable bot may stream, relay and
-Socket Mode ingress must first learn to recognise the finalization from stop-time metadata, since
-the `message_changed` edit they key on today will no longer be emitted. Until then the two facts
-hold each other up — the carve-out is what makes stop-carried finalization safe, and teaching
-ingress is what makes the carve-out liftable.
+**Why this was safe to do, and what the carve-out lift owed.** Nothing reads the finalization
+event except agent-to-agent routing, and A2A happens only on shareable bots — which §7.1 kept
+off the streaming path while it existed. So no consumer could miss it. That made it a
+**prerequisite of lifting the carve-out**, not an afterthought: before a shareable bot could
+stream, relay and Socket Mode ingress had to first recognise the finalization from stop-time
+metadata, since the `message_changed` edit they keyed on is no longer emitted. Both are now done
+— `normalizeSlackResponseFinalization` recognises a `final` claim whether it arrives on a
+`message_changed` edit (legacy) or at the top level of a stop-time event (streamed), so the
+carve-out is lifted (§7.1).
 
 ### 3.4 Length and continuation
 
@@ -441,7 +442,8 @@ latch is wrong for a capability a workspace can gain by upgrading a plan):
   to supply. DMs are unaffected.
 - Output mode `none`.
 
-A fifth carve-out is not structural but a staged rollout — see §7.1.
+These four are the only carve-outs left. A fifth — the shareable-bot staged rollout — has since
+been lifted; see §7.1.
 
 **Mid-turn failure.** If an append fails, stop the stream best-effort and finish the remaining
 body through the ordinary `post` path — the same shape Feishu already ships (_"A final CardKit
@@ -502,44 +504,57 @@ silently drop its attribution footer. The same rule governs an append refusal: i
 handle only when the error proves the message stopped, so a transient one still leaves
 something for the stop to land on.
 
-### 7.1 The shareable-bot carve-out, and why it is temporary
+### 7.1 The shareable-bot carve-out, lifted
 
-One more carve-out ships with the first version, and unlike the four above it is not structural
-— it is a **staged rollout expressed as a predicate**. Turns on a **shareable** (multi-agent)
-Slack bot take the legacy pipeline; dedicated bots stream.
+The first version shipped one more carve-out, and unlike the four structural ones it was a
+**staged rollout expressed as a predicate**: turns on a **shareable** (multi-agent) Slack bot
+took the legacy pipeline while dedicated bots streamed. It has since been **lifted** — shareable
+bots now stream too — once ingress learned to read the finalization from stop-time metadata. This
+section records why it existed and what the lift required.
 
-The reason is §10 Q1. Whether the §5.5 closing `chat.update` still works on a _stopped stream_,
-and whether it still emits the `message_changed` event ingress recognises, is undocumented in
-both directions. Agent-to-agent routing over Slack depends on exactly that edit being seen — and
-**agent-to-agent conversation only happens on a shareable bot**, because that is the only bot
-that hosts more than one agent to address. So the population where a wrong answer to Q1 costs
-real behavior is precisely the population this predicate excludes.
+**Why it existed.** The open question was §10 Q1: whether the §5.5 closing `chat.update` still
+worked on a stopped stream and still emitted the `message_changed` event ingress recognises was
+undocumented in both directions. Agent-to-agent routing over Slack depends on that finalization
+being seen — and **agent-to-agent conversation only happens on a shareable bot**, because that is
+the only bot that hosts more than one agent to address. So the population where a wrong answer to
+Q1 could cost real behavior was precisely the population the carve-out excluded, which converted
+Q1 from a merge gate into a bounded post-deploy verification.
 
-That converts Q1 from a merge gate into a **post-deploy verification**: streaming ships now for
-the large majority of installs (dedicated bots), and one live check on a shareable bot decides
-whether the carve-out is lifted. Until then the risk is bounded to _no change_ — a shareable bot
-behaves exactly as it does today.
-
-It gates on the codebase's **existing** shareable predicate — the same
+It gated on the codebase's **existing** shareable predicate — the same
 `platformIntegrationConfig('slack', …).shareable` fact that decides whether the status bar offers
-"Switch agent" — not on a new flag invented for this change. Nothing new becomes configurable, so
-nothing new can acquire callers and become permanent.
+"Switch agent" — not on a new flag. Nothing new became configurable, so nothing could acquire
+callers and become permanent.
 
-**The carve-out has since become load-bearing for a second reason, and that raised its lift
-price.** §3.3 moved the §5.5 finalization onto `chat.stopStream`, because the closing
-`chat.update` it replaced was erasing the task cards. That means a streamed turn no longer emits
-the `message_changed` event ingress keys on. Harmless today — the only consumer is A2A routing,
-which happens only on shareable bots, which do not stream — but it makes the lift a two-part
-change, in order:
+**Why the lift owed an ingress change first.** §3.3 moved the §5.5 finalization onto
+`chat.stopStream`, because the closing `chat.update` it replaced was erasing the task cards. That
+means a streamed turn no longer emits the `message_changed` event ingress used to key on. Harmless
+while shareable bots did not stream (the only consumer is A2A routing, which happens only there) —
+but it made the lift a two-part change, in order:
 
 1. **Teach relay and Socket Mode ingress to recognise a finalization from stop-time metadata**,
-   alongside the edit they read today.
+   alongside the edit they read for the legacy path.
 2. **Then** delete the predicate from the eligibility check.
 
 Doing (2) without (1) would silently stop agent-to-agent routing on exactly the bots that use it.
-So the lift is no longer "one line plus its test" — the line is still one line, but it is the
-second of two changes, and the first belongs to the ingress seam this design otherwise leaves
-alone.
+
+**How both landed.** The daemon already stamps the §5.5 `final` metadata onto `chat.stopStream`
+(§3.3) — the SAME `agentconnect_thread_event` payload (`author_agent_id`, `response_id`,
+`delivery_state: 'final'`, `hop_count`, `mentioned_agent_ids`, `addressed_anyone`) the legacy
+`chat.update` carried. `normalizeSlackResponseFinalization` now recognises that `final` claim
+whether it arrives nested in a `message_changed` edit (legacy) or at the **top level** of an
+ordinary stop-time event (streamed); both map to the same `response-final`-tagged finalization,
+so downstream A2A routing (`verifyAgentAuthor` → the §6 ladder) is unchanged. Both ingress seams
+call that one normaliser, before their own-echo filter, so relay and Socket Mode gain the
+recognition together. With (1) in place, (2) is the removal of the single shareable line from
+`slackStreamingEligible`.
+
+**The `include_all_metadata` requirement.** The live routing path reads the metadata off the
+message EVENT (the Events API payload on the relay, the Socket Mode frame on the daemon), which
+carries it natively for the app that published it — a shared bot posts and receives under one app,
+so the payload includes the full `event_payload`. The only place a **read-back** is used —
+`conversations.replies` thread backfill — must pass `include_all_metadata: true`, or Slack returns
+just `metadata.event_type` and drops the payload; `getThreadReplies` already does. `chat.stopStream`
+`metadata` persists on the finalized message intact (verified live), so a read-back sees it too.
 
 **SDK note.** `@slack/web-api` resolves to 8.0.0 in this workspace, and — checked against the
 resolved package, not assumed — it **does** type all three methods (`chat.startStream`,
@@ -595,8 +610,9 @@ it.
 
 1. **This PR** lands the whole pipeline — connection members, converger axis, applier, daemon
    hooks, the status-choreography guards, the eval guard, and this document.
-2. **A follow-up PR lifts the §7.1 shareable carve-out** once a live shareable-bot turn confirms
-   §10 Q1. It is a predicate deletion plus its test; it is not a prerequisite for anything here.
+2. **A follow-up PR lifted the §7.1 shareable carve-out** (done). It taught ingress to read the
+   stop-time finalization metadata, then deleted the predicate from the eligibility check, so
+   shareable bots stream and A2A routing is unchanged (§7.1).
 3. **[#1478](https://github.com/agentconnect-md/agentconnect/pull/1478) closes as superseded when
    this merges** — not merged first, not rebased. Its ordering fix applies to a path streaming
    retires wherever it works, and §10 Q5 explains why its order is the wrong one for the
@@ -643,8 +659,11 @@ population a wrong answer could hurt never streams. Seeing the edit run in a rea
 answered the question in the worst way available: it works, and it is destructive — `chat.update`
 replaces the message wholesale, erasing every task card and marking the answer "(edited)". So the
 edit is gone from the streamed path entirely (§3.3), and what replaces it is stop-time metadata.
-The open question is no longer "does the edit survive" but "can ingress read a finalization that
-never arrives as an edit" — see §7.1, where it is now the first half of the carve-out lift.
+The open question became "can ingress read a finalization that never arrives as an edit" —
+_now answered yes._ The finalized message carries the stop-time `metadata` intact (verified live;
+readable back with `include_all_metadata: true`), and it reaches ingress as an ordinary message
+event carrying that metadata at top level. `normalizeSlackResponseFinalization` reads the `final`
+claim from either the nested edit or the top-level event, so the carve-out is lifted (§7.1).
 
 **Q2. What is the accumulated-length cap of a streamed message, and does `chat.stopStream` accept
 `session_status: "processing"`?** The 12,000 figure is documented per call, not per message;

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9403,14 +9403,18 @@ export class Daemon {
   }
 
   /**
-   * May this Slack turn take the native streaming pipeline? Every §7 carve-out that can be
-   * decided before the call is attempted, plus §7.1's staged one:
+   * May this Slack turn take the native streaming pipeline? Every §7 structural carve-out that
+   * can be decided before the call is attempted:
    *
    *  - a streamed message must be a thread reply, so a channel-root turn cannot stream;
-   *  - `recipient_user_id` is required outside a DM and only a human initiator supplies one;
-   *  - `none` delivers nothing to the channel at all;
-   *  - a SHAREABLE (multi-agent) bot keeps the legacy pipeline until §10 Q1 is verified live,
-   *    because agent-to-agent routing — the thing Q1 puts at risk — happens only there.
+   *  - `recipient_user_id` is required outside a DM and only a human initiator supplies one, so a
+   *    channel turn with no human initiator (agent-to-agent, cron, hook, dream) cannot stream;
+   *  - `none` delivers nothing to the channel at all.
+   *
+   * §7.1's shareable carve-out is LIFTED (slack-streaming-turn-output.md §7.1): shareable
+   * (multi-agent) bots now stream like the rest, because ingress recognises the finalization
+   * from `chat.stopStream`'s stop-time metadata (`normalizeSlackResponseFinalization`), so the
+   * agent-to-agent routing that only happens there is unchanged even without the closing edit.
    *
    * The remaining answer is Slack's own: `streamingLikely()` reads the capability latch, and
    * `chat.startStream` decides for real.
@@ -9418,7 +9422,6 @@ export class Daemon {
   private slackStreamingEligible(plan: TurnPlan, entry: QueueEntry, conn: ReplyConnection | undefined): boolean {
     if (plan.platform !== 'slack' || plan.mode === 'none' || !plan.thread) return false
     if (!plan.isDm && !slackStreamRecipient(entry.msg)) return false
-    if (this.isShareableSlackIntegration(plan.agentId, plan.integrationId)) return false
     const likely = (conn as Partial<SlackConnection> | undefined)?.streamingLikely
     return typeof likely === 'function' && likely.call(conn)
   }

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it, expect, vi } from 'vitest'
 import { encodeSlackStatusOverflowValue, SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID } from '@agentconnect.md/protocol'
+import { SLACK_RESPONSE_FINAL_EVENT_TAG } from '@agentconnect.md/message'
 import { consolidate, SlackConnection } from '../src/slack/connection.js'
 import type { Agent } from '../src/agents/agent-schema.js'
 
@@ -928,6 +929,71 @@ describe('SlackConnection assistant DM threads', () => {
       'is checking the deployment',
       'peer bot update'
     ])
+  })
+
+  it('recognizes a stop-time finalization on the bot own message, past own-echo (streaming §3.3/§7.1)', async () => {
+    // A native streamed turn closes its response on `chat.stopStream`, which emits no
+    // `message_changed` edit — the finalized message arrives as an ordinary bot message carrying
+    // the SAME `final` metadata. It must route despite being the bot's own post, or agent-to-agent
+    // routing stops on the shareable bots that stream; a mid-stream `streaming` post still drops.
+    let messageHandler!: (a: { message: unknown }) => unknown
+    const delivered: any[] = []
+    const conn = new SlackConnection(
+      {
+        ...deps(),
+        onMessage: (msg: unknown) => delivered.push(msg)
+      } as any,
+      () =>
+        ({
+          message(h: (a: { message: unknown }) => unknown) {
+            messageHandler = h
+          },
+          event() {},
+          action() {},
+          shortcut() {},
+          client: {
+            auth: { test: async () => ({ user_id: 'UBOT', bot_id: 'BSELF' }) },
+            views: { open: async () => {}, update: async () => {} }
+          },
+          start: async () => {},
+          stop: async () => {}
+        }) as any
+    )
+    await conn.start()
+
+    const streamedFinal = (deliveryState: 'streaming' | 'final', ts: string) => ({
+      message: {
+        type: 'message',
+        channel: 'C1',
+        ts,
+        thread_ts: '1727484200.000000',
+        bot_id: 'BSELF',
+        app_id: 'AMANAGED',
+        text: '<@UPEER> please verify the rollout',
+        metadata: {
+          event_type: 'agentconnect_thread_event',
+          event_payload: {
+            author_agent_id: 'agent-author',
+            response_id: 'r-1',
+            delivery_state: deliveryState,
+            hop_count: 2,
+            mentioned_agent_ids: ['agent-peer']
+          }
+        }
+      }
+    })
+
+    // Mid-stream: dropped by own-echo exactly as before.
+    await messageHandler(streamedFinal('streaming', '1727484201.000000'))
+    expect(delivered).toEqual([])
+
+    // The stop: recognized as the finalization even though it is the bot's own message.
+    await messageHandler(streamedFinal('final', '1727484202.000000'))
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0].ingressEventTag).toBe(SLACK_RESPONSE_FINAL_EVENT_TAG)
+    expect(delivered[0].agentAuthorship?.authorAgentId).toBe('agent-author')
+    expect(delivered[0].agentAuthorship?.mentionedAgentIds).toEqual(['agent-peer'])
+    expect(delivered[0].msgId).toBe('slack:C1:1727484202.000000')
   })
 })
 

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -930,6 +930,44 @@ describe('SlackConnection streaming', () => {
     )
   })
 
+  it('stamps the §5.5 finalization metadata onto chat.stopStream so ingress can read it back', async () => {
+    // The closing edit is gone from the streamed path (§3.3), so `chat.stopStream` carries the
+    // SAME `final` metadata the old `chat.update` did — this is exactly what
+    // `normalizeSlackResponseFinalization` recognises on the other daemon / the relay. The
+    // producer and the reader must agree on the payload shape, so pin it here.
+    const { conn, app } = await connect()
+    const stream = (await conn.startTurnStream('C1', 'T1'))!
+    await conn.stopTurnStream(stream, {
+      blocks: [{ type: 'context' }],
+      agentAuthorId: 'bot-a',
+      response: {
+        responseId: 'r-1',
+        deliveryState: 'final',
+        hopCount: 2,
+        mentionedAgentIds: ['agent-2'],
+        addressedAnyone: true
+      }
+    })
+    expect(app.client.chat.stopStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'C1',
+        ts: '900.1',
+        blocks: [{ type: 'context' }],
+        metadata: {
+          event_type: 'agentconnect_thread_event',
+          event_payload: {
+            author_agent_id: 'bot-a',
+            response_id: 'r-1',
+            delivery_state: 'final',
+            hop_count: 2,
+            mentioned_agent_ids: ['agent-2'],
+            addressed_anyone: true
+          }
+        }
+      })
+    )
+  })
+
   it('answers "cannot stream" when the SDK has no such method, and latches it', async () => {
     const { conn } = await connect({ chat: { startStream: undefined } })
     expect(await conn.startTurnStream('C1', 'T1')).toBeUndefined()
@@ -1299,7 +1337,10 @@ describe('Daemon Slack streaming turn', () => {
     await daemon.stop()
   }, 15_000)
 
-  it('keeps a SHAREABLE bot on the legacy pipeline until §10 Q1 is verified live', async () => {
+  it('streams a SHAREABLE bot now that the §7.1 carve-out is lifted', async () => {
+    // §7.1 lift: shareable (multi-agent) bots stream like the rest — ingress recognises the
+    // finalization from `chat.stopStream`'s metadata, so agent-to-agent routing is unchanged
+    // without the closing edit. The turn takes the stream, not the legacy post boundary.
     const { daemon } = booted(scaffold())
     await daemon.start()
     const conn = connect(daemon, {}, true)
@@ -1310,9 +1351,19 @@ describe('Daemon Slack streaming turn', () => {
       'int-a'
     )
 
-    expect(conn.startTurnStream).not.toHaveBeenCalled()
-    expect(conn.setStatus).toHaveBeenCalled()
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', 'streamed answer', 'T1', expect.anything())
+    expect(conn.startTurnStream).toHaveBeenCalledOnce()
+    const streamed = conn.appendTurnStream.mock.calls
+      .flatMap((call) => call[1] ?? [])
+      .map((c: SlackStreamChunk) => (c.type === 'markdown_text' ? c.text : ''))
+      .join('')
+    expect(streamed).toContain('streamed answer')
+    // The finalization rides the stop, carrying the §5.5 `final` state ingress reads back.
+    expect(conn.stopTurnStream).toHaveBeenCalledOnce()
+    expect(conn.stopTurnStream.mock.calls[0]![1]).toMatchObject({
+      response: expect.objectContaining({ deliveryState: 'final' })
+    })
+    // The answer never takes the legacy post boundary on a streaming turn.
+    expect(conn.postMessage).not.toHaveBeenCalledWith('C1', 'streamed answer', 'T1', expect.anything())
     await daemon.stop()
   }, 15_000)
 

--- a/packages/message/src/slack-message.ts
+++ b/packages/message/src/slack-message.ts
@@ -209,39 +209,48 @@ export function normalizeSlackMessage(
 export const SLACK_RESPONSE_FINAL_EVENT_TAG = 'response-final'
 
 /**
- * Normalize the `message_changed` wrapper that CLOSES an AgentConnect logical response
- * (send-message-routing-rework.md §5), or return null for every other edit.
+ * Normalize the event that CLOSES an AgentConnect logical response
+ * (send-message-routing-rework.md §5), or return null for every other event.
+ *
+ * A response is finalized two ways, and BOTH are recognized by the same daemon-written
+ * `final` metadata rather than by the event's shape (slack-streaming-turn-output.md
+ * §3.3/§7.1):
+ *  - the legacy pipeline's closing `chat.update`, delivered as a `message_changed` edit
+ *    whose NESTED message carries the metadata (the wrapper owns the channel); and
+ *  - a native streamed turn's `chat.stopStream`, which emits NO edit — the finalized
+ *    message arrives as an ordinary event carrying the metadata at top level.
  *
  * Slack ingest drops edit wrappers wholesale, and for human edits that is still right:
  * normalizing the outer wrapper would produce an anonymous empty message, and re-routing
- * arbitrary edits would let one message activate an agent repeatedly. But a streamed
- * agent answer can only be declared complete by editing its last message — that edit IS
- * the final response event — so exactly this one shape must survive, and it is
- * recognized by daemon-written metadata rather than by being an edit at all.
+ * arbitrary edits would let one message activate an agent repeatedly. So only the shape
+ * carrying `final` metadata survives, whether it arrives as an edit or as a stop-time post.
  *
- * Selectivity is the whole point: a `streaming` edit (an in-place update mid-answer)
- * returns null, so intermediate states never route. Verification of the CLAIM still
- * happens downstream — this function proves nothing about who authored the message.
+ * Selectivity is the whole point: a `streaming` claim (an in-place update mid-answer, or a
+ * streamed append) returns null, so intermediate states never route, and an event with no
+ * agent claim at all returns null. Verification of the CLAIM still happens downstream —
+ * this function proves nothing about who authored the message.
  */
 export function normalizeSlackResponseFinalization(
   event: SlackMessageLike & { message?: unknown },
   context: { traceId?: string } = {}
 ): NormalizedPlatformMessage | null {
-  if (event.subtype !== 'message_changed') return null
-  const edited = event.message
-  if (!edited || typeof edited !== 'object') return null
-  const nested = edited as SlackMessageLike
+  // A `message_changed` nests the real message; a stop-time finalization is already the
+  // top-level event. Either way the metadata to key on lives on `source`.
+  const source = event.subtype === 'message_changed' ? event.message : event
+  if (!source || typeof source !== 'object') return null
+  const nested = source as SlackMessageLike
   const claim = readAgentAuthorshipClaim(nested)
   if (claim?.deliveryState !== 'final') return null
-  // The nested message carries no `channel` (the wrapper owns it) and its `ts` is the
-  // ORIGINAL post's — which is the identity that matters everywhere downstream.
+  // The `message_changed` nested message carries no `channel` (the wrapper owns it) and its
+  // `ts` is the ORIGINAL post's; a stop-time event is `source === event`, so `event.channel`
+  // is its own channel. Either way the identity that matters downstream is on the event.
   const normalized = normalizeSlackMessage(
     {
       ...nested,
       channel: event.channel,
       ...(event.channel_type !== undefined ? { channel_type: event.channel_type } : {}),
-      // The wrapper's own `subtype` must not travel: the unwrapped message is an
-      // ordinary post as far as every later stage is concerned.
+      // The wrapper's own `subtype` must not travel (a stop-time event has none): every later
+      // stage must see an ordinary post.
       subtype: undefined,
       message: undefined
     },

--- a/packages/message/test/slack-agent-authorship.test.ts
+++ b/packages/message/test/slack-agent-authorship.test.ts
@@ -177,11 +177,10 @@ describe('normalizeSlackResponseFinalization (§5)', () => {
     expect(normalizeSlackResponseFinalization(wrapper(claim({ delivery_state: 'streaming' })))).toBeNull()
   })
 
-  it('returns null for an ordinary human edit and for non-edit events', () => {
+  it('returns null for an ordinary human edit and for an edit carrying no agent claim', () => {
     expect(normalizeSlackResponseFinalization(wrapper({ user: 'U1', metadata: undefined }))).toBeNull()
-    expect(
-      normalizeSlackResponseFinalization({ type: 'message', channel: 'C1', ts: '1', text: 'hi', ...claim() })
-    ).toBeNull()
+    // A plain post that carries no agent metadata at all is not a finalization.
+    expect(normalizeSlackResponseFinalization({ type: 'message', channel: 'C1', ts: '1', text: 'hi' })).toBeNull()
   })
 
   it('returns null for a chrome edit', () => {
@@ -189,6 +188,52 @@ describe('normalizeSlackResponseFinalization (§5)', () => {
     expect(
       normalizeSlackResponseFinalization(
         wrapper({ metadata: { event_type: 'agentconnect_chrome', event_payload: {} } })
+      )
+    ).toBeNull()
+  })
+})
+
+describe('normalizeSlackResponseFinalization — stop-time metadata (streaming §3.3/§7.1)', () => {
+  // A native streamed turn closes its response on `chat.stopStream`, which emits NO edit: the
+  // finalized message arrives as an ordinary top-level event carrying the SAME `final` metadata
+  // the legacy closing `chat.update` used to carry on a `message_changed` wrapper. Ingress must
+  // recognize it identically, or agent-to-agent routing stops on the shareable bots that stream.
+  const stopEvent = (nested: Record<string, unknown>) => ({
+    type: 'message',
+    channel: 'C1',
+    ts: '1720000000.000100',
+    thread_ts: '1720000000.000001',
+    bot_id: 'B1',
+    app_id: 'A1',
+    text: '<@U01PEER> please verify the rollout',
+    ...nested
+  })
+
+  it('recognizes a stop-time finalization delivered without a message_changed wrapper', () => {
+    const msg = normalizeSlackResponseFinalization(stopEvent(claim()))
+    expect(msg).not.toBeNull()
+    // Same downstream shape the wrapped edit produces: original identity, thread, text, author,
+    // recipient set, and the finalization tag.
+    expect(msg!.channel).toBe('C1')
+    expect(msg!.thread).toBe('1720000000.000001')
+    expect(msg!.text).toBe('<@U01PEER> please verify the rollout')
+    expect(msg!.sender.appId).toBe('A1')
+    expect(msg!.agentAuthorship?.authorAgentId).toBe(AUTHOR)
+    expect(msg!.agentAuthorship?.mentionedAgentIds).toEqual([PEER])
+    expect(msg!.ingressEventTag).toBe(SLACK_RESPONSE_FINAL_EVENT_TAG)
+    // The ts is the streamed message's own, recoverable by the ordinary split.
+    expect(msg!.msgId).toBe('slack:C1:1720000000.000100')
+  })
+
+  it('does not misread a mid-stream append (streaming metadata) as final', () => {
+    // The streamed appends carry `streaming` until the stop stamps `final`; only the stop routes.
+    expect(normalizeSlackResponseFinalization(stopEvent(claim({ delivery_state: 'streaming' })))).toBeNull()
+  })
+
+  it('ignores a stop-time event that carries chrome metadata rather than a response', () => {
+    expect(
+      normalizeSlackResponseFinalization(
+        stopEvent({ metadata: { event_type: 'agentconnect_chrome', event_payload: {} } })
       )
     ).toBeNull()
   })

--- a/packages/relay/src/platforms/slack/http-ingest.test.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.test.ts
@@ -11,6 +11,7 @@ import {
   encodeSlackStatusOverflowValue,
   encodeSharedSlackStatusTarget
 } from '@agentconnect.md/protocol'
+import { SLACK_RESPONSE_FINAL_EVENT_TAG } from '@agentconnect.md/message'
 import {
   normalizeSlackMessage,
   parseHttpSlackAgentSelection,
@@ -637,6 +638,90 @@ describe('normalizeSlackMessage conversation kinds', () => {
 })
 
 describe('SlackHttpIngest message events', () => {
+  const ingestFor = (onMessage: SlackHttpIngestDeps['onMessage'], botId = 'BSELF') =>
+    new SlackHttpIngest(
+      'bot',
+      { botToken: 'xoxb', signingSecret: 's' },
+      {
+        onMessage,
+        onBotUserId: vi.fn(),
+        onChannelsChanged: vi.fn(),
+        agents: () => [],
+        currentOwner: () => undefined,
+        onSetChannelAgent: vi.fn(),
+        onSelectThreadAgent: vi.fn(),
+        onSessionAction: vi.fn(),
+        onSessionShortcut: vi.fn(() => false),
+        onSessionStopped: vi.fn(),
+        webClientFactory: () => ({ auth: { test: vi.fn(async () => ({ user_id: 'UBOT', bot_id: botId })) } }) as never,
+        log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
+      }
+    )
+
+  // slack-streaming-turn-output.md §3.3/§7.1: a native streamed turn closes its response on
+  // `chat.stopStream`, which emits no `message_changed` edit — the finalized message arrives as
+  // an ordinary bot message carrying the SAME `final` metadata the legacy closing edit carried.
+  // A2A on shareable bots (all relay-inbound) depends on ingress recognising THAT, before the
+  // own-echo filter that would otherwise drop the bot's own post.
+  const finalMetadata = (deliveryState: 'streaming' | 'final') => ({
+    metadata: {
+      event_type: 'agentconnect_thread_event',
+      event_payload: {
+        author_agent_id: 'agent-author',
+        response_id: 'r-1',
+        delivery_state: deliveryState,
+        hop_count: 2,
+        mentioned_agent_ids: ['agent-peer']
+      }
+    }
+  })
+
+  it('forwards a stop-time finalization on the bot own message, past the own-echo filter', async () => {
+    const onMessage = vi.fn<SlackHttpIngestDeps['onMessage']>(async () => {})
+    const ingest = ingestFor(onMessage)
+    await ingest.start()
+
+    // The bot's OWN post (bot_id === the resolved self id) still forwards, because it closes a
+    // logical response — echo suppression alone would make shared-bot A2A impossible.
+    await ingest.handleEvent({
+      type: 'message',
+      channel: 'C1',
+      ts: '900.1',
+      thread_ts: '900.0',
+      bot_id: 'BSELF',
+      app_id: 'AMANAGED',
+      text: '<@UPEER> please verify the rollout',
+      ...finalMetadata('final')
+    })
+
+    expect(onMessage).toHaveBeenCalledTimes(1)
+    const [message] = onMessage.mock.calls[0]!
+    expect(message.ingressEventTag).toBe(SLACK_RESPONSE_FINAL_EVENT_TAG)
+    expect(message.agentAuthorship?.authorAgentId).toBe('agent-author')
+    expect(message.agentAuthorship?.mentionedAgentIds).toEqual(['agent-peer'])
+    expect(message.msgId).toBe('slack:C1:900.1')
+  })
+
+  it('does not forward a mid-stream append (streaming metadata) as a finalization', async () => {
+    const onMessage = vi.fn<SlackHttpIngestDeps['onMessage']>(async () => {})
+    const ingest = ingestFor(onMessage)
+    await ingest.start()
+
+    await ingest.handleEvent({
+      type: 'message',
+      channel: 'C1',
+      ts: '900.1',
+      thread_ts: '900.0',
+      bot_id: 'BSELF',
+      app_id: 'AMANAGED',
+      text: 'partial answer so far',
+      ...finalMetadata('streaming')
+    })
+
+    // A `streaming` post is dropped by the own-echo filter exactly as before — only the stop routes.
+    expect(onMessage).not.toHaveBeenCalled()
+  })
+
   it('drops self and Slack system messages while forwarding peer app text', async () => {
     const onMessage = vi.fn<SlackHttpIngestDeps['onMessage']>(async () => {})
     const botIds = [undefined, 'BSELF']


### PR DESCRIPTION
## What

Lifts the shareable-bot carve-out from Slack native streaming: shareable (multi-agent) bots now stream like the rest, by teaching ingress to read the response finalization from `chat.stopStream`'s stop-time metadata instead of the closing edit it no longer emits.

## The carve-out being lifted, and why it existed

Slack native streaming (#1483 / #1487 / #1489) excluded shareable bots (`mode === 'shared'` + `IntegrationSlackConfig.shareable === true`) from the streaming path — they fell back to the legacy post pipeline. The reason was the finalization signal:

- The legacy pipeline closes a logical response with a follow-up `chat.update`, which emits a `message_changed` event. Relay and Socket Mode ingress recognise a finished agent answer from that edit via `normalizeSlackResponseFinalization`, and agent-to-agent (A2A) reply routing over Slack depends on seeing it.
- Streaming moved the §5.5 finalization off that closing `chat.update` onto `chat.stopStream` (its `blocks` + `metadata`), because `chat.update` replaces the whole message — erasing every task card and marking the answer "(edited)". So a streamed turn no longer emits a `message_changed` event.
- A2A conversation only happens on shareable bots. Streaming them without teaching ingress to read the new signal would silently break A2A — so the carve-out kept shareable bots on the legacy path until ingress could recognise the stop-time finalization.

## The finalization-signal move, and how ingress now recognises it

The daemon already stamps the §5.5 `final` metadata onto `chat.stopStream` (from the merged streaming work): the same `agentconnect_thread_event` payload the legacy `chat.update` carried — `author_agent_id`, `response_id`, `delivery_state: 'final'`, `hop_count`, `mentioned_agent_ids`, `addressed_anyone`.

This PR extends `normalizeSlackResponseFinalization` (in `@agentconnect.md/message`) to recognise that `final` claim whether it arrives:

- nested inside a `message_changed` edit (legacy path, unchanged), or
- at the **top level** of an ordinary stop-time message event (streamed path — the finalized message reaches ingress carrying the metadata directly, not as an edit).

Both map to the identical `response-final`-tagged normalized finalization, so the downstream A2A path (`verifyAgentAuthor` → the §6 routing ladder, transcript `authoritative` refresh) is unchanged. Both ingress seams — the relay HTTP ingest and the daemon Socket Mode handler — call that one normaliser before their own-echo filter, so both gain the recognition together.

With ingress recognition in place, the lift itself is the removal of the single shareable line from `slackStreamingEligible`. Every other structural carve-out stays: no `thread_ts`, no human initiator in a channel (A2A / cron / hook / dream), output mode `none`, and the feature-detect fallback.

## The `include_all_metadata` requirement

The live routing path reads the metadata off the message event itself (the Events API payload on the relay, the Socket Mode frame on the daemon), which carries it natively for the app that published it — a shared bot posts and receives under one app, so the payload includes the full `event_payload`. The only place a read-back is used, the `conversations.replies` thread backfill, must pass `include_all_metadata: true` (otherwise Slack returns only `metadata.event_type` and drops the payload); `getThreadReplies` already does. The `chat.stopStream` `metadata` persists on the finalized message intact, verified live, so a read-back sees it too.

## A2A downstream shape unchanged

The recognised finalization is byte-for-byte the same normalized message the old `message_changed` path produced (same `msgId`, thread, text, `agentAuthorship`, `ingressEventTag: 'response-final'`). Nothing downstream of `normalizeSlackResponseFinalization` changes.

## Guardrail outcome: LIFTED

The blocker in the guardrail was: if the finalization consumer needed a `message_changed`-style event and `chat.stopStream` provably emitted none, the lift would be blocked. It is not — the finalized streamed message reaches ingress as an ordinary message event carrying the finalization metadata (confirmed live), so ingress can recognise it. The carve-out is lifted. The removal is isolated to one line in `slackStreamingEligible`, so it can be reverted alone if a real deployment surfaces an A2A problem.

## Verified

- `pnpm --filter @agentconnect.md/message test` — pass
- `pnpm --filter @agentconnect.md/relay test` — pass
- `pnpm --filter @agentconnect.md/daemon test` — pass (pre-existing local-env failures unrelated to this change: `shim-workspace-files`, `shim-exec-handler`, `shim-cancellation`, `acp-matrix`)
- `pnpm --filter @agentconnect.md/protocol test` — pass
- `pnpm eval:gates` — pass
- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm format:check` — pass

The design doc `docs/designs/slack-streaming-turn-output.md` (§7.1, §3.3, §10 Q1, §9) is updated to record that the lift landed, that ingress reads stop-time metadata, and the `include_all_metadata` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
