### PR TITLE
fix(web): gate billing attribution per agent, and record the exception

### DIFF
--- a/docs/designs/session-visibility.md
+++ b/docs/designs/session-visibility.md
@@ -545,6 +545,23 @@ Invariants preserved:
   learn a restricted Agent's activity pattern at all — that needs the residual
   gone, not narrowed.
 
+- **Billing-ledger exception (accepted, product decision).** The billing
+  Transactions feed names an agent on a charge when that agent appears in the
+  viewer's `/usage?source=gateway` projection for the charge's period — i.e.
+  under exactly the intersection this section already uses for Analytics —
+  and renders the billing service's per-charge amount beside that name. A
+  named agent's per-charge amount may therefore include spend the projection
+  itself withholds (an agent with readable and private spend in the same
+  period is named for charges that cover both). This is a deliberate,
+  narrower cousin of the residual inference channel above and is accepted on
+  the same grounds: the ledger already publishes every charge's amount to
+  every member, and the stricter alternative — naming only in periods whose
+  projection withholds nothing — was shipped and blanked attribution for any
+  org with a single private session. What remains enforced: an agent absent
+  from the projection (no readable spend at all) is never named on any charge,
+  ids the roster cannot resolve are never rendered, and everything withheld on
+  a charge folds into one id-less rollup with no count and no partition.
+
 - 404, never 403, for invisible sessions (no existence oracle).
 - A `?triggeredBy=` / `?channel=` query filter remains a filter, not an
   authorization boundary; the predicate is applied regardless.

--- a/packages/web/src/components/console/views/BillingView.agents.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.agents.test.tsx
@@ -6,10 +6,11 @@
  * the only thing that knows how one charge divides — and the PERMISSION to put a name beside
  * one comes from the CP's viewer-scoped `/usage` projection for that charge's period.
  *
- * The gate is the projection's `complete`, not membership in it. `/usage.agents` lists an agent
- * when ANY of its spend is readable and hides the rest in one id-less residual, so membership
- * alone would let an agent with $1 readable and $99 private be named for charges covering the
- * $99. Only a period that withholds nothing makes a name safe. These are security properties.
+ * The gate is per-agent MEMBERSHIP in the projection — the intersection under which Analytics
+ * already names that agent to this viewer — per the billing exception in
+ * `session-visibility.md` §5. A period-completeness gate was tried and blanked attribution for
+ * any org with one private session. What §5 still forbids is pinned here: an agent in NO
+ * readable session stays id-less, and withheld parts fold into one countless rollup.
  *
  * The fixtures are real figures from a test org: one August with three separate charges, whose
  * amounts sum to exactly the month's projected total. A period holds MANY charges — assuming
