### PR TITLE
feat(daemon): tell the user when a turn is waiting on a sandbox pod

### DIFF
--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -125,6 +125,24 @@ agent finishes the text block (a tool call, a plan, a thinking step), or until t
 ends. Splits the reader already expects — a completed text block before the agent starts
 working, or a body longer than the platform's per-message limit — are unaffected.
 
+## A cold sandbox pod is announced, not waited out in silence
+
+A turn whose agent runs in the cluster and has no pod up yet must first claim (or resume) a
+Sandbox, wait for it to become Ready, and bind its shim before the runtime sees the prompt.
+That is up to a minute and a half in which nothing is streaming, and a reader with no signal
+reads it as the agent having ignored them.
+
+So the turn says what it is waiting for, once, before the wait starts. A platform with a pushed
+per-turn status bar carries it there, in place of the generic startup label; every other surface —
+the console playground, the on-demand-status chat platforms — gets a short message of its own.
+Exactly one of the two, never both.
+
+It is live chrome and is never recorded: reloading a conversation rebuilds it from the
+transcript, where a wait that is over has nothing to say. A turn whose pod is already up says
+nothing at all, so the notice always means a real wait — and neither does the wait's label
+outlive it: once the pod is up the status returns to the ordinary working state, so a streamed
+answer is never delivered under a line still claiming a sandbox is being allocated.
+
 ## Slack message attribution footer
 
 The attribution footer for an agent response must be attached to the final Slack

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -511,6 +511,7 @@ import {
   MAX_TURN_CONTEXT_REGENERATION_MS,
   MAX_TURN_CONTEXT_REGENERATIONS,
   PROBE_ROOT_SWEEP_INTERVAL_MS,
+  SANDBOX_BOOTSTRAP_NOTICE,
   SESSION_RETENTION_SWEEP_INTERVAL_MS
 } from './daemon/constants.js'
 import type {
@@ -9245,6 +9246,8 @@ export class Daemon {
       // Read here, not in the planner: the sticky override is live daemon state.
       stickyOutputMode: await this.store.getOutputModeOverride(key),
       hostAlreadyRunning: this.hostStarts.has(agentId) || this.modelSessions.hasStartedHost(key),
+      // Synchronous and exact: an attached shim session IS the pod being up, so no cluster read.
+      clusterPodBootstrap: this.k8sPlane !== undefined && !this.k8sPlane.runsInSandbox(agentId),
       protectedAddresses: this.compoundMentionAddresses(agentId, msg),
       codexUsageIsPerPrompt: this.isCodexRuntime(agentId),
       features: { turnFinalContextRefresh: this.cfg.features.turnFinalContextRefresh },
@@ -9259,7 +9262,15 @@ export class Daemon {
     const conv = plan.turnSurface.createConverger(plan.turnCtx)
     const replyConn = plan.suppressReplyConn ? undefined : this.replyConnFor(agentId, integrationId)
     const run: TurnRun = { entry, key, plan, agent, replyConn, evaluation }
+    // Add the streaming fields onto the SAME webchat object held by QueueEntry. Sharing
+    // `doneSent` closes a Pending-vs-gate race where cancel could otherwise terminally signal
+    // each copy once. Seeded HERE, before `openSession`, because the sandbox-bootstrap notice
+    // below emits on this turn's `index` and must not collide with the reply's.
+    const pendingWebchat = webchat
+      ? Object.assign(webchat, { index: 0, replyText: '', heldText: '', messageEmitted: false })
+      : undefined
     this.showActivity(replyConn, msg.channel, plan.statusThread, plan.startupActivityLabel, plan.statusOptions)
+    if (plan.clusterPodBootstrap) this.announceSandboxBootstrap(run, pendingWebchat)
     const releaseReplyConn = this.holdReplyConnection(replyConn)
     const opened = await this.openSession(run, releaseReplyConn)
     if (opened.kind === 'cancelled') return null
@@ -9298,12 +9309,6 @@ export class Daemon {
       this.log.info(`dispatch: initialized session ${key} from self-authored channel root without a model turn`)
       return sessionId
     }
-    // Add the streaming fields onto the SAME webchat object held by QueueEntry. Sharing
-    // `doneSent` closes a Pending-vs-gate race where cancel could otherwise terminally
-    // signal each copy once.
-    const pendingWebchat = webchat
-      ? Object.assign(webchat, { index: 0, replyText: '', heldText: '', messageEmitted: false })
-      : undefined
     // Resolved once for the turn: the console addresses this session by its outward id (§1.1),
     // and most of the turn's link/status producers are synchronous.
     const outwardSessionId = await this.store.ensureOutwardSessionId(
@@ -9360,6 +9365,29 @@ export class Daemon {
   /** Clear this turn's transient platform activity indicator ("is thinking…"). */
   private clearTurnActivity(run: TurnRun): void {
     this.showActivity(run.replyConn, run.plan.channel, run.plan.statusThread, '')
+  }
+
+  /** Say that this turn is waiting on a cluster Sandbox pod, before the wait starts.
+   *  Live-only chrome: nothing is recorded, because the wait is not part of the conversation. */
+  private announceSandboxBootstrap(run: TurnRun, webchat: Pending['webchat']): void {
+    const { plan, entry, replyConn } = run
+    if (webchat) {
+      webchat.sink.output({
+        conversationId: webchat.conversationId,
+        turnId: webchat.turnId,
+        index: webchat.index++,
+        event: { kind: 'notice', text: SANDBOX_BOOTSTRAP_NOTICE }
+      })
+    }
+    // Chat origins only: a hook/code-host turn publishes one artifact at the end and must not
+    // grow a second message of its own.
+    if (!replyConn || originKindOf(plan.platform) !== 'chat') return
+    // A pushed status bar carries this turn's `startupActivityLabel` already, so a platform that
+    // shows one never reaches this post — and none that does has chrome metadata to be marked with.
+    if (turnChromeFor(plan.platform).statusSurface === 'turn-bar') return
+    void replyConn
+      .postMessage(plan.channel, SANDBOX_BOOTSTRAP_NOTICE, entry.msg.thread)
+      .catch((err) => this.log.warn(`cluster: sandbox bootstrap notice failed (${formatErr(err)})`))
   }
 
   /** §3.3 source gate: bind this session to the inbound envelope's external audience, then — only
@@ -9933,7 +9961,11 @@ export class Daemon {
     if (p.conv instanceof FeishuConverger) {
       for (const action of p.conv.onStart()) this.enqueueApply(p, action)
     }
-    if (!plan.hostAlreadyRunning)
+    // The pod wait ENDED inside openSession, so its label must not outlive it: a bootstrap turn
+    // transitions to "is thinking…" here even when its host was already running (a suspended pod
+    // drops its channel while `hostStarts` still holds the agent).
+    const podWaitOver = plan.clusterPodBootstrap
+    if (podWaitOver || !plan.hostAlreadyRunning)
       this.showActivity(replyConn, plan.channel, plan.statusThread, 'is thinking…', plan.statusOptions)
     // Post/refresh the session status bar up front — with the model now known (session
     // created) plus any usage carried over from prior turns — so it sits at the top of

--- a/packages/daemon/src/daemon/constants.ts
+++ b/packages/daemon/src/daemon/constants.ts
@@ -77,3 +77,7 @@ export const MAX_BG_TASK_WAKES_PER_SESSION = 20
  *  or the host is reclaimed. 20 is a display depth, not a durability promise — the panel is a
  *  live view, and the retained records are strictly outside the liveness set (see `settled`). */
 export const MAX_SETTLED_TASKS_PER_SESSION = 20
+
+/** Shown while a cluster turn waits for its Sandbox pod to come up and bind — up to
+ *  `K8sDriver.podUpTimeoutMs` of silence otherwise, with nothing to read as progress. */
+export const SANDBOX_BOOTSTRAP_NOTICE = '⏳ Allocating a sandbox pod…'

--- a/packages/daemon/src/daemon/turn-plan.ts
+++ b/packages/daemon/src/daemon/turn-plan.ts
@@ -38,6 +38,9 @@ export interface TurnPlanInput {
   stickyOutputMode: OutputMode | undefined
   /** `hostStarts.has(agentId) || modelSessions.hasStartedHost(key)`, read cold. */
   hostAlreadyRunning: boolean
+  /** `!k8sPlane.runsInSandbox(agentId)` on a cluster daemon: this turn must first bring a
+   *  Sandbox pod up and bind its shim, which is up to a minute and a half of silence. */
+  clusterPodBootstrap: boolean
   /** `daemon.compoundMentionAddresses(agentId, msg)`. */
   protectedAddresses: readonly string[]
   /** Pre-computed `isCodexRuntime(agentId)` — it reads the runtime command config, not just the name. */
@@ -71,8 +74,10 @@ export interface TurnPlan {
 
   /** True when this turn takes the null-connection seam: headless, non-continuation webchat, or `none`. */
   readonly suppressReplyConn: boolean
-  readonly startupActivityLabel: 'is thinking…' | 'is starting up…'
+  readonly startupActivityLabel: 'is thinking…' | 'is starting up…' | 'is allocating a sandbox pod…'
   readonly hostAlreadyRunning: boolean
+  /** This turn waits on a cluster sandbox pod — see {@link TurnPlanInput.clusterPodBootstrap}. */
+  readonly clusterPodBootstrap: boolean
 
   readonly turnSurface: DaemonTurnOutputSurface
   readonly turnCtx: TurnOutputContext<NormalizedMessage>
@@ -153,8 +158,14 @@ export function buildTurnPlan(input: TurnPlanInput): TurnPlan {
     }),
     suppressReplyConn,
     // Cold/warm is captured BEFORE sessions.handle(), which boots the host via hostFor().
-    startupActivityLabel: input.hostAlreadyRunning ? 'is thinking…' : 'is starting up…',
+    // A pod that is not up yet outranks both: it is the wait the user is actually about to sit through.
+    startupActivityLabel: input.clusterPodBootstrap
+      ? 'is allocating a sandbox pod…'
+      : input.hostAlreadyRunning
+        ? 'is thinking…'
+        : 'is starting up…',
     hostAlreadyRunning: input.hostAlreadyRunning,
+    clusterPodBootstrap: input.clusterPodBootstrap,
     turnSurface,
     turnCtx,
     statusOptions: slackStatusOptions(msg.platform, agentName, iconUrl),

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
+import { LocalMemoryFs } from '../src/memory/fs.js'
 import type { WebchatOutput, WebchatDone, RdChatEvent, RdMsgWebchat } from '@agentconnect.md/protocol'
 
 // A webchat conversation/agent target. agentId is a real UUID because the protocol
@@ -149,6 +150,24 @@ const sessionTitleToolCall = (toolCallId: string, status = 'in_progress') => ({
 })
 const sessionInfo = (title: string | null) => ({ sessionUpdate: 'session_info_update', title })
 
+/** The slice of `K8sRuntimePlane` a webchat turn touches, with the one fact under test:
+ *  whether this agent already has an attached shim session (i.e. its pod is up). */
+function fakeK8sPlane(bound: boolean) {
+  return {
+    runsInSandbox: () => bound,
+    withSandbox: (_id: string, work: () => Promise<unknown>) => work(),
+    ensureChannel: async () => {},
+    workspaceRootFor: () => undefined,
+    gitRunnerFor: () => undefined,
+    workspaceFsFor: () => undefined,
+    memoryFsFor: () => new LocalMemoryFs(mkdtempSync(join(tmpdir(), 'ac-wc-mem-'))),
+    autoMergeFor: () => undefined,
+    releaseAgent: () => {},
+    launchedAgents: () => [],
+    stop: async () => {}
+  }
+}
+
 describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
   it('maps message/thinking/tool chunks to webchat events with a monotonic index, then done', async () => {
     const { factory } = streamingHost([
@@ -189,6 +208,67 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
 
     // The turn closes with exactly one webchat/done carrying the stop reason.
     expect(cp.dones).toEqual([{ conversationId: CONV, turnId, stopReason: 'end_turn' }])
+    await daemon.stop()
+  }, 15_000)
+
+  it('streams a sandbox-bootstrap notice ahead of the reply when the pod is not up yet', async () => {
+    const { factory } = streamingHost([text('here is the answer')])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    // The one plane fact the turn reads: no attached shim session ⇒ this turn brings a pod up.
+    ;(daemon as any).k8sPlane = fakeK8sPlane(false)
+    const cp = fakeCpClient()
+    ;(daemon as any).cpClient = cp
+
+    const turnId = '55555555-5555-4555-8555-555555555555'
+    const msg = {
+      msgId: `webchat:${CONV}:${turnId}`,
+      traceId: turnId,
+      source: 'user' as const,
+      platform: 'webchat' as const,
+      channel: CONV,
+      sender: { id: 'alice', isBot: false },
+      text: 'go',
+      mentionedBots: [] as string[],
+      isDm: true,
+      trigger: 'dm' as const
+    }
+    await (daemon as any).dispatch(AGENT_ID, msg, undefined, { conversationId: CONV, turnId, sink: cp.sink })
+
+    // The notice leads the stream, and the reply's indices continue from it rather than
+    // restarting at 0 — a duplicate index is silently dropped by the browser's cursor.
+    expect(cp.outputs.filter((o) => o.event).map((o) => o.event)).toEqual([
+      { kind: 'notice', text: '\u23f3 Allocating a sandbox pod\u2026' },
+      { kind: 'message', text: 'here is the answer' }
+    ])
+    expect(cp.outputs.map((o) => o.index)).toEqual([...cp.outputs.keys()])
+    await daemon.stop()
+  }, 15_000)
+
+  it('leaves the webchat stream alone when the agent already has a bound sandbox', async () => {
+    const { factory } = streamingHost([text('here is the answer')])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    ;(daemon as any).k8sPlane = fakeK8sPlane(true)
+    const cp = fakeCpClient()
+    ;(daemon as any).cpClient = cp
+
+    const turnId = '44444444-4444-4444-8444-444444444444'
+    const msg = {
+      msgId: `webchat:${CONV}:${turnId}`,
+      traceId: turnId,
+      source: 'user' as const,
+      platform: 'webchat' as const,
+      channel: CONV,
+      sender: { id: 'alice', isBot: false },
+      text: 'go',
+      mentionedBots: [] as string[],
+      isDm: true,
+      trigger: 'dm' as const
+    }
+    await (daemon as any).dispatch(AGENT_ID, msg, undefined, { conversationId: CONV, turnId, sink: cp.sink })
+
+    expect(cp.outputs.some((o) => o.event?.kind === 'notice')).toBe(false)
     await daemon.stop()
   }, 15_000)
 

--- a/packages/daemon/test/sandbox-bootstrap-notice.test.ts
+++ b/packages/daemon/test/sandbox-bootstrap-notice.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Daemon } from '../src/daemon.js'
+import { SANDBOX_BOOTSTRAP_NOTICE } from '../src/daemon/constants.js'
+import { LocalMemoryFs } from '../src/memory/fs.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import type { NormalizedMessage } from '../src/messages/normalized.js'
+
+/**
+ * The sandbox-bootstrap notice (#1475), on the legacy (non-streaming) pipeline. A cluster turn
+ * whose agent has no attached shim session must bring a pod up first — up to a minute and a half
+ * of silence with nothing to read as progress — and the daemon says so before the wait. On a
+ * turn-bar platform (Slack) the wait rides the per-turn status bar and posts NO extra message; on
+ * an on-demand chat platform it is a message of its own. Either label then retires to
+ * "is thinking…" once the wait is over — even on a warm host, because a suspended pod drops its
+ * channel while `hostStarts` still holds the agent. The webchat `notice` event is covered in
+ * daemon-webchat.test.ts.
+ */
+
+function scaffold(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-sandbox-notice-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  const agentDir = join(root, 'agents', 'bot-a')
+  mkdirSync(agentDir, { recursive: true })
+  writeFileSync(
+    join(agentDir, 'agent.json'),
+    JSON.stringify({
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      workspace: { mode: 'from-scratch', path: join(agentDir, 'workspace') },
+      integrations: [],
+      output: { mode: 'low' }
+    })
+  )
+  return root
+}
+
+/** A cluster daemon whose agent has no bound pod: the one plane fact the notice is decided on. */
+function coldSandbox(daemon: Daemon): void {
+  ;(daemon as unknown as { k8sPlane: unknown }).k8sPlane = {
+    runsInSandbox: () => false,
+    withSandbox: (_id: string, work: () => Promise<unknown>) => work(),
+    ensureChannel: async () => {},
+    workspaceRootFor: () => undefined,
+    gitRunnerFor: () => undefined,
+    workspaceFsFor: () => undefined,
+    memoryFsFor: () => new LocalMemoryFs(mkdtempSync(join(tmpdir(), 'ac-sandbox-notice-mem-'))),
+    autoMergeFor: () => undefined,
+    releaseAgent: () => {},
+    launchedAgents: () => [],
+    stop: async () => {}
+  }
+}
+
+function bootDaemon(root: string): Daemon {
+  const host = {
+    __started: true,
+    start: vi.fn(async () => {}),
+    newSession: vi.fn(async () => 'acp-1'),
+    prompt: vi.fn(async () => 'end_turn'),
+    cancel: vi.fn(),
+    stop: vi.fn()
+  }
+  return new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => host as never } as never)
+}
+
+function chatMsg(platform: 'slack' | 'telegram', id: string): NormalizedMessage {
+  return {
+    msgId: `cron:${platform}:${id}`,
+    traceId: id,
+    source: 'cron',
+    platform,
+    channel: 'C1',
+    thread: 'T1',
+    sender: { id: 'cron:s', isBot: false },
+    text: 'go',
+    mentionedBots: [],
+    isDm: false,
+    trigger: 'cron'
+  } as NormalizedMessage
+}
+
+type Dispatchable = { dispatch: (agentId: string, msg: NormalizedMessage) => Promise<unknown> }
+
+describe('sandbox-bootstrap notice on the legacy pipeline', () => {
+  it("narrates a cold sandbox on Slack's status bar and posts no message for it", async () => {
+    const daemon = bootDaemon(scaffold())
+    await daemon.start()
+    coldSandbox(daemon)
+    const statuses: string[] = []
+    const conn = {
+      setStatus: vi.fn(async (_c: string, _t: string, status: string) => void statuses.push(status)),
+      postMessage: vi.fn(async () => undefined)
+    }
+    vi.spyOn(daemon as never as { replyConnFor: () => unknown }, 'replyConnFor').mockReturnValue(conn)
+
+    await (daemon as never as Dispatchable).dispatch('bot-a', chatMsg('slack', '1'))
+
+    expect(statuses).toContain('is allocating a sandbox pod…')
+    // Slack is turn-bar: the label rides the status bar, so no second message says the same thing.
+    expect(conn.postMessage).not.toHaveBeenCalledWith('C1', SANDBOX_BOOTSTRAP_NOTICE, expect.anything())
+    // The label does not outlive the wait it names — the row retires to "is thinking…".
+    expect(statuses.filter((text) => text !== '').at(-1)).toBe('is thinking…')
+    await daemon.stop()
+  }, 15_000)
+
+  it('retires the bootstrap label to "is thinking…" on a warm-host turn that still has no pod', async () => {
+    // The transition must not depend on the host being cold: a suspended pod drops its channel
+    // while `hostStarts` still holds the agent, which is a bootstrap turn with a warm host.
+    const daemon = bootDaemon(scaffold())
+    await daemon.start()
+    coldSandbox(daemon)
+    const statuses: string[] = []
+    const conn = {
+      setStatus: vi.fn(async (_c: string, _t: string, status: string) => void statuses.push(status)),
+      postMessage: vi.fn(async () => undefined)
+    }
+    vi.spyOn(daemon as never as { replyConnFor: () => unknown }, 'replyConnFor').mockReturnValue(conn)
+
+    await (daemon as never as Dispatchable).dispatch('bot-a', chatMsg('slack', '1')) // warms the host
+    statuses.length = 0
+    await (daemon as never as Dispatchable).dispatch('bot-a', chatMsg('slack', '2')) // warm host, still no pod
+
+    expect(statuses).toContain('is allocating a sandbox pod…')
+    expect(statuses.filter((text) => text !== '').at(-1)).toBe('is thinking…')
+    await daemon.stop()
+  }, 15_000)
+
+  it('posts the notice as its own message on an on-demand chat platform', async () => {
+    const daemon = bootDaemon(scaffold())
+    await daemon.start()
+    coldSandbox(daemon)
+    // Telegram is on-demand, not turn-bar, so the wait cannot ride a pushed status bar.
+    const conn = {
+      sendChatAction: vi.fn(async () => {}),
+      postMessage: vi.fn(async () => 'm1')
+    }
+    vi.spyOn(daemon as never as { replyConnFor: () => unknown }, 'replyConnFor').mockReturnValue(conn)
+
+    await (daemon as never as Dispatchable).dispatch('bot-a', chatMsg('telegram', '1'))
+
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', SANDBOX_BOOTSTRAP_NOTICE, 'T1')
+    await daemon.stop()
+  }, 15_000)
+})

--- a/packages/daemon/test/turn-plan.test.ts
+++ b/packages/daemon/test/turn-plan.test.ts
@@ -62,6 +62,7 @@ const planFor = (over: Partial<TurnPlanInput> = {}) =>
     evaluationTurnId: 'turn-1',
     stickyOutputMode: undefined,
     hostAlreadyRunning: true,
+    clusterPodBootstrap: false,
     protectedAddresses: [],
     codexUsageIsPerPrompt: false,
     features: { turnFinalContextRefresh: true },
@@ -112,6 +113,15 @@ describe('buildTurnPlan', () => {
   it('labels startup activity by whether the host is already running', () => {
     expect(planFor({ hostAlreadyRunning: true }).startupActivityLabel).toBe('is thinking…')
     expect(planFor({ hostAlreadyRunning: false }).startupActivityLabel).toBe('is starting up…')
+  })
+
+  it('lets a sandbox pod that is not up yet outrank both startup labels', () => {
+    for (const hostAlreadyRunning of [true, false]) {
+      const plan = planFor({ hostAlreadyRunning, clusterPodBootstrap: true })
+      expect(plan.startupActivityLabel).toBe('is allocating a sandbox pod…')
+      expect(plan.clusterPodBootstrap).toBe(true)
+    }
+    expect(planFor({ clusterPodBootstrap: false }).clusterPodBootstrap).toBe(false)
   })
 
   it('routes the final context refresh to exactly one of stageAnswer / webchatRefresh', () => {

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -129,7 +129,10 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   // is the replacement's ordinal (1 = first retry). An event rather than a
   // terminal frame: the turn still ends with exactly one `done`, so replay,
   // busy-state, and older browsers (which ignore unknown kinds) stay coherent.
-  z.object({ kind: z.literal('superseded'), generation: z.number().int() })
+  z.object({ kind: z.literal('superseded'), generation: z.number().int() }),
+  // Live-only chrome for a wait the user cannot otherwise see (a cluster sandbox pod coming up).
+  // Never persisted — a refresh rebuilds from the transcript, which does not record it.
+  z.object({ kind: z.literal('notice'), text: z.string() })
 ])
 export type WebchatEvent = z.infer<typeof WebchatEvent>
 

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -231,6 +231,7 @@ type WebchatEvent =
   | { kind: 'tool_update'; toolCallId: string; status: string; title?: string }
   | { kind: 'session_info'; title: string }
   | { kind: 'superseded'; generation: number }
+  | { kind: 'notice'; text: string }
 
 /** The session status snapshot carried in a relay `rd/chat` WebchatOutput payload
  *  (mirrors protocol WebchatStatus). Partial: context/cost stream live, token
@@ -527,6 +528,12 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             ...collapsed,
             lane({ kind: 'plan', text: 'The conversation moved on — updating this answer…', boundary: true })
           ]
+        }
+        if (ev.kind === 'notice') {
+          // Daemon chrome for a wait with nothing else to show (a sandbox pod coming up).
+          // Live-only, so it goes in the collapsible work lane; `boundary` keeps the reply
+          // chunks that follow from accumulating into it.
+          return [...steps, lane({ kind: 'plan', text: ev.text, boundary: true })]
         }
         if (ev.kind === 'message') {
           if (last && last.kind === 'done' && last.who === who) {

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -327,6 +327,33 @@ describe('stream text delta batching', () => {
     ])
   })
 
+  it('renders a daemon notice in the work lane without swallowing the reply that follows', async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId, agentId: 'agent-1', index: 0, event: { kind: 'notice', text: 'Allocating a sandbox pod…' } }
+        })
+      })
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId, agentId: 'agent-1', index: 1, event: { kind: 'thinking', text: 'here goes' } }
+        })
+      })
+    })
+    act(runFrame)
+
+    // The notice is its own step: `boundary` keeps the thinking chunk from accumulating into it.
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toMatchObject([
+      { kind: 'plan', text: 'Allocating a sandbox pod…', boundary: true },
+      { kind: 'plan', text: 'here goes' }
+    ])
+  })
+
   it('flushes the final text before applying done', async () => {
     const runFrame = captureAnimationFrames()
     const { socket, turnId } = await openStream()


### PR DESCRIPTION
## What

Re-lands #1475 — "tell the user when a turn is waiting on a sandbox pod" — on the legacy (non-streaming) Slack pipeline.

#1475 was backed out by #1495 because it had become entangled with the Slack native-streaming work that #1495 reverted. The pod-wait notice itself is an independent feature and was not the reason for the revert, so it comes back here on its own. #1495 is already merged into `main`, so this PR does not stack on anything: it targets `main` and its diff is only the pod-wait feature — no revert commits, no streaming.

Tracking: #1494. Original: #1475.

## Why it matters

A cluster turn whose agent has no attached shim session must claim (or resume) a Sandbox and wait for the pod to report Ready and bind its shim before anything runs — up to `K8sDriver.podUpTimeoutMs` of silence with nothing to read as progress. The turn plan now carries that fact as `clusterPodBootstrap`, read synchronously off `runsInSandbox` (an attached session IS the pod being up, so no extra cluster read), and the turn tells the user the wait is happening:

- On Slack (a turn-bar status surface) the per-turn status bar shows a third startup label, "is allocating a sandbox pod…", that outranks both the cold and warm labels. No second message is posted.
- On surfaces without a pushed status bar the notice is a message of its own: a new live-only `notice` webchat event for the console, and a chat post on the on-demand-status chat platforms. Chat origins only — a hook/code-host turn publishes one artifact at the end and must not grow a second message.

The notice is chrome, never recorded — a refresh rebuilds from the transcript, which does not hold it. Once the pod wait ends inside `openSession`, the label retires to "is thinking…", on a warm-host bootstrap turn too (a suspended pod drops its channel while `hostStarts` still holds the agent).

## How this differs from #1475

The cherry-pick was resolved to the legacy path in `daemon.ts`: all Slack native-streaming plumbing is dropped (`enableStreaming` / `slackStreamingEligible` / `streamsTurnStatus` / the streaming `loadingStatus` snapshot / the `conv` field on `TurnRun`), and only the pod-wait feature is layered on. Concretely:

- `openTurnChrome` keeps the legacy `TurnRun` and 5-arg `showActivity`; the webchat output fields are seeded before `openSession` (so the notice's `index` does not collide with the reply's) and `announceSandboxBootstrap` runs before the pod wait.
- `announceSandboxBootstrap` is kept, with its doc comment stripped of streaming references; it emits the webchat `notice`, returns for non-chat origins and for turn-bar platforms, and otherwise posts the notice.
- The "is thinking…" transition drops the streaming condition and fires on `podWaitOver || !hostAlreadyRunning`.

The Slack coverage the reverted streaming test file carried is re-homed to a new `packages/daemon/test/sandbox-bootstrap-notice.test.ts`, rewritten for the legacy path (status-bar label + no duplicate message on Slack; the "is thinking…" transition on both cold and warm-host turns; the message post on an on-demand chat platform). The webchat `notice` event stays covered by `daemon-webchat.test.ts`.

## Verified

All from this branch's worktree:

- `pnpm --filter @agentconnect.md/daemon test` — 4807 passed; the only failures are pre-existing local-env ones (the `shim-*` / `acp-matrix` suites need a sandbox `exec` capability and installed runtimes this machine lacks) plus three files that time out under CPU contention (`curated-runtime-daemon`, `daemon-duty-drain`, `daemon-k8s-mode`) and pass cleanly in isolation. The new `sandbox-bootstrap-notice` suite and `daemon-webchat` / `turn-plan` pass.
- `pnpm --filter @agentconnect.md/protocol test` — 452 passed.
- `pnpm --filter @agentconnect.md/web test` — 2008 passed.
- `pnpm eval:gates` — 28 files / 193 passed.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed.
- `pnpm format:check` — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
