### PR TITLE
fix(console): gate the platform tiles on the agent's placement

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.placement.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.placement.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+/**
+ * The wizard's platform tiles are gated on the adapters the agent's PLACEMENT advertises. A set
+ * placement names no member, so resolving `Agent.daemon` as a daemon id found nothing and read as
+ * "no daemon yet" — which offered a pool agent every chat platform, including ones its own members
+ * cannot serve. Resolved through `agentCapabilitySource`, one serving member answers for the set.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Agent, DaemonRow } from '@/lib/data'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const mocks = vi.hoisted(() => ({
+  daemons: [] as unknown[],
+  memberSets: [] as unknown[]
+}))
+
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, orgPath: (path: string) => path })
+}))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    bots: [],
+    daemons: mocks.daemons,
+    daemonsLoading: false,
+    memberSets: mocks.memberSets,
+    createIntegration: vi.fn(),
+    createHook: vi.fn(),
+    createGithubHook: vi.fn(),
+    createGitlabHook: vi.fn(),
+    refresh: vi.fn(),
+    updateAgent: vi.fn()
+  })
+}))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchAgentHooks: vi.fn(async () => []),
+  fetchAgentRepos: vi.fn(async () => []),
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
+  fetchGithubInstallUrl: vi.fn(async () => null),
+  fetchGitlabProjects: vi.fn(async () => []),
+  fetchGitlabConnections: vi.fn(async () => ({ enabled: false, connections: [] })),
+  searchGitlabProjects: vi.fn(async () => ({ projects: [], nextPage: null }))
+}))
+
+const AddIntegrationModal = (await import('./AddIntegrationModal')).default
+
+/** A daemon advertising exactly the chat adapters named. */
+function daemon(over: Partial<DaemonRow>): DaemonRow {
+  return {
+    daemonId: 'd1',
+    pool: false,
+    memberSetId: null,
+    name: 'edge-1',
+    status: 'online',
+    caps: { platforms: ['slack'], runtimes: ['claude'], acp: true, features: [] },
+    runtimeModels: [],
+    mcpServers: [],
+    ...over
+  } as unknown as DaemonRow
+}
+
+const agent = {
+  id: 'agent-a',
+  name: 'pilot',
+  daemon: 'pool',
+  placementKind: 'set',
+  setId: null,
+  canEdit: true,
+  workspace: { mode: 'scratch', files: [] }
+} as unknown as Agent
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+/** Every tile by label, with the greyed-out treatment it carries. */
+function tileStates(): Record<string, boolean> {
+  return Object.fromEntries(
+    [...document.querySelectorAll<HTMLDivElement>('.ptile')].map((tile) => [
+      (tile.textContent ?? '').trim(),
+      tile.getAttribute('aria-disabled') === 'true'
+    ])
+  )
+}
+
+async function render(over: Record<string, unknown> = {}): Promise<void> {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(<AddIntegrationModal agent={{ ...agent, ...over } as unknown as Agent} onClose={() => undefined} />)
+  })
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  mocks.daemons = []
+  mocks.memberSets = []
+})
+
+describe('AddIntegrationModal, platform tiles by placement', () => {
+  it("greys out a platform the POOL's members do not advertise", async () => {
+    mocks.daemons = [daemon({ daemonId: 'pod-1', pool: true })]
+    await render()
+    const tiles = tileStates()
+    expect(tiles['Slack']).toBe(false)
+    expect(tiles['Telegram']).toBe(true)
+    // Relay/CP-backed triggers ride no daemon adapter, so they stay selectable.
+    expect(tiles['Webhook']).toBe(false)
+    expect(tiles['GitHub']).toBe(false)
+  })
+
+  it('reads a GROUP placement through one of its members', async () => {
+    mocks.memberSets = [{ setId: 'g1', name: 'lab', memberDaemonIds: ['lab-1'], agentCount: 1 }]
+    mocks.daemons = [
+      daemon({
+        daemonId: 'lab-1',
+        memberSetId: 'g1',
+        caps: { platforms: ['telegram'], runtimes: [], acp: true, features: [] }
+      })
+    ]
+    await render({ daemon: 'set:g1', setId: 'g1' })
+    const tiles = tileStates()
+    expect(tiles['Telegram']).toBe(false)
+    expect(tiles['Slack']).toBe(true)
+  })
+
+  it('keeps every platform selectable for an UNPLACED agent', async () => {
+    await render({ daemon: '—', placementKind: 'daemon' })
+    expect(Object.values(tileStates()).every((disabled) => !disabled)).toBe(true)
+  })
+
+  it('gates a single machine on its own adapters', async () => {
+    mocks.daemons = [daemon({})]
+    await render({ daemon: 'd1', placementKind: 'daemon' })
+    const tiles = tileStates()
+    expect(tiles['Slack']).toBe(false)
+    expect(tiles['Telegram']).toBe(true)
+  })
+})

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -41,7 +41,7 @@ import {
 } from '@/components/console/platforms/publish'
 import { platformRegistry, platformSupportsSharing } from '@/components/console/platforms/registry'
 import { BOT_PLATFORMS, PLATFORMS, isCoreTriggerKind } from '@/components/console/platforms/host-projections'
