### PR TITLE
fix(web): a billing period holds many charges, not one

### DIFF
--- a/packages/web/src/components/console/views/BillingView.agents.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.agents.test.tsx
@@ -2,34 +2,42 @@
 /**
  * What a usage row may say about who spent the money.
  *
- * Every figure comes from the CP's viewer-scoped `/usage` projection, gateway-scoped like the
- * charge itself — never from the billing service's own split, whose ids AND amounts are the
- * ORG's (it authorizes on org membership alone). That distinction is the whole boundary:
- * `session-visibility.md` §5 makes usage attribution the intersection of Agent visibility and
- * the Session predicate, and `/usage` applies both, so what it hands over per agent is what
- * this viewer may attribute — never an authorization for that agent's whole month. An agent
- * with $1 of readable spend and $99 of private spend is worth $1 here, and the $99 stays in
- * the id-less residual. These are security properties, not formatting ones.
+ * Two sources, two different questions. The AMOUNTS come from the billing service's split —
+ * the only thing that knows how one charge divides — and the PERMISSION to put a name beside
+ * one comes from the CP's viewer-scoped `/usage` projection for that charge's period.
+ *
+ * The gate is the projection's `complete`, not membership in it. `/usage.agents` lists an agent
+ * when ANY of its spend is readable and hides the rest in one id-less residual, so membership
+ * alone would let an agent with $1 readable and $99 private be named for charges covering the
+ * $99. Only a period that withholds nothing makes a name safe. These are security properties.
+ *
+ * The fixtures are real figures from a test org: one August with three separate charges, whose
+ * amounts sum to exactly the month's projected total. A period holds MANY charges — assuming
+ * one charge per period is what blanked the whole feed before.
  */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Agent } from '@/lib/data'
+import type { GatewayAttribution } from '@/lib/api'
 
