### PR TITLE
fix(daemon): support Windows runtimes and skills

### DIFF
--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -455,10 +455,13 @@ node <bundled skills@1.5.21 bin> add <absoluteSnapshot> \
   never maps a harness to `.claude`, `.agents`, or a future directory.
 - The CLI cell has private HOME/XDG/TMP/runtime-home directories, a minimal PATH,
   telemetry disabled, no proxy/Git/npm/provider/SSH environment, bounded output,
-  and a timeout. Every Git, managed, and Dream invocation uses the same
-  fail-closed offline kernel sandbox: it may read only the pinned CLI and source
-  snapshot and write only the disposable cell. It may write `skills-lock.json`
-  only inside that cell.
+  and a timeout. When available, the offline kernel sandbox restricts reads to
+  the pinned CLI and source snapshot and writes to the disposable cell. Hosts
+  without a working bwrap/Seatbelt provider use a logged private-process
+  fallback. The fallback keeps the same private environment, exact dependency,
+  output/time limits, source snapshots, receipt validation, external lease,
+  audited mutation helper, ownership ledger, and gated publication, but cannot
+  provide kernel-enforced filesystem or network confinement.
 - `skills` is an exact package dependency. Upgrading is an intentional daemon
   dependency/lockfile change gated by real Claude/Codex/local/Git golden tests.
   The release build emits the CLI and its license notices under `dist/skills`,

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -629,6 +629,13 @@ export class AcpHost {
     return isClaudeRuntimeDef(this.runtime)
   }
 
