### PR TITLE
feat(daemon): admit DeepSeek Harness for skill installation

### DIFF
--- a/packages/daemon/src/runtimes/curated.ts
+++ b/packages/daemon/src/runtimes/curated.ts
@@ -56,8 +56,15 @@ export const CURATED_RUNTIME_CATALOG: Readonly<Record<string, CuratedRuntimeEntr
   // bundles the harness itself and only reuses $DSH_HOME credentials — so it is
   // fetched on demand rather than installed into the operator's dsh profile.
   // `-p` is required: the package's single bin (`dsh-acp`) is not its name.
+  // Its skill provider scans `<projectRoot>/.agents/skills`, which is exactly what the CLI's
+  // `universal` identity writes; `dsh` is not a CLI agent id.
   'dsh-acp': {
     name: 'DeepSeek Harness',
-    runtime: { command: 'npx', args: ['-y', '-p', '@openma/deepseek-harness-acp@^0.4', 'dsh-acp'], env: [] }
+    runtime: {
+      command: 'npx',
+      args: ['-y', '-p', '@openma/deepseek-harness-acp@^0.4', 'dsh-acp'],
+      env: [],
+      skillsAgentId: 'universal'
+    }
   }
 })

--- a/packages/daemon/src/runtimes/skills-capability.ts
+++ b/packages/daemon/src/runtimes/skills-capability.ts
@@ -44,6 +44,9 @@ export const AUDITED_RUNTIME_SKILLS_AGENTS: Readonly<Record<string, string>> = O
   // Curated/legacy ids whose RuntimeDef also carries the declaration.
   hermes: 'hermes-agent',
   'hermes-agent': 'hermes-agent',
+  // DeepSeek Harness has no CLI agent id of its own; its filesystem skill provider scans the
+  // cross-agent `<projectRoot>/.agents/skills` root the CLI's `universal` identity writes.
+  'dsh-acp': 'universal',
   'kiro-cli': 'kiro-cli',
   'qoder-cli': 'qoder',
   'qoder-cli-cn': 'qoder-cn'

--- a/packages/daemon/test/registry.test.ts
+++ b/packages/daemon/test/registry.test.ts
@@ -275,7 +275,12 @@ describe('curated native ACP runtimes', () => {
       },
       'dsh-acp': {
         name: 'DeepSeek Harness',
-        runtime: { command: 'npx', args: ['-y', '-p', '@openma/deepseek-harness-acp@^0.4', 'dsh-acp'], env: [] }
+        runtime: {
+          command: 'npx',
+          args: ['-y', '-p', '@openma/deepseek-harness-acp@^0.4', 'dsh-acp'],
+          env: [],
+          skillsAgentId: 'universal'
+        }
       }
     })
   })

