### PR TITLE
fix(daemon): archive runtime matrix sessions

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -523,6 +523,7 @@ export class AcpHost {
   // whether the agent accepts repository roots in addition to the session cwd.
   // This is capability-gated because older ACP adapters reject the field.
   private canUseAdditionalDirectories = false
+  private canDelete = false
   // prompt content-block variants the agent opted into at initialize. text +
   // resource_link are always baseline; image/audio/embeddedContext are gated.
   private promptCaps: { image?: boolean; audio?: boolean; embeddedContext?: boolean } = {}
@@ -799,6 +800,7 @@ export class AcpHost {
     this.negotiatedProtocolVersion = init.protocolVersion
     this.canLoad = init.agentCapabilities?.loadSession ?? false
     this.canUseAdditionalDirectories = init.agentCapabilities?.sessionCapabilities?.additionalDirectories != null
+    this.canDelete = init.agentCapabilities?.sessionCapabilities?.delete != null
     this.promptCaps = init.agentCapabilities?.promptCapabilities ?? {}
     const mcp = init.agentCapabilities?.mcpCapabilities
     this.mcpCaps = {
@@ -1117,6 +1119,11 @@ export class AcpHost {
     return this.canLoad
   }
 
+  /** Whether the agent advertised support for ACP session/delete. */
+  deleteSupported(): boolean {
+    return this.canDelete
+  }
+
   /** Resume a previously-created session by id (ACP `session/load`). The agent
    *  restores its own history server-side; replayed conversation/tool output is
    *  suppressed while metadata updates still converge. `mcpServers` must be
@@ -1182,9 +1189,15 @@ export class AcpHost {
     await this.conn!.agent.notify(methods.agent.session.cancel, { sessionId })
   }
 
-  /** Forget a daemon-private session that failed setup before it could be used.
-   * ACP has no portable session/delete method; dropping all local ownership keeps
-   * the host's live/session-config sets bounded until the adapter process exits. */
+  /** Delete persisted adapter state when supported, then release local ownership. */
+  async deleteSession(sessionId: string): Promise<boolean> {
+    if (!this.canDelete) return false
+    await this.conn!.agent.request(methods.agent.session.delete, { sessionId })
+    this.forgetSession(sessionId)
+    return true
+  }
+
+  /** Forget a failed setup locally without deleting persisted adapter state. */
   discardSession(sessionId: string): void {
     this.live.delete(sessionId)
     this.sessionConfigs.delete(sessionId)

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -137,6 +137,21 @@ describe('AcpHost additional workspace directories', () => {
   }, 15_000)
 })
 
+describe('AcpHost session deletion', () => {
+  it('uses session/delete when advertised and releases local ownership', async () => {
+    const host = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: [] },
+      { onUpdate: () => {}, env: { AC_DELETE_SESSION: '1' } }
+    )
+    await host.start()
+    expect(host.deleteSupported()).toBe(true)
+    const sessionId = await host.newSession('/tmp')
+    expect(await host.deleteSession(sessionId)).toBe(true)
+    expect(host.hasSession(sessionId)).toBe(false)
+    await host.stop()
+  }, 15_000)
+})
+
 describe('AcpHost session/load update filtering', () => {
   it('forwards restored title metadata while suppressing replayed conversation output', async () => {
     const updates: string[] = []

--- a/packages/daemon/test/acp-matrix/README.md
+++ b/packages/daemon/test/acp-matrix/README.md
@@ -16,6 +16,9 @@ CI skips this suite. Run it locally with:
 pnpm --filter @agentconnect.md/daemon test:runtime-matrix
 ```
 
+Disposable sessions are removed after each probe when the adapter advertises
+ACP `session/delete`; Codex maps that request to a recoverable thread archive.
+
 To limit a diagnostic rerun:
 
 ```bash

--- a/packages/daemon/test/acp-matrix/acp-matrix.test.ts
+++ b/packages/daemon/test/acp-matrix/acp-matrix.test.ts
@@ -473,7 +473,10 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
             failures.push(error)
           }
         }
-        if (failures.length > 0) throw failures[0]
+        if (failures.length > 0) {
+          const cleanupError = `session cleanup: ${failures.map(turnFailureReason).join('; ')}`
+          result.error = result.error ? `${result.error}; ${cleanupError}` : cleanupError
+        }
       }
     } finally {
       endpoint?.server.close()

--- a/packages/daemon/test/acp-matrix/acp-matrix.test.ts
+++ b/packages/daemon/test/acp-matrix/acp-matrix.test.ts
@@ -43,6 +43,7 @@ interface RuntimeResult {
   reachable: boolean
   features: Partial<Record<FeatureId, Outcome>>
   error?: string
+  cleanupError?: string
   models: string[]
   modes: string[]
   mcp: { http: boolean; sse: boolean }
@@ -475,6 +476,7 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
         }
         if (failures.length > 0) {
           const cleanupError = `session cleanup: ${failures.map(turnFailureReason).join('; ')}`
+          result.cleanupError = cleanupError
           result.error = result.error ? `${result.error}; ${cleanupError}` : cleanupError
         }
       }
