### PR TITLE
docs: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues or
+community channels.
+
+Report them privately through
+[GitHub security advisories](https://github.com/agentconnect-md/agentconnect/security/advisories/new).
+We will review the report, work with you on a fix, and coordinate disclosure.
+
+## Supported versions
+
+Security fixes land in the latest release. If you self-host AgentConnect, stay
+on the most recent version.


### PR DESCRIPTION
## Summary

Adds `SECURITY.md`. Private vulnerability reporting is already enabled on the repository, so the policy routes reports to GitHub security advisories — no separate contact channel needed — and states that security fixes land in the latest release. The file also gives the repository page a Security tab next to README, Contributing, and the license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
