### PR TITLE
docs(design): remap the Linear integration onto the shipped platform-module contracts

### DIFF
--- a/docs/designs/integration-plugin-architecture.md
+++ b/docs/designs/integration-plugin-architecture.md
@@ -149,7 +149,8 @@ reason.
   _output surface_: renderer lifecycle over a converger/applier pair) is
   implemented by chat platforms **and** by the GitHub poster/collector, so
   the generalized turn record stops carrying a permanent `github` special
-  case. Linear (per its design) lands as Layer 2 + hook-style ingress;
+  case. Linear (per its revised design) lands as Layer 2 plus relay-plugin
+  ingress with only a minimal send-side Layer 1 (no socket);
   Teams/Mattermost-class platforms take the full contract.
 - **D6 — Bot demux identity stays in real columns.** `Bot.slackAppId +
 teamId` is a load-bearing composite-unique demux key (admission and
@@ -191,8 +192,8 @@ interface PlatformManifest {
 
   // ---- CP-facing axes (read at install/config time, still pre-dispatch) ----
   credentialShape: 'token' | 'token+appToken' | 'appId+appSecret' | 'appId+appSecret+signing'
-  // Demux identity shape: tenant-scoped (Slack app+team) or app/token-scoped
-  // (Linear urlToken). Drives how core persists Bot identity columns (§11).
+  // Demux identity shape: tenant-scoped (Slack app+team, Linear app+workspace)
+  // or app-scoped (Feishu app id). Drives how core persists Bot identity columns (§11).
   // NOT a per-platform constant — amended in §5.1 below.
   identityScope: 'tenant' | 'app'
   multiAgentShareable: boolean
@@ -510,12 +511,12 @@ registry.
 
 ### 7.6 Contract layering summary
 
-| Implementer                   | Layer 1 (connect + ingress + read port) | Layer 2 (turn output surface) |
-| ----------------------------- | --------------------------------------- | ----------------------------- |
-| Slack/Telegram/Discord/Feishu | yes                                     | yes                           |
-| GitHub poster                 | no                                      | yes                           |
-| Linear (per its design)       | no (hook-style ingress)                 | yes                           |
-| webchat                       | core-owned                              | core-owned                    |
+| Implementer                   | Layer 1 (connect + ingress + read port)   | Layer 2 (turn output surface) |
+| ----------------------------- | ----------------------------------------- | ----------------------------- |
+| Slack/Telegram/Discord/Feishu | yes                                       | yes                           |
+| GitHub poster                 | no                                        | yes                           |
+| Linear (per its design)       | minimal (relay-plugin ingress; no socket) | yes                           |
+| webchat                       | core-owned                                | core-owned                    |
 
 ## 8. Relay Slot
 
@@ -729,7 +730,7 @@ Two decisions specific to this host:
   ```prisma
   model Bot {
     platform          String
-    externalAppId     String?   // Slack A… app id; Linear urlToken; …
+    externalAppId     String?   // Slack A… app id; Linear OAuth client id; …
     externalTenantId  String?   // Slack T… team id; '-' sentinel where tenantless
     platformConfig    Json?     // display ids, region, portal hints
     @@unique([platform, externalAppId, externalTenantId])
@@ -738,10 +739,13 @@ Two decisions specific to this host:
 
   **Tenantless identities need a sentinel, not NULL.** Postgres treats
   NULLs as distinct in unique indexes, so a NULL `externalTenantId` would
-  not enforce uniqueness for tenant-free identities — and Linear's
-  bot-scoped `urlToken` (this table's replacement for the Linear design's
-  `linearUrlToken @unique`) must stay unique because the relay selects the
-  bot by it. Rule: **NULL is reserved for legacy rows only** (pre-capture
+  not enforce uniqueness for tenant-free identities — and a tenantless
+  platform's app id (Feishu's `cli_…`) must stay unique because the relay
+  demuxes callbacks by it. (Linear, whose earlier design minted a bot-scoped
+  `urlToken @unique` here, is tenant-scoped in its revised design — OAuth
+  client id + workspace `organizationId` on the composite index — and uses
+  the sentinel only for a not-yet-connected install.)
+  Rule: **NULL is reserved for legacy rows only** (pre-capture
   Slack rows keep today's NULLs-distinct behavior); every new row on a
   tenantless platform writes the sentinel `'-'` as `externalTenantId`, so
   the composite unique index enforces `(platform, externalAppId)`

--- a/docs/designs/integration-plugin-architecture.md
+++ b/docs/designs/integration-plugin-architecture.md
@@ -743,8 +743,8 @@ Two decisions specific to this host:
   platform's app id (Feishu's `cli_…`) must stay unique because the relay
   demuxes callbacks by it. (Linear, whose earlier design minted a bot-scoped
   `urlToken @unique` here, is tenant-scoped in its revised design — OAuth
-  client id + workspace `organizationId` on the composite index — and uses
-  the sentinel only for a not-yet-connected install.)
+  client id + workspace `organizationId` on the composite index, with rows
+  created only once the workspace is known.)
   Rule: **NULL is reserved for legacy rows only** (pre-capture
   Slack rows keep today's NULLs-distinct behavior); every new row on a
   tenantless platform writes the sentinel `'-'` as `externalTenantId`, so

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -280,8 +280,10 @@ with several agents bound to it:
   workspace's enabled members, exactly as a GitHub comment addresses one
   agent by name inside a thread the App owns. The name is plain text (agents
   are not Linear entities; only the app is mentionable), matched by
-  per-member name routes in the relay's existing ladder (compiled through
-  the §9.2 routing seams) with `defaultAgentId` as the fallback.
+  the per-member keyword routes the HTTP-bot orchestrator's compile
+  **already emits** — one unscoped `{ kind: 'keyword', value: agent.name }`
+  rule per placed non-gated member (§6.2) — with `defaultAgentId` as the
+  fallback.
 - **One AgentSession binds to one agent at creation** and never changes
   hands: follow-ups and stop go to that agent. Addressing a _different_
   agent is a new mention on the issue → a new session → another thread in
@@ -518,9 +520,9 @@ idle window).
     `host.forward(botId, msg)`. Relay-core arbitration resolves the target
     with the ladder it already runs for shared bots: `prompted` follows the
     session's thread affinity (the session's bound agent); a `created` from
-    a mention matches the per-member **name routes** the CP compiles from
-    the enabled agents' names (`@<agent-name>` in the text, §4.3; sourced
-    via `projectMemberRoutes`, §9.2); anything
+    a mention matches the per-member **name routes** the shipped HTTP-bot
+    compile already emits for every placed non-gated member
+    (`@<agent-name>` in the text, §4.3/§6.2); anything
     else — bare delegation, automation delegation, no name matched — falls
     to `defaultAgentId`. Every event is explicitly addressed by
     construction.
@@ -565,14 +567,15 @@ core-assembled as for every platform — and for Linear the shared-bot members
 are doing real work: `members`/`agents` list the workspace's enabled agents,
 `routes` carries the per-member name rules (§6.1), `defaultAgentId` the
 workspace default, and `credentialRevision` fences signing-secret rotation
-(§10.6). Two of those inputs need seams the shipped compiler lacks,
-inventoried in §9.2, because `projectBotAssign` deliberately carries **no
-routing** (only the two opaque bags — members, routes, and the default are
-assembled by the HTTP-bot orchestrator's core compile): the compiler today
-derives `defaultAgentId` as the earliest non-gated member, so the bot row
-gains a generic **persisted preferred default** it prefers when set and
-still routable; and it has no source for member-name rules, so the provider
-contributes them through the `projectMemberRoutes` contract extension. The
+(§10.6). Routing is assembled by the HTTP-bot orchestrator's core compile —
+`projectBotAssign` deliberately carries **no routing**, only the two opaque
+bags — and that compile **already emits the member-name rules Linear
+needs**: one unscoped `{ kind: 'keyword', value: agent.name }` route per
+placed non-gated member (its keyword-disambiguation loop), which is exactly
+the `@<agent-name>` path, reused with zero new code. The one input the
+compiler lacks is the default: it derives `defaultAgentId` as the earliest
+non-gated member, so the bot row gains a generic **persisted preferred
+default** it prefers when set and still routable (§9.2). The
 earlier revision's `RcLinearAssign` / `RcLinearRemove` frames and the
 relay-local Linear rule table are gone — replay-on-register, placement
 re-broadcast, and lifecycle edges are the shared machinery.
@@ -673,8 +676,8 @@ member Integration on the workspace bot (the generic existing-bot path — no
 reuse fence exists or is needed under this model); the workspace card also
 moves the default among members (persisted, §9.2 — the compiler's
 earliest-member fallback alone cannot honor a choice). Every enabled agent's
-name compiles into a member route (`projectMemberRoutes`, §9.2), which is
-what makes `@<agent-name>` addressing work.
+name already compiles into a member keyword route (the shipped compile,
+§6.2), which is what makes `@<agent-name>` addressing work.
 
 If the tail refuses after step 1 (identity taken, workspace claimed), the
 orphaned token row is inert: no bot references it, and the next connect
@@ -862,22 +865,22 @@ tile.
   - `pendingInstalls` — `linear_install_state` + TTL reaper.
   - `projectIntegrationConfig` (async, loads `linear_token` by the bot's D6
     identity — write-before-create ordering per §7.1) and `projectBotAssign`
-    (§6.2, including the per-member keyword routes and `defaultAgentId`).
+    (§6.2, strictly the two opaque bags — routing, including the per-member
+    keyword rules, is the core compile's, which already emits them).
   - `LinearTokenService` — exchange, single-flight rotate-and-retry refresh,
     revoke; surfaced to the WS `linearcred` handler (§7.3).
   - `backgroundLoops` — the orphan-token sweeper (§7.1): org-scoped
     selection, local delete always, upstream revoke only for globally
     unowned identities, behind a grace window.
-  - **Two contract extensions** this design needs core to grow, each
-    consulted only for platforms that declare it:
+  - **One contract extension** this design needs core to grow, consulted
+    only for platforms that declare it:
     `sideEffects.onBotDelete?(bot, secrets)` for the disconnect revoke
-    (§7.4), best-effort like `postCreate`; and
-    `projectMemberRoutes?(bot, members)` — the member-name keyword rules the
-    HTTP-bot orchestrator's compile folds into the assign's `routes` (§6.2),
-    which is what makes `@<agent-name>` addressing routable without a
-    Linear-named branch in the compiler. (The earlier revision's
-    `validateBotReuse` reuse fence died with the per-agent-app model —
-    adding a member agent is an ordinary, unfenced operation now.)
+    (§7.4), best-effort like `postCreate`. (The earlier revision's
+    `validateBotReuse` reuse fence died with the per-agent-app model, and a
+    `projectMemberRoutes` extension briefly sketched here died on
+    inspection: the shipped compile's keyword-disambiguation loop already
+    emits exactly the member-name routes §4.3 needs, so member addressing
+    costs no contract change at all.)
   - **One generic core change**: a persisted bot-level **preferred default
     agent** (nullable), preferred by the orchestrator's compile over its
     earliest-non-gated fallback and settable from the workspace card —
@@ -1038,8 +1041,9 @@ tile.
 
 - **P1 — the core loop.** `linearcred` frames; deployment-app configuration
   (Setup Server document + `envSchema` slice); CP provider (connect funnel +
-  callback, member/default management, token service + broker, projectors
-  with keyword routes, the `onBotDelete` contract extension) + registry
+  callback, member/default management, token service + broker, projectors,
+  the persisted preferred default, the `onBotDelete` contract extension) +
+  registry
   line; relay ingress plugin + registry line; daemon module (connection,
   ack with agent attribution, converger
   `thought`/`action`/`response`/`error`, follow-ups, stop, config schema) +
@@ -1085,9 +1089,9 @@ tile.
   winner); D6 external-identity and workspace-claim 409s; the workspace bot
   is created `shareable: true` and a second member Integration is admitted
   (the manifest's `multiAgentShareable` row, §9.1); member add/remove
-  recompiles member routes without touching the token; the compile prefers
-  the persisted default over the earliest member and `projectMemberRoutes`
-  output reaches the assign's `routes`; removing the default
+  recompiles the compile's existing member-name keyword routes without
+  touching the token; the compile prefers the persisted default over the
+  earliest member; removing the default
   agent is blocked until a new default is named; reconnect replaces a dead
   token in place; broker scope denial for a foreign daemon; workspace
   disconnect (bot delete) revoke convergence.

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -242,6 +242,14 @@ The mapping onto existing tables:
   before the workspace is known. `transport` is always `http`; `shareable` is
   dropped by the provider (one app = one agent).
 - **`Integration`** = the bot's agent binding (1:1 for Linear).
+- **The app-as-agent identity is durable.** The operator manually names and
+  brands the Linear app after one agent, and AgentConnect cannot push that
+  branding — so the bot records the agent it was branded for
+  (`platformConfig.brandedAgentId`, stamped at funnel start) and every
+  binding, including reuse of a freed bot, is fenced to that agent (§7.4).
+  An app visibly named "Agent A" must never route delegations to Agent B;
+  rebinding is a deliberate rebrand — delete the bot and install fresh for
+  the new agent (an explicit rebrand-and-reconnect flow is P3).
 - Installing the same app into a **second workspace** is a second Bot row
   created from the same pasted app credentials (v1: run the wizard again;
   a credential-reuse affordance is P3). The composite unique
@@ -270,15 +278,20 @@ Postgres (precedent: Slack config-token rotate-and-retry). The daemon never
 holds the client secret or refresh token. Instead:
 
 - The provider stores `{accessToken, refreshToken, expiresAt}` per
-  **workspace install — 1:1 with the Bot row, not the Integration** — in its
-  own `linear_token` table, encrypted through the existing `SecretCipher`
-  seam. The token is the workspace's authorization of the app, so it belongs
-  to the install identity and survives the agent binding: deleting an
-  integration frees the bot **with** its token, which is what makes generic
+  **workspace install** in its own `linear_token` table, encrypted through
+  the existing `SecretCipher` seam — keyed by the **install identity**
+  `(orgId, clientId, organizationId)`, the same pair the bot's D6 columns
+  mirror, **not by the Bot row id**. The token is the workspace's
+  authorization of the app, so it belongs to that identity and survives both
+  the agent binding and the Bot row itself. Two things fall out of the key
+  choice: the OAuth callback can write the token **before** any Bot row
+  exists (which is what makes §7.1's ordering implementable against the
+  shipped create tail, whose bot id is minted internally), and deleting an
+  integration frees the bot with its token, which is what makes same-agent
   bot reuse work (§7.4). (The CP provider contract's projectors are async for
   exactly this case — the provider loads from its own secret store inside
-  `projectIntegrationConfig`, resolving the integration's bot; core awaits
-  uniformly.)
+  `projectIntegrationConfig`, resolving by the bot's D6 identity; core
+  awaits uniformly.)
 - `projectIntegrationConfig` embeds the **current access token + expiry** in
   the opaque `IntegrationSpec.config`, so `agent.json` always carries a ≤24 h
   token — the daemon can restart and keep posting activities while the CP is
@@ -576,27 +589,43 @@ https://linear.app/oauth/authorize?client_id=…&redirect_uri=…&response_type=
 
 The public callback exchanges the code at
 `https://api.linear.app/oauth/token`, queries
-`viewer { id organization { id name } }`, and only now — with the workspace
-identity **and** a token in hand — runs the shared create tail in one
-transaction: Bot (D6 identity `externalAppId` = client id,
-`externalTenantId` = `organizationId`; display `workspaceId`/`workspaceName`;
-`botUserId` = the app user id) + the `BotSecret` row + the `linear_token` row
+`viewer { id organization { id name } }`, and proceeds in an order the
+shipped create tail supports **without a new persistence seam** — possible
+only because `linear_token` is keyed by the install identity, not the Bot
+row id (§4.4; `installNewBot` mints the bot id internally and calls
+`syncBot` before returning, so a bot-keyed row could never be inserted in
+between):
 
-- the Integration, `active` from birth. The D6 composite pre-check and the
-  cross-org `workspaceClaim` fence run here, and the tail's normal `syncBot`
-  hand-off broadcasts `rc/bot-assign` + `integration/upsert` — the projector
-  finds its token because the row order guarantees it.
+1. **Upsert `linear_token`** under `(orgId, clientId, organizationId)` —
+   idempotent, replacing any prior row for the same workspace install (the
+   reconnect flow of §7.4 is this same arm).
+2. **Run the shared create tail unchanged**: `buildNewBotInstall` packs the
+   Bot columns (D6 identity `externalAppId` = client id, `externalTenantId`
+   = `organizationId`; display `workspaceId`/`workspaceName`; `botUserId` =
+   the app user id), the D6 composite pre-check and the cross-org
+   `workspaceClaim` fence run, the `BotSecret` row and the Integration
+   (`active` from birth) are written, and the tail's normal `syncBot`
+   hand-off broadcasts `rc/bot-assign` + `integration/upsert`.
+   `projectIntegrationConfig` resolves the token by the bot's D6 identity —
+   already durable from step 1, so the ordering is guaranteed by
+   construction rather than by a transaction the tail does not offer.
+
+If the tail refuses after step 1 (identity taken, workspace claimed), the
+orphaned token row is inert: no bot references it, the next connect attempt
+for the same workspace overwrites it, and the flows that own the identity
+delete it (§7.4). The funnel row's TTL reaper separately bounds how long the
+funnel-held pasted secrets linger.
 
 ### 7.2 Storage
 
-| Value                                           | Where                                                                                                                  | Visibility                                                     |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| Client ID                                       | `Bot.externalAppId` (D6 column)                                                                                        | console, authorize URL, relay ingress bag                      |
-| Workspace (organization) id                     | `Bot.externalTenantId` + display `workspaceId`/`workspaceName`                                                         | console, relay ingress bag                                     |
-| Client Secret                                   | `BotSecret.botToken` slot (`secretShape.slots` labels it)                                                              | CP only (code exchange + refresh)                              |
-| Webhook signing secret                          | `BotSecret.signingSecret` slot; `httpAssignRequires: ['signingSecret']`                                                | relay only, via the `rc/bot-assign` secrets bag                |
-| Access + refresh token, expiry                  | provider-owned `linear_token` table, **1:1 with the Bot** (the workspace install, §4.4), values through `SecretCipher` | access token → daemon (spec + broker); refresh token → CP only |
-| Pasted credentials + `state` nonce, pre-connect | provider-owned `linear_install_state` funnel table (SecretCipher values, TTL-reaped)                                   | CP only                                                        |
+| Value                                           | Where                                                                                                                                        | Visibility                                                     |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Client ID                                       | `Bot.externalAppId` (D6 column)                                                                                                              | console, authorize URL, relay ingress bag                      |
+| Workspace (organization) id                     | `Bot.externalTenantId` + display `workspaceId`/`workspaceName`                                                                               | console, relay ingress bag                                     |
+| Client Secret                                   | `BotSecret.botToken` slot (`secretShape.slots` labels it)                                                                                    | CP only (code exchange + refresh)                              |
+| Webhook signing secret                          | `BotSecret.signingSecret` slot; `httpAssignRequires: ['signingSecret']`                                                                      | relay only, via the `rc/bot-assign` secrets bag                |
+| Access + refresh token, expiry                  | provider-owned `linear_token` table, keyed by the install identity `(orgId, clientId, organizationId)` (§4.4), values through `SecretCipher` | access token → daemon (spec + broker); refresh token → CP only |
+| Pasted credentials + `state` nonce, pre-connect | provider-owned `linear_install_state` funnel table (SecretCipher values, TTL-reaped)                                                         | CP only                                                        |
 
 The opaque `IntegrationSpec.config` payload the provider projects (validated
 on the daemon by the linear module's schema in `CONFIG_SCHEMAS`):
@@ -633,30 +662,35 @@ replying, then a spec re-push so `agent.json` converges.
 
 ### 7.4 Unbind, reuse, uninstall, revocation
 
-Three distinct lifecycle edges, because the token rides the Bot (§4.4):
+Three distinct lifecycle edges, because the token rides the workspace-install
+identity (§4.4):
 
 - **Unbind the agent** — `DELETE /integrations/:id` rides the standard
   uninstall broadcast (bot unassign + `integration/remove`) and **keeps** the
-  bot's `linear_token`: the workspace's authorization of the app is still
-  live at Linear, and the freed bot _is_ that still-authorized install.
-  Generic web reuse therefore composes as-is: `freeBotFilter` offers the
-  freed bot, `buildReuseInput` binds a new agent, and the projector/broker
-  find the token by bot id — no OAuth re-run, no modal detour.
+  `linear_token`: the workspace's authorization of the app is still live at
+  Linear, and the freed bot _is_ that still-authorized install. Reuse
+  therefore needs no OAuth re-run — but it is **same-agent only** (§4.3):
+  the module's `freeBotFilter` offers a freed bot only for the agent recorded
+  in `platformConfig.brandedAgentId`, and the CP enforces the same fence
+  durably on the reuse path through the provider's `validateBotReuse` (the
+  second contract extension, §9.2) — a 409 whose copy says to rebrand the
+  app at Linear and reinstall, never a silent rebind of an app visibly named
+  for another agent. Within the fence, the projector/broker find the token
+  by the bot's D6 identity — no modal detour.
 - **Uninstall** — deleting the **Bot** is the real teardown: best-effort
-  `POST /oauth/revoke` at Linear plus deletion of the `linear_token` row.
-  The shipped `CpPlatformProvider` has no bot-delete lifecycle member, so
-  this design adds the one contract extension it needs:
+  `POST /oauth/revoke` at Linear plus deletion of the identity's
+  `linear_token` row. The shipped `CpPlatformProvider` has no bot-delete
+  lifecycle member, so this design adds one:
   `sideEffects.onBotDelete?(bot, secrets)` — best-effort by contract like
   `postCreate`, called from core's bot-delete path for any platform that
   declares it.
 - **Dead token** (refresh rejected, app secret rotated, workspace revoked
   upstream) — the integration flips `error` with a **Reconnect** CTA: an
   org-scoped provider route restarts the OAuth funnel against the existing
-  bot, and the callback's update arm (matched by the D6 identity) replaces
-  the `linear_token` row in place. The `OAuthApp revoked` doorbell (§6.1)
-  converges the same state when revocation originates on the Linear side —
-  re-verified at the CP behind the `credentialRevision` fence, never trusted
-  from the payload.
+  bot, and the callback's step-1 upsert (§7.1) replaces the `linear_token`
+  row in place. The `OAuthApp revoked` doorbell (§6.1) converges the same
+  state when revocation originates on the Linear side — re-verified at the
+  CP behind the `credentialRevision` fence, never trusted from the payload.
 
 ## 8. Prompt assembly and trust boundary
 
@@ -724,24 +758,31 @@ tile.
     Feishu one-click precedent), packing the secret slots and declaring the
     D6 `externalIdentity` `(clientId, organizationId)` + the
     `workspaceClaim`.
-  - `secretShape` (§7.2); `projectBotIdentity` (clientId / organizationId).
-  - `installRoutes('org')` — funnel start, connect status, reconnect (§7.4);
+  - `secretShape` (§7.2); `projectBotIdentity` (clientId / organizationId;
+    `platformConfig` carries `brandedAgentId` (§4.3) + workspace display
+    metadata).
+  - `installRoutes('org')` — funnel start (stamps `brandedAgentId` from the
+    selected agent), connect status, reconnect (§7.4);
     `installRoutes('public-callback')` — the OAuth callback (§7.1). Repo
     OpenAPI conventions on every route.
   - `pendingInstalls` — `linear_install_state` + TTL reaper.
-  - `projectIntegrationConfig` (async, loads `linear_token` by the
-    integration's bot) and `projectBotAssign` (§6.2).
+  - `projectIntegrationConfig` (async, loads `linear_token` by the bot's D6
+    identity — write-before-create ordering per §7.1) and `projectBotAssign`
+    (§6.2).
   - `LinearTokenService` — exchange, single-flight rotate-and-retry refresh,
     revoke; surfaced to the WS `linearcred` handler (§7.3).
-  - **One contract extension** this design needs core to grow:
+  - **Two contract extensions** this design needs core to grow, both
+    consulted only for platforms that declare them:
     `sideEffects.onBotDelete?(bot, secrets)` for the uninstall revoke (§7.4),
-    best-effort like `postCreate`.
+    best-effort like `postCreate`; and `validateBotReuse?(bot, agentId)` on
+    the existing-bot reuse path, returning the 409 refusal that keeps a
+    freed bot fenced to its branded agent (§7.4).
 - Prisma: new `linear_token` and `linear_install_state` tables only — Bot
   identity rides the existing D6 columns, and `platform` columns are already
   text.
 - Tests: provider unit (schema guards, projector shapes); integration-route +
   OAuth callback + broker integration tests against a fake Linear token
-  endpoint; workspace-claim and external-identity 409s.
+  endpoint; workspace-claim, external-identity, and cross-agent-reuse 409s.
 
 ### 9.3 `packages/relay`
 
@@ -804,8 +845,10 @@ tile.
   - `Mark` — Linear brand SVG (60 % box, `fillPct` convention).
   - `wizard` — the two-step facet (§7.1); tile availability = daemon
     capability ∧ `relayCapability.available`; `freeBotFilter` /
-    `buildReuseInput` offer a freed bot as-is — its workspace token rides the
-    Bot row (§7.4), so reuse needs no OAuth detour.
+    `buildReuseInput` offer a freed bot **only to its branded agent**
+    (`platformConfig.brandedAgentId`, §4.3/§7.4) — its workspace token rides
+    the install identity, so same-agent reuse needs no OAuth detour, and the
+    CP's `validateBotReuse` fence backs the client-side filter.
   - `apiBindings` — funnel-start, connect-status, and reconnect calls.
   - `settingsFragments` — workspace name, connect status, reconnect action
     when the token is dead (§7.4).
@@ -882,8 +925,9 @@ tile.
 ## 13. Phasing
 
 - **P1 — the core loop.** `linearcred` frames; CP provider (install funnel +
-  callback, token service + broker, projectors, the `onBotDelete` contract
-  extension) + registry line; relay ingress plugin + registry line; daemon
+  callback, token service + broker, projectors, the `onBotDelete` and
+  `validateBotReuse` contract extensions) + registry line; relay ingress
+  plugin + registry line; daemon
   module (connection, ack, converger `thought`/`action`/`response`/`error`,
   follow-ups, stop, config schema) + the §9.4 composition lines; web module
   (wizard, mark, settings, session display) + registry line. Exit criteria:
@@ -921,10 +965,13 @@ tile.
   projector output shapes.
 - **CP integration:** funnel start → callback → active lifecycle against a
   stubbed Linear OAuth server, asserting **no Bot/Integration row exists
-  before the callback**; D6 external-identity and workspace-claim 409s;
-  unbind keeps the bot's token and generic reuse re-projects it; reconnect
-  replaces a dead token in place; broker scope denial for a foreign daemon;
-  bot-delete revoke convergence.
+  before the callback** and that the token upsert precedes the create tail
+  (a tail refusal after step 1 leaves an inert row the next connect
+  overwrites); D6 external-identity and workspace-claim 409s; unbind keeps
+  the workspace token, same-agent reuse re-projects it, and cross-agent
+  reuse 409s through `validateBotReuse`; reconnect replaces a dead token in
+  place; broker scope denial for a foreign daemon; bot-delete revoke
+  convergence.
 - **Live checklist:** real OAuth app in a scratch Linear workspace —
   delegate, mention, follow-up, stop, redelivery replay (Linear's webhook
   console), token refresh across the 24 h boundary, workspace revoke.

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -611,10 +611,16 @@ between):
    construction rather than by a transaction the tail does not offer.
 
 If the tail refuses after step 1 (identity taken, workspace claimed), the
