### PR TITLE
docs(readme): ground Why in the shared-glue problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ work can begin from a message, issue, pull request, webhook, or schedule.
 
 ## Why AgentConnect?
 
-An agent is more than a model API call. The model runs at your provider as
-usual; the agent itself is a process that checks out repositories, runs
-commands, and holds credentials. Your agents can touch real things. Something
-has to manage that.
+AI agents are taking on work across the team, but most still live in
+individual terminals. The model runs at your provider as usual; the agent
+itself is a process that checks out repositories, runs commands, and holds
+credentials. Your agents can touch real things. Something has to manage that.
 
 AgentConnect is that layer. Teams use it to:
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,13 @@ work can begin from a message, issue, pull request, webhook, or schedule.
 
 ## Why AgentConnect?
 
-AI agents are taking on work across the team, but most still live in
-individual terminals. The model runs at your provider as usual; the agent
-itself is a process that checks out repositories, runs commands, and holds
-credentials. Your agents can touch real things. Something has to manage that.
+AI agents are getting better at doing work. The harder problem is making
+multiple agents work well with a team—and with each other.
+
+An agent is not "an API call to a model." The model may run at a provider—the
+agent itself is a real process that checks out your repos, runs commands, and
+holds your credentials. Your agents can touch real things. Something has to
+manage that.
 
 AgentConnect is that layer. Teams use it to:
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ work can begin from a message, issue, pull request, webhook, or schedule.
 AI agents are getting better at doing work. The harder problem is making
 multiple agents work well with a team—and with each other.
 
-An agent is not "an API call to a model." The model may run at a provider—the
-agent itself is a real process that checks out your repos, runs commands, and
-holds your credentials. Your agents can touch real things. Something has to
-manage that.
+Most agents still live like personal tools, in one person's terminal. Teammates
+can't see what an agent is doing, can't take over a session, can't review its
+output, and the context it builds stays on one laptop. So every team writes the
+same glue: message channels, cron jobs, credential handling, context stitching.
 
-AgentConnect is that layer. Teams use it to:
+AgentConnect turns that glue into a platform. Teams use it to:
 
 - **Triage issues together.** People and agents investigate in one shared
   thread, bring in the right specialists, and keep the fix and verification


### PR DESCRIPTION
## Summary

Rewrites the opening of "Why AgentConnect?" with concrete copy from our published posts:

- The launch post's opener: AI agents are getting better at doing work; the harder problem is making multiple agents work well with a team—and with each other.
- The origin story's concrete breakdown: agents live like personal tools in one person's terminal — teammates can't see what an agent is doing, can't take over a session, can't review its output, and its context stays on one laptop — so every team writes the same glue: message channels, cron jobs, credential handling, context stitching.
- "AgentConnect turns that glue into a platform" replaces the abstract "is that layer" lead into the use-case list.

The definitional "an agent is not an API call to a model" paragraph is gone — it carried no concrete information outside its original narrative. The docs introduction gets the same opening in agentconnect-md/docs#83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
