### PR TITLE
feat(hooks): one code-host trigger row per subject family

### DIFF
--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -720,9 +720,12 @@ candidate set, each of them an active side-effect-free retry row; a landed run
 from outside the set still blocks the whole request. A candidate that landed
 nothing is the relay's own precise filtering — subject family, mention text,
 labels, none of which the summary carries — which the redelivered payload
-reproduces exactly, so it is tolerated. The single exception is a candidate hook
-created after the delivery was ingested: it would read the redelivery as a first
-run of a stale event, and it blocks.
+reproduces exactly, so it is tolerated. That proof holds only while the rule
+itself is unchanged: a candidate whose definition moved after the delivery was
+ingested — created then, re-enabled, or its filters relaxed — might treat the
+redelivery as a first run of a stale event, so any unlanded candidate modified
+since the delivery blocks the claim. Every user-facing edit moves
+`lastModifiedAt`, which is the fence.
 
 An admitted turn ended by a handover (`agent_handover`) is deliberately outside
 that set, and the reason is a stage question rather than a wording one. Retry

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -720,12 +720,17 @@ candidate set, each of them an active side-effect-free retry row; a landed run
 from outside the set still blocks the whole request. A candidate that landed
 nothing is the relay's own precise filtering — subject family, mention text,
 labels, none of which the summary carries — which the redelivered payload
-reproduces exactly, so it is tolerated. That proof holds only while the rule
-itself is unchanged: a candidate whose definition moved after the delivery was
-ingested — created then, re-enabled, or its filters relaxed — might treat the
-redelivery as a first run of a stale event, so any unlanded candidate modified
-since the delivery blocks the claim. Every user-facing edit moves
-`lastModifiedAt`, which is the fence.
+reproduces exactly, so it can be tolerated. That proof needs the candidate's
+EFFECTIVE rule to be the one that filtered the original delivery, and the rule
+is mutable even when the payload is not — an edit, a re-enable, an agent
+rename, or a pause/resume can all change what compiles for it. Tolerance is
+therefore restricted to candidates on the same agent as a landed run: the run
+shows the agent was live and routing at ingestion, and family uniqueness plus
+the per-row shape gate keep a sibling family from ever matching the event. Two
+`lastModifiedAt` fences (hook row and agent — every user-facing edit moves
+them) remain as defense in depth. Every other unlanded candidate — cross-agent
+ones above all, whose pause and rename history the claim cannot reconstruct —
+blocks the request, exactly as the pre-split exact-fanout rule did.
 
 An admitted turn ended by a handover (`agent_handover`) is deliberately outside
 that set, and the reason is a stage question rather than a wording one. Retry

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -592,15 +592,44 @@ and redeliveries converge on one record. A reaper marks stale running rows as
 
 The Prisma schema is authoritative. The main records are:
 
-- `HookDef`: definition, repository identity, event filters, session policy,
-  immutable revision fences, review/reporting policy, optional anchor, and
-  owning agent.
+- `HookDef`: definition, repository identity, subject family, event filters,
+  session policy, immutable revision fences, review/reporting policy, optional
+  anchor, and owning agent.
 - `HookSecret`: the generic hook's HMAC secret, separated from normal hook
   reads and DTOs.
 - `HookRun`: body-free delivery, dispatch, revision, review, projection,
   session, and redelivery metadata.
 - `HookReviewProjection`: durable external Check or reporting state that can be
   cleaned up even if its owning hook is deleted.
+
+### One Row per Subject Family
+
+A code-host `HookDef` row covers exactly ONE subject family — `pull_request`,
+`issues` or `push` for GitHub, `merge_request`, `issues` or `push` for GitLab —
+recorded in `family` and unique per `(agentId, kind, repoId, family)`. Watching a
+repository for both pull requests and issues is therefore two rows, each with its
+own cadence, label filter and `mentionOnly` gate: pull requests can fire on every
+update while issues fire only on an explicit mention. `family` is immutable, so
+the update body carries none; changing it is a delete plus a create.
+
+Nothing on the wire changes. The relay already fans one delivery out to every
+rule matching the repository, and `commentFamilies` already isolates comment
+traffic per family — so each row compiles into an ordinary independent rule.
+Three constraints keep those rules from overlapping:
+
+- every stored pattern must belong to the row's family, with `issue_comment` and
+  `pull_request_review_comment` riding the thread family that owns them;
+- `commentFamilies` may only name the row's own family, and a GitHub row carrying
+  an `issue_comment` subscription must set it — left empty it would keep the
+  legacy repository-wide meaning and double-fire against its sibling; and
+- `reviewPolicy`, `reportingMode` and `gateMode` may leave their defaults only on
+  a pull-request or merge-request row.
+
+Sibling rows of one repository answer the same threads, so they must agree on the
+anchoring target and share one session-key prefix; a divergent anchor is refused.
+Legacy rows are split by migration, the review-capable family keeping the
+original row id so review projections, publication leases and run history stay
+attached to it.
 
 A hook belongs to one agent and has no independent visibility setting. Access
 inherits the owning agent's visibility. Agent deletion cascades to hook

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -627,6 +627,9 @@ Three constraints keep those rules from overlapping:
 
 Sibling rows of one repository answer the same threads, so they must agree on the
 anchoring target and share one session-key prefix; a divergent anchor is refused.
+Either half of a row's binding moving — a repository re-target or a reassignment
+to another agent — re-reads the destination's siblings and adopts their prefix,
+so a moved row never opens a second namespace beside the family it joins.
 Legacy rows are split by migration, the review-capable family keeping the
 original row id so review projections, publication leases and run history stay
 attached to it.
@@ -708,6 +711,18 @@ Reconciliation does not retry an ambiguous dispatch, an agent/business
 rejection, or any row that may already have produced an effect. Partial
 `review_request_required` fanout is retried only when every observed sibling
 proves that no agent or external review effect occurred.
+
+A delivery summary names only the event, action and repository, so the candidate
+set for one GUID is deliberately coarse — an `issue_comment` delivery lists both
+comment-family sibling rows even though only one of them can own the thread. The
+retryable claim therefore requires the landed runs to be a _subset_ of that
+candidate set, each of them an active side-effect-free retry row; a landed run
+from outside the set still blocks the whole request. A candidate that landed
+nothing is the relay's own precise filtering — subject family, mention text,
+labels, none of which the summary carries — which the redelivered payload
+reproduces exactly, so it is tolerated. The single exception is a candidate hook
+created after the delivery was ingested: it would read the redelivery as a first
+run of a stale event, and it blocks.
 
 An admitted turn ended by a handover (`agent_handover`) is deliberately outside
 that set, and the reason is a stage question rather than a wording one. Retry

