### PR TITLE
fix(console): retire the sandbox-pod notice once the turn streams

### DIFF
--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -444,6 +444,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [mutateSteps]
   )
 
+  /** Retire a lane's wait notice on an event that is not folded into a step (a title, a clean end). */
+  const retireWaitNotice = useCallback(
+    (id: string, agentId: string | undefined, turnId: string): void =>
+      mutateSteps(id, (steps) => dropWaitNotices(steps, agentId, turnId)),
+    [mutateSteps]
+  )
+
   /** Apply the runtime's streamed session title so a live playground session renames
    *  in place — a synthetic 'pg_' session starts with a static "Playground · <agent>"
    *  label; the agent's auto-generated title arrives mid-turn (like a Slack session's).
@@ -735,8 +742,11 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             // Tool/supersession events are ordering fences: make preceding text
             // visible before applying the non-text event.
             deltaBuffer.flush(cursorKey)
-            if (event.kind === 'session_info') applyTitle(id, event.title, agentId)
-            else applyEvent(id, event, agentId, output.turnId)
+            if (event.kind === 'session_info') {
+              // Not a step, but still streamed by a live runtime — so it ends the wait too.
+              applyTitle(id, event.title, agentId)
+              retireWaitNotice(id, agentId, output.turnId)
+            } else applyEvent(id, event, agentId, output.turnId)
           }
         }
       }
@@ -753,6 +763,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         else finishedTurnLanes.current.set(id, { turnId: result.done.turnId, agents: new Set([agentId]) })
       }
       if (result.done.error) {
+        // The notice STAYS on a failure: a turn that died waiting for its pod is explained by it.
         const name = participantName(id, agentId)
         pushStep(id, {
           kind: 'done',
@@ -761,11 +772,15 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           ...(name ? { who: name } : {}),
           text: `⚠️ ${result.done.error}`
         })
+      } else {
+        // A lane can end having streamed nothing at all — a silent AC_NO_RESPONSE decline holds
+        // every chunk back — so a clean end is the last chance to retire the wait it announced.
+        retireWaitNotice(id, agentId, result.done.turnId)
       }
       // The turn stays busy until every targeted participant's lane finished.
       if (lanesOf(id).length === 0) setBusy(id, false)
     },
-    [applyEvent, applyStatus, applyTitle, deltaBuffer, failStream, participantName, pushStep, setBusy]
+    [applyEvent, applyStatus, applyTitle, deltaBuffer, failStream, participantName, pushStep, retireWaitNotice, setBusy]
   )
 
   const receiveOutput = useCallback(

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -212,6 +212,13 @@ function stampStep(step: UnstampedStep, observedAtMs = Date.now()): SessionStep 
   }
 }
 
+/** Drop this lane's live-only wait notice — streamed output IS the wait ending, so the line must go. */
+function dropWaitNotices(steps: SessionStep[], agentId: string | undefined, turnId: string): SessionStep[] {
+  const waiting = (s: SessionStep): boolean =>
+    s.kind === 'notice' && (s.agentId ?? undefined) === agentId && s.turnId === turnId
+  return steps.some(waiting) ? steps.filter((s) => !waiting(s)) : steps
+}
+
 const Ctx = createContext<PlaygroundData | null>(null)
 
 /** One live webchat socket per playground session. */
@@ -476,7 +483,9 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       const who = participantName(id, agentId)
       const lane = (extra: Omit<SessionStep, 'text' | 'turnId'> & { text: string }): SessionStep =>
         stampStep({ ...extra, turnId, ...(agentId ? { agentId } : {}), ...(who ? { who } : {}) }, observedAtMs)
-      mutateSteps(id, (steps) => {
+      mutateSteps(id, (arrived) => {
+        // Any streamed event ends the wait a `notice` announced, so it retires before this event lands.
+        const steps = ev.kind === 'notice' ? arrived : dropWaitNotices(arrived, agentId, turnId)
         // Concurrent participant streams interleave: accumulate each chunk into
         // the most recent step OF THIS LANE (same agentId), not the array tail.
         // A user message is a hard turn boundary — never merge across it, or a

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -327,7 +327,26 @@ describe('stream text delta batching', () => {
     ])
   })
 
-  it('renders a daemon notice in its own lane without swallowing the reply that follows', async () => {
+  it('renders a daemon notice in its own lane while the wait it announces is all there is', async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId, agentId: 'agent-1', index: 0, event: { kind: 'notice', text: 'Allocating a sandbox pod…' } }
+        })
+      })
+    })
+    act(runFrame)
+
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toMatchObject([
+      { kind: 'notice', text: 'Allocating a sandbox pod…', boundary: true }
+    ])
+  })
+
+  it('retires the notice as soon as the turn streams, so it never stands above the answer', async () => {
     const runFrame = captureAnimationFrames()
     const { socket, turnId } = await openStream()
 
@@ -344,13 +363,40 @@ describe('stream text delta batching', () => {
           output: { turnId, agentId: 'agent-1', index: 1, event: { kind: 'thinking', text: 'here goes' } }
         })
       })
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId, agentId: 'agent-1', index: 2, event: { kind: 'message', text: 'Hello!' } }
+        })
+      })
     })
     act(runFrame)
 
