### PR TITLE
docs(readme): show the product release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
   <a href="https://slack.agentconnect.md"><img src="https://custom-icon-badges.demolab.com/badge/Slack-4A154B?logo=slack&logoColor=fff" alt="Join AgentConnect on Slack" /></a>
   <a href="https://x.com/getAgentConnect"><img src="https://img.shields.io/badge/Follow-000000?logo=x&logoColor=fff" alt="Follow @getAgentConnect on X" /></a>
   <a href="https://github.com/agentconnect-md/agentconnect/actions/workflows/test.yaml"><img src="https://github.com/agentconnect-md/agentconnect/actions/workflows/test.yaml/badge.svg" alt="Test status" /></a>
-  <a href="https://www.npmjs.com/package/@agentconnect.md/daemon/v/latest"><img src="https://img.shields.io/npm/v/%40agentconnect.md%2Fdaemon/latest?label=daemon%20latest" alt="Latest daemon version" /></a>
+  <a href="https://github.com/agentconnect-md/agentconnect/releases/latest"><img src="https://img.shields.io/github/v/release/agentconnect-md/agentconnect" alt="Latest release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Apache 2.0 license" /></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ command, and create your first agent. The default stack listens only on
 
 For Kubernetes, install the official Helm chart in
 [`charts/agentconnect`](charts/agentconnect), published to
-`oci://ghcr.io/agentconnect-md/charts/agentconnect` on every release. For
+`oci://ghcr.io/agentconnect-md/charts/agentconnect` on every release with the
+same version number as the release itself. For
 authentication, public URLs, Linux sandbox requirements, provider apps, image
 pinning, secrets, and optional Mem0 configuration, follow the
 [AgentConnect OSS guide](https://docs.agentconnect.md/docs/oss-get-started).


### PR DESCRIPTION
## Summary

The version badge read "daemon latest", but the release train versions every component together, so the daemon-specific label added nothing for a README reader. The badge is now the standard GitHub release badge ("release | vX.Y.Z", latest stable), and it links to the releases page instead of one npm package.

That one badge also covers the Helm chart: the release workflow stamps the published chart with the release version, so Get started now says the chart carries the same version number as the release itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
