### PR TITLE
fix(release): retry an npm publish that a transient signing failure killed

### DIFF
--- a/scripts/npm-publish-with-retry.sh
+++ b/scripts/npm-publish-with-retry.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Publish the package in the current working directory under a dist-tag, retrying
+# transient upstream failures. semantic-release pushes the tag and its channel note
+# BEFORE publish plugins run, so a failed publish cannot be recovered by re-running
+# the job: the next run sees the release as done and never reaches npm again. The
+# observed flake is Sigstore's Fulcio CA answering the provenance attestation with
+# `CA_CREATE_SIGNING_CERTIFICATE_ERROR ... (403) Forbidden`; provenance is implicit
+# under npm OIDC trusted publishing, so the whole publish is the retry unit.
+set -eu
+
+TAG="$1"
+ATTEMPTS=3
+attempt=1
+
+while :; do
+  if OUTPUT=$(pnpm publish --no-git-checks --ignore-scripts --tag "$TAG" 2>&1); then
+    printf '%s\n' "$OUTPUT"
+    exit 0
+  fi
+  printf '%s\n' "$OUTPUT"
+
+  # An attempt that uploaded before failing leaves the version on the registry; the
+  # conflict is also a 403, so match the message rather than the status code.
+  case "$OUTPUT" in
+    *EPUBLISHCONFLICT* | *'cannot publish over'* | *'previously published version'*)
+      echo "version is already on the registry — treating this publish as done"
+      exit 0
+      ;;
+  esac
+
+  if [ "$attempt" -ge "$ATTEMPTS" ]; then
+    echo "publish failed after ${ATTEMPTS} attempts" >&2
+    exit 1
+  fi
+
+  DELAY=$((attempt * 20))
+  echo "publish attempt ${attempt}/${ATTEMPTS} failed — retrying in ${DELAY}s"
+  sleep "$DELAY"
+  attempt=$((attempt + 1))
+done

--- a/scripts/publish-cli-if-changed.sh
+++ b/scripts/publish-cli-if-changed.sh
@@ -83,4 +83,4 @@ fi
 # is NOT rebuilt with dependencies now stripped (which would re-break the
 # bundle).
 cd "$REPO_ROOT/packages/cli"
-pnpm publish --no-git-checks --ignore-scripts --tag "$VALUE"
+sh "$REPO_ROOT/scripts/npm-publish-with-retry.sh" "$VALUE"

--- a/scripts/publish-daemon-if-changed.sh
+++ b/scripts/publish-daemon-if-changed.sh
@@ -92,4 +92,4 @@ fi
 # is NOT rebuilt with dependencies now stripped (which would re-break the
 # bundle).
 cd "$REPO_ROOT/packages/daemon"
-pnpm publish --no-git-checks --ignore-scripts --tag "$VALUE"
+sh "$REPO_ROOT/scripts/npm-publish-with-retry.sh" "$VALUE"

--- a/scripts/publish-setup-if-changed.sh
+++ b/scripts/publish-setup-if-changed.sh
@@ -63,4 +63,4 @@ if [ "$MODE" = prepare ]; then
 fi
 
 cd "$REPO_ROOT/packages/setup"
-pnpm publish --no-git-checks --ignore-scripts --tag "$VALUE"
+sh "$REPO_ROOT/scripts/npm-publish-with-retry.sh" "$VALUE"


### PR DESCRIPTION
## What broke

`v1.51.0-rc.2` was tagged but never published. `pnpm publish` failed with
`[CA_CREATE_SIGNING_CERTIFICATE_ERROR] error creating signing certificate - (403) Forbidden`
from Sigstore's Fulcio CA while building the provenance attestation. The release job
publishes through npm OIDC trusted publishing, which implies provenance, so every publish
depends on that CA answering.

## Why the retry cannot live in the workflow

semantic-release pushes the git tag and its channel note **before** running publish plugins.
Re-running the job therefore finds the release already made, reports no new version, and
exits — the package never reaches npm, and image publication is skipped for want of a
version output. The retry has to sit inside the publish command, and the publish call is the
retry unit because pnpm attests and uploads in one step.

## What changed

`scripts/npm-publish-with-retry.sh` wraps the `pnpm publish` line that the daemon, CLI, and
setup publish scripts all shared: three attempts, 20s and 40s apart. An attempt that uploaded
before failing leaves the version on the registry, so a republish conflict counts as done —
matched on the message, because that answer is a 403 as well.

Note that `scripts` is part of the setup package's change-detection input set (it mirrors the
control-plane image inputs), so this commit alone makes setup publish on the next release —
which also closes the gap left by the failed one. The daemon and CLI input sets do not
include `scripts`, so they are unaffected.

## Testing

Exercised the wrapper against a stubbed `pnpm`: a transient failure retries and then
succeeds, a republish conflict short-circuits to success, and a permanent failure exhausts
the attempts and exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
