### PR TITLE
feat(relay): accept a GitHub team mention as the targeted agent handle

### DIFF
--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -249,11 +249,21 @@ comment may match a shared `issue_comment` subscription or an explicit
 
 With `mentionOnly` enabled, authored event text must contain either:
 
-- `@<agent-name>` to select one agent; or
+- `@<agent-name>` to select one agent;
+- `@<owner>/<agent-name>` to select that same agent as a GitHub team mention; or
 - `@<app-slug>` to broadcast to all matching hooks in the repository.
 
 The App handle wins when both forms are present. Unrelated mentions do not
 change the candidate set.
+
+The team form exists for discoverability. GitHub's comment composer
+autocompletes organization teams but never a bare agent slug, so an organization
+that creates a visible team named after the agent gets the targeted handle
+suggested as a reporter types. Nothing else changes: the owner comes from the
+delivery's own repository, matching stays pure text against the authored body,
+the team is never read back through the API and needs no members, and a
+same-named team in any other organization selects nobody. Because `@<owner>/<slug>`
+is GitHub's team syntax, it is never also read as a bare mention of `<owner>`.
 
 Every numbered-thread event passes a live, body-free permission decision owned
 by the CP. Webhook `author_association` values are descriptive only: `MEMBER`
@@ -692,6 +702,9 @@ The implementation does not provide:
 - daemon polling as an alternative public ingress;
 - queueing arbitrary generic deliveries while a daemon is offline;
 - automatic replay of ambiguous dispatches;
+- creating, renaming, or deleting the GitHub teams that back the team-mention
+  form — an organization owns those, and the App requests no organization
+  permissions;
 - required GitHub review gates;
 - commit-status reporting; or
 - per-organization custom GitHub Apps or GitHub Enterprise Server support.

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -250,7 +250,8 @@ comment may match a shared `issue_comment` subscription or an explicit
 With `mentionOnly` enabled, authored event text must contain either:
 
 - `@<agent-name>` to select one agent;
-- `@<owner>/<agent-name>` to select that same agent as a GitHub team mention; or
+- `@<owner>/<agent-name>` to select that same agent as a GitHub team mention, on
+  an organization-owned repository; or
 - `@<app-slug>` to broadcast to all matching hooks in the repository.
 
 The App handle wins when both forms are present. Unrelated mentions do not
@@ -264,6 +265,11 @@ delivery's own repository, matching stays pure text against the authored body,
 the team is never read back through the API and needs no members, and a
 same-named team in any other organization selects nobody. Because `@<owner>/<slug>`
 is GitHub's team syntax, it is never also read as a bare mention of `<owner>`.
+
+The form is gated on the signed `repository.owner.type`. A personal account has
+no teams, so `@<owner>/<agent-name>` selects nobody there and neither summons an
+agent nor requests a review; a payload that does not carry the owner kind fails
+to the same inert state. The bare handle is unaffected either way.
 
 Every numbered-thread event passes a live, body-free permission decision owned
 by the CP. Webhook `author_association` values are descriptive only: `MEMBER`

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -952,13 +952,14 @@ separate, stricter gate: it asks the console user for `write` or `admin` and nev
 ## GitHub review mention routing
 
 An explicit `@<agent-name>` in GitHub targets only that AgentConnect agent's
-matching review integration. `@<owner>/<agent-name>` is the same targeted form
-written as a GitHub team mention: an organization that creates a visible team
-named after the agent gets that handle autocompleted in GitHub's comment
-composer, and the team needs no members because matching only reads the authored
-text and the repository's own owner. A same-named team in a different
-organization targets nobody, and AgentConnect never creates, renames, or deletes
-these teams. An explicit `@<github-app-name>` is the broadcast
+matching review integration. On an organization-owned repository,
+`@<owner>/<agent-name>` is the same targeted form written as a GitHub team
+mention: an organization that creates a visible team named after the agent gets
+that handle autocompleted in GitHub's comment composer, and the team needs no
+members because matching only reads the authored text and the repository's own
+owner. A same-named team in a different organization targets nobody, a personal
+repository has no teams and so ignores the form entirely, and AgentConnect never
+creates, renames, or deletes these teams. An explicit `@<github-app-name>` is the broadcast
 form and targets every matching review agent for the repository. When both forms
 are present, broadcast wins; mentioning an unrelated GitHub user does not change
 the configured review cadence.

--- a/docs/product-conventions.md
+++ b/docs/product-conventions.md
@@ -952,7 +952,13 @@ separate, stricter gate: it asks the console user for `write` or `admin` and nev
 ## GitHub review mention routing
 
 An explicit `@<agent-name>` in GitHub targets only that AgentConnect agent's
-matching review integration. An explicit `@<github-app-name>` is the broadcast
+matching review integration. `@<owner>/<agent-name>` is the same targeted form
+written as a GitHub team mention: an organization that creates a visible team
+named after the agent gets that handle autocompleted in GitHub's comment
+composer, and the team needs no members because matching only reads the authored
+text and the repository's own owner. A same-named team in a different
+organization targets nobody, and AgentConnect never creates, renames, or deletes
+these teams. An explicit `@<github-app-name>` is the broadcast
 form and targets every matching review agent for the repository. When both forms
 are present, broadcast wins; mentioning an unrelated GitHub user does not change
 the configured review cadence.

