### PR TITLE
fix(control-plane): state the org quota without naming exempt accounts

### DIFF
--- a/packages/control-plane/src/persistence/errors.test.ts
+++ b/packages/control-plane/src/persistence/errors.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { OrgCreationLimitReached } from './errors.js'
+
+describe('OrgCreationLimitReached', () => {
+  it('states the ceiling without naming the accounts that are exempt', () => {
+    for (const limit of [0, 1, 2]) {
+      expect(new OrgCreationLimitReached(limit).message).not.toMatch(/admin/i)
+    }
+  })
+
+  it('agrees in number with the ceiling', () => {
+    expect(new OrgCreationLimitReached(1).message).toBe('this account has reached its limit of 1 organization')
+    expect(new OrgCreationLimitReached(2).message).toBe('this account has reached its limit of 2 organizations')
+    expect(new OrgCreationLimitReached(0).message).toBe("organization creation isn't available for this account")
+  })
+})

--- a/packages/control-plane/src/persistence/errors.ts
+++ b/packages/control-plane/src/persistence/errors.ts
@@ -378,15 +378,15 @@ export class OrgOwnerRequired extends Error {
   }
 }
 
-/** A non-admin account reached the deployment's organization creation quota. */
+/** A non-admin account reached the org creation quota; the message states the ceiling, never who is exempt. */
 export class OrgCreationLimitReached extends Error {
   readonly code = 'ORG_CREATION_LIMIT_REACHED' as const
 
   constructor(readonly limit: number) {
     super(
       limit === 0
-        ? 'organization creation is disabled for non-admin accounts'
-        : `non-admin accounts may create at most ${limit} organizations`
+        ? "organization creation isn't available for this account"
+        : `this account has reached its limit of ${limit} organization${limit === 1 ? '' : 's'}`
     )
     this.name = 'OrgCreationLimitReached'
   }


### PR DESCRIPTION
## What

Reword the two messages `OrgCreationLimitReached` carries, and lock them with a unit test.

| limit | before | after |
| --- | --- | --- |
| >= 1 | `non-admin accounts may create at most 1 organizations` | `this account has reached its limit of 1 organization` |
| 0 | `organization creation is disabled for non-admin accounts` | `organization creation isn't available for this account` |

## Why

The console renders this message verbatim to the person who hit the quota (`Could not create — <message>`). The old wording taught that reader how the deployment classifies accounts: that some accounts are exempt from the quota, and that theirs is not one of them. That is an implementation detail of the quota, not something the person who ran into it needs.

Two smaller problems rode along:

- **Number agreement.** The message was hardcoded plural, so the default limit rendered as "at most **1 organizations**".
- **A repeated verb.** The console supplies "Could not create — " itself, so a message starting with "may create" read as "Could not create — ... may create ...". The new line reads `Could not create — this account has reached its limit of 1 organization`.

## Not changed, on purpose

The `ORG_CREATION_LIMIT_REACHED` code, the exception class name, and the deployment setting that carries the ceiling all keep their current names. Those surfaces are read by operators and by clients switching on the code, not by the person who hit the limit, and renaming them would break consumers for no reader's benefit.

## Test

`src/persistence/errors.test.ts` asserts both properties the wording has to keep: no message mentions how accounts are classified (checked at limits 0, 1, and 2), and each of the three strings is exact. The number-agreement case is what a later edit is most likely to regress. Unit project, no Docker.
