### PR TITLE
feat(web): notify when agent traffic pauses on an empty billing balance

### DIFF
--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -38,6 +38,7 @@ import { NotificationProvider } from '@/lib/notifications'
 import { NotificationBell, NotificationToastContainer } from './NotificationCenter'
 import { useDaemonNotifier } from '@/lib/daemon-notifications'
 import { useSessionAccessNotifier } from '@/lib/session-access-notifier'
+import { useBillingSuspensionNotifier } from '@/lib/billing-notifications'
 import { MOBILE_NAV, MORE_ROWS, NAV_GROUPS, SECTIONS, navVisible } from './nav'
 
 // Top-level routes own the tab-bar + list app bar (no back button, bottom nav shown);
@@ -338,6 +339,7 @@ function ShellChromeInner({ children }: { children: ReactNode }) {
     useConsoleData()
   useDaemonNotifier(daemons)
   useSessionAccessNotifier({ sessionAccessSnapshot, usageAccessSnapshot, orgPath })
+  useBillingSuspensionNotifier(activeOrg?.id ?? null, orgPath)
   // Mobile-only chrome state: which bottom sheet is open, and the full-screen search.
   const [mobileSheet, setMobileSheet] = useState<'more' | 'org' | null>(null)
   const [mobileSearch, setMobileSearch] = useState(false)

--- a/packages/web/src/lib/billing-notifications.test.ts
+++ b/packages/web/src/lib/billing-notifications.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { BILLING_SUSPENDED_SOURCE_KEY, billingSuspensionNotifications } from '@/lib/billing-notifications'
+import type { BillingAccount } from '@/lib/billing-api'
+
+const orgPath = (path: string) => `/acme${path}`
+
+function account(state: BillingAccount['state'], balanceMicro = 0): BillingAccount {
+  return { orgId: 'org-1', balanceMicro, state }
+}
+
+describe('billingSuspensionNotifications', () => {
+  it('notifies when a funded org is suspended', () => {
+    const items = billingSuspensionNotifications(account('suspended'), true, orgPath)
+    expect(items).toHaveLength(1)
+    expect(items![0]).toMatchObject({
+      category: 'billing',
+      severity: 'error',
+      sourceKey: BILLING_SUSPENDED_SOURCE_KEY,
+      action: { label: 'Add credits', href: '/acme/billing', external: false }
+    })
+  })
+
+  it('resolves once the account is active again', () => {
+    expect(billingSuspensionNotifications(account('active', 5_000_000), null, orgPath)).toEqual([])
+  })
+
+  it('stays silent for a never-funded org (onboarding, not an outage)', () => {
+    expect(billingSuspensionNotifications(account('suspended'), false, orgPath)).toEqual([])
+  })
+
+  it('does not sync while undecidable: no account, unknown state, or unanswered ledger', () => {
+    expect(billingSuspensionNotifications(undefined, true, orgPath)).toBeNull()
+    expect(billingSuspensionNotifications(account('unknown'), true, orgPath)).toBeNull()
+    expect(billingSuspensionNotifications(account('suspended'), null, orgPath)).toBeNull()
+  })
+})

--- a/packages/web/src/lib/billing-notifications.ts
+++ b/packages/web/src/lib/billing-notifications.ts
@@ -45,9 +45,13 @@ export function useBillingSuspensionNotifier(orgId: string | null, orgPath: (pat
     refreshInterval: 60_000
   })
   const suspended = account.data?.state === 'suspended'
-  // The ledger is read only to tell spent-out from never-funded, so only while suspended.
-  const ledger = useSWR(offered && suspended ? consoleKeys.billingTransactions(orgId) : null, () =>
-    fetchBillingTransactions(orgId!)
+  // The ledger tells spent-out from never-funded, so it must stay LIVE while suspended: a
+  // never-funded org can fund and spend out between account polls with both observed states
+  // still 'suspended', and a cached empty ledger would silence exactly the outage this surfaces.
+  const ledger = useSWR(
+    offered && suspended ? consoleKeys.billingTransactions(orgId) : null,
+    () => fetchBillingTransactions(orgId!),
+    { refreshInterval: 60_000 }
   )
   const accountData = account.data
   const hasHistory = ledgerHistory(ledger.data)

--- a/packages/web/src/lib/billing-notifications.ts
+++ b/packages/web/src/lib/billing-notifications.ts
@@ -1,0 +1,60 @@
+'use client'
+
+// Billing suspension → notification center: mirrors `balanceBanner`'s red arm — spent-out orgs notify, never-funded ones don't.
+import { useEffect } from 'react'
+import useSWR from 'swr'
+import { billingBase, fetchBillingAccount, fetchBillingTransactions, type BillingAccount } from '@/lib/billing-api'
+import { ledgerHistory } from '@/lib/billing-banner'
+import { featureFlagEnabled } from '@/lib/feature-flags'
+import { consoleKeys } from '@/lib/swr-keys'
+import { useNotifications, type NotificationSnapshotInput } from '@/lib/notifications'
+
+export const BILLING_SUSPENDED_SOURCE_KEY = 'billing:suspended'
+
+// The billing snapshot for `syncSourceSnapshot`; `null` = undecidable, do not sync — never resolve a real suspension mid-load only to re-add (and re-toast) it.
+export function billingSuspensionNotifications(
+  account: BillingAccount | undefined,
+  hasHistory: boolean | null,
+  orgPath: (path: string) => string
+): NotificationSnapshotInput[] | null {
+  if (!account) return null
+  // 'unknown' is the gateway mid-decision — flapping the notification on it would duplicate history.
+  if (account.state === 'unknown') return null
+  if (account.state !== 'suspended') return []
+  // Only an answered ledger can tell spent-out from never-funded — hold off until it does.
+  if (hasHistory === null) return null
+  if (!hasHistory) return []
+  return [
+    {
+      category: 'billing',
+      severity: 'error',
+      sourceKey: BILLING_SUSPENDED_SOURCE_KEY,
+      title: 'Agent traffic is paused — balance is empty',
+      message:
+        'LLM requests from this org are being rejected at the gateway because the prepaid balance is empty. Adding credits resumes service within a minute.',
+      action: { label: 'Add credits', href: orgPath('/billing'), external: false }
+    }
+  ]
+}
+
+/** Polls the billing account and keeps one suspension notification in sync with it. */
+export function useBillingSuspensionNotifier(orgId: string | null, orgPath: (path: string) => string): void {
+  const { syncSourceSnapshot } = useNotifications()
+  const offered = featureFlagEnabled('billing') && billingBase() !== null && orgId !== null
+  const account = useSWR(offered ? consoleKeys.billingAccount(orgId) : null, () => fetchBillingAccount(orgId!), {
+    refreshInterval: 60_000
+  })
+  const suspended = account.data?.state === 'suspended'
+  // The ledger is read only to tell spent-out from never-funded, so only while suspended.
+  const ledger = useSWR(offered && suspended ? consoleKeys.billingTransactions(orgId) : null, () =>
+    fetchBillingTransactions(orgId!)
+  )
+  const accountData = account.data
+  const hasHistory = ledgerHistory(ledger.data)
+
+  useEffect(() => {
+    if (!offered) return
+    const items = billingSuspensionNotifications(accountData, hasHistory, orgPath)
+    if (items) syncSourceSnapshot('billing', items)
+  }, [offered, accountData, hasHistory, orgPath, syncSourceSnapshot])
+}

--- a/packages/web/src/lib/notifications.tsx
+++ b/packages/web/src/lib/notifications.tsx
@@ -1,14 +1,11 @@
 'use client'
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
-import type {
-  SessionAccessNotificationAction,
-  SessionAccessNotificationInput
-} from '@/lib/session-access-notifications'
+import type { SessionAccessNotificationAction } from '@/lib/session-access-notifications'
 
 export type NotificationSeverity = 'info' | 'success' | 'warning' | 'error'
-export type NotificationCategory = 'daemon_lifecycle' | 'session_retention' | 'session_access'
-export type NotificationSourceScope = 'sessions-access' | 'usage-access'
+export type NotificationCategory = 'daemon_lifecycle' | 'session_retention' | 'session_access' | 'billing'
+export type NotificationSourceScope = 'sessions-access' | 'usage-access' | 'billing'
 
 export interface NotificationItem {
   id: string
@@ -31,6 +28,10 @@ export interface NotificationStoreState {
 }
 
 type AddNotificationInput = Omit<NotificationItem, 'id' | 'timestamp' | 'read'>
+/** A snapshot-synced source item: keyed by `sourceKey` so it can resolve when the condition clears. */
+export type NotificationSnapshotInput = Omit<NotificationItem, 'id' | 'timestamp' | 'read' | 'resolvedAt'> & {
+  sourceKey: string
+}
 type NotificationStorage = Pick<Storage, 'getItem' | 'setItem'>
 
 interface NotificationContextValue {
@@ -38,7 +39,7 @@ interface NotificationContextValue {
   unreadCount: number
   toasts: NotificationItem[]
   addNotification: (item: AddNotificationInput) => void
-  syncSourceSnapshot: (scope: NotificationSourceScope, items: SessionAccessNotificationInput[]) => void
+  syncSourceSnapshot: (scope: NotificationSourceScope, items: NotificationSnapshotInput[]) => void
   markAsRead: (id: string) => void
   markAllAsRead: () => void
   clearAll: () => void
@@ -66,7 +67,8 @@ export function emptyNotificationState(): NotificationStoreState {
     notifications: [],
     activeSources: {
       'sessions-access': [],
-      'usage-access': []
+      'usage-access': [],
+      billing: []
     }
   }
 }
@@ -88,6 +90,9 @@ export function loadNotificationState(orgId?: string | null, storage?: Notificat
           : [],
         'usage-access': Array.isArray(activeRecord['usage-access'])
           ? activeRecord['usage-access'].filter((key): key is string => typeof key === 'string')
+          : [],
+        billing: Array.isArray(activeRecord['billing'])
+          ? activeRecord['billing'].filter((key): key is string => typeof key === 'string')
           : []
       }
     }
@@ -121,7 +126,7 @@ function defaultNotificationId(): string {
 export function syncNotificationSourceSnapshot(
   state: NotificationStoreState,
   scope: NotificationSourceScope,
-  items: SessionAccessNotificationInput[],
+  items: NotificationSnapshotInput[],
   now = new Date().toISOString(),
   makeId: () => string = defaultNotificationId
 ): { state: NotificationStoreState; added: NotificationItem[] } {
@@ -225,7 +230,7 @@ export function NotificationProvider({ orgId, children }: { orgId?: string | nul
     }))
   }, [])
 
-  const syncSourceSnapshot = useCallback((scope: NotificationSourceScope, items: SessionAccessNotificationInput[]) => {
+  const syncSourceSnapshot = useCallback((scope: NotificationSourceScope, items: NotificationSnapshotInput[]) => {
     setProviderState((prev) => {
       const nextKeys = new Set(items.map((item) => item.sourceKey))
       const resolvedKeys = new Set(prev.store.activeSources[scope].filter((key) => !nextKeys.has(key)))


### PR DESCRIPTION
## What

When the billing gateway suspends an org because its prepaid balance is empty, the console's notification center (bell) now shows a standing error notification — "Agent traffic is paused — balance is empty" — with an **Add credits** link to the Billing page. It appears as a toast + history entry on suspension and auto-resolves once credits land and the account is active again.

## Why

The suspension was only visible on the Billing page's own banner; an org whose agents silently stopped taking sessions had no signal anywhere else in the console.

## How

- **`lib/billing-notifications.ts`** — a new snapshot notification source, reusing the existing snapshot machinery (appear / auto-resolve / persistence) that session-access notifications use:
  - `billingSuspensionNotifications()`: pure decision mirroring `balanceBanner`'s red arm. Suspended **and** the ledger has history (genuinely spent out) → one `error` item. Never-funded orgs stay silent — that's onboarding, not an outage. `state: 'unknown'` or an unanswered read returns `null` ("don't sync"), so a mid-load or mid-decision snapshot never resolves a real suspension only to re-add and re-toast it.
  - `useBillingSuspensionNotifier()`: polls the billing account every 60s on the shared `consoleKeys.billingAccount` SWR key (dedupes with BillingView); reads one ledger page only while suspended, to tell spent-out from never-funded. Fully inert when the `billing` feature flag is off or `BILLING_URL` is unset, and fails closed on fetch errors.
- **`lib/notifications.tsx`** — adds `'billing'` to `NotificationCategory` / `NotificationSourceScope`, and generalizes the snapshot-sync input from the session-access-specific type to a new `NotificationSnapshotInput` (the session-access type remains structurally assignable).
- **`components/console/Shell.tsx`** — mounts the notifier alongside the daemon and session-access notifiers, so the notification is visible from any console page.

## Reviewer notes

- The spent-out vs never-funded distinction (and its copy) deliberately follows `lib/billing-banner.ts` so the two surfaces cannot drift on what "suspended" means to a customer.
- Members whose billing reads 403 simply get no notification (SWR error → no sync) — same fail-closed posture as the rest of the console.
- Tests: 4 new cases for the pure decision; full web suite passes (2048 tests), typecheck/lint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)