### PR TITLE
docs: drop daemon-centric branding from product-facing copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "agentconnect",
   "version": "1.0.0-dev",
-  "description": "Daemon-centric multi-agent platform bridging IM platforms to AI coding agents",
+  "description": "Multi-agent platform bridging IM platforms to AI coding agents",
   "license": "Apache-2.0",
   "scripts": {
     "build": "pnpm -r build",

--- a/packages/web/src/app/waitlist/Waitlist.tsx
+++ b/packages/web/src/app/waitlist/Waitlist.tsx
@@ -572,7 +572,7 @@ const FEATURES: { icon: string; title: string; body: string }[] = [
     title: 'One operator console',
     body: 'Volume, latency, escalations and live transcripts in one view.'
   },
-  { icon: 'key', title: 'Your keys stay put', body: 'Daemon-centric — credentials never leave your machines.' }
+  { icon: 'key', title: 'Your keys stay put', body: 'Agents run on your machines — credentials never leave them.' }
 ]
 
 function IntakeAside() {

--- a/packages/web/src/components/Auth.tsx
+++ b/packages/web/src/components/Auth.tsx
@@ -23,7 +23,7 @@ function BrandPanel() {
       <div className="brand-foot mt-[30px]">
         <span className="dot h-2 w-2 rounded-full bg-(--status-online) shadow-[0_0_0_3px_rgba(21,166,97,.25)]" />
         <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-inverse-dim)">
-          Daemon-centric — your keys never leave your machines.
+          Agents run on your machines — keys never leave them.
         </span>
       </div>
       <span className="facet">


### PR DESCRIPTION
Follow-up to #1507, which stopped branding the architecture diagram. The same
label was still doing product positioning in three more places, so this replaces
it with what the design actually gives the reader.

- **Sign-in brand panel** — `Daemon-centric — your keys never leave your machines.`
  becomes `Agents run on your machines — keys never leave them.`
- **Waitlist feature list** — the "Your keys stay put" item now says
  `Agents run on your machines — credentials never leave them.`
- **Repository description** — drops the `Daemon-centric` prefix.

The term stays where it belongs: the design documents, `CLAUDE.md`, and the two
code comments that reference the architecture invariant by name. It is
terminology for people reading the design, not a product claim for people
reading a sign-in page.

Copy-only; no behavior change. Prettier and ESLint pass on the touched files.
