### PR TITLE
fix(console): fit the workspace source picker on one row

### DIFF
--- a/packages/web/src/components/console/WorkspaceFormFields.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.test.tsx
@@ -48,11 +48,14 @@ describe('WorkspaceFormFields', () => {
     // Both code hosts are always offered; a deployment that configures neither
     // says so in the pane the tile opens, never by dropping the tile.
     const buttons = Array.from(container?.querySelectorAll('button') ?? [])
-    expect(buttons.map((button) => button.textContent)).toEqual([
-      'From scratchFresh empty directory.',
-      'From GitHubClone a repo on a branch.',
-      'From GitLabClone a project on a branch.'
+    expect(buttons.map((button) => button.textContent)).toEqual(['From scratch', 'From GitHub', 'From GitLab'])
+    // The tiles are compact chips, so each one's one-line description is its tooltip.
+    expect(buttons.map((button) => button.getAttribute('title'))).toEqual([
+      'Fresh empty directory.',
+      'Clone a repo on a branch.',
+      'Clone a project on a branch.'
     ])
+    expect(buttons.map((button) => button.getAttribute('aria-pressed'))).toEqual(['true', 'false', 'false'])
 
     await act(async () => buttons[1]?.click())
     expect(onChange).toHaveBeenCalledWith('github')

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -18,85 +18,77 @@ export const REPOSITORY_ACCESS_BADGE: Record<RepoAccess, string> = {
   write: 'badge flex-none bg-(--status-paused-soft) text-(--amber-500)'
 }
 
+// GitHub and GitLab ship as full-bleed marks, so they fill an 18px box next to the 16px lucide glyph.
+const workspaceModeMark = (child: ReactNode) => (
+  <span className="flex h-[18px] w-[18px] flex-none items-center justify-center">{child}</span>
+)
+
+// One short choice, so each tile carries its label alone and hands the one-line description to its tooltip.
+const WORKSPACE_MODE_OPTIONS: {
+  value: WorkspaceMode
+  label: string
+  hint: string
+  mark: (selected: boolean) => ReactNode
+}[] = [
+  {
+    value: 'scratch',
+    label: 'From scratch',
+    hint: 'Fresh empty directory.',
+    mark: (selected) =>
+      workspaceModeMark(<Icon name="sparkles" size={16} color={selected ? 'var(--brand)' : 'var(--text-tertiary)'} />)
+  },
+  {
+    value: 'github',
+    label: 'From GitHub',
+    hint: 'Clone a repo on a branch.',
+    mark: () => workspaceModeMark(<GithubMark color="var(--text-primary)" fillPct={100} />)
+  },
+  {
+    value: 'gitlab',
+    label: 'From GitLab',
+    hint: 'Clone a project on a branch.',
+    mark: () => workspaceModeMark(<GitlabMark fillPct={100} />)
+  }
+]
+
 export function WorkspaceModeField({
   value,
   onChange,
   className,
-  // Add-agent renders this under a "Workspace" section heading, so it overrides
-  // the label to avoid saying "Workspace" twice.
+  // Add-agent renders this under a "Workspace" section heading, so it passes `null`
+  // to drop the label rather than say "Workspace" twice.
   label = 'Workspace'
 }: {
   value: WorkspaceMode
   onChange: (value: WorkspaceMode) => void
   className?: string
-  label?: string
+  label?: string | null
 }) {
   const fieldClassName = className ? `fld ${className}` : 'fld'
-  const radio = (selected: boolean) => (
-    <span
-      className={
-        selected
-          ? 'ml-auto flex h-4 w-4 flex-none items-center justify-center self-center rounded-full border-[1.5px] border-(--brand)'
-          : 'ml-auto flex h-4 w-4 flex-none items-center justify-center self-center rounded-full border-[1.5px] border-(--border-strong)'
-      }
-    >
-      {selected && <span className="h-2 w-2 rounded-full bg-(--brand)" />}
-    </span>
-  )
-  const tileIcon = (child: ReactNode) => (
-    <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-default) bg-(--surface-card)">
-      {child}
-    </span>
-  )
 
   return (
     <div className={fieldClassName}>
-      <span className="fldlbl">{label}</span>
-      <div className="grid grid-cols-1 gap-[10px] desktop:grid-cols-3">
-        <button
-          type="button"
-          className={value === 'scratch' ? 'ptile on items-start text-left' : 'ptile items-start text-left'}
-          onClick={() => onChange('scratch')}
-        >
-          {tileIcon(
-            <Icon name="sparkles" size={16} color={value === 'scratch' ? 'var(--brand)' : 'var(--text-tertiary)'} />
-          )}
-          <span className="min-w-0 flex-1">
-            <span className="block font-sans text-[13px] font-semibold leading-normal">From scratch</span>
-            <span className="mt-[2px] block truncate font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-              Fresh empty directory.
-            </span>
-          </span>
-          {radio(value === 'scratch')}
-        </button>
-        <button
-          type="button"
-          className={value === 'github' ? 'ptile on items-start text-left' : 'ptile items-start text-left'}
-          onClick={() => onChange('github')}
-        >
-          {tileIcon(<GithubMark color="var(--text-primary)" />)}
-          <span className="min-w-0 flex-1">
-            <span className="block font-sans text-[13px] font-semibold leading-normal">From GitHub</span>
-            <span className="mt-[2px] block truncate font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-              Clone a repo on a branch.
-            </span>
-          </span>
-          {radio(value === 'github')}
-        </button>
-        <button
-          type="button"
-          className={value === 'gitlab' ? 'ptile on items-start text-left' : 'ptile items-start text-left'}
-          onClick={() => onChange('gitlab')}
-        >
-          {tileIcon(<GitlabMark />)}
-          <span className="min-w-0 flex-1">
-            <span className="block font-sans text-[13px] font-semibold leading-normal">From GitLab</span>
-            <span className="mt-[2px] block truncate font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-              Clone a project on a branch.
-            </span>
-          </span>
-          {radio(value === 'gitlab')}
-        </button>
+      {label !== null && <span className="fldlbl">{label}</span>}
+      <div className="flex flex-wrap gap-[10px]">
+        {WORKSPACE_MODE_OPTIONS.map((option) => {
+          const selected = value === option.value
+          return (
+            <button
+              key={option.value}
+              type="button"
+              title={option.hint}
+              aria-pressed={selected}
+              className={selected ? 'ptile on flex-none px-[13px] py-[9px]' : 'ptile flex-none px-[13px] py-[9px]'}
+              onClick={() => onChange(option.value)}
+            >
+              {option.mark(selected)}
+              <span className="font-sans text-[13px] font-semibold leading-normal whitespace-nowrap">
+                {option.label}
+              </span>
+              {selected && <Icon name="check" size={14} className="flex-none" color="var(--brand)" />}
+            </button>
+          )
+        })}
       </div>
     </div>
   )

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -1235,12 +1235,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
           <section ref={sectionRef('workspace')} className="mt-5 border-t border-(--border-subtle) pt-5">
             <div className="font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">Workspace</div>
             <div className="mt-[13px] grid grid-cols-1 gap-[14px] desktop:grid-cols-2">
-              <WorkspaceModeField
-                className="desktop:col-span-2"
-                label="Where the agent works"
-                value={wsMode}
-                onChange={setWsMode}
-              />
+              <WorkspaceModeField className="desktop:col-span-2" label={null} value={wsMode} onChange={setWsMode} />
 
               {wsMode === 'github' && ghEnabled === true && ghInstalls.length === 0 && (
                 <GithubInstallPrompt onInstall={installGithubApp} />


### PR DESCRIPTION
## What

Rebuild the workspace source picker (`WorkspaceModeField`) as a compact chip row.

Before, each of the three sources was a tile carrying a bordered icon box, a title, a
one-line description and a radio dot, laid out as `desktop:grid-cols-3`. The Add-agent
modal's form column is far narrower than that needs: every description truncated to
`Fresh empt…`, and each label wrapped mid-phrase (`From` / `scratch`). The picker read as
broken rather than dense.

Now each source is a chip: an 18px mark, the label, and a brand check on the selected one.
They sit in a wrapping flex row instead of a three-column grid.

## Why it fits now

- All three chips fit **one line** inside the modal's form column.
- On mobile (≤768px) they fold to two rows instead of stacking three full-width cards —
  meaningfully less vertical space in a bottom sheet.
- Each option's one-line description moves to the chip's `title`, so it comes back through
  the console's own Tooltip. That is where the neighbouring permission-mode pills already
  keep theirs (`title={o.description}` in `AddAgentModal`).

## Also in here

- The three near-identical JSX blocks collapse into one `WORKSPACE_MODE_OPTIONS` table.
- `label` now accepts `null`. Add-agent passes it, because that field sat directly under a
  `Workspace` section heading and its `Where the agent works` label only said the same
  thing a second time. Edit-workspace has no heading of its own and keeps the default
  `Workspace` label.
- Buttons gain `aria-pressed`; the removed radio dot was the only prior state signal and it
  was purely visual.

## Notes for review

- Mark sizes are unchanged: the GitHub/GitLab marks rendered at 18px inside the old 30px
  box (`fillPct` 60), and render at 18px again in an 18px box at `fillPct={100}`. The
  sparkles glyph stays at 16px.
- The selected chip is wider than an unselected one (it grows by the check), so picking a
  source nudges the chips after it. That is the intended behaviour of the target design.
- No new globals.css classes — the chips compose the existing `.ptile` / `.ptile.on` with
  utilities, per `packages/web/STYLE.md` rule 9.

## Verification

- Browser-checked against a local console: Add-agent → Workspace with each source selected
  (the GitHub repo/branch panel still expands normally), at desktop and at 375px, in light
  and dark themes.
- `pnpm --filter @agentconnect.md/web test` — 186 files / 2126 tests pass. The
  `WorkspaceFormFields` case swapped its old tile-text assertion for label + tooltip +
  `aria-pressed` assertions.
- `typecheck`, eslint and prettier clean.
