### PR TITLE
feat(daemon): name a Slack plan card's steps, and give a high step its code block

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -33,7 +33,7 @@ in order to move an answer between transports is gone with it (§9).
 medium/high turns; change **nothing** about the body (post / live-reply / final-live-reply,
 response finalization by edit, the attribution footer, the transcript, the status bar, the
 transient status text, permission and elicitation cards, attachments, the ACP plan message, the
-high-mode Thinking message, tool-output code blocks); degrade to today's `progress` message
+high-mode Thinking message); degrade to today's `progress` message
 wherever streaming is unavailable, from Slack's own errors, with no config knob and no environment
 kill switch; and leave Layer 0's stop seam, `setSessionLifecycle`, the manifest, the relay, the
 control plane, the protocol, and every other platform alone.
@@ -128,6 +128,27 @@ contradict the published documentation, and two of them changed the design.
    cron, hook, dream — names the bot's OWN user id and its team id, which Slack accepts. There
    is no structural carve-out for non-human turns.
 
+Four more from the 2026-08-29 pass, which is where the card BODY was settled:
+
+10. **A card with a body is expandable, and starts expanded.** `details` / `output` / `sources`
+    each give the card a chevron the reader can fold, and there is no field that sets the
+    initial state: `collapsed`, `expanded`, `is_expanded`, `default_expanded`,
+    `initially_expanded`, `collapsible`, `hide_details` and `details_display_mode` are all
+    accepted by the API and then silently discarded (they do not survive into the finalized
+    block). The only default fold is the plan container itself. Slack messages have no hover
+    affordance at all, so the chevron is the whole disclosure story.
+11. **`title` can be rewritten mid-stream**, which is what lets a card be opened as a
+    placeholder and renamed once the run names itself.
+12. **A body over the limit is dropped, not rejected.** 8,000 characters store and render; at
+    12,000 the append still answers `ok: true` and the field comes back empty. Long bodies do
+    get a native "Show more" after roughly six rendered lines, so height is Slack's problem —
+    length is ours.
+13. **`hide_title` and `icon` exist but are not for us.** `hide_title: true` replaces the row's
+    title with its details text and takes the chevron away; `icon` is an object
+    (`{ type, name }` where `name` is an image URL), and the plausible string form is rejected
+    outright. `@slack/types` 2.22.0 declares neither — the published reference is ahead of the
+    SDK, so neither is safe to take on type inference alone.
+
 ## 5. ACP → card mapping
 
 Slack's streaming chunk vocabulary, as `@slack/types` declares it, is
@@ -137,21 +158,34 @@ Slack's streaming chunk vocabulary, as `@slack/types` declares it, is
 `{ type: 'blocks', blocks }`. **This design sends no `markdown_text` chunk, ever.**
 
 **The fields do not all behave the same way, and that is the single most load-bearing detail.**
-`title` and `status` REPLACE per card id — re-send them as often as you like. `details`
-**appends** server-side, and `output` is written once at completion. Refreshing an appending
-field per update therefore concatenates on Slack's side instead of replacing it: streaming a
-thinking line into `details` on every chunk is what ran repeated `**bold**` fragments together
-into literal `****`, since card fields render as plain text and never interpret emphasis. The
-rule is **write-once for anything that appends**: `output` at completion, `details` never, and
-everything else expressed through `title` / `status`.
+`title` and `status` REPLACE per card id — re-send them as often as you like. `details`,
+`output` and `sources` all **append** server-side (measured 2026-08-29: the same field written
+twice comes back concatenated with no separator, and a second `sources` entry lands beside the
+first). Refreshing an appending field per update therefore concatenates on Slack's side instead
+of replacing it — which is how repeated `**bold**` fragments once ran together into literal
+`****`. The rule is **write-once for anything that appends**: the whole card body is emitted in
+ONE chunk, at completion, and everything live is expressed through `title` / `status`.
+
+`details` and `output` are **markdown**, not plain text — the earlier reading of the `****`
+incident was wrong. A fenced value renders as a real code block, backticks as inline code,
+`**bold**` as bold and `<url|text>` as a link. That is what makes the card body the shape the
+web console already uses: the **command in a code block** (`details`), its **result** below it
+(`output`). The two render identically and carry no labels of their own; only their order is
+fixed. `sources` renders under them as a list of links.
+
+**Both bodies are capped here, because Slack will not complain.** The documented 256-character
+limit is not what the API enforces: 8,000 characters store and render fine, and somewhere past
+that an oversized field comes back `ok: true` with the field SILENTLY EMPTY. Card bodies
+therefore take the same 2,800-character cap as the legacy tool-output block, and titles a much
+tighter one (below).
 
 | ACP `session/update`             | today                                              | with the chrome stream                                                                                                                                                                           |
 | -------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `agent_message_chunk`            | buffered → `post` / `live-reply`                   | **unchanged**                                                                                                                                                                                    |
 | `tool_call` / `tool_call_update` | in-place `progress` message + rotating status text | `task_update` keyed by `toolCallId`; ACP `pending`/`in_progress` → `in_progress`, `completed` → `complete`, `failed` → `error`. The status text is unchanged; the `progress` message is replaced |