@@ -19,7 +20,6 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Agent } from '@/lib/data'
-import type { GatewayAttribution } from '@/lib/api'
 
 const AGENT_ID = '8173602b-1d84-41c5-9777-22a6eb2d2b51'
 const debit = (id: string, amount: string) => ({
@@ -34,10 +34,7 @@ const DEBITS = [debit('d1', '0.006822824'), debit('d2', '0.015224848'), debit('d
 
 const mocks = vi.hoisted(() => ({
   fetchAgents: vi.fn(async () => [{ id: '8173602b-1d84-41c5-9777-22a6eb2d2b51', name: 'reviewer', runtime: 'claude' }]),
-  fetchAttribution: vi.fn(async () => ({
-    agents: new Set(['8173602b-1d84-41c5-9777-22a6eb2d2b51']),
-    complete: true
-  }))
+  fetchAttribution: vi.fn(async () => new Set(['8173602b-1d84-41c5-9777-22a6eb2d2b51']))
 }))
 
 vi.mock('@/lib/org-context', () => ({
@@ -69,31 +66,31 @@ const roster = new Map([
   ['agt_1', agent('agt_1', 'reviewer')],
   ['agt_2', agent('agt_2', 'triage')]
 ])
-const complete = (...ids: string[]): GatewayAttribution => ({ agents: new Set(ids), complete: true })
-const partial = (...ids: string[]): GatewayAttribution => ({ agents: new Set(ids), complete: false })
+const proj = (...ids: string[]): ReadonlySet<string> => new Set(ids)
 
 describe('rowAttribution', () => {
-  it('names an agent for its exact per-row amount when the period withholds nothing', () => {
-    const chips = rowAttribution([{ agentId: 'agt_1', amount: '0.006822824' }], complete('agt_1'), roster)
+  it('names an agent the projection lists, for its exact per-row amount', () => {
+    const chips = rowAttribution([{ agentId: 'agt_1', amount: '0.006822824' }], proj('agt_1'), roster)
     expect(chips).toEqual([{ key: 'agt_1', agent: roster.get('agt_1'), amount: '0.006822824' }])
   })
 
-  it('refuses to name ANY agent in a period that withholds something', () => {
-    // The $1-readable / $99-private case: the agent is in `agents`, but the residual means the
-    // projection cannot say which spend was readable, so no charge in the period may carry a
-    // name — however small the residual is.
-    const chips = rowAttribution([{ agentId: 'agt_1', amount: '100' }], partial('agt_1'), roster)
-    expect(chips).toEqual([{ key: 'withheld', amount: '100' }])
-    expect(JSON.stringify(chips)).not.toContain('agt_1')
+  it('still names an agent when the period withholds OTHER spend — the billing exception', () => {
+    // The projection lists agt_1 (Analytics already names it to this viewer). Some of the
+    // period's spend being withheld no longer blanks the whole period — that gate blanked
+    // every org with one private session. Recorded in session-visibility.md §5.
+    const chips = rowAttribution([{ agentId: 'agt_1', amount: '100' }], proj('agt_1'), roster)
+    expect(chips).toEqual([{ key: 'agt_1', agent: roster.get('agt_1'), amount: '100' }])
   })
 
   it('withholds an agent the projection does not list at all', () => {
-    const chips = rowAttribution([{ agentId: 'agt_2', amount: '3' }], complete('agt_1'), roster)
+    // No readable spend anywhere in the window ⇒ §5 still forbids naming it here.
+    const chips = rowAttribution([{ agentId: 'agt_2', amount: '3' }], proj('agt_1'), roster)
     expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
+    expect(JSON.stringify(chips)).not.toContain('agt_2')
   })
 
   it('withholds an agent the roster cannot resolve, id and all', () => {
-    const chips = rowAttribution([{ agentId: 'agt_gone', amount: '3' }], complete('agt_gone'), roster)
+    const chips = rowAttribution([{ agentId: 'agt_gone', amount: '3' }], proj('agt_gone'), roster)
     expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
     expect(JSON.stringify(chips)).not.toContain('agt_gone')
   })
@@ -105,7 +102,7 @@ describe('rowAttribution', () => {
         { agentId: 'x', amount: '0.1' },
         { agentId: 'y', amount: '0.2' }
       ],
-      complete('agt_1', 'x', 'y'),
+      proj('agt_1', 'x', 'y'),
       roster
     )
     expect(chips).toHaveLength(2)
@@ -119,7 +116,7 @@ describe('rowAttribution', () => {
         { agentId: 'agt_1', amount: '0.40' },
         { agentId: 'agt_2', amount: '2.50' }
       ],
-      complete('agt_1', 'agt_2'),
+      proj('agt_1', 'agt_2'),
       roster
     )
     expect(chips.map((c) => c.agent?.name)).toEqual(['triage', 'reviewer'])
@@ -131,20 +128,20 @@ describe('rowAttribution', () => {
   })
 
   it('fails closed on an empty roster', () => {
-    const chips = rowAttribution([{ agentId: 'agt_1', amount: '3' }], complete('agt_1'), new Map())
+    const chips = rowAttribution([{ agentId: 'agt_1', amount: '3' }], proj('agt_1'), new Map())
     expect(chips).toEqual([{ key: 'withheld', amount: '3' }])
   })
 
   it('renders nothing when the service sent no split, or an empty one', () => {
-    expect(rowAttribution(undefined, complete('agt_1'), roster)).toEqual([])
-    expect(rowAttribution(null, complete('agt_1'), roster)).toEqual([])
-    expect(rowAttribution([], complete('agt_1'), roster)).toEqual([])
+    expect(rowAttribution(undefined, proj('agt_1'), roster)).toEqual([])
+    expect(rowAttribution(null, proj('agt_1'), roster)).toEqual([])
+    expect(rowAttribution([], proj('agt_1'), roster)).toEqual([])
     // A zero part is noise, not attribution.
-    expect(rowAttribution([{ agentId: 'agt_1', amount: '0' }], complete('agt_1'), roster)).toEqual([])
+    expect(rowAttribution([{ agentId: 'agt_1', amount: '0' }], proj('agt_1'), roster)).toEqual([])
   })
 
   it('drops a part whose amount is not a number rather than rendering NaN', () => {
-    expect(rowAttribution([{ agentId: 'agt_1', amount: 'twelve' }], complete('agt_1'), roster)).toEqual([])
+    expect(rowAttribution([{ agentId: 'agt_1', amount: 'twelve' }], proj('agt_1'), roster)).toEqual([])
   })
 })
 

--- a/packages/web/src/components/console/views/BillingView.agents.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.agents.test.tsx
@@ -180,8 +180,15 @@ describe('the usage row', () => {
     // what blanked all three of these before, so each one is asserted.
     const host = await render()
     const chips = [...host.querySelectorAll('[data-tx-agent]')]
-    // Sub-cent charges keep their significant digits rather than all rounding to `$0.00`.
-    expect(chips.map((c) => c.textContent)).toEqual(['reviewer$0.006823', 'reviewer$0.01522', 'reviewer$0.001036'])
+    // The chip shows only the name; the per-agent amount is on hover (`title`) and mirrored to
+    // `aria-label`. Sub-cent amounts keep significant digits rather than rounding to `$0.00`.
+    expect(chips.map((c) => c.textContent)).toEqual(['reviewer', 'reviewer', 'reviewer'])
+    expect(chips.map((c) => c.getAttribute('title'))).toEqual([
+      'reviewer — $0.006823',
+      'reviewer — $0.01522',
+      'reviewer — $0.001036'
+    ])
+    expect(chips[0]!.getAttribute('aria-label')).toBe('reviewer — $0.006823')
     expect(host.querySelector('[data-tx-agent-default]')).toBeNull()
   })
 })

--- a/packages/web/src/components/console/views/BillingView.agents.test.tsx
+++ b/packages/web/src/components/console/views/BillingView.agents.test.tsx
@@ -180,15 +180,18 @@ describe('the usage row', () => {
     // what blanked all three of these before, so each one is asserted.
     const host = await render()
     const chips = [...host.querySelectorAll('[data-tx-agent]')]
-    // The chip shows only the name; the per-agent amount is on hover (`title`) and mirrored to
-    // `aria-label`. Sub-cent amounts keep significant digits rather than rounding to `$0.00`.
-    expect(chips.map((c) => c.textContent)).toEqual(['reviewer', 'reviewer', 'reviewer'])
+    // Desktop shows the name; the share is disclosure — `title`, which the TooltipLayer opens on
+    // hover and on keyboard focus (hence tabbable). The trailing amount span is the ≤768px copy
+    // (visible where touch has neither hover nor focus), CSS-hidden on desktop but present in
+    // textContent here. Sub-cent amounts keep significant digits rather than rounding to `$0.00`.
+    expect(chips.map((c) => c.textContent)).toEqual(['reviewer$0.006823', 'reviewer$0.01522', 'reviewer$0.001036'])
     expect(chips.map((c) => c.getAttribute('title'))).toEqual([
       'reviewer — $0.006823',
       'reviewer — $0.01522',
       'reviewer — $0.001036'
     ])
     expect(chips[0]!.getAttribute('aria-label')).toBe('reviewer — $0.006823')
+    expect(chips.every((c) => c.getAttribute('tabindex') === '0')).toBe(true)
     expect(host.querySelector('[data-tx-agent-default]')).toBeNull()
   })
 })

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -1115,42 +1115,51 @@ export default function BillingView() {
                             const rest = named.length - shown.length
                             return (
                               <>
-                                {[...shown, ...(rollup ? [rollup] : [])].map((chip) => (
-                                  <span
-                                    key={chip.key}
-                                    data-tx-agent="true"
-                                    className="inline-flex h-[21px] min-w-0 flex-none items-center gap-[5px] rounded-[4px] bg-(--surface-active) p-[2px] pr-[7px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary)"
-                                  >
-                                    <span className="av h-[17px] w-[17px] flex-none rounded-[5px]">
-                                      {chip.agent ? (
-                                        <AgentIconView icon={chip.agent.icon} runtime={chip.agent.runtime} size={17} />
-                                      ) : (
-                                        // The default avatar. This viewer may not learn which
-                                        // agents these are, how many, or how the amount splits
-                                        // between them — only that the rest of the charge is
-                                        // theirs. Labelled for assistive tech, since the glyph
-                                        // alone says nothing.
-                                        <span
-                                          data-tx-agent-default="true"
-                                          role="img"
-                                          aria-label="Agents you don’t have access to"
-                                          className="flex h-full w-full items-center justify-center rounded-[inherit] bg-(--surface-sunken) text-(--text-tertiary)"
-                                        >
-                                          <Icon name="bot" size={10} strokeWidth={2} />
-                                        </span>
+                                {/* The per-agent amount lives on HOVER (`title`), not in the
+                                    chip — eight visible dollar figures per row drowned the row's
+                                    own amount. `aria-label` carries the same text, so a reader
+                                    that cannot hover still gets it. A product trade: touch gets
+                                    the row total only. */}
+                                {[...shown, ...(rollup ? [rollup] : [])].map((chip) => {
+                                  const share = chip.agent
+                                    ? `${agentLabel(chip.agent)} — ${fmtDecimalUsd(chip.amount)}`
+                                    : `Agents you don’t have access to — ${fmtDecimalUsd(chip.amount)}`
+                                  return (
+                                    <span
+                                      key={chip.key}
+                                      data-tx-agent="true"
+                                      title={share}
+                                      aria-label={share}
+                                      className={`inline-flex h-[21px] min-w-0 flex-none items-center gap-[5px] rounded-[4px] bg-(--surface-active) p-[2px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) ${
+                                        chip.agent ? 'pr-[7px]' : ''
+                                      }`}
+                                    >
+                                      <span className="av h-[17px] w-[17px] flex-none rounded-[5px]">
+                                        {chip.agent ? (
+                                          <AgentIconView
+                                            icon={chip.agent.icon}
+                                            runtime={chip.agent.runtime}
+                                            size={17}
+                                          />
+                                        ) : (
+                                          // The default avatar. This viewer may not learn which
+                                          // agents these are, how many, or how the amount splits
+                                          // between them — only that the rest of the charge is
+                                          // theirs.
+                                          <span
+                                            data-tx-agent-default="true"
+                                            className="flex h-full w-full items-center justify-center rounded-[inherit] bg-(--surface-sunken) text-(--text-tertiary)"
+                                          >
+                                            <Icon name="bot" size={10} strokeWidth={2} />
+                                          </span>
+                                        )}
+                                      </span>
+                                      {chip.agent && (
+                                        <span className="max-w-[110px] truncate">{agentLabel(chip.agent)}</span>
                                       )}
                                     </span>
-                                    {chip.agent && (
-                                      <span className="max-w-[110px] truncate">{agentLabel(chip.agent)}</span>
-                                    )}
-                                    {/* Visible, not a tooltip: the console's tooltip ignores
-                                        touch and this chip is not focusable, so a `title` would
-                                        put the amount out of reach on mobile and by keyboard. */}
-                                    <span className="mono flex-none text-(--text-tertiary)">
-                                      {fmtDecimalUsd(chip.amount)}
-                                    </span>
-                                  </span>
-                                ))}
+                                  )
+                                })}
                                 {rest > 0 && (
                                   <span className="mono flex-none text-[11.5px] text-(--text-tertiary)">+{rest}</span>
                                 )}

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -1115,11 +1115,12 @@ export default function BillingView() {
                             const rest = named.length - shown.length
                             return (
                               <>
-                                {/* The per-agent amount lives on HOVER (`title`), not in the
-                                    chip — eight visible dollar figures per row drowned the row's
-                                    own amount. `aria-label` carries the same text, so a reader
-                                    that cannot hover still gets it. A product trade: touch gets
-                                    the row total only. */}
+                                {/* On desktop the per-agent amount is disclosure, not decoration:
+                                    eight visible dollar figures per row drowned the row's own
+                                    amount, so it lives in `title` — the console TooltipLayer shows
+                                    it on hover AND on keyboard focus (the chip is tabbable for
+                                    exactly that). Touch has neither, so ≤768px keeps the amount
+                                    visible in the chip; that card already scrolls sideways. */}
                                 {[...shown, ...(rollup ? [rollup] : [])].map((chip) => {
                                   const share = chip.agent
                                     ? `${agentLabel(chip.agent)} — ${fmtDecimalUsd(chip.amount)}`
@@ -1128,10 +1129,11 @@ export default function BillingView() {
                                     <span
                                       key={chip.key}
                                       data-tx-agent="true"
+                                      tabIndex={0}
                                       title={share}
                                       aria-label={share}
-                                      className={`inline-flex h-[21px] min-w-0 flex-none items-center gap-[5px] rounded-[4px] bg-(--surface-active) p-[2px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) ${
-                                        chip.agent ? 'pr-[7px]' : ''
+                                      className={`inline-flex h-[21px] min-w-0 flex-none items-center gap-[5px] rounded-[4px] bg-(--surface-active) p-[2px] pr-[7px] font-sans text-[11.5px] font-medium leading-normal text-(--text-secondary) ${
+                                        chip.agent ? '' : 'desktop:pr-[2px]'
                                       }`}
                                     >
                                       <span className="av h-[17px] w-[17px] flex-none rounded-[5px]">
@@ -1157,6 +1159,11 @@ export default function BillingView() {
                                       {chip.agent && (
                                         <span className="max-w-[110px] truncate">{agentLabel(chip.agent)}</span>
                                       )}
+                                      {/* Touch's reachable copy of the share; desktop keeps it
+                                          in the tooltip. */}
+                                      <span className="mono flex-none text-(--text-tertiary) desktop:hidden">
+                                        {fmtDecimalUsd(chip.amount)}
+                                      </span>
                                     </span>
                                   )
                                 })}

--- a/packages/web/src/components/console/views/BillingView.tsx
+++ b/packages/web/src/components/console/views/BillingView.tsx
@@ -38,7 +38,7 @@ import {
 } from '@/lib/billing-activity'
 import { balanceBanner, ledgerHistory } from '@/lib/billing-banner'
 import { featureFlagEnabled } from '@/lib/feature-flags'
-import { fetchAgents, fetchGatewayAttribution, type GatewayAttribution } from '@/lib/api'
+import { fetchAgents, fetchGatewayAttribution } from '@/lib/api'
 import { agentLabel, type Agent } from '@/lib/data'
 import { sumAmounts } from '@/lib/amount'
 import { useOrgs } from '@/lib/org-context'
@@ -73,19 +73,19 @@ export interface TxAgentChip {
 // `/usage` projection for that charge's period. They are different questions and neither source
 // can answer the other's.
 //
-// The gate is `projection.complete`, not membership. `/usage.agents` lists an agent when ANY of
-// its spend is readable, and hides the rest in one id-less residual — so membership alone would
-// let an agent with $1 readable and $99 private be named for charges that include the $99. Only
-// a period whose projection withholds NOTHING makes attribution safe, because then this viewer
-// may already attribute every dollar in it and a chip discloses nothing new. Any residual, and
-// the whole period falls back to id-less rollups.
+// The gate is per-agent MEMBERSHIP in the projection, the same intersection (Agent visibility ∩
+// Session predicate) under which the Analytics page already names that agent to this viewer for
+// this window. A named agent's per-charge amount may therefore include spend the projection
+// withholds — an agent with $1 readable and $99 private is named for a charge covering the $99.
+// That is the deliberate billing exception recorded in `session-visibility.md` §5: a stricter
+// period-completeness gate was tried and blanked every org with any private session. What §5
+// still forbids holds: an agent in NO readable session stays id-less, and everything withheld
+// folds into ONE rollup — no count, no partition.
 //
-// `agentById` supplies the name and icon; an id it cannot resolve is not named either. Whatever
-// is not named is summed into ONE rollup — no count, no partition — which is §5's rule that
-// withheld usage comes back id-less.
+// `agentById` supplies the name and icon; an id it cannot resolve is not named either.
 export function rowAttribution(
   parts: BillingDebitAgent[] | null | undefined,
-  projection: GatewayAttribution | undefined,
+  projection: ReadonlySet<string> | undefined,
   agentById: Map<string, Agent>
 ): TxAgentChip[] {
   if (!parts?.length) return []
@@ -94,9 +94,9 @@ export function rowAttribution(
   for (const part of parts) {
     const value = Number(part.amount)
     if (!Number.isFinite(value) || value === 0) continue
-    // Every clause fails CLOSED: no projection (unloaded or errored), a period with any
-    // withheld spend, an agent outside it, or an id the roster cannot resolve.
-    const agent = projection?.complete && projection.agents.has(part.agentId) ? agentById.get(part.agentId) : undefined
+    // Every clause fails CLOSED: no projection (unloaded or errored), an agent outside it, or
+    // an id the roster cannot resolve.
+    const agent = projection?.has(part.agentId) ? agentById.get(part.agentId) : undefined
     // The id never enters a chip it cannot name — `key` included, so it cannot leak through a
     // prop that ends up serialized.
     if (agent) named.push({ chip: { key: part.agentId, agent, amount: part.amount }, value })
@@ -805,7 +805,7 @@ export default function BillingView() {
   // one read per period on screen. Per PERIOD and never unioned across them — spend a viewer
   // may attribute in one month says nothing about another. Fail closed on error.
   const periods = [...new Set(txItems.filter((t) => t.type === 'debit').map((t) => t.period))].sort()
-  const attribution = useSWR<Map<string, GatewayAttribution>>(
+  const attribution = useSWR<Map<string, Set<string>>>(
     orgId && periods.length ? consoleKeys.billingAttribution(orgId, periods.join(',')) : null,
     async ([, , , joined]) => {
       const wanted = (joined as string).split(',')
@@ -815,7 +815,7 @@ export default function BillingView() {
       return new Map(wanted.map((p, i) => [p, reads[i]!]))
     }
   )
-  const attributionIn = (period: string): GatewayAttribution | undefined =>
+  const attributionIn = (period: string): ReadonlySet<string> | undefined =>
     attribution.error ? undefined : attribution.data?.get(period)
 
   // Deep-link landing for a console that does not offer billing: the rail hides

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -145,21 +145,14 @@ describe('fetchGatewayAttribution', () => {
     expect(calls[0]).toContain('source=gateway')
   })
 
-  it('is complete only when the residual is ABSENT, never when it is present and zero', async () => {
-    // The CP omits `unattributed` rather than zeroing it so a reader can tell "nothing was
-    // hidden" from "something was hidden and cost 0" — it is keyed on withheld SESSIONS, and an
-    // aggregate amount nets to zero through downward corrections. Reading a zero residual as
-    // completeness would qualify exactly the periods whose hidden usage is hardest to notice.
+  it('returns projection MEMBERSHIP, unaffected by a withheld residual', async () => {
+    // The billing exception (`session-visibility.md` §5): an id in `/usage.agents` is one
+    // Analytics already names to this viewer, and that alone gates naming on the ledger —
+    // a period-completeness gate was tried and blanked every org with one private session.
     const window = ['2026-08-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z', 'org-1'] as const
 
-    usage({})
-    expect((await fetchGatewayAttribution(...window)).complete).toBe(true)
-
-    usage({ unattributed: { sessions: 1, totalTokens: 0, costAmount: '0' } })
-    expect((await fetchGatewayAttribution(...window)).complete).toBe(false)
-
     usage({ unattributed: { sessions: 2, totalTokens: 40, costAmount: '99' } })
-    expect((await fetchGatewayAttribution(...window)).complete).toBe(false)
+    expect(await fetchGatewayAttribution(...window)).toEqual(new Set(['agt_1']))
   })
 })
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3555,39 +3555,23 @@ export function usageWindow(range: UsageRange, now: Date = new Date()): { from: 
   return { from: from.toISOString(), to: to.toISOString() }
 }
 
-/** What the CP's viewer-scoped `/usage` projection says about one window. `complete` is the
- *  load-bearing field: false ⇒ SOME spend in this window is withheld from this caller, and the
- *  projection cannot say whose, so nothing in the window may be attributed to a name. */
-export interface GatewayAttribution {
-  agents: Set<string>
-  complete: boolean
-}
-
-// The viewer-scoped, gateway-metered attribution for one explicit window.
+// The agents this viewer may see gateway spend attributed to, for one explicit window.
 //
-// `/usage` intersects Agent visibility with the request-time Session predicate and returns what
-// it withholds as ONE id-less `unattributed` rollup (`session-visibility.md` §5) — id-less by
-// design, so an agent's presence in `agents` never proves that agent's whole window is readable.
-// An agent with $1 of readable spend and $99 of private spend appears in `agents` with $1 while
-// the $99 sits in `unattributed`, indistinguishable from any other agent's withheld spend.
-//
-// Hence `complete`: only when the projection withholds NOTHING is membership equivalent to
-// "this caller may attribute every dollar in this window", which is the only condition under
-// which a second surface may put an amount next to a name.
-//
-// PRESENCE of the rollup is that signal, never its amount. The CP omits it rather than zeroing
-// it precisely so a reader can tell "nothing was hidden" from "something was hidden and cost 0"
-// — it is keyed on withheld SESSIONS, and an aggregate amount can net to zero through downward
-// corrections. Reading a zero residual as completeness would qualify exactly the periods whose
-// hidden usage is hardest to notice.
+// `/usage` intersects Agent visibility with the request-time Session predicate, so an id in its
+// `agents` list is one the Analytics page ALREADY names to this viewer for this window — that
+// membership is the billing ledger's naming gate. Per the billing exception in
+// `session-visibility.md` §5, a named agent's per-charge amount may include spend the projection
+// itself withholds; accepted there deliberately, so do not "fix" it back to a period-completeness
+// gate — that shape blanked every org with any private session (#1498 follow-up). An id absent
+// from the list stays id-less on every billing row.
 //
 // `source=gateway` because that is the ingress a billing charge settles from (see the route's
 // own note): unscoped, a readable DAEMON session could qualify an agent whose gateway spend is
 // entirely private.
-export async function fetchGatewayAttribution(from: string, to: string, orgId?: string): Promise<GatewayAttribution> {
+export async function fetchGatewayAttribution(from: string, to: string, orgId?: string): Promise<Set<string>> {
   const query = new URLSearchParams({ from, to, source: 'gateway' })
   const usage = await apiGet<UsageDto>(`${orgBase(orgId)}/usage?${query.toString()}`)
-  return { agents: new Set(usage.agents.map((a) => a.agentId)), complete: usage.unattributed === undefined }
+  return new Set(usage.agents.map((a) => a.agentId))
 }
 
 export async function fetchUsage(range: UsageRange, orgId?: string, source?: UsageSource): Promise<UsageDto> {

--- a/packages/web/src/lib/billing-api.ts
+++ b/packages/web/src/lib/billing-api.ts
@@ -62,11 +62,10 @@ export interface BillingAccount {
 // It is NOT self-authorizing. The service holds no Agent or Session visibility, so its ids and
 // its amounts are both the ORG's, and rendering one as-is is the discovery
 // `docs/designs/authorization-policy.md` §4 forbids. The row may put an agent's name beside one
-// of these amounts only when the CP's viewer-scoped `/usage` projection says this viewer may
-// attribute EVERY dollar in that billing period (`fetchGatewayAttribution`, and `complete`
-// specifically). Otherwise the period's charges render one id-less rollup apiece, which is
-// `session-visibility.md` §5's rule that withheld usage comes back without an id. The gate lives
-// in `rowAttribution` in BillingView; nothing else may read this field.
+// of these amounts only when that agent is in the CP's viewer-scoped `/usage` projection for the
+// charge's period (`fetchGatewayAttribution`) — the billing exception in
+// `session-visibility.md` §5. Ids outside it fold into one id-less rollup per charge. The gate
+// lives in `rowAttribution` in BillingView; nothing else may read this field.
 export interface BillingCredit {
   type: 'credit'
   id: string


### PR DESCRIPTION
Follow-up to #1498. On any real org, the Transactions feed rendered **only default robot avatars** — including for agents the viewer fully sees and whom the Analytics page already names to them.

## Why

The period-completeness gate from #1498 required the charge's whole `YYYY-MM` window to carry **zero** withheld spend (`unattributed` absent from `/usage?source=gateway`) before naming *anyone*. The `agentconnect` org has private sessions, so its August carries a residual → every charge in the month fell back to the id-less rollup. `dz-test3` looked fine only because it has no private sessions at all. A gate that fires org-wide on one private session doesn't protect anything — it deletes the feature everywhere it matters.

## What changed — a deliberate product decision, recorded in the design doc

The gate is now **per-agent membership** in the viewer's `/usage?source=gateway` projection for the charge's period — the same intersection (Agent visibility ∩ Session predicate) under which Analytics already names that agent to this viewer for that window.

This knowingly reopens the finding from #1493's review: a named agent's per-charge amount may include spend the projection itself withholds (readable + private spend in the same period). That trade-off is now an **explicit billing-ledger exception in `session-visibility.md` §5**, accepted on the same grounds as §5's existing residual-inference-channel bullet: the ledger already publishes every charge's amount to every member, and the stricter alternative was shipped and measured — it blanked attribution for any org with one private session. Reviewers: please evaluate against the amended §5, not the pre-amendment text.

Still enforced, with tests:

- An agent with **no readable spend** in the window is never named on any charge (absent from the projection ⇒ id-less).
- Ids the roster cannot resolve never render — not even as a React `key`.
- Everything withheld on a charge folds into **one** id-less rollup: no count, no partition, exact `sumAmounts` arithmetic.
- Fail closed on unloaded/errored projection or roster; nothing renders while the projection is in flight.
- `source=gateway` stays — the ingress a charge settles from.

`GatewayAttribution.complete` is gone with the gate it existed for; `fetchGatewayAttribution` now returns the membership `Set`.

## Verification

Browser, against the test backend, on the exact org that was blanked (`/agentconnect/billing`): all rows name their agents with real icons and per-row amounts — including a charge correctly split across two agents (`test-cloud-2 $0.09946` + `cloud-test-2 $0.01355`). Zero default-avatar chips.

Full `@agentconnect.md/web` suite: 2011 passed. typecheck / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)