### PR TITLE
fix(daemon): dispatch sandbox provider from cluster shim

### DIFF
--- a/packages/daemon/scripts/assert-self-contained.mjs
+++ b/packages/daemon/scripts/assert-self-contained.mjs
@@ -10,7 +10,10 @@
 // after tsdown in the daemon's `build` script; it ships nowhere (files: ["dist"]).
 import { existsSync, readFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
+import { builtinModules } from 'node:module'
 import { fileURLToPath } from 'node:url'
+
+const nodeBuiltins = new Set(builtinModules.flatMap((spec) => [spec, `node:${spec}`]))
 
 const bundlePath = new URL('../dist/index.js', import.meta.url)
 const bundle = readFileSync(bundlePath, 'utf8')
@@ -86,10 +89,10 @@ for (const entry of ['index.js', 'git-credential.js', 'gh-token.js']) {
     ...shim.matchAll(/\bfrom\s*["']([^"']+)["']/g),
     ...shim.matchAll(/\bimport\(\s*["']([^"']+)["']\s*\)/g)
   ].map((match) => match[1])
-  const shimLeaked = shimSpecs.filter((spec) => !spec.startsWith('node:'))
+  const shimLeaked = shimSpecs.filter((spec) => !nodeBuiltins.has(spec))
   if (shimLeaked.length > 0) {
     console.error(
-      `✗ shim bundle ${entry} is not self-contained — it imports outside node: builtins:\n` +
+      `✗ shim bundle ${entry} is not self-contained — it imports outside Node builtins:\n` +
         [...new Set(shimLeaked)]
           .sort()
           .map((s) => `    ${s}`)
@@ -98,6 +101,20 @@ for (const entry of ['index.js', 'git-credential.js', 'gh-token.js']) {
     )
     process.exit(1)
   }
+}
+
+const shimEntry = new URL('../dist/shim/index.js', import.meta.url)
+const shimOfflineProvider = spawnSync(process.execPath, [fileURLToPath(shimEntry), '__sandbox-runtime-offline'], {
+  encoding: 'utf8',
+  timeout: 10_000,
+  env: { PATH: process.env.PATH ?? '' }
+})
+if (
+  shimOfflineProvider.status !== 2 ||
+  !shimOfflineProvider.stderr.includes('expected <settings> <owner-pid> <cwd> -- <command> [args...]')
+) {
+  console.error('✗ shim bundle does not dispatch its confined offline-sandbox provider entry')
+  process.exit(1)
 }
 
 const shimSkillsCli = new URL('../dist/shim/skills/dist/cli.js', import.meta.url)
@@ -124,4 +141,4 @@ if (!readFileSync(ghWrapper, 'utf8').includes('/opt/agentconnect/shim/gh-token.j
 }
 
 console.log('✓ daemon bundle is self-contained (including skills CLI 1.5.21 and SRT seccomp helpers)')
-console.log('✓ shim bundles are self-contained (channel + credential helper + gh token, node: builtins only)')
+console.log('✓ shim bundles are self-contained (channel + credential helper + gh token, Node builtins only)')

--- a/packages/daemon/src/shim/index.ts
+++ b/packages/daemon/src/shim/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /** The in-sandbox shim executable. Lives at a fixed path in the runtime image
  *  (`/opt/agentconnect/shim`), root-owned and read-only, with tini as PID 1. */
+import { runSandboxRuntimeProvider } from '../acp/sandbox-runtime-provider.js'
 import { ShimClient } from './client.js'
 import { createAutoMergeHandler } from './auto-merge-handler.js'
 import { createExecHandler } from './exec-handler.js'
@@ -13,6 +14,14 @@ import {
 } from './protocol.js'
 import { ShimServer } from './server.js'
 import { TunnelHost } from './tunnel-host.js'
+
+if (process.argv[2] === '__sandbox-runtime' || process.argv[2] === '__sandbox-runtime-offline') {
+  process.exit(
+    await runSandboxRuntimeProvider(process.argv.slice(3), {
+      offline: process.argv[2] === '__sandbox-runtime-offline'
+    })
+  )
+}
 
 const log = {
   info: (message: string) => console.error(`[shim] ${message}`),

--- a/scripts/verify-runtime-image.mjs
+++ b/scripts/verify-runtime-image.mjs
@@ -14,6 +14,7 @@
  * its own manifests, but wrong about what runs, still fails.
  */
 import { execFileSync } from 'node:child_process'
+import { builtinModules } from 'node:module'
 
 import { diffRuntimeTables } from './runtime-table-diff.mjs'
 
@@ -26,6 +27,7 @@ if (!image) {
 const failures = []
 const notes = []
 const warnings = []
+const nodeBuiltins = new Set(builtinModules.flatMap((spec) => [spec, `node:${spec}`]))
 
 function check(name, fn) {
   try {
@@ -182,8 +184,7 @@ check('the MCP bridge starts and fails loudly with no daemon socket', () => {
   return 'exits 1 with an actionable message'
 })
 
-// The bundles are built with everything inlined so this image installs no node_modules for them. A
-// require of anything but a node: builtin means a bundle is depending on a tree that is absent.
+// The bundles are built with everything inlined, so only Node builtins may remain as imports.
 check('the shim bundles are self-contained', () => {
   // Same specifier shapes the daemon package's own assert-self-contained step looks for, run
   // against the artifacts that actually shipped. The local build being clean says nothing about
@@ -191,14 +192,15 @@ check('the shim bundles are self-contained', () => {
   // deps, and produced a bundle that imported them externally — which the image cannot resolve.
   const external = []
   for (const path of [SHIM_PATH, MCP_BRIDGE_PATH]) {
-    const specs = inImage(
-      `grep -oE '\\b(from|import)[[:space:]]*\\(?[[:space:]]*"[^"]+"' ${path} | ` +
-        `grep -oE '"[^"]+"' | tr -d '"' | sort -u | grep -v '^node:' || true`
+    const bundle = inImage(`cat ${path}`)
+    const specs = [...bundle.matchAll(/\bfrom\s*"([^"]+)"/g), ...bundle.matchAll(/\bimport\(\s*"([^"]+)"\s*\)/g)].map(
+      (match) => match[1]
     )
-    if (specs) external.push(`${path}: ${specs.split('\n').join(', ')}`)
+    const leaked = [...new Set(specs.filter((spec) => !nodeBuiltins.has(spec)))].sort()
+    if (leaked.length > 0) external.push(`${path}: ${leaked.join(', ')}`)
   }
   if (external.length > 0) throw new Error(`bundles reference non-builtin modules — ${external.join('; ')}`)
-  return 'node: builtins only'
+  return 'Node builtins only'
 })
 
 // The pod template owns identity projection. An image carrying its own token would be an


### PR DESCRIPTION
## Summary

Fix cluster runtime skill installation for Codex-backed sandbox pods.

The runtime shim was re-executed with the hidden `__sandbox-runtime-offline` command during confined workspace mutation, but the shim entry ignored that command and started a second shim server. The mutation failed, and rollback failed through the same path, producing:

- `confined skill workspace mutation was refused`
- `skill installation failed and the prior executable set could not be restored`

## Changes

- Dispatch hidden sandbox-runtime provider commands from the in-sandbox shim entry.
- Add a build-time regression check against the emitted shim bundle.
- Keep the self-contained bundle check strict while recognizing Node builtins with or without the `node:` prefix.

## Verification

- [x] `pnpm --filter @agentconnect.md/daemon build`
- [x] `pnpm --filter @agentconnect.md/daemon typecheck`
- [x] Relevant daemon tests: 28 passed, 12 Linux-only tests skipped on macOS
- [x] ESLint and Prettier checks for changed files
- [x] Pre-push repository lint gate