-orphaned token row is inert: no bot references it, the next connect attempt
-for the same workspace overwrites it, and the flows that own the identity
-delete it (§7.4). The funnel row's TTL reaper separately bounds how long the
-funnel-held pasted secrets linger.
+orphaned token row is inert: no bot references it, and the next connect
+attempt for the same workspace overwrites it. Inert is not unbounded — the
+row holds an encrypted refresh token and has no Bot FK for §7.4's delete
+flow to find, so the provider registers an **orphan-token sweeper** via the
+contract's `backgroundLoops`: any `linear_token` row whose identity matches
+no Bot and whose last write is older than a grace window (long enough to
+never race a callback between steps 1 and 2, e.g. 1 h) is revoked
+best-effort at Linear and deleted. The same sweep is the backstop for a
+failed best-effort `onBotDelete` (§7.4). The funnel row's TTL reaper
+separately bounds how long the funnel-held pasted secrets linger.
 
 ### 7.2 Storage
 
@@ -771,6 +777,14 @@ tile.
     (§6.2).
   - `LinearTokenService` — exchange, single-flight rotate-and-retry refresh,
     revoke; surfaced to the WS `linearcred` handler (§7.3).
+  - `backgroundLoops` — the orphan-token sweeper (§7.1): revoke-and-delete
+    for token identities with no matching Bot, behind a grace window.
+  - `BotDto` projection — the shipped `/bots` DTO does not expose
+    `platformConfig`, so the inventory includes a generic, validated
+    **public-metadata projection** of that bag (public by construction — D6
+    reserves it for display metadata, never secret material), which is what
+    lets the web module's `freeBotFilter` read `brandedAgentId`. Until it
+    lands, the wizard leans on the authoritative `validateBotReuse` 409.
   - **Two contract extensions** this design needs core to grow, both
     consulted only for platforms that declare them:
     `sideEffects.onBotDelete?(bot, secrets)` for the uninstall revoke (§7.4),
@@ -845,10 +859,11 @@ tile.
   - `Mark` — Linear brand SVG (60 % box, `fillPct` convention).
   - `wizard` — the two-step facet (§7.1); tile availability = daemon
     capability ∧ `relayCapability.available`; `freeBotFilter` /
-    `buildReuseInput` offer a freed bot **only to its branded agent**
-    (`platformConfig.brandedAgentId`, §4.3/§7.4) — its workspace token rides
-    the install identity, so same-agent reuse needs no OAuth detour, and the
-    CP's `validateBotReuse` fence backs the client-side filter.
+    `buildReuseInput` offer a freed bot **only to its branded agent**,
+    reading `brandedAgentId` from the `BotDto` public-metadata projection
+    (§9.2 inventory item) — its workspace token rides the install identity,
+    so same-agent reuse needs no OAuth detour. The filter is convenience;
+    the CP's `validateBotReuse` 409 is the authoritative fence either way.
   - `apiBindings` — funnel-start, connect-status, and reconnect calls.
   - `settingsFragments` — workspace name, connect status, reconnect action
     when the token is dead (§7.4).

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -11,6 +11,13 @@
 > `platform_action`, the relay platform-ingress plugin, and the CP platform
 > provider.
 >
+> Second 2026-08 revision: the identity model flipped from **one OAuth app per
+> agent** to **one deployment-owned Linear app** fronting every agent — the
+> GitHub-App model. An issue behaves like a channel with several agents bound
+> to it: delegation reaches the workspace's default agent, `@<agent-name>` in
+> the mention text addresses a specific one (GitHub-events semantics), and
+> per-agent identity renders as in-content attribution (§4.3, §5).
+>
 > Related documents:
 > [architecture.md](architecture.md),
 > [integration-plugin-architecture.md](integration-plugin-architecture.md),
@@ -45,8 +52,8 @@ rather than inventing a Linear-shaped side channel.
 
 | Linear agent experience                             | This design                                                  | Phase |
 | --------------------------------------------------- | ------------------------------------------------------------ | ----- |
-| Assign/delegate an issue to the agent               | `AgentSessionEvent created` → new session                    | P1    |
-| Mention with instructions in a comment              | Same webhook, comment context                                | P1    |
+| Assign/delegate an issue to the app                 | `AgentSessionEvent created` → session with the default agent | P1    |
+| Address a specific agent with instructions          | Same webhook; `@<agent-name>` in the mention text routes     | P1    |
 | Instant acknowledgement in the feed                 | Daemon-side auto-ack `thought` before the turn starts        | P1    |
 | Real-time activity feed (commands, files, progress) | `LinearConverger` → `agentActivityCreate`                    | P1    |
 | Follow-up messages in the session thread            | `prompted` → same AgentConnect session                       | P1    |
@@ -63,10 +70,11 @@ rather than inventing a Linear-shaped side channel.
 issue (they receive a bounded unsupported-surface response, §4.5 — never a
 crash or silence),
 proactive session creation (`agentSessionCreateOnIssue`) as a cron/sendMessage
-target, marketplace/public-app distribution, per-team configuration, a shared
-multi-agent app (a Linear app _is_ one agent's identity — sharing does not fit
-the model; see §4.3), and multi-workspace install UX beyond "run the wizard
-again" (§4.3, P3).
+target, marketplace/public-app distribution, per-team configuration (default
+agents are per workspace; a per-team mapping is P3), and **dedicated
+per-agent Linear apps** — every agent fronts through the one deployment app
+with in-content attribution; §4.3 records why the per-agent-app model of
+earlier revisions was dropped.
 
 ## 2. Background: Linear's agent protocol in one page
 
@@ -123,7 +131,9 @@ No socket/long-poll transport exists — **webhooks are the only ingress**.
 Linear is a **chat-kind platform module** (`PlatformId` `'linear'`,
 `originKind: 'chat'`) whose _ingress_ is relay-terminated (like Slack HTTP
 transport and Feishu callbacks) and whose _egress_ is daemon-direct GraphQL
-(like every other platform's outbound path). The Control Plane stays off the
+(like every other platform's outbound path). Its Linear-side identity is the
+**deployment's one OAuth app** (§4.3); a connected workspace is a shared bot
+whose members are the enabled agents. The Control Plane stays off the
 message hot path.
 
 Adding it is close to the checklist-shaped task the plugin architecture
@@ -197,9 +207,9 @@ platform tables is that they have no chat ingress and implement a much
 narrower surface.
 
 Linear has chat ingress in all but name. Its product hands us the platform
-shape natively: the OAuth app _is_ the assignable identity users pick in the
-delegate menu (§4.3), so each agent needs its own app — a `Bot` row with
-`Integration` as its agent binding, the same tables every chat platform uses.
+shape natively: the deployment's OAuth app is the identity users delegate to
+and mention (§4.3), a connected workspace is a `Bot` row with `Integration`
+rows as its enabled-agent members — the same tables every chat platform uses.
 Its sessions are conversations (channel = issue, thread = agent session) with
 follow-ups and a streaming reply surface. Linear therefore implements all four
 platform contracts and renders in the console as ordinary conversations
@@ -223,52 +233,65 @@ enforces for `transport: 'http'` at create time. The web wizard tile is gated
 on the daemon advertising `linear` (`capabilities.platforms`, read by the CP's
 pre-install gate and the console) **and** on `WizardHost.relayCapability`.
 
-### 4.3 One Linear OAuth app per agent; one Bot row per workspace install
+### 4.3 One deployment-owned Linear app; a Bot row per connected workspace; agents are members
 
-In Linear, the OAuth app _is_ the assignable identity — its name and icon are
-what users see in the delegate menu. "Assign it to MyAgent" therefore requires
-each agent to have its own app, exactly as each Slack bot today is its own
-Slack app. Linear has no app-creation API, so the user creates the app
-manually in Linear settings and pastes three values into the console (§7). A
-single shared app fronting many agents would collapse them into one Linear
-identity and force label/keyword dispatch — rejected.
+The deployment operates **one Linear OAuth app** — the same class of
+deployment infrastructure as its GitHub App, Google App, and Slack platform
+app, administered the same way (Setup Server owns the typed deployment
+document and write-only secrets for a self-host; a managed deployment ships
+one product-branded app for every customer workspace). Linear has no
+app-creation API, so this one app is created manually, **once per
+deployment**, never per agent and never per organization (§7.1).
 
-The mapping onto existing tables:
+The mapping onto existing tables — the Slack shared-bot shape, not a new one:
 
-- **`Bot`** (platform `linear`) = **one workspace install** of the OAuth app.
-  D6 identity columns: `externalAppId` = the OAuth client id,
-  `externalTenantId` = the Linear `organizationId` (the workspace) — always
-  complete, because the rows are created at the OAuth callback (§7.1), never
-  before the workspace is known. `transport` is always `http`; `shareable` is
-  dropped by the provider (one app = one agent).
-- **`Integration`** = the bot's agent binding (1:1 for Linear).
-- **The app-as-agent identity is durable.** The operator manually names and
-  brands the Linear app after one agent, and AgentConnect cannot push that
-  branding — so the bot records the agent it was branded for
-  (`platformConfig.brandedAgentId`, stamped at funnel start) and every
-  binding, including reuse of a freed bot, is fenced to that agent (§7.4).
-  An app visibly named "Agent A" must never route delegations to Agent B;
-  rebinding is a deliberate rebrand — delete the bot and install fresh for
-  the new agent (an explicit rebrand-and-reconnect flow is P3).
-- Installing the same app into a **second workspace** is a second Bot row
-  created from the same pasted app credentials (v1: run the wizard again;
-  a credential-reuse affordance is P3). The composite unique
-  `(platform, externalAppId, externalTenantId)` fences duplicates, and the
-  cross-org `workspaceClaim` fence refuses a workspace another organization
-  already holds — two rows sharing one signing secret **and** one workspace
-  would make delivery attribution a pool-order accident.
+- **`Bot`** (platform `linear`) = **one connected workspace**. D6 identity
+  columns: `externalAppId` = the deployment app's client id (constant across
+  rows), `externalTenantId` = the Linear `organizationId` — always complete,
+  because the rows are created at the OAuth callback (§7.1), never before
+  the workspace is known. `transport` is always `http`.
+- **`Integration`** = one **enabled agent** on that workspace
+  (`Integration.botId` is deliberately non-unique — the shared-bot
+  precedent). The workspace records a **default agent** among its members,
+  compiled into `rc/bot-assign.defaultAgentId` like any shared bot's.
+- The cross-org `workspaceClaim` fence refuses a workspace another
+  organization already holds — every workspace's events verify against the
+  same deployment signing secret, so the tenant composite is the only thing
+  standing between two organizations' attributions.
 
-**Delta from the earlier revision**, recorded because the parent design's §11
-once cited it: the old shape was one Bot = the app, integrations = workspaces,
-demuxed by a minted capability-URL token (`linearUrlToken @unique`). It is
-superseded because the relay's shipped demux and arbitration are keyed by
-per-assignment `(appId, tenantId)` identity
-([integration-plugin-architecture.md §5.1](integration-plugin-architecture.md)) —
-and Linear's multi-workspace app is exactly the tenant-scoped shape that axis
-was built for: every install shares one client id and one signing secret, so
-the composite is the only safe demux. A one-bot-many-workspaces shape would
-have needed a workspace-selection mechanism _inside_ a bot that no other
-platform has, plus the bespoke rule table to carry it.
+**Trigger model — GitHub-events semantics.** An issue behaves like a channel
+with several agents bound to it:
+
+- **Delegating an issue to the app** (no text) starts a session with the
+  workspace's **default agent**. Linear-side automations that auto-delegate
+  land here too.
+- **Mentioning the app with text** starts a session with the agent the text
+  names — `@<agent-name>` anywhere in the instruction, matched against the
+  workspace's enabled members, exactly as a GitHub comment addresses one
+  agent by name inside a thread the App owns. The name is plain text (agents
+  are not Linear entities; only the app is mentionable), matched by the
+  relay's compiled per-member keyword routes with `defaultAgentId` as the
+  fallback — the Slack shared-bot ladder, unchanged.
+- **One AgentSession binds to one agent at creation** and never changes
+  hands: follow-ups and stop go to that agent. Addressing a _different_
+  agent is a new mention on the issue → a new session → another thread in
+  the same channel. Naming several agents in one mention selects the first;
+  Linear mints exactly one session per mention, so there is nothing to
+  broadcast to (unlike GitHub's `@app-slug` fan-out).
+- **Identity renders in content**, not in the sender: the feed shows the one
+  app's name and icon, the ≤10 s ack opens with the acting agent's name, and
+  the final `response` carries the attribution footer — the GitHub comment
+  model, using the same chrome helpers (§5).
+
+**Rejected — one OAuth app per agent** (the model of every earlier revision
+of this section): it made each agent a first-class assignable identity in
+Linear's delegate menu, but Linear has no app-creation API, so it priced
+every agent at a manual app-creation checklist and cluttered the delegate
+menu in proportion to fleet size; the integrations in Linear's own agent
+directory are one app per product. A hybrid (shared app plus optional
+dedicated apps) was also rejected as two install stories to explain and
+maintain. The cost accepted in exchange: `@<agent-name>` works only inside
+an app mention, and per-agent avatars do not appear in the feed.
 
 ### 4.4 Token custody: CP owns refresh, daemon gets brokered access tokens
 
@@ -278,20 +301,19 @@ Postgres (precedent: Slack config-token rotate-and-retry). The daemon never
 holds the client secret or refresh token. Instead:
 
 - The provider stores `{accessToken, refreshToken, expiresAt}` per
-  **workspace install** in its own `linear_token` table, encrypted through
-  the existing `SecretCipher` seam — keyed by the **install identity**
+  **connected workspace** in its own `linear_token` table, encrypted through
+  the existing `SecretCipher` seam — keyed by the **connection identity**
   `(orgId, clientId, organizationId)`, the same pair the bot's D6 columns
   mirror, **not by the Bot row id**. The token is the workspace's
   authorization of the app, so it belongs to that identity and survives both
-  the agent binding and the Bot row itself. Two things fall out of the key
-  choice: the OAuth callback can write the token **before** any Bot row
+  agent-membership churn and the Bot row itself. Two things fall out of the
+  key choice: the OAuth callback can write the token **before** any Bot row
   exists (which is what makes §7.1's ordering implementable against the
-  shipped create tail, whose bot id is minted internally), and deleting an
-  integration frees the bot with its token, which is what makes same-agent
-  bot reuse work (§7.4). (The CP provider contract's projectors are async for
-  exactly this case — the provider loads from its own secret store inside
-  `projectIntegrationConfig`, resolving by the bot's D6 identity; core
-  awaits uniformly.)
+  shipped create tail, whose bot id is minted internally), and adding or
+  removing member agents never touches the credential. (The CP provider
+  contract's projectors are async for exactly this case — the provider loads
+  from its own secret store inside `projectIntegrationConfig`, resolving by
+  the bot's D6 identity; core awaits uniformly.)
 - `projectIntegrationConfig` embeds the **current access token + expiry** in
   the opaque `IntegrationSpec.config`, so `agent.json` always carries a ≤24 h
   token — the daemon can restart and keep posting activities while the CP is
@@ -329,7 +351,9 @@ install.
     well-keyed.
   - `thread` = the AgentSession UUID. A second delegation or a new comment
     mention on the same issue is a new Linear session → a new AgentConnect
-    session in the same channel, matching Slack's thread model.
+    session in the same channel, matching Slack's thread model — and the
+    natural way to bring a **different agent** onto the same issue (§4.3):
+    each session is bound to one agent at creation and never changes hands.
   - The relay computes its session key from `(channel, thread)` exactly as it
     does for every shared bot; the daemon's local key adds the agent id as
     usual.
@@ -366,6 +390,13 @@ per-turn Linear state (activity caps, last plan hash). GitHub's turn-final
 shape is deliberately **not** used: Linear's product is the live feed, so it
 emits as it goes, like the chat platforms.
 
+Because every agent posts through the one deployment app (§4.3), **the acting
+agent's identity is rendered in content** — the ≤10 s ack opens with the
+agent's name ("**review-bot** · reading TEAM-123 …") and the final `response`
+carries the attribution footer — the GitHub comment model, reusing the shared
+fence-aware chrome helpers. Intermediate thoughts and actions stay unprefixed:
+the session is single-agent (§4.5), so the ack has already named its owner.
+
 The converger emits a Linear-shaped IR:
 
 ```ts
@@ -390,7 +421,7 @@ coalesce aggressively, post meaningfully.
 
 | ACP update                                                               | Linear activity                                | Notes                                                                                                                                                                                                                                                                                       |
 | ------------------------------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| turn admission (`created`)                                               | `thought` (ephemeral)                          | The ≤10 s ack, posted by the dispatch path **before** agent spawn: "Reading TEAM-123 …" — or "Queued behind the current task" when the agent is busy                                                                                                                                        |
+| turn admission (`created`)                                               | `thought` (ephemeral)                          | The ≤10 s ack, posted by the dispatch path **before** agent spawn, opening with the acting agent's name: "**review-bot** · reading TEAM-123 …" — or "… queued behind the current task" when the agent is busy                                                                               |
 | `agent_thought_chunk`                                                    | `thought` (ephemeral)                          | Coalesced per idle window (reuse the 2 s idle-flush timer), tail-clamped like `MAX_REASONING`                                                                                                                                                                                               |
 | `agent_message_chunk` (intermediate, flushed at a tool boundary or idle) | `thought` (non-ephemeral)                      | Progress narration between tool calls stays visible in the feed                                                                                                                                                                                                                             |
 | `tool_call` → terminal `tool_call_update`                                | `action`                                       | Emitted once at terminal status: `action` = tool title, `parameter` = input summary, `result` = head-clamped output (~2 800 chars). Consecutive same-title calls collapse; per-turn cap with a final "… and N more" thought                                                                 |
@@ -474,9 +505,13 @@ idle window).
   returns the typed parsed `AgentSessionEvent` — parsed exactly once.
 - **`handle`**:
   - `created` / `prompted` → a `WireNormalizedMessage` (§6.3) through
-    `host.forward(botId, msg)`. Relay-core arbitration resolves the target:
-    a Linear bot has one member integration, so the compiled
-    `defaultAgentId` answers, and every event is explicitly addressed by
+    `host.forward(botId, msg)`. Relay-core arbitration resolves the target
+    with the ladder it already runs for shared bots: `prompted` follows the
+    session's thread affinity (the session's bound agent); a `created` from
+    a mention matches the per-member **keyword routes** the CP compiles from
+    the enabled agents' names (`@<agent-name>` in the text, §4.3); anything
+    else — bare delegation, automation delegation, no name matched — falls
+    to `defaultAgentId`. Every event is explicitly addressed by
     construction.
   - `prompted` + `signal: "stop"` → `host.forwardAction` with a
     `platform_action` envelope (§6.3) routed via the directory — an
@@ -512,13 +547,16 @@ produces the two opaque bags:
 { clientId, organizationId, appUserId? }
 ```
 
-The client secret and the refresh token never reach the relay. Everything
-else on the frame stays core-assembled as for every platform: the member
-directory, the compiled route/default-agent table, gating fences, and
-`credentialRevision` (which fences signing-secret rotation, §10.6). The
-earlier revision's `RcLinearAssign` / `RcLinearRemove` frames and the
-relay-local Linear rule table are gone — replay-on-register, placement
-re-broadcast, and lifecycle edges are the shared machinery.
+The signing secret is the deployment app's (§7.1), stamped into each
+workspace bot's secret row at connect; the client secret and the refresh
+token never reach the relay. Everything else on the frame stays
+core-assembled as for every platform — and for Linear the shared-bot members
+are doing real work: `members`/`agents` list the workspace's enabled agents,
+`routes` carries the per-member keyword rules (§6.1), `defaultAgentId` the
+workspace default, and `credentialRevision` fences signing-secret rotation
+(§10.6). The earlier revision's `RcLinearAssign` / `RcLinearRemove` frames
+and the relay-local Linear rule table are gone — replay-on-register,
+placement re-broadcast, and lifecycle edges are the shared machinery.
 
 ### 6.3 Relay → daemon frames: `im` + `platform_action`
 
@@ -545,93 +583,112 @@ every interaction.
 
 ## 7. Install flow and credential model
 
-### 7.1 Console flow (the module's wizard facet, two steps)
+### 7.1 Once per deployment, once per workspace, then per agent
 
-**Step 1 — app credentials.** The user picks the agent and pastes three
-values from a Linear OAuth app they create at
-_Linear Settings → API → OAuth applications_:
-
-- Client ID (public → `Bot.externalAppId`)
-- Client Secret (CP-only)
-- Webhook signing secret (relay-only)
-
-The wizard checklist (following the Feishu module's) tells them to: name the
-app after the agent and upload the agent's icon (Linear renders the app's own
-branding; AgentConnect cannot push it); set the callback URL to
+**Once per deployment — create the Linear app.** A deployment administrator
+creates the one OAuth app at _Linear Settings → API → OAuth applications_
+and records its three values as **deployment credentials**, exactly like the
+deployment's GitHub App: on a self-host the Setup Server flow owns them
+(typed deployment document, write-only secret entries); a managed deployment
+configures its product-branded app the same way. The checklist: name and
+icon are the **product's** (per-agent branding does not exist in this model,
+§4.3); callback URL
 `<PUBLIC_CP_URL>/v1/integrations/linear/oauth/callback` (the public `/v1`
 form — the provider's `public-callback` routes are mounted at both scopes by
-core, per the Slack precedent); enable webhooks with **Agent session events**
-checked; and paste the webhook URL `https://<relay>/linear/events` (from
-`relayCapability.publicUrl`).
+core, per the Slack precedent); webhooks enabled with **Agent session
+events** checked, pointed at `https://<relay>/linear/events`. No
+organization and no agent ever handles these credentials: the provider
+receives them as its config slice (`envSchema` / deployment document — the
+`SLACK_PLATFORM_*` precedent), and the console's Linear surface stays hidden
+until they exist, the platform-app funnel's self-disable pattern.
 
