### PR TITLE
fix(cli): use junctions for Windows version pointers

### DIFF
--- a/packages/cli/src/version-ops.ts
+++ b/packages/cli/src/version-ops.ts
@@ -2,7 +2,7 @@
  * Activation + cleanup for the version store (cli-daemon-split.md §5). Both MUTATE
  * and must run inside the version lock (version-lock.ts).
  */
-import { renameSync, rmSync, statSync, symlinkSync } from 'node:fs'
+import { existsSync, renameSync, rmSync, statSync, symlinkSync } from 'node:fs'
 import { basename } from 'node:path'
 import { currentLink, versionDir } from './paths.js'
 import { commandSelector } from './service/instance.js'
@@ -24,13 +24,37 @@ export function useVersion(root: string, version: string): void {
 
   const link = currentLink(root)
   const tmp = `${link}.tmp`
-  rmSync(tmp, { force: true })
-  // Relative target so the whole root stays relocatable.
-  symlinkSync(`versions/${version}`, tmp)
-  renameSync(tmp, link) // atomic replace of the existing symlink
+  rmSync(tmp, { recursive: true, force: true })
+  if (process.platform === 'win32') replaceWindowsCurrentJunction(root, version, link, tmp)
+  else {
+    symlinkSync(`versions/${version}`, tmp)
+    renameSync(tmp, link)
+  }
 
   if (prev && prev !== version) {
     writeMeta(root, { ...readMeta(root), previous: prev })
+  }
+}
+
+/** Publish a Windows junction without requiring Developer Mode or administrator symlink privileges. */
+function replaceWindowsCurrentJunction(root: string, version: string, link: string, tmp: string): void {
+  const backup = `${link}.previous`
+  if (!existsSync(link) && existsSync(backup)) renameSync(backup, link)
+  rmSync(backup, { recursive: true, force: true })
+  symlinkSync(versionDir(root, version), tmp, 'junction')
+  let movedCurrent = false
+  try {
+    if (existsSync(link)) {
+      renameSync(link, backup)
+      movedCurrent = true
+    }
+    renameSync(tmp, link)
+  } catch (error) {
+    if (movedCurrent && !existsSync(link)) renameSync(backup, link)
+    throw error
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+    if (existsSync(link)) rmSync(backup, { recursive: true, force: true })
   }
 }
 

--- a/packages/cli/src/version-store.ts
+++ b/packages/cli/src/version-store.ts
@@ -75,7 +75,17 @@ export function currentVersion(root: string): string | null {
   try {
     return basename(readlinkSync(link))
   } catch {
-    return null
+    if (process.platform !== 'win32') return null
+    try {
+      renameSync(`${link}.previous`, link)
+      return basename(readlinkSync(link))
+    } catch {
+      try {
+        return basename(readlinkSync(link))
+      } catch {
+        return null
+      }
+    }
   }
 }
 

--- a/packages/cli/src/version-store.ts
+++ b/packages/cli/src/version-store.ts
@@ -2,7 +2,7 @@
  * The on-disk daemon version store (cli-daemon-split.md §3/§5). Layout under
  * `<root>`:
  *   versions/<v>/        — one extracted, self-contained daemon bundle
- *   current -> versions/<v>  — the active version (atomic symlink)
+ *   current -> versions/<v>  — the active version (symlink; directory junction on Windows)
  *   versions.json        — CLI-private metadata (channel + rollback target)
  *
  * All MUTATING operations here must run inside the version lock (version-lock.ts);

--- a/packages/cli/test/version-ops.test.ts
+++ b/packages/cli/test/version-ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mkdtempSync, mkdirSync, existsSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, existsSync, readlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pruneVersions, useVersion } from '../src/version-ops.js'
@@ -14,6 +14,12 @@ describe('useVersion', () => {
     install(r, '1.0.0')
     useVersion(r, '1.0.0')
     expect(currentVersion(r)).toBe('1.0.0')
+  })
+  it.skipIf(process.platform !== 'win32')('uses a privilege-free Windows directory junction', () => {
+    const r = root()
+    install(r, '1.0.0')
+    useVersion(r, '1.0.0')
+    expect(readlinkSync(join(r, 'current'))).toBe(join(r, 'versions', '1.0.0'))
   })
   it('records the replaced version as previous (rollback target)', () => {
     const r = root()

--- a/packages/cli/test/version-ops.test.ts
+++ b/packages/cli/test/version-ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mkdtempSync, mkdirSync, existsSync, readlinkSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, existsSync, readlinkSync, renameSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pruneVersions, useVersion } from '../src/version-ops.js'
@@ -20,6 +20,18 @@ describe('useVersion', () => {
     install(r, '1.0.0')
     useVersion(r, '1.0.0')
     expect(readlinkSync(join(r, 'current'))).toBe(join(r, 'versions', '1.0.0'))
+  })
+  it.skipIf(process.platform !== 'win32')('recovers an interrupted swap before preserving the rollback version', () => {
+    const r = root()
+    install(r, '1.0.0')
+    install(r, '2.0.0')
+    useVersion(r, '1.0.0')
+    renameSync(join(r, 'current'), join(r, 'current.previous'))
+
+    useVersion(r, '2.0.0')
+
+    expect(currentVersion(r)).toBe('2.0.0')
+    expect(readMeta(r).previous).toBe('1.0.0')
   })
   it('records the replaced version as previous (rollback target)', () => {
     const r = root()

--- a/packages/cli/test/version-store.test.ts
+++ b/packages/cli/test/version-store.test.ts
@@ -46,7 +46,8 @@ describe('currentVersion', () => {
   it('reads the basename of the current symlink target', () => {
     const r = root()
     mkdirSync(join(r, 'versions', '1.5.0'), { recursive: true })
-    symlinkSync('versions/1.5.0', join(r, 'current'))
+    if (process.platform === 'win32') symlinkSync(join(r, 'versions', '1.5.0'), join(r, 'current'), 'junction')
+    else symlinkSync('versions/1.5.0', join(r, 'current'))
     expect(currentVersion(r)).toBe('1.5.0')
   })
   it('is null when no current symlink exists', () => {


### PR DESCRIPTION
## Summary

- use Windows directory junctions for the active daemon version pointer, avoiding administrator or Developer Mode symlink requirements
- swap an existing Windows pointer through a recoverable `current.previous` backup and restore it if publication fails
- retain the existing relative symlink + atomic rename behavior on Linux and macOS
- make version-store tests use the native pointer type on Windows

## Tests

- `corepack pnpm --filter '@agentconnect.md/cli' exec vitest run test/version-ops.test.ts test/version-store.test.ts test/version-install.test.ts test/upgrade.test.ts` (31 passed)
- `corepack pnpm --filter '@agentconnect.md/cli' typecheck`
- `git diff --check`

## Manual verification

Recovered `C:\Users\space\.agentconnect\current` as a junction to the installed `1.46.0-rc.11` bundle and verified `current\dist\index.js` resolves.