### PR TITLE
feat(console): expandable per-family cards in the code-host wizard

### DIFF
--- a/packages/web/src/components/console/CodeHostReviewSettings.tsx
+++ b/packages/web/src/components/console/CodeHostReviewSettings.tsx
@@ -5,7 +5,10 @@ import { Icon } from '@/components/ui'
 import {
   codeHostReviewCapabilities,
   codeHostReviewSettingsFromCapabilities,
+  REVIEW_FORMATS,
   REVIEW_PRESETS,
+  reviewFormatOf,
+  reviewFormatValue,
   reviewPresetOf,
   withCapability,
   type CodeHostReviewCapabilities,
@@ -22,8 +25,11 @@ export interface ReviewCapabilityHelp {
   statusCheck: string
 }
 
-// The disclosure both code hosts render: preset row, capability checkboxes, and a notice slot.
-// It holds no authorization opinion — each host computes its own blockers and passes them in.
+// The surface both code hosts render, in one of two layouts. `disclosure` is the
+// agent page's collapsible None/Brief/Details block; `format` is the create
+// surface's "Review format" section, where None is replaced by Custom — an
+// all-off Custom IS the no-review state. It holds no authorization opinion —
+// each host computes its own blockers and passes them in.
 export function CodeHostReviewSettings({
   title,
   value,
@@ -31,6 +37,7 @@ export function CodeHostReviewSettings({
   onReportingModeChange,
   help,
   statusCheckLabel,
+  layout = 'disclosure',
   defaultExpanded = false,
   notices
 }: {
@@ -40,10 +47,14 @@ export function CodeHostReviewSettings({
   onReportingModeChange: (mode: HookReportingMode) => void
   help: ReviewCapabilityHelp
   statusCheckLabel: string
+  layout?: 'disclosure' | 'format'
   defaultExpanded?: boolean
   notices?: ReactNode
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded)
+  // Custom is a disclosure the value cannot express: an exact Details value the
+  // user opened Custom on must keep the checkboxes visible.
+  const [customPinned, setCustomPinned] = useState(() => reviewFormatOf(value) === 'custom')
   const preset = reviewPresetOf(value)
   const capabilities = codeHostReviewCapabilities(value)
 
@@ -54,6 +65,71 @@ export function CodeHostReviewSettings({
 
   const setCapability = (key: keyof CodeHostReviewCapabilities, enabled: boolean) => {
     applyValue(codeHostReviewSettingsFromCapabilities(withCapability(capabilities, key, enabled)))
+  }
+
+  const checkboxes = (
+    <div className="grid grid-cols-2 gap-x-3 gap-y-2 desktop:grid-cols-4">
+      <Capability
+        label="Inline comments"
+        help={help.inlineComments}
+        checked={capabilities.inlineComments}
+        onChange={(checked) => setCapability('inlineComments', checked)}
+      />
+      <Capability
+        label="Request changes"
+        help={help.requestChanges}
+        checked={capabilities.requestChanges}
+        onChange={(checked) => setCapability('requestChanges', checked)}
+      />
+      <Capability
+        label="Approve"
+        help={help.approve}
+        checked={capabilities.approve}
+        onChange={(checked) => setCapability('approve', checked)}
+      />
+      <Capability
+        label={statusCheckLabel}
+        help={help.statusCheck}
+        checked={capabilities.statusCheck}
+        onChange={(checked) => setCapability('statusCheck', checked)}
+      />
+    </div>
+  )
+
+  if (layout === 'format') {
+    const format = customPinned ? 'custom' : reviewFormatOf(value)
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="fldlbl">Review format</div>
+        <div className="grid grid-cols-3 gap-2">
+          {REVIEW_FORMATS.map((option) => {
+            const active = format === option.id
+            return (
+              <button
+                key={option.id}
+                type="button"
+                data-review-format={option.id}
+                aria-pressed={active}
+                onClick={() => {
+                  setCustomPinned(option.id === 'custom')
+                  const next = reviewFormatValue(option.id)
+                  if (next) applyValue(next)
+                }}
+                className={
+                  active
+                    ? 'h-10 rounded-md border border-(--brand) bg-(--brand-soft) font-sans text-[12.5px] font-semibold leading-normal text-(--brand-soft-text)'
+                    : 'h-10 rounded-md border border-(--border-default) bg-(--surface-card) font-sans text-[12.5px] font-semibold leading-normal text-(--text-secondary)'
+                }
+              >
+                {option.label}
+              </button>
+            )
+          })}
+        </div>
+        {format === 'custom' && checkboxes}
+        {notices}
+      </div>
+    )
   }
 
   return (
@@ -91,34 +167,7 @@ export function CodeHostReviewSettings({
             })}
           </div>
 
-          {preset === 'details' && (
-            <div className="grid grid-cols-2 gap-x-3 gap-y-2 desktop:grid-cols-4">
-              <Capability
-                label="Inline comments"
-                help={help.inlineComments}
-                checked={capabilities.inlineComments}
-                onChange={(checked) => setCapability('inlineComments', checked)}
-              />
-              <Capability
-                label="Request changes"
-                help={help.requestChanges}
-                checked={capabilities.requestChanges}
-                onChange={(checked) => setCapability('requestChanges', checked)}
-              />
-              <Capability
-                label="Approve"
-                help={help.approve}
-                checked={capabilities.approve}
-                onChange={(checked) => setCapability('approve', checked)}
-              />
-              <Capability
-                label={statusCheckLabel}
-                help={help.statusCheck}
-                checked={capabilities.statusCheck}
-                onChange={(checked) => setCapability('statusCheck', checked)}
-              />
-            </div>
-          )}
+          {preset === 'details' && checkboxes}
         </div>
       )}
 

--- a/packages/web/src/components/console/GithubReviewSettings.tsx
+++ b/packages/web/src/components/console/GithubReviewSettings.tsx
@@ -29,6 +29,7 @@ export function GithubReviewSettings({
   installation,
   publicRepo = false,
   repoSelected = true,
+  layout = 'disclosure',
   defaultExpanded = false,
   canAuthorizeRepo = false,
   authorizingRepo = false,
@@ -41,6 +42,7 @@ export function GithubReviewSettings({
   installation?: InstallationPermissionView
   publicRepo?: boolean
   repoSelected?: boolean
+  layout?: 'disclosure' | 'format'
   defaultExpanded?: boolean
   canAuthorizeRepo?: boolean
   authorizingRepo?: boolean
@@ -70,6 +72,7 @@ export function GithubReviewSettings({
       value={value}
       onReviewPolicyChange={onReviewPolicyChange}
       onReportingModeChange={onReportingModeChange}
+      layout={layout}
       defaultExpanded={defaultExpanded}
       statusCheckLabel="Status check"
       help={{

--- a/packages/web/src/components/console/GitlabReviewSettings.tsx
+++ b/packages/web/src/components/console/GitlabReviewSettings.tsx
@@ -10,12 +10,14 @@ export function GitlabReviewSettings({
   onReviewPolicyChange,
   onReportingModeChange,
   projectBotReady = true,
+  layout = 'disclosure',
   defaultExpanded = false
 }: {
   value: CodeHostReviewSettingsValue
   onReviewPolicyChange: (policy: HookReviewPolicy) => void
   onReportingModeChange: (mode: HookReportingMode) => void
   projectBotReady?: boolean
+  layout?: 'disclosure' | 'format'
   defaultExpanded?: boolean
 }) {
   const botMissing = !projectBotReady && (value.reviewPolicy !== 'off' || value.reportingMode === 'check')
@@ -25,6 +27,7 @@ export function GitlabReviewSettings({
       value={value}
       onReviewPolicyChange={onReviewPolicyChange}
       onReportingModeChange={onReportingModeChange}
+      layout={layout}
       defaultExpanded={defaultExpanded}
       statusCheckLabel="Run note"
       help={{

--- a/packages/web/src/components/console/modals/AddIntegrationModal.github.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.github.test.tsx
@@ -1,0 +1,322 @@
+// @vitest-environment happy-dom
+/**
+ * The GitHub trigger kind in the Add-integration wizard, on the axis its GitLab
+ * twin covers too: a hook row is (agent, repo, SUBJECT FAMILY) and each row
+ * carries its OWN trigger cadence, so a single pass can watch pull requests on
+ * every update while issues answer only an @mention. The wizard's job is to
+ * compile that pick into one create per family with that family's own `events`,
+ * `commentFamilies` and `mentionOnly`.
+ *
+ * "Listen for" is a stack of expandable family cards: a card ticked open reveals
+ * that subject's own "Trigger when" tiles, and the change-proposal card also
+ * carries the review format. An unticked card reveals nothing.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent } from '@/lib/data'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const mocks = vi.hoisted(() => ({
+  // Declared parameter keeps `mock.calls` typed — the tests read the bodies back.
+  createGithubHook: vi.fn(async (_input: { family: string; events: string[] }) => ({
+    id: 'hook-1',
+    agentId: 'agent-a',
+    kind: 'github'
+  })),
+  fetchAgentRepos: vi.fn(),
+  fetchAgentHooks: vi.fn(async () => [] as unknown[])
+}))
+
+const installation = {
+  id: 'inst-1',
+  installationId: 42,
+  accountLogin: 'acme',
+  accountType: 'Organization',
+  repositorySelection: 'all',
+  suspended: false,
+  permissionsStatus: 'current' as const,
+  pullRequestsPermission: 'write' as const,
+  checksPermission: 'write' as const,
+  settingsUrl: 'https://github.example.test/settings/installations/42',
+  createdAt: '2026-08-01T00:00:00.000Z'
+}
+
+const repo = {
+  repoId: '990',
+  fullName: 'acme/platform',
+  private: true,
+  defaultBranch: 'main',
+  description: null,
+  updatedAt: null,
+  installationId: 'inst-1'
+}
+
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, orgPath: (path: string) => `/acme${path}` })
+}))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    bots: [],
+    daemons: [],
+    daemonsLoading: false,
+    createIntegration: vi.fn(),
+    createHook: vi.fn(),
+    createGithubHook: mocks.createGithubHook,
+    createGitlabHook: vi.fn(),
+    refresh: vi.fn(),
+    updateAgent: vi.fn()
+  })
+}))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchAgentHooks: mocks.fetchAgentHooks,
+  fetchAgentRepos: mocks.fetchAgentRepos,
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: true, installations: [installation] })),
+  fetchGithubInstallUrl: vi.fn(async () => null),
+  fetchGithubRepoRoster: vi.fn(async () => ({ repos: [repo], privateReposHidden: false, failed: false })),
+  syncGithubInstallations: vi.fn(async () => [installation]),
+  fetchGitlabProjects: vi.fn(async () => []),
+  fetchGitlabConnections: vi.fn(async () => ({ enabled: false, connections: [] })),
+  searchGitlabProjects: vi.fn(async () => ({ projects: [], nextPage: null }))
+}))
+
+const AddIntegrationModal = (await import('./AddIntegrationModal')).default
+
+// An App-backed workspace repo at write: the pick is implicit and the review
+// settings are unblocked, so every case here is about the cadence rows alone.
+const agent = {
+  id: 'agent-a',
+  name: 'build-agent',
+  daemon: 'daemon-1',
+  canEdit: true,
+  workspace: {
+    mode: 'github',
+    repo: 'acme/platform',
+    repoId: '990',
+    installationId: 'inst-1',
+    gitAccess: 'write'
+  }
+} as unknown as Agent
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+const tileNamed = (label: string) =>
+  Array.from(document.querySelectorAll<HTMLDivElement>('.ptile')).find((tile) => tile.textContent === label)
+const clickText = (text: string) =>
+  Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.includes(text))
+const family = (fam: string) => document.querySelector<HTMLDivElement>(`[data-github-family="${fam}"]`)
+/** Cadence is per subject, so a tile is addressed by (family, mode). */
+const trigger = (fam: string, mode: string) =>
+  document.querySelector<HTMLButtonElement>(`[data-github-trigger="${fam}:${mode}"]`)
+const format = (id: string) => document.querySelector<HTMLButtonElement>(`[data-review-format="${id}"]`)
+const checkbox = (label: string) =>
+  Array.from(document.querySelectorAll<HTMLLabelElement>('label')).find((row) => row.textContent?.includes(label))
+    ?.firstElementChild as HTMLInputElement | undefined
+
+/** Each case renders a DISTINCT agent id — the grant read is cached per agent. */
+async function renderAgent(over: Record<string, unknown> = {}) {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(<AddIntegrationModal agent={{ ...agent, ...over } as unknown as Agent} onClose={() => undefined} />)
+  })
+  await act(async () => tileNamed('GitHub')?.click())
+}
+
+beforeEach(() => {
+  mocks.fetchAgentRepos.mockResolvedValue([])
+  mocks.fetchAgentHooks.mockResolvedValue([])
+})
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  mocks.createGithubHook.mockClear()
+  mocks.fetchAgentRepos.mockReset()
+  mocks.fetchAgentHooks.mockReset()
+})
+
+describe('AddIntegrationModal, GitHub trigger cadence', () => {
+  it('defaults every selected subject to the opened cadence', async () => {
+    await renderAgent({ id: 'agent-default' })
+
+    // No cadence click: the form opens on "opened", pull requests only.
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGithubHook).toHaveBeenCalledTimes(1)
+    expect(mocks.createGithubHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        family: 'pull_request',
+        events: ['pull_request:opened'],
+        commentFamilies: ['pull_request'],
+        mentionOnly: false
+      })
+    )
+  })
+
+  it('opens a subject card on tick and reveals nothing while it is unticked', async () => {
+    await renderAgent({ id: 'agent-cards' })
+
+    // Pull requests ride the default selection; issues start closed.
+    expect(trigger('pull_request', 'first')).not.toBeNull()
+    expect(document.querySelectorAll('[data-github-trigger^="issues:"]')).toHaveLength(0)
+
+    await act(async () => family('issues')?.click())
+    expect(trigger('issues', 'first')).not.toBeNull()
+
+    // Untick and the whole body folds away again.
+    await act(async () => family('issues')?.click())
+    expect(document.querySelectorAll('[data-github-trigger^="issues:"]')).toHaveLength(0)
+  })
+
+  it('offers each subject its own three cadences — label events on issues alone', async () => {
+    await renderAgent({ id: 'agent-per-family-tiles' })
+    await act(async () => family('issues')?.click())
+
+    expect(trigger('pull_request', 'every')).not.toBeNull()
+    expect(trigger('pull_request', 'labeled')).toBeNull()
+    expect(trigger('issues', 'labeled')).not.toBeNull()
+    // Issues trade "any update" for the label cadence in the wizard.
+    expect(trigger('issues', 'every')).toBeNull()
+    expect(document.querySelectorAll('[data-github-trigger]')).toHaveLength(6)
+  })
+
+  it('gives each selected subject its own cadence in a single pass', async () => {
+    await renderAgent({ id: 'agent-mixed' })
+    await act(async () => family('issues')?.click())
+    // Pull requests move to every update; issues answer an @mention only.
+    await act(async () => trigger('pull_request', 'every')?.click())
+    await act(async () => trigger('issues', 'mention')?.click())
+
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGithubHook).toHaveBeenCalledTimes(2)
+    expect(mocks.createGithubHook).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        family: 'pull_request',
+        events: ['pull_request:*', 'issue_comment:created'],
+        commentFamilies: ['pull_request'],
+        mentionOnly: false,
+        // Reviews and Checks ride the pull-request row only.
+        reviewPolicy: 'full',
+        reportingMode: 'check'
+      })
+    )
+    expect(mocks.createGithubHook).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        family: 'issues',
+        events: ['issues:*', 'issue_comment:created'],
+        commentFamilies: ['issues'],
+        mentionOnly: true,
+        reviewPolicy: 'off',
+        reportingMode: 'off'
+      })
+    )
+  })
+
+  it('compiles the label cadence to the bare label event with no reply scope', async () => {
+    await renderAgent({ id: 'agent-labeled' })
+    await act(async () => family('issues')?.click())
+    await act(async () => trigger('issues', 'labeled')?.click())
+
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGithubHook).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        family: 'issues',
+        events: ['issues:labeled'],
+        commentFamilies: [],
+        mentionOnly: false
+      })
+    )
+  })
+
+  it('offers a cadence row per selected subject and none for an already-watched one', async () => {
+    mocks.fetchAgentHooks.mockResolvedValue([
+      {
+        id: 'hook-pr',
+        kind: 'github',
+        repoFullName: 'acme/platform',
+        family: 'pull_request',
+        events: ['pull_request:*']
+      }
+    ])
+    await renderAgent({ id: 'agent-half-watched' })
+
+    expect(family('pull_request')?.getAttribute('aria-disabled')).toBe('true')
+    await act(async () => family('issues')?.click())
+    expect(document.querySelectorAll('[data-github-trigger]')).toHaveLength(3)
+    expect(trigger('issues', 'first')).not.toBeNull()
+    expect(trigger('pull_request', 'first')).toBeNull()
+
+    await act(async () => clickText('Connect')?.click())
+    expect(mocks.createGithubHook).toHaveBeenCalledTimes(1)
+    expect(mocks.createGithubHook).toHaveBeenCalledWith(expect.objectContaining({ family: 'issues' }))
+  })
+})
+
+describe('AddIntegrationModal, GitHub review format', () => {
+  it('lives in the pull-request card, opens on Details, and offers no None', async () => {
+    await renderAgent({ id: 'agent-format' })
+
+    expect(document.body.textContent).toContain('Review format')
+    expect(format('brief')).not.toBeNull()
+    expect(format('details')?.getAttribute('aria-pressed')).toBe('true')
+    expect(format('custom')).not.toBeNull()
+    expect(format('none')).toBeNull()
+    // Details is the whole set, so the manual checkboxes stay hidden.
+    expect(checkbox('Inline comments')).toBeUndefined()
+
+    await act(async () => clickText('Connect')?.click())
+    expect(mocks.createGithubHook).toHaveBeenCalledWith(
+      expect.objectContaining({ reviewPolicy: 'full', reportingMode: 'check' })
+    )
+  })
+
+  it('folds the format away with the pull-request card', async () => {
+    await renderAgent({ id: 'agent-format-folds' })
+    await act(async () => family('pull_request')?.click())
+
+    expect(document.body.textContent).not.toContain('Review format')
+  })
+
+  it('sends the Brief mapping the preset already had', async () => {
+    await renderAgent({ id: 'agent-brief' })
+    await act(async () => format('brief')?.click())
+
+    await act(async () => clickText('Connect')?.click())
+    expect(mocks.createGithubHook).toHaveBeenCalledWith(
+      expect.objectContaining({ reviewPolicy: 'comment', reportingMode: 'off' })
+    )
+  })
+
+  it('reveals the four capabilities on Custom, and an all-off Custom is the no-review state', async () => {
+    await renderAgent({ id: 'agent-custom' })
+    await act(async () => format('custom')?.click())
+
+    // Custom only discloses — the value is still whatever Details left.
+    expect(checkbox('Inline comments')?.checked).toBe(true)
+    expect(checkbox('Status check')?.checked).toBe(true)
+
+    // Inline comments carries the other two review capabilities down with it.
+    await act(async () => checkbox('Inline comments')?.click())
+    await act(async () => checkbox('Status check')?.click())
+    expect(checkbox('Approve')?.checked).toBe(false)
+    expect(checkbox('Request changes')?.checked).toBe(false)
+
+    await act(async () => clickText('Connect')?.click())
+    expect(mocks.createGithubHook).toHaveBeenCalledWith(
+      expect.objectContaining({ reviewPolicy: 'off', reportingMode: 'off' })
+    )
+  })
+})

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -132,7 +132,13 @@ const tileNamed = (label: string) =>
 const clickText = (text: string) =>
   Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.includes(text))
 const family = (fam: string) => document.querySelector<HTMLDivElement>(`[data-gitlab-family="${fam}"]`)
