### PR TITLE
docs(readme): link the star ask back to the repo top

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ pinning, secrets, and optional Mem0 configuration, follow the
 
 If AgentConnect looks useful, here's how you can support the project:
 
-- ⭐ **Star this repo** to help more teams discover the project.
+- ⭐ **[Star this repo](https://github.com/agentconnect-md/agentconnect)** to
+  help more teams discover the project.
 - 💬 [Join the Slack community](https://slack.agentconnect.md) for questions,
   ideas, and product discussions.
 - 📣 Share AgentConnect on


### PR DESCRIPTION
## Summary

The Community star ask was plain text; a reader deep in the page had to scroll back on their own. "Star this repo" now links to the repository page, which lands them at the top where the Star button is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
