### PR TITLE
fix(daemon): make workspace swaps Windows-safe

### DIFF
--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -6,12 +6,13 @@ import {
   readdirSync,
   realpathSync,
   renameSync,
-  rmdirSync,
   rmSync,
   statSync,
   writeFileSync
 } from 'node:fs'
+import { rename } from 'node:fs/promises'
 import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
 import {
   gitRepoLabel,
   normalizeGitCloneUrl,
@@ -61,6 +62,9 @@ import { SANDBOX_CHECKOUT_DIR } from '../shim/sandbox-paths.js'
 
 const skillsLog = makeLogger('info')
 const workspaceLog = makeLogger('info')
+const WINDOWS_DIRECTORY_RENAME_RETRIES = 10
+const WINDOWS_DIRECTORY_RENAME_DELAY_MS = 100
+const WINDOWS_TRANSIENT_FS_ERRORS = new Set(['EACCES', 'EBUSY', 'EPERM'])
 
 /**
  * Post-clone skills step (docs/designs/shared-skills.md §6). Installs the agent's
@@ -2113,6 +2117,61 @@ export class WorkspaceManager {
     return removed
   }
 
+  private async renameWorkspaceDirectory(from: string, to: string): Promise<void> {
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await rename(from, to)
+        return
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code
+        if (
+          process.platform !== 'win32' ||
+          code === undefined ||
+          !WINDOWS_TRANSIENT_FS_ERRORS.has(code) ||
+          attempt >= WINDOWS_DIRECTORY_RENAME_RETRIES
+        ) {
+          throw err
+        }
+        await delay(WINDOWS_DIRECTORY_RENAME_DELAY_MS)
+      }
+    }
+  }
+
+  private async publishStagedWorkspace(cwd: string, staged: string, requireEmpty: boolean): Promise<void> {
+    const previous = existsSync(cwd) ? `${cwd}.old-${randomUUID()}` : undefined
+    if (previous !== undefined) {
+      await this.renameWorkspaceDirectory(cwd, previous)
+      if (requireEmpty && readdirSync(previous).length !== 0) {
+        await this.renameWorkspaceDirectory(previous, cwd)
+        throw new Error('workspace changed while conversion was cloning; retry after making it empty')
+      }
+    }
+
+    try {
+      await this.renameWorkspaceDirectory(staged, cwd)
+    } catch (err) {
+      if (previous !== undefined && !existsSync(cwd)) {
+        try {
+          await this.renameWorkspaceDirectory(previous, cwd)
+        } catch (restoreErr) {
+          throw new AggregateError(
+            [err, restoreErr],
+            'workspace publication failed and the previous workspace could not be restored'
+          )
+        }
+      }
+      throw err
+    }
+
+    if (previous !== undefined) {
+      try {
+        rmSync(previous, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+      } catch (err) {
+        workspaceLog.warn(`workspace: could not remove replaced directory "${previous}" (${formatErr(err)})`)
+      }
+    }
+  }
+
   async prepareWorkspaceForActivation(
     agent: Agent,
     {
@@ -2212,8 +2271,7 @@ export class WorkspaceManager {
       this.resolveAcpCwd(staged, normalizeRepoSubdir(agent.workspace.agentDir))
       if (replace) {
         this.clearSessionWorktrees(agent)
-        rmSync(cwd, { recursive: true, force: true })
-        renameSync(staged, cwd)
+        await this.publishStagedWorkspace(cwd, staged, false)
         try {
           this.recordWorkspaceMaterialization(agent)
         } catch (err) {
@@ -2233,18 +2291,7 @@ export class WorkspaceManager {
       if (!this.isWorkspaceEmpty(agent)) {
         throw new Error('workspace changed while conversion was cloning; retry after making it empty')
       }
-      try {
-        // Windows cannot rename over an empty directory, so rmdir proves emptiness before publication.
-        if (process.platform === 'win32' && existsSync(cwd)) rmdirSync(cwd)
-        renameSync(staged, cwd)
-      } catch (err) {
-        if (!this.isWorkspaceEmpty(agent)) {
-          throw new Error('workspace changed while conversion was cloning; retry after making it empty', {
-            cause: err
-          })
-        }
-        throw err
-      }
+      await this.publishStagedWorkspace(cwd, staged, true)
     } catch (err) {
       rmSync(staged, { recursive: true, force: true })
       throw err

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -2154,6 +2154,7 @@ export class WorkspaceManager {
         try {
           await this.renameWorkspaceDirectory(previous, cwd)
         } catch (restoreErr) {
+          mkdirSync(cwd, { recursive: true })
           throw new AggregateError(
             [err, restoreErr],
             'workspace publication failed and the previous workspace could not be restored'

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -14,6 +14,10 @@ import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import type { Agent } from '../src/agents/agent-schema.js'
 
+const { rename: realRename } = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+const renameMock = vi.fn(realRename)
+vi.mock('node:fs/promises', () => ({ rename: renameMock }))
+
 // Mock simple-git so clone/pull don't touch the network. The clone mock is
 // reassignable per test (success / failure / slow) via `cloneImpl`.
 let cloneImpl: (...args: any[]) => Promise<unknown>
@@ -104,6 +108,7 @@ function githubAppAgent(path: string): Agent {
 
 beforeEach(() => {
   cloneImpl = vi.fn().mockResolvedValue(undefined)
+  renameMock.mockReset().mockImplementation(realRename)
   lastGitEnv = undefined
   pullMock.mockClear()
   rawMock.mockReset().mockResolvedValue('')
@@ -702,6 +707,28 @@ describe('prepareWorkspaceForActivation', () => {
     await rollback()
     expect(existsSync(path)).toBe(true)
     expect(readdirSync(path)).toEqual([])
+  })
+
+  it.runIf(process.platform === 'win32')('retries transient Windows directory rename failures', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'ac-ws-convert-'))
+    const path = join(parent, 'workspace')
+    let failed = false
+    renameMock.mockImplementation(async (from, to) => {
+      if (!failed && from === path) {
+        failed = true
+        throw Object.assign(new Error('directory is busy'), { code: 'EPERM' })
+      }
+      await realRename(from, to)
+    })
+    cloneImpl = vi.fn().mockImplementation(async (_repo: string, target: string) => {
+      mkdirSync(join(target, '.git'), { recursive: true })
+    })
+
+    await workspaces.prepareWorkspaceForActivation(gitRepoAgent(path))
+
+    expect(failed).toBe(true)
+    expect(existsSync(join(path, '.git'))).toBe(true)
+    expect(readdirSync(parent).filter((entry) => entry.startsWith('workspace.old-'))).toEqual([])
   })
 
   it('refuses a non-empty scratch directory without starting a clone', async () => {

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -709,9 +709,10 @@ describe('prepareWorkspaceForActivation', () => {
     expect(readdirSync(path)).toEqual([])
   })
 
-  it.runIf(process.platform === 'win32')('retries transient Windows directory rename failures', async () => {
+  it('retries transient Windows directory rename failures', async () => {
     const parent = mkdtempSync(join(tmpdir(), 'ac-ws-convert-'))
     const path = join(parent, 'workspace')
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     let failed = false
     renameMock.mockImplementation(async (from, to) => {
       if (!failed && from === path) {
@@ -724,7 +725,11 @@ describe('prepareWorkspaceForActivation', () => {
       mkdirSync(join(target, '.git'), { recursive: true })
     })
 
-    await workspaces.prepareWorkspaceForActivation(gitRepoAgent(path))
+    try {
+      await workspaces.prepareWorkspaceForActivation(gitRepoAgent(path))
+    } finally {
+      platform.mockRestore()
+    }
 
     expect(failed).toBe(true)
     expect(existsSync(join(path, '.git'))).toBe(true)


### PR DESCRIPTION
## Summary
- publish staged workspaces by first renaming the existing directory to a unique backup path
- retry transient Windows directory rename failures and clean replaced directories with recursive-delete retries
- preserve the empty-directory race check and restore the previous workspace when publication fails
- add a Windows regression test for transient EPERM during activation

## Verification
- corepack pnpm --filter '@agentconnect.md/daemon' exec vitest run test/workspace.test.ts -t 'prepareWorkspaceForActivation' (10 passed)
- corepack pnpm --filter '@agentconnect.md/daemon' typecheck
- corepack pnpm exec eslint packages/daemon/src/workspace/workspace-manager.ts packages/daemon/test/workspace.test.ts

## Windows full-file test note
The complete workspace.test.ts run passes all activation tests, but this local Windows account reports 6 unrelated existing failures: four tests require symlink privilege and two POSIX pod-path expectations use Windows path separators.