### PR TITLE
feat(console): flat per-family trigger rows with folded row actions

### DIFF
--- a/packages/web/src/components/console/modals/DeleteHookModal.test.tsx
+++ b/packages/web/src/components/console/modals/DeleteHookModal.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+/**
+ * One confirm can target one row, one repository's whole family set, or the
+ * whole host — the rows it carries decide which, and the copy has to say so.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { HookDto } from '@/lib/api'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+// Declare the parameters: a bare `vi.fn(async () => …)` infers a zero-arg mock.
+const deleteHook = vi.hoisted(() => vi.fn(async (_id: string, _agentId?: string | null) => undefined))
+vi.mock('@/lib/data-context', () => ({ useConsoleData: () => ({ deleteHook }) }))
+
+const DeleteHookModal = (await import('./DeleteHookModal')).default
+
+function hook(partial: Partial<HookDto>): HookDto {
+  return {
+    id: 'hook-1',
+    agentId: 'agent-1',
+    kind: 'github',
+    name: 'acme/api',
+    repoFullName: 'acme/api',
+    family: 'pull_request',
+    events: ['pull_request:*'],
+    commentFamilies: [],
+    ...partial
+  } as HookDto
+}
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+async function render(target: HookDto | HookDto[]): Promise<string> {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root!.render(<DeleteHookModal hook={target} onClose={() => {}} />)
+  })
+  return host.textContent ?? ''
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  deleteHook.mockClear()
+})
+
+describe('DeleteHookModal', () => {
+  it('names every family a one-repository set removes', async () => {
+    const text = await render([
+      hook({ id: 'a', family: 'pull_request', events: ['pull_request:*'] }),
+      hook({ id: 'b', family: 'issues', events: ['issues:*'] })
+    ])
+    expect(text).toContain('Remove repository')
+    expect(text).toContain('acme/api · PRs, Issues')
+    expect(text).not.toContain('Disconnect')
+  })
+
+  it('reads as the host disconnect once it spans repositories', async () => {
+    const text = await render([
+      hook({ id: 'a', name: 'acme/api', repoFullName: 'acme/api' }),
+      hook({ id: 'b', name: 'acme/web', repoFullName: 'acme/web' })
+    ])
+    expect(text).toContain('Disconnect GitHub')
+    expect(text).toContain('acme/api, acme/web')
+  })
+
+  it('names the one family a single row removes', async () => {
+    const text = await render(
+      hook({ kind: 'gitlab', name: 'group/proj', repoFullName: 'group/proj', family: 'issues', events: ['issues:*'] })
+    )
+    expect(text).toContain('Remove project')
+    expect(text).toContain('group/proj · Issues')
+  })
+
+  it('deletes every row it names', async () => {
+    await render([hook({ id: 'a' }), hook({ id: 'b', family: 'issues', events: ['issues:*'] })])
+    const del = [...host!.querySelectorAll('button')].find((b) => b.textContent?.includes('Delete'))!
+    await act(async () => del.click())
+    expect(deleteHook.mock.calls.map(([id]) => id)).toEqual(['a', 'b'])
+  })
+})

--- a/packages/web/src/components/console/modals/DeleteHookModal.tsx
+++ b/packages/web/src/components/console/modals/DeleteHookModal.tsx
@@ -12,16 +12,15 @@ import { Button, Icon } from '@/components/ui'
 // get a uniform 404); a github subscription stops matching that repo's events;
 // Past runs and their sessions survive. The list re-pulls via the data context.
 // a gitlab subscription stops matching that project's events.
-// An ARRAY target = the GitHub group card's header unplug: disconnect GitHub by
-// removing every repo subscription of this agent in one confirm.
+// An ARRAY target removes a set in one confirm — one repo's whole family set, or every repo; the repos named decide.
 export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | HookDto[]; onClose: () => void }) {
   const { deleteHook } = useConsoleData()
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const hooks = Array.isArray(hook) ? hook : [hook]
-  const group = Array.isArray(hook)
   // A repo watched for two subject families is two rows — name each repo once.
   const repoNames = [...new Set(hooks.map((h) => h.repoFullName ?? h.name))]
+  const group = Array.isArray(hook) && repoNames.length > 1
   // A code-host row covers ONE family, so name it: the repo's other families keep firing.
   const familyOf = (h: HookDto) => {
     if (h.kind === 'gitlab') {
@@ -35,8 +34,12 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
     return undefined
   }
   const first = hooks[0]!
-  const isGithub = group || first.kind === 'github'
-  const isGitlab = !group && first.kind === 'gitlab'
+  const isGithub = first.kind === 'github'
+  const isGitlab = first.kind === 'gitlab'
+  const hostName = isGitlab ? 'GitLab' : 'GitHub'
+  // Every family this confirm removes from the one repository it names.
+  const familyList = [...new Set(hooks.map(familyOf).filter((pill): pill is string => !!pill))].join(', ')
+  const subject = `${first.repoFullName ?? first.name}${familyList ? ` · ${familyList}` : ''}`
 
   const onDelete = async () => {
     if (busy) return
@@ -59,7 +62,7 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
         </span>
         <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">
           {group
-            ? 'Disconnect GitHub'
+            ? `Disconnect ${hostName}`
             : isGithub
               ? 'Remove repository'
               : isGitlab
@@ -74,28 +77,20 @@ export default function DeleteHookModal({ hook, onClose }: { hook: HookDto | Hoo
         <p className="m-0 font-sans text-[13.5px] font-normal leading-[1.6] text-(--text-secondary)">
           {group ? (
             <>
-              Removes {repoNames.length === 1 ? 'the' : `all ${repoNames.length}`} repository subscription
-              {repoNames.length === 1 ? '' : 's'} (
-              <span className="mono text-(--text-primary)">{repoNames.join(', ')}</span>) — GitHub events stop
+              Removes all {repoNames.length} repository subscriptions (
+              <span className="mono text-(--text-primary)">{repoNames.join(', ')}</span>) — {hostName} events stop
               triggering this agent. Past runs and their sessions stay.
             </>
           ) : isGithub ? (
             <>
-              <span className="mono text-(--text-primary)">
-                {first.repoFullName ?? first.name}
-                {familyOf(first) ? ` · ${familyOf(first)}` : ''}
-              </span>
-              &#32;stops triggering this agent — those GitHub events are ignored from now on. Past runs and their
-              sessions stay.
+              <span className="mono text-(--text-primary)">{subject}</span>&#32;stops triggering this agent — those
+              GitHub events are ignored from now on. Past runs and their sessions stay.
             </>
           ) : isGitlab ? (
             <>
-              <span className="mono text-(--text-primary)">
-                {first.repoFullName ?? first.name}
-                {familyOf(first) ? ` · ${familyOf(first)}` : ''}
-              </span>
-              &#32;stops triggering this agent — those GitLab events are ignored from now on. The project itself, its
-              bot and its webhook are untouched. Past runs and their sessions stay.
+              <span className="mono text-(--text-primary)">{subject}</span>&#32;stops triggering this agent — those
+              GitLab events are ignored from now on. The project itself, its bot and its webhook are untouched. Past
+              runs and their sessions stay.
             </>
           ) : (
             <>

--- a/packages/web/src/components/console/views/AgentDetailView.codehost.test.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.codehost.test.tsx
@@ -1,0 +1,287 @@
+// @vitest-environment happy-dom
+/**
+ * The code-host panes list ONE flat row per `(repo, family)` subscription — no
+ * repo header, no group control. A repository's rows sit adjacent with change
+ * proposals first, secondary row actions fold into a ⋯ menu, and a family the
+ * repo does not watch yet is offered by a + menu on its first row.
+ */
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { SWRConfig } from 'swr'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const mocks = vi.hoisted(() => ({
+  hooks: [] as unknown[],
+  createGithubHook: vi.fn(),
+  openModal: vi.fn()
+}))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'agent-1' }),
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() })
+}))
+vi.mock('next/link', () => ({ default: ({ children }: { children?: ReactNode }) => <span>{children}</span> }))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, myRole: 'owner', orgPath: (path: string) => path })
+}))
+vi.mock('@/components/console/PlaygroundProvider', () => ({ usePlayground: () => ({ openPlayground: vi.fn() }) }))
+vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: mocks.openModal }) }))
+vi.mock('@/lib/use-session-list', () => ({ useSessionList: () => ({ sessions: [], total: 0, isLoading: false }) }))
+vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({ runtimes: [] }), acpRuntime: () => null }))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    agents: [agent],
+    getAgent: () => agent,
+    getSessions: () => [],
+    daemons: [],
+    daemonsLoading: false,
+    integrations: [],
+    agentsLoading: false,
+    updateAgent: vi.fn(async () => undefined),
+    refresh: vi.fn(),
+    memberSets: [],
+    orgSetIds: new Set<string>()
+  })
+}))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchAgentHooks: vi.fn(async () => mocks.hooks),
+  fetchAgentRepos: vi.fn(async () => []),
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
+  fetchGitlabConnections: vi.fn(async () => ({ enabled: false, connections: [] })),
+  createGithubHook: mocks.createGithubHook
+}))
+
+const agent = {
+  id: 'agent-1',
+  name: 'pilot',
+  model: 'sonnet',
+  runtime: 'claude',
+  desc: '',
+  outputMode: '—',
+  showFooter: true,
+  showStatusBar: false,
+  reasoning: '',
+  fastMode: false,
+  pause: false,
+  memoryProvider: 'none',
+  memoryAutoDistill: false,
+  status: 'online',
+  workspace: { mode: 'scratch', files: [] },
+  integrations: [],
+  visibility: 'org'
+} as unknown as Parameters<typeof Object.freeze>[0]
+
+function githubHook(partial: Record<string, unknown>): unknown {
+  return {
+    agentId: 'agent-1',
+    kind: 'github',
+    enabled: true,
+    commentFamilies: [],
+    labelFilter: [],
+    mentionOnly: false,
+    reviewPolicy: 'off',
+    reportingMode: 'off',
+    gateMode: 'informational',
+    ...partial
+  }
+}
+
+// acme/api is watched for BOTH subjects; acme/web only for issues.
+const PR_ROW = githubHook({
+  id: 'hook-pr',
+  repoId: '1',
+  name: 'acme/api',
+  repoFullName: 'acme/api',
+  family: 'pull_request',
+  events: ['pull_request:*', 'issue_comment:created']
+})
+const ISSUES_ROW = githubHook({
+  id: 'hook-issues',
+  repoId: '1',
+  name: 'acme/api',
+  repoFullName: 'acme/api',
+  family: 'issues',
+  events: ['issues:*', 'issue_comment:created']
+})
+const WEB_ISSUES_ROW = githubHook({
+  id: 'hook-web',
+  repoId: '2',
+  name: 'acme/web',
+  repoFullName: 'acme/web',
+  family: 'issues',
+  events: ['issues:*', 'issue_comment:created']
+})
+
+const AgentDetailView = (await import('./AgentDetailView')).default
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+async function render(): Promise<HTMLDivElement> {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root!.render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <AgentDetailView />
+      </SWRConfig>
+    )
+  })
+  return host
+}
+
+/** Elements by their tooltip/aria text — the console's own handles on a control. */
+function byTitle(scope: HTMLElement, title: string): HTMLElement[] {
+  return [...scope.querySelectorAll<HTMLElement>(`[title="${title}"]`)]
+}
+
+/** An open flyout's item by label — the menu is body-portaled, so search the document. */
+function menuItem(label: string): HTMLElement | undefined {
+  return [...document.querySelectorAll<HTMLElement>('button.fopt')].find((el) => el.textContent?.trim() === label)
+}
+
+/** The mono spans that name a repository — one per responsive tree, on the block's FIRST row only. */
+function repoNames(scope: HTMLElement, repo: string): HTMLElement[] {
+  return [...scope.querySelectorAll<HTMLElement>('span.mono')].filter((el) => el.textContent === repo)
+}
+
+/** The element sitting immediately before one row's trigger control — where the family marker belongs. */
+function markerBeforeTrigger(scope: HTMLElement, ariaLabel: string): HTMLElement | null {
+  const button = scope.querySelector<HTMLElement>(`[aria-label="${ariaLabel}"]`)
+  const select = button?.closest('span.inline-flex') ?? null
+  return (select?.previousElementSibling as HTMLElement | null) ?? null
+}
+
+/** Every trigger control in list order, named by the row it belongs to. */
+function triggerOrder(scope: HTMLElement): string[] {
+  return [...scope.querySelectorAll<HTMLElement>('[aria-label^="Trigger for "]')].map(
+    (el) => el.getAttribute('aria-label') ?? ''
+  )
+}
+
+beforeEach(() => {
+  mocks.hooks = [ISSUES_ROW, PR_ROW, WEB_ISSUES_ROW]
+  mocks.createGithubHook.mockReset()
+  mocks.createGithubHook.mockResolvedValue({ id: 'hook-new' })
+  mocks.openModal.mockReset()
+})
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+})
+
+describe('AgentDetailView, code-host repository blocks', () => {
+  it('keeps a repository two rows and names it once', async () => {
+    const scope = await render()
+    // Two families ⇒ two rows, and exactly one of them names the repo (once per responsive tree).
+    expect(repoNames(scope, 'acme/api')).toHaveLength(2)
+    expect(repoNames(scope, 'acme/web')).toHaveLength(2)
+    // Repos sorted by name, a repo's rows adjacent, change proposals before issues.
+    expect(triggerOrder(scope)).toEqual([
+      'Trigger for acme/api PRs',
+      'Trigger for acme/api Issues',
+      'Trigger for acme/web Issues'
+    ])
+  })
+
+  it('has no repository header or group-level remove', async () => {
+    const scope = await render()
+    expect(byTitle(scope, 'Remove repository')).toHaveLength(0)
+    // Every row's own X is the only removal — a repo goes away one family at a time.
+    expect(byTitle(scope, 'Stop watching PRs')).toHaveLength(1)
+    expect(byTitle(scope, 'Stop watching Issues')).toHaveLength(2)
+  })
+
+  it('deletes just one family from the per-row control', async () => {
+    const scope = await render()
+    const removeIssues = byTitle(scope, 'Stop watching Issues')[0]!
+    await act(async () => removeIssues.click())
+    expect(mocks.openModal).toHaveBeenCalledWith('deleteHook', expect.objectContaining({ id: 'hook-issues' }))
+  })
+
+  it('states the family as a plain label at the head of the row control cluster', async () => {
+    const scope = await render()
+    for (const [ariaLabel, family] of [
+      ['Trigger for acme/api PRs', 'PRs'],
+      ['Trigger for acme/api Issues', 'Issues']
+    ] as const) {
+      const marker = markerBeforeTrigger(scope, ariaLabel)
+      expect(marker?.textContent).toBe(family)
+      // A label, never a control: no button, no segmented container around it.
+      expect(marker?.tagName).toBe('SPAN')
+      expect(marker?.querySelector('button')).toBeNull()
+      expect(marker?.className).not.toContain('border')
+    }
+  })
+
+  it('offers a + menu only on a repository missing a family, inline on its first row', async () => {
+    const scope = await render()
+    // acme/api watches both offered subjects, so only acme/web carries the + (once per responsive tree).
+    const triggers = byTitle(scope, 'Watch another subject')
+    expect(triggers).toHaveLength(2)
+    for (const trigger of triggers) {
+      expect(trigger.closest('div')!.textContent).toContain('acme/web')
+    }
+    // The menu (body-portaled) lists only what is missing.
+    await act(async () => triggers[0]!.click())
+    expect(menuItem('Add Pull requests')).toBeTruthy()
+    expect(menuItem('Add Issues')).toBeUndefined()
+  })
+
+  it('creates the missing family row at the default trigger', async () => {
+    const scope = await render()
+    await act(async () => byTitle(scope, 'Watch another subject')[0]!.click())
+    await act(async () => menuItem('Add Pull requests')!.click())
+    expect(mocks.createGithubHook).toHaveBeenCalledTimes(1)
+    expect(mocks.createGithubHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'agent-1',
+        repoFullName: 'acme/web',
+        family: 'pull_request',
+        events: ['pull_request:*', 'issue_comment:created'],
+        commentFamilies: ['pull_request'],
+        mentionOnly: false
+      })
+    )
+  })
+
+  it('surfaces a refused create instead of wedging the pane', async () => {
+    mocks.createGithubHook.mockRejectedValue(new Error('No GitHub App installation for acme/web'))
+    const scope = await render()
+    await act(async () => byTitle(scope, 'Watch another subject')[0]!.click())
+    await act(async () => menuItem('Add Pull requests')!.click())
+    expect(scope.textContent).toContain('No GitHub App installation for acme/web')
+    // The + is still there and still clickable — the failure is not terminal.
+    expect(byTitle(scope, 'Watch another subject')).toHaveLength(2)
+  })
+
+  it('keeps the review surface off the issues rows', async () => {
+    const scope = await render()
+    // Desktop folds settings into the row's ⋯ menu; mobile keeps its inline icon (one PR row ⇒ one).
+    expect(byTitle(scope, 'PR review and Checks settings')).toHaveLength(1)
+    const prMore = scope.querySelector<HTMLElement>('[aria-label="More for acme/api PRs"]')!
+    await act(async () => prMore.click())
+    expect(menuItem('Review & Checks settings')).toBeTruthy()
+    await act(async () => prMore.click()) // close before opening the next menu
+    const issuesMore = scope.querySelector<HTMLElement>('[aria-label="More for acme/api Issues"]')!
+    await act(async () => issuesMore.click())
+    expect(menuItem('Review & Checks settings')).toBeUndefined()
+    expect(menuItem('Recent deliveries')).toBeTruthy()
+
+    mocks.hooks = [WEB_ISSUES_ROW]
+    await act(async () => root!.unmount())
+    root = undefined
+    host?.remove()
+    const issuesOnly = await render()
+    expect(byTitle(issuesOnly, 'PR review and Checks settings')).toHaveLength(0)
+  })
+})

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -26,6 +26,8 @@ import {
   type IntegrationRow
 } from '@/lib/data'
 import {
+  createGithubHook,
+  createGitlabHook,
   creatorLabel,
   fetchAgentHooks,
   fetchAgentRepos,
@@ -55,6 +57,7 @@ import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { IntegrationChannelList, roomGlyph, rowLabel } from '@/components/console/IntegrationChannelList'
 import { RecentSessionsCard } from '@/components/console/RecentSessionsCard'
 import { TriggerSelect } from '@/components/console/TriggerSelect'
+import { AnchoredFlyout } from '@/components/ui/AnchoredFlyout'
 import { discordBotInviteUrl } from '@/components/console/platforms/discord/invite'
 import { WorkspaceCard, type WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
 import { WorkspaceFiles, workspaceReadModelKey } from '@/components/console/WorkspaceFiles'
@@ -73,6 +76,7 @@ import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import type { Platform } from '@/components/console/modals/AddIntegrationModal'
 import { INTEGRATION_BLURB, PLATFORMS, isCoreTriggerKind } from '@/components/console/platforms/host-projections'
 import {
+  GL_DEFAULT_TRIGGER_MODE,
   GL_TRIGGER_MODES,
   GL_TRIGGER_PILL,
   gitlabCadencePick,
@@ -88,6 +92,7 @@ import {
   type GlTriggerMode
 } from '@/lib/gitlab-events'
 import { gitlabInstanceHost } from '@/lib/gitlab-projects'
+import { orderedGithubHookRows, orderedGitlabHookRows } from '@/lib/code-host-hook-groups'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
 import { BuiltinBadge } from '@/components/console/BuiltinBadge'
 import { NotFound } from '@/components/console/NotFound'
@@ -97,6 +102,7 @@ import { consoleKeys } from '@/lib/swr-keys'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { useSessionList } from '@/lib/use-session-list'
 import {
+  GH_DEFAULT_TRIGGER_MODE,
   GH_TRIGGER_MODES,
   GH_TRIGGER_PILL,
   githubCommentFamilies,
@@ -238,6 +244,9 @@ export default function AgentDetailView() {
   const webhookHooks = agentHooks.filter((h) => h.kind === 'webhook')
   const githubHooks = agentHooks.filter((h) => h.kind === 'github')
   const gitlabHooks = agentHooks.filter((h) => h.kind === 'gitlab')
+  // One flat row per subscription still — the grouping is only the ORDER (a repo's rows adjacent) plus its add offer.
+  const githubRows = orderedGithubHookRows(githubHooks)
+  const gitlabRows = orderedGitlabHookRows(gitlabHooks)
   const githubInstallationsKey =
     activeOrg && githubHooks.length > 0 ? (['github-review-installations', activeOrg.id] as const) : null
   const { data: githubInstallationsData } = useSWR<GithubInstallationDto[]>(githubInstallationsKey, () =>
@@ -457,6 +466,55 @@ export default function AgentDetailView() {
     if (!fam) return
     if (mode === triggerModeOf(h) && !githubHookNeedsNormalization(h)) return
     await saveHookEvents(h, fam, mode)
+  }
+  // Watch one MORE subject on a watched repo: the family is create-only, so a missing family is a new row, not an edit.
+  const [addFamilyBusy, setAddFamilyBusy] = useState<string | null>(null)
+  const [addFamilyError, setAddFamilyError] = useState<{ key: string; message: string } | null>(null)
+  const addFamilyKey = (repoKey: string, fam: string) => `${repoKey}:${fam}`
+  // `seed` is any row of the repository — the siblings all name the same repo.
+  const addGithubFamily = async (seed: HookDto, repoKey: string, fam: GhFamily) => {
+    if (addFamilyBusy || !seed.agentId || !seed.repoFullName) return
+    setAddFamilyBusy(addFamilyKey(repoKey, fam))
+    setAddFamilyError(null)
+    try {
+      await createGithubHook({
+        agentId: seed.agentId,
+        name: seed.repoFullName,
+        repoFullName: seed.repoFullName,
+        family: fam,
+        ...githubFamilySubscription(fam, GH_DEFAULT_TRIGGER_MODE),
+        reviewPolicy: 'off',
+        reportingMode: 'off',
+        gateMode: 'informational'
+      })
+      await mutateHooks()
+    } catch (error) {
+      setAddFamilyError({ key: repoKey, message: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setAddFamilyBusy(null)
+    }
+  }
+  // The GitLab counterpart — its create keys on the numeric project id.
+  const addGitlabFamily = async (seed: HookDto, repoKey: string, fam: GlFamily) => {
+    if (addFamilyBusy || !seed.agentId || !seed.repoId) return
+    setAddFamilyBusy(addFamilyKey(repoKey, fam))
+    setAddFamilyError(null)
+    try {
+      await createGitlabHook({
+        agentId: seed.agentId,
+        name: seed.repoFullName ?? seed.name,
+        projectId: seed.repoId,
+        family: fam,
+        ...gitlabFamilySubscription(fam, GL_DEFAULT_TRIGGER_MODE),
+        reviewPolicy: 'off',
+        reportingMode: 'off'
+      })
+      await mutateHooks()
+    } catch (error) {
+      setAddFamilyError({ key: repoKey, message: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setAddFamilyBusy(null)
+    }
   }
   // The row's family is a read-only fact now: it labels the row and decides
   // whether the review/Check surface applies to it at all.
@@ -1376,34 +1434,63 @@ export default function AgentDetailView() {
                       </span>
                     </div>
                   ))}
-                  {githubHooks.map((h, i) => (
+                  {/* The desktop blocks in mobile anatomy: the repo's first row names it, its siblings indent under it. */}
+                  {githubRows.map(({ hook: h, repoKey, first, last, addFamilies }, i) => (
                     <div
                       key={h.id}
-                      className={`flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3 ${
-                        agentInts.length + webhookHooks.length + i > 0 ? 'border-t' : ''
+                      className={`${codeHostMobileRowCls(first, last)} ${
+                        first && agentInts.length + webhookHooks.length + i > 0 ? 'border-t' : ''
                       }`}
                     >
-                      <span className="flex h-9 w-9 flex-none items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
-                        <span className="flex h-[18px] w-[18px] items-center justify-center">
-                          <PlatformMark platform="github" fillPct={100} />
-                        </span>
-                      </span>
-                      <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
-                        <span className="flex min-w-0 items-center gap-2">
-                          <span className="mono min-w-0 truncate text-[13px] font-semibold">
-                            {h.repoFullName ?? h.name}
+                      {first && (
+                        <span className="flex h-9 w-9 flex-none items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
+                          <span className="flex h-[18px] w-[18px] items-center justify-center">
+                            <PlatformMark platform="github" fillPct={100} />
                           </span>
-                          {watchUnauthorized(h) && <UnauthorizedWatchBadge />}
                         </span>
-                        <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                          {/* One row = one subject family, so this states which. */}
-                          {ghRowPill(h)}
-                          {` · ${GH_TRIGGER_PILL[triggerModeOf(h)]}`}
+                      )}
+                      <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
+                        {first && (
+                          <span className="flex min-w-0 items-center gap-2">
+                            <span className="mono min-w-0 truncate text-[13px] font-semibold">
+                              {h.repoFullName ?? h.name}
+                            </span>
+                            {/* The repo's first row offers what it does not watch yet — same + menu as desktop. */}
+                            {addFamilies.length > 0 && (
+                              <RowMoreMenu
+                                ariaLabel={`Watch more on ${h.repoFullName ?? h.name}`}
+                                icon="plus"
+                                title="Watch another subject"
+                                triggerClassName={ADD_SUBJECT_BTN}
+                                align="start"
+                                items={addFamilies.map((fam) => ({
+                                  icon: (githubFamilyTile(fam)?.icon ?? 'plus') as Parameters<typeof Icon>[0]['name'],
+                                  label: `Add ${githubFamilyTile(fam)?.label ?? fam}`,
+                                  onClick: () => void addGithubFamily(h, repoKey, fam)
+                                }))}
+                              />
+                            )}
+                            {watchUnauthorized(h) && <UnauthorizedWatchBadge />}
+                          </span>
+                        )}
+                        <span className="flex min-w-0 items-center gap-2">
+                          {/* What this row subscribes to — a label, not a control — then when it runs. */}
+                          <span className="flex-none font-sans text-[12px] font-semibold leading-normal text-(--text-primary)">
+                            {ghRowPill(h)}
+                          </span>
+                          <span className="truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                            {GH_TRIGGER_PILL[triggerModeOf(h)]}
+                          </span>
                         </span>
                         {(h.reviewPolicy !== 'off' || h.reportingMode === 'check') && (
                           <span className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
                             {reviewPolicyLabel(h.reviewPolicy)} review
                             {h.reportingMode === 'check' ? ' · informational Check' : ''}
+                          </span>
+                        )}
+                        {addFamilyError?.key === repoKey && addFamilies.length > 0 && (
+                          <span className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--status-error)">
+                            {addFamilyError.message}
                           </span>
                         )}
                       </span>
@@ -1419,31 +1506,61 @@ export default function AgentDetailView() {
                       )}
                     </div>
                   ))}
-                  {gitlabHooks.map((h, i) => (
+                  {gitlabRows.map(({ hook: h, repoKey, first, last, addFamilies }, i) => (
                     <div
                       key={h.id}
-                      className={`flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3 ${
-                        agentInts.length + webhookHooks.length + githubHooks.length + i > 0 ? 'border-t' : ''
+                      className={`${codeHostMobileRowCls(first, last)} ${
+                        first && agentInts.length + webhookHooks.length + githubRows.length + i > 0 ? 'border-t' : ''
                       }`}
                     >
-                      <span className="flex h-9 w-9 flex-none items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
-                        <span className="flex h-[18px] w-[18px] items-center justify-center">
-                          <PlatformMark platform="gitlab" fillPct={100} />
+                      {first && (
+                        <span className="flex h-9 w-9 flex-none items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
+                          <span className="flex h-[18px] w-[18px] items-center justify-center">
+                            <PlatformMark platform="gitlab" fillPct={100} />
+                          </span>
                         </span>
-                      </span>
+                      )}
                       <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
-                        <span className="mono min-w-0 truncate text-[13px] font-semibold">
-                          {h.repoFullName ?? h.name}
-                        </span>
-                        <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                          {/* One row = one subject family, so this states which. */}
-                          {glRowPill(h)}
-                          {` · ${GL_TRIGGER_PILL[gitlabTriggerModeOf(h)]}`}
+                        {first && (
+                          <span className="flex min-w-0 items-center gap-2">
+                            <span className="mono min-w-0 truncate text-[13px] font-semibold">
+                              {h.repoFullName ?? h.name}
+                            </span>
+                            {/* The project's first row offers what it does not watch yet — same + menu as desktop. */}
+                            {addFamilies.length > 0 && (
+                              <RowMoreMenu
+                                ariaLabel={`Watch more on ${h.repoFullName ?? h.name}`}
+                                icon="plus"
+                                title="Watch another subject"
+                                triggerClassName={ADD_SUBJECT_BTN}
+                                align="start"
+                                items={addFamilies.map((fam) => ({
+                                  icon: (gitlabFamilyTile(fam)?.icon ?? 'plus') as Parameters<typeof Icon>[0]['name'],
+                                  label: `Add ${gitlabFamilyTile(fam)?.label ?? fam}`,
+                                  onClick: () => void addGitlabFamily(h, repoKey, fam)
+                                }))}
+                              />
+                            )}
+                          </span>
+                        )}
+                        <span className="flex min-w-0 items-center gap-2">
+                          {/* What this row subscribes to — a label, not a control — then when it runs. */}
+                          <span className="flex-none font-sans text-[12px] font-semibold leading-normal text-(--text-primary)">
+                            {glRowPill(h)}
+                          </span>
+                          <span className="truncate font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                            {GL_TRIGGER_PILL[gitlabTriggerModeOf(h)]}
+                          </span>
                         </span>
                         {(h.reviewPolicy !== 'off' || h.reportingMode === 'check') && (
                           <span className="truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
                             {reviewPolicyLabel(h.reviewPolicy)} review
                             {h.reportingMode === 'check' ? ' · run note' : ''}
+                          </span>
+                        )}
+                        {addFamilyError?.key === repoKey && addFamilies.length > 0 && (
+                          <span className="font-sans text-[11.5px] font-normal leading-[1.5] text-(--status-error)">
+                            {addFamilyError.message}
                           </span>
                         )}
                       </span>
@@ -1559,9 +1676,7 @@ export default function AgentDetailView() {
                       )}
                     </div>
                   ))}
-                  {/* GitHub group (design): one card, a row per hook — one per
-                        (repo, subject family) — each with its family pill and its
-                        own "when created/updated" cadence select. */}
+                  {/* GitHub group (design): one card, one group per watched repo, a family line per row under it. */}
                   {githubHooks.length > 0 && (
                     <div className="overflow-hidden rounded-[9px] border border-(--border-subtle)">
                       <div className="flex items-center gap-3 px-[14px] py-3">
@@ -1578,7 +1693,6 @@ export default function AgentDetailView() {
                               connected
                             </span>
                           </div>
-                          <div className="mono mt-[3px] text-[11.5px] font-normal text-(--text-tertiary)">GitHub</div>
                         </div>
                         <button
                           className="iconbtn"
@@ -1589,29 +1703,48 @@ export default function AgentDetailView() {
                         </button>
                       </div>
                       <div className="border-t border-(--border-subtle) bg-(--surface-app)">
-                        {githubHooks.map((h) => (
-                          <div key={h.id} className="border-b border-(--border-subtle)">
-                            {/* Design row: wraps (gap 6×8) — the repo name keeps ≥90px and the
-                                  control clusters flow to the next line instead of crushing it. */}
-                            <div className="flex flex-wrap items-center gap-x-2 gap-y-[6px] px-[14px] py-[9px]">
-                              <Icon name="folder-git-2" size={14} color="var(--text-tertiary)" className="flex-none" />
-                              <span className="mono min-w-[90px] flex-1 truncate text-[12px] text-(--text-primary)">
-                                {h.repoFullName ?? h.name}
+                        {githubRows.map(({ hook: h, repoKey, first, last, addFamilies }) => (
+                          <div key={h.id} className={last ? 'border-b border-(--border-subtle)' : undefined}>
+                            {/* One repo = one attached block: its first row names it, its
+                                  siblings indent to that name and only state their family. */}
+                            <div className={codeHostRowCls(first, last)}>
+                              {first ? (
+                                <>
+                                  <Icon
+                                    name="folder-git-2"
+                                    size={14}
+                                    color="var(--text-tertiary)"
+                                    className="flex-none"
+                                  />
+                                  <span className="mono min-w-[90px] max-w-full truncate text-[12px] text-(--text-primary)">
+                                    {h.repoFullName ?? h.name}
+                                  </span>
+                                </>
+                              ) : null}
+                              {/* The repo's first row offers what it does not watch yet — a + menu, so new subjects just add items. */}
+                              {addFamilies.length > 0 && (
+                                <RowMoreMenu
+                                  ariaLabel={`Watch more on ${h.repoFullName ?? h.name}`}
+                                  icon="plus"
+                                  title="Watch another subject"
+                                  triggerClassName={ADD_SUBJECT_BTN}
+                                  align="start"
+                                  items={addFamilies.map((fam) => ({
+                                    icon: (githubFamilyTile(fam)?.icon ?? 'plus') as Parameters<typeof Icon>[0]['name'],
+                                    label: `Add ${githubFamilyTile(fam)?.label ?? fam}`,
+                                    onClick: () => void addGithubFamily(h, repoKey, fam)
+                                  }))}
+                                />
+                              )}
+                              {/* Authorization is repo-scoped, so the badge shows once per group. */}
+                              {first && watchUnauthorized(h) && <UnauthorizedWatchBadge />}
+                              {/* What this row subscribes to, stated at the head of its control cluster — a label, not a control. Fixed width so the trigger column aligns across rows. */}
+                              <span className="ml-auto w-[56px] flex-none whitespace-nowrap text-right font-sans text-[12px] font-semibold leading-normal text-(--text-primary)">
+                                {ghRowPill(h)}
                               </span>
-                              {watchUnauthorized(h) && <UnauthorizedWatchBadge />}
-                              {/* One row = one subject family, and the family is
-                                  immutable — the pill states it, it no longer toggles. */}
-                              <div
-                                className="ml-auto inline-flex flex-none gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) p-[2px]"
-                                title="Add or remove families from Add integration"
-                              >
-                                <span className="rounded-[7px] bg-(--surface-card) px-[9px] py-[3px] font-sans text-[11.5px] font-semibold leading-normal text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]">
-                                  {ghRowPill(h)}
-                                </span>
-                              </div>
                               {/* Trigger — the same ⚡ dropdown the IM channel rows carry, mention last. */}
                               <TriggerSelect
-                                className="flex-none"
+                                className="w-[126px] flex-none"
                                 options={GH_TRIGGER_MODES.map((mode) => ({
                                   value: mode,
                                   label: GH_TRIGGER_PILL[mode],
@@ -1619,37 +1752,45 @@ export default function AgentDetailView() {
                                 }))}
                                 value={triggerModeOf(h)}
                                 onChange={(mode) => void setHookCadence(h, mode)}
-                                ariaLabel={`Trigger for ${h.repoFullName ?? h.name}`}
+                                ariaLabel={`Trigger for ${h.repoFullName ?? h.name} ${ghRowPill(h)}`}
                                 hint="Trigger — when this agent runs"
                                 busy={hookBusy === h.id}
                               />
                               <span className="inline-flex flex-none gap-[2px]">
                                 {/* Reviews and Checks exist on the pull-request row only. */}
-                                {ghRowCarriesReviews(h) && (
-                                  <button
-                                    className="iconbtn h-[26px] w-[26px] flex-none"
-                                    title="PR review and Checks settings"
-                                    onClick={() => openReviewSettings(h)}
-                                  >
-                                    <Icon name="settings-2" size={13} />
-                                  </button>
-                                )}
+                                <RowMoreMenu
+                                  ariaLabel={`More for ${h.repoFullName ?? h.name} ${ghRowPill(h)}`}
+                                  items={[
+                                    ...(ghRowCarriesReviews(h)
+                                      ? [
+                                          {
+                                            icon: 'settings-2' as const,
+                                            label: 'Review & Checks settings',
+                                            onClick: () => openReviewSettings(h)
+                                          }
+                                        ]
+                                      : []),
+                                    {
+                                      icon: 'history' as const,
+                                      label: hookRunsFor === h.id ? 'Hide recent deliveries' : 'Recent deliveries',
+                                      onClick: () => setHookRunsFor(hookRunsFor === h.id ? null : h.id)
+                                    }
+                                  ]}
+                                />
                                 <button
                                   className="iconbtn h-[26px] w-[26px] flex-none"
-                                  title="Recent deliveries"
-                                  onClick={() => setHookRunsFor(hookRunsFor === h.id ? null : h.id)}
-                                >
-                                  <Icon name={hookRunsFor === h.id ? 'chevron-up' : 'history'} size={13} />
-                                </button>
-                                <button
-                                  className="iconbtn h-[26px] w-[26px] flex-none"
-                                  title="Remove repository"
+                                  title={`Stop watching ${ghRowPill(h)}`}
                                   onClick={() => openModal('deleteHook', h)}
                                 >
                                   <Icon name="x" size={13} />
                                 </button>
                               </span>
                             </div>
+                            {addFamilyError?.key === repoKey && addFamilies.length > 0 && (
+                              <div className="px-[14px] pb-[9px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--status-error)">
+                                {addFamilyError.message}
+                              </div>
+                            )}
                             {hookRunsFor === h.id && (
                               <HookRunsPanel hookId={h.id} sessionHref={(sid) => orgPath(`/sessions/${sid}`)} />
                             )}
@@ -1698,13 +1839,39 @@ export default function AgentDetailView() {
                         </div>
                       </div>
                       <div className="border-t border-(--border-subtle) bg-(--surface-app)">
-                        {gitlabHooks.map((h) => (
-                          <div key={h.id} className="border-b border-(--border-subtle)">
-                            <div className="flex flex-wrap items-center gap-x-2 gap-y-[6px] px-[14px] py-[9px]">
-                              <Icon name="folder-git-2" size={14} color="var(--text-tertiary)" className="flex-none" />
-                              <span className="mono min-w-[90px] flex-1 truncate text-[12px] text-(--text-primary)">
-                                {h.repoFullName ?? h.name}
-                              </span>
+                        {gitlabRows.map(({ hook: h, repoKey, first, last, addFamilies }) => (
+                          <div key={h.id} className={last ? 'border-b border-(--border-subtle)' : undefined}>
+                            {/* One project = one attached block: its first row names it, its
+                                  siblings indent to that name and only state their family. */}
+                            <div className={codeHostRowCls(first, last)}>
+                              {first ? (
+                                <>
+                                  <Icon
+                                    name="folder-git-2"
+                                    size={14}
+                                    color="var(--text-tertiary)"
+                                    className="flex-none"
+                                  />
+                                  <span className="mono min-w-[90px] max-w-full truncate text-[12px] text-(--text-primary)">
+                                    {h.repoFullName ?? h.name}
+                                  </span>
+                                </>
+                              ) : null}
+                              {/* The project's first row offers what it does not watch yet — a + menu, so new subjects just add items. */}
+                              {addFamilies.length > 0 && (
+                                <RowMoreMenu
+                                  ariaLabel={`Watch more on ${h.repoFullName ?? h.name}`}
+                                  icon="plus"
+                                  title="Watch another subject"
+                                  triggerClassName={ADD_SUBJECT_BTN}
+                                  align="start"
+                                  items={addFamilies.map((fam) => ({
+                                    icon: (gitlabFamilyTile(fam)?.icon ?? 'plus') as Parameters<typeof Icon>[0]['name'],
+                                    label: `Add ${gitlabFamilyTile(fam)?.label ?? fam}`,
+                                    onClick: () => void addGitlabFamily(h, repoKey, fam)
+                                  }))}
+                                />
+                              )}
                               {gitlabHookNeedsNormalization(h) && (
                                 <span
                                   className="badge flex-none bg-(--surface-active) text-(--text-tertiary)"
@@ -1713,19 +1880,13 @@ export default function AgentDetailView() {
                                   custom rule
                                 </span>
                               )}
-                              {/* One row = one subject family, and the family is
-                                  immutable — the pill states it, it no longer toggles. */}
-                              <div
-                                className="ml-auto inline-flex flex-none gap-[2px] rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) p-[2px]"
-                                title="Add or remove families from Add integration"
-                              >
-                                <span className="rounded-[7px] bg-(--surface-card) px-[9px] py-[3px] font-sans text-[11.5px] font-semibold leading-normal text-(--text-primary) shadow-[0_1px_2px_rgba(0,0,0,0.08)]">
-                                  {glRowPill(h)}
-                                </span>
-                              </div>
+                              {/* What this row subscribes to, stated at the head of its control cluster — a label, not a control. Fixed width so the trigger column aligns across rows. */}
+                              <span className="ml-auto w-[56px] flex-none whitespace-nowrap text-right font-sans text-[12px] font-semibold leading-normal text-(--text-primary)">
+                                {glRowPill(h)}
+                              </span>
                               {/* Trigger — the same ⚡ dropdown the GitHub rows carry. */}
                               <TriggerSelect
-                                className="flex-none"
+                                className="w-[126px] flex-none"
                                 options={GL_TRIGGER_MODES.map((mode) => ({
                                   value: mode,
                                   label: GL_TRIGGER_PILL[mode],
@@ -1733,37 +1894,45 @@ export default function AgentDetailView() {
                                 }))}
                                 value={gitlabTriggerModeOf(h)}
                                 onChange={(mode) => void setGitlabHookCadence(h, mode)}
-                                ariaLabel={`Trigger for ${h.repoFullName ?? h.name}`}
+                                ariaLabel={`Trigger for ${h.repoFullName ?? h.name} ${glRowPill(h)}`}
                                 hint="Trigger — when this agent runs"
                                 busy={hookBusy === h.id}
                               />
                               <span className="inline-flex flex-none gap-[2px]">
                                 {/* Reviews and the run note exist on the merge-request row only. */}
-                                {glRowCarriesReviews(h) && (
-                                  <button
-                                    className="iconbtn h-[26px] w-[26px] flex-none"
-                                    title="MR review and run note settings"
-                                    onClick={() => openReviewSettings(h)}
-                                  >
-                                    <Icon name="settings-2" size={13} />
-                                  </button>
-                                )}
+                                <RowMoreMenu
+                                  ariaLabel={`More for ${h.repoFullName ?? h.name} ${glRowPill(h)}`}
+                                  items={[
+                                    ...(glRowCarriesReviews(h)
+                                      ? [
+                                          {
+                                            icon: 'settings-2' as const,
+                                            label: 'Review & run note settings',
+                                            onClick: () => openReviewSettings(h)
+                                          }
+                                        ]
+                                      : []),
+                                    {
+                                      icon: 'history' as const,
+                                      label: hookRunsFor === h.id ? 'Hide recent deliveries' : 'Recent deliveries',
+                                      onClick: () => setHookRunsFor(hookRunsFor === h.id ? null : h.id)
+                                    }
+                                  ]}
+                                />
                                 <button
                                   className="iconbtn h-[26px] w-[26px] flex-none"
-                                  title="Recent deliveries"
-                                  onClick={() => setHookRunsFor(hookRunsFor === h.id ? null : h.id)}
-                                >
-                                  <Icon name={hookRunsFor === h.id ? 'chevron-up' : 'history'} size={13} />
-                                </button>
-                                <button
-                                  className="iconbtn h-[26px] w-[26px] flex-none"
-                                  title="Remove project"
+                                  title={`Stop watching ${glRowPill(h)}`}
                                   onClick={() => openModal('deleteHook', h)}
                                 >
                                   <Icon name="x" size={13} />
                                 </button>
                               </span>
                             </div>
+                            {addFamilyError?.key === repoKey && addFamilies.length > 0 && (
+                              <div className="px-[14px] pb-[9px] font-sans text-[11.5px] font-normal leading-[1.5] text-(--status-error)">
+                                {addFamilyError.message}
+                              </div>
+                            )}
                             {hookRunsFor === h.id && (
                               <HookRunsPanel hookId={h.id} sessionHref={(sid) => orgPath(`/sessions/${sid}`)} />
                             )}
@@ -2181,6 +2350,84 @@ function UnauthorizedWatchBadge() {
       write-back unauthorized
     </span>
   )
+}
+
+// The add-subject trigger keeps the retired dashed chip's look — transparent ground, tint on hover only.
+const ADD_SUBJECT_BTN =
+  'inline-flex h-[26px] w-[26px] flex-none items-center justify-center rounded-[7px] border border-dashed border-(--border-subtle) bg-transparent text-(--text-tertiary) transition-colors hover:border-(--border-strong) hover:bg-(--surface-hover) hover:text-(--text-secondary)'
+
+// A one-button flyout for row controls: ⋯ folds the secondary actions, + offers the subjects a repo could still watch.
+function RowMoreMenu({
+  ariaLabel,
+  items,
+  icon = 'ellipsis',
+  title = 'More',
+  align = 'end',
+  triggerClassName = 'iconbtn h-[26px] w-[26px] flex-none'
+}: {
+  ariaLabel: string
+  items: { icon: Parameters<typeof Icon>[0]['name']; label: string; onClick: () => void }[]
+  icon?: Parameters<typeof Icon>[0]['name']
+  title?: string
+  align?: 'start' | 'end'
+  triggerClassName?: string
+}) {
+  return (
+    <AnchoredFlyout
+      ariaLabel={ariaLabel}
+      align={align}
+      width={210}
+      estimatedHeight={10 + items.length * 34}
+      triggerClassName="flex"
+      trigger={({ open, menuId, toggle }) => (
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-controls={open ? menuId : undefined}
+          title={title}
+          onClick={toggle}
+          className={triggerClassName}
+        >
+          <Icon name={icon} size={13} />
+        </button>
+      )}
+    >
+      {({ close }) => (
+        <>
+          {items.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              role="menuitem"
+              className="fopt"
+              onClick={() => {
+                close(true)
+                item.onClick()
+              }}
+            >
+              <Icon name={item.icon} size={14} className="flex-none" />
+              <span className="min-w-0 flex-1 truncate">{item.label}</span>
+            </button>
+          ))}
+        </>
+      )}
+    </AnchoredFlyout>
+  )
+}
+
+// A repo's rows read as one block: the opener carries the name, the siblings indent to it and the pair breathes as one.
+// No wrapping: the right cluster is fixed-width columns, so the truncating repo name absorbs the squeeze instead.
+function codeHostRowCls(first: boolean, last: boolean): string {
+  const base = 'flex flex-nowrap items-center gap-x-2 px-[14px]'
+  return `${base} ${first ? 'pt-[9px]' : 'pt-[3px]'} ${last ? 'pb-[9px]' : 'pb-[3px]'} ${first ? '' : 'pl-[36px]'}`
+}
+
+// The same block on mobile, where the platform mark — not a folder icon — sets the sibling rows' indent.
+function codeHostMobileRowCls(first: boolean, last: boolean): string {
+  const base = 'flex items-center gap-3 border-(--border-subtle) px-4'
+  return `${base} ${first ? 'pt-3' : 'pt-1'} ${last ? 'border-b pb-3' : 'pb-1'} ${first ? '' : 'pl-16'}`
 }
 
 // "3m ago" for a hook's last-fired stamp and its delivery rows.

--- a/packages/web/src/lib/code-host-hook-groups.test.ts
+++ b/packages/web/src/lib/code-host-hook-groups.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { orderedGithubHookRows, orderedGitlabHookRows } from './code-host-hook-groups'
+import type { HookDto } from './api'
+
+function hook(partial: Partial<HookDto> & Pick<HookDto, 'id'>): HookDto {
+  return {
+    agentId: 'agent-1',
+    kind: 'github',
+    name: partial.repoFullName ?? 'owner/repo',
+    sessionMode: 'perThread',
+    enabled: true,
+    url: null,
+    hmacConfigured: false,
+    repoId: null,
+    repoFullName: 'owner/repo',
+    family: null,
+    events: [],
+    commentFamilies: [],
+    labelFilter: [],
+    mentionOnly: false,
+    configRevision: '1',
+    reviewPolicy: 'off',
+    reportingMode: 'off',
+    gateMode: 'informational',
+    lastFiredAt: null,
+    createdBy: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...partial
+  } as HookDto
+}
+
+describe('orderedGithubHookRows', () => {
+  it('keeps a repository as two rows, change proposals first', () => {
+    const rows = orderedGithubHookRows([
+      hook({ id: 'a', repoId: '1', repoFullName: 'acme/api', family: 'issues', events: ['issues:*'] }),
+      hook({ id: 'b', repoId: '1', repoFullName: 'acme/api', family: 'pull_request', events: ['pull_request:*'] })
+    ])
+    expect(rows.map((row) => row.hook.id)).toEqual(['b', 'a'])
+    expect(rows.map((row) => row.family)).toEqual(['pull_request', 'issues'])
+    expect(rows.every((row) => row.repoKey === '1')).toBe(true)
+    // The block's edges: the opener names the repo, the closer carries the divider.
+    expect(rows.map((row) => [row.first, row.last])).toEqual([
+      [true, false],
+      [false, true]
+    ])
+    // Nothing left to add, so no row offers a chip.
+    expect(rows.flatMap((row) => row.addFamilies)).toEqual([])
+  })
+
+  it('offers a missing family on the repository first row only', () => {
+    const rows = orderedGithubHookRows([
+      hook({ id: 'a', repoId: '1', repoFullName: 'acme/api', family: 'issues', events: ['issues:*'] })
+    ])
+    expect(rows[0]!.addFamilies).toEqual(['pull_request'])
+    // A one-row block opens and closes on the same row.
+    expect([rows[0]!.first, rows[0]!.last]).toEqual([true, true])
+  })
+
+  it('never offers the held-back push subject', () => {
+    const rows = orderedGithubHookRows([
+      hook({ id: 'a', repoId: '1', repoFullName: 'acme/api', family: 'pull_request', events: ['pull_request:*'] }),
+      hook({ id: 'b', repoId: '1', repoFullName: 'acme/api', family: 'issues', events: ['issues:*'] })
+    ])
+    expect(rows.flatMap((row) => row.addFamilies)).toEqual([])
+  })
+
+  it('keeps a repository adjacent and sorts repositories by name', () => {
+    const rows = orderedGithubHookRows([
+      hook({ id: 'w1', repoId: '2', repoFullName: 'acme/web', family: 'issues', events: ['issues:*'] }),
+      hook({ id: 'a1', repoId: '1', repoFullName: 'acme/api', family: 'issues', events: ['issues:*'] }),
+      hook({ id: 'a2', repoId: '1', repoFullName: 'acme/api', family: 'pull_request', events: ['pull_request:*'] })
+    ])
+    expect(rows.map((row) => row.hook.id)).toEqual(['a2', 'a1', 'w1'])
+  })
+
+  it('derives a legacy row family from its events and sorts an unplaceable one last', () => {
+    const rows = orderedGithubHookRows([
+      hook({ id: 'a', repoId: '1', repoFullName: 'acme/api', family: null, events: ['issue_comment:created'] }),
+      hook({ id: 'b', repoId: '1', repoFullName: 'acme/api', family: null, events: ['pull_request:*'] })
+    ])
+    expect(rows.map((row) => row.family)).toEqual(['pull_request', null])
+    // The unplaceable row covers nothing, so issues is still on offer — on the first row.
+    expect(rows[0]!.addFamilies).toEqual(['issues'])
+    expect(rows[1]!.addFamilies).toEqual([])
+  })
+
+  it('keys a repository with no numeric id by its name', () => {
+    const rows = orderedGithubHookRows([
+      hook({ id: 'a', repoFullName: 'acme/api', family: 'issues', events: ['issues:*'] }),
+      hook({ id: 'b', repoFullName: 'acme/api', family: 'pull_request', events: ['pull_request:*'] })
+    ])
+    expect(rows.map((row) => row.repoKey)).toEqual(['acme/api', 'acme/api'])
+    expect(rows.flatMap((row) => row.addFamilies)).toEqual([])
+  })
+})
+
+describe('orderedGitlabHookRows', () => {
+  it('leads with merge requests and offers the missing subject', () => {
+    const rows = orderedGitlabHookRows([
+      hook({ id: 'a', kind: 'gitlab', repoId: '7', repoFullName: 'group/proj', family: 'issues', events: ['issues:*'] })
+    ])
+    expect(rows[0]!.addFamilies).toEqual(['merge_request'])
+    const both = orderedGitlabHookRows([
+      hook({
+        id: 'a',
+        kind: 'gitlab',
+        repoId: '7',
+        repoFullName: 'group/proj',
+        family: 'issues',
+        events: ['issues:*']
+      }),
+      hook({
+        id: 'b',
+        kind: 'gitlab',
+        repoId: '7',
+        repoFullName: 'group/proj',
+        family: 'merge_request',
+        events: ['merge_request:*']
+      })
+    ])
+    expect(both.map((row) => row.family)).toEqual(['merge_request', 'issues'])
+    expect(both.flatMap((row) => row.addFamilies)).toEqual([])
+  })
+})

--- a/packages/web/src/lib/code-host-hook-groups.ts
+++ b/packages/web/src/lib/code-host-hook-groups.ts
@@ -1,0 +1,86 @@
+/**
+ * A code-host row is `(agent, repo, family)`, so one watched repository is one
+ * row per subject family and never a row of its own. This orders those rows
+ * into per-repository blocks — a repository's rows adjacent, change proposals
+ * before issues — and marks the block's edges: the FIRST row carries the repo
+ * name and the "+ Issues" offer for what the repo does not watch yet, the LAST
+ * row carries the divider that separates one repository from the next.
+ */
+
+import type { HookDto } from './api'
+import { GH_FAMILIES, githubHookFamily, type GhFamily } from './github-events'
+import { GL_FAMILIES, gitlabHookFamily, type GlFamily } from './gitlab-events'
+
+// Sibling order for one repo: the change-proposal subject (it carries reviews), then issues, then the held-back push.
+const GH_ROW_ORDER: readonly GhFamily[] = ['pull_request', 'issues', 'push']
+const GL_ROW_ORDER: readonly GlFamily[] = ['merge_request', 'issues', 'push']
+
+/** One listed subscription: its row, the family it covers (null on a legacy-inert row), and its place in the block. */
+export interface CodeHostHookRow<F extends string> {
+  hook: HookDto
+  family: F | null
+  /** Stable per-repository identity — the numeric repo id when the rows carry one. Keys the row's add-family state. */
+  repoKey: string
+  /** This row opens its repository's block: it names the repo and carries the add-family offer. */
+  first: boolean
+  /** This row closes its repository's block: it carries the divider to the next repository. */
+  last: boolean
+  /** Families this repository does not watch yet — carried by its FIRST row only, so the chip is offered once. */
+  addFamilies: F[]
+}
+
+function hookLabel(hook: HookDto): string {
+  return hook.repoFullName ?? hook.name
+}
+
+function orderRows<F extends string>(
+  hooks: readonly HookDto[],
+  familyOf: (hook: HookDto) => F | null,
+  order: readonly F[],
+  offered: readonly F[]
+): CodeHostHookRow<F>[] {
+  const byRepo = new Map<string, { label: string; rows: { hook: HookDto; family: F | null }[] }>()
+  for (const hook of hooks) {
+    const key = hook.repoId ?? hookLabel(hook)
+    const group = byRepo.get(key)
+    if (group) group.rows.push({ hook, family: familyOf(hook) })
+    else byRepo.set(key, { label: hookLabel(hook), rows: [{ hook, family: familyOf(hook) }] })
+  }
+  // An unplaceable row sorts last rather than jumping ahead of the real subjects.
+  const rank = (family: F | null) => (family === null ? order.length : order.indexOf(family))
+  return [...byRepo.entries()]
+    .sort(([, a], [, b]) => a.label.localeCompare(b.label))
+    .flatMap(([repoKey, group]) => {
+      const ordered = [...group.rows].sort((a, b) => rank(a.family) - rank(b.family))
+      const present = new Set(ordered.map((row) => row.family))
+      const missing = offered.filter((family) => !present.has(family))
+      return ordered.map((row, index) => ({
+        ...row,
+        repoKey,
+        first: index === 0,
+        last: index === ordered.length - 1,
+        addFamilies: index === 0 ? missing : []
+      }))
+    })
+}
+
+/** The agent's github rows in list order, each carrying its repo's add-family offer. */
+export function orderedGithubHookRows(hooks: readonly HookDto[]): CodeHostHookRow<GhFamily>[] {
+  return orderRows(
+    hooks,
+    githubHookFamily,
+    GH_ROW_ORDER,
+    // Offered in this file's sibling order, so a chip reads where its row would sit.
+    GH_ROW_ORDER.filter((family) => GH_FAMILIES.some((tile) => tile.fam === family))
+  )
+}
+
+/** The agent's gitlab rows in list order, each carrying its project's add-family offer. */
+export function orderedGitlabHookRows(hooks: readonly HookDto[]): CodeHostHookRow<GlFamily>[] {
+  return orderRows(
+    hooks,
+    gitlabHookFamily,
+    GL_ROW_ORDER,
+    GL_ROW_ORDER.filter((family) => GL_FAMILIES.some((tile) => tile.fam === family))
+  )
+}


### PR DESCRIPTION
The console follow-up to #1544: the code-host panes now present the per-family rows the way the model reads.

## What changed

- **Adjacent per-family rows, named once.** A repository's rows sort together (change proposals first, then issues, then push); only the first row carries the folder icon and repo name. No repository header row and no group-level remove — removing a repository is removing each of its family rows.
- **The family is a prominent plain label** at the head of the row's control cluster, right before the trigger dropdown — a label, not a toggle. Label, dropdown, and trailing buttons hold fixed widths so the columns align across rows; the truncating repo name absorbs the squeeze instead of wrapping.
- **Row actions fold into a ⋯ menu** (review/Checks settings on change-proposal rows only, recent deliveries), so every row ends in the same [⋯][X]. The per-row X deletes one family and the confirm dialog names it; the delete modal also now words a single-repository multi-row target as the repo-scoped removal, and no longer assumes an array target is GitHub.
- **Adding a family is a + menu** on the repository's first row — dashed, transparent, offering only the families the repo does not watch yet, creating at the default trigger with the single-family body (`family`, events, comment scope). A refused create surfaces inline and never wedges the pane. A menu rather than per-family chips, so future subjects (releases, …) only add items.
- The write-authorization badge shows once per repository, and the GitHub card header drops its redundant "GitHub" subtitle (the mark and account name already say it). Both the desktop and mobile trees carry the same structure.

## Tests

New `code-host-hook-groups` grouping unit tests, reworked `AgentDetailView.codehost` cases (adjacency and single naming, plain-label family marker, + menu offer/create/error paths, review surface gated to change-proposal rows through the ⋯ menu), and DeleteHookModal wording cases. Web suite 186 files / 2088 passed; `pnpm typecheck`, `lint`, `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
