### PR TITLE
feat(web): default a new PR/MR subscription to every update

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.github.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.github.test.tsx
@@ -144,17 +144,17 @@ afterEach(async () => {
 })
 
 describe('AddIntegrationModal, GitHub trigger cadence', () => {
-  it('defaults every selected subject to the opened cadence', async () => {
+  it('defaults a pull-request subject to the any-update cadence', async () => {
     await renderAgent({ id: 'agent-default' })
 
-    // No cadence click: the form opens on "opened", pull requests only.
+    // No cadence click: the form opens on "any update", pull requests only.
     await act(async () => clickText('Connect')?.click())
 
     expect(mocks.createGithubHook).toHaveBeenCalledTimes(1)
     expect(mocks.createGithubHook).toHaveBeenCalledWith(
       expect.objectContaining({
         family: 'pull_request',
-        events: ['pull_request:opened'],
+        events: ['pull_request:*', 'issue_comment:created'],
         commentFamilies: ['pull_request'],
         mentionOnly: false
       })

--- a/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.gitlab.test.tsx
@@ -210,12 +210,12 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     expect(document.body.textContent).not.toContain('Couldn’t load your GitLab projects')
   })
 
-  it('defaults to the opened trigger, which subscribes to no notes', async () => {
+  it('defaults a merge-request subject to the any-update trigger, notes included', async () => {
     mocks.fetchGitlabProjects.mockResolvedValue([project])
     await render()
     await pickProject()
 
-    // No cadence click: the form opens on "opened", merge requests only.
+    // No cadence click: the form opens on "any update", merge requests only.
     await act(async () => clickText('Connect')?.click())
 
     expect(mocks.createGitlabHook).toHaveBeenCalledWith({
@@ -223,8 +223,8 @@ describe('AddIntegrationModal, GitLab trigger', () => {
       name: 'acme/platform',
       projectId: '4210',
       family: 'merge_request',
-      events: ['merge_request:opened'],
-      commentFamilies: [],
+      events: ['merge_request:*'],
+      commentFamilies: ['merge_request'],
       mentionOnly: false,
       // The review format opens on the full set, exactly like the github pane.
       reviewPolicy: 'full',
@@ -434,7 +434,7 @@ describe('AddIntegrationModal, GitLab trigger', () => {
     expect(mocks.createGitlabHook.mock.calls.map(([body]) => body.family)).toEqual(['issues', 'merge_request'])
     expect(mocks.createGitlabHook.mock.calls.flatMap(([body]) => body.events)).toEqual([
       'issues:opened',
-      'merge_request:opened'
+      'merge_request:*'
     ])
   })
 

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -66,10 +66,10 @@ import {
 import EditWorkspaceModal from './EditWorkspaceModal'
 import {
   GH_DEFAULT_FAMILIES,
-  GH_DEFAULT_TRIGGER_MODE,
   GH_FAMILIES,
   GH_TRIGGER_LABEL,
   famCovered,
+  githubDefaultTriggerMode,
   githubFamilyCarriesReviews,
   githubFamilySubscription,
   githubMentionUsage,
@@ -79,9 +79,9 @@ import {
 } from '@/lib/github-events'
 import {
   GL_DEFAULT_FAMILIES,
-  GL_DEFAULT_TRIGGER_MODE,
   GL_FAMILIES,
   GL_TRIGGER_LABEL,
+  gitlabDefaultTriggerMode,
   gitlabFamCovered,
   gitlabFamilyCarriesReviews,
   gitlabFamilySubscription,
@@ -451,9 +451,9 @@ export default function AddIntegrationModal({
   const [ghExactRepoLoading, setGhExactRepoLoading] = useState(false)
   const [ghFams, setGhFams] = useState<Set<GhFamily>>(new Set(GH_DEFAULT_FAMILIES))
   // Cadence is per SUBJECT — one hook row per family, each with its own trigger.
-  // Unset ⇒ the shared default, so a newly ticked family needs no seeding here.
+  // Unset ⇒ that family's default, so a newly ticked family needs no seeding here.
   const [ghModes, setGhModes] = useState<Partial<Record<GhFamily, GhTriggerMode>>>({})
-  const ghModeOf = (fam: GhFamily): GhTriggerMode => ghModes[fam] ?? GH_DEFAULT_TRIGGER_MODE
+  const ghModeOf = (fam: GhFamily): GhTriggerMode => ghModes[fam] ?? githubDefaultTriggerMode(fam)
   const [ghReviewPolicy, setGhReviewPolicy] = useState<HookReviewPolicy>('full')
   const [ghReportingMode, setGhReportingMode] = useState<HookReportingMode>('check')
   const [ghSyncing, setGhSyncing] = useState(false)
@@ -555,7 +555,7 @@ export default function AddIntegrationModal({
   const gl = useGitlabProjects(platform === 'gitlab', glQ)
   const [glFams, setGlFams] = useState<Set<GlFamily>>(new Set(GL_DEFAULT_FAMILIES))
   const [glModes, setGlModes] = useState<Partial<Record<GlFamily, GlTriggerMode>>>({})
-  const glModeOf = (fam: GlFamily): GlTriggerMode => glModes[fam] ?? GL_DEFAULT_TRIGGER_MODE
+  const glModeOf = (fam: GlFamily): GlTriggerMode => glModes[fam] ?? gitlabDefaultTriggerMode(fam)
   const [glReviewPolicy, setGlReviewPolicy] = useState<HookReviewPolicy>('full')
   const [glReportingMode, setGlReportingMode] = useState<HookReportingMode>('check')
 

--- a/packages/web/src/components/console/views/AgentDetailView.codehost.test.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.codehost.test.tsx
@@ -251,7 +251,7 @@ describe('AgentDetailView, code-host repository blocks', () => {
   })
 
   it('creates the missing family row at the default trigger', async () => {
-    // The same default the wizard opens a new subject on: the opening itself.
+    // The same default the wizard opens the subject on: every update, for a PR.
     const scope = await render()
     await act(async () => byTitle(scope, 'Watch another subject')[0]!.click())
     await act(async () => menuItem('Add Pull requests')!.click())
@@ -261,7 +261,7 @@ describe('AgentDetailView, code-host repository blocks', () => {
         agentId: 'agent-1',
         repoFullName: 'acme/web',
         family: 'pull_request',
-        events: ['pull_request:opened'],
+        events: ['pull_request:*', 'issue_comment:created'],
         commentFamilies: ['pull_request'],
         mentionOnly: false
       })

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -77,11 +77,11 @@ import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import type { Platform } from '@/components/console/modals/AddIntegrationModal'
 import { INTEGRATION_BLURB, PLATFORMS, isCoreTriggerKind } from '@/components/console/platforms/host-projections'
 import {
-  GL_DEFAULT_TRIGGER_MODE,
   GL_TRIGGER_MODES,
   GL_TRIGGER_PILL,
   gitlabCadencePick,
   gitlabCommentFamilies,
+  gitlabDefaultTriggerMode,
   gitlabFamilyCarriesReviews,
   gitlabFamilySubscription,
   gitlabFamilyTile,
@@ -103,10 +103,10 @@ import { consoleKeys } from '@/lib/swr-keys'
 import { acpRuntime, useAcpRegistry } from '@/lib/acp-registry'
 import { useSessionList } from '@/lib/use-session-list'
 import {
-  GH_DEFAULT_TRIGGER_MODE,
   GH_TRIGGER_MODES,
   GH_TRIGGER_PILL,
   githubCommentFamilies,
+  githubDefaultTriggerMode,
   githubFamilyCarriesReviews,
   githubFamilySubscription,
   githubFamilyTile,
@@ -484,7 +484,7 @@ export default function AgentDetailView() {
         name: seed.repoFullName,
         repoFullName: seed.repoFullName,
         family: fam,
-        ...githubFamilySubscription(fam, GH_DEFAULT_TRIGGER_MODE),
+        ...githubFamilySubscription(fam, githubDefaultTriggerMode(fam)),
         reviewPolicy: 'off',
         reportingMode: 'off',
         gateMode: 'informational'
@@ -507,7 +507,7 @@ export default function AgentDetailView() {
         name: seed.repoFullName ?? seed.name,
         projectId: seed.repoId,
         family: fam,
-        ...gitlabFamilySubscription(fam, GL_DEFAULT_TRIGGER_MODE),
+        ...gitlabFamilySubscription(fam, gitlabDefaultTriggerMode(fam)),
         reviewPolicy: 'off',
         reportingMode: 'off'
       })

--- a/packages/web/src/lib/github-events.test.ts
+++ b/packages/web/src/lib/github-events.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   commentFamiliesForFamilies,
   eventsForFamilies,
-  GH_DEFAULT_TRIGGER_MODE,
   GH_FAMILIES,
   GH_TRIGGER_LABEL,
   GH_TRIGGER_MODES,
   GH_TRIGGER_PILL,
+  githubDefaultTriggerMode,
   githubFamilyCarriesReviews,
   githubFamilySubscription,
   githubFamilyTile,
@@ -20,9 +20,12 @@ import {
 } from './github-events'
 
 describe('GH_TRIGGER_LABEL', () => {
-  it('opens every new subscription on the opening itself', () => {
-    expect(GH_DEFAULT_TRIGGER_MODE).toBe('first')
-    expect(GH_TRIGGER_LABEL[GH_DEFAULT_TRIGGER_MODE]).toBe('opened')
+  it('opens a pull-request subscription on every update and every other one on the opening', () => {
+    expect(githubDefaultTriggerMode('pull_request')).toBe('every')
+    expect(GH_TRIGGER_LABEL[githubDefaultTriggerMode('pull_request')]).toBe('any update')
+    expect(githubDefaultTriggerMode('issues')).toBe('first')
+    expect(githubDefaultTriggerMode('push')).toBe('first')
+    expect(GH_TRIGGER_LABEL[githubDefaultTriggerMode('issues')]).toBe('opened')
   })
 
   it('spells the cadences out for the create surfaces', () => {
@@ -146,11 +149,11 @@ describe('githubFamilySubscription', () => {
     })
   })
 
-  it('falls back to the default cadence for a family that has no label events', () => {
+  it('narrows to the opening for a family that has no label events', () => {
     // The console never offers `labeled` off the issues subject; a stray pick
-    // must not compile `pull_request:labeled`.
+    // must not compile `pull_request:labeled`, nor widen past what was picked.
     expect(githubFamilySubscription('pull_request', 'labeled')).toEqual(
-      githubFamilySubscription('pull_request', GH_DEFAULT_TRIGGER_MODE)
+      githubFamilySubscription('pull_request', 'first')
     )
   })
 

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -121,10 +121,10 @@ export function githubMentionUsage(agentName: string, teamOwner?: string | null)
 /** The default create-form selection: pull requests only. */
 export const GH_DEFAULT_FAMILIES: readonly GhFamily[] = ['pull_request']
 
-/** The default cadence every create surface opens a new subject on: the opening
- *  itself. The wizard's newly ticked family and the agent page's "add subject"
- *  read the same constant, so a subject starts the same way wherever it is made. */
-export const GH_DEFAULT_TRIGGER_MODE: GhTriggerMode = 'first'
+/** The cadence a create surface opens a new subject on — a change proposal on every update, the rest on the opening. */
+export function githubDefaultTriggerMode(fam: GhFamily): GhTriggerMode {
+  return fam === 'pull_request' ? 'every' : 'first'
+}
 
 /** The comment subscription that rides updated/mention-only modes for thread families. */
 export const THREAD_COMMENT_EVENT = 'issue_comment:created'
@@ -134,10 +134,9 @@ export function githubCommentFamilies(families: readonly HookCommentFamily[]): G
   return families.filter((family): family is GithubCommentFamily => family === 'issues' || family === 'pull_request')
 }
 
-/** A cadence a family cannot carry falls back to the shared default; only the
- *  issues-only `labeled` can reach this, and the console never offers it elsewhere. */
+/** A cadence a family cannot carry narrows to the opening, never widens — only issues-only `labeled` reaches this. */
 function effectiveMode(fam: GhFamily, mode: GhTriggerMode): GhTriggerMode {
-  return githubFamilySupportsMode(fam, mode) ? mode : GH_DEFAULT_TRIGGER_MODE
+  return githubFamilySupportsMode(fam, mode) ? mode : 'first'
 }
 
 /** Derive the explicit comment scope from the selected issue/PR families — a

--- a/packages/web/src/lib/gitlab-events.test.ts
+++ b/packages/web/src/lib/gitlab-events.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  GL_DEFAULT_TRIGGER_MODE,
   GL_FAMILIES,
   GL_TRIGGER_LABEL,
   GL_TRIGGER_MODES,
@@ -8,6 +7,7 @@ import {
   commentFamiliesForGitlabFamilies,
   eventsForGitlabFamilies,
   gitlabCadencePick,
+  gitlabDefaultTriggerMode,
   gitlabFamilyCarriesReviews,
   gitlabFamilySubscription,
   gitlabFamilyTile,
@@ -25,9 +25,12 @@ describe('GL_TRIGGER_LABEL', () => {
     expect(GL_TRIGGER_LABEL.mention).toBe('@-mention')
   })
 
-  it('opens every new subscription on the opening itself', () => {
-    expect(GL_DEFAULT_TRIGGER_MODE).toBe('first')
-    expect(GL_TRIGGER_LABEL[GL_DEFAULT_TRIGGER_MODE]).toBe('opened')
+  it('opens a merge-request subscription on every update and every other one on the opening', () => {
+    expect(gitlabDefaultTriggerMode('merge_request')).toBe('every')
+    expect(GL_TRIGGER_LABEL[gitlabDefaultTriggerMode('merge_request')]).toBe('any update')
+    expect(gitlabDefaultTriggerMode('issues')).toBe('first')
+    expect(gitlabDefaultTriggerMode('push')).toBe('first')
+    expect(GL_TRIGGER_LABEL[gitlabDefaultTriggerMode('issues')]).toBe('opened')
   })
 
   it('offers no label cadence — GitLab label events are not subscribed here', () => {

--- a/packages/web/src/lib/gitlab-events.ts
+++ b/packages/web/src/lib/gitlab-events.ts
@@ -103,9 +103,10 @@ export function gitlabMentionUsage(agentName: string): string {
 /** The default create-form selection: merge requests only. */
 export const GL_DEFAULT_FAMILIES: readonly GlFamily[] = ['merge_request']
 
-/** The default cadence every create surface opens a new subject on: the opening
- *  itself, exactly as the GitHub side does. */
-export const GL_DEFAULT_TRIGGER_MODE: GlTriggerMode = 'first'
+/** The cadence a create surface opens a new subject on — a merge request on every update, the rest on the opening. */
+export function gitlabDefaultTriggerMode(fam: GlFamily): GlTriggerMode {
+  return fam === 'merge_request' ? 'every' : 'first'
+}
 
 /** Narrow a stored cross-host comment scope to the GitLab families a gitlab hook may carry. */
 export function gitlabCommentFamilies(families: readonly HookCommentFamily[]): GitlabCommentFamily[] {


### PR DESCRIPTION
## What

A newly created code-host subscription now opens on **any update** for the change-proposal subject — GitHub pull requests and GitLab merge requests — instead of on the opening. Issues are unchanged: they still start on `opened`.

## Why

Both create surfaces opened every new subject on the `opened` cadence, so a freshly connected repository ran the agent once when a PR or MR was filed and then stayed silent on the pushes and replies that follow — the updates a reviewing agent actually exists for. The opening is the right default for an issue, where the filing is the event that matters; it is the wrong one for a change proposal.

## How

The shared per-host constant becomes a per-family helper:

- `GH_DEFAULT_TRIGGER_MODE` → `githubDefaultTriggerMode(fam)` — `pull_request` → `every`, everything else → `first`
- `GL_DEFAULT_TRIGGER_MODE` → `gitlabDefaultTriggerMode(fam)` — `merge_request` → `every`, everything else → `first`

Both create surfaces read the same helper, so a subject starts the same way wherever it is made: the wizard's per-family cadence (`ghModeOf` / `glModeOf` in `AddIntegrationModal`) and the agent page's "Watch another subject" (`addGithubFamily` / `addGitlabFamily` in `AgentDetailView`).

## For the reviewer

One deliberate tightening rides along. `effectiveMode` in `github-events.ts` used to fall back to the shared default for a cadence a family cannot carry — reachable only by the issues-only `labeled` mode. With a per-family default that fallback would have quietly widened a stray `pull_request` + `labeled` pick from `pull_request:opened` to `pull_request:*`, so it now names `'first'` outright: a fallback may narrow, never widen.

Stored rows are untouched — this changes only what a *new* subscription starts as. Existing hooks keep their cadence, and nothing normalizes them implicitly.

Full web suite green (189 files / 2142 tests), plus typecheck, lint and format.