-const trigger = (mode: string) => document.querySelector<HTMLDivElement>(`[data-gitlab-trigger="${mode}"]`)
+/** Cadence is per subject now, so a tile is addressed by (family, mode). */
+const trigger = (fam: string, mode: string) =>
+  document.querySelector<HTMLButtonElement>(`[data-gitlab-trigger="${fam}:${mode}"]`)
+const format = (id: string) => document.querySelector<HTMLButtonElement>(`[data-review-format="${id}"]`)
+const checkbox = (label: string) =>
+  Array.from(document.querySelectorAll<HTMLLabelElement>('label')).find((row) => row.textContent?.includes(label))
+    ?.firstElementChild as HTMLInputElement | undefined
 
 async function pickProject() {
   await act(async () => tileNamed('GitLab')?.click())
@@ -204,12 +210,12 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     expect(document.body.textContent).not.toContain('Couldn’t load your GitLab projects')
   })
 
-  it('defaults to the updated trigger, scoping replies to the selected subjects', async () => {
+  it('defaults to the opened trigger, which subscribes to no notes', async () => {
     mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
     await pickProject()
 
-    // No cadence click: the form opens on "updated", merge requests only.
+    // No cadence click: the form opens on "opened", merge requests only.
     await act(async () => clickText('Connect')?.click())
 
     expect(mocks.createGitlabHook).toHaveBeenCalledWith({
@@ -217,21 +223,22 @@ describe('AddIntegrationModal, GitLab trigger', () => {
       name: 'acme/platform',
       projectId: '4210',
       family: 'merge_request',
-      events: ['merge_request:*'],
-      commentFamilies: ['merge_request'],
+      events: ['merge_request:opened'],
+      commentFamilies: [],
       mentionOnly: false,
-      // The review disclosure opens on the full preset, exactly like the github pane.
+      // The review format opens on the full set, exactly like the github pane.
       reviewPolicy: 'full',
       reportingMode: 'check'
     })
   })
 
-  it('compiles the created trigger to openings with no note subscription', async () => {
+  it('compiles the opened trigger to openings with no note subscription', async () => {
     mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
     await pickProject()
     await act(async () => family('issues')?.click())
-    await act(async () => trigger('first')?.click())
+    await act(async () => trigger('issues', 'first')?.click())
+    await act(async () => trigger('merge_request', 'first')?.click())
 
     await act(async () => clickText('Connect')?.click())
 
@@ -256,7 +263,8 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     await render()
     await pickProject()
     await act(async () => family('issues')?.click())
-    await act(async () => trigger('mention')?.click())
+    await act(async () => trigger('issues', 'mention')?.click())
+    await act(async () => trigger('merge_request', 'mention')?.click())
 
     await act(async () => clickText('Connect')?.click())
 
@@ -285,19 +293,99 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     })
   })
 
-  it('offers the review disclosure and sends whichever preset is chosen', async () => {
+  it('gives each selected subject its own cadence in a single pass', async () => {
+    // The point of the per-family rows: one wizard pass can watch merge requests
+    // on every update while issues only answer an @mention.
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    await render()
+    await pickProject()
+    await act(async () => family('issues')?.click())
+    await act(async () => trigger('issues', 'mention')?.click())
+    await act(async () => trigger('merge_request', 'every')?.click())
+
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGitlabHook).toHaveBeenCalledTimes(2)
+    expect(mocks.createGitlabHook).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        family: 'issues',
+        events: ['issues:*'],
+        commentFamilies: ['issues'],
+        mentionOnly: true
+      })
+    )
+    expect(mocks.createGitlabHook).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        family: 'merge_request',
+        events: ['merge_request:*'],
+        commentFamilies: ['merge_request'],
+        mentionOnly: false
+      })
+    )
+  })
+
+  it('clears the note subscription only on the row picked as opened', async () => {
+    // Opened mode is the one cadence that drops notes entirely (a shared note
+    // subscription would fire on every reply), and it must drop them for THAT
+    // row alone — the sibling on "any update" keeps its own.
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    await render()
+    await pickProject()
+    await act(async () => family('issues')?.click())
+    await act(async () => trigger('merge_request', 'every')?.click())
+
+    await act(async () => clickText('Connect')?.click())
+
+    expect(mocks.createGitlabHook).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ family: 'issues', events: ['issues:opened'], commentFamilies: [], mentionOnly: false })
+    )
+    expect(mocks.createGitlabHook).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        family: 'merge_request',
+        events: ['merge_request:*'],
+        commentFamilies: ['merge_request'],
+        mentionOnly: false
+      })
+    )
+  })
+
+  it('offers a cadence row per selected subject and none for an already-watched one', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    mocks.fetchAgentHooks.mockResolvedValue([
+      { id: 'hook-mr', kind: 'gitlab', repoId: '4210', family: 'merge_request', events: ['merge_request:*'] }
+    ])
+    await renderAgent({ id: 'agent-one-row' })
+    await pickProject()
+
+    // Merge requests are taken, so only the issues card opens.
+    await act(async () => family('issues')?.click())
+    expect(document.querySelectorAll('[data-gitlab-trigger]')).toHaveLength(3)
+    expect(trigger('issues', 'every')).not.toBeNull()
+    expect(trigger('merge_request', 'every')).toBeNull()
+
+    // Deselecting the last subject leaves nothing to schedule.
+    await act(async () => family('issues')?.click())
+    expect(document.querySelectorAll('[data-gitlab-trigger]')).toHaveLength(0)
+  })
+
+  it('carries the review format inside the merge-request card, with no None tile', async () => {
     mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
     await pickProject()
 
-    // The section exists on the GitLab pane, worded for merge requests.
-    const disclosure = clickText('MR review')
-    expect(disclosure).toBeDefined()
-    await act(async () => disclosure?.click())
-    expect(document.body.textContent).toContain('Run note')
+    expect(document.body.textContent).toContain('Review format')
+    expect(format('details')?.getAttribute('aria-pressed')).toBe('true')
+    expect(format('none')).toBeNull()
 
-    // "None" turns both axes off in one click.
-    await act(async () => clickText('None')?.click())
+    // Turning every Custom capability off is the no-review state the None tile used to be.
+    await act(async () => format('custom')?.click())
+    expect(document.body.textContent).toContain('Run note')
+    await act(async () => checkbox('Inline comments')?.click())
+    await act(async () => checkbox('Run note')?.click())
     await act(async () => clickText('Connect')?.click())
 
     expect(mocks.createGitlabHook).toHaveBeenCalledWith(
@@ -305,11 +393,20 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     )
   })
 
