### PR TITLE
fix(console): read an agent's model catalog through its placement

### DIFF
--- a/packages/web/src/components/console/AgentCallVisibility.tsx
+++ b/packages/web/src/components/console/AgentCallVisibility.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { Agent, AgentCallPolicy, DaemonRow, MemberSetRow } from '@/lib/data'
-import { agentDaemonLabel, agentLabel, agentModelDisplay } from '@/lib/data'
+import { agentCapabilitySource, agentDaemonLabel, agentLabel, agentModelDisplay } from '@/lib/data'
 import { AgentIconView } from '@/components/marks'
 import { Icon } from '@/components/ui'
 
@@ -347,11 +347,7 @@ export function AgentCallVisibility({
                         {agentLabel(peer)}
                       </span>
                       <span className="truncate font-mono text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                        {agentModelDisplay(
-                          daemons.find((d) => d.daemonId === peer.daemon),
-                          peer.runtime,
-                          peer.model
-                        )}
+                        {agentModelDisplay(agentCapabilitySource(peer, daemons, groups), peer.runtime, peer.model)}
                       </span>
                     </span>
                     <span className="max-w-[90px] flex-none truncate font-mono text-[11.5px] font-normal leading-normal text-(--text-tertiary)">

--- a/packages/web/src/components/console/views/AgentDetailView.placement.test.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.placement.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment happy-dom
+/**
+ * The Configuration rows read the runtime catalog through the PLACEMENT, not through a member id.
+ * A set placement carries the pool sentinel in `daemon`, which matches no daemon row — resolving
+ * it as a machine found nothing and printed an em-dash model for every Cloud and group agent,
+ * even one with a model explicitly saved.
+ */
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { SWRConfig } from 'swr'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Agent, DaemonRow, MemberSetRow } from '@/lib/data'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const mocks = vi.hoisted(() => ({
+  agent: {} as unknown,
+  daemons: [] as unknown[],
+  memberSets: [] as unknown[]
+}))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'agent-1' }),
+  useSearchParams: () => new URLSearchParams('tab=config'),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() })
+}))
+vi.mock('next/link', () => ({ default: ({ children }: { children?: ReactNode }) => <span>{children}</span> }))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, myRole: 'owner', orgPath: (path: string) => path })
+}))
+vi.mock('@/components/console/PlaygroundProvider', () => ({ usePlayground: () => ({ openPlayground: vi.fn() }) }))
+vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: vi.fn() }) }))
+vi.mock('@/lib/use-session-list', () => ({ useSessionList: () => ({ sessions: [], total: 0, isLoading: false }) }))
+vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({ runtimes: [] }), acpRuntime: () => null }))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    agents: [mocks.agent],
+    getAgent: () => mocks.agent,
+    getSessions: () => [],
+    daemons: mocks.daemons,
+    daemonsLoading: false,
+    integrations: [],
+    agentsLoading: false,
+    updateAgent: vi.fn(async () => undefined),
+    refresh: vi.fn(),
+    memberSets: mocks.memberSets,
+    orgSetIds: new Set((mocks.memberSets as MemberSetRow[]).map((set) => set.setId))
+  })
+}))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchAgentHooks: vi.fn(async () => []),
+  fetchAgentRepos: vi.fn(async () => []),
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
+  fetchGitlabConnections: vi.fn(async () => ({ enabled: false, connections: [] }))
+}))
+
+/** One daemon reporting a claude catalog. `pool` and `memberSetId` are what a set resolves through. */
+function daemon(over: Partial<DaemonRow>): DaemonRow {
+  return {
+    daemonId: 'd1',
+    pool: false,
+    memberSetId: null,
+    name: 'edge-1',
+    status: 'online',
+    caps: { platforms: [], runtimes: ['claude'], acp: true, features: [] },
+    runtimeModels: [
+      {
+        runtime: 'claude',
+        version: '2.0.0',
+        models: ['opus', 'sonnet'],
+        acpProtocolVersion: 1,
+        mcpCapabilities: null,
+        modelCatalog: {
+          defaultModel: 'sonnet',
+          models: [
+            { id: 'opus', name: 'Opus' },
+            { id: 'sonnet', name: 'Sonnet' }
+          ]
+        },
+        authRequired: false
+      }
+    ],
+    mcpServers: [],
+    ...over
+  } as unknown as DaemonRow
+}
+
+function agentOn(placement: Partial<Agent>): Agent {
+  return {
+    id: 'agent-1',
+    name: 'pilot',
+    model: 'opus',
+    runtime: 'claude',
+    desc: '',
+    outputMode: '—',
+    showFooter: true,
+    showStatusBar: false,
+    reasoning: '',
+    fastMode: false,
+    pause: false,
+    memoryProvider: 'none',
+    memoryAutoDistill: false,
+    status: 'online',
+    placementReady: true,
+    workspace: { mode: 'scratch', files: [] },
+    integrations: [],
+    visibility: 'org',
+    callableBy: 'all',
+    allowedCallerAgentIds: [],
+    canCall: 'all',
+    allowedTargetAgentIds: [],
+    env: [],
+    secretKeys: [],
+    organizationVariables: [],
+    organizationSecretKeys: [],
+    hookKinds: [],
+    sharedWith: [],
+    permissionMode: '',
+    createdBy: '',
+    createdAt: '',
+    lastModifiedBy: '',
+    lastModifiedAt: '',
+    region: '—',
+    repo: '—',
+    workdir: '—',
+    tokens: '—',
+    cost: '—',
+    ...placement
+  } as unknown as Agent
+}
+
+const AgentDetailView = (await import('./AgentDetailView')).default
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+async function render(): Promise<string> {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root!.render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <AgentDetailView />
+      </SWRConfig>
+    )
+  })
+  return host.textContent ?? ''
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  mocks.daemons = []
+  mocks.memberSets = []
+})
+
+describe('AgentDetailView, model row by placement', () => {
+  it('names the saved model for a POOL agent, which names no member', async () => {
+    mocks.agent = agentOn({ daemon: 'pool', placementKind: 'set', setId: null })
+    mocks.daemons = [daemon({ daemonId: 'pod-1', pool: true })]
+    const text = await render()
+    expect(text).toContain('opus')
+  })
+
+  it("falls back to the pool catalog's own default when no model is saved", async () => {
+    mocks.agent = agentOn({ daemon: 'pool', placementKind: 'set', setId: null, model: '' })
+    mocks.daemons = [daemon({ daemonId: 'pod-1', pool: true })]
+    const text = await render()
+    expect(text).toContain('sonnet')
+  })
+
+  it('reads a GROUP placement through one of its members', async () => {
+    mocks.agent = agentOn({ daemon: 'set:g1', placementKind: 'set', setId: 'g1' })
+    mocks.memberSets = [{ setId: 'g1', name: 'lab', memberDaemonIds: ['lab-1'], agentCount: 1 }]
+    mocks.daemons = [daemon({ daemonId: 'lab-1', memberSetId: 'g1' })]
+    const text = await render()
+    expect(text).toContain('opus')
+  })
+
+  it('still names a single machine’s model through that machine', async () => {
+    mocks.agent = agentOn({ daemon: 'd1', placementKind: 'daemon', setId: null })
+    mocks.daemons = [daemon({})]
+    const text = await render()
+    expect(text).toContain('opus')
+  })
+
+  it('keeps the em-dash when nothing reports a catalog at all', async () => {
+    mocks.agent = agentOn({ daemon: 'pool', placementKind: 'set', setId: null })
+    mocks.daemons = [daemon({ daemonId: 'pod-1', pool: true, runtimeModels: [] })]
+    const text = await render()
+    expect(text).not.toContain('opus')
+    expect(text).toContain('—')
+  })
+})

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 import Link from 'next/link'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import {
+  agentCapabilitySource,
   agentDaemonLabel,
   agentEffortDisplay,
   agentLabel,
@@ -588,12 +589,17 @@ export default function AgentDetailView() {
   // The owning daemon (if placed in the live fleet). Gates the agent's "online" —
   // an agent can't be online when its daemon is offline — and names the daemon.
   const owningDaemon = daemons.find((d) => d.daemonId === da.daemon)
+  // Whose reported catalog the config rows read — resolved through the PLACEMENT, so a pool or
+  // group agent reads its set's real catalog via one serving member instead of the static tables.
+  // `owningDaemon` cannot answer that: a set placement names no member, and the nothing it found
+  // is what showed every such agent an em-dash model even when one was explicitly saved.
+  const capabilitySource = agentCapabilitySource(da, daemons, memberSets)
   const runtimeMeta = acpRuntime(acpRegistry, da.runtime)
   // Config rows read the daemon-advertised runtime-model catalog so a placed
   // agent shows the SAME effective model / effort / permission the Edit modal
   // does (else a blank model reads "Default" here but its resolved default in the
   // editor). Falls back to the static labels when the daemon reports no catalog.
-  const modelText = agentModelDisplay(owningDaemon, da.runtime, da.model)
+  const modelText = agentModelDisplay(capabilitySource, da.runtime, da.model)
   const ds = status(effectiveAgentStatus(da, owningDaemon))
   const ws = da.workspace
   // Demo agents have no daemon to read git state from, so the workspace card's
@@ -1111,7 +1117,7 @@ export default function AgentDetailView() {
                         Permission mode
                       </span>
                       <span className="badge bg-(--surface-active) text-(--text-secondary) max-desktop:px-[10px] max-desktop:py-[3px] max-desktop:text-[12px]">
-                        {agentPermissionDisplay(owningDaemon, da.runtime, da.permissionMode, da.approvalsReviewer)}
+                        {agentPermissionDisplay(capabilitySource, da.runtime, da.permissionMode, da.approvalsReviewer)}
                       </span>
                     </div>
                     <div className="flex items-center justify-between gap-4 border-b border-(--border-subtle) px-4 py-3">
@@ -1119,7 +1125,7 @@ export default function AgentDetailView() {
                         {effortField(da.runtime).label}
                       </span>
                       <span className="badge bg-(--surface-active) text-(--text-secondary) max-desktop:px-[10px] max-desktop:py-[3px] max-desktop:text-[12px]">
-                        {agentEffortDisplay(owningDaemon, da.runtime, da.model, da.reasoning)}
+                        {agentEffortDisplay(capabilitySource, da.runtime, da.model, da.reasoning)}
                       </span>
                     </div>
                     <div className="flex items-center justify-between gap-4 border-b border-(--border-subtle) px-4 py-3">

--- a/packages/web/src/components/console/views/AgentsView.tsx
+++ b/packages/web/src/components/console/views/AgentsView.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useMemo, useState, type ReactNode } from 'react'
 import {
+  agentCapabilitySource,
   agentDaemonLabel,
   agentLabel,
   agentModelDisplay,
@@ -399,6 +400,9 @@ export default function AgentsView() {
             </div>
             {filtered.map((a, i) => {
               const owning = daemons.find((d) => d.daemonId === a.daemon)
+              // The model comes from whoever reports the catalog for this PLACEMENT — a set names no
+              // member, so `owning` finds nothing there and the cell fell back to an em-dash.
+              const capabilitySource = agentCapabilitySource(a, daemons, memberSets)
               const runtimeMeta = acpRuntime(acpRegistry, a.runtime)
               const s = status(effectiveAgentStatus(a, owning))
               const agentInts = integrations.filter((int) => int.agentId === a.id)
@@ -434,7 +438,8 @@ export default function AgentsView() {
                       />
                     </span>
                     <span className="truncate font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                      {runtimeLabel(a.runtime, runtimeMeta?.name)} · {agentModelDisplay(owning, a.runtime, a.model)}
+                      {runtimeLabel(a.runtime, runtimeMeta?.name)} ·{' '}
+                      {agentModelDisplay(capabilitySource, a.runtime, a.model)}
                     </span>
                   </span>
                   {/* Trailing cluster. */}
@@ -558,6 +563,7 @@ export default function AgentsView() {
         ) : (
           visible.map((a) => {
             const owning = daemons.find((d) => d.daemonId === a.daemon)
+            const capabilitySource = agentCapabilitySource(a, daemons, memberSets)
             const runtimeMeta = acpRuntime(acpRegistry, a.runtime)
             const s = status(effectiveAgentStatus(a, owning))
             const sessionCount = sessions24h(a.id)
@@ -621,7 +627,7 @@ export default function AgentsView() {
                         {runtimeLabel(a.runtime, runtimeMeta?.name)}
                       </span>
                       <span className="text-(--border-strong)">·</span>
-                      <span className="mono truncate">{agentModelDisplay(owning, a.runtime, a.model)}</span>
+                      <span className="mono truncate">{agentModelDisplay(capabilitySource, a.runtime, a.model)}</span>
                     </div>
                   </div>
                 </div>

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -830,11 +830,7 @@ export default function HomeView() {
                       </span>
                       <span className="mono block truncate text-[11px] text-(--text-tertiary)">
                         {runtimeLabel(a.runtime)} ·{' '}
-                        {agentModelDisplay(
-                          daemons.find((d) => d.daemonId === a.daemon),
-                          a.runtime,
-                          a.model
-                        )}
+                        {agentModelDisplay(agentCapabilitySource(a, daemons, memberSets), a.runtime, a.model)}
                       </span>
                     </span>
                     <span className="mono whitespace-nowrap text-[12px] text-(--text-secondary)">


### PR DESCRIPTION
## Problem

A set placement names no member on purpose, so `Agent.daemon` carries the pool sentinel (`lib/data.ts` `POOL_PLACEMENT`) rather than a daemon id. The console's read-only surfaces resolved it with a `daemonId` lookup, found nothing, and were then left with no runtime catalog to resolve the model against — so every Cloud- and group-placed agent printed an em-dash model.

Two things made this more than a cosmetic gap:

- The em-dash appeared even when a model was **explicitly saved**. `selectedModelId` only trusts a stored model that the reported list contains; with no list, an explicit choice is discarded exactly like a blank one.
- The same agent named its model correctly on the set's own page, which passes a serving member as its capability source — so the two pages disagreed about one agent.

The Edit modal hit this first and fixed it with `editAgentCapabilitySource`; the rule was then generalized as `agentCapabilitySource` and adopted by the composer and the sign-in-required warning. These read-only call sites were never moved over.

## Change

Point them at the existing `agentCapabilitySource(agent, daemons, groups)`: a set resolves to one serving member standing in for it, a machine placement to itself.

- `AgentDetailView` — the header chip and the Basics **Model** row, plus the **Permission mode** and effort rows fed by the same catalog
- `AgentsView` — desktop table and mobile list (both printed the model)
- `HomeView` — the agent list
- `AgentCallVisibility` — the peer list

`owningDaemon` keeps its own meaning everywhere it still applies: placement naming, `effectiveAgentStatus`, the offline "safe move unavailable" notice, and the links into a machine's page. A set is therefore still never drawn as the member currently answering for it.

## Tests

New `AgentDetailView.placement.test.tsx`: a pool agent with a saved model, a pool agent without one (falls through to the catalog's own default), a group agent resolved via its member, a single machine (unchanged), and the case where nothing reports a catalog at all (the em-dash is still correct there).

Reverted the fix locally as a control — the three set-placement cases fail, the machine and em-dash cases still pass — so the suite is anchored on this defect rather than passing incidentally.

`typecheck`, `lint`, `format:check`, and the full web suite (2135 tests) are green.

## Reviewer notes

Not touched here, same root cause, each worth its own change:

- `AgentDetailView` gates the integration platform grid on `owningDaemon.caps.platforms`; a set placement resolves to `undefined`, which currently reads as "every platform available". Fixing it turns tiles **off**, so it is a behavior change rather than a display one.
- The Tools card takes `daemon={owningDaemon}`, so a set-placed agent lists no MCP servers.
- `SessionDetailView`'s composer permission chip falls back to `agent.daemon` when a session has no executing daemon yet, landing on the same sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
