### PR TITLE
fix(web): patch runtime/model before moving the preset in onboarding

### DIFF
--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -309,17 +309,18 @@ describe('onboarding — daemon online: configure + finish', () => {
     expect(moveOrder).toBeLessThan(flagOrder)
   })
 
-  it('re-homes an already-placed built-in agent: move onto the daemon FIRST, then patch', async () => {
-    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: 'dmn_pool', runtime: 'claude' }]
+  it('re-homes an already-placed built-in agent: patch the spec FIRST, then move', async () => {
+    // Born pool-placed with a pool-only runtime — the move validates the CURRENT
+    // runtime against the target, so moving first would be rejected.
+    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: 'dmn_pool', runtime: 'dsh-acp' }]
     await render()
     expect(host.textContent).toContain('What should the agent run on?')
     await click('Finish')
-    expect(mocks.moveAgent).toHaveBeenCalledWith('ag_ac', { kind: 'daemon', daemonId: 'dmn_new' })
     expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude', model: 'claude-sonnet-4-5' })
-    // Already configured ⇒ the spec PATCH must run against its new home, so the move lands first.
-    const moveOrder = mocks.moveAgent.mock.invocationCallOrder[0] ?? Infinity
-    const updateOrder = mocks.updateAgent.mock.invocationCallOrder[0] ?? 0
-    expect(moveOrder).toBeLessThan(updateOrder)
+    expect(mocks.moveAgent).toHaveBeenCalledWith('ag_ac', { kind: 'daemon', daemonId: 'dmn_new' })
+    const updateOrder = mocks.updateAgent.mock.invocationCallOrder[0] ?? Infinity
+    const moveOrder = mocks.moveAgent.mock.invocationCallOrder[0] ?? 0
+    expect(updateOrder).toBeLessThan(moveOrder)
     expect(mocks.updateOrg).toHaveBeenCalledWith('org-1', { onboardingCompleted: true })
   })
 

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -324,6 +324,16 @@ describe('onboarding — daemon online: configure + finish', () => {
     expect(mocks.updateOrg).toHaveBeenCalledWith('org-1', { onboardingCompleted: true })
   })
 
+  it('clears the old model pin when the target advertises no models yet', async () => {
+    // Runtime probe not settled: the runtime is known but its model list is empty. The
+    // PATCH must send model:null so the pool preset's cross-runtime pin does not survive.
+    mocks.daemons = [{ ...mocks.daemons[0], runtimeModels: [{ runtime: 'claude', models: [] }] }]
+    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: 'dmn_pool', runtime: 'dsh-acp' }]
+    await render()
+    await click('Finish')
+    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'claude', model: null })
+  })
+
   it('hides the pickers only when the org has no built-in agent at all', async () => {
     mocks.agents = []
     await render()

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -106,20 +106,12 @@ export default function OnboardingView() {
     setSaving(true)
     setSaveErr(null)
     try {
-      const place = async () => {
-        if (target) await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: target.daemonId })
-      }
-      const patch = () => updateAgent(builtinAgent.id, { runtime, ...(model ? { model } : {}) })
-      // A deferred-runtime preset must set the runtime FIRST (the CP rejects a move on a
-      // runtime-less agent). An already-configured one (e.g. born pool-placed) moves onto
-      // the chosen home FIRST, so the spec PATCH runs against the daemon it will run on.
-      if (builtinAgent.runtime) {
-        await place()
-        await patch()
-      } else {
-        await patch()
-        await place()
-      }
+      // PATCH first, always: the move validates the agent's CURRENT runtime/model against
+      // the target daemon, so moving a pool-born preset (e.g. runtime dsh-acp) before the
+      // spec update is rejected with "target daemon does not support runtime …". The picker
+      // sources runtime/model from the target's own profiles, so patch-then-move admits.
+      await updateAgent(builtinAgent.id, { runtime, ...(model ? { model } : {}) })
+      if (target) await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: target.daemonId })
       await refresh()
       return true
     } catch (e) {

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -110,7 +110,9 @@ export default function OnboardingView() {
       // the target daemon, so moving a pool-born preset (e.g. runtime dsh-acp) before the
       // spec update is rejected with "target daemon does not support runtime …". The picker
       // sources runtime/model from the target's own profiles, so patch-then-move admits.
-      await updateAgent(builtinAgent.id, { runtime, ...(model ? { model } : {}) })
+      // model || null: an empty selection (target's model probe not settled yet) must CLEAR
+      // the pool preset's old model pin, not silently keep it across the runtime change.
+      await updateAgent(builtinAgent.id, { runtime, model: model || null })
       if (target) await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: target.daemonId })
       await refresh()
       return true


### PR DESCRIPTION
## What changed

In the onboarding wizard's daemon path, `saveAgentSetup` now always PATCHes the built-in preset's runtime/model first and only then moves it onto the chosen daemon, removing the old "already-configured agents move first" branch. The re-home test now models the real failing scenario (a pool-born preset with runtime `dsh-acp`) and asserts the PATCH lands before the move.

## Why

A preset born pool-placed carries a pool-only runtime (`dsh-acp`). Moving it first made the CP's move endpoint validate that stale runtime against the target daemon's `runtimeProfiles` and reject Finish with `target daemon does not support runtime dsh-acp` — the runtime/model PATCH never got sent, so the console showed only a `PUT /agents/:id/daemon` carrying just `daemonId`.

## Reviewer notes

- Only the move endpoint validates runtime/model against a daemon; the spec PATCH does not validate against the current placement, so patching while pool-placed is accepted.
- The wizard's runtime/model pickers source their options from the target daemon's own reported profiles, so patch-then-move always passes the move's admits check.
- The old "CP rejects a move on a runtime-less agent" constraint is naturally covered by the unified patch-first order.
- Full web test suite passes (2042 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)