-const DEBIT = {
+const AGENT_ID = '8173602b-1d84-41c5-9777-22a6eb2d2b51'
+const debit = (id: string, amount: string) => ({
   type: 'debit' as const,
-  id: 'd1',
+  id,
   period: '2026-08',
-  amount: '100.00',
-  at: '2026-08-20T10:00:00.000Z',
-  // The billing service's own org-scoped split. Nothing reads it — the assertions below pin
-  // that the row's figures come from the projection instead, not from these numbers.
-  agents: [{ agentId: 'agt_1', amount: '100.00' }]
-}
+  amount,
+  at: '2026-08-25T02:20:00.000Z',
+  agents: [{ agentId: AGENT_ID, amount }]
+})
+const DEBITS = [debit('d1', '0.006822824'), debit('d2', '0.015224848'), debit('d3', '0.001036384')]
 
 const mocks = vi.hoisted(() => ({
-  fetchAgents: vi.fn(async () => [{ id: 'agt_1', name: 'reviewer', runtime: 'claude' }]),
-  fetchAttribution: vi.fn(async () => new Map([['agt_1', '1.00']]))
+  fetchAgents: vi.fn(async () => [{ id: '8173602b-1d84-41c5-9777-22a6eb2d2b51', name: 'reviewer', runtime: 'claude' }]),
+  fetchAttribution: vi.fn(async () => ({
+    agents: new Set(['8173602b-1d84-41c5-9777-22a6eb2d2b51']),
+    complete: true
+  }))
 }))
 
 vi.mock('@/lib/org-context', () => ({
@@ -50,8 +58,8 @@ vi.mock('@/lib/billing-api', async () => ({
   createBillingPurchase: vi.fn(),
   fetchBillingPurchase: vi.fn(),
   fetchBillingAccount: async () => ({ orgId: 'org-1', balanceMicro: 10_000_000 }),
-  fetchBillingTransactions: async () => ({ items: [DEBIT], nextCursor: null }),
-  fetchBillingTransactionsSince: async () => [DEBIT]
+  fetchBillingTransactions: async () => ({ items: DEBITS, nextCursor: null }),
+  fetchBillingTransactionsSince: async () => DEBITS
 }))
 
 const { default: BillingView, rowAttribution } = await import('./BillingView')
@@ -61,89 +69,82 @@ const roster = new Map([
   ['agt_1', agent('agt_1', 'reviewer')],
   ['agt_2', agent('agt_2', 'triage')]
 ])
+const complete = (...ids: string[]): GatewayAttribution => ({ agents: new Set(ids), complete: true })
+const partial = (...ids: string[]): GatewayAttribution => ({ agents: new Set(ids), complete: false })
 
 describe('rowAttribution', () => {
-  it('names an agent for its SCOPED amount, never the row it appears on', () => {
-    // $1 readable + $99 private on one visible agent. Membership would name it for $100;
-    // the projection's own figure is the only one it may be named for.
-    const chips = rowAttribution('100', new Map([['agt_1', '1']]), roster)
-    expect(chips).toEqual([
-      { key: 'agt_1', agent: roster.get('agt_1'), amount: '1' },
-      { key: 'withheld', amount: '99' }
-    ])
+  it('names an agent for its exact per-row amount when the period withholds nothing', () => {
+    const chips = rowAttribution([{ agentId: 'agt_1', amount: '0.006822824' }], complete('agt_1'), roster)
+    expect(chips).toEqual([{ key: 'agt_1', agent: roster.get('agt_1'), amount: '0.006822824' }])
   })
 
-  it('leaves an unresolvable agent’s spend in the residual, id and all', () => {
-    const chips = rowAttribution('10', new Map([['agt_gone', '4']]), roster)
-    expect(chips).toEqual([{ key: 'withheld', amount: '10' }])
+  it('refuses to name ANY agent in a period that withholds something', () => {
+    // The $1-readable / $99-private case: the agent is in `agents`, but the residual means the
+    // projection cannot say which spend was readable, so no charge in the period may carry a
+    // name — however small the residual is.
+    const chips = rowAttribution([{ agentId: 'agt_1', amount: '100' }], partial('agt_1'), roster)
+    expect(chips).toEqual([{ key: 'withheld', amount: '100' }])
+    expect(JSON.stringify(chips)).not.toContain('agt_1')
+  })
+
+  it('withholds an agent the projection does not list at all', () => {
+    const chips = rowAttribution([{ agentId: 'agt_2', amount: '3' }], complete('agt_1'), roster)
+    expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
+  })
+
+  it('withholds an agent the roster cannot resolve, id and all', () => {
+    const chips = rowAttribution([{ agentId: 'agt_gone', amount: '3' }], complete('agt_gone'), roster)
+    expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
     expect(JSON.stringify(chips)).not.toContain('agt_gone')
   })
 
   it('collapses everything withheld into ONE rollup — no count, no partition', () => {
     const chips = rowAttribution(
-      '10',
-      new Map([
-        ['agt_1', '1'],
-        ['x', '2'],
-        ['y', '3']
-      ]),
+      [
+        { agentId: 'agt_1', amount: '1' },
+        { agentId: 'x', amount: '0.1' },
+        { agentId: 'y', amount: '0.2' }
+      ],
+      complete('agt_1', 'x', 'y'),
       roster
     )
     expect(chips).toHaveLength(2)
-    expect(chips[1]).toEqual({ key: 'withheld', amount: '9' })
-  })
-
-  it('subtracts exactly, never as a float', () => {
-    // 0.3 - 0.1 - 0.1 is 0.09999999999999999 in binary floating point.
-    const chips = rowAttribution(
-      '0.3',
-      new Map([
-        ['agt_1', '0.1'],
-        ['agt_2', '0.1']
-      ]),
-      roster
-    )
-    expect(chips.at(-1)).toEqual({ key: 'withheld', amount: '0.1' })
-  })
-
-  it('omits the rollup when the viewer can attribute the whole row', () => {
-    const chips = rowAttribution(
-      '3',
-      new Map([
-        ['agt_1', '1'],
-        ['agt_2', '2']
-      ]),
-      roster
-    )
-    expect(chips.map((c) => c.key)).toEqual(['agt_2', 'agt_1'])
+    // 0.1 + 0.2 is 0.30000000000000004 in binary floating point.
+    expect(chips[1]).toEqual({ key: 'withheld', amount: '0.3' })
   })
 
   it('orders named agents by spend, biggest first', () => {
     const chips = rowAttribution(
-      '9',
-      new Map([
-        ['agt_1', '0.4'],
-        ['agt_2', '2.5']
-      ]),
+      [
+        { agentId: 'agt_1', amount: '0.40' },
+        { agentId: 'agt_2', amount: '2.50' }
+      ],
+      complete('agt_1', 'agt_2'),
       roster
     )
-    expect(chips.map((c) => c.agent?.name)).toEqual(['triage', 'reviewer', undefined])
+    expect(chips.map((c) => c.agent?.name)).toEqual(['triage', 'reviewer'])
   })
 
-  it('shows NOTHING rather than an overstated chip when naming exceeds the row', () => {
-    // A partial period, or a settlement this window does not describe: not reconcilable, so
-    // there is no split that both adds up and does not overstate. Say nothing.
-    expect(rowAttribution('1', new Map([['agt_1', '5']]), roster)).toEqual([])
+  it('fails closed while the projection is unloaded or errored', () => {
+    const chips = rowAttribution([{ agentId: 'agt_1', amount: '3' }], undefined, roster)
+    expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
   })
 
-  it('fails closed on a missing projection or an empty roster', () => {
-    expect(rowAttribution('10', undefined, roster)).toEqual([])
-    expect(rowAttribution('10', new Map(), roster)).toEqual([])
-    expect(rowAttribution('10', new Map([['agt_1', '1']]), new Map())).toEqual([{ key: 'withheld', amount: '10' }])
+  it('fails closed on an empty roster', () => {
+    const chips = rowAttribution([{ agentId: 'agt_1', amount: '3' }], complete('agt_1'), new Map())
+    expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
+  })
+
+  it('renders nothing when the service sent no split, or an empty one', () => {
+    expect(rowAttribution(undefined, complete('agt_1'), roster)).toEqual([])
+    expect(rowAttribution(null, complete('agt_1'), roster)).toEqual([])
+    expect(rowAttribution([], complete('agt_1'), roster)).toEqual([])
+    // A zero part is noise, not attribution.
+    expect(rowAttribution([{ agentId: 'agt_1', amount: '0' }], complete('agt_1'), roster)).toEqual([])
   })
 
   it('drops a part whose amount is not a number rather than rendering NaN', () => {
-    expect(rowAttribution('10', new Map([['agt_1', 'twelve']]), roster)).toEqual([{ key: 'withheld', amount: '10' }])
+    expect(rowAttribution([{ agentId: 'agt_1', amount: 'twelve' }], complete('agt_1'), roster)).toEqual([])
   })
 })
 
@@ -171,25 +172,19 @@ describe('the usage row', () => {
     ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = {}
   })
 
-  it('asks the CP for the periods on screen, not for a preset range', async () => {
+  it('asks the CP once for the period the rows share, not once per row', async () => {
     await render()
+    expect(mocks.fetchAttribution).toHaveBeenCalledTimes(1)
     expect(mocks.fetchAttribution).toHaveBeenCalledWith('2026-08-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z', 'org-1')
   })
 
-  it('renders the projection’s amount, not the billing service’s org-scoped one', async () => {
+  it('names the agent on EVERY charge in the period, not just one', async () => {
+    // A period holds many charges. Reconciling a monthly projection against a single row is
+    // what blanked all three of these before, so each one is asserted.
     const host = await render()
-    const chips = host.querySelectorAll('[data-tx-agent]')
-    expect(chips).toHaveLength(2)
-
-    // The projection attributes $1 of this $100 charge to a roster agent...
-    expect(chips[0]!.textContent).toBe('reviewer$1.00')
-    expect(chips[0]!.querySelector('[data-tx-agent-default]')).toBeNull()
-    // ...and the other $99 is the id-less residual. The billing split said $100 for this same
-    // agent; if that number ever reaches a CHIP, this assertion is what catches it. The row's
-    // own total is still $100 — that figure is the org's charge and was never in question.
-    expect(chips[1]!.textContent).toBe('$99.00')
-    expect(chips[1]!.querySelector('[data-tx-agent-default]')).not.toBeNull()
-    expect([...chips].map((c) => c.textContent).join('')).not.toContain('$100.00')
-    expect(host.textContent).toContain('-$100.00')
+    const chips = [...host.querySelectorAll('[data-tx-agent]')]
+    // Sub-cent charges keep their significant digits rather than all rounding to `$0.00`.
+    expect(chips.map((c) => c.textContent)).toEqual(['reviewer$0.006823', 'reviewer$0.01522', 'reviewer$0.001036'])
+    expect(host.querySelector('[data-tx-agent-default]')).toBeNull()
   })
 })

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -24,6 +24,7 @@ import {
   fmtDecimalUsd,
   fmtMicroUsd,
   type BillingAccount,
+  type BillingDebitAgent,
   type BillingPurchase,
   type BillingTransaction
 } from '@/lib/billing-api'
@@ -37,7 +38,7 @@ import {
 } from '@/lib/billing-activity'
 import { balanceBanner, ledgerHistory } from '@/lib/billing-banner'
 import { featureFlagEnabled } from '@/lib/feature-flags'
-import { fetchAgents, fetchGatewayAttribution } from '@/lib/api'
+import { fetchAgents, fetchGatewayAttribution, type GatewayAttribution } from '@/lib/api'
 import { agentLabel, type Agent } from '@/lib/data'
 import { sumAmounts } from '@/lib/amount'
 import { useOrgs } from '@/lib/org-context'
@@ -67,38 +68,43 @@ export interface TxAgentChip {
 
 // What a usage row may say about who spent the money.
 //
-// Every figure here comes from `projection` — the CP's viewer-scoped `/usage` read for this
-// row's period, gateway-scoped like the charge itself. That is the whole point: the billing
-// service's own split is org-scoped in BOTH its ids and its amounts, so an agent with $1 of
-// readable spend and $99 of private spend would be named for $100. The projection hands over
-// the $1 and keeps the $99 in the residual, which is `session-visibility.md` §5's rule that
-// withheld usage comes back id-less — and what is withheld is withheld by EITHER predicate.
+// The AMOUNTS come from the billing service's own split — the only thing that knows how one
+// charge divides — and the PERMISSION to attach a name to one comes from the CP's viewer-scoped
+// `/usage` projection for that charge's period. They are different questions and neither source
+// can answer the other's.
 //
-// `agentById` supplies only the name and icon: an id the roster cannot resolve is not named,
-// and its amount falls into the residual like any other withheld spend.
+// The gate is `projection.complete`, not membership. `/usage.agents` lists an agent when ANY of
+// its spend is readable, and hides the rest in one id-less residual — so membership alone would
+// let an agent with $1 readable and $99 private be named for charges that include the $99. Only
+// a period whose projection withholds NOTHING makes attribution safe, because then this viewer
+// may already attribute every dollar in it and a chip discloses nothing new. Any residual, and
+// the whole period falls back to id-less rollups.
 //
-// The residual is the ROW's total minus what was named, so the chips always add up to the line
-// they sit on. If naming exceeds the row — a partial period, or a settlement this projection's
-// window does not describe — the row is not reconcilable and gets NO attribution rather than an
-// overstated chip.
+// `agentById` supplies the name and icon; an id it cannot resolve is not named either. Whatever
+// is not named is summed into ONE rollup — no count, no partition — which is §5's rule that
+// withheld usage comes back id-less.
 export function rowAttribution(
-  rowAmount: string,
-  projection: ReadonlyMap<string, string> | undefined,
+  parts: BillingDebitAgent[] | null | undefined,
+  projection: GatewayAttribution | undefined,
   agentById: Map<string, Agent>
 ): TxAgentChip[] {
-  if (!projection?.size) return []
+  if (!parts?.length) return []
   const named: { chip: TxAgentChip; value: number }[] = []
-  for (const [agentId, amount] of projection) {
-    const agent = agentById.get(agentId)
-    const value = Number(amount)
-    if (!agent || !Number.isFinite(value) || value === 0) continue
-    named.push({ chip: { key: agentId, agent, amount }, value })
+  const withheld: string[] = []
+  for (const part of parts) {
+    const value = Number(part.amount)
+    if (!Number.isFinite(value) || value === 0) continue
+    // Every clause fails CLOSED: no projection (unloaded or errored), a period with any
+    // withheld spend, an agent outside it, or an id the roster cannot resolve.
+    const agent = projection?.complete && projection.agents.has(part.agentId) ? agentById.get(part.agentId) : undefined
+    // The id never enters a chip it cannot name — `key` included, so it cannot leak through a
+    // prop that ends up serialized.
+    if (agent) named.push({ chip: { key: part.agentId, agent, amount: part.amount }, value })
+    else withheld.push(part.amount)
   }
-  const residual = sumAmounts([rowAmount, ...named.map(({ chip }) => `-${chip.amount}`)])
-  if (residual.startsWith('-')) return []
   named.sort((a, b) => b.value - a.value)
   const chips = named.map(({ chip }) => chip)
-  if (Number(residual) > 0) chips.push({ key: 'withheld', amount: residual })
+  if (withheld.length) chips.push({ key: 'withheld', amount: sumAmounts(withheld) })
   return chips
 }
 
@@ -799,7 +805,7 @@ export default function BillingView() {
   // one read per period on screen. Per PERIOD and never unioned across them — spend a viewer
   // may attribute in one month says nothing about another. Fail closed on error.
   const periods = [...new Set(txItems.filter((t) => t.type === 'debit').map((t) => t.period))].sort()
-  const attribution = useSWR<Map<string, Map<string, string>>>(
+  const attribution = useSWR<Map<string, GatewayAttribution>>(
     orgId && periods.length ? consoleKeys.billingAttribution(orgId, periods.join(',')) : null,
     async ([, , , joined]) => {
       const wanted = (joined as string).split(',')
@@ -809,7 +815,7 @@ export default function BillingView() {
       return new Map(wanted.map((p, i) => [p, reads[i]!]))
     }
   )
-  const attributionIn = (period: string): ReadonlyMap<string, string> | undefined =>
+  const attributionIn = (period: string): GatewayAttribution | undefined =>
     attribution.error ? undefined : attribution.data?.get(period)
 
   // Deep-link landing for a console that does not offer billing: the rail hides
@@ -1092,7 +1098,14 @@ export default function BillingView() {
                             with a default avatar. See `agentSplit` and billing-api.ts. */}
                         {!credit &&
                           (() => {
-                            const split = rowAttribution(t.amount, attributionIn(t.period), agentById)
+                            // Nothing at all while the projection is in flight. Rendering the
+                            // fail-closed answer first would tell the reader they have no access
+                            // to an agent, then take it back a second later — a wrong statement,
+                            // not a slow one. Fail closed applies to a MISSING answer, not a
+                            // pending one.
+                            const split = attribution.isLoading
+                              ? []
+                              : rowAttribution(t.agents, attributionIn(t.period), agentById)
                             // The description column shares the row with the amount, so the
                             // NAMED chips are capped. The rollup is appended after the cap: it
                             // is the one chip that must never be hidden behind a `+N`.

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -8,6 +8,7 @@ import {
   deleteMemoryRecord,
   deleteOrgIcon,
   fetchAllGithubRepos,
+  fetchGatewayAttribution,
   fetchConversations,
   fetchConversationByKey,
   fetchSessionFacets,
@@ -105,6 +106,60 @@ describe('session profile identity hints', () => {
 
     await expect(fetchMySessionIdentity('lark')).resolves.toEqual({ linked: true })
     await expect(fetchMySessionIdentity('feishu')).resolves.toEqual({ linked: false })
+  })
+})
+
+describe('fetchGatewayAttribution', () => {
+  afterEach(() => {
+    setApiOrgId(null)
+    vi.unstubAllGlobals()
+  })
+
+  const usage = (extra: Record<string, unknown>) => {
+    const calls: string[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        calls.push(url)
+        return new Response(
+          JSON.stringify({
+            from: 'x',
+            to: 'y',
+            totals: { sessions: 0, totalTokens: 0, costAmount: '0', costCurrency: null },
+            agents: [{ agentId: 'agt_1', costAmount: '1' }],
+            models: [],
+            sources: [],
+            series: { bucket: 'day', points: [] },
+            ...extra
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      })
+    )
+    return calls
+  }
+
+  it('scopes the read to the gateway ingress a charge settles from', async () => {
+    const calls = usage({})
+    await fetchGatewayAttribution('2026-08-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z', 'org-1')
+    expect(calls[0]).toContain('source=gateway')
+  })
+
+  it('is complete only when the residual is ABSENT, never when it is present and zero', async () => {
+    // The CP omits `unattributed` rather than zeroing it so a reader can tell "nothing was
+    // hidden" from "something was hidden and cost 0" — it is keyed on withheld SESSIONS, and an
+    // aggregate amount nets to zero through downward corrections. Reading a zero residual as
+    // completeness would qualify exactly the periods whose hidden usage is hardest to notice.
+    const window = ['2026-08-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z', 'org-1'] as const
+
+    usage({})
+    expect((await fetchGatewayAttribution(...window)).complete).toBe(true)
+
+    usage({ unattributed: { sessions: 1, totalTokens: 0, costAmount: '0' } })
+    expect((await fetchGatewayAttribution(...window)).complete).toBe(false)
+
+    usage({ unattributed: { sessions: 2, totalTokens: 40, costAmount: '99' } })
+    expect((await fetchGatewayAttribution(...window)).complete).toBe(false)
   })
 })
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3573,8 +3573,13 @@ export interface GatewayAttribution {
 //
 // Hence `complete`: only when the projection withholds NOTHING is membership equivalent to
 // "this caller may attribute every dollar in this window", which is the only condition under
-// which a second surface may put an amount next to a name. A window with any residual is
-// unusable for naming, however small the residual is.
+// which a second surface may put an amount next to a name.
+//
+// PRESENCE of the rollup is that signal, never its amount. The CP omits it rather than zeroing
+// it precisely so a reader can tell "nothing was hidden" from "something was hidden and cost 0"
+// — it is keyed on withheld SESSIONS, and an aggregate amount can net to zero through downward
+// corrections. Reading a zero residual as completeness would qualify exactly the periods whose
+// hidden usage is hardest to notice.
 //
 // `source=gateway` because that is the ingress a billing charge settles from (see the route's
 // own note): unscoped, a readable DAEMON session could qualify an agent whose gateway spend is
@@ -3582,11 +3587,7 @@ export interface GatewayAttribution {
 export async function fetchGatewayAttribution(from: string, to: string, orgId?: string): Promise<GatewayAttribution> {
   const query = new URLSearchParams({ from, to, source: 'gateway' })
   const usage = await apiGet<UsageDto>(`${orgBase(orgId)}/usage?${query.toString()}`)
-  const residual = usage.unattributed?.costAmount
-  return {
-    agents: new Set(usage.agents.map((a) => a.agentId)),
-    complete: residual === undefined || Number(residual) === 0
-  }
+  return { agents: new Set(usage.agents.map((a) => a.agentId)), complete: usage.unattributed === undefined }
 }
 
 export async function fetchUsage(range: UsageRange, orgId?: string, source?: UsageSource): Promise<UsageDto> {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3555,22 +3555,38 @@ export function usageWindow(range: UsageRange, now: Date = new Date()): { from: 
   return { from: from.toISOString(), to: to.toISOString() }
 }
 
-// The viewer-scoped, gateway-metered per-agent spend for one explicit window.
+/** What the CP's viewer-scoped `/usage` projection says about one window. `complete` is the
+ *  load-bearing field: false ⇒ SOME spend in this window is withheld from this caller, and the
+ *  projection cannot say whose, so nothing in the window may be attributed to a name. */
+export interface GatewayAttribution {
+  agents: Set<string>
+  complete: boolean
+}
+
+// The viewer-scoped, gateway-metered attribution for one explicit window.
 //
-// `/usage` is the CP's attribution projection: it intersects Agent visibility with the
-// request-time Session predicate and returns what it withholds as one id-less `unattributed`
-// rollup (`session-visibility.md` §5). What comes back per agent is therefore the amount this
-// viewer may attribute — NOT an authorization for that agent's whole month. An agent with $1
-// of readable spend and $99 of private spend appears here with $1, and the $99 stays in the
-// residual; a caller that reduced this to a set of ids would reattach the $99 to the name.
+// `/usage` intersects Agent visibility with the request-time Session predicate and returns what
+// it withholds as ONE id-less `unattributed` rollup (`session-visibility.md` §5) — id-less by
+// design, so an agent's presence in `agents` never proves that agent's whole window is readable.
+// An agent with $1 of readable spend and $99 of private spend appears in `agents` with $1 while
+// the $99 sits in `unattributed`, indistinguishable from any other agent's withheld spend.
+//
+// Hence `complete`: only when the projection withholds NOTHING is membership equivalent to
+// "this caller may attribute every dollar in this window", which is the only condition under
+// which a second surface may put an amount next to a name. A window with any residual is
+// unusable for naming, however small the residual is.
 //
 // `source=gateway` because that is the ingress a billing charge settles from (see the route's
 // own note): unscoped, a readable DAEMON session could qualify an agent whose gateway spend is
 // entirely private.
-export async function fetchGatewayAttribution(from: string, to: string, orgId?: string): Promise<Map<string, string>> {
+export async function fetchGatewayAttribution(from: string, to: string, orgId?: string): Promise<GatewayAttribution> {
   const query = new URLSearchParams({ from, to, source: 'gateway' })
   const usage = await apiGet<UsageDto>(`${orgBase(orgId)}/usage?${query.toString()}`)
-  return new Map(usage.agents.map((a) => [a.agentId, a.costAmount]))
+  const residual = usage.unattributed?.costAmount
+  return {
+    agents: new Set(usage.agents.map((a) => a.agentId)),
+    complete: residual === undefined || Number(residual) === 0
+  }
 }
 
 export async function fetchUsage(range: UsageRange, orgId?: string, source?: UsageSource): Promise<UsageDto> {

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -56,18 +56,17 @@ export interface BillingAccount {
 // `note` is optional for the same reason `type` is: a service that predates it omits it, and
 // the console routinely runs ahead of that image. Absent or null ⇒ the row renders without it.
 //
-// The debit arm's `agents` — the billing service's per-agent split of a charge — is
-// DELIBERATELY not mirrored. The service authorizes on org membership alone; it holds no Agent
-// or Session visibility, so its `agentId`s are the org's, not the viewer's, and its per-agent
-// AMOUNTS are the org's too. Naming one to every member is the discovery that
-// `docs/designs/authorization-policy.md` §4 forbids and a second attribution surface beside the
-// viewer-scoped one in `session-visibility.md` §5, whose whole rule is that withheld usage comes
-// back id-less. An opaque id is still an existence disclosure.
+// The debit arm's `agents` is the billing service's per-agent split of a charge — the real
+// per-ROW amounts, which is why it is mirrored: nothing else knows how one charge divides.
 //
-// The usage row DOES show attribution, and it gets every part of it — ids and amounts alike —
-// from the CP's viewer-scoped `/usage` projection instead (`fetchGatewayAttribution`, rendered
-// by `rowAttribution` in BillingView). Nothing this file declares is involved, which is the
-// point: a field nothing declares is a field nothing can render.
+// It is NOT self-authorizing. The service holds no Agent or Session visibility, so its ids and
+// its amounts are both the ORG's, and rendering one as-is is the discovery
+// `docs/designs/authorization-policy.md` §4 forbids. The row may put an agent's name beside one
+// of these amounts only when the CP's viewer-scoped `/usage` projection says this viewer may
+// attribute EVERY dollar in that billing period (`fetchGatewayAttribution`, and `complete`
+// specifically). Otherwise the period's charges render one id-less rollup apiece, which is
+// `session-visibility.md` §5's rule that withheld usage comes back without an id. The gate lives
+// in `rowAttribution` in BillingView; nothing else may read this field.
 export interface BillingCredit {
   type: 'credit'
   id: string
@@ -93,6 +92,16 @@ export interface BillingDebit {
   amount: string
   /** ISO 8601 instant. */
   at: string
+  /** This charge's per-agent split. Decimal strings, same unit as `amount`. Absent or null ⇒
+   *  an older service, or a charge it could not split. Ids AND amounts are the ORG's — see the
+   *  note above: gate on the CP's projection before either reaches a chip. */
+  agents?: BillingDebitAgent[] | null
+}
+
+export interface BillingDebitAgent {
+  agentId: string
+  /** Decimal string, NOT a number. Parse it only to display it. */
+  amount: string
 }
 
 export type BillingTransaction = BillingCredit | BillingDebit
@@ -161,6 +170,20 @@ export class BillingShapeError extends BillingError {
 
 function isFiniteNumber(v: unknown): boolean {
   return typeof v === 'number' && Number.isFinite(v)
+}
+
+// Absent/null is the older contract; anything else must be a well-formed split or it is dropped.
+function isAgentSplit(v: unknown): v is BillingDebitAgent[] | null | undefined {
+  if (v === undefined || v === null) return true
+  return (
+    Array.isArray(v) &&
+    v.every(
+      (e) =>
+        !!e &&
+        typeof (e as BillingDebitAgent).agentId === 'string' &&
+        typeof (e as BillingDebitAgent).amount === 'string'
+    )
+  )
 }
 
 // Hand-rolled rather than zod: this is the whole surface, and pulling a schema
@@ -243,9 +266,9 @@ export function assertTransactionsPage(
       // A string, and never coerced to a number here — the exact value is what the
       // service sent, and only the display rounds it.
       if (typeof t.amount !== 'string' || typeof t.period !== 'string') throw new BillingShapeError('transaction')
-      // `agents` is checked by its ABSENCE from this list, not by a rule: an unmirrored field
-      // passes through unread, which is what keeps a service that sends one from failing the
-      // page. Nothing downstream can render what nothing here declares.
+      // ABSENT is the older contract. A malformed split drops to `undefined` rather than
+      // failing the page: the money on the row is the fact, the attribution is a garnish.
+      if (!isAgentSplit(t.agents)) delete t.agents
     } else {
       throw new BillingShapeError('transaction')
     }


### PR DESCRIPTION
Follow-up to #1493, which shipped a **blank usage feed**. Sorry — this is a regression I merged.

## What broke

Verified against a real org on the test backend. August has **three separate debit rows**, each carrying `period: "2026-08"`:

| row | amount |
|---|---|
| d1 | `$0.006822824` |
| d2 | `$0.015224848` |
| d3 | `$0.001036384` |
| **sum** | **`$0.023084056`** |

And `/usage?source=gateway` for August returns exactly `$0.023084056` for that one agent — the **month's** total.

#1493 computed each row's residual as `rowAmount − Σ named` against that monthly projection. Every row came out negative, hit the "not reconcilable → render nothing" guard, and the whole feed went blank. **One debit is a charge, not a period** — I assumed the wrong cardinality.

## The fix

Reconciling a period aggregate against a single charge was never going to work, so each source goes back to the question it can actually answer:

- **Amounts** ← the billing service's per-row split. It is the only thing that knows how one charge divides.
- **Permission to attach a name** ← the CP's viewer-scoped `/usage` projection for that charge's period.

The gate is the projection's **`complete`**, not membership in it — which preserves exactly what #1493's review was right about. `/usage.agents` lists an agent when *any* of its spend is readable and hides the rest in one id-less residual, so membership alone would let an agent with `$1` readable and `$99` private be named for charges covering the `$99`. Only a period whose projection withholds **nothing** makes a name safe: then the viewer may already attribute every dollar in it, and a chip discloses nothing new. Any residual, and the whole period falls back to id-less rollups. Still `source=gateway`, the ingress a charge settles from.

Every clause still fails closed: no projection, a period with any withheld spend, an agent outside it, or an id the roster cannot resolve.

## Also

No chips while the projection is in flight. Rendering the fail-closed answer first told the reader they had no access to an agent and took it back seven seconds later (the proxied `/usage` call takes 4.7–7.3s) — a wrong statement, not a slow one. Fail closed is for a *missing* answer, not a *pending* one.

## Verification

Browser, against the test backend — all three rows render the agent's avatar, name, and exact per-row amount, no default-avatar flash:

```
Usage — 2026-08  USAGE  ◆ AgentConnect $0.006823    -$0.006823  2026-08-25 10:20
```

Tests pin the cardinality that broke it (`names the agent on EVERY charge in the period, not just one`, using these real figures) and the gate (`refuses to name ANY agent in a period that withholds something`). Full `@agentconnect.md/web` suite: 2010 passed. typecheck / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)