### PR TITLE
feat(web): draw a placement by what it is, and resolve one by placement

### DIFF
--- a/packages/web/src/app/(app)/[slug]/settings/page.tsx
+++ b/packages/web/src/app/(app)/[slug]/settings/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import SettingsView from '@/components/console/views/SettingsView'
 
-export const metadata: Metadata = { title: 'Settings · AgentConnect' }
+export const metadata: Metadata = { title: 'Organization settings · AgentConnect' }
 
 export default function Page() {
   return <SettingsView />

--- a/packages/web/src/components/console/DaemonSelect.tsx
+++ b/packages/web/src/components/console/DaemonSelect.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
 import { Icon } from '@/components/ui'
+import { placementIcon, type PlacementIconKind } from '@/lib/data'
 
 /** What a placement option NAMES (daemon-groups.md §2): the install-wide pool, one of the org's
  *  own groups, or a single machine. The first two are member sets and behave alike — the server
  *  picks the member — so they share an icon language and differ only in badge. */
-export type PlacementOptionKind = 'pool' | 'group' | 'daemon'
+export type PlacementOptionKind = PlacementIconKind
 
 export interface DaemonSelectOption {
   value: string
@@ -21,7 +22,7 @@ export interface DaemonSelectOption {
 /** A set target is drawn as a target, never as the member that happens to answer for it. */
 const isSet = (option: Pick<DaemonSelectOption, 'kind'>): boolean => option.kind === 'pool' || option.kind === 'group'
 const iconFor = (option: DaemonSelectOption): string =>
-  option.kind === 'pool' ? 'cloud' : option.kind === 'group' ? 'layers' : option.value ? 'server' : 'server-off'
+  option.kind || option.value ? placementIcon(option.kind ?? 'daemon') : 'server-off'
 
 function enabledIndex(options: readonly DaemonSelectOption[], start: number, delta: 1 | -1): number {
   if (!options.length) return -1

--- a/packages/web/src/components/console/GlobalSearch.test.tsx
+++ b/packages/web/src/components/console/GlobalSearch.test.tsx
@@ -24,8 +24,17 @@ vi.mock('swr', () => ({
 vi.mock('@/lib/api', () => ({
   fetchSessionExternalAccess: vi.fn()
 }))
+// Mutable so a test can hand the box a fleet; every entry defaults empty.
+const consoleData = vi.hoisted(() => ({
+  agents: [] as unknown[],
+  daemons: [] as unknown[],
+  memberSets: [] as unknown[],
+  orgSetIds: new Set<string>(),
+  crons: [] as unknown[],
+  allSessions: [] as unknown[]
+}))
 vi.mock('@/lib/data-context', () => ({
-  useConsoleData: () => ({ agents: [], daemons: [], crons: [], allSessions: [] })
+  useConsoleData: () => consoleData
 }))
 const authConfigured = vi.fn(() => true)
 vi.mock('@/lib/auth', () => ({
@@ -46,6 +55,13 @@ let root: Root
 
 beforeEach(() => {
   push.mockClear()
+  consoleData.agents = []
+  consoleData.daemons = []
+  consoleData.memberSets = []
+  consoleData.orgSetIds = new Set()
+  consoleData.crons = []
+  consoleData.allSessions = []
+  setFlags('')
   authConfigured.mockReturnValue(true)
   myRole.mockReturnValue('owner')
   sessionAccess.mockReturnValue({ available: true, enabled: false })
@@ -75,6 +91,11 @@ function type(value: string) {
     setter?.call(input, value)
     input.dispatchEvent(new Event('input', { bubbles: true }))
   })
+}
+
+/** The console names and offers the pool and groups only where the deployment asked for them. */
+const setFlags = (value: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: value }
 }
 
 // Page/setting result rows render the route as their meta line, which the
@@ -184,5 +205,73 @@ describe('GlobalSearch pages & settings', () => {
     render()
     type('zzz-no-such-thing')
     expect(host.textContent).toContain('No results for')
+  })
+})
+
+// The Infra page shows three entities — the pool as ONE entry, the machines, the groups — and the
+// box has to agree with it. Matching `daemons` alone found every pool Pod under the pool's shared
+// name (N identical rows, each opening a Pod a roll replaces) and never found a group at all.
+describe('GlobalSearch infra entities', () => {
+  const daemonRow = (over: Record<string, unknown>) => ({
+    daemonId: 'd',
+    pool: false,
+    memberSetId: null,
+    name: 'edge-1',
+    version: '1.41.0',
+    status: 'online',
+    lifecycleStatus: null,
+    ...over
+  })
+
+  const withFleet = () => {
+    // Two Pods, one pool: the shared name is exactly what used to duplicate the row.
+    consoleData.daemons = [
+      daemonRow({ daemonId: 'pod-a', pool: true, memberSetId: 'set-pool', name: 'AgentConnect Cloud' }),
+      daemonRow({ daemonId: 'pod-b', pool: true, memberSetId: 'set-pool', name: 'AgentConnect Cloud' }),
+      daemonRow({ daemonId: 'dmn-1', name: 'edge-1' }),
+      daemonRow({ daemonId: 'dmn-2', memberSetId: 'set-lab', name: 'lab-box' })
+    ]
+    consoleData.memberSets = [{ setId: 'set-lab', name: 'lab', memberDaemonIds: ['dmn-2'], agentCount: 2 }]
+    consoleData.orgSetIds = new Set(['set-lab'])
+  }
+
+  it('finds the pool as one entry and opens the pool, never a member Pod', () => {
+    setFlags('daemon-pool,managed')
+    withFleet()
+    render()
+    type('agentconnect cloud')
+    const rows = [...host.querySelectorAll('button')].filter((b) => b.textContent?.includes('AgentConnect Cloud'))
+    expect(rows).toHaveLength(1)
+    act(() => rows[0]!.click())
+    expect(push).toHaveBeenCalledWith('/org-test/daemons/cluster')
+  })
+
+  it('finds a group by name and opens the group', () => {
+    setFlags('daemon-pool,daemon-groups,managed')
+    withFleet()
+    render()
+    type('lab')
+    act(() => resultButton('1 daemon · 2 agents').click())
+    expect(push).toHaveBeenCalledWith('/org-test/daemons/groups/set-lab')
+  })
+
+  it('still finds a machine, and a group member is one', () => {
+    setFlags('daemon-pool,daemon-groups,managed')
+    withFleet()
+    render()
+    type('lab-box')
+    act(() => resultButton('lab-box').click())
+    expect(push).toHaveBeenCalledWith('/org-test/daemons/dmn-2')
+  })
+
+  it('offers neither the pool nor a group where the deployment does not', () => {
+    withFleet()
+    render()
+    type('cloud')
+    expect(host.textContent).not.toContain('AgentConnect Cloud')
+    type('lab')
+    // The group is hidden; the machine that happens to be in it is not.
+    expect(host.textContent).toContain('lab-box')
+    expect([...host.querySelectorAll('button')].some((b) => b.textContent?.includes('1 daemon ·'))).toBe(false)
   })
 })

--- a/packages/web/src/components/console/GlobalSearch.tsx
+++ b/packages/web/src/components/console/GlobalSearch.tsx
@@ -16,7 +16,20 @@ import { useRouter } from 'next/navigation'
 import useSWR from 'swr'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
-import { agentLabel, effectiveAgentStatus, presentedDaemonStatus, status } from '@/lib/data'
+import {
+  agentDaemonLabel,
+  agentLabel,
+  effectiveAgentStatus,
+  groupFleetStatus,
+  isPoolPlacementKind,
+  localDaemons,
+  placementIcon,
+  poolFleetStatus,
+  poolLabel,
+  presentedDaemonStatus,
+  status
+} from '@/lib/data'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import { cronHuman } from '@/lib/cron'
 import { isAuthConfigured } from '@/lib/auth'
 import { fetchSessionExternalAccess, type SessionAccessProvider } from '@/lib/api'
@@ -40,7 +53,8 @@ interface SearchItem {
   icon?: AgentIcon | null
   model?: string
   runtime?: string
-  /** Icon-well glyph for page/setting results (the entry's nav icon). */
+  /** Icon-well glyph: the entry's nav icon for a page/setting, the placement's own glyph for the
+   *  pool and groups. Absent ⇒ the kind's default. */
   iconName?: string
   /** Org-scoped navigation target for this result. */
   href: string
@@ -61,10 +75,10 @@ type TypeFilter = 'all' | SearchKind
 // label so a wider match set is still discoverable).
 const CAP = 3
 
-// Icon-well glyph for every non-agent kind (agents render their avatar instead).
-// Page/setting results carry their own nav icon on the item.
+// Icon-well glyph for every non-agent kind (agents render their avatar instead). Pages, settings
+// and the three infra entities carry their own glyph on the item; the rest are fixed per kind.
 const wellIcon = (it: SearchItem): string => {
-  if (it.kind === 'daemon') return 'server'
+  if (it.kind === 'daemon') return it.iconName ?? 'server'
   if (it.kind === 'schedule') return 'alarm-clock'
   if (it.kind === 'session') return 'message-square-text'
   return it.iconName ?? 'panel-left'
@@ -78,7 +92,7 @@ export function GlobalSearch({
 }: { autoFocus?: boolean; mobile?: boolean; rail?: boolean; onClose?: () => void } = {}) {
   const router = useRouter()
   const { orgPath, myRole, activeOrg } = useOrgs()
-  const { agents, daemons, crons, allSessions } = useConsoleData()
+  const { agents, daemons, crons, allSessions, memberSets, orgSetIds } = useConsoleData()
 
   const [open, setOpen] = useState(false)
   const [q, setQ] = useState('')
@@ -131,15 +145,16 @@ export function GlobalSearch({
 
     const agentMatches = agents.filter((a) => hit(agentLabel(a)) || hit(a.name))
     const agentItems: SearchItem[] = agentMatches.slice(0, CAP).map((a) => {
-      // Gate "online" on the owning daemon being connected (as the Agents view does),
-      // and surface the daemon's display NAME — never its host.
+      // Gate "online" on the owning daemon being connected (as the Agents view does), and surface
+      // what it RUNS ON by display name — never its host, and never a set resolved as a machine.
       const owning = daemonById.get(a.daemon)
       const s = status(effectiveAgentStatus(a, owning))
+      const placement = agentDaemonLabel(a, daemons, memberSets)
       return {
         key: `agent:${a.id}`,
         kind: 'agent',
         title: agentLabel(a),
-        meta: [a.model || undefined, owning?.name].filter(Boolean).join(' · '),
+        meta: [a.model || undefined, placement === '—' ? undefined : placement].filter(Boolean).join(' · '),
         aux: s.label,
         dot: s.dot,
         icon: a.icon,
@@ -153,18 +168,54 @@ export function GlobalSearch({
     // view's "Agents hosted"). NOT daemon.agents, which is the active-session count.
     const hostedByDaemon = new Map<string, number>()
     for (const a of agents) hostedByDaemon.set(a.daemon, (hostedByDaemon.get(a.daemon) ?? 0) + 1)
-    const daemonMatches = daemons.filter((d) => hit(d.name))
-    const daemonItems: SearchItem[] = daemonMatches.slice(0, CAP).map((d) => {
-      const hosted = hostedByDaemon.get(d.daemonId) ?? 0
-      return {
+    const plural = (n: number, noun: string) => `${n} ${noun}${n === 1 ? '' : 's'}`
+    // The Infra page's own three entities, in its own order — the pool as ONE entry, the machines,
+    // then the groups. Matching `daemons` alone found every pool Pod under the pool's shared name
+    // (N identical rows, each opening a Pod that a roll replaces) and no group at all.
+    const poolMembers = featureFlagEnabled('daemon-pool') ? daemons.filter((d) => d.pool) : []
+    const poolMatches =
+      poolMembers.length > 0 && hit(poolLabel())
+        ? [
+            {
+              key: 'daemon:pool',
+              kind: 'daemon' as const,
+              title: poolLabel(),
+              meta: plural(
+                agents.filter((a) => isPoolPlacementKind(a.placementKind, a.setId, orgSetIds)).length,
+                'agent'
+              ),
+              aux: status(poolFleetStatus(poolMembers)).label,
+              iconName: placementIcon('pool'),
+              href: orgPath('/daemons/cluster')
+            }
+          ]
+        : []
+    const machineMatches = localDaemons(daemons)
+      .filter((d) => hit(d.name))
+      .map((d) => ({
         key: `daemon:${d.daemonId}`,
-        kind: 'daemon',
+        kind: 'daemon' as const,
         title: d.name,
-        meta: [d.version || undefined, `${hosted} agent${hosted === 1 ? '' : 's'}`].filter(Boolean).join(' · '),
+        meta: [d.version || undefined, plural(hostedByDaemon.get(d.daemonId) ?? 0, 'agent')]
+          .filter(Boolean)
+          .join(' · '),
         aux: status(presentedDaemonStatus(d)).label,
+        iconName: placementIcon('daemon'),
         href: orgPath(`/daemons/${d.daemonId}`)
-      }
-    })
+      }))
+    const groupMatches = (featureFlagEnabled('daemon-groups') ? memberSets : [])
+      .filter((group) => hit(group.name))
+      .map((group) => ({
+        key: `group:${group.setId}`,
+        kind: 'daemon' as const,
+        title: group.name,
+        meta: [plural(group.memberDaemonIds.length, 'daemon'), plural(group.agentCount, 'agent')].join(' · '),
+        aux: status(groupFleetStatus(group, daemons)).label,
+        iconName: placementIcon('group'),
+        href: orgPath(`/daemons/groups/${group.setId}`)
+      }))
+    const daemonMatches: SearchItem[] = [...poolMatches, ...machineMatches, ...groupMatches]
+    const daemonItems = daemonMatches.slice(0, CAP)
 
     // Only named schedules are searchable — legacy/CLI cron rows have a null name.
     // The `c.name` guard also keeps them out of the empty-query chip count (where
@@ -241,7 +292,21 @@ export function GlobalSearch({
         items: settingMatches.slice(0, CAP).map(toItem)
       }
     ]
-  }, [query, agents, daemons, crons, allSessions, daemonById, agentById, orgPath, authed, myRole, sessionAccessRenders])
+  }, [
+    query,
+    agents,
+    daemons,
+    memberSets,
+    orgSetIds,
+    crons,
+    allSessions,
+    daemonById,
+    agentById,
+    orgPath,
+    authed,
+    myRole,
+    sessionAccessRenders
+  ])
 
   const totalCount = useMemo(() => groups.reduce((n, g) => n + g.count, 0), [groups])
   // Chips: "All" + every kind with at least one match.

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -300,7 +300,7 @@ function RailAccount({
             </Link>
             <Link href={orgPath('/settings')} className="dmi no-underline" onClick={() => setOpen(false)}>
               <Icon name="settings" size={15} color="var(--text-tertiary)" />
-              Settings
+              Organization settings
             </Link>
             <div className="dmsep" />
             <button className="dmi" onClick={onToggleTheme}>
@@ -849,7 +849,7 @@ function ShellChromeInner({ children }: { children: ReactNode }) {
                       className="lnk flex-none text-[12px]"
                       onClick={() => setGithubNotice(null)}
                     >
-                      Settings
+                      Organization settings
                     </Link>
                   ) : (
                     <button
@@ -1071,7 +1071,7 @@ function UserMenu({
             </Link>
             <Link href={orgPath('/settings')} className="usermenu-item no-underline" onClick={() => setOpen(false)}>
               <Icon name="settings" size={15} color="var(--text-tertiary)" />
-              Settings
+              Organization settings
             </Link>
             <button className="usermenu-item" onClick={onSignOut}>
               <Icon name="log-out" size={15} color="var(--text-tertiary)" />

--- a/packages/web/src/components/console/nav.ts
+++ b/packages/web/src/components/console/nav.ts
@@ -51,8 +51,8 @@ export const MOBILE_NAV: NavItem[] = [
 ]
 
 // The "More" sheet's destinations — the desktop rail items beyond the 4 primary
-// tabs, plus Settings. Profile is NOT here: it lives in the mobile app bar as a
-// top-right avatar (mirroring the desktop top bar). The org switcher is
+// tabs, plus the org's settings. Profile is NOT here: it lives in the mobile app
+// bar as a top-right avatar (mirroring the desktop top bar). The org switcher is
 // prepended separately, in the sheet itself.
 export const MORE_ROWS: NavItem[] = [
   { href: '/tools', label: 'Tools & Skills', icon: 'blocks' },
@@ -61,7 +61,7 @@ export const MORE_ROWS: NavItem[] = [
   { href: '/daemons', label: 'Infra', icon: 'server' },
   { href: '/usage', label: 'Analytics', icon: 'circle-gauge' },
   { href: '/billing', label: 'Billing', icon: 'credit-card', requires: 'billing' },
-  { href: '/settings', label: 'Settings', icon: 'settings' }
+  { href: '/settings', label: 'Organization settings', icon: 'settings' }
 ]
 
 // Section label for the mobile app bar, matched by path prefix. (Desktop has no

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -10,6 +10,7 @@ import {
   agentLabel,
   agentModelDisplay,
   agentPermissionDisplay,
+  agentPlacementIcon,
   effectiveAgentStatus,
   effortField,
   enrichSessionWithAgent,
@@ -586,6 +587,9 @@ export default function AgentDetailView() {
       }
     : undefined
   const daemonLabel = agentDaemonLabel(da, daemons, memberSets)
+  // The glyph says WHAT it is placed on — a machine, a group, or the pool — so the line never
+  // draws a set target as the one server that happens to answer for it.
+  const daemonIcon = agentPlacementIcon(da, memberSets)
   // Append region only when the Agent projection has a real one.
   const daemonLine = da.region && da.region !== '—' ? `${daemonLabel} · ${da.region}` : daemonLabel
   // Only a daemon in the viewer's fleet has a working detail route.
@@ -659,7 +663,7 @@ export default function AgentDetailView() {
             </span>
             {owningDaemon ? (
               <Link className="lnk font-sans text-[12.5px] font-medium leading-normal" href={daemonHref}>
-                <Icon name="server" size={14} color="var(--text-tertiary)" />
+                <Icon name={daemonIcon} size={14} color="var(--text-tertiary)" />
                 {daemonLine}
               </Link>
             ) : da.daemon === '—' ? (
@@ -681,7 +685,7 @@ export default function AgentDetailView() {
               </button>
             ) : (
               <span className="inline-flex items-center gap-[6px] font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
-                <Icon name="server" size={14} color="var(--text-tertiary)" />
+                <Icon name={daemonIcon} size={14} color="var(--text-tertiary)" />
                 {daemonLine}
               </span>
             )}
@@ -785,7 +789,7 @@ export default function AgentDetailView() {
               {modelText}
             </span>
             <span className="inline-flex items-center gap-[6px] font-mono text-[12px] font-medium leading-normal whitespace-nowrap text-(--text-secondary)">
-              <Icon name="server" size={14} color="var(--text-tertiary)" />
+              <Icon name={daemonIcon} size={14} color="var(--text-tertiary)" />
               {daemonLine}
             </span>
           </div>

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -6,6 +6,7 @@ import {
   agentDaemonLabel,
   agentLabel,
   agentModelDisplay,
+  agentPlacementIcon,
   effectiveAgentStatus,
   isGitWorkspace,
   runtimeLabel,
@@ -655,8 +656,14 @@ export default function AgentsView() {
                     </span>
                   </div>
                 ) : (
-                  <div className="mono min-w-0 truncate pr-3 text-[12px] text-(--text-primary)" title={daemonName(a)}>
-                    {daemonName(a)}
+                  <div className="flex min-w-0 items-center gap-[6px] pr-3" title={daemonName(a)}>
+                    <Icon
+                      name={agentPlacementIcon(a, memberSets)}
+                      size={13}
+                      color="var(--text-tertiary)"
+                      className="flex-none"
+                    />
+                    <span className="mono min-w-0 truncate text-[12px] text-(--text-primary)">{daemonName(a)}</span>
                   </div>
                 )}
                 {a.createdBy ? (

--- a/packages/web/src/components/console/views/HomeView.test.tsx
+++ b/packages/web/src/components/console/views/HomeView.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   agents: [] as Array<Record<string, unknown>>,
   daemons: [] as Array<Record<string, unknown>>,
+  memberSets: [] as Array<Record<string, unknown>>,
   menus: [] as Array<{ title: string; value: string; options: string[] }>,
   openPlayground: vi.fn(() => 'pg_1'),
   pgSend: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({
     agents: mocks.agents,
     daemons: mocks.daemons,
+    memberSets: mocks.memberSets,
     crons: [],
     allSessions: [],
     usage24h: null,
@@ -125,6 +127,7 @@ const render = async () => {
 
 beforeEach(() => {
   mocks.menus = []
+  mocks.memberSets = []
   mocks.openPlayground.mockClear()
   mocks.pgSend.mockClear()
   mocks.pgSetModel.mockClear()
@@ -375,5 +378,63 @@ describe('HomeView readiness gate', () => {
     mocks.daemons = [daemon()]
     await render()
     expect(mocks.menus.find((m) => m.title === 'Agent')?.value).toBe('a-pre')
+  })
+})
+
+// A pool or group agent names no member — `daemon` carries the set sentinel — so resolving its
+// daemon BY ID found nothing. Nothing reads as "no runtime reported a login problem", which is why
+// such an agent was never blocked and its real model catalog never reached the composer.
+describe('HomeView readiness through the placement', () => {
+  const onPool = (over: Record<string, unknown> = {}) =>
+    agent({ daemon: 'pool', placementKind: 'set', setId: null, placementReady: true, ...over })
+  const poolMember = (authRequired: boolean) =>
+    daemon({
+      daemonId: 'pod-a',
+      pool: true,
+      memberSetId: 'set-pool',
+      name: 'AgentConnect Cloud',
+      runtimeModels: [{ runtime: 'claude', models: ['claude-sonnet-4-5'], modelCatalog: claudeCatalog, authRequired }]
+    })
+
+  it('blocks a pool agent whose runtime needs a login, and names what it runs on', async () => {
+    mocks.agents = [onPool()]
+    mocks.daemons = [poolMember(true)]
+    await render()
+    expect(host.textContent).toContain('No AI runtime is signed in')
+    expect(host.textContent).toContain('Kubernetes cluster')
+  })
+
+  it('leaves it startable when the pool member is signed in', async () => {
+    mocks.agents = [onPool()]
+    mocks.daemons = [poolMember(false)]
+    await render()
+    expect(host.textContent).not.toContain('No AI runtime is signed in')
+  })
+
+  it('reads the pool’s own model catalog, not the static fallback', async () => {
+    mocks.agents = [onPool({ model: '' })]
+    mocks.daemons = [poolMember(false)]
+    await render()
+    expect(menu('Model')?.value).toBe('claude-sonnet-4-5')
+    expect(menu('Effort')?.value).toBe('high')
+  })
+
+  it('resolves a GROUP placement to its own member, never to a pool member', async () => {
+    mocks.agents = [onPool({ placementKind: 'set', setId: 'set-lab' })]
+    mocks.memberSets = [{ setId: 'set-lab', name: 'lab', memberDaemonIds: ['dmn-lab'], agentCount: 1 }]
+    mocks.daemons = [
+      poolMember(false),
+      daemon({
+        daemonId: 'dmn-lab',
+        memberSetId: 'set-lab',
+        name: 'lab-box',
+        runtimeModels: [
+          { runtime: 'claude', models: ['claude-sonnet-4-5'], modelCatalog: claudeCatalog, authRequired: true }
+        ]
+      })
+    ]
+    await render()
+    expect(host.textContent).toContain('No AI runtime is signed in')
+    expect(host.textContent).toContain('lab')
   })
 })

--- a/packages/web/src/components/console/views/HomeView.test.tsx
+++ b/packages/web/src/components/console/views/HomeView.test.tsx
@@ -125,9 +125,15 @@ const render = async () => {
   await act(async () => root.render(<HomeView />))
 }
 
+/** The console offers a set target's own page only where the deployment asked for that surface. */
+const setFlags = (value: string) => {
+  ;(window as unknown as { __AC_ENV?: Record<string, string> }).__AC_ENV = { FEATURE_FLAGS: value }
+}
+
 beforeEach(() => {
   mocks.menus = []
   mocks.memberSets = []
+  setFlags('daemon-pool,daemon-groups')
   mocks.openPlayground.mockClear()
   mocks.pgSend.mockClear()
   mocks.pgSetModel.mockClear()
@@ -436,5 +442,102 @@ describe('HomeView readiness through the placement', () => {
     await render()
     expect(host.textContent).toContain('No AI runtime is signed in')
     expect(host.textContent).toContain('lab')
+  })
+})
+
+// Agents, daemons and member sets are three independent reads. Readiness depends on all three, so
+// the default-agent memo has to as well — a group placement reads as the POOL until its group
+// resolves, which is exactly the window in which an auth-blocked agent looks startable.
+describe('HomeView default agent across a late member-set read', () => {
+  const catalogFor = (authRequired: boolean) => [
+    { runtime: 'claude', models: ['claude-sonnet-4-5'], modelCatalog: claudeCatalog, authRequired }
+  ]
+
+  it('re-picks the default once the group resolves the preset as auth-blocked', async () => {
+    // The preset sits on a group whose member needs a login; another agent on a machine is ready.
+    mocks.agents = [
+      agent({
+        id: 'preset',
+        name: 'agentconnect',
+        daemon: 'pool',
+        placementKind: 'set',
+        setId: 'set-lab',
+        placementReady: true
+      }),
+      agent({ id: 'ready', name: 'other', daemon: 'dmn-1' })
+    ]
+    mocks.daemons = [
+      daemon({ daemonId: 'pod-a', pool: true, memberSetId: 'set-pool', runtimeModels: catalogFor(false) }),
+      daemon({ daemonId: 'dmn-lab', memberSetId: 'set-lab', runtimeModels: catalogFor(true) }),
+      daemon({ daemonId: 'dmn-1', runtimeModels: catalogFor(false) })
+    ]
+    // Member sets have not landed: the group placement reads as the pool, whose member IS signed
+    // in, so the preset looks ready and is chosen.
+    await render()
+    expect(host.textContent).not.toContain('No AI runtime is signed in')
+
+    // The SAME mount then receives the group list — a re-render, not a remount, because a remount
+    // rebuilds the memo and would pass either way.
+    mocks.memberSets = [{ setId: 'set-lab', name: 'lab', memberDaemonIds: ['dmn-lab'], agentCount: 1 }]
+    await act(async () => root.render(<HomeView />))
+    // With the group known the preset is auth-blocked, so the default moves to the ready agent and
+    // no banner shows. While `memberSets` was not an input, the stale preset stayed selected.
+    expect(host.textContent).not.toContain('No AI runtime is signed in')
+  })
+})
+
+// Both set targets NotFound behind their own flag, while a placement made before the flag went off
+// is still NAMED here — so the banner's action must not offer a door that does not open.
+describe('HomeView blocked-banner action behind the flags', () => {
+  const blockedOnGroup = () => {
+    mocks.agents = [agent({ daemon: 'pool', placementKind: 'set', setId: 'set-lab', placementReady: true })]
+    mocks.memberSets = [{ setId: 'set-lab', name: 'lab', memberDaemonIds: ['dmn-lab'], agentCount: 1 }]
+    mocks.daemons = [
+      daemon({
+        daemonId: 'dmn-lab',
+        memberSetId: 'set-lab',
+        runtimeModels: [
+          { runtime: 'claude', models: ['claude-sonnet-4-5'], modelCatalog: claudeCatalog, authRequired: true }
+        ]
+      })
+    ]
+  }
+  const clickAction = () => {
+    const btn = [...host.querySelectorAll('button')].find((b) => b.textContent === 'Fix')
+    if (!btn) throw new Error('Fix action not rendered')
+    act(() => btn.click())
+  }
+
+  it('opens the group where the deployment offers groups', async () => {
+    blockedOnGroup()
+    await render()
+    clickAction()
+    expect(mocks.push).toHaveBeenCalledWith('/acme/daemons/groups/set-lab')
+  })
+
+  it('falls back to Infra where it does not, instead of the group NotFound', async () => {
+    setFlags('')
+    blockedOnGroup()
+    await render()
+    clickAction()
+    expect(mocks.push).toHaveBeenCalledWith('/acme/daemons')
+  })
+
+  it('falls back to Infra for a pool placement behind the pool flag', async () => {
+    setFlags('')
+    mocks.agents = [agent({ daemon: 'pool', placementKind: 'set', setId: null, placementReady: true })]
+    mocks.daemons = [
+      daemon({
+        daemonId: 'pod-a',
+        pool: true,
+        memberSetId: 'set-pool',
+        runtimeModels: [
+          { runtime: 'claude', models: ['claude-sonnet-4-5'], modelCatalog: claudeCatalog, authRequired: true }
+        ]
+      })
+    ]
+    await render()
+    clickAction()
+    expect(mocks.push).toHaveBeenCalledWith('/acme/daemons')
   })
 })

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -30,7 +30,10 @@ import { AgentIconView, ModelMark, LoadingState, LogoMark, Spinner } from '@/com
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { useProfile } from '@/lib/profile'
 import {
+  agentCapabilitySource,
+  agentDaemonLabel,
   agentLabel,
+  agentPlacementKind,
   modelLabel,
   agentModelDisplay,
   runtimeLabel,
@@ -116,7 +119,7 @@ export default function HomeView() {
   const { user } = useProfile()
   const firstName = user.name.trim().split(/\s+/)[0] ?? ''
   const { orgPath } = useOrgs()
-  const { agents, daemons, crons, allSessions, usage24h, getAgent, loading } = useConsoleData()
+  const { agents, daemons, crons, allSessions, usage24h, getAgent, loading, memberSets } = useConsoleData()
   const { openPlayground, pgSend, pgSetModel, pgSetEffort, pgSetPermissionPreset } = usePlayground()
   // Home is the default landing, so it owns the fresh-org bounce to /onboarding.
   const holdForOnboarding = useOnboardingRedirect()
@@ -128,8 +131,10 @@ export default function HomeView() {
       a,
       daemons.find((d) => d.daemonId === a.daemon)
     ) === 'online'
+  // Resolved through the PLACEMENT, not by daemon id: a pool or group agent names no member, so
+  // looking one up found nothing and every such agent read as signed in (never blocked, never fixed).
   const authRequiredFor = (a: Agent) =>
-    !!daemons.find((d) => d.daemonId === a.daemon)?.runtimeModels.find((r) => r.runtime === a.runtime)?.authRequired
+    !!agentCapabilitySource(a, daemons, memberSets)?.runtimeModels.find((r) => r.runtime === a.runtime)?.authRequired
   const agentReady = (a: Agent) => isOnline(a) && !authRequiredFor(a)
 
   // Preferred default agent: the "agentconnect" preset when it's READY, else the
@@ -222,8 +227,22 @@ export default function HomeView() {
     setWorktreeOverride(undefined)
   }, [agent?.id])
 
-  // The selected agent's owning daemon supplies the model catalog + defaults.
-  const owningDaemon = agent ? daemons.find((d) => d.daemonId === agent.daemon) : undefined
+  // What the selected agent RUNS ON supplies the model catalog + defaults — resolved through the
+  // placement, so a pool or group agent reads its set's real catalog instead of the static tables.
+  const owningDaemon = agent ? agentCapabilitySource(agent, daemons, memberSets) : undefined
+  // What to CALL it, and where to send the reader: a set is named and opened as itself, never as
+  // the member standing in for it — a pool member is a Pod that no longer exists after a roll.
+  const placementKind = agent ? agentPlacementKind(agent, memberSets) : undefined
+  const placementLabel = agent ? agentDaemonLabel(agent, daemons, memberSets) : '—'
+  const placementName = placementLabel === '—' ? '' : placementLabel
+  const placementHref =
+    placementKind === 'pool'
+      ? orgPath('/daemons/cluster')
+      : placementKind === 'group' && agent?.setId
+        ? orgPath(`/daemons/groups/${agent.setId}`)
+        : owningDaemon
+          ? orgPath(`/daemons/${owningDaemon.daemonId}`)
+          : null
   const runtimeProfile = owningDaemon?.runtimeModels.find((r) => r.runtime === agent?.runtime)
   const models = runtimeProfile?.models ?? []
   const modelCatalog = runtimeProfile?.modelCatalog ?? undefined
@@ -292,7 +311,6 @@ export default function HomeView() {
   // readiness can change mid-compose regardless of how a member was added.
   const canSend = !!agent && blocked === null && members.every(agentReady)
   const notReadyMember = members.find((m) => !agentReady(m))
-  const daemonHref = owningDaemon ? orgPath(`/daemons/${owningDaemon.daemonId}`) : null
 
   const onImageFile = async (file: File | undefined): Promise<void> => {
     if (!file || imagePreparing) return
@@ -711,7 +729,7 @@ export default function HomeView() {
               blocked === 'offline'
                 ? `${agentLabel(agent!)} is offline — can't start a session`
                 : blocked === 'auth'
-                  ? `No AI runtime is signed in on ${owningDaemon?.name ?? 'the daemon'} — can't start a session`
+                  ? `No AI runtime is signed in on ${placementName || 'the daemon'} — can't start a session`
                   : notReadyMember
                     ? !isOnline(notReadyMember)
                       ? `${agentLabel(notReadyMember)} is offline — can't start a session`
@@ -739,23 +757,23 @@ export default function HomeView() {
             ) : (
               <>
                 {'No AI runtime is signed in'}
-                {owningDaemon ? (
+                {placementName ? (
                   <>
                     {' on '}
-                    <span className="font-semibold">{owningDaemon.name}</span>
+                    <span className="font-semibold">{placementName}</span>
                   </>
                 ) : null}
                 {', so agents can’t take a session.'}
               </>
             )}
           </span>
-          {daemonHref && (
+          {placementHref && (
             <button
               type="button"
               className="flex-none font-sans text-[13px] font-semibold leading-normal text-(--text-brand) hover:underline"
-              onClick={() => router.push(daemonHref)}
+              onClick={() => router.push(placementHref)}
             >
-              {blocked === 'auth' ? 'Fix' : 'View daemon'}
+              {blocked === 'auth' ? 'Fix' : placementKind === 'daemon' ? 'View daemon' : 'View infra'}
             </button>
           )}
         </div>

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -29,6 +29,7 @@ import { Icon } from '@/components/ui'
 import { AgentIconView, ModelMark, LoadingState, LogoMark, Spinner } from '@/components/marks'
 import { clipboardImageFile, prepareWebchatImage } from '@/lib/webchat-image'
 import { useProfile } from '@/lib/profile'
+import { featureFlagEnabled, type FeatureFlagId } from '@/lib/feature-flags'
 import {
   agentCapabilitySource,
   agentDaemonLabel,
@@ -142,10 +143,13 @@ export default function HomeView() {
   // if the preset's daemon is offline/unsigned-in while another daemon serves ready
   // agents, defaulting to the preset would flash the blocked banner for a daemon the
   // user isn't even using (composer must default to something startable).
+  // `memberSets` is an input because readiness reads it: agents, daemons and member sets are
+  // independent reads, and until the last lands a group placement is deliberately read as the pool
+  // — so a group agent can look ready here and settle as auth-blocked without a recompute.
   const preferred = useMemo(() => {
     const preset = agents.find((a) => a.name === 'agentconnect')
     return preset && agentReady(preset) ? preset : (agents.find(agentReady) ?? preset ?? agents[0])
-  }, [agents, daemons])
+  }, [agents, daemons, memberSets])
   const [agentId, setAgentId] = useState<string | undefined>(undefined)
   const agent = agents.find((a) => a.id === agentId) ?? preferred
   const agentOnline = agent ? isOnline(agent) : false
@@ -235,11 +239,15 @@ export default function HomeView() {
   const placementKind = agent ? agentPlacementKind(agent, memberSets) : undefined
   const placementLabel = agent ? agentDaemonLabel(agent, daemons, memberSets) : '—'
   const placementName = placementLabel === '—' ? '' : placementLabel
+  // A set target's own page exists only where the deployment offers that surface — both return
+  // NotFound behind their flag, while a placement made before the flag went off is still named
+  // here. Send those to the Infra list rather than to a dead end.
+  const setHref = (flag: FeatureFlagId, path: string) => orgPath(featureFlagEnabled(flag) ? path : '/daemons')
   const placementHref =
     placementKind === 'pool'
-      ? orgPath('/daemons/cluster')
+      ? setHref('daemon-pool', '/daemons/cluster')
       : placementKind === 'group' && agent?.setId
-        ? orgPath(`/daemons/groups/${agent.setId}`)
+        ? setHref('daemon-groups', `/daemons/groups/${agent.setId}`)
         : owningDaemon
           ? orgPath(`/daemons/${owningDaemon.daemonId}`)
           : null

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -13,6 +13,7 @@ import {
   agentDaemonLabel,
   agentLabel,
   agentPermissionDisplay,
+  agentPlacementIcon,
   displayedEffort,
   effortLabel,
   fastModeAvailableFor,
@@ -3226,6 +3227,9 @@ export default function SessionDetailView() {
           ? focusedDaemonId.slice(0, 8)
           : focusedDaemonId
         : '')
+  // Match the glyph to what the name says: a resolved machine is a server, an unresolved
+  // placement takes its target's own icon (pool / group / daemon).
+  const focusedDaemonIcon = !focusedDaemon && focusedAgent ? agentPlacementIcon(focusedAgent, memberSets) : 'server'
   // A cron-triggered session carries `user === "cron:<scheduleId>"`. When that's the
   // shown participant, render the chip as a link back to the owning schedule
   // (name-first once the crons list resolves it; the raw `cron:<id>` still links if
@@ -3403,7 +3407,7 @@ export default function SessionDetailView() {
     { icon: 'circle-dollar-sign', label: 'Cost', value: focusedSession?.cost ?? '—' },
     { icon: 'wrench', label: 'Tool calls', value: String(displayToolCount) }
   ]
-  if (focusedDaemonName) headerFacts.push({ icon: 'server', label: 'Daemon', value: focusedDaemonName })
+  if (focusedDaemonName) headerFacts.push({ icon: focusedDaemonIcon, label: 'Daemon', value: focusedDaemonName })
   if (focusedAgentRuntime)
     headerFacts.push({
       icon: 'cpu',

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -147,6 +147,39 @@ export function agentDaemonLabel(
   return daemons.find((daemon) => daemon.daemonId === agent.daemon)?.name ?? agent.daemonName ?? '—'
 }
 
+/** What a placement TARGET is, as the console draws it: the install-wide pool, one of the org's
+ *  own groups, or a single machine. Same three cases `agentDaemonLabel` names. */
+export type PlacementIconKind = 'pool' | 'group' | 'daemon'
+
+/** The pool's own glyph — the product's cloud on a managed install, a cluster everywhere else,
+ *  matching how the pool draws itself on the Infra list and its detail page. */
+export function poolIcon(): string {
+  return featureFlagEnabled('managed') ? 'cloud' : 'boxes'
+}
+
+/** The ONE icon language for placements, so the picker, the list and every header agree. */
+export function placementIcon(kind: PlacementIconKind): string {
+  return kind === 'pool' ? poolIcon() : kind === 'group' ? 'layers' : 'server'
+}
+
+/** Which of the three a given agent is placed on — the icon half of `agentDaemonLabel`, resolved
+ *  from the same pair, so a row's glyph can never disagree with the name beside it. */
+export function agentPlacementKind(
+  agent: Pick<Agent, 'placementKind' | 'setId'>,
+  groups: readonly Pick<MemberSetRow, 'setId'>[]
+): PlacementIconKind {
+  if (!isSetPlacementKind(agent.placementKind)) return 'daemon'
+  return agent.setId && groups.some((candidate) => candidate.setId === agent.setId) ? 'group' : 'pool'
+}
+
+/** The glyph for an agent's placement. */
+export function agentPlacementIcon(
+  agent: Pick<Agent, 'placementKind' | 'setId'>,
+  groups: readonly Pick<MemberSetRow, 'setId'>[]
+): string {
+  return placementIcon(agentPlacementKind(agent, groups))
+}
+
 /**
  * One of the organization's own member sets, as the console holds it (daemon-groups.md §2).
  *

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -180,6 +180,24 @@ export function agentPlacementIcon(
   return placementIcon(agentPlacementKind(agent, groups))
 }
 
+/** The daemon whose REPORTED capabilities describe an agent's placement — runtimes, model catalog,
+ *  and whether that runtime is signed in. A set target resolves to one SERVING member standing in
+ *  for the set (the rule `editAgentCapabilitySource` already uses), never to the placement:
+ *  `POOL_PLACEMENT` matches no daemon id, and the `undefined` that yields reads as "nothing to
+ *  report" rather than "not known" — which is what let a pool agent needing a login look ready. */
+export function agentCapabilitySource<T extends Pick<DaemonRow, 'daemonId' | 'pool' | 'memberSetId' | 'status'>>(
+  agent: Pick<Agent, 'daemon' | 'placementKind' | 'setId'>,
+  daemons: readonly T[],
+  groups: readonly Pick<MemberSetRow, 'setId'>[]
+): T | undefined {
+  const kind = agentPlacementKind(agent, groups)
+  if (kind === 'daemon') return daemons.find((daemon) => daemon.daemonId === agent.daemon)
+  const members = daemons.filter((daemon) =>
+    kind === 'pool' ? daemon.pool : !daemon.pool && daemon.memberSetId === agent.setId
+  )
+  return members.find((daemon) => daemon.status === 'online') ?? members[0]
+}
+
 /**
  * One of the organization's own member sets, as the console holds it (daemon-groups.md §2).
  *

--- a/packages/web/src/lib/placement-value.test.ts
+++ b/packages/web/src/lib/placement-value.test.ts
@@ -4,6 +4,7 @@ import {
   CLUSTER_LABEL,
   POOL_LABEL,
   POOL_PLACEMENT,
+  agentCapabilitySource,
   agentDaemonLabel,
   agentPlacementIcon,
   agentPlacementKind,
@@ -187,5 +188,46 @@ describe('agentPlacementKind / agentPlacementIcon', () => {
   it('draws a group as a stack and a machine as a server', () => {
     expect(agentPlacementIcon({ placementKind: 'set', setId: 'set-lab' }, groups)).toBe('layers')
     expect(agentPlacementIcon({ placementKind: 'daemon', setId: null }, groups)).toBe('server')
+  })
+})
+
+// A set placement names no member, so resolving it BY DAEMON ID answers `undefined` — which every
+// caller reads as "nothing reported" rather than "not known". That is how a pool agent whose
+// runtime needs a login kept looking ready on Home.
+describe('agentCapabilitySource', () => {
+  const source = (over: Partial<DaemonRow>): DaemonRow =>
+    ({ daemonId: 'd', pool: false, memberSetId: null, status: 'online', ...over }) as DaemonRow
+  const groups = [{ setId: 'set-lab' }]
+  const fleet = [
+    source({ daemonId: 'pod-down', pool: true, memberSetId: 'set-pool', status: 'offline' }),
+    source({ daemonId: 'pod-up', pool: true, memberSetId: 'set-pool' }),
+    source({ daemonId: 'dmn-1' }),
+    source({ daemonId: 'lab-down', memberSetId: 'set-lab', status: 'offline' }),
+    source({ daemonId: 'lab-up', memberSetId: 'set-lab' })
+  ]
+
+  it('resolves a machine placement to that machine', () => {
+    expect(agentCapabilitySource({ daemon: 'dmn-1', placementKind: 'daemon' }, fleet, groups)?.daemonId).toBe('dmn-1')
+    expect(agentCapabilitySource({ daemon: 'gone', placementKind: 'daemon' }, fleet, groups)).toBeUndefined()
+  })
+
+  it('resolves the pool and a group to a SERVING member, never to the placement', () => {
+    const pool = { daemon: POOL_PLACEMENT, placementKind: 'set' as const, setId: 'set-pool' }
+    expect(agentCapabilitySource(pool, fleet, groups)?.daemonId).toBe('pod-up')
+    const group = { daemon: POOL_PLACEMENT, placementKind: 'set' as const, setId: 'set-lab' }
+    expect(agentCapabilitySource(group, fleet, groups)?.daemonId).toBe('lab-up')
+  })
+
+  it('falls back to an offline member rather than to nothing — a stale catalog still reports', () => {
+    const offlinePool = [fleet[0]!]
+    const pool = { daemon: POOL_PLACEMENT, placementKind: 'set' as const, setId: 'set-pool' }
+    expect(agentCapabilitySource(pool, offlinePool, groups)?.daemonId).toBe('pod-down')
+  })
+
+  it('never hands a group placement a pool member, nor the pool a group member', () => {
+    const group = { daemon: POOL_PLACEMENT, placementKind: 'set' as const, setId: 'set-lab' }
+    expect(agentCapabilitySource(group, [fleet[1]!], groups)).toBeUndefined()
+    const pool = { daemon: POOL_PLACEMENT, placementKind: 'set' as const, setId: 'set-pool' }
+    expect(agentCapabilitySource(pool, [fleet[4]!], groups)).toBeUndefined()
   })
 })

--- a/packages/web/src/lib/placement-value.test.ts
+++ b/packages/web/src/lib/placement-value.test.ts
@@ -5,6 +5,8 @@ import {
   POOL_LABEL,
   POOL_PLACEMENT,
   agentDaemonLabel,
+  agentPlacementIcon,
+  agentPlacementKind,
   effectiveAgentStatus,
   agentIsPlaced,
   groupPlacementValue,
@@ -152,5 +154,38 @@ describe('what the console calls the pool', () => {
     process.env.FEATURE_FLAGS = 'managed'
     expect(poolLabel()).toBe(POOL_LABEL)
     expect(agentDaemonLabel(pool, [], [])).toBe(POOL_LABEL)
+  })
+})
+
+// The glyph beside a placement is derived from the same pair as its name, so a row can never draw
+// a group or the pool as the one machine that happens to answer for it.
+describe('agentPlacementKind / agentPlacementIcon', () => {
+  const groups = [{ setId: 'set-lab' }]
+
+  afterEach(() => {
+    delete process.env.FEATURE_FLAGS
+  })
+
+  it('tells a machine, one of the org’s groups, and the pool apart', () => {
+    expect(agentPlacementKind({ placementKind: 'daemon', setId: null }, groups)).toBe('daemon')
+    expect(agentPlacementKind({ placementKind: 'set', setId: 'set-lab' }, groups)).toBe('group')
+    expect(agentPlacementKind({ placementKind: 'set', setId: 'set-pool' }, groups)).toBe('pool')
+    expect(agentPlacementKind({ placementKind: 'pool', setId: null }, groups)).toBe('pool')
+  })
+
+  it('reads a group as the pool while the group list is still loading — same as the label does', () => {
+    expect(agentPlacementKind({ placementKind: 'set', setId: 'set-lab' }, [])).toBe('pool')
+  })
+
+  it('draws the pool as this deployment’s own infrastructure', () => {
+    const pool = { placementKind: 'set' as const, setId: 'set-pool' }
+    expect(agentPlacementIcon(pool, groups)).toBe('boxes')
+    process.env.FEATURE_FLAGS = 'managed'
+    expect(agentPlacementIcon(pool, groups)).toBe('cloud')
+  })
+
+  it('draws a group as a stack and a machine as a server', () => {
+    expect(agentPlacementIcon({ placementKind: 'set', setId: 'set-lab' }, groups)).toBe('layers')
+    expect(agentPlacementIcon({ placementKind: 'daemon', setId: null }, groups)).toBe('server')
   })
 })


### PR DESCRIPTION
Several small console tweaks that turned out to share one theme: saying **which thing you are looking at**. Two of them are behaviour bugs, not cosmetics.

## 1. "Settings" is the organization's

Renamed at every entry point landing on the org-scoped `/settings`: the rail account menu, the top-bar user menu, the mobile More sheet, the GitHub-install notice link, and the page title. Sitting directly beside **Profile**, the old label read as a personal setting.

The mobile app-bar section header deliberately keeps the short "Settings" — the title strip has 120px and "Organization settings" needs 164px, so it would render as `Organization se…`.

## 2. One icon language for placements

`agentPlacementIcon()` derives the glyph from the *same* `placementKind`/`setId` pair `agentDaemonLabel` derives the name from, so a row's icon can never disagree with the text beside it:

| placed on | glyph |
| --- | --- |
| a machine | `server` |
| one of the org's groups | `layers` |
| the pool | `cloud` (managed) / `boxes` (self-hosted) |

- The Agents list's **Runs on** cell gains that indicator.
- The agent-detail header and the session **Details** popover were hardcoded to `server`, so the pool and every group were drawn as the one machine that happens to answer for them.
- The placement picker had drifted independently — it always showed `cloud` for the pool, even on an install that calls it "Kubernetes cluster" everywhere else. It now goes through the same helper.

## 3. A set placement resolved by daemon id — two real bugs

An agent on the pool or a group **names no member**: `Agent.daemon` carries the set sentinel. So `daemons.find(d => d.daemonId === a.daemon)` answered `undefined`, and two surfaces read that as *"nothing to report"* rather than *"not known"*.

New `agentCapabilitySource()` resolves a set to one **serving** member standing in for it — the rule `editAgentCapabilitySource` already used for the Edit form — falling back to an offline member rather than to nothing.

**Home** (`authRequiredFor`) therefore never fired for such an agent. The composer would default to one whose runtime is not signed in, send, and fail, with no blocked banner and no Fix link. The same lookup fed the model catalog, so the run selectors fell back to the static tables instead of the set's real models. The banner now names and links the placement itself — `/daemons/cluster`, or the group's own page — never the Pod standing in for it, which a roll replaces.

**Search** matched the raw daemon list, which is worse than "can't find the pool": every pool Pod is in that list under the pool's shared display name, so a 3-replica pool returned three identical "AgentConnect Cloud" rows, each opening a different Pod page. Groups were not indexed at all. The Daemons results are now the Infra page's own three entities in its own order — pool as one entry, machines, then groups — each with its placement glyph and each gated on the same flags the Infra page uses. Agent results also name what they run on through the shared projection.

## Reviewer notes

- The two behaviour fixes have regression coverage that I verified actually discriminates: reverting the two HomeView lines fails 3 of the 4 new tests there.
- `GlobalSearch.test.tsx`'s `useConsoleData` mock was a fixed empty object; it is now a mutable hoisted fixture so a test can hand the box a fleet. Existing tests still see empty defaults.
- `PlacementOptionKind` in `DaemonSelect` is now an alias of the shared `PlacementIconKind` so the two cannot drift.
- Verified in the mock console: pool renders `cloud` + "AgentConnect Cloud" under `managed` and `boxes` + "Kubernetes cluster" without it; machines render `server`.

`pnpm typecheck`, `lint`, `format:check` clean; 2040 web tests pass.
