### PR TITLE
feat(control-plane): carry the org slug on an info series

### DIFF
--- a/packages/control-plane/src/observability/org-metrics.test.ts
+++ b/packages/control-plane/src/observability/org-metrics.test.ts
@@ -6,6 +6,7 @@ const NOW = new Date('2026-01-01T00:00:00Z')
 
 const row = (over: Partial<OrgTelemetryRow> = {}): OrgTelemetryRow => ({
   orgId: 'org_acme',
+  slug: 'acme',
   daemons: 2,
   agents: 7,
   sessionsTotal: 900,
@@ -33,6 +34,16 @@ describe('orgObservations', () => {
     expect(valueOf(obs, 'sessions', '24h')).toBe(5)
     // The ID, never the slug: a slug is mutable and is user-chosen text.
     expect(obs.every((o) => o.attrs.org === 'org_acme')).toBe(true)
+    expect(obs.filter((o) => o.metric !== 'info').every((o) => o.attrs.slug === undefined)).toBe(true)
+  })
+
+  // The whole point of the info series: the readable handle lives on ONE series a dashboard joins
+  // by `org`, so renaming an org churns that series alone and leaves every count's identity intact.
+  it('carries the slug on a separate always-1 info series', () => {
+    const obs = orgObservations([row()])
+    expect(obs.filter((o) => o.metric === 'info')).toEqual([
+      { metric: 'info', value: 1, attrs: { org: 'org_acme', slug: 'acme' } }
+    ])
   })
 
   // The counts are not a hierarchy: only `total` is cumulative, so an org that has stopped using
@@ -46,11 +57,11 @@ describe('orgObservations', () => {
 
   // A series that vanishes on the way to zero is invisible on a dashboard — an org that removed
   // its last daemon would look like an org that was never there.
-  it('emits all five series for an org holding nothing, as zeros', () => {
+  it('emits all five counts for an org holding nothing, as zeros', () => {
     const empty = row({ orgId: 'org_empty', daemons: 0, agents: 0, sessionsTotal: 0, sessions30d: 0, sessions24h: 0 })
-    const obs = orgObservations([empty])
-    expect(obs).toHaveLength(5)
-    expect(obs.map((o) => o.value)).toEqual([0, 0, 0, 0, 0])
+    const counts = orgObservations([empty]).filter((o) => o.metric !== 'info')
+    expect(counts).toHaveLength(5)
+    expect(counts.map((o) => o.value)).toEqual([0, 0, 0, 0, 0])
   })
 
   it('reports every org, so a busy one cannot be averaged away by an idle one', () => {

--- a/packages/control-plane/src/observability/org-metrics.ts
+++ b/packages/control-plane/src/observability/org-metrics.ts
@@ -16,15 +16,18 @@
  *  - `org.sessions{window="total"}` is a lifetime count over an unpruned table, so it only ever
  *    climbs. The `30d`/`24h` windows are the ones that show whether an org is still active.
  *
- * The `org` label is the org's ID, never its slug. A slug is mutable, so labelling with it would
- * retire a series on rename — exactly the disappearance the zeros below exist to prevent — and a
- * slug is user-chosen text, which has no business being a label value in a metrics backend.
- * Resolving an id to a name is the dashboard's job.
+ * The `org` label on a count is the org's ID, never its slug. A slug is mutable, so labelling a
+ * count with it would retire that series on rename — exactly the disappearance the zeros below
+ * exist to prevent. The readable handle rides one dedicated series instead: `agentconnect.org.info`
+ * is always 1 and carries `slug`, which a dashboard joins onto the counts by `org`
+ * (`… * on (org) group_left(slug) max by (org, slug) (agentconnect.org.info)`). A rename then
+ * churns that one series and leaves every count intact. The org's optional display NAME is not
+ * exported at all: it is free-form text a user typed, which has no business in a metrics backend.
  *
  * Every CP replica observes the same install-wide numbers, so these are fleet totals repeated per
  * pod, not per-pod shards: aggregate them with `max by (...)`, never `sum`. Cardinality, not the
  * query, is the dominant cost: a signup-driven install where most users create an org of their own
- * reports closer to (users × 5) series per replica, every one of them re-reported each collection
+ * reports closer to (users × 6) series per replica, every one of them re-reported each collection
  * interval whether or not that org has ever held anything.
  */
 import { metrics, type BatchObservableResult, type ObservableGauge } from '@opentelemetry/api'
@@ -46,7 +49,7 @@ export interface OrgMetricsDeps {
   log?: OrgMetricsLog
 }
 
-export type OrgMetricName = 'daemons' | 'agents' | 'sessions'
+export type OrgMetricName = 'info' | 'daemons' | 'agents' | 'sessions'
 
 /** `total` is the lifetime count; the others are how many sessions STARTED in that window. */
 export type SessionWindow = 'total' | '30d' | '24h'
@@ -54,7 +57,8 @@ export type SessionWindow = 'total' | '30d' | '24h'
 export interface OrgObservation {
   metric: OrgMetricName
   value: number
-  attrs: { org: string; window?: SessionWindow }
+  /** `window` belongs to `sessions`, `slug` to `info`; a count carries `org` alone. */
+  attrs: { org: string; window?: SessionWindow; slug?: string }
 }
 
 /** Rows → the series each gauge reports, labelled by org ID. Pure, so a dashboard's input is
@@ -68,6 +72,9 @@ export function orgObservations(rows: readonly OrgTelemetryRow[]): OrgObservatio
       attrs: { org, window }
     })
     return [
+      // The slug, never the display name: a slug is a constrained unique handle a URL and a CLI
+      // already take, where a display name is free-form text a user typed.
+      { metric: 'info', value: 1, attrs: { org, slug: row.slug } },
       { metric: 'daemons', value: row.daemons, attrs: { org } },
       { metric: 'agents', value: row.agents, attrs: { org } },
       sessions('total', row.sessionsTotal),
@@ -102,6 +109,11 @@ const meter = metrics.getMeter('@agentconnect.md/control-plane-org', '1.0.0')
 
 function createGauges(): Record<OrgMetricName, ObservableGauge> {
   return {
+    info: meter.createObservableGauge('agentconnect.org.info', {
+      unit: '{org}',
+      description:
+        'Always 1. Carries the org slug so a dashboard can join a readable handle onto the id-labelled counts. The optional display name is deliberately not exported'
+    }),
     daemons: meter.createObservableGauge('agentconnect.org.daemons', {
       unit: '{daemon}',
       description:

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4809,9 +4809,12 @@ export interface OrgRecord {
 
 /** One org's footprint, for the per-org gauges (observability/org-metrics.ts). */
 export interface OrgTelemetryRow {
-  /** What the gauge labels the series with. The slug is deliberately NOT read here: it is mutable,
-   *  and an org's is chosen by whoever created it. */
+  /** What every count is labelled with — an id, so no rename can retire a series. */
   orgId: string
+  /** The org's handle. Reported ONLY on the `info` series, never as a label on a count: it is
+   *  mutable, and labelling a count with it would retire that count on rename. The org's optional
+   *  display name is deliberately NOT read — free-form text does not belong in a metrics backend. */
+  slug: string
   /** Daemons registered to the org, any status. An install-wide pool member belongs to NO org
    *  (`daemon.orgId IS NULL`) and is counted for none of them — a pool-backed org reads zero here
    *  however much of the pool it occupies, which `duty_group` is the ledger for. */

--- a/packages/control-plane/src/persistence/repositories/org.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/org.repo.ts
@@ -217,6 +217,7 @@ export class PgOrgRepo implements OrgRepo {
       )
       -- Driven from "org" so an org holding nothing still reports its zeros.
       SELECT o.id AS "orgId",
+             o.slug AS "slug",
              COALESCE(d.n, 0)::int AS "daemons",
              COALESCE(a.n, 0)::int AS "agents",
              COALESCE(s.total, 0)::int AS "sessionsTotal",

--- a/packages/control-plane/test/repo/org-telemetry.repo.test.ts
+++ b/packages/control-plane/test/repo/org-telemetry.repo.test.ts
@@ -42,18 +42,25 @@ describe('orgTelemetry', () => {
     expect(byId(rows, other.id)).toMatchObject({ daemons: 0, agents: 1, sessionsTotal: 1 })
   })
 
-  // The label has to survive a rename, and must not carry user-chosen text — so the row is keyed
-  // by id and the slug is never read.
-  it('identifies an org by id, not by its mutable slug', async () => {
-    const org = await prisma.org.create({ data: { slug: 'before-rename' } })
+  // The counts have to survive a rename, so a row is keyed by id; the slug is read beside it and is
+  // meant to follow the rename — that is the whole job of the info series it feeds.
+  it('keys a row by id while the slug follows a rename', async () => {
+    const org = await prisma.org.create({ data: { slug: 'before-rename', name: 'Display Name' } })
 
     const before = await repo().orgTelemetry(NOW)
     await prisma.org.update({ where: { id: org.id }, data: { slug: 'after-rename' } })
     const after = await repo().orgTelemetry(NOW)
 
-    expect(byId(before, org.id)).toBeDefined()
-    expect(byId(after, org.id)).toBeDefined()
-    expect(Object.keys(byId(after, org.id))).not.toContain('orgSlug')
+    expect(byId(before, org.id)).toMatchObject({ slug: 'before-rename' })
+    expect(byId(after, org.id)).toMatchObject({ slug: 'after-rename' })
+  })
+
+  // The display name is free-form text a user typed; nothing downstream may export it, so the read
+  // must not hand it out in the first place.
+  it('does not read the org display name at all', async () => {
+    const org = await prisma.org.create({ data: { slug: 'named-org', name: 'Display Name' } })
+
+    expect(Object.keys(byId(await repo().orgTelemetry(NOW), org.id))).not.toContain('name')
   })
 
   // An org running entirely on the install-wide pool reads zero daemons — the member is shared by


### PR DESCRIPTION
## Why

`agentconnect.org.daemons` / `.agents` / `.sessions` are labelled with the org **id** and nothing else, so any dashboard built on them shows a column of cuids. That was deliberate — `org-metrics.ts` argues that a slug is mutable, and labelling a count with it would retire that count's series on a rename, exactly the disappearance the zeros in that file exist to prevent — and it closed with "resolving an id to a name is the dashboard's job". Nothing was ever exported for the dashboard to resolve it *with*, which is where this leaves the reader today.

## What

One more series per org, the standard info-metric shape: `agentconnect.org.info` is always `1` and carries `slug` beside `org`. A dashboard joins it onto the counts by `org`:

```
max by (org) (agentconnect.org.agents)
  * on (org) group_left(slug) max by (org, slug) (agentconnect.org.info)
```

- the counts keep the id label they had, so a rename churns that one info series and leaves every count's identity intact;
- the slug rides one series rather than five, so the churn is bounded;
- it comes out of the same single read the gauges already do — `orgTelemetry` selects one more column, no extra query.

The org's **optional display name is deliberately not exported**, not even as a fallback: a slug is a constrained unique handle that a URL and the CLI already take, where a display name is free-form text a user typed. The repo read does not select it, and there is an integration test asserting the row never carries it.

## Cost

Per-org series count goes 5 → 6 (+20%), re-reported each collection interval like the rest.

## Reviewer notes

- The join is only as good as the info series being present in the same window: a dashboard that hard-joins will drop an org whose info sample is missing. For a table panel prefer two queries plus a join-by-field transformation, which keeps the row and leaves the slug cell empty.
- Within the staleness window right after a rename, both the old and new info series can resolve and a PromQL `group_left` will report multiple matches. Same recommendation as above for tables.
- No migration, no API change, no consumer outside `observability/org-metrics.ts`.

## Test

`typecheck`, `test:unit`, `test:int`, `lint` all pass. New coverage: the info series shape, that no count carries a `slug` label, that a row keeps its id while the slug follows a rename, and that the display name is never read.