--- a/packages/daemon/test/skills-cli-golden.test.ts
+++ b/packages/daemon/test/skills-cli-golden.test.ts
@@ -38,7 +38,9 @@ const hasBwrap = detectSandbox() === 'bwrap'
 describe.skipIf(!hasBwrap)('skills@1.5.21 local-source golden', () => {
   it.each([
     ['claude-code', '.claude/skills/local-golden'],
-    ['codex', '.agents/skills/local-golden']
+    ['codex', '.agents/skills/local-golden'],
+    // dsh-acp's identity: the DeepSeek Harness scans `<projectRoot>/.agents/skills`.
+    ['universal', '.agents/skills/local-golden']
   ])('uses the exact installed CLI for %s and derives %s', async (agentId, expectedPath) => {
     const { root, source } = await fixture()
     const result = await stageSkillsCliCell({

--- a/packages/daemon/test/skills.test.ts
+++ b/packages/daemon/test/skills.test.ts
@@ -10,6 +10,7 @@ describe('skillsAgentIdForRuntime', () => {
     expect(skillsAgentIdForRuntime('codex-acp')).toBe('codex')
     expect(skillsAgentIdForRuntime('factory-droid')).toBe('droid')
     expect(skillsAgentIdForRuntime('qoder-cli-cn')).toBe('qoder-cn')
+    expect(skillsAgentIdForRuntime('dsh-acp')).toBe('universal')
     expect(skillsAgentIdForRuntime('qwen-code')).toBe('qwen-code')
     expect(skillsAgentIdForRuntime('some-exotic-agent')).toBeUndefined()
   })

--- a/packages/daemon/test/unified-skills.test.ts
+++ b/packages/daemon/test/unified-skills.test.ts
@@ -127,6 +127,21 @@ describe.skipIf(!hasBwrap)('unified isolated skill installation', () => {
     expect(await readFile(join(cwd, '.claude/skills/audit/SKILL.md'), 'utf8')).toContain('# audit')
   })
 
+  // The real CLI decides the destination: dsh-acp's `universal` identity must land in the
+  // `<projectRoot>/.agents/skills` root the DeepSeek Harness skill provider scans.
+  it('publishes a DeepSeek Harness skill through the real CLI into .agents/skills', async () => {
+    const sourceDir = await writeSkill(sources, 'dsh-golden', 'dsh-golden')
+
+    const result = await installSkills({ id: 'a1', runtime: 'dsh-acp', skills: [] }, cwd, {
+      stateDir,
+      localSkills: [{ kind: 'dream', key: 'dream:dsh-golden', name: 'dsh-golden', sourceDir }]
+    })
+
+    expect(result.errors).toEqual([])
+    expect(result.installed).toEqual(['.agents/skills/dsh-golden'])
+    expect(await readFile(join(cwd, '.agents/skills/dsh-golden/SKILL.md'), 'utf8')).toContain('# dsh-golden')
+  }, 120_000)
+
   it('keeps an aliased skill root owned across a harness switch', async () => {
     const sourceDir = await writeSkill(sources, 'aliased', 'v1')
     const localSkills: LocalSkillSource[] = [{ kind: 'dream', key: 'dream:aliased', name: 'aliased', sourceDir }]


### PR DESCRIPTION
## Problem

`dsh-acp` carried no `skillsAgentId`, so it had **no skill support at all**: `installSkills` logged `runtime "dsh-acp" has not passed skills CLI compatibility admission` and installed nothing, and the cluster path failed closed with `cluster runtime lacks skill installation support` as soon as an agent had any source bound.

## The harness does load skills

`@openma/deepseek-harness-acp` disables `skill-filesystem` / `tool-skill` on the host plane only because those rows moved into each agent preset; the bundle pins `agent-presets: default: standard`, and `standard` (like `code` and `cordis`) mounts both. Its provider's discovery roots:

| rank | source | path |
|---|---|---|
| 100 | project-dsh | `<projectRoot>/.dsh/skills` |
| 200 | project-agents | `<projectRoot>/.agents/skills` |
| 300 | custom | `customSkillDirs` |
| 400 | user-dsh | `$DSH_HOME/skills` |
| 500 | user-agents | `$DSH_AGENTS_HOME/skills` |

`projectRoot` is the nearest `.git` ancestor of the ACP cwd, else the cwd.

## Fix

Map `dsh-acp` to the CLI's `universal` identity, whose project destination is `.agents/skills` — byte-for-byte the same publication `-a codex` produces, and exactly the cross-agent root the harness scans. `dsh` is not a skills CLI agent id in `skills@1.5.21`, and labelling the harness `codex` would mislabel the audit table and couple it to another harness's future layout, so the table keeps naming the convention rather than a neighbour.

Both the declaration on the curated `RuntimeDef` and the audited-table entry are added, matching how the other curated harnesses (hermes, kiro, qoder) are admitted. Nothing else gated dsh: the cluster side keys off the shim's `cluster-skills-v1` feature, not a runtime allowlist, so local and sandbox installs turn on together.

## Verification

- `test/skills-cli-golden.test.ts` — the real pinned CLI in the bwrap cell derives `.agents/skills/local-golden` for `universal`, on the same table row as `codex`
- `test/unified-skills.test.ts` — a full install with `runtime: 'dsh-acp'` through the real CLI publishes `['.agents/skills/dsh-golden']` with correct content
- `test/skills.test.ts`, `test/registry.test.ts` — mapping and curated-catalog snapshot
- `pnpm typecheck` clean; `skills` / `registry` / `curated-runtime-daemon` 42 passed; `unified-skills` + `skills-cli-cell` + `cluster-skill-coordinator` + `skill-install-ledger` + `shim-skill-handler` 72 passed / 1 skipped

## Known boundary (not addressed here)

An agent with a configured working subdirectory installs at that subdirectory, while the harness resolves `projectRoot` to the enclosing `.git` root — those skills stay invisible. Codex has the same shape, so moving the install root is a cross-runtime decision rather than something to slip into this admission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)