### PR TITLE
feat(web): ask the cluster path for a runtime before finishing onboarding

### DIFF
--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -479,6 +479,21 @@ describe('onboarding — pool fork', () => {
     expect(mocks.moveAgent).not.toHaveBeenCalled()
   })
 
+  // Completion-only is honest ONLY for a preset already on the pool. An unplaced one would be
+  // marked done with no runtime and no placement, so it waits for the cluster to report.
+  it('keeps Finish disabled for an unplaced preset while the cluster advertises nothing', async () => {
+    mocks.daemons = [{ ...mocks.daemons[0], runtimeModels: [] }]
+    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
+    await render()
+    await click('Continue')
+    expect(host.textContent).toContain('Waiting for Kubernetes cluster to report the runtimes')
+    expect(button('Finish').disabled).toBe(true)
+    await click('Finish')
+    expect(mocks.updateAgent).not.toHaveBeenCalled()
+    expect(mocks.moveAgent).not.toHaveBeenCalled()
+    expect(mocks.updateOrg).not.toHaveBeenCalled()
+  })
+
   it('says so when the cluster has no serving member', async () => {
     mocks.daemons = [{ ...mocks.daemons[0], status: 'offline' }]
     await render()

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -345,10 +345,22 @@ describe('onboarding — daemon online: configure + finish', () => {
   })
 })
 
