### PR TITLE
fix(daemon): ship cluster skill mutation helper

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -133,7 +133,8 @@ COPY --from=shim-builder --chown=0:0 /build/packages/daemon/dist/shim/auto-merge
 COPY --from=shim-builder --chown=0:0 /build/packages/daemon/dist/shim/skills /opt/agentconnect/shim/skills
 RUN chmod 0444 /opt/agentconnect/shim/index.js /opt/agentconnect/shim/git-credential.js \
   /opt/agentconnect/shim/gh-token.js /opt/agentconnect/shim/mcp-bridge.js /opt/agentconnect/shim/auto-merge.js \
-  /opt/agentconnect/shim/skills/dist/cli.js /opt/agentconnect/shim/skills/package.json \
+  /opt/agentconnect/shim/skills/dist/cli.js /opt/agentconnect/shim/skills/workspace-mutation.js \
+  /opt/agentconnect/shim/skills/package.json \
   && chmod 0555 /opt/agentconnect/shim
 
 # The executable git runs as its credential helper. A wrapper because git needs something

--- a/packages/daemon/scripts/assert-self-contained.mjs
+++ b/packages/daemon/scripts/assert-self-contained.mjs
@@ -78,7 +78,7 @@ for (const arch of ['x64', 'arm64']) {
 // Every entry the image ships, checked identically: the credential helper and the gh token fetch are separate
 // bundles precisely so their graphs stay disjoint from the channel's, and a shared module would show up here
 // as a relative chunk import — a file the image never copies.
-for (const entry of ['index.js', 'git-credential.js', 'gh-token.js']) {
+for (const entry of ['index.js', 'git-credential.js', 'gh-token.js', 'skills/workspace-mutation.js']) {
   const shimPath = new URL(`../dist/shim/${entry}`, import.meta.url)
   if (!existsSync(shimPath)) {
     console.error(`✗ shim bundle ${entry} is missing — \`tsdown --config tsdown.shim.config.ts\` did not run`)

--- a/packages/daemon/tsdown.shim.config.ts
+++ b/packages/daemon/tsdown.shim.config.ts
@@ -38,5 +38,6 @@ export default defineConfig([
   { ...shared, entry: { 'gh-token': 'src/shim/gh-token.ts' } },
   { ...shared, entry: { 'mcp-bridge': 'src/shim/mcp-bridge.ts' } },
   { ...shared, entry: { 'auto-merge': 'src/shim/auto-merge.ts' } },
+  { ...shared, entry: { 'skills/workspace-mutation': 'src/skills/skill-workspace-mutation-cli.ts' } },
   { ...shared, entry: { 'skills/dist/cli': skillsCliEntry } }
 ])

--- a/scripts/verify-runtime-image.mjs
+++ b/scripts/verify-runtime-image.mjs
@@ -62,6 +62,7 @@ const GH_WRAPPER_PATH = '/opt/agentconnect/pathbin/gh'
  *  retrying a module that is not there, which is how an agent silently lost its AgentConnect tools. */
 const MCP_BRIDGE_PATH = '/opt/agentconnect/shim/mcp-bridge.js'
 const SKILLS_CLI_PATH = '/opt/agentconnect/shim/skills/dist/cli.js'
+const SKILL_MUTATION_PATH = '/opt/agentconnect/shim/skills/workspace-mutation.js'
 const TABLE_PATH = '/opt/agentconnect/runtime/k8s-runtimes.json'
 
 // The runtime is the untrusted party in this image, so root would hand it the whole filesystem.
@@ -101,6 +102,18 @@ check('the pinned skills CLI is present, immutable and executable', () => {
   const version = inImage(`node ${SKILLS_CLI_PATH} --version`)
   if (version !== '1.5.21') throw new Error(`skills CLI version is ${version}`)
   return `${owner}, version ${version}`
+})
+
+check('the skill workspace mutation helper is present and immutable', () => {
+  const owner = inImage(`stat -c '%U:%G %a' ${SKILL_MUTATION_PATH}`)
+  if (!owner.startsWith('root:root')) throw new Error(`skill mutation helper is not root-owned (${owner})`)
+  const mode = owner.split(' ')[1]
+  if (/[2367]$/.test(mode) || /^.[2367]/.test(mode)) {
+    throw new Error(`skill mutation helper is group/other writable (${mode})`)
+  }
+  const refused = inImage(`(echo x >> ${SKILL_MUTATION_PATH} && echo WRITABLE) || echo refused`)
+  if (refused !== 'refused') throw new Error('the runtime user can modify the skill mutation helper')
+  return owner
 })
 
 // Git spawns a credential helper per invocation, so the pod needs one as an executable — and it
@@ -191,7 +204,7 @@ check('the shim bundles are self-contained', () => {
   // the image: an earlier version of this Dockerfile ran tsdown without building the workspace
   // deps, and produced a bundle that imported them externally — which the image cannot resolve.
   const external = []
-  for (const path of [SHIM_PATH, MCP_BRIDGE_PATH]) {
+  for (const path of [SHIM_PATH, MCP_BRIDGE_PATH, SKILL_MUTATION_PATH]) {
     const bundle = inImage(`cat ${path}`)
     const specs = [...bundle.matchAll(/\bfrom\s*"([^"]+)"/g), ...bundle.matchAll(/\bimport\(\s*"([^"]+)"\s*\)/g)].map(
       (match) => match[1]


### PR DESCRIPTION
## Summary

Fix the remaining cluster skill installation failure after #1547.

The runtime shim could now dispatch the sandbox provider, but the runtime-sandbox image did not contain the audited `skills/workspace-mutation.js` helper that `runSkillWorkspaceMutation()` launches. Apply failed while resolving the helper, and rollback failed through the same path, producing `skill installation failed and the prior executable set could not be restored`.

## Changes

- Build the workspace mutation CLI as an independent shim artifact.
- Ship it in the runtime-sandbox image as an immutable root-owned file.
- Extend package self-containment checks to cover the helper.
- Extend built-image verification to require and inspect the helper.

## Verification

- [x] Red/green bundle regression: missing helper failed `assert-self-contained.mjs`, new entry passes
- [x] Daemon build and typecheck
- [x] Relevant skill/shim tests: 28 passed
- [x] Built `runtime-sandbox` Docker image locally
- [x] Full `scripts/verify-runtime-image.mjs` passed against the built image
- [x] ESLint, Prettier, and diff checks
