### PR TITLE
docs(readme): give Why two subsections, use cases and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,16 +106,15 @@ Teams use it to:
 
 ### Features
 
-- **Work as one team.** Create agents with different roles and let them call on
-  one another, while people follow along in the conversations where the work
-  happens.
+- **Work as one team, on any runtime.** Create agents with different roles and
+  let them call on one another, while people follow along in the conversations
+  where the work happens. Claude Code, Codex, Grok Build, DeepSeek, Pi, and any
+  other ACP-compatible runtime run side by side, and changing one does not
+  rebuild the workflow around it.
 - **Keep work where it happens.** Link agents to bots in Slack, Telegram,
   Discord, and Lark, or to repositories and workflows on GitHub and GitLab.
 - **Choose the right agent for every job.** Configure each agent's runtime,
   model, workspace, tools, and machine independently.
-- **Stay provider-neutral.** Claude Code, Codex, Grok Build, DeepSeek, Pi, and
-  any other ACP-compatible runtime run side by side, and changing an agent's
-  runtime does not rebuild the workflow around it.
 - **Carry context forward.** Give each agent its own memory and skills, and
   publish reviewed
   [Knowledge](https://docs.agentconnect.md/docs/knowledge) that every agent can

--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ can't see what an agent is doing, can't take over a session, can't review its
 output, and the context it builds stays on one laptop. So every team writes the
 same glue: message channels, cron jobs, credential handling, context stitching.
 
-AgentConnect turns that glue into a platform. Teams use it to:
+AgentConnect turns that glue into a platform.
+
+### Use cases
+
+Teams use it to:
 
 - **Triage issues together.** People and agents investigate in one shared
   thread, bring in the right specialists, and keep the fix and verification
@@ -100,12 +104,23 @@ AgentConnect turns that glue into a platform. Teams use it to:
   them. Each reviewer can use its own model, instructions, repository access,
   tools, and sandbox policy.
 
-Behind these workflows, every agent gets the model, workspace, memory, MCP
-servers, skills, repository access, and sandbox policy its role requires, and
-permissions separate who may use an agent, who may see its sessions, and which
-repositories, tools, and other agents it may reach. Agents remember what they
-learn as they go. And the Apache-2.0 stack is yours to self-host, with agent
-execution and workspaces staying in the environment you operate.
+### Features
+
+- **Any ACP agent.** Claude Code, Codex, Grok Build, DeepSeek, Pi, and other
+  ACP-compatible runtimes, side by side and chosen per agent.
+- **Wherever work happens.** Slack, Telegram, Discord, and Lark; GitHub and
+  GitLab events; webhooks, schedules, and webchat.
+- **Agents that call one another.** Give each agent a role and let it bring in
+  the specialist a turn needs, while people follow in the same thread.
+- **Configured per role.** Model, workspace, memory, MCP servers, skills,
+  repository access, and sandbox policy, set for each agent independently.
+- **Memory that carries forward.** Agents remember what they learn across
+  sessions and channels instead of starting cold every time.
+- **Boundaries that stay separate.** Who may use an agent, who may see its
+  sessions, and which repositories, tools, and other agents it may reach are
+  three different decisions.
+- **Yours to self-host.** The Apache-2.0 stack runs in your environment, and
+  agent execution and workspaces stay there.
 
 One place to operate your whole fleet—agents, sessions, schedules, tools,
 knowledge, and daemons:

--- a/README.md
+++ b/README.md
@@ -106,21 +106,21 @@ Teams use it to:
 
 ### Features
 
-- **Any ACP agent.** Claude Code, Codex, Grok Build, DeepSeek, Pi, and other
-  ACP-compatible runtimes, side by side and chosen per agent.
-- **Wherever work happens.** Slack, Telegram, Discord, and Lark; GitHub and
-  GitLab events; webhooks, schedules, and webchat.
-- **Agents that call one another.** Give each agent a role and let it bring in
-  the specialist a turn needs, while people follow in the same thread.
-- **Configured per role.** Model, workspace, memory, MCP servers, skills,
-  repository access, and sandbox policy, set for each agent independently.
-- **Memory that carries forward.** Agents remember what they learn across
-  sessions and channels instead of starting cold every time.
-- **Boundaries that stay separate.** Who may use an agent, who may see its
-  sessions, and which repositories, tools, and other agents it may reach are
-  three different decisions.
-- **Yours to self-host.** The Apache-2.0 stack runs in your environment, and
-  agent execution and workspaces stay there.
+- **Work as one team.** Create agents with different roles and let them call on
+  one another, while people follow along in the conversations where the work
+  happens.
+- **Keep work where it happens.** Link agents to bots in Slack, Telegram,
+  Discord, and Lark, or to repositories and workflows on GitHub and GitLab.
+- **Choose the right agent for every job.** Configure each agent's runtime,
+  model, workspace, tools, and machine independently.
+- **Carry context forward.** Give each agent its own memory and skills, and
+  publish reviewed
+  [Knowledge](https://docs.agentconnect.md/docs/knowledge) that every agent can
+  find on demand.
+- **Set clear boundaries.** Decide who can see each agent and session, which
+  repositories and tools it may use, and which other agents it may call.
+- **Stay in control.** Self-host the Apache-2.0 stack, run agents in your
+  environment, and change runtimes without locking the team to one vendor.
 
 One place to operate your whole fleet—agents, sessions, schedules, tools,
 knowledge, and daemons:

--- a/README.md
+++ b/README.md
@@ -113,14 +113,17 @@ Teams use it to:
   Discord, and Lark, or to repositories and workflows on GitHub and GitLab.
 - **Choose the right agent for every job.** Configure each agent's runtime,
   model, workspace, tools, and machine independently.
+- **Stay provider-neutral.** Claude Code, Codex, Grok Build, DeepSeek, Pi, and
+  any other ACP-compatible runtime run side by side, and changing an agent's
+  runtime does not rebuild the workflow around it.
 - **Carry context forward.** Give each agent its own memory and skills, and
   publish reviewed
   [Knowledge](https://docs.agentconnect.md/docs/knowledge) that every agent can
   find on demand.
 - **Set clear boundaries.** Decide who can see each agent and session, which
   repositories and tools it may use, and which other agents it may call.
-- **Stay in control.** Self-host the Apache-2.0 stack, run agents in your
-  environment, and change runtimes without locking the team to one vendor.
+- **Stay in control.** Self-host the Apache-2.0 stack and keep agent execution
+  and workspaces in the environment you operate.
 
 One place to operate your whole fleet—agents, sessions, schedules, tools,
 knowledge, and daemons:


### PR DESCRIPTION
## Summary

"Why AgentConnect?" now has two subsections instead of a list followed by a dense paragraph:

- **Use cases** — the five workflows, unchanged.
- **Features** — the same six bullets the [docs introduction](https://docs.agentconnect.md/docs/getting-started) uses, in the same words: work as one team, keep work where it happens, choose the right agent for every job, carry context forward, set clear boundaries, stay in control. This replaces the "Behind these workflows…" paragraph, which packed the same material into five lines of prose nobody skims, and it keeps the README and the docs from describing the platform two different ways.

Use cases stay first: the section builds from the shared-glue problem to "AgentConnect turns that glue into a platform", and concrete workflows before the capability list is the order our messaging guidance asks for. Easy to flip if you'd rather lead with features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
