### PR TITLE
fix(web): skip onboarding's configure phase on the cloud pool

### DIFF
--- a/packages/web/src/components/console/GettingStartedChecklist.test.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.test.tsx
@@ -85,6 +85,15 @@ describe('useGsActions — the agent step', () => {
     expect(mocks.openModal).toHaveBeenCalledWith('editAgent', mocks.agents[0], { focusSection: 'basics' })
   })
 
+  // The offered pool is a placement target even before any member Pod registers — the
+  // editor shows Cloud (available or not); never send a pool-mode user to Add Daemon.
+  it('edits directly on the offered pool even with an empty fleet snapshot', async () => {
+    setFlags('daemon-pool')
+    await render()
+    act(() => run({ kind: 'agent' }))
+    expect(mocks.openModal).toHaveBeenCalledWith('editAgent', mocks.agents[0], { focusSection: 'basics' })
+  })
+
   it('falls back to the create dialog for an org with no agent row at all', async () => {
     mocks.agents = []
     await render()

--- a/packages/web/src/components/console/GettingStartedChecklist.tsx
+++ b/packages/web/src/components/console/GettingStartedChecklist.tsx
@@ -44,7 +44,10 @@ export function useGsActions() {
   // (placement + runtime/model) rather than creating a new one — only a truly empty org
   // (no preset row) falls back to the create modal.
   const builtinAgent = agents.find((a) => a.builtin) ?? firstAgent
-  const placeableDaemons = featureFlagEnabled('daemon-pool') ? daemons : localDaemons(daemons)
+  // The offered pool is ITSELF a placement target, member Pods registered or not — the
+  // editor shows Cloud (available or unavailable); only self-hosted with zero machines
+  // needs the Add-daemon chain first.
+  const hasPlacementTarget = featureFlagEnabled('daemon-pool') || localDaemons(daemons).length > 0
 
   const runAction = useCallback(
     (action: GsAction) => {
@@ -56,11 +59,10 @@ export function useGsActions() {
           // Same chain the Agents / Agent detail "Add daemon" chips use (preset-agents.md
           // §3.4): with nothing to place onto the edit modal's picker would offer only "No
           // daemon", so mint one first and chain back into the edit dialog, where the
-          // fresh (and only) daemon is auto-preselected. Cloud counts only where the
-          // deployment offers it — the picker hides pool Pods otherwise.
-          return placeableDaemons.length === 0
-            ? openModal('daemon', builtinAgent, { focusSection: 'basics' })
-            : openModal('editAgent', builtinAgent, { focusSection: 'basics' })
+          // fresh (and only) daemon is auto-preselected.
+          return hasPlacementTarget
+            ? openModal('editAgent', builtinAgent, { focusSection: 'basics' })
+            : openModal('daemon', builtinAgent, { focusSection: 'basics' })
         case 'slack': {
           // The action targets the built-in preset; honor it — agents[0] is commonly an
           // older custom agent in backfilled orgs, and the manual fallback must not
@@ -91,7 +93,7 @@ export function useGsActions() {
           return router.push(orgPath('/settings#session-access'))
       }
     },
-    [openModal, router, orgPath, firstAgent, builtinAgent, agents, placeableDaemons]
+    [openModal, router, orgPath, firstAgent, builtinAgent, agents, hasPlacementTarget]
   )
 
   return { runAction, firstAgent }

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -83,7 +83,6 @@ vi.mock('@/components/ui', () => ({
 }))
 
 import OnboardingView from './OnboardingView'
-import { FALLBACK_RUNTIME_IDS } from '@/lib/data'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -292,8 +291,9 @@ describe('onboarding — configure the built-in agent', () => {
   })
 })
 
-// The cloud pool hosts the agents, so there is nothing to connect: no mint, no waiting
-// card, and the built-in agent is configured without a placement move.
+// The cloud pool hosts the agents, so there is nothing to connect and nothing to pin the
+// built-in preset to: no mint, no waiting card, no configure phase — straight to the
+// checklist, whose agent row owns the setup.
 describe('onboarding — cloud pool', () => {
   beforeEach(() => setFlags('daemon-pool'))
 
@@ -305,39 +305,12 @@ describe('onboarding — cloud pool', () => {
     expect(host.textContent).toContain('Welcome to AgentConnect')
   })
 
-  it('configures the built-in agent with no daemon row and no placement move', async () => {
+  it('skips the configure phase even with an unplaced built-in agent', async () => {
     mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
     await render()
-    expect(host.textContent).toContain('Configure')
-    expect(host.textContent).not.toContain('just connected') // no "Runs on" row
-    await click('Save and continue')
-    // No daemon reports runtimes on the pool, so the static fallback seeds the picker. With no
-    // pool member either there is nothing to place onto — the agent editor owns that choice.
-    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: FALLBACK_RUNTIME_IDS[0] })
-    expect(mocks.moveAgent).not.toHaveBeenCalled()
+    expect(host.textContent).not.toContain('Configure')
     expect(host.textContent).toContain('Welcome to AgentConnect')
-  })
-
-  // GET /daemons carries the install-wide pool's member Pods in every org's fleet. They are
-  // replaceable identities: one may seed the runtime/model pickers, but the placement names
-  // the POOL, never a Pod, and nothing here "just connected".
-  it('reads runtimes from a pool member but places on the pool, not the Pod', async () => {
-    mocks.daemons = [
-      {
-        daemonId: 'pool-pod-1',
-        pool: true,
-        status: 'online',
-        name: 'ac-cloud-7f9',
-        runtimeModels: [{ runtime: 'claude', models: ['claude-sonnet-4-5'] }]
-      }
-    ]
-    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
-    await render()
-    expect(host.textContent).toContain('runtime-claude') // seeded from the pool member
-    expect(host.textContent).not.toContain('just connected')
-    expect(host.textContent).not.toContain('ac-cloud-7f9')
-    await click('Save and continue')
-    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude', model: 'claude-sonnet-4-5' })
-    expect(mocks.moveAgent).toHaveBeenCalledWith('ag_ac', { kind: 'pool' })
+    expect(mocks.updateAgent).not.toHaveBeenCalled()
+    expect(mocks.moveAgent).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -28,7 +28,6 @@ import {
   agentLabel,
   localDaemons,
   modelLabel,
-  poolLabel,
   preferredModelFor,
   loginRequiredRuntimeIds
 } from '@/lib/data'
@@ -36,8 +35,8 @@ import type { Agent, DaemonRow } from '@/lib/data'
 import type { DaemonConnectDto } from '@/lib/api'
 
 // Onboarding (design: "AgentConnect Onboarding"). Where the deployment offers the cloud
-// pool (`daemon-pool`) there is nothing to connect, so the daemon phase is skipped
-// entirely and onboarding opens on the built-in agent's configuration. Self-hosted
+// pool (`daemon-pool`) there is nothing to connect NOR to pin the built-in agent to, so
+// both the daemon and configure phases are skipped straight to the checklist. Self-hosted
 // (flag off) keeps the flow below unchanged: connecting a daemon is the ONLY
 // blocking step; when one comes online the screen transitions in place and reveals the
 // SAME getting-started checklist the console shows (lib/getting-started.ts). No more
@@ -101,38 +100,26 @@ export default function OnboardingView() {
   // the checklist reveal: auto-assign it to that daemon and let the user pick a runtime +
   // model (design: the built-in agent replaces "create your first agent"). The preset
   // ships unplaced (daemon '—', deferred runtime); it's ready once both are set. Older
-  // orgs without the preset just skip straight to the reveal.
+  // orgs without the preset just skip straight to the reveal. Pool mode skips this phase
+  // too — nothing "just connected" to pin to, and the checklist's agent row (expanded by
+  // default on the pool) owns the setup instead.
   const builtinAgent = agents.find((a) => a.builtin)
   const servingDaemon = machines.find((d) => d.status === 'online') ?? machines.find(daemonCompletesOnboarding)
-  // The fleet list includes the install-wide pool's member Pods, which are replaceable
-  // identities — pinning the preset to one is never right. So pool mode has NO concrete
-  // placement target here (the agent editor owns the Cloud choice); one live member still
-  // stands in for the pool's REPORTED runtimes/models, the same seam the edit form's
-  // capability source uses. Off the pool both are the daemon we just brought online.
-  const placementDaemon = cloudDaemon ? undefined : servingDaemon
-  const capabilityDaemon = cloudDaemon
-    ? (daemons.find((d) => d.pool && d.status === 'online') ?? daemons.find((d) => d.pool))
-    : servingDaemon
-  // Placing on the pool needs a pool that exists; without one the agent editor owns the choice.
-  const poolTarget = cloudDaemon && capabilityDaemon !== undefined
-  const needsAgentSetup = !!builtinAgent && (cloudDaemon || !!placementDaemon) && !agentIsPlaced(builtinAgent)
+  const needsAgentSetup = !cloudDaemon && !!builtinAgent && !!servingDaemon && !agentIsPlaced(builtinAgent)
   const [skipSetup, setSkipSetup] = useState(false)
   const [saving, setSaving] = useState(false)
   const [saveErr, setSaveErr] = useState<string | null>(null)
 
   // Runtime becomes mandatory at placement, so set it FIRST, then move onto the daemon
   // (the CP rejects a move on a runtime-less agent). A placed agent flips needsAgentSetup
-  // off by itself; latching `skipSetup` also advances the pool case, where nothing moved.
+  // off by itself; `skipSetup` covers the save-raced edge until the refresh lands.
   const saveAgentSetup = async (runtime: string, model: string) => {
-    if (!builtinAgent) return
+    if (!builtinAgent || !servingDaemon) return
     setSaving(true)
     setSaveErr(null)
     try {
       await updateAgent(builtinAgent.id, { runtime, ...(model ? { model } : {}) })
-      // Onto the machine just connected, or — on the pool — onto the POOL itself. A pool
-      // placement names the pool, never the member Pod whose capabilities seeded the form.
-      if (placementDaemon) await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: placementDaemon.daemonId })
-      else if (poolTarget) await moveAgent(builtinAgent.id, { kind: 'pool' })
+      await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: servingDaemon.daemonId })
       await refresh()
       setSkipSetup(true)
     } catch (e) {
@@ -260,9 +247,7 @@ export default function OnboardingView() {
       ) : needsAgentSetup && !skipSetup ? (
         <ConfigureAgent
           agent={builtinAgent!}
-          daemon={capabilityDaemon}
-          runsOn={placementDaemon}
-          poolTarget={poolTarget}
+          daemon={servingDaemon!}
           saving={saving}
           err={saveErr}
           onSave={saveAgentSetup}
@@ -412,38 +397,30 @@ function ConnectDaemon({
 function ConfigureAgent({
   agent,
   daemon,
-  runsOn,
-  poolTarget,
   saving,
   err,
   onSave,
   onSkip
 }: {
   agent: Agent
-  /** Whose reported runtimes/models seed the pickers — a pool member on the pool, else the
-   *  just-connected daemon. Absent ⇒ the static fallback list. Never a placement. */
-  daemon?: DaemonRow
-  /** The machine this agent is being placed onto — absent on the pool, which has no member
-   *  identity to pin to. */
-  runsOn?: DaemonRow
-  /** Pool mode with a live pool: the agent lands on the pool itself. */
-  poolTarget: boolean
+  /** The just-connected daemon: both the placement target and the picker seed. */
+  daemon: DaemonRow
   saving: boolean
   err: string | null
   onSave: (runtime: string, model: string) => void
   onSkip: () => void
 }) {
-  const runtimeIds = daemon?.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
+  const runtimeIds = daemon.runtimeModels.length ? daemon.runtimeModels.map((r) => r.runtime) : FALLBACK_RUNTIME_IDS
   // Logged-out runtimes are marked, not blocked; the default just prefers a signed-in
   // one so a first agent starts answerable where the daemon allows it.
-  const runtimesNeedingLogin = daemon ? loginRequiredRuntimeIds(daemon) : []
+  const runtimesNeedingLogin = loginRequiredRuntimeIds(daemon)
   const defaultRuntime = runtimeIds.find((id) => !runtimesNeedingLogin.includes(id)) ?? runtimeIds[0] ?? ''
   const [runtime, setRuntime] = useState('') // '' = untouched
   const effectiveRuntime = runtime && runtimeIds.includes(runtime) ? runtime : defaultRuntime
-  const models = daemon?.runtimeModels.find((r) => r.runtime === effectiveRuntime)?.models ?? []
+  const models = daemon.runtimeModels.find((r) => r.runtime === effectiveRuntime)?.models ?? []
   const [model, setModel] = useState('')
   // Keep the selection valid as the runtime (and so the model set) changes.
-  const selectedModel = models.includes(model) ? model : daemon ? preferredModelFor(daemon, effectiveRuntime) : ''
+  const selectedModel = models.includes(model) ? model : preferredModelFor(daemon, effectiveRuntime)
 
   return (
     <div className="flex w-full max-w-[520px] flex-col gap-[22px]">
@@ -458,33 +435,21 @@ function ConfigureAgent({
           Configure {agentLabel(agent)}
         </h1>
         <p className="max-w-[430px] font-sans text-[14.5px] font-normal leading-[1.55] text-(--text-secondary)">
-          {runsOn
-            ? 'Your org’s built-in agent runs on the daemon you just connected. Pick a runtime and model, and it’s ready to work.'
-            : `Your org’s built-in agent runs on ${poolTarget ? poolLabel() : 'your infrastructure'}. Pick a runtime and model, and it’s ready to work.`}
+          Your org’s built-in agent runs on the daemon you just connected. Pick a runtime and model, and it’s ready to
+          work.
         </p>
       </div>
 
       <div className="flex flex-col gap-[14px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-4 shadow-(--shadow-xs)">
-        {(runsOn || poolTarget) && (
-          <div className="fld">
-            <span className="fldlbl">Runs on</span>
-            <div
-              className="inp cursor-not-allowed"
-              title={
-                runsOn
-                  ? 'Set to the daemon you just connected'
-                  : 'Move it to a machine any time from the agent’s settings'
-              }
-            >
-              <span className="truncate text-(--text-primary)">{runsOn ? runsOn.name : poolLabel()}</span>
-              {runsOn && (
-                <span className="ml-auto flex-none font-sans text-[11.5px] leading-none text-(--text-tertiary)">
-                  just connected
-                </span>
-              )}
-            </div>
+        <div className="fld">
+          <span className="fldlbl">Runs on</span>
+          <div className="inp cursor-not-allowed" title="Set to the daemon you just connected">
+            <span className="truncate text-(--text-primary)">{daemon.name}</span>
+            <span className="ml-auto flex-none font-sans text-[11.5px] leading-none text-(--text-tertiary)">
+              just connected
+            </span>
           </div>
-        )}
+        </div>
         <div className="grid grid-cols-1 gap-[14px] desktop:grid-cols-2">
           <div className="fld">
             <span className="fldlbl">Runtime</span>


### PR DESCRIPTION
## What

When the `daemon-pool` feature flag is on, onboarding now skips the "Configure agentconnect" phase too — the flow goes straight from the (already skipped) daemon phase to the getting-started checklist.

## Why

The pool has nothing "just connected" to pin the built-in preset to, and the revealed checklist's agent row (expanded by default on the pool) already owns the agent setup. Showing the configure screen there duplicated that step against a placement target that shouldn't be named.

## Changes

- `needsAgentSetup` gains a `!cloudDaemon` guard, so pool mode never enters the configure phase.
- Deletes the now-dead pool plumbing in `ConfigureAgent`: the capability/placement daemon split, `poolTarget`, the `kind: 'pool'` placement move, and the pool copy — `daemon` is now the single required prop (the just-connected machine).
- Tests: the two pool configure cases collapse into one asserting the phase is skipped even with an unplaced built-in agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)