-Submitting starts the provider's **install funnel** — it deliberately does
-**not** run the common create tail. `IntegrationStatus` has no pending value,
-and `installNewBot` synchronizes an `http` bot immediately, which would drive
-`projectIntegrationConfig` before any `linear_token` exists — either failing
-after rows were written or publishing an assignment the daemon cannot use. So
-**no Bot or Integration row exists until the workspace is connected**: the
-org-scoped funnel-start route validates the pasted values (shape only —
-unlike Slack `auth.test` there is no pre-persistence probe; the client secret
-is unverifiable without an OAuth exchange, so the live check is the callback
-itself), stores them with a one-shot `state` nonce in `linear_install_state`
-(SecretCipher values, TTL-reaped via `pendingInstalls`), and returns the
-authorize + webhook URLs. Core's relay-availability 409 applies here. The
-funnel-creates-the-rows shape is the Feishu one-click and Slack platform-app
-precedent, not an invention.
-
-**Step 2 — connect the workspace.** The console offers **Connect to
-Linear**: an authorize URL
+**Once per workspace — connect it (org console).** An org admin picks
+**Connect Linear**, chooses the workspace's **default agent**, and is sent
+to
 
 ```text
 https://linear.app/oauth/authorize?client_id=…&redirect_uri=…&response_type=code
   &scope=read,write,app:assignable,app:mentionable&actor=app&state=<nonce>
 ```
 
+with a one-shot `state` nonce persisted in `linear_install_state`
+(TTL-reaped via `pendingInstalls`; it carries the nonce, the initiating
+org/user, and the chosen default agent — **no secrets**, unlike the earlier
+per-agent revision's funnel). Core's relay-availability 409 applies at
+funnel start. **No Bot or Integration row exists before the callback**:
+`IntegrationStatus` has no pending value, and `installNewBot` synchronizes
+an `http` bot immediately, which would drive `projectIntegrationConfig`
+before any `linear_token` exists — the funnel-creates-the-rows shape is the
+Feishu one-click and Slack platform-app precedent.
+
 The public callback exchanges the code at
 `https://api.linear.app/oauth/token`, queries
 `viewer { id organization { id name } }`, and proceeds in an order the
 shipped create tail supports **without a new persistence seam** — possible
-only because `linear_token` is keyed by the install identity, not the Bot
+only because `linear_token` is keyed by the connection identity, not the Bot
 row id (§4.4; `installNewBot` mints the bot id internally and calls
 `syncBot` before returning, so a bot-keyed row could never be inserted in
 between):
 
 1. **Upsert `linear_token`** under `(orgId, clientId, organizationId)` —
-   idempotent, replacing any prior row for the same workspace install (the
+   idempotent, replacing any prior row for the same workspace (the
    reconnect flow of §7.4 is this same arm).
 2. **Run the shared create tail unchanged**: `buildNewBotInstall` packs the
-   Bot columns (D6 identity `externalAppId` = client id, `externalTenantId`
-   = `organizationId`; display `workspaceId`/`workspaceName`; `botUserId` =
-   the app user id), the D6 composite pre-check and the cross-org
-   `workspaceClaim` fence run, the `BotSecret` row and the Integration
-   (`active` from birth) are written, and the tail's normal `syncBot`
+   Bot columns (D6 identity `externalAppId` = the deployment app's client
+   id, `externalTenantId` = `organizationId`; display
+   `workspaceId`/`workspaceName`; `botUserId` = the app user id) and stamps
+   the deployment app credentials into the workspace bot's `BotSecret` row
+   (which is what the shipped assign machinery projects and
+   revision-fences); the D6 composite pre-check and the cross-org
+   `workspaceClaim` fence run; the Integration for the chosen default agent
+   (`active` from birth) is written; and the tail's normal `syncBot`
    hand-off broadcasts `rc/bot-assign` + `integration/upsert`.
    `projectIntegrationConfig` resolves the token by the bot's D6 identity —
    already durable from step 1, so the ordering is guaranteed by
    construction rather than by a transaction the tail does not offer.
+
+**Per agent — enable it on the workspace.** Adding an agent is one more
+member Integration on the workspace bot (the generic existing-bot path — no
+reuse fence exists or is needed under this model); the workspace card also
+moves the default among members. Every enabled agent's name compiles into a
+keyword route (§6.1), which is what makes `@<agent-name>` addressing work.
 
 If the tail refuses after step 1 (identity taken, workspace claimed), the
 orphaned token row is inert: no bot references it, and the next connect
 attempt for the same workspace overwrites it. Inert is not unbounded — the
 row holds an encrypted refresh token and has no Bot FK for §7.4's delete
 flow to find, so the provider registers an **orphan-token sweeper** via the
-contract's `backgroundLoops`: any `linear_token` row whose identity matches
-no Bot and whose last write is older than a grace window (long enough to
-never race a callback between steps 1 and 2, e.g. 1 h) is revoked
-best-effort at Linear and deleted. The same sweep is the backstop for a
-failed best-effort `onBotDelete` (§7.4). The funnel row's TTL reaper
-separately bounds how long the funnel-held pasted secrets linger.
+contract's `backgroundLoops`. Its selection and its upstream revocation are
+deliberately conditioned on **two different scopes**, because the identity
+fences are global while token rows are org-scoped — the cross-org loser
+(refused because another organization's Bot already holds the
+`(clientId, organizationId)` pair) must be sweepable even though the
+winner's Bot is alive:
+
+- **Select org-scoped:** a row is an orphan when its _own_ organization has
+  no Bot for the identity and its last write is older than a grace window
+  (long enough to never race a callback between steps 1 and 2, e.g. 1 h).
+- **Delete locally, unconditionally:** the row is dead weight in its
+  organization regardless of who else holds the identity.
+- **Revoke upstream only when no organization's Bot holds the identity
+  globally:** the same Linear app + workspace backs the winner's live
+  install, so a loser-initiated `POST /oauth/revoke` would tear it down.
+
+The same sweep is the backstop for a failed best-effort `onBotDelete`
+(§7.4). The funnel row's TTL reaper separately bounds stale connect
+attempts (the funnel row carries no secrets in this model, §7.1).
 
 ### 7.2 Storage
 
-| Value                                           | Where                                                                                                                                        | Visibility                                                     |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| Client ID                                       | `Bot.externalAppId` (D6 column)                                                                                                              | console, authorize URL, relay ingress bag                      |
-| Workspace (organization) id                     | `Bot.externalTenantId` + display `workspaceId`/`workspaceName`                                                                               | console, relay ingress bag                                     |
-| Client Secret                                   | `BotSecret.botToken` slot (`secretShape.slots` labels it)                                                                                    | CP only (code exchange + refresh)                              |
-| Webhook signing secret                          | `BotSecret.signingSecret` slot; `httpAssignRequires: ['signingSecret']`                                                                      | relay only, via the `rc/bot-assign` secrets bag                |
-| Access + refresh token, expiry                  | provider-owned `linear_token` table, keyed by the install identity `(orgId, clientId, organizationId)` (§4.4), values through `SecretCipher` | access token → daemon (spec + broker); refresh token → CP only |
-| Pasted credentials + `state` nonce, pre-connect | provider-owned `linear_install_state` funnel table (SecretCipher values, TTL-reaped)                                                         | CP only                                                        |
+| Value                                       | Where                                                                                                                                           | Visibility                                                      |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Deployment app credentials (id + 2 secrets) | deployment config / secret store (Setup Server document, `envSchema` slice), stamped into each workspace bot's `BotSecret` at connect (§7.1)    | CP; signing secret additionally to the relay via the assign bag |
+| Client ID                                   | `Bot.externalAppId` (D6 column; constant across rows)                                                                                           | console, authorize URL, relay ingress bag                       |
+| Workspace (organization) id                 | `Bot.externalTenantId` + display `workspaceId`/`workspaceName`                                                                                  | console, relay ingress bag                                      |
+| Client Secret                               | `BotSecret.botToken` slot (`secretShape.slots` labels it)                                                                                       | CP only (code exchange + refresh)                               |
+| Webhook signing secret                      | `BotSecret.signingSecret` slot; `httpAssignRequires: ['signingSecret']`                                                                         | relay only, via the `rc/bot-assign` secrets bag                 |
+| Access + refresh token, expiry              | provider-owned `linear_token` table, keyed by the connection identity `(orgId, clientId, organizationId)` (§4.4), values through `SecretCipher` | access token → daemon (spec + broker); refresh token → CP only  |
+| `state` nonce + default agent, pre-connect  | provider-owned `linear_install_state` funnel table (TTL-reaped; carries no secrets)                                                             | CP only                                                         |
 
 The opaque `IntegrationSpec.config` payload the provider projects (validated
 on the daemon by the linear module's schema in `CONFIG_SCHEMAS`):
@@ -666,37 +723,32 @@ provider's token service owns the work: single-flight refresh when the stored
 token is near expiry, durable persist of the rotated pair **before**
 replying, then a spec re-push so `agent.json` converges.
 
-### 7.4 Unbind, reuse, uninstall, revocation
+### 7.4 Membership, disconnect, revocation
 
-Three distinct lifecycle edges, because the token rides the workspace-install
-identity (§4.4):
+Three distinct lifecycle edges, because the token rides the connection
+identity (§4.4), not any agent binding:
 
-- **Unbind the agent** — `DELETE /integrations/:id` rides the standard
-  uninstall broadcast (bot unassign + `integration/remove`) and **keeps** the
-  `linear_token`: the workspace's authorization of the app is still live at
-  Linear, and the freed bot _is_ that still-authorized install. Reuse
-  therefore needs no OAuth re-run — but it is **same-agent only** (§4.3):
-  the module's `freeBotFilter` offers a freed bot only for the agent recorded
-  in `platformConfig.brandedAgentId`, and the CP enforces the same fence
-  durably on the reuse path through the provider's `validateBotReuse` (the
-  second contract extension, §9.2) — a 409 whose copy says to rebrand the
-  app at Linear and reinstall, never a silent rebind of an app visibly named
-  for another agent. Within the fence, the projector/broker find the token
-  by the bot's D6 identity — no modal detour.
-- **Uninstall** — deleting the **Bot** is the real teardown: best-effort
-  `POST /oauth/revoke` at Linear plus deletion of the identity's
+- **Remove an agent** — `DELETE /integrations/:id` drops one member from the
+  workspace bot (standard broadcast: assign rebuild + `integration/remove`)
+  and touches nothing else; its keyword route disappears, the workspace and
+  its token stay live. Removing the default agent requires naming a new
+  default first (or the workspace card blocks it) — a workspace with members
+  but no default would strand bare delegations.
+- **Disconnect the workspace** — deleting the **Bot** is the real teardown:
+  best-effort `POST /oauth/revoke` at Linear plus deletion of the identity's
   `linear_token` row. The shipped `CpPlatformProvider` has no bot-delete
   lifecycle member, so this design adds one:
   `sideEffects.onBotDelete?(bot, secrets)` — best-effort by contract like
   `postCreate`, called from core's bot-delete path for any platform that
   declares it.
 - **Dead token** (refresh rejected, app secret rotated, workspace revoked
-  upstream) — the integration flips `error` with a **Reconnect** CTA: an
-  org-scoped provider route restarts the OAuth funnel against the existing
-  bot, and the callback's step-1 upsert (§7.1) replaces the `linear_token`
-  row in place. The `OAuthApp revoked` doorbell (§6.1) converges the same
-  state when revocation originates on the Linear side — re-verified at the
-  CP behind the `credentialRevision` fence, never trusted from the payload.
+  upstream) — the workspace connection flips `error` with a **Reconnect**
+  CTA: the org-scoped reconnect route restarts the OAuth funnel against the
+  existing bot, and the callback's step-1 upsert (§7.1) replaces the
+  `linear_token` row in place. The `OAuthApp revoked` doorbell (§6.1)
+  converges the same state when revocation originates on the Linear side —
+  re-verified at the CP behind the `credentialRevision` fence, never trusted
+  from the payload.
 
 ## 8. Prompt assembly and trust boundary
 
@@ -755,48 +807,47 @@ tile.
 
 - `src/platforms/linear/` implementing `CpPlatformProvider` + one
   `registry.ts` line:
-  - `credentialBodySchema` `{ clientId, clientSecret, signingSecret }`,
-    consumed by the funnel-start route; `validateConfig` **refuses the
-    generic `POST /integrations` credential path** with a pointer at the
-    funnel — install is funnel-only, because an integration must never exist
-    without its workspace token (§7.1).
+  - `envSchema` / deployment-document slice — the deployment app's client
+    id, client secret, and signing secret (§7.1, the `SLACK_PLATFORM_*`
+    precedent); the provider self-disables without them.
+  - `credentialBodySchema` is vestigial by design: `validateConfig`
+    **refuses the generic `POST /integrations` credential path** with a
+    pointer at the connect flow — there are no per-org app credentials to
+    paste, and a member Integration must never exist outside a connected
+    workspace (§7.1).
   - `buildNewBotInstall` — invoked from the OAuth callback's finalize (the
-    Feishu one-click precedent), packing the secret slots and declaring the
-    D6 `externalIdentity` `(clientId, organizationId)` + the
-    `workspaceClaim`.
-  - `secretShape` (§7.2); `projectBotIdentity` (clientId / organizationId;
-    `platformConfig` carries `brandedAgentId` (§4.3) + workspace display
-    metadata).
-  - `installRoutes('org')` — funnel start (stamps `brandedAgentId` from the
-    selected agent), connect status, reconnect (§7.4);
+    Feishu one-click precedent), stamping the deployment credentials into
+    the workspace bot's secret row and declaring the D6 `externalIdentity`
+    `(clientId, organizationId)` + the `workspaceClaim`.
+  - `secretShape` (§7.2); `projectBotIdentity` (clientId / organizationId +
+    workspace display metadata in `platformConfig`).
+  - `installRoutes('org')` — connect-workspace funnel start (records the
+    chosen default agent), connect status, reconnect (§7.4), member/default
+    management for the workspace card;
     `installRoutes('public-callback')` — the OAuth callback (§7.1). Repo
     OpenAPI conventions on every route.
   - `pendingInstalls` — `linear_install_state` + TTL reaper.
   - `projectIntegrationConfig` (async, loads `linear_token` by the bot's D6
     identity — write-before-create ordering per §7.1) and `projectBotAssign`
-    (§6.2).
+    (§6.2, including the per-member keyword routes and `defaultAgentId`).
   - `LinearTokenService` — exchange, single-flight rotate-and-retry refresh,
     revoke; surfaced to the WS `linearcred` handler (§7.3).
-  - `backgroundLoops` — the orphan-token sweeper (§7.1): revoke-and-delete
-    for token identities with no matching Bot, behind a grace window.
-  - `BotDto` projection — the shipped `/bots` DTO does not expose
-    `platformConfig`, so the inventory includes a generic, validated
-    **public-metadata projection** of that bag (public by construction — D6
-    reserves it for display metadata, never secret material), which is what
-    lets the web module's `freeBotFilter` read `brandedAgentId`. Until it
-    lands, the wizard leans on the authoritative `validateBotReuse` 409.
-  - **Two contract extensions** this design needs core to grow, both
-    consulted only for platforms that declare them:
-    `sideEffects.onBotDelete?(bot, secrets)` for the uninstall revoke (§7.4),
-    best-effort like `postCreate`; and `validateBotReuse?(bot, agentId)` on
-    the existing-bot reuse path, returning the 409 refusal that keeps a
-    freed bot fenced to its branded agent (§7.4).
+  - `backgroundLoops` — the orphan-token sweeper (§7.1): org-scoped
+    selection, local delete always, upstream revoke only for globally
+    unowned identities, behind a grace window.
+  - **One contract extension** this design needs core to grow, consulted
+    only for platforms that declare it:
+    `sideEffects.onBotDelete?(bot, secrets)` for the disconnect revoke
+    (§7.4), best-effort like `postCreate`. (The earlier revision's
+    `validateBotReuse` reuse fence died with the per-agent-app model —
+    adding a member agent is an ordinary, unfenced operation now.)
 - Prisma: new `linear_token` and `linear_install_state` tables only — Bot
   identity rides the existing D6 columns, and `platform` columns are already
   text.
-- Tests: provider unit (schema guards, projector shapes); integration-route +
-  OAuth callback + broker integration tests against a fake Linear token
-  endpoint; workspace-claim, external-identity, and cross-agent-reuse 409s.
+- Tests: provider unit (schema guards, projector shapes incl. keyword
+  routes); connect-funnel + OAuth callback + broker integration tests
+  against a fake Linear token endpoint; workspace-claim and
+  external-identity 409s.
 
 ### 9.3 `packages/relay`
 
@@ -857,16 +908,18 @@ tile.
 - `src/components/console/platforms/linear/` implementing
   `WebPlatformModule` + one `registry.ts` line:
   - `Mark` — Linear brand SVG (60 % box, `fillPct` convention).
-  - `wizard` — the two-step facet (§7.1); tile availability = daemon
-    capability ∧ `relayCapability.available`; `freeBotFilter` /
-    `buildReuseInput` offer a freed bot **only to its branded agent**,
-    reading `brandedAgentId` from the `BotDto` public-metadata projection
-    (§9.2 inventory item) — its workspace token rides the install identity,
-    so same-agent reuse needs no OAuth detour. The filter is convenience;
-    the CP's `validateBotReuse` 409 is the authoritative fence either way.
-  - `apiBindings` — funnel-start, connect-status, and reconnect calls.
-  - `settingsFragments` — workspace name, connect status, reconnect action
-    when the token is dead (§7.4).
+  - `wizard` — for an agent, "enable on a connected workspace": the
+    connected-workspace bots are the existing-bot list (`freeBotFilter`
+    offers any of the org's connected workspaces, `buildReuseInput` adds the
+    agent as a member — unfenced, §7.4), with a "connect a workspace first"
+    hand-off to the org-level connect flow when none exists. Tile
+    availability = daemon capability ∧ `relayCapability.available` ∧ the
+    deployment app being configured.
+  - `apiBindings` — connect-funnel, connect-status, reconnect, and
+    member/default management calls.
+  - `settingsFragments` — the workspace card: workspace name, connect
+    status, member agents + default, reconnect action when the token is
+    dead (§7.4).
   - `channelList` — `roomNoun: 'issue'`, no leave affordance.
   - `messageIdentity` — agent-activity id, else `null` (never dedupes).
   - `transcriptOrdering` — default `'seq'`.
@@ -896,9 +949,11 @@ tile.
    configured `permissionMode` governs, exactly like GitHub hook turns.
 5. **No Linear-side title push.** Linear names agent sessions from the issue;
    AgentConnect's session titles remain console-local.
-6. **Signing-secret rotation** = paste the new secret in the console: the bot
-   secret update advances `credentialRevision` and re-broadcasts
-   `rc/bot-assign`, and the plugin rebuilds the ingest. No dual-key window in
+6. **Signing-secret rotation is a deployment action**: update the deployment
+   credentials (Setup Server / deployment config), then a provider-owned
+   re-stamp fans the new secret out to every Linear workspace bot's secret
+   row, advancing each `credentialRevision` and re-broadcasting
+   `rc/bot-assign` so the plugin rebuilds every ingest. No dual-key window in
    v1; rotation races drop deliveries for seconds, recovered by Linear's
    retry ladder (the one case where we _want_ the non-200: an unverifiable
    delivery returns 401 and Linear retries).