-    // The notice is its own step: `boundary` keeps the thinking chunk from accumulating into it.
+    // The pod is up — the wait's line is gone, and the reply chunks still start their own blocks.
     expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toMatchObject([
-      { kind: 'notice', text: 'Allocating a sandbox pod…', boundary: true },
-      { kind: 'plan', text: 'here goes' }
+      { kind: 'plan', text: 'here goes' },
+      { kind: 'done', text: 'Hello!' }
+    ])
+  })
+
+  it("retires only the streaming lane's notice — a lane still waiting keeps its own", async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    act(() => {
+      for (const output of [
+        { agentId: 'agent-1', index: 0, event: { kind: 'notice', text: 'Allocating a sandbox pod…' } },
+        { agentId: 'agent-2', index: 0, event: { kind: 'notice', text: 'Allocating a sandbox pod…' } },
+        { agentId: 'agent-1', index: 1, event: { kind: 'thinking', text: 'mine is up' } }
+      ]) {
+        socket.onmessage?.({ data: JSON.stringify({ type: 'output', output: { turnId, ...output } }) })
+      }
+    })
+    act(runFrame)
+
+    expect(getLiveSteps('s1').filter((step) => step.agentId)).toMatchObject([
+      { kind: 'notice', agentId: 'agent-2' },
+      { kind: 'plan', agentId: 'agent-1', text: 'mine is up' }
     ])
   })
 

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -400,6 +400,76 @@ describe('stream text delta batching', () => {
     ])
   })
 
+  it('retires the notice when a lane ends cleanly having streamed nothing', async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    // A silent AC_NO_RESPONSE decline holds every chunk back: the lane closes with no events.
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId, agentId: 'agent-1', index: 0, event: { kind: 'notice', text: 'Allocating a sandbox pod…' } }
+        })
+      })
+      socket.onmessage?.({
+        data: JSON.stringify({ type: 'done', done: { turnId, agentId: 'agent-1', lastIndex: 0 } })
+      })
+    })
+    act(runFrame)
+
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toEqual([])
+  })
+
+  it('keeps the notice when the turn fails, where it explains the failure', async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId, agentId: 'agent-1', index: 0, event: { kind: 'notice', text: 'Allocating a sandbox pod…' } }
+        })
+      })
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'done',
+          done: { turnId, agentId: 'agent-1', lastIndex: 0, error: 'the sandbox never came up' }
+        })
+      })
+    })
+    act(runFrame)
+
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toMatchObject([
+      { kind: 'notice', text: 'Allocating a sandbox pod…' },
+      { kind: 'done', text: '⚠️ the sandbox never came up' }
+    ])
+  })
+
+  it('retires the notice on a streamed session title', async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId, agentId: 'agent-1', index: 0, event: { kind: 'notice', text: 'Allocating a sandbox pod…' } }
+        })
+      })
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId, agentId: 'agent-1', index: 1, event: { kind: 'session_info', title: 'Skills on hand' } }
+        })
+      })
+    })
+    act(runFrame)
+
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toEqual([])
+  })
+
   it('flushes the final text before applying done', async () => {
     const runFrame = captureAnimationFrames()
     const { socket, turnId } = await openStream()


### PR DESCRIPTION
The console playground kept "⏳ Allocating a sandbox pod…" standing above the answer it
preceded. The daemon's live-only `notice` event is folded into a `notice` step
(#1500) and nothing ever removed it, so once the pod came up and the reply streamed, the
reader saw a line still claiming a sandbox was being allocated next to a finished answer.

`docs/product-conventions.md` already forbids exactly that — "once the pod is up the status
returns to the ordinary working state, so a streamed answer is never delivered under a line
still claiming a sandbox is being allocated". Slack honored it through
`startupActivityLabel` retiring inside `openSession`; the console never did, because a
message-shaped notice has no label to retire.

Any streamed event of a lane IS proof that lane's wait ended, so `applyEvent` drops the
lane's `notice` steps for this turn before folding the event in. Scoped to lane + turn, so a
multi-agent conversation whose participants boot separately keeps the still-waiting
participant's line while the ready one starts answering. A turn that ends in an error
without streaming anything keeps its notice — there it is the explanation.

## Verification

- `PlaygroundSend.test.tsx`: the assertion that the notice survives the reply is replaced by
  three — it shows while the wait is all there is, it retires as soon as the turn streams,
  and only the streaming lane's notice goes.
- `packages/web` suite green (187 files / 2125 tests), plus typecheck, eslint and prettier on
  the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