-| `agent_thought_chunk`            | `high`: in-place Thinking message; status text     | plus ONE `task_update` per thinking run, `title: "Thinking"`, status only. `high` keeps its full in-place Thinking message, which is where 2,800 characters belong                               |
+| `agent_thought_chunk`            | `high`: in-place Thinking message; status text     | plus ONE `task_update` per thinking run, titled by the run's FIRST LINE, status only. `high` keeps its full in-place Thinking message, which is where 2,800 characters belong                    |
 | `plan`                           | in-place `plan` message                            | **unchanged** — an ACP plan is a full entry list with per-entry statuses, i.e. a checklist, not a one-line container label                                                                       |
-| tool output, terminal (`high`)   | separate code-block message                        | **unchanged**, plus the result written ONCE as the card's `output` (high only), clamped to 256 characters                                                                                        |
+| tool output, terminal (`high`)   | separate code-block message                        | the command and its result become the card's body (`details` + `output`, high only); the separate code-block message is **dropped on a streaming turn**, which would otherwise say it twice      |
 | `usage_update`                   | dropped                                            | dropped                                                                                                                                                                                          |
 
 **`task_display_mode: 'plan'`, fixed, never configurable.** Every task card is collected into
@@ -166,10 +200,28 @@ everything around it. The container's own arc:
 Counted rather than narrated, deliberately: it is derived from the cards the turn actually
 emitted, so it needs no second model call and cannot disagree with what is inside the container.
 
+**A card title is one line, and the daemon is what makes it one.** Slack wraps a long title
+into a paragraph instead of truncating it, offers no hover and no per-title disclosure, so a
+raw shell command as a title buries the step list — which is what a title straight off ACP is,
+because a shell tool's ACP title IS its command. Two sources, in order: the runtime's own
+one-line description when it sent one (`rawInput.description`, which Claude Code's shell tools
+carry), else the title clamped to 72 characters. The verbatim command is not lost — it is the
+card's code block on `high`, and it is skipped when the title already showed it whole.
+
+**A thinking card is titled by its run's first line.** Runtimes open a thought with a short
+`**heading**` — the same line the web console shows as the step title — so the card says what
+the agent is thinking about rather than the bare word "Thinking". The card is opened before
+that line has arrived and renamed once it has, which is free: `title` REPLACES per id. A run
+whose head yields nothing keeps the placeholder.
+
 **Output modes.** `none`, `minimal` and `low` have no tool chrome today and gain none: they
-never take the axis. `medium` gets card titles and statuses; `high` adds the card `output`.
-This is the same ladder the modes already express — the stream changes the transport of the
-medium/high rung, not which rung shows what.
+never take the axis. `medium` gets card titles and statuses — one line per step; `high` adds
+the card body, the command as a code block and its result beneath. This is the same ladder the
+modes already express — the stream changes the transport of the medium/high rung, not which
+rung shows what. It also decides how tall the container is once opened, and that is the only
+control there is: a card body cannot start collapsed. The reader can fold each one away, and
+the container itself is still collapsed by default, but no chunk field sets the initial state
+(§4 fact 10), so on `medium` a step stays a step.
 
 **DM and channel take the same code path.** The only difference is the recipient argument
 (§4 fact 9).
@@ -317,5 +369,7 @@ is indistinguishable from `streamingUnavailableUntil` being set.
 Two cosmetic questions stay open. **Does the counted label read well after a long turn?**
 `Completed 41 steps` is honest but not informative; a model-narrated label was rejected (a second
 call, and a label that can disagree with the cards), and the next candidate is the last tool's