@@ -939,24 +994,26 @@ tile.
 
 ## 13. Phasing
 
-- **P1 — the core loop.** `linearcred` frames; CP provider (install funnel +
-  callback, token service + broker, projectors, the `onBotDelete` and
-  `validateBotReuse` contract extensions) + registry line; relay ingress
-  plugin + registry line; daemon
-  module (connection, ack, converger `thought`/`action`/`response`/`error`,
-  follow-ups, stop, config schema) + the §9.4 composition lines; web module
-  (wizard, mark, settings, session display) + registry line. Exit criteria:
-  delegate an issue →
-  acknowledged ≤10 s → streamed activities → response; reply and stop work;
-  sessions render in the console.
+- **P1 — the core loop.** `linearcred` frames; deployment-app configuration
+  (Setup Server document + `envSchema` slice); CP provider (connect funnel +
+  callback, member/default management, token service + broker, projectors
+  with keyword routes, the `onBotDelete` contract extension) + registry
+  line; relay ingress plugin + registry line; daemon module (connection,
+  ack with agent attribution, converger
+  `thought`/`action`/`response`/`error`, follow-ups, stop, config schema) +
+  the §9.4 composition lines; web module (workspace connect + agent enable,
+  mark, settings, session display) + registry line. Exit criteria: delegate
+  an issue → default agent acknowledges ≤10 s (named in the ack) → streamed
+  activities → response; `@<agent-name>` routes to the named member; reply
+  and stop work; sessions render in the console.
 - **P2 — workflow polish.** Plan sync; `externalUrls` (PR + console links);
   issue auto-start transition; daemon-local Linear read tool (bounded
   `getIssue`/comments via the connection token); elicitation deep-link card.
-- **P3 — breadth.** Label → skill playbook mapping; proactive sessions
-  (`agentSessionCreateOnIssue`) as a cron/sendMessage target (extends
-  `frames/cron.ts`); `issueRepositorySuggestions` for multi-repo agents;
-  interactive permission approval over activities; multi-workspace install UX
-  (credential reuse across a second workspace's bot).
+- **P3 — breadth.** Label → skill playbook mapping; per-team default-agent
+  mapping (the delegation-granularity upgrade §4.3 defers); proactive
+  sessions (`agentSessionCreateOnIssue`) as a cron/sendMessage target
+  (extends `frames/cron.ts`); `issueRepositorySuggestions` for multi-repo
+  agents; interactive permission approval over activities.
 
 ## 14. Tests
 
@@ -978,15 +1035,16 @@ tile.
 - **CP unit:** provider schema guards; token service rotate-and-retry with a
   failing-then-succeeding fake token endpoint; single-flight refresh;
   projector output shapes.
-- **CP integration:** funnel start → callback → active lifecycle against a
+- **CP integration:** connect funnel → callback → active lifecycle against a
   stubbed Linear OAuth server, asserting **no Bot/Integration row exists
   before the callback** and that the token upsert precedes the create tail
   (a tail refusal after step 1 leaves an inert row the next connect
-  overwrites); D6 external-identity and workspace-claim 409s; unbind keeps
-  the workspace token, same-agent reuse re-projects it, and cross-agent
-  reuse 409s through `validateBotReuse`; reconnect replaces a dead token in
-  place; broker scope denial for a foreign daemon; bot-delete revoke
-  convergence.
+  overwrites, and the sweeper's cross-org split never revokes a live
+  winner); D6 external-identity and workspace-claim 409s; member add/remove
+  recompiles keyword routes without touching the token; removing the default
+  agent is blocked until a new default is named; reconnect replaces a dead
+  token in place; broker scope denial for a foreign daemon; workspace
+  disconnect (bot delete) revoke convergence.
 - **Live checklist:** real OAuth app in a scratch Linear workspace —
   delegate, mention, follow-up, stop, redelivery replay (Linear's webhook
   console), token refresh across the 24 h boundary, workspace revoke.

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -2,8 +2,9 @@
 
 > **Status:** Proposed. Revised 2026-08 against the shipped
 > [integration-plugin-architecture.md](integration-plugin-architecture.md): Linear
-> now lands as a standard platform module — the four host contracts plus one
-> registry line per host — and this doc's earlier bespoke machinery
+> now lands as a standard platform module — the four host contracts, registry
+> lines, and the enumerated daemon composition set of §9.4 — and this doc's
+> earlier bespoke machinery
 > (`RcLinearAssign` / `RdMsgLinear` frames, a capability-URL webhook, hook-table
 > borrowings, per-enum change checklists) is superseded by the generalized seams
 > that shipped since: `rc/bot-assign` opaque bags, `rd/msg` `im` +

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1,9 +1,18 @@
 # Linear Integration Design
 
-> **Status:** Proposed.
+> **Status:** Proposed. Revised 2026-08 against the shipped
+> [integration-plugin-architecture.md](integration-plugin-architecture.md): Linear
+> now lands as a standard platform module — the four host contracts plus one
+> registry line per host — and this doc's earlier bespoke machinery
+> (`RcLinearAssign` / `RdMsgLinear` frames, a capability-URL webhook, hook-table
+> borrowings, per-enum change checklists) is superseded by the generalized seams
+> that shipped since: `rc/bot-assign` opaque bags, `rd/msg` `im` +
+> `platform_action`, the relay platform-ingress plugin, and the CP platform
+> provider.
 >
 > Related documents:
 > [architecture.md](architecture.md),
+> [integration-plugin-architecture.md](integration-plugin-architecture.md),
 > [webhook-triggers-and-github-events.md](webhook-triggers-and-github-events.md),
 > [shared-bot-relay.md](shared-bot-relay.md),
 > [feishu-integration.md](feishu-integration.md),
@@ -53,15 +62,16 @@ rather than inventing a Linear-shaped side channel.
 issue (they receive a bounded unsupported-surface response, §4.5 — never a
 crash or silence),
 proactive session creation (`agentSessionCreateOnIssue`) as a cron/sendMessage
-target, marketplace/public-app distribution, per-team configuration, and a
-shared multi-agent app (a Linear app _is_ one agent's identity — sharing does
-not fit the model; see §4.3).
+target, marketplace/public-app distribution, per-team configuration, a shared
+multi-agent app (a Linear app _is_ one agent's identity — sharing does not fit
+the model; see §4.3), and multi-workspace install UX beyond "run the wizard
+again" (§4.3, P3).
 
 ## 2. Background: Linear's agent protocol in one page
 
-Facts this design depends on (from Linear's developer docs; verify against
-[linear.app/developers/agents](https://linear.app/developers/agents) when
-implementing):
+Facts this design depends on (from Linear's developer docs, re-verified
+2026-08; check [linear.app/developers/agents](https://linear.app/developers/agents)
+again when implementing):
 
 - **Identity.** A standard Linear OAuth application, authorized with
   `actor=app`, becomes an **app user** in the workspace: it appears in the
@@ -83,8 +93,9 @@ implementing):
   `elicitation`, `response`, `error`. Bodies support Markdown. `thought` and
   `action` accept an `ephemeral` flag (transient display).
   `agentSessionUpdate` sets `plan` (full-array replace; entries
-  `{content, status: pending|inProgress|completed|canceled}`, technology
-  preview) and `externalUrls` / `addedExternalUrls` (`{label, url}`).
+  `{content, status: pending|inProgress|completed|canceled}`, still a
+  technology preview as of this revision) and `externalUrls` /
+  `addedExternalUrls` / `removedExternalUrls` (`{label, url}`).
 - **Session state is inferred**, not set: activities drive
   `pending → active → complete/error/awaitingInput`, with `stale` after
   ~30 minutes of silence (recoverable by a new activity).
@@ -95,8 +106,9 @@ implementing):
   `Linear-Delivery` (UUID), `Linear-Signature` (HMAC-SHA256 hex over the raw
   body, keyed by the OAuth app's **webhook signing secret**), and a
   `webhookTimestamp` field to bound replay (docs recommend rejecting > 60 s
-  skew). Failed deliveries retry after 1 min / 1 h / 6 h, then the webhook may
-  be auto-disabled.
+  skew). Payloads carry `organizationId` (the workspace) and the app's
+  `oauthClientId`. Failed deliveries retry after 1 min / 1 h / 6 h, then the
+  webhook may be auto-disabled.
 - **Tokens.** OAuth `authorization_code` grant returns an access token
   (~24 h) plus a refresh token; refresh rotates with a 30-minute replay grace
   window. Per-app opt-in `client_credentials` tokens (30-day, app actor) also
@@ -107,159 +119,143 @@ No socket/long-poll transport exists — **webhooks are the only ingress**.
 
 ## 3. Architecture
 
