### PR TITLE
feat(web): attribute a billing usage row to the agents that spent it

### DIFF
--- a/packages/web/src/components/console/views/BillingView.agents.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.agents.test.tsx
@@ -1,14 +1,15 @@
 // @vitest-environment happy-dom
 /**
- * The debit row's agent attribution, reduced to what the viewer is entitled to.
+ * What a usage row may say about who spent the money.
  *
- * The billing service authorizes on ORG membership alone, so the `agents` split it sends
- * carries the org's agent ids and not the viewer's. `session-visibility.md` §5 makes usage
- * attribution the INTERSECTION of Agent visibility and the Session predicate, and returns
- * everything it withholds as one id-less rollup carrying no count. Naming an agent here
- * therefore needs both halves — the viewer's `/agents` roster and the CP's viewer-scoped
- * `/usage` projection for that period — and what fails either must collapse, not merely
- * lose its name. What is pinned below is that boundary, not a formatting choice.
+ * Every figure comes from the CP's viewer-scoped `/usage` projection, gateway-scoped like the
+ * charge itself — never from the billing service's own split, whose ids AND amounts are the
+ * ORG's (it authorizes on org membership alone). That distinction is the whole boundary:
+ * `session-visibility.md` §5 makes usage attribution the intersection of Agent visibility and
+ * the Session predicate, and `/usage` applies both, so what it hands over per agent is what
+ * this viewer may attribute — never an authorization for that agent's whole month. An agent
+ * with $1 of readable spend and $99 of private spend is worth $1 here, and the $99 stays in
+ * the id-less residual. These are security properties, not formatting ones.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -19,20 +20,16 @@ const DEBIT = {
   type: 'debit' as const,
   id: 'd1',
   period: '2026-08',
-  amount: '1.40',
+  amount: '100.00',
   at: '2026-08-20T10:00:00.000Z',
-  agents: [
-    { agentId: 'agt_1', amount: '1.00' },
-    { agentId: 'agt_hidden', amount: '0.40' }
-  ]
+  // The billing service's own org-scoped split. Nothing reads it — the assertions below pin
+  // that the row's figures come from the projection instead, not from these numbers.
+  agents: [{ agentId: 'agt_1', amount: '100.00' }]
 }
 
 const mocks = vi.hoisted(() => ({
-  fetchAgents: vi.fn(async () => [
-    { id: 'agt_1', name: 'reviewer', runtime: 'claude' },
-    { id: 'agt_hidden', name: 'secret-bot', runtime: 'claude' }
-  ]),
-  fetchAttributable: vi.fn(async () => new Set(['agt_1']))
+  fetchAgents: vi.fn(async () => [{ id: 'agt_1', name: 'reviewer', runtime: 'claude' }]),
+  fetchAttribution: vi.fn(async () => new Map([['agt_1', '1.00']]))
 }))
 
 vi.mock('@/lib/org-context', () => ({
@@ -46,7 +43,7 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/lib/api', async () => ({
   ...(await vi.importActual<typeof import('@/lib/api')>('@/lib/api')),
   fetchAgents: mocks.fetchAgents,
-  fetchAttributableAgentIds: mocks.fetchAttributable
+  fetchGatewayAttribution: mocks.fetchAttribution
 }))
 vi.mock('@/lib/billing-api', async () => ({
   ...(await vi.importActual<typeof import('@/lib/billing-api')>('@/lib/billing-api')),
@@ -57,94 +54,96 @@ vi.mock('@/lib/billing-api', async () => ({
   fetchBillingTransactionsSince: async () => [DEBIT]
 }))
 
-const { default: BillingView, agentSplit } = await import('./BillingView')
+const { default: BillingView, rowAttribution } = await import('./BillingView')
 
 const agent = (id: string, name: string) => ({ id, name, runtime: 'claude' }) as Agent
 const roster = new Map([
   ['agt_1', agent('agt_1', 'reviewer')],
   ['agt_2', agent('agt_2', 'triage')]
 ])
-const both = new Set(['agt_1', 'agt_2'])
 
-describe('agentSplit', () => {
-  it('names an agent only when BOTH predicates clear', () => {
-    // On the roster but NOT attributable for this period: the viewer can see the agent, but
-    // its billed spend came from sessions they may not read. Agent visibility alone is not
-    // the permission this surface needs, so it must not be named.
-    const rows = agentSplit(
-      [
-        { agentId: 'agt_1', amount: '1.00' },
-        { agentId: 'agt_2', amount: '0.50' }
-      ],
-      roster,
-      new Set(['agt_1'])
-    )
-    expect(rows.map((r) => r.agent?.name)).toEqual(['reviewer', undefined])
-    expect(JSON.stringify(rows)).not.toContain('agt_2')
+describe('rowAttribution', () => {
+  it('names an agent for its SCOPED amount, never the row it appears on', () => {
+    // $1 readable + $99 private on one visible agent. Membership would name it for $100;
+    // the projection's own figure is the only one it may be named for.
+    const chips = rowAttribution('100', new Map([['agt_1', '1']]), roster)
+    expect(chips).toEqual([
+      { key: 'agt_1', agent: roster.get('agt_1'), amount: '1' },
+      { key: 'withheld', amount: '99' }
+    ])
   })
 
-  it('withholds an attributable agent that is missing from the roster', () => {
-    const rows = agentSplit([{ agentId: 'agt_gone', amount: '1.00' }], roster, new Set(['agt_gone']))
-    expect(rows).toEqual([{ key: 'withheld', amount: '1' }])
+  it('leaves an unresolvable agent’s spend in the residual, id and all', () => {
+    const chips = rowAttribution('10', new Map([['agt_gone', '4']]), roster)
+    expect(chips).toEqual([{ key: 'withheld', amount: '10' }])
+    expect(JSON.stringify(chips)).not.toContain('agt_gone')
   })
 
-  it('collapses every withheld part into ONE rollup, disclosing neither count nor partition', () => {
-    const rows = agentSplit(
-      [
-        { agentId: 'x', amount: '0.10' },
-        { agentId: 'y', amount: '0.20' },
-        { agentId: 'z', amount: '0.05' },
-        { agentId: 'agt_2', amount: '1.00' }
-      ],
-      roster,
-      both
+  it('collapses everything withheld into ONE rollup — no count, no partition', () => {
+    const chips = rowAttribution(
+      '10',
+      new Map([
+        ['agt_1', '1'],
+        ['x', '2'],
+        ['y', '3']
+      ]),
+      roster
     )
-    expect(rows).toHaveLength(2)
-    // The sum, and only the sum — three contributors must not be legible as three chips.
-    expect(rows[1]).toEqual({ key: 'withheld', amount: '0.35' })
+    expect(chips).toHaveLength(2)
+    expect(chips[1]).toEqual({ key: 'withheld', amount: '9' })
   })
 
-  it('sums the rollup exactly, never as a float', () => {
-    const rows = agentSplit(
-      [
-        { agentId: 'x', amount: '0.1' },
-        { agentId: 'y', amount: '0.2' }
-      ],
-      roster,
-      both
+  it('subtracts exactly, never as a float', () => {
+    // 0.3 - 0.1 - 0.1 is 0.09999999999999999 in binary floating point.
+    const chips = rowAttribution(
+      '0.3',
+      new Map([
+        ['agt_1', '0.1'],
+        ['agt_2', '0.1']
+      ]),
+      roster
     )
-    expect(rows[0]!.amount).toBe('0.3')
+    expect(chips.at(-1)).toEqual({ key: 'withheld', amount: '0.1' })
+  })
+
+  it('omits the rollup when the viewer can attribute the whole row', () => {
+    const chips = rowAttribution(
+      '3',
+      new Map([
+        ['agt_1', '1'],
+        ['agt_2', '2']
+      ]),
+      roster
+    )
+    expect(chips.map((c) => c.key)).toEqual(['agt_2', 'agt_1'])
   })
 
   it('orders named agents by spend, biggest first', () => {
-    const rows = agentSplit(
-      [
-        { agentId: 'agt_1', amount: '0.40' },
-        { agentId: 'agt_2', amount: '2.50' }
-      ],
-      roster,
-      both
+    const chips = rowAttribution(
+      '9',
+      new Map([
+        ['agt_1', '0.4'],
+        ['agt_2', '2.5']
+      ]),
+      roster
     )
-    expect(rows.map((r) => r.agent?.name)).toEqual(['triage', 'reviewer'])
+    expect(chips.map((c) => c.agent?.name)).toEqual(['triage', 'reviewer', undefined])
   })
 
-  it('renders nothing when the service sent no split, or an empty one', () => {
-    expect(agentSplit(undefined, roster, both)).toEqual([])
-    expect(agentSplit(null, roster, both)).toEqual([])
-    expect(agentSplit([], roster, both)).toEqual([])
-    // A zero part is noise, not attribution.
-    expect(agentSplit([{ agentId: 'agt_1', amount: '0' }], roster, both)).toEqual([])
+  it('shows NOTHING rather than an overstated chip when naming exceeds the row', () => {
+    // A partial period, or a settlement this window does not describe: not reconcilable, so
+    // there is no split that both adds up and does not overstate. Say nothing.
+    expect(rowAttribution('1', new Map([['agt_1', '5']]), roster)).toEqual([])
+  })
+
+  it('fails closed on a missing projection or an empty roster', () => {
+    expect(rowAttribution('10', undefined, roster)).toEqual([])
+    expect(rowAttribution('10', new Map(), roster)).toEqual([])
+    expect(rowAttribution('10', new Map([['agt_1', '1']]), new Map())).toEqual([{ key: 'withheld', amount: '10' }])
   })
 
   it('drops a part whose amount is not a number rather than rendering NaN', () => {
-    expect(agentSplit([{ agentId: 'agt_1', amount: 'twelve' }], roster, both)).toEqual([])
-  })
-
-  it('fails closed when either input is empty', () => {
-    const parts = [{ agentId: 'agt_1', amount: '0.40' }]
-    // An unloaded or failed roster, and an unloaded or failed projection: both must withhold.
-    expect(agentSplit(parts, new Map(), both)).toEqual([{ key: 'withheld', amount: '0.4' }])
-    expect(agentSplit(parts, roster, new Set())).toEqual([{ key: 'withheld', amount: '0.4' }])
+    expect(rowAttribution('10', new Map([['agt_1', 'twelve']]), roster)).toEqual([{ key: 'withheld', amount: '10' }])
   })
 })
 
@@ -174,28 +173,23 @@ describe('the usage row', () => {
 
   it('asks the CP for the periods on screen, not for a preset range', async () => {
     await render()
-    expect(mocks.fetchAttributable).toHaveBeenCalledWith(
-      '2026-08-01T00:00:00.000Z',
-      '2026-09-01T00:00:00.000Z',
-      'org-1'
-    )
+    expect(mocks.fetchAttribution).toHaveBeenCalledWith('2026-08-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z', 'org-1')
   })
 
-  it('pictures the agent it may name, and a default avatar for the rest', async () => {
+  it('renders the projection’s amount, not the billing service’s org-scoped one', async () => {
     const host = await render()
     const chips = host.querySelectorAll('[data-tx-agent]')
     expect(chips).toHaveLength(2)
 
-    // Attributable and on the roster: its own avatar, its label, its amount.
+    // The projection attributes $1 of this $100 charge to a roster agent...
     expect(chips[0]!.textContent).toBe('reviewer$1.00')
     expect(chips[0]!.querySelector('[data-tx-agent-default]')).toBeNull()
-
-    // Withheld: the default avatar and the summed amount — no name, and no id anywhere in
-    // the DOM, even though this agent IS on the viewer's roster. `/agents` proves only that
-    // they may see the agent, never that they may read the sessions this spend came from.
-    expect(chips[1]!.textContent).toBe('$0.40')
+    // ...and the other $99 is the id-less residual. The billing split said $100 for this same
+    // agent; if that number ever reaches a CHIP, this assertion is what catches it. The row's
+    // own total is still $100 — that figure is the org's charge and was never in question.
+    expect(chips[1]!.textContent).toBe('$99.00')
     expect(chips[1]!.querySelector('[data-tx-agent-default]')).not.toBeNull()
-    expect(host.innerHTML).not.toContain('agt_hidden')
-    expect(host.innerHTML).not.toContain('secret-bot')
+    expect([...chips].map((c) => c.textContent).join('')).not.toContain('$100.00')
+    expect(host.textContent).toContain('-$100.00')
   })
 })

--- a/packages/web/src/components/console/views/BillingView.agents.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.agents.test.tsx
@@ -1,14 +1,15 @@
+// @vitest-environment happy-dom
 /**
  * The debit row's agent attribution, reduced to what the viewer is entitled to.
  *
  * The billing service authorizes on ORG membership alone, so the `agents` split it sends
- * carries the org's agent ids and not the viewer's. Naming one the viewer cannot otherwise
- * see would be the resource-existence disclosure `session-visibility.md` §5 forbids, whose
- * rule is that withheld usage comes back id-less. Every part still gets its own entry — the
- * roster decides whether it is NAMED, not whether it appears — so what is pinned here is a
- * security property (no unresolvable id survives the reduction), not a formatting one.
+ * carries the org's agent ids and not the viewer's. `session-visibility.md` §5 makes usage
+ * attribution the INTERSECTION of Agent visibility and the Session predicate, and returns
+ * everything it withholds as one id-less rollup carrying no count. Naming an agent here
+ * therefore needs both halves — the viewer's `/agents` roster and the CP's viewer-scoped
+ * `/usage` projection for that period — and what fails either must collapse, not merely
+ * lose its name. What is pinned below is that boundary, not a formatting choice.
  */
