### PR TITLE
fix(web): render the sandbox-pod notice as its own line, not a thought step

### DIFF
--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -531,9 +531,10 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         }
         if (ev.kind === 'notice') {
           // Daemon chrome for a wait with nothing else to show (a sandbox pod coming up).
-          // Live-only, so it goes in the collapsible work lane; `boundary` keeps the reply
-          // chunks that follow from accumulating into it.
-          return [...steps, lane({ kind: 'plan', text: ev.text, boundary: true })]
+          // Its own lane, not the work lane: it is not something the agent thought or did,
+          // so it must not be counted or hidden as a reasoning step. `boundary` keeps the
+          // reply chunks that follow from accumulating into it.
+          return [...steps, lane({ kind: 'notice', text: ev.text, boundary: true })]
         }
         if (ev.kind === 'message') {
           if (last && last.kind === 'done' && last.who === who) {

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -327,7 +327,7 @@ describe('stream text delta batching', () => {
     ])
   })
 
-  it('renders a daemon notice in the work lane without swallowing the reply that follows', async () => {
+  it('renders a daemon notice in its own lane without swallowing the reply that follows', async () => {
     const runFrame = captureAnimationFrames()
     const { socket, turnId } = await openStream()
 
@@ -349,7 +349,7 @@ describe('stream text delta batching', () => {
 
     // The notice is its own step: `boundary` keeps the thinking chunk from accumulating into it.
     expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toMatchObject([
-      { kind: 'plan', text: 'Allocating a sandbox pod…', boundary: true },
+      { kind: 'notice', text: 'Allocating a sandbox pod…', boundary: true },
       { kind: 'plan', text: 'here goes' }
     ])
   })

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -3,6 +3,11 @@
 // file edits (EDIT) — behind a per-turn "Thought through…" toggle.
 export const WORK_LANES = new Set(['THINK', 'PLAN', 'TOOL', 'EDIT'])
 
+/** Daemon chrome for a wait (a sandbox pod coming up) — deliberately NOT a work lane:
+ *  it is not something the agent thought or did, so it renders as its own standalone
+ *  line instead of being counted and hidden as a reasoning step. */
+export const NOTICE_LANE = 'NOTICE'
+
 /** Split an agent turn's collapsed work steps into the counts the summary reports:
  *  reasoning STEPS (THINK/PLAN), tool-command STEPS (TOOL), and edited FILES — the
  *  DISTINCT file paths across all EDIT steps (a single EDIT row can touch several

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -94,6 +94,7 @@ import { useCommandAutocomplete } from '@/components/console/useCommandAutocompl
 import { useRuntimeCommands } from '@/components/console/useRuntimeCommands'
 import type { AgentIcon } from '@/lib/agent-icon'
 import {
+  NOTICE_LANE,
   WORK_LANES,
   sessionTurnInFlight,
   toggleWorkPanel,
@@ -3983,7 +3984,12 @@ export default function SessionDetailView() {
                           (() => {
                             // 2b: the spoken answer (MSG/DONE) is plain text; the agent's work
                             // (reasoning / plan / tool / edit) collapses behind a per-turn toggle.
-                            const textSteps = turn.steps.filter((s) => !WORK_LANES.has(s.lane))
+                            // A daemon notice (a sandbox pod coming up) is neither: it renders
+                            // as its own standalone line above the answer.
+                            const noticeSteps = turn.steps.filter((s) => s.lane === NOTICE_LANE)
+                            const textSteps = turn.steps.filter(
+                              (s) => !WORK_LANES.has(s.lane) && s.lane !== NOTICE_LANE
+                            )
                             const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
                             // Reasoning steps / tool commands / edited FILES (distinct paths across
                             // EDIT rows, since one EDIT row can touch several files).
@@ -4071,6 +4077,20 @@ export default function SessionDetailView() {
                                   <div className="mb-[5px] flex items-center gap-[7px]">
                                     <span className={AGENT_NAME}>{turn.agentName}</span>
                                   </div>
+                                  {noticeSteps.length > 0 && (
+                                    <div
+                                      className={`flex min-w-0 flex-col gap-[3px] ${textSteps.length > 0 || workSteps.length > 0 ? 'mb-2' : ''}`}
+                                    >
+                                      {noticeSteps.map((st, si) => (
+                                        <span
+                                          key={`n:${si}`}
+                                          className="min-w-0 truncate font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)"
+                                        >
+                                          {st.text}
+                                        </span>
+                                      ))}
+                                    </div>
+                                  )}
                                   {/* One bubble per text step: a turn that answers in two chunks
                             arrives as two delivered messages, so one wrapper around the set
                             would merge messages the platform kept apart. */}

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -273,7 +273,7 @@ export function agentIsPlaced(agent: Pick<Agent, 'daemon' | 'runtime' | 'placeme
   return (isPoolPlacementKind(agent.placementKind) || agent.daemon !== '—') && agent.runtime !== ''
 }
 
-export type LaneKind = 'msg' | 'plan' | 'tool' | 'edit' | 'done'
+export type LaneKind = 'msg' | 'plan' | 'tool' | 'edit' | 'done' | 'notice'
 
 export interface LaneInfo {
   lane: string
@@ -317,6 +317,17 @@ const LANE_MAP: Record<LaneKind, LaneInfo> = {
     weight: 500,
     textColor: 'var(--text-secondary)',
     codeColor: 'var(--text-secondary)'
+  },
+  // Daemon chrome for a wait the agent has nothing else to show for (a sandbox pod coming
+  // up). Not the agent's work — it renders as its own standalone line, never inside the
+  // collapsible work panel (see WORK_LANES).
+  notice: {
+    lane: 'NOTICE',
+    laneColor: 'var(--text-tertiary)',
+    dot: 'var(--text-disabled)',
+    weight: 400,
+    textColor: 'var(--text-tertiary)',
+    codeColor: 'var(--text-tertiary)'
   },
   // An assistant's completed reply — rendered neutrally, identical to a real transcript
   // text row (see SessionDetailView.msgStep). Keeping this in sync means a live playground


### PR DESCRIPTION
## Problem

A turn whose only content was the daemon's `notice` event rendered as:

> `>` Thought through 1 step · ⏳ Allocating a sandbox pod…

The notice folded into the PLAN lane, so `workCounts` counted it as a reasoning
step and the work toggle hid it. A wait the daemon announces is not something
the agent thought or did.

## Fix

Give the notice its own lane:

- `lib/data.ts` — `LaneKind` gains `'notice'` plus a neutral tertiary `LANE_MAP` entry.
- `PlaygroundProvider.tsx` — the `notice` webchat event produces a `kind: 'notice'` step (still `boundary`, so the reply chunks that follow start their own block).
- `session-work.ts` — new `NOTICE_LANE`, deliberately outside `WORK_LANES`: never counted by `workCounts`, never collapsed into the work panel.
- `SessionDetailView.tsx` — the turn render splits `noticeSteps` out of `textSteps` and draws them as standalone tertiary lines under the agent name, above the answer bubbles. They also stay out of the turn's copyable answer text.

A notice-only turn now shows just `⏳ Allocating a sandbox pod…` — no chevron, no "Thought through 1 step".

## Verification

`pnpm --filter @agentconnect.md/web typecheck`, eslint, and prettier clean; web suite green (186 files / 2090 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)