### PR TITLE
feat(web): connect a daemon from the Edit-agent placement picker

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1361,6 +1361,12 @@
     border-color: var(--border-focus);
     box-shadow: 0 0 0 3px var(--brand-ring);
   }
+  /* The focus highlight is the brand ring above — the UA outline would double it in the
+     browser's own blue, on `.inp` itself and on a field nested inside one. */
+  .inp:focus,
+  .inp :focus {
+    outline: none;
+  }
   .inp.ph {
     color: var(--text-disabled);
   }

--- a/packages/web/src/components/console/DaemonSelect.test.tsx
+++ b/packages/web/src/components/console/DaemonSelect.test.tsx
@@ -61,6 +61,29 @@ describe('DaemonSelect', () => {
     expect(rows[1]?.className).not.toMatch(/\bon\b/)
   })
 
+  it('draws an action row with its own icon and reports it like any other choice', async () => {
+    const picked: string[] = []
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () =>
+      root?.render(
+        <DaemonSelect
+          value="pool-1"
+          options={[...options, { value: '__add_daemon__', label: 'Add daemon', icon: 'plus' }]}
+          onChange={(next) => picked.push(next)}
+        />
+      )
+    )
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-haspopup="listbox"]')!
+    await act(async () => trigger.click())
+    const rows = [...container.querySelectorAll<HTMLButtonElement>('[role="option"]')]
+
+    expect(rows[3]?.querySelector('svg')?.getAttribute('class')).toContain('lucide-plus')
+    await act(async () => rows[3]?.click())
+    expect(picked).toEqual(['__add_daemon__'])
+  })
+
   it('selects a local daemon and skips unavailable choices with the keyboard', async () => {
     await mount()
     const trigger = container!.querySelector<HTMLButtonElement>('[aria-haspopup="listbox"]')!

--- a/packages/web/src/components/console/DaemonSelect.tsx
+++ b/packages/web/src/components/console/DaemonSelect.tsx
@@ -17,12 +17,14 @@ export interface DaemonSelectOption {
   title?: string
   kind?: PlacementOptionKind
   disabled?: boolean
+  /** Icon override — an action row ("Add daemon") names itself, not a placement kind. */
+  icon?: string
 }
 
 /** A set target is drawn as a target, never as the member that happens to answer for it. */
 const isSet = (option: Pick<DaemonSelectOption, 'kind'>): boolean => option.kind === 'pool' || option.kind === 'group'
 const iconFor = (option: DaemonSelectOption): string =>
-  option.kind || option.value ? placementIcon(option.kind ?? 'daemon') : 'server-off'
+  option.icon ?? (option.kind || option.value ? placementIcon(option.kind ?? 'daemon') : 'server-off')
 
 function enabledIndex(options: readonly DaemonSelectOption[], start: number, delta: 1 | -1): number {
   if (!options.length) return -1

--- a/packages/web/src/components/console/ModalProvider.test.tsx
+++ b/packages/web/src/components/console/ModalProvider.test.tsx
@@ -40,6 +40,7 @@ vi.mock('@/lib/data-context', () => ({
 vi.mock('@/lib/profile', () => ({ useProfile: () => ({ user: null, me: null }) }))
 
 import { ModalProvider, useModal } from './ModalProvider'
+import AddDaemonModal from './modals/AddDaemonModal'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -161,5 +162,26 @@ describe('ModalProvider dismissal', () => {
       await Promise.resolve()
     })
     expect(host.textContent).not.toContain('Daemon connected')
+  })
+})
+
+// The chained Edit-agent dialog preselects the machine the operator just connected, so
+// Continue has to name it — closing alone would drop the operator back on the old placement.
+describe('AddDaemonModal chaining', () => {
+  it('hands Continue’s chain the daemon that just connected', async () => {
+    mocks.provisionDaemon.mockResolvedValue({
+      daemonId: 'dmn_live',
+      command: 'npx -y @agentconnect.md/daemon run --api-url https://example.test --api-key test'
+    })
+    mocks.daemons = [{ daemonId: 'dmn_live', name: 'edge-1', status: 'online' }]
+    const onDone = vi.fn()
+
+    await act(async () =>
+      root.render(<AddDaemonModal onClose={() => {}} onDone={onDone} registerDismiss={() => () => {}} />)
+    )
+    const done = [...host.querySelectorAll('button')].find((b) => b.textContent === 'Continue')!
+    await act(async () => done.click())
+
+    expect(onDone).toHaveBeenCalledWith('dmn_live')
   })
 })

--- a/packages/web/src/components/console/ModalProvider.tsx
+++ b/packages/web/src/components/console/ModalProvider.tsx
@@ -62,6 +62,8 @@ interface ModalOpts {
   platform?: IntegrationPlatform
   feishuRegion?: FeishuRegion
   focusSection?: EditAgentSection
+  /** The daemon the Edit-agent picker opens on — the one the chained Add-daemon dialog just connected. */
+  daemonId?: string
 }
 
 interface ModalData {
@@ -130,13 +132,17 @@ export function ModalProvider({ children }: { children: ReactNode }) {
               <DeleteGroupModal group={open.target as MemberSetRow} onClose={close} />
             )}
             {open.kind === 'agent' && <AddAgentModal onClose={close} />}
-            {/* Opened from an unplaced agent's "Add daemon" chip: once the daemon
-                connects, Continue chains back into that agent's edit dialog, where
-                the fresh (and only) daemon is auto-preselected by its autofill. */}
+            {/* Opened from an agent's "Add daemon" affordance: once the daemon connects,
+                Continue chains back into that agent's edit dialog with the fresh daemon
+                selected in the placement picker. */}
             {open.kind === 'daemon' && (
               <AddDaemonModal
                 onClose={close}
-                onDone={open.target ? () => openModal('editAgent', open.target, open.opts) : undefined}
+                onDone={
+                  open.target
+                    ? (daemonId) => openModal('editAgent', open.target, { ...open.opts, daemonId })
+                    : undefined
+                }
                 registerDismiss={registerDismiss}
               />
             )}
@@ -184,7 +190,12 @@ export function ModalProvider({ children }: { children: ReactNode }) {
               <DeleteAgentModal agent={open.target as Agent} onClose={close} />
             )}
             {open.kind === 'editAgent' && open.target && (
-              <EditAgentModal agent={open.target as Agent} focusSection={open.opts?.focusSection} onClose={close} />
+              <EditAgentModal
+                agent={open.target as Agent}
+                focusSection={open.opts?.focusSection}
+                preselectDaemonId={open.opts?.daemonId}
+                onClose={close}
+              />
             )}
             {open.kind === 'editAgentDesc' && open.target && (
               <EditDescriptionModal agent={open.target as Agent} onClose={close} />

--- a/packages/web/src/components/console/modals/AddDaemonModal.tsx
+++ b/packages/web/src/components/console/modals/AddDaemonModal.tsx
@@ -86,14 +86,15 @@ function CommandBox({ tabs, placeholder }: { tabs: CommandTab[]; placeholder: Re
 
 // `onDone` (optional) replaces plain close on the connected path's Done button —
 // ModalProvider uses it to chain back into the Edit-agent dialog when this modal
-// was opened from an unplaced agent's "Add daemon" affordance. Cancel never chains.
+// was opened from an agent's "Add daemon" affordance, carrying the daemon just
+// connected so that dialog can preselect it. Cancel never chains.
 export default function AddDaemonModal({
   onClose,
   onDone,
   registerDismiss
 }: {
   onClose: () => void
-  onDone?: () => void
+  onDone?: (daemonId: string) => void
   registerDismiss: (handler: () => void) => () => void
 }) {
   const { provisionDaemon, daemons, refresh, deleteDaemon, renameDaemon, setDaemonSessionRetention, saveSharing } =
@@ -182,7 +183,8 @@ export default function AddDaemonModal({
       // operator already left. (`cancel` fences on `saving`, so this only catches a
       // dismissal that raced the flag; the guard makes the ordering irrelevant.)
       if (dismissed.current) return
-      ;(onDone ?? onClose)()
+      if (onDone) onDone(connect.daemonId)
+      else onClose()
     } catch (e) {
       if (dismissed.current) return
       setSaveErr(e instanceof Error ? e.message : String(e))

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -43,8 +43,9 @@ import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import { Spinner } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
 import { DaemonSelect, type DaemonSelectOption } from '@/components/console/DaemonSelect'
+import { useModal } from '@/components/console/ModalProvider'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
-import { editAgentCapabilitySource, editAgentDaemonChoices } from './edit-agent-daemon-choice'
+import { editAgentCapabilitySource, editAgentDaemonChoices, preselectPlacementReset } from './edit-agent-daemon-choice'
 import { VisibilityField, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
 import { AgentCallVisibility } from '@/components/console/AgentCallVisibility'
 import {
@@ -68,6 +69,10 @@ import { isOutputMode, type OutputMode } from '@/lib/output-mode'
 // edit surfaces stay identical. Workspace and Memory keep their own dedicated
 // editors (the Workspace card / the Memory tab), so they are NOT sections here.
 export type EditAgentSection = 'basics' | 'runtime' | 'access' | 'secrets'
+
+// A picker row that opens the join-command dialog instead of naming a placement. Never a
+// daemonId, so it can never be saved: the onChange below intercepts it.
+const ADD_DAEMON = '__add_daemon__'
 
 const SECTIONS: ReadonlyArray<{ id: EditAgentSection; label: string; icon: string }> = [
   { id: 'basics', label: 'Basics', icon: 'id-card' },
@@ -94,10 +99,14 @@ function normalizeSelected(subjectAgentId: string, ids: string[]): string[] {
 export default function EditAgentModal({
   agent,
   focusSection,
+  preselectDaemonId,
   onClose
 }: {
   agent: Agent
   focusSection?: EditAgentSection
+  /** A daemon to open the placement picker on — set when a chained Add-daemon dialog just
+   *  connected one, so Continue lands on a form already pointed at the new machine. */
+  preselectDaemonId?: string
   onClose: () => void
 }) {
   const acpRegistry = useAcpRegistry()
@@ -116,6 +125,7 @@ export default function EditAgentModal({
   // Organization settings from the read-only "From organization" group (§8.2);
   // other members see the group and its explanation alone.
   const { myRole, orgPath } = useOrgs()
+  const { openModal } = useModal()
   const [loaded, setLoaded] = useState(false)
   const [sharing, setSharing] = useState<SharingValue>({ visibility: agent.visibility, sharedWith: agent.sharedWith })
   const initialSharing = useRef<SharingValue>({ visibility: agent.visibility, sharedWith: agent.sharedWith })
@@ -224,7 +234,9 @@ export default function EditAgentModal({
         // Through the SAME mapping the list projection uses, so a pool agent reloads as the pool
         // rather than as unplaced — `daemonId` is null for it by design.
         const placement = placementValueOf(dto, orgSetIds) ?? ''
-        setDaemonId(placement)
+        // The ref stays the SAVED placement — a preselect is a pending change like any other,
+        // so the move flow and the Save button see it as one.
+        setDaemonId(preselectDaemonId || placement)
         initialDaemonId.current = placement
         setModel(dto.model ?? '')
         initialModel.current = dto.model ?? ''
@@ -255,6 +267,20 @@ export default function EditAgentModal({
         const fresh: SharingValue = { visibility: dto.visibility, sharedWith: dto.sharedWith }
         setSharing(fresh)
         initialSharing.current = fresh
+        // A chained Add-daemon lands the form on a brand-new machine — reset the runtime/model
+        // to what it actually reports rather than a pair it cannot run.
+        const target = preselectDaemonId ? daemons.find((d) => d.daemonId === preselectDaemonId) : undefined
+        const reset = preselectPlacementReset(target?.runtimeModels, dto.runtime ?? '', dto.model ?? '')
+        if (reset?.kind === 'runtime') {
+          setRuntime(reset.runtime)
+          setModel('')
+          setEffort('')
+          setPermissionMode(permissionModeDefault(reset.runtime))
+          setApprovalsReviewer(approvalsReviewerDefault(reset.runtime))
+        } else if (reset?.kind === 'model') {
+          setModel('')
+          setEffort('')
+        }
         setLoaded(true)
       },
       (e) => {
@@ -446,7 +472,9 @@ export default function EditAgentModal({
               : 'Uses the credentials on this machine.',
         disabled: !current && !eligible
       }
-    })
+    }),
+    // Last row: no machine to pick means the picker itself offers connecting one.
+    { value: ADD_DAEMON, label: 'Add daemon', title: 'Connect a new machine to this org.', icon: 'plus' }
   ]
   const sourceUnavailable = !!sourceDaemon && !moveReady(sourceDaemon)
   const sourceOffline = sourceDaemon?.status === 'offline'
@@ -779,6 +807,12 @@ export default function EditAgentModal({
                     options={daemonOptions}
                     placeholder="No daemon"
                     onChange={(nextDaemonId) => {
+                      // Chaining through ModalProvider replaces this dialog; Continue reopens it
+                      // with the fresh daemon listed (same path as the unplaced agent's chip).
+                      if (nextDaemonId === ADD_DAEMON) {
+                        openModal('daemon', agent, { focusSection: 'basics' })
+                        return
+                      }
                       setDaemonId(nextDaemonId)
                       setRepairPlacement(false)
                       setForceReassign(false)

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { editAgentCapabilitySource, editAgentDaemonChoices } from './edit-agent-daemon-choice'
+import { editAgentCapabilitySource, editAgentDaemonChoices, preselectPlacementReset } from './edit-agent-daemon-choice'
 
 type Row = {
   caps: { features: string[] }
@@ -139,5 +139,30 @@ describe('editAgentCapabilitySource', () => {
 
     expect(editAgentCapabilitySource(daemons, 'local-2', [group], undefined)?.daemonId).toBe('local-2')
     expect(editAgentCapabilitySource(daemons, 'gone', [group], undefined)).toBeUndefined()
+  })
+})
+
+describe('preselectPlacementReset', () => {
+  const profiles = [
+    { runtime: 'claude', models: ['claude-opus-5', 'claude-sonnet-5'] },
+    { runtime: 'codex', models: ['gpt-5'] }
+  ]
+
+  it('keeps a pair the new machine reports', () => {
+    expect(preselectPlacementReset(profiles, 'claude', 'claude-sonnet-5')).toBeNull()
+  })
+
+  it('switches to the machine’s first runtime when it does not run the saved one', () => {
+    expect(preselectPlacementReset(profiles, 'gemini', 'gemini-3-pro')).toEqual({ kind: 'runtime', runtime: 'claude' })
+  })
+
+  it('falls the model back to the runtime default when only the model is unknown', () => {
+    expect(preselectPlacementReset(profiles, 'codex', 'gpt-4')).toEqual({ kind: 'model' })
+  })
+
+  it('resets nothing when the machine reports no profiles, or the runtime advertises no models', () => {
+    expect(preselectPlacementReset(undefined, 'claude', 'claude-opus-5')).toBeNull()
+    expect(preselectPlacementReset([], 'claude', 'claude-opus-5')).toBeNull()
+    expect(preselectPlacementReset([{ runtime: 'cursor', models: [] }], 'cursor', 'auto')).toBeNull()
   })
 })

--- a/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
+++ b/packages/web/src/components/console/modals/edit-agent-daemon-choice.ts
@@ -69,3 +69,21 @@ export function editAgentCapabilitySource<T extends DaemonChoiceRow>(
   if (selectedDaemonId === POOL_PLACEMENT) return poolChoice
   return daemons.find((daemon) => daemon.daemonId === selectedDaemonId)
 }
+
+/** What a freshly chained Add-daemon forces the runtime/model back to. A brand-new machine need
+ *  not run the saved runtime or advertise the saved model, and Save refuses a placement it cannot
+ *  honour — so the form lands on what the target reports instead of on a blocked choice.
+ *  `null` keeps the saved pair; `runtime` also clears model/effort/permission (a new runtime's
+ *  vocabularies are its own); `model` falls back to the runtime's own default, stored as ''. */
+export function preselectPlacementReset(
+  profiles: ReadonlyArray<{ runtime: string; models: readonly string[] }> | undefined,
+  savedRuntime: string,
+  savedModel: string
+): { kind: 'runtime'; runtime: string } | { kind: 'model' } | null {
+  if (!profiles?.length) return null
+  const profile = profiles.find((candidate) => candidate.runtime === savedRuntime)
+  if (!profile) return { kind: 'runtime', runtime: profiles[0]!.runtime }
+  // No advertised models means nothing to contradict — a runtime like cursor reports none.
+  if (savedModel && profile.models.length && !profile.models.includes(savedModel)) return { kind: 'model' }
+  return null
+}


### PR DESCRIPTION
## What

Adds a daemon-connect path to the Edit-agent dialog's **Runs on** picker, and makes the round trip land on a form that can actually be saved.

- **`Add daemon` row** at the end of the placement picker (`DaemonSelect` gained an optional per-option `icon` so an action row can name itself). It is a sentinel value the modal intercepts — never a `daemonId`, so it can never be saved.
- **Continue carries the daemon it connected.** `AddDaemonModal`'s `onDone` is now `(daemonId) => void`; `ModalProvider` forwards it as `ModalOpts.daemonId` when chaining back into `editAgent`, and `EditAgentModal` opens the picker on it (`preselectDaemonId`). The saved placement stays in `initialDaemonId`, so the preselect is a pending change like any other — the move flow and the Save button see it as one, and nothing is written until Save.
- **Runtime / Model reset to the new machine's own.** A brand-new daemon need not run the saved runtime or advertise the saved model, and Save refuses exactly that (`runtimeUnavailable` / `modelUnavailable`). `preselectPlacementReset()` decides: runtime not offered → switch to the machine's first and clear model/effort/permission/reviewer; runtime offered but model unknown → model falls back to the runtime's default (stored `''`) and effort clears; no reported profiles, or a runtime that advertises no models (cursor) → nothing changes.
- **`.inp` focus highlight is the brand ring only.** The UA outline was rendering *on top of* the design's ring in the browser's own blue on every `.inp` field (visible on Add daemon's Name input). `globals.css` now clears it for `.inp` itself and for a field nested inside one.

## Why

Before this, an agent whose only offered placement was unavailable was a dead end: the picker listed the unreachable target and nothing else, and connecting a machine meant abandoning the dialog for the Daemons page. The existing "Add daemon" chip on an *unplaced* agent already chained through `ModalProvider` — this reuses that path from inside the picker, and finishes it by preselecting rather than relying on the unplaced-agent autofill (which never fires for an already-placed agent).

## Notes for reviewers

- Chaining replaces the dialog, so **unsaved Edit-agent edits are lost** when `Add daemon` is chosen — same as the pre-existing chip flow. Left as is; say the word if it should warn or preserve state.
- The reset is scoped to the preselect path only. A hand-picked placement change still keeps the operator's runtime/model and reports the incompatibility on Save, which is the documented behavior (`runtime-model-catalog.md` idiom: never silently rewrite a stored value).
- `AddAgentModal`'s picker did **not** get the `Add daemon` row — out of scope here.

## Verification

- `pnpm --filter @agentconnect.md/web test` — 182 files / 2050 tests pass, including 4 new cases for `preselectPlacementReset`, one for the `DaemonSelect` action row, and one asserting Continue hands the chain the connected `daemonId`.
- `typecheck`, `eslint`, `prettier --check` clean.
- CSS fix checked in a running dev server: a focused `.inp` (direct and nested) computes `outline: none` with only `border rgb(198,42,120)` + `box-shadow rgba(198,42,120,.32) 0 0 0 3px`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)