-title. **Should a `failed` card carry its error text as `output` on medium?** Today `output` is a
-high-only rung, matching the legacy pipeline; the card already says `error`.
+title. **Should a `failed` card carry its error text as `output` on medium?** Today the body is a
+high-only rung, matching the legacy pipeline; the card already says `error`, and a body cannot
+start collapsed (§4 fact 10), so granting one to medium would cost every medium step its single
+line — the failed one included.

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -102,10 +102,15 @@ export type SlackAction =
  * `markdown_text` is ever sent — this stream carries chrome only.
  *
  * The FIELD SEMANTICS are not uniform, and that is the load-bearing fact here: `title` and
- * `status` REPLACE per id, but `details` APPENDS server-side. Refreshing an appending field
- * per update concatenates on Slack's side rather than replacing — which is how repeated
- * `**bold**` fragments ran together into literal `****`. Write-once fields only: `output` at
- * completion, and `details` never at all.
+ * `status` REPLACE per id, while `details` and `output` APPEND server-side. Refreshing an
+ * appending field per update concatenates on Slack's side rather than replacing — which is
+ * how repeated `**bold**` fragments once ran together into literal `****`. So both bodies are
+ * written EXACTLY ONCE, when the call completes; only `title` and `status` are ever refreshed.
+ *
+ * Both bodies are markdown (verified live 2026-08-29): a fenced value renders as a real code
+ * block, which is what puts the command in `details` and its result in `output`. Slack accepts
+ * far more than the documented 256 characters but SILENTLY DROPS an oversized field, so
+ * everything is capped here rather than trusting an error.
  */
 export type SlackStreamChunk =
   | {
@@ -113,6 +118,7 @@ export type SlackStreamChunk =
       id: string
       title: string
       status: 'in_progress' | 'complete' | 'error'
+      details?: string
       output?: string
     }
   // The collapsed container's own label. `plan` display mode renders every task card inside
@@ -136,6 +142,15 @@ const MAX_REASONING = 2800
 // Every streaming card field caps at 256 characters ON THE WIRE, per chunk. Because nothing
 // appending is ever re-sent, a clamped field is also the card's final size.
 const MAX_STREAM_TASK = 256
+// A card title is a ONE-LINE step label, so it is clamped far below the wire cap: Slack wraps
+// a long title into a paragraph of shell instead of truncating it, and there is no hover or
+// per-title disclosure to recover the rest. The verbatim command rides the card's code block.
+const MAX_CARD_TITLE = 72
+/** The card that stands for one thinking run until its first line names it. */
+const THINKING_CARD = 'Thinking'
+// How much of a thinking run to hold while waiting for its first line to end. A runtime opens
+// a thought with a short `**heading**`, so this only ever buffers one line's worth.
+const MAX_THINKING_HEAD = 400
 /** The collapsed container's label while the turn is still working (§4). */
 const STREAM_PLAN_WORKING = 'Working…'
 /** …and after a cancel, a user Stop, or suppression — the in-flight cards settle as errors. */
@@ -190,6 +205,16 @@ const MAX_TOOL_OUTPUT = 2800
 function capOutput(s: string): string {
   const t = s.trim()
   return t.length > MAX_TOOL_OUTPUT ? `${t.slice(0, MAX_TOOL_OUTPUT - 1)}…` : t
+}
+
+/** A tool call's `rawInput` field, when the runtime sent one as a string. MCP-shaped calls nest
+ *  the tool's own arguments one level down, so read both. */
+function rawInputField(update: { rawInput?: unknown }, key: 'command' | 'description'): string {
+  const raw = update.rawInput as Record<string, unknown> | undefined
+  if (!raw || typeof raw !== 'object') return ''
+  const args = raw.arguments as Record<string, unknown> | undefined
+  const value = typeof raw[key] === 'string' ? raw[key] : args && typeof args[key] === 'string' ? args[key] : ''
+  return typeof value === 'string' ? value.trim() : ''
 }
 
 /** Escape interpolated labels before embedding them in Slack mrkdwn. `|` is a link-label
@@ -894,13 +919,20 @@ export class OutputConverger {
   private emittedTasks = new Map<string, string>()
   private taskTitles = new Map<string, string>()
   private openTasks = new Set<string>()
-  /** Cards whose write-once `output` has been sent, so a later update cannot append a second. */
+  /** Cards whose write-once body has been sent, so a later update cannot append a second. */
   private outputWritten = new Set<string>()
   /** Cards that ended in error — the closing label counts these, never the model. */
   private failedTasks = new Set<string>()