--- a/packages/relay/src/hooks/github-ingress.test.ts
+++ b/packages/relay/src/hooks/github-ingress.test.ts
@@ -2062,6 +2062,36 @@ describe('github ingress', () => {
       expect(h.sent.map((msg) => msg.agentId)).toEqual([AGENT, AGENT, AGENT_B])
     })
 
+    it('a team mention narrows the fan-out exactly like the bare agent handle', async () => {
+      const github = {
+        events: ['issue_comment:created'],
+        commentFamilies: ['pull_request' as const],
+        appSlug: 'example-review-app'
+      }
+      h.table.upsert(rule({}, { ...github, agentName: 'review-alpha' }))
+      h.table.upsert(rule({ hookId: HOOK_B, agentId: AGENT_B }, { ...github, agentName: 'review-beta' }))
+      const comment = (body: string, key: string) =>
+        post(
+          'issue_comment',
+          issuesPayload({
+            action: 'created',
+            issue: { number: 43, pull_request: { url: 'https://api.github.com/repos/acme/infra/pulls/43' } },
+            comment: { body, author_association: 'MEMBER' }
+          }),
+          { headers: { 'x-github-delivery': key } }
+        )
+
+      // The team lives in the repository's org, so `@acme/review-alpha` targets that agent alone.
+      await comment('@acme/review-alpha please take another look', 'target-team')
+      await flush()
+      expect(h.sent.map((msg) => msg.agentId)).toEqual([AGENT])
+
+      // A same-named team in a foreign org targets nobody, so the whole repo fan-out stays.
+      await comment('@other-org/review-alpha please take another look', 'foreign-team')
+      await flush()
+      expect(h.sent.map((msg) => msg.agentId)).toEqual([AGENT, AGENT, AGENT_B])
+    })
+
     it('mention mode fails closed when an older rule carries no mention handles', async () => {
       h.table.upsert(rule({}, { events: ['issue_comment:created'], mentionOnly: true }))
       await post(
@@ -2531,8 +2561,22 @@ describe('githubRuleVerdict (pure predicate)', () => {
     // Bounded on BOTH sides — emails/URLs are not mentions, and neither is a
     // longer login that merely starts with our slug.
     expect(matches(r, { ...ctx, mentionText: 'mail team@example-review-app.test' })).toBe(false)
-    expect(matches(r, { ...ctx, mentionText: 'see /apps/@example-review-app/config' })).toBe(true) // '/' is a boundary
     expect(matches(r, { ...ctx, mentionText: 'cc @example-review-apper' })).toBe(false)
+    // `@owner/slug` is GitHub's TEAM form, so it is never a bare mention of the owner.
+    expect(matches(r, { ...ctx, mentionText: 'see /apps/@example-review-app/config' })).toBe(false)
+    expect(matches(r, { ...ctx, mentionText: 'see @example-review-app/ for the app' })).toBe(true)
+  })
+
+  it('accepts the owner-qualified team form of the agent handle, scoped to the repository owner', () => {
+    const r = rule({}, { events: ['issues:*'], mentionOnly: true, agentName: 'review-alpha' })
+    const owned = { ...ctx, eventAction: 'issues:labeled', repoOwnerLogin: 'acme' }
+    expect(matches(r, { ...owned, mentionText: 'cc @acme/review-alpha' })).toBe(true)
+    expect(matches(r, { ...owned, mentionText: 'cc @Acme/Review-Alpha' })).toBe(true) // logins fold case
+    expect(matches(r, { ...owned, mentionText: 'cc @acme/review-alpha-fast' })).toBe(false) // a prefix is not the team
+    expect(matches(r, { ...owned, mentionText: 'cc @other-org/review-alpha' })).toBe(false) // another org's team
+    // The bare handle keeps working, and an unknown owner leaves only that form.
+    expect(matches(r, { ...owned, mentionText: 'cc @review-alpha' })).toBe(true)
+    expect(matches(r, { ...ctx, eventAction: 'issues:labeled', mentionText: 'cc @acme/review-alpha' })).toBe(false)
   })
 
   it.each([

--- a/packages/relay/src/hooks/github-ingress.test.ts
+++ b/packages/relay/src/hooks/github-ingress.test.ts
@@ -21,6 +21,7 @@ import { HookRateLimiter } from './rate-limit.js'
 import {
   registerGithubIngress,
   githubRuleVerdict,
+  githubTeamOwner,
   buildGithubContext,
   buildTrustedGithubMetadata,
   GITHUB_BODY_EXCERPT_MAX
@@ -87,7 +88,7 @@ function issuesPayload(overrides: Record<string, unknown> = {}): Record<string, 
   return {
     action: 'opened',
     installation: { id: INSTALLATION },
-    repository: { id: REPO_ID, full_name: 'acme/infra' },
+    repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
     sender,
     ...overrides,
     issue,
@@ -99,7 +100,7 @@ function pullPayload(overrides: Record<string, unknown> = {}): Record<string, un
   return {
     action: 'opened',
     installation: { id: INSTALLATION },
-    repository: { id: REPO_ID, full_name: 'acme/infra' },
+    repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
     sender: { login: 'alice', type: 'User' },
     pull_request: {
       number: 77,
@@ -121,7 +122,7 @@ function rerequestPayload(overrides: Record<string, unknown> = {}): Record<strin
   return {
     action: 'rerequested',
     installation: { id: INSTALLATION },
-    repository: { id: REPO_ID, full_name: 'acme/infra' },
+    repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
     sender: { login: 'alice', type: 'User' },
     check_run: {
       id: 86617583005,
@@ -142,7 +143,7 @@ function suiteRerequestPayload(overrides: Record<string, unknown> = {}): Record<
   return {
     action: 'rerequested',
     installation: { id: INSTALLATION },
-    repository: { id: REPO_ID, full_name: 'acme/infra' },
+    repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
     sender: { login: 'alice', type: 'User' },
     check_suite: {
       id: 81913432144,
@@ -157,7 +158,7 @@ function workflowRunPayload(overrides: Record<string, unknown> = {}): Record<str
   return {
     action: 'in_progress',
     installation: { id: INSTALLATION },
-    repository: { id: REPO_ID, full_name: 'acme/infra' },
+    repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
     sender: { login: 'github-actions[bot]', type: 'Bot' },
     workflow_run: {
       event: 'pull_request',
@@ -394,7 +395,7 @@ describe('github ingress', () => {
       const failed = await post('check_suite', {
         action: 'completed',
         installation: { id: INSTALLATION },
-        repository: { id: REPO_ID, full_name: 'acme/infra' },
+        repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         check_suite: { conclusion: 'failure', pull_requests: [{ number: 77 }, { number: 78 }] }
       })
       expect(failed.statusCode).toBe(202)
@@ -403,7 +404,7 @@ describe('github ingress', () => {
       await post('check_suite', {
         action: 'completed',
         installation: { id: INSTALLATION },
-        repository: { id: REPO_ID, full_name: 'acme/infra' },
+        repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         check_suite: { conclusion: 'success', pull_requests: [{ number: 77 }] }
       })
       expect(h.feedback).toHaveLength(2)
@@ -1358,7 +1359,7 @@ describe('github ingress', () => {
       const basePayload = {
         action: 'edited',
         installation: { id: INSTALLATION },
-        repository: { id: REPO_ID, full_name: 'acme/infra' },
+        repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         sender: { login: 'alice', type: 'User' },
         pull_request: {
           number: 77,
@@ -1832,7 +1833,7 @@ describe('github ingress', () => {
             : {
                 action: 'created',
                 installation: { id: INSTALLATION },
-                repository: { id: REPO_ID, full_name: 'acme/infra' },
+                repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
                 sender: { login: 'alice', type: 'User' },
                 pull_request: { number: 7, user: { login: 'alice' } },
                 comment: {
@@ -2092,6 +2093,29 @@ describe('github ingress', () => {
       expect(h.sent.map((msg) => msg.agentId)).toEqual([AGENT, AGENT, AGENT_B])
     })
 
+    it('leaves the team form inert on a personal repository, which has no teams', async () => {
+      const github = {
+        events: ['issue_comment:created'],
+        commentFamilies: ['pull_request' as const],
+        appSlug: 'example-review-app'
+      }
+      h.table.upsert(rule({}, { ...github, agentName: 'review-alpha' }))
+      h.table.upsert(rule({ hookId: HOOK_B, agentId: AGENT_B }, { ...github, agentName: 'review-beta' }))
+      const payload = issuesPayload({
+        action: 'created',
+        issue: { number: 43, pull_request: { url: 'https://api.github.com/repos/acme/infra/pulls/43' } },
+        comment: { body: '@acme/review-alpha please take another look', author_association: 'MEMBER' }
+      })
+      await post(
+        'issue_comment',
+        { ...payload, repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'User' } } },
+        { headers: { 'x-github-delivery': 'personal-owner' } }
+      )
+      await flush()
+      // `@acme/review-alpha` is not a team mention here, so it narrows nothing.
+      expect(h.sent.map((msg) => msg.agentId)).toEqual([AGENT, AGENT_B])
+    })
+
     it('mention mode fails closed when an older rule carries no mention handles', async () => {
       h.table.upsert(rule({}, { events: ['issue_comment:created'], mentionOnly: true }))
       await post(
@@ -2113,7 +2137,7 @@ describe('github ingress', () => {
           {
             action: 'created',
             installation: { id: INSTALLATION },
-            repository: { id: REPO_ID, full_name: 'acme/infra' },
+            repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
             sender: { login: 'alice', type: 'User' },
             pull_request: { number: 7, title: 'tighten backoff', user: { login: 'alice' } },
             comment: {
@@ -2158,7 +2182,7 @@ describe('github ingress', () => {
       await post('pull_request_review_comment', {
         action: 'created',
         installation: { id: INSTALLATION },
-        repository: { id: REPO_ID, full_name: 'acme/infra' },
+        repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         sender: { login: 'alice', type: 'User' },
         pull_request: { number: 7, title: 'tighten backoff', user: { login: 'alice' } },
         comment: {
@@ -2184,7 +2208,7 @@ describe('github ingress', () => {
       const reviewPayload = {
         action: 'created',
         installation: { id: INSTALLATION },
-        repository: { id: REPO_ID, full_name: 'acme/infra' },
+        repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         sender: { login: 'alice', type: 'User' },
         pull_request: { number: 7, title: 'tighten backoff', user: { login: 'alice' } },
         comment: {
@@ -2215,7 +2239,7 @@ describe('github ingress', () => {
       const reviewPayload = {
         action: 'created',
         installation: { id: INSTALLATION },
-        repository: { id: REPO_ID, full_name: 'acme/infra' },
+        repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         sender: { login: 'alice', type: 'User' },
         pull_request: { number: 7, title: 'tighten backoff', user: { login: 'alice' } },
         comment: {
@@ -2271,7 +2295,7 @@ describe('github ingress', () => {
       await post('pull_request_review_comment', {
         action: 'created',
         installation: { id: INSTALLATION },
-        repository: { id: REPO_ID, full_name: 'acme/infra' },
+        repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         sender: { login: 'alice', type: 'User' },
         pull_request: { number: 7, user: { login: 'alice' } },
         comment: { user: { login: 'alice' }, body: 'explicitly subscribed', author_association: 'MEMBER' }
@@ -2289,7 +2313,7 @@ describe('github ingress', () => {
           {
             action: 'created',
             installation: { id: INSTALLATION },
-            repository: { id: REPO_ID, full_name: 'acme/infra' },
+            repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
             sender: { login: 'alice', type: 'User' },
             pull_request: { number: 7, user: { login: 'alice' } },
             comment: { user: { login: 'alice' }, body, author_association: 'MEMBER' }
@@ -2314,7 +2338,7 @@ describe('github ingress', () => {
         compare: 'https://github.com/acme/infra/compare/abc...def',
         head_commit: { message: 'fix: tighten relay backoff' },
         installation: { id: INSTALLATION },
-        repository: { id: REPO_ID, full_name: 'acme/infra' },
+        repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         sender: { login: 'alice', type: 'User' }
       })
       expect(res.statusCode).toBe(202)
@@ -2347,7 +2371,7 @@ describe('github ingress', () => {
           head_commit: { message: 'chore: bump deps' },
           commits: [{ message: 'fix: flaky test' }, { message: 'docs: ask @example-review-app to review' }],
           installation: { id: INSTALLATION },
-          repository: { id: REPO_ID, full_name: 'acme/infra' },
+          repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
           sender: { login: 'alice', type: 'User' }
         },
         { headers: { 'x-github-delivery': 'push-m-1' } }
@@ -2361,7 +2385,7 @@ describe('github ingress', () => {
       const res = await post('push', {
         ref: 'refs/heads/main',
         installation: { id: INSTALLATION },
-        repository: { id: REPO_ID, full_name: 'acme/infra' },
+        repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         sender: { login: 'alice', type: 'User' }
       })
       expect(res.statusCode).toBe(202)
@@ -2483,7 +2507,7 @@ describe('buildTrustedGithubMetadata review comment ids', () => {
       'pull_request_review_comment',
       {
         installation: { id: INSTALLATION },
-        repository: { id: REPO_ID, full_name: 'acme/infra' },
+        repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         pull_request: { number: 7 },
         comment: {
           id,
@@ -2569,7 +2593,7 @@ describe('githubRuleVerdict (pure predicate)', () => {
 
   it('accepts the owner-qualified team form of the agent handle, scoped to the repository owner', () => {
     const r = rule({}, { events: ['issues:*'], mentionOnly: true, agentName: 'review-alpha' })
-    const owned = { ...ctx, eventAction: 'issues:labeled', repoOwnerLogin: 'acme' }
+    const owned = { ...ctx, eventAction: 'issues:labeled', teamOwnerLogin: 'acme' }
     expect(matches(r, { ...owned, mentionText: 'cc @acme/review-alpha' })).toBe(true)
     expect(matches(r, { ...owned, mentionText: 'cc @Acme/Review-Alpha' })).toBe(true) // logins fold case
     expect(matches(r, { ...owned, mentionText: 'cc @acme/review-alpha-fast' })).toBe(false) // a prefix is not the team
@@ -2577,6 +2601,15 @@ describe('githubRuleVerdict (pure predicate)', () => {
     // The bare handle keeps working, and an unknown owner leaves only that form.
     expect(matches(r, { ...owned, mentionText: 'cc @review-alpha' })).toBe(true)
     expect(matches(r, { ...ctx, eventAction: 'issues:labeled', mentionText: 'cc @acme/review-alpha' })).toBe(false)
+  })
+
+  it('yields a team owner only for an organization-owned repository', () => {
+    const org = { login: 'acme', type: 'Organization' }
+    expect(githubTeamOwner({ full_name: 'acme/infra', owner: org })).toBe('acme')
+    expect(githubTeamOwner({ full_name: 'acme/infra', owner: { login: 'acme', type: 'User' } })).toBeUndefined()
+    expect(githubTeamOwner({ full_name: 'acme/infra' })).toBeUndefined() // no signed owner kind ⇒ no team form
+    expect(githubTeamOwner(undefined)).toBeUndefined()
+    expect(githubTeamOwner({ full_name: 'acme/infra', owner: { type: 'Organization' } })).toBe('acme')
   })
 
   it.each([
@@ -2649,7 +2682,7 @@ describe('buildGithubContext', () => {
   it('pull_request deliveries source the subject from payload.pull_request', () => {
     const c = buildGithubContext('pull_request', {
       action: 'opened',
-      repository: { id: REPO_ID, full_name: 'acme/infra' },
+      repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
       sender: { login: 'alice', type: 'User', avatar_url: 'https://avatars.example.test/alice.png' },
       pull_request: { number: 7, title: 'fix', body: 'diff', html_url: 'u', author_association: 'OWNER', labels: [] }
     })
@@ -2665,7 +2698,7 @@ describe('buildGithubContext', () => {
   it('a null subject body yields no excerpt and truncated:false', () => {
     const c = buildGithubContext('issues', {
       action: 'opened',
-      repository: { id: REPO_ID, full_name: 'acme/infra' },
+      repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
       issue: { number: 1, title: 't', body: null }
     })
     expect(c.bodyExcerpt).toBeUndefined()

--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -167,6 +167,8 @@ export interface GithubMatchCtx {
   headRepoFullName?: string
   baseRepoFullName?: string
   commentAuthorLogin?: string
+  /** The repository owner login — scopes `@<owner>/<agent>` team mentions. */
+  repoOwnerLogin?: string
   mentionText: string | undefined
   /** GitHub's native reviewer request target. Only this App's `[bot]` login
    * turns `pull_request:review_requested` into a manual review request. */
@@ -206,11 +208,28 @@ export type GithubRuleVerdict = 'no-match' | 'trusted' | 'needs-authz'
 /** `@<handle>` as a whole token, case-insensitive (GitHub logins are), bounded
  *  on BOTH sides: a slug prefix must not match (`@example-review` ≠
  *  `@example-review-app`) and a word-char before the `@` must not either —
- *  GitHub never renders `team@slug.dev` as a mention. */
+ *  GitHub never renders `team@slug.dev` as a mention. A trailing `/<slug>` is
+ *  GitHub's TEAM form, so it never reads as a bare mention of the owner. */
 export function mentionsGithubHandle(body: string | undefined, handle: string | undefined): boolean {
   if (!body || !handle) return false
   const escaped = handle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return new RegExp(`(?<![\\w-])@${escaped}(?![\\w-])`, 'i').test(body)
+  return new RegExp(`(?<![\\w-])@${escaped}(?![\\w-]|/[\\w-])`, 'i').test(body)
+}
+
+/** `@<owner>/<agent-slug>` — GitHub's team-mention form. An org team named after
+ *  the agent slug makes the targeted handle autocomplete in GitHub's composer;
+ *  the team only has to exist and be visible, and matching stays pure text. */
+export function mentionsGithubTeam(
+  body: string | undefined,
+  owner: string | undefined,
+  slug: string | undefined
+): boolean {
+  return !!owner && !!slug && mentionsGithubHandle(body, `${owner}/${slug}`)
+}
+
+/** The repository owner login — the org whose teams a team mention can name. */
+export function githubRepoOwner(repoFullName: string | undefined): string | undefined {
+  return repoFullName?.split('/')[0] || undefined
 }
 
 function requestsGithubAppReviewer(login: string | undefined, appSlug: string | undefined): boolean {
@@ -256,19 +275,29 @@ function isGithubThreadComment(ctx: GithubMatchCtx): boolean {
   return ctx.event === 'issue_comment' || ctx.event === 'pull_request_review_comment'
 }
 
+/** The targeted agent handle in either accepted form: the bare slug, or the
+ *  `@<owner>/<slug>` team an org creates so the same handle autocompletes. */
+function githubMentionsAgent(body: string | undefined, rule: RcHookAssign, owner: string | undefined): boolean {
+  return mentionsGithubHandle(body, rule.github?.agentName) || mentionsGithubTeam(body, owner, rule.github?.agentName)
+}
+
 function githubRuleIsSummoned(rule: RcHookAssign, ctx: GithubMatchCtx): boolean {
   return (
     mentionsGithubHandle(ctx.mentionText, rule.github?.appSlug) ||
-    mentionsGithubHandle(ctx.mentionText, rule.github?.agentName)
+    githubMentionsAgent(ctx.mentionText, rule, ctx.repoOwnerLogin)
   )
 }
 
 /** Explicit agent handles narrow a repo fan-out; the App handle deliberately
  *  wins as the broadcast form. A non-AgentConnect @mention changes nothing. */
-export function githubMentionCandidates(rules: RcHookAssign[], body: string | undefined): RcHookAssign[] {
+export function githubMentionCandidates(
+  rules: RcHookAssign[],
+  body: string | undefined,
+  owner?: string
+): RcHookAssign[] {
   if (rules.some((rule) => mentionsGithubHandle(body, rule.github?.appSlug))) return rules
   const targetedAgentIds = new Set(
-    rules.filter((rule) => mentionsGithubHandle(body, rule.github?.agentName)).map((rule) => rule.agentId)
+    rules.filter((rule) => githubMentionsAgent(body, rule, owner)).map((rule) => rule.agentId)
   )
   return targetedAgentIds.size === 0 ? rules : rules.filter((rule) => targetedAgentIds.has(rule.agentId))
 }
@@ -448,7 +477,7 @@ export function buildTrustedGithubMetadata(
     event === 'issue_comment' &&
     payload.action === 'created' &&
     (mentionsGithubHandle(payload.comment?.body, rule.github.appSlug) ||
-      mentionsGithubHandle(payload.comment?.body, rule.github.agentName))
+      githubMentionsAgent(payload.comment?.body, rule, githubRepoOwner(payload.repository?.full_name)))
   const pr = payload.pull_request
   const headSha = pr?.head?.sha
   const baseChanged = githubPullRequestBaseChanged(event, payload)
@@ -956,6 +985,7 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
         headRepoFullName: subject?.head?.repo?.full_name,
         baseRepoFullName: subject?.base?.repo?.full_name,
         commentAuthorLogin: payload.comment?.user?.login,
+        repoOwnerLogin: githubRepoOwner(payload.repository?.full_name),
         requestedReviewerLogin: payload.requested_reviewer?.login,
         baseChanged: githubPullRequestBaseChanged(event, payload),
         commentSubjectFamily:
@@ -1165,7 +1195,9 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
       }
 
       const candidates =
-        ctx.eventAction === 'pull_request:review_requested' ? rules : githubMentionCandidates(rules, ctx.mentionText)
+        ctx.eventAction === 'pull_request:review_requested'
+          ? rules
+          : githubMentionCandidates(rules, ctx.mentionText, ctx.repoOwnerLogin)
       const matched = candidates
         .map((rule) => ({ rule, verdict: githubRuleVerdict(rule, ctx) }))
         .filter((candidate) => candidate.verdict !== 'no-match')

--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -89,7 +89,7 @@ interface GithubPayload {
   action?: string
   changes?: { base?: unknown }
   installation?: { id?: number }
-  repository?: { id?: number; full_name?: string }
+  repository?: GithubRepositoryRef
   sender?: { login?: string; type?: string; avatar_url?: string }
   requested_reviewer?: { login?: string; type?: string }
   requested_action?: { identifier?: string }
@@ -134,6 +134,13 @@ interface GithubPayload {
   }
 }
 
+/** The delivery's own repository. `owner.type` is GitHub's signed owner kind. */
+interface GithubRepositoryRef {
+  id?: number
+  full_name?: string
+  owner?: { login?: string; type?: string }
+}
+
 interface GithubSubject {
   number?: number
   title?: string
@@ -167,8 +174,9 @@ export interface GithubMatchCtx {
   headRepoFullName?: string
   baseRepoFullName?: string
   commentAuthorLogin?: string
-  /** The repository owner login — scopes `@<owner>/<agent>` team mentions. */
-  repoOwnerLogin?: string
+  /** The organization login that scopes `@<owner>/<agent>` team mentions.
+   *  Absent for a personal repository, which has no teams to mention. */
+  teamOwnerLogin?: string
   mentionText: string | undefined
   /** GitHub's native reviewer request target. Only this App's `[bot]` login
    * turns `pull_request:review_requested` into a manual review request. */
@@ -227,9 +235,13 @@ export function mentionsGithubTeam(
   return !!owner && !!slug && mentionsGithubHandle(body, `${owner}/${slug}`)
 }
 
-/** The repository owner login — the org whose teams a team mention can name. */
-export function githubRepoOwner(repoFullName: string | undefined): string | undefined {
-  return repoFullName?.split('/')[0] || undefined
+/** The organization whose teams a team mention can name. A personal repository
+ *  has no teams, so an owner GitHub does not sign as `Organization` yields none
+ *  and `@<owner>/<agent>` stays inert there — including a payload too old or too
+ *  partial to carry the owner kind. */
+export function githubTeamOwner(repository: GithubRepositoryRef | undefined): string | undefined {
+  if (repository?.owner?.type !== 'Organization') return undefined
+  return repository.owner.login || repository.full_name?.split('/')[0] || undefined
 }
 
 function requestsGithubAppReviewer(login: string | undefined, appSlug: string | undefined): boolean {
@@ -284,7 +296,7 @@ function githubMentionsAgent(body: string | undefined, rule: RcHookAssign, owner
 function githubRuleIsSummoned(rule: RcHookAssign, ctx: GithubMatchCtx): boolean {
   return (
     mentionsGithubHandle(ctx.mentionText, rule.github?.appSlug) ||
-    githubMentionsAgent(ctx.mentionText, rule, ctx.repoOwnerLogin)
+    githubMentionsAgent(ctx.mentionText, rule, ctx.teamOwnerLogin)
   )
 }
 
@@ -477,7 +489,7 @@ export function buildTrustedGithubMetadata(
     event === 'issue_comment' &&
     payload.action === 'created' &&
     (mentionsGithubHandle(payload.comment?.body, rule.github.appSlug) ||
-      githubMentionsAgent(payload.comment?.body, rule, githubRepoOwner(payload.repository?.full_name)))
+      githubMentionsAgent(payload.comment?.body, rule, githubTeamOwner(payload.repository)))
   const pr = payload.pull_request
   const headSha = pr?.head?.sha
   const baseChanged = githubPullRequestBaseChanged(event, payload)
@@ -985,7 +997,7 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
         headRepoFullName: subject?.head?.repo?.full_name,
         baseRepoFullName: subject?.base?.repo?.full_name,
         commentAuthorLogin: payload.comment?.user?.login,
-        repoOwnerLogin: githubRepoOwner(payload.repository?.full_name),
+        teamOwnerLogin: githubTeamOwner(payload.repository),
         requestedReviewerLogin: payload.requested_reviewer?.login,
         baseChanged: githubPullRequestBaseChanged(event, payload),
         commentSubjectFamily:
@@ -1197,7 +1209,7 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
       const candidates =
         ctx.eventAction === 'pull_request:review_requested'
           ? rules
-          : githubMentionCandidates(rules, ctx.mentionText, ctx.repoOwnerLogin)
+          : githubMentionCandidates(rules, ctx.mentionText, ctx.teamOwnerLogin)
       const matched = candidates
         .map((rule) => ({ rule, verdict: githubRuleVerdict(rule, ctx) }))
         .filter((candidate) => candidate.verdict !== 'no-match')

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -353,6 +353,9 @@ export default function AddIntegrationModal({
   const ghSelectedInstallation =
     gh?.installations.find((installation) => installation.id === ghSelectedRepo?.installationId) ??
     installationForRepo(ghRepoPick, gh?.installations ?? [])
+  // Teams exist only under an organization, so a personal installation gets no team form.
+  const ghTeamOwner =
+    ghSelectedInstallation?.accountType === 'Organization' ? ghSelectedInstallation.accountLogin : null
   const ghReviewSettingsBlocked =
     !!ghRepoPick &&
     (!repoAccessSatisfies(ghRepoAccess, ghNeededAccess) ||
@@ -1606,7 +1609,7 @@ export default function AddIntegrationModal({
                     return (
                       <div
                         key={m.mode}
-                        title={m.mode === 'mention' ? githubMentionUsage(agent.name, ghRepoPick) : undefined}
+                        title={m.mode === 'mention' ? githubMentionUsage(agent.name, ghTeamOwner) : undefined}
                         className={`flex min-w-0 cursor-pointer items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
                           on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'
                         }`}

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -1606,7 +1606,7 @@ export default function AddIntegrationModal({
                     return (
                       <div
                         key={m.mode}
-                        title={m.mode === 'mention' ? githubMentionUsage(agent.name) : undefined}
+                        title={m.mode === 'mention' ? githubMentionUsage(agent.name, ghRepoPick) : undefined}
                         className={`flex min-w-0 cursor-pointer items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
                           on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'
                         }`}

--- a/packages/web/src/lib/github-events.test.ts
+++ b/packages/web/src/lib/github-events.test.ts
@@ -8,6 +8,7 @@ import {
   GH_TRIGGER_MODES,
   GH_TRIGGER_PILL,
   githubHookNeedsNormalization,
+  githubMentionUsage,
   githubTriggerTooltip,
   THREAD_COMMENT_EVENT
 } from './github-events'
@@ -35,6 +36,13 @@ describe('GH_TRIGGER_PILL', () => {
     expect(githubTriggerTooltip('every', 'reviewer')).toBe(
       'Runs when an issue or PR is opened and on supported updates and replies (close, reopen and title/body edits are ignored).'
     )
+  })
+
+  it('offers the owner-qualified team form only once a repository names the organization', () => {
+    expect(githubMentionUsage('reviewer')).toBe('Use @reviewer to trigger only this agent.')
+    const owned = githubMentionUsage('reviewer', 'acme/infra')
+    expect(owned).toContain('@reviewer')
+    expect(owned).toContain('@acme/reviewer')
   })
 
   it('mention-mode copy admits the App broadcast and explicit App review requests, without an absolute "only"', () => {

--- a/packages/web/src/lib/github-events.test.ts
+++ b/packages/web/src/lib/github-events.test.ts
@@ -38,9 +38,11 @@ describe('GH_TRIGGER_PILL', () => {
     )
   })
 
-  it('offers the owner-qualified team form only once a repository names the organization', () => {
+  it('offers the owner-qualified team form only for an organization-owned repository', () => {
+    // No organization (a personal installation) ⇒ no team to name.
     expect(githubMentionUsage('reviewer')).toBe('Use @reviewer to trigger only this agent.')
-    const owned = githubMentionUsage('reviewer', 'acme/infra')
+    expect(githubMentionUsage('reviewer', null)).toBe('Use @reviewer to trigger only this agent.')
+    const owned = githubMentionUsage('reviewer', 'acme')
     expect(owned).toContain('@reviewer')
     expect(owned).toContain('@acme/reviewer')
   })

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -80,9 +80,14 @@ export function githubTriggerTooltip(mode: GhTriggerMode, agentName: string): st
   }
 }
 
-/** Concrete hover copy for the agent-targeted GitHub mention form. */
-export function githubMentionUsage(agentName: string): string {
-  return `Use @${agentName} to trigger only this agent.`
+/** Concrete hover copy for the agent-targeted GitHub mention form. The owner
+ *  form is offered whenever a repository is known: a GitHub team named after the
+ *  agent makes the same handle autocomplete in GitHub's comment composer. */
+export function githubMentionUsage(agentName: string, repoFullName?: string | null): string {
+  const owner = repoFullName?.split('/')[0]
+  return owner
+    ? `Use @${agentName} — or @${owner}/${agentName}, once the organization has a team named ${agentName} — to trigger only this agent.`
+    : `Use @${agentName} to trigger only this agent.`
 }
 
 /** The default create-form selection: pull requests only. */

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -80,13 +80,13 @@ export function githubTriggerTooltip(mode: GhTriggerMode, agentName: string): st
   }
 }
 
-/** Concrete hover copy for the agent-targeted GitHub mention form. The owner
- *  form is offered whenever a repository is known: a GitHub team named after the
- *  agent makes the same handle autocomplete in GitHub's comment composer. */
-export function githubMentionUsage(agentName: string, repoFullName?: string | null): string {
-  const owner = repoFullName?.split('/')[0]
-  return owner
-    ? `Use @${agentName} — or @${owner}/${agentName}, once the organization has a team named ${agentName} — to trigger only this agent.`
+/** Concrete hover copy for the agent-targeted GitHub mention form. `teamOwner`
+ *  is the ORGANIZATION that owns the repository: a team named after the agent
+ *  makes the same handle autocomplete in GitHub's comment composer. A personal
+ *  account has no teams, so callers pass none and the copy stays on the bare form. */
+export function githubMentionUsage(agentName: string, teamOwner?: string | null): string {
+  return teamOwner
+    ? `Use @${agentName} — or @${teamOwner}/${agentName}, once the organization has a team named ${agentName} — to trigger only this agent.`
     : `Use @${agentName} to trigger only this agent.`
 }
 


### PR DESCRIPTION
## Why

`@<agent>` never autocompletes in GitHub's comment composer, so a reporter has to
remember the agent slug exactly. GitHub *does* autocomplete organization teams, so a
visible team named after the agent gives the same targeted handle a suggestion — and
that is all this change needs from the team.

## What changed

`@<owner>/<agent>` now selects exactly the rules `@<agent>` selects, on all three
paths that read the targeted handle: mention-only mode, the additive summon in
`created`/`updated` mode, and an explicit review request.

The owner comes from the delivery's own `repository.full_name`, so matching stays pure
text against the authored body: the team is never read back through the API, it needs
no members for matching, and a same-named team in another organization selects nobody.

Along the way this fixes a real footgun. `@x/y` used to count as a bare mention of
`@x` (an old test asserted `'/' is a boundary`). If a GitHub App slug happens to equal
the organization login, *every* team mention would hit the broadcast branch and wake
every agent in the repository. `@<owner>/<slug>` is GitHub's team syntax, so it is now
parsed only that way.

The Add-integration mention tile's hover copy names the exact team to create once a
repository is picked.

## For the reviewer

- **Creating the team stays the organization's job.** `POST /orgs/{org}/teams` needs the
  organization `Members: write` permission; this App requests no organization
  permissions at all, and adding one would put every existing installation into a
  "new permissions requested" state that only an org owner can clear. Not worth it for
  a mention shortcut — recorded under Unsupported Capabilities.
- The team must be `closed` (visible). `secret` teams are not offered in the composer.
- The agent slug regex is already a legal team slug and the slug is immutable, so
  name == slug needs no rename handling.
- `mentionsGithubHandle` is shared with GitLab ingress, so the `@x/y` fix applies there
  too — which matches GitLab group-mention syntax. GitLab does not yet get the
  `@group/<agent>` form; that would be a separate change.

Relay (543) and web (2043) suites pass; typecheck, lint and prettier are clean.
