### PR TITLE
docs: stop branding the architecture diagram daemon-centric

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If AgentConnect looks useful, here's how you can support the project:
 
 ## Architecture
 
-![AgentConnect daemon-centric message paths](docs/designs/daemon-centric-architecture.svg)
+![AgentConnect message paths between the platforms, daemons, relay, and Control Plane](docs/designs/daemon-centric-architecture.svg)
 
 | Component                  | Responsibility                                                                                                                                                                                                     |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -180,8 +180,8 @@ temporarily unavailable, established sessions and daemon-local schedules
 continue; new assignments and configuration changes resume after reconnection.
 
 See the
-[daemon-centric architecture](docs/designs/daemon-centric-architecture.md) for
-the complete message paths, trust boundaries, and failure model.
+[architecture design](docs/designs/daemon-centric-architecture.md) for the
+complete message paths, trust boundaries, and failure model.
 
 ## Development
 

--- a/docs/designs/daemon-centric-architecture.md
+++ b/docs/designs/daemon-centric-architecture.md
@@ -49,7 +49,7 @@ The direct consequences are:
 
 ## 3. Architecture Overview
 
-![Daemon-centric architecture with optional relay ingress](daemon-centric-architecture.svg)
+![AgentConnect message paths with optional relay ingress](daemon-centric-architecture.svg)
 
 The equivalent ASCII representation below makes the same design easier to diff
 and search.

--- a/docs/designs/daemon-centric-architecture.svg
+++ b/docs/designs/daemon-centric-architecture.svg
@@ -97,7 +97,7 @@
   </defs>
 
   <rect width="1600" height="1040" rx="32" fill="#f8fafc" />
-  <text x="64" y="68" class="title">AgentConnect: daemon-centric message paths</text>
+  <text x="64" y="68" class="title">AgentConnect: message paths</text>
   <text x="64" y="108" class="subtitle">
     Live content stays on the daemon and optional relay data plane.
   </text>

--- a/docs/designs/daemon-centric-architecture.svg
+++ b/docs/designs/daemon-centric-architecture.svg
@@ -6,7 +6,7 @@
   role="img"
   aria-labelledby="title description"
 >
-  <title id="title">AgentConnect daemon-centric architecture</title>
+  <title id="title">AgentConnect message paths</title>
   <desc id="description">
     Direct platform connections terminate on daemons. Slack and Lark / Feishu HTTP
     callbacks, GitHub and generic webhooks, and webchat enter through an optional


### PR DESCRIPTION
## Summary

The architecture section led with the internal design name. The diagram's baked-in title, the README alt text, and the closing link label now describe what the picture shows — message paths between the platforms, daemons, the relay, and the Control Plane — instead of branding it "daemon-centric". The design document under `docs/designs/` keeps its name and remains linked; only the reader-facing labels change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
