### PR TITLE
docs(design): the host-neutral git workspace model

### DIFF
--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -1,0 +1,204 @@
+# The Host-Neutral Git Workspace Model
+
+> **Status:** Accepted, not yet implemented. This document re-models the
+> workspace contract that [github-app-git-credentials.md](github-app-git-credentials.md)
+> and [gitlab-com-integration.md](gitlab-com-integration.md) currently share
+> implicitly; both keep describing their credential tracks and point here for
+> the workspace shape. The route-level behavior it consolidates shipped
+> incrementally (#1561, #1567); the wire and storage changes below have not.
+
+## 1. Why
+
+Today the workspace discriminant is the code host: `scratch | github | gitlab`.
+That bakes a UI notion — which picker the repository came from — into the wire
+contract, the database, and two independently written route validations. One
+class of defect followed from it repeatedly:
+
+- Replacing a workspace refused the anonymous public repository that creating
+  an agent had always accepted, because the two routes validated the `github`
+  arm independently and only one kept the anonymous branch (#1561).
+- The console reported a public repository on a foreign account as App-backed,
+  because the client — not the server — decided which installation vouched for
+  a repository, and the write path then refused its own picker's choice (#1561).
+- An unstated access tier meant `write` at creation and `read` on the next
+  edit, because each route carried its own default (#1567).
+- Public GitLab projects and bare Git servers are representable on the wire
+  (the `github` arm's `gitRepo` is deliberately host-agnostic) but reachable
+  from no console surface, because every surface is host-shaped.
+
+The daemon never had this problem, because it never adopted the host-shaped
+model. It collapses the wire modes on arrival (`write-agent.ts`,
+`mapWorkspaceMode`) into `git-repo | from-scratch` plus an independent
+`gitCredential: 'github-app' | 'gitlab' | absent`, and its ~2000-line workspace
+manager branches on that pair exclusively. **This design promotes the daemon's
+internal model to the wire, the control plane, and the console.**
+
+## 2. The invariant
+
+**`mode` answers "is there a repository"; `credential` answers "who vouches for
+it".** Two orthogonal axes, never re-combined into one discriminant:
+
+- A new code host is a new `credential` variant — never a new `mode`, so it
+  cannot re-introduce per-host route arms or per-host console modules.
+- "Anonymous + write" is unrepresentable: `access` lives inside the credential,
+  and an anonymous workspace has no credential to carry it. The bug class
+  #1561 fixed at runtime is gone structurally.
+
+## 3. Wire contract (protocol `AgentWorkspace`)
+
+```ts
+{ mode: 'scratch', isolation, gitCredential?, additionalRepos }   // unchanged
+{ mode: 'git',
+  isolation,
+  gitRepo,                    // FULL cloneable https/ssh address (normalizeGitCloneUrl)
+  branch,
+  agentDir?,
+  credential?:                // absent ⇒ anonymous clone; the host's own policy
+                              // (workspaceGitAllowedOrigins) still gates the origin
+      { provider: 'github' }                    // minting re-resolves the live
+                                                // installation by owner, as today
+    | { provider: 'gitlab', projectId },        // rename-stable id; gitcred v2
+                                                // verifies every echo against it
+  additionalRepos }
+```
+
+The `git` arm is a near-identity mapping onto the daemon's internal model, so
+the daemon-side change is essentially the decoder. `installationId` stays off
+the wire (minting resolves live by owner, so uninstall→reinstall self-heals);
+`access` stays off the wire (the CP clamps minted tokens server-side; the
+daemon never reads it today either).
+
+The `github` and `gitlab` arms remain decodable during the transition (§8).
+
+## 4. Storage (control plane)
+
+- `workspaceMode` collapses to `scratch | git`; a migration rewrites
+  `github | gitlab → git`.
+- New column `gitCredentialProvider: 'github' | 'gitlab' | null`. It cannot be
+  derived from existing columns: `workspaceRepoId` is shared between GitHub's
+  numeric repo id and GitLab's project id, so provider must be explicit.
+  Backfill: `github` rows with an `installationId` → `'github'`; `gitlab` rows
+  → `'gitlab'`; everything else → null.
+- `installationId`, `workspaceRepoId`, `gitAccess`, `workspaceIsolation` stay.
+  `gitAccess` is meaningful only where `gitCredentialProvider` is non-null.
+
+## 5. API surface
+
+One workspace input shape, shared verbatim by agent creation and workspace
+replacement:
+
+```ts
+{ mode: 'scratch' }
+{ mode: 'git', gitRepo, gitBranch?, agentDir?, worktree?, access?: 'read' | 'write' }
+```
+
+- **`installationId` and `projectId` are removed from input.** Provenance is a
+  server-side fact derived from the address (§6). Every #1561-class bug shared
+  the same root: the client reported provenance and two routes verified it
+  independently.
+- `access` on the input is a request; the derived credential records the
+  result. Unstated `access` takes the highest tier the target carries (#1567):
+  `write` where credentials are minted, `read` for an anonymous checkout, and
+  an explicit `write` against an anonymous target is refused.
+- Shorthand convention: bare `owner/repo` is GitHub-only sugar. Every other
+  host is written as a full https/ssh URL; a dotted two-segment input is not
+  reinterpreted as a bare host.
+
+### The resolve endpoint
+
+`GET /orgs/:orgId/git/resolve?gitRepo=…` runs the same derivation the write
+paths run and returns the outcome — provider, access ceiling, canonical
+address, default branch — for the console's badges and branch defaults. Because
+the routes and the UI preview call one function, the picker can no longer
+disagree with the write path about what a pick means. It also replaces the
+console's browser-direct `api.github.com` reads (rate-limited, unauthenticated,
+and a second implementation of the server's rules) over time.
+
+## 6. Credential derivation — one function, three callers
+
+`deriveWorkspaceCredential(orgId, gitRepo)`, called by the create route, the
+replace route, and the resolve endpoint. No other code decides provenance.
+
+| Target                                                            | Outcome                                                                                                                                                                                                          |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| github.com, a live installation covers the owner, repo resolves   | `{ provider: 'github' }` — catalog row converges, identity gate runs                                                                                                                                             |
+| github.com, a live installation covers the owner, repo missing    | **refuse**: an installation token reads any public repository, so a miss under a covered owner is private-and-ungranted or absent; an anonymous clone cannot serve it, and the actionable answer names the grant |
+| github.com, no covering installation, anonymous read says public  | anonymous                                                                                                                                                                                                        |
+| github.com, no covering installation, not public                  | **refuse**                                                                                                                                                                                                       |
+| the deployment's GitLab host, managed binding exists              | `{ provider: 'gitlab', projectId }`                                                                                                                                                                              |
+| the deployment's GitLab host, unbound, anonymous read says public | anonymous                                                                                                                                                                                                        |
+| the deployment's GitLab host, unbound, not public                 | **refuse** ("add the project first")                                                                                                                                                                             |
+| any other host (bare Git, an unmanaged GitLab instance, GHE, …)   | anonymous — no preflight; the daemon's clone boundary reports failure, exactly as creation behaves today                                                                                                         |
+| anonymous outcome + requested `access: 'write'`                   | **refuse** ("write requires managed credentials")                                                                                                                                                                |
+
+Host comparison for the GitLab branch reuses `gitlabManagedHost` (§24.1 of the
+GitLab design; the base URL may carry a path prefix an origin may not).
+
+## 7. Console
+
+Provider tiles stay — they carry the lexicon and the guidance a neutral input
+cannot (`org/name` shorthand, "install the GitHub App", "connect GitLab",
+provision-on-pick):
+
+| Tile           | Accepts                                | Candidates                                                    |
+| -------------- | -------------------------------------- | ------------------------------------------------------------- |
+| From scratch   | —                                      | —                                                             |
+| From GitHub    | `org/name`, full URL                   | installation roster, owner-scoped exact lookup, public search |
+| From GitLab    | `group/project`, full URL              | bound projects, bindable projects, **public projects** (new)  |
+| From a Git URL | full https/ssh URL only — no shorthand | none; static "host credentials" note                          |
+
+- Every tile produces the same payload: one `gitRepo` address (plus branch,
+  directory, worktree, access). The tile chooses how you type, never what is
+  stored.
+- The Git URL tile refuses github.com and the deployment's GitLab host with a
+  switch-tile hint, so tile ↔ stored-shape stays injective by construction.
+- **No `source` field is stored.** The displayed tile is derived from host +
+  credential (`provider 'github'` → GitHub; `provider 'gitlab'` → GitLab;
+  anonymous on a managed host → that host's tile with a `public` badge;
+  anonymous elsewhere → Git URL with a `host credentials` note). A stored
+  choice would contradict the derived credential and go stale as capabilities
+  change; the derivation cannot.
+
+## 8. Rollout — readers first
+
+1. **protocol**: add the `git` arm and credential union; keep decoding the
+   `github`/`gitlab` arms. Define the `workspace-git-v1` daemon feature.
+2. **daemon**: decode the `git` arm (near-identity onto the internal model);
+   advertise `workspace-git-v1`.
+3. **control plane**: the derivation function, the storage migration, both
+   routes on the unified input, the resolve endpoint. Spec assembly
+   dual-encodes: the `git` arm to daemons advertising `workspace-git-v1`, the
+   legacy arms to everyone else — an old daemon must never receive a frame it
+   fatals on.
+4. **web**: the four tiles over the resolve endpoint; delete the browser-direct
+   GitHub reads.
+5. **cleanup** once the fleet advertises the feature: drop the legacy arms and
+   the dual encoding.
+
+Each step ships independently; nothing observable changes before step 3.
+
+## 9. Decided
+
+- **Provenance is fixed at write time and re-derived on the next workspace
+  write — never auto-upgraded.** An anonymous workspace whose owner later
+  installs the App stays anonymous until someone edits it; silently escalating
+  a workspace's credentials is worse than a stale anonymous checkout.
+- **Bare Git rides the anonymous arm** ("host credentials"): the daemon
+  installs no helper, so clone/push use whatever git credentials the machine
+  itself holds. Works self-hosted; fails at clone time in a sandbox pool. A
+  distinct `{ provider: 'host' }` variant — which would let placement refuse a
+  pool for such a workspace up front — is future work, not this design.
+- **A covered owner's ungranted repository refuses; it never degrades to
+  anonymous** (from #1561 review): the miss proves the repo is
+  private-and-ungranted or absent, and the useful error names the grant.
+
+## 10. Non-goals
+
+- New credential providers (GitHub Enterprise, Bitbucket, `host`). The union is
+  where they land when wanted; this design only guarantees they will not need a
+  new mode.
+- Changing the `scratch` arm, additional repositories, gitcred v2, or the
+  daemon's clone-origin policy (`workspaceGitAllowedOrigins` remains the
+  operator's boundary and the only place the host list lives).
+- Skill sources, which stay deliberately GitHub-only
+  ([shared-skills.md](shared-skills.md)).

--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -104,20 +104,53 @@ replacement:
   host is written as a full https/ssh URL; a dotted two-segment input is not
   reinterpreted as a bare host.
 
+### The read shape
+
+The agent DTO's workspace mirrors **persisted** state — the provenance fixed at
+the last workspace write (§9), never a live re-derivation:
+
+```ts
+{ mode: 'scratch' }
+{ mode: 'git', gitRepo, gitBranch, agentDir?, worktree,
+  credential?: { provider: 'github', access: 'read' | 'write' }
+             | { provider: 'gitlab', access: 'read' | 'write', projectId } }
+```
+
+The console renders an existing workspace from this shape alone. Rendering
+through the live resolver instead would silently re-badge an anonymous
+workspace the moment its owner installs the App — exactly the auto-upgrade §9
+rules out. The resolve endpoint below exists for **picking**, i.e. previewing a
+prospective write; it is never consulted to display a stored workspace.
+
 ### The resolve endpoint
 
 `GET /orgs/:orgId/git/resolve?gitRepo=…` runs the same derivation the write
-paths run and returns the outcome — provider, access ceiling, canonical
-address, default branch — for the console's badges and branch defaults. Because
-the routes and the UI preview call one function, the picker can no longer
-disagree with the write path about what a pick means. It also replaces the
-console's browser-direct `api.github.com` reads (rate-limited, unauthenticated,
-and a second implementation of the server's rules) over time.
+paths run — for the **authenticated caller**, since eligibility is per-user
+(§6) — and returns the outcome: provider, that caller's access ceiling,
+canonical address, default branch. The picker's badges and branch defaults come
+from it, so the picker can no longer disagree with the write path about what a
+pick means. It also replaces the console's browser-direct `api.github.com`
+reads (rate-limited, unauthenticated, and a second implementation of the
+server's rules) over time.
 
 ## 6. Credential derivation — one function, three callers
 
-`deriveWorkspaceCredential(orgId, gitRepo)`, called by the create route, the
-replace route, and the resolve endpoint. No other code decides provenance.
+`deriveWorkspaceCredential(orgId, actorUserId, gitRepo, requestedAccess?)`,
+called by the create route, the replace route, and the resolve endpoint. No
+other code decides provenance.
+
+The two inputs answer different questions and both are required. **Provenance**
+depends only on `(orgId, gitRepo)` — which installation or binding vouches.
+**Eligibility and tier** depend on the actor: where identity attestation is
+configured, the GitHub outcome runs `githubUserAuthz.assertAccess(actorUserId,
+installation, owner, repo, access)` inside the derivation, so two members of
+one organization can legitimately receive different ceilings — or a refusal —
+for the same address. The write paths pass the requested tier (unstated ⇒ the
+target's highest, §5) and are refused when the actor does not hold it; the
+resolve endpoint passes the authenticated caller and returns that caller's
+ceiling instead of enforcing one. Keeping the gate inside the one function is
+the point: an implementation that hoisted it back into a route would
+re-introduce exactly the route-local divergence this design removes.
 
 | Target                                                            | Outcome                                                                                                                                                                                                          |
 | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -169,7 +202,11 @@ provision-on-pick):
    routes on the unified input, the resolve endpoint. Spec assembly
    dual-encodes: the `git` arm to daemons advertising `workspace-git-v1`, the
    legacy arms to everyone else — an old daemon must never receive a frame it
-   fatals on.
+   fatals on. Before dual encoding begins, every gate that branches on
+   `workspace.mode === 'gitlab'` today (the `requiredGitlabFeatures` checks at
+   direct placement and on the serving daemon, §17.3/§24.4 of the GitLab
+   design) re-keys onto `credential.provider === 'gitlab'`, or a `git`-mode
+   workspace would slip past the daemon-capability fence.
 4. **web**: the four tiles over the resolve endpoint; delete the browser-direct
    GitHub reads.
 5. **cleanup** once the fleet advertises the feature: drop the legacy arms and

--- a/docs/designs/github-app-git-credentials.md
+++ b/docs/designs/github-app-git-credentials.md
@@ -20,6 +20,11 @@
 > Credential-degradation telemetry and the corresponding web warnings remain
 > planned; the rest of this document states the current security contract.
 >
+> The workspace _shape_ this document assumes (a per-host `github` mode) is
+> being re-modeled into a host-neutral `git` mode with a credential union —
+> see [git-workspace-model.md](git-workspace-model.md). The credential track
+> here (installations, minting, gitcred) is unchanged by that design.
+>
 > This design solves two problems: (1) when selecting git mode for a workspace,
 > choose a repository directly in the console through the GitHub App instead of
 > manually entering a URL; and (2) when the daemon—and the coding agent running

--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -10,6 +10,11 @@
 > Scope: **GitLab.com Free and Premium**. GitLab Self-Managed, GitLab
 > Dedicated, and Ultimate-only capabilities are outside the v1 support
 > contract.
+>
+> The workspace _shape_ this document assumes (a per-host `gitlab` mode) is
+> being re-modeled into a host-neutral `git` mode with a credential union —
+> see [git-workspace-model.md](git-workspace-model.md). The credential track
+> here (bindings, per-agent accounts, gitcred v2) is unchanged by that design.
 
 This design adds GitLab.com as a first-class code-host provider with semantic
 parity to AgentConnect's current GitHub integration. The user experience is a


### PR DESCRIPTION
## What

The design for re-modeling the workspace contract from host-shaped modes
(`scratch | github | gitlab`) to a host-neutral `git` mode with a credential
union — plus pointer notes in the two provider design docs, whose credential
tracks (installations/minting/gitcred, bindings/per-agent accounts/gitcred v2)
are explicitly unchanged.

## Why now

Three shipped defects shared one root: the host-shaped discriminant forces two
routes and the console to each re-implement "who vouches for this repository".

- #1561 — replace refused the anonymous public repo creation accepted; the
  picker reported a foreign-account public repo as App-backed and the write
  path then refused its own picker's choice.
- #1567 — an unstated access tier meant `write` at creation, `read` on edit.

The daemon already runs the proposed model (`git-repo | from-scratch` + an
independent `gitCredential`) — it collapses the wire arms on arrival. The
design promotes that model to the wire, the CP, and the console.

## Shape (details in the doc)

- **Invariant:** `mode` answers "is there a repository"; `credential` answers
  "who vouches for it". A new code host is a new credential variant, never a
  new mode. "Anonymous + write" becomes unrepresentable.
- **One derivation function**, three callers: create, replace, and a
  `git/resolve` endpoint the console badges call — the picker can no longer
  disagree with the write path. `installationId`/`projectId` leave the API
  input; provenance is a server-side fact.
- **Console:** provider tiles stay (lexicon + guidance) and all produce the
  same payload; a "From a Git URL" tile and GitLab public-project candidates
  fall out of the neutral shape. The displayed tile is derived from
  host + credential, never stored.
- **Rollout:** readers-first behind a `workspace-git-v1` daemon feature with
  dual-encoding, so an old daemon never receives an arm it fatals on.

## Decided rules the doc records

- Provenance is fixed at write time, re-derived on the next workspace write,
  never auto-upgraded.
- Bare Git rides the anonymous arm ("host credentials"); a distinct `host`
  provider variant (with a pool-placement gate) is future work.
- Unstated `access` takes the highest tier the target carries (shipped, #1567).
- A covered owner's ungranted repository refuses; it never degrades to
  anonymous (from #1561 review).
- Bare `owner/repo` shorthand stays GitHub-only sugar; other hosts are written
  as full URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
