### PR TITLE
fix(daemon): suppress Claude Code's built-in SendMessage on managed sessions

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -23,6 +23,7 @@ import type { RuntimeDef } from '../config/config-schema.js'
 import {
   augmentClaudeEfforts,
   claudeInnerSandboxSettings,
+  CLAUDE_DISALLOWED_BUILTIN_TOOLS,
   isClaudeRuntimeDef,
   type ClaudeInnerSandboxSettings,
   type ClaudeProtectedSettings,
@@ -339,7 +340,7 @@ export { ULTRACODE_EFFORT }
 
 /** The session `_meta` sent to a Claude runtime on session/new and session/load
  *  (`_meta.claudeCode.options` is spread into the SDK `query()` options layer), or
- *  undefined off Claude runtimes. Four things ride on it:
+ *  undefined off Claude runtimes. Five things ride on it:
  *
  *  - `thinking`: recent models default `thinking.display` to "omitted" — thinking
  *    blocks stream signature-only with empty text, so the ACP wrapper never emits
@@ -353,6 +354,10 @@ export { ULTRACODE_EFFORT }
  *  - `options.sandbox` (only when the ACP runtime already has an outer
  *    AgentConnect sandbox): enables Claude's native Bash sandbox fail-closed and
  *    denies its sandboxed commands the provider credentials the parent can read.
+ *  - `disallowedTools`: suppresses Claude Code's built-in agent-teams `SendMessage`,
+ *    which collides with `mcp__agentconnect__sendMessage` (#800) and can DELIVER
+ *    session-private content to unrelated co-located sessions (#998). Sent on every
+ *    Claude session — AgentConnect owns all inter-session messaging for its sessions.
  *  - `systemPrompt` (top-level, sibling of `claudeCode`): the agent's system-prompt
  *    seed PLUS, on a fresh session, the agent's memory index (standing context, not a
  *    user turn — see SessionManager). We send it as `{ append }` so it layers ON TOP
@@ -394,6 +399,7 @@ export function claudeSessionMeta(
       claudeCode: {
         options: {
           thinking: { type: 'adaptive'; display: 'summarized' }
+          disallowedTools: readonly string[]
           settings?: ClaudeSessionSettings
           sandbox?: ClaudeInnerSandboxSettings
         }
@@ -415,6 +421,9 @@ export function claudeSessionMeta(
     claudeCode: {
       options: {
         thinking: { type: 'adaptive', display: 'summarized' },
+        // #998: the built-in agent-teams SendMessage is a live misdelivery channel;
+        // adapters spread this into SDK query() options (older ones ignore it).
+        disallowedTools: CLAUDE_DISALLOWED_BUILTIN_TOOLS,
         ...(protectedCredentialRoots
           ? { sandbox: claudeInnerSandboxSettings(protectedCredentialRoots, allowModelToolUnixSockets) }
           : {}),

--- a/packages/daemon/src/runtime-defs/claude-runtime.ts
+++ b/packages/daemon/src/runtime-defs/claude-runtime.ts
@@ -154,6 +154,14 @@ export function claudeInnerSandboxSettings(
   }
 }
 
+/** Claude Code built-in tools suppressed on every AgentConnect-managed session via
+ * `_meta.claudeCode.options.disallowedTools` (spread into SDK `query()` options).
+ * The agent-teams `SendMessage` collides with `mcp__agentconnect__sendMessage` (#800)
+ * and is a WORKING delivery channel to unrelated co-located sessions — a mis-picked
+ * call exfiltrates session-private content with no audit trail (#998). AgentConnect
+ * owns all inter-session messaging for its sessions, so the built-in is always wrong. */
+export const CLAUDE_DISALLOWED_BUILTIN_TOOLS = ['SendMessage'] as const
+
 /** A Claude Code runtime (its command/args reference `claude`) — these embed the
  *  @anthropic-ai/claude-agent-sdk, which needs a Claude Code executable. The ONE
  *  Claude predicate: AcpHost and the model-catalog path both delegate here, matching

--- a/packages/daemon/test/acp-config.test.ts
+++ b/packages/daemon/test/acp-config.test.ts
@@ -10,6 +10,7 @@ import {
   planConfigSelection,
   SDK_LIFECYCLE_FILTERS
 } from '../src/acp/acp-host.js'
+import { CLAUDE_DISALLOWED_BUILTIN_TOOLS } from '../src/runtime-defs/claude-runtime.js'
 import {
   permissionPresetSettings,
   permissionPresetValues,
@@ -276,9 +277,17 @@ describe('claudeSessionMeta', () => {
   // transcript loses its reasoning rows.
   const THINKING = { type: 'adaptive', display: 'summarized' }
   // Every Claude session also opts into the filtered SDK-lifecycle feed (the
-  // background-task lease). `options` is the only per-call-varying part.
+  // background-task lease) and the #998 built-in messaging-tool suppression.
+  // `options` is the only per-call-varying part.
   const cc = (options: Record<string, unknown>) => ({
-    claudeCode: { options, emitRawSDKMessages: SDK_LIFECYCLE_FILTERS }
+    claudeCode: {
+      options: { disallowedTools: CLAUDE_DISALLOWED_BUILTIN_TOOLS, ...options },
+      emitRawSDKMessages: SDK_LIFECYCLE_FILTERS
+    }
+  })
+
+  it('always disallows the built-in agent-teams SendMessage (#800 collision / #998 exfiltration)', () => {
+    expect(claudeSessionMeta(undefined, true)?.claudeCode.options.disallowedTools).toEqual(['SendMessage'])
   })
 
   it('always requests summarized thinking on a Claude runtime', () => {


### PR DESCRIPTION
## What

Disallow Claude Code's built-in agent-teams `SendMessage` tool on every AgentConnect-managed Claude session, via `_meta.claudeCode.options.disallowedTools` at `session/new` and `session/load`. This is fix 1 of #800 — the mechanism-level suppression — and closes the misdelivery channel #998 caught live.

## Why

- #998: the built-in tool is not a black hole — it **delivered** a game-private night action to an unrelated local Claude session on the same machine. The artifact audit found the built-in channel reached in **every one of nine trials** (4–9 calls each).
- #984 (inferred reply, merged) recovers *lost* reports but cannot recover content that already left the process; #905's directive-level mitigation covers only the `needsParentReply` child population — its own A/B run showed the collision also firing on the **caller** side, which only adapter-level suppression reaches.

## How

- `CLAUDE_DISALLOWED_BUILTIN_TOOLS = ['SendMessage']` in `runtime-defs/claude-runtime.ts`
- `claudeSessionMeta()` now always includes `disallowedTools` in `claudeCode.options`, so both `newSession` and `loadSession` carry it
- claude-agent-acp spreads `claudeCode.options` into the SDK `query()` options layer, which natively supports `disallowedTools`; **older adapters ignore the unknown option** (same degradation pattern as `settings` / `systemPrompt`)
- Runtime-gated by construction: `claudeSessionMeta` returns `undefined` off Claude runtimes and is only invoked for daemon-managed sessions

## Validation

- `test/acp-config.test.ts`: new dedicated assertion + the shared `cc` expectation helper now pins `disallowedTools` on every `claudeSessionMeta` shape (78 tests pass across acp-config + acp-host)
- daemon `typecheck` clean

## Open question for reviewers

Whether Claude Code's own subagent machinery (Task tool) tolerates a disallowed `SendMessage` — #998 flags this as the confidence gap. The SDK treats `disallowedTools` as a top-level tool filter, and AgentConnect sessions never legitimately use agent-teams messaging, but a real-model smoke run on a delegation flow would confirm.

Fixes #998. Refs #800, #984, #905.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>