-Linear is a **bot platform** (`Platform` value `'linear'`) whose _ingress_ is
-relay-terminated (like Slack HTTP transport and GitHub hooks) and whose
-_egress_ is daemon-direct GraphQL (like every other platform's outbound path).
-The Control Plane stays off the message hot path.
+Linear is a **chat-kind platform module** (`PlatformId` `'linear'`,
+`originKind: 'chat'`) whose _ingress_ is relay-terminated (like Slack HTTP
+transport and Feishu callbacks) and whose _egress_ is daemon-direct GraphQL
+(like every other platform's outbound path). The Control Plane stays off the
+message hot path.
+
+Adding it is the checklist-shaped task the plugin architecture exists for:
+implement the four host contracts in each host's `platforms/linear/`
+directory, add one registry line per host, and touch **no core switch, no
+protocol enum, and no Prisma platform migration** — `Platform` is an open
+string with tolerant readers (S1a), bot identity rides the generic D6 columns,
+and `IntegrationSpec` carries an opaque per-platform config (§6.3 of the
+parent design).
 
 ```text
 Linear workspace
   │  delegate / mention / follow-up / stop
   ▼
-AgentSessionEvent webhook ──POST /webhooks/linear/:token──▶ relay ingress
-                                    verify Linear-Signature + timestamp
-                                    resolve rc/linear-assign rule
+AgentSessionEvent webhook ──POST /linear/events──▶ relay linear ingress plugin
+                                verify Linear-Signature + timestamp
+                                demux (oauthClientId, organizationId)
                                     │
-                        rd/msg { source: 'linear' }
+                     rd/msg im { platform: 'linear' }   (stop → platform_action)
                                     │
                                     ▼
-                                 daemon
-              dedupe → ack thought ≤10 s → ACP turn
+                                 daemon linear module
+              inbox dedup → ack thought ≤10 s → ACP turn
                                     │
-             LinearConverger → agentActivityCreate / agentSessionUpdate
+             Layer-2 output surface → agentActivityCreate / agentSessionUpdate
                                     │  (GraphQL, daemon-direct egress)
                                     ▼
                              api.linear.app
 
-Control Plane: integration CRUD, OAuth install + token custody/refresh,
-rc/linear-assign compilation, linearcred token broker, session metadata.
+Control Plane: platform provider (install routes, OAuth custody/refresh,
+spec + bot-assign projection), linearcred token broker, session metadata.
 Never sees activity bodies or promptContext.
 ```
 
-Precedents each leg reuses:
+What each leg reuses — every row is a **shipped seam**, not a precedent to
+imitate:
 
-| Leg                                                         | Precedent                                                                                 |
-| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| Relay HTTP ingress, HMAC verify, rule table, dispatch retry | `packages/relay/src/hooks/github-ingress.ts`, `hooks/signature.ts`, `hooks/hook-table.ts` |
-| CP → relay rule compilation & replay                        | `RcHookAssign` / `HookService` (`packages/control-plane/src/hooks/hook.service.ts`)       |
-| Relay → daemon delivery + durable dedup                     | `rd/msg` + inbox `(sessionKey, msgId)` (`packages/protocol/src/frames/relay-daemon.ts`)   |
-| Daemon platform silo (normalize / converger / apply)        | `packages/daemon/src/feishu/` (smallest complete adapter)                                 |
-| Turn-scoped outbound poster w/ final-answer selection       | `packages/daemon/src/github/poster.ts`                                                    |
-| Short-lived token brokered over the control WS              | `packages/protocol/src/frames/gitcred.ts` + `packages/daemon/src/cp/git-credential.ts`    |
-| Durable token rotate-and-retry at the CP                    | Slack config-token rotation (`routes/slack-install.ts`)                                   |
+| Leg                                                 | Shipped seam                                                                                                                                 |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Relay signed HTTP ingress, demux, per-bot lifecycle | `RelayPlatformIngressPlugin` (`packages/relay/src/platforms/contract.ts`); HMAC/timestamp primitives shared with the webhook seam            |
+| CP → relay credential + demux distribution, replay  | `rc/bot-assign` opaque `secrets`/`ingress` bags, produced by the provider's `projectBotAssign`                                               |
+| Relay → daemon delivery + durable dedup             | `rd/msg` `im` / `platform_action` + the daemon inbox on `(botId, sessionKey, msgId)`                                                         |
+| Daemon spec ingestion (opaque config, fail-closed)  | `platforms/integration-config.ts` `CONFIG_SCHEMAS` — the daemon's platform-set authority, advertised as `capabilities.platforms`             |
+| Turn rendering                                      | Layer-2 `TurnOutputSurface` (`packages/daemon/src/platforms/turn-output.ts`) — the streaming trio: converger + apply + opaque per-turn state |
+| Outbound pacing                                     | `PlatformSendQueue` (`packages/daemon/src/platforms/send-queue.ts`)                                                                          |
+| Final-answer selection                              | The GitHub Layer-2 member's heuristics (`packages/daemon/src/platforms/github/turn-output.ts`)                                               |
+| Short-lived token brokered over the control WS      | `gitcred` (`packages/protocol/src/frames/gitcred.ts`, `packages/daemon/src/cp/git-credential.ts`)                                            |
+| Durable token rotate-and-retry at the CP            | Slack config-token rotation (`packages/control-plane/src/platforms/slack/`)                                                                  |
+| Install funnel state + TTL reaper                   | `CpPendingInstallDecl` + the shared reaper class                                                                                             |
 
 ## 4. Key decisions
 
 ### 4.1 Platform, not hook
 
-Linear lands on the platform tables because its product hands us that shape
-natively: the OAuth app _is_ the assignable identity users pick in the delegate
-menu (§4.3), so each agent needs its own app — which is precisely a `Bot` row,
-with `Integration` as one workspace installation of it. Those are the same
-tables Slack uses. Linear therefore becomes the sixth persisted `Platform` with
-its own daemon silo and converger, and its sessions render in the console as
-ordinary conversations (`platform: 'linear'`, channel = issue, thread = agent
-session).
+Earlier revisions of this section argued at length why GitHub sits on the
+webhook/code-host seam while Linear gets the platform tables. That argument is
+settled and recorded where it belongs —
+[integration-plugin-architecture.md §2–3](integration-plugin-architecture.md)
+(code hosts implement only Layer-2 turn output plus the review adapter; chat
+platforms implement the full contract) and
+[gitlab-com-integration.md](gitlab-com-integration.md) (the code-host seam's
+second implementer, which extracted the shared members the old text predicted
+would be "designed from two code hosts, not asserted from one"). The one-line
+summary that survives: **no conceptual line separates the seams** —
+conversation identity, streaming, shared posting identity, and authorization
+direction all failed as dividing lines; what keeps GitHub and GitLab off the
+platform tables is that they have no chat ingress and implement a much
+narrower surface.
 
-The obvious follow-up — then why is GitHub on `HookDef` and not here? — has a
-less obvious answer than earlier revisions of this section claimed, and it is
-worth recording precisely because every _conceptual_ line once drawn between
-the two seams has failed scrutiny:
+Linear has chat ingress in all but name. Its product hands us the platform
+shape natively: the OAuth app _is_ the assignable identity users pick in the
+delegate menu (§4.3), so each agent needs its own app — a `Bot` row with
+`Integration` as its agent binding, the same tables every chat platform uses.
+Its sessions are conversations (channel = issue, thread = agent session) with
+follow-ups and a streaming reply surface. Linear therefore implements all four
+platform contracts and renders in the console as ordinary conversations
+(`platform: 'linear'`).
 
-- **Conversation is not the line.** An earlier revision claimed GitHub events
-  are one-shot with no conversational identity; the GitHub-events work
-  falsified that. GitHub hooks are `perThread` — the session key is the hook's
-  immutable prefix plus the issue or pull-request number, later events resume
-  the same ACP session, `@<agent-name>` addresses one agent while
-  `@<app-slug>` broadcasts to the repository's matching hooks. A follow-up
-  question in a thread continues the same conversation.
-- **Streaming is not the line.** "Publishes once" is a point on the existing
-  output-mode axis, which the daemon already reads live per dispatch; Slack
-  streams through an edit loop, and Telegram/Discord differ again. The GitHub
-  poster already implements the narrower Layer-2 output surface
-  ([integration-plugin-architecture.md §7.6](integration-plugin-architecture.md)),
-  so this is a capability difference _inside_ a contract, not a reason for a
-  different seam.
-- **A shared posting identity is not the line.** Every agent posts through the
-  one GitHub App installation, with per-agent identity rendered inside the
-  comment (avatar plus attribution footer) — but that is exactly what a Slack
-  shared bot does, one app fronting many agents disambiguated per message, and
-  Slack is a platform module.
-- **Authorization direction is not the line either.** Both seams share one
-  structure: _installation grants presence; per-event policy decides who may
-  address the agent_. Chat platforms default open (anyone in the conversation)
-  and our gating narrows; GitHub defaults strict (live write/admin check
-  against `comment.user`) and a future policy could widen — "anyone may
-  address" on a repository is the same knob as chat-side conversation gating,
-  currently implemented once per seam. The strict default is threat-surface
-  tuning, not structure: a public repository's audience is the whole internet
-  and the agent holds repository credentials — but a public Discord server
-  poses the same class of exposure and lives inside the platform contract.
-- **Even the resource rows are isomorphic, not alien.** `HookDef` ≈
-  `Integration` plus per-hook event-subscription filters, and one App
-  installation fanning out to many hooks is the same shape as one shared `Bot`
-  row fronting many `Integration` rows with per-message routing. A migration
-  is feasible; it is not conceptually blocked.
-
-What actually keeps GitHub on the hook seam today is discipline and economics,
-not concept. The four platform contracts were settled from four chat
-implementers; reshaping them around a fifth, non-chat implementer would be
-extracting an interface from one example — the failure mode this codebase
-explicitly defers on (the `CodeHostRepository` deferral in
-[gitlab-com-integration.md §8.1](gitlab-com-integration.md)) — and the
-migration's user-visible payoff today is nil. The convergence point is GitLab:
-the §7.6 layering table already admits facet-subset implementers (the GitHub
-poster ships Layer 2 with no Layer 1), so the expected end state is one module
-system in which chat platforms implement the full facet set and code hosts a
-subset plus facets of their own (event subscriptions, check/review
-projections, repository authorization) — designed from two code hosts, not
-asserted from one. GitHub does not "graduate into" a platform; the module
-system learns to express it.
-
-One consequence does not wait for GitLab: the "who may address the agent"
-policy knob exists today as chat-side conversation gating and, separately, as
-GitHub's write/admin gate — one policy family, implemented twice. The next
-change to either should design it as the cross-platform policy it is, not
-deepen it as a per-seam feature.
-
-What Linear borrows from hooks anyway: relay-terminated signed ingress, the
-in-memory assign-rule table with CP replay, delivery retry cadence, and the
-daemon's durable inbox dedup. The second item is itself evidence for the
-convergence above — the hook seam's assign-rule table restates platform
-routing rules, and merging that duplication belongs to the same GitLab-time
-consolidation.
+What the earlier revision "borrowed from hooks" — signed relay-terminated
+ingress, an in-memory assign table with CP replay, dispatch retry toward the
+daemon, durable inbox dedup — has since been generalized into relay core and
+the platform-ingress plugin contract. There is nothing left to borrow: the
+shipped seam already **is** that machinery, and the bespoke
+`RcLinearAssign` / `RdMsgLinear` frames this doc used to define would now be a
+second copy of it.
 
 ### 4.2 Relay-terminated ingress is mandatory
 
 Lark / Feishu chose a daemon-direct `WSClient` because the daemon must dial out.
-Linear offers no such transport, so the integration **requires a configured
-`PUBLIC_RELAY_URL` and at least one live relay** — the same precondition hooks
-already enforce at creation time (`routes/hooks.ts` 409s without them). The
-web tile for Linear is gated on relay availability _in addition to_ the
-three-part daemon/CP/web capability invariant from
-[feishu-integration.md §5](feishu-integration.md).
+Linear offers no such transport, so a Linear bot exists **only on the `http`
+transport** and the integration requires a configured `PUBLIC_RELAY_URL` and
+at least one live relay — the same relay-availability 409 core already
+enforces for `transport: 'http'` at create time. The web wizard tile is gated
+on the daemon advertising `linear` (`capabilities.platforms`, read by the CP's
+pre-install gate and the console) **and** on `WizardHost.relayCapability`.
 
-### 4.3 One Linear OAuth app per agent
+### 4.3 One Linear OAuth app per agent; one Bot row per workspace install
 
 In Linear, the OAuth app _is_ the assignable identity — its name and icon are
 what users see in the delegate menu. "Assign it to MyAgent" therefore requires
 each agent to have its own app, exactly as each Slack bot today is its own
-Slack app. Linear has no app-creation API, so the user
-creates the app manually in Linear settings and pastes three values into the
-console (§7). A single shared app fronting many agents would collapse them
-into one Linear identity and force label/keyword dispatch — rejected.
+Slack app. Linear has no app-creation API, so the user creates the app
+manually in Linear settings and pastes three values into the console (§7). A
+single shared app fronting many agents would collapse them into one Linear
+identity and force label/keyword dispatch — rejected.
 
 The mapping onto existing tables:
 
-- **`Bot`** (platform `linear`) = the OAuth application. Durable identity,
-  reusable after uninstall, `linearClientId` as public metadata (following
-  `discordAppId`).
-- **`Integration`** = one workspace installation of that app, bound to one
-  agent. Installing the same app into a second workspace is a second
-  integration on the same bot (`Integration.botId` is deliberately not
-  unique). A Linear app has exactly **one** webhook URL, so ingress is
-  bot-scoped and the verified `organizationId` selects the integration
-  (§6.1).
+- **`Bot`** (platform `linear`) = **one workspace install** of the OAuth app.
+  D6 identity columns: `externalAppId` = the OAuth client id,
+  `externalTenantId` = the Linear `organizationId` (the workspace), with the
+  pre-connect sentinel rule below. `transport` is always `http`;
+  `shareable` is dropped by the provider (one app = one agent).
+- **`Integration`** = the bot's agent binding (1:1 for Linear).
+- Installing the same app into a **second workspace** is a second Bot row
+  created from the same pasted app credentials (v1: run the wizard again;
+  a credential-reuse affordance is P3). The composite unique
+  `(platform, externalAppId, externalTenantId)` fences duplicates, and the
+  cross-org `workspaceClaim` fence refuses a workspace another organization
+  already holds — two rows sharing one signing secret **and** one workspace
+  would make delivery attribution a pool-order accident.
+
+**Delta from the earlier revision**, recorded because the parent design's §11
+once cited it: the old shape was one Bot = the app, integrations = workspaces,
+demuxed by a minted capability-URL token (`linearUrlToken @unique`). It is
+superseded because the relay's shipped demux and arbitration are keyed by
+per-assignment `(appId, tenantId)` identity
+([integration-plugin-architecture.md §5.1](integration-plugin-architecture.md)) —
+and Linear's multi-workspace app is exactly the tenant-scoped shape that axis
+was built for: every install shares one client id and one signing secret, so
+the composite is the only safe demux. A one-bot-many-workspaces shape would
+have needed a workspace-selection mechanism _inside_ a bot that no other
+platform has, plus the bespoke rule table to carry it.
 
 ### 4.4 Token custody: CP owns refresh, daemon gets brokered access tokens
 
@@ -268,10 +264,13 @@ token. Rotating credentials need one durable writer; that is the CP with
 Postgres (precedent: Slack config-token rotate-and-retry). The daemon never
 holds the client secret or refresh token. Instead:
 
-- The CP stores `{accessToken, refreshToken, expiresAt, workspaceId}` per
-  integration, encrypted through the existing `SecretCipher` seam.
-- `integrationToSpec` embeds the **current access token + expiry** in the
-  pushed `IntegrationSpec.linear`, so `agent.json` always carries a ≤24 h
+- The provider stores `{accessToken, refreshToken, expiresAt}` per
+  integration in its own `linear_token` table, encrypted through the existing
+  `SecretCipher` seam. (The CP provider contract's projectors are async for
+  exactly this case — the provider loads from its own secret store inside
+  `projectIntegrationConfig`; core awaits uniformly.)
+- `projectIntegrationConfig` embeds the **current access token + expiry** in
+  the opaque `IntegrationSpec.config`, so `agent.json` always carries a ≤24 h
   token — the daemon can restart and keep posting activities while the CP is
   briefly down (graceful degradation, bounded by token lifetime).
 - A `linearcred/request { integrationId }` REQ on the control WS (mirroring
@@ -288,34 +287,39 @@ token; only _renewal_ touches the CP, at most ~once a day per integration.
 
 ### 4.5 Session mapping and dedup keys
 
-- One Linear **AgentSession** ↔ one AgentConnect session.
-  Local key: `linear:<channel>:<agentSessionId>:<agentId>`.
+- One Linear **AgentSession** ↔ one AgentConnect session, through the
+  ordinary normalized coordinates — no Linear-shaped keying:
   - `channel` = Linear issue **UUID** when the session is attached to an
     issue (immutable; the human identifier `TEAM-123` changes when an issue
-    moves teams, so it is display metadata only — `channelName` carries
-    `TEAM-123 · <title>` and `threadUrl` the issue URL for console deep
-    links). `app:mentionable` also covers documents and other editor
-    surfaces, and Linear's schema makes the session's issue nullable, so a
-    session **without** an issue is defined, not an error: `channel` falls
-    back to the AgentSession UUID and `channelName` to the session/source
-    title. Never `linear:undefined:…`. **v1 behavior for no-issue sessions:**
-    after durable admission/dedup, the daemon posts one bounded `response`
-    ("mention me on an issue — this surface isn't supported yet") and does
-    **not** start an ACP turn; the key fallback exists so this path, and any
-    future generic support, stays well-keyed.
+    moves teams, so it is display metadata only — session `channelName`
+    carries `TEAM-123 · <title>` and the normalized message's `threadUrl`
+    carries the issue URL for console deep links). `app:mentionable` also
+    covers documents and other editor surfaces, and Linear's schema makes the
+    session's issue nullable, so a session **without** an issue is defined,
+    not an error: `channel` falls back to the AgentSession UUID and
+    `channelName` to the session/source title. Never `linear:undefined:…`.
+    **v1 behavior for no-issue sessions:** after durable admission/dedup, the
+    daemon posts one bounded `response` ("mention me on an issue — this
+    surface isn't supported yet") and does **not** start an ACP turn; the key
+    fallback exists so this path, and any future generic support, stays
+    well-keyed.
   - `thread` = the AgentSession UUID. A second delegation or a new comment
     mention on the same issue is a new Linear session → a new AgentConnect
     session in the same channel, matching Slack's thread model.
-- Follow-ups: `prompted` events carry the same `agentSession.id` → the relay
-  computes the same session key → the daemon resumes the same ACP session.
+  - The relay computes its session key from `(channel, thread)` exactly as it
+    does for every shared bot; the daemon's local key adds the agent id as
+    usual.
+- Follow-ups: `prompted` events carry the same `agentSession.id` → the same
+  coordinates → the daemon resumes the same ACP session.
 - Dedup `msgId` is **content-derived**, not delivery-derived, so Linear's
   1 min/1 h/6 h redeliveries and relay-internal retries converge regardless of
   whether `Linear-Delivery` is stable across attempts:
   - `created` → `linear:<agentSessionId>:created`
   - `prompted` → `linear:<agentActivityId>`
 
-  The daemon's durable inbox on `(sessionKey, msgId)` (same mechanism as
-  hooks) absorbs duplicates.
+  The plugin mints the identity; relay core's TTL dedup table absorbs
+  same-pod replays and the daemon's durable inbox on
+  `(botId, sessionKey, msgId)` absorbs the rest.
 
 ### 4.6 Single-writer egress
 
@@ -329,9 +333,16 @@ connection's token without exposing it, following the Slack
 
 ## 5. Interaction mapping: ACP stream → Agent Activities
 
-A new `LinearConverger` (`packages/daemon/src/linear/render.ts`) follows the
-converger contract (`constructor(mode)`, `onUpdate`, `hasBuffered`,
-`flushBuffered`, `onFinal`) and emits a Linear-shaped IR:
+The daemon module registers a **streaming Layer-2 surface**
+(`TurnOutputSurface`, `packages/daemon/src/platforms/linear/turn-output.ts`)
+for `'linear'`: `createConverger(ctx)` builds a fresh `LinearConverger` per
+turn, `apply(turn, action)` maps its actions to GraphQL calls through the
+per-integration `PlatformSendQueue`, and `initialTurnState` carries the
+per-turn Linear state (activity caps, last plan hash). GitHub's turn-final
+shape is deliberately **not** used: Linear's product is the live feed, so it
+emits as it goes, like the chat platforms.
+
+The converger emits a Linear-shaped IR:
 
 ```ts
 export type LinearAction =
@@ -344,8 +355,8 @@ export type LinearAction =
   | { kind: 'external-urls'; add: { label: string; url: string }[] }
 ```
 
-`applyLinearAction` maps `activity` → `agentActivityCreate`, `plan` /
-`external-urls` → `agentSessionUpdate`, through the per-integration send queue.
+`apply` maps `activity` → `agentActivityCreate`, `plan` / `external-urls` →
+`agentSessionUpdate`.
 
 ### 5.1 Event translation
 
@@ -353,18 +364,18 @@ Unlike Slack, Linear activities are **append-only snapshots** — there is no
 message editing. The converger therefore runs in a discrete-update posture:
 coalesce aggressively, post meaningfully.
 
-| ACP update                                                               | Linear activity                                | Notes                                                                                                                                                                                                                                                                                               |
-| ------------------------------------------------------------------------ | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| turn admission (`created`)                                               | `thought` (ephemeral)                          | The ≤10 s ack, posted by the dispatch path **before** agent spawn: "Reading TEAM-123 …" — or "Queued behind the current task" when the agent is busy                                                                                                                                                |
-| `agent_thought_chunk`                                                    | `thought` (ephemeral)                          | Coalesced per idle window (reuse the 2 s idle-flush timer), tail-clamped like `MAX_REASONING`                                                                                                                                                                                                       |
-| `agent_message_chunk` (intermediate, flushed at a tool boundary or idle) | `thought` (non-ephemeral)                      | Progress narration between tool calls stays visible in the feed                                                                                                                                                                                                                                     |
-| `tool_call` → terminal `tool_call_update`                                | `action`                                       | Emitted once at terminal status: `action` = tool title, `parameter` = input summary, `result` = head-clamped output (~2 800 chars). Consecutive same-title calls collapse; per-turn cap with a final "… and N more" thought                                                                         |
-| ACP `plan` update                                                        | `plan`                                         | Both sides are full-array replace — direct mapping                                                                                                                                                                                                                                                  |
-| turn end (`onFinal`)                                                     | `response`                                     | The accumulated final answer (final-answer selection reuses the `GithubReplyCollector` heuristics: `_meta.codex.phase === 'final_answer'`, else message grouping, else last text run). Attribution footer appended per `output.showFooter`, Markdown-safe via the shared fence-aware chrome helpers |
-| turn failure (quota / auth / crash)                                      | `error`                                        | Reuses `turnFailureReason`/`turnFailureCode`; converger buffer flushed first so runtime-narrated errors are not duplicated                                                                                                                                                                          |
-| permission gate would block the turn                                     | `elicitation`                                  | v1 posts "This step needs approval — open the session in the console" + deep link; interactive approval from Linear is out of scope (§13)                                                                                                                                                           |
-| `session_info_update` (title)                                            | —                                              | Persisted locally for the console; Linear names sessions itself                                                                                                                                                                                                                                     |
-| stop (`prompted` + `signal: "stop"`)                                     | `response` "Stopped — reply here to continue." | After `interruptTurn` completes; a `response` settles the Linear session state instead of leaving it `active`                                                                                                                                                                                       |
+| ACP update                                                               | Linear activity                                | Notes                                                                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| turn admission (`created`)                                               | `thought` (ephemeral)                          | The ≤10 s ack, posted by the dispatch path **before** agent spawn: "Reading TEAM-123 …" — or "Queued behind the current task" when the agent is busy                                                                                                                                        |
+| `agent_thought_chunk`                                                    | `thought` (ephemeral)                          | Coalesced per idle window (reuse the 2 s idle-flush timer), tail-clamped like `MAX_REASONING`                                                                                                                                                                                               |
+| `agent_message_chunk` (intermediate, flushed at a tool boundary or idle) | `thought` (non-ephemeral)                      | Progress narration between tool calls stays visible in the feed                                                                                                                                                                                                                             |
+| `tool_call` → terminal `tool_call_update`                                | `action`                                       | Emitted once at terminal status: `action` = tool title, `parameter` = input summary, `result` = head-clamped output (~2 800 chars). Consecutive same-title calls collapse; per-turn cap with a final "… and N more" thought                                                                 |
+| ACP `plan` update                                                        | `plan`                                         | Both sides are full-array replace — direct mapping                                                                                                                                                                                                                                          |
+| turn end                                                                 | `response`                                     | The accumulated final answer (final-answer selection reuses the GitHub Layer-2 heuristics: `_meta.codex.phase === 'final_answer'`, else message grouping, else last text run). Attribution footer appended per `output.showFooter`, Markdown-safe via the shared fence-aware chrome helpers |
+| turn failure (quota / auth / crash)                                      | `error`                                        | Reuses `turnFailureReason`/`turnFailureCode`; converger buffer flushed first so runtime-narrated errors are not duplicated                                                                                                                                                                  |
+| permission gate would block the turn                                     | `elicitation`                                  | v1 posts "This step needs approval — open the session in the console" + deep link; interactive approval from Linear is out of scope (§13)                                                                                                                                                   |
+| `session_info_update` (title)                                            | —                                              | Persisted locally for the console; Linear names sessions itself                                                                                                                                                                                                                             |
+| stop (`prompted` + `signal: "stop"`)                                     | `response` "Stopped — reply here to continue." | After `interruptTurn` completes; a `response` settles the Linear session state instead of leaving it `active`                                                                                                                                                                               |
 
 `AC_NO_RESPONSE` keeps the product invariant with one **explicit, structural
 exception**: the pre-spawn acknowledgement (§10.1) is posted before the ACP
@@ -401,172 +412,185 @@ misconfiguration warning.
 ### 5.3 Rate limiting
 
 Linear allows 5 000 requests/hour per OAuth app per workspace (per its
-published rate-limiting docs). The per-integration send queue (reuse `PlatformSendQueue`) enforces FIFO plus a
-minimum interval (~1 s for activities), and the converger's coalescing keeps
-a busy turn to tens of activities, not hundreds. `plan` and `external-urls`
-updates are debounced (last-write-wins within the idle window).
+published rate-limiting docs). The per-integration `PlatformSendQueue`
+enforces FIFO plus a minimum interval (~1 s for activities), and the
+converger's coalescing keeps a busy turn to tens of activities, not hundreds.
+`plan` and `external-urls` updates are debounced (last-write-wins within the
+idle window).
 
 ## 6. Ingress detail
 
-### 6.1 Relay endpoint
+### 6.1 Relay platform-ingress plugin
 
-```text
-POST /webhooks/linear/:token
-```
+`packages/relay/src/platforms/linear/` implements
+`RelayPlatformIngressPlugin` plus one registry line. Per member:
 
-- `:token` is a **bot-scoped** capability token (`lin_<32hex>`, ≥128-bit)
-  minted when the bot (= OAuth app) is created — a Linear app configures
-  exactly one webhook URL, so the URL identifies the app, not a workspace
-  install. Unknown token → 404 (no oracle).
-- Verify `Linear-Signature` = HMAC-SHA256(raw body) with the bot's signing
-  secret, timing-safe (extend `packages/relay/src/hooks/signature.ts`
-  with `verifyLinearSignature` — one home so implementations cannot drift).
-  Invalid → 400. Reject `webhookTimestamp` skew > 60 s.
-- Route by the verified payload identity: `oauthClientId` must equal the
-  bot's client id (belt-and-suspenders with the signature), then
-  `organizationId` selects, among the bot's assign rules, the one whose
-  `workspaceId` matches — that rule names the integration, agent, and
-  daemon. A verified event from a workspace with no matching integration
-  (installed but not yet connected, or removed) → 200 drop with a log
-  line — never a different workspace's integration.
-- Ignore non-`AgentSessionEvent` events with 200 (the user may have enabled
-  broader webhook categories; also accept the `OAuthApp revoked` event and
-  forward it to the CP as a revocation doorbell, following the
-  `rc/github-installation` cache-invalidation pattern — mark the integration
-  revoked after re-verifying against the API, never trusting the payload).
-- Per-integration token-bucket rate limit (reuse `hooks/rate-limit.ts`).
-- Body cap 1 MiB; `promptContext`/`previousComments` truncated to a bounded
-  excerpt (32 KiB budget, `truncateUtf8` on code-point boundaries) before the
-  frame is built.
-- **Always return 200 after signature verification**, before daemon dispatch
-  resolves. Linear's retry ladder (1 min/1 h/6 h, then auto-disable) is too
-  slow and too dangerous to use as our queue; the relay runs its own dispatch
-  retry cadence (`[0, 1 s, 3 s, 8 s]`, as hooks do) toward the daemon. If the
-  daemon stays offline the event is dropped and the Linear session honestly
-  shows unresponsive/stale (§11).
+- **`installRoutes`** mounts `POST /linear/events` — plugin-declared like
+  `/slack/events` and `/feishu/events`, raw-body content-type parser (the
+  HMAC is over the exact request bytes), pinned by
+  `platforms/route-mounts.test.ts`. One **static, shared** URL: a Linear app
+  configures exactly one webhook URL, and the trust model is the same as
+  Slack's shared endpoint — the signature authenticates, the verified payload
+  identity demuxes. The earlier revision's minted capability-URL token is
+  dropped: it added a second secret that only re-proved what the HMAC already
+  proves. A delivery no assigned bot owns answers 401.
+- **`extractDemuxHints`** reads the platform's identity vocabulary from the
+  body: `appId` = `oauthClientId`, `tenantId` = `organizationId`. Every
+  Linear assignment is **tenant-scoped** (§5.1 of the parent design):
+  assign-derived, never learned from traffic, eagerly evicted on unassign —
+  sibling installs of the same app share a signing secret, so the composite
+  index is the only demux that cannot leak one workspace's events into
+  another's bot.
+- **`buildIngest`** validates the assignment's opaque bags (§6.2) and builds
+  the per-bot ingest: a pure HTTP decoder — no `start`, no-op `stop`, no
+  relay-side `egress` facet (the daemon owns all Linear egress, like Feishu).
+- **`verify`** checks `Linear-Signature` (timing-safe HMAC-SHA256 over raw
+  bytes, via the shared signature primitives relay core already serves both
+  seams with) and the `webhookTimestamp` 60 s window on the host clock, and
+  returns the typed parsed `AgentSessionEvent` — parsed exactly once.
+- **`handle`**:
+  - `created` / `prompted` → a `WireNormalizedMessage` (§6.3) through
+    `host.forward(botId, msg)`. Relay-core arbitration resolves the target:
+    a Linear bot has one member integration, so the compiled
+    `defaultAgentId` answers, and every event is explicitly addressed by
+    construction.
+  - `prompted` + `signal: "stop"` → `host.forwardAction` with a
+    `platform_action` envelope (§6.3) routed via the directory — an
+    interaction, not a message, exactly like a Slack cancel button.
+  - The plugin mints the content-derived dedup identity (§4.5);
+    `host.dedupSeen` drops same-pod replays before any forward.
+  - Non-`AgentSessionEvent` events are dropped with 200 (the user may have
+    enabled broader webhook categories) — except `OAuthApp revoked`, which
+    flows to `host.reportRevoked(botId, reason, eventAt, credentialRevision)`;
+    the CP re-verifies against the API behind the revision fence before
+    flipping the integration, exactly as platform revocations already
+    converge.
+  - **Always return 200 after signature verification**, before daemon
+    delivery resolves. Linear's retry ladder (1 min/1 h/6 h, then
+    auto-disable) is too slow and too dangerous to use as our queue; relay
+    core's own forward retry/backoff covers transient daemon absence. If the
+    daemon stays offline the event is dropped and the Linear session honestly
+    shows unresponsive/stale (§11).
+  - Body cap 1 MiB; `promptContext`/`previousComments` truncated to a bounded
+    excerpt (32 KiB budget, `truncateUtf8` on code-point boundaries) before
+    the frame is built. A per-bot ingress token bucket reuses the shared
+    limiter.
 
-### 6.2 Rule table
+### 6.2 CP → relay distribution: `rc/bot-assign`, nothing bespoke
 
-The CP compiles each active Linear integration into a broadcast rule,
-mirroring `RcHookAssign` semantics (empty table at relay start, full replay
-after register, re-broadcast on placement change):
-
-```ts
-// packages/protocol/src/frames/relay-cp.ts
-export const RcLinearAssign = z.object({
-  integrationId: z.string().uuid(),
-  botId: z.string().uuid(),
-  agentId: z.string().uuid(),
-  daemonId: z.string().uuid(), // agent's current placement
-  urlToken: z.string().min(1), // bot-scoped ingress routing key (§6.1)
-  signingSecret: z.string().min(1), // bot-scoped; relay-only; never logged
-  linearClientId: z.string().min(1), // bot-scoped, semi-public; §6.1 oauthClientId cross-check
-  workspaceId: z.string().min(1) // Linear organizationId — selects this rule
-})
-export const RcLinearRemove = z.object({ integrationId: z.string().uuid() })
-```
-
-`urlToken`, `signingSecret`, and `linearClientId` are bot-level values
-repeated on each of the bot's rules; the relay indexes rules by token and,
-within a token group, by `workspaceId`.
-
-### 6.3 Relay → daemon frame
-
-A new `rd/msg` variant joins the discriminated union:
+Linear rides the standard bot assignment. The provider's `projectBotAssign`
+produces the two opaque bags:
 
 ```ts
-// packages/protocol/src/frames/relay-daemon.ts
-export const RdMsgLinear = z.object({
-  source: z.literal('linear'),
-  agentId: z.string().uuid(),
-  integrationId: z.string().uuid(),
-  sessionKey: z.string().min(1), // linear:<issueId ?? agentSessionId>:<agentSessionId>
-  msgId: z.string().min(1), // §4.5 content-derived dedup key
-  action: z.enum(['created', 'prompted']),
-  linear: z.object({
-    agentSessionId: z.string(),
-    issueId: z.string().optional(), // absent for document/editor-surface sessions (§4.5)
-    issueIdentifier: z.string().optional(), // "TEAM-123", display only
-    issueTitle: z.string().optional(), // sanitized, ≤200 chars
-    issueUrl: z.string().optional(),
-    actor: z.object({ id: z.string(), name: z.string().optional() }).optional(),
-    signal: z.enum(['stop']).optional(),
-    // prompted: agentActivity.body (the follow-up message).
-    // created via mention: the triggering comment's own text — the member's
-    // instruction, extracted so it is NOT only inside fenced promptContext.
-    body: z.string().optional(),
-    promptContext: z.string().optional(), // created: bounded excerpt
-    guidance: z.string().optional(), // created: workspace agent guidance
-    previousComments: z.string().optional(), // created: bounded excerpt
-    truncated: z.boolean().optional()
-  })
-})
+// secrets bag — relay-only material
+{ signingSecret }
+// ingress bag — demux identity + self-echo metadata
+{ clientId, organizationId, appUserId? }
 ```
 
-The daemon acknowledges admission with the existing `rd/ack`.
+The client secret and the refresh token never reach the relay. Everything
+else on the frame stays core-assembled as for every platform: the member
+directory, the compiled route/default-agent table, gating fences, and
+`credentialRevision` (which fences signing-secret rotation, §10.6). The
+earlier revision's `RcLinearAssign` / `RcLinearRemove` frames and the
+relay-local Linear rule table are gone — replay-on-register, placement
+re-broadcast, and lifecycle edges are the shared machinery.
+
+### 6.3 Relay → daemon frames: `im` + `platform_action`
+
+No new `rd/msg` union member. Events ride `RdMsgIm` with a
+`WireNormalizedMessage`:
+
+- `platform: 'linear'`, `channel` = issue UUID (or session UUID fallback,
+  §4.5), `thread` = AgentSession UUID, `threadUrl` = issue URL,
+  `sender.id = linear:<actorId>`, `isDm: false`.
+- `text` = the member's instruction — the delegation line, the triggering
+  comment's own text for a mention-created session (extracted so it is
+  **never only inside fenced context**), or the follow-up
+  `agentActivity.body` verbatim.
+- `adapterExt.linear` = `{ agentSessionId, issueIdentifier?, issueTitle?,
+promptContext?, guidance?, previousComments?, truncated? }` — the §6.4
+  adapter-extension bag: opaque to core, round-tripped to the daemon's linear
+  module, which owns fencing and prompt assembly (§8).
+
+Stop rides `RdMsgPlatformAction` (`platformId: 'linear'`, payload
+`{ kind: 'stop', agentSessionId }`): the daemon-side linear module decodes it,
+short-circuits to `interruptTurn`, and posts the settling `response` — no
+turn, no arbitration, dedup on the same `(botId, sessionKey, msgId)` scope as
+every interaction.
 
 ## 7. Install flow and credential model
 
