### PR TITLE
feat(console): tick passed getting-started steps, gate the tutorial to owners

### DIFF
--- a/docs/designs/preset-agents.md
+++ b/docs/designs/preset-agents.md
@@ -375,8 +375,12 @@ view — non-blocking, dismissible, reopenable from Help.
 
 ### 6.2 Derived state, not stored ticks
 
-Every item derives from live resources; nothing stores "step done". The only persisted
-bit is a per-user dismissal.
+Every item derives from live resources; nothing stores a per-item "step done". What
+does persist: a per-device dismissal, and the tutorial's current position
+(`org.gettingStartedStep`, owner-only PATCH, clamped monotonic) — steps behind the
+position display as ticked (passed via signal OR Next-skipped) while the derivation
+below stays the ground truth. The checklist and its re-entry menu items render for
+the org owner only, matching the onboarding wizard.
 
 | Item                          | Derivation                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/web/src/components/console/GettingStarted.tsx
+++ b/packages/web/src/components/console/GettingStarted.tsx
@@ -83,8 +83,7 @@ export default function GettingStarted() {
   // Per-org client state, KEYED by org id at render time: an effect-only reset would
   // leave one commit where a cached org switch still renders — and auto-advances /
   // persists — with the previous org's values. `saReviewed` mirrors this org's
-  // localStorage flag; `localFloor` covers the window before the PATCHed org list
-  // refreshes, and non-owners whose PATCH the CP refuses (session-local progress).
+  // localStorage flag; `localFloor` covers the window before the PATCHed org list refreshes.
   const orgId = activeOrg?.id ?? null
   const [saReviewed, setSaReviewed] = useState<{ orgId: string | null; on: boolean }>({ orgId: null, on: false })
   const [localFloor, setLocalFloor] = useState<{ orgId: string | null; step: number }>({ orgId: null, step: 0 })
@@ -188,11 +187,14 @@ export default function GettingStarted() {
   // /onboarding wizard is a separate route (AgentsView redirects an empty org there);
   // the pill only steps aside for that route, not for the empty-org state itself.
   const onOnboardingRoute = pathname?.includes('/onboarding')
+  // Owner-only, like the onboarding wizard: setting an org up is the owner's job, and
+  // the step-position persistence (PATCH /orgs) is owner-gated anyway.
+  const isOwner = activeOrg?.role === 'owner'
   // Gate on the aggregate `loading`, not just agents+daemons: the checklist reads
   // integrations, sessions and members too, so a partial first paint showed the pill
   // with a too-low count that then jumped (and could even flash for an org that is
   // already allDone). One transition, once everything has landed.
-  if (loading || onOnboardingRoute) return null
+  if (loading || onOnboardingRoute || !isOwner) return null
   // The pill is the passive nudge — it hides once the tutorial is over (all steps
   // passed or every signal done) or the user skipped the whole thing.
   const showPill = !gs.allDone && !skipped && !finished
@@ -308,6 +310,9 @@ export default function GettingStarted() {
             <div className="flex-1 overflow-auto">
               {gs.items.map((it, i) => {
                 const isCurrent = i === currentIndex
+                // A step behind the position was passed (live signal OR Next) — show it
+                // ticked; the body/CTA below stay on the honest `it.done`.
+                const passed = it.done || i < step
                 const open = isCurrent || expanded === it.key
                 return (
                   <div
@@ -319,19 +324,19 @@ export default function GettingStarted() {
                   >
                     <span
                       className={`mt-[1px] flex h-[18px] w-[18px] flex-none items-center justify-center rounded-full ${
-                        it.done
+                        passed
                           ? 'bg-(--brand) text-white'
                           : isCurrent
                             ? 'border-[1.5px] border-(--brand)'
                             : 'border-[1.5px] border-(--border-strong)'
                       }`}
                     >
-                      {it.done && <Icon name="check" size={12} />}
+                      {passed && <Icon name="check" size={12} />}
                     </span>
                     <div className="min-w-0 flex-1">
                       <span
                         className={`font-sans text-[13.5px] leading-normal ${
-                          it.done
+                          passed
                             ? 'font-normal text-(--text-tertiary) line-through'
                             : 'font-medium text-(--text-primary)'
                         }`}

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -761,17 +761,20 @@ function ShellChromeInner({ children }: { children: ReactNode }) {
                       <div className="fixed inset-0 z-45" onClick={() => setHelpMenu(false)} />
                       <div className="absolute bottom-[calc(100%_+_8px)] left-0 z-50 w-[236px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-[5px] shadow-(--shadow-lg)">
                         {/* The desktop way back to a skipped checklist, both auth modes — the
-                          pill has no other desktop re-entry point. */}
-                        <button
-                          className="dmi"
-                          onClick={() => {
-                            setHelpMenu(false)
-                            openGettingStarted()
-                          }}
-                        >
-                          <Icon name="rocket" size={15} color="var(--text-tertiary)" />
-                          Getting started
-                        </button>
+                          pill has no other desktop re-entry point. Owner-only, like the
+                          checklist itself. */}
+                        {activeOrg?.role === 'owner' && (
+                          <button
+                            className="dmi"
+                            onClick={() => {
+                              setHelpMenu(false)
+                              openGettingStarted()
+                            }}
+                          >
+                            <Icon name="rocket" size={15} color="var(--text-tertiary)" />
+                            Getting started
+                          </button>
+                        )}
                         <button
                           className="dmi"
                           onClick={() => {
@@ -1198,18 +1201,21 @@ function MobileSheets({
               </Link>
             ))}
             {/* The rail (and both of its re-entry menus) is hidden at mobile widths, so
-                this is the phone/tablet way back to a skipped checklist — both auth modes. */}
-            <button
-              type="button"
-              className="msheet-row"
-              onClick={() => {
-                onClose()
-                openGettingStarted()
-              }}
-            >
-              <Icon name="rocket" size={20} color="var(--text-tertiary)" />
-              <span>Getting started</span>
-            </button>
+                this is the phone/tablet way back to a skipped checklist — both auth modes.
+                Owner-only, like the checklist itself. */}
+            {activeOrg?.role === 'owner' && (
+              <button
+                type="button"
+                className="msheet-row"
+                onClick={() => {
+                  onClose()
+                  openGettingStarted()
+                }}
+              >
+                <Icon name="rocket" size={20} color="var(--text-tertiary)" />
+                <span>Getting started</span>
+              </button>
+            )}
             <button type="button" className="msheet-cancel" onClick={onClose}>
               Cancel
             </button>


### PR DESCRIPTION
## What changed

Rebuilt on top of #1518's tutorial-style drawer (this PR originally carried a parallel `gsClickedSteps` implementation written before #1518 landed; that work is dropped — the tutorial's persisted `org.gettingStartedStep` already covers persistence).

**Passed steps display as done.** Steps behind the tutorial position now render ticked (brand check + line-through) — whether they were passed by their live signal or skipped with the footer's **Next**. Previously a Next-skipped step kept rendering as incomplete, which read as broken. Row bodies and CTAs stay on the honest live-derived state, so a skipped-but-unconfigured step still offers its CTA when expanded (and the Slack body never claims "Connected" falsely).

**Owner-only surface.** The checklist (pill + drawer) and both of its re-entry menu items (desktop help menu, mobile sheet) render only for the org owner — matching the onboarding wizard's gate and the owner-only step-position PATCH.

Also amends preset-agents.md §6.2, which still said "nothing stores step done" — it now records the `gettingStartedStep` persistence (#1518), the passed-step display, and the owner-only gate.

## Notes for review

- Display-only change on the web side; no CP/API/schema changes.
- `passed = it.done || i < step` is computed per row; progress ring/counter were already position-based.
- Web suite: 2044 tests green; typecheck/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)