-  // The current thinking run: whether one is open, and a counter so each gets its own card.
+  // A tool call's own one-line label and verbatim command, remembered from whichever update
+  // carried `rawInput` — a streamed `tool_call_update` usually carries none.
+  private toolDescriptions = new Map<string, string>()
+  private toolCommands = new Map<string, string>()
+  // The current thinking run: whether one is open, a counter so each gets its own card, and
+  // the head of its text until the first line names it.
   private thinkingActive = false
   private thinkingRun = 0
+  private thinkingHead = ''
+  private thinkingTitle = ''
   /** The container's label, so an unchanged one is never re-sent, plus the one awaiting the
    *  next append and the legacy `progress` text that append would degrade to. */
   private planTitle = ''
@@ -1018,21 +1050,31 @@ export class OutputConverger {
   /**
    * Queue one task card, keyed by id so streamed updates edit the same card and an unchanged
    * repeat emits nothing. `title` and `status` may be re-sent freely — Slack REPLACES them per
-   * id. `output` may not: it is written exactly once, at completion.
+   * id. The body may not: `details` and `output` both append, so they are written together
+   * exactly once, at completion. Callers pass the command and result RAW — the cap and the
+   * code fence belong here, where the wire limit is known.
    */
-  private queueTask(id: string, title: string, status: 'in_progress' | 'complete' | 'error', output = ''): void {
-    const clamped = clampTo(plainCardText(title), MAX_STREAM_TASK) || 'tool'
-    const writeOutput = output && !this.outputWritten.has(id) ? clampTo(plainCardText(output), MAX_STREAM_TASK) : ''
+  private queueTask(
+    id: string,
+    title: string,
+    status: 'in_progress' | 'complete' | 'error',
+    body: { command?: string; output?: string } = {}
+  ): void {
+    const clamped = clampTo(plainCardText(title), MAX_CARD_TITLE) || 'tool'
+    const fresh = !this.outputWritten.has(id)
+    const details = fresh && body.command ? codeSpan(capOutput(body.command), true) : ''
+    const output = fresh && body.output ? capOutput(body.output) : ''
     const chunk: Extract<SlackStreamChunk, { type: 'task_update' }> = {
       type: 'task_update',
       id,
       title: clamped,
       status,
-      ...(writeOutput ? { output: writeOutput } : {})
+      ...(details ? { details } : {}),
+      ...(output ? { output } : {})
     }
     const signature = `${chunk.title} ${chunk.status}`
-    if (!writeOutput && this.emittedTasks.get(id) === signature) return
-    if (writeOutput) this.outputWritten.add(id)
+    if (!details && !output && this.emittedTasks.get(id) === signature) return
+    if (details || output) this.outputWritten.add(id)
     this.emittedTasks.set(id, signature)
     this.taskTitles.set(id, clamped)
     if (status === 'error') this.failedTasks.add(id)
@@ -1062,14 +1104,50 @@ export class OutputConverger {
     return failed === 0 ? `Completed ${steps}` : `Completed ${steps} · ${failed} failed`
   }
 
+  private thinkingId(): string {
+    return `thinking-${this.thinkingRun}`
+  }
+
+  /**
+   * Title a thinking run from its FIRST LINE. Runtimes open a thought with a short
+   * `**heading**` — the same line the web console shows as the step's title — so the card can
+   * say what the agent is thinking about instead of the bare word "Thinking". The card opens
+   * before that line has arrived, which costs nothing: `title` REPLACES per id, so the
+   * placeholder is simply renamed (verified live 2026-08-29).
+   *
+   * Runs once per run, at the first newline or once the head is title-width, whichever comes
+   * first — a runtime that streams one unbroken paragraph still gets a title out of its head.
+   */
+  private noteThinkingTitle(thought: string): void {
+    if (this.thinkingTitle) return
+    this.thinkingHead = (this.thinkingHead + thought).slice(0, MAX_THINKING_HEAD)
+    const title = this.thinkingTitleFrom(false)
+    if (title) this.queueTask(this.thinkingId(), title, 'in_progress')
+  }
+
+  /** The run's title, resolved from its head, or '' while the first line could still grow.
+   *  `final` takes whatever the head holds — at settle time no more of it is coming, which is
+   *  what titles a short last thought that never reached a newline. */
+  private thinkingTitleFrom(final: boolean): string {
+    if (this.thinkingTitle) return this.thinkingTitle
+    // trimStart: a thought can open with blank lines, which must not resolve to a blank title.
+    const head = this.thinkingHead.trimStart()
+    const nl = head.indexOf('\n')
+    if (!final && nl < 0 && head.length < MAX_CARD_TITLE) return ''
+    this.thinkingTitle = clampTo(plainCardText(nl < 0 ? head : head.slice(0, nl)), MAX_CARD_TITLE)
+    return this.thinkingTitle
+  }
+
   /** A thinking run ends at the next tool call or at turn end — settle its card rather than
-   *  leaving a spinner behind. Title and status only: the thought text would have to ride
-   *  `details`, which appends server-side. */
+   *  leaving a spinner behind. Title and status only: the thought text itself belongs in
+   *  high mode's in-place Thinking message, which is where 2,800 characters fit. */
   private closeThinkingRun(status: 'complete' | 'error' = 'complete'): void {
     if (!this.thinkingActive) return
-    this.queueTask(`thinking-${this.thinkingRun}`, 'Thinking', status)
+    this.queueTask(this.thinkingId(), this.thinkingTitleFrom(true) || THINKING_CARD, status)
     this.thinkingActive = false
     this.thinkingRun += 1
+    this.thinkingHead = ''
+    this.thinkingTitle = ''
   }
 
   /** Flush pending output for the idle timer: in high mode one in-place `reasoning` update
@@ -1207,6 +1285,34 @@ export class OutputConverger {
     return (id && this.toolTitles.get(id)) ?? id ?? 'tool'
   }
 
+  /** Remember what a tool call's `rawInput` said about itself. Only some updates carry it — a
+   *  streamed `tool_call_update` usually does not — so the first one that does wins. */
+  private noteToolInput(update: { toolCallId?: string; rawInput?: unknown }): void {
+    const id = update.toolCallId
+    if (!id || update.rawInput === undefined) return
+    const description = rawInputField(update, 'description')
+    const command = rawInputField(update, 'command')
+    if (description && !this.toolDescriptions.has(id)) this.toolDescriptions.set(id, description)
+    if (command && !this.toolCommands.has(id)) this.toolCommands.set(id, command)
+  }
+
+  /** A card's one-line step label: the runtime's own description when it gave one, else the
+   *  tool title clamped. An ACP title for a shell tool IS the command, which reads as a
+   *  paragraph of shell on a card; a description ("List files in working directory") is the
+   *  line a reader actually wants, and is what the web console shows too. */
+  private cardTitle(id: string, label: string): string {
+    return this.toolDescriptions.get(id) || label
+  }
+
+  /** What the card's code block shows: the verbatim command, or the full title when that is
+   *  all the runtime gave. Skipped when the title already shows it whole — an untruncated
+   *  one-line label needs no code block repeating it. */
+  private cardCommand(id: string, label: string): string {
+    const command = this.toolCommands.get(id) || label
+    const title = clampTo(plainCardText(this.cardTitle(id, label)), MAX_CARD_TITLE)
+    return plainCardText(command) === title ? '' : command
+  }
+
   /** Refresh the newest output for one tool call. content/rawOutput are a whole replacement
    *  when present, so only touch the cache when this update actually carries them: set the
    *  newest text, or clear a stale entry if the replacement is empty / a non-text block. */
@@ -1274,11 +1380,14 @@ export class OutputConverger {
           this.reasoningDirty = true
         }
         // streaming: ONE card per thinking run, opened once and settled once — title and
-        // status only. high keeps its full in-place Thinking message, which is where 2,800
-        // characters belong anyway (§4).
-        if (this.streaming && thought && !this.thinkingActive) {
-          this.thinkingActive = true
-          this.queueTask(`thinking-${this.thinkingRun}`, 'Thinking', 'in_progress')
+        // status only, the title being the run's own first line (§5). high keeps its full
+        // in-place Thinking message, which is where 2,800 characters belong anyway (§4).
+        if (this.streaming && thought) {
+          if (!this.thinkingActive) {
+            this.thinkingActive = true
+            this.queueTask(this.thinkingId(), THINKING_CARD, 'in_progress')
+          }
+          this.noteThinkingTitle(thought)
         }
         // minimal: keep the streamed reply intact (thinking mid-reply doesn't close a
         // segment) — only surface the transient status.
@@ -1293,12 +1402,14 @@ export class OutputConverger {
           title?: string
           status?: string
           content?: unknown
+          rawInput?: unknown
           rawOutput?: unknown
         }
         // Minimal deliberately hides the concrete tool label as well as tool cards/output:
         // keep Slack's transient working indicator generic so commands and tool names do
         // not leak into the channel chrome. Thinking remains a distinct thought-chunk state.
         const label = this.mode === 'minimal' ? WORKING : this.toolLabel(u)
+        this.noteToolInput(u)
         const status = this.pushActivity(label)
         // minimal: a tool boundary closes the current reply segment (record it + settle the
         // live message); closeSegment marks the next chunk as a fresh segment. No progress/
@@ -1317,22 +1428,28 @@ export class OutputConverger {
         if (this.streaming && u.toolCallId) {
           this.closeThinkingRun()
           const terminal = u.status === 'completed' || u.status === 'failed'
-          // The tool's own result is HIGH only — medium keeps the card's title and status,
-          // matching the legacy pipeline where tool output is a high-mode rung.
+          // The card's BODY is HIGH only — medium keeps one line per step, matching the legacy
+          // pipeline where tool output is a high-mode rung. The body cannot start collapsed
+          // (Slack has no such field), so on medium a step stays a step.
           if (terminal && this.mode === 'high') this.noteToolOutput(u)
-          const result = terminal && this.mode === 'high' ? (this.toolOutputs.get(u.toolCallId) ?? '') : ''
+          const body =
+            terminal && this.mode === 'high'
+              ? { command: this.cardCommand(u.toolCallId, label), output: this.toolOutputs.get(u.toolCallId) ?? '' }
+              : {}
           this.queueTask(
             u.toolCallId,
-            label,
+            this.cardTitle(u.toolCallId, label),
             u.status === 'completed' ? 'complete' : u.status === 'failed' ? 'error' : 'in_progress',
-            result
+            body
           )
+          if (terminal) this.toolOutputs.delete(u.toolCallId)
           this.pendingProgress = progressText
         } else {
           actions.push({ kind: 'progress', text: progressText })
         }
-        // high only: once the tool finishes, post its output as a code block.
-        if (this.mode === 'high') actions.push(...this.drainToolOutput(u))
+        // high only, and only off the stream: a streaming turn's card already carries the same
+        // command and result, so posting the code block too would say everything twice.
+        if (this.mode === 'high' && !this.streaming) actions.push(...this.drainToolOutput(u))
         return actions
       }
       case 'plan': {

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -29,6 +29,17 @@ const toolDone = (id: string, title: string, output: string, status = 'completed
     status,
     content: [{ type: 'content', content: { type: 'text', text: output } }]
   }) as never
+// A shell tool call as a runtime that describes its own calls sends it: the ACP title is the
+// command, and `rawInput` carries the one-line description the card is titled with.
+const bash = (id: string, command: string, description: string, output = '', status = 'pending') =>
+  ({
+    sessionUpdate: output ? 'tool_call_update' : 'tool_call',
+    toolCallId: id,
+    title: command,
+    status,
+    rawInput: { command, description },
+    ...(output ? { content: [{ type: 'content', content: { type: 'text', text: output } }] } : {})
+  }) as never
 const think = (text: string) => ({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text } }) as never
 
 const attribution = () => ({
@@ -285,7 +296,7 @@ describe('OutputConverger streaming axis', () => {
     expect(mediumCard && 'output' in mediumCard).toBe(false)
   })
 
-  it('flattens markdown emphasis out of card fields, which render as plain text', () => {
+  it('flattens markdown emphasis out of a card TITLE, which is one plain line', () => {
     const converger = streaming('medium')
     converger.onUpdate(tool('t1', '**Read** `src/a.ts`'))
     expect(cards(converger.streamUpdate())).toEqual([
@@ -293,30 +304,110 @@ describe('OutputConverger streaming axis', () => {
     ])
   })
 
-  it('clamps a card field to the 256-character wire limit', () => {
+  it('titles a high card with the runtime description and fences the command below it', () => {
     const converger = streaming('high')
-    converger.onUpdate(toolDone('t1', 'x'.repeat(400), 'y'.repeat(400)))
-    const card = cards(converger.streamUpdate())[0]
-    expect(card?.type === 'task_update' && card.title.length).toBe(256)
-    expect(card?.type === 'task_update' && card.output?.length).toBe(256)
+    converger.onUpdate(bash('t1', 'ls -la', 'List files in working directory'))
+    converger.streamUpdate()
+    converger.onUpdate(bash('t1', 'ls -la', 'List files in working directory', 'total 8', 'completed'))
+    expect(cards(converger.streamUpdate())).toEqual([
+      {
+        type: 'task_update',
+        id: 't1',
+        title: 'List files in working directory',
+        status: 'complete',
+        details: '```\nls -la\n```',
+        output: 'total 8'
+      }
+    ])
   })
 
-  it('gives a thinking run one card and settles it at the next tool call', () => {
+  it('falls back to the tool title, clamped to one line, when the runtime described nothing', () => {
     const converger = streaming('medium')
-    converger.onUpdate(think('weighing the options'))
-    // Title and status only. `details` appends server-side, so a per-line refresh concatenates
-    // instead of replacing — which is how repeated emphasis ran together into literal `****`.
+    const command = `git log --since='2026-08-28' --pretty=format:'%h%x09%ad%x09%an%x09%s' --decorate --all -n 80`
+    converger.onUpdate(tool('t1', command))
+    const card = cards(converger.streamUpdate())[0]
+    expect(card?.type === 'task_update' && card.title).toBe(`${command.slice(0, 71)}…`)
+  })
+
+  it('keeps the command out of a card whose title already shows it whole', () => {
+    const converger = streaming('high')
+    converger.onUpdate(toolDone('t1', 'ls -la', 'total 8'))
+    const card = cards(converger.streamUpdate())[0]
+    expect(card).toEqual({ type: 'task_update', id: 't1', title: 'ls -la', status: 'complete', output: 'total 8' })
+  })
+
+  it('leaves the duplicate tool-output message to the turns that have no card', () => {
+    // A streaming high turn's card carries the same command and result, so posting the code
+    // block as well would say everything twice. A turn off the axis still posts it.
+    const streamed = streaming('high')
+    streamed.onUpdate(tool('t1', 'Read file'))
+    expect(kinds(streamed.onUpdate(toolDone('t1', 'Read file', 'read 42 lines')))).not.toContain('tool-output')
+    const legacy = new OutputConverger('high')
+    legacy.onUpdate(tool('t1', 'Read file'))
+    expect(kinds(legacy.onUpdate(toolDone('t1', 'Read file', 'read 42 lines')))).toContain('tool-output')
+  })
+
+  it('clamps a card title to one line and a card body to the output cap', () => {
+    // Slack accepts far more than the documented 256 characters but silently DROPS an
+    // oversized field, so both caps are ours to enforce, not Slack's to report.
+    const converger = streaming('high')
+    converger.onUpdate(toolDone('t1', 'x'.repeat(400), 'y'.repeat(4000)))
+    const card = cards(converger.streamUpdate())[0]
+    expect(card?.type === 'task_update' && card.title.length).toBe(72)
+    expect(card?.type === 'task_update' && card.output?.length).toBe(2800)
+  })
+
+  it('gives a thinking run one card, titled by its first line, settled at the next tool call', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(think('**Weighing the options**'))
+    // The card opens before the line has ended, which costs nothing: `title` REPLACES per id.
     expect(cards(converger.streamUpdate())).toEqual([
       { type: 'task_update', id: 'thinking-0', title: 'Thinking', status: 'in_progress' }
     ])
-    converger.onUpdate(think('\nand another line'))
+    converger.onUpdate(think('\nand the body follows'))
+    expect(cards(converger.streamUpdate())).toEqual([
+      { type: 'task_update', id: 'thinking-0', title: 'Weighing the options', status: 'in_progress' }
+    ])
+    // The run is named once — later lines of the same thought do not re-title it.
     converger.onUpdate(think('\nand a third'))
     expect(converger.streamUpdate()).toEqual([])
     converger.onUpdate(tool('t1', 'Read file'))
     expect(cards(converger.streamUpdate())).toContainEqual({
       type: 'task_update',
       id: 'thinking-0',
-      title: 'Thinking',
+      title: 'Weighing the options',
+      status: 'complete'
+    })
+  })
+
+  it('names each thinking run separately, and keeps the placeholder when a run has no line', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(think('**First pass**\nbody'))
+    converger.onUpdate(tool('t1', 'Read file'))
+    converger.onUpdate(think('**Second pass**\nbody'))
+    converger.onUpdate(toolDone('t1', 'Read file', ''))
+    const titles = cards(converger.streamUpdate())
+      .filter((c) => c.type === 'task_update' && c.id.startsWith('thinking-'))
+      .map((c) => (c.type === 'task_update' ? c.title : ''))
+    expect(titles).toEqual(['First pass', 'Second pass'])
+
+    const unnamed = streaming('medium')
+    unnamed.onUpdate(think('   '))
+    expect(cards(unnamed.streamUpdate())).toEqual([
+      { type: 'task_update', id: 'thinking-0', title: 'Thinking', status: 'in_progress' }
+    ])
+  })
+
+  it('names a last thought that ends without a line break — nothing more is coming', () => {
+    // A run that ends as the turn does never reaches a newline, and 'Thinking' would be the
+    // one card in the container that says nothing.
+    const converger = streaming('medium')
+    converger.onUpdate(tool('t1', 'Read file'))
+    converger.onUpdate(think('**Summarizing four update groups**'))
+    expect(appends(converger.settleStream('completed'))).toContainEqual({
+      type: 'task_update',
+      id: 'thinking-0',
+      title: 'Summarizing four update groups',
       status: 'complete'
     })
   })


### PR DESCRIPTION
A Slack turn's plan card said `Thinking` for every thought and carried a wrapped paragraph of
shell for every tool call. Both are one-line labels the daemon controls, so both are fixed here,
and `high` gains the card body the web console has always shown: the command as a code block,
its result beneath.

## What changed

**A thinking card is titled by its run's first line.** Runtimes open a thought with a short
heading — the same line the console shows as the step title — so the card says what the agent
is thinking about. The card opens as a placeholder and is renamed once that line lands, which
is free: `title` REPLACES per card id. A run that ends without a line break is named at settle
from whatever its head holds, since nothing more is coming.

**A tool card is titled by the runtime's own one-line description** (`rawInput.description`,
which Claude Code's shell tools carry), else the ACP title clamped to 72 characters. Slack
wraps a long title instead of truncating it and offers no hover, so a shell tool's ACP title —
which IS its command — otherwise buries the step list.

**`high` cards carry the command and its result as the card body.** The command rides `details`
as a fenced code block, the result rides `output`. Because the card now says what the separate
tool-output code block said, a streaming turn no longer posts that message too.

**`medium` is unchanged in shape** — one line per step.

## Why the fields work this way

Four things this design believed about the card fields were wrong, and each was re-probed
against a real workspace before relying on it:

- `details` and `output` are **markdown**, not plain text: a fenced value renders as a real code
  block, backticks as inline code. The earlier reading of the literal `****` incident was wrong
  — that was the append semantics splitting the markers, not a lack of markdown support.
- `output` and `sources` **append** exactly as `details` does (the same field written twice comes
  back concatenated), so the whole body is written once, at completion.
- An oversized body is **dropped, not rejected**: 8,000 characters store and render, and at
  12,000 the append still answers `ok: true` with the field silently empty. Both bodies are
  therefore capped here rather than trusting an error.
- `title` can be rewritten mid-stream, which is what lets a card be opened as a placeholder.

## Why medium keeps one line

A card body **cannot start collapsed**. No field sets the initial state at the chunk, at the
`plan` block, or on `chat.startStream`: the Block Kit schema for a task card is
`{type, task_id, title, details, output, sources, status}` and has no such member, and the eight
plausible chunk-level names (`collapsed`, `expanded`, `is_expanded`, `default_expanded`,
`initially_expanded`, `collapsible`, `hide_details`, `details_display_mode`) are all accepted by
the API and then discarded. The reader can fold each body away and the container itself is still
collapsed by default, but granting a body to `medium` would cost every medium step its single
line — so the mode ladder is what decides how tall the container is once opened.

## Reviewer notes

- The one behavior change beyond the labels: a **streaming** `high` turn no longer posts the
  separate tool-output code block. A turn that degrades off the stream therefore loses tool
  output from the channel for that turn; chrome is lossy-tolerant by design and the transcript
  still records the tool bodies, but it is a real difference and easy to revert if unwanted.
- Verified end to end by feeding a realistic ACP turn through the real converger and rendering
  its chunks in a workspace, on both `medium` and `high`.
- `docs/designs/slack-streaming-turn-output.md` is updated: the corrected field semantics, four
  new live-verified facts, and the title/body rules.