-import { agentLabel, MOCK_MODE, type Agent } from '@/lib/data'
+import { agentCapabilitySource, agentLabel, MOCK_MODE, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
 import { useProfile } from '@/lib/profile'
@@ -403,6 +403,7 @@ export default function AddIntegrationModal({
     createGitlabHook,
     daemons,
     daemonsLoading,
+    memberSets,
     refresh,
     updateAgent
   } = useConsoleData()
@@ -594,17 +595,15 @@ export default function AddIntegrationModal({
   const [regionLocked, setRegionLocked] = useState(false)
   const setError = useCallback((message: string | null) => setErr(message), [])
 
-  // A bot integration is runnable only when the owning daemon has reported its
-  // adapter on register. Do not substitute `maxAgents`: it is a concurrency
-  // ceiling, while `caps.platforms` is the adapter-capability declaration.
-  // An UNPLACED agent (no daemon yet — the preset before placement) keeps the
-  // bot platforms selectable: the platform "Add to Slack" card and the funnel
-  // both create CP-side rows whose delivery converges at placement, and the
-  // server backstops the paths that genuinely require a daemon.
-  const daemon = daemons.find((d) => d.daemonId === agent.daemon)
-  const unplaced = !daemon
+  // A bot integration is runnable only where the PLACEMENT reported that adapter on register — resolved as a
+  // placement, since a set names no member and an id lookup found none, offering a pool agent every platform.
+  // Not `maxAgents`: that is a concurrency ceiling, while `caps.platforms` is the adapter-capability declaration.
+  // No caps source at all keeps the bot platforms selectable — the platform "Add to Slack" card and the funnel
+  // mint CP-side rows whose delivery converges at placement, and the server backstops what needs a daemon.
+  const daemon = agentCapabilitySource(agent, daemons, memberSets)
+  const capsUnknown = !daemon
   const supportedBotPlatforms =
-    daemonsLoading || unplaced ? BOT_PLATFORMS : BOT_PLATFORMS.filter((p) => daemon.caps.platforms.includes(p.key))
+    daemonsLoading || capsUnknown ? BOT_PLATFORMS : BOT_PLATFORMS.filter((p) => daemon.caps.platforms.includes(p.key))
   const firstSupportedBotPlatform = supportedBotPlatforms[0]?.key
   // webhook + github are relay/CP-backed triggers — always available, never
   // gated by the daemon's adapter capabilities.

--- a/packages/web/src/components/console/views/AgentDetailView.placement.test.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.placement.test.tsx
@@ -16,12 +16,13 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
 const mocks = vi.hoisted(() => ({
   agent: {} as unknown,
   daemons: [] as unknown[],
-  memberSets: [] as unknown[]
+  memberSets: [] as unknown[],
+  tab: 'tab=config'
 }))
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({ id: 'agent-1' }),
-  useSearchParams: () => new URLSearchParams('tab=config'),
+  useSearchParams: () => new URLSearchParams(mocks.tab),
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() })
 }))
 vi.mock('next/link', () => ({ default: ({ children }: { children?: ReactNode }) => <span>{children}</span> }))
@@ -150,6 +151,14 @@ async function render(): Promise<string> {
   return host.textContent ?? ''
 }
 