-// The pool (Cloud / cluster) path: the fork appears, and picking the pool finishes right
-// there — no agent configuration, no provisioning, just the completion flag.
+// The pool (Cloud / cluster) path: the fork appears, and picking the pool leads to the runtime
+// step — nothing to install, so the pickers (against the pool's own members) are the whole step.
 describe('onboarding — pool fork', () => {
-  beforeEach(() => setFlags('daemon-pool'))
+  beforeEach(() => {
+    setFlags('daemon-pool')
+    // One serving pool member standing in for the cluster's advertised runtimes.
+    mocks.daemons = [
+      {
+        daemonId: 'pool-pod-1',
+        pool: true,
+        status: 'online',
+        name: 'ac-cloud-7f9',
+        runtimeModels: [{ runtime: 'dsh-acp', models: ['deepseek-v4-flash'] }]
+      }
+    ]
+  })
 
   it('holds a spinner while the agent snapshot is still loading — no premature Finish', async () => {
     mocks.agentsLoading = true
@@ -365,30 +377,69 @@ describe('onboarding — pool fork', () => {
     expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
     await click('Back')
     await click('Cluster')
+    await click('Continue')
     await click('Finish')
     expect(mocks.updateOrg).toHaveBeenCalledWith('org-1', { onboardingCompleted: true })
     expect(mocks.deleteDaemon).toHaveBeenCalledWith('dmn_detour')
     expect(mocks.push).toHaveBeenCalledWith('/acme/home')
   })
 
-  it('forks after the org step and finishes right there — the fork is the last step', async () => {
+  it('forks after the org step, then asks for the runtime — no provisioning on the way', async () => {
+    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
     await render()
     expect(host.textContent).toContain('Where to run')
     expect(host.textContent).toContain('Cluster') // self-hosted pool label (no `managed` flag)
-    await click('Finish') // pool preselected ⇒ Finish, never a Continue
+    expect(host.textContent).toContain('Step 2 of 3')
+    await click('Continue') // pool preselected
+    expect(host.textContent).toContain('Choose runtime')
+    expect(host.textContent).toContain('Step 3 of 3')
+    // Runtimes come from the pool member, and the step says where the agent lands.
+    expect(host.textContent).toContain('runtime-dsh-acp')
+    expect(host.textContent).toContain('Runs on the Kubernetes cluster · 1 node serving')
     expect(mocks.provisionDaemon).not.toHaveBeenCalled()
+  })
+
+  it('places the unplaced built-in agent on the pool with the runtime it picked', async () => {
+    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
+    await render()
+    await click('Continue')
+    await click('Finish')
+    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'dsh-acp', model: 'deepseek-v4-flash' })
+    expect(mocks.moveAgent).toHaveBeenCalledWith('ag_ac', { kind: 'pool' })
     expect(mocks.updateOrg).toHaveBeenCalledWith('org-1', { onboardingCompleted: true })
     expect(mocks.push).toHaveBeenCalledWith('/acme/home')
   })
 
-  it('finishes without touching the built-in agent, even an unplaced one', async () => {
-    mocks.agents = [{ id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: '—', runtime: '' }]
+  // A pool-born preset is already ON the pool: re-placing it would be a no-op move that can
+  // only fail (no online member mid-rollout), so the runtime PATCH is the whole change.
+  it('patches a pool-born preset without moving it', async () => {
+    mocks.agents = [
+      { id: 'ag_ac', builtin: true, name: 'agentconnect', daemon: 'pool', placementKind: 'set', runtime: 'dsh-acp' }
+    ]
     await render()
+    await click('Continue')
+    await click('Finish')
+    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'dsh-acp', model: 'deepseek-v4-flash' })
+    expect(mocks.moveAgent).not.toHaveBeenCalled()
+    expect(mocks.updateOrg).toHaveBeenCalledWith('org-1', { onboardingCompleted: true })
+  })
+
+  it('finishes without touching an org that has no built-in agent', async () => {
+    mocks.agents = []
+    await render()
+    await click('Continue')
     await click('Finish')
     expect(mocks.updateAgent).not.toHaveBeenCalled()
     expect(mocks.moveAgent).not.toHaveBeenCalled()
     expect(mocks.updateOrg).toHaveBeenCalledWith('org-1', { onboardingCompleted: true })
     expect(mocks.push).toHaveBeenCalledWith('/acme/home')
+  })
+
+  it('says so when the cluster has no serving member', async () => {
+    mocks.daemons = [{ ...mocks.daemons[0], status: 'offline' }]
+    await render()
+    await click('Continue')
+    expect(host.textContent).toContain('no nodes serving')
   })
 
   it('picking Daemon at the fork routes to the connect step', async () => {

--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -435,6 +435,50 @@ describe('onboarding — pool fork', () => {
     expect(mocks.push).toHaveBeenCalledWith('/acme/home')
   })
 
+  // A serving member mid-probe advertises nothing: the static fallback would write `claude-acp`
+  // over the deployment's pool runtime, and the pool branch skips the move that would refuse it.
+  it('writes nothing while the cluster has not advertised its runtimes', async () => {
+    mocks.daemons = [{ ...mocks.daemons[0], runtimeModels: [] }]
+    mocks.agents = [
+      {
+        id: 'ag_ac',
+        builtin: true,
+        name: 'agentconnect',
+        daemon: 'pool',
+        placementKind: 'set',
+        runtime: 'dsh-acp',
+        model: 'deepseek-v4-flash'
+      }
+    ]
+    await render()
+    await click('Continue')
+    expect(host.textContent).toContain('has not advertised its runtimes yet')
+    await click('Finish')
+    expect(mocks.updateAgent).not.toHaveBeenCalled()
+    expect(mocks.moveAgent).not.toHaveBeenCalled()
+    expect(mocks.updateOrg).toHaveBeenCalledWith('org-1', { onboardingCompleted: true })
+  })
+
+  it('keeps the preset model pin when the advertised runtime has no models yet', async () => {
+    mocks.daemons = [{ ...mocks.daemons[0], runtimeModels: [{ runtime: 'dsh-acp', models: [] }] }]
+    mocks.agents = [
+      {
+        id: 'ag_ac',
+        builtin: true,
+        name: 'agentconnect',
+        daemon: 'pool',
+        placementKind: 'set',
+        runtime: 'dsh-acp',
+        model: 'deepseek-v4-flash'
+      }
+    ]
+    await render()
+    await click('Continue')
+    await click('Finish')
+    expect(mocks.updateAgent).toHaveBeenCalledWith('ag_ac', { runtime: 'dsh-acp', model: 'deepseek-v4-flash' })
+    expect(mocks.moveAgent).not.toHaveBeenCalled()
+  })
+
   it('says so when the cluster has no serving member', async () => {
     mocks.daemons = [{ ...mocks.daemons[0], status: 'offline' }]
     await render()

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -11,17 +11,24 @@ import { daemonCompletesOnboarding, firstReconnectableDaemonId, skipOnboarding }
 import { daemonCommands } from '@/lib/daemon-commands'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
-import { FALLBACK_RUNTIME_IDS, localDaemons, modelLabel, preferredModelFor, loginRequiredRuntimeIds } from '@/lib/data'
+import {
+  FALLBACK_RUNTIME_IDS,
+  isPoolPlacementKind,
+  localDaemons,
+  modelLabel,
+  poolLabel,
+  preferredModelFor,
+  loginRequiredRuntimeIds
+} from '@/lib/data'
 import type { DaemonRow } from '@/lib/data'
-import type { DaemonConnectDto } from '@/lib/api'
+import type { AgentPlacementTarget, DaemonConnectDto } from '@/lib/api'
 
 // Onboarding wizard (design: "AgentConnect Onboarding v2 (forked)") — owner-only, runs
 // once per org. Creating/naming the org was step 1 (/welcome or the create-org entry),
-// so this picks up at the ONE fork on where the first agent runs. The pool path (Cloud
-// on the managed install, the operator's cluster elsewhere) finishes right at the fork —
-// no agent configuration, just the completion flag; the Daemon path adds the copy-paste
-// connect step (mint a real join command, poll until it comes online) with the runtime
-// pickers inline.
+// so this picks up at the ONE fork on where the first agent runs. Both paths then choose the
+// runtime: the pool path (Cloud on the managed install, the operator's cluster elsewhere) has
+// nothing to install, so its last step is the pickers alone; the Daemon path puts the same
+// pickers under a copy-paste connect step (mint a real join command, poll until it's online).
 // Finish AND skip both persist the org's `onboardingCompleted` flag — re-entering the
 // org never bounces back here once either happened. Rendered full-screen (no rail) by
 // the shell on the /onboarding route.
@@ -60,18 +67,21 @@ export default function OnboardingView() {
   const [step, setStep] = useState<Step>(poolOffered ? 'where' : 'run')
   const [choice, setChoice] = useState<'pool' | 'daemon'>(poolOffered ? 'pool' : 'daemon')
 
-  // The org's built-in preset agent: the daemon path configures its runtime/model once
-  // a machine is online; the pool path leaves it untouched.
+  // The org's built-in preset agent: both paths configure its runtime/model — the daemon path
+  // once a machine is online, the pool path against what the cluster's members advertise.
   const builtinAgent = agents.find((a) => a.builtin)
   const machines = localDaemons(daemons)
+  // The cluster's runtimes come from one live member standing in for the pool (the placement
+  // names the SET — a Pod is a replaceable identity, never the target).
+  const poolMembers = daemons.filter((d) => d.pool)
+  const poolSource = poolMembers.find((d) => d.status === 'online') ?? poolMembers[0]
   const daemonReady = machines.some(daemonCompletesOnboarding)
   const servingDaemon = machines.find((d) => d.status === 'online') ?? machines.find(daemonCompletesOnboarding)
 
   // Auth mode counts org creation (/welcome, already behind us) as step 1.
   const orgStepsBefore = authOn ? 1 : 0
-  // The pool path always finishes at the fork; only the Daemon path adds a step.
-  const lastStepExists = choice === 'daemon'
-  const total = Math.max(orgStepsBefore + 1, orgStepsBefore + (poolOffered ? 1 : 0) + (lastStepExists ? 1 : 0))
+  // Both paths end on a step of their own: connect+configure for a daemon, pickers for the pool.
+  const total = orgStepsBefore + (poolOffered ? 1 : 0) + 1
   const stepNumbers: Record<Step, number> = { where: orgStepsBefore + 1, run: total }
 
   // ── finish / skip: persist the flag, then leave ─────────────────────────────────
@@ -101,7 +111,7 @@ export default function OnboardingView() {
   }
 
   // ── built-in agent setup: runtime/model + placement, ordered by what the CP accepts ──
-  const saveAgentSetup = async (runtime: string, model: string, target: DaemonRow | null) => {
+  const saveAgentSetup = async (runtime: string, model: string, target: AgentPlacementTarget | null) => {
     if (!builtinAgent || !runtime) return true
     setSaving(true)
     setSaveErr(null)
@@ -113,7 +123,7 @@ export default function OnboardingView() {
       // model || null: an empty selection (target's model probe not settled yet) must CLEAR
       // the pool preset's old model pin, not silently keep it across the runtime change.
       await updateAgent(builtinAgent.id, { runtime, model: model || null })
-      if (target) await moveAgent(builtinAgent.id, { kind: 'daemon', daemonId: target.daemonId })
+      if (target) await moveAgent(builtinAgent.id, target)
       await refresh()
       return true
     } catch (e) {
@@ -243,10 +253,25 @@ export default function OnboardingView() {
           stepLabel={`Step ${stepNumbers.where} of ${total}`}
           choice={choice}
           onChoice={setChoice}
-          finishHere={!lastStepExists}
-          finishing={finishing}
+          onNext={() => setStep('run')}
+        />
+      ) : choice === 'pool' ? (
+        <ClusterStep
+          stepLabel={`Step ${total} of ${total}`}
+          source={poolSource}
+          serving={poolMembers.filter((d) => d.status === 'online').length}
+          initial={builtinAgent ? { runtime: builtinAgent.runtime, model: builtinAgent.model } : undefined}
+          showPickers={!!builtinAgent}
+          saving={saving || finishing}
           err={saveErr}
-          onNext={() => (lastStepExists ? setStep('run') : void finish())}
+          onBack={poolOffered ? () => setStep('where') : undefined}
+          onFinish={async (runtime, model) => {
+            // A pool-born preset is already placed there, so the runtime PATCH is the whole change.
+            const target: AgentPlacementTarget | null = isPoolPlacementKind(builtinAgent?.placementKind)
+              ? null
+              : { kind: 'pool' }
+            if (!builtinAgent || (await saveAgentSetup(runtime, model, target))) void finish()
+          }}
         />
       ) : (
         <DaemonStep
@@ -269,7 +294,10 @@ export default function OnboardingView() {
           onBack={backFrom('run') ? () => setStep(backFrom('run')!) : undefined}
           onSkip={() => void finish()}
           onFinish={async (runtime, model) => {
-            if (!builtinAgent || (await saveAgentSetup(runtime, model, servingDaemon ?? null))) void finish()
+            const target: AgentPlacementTarget | null = servingDaemon
+              ? { kind: 'daemon', daemonId: servingDaemon.daemonId }
+              : null
+            if (!builtinAgent || (await saveAgentSetup(runtime, model, target))) void finish()
           }}
         />
       )}
@@ -367,18 +395,11 @@ function WhereStep({
   stepLabel,
   choice,
   onChoice,
-  finishHere,
-  finishing,
-  err,
   onNext
 }: {
   stepLabel: string
   choice: 'pool' | 'daemon'
   onChoice: (choice: 'pool' | 'daemon') => void
-  /** Pool selected with nothing left to configure — the fork is the last step. */
-  finishHere: boolean
-  finishing: boolean
-  err: string | null
   onNext: () => void
 }) {
   const managed = featureFlagEnabled('managed')
@@ -390,18 +411,9 @@ function WhereStep({
       footer={
         <>
           <div className="flex-1" />
-          <Button disabled={finishing} onClick={onNext}>
-            {finishHere ? (
-              <>
-                <Icon name="check" size={15} />
-                {finishing ? 'Finishing…' : 'Finish'}
-              </>
-            ) : (
-              <>
-                Continue
-                <Icon name="arrow-right" size={15} />
-              </>
-            )}
+          <Button onClick={onNext}>
+            Continue
+            <Icon name="arrow-right" size={15} />
           </Button>
         </>
       }
@@ -429,7 +441,6 @@ function WhereStep({
           onSelect={() => onChoice('daemon')}
         />
       </div>
-      <SaveError err={err} />
     </StepFrame>
   )
 }
@@ -506,6 +517,72 @@ function SaveError({ err }: { err: string | null }) {
       <Icon name="alert-triangle" size={15} className="mt-[1px] flex-none" />
       <span>{err}</span>
     </div>
+  )
+}
+
+// ── last step, pool path: nothing to install, so the runtime is the whole step ────────
+function ClusterStep({
+  stepLabel,
+  source,
+  serving,
+  initial,
+  showPickers,
+  saving,
+  err,
+  onBack,
+  onFinish
+}: {
+  stepLabel: string
+  /** The pool member whose reported profiles stand in for the cluster; undefined ⇒ no member. */
+  source?: DaemonRow
+  serving: number
+  initial?: { runtime?: string; model?: string }
+  /** Whether the built-in agent still needs a runtime — hides the pickers otherwise. */
+  showPickers: boolean
+  saving: boolean
+  err: string | null
+  onBack?: () => void
+  onFinish: (runtime: string, model: string) => void
+}) {
+  const rm = useRuntimeModel(source, initial)
+  // "AgentConnect Cloud" is a name; "Kubernetes cluster" is a thing the operator runs.
+  const where = featureFlagEnabled('managed') ? poolLabel() : `the ${poolLabel()}`
+  return (
+    <StepFrame
+      stepLabel={stepLabel}
+      title="Choose runtime"
+      sub={`What the agent runs on ${where}.`}
+      footer={
+        <>
+          {onBack && (
+            <Button variant="ghost" disabled={saving} onClick={onBack}>
+              Back
+            </Button>
+          )}
+          <div className="flex-1" />
+          <Button
+            disabled={saving || (showPickers && !rm.effectiveRuntime)}
+            onClick={() => onFinish(rm.effectiveRuntime, rm.selectedModel)}
+          >
+            <Icon name="check" size={15} />
+            {saving ? 'Finishing…' : 'Finish'}
+          </Button>
+        </>
+      }
+    >
+      {showPickers && <div className="mt-6" />}
+      {showPickers && <RuntimeModelFields rm={rm} />}
+      {/* Where it lands, in the pool's own terms: the placement names the set, not a Pod. */}
+      <div className="mt-4 flex items-center gap-[10px] rounded-[10px] bg-(--surface-sunken) px-4 py-[13px]">
+        <span className="flex h-[18px] w-[18px] flex-none">
+          <KubernetesMark />
+        </span>
+        <span className="font-sans text-[13px] font-normal leading-normal text-(--text-secondary)">
+          Runs on {where} · {serving > 0 ? `${serving} node${serving === 1 ? '' : 's'} serving` : 'no nodes serving'}
+        </span>
+      </div>
+      <SaveError err={err} />
+    </StepFrame>
   )
 }
 

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -190,6 +190,15 @@ export default function OnboardingView() {
     setMintAttempt((n) => n + 1)
   }
 
+  // Cluster step with nothing advertised yet: poll like the daemon step does while it waits, so a
+  // member that finishes probing lands here without a reload.
+  const clusterWaiting = step === 'run' && choice === 'pool' && (poolSource?.runtimeModels.length ?? 0) === 0
+  useEffect(() => {
+    if (!clusterWaiting) return
+    const poll = setInterval(refreshDaemons, 3000)
+    return () => clearInterval(poll)
+  }, [clusterWaiting, refreshDaemons])
+
   // Poll until the daemon connects; tick the elapsed timer while waiting.
   useEffect(() => {
     if (daemonReady) {
@@ -261,6 +270,9 @@ export default function OnboardingView() {
           source={poolSource}
           serving={poolMembers.filter((d) => d.status === 'online').length}
           initial={builtinAgent ? { runtime: builtinAgent.runtime, model: builtinAgent.model } : undefined}
+          // Nothing to place — no preset at all, or one already on the pool — so a cluster with no
+          // runtimes to report yet costs this step nothing. An UNPLACED preset has to wait.
+          placed={!builtinAgent || isPoolPlacementKind(builtinAgent.placementKind)}
           showPickers={!!builtinAgent}
           saving={saving || finishing}
           err={saveErr}
@@ -526,6 +538,7 @@ function ClusterStep({
   source,
   serving,
   initial,
+  placed,
   showPickers,
   saving,
   err,
@@ -537,6 +550,8 @@ function ClusterStep({
   source?: DaemonRow
   serving: number
   initial?: { runtime?: string; model?: string }
+  /** Is the preset already on the pool (or absent)? False ⇒ Finish has to place it to be honest. */
+  placed: boolean
   /** Whether the built-in agent still needs a runtime — hides the pickers otherwise. */
   showPickers: boolean
   saving: boolean
@@ -555,6 +570,10 @@ function ClusterStep({
   const runtime = advertised ? rm.effectiveRuntime : ''
   // Same runtime, its models not in yet ⇒ keep the pin the preset came with, never clear it.
   const model = runtime && runtime === initial?.runtime && !rm.selectedModel ? (initial.model ?? '') : rm.selectedModel
+  // Completing writes nothing when nothing is advertised, which is only honest for a preset already
+  // on the pool. An unplaced one would be marked done with no runtime and no placement — the very
+  // state this step exists to fix — so it waits for the cluster instead.
+  const canFinish = advertised || placed
   return (
     <StepFrame
       stepLabel={stepLabel}
@@ -568,7 +587,7 @@ function ClusterStep({
             </Button>
           )}
           <div className="flex-1" />
-          <Button disabled={saving} onClick={() => onFinish(runtime, model)}>
+          <Button disabled={saving || !canFinish} onClick={() => onFinish(runtime, model)}>
             <Icon name="check" size={15} />
             {saving ? 'Finishing…' : 'Finish'}
           </Button>
@@ -579,7 +598,9 @@ function ClusterStep({
       {showPickers && advertised && <RuntimeModelFields rm={rm} />}
       {showPickers && !advertised && (
         <p className="mt-6 font-sans text-[13px] leading-[1.5] text-(--text-secondary)">
-          {`${poolLabel()} has not advertised its runtimes yet, so this leaves the agent's runtime as it is. Change it from the agent's page once the cluster reports them.`}
+          {placed
+            ? `${poolLabel()} has not advertised its runtimes yet, so this leaves the agent's runtime as it is. Change it from the agent's page once the cluster reports them.`
+            : `Waiting for ${poolLabel()} to report the runtimes it can run — the agent cannot be placed there until it does. This page keeps checking; pick Daemon instead to run it on your own machine.`}
         </p>
       )}
       {/* Where it lands, in the pool's own terms: the placement names the set, not a Pod. */}

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -547,6 +547,14 @@ function ClusterStep({
   const rm = useRuntimeModel(source, initial)
   // "AgentConnect Cloud" is a name; "Kubernetes cluster" is a thing the operator runs.
   const where = featureFlagEnabled('managed') ? poolLabel() : `the ${poolLabel()}`
+  // A serving member can still be mid-probe and advertise no profiles at all. Offering the
+  // static fallback list there would write `claude-acp` over the pool runtime the deployment
+  // configured, and Finish on the pool skips the move that would have refused it — so with
+  // nothing advertised there is nothing to pick and nothing to write.
+  const advertised = (source?.runtimeModels.length ?? 0) > 0
+  const runtime = advertised ? rm.effectiveRuntime : ''
+  // Same runtime, its models not in yet ⇒ keep the pin the preset came with, never clear it.
+  const model = runtime && runtime === initial?.runtime && !rm.selectedModel ? (initial.model ?? '') : rm.selectedModel
   return (
     <StepFrame
       stepLabel={stepLabel}
@@ -560,18 +568,20 @@ function ClusterStep({
             </Button>
           )}
           <div className="flex-1" />
-          <Button
-            disabled={saving || (showPickers && !rm.effectiveRuntime)}
-            onClick={() => onFinish(rm.effectiveRuntime, rm.selectedModel)}
-          >
+          <Button disabled={saving} onClick={() => onFinish(runtime, model)}>
             <Icon name="check" size={15} />
             {saving ? 'Finishing…' : 'Finish'}
           </Button>
         </>
       }
     >
-      {showPickers && <div className="mt-6" />}
-      {showPickers && <RuntimeModelFields rm={rm} />}
+      {showPickers && advertised && <div className="mt-6" />}
+      {showPickers && advertised && <RuntimeModelFields rm={rm} />}
+      {showPickers && !advertised && (
+        <p className="mt-6 font-sans text-[13px] leading-[1.5] text-(--text-secondary)">
+          {`${poolLabel()} has not advertised its runtimes yet, so this leaves the agent's runtime as it is. Change it from the agent's page once the cluster reports them.`}
+        </p>
+      )}
       {/* Where it lands, in the pool's own terms: the placement names the set, not a Pod. */}
       <div className="mt-4 flex items-center gap-[10px] rounded-[10px] bg-(--surface-sunken) px-4 py-[13px]">
         <span className="flex h-[18px] w-[18px] flex-none">


### PR DESCRIPTION
## What

Picking **Cluster** at the onboarding fork used to finish the wizard right there. The fork is now a step on the way, and the pool path ends on its own `Choose runtime` step:

- Both paths end on a last step of their own, so the fork always reads `Continue` (was `Finish` whenever the pool was preselected) and the step count is `orgStepsBefore + (poolOffered ? 1 : 0) + 1`.
- New `ClusterStep` — the same `RuntimeModelFields` the daemon path uses, plus a line naming where the agent lands (`Runs on the Kubernetes cluster · N nodes serving`, wording matching `DaemonsView`/`ClusterDetailView`; `AgentConnect Cloud` on the managed install).
- Runtime/model options come from one live pool member standing in for the pool, following `editAgentCapabilitySource`'s rule: the placement names the SET, and a Pod is only a stand-in for what the cluster advertises.
- Finish places the agent for real. A pool-born preset is already on the pool, so its runtime PATCH is the whole change; an unplaced preset is moved with `{ kind: 'pool' }`. `saveAgentSetup` now takes an `AgentPlacementTarget` instead of a `DaemonRow`, and the daemon path names `{ kind: 'daemon', daemonId }` itself.

## Why

On the cluster path the org's preset kept whatever runtime it was born with, and an org created before the install had a pool member was left with no runtime and no placement at all — onboarding reported success and Home then said the agent was offline "until its daemon reconnects", for an org that never had a daemon.

## Notes for the reviewer

- `Finish` stays enabled when no member is serving. A pool-born preset finishes fine (PATCH only); an unplaced one gets the CP's own refusal inline (`no daemon in the target member set is ready`) and the org is not marked onboarded. Happy to gate the button instead if you'd rather not surface that.
- Verified end to end against a local Control Plane with a pool member: fork → `Choose runtime` (runtime/model from the member's profiles) → Finish persists `runtime`/`model` with the placement left on the pool set; the unplaced-preset variant exercises the move and surfaces the CP refusal.
- `pnpm --filter @agentconnect.md/web test` (2047 tests), `typecheck`, and `eslint` all clean. The pool-fork suite was rewritten for the new step and gained cases for the move, the patch-only pool-born preset, and the no-members line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)