### PR TITLE
feat(slack): drop the status chrome's cancel controls

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9944,7 +9944,7 @@ export class Daemon {
       entry,
       conv,
       rec,
-      chrome: { statusCancellable: true },
+      chrome: {},
       reply: {
         text: '',
         attemptText: '',
@@ -11829,7 +11829,7 @@ export class Daemon {
    *  controls modal on click. Undefined on unknown key. */
   private async statusInfoForKey(
     sessionKey: string
-  ): Promise<{ info: StatusBarInfo; identity: StatusModalIdentity; link?: string; cancellable: boolean } | undefined> {
+  ): Promise<{ info: StatusBarInfo; identity: StatusModalIdentity; link?: string } | undefined> {
     const rec = await this.store.getSession(sessionKey)
     if (!rec) return undefined
     const info = await this.statusInfoFrom(rec.agentId, sessionKey, rec.acpSessionId ?? undefined, { breakdown: true })
@@ -11845,17 +11845,13 @@ export class Daemon {
     }
     const outward = rec.sessionId ?? rec.acpSessionId
     const link = outward ? this.sessionLink(outward, 'slack') : undefined
-    const pending = [...this.pending.values()].find((turn) => turn.plan.sessionKey === sessionKey)
-    const cancellable = pending?.chrome.statusCancellable ?? this.inflight.has(sessionKey)
-    return { info, identity, ...(link ? { link } : {}), cancellable }
+    return { info, identity, ...(link ? { link } : {}) }
   }
 
-  /** Close the turn out on the persistent Slack status row — the final usage snapshot, and
-   *  the flag that keeps Session options' Cancel turn out of a modal opened afterwards —
+  /** Close the turn out on the persistent Slack status row — the final usage snapshot —
    *  without reviving suppressed turn output. */
   private async settleStatusBar(p: Pending): Promise<void> {
     const emitted = p.chrome.lastStatusBar !== undefined
-    p.chrome.statusCancellable = false
     if (turnChromeFor(p.plan.platform).statusSurface === 'turn-bar' && emitted) await this.emitStatusBar(p, true, true)
   }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11027,7 +11027,7 @@ export class Daemon {
     // reaches cleanup. Clear its host-kill backstop BEFORE awaiting renderer I/O;
     // renderer drain is tracked separately by this dispatch/safety lease.
     this.clearCancelBackstop(agentId, sessionId)
-    // Remove Cancel run before releasing the Slack transport. Suppressed turns still
+    // Settle the status row before releasing the Slack transport. Suppressed turns still
     // allow this one terminal chrome update; ordinary queued output remains blocked.
     await this.settleStatusBar(p)
     await p.signals.applyChain.catch(() => {})
@@ -11850,11 +11850,13 @@ export class Daemon {
     return { info, identity, ...(link ? { link } : {}), cancellable }
   }
 
-  /** Settle the persistent Slack status row without reviving suppressed turn output. */
+  /** Close the turn out on the persistent Slack status row — the final usage snapshot, and
+   *  the flag that keeps Session options' Cancel turn out of a modal opened afterwards —
+   *  without reviving suppressed turn output. */
   private async settleStatusBar(p: Pending): Promise<void> {
     const emitted = p.chrome.lastStatusBar !== undefined
     p.chrome.statusCancellable = false
-    if (turnChromeFor(p.plan.platform).statusSurface === 'turn-bar' && emitted) await this.emitStatusBar(p, true)
+    if (turnChromeFor(p.plan.platform).statusSurface === 'turn-bar' && emitted) await this.emitStatusBar(p, true, true)
   }
 
   /** Emit/refresh the session's status bar (model / context / tokens / cost). Called at
@@ -11865,7 +11867,7 @@ export class Daemon {
    *  Telegram has NO status bar — state is queried on
    *  demand via `/status` (see handleCommand) — so it's skipped here. Headless no-ops in
    *  applyAction (no connection), which is fine. */
-  private async emitStatusBar(p: Pending, allowWhenSuppressed = false): Promise<void> {
+  private async emitStatusBar(p: Pending, allowWhenSuppressed = false, terminal = false): Promise<void> {
     if (p.outputSuppressed && !allowWhenSuppressed) return
     const statusSurface = turnChromeFor(p.plan.platform).statusSurface
     if (statusSurface === 'turn-bar' && !p.plan.showStatusBar) {
@@ -11876,7 +11878,9 @@ export class Daemon {
       return
     }
     const info = await this.buildStatusInfo(p)
-    const key = JSON.stringify([info, statusSurface === 'turn-bar' ? p.chrome.statusCancellable : null])
+    // `terminal` keeps the turn's closing write distinct from every in-turn one, so it always
+    // lands: it carries the final usage and reposts a bar whose ts an edit proved dead.
+    const key = JSON.stringify([info, terminal])
     if (key === p.chrome.lastStatusBar) return // unchanged since the last emit — no-op
     if (p.webchat) {
       // Webchat: skip a truly-empty frame (nothing for the web bar to show); the model /
@@ -11922,7 +11926,7 @@ export class Daemon {
         {
           kind: 'status-bar',
           text: renderStatusBar(info),
-          blocks: buildStatusBlocks(info, p.plan.sessionKey, link, shared, p.chrome.statusCancellable)
+          blocks: buildStatusBlocks(info, p.plan.sessionKey, link, shared)
         },
         { allowWhenSuppressed }
       )

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -435,12 +435,12 @@ export interface TurnChromeCursors {
    *  session row so later turns update the first line instead of posting duplicates. */
   statusBarTs?: string
   statusBarAttempted?: boolean
-  /** Dedup key for the last status snapshot + cancel availability emitted this turn, so
-   *  a `usage_update` that changes nothing observable skips a redundant edit. */
+  /** Dedup key for the last status snapshot emitted this turn, so a `usage_update` that
+   *  changes nothing observable skips a redundant edit. */
   lastStatusBar?: string
-  /** Whether the Slack status controls may still interrupt this turn. Cleared as soon as
-   *  cancellation starts or terminal cleanup begins, then included in the dedup key so
-   *  the persisted status row drops its stale Cancel run option. */
+  /** Whether the Slack status controls may still interrupt this turn — gates Cancel turn in
+   *  the Session options modal. Cleared as soon as cancellation starts or terminal cleanup
+   *  begins, so a modal opened afterwards offers nothing stale. */
   statusCancellable: boolean
 }
 

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -438,10 +438,6 @@ export interface TurnChromeCursors {
   /** Dedup key for the last status snapshot emitted this turn, so a `usage_update` that
    *  changes nothing observable skips a redundant edit. */
   lastStatusBar?: string
-  /** Whether the Slack status controls may still interrupt this turn — gates Cancel turn in
-   *  the Session options modal. Cleared as soon as cancellation starts or terminal cleanup
-   *  begins, so a modal opened afterwards offers nothing stale. */
-  statusCancellable: boolean
 }
 
 /** What one turn has said so far: the raw stream, the generation-local attempt held behind

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -285,11 +285,11 @@ export interface SlackDeps {
     outputMode?: 'none' | 'minimal' | 'low' | 'medium' | 'high'
   }) => void
   /** Synchronous getter into the daemon (source of truth) for a session's agent identity,
-   *  current status snapshot, deep link, and cancel availability — used to build the
-   *  Configure controls modal on demand. Undefined for an unknown/closed session key. */
+   *  current status snapshot, and deep link — used to build the Configure controls modal on
+   *  demand. Undefined for an unknown/closed session key. */
   onStatusInfo?: (
     sessionKey: string
-  ) => Promise<{ info: StatusBarInfo; identity?: StatusModalIdentity; link?: string; cancellable: boolean } | undefined>
+  ) => Promise<{ info: StatusBarInfo; identity?: StatusModalIdentity; link?: string } | undefined>
   /** Resolve the exact local session owned by the selected Slack conversation, awaited
    *  before the one-shot shortcut trigger opens its modal. */
   onMessageShortcut?: (a: { channel: string; thread: string; userId: string }) => Promise<string | undefined>
@@ -1012,7 +1012,7 @@ export class SlackConnection implements PlatformConnection {
         trigger_id: triggerId,
         view:
           data && sessionKey
-            ? buildStatusModal(data.info, sessionKey, data.link, privateMetadata, data.cancellable, data.identity)
+            ? buildStatusModal(data.info, sessionKey, data.link, privateMetadata, data.identity)
             : buildStatusUnavailableModal()
       })
     } catch (err) {

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -569,27 +569,25 @@ export interface SharedStatusActions {
   shareable: boolean
 }
 
-/** Build the compact in-thread status message. Both dedicated and shared bots use
- *  one overflow accessory so the status stays on a single row. A SHAREABLE (multi-agent)
- *  bot also exposes Switch agent; Cancel run is present only while the current turn can
- *  still be interrupted. */
+/** Build the compact in-thread status message. Both dedicated and shared bots use one
+ *  overflow accessory so the status stays on a single row; a SHAREABLE (multi-agent) bot
+ *  also exposes Switch agent. Interrupting a turn is Slack's own Stop control or Session
+ *  options' Cancel turn — the overflow carries no cancel item. */
 export function buildStatusBlocks(
   info: StatusBarInfo,
   sessionKey: string,
   link?: string,
-  shared?: SharedStatusActions,
-  cancellable = false
+  shared?: SharedStatusActions
 ): unknown[] {
   const text = `${renderStatusBar(info)}${link ? `  ·  <${link}|View Session>` : ''}`
   const target = shared?.sessionTarget ?? sessionKey
-  const option = (label: string, action: 'switch-agent' | 'manage' | 'cancel') => ({
+  const option = (label: string, action: 'switch-agent' | 'manage') => ({
     text: { type: 'plain_text', text: label },
     value: encodeSlackStatusOverflowValue(action)
   })
   const options = [
     ...(shared?.shareable ? [option('Switch agent', 'switch-agent')] : []),
-    option('Session options', 'manage'),
-    ...(cancellable ? [option('Cancel run', 'cancel')] : [])
+    option('Session options', 'manage')
   ]
   return [
     {

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -636,14 +636,14 @@ export function buildStatusUnavailableModal(): Record<string, unknown> {
  * stream). `private_metadata` carries either the direct session key or a shared-bot
  * routing target so the modal's `block_actions` resolve the session. The modal stays
  * compact: identity + View-session share one line, related selectors render two per
- * row, and usage uses label-over-value fields. Cancel appears only while the turn is active.
+ * row, and usage uses label-over-value fields. Interrupting a turn is Slack's own Stop
+ * control — the modal carries no cancel button.
  */
 export function buildStatusModal(
   info: StatusBarInfo,
   sessionKey: string,
   link?: string,
   privateMetadata = sessionKey,
-  cancellable = false,
   identity?: StatusModalIdentity
 ): Record<string, unknown> {
   const blocks: unknown[] = []
@@ -823,21 +823,6 @@ export function buildStatusModal(
     if (blocks.length) blocks.push({ type: 'divider' })
     if (summaryFields.length) blocks.push({ type: 'section', fields: summaryFields })
     if (breakdownFields.length) blocks.push({ type: 'section', fields: breakdownFields })
-  }
-
-  if (cancellable) {
-    blocks.push({
-      type: 'actions',
-      elements: [
-        {
-          type: 'button',
-          action_id: STATUS_ACTION.cancel,
-          text: { type: 'plain_text', text: 'Cancel turn' },
-          style: 'danger',
-          value: sessionKey
-        }
-      ]
-    })
   }
 
   return {

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -574,8 +574,7 @@ describe('SlackConnection membership events', () => {
             iconUrl: 'https://app/icons/review-bot.png',
             sessionTitle: 'Fix login flow'
           },
-          link: `https://app/s/${k}`,
-          cancellable: true
+          link: `https://app/s/${k}`
         })
       } as any,
       () => fakeAppWithEvents(handlers, actions, opened) as any
@@ -645,8 +644,7 @@ describe('SlackConnection membership events', () => {
         onMessageShortcut: resolve,
         onStatusInfo: (key: string) => ({
           info: { model: 'opus-4.8' },
-          link: `https://app/s/${key}`,
-          cancellable: false
+          link: `https://app/s/${key}`
         })
       } as any,
       () => fakeAppWithEvents(new Map(), new Map(), opened, shortcuts) as any
@@ -699,8 +697,7 @@ describe('SlackConnection membership events', () => {
         ...deps(),
         onStatusInfo: (k: string) => ({
           info: { model: 'opus-4.8' },
-          link: `https://app/s/${k}`,
-          cancellable: true
+          link: `https://app/s/${k}`
         })
       } as any,
       () => fakeAppWithEvents(new Map(), new Map(), opened) as any

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -2286,10 +2286,8 @@ describe('Slack interactive status bar', () => {
     expect(data.identity.sessionTitle).toBeUndefined()
     await (daemon as any).store.setSessionTitle(SESSION_KEY, 'Fix login flow')
     expect((await (daemon as any).statusInfoForKey(SESSION_KEY)).identity.sessionTitle).toBe('Fix login flow')
-    expect(data.cancellable).toBe(true)
     release()
     await t1
-    expect((await (daemon as any).statusInfoForKey(SESSION_KEY)).cancellable).toBe(false)
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1505,9 +1505,11 @@ describe('Slack interactive status bar', () => {
     // The status line uses the selected agent identity even in DMs, and remains marked as
     // chrome so a peer daemon's thread backfill skips it.
     expect(conn.postBlocks.mock.calls[0]?.[4]).toEqual(STATUS_BAR_POST_OPTIONS)
-    expect(statusActions(conn.postBlocks.mock.calls[0]![1] as any[])).toEqual(['manage', 'cancel'])
+    expect(statusActions(conn.postBlocks.mock.calls[0]![1] as any[])).toEqual(['manage'])
     release()
     await t1
+    // The turn's closing write still lands, and no emission ever offers a cancel item —
+    // interrupting is Slack's own Stop control, or Cancel turn inside Session options.
     const settledStatus = [...conn.updateBlocks.mock.calls]
       .reverse()
       .find((call) => statusActions(call[2] as any[]) !== undefined)
@@ -1664,7 +1666,7 @@ describe('Slack interactive status bar', () => {
       action_id: SLACK_STATUS_ACTION.more
     })
     const choices = section!.accessory.options.map((o: any) => decodeSlackStatusOverflowValue(o.value)?.action)
-    expect(choices).toEqual(['switch-agent', 'manage', 'cancel'])
+    expect(choices).toEqual(['switch-agent', 'manage'])
     expect(decodeSharedSlackStatusTarget(section!.block_id!)).toEqual({
       v: 1,
       agentId: 'bot-a',
@@ -1708,9 +1710,9 @@ describe('Slack interactive status bar', () => {
     const [section] = blocks
 
     const choices = section!.accessory.options.map((o: any) => decodeSlackStatusOverflowValue(o.value)?.action)
-    expect(choices).toEqual(['manage', 'cancel']) // no 'switch-agent'
+    expect(choices).toEqual(['manage']) // no 'switch-agent'
     // Overflow still routes through the relay (the block_id is the encoded session target),
-    // so Session options / Cancel run keep working for a single-agent http bot.
+    // so Session options keeps working for a single-agent http bot.
     expect(decodeSharedSlackStatusTarget(section!.block_id!)).toEqual({
       v: 1,
       agentId: 'bot-a',
@@ -2364,7 +2366,7 @@ describe('Slack interactive status bar', () => {
     })
     await daemon.start()
     ;(daemon as any).agents.get('bot-a').allowRuntimeChangesInChat = true
-    const conn = routableWithBlocks(daemon)
+    routableWithBlocks(daemon)
     const store = (daemon as any).store
     const key = SESSION_KEY
 
@@ -2380,12 +2382,6 @@ describe('Slack interactive status bar', () => {
     await (daemon as any).commands.handleStatusAction({ kind: 'cancel', sessionKey: key })
     expect(host.cancel).toHaveBeenCalledWith('acp-1')
     expect(await store.isSessionMuted(key)).toBe(false)
-    await vi.waitFor(() => {
-      const settledStatus = [...conn.updateBlocks.mock.calls]
-        .reverse()
-        .find((call) => statusActions(call[2] as any[]) !== undefined)
-      expect(statusActions(settledStatus?.[2] as any[])).toEqual(['manage'])
-    }, WAIT)
 
     release()
     await t1

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -976,7 +976,6 @@ describe('buildStatusModal (Configure controls modal)', () => {
       KEY,
       'https://app/sessions/acp-1',
       KEY,
-      true,
       {
         name: 'Review Bot',
         agentUrl: 'https://app/agents/review-bot',
@@ -1031,11 +1030,13 @@ describe('buildStatusModal (Configure controls modal)', () => {
       '*Cache read* · *Cache write*\n1.2M · 800'
     ])
 
-    const cancel = (view.blocks as any[])
-      .filter((b) => b.type === 'actions')
-      .flatMap((b) => b.elements)
-      .find((element) => element.action_id === 'ac_cancel')
-    expect(cancel).toMatchObject({ type: 'button', action_id: 'ac_cancel', value: KEY, style: 'danger' })
+    // Interrupting a turn is Slack's own Stop control — the modal offers no cancel button.
+    expect(
+      (view.blocks as any[])
+        .filter((b) => b.type === 'actions')
+        .flatMap((b) => b.elements)
+        .map((element: any) => element.action_id)
+    ).not.toContain('ac_cancel')
   })
 
   it('keeps both cache columns when the runtime omits cache-write usage', () => {
@@ -1047,7 +1048,7 @@ describe('buildStatusModal (Configure controls modal)', () => {
     expect(cache.text).toBe('*Cache read* · *Cache write*\n15K · —')
   })
 
-  it('omits the select and terminal actions when the session is idle with no link', () => {
+  it('omits the selects when the session is idle with no link', () => {
     const view = buildStatusModal({ model: 'sonnet-5', totalTokens: 10 }, KEY)
     expect(
       (view.blocks as Block[]).some(

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -860,9 +860,7 @@ describe('buildStatusBlocks (compact in-thread line)', () => {
     const [section, ...rest] = buildStatusBlocks(
       { model: 'opus-4.8', models: ['opus-4.8', 'sonnet-5'], contextUsed: 120_000, contextSize: 200_000 },
       KEY,
-      'https://app/sessions/acp-1',
-      undefined,
-      true
+      'https://app/sessions/acp-1'
     ) as any[]
     expect(rest).toHaveLength(0)
     expect(section.type).toBe('section')
@@ -873,8 +871,7 @@ describe('buildStatusBlocks (compact in-thread line)', () => {
       accessory: { type: 'overflow', action_id: SLACK_STATUS_ACTION.more }
     })
     expect(section.accessory.options.map((o: any) => decodeSlackStatusOverflowValue(o.value)?.action)).toEqual([
-      'manage',
-      'cancel'
+      'manage'
     ])
   })
 
@@ -895,16 +892,10 @@ describe('buildStatusBlocks (compact in-thread line)', () => {
       integrationId: '22222222-2222-4222-8222-222222222222',
       sessionKey: `slack:C1234567890:1720000000.000100:${agentId}`
     })
-    const [section, ...rest] = buildStatusBlocks(
-      { model: 'x' },
-      KEY,
-      'https://app/sessions/acp-1',
-      {
-        sessionTarget,
-        shareable: true
-      },
-      true
-    ) as any[]
+    const [section, ...rest] = buildStatusBlocks({ model: 'x' }, KEY, 'https://app/sessions/acp-1', {
+      sessionTarget,
+      shareable: true
+    }) as any[]
     const [dedicatedSection] = buildStatusBlocks({ model: 'x' }, KEY, 'https://app/sessions/acp-1') as any[]
 
     expect(rest).toHaveLength(0)
@@ -921,14 +912,9 @@ describe('buildStatusBlocks (compact in-thread line)', () => {
     expect(section.text.text).toContain('<https://app/sessions/acp-1|View Session>')
     expect(section.accessory.options.map((o: any) => decodeSlackStatusOverflowValue(o.value)?.action)).toEqual([
       'switch-agent',
-      'manage',
-      'cancel'
+      'manage'
     ])
-    expect(section.accessory.options.map((o: any) => o.text.text)).toEqual([
-      'Switch agent',
-      'Session options',
-      'Cancel run'
-    ])
+    expect(section.accessory.options.map((o: any) => o.text.text)).toEqual(['Switch agent', 'Session options'])
     expect(section.block_id.length).toBeLessThanOrEqual(255)
     for (const option of section.accessory.options) expect(option.value.length).toBeLessThanOrEqual(150)
   })
@@ -941,25 +927,18 @@ describe('buildStatusBlocks (compact in-thread line)', () => {
       integrationId: '22222222-2222-4222-8222-222222222222',
       sessionKey: `slack:C1234567890:1720000000.000100:${agentId}`
     })
-    const [section] = buildStatusBlocks(
-      { model: 'x' },
-      KEY,
-      'https://app/sessions/acp-1',
-      {
-        sessionTarget,
-        shareable: false
-      },
-      true
-    ) as any[]
+    const [section] = buildStatusBlocks({ model: 'x' }, KEY, 'https://app/sessions/acp-1', {
+      sessionTarget,
+      shareable: false
+    }) as any[]
 
-    // Overflow still targets the relay (block_id == sessionTarget), so Session options /
-    // Cancel run keep working — only the multi-agent "Switch agent" option is dropped.
+    // Overflow still targets the relay (block_id == sessionTarget), so Session options keeps
+    // working — only the multi-agent "Switch agent" option is dropped.
     expect(section.block_id).toBe(sessionTarget)
     expect(section.accessory.options.map((o: any) => decodeSlackStatusOverflowValue(o.value)?.action)).toEqual([
-      'manage',
-      'cancel'
+      'manage'
     ])
-    expect(section.accessory.options.map((o: any) => o.text.text)).toEqual(['Session options', 'Cancel run'])
+    expect(section.accessory.options.map((o: any) => o.text.text)).toEqual(['Session options'])
   })
 })
 


### PR DESCRIPTION
Slack's chrome no longer offers a cancel control anywhere. The in-thread status row's overflow keeps only **Switch agent** (shareable bots) and **Session options**, and the Session options modal keeps only its selectors and usage. Interrupting a turn is the platform's own **Stop** on the working row, or `!cancel` / `!stop`.

## What was removed

- The overflow's `Cancel run` item, and `buildStatusBlocks`' `cancellable` parameter.
- The modal's red `Cancel turn` button, and `buildStatusModal`' `cancellable` parameter.
- `Pending.chrome.statusCancellable` in full — those two controls were its only readers — together with its per-turn initialization, the flip in `settleStatusBar`, and the `cancellable` field threaded from `statusInfoForKey` through the connection's `onStatusInfo`.

## What was NOT removed

Nothing on the receiving side. `SLACK_STATUS_ACTION.cancel`, the `ac_cancel` handler, the `ac_more` cancel branch, the relay's parsing of both, and the `kind: 'cancel'` status action are all untouched — for two reasons:

- A status row posted before this change keeps its rendered option forever (its blocks live in Slack, not here), and clicking it must still work.
- The native Stop *is* a `kind: 'cancel'` status action: `agent_session_stopped` resolves the displayed turn and raises exactly the verb the button used to raise. So does webchat's cancel frame. Deleting the render is not deleting the verb.

## The turn's closing status write

That write used to ride on `statusCancellable` flipping in the dedup key — the row varied by it, so the flip forced one final emit. With the option gone the row no longer varies by the flag, and the write was silently deduped away (caught by the existing "drops a persisted status-bar ts when Slack rejects the update, and reposts" test, which depends on it).

It is now explicit: `emitStatusBar(p, allowWhenSuppressed, terminal)` keeps the closing write distinct from every in-turn one. It still lands exactly once, still carries the final usage, and still reposts a bar whose ts an edit proved dead. `terminal` is only ever true for a `statusSurface: 'turn-bar'` platform, which is Slack alone, so every other surface's dedup key behaves exactly as before.

## Other platforms

Untouched. Feishu's Cancel run lives in its own reply card and its own callback; Telegram and Discord have no status bar and cancel by text command; webchat cancels over its browser frame.

## Verification

`typecheck`, `lint` and `format` are clean. The daemon suite reports the same 4 files failing before and after — the sandbox shim tests (`shim-cancellation`, `shim-exec-handler`, `shim-workspace-files`, no sandbox available here) and `acp-matrix`, which drives live external runtimes that are out of quota or no longer serving. None of them import the modules this touches.
