### PR TITLE
fix(daemon): survive a runtime binary that cannot be spawned

### DIFF
--- a/packages/daemon/src/acp/spawn-driver.ts
+++ b/packages/daemon/src/acp/spawn-driver.ts
@@ -225,6 +225,8 @@ class LocalSpawnedRuntime implements SpawnedRuntime {
   readonly toAgent: WritableStream<Uint8Array>
   readonly fromAgent: ReadableStream<Uint8Array>
   private stopped = false
+  /** Set when the command never became a process, so there is nothing to signal. */
+  private neverStarted = false
 
   constructor(
     private child: ChildProcess,
@@ -232,10 +234,31 @@ class LocalSpawnedRuntime implements SpawnedRuntime {
   ) {
     this.toAgent = Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>
     this.fromAgent = Readable.toWeb(child.stdout!) as unknown as ReadableStream<Uint8Array>
+    // A command that cannot be executed — missing binary, no execute bit, or a script
+    // whose shebang interpreter is gone — emits 'error' and never 'exit'. Node rethrows
+    // an unhandled 'error' event as an uncaught exception, so one broken runtime on
+    // PATH would kill the daemon and every agent it hosts. Fail this launch alone:
+    // destroying the pipes hands the real errno to whoever reads the stream pair,
+    // which is the only failure channel this seam has.
+    child.once('error', (err: Error) => {
+      this.neverStarted = true
+      this.log?.warn(`acp: ${child.spawnfile} failed to start — ${err.message}`)
+      child.stdin?.destroy(err)
+      child.stdout?.destroy(err)
+    })
   }
 
   onExit(listener: () => void): void {
-    this.child.once('exit', listener)
+    // 'close' as well as 'exit': a child that never started emits only 'close', and a
+    // waiter that listens for 'exit' alone would hang there forever.
+    let fired = false
+    const once = () => {
+      if (fired) return
+      fired = true
+      listener()
+    }
+    this.child.once('exit', once)
+    this.child.once('close', once)
   }
 
   async stop(deadlineMs: number): Promise<void> {
@@ -261,6 +284,10 @@ class LocalSpawnedRuntime implements SpawnedRuntime {
     // minutes (idle sweep cadence) and its pgid recycled to an unrelated process;
     // the spawn-time 'exit' listener already swept while the pgid was provably ours.
     if (child.exitCode !== null || child.signalCode !== null) return
+    // A failed spawn leaves both codes null forever: there is no pid to signal, and
+    // waiting below would burn the full deadline and then warn about a SIGTERM that
+    // no process ever ignored.
+    if (this.neverStarted) return
     // Graceful first: ACP is a stdio protocol, EOF on stdin is the idiomatic "we're
     // done" and propagates through an npx wrapper to the adapter. The web-stream
     // wrapper may hold the pipe locked mid-write — then the signals below still land.

--- a/packages/daemon/test/spawn-driver.test.ts
+++ b/packages/daemon/test/spawn-driver.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { AcpHost } from '../src/acp/acp-host.js'
-import { resolveWindowsCodexNative, sanitizeWindowsCodexAdapterEnv } from '../src/acp/spawn-driver.js'
+import { LocalDriver, resolveWindowsCodexNative, sanitizeWindowsCodexAdapterEnv } from '../src/acp/spawn-driver.js'
 import type { SpawnDriver, SpawnRequest, SpawnedRuntime } from '../src/acp/spawn-driver.js'
 
 /**
@@ -182,5 +184,41 @@ describe('SpawnDriver seam', () => {
     await npxHost.start()
     expect(npx.requests[0]?.hints).toEqual([{ envVar: 'CODEX_PATH', command: 'codex' }])
     await npxHost.stop(10)
+  })
+})
+
+/**
+ * A missing or unrunnable command must fail the launch, not the daemon. Node emits
+ * `error` (and then `close`) on the ChildProcess with no `exit`; an unhandled
+ * `error` event is rethrown as an uncaught exception, which would take down every
+ * other agent this daemon runs.
+ */
+describe('LocalDriver spawn failures', () => {
+  const missing = join(tmpdir(), 'agentconnect-nonexistent-runtime')
+
+  it('surfaces the spawn error on the agent stream instead of crashing the process', async () => {
+    const driver = new LocalDriver()
+    const runtime = await driver.launch({ command: missing, args: ['acp'], env: {} })
+    await expect(new Response(runtime.fromAgent as any).text()).rejects.toThrow(/ENOENT/)
+  })
+
+  it('stops immediately instead of waiting out the kill deadline for a pid that never existed', async () => {
+    const driver = new LocalDriver()
+    const runtime = await driver.launch({ command: missing, args: ['acp'], env: {} })
+    await new Promise<void>((resolve) => runtime.onExit(resolve))
+    const started = Date.now()
+    await runtime.stop(5000)
+    expect(Date.now() - started).toBeLessThan(1000)
+  })
+
+  it('reaches terminal exit so lifecycle waiters do not hang', async () => {
+    const driver = new LocalDriver()
+    const runtime = await driver.launch({ command: missing, args: ['acp'], env: {} })
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        runtime.onExit(resolve)
+        setTimeout(() => reject(new Error('onExit never fired after a failed spawn')), 2000)
+      })
+    ).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
## Problem

`LocalDriver.launch` spawns the ACP runtime without an `'error'` listener on the child process. A command that cannot be executed emits `'error'` and never `'exit'`, and Node rethrows an unhandled `'error'` event as an uncaught exception — so **one broken runtime binary terminates the whole daemon**, taking every other agent it hosts with it.

The startup runtime probe makes this easy to hit: it spawns every curated runtime whose command resolves on `PATH`. On a fresh self-host install, a leftover `hermes` wrapper whose Python venv interpreter had been removed was enough to kill the daemon on every start:

```
[agentconnect] INFO  daemon ready
[agentconnect] INFO  cp: connecting to ws://localhost:8080/daemon/ws…
[agentconnect] INFO  probe: sweeping 1 runtime(s): hermes-agent
node:events:487
      throw er; // Unhandled 'error' event
      ^
Error: spawn /Users/me/.local/bin/hermes ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
```

Worth noting for anyone tempted by a pre-flight check: the file existed and was executable. The `ENOENT` came from its **shebang interpreter** being gone, which only `execve` can discover.

`probeRuntime` documents itself as "Never throws: any failure (spawn error, handshake failure, timeout) is captured in `{ ok: false, error }`" — its `try/catch` cannot see an event emitted asynchronously on the child, so that contract was not actually held.

## Fix

Fail the launch instead of the process, in `packages/daemon/src/acp/spawn-driver.ts`:

- Handle `'error'` and destroy the stdio pipes with it, so the real errno reaches whoever reads the stream pair — the only failure channel this seam has. `probeRuntime` then records `{ ok: false, error }` as documented and the runtime is simply marked unavailable.
- Fire `onExit` on `'close'` as well as `'exit'`. A child that never started emits only `'close'`, so lifecycle waiters listening for `'exit'` alone would hang.
- Return early from `stop()` when the spawn failed. There is no pid to signal, and the old path burned the full deadline and then warned about a SIGTERM that no process ever ignored.

## Tests

Three cases added to `packages/daemon/test/spawn-driver.test.ts`, driving the real `LocalDriver` against a nonexistent command: the spawn error surfaces on the agent stream rather than crashing the process, `onExit` reaches terminal exit, and `stop()` returns immediately instead of waiting out the kill deadline.

Verified they fail without the source change — the first two reproduce the exact uncaught exception above:

```
⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
Error: spawn /var/folders/.../agentconnect-nonexistent-runtime ENOENT
 ❯ Process.ChildProcess._handle.onexit ../../node:internal/child_process:286:19
 Test Files  1 failed (1)
      Tests  2 failed | 5 passed (7)
```

With the change, `vitest run test/spawn-driver.test.ts` is 8/8 green, and `pnpm --filter @agentconnect.md/daemon typecheck`, `eslint`, and `prettier --check` are clean on the touched files.

On the full daemon suite this environment is already red before the change — the failures are real-runtime and timing-sensitive cases (`acp-matrix` hitting `github-copilot-cli` authorization, `mcp-bridge-e2e`, `shim-*`). For what it is worth the change strictly reduces them here: **19 failed / 5 files on the base commit → 14 failed / 4 files with the fix**, with none of the failures in the touched area.
