### PR TITLE
refactor(web): move Analytics beside Infra, Integrations above Knowledge

### DIFF
--- a/packages/web/src/components/console/nav.ts
+++ b/packages/web/src/components/console/nav.ts
@@ -20,9 +20,9 @@ export function navVisible(item: { requires?: FeatureFlagId }): boolean {
 }
 
 // The rail's destinations, in groups separated by a rule: what the organization
-// runs (agents and the surfaces they answer on) first, then the fleet the work
-// runs on. Daemons sits alone at the bottom because it is infrastructure — you
-// visit it when something is wrong, not to get work done.
+// runs (agents and the surfaces they answer on) first, then what it runs on and
+// pays for — infrastructure, the usage that came out of it, the bill. You visit
+// the second group to check on the deployment, not to get work done.
 export const NAV_GROUPS: NavItem[][] = [
   [
     { href: '/home', label: 'Home', icon: 'house' },
@@ -30,12 +30,12 @@ export const NAV_GROUPS: NavItem[][] = [
     { href: '/sessions', label: 'Sessions', icon: 'messages-square' },
     { href: '/crons', label: 'Schedules', icon: 'calendar-clock' },
     { href: '/tools', label: 'Tools & Skills', icon: 'blocks' },
-    { href: '/knowledge', label: 'Knowledge', icon: 'book-open' },
     { href: '/integrations', label: 'Integrations', icon: 'plug' },
-    { href: '/usage', label: 'Analytics', icon: 'circle-gauge' }
+    { href: '/knowledge', label: 'Knowledge', icon: 'book-open' }
   ],
   [
     { href: '/daemons', label: 'Infra', icon: 'server' },
+    { href: '/usage', label: 'Analytics', icon: 'circle-gauge' },
     { href: '/billing', label: 'Billing', icon: 'credit-card', requires: 'billing' }
   ]
 ]
@@ -55,11 +55,11 @@ export const MOBILE_NAV: NavItem[] = [
 // top-right avatar (mirroring the desktop top bar). The org switcher is
 // prepended separately, in the sheet itself.
 export const MORE_ROWS: NavItem[] = [
-  { href: '/usage', label: 'Analytics', icon: 'circle-gauge' },
   { href: '/tools', label: 'Tools & Skills', icon: 'blocks' },
-  { href: '/knowledge', label: 'Knowledge', icon: 'book-open' },
   { href: '/integrations', label: 'Integrations', icon: 'plug' },
+  { href: '/knowledge', label: 'Knowledge', icon: 'book-open' },
   { href: '/daemons', label: 'Infra', icon: 'server' },
+  { href: '/usage', label: 'Analytics', icon: 'circle-gauge' },
   { href: '/billing', label: 'Billing', icon: 'credit-card', requires: 'billing' },
   { href: '/settings', label: 'Settings', icon: 'settings' }
 ]
@@ -73,10 +73,10 @@ export const SECTIONS: { prefix: string; label: string }[] = [
   // Merged conversation pages live in the Sessions section (§5.3).
   { prefix: '/conversations', label: 'Sessions' },
   { prefix: '/crons', label: 'Schedules' },
-  { prefix: '/daemons', label: 'Infra' },
   { prefix: '/tools', label: 'Tools & Skills' },
-  { prefix: '/knowledge', label: 'Knowledge' },
   { prefix: '/integrations', label: 'Integrations' },
+  { prefix: '/knowledge', label: 'Knowledge' },
+  { prefix: '/daemons', label: 'Infra' },
   { prefix: '/usage', label: 'Analytics' },
   { prefix: '/billing', label: 'Billing' },
   { prefix: '/settings', label: 'Settings' },


### PR DESCRIPTION
## What

Two console rail reorderings:

- **Analytics** leaves the first group and joins the second, under Infra — the group is now Infra, Analytics, Billing.
- **Integrations** moves above Knowledge, so it sits next to Tools & Skills.

## Why

The first group is what the organization runs — agents and the surfaces they answer on. Analytics is a view of the deployment rather than one of those surfaces, so it belongs with Infra and Billing, below the rule. Integrations and Tools & Skills are both about what agents connect out to, so they read better adjacent.

## Notes for reviewers

Both moves happen in the single nav table in `packages/web/src/components/console/nav.ts`, which feeds four surfaces at once — the desktop rail (`NAV_GROUPS`), the mobile "More" sheet (`MORE_ROWS`), the app-bar section titles (`SECTIONS`), and the global-search page index (`SEARCH_PAGES`, derived from `NAV_GROUPS`). All four were kept in the same order so mobile cannot disagree with desktop.

The group comment above `NAV_GROUPS` was updated: it claimed the bottom group was Daemons alone, which was already untrue with Billing there and is more so now.

No route, component, or feature-flag change — ordering and one comment only.

## Verification

- `nav.test.ts` and `GlobalSearch.test.tsx` — 15/15 pass. They assert nav/search coverage by href set rather than order, so no test needed updating.
- `pnpm --filter @agentconnect.md/web typecheck` clean; prettier clean.