-### 7.1 Console flow (AddIntegrationModal, two steps like `webhook`)
+### 7.1 Console flow (the module's wizard facet, two steps)
 
 **Step 1 — app credentials.** The user picks the agent and pastes three
 values from a Linear OAuth app they create at
 _Linear Settings → API → OAuth applications_:
 
-- Client ID (public → `Bot.linearClientId`)
+- Client ID (public → `Bot.externalAppId`)
 - Client Secret (CP-only)
 - Webhook signing secret (relay-only)
 
-The checklist (following `FEISHU_CHECKLIST`) tells them to: name the app
-after the agent and upload the agent's icon (Linear renders the app's own
+The wizard checklist (following the Feishu module's) tells them to: name the
+app after the agent and upload the agent's icon (Linear renders the app's own
 branding; AgentConnect cannot push it); set the callback URL to
-`<PUBLIC_CP_URL>/v1/integrations/linear/oauth/callback` (note: the deployed
-public prefix is `/v1`, per the Slack-callback precedent); enable webhooks
-with **Agent session events** checked; and paste the webhook URL revealed in
-step 2.
+`<PUBLIC_CP_URL>/v1/integrations/linear/oauth/callback` (the public `/v1`
+form — the provider's `public-callback` routes are mounted at both scopes by
+core, per the Slack precedent); enable webhooks with **Agent session events**
+checked; and paste the webhook URL `https://<relay>/linear/events` (from
+`relayCapability.publicUrl`).
 
-Creating the integration requires `PUBLIC_RELAY_URL` + a live relay (409
-otherwise). The bot-scoped `urlToken` is minted with the bot (step 1); a
-second workspace install on the same bot reuses it. The integration starts
-`pending`.
+Submitting runs the common create tail: the provider's
+`credentialBodySchema` block, `validateConfig` (shape checks only — unlike
+Slack `auth.test` there is **no** pre-persistence probe; the client secret is
+unverifiable without an OAuth exchange, so the live check is the callback
+itself), and `buildNewBotInstall`, which packs the secret row and declares
+the D6 `externalIdentity` `(clientId, '-')` — the pre-capture sentinel, so at
+most one not-yet-connected install per app exists at a time (the 409 copy
+says "finish connecting the existing install"). Core's relay-availability
+409 applies. The bot + integration are created `pending`.
 
-**Step 2 — connect the workspace.** The console reveals the webhook URL
-(`https://<relay>/webhooks/linear/<token>`) for the user to paste into the
-Linear app config, then offers **Connect to Linear**: an authorize URL
+**Step 2 — connect the workspace.** The console offers **Connect to
+Linear**: an authorize URL
 
 ```text
 https://linear.app/oauth/authorize?client_id=…&redirect_uri=…&response_type=code
   &scope=read,write,app:assignable,app:mentionable&actor=app&state=<nonce>
 ```
 
-with a one-shot `state` nonce (mirroring `GithubInstallState`). The CP
-callback exchanges the code at `https://api.linear.app/oauth/token`, queries
-`viewer { id organization { id name } }` to learn `workspaceId` and the app
-user id, persists the token row, flips the integration `active`, and
-broadcasts `rc/linear-assign` + `integration/upsert`. The token exchange
-doubles as credential verification — there is no separate `verifyLinearBot`
-probe (unlike Lark / Feishu, the client secret cannot be validated without OAuth).
+with a one-shot `state` nonce persisted in the provider's
+`linear_install_state` funnel table (declared via `pendingInstalls`, swept by
+the shared TTL reaper). The public callback exchanges the code at
+`https://api.linear.app/oauth/token`, queries
+`viewer { id organization { id name } }`, then in one transaction: persists
+the token row, stamps the bot's workspace identity
+(`externalTenantId` = `organizationId`, display `workspaceId`/`workspaceName`,
+`botUserId` = the app user id), runs the cross-org `workspaceClaim` fence,
+flips the integration `active`, and lets core broadcast the standard
+`rc/bot-assign` + `integration/upsert`.
 
 ### 7.2 Storage
 
-| Value                                                                 | Where                                                                         | Visibility                                                                              |
-| --------------------------------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| Client ID                                                             | `Bot.linearClientId` (public metadata column)                                 | console, authorize URL                                                                  |
-| Client Secret                                                         | `BotSecret.botToken`                                                          | CP only (code exchange + refresh)                                                       |
-| Webhook signing secret                                                | `BotSecret.signingSecret`                                                     | relay only, via `rc/linear-assign` (existing column; already relay-only for Slack http) |
-| Access + refresh token, expiry, workspaceId, workspaceName, appUserId | new `linear_token` table, 1:1 with Integration, values through `SecretCipher` | access token → daemon (spec + broker); refresh token → CP only                          |
+| Value                          | Where                                                                                    | Visibility                                                     |
+| ------------------------------ | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Client ID                      | `Bot.externalAppId` (D6 column)                                                          | console, authorize URL, relay ingress bag                      |
+| Workspace (organization) id    | `Bot.externalTenantId` + display `workspaceId`/`workspaceName`                           | console, relay ingress bag                                     |
+| Client Secret                  | `BotSecret.botToken` slot (`secretShape.slots` labels it)                                | CP only (code exchange + refresh)                              |
+| Webhook signing secret         | `BotSecret.signingSecret` slot; `httpAssignRequires: ['signingSecret']`                  | relay only, via the `rc/bot-assign` secrets bag                |
+| Access + refresh token, expiry | provider-owned `linear_token` table, 1:1 with Integration, values through `SecretCipher` | access token → daemon (spec + broker); refresh token → CP only |
+| OAuth `state` nonce            | provider-owned `linear_install_state` funnel table (TTL-reaped)                          | CP only                                                        |
 
-The `IntegrationSpec.linear` pushed to the daemon:
+The opaque `IntegrationSpec.config` payload the provider projects (validated
+on the daemon by the linear module's schema in `CONFIG_SCHEMAS`):
 
 ```ts
-// packages/protocol/src/frames/integration.ts
-export const IntegrationLinearConfig = z.object({
-  workspaceId: z.string(),
-  workspaceName: z.string().optional(),
-  appUserId: z.string().optional(), // the app's Linear user id (self-echo guard)
-  accessToken: z.string(), // ≤24 h snapshot; refreshed via linearcred
-  accessTokenExpiresAt: z.string().datetime()
-})
+{
+  workspaceId: string
+  workspaceName?: string
+  appUserId?: string           // the app's Linear user id (self-echo guard)
+  accessToken: string          // ≤24 h snapshot; refreshed via linearcred
+  accessTokenExpiresAt: string // ISO datetime
+}
 ```
 
 `agent.json` therefore holds a short-lived token, not a durable secret — a
@@ -583,37 +607,37 @@ export const LinearCredGrant = z.object({
 })
 ```
 
-CP handler: placement scope check (`agent.daemonId === conn.daemonId`, as
-gitcred does), single-flight refresh when the stored token is near expiry,
-durable persist of the rotated pair **before** replying, then also re-push
-the integration spec so `agent.json` converges.
+The CP handler follows the `gitcred` shape — core owns the frame family and
+the placement scope check (`agent.daemonId === conn.daemonId`); the
+provider's token service owns the work: single-flight refresh when the stored
+token is near expiry, durable persist of the rotated pair **before**
+replying, then a spec re-push so `agent.json` converges.
 
 ### 7.4 Uninstall / revocation
 
 `DELETE /integrations/:id` revokes the token at Linear
-(`POST /oauth/revoke`, best-effort), deletes the `linear_token` row,
-broadcasts `rc/linear-remove` + `integration/remove`, and frees the bot for
-reuse — matching existing uninstall semantics. The `OAuthApp revoked`
-doorbell (§6.1) converges the same state when revocation originates on the
-Linear side.
+(`POST /oauth/revoke`, best-effort), deletes the `linear_token` row, and
+rides the standard uninstall broadcast (bot unassign + `integration/remove`),
+freeing the bot for reuse. The `OAuthApp revoked` doorbell (§6.1) converges
+the same state when revocation originates on the Linear side — re-verified at
+the CP behind the `credentialRevision` fence, never trusted from the payload.
 
 ## 8. Prompt assembly and trust boundary
 
-`buildLinearMessage` (new `packages/daemon/src/messages/linear-message.ts`,
-shaped after `hook-message.ts`) synthesizes the `NormalizedMessage`:
+The daemon linear module owns turning the delivered `im` message into the
+dispatch prompt (its per-platform strategy seat, fed by the round-tripped
+`adapterExt.linear` bag):
 
 - `platform: 'linear'`, `source: 'user'`, `trigger: 'mention'`,
   `sender.id = linear:<actorId>`, `isDm: false`, `headless: false` (the
   session has a live reply surface — the activity feed).
 - **Trusted header** (daemon-authored): `Linear TEAM-123 "title" — delegated
 by <actor>` + issue URL, with `sanitizeTitle` flattening.
-- **Instruction text**: for `prompted`, the user's `agentActivity.body`
-  verbatim — workspace members are the same trust class as Slack users, and
-  their messages are instructions. For `created`, the instructions are the
-  delegation line, **the triggering comment's own text** when the session was
-  started by a mention (`@Agent fix X` is the member's directive — the relay
-  extracts it into `linear.body`, bounded, so it never lives only inside the
-  fenced context), and `guidance` (workspace-admin-authored).
+- **Instruction text**: `msg.text` (§6.3) — the follow-up body verbatim for
+  `prompted` (workspace members are the same trust class as Slack users, and
+  their messages are instructions), or the delegation line plus the
+  triggering comment's own text for `created`, plus `guidance`
+  (workspace-admin-authored).
 - **Quoted context**: `promptContext` and `previousComments` wrap in the
   existing `UNTRUSTED_CONTENT_BEGIN/END` fence with `neutralizeDelimiters`.
   Issue bodies can contain text authored outside the workspace (customer
@@ -626,110 +650,107 @@ by <actor>` + issue URL, with `sanitizeTitle` flattening.
   instructions are injected — activities take CommonMark, so rendering is
   last-mile in the converger like every other platform.
 
-## 9. Change inventory by layer
+## 9. Change inventory by host
 
-Following the [feishu-integration.md §4](feishu-integration.md) template;
-`[enum]` marks every enumeration site. Linear's capability gate is
-**four-part**: daemon `capabilities().platforms`, CP availability check, web
-tile filter, **plus** relay presence (`PUBLIC_RELAY_URL` + live relay).
+Adding Linear is implementing the four contracts plus one registry line per
+host — no core `switch`, no closed union, no platform enum migration. The
+capability chain that gates availability end to end: the daemon's
+`CONFIG_SCHEMAS` registry line → `capabilities.platforms` in the register
+handshake → the CP's daemon-platform-capability gate (plus the relay 409 for
+`http`) → the console tile.
 
 ### 9.1 `packages/protocol`
 
-- `frames/route.ts` — `[enum]` `Platform` += `'linear'`.
-- `frames/integration.ts` — `IntegrationLinearConfig` (§7.2) + `[enum]`
-  `IntegrationSpec` union branch.
-- `frames/relay-daemon.ts` — `RdMsgLinear` (§6.3) into the `RdMsg` union;
-  `[enum]` `WireNormalizedMessage.platform` and the three agentmsg coord
-  enums stay in lockstep with `NormalizedMessage`.
-- `frames/relay-cp.ts` — `RcLinearAssign` / `RcLinearRemove` (§6.2) +
-  registration.
-- `frames/linearcred.ts` — broker REQ/RES (§7.3).
+- `frames/linearcred.ts` — broker REQ/REP (§7.3) + codec round-trips. **The
+  only new frames.** `Platform` is already an open string with tolerant
+  readers (`platform-tolerance.test.ts`); `rd/msg` and `rc/bot-assign` carry
+  Linear without change.
+- `platform-manifest.ts` — no entry needed: `DEFAULT_MANIFEST`'s fail-closed
+  arms are exactly Linear's truth (observed membership, no bot-sender
+  routing, conversation-granularity leave). Per the manifest's own rule, a
+  row lands only with a justified pre-dispatch field.
+- The opaque integration-config payload shape (§7.2) is documented beside its
+  peers in `frames/integration.ts`.
 - `frames/cron.ts` — **not** extended in v1 (no cron target).
-- `codec.test.ts` round-trips for every new frame.
 
 ### 9.2 `packages/control-plane`
 
-- Prisma: `[enum]` `enum Platform` += `linear` (migration `ALTER TYPE … ADD
-VALUE`), `Bot.linearClientId String?`, `Bot.linearUrlToken String? @unique`
-  (bot-scoped ingress token, §6.1), new `linear_token` and
-  `linear_install_state` tables; `prisma:generate`.
-- `persistence/platform.ts` — pass `'linear'` through `toDbPlatform`.
-- `routes/integrations.ts` — `linear` create branch (mints the bot-scoped
-  urlToken with a new bot, 409s without relay). Note: the existing create
-  route caps a non-`shareable` bot at one integration; for Linear that cap
-  becomes **one integration per (bot, workspace)** — same-bot installs into
-  distinct workspaces are allowed without the Slack `shareable` semantics.
-  `routes/linear-install.ts` — authorize-URL endpoint + public OAuth
-  callback (mounted under the public `/v1` prefix alias, per the Slack
-  callback precedent).
-- `dto/index.ts` — `[enum]` `CreateIntegrationBody.platform`, `linear:
-z.object({ clientId, clientSecret, signingSecret })` block + both
-  `superRefine` guards; `IntegrationDto` gains `linear` status fields
-  (workspaceName, connected).
-- `http/daemon-platform-capability.ts` — `[enum]` += `'linear'`, plus the
-  relay-presence check for this platform.
-- New `linear/` service dir: `LinearAssignService` (compile/broadcast/replay,
-  mirroring `HookService`), `LinearTokenService` (exchange, single-flight
-  rotate-and-retry refresh, revoke), OAuth client.
-- `orchestrator/placement.ts#integrationToSpec` — `linear` branch embedding
-  the token snapshot.
-- WS: `linearcred` handler; revocation doorbell handler.
-- OpenAPI: tags/summary/operationId on every new route.
-- Tests: DTO guards unit; integration-route + OAuth callback + broker
-  integration tests with a fake Linear token endpoint.
+- `src/platforms/linear/` implementing `CpPlatformProvider` + one
+  `registry.ts` line:
+  - `credentialBodySchema` `{ clientId, clientSecret, signingSecret }`;
+    `validateConfig` shape-only (§7.1); `buildNewBotInstall` packing the
+    secret slots + the D6 `externalIdentity` pre-capture fence.
+  - `secretShape` (§7.2); `projectBotIdentity` (clientId / organizationId /
+    sentinel).
+  - `installRoutes('org')` — authorize-URL mint + connect status;
+    `installRoutes('public-callback')` — the OAuth callback (§7.1). Repo
+    OpenAPI conventions on every route.
+  - `pendingInstalls` — `linear_install_state` + TTL reaper.
+  - `projectIntegrationConfig` (async, loads `linear_token`) and
+    `projectBotAssign` (§6.2).
+  - `LinearTokenService` — exchange, single-flight rotate-and-retry refresh,
+    revoke; surfaced to the WS `linearcred` handler (§7.3).
+- Prisma: new `linear_token` and `linear_install_state` tables only — Bot
+  identity rides the existing D6 columns, and `platform` columns are already
+  text.
+- Tests: provider unit (schema guards, projector shapes); integration-route +
+  OAuth callback + broker integration tests against a fake Linear token
+  endpoint; workspace-claim and external-identity 409s.
 
 ### 9.3 `packages/relay`
 
-- New `src/linear-ingress.ts` (§6.1) registered when any rule exists;
-  `hooks/signature.ts#verifyLinearSignature`; rule table keyed by urlToken
-  (reuse `HookTable` shape); dispatch retry identical to hooks.
-- `relay-cp-client.ts` — handle `rc/linear-assign` / `rc/linear-remove` +
-  replay-on-register.
+- `src/platforms/linear/` implementing `RelayPlatformIngressPlugin` (§6.1) +
+  one `registry.ts` line; a `platforms/route-mounts.test.ts` row pins
+  `POST /linear/events`.
+- Tests: signature/timestamp vectors, demux-hint extraction, verified-but-
+  unmatched workspace → no candidate, truncation budgets, dedup-identity
+  derivation, stop → `platform_action`, revoked-event doorbell.
 
 ### 9.4 `packages/daemon`
 
-- New `src/linear/` silo:
-  - `connection.ts` — `LinearConnection` per integration: GraphQL client
-    (plain `fetch` against `api.linear.app/graphql`; the `@linear/sdk`
-    dependency is optional — the agent surface is four mutations and two
-    queries), token cache + `linearcred` renewal, send queue,
-    `createActivity`, `updateSession`, `resolveTeamStates`,
-    `moveIssueToStarted` (P2), `stop()`/`start()` (no socket — start warms
-    the token). Self-echo guard on `appUserId`.
-  - `normalize.ts` — `RdMsgLinear` → `NormalizedMessage` (§8), stop-signal
-    short-circuit to `interruptTurn`.
-  - `render.ts` — `LinearConverger` + `LinearAction` (§5).
-- `daemon.ts` touchpoints (the ~40-site checklist from Lark / Feishu): conns map by
-  integrationId, `reconcileLinearConnections()` at the three call sites,
-  `applyLinearAction` in `enqueueApply`, converger construction branch,
-  `replyConnFor`/`connForIntegration` union widening, ≤10 s ack in the
-  relay-msg admission path, `[enum]` `capabilities().platforms` += `'linear'`,
-  shutdown.
-- `messages/normalized.ts` — `[enum]` platform union += `'linear'`.
-- `messages/linear-message.ts` (§8).
-- `router/routing-rule.ts` — Linear branch (trivial: relay delivery is
-  pre-attributed with explicit `agentId`, so no arbitration ladder;
-  mirrors the hook path).
-- `agents/agent-schema.ts` — `[enum]` `IntegrationSchema` union +
-  `write-integration.ts` branch.
-- `handleRelayMsg` — route `source: 'linear'`.
+- `src/platforms/linear/`:
+  - `connection.ts` — the per-integration egress client, a **minimal
+    Layer 1**: `start()` warms the token (no socket to open), `stop()` clears
+    timers; GraphQL over plain `fetch` (the `@linear/sdk` dependency is
+    unnecessary — the agent surface is four mutations and two queries); token
+    cache + `linearcred` renewal; `PlatformSendQueue`; self-echo guard on
+    `appUserId`. The read port answers what Linear affords — `getChannelInfo`
+    resolves the issue, `getUserProfile` the Linear user — and returns
+    empty/`null` elsewhere (no `listBotChannels`, no `leaveChannel`,
+    `downloadFile` deferred).
+  - `turn-output.ts` — the streaming Layer-2 surface + `LinearConverger` +
+    `LinearAction` (§5).
+  - message strategy — `adapterExt.linear` → prompt assembly and fencing
+    (§8); no-issue unsupported-surface response (§4.5); stop decoder for the
+    `platform_action` payload → `interruptTurn` + settling response.
+  - The ≤10 s ack at `rd/msg` admission, after inbox dedup (§10.1).
+- `platforms/integration-config.ts` — the `linear` `CONFIG_SCHEMAS` line
+  (+ the schema in `agents/agent-schema.ts`). This single line is what flips
+  `capabilities.platforms`.
 - Session metadata: `channelName`/`threadUrl` from issue identifier/URL.
-- Tests: `linear-normalize.test.ts`, `linear-render.test.ts` (converger
-  translation table, coalescing, no-response ack-only), dedup-before-ack
-  ordering unit.
+- Tests: normalize (created/prompted/stop, mention-comment `text`
+  extraction, no-issue created event → session-UUID channel + bounded
+  unsupported-surface `response` with **no ACP turn**), converger
+  translation table per mode, coalescing caps, no-response **ack-only**
+  (nothing posted after the pre-spawn ack; `none` mode remains
+  zero-activity since it never acks), dedup-key derivation,
+  **dedup-before-ack ordering including concurrent same-`msgId` deliveries
+  collapsing to one ack** (fake clock).
 
 ### 9.5 `packages/web`
 
-- `components/marks.tsx#PlatformMark` — Linear brand SVG.
-- `AddIntegrationModal.tsx` — `linear` in `BOT_PLATFORMS`, two-step flow
-  (§7.1), `CREATE_DESC.linear`, `LINEAR_CHECKLIST`, availability =
-  daemon capability ∧ relay present.
-- `SettingsView.tsx` — Bots card tab.
-- `AgentDetailView.tsx` — Integrations card row (workspace name, connect
-  status, re-connect action when `pending`/token-revoked).
-- `lib/api.ts` — `CreateIntegrationInput` union + `linear` DTO fields;
-  `lib/data.ts#sessionPlatform` + session filters; `lib/data-context.tsx`
-  mock rows.
+- `src/components/console/platforms/linear/` implementing
+  `WebPlatformModule` + one `registry.ts` line:
+  - `Mark` — Linear brand SVG (60 % box, `fillPct` convention).
+  - `wizard` — the two-step facet (§7.1); tile availability = daemon
+    capability ∧ `relayCapability.available`; `freeBotFilter` /
+    `buildReuseInput` for freed bots.
+  - `apiBindings` — authorize-URL + connect-status calls.
+  - `settingsFragments` — workspace name, connect status, re-connect action
+    when `pending`/token-revoked.
+  - `channelList` — `roomNoun: 'issue'`, no leave affordance.
+  - `messageIdentity` — agent-activity id, else `null` (never dedupes).
+  - `transcriptOrdering` — default `'seq'`.
 
 ## 10. Linear-specific decisions
 