-// @vitest-environment happy-dom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -27,7 +28,11 @@ const DEBIT = {
 }
 
 const mocks = vi.hoisted(() => ({
-  fetchAgents: vi.fn(async () => [{ id: 'agt_1', name: 'reviewer', runtime: 'claude' }])
+  fetchAgents: vi.fn(async () => [
+    { id: 'agt_1', name: 'reviewer', runtime: 'claude' },
+    { id: 'agt_hidden', name: 'secret-bot', runtime: 'claude' }
+  ]),
+  fetchAttributable: vi.fn(async () => new Set(['agt_1']))
 }))
 
 vi.mock('@/lib/org-context', () => ({
@@ -40,7 +45,8 @@ vi.mock('next/navigation', () => ({
 }))
 vi.mock('@/lib/api', async () => ({
   ...(await vi.importActual<typeof import('@/lib/api')>('@/lib/api')),
-  fetchAgents: mocks.fetchAgents
+  fetchAgents: mocks.fetchAgents,
+  fetchAttributableAgentIds: mocks.fetchAttributable
 }))
 vi.mock('@/lib/billing-api', async () => ({
   ...(await vi.importActual<typeof import('@/lib/billing-api')>('@/lib/billing-api')),
@@ -53,77 +59,92 @@ vi.mock('@/lib/billing-api', async () => ({
 
 const { default: BillingView, agentSplit } = await import('./BillingView')
 
-beforeEach(() => {
-  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: 'billing' }
-})
-afterEach(() => {
-  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = {}
-})
-
 const agent = (id: string, name: string) => ({ id, name, runtime: 'claude' }) as Agent
 const roster = new Map([
   ['agt_1', agent('agt_1', 'reviewer')],
   ['agt_2', agent('agt_2', 'triage')]
 ])
+const both = new Set(['agt_1', 'agt_2'])
 
 describe('agentSplit', () => {
-  it('resolves an agent on the viewer’s roster, and only that one', () => {
+  it('names an agent only when BOTH predicates clear', () => {
+    // On the roster but NOT attributable for this period: the viewer can see the agent, but
+    // its billed spend came from sessions they may not read. Agent visibility alone is not
+    // the permission this surface needs, so it must not be named.
     const rows = agentSplit(
       [
-        { agentId: 'agt_1', amount: '0.40' },
-        { agentId: 'agt_hidden', amount: '0.10' }
+        { agentId: 'agt_1', amount: '1.00' },
+        { agentId: 'agt_2', amount: '0.50' }
       ],
-      roster
+      roster,
+      new Set(['agt_1'])
     )
     expect(rows.map((r) => r.agent?.name)).toEqual(['reviewer', undefined])
-    // The whole point: no unresolvable id reaches the row, in any field — including `key`,
-    // so the id cannot leak through a prop that ends up serialized.
-    expect(JSON.stringify(rows)).not.toContain('agt_hidden')
+    expect(JSON.stringify(rows)).not.toContain('agt_2')
   })
 
-  it('gives every unresolvable part its OWN entry rather than folding them', () => {
+  it('withholds an attributable agent that is missing from the roster', () => {
+    const rows = agentSplit([{ agentId: 'agt_gone', amount: '1.00' }], roster, new Set(['agt_gone']))
+    expect(rows).toEqual([{ key: 'withheld', amount: '1' }])
+  })
+
+  it('collapses every withheld part into ONE rollup, disclosing neither count nor partition', () => {
     const rows = agentSplit(
       [
         { agentId: 'x', amount: '0.10' },
         { agentId: 'y', amount: '0.20' },
+        { agentId: 'z', amount: '0.05' },
         { agentId: 'agt_2', amount: '1.00' }
       ],
-      roster
+      roster,
+      both
     )
-    expect(rows).toHaveLength(3)
-    expect(rows.filter((r) => !r.agent)).toHaveLength(2)
-    // Distinct keys, or React collapses the two into one chip.
-    expect(new Set(rows.map((r) => r.key)).size).toBe(3)
+    expect(rows).toHaveLength(2)
+    // The sum, and only the sum — three contributors must not be legible as three chips.
+    expect(rows[1]).toEqual({ key: 'withheld', amount: '0.35' })
   })
 
-  it('orders by spend, biggest first, resolved or not', () => {
+  it('sums the rollup exactly, never as a float', () => {
+    const rows = agentSplit(
+      [
+        { agentId: 'x', amount: '0.1' },
+        { agentId: 'y', amount: '0.2' }
+      ],
+      roster,
+      both
+    )
+    expect(rows[0]!.amount).toBe('0.3')
+  })
+
+  it('orders named agents by spend, biggest first', () => {
     const rows = agentSplit(
       [
         { agentId: 'agt_1', amount: '0.40' },
-        { agentId: 'hidden', amount: '5.00' },
         { agentId: 'agt_2', amount: '2.50' }
       ],
-      roster
+      roster,
+      both
     )
-    expect(rows.map((r) => r.agent?.name ?? '—')).toEqual(['—', 'triage', 'reviewer'])
+    expect(rows.map((r) => r.agent?.name)).toEqual(['triage', 'reviewer'])
   })
 
   it('renders nothing when the service sent no split, or an empty one', () => {
-    expect(agentSplit(undefined, roster)).toEqual([])
-    expect(agentSplit(null, roster)).toEqual([])
-    expect(agentSplit([], roster)).toEqual([])
+    expect(agentSplit(undefined, roster, both)).toEqual([])
+    expect(agentSplit(null, roster, both)).toEqual([])
+    expect(agentSplit([], roster, both)).toEqual([])
     // A zero part is noise, not attribution.
-    expect(agentSplit([{ agentId: 'agt_1', amount: '0' }], roster)).toEqual([])
+    expect(agentSplit([{ agentId: 'agt_1', amount: '0' }], roster, both)).toEqual([])
   })
 
   it('drops a part whose amount is not a number rather than rendering NaN', () => {
-    expect(agentSplit([{ agentId: 'agt_1', amount: 'twelve' }], roster)).toEqual([])
+    expect(agentSplit([{ agentId: 'agt_1', amount: 'twelve' }], roster, both)).toEqual([])
   })
 
-  it('names nothing while the roster is still empty', () => {
-    // An unloaded or failed roster must fail CLOSED — a default avatar, never a name.
-    const rows = agentSplit([{ agentId: 'agt_1', amount: '0.40' }], new Map())
-    expect(rows.map((r) => r.agent)).toEqual([undefined])
+  it('fails closed when either input is empty', () => {
+    const parts = [{ agentId: 'agt_1', amount: '0.40' }]
+    // An unloaded or failed roster, and an unloaded or failed projection: both must withhold.
+    expect(agentSplit(parts, new Map(), both)).toEqual([{ key: 'withheld', amount: '0.4' }])
+    expect(agentSplit(parts, roster, new Set())).toEqual([{ key: 'withheld', amount: '0.4' }])
   })
 })
 
@@ -141,24 +162,40 @@ describe('the usage row', () => {
     return host
   }
 
+  beforeEach(() => {
+    ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: 'billing' }
+  })
   afterEach(async () => {
     if (root) await act(async () => root!.unmount())
     host?.remove()
     root = undefined
+    ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = {}
   })
 
-  it('pictures the agent it may name, and a default avatar for the one it may not', async () => {
+  it('asks the CP for the periods on screen, not for a preset range', async () => {
+    await render()
+    expect(mocks.fetchAttributable).toHaveBeenCalledWith(
+      '2026-08-01T00:00:00.000Z',
+      '2026-09-01T00:00:00.000Z',
+      'org-1'
+    )
+  })
+
+  it('pictures the agent it may name, and a default avatar for the rest', async () => {
     const host = await render()
     const chips = host.querySelectorAll('[data-tx-agent]')
     expect(chips).toHaveLength(2)
 
-    // Resolved: the agent's own avatar and label.
-    expect(chips[0]!.textContent).toBe('reviewer')
+    // Attributable and on the roster: its own avatar, its label, its amount.
+    expect(chips[0]!.textContent).toBe('reviewer$1.00')
     expect(chips[0]!.querySelector('[data-tx-agent-default]')).toBeNull()
 
-    // Unresolved: the default avatar, no name — and its id nowhere in the DOM.
-    expect(chips[1]!.textContent).toBe('')
+    // Withheld: the default avatar and the summed amount — no name, and no id anywhere in
+    // the DOM, even though this agent IS on the viewer's roster. `/agents` proves only that
+    // they may see the agent, never that they may read the sessions this spend came from.
+    expect(chips[1]!.textContent).toBe('$0.40')
     expect(chips[1]!.querySelector('[data-tx-agent-default]')).not.toBeNull()
     expect(host.innerHTML).not.toContain('agt_hidden')
+    expect(host.innerHTML).not.toContain('secret-bot')
   })
 })

--- a/packages/web/src/components/console/views/BillingView.agents.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.agents.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * The debit row's agent attribution, reduced to what the viewer is entitled to.
+ *
+ * The billing service authorizes on ORG membership alone, so the `agents` split it sends
+ * carries the org's agent ids and not the viewer's. Naming one the viewer cannot otherwise
+ * see would be the resource-existence disclosure `session-visibility.md` §5 forbids, whose
+ * rule is that withheld usage comes back id-less. Every part still gets its own entry — the
+ * roster decides whether it is NAMED, not whether it appears — so what is pinned here is a
+ * security property (no unresolvable id survives the reduction), not a formatting one.
+ */
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent } from '@/lib/data'
+
+const DEBIT = {
+  type: 'debit' as const,
+  id: 'd1',
+  period: '2026-08',
+  amount: '1.40',
+  at: '2026-08-20T10:00:00.000Z',
+  agents: [
+    { agentId: 'agt_1', amount: '1.00' },
+    { agentId: 'agt_hidden', amount: '0.40' }
+  ]
+}
+
+const mocks = vi.hoisted(() => ({
+  fetchAgents: vi.fn(async () => [{ id: 'agt_1', name: 'reviewer', runtime: 'claude' }])
+}))
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, myRole: 'owner', orgPath: (p: string) => p, loading: false })
+}))
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/acme/billing',
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams()
+}))
+vi.mock('@/lib/api', async () => ({
+  ...(await vi.importActual<typeof import('@/lib/api')>('@/lib/api')),
+  fetchAgents: mocks.fetchAgents
+}))
+vi.mock('@/lib/billing-api', async () => ({
+  ...(await vi.importActual<typeof import('@/lib/billing-api')>('@/lib/billing-api')),
+  createBillingPurchase: vi.fn(),
+  fetchBillingPurchase: vi.fn(),
+  fetchBillingAccount: async () => ({ orgId: 'org-1', balanceMicro: 10_000_000 }),
+  fetchBillingTransactions: async () => ({ items: [DEBIT], nextCursor: null }),
+  fetchBillingTransactionsSince: async () => [DEBIT]
+}))
+
+const { default: BillingView, agentSplit } = await import('./BillingView')
+
+beforeEach(() => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: 'billing' }
+})
+afterEach(() => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = {}
+})
+
+const agent = (id: string, name: string) => ({ id, name, runtime: 'claude' }) as Agent
+const roster = new Map([
+  ['agt_1', agent('agt_1', 'reviewer')],
+  ['agt_2', agent('agt_2', 'triage')]
+])
+
+describe('agentSplit', () => {
+  it('resolves an agent on the viewer’s roster, and only that one', () => {
+    const rows = agentSplit(
+      [
+        { agentId: 'agt_1', amount: '0.40' },
+        { agentId: 'agt_hidden', amount: '0.10' }
+      ],
+      roster
+    )
+    expect(rows.map((r) => r.agent?.name)).toEqual(['reviewer', undefined])
+    // The whole point: no unresolvable id reaches the row, in any field — including `key`,
+    // so the id cannot leak through a prop that ends up serialized.
+    expect(JSON.stringify(rows)).not.toContain('agt_hidden')
+  })
+
+  it('gives every unresolvable part its OWN entry rather than folding them', () => {
+    const rows = agentSplit(
+      [
+        { agentId: 'x', amount: '0.10' },
+        { agentId: 'y', amount: '0.20' },
+        { agentId: 'agt_2', amount: '1.00' }
+      ],
+      roster
+    )
+    expect(rows).toHaveLength(3)
+    expect(rows.filter((r) => !r.agent)).toHaveLength(2)
+    // Distinct keys, or React collapses the two into one chip.
+    expect(new Set(rows.map((r) => r.key)).size).toBe(3)
+  })
+
+  it('orders by spend, biggest first, resolved or not', () => {
+    const rows = agentSplit(
+      [
+        { agentId: 'agt_1', amount: '0.40' },
+        { agentId: 'hidden', amount: '5.00' },
+        { agentId: 'agt_2', amount: '2.50' }
+      ],
+      roster
+    )
+    expect(rows.map((r) => r.agent?.name ?? '—')).toEqual(['—', 'triage', 'reviewer'])
+  })
+
+  it('renders nothing when the service sent no split, or an empty one', () => {
+    expect(agentSplit(undefined, roster)).toEqual([])
+    expect(agentSplit(null, roster)).toEqual([])
+    expect(agentSplit([], roster)).toEqual([])
+    // A zero part is noise, not attribution.
+    expect(agentSplit([{ agentId: 'agt_1', amount: '0' }], roster)).toEqual([])
+  })
+
+  it('drops a part whose amount is not a number rather than rendering NaN', () => {
+    expect(agentSplit([{ agentId: 'agt_1', amount: 'twelve' }], roster)).toEqual([])
+  })
+
+  it('names nothing while the roster is still empty', () => {
+    // An unloaded or failed roster must fail CLOSED — a default avatar, never a name.
+    const rows = agentSplit([{ agentId: 'agt_1', amount: '0.40' }], new Map())
+    expect(rows.map((r) => r.agent)).toEqual([undefined])
+  })
+})
+
+describe('the usage row', () => {
+  let root: Root | undefined
+  let host: HTMLElement | undefined
+
+  async function render(): Promise<HTMLElement> {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+    await act(async () => {
+      root!.render(<BillingView />)
+    })
+    return host
+  }
+
+  afterEach(async () => {
+    if (root) await act(async () => root!.unmount())
+    host?.remove()
+    root = undefined
+  })
+
+  it('pictures the agent it may name, and a default avatar for the one it may not', async () => {
+    const host = await render()
+    const chips = host.querySelectorAll('[data-tx-agent]')
+    expect(chips).toHaveLength(2)
+
+    // Resolved: the agent's own avatar and label.
+    expect(chips[0]!.textContent).toBe('reviewer')
+    expect(chips[0]!.querySelector('[data-tx-agent-default]')).toBeNull()
+
+    // Unresolved: the default avatar, no name — and its id nowhere in the DOM.
+    expect(chips[1]!.textContent).toBe('')
+    expect(chips[1]!.querySelector('[data-tx-agent-default]')).not.toBeNull()
+    expect(host.innerHTML).not.toContain('agt_hidden')
+  })
+})

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -25,7 +25,6 @@ import {
   fmtMicroUsd,
   type BillingAccount,
   type BillingPurchase,
-  type BillingDebitAgent,
   type BillingTransaction
 } from '@/lib/billing-api'
 import {
@@ -38,7 +37,7 @@ import {
 } from '@/lib/billing-activity'
 import { balanceBanner, ledgerHistory } from '@/lib/billing-banner'
 import { featureFlagEnabled } from '@/lib/feature-flags'
-import { fetchAgents, fetchAttributableAgentIds } from '@/lib/api'
+import { fetchAgents, fetchGatewayAttribution } from '@/lib/api'
 import { agentLabel, type Agent } from '@/lib/data'
 import { sumAmounts } from '@/lib/amount'
 import { useOrgs } from '@/lib/org-context'
@@ -66,42 +65,40 @@ export interface TxAgentChip {
   amount: string
 }
 
-// A debit's per-agent split, reduced to what this viewer is already entitled to know.
+// What a usage row may say about who spent the money.
 //
-// Naming an agent here needs BOTH predicates that `session-visibility.md` §5 makes usage
-// attribution intersect, and neither comes from the billing service — it authorizes on org
-// membership alone, so its ids are the ORG's:
+// Every figure here comes from `projection` — the CP's viewer-scoped `/usage` read for this
+// row's period, gateway-scoped like the charge itself. That is the whole point: the billing
+// service's own split is org-scoped in BOTH its ids and its amounts, so an agent with $1 of
+// readable spend and $99 of private spend would be named for $100. The projection hands over
+// the $1 and keeps the $99 in the residual, which is `session-visibility.md` §5's rule that
+// withheld usage comes back id-less — and what is withheld is withheld by EITHER predicate.
 //
-//   `agentById`     — Agent visibility, from the viewer's own `/agents` roster (name + icon);
-//   `attributable`  — the Session predicate, from the CP's viewer-scoped `/usage` projection
-//                     for this row's period. An id in it is one the console ALREADY attributes
-//                     to this viewer for that window, so naming it discloses nothing new.
+// `agentById` supplies only the name and icon: an id the roster cannot resolve is not named,
+// and its amount falls into the residual like any other withheld spend.
 //
-// Everything else — a restricted agent, or spend from a session this viewer may not read —
-// collapses into ONE id-less rollup carrying only its summed amount. Not one entry each:
-// the row's own total already discloses the sum, but the partition and the number of
-// withheld contributors are not the viewer's to learn, and `unattributed` carries no count
-// for the same reason. Zero and unparseable parts are noise and are dropped.
-export function agentSplit(
-  parts: BillingDebitAgent[] | null | undefined,
-  agentById: Map<string, Agent>,
-  attributable: ReadonlySet<string>
+// The residual is the ROW's total minus what was named, so the chips always add up to the line
+// they sit on. If naming exceeds the row — a partial period, or a settlement this projection's
+// window does not describe — the row is not reconcilable and gets NO attribution rather than an
+// overstated chip.
+export function rowAttribution(
+  rowAmount: string,
+  projection: ReadonlyMap<string, string> | undefined,
+  agentById: Map<string, Agent>
 ): TxAgentChip[] {
-  if (!parts?.length) return []
+  if (!projection?.size) return []
   const named: { chip: TxAgentChip; value: number }[] = []
-  const withheld: string[] = []
-  for (const part of parts) {
-    const value = Number(part.amount)
-    if (!Number.isFinite(value) || value === 0) continue
-    const agent = attributable.has(part.agentId) ? agentById.get(part.agentId) : undefined
-    // The id never enters a chip it cannot name — `key` included, so it cannot leak through
-    // a prop that ends up serialized.
-    if (agent) named.push({ chip: { key: part.agentId, agent, amount: part.amount }, value })
-    else withheld.push(part.amount)
+  for (const [agentId, amount] of projection) {
+    const agent = agentById.get(agentId)
+    const value = Number(amount)
+    if (!agent || !Number.isFinite(value) || value === 0) continue
+    named.push({ chip: { key: agentId, agent, amount }, value })
   }
+  const residual = sumAmounts([rowAmount, ...named.map(({ chip }) => `-${chip.amount}`)])
+  if (residual.startsWith('-')) return []
   named.sort((a, b) => b.value - a.value)
   const chips = named.map(({ chip }) => chip)
-  if (withheld.length) chips.push({ key: 'withheld', amount: sumAmounts(withheld) })
+  if (Number(residual) > 0) chips.push({ key: 'withheld', amount: residual })
   return chips
 }
 
@@ -111,9 +108,6 @@ const nextPeriod = (period: string) => {
   const [y, m] = period.split('-').map(Number) as [number, number]
   return m === 12 ? `${y + 1}-01` : `${y}-${String(m + 1).padStart(2, '0')}`
 }
-
-// Shared so a row with no projection yet reuses one empty set rather than allocating per render.
-const EMPTY_ATTRIBUTION: ReadonlySet<string> = new Set()
 
 // The Transactions filter, the same Usage / Top-ups split the Activity chart offers — plus
 // `all`, which is the table's own default and the whole ledger it always showed. `type` goes
@@ -801,24 +795,22 @@ export default function BillingView() {
   const txItems = sideType ? loaded.filter((t) => t.type === sideType) : loaded
   const nextCursor = mine ? mine.nextCursor : (transactions.data?.nextCursor ?? null)
 
-  // The Session half of the attribution predicate, one read for every period on screen. The
-  // CP's `/usage` is the viewer-scoped projection: an id it returns for a window is one the
-  // console already attributes to this viewer there, so naming the same agent on a charge for
-  // that window discloses nothing new. Per PERIOD and never unioned across them — an agent
-  // attributable in one month is not thereby attributable in another. Fail closed on error.
+  // Where a usage row's attribution comes from: the CP's viewer-scoped `/usage` projection,
+  // one read per period on screen. Per PERIOD and never unioned across them — spend a viewer
+  // may attribute in one month says nothing about another. Fail closed on error.
   const periods = [...new Set(txItems.filter((t) => t.type === 'debit').map((t) => t.period))].sort()
-  const attribution = useSWR<Map<string, Set<string>>>(
+  const attribution = useSWR<Map<string, Map<string, string>>>(
     orgId && periods.length ? consoleKeys.billingAttribution(orgId, periods.join(',')) : null,
     async ([, , , joined]) => {
       const wanted = (joined as string).split(',')
-      const sets = await Promise.all(
-        wanted.map((p) => fetchAttributableAgentIds(periodStart(p), periodStart(nextPeriod(p)), orgId!))
+      const reads = await Promise.all(
+        wanted.map((p) => fetchGatewayAttribution(periodStart(p), periodStart(nextPeriod(p)), orgId!))
       )
-      return new Map(wanted.map((p, i) => [p, sets[i]!]))
+      return new Map(wanted.map((p, i) => [p, reads[i]!]))
     }
   )
-  const attributableIn = (period: string): ReadonlySet<string> =>
-    (attribution.error ? undefined : attribution.data?.get(period)) ?? EMPTY_ATTRIBUTION
+  const attributionIn = (period: string): ReadonlyMap<string, string> | undefined =>
+    attribution.error ? undefined : attribution.data?.get(period)
 
   // Deep-link landing for a console that does not offer billing: the rail hides
   // the entry, so anyone here typed the URL or followed an old bookmark. Gated on
@@ -1100,7 +1092,7 @@ export default function BillingView() {
                             with a default avatar. See `agentSplit` and billing-api.ts. */}
                         {!credit &&
                           (() => {
-                            const split = agentSplit(t.agents, agentById, attributableIn(t.period))
+                            const split = rowAttribution(t.amount, attributionIn(t.period), agentById)
                             // The description column shares the row with the amount, so the
                             // NAMED chips are capped. The rollup is appended after the cap: it
                             // is the one chip that must never be hidden behind a `+N`.

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -7,7 +7,7 @@
 // the purchase until the service says the payment settled. The return redirect
 // itself is never treated as proof of payment.
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import useSWR, { useSWRConfig } from 'swr'
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts'
@@ -25,6 +25,7 @@ import {
   fmtMicroUsd,
   type BillingAccount,
   type BillingPurchase,
+  type BillingDebitAgent,
   type BillingTransaction
 } from '@/lib/billing-api'
 import {
@@ -37,10 +38,12 @@ import {
 } from '@/lib/billing-activity'
 import { balanceBanner, ledgerHistory } from '@/lib/billing-banner'
 import { featureFlagEnabled } from '@/lib/feature-flags'
+import { fetchAgents } from '@/lib/api'
+import { agentLabel, type Agent } from '@/lib/data'
 import { useOrgs } from '@/lib/org-context'
 import { SEG_FILL, tickInterval } from '@/lib/spend-chart'
 import { consoleKeys } from '@/lib/swr-keys'
-import { LoadingState } from '@/components/marks'
+import { AgentIconView, LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 
 // `.row` is a bare grid — the column template is the caller's, as a full literal.
@@ -49,6 +52,31 @@ import { Button, Icon } from '@/components/ui'
 // `auto` track sizes per-row and pulls the header out of line with the body below it.
 // Mobile scrolls the card sideways (globals' `.card:has(.row)`), so one template serves both.
 const TX_GRID = 'grid-cols-[34px_minmax(0,1fr)_132px_24px_190px] gap-2'
+
+// Agent chips a usage row shows before the tail becomes a `+N` count.
+const TX_AGENT_CHIPS = 4
+
+// A debit's per-agent split, ordered biggest spend first. Every part gets its own entry —
+// what a viewer's roster decides is whether it is NAMED, not whether it appears. An id the
+// roster cannot resolve is carried as `agent: undefined` and its id is dropped here, so the
+// row renders a default avatar and an amount: `session-visibility.md` §5's rule that withheld
+// usage comes back id-less. Zero and unparseable parts are noise and are dropped.
+export function agentSplit(
+  parts: BillingDebitAgent[] | null | undefined,
+  agentById: Map<string, Agent>
+): { key: string; agent?: Agent; amount: string }[] {
+  if (!parts?.length) return []
+  return parts
+    .map((part, i) => ({ part, i, value: Number(part.amount) }))
+    .filter(({ value }) => Number.isFinite(value) && value !== 0)
+    .sort((a, b) => b.value - a.value)
+    .map(({ part, i }) => {
+      const agent = agentById.get(part.agentId)
+      // The key is positional for an unresolved part — a React key is not rendered, but
+      // keeping the id out of the component entirely is what makes that easy to review.
+      return { key: agent ? part.agentId : `hidden-${i}`, agent, amount: part.amount }
+    })
+}
 
 // The Transactions filter, the same Usage / Top-ups split the Activity chart offers — plus
 // `all`, which is the table's own default and the whole ledger it always showed. `type` goes
@@ -592,6 +620,13 @@ function MembersDontPayCard() {
 
 export default function BillingView() {
   const { activeOrg, myRole, loading: orgLoading } = useOrgs()
+  // The viewer's OWN roster — `/agents` is visibility-scoped, so an id missing from it is an
+  // id this viewer may not learn. Read on the console data provider's own SWR key so this
+  // shares its cache instead of fetching twice, and reads as empty (⇒ nothing named) if it fails.
+  const { data: agents } = useSWR<Agent[]>(consoleKeys.agents(activeOrg?.id ?? null), ([, orgId]) =>
+    fetchAgents(orgId as string)
+  )
+  const agentById = useMemo(() => new Map((agents ?? []).map((a) => [a.id, a])), [agents])
   const orgId = activeOrg?.id ?? null
   const router = useRouter()
   const pathname = usePathname()
@@ -998,9 +1033,54 @@ export default function BillingView() {
                         >
                           {credit ? t.kind : 'usage'}
                         </span>
-                        {/* No agent attribution here, deliberately: this feed is authorized on
-                            org membership alone, so naming the agent behind a charge would
-                            hand every member a resource-existence oracle. See billing-api.ts. */}
+                        {/* Who the charge is attributed to. An agent this viewer's roster
+                            cannot resolve still gets a chip — a default avatar and an amount,
+                            never a name and never its id. See billing-api.ts. */}
+                        {!credit &&
+                          (() => {
+                            const split = agentSplit(t.agents, agentById)
+                            // The description column is shared with the amount; cap the chips
+                            // so a period spanning the whole fleet cannot push it off the row.
+                            const shown = split.slice(0, TX_AGENT_CHIPS)
+                            const rest = split.length - shown.length
+                            return (
+                              <>
+                                {shown.map((part) => (
+                                  <span
+                                    key={part.key}
+                                    data-tx-agent="true"
+                                    className={`inline-flex h-[21px] min-w-0 flex-none items-center gap-[5px] rounded-[4px] bg-(--surface-active) p-[2px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) ${
+                                      part.agent ? 'pr-[7px]' : ''
+                                    }`}
+                                    title={
+                                      part.agent ? `${agentLabel(part.agent)} — $${part.amount}` : `$${part.amount}`
+                                    }
+                                  >
+                                    <span className="av h-[17px] w-[17px] flex-none rounded-[5px]">
+                                      {part.agent ? (
+                                        <AgentIconView icon={part.agent.icon} runtime={part.agent.runtime} size={17} />
+                                      ) : (
+                                        // The default avatar: this viewer may not learn which
+                                        // agent this is, only that the charge has another part.
+                                        <span
+                                          data-tx-agent-default="true"
+                                          className="flex h-full w-full items-center justify-center rounded-[inherit] bg-(--surface-sunken) text-(--text-tertiary)"
+                                        >
+                                          <Icon name="bot" size={10} strokeWidth={2} />
+                                        </span>
+                                      )}
+                                    </span>
+                                    {part.agent && (
+                                      <span className="max-w-[120px] truncate">{agentLabel(part.agent)}</span>
+                                    )}
+                                  </span>
+                                ))}
+                                {rest > 0 && (
+                                  <span className="mono flex-none text-[11.5px] text-(--text-tertiary)">+{rest}</span>
+                                )}
+                              </>
+                            )
+                          })()}
                         {/* Free operator text, rendered as TEXT — truncated, with the whole
                             note on hover, so a long one cannot push the amount column out. */}
                         {credit && t.note && (

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -38,8 +38,9 @@ import {
 } from '@/lib/billing-activity'
 import { balanceBanner, ledgerHistory } from '@/lib/billing-banner'
 import { featureFlagEnabled } from '@/lib/feature-flags'
-import { fetchAgents } from '@/lib/api'
+import { fetchAgents, fetchAttributableAgentIds } from '@/lib/api'
 import { agentLabel, type Agent } from '@/lib/data'
+import { sumAmounts } from '@/lib/amount'
 import { useOrgs } from '@/lib/org-context'
 import { SEG_FILL, tickInterval } from '@/lib/spend-chart'
 import { consoleKeys } from '@/lib/swr-keys'
@@ -53,30 +54,66 @@ import { Button, Icon } from '@/components/ui'
 // Mobile scrolls the card sideways (globals' `.card:has(.row)`), so one template serves both.
 const TX_GRID = 'grid-cols-[34px_minmax(0,1fr)_132px_24px_190px] gap-2'
 
-// Agent chips a usage row shows before the tail becomes a `+N` count.
+// Named agent chips a usage row shows before the tail becomes a `+N` count. The withheld
+// rollup is never one of them — it is appended after, so it cannot be capped out of view.
 const TX_AGENT_CHIPS = 4
 
-// A debit's per-agent split, ordered biggest spend first. Every part gets its own entry —
-// what a viewer's roster decides is whether it is NAMED, not whether it appears. An id the
-// roster cannot resolve is carried as `agent: undefined` and its id is dropped here, so the
-// row renders a default avatar and an amount: `session-visibility.md` §5's rule that withheld
-// usage comes back id-less. Zero and unparseable parts are noise and are dropped.
+/** One chip on a usage row. `agent` absent ⇒ the withheld rollup: no id, no count, no name. */
+export interface TxAgentChip {
+  key: string
+  agent?: Agent
+  /** Exact decimal string, added with `sumAmounts` — never a float. */
+  amount: string
+}
+
+// A debit's per-agent split, reduced to what this viewer is already entitled to know.
+//
+// Naming an agent here needs BOTH predicates that `session-visibility.md` §5 makes usage
+// attribution intersect, and neither comes from the billing service — it authorizes on org
+// membership alone, so its ids are the ORG's:
+//
+//   `agentById`     — Agent visibility, from the viewer's own `/agents` roster (name + icon);
+//   `attributable`  — the Session predicate, from the CP's viewer-scoped `/usage` projection
+//                     for this row's period. An id in it is one the console ALREADY attributes
+//                     to this viewer for that window, so naming it discloses nothing new.
+//
+// Everything else — a restricted agent, or spend from a session this viewer may not read —
+// collapses into ONE id-less rollup carrying only its summed amount. Not one entry each:
+// the row's own total already discloses the sum, but the partition and the number of
+// withheld contributors are not the viewer's to learn, and `unattributed` carries no count
+// for the same reason. Zero and unparseable parts are noise and are dropped.
 export function agentSplit(
   parts: BillingDebitAgent[] | null | undefined,
-  agentById: Map<string, Agent>
-): { key: string; agent?: Agent; amount: string }[] {
+  agentById: Map<string, Agent>,
+  attributable: ReadonlySet<string>
+): TxAgentChip[] {
   if (!parts?.length) return []
-  return parts
-    .map((part, i) => ({ part, i, value: Number(part.amount) }))
-    .filter(({ value }) => Number.isFinite(value) && value !== 0)
-    .sort((a, b) => b.value - a.value)
-    .map(({ part, i }) => {
-      const agent = agentById.get(part.agentId)
-      // The key is positional for an unresolved part — a React key is not rendered, but
-      // keeping the id out of the component entirely is what makes that easy to review.
-      return { key: agent ? part.agentId : `hidden-${i}`, agent, amount: part.amount }
-    })
+  const named: { chip: TxAgentChip; value: number }[] = []
+  const withheld: string[] = []
+  for (const part of parts) {
+    const value = Number(part.amount)
+    if (!Number.isFinite(value) || value === 0) continue
+    const agent = attributable.has(part.agentId) ? agentById.get(part.agentId) : undefined
+    // The id never enters a chip it cannot name — `key` included, so it cannot leak through
+    // a prop that ends up serialized.
+    if (agent) named.push({ chip: { key: part.agentId, agent, amount: part.amount }, value })
+    else withheld.push(part.amount)
+  }
+  named.sort((a, b) => b.value - a.value)
+  const chips = named.map(({ chip }) => chip)
+  if (withheld.length) chips.push({ key: 'withheld', amount: sumAmounts(withheld) })
+  return chips
 }
+
+// A debit's `period` is a UTC calendar month (`YYYY-MM`); these are its half-open window.
+const periodStart = (period: string) => `${period}-01T00:00:00.000Z`
+const nextPeriod = (period: string) => {
+  const [y, m] = period.split('-').map(Number) as [number, number]
+  return m === 12 ? `${y + 1}-01` : `${y}-${String(m + 1).padStart(2, '0')}`
+}
+
+// Shared so a row with no projection yet reuses one empty set rather than allocating per render.
+const EMPTY_ATTRIBUTION: ReadonlySet<string> = new Set()
 
 // The Transactions filter, the same Usage / Top-ups split the Activity chart offers — plus
 // `all`, which is the table's own default and the whole ledger it always showed. `type` goes
@@ -620,13 +657,19 @@ function MembersDontPayCard() {
 
 export default function BillingView() {
   const { activeOrg, myRole, loading: orgLoading } = useOrgs()
-  // The viewer's OWN roster — `/agents` is visibility-scoped, so an id missing from it is an
-  // id this viewer may not learn. Read on the console data provider's own SWR key so this
-  // shares its cache instead of fetching twice, and reads as empty (⇒ nothing named) if it fails.
-  const { data: agents } = useSWR<Agent[]>(consoleKeys.agents(activeOrg?.id ?? null), ([, orgId]) =>
+  // The viewer's OWN roster, for the name and icon of an agent this row may name. Read on the
+  // console data provider's own SWR key so it shares that cache instead of fetching twice.
+  //
+  // `error` is read, not just `data`: SWR keeps the last successful roster when a revalidation
+  // fails, so ignoring it would keep naming agents from a roster that may since have had
+  // visibility revoked. A failed refresh reads as EMPTY — fail closed, name nothing.
+  const { data: agents, error: agentsError } = useSWR<Agent[]>(consoleKeys.agents(activeOrg?.id ?? null), ([, orgId]) =>
     fetchAgents(orgId as string)
   )
-  const agentById = useMemo(() => new Map((agents ?? []).map((a) => [a.id, a])), [agents])
+  const agentById = useMemo(
+    () => (agentsError ? new Map<string, Agent>() : new Map((agents ?? []).map((a) => [a.id, a]))),
+    [agents, agentsError]
+  )
   const orgId = activeOrg?.id ?? null
   const router = useRouter()
   const pathname = usePathname()
@@ -746,6 +789,37 @@ export default function BillingView() {
     }
   }, [orgId, checkout, refreshMoney])
 
+  // Page one from SWR plus the appended tail, deduped: a revalidated page one can
+  // grow into rows the tail already fetched.
+  const mine = tail && tail.orgId === orgId && tail.side === side ? tail : null
+  const tailItems = mine ? mine.items : []
+  const firstIds = new Set(transactions.data?.items.map((t) => t.id))
+  const loaded = transactions.data ? [...transactions.data.items, ...tailItems.filter((t) => !firstIds.has(t.id))] : []
+  // The side is a REQUEST: a billing image that predates `type` ignores it and answers with
+  // the whole ledger. Cutting again here is what stops that image from rendering top-ups
+  // under a pill that says Usage — a wrong answer is worse than a narrower one.
+  const txItems = sideType ? loaded.filter((t) => t.type === sideType) : loaded
+  const nextCursor = mine ? mine.nextCursor : (transactions.data?.nextCursor ?? null)
+
+  // The Session half of the attribution predicate, one read for every period on screen. The
+  // CP's `/usage` is the viewer-scoped projection: an id it returns for a window is one the
+  // console already attributes to this viewer there, so naming the same agent on a charge for
+  // that window discloses nothing new. Per PERIOD and never unioned across them — an agent
+  // attributable in one month is not thereby attributable in another. Fail closed on error.
+  const periods = [...new Set(txItems.filter((t) => t.type === 'debit').map((t) => t.period))].sort()
+  const attribution = useSWR<Map<string, Set<string>>>(
+    orgId && periods.length ? consoleKeys.billingAttribution(orgId, periods.join(',')) : null,
+    async ([, , , joined]) => {
+      const wanted = (joined as string).split(',')
+      const sets = await Promise.all(
+        wanted.map((p) => fetchAttributableAgentIds(periodStart(p), periodStart(nextPeriod(p)), orgId!))
+      )
+      return new Map(wanted.map((p, i) => [p, sets[i]!]))
+    }
+  )
+  const attributableIn = (period: string): ReadonlySet<string> =>
+    (attribution.error ? undefined : attribution.data?.get(period)) ?? EMPTY_ATTRIBUTION
+
   // Deep-link landing for a console that does not offer billing: the rail hides
   // the entry, so anyone here typed the URL or followed an old bookmark. Gated on
   // the flag, not on BILLING_URL — with the flag on and no endpoint configured the
@@ -772,18 +846,6 @@ export default function BillingView() {
   if (!account.data && !account.error) return <LoadingState fill />
 
   const acct = account.data
-
-  // Page one from SWR plus the appended tail, deduped: a revalidated page one can
-  // grow into rows the tail already fetched.
-  const mine = tail && tail.orgId === orgId && tail.side === side ? tail : null
-  const tailItems = mine ? mine.items : []
-  const firstIds = new Set(transactions.data?.items.map((t) => t.id))
-  const loaded = transactions.data ? [...transactions.data.items, ...tailItems.filter((t) => !firstIds.has(t.id))] : []
-  // The side is a REQUEST: a billing image that predates `type` ignores it and answers with
-  // the whole ledger. Cutting again here is what stops that image from rendering top-ups
-  // under a pill that says Usage — a wrong answer is worse than a narrower one.
-  const txItems = sideType ? loaded.filter((t) => t.type === sideType) : loaded
-  const nextCursor = mine ? mine.nextCursor : (transactions.data?.nextCursor ?? null)
 
   const loadMore = async () => {
     if (!nextCursor || loadingMore) return
@@ -1033,46 +1095,55 @@ export default function BillingView() {
                         >
                           {credit ? t.kind : 'usage'}
                         </span>
-                        {/* Who the charge is attributed to. An agent this viewer's roster
-                            cannot resolve still gets a chip — a default avatar and an amount,
-                            never a name and never its id. See billing-api.ts. */}
+                        {/* Who the charge is attributed to. An agent is named only when BOTH
+                            visibility predicates clear; everything else is one id-less rollup
+                            with a default avatar. See `agentSplit` and billing-api.ts. */}
                         {!credit &&
                           (() => {
-                            const split = agentSplit(t.agents, agentById)
-                            // The description column is shared with the amount; cap the chips
-                            // so a period spanning the whole fleet cannot push it off the row.
-                            const shown = split.slice(0, TX_AGENT_CHIPS)
-                            const rest = split.length - shown.length
+                            const split = agentSplit(t.agents, agentById, attributableIn(t.period))
+                            // The description column shares the row with the amount, so the
+                            // NAMED chips are capped. The rollup is appended after the cap: it
+                            // is the one chip that must never be hidden behind a `+N`.
+                            const named = split.filter((c) => c.agent)
+                            const rollup = split.find((c) => !c.agent)
+                            const shown = named.slice(0, TX_AGENT_CHIPS)
+                            const rest = named.length - shown.length
                             return (
                               <>
-                                {shown.map((part) => (
+                                {[...shown, ...(rollup ? [rollup] : [])].map((chip) => (
                                   <span
-                                    key={part.key}
+                                    key={chip.key}
                                     data-tx-agent="true"
-                                    className={`inline-flex h-[21px] min-w-0 flex-none items-center gap-[5px] rounded-[4px] bg-(--surface-active) p-[2px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) ${
-                                      part.agent ? 'pr-[7px]' : ''
-                                    }`}
-                                    title={
-                                      part.agent ? `${agentLabel(part.agent)} — $${part.amount}` : `$${part.amount}`
-                                    }
+                                    className="inline-flex h-[21px] min-w-0 flex-none items-center gap-[5px] rounded-[4px] bg-(--surface-active) p-[2px] pr-[7px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)"
                                   >
                                     <span className="av h-[17px] w-[17px] flex-none rounded-[5px]">
-                                      {part.agent ? (
-                                        <AgentIconView icon={part.agent.icon} runtime={part.agent.runtime} size={17} />
+                                      {chip.agent ? (
+                                        <AgentIconView icon={chip.agent.icon} runtime={chip.agent.runtime} size={17} />
                                       ) : (
-                                        // The default avatar: this viewer may not learn which
-                                        // agent this is, only that the charge has another part.
+                                        // The default avatar. This viewer may not learn which
+                                        // agents these are, how many, or how the amount splits
+                                        // between them — only that the rest of the charge is
+                                        // theirs. Labelled for assistive tech, since the glyph
+                                        // alone says nothing.
                                         <span
                                           data-tx-agent-default="true"
+                                          role="img"
+                                          aria-label="Agents you don’t have access to"
                                           className="flex h-full w-full items-center justify-center rounded-[inherit] bg-(--surface-sunken) text-(--text-tertiary)"
                                         >
                                           <Icon name="bot" size={10} strokeWidth={2} />
                                         </span>
                                       )}
                                     </span>
-                                    {part.agent && (
-                                      <span className="max-w-[120px] truncate">{agentLabel(part.agent)}</span>
+                                    {chip.agent && (
+                                      <span className="max-w-[110px] truncate">{agentLabel(chip.agent)}</span>
                                     )}
+                                    {/* Visible, not a tooltip: the console's tooltip ignores
+                                        touch and this chip is not focusable, so a `title` would
+                                        put the amount out of reach on mobile and by keyboard. */}
+                                    <span className="mono flex-none text-(--text-tertiary)">
+                                      {fmtDecimalUsd(chip.amount)}
+                                    </span>
                                   </span>
                                 ))}
                                 {rest > 0 && (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3555,6 +3555,20 @@ export function usageWindow(range: UsageRange, now: Date = new Date()): { from: 
   return { from: from.toISOString(), to: to.toISOString() }
 }
 
+// Which agents this VIEWER may see spend attributed to, over one explicit window.
+//
+// `/usage` is the CP's viewer-scoped attribution projection: it intersects Agent visibility
+// with the request-time Session predicate and returns what it withholds as one id-less
+// `unattributed` rollup (`session-visibility.md` §5). So an id in `agents` here is one the
+// console ALREADY names to this viewer for this window — which is exactly the permission a
+// second attribution surface needs before it names the same agent. Callers that only need
+// that set skip the rest of the aggregate.
+export async function fetchAttributableAgentIds(from: string, to: string, orgId?: string): Promise<Set<string>> {
+  const query = new URLSearchParams({ from, to })
+  const usage = await apiGet<UsageDto>(`${orgBase(orgId)}/usage?${query.toString()}`)
+  return new Set(usage.agents.map((a) => a.agentId))
+}
+
 export async function fetchUsage(range: UsageRange, orgId?: string, source?: UsageSource): Promise<UsageDto> {
   // Send the viewer's tz offset so the CP buckets the spend series to local
   // day/hour (getTimezoneOffset ⇒ UTC − local; stable per client, not in the key).

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3555,18 +3555,22 @@ export function usageWindow(range: UsageRange, now: Date = new Date()): { from: 
   return { from: from.toISOString(), to: to.toISOString() }
 }
 
-// Which agents this VIEWER may see spend attributed to, over one explicit window.
+// The viewer-scoped, gateway-metered per-agent spend for one explicit window.
 //
-// `/usage` is the CP's viewer-scoped attribution projection: it intersects Agent visibility
-// with the request-time Session predicate and returns what it withholds as one id-less
-// `unattributed` rollup (`session-visibility.md` §5). So an id in `agents` here is one the
-// console ALREADY names to this viewer for this window — which is exactly the permission a
-// second attribution surface needs before it names the same agent. Callers that only need
-// that set skip the rest of the aggregate.
-export async function fetchAttributableAgentIds(from: string, to: string, orgId?: string): Promise<Set<string>> {
-  const query = new URLSearchParams({ from, to })
+// `/usage` is the CP's attribution projection: it intersects Agent visibility with the
+// request-time Session predicate and returns what it withholds as one id-less `unattributed`
+// rollup (`session-visibility.md` §5). What comes back per agent is therefore the amount this
+// viewer may attribute — NOT an authorization for that agent's whole month. An agent with $1
+// of readable spend and $99 of private spend appears here with $1, and the $99 stays in the
+// residual; a caller that reduced this to a set of ids would reattach the $99 to the name.
+//
+// `source=gateway` because that is the ingress a billing charge settles from (see the route's
+// own note): unscoped, a readable DAEMON session could qualify an agent whose gateway spend is
+// entirely private.
+export async function fetchGatewayAttribution(from: string, to: string, orgId?: string): Promise<Map<string, string>> {
+  const query = new URLSearchParams({ from, to, source: 'gateway' })
   const usage = await apiGet<UsageDto>(`${orgBase(orgId)}/usage?${query.toString()}`)
-  return new Set(usage.agents.map((a) => a.agentId))
+  return new Map(usage.agents.map((a) => [a.agentId, a.costAmount]))
 }
 
 export async function fetchUsage(range: UsageRange, orgId?: string, source?: UsageSource): Promise<UsageDto> {

--- a/packages/web/src/lib/billing-api.test.ts
+++ b/packages/web/src/lib/billing-api.test.ts
@@ -12,7 +12,8 @@ import {
   fetchBillingTransactions,
   fmtDecimalUsd,
   BillingShapeError,
-  fmtMicroUsd
+  fmtMicroUsd,
+  type BillingDebit
 } from './billing-api'
 
 const tx = { type: 'credit', id: 't1', kind: 'purchase', amountMicro: 25_000_000, at: '2026-08-17T09:25:33.751Z' }
@@ -116,16 +117,21 @@ describe('assertTransactionsPage', () => {
     expect(() => assertTransactionsPage({ items: [{ ...tx, note: 7 }], nextCursor: null })).toThrow(BillingShapeError)
   })
 
-  it('passes a debit’s agent split through UNREAD rather than refusing the page', () => {
-    // Deliberately unmirrored: this feed is authorized on org membership alone, so its agent
-    // ids are the org's and not the viewer's. Nothing declares the field, so nothing can
-    // render it — and a service that sends one must still not take the page down.
-    expect(() =>
-      assertTransactionsPage({
-        items: [{ ...debit, agents: [{ agentId: 'agt_1', amount: '0.4' }] }],
-        nextCursor: null
-      })
-    ).not.toThrow()
+  it('mirrors a debit’s agent split, and drops a malformed one instead of failing the page', () => {
+    // The ids are the ORG's, not the viewer's — this boundary only carries them; the row
+    // resolves them against the viewer's roster before naming one (BillingView `agentSplit`).
+    const page = { items: [{ ...debit, agents: [{ agentId: 'agt_1', amount: '0.4' }] }], nextCursor: null }
+    expect(() => assertTransactionsPage(page)).not.toThrow()
+    expect((page.items[0] as unknown as BillingDebit).agents).toEqual([{ agentId: 'agt_1', amount: '0.4' }])
+
+    // The money on the row is the fact; the attribution is a garnish, so a bad split is
+    // dropped rather than taking a statement line down with it. ABSENT stays valid.
+    for (const agents of [[{ agentId: 'agt_1', amount: 0.4 }], [{ amount: '0.4' }], 'nope', 7]) {
+      const bad = { items: [{ ...debit, agents }], nextCursor: null }
+      expect(() => assertTransactionsPage(bad)).not.toThrow()
+      expect((bad.items[0] as unknown as BillingDebit).agents).toBeUndefined()
+    }
+    expect(() => assertTransactionsPage({ items: [debit], nextCursor: null })).not.toThrow()
   })
 
   it('refuses a row whose type this build cannot read', () => {

--- a/packages/web/src/lib/billing-api.test.ts
+++ b/packages/web/src/lib/billing-api.test.ts
@@ -12,8 +12,7 @@ import {
   fetchBillingTransactions,
   fmtDecimalUsd,
   BillingShapeError,
-  fmtMicroUsd,
-  type BillingDebit
+  fmtMicroUsd
 } from './billing-api'
 
 const tx = { type: 'credit', id: 't1', kind: 'purchase', amountMicro: 25_000_000, at: '2026-08-17T09:25:33.751Z' }
@@ -117,21 +116,16 @@ describe('assertTransactionsPage', () => {
     expect(() => assertTransactionsPage({ items: [{ ...tx, note: 7 }], nextCursor: null })).toThrow(BillingShapeError)
   })
 
-  it('mirrors a debit’s agent split, and drops a malformed one instead of failing the page', () => {
-    // The ids are the ORG's, not the viewer's — this boundary only carries them; the row
-    // resolves them against the viewer's roster before naming one (BillingView `agentSplit`).
-    const page = { items: [{ ...debit, agents: [{ agentId: 'agt_1', amount: '0.4' }] }], nextCursor: null }
-    expect(() => assertTransactionsPage(page)).not.toThrow()
-    expect((page.items[0] as unknown as BillingDebit).agents).toEqual([{ agentId: 'agt_1', amount: '0.4' }])
-
-    // The money on the row is the fact; the attribution is a garnish, so a bad split is
-    // dropped rather than taking a statement line down with it. ABSENT stays valid.
-    for (const agents of [[{ agentId: 'agt_1', amount: 0.4 }], [{ amount: '0.4' }], 'nope', 7]) {
-      const bad = { items: [{ ...debit, agents }], nextCursor: null }
-      expect(() => assertTransactionsPage(bad)).not.toThrow()
-      expect((bad.items[0] as unknown as BillingDebit).agents).toBeUndefined()
-    }
-    expect(() => assertTransactionsPage({ items: [debit], nextCursor: null })).not.toThrow()
+  it('passes a debit’s agent split through UNREAD rather than refusing the page', () => {
+    // Deliberately unmirrored: this feed is authorized on org membership alone, so its agent
+    // ids are the org's and not the viewer's. Nothing declares the field, so nothing can
+    // render it — and a service that sends one must still not take the page down.
+    expect(() =>
+      assertTransactionsPage({
+        items: [{ ...debit, agents: [{ agentId: 'agt_1', amount: '0.4' }] }],
+        nextCursor: null
+      })
+    ).not.toThrow()
   })
 
   it('refuses a row whose type this build cannot read', () => {

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -57,11 +57,12 @@ export interface BillingAccount {
 // the console routinely runs ahead of that image. Absent or null ⇒ the row renders without it.
 //
 // The debit arm's `agents` is the billing service's per-agent split of a charge. The service
-// authorizes on org membership alone, so its `agentId`s are the org's and NOT the viewer's:
-// the id is carried here, never rendered. The row names and pictures an agent only when the id
-// is already on the viewer's own `/agents` roster; every other part renders as a default avatar
-// and an amount, which is `session-visibility.md` §5's rule that withheld usage comes back
-// id-less, enforced on the read side because this service cannot enforce it on the write side.
+// authorizes on org membership alone, so its `agentId`s are the ORG's and NOT the viewer's:
+// this boundary only CARRIES them. Naming one is `session-visibility.md` §5's intersection —
+// Agent visibility AND the Session predicate — and neither is knowable here, so the row that
+// renders it resolves the ids against the viewer's `/agents` roster and the CP's viewer-scoped
+// `/usage` projection for that period, and collapses everything else into the one id-less
+// rollup §5 requires. See `agentSplit` in BillingView; nothing else may read this field.
 export interface BillingCredit {
   type: 'credit'
   id: string

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -56,13 +56,18 @@ export interface BillingAccount {
 // `note` is optional for the same reason `type` is: a service that predates it omits it, and
 // the console routinely runs ahead of that image. Absent or null ⇒ the row renders without it.
 //
-// The debit arm's `agents` is the billing service's per-agent split of a charge. The service
-// authorizes on org membership alone, so its `agentId`s are the ORG's and NOT the viewer's:
-// this boundary only CARRIES them. Naming one is `session-visibility.md` §5's intersection —
-// Agent visibility AND the Session predicate — and neither is knowable here, so the row that
-// renders it resolves the ids against the viewer's `/agents` roster and the CP's viewer-scoped
-// `/usage` projection for that period, and collapses everything else into the one id-less
-// rollup §5 requires. See `agentSplit` in BillingView; nothing else may read this field.
+// The debit arm's `agents` — the billing service's per-agent split of a charge — is
+// DELIBERATELY not mirrored. The service authorizes on org membership alone; it holds no Agent
+// or Session visibility, so its `agentId`s are the org's, not the viewer's, and its per-agent
+// AMOUNTS are the org's too. Naming one to every member is the discovery that
+// `docs/designs/authorization-policy.md` §4 forbids and a second attribution surface beside the
+// viewer-scoped one in `session-visibility.md` §5, whose whole rule is that withheld usage comes
+// back id-less. An opaque id is still an existence disclosure.
+//
+// The usage row DOES show attribution, and it gets every part of it — ids and amounts alike —
+// from the CP's viewer-scoped `/usage` projection instead (`fetchGatewayAttribution`, rendered
+// by `rowAttribution` in BillingView). Nothing this file declares is involved, which is the
+// point: a field nothing declares is a field nothing can render.
 export interface BillingCredit {
   type: 'credit'
   id: string
@@ -88,16 +93,6 @@ export interface BillingDebit {
   amount: string
   /** ISO 8601 instant. */
   at: string
-  /** The charge's per-agent split. Decimal strings, same unit as `amount`. Absent or null ⇒
-   *  an older service, or a charge the service could not attribute. Ids are the ORG's — see
-   *  the note above; resolve them against the viewer's roster before naming one. */
-  agents?: BillingDebitAgent[] | null
-}
-
-export interface BillingDebitAgent {
-  agentId: string
-  /** Decimal string, NOT a number. Parse it only to display it. */
-  amount: string
 }
 
 export type BillingTransaction = BillingCredit | BillingDebit
@@ -166,20 +161,6 @@ export class BillingShapeError extends BillingError {
 
 function isFiniteNumber(v: unknown): boolean {
   return typeof v === 'number' && Number.isFinite(v)
-}
-
-// Absent/null is the older contract; anything else must be a well-formed split or it is dropped.
-function isAgentSplit(v: unknown): v is BillingDebitAgent[] | null | undefined {
-  if (v === undefined || v === null) return true
-  return (
-    Array.isArray(v) &&
-    v.every(
-      (e) =>
-        !!e &&
-        typeof (e as BillingDebitAgent).agentId === 'string' &&
-        typeof (e as BillingDebitAgent).amount === 'string'
-    )
-  )
 }
 
 // Hand-rolled rather than zod: this is the whole surface, and pulling a schema
@@ -262,9 +243,9 @@ export function assertTransactionsPage(
       // A string, and never coerced to a number here — the exact value is what the
       // service sent, and only the display rounds it.
       if (typeof t.amount !== 'string' || typeof t.period !== 'string') throw new BillingShapeError('transaction')
-      // ABSENT is the older contract. A malformed split drops to `undefined` rather than
-      // failing the page: the money on the row is the fact, the attribution is a garnish.
-      if (!isAgentSplit(t.agents)) delete t.agents
+      // `agents` is checked by its ABSENCE from this list, not by a rule: an unmirrored field
+      // passes through unread, which is what keeps a service that sends one from failing the
+      // page. Nothing downstream can render what nothing here declares.
     } else {
       throw new BillingShapeError('transaction')
     }

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -56,13 +56,12 @@ export interface BillingAccount {
 // `note` is optional for the same reason `type` is: a service that predates it omits it, and
 // the console routinely runs ahead of that image. Absent or null ⇒ the row renders without it.
 //
-// The debit arm's `agents` — the control plane's per-agent split of a charge — is DELIBERATELY
-// not mirrored. The billing service authorizes on org membership alone; it holds no Agent or
-// Session visibility, so its `agentId`s are the org's, not the viewer's. Naming one to every
-// member is the discovery that `docs/designs/authorization-policy.md` §4 forbids and a second
-// attribution surface beside the viewer-scoped one in `session-visibility.md` §5, whose whole
-// rule is that withheld usage comes back id-less. An opaque id is still an existence
-// disclosure. Mirroring it needs a viewer-scoped response first — see #1480.
+// The debit arm's `agents` is the billing service's per-agent split of a charge. The service
+// authorizes on org membership alone, so its `agentId`s are the org's and NOT the viewer's:
+// the id is carried here, never rendered. The row names and pictures an agent only when the id
+// is already on the viewer's own `/agents` roster; every other part renders as a default avatar
+// and an amount, which is `session-visibility.md` §5's rule that withheld usage comes back
+// id-less, enforced on the read side because this service cannot enforce it on the write side.
 export interface BillingCredit {
   type: 'credit'
   id: string
@@ -88,6 +87,16 @@ export interface BillingDebit {
   amount: string
   /** ISO 8601 instant. */
   at: string
+  /** The charge's per-agent split. Decimal strings, same unit as `amount`. Absent or null ⇒
+   *  an older service, or a charge the service could not attribute. Ids are the ORG's — see
+   *  the note above; resolve them against the viewer's roster before naming one. */
+  agents?: BillingDebitAgent[] | null
+}
+
+export interface BillingDebitAgent {
+  agentId: string
+  /** Decimal string, NOT a number. Parse it only to display it. */
+  amount: string
 }
 
 export type BillingTransaction = BillingCredit | BillingDebit
@@ -156,6 +165,20 @@ export class BillingShapeError extends BillingError {
 
 function isFiniteNumber(v: unknown): boolean {
   return typeof v === 'number' && Number.isFinite(v)
+}
+
+// Absent/null is the older contract; anything else must be a well-formed split or it is dropped.
+function isAgentSplit(v: unknown): v is BillingDebitAgent[] | null | undefined {
+  if (v === undefined || v === null) return true
+  return (
+    Array.isArray(v) &&
+    v.every(
+      (e) =>
+        !!e &&
+        typeof (e as BillingDebitAgent).agentId === 'string' &&
+        typeof (e as BillingDebitAgent).amount === 'string'
+    )
+  )
 }
 
 // Hand-rolled rather than zod: this is the whole surface, and pulling a schema
@@ -238,9 +261,9 @@ export function assertTransactionsPage(
       // A string, and never coerced to a number here — the exact value is what the
       // service sent, and only the display rounds it.
       if (typeof t.amount !== 'string' || typeof t.period !== 'string') throw new BillingShapeError('transaction')
-      // `agents` is checked by its ABSENCE from this list, not by a rule: an unmirrored field
-      // passes through unread, which is what keeps a service that sends one from failing the
-      // page. Nothing downstream can render what nothing here declares.
+      // ABSENT is the older contract. A malformed split drops to `undefined` rather than
+      // failing the page: the money on the row is the fact, the attribution is a garnish.
+      if (!isAgentSplit(t.agents)) delete t.agents
     } else {
       throw new BillingShapeError('transaction')
     }

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -54,6 +54,10 @@ export const consoleKeys = {
     orgId: string | null | undefined,
     side: Side = 'all' as Side
   ) => consoleKey(orgId, 'billing-transactions', side),
+  /** The agents a viewer may see spend attributed to, per UTC billing period (`YYYY-MM`).
+   *  Keyed on the periods actually on screen, joined — one read serves the whole feed. */
+  billingAttribution: (orgId: string | null | undefined, periods: string) =>
+    consoleKey(orgId, 'billing-attribution', periods),
   /** The credit rows of the last 30 days — paged out of the same feed, so it keys apart
    *  from the first page `billingTransactions` serves the Billing table. */
   billingTopUps: (orgId: string | null | undefined) => consoleKey(orgId, 'billing-top-ups'),

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -54,8 +54,8 @@ export const consoleKeys = {
     orgId: string | null | undefined,
     side: Side = 'all' as Side
   ) => consoleKey(orgId, 'billing-transactions', side),
-  /** The agents a viewer may see spend attributed to, per UTC billing period (`YYYY-MM`).
-   *  Keyed on the periods actually on screen, joined — one read serves the whole feed. */
+  /** The viewer-scoped gateway spend per agent, per UTC billing period (`YYYY-MM`). Keyed on
+   *  the periods actually on screen, joined — one read serves the whole feed. */
   billingAttribution: (orgId: string | null | undefined, periods: string) =>
     consoleKey(orgId, 'billing-attribution', periods),
   /** The credit rows of the last 30 days — paged out of the same feed, so it keys apart


### PR DESCRIPTION
## What

The billing service already sends a per-agent split on every debit row; the console dropped it on the floor. A usage line in **Billing → Transactions** now shows who spent the money.

Each part of the split gets its own chip: the agent's avatar and label when the console can resolve it, a **default avatar and the amount** when it cannot. Chips are ordered by spend, capped at 4 with a `+N` tail so a period spanning the whole fleet can't push the amount column off the row.

## The authorization boundary

This is the part worth reviewing. `billing-api.ts` used to carry a long comment explaining why the split was *deliberately* unmirrored, and that reasoning still holds — it just has a read-side answer now.

The billing service authorizes on **org membership alone**, so the `agentId`s it sends are the *org's* and not the viewer's. Naming one to every member is the resource-existence disclosure `docs/designs/authorization-policy.md` §4 forbids, and a second attribution surface beside the viewer-scoped one in `session-visibility.md` §5 — whose whole rule is that withheld usage comes back id-less.

So the split is resolved against the viewer's own visibility-scoped `/agents` roster, and **an unresolvable id is dropped inside the reduction — React `key` included**. It never reaches the component, let alone the DOM. The roster decides whether a part is *named*, never whether it *appears*: cardinality and amount were already disclosed by the row's own total, identity is not.

An unloaded or failed roster **fails closed** — default avatars, no names.

## Known gap, and it is the service's to close

`/agents` scopes *agent* visibility but cannot apply the *Session* predicate. So a visible agent whose spend came from a session this viewer may not read is still attributed to it. Closing that needs a viewer-scoped split from the billing service, the way `http/routes/usage.ts` returns an id-less `unattributed` rollup. Flagging rather than fixing here — the fix does not live in the console.

## Tests

`BillingView.agents.test.tsx` — 7 cases. Six pin the reduction (including *"no unresolvable id survives, in any field"* and *"an empty roster names nothing"*), one renders the real view and asserts that the resolvable agent gets its avatar + name, the unresolvable one gets the default avatar with no name, and its id appears nowhere in the DOM.

`billing-api.test.ts` — the boundary now mirrors `agents` and **drops a malformed split rather than failing the page**: the money on the row is the fact, the attribution is a garnish. Absent stays valid (older service).

Full `@agentconnect.md/web` suite: 2005 passed. typecheck / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)