@@ -584,11 +586,12 @@ describe.skipIf(IS_CI)('local live ACP runtime support matrix', () => {
         }
       }
 
-      const failures = results.flatMap((result) =>
-        features
+      const failures = results.flatMap((result) => [
+        ...features
           .filter((feature) => result.features[feature]?.status === 'fail')
-          .map((feature) => `${result.id}/${feature}: ${result.features[feature]!.detail}`)
-      )
+          .map((feature) => `${result.id}/${feature}: ${result.features[feature]!.detail}`),
+        ...(result.cleanupError ? [`${result.id}/cleanup: ${result.cleanupError}`] : [])
+      ])
       if (features.includes('lifecycle')) {
         expect(
           results.some((result) => result.features.lifecycle?.status === 'ok'),

--- a/packages/daemon/test/acp-matrix/acp-matrix.test.ts
+++ b/packages/daemon/test/acp-matrix/acp-matrix.test.ts
@@ -230,9 +230,10 @@ async function runSandboxProbe(target: RuntimeTarget, root: string, token: strin
     inheritProcessEnv: composed.launch.inheritProcessEnv,
     sandbox: composed.launch.sandbox
   })
+  let sessionId: string | undefined
   try {
     await withTimeout(host.start(), `${target.id}/sandbox start`)
-    const sessionId = await withTimeout(host.newSession(sandboxCwd), `${target.id}/sandbox session`)
+    sessionId = await withTimeout(host.newSession(sandboxCwd), `${target.id}/sandbox session`)
     await withTimeout(
       host.prompt(sessionId, [{ type: 'text', text: `Reply with exactly ${token} and nothing else.` }]),
       `${target.id}/sandbox prompt`
@@ -242,7 +243,12 @@ async function runSandboxProbe(target: RuntimeTarget, root: string, token: strin
       ? { status: 'ok', detail: `real model turn completed inside ${mechanism}` }
       : { status: 'fail', detail: `sandboxed model reply did not contain ${token}` }
   } finally {
-    await host.stop().catch(() => {})
+    try {
+      if (sessionId && host.deleteSupported())
+        await withTimeout(host.deleteSession(sessionId), `${target.id}/sandbox session delete`)
+    } finally {
+      await host.stop().catch(() => {})
+    }
   }
 }
 
@@ -267,6 +273,11 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
   let permissionRequested = false
   let host: AcpHost | undefined
   let endpoint: ProbeEndpoint | undefined
+  const sessionIds = new Set<string>()
+  const rememberSession = (sessionId: string): string => {
+    sessionIds.add(sessionId)
+    return sessionId
+  }
 
   try {
     const skillInstall = await installProbeSkill(target, root, agentDir, cwd, skillToken).catch((error): Outcome => ({
@@ -288,9 +299,8 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
     result.mcp = host.mcpCapabilities() ?? { http: false, sse: false }
 
     const usesMeta = host.usesMetaSystemPrompt()
-    const sessionId = await withTimeout(
-      host.newSession(cwd, [], undefined, usesMeta ? memoryToken : undefined),
-      `${target.id}/session`
+    const sessionId = rememberSession(
+      await withTimeout(host.newSession(cwd, [], undefined, usesMeta ? memoryToken : undefined), `${target.id}/session`)
     )
     result.models = host.modelOptions()?.models ?? []
     result.modes = host.permissionModeOptions()?.modes ?? []
@@ -351,7 +361,9 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
         url: endpoint.url,
         headers: []
       }
-      const mcpSession = await withTimeout(host.newSession(cwd, [descriptor]), `${target.id}/mcp session`)
+      const mcpSession = rememberSession(
+        await withTimeout(host.newSession(cwd, [descriptor]), `${target.id}/mcp session`)
+      )
       const mcpStart = updates.length
       await withTimeout(
         host.prompt(mcpSession, [
@@ -398,7 +410,9 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
 
     // Keep this independent of the permission-mode switch above: modes such as
     // read-only, plan, or full-access can suppress the permission request itself.
-    const permissionSession = await withTimeout(host.newSession(cwd), `${target.id}/permission session`)
+    const permissionSession = rememberSession(
+      await withTimeout(host.newSession(cwd), `${target.id}/permission session`)
+    )
     permissionRequested = false
     const permissionStart = updates.length
     await withTimeout(
@@ -449,9 +463,23 @@ async function runRuntime(target: RuntimeTarget): Promise<RuntimeResult> {
       result.features[feature] ??= { status, detail: result.error }
     }
   } finally {
-    endpoint?.server.close()
-    await host?.stop().catch(() => {})
-    rmSync(root, { recursive: true, force: true })
+    try {
+      if (host?.deleteSupported()) {
+        const failures: unknown[] = []
+        for (const sessionId of sessionIds) {
+          try {
+            await withTimeout(host.deleteSession(sessionId), `${target.id}/session delete`)
+          } catch (error) {
+            failures.push(error)
+          }
+        }
+        if (failures.length > 0) throw failures[0]
+      }
+    } finally {
+      endpoint?.server.close()
+      await host?.stop().catch(() => {})
+      rmSync(root, { recursive: true, force: true })
+    }
   }
   return result
 }

--- a/packages/daemon/test/fixtures/fake-acp-agent.mjs
+++ b/packages/daemon/test/fixtures/fake-acp-agent.mjs
@@ -29,6 +29,7 @@ const sessionPermissionModes = new Map()
 const reviewerEnabled = process.env.AC_APPROVALS_REVIEWER === '1'
 const sessionReviewers = new Map()
 const additionalDirectoriesEnabled = process.env.AC_ADDITIONAL_DIRECTORIES === '1'
+const deleteSessionEnabled = process.env.AC_DELETE_SESSION === '1'
 const expectedAdditionalDirectories = process.env.AC_EXPECT_ADDITIONAL_DIRECTORIES
   ? JSON.parse(process.env.AC_EXPECT_ADDITIONAL_DIRECTORIES)
   : undefined
@@ -62,7 +63,14 @@ const agentCapabilities = () => ({
       }
     : {}),
   ...(process.env.AC_LOAD_UPDATES ? { loadSession: true } : {}),
-  ...(additionalDirectoriesEnabled ? { sessionCapabilities: { additionalDirectories: {} } } : {})
+  ...(additionalDirectoriesEnabled || deleteSessionEnabled
+    ? {
+        sessionCapabilities: {
+          ...(additionalDirectoriesEnabled ? { additionalDirectories: {} } : {}),
+          ...(deleteSessionEnabled ? { delete: {} } : {})
+        }
+      }
+    : {})
 })
 const configOptions = (sessionId) => {
   const options = []
@@ -154,6 +162,11 @@ rl.on('line', async (line) => {
       })
     }
     send({ jsonrpc: '2.0', id, result: { configOptions: configOptions(params.sessionId) } })
+  } else if (method === 'session/delete') {
+    sessionModels.delete(params.sessionId)
+    sessionPermissionModes.delete(params.sessionId)
+    sessionReviewers.delete(params.sessionId)
+    send({ jsonrpc: '2.0', id, result: {} })
   } else if (method === 'session/prompt') {
     const text = (params.prompt ?? []).map((b) => b.text ?? '').join('')
     // send a session/update notification to the client


### PR DESCRIPTION
## Summary

- expose ACP session deletion through `AcpHost` when the adapter advertises it
- remove disposable runtime-matrix sessions during teardown, including failure paths
- cover the capability with the fake ACP agent and document Codex's recoverable archive behavior

## Testing

- `pnpm --filter @agentconnect.md/daemon exec vitest run test/acp-host.test.ts`
- `pnpm --filter @agentconnect.md/daemon typecheck`
- `pnpm exec eslint packages/daemon/src/acp/acp-host.ts packages/daemon/test/acp-host.test.ts packages/daemon/test/acp-matrix/acp-matrix.test.ts packages/daemon/test/fixtures/fake-acp-agent.mjs`
- pre-push `eslint .`

Created by Codex . gpt-5.6-sol
