### PR TITLE
fix(daemon): let the native Slack Stop cancel a turn that is still cold

### DIFF
--- a/packages/daemon/src/commands/handlers.ts
+++ b/packages/daemon/src/commands/handlers.ts
@@ -178,7 +178,9 @@ export class CommandHandlers {
     // Cancel a gate-owned/queued session even if it has no live ACP turn yet (§6.9 #390):
     // interruptTurn drains the queue by key and cancels the ACP turn only if one exists.
     if (!this.host.inflight().has(key)) return false
-    const agentId = rec?.agentId ?? this.host.serialQueue().get(key)?.[0]?.agentId
+    // The cold head owns the key from the gate alone — no row, and not queued behind itself.
+    const agentId =
+      rec?.agentId ?? this.host.activeGateEntries().get(key)?.agentId ?? this.host.serialQueue().get(key)?.[0]?.agentId
     if (!agentId) return false
     await this.host.interruptTurn(agentId, key, 'cancel', rec?.acpSessionId ?? undefined)
     return true // reports whether a turn was actually interrupted (nothing else reads it)
@@ -523,16 +525,14 @@ export class CommandHandlers {
     // a `!stop` sent in the cold thread can mute/cancel an older thread and leave the
     // actual turn running. Check all gate representations because commands can race the
     // short hand-offs between them.
-    const gateActiveFor = (candidateKey: string): boolean =>
-      this.host.activeGateEntries().has(candidateKey) || (this.host.serialQueue().get(candidateKey)?.length ?? 0) > 0
-    let directGateActive = gateActiveFor(key)
+    let directGateActive = this.gateActiveFor(key)
     if (!rec && !directGateActive) {
       const latest = await this.host.store().latestSessionForTransport(target.agentId, msg.channel, msg.transportScope)
       if (latest) {
         rec = latest
         key = latest.key
         thread = latest.thread
-        directGateActive = gateActiveFor(key)
+        directGateActive = this.gateActiveFor(key)
       }
     }
     const acpSessionId = rec?.acpSessionId
@@ -911,6 +911,27 @@ export class CommandHandlers {
     return (await this.admittedSessions(platform, channel, srcIntegrationIds, transportScope, thread))[0] ?? null
   }
 
+  /** A turn currently owns this logical key — the gate's admitted head, or the queue behind
+   *  it. True through the cold window too, where no session row exists yet. */
+  private gateActiveFor(key: string): boolean {
+    return this.host.activeGateEntries().has(key) || (this.host.serialQueue().get(key)?.length ?? 0) > 0
+  }
+
+  /** The agents whose own-platform integrations admit this conversation — one entry each,
+   *  whichever of its integrations qualified. */
+  private admittedAgentIds(platform: string, channel: string, srcIntegrationIds: readonly string[]): string[] {
+    const agentIds: string[] = []
+    for (const [agentId, agent] of this.host.agents()) {
+      for (const integration of agent.integrations) {
+        if (integration.platform !== platform || !srcIntegrationIds.includes(integration.id)) continue
+        if (!conversationAdmitted(integrationRouting(integration), channel)) continue
+        agentIds.push(agentId)
+        break
+      }
+    }
+    return agentIds
+  }
+
   /** Every admitted session in the conversation, one per participating agent, newest first. */
   private async admittedSessions(
     platform: string,
@@ -920,14 +941,9 @@ export class CommandHandlers {
     thread?: string
   ): Promise<SessionRecord[]> {
     const candidates: SessionRecord[] = []
-    for (const [agentId, agent] of this.host.agents()) {
-      for (const integration of agent.integrations) {
-        if (integration.platform !== platform || !srcIntegrationIds.includes(integration.id)) continue
-        const routing = integrationRouting(integration)
-        if (!conversationAdmitted(routing, channel)) continue
-        const session = await this.host.store().latestSessionForTransport(agentId, channel, transportScope, thread)
-        if (session) candidates.push(session)
-      }
+    for (const agentId of this.admittedAgentIds(platform, channel, srcIntegrationIds)) {
+      const session = await this.host.store().latestSessionForTransport(agentId, channel, transportScope, thread)
+      if (session) candidates.push(session)
     }
     candidates.sort((a, b) => b.updatedAt - a.updatedAt || a.agentId.localeCompare(b.agentId))
     return candidates
@@ -956,7 +972,10 @@ export class CommandHandlers {
   }
 
   /** Every addressable session in one Slack conversation, newest first — the native
-   *  session-level Stop must interrupt ALL of the thread's in-flight turns, not one. */
+   *  session-level Stop must interrupt ALL of the thread's in-flight turns, not one.
+   *  A turn owns its logical key from admission, but its row is written only once the
+   *  runtime answers `session/new`; the Stop control renders over that whole cold window,
+   *  so the gate is read alongside the store or the first click cancels nothing. */
   async slackThreadSessions(
     shortcut: { channel: string; thread: string },
     srcIntegrationIds: readonly string[]
@@ -969,6 +988,11 @@ export class CommandHandlers {
       transportScope,
       shortcut.thread
     )
-    return sessions.map((s) => s.key)
+    const keys = sessions.map((s) => s.key)
+    for (const agentId of this.admittedAgentIds('slack', shortcut.channel, srcIntegrationIds)) {
+      const cold = sessionKey('slack', shortcut.channel, shortcut.thread, agentId, transportScope)
+      if (!keys.includes(cold) && this.gateActiveFor(cold)) keys.push(cold)
+    }
+    return keys
   }
 }

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -654,6 +654,47 @@ describe('Daemon in-conversation commands', () => {
     await daemon.stop()
   })
 
+  // Slack renders the native Stop from the moment the turn sets `processing`, which is BEFORE
+  // session/new answers and the row is written. connection.test.ts covers the event wiring; this
+  // is the resolve → cancel half it drives, in that cold window.
+  it('the native Slack Stop cancels a cold turn whose session row does not exist yet', async () => {
+    let releaseSession!: () => void
+    const sessionBlocked = new Promise<void>((resolve) => (releaseSession = resolve))
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => {
+        await sessionBlocked
+        return 'acp-cold'
+      }),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async () => 'end_turn'),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
+    await daemon.start()
+    makeRoutable(daemon)
+
+    const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
+    await vi.waitFor(() => expect(host.newSession).toHaveBeenCalled(), WAIT)
+    expect(await (daemon as any).store.getSession(SESSION_KEY)).toBeUndefined()
+
+    // Exactly what SlackConnection.agentSessionStopped runs for the tapped conversation.
+    const keys = await (daemon as any).commands.slackThreadSessions({ channel: 'C1', thread: 'T1' }, ['int-a'])
+    expect(keys).toEqual([SESSION_KEY])
+    for (const key of keys)
+      await (daemon as any).commands.handleStatusAction({ kind: 'cancel', sessionKey: key, actor: { userId: 'U1' } })
+
+    releaseSession()
+    await expect(turn).resolves.toBeNull()
+    expect(host.prompt).not.toHaveBeenCalled()
+    await daemon.stop()
+  })
+
   it('!cancel interrupts the in-flight turn WITHOUT muting the thread', async () => {
     const blocked = blockingHost()
     const daemon = new Daemon({


### PR DESCRIPTION
## What

Slack's native agent-session **Stop** control did nothing when it was clicked early in a
turn: the turn kept running, then visibly resumed a moment later. Clicking again, after the
first output landed, worked. This fixes the first click.

## Why

The Stop control renders as soon as a turn sets the session to `processing`, which happens
at the very start of dispatch — before `session/new` is answered and before the session row
is written (the row is created only once the runtime hands back an ACP id). Both stop
transports (Socket Mode event and the forwarded one) resolve the tapped conversation through
`SlackConnection.agentSessionStopped` → `slackThreadSessions`, and that resolution went to
the store alone, whose lookup requires a persisted ACP id.

So for the whole cold window — workspace preparation plus runtime start, easily tens of
seconds on a first turn — the resolution returned an empty set, nothing was cancelled, and
the session was still transitioned back to `active`, which clears the control and reads as
though the stop had worked. The turn then re-asserted `processing` on its next status write
and carried on.

The text commands already handle this: `!stop` / `!cancel` explicitly consult the dispatch
gate for a cold turn that owns its logical key before the row exists. The native Stop was the
one entry that never got that treatment, and it is untested for the cold case (every existing
test seeds a session with an ACP id).

## Changes

- **`slackThreadSessions`** reads the dispatch gate alongside the store. For each agent the
  conversation admits, the deterministic logical key is derived and joins the resolved rows
  when a turn currently owns it. Extracted `gateActiveFor` (previously inline in
  `handleCommand`) and `admittedAgentIds` so both callers share one admission walk.
- **`cancelSessionByKey`** resolves the agent from the gate's admitted head too. A cold head
  has no row and is not queued behind itself, so it returned `false` even when handed the
  right key — both halves are required for the click to take effect.
- Regression test: a turn blocked inside `session/new` is cancelled through the native Stop
  path (resolve → cancel) and never reaches `prompt`. Reverting either half fails it.

## Notes for review

- Cancellation machinery itself needed nothing — `interruptTurn` already latches a cold head
  through `activeGateEntries` and arms the cold backstop. This is purely a resolution gap.
- Deliberately unchanged: the unconditional transition back to `active`. With resolution
  fixed, an empty result now genuinely means nothing is running there, so reporting `active`
  is correct.
- `admittedAgentIds` yields one entry per agent; `admittedSessions` previously produced a
  duplicate row when an agent had two admitting integrations in the same source set.