--- a/packages/control-plane/prisma/migrations/20260917000000_hook_family_split/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260917000000_hook_family_split/migration.sql
@@ -1,0 +1,170 @@
+-- Split a code-host hook into one row per (agent, repo, subject family) so each
+-- family carries its own cadence and its own mention gate
+-- (webhook-triggers-and-github-events.md). Written idempotently: re-executing
+-- the file is a no-op, because the backfill only visits family-less rows.
+
+-- AlterTable
+ALTER TABLE "hook_def" ADD COLUMN IF NOT EXISTS "family" TEXT;
+
+-- Backfill: give every legacy github/gitlab row a family, keeping the
+-- review-capable family on the EXISTING id (projections, review leases and run
+-- history all key on it) and inserting a sibling row for every other family the
+-- old row's subscriptions covered.
+DO $$
+DECLARE
+  hook RECORD;
+  pattern TEXT;
+  prefix TEXT;
+  fams TEXT[];
+  ordered TEXT[];
+  candidate TEXT;
+  primary_family TEXT;
+  has_issue_comment BOOLEAN;
+  row_events TEXT[];
+  row_comments TEXT[];
+BEGIN
+  FOR hook IN
+    SELECT * FROM "hook_def"
+    WHERE "kind" IN ('github', 'gitlab') AND "family" IS NULL
+    ORDER BY "createdAt", "id"
+  LOOP
+    fams := ARRAY[]::TEXT[];
+    has_issue_comment := FALSE;
+    -- The subject each stored pattern names. GitHub's issue_comment covers both
+    -- thread families, so on its own it names none.
+    FOREACH pattern IN ARRAY COALESCE(hook."events", ARRAY[]::TEXT[]) LOOP
+      prefix := split_part(pattern, ':', 1);
+      IF prefix = 'issue_comment' THEN
+        has_issue_comment := TRUE;
+      ELSIF prefix = 'pull_request_review_comment' THEN
+        fams := fams || 'pull_request';
+      ELSIF prefix IN ('issues', 'pull_request', 'merge_request', 'push') THEN
+        fams := fams || prefix;
+      END IF;
+    END LOOP;
+    IF hook."kind" = 'gitlab' THEN
+      -- GitLab's commentFamilies IS the note subscription, so it names subjects.
+      fams := fams || COALESCE(hook."commentFamilies", ARRAY[]::TEXT[]);
+    ELSIF has_issue_comment THEN
+      IF COALESCE(cardinality(hook."commentFamilies"), 0) > 0 THEN
+        fams := fams || ARRAY(
+          SELECT f FROM unnest(hook."commentFamilies") AS f WHERE f IN ('issues', 'pull_request')
+        );
+      ELSIF cardinality(fams) = 0 THEN
+        -- A comment-only repo-wide rule covered both thread families.
+        fams := ARRAY['issues', 'pull_request'];
+      END IF;
+      -- Otherwise legacy repo-wide comments are deliberately narrowed to the
+      -- families this row already subscribed to (accepted behavior change).
+    END IF;
+    -- Preference order: a review-capable family always keeps the existing id.
+    ordered := ARRAY(
+      SELECT f FROM unnest(ARRAY['pull_request', 'merge_request', 'issues', 'push']) AS f
+      WHERE f = ANY(fams)
+    );
+    IF cardinality(ordered) = 0 THEN
+      -- A row that subscribes to nothing still needs a family to stay editable.
+      ordered := ARRAY[CASE WHEN hook."kind" = 'gitlab' THEN 'merge_request' ELSE 'pull_request' END];
+    END IF;
+
+    -- Duplicate legacy rows on one (agent, kind, repo) predate the split, so
+    -- claim only free slots; a row left with a NULL family stays legacy-inert.
+    primary_family := NULL;
+    FOREACH candidate IN ARRAY ordered LOOP
+      IF NOT EXISTS (
+        SELECT 1 FROM "hook_def" x
+        WHERE x."id" <> hook."id"
+          AND x."agentId" IS NOT DISTINCT FROM hook."agentId"
+          AND x."kind" = hook."kind"
+          AND x."repoId" IS NOT DISTINCT FROM hook."repoId"
+          AND x."family" = candidate
+      ) THEN
+        primary_family := candidate;
+        EXIT;
+      END IF;
+    END LOOP;
+    CONTINUE WHEN primary_family IS NULL;
+
+    row_events := ARRAY(
+      SELECT e FROM unnest(COALESCE(hook."events", ARRAY[]::TEXT[])) AS e
+      WHERE split_part(e, ':', 1) = primary_family
+        OR (hook."kind" = 'github' AND split_part(e, ':', 1) = 'pull_request_review_comment'
+            AND primary_family = 'pull_request')
+        OR (hook."kind" = 'github' AND split_part(e, ':', 1) = 'issue_comment'
+            AND primary_family IN ('issues', 'pull_request')
+            AND (COALESCE(cardinality(hook."commentFamilies"), 0) = 0
+                 OR primary_family = ANY(hook."commentFamilies")))
+    );
+    IF hook."kind" = 'github' THEN
+      row_comments := CASE
+        WHEN EXISTS (SELECT 1 FROM unnest(row_events) AS e WHERE split_part(e, ':', 1) = 'issue_comment')
+        THEN ARRAY[primary_family] ELSE ARRAY[]::TEXT[] END;
+    ELSE
+      row_comments := CASE
+        WHEN primary_family = ANY(COALESCE(hook."commentFamilies", ARRAY[]::TEXT[]))
+        THEN ARRAY[primary_family] ELSE ARRAY[]::TEXT[] END;
+    END IF;
+    -- A narrowed subscription is a new compiled definition, so it must be pushed.
+    UPDATE "hook_def" SET
+      "family" = primary_family,
+      "events" = row_events,
+      "commentFamilies" = row_comments,
+      "configRevision" = CASE
+        WHEN row_events IS DISTINCT FROM COALESCE(hook."events", ARRAY[]::TEXT[])
+          OR row_comments IS DISTINCT FROM COALESCE(hook."commentFamilies", ARRAY[]::TEXT[])
+        THEN "configRevision" + 1 ELSE "configRevision" END
+    WHERE "id" = hook."id";
+
+    FOREACH candidate IN ARRAY ordered LOOP
+      CONTINUE WHEN candidate = primary_family;
+      CONTINUE WHEN EXISTS (
+        SELECT 1 FROM "hook_def" x
+        WHERE x."agentId" IS NOT DISTINCT FROM hook."agentId"
+          AND x."kind" = hook."kind"
+          AND x."repoId" IS NOT DISTINCT FROM hook."repoId"
+          AND x."family" = candidate
+      );
+      row_events := ARRAY(
+        SELECT e FROM unnest(COALESCE(hook."events", ARRAY[]::TEXT[])) AS e
+        WHERE split_part(e, ':', 1) = candidate
+          OR (hook."kind" = 'github' AND split_part(e, ':', 1) = 'pull_request_review_comment'
+              AND candidate = 'pull_request')
+          OR (hook."kind" = 'github' AND split_part(e, ':', 1) = 'issue_comment'
+              AND candidate IN ('issues', 'pull_request')
+              AND (COALESCE(cardinality(hook."commentFamilies"), 0) = 0
+                   OR candidate = ANY(hook."commentFamilies")))
+      );
+      IF hook."kind" = 'github' THEN
+        row_comments := CASE
+          WHEN EXISTS (SELECT 1 FROM unnest(row_events) AS e WHERE split_part(e, ':', 1) = 'issue_comment')
+          THEN ARRAY[candidate] ELSE ARRAY[]::TEXT[] END;
+      ELSE
+        row_comments := CASE
+          WHEN candidate = ANY(COALESCE(hook."commentFamilies", ARRAY[]::TEXT[]))
+          THEN ARRAY[candidate] ELSE ARRAY[]::TEXT[] END;
+      END IF;
+      -- A sibling is never a review family (those win the primary slot), so its
+      -- review trio starts at the defaults rather than inheriting the old row's.
+      INSERT INTO "hook_def" (
+        "id", "orgId", "agentId", "kind", "name", "enabled", "sessionMode",
+        "repoId", "repoFullName", "githubSessionKey", "family",
+        "events", "commentFamilies", "labelFilter", "mentionOnly",
+        "configRevision", "dispatchRevision", "projectionEpoch",
+        "reviewPolicy", "reportingMode", "gateMode",
+        "targetPlatform", "targetChannel", "targetIntegrationId",
+        "createdByUserId", "lastModifiedByUserId", "lastModifiedAt", "createdAt", "updatedAt"
+      ) VALUES (
+        gen_random_uuid(), hook."orgId", hook."agentId", hook."kind", hook."name", hook."enabled", hook."sessionMode",
+        hook."repoId", hook."repoFullName", hook."githubSessionKey", candidate,
+        row_events, row_comments, hook."labelFilter", hook."mentionOnly",
+        1, 1, 1,
+        'off'::"HookReviewPolicy", 'off'::"HookReportingMode", 'informational'::"HookGateMode",
+        hook."targetPlatform", hook."targetChannel", hook."targetIntegrationId",
+        hook."createdByUserId", hook."lastModifiedByUserId", now(), now(), now()
+      );
+    END LOOP;
+  END LOOP;
+END $$;
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "hook_def_agent_repo_family_key" ON "hook_def"("agentId", "kind", "repoId", "family");

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1755,6 +1755,7 @@ model HookDef {
   repoId                             BigInt? // GitHub numeric repo id — the match key (rename-proof)
   repoFullName                       String? // "owner/repo" — display + create-time validation; never matched on
   githubSessionKey                   String? // immutable per-thread namespace; existing rows keep their pre-rename owner/repo
+  family                             String? // subject family of this row; a github/gitlab hook row covers exactly one family (webhook kind: null)
   events                             String[]          @default([]) // "issues:opened" / "pull_request:*" / "issue_comment:created"
   commentFamilies                    String[]          @default([]) // empty = legacy repo-wide comments; otherwise issues/pull_request scope
   labelFilter                        String[]          @default([]) // non-empty ⇒ issue/PR must carry one of these labels
@@ -1796,6 +1797,10 @@ model HookDef {
   lastModifiedBy    User?        @relation("HookModifiedBy", fields: [lastModifiedByUserId], references: [id], onDelete: SetNull)
   secret            HookSecret?
 
+  // One subscription row per (agent, repo, subject family) — the database owns
+  // the rule, so the routes need no duplicate probe. Postgres skips rows with a
+  // NULL member, so webhook-kind and legacy inert rows never conflict.
+  @@unique([agentId, kind, repoId, family], map: "hook_def_agent_repo_family_key")
   @@index([orgId])
   @@index([agentId])
   @@index([kind, repoId]) // github rule-compile main query (P2)

--- a/packages/control-plane/src/codehost/review-lease.service.test.ts
+++ b/packages/control-plane/src/codehost/review-lease.service.test.ts
@@ -95,6 +95,7 @@ function hook(overrides: Partial<HookRecord> = {}): HookRecord {
     repoId: PROJECT,
     repoFullName: 'example-group/example-project',
     events: ['merge_request:*'],
+    family: 'merge_request',
     commentFamilies: [],
     labelFilter: [],
     mentionOnly: false,

--- a/packages/control-plane/src/github/review-broker.service.test.ts
+++ b/packages/control-plane/src/github/review-broker.service.test.ts
@@ -52,6 +52,7 @@ function hook(overrides: Partial<HookRecord> = {}): HookRecord {
     repoId: 123n,
     repoFullName: 'acme/widgets',
     events: ['pull_request:*'],
+    family: 'pull_request',
     commentFamilies: [],
     labelFilter: [],
     mentionOnly: false,

--- a/packages/control-plane/src/hooks/hook-family.test.ts
+++ b/packages/control-plane/src/hooks/hook-family.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The per-family row shape (webhook-triggers-and-github-events.md). One row =
+ * one subject family, so these predicates decide what a single row may carry.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  familyCarriesReviews,
+  familyOfEventPattern,
+  eventPatternFitsFamily,
+  hasSharedCommentPattern,
+  hookFamilyShapeError,
+  hookSiblingShapeError,
+  type HookFamily
+} from './hook-family.js'
+
+const shape = (over: Partial<Parameters<typeof hookFamilyShapeError>[0]> = {}) =>
+  hookFamilyShapeError({
+    kind: 'github',
+    family: 'pull_request',
+    events: ['pull_request:*'],
+    commentFamilies: [],
+    reviewPolicy: 'off',
+    reportingMode: 'off',
+    gateMode: 'informational',
+    ...over
+  })
+
+describe('hook family — pattern classification', () => {
+  it('maps a stored pattern prefix onto its subject family', () => {
+    expect(familyOfEventPattern('issues:opened')).toBe('issues')
+    expect(familyOfEventPattern('pull_request:*')).toBe('pull_request')
+    expect(familyOfEventPattern('merge_request:*')).toBe('merge_request')
+    expect(familyOfEventPattern('push:*')).toBe('push')
+    // A diff-line review comment is a pull-request subject…
+    expect(familyOfEventPattern('pull_request_review_comment:created')).toBe('pull_request')
+    // …but GitHub's shared conversation subscription names no subject by itself.
+    expect(familyOfEventPattern('issue_comment:created')).toBeNull()
+    expect(familyOfEventPattern('releases:published')).toBeNull()
+  })
+
+  it('admits the shared comment families only on the hosts and subjects that have them', () => {
+    expect(eventPatternFitsFamily('github', 'issues', 'issue_comment:created')).toBe(true)
+    expect(eventPatternFitsFamily('github', 'pull_request', 'issue_comment:created')).toBe(true)
+    expect(eventPatternFitsFamily('github', 'push', 'issue_comment:created')).toBe(false)
+    // GitLab notes are their own subscription, never a shared issue_comment one.
+    expect(eventPatternFitsFamily('gitlab', 'issues', 'issue_comment:created')).toBe(false)
+    expect(eventPatternFitsFamily('github', 'pull_request', 'pull_request_review_comment:created')).toBe(true)
+    expect(eventPatternFitsFamily('github', 'issues', 'pull_request_review_comment:created')).toBe(false)
+    expect(eventPatternFitsFamily('gitlab', 'merge_request', 'merge_request:*')).toBe(true)
+    expect(eventPatternFitsFamily('gitlab', 'merge_request', 'issues:*')).toBe(false)
+  })
+
+  it('knows which families can carry reviews, and which patterns ride the shared subscription', () => {
+    const carries: [HookFamily, boolean][] = [
+      ['pull_request', true],
+      ['merge_request', true],
+      ['issues', false],
+      ['push', false]
+    ]
+    for (const [family, expected] of carries) expect(familyCarriesReviews(family)).toBe(expected)
+    expect(hasSharedCommentPattern(['pull_request:*', 'issue_comment:created'])).toBe(true)
+    expect(hasSharedCommentPattern(['pull_request:*'])).toBe(false)
+  })
+})
+
+describe('hook family — one-row shape', () => {
+  it('accepts a row whose whole subscription belongs to its own family', () => {
+    expect(shape()).toBeNull()
+    expect(
+      shape({
+        events: ['pull_request:*', 'issue_comment:created', 'pull_request_review_comment:created'],
+        commentFamilies: ['pull_request']
+      })
+    ).toBeNull()
+    expect(
+      shape({ family: 'issues', events: ['issues:*', 'issue_comment:created'], commentFamilies: ['issues'] })
+    ).toBeNull()
+    expect(shape({ family: 'push', events: ['push:*'] })).toBeNull()
+    expect(
+      shape({
+        kind: 'gitlab',
+        family: 'merge_request',
+        events: ['merge_request:*'],
+        commentFamilies: ['merge_request']
+      })
+    ).toBeNull()
+  })
+
+  it('names the offending pattern when it belongs to another family', () => {
+    expect(shape({ events: ['pull_request:*', 'issues:opened'] })).toMatch(/"issues:opened".*pull_request family/)
+    expect(shape({ family: 'push', events: ['push:*', 'issue_comment:created'] })).toMatch(/issue_comment:created/)
+  })
+
+  it('keeps commentFamilies inside the row it scopes', () => {
+    expect(shape({ commentFamilies: ['issues'] })).toMatch(/not issues/)
+    expect(shape({ family: 'push', commentFamilies: ['issues'], events: ['push:*'] })).toMatch(/not issues/)
+  })
+
+  it('refuses a GitHub issue_comment subscription with no scope — that is the repo-wide legacy meaning', () => {
+    // Left empty, the sibling row that owns the other thread family would fire too.
+    expect(shape({ events: ['pull_request:*', 'issue_comment:created'] })).toMatch(
+      /must set commentFamilies to \["pull_request"\]/
+    )
+    // GitLab has no shared subscription, so an empty note scope is just "no notes".
+    expect(shape({ kind: 'gitlab', family: 'merge_request', events: ['merge_request:*'] })).toBeNull()
+  })
+
+  it('confines the review and reporting axes to a change-proposal family', () => {
+    const reviews = 'reviews and run reporting apply to pull-request/merge-request rows'
+    expect(shape({ family: 'issues', events: ['issues:*'], reviewPolicy: 'comment' })).toBe(reviews)
+    expect(shape({ family: 'issues', events: ['issues:*'], reportingMode: 'check' })).toBe(reviews)
+    expect(shape({ family: 'push', events: ['push:*'], gateMode: 'required' })).toBe(reviews)
+    expect(shape({ reviewPolicy: 'full', reportingMode: 'check' })).toBeNull()
+    expect(
+      shape({ kind: 'gitlab', family: 'merge_request', events: ['merge_request:*'], reviewPolicy: 'full' })
+    ).toBeNull()
+  })
+})
+
+describe('hook family — sibling anchoring', () => {
+  const anchored = {
+    targetPlatform: 'slack',
+    targetChannel: 'C1',
+    targetIntegrationId: 'i1',
+    sessionMode: 'perThread'
+  }
+
+  it('accepts siblings that post to the same place (and the no-sibling case)', () => {
+    expect(hookSiblingShapeError([], anchored, 'acme/infra')).toBeNull()
+    expect(hookSiblingShapeError([anchored, anchored], { ...anchored }, 'acme/infra')).toBeNull()
+  })
+
+  it('refuses a divergent anchor on any leg of the trio', () => {
+    for (const drift of [
+      { targetPlatform: 'discord' },
+      { targetChannel: 'C2' },
+      { targetIntegrationId: 'i2' },
+      { targetChannel: null },
+      { sessionMode: 'shared' }
+    ]) {
+      expect(hookSiblingShapeError([{ ...anchored, ...drift }], anchored, 'acme/infra')).toMatch(
+        /acme\/infra triggers post somewhere else/
+      )
+    }
+  })
+})

--- a/packages/control-plane/src/hooks/hook-family.ts
+++ b/packages/control-plane/src/hooks/hook-family.ts
@@ -1,0 +1,122 @@
+/**
+ * `hooks/hook-family.ts` — the per-family shape of a code-host hook row
+ * (webhook-triggers-and-github-events.md).
+ *
+ * A github/gitlab HookDef row covers exactly ONE subject family, so each family
+ * carries its own cadence and its own mention gate. These are pure predicates:
+ * the routes call them before any I/O, and the database's
+ * (agent, kind, repo, family) uniqueness owns the duplicate rule.
+ */
+
+/** Every subject family the two code hosts between them subscribe to. */
+export type HookFamily = 'issues' | 'pull_request' | 'merge_request' | 'push'
+
+/** The families a row of each kind may declare. */
+export const GITHUB_FAMILIES = ['pull_request', 'issues', 'push'] as const
+export const GITLAB_FAMILIES = ['merge_request', 'issues', 'push'] as const
+
+/** Reviews and run reporting exist only on a change-proposal subject. */
+const REVIEW_FAMILIES = new Set<HookFamily>(['pull_request', 'merge_request'])
+
+/** Whether the review/reporting axes may be non-default on this row. */
+export function familyCarriesReviews(family: HookFamily): boolean {
+  return REVIEW_FAMILIES.has(family)
+}
+
+/** The family a stored `family:action` pattern names, or null when it names none
+ *  (GitHub's `issue_comment` covers both thread families, so alone it names no
+ *  subject; the pattern's own scope comes from `commentFamilies`). */
+export function familyOfEventPattern(pattern: string): HookFamily | null {
+  const prefix = pattern.split(':', 1)[0]
+  switch (prefix) {
+    case 'issues':
+    case 'pull_request':
+    case 'merge_request':
+    case 'push':
+      return prefix
+    case 'pull_request_review_comment':
+      return 'pull_request'
+    default:
+      return null
+  }
+}
+
+/** Whether one stored pattern belongs on a row of this kind and family. */
+export function eventPatternFitsFamily(kind: 'github' | 'gitlab', family: HookFamily, pattern: string): boolean {
+  const prefix = pattern.split(':', 1)[0]
+  if (prefix === 'issue_comment') {
+    return kind === 'github' && (family === 'issues' || family === 'pull_request')
+  }
+  if (prefix === 'pull_request_review_comment') return kind === 'github' && family === 'pull_request'
+  return prefix === family
+}
+
+/** Whether any pattern rides GitHub's shared issue_comment subscription. */
+export function hasSharedCommentPattern(events: readonly string[]): boolean {
+  return events.some((pattern) => pattern.split(':', 1)[0] === 'issue_comment')
+}
+
+/** The per-row subscription block a write proposes. */
+export interface HookFamilyShape {
+  kind: 'github' | 'gitlab'
+  family: HookFamily
+  events: readonly string[]
+  commentFamilies: readonly string[]
+  reviewPolicy: string
+  reportingMode: string
+  gateMode: string
+}
+
+/**
+ * The 400 reason this row shape is not a single-family subscription, or null.
+ * Every check is a statement about ONE row: the sibling comparisons (identical
+ * anchoring, one row per family) live with the route that can read siblings.
+ */
+export function hookFamilyShapeError(shape: HookFamilyShape): string | null {
+  const offending = shape.events.find((pattern) => !eventPatternFitsFamily(shape.kind, shape.family, pattern))
+  if (offending !== undefined) {
+    return `event "${offending}" does not belong to the ${shape.family} family — subscribe to it on that family's own trigger`
+  }
+  const strayComment = shape.commentFamilies.find((candidate) => candidate !== shape.family)
+  if (strayComment !== undefined) {
+    return `commentFamilies may only scope this row's own ${shape.family} family, not ${strayComment}`
+  }
+  // GitHub narrows its shared issue_comment subscription with commentFamilies;
+  // leaving it empty is the legacy repo-wide meaning, which would double-fire
+  // against the sibling row that owns the other thread family.
+  if (shape.kind === 'github' && hasSharedCommentPattern(shape.events) && shape.commentFamilies.length === 0) {
+    return `an issue_comment subscription must set commentFamilies to ["${shape.family}"]`
+  }
+  if (!familyCarriesReviews(shape.family)) {
+    if (shape.reviewPolicy !== 'off' || shape.reportingMode !== 'off' || shape.gateMode !== 'informational') {
+      return 'reviews and run reporting apply to pull-request/merge-request rows'
+    }
+  }
+  return null
+}
+
+/** The anchoring/session block sibling rows of one (agent, repo) must agree on:
+ *  they answer the same thread, so a divergent anchor would split its replies. */
+export interface HookSiblingShape {
+  targetPlatform: string
+  targetChannel: string | null
+  targetIntegrationId: string | null
+  sessionMode: string
+}
+
+/** The 409 reason this row disagrees with its siblings on that block, or null. */
+export function hookSiblingShapeError(
+  siblings: readonly HookSiblingShape[],
+  proposed: HookSiblingShape,
+  repoLabel: string
+): string | null {
+  const differs = siblings.find(
+    (sibling) =>
+      sibling.targetPlatform !== proposed.targetPlatform ||
+      sibling.targetChannel !== proposed.targetChannel ||
+      sibling.targetIntegrationId !== proposed.targetIntegrationId ||
+      sibling.sessionMode !== proposed.sessionMode
+  )
+  if (!differs) return null
+  return `this agent's other ${repoLabel} triggers post somewhere else — change them together, or they would answer one thread in two places`
+}

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2490,8 +2490,15 @@ export const CreateWebhookHookBody = HookBodyBase.extend({
   hmac: z.boolean().default(false)
 })
 
+/** The subject family one row covers. A row is `(agent, repo, family)`: each
+ *  family carries its own cadence and its own mention gate, so a repository the
+ *  agent watches for both PRs and issues is TWO rows. Immutable after create. */
+export const GithubHookFamily = z.enum(['pull_request', 'issues', 'push'])
+export const GitlabHookFamily = z.enum(['merge_request', 'issues', 'push'])
+
 export const CreateGithubHookBody = HookBodyBase.extend({
   kind: z.literal('github'),
+  family: GithubHookFamily,
   // No sessionMode: github is perThread by definition (same issue/PR continues
   // one session). No hmac: the App webhook secret signs deliveries pool-wide.
   // The repo must sit inside one of the org's App installations; the CP resolves
@@ -2500,9 +2507,11 @@ export const CreateGithubHookBody = HookBodyBase.extend({
     .string()
     .trim()
     .regex(/^[^/\s]+\/[^/\s]+$/, 'expected "owner/repo"'),
+  // Every pattern must belong to `family`; `issue_comment` and
+  // `pull_request_review_comment` ride the thread families that own them.
   events: z.array(z.string().regex(HookEventPattern)).min(1).max(20),
-  // GitHub emits one issue_comment family for both issue and PR conversations.
-  // Empty preserves the published API's legacy repo-wide comment semantics.
+  // GitHub emits one issue_comment family for both issue and PR conversations,
+  // so a row carrying such a subscription must scope it to its own family.
   commentFamilies: GithubCommentFamilies.default([]),
   labelFilter: z.array(z.string().trim().min(1).max(100)).max(20).default([]),
   // P3 summon mode: every event's authored text must @-mention the assigned
@@ -2523,8 +2532,9 @@ export const CreateGitlabHookBody = HookBodyBase.extend({
   // The project must already be a managed binding in this organization; the
   // numeric id is validated against it server-side (never trusted for facts).
   projectId: z.string().regex(/^[1-9]\d*$/),
+  family: GitlabHookFamily,
   events: z.array(z.string().regex(GitlabHookEventPattern)).min(1).max(20),
-  // Note events for the selected subject families (§12); empty = no comments.
+  // Note events for this row's own subject family (§12); empty = no comments.
   commentFamilies: z.array(GitlabCommentFamily).max(2).default([]),
   mentionOnly: z.boolean().default(false),
   // The two effect axes github carries; `check` is the §16 run note. No gateMode — GitLab has no required gate.
@@ -2547,8 +2557,10 @@ export const CreateHookBody = z.discriminatedUnion('kind', [
 // URL (urlToken) and signing secret — the capability URL must survive edits,
 // secret rotation is a delete/re-create. The github repo IS re-targetable
 // (repoId re-resolved).
+// `family` is absent from every update member: it is immutable, so a retarget
+// keeps the row's own family and a client echoing it back changes nothing.
 export const UpdateHookBody = z.union([
-  CreateGitlabHookBody.extend({
+  CreateGitlabHookBody.omit({ family: true }).extend({
     enabled: z.boolean().optional(),
     commentFamilies: z.array(GitlabCommentFamily).max(2).optional(),
     mentionOnly: z.boolean().optional(),
@@ -2559,7 +2571,7 @@ export const UpdateHookBody = z.union([
   // mentionOnly OPTIONAL on update (unlike create's default-false): a pre-P3
   // client echoing a hook back must not silently downgrade mention mode — the
   // route falls back to the stored value when the key is absent.
-  CreateGithubHookBody.extend({
+  CreateGithubHookBody.omit({ family: true }).extend({
     // Unlike create's default-true, omission on whole-definition UPDATE means
     // preserve the stored enablement state. Old web clients did not echo it.
     enabled: z.boolean().optional(),
@@ -2595,6 +2607,9 @@ export const HookDto = z.object({
   // ── github kind (P2; read-side seats) ──
   repoId: z.string().nullable(), // rename-proof GitHub numeric id; null for webhook kind
   repoFullName: z.string().nullable(),
+  // The one subject family this row covers; null for webhook kind and for a
+  // legacy row the split could not place.
+  family: z.string().nullable(),
   events: z.array(z.string()),
   // The stored union across code hosts; each row carries its own host's subset.
   commentFamilies: z.array(z.enum(['issues', 'pull_request', 'merge_request'])),

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -33,6 +33,7 @@ import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView } from '../../authorization/policy.js'
 import { toDbPlatform, type DbPlatform } from '../../persistence/platform.js'
 import { AgentWorkspaceIntegrationConflict } from '../../persistence/errors.js'
+import { hookFamilyShapeError, hookSiblingShapeError, type HookFamily } from '../../hooks/hook-family.js'
 import { Tag } from '../plugins/openapi.js'
 import {
   CreateHookBody,
@@ -55,6 +56,19 @@ const RERUN_STATUS_TEXT = {
   502: 'Bad Gateway',
   503: 'Service Unavailable'
 } as const
+
+/** The (agent, kind, repo, family) uniqueness lives in Postgres, so a duplicate
+ *  subscription arrives here as a constraint violation rather than a probe. */
+class DuplicateHookFamily extends Error {}
+const HOOK_FAMILY_INDEX = 'hook_def_agent_repo_family_key'
+function isHookFamilyCollision(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  if (Reflect.get(err, 'code') !== 'P2002') return false
+  // Prisma names the violated constraint differently per driver — a `target`
+  // field list, or the driver error's own index name — so read the whole meta.
+  const meta = JSON.stringify(Reflect.get(err, 'meta') ?? '')
+  return meta.includes(HOOK_FAMILY_INDEX) || meta.includes('family')
+}
 
 /** The full ingress URL for a hook's urlToken (pool-level origin + fixed path). */
 export function hookIngressUrl(publicRelayUrl: string, urlToken: string): string {
@@ -81,6 +95,7 @@ function toDto(h: HookRecord, publicRelayUrl?: string): HookDtoT {
     hmacConfigured: h.hmacConfigured,
     repoId: h.repoId?.toString() ?? null,
     repoFullName: h.repoFullName,
+    family: h.family,
     events: h.events,
     commentFamilies: h.commentFamilies,
     labelFilter: h.labelFilter,
@@ -200,7 +215,8 @@ export function hookRoutes(deps: HttpDeps) {
     // The repository repeats the workspace-access invariant under its shared
     // transaction fence. Surface a concurrent loser as the same 409 as the
     // route's fast preflight instead of leaking it as a generic 500.
-    const persistHook = async (input: UpsertHookInput): Promise<HookRecord | AgentWorkspaceIntegrationConflict> => {
+    type PersistOutcome = HookRecord | AgentWorkspaceIntegrationConflict | DuplicateHookFamily
+    const persistHook = async (input: UpsertHookInput): Promise<PersistOutcome> => {
       try {
         // §24.1: every gitlab-kind write carries the instance its repoId names,
         // enabled or not — the disabled path reaches this with no lease at all.
@@ -209,8 +225,56 @@ export function hookRoutes(deps: HttpDeps) {
         return await deps.repos.hook.upsert(fenced)
       } catch (err) {
         if (err instanceof AgentWorkspaceIntegrationConflict) return err
+        if (isHookFamilyCollision(err)) return new DuplicateHookFamily()
         throw err
       }
+    }
+
+    // The pure per-row shape gate: every stored pattern belongs to the row's own
+    // family, comments are scoped to it, and only a change-proposal family may
+    // carry the review/reporting axes. Runs before any upstream call.
+    const familyShapeError = (body: {
+      kind: 'github' | 'gitlab'
+      family: HookFamily
+      events: string[]
+      commentFamilies?: string[]
+      reviewPolicy?: string
+      reportingMode?: string
+      gateMode?: string
+    }): string | null =>
+      hookFamilyShapeError({
+        kind: body.kind,
+        family: body.family,
+        events: body.events,
+        commentFamilies: body.commentFamilies ?? [],
+        reviewPolicy: body.reviewPolicy ?? 'off',
+        reportingMode: body.reportingMode ?? 'off',
+        gateMode: body.gateMode ?? 'informational'
+      })
+
+    // Sibling rows of one (agent, repo) answer the same threads, so they must
+    // agree on where the turn posts. Excludes the row being written.
+    const siblingShapeError = async (
+      agentId: string,
+      kind: HookRecord['kind'],
+      repoId: bigint,
+      repoLabel: string,
+      selfId: string,
+      proposed: { targetPlatform: string; targetChannel: string | null; targetIntegrationId: string | null }
+    ): Promise<string | null> => {
+      const siblings = (await deps.repos.hook.listForAgent(AgentId(agentId))).filter(
+        (h) => h.id !== selfId && h.kind === kind && h.repoId === repoId
+      )
+      return hookSiblingShapeError(
+        siblings.map((h) => ({
+          targetPlatform: h.targetPlatform,
+          targetChannel: h.targetChannel,
+          targetIntegrationId: h.targetIntegrationId,
+          sessionMode: h.sessionMode
+        })),
+        { ...proposed, sessionMode: 'perThread' },
+        repoLabel
+      )
     }
 
     // github kind: resolve "owner/repo" to the NUMERIC repo id through the org's
@@ -435,7 +499,7 @@ export function hookRoutes(deps: HttpDeps) {
           tags: [Tag.Hooks],
           summary: 'Create a hook',
           description:
-            'Create a trigger for one agent. `kind:"webhook"` mints an ingress URL (the response carries it plus — when requested — the one-time HMAC signing secret, never retrievable again). `kind:"github"` subscribes a repository covered by one of the organization’s GitHub App installations to issue/PR events.',
+            'Create a trigger for one agent. `kind:"webhook"` mints an ingress URL (the response carries it plus — when requested — the one-time HMAC signing secret, never retrievable again). `kind:"github"` subscribes a repository covered by one of the organization’s GitHub App installations to issue/PR events. A code-host trigger covers ONE subject `family`, so a repository watched for both pull requests and issues is two triggers, each with its own cadence and mention gate; a second trigger on the same family is a 409.',
           operationId: 'createHook',
           body: CreateHookBody,
           response: { 200: CreatedHookDto, 400: ErrorDto, 403: ErrorDto, 409: ErrorDto, 429: ErrorDto, 502: ErrorDto }
@@ -462,6 +526,20 @@ export function hookRoutes(deps: HttpDeps) {
             message: 'targetIntegrationId is not an integration of this agent'
           })
         }
+        if (req.body.kind !== 'webhook') {
+          const shapeError = familyShapeError({
+            kind: req.body.kind,
+            family: req.body.family,
+            events: req.body.events,
+            commentFamilies: req.body.commentFamilies,
+            reviewPolicy: req.body.reviewPolicy,
+            reportingMode: req.body.reportingMode,
+            gateMode: req.body.kind === 'github' ? req.body.gateMode : 'informational'
+          })
+          if (shapeError) {
+            return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: shapeError })
+          }
+        }
         // Server-minted identifiers: the row id and (webhook kind) the ≥128-bit
         // capability token. Prefixes follow the Stripe-style shapes (whk_ / whsec_).
         const hookId = HookId(randomUUID())
@@ -486,15 +564,22 @@ export function hookRoutes(deps: HttpDeps) {
                       message: 'the project is not a managed GitLab binding in this organization'
                     }
                   }
-                  const dup = (await deps.repos.hook.listForAgent(agent.id)).some(
-                    (h) => h.kind === 'gitlab' && h.repoId === projectId
-                  )
-                  if (dup) {
-                    return {
-                      ok: false as const,
-                      status: 409 as const,
-                      message: `this agent already watches ${binding.projectPath}`
+                  // A duplicate family is the database's own rule; what only the
+                  // route can see is a sibling family anchored somewhere else.
+                  const siblingError = await siblingShapeError(
+                    agent.id,
+                    'gitlab',
+                    projectId,
+                    binding.projectPath,
+                    hookId,
+                    {
+                      targetPlatform: target.targetPlatform,
+                      targetChannel: req.body.targetChannel ?? null,
+                      targetIntegrationId: target.targetIntegrationId ?? null
                     }
+                  )
+                  if (siblingError) {
+                    return { ok: false as const, status: 409 as const, message: siblingError }
                   }
                   // §8.3: creating a hook never creates a grant, so the project must
                   // ALREADY be the workspace or an explicit additional authorization.
@@ -517,17 +602,20 @@ export function hookRoutes(deps: HttpDeps) {
               : await (async () => {
                   const repo = await resolveGithubRepo(orgId, (req.body as { repoFullName: string }).repoFullName)
                   if (!repo.ok) return repo
-                  // One subscription per (agent, repo): edit the existing hook's
-                  // events instead of stacking duplicates that would double-fire.
-                  const dup = (await deps.repos.hook.listForAgent(agent.id)).some(
-                    (h) => h.kind === 'github' && h.repoId === repo.repoId
-                  )
-                  if (dup) {
-                    return {
-                      ok: false as const,
-                      status: 409 as const,
-                      message: `this agent already watches ${repo.repoFullName}`
+                  const siblingError = await siblingShapeError(
+                    agent.id,
+                    'github',
+                    repo.repoId,
+                    repo.repoFullName,
+                    hookId,
+                    {
+                      targetPlatform: target.targetPlatform,
+                      targetChannel: req.body.targetChannel ?? null,
+                      targetIntegrationId: target.targetIntegrationId ?? null
                     }
+                  )
+                  if (siblingError) {
+                    return { ok: false as const, status: 409 as const, message: siblingError }
                   }
                   const authz = await watchRepoAuthorized(agent, 'github', repo.repoId, repo.repoFullName)
                   if (!authz.ok) return authz
@@ -553,7 +641,7 @@ export function hookRoutes(deps: HttpDeps) {
           return reply.code(status).send({ error: ERROR_NAMES[status], statusCode: status, message })
         }
         const { hmacSecret, ...upsertFields } = kindFields
-        const writeHook = (): Promise<HookRecord | AgentWorkspaceIntegrationConflict> =>
+        const writeHook = (): Promise<PersistOutcome> =>
           persistHook({
             hookId,
             orgId,
@@ -564,6 +652,7 @@ export function hookRoutes(deps: HttpDeps) {
             ...upsertFields,
             ...(req.body.kind === 'github'
               ? {
+                  family: req.body.family,
                   events: req.body.events,
                   commentFamilies: req.body.commentFamilies,
                   labelFilter: req.body.labelFilter,
@@ -575,6 +664,7 @@ export function hookRoutes(deps: HttpDeps) {
               : {}),
             ...(req.body.kind === 'gitlab'
               ? {
+                  family: req.body.family,
                   events: req.body.events,
                   commentFamilies: req.body.commentFamilies,
                   mentionOnly: req.body.mentionOnly,
@@ -602,6 +692,15 @@ export function hookRoutes(deps: HttpDeps) {
         const hook = written.result
         if (hook instanceof AgentWorkspaceIntegrationConflict) {
           return reply.code(409).send({ error: ERROR_NAMES[409], statusCode: 409, message: hook.message })
+        }
+        if (hook instanceof DuplicateHookFamily) {
+          const label = 'repoFullName' in upsertFields ? upsertFields.repoFullName : null
+          const family = req.body.kind === 'webhook' ? null : req.body.family
+          return reply.code(409).send({
+            error: ERROR_NAMES[409],
+            statusCode: 409,
+            message: `this agent already watches ${label} (${family})`
+          })
         }
         if (hmacSecret) await deps.repos.hookSecret.put(orgOf(req), hookId, hmacSecret)
         void deps.repos.audit
@@ -681,7 +780,7 @@ export function hookRoutes(deps: HttpDeps) {
           tags: [Tag.Hooks],
           summary: 'Update a hook',
           description:
-            'Update a hook definition. `kind` is immutable (it discriminates the body); a webhook hook’s ingress URL and signing secret are immutable too — rotating either is a delete + re-create. A github hook’s repository may be re-targeted (re-validated against the organization’s installations).',
+            'Update a hook definition. `kind` is immutable (it discriminates the body); so is a code-host trigger’s subject `family`, which is why the update body carries none — delete and re-create to change it. A webhook hook’s ingress URL and signing secret are immutable too — rotating either is a delete + re-create. A github hook’s repository may be re-targeted (re-validated against the organization’s installations).',
           operationId: 'updateHook',
           params: IdParam,
           body: UpdateHookBody,
@@ -745,6 +844,20 @@ export function hookRoutes(deps: HttpDeps) {
             reportingMode: req.body.reportingMode ?? existing.reportingMode,
             gateMode: req.body.gateMode ?? existing.gateMode
           }
+          // The family is immutable, so the edit is re-shaped against the STORED
+          // one. A legacy row the split could not place has none and is grandfathered.
+          const shapeError = existing.family
+            ? familyShapeError({
+                kind: 'github',
+                family: existing.family as HookFamily,
+                events: req.body.events,
+                commentFamilies: req.body.commentFamilies ?? existing.commentFamilies,
+                ...effectConfig
+              })
+            : null
+          if (shapeError) {
+            return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: shapeError })
+          }
           // Future modes remain fail-closed even on a disabled definition; a
           // later re-enable must never activate a value R2a cannot execute.
           if (effectConfig.gateMode === 'required' || effectConfig.reportingMode === 'status') {
@@ -777,17 +890,22 @@ export function hookRoutes(deps: HttpDeps) {
             const { status, message } = repo
             return reply.code(status).send({ error: ERROR_NAMES[status], statusCode: status, message })
           }
-          // Same one-subscription-per-(agent, repo) rule as create — a re-target
-          // onto a repo another hook of this agent already watches would double-fire.
-          const dup = (await deps.repos.hook.listForAgent(agent.id)).some(
-            (h) => h.id !== existing.id && h.kind === 'github' && h.repoId === repo.repoId
+          // The duplicate-family rule is the database's; the route's own check is
+          // that the sibling families of this repo post to the same place.
+          const siblingError = await siblingShapeError(
+            agent.id,
+            'github',
+            repo.repoId,
+            repo.repoFullName,
+            existing.id,
+            {
+              targetPlatform: target.targetPlatform,
+              targetChannel: req.body.targetChannel ?? null,
+              targetIntegrationId: target.targetIntegrationId ?? null
+            }
           )
-          if (dup) {
-            return reply.code(409).send({
-              error: ERROR_NAMES[409],
-              statusCode: 409,
-              message: `this agent already watches ${repo.repoFullName}`
-            })
+          if (siblingError) {
+            return reply.code(409).send({ error: ERROR_NAMES[409], statusCode: 409, message: siblingError })
           }
           // Binding-CHANGING edits go through the authorization gate — a new
           // repo, or the same repo moved onto a different agent. An edit that
@@ -835,15 +953,20 @@ export function hookRoutes(deps: HttpDeps) {
               message: 'the project is not a managed GitLab binding in this organization'
             })
           }
-          const dup = (await deps.repos.hook.listForAgent(agent.id)).some(
-            (h) => h.id !== existing.id && h.kind === 'gitlab' && h.repoId === projectId
+          const siblingError = await siblingShapeError(
+            agent.id,
+            'gitlab',
+            projectId,
+            binding.projectPath,
+            existing.id,
+            {
+              targetPlatform: target.targetPlatform,
+              targetChannel: req.body.targetChannel ?? null,
+              targetIntegrationId: target.targetIntegrationId ?? null
+            }
           )
-          if (dup) {
-            return reply.code(409).send({
-              error: ERROR_NAMES[409],
-              statusCode: 409,
-              message: `this agent already watches ${binding.projectPath}`
-            })
+          if (siblingError) {
+            return reply.code(409).send({ error: ERROR_NAMES[409], statusCode: 409, message: siblingError })
           }
           // Binding-CHANGING edits go through the §8.3 gate — a new project, or the
           // same project moved onto a different agent. An edit that keeps the
@@ -861,6 +984,18 @@ export function hookRoutes(deps: HttpDeps) {
           const effectConfig = {
             reviewPolicy: req.body.reviewPolicy ?? existing.reviewPolicy,
             reportingMode: req.body.reportingMode ?? existing.reportingMode
+          }
+          const shapeError = existing.family
+            ? familyShapeError({
+                kind: 'gitlab',
+                family: existing.family as HookFamily,
+                events: req.body.events,
+                commentFamilies: req.body.commentFamilies ?? existing.commentFamilies,
+                ...effectConfig
+              })
+            : null
+          if (shapeError) {
+            return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: shapeError })
           }
           const effectError = validateGitlabEffects(binding, effectConfig)
           if (effectError) {
@@ -886,7 +1021,7 @@ export function hookRoutes(deps: HttpDeps) {
         // enablement changes tombstone the old projection epoch before this
         // definition advances to its new epoch.
         const nowEnabled = req.body.enabled ?? existing.enabled
-        const writeHook = (): Promise<HookRecord | AgentWorkspaceIntegrationConflict> =>
+        const writeHook = (): Promise<PersistOutcome> =>
           persistHook({
             hookId: existing.id,
             expectedAgentId: existing.agentId!,
@@ -913,6 +1048,15 @@ export function hookRoutes(deps: HttpDeps) {
         const hook = written.result
         if (hook instanceof AgentWorkspaceIntegrationConflict) {
           return reply.code(409).send({ error: ERROR_NAMES[409], statusCode: 409, message: hook.message })
+        }
+        // A retarget carries the row's own family onto the new repository, where
+        // another row of this agent may already own it.
+        if (hook instanceof DuplicateHookFamily) {
+          return reply.code(409).send({
+            error: ERROR_NAMES[409],
+            statusCode: 409,
+            message: `this agent already watches ${kindFields.repoFullName} (${existing.family})`
+          })
         }
         void deps.repos.audit
           .append({

--- a/packages/control-plane/src/orchestrator/hookRedeliveryReconciler.test.ts
+++ b/packages/control-plane/src/orchestrator/hookRedeliveryReconciler.test.ts
@@ -239,6 +239,27 @@ describe('HookRedeliveryReconciler', () => {
     expect(pullRequest.redelivered).toEqual(['7', '8'])
   })
 
+  // The summary carries no issue-vs-PR subject, so BOTH family rows are handed
+  // to the claim; deciding which of them actually landed a run is its job.
+  it('offers both comment-family sibling rows as candidates for one issue_comment GUID', async () => {
+    const pullRow = HookId('33333333-3333-4333-8333-333333333333')
+    const issuesRow = HookId('44444444-4444-4444-8444-444444444444')
+    const h = make({
+      hooks: [
+        ghHook({ id: pullRow, events: ['pull_request:*', 'issue_comment:created'], commentFamilies: ['pull_request'] }),
+        ghHook({ id: issuesRow, events: ['issues:*', 'issue_comment:created'], commentFamilies: ['issues'] })
+      ],
+      deliveries: [delivery({ id: '9', guid: 'shared-comment', event: 'issue_comment', action: 'created' })],
+      landed: ['shared-comment'],
+      claim: true
+    })
+    await h.reconciler.tick()
+    expect(h.claimMock).toHaveBeenCalledWith('shared-comment', [pullRow, issuesRow], new Date(NOW), [
+      ...FAILED_DELIVERY_BACKOFF_MS
+    ])
+    expect(h.redelivered).toEqual(['9'])
+  })
+
   it('silences issue/PR edits and close/reopen events', async () => {
     const h = make({
       hooks: [ghHook({ events: ['issues:*', 'pull_request:*'] })],

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -2208,8 +2208,11 @@ export interface UpsertHookInput {
   /** GitHub numeric repo id — the relay match key (rename-immune, decision 6). */
   repoId?: bigint
   repoFullName?: string
+  /** The one subject family this row covers; absent on update leaves it as it is
+   *  (immutable), and absent on a create leaves a legacy family-less row. */
+  family?: string
   events?: string[]
-  /** Empty preserves the published API's legacy repo-wide issue_comment semantics. */
+  /** Scopes GitHub's shared issue_comment subscription to this row's family. */
   commentFamilies?: HookCommentFamily[]
   labelFilter?: string[]
   mentionOnly?: boolean
@@ -2244,6 +2247,9 @@ export interface HookRecord {
   /** Immutable relay session namespace. Existing rows retain their historical
    * owner/repo prefix; new rows use the numeric repository identity. */
   githubSessionKey?: string | null
+  /** The one subject family this row covers; null for webhook kind and for a
+   *  legacy row the family split could not place. */
+  family: string | null
   events: string[]
   /** Empty = legacy repo-wide comments; non-empty scopes comments to these subjects. */
   commentFamilies: HookCommentFamily[]

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -2089,17 +2089,32 @@ export class PgHookRepo implements HookRepo {
       const landedSet = new Set<string>(landed)
       const unlanded = expected.filter((hookId) => !landedSet.has(hookId))
       if (unlanded.length > 0) {
-        // The payload is immutable but the relay rule is not: a candidate whose
-        // definition changed since the GUID was ingested (created, re-enabled,
-        // mention/label filter relaxed) may no longer reproduce the original
-        // filtering and would read the redelivery as a first run of a stale
-        // event. Every user-facing edit bumps lastModifiedAt, so it fences all
-        // of those at once (creation included — it starts equal to createdAt).
+        // Tolerating an unlanded candidate needs proof its EFFECTIVE relay rule
+        // is the one that filtered the original delivery — the payload is
+        // immutable, the rule is not. A candidate on the same agent as a landed
+        // row carries that proof structurally: the landed run shows the agent
+        // was live and routing at ingestion, and family uniqueness plus the
+        // per-row shape gate keep a sibling family from ever matching this
+        // event. The two lastModifiedAt fences (hook and agent — every
+        // user-facing edit bumps them, creation/rename/pause included) stay as
+        // defense in depth. Anything else — cross-agent candidates above all,
+        // whose pause/rename history this claim cannot reconstruct — blocks,
+        // exactly as the pre-split exact-fanout claim did. A deleted candidate
+        // stays tolerated: the relay no longer holds a rule for it.
         const deliveredAt = new Date(Math.min(...rows.map((row) => row.startedAt.getTime())))
-        const postdating = await tx.hookDef.count({
-          where: { id: { in: unlanded }, lastModifiedAt: { gt: deliveredAt } }
+        const landedAgentIds = new Set(rows.map((row) => row.agentId).filter((id): id is string => id !== null))
+        const candidates = await tx.hookDef.findMany({
+          where: { id: { in: unlanded } },
+          select: { agentId: true, lastModifiedAt: true, agent: { select: { lastModifiedAt: true } } }
         })
-        if (postdating > 0) {
+        const unsafeCandidate = candidates.some(
+          (candidate) =>
+            candidate.agentId === null ||
+            !landedAgentIds.has(candidate.agentId) ||
+            candidate.lastModifiedAt > deliveredAt ||
+            (candidate.agent !== null && candidate.agent.lastModifiedAt > deliveredAt)
+        )
+        if (unsafeCandidate) {
           await settleActive()
           return false
         }

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -90,6 +90,7 @@ function toRecord(h: HookWithUsers): HookRecord {
     repoId: h.repoId,
     repoFullName: h.repoFullName,
     githubSessionKey: h.githubSessionKey,
+    family: h.family,
     events: h.events,
     commentFamilies: h.commentFamilies as GithubCommentFamily[],
     labelFilter: h.labelFilter,
@@ -503,6 +504,8 @@ export class PgHookRepo implements HookRepo {
       // re-target allowed); webhook kind never sends it, and these stay null/[].
       repoId: input.repoId ?? null,
       repoFullName: input.repoFullName ?? null,
+      // Immutable: an update never carries it, so omission must preserve the row's own.
+      ...(input.family !== undefined ? { family: input.family } : {}),
       events: input.events ?? [],
       commentFamilies: input.commentFamilies ?? [],
       labelFilter: input.labelFilter ?? [],
@@ -567,11 +570,22 @@ export class PgHookRepo implements HookRepo {
         }
         const nextReportingMode = input.reportingMode ?? existing?.reportingMode ?? 'off'
         const nextGateMode = input.gateMode ?? existing?.gateMode ?? 'informational'
+        // Sibling family rows of one (agent, repo) answer the same threads, so
+        // they must share one session namespace — including a grandfathered
+        // owner/repo prefix, which a freshly minted numeric key would diverge from.
+        const siblingKeyRow =
+          input.kind === 'github' && input.repoId !== undefined && existing?.repoId !== input.repoId
+            ? await tx.hookDef.findFirst({
+                where: { id: { not: input.hookId }, agentId: input.agentId, kind: 'github', repoId: input.repoId },
+                select: { githubSessionKey: true, repoFullName: true },
+                orderBy: { createdAt: 'asc' }
+              })
+            : null
         const githubSessionKey =
           input.kind === 'github' && input.repoId !== undefined
             ? existing?.kind === 'github' && existing.repoId === input.repoId
               ? (existing.githubSessionKey ?? existing.repoFullName ?? `github:${input.repoId}`)
-              : `github:${input.repoId}`
+              : (siblingKeyRow?.githubSessionKey ?? siblingKeyRow?.repoFullName ?? `github:${input.repoId}`)
             : null
         const lifecycleChanged =
           existing !== null &&

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -570,22 +570,28 @@ export class PgHookRepo implements HookRepo {
         }
         const nextReportingMode = input.reportingMode ?? existing?.reportingMode ?? 'off'
         const nextGateMode = input.gateMode ?? existing?.gateMode ?? 'informational'
-        // Sibling family rows of one (agent, repo) answer the same threads, so
-        // they must share one session namespace — including a grandfathered
-        // owner/repo prefix, which a freshly minted numeric key would diverge from.
+        // Sibling rows of one (agent, repo) answer the same threads: one session namespace, grandfathered prefix included.
+        // A moved binding (repo or agent) re-reads the destination's siblings, whose key wins over this row's own.
+        const bindingMoved = existing?.repoId !== input.repoId || existing?.agentId !== input.agentId
         const siblingKeyRow =
-          input.kind === 'github' && input.repoId !== undefined && existing?.repoId !== input.repoId
+          input.kind === 'github' && input.repoId !== undefined && bindingMoved
             ? await tx.hookDef.findFirst({
                 where: { id: { not: input.hookId }, agentId: input.agentId, kind: 'github', repoId: input.repoId },
                 select: { githubSessionKey: true, repoFullName: true },
                 orderBy: { createdAt: 'asc' }
               })
             : null
+        // Only a row still on this repo may keep its own key; a repo move mints fresh.
+        const ownSessionKey =
+          existing?.kind === 'github' && existing.repoId === input.repoId
+            ? (existing.githubSessionKey ?? existing.repoFullName)
+            : null
         const githubSessionKey =
           input.kind === 'github' && input.repoId !== undefined
-            ? existing?.kind === 'github' && existing.repoId === input.repoId
-              ? (existing.githubSessionKey ?? existing.repoFullName ?? `github:${input.repoId}`)
-              : (siblingKeyRow?.githubSessionKey ?? siblingKeyRow?.repoFullName ?? `github:${input.repoId}`)
+            ? (siblingKeyRow?.githubSessionKey ??
+              siblingKeyRow?.repoFullName ??
+              ownSessionKey ??
+              `github:${input.repoId}`)
             : null
         const lifecycleChanged =
           existing !== null &&
@@ -2071,23 +2077,30 @@ export class PgHookRepo implements HookRepo {
         })
       }
 
-      // A GitHub redelivery broadcasts to every hook that currently matches
-      // the GUID. It is safe only when that exact fanout already has one active,
-      // side-effect-free retry row per hook. A success, pause/no-agent verdict,
-      // newly-created hook, removed hook, or effect-bearing row blocks the whole
-      // POST because daemon dedup is local rather than cross-placement.
+      // Landed rows must be a SUBSET of the candidate fanout, each an active side-effect-free retry row: a success,
+      // verdict, effect-bearing row, or a landed row from outside the set blocks the POST (daemon dedup is local).
+      // An unlanded candidate is the relay's own precise filtering, which the payload reproduces, so it is tolerated.
       const landed = [...new Set(rows.map((row) => row.hookId))].sort()
-      if (
-        expected.length !== landed.length ||
-        expected.some((hookId, index) => hookId !== landed[index]) ||
-        active.length !== rows.length
-      ) {
+      const expectedSet = new Set<string>(expected)
+      if (rows.length === 0 || landed.some((hookId) => !expectedSet.has(hookId)) || active.length !== rows.length) {
         await settleActive()
         return false
       }
+      const landedSet = new Set<string>(landed)
+      const unlanded = expected.filter((hookId) => !landedSet.has(hookId))
+      if (unlanded.length > 0) {
+        // A hook created after the relay ingested this GUID would read the
+        // redelivery as a first run of a stale event, so it still blocks.
+        const deliveredAt = new Date(Math.min(...rows.map((row) => row.startedAt.getTime())))
+        const postdating = await tx.hookDef.count({ where: { id: { in: unlanded }, createdAt: { gt: deliveredAt } } })
+        if (postdating > 0) {
+          await settleActive()
+          return false
+        }
+      }
 
       const currentHooks = await tx.hookDef.findMany({
-        where: { id: { in: expected }, enabled: true, kind: 'github' },
+        where: { id: { in: landed }, enabled: true, kind: 'github' },
         select: {
           id: true,
           agentId: true,
@@ -2113,7 +2126,7 @@ export class PgHookRepo implements HookRepo {
           return false
         return true
       })
-      if (currentHooks.length !== expected.length || !authoritySafe) {
+      if (currentHooks.length !== landed.length || !authoritySafe) {
         await settleActive()
         return false
       }

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -2089,10 +2089,16 @@ export class PgHookRepo implements HookRepo {
       const landedSet = new Set<string>(landed)
       const unlanded = expected.filter((hookId) => !landedSet.has(hookId))
       if (unlanded.length > 0) {
-        // A hook created after the relay ingested this GUID would read the
-        // redelivery as a first run of a stale event, so it still blocks.
+        // The payload is immutable but the relay rule is not: a candidate whose
+        // definition changed since the GUID was ingested (created, re-enabled,
+        // mention/label filter relaxed) may no longer reproduce the original
+        // filtering and would read the redelivery as a first run of a stale
+        // event. Every user-facing edit bumps lastModifiedAt, so it fences all
+        // of those at once (creation included — it starts equal to createdAt).
         const deliveredAt = new Date(Math.min(...rows.map((row) => row.startedAt.getTime())))
-        const postdating = await tx.hookDef.count({ where: { id: { in: unlanded }, createdAt: { gt: deliveredAt } } })
+        const postdating = await tx.hookDef.count({
+          where: { id: { in: unlanded }, lastModifiedAt: { gt: deliveredAt } }
+        })
         if (postdating > 0) {
           await settleActive()
           return false

--- a/packages/control-plane/test/integration/agent-repos.route.test.ts
+++ b/packages/control-plane/test/integration/agent-repos.route.test.ts
@@ -957,6 +957,7 @@ describe('agent repo authorizations REST — grant, list, revoke, gates', () => 
       kind: 'github',
       name: 'gh-hook',
       repoFullName: 'acme/tools',
+      family: 'issues',
       events: ['issues:opened'],
       ...over
     })

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -229,15 +229,22 @@ function channel(features?: string[], answer?: RcHookRerunResult | (() => RcHook
   return { ch, sent, requests }
 }
 
+// One row per (agent, project, family): the default body is the MERGE_REQUEST
+// family, the only one that may carry the review and reporting axes.
 const glBody = (agentId: string, over: Record<string, unknown> = {}) => ({
   agentId,
   kind: 'gitlab',
   name: 'gl-hook',
   projectId: PROJECT.toString(),
-  events: ['issues:*', 'merge_request:opened'],
-  commentFamilies: ['issues', 'merge_request'],
+  family: 'merge_request',
+  events: ['merge_request:*'],
+  commentFamilies: ['merge_request'],
   ...over
 })
+
+/** The issues family on the same project — a sibling row, not an edit. */
+const glIssuesBody = (agentId: string, over: Record<string, unknown> = {}) =>
+  glBody(agentId, { name: 'gl-issues', family: 'issues', events: ['issues:*'], commentFamilies: ['issues'], ...over })
 
 describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.3)', () => {
   it('create compiles a rule for feature-advertising relays only, and installs the managed webhook', async () => {
@@ -256,20 +263,32 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect(res.statusCode).toBe(200)
     const dto = res.json() as { id: string; kind: string; url: string | null }
     expect(dto.kind).toBe('gitlab')
+    // A sibling family row on the same project: the webhook union spans both.
+    expect(
+      (await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glIssuesBody(h.agentId) })).statusCode
+    ).toBe(200)
 
-    // The converge kick installs the webhook (§11.1) with the hook's union…
+    // The converge kick installs the webhook (§11.1) with the hooks' union…
     await vi.waitFor(() => expect(h.fake.webhooks.size).toBe(1), { timeout: 20_000 })
     const webhook = [...h.fake.webhooks.values()][0]!
     expect(webhook.url).toBe(`${RELAY_URL}/webhooks/gitlab`)
-    expect(webhook.events['issues_events']).toBe(true)
-    expect(webhook.events['merge_requests_events']).toBe(true)
-    expect(webhook.events['note_events']).toBe(true)
-    expect(webhook.events['push_events']).toBeFalsy()
+    await vi.waitFor(
+      () => {
+        const current = [...h.fake.webhooks.values()][0]!
+        expect(current.events['issues_events']).toBe(true)
+        expect(current.events['merge_requests_events']).toBe(true)
+        expect(current.events['note_events']).toBe(true)
+        expect(current.events['push_events']).toBeFalsy()
+      },
+      { timeout: 20_000 }
+    )
 
     // …then re-broadcasts the now-complete rule, only to relays advertising the feature (§17.3).
     await vi.waitFor(
       () => {
-        const assigns = glab.sent.filter((frame) => frame.type === 'rc/hook-assign')
+        const assigns = glab.sent.filter(
+          (frame) => frame.type === 'rc/hook-assign' && (frame.payload as RcHookAssign).hookId === dto.id
+        )
         expect(assigns.length).toBeGreaterThan(0)
         const rule = assigns.at(-1)!.payload as RcHookAssign
         expect(rule.kind).toBe('gitlab')
@@ -281,7 +300,8 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
         // §12.1 veto set: every account bound to the project (§7.2).
         expect(rule.gitlab?.boundServiceAccountUserIds).toEqual([rule.gitlab!.serviceAccountUserId])
         expect(rule.gitlab?.signingToken).toBe(webhook.token)
-        expect(rule.gitlab?.events).toEqual(['issues:*', 'merge_request:opened'])
+        expect(rule.gitlab?.events).toEqual(['merge_request:*'])
+        expect(rule.gitlab?.commentFamilies).toEqual(['merge_request'])
         // The value never reaches the rule; the empty array only keeps an older relay decoding.
         expect(rule.gitlab?.labelFilter).toEqual([])
       },
@@ -498,7 +518,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     expect(moved.statusCode).toBe(409)
   })
 
-  it('create is fenced on a managed binding; a second hook on the same project+agent is a 409', async () => {
+  it('create is fenced on a managed binding; a second hook on the same project+agent+family is a 409', async () => {
     const h = await harness()
     const unbound = await h.a.app.inject({
       method: 'POST',
@@ -512,6 +532,11 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     )
     const dup = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glBody(h.agentId) })
     expect(dup.statusCode).toBe(409)
+    expect((dup.json() as { message: string }).message).toMatch(/already watches .* \(merge_request\)/)
+    // Another FAMILY on the same project is exactly what the split allows.
+    expect(
+      (await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: glIssuesBody(h.agentId) })).statusCode
+    ).toBe(200)
   })
 
   it('delete drops the rule and uninstalls the webhook once no hook wants events (§11.1 inverse)', async () => {
@@ -625,19 +650,35 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     })
     expect(retarget.statusCode).toBe(409)
 
+    // An in-family cadence edit lands (the family itself is immutable).
     const ok = await h.a.app.inject({
       method: 'PUT',
       url: `${ORG}/hooks/${hookId}`,
-      payload: glBody(h.agentId, { events: ['push:*'], commentFamilies: [] })
+      payload: glBody(h.agentId, { events: ['merge_request:opened'] })
     })
     expect(ok.statusCode).toBe(200)
     const row = (await h.hookRepo.get(OrgId(DEFAULT_ORG_ID), HookId(hookId)))!
-    expect(row.events).toEqual(['push:*'])
-    // The saga converges the webhook down to the new union.
+    expect(row.events).toEqual(['merge_request:opened'])
+
+    // A sibling push row widens the desired union; disabling it shrinks it back
+    // — the saga converges the managed webhook either way.
+    const pushRow = glBody(h.agentId, { name: 'gl-push', family: 'push', events: ['push:*'], commentFamilies: [] })
+    const pushes = await h.a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: pushRow })
+    expect(pushes.statusCode).toBe(200)
+    await vi.waitFor(() => expect([...h.fake.webhooks.values()][0]!.events['push_events']).toBe(true), {
+      timeout: 20_000
+    })
+    const disabled = await h.a.app.inject({
+      method: 'PUT',
+      url: `${ORG}/hooks/${(pushes.json() as { id: string }).id}`,
+      payload: { ...pushRow, enabled: false }
+    })
+    expect(disabled.statusCode).toBe(200)
     await vi.waitFor(
       () => {
         const webhook = [...h.fake.webhooks.values()][0]!
-        expect(webhook.events['push_events']).toBe(true)
+        expect(webhook.events['merge_requests_events']).toBe(true)
+        expect(webhook.events['push_events']).toBeFalsy()
         expect(webhook.events['issues_events']).toBeFalsy()
       },
       { timeout: 20_000 }

--- a/packages/control-plane/test/integration/hook-family-migration.test.ts
+++ b/packages/control-plane/test/integration/hook-family-migration.test.ts
@@ -1,0 +1,243 @@
+/**
+ * The `hook_family_split` backfill (webhook-triggers-and-github-events.md).
+ *
+ * Legacy rows held every subject family of one (agent, repo) in ONE row. The
+ * migration splits them into one row per family, keeping the review-capable
+ * family on the existing id — projections, review leases and run history all
+ * key on it. This test inserts legacy-shaped rows into the already-migrated
+ * test database and re-executes the migration file verbatim, which is why that
+ * file must be idempotent.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { prisma } from '../setup.db.js'
+import { seedAgent, seedDaemon } from '../fixtures/seed.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+
+const DAEMON = 'd7d7d7d7-dddd-4ddd-8ddd-dddddddddddd'
+const MIGRATION = fileURLToPath(
+  new URL('../../prisma/migrations/20260917000000_hook_family_split/migration.sql', import.meta.url)
+)
+
+let migrationSql: string
+beforeAll(async () => {
+  migrationSql = await readFile(MIGRATION, 'utf8')
+})
+
+/** Split the file into executable statements, keeping `$$ … $$` blocks whole. */
+function statements(sql: string): string[] {
+  const parts: string[] = []
+  let buf = ''
+  let inDollarBlock = false
+  for (let i = 0; i < sql.length; i += 1) {
+    if (sql.startsWith('$$', i)) {
+      inDollarBlock = !inDollarBlock
+      buf += '$$'
+      i += 1
+      continue
+    }
+    if (sql[i] === ';' && !inDollarBlock) {
+      parts.push(buf)
+      buf = ''
+      continue
+    }
+    buf += sql[i]
+  }
+  parts.push(buf)
+  // A trailing segment is comments/whitespace only — Postgres would reject it.
+  return parts.map((part) => part.trim()).filter((part) => /[^\s-]/.test(part.replace(/--[^\n]*/g, '')))
+}
+
+async function runMigration(): Promise<void> {
+  for (const statement of statements(migrationSql)) await prisma.$executeRawUnsafe(statement)
+}
+
+/** A legacy row: one family-less definition holding every subscription. */
+async function legacyHook(
+  agentId: string,
+  over: {
+    kind: 'github' | 'gitlab' | 'webhook'
+    repoId?: bigint
+    events?: string[]
+    commentFamilies?: string[]
+    reviewPolicy?: 'off' | 'full'
+    reportingMode?: 'off' | 'check'
+    configRevision?: bigint
+  }
+): Promise<string> {
+  const id = randomUUID()
+  await prisma.hookDef.create({
+    data: {
+      id,
+      orgId: DEFAULT_ORG_ID,
+      agentId,
+      kind: over.kind,
+      name: 'legacy',
+      sessionMode: over.kind === 'webhook' ? 'perDelivery' : 'perThread',
+      family: null,
+      mentionOnly: true,
+      labelFilter: ['bug'],
+      targetPlatform: 'slack',
+      targetChannel: 'C-legacy',
+      ...(over.kind === 'webhook' ? { urlToken: `whk_${randomUUID().replaceAll('-', '')}` } : {}),
+      ...(over.repoId !== undefined
+        ? { repoId: over.repoId, repoFullName: 'acme/legacy', githubSessionKey: 'acme/legacy' }
+        : {}),
+      events: over.events ?? [],
+      commentFamilies: over.commentFamilies ?? [],
+      reviewPolicy: over.reviewPolicy ?? 'off',
+      reportingMode: over.reportingMode ?? 'off',
+      configRevision: over.configRevision ?? 1n
+    }
+  })
+  return id
+}
+
+const familyRows = (agentId: string, repoId: bigint) =>
+  prisma.hookDef.findMany({ where: { agentId, repoId }, orderBy: { family: 'asc' } })
+
+describe('hook_family_split — legacy rows become one row per subject family', () => {
+  it('splits a multi-family github row, keeping the id and review trio on the pull-request family', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    const repoId = 5001n
+    const legacyId = await legacyHook(agentId, {
+      kind: 'github',
+      repoId,
+      events: ['pull_request:*', 'issues:opened', 'issue_comment:created', 'push:*'],
+      commentFamilies: ['issues', 'pull_request'],
+      reviewPolicy: 'full',
+      reportingMode: 'check',
+      configRevision: 5n
+    })
+
+    await runMigration()
+
+    const rows = await familyRows(agentId, repoId)
+    expect(rows.map((row) => row.family)).toEqual(['issues', 'pull_request', 'push'])
+    const [issues, pullRequest, push] = rows
+
+    // The review-capable family keeps the row id (and therefore its history).
+    expect(pullRequest!.id).toBe(legacyId)
+    expect(pullRequest!.events).toEqual(['pull_request:*', 'issue_comment:created'])
+    expect(pullRequest!.commentFamilies).toEqual(['pull_request'])
+    expect(pullRequest!.reviewPolicy).toBe('full')
+    expect(pullRequest!.reportingMode).toBe('check')
+    // The compiled definition shrank, so the relay must be pushed again.
+    expect(pullRequest!.configRevision).toBe(6n)
+
+    // A sibling is a fresh row at the default fences, never a review row.
+    expect(issues!.events).toEqual(['issues:opened', 'issue_comment:created'])
+    expect(issues!.commentFamilies).toEqual(['issues'])
+    expect(issues!.reviewPolicy).toBe('off')
+    expect(issues!.reportingMode).toBe('off')
+    expect(issues!.configRevision).toBe(1n)
+    expect(push!.events).toEqual(['push:*'])
+    expect(push!.commentFamilies).toEqual([])
+
+    // Everything the family does not decide travels with the split.
+    for (const row of rows) {
+      expect(row.mentionOnly).toBe(true)
+      expect(row.labelFilter).toEqual(['bug'])
+      expect(row.targetChannel).toBe('C-legacy')
+      // Sibling rows answer the same threads: one grandfathered session namespace.
+      expect(row.githubSessionKey).toBe('acme/legacy')
+    }
+
+    // Re-running the file is a no-op: the rows already have a family.
+    await runMigration()
+    expect(await prisma.hookDef.count({ where: { agentId, repoId } })).toBe(3)
+  })
+
+  it('splits a comment-only github rule into both thread families and bumps its revision', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    const repoId = 5002n
+    const legacyId = await legacyHook(agentId, {
+      kind: 'github',
+      repoId,
+      events: ['issue_comment:created'],
+      commentFamilies: []
+    })
+
+    await runMigration()
+
+    const rows = await familyRows(agentId, repoId)
+    expect(rows.map((row) => row.family)).toEqual(['issues', 'pull_request'])
+    for (const row of rows) expect(row.events).toEqual(['issue_comment:created'])
+    expect(rows[0]!.commentFamilies).toEqual(['issues'])
+    expect(rows[1]!.commentFamilies).toEqual(['pull_request'])
+    // The events did not change but the repo-wide comment scope did — narrowing
+    // it IS a new compiled definition.
+    expect(rows.find((row) => row.id === legacyId)!.configRevision).toBe(2n)
+  })
+
+  it('gives a gitlab note-only family its own row, even with no matching event pattern', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    const repoId = 5003n
+    await legacyHook(agentId, {
+      kind: 'gitlab',
+      repoId,
+      events: ['merge_request:*'],
+      commentFamilies: ['issues', 'merge_request']
+    })
+
+    await runMigration()
+
+    const rows = await familyRows(agentId, repoId)
+    expect(rows.map((row) => row.family)).toEqual(['issues', 'merge_request'])
+    // The issues family arrived through the note subscription alone, so it
+    // watches notes and nothing else — an empty event list is valid at the DB.
+    expect(rows[0]!.events).toEqual([])
+    expect(rows[0]!.commentFamilies).toEqual(['issues'])
+    expect(rows[1]!.events).toEqual(['merge_request:*'])
+    expect(rows[1]!.commentFamilies).toEqual(['merge_request'])
+  })
+
+  it('labels a single-family row in place, without a sibling or a revision bump', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    const repoId = 5004n
+    const legacyId = await legacyHook(agentId, {
+      kind: 'github',
+      repoId,
+      events: ['pull_request:*'],
+      commentFamilies: [],
+      configRevision: 3n
+    })
+
+    await runMigration()
+
+    const rows = await familyRows(agentId, repoId)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      id: legacyId,
+      family: 'pull_request',
+      configRevision: 3n,
+      events: ['pull_request:*'],
+      commentFamilies: []
+    })
+  })
+
+  it('leaves a generic webhook row alone — it has no subject family', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId, { daemonId: DAEMON })
+    const legacyId = await legacyHook(agentId, { kind: 'webhook', configRevision: 4n })
+
+    await runMigration()
+
+    expect(await prisma.hookDef.findUniqueOrThrow({ where: { id: legacyId } })).toMatchObject({
+      family: null,
+      configRevision: 4n
+    })
+    expect(await prisma.hookDef.count({ where: { agentId } })).toBe(1)
+  })
+})

--- a/packages/control-plane/test/integration/hook-report.test.ts
+++ b/packages/control-plane/test/integration/hook-report.test.ts
@@ -134,12 +134,13 @@ async function placedCommentFamilyPair(
     reviewPolicy: 'off',
     reportingMode: 'off'
   })
-  // Both rows predate the delivery AND are unmodified since: any later
-  // definition change (lastModifiedAt) blocks the claim by design.
+  // Both rows AND their agent predate the delivery unmodified: any later
+  // definition change (either lastModifiedAt) blocks the claim by design.
   await prisma.hookDef.updateMany({
     where: { id: { in: [pullHookId, issuesHookId] } },
     data: { createdAt, lastModifiedAt: createdAt }
   })
+  await prisma.agent.update({ where: { id: agentId }, data: { lastModifiedAt: createdAt } })
   return { agentId, pullHookId, issuesHookId }
 }
 
@@ -400,6 +401,59 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     })
   })
 
+  it('blocks the claim when an unlanded candidate belongs to another agent', async () => {
+    const firedAt = new Date('2026-07-03T11:07:00.000Z')
+    const backdated = new Date(firedAt.getTime() - 60_000)
+    const pairA = await placedCommentFamilyPair(backdated)
+    const pairB = await placedCommentFamilyPair(backdated)
+    await recordGithubDeliveryFailure(
+      pairA.pullHookId,
+      pairA.agentId,
+      'cross-agent-guid',
+      firedAt,
+      HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+      DAEMON,
+      { event: 'issue_comment:created', subjectKind: 'pull_request' }
+    )
+
+    // B's same-family rule was filtered at ingestion (say, mentionOnly); this
+    // claim cannot reconstruct B's pause/rename history, so B blocks even
+    // though both timestamps predate the delivery.
+    const expected = [HookId(pairA.pullHookId), HookId(pairB.pullHookId)].sort()
+    expect(await repo().claimRetryableDeliveryRedelivery('cross-agent-guid', expected, firedAt, [30_000])).toBe(false)
+    expect(await repo().getRun(HookId(pairA.pullHookId), 'cross-agent-guid')).toMatchObject({
+      redeliveryAttempts: 0,
+      redeliveryNextAttemptAt: null
+    })
+  })
+
+  it('blocks the claim when the shared agent was modified after the delivery', async () => {
+    const firedAt = new Date('2026-07-03T11:08:00.000Z')
+    const { agentId, pullHookId, issuesHookId } = await placedCommentFamilyPair(new Date(firedAt.getTime() - 60_000))
+    await recordGithubDeliveryFailure(
+      pullHookId,
+      agentId,
+      'renamed-agent-guid',
+      firedAt,
+      HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+      DAEMON,
+      { event: 'issue_comment:created', subjectKind: 'pull_request' }
+    )
+    // A rename can change what the sibling's mention gate matches, so an agent
+    // PATCH after ingestion blocks the tolerance.
+    await prisma.agent.update({
+      where: { id: agentId },
+      data: { lastModifiedAt: new Date(firedAt.getTime() + 1_000) }
+    })
+
+    const expected = [HookId(pullHookId), HookId(issuesHookId)].sort()
+    expect(await repo().claimRetryableDeliveryRedelivery('renamed-agent-guid', expected, firedAt, [30_000])).toBe(false)
+    expect(await repo().getRun(HookId(pullHookId), 'renamed-agent-guid')).toMatchObject({
+      redeliveryAttempts: 0,
+      redeliveryNextAttemptAt: null
+    })
+  })
+
   it('blocks the claim when an unlanded candidate was modified after the delivery', async () => {
     const firedAt = new Date('2026-07-03T11:06:00.000Z')
     const { agentId, pullHookId, issuesHookId } = await placedCommentFamilyPair(new Date(firedAt.getTime() - 60_000))
@@ -417,8 +471,8 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
       DAEMON,
       { event: 'issue_comment:created', subjectKind: 'pull_request' }
     )
-    // Relaxing the filter afterwards means the redelivery would no longer be
-    // filtered — the payload is immutable, the rule is not.
+    // Family isolation keeps this sibling from ever matching a PR comment, but
+    // the hook-level fence is defense in depth: ANY post-ingestion edit blocks.
     await prisma.hookDef.update({
       where: { id: issuesHookId },
       data: { mentionOnly: false, lastModifiedAt: new Date(firedAt.getTime() + 1_000) }

--- a/packages/control-plane/test/integration/hook-report.test.ts
+++ b/packages/control-plane/test/integration/hook-report.test.ts
@@ -35,6 +35,7 @@ import {
   type RetryableHookDeliveryReason
 } from '@agentconnect.md/protocol'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import type { HookCommentFamily } from '../../src/persistence/ports.js'
 
 const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const OTHER_DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
@@ -80,7 +81,16 @@ async function seedHook(agentId: string): Promise<string> {
   return hookId
 }
 
-async function seedGithubHook(agentId: string): Promise<string> {
+async function seedGithubHook(
+  agentId: string,
+  over: {
+    family?: string
+    events?: string[]
+    commentFamilies?: HookCommentFamily[]
+    reviewPolicy?: 'off' | 'full'
+    reportingMode?: 'off' | 'check'
+  } = {}
+): Promise<string> {
   const hookId = randomUUID()
   await repo().upsert({
     hookId: HookId(hookId),
@@ -91,13 +101,42 @@ async function seedGithubHook(agentId: string): Promise<string> {
     sessionMode: 'perThread',
     repoId: 987654321n,
     repoFullName: 'acme/infra',
-    events: ['issues:*'],
-    reviewPolicy: 'full',
-    reportingMode: 'check',
+    ...(over.family !== undefined ? { family: over.family } : {}),
+    events: over.events ?? ['issues:*'],
+    ...(over.commentFamilies !== undefined ? { commentFamilies: over.commentFamilies } : {}),
+    reviewPolicy: over.reviewPolicy ?? 'full',
+    reportingMode: over.reportingMode ?? 'check',
     gateMode: 'informational',
     targetPlatform: 'slack'
   })
   return hookId
+}
+
+/** The motivating configuration of the family split: one repo watched for PR
+ *  comments and issue comments as two rows sharing one issue_comment cadence. */
+async function placedCommentFamilyPair(
+  createdAt: Date
+): Promise<{ agentId: string; pullHookId: string; issuesHookId: string }> {
+  // A test may build two pairs, so the shared daemon is seeded at most once.
+  if ((await prisma.daemon.count({ where: { id: DAEMON } })) === 0) await seedDaemon(prisma, DAEMON)
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, { daemonId: DAEMON })
+  await prisma.agent.update({ where: { id: agentId }, data: { status: 'active' } })
+  const pullHookId = await seedGithubHook(agentId, {
+    family: 'pull_request',
+    events: ['pull_request:*', 'issue_comment:created'],
+    commentFamilies: ['pull_request']
+  })
+  const issuesHookId = await seedGithubHook(agentId, {
+    family: 'issues',
+    events: ['issues:*', 'issue_comment:created'],
+    commentFamilies: ['issues'],
+    reviewPolicy: 'off',
+    reportingMode: 'off'
+  })
+  // Both rows predate the delivery: a hook created afterwards blocks by design.
+  await prisma.hookDef.updateMany({ where: { id: { in: [pullHookId, issuesHookId] } }, data: { createdAt } })
+  return { agentId, pullHookId, issuesHookId }
 }
 
 async function placedHook(daemonId = DAEMON): Promise<{ agentId: string; hookId: string }> {
@@ -121,13 +160,14 @@ async function recordGithubDeliveryFailure(
   deliveryKey: string,
   firedAt: Date,
   reason: RetryableHookDeliveryReason | typeof HOOK_DELIVERY_REASON_DISPATCH_TIMEOUT,
-  daemonId = DAEMON
+  daemonId = DAEMON,
+  over: { event?: string; subjectKind?: string } = {}
 ) {
   const hook = (await repo().getUnscoped(HookId(hookId)))!
   await repo().recordDelivery(HookId(hookId), {
     deliveryKey,
     firedAt,
-    event: 'issues:opened',
+    event: over.event ?? 'issues:opened',
     status: 'failed',
     reason,
     agentId: AgentId(agentId),
@@ -139,7 +179,7 @@ async function recordGithubDeliveryFailure(
     gateModeSnapshot: hook.gateMode,
     repoId: hook.repoId ?? undefined,
     repoFullName: hook.repoFullName ?? undefined,
-    subjectKind: 'issue'
+    subjectKind: over.subjectKind ?? 'issue'
   })
   return hook
 }
@@ -274,7 +314,7 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     expect(rows.every((row) => row.redeliveryLastRequestedAt?.getTime() === firedAt.getTime())).toBe(true)
   })
 
-  it('blocks a GUID-wide redelivery when any current fanout sibling is nonretryable or missing', async () => {
+  it('blocks a GUID-wide redelivery when any landed fanout sibling is nonretryable', async () => {
     const { agentId, hookId } = await placedGithubHook()
     const siblingHookId = await seedGithubHook(agentId)
     const firedAt = new Date('2026-07-03T10:30:00.000Z')
@@ -301,23 +341,134 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
       )
     ).toBe(false)
     expect(await repo().getRun(HookId(hookId), 'mixed-guid')).toMatchObject({ redeliveryNextAttemptAt: null })
+  })
 
+  // The reconciler cannot tell an issue comment from a PR comment in a delivery
+  // summary, so both sibling family rows are always candidates for one GUID.
+  it('redelivers a comment failure that landed only on the subject family that matched', async () => {
+    const firedAt = new Date('2026-07-03T11:00:00.000Z')
+    const { agentId, pullHookId, issuesHookId } = await placedCommentFamilyPair(new Date(firedAt.getTime() - 60_000))
     await recordGithubDeliveryFailure(
-      hookId,
+      pullHookId,
       agentId,
-      'missing-sibling-guid',
+      'pull-comment-guid',
       firedAt,
-      HOOK_DELIVERY_REASON_DAEMON_OFFLINE
+      HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+      DAEMON,
+      { event: 'issue_comment:created', subjectKind: 'pull_request' }
     )
+
+    const expected = [HookId(pullHookId), HookId(issuesHookId)].sort()
+    expect(await repo().claimRetryableDeliveryRedelivery('pull-comment-guid', expected, firedAt, [30_000])).toBe(true)
+    expect(await repo().getRun(HookId(pullHookId), 'pull-comment-guid')).toMatchObject({
+      redeliveryAttempts: 1,
+      redeliveryLastRequestedAt: firedAt,
+      redeliveryNextAttemptAt: new Date(firedAt.getTime() + 30_000)
+    })
+    // The sibling family never landed a row and must not be invented.
+    expect(await repo().getRun(HookId(issuesHookId), 'pull-comment-guid')).toBeNull()
+  })
+
+  it('blocks the claim when an unlanded candidate hook was created after the delivery', async () => {
+    const firedAt = new Date('2026-07-03T11:05:00.000Z')
+    const { agentId, pullHookId, issuesHookId } = await placedCommentFamilyPair(new Date(firedAt.getTime() - 60_000))
+    await recordGithubDeliveryFailure(
+      pullHookId,
+      agentId,
+      'late-sibling-guid',
+      firedAt,
+      HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+      DAEMON,
+      { event: 'issue_comment:created', subjectKind: 'pull_request' }
+    )
+    // A hook created after the relay ingested this GUID would read the
+    // redelivery as a first run of a stale event.
+    await prisma.hookDef.update({
+      where: { id: issuesHookId },
+      data: { createdAt: new Date(firedAt.getTime() + 1_000) }
+    })
+
+    const expected = [HookId(pullHookId), HookId(issuesHookId)].sort()
+    expect(await repo().claimRetryableDeliveryRedelivery('late-sibling-guid', expected, firedAt, [30_000])).toBe(false)
+    expect(await repo().getRun(HookId(pullHookId), 'late-sibling-guid')).toMatchObject({
+      redeliveryAttempts: 0,
+      redeliveryNextAttemptAt: null
+    })
+  })
+
+  it('blocks the claim when a landed row belongs to a hook outside the candidate fanout', async () => {
+    const firedAt = new Date('2026-07-03T11:10:00.000Z')
+    const { agentId, pullHookId, issuesHookId } = await placedCommentFamilyPair(new Date(firedAt.getTime() - 60_000))
+    for (const id of [pullHookId, issuesHookId]) {
+      await recordGithubDeliveryFailure(
+        id,
+        agentId,
+        'stray-guid',
+        firedAt,
+        HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+        DAEMON,
+        {
+          event: 'issue_comment:created'
+        }
+      )
+    }
+
+    expect(await repo().claimRetryableDeliveryRedelivery('stray-guid', [HookId(pullHookId)], firedAt, [30_000])).toBe(
+      false
+    )
+    for (const id of [pullHookId, issuesHookId]) {
+      expect(await repo().getRun(HookId(id), 'stray-guid')).toMatchObject({
+        redeliveryAttempts: 0,
+        redeliveryNextAttemptAt: null
+      })
+    }
+  })
+
+  it('tolerates a deleted unlanded candidate but not a deleted landed one', async () => {
+    const firedAt = new Date('2026-07-03T11:15:00.000Z')
+    const pair = await placedCommentFamilyPair(new Date(firedAt.getTime() - 60_000))
+    await recordGithubDeliveryFailure(
+      pair.pullHookId,
+      pair.agentId,
+      'gone-unlanded-guid',
+      firedAt,
+      HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+      DAEMON,
+      { event: 'issue_comment:created', subjectKind: 'pull_request' }
+    )
+    await prisma.hookDef.delete({ where: { id: pair.issuesHookId } })
+    // The relay has no rule left for the removed row, so it cannot fire again.
     expect(
       await repo().claimRetryableDeliveryRedelivery(
-        'missing-sibling-guid',
-        [HookId(hookId), HookId(siblingHookId)],
+        'gone-unlanded-guid',
+        [HookId(pair.pullHookId), HookId(pair.issuesHookId)].sort(),
+        firedAt,
+        [30_000]
+      )
+    ).toBe(true)
+
+    const second = await placedCommentFamilyPair(new Date(firedAt.getTime() - 60_000))
+    for (const id of [second.pullHookId, second.issuesHookId]) {
+      await recordGithubDeliveryFailure(
+        id,
+        second.agentId,
+        'gone-landed-guid',
+        firedAt,
+        HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+        DAEMON,
+        { event: 'issue_comment:created' }
+      )
+    }
+    await prisma.hookDef.delete({ where: { id: second.issuesHookId } })
+    expect(
+      await repo().claimRetryableDeliveryRedelivery(
+        'gone-landed-guid',
+        [HookId(second.pullHookId), HookId(second.issuesHookId)].sort(),
         firedAt,
         [30_000]
       )
     ).toBe(false)
-    expect(await repo().getRun(HookId(hookId), 'missing-sibling-guid')).toMatchObject({
+    expect(await repo().getRun(HookId(second.pullHookId), 'gone-landed-guid')).toMatchObject({
       redeliveryNextAttemptAt: null
     })
   })

--- a/packages/control-plane/test/integration/hook-report.test.ts
+++ b/packages/control-plane/test/integration/hook-report.test.ts
@@ -134,8 +134,12 @@ async function placedCommentFamilyPair(
     reviewPolicy: 'off',
     reportingMode: 'off'
   })
-  // Both rows predate the delivery: a hook created afterwards blocks by design.
-  await prisma.hookDef.updateMany({ where: { id: { in: [pullHookId, issuesHookId] } }, data: { createdAt } })
+  // Both rows predate the delivery AND are unmodified since: any later
+  // definition change (lastModifiedAt) blocks the claim by design.
+  await prisma.hookDef.updateMany({
+    where: { id: { in: [pullHookId, issuesHookId] } },
+    data: { createdAt, lastModifiedAt: createdAt }
+  })
   return { agentId, pullHookId, issuesHookId }
 }
 
@@ -385,12 +389,46 @@ describe('HookRun bookkeeping — delivery opens, completion closes', () => {
     // redelivery as a first run of a stale event.
     await prisma.hookDef.update({
       where: { id: issuesHookId },
-      data: { createdAt: new Date(firedAt.getTime() + 1_000) }
+      data: { createdAt: new Date(firedAt.getTime() + 1_000), lastModifiedAt: new Date(firedAt.getTime() + 1_000) }
     })
 
     const expected = [HookId(pullHookId), HookId(issuesHookId)].sort()
     expect(await repo().claimRetryableDeliveryRedelivery('late-sibling-guid', expected, firedAt, [30_000])).toBe(false)
     expect(await repo().getRun(HookId(pullHookId), 'late-sibling-guid')).toMatchObject({
+      redeliveryAttempts: 0,
+      redeliveryNextAttemptAt: null
+    })
+  })
+
+  it('blocks the claim when an unlanded candidate was modified after the delivery', async () => {
+    const firedAt = new Date('2026-07-03T11:06:00.000Z')
+    const { agentId, pullHookId, issuesHookId } = await placedCommentFamilyPair(new Date(firedAt.getTime() - 60_000))
+    // The sibling filtered the original event via mentionOnly, so it never landed a row.
+    await prisma.hookDef.update({
+      where: { id: issuesHookId },
+      data: { mentionOnly: true, lastModifiedAt: new Date(firedAt.getTime() - 60_000) }
+    })
+    await recordGithubDeliveryFailure(
+      pullHookId,
+      agentId,
+      'relaxed-sibling-guid',
+      firedAt,
+      HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+      DAEMON,
+      { event: 'issue_comment:created', subjectKind: 'pull_request' }
+    )
+    // Relaxing the filter afterwards means the redelivery would no longer be
+    // filtered — the payload is immutable, the rule is not.
+    await prisma.hookDef.update({
+      where: { id: issuesHookId },
+      data: { mentionOnly: false, lastModifiedAt: new Date(firedAt.getTime() + 1_000) }
+    })
+
+    const expected = [HookId(pullHookId), HookId(issuesHookId)].sort()
+    expect(await repo().claimRetryableDeliveryRedelivery('relaxed-sibling-guid', expected, firedAt, [30_000])).toBe(
+      false
+    )
+    expect(await repo().getRun(HookId(pullHookId), 'relaxed-sibling-guid')).toMatchObject({
       redeliveryAttempts: 0,
       redeliveryNextAttemptAt: null
     })

--- a/packages/control-plane/test/integration/hooks.route.test.ts
+++ b/packages/control-plane/test/integration/hooks.route.test.ts
@@ -21,6 +21,7 @@ import { buildHttpApp, TEST_API_KEY_PEPPER, type HttpApp } from '../fakes/build-
 import { GithubService } from '../../src/github/service.js'
 import { PgGithubInstallationRepo, PgGithubInstallStateStore } from '../../src/persistence/index.js'
 import { systemClock } from '../../src/domain/clock.js'
+import { AgentId } from '../../src/domain/ids.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
@@ -243,15 +244,29 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
       return agentId
     }
 
+    // One row per (agent, repo, family): the default body is the ISSUES family,
+    // and a github issue_comment subscription must scope itself to it.
     const ghBody = (agentId: string, over: Record<string, unknown> = {}) => ({
       agentId,
       kind: 'github',
       name: 'issues-hook',
       repoFullName: 'acme/infra',
+      family: 'issues',
       events: ['issues:opened', 'issue_comment:created'],
+      commentFamilies: ['issues'],
       labelFilter: ['bug'],
       ...over
     })
+
+    /** The pull-request family — the only one that may carry review/reporting. */
+    const prBody = (agentId: string, over: Record<string, unknown> = {}) =>
+      ghBody(agentId, {
+        name: 'pr-hook',
+        family: 'pull_request',
+        events: ['pull_request:*'],
+        commentFamilies: [],
+        ...over
+      })
 
     async function seedInstallation(over: Record<string, unknown> = {}): Promise<void> {
       await prisma.githubInstallation.create({
@@ -329,6 +344,7 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
         sessionMode: 'perThread',
         repoId: String(REPO_ID),
         repoFullName: 'acme/infra',
+        family: 'issues',
         events: ['issues:opened', 'issue_comment:created'],
         commentFamilies: ['issues'],
         labelFilter: ['bug'],
@@ -341,6 +357,7 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
       // and lands in the row as BigInt.
       const row = await prisma.hookDef.findUniqueOrThrow({ where: { id: dto.id as string } })
       expect(row.repoId).toBe(BigInt(REPO_ID))
+      expect(row.family).toBe('issues')
       expect(row.githubSessionKey).toBe(`github:${REPO_ID}`)
       expect(row.commentFamilies).toEqual(['issues'])
       expect(row.urlToken).toBeNull()
@@ -369,14 +386,14 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
         const rejected = await a.app.inject({
           method: 'POST',
           url: `${ORG}/hooks`,
-          payload: ghBody(agentId, { enabled: false, ...patch })
+          payload: prBody(agentId, { enabled: false, ...patch })
         })
         expect(rejected.statusCode).toBe(409)
         expect((rejected.json() as { message: string }).message).toMatch(message)
       }
       expect(await prisma.hookDef.count({ where: { agentId } })).toBe(0)
 
-      const created = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: ghBody(agentId) })
+      const created = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: prBody(agentId) })
       expect(created.statusCode).toBe(200)
       const hookId = (created.json() as { id: string }).id
 
@@ -384,7 +401,7 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
         const rejected = await a.app.inject({
           method: 'PUT',
           url: `${ORG}/hooks/${hookId}`,
-          payload: ghBody(agentId, { enabled: false, ...patch })
+          payload: prBody(agentId, { enabled: false, ...patch })
         })
         expect(rejected.statusCode).toBe(409)
         expect((rejected.json() as { message: string }).message).toMatch(message)
@@ -465,7 +482,7 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
       await seedRelay()
       await seedInstallation()
       const a = ghApp()
-      const created = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: ghBody(agentId) })
+      const created = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: prBody(agentId) })
       expect(created.statusCode).toBe(200)
       const hookId = (created.json() as { id: string }).id
       await running!.close()
@@ -477,33 +494,40 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
       const res = await b.app.inject({
         method: 'PUT',
         url: `${ORG}/hooks/${hookId}`,
-        payload: ghBody(agentId, { reviewPolicy: 'comment' })
+        payload: prBody(agentId, { reviewPolicy: 'comment' })
       })
       expect(res.statusCode).toBe(502)
       expect((res.json() as { message: string }).message).toMatch(/github/)
       expect(await prisma.hookDef.findUniqueOrThrow({ where: { id: hookId } })).toMatchObject({ reviewPolicy: 'off' })
     })
 
-    it('POST accepts push ("commits") subscriptions and 409s a duplicate repo for the same agent', async () => {
+    it('POST accepts push ("commits") subscriptions and 409s a duplicate FAMILY for the same repo', async () => {
       const agentId = await githubAgent()
       await seedRelay()
       await seedInstallation()
       const a = ghApp()
 
-      const first = await a.app.inject({
-        method: 'POST',
-        url: `${ORG}/hooks`,
-        payload: ghBody(agentId, { events: ['pull_request:*', 'push:*'], labelFilter: [] })
+      const pushBody = ghBody(agentId, {
+        name: 'push-hook',
+        family: 'push',
+        events: ['push:*'],
+        commentFamilies: [],
+        labelFilter: []
       })
+      const first = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: pushBody })
       expect(first.statusCode).toBe(200)
-      expect((first.json() as { events: string[] }).events).toEqual(['pull_request:*', 'push:*'])
+      expect((first.json() as { events: string[] }).events).toEqual(['push:*'])
       expect((first.json() as { commentFamilies: string[] }).commentFamilies).toEqual([])
 
-      // Same repo again for the same agent — one subscription per (agent, repo).
-      const dup = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: ghBody(agentId) })
+      // Same repo AND family again for the same agent — the database's rule.
+      const dup = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: pushBody })
       expect(dup.statusCode).toBe(409)
-      expect((dup.json() as { message: string }).message).toMatch(/already watches acme\/infra/)
+      expect((dup.json() as { message: string }).message).toMatch(/already watches acme\/infra \(push\)/)
       expect(await prisma.hookDef.count()).toBe(1)
+
+      // Another FAMILY on the same repo is the whole point of the split.
+      const issues = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: ghBody(agentId) })
+      expect(issues.statusCode).toBe(200)
 
       // A DIFFERENT agent may watch the same repo (its own workspace here).
       const otherAgent = randomUUID()
@@ -560,8 +584,8 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
         url: `${ORG}/hooks/${id}`,
         payload: ghBody(agentId, {
           name: 'renamed',
-          events: ['pull_request:*', 'issue_comment:created'],
-          commentFamilies: ['pull_request'],
+          events: ['issues:*', 'issue_comment:created'],
+          commentFamilies: ['issues'],
           labelFilter: [],
           mentionOnly: true
         })
@@ -570,8 +594,9 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
       expect(put.json()).toMatchObject({
         name: 'renamed',
         sessionMode: 'perThread',
-        events: ['pull_request:*', 'issue_comment:created'],
-        commentFamilies: ['pull_request'],
+        family: 'issues',
+        events: ['issues:*', 'issue_comment:created'],
+        commentFamilies: ['issues'],
         mentionOnly: true
       })
 
@@ -580,10 +605,17 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
       const echo = await a.app.inject({
         method: 'PUT',
         url: `${ORG}/hooks/${id}`,
-        payload: ghBody(agentId, { name: 'renamed', events: ['pull_request:*', 'issue_comment:created'] })
+        payload: {
+          agentId,
+          kind: 'github',
+          name: 'renamed',
+          repoFullName: 'acme/infra',
+          events: ['issues:*', 'issue_comment:created'],
+          labelFilter: []
+        }
       })
       expect(echo.statusCode).toBe(200)
-      expect(echo.json()).toMatchObject({ mentionOnly: true, commentFamilies: ['pull_request'] })
+      expect(echo.json()).toMatchObject({ mentionOnly: true, commentFamilies: ['issues'] })
 
       const flip = await a.app.inject({
         method: 'PUT',
@@ -605,8 +637,7 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
         where: { id: agentId },
         data: { installationId: installation.id, gitAccess: 'write' }
       })
-      const createPayload = ghBody(agentId, {
-        events: ['pull_request:*'],
+      const createPayload = prBody(agentId, {
         labelFilter: [],
         reviewPolicy: 'off',
         reportingMode: 'check',
@@ -724,8 +755,7 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
         data: { installationId: installation.id, gitAccess: 'write' }
       })
       const a = ghApp()
-      const payload = ghBody(firstAgent, {
-        events: ['pull_request:*'],
+      const payload = prBody(firstAgent, {
         labelFilter: [],
         reviewPolicy: 'off',
         reportingMode: 'check',
@@ -768,6 +798,119 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
         agentId: firstAgent,
         tombstonedAt: expect.any(Date)
       })
+    })
+
+    // The point of the split: one repository, two families, two cadences.
+    it('watches one repo per family, each with its own mention gate and compiled rule', async () => {
+      const agentId = await githubAgent()
+      await seedRelay()
+      await seedInstallation()
+      const a = ghApp()
+
+      // PRs fire on every update; issues only when the agent is summoned.
+      const pr = await a.app.inject({
+        method: 'POST',
+        url: `${ORG}/hooks`,
+        payload: prBody(agentId, {
+          events: ['pull_request:*', 'issue_comment:created'],
+          commentFamilies: ['pull_request'],
+          labelFilter: [],
+          mentionOnly: false
+        })
+      })
+      const issues = await a.app.inject({
+        method: 'POST',
+        url: `${ORG}/hooks`,
+        payload: ghBody(agentId, {
+          events: ['issues:*', 'issue_comment:created'],
+          commentFamilies: ['issues'],
+          labelFilter: [],
+          mentionOnly: true
+        })
+      })
+      expect([pr.statusCode, issues.statusCode]).toEqual([200, 200])
+      expect(pr.json()).toMatchObject({ family: 'pull_request', mentionOnly: false })
+      expect(issues.json()).toMatchObject({ family: 'issues', mentionOnly: true })
+
+      const rows = await prisma.hookDef.findMany({ where: { agentId }, orderBy: { family: 'asc' } })
+      expect(rows.map((r) => [r.family, r.mentionOnly, r.commentFamilies])).toEqual([
+        ['issues', true, ['issues']],
+        ['pull_request', false, ['pull_request']]
+      ])
+      // Sibling rows answer the same threads, so they share one session namespace.
+      expect(new Set(rows.map((r) => r.githubSessionKey))).toEqual(new Set([`github:${REPO_ID}`]))
+
+      // Two independent wire rules — the relay already fans one delivery out to
+      // every rule for the repository, so the per-rule gate is what differs.
+      const records = (await a.deps.repos.hook.listForAgent(AgentId(agentId))).sort((x, y) =>
+        (x.family ?? '').localeCompare(y.family ?? '')
+      )
+      const compiled = await Promise.all(records.map((record) => a.deps.hooks.compile(record)))
+      expect(
+        compiled.map((rule) => [rule?.github?.commentFamilies, rule?.github?.mentionOnly, rule?.github?.events])
+      ).toEqual([
+        [['issues'], true, ['issues:*', 'issue_comment:created']],
+        [['pull_request'], false, ['pull_request:*', 'issue_comment:created']]
+      ])
+    })
+
+    it('400s a subscription that strays outside the row’s own family', async () => {
+      const agentId = await githubAgent()
+      await seedRelay()
+      await seedInstallation()
+      const a = ghApp()
+      const cases: [Record<string, unknown>, RegExp][] = [
+        // A pattern belonging to another family — that family has its own row.
+        [{ family: 'pull_request', events: ['pull_request:*', 'issues:opened'] }, /"issues:opened"/],
+        [{ family: 'push', events: ['push:*', 'issue_comment:created'] }, /"issue_comment:created"/],
+        // An unscoped issue_comment is the legacy repo-wide meaning: it would
+        // double-fire against the sibling row that owns the other thread family.
+        [
+          { family: 'pull_request', events: ['pull_request:*', 'issue_comment:created'], commentFamilies: [] },
+          /must set commentFamilies/
+        ],
+        // commentFamilies may only narrow this row's own family.
+        [{ family: 'pull_request', events: ['pull_request:*'], commentFamilies: ['issues'] }, /not issues/],
+        // Reviews and run reporting belong to the change-proposal family.
+        [{ reviewPolicy: 'comment' }, /pull-request\/merge-request rows/],
+        [{ reportingMode: 'check' }, /pull-request\/merge-request rows/]
+      ]
+      for (const [over, message] of cases) {
+        const res = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: ghBody(agentId, over) })
+        expect(res.statusCode).toBe(400)
+        expect((res.json() as { message: string }).message).toMatch(message)
+      }
+      expect(await prisma.hookDef.count({ where: { agentId } })).toBe(0)
+
+      // The family is immutable, so an edit is re-shaped against the STORED one.
+      const created = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: ghBody(agentId) })
+      expect(created.statusCode).toBe(200)
+      const strayEdit = await a.app.inject({
+        method: 'PUT',
+        url: `${ORG}/hooks/${(created.json() as { id: string }).id}`,
+        payload: ghBody(agentId, { events: ['pull_request:*'], commentFamilies: [] })
+      })
+      expect(strayEdit.statusCode).toBe(400)
+      expect((strayEdit.json() as { message: string }).message).toMatch(/issues family/)
+    })
+
+    it('409s a sibling family anchored somewhere else — one thread, one destination', async () => {
+      const agentId = await githubAgent()
+      await seedRelay()
+      await seedInstallation()
+      const a = ghApp()
+      expect((await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: ghBody(agentId) })).statusCode).toBe(
+        200
+      )
+
+      const diverging = await a.app.inject({
+        method: 'POST',
+        url: `${ORG}/hooks`,
+        payload: prBody(agentId, { targetChannel: 'C-elsewhere' })
+      })
+      expect(diverging.statusCode).toBe(409)
+      expect((diverging.json() as { message: string }).message).toMatch(/post somewhere else/)
+      expect(await prisma.hookDef.count({ where: { agentId } })).toBe(1)
     })
   })
 

--- a/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
+++ b/packages/control-plane/test/repo/github-review-persistence.repo.test.ts
@@ -1737,6 +1737,61 @@ describe('R1/R2a persistence foundation', () => {
     ).toEqual({ repoFullName: 'acme/new-name', lastFiredAt: redeliveredAt })
   })
 
+  it('adopts the destination sibling session namespace when a github row is reassigned', async () => {
+    await seedDaemon(prisma, D1)
+    const hooks = new PgHookRepo(prisma)
+    const agentA = AgentId(randomUUID())
+    const agentB = AgentId(randomUUID())
+    await seedAgent(prisma, agentA, { daemonId: D1, name: `move-from-${randomUUID().slice(0, 8)}` })
+    await seedAgent(prisma, agentB, { daemonId: D1, name: `move-to-${randomUUID().slice(0, 8)}` })
+    const sharedRepoId = 7701n
+    const soloRepoId = 7702n
+    const githubRow = (hookId: HookId, agentId: AgentId, repoId: bigint, family: string, events: string[]) => ({
+      hookId,
+      orgId: OrgId(DEFAULT_ORG_ID),
+      agentId,
+      kind: 'github' as const,
+      name: `family-${family}-${hookId}`,
+      sessionMode: 'perThread' as const,
+      repoId,
+      repoFullName: 'acme/legacy',
+      family,
+      events
+    })
+
+    // B already watches the shared repo on a grandfathered owner/repo namespace.
+    const destinationSibling = HookId(randomUUID())
+    await hooks.upsert(githubRow(destinationSibling, agentB, sharedRepoId, 'issues', ['issues:*']))
+    await prisma.hookDef.update({ where: { id: destinationSibling }, data: { githubSessionKey: 'acme/legacy' } })
+
+    const moved = HookId(randomUUID())
+    await hooks.upsert(githubRow(moved, agentA, sharedRepoId, 'pull_request', ['pull_request:*']))
+    expect(
+      await prisma.hookDef.findUniqueOrThrow({ where: { id: moved }, select: { githubSessionKey: true } })
+    ).toEqual({ githubSessionKey: `github:${sharedRepoId}` })
+
+    // Reassigning to B on the SAME repo must join B's family namespace.
+    await hooks.upsert({
+      ...githubRow(moved, agentB, sharedRepoId, 'pull_request', ['pull_request:*']),
+      expectedAgentId: agentA
+    })
+    expect(
+      await prisma.hookDef.findUniqueOrThrow({ where: { id: moved }, select: { githubSessionKey: true } })
+    ).toEqual({ githubSessionKey: 'acme/legacy' })
+
+    // With no destination sibling, a same-repo agent move keeps its own key.
+    const solo = HookId(randomUUID())
+    await hooks.upsert(githubRow(solo, agentA, soloRepoId, 'pull_request', ['pull_request:*']))
+    await prisma.hookDef.update({ where: { id: solo }, data: { githubSessionKey: 'acme/solo' } })
+    await hooks.upsert({
+      ...githubRow(solo, agentB, soloRepoId, 'pull_request', ['pull_request:*']),
+      expectedAgentId: agentA
+    })
+    expect(await prisma.hookDef.findUniqueOrThrow({ where: { id: solo }, select: { githubSessionKey: true } })).toEqual(
+      { githubSessionKey: 'acme/solo' }
+    )
+  })
+
   it('persists effective installation permissions and never moves an org claim', async () => {
     const repo = new PgGithubInstallationRepo(prisma)
     const installationId = BigInt(4_000_000 + Math.floor(Math.random() * 100_000))

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -9,6 +9,9 @@
  * exactly the two subjects GitHub does, so no reachable selection compiles a
  * push event.
  *
+ * A row is `(agent, project, family)`, so a multi-subject pick is one create PER
+ * FAMILY and a family the project is already watched for is not on offer.
+ *
  * The picker also offers projects the organization has not added yet, because
  * this wizard is now where a project joins the organization.
  */
@@ -21,12 +24,19 @@ import type { Agent } from '@/lib/data'
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 
 const mocks = vi.hoisted(() => ({
-  createGitlabHook: vi.fn(async () => ({ id: 'hook-1', agentId: 'agent-a', kind: 'gitlab' })),
+  // The parameter is declared so `mock.calls` stays typed — the wizard now makes
+  // one call per subject family and the tests read those bodies back.
+  createGitlabHook: vi.fn(async (_input: { family: string; events: string[] }) => ({
+    id: 'hook-1',
+    agentId: 'agent-a',
+    kind: 'gitlab'
+  })),
   fetchGitlabProjects: vi.fn(),
   fetchGitlabConnections: vi.fn(),
   searchGitlabProjects: vi.fn(),
   createGitlabProject: vi.fn(),
   fetchAgentRepos: vi.fn(),
+  fetchAgentHooks: vi.fn(async () => [] as unknown[]),
   startGitlabOauth: vi.fn(),
   daemons: [] as unknown[]
 }))
@@ -57,7 +67,7 @@ vi.mock('@/lib/data-context', () => ({
 }))
 vi.mock('@/lib/api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/api')>()),
-  fetchAgentHooks: vi.fn(async () => []),
+  fetchAgentHooks: mocks.fetchAgentHooks,
   fetchAgentRepos: mocks.fetchAgentRepos,
   fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
   fetchGithubInstallUrl: vi.fn(async () => null),
@@ -147,6 +157,7 @@ beforeEach(() => {
   mocks.fetchGitlabConnections.mockResolvedValue({ enabled: true, connections: [connection] })
   mocks.searchGitlabProjects.mockResolvedValue({ projects: [], nextPage: null })
   mocks.fetchAgentRepos.mockResolvedValue([authorization])
+  mocks.fetchAgentHooks.mockResolvedValue([])
 })
 
 /** Candidates are searched on GitLab behind a debounce; let it elapse for real. */
@@ -167,6 +178,7 @@ afterEach(async () => {
   mocks.searchGitlabProjects.mockReset()
   mocks.createGitlabProject.mockReset()
   mocks.fetchAgentRepos.mockReset()
+  mocks.fetchAgentHooks.mockReset()
   mocks.startGitlabOauth.mockReset()
   opened.length = 0
   mocks.daemons = []
@@ -204,6 +216,7 @@ describe('AddIntegrationModal, GitLab trigger', () => {
       agentId: 'agent-a',
       name: 'acme/platform',
       projectId: '4210',
+      family: 'merge_request',
       events: ['merge_request:*'],
       commentFamilies: ['merge_request'],
       mentionOnly: false,
@@ -222,9 +235,16 @@ describe('AddIntegrationModal, GitLab trigger', () => {
 
     await act(async () => clickText('Connect')?.click())
 
-    expect(mocks.createGitlabHook).toHaveBeenCalledWith(
+    // One row per subject family — each carries its own single-family events.
+    expect(mocks.createGitlabHook).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ family: 'issues', events: ['issues:opened'], commentFamilies: [], mentionOnly: false })
+    )
+    expect(mocks.createGitlabHook).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
-        events: ['issues:opened', 'merge_request:opened'],
+        family: 'merge_request',
+        events: ['merge_request:opened'],
         commentFamilies: [],
         mentionOnly: false
       })
@@ -240,12 +260,25 @@ describe('AddIntegrationModal, GitLab trigger', () => {
 
     await act(async () => clickText('Connect')?.click())
 
-    expect(mocks.createGitlabHook).toHaveBeenCalledWith({
+    // Reviews and the run note ride the merge-request row; the issues row is off.
+    expect(mocks.createGitlabHook).toHaveBeenNthCalledWith(1, {
       agentId: 'agent-a',
       name: 'acme/platform',
       projectId: '4210',
-      events: ['issues:*', 'merge_request:*'],
-      commentFamilies: ['issues', 'merge_request'],
+      family: 'issues',
+      events: ['issues:*'],
+      commentFamilies: ['issues'],
+      mentionOnly: true,
+      reviewPolicy: 'off',
+      reportingMode: 'off'
+    })
+    expect(mocks.createGitlabHook).toHaveBeenNthCalledWith(2, {
+      agentId: 'agent-a',
+      name: 'acme/platform',
+      projectId: '4210',
+      family: 'merge_request',
+      events: ['merge_request:*'],
+      commentFamilies: ['merge_request'],
       mentionOnly: true,
       reviewPolicy: 'full',
       reportingMode: 'check'
@@ -301,9 +334,8 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     await act(async () => family('issues')?.click())
     await act(async () => clickText('Connect')?.click())
 
-    expect(mocks.createGitlabHook).toHaveBeenCalledWith(
-      expect.objectContaining({ events: ['issues:*', 'merge_request:*'] })
-    )
+    expect(mocks.createGitlabHook.mock.calls.map(([body]) => body.family)).toEqual(['issues', 'merge_request'])
+    expect(mocks.createGitlabHook.mock.calls.flatMap(([body]) => body.events)).toEqual(['issues:*', 'merge_request:*'])
   })
 
   it('drops the separate comments row and mention checkbox the form used to expose', async () => {
@@ -423,6 +455,26 @@ describe('AddIntegrationModal, GitLab trigger', () => {
 
     await act(async () => clickText('Connect')?.click())
     expect(mocks.createGitlabHook).not.toHaveBeenCalled()
+  })
+
+  it('takes an already-watched family out of the offer instead of blocking the project', async () => {
+    // A row is (agent, project, family), so watching merge requests leaves
+    // issues free — the old repo-level block refused the whole project.
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    mocks.fetchAgentHooks.mockResolvedValue([
+      { id: 'hook-mr', kind: 'gitlab', repoId: '4210', family: 'merge_request', events: ['merge_request:*'] }
+    ])
+    await renderAgent({ id: 'agent-half-watched' })
+    await pickProject()
+
+    expect(family('merge_request')?.getAttribute('aria-disabled')).toBe('true')
+    expect(family('issues')?.getAttribute('aria-disabled')).toBe('false')
+
+    await act(async () => family('issues')?.click())
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGitlabHook).toHaveBeenCalledTimes(1)
+    expect(mocks.createGitlabHook).toHaveBeenCalledWith(expect.objectContaining({ family: 'issues' }))
   })
 
   it('accepts the agent’s own workspace project without a separate grant', async () => {

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -68,8 +68,9 @@ import {
   GH_DEFAULT_TRIGGER_MODE,
   GH_FAMILIES,
   GH_TRIGGER_LABEL,
-  commentFamiliesForFamilies,
-  eventsForFamilies,
+  famCovered,
+  githubFamilyCarriesReviews,
+  githubFamilySubscription,
   githubMentionUsage,
   type GhFamily,
   type GhTriggerMode
@@ -79,8 +80,9 @@ import {
   GL_DEFAULT_TRIGGER_MODE,
   GL_FAMILIES,
   GL_TRIGGER_LABEL,
-  commentFamiliesForGitlabFamilies,
-  eventsForGitlabFamilies,
+  gitlabFamCovered,
+  gitlabFamilyCarriesReviews,
+  gitlabFamilySubscription,
   gitlabMentionUsage,
   type GlFamily,
   type GlTriggerMode
@@ -299,21 +301,42 @@ export default function AddIntegrationModal({
   const [ghSyncing, setGhSyncing] = useState(false)
   const [ghAccessSaving, setGhAccessSaving] = useState(false)
   const [ghWorkspaceAccessOverride, setGhWorkspaceAccessOverride] = useState<'write' | null>(null)
-  // Repos this agent ALREADY watches — offered rows are disabled, free-typed
-  // duplicates rejected inline (the CP 409s them as the backstop).
+  // What this agent ALREADY watches is per (repo, FAMILY) now — one row covers
+  // one subject, so a repo may be watched for PRs and still free for issues.
+  // Offered rows are disabled only once every offered family is taken (the CP
+  // 409s a duplicate family as the backstop).
   const { activeOrg, orgPath } = useOrgs()
   const agentHooksKey = consoleKeys.agentHooks(activeOrg?.id, agent.id)
-  const { data: agentHooksData } = useSWR(agentHooksKey, ([, orgId, , agentId]) => fetchAgentHooks(agentId, orgId))
-  const watchedRepos = useMemo(
-    () =>
-      new Set(
-        (agentHooksData ?? [])
-          .filter((h) => h.kind === 'github' && h.repoFullName)
-          .map((h) => h.repoFullName!.toLowerCase())
-      ),
-    [agentHooksData]
+  const { data: agentHooksData, mutate: mutateAgentHooks } = useSWR(agentHooksKey, ([, orgId, , agentId]) =>
+    fetchAgentHooks(agentId, orgId)
   )
-  const ghRepoAlreadyWatched = !!ghRepoPick && watchedRepos.has(ghRepoPick.toLowerCase())
+  const watchedGhFamilies = useMemo(() => {
+    const byRepo = new Map<string, Set<GhFamily>>()
+    for (const h of agentHooksData ?? []) {
+      if (h.kind !== 'github' || !h.repoFullName) continue
+      const key = h.repoFullName.toLowerCase()
+      const taken = byRepo.get(key) ?? new Set<GhFamily>()
+      // A null-family legacy row still blocks every family its events cover.
+      for (const { fam } of GH_FAMILIES) {
+        if (h.family ? h.family === fam : famCovered(h.events, fam)) taken.add(fam)
+      }
+      byRepo.set(key, taken)
+    }
+    return byRepo
+  }, [agentHooksData])
+  const repoFullyWatched = (repo: string) => {
+    const taken = watchedGhFamilies.get(repo.toLowerCase())
+    return !!taken && GH_FAMILIES.every(({ fam }) => taken.has(fam))
+  }
+  const ghPickedWatched = (ghRepoPick && watchedGhFamilies.get(ghRepoPick.toLowerCase())) || new Set<GhFamily>()
+  const ghRepoAlreadyWatched = !!ghRepoPick && repoFullyWatched(ghRepoPick)
+  // A family already watched on the picked repo is not selectable, so the
+  // enablement, the review gating and the create loop all read this set.
+  const ghSelectedFams = GH_FAMILIES.map(({ fam }) => fam).filter((fam) => ghFams.has(fam) && !ghPickedWatched.has(fam))
+  // Reviews and Checks ride the pull-request row only; an issues-only pick drops them.
+  const ghPrSelected = ghSelectedFams.includes('pull_request')
+  const ghEffectiveReviewPolicy: HookReviewPolicy = ghPrSelected ? ghReviewPolicy : 'off'
+  const ghEffectiveReportingMode: HookReportingMode = ghPrSelected ? ghReportingMode : 'off'
   // Multi-repo design decision 6 + issue #457 UX layer: a github hook may only
   // watch the agent's workspace repo or an explicitly authorized one (the CP
   // 409s anything else). The picker lists ALL App-visible repos and guides the
@@ -349,7 +372,10 @@ export default function AddIntegrationModal({
   })
   const ghRepoAccess =
     ghSelectedIsWorkspace && ghWorkspaceAccessOverride ? ghWorkspaceAccessOverride : resolvedGhRepoAccess
-  const ghNeededAccess = requiredRepoAccess({ reviewPolicy: ghReviewPolicy, reportingMode: ghReportingMode })
+  const ghNeededAccess = requiredRepoAccess({
+    reviewPolicy: ghEffectiveReviewPolicy,
+    reportingMode: ghEffectiveReportingMode
+  })
   const ghSelectedInstallation =
     gh?.installations.find((installation) => installation.id === ghSelectedRepo?.installationId) ??
     installationForRepo(ghRepoPick, gh?.installations ?? [])
@@ -359,8 +385,8 @@ export default function AddIntegrationModal({
   const ghReviewSettingsBlocked =
     !!ghRepoPick &&
     (!repoAccessSatisfies(ghRepoAccess, ghNeededAccess) ||
-      (ghReviewPolicy !== 'off' && !hasPullRequestsWritePermission(ghSelectedInstallation)) ||
-      (ghReportingMode === 'check' &&
+      (ghEffectiveReviewPolicy !== 'off' && !hasPullRequestsWritePermission(ghSelectedInstallation)) ||
+      (ghEffectiveReportingMode === 'check' &&
         (!hasChecksWritePermission(ghSelectedInstallation) || !hasPullRequestsReadPermission(ghSelectedInstallation))))
 
   // GitLab path: one hook per project, picked here. A project the organization
@@ -818,13 +844,29 @@ export default function AddIntegrationModal({
     setGlOpen(false)
     setErr(null)
   }
-  // One hook per (agent, project) — the CP 409s a second one, so the picker says so first.
-  const glWatchedProjects = useMemo(
-    () =>
-      new Set((agentHooksData ?? []).filter((h) => h.kind === 'gitlab' && h.repoId).map((h) => h.repoId!.toString())),
-    [agentHooksData]
-  )
-  const glAlreadyWatched = !!glProject && glWatchedProjects.has(glProject)
+  // One hook per (agent, project, FAMILY) — the CP 409s a duplicate family, so
+  // the picker takes the taken families out of the offer first.
+  const glWatchedFamilies = useMemo(() => {
+    const byProject = new Map<string, Set<GlFamily>>()
+    for (const h of agentHooksData ?? []) {
+      if (h.kind !== 'gitlab' || !h.repoId) continue
+      const key = h.repoId.toString()
+      const taken = byProject.get(key) ?? new Set<GlFamily>()
+      // A null-family legacy row still blocks every family its events cover.
+      for (const { fam } of GL_FAMILIES) {
+        if (h.family ? h.family === fam : gitlabFamCovered(h.events, fam)) taken.add(fam)
+      }
+      byProject.set(key, taken)
+    }
+    return byProject
+  }, [agentHooksData])
+  const glPickedWatched = (glProject && glWatchedFamilies.get(glProject)) || new Set<GlFamily>()
+  const glAlreadyWatched = !!glProject && GL_FAMILIES.every(({ fam }) => glPickedWatched.has(fam))
+  const glSelectedFams = GL_FAMILIES.map(({ fam }) => fam).filter((fam) => glFams.has(fam) && !glPickedWatched.has(fam))
+  // Reviews and the run note ride the merge-request row only.
+  const glMrSelected = glSelectedFams.includes('merge_request')
+  const glEffectiveReviewPolicy: HookReviewPolicy = glMrSelected ? glReviewPolicy : 'off'
+  const glEffectiveReportingMode: HookReportingMode = glMrSelected ? glReportingMode : 'off'
   // §8.3: a trigger never creates a grant, so the watched project must already be the
   // agent's workspace project or an authorized additional one — the CP 409s anything
   // else, and saying so here beats letting the user reach a refusal at the last click.
@@ -833,9 +875,11 @@ export default function AddIntegrationModal({
     (agent.workspace.mode === 'gitlab' && agent.workspace.projectId === glProject) ||
     authorizedRepos.some((r) => repoAuthProvider(r) === 'gitlab' && r.repoId === glProject)
 
-  // One subscription = one hook row on this agent, named after the project.
+  // One subscription = one hook row PER SELECTED FAMILY on this agent, all named
+  // after the project. The creates run in order; a failure part-way leaves the
+  // earlier families created, which the refreshed picker then shows as watched.
   const submitGitlab = async () => {
-    if (busyRef.current || !glProject || glFams.size === 0) return
+    if (busyRef.current || !glProject || glSelectedFams.length === 0) return
     if (glAlreadyWatched) {
       setErr(
         `This agent already watches ${glPicked?.projectPath ?? 'this project'} — edit its events on the agent page instead.`
@@ -853,30 +897,33 @@ export default function AddIntegrationModal({
     setSaving(true)
     setErr(null)
     try {
-      await createGitlabHook({
-        agentId: agent.id,
-        name: glPicked?.projectPath ?? glProject,
-        projectId: glProject,
-        events: eventsForGitlabFamilies(glFams, glMode),
-        commentFamilies: commentFamiliesForGitlabFamilies(glFams, glMode),
-        mentionOnly: glMode === 'mention',
-        reviewPolicy: glReviewPolicy,
-        reportingMode: glReportingMode
-      })
+      for (const fam of glSelectedFams) {
+        const reviews = gitlabFamilyCarriesReviews(fam)
+        await createGitlabHook({
+          agentId: agent.id,
+          name: glPicked?.projectPath ?? glProject,
+          projectId: glProject,
+          family: fam,
+          ...gitlabFamilySubscription(fam, glMode),
+          reviewPolicy: reviews ? glEffectiveReviewPolicy : 'off',
+          reportingMode: reviews ? glEffectiveReportingMode : 'off'
+        })
+      }
       onClose()
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
+      void mutateAgentHooks()
       setSaving(false)
       busyRef.current = false
     }
   }
 
-  // One subscription = one hook row on this agent, named after the repo. The CP
-  // resolves owner/repo to the numeric id, 400s anything outside the grant, and
-  // 409s a repo this agent already watches.
+  // One subscription = one hook row PER SELECTED FAMILY on this agent, all named
+  // after the repo. The CP resolves owner/repo to the numeric id, 400s anything
+  // outside the grant, and 409s a (repo, family) this agent already watches.
   const submitGithub = async () => {
-    if (busyRef.current || !ghRepoPick || ghFams.size === 0) return
-    if (watchedRepos.has(ghRepoPick.toLowerCase())) {
+    if (busyRef.current || !ghRepoPick || ghSelectedFams.length === 0) return
+    if (repoFullyWatched(ghRepoPick)) {
       setErr(`This agent already watches ${ghRepoPick} — edit its events on the agent page instead.`)
       return
     }
@@ -893,7 +940,7 @@ export default function AddIntegrationModal({
       setErr(`This review/check configuration needs write access to ${ghRepoPick}. Use Upgrade access above first.`)
       return
     }
-    if (ghReviewPolicy !== 'off' && !hasPullRequestsWritePermission(ghSelectedInstallation)) {
+    if (ghEffectiveReviewPolicy !== 'off' && !hasPullRequestsWritePermission(ghSelectedInstallation)) {
       setErr(
         ghSelectedInstallation?.pullRequestsPermission === 'missing'
           ? 'The repository’s GitHub App installation must grant Pull requests write permission first.'
@@ -904,7 +951,7 @@ export default function AddIntegrationModal({
       return
     }
     if (
-      ghReportingMode === 'check' &&
+      ghEffectiveReportingMode === 'check' &&
       (!hasChecksWritePermission(ghSelectedInstallation) || !hasPullRequestsReadPermission(ghSelectedInstallation))
     ) {
       setErr(
@@ -922,20 +969,23 @@ export default function AddIntegrationModal({
     setSaving(true)
     setErr(null)
     try {
-      await createGithubHook({
-        agentId: agent.id,
-        name: ghRepoPick,
-        repoFullName: ghRepoPick,
-        events: eventsForFamilies(ghFams, ghMode),
-        commentFamilies: commentFamiliesForFamilies(ghFams),
-        mentionOnly: ghMode === 'mention',
-        reviewPolicy: ghReviewPolicy,
-        reportingMode: ghReportingMode,
-        gateMode: 'informational'
-      })
+      for (const fam of ghSelectedFams) {
+        const reviews = githubFamilyCarriesReviews(fam)
+        await createGithubHook({
+          agentId: agent.id,
+          name: ghRepoPick,
+          repoFullName: ghRepoPick,
+          family: fam,
+          ...githubFamilySubscription(fam, ghMode),
+          reviewPolicy: reviews ? ghEffectiveReviewPolicy : 'off',
+          reportingMode: reviews ? ghEffectiveReportingMode : 'off',
+          gateMode: 'informational'
+        })
+      }
       onClose()
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
+      void mutateAgentHooks()
       setSaving(false)
       busyRef.current = false
     }
@@ -966,14 +1016,14 @@ export default function AddIntegrationModal({
         ? {
             label: 'Connect',
             act: () => void submitGithub(),
-            enabled: !!ghRepoPick && !ghRepoAlreadyWatched && ghFams.size > 0 && !ghReviewSettingsBlocked,
+            enabled: !!ghRepoPick && !ghRepoAlreadyWatched && ghSelectedFams.length > 0 && !ghReviewSettingsBlocked,
             hidden: false
           }
         : platform === 'gitlab'
           ? {
               label: 'Connect',
               act: () => void submitGitlab(),
-              enabled: !!glProject && !glAlreadyWatched && glProjectAuthorized && glFams.size > 0,
+              enabled: !!glProject && !glAlreadyWatched && glProjectAuthorized && glSelectedFams.length > 0,
               hidden: false
             }
           : mode === 'existing'
@@ -1300,7 +1350,7 @@ export default function AddIntegrationModal({
                       const lc = r.fullName.toLowerCase()
                       return {
                         repo: r,
-                        watched: watchedRepos.has(lc),
+                        watched: repoFullyWatched(lc),
                         isWorkspace: wsLc === lc,
                         authTier: authByName.get(lc)
                       }
@@ -1316,7 +1366,7 @@ export default function AddIntegrationModal({
                   const typedRepo = ghTypedRepo
                   const typedLc = typedRepo?.toLowerCase() ?? null
                   const typedInList = !!typedLc && listSource.some((r) => r.fullName.toLowerCase() === typedLc)
-                  const typedWatched = !!typedLc && watchedRepos.has(typedLc)
+                  const typedWatched = !!typedLc && repoFullyWatched(typedLc)
                   const typedWorkspace = !!typedLc && wsLc === typedLc
                   const typedAuthorized = !!typedLc && authByName.has(typedLc)
                   return (
@@ -1570,14 +1620,22 @@ export default function AddIntegrationModal({
                 <div className="fldlbl mb-2">Listen for</div>
                 <div className="mb-4 grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-2">
                   {GH_FAMILIES.map((r) => {
-                    const on = ghFams.has(r.fam)
+                    // A family the picked repo is already watched for is not a
+                    // second trigger — it is edited on the agent page.
+                    const taken = ghPickedWatched.has(r.fam)
+                    const on = !taken && ghFams.has(r.fam)
                     return (
                       <div
                         key={r.fam}
-                        className={`flex min-w-0 cursor-pointer items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
-                          on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'
-                        }`}
-                        onClick={() => toggleGhFam(r.fam)}
+                        data-github-family={r.fam}
+                        aria-disabled={taken}
+                        title={taken ? 'Already watched — change its trigger on the agent page' : undefined}
+                        className={`flex min-w-0 items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
+                          taken ? 'cursor-default opacity-55' : 'cursor-pointer'
+                        } ${on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'}`}
+                        onClick={() => {
+                          if (!taken) toggleGhFam(r.fam)
+                        }}
                       >
                         <Icon
                           name={r.icon}
@@ -1588,7 +1646,7 @@ export default function AddIntegrationModal({
                         <span className="min-w-0 flex-1">
                           <span className="block font-sans text-[12.5px] font-semibold leading-normal">{r.label}</span>
                           <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-                            {r.desc}
+                            {taken ? 'already watched' : r.desc}
                           </span>
                         </span>
                         <span
@@ -1632,29 +1690,33 @@ export default function AddIntegrationModal({
                     )
                   })}
                 </div>
-                <div className="mb-4">
-                  <GithubReviewSettings
-                    value={{ reviewPolicy: ghReviewPolicy, reportingMode: ghReportingMode }}
-                    onReviewPolicyChange={(policy) => {
-                      setGhReviewPolicy(policy)
-                      setErr(null)
-                    }}
-                    onReportingModeChange={(m) => {
-                      setGhReportingMode(m)
-                      setErr(null)
-                    }}
-                    repoAccess={ghRepoAccess}
-                    installation={ghSelectedInstallation}
-                    publicRepo={ghSelectedRepo ? !ghSelectedRepo.private : false}
-                    repoSelected={Boolean(ghRepoPick)}
-                    canAuthorizeRepo={
-                      canEditAgent &&
-                      (ghRepoAccess === 'none' || ghSelectedIsWorkspace || ghSelectedAuthorization !== undefined)
-                    }
-                    authorizingRepo={ghAccessSaving}
-                    onAuthorizeRepo={() => void authorizeSelectedRepo()}
-                  />
-                </div>
+                {/* Reviews and Checks live on the pull-request row, so the section
+                    appears only when that family is part of the pick. */}
+                {ghPrSelected && (
+                  <div className="mb-4">
+                    <GithubReviewSettings
+                      value={{ reviewPolicy: ghReviewPolicy, reportingMode: ghReportingMode }}
+                      onReviewPolicyChange={(policy) => {
+                        setGhReviewPolicy(policy)
+                        setErr(null)
+                      }}
+                      onReportingModeChange={(m) => {
+                        setGhReportingMode(m)
+                        setErr(null)
+                      }}
+                      repoAccess={ghRepoAccess}
+                      installation={ghSelectedInstallation}
+                      publicRepo={ghSelectedRepo ? !ghSelectedRepo.private : false}
+                      repoSelected={Boolean(ghRepoPick)}
+                      canAuthorizeRepo={
+                        canEditAgent &&
+                        (ghRepoAccess === 'none' || ghSelectedIsWorkspace || ghSelectedAuthorization !== undefined)
+                      }
+                      authorizingRepo={ghAccessSaving}
+                      onAuthorizeRepo={() => void authorizeSelectedRepo()}
+                    />
+                  </div>
+                )}
               </>
             )}
           </>
@@ -1727,15 +1789,22 @@ export default function AddIntegrationModal({
                 <div className="fldlbl mb-2">Listen for</div>
                 <div className="mb-4 grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-2">
                   {GL_FAMILIES.map((r) => {
-                    const on = glFams.has(r.fam)
+                    // A family the picked project is already watched for is not a
+                    // second trigger — it is edited on the agent page.
+                    const taken = glPickedWatched.has(r.fam)
+                    const on = !taken && glFams.has(r.fam)
                     return (
                       <div
                         key={r.fam}
                         data-gitlab-family={r.fam}
-                        className={`flex min-w-0 cursor-pointer items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
-                          on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'
-                        }`}
-                        onClick={() => toggleGlFam(r.fam)}
+                        aria-disabled={taken}
+                        title={taken ? 'Already watched — change its trigger on the agent page' : undefined}
+                        className={`flex min-w-0 items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
+                          taken ? 'cursor-default opacity-55' : 'cursor-pointer'
+                        } ${on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'}`}
+                        onClick={() => {
+                          if (!taken) toggleGlFam(r.fam)
+                        }}
                       >
                         <Icon
                           name={r.icon}
@@ -1746,7 +1815,7 @@ export default function AddIntegrationModal({
                         <span className="min-w-0 flex-1">
                           <span className="block font-sans text-[12.5px] font-semibold leading-normal">{r.label}</span>
                           <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-                            {r.desc}
+                            {taken ? 'already watched' : r.desc}
                           </span>
                         </span>
                         <span
@@ -1791,20 +1860,23 @@ export default function AddIntegrationModal({
                     )
                   })}
                 </div>
-                <div className="mb-4">
-                  <GitlabReviewSettings
-                    value={{ reviewPolicy: glReviewPolicy, reportingMode: glReportingMode }}
-                    onReviewPolicyChange={(policy) => {
-                      setGlReviewPolicy(policy)
-                      setErr(null)
-                    }}
-                    onReportingModeChange={(mode) => {
-                      setGlReportingMode(mode)
-                      setErr(null)
-                    }}
-                    projectBotReady={!glPicked?.binding || glPicked.binding.state !== 'provisioning'}
-                  />
-                </div>
+                {/* Reviews and the run note live on the merge-request row only. */}
+                {glMrSelected && (
+                  <div className="mb-4">
+                    <GitlabReviewSettings
+                      value={{ reviewPolicy: glReviewPolicy, reportingMode: glReportingMode }}
+                      onReviewPolicyChange={(policy) => {
+                        setGlReviewPolicy(policy)
+                        setErr(null)
+                      }}
+                      onReportingModeChange={(mode) => {
+                        setGlReportingMode(mode)
+                        setErr(null)
+                      }}
+                      projectBotReady={!glPicked?.binding || glPicked.binding.state !== 'provisioning'}
+                    />
+                  </div>
+                )}
               </>
             )}
           </>

--- a/packages/web/src/components/console/modals/DeleteHookModal.tsx
+++ b/packages/web/src/components/console/modals/DeleteHookModal.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import { useConsoleData } from '@/lib/data-context'
 import type { HookDto } from '@/lib/api'
+import { githubFamilyTile, githubHookFamily } from '@/lib/github-events'
+import { gitlabFamilyTile, gitlabHookFamily } from '@/lib/gitlab-events'
 import { Button, Icon } from '@/components/ui'
 
 // Confirm-delete a trigger. The CP drops the row and the relay pool drops its
@@ -18,6 +20,20 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
   const [err, setErr] = useState<string | null>(null)
   const hooks = Array.isArray(hook) ? hook : [hook]
   const group = Array.isArray(hook)
+  // A repo watched for two subject families is two rows — name each repo once.
+  const repoNames = [...new Set(hooks.map((h) => h.repoFullName ?? h.name))]
+  // A code-host row covers ONE family, so name it: the repo's other families keep firing.
+  const familyOf = (h: HookDto) => {
+    if (h.kind === 'gitlab') {
+      const fam = gitlabHookFamily(h)
+      return fam ? gitlabFamilyTile(fam)?.pill : undefined
+    }
+    if (h.kind === 'github') {
+      const fam = githubHookFamily(h)
+      return fam ? githubFamilyTile(fam)?.pill : undefined
+    }
+    return undefined
+  }
   const first = hooks[0]!
   const isGithub = group || first.kind === 'github'
   const isGitlab = !group && first.kind === 'gitlab'
@@ -58,23 +74,28 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
         <p className="m-0 font-sans text-[13.5px] font-normal leading-[1.6] text-(--text-secondary)">
           {group ? (
             <>
-              Removes {hooks.length === 1 ? 'the' : `all ${hooks.length}`} repository subscription
-              {hooks.length === 1 ? '' : 's'} (
-              <span className="mono text-(--text-primary)">
-                {hooks.map((h) => h.repoFullName ?? h.name).join(', ')}
-              </span>
-              ) — GitHub events stop triggering this agent. Past runs and their sessions stay.
+              Removes {repoNames.length === 1 ? 'the' : `all ${repoNames.length}`} repository subscription
+              {repoNames.length === 1 ? '' : 's'} (
+              <span className="mono text-(--text-primary)">{repoNames.join(', ')}</span>) — GitHub events stop
+              triggering this agent. Past runs and their sessions stay.
             </>
           ) : isGithub ? (
             <>
-              <span className="mono text-(--text-primary)">{first.repoFullName ?? first.name}</span>&#32;stops
-              triggering this agent — its GitHub events are ignored from now on. Past runs and their sessions stay.
+              <span className="mono text-(--text-primary)">
+                {first.repoFullName ?? first.name}
+                {familyOf(first) ? ` · ${familyOf(first)}` : ''}
+              </span>
+              &#32;stops triggering this agent — those GitHub events are ignored from now on. Past runs and their
+              sessions stay.
             </>
           ) : isGitlab ? (
             <>
-              <span className="mono text-(--text-primary)">{first.repoFullName ?? first.name}</span>&#32;stops
-              triggering this agent — its GitLab events are ignored from now on. The project itself, its bot and its
-              webhook are untouched. Past runs and their sessions stay.
+              <span className="mono text-(--text-primary)">
+                {first.repoFullName ?? first.name}
+                {familyOf(first) ? ` · ${familyOf(first)}` : ''}
+              </span>
+              &#32;stops triggering this agent — those GitLab events are ignored from now on. The project itself, its
+              bot and its webhook are untouched. Past runs and their sessions stay.
             </>
           ) : (
             <>

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -75,14 +75,13 @@ import { INTEGRATION_BLURB, PLATFORMS, isCoreTriggerKind } from '@/components/co
 import {
   GL_TRIGGER_MODES,
   GL_TRIGGER_PILL,
-  commentFamiliesForGitlabFamilies,
-  eventsForGitlabFamilies,
   gitlabCadencePick,
   gitlabCommentFamilies,
-  gitlabFamCovered,
-  gitlabFamilyToggle,
+  gitlabFamilyCarriesReviews,
+  gitlabFamilySubscription,
+  gitlabFamilyTile,
+  gitlabHookFamily,
   gitlabHookNeedsNormalization,
-  gitlabRowFamilies,
   gitlabTriggerModeOf,
   gitlabTriggerTooltip,
   type GlFamily,
@@ -98,13 +97,13 @@ import { consoleKeys } from '@/lib/swr-keys'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { useSessionList } from '@/lib/use-session-list'
 import {
-  GH_FAMILIES,
   GH_TRIGGER_MODES,
   GH_TRIGGER_PILL,
-  commentFamiliesForFamilies,
   githubCommentFamilies,
-  eventsForFamilies,
-  famCovered,
+  githubFamilyCarriesReviews,
+  githubFamilySubscription,
+  githubFamilyTile,
+  githubHookFamily,
   githubHookNeedsNormalization,
   githubTriggerTooltip,
   triggerModeOf,
@@ -402,10 +401,10 @@ export default function AgentDetailView() {
   }
 
   // Edit one github subscription in place (PUT re-sends the whole block); the
-  // SWR row is patched — no full revalidation. Families and the
-  // create/update/@-mention trigger both ride the stored event patterns.
+  // SWR row is patched — no full revalidation. The row's family is immutable and
+  // absent from the body; only the create/update/@-mention trigger moves.
   const [hookBusy, setHookBusy] = useState<string | null>(null)
-  const saveHookEvents = async (h: HookDto, fams: GhFamily[], mode: GhTriggerMode) => {
+  const saveHookEvents = async (h: HookDto, fam: GhFamily, mode: GhTriggerMode) => {
     if (hookBusy || !h.agentId || !h.repoFullName) return
     setHookBusy(h.id)
     try {
@@ -414,10 +413,8 @@ export default function AgentDetailView() {
         name: h.name,
         enabled: h.enabled,
         repoFullName: h.repoFullName,
-        events: eventsForFamilies(fams, mode),
-        commentFamilies: commentFamiliesForFamilies(fams),
+        ...githubFamilySubscription(fam, mode),
         labelFilter: h.labelFilter,
-        mentionOnly: mode === 'mention',
         reviewPolicy: h.reviewPolicy,
         reportingMode: h.reportingMode,
         gateMode: 'informational'
@@ -429,9 +426,8 @@ export default function AgentDetailView() {
       setHookBusy(null)
     }
   }
-  // The GitLab counterpart of saveHookEvents — same two axes, no review knobs
-  // yet (the M6 slice adds those, and the row must not imply them).
-  const saveGitlabHookEvents = async (h: HookDto, families: GlFamily[], mode: GlTriggerMode) => {
+  // The GitLab counterpart of saveHookEvents — its own whole-block PUT, no gateMode.
+  const saveGitlabHookEvents = async (h: HookDto, fam: GlFamily, mode: GlTriggerMode) => {
     if (hookBusy || !h.agentId || !h.repoId) return
     setHookBusy(h.id)
     try {
@@ -440,9 +436,7 @@ export default function AgentDetailView() {
         name: h.name,
         enabled: h.enabled,
         projectId: h.repoId,
-        events: eventsForGitlabFamilies(families, mode),
-        commentFamilies: commentFamiliesForGitlabFamilies(families, mode),
-        mentionOnly: mode === 'mention',
+        ...gitlabFamilySubscription(fam, mode),
         reviewPolicy: h.reviewPolicy,
         reportingMode: h.reportingMode
       })
@@ -453,27 +447,34 @@ export default function AgentDetailView() {
       setHookBusy(null)
     }
   }
-  // Pure helpers decide both edits: the toggle refuses to drop the last family, and the cadence pick refuses a no-op write, which is what leaves an inexpressible stored rule untouched.
-  const toggleGitlabHookFam = async (h: HookDto, fam: GlFamily) => {
-    const edit = gitlabFamilyToggle(h, fam)
-    if (edit) await saveGitlabHookEvents(h, edit.families, edit.mode)
-  }
+  // A pure helper decides the gitlab edit: it refuses a no-op write, which is what leaves an inexpressible stored rule untouched.
   const setGitlabHookCadence = async (h: HookDto, mode: GlTriggerMode) => {
     const edit = gitlabCadencePick(h, mode)
-    if (edit) await saveGitlabHookEvents(h, edit.families, edit.mode)
-  }
-  const toggleHookFam = async (h: HookDto, fam: GhFamily) => {
-    const fams = GH_FAMILIES.map((f) => f.fam).filter((f) =>
-      f === fam ? !famCovered(h.events, f) : famCovered(h.events, f)
-    )
-    if (fams.length === 0) return // at least one family must stay subscribed
-    const mode = triggerModeOf(h)
-    await saveHookEvents(h, fams, mode)
+    if (edit) await saveGitlabHookEvents(h, edit.family, edit.mode)
   }
   const setHookCadence = async (h: HookDto, mode: GhTriggerMode) => {
+    const fam = githubHookFamily(h)
+    if (!fam) return
     if (mode === triggerModeOf(h) && !githubHookNeedsNormalization(h)) return
-    const fams = GH_FAMILIES.map((f) => f.fam).filter((f) => famCovered(h.events, f))
-    await saveHookEvents(h, fams, mode)
+    await saveHookEvents(h, fam, mode)
+  }
+  // The row's family is a read-only fact now: it labels the row and decides
+  // whether the review/Check surface applies to it at all.
+  const ghRowPill = (h: HookDto) => {
+    const fam = githubHookFamily(h)
+    return fam ? (githubFamilyTile(fam)?.pill ?? fam) : 'no events'
+  }
+  const ghRowCarriesReviews = (h: HookDto) => {
+    const fam = githubHookFamily(h)
+    return !!fam && githubFamilyCarriesReviews(fam)
+  }
+  const glRowPill = (h: HookDto) => {
+    const fam = gitlabHookFamily(h)
+    return fam ? (gitlabFamilyTile(fam)?.pill ?? fam) : 'no events'
+  }
+  const glRowCarriesReviews = (h: HookDto) => {
+    const fam = gitlabHookFamily(h)
+    return !!fam && gitlabFamilyCarriesReviews(fam)
   }
   // One open-state drives both agent-actions surfaces: the desktop kebab dropdown
   // and the mobile bottom sheet (only one is ever visible — CSS gates them).
@@ -1395,9 +1396,9 @@ export default function AgentDetailView() {
                           {watchUnauthorized(h) && <UnauthorizedWatchBadge />}
                         </span>
                         <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                          {GH_FAMILIES.filter((f) => famCovered(h.events, f.fam))
-                            .map((f) => f.pill)
-                            .join(' · ') || 'no events'}
+                          {/* One row = one subject family, so this states which. */}
+                          {ghRowPill(h)}
+                          {` · ${GH_TRIGGER_PILL[triggerModeOf(h)]}`}
                         </span>
                         {(h.reviewPolicy !== 'off' || h.reportingMode === 'check') && (
                           <span className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
@@ -1406,13 +1407,16 @@ export default function AgentDetailView() {
                           </span>
                         )}
                       </span>
-                      <button
-                        className="iconbtn flex-none"
-                        title="PR review and Checks settings"
-                        onClick={() => openReviewSettings(h)}
-                      >
-                        <Icon name="settings-2" size={15} />
-                      </button>
+                      {/* Reviews and Checks exist on the pull-request row only. */}
+                      {ghRowCarriesReviews(h) && (
+                        <button
+                          className="iconbtn flex-none"
+                          title="PR review and Checks settings"
+                          onClick={() => openReviewSettings(h)}
+                        >
+                          <Icon name="settings-2" size={15} />
+                        </button>
+                      )}
                     </div>
                   ))}
                   {gitlabHooks.map((h, i) => (
@@ -1432,10 +1436,8 @@ export default function AgentDetailView() {
                           {h.repoFullName ?? h.name}
                         </span>
                         <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                          {gitlabRowFamilies(h.events)
-                            .filter((f) => gitlabFamCovered(h.events, f.fam))
-                            .map((f) => f.pill)
-                            .join(' · ') || 'no events'}
+                          {/* One row = one subject family, so this states which. */}
+                          {glRowPill(h)}
                           {` · ${GL_TRIGGER_PILL[gitlabTriggerModeOf(h)]}`}
                         </span>
                         {(h.reviewPolicy !== 'off' || h.reportingMode === 'check') && (
@@ -1445,13 +1447,16 @@ export default function AgentDetailView() {
                           </span>
                         )}
                       </span>
-                      <button
-                        className="iconbtn flex-none"
-                        title="MR review and run note settings"
-                        onClick={() => openReviewSettings(h)}
-                      >
-                        <Icon name="settings-2" size={15} />
-                      </button>
+                      {/* Reviews and the run note exist on the merge-request row only. */}
+                      {glRowCarriesReviews(h) && (
+                        <button
+                          className="iconbtn flex-none"
+                          title="MR review and run note settings"
+                          onClick={() => openReviewSettings(h)}
+                        >
+                          <Icon name="settings-2" size={15} />
+                        </button>
+                      )}
                     </div>
                   ))}
                 </div>
@@ -1554,9 +1559,9 @@ export default function AgentDetailView() {
                       )}
                     </div>
                   ))}
-                  {/* GitHub group (design): one card, a row per watched repo with
-                        event toggle pills + a "when created/updated" cadence select;
-                        hooks under the hood — one per repo. */}
+                  {/* GitHub group (design): one card, a row per hook — one per
+                        (repo, subject family) — each with its family pill and its
+                        own "when created/updated" cadence select. */}
                   {githubHooks.length > 0 && (
                     <div className="overflow-hidden rounded-[9px] border border-(--border-subtle)">
                       <div className="flex items-center gap-3 px-[14px] py-3">
@@ -1594,25 +1599,15 @@ export default function AgentDetailView() {
                                 {h.repoFullName ?? h.name}
                               </span>
                               {watchUnauthorized(h) && <UnauthorizedWatchBadge />}
-                              <div className="ml-auto inline-flex flex-none gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) p-[2px]">
-                                {GH_FAMILIES.map((f) => {
-                                  const on = famCovered(h.events, f.fam)
-                                  return (
-                                    <button
-                                      key={f.fam}
-                                      onClick={() => void toggleHookFam(h, f.fam)}
-                                      disabled={hookBusy === h.id}
-                                      title={on ? `Stop listening for ${f.pill}` : `Listen for ${f.pill}`}
-                                      className={`cursor-pointer rounded-[7px] border-0 px-[9px] py-[3px] font-sans text-[11.5px] leading-normal ${
-                                        on
-                                          ? 'bg-(--surface-card) font-semibold text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]'
-                                          : 'bg-transparent font-normal text-(--text-tertiary)'
-                                      } ${hookBusy === h.id ? 'opacity-60' : ''}`}
-                                    >
-                                      {f.pill}
-                                    </button>
-                                  )
-                                })}
+                              {/* One row = one subject family, and the family is
+                                  immutable — the pill states it, it no longer toggles. */}
+                              <div
+                                className="ml-auto inline-flex flex-none gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) p-[2px]"
+                                title="Add or remove families from Add integration"
+                              >
+                                <span className="rounded-[7px] bg-(--surface-card) px-[9px] py-[3px] font-sans text-[11.5px] font-semibold leading-normal text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]">
+                                  {ghRowPill(h)}
+                                </span>
                               </div>
                               {/* Trigger — the same ⚡ dropdown the IM channel rows carry, mention last. */}
                               <TriggerSelect
@@ -1629,13 +1624,16 @@ export default function AgentDetailView() {
                                 busy={hookBusy === h.id}
                               />
                               <span className="inline-flex flex-none gap-[2px]">
-                                <button
-                                  className="iconbtn h-[26px] w-[26px] flex-none"
-                                  title="PR review and Checks settings"
-                                  onClick={() => openReviewSettings(h)}
-                                >
-                                  <Icon name="settings-2" size={13} />
-                                </button>
+                                {/* Reviews and Checks exist on the pull-request row only. */}
+                                {ghRowCarriesReviews(h) && (
+                                  <button
+                                    className="iconbtn h-[26px] w-[26px] flex-none"
+                                    title="PR review and Checks settings"
+                                    onClick={() => openReviewSettings(h)}
+                                  >
+                                    <Icon name="settings-2" size={13} />
+                                  </button>
+                                )}
                                 <button
                                   className="iconbtn h-[26px] w-[26px] flex-none"
                                   title="Recent deliveries"
@@ -1675,8 +1673,7 @@ export default function AgentDetailView() {
                       </div>
                     </div>
                   )}
-                  {/* GitLab group — the same one-card shape as GitHub, minus the
-                      review and Check controls the M6 slice has not landed yet. */}
+                  {/* GitLab group — the same one-card, one-row-per-family shape. */}
                   {gitlabHooks.length > 0 && (
                     <div className="overflow-hidden rounded-[9px] border border-(--border-subtle)">
                       <div className="flex items-center gap-3 px-[14px] py-3">
@@ -1716,26 +1713,15 @@ export default function AgentDetailView() {
                                   custom rule
                                 </span>
                               )}
-                              <div className="ml-auto inline-flex flex-none gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) p-[2px]">
-                                {/* Pushes appear only on a hook that already listens to them — visible and removable, never addable. */}
-                                {gitlabRowFamilies(h.events).map((f) => {
-                                  const on = gitlabFamCovered(h.events, f.fam)
-                                  return (
-                                    <button
-                                      key={f.fam}
-                                      onClick={() => void toggleGitlabHookFam(h, f.fam)}
-                                      disabled={hookBusy === h.id}
-                                      title={on ? `Stop listening for ${f.label}` : `Listen for ${f.label}`}
-                                      className={`cursor-pointer rounded-[7px] border-0 px-[9px] py-[3px] font-sans text-[11.5px] leading-normal ${
-                                        on
-                                          ? 'bg-(--surface-card) font-semibold text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]'
-                                          : 'bg-transparent font-normal text-(--text-tertiary)'
-                                      } ${hookBusy === h.id ? 'opacity-60' : ''}`}
-                                    >
-                                      {f.pill}
-                                    </button>
-                                  )
-                                })}
+                              {/* One row = one subject family, and the family is
+                                  immutable — the pill states it, it no longer toggles. */}
+                              <div
+                                className="ml-auto inline-flex flex-none gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) p-[2px]"
+                                title="Add or remove families from Add integration"
+                              >
+                                <span className="rounded-[7px] bg-(--surface-card) px-[9px] py-[3px] font-sans text-[11.5px] font-semibold leading-normal text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]">
+                                  {glRowPill(h)}
+                                </span>
                               </div>
                               {/* Trigger — the same ⚡ dropdown the GitHub rows carry. */}
                               <TriggerSelect
@@ -1752,13 +1738,16 @@ export default function AgentDetailView() {
                                 busy={hookBusy === h.id}
                               />
                               <span className="inline-flex flex-none gap-[2px]">
-                                <button
-                                  className="iconbtn h-[26px] w-[26px] flex-none"
-                                  title="MR review and run note settings"
-                                  onClick={() => openReviewSettings(h)}
-                                >
-                                  <Icon name="settings-2" size={13} />
-                                </button>
+                                {/* Reviews and the run note exist on the merge-request row only. */}
+                                {glRowCarriesReviews(h) && (
+                                  <button
+                                    className="iconbtn h-[26px] w-[26px] flex-none"
+                                    title="MR review and run note settings"
+                                    onClick={() => openReviewSettings(h)}
+                                  >
+                                    <Icon name="settings-2" size={13} />
+                                  </button>
+                                )}
                                 <button
                                   className="iconbtn h-[26px] w-[26px] flex-none"
                                   title="Recent deliveries"

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -415,12 +415,15 @@ describe('GitHub hook review settings', () => {
       gateMode: 'informational' as const
     }
 
-    await createGithubHook(input)
+    // The family is create-only: it discriminates the row, and the update body
+    // must not carry it (the row's family is immutable).
+    await createGithubHook({ ...input, family: 'pull_request' })
     await updateGithubHook('hook-1', input)
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(JSON.parse(String(fetchMock.mock.calls[0]![1]?.body))).toMatchObject({
       kind: 'github',
+      family: 'pull_request',
       reviewPolicy: 'request_changes',
       reportingMode: 'check',
       gateMode: 'informational'

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3924,6 +3924,10 @@ export type { HookKind }
 export type GithubCommentFamily = 'issues' | 'pull_request'
 /** GitLab's own note families — the merge-request counterpart of a pull request. */
 export type GitlabCommentFamily = 'issues' | 'merge_request'
+/** The subject family ONE code-host row covers: a row is `(agent, repo, family)`,
+ *  each with its own cadence and mention gate, and the family is immutable. */
+export type GithubHookFamily = 'pull_request' | 'issues' | 'push'
+export type GitlabHookFamily = 'merge_request' | 'issues' | 'push'
 /** The stored union across code hosts; each row carries only its own host's subset. */
 export type HookCommentFamily = GithubCommentFamily | GitlabCommentFamily
 export type HookReviewPolicy = 'off' | 'comment' | 'request_changes' | 'full'
@@ -3944,6 +3948,7 @@ export interface HookDto {
   // ── code-host kinds ── repo/project + subscription (empty/null on webhook kind)
   repoId?: string | null // GitHub numeric repo id, or the GitLab numeric project id
   repoFullName: string | null // owner/repo as GitHub cases it, or the GitLab project path
+  family: string | null // the one subject family this row covers; null on webhook kind and legacy-inert rows
   events: string[] // 'issues:*' / 'issue_comment:created' / 'merge_request:*' / …
   commentFamilies: HookCommentFamily[] // thread kinds whose replies may fire this hook
   labelFilter: string[]
@@ -3990,6 +3995,7 @@ export interface CreateGithubHookInput {
   name: string
   enabled?: boolean
   repoFullName: string
+  family: GithubHookFamily // one row per family; every event pattern must belong to it
   events: string[] // 'issues:*' etc — at least one
   commentFamilies?: GithubCommentFamily[]
   labelFilter?: string[]
@@ -4007,6 +4013,7 @@ export interface CreateGitlabHookInput {
   name: string
   enabled?: boolean
   projectId: string // numeric GitLab project id
+  family: GitlabHookFamily // one row per family; every event pattern must belong to it
   events: string[] // 'issues:*' / 'merge_request:*' / 'push:*' — at least one
   commentFamilies?: GitlabCommentFamily[]
   mentionOnly?: boolean
@@ -4014,6 +4021,11 @@ export interface CreateGitlabHookInput {
   // 'check' publishes the merge-request run note; no gateMode — GitLab has no required gate.
   reportingMode?: HookReportingMode
 }
+
+// The family is immutable, so no update body carries it — changing a row's
+// family is a delete plus a create.
+export type UpdateGithubHookInput = Omit<CreateGithubHookInput, 'family'>
+export type UpdateGitlabHookInput = Omit<CreateGitlabHookInput, 'family'>
 
 // A hook is subordinate to its agent (like an Integration), so there is no
 // org-wide hook list — you fetch ONE agent's hooks, gated server-side by that
@@ -4041,7 +4053,7 @@ export async function createGithubHook(input: CreateGithubHookInput): Promise<Cr
 
 // Update a github hook's subscription (event pills / labels / repo re-target).
 // The body re-sends the full github block — PUT is whole-definition.
-export async function updateGithubHook(id: string, input: CreateGithubHookInput): Promise<HookDto> {
+export async function updateGithubHook(id: string, input: UpdateGithubHookInput): Promise<HookDto> {
   return apiPut<HookDto>(`${orgBase()}/hooks/${encodeURIComponent(id)}`, { kind: 'github', ...input })
 }
 
@@ -4054,7 +4066,7 @@ export async function createGitlabHook(input: CreateGitlabHookInput): Promise<Cr
 }
 
 // Update a gitlab hook's subscription. Whole-definition PUT, like the github one.
-export async function updateGitlabHook(id: string, input: CreateGitlabHookInput): Promise<HookDto> {
+export async function updateGitlabHook(id: string, input: UpdateGitlabHookInput): Promise<HookDto> {
   return apiPut<HookDto>(`${orgBase()}/hooks/${encodeURIComponent(id)}`, { kind: 'gitlab', ...input })
 }
 

--- a/packages/web/src/lib/github-events.test.ts
+++ b/packages/web/src/lib/github-events.test.ts
@@ -7,6 +7,10 @@ import {
   GH_TRIGGER_LABEL,
   GH_TRIGGER_MODES,
   GH_TRIGGER_PILL,
+  githubFamilyCarriesReviews,
+  githubFamilySubscription,
+  githubFamilyTile,
+  githubHookFamily,
   githubHookNeedsNormalization,
   githubMentionUsage,
   githubTriggerTooltip,
@@ -63,6 +67,73 @@ describe('GH_FAMILIES', () => {
 
   it('omits the commit (push) family — the subscription flow is held back for now', () => {
     expect(GH_FAMILIES.map(({ fam }) => fam)).toEqual(['pull_request', 'issues'])
+  })
+
+  it('still labels a stored push row the console never offers', () => {
+    expect(githubFamilyTile('push')?.pill).toBe('Commits')
+  })
+})
+
+describe('githubHookFamily', () => {
+  it('reads the row’s own family, whatever its stored events look like', () => {
+    expect(githubHookFamily({ family: 'issues', events: ['pull_request:*'] })).toBe('issues')
+    expect(githubHookFamily({ family: 'push', events: [] })).toBe('push')
+  })
+
+  it('falls back to the events for a legacy row the split could not place', () => {
+    expect(githubHookFamily({ family: null, events: ['issues:*', THREAD_COMMENT_EVENT] })).toBe('issues')
+    // Display order decides which family a legacy both-subject row shows as.
+    expect(githubHookFamily({ family: null, events: ['issues:*', 'pull_request:*'] })).toBe('pull_request')
+  })
+
+  it('names no family for a comment-only rule', () => {
+    expect(githubHookFamily({ family: null, events: [THREAD_COMMENT_EVENT] })).toBeNull()
+  })
+})
+
+describe('githubFamilySubscription', () => {
+  it('scopes the shared issue_comment subscription to the row’s own family', () => {
+    // The CP 400s an `issue_comment` pattern whose commentFamilies is empty.
+    expect(githubFamilySubscription('pull_request', 'every')).toEqual({
+      events: ['pull_request:*', THREAD_COMMENT_EVENT],
+      commentFamilies: ['pull_request'],
+      mentionOnly: false
+    })
+    expect(githubFamilySubscription('issues', 'mention')).toEqual({
+      events: ['issues:*', THREAD_COMMENT_EVENT],
+      commentFamilies: ['issues'],
+      mentionOnly: true
+    })
+  })
+
+  it('drops replies in created mode and comments altogether on a push row', () => {
+    expect(githubFamilySubscription('issues', 'first')).toEqual({
+      events: ['issues:opened'],
+      commentFamilies: ['issues'],
+      mentionOnly: false
+    })
+    expect(githubFamilySubscription('push', 'every')).toEqual({
+      events: ['push:*'],
+      commentFamilies: [],
+      mentionOnly: false
+    })
+  })
+
+  it('never emits a pattern from another family', () => {
+    for (const fam of ['pull_request', 'issues', 'push'] as const) {
+      for (const mode of GH_TRIGGER_MODES) {
+        const { events } = githubFamilySubscription(fam, mode)
+        expect(events.every((event) => event.startsWith(`${fam}:`) || event === THREAD_COMMENT_EVENT)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('githubFamilyCarriesReviews', () => {
+  it('confines reviews and Checks to the change-proposal subject', () => {
+    expect(githubFamilyCarriesReviews('pull_request')).toBe(true)
+    expect(githubFamilyCarriesReviews('issues')).toBe(false)
+    expect(githubFamilyCarriesReviews('push')).toBe(false)
   })
 })
 

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -1,18 +1,20 @@
-import type { GithubCommentFamily, HookCommentFamily } from './api'
+import type { GithubCommentFamily, GithubHookFamily, HookCommentFamily } from './api'
 
 /**
  * GitHub subscription event model shared by the Add-integration form and the
- * agent-detail pills. The console works in FAMILIES (pull requests / issues /
- * commits) plus a per-repo TRIGGER MODE ("when"); the stored `HookDef.events`
- * patterns plus the `mentionOnly` flag encode both:
+ * agent-detail pills. A stored row covers exactly ONE family (pull requests /
+ * issues / commits) and carries its own TRIGGER MODE ("when"), so a repository
+ * watched for both PRs and issues is two rows; the family is immutable, and the
+ * row's stored `events` patterns plus its `mentionOnly` flag encode the mode:
  *
  *   created  → `family:opened` for the regular cadence; the relay additionally accepts a later explicit
- *              @mention in the selected thread family (commits have no "first"
+ *              @mention in the row's thread family (commits have no "first"
  *              — a push subscription is inherently per-push, so `push:*` rides
  *              along unchanged)
- *   updated  → `family:*` + `issue_comment:created` when a thread family is
- *              selected. The relay ignores close/reopen and content edits;
- *              PR target-branch changes, other supported updates, and replies run.
+ *   updated  → `family:*` + `issue_comment:created` on a thread family, scoped
+ *              to that family by `commentFamilies`. The relay ignores
+ *              close/reopen and content edits; PR target-branch changes, other
+ *              supported updates, and replies run.
  *   mention only → the same subscriptions as updated, with `mentionOnly: true` —
  *              an event fires ONLY when its text (issue/PR body, comment body,
  *              commit message) @-mentions the assigned agent or the App. The
@@ -23,17 +25,22 @@ import type { GithubCommentFamily, HookCommentFamily } from './api'
  * emit them.
  */
 
-export type GhFamily = 'pull_request' | 'issues' | 'push'
+export type GhFamily = GithubHookFamily
 export type GhTriggerMode = 'first' | 'every' | 'mention'
+
+export interface GhFamilyTile {
+  fam: GhFamily
+  pill: string
+  icon: string
+  label: string
+  desc: string
+}
 
 // `desc` is the Add-integration tile subtitle — the design's compact grid, so
 // keep it to a short fragment that fits one or two 11.5px lines.
-//
-// The `push` (Commits) family is intentionally omitted for now — the
-// commit-subscription flow is held back. `GhFamily` still includes 'push' so
-// the event helpers keep reading any already-stored push subscription; re-add
-// the tile here (and restore the 3-up grid) to bring the feature back.
-export const GH_FAMILIES: { fam: GhFamily; pill: string; icon: string; label: string; desc: string }[] = [
+// Every subject the wire knows, in display order — a stored push row still
+// reads its own label from here even though the console never offers one.
+const GH_ALL_FAMILIES: GhFamilyTile[] = [
   {
     fam: 'pull_request',
     pill: 'PRs',
@@ -47,8 +54,30 @@ export const GH_FAMILIES: { fam: GhFamily; pill: string; icon: string; label: st
     icon: 'circle-dot',
     label: 'Issues',
     desc: 'opened, labels, replies'
+  },
+  {
+    fam: 'push',
+    pill: 'Commits',
+    icon: 'git-commit-horizontal',
+    label: 'Commits',
+    desc: 'commits pushed to a branch'
   }
 ]
+
+// The subjects the console OFFERS. The `push` (Commits) tile is intentionally
+// held back for now — the commit-subscription flow is not exposed; re-add it
+// here (and restore the 3-up grid) to bring the feature back.
+export const GH_FAMILIES: GhFamilyTile[] = GH_ALL_FAMILIES.filter((entry) => entry.fam !== 'push')
+
+/** The display metadata for one family, including the held-back push subject. */
+export function githubFamilyTile(fam: GhFamily): GhFamilyTile | undefined {
+  return GH_ALL_FAMILIES.find((entry) => entry.fam === fam)
+}
+
+/** Reviews and Checks exist only on the change-proposal subject (the CP 400s otherwise). */
+export function githubFamilyCarriesReviews(fam: GhFamily): boolean {
+  return fam === 'pull_request'
+}
 
 /** The trigger modes in display order — mention deliberately last. */
 export const GH_TRIGGER_MODES: readonly GhTriggerMode[] = ['first', 'every', 'mention']
@@ -123,6 +152,31 @@ export function eventsForFamilies(fams: Iterable<GhFamily>, mode: GhTriggerMode)
 /** Whether a hook's stored events cover a family (any action pattern counts). */
 export function famCovered(events: string[], fam: GhFamily): boolean {
   return events.some((e) => e.startsWith(`${fam}:`))
+}
+
+/** The one subject family a stored row covers: its own `family`, or — for a
+ *  legacy row the split could not place — the first family its events cover. */
+export function githubHookFamily(hook: { family: string | null; events: string[] }): GhFamily | null {
+  const declared = GH_ALL_FAMILIES.find((entry) => entry.fam === hook.family)
+  if (declared) return declared.fam
+  return GH_ALL_FAMILIES.find((entry) => famCovered(hook.events, entry.fam))?.fam ?? null
+}
+
+/** The subscription block ONE (family, mode) row writes — `family` itself is
+ *  create-only, so it is not part of this body. */
+export interface GithubFamilySubscription {
+  events: string[]
+  commentFamilies: GithubCommentFamily[]
+  mentionOnly: boolean
+}
+
+/** Compile one row's family+mode into the fields its create/update body carries. */
+export function githubFamilySubscription(fam: GhFamily, mode: GhTriggerMode): GithubFamilySubscription {
+  return {
+    events: eventsForFamilies([fam], mode),
+    commentFamilies: commentFamiliesForFamilies([fam]),
+    mentionOnly: mode === 'mention'
+  }
 }
 
 /** Recover the trigger mode: the mentionOnly flag wins, `:opened`-only ⇒ created. */

--- a/packages/web/src/lib/gitlab-events.test.ts
+++ b/packages/web/src/lib/gitlab-events.test.ts
@@ -8,9 +8,11 @@ import {
   commentFamiliesForGitlabFamilies,
   eventsForGitlabFamilies,
   gitlabCadencePick,
-  gitlabFamilyToggle,
+  gitlabFamilyCarriesReviews,
+  gitlabFamilySubscription,
+  gitlabFamilyTile,
+  gitlabHookFamily,
   gitlabHookNeedsNormalization,
-  gitlabRowFamilies,
   gitlabTriggerModeOf,
   gitlabTriggerTooltip,
   parseGitlabHookThread
@@ -57,15 +59,71 @@ describe('GL_FAMILIES', () => {
   })
 })
 
-describe('gitlabRowFamilies', () => {
-  it('shows only the offered subjects for a hook that never listened to pushes', () => {
-    expect(gitlabRowFamilies(['merge_request:*']).map(({ fam }) => fam)).toEqual(['issues', 'merge_request'])
+describe('gitlabFamilyTile', () => {
+  it('still labels a stored push row the console never offers', () => {
+    expect(gitlabFamilyTile('push')?.pill).toBe('Pushes')
+    expect(gitlabFamilyTile('push')?.desc).toBe('commits pushed to a branch')
+  })
+})
+
+describe('gitlabHookFamily', () => {
+  it('reads the row’s own family, whatever its stored events look like', () => {
+    expect(gitlabHookFamily({ family: 'issues', events: ['merge_request:*'] })).toBe('issues')
+    expect(gitlabHookFamily({ family: 'push', events: [] })).toBe('push')
   })
 
-  it('keeps the pushes toggle on a hook that already stores push events', () => {
-    const rows = gitlabRowFamilies(['merge_request:*', 'push:*'])
-    expect(rows.map(({ fam }) => fam)).toEqual(['issues', 'merge_request', 'push'])
-    expect(rows.find(({ fam }) => fam === 'push')?.desc).toBe('commits pushed to a branch')
+  it('falls back to the events for a legacy row the split could not place', () => {
+    expect(gitlabHookFamily({ family: null, events: ['merge_request:*'] })).toBe('merge_request')
+    // Display order decides which family a legacy both-subject row shows as.
+    expect(gitlabHookFamily({ family: null, events: ['merge_request:*', 'issues:*'] })).toBe('issues')
+  })
+
+  it('names no family for a note-only rule', () => {
+    expect(gitlabHookFamily({ family: null, events: ['note:*'] })).toBeNull()
+  })
+})
+
+describe('gitlabFamilySubscription', () => {
+  it('scopes the note subscription to the row’s own family', () => {
+    expect(gitlabFamilySubscription('merge_request', 'every')).toEqual({
+      events: ['merge_request:*'],
+      commentFamilies: ['merge_request'],
+      mentionOnly: false
+    })
+    expect(gitlabFamilySubscription('issues', 'mention')).toEqual({
+      events: ['issues:*'],
+      commentFamilies: ['issues'],
+      mentionOnly: true
+    })
+  })
+
+  it('clears the note family in created mode and on a push row', () => {
+    expect(gitlabFamilySubscription('merge_request', 'first')).toEqual({
+      events: ['merge_request:opened'],
+      commentFamilies: [],
+      mentionOnly: false
+    })
+    expect(gitlabFamilySubscription('push', 'every')).toEqual({
+      events: ['push:*'],
+      commentFamilies: [],
+      mentionOnly: false
+    })
+  })
+
+  it('never emits a pattern from another family', () => {
+    for (const fam of ['issues', 'merge_request', 'push'] as const) {
+      for (const mode of GL_TRIGGER_MODES) {
+        expect(gitlabFamilySubscription(fam, mode).events.every((event) => event.startsWith(`${fam}:`))).toBe(true)
+      }
+    }
+  })
+})
+
+describe('gitlabFamilyCarriesReviews', () => {
+  it('confines reviews and the run note to the change-proposal subject', () => {
+    expect(gitlabFamilyCarriesReviews('merge_request')).toBe(true)
+    expect(gitlabFamilyCarriesReviews('issues')).toBe(false)
+    expect(gitlabFamilyCarriesReviews('push')).toBe(false)
   })
 })
 
@@ -192,37 +250,17 @@ describe('parseGitlabHookThread', () => {
   })
 })
 
-describe('gitlabFamilyToggle', () => {
-  const updatedMr = { events: ['merge_request:*'], mentionOnly: false }
-
-  it('adds and removes a subject while carrying the stored cadence along', () => {
-    expect(gitlabFamilyToggle(updatedMr, 'issues')).toEqual({ families: ['issues', 'merge_request'], mode: 'every' })
-    expect(gitlabFamilyToggle({ events: ['issues:opened', 'push:*'], mentionOnly: false }, 'push')).toEqual({
-      families: ['issues'],
-      mode: 'first'
-    })
-  })
-
-  it('carries a stored push subscription through an edit that never mentioned it', () => {
-    expect(gitlabFamilyToggle({ events: ['merge_request:*', 'push:*'], mentionOnly: false }, 'issues')).toEqual({
-      families: ['issues', 'merge_request', 'push'],
-      mode: 'every'
-    })
-  })
-
-  it('refuses to unsubscribe the last remaining subject', () => {
-    expect(gitlabFamilyToggle(updatedMr, 'merge_request')).toBeNull()
-  })
-})
-
 describe('gitlabCadencePick', () => {
   const canonicalUpdated = {
+    family: 'merge_request',
     events: ['merge_request:*'],
     commentFamilies: ['merge_request'] as const,
     mentionOnly: false
   }
-  // Replies on issues but not merge requests: no radio state encodes it.
+  // A legacy row watching both subjects, with replies on issues only: no radio
+  // state encodes it, and its family was never placed.
   const nonCollapsing = {
+    family: null,
     events: ['issues:*', 'merge_request:*'],
     commentFamilies: ['issues'] as const,
     mentionOnly: false
@@ -232,26 +270,23 @@ describe('gitlabCadencePick', () => {
     expect(gitlabCadencePick(canonicalUpdated, 'every')).toBeNull()
   })
 
-  it('rewrites the whole block when a different cadence is picked', () => {
-    expect(gitlabCadencePick(canonicalUpdated, 'first')).toEqual({ families: ['merge_request'], mode: 'first' })
-    expect(gitlabCadencePick(canonicalUpdated, 'mention')).toEqual({ families: ['merge_request'], mode: 'mention' })
+  it('keeps the row’s immutable family and only moves the cadence', () => {
+    expect(gitlabCadencePick(canonicalUpdated, 'first')).toEqual({ family: 'merge_request', mode: 'first' })
+    expect(gitlabCadencePick(canonicalUpdated, 'mention')).toEqual({ family: 'merge_request', mode: 'mention' })
   })
 
   it('leaves a rule the trigger cannot express alone until a cadence is picked', () => {
     // Displaying it must not rewrite it — but the nearest state is still shown,
-    // and re-picking that same state is the explicit opt-in that normalizes.
+    // and re-picking that same state is the explicit opt-in that normalizes it
+    // down to the one family the row can keep.
     expect(gitlabTriggerModeOf(nonCollapsing)).toBe('every')
     expect(gitlabHookNeedsNormalization(nonCollapsing)).toBe(true)
-    expect(gitlabCadencePick(nonCollapsing, 'every')).toEqual({
-      families: ['issues', 'merge_request'],
-      mode: 'every'
-    })
+    expect(gitlabCadencePick(nonCollapsing, 'every')).toEqual({ family: 'issues', mode: 'every' })
   })
 
-  it('never invents a subject the stored rule did not watch', () => {
-    expect(gitlabCadencePick({ events: ['push:*'], commentFamilies: [], mentionOnly: false }, 'mention')).toEqual({
-      families: ['push'],
-      mode: 'mention'
-    })
+  it('writes no edit for a rule that names no subject at all', () => {
+    expect(
+      gitlabCadencePick({ family: null, events: ['note:*'], commentFamilies: [], mentionOnly: false }, 'mention')
+    ).toBeNull()
   })
 })

--- a/packages/web/src/lib/gitlab-events.ts
+++ b/packages/web/src/lib/gitlab-events.ts
@@ -3,14 +3,16 @@
  *
  * The console presents the same two axes GitHub does: SUBJECT families (issues
  * and merge requests — pushes are wire-supported but held back from the console,
- * see `GL_FAMILIES`) plus one TRIGGER MODE. The stored `events` patterns,
- * `commentFamilies` and the `mentionOnly` flag encode both:
+ * see `GL_FAMILIES`) plus one TRIGGER MODE. A stored row covers exactly ONE
+ * family and carries its own mode, so a project watched for both subjects is two
+ * rows and the family is immutable; the row's `events` patterns,
+ * `commentFamilies` and `mentionOnly` flag encode the mode:
  *
- *   created  → `family:opened` for the thread families and NO note family; the
+ *   created  → `family:opened` for a thread family and NO note family; the
  *              relay additionally accepts a later explicit @mention in an
  *              `:opened`-cadence thread family. Pushes have no "first" — a push
  *              subscription is inherently per-push, so `push:*` rides along.
- *   updated  → `family:*` plus the selected thread families as note families,
+ *   updated  → `family:*` plus the row's own thread family as its note family,
  *              so replies fire too. Close, reopen, merge and draft toggles stay
  *              inert; supported updates and replies run.
  *   mention only → the same subscriptions as updated, with `mentionOnly: true` —
@@ -28,9 +30,9 @@
  * The wire accepts finer `family:action` patterns; these helpers never emit one.
  */
 
-import type { GitlabCommentFamily, HookCommentFamily } from './api'
+import type { GitlabCommentFamily, GitlabHookFamily, HookCommentFamily } from './api'
 
-export type GlFamily = 'issues' | 'merge_request' | 'push'
+export type GlFamily = GitlabHookFamily
 export type GlTriggerMode = 'first' | 'every' | 'mention'
 
 export interface GlFamilyTile {
@@ -43,9 +45,8 @@ export interface GlFamilyTile {
 
 // `desc` is the Add-integration tile subtitle — keep it to a short fragment
 // naming signals the relay really forwards, on one or two 11.5px lines.
-// Every subject the wire knows, in display order. The event helpers read THIS
-// list, so an already-stored push subscription round-trips instead of being
-// silently dropped by an edit that never mentioned pushes.
+// Every subject the wire knows, in display order — a stored push row still
+// reads its own label from here even though the console never offers one.
 const GL_ALL_FAMILIES: GlFamilyTile[] = [
   { fam: 'issues', pill: 'Issues', icon: 'circle-dot', label: 'Issues', desc: 'opened, labels, replies' },
   {
@@ -63,10 +64,14 @@ const GL_ALL_FAMILIES: GlFamilyTile[] = [
 // re-add it here (and restore the 3-up grid) to bring the feature back.
 export const GL_FAMILIES: GlFamilyTile[] = GL_ALL_FAMILIES.filter((entry) => entry.fam !== 'push')
 
-/** The subject toggles ONE stored hook shows: the offered ones, plus pushes when
- *  it already listens to them so the stored rule stays legible and removable. */
-export function gitlabRowFamilies(events: readonly string[]): GlFamilyTile[] {
-  return GL_ALL_FAMILIES.filter((entry) => entry.fam !== 'push' || gitlabFamCovered(events, 'push'))
+/** The display metadata for one family, including the held-back push subject. */
+export function gitlabFamilyTile(fam: GlFamily): GlFamilyTile | undefined {
+  return GL_ALL_FAMILIES.find((entry) => entry.fam === fam)
+}
+
+/** Reviews and the run note exist only on the change-proposal subject (the CP 400s otherwise). */
+export function gitlabFamilyCarriesReviews(fam: GlFamily): boolean {
+  return fam === 'merge_request'
 }
 
 /** The trigger modes in display order — mention deliberately last. */
@@ -176,29 +181,40 @@ export function gitlabHookNeedsNormalization(hook: {
   )
 }
 
-/** One edit-path write: the whole subscription block the row must PUT. */
-export interface GitlabSubscriptionEdit {
-  families: GlFamily[]
-  mode: GlTriggerMode
-}
-
 /** The stored subject families, in display order. */
 function gitlabFamiliesOf(events: readonly string[]): GlFamily[] {
   return GL_ALL_FAMILIES.map((entry) => entry.fam).filter((family) => gitlabFamCovered(events, family))
 }
 
-/** A subject toggle on an existing hook — null when it would leave the hook
- *  watching nothing. The stored cadence rides along unchanged; a rule the radio
- *  cannot express is normalized, because the toggle is an explicit edit. */
-export function gitlabFamilyToggle(
-  hook: { events: readonly string[]; mentionOnly: boolean },
-  fam: GlFamily
-): GitlabSubscriptionEdit | null {
-  const families = GL_ALL_FAMILIES.map((entry) => entry.fam).filter((family) =>
-    family === fam ? !gitlabFamCovered(hook.events, family) : gitlabFamCovered(hook.events, family)
-  )
-  if (families.length === 0) return null
-  return { families, mode: gitlabTriggerModeOf(hook) }
+/** The one subject family a stored row covers: its own `family`, or — for a
+ *  legacy row the split could not place — the first family its events cover. */
+export function gitlabHookFamily(hook: { family: string | null; events: readonly string[] }): GlFamily | null {
+  const declared = GL_ALL_FAMILIES.find((entry) => entry.fam === hook.family)
+  if (declared) return declared.fam
+  return gitlabFamiliesOf(hook.events)[0] ?? null
+}
+
+/** The subscription block ONE (family, mode) row writes — `family` itself is
+ *  create-only, so it is not part of this body. */
+export interface GitlabFamilySubscription {
+  events: string[]
+  commentFamilies: GitlabCommentFamily[]
+  mentionOnly: boolean
+}
+
+/** Compile one row's family+mode into the fields its create/update body carries. */
+export function gitlabFamilySubscription(fam: GlFamily, mode: GlTriggerMode): GitlabFamilySubscription {
+  return {
+    events: eventsForGitlabFamilies([fam], mode),
+    commentFamilies: commentFamiliesForGitlabFamilies([fam], mode),
+    mentionOnly: mode === 'mention'
+  }
+}
+
+/** One edit-path write: the row's immutable family plus the cadence to store. */
+export interface GitlabSubscriptionEdit {
+  family: GlFamily
+  mode: GlTriggerMode
 }
 
 /** A cadence pick on an existing hook — null when nothing would change, which
@@ -206,11 +222,18 @@ export function gitlabFamilyToggle(
  *  the mere act of displaying it. Re-picking the DISPLAYED cadence on such a
  *  rule does write: that is the explicit opt-in that normalizes it. */
 export function gitlabCadencePick(
-  hook: { events: readonly string[]; commentFamilies: readonly HookCommentFamily[]; mentionOnly: boolean },
+  hook: {
+    family: string | null
+    events: readonly string[]
+    commentFamilies: readonly HookCommentFamily[]
+    mentionOnly: boolean
+  },
   mode: GlTriggerMode
 ): GitlabSubscriptionEdit | null {
+  const family = gitlabHookFamily(hook)
+  if (!family) return null
   if (mode === gitlabTriggerModeOf(hook) && !gitlabHookNeedsNormalization(hook)) return null
-  return { families: gitlabFamiliesOf(hook.events), mode }
+  return { family, mode }
 }
 
 /**


### PR DESCRIPTION
## What

A `kind:"github"`/`kind:"gitlab"` trigger row now covers exactly **one subject family** — `pull_request`/`merge_request`, `issues`, or `push` — recorded in a new `family` column and unique per `(agent, kind, repo, family)`. Watching a repository for both pull requests and issues is two rows, each with its own cadence, label filter, and `mentionOnly` gate. The motivating configuration now works: PRs trigger on every update while issues summon the agent only on an explicit @mention.

## Why the wire and relay are untouched

The relay already fans one delivery out to every rule matching the repository, and `commentFamilies` already isolates comment traffic per family — so each row compiles into an ordinary independent rule. A dedicated integration test asserts two sibling rows compile into two wire rules carrying their own `mentionOnly`.

## Control plane

- `HookDef.family` + unique index `(agentId, kind, repoId, family)`; the four "already watches" probes are gone — a duplicate arrives as the constraint violation and answers the same 409, now naming the family.
- New pure per-row shape gate (`hooks/hook-family.ts`, 400): every stored pattern belongs to the row's family (`issue_comment:*` rides GitHub thread families, `pull_request_review_comment:*` rides `pull_request`); `commentFamilies` is `[]` or `[family]`, and a GitHub row with an `issue_comment` subscription must set it (empty would keep the legacy repo-wide meaning and double-fire against the sibling); review/reporting axes only on change-proposal families.
- Sibling rows of one repo answer the same threads, so they must share the anchoring target and the session-key prefix (409 otherwise; the session key is inherited from an existing sibling).
- `family` is immutable — the update body does not carry it; changing it is delete + create.

## Migration

Idempotent split of legacy rows: the review-capable family keeps the existing row id (review projections, publication leases, and run history all key on it); siblings are new rows with review axes at defaults. A comment-only repo-wide GitHub rule splits into both thread families. Legacy empty `commentFamilies` (repo-wide comments) is deliberately narrowed to each row's own family — an accepted behavior change; the old width was an accident of the shared `issue_comment` event. Pre-existing duplicate rows on one (agent, repo) claim free family slots and otherwise stay legacy-inert with `family = NULL`. A test re-executes the migration SQL against legacy-shaped fixtures.

## Console (minimal slice)

- Add integration creates one trigger per selected family and blocks already-watched families instead of whole repositories.
- Agent detail: the family pills are now read-only indicators of the row's family; the per-row trigger selector, review settings (change-proposal rows only), and delete keep working. A repo watched for two families renders as two rows — the grouped per-repo display is a follow-up, together with per-family trigger modes in a single Add-integration pass.

## Tests

- control-plane `test:unit` 180 files / 2068 passed, `test:int` 114 files / 1804 passed (includes the migration-split and two-sibling wire-compile cases)
- web tests 183 files / 2069 passed; `pnpm typecheck`, `lint`, `format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