+  it('folds the review format away with the merge-request card', async () => {
+    mocks.fetchGitlabProjects.mockResolvedValue([project])
+    await render()
+    await pickProject()
+    await act(async () => family('merge_request')?.click())
+
+    expect(document.body.textContent).not.toContain('Review format')
+  })
+
   it('names GitLab tier semantics in the review copy, not GitHub ones', async () => {
     mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
     await pickProject()
-    await act(async () => clickText('MR review')?.click())
+    await act(async () => format('custom')?.click())
 
     const help = Array.from(document.querySelectorAll('label[title]')).map((row) => row.getAttribute('title') ?? '')
     // §15.3: request-changes needs the bot to be a current reviewer; approval is its own act.
@@ -335,7 +432,10 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     await act(async () => clickText('Connect')?.click())
 
     expect(mocks.createGitlabHook.mock.calls.map(([body]) => body.family)).toEqual(['issues', 'merge_request'])
-    expect(mocks.createGitlabHook.mock.calls.flatMap(([body]) => body.events)).toEqual(['issues:*', 'merge_request:*'])
+    expect(mocks.createGitlabHook.mock.calls.flatMap(([body]) => body.events)).toEqual([
+      'issues:opened',
+      'merge_request:opened'
+    ])
   })
 
   it('drops the separate comments row and mention checkbox the form used to expose', async () => {

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -7,7 +7,8 @@ import {
   useMemo,
   useRef,
   useState,
-  type KeyboardEvent as ReactKeyboardEvent
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode
 } from 'react'
 import useSWR from 'swr'
 import LarkFeishuSwitcher, { type LarkFeishuTarget } from '@/components/LarkFeishuSwitcher'
@@ -72,6 +73,7 @@ import {
   githubFamilyCarriesReviews,
   githubFamilySubscription,
   githubMentionUsage,
+  githubTriggerTooltip,
   type GhFamily,
   type GhTriggerMode
 } from '@/lib/github-events'
@@ -84,6 +86,7 @@ import {
   gitlabFamilyCarriesReviews,
   gitlabFamilySubscription,
   gitlabMentionUsage,
+  gitlabTriggerTooltip,
   type GlFamily,
   type GlTriggerMode
 } from '@/lib/gitlab-events'
@@ -142,37 +145,185 @@ export type FeishuRegion = LarkFeishuTarget
 
 type GithubRepoChoice = GithubRepoDto & { installationId: string }
 
-/** The trigger cadences (design vocabulary: "when created / updated / mention only"
- *  — the stored event patterns + the mentionOnly flag encode the choice).
- *  `desc` stays a one-liner so the design's 3-up tiles keep equal height. */
-const GH_TRIGGER_TILES: { mode: GhTriggerMode; label: string; desc: string }[] = [
-  { mode: 'first', label: GH_TRIGGER_LABEL.first, desc: 'When opened, plus later @mentions.' },
-  {
-    mode: 'every',
-    label: GH_TRIGGER_LABEL.every,
-    desc: 'Updates, plus replies for selected issues and PRs.'
-  },
-  {
-    mode: 'mention',
-    label: GH_TRIGGER_LABEL.mention,
-    desc: 'Only when @-mentioned.'
-  }
-]
+/** One cadence choice offered inside a family card. */
+interface TriggerTile<M extends string> {
+  mode: M
+  label: string
+  desc: string
+}
 
-/** The GitLab cadences — the same three choices, worded like GitHub's. */
-const GL_TRIGGER_TILES: { mode: GlTriggerMode; label: string; desc: string }[] = [
-  { mode: 'first', label: GL_TRIGGER_LABEL.first, desc: 'When opened, plus later @mentions.' },
-  {
-    mode: 'every',
-    label: GL_TRIGGER_LABEL.every,
-    desc: 'Updates, plus replies for selected issues and MRs.'
-  },
-  {
-    mode: 'mention',
-    label: GL_TRIGGER_LABEL.mention,
-    desc: 'Only when @-mentioned.'
-  }
-]
+/** The cadences each GitHub subject offers, worded for that subject. Issues trade
+ *  "any update" for "labeled" here: a label is the signal a triaging agent waits
+ *  on, and the agent page still offers the full four. */
+const GH_TRIGGER_TILES: Partial<Record<GhFamily, TriggerTile<GhTriggerMode>[]>> = {
+  pull_request: [
+    { mode: 'first', label: GH_TRIGGER_LABEL.first, desc: 'A PR is opened or marked ready' },
+    { mode: 'every', label: GH_TRIGGER_LABEL.every, desc: 'Every push, review or comment' },
+    { mode: 'mention', label: GH_TRIGGER_LABEL.mention, desc: 'Only when the agent is @-mentioned' }
+  ],
+  issues: [
+    { mode: 'first', label: GH_TRIGGER_LABEL.first, desc: 'A new issue is filed' },
+    { mode: 'labeled', label: GH_TRIGGER_LABEL.labeled, desc: 'A watched label is applied' },
+    { mode: 'mention', label: GH_TRIGGER_LABEL.mention, desc: 'Only when the agent is @-mentioned' }
+  ]
+}
+
+/** The GitLab cadences — the same shape, minus the label mode: GitLab label
+ *  events are not a verified subscription here, so its issues keep the three
+ *  modes the wire already carries. */
+const GL_TRIGGER_TILES: Partial<Record<GlFamily, TriggerTile<GlTriggerMode>[]>> = {
+  merge_request: [
+    { mode: 'first', label: GL_TRIGGER_LABEL.first, desc: 'An MR is opened or marked ready' },
+    { mode: 'every', label: GL_TRIGGER_LABEL.every, desc: 'Every push, review or comment' },
+    { mode: 'mention', label: GL_TRIGGER_LABEL.mention, desc: 'Only when the agent is @-mentioned' }
+  ],
+  issues: [
+    { mode: 'first', label: GL_TRIGGER_LABEL.first, desc: 'A new issue is filed' },
+    { mode: 'every', label: GL_TRIGGER_LABEL.every, desc: 'Every update or comment' },
+    { mode: 'mention', label: GL_TRIGGER_LABEL.mention, desc: 'Only when the agent is @-mentioned' }
+  ]
+}
+
+/**
+ * "Listen for": one full-width card per subject family. Unchecked it is a slim
+ * row — glyph, name, checkbox. Checked, that row becomes the card's tinted
+ * header band and the body opens beneath it with the subject's own "Trigger
+ * when" tiles, plus whatever else rides that subject (the review format, on the
+ * change-proposal family). A code-host hook row is (agent, repo, family) and
+ * carries its own cadence, so one wizard pass can watch PRs on every update and
+ * issues on a label. A family the picked repository already watches is not on
+ * offer — its row is inert and says so.
+ */
+function FamilyCards<F extends string, M extends string>({
+  families,
+  tilesOf,
+  takenOf,
+  onOf,
+  onToggle,
+  modeOf,
+  onPick,
+  familyAttr,
+  triggerAttr,
+  titleOf,
+  bodyExtra
+}: {
+  families: readonly { fam: F; pill: string; icon: string; label: string }[]
+  tilesOf: (fam: F) => readonly TriggerTile<M>[]
+  takenOf: (fam: F) => boolean
+  onOf: (fam: F) => boolean
+  onToggle: (fam: F) => void
+  modeOf: (fam: F) => M
+  onPick: (fam: F, mode: M) => void
+  familyAttr: 'data-github-family' | 'data-gitlab-family'
+  triggerAttr: 'data-github-trigger' | 'data-gitlab-trigger'
+  /** Hover copy that goes BEYOND the tile's own subtitle, which the user can already read. */
+  titleOf: (mode: M) => string
+  bodyExtra?: (fam: F) => ReactNode
+}) {
+  return (
+    <>
+      <div className="fldlbl mb-2">Listen for</div>
+      <div className="mb-4 flex flex-col gap-[9px]">
+        {families.map((row) => {
+          const taken = takenOf(row.fam)
+          const on = !taken && onOf(row.fam)
+          const active = modeOf(row.fam)
+          const extra = on ? bodyExtra?.(row.fam) : null
+          return (
+            <div
+              key={row.fam}
+              className={`overflow-hidden rounded-[9px] border ${
+                on ? 'border-(--brand)' : 'border-(--border-default)'
+              }`}
+            >
+              <div
+                {...{ [familyAttr]: row.fam }}
+                aria-disabled={taken}
+                title={taken ? 'Already watched — change its trigger on the agent page' : undefined}
+                className={`flex min-w-0 items-center gap-[9px] px-3 py-[10px] ${
+                  taken ? 'cursor-default opacity-55' : 'cursor-pointer'
+                } ${on ? 'bg-(--brand-soft)' : 'bg-(--surface-card)'}`}
+                onClick={() => {
+                  if (!taken) onToggle(row.fam)
+                }}
+              >
+                <Icon
+                  name={row.icon}
+                  size={16}
+                  color={on ? 'var(--brand)' : 'var(--text-tertiary)'}
+                  className="flex-none"
+                />
+                <span className="min-w-0 flex-1 truncate font-sans text-[12.5px] font-semibold leading-normal">
+                  {row.label}
+                </span>
+                {taken && (
+                  <span className="flex-none font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                    already watched
+                  </span>
+                )}
+                <span
+                  className={`flex h-[18px] w-[18px] flex-none items-center justify-center rounded-[5px] border-[1.5px] ${
+                    on ? 'border-(--brand) bg-(--brand)' : 'border-(--border-default) bg-(--surface-card)'
+                  }`}
+                >
+                  {on && <Icon name="check" size={12} color="#fff" />}
+                </span>
+              </div>
+              {on && (
+                <div className="flex flex-col gap-3 border-t border-(--brand) bg-(--surface-card) px-3 py-3">
+                  <div>
+                    <div className="fldlbl mb-2">Trigger when</div>
+                    <div
+                      className="grid grid-cols-1 gap-2 desktop:grid-cols-3"
+                      role="group"
+                      aria-label={`Trigger for ${row.pill}`}
+                    >
+                      {tilesOf(row.fam).map((tile) => {
+                        const picked = tile.mode === active
+                        return (
+                          <button
+                            key={tile.mode}
+                            type="button"
+                            {...{ [triggerAttr]: `${row.fam}:${tile.mode}` }}
+                            aria-pressed={picked}
+                            title={titleOf(tile.mode)}
+                            className={`flex min-w-0 cursor-pointer items-start gap-[9px] rounded-[9px] border px-3 py-[10px] text-left ${
+                              picked
+                                ? 'border-(--brand) bg-(--brand-soft)'
+                                : 'border-(--border-default) bg-(--surface-card)'
+                            }`}
+                            onClick={() => onPick(row.fam, tile.mode)}
+                          >
+                            <span
+                              className={`mt-[1px] flex h-4 w-4 flex-none items-center justify-center rounded-full border-[1.5px] bg-(--surface-card) ${
+                                picked ? 'border-(--brand)' : 'border-(--border-default)'
+                              }`}
+                            >
+                              {picked && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
+                            </span>
+                            <span className="min-w-0 flex-1">
+                              <span className="block font-sans text-[12.5px] font-semibold leading-normal">
+                                {tile.label}
+                              </span>
+                              <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+                                {tile.desc}
+                              </span>
+                            </span>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
+                  {extra && <div className="border-t border-(--border-subtle) pt-3">{extra}</div>}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </>
+  )
+}
 
 // "12d ago" for the freed-bot sub-line; null ⇒ the bot was never installed.
 function fmtAgo(iso: string | null): string {
@@ -295,7 +446,10 @@ export default function AddIntegrationModal({
   const [ghQ, setGhQ] = useState('')
   const [ghExactRepoLoading, setGhExactRepoLoading] = useState(false)
   const [ghFams, setGhFams] = useState<Set<GhFamily>>(new Set(GH_DEFAULT_FAMILIES))
-  const [ghMode, setGhMode] = useState<GhTriggerMode>(GH_DEFAULT_TRIGGER_MODE)
+  // Cadence is per SUBJECT — one hook row per family, each with its own trigger.
+  // Unset ⇒ the shared default, so a newly ticked family needs no seeding here.
+  const [ghModes, setGhModes] = useState<Partial<Record<GhFamily, GhTriggerMode>>>({})
+  const ghModeOf = (fam: GhFamily): GhTriggerMode => ghModes[fam] ?? GH_DEFAULT_TRIGGER_MODE
   const [ghReviewPolicy, setGhReviewPolicy] = useState<HookReviewPolicy>('full')
   const [ghReportingMode, setGhReportingMode] = useState<HookReportingMode>('check')
   const [ghSyncing, setGhSyncing] = useState(false)
@@ -396,7 +550,8 @@ export default function AddIntegrationModal({
   const [glQ, setGlQ] = useState('')
   const gl = useGitlabProjects(platform === 'gitlab', glQ)
   const [glFams, setGlFams] = useState<Set<GlFamily>>(new Set(GL_DEFAULT_FAMILIES))
-  const [glMode, setGlMode] = useState<GlTriggerMode>(GL_DEFAULT_TRIGGER_MODE)
+  const [glModes, setGlModes] = useState<Partial<Record<GlFamily, GlTriggerMode>>>({})
+  const glModeOf = (fam: GlFamily): GlTriggerMode => glModes[fam] ?? GL_DEFAULT_TRIGGER_MODE
   const [glReviewPolicy, setGlReviewPolicy] = useState<HookReviewPolicy>('full')
   const [glReportingMode, setGlReportingMode] = useState<HookReportingMode>('check')
 
@@ -875,9 +1030,10 @@ export default function AddIntegrationModal({
     (agent.workspace.mode === 'gitlab' && agent.workspace.projectId === glProject) ||
     authorizedRepos.some((r) => repoAuthProvider(r) === 'gitlab' && r.repoId === glProject)
 
-  // One subscription = one hook row PER SELECTED FAMILY on this agent, all named
-  // after the project. The creates run in order; a failure part-way leaves the
-  // earlier families created, which the refreshed picker then shows as watched.
+  // One subscription = one hook row PER SELECTED FAMILY on this agent, each with
+  // its OWN cadence, all named after the project. The creates run in order; a
+  // failure part-way leaves the earlier families created, which the refreshed
+  // picker then shows as watched.
   const submitGitlab = async () => {
     if (busyRef.current || !glProject || glSelectedFams.length === 0) return
     if (glAlreadyWatched) {
@@ -904,7 +1060,7 @@ export default function AddIntegrationModal({
           name: glPicked?.projectPath ?? glProject,
           projectId: glProject,
           family: fam,
-          ...gitlabFamilySubscription(fam, glMode),
+          ...gitlabFamilySubscription(fam, glModeOf(fam)),
           reviewPolicy: reviews ? glEffectiveReviewPolicy : 'off',
           reportingMode: reviews ? glEffectiveReportingMode : 'off'
         })
@@ -918,9 +1074,10 @@ export default function AddIntegrationModal({
     }
   }
 
-  // One subscription = one hook row PER SELECTED FAMILY on this agent, all named
-  // after the repo. The CP resolves owner/repo to the numeric id, 400s anything
-  // outside the grant, and 409s a (repo, family) this agent already watches.
+  // One subscription = one hook row PER SELECTED FAMILY on this agent, each with
+  // its OWN cadence, all named after the repo. The CP resolves owner/repo to the
+  // numeric id, 400s anything outside the grant, and 409s a (repo, family) this
+  // agent already watches.
   const submitGithub = async () => {
     if (busyRef.current || !ghRepoPick || ghSelectedFams.length === 0) return
     if (repoFullyWatched(ghRepoPick)) {
@@ -976,7 +1133,7 @@ export default function AddIntegrationModal({
           name: ghRepoPick,
           repoFullName: ghRepoPick,
           family: fam,
-          ...githubFamilySubscription(fam, ghMode),
+          ...githubFamilySubscription(fam, ghModeOf(fam)),
           reviewPolicy: reviews ? ghEffectiveReviewPolicy : 'off',
           reportingMode: reviews ? ghEffectiveReportingMode : 'off',
           gateMode: 'informational'
@@ -1615,108 +1772,52 @@ export default function AddIntegrationModal({
                     </div>
                   )
                 })()}
-                {/* Design: compact 3-up tile grids — 16px lead glyph, 12.5px title,
-                    11.5px fragment subtitle; checkbox / radio per tile. */}
-                <div className="fldlbl mb-2">Listen for</div>
-                <div className="mb-4 grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-2">
-                  {GH_FAMILIES.map((r) => {
-                    // A family the picked repo is already watched for is not a
-                    // second trigger — it is edited on the agent page.
-                    const taken = ghPickedWatched.has(r.fam)
-                    const on = !taken && ghFams.has(r.fam)
-                    return (
-                      <div
-                        key={r.fam}
-                        data-github-family={r.fam}
-                        aria-disabled={taken}
-                        title={taken ? 'Already watched — change its trigger on the agent page' : undefined}
-                        className={`flex min-w-0 items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
-                          taken ? 'cursor-default opacity-55' : 'cursor-pointer'
-                        } ${on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'}`}
-                        onClick={() => {
-                          if (!taken) toggleGhFam(r.fam)
+                <FamilyCards
+                  families={GH_FAMILIES}
+                  tilesOf={(fam) => GH_TRIGGER_TILES[fam] ?? []}
+                  // A family the picked repo is already watched for is not a
+                  // second trigger — it is edited on the agent page.
+                  takenOf={(fam) => ghPickedWatched.has(fam)}
+                  onOf={(fam) => ghFams.has(fam)}
+                  onToggle={toggleGhFam}
+                  modeOf={ghModeOf}
+                  onPick={(fam, mode) => setGhModes((prev) => ({ ...prev, [fam]: mode }))}
+                  familyAttr="data-github-family"
+                  triggerAttr="data-github-trigger"
+                  titleOf={(mode) =>
+                    mode === 'mention'
+                      ? githubMentionUsage(agent.name, ghTeamOwner)
+                      : githubTriggerTooltip(mode, agent.name)
+                  }
+                  // Reviews and Checks ride the change-proposal subject, so the
+                  // format section lives in that card's body and nowhere else.
+                  bodyExtra={(fam) =>
+                    githubFamilyCarriesReviews(fam) ? (
+                      <GithubReviewSettings
+                        layout="format"
+                        value={{ reviewPolicy: ghReviewPolicy, reportingMode: ghReportingMode }}
+                        onReviewPolicyChange={(policy) => {
+                          setGhReviewPolicy(policy)
+                          setErr(null)
                         }}
-                      >
-                        <Icon
-                          name={r.icon}
-                          size={16}
-                          color={on ? 'var(--brand)' : 'var(--text-tertiary)'}
-                          className="mt-[1px] flex-none"
-                        />
-                        <span className="min-w-0 flex-1">
-                          <span className="block font-sans text-[12.5px] font-semibold leading-normal">{r.label}</span>
-                          <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-                            {taken ? 'already watched' : r.desc}
-                          </span>
-                        </span>
-                        <span
-                          className={`mt-[1px] flex h-[18px] w-[18px] flex-none items-center justify-center rounded-[5px] border-[1.5px] ${
-                            on ? 'border-(--brand) bg-(--brand)' : 'border-(--border-default) bg-(--surface-card)'
-                          }`}
-                        >
-                          {on && <Icon name="check" size={12} color="#fff" />}
-                        </span>
-                      </div>
-                    )
-                  })}
-                </div>
-                <div className="fldlbl mb-2">Trigger when</div>
-                <div className="mb-4 grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-3">
-                  {GH_TRIGGER_TILES.map((m) => {
-                    const on = ghMode === m.mode
-                    return (
-                      <div
-                        key={m.mode}
-                        title={m.mode === 'mention' ? githubMentionUsage(agent.name, ghTeamOwner) : undefined}
-                        className={`flex min-w-0 cursor-pointer items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
-                          on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'
-                        }`}
-                        onClick={() => setGhMode(m.mode)}
-                      >
-                        <span
-                          className={`mt-[1px] flex h-4 w-4 flex-none items-center justify-center rounded-full border-[1.5px] bg-(--surface-card) ${
-                            on ? 'border-(--brand)' : 'border-(--border-default)'
-                          }`}
-                        >
-                          {on && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
-                        </span>
-                        <span className="min-w-0 flex-1">
-                          <span className="block font-sans text-[12.5px] font-semibold leading-normal">{m.label}</span>
-                          <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-                            {m.desc}
-                          </span>
-                        </span>
-                      </div>
-                    )
-                  })}
-                </div>
-                {/* Reviews and Checks live on the pull-request row, so the section
-                    appears only when that family is part of the pick. */}
-                {ghPrSelected && (
-                  <div className="mb-4">
-                    <GithubReviewSettings
-                      value={{ reviewPolicy: ghReviewPolicy, reportingMode: ghReportingMode }}
-                      onReviewPolicyChange={(policy) => {
-                        setGhReviewPolicy(policy)
-                        setErr(null)
-                      }}
-                      onReportingModeChange={(m) => {
-                        setGhReportingMode(m)
-                        setErr(null)
-                      }}
-                      repoAccess={ghRepoAccess}
-                      installation={ghSelectedInstallation}
-                      publicRepo={ghSelectedRepo ? !ghSelectedRepo.private : false}
-                      repoSelected={Boolean(ghRepoPick)}
-                      canAuthorizeRepo={
-                        canEditAgent &&
-                        (ghRepoAccess === 'none' || ghSelectedIsWorkspace || ghSelectedAuthorization !== undefined)
-                      }
-                      authorizingRepo={ghAccessSaving}
-                      onAuthorizeRepo={() => void authorizeSelectedRepo()}
-                    />
-                  </div>
-                )}
+                        onReportingModeChange={(m) => {
+                          setGhReportingMode(m)
+                          setErr(null)
+                        }}
+                        repoAccess={ghRepoAccess}
+                        installation={ghSelectedInstallation}
+                        publicRepo={ghSelectedRepo ? !ghSelectedRepo.private : false}
+                        repoSelected={Boolean(ghRepoPick)}
+                        canAuthorizeRepo={
+                          canEditAgent &&
+                          (ghRepoAccess === 'none' || ghSelectedIsWorkspace || ghSelectedAuthorization !== undefined)
+                        }
+                        authorizingRepo={ghAccessSaving}
+                        onAuthorizeRepo={() => void authorizeSelectedRepo()}
+                      />
+                    ) : null
+                  }
+                />
               </>
             )}
           </>
@@ -1786,97 +1887,40 @@ export default function AddIntegrationModal({
                     </span>
                   </div>
                 )}
-                <div className="fldlbl mb-2">Listen for</div>
-                <div className="mb-4 grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-2">
-                  {GL_FAMILIES.map((r) => {
-                    // A family the picked project is already watched for is not a
-                    // second trigger — it is edited on the agent page.
-                    const taken = glPickedWatched.has(r.fam)
-                    const on = !taken && glFams.has(r.fam)
-                    return (
-                      <div
-                        key={r.fam}
-                        data-gitlab-family={r.fam}
-                        aria-disabled={taken}
-                        title={taken ? 'Already watched — change its trigger on the agent page' : undefined}
-                        className={`flex min-w-0 items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
-                          taken ? 'cursor-default opacity-55' : 'cursor-pointer'
-                        } ${on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'}`}
-                        onClick={() => {
-                          if (!taken) toggleGlFam(r.fam)
+                <FamilyCards
+                  families={GL_FAMILIES}
+                  tilesOf={(fam) => GL_TRIGGER_TILES[fam] ?? []}
+                  // A family the picked project is already watched for is not a
+                  // second trigger — it is edited on the agent page.
+                  takenOf={(fam) => glPickedWatched.has(fam)}
+                  onOf={(fam) => glFams.has(fam)}
+                  onToggle={toggleGlFam}
+                  modeOf={glModeOf}
+                  onPick={(fam, mode) => setGlModes((prev) => ({ ...prev, [fam]: mode }))}
+                  familyAttr="data-gitlab-family"
+                  triggerAttr="data-gitlab-trigger"
+                  titleOf={(mode) =>
+                    mode === 'mention' ? gitlabMentionUsage(agent.name) : gitlabTriggerTooltip(mode, agent.name)
+                  }
+                  // Reviews and the run note ride the merge-request subject only.
+                  bodyExtra={(fam) =>
+                    gitlabFamilyCarriesReviews(fam) ? (
+                      <GitlabReviewSettings
+                        layout="format"
+                        value={{ reviewPolicy: glReviewPolicy, reportingMode: glReportingMode }}
+                        onReviewPolicyChange={(policy) => {
+                          setGlReviewPolicy(policy)
+                          setErr(null)
                         }}
-                      >
-                        <Icon
-                          name={r.icon}
-                          size={16}
-                          color={on ? 'var(--brand)' : 'var(--text-tertiary)'}
-                          className="mt-[1px] flex-none"
-                        />
-                        <span className="min-w-0 flex-1">
-                          <span className="block font-sans text-[12.5px] font-semibold leading-normal">{r.label}</span>
-                          <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-                            {taken ? 'already watched' : r.desc}
-                          </span>
-                        </span>
-                        <span
-                          className={`mt-[1px] flex h-[18px] w-[18px] flex-none items-center justify-center rounded-[5px] border-[1.5px] ${
-                            on ? 'border-(--brand) bg-(--brand)' : 'border-(--border-default) bg-(--surface-card)'
-                          }`}
-                        >
-                          {on && <Icon name="check" size={12} color="#fff" />}
-                        </span>
-                      </div>
-                    )
-                  })}
-                </div>
-                <div className="fldlbl mb-2">Trigger when</div>
-                <div className="mb-4 grid grid-cols-1 gap-[9px] min-[440px]:grid-cols-3">
-                  {GL_TRIGGER_TILES.map((m) => {
-                    const on = glMode === m.mode
-                    return (
-                      <div
-                        key={m.mode}
-                        data-gitlab-trigger={m.mode}
-                        title={m.mode === 'mention' ? gitlabMentionUsage(agent.name) : undefined}
-                        className={`flex min-w-0 cursor-pointer items-start gap-[9px] rounded-[9px] border px-3 py-[10px] ${
-                          on ? 'border-(--brand) bg-(--brand-soft)' : 'border-(--border-default) bg-(--surface-card)'
-                        }`}
-                        onClick={() => setGlMode(m.mode)}
-                      >
-                        <span
-                          className={`mt-[1px] flex h-4 w-4 flex-none items-center justify-center rounded-full border-[1.5px] bg-(--surface-card) ${
-                            on ? 'border-(--brand)' : 'border-(--border-default)'
-                          }`}
-                        >
-                          {on && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
-                        </span>
-                        <span className="min-w-0 flex-1">
-                          <span className="block font-sans text-[12.5px] font-semibold leading-normal">{m.label}</span>
-                          <span className="mt-[2px] block font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-                            {m.desc}
-                          </span>
-                        </span>
-                      </div>
-                    )
-                  })}
-                </div>
-                {/* Reviews and the run note live on the merge-request row only. */}
-                {glMrSelected && (
-                  <div className="mb-4">
-                    <GitlabReviewSettings
-                      value={{ reviewPolicy: glReviewPolicy, reportingMode: glReportingMode }}
-                      onReviewPolicyChange={(policy) => {
-                        setGlReviewPolicy(policy)
-                        setErr(null)
-                      }}
-                      onReportingModeChange={(mode) => {
-                        setGlReportingMode(mode)
-                        setErr(null)
-                      }}
-                      projectBotReady={!glPicked?.binding || glPicked.binding.state !== 'provisioning'}
-                    />
-                  </div>
-                )}
+                        onReportingModeChange={(mode) => {
+                          setGlReportingMode(mode)
+                          setErr(null)
+                        }}
+                        projectBotReady={!glPicked?.binding || glPicked.binding.state !== 'provisioning'}
+                      />
+                    ) : null
+                  }
+                />
               </>
             )}
           </>

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -157,13 +157,15 @@ interface TriggerTile<M extends string> {
  *  on, and the agent page still offers the full four. */
 const GH_TRIGGER_TILES: Partial<Record<GhFamily, TriggerTile<GhTriggerMode>[]>> = {
   pull_request: [
-    { mode: 'first', label: GH_TRIGGER_LABEL.first, desc: 'A PR is opened or marked ready' },
-    { mode: 'every', label: GH_TRIGGER_LABEL.every, desc: 'Every push, review or comment' },
+    // Subtitles promise only what the ingress admits: ready-for-review and
+    // submitted formal reviews are deliberately silent there.
+    { mode: 'first', label: GH_TRIGGER_LABEL.first, desc: 'A new PR is opened' },
+    { mode: 'every', label: GH_TRIGGER_LABEL.every, desc: 'Every new commit or reply' },
     { mode: 'mention', label: GH_TRIGGER_LABEL.mention, desc: 'Only when the agent is @-mentioned' }
   ],
   issues: [
     { mode: 'first', label: GH_TRIGGER_LABEL.first, desc: 'A new issue is filed' },
-    { mode: 'labeled', label: GH_TRIGGER_LABEL.labeled, desc: 'A watched label is applied' },
+    { mode: 'labeled', label: GH_TRIGGER_LABEL.labeled, desc: 'A label is applied' },
     { mode: 'mention', label: GH_TRIGGER_LABEL.mention, desc: 'Only when the agent is @-mentioned' }
   ]
 }
@@ -173,8 +175,9 @@ const GH_TRIGGER_TILES: Partial<Record<GhFamily, TriggerTile<GhTriggerMode>[]>> 
  *  modes the wire already carries. */
 const GL_TRIGGER_TILES: Partial<Record<GlFamily, TriggerTile<GlTriggerMode>[]>> = {
   merge_request: [
-    { mode: 'first', label: GL_TRIGGER_LABEL.first, desc: 'An MR is opened or marked ready' },
-    { mode: 'every', label: GL_TRIGGER_LABEL.every, desc: 'Every push, review or comment' },
+    // Same honesty rule: draft/ready flips are dropped by ingress normalization.
+    { mode: 'first', label: GL_TRIGGER_LABEL.first, desc: 'A new MR is opened' },
+    { mode: 'every', label: GL_TRIGGER_LABEL.every, desc: 'Every new commit or reply' },
     { mode: 'mention', label: GL_TRIGGER_LABEL.mention, desc: 'Only when the agent is @-mentioned' }
   ],
   issues: [

--- a/packages/web/src/components/console/views/AgentDetailView.codehost.test.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.codehost.test.tsx
@@ -237,7 +237,21 @@ describe('AgentDetailView, code-host repository blocks', () => {
     expect(menuItem('Add Issues')).toBeUndefined()
   })
 
+  it('offers the label cadence on an issues row only', async () => {
+    const scope = await render()
+    // The menu is body-portaled, so read it off the document after opening.
+    await act(async () => scope.querySelector<HTMLElement>('[aria-label="Trigger for acme/api Issues"]')!.click())
+    expect(menuItem('labeled')).toBeTruthy()
+    expect(menuItem('update')).toBeTruthy()
+    await act(async () => menuItem('@-mention')!.click())
+
+    await act(async () => scope.querySelector<HTMLElement>('[aria-label="Trigger for acme/api PRs"]')!.click())
+    expect(menuItem('labeled')).toBeUndefined()
+    expect(menuItem('update')).toBeTruthy()
+  })
+
   it('creates the missing family row at the default trigger', async () => {
+    // The same default the wizard opens a new subject on: the opening itself.
     const scope = await render()
     await act(async () => byTitle(scope, 'Watch another subject')[0]!.click())
     await act(async () => menuItem('Add Pull requests')!.click())
@@ -247,7 +261,7 @@ describe('AgentDetailView, code-host repository blocks', () => {
         agentId: 'agent-1',
         repoFullName: 'acme/web',
         family: 'pull_request',
-        events: ['pull_request:*', 'issue_comment:created'],
+        events: ['pull_request:opened'],
         commentFamilies: ['pull_request'],
         mentionOnly: false
       })

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -111,6 +111,7 @@ import {
   githubFamilyTile,
   githubHookFamily,
   githubHookNeedsNormalization,
+  githubTriggerModes,
   githubTriggerTooltip,
   triggerModeOf,
   type GhFamily,
@@ -525,6 +526,11 @@ export default function AgentDetailView() {
   const ghRowCarriesReviews = (h: HookDto) => {
     const fam = githubHookFamily(h)
     return !!fam && githubFamilyCarriesReviews(fam)
+  }
+  // The cadences THIS row may pick: label events ride issues alone.
+  const ghRowTriggerModes = (h: HookDto): readonly GhTriggerMode[] => {
+    const fam = githubHookFamily(h)
+    return fam ? githubTriggerModes(fam) : GH_TRIGGER_MODES
   }
   const glRowPill = (h: HookDto) => {
     const fam = gitlabHookFamily(h)
@@ -1745,7 +1751,8 @@ export default function AgentDetailView() {
                               {/* Trigger — the same ⚡ dropdown the IM channel rows carry, mention last. */}
                               <TriggerSelect
                                 className="w-[126px] flex-none"
-                                options={GH_TRIGGER_MODES.map((mode) => ({
+                                // Per family: the label cadence exists on issues alone.
+                                options={ghRowTriggerModes(h).map((mode) => ({
                                   value: mode,
                                   label: GH_TRIGGER_PILL[mode],
                                   hint: githubTriggerTooltip(mode, da.name)

--- a/packages/web/src/lib/code-host-review-settings.test.ts
+++ b/packages/web/src/lib/code-host-review-settings.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   codeHostReviewCapabilities,
   codeHostReviewSettingsFromCapabilities,
+  REVIEW_FORMAT_DEFAULT,
+  REVIEW_FORMATS,
   REVIEW_PRESETS,
+  reviewFormatOf,
+  reviewFormatValue,
   reviewPolicyLabel,
   reviewPresetOf,
   withCapability,
@@ -77,6 +81,37 @@ describe('reviewPresetOf', () => {
   it('reads anything richer than brief as details', () => {
     expect(reviewPresetOf({ reviewPolicy: 'comment', reportingMode: 'check' })).toBe('details')
     expect(reviewPresetOf({ reviewPolicy: 'request_changes', reportingMode: 'off' })).toBe('details')
+  })
+})
+
+describe('reviewFormatOf', () => {
+  it('offers Brief, Details and Custom — never None', () => {
+    expect(REVIEW_FORMATS.map(({ id }) => id)).toEqual(['brief', 'details', 'custom'])
+    expect(REVIEW_FORMATS.map(({ label }) => label)).not.toContain('None')
+  })
+
+  it('opens on Details — the full set of capabilities', () => {
+    expect(REVIEW_FORMAT_DEFAULT).toEqual({ reviewPolicy: 'full', reportingMode: 'check' })
+    expect(reviewFormatOf(REVIEW_FORMAT_DEFAULT)).toBe('details')
+    expect(codeHostReviewCapabilities(REVIEW_FORMAT_DEFAULT)).toEqual({
+      inlineComments: true,
+      requestChanges: true,
+      approve: true,
+      statusCheck: true
+    })
+  })
+
+  it('reads the old None value and every hand-tuned mix as custom', () => {
+    expect(reviewFormatOf({ reviewPolicy: 'off', reportingMode: 'off' })).toBe('custom')
+    expect(reviewFormatOf({ reviewPolicy: 'request_changes', reportingMode: 'off' })).toBe('custom')
+    expect(reviewFormatOf({ reviewPolicy: 'comment', reportingMode: 'check' })).toBe('custom')
+    expect(reviewFormatOf({ reviewPolicy: 'comment', reportingMode: 'off' })).toBe('brief')
+  })
+
+  it('applies a preset value for the two preset tiles and none for custom', () => {
+    expect(reviewFormatValue('brief')).toEqual({ reviewPolicy: 'comment', reportingMode: 'off' })
+    expect(reviewFormatValue('details')).toEqual(REVIEW_FORMAT_DEFAULT)
+    expect(reviewFormatValue('custom')).toBeNull()
   })
 })
 

--- a/packages/web/src/lib/code-host-review-settings.ts
+++ b/packages/web/src/lib/code-host-review-settings.ts
@@ -52,6 +52,34 @@ export const REVIEW_PRESETS = [
 
 export type ReviewPresetId = (typeof REVIEW_PRESETS)[number]['id']
 
+/** The create surfaces' format row. `None` is not a tile there: turning every
+ *  Custom capability off IS the no-review state, and one fewer way to say the
+ *  same thing. Custom is a DISCLOSURE, not a value — it reveals the capability
+ *  checkboxes and leaves the current value alone until one is clicked. */
+export const REVIEW_FORMATS = [
+  { id: 'brief', label: 'Brief' },
+  { id: 'details', label: 'Details' },
+  { id: 'custom', label: 'Custom' }
+] as const satisfies ReadonlyArray<{ id: string; label: string }>
+
+export type ReviewFormatId = (typeof REVIEW_FORMATS)[number]['id']
+
+/** The format row's default: the full set — inline comments, request changes, approve, status check. */
+export const REVIEW_FORMAT_DEFAULT: CodeHostReviewSettingsValue = { reviewPolicy: 'full', reportingMode: 'check' }
+
+/** Which format tile a value reads as — anything but an exact Brief or Details is custom. */
+export function reviewFormatOf(value: CodeHostReviewSettingsValue): ReviewFormatId {
+  const exact = REVIEW_PRESETS.find(
+    (preset) => preset.value.reviewPolicy === value.reviewPolicy && preset.value.reportingMode === value.reportingMode
+  )
+  return exact?.id === 'brief' || exact?.id === 'details' ? exact.id : 'custom'
+}
+
+/** The value a format tile applies; `custom` applies none. */
+export function reviewFormatValue(id: ReviewFormatId): CodeHostReviewSettingsValue | null {
+  return REVIEW_PRESETS.find((preset) => preset.id === id)?.value ?? null
+}
+
 /** Which preset a stored value reads as; anything richer than "brief" is details. */
 export function reviewPresetOf(value: CodeHostReviewSettingsValue): ReviewPresetId {
   if (value.reviewPolicy === 'off' && value.reportingMode === 'off') return 'none'

--- a/packages/web/src/lib/github-events.test.ts
+++ b/packages/web/src/lib/github-events.test.ts
@@ -13,18 +13,30 @@ import {
   githubHookFamily,
   githubHookNeedsNormalization,
   githubMentionUsage,
+  githubTriggerModes,
   githubTriggerTooltip,
+  triggerModeOf,
   THREAD_COMMENT_EVENT
 } from './github-events'
 
 describe('GH_TRIGGER_LABEL', () => {
-  it('defaults new subscriptions to updated mode', () => {
-    expect(GH_DEFAULT_TRIGGER_MODE).toBe('every')
-    expect(GH_TRIGGER_LABEL[GH_DEFAULT_TRIGGER_MODE]).toBe('updated')
+  it('opens every new subscription on the opening itself', () => {
+    expect(GH_DEFAULT_TRIGGER_MODE).toBe('first')
+    expect(GH_TRIGGER_LABEL[GH_DEFAULT_TRIGGER_MODE]).toBe('opened')
   })
 
-  it('makes the restrictive mention mode explicit', () => {
-    expect(GH_TRIGGER_LABEL.mention).toBe('mention only')
+  it('spells the cadences out for the create surfaces', () => {
+    expect(GH_TRIGGER_LABEL.every).toBe('any update')
+    expect(GH_TRIGGER_LABEL.labeled).toBe('labeled')
+    expect(GH_TRIGGER_LABEL.mention).toBe('@-mention')
+  })
+})
+
+describe('githubTriggerModes', () => {
+  it('offers the label cadence on issues alone', () => {
+    expect(githubTriggerModes('issues')).toEqual(['first', 'every', 'labeled', 'mention'])
+    expect(githubTriggerModes('pull_request')).toEqual(['first', 'every', 'mention'])
+    expect(githubTriggerModes('push')).toEqual(['first', 'every', 'mention'])
   })
 })
 
@@ -32,6 +44,12 @@ describe('GH_TRIGGER_PILL', () => {
   it('keeps mention as the last segment, worded like the IM bar', () => {
     expect(GH_TRIGGER_MODES[GH_TRIGGER_MODES.length - 1]).toBe('mention')
     expect(GH_TRIGGER_PILL.mention).toBe('@-mention')
+  })
+
+  it('keeps the short forms the IM trigger bar shares', () => {
+    expect(GH_TRIGGER_PILL.first).toBe('create')
+    expect(GH_TRIGGER_PILL.every).toBe('update')
+    expect(GH_TRIGGER_PILL.labeled).toBe('labeled')
   })
 
   it('names the agent in the per-segment hover copy', () => {
@@ -60,9 +78,8 @@ describe('GH_TRIGGER_PILL', () => {
 })
 
 describe('GH_FAMILIES', () => {
-  it('describes the supported update signals without promising silent lifecycle or metadata events', () => {
-    expect(GH_FAMILIES.find(({ fam }) => fam === 'pull_request')?.desc).toBe('opened, revision changes, replies')
-    expect(GH_FAMILIES.find(({ fam }) => fam === 'issues')?.desc).toBe('opened, labels, replies')
+  it('names each subject without promising signals its cadences do not carry', () => {
+    expect(GH_FAMILIES.map(({ label }) => label)).toEqual(['Pull requests', 'Issues'])
   })
 
   it('omits the commit (push) family — the subscription flow is held back for now', () => {
@@ -117,6 +134,24 @@ describe('githubFamilySubscription', () => {
       commentFamilies: [],
       mentionOnly: false
     })
+  })
+
+  it('compiles the label cadence to the bare label event, with no reply scope', () => {
+    // A label is applied to a thread, not said in it — so no issue_comment
+    // subscription and no commentFamilies to narrow one.
+    expect(githubFamilySubscription('issues', 'labeled')).toEqual({
+      events: ['issues:labeled'],
+      commentFamilies: [],
+      mentionOnly: false
+    })
+  })
+
+  it('falls back to the default cadence for a family that has no label events', () => {
+    // The console never offers `labeled` off the issues subject; a stray pick
+    // must not compile `pull_request:labeled`.
+    expect(githubFamilySubscription('pull_request', 'labeled')).toEqual(
+      githubFamilySubscription('pull_request', GH_DEFAULT_TRIGGER_MODE)
+    )
   })
 
   it('never emits a pattern from another family', () => {
@@ -210,5 +245,31 @@ describe('githubHookNeedsNormalization', () => {
     expect(
       githubHookNeedsNormalization({ events: [THREAD_COMMENT_EVENT], commentFamilies: [], mentionOnly: false })
     ).toBe(false)
+  })
+
+  it('accepts a canonical labeled row', () => {
+    expect(githubHookNeedsNormalization({ events: ['issues:labeled'], commentFamilies: [], mentionOnly: false })).toBe(
+      false
+    )
+    // A labeled row that also carries a reply scope is not what the console writes.
+    expect(
+      githubHookNeedsNormalization({ events: ['issues:labeled'], commentFamilies: ['issues'], mentionOnly: false })
+    ).toBe(true)
+  })
+})
+
+describe('triggerModeOf', () => {
+  it('round-trips the label cadence, and only for the exact issues subscription', () => {
+    expect(triggerModeOf({ events: ['issues:labeled'], mentionOnly: false })).toBe('labeled')
+    // Anything wider than the bare label event is an update rule, not a label one.
+    expect(triggerModeOf({ events: ['issues:labeled', THREAD_COMMENT_EVENT], mentionOnly: false })).toBe('every')
+    expect(triggerModeOf({ events: ['pull_request:labeled'], mentionOnly: false })).toBe('every')
+    // The mention flag still wins over every events shape.
+    expect(triggerModeOf({ events: ['issues:labeled'], mentionOnly: true })).toBe('mention')
+  })
+
+  it('keeps reading the opened and updated encodings', () => {
+    expect(triggerModeOf({ events: ['issues:opened'], mentionOnly: false })).toBe('first')
+    expect(triggerModeOf({ events: ['issues:*', THREAD_COMMENT_EVENT], mentionOnly: false })).toBe('every')
   })
 })

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -7,15 +7,18 @@ import type { GithubCommentFamily, GithubHookFamily, HookCommentFamily } from '.
  * watched for both PRs and issues is two rows; the family is immutable, and the
  * row's stored `events` patterns plus its `mentionOnly` flag encode the mode:
  *
- *   created  → `family:opened` for the regular cadence; the relay additionally accepts a later explicit
+ *   opened   → `family:opened` for the regular cadence; the relay additionally accepts a later explicit
  *              @mention in the row's thread family (commits have no "first"
  *              — a push subscription is inherently per-push, so `push:*` rides
  *              along unchanged)
- *   updated  → `family:*` + `issue_comment:created` on a thread family, scoped
+ *   any update → `family:*` + `issue_comment:created` on a thread family, scoped
  *              to that family by `commentFamilies`. The relay ignores
  *              close/reopen and content edits; PR target-branch changes, other
  *              supported updates, and replies run.
- *   mention only → the same subscriptions as updated, with `mentionOnly: true` —
+ *   labeled  → `issues:labeled` alone. Issues-only, and the one cadence that
+ *              subscribes to no replies at all: a label is applied to a thread,
+ *              not said in it. An empty `labelFilter` means any label.
+ *   @-mention → the same subscriptions as any update, with `mentionOnly: true` —
  *              an event fires ONLY when its text (issue/PR body, comment body,
  *              commit message) @-mentions the assigned agent or the App. The
  *              agent handle targets one rule; the App handle broadcasts.
@@ -26,42 +29,22 @@ import type { GithubCommentFamily, GithubHookFamily, HookCommentFamily } from '.
  */
 
 export type GhFamily = GithubHookFamily
-export type GhTriggerMode = 'first' | 'every' | 'mention'
+export type GhTriggerMode = 'first' | 'every' | 'labeled' | 'mention'
 
 export interface GhFamilyTile {
   fam: GhFamily
   pill: string
   icon: string
   label: string
-  desc: string
 }
 
-// `desc` is the Add-integration tile subtitle — the design's compact grid, so
-// keep it to a short fragment that fits one or two 11.5px lines.
 // Every subject the wire knows, in display order — a stored push row still
-// reads its own label from here even though the console never offers one.
+// reads its own label from here even though the console never offers one. What
+// a subject listens to is stated by its cadence tiles, not a subtitle.
 const GH_ALL_FAMILIES: GhFamilyTile[] = [
-  {
-    fam: 'pull_request',
-    pill: 'PRs',
-    icon: 'git-pull-request',
-    label: 'Pull requests',
-    desc: 'opened, revision changes, replies'
-  },
-  {
-    fam: 'issues',
-    pill: 'Issues',
-    icon: 'circle-dot',
-    label: 'Issues',
-    desc: 'opened, labels, replies'
-  },
-  {
-    fam: 'push',
-    pill: 'Commits',
-    icon: 'git-commit-horizontal',
-    label: 'Commits',
-    desc: 'commits pushed to a branch'
-  }
+  { fam: 'pull_request', pill: 'PRs', icon: 'git-pull-request', label: 'Pull requests' },
+  { fam: 'issues', pill: 'Issues', icon: 'circle-dot', label: 'Issues' },
+  { fam: 'push', pill: 'Commits', icon: 'git-commit-horizontal', label: 'Commits' }
 ]
 
 // The subjects the console OFFERS. The `push` (Commits) tile is intentionally
@@ -80,19 +63,31 @@ export function githubFamilyCarriesReviews(fam: GhFamily): boolean {
 }
 
 /** The trigger modes in display order — mention deliberately last. */
-export const GH_TRIGGER_MODES: readonly GhTriggerMode[] = ['first', 'every', 'mention']
-/** The Add-integration cadence tiles' vocabulary ("Trigger when …"). */
+export const GH_TRIGGER_MODES: readonly GhTriggerMode[] = ['first', 'every', 'labeled', 'mention']
+/** The cadence vocabulary ("Trigger when …") the create surfaces spell out. */
 export const GH_TRIGGER_LABEL: Record<GhTriggerMode, string> = {
-  first: 'created',
-  every: 'updated',
-  mention: 'mention only'
+  first: 'opened',
+  every: 'any update',
+  labeled: 'labeled',
+  mention: '@-mention'
 }
-/** The agent-detail trigger bar's segment vocabulary (shared with the IM bar's
- *  "@-mention" wording; mention sits last there too). */
+/** The agent-detail trigger bar's segment vocabulary — deliberately shorter than
+ *  the labels above and shared with the IM bar, so the two bars read alike. */
 export const GH_TRIGGER_PILL: Record<GhTriggerMode, string> = {
   first: 'create',
   every: 'update',
+  labeled: 'labeled',
   mention: '@-mention'
+}
+
+/** Label events ride the issues subject alone — a PR row never offers or compiles one. */
+export function githubFamilySupportsMode(fam: GhFamily, mode: GhTriggerMode): boolean {
+  return mode !== 'labeled' || fam === 'issues'
+}
+
+/** The cadences one family offers, in display order. */
+export function githubTriggerModes(fam: GhFamily): readonly GhTriggerMode[] {
+  return GH_TRIGGER_MODES.filter((mode) => githubFamilySupportsMode(fam, mode))
 }
 
 /** Per-segment hover copy for the trigger bar. */
@@ -102,6 +97,8 @@ export function githubTriggerTooltip(mode: GhTriggerMode, agentName: string): st
       return `Runs when an issue or PR opens, plus later @${agentName} mentions.`
     case 'every':
       return 'Runs when an issue or PR is opened and on supported updates and replies (close, reopen and title/body edits are ignored).'
+    case 'labeled':
+      return 'Runs when a label is applied to an issue — any label while no label filter is set. Replies do not run it.'
     case 'mention':
       // Not "only @agent": the App handle is the repository-wide broadcast, and
       // an authorized native App review request bypasses cadence/mention/label.
@@ -122,8 +119,10 @@ export function githubMentionUsage(agentName: string, teamOwner?: string | null)
 /** The default create-form selection: pull requests only. */
 export const GH_DEFAULT_FAMILIES: readonly GhFamily[] = ['pull_request']
 
-/** The default create-form cadence: react to issue or pull-request updates. */
-export const GH_DEFAULT_TRIGGER_MODE: GhTriggerMode = 'every'
+/** The default cadence every create surface opens a new subject on: the opening
+ *  itself. The wizard's newly ticked family and the agent page's "add subject"
+ *  read the same constant, so a subject starts the same way wherever it is made. */
+export const GH_DEFAULT_TRIGGER_MODE: GhTriggerMode = 'first'
 
 /** The comment subscription that rides updated/mention-only modes for thread families. */
 export const THREAD_COMMENT_EVENT = 'issue_comment:created'
@@ -133,8 +132,16 @@ export function githubCommentFamilies(families: readonly HookCommentFamily[]): G
   return families.filter((family): family is GithubCommentFamily => family === 'issues' || family === 'pull_request')
 }
 
-/** Derive the explicit comment scope from the selected issue/PR families. */
-export function commentFamiliesForFamilies(fams: Iterable<GhFamily>): GithubCommentFamily[] {
+/** A cadence a family cannot carry falls back to the shared default; only the
+ *  issues-only `labeled` can reach this, and the console never offers it elsewhere. */
+function effectiveMode(fam: GhFamily, mode: GhTriggerMode): GhTriggerMode {
+  return githubFamilySupportsMode(fam, mode) ? mode : GH_DEFAULT_TRIGGER_MODE
+}
+
+/** Derive the explicit comment scope from the selected issue/PR families — a
+ *  labeled subscription listens to no replies, so it carries no scope. */
+export function commentFamiliesForFamilies(fams: Iterable<GhFamily>, mode?: GhTriggerMode): GithubCommentFamily[] {
+  if (mode === 'labeled') return []
   return [...fams].filter((fam): fam is GithubCommentFamily => fam === 'issues' || fam === 'pull_request')
 }
 
@@ -142,10 +149,16 @@ export function commentFamiliesForFamilies(fams: Iterable<GhFamily>): GithubComm
 export function eventsForFamilies(fams: Iterable<GhFamily>, mode: GhTriggerMode): string[] {
   const families = [...fams]
   const familyEvents = families.flatMap((fam) => {
-    if (mode !== 'first' || fam === 'push') return [`${fam}:*`]
+    const own = effectiveMode(fam, mode)
+    if (own === 'labeled') return [`${fam}:labeled`]
+    if (own !== 'first' || fam === 'push') return [`${fam}:*`]
     return [`${fam}:opened`]
   })
-  const listensForThreadReplies = mode !== 'first' && commentFamiliesForFamilies(families).length > 0
+  const listensForThreadReplies =
+    families.some((fam) => {
+      const own = effectiveMode(fam, mode)
+      return own === 'every' || own === 'mention'
+    }) && commentFamiliesForFamilies(families, mode).length > 0
   return listensForThreadReplies ? [...familyEvents, THREAD_COMMENT_EVENT] : familyEvents
 }
 
@@ -172,16 +185,22 @@ export interface GithubFamilySubscription {
 
 /** Compile one row's family+mode into the fields its create/update body carries. */
 export function githubFamilySubscription(fam: GhFamily, mode: GhTriggerMode): GithubFamilySubscription {
+  const own = effectiveMode(fam, mode)
   return {
-    events: eventsForFamilies([fam], mode),
-    commentFamilies: commentFamiliesForFamilies([fam]),
-    mentionOnly: mode === 'mention'
+    events: eventsForFamilies([fam], own),
+    commentFamilies: commentFamiliesForFamilies([fam], own),
+    mentionOnly: own === 'mention'
   }
 }
 
-/** Recover the trigger mode: the mentionOnly flag wins, `:opened`-only ⇒ created. */
+/** The one events shape the labeled cadence writes — its own round-trip anchor. */
+const LABELED_EVENT = 'issues:labeled'
+
+/** Recover the trigger mode: the mentionOnly flag wins, the bare label
+ *  subscription is labeled, and `:opened` ⇒ opened. */
 export function triggerModeOf(h: { events: string[]; mentionOnly: boolean }): GhTriggerMode {
   if (h.mentionOnly) return 'mention'
+  if (h.events.length === 1 && h.events[0] === LABELED_EVENT) return 'labeled'
   return h.events.some((e) => e.endsWith(':opened')) ? 'first' : 'every'
 }
 
@@ -205,6 +224,6 @@ export function githubHookNeedsNormalization(h: {
   }
   return (
     !sameMembers(h.events, eventsForFamilies(families, mode)) ||
-    !sameMembers(githubCommentFamilies(h.commentFamilies), commentFamiliesForFamilies(families))
+    !sameMembers(githubCommentFamilies(h.commentFamilies), commentFamiliesForFamilies(families, mode))
   )
 }

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -17,7 +17,9 @@ import type { GithubCommentFamily, GithubHookFamily, HookCommentFamily } from '.
  *              supported updates, and replies run.
  *   labeled  → `issues:labeled` alone. Issues-only, and the one cadence that
  *              subscribes to no replies at all: a label is applied to a thread,
- *              not said in it. An empty `labelFilter` means any label.
+ *              not said in it. A `labelFilter` intersects the issue's CURRENT
+ *              label set (relay semantics for every cadence), not the label
+ *              this delivery applied; empty means any label.
  *   @-mention → the same subscriptions as any update, with `mentionOnly: true` —
  *              an event fires ONLY when its text (issue/PR body, comment body,
  *              commit message) @-mentions the assigned agent or the App. The
@@ -98,7 +100,7 @@ export function githubTriggerTooltip(mode: GhTriggerMode, agentName: string): st
     case 'every':
       return 'Runs when an issue or PR is opened and on supported updates and replies (close, reopen and title/body edits are ignored).'
     case 'labeled':
-      return 'Runs when a label is applied to an issue — any label while no label filter is set. Replies do not run it.'
+      return "Runs when a label is applied to an issue. A label filter matches the issue's current labels, not just the one applied. Replies do not run it."
     case 'mention':
       // Not "only @agent": the App handle is the repository-wide broadcast, and
       // an authorized native App review request bypasses cadence/mention/label.

--- a/packages/web/src/lib/gitlab-events.test.ts
+++ b/packages/web/src/lib/gitlab-events.test.ts
@@ -20,14 +20,18 @@ import {
 
 describe('GL_TRIGGER_LABEL', () => {
   it('speaks the same vocabulary as the GitHub form', () => {
-    expect(GL_TRIGGER_LABEL.first).toBe('created')
-    expect(GL_TRIGGER_LABEL.every).toBe('updated')
-    expect(GL_TRIGGER_LABEL.mention).toBe('mention only')
+    expect(GL_TRIGGER_LABEL.first).toBe('opened')
+    expect(GL_TRIGGER_LABEL.every).toBe('any update')
+    expect(GL_TRIGGER_LABEL.mention).toBe('@-mention')
   })
 
-  it('defaults new subscriptions to updated mode', () => {
-    expect(GL_DEFAULT_TRIGGER_MODE).toBe('every')
-    expect(GL_TRIGGER_LABEL[GL_DEFAULT_TRIGGER_MODE]).toBe('updated')
+  it('opens every new subscription on the opening itself', () => {
+    expect(GL_DEFAULT_TRIGGER_MODE).toBe('first')
+    expect(GL_TRIGGER_LABEL[GL_DEFAULT_TRIGGER_MODE]).toBe('opened')
+  })
+
+  it('offers no label cadence — GitLab label events are not subscribed here', () => {
+    expect(GL_TRIGGER_MODES).toEqual(['first', 'every', 'mention'])
   })
 })
 
@@ -54,15 +58,14 @@ describe('GL_TRIGGER_PILL', () => {
 describe('GL_FAMILIES', () => {
   it('offers the same two subjects GitHub does — pushes stay held back', () => {
     expect(GL_FAMILIES.map(({ fam }) => fam)).toEqual(['issues', 'merge_request'])
-    expect(GL_FAMILIES.find(({ fam }) => fam === 'issues')?.desc).toBe('opened, labels, replies')
-    expect(GL_FAMILIES.find(({ fam }) => fam === 'merge_request')?.desc).toBe('opened, new commits, replies')
+    expect(GL_FAMILIES.map(({ label }) => label)).toEqual(['Issues', 'Merge requests'])
   })
 })
 
 describe('gitlabFamilyTile', () => {
   it('still labels a stored push row the console never offers', () => {
     expect(gitlabFamilyTile('push')?.pill).toBe('Pushes')
-    expect(gitlabFamilyTile('push')?.desc).toBe('commits pushed to a branch')
+    expect(gitlabFamilyTile('push')?.label).toBe('Pushes')
   })
 })
 

--- a/packages/web/src/lib/gitlab-events.ts
+++ b/packages/web/src/lib/gitlab-events.ts
@@ -8,14 +8,14 @@
  * rows and the family is immutable; the row's `events` patterns,
  * `commentFamilies` and `mentionOnly` flag encode the mode:
  *
- *   created  → `family:opened` for a thread family and NO note family; the
+ *   opened   → `family:opened` for a thread family and NO note family; the
  *              relay additionally accepts a later explicit @mention in an
  *              `:opened`-cadence thread family. Pushes have no "first" — a push
  *              subscription is inherently per-push, so `push:*` rides along.
- *   updated  → `family:*` plus the row's own thread family as its note family,
+ *   any update → `family:*` plus the row's own thread family as its note family,
  *              so replies fire too. Close, reopen, merge and draft toggles stay
  *              inert; supported updates and replies run.
- *   mention only → the same subscriptions as updated, with `mentionOnly: true` —
+ *   @-mention → the same subscriptions as any update, with `mentionOnly: true` —
  *              an event fires ONLY when its text (issue/MR description, note
  *              body, commit message) @-mentions the agent or the project's
  *              service account. The agent handle targets one rule; the service
@@ -24,7 +24,7 @@
  *
  * One asymmetry with GitHub is deliberate: there, `commentFamilies` only
  * NARROWS a shared `issue_comment` subscription, so it may stay populated in
- * created mode. Here it is the note subscription itself, so created mode must
+ * opened mode. Here it is the note subscription itself, so opened mode must
  * clear it or every reply would fire.
  *
  * The wire accepts finer `family:action` patterns; these helpers never emit one.
@@ -40,23 +40,15 @@ export interface GlFamilyTile {
   pill: string
   icon: string
   label: string
-  desc: string
 }
 
-// `desc` is the Add-integration tile subtitle — keep it to a short fragment
-// naming signals the relay really forwards, on one or two 11.5px lines.
 // Every subject the wire knows, in display order — a stored push row still
-// reads its own label from here even though the console never offers one.
+// reads its own label from here even though the console never offers one. What
+// a subject listens to is stated by its cadence tiles, not a subtitle.
 const GL_ALL_FAMILIES: GlFamilyTile[] = [
-  { fam: 'issues', pill: 'Issues', icon: 'circle-dot', label: 'Issues', desc: 'opened, labels, replies' },
-  {
-    fam: 'merge_request',
-    pill: 'MRs',
-    icon: 'git-pull-request',
-    label: 'Merge requests',
-    desc: 'opened, new commits, replies'
-  },
-  { fam: 'push', pill: 'Pushes', icon: 'git-commit-horizontal', label: 'Pushes', desc: 'commits pushed to a branch' }
+  { fam: 'issues', pill: 'Issues', icon: 'circle-dot', label: 'Issues' },
+  { fam: 'merge_request', pill: 'MRs', icon: 'git-pull-request', label: 'Merge requests' },
+  { fam: 'push', pill: 'Pushes', icon: 'git-commit-horizontal', label: 'Pushes' }
 ]
 
 // The subjects the console OFFERS — the two GitHub offers too. The push tile is
@@ -76,11 +68,11 @@ export function gitlabFamilyCarriesReviews(fam: GlFamily): boolean {
 
 /** The trigger modes in display order — mention deliberately last. */
 export const GL_TRIGGER_MODES: readonly GlTriggerMode[] = ['first', 'every', 'mention']
-/** The Add-integration cadence tiles' vocabulary ("Trigger when …"). */
+/** The cadence vocabulary ("Trigger when …") the create surfaces spell out. */
 export const GL_TRIGGER_LABEL: Record<GlTriggerMode, string> = {
-  first: 'created',
-  every: 'updated',
-  mention: 'mention only'
+  first: 'opened',
+  every: 'any update',
+  mention: '@-mention'
 }
 /** The agent-detail trigger bar's segment vocabulary, worded like the IM bar. */
 export const GL_TRIGGER_PILL: Record<GlTriggerMode, string> = {
@@ -111,15 +103,16 @@ export function gitlabMentionUsage(agentName: string): string {
 /** The default create-form selection: merge requests only. */
 export const GL_DEFAULT_FAMILIES: readonly GlFamily[] = ['merge_request']
 
-/** The default create-form cadence: react to issue or merge-request updates. */
-export const GL_DEFAULT_TRIGGER_MODE: GlTriggerMode = 'every'
+/** The default cadence every create surface opens a new subject on: the opening
+ *  itself, exactly as the GitHub side does. */
+export const GL_DEFAULT_TRIGGER_MODE: GlTriggerMode = 'first'
 
 /** Narrow a stored cross-host comment scope to the GitLab families a gitlab hook may carry. */
 export function gitlabCommentFamilies(families: readonly HookCommentFamily[]): GitlabCommentFamily[] {
   return families.filter((family): family is GitlabCommentFamily => family === 'issues' || family === 'merge_request')
 }
 
-/** The note families replies may arrive on — empty in created mode, where a
+/** The note families replies may arrive on — empty in opened mode, where a
  *  reply fires only by summoning the agent in an already-opened thread. */
 export function commentFamiliesForGitlabFamilies(
   families: Iterable<GlFamily>,


### PR DESCRIPTION
The Add-integration wizard's code-host section is redesigned around expandable per-family cards (user-provided mocks), completing the per-family trigger model of #1544/#1546 in the create flow.

## What changed

- **Family cards.** "Listen for" is now stacked full-width cards: a slim icon + name + checkbox row when unchecked; checking it expands a brand-tinted card whose body carries that family's own settings. Two families ⇒ two cards, each independent.
- **Per-family "Trigger when"**, three tiles across: `opened` / `any update` / `@-mention` for pull requests and merge requests; GitHub issues offer `opened` / `labeled` / `@-mention`. Each selected family creates its subscription at its own cadence in one pass — the motivating PR-updated / issues-mention configuration is a single wizard run. The default cadence is now `opened`, read from the same constant by the wizard and the agent page's add-family menu.
- **New `labeled` cadence (GitHub issues only).** Compiles to `events: ['issues:labeled']` with no comment subscription; the wire and the relay already match exact `family:action` patterns, so nothing changes outside the console. The agent page's issues rows offer it in their trigger dropdown. The label set stays the existing `labelFilter` field (empty = any label); a label-picker UI is deliberately out of scope.
- **"Review format" replaces the collapsible "PR review" section**, grouped inside the change-proposal card: `Brief` / `Details` / `Custom`, defaulting to **Details** (inline comments, request changes, approve, status check all on — the same field mapping the presets already had). `Custom` discloses the four capability checkboxes; turning every box off expresses the removed `None` tile. The repository-authorization preflight banner is unchanged and now engages by default, which is intended.
- Trigger vocabulary re-worded in the shared label maps (`opened` / `any update` / `@-mention`); the agent-detail pill map keeps its short forms shared with the IM trigger bar. The agent page's review-settings dialog (with its None preset) is untouched.
- GitLab pane mirrors the whole interaction minus `labeled`.

## Tests

Wizard: `AddIntegrationModal.github.test.tsx` 10 cases (new file), `.gitlab` 19 — card expand/collapse, per-family defaults, mixed cadence bodies, labeled compile, Details default mapping, Custom all-off ⇒ off/off, no None tile. `github-events` / `gitlab-events` round-trip and normalization for the new vocabulary; review-format helpers 12 cases. Web suite **187 files / 2117 tests** passing; `pnpm typecheck`, `lint`, `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
