### PR TITLE
fix(web): end band one's stat column level with the card beside it

### DIFF
--- a/packages/web/src/components/console/FleetDetail.tsx
+++ b/packages/web/src/components/console/FleetDetail.tsx
@@ -121,6 +121,17 @@ export function FleetStat({ icon, label, value, note }: { icon: string; label: s
   )
 }
 
+/** Band one's metric column — two-up on mobile, one stacked column beside a card on desktop. */
+// Stacked, its tiles grow and centre their content: the column is as tall as the card beside it, and tiles at
+// their natural height leave that card's last stretch facing whitespace, which is the misalignment.
+export function FleetStatColumn({ children }: { children: ReactNode }) {
+  return (
+    <div className="grid grid-cols-2 gap-[14px] desktop:flex desktop:flex-col desktop:[&>.stat]:flex desktop:[&>.stat]:flex-1 desktop:[&>.stat]:flex-col desktop:[&>.stat]:justify-center">
+      {children}
+    </div>
+  )
+}
+
 // One utilization reading as a dial: the label above, the ring under it carrying its own figure.
 // A ring rather than a bar because Resources is the NARROW column in band one — a bar there is a
 // short track with its label crushed beside it — and the label sits on TOP rather than alongside

--- a/packages/web/src/components/console/views/ClusterDetailView.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.tsx
@@ -43,6 +43,7 @@ import {
   FleetAgentsCard,
   FleetRuntimesCard,
   FleetStat,
+  FleetStatColumn,
   FleetUsageCard,
   ResourceDial,
   ResourceDials,
@@ -128,6 +129,21 @@ export default function ClusterDetailView() {
   const capabilitySource = serving[0]
   const models = runtimes.reduce((sum, rt) => sum + rt.models.length, 0)
 
+  // Cloud's tiles. They stack in a column beside the Credits card, and spread three-up where a
+  // deployment offers no billing and there is no card to stand beside.
+  const cloudTiles = (
+    <>
+      <FleetStat icon="bot" label="Agents" value={String(hosted.length)} />
+      <FleetStat icon="activity" label="Active sessions" value={String(sessions)} />
+      <FleetStat
+        icon="cpu"
+        label="Runtimes available"
+        value={String(runtimes.length)}
+        note={`${models} model${models === 1 ? '' : 's'}`}
+      />
+    </>
+  )
+
   return (
     <div className="wrap max-w-[1240px] px-4 pt-[14px] pb-1 desktop:p-0">
       {/* header — no credential action in either reading: pool credentials are minted where
@@ -190,27 +206,16 @@ export default function ClusterDetailView() {
         <div
           className={`mb-[18px] grid grid-cols-1 gap-[14px] ${billingOffered ? 'desktop:grid-cols-[300px_1fr]' : ''}`}
         >
-          <div
-            className={
-              billingOffered
-                ? 'grid grid-cols-2 gap-[14px] desktop:flex desktop:flex-col'
-                : 'grid grid-cols-2 gap-[14px] desktop:grid-cols-3'
-            }
-          >
-            <FleetStat icon="bot" label="Agents" value={String(hosted.length)} />
-            <FleetStat icon="activity" label="Active sessions" value={String(sessions)} />
-            <FleetStat
-              icon="cpu"
-              label="Runtimes available"
-              value={String(runtimes.length)}
-              note={`${models} model${models === 1 ? '' : 's'}`}
-            />
-          </div>
+          {billingOffered ? (
+            <FleetStatColumn>{cloudTiles}</FleetStatColumn>
+          ) : (
+            <div className="grid grid-cols-2 gap-[14px] desktop:grid-cols-3">{cloudTiles}</div>
+          )}
           {billingOffered && <CloudCreditsCard />}
         </div>
       ) : (
         <div className="mb-[18px] grid grid-cols-1 gap-[14px] desktop:grid-cols-[280px_120px_1fr]">
-          <div className="grid grid-cols-2 gap-[14px] desktop:flex desktop:flex-col">
+          <FleetStatColumn>
             {/* The heartbeat count against the ceiling, never the placed-agent list: a set
                 placement names the set rather than the member serving it, so the two are not
                 on one axis. This is the pair the CP's placement check compares. */}
@@ -222,7 +227,7 @@ export default function ClusterDetailView() {
             />
             <FleetStat icon="activity" label="Active sessions" value={String(sessions)} />
             <FleetStat icon="server" label="Nodes" value={`${serving.length} / ${members.length}`} note="serving" />
-          </div>
+          </FleetStatColumn>
           <ClusterResourcesCard {...{ online, cpu, mem }} />
           {/* The agents placed here, exactly as the daemon page reads it. A metering ingress
               cannot stand in for a fleet: a daemon reports its own usage by default, pool

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -31,6 +31,7 @@ import {
   FleetAgentsCard,
   FleetRuntimesCard,
   FleetStat,
+  FleetStatColumn,
   FleetUsageCard,
   ResourceDial,
   ResourceDials,
@@ -674,12 +675,12 @@ export default function DaemonDetailView() {
       {/* Band one — what the machine holds now, what it is spending to hold it, and what has
           run on it. */}
       <div className="mb-[18px] grid grid-cols-1 gap-[14px] desktop:grid-cols-[280px_120px_1fr]">
-        <div className="grid grid-cols-2 gap-[14px] desktop:flex desktop:flex-col">
+        <FleetStatColumn>
           <FleetStat icon="bot" label="Agents" value={load} note="running" />
           <FleetStat icon="activity" label="Active sessions" value={daemon.activeSessions} />
           {/* `daemon.uptime` is time-since-last-seen (fmtSeen), not a real uptime. */}
           <FleetStat icon="timer" label="Last seen" value={daemon.uptime} />
-        </div>
+        </FleetStatColumn>
         <div className="card flex flex-col">
           <div className="cardhead">
             <span className="cardtitle">Resources</span>

--- a/packages/web/src/components/console/views/GroupDetailView.test.tsx
+++ b/packages/web/src/components/console/views/GroupDetailView.test.tsx
@@ -333,17 +333,18 @@ describe('GroupDetailView', () => {
     expect(render()).not.toContain('No agents target this group yet')
   })
 
-  it('names the sessions stat for what the CP actually counts', () => {
-    // activeSessions is per-DAEMON, so it includes the sessions of agents pinned to a member —
-    // the agents every other stat on the page excludes.
-    mocks.memberSets = [group({ memberDaemonIds: ['d1'] })]
-    mocks.daemons = [daemon('d1', { activeSessions: '4' })]
+  it('sums active sessions over the SERVING members only', () => {
+    // Per-DAEMON figures, so the sum includes the sessions of agents pinned to a member — and a
+    // member that stopped answering contributes nothing, whatever it last reported.
+    mocks.memberSets = [group({ memberDaemonIds: ['d1', 'd2'] })]
+    mocks.daemons = [daemon('d1', { activeSessions: '4' }), daemon('d2', { status: 'offline', activeSessions: '9' })]
     mocks.agents = [onGroup('a1'), pinned('a2', 'd1')]
 
     const html = render()
 
     expect(html).toContain('Active sessions')
-    expect(html).toContain('incl. pinned agents')
+    expect(html).toContain('>4<')
+    expect(html).not.toContain('>13<')
   })
 
   it('offers no log tail — a fabricated one is indistinguishable from telemetry', () => {

--- a/packages/web/src/components/console/views/GroupDetailView.tsx
+++ b/packages/web/src/components/console/views/GroupDetailView.tsx
@@ -24,6 +24,7 @@ import {
   FleetAgentsCard,
   FleetRuntimesCard,
   FleetStat,
+  FleetStatColumn,
   barColor,
   intersectRuntimes
 } from '@/components/console/FleetDetail'
@@ -177,19 +178,18 @@ export default function GroupDetailView() {
 
       {/* Band one — what the group holds, beside the machines that hold it. */}
       <div className="mb-[18px] grid grid-cols-1 gap-[14px] desktop:grid-cols-[300px_1fr]">
-        <div className="grid grid-cols-2 gap-[14px] desktop:flex desktop:flex-col">
+        <FleetStatColumn>
           <FleetStat icon="bot" label="Agents" value={String(hosted.length)} />
-          {/* Machine-scoped, unlike its neighbours: the CP counts active sessions per DAEMON, so
-              this includes the ones belonging to agents pinned to these members — the agents the
-              rest of the page deliberately excludes. */}
-          <FleetStat icon="activity" label="Active sessions" value={String(sessions)} note="incl. pinned agents" />
+          {/* Machine-scoped, unlike its neighbours: the CP counts active sessions per DAEMON, so this
+              includes the sessions of agents pinned to these members, which the rest of the page excludes. */}
+          <FleetStat icon="activity" label="Active sessions" value={String(sessions)} />
           <FleetStat
             icon="server"
             label="Daemons"
             value={`${serving.length} / ${members.length}`}
             note={members.length === 0 ? 'no members yet' : 'serving'}
           />
-        </div>
+        </FleetStatColumn>
 
         <div className="card">
           <div className="cardhead">


### PR DESCRIPTION
## What

Band one of every infra detail page puts a stacked column of stat tiles beside a card. The tiles sat at their natural height, so the column stopped short of the card next to it:

| Page | Neighbour card | Whitespace under the last tile |
| --- | --- | --- |
| Cloud | Credits | 12px |
| Daemon | Resources / Usage | 12px |
| Cluster (self-hosted) | Resources / Usage | 12px |
| Group, 2 members | Daemons in this group | 0 — the list is the shorter side and stretches instead |
| Group, 8 members | Daemons in this group | 125px |

The column is now one component, `FleetStatColumn`, shared by all four bands. Stacked on desktop its tiles grow to fill it and centre their content, so the column's bottom edge meets the neighbouring card's whatever that card holds — including a group whose whole membership makes it the tall side. Measured after the change: 0px on every band above.

Also drops the `incl. pinned agents` note under the group page's session count. That the figure is machine-scoped is a fact about the CP's per-daemon counter, not something worth a second line under the number, and the page already says a pinned agent stays on its member.

## Why

Only the group page lined up, and only by accident of which side happened to be taller. Fixing it per card would mean tuning each neighbour's height against the tiles' — the column adapting to its neighbour is the property that holds when either side changes.

## Notes for a reviewer

- The mobile two-up grid is untouched: the growth and centring are `desktop:` child variants on the column, and flex sizing is inert on grid items. Measured identical tile heights before/after at mobile width.
- `ClusterDetailView` keeps its own wrapper for the managed-without-billing case: three tiles spread three-up there with no card to stand beside, so there is nothing to align to. Its tiles moved into a `cloudTiles` fragment shared by both shapes.
- The group page's session test asserted the removed note. It now pins the aggregate it was really about — the sum over the SERVING members, so an offline member that last reported 9 contributes nothing.
- Verified by rendering each band's real markup against the project's compiled CSS at 1440px and measuring the column and card boxes; the numbers above are from that. The console's mock mode carries no daemons (`data-context`: "daemons: live fleet only"), so these three pages cannot be exercised without a seeded control plane.
- `pnpm --filter @agentconnect.md/web test` (2051 tests), typecheck, eslint and prettier are clean.