+/** The Integrations grid's tiles by label, with the greyed-out treatment each carries. */
+function tileStates(): Record<string, boolean> {
+  const tiles = host!.querySelectorAll('[aria-disabled]')
+  return Object.fromEntries(
+    [...tiles].map((tile) => [(tile.textContent ?? '').trim(), tile.getAttribute('aria-disabled') === 'true'])
+  )
+}
+
 afterEach(async () => {
   if (root) await act(async () => root!.unmount())
   host?.remove()
@@ -157,6 +166,7 @@ afterEach(async () => {
   host = undefined
   mocks.daemons = []
   mocks.memberSets = []
+  mocks.tab = 'tab=config'
 })
 
 describe('AgentDetailView, model row by placement', () => {
@@ -195,5 +205,40 @@ describe('AgentDetailView, model row by placement', () => {
     const text = await render()
     expect(text).not.toContain('opus')
     expect(text).toContain('—')
+  })
+})
+
+describe('AgentDetailView, platform grid by placement', () => {
+  it("greys out a bot platform the POOL's members do not advertise", async () => {
+    mocks.tab = ''
+    mocks.agent = agentOn({ daemon: 'pool', placementKind: 'set', setId: null })
+    mocks.daemons = [
+      daemon({
+        daemonId: 'pod-1',
+        pool: true,
+        caps: { platforms: ['slack'], runtimes: ['claude'], acp: true, features: [] }
+      })
+    ]
+    await render()
+    const tiles = tileStates()
+    expect(tiles['Slack']).toBe(false)
+    expect(tiles['Telegram']).toBe(true)
+    // Relay/CP-backed triggers ride no daemon adapter, so they stay selectable.
+    expect(tiles['Webhook']).toBe(false)
+    expect(tiles['GitHub']).toBe(false)
+  })
+
+  it('keeps every platform selectable for an UNPLACED agent', async () => {
+    mocks.tab = ''
+    mocks.agent = agentOn({
+      daemon: '—',
+      placementKind: 'daemon',
+      setId: null,
+      status: 'offline',
+      placementReady: false
+    })
+    mocks.daemons = []
+    await render()
+    expect(Object.values(tileStates()).every((disabled) => !disabled)).toBe(true)
   })
 })

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -623,17 +623,12 @@ export default function AgentDetailView() {
   const agentInts = integrations.filter((i) => i.agentId === da.id)
   // Peer agents for the read-only Access card's agent-call summary (self excluded).
   const agentPeers = agents.filter((peer) => peer.id !== da.id)
-  // The empty Integrations tab renders the SAME platform grid as the
-  // Add-integration modal — same list, order, tile size and disabled treatment.
-  // A bot platform the owning daemon doesn't advertise is greyed out rather than
-  // clickable (the modal applies this identical gate), so a tile can never open a
-  // pane other than the one it names. webhook/github are relay/CP-backed
-  // triggers: always available.
-  // An UNPLACED agent keeps bot platforms selectable — the platform "Add to
-  // Slack" card / the funnel mint CP-side rows whose delivery converges at
-  // placement; the modal + server gate what genuinely needs a daemon.
+  // The empty Integrations tab renders the SAME grid as the Add-integration modal, under this identical gate.
+  // A bot platform the PLACEMENT does not advertise is greyed out, so a tile never opens a pane it cannot honour.
+  // webhook/github are relay/CP-backed triggers: never gated. No caps source (unplaced, or a set whose members
+  // this viewer cannot see) keeps every platform selectable — the modal and the server gate what needs a daemon.
   const integrationPlatformAvailable = (key: Platform) =>
-    isCoreTriggerKind(key) || daemonsLoading || !owningDaemon || owningDaemon.caps.platforms.includes(key)
+    isCoreTriggerKind(key) || daemonsLoading || !capabilitySource || capabilitySource.caps.platforms.includes(key)
   // Effective (intersection) peer sets for the read-only Access summary.
   const inboundEffectiveIds = agentReach.incomingByAgentId.get(da.id) ?? []
   const outboundEffectiveIds = agentReach.outgoingByAgentId.get(da.id) ?? []


### PR DESCRIPTION
Follow-up to #1564, which fixed the model/effort/permission rows. This is the remaining member of the same family — and the one that changes behavior rather than only display, which is why it is separate.

## Problem

Two grids grey out a chat platform the agent's daemon never advertised on register: the Integrations tab's empty-state grid and the Add-integration wizard's picker. Both resolved that daemon by id:

```ts
const daemon = daemons.find((d) => d.daemonId === agent.daemon)
const unplaced = !daemon
```

A set placement carries no member id — it names no member on purpose — so both landed on `undefined` and read it as "no daemon yet, keep everything selectable". Consequences for a Cloud- or group-placed agent:

- It was offered **every** chat platform, including ones no member of its own set can serve. The tile promised a pane the server would then refuse.
- The wizard classified it as `unplaced` while the page hosting the wizard showed it placed and online — the same disagreement between two surfaces that #1564 removed from the model row.

## Change

Resolve the caps source through `agentCapabilitySource`, the rule the model rows and the editor already use: a set resolves to one serving member standing in for it, a machine placement to itself.

What stays selectable is unchanged in the two cases that were never the bug: a genuinely unplaced agent (the platform "Add to Slack" card and the funnel mint CP-side rows whose delivery converges at placement), and a set with no member this viewer can see. `webhook`, `github` and `gitlab` are relay/CP-backed triggers and remain ungated.

The wizard's `unplaced` local is renamed `capsUnknown`, since "no caps to read" and "not placed" are no longer the same condition.

## Tests

`AddIntegrationModal.placement.test.tsx` is new; `AgentDetailView.placement.test.tsx` gains the grid cases. Between them: pool, group, single machine, and unplaced, asserting the greyed-out treatment tile by tile and that the core triggers stay on.

Both were checked against a reverted fix — the pool and group cases fail, machine and unplaced pass — so they are anchored on this defect.

`typecheck`, `lint`, `format:check`, and the full web suite (2141 tests) are green.

## Reviewer notes

- **This turns tiles off.** On a pool or group placement whose members advertise a subset of the platforms, tiles that were clickable become greyed out. That is the intended correction — those clicks led to a refusal — but it is worth a look if any deployment leaned on the permissive behavior.
- The disabled tooltip still reads "Not supported by this daemon" on both grids. Accurate enough (a member is a daemon, and the console calls it that everywhere) so it is left alone rather than reworded in a behavior fix.
- Still untouched from #1564's list: the Tools card takes `daemon={owningDaemon}`, so a set-placed agent lists no MCP servers, and `SessionDetailView`'s composer permission chip falls back to `agent.daemon` when a session has no executing daemon yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
