### PR TITLE
docs: move the development guide into CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to AgentConnect
+
+Thanks for helping improve AgentConnect. This guide covers the development
+setup, the pull request conventions, the monorepo layout, and where the deeper
+documentation lives. For questions and ideas,
+[join the Slack community](https://slack.agentconnect.md) or
+[open an issue](https://github.com/agentconnect-md/agentconnect/issues).
+
+## Development setup
+
+Development requires Node >= 24.12.0 and pnpm 11. Docker is required for the
+Control Plane integration tests.
+
+```bash
+pnpm install
+pnpm dev          # run all packages in parallel
+pnpm build        # build all packages
+pnpm typecheck    # type-check all packages
+pnpm lint         # lint the workspace
+pnpm format:check # check formatting
+pnpm test         # test all packages
+
+# single package
+pnpm --filter @agentconnect.md/daemon dev
+pnpm --filter @agentconnect.md/control-plane dev
+pnpm --filter @agentconnect.md/web dev
+```
+
+For a complete local Control Plane and PostgreSQL development setup, follow the
+[Control Plane quickstart](packages/control-plane/README.md#local-dev-quickstart).
+
+## Pull requests
+
+Pull request titles and at least one commit must follow the
+[Conventional Commits](https://www.conventionalcommits.org) style (`feat: ...`,
+`fix: ...`, `docs: ...`); a status check enforces this. Keep changes focused,
+and run `pnpm typecheck`, `pnpm lint`, and `pnpm test` before pushing.
+
+## Monorepo layout
+
+This repository is a pnpm workspace. Product packages live under `packages/`:
+
+| Package                               | Path                                                         | Role                                                              |
+| ------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `@agentconnect.md/cli`                | [`packages/cli`](packages/cli)                               | Stable `agentconnect` entry point, daemon lifecycle, and upgrades |
+| `@agentconnect.md/connection`         | [`packages/connection`](packages/connection)                 | Shared WebSocket transport, correlation, backoff, and keepalive   |
+| `@agentconnect.md/control-plane`      | [`packages/control-plane`](packages/control-plane)           | Orchestration, registry, authentication, and Web UI BFF           |
+| `@agentconnect.md/daemon`             | [`packages/daemon`](packages/daemon)                         | Edge message processing and agent execution unit                  |
+| `@agentconnect.md/memory-plugin-mem0` | [`packages/memory-plugin-mem0`](packages/memory-plugin-mem0) | Mem0 Cloud and OSS memory-plugin profiles                         |
+| `@agentconnect.md/message`            | [`packages/message`](packages/message)                       | Pure platform message normalization                               |
+| `@agentconnect.md/protocol`           | [`packages/protocol`](packages/protocol)                     | Shared daemon, relay, and Control Plane wire contracts            |
+| `@agentconnect.md/relay`              | [`packages/relay`](packages/relay)                           | Callback ingress, webchat, and centralized MCP proxy              |
+| `@agentconnect.md/setup`              | [`packages/setup`](packages/setup)                           | Browser-based self-hosting and provider App administration        |
+| `@agentconnect.md/web`                | [`packages/web`](packages/web)                               | Next.js configuration and monitoring console                      |
+
+## Explore further
+
+- [Public documentation](https://docs.agentconnect.md)
+- [Architecture and detailed designs](docs/designs/)
+- [CLI and daemon lifecycle](docs/designs/cli-daemon-split.md)
+- [Setup Server](packages/setup/README.md)
+- [Daemon configuration](docs/designs/daemon-detailed-design.md)
+- [Config-file secrets](docs/config-file-secrets.md)
+- [Product conventions](docs/product-conventions.md)
+- [Add-on evaluation harness](evals/README.md)

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@
   <a href="#why-agentconnect">Why AgentConnect?</a> ·
   <a href="#get-started">Get started</a> ·
   <a href="#community">Community</a> ·
-  <a href="#architecture">Architecture</a> ·
-  <a href="#contributing">Contributing</a>
+  <a href="#architecture">Architecture</a>
 </p>
 
 AgentConnect is an open-source platform where teams and multiple AI agents work
@@ -160,7 +159,8 @@ If AgentConnect looks useful, here's how you can support the project:
   report bugs or suggest features.
 - 📺 Follow updates on [X](https://x.com/getAgentConnect) and
   [YouTube](https://www.youtube.com/@agentconnect-md).
-- 🧑‍💻 [Contribute](CONTRIBUTING.md) — we'd love your help.
+- 🧑‍💻 [Contribute](CONTRIBUTING.md) — we'd love your help. The guide covers
+  development setup, pull request conventions, and the monorepo layout.
 
 ## Architecture
 
@@ -182,13 +182,6 @@ continue; new assignments and configuration changes resume after reconnection.
 See the
 [architecture design](docs/designs/daemon-centric-architecture.md) for the
 complete message paths, trust boundaries, and failure model.
-
-## Contributing
-
-Contributions are welcome. Development needs Node >= 24.12.0 and pnpm 11;
-`pnpm install && pnpm dev` runs every package in watch mode. The
-[contributing guide](CONTRIBUTING.md) covers the full setup, the pull request
-conventions, the monorepo layout, and the deeper design documentation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ Contributions are welcome. Development needs Node >= 24.12.0 and pnpm 11;
 [contributing guide](CONTRIBUTING.md) covers the full setup, the pull request
 conventions, the monorepo layout, and the deeper design documentation.
 
+Thanks to everyone who has already contributed:
+
+<a href="https://github.com/agentconnect-md/agentconnect/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=agentconnect-md/agentconnect" alt="AgentConnect contributors" />
+</a>
+
 ## Architecture
 
 ![AgentConnect message paths between the platforms, daemons, relay, and Control Plane](docs/designs/daemon-centric-architecture.svg)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@
   <a href="#get-started">Get started</a> ·
   <a href="#community">Community</a> ·
   <a href="#architecture">Architecture</a> ·
-  <a href="#development">Development</a> ·
-  <a href="#explore">Explore</a>
+  <a href="#contributing">Contributing</a>
 </p>
 
 AgentConnect is an open-source platform where teams and multiple AI agents work
@@ -161,6 +160,7 @@ If AgentConnect looks useful, here's how you can support the project:
   report bugs or suggest features.
 - 📺 Follow updates on [X](https://x.com/getAgentConnect) and
   [YouTube](https://www.youtube.com/@agentconnect-md).
+- 🧑‍💻 [Contribute](CONTRIBUTING.md) — we'd love your help.
 
 ## Architecture
 
@@ -183,57 +183,12 @@ See the
 [architecture design](docs/designs/daemon-centric-architecture.md) for the
 complete message paths, trust boundaries, and failure model.
 
-## Development
+## Contributing
 
-Development requires Node >= 24.12.0 and pnpm 11. Docker is required for the Control
-Plane integration tests.
-
-```bash
-pnpm install
-pnpm dev          # run all packages in parallel
-pnpm build        # build all packages
-pnpm typecheck    # type-check all packages
-pnpm lint         # lint the workspace
-pnpm format:check # check formatting
-pnpm test         # test all packages
-
-# single package
-pnpm --filter @agentconnect.md/daemon dev
-pnpm --filter @agentconnect.md/control-plane dev
-pnpm --filter @agentconnect.md/web dev
-```
-
-For a complete local Control Plane and PostgreSQL development setup, follow the
-[Control Plane quickstart](packages/control-plane/README.md#local-dev-quickstart).
-
-## Monorepo layout
-
-This repository is a pnpm workspace. Product packages live under `packages/`:
-
-| Package                               | Path                                                         | Role                                                              |
-| ------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------- |
-| `@agentconnect.md/cli`                | [`packages/cli`](packages/cli)                               | Stable `agentconnect` entry point, daemon lifecycle, and upgrades |
-| `@agentconnect.md/connection`         | [`packages/connection`](packages/connection)                 | Shared WebSocket transport, correlation, backoff, and keepalive   |
-| `@agentconnect.md/control-plane`      | [`packages/control-plane`](packages/control-plane)           | Orchestration, registry, authentication, and Web UI BFF           |
-| `@agentconnect.md/daemon`             | [`packages/daemon`](packages/daemon)                         | Edge message processing and agent execution unit                  |
-| `@agentconnect.md/memory-plugin-mem0` | [`packages/memory-plugin-mem0`](packages/memory-plugin-mem0) | Mem0 Cloud and OSS memory-plugin profiles                         |
-| `@agentconnect.md/message`            | [`packages/message`](packages/message)                       | Pure platform message normalization                               |
-| `@agentconnect.md/protocol`           | [`packages/protocol`](packages/protocol)                     | Shared daemon, relay, and Control Plane wire contracts            |
-| `@agentconnect.md/relay`              | [`packages/relay`](packages/relay)                           | Callback ingress, webchat, and centralized MCP proxy              |
-| `@agentconnect.md/setup`              | [`packages/setup`](packages/setup)                           | Browser-based self-hosting and provider App administration        |
-| `@agentconnect.md/web`                | [`packages/web`](packages/web)                               | Next.js configuration and monitoring console                      |
-
-## Explore
-
-- [Public documentation](https://docs.agentconnect.md)
-- [Self-host AgentConnect OSS](https://docs.agentconnect.md/docs/oss-get-started)
-- [Architecture and detailed designs](docs/designs/)
-- [CLI and daemon lifecycle](docs/designs/cli-daemon-split.md)
-- [Setup Server](packages/setup/README.md)
-- [Daemon configuration](docs/designs/daemon-detailed-design.md)
-- [Config-file secrets](docs/config-file-secrets.md)
-- [Product conventions](docs/product-conventions.md)
-- [Add-on evaluation harness](evals/README.md)
+Contributions are welcome. Development needs Node >= 24.12.0 and pnpm 11;
+`pnpm install && pnpm dev` runs every package in watch mode. The
+[contributing guide](CONTRIBUTING.md) covers the full setup, the pull request
+conventions, the monorepo layout, and the deeper design documentation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
   <a href="#why-agentconnect">Why AgentConnect?</a> ·
   <a href="#get-started">Get started</a> ·
   <a href="#community">Community</a> ·
+  <a href="#contributing">Contributing</a> ·
   <a href="#architecture">Architecture</a>
 </p>
 
@@ -159,8 +160,13 @@ If AgentConnect looks useful, here's how you can support the project:
   report bugs or suggest features.
 - 📺 Follow updates on [X](https://x.com/getAgentConnect) and
   [YouTube](https://www.youtube.com/@agentconnect-md).
-- 🧑‍💻 [Contribute](CONTRIBUTING.md) — we'd love your help. The guide covers
-  development setup, pull request conventions, and the monorepo layout.
+
+## Contributing
+
+Contributions are welcome. Development needs Node >= 24.12.0 and pnpm 11;
+`pnpm install && pnpm dev` runs every package in watch mode. The
+[contributing guide](CONTRIBUTING.md) covers the full setup, the pull request
+conventions, the monorepo layout, and the deeper design documentation.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ conventions, the monorepo layout, and the deeper design documentation.
 Thanks to everyone who has already contributed:
 
 <a href="https://github.com/agentconnect-md/agentconnect/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=agentconnect-md/agentconnect" alt="AgentConnect contributors" />
+  <img src="https://contrib.rocks/image?repo=agentconnect-md/agentconnect" height="40" alt="AgentConnect contributors" />
 </a>
 
 ## Architecture


### PR DESCRIPTION
## Summary

The README's tail carried three developer-facing sections that a product reader never needs. They now live in a `CONTRIBUTING.md`, which GitHub also surfaces automatically on new pull requests and issues:

- **Development** (requirements, workspace commands, the Control Plane quickstart pointer) — moved as-is.
- **Monorepo layout** (the package table) — moved as-is.
- **Explore** — moved as "Explore further", minus the self-hosting link that the Get started section already carries.
- New **Pull requests** section documenting the Conventional Commits rule the Semantic PR status check already enforces.

In the README, a short **Contributing** section now sits directly after Community: the requirements one-liner, the pointer to the guide, and a contributors wall (contrib.rocks, rendered from the contributors graph so it updates itself). The navigation row drops from seven entries to six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
