### PR TITLE
fix(web): keep managed Cloud finishing at the onboarding fork

### DIFF
--- a/packages/web/src/components/console/views/OnboardingView.test.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.test.tsx
@@ -510,3 +510,52 @@ describe('onboarding — pool fork', () => {
     expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
   })
 })
+
+// Managed Cloud: the pool is AgentConnect's own image, so a Cloud preset is born configured and
+// the fork stays the last step — there is no runtime for the operator to choose.
+describe('onboarding — managed Cloud fork', () => {
+  beforeEach(() => {
+    setFlags('daemon-pool,managed')
+    mocks.daemons = [
+      {
+        daemonId: 'pool-pod-1',
+        pool: true,
+        status: 'online',
+        name: 'ac-cloud-7f9',
+        runtimeModels: [{ runtime: 'dsh-acp', models: ['deepseek-v4-flash'] }]
+      }
+    ]
+    mocks.agents = [
+      {
+        id: 'ag_ac',
+        builtin: true,
+        name: 'agentconnect',
+        daemon: 'pool',
+        placementKind: 'set',
+        runtime: 'dsh-acp',
+        model: 'deepseek-v4-flash'
+      }
+    ]
+  })
+
+  it('finishes at the fork without a runtime step', async () => {
+    await render()
+    expect(host.textContent).toContain('Cloud')
+    expect(host.textContent).toContain('Step 2 of 2')
+    await click('Finish') // Cloud preselected ⇒ Finish, never a Continue
+    expect(host.textContent).not.toContain('Choose runtime')
+    expect(mocks.updateAgent).not.toHaveBeenCalled()
+    expect(mocks.moveAgent).not.toHaveBeenCalled()
+    expect(mocks.updateOrg).toHaveBeenCalledWith('org-1', { onboardingCompleted: true })
+    expect(mocks.push).toHaveBeenCalledWith('/acme/home')
+  })
+
+  it('still routes the Daemon choice through the connect step', async () => {
+    await render()
+    await click('Daemon')
+    expect(host.textContent).toContain('Step 2 of 3')
+    await click('Continue')
+    expect(host.textContent).toContain('Run the daemon')
+    expect(mocks.provisionDaemon).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -25,10 +25,11 @@ import type { AgentPlacementTarget, DaemonConnectDto } from '@/lib/api'
 
 // Onboarding wizard (design: "AgentConnect Onboarding v2 (forked)") — owner-only, runs
 // once per org. Creating/naming the org was step 1 (/welcome or the create-org entry),
-// so this picks up at the ONE fork on where the first agent runs. Both paths then choose the
-// runtime: the pool path (Cloud on the managed install, the operator's cluster elsewhere) has
-// nothing to install, so its last step is the pickers alone; the Daemon path puts the same
-// pickers under a copy-paste connect step (mint a real join command, poll until it's online).
+// so this picks up at the ONE fork on where the first agent runs. The Daemon path adds a
+// copy-paste connect step (mint a real join command, poll until it's online) with the runtime
+// pickers inline. A SELF-HOSTED cluster adds the pickers alone — nothing to install, but the
+// operator's own pool image decides what it can run. Managed Cloud runs AgentConnect's image, so
+// its preset is born configured and the fork is the last step.
 // Finish AND skip both persist the org's `onboardingCompleted` flag — re-entering the
 // org never bounces back here once either happened. Rendered full-screen (no rail) by
 // the shell on the /onboarding route.
@@ -80,8 +81,10 @@ export default function OnboardingView() {
 
   // Auth mode counts org creation (/welcome, already behind us) as step 1.
   const orgStepsBefore = authOn ? 1 : 0
-  // Both paths end on a step of their own: connect+configure for a daemon, pickers for the pool.
-  const total = orgStepsBefore + (poolOffered ? 1 : 0) + 1
+  // Cloud's preset is born on its pool with the deployment's runtime, so there is nothing left to
+  // ask: the fork finishes. Every other path has a step of its own after it.
+  const lastStepExists = choice === 'daemon' || !featureFlagEnabled('managed')
+  const total = Math.max(orgStepsBefore + 1, orgStepsBefore + (poolOffered ? 1 : 0) + (lastStepExists ? 1 : 0))
   const stepNumbers: Record<Step, number> = { where: orgStepsBefore + 1, run: total }
 
   // ── finish / skip: persist the flag, then leave ─────────────────────────────────
@@ -262,7 +265,10 @@ export default function OnboardingView() {
           stepLabel={`Step ${stepNumbers.where} of ${total}`}
           choice={choice}
           onChoice={setChoice}
-          onNext={() => setStep('run')}
+          finishHere={!lastStepExists}
+          finishing={finishing}
+          err={saveErr}
+          onNext={() => (lastStepExists ? setStep('run') : void finish())}
         />
       ) : choice === 'pool' ? (
         <ClusterStep
@@ -407,11 +413,18 @@ function WhereStep({
   stepLabel,
   choice,
   onChoice,
+  finishHere,
+  finishing,
+  err,
   onNext
 }: {
   stepLabel: string
   choice: 'pool' | 'daemon'
   onChoice: (choice: 'pool' | 'daemon') => void
+  /** Cloud selected: its preset needs nothing picked, so the fork IS the last step. */
+  finishHere: boolean
+  finishing: boolean
+  err: string | null
   onNext: () => void
 }) {
   const managed = featureFlagEnabled('managed')
@@ -423,9 +436,18 @@ function WhereStep({
       footer={
         <>
           <div className="flex-1" />
-          <Button onClick={onNext}>
-            Continue
-            <Icon name="arrow-right" size={15} />
+          <Button disabled={finishing} onClick={onNext}>
+            {finishHere ? (
+              <>
+                <Icon name="check" size={15} />
+                {finishing ? 'Finishing…' : 'Finish'}
+              </>
+            ) : (
+              <>
+                Continue
+                <Icon name="arrow-right" size={15} />
+              </>
+            )}
           </Button>
         </>
       }
@@ -453,6 +475,7 @@ function WhereStep({
           onSelect={() => onChoice('daemon')}
         />
       </div>
+      <SaveError err={err} />
     </StepFrame>
   )
 }


### PR DESCRIPTION
Follow-up to #1541, which gave the pool path a `Choose runtime` step. On **managed Cloud** that step asks a question whose answer is already fixed: Cloud's pool runs AgentConnect's own image, so a Cloud preset is born placed on it with the deployment's runtime and model (`PRESET_AGENT_POOL_RUNTIME`/`_MODEL`). Picking Cloud now finishes at the fork exactly as it did before #1541.

## What

- `lastStepExists = choice === 'daemon' || !featureFlagEnabled('managed')` — the runtime step is the **self-hosted cluster's**, whose pool image belongs to the operator and whose members advertise what they can run.
- The fork's button is `Finish` again whenever the chosen path has nothing after it (managed + Cloud), and it carries the completion error back, as before #1541.
- The Daemon path is unchanged on both deployment shapes.

## Verified

- Local stack with `FEATURE_FLAGS=daemon-pool,daemon-groups,managed`: the fork reads `Cloud` / `Finish`, selecting `Daemon` flips it to `Continue` and adds the step back, and finishing on Cloud left the preset's born pair (`dsh-acp` / `deepseek-v4-flash`, pool-placed) untouched while marking the org onboarded.
- New tests cover both managed cases (Cloud finishes at the fork with no `Choose runtime` and no agent writes; Daemon still routes through the connect step). `pnpm --filter @agentconnect.md/web test` (2052 tests), `typecheck`, and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)