@@ -756,33 +777,36 @@ z.object({ clientId, clientSecret, signingSecret })` block + both
    configured `permissionMode` governs, exactly like GitHub hook turns.
 5. **No Linear-side title push.** Linear names agent sessions from the issue;
    AgentConnect's session titles remain console-local.
-6. **Signing-secret rotation** = paste the new secret in the console (bot
-   secret update → recompile → `rc/linear-assign` re-broadcast). No dual-key
-   window in v1; rotation races drop deliveries for seconds, recovered by
-   Linear's retry ladder (the one case where we _want_ the non-200: an
-   unverifiable delivery returns 400 and Linear retries).
+6. **Signing-secret rotation** = paste the new secret in the console: the bot
+   secret update advances `credentialRevision` and re-broadcasts
+   `rc/bot-assign`, and the plugin rebuilds the ingest. No dual-key window in
+   v1; rotation races drop deliveries for seconds, recovered by Linear's
+   retry ladder (the one case where we _want_ the non-200: an unverifiable
+   delivery returns 401 and Linear retries).
 
 ## 11. Failure and degradation semantics
 
-| Failure                                                     | Behavior                                                                                                                                                                                                                                                                                                                                                                   |
-| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CP down, daemon up                                          | Established sessions keep streaming (cached/spec token, ≤24 h). New `created`/`prompted` events still flow (relay rules are in relay memory; delivery is relay→daemon). Token renewal and install/uninstall stall.                                                                                                                                                         |
-| Daemon offline                                              | Relay retries `[0, 1 s, 3 s, 8 s]`, then drops; the Linear session shows unresponsive/stale — an honest signal, surfaced in the console alongside daemon health. A CP-posted failure activity was considered and **rejected**: the CP performing provider egress would create a second Linear writer and put it on the message path, violating the architecture invariant. |
-| All relays down                                             | Linear gets timeouts/5xx → its retry ladder (1 min/1 h/6 h) redelivers after recovery; content-derived dedup absorbs replays. Repeated failure risks Linear auto-disabling the webhook — surface `lastDeliveryAt` staleness in the console.                                                                                                                                |
-| Token refresh fails (secret rotated at Linear, app deleted) | Broker returns terminal error; daemon posts `error` activity while its cached token lasts, else goes silent; integration flips `error` in the console with a re-connect CTA.                                                                                                                                                                                               |
-| Linear API down                                             | Egress-queue retries with backoff; activities are droppable chrome (the transcript is authoritative); the final `response` retries hardest (bounded, like `GithubFinalPoster`'s 15 s finalize budget).                                                                                                                                                                     |
-| Duplicate webhook delivery                                  | Daemon inbox dedup (§4.5).                                                                                                                                                                                                                                                                                                                                                 |
-| Workspace admin revokes the app                             | `OAuthApp revoked` doorbell → verify → integration `revoked`, rules removed.                                                                                                                                                                                                                                                                                               |
+| Failure                                                     | Behavior                                                                                                                                                                                                                                                                                                                                                                  |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CP down, daemon up                                          | Established sessions keep streaming (cached/spec token, ≤24 h). New `created`/`prompted` events still flow (assignments live in relay memory; delivery is relay→daemon). Token renewal and install/uninstall stall.                                                                                                                                                       |
+| Daemon offline                                              | Relay core's forward retry/backoff, then drop; the Linear session shows unresponsive/stale — an honest signal, surfaced in the console alongside daemon health. A CP-posted failure activity was considered and **rejected**: the CP performing provider egress would create a second Linear writer and put it on the message path, violating the architecture invariant. |
+| All relays down                                             | Linear gets timeouts/5xx → its retry ladder (1 min/1 h/6 h) redelivers after recovery; content-derived dedup absorbs replays. Repeated failure risks Linear auto-disabling the webhook — surface `lastDeliveryAt` staleness in the console.                                                                                                                               |
+| Token refresh fails (secret rotated at Linear, app deleted) | Broker returns terminal error; daemon posts `error` activity while its cached token lasts, else goes silent; integration flips `error` in the console with a re-connect CTA.                                                                                                                                                                                              |
+| Linear API down                                             | Send-queue retries with backoff; activities are droppable chrome (the transcript is authoritative); the final `response` retries hardest (bounded, like the GitHub finalizer's 15 s budget).                                                                                                                                                                              |
+| Duplicate webhook delivery                                  | Relay TTL dedup + daemon inbox (§4.5).                                                                                                                                                                                                                                                                                                                                    |
+| Workspace admin revokes the app                             | `OAuthApp revoked` doorbell → fenced re-verify → integration `revoked`, assignment removed.                                                                                                                                                                                                                                                                               |
 
 ## 12. Security checklist
 
-- Signing secret: relay-only; never in daemon specs, logs, or DTOs. Client
-  secret: CP-only. Refresh token: CP-only, `SecretCipher`-encrypted. Access
-  token: daemon memory + `agent.json` (≤24 h lifetime).
+- Signing secret: relay-only, via the `rc/bot-assign` secrets bag — never in
+  daemon specs, logs, or DTOs. Client secret: CP-only. Refresh token:
+  CP-only, `SecretCipher`-encrypted. Access token: daemon memory +
+  `agent.json` (≤24 h lifetime).
 - HMAC verified timing-safe over raw bytes before any parsing side effects;
-  `webhookTimestamp` replay window; verified `organizationId` selects the
-  integration within the bot's token group (unmatched workspace → drop);
-  capability-URL token ≥128-bit, 404 on unknown.
+  `webhookTimestamp` replay window; demux is the tenant-scoped
+  `(clientId, organizationId)` composite — assign-derived, never learned, so
+  sibling installs of the same app (same signing secret) can never receive
+  each other's workspaces' events. Unmatched delivery → 401, no oracle.
 - Event bodies never transit or persist at the CP (activity bodies flow
   daemon → Linear only; CP stores session metadata, not content).
 - Untrusted-content fencing for issue-derived text (§8); sanitized trusted
@@ -790,46 +814,52 @@ z.object({ clientId, clientSecret, signingSecret })` block + both
 - Agent environment contains no Linear credentials; all writes go through
   the daemon-owned single writer (§4.6).
 - OAuth `state` one-shot nonces; callback exchanges bind to the pending
-  integration id.
-- Rate limits both directions (ingress bucket per integration; egress queue).
+  integration id; cross-org `workspaceClaim` fence at connect.
+- Rate limits both directions (per-bot ingress bucket; egress send queue).
 
 ## 13. Phasing
 
-- **P1 — the core loop.** Protocol frames + enums; CP schema, create/OAuth/
-  callback routes, assign compiler, token service + broker; relay ingress;
-  daemon silo with ack, converger (`thought`/`action`/`response`/`error`),
-  follow-ups, stop; web install flow, marks, session display. Exit criteria:
-  delegate an issue → acknowledged ≤10 s → streamed activities → response;
-  reply and stop work; sessions render in the console.
+- **P1 — the core loop.** `linearcred` frames; CP provider (create,
+  OAuth funnel + callback, token service + broker, projectors) + registry
+  line; relay ingress plugin + registry line; daemon module (connection,
+  ack, converger `thought`/`action`/`response`/`error`, follow-ups, stop,
+  config schema) + registry line; web module (wizard, mark, settings,
+  session display) + registry line. Exit criteria: delegate an issue →
+  acknowledged ≤10 s → streamed activities → response; reply and stop work;
+  sessions render in the console.
 - **P2 — workflow polish.** Plan sync; `externalUrls` (PR + console links);
   issue auto-start transition; daemon-local Linear read tool (bounded
   `getIssue`/comments via the connection token); elicitation deep-link card.
 - **P3 — breadth.** Label → skill playbook mapping; proactive sessions
-  (`agentSessionCreateOnIssue`) as a cron/sendMessage target (adds the cron
-  `[enum]`); `issueRepositorySuggestions` for multi-repo agents; interactive
-  permission approval over activities; multi-workspace install UX.
+  (`agentSessionCreateOnIssue`) as a cron/sendMessage target (extends
+  `frames/cron.ts`); `issueRepositorySuggestions` for multi-repo agents;
+  interactive permission approval over activities; multi-workspace install UX
+  (credential reuse across a second workspace's bot).
 
 ## 14. Tests
 
-- **Protocol:** codec round-trips for `RdMsgLinear`, `RcLinearAssign/Remove`,
-  `linearcred/*`, `IntegrationLinearConfig`.
-- **Relay unit:** signature/timestamp verification vectors, workspace →
-  integration routing within a token group (incl. verified-but-unmatched
-  workspace → 200 drop, and `oauthClientId` ≠ rule `linearClientId` → drop),
-  truncation budgets, rule replay, retry cadence, 200-after-verify ordering.
-- **Daemon unit:** normalize (created/prompted/stop, mention-comment `body`
+- **Protocol:** codec round-trips for `linearcred/*`; the existing
+  platform-tolerance suite already covers an unknown-to-peer `'linear'` id.
+- **Relay unit (plugin):** signature/timestamp verification vectors,
+  demux-hint extraction, tenant-composite candidate selection (incl.
+  verified-but-unmatched workspace → no candidate, sibling-install
+  isolation), truncation budgets, dedup-identity derivation, stop →
+  `platform_action`, revoked doorbell, route-mounts row.
+- **Daemon unit:** normalize (created/prompted/stop, mention-comment `text`
   extraction, no-issue created event → session-UUID channel + bounded
   unsupported-surface `response` with **no ACP turn**), converger
   translation table per mode, coalescing caps, no-response **ack-only**
   (nothing posted after the pre-spawn ack; `none` mode remains
   zero-activity since it never acks), dedup-key derivation,
   **dedup-before-ack ordering including concurrent same-`msgId` deliveries
-  collapsing to one ack** (fake clock).
-- **CP unit:** DTO `superRefine` guards; token service rotate-and-retry with
-  a failing-then-succeeding fake token endpoint; single-flight refresh.
-- **CP integration:** migration; create → pending → callback → active
-  lifecycle against a stubbed Linear OAuth server; broker scope denial for a
-  foreign daemon; uninstall/revocation convergence.
+  collapsing to one ack** (fake clock), config-schema fail-closed reads.
+- **CP unit:** provider schema guards; token service rotate-and-retry with a
+  failing-then-succeeding fake token endpoint; single-flight refresh;
+  projector output shapes.
+- **CP integration:** create → pending → callback → active lifecycle against
+  a stubbed Linear OAuth server; D6 external-identity and workspace-claim
+  409s; broker scope denial for a foreign daemon; uninstall/revocation
+  convergence.
 - **Live checklist:** real OAuth app in a scratch Linear workspace —
   delegate, mention, follow-up, stop, redelivery replay (Linear's webhook
   console), token refresh across the 24 h boundary, workspace revoke.
@@ -842,8 +872,8 @@ z.object({ clientId, clientSecret, signingSecret })` block + both
    Resolve against the live API during P1 (design assumes terminal-only).
 2. **`prompted` after `complete`** — whether Linear reopens the session or
    requires a new one; determines resume behavior after the stop `response`.
-3. **Plan API stability** — Linear marks it technology preview; P2 should
-   feature-flag plan sync per integration.
+3. **Plan API stability** — Linear still marks it technology preview; P2
+   should feature-flag plan sync per integration.
 4. **`client_credentials` tokens** (30-day, per-app opt-in) are documented as
    app actors, so they could replace the refresh machinery for the app's home
    workspace. Open: whether they work for workspaces the app was installed

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -259,8 +259,11 @@ The mapping onto existing tables — the Slack shared-bot shape, not a new one:
   constant it sets.
 - **`Integration`** = one **enabled agent** on that workspace
   (`Integration.botId` is deliberately non-unique — the shared-bot
-  precedent). The workspace records a **default agent** among its members,
-  compiled into `rc/bot-assign.defaultAgentId` like any shared bot's.
+  precedent). The workspace records a **default agent** among its members —
+  a durable choice, which is why it rides the generic persisted preferred
+  default of §9.2 (the orchestrator's compile today has no such input and
+  falls back to the earliest non-gated member) rather than anything the
+  provider could smuggle through its opaque assign bags.
 - The cross-org `workspaceClaim` fence refuses a workspace another
   organization already holds — every workspace's events verify against the
   same deployment signing secret, so the tenant composite is the only thing

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -276,9 +276,9 @@ with several agents bound to it:
   names — `@<agent-name>` anywhere in the instruction, matched against the
   workspace's enabled members, exactly as a GitHub comment addresses one
   agent by name inside a thread the App owns. The name is plain text (agents
-  are not Linear entities; only the app is mentionable), matched by the
-  relay's compiled per-member keyword routes with `defaultAgentId` as the
-  fallback — the Slack shared-bot ladder, unchanged.
+  are not Linear entities; only the app is mentionable), matched by
+  per-member name routes in the relay's existing ladder (compiled through
+  the §9.2 routing seams) with `defaultAgentId` as the fallback.
 - **One AgentSession binds to one agent at creation** and never changes
   hands: follow-ups and stop go to that agent. Addressing a _different_
   agent is a new mention on the issue → a new session → another thread in
@@ -515,8 +515,9 @@ idle window).
     `host.forward(botId, msg)`. Relay-core arbitration resolves the target
     with the ladder it already runs for shared bots: `prompted` follows the
     session's thread affinity (the session's bound agent); a `created` from
-    a mention matches the per-member **keyword routes** the CP compiles from
-    the enabled agents' names (`@<agent-name>` in the text, §4.3); anything
+    a mention matches the per-member **name routes** the CP compiles from
+    the enabled agents' names (`@<agent-name>` in the text, §4.3; sourced
+    via `projectMemberRoutes`, §9.2); anything
     else — bare delegation, automation delegation, no name matched — falls
     to `defaultAgentId`. Every event is explicitly addressed by
     construction.
@@ -559,11 +560,19 @@ workspace bot's secret row at connect; the client secret and the refresh
 token never reach the relay. Everything else on the frame stays
 core-assembled as for every platform — and for Linear the shared-bot members
 are doing real work: `members`/`agents` list the workspace's enabled agents,
-`routes` carries the per-member keyword rules (§6.1), `defaultAgentId` the
+`routes` carries the per-member name rules (§6.1), `defaultAgentId` the
 workspace default, and `credentialRevision` fences signing-secret rotation
-(§10.6). The earlier revision's `RcLinearAssign` / `RcLinearRemove` frames
-and the relay-local Linear rule table are gone — replay-on-register,
-placement re-broadcast, and lifecycle edges are the shared machinery.
+(§10.6). Two of those inputs need seams the shipped compiler lacks,
+inventoried in §9.2, because `projectBotAssign` deliberately carries **no
+routing** (only the two opaque bags — members, routes, and the default are
+assembled by the HTTP-bot orchestrator's core compile): the compiler today
+derives `defaultAgentId` as the earliest non-gated member, so the bot row
+gains a generic **persisted preferred default** it prefers when set and
+still routable; and it has no source for member-name rules, so the provider
+contributes them through the `projectMemberRoutes` contract extension. The
+earlier revision's `RcLinearAssign` / `RcLinearRemove` frames and the
+relay-local Linear rule table are gone — replay-on-register, placement
+re-broadcast, and lifecycle edges are the shared machinery.
 
 ### 6.3 Relay → daemon frames: `im` + `platform_action`
 
@@ -659,8 +668,10 @@ between):
 **Per agent — enable it on the workspace.** Adding an agent is one more
 member Integration on the workspace bot (the generic existing-bot path — no
 reuse fence exists or is needed under this model); the workspace card also
-moves the default among members. Every enabled agent's name compiles into a
-keyword route (§6.1), which is what makes `@<agent-name>` addressing work.
+moves the default among members (persisted, §9.2 — the compiler's
+earliest-member fallback alone cannot honor a choice). Every enabled agent's
+name compiles into a member route (`projectMemberRoutes`, §9.2), which is
+what makes `@<agent-name>` addressing work.
 
 If the tail refuses after step 1 (identity taken, workspace claimed), the
 orphaned token row is inert: no bot references it, and the next connect
@@ -804,10 +815,19 @@ tile.
   only new frames.** `Platform` is already an open string with tolerant
   readers (`platform-tolerance.test.ts`); `rd/msg` and `rc/bot-assign` carry
   Linear without change.
-- `platform-manifest.ts` — no entry needed: `DEFAULT_MANIFEST`'s fail-closed
-  arms are exactly Linear's truth (observed membership, no bot-sender
-  routing, conversation-granularity leave). Per the manifest's own rule, a
-  row lands only with a justified pre-dispatch field.
+- `platform-manifest.ts` — Linear becomes a manifest row, and it is
+  **earned**: multi-agent sharing is gated today by a core interim predicate
+  (`control-plane/src/platforms/sharing.ts#supportsMultiAgentBots`,
+  Slack-only — without a change here, `validateShareableInstall` refuses a
+  second Linear member before `addBotMembership` runs), and that module's
+  own doc names the §5 `multiAgentShareable` manifest field as its
+  replacement once a second platform needs it. Linear is that second
+  platform, so the field lands with the rows it needs (`slack: true`,
+  `linear: true`; `DEFAULT_MANIFEST` stays `false`) and retires the
+  predicate at its two call sites — an install-time, pre-dispatch read, per
+  the manifest's own rule. Every other axis keeps the fail-closed defaults
+  (observed membership, no bot-sender routing, conversation-granularity
+  leave).
 - The opaque integration-config payload shape (§7.2) is documented beside its
   peers in `frames/integration.ts`.
 - `frames/cron.ts` — **not** extended in v1 (no cron target).
@@ -845,12 +865,21 @@ tile.
   - `backgroundLoops` — the orphan-token sweeper (§7.1): org-scoped
     selection, local delete always, upstream revoke only for globally
     unowned identities, behind a grace window.
-  - **One contract extension** this design needs core to grow, consulted
-    only for platforms that declare it:
+  - **Two contract extensions** this design needs core to grow, each
+    consulted only for platforms that declare it:
     `sideEffects.onBotDelete?(bot, secrets)` for the disconnect revoke
-    (§7.4), best-effort like `postCreate`. (The earlier revision's
+    (§7.4), best-effort like `postCreate`; and
+    `projectMemberRoutes?(bot, members)` — the member-name keyword rules the
+    HTTP-bot orchestrator's compile folds into the assign's `routes` (§6.2),
+    which is what makes `@<agent-name>` addressing routable without a
+    Linear-named branch in the compiler. (The earlier revision's
     `validateBotReuse` reuse fence died with the per-agent-app model —
     adding a member agent is an ordinary, unfenced operation now.)
+  - **One generic core change**: a persisted bot-level **preferred default
+    agent** (nullable), preferred by the orchestrator's compile over its
+    earliest-non-gated fallback and settable from the workspace card —
+    platform-free (Slack shared bots gain the same knob), and the only way
+    "move the default" can actually move bare delegations (§6.2).
 - Prisma: new `linear_token` and `linear_install_state` tables only — Bot
   identity rides the existing D6 columns, and `platform` columns are already
   text.
@@ -1051,9 +1080,11 @@ tile.
   (a tail refusal after step 1 leaves an inert row the next connect
   overwrites, and the sweeper's cross-org split never revokes a live
   winner); D6 external-identity and workspace-claim 409s; the workspace bot
-  is created `shareable: true` and a second member Integration is admitted;
-  member add/remove recompiles keyword routes without touching the token;
-  removing the default
+  is created `shareable: true` and a second member Integration is admitted
+  (the manifest's `multiAgentShareable` row, §9.1); member add/remove
+  recompiles member routes without touching the token; the compile prefers
+  the persisted default over the earliest member and `projectMemberRoutes`
+  output reaches the assign's `routes`; removing the default
   agent is blocked until a new default is named; reconnect replaces a dead
   token in place; broker scope denial for a foreign daemon; workspace
   disconnect (bot delete) revoke convergence.

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -125,13 +125,16 @@ transport and Feishu callbacks) and whose _egress_ is daemon-direct GraphQL
 (like every other platform's outbound path). The Control Plane stays off the
 message hot path.
 
-Adding it is the checklist-shaped task the plugin architecture exists for:
-implement the four host contracts in each host's `platforms/linear/`
-directory, add one registry line per host, and touch **no core switch, no
-protocol enum, and no Prisma platform migration** — `Platform` is an open
-string with tolerant readers (S1a), bot identity rides the generic D6 columns,
-and `IntegrationSpec` carries an opaque per-platform config (§6.3 of the
-parent design).
+Adding it is close to the checklist-shaped task the plugin architecture
+exists for: implement the four host contracts in each host's
+`platforms/linear/` directory, and touch **no core switch, no protocol enum,
+and no Prisma platform migration** — `Platform` is an open string with
+tolerant readers (S1a), bot identity rides the generic D6 columns, and
+`IntegrationSpec` carries an opaque per-platform config (§6.3 of the parent
+design). "Close to", honestly: relay, CP, and web are registry-only (one line
+each), but the daemon's connection lifecycle is not yet registry-driven end
+to end, so Linear also lands a small **enumerated** set of composition lines
+in `daemon.ts` — additive registrations, no branch grows — listed in §9.4.
 
 ```text
 Linear workspace
@@ -233,9 +236,10 @@ The mapping onto existing tables:
 
 - **`Bot`** (platform `linear`) = **one workspace install** of the OAuth app.
   D6 identity columns: `externalAppId` = the OAuth client id,
-  `externalTenantId` = the Linear `organizationId` (the workspace), with the
-  pre-connect sentinel rule below. `transport` is always `http`;
-  `shareable` is dropped by the provider (one app = one agent).
+  `externalTenantId` = the Linear `organizationId` (the workspace) — always
+  complete, because the rows are created at the OAuth callback (§7.1), never
+  before the workspace is known. `transport` is always `http`; `shareable` is
+  dropped by the provider (one app = one agent).
 - **`Integration`** = the bot's agent binding (1:1 for Linear).
 - Installing the same app into a **second workspace** is a second Bot row
   created from the same pasted app credentials (v1: run the wizard again;
@@ -265,10 +269,15 @@ Postgres (precedent: Slack config-token rotate-and-retry). The daemon never
 holds the client secret or refresh token. Instead:
 
 - The provider stores `{accessToken, refreshToken, expiresAt}` per
-  integration in its own `linear_token` table, encrypted through the existing
-  `SecretCipher` seam. (The CP provider contract's projectors are async for
+  **workspace install — 1:1 with the Bot row, not the Integration** — in its
+  own `linear_token` table, encrypted through the existing `SecretCipher`
+  seam. The token is the workspace's authorization of the app, so it belongs
+  to the install identity and survives the agent binding: deleting an
+  integration frees the bot **with** its token, which is what makes generic
+  bot reuse work (§7.4). (The CP provider contract's projectors are async for
   exactly this case — the provider loads from its own secret store inside
-  `projectIntegrationConfig`; core awaits uniformly.)
+  `projectIntegrationConfig`, resolving the integration's bot; core awaits
+  uniformly.)
 - `projectIntegrationConfig` embeds the **current access token + expiry** in
   the opaque `IntegrationSpec.config`, so `agent.json` always carries a ≤24 h
   token — the daemon can restart and keep posting activities while the CP is
@@ -283,7 +292,8 @@ Rejected alternative — daemon-side refresh: requires shipping the client
 secret to the edge, makes the daemon the writer of a rotating credential held
 only on its disk, and loses the token permanently if `agent.json` is wiped
 mid-rotation. The hot path does not need it: egress works from the cached
-token; only _renewal_ touches the CP, at most ~once a day per integration.
+token; only _renewal_ touches the CP, at most ~once a day per workspace
+install.
 
 ### 4.5 Session mapping and dedup keys
 
@@ -540,15 +550,20 @@ core, per the Slack precedent); enable webhooks with **Agent session events**
 checked; and paste the webhook URL `https://<relay>/linear/events` (from
 `relayCapability.publicUrl`).
 
-Submitting runs the common create tail: the provider's
-`credentialBodySchema` block, `validateConfig` (shape checks only — unlike
-Slack `auth.test` there is **no** pre-persistence probe; the client secret is
-unverifiable without an OAuth exchange, so the live check is the callback
-itself), and `buildNewBotInstall`, which packs the secret row and declares
-the D6 `externalIdentity` `(clientId, '-')` — the pre-capture sentinel, so at
-most one not-yet-connected install per app exists at a time (the 409 copy
-says "finish connecting the existing install"). Core's relay-availability
-409 applies. The bot + integration are created `pending`.
+Submitting starts the provider's **install funnel** — it deliberately does
+**not** run the common create tail. `IntegrationStatus` has no pending value,
+and `installNewBot` synchronizes an `http` bot immediately, which would drive
+`projectIntegrationConfig` before any `linear_token` exists — either failing
+after rows were written or publishing an assignment the daemon cannot use. So
+**no Bot or Integration row exists until the workspace is connected**: the
+org-scoped funnel-start route validates the pasted values (shape only —
+unlike Slack `auth.test` there is no pre-persistence probe; the client secret
+is unverifiable without an OAuth exchange, so the live check is the callback
+itself), stores them with a one-shot `state` nonce in `linear_install_state`
+(SecretCipher values, TTL-reaped via `pendingInstalls`), and returns the
+authorize + webhook URLs. Core's relay-availability 409 applies here. The
+funnel-creates-the-rows shape is the Feishu one-click and Slack platform-app
+precedent, not an invention.
 
 **Step 2 — connect the workspace.** The console offers **Connect to
 Linear**: an authorize URL
@@ -558,27 +573,29 @@ https://linear.app/oauth/authorize?client_id=…&redirect_uri=…&response_type=
   &scope=read,write,app:assignable,app:mentionable&actor=app&state=<nonce>
 ```
 
-with a one-shot `state` nonce persisted in the provider's
-`linear_install_state` funnel table (declared via `pendingInstalls`, swept by
-the shared TTL reaper). The public callback exchanges the code at
+The public callback exchanges the code at
 `https://api.linear.app/oauth/token`, queries
-`viewer { id organization { id name } }`, then in one transaction: persists
-the token row, stamps the bot's workspace identity
-(`externalTenantId` = `organizationId`, display `workspaceId`/`workspaceName`,
-`botUserId` = the app user id), runs the cross-org `workspaceClaim` fence,
-flips the integration `active`, and lets core broadcast the standard
-`rc/bot-assign` + `integration/upsert`.
+`viewer { id organization { id name } }`, and only now — with the workspace
+identity **and** a token in hand — runs the shared create tail in one
+transaction: Bot (D6 identity `externalAppId` = client id,
+`externalTenantId` = `organizationId`; display `workspaceId`/`workspaceName`;
+`botUserId` = the app user id) + the `BotSecret` row + the `linear_token` row
+
+- the Integration, `active` from birth. The D6 composite pre-check and the
+  cross-org `workspaceClaim` fence run here, and the tail's normal `syncBot`
+  hand-off broadcasts `rc/bot-assign` + `integration/upsert` — the projector
+  finds its token because the row order guarantees it.
 
 ### 7.2 Storage
 
-| Value                          | Where                                                                                    | Visibility                                                     |
-| ------------------------------ | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| Client ID                      | `Bot.externalAppId` (D6 column)                                                          | console, authorize URL, relay ingress bag                      |
-| Workspace (organization) id    | `Bot.externalTenantId` + display `workspaceId`/`workspaceName`                           | console, relay ingress bag                                     |
-| Client Secret                  | `BotSecret.botToken` slot (`secretShape.slots` labels it)                                | CP only (code exchange + refresh)                              |
-| Webhook signing secret         | `BotSecret.signingSecret` slot; `httpAssignRequires: ['signingSecret']`                  | relay only, via the `rc/bot-assign` secrets bag                |
-| Access + refresh token, expiry | provider-owned `linear_token` table, 1:1 with Integration, values through `SecretCipher` | access token → daemon (spec + broker); refresh token → CP only |
-| OAuth `state` nonce            | provider-owned `linear_install_state` funnel table (TTL-reaped)                          | CP only                                                        |
+| Value                                           | Where                                                                                                                  | Visibility                                                     |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Client ID                                       | `Bot.externalAppId` (D6 column)                                                                                        | console, authorize URL, relay ingress bag                      |
+| Workspace (organization) id                     | `Bot.externalTenantId` + display `workspaceId`/`workspaceName`                                                         | console, relay ingress bag                                     |
+| Client Secret                                   | `BotSecret.botToken` slot (`secretShape.slots` labels it)                                                              | CP only (code exchange + refresh)                              |
+| Webhook signing secret                          | `BotSecret.signingSecret` slot; `httpAssignRequires: ['signingSecret']`                                                | relay only, via the `rc/bot-assign` secrets bag                |
+| Access + refresh token, expiry                  | provider-owned `linear_token` table, **1:1 with the Bot** (the workspace install, §4.4), values through `SecretCipher` | access token → daemon (spec + broker); refresh token → CP only |
+| Pasted credentials + `state` nonce, pre-connect | provider-owned `linear_install_state` funnel table (SecretCipher values, TTL-reaped)                                   | CP only                                                        |
 
 The opaque `IntegrationSpec.config` payload the provider projects (validated
 on the daemon by the linear module's schema in `CONFIG_SCHEMAS`):
@@ -613,14 +630,32 @@ provider's token service owns the work: single-flight refresh when the stored
 token is near expiry, durable persist of the rotated pair **before**
 replying, then a spec re-push so `agent.json` converges.
 
-### 7.4 Uninstall / revocation
+### 7.4 Unbind, reuse, uninstall, revocation
 
-`DELETE /integrations/:id` revokes the token at Linear
-(`POST /oauth/revoke`, best-effort), deletes the `linear_token` row, and
-rides the standard uninstall broadcast (bot unassign + `integration/remove`),
-freeing the bot for reuse. The `OAuthApp revoked` doorbell (§6.1) converges
-the same state when revocation originates on the Linear side — re-verified at
-the CP behind the `credentialRevision` fence, never trusted from the payload.
+Three distinct lifecycle edges, because the token rides the Bot (§4.4):
+
+- **Unbind the agent** — `DELETE /integrations/:id` rides the standard
+  uninstall broadcast (bot unassign + `integration/remove`) and **keeps** the
+  bot's `linear_token`: the workspace's authorization of the app is still
+  live at Linear, and the freed bot _is_ that still-authorized install.
+  Generic web reuse therefore composes as-is: `freeBotFilter` offers the
+  freed bot, `buildReuseInput` binds a new agent, and the projector/broker
+  find the token by bot id — no OAuth re-run, no modal detour.
+- **Uninstall** — deleting the **Bot** is the real teardown: best-effort
+  `POST /oauth/revoke` at Linear plus deletion of the `linear_token` row.
+  The shipped `CpPlatformProvider` has no bot-delete lifecycle member, so
+  this design adds the one contract extension it needs:
+  `sideEffects.onBotDelete?(bot, secrets)` — best-effort by contract like
+  `postCreate`, called from core's bot-delete path for any platform that
+  declares it.
+- **Dead token** (refresh rejected, app secret rotated, workspace revoked
+  upstream) — the integration flips `error` with a **Reconnect** CTA: an
+  org-scoped provider route restarts the OAuth funnel against the existing
+  bot, and the callback's update arm (matched by the D6 identity) replaces
+  the `linear_token` row in place. The `OAuthApp revoked` doorbell (§6.1)
+  converges the same state when revocation originates on the Linear side —
+  re-verified at the CP behind the `credentialRevision` fence, never trusted
+  from the payload.
 
 ## 8. Prompt assembly and trust boundary
 
@@ -652,12 +687,14 @@ by <actor>` + issue URL, with `sanitizeTitle` flattening.
 
 ## 9. Change inventory by host
 
-Adding Linear is implementing the four contracts plus one registry line per
-host — no core `switch`, no closed union, no platform enum migration. The
-capability chain that gates availability end to end: the daemon's
-`CONFIG_SCHEMAS` registry line → `capabilities.platforms` in the register
-handshake → the CP's daemon-platform-capability gate (plus the relay 409 for
-`http`) → the console tile.
+Adding Linear is implementing the four contracts, plus one registry line in
+relay, CP, and web, plus an **enumerated** composition set in the daemon
+(§9.4, whose connection lifecycle is not yet registry-driven end to end) — no
+core `switch`, no closed union, no platform enum migration. The capability
+chain that gates availability end to end: the daemon's `CONFIG_SCHEMAS`
+registry line → `capabilities.platforms` in the register handshake → the CP's
+daemon-platform-capability gate (plus the relay 409 for `http`) → the console
+tile.
 
 ### 9.1 `packages/protocol`
 
@@ -677,19 +714,27 @@ handshake → the CP's daemon-platform-capability gate (plus the relay 409 for
 
 - `src/platforms/linear/` implementing `CpPlatformProvider` + one
   `registry.ts` line:
-  - `credentialBodySchema` `{ clientId, clientSecret, signingSecret }`;
-    `validateConfig` shape-only (§7.1); `buildNewBotInstall` packing the
-    secret slots + the D6 `externalIdentity` pre-capture fence.
-  - `secretShape` (§7.2); `projectBotIdentity` (clientId / organizationId /
-    sentinel).
-  - `installRoutes('org')` — authorize-URL mint + connect status;
+  - `credentialBodySchema` `{ clientId, clientSecret, signingSecret }`,
+    consumed by the funnel-start route; `validateConfig` **refuses the
+    generic `POST /integrations` credential path** with a pointer at the
+    funnel — install is funnel-only, because an integration must never exist
+    without its workspace token (§7.1).
+  - `buildNewBotInstall` — invoked from the OAuth callback's finalize (the
+    Feishu one-click precedent), packing the secret slots and declaring the
+    D6 `externalIdentity` `(clientId, organizationId)` + the
+    `workspaceClaim`.
+  - `secretShape` (§7.2); `projectBotIdentity` (clientId / organizationId).
+  - `installRoutes('org')` — funnel start, connect status, reconnect (§7.4);
     `installRoutes('public-callback')` — the OAuth callback (§7.1). Repo
     OpenAPI conventions on every route.
   - `pendingInstalls` — `linear_install_state` + TTL reaper.
-  - `projectIntegrationConfig` (async, loads `linear_token`) and
-    `projectBotAssign` (§6.2).
+  - `projectIntegrationConfig` (async, loads `linear_token` by the
+    integration's bot) and `projectBotAssign` (§6.2).
   - `LinearTokenService` — exchange, single-flight rotate-and-retry refresh,
     revoke; surfaced to the WS `linearcred` handler (§7.3).
+  - **One contract extension** this design needs core to grow:
+    `sideEffects.onBotDelete?(bot, secrets)` for the uninstall revoke (§7.4),
+    best-effort like `postCreate`.
 - Prisma: new `linear_token` and `linear_install_state` tables only — Bot
   identity rides the existing D6 columns, and `platform` columns are already
   text.
@@ -725,8 +770,22 @@ handshake → the CP's daemon-platform-capability gate (plus the relay 409 for
     `platform_action` payload → `interruptTurn` + settling response.
   - The ≤10 s ack at `rd/msg` admission, after inbox dedup (§10.1).
 - `platforms/integration-config.ts` — the `linear` `CONFIG_SCHEMAS` line
-  (+ the schema in `agents/agent-schema.ts`). This single line is what flips
-  `capabilities.platforms`.
+  (+ the schema in `agents/agent-schema.ts`). This line flips
+  `capabilities.platforms` — the **advertisement**, not the wiring.
+- **Enumerated `daemon.ts` composition lines** — the daemon's connection
+  lifecycle is not yet registry-driven end to end (production connections
+  still live in per-platform typed maps behind `bindSlack`/`bindTelegram`/…
+  lambdas with explicit reconcile call sites, and the turn/action registries
+  are assembled inline), so Linear lands the same additive set its four
+  peers have, stated here so nobody mistakes `CONFIG_SCHEMAS` for the whole
+  seam: a `linear` connection map + bind lambda, `reconcileLinearConnections`
+  wiring at the shared reconcile call sites, one
+  `TurnOutputRegistry.register(linearSurface)` line, and one
+  `platformActionDecoders` entry for the stop decoder (without it the payload
+  answers `unsupported_action`). All registrations, no branches; folding
+  these maps into the §7.5 key-driven `ConnectionPool` registry is the parent
+  design's remaining daemon stage and deliberately **not** a prerequisite
+  here.
 - Session metadata: `channelName`/`threadUrl` from issue identifier/URL.
 - Tests: normalize (created/prompted/stop, mention-comment `text`
   extraction, no-issue created event → session-UUID channel + bounded
@@ -744,10 +803,11 @@ handshake → the CP's daemon-platform-capability gate (plus the relay 409 for
   - `Mark` — Linear brand SVG (60 % box, `fillPct` convention).
   - `wizard` — the two-step facet (§7.1); tile availability = daemon
     capability ∧ `relayCapability.available`; `freeBotFilter` /
-    `buildReuseInput` for freed bots.
-  - `apiBindings` — authorize-URL + connect-status calls.
-  - `settingsFragments` — workspace name, connect status, re-connect action
-    when `pending`/token-revoked.
+    `buildReuseInput` offer a freed bot as-is — its workspace token rides the
+    Bot row (§7.4), so reuse needs no OAuth detour.
+  - `apiBindings` — funnel-start, connect-status, and reconnect calls.
+  - `settingsFragments` — workspace name, connect status, reconnect action
+    when the token is dead (§7.4).
   - `channelList` — `roomNoun: 'issue'`, no leave affordance.
   - `messageIdentity` — agent-activity id, else `null` (never dedupes).
   - `transcriptOrdering` — default `'seq'`.
@@ -813,18 +873,20 @@ handshake → the CP's daemon-platform-capability gate (plus the relay 409 for
   header; delimiter neutralization.
 - Agent environment contains no Linear credentials; all writes go through
   the daemon-owned single writer (§4.6).
-- OAuth `state` one-shot nonces; callback exchanges bind to the pending
-  integration id; cross-org `workspaceClaim` fence at connect.
+- OAuth `state` one-shot nonces; callback exchanges bind to the funnel row
+  that minted them; cross-org `workspaceClaim` fence at connect; no
+  Bot/Integration row exists before the token does (§7.1).
 - Rate limits both directions (per-bot ingress bucket; egress send queue).
 
 ## 13. Phasing
 
-- **P1 — the core loop.** `linearcred` frames; CP provider (create,
-  OAuth funnel + callback, token service + broker, projectors) + registry
-  line; relay ingress plugin + registry line; daemon module (connection,
-  ack, converger `thought`/`action`/`response`/`error`, follow-ups, stop,
-  config schema) + registry line; web module (wizard, mark, settings,
-  session display) + registry line. Exit criteria: delegate an issue →
+- **P1 — the core loop.** `linearcred` frames; CP provider (install funnel +
+  callback, token service + broker, projectors, the `onBotDelete` contract
+  extension) + registry line; relay ingress plugin + registry line; daemon
+  module (connection, ack, converger `thought`/`action`/`response`/`error`,
+  follow-ups, stop, config schema) + the §9.4 composition lines; web module
+  (wizard, mark, settings, session display) + registry line. Exit criteria:
+  delegate an issue →
   acknowledged ≤10 s → streamed activities → response; reply and stop work;
   sessions render in the console.
 - **P2 — workflow polish.** Plan sync; `externalUrls` (PR + console links);
@@ -856,10 +918,12 @@ handshake → the CP's daemon-platform-capability gate (plus the relay 409 for
 - **CP unit:** provider schema guards; token service rotate-and-retry with a
   failing-then-succeeding fake token endpoint; single-flight refresh;
   projector output shapes.
-- **CP integration:** create → pending → callback → active lifecycle against
-  a stubbed Linear OAuth server; D6 external-identity and workspace-claim
-  409s; broker scope denial for a foreign daemon; uninstall/revocation
-  convergence.
+- **CP integration:** funnel start → callback → active lifecycle against a
+  stubbed Linear OAuth server, asserting **no Bot/Integration row exists
+  before the callback**; D6 external-identity and workspace-claim 409s;
+  unbind keeps the bot's token and generic reuse re-projects it; reconnect
+  replaces a dead token in place; broker scope denial for a foreign daemon;
+  bot-delete revoke convergence.
 - **Live checklist:** real OAuth app in a scratch Linear workspace —
   delegate, mention, follow-up, stop, redelivery replay (Linear's webhook
   console), token refresh across the 24 h boundary, workspace revoke.

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -249,7 +249,14 @@ The mapping onto existing tables — the Slack shared-bot shape, not a new one:
   columns: `externalAppId` = the deployment app's client id (constant across
   rows), `externalTenantId` = the Linear `organizationId` — always complete,
   because the rows are created at the OAuth callback (§7.1), never before
-  the workspace is known. `transport` is always `http`.
+  the workspace is known. `transport` is always `http`, and the provider
+  stamps **`shareable: true` structurally** on every workspace bot —
+  `Bot.shareable` is the switch the shipped install validation gates
+  multi-integration membership on
+  ([shared-bot-relay.md §1](shared-bot-relay.md): a non-shareable bot caps
+  at one integration), and a connected workspace is definitionally
+  multi-agent, so this is not a caller flag the provider honors but a
+  constant it sets.
 - **`Integration`** = one **enabled agent** on that workspace
   (`Integration.botId` is deliberately non-unique — the shared-bot
   precedent). The workspace records a **default agent** among its members,
@@ -636,13 +643,15 @@ between):
 2. **Run the shared create tail unchanged**: `buildNewBotInstall` packs the
    Bot columns (D6 identity `externalAppId` = the deployment app's client
    id, `externalTenantId` = `organizationId`; display
-   `workspaceId`/`workspaceName`; `botUserId` = the app user id) and stamps
-   the deployment app credentials into the workspace bot's `BotSecret` row
-   (which is what the shipped assign machinery projects and
-   revision-fences); the D6 composite pre-check and the cross-org
-   `workspaceClaim` fence run; the Integration for the chosen default agent
-   (`active` from birth) is written; and the tail's normal `syncBot`
-   hand-off broadcasts `rc/bot-assign` + `integration/upsert`.
+   `workspaceId`/`workspaceName`; `botUserId` = the app user id;
+   **`shareable: true`** — structural, §4.3, so member additions pass the
+   shipped multi-integration gate) and stamps the deployment app credentials
+   into the workspace bot's `BotSecret` row (which is what the shipped
+   assign machinery projects and revision-fences); the D6 composite
+   pre-check and the cross-org `workspaceClaim` fence run; the Integration
+   for the chosen default agent (`active` from birth) is written; and the
+   tail's normal `syncBot` hand-off broadcasts `rc/bot-assign` +
+   `integration/upsert`.
    `projectIntegrationConfig` resolves the token by the bot's D6 identity —
    already durable from step 1, so the ordering is guaranteed by
    construction rather than by a transaction the tail does not offer.
@@ -817,8 +826,9 @@ tile.
     workspace (§7.1).
   - `buildNewBotInstall` — invoked from the OAuth callback's finalize (the
     Feishu one-click precedent), stamping the deployment credentials into
-    the workspace bot's secret row and declaring the D6 `externalIdentity`
-    `(clientId, organizationId)` + the `workspaceClaim`.
+    the workspace bot's secret row, setting `shareable: true` structurally
+    (§4.3 — the multi-integration gate), and declaring the D6
+    `externalIdentity` `(clientId, organizationId)` + the `workspaceClaim`.
   - `secretShape` (§7.2); `projectBotIdentity` (clientId / organizationId +
     workspace display metadata in `platformConfig`).
   - `installRoutes('org')` — connect-workspace funnel start (records the
@@ -1040,8 +1050,10 @@ tile.
   before the callback** and that the token upsert precedes the create tail
   (a tail refusal after step 1 leaves an inert row the next connect
   overwrites, and the sweeper's cross-org split never revokes a live
-  winner); D6 external-identity and workspace-claim 409s; member add/remove
-  recompiles keyword routes without touching the token; removing the default
+  winner); D6 external-identity and workspace-claim 409s; the workspace bot
+  is created `shareable: true` and a second member Integration is admitted;
+  member add/remove recompiles keyword routes without touching the token;
+  removing the default
   agent is blocked until a new default is named; reconnect replaces a dead
   token in place; broker scope denial for a foreign daemon; workspace
   disconnect (bot delete) revoke convergence.


### PR DESCRIPTION
## What

Revises [docs/designs/linear-integration.md](../blob/claude/update-linear-design-30d36c/docs/designs/linear-integration.md) (still **Proposed**, nothing built yet) in two passes, and updates the parent design's Linear references to match.

**Pass 1 — remap onto the shipped platform-module architecture.** The original plan predated the integration-plugin refactor and would have rebuilt machinery that now exists in generalized form: bespoke `RcLinearAssign`/`RdMsgLinear` frames, a relay-local rule table, a minted capability-URL webhook, and a ~40-site enum checklist. The revision targets the shipped seams instead: `RelayPlatformIngressPlugin` at `POST /linear/events`, `rc/bot-assign` opaque bags, `rd/msg` `im` + `platform_action`, the streaming Layer-2 `TurnOutputSurface`, a `CpPlatformProvider` with async projectors, and a `WebPlatformModule` — with `linearcred` broker frames as the only protocol addition and an honest enumerated list of the daemon composition lines that are not yet registry-driven.

**Pass 2 — one deployment-owned Linear app (maintainer decision).** The identity model flipped from one OAuth app per agent to **one app per deployment**, the GitHub-App model: Linear has no app-creation API, so per-agent apps priced every agent at a manual checklist, and the integrations in Linear's own agent directory are one app per product.

## The final shape

- The deployment operates one Linear OAuth app (Setup Server document / env slice — the same class as the deployment's GitHub App). Organizations connect workspaces via OAuth; a connected workspace is a shared `Bot` row (D6: constant client id + `organizationId`), enabled agents are member `Integration`s with a required default.
- **Trigger model, GitHub-events semantics:** an issue behaves like a channel — delegation reaches the default agent; `@<agent-name>` in the mention text addresses a member (compiled per-member keyword routes + `defaultAgentId`, the shared-bot ladder unchanged); one AgentSession binds to one agent at creation; a new mention starts a new session, so one issue can host several agents' threads. Identity renders in content: the ≤10 s ack opens with the acting agent's name, the response carries the attribution footer.
- Token custody: CP-owned refresh, brokered ≤24 h access tokens; `linear_token` keyed by the connection identity `(orgId, clientId, organizationId)` so the OAuth callback writes it before the unchanged shared create tail runs (no new persistence seam), with an orphan sweeper whose local delete and upstream revoke are conditioned on different scopes (the cross-org loser is sweepable without revoking the winner's live install).
- One provider contract extension: `sideEffects.onBotDelete` for workspace-disconnect revoke. The interim per-agent branding fence (`brandedAgentId`, `validateBotReuse`) dissolved with the model flip.

All five blocking findings and both non-blocking notes from the review rounds are addressed and their threads resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