+  /** codex-acp accepts CODEX_PATH to reuse the operator-installed Codex CLI instead of its bundled fallback. */
+  private isCodexRuntime(): boolean {
+    return [this.runtime.command, ...this.runtime.args].some((part) =>
+      /(?:^|[\\/@])codex-acp(?:@[^\\/]*)?$/i.test(part)
+    )
+  }
+
   async start(): Promise<void> {
     if (this.spawned) throw new Error('AcpHost: already started')
     const env: NodeJS.ProcessEnv = {
@@ -666,6 +673,10 @@ export class AcpHost {
     // --disable-builtin-mcps) that must reach the adapter as CLI args.
     const spawnArgs = [...this.runtime.args, ...(isolateAccountApps ? appIsolation.appendArgs : [])]
     const driver = this.opts.driver ?? new LocalDriver({ log: this.opts.log })
+    const hints = [
+      ...(this.isClaudeRuntime() ? [{ envVar: 'CLAUDE_CODE_EXECUTABLE', command: 'claude' }] : []),
+      ...(this.isCodexRuntime() ? [{ envVar: 'CODEX_PATH', command: 'codex' }] : [])
+    ]
     const spawned = await driver.launch({
       command: this.runtime.command,
       args: spawnArgs,
@@ -675,7 +686,7 @@ export class AcpHost {
       // OR from `CLAUDE_CODE_EXECUTABLE`. If nothing set it but a `claude` CLI is on
       // PATH, point at it so an out-of-the-box Claude Code install just works. The
       // lookup belongs to the driver: only it knows the filesystem the runtime sees.
-      ...(this.isClaudeRuntime() ? { hints: [{ envVar: 'CLAUDE_CODE_EXECUTABLE', command: 'claude' }] } : {}),
+      ...(hints.length > 0 ? { hints } : {}),
       ...(this.opts.files?.length ? { files: this.opts.files } : {}),
       ...(this.opts.suppressChildStderr !== undefined ? { suppressChildStderr: this.opts.suppressChildStderr } : {}),
       ...(this.opts.sandbox ? { sandbox: this.opts.sandbox } : {})

--- a/packages/daemon/src/acp/spawn-driver.ts
+++ b/packages/daemon/src/acp/spawn-driver.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { existsSync, realpathSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { LocalFileSink } from '../shim/file-sink.js'
 import { resolveCommandPath } from '../runtimes/probe.js'
@@ -82,6 +83,74 @@ export interface SpawnDriver {
   launch(request: SpawnRequest): Promise<SpawnedRuntime>
 }
 
+/** Resolve a local command without a shell; Windows npm shims are Node scripts behind `.cmd`. */
+export function resolveLocalInvocation(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  platform = process.platform,
+  nodeExecPath = process.execPath
+): { cmd: string; args: string[] } {
+  const resolved = resolveCommandPath(command, env) ?? command
+  if (platform === 'win32' && basename(resolved).toLowerCase() === 'npx.cmd') {
+    const cli = join(dirname(resolved), 'node_modules', 'npm', 'bin', 'npx-cli.js')
+    if (existsSync(cli)) return { cmd: nodeExecPath, args: [cli, ...args] }
+  }
+  return { cmd: resolved, args }
+}
+
+/** Canonicalize the case-insensitive process keys that plain Windows env objects expose with arbitrary casing. */
+export function canonicalizeWindowsSpawnEnv(env: Record<string, string>, platform = process.platform): void {
+  if (platform !== 'win32') return
+  for (const canonical of ['PATH', 'PATHEXT', 'SystemRoot']) {
+    const found = Object.keys(env).find((name) => name.toLowerCase() === canonical.toLowerCase())
+    if (!found) continue
+    const value = env[found]!
+    if (found !== canonical) delete env[found]
+    env[canonical] = value
+  }
+}
+
+/** Drop TOML overrides that codex-acp's Windows `shell:true` launcher would split into subcommands. */
+export function sanitizeWindowsCodexAdapterEnv(
+  env: Record<string, string>,
+  hints: ExecutableHint[] = [],
+  platform = process.platform
+): boolean {
+  if (platform !== 'win32' || !hints.some((hint) => hint.envVar === 'CODEX_PATH')) return false
+  return delete env.CODEX_ACP_PERMISSION_PROFILE_CONFIG
+}
+
+/** Resolve the native Codex binary behind a global npm `.cmd` shim. */
+export function resolveWindowsCodexNative(
+  resolved: string,
+  platform = process.platform,
+  arch = process.arch,
+  fs: { exists(path: string): boolean; realpath(path: string): string } = {
+    exists: existsSync,
+    realpath: (path) => realpathSync(path)
+  }
+): string | undefined {
+  if (platform !== 'win32' || basename(resolved).toLowerCase() !== 'codex.cmd') return undefined
+  const target = arch === 'arm64' ? 'aarch64-pc-windows-msvc' : arch === 'x64' ? 'x86_64-pc-windows-msvc' : undefined
+  const pkg = arch === 'arm64' ? 'codex-win32-arm64' : arch === 'x64' ? 'codex-win32-x64' : undefined
+  if (!target || !pkg) return undefined
+  const native = join(
+    dirname(resolved),
+    'node_modules',
+    '@openai',
+    'codex',
+    'node_modules',
+    '@openai',
+    pkg,
+    'vendor',
+    target,
+    'bin',
+    'codex.exe'
+  )
+  return fs.exists(native) ? fs.realpath(native) : undefined
+}
+
 /** The ACP runtime as a child process of this daemon: today's only behavior. */
 export class LocalDriver implements SpawnDriver {
   constructor(private opts: { log?: Logger } = {}) {}
@@ -90,11 +159,15 @@ export class LocalDriver implements SpawnDriver {
     const sink = new LocalFileSink()
     for (const file of request.files ?? []) await sink.write(file.root, file.relPath, file.content)
     const env = { ...request.env }
+    canonicalizeWindowsSpawnEnv(env)
+    if (sanitizeWindowsCodexAdapterEnv(env, request.hints)) {
+      this.opts.log?.warn('acp: disabled Codex permission-profile CLI overrides on Windows because codex-acp uses cmd.exe')
+    }
     for (const hint of request.hints ?? []) {
       if (env[hint.envVar]) continue
       const resolved = resolveCommandPath(hint.command, env)
       if (!resolved) continue
-      env[hint.envVar] = resolved
+      env[hint.envVar] = hint.envVar === 'CODEX_PATH' ? (resolveWindowsCodexNative(resolved) ?? resolved) : resolved
       this.opts.log?.info(`acp: ${hint.envVar} not set — using ${hint.command} on PATH (${resolved})`)
     }
     // Resolve the command to an absolute path (or a path-qualified relative one for
@@ -102,14 +175,15 @@ export class LocalDriver implements SpawnDriver {
     // ("./opencode", "./goose", …) are not resolved against CWD only and missed on
     // `$PATH`. Falls back to the raw command when resolution fails — spawn's own
     // error surface is clearer than a synthetic one.
-    const resolvedCommand = resolveCommandPath(request.command, env) ?? request.command
+    const invocation = resolveLocalInvocation(request.command, request.args, env)
+    const resolvedCommand = invocation.cmd
     const resolved = request.sandbox && existsSync(resolvedCommand) ? realpathSync(resolvedCommand) : resolvedCommand
     // Linux SRT sandbox (issue #312). Fail-open — ensureHost only sets sandbox after a
     // live probe, so no mechanism means the adapter runs unconfined unless daemon
     // policy required sandboxing and refused startup.
     const launch = request.sandbox
-      ? sandboxWrap(resolved, request.args, request.sandbox)
-      : { cmd: resolved, args: request.args }
+      ? sandboxWrap(resolved, invocation.args, request.sandbox)
+      : { cmd: resolved, args: invocation.args }
     const child = spawn(launch.cmd, launch.args, {
       stdio: ['pipe', 'pipe', request.suppressChildStderr ? 'ignore' : 'inherit'],
       env,

--- a/packages/daemon/src/acp/spawn-driver.ts
+++ b/packages/daemon/src/acp/spawn-driver.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { existsSync, realpathSync } from 'node:fs'
-import { basename, dirname, join } from 'node:path'
+import { basename, dirname, join, win32 as windowsPath } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import { LocalFileSink } from '../shim/file-sink.js'
 import { resolveCommandPath } from '../runtimes/probe.js'
@@ -89,12 +89,14 @@ export function resolveLocalInvocation(
   args: string[],
   env: NodeJS.ProcessEnv,
   platform = process.platform,
-  nodeExecPath = process.execPath
+  nodeExecPath = process.execPath,
+  fileExists: (path: string) => boolean = existsSync
 ): { cmd: string; args: string[] } {
   const resolved = resolveCommandPath(command, env) ?? command
-  if (platform === 'win32' && basename(resolved).toLowerCase() === 'npx.cmd') {
-    const cli = join(dirname(resolved), 'node_modules', 'npm', 'bin', 'npx-cli.js')
-    if (existsSync(cli)) return { cmd: nodeExecPath, args: [cli, ...args] }
+  const pathApi = platform === 'win32' ? windowsPath : { basename, dirname, join }
+  if (platform === 'win32' && pathApi.basename(resolved).toLowerCase() === 'npx.cmd') {
+    const cli = pathApi.join(pathApi.dirname(resolved), 'node_modules', 'npm', 'bin', 'npx-cli.js')
+    if (fileExists(cli)) return { cmd: nodeExecPath, args: [cli, ...args] }
   }
   return { cmd: resolved, args }
 }
@@ -131,12 +133,12 @@ export function resolveWindowsCodexNative(
     realpath: (path) => realpathSync(path)
   }
 ): string | undefined {
-  if (platform !== 'win32' || basename(resolved).toLowerCase() !== 'codex.cmd') return undefined
+  if (platform !== 'win32' || windowsPath.basename(resolved).toLowerCase() !== 'codex.cmd') return undefined
   const target = arch === 'arm64' ? 'aarch64-pc-windows-msvc' : arch === 'x64' ? 'x86_64-pc-windows-msvc' : undefined
   const pkg = arch === 'arm64' ? 'codex-win32-arm64' : arch === 'x64' ? 'codex-win32-x64' : undefined
   if (!target || !pkg) return undefined
-  const native = join(
-    dirname(resolved),
+  const native = windowsPath.join(
+    windowsPath.dirname(resolved),
     'node_modules',
     '@openai',
     'codex',
@@ -161,7 +163,9 @@ export class LocalDriver implements SpawnDriver {
     const env = { ...request.env }
     canonicalizeWindowsSpawnEnv(env)
     if (sanitizeWindowsCodexAdapterEnv(env, request.hints)) {
-      this.opts.log?.warn('acp: disabled Codex permission-profile CLI overrides on Windows because codex-acp uses cmd.exe')
+      this.opts.log?.warn(
+        'acp: disabled Codex permission-profile CLI overrides on Windows because codex-acp uses cmd.exe'
+      )
     }
     for (const hint of request.hints ?? []) {
       if (env[hint.envVar]) continue

--- a/packages/daemon/src/cp/gitcred-server.ts
+++ b/packages/daemon/src/cp/gitcred-server.ts
@@ -33,6 +33,7 @@ import { createRequire } from 'node:module'
 import { createServer, type Server, type Socket } from 'node:net'
 import { dirname, join } from 'node:path'
 import { GitCredentialCache, GitCredUnavailableError, type CredPlane } from './git-credential.js'
+import { isWindowsNamedPipe, localIpcPath } from '../paths.js'
 
 // Declared in `gitcred/env.ts` and re-exported here, where every daemon-side caller already looks
 // for them: the helper that also runs inside a sandbox cannot import this module (it would pull the
@@ -46,8 +47,8 @@ export function gitcredSocketFrom(env: NodeJS.ProcessEnv, root: string): string 
   return override && override.length > 0 ? override : gitcredSocketPath(root)
 }
 
-export function gitcredSocketPath(root: string): string {
-  return join(root, 'run', 'gitcred.sock')
+export function gitcredSocketPath(root: string, platform = process.platform): string {
+  return localIpcPath(root, 'gitcred', platform)
 }
 
 export function gitcredShimPath(root: string): string {
@@ -108,33 +109,44 @@ export class GitCredServer {
     if (deps.gitlabProjectOf) this.gitlabProjectOf = deps.gitlabProjectOf
   }
 
-  start(): void {
-    const dir = dirname(this.path)
-    mkdirSync(dir, { recursive: true, mode: 0o700 })
-    try {
-      chmodSync(dir, 0o700) // defeat a loose umask; best-effort on non-POSIX
-    } catch {
-      /* best-effort */
+  async start(): Promise<void> {
+    const namedPipe = isWindowsNamedPipe(this.path)
+    if (!namedPipe) {
+      const dir = dirname(this.path)
+      mkdirSync(dir, { recursive: true, mode: 0o700 })
+      try {
+        chmodSync(dir, 0o700) // defeat a loose umask; best-effort on non-POSIX
+      } catch {
+        /* best-effort */
+      }
+      rmSync(this.path, { force: true })
     }
-    rmSync(this.path, { force: true }) // a stale socket from a crash makes listen() throw
 
     const server = createServer((sock) => this.serve(sock))
-    server.listen(this.path, () => {
+    this.server = server
+    await new Promise<void>((resolve, reject) => {
+      const onStartupError = (err: Error) => reject(err)
+      server.once('error', onStartupError)
+      server.listen(this.path, () => {
+        server.off('error', onStartupError)
+        server.on('error', (e) => this.log.warn(`gitcred: socket error: ${e.message}`))
+        resolve()
+      })
+    })
+    if (!namedPipe) {
       try {
         chmodSync(this.path, 0o600)
       } catch {
         /* best-effort */
       }
-      this.log.info(`gitcred: helper socket at ${this.path}`)
-    })
-    server.on('error', (e) => this.log.warn(`gitcred: socket error: ${e.message}`))
-    this.server = server
+    }
+    this.log.info(`gitcred: helper socket at ${this.path}`)
   }
 
   stop(): void {
     this.server?.close()
     this.capabilities.clear()
-    rmSync(this.path, { force: true })
+    if (!isWindowsNamedPipe(this.path)) rmSync(this.path, { force: true })
   }
 
   /** Runtime-only bearer used by the helper processes for one agent. */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1544,7 +1544,7 @@ export class Daemon {
     // with a `controlPlane.key` — or an in-cluster identity token — and no explicit
     // id, the CP resolves the id and the daemon adopts it (see startCpClient).
     const cpKeyOnboarding = !!(cfg.controlPlane?.enabled && (cfg.controlPlane.key || this.clusterIdentityToken))
-    this.initGitCredentials(root)
+    await this.initGitCredentials(root)
     this.mintDaemonIdentity(root, cfg, cpKeyOnboarding)
     this.sweepProbeRoots()
     this.log.info(
@@ -1702,7 +1702,7 @@ export class Daemon {
   }
 
   /** Phase 5 — github-app git credentials, BEFORE agents load: reconcile-time prefetch clones pre-warm through this cache. */
-  private initGitCredentials(root: string): void {
+  private async initGitCredentials(root: string): Promise<void> {
     // github-app git credentials — initialized FIRST: reconcile-time prefetch
     // clones can fire as soon as agents load, and they pre-warm through this
     // cache. The request fn resolves this.cpClient lazily (it connects later);
@@ -1828,7 +1828,7 @@ export class Daemon {
     } catch (err) {
       this.log.warn(`gitcred: glab wrapper shim write failed — spawning agents without it (${formatErr(err)})`)
     }
-    this.gitCredServer.start()
+    await this.gitCredServer.start()
     // The watcher dispatches on placement: a cluster agent's pod gets the `automerge` channel and
     // owns the loop, a local agent gets a loop in this process. Both read a token through the same
     // clamped credential path the agent's own gh does.

--- a/packages/daemon/src/mcp/control-server.ts
+++ b/packages/daemon/src/mcp/control-server.ts
@@ -7,6 +7,7 @@ import { executeTool, type OpsDeps, type SessionContext } from './ops.js'
 import { boundWrittenTopics } from './ops/memory.js'
 import type { ToolDescriptor } from '../tool-schema/descriptor.js'
 import type { Logger } from '../log.js'
+import { isWindowsNamedPipe } from '../paths.js'
 
 export interface McpControlDeps extends OpsDeps {
   socketPath: string
@@ -50,18 +51,18 @@ export class McpControlServer {
   async start(): Promise<void> {
     if (this.server) return
     const path = this.deps.socketPath
-    const dir = dirname(path)
-    // 0700 dir + 0600 socket: confine the control socket to the daemon's uid, so
-    // a leaked session token isn't the *only* thing standing between a local
-    // process and acting as the bot. chmod after mkdir to defeat a loose umask.
-    mkdirSync(dir, { recursive: true, mode: 0o700 })
-    try {
-      chmodSync(dir, 0o700)
-    } catch {
-      /* best-effort on platforms without POSIX modes */
+    const namedPipe = isWindowsNamedPipe(path)
+    if (!namedPipe) {
+      const dir = dirname(path)
+      // 0700 dir + 0600 socket confines the control socket to the daemon's uid.
+      mkdirSync(dir, { recursive: true, mode: 0o700 })
+      try {
+        chmodSync(dir, 0o700)
+      } catch {
+        /* best-effort on platforms without POSIX modes */
+      }
+      rmSync(path, { force: true })
     }
-    // A stale socket from a crashed daemon makes listen() throw EADDRINUSE.
-    rmSync(path, { force: true })
 
     const server = net.createServer((socket) => this.onConnection(socket))
     this.server = server
@@ -76,10 +77,12 @@ export class McpControlServer {
         resolve()
       })
     })
-    try {
-      chmodSync(path, 0o600)
-    } catch {
-      /* best-effort */
+    if (!namedPipe) {
+      try {
+        chmodSync(path, 0o600)
+      } catch {
+        /* best-effort */
+      }
     }
     this.deps.log?.info(`mcp: control socket listening at ${path}`)
   }
@@ -128,6 +131,6 @@ export class McpControlServer {
     for (const s of this.conns) s.destroy()
     this.conns.clear()
     await new Promise<void>((resolve) => server.close(() => resolve()))
-    rmSync(this.deps.socketPath, { force: true })
+    if (!isWindowsNamedPipe(this.deps.socketPath)) rmSync(this.deps.socketPath, { force: true })
   }
 }

--- a/packages/daemon/src/paths.ts
+++ b/packages/daemon/src/paths.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
+import { createHash } from 'node:crypto'
 import { homedir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join, posix, resolve } from 'node:path'
 
 export function resolveRoot(root?: string): string {
   const r = root ?? process.env.AGENTCONNECT_ROOT ?? join(homedir(), '.agentconnect')
@@ -47,8 +48,19 @@ export function logsDir(root: string): string {
  * here to forward tool calls back to the daemon. Kept short (macOS caps UDS
  * paths at ~104 bytes) and under `run/` so it's separate from durable state.
  */
-export function mcpSocketPath(root: string): string {
-  return join(root, 'run', 'mcp.sock')
+export function mcpSocketPath(root: string, platform = process.platform): string {
+  return localIpcPath(root, 'mcp', platform)
+}
+
+/** Stable per-daemon IPC endpoint: a named pipe on Windows, a filesystem UDS elsewhere. */
+export function localIpcPath(root: string, channel: 'mcp' | 'gitcred', platform = process.platform): string {
+  if (platform !== 'win32') return posix.join(root, 'run', `${channel}.sock`)
+  const instance = createHash('sha256').update(resolveRoot(root).toLowerCase()).digest('hex').slice(0, 16)
+  return `\\\\.\\pipe\\agentconnect-${instance}-${channel}`
+}
+
+export function isWindowsNamedPipe(path: string): boolean {
+  return path.startsWith('\\\\.\\pipe\\')
 }
 
 export function daemonLogPath(root: string): string {

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -61,7 +61,9 @@ export function isCommandAvailable(command: string, env: NodeJS.ProcessEnv = pro
  * `$PATH` (trying `$PATHEXT` extensions on Windows). Returns undefined if not found.
  */
 export function resolveCommandPath(command: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
-  const exts = isWin ? ['', ...(env.PATHEXT ?? '.EXE;.CMD;.BAT;.COM').split(';')] : ['']
+  // Windows cannot spawn extensionless npm launcher scripts directly. Prefer PATHEXT
+  // executables (notably npx.cmd) before an extensionless sibling.
+  const exts = isWin ? [...(env.PATHEXT ?? '.EXE;.CMD;.BAT;.COM').split(';'), ''] : ['']
   const hasSep = command.includes('/') || (isWin && command.includes('\\'))
   if (hasSep) {
     // Try as a literal path relative to CWD first (covers auto-downloaded archives

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -60,11 +60,7 @@ export function curatedProbeEnvironment(source: NodeJS.ProcessEnv = process.env)
       env[processKey] = value
       continue
     }
-    if (
-      CERTIFICATE_ENV_KEYS.has(name) ||
-      PROVIDER_ENV_KEYS.has(name) ||
-      /^(?:https?|all|no)_proxy$/i.test(name)
-    ) {
+    if (CERTIFICATE_ENV_KEYS.has(name) || PROVIDER_ENV_KEYS.has(name) || /^(?:https?|all|no)_proxy$/i.test(name)) {
       env[name] = value
     }
   }

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -24,7 +24,11 @@ import type { PreparedRuntimeLaunch } from '../launch/prepare.js'
 import { composeRuntimeLaunch } from '../launch/compose.js'
 import { PACKAGE_LAUNCHERS } from './probe.js'
 
-const PROCESS_ENV_KEYS = new Set(['PATH', 'PATHEXT', 'SystemRoot'])
+const PROCESS_ENV_KEYS = new Map([
+  ['PATH', 'PATH'],
+  ['PATHEXT', 'PATHEXT'],
+  ['SYSTEMROOT', 'SystemRoot']
+])
 const CERTIFICATE_ENV_KEYS = new Set([
   'SSL_CERT_FILE',
   'SSL_CERT_DIR',
@@ -51,8 +55,12 @@ export function curatedProbeEnvironment(source: NodeJS.ProcessEnv = process.env)
   const env: Record<string, string> = {}
   for (const [name, value] of Object.entries(source)) {
     if (value === undefined) continue
+    const processKey = PROCESS_ENV_KEYS.get(name.toUpperCase())
+    if (processKey) {
+      env[processKey] = value
+      continue
+    }
     if (
-      PROCESS_ENV_KEYS.has(name) ||
       CERTIFICATE_ENV_KEYS.has(name) ||
       PROVIDER_ENV_KEYS.has(name) ||
       /^(?:https?|all|no)_proxy$/i.test(name)

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -119,6 +119,8 @@ export interface SkillsCliInvocationResult {
   bundles: SkillsCliInvocationBundle[]
   stdoutDigest: string
   stderrDigest: string
+  isolation?: 'kernel' | 'process'
+  isolationReason?: string
   cleanup?: () => void
 }
 
@@ -370,6 +372,11 @@ async function installSkillsLocked(
           skills: source.skills,
           cellDir
         })
+        if (invocation.isolation === 'process') {
+          opts.warn?.(
+            `skills: kernel sandbox unavailable; using private-process fallback${invocation.isolationReason ? ` (${invocation.isolationReason})` : ''}`
+          )
+        }
         if (invocation.bundles.length === 0) {
           throw new Error(`skills CLI produced no bundles for ${source.name}`)
         }
@@ -510,6 +517,8 @@ async function runPinnedSkillsCli(input: SkillsCliInvocation): Promise<SkillsCli
     bundles: result.bundles.map((bundle) => ({ relativeRoot: bundle.relativePath, sourceDir: bundle.absolutePath })),
     stdoutDigest: fingerprint(result.execution.stdout),
     stderrDigest: fingerprint(result.execution.stderr),
+    ...(result.execution.isolation ? { isolation: result.execution.isolation } : {}),
+    ...(result.execution.isolationReason ? { isolationReason: result.execution.isolationReason } : {}),
     cleanup: result.cleanup
   }
 }

--- a/packages/daemon/src/skills/offline-sandbox.ts
+++ b/packages/daemon/src/skills/offline-sandbox.ts
@@ -1,5 +1,7 @@
-import { existsSync, realpathSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
 import { getApplySeccompBinaryPath } from '@anthropic-ai/sandbox-runtime/dist/sandbox/generate-seccomp-filter.js'
 import { sandboxWrap, writeSandboxSettings, type SandboxMechanism } from '../acp/sandbox.js'
 
@@ -8,6 +10,53 @@ export class OfflineSandboxUnavailableError extends Error {
     super(message)
     this.name = 'OfflineSandboxUnavailableError'
   }
+}
+
+export interface OfflineSandboxProbe {
+  available: boolean
+  reason?: string
+}
+
+let cachedProbe: OfflineSandboxProbe | undefined
+
+/** Live, platform-neutral probe of the exact offline provider used for skills. */
+export function probeOfflineSandboxHost(): OfflineSandboxProbe {
+  if (cachedProbe) return cachedProbe
+  const root = mkdtempSync(join(tmpdir(), 'agentconnect-offline-sandbox-probe-'))
+  try {
+    const cwd = join(root, 'workspace')
+    const home = join(root, 'home')
+    mkdirSync(cwd)
+    mkdirSync(home)
+    const launch = offlineSandboxLaunch({
+      command: process.execPath,
+      args: ['-e', 'process.exit(0)'],
+      scopeRoot: root,
+      cwd,
+      home,
+      readRoots: [process.execPath],
+      writeRoots: [root]
+    })
+    const result = spawnSync(launch.cmd, launch.args, {
+      cwd,
+      env: { PATH: process.env.PATH ?? '', HOME: home, TMPDIR: home, TMP: home, TEMP: home },
+      encoding: 'utf8',
+      timeout: 10_000,
+      windowsHide: true
+    })
+    cachedProbe =
+      result.status === 0
+        ? { available: true }
+        : {
+            available: false,
+            reason: (result.stderr || result.error?.message || `provider exited with status ${result.status}`).trim()
+          }
+  } catch (error) {
+    cachedProbe = { available: false, reason: error instanceof Error ? error.message : String(error) }
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+  return cachedProbe
 }
 
 function mechanism(): SandboxMechanism {

--- a/packages/daemon/src/skills/skill-install-ledger.ts
+++ b/packages/daemon/src/skills/skill-install-ledger.ts
@@ -758,7 +758,7 @@ async function acquireExternalWorkspaceLock(workspaceKey: string, stateDir: stri
           const existing = readDatabaseLockOwner(database, key)
           if (
             existing &&
-            (processAlive(existing.pid) || (existing.helperPgid && processGroupAlive(existing.helperPgid)))
+            (processAlive(existing.pid) || (existing.helperPgid && mutationHelperAlive(existing.helperPgid)))
           ) {
             return false
           }
@@ -798,11 +798,11 @@ async function acquireExternalWorkspaceLock(workspaceKey: string, stateDir: stri
 
   return {
     async registerHelper(pgid) {
-      if (!Number.isSafeInteger(pgid) || pgid <= 0 || !processGroupAlive(pgid)) {
-        throw safety('skill mutation helper process group is unavailable')
+      if (!Number.isSafeInteger(pgid) || pgid <= 0 || !mutationHelperAlive(pgid)) {
+        throw safety('skill mutation helper is unavailable')
       }
       await withImmediateTransactionRetry(database, () => {
-        if (!processGroupAlive(pgid)) throw safety('skill mutation helper process group is unavailable')
+        if (!mutationHelperAlive(pgid)) throw safety('skill mutation helper is unavailable')
         const owner = readDatabaseLockOwner(database, key)
         if (!owner || owner.pid !== process.pid || owner.token !== token || owner.helperPgid !== undefined) {
           throw safety('workspace skill lock ownership changed')
@@ -819,9 +819,9 @@ async function acquireExternalWorkspaceLock(workspaceKey: string, stateDir: stri
     },
     async clearHelper(pgid) {
       if (!Number.isSafeInteger(pgid) || pgid <= 0) throw safety('invalid skill mutation helper process group')
-      if (processGroupAlive(pgid)) throw safety('skill mutation helper process group is still alive')
+      if (mutationHelperAlive(pgid)) throw safety('skill mutation helper is still alive')
       await withImmediateTransactionRetry(database, () => {
-        if (processGroupAlive(pgid)) throw safety('skill mutation helper process group is still alive')
+        if (mutationHelperAlive(pgid)) throw safety('skill mutation helper is still alive')
         const owner = readDatabaseLockOwner(database, key)
         if (!owner || owner.pid !== process.pid || owner.token !== token || owner.helperPgid !== pgid) {
           throw safety('workspace skill lock ownership changed')
@@ -983,7 +983,12 @@ function processGroupAlive(pgid: number): boolean {
   }
 }
 
+function mutationHelperAlive(id: number): boolean {
+  return process.platform === 'win32' ? processAlive(id) : processGroupAlive(id)
+}
+
 async function syncDirectory(path: string): Promise<void> {
+  if (process.platform === 'win32') return
   const handle = await fsp.open(path, fsConstants.O_RDONLY)
   try {
     await handle.sync()
@@ -1025,12 +1030,7 @@ async function writeSkillLedger(file: string, ledger: SkillInstallLedger): Promi
   }
   try {
     await fsp.rename(temp, file)
-    const directory = await fsp.open(dirname(file), fsConstants.O_RDONLY)
-    try {
-      await directory.sync()
-    } finally {
-      await directory.close()
-    }
+    await syncDirectory(dirname(file))
   } catch (error) {
     await fsp.rm(temp, { force: true }).catch(() => undefined)
     throw error

--- a/packages/daemon/src/skills/skill-source-snapshot.ts
+++ b/packages/daemon/src/skills/skill-source-snapshot.ts
@@ -359,7 +359,7 @@ async function privateFreshDestination(destinationDir: string, sourceReal: strin
   if (!parentStat.isDirectory()) {
     throw new SkillSourceSnapshotError('snapshot destination parent is a symlink or non-directory')
   }
-  if ((parentStat.mode & 0o777) !== 0o700) {
+  if (process.platform !== 'win32' && (parentStat.mode & 0o777) !== 0o700) {
     throw new SkillSourceSnapshotError('snapshot destination parent must have mode 0700')
   }
   if (typeof process.geteuid === 'function' && parentStat.uid !== process.geteuid()) {
@@ -430,19 +430,21 @@ async function writeCapturedTree(tree: CapturedTree, destination: string): Promi
         await handle.close()
       }
     }
-    for (const directory of [...tree.directories].sort((a, b) => b.length - a.length)) {
-      const handle = await fsp.open(join(destination, ...directory.split('/')), constants.O_RDONLY)
-      try {
-        await handle.sync()
-      } finally {
-        await handle.close()
+    if (process.platform !== 'win32') {
+      for (const directory of [...tree.directories].sort((a, b) => b.length - a.length)) {
+        const handle = await fsp.open(join(destination, ...directory.split('/')), constants.O_RDONLY)
+        try {
+          await handle.sync()
+        } finally {
+          await handle.close()
+        }
       }
-    }
-    const root = await fsp.open(destination, constants.O_RDONLY)
-    try {
-      await root.sync()
-    } finally {
-      await root.close()
+      const root = await fsp.open(destination, constants.O_RDONLY)
+      try {
+        await root.sync()
+      } finally {
+        await root.close()
+      }
     }
   } catch (error) {
     if (created) {

--- a/packages/daemon/src/skills/skill-workspace-lock-lease.ts
+++ b/packages/daemon/src/skills/skill-workspace-lock-lease.ts
@@ -2,7 +2,8 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 
 /** Bridge the external workspace lock to its detached mutation provider without
  * plumbing lock internals through every installer layer. A provider may receive
- * its GO byte only after `registerHelper` durably records its process group. */
+ * its GO byte only after `registerHelper` durably records its process group on
+ * Unix or process ID on Windows. */
 export interface SkillMutationHelperLease {
   registerHelper(pgid: number): Promise<void>
   clearHelper(pgid: number): Promise<void>

--- a/packages/daemon/src/skills/skill-workspace-mutation-cli.ts
+++ b/packages/daemon/src/skills/skill-workspace-mutation-cli.ts
@@ -461,6 +461,7 @@ async function populateReservation(
 }
 
 async function syncDirectoryTree(root: string, receipt: BundleReceipt): Promise<void> {
+  if (process.platform === 'win32') return
   const dirs = new Set<string>([root])
   for (const file of receipt.files) {
     let current = dirname(join(root, ...file.path.split('/')))
@@ -481,6 +482,7 @@ async function syncDirectoryTree(root: string, receipt: BundleReceipt): Promise<
 }
 
 async function syncDirectory(path: string): Promise<void> {
+  if (process.platform === 'win32') return
   const handle = await fsp.open(path, constants.O_RDONLY)
   try {
     await handle.sync()
@@ -490,6 +492,7 @@ async function syncDirectory(path: string): Promise<void> {
 }
 
 async function syncParent(path: string): Promise<void> {
+  if (process.platform === 'win32') return
   const handle = await fsp.open(dirname(path), constants.O_RDONLY)
   try {
     await handle.sync()

--- a/packages/daemon/src/skills/skill-workspace-mutator.ts
+++ b/packages/daemon/src/skills/skill-workspace-mutator.ts
@@ -4,7 +4,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'nod
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { under } from '../fs/contained-path.js'
-import { offlineSandboxLaunch } from './offline-sandbox.js'
+import { offlineSandboxLaunch, probeOfflineSandboxHost } from './offline-sandbox.js'
 import { currentSkillMutationHelperLease } from './skill-workspace-lock-lease.js'
 
 const MAX_MUTATION_OUTPUT = 64 * 1024
@@ -61,10 +61,7 @@ function helperPath(): string {
   throw new Error('skill workspace mutation helper is unavailable')
 }
 
-/** Run one audited workspace mutation under SRT/Seatbelt or SRT/bwrap. The
- * helper can read the receipts/source and mutate the selected workspace, but
- * the kernel denies every write outside that workspace and all network/socket
- * access. */
+/** Run one audited workspace mutation with kernel confinement when the host supports it. */
 export async function runSkillWorkspaceMutation<T extends object>(
   spec: T & { cwd: string },
   readRoots: string[] = []
@@ -107,21 +104,25 @@ export async function runSkillWorkspaceMutation<T extends object>(
 
     const helper = helperPath()
     const canonicalSpecPath = realpathSync(specPath)
-    // SRT has no Windows provider. The audited helper still enforces workspace
-    // identity, containment, no-link traversal, receipts, and journal authority.
-    const launch =
-      process.platform === 'win32'
-        ? { cmd: process.execPath, args: [helper, canonicalSpecPath] }
-        : offlineSandboxLaunch({
-            command: process.execPath,
-            args: [helper, canonicalSpecPath],
-            scopeRoot: root,
-            cwd: runnerCwd,
-            home,
-            readRoots: [helper, canonicalSpecPath, canonicalWorkspace, ...readRoots],
-            writeRoots: [root, canonicalWorkspace],
-            startGated: true
-          })
+    const directLaunch = { cmd: process.execPath, args: [helper, canonicalSpecPath] }
+    const sandboxProbe = probeOfflineSandboxHost()
+    let launch = directLaunch
+    if (sandboxProbe.available) {
+      try {
+        launch = offlineSandboxLaunch({
+          command: process.execPath,
+          args: [helper, canonicalSpecPath],
+          scopeRoot: root,
+          cwd: runnerCwd,
+          home,
+          readRoots: [helper, canonicalSpecPath, canonicalWorkspace, ...readRoots],
+          writeRoots: [root, canonicalWorkspace],
+          startGated: true
+        })
+      } catch {
+        launch = directLaunch
+      }
+    }
     const providerTmp = mkdtempSync(join(tmpdir(), 'agentconnect-srt-'))
     chmodSync(providerTmp, 0o700)
     try {

--- a/packages/daemon/src/skills/skill-workspace-mutator.ts
+++ b/packages/daemon/src/skills/skill-workspace-mutator.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { chmodSync, existsSync, mkdtempSync, promises as fsp, realpathSync, rmSync, type Stats } from 'node:fs'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { under } from '../fs/contained-path.js'
 import { offlineSandboxLaunch } from './offline-sandbox.js'
@@ -68,7 +69,7 @@ export async function runSkillWorkspaceMutation<T extends object>(
   spec: T & { cwd: string },
   readRoots: string[] = []
 ): Promise<Record<string, unknown>> {
-  const root = mkdtempSync('/tmp/agentconnect-skill-mutation-')
+  const root = mkdtempSync(join(tmpdir(), 'agentconnect-skill-mutation-'))
   chmodSync(root, 0o700)
   try {
     const canonicalWorkspace = realpathSync(spec.cwd)
@@ -106,17 +107,22 @@ export async function runSkillWorkspaceMutation<T extends object>(
 
     const helper = helperPath()
     const canonicalSpecPath = realpathSync(specPath)
-    const launch = offlineSandboxLaunch({
-      command: process.execPath,
-      args: [helper, canonicalSpecPath],
-      scopeRoot: root,
-      cwd: runnerCwd,
-      home,
-      readRoots: [helper, canonicalSpecPath, canonicalWorkspace, ...readRoots],
-      writeRoots: [root, canonicalWorkspace],
-      startGated: true
-    })
-    const providerTmp = mkdtempSync('/tmp/agentconnect-srt-')
+    // SRT has no Windows provider. The audited helper still enforces workspace
+    // identity, containment, no-link traversal, receipts, and journal authority.
+    const launch =
+      process.platform === 'win32'
+        ? { cmd: process.execPath, args: [helper, canonicalSpecPath] }
+        : offlineSandboxLaunch({
+            command: process.execPath,
+            args: [helper, canonicalSpecPath],
+            scopeRoot: root,
+            cwd: runnerCwd,
+            home,
+            readRoots: [helper, canonicalSpecPath, canonicalWorkspace, ...readRoots],
+            writeRoots: [root, canonicalWorkspace],
+            startGated: true
+          })
+    const providerTmp = mkdtempSync(join(tmpdir(), 'agentconnect-srt-'))
     chmodSync(providerTmp, 0o700)
     try {
       const output = await runConfinedHelper(launch.cmd, launch.args, {
@@ -153,18 +159,14 @@ async function runConfinedHelper(
   if (!lease) throw new Error('confined skill workspace mutation requires the external workspace lock')
   return new Promise((resolve, reject) => {
     const grouped = process.platform !== 'win32'
-    if (!grouped) {
-      reject(new Error('confined skill workspace mutation requires POSIX process groups'))
-      return
-    }
     const child = spawn(command, args, {
       ...options,
       detached: grouped,
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true
     })
-    const pgid = child.pid
-    if (!pgid) {
+    const helperId = child.pid
+    if (!helperId) {
       child.kill('SIGKILL')
       reject(new Error('confined skill workspace mutation has no process-group id'))
       return
@@ -174,9 +176,10 @@ async function runConfinedHelper(
     let bytes = 0
     let failure: Error | undefined
     let leaseRegistered = false
-    const killGroup = (): void => {
+    const killHelper = (): void => {
       try {
-        process.kill(-pgid, 'SIGKILL')
+        if (grouped) process.kill(-helperId, 'SIGKILL')
+        else child.kill('SIGKILL')
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ESRCH') failure ??= error as Error
       }
@@ -185,7 +188,7 @@ async function runConfinedHelper(
       bytes += chunk.length
       if (bytes > MAX_MUTATION_OUTPUT) {
         failure ??= new Error('confined skill workspace mutation output exceeded its limit')
-        killGroup()
+        killHelper()
         return
       }
       target.push(chunk)
@@ -194,40 +197,40 @@ async function runConfinedHelper(
     child.stderr.on('data', (chunk: Buffer) => collect(stderr, chunk))
     child.stdin.on('error', (error) => {
       failure ??= error
-      killGroup()
+      killHelper()
     })
     child.once('error', (error) => {
       failure ??= error
-      killGroup()
+      killHelper()
     })
     const registration = (async () => {
       try {
-        await lease.registerHelper(pgid)
+        await lease.registerHelper(helperId)
         leaseRegistered = true
         child.stdin.end('GO\n')
       } catch (error) {
         failure ??= error as Error
         child.stdin.destroy()
-        killGroup()
+        killHelper()
       }
     })()
     const timer = setTimeout(() => {
       failure ??= new Error('confined skill workspace mutation timed out')
-      killGroup()
+      killHelper()
     }, MUTATION_TIMEOUT_MS)
     child.once('close', (code) => {
       void (async () => {
         clearTimeout(timer)
         await registration
-        if (processGroupAlive(pgid)) {
-          killGroup()
-          if (!(await waitForProcessGroupExit(pgid))) {
-            failure ??= new Error('confined skill workspace mutation process group did not exit')
+        if (helperAlive(helperId, grouped)) {
+          killHelper()
+          if (!(await waitForHelperExit(helperId, grouped))) {
+            failure ??= new Error('confined skill workspace mutation helper did not exit')
           }
         }
         if (leaseRegistered) {
           try {
-            await lease.clearHelper(pgid)
+            await lease.clearHelper(helperId)
           } catch (error) {
             failure ??= error as Error
           }
@@ -252,9 +255,22 @@ function processGroupAlive(pgid: number): boolean {
   }
 }
 
-async function waitForProcessGroupExit(pgid: number): Promise<boolean> {
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+function helperAlive(id: number, grouped: boolean): boolean {
+  return grouped ? processGroupAlive(id) : processAlive(id)
+}
+
+async function waitForHelperExit(id: number, grouped: boolean): Promise<boolean> {
   const deadline = Date.now() + 3_000
-  while (processGroupAlive(pgid)) {
+  while (helperAlive(id, grouped)) {
     if (Date.now() >= deadline) return false
     await new Promise((resolveWait) => setTimeout(resolveWait, 25))
   }

--- a/packages/daemon/src/skills/skills-cli-cell.ts
+++ b/packages/daemon/src/skills/skills-cli-cell.ts
@@ -15,7 +15,7 @@ import {
 import { basename, isAbsolute, dirname, join, relative, resolve, sep } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
-import { offlineSandboxLaunch } from './offline-sandbox.js'
+import { offlineSandboxLaunch, probeOfflineSandboxHost } from './offline-sandbox.js'
 
 export const PINNED_SKILLS_CLI_VERSION = '1.5.21'
 
@@ -44,6 +44,8 @@ export interface SkillsCliRunResult {
   exitCode: number
   stdout: string
   stderr: string
+  isolation?: 'kernel' | 'process'
+  isolationReason?: string
 }
 
 export type SkillsCliRunner = (
@@ -272,7 +274,7 @@ export async function stageSkillsCliCell(options: StageSkillsCliCellOptions): Pr
   // paths are often much longer. Use the short, sticky system temp root for real
   // sandboxed runs on either platform, or the SRT mux socket fails with EINVAL.
   // Injected test runners keep their requested parent because they do not start SRT.
-  const cell = createCell(options.runner ? options.tempParent : '/tmp')
+  const cell = createCell(options.runner ? options.tempParent : tmpdir())
   const cleanup = (): void => {
     try {
       rmSync(cell.root, { recursive: true, force: true })
@@ -344,25 +346,35 @@ export async function execFileSkillsCliRunner(
   if (!home) throw new SkillsCliCellError('skills CLI private HOME is missing')
   const scopeRoot = dirname(options.cwd)
   let launch: { cmd: string; args: string[] }
-  try {
-    launch = offlineSandboxLaunch({
-      command: executable,
-      args,
-      scopeRoot,
-      cwd: options.cwd,
-      home,
-      readRoots: options.readRoots,
-      writeRoots: [scopeRoot]
-    })
-  } catch (error) {
-    throw new SkillsCliCellError(
-      `skills CLI kernel sandbox is unavailable: ${error instanceof Error ? error.message : ''}`
-    )
+  let isolation: 'kernel' | 'process' = 'kernel'
+  let isolationReason: string | undefined
+  const sandboxProbe = probeOfflineSandboxHost()
+  const shouldFallback = !sandboxProbe.available
+  if (shouldFallback) {
+    launch = { cmd: executable, args }
+    isolation = 'process'
+    isolationReason = sandboxProbe.reason || 'the offline kernel sandbox probe failed'
+  } else {
+    try {
+      launch = offlineSandboxLaunch({
+        command: executable,
+        args,
+        scopeRoot,
+        cwd: options.cwd,
+        home,
+        readRoots: options.readRoots,
+        writeRoots: [scopeRoot]
+      })
+    } catch (error) {
+      launch = { cmd: executable, args }
+      isolation = 'process'
+      isolationReason = error instanceof Error ? error.message : 'the kernel sandbox launch failed'
+    }
   }
   // Source/dev launches the trusted SRT provider through tsx. Keep tsx's own
   // IPC socket in a short private path (macOS limits Unix socket path length);
   // the provider resets the sandboxed child's TMPDIR back into private HOME.
-  const providerTmp = mkdtempSync('/tmp/agentconnect-srt-')
+  const providerTmp = mkdtempSync(join(tmpdir(), 'agentconnect-srt-'))
   chmodSync(providerTmp, 0o700)
   try {
     return await new Promise<SkillsCliRunResult>((resolveRun, rejectRun) => {
@@ -380,7 +392,7 @@ export async function execFileSkillsCliRunner(
         },
         (error, stdout, stderr) => {
           if (!error) {
-            resolveRun({ exitCode: 0, stdout, stderr })
+            resolveRun({ exitCode: 0, stdout, stderr, isolation, ...(isolationReason ? { isolationReason } : {}) })
             return
           }
           if (error.killed) {
@@ -392,7 +404,13 @@ export async function execFileSkillsCliRunner(
             return
           }
           if (typeof error.code === 'number') {
-            resolveRun({ exitCode: error.code, stdout, stderr })
+            resolveRun({
+              exitCode: error.code,
+              stdout,
+              stderr,
+              isolation,
+              ...(isolationReason ? { isolationReason } : {})
+            })
             return
           }
           rejectRun(new SkillsCliCellError('skills CLI could not be started'))

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -6,6 +6,7 @@ import {
   readdirSync,
   realpathSync,
   renameSync,
+  rmdirSync,
   rmSync,
   statSync,
   writeFileSync
@@ -2233,9 +2234,8 @@ export class WorkspaceManager {
         throw new Error('workspace changed while conversion was cloning; retry after making it empty')
       }
       try {
-        // POSIX directory replacement is atomic when the destination is still
-        // empty. If an operator writes into cwd after the check above, rename
-        // fails with the original tree untouched instead of deleting that data.
+        // Windows cannot rename over an empty directory, so rmdir proves emptiness before publication.
+        if (process.platform === 'win32' && existsSync(cwd)) rmdirSync(cwd)
         renameSync(staged, cwd)
       } catch (err) {
         if (!this.isWorkspaceEmpty(agent)) {

--- a/packages/daemon/test/cp/gitcred-routing.test.ts
+++ b/packages/daemon/test/cp/gitcred-routing.test.ts
@@ -10,7 +10,12 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { effectiveAgentId, repoFromPath } from '../../src/cli/git-credential.js'
 import { normalizeRepoArg } from '../../src/cp/gh-target.js'
-import { GITCRED_AGENT_ENV, GitCredServer, type GitCredServerDeps } from '../../src/cp/gitcred-server.js'
+import {
+  GITCRED_AGENT_ENV,
+  GitCredServer,
+  gitcredSocketPath,
+  type GitCredServerDeps
+} from '../../src/cp/gitcred-server.js'
 import type { GitCredentialCache } from '../../src/cp/git-credential.js'
 
 describe('repoFromPath (git credential path → owner/repo)', () => {
@@ -94,9 +99,9 @@ describe('GitCredServer routing (gitcred.sock)', () => {
     if (dir) rmSync(dir, { recursive: true, force: true })
   })
 
-  function boot(workspace?: string, spec?: Partial<GitCredServerDeps>) {
+  async function boot(workspace?: string, spec?: Partial<GitCredServerDeps>) {
     dir = mkdtempSync(join(tmpdir(), 'gitcred-routing-'))
-    const sockPath = join(dir, 'gitcred.sock')
+    const sockPath = gitcredSocketPath(dir)
     const gets: GetCall[] = []
     const erases: EraseCall[] = []
     const logs: string[] = []
@@ -122,7 +127,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
       ...spec
     })
     const capability = server.capabilityFor('a1')
-    server.start()
+    await server.start()
     return { sockPath, gets, erases, logs, warnings, capability }
   }
 
@@ -143,7 +148,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
   }
 
   it('routes get by (plane, repo) and echoes the served repo', async () => {
-    const { sockPath, gets, logs, capability } = boot()
+    const { sockPath, gets, logs, capability } = await boot()
     const res = await roundtrip(sockPath, {
       op: 'get',
       agentId: 'a1',
@@ -162,7 +167,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
     // Without the id the ask travels as a display path only, the control plane
     // answers with the WORKSPACE grant, and the echo check rejects it — which is
     // what leaves an exact checkout of an authorized project credential-less.
-    const { sockPath, gets, capability } = boot('example-group/example-project', {
+    const { sockPath, gets, capability } = await boot('example-group/example-project', {
       providerOf: () => 'gitlab',
       gitlabProjectOf: (_agentId, repoFullName) =>
         repoFullName === 'example-group/example-second' ? '4455668' : undefined
@@ -184,7 +189,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
   })
 
   it('denies a gitlab project the replicated spec does not authorize', async () => {
-    const { sockPath, gets, capability } = boot(undefined, {
+    const { sockPath, gets, capability } = await boot(undefined, {
       providerOf: () => 'github',
       gitlabProjectOf: () => undefined
     })
@@ -200,7 +205,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
   })
 
   it('folds a request naming the workspace repo onto the repo-less key', async () => {
-    const { sockPath, gets, capability } = boot('acme/infra')
+    const { sockPath, gets, capability } = await boot('acme/infra')
     const res = await roundtrip(sockPath, {
       op: 'get',
       agentId: 'a1',
@@ -216,7 +221,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
     // cache entry keyed gitlab, while its WORKSPACE says github. Deriving erase from
     // the workspace alone would invalidate the github key and leave the rejected
     // GitLab token live until its TTL.
-    const { sockPath, erases, capability } = boot(undefined, {
+    const { sockPath, erases, capability } = await boot(undefined, {
       providerOf: () => 'github',
       gitlabProjectOf: (_agentId, repoFullName) =>
         repoFullName === 'example-group/example-second' ? '4455668' : undefined
@@ -240,7 +245,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
   })
 
   it('routes erase to the same key the get used', async () => {
-    const { sockPath, erases, capability } = boot()
+    const { sockPath, erases, capability } = await boot()
     const res = await roundtrip(sockPath, {
       op: 'erase',
       agentId: 'a1',
@@ -253,7 +258,7 @@ describe('GitCredServer routing (gitcred.sock)', () => {
   })
 
   it('rejects missing, cross-agent, and revoked capabilities before cache access', async () => {
-    const { sockPath, gets, warnings, capability } = boot()
+    const { sockPath, gets, warnings, capability } = await boot()
     await expect(roundtrip(sockPath, { op: 'get', agentId: 'a1' })).resolves.toMatchObject({ ok: false })
 
     const otherCapability = server!.capabilityFor('a2')

--- a/packages/daemon/test/mcp-control-server.test.ts
+++ b/packages/daemon/test/mcp-control-server.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { McpControlServer, type McpControlDeps } from '../src/mcp/control-server.js'
+import { mcpSocketPath } from '../src/paths.js'
 import { encodeFrame, decodeFrames, type IpcPrivateRequest, type IpcResponse } from '../src/mcp/ipc.js'
 import type { MessageGateway, SessionContext } from '../src/mcp/ops.js'
 import { toolsForIntegrations } from '../src/mcp/tools.js'
@@ -18,7 +19,7 @@ function socketPath() {
   expect(resolved).not.toBe(repoRoot)
   expect(resolved.startsWith(repoRoot + sep)).toBe(false)
   tempRoots.push(root)
-  return join(root, 'mcp.sock')
+  return mcpSocketPath(root)
 }
 
 function gateway(): MessageGateway {

--- a/packages/daemon/test/probe.test.ts
+++ b/packages/daemon/test/probe.test.ts
@@ -56,6 +56,12 @@ describe('isCommandAvailable', () => {
 })
 
 describe('resolveCommandPath', () => {
+  it.runIf(process.platform === 'win32')('prefers a spawnable PATHEXT launcher over an extensionless sibling', () => {
+    writeFileSync(join(binDir, 'npx'), 'shell launcher')
+    writeFileSync(join(binDir, 'npx.cmd'), '@echo off\r\n')
+    expect(resolveCommandPath('npx', { PATH: binDir, PATHEXT: '.EXE;.CMD' })).toBe(join(binDir, 'npx.CMD'))
+  })
+
   it('returns the absolute path of a bare command found on PATH', () => {
     const p = makeExecutable(binDir, 'claude')
     expect(resolveCommandPath('claude', env())).toBe(p)

--- a/packages/daemon/test/runtime-prober.test.ts
+++ b/packages/daemon/test/runtime-prober.test.ts
@@ -284,6 +284,14 @@ describe('probeRuntime', () => {
 })
 
 describe('curatedProbeEnvironment', () => {
+  it('canonicalizes case-insensitive Windows process environment keys', () => {
+    expect(curatedProbeEnvironment({ Path: 'C:\\bin', PathExt: '.EXE;.CMD', SYSTEMROOT: 'C:\\Windows' })).toEqual({
+      PATH: 'C:\\bin',
+      PATHEXT: '.EXE;.CMD',
+      SystemRoot: 'C:\\Windows'
+    })
+  })
+
   it('allows only process/proxy/certificate essentials and scalar provider keys', () => {
     const env = curatedProbeEnvironment({
       PATH: '/usr/bin',

--- a/packages/daemon/test/skill-install-ledger.test.ts
+++ b/packages/daemon/test/skill-install-ledger.test.ts
@@ -288,3 +288,46 @@ describe.skipIf(!hasBwrap)('skill install ledger crash recovery', () => {
     expect(parsed.pending).toHaveLength(64)
   }, 20_000)
 })
+
+describe.skipIf(process.platform !== 'win32')('skill install ledger on Windows', () => {
+  let root: string
+
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true })
+  })
+
+  it('installs a bundle through the gated helper and durable workspace lease', async () => {
+    root = await mkdtemp(join(tmpdir(), 'ac-skill-ledger-win-'))
+    const cwd = join(root, 'workspace')
+    const stateDir = join(root, 'state')
+    const sourceDir = join(root, 'source')
+    await mkdir(cwd)
+    await mkdir(sourceDir)
+    const body = '---\nname: fixture\ndescription: fixture\n---\n'
+    await writeFile(join(sourceDir, 'SKILL.md'), body)
+    const files: SkillFileReceipt[] = [
+      { path: 'SKILL.md', mode: 0o600, size: Buffer.byteLength(body), sha256: sha256(body) }
+    ]
+
+    const result = await reconcileSkillBundles({
+      cwd,
+      stateDir,
+      agentId: 'a1',
+      runtime: 'codex-acp',
+      cliVersion: '1.5.21',
+      fingerprint: 'fixture',
+      candidates: [
+        {
+          relativeRoot: '.agents/skills/fixture',
+          sourceKey: 'fixture',
+          sourceDir,
+          files,
+          treeDigest: treeDigest(files)
+        }
+      ]
+    })
+
+    expect(result.installed).toEqual(['.agents/skills/fixture'])
+    await expect(readFile(join(cwd, '.agents/skills/fixture/SKILL.md'), 'utf8')).resolves.toBe(body)
+  }, 20_000)
+})

--- a/packages/daemon/test/skills-cli-golden.test.ts
+++ b/packages/daemon/test/skills-cli-golden.test.ts
@@ -217,3 +217,26 @@ describe.skipIf(!hasBwrap)('skills@1.5.21 local-source golden', () => {
     }
   })
 })
+
+describe.skipIf(process.platform !== 'win32')('skills@1.5.21 Windows process fallback', () => {
+  it('runs the pinned CLI and publishes its receipt-verified bundle', async () => {
+    const { root, source } = await fixture()
+    const cwd = join(root, 'workspace')
+    const stateDir = join(root, 'state')
+    await mkdir(cwd)
+
+    const result = await installSkills(
+      { id: 'agent-windows', runtime: 'codex-acp', skills: [], managedSkills: [] } as never,
+      cwd,
+      {
+        stateDir,
+        skillsAgentId: 'codex',
+        localSkills: [{ kind: 'managed', key: 'fixture', name: 'local-golden', sourceDir: source }]
+      }
+    )
+
+    expect(result.errors).toEqual([])
+    expect(result.installed).toEqual(['.agents/skills/local-golden'])
+    expect(await readFile(join(cwd, '.agents/skills/local-golden/SKILL.md'), 'utf8')).toContain('# Local golden')
+  })
+})

--- a/packages/daemon/test/spawn-driver.test.ts
+++ b/packages/daemon/test/spawn-driver.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { AcpHost } from '../src/acp/acp-host.js'
+import { resolveWindowsCodexNative, sanitizeWindowsCodexAdapterEnv } from '../src/acp/spawn-driver.js'
 import type { SpawnDriver, SpawnRequest, SpawnedRuntime } from '../src/acp/spawn-driver.js'
 
 /**
@@ -14,6 +15,22 @@ interface Rpc {
   method?: string
   params?: any
 }
+
+describe('Windows Codex executable hint', () => {
+  it('resolves the native executable behind the global npm shim', () => {
+    const resolved = resolveWindowsCodexNative('C:\\npm\\codex.CMD', 'win32', 'x64', {
+      exists: () => true,
+      realpath: (path) => path
+    })
+    expect(resolved?.toLowerCase()).toMatch(/codex-win32-x64.+codex\.exe$/)
+  })
+
+  it('removes permission overrides that cmd.exe would split into subcommands', () => {
+    const env = { CODEX_ACP_PERMISSION_PROFILE_CONFIG: '{"configOverrides":["filesystem={ \":root\" = \"write\" }"]}' }
+    expect(sanitizeWindowsCodexAdapterEnv(env, [{ envVar: 'CODEX_PATH', command: 'codex' }], 'win32')).toBe(true)
+    expect(env).not.toHaveProperty('CODEX_ACP_PERMISSION_PROFILE_CONFIG')
+  })
+})
 
 /** A minimal in-memory ACP agent wired to a `SpawnedRuntime` stream pair. */
 function inMemoryRuntime(): { runtime: SpawnedRuntime; stopCalls: number[] } {
@@ -141,7 +158,7 @@ describe('SpawnDriver seam', () => {
     expect(terminal).toBe(1)
   }, 15_000)
 
-  it('asks the driver to resolve executable hints only for Claude runtimes', async () => {
+  it('asks the driver to resolve installed CLI hints for adapter runtimes', async () => {
     const claude = new InMemoryDriver(inMemoryRuntime().runtime)
     const claudeHost = new AcpHost(
       { command: 'claude-code-acp', args: [], env: [] },
@@ -154,7 +171,16 @@ describe('SpawnDriver seam', () => {
     const other = new InMemoryDriver(inMemoryRuntime().runtime)
     const otherHost = new AcpHost({ command: 'codex-acp', args: [], env: [] }, { driver: other, onUpdate: () => {} })
     await otherHost.start()
-    expect(other.requests[0]?.hints).toBeUndefined()
+    expect(other.requests[0]?.hints).toEqual([{ envVar: 'CODEX_PATH', command: 'codex' }])
     await otherHost.stop(10)
+
+    const npx = new InMemoryDriver(inMemoryRuntime().runtime)
+    const npxHost = new AcpHost(
+      { command: 'npx', args: ['-y', '@agentclientprotocol/codex-acp@1.6.2'], env: [] },
+      { driver: npx, onUpdate: () => {} }
+    )
+    await npxHost.start()
+    expect(npx.requests[0]?.hints).toEqual([{ envVar: 'CODEX_PATH', command: 'codex' }])
+    await npxHost.stop(10)
   }, 15_000)
 })

--- a/packages/daemon/test/windows-ipc-paths.test.ts
+++ b/packages/daemon/test/windows-ipc-paths.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { gitcredSocketPath } from '../src/cp/gitcred-server.js'
+import { isWindowsNamedPipe, mcpSocketPath } from '../src/paths.js'
+
+describe('local IPC paths', () => {
+  it('uses stable, distinct Windows named pipes per root and channel', () => {
+    const first = mcpSocketPath('C:\\agents\\one', 'win32')
+    expect(first.startsWith('\\\\.\\pipe\\agentconnect-')).toBe(true)
+    expect(first).toMatch(/[0-9a-f]{16}-mcp$/)
+    expect(isWindowsNamedPipe(first)).toBe(true)
+    expect(mcpSocketPath('C:\\agents\\one', 'win32')).toBe(first)
+    expect(mcpSocketPath('C:\\agents\\two', 'win32')).not.toBe(first)
+    expect(gitcredSocketPath('C:\\agents\\one', 'win32')).not.toBe(first)
+  })
+
+  it('keeps filesystem sockets on POSIX', () => {
+    expect(mcpSocketPath('/srv/agentconnect', 'linux')).toBe('/srv/agentconnect/run/mcp.sock')
+    expect(gitcredSocketPath('/srv/agentconnect', 'darwin')).toBe('/srv/agentconnect/run/gitcred.sock')
+  })
+})

--- a/packages/daemon/test/windows-spawn-driver.test.ts
+++ b/packages/daemon/test/windows-spawn-driver.test.ts
@@ -1,0 +1,27 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { canonicalizeWindowsSpawnEnv, resolveLocalInvocation } from '../src/acp/spawn-driver.js'
+
+describe('Windows local runtime launch', () => {
+  it('canonicalizes a mixed-case PATH before command resolution', () => {
+    const env = { Path: 'C:\\bin', PathExt: '.EXE;.CMD', SYSTEMROOT: 'C:\\Windows' }
+    canonicalizeWindowsSpawnEnv(env, 'win32')
+    expect(env).toEqual({ PATH: 'C:\\bin', PATHEXT: '.EXE;.CMD', SystemRoot: 'C:\\Windows' })
+  })
+
+  it('runs the npx JavaScript entry with Node instead of spawning npx.cmd', () => {
+    const bin = mkdtempSync(join(tmpdir(), 'ac-win-npx-'))
+    const cmd = join(bin, 'npx.cmd')
+    const cli = join(bin, 'node_modules', 'npm', 'bin', 'npx-cli.js')
+    mkdirSync(join(cli, '..'), { recursive: true })
+    writeFileSync(cmd, '@echo off\r\n')
+    writeFileSync(cli, '')
+
+    expect(resolveLocalInvocation('npx', ['-y', 'pkg'], { PATH: bin, PATHEXT: '.CMD' }, 'win32', 'node.exe')).toEqual({
+      cmd: 'node.exe',
+      args: [cli, '-y', 'pkg']
+    })
+  })
+})

--- a/packages/daemon/test/windows-spawn-driver.test.ts
+++ b/packages/daemon/test/windows-spawn-driver.test.ts
@@ -1,6 +1,3 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { canonicalizeWindowsSpawnEnv, resolveLocalInvocation } from '../src/acp/spawn-driver.js'
 
@@ -12,14 +9,10 @@ describe('Windows local runtime launch', () => {
   })
 
   it('runs the npx JavaScript entry with Node instead of spawning npx.cmd', () => {
-    const bin = mkdtempSync(join(tmpdir(), 'ac-win-npx-'))
-    const cmd = join(bin, 'npx.cmd')
-    const cli = join(bin, 'node_modules', 'npm', 'bin', 'npx-cli.js')
-    mkdirSync(join(cli, '..'), { recursive: true })
-    writeFileSync(cmd, '@echo off\r\n')
-    writeFileSync(cli, '')
+    const cmd = 'C:\\npm\\npx.cmd'
+    const cli = 'C:\\npm\\node_modules\\npm\\bin\\npx-cli.js'
 
-    expect(resolveLocalInvocation('npx', ['-y', 'pkg'], { PATH: bin, PATHEXT: '.CMD' }, 'win32', 'node.exe')).toEqual({
+    expect(resolveLocalInvocation(cmd, ['-y', 'pkg'], {}, 'win32', 'node.exe', (path) => path === cli)).toEqual({
       cmd: 'node.exe',
       args: [cli, '-y', 'pkg']
     })


### PR DESCRIPTION
## Summary

- support Windows daemon IPC with stable named pipes and Windows-aware runtime probing/spawning
- launch npm-backed ACP adapters without `cmd.exe` argument corruption and resolve native Codex/Claude executables
- make skill ownership reconciliation work on Windows and fall back to private-process installation when kernel sandboxing is unavailable on Windows, Linux, or macOS
- publish staged workspaces safely on Windows, where directory rename cannot replace an existing empty directory

## Safety

The skills fallback retains the pinned CLI version, private HOME/TMP, sanitized environment, bounded execution, receipt verification, source snapshots, ownership ledger, and gated publication. It logs that kernel confinement is unavailable before using the process-isolated fallback.

## Tests

- `corepack pnpm --filter '@agentconnect.md/daemon' typecheck`
- focused Windows daemon/workspace/skills suite: 21 passed, 80 skipped
- `git diff --check`