### PR TITLE
fix(daemon): stop a Slack card taking its label from a tool payload, and keep its output

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -208,6 +208,19 @@ one-line description when it sent one (`rawInput.description`, which Claude Code
 carry), else the title clamped to 72 characters. The verbatim command is not lost — it is the
 card's code block on `high`, and it is skipped when the title already showed it whole.
 
+**Only the TOP LEVEL of `rawInput` is read, and only when it looks like a label.** A nested
+`arguments` object holds the TOOL's own fields, where the same key means whatever that tool
+says it means: `createCodeHostMergeRequest` takes a whole merge-request body as
+`arguments.description`, and titling a step with a document is worse than titling it with a
+command. Even a top-level description is a string the daemon did not author, so it stands as a
+title only if it reads as one — a single line, short enough that clamping it would not be
+hiding most of it — and otherwise the ACP title is used.
+
+**A card body is tracked across the whole call, not read off its last update.** ACP sends tool
+output as deltas: the text can arrive while the call is still `in_progress` and the update that
+finishes it carry nothing but a status. Sampling only the terminal update writes a blank body,
+and on a streaming turn there is no separate code-block message left to carry it.
+
 **A thinking card is titled by its run's first line.** Runtimes open a thought with a short
 `**heading**` — the same line the web console shows as the step title — so the card says what
 the agent is thinking about rather than the bare word "Thinking". The card is opened before

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -207,14 +207,25 @@ function capOutput(s: string): string {
   return t.length > MAX_TOOL_OUTPUT ? `${t.slice(0, MAX_TOOL_OUTPUT - 1)}…` : t
 }
 
-/** A tool call's `rawInput` field, when the runtime sent one as a string. MCP-shaped calls nest
- *  the tool's own arguments one level down, so read both. */
+/**
+ * A tool call's own TOP-LEVEL `rawInput` string, when the runtime sent one — the envelope a
+ * runtime writes about its call, never the call's payload.
+ *
+ * A nested `arguments` object is deliberately NOT read: those keys belong to the tool, and a
+ * tool is free to mean something else entirely by them. `createCodeHostMergeRequest` takes a
+ * whole merge-request body as `arguments.description`, which is a document, not a step label.
+ */
 function rawInputField(update: { rawInput?: unknown }, key: 'command' | 'description'): string {
   const raw = update.rawInput as Record<string, unknown> | undefined
   if (!raw || typeof raw !== 'object') return ''
-  const args = raw.arguments as Record<string, unknown> | undefined
-  const value = typeof raw[key] === 'string' ? raw[key] : args && typeof args[key] === 'string' ? args[key] : ''
-  return typeof value === 'string' ? value.trim() : ''
+  return typeof raw[key] === 'string' ? raw[key].trim() : ''
+}
+
+/** Whether a runtime's description can stand as a card's one-line label. Even at the top level
+ *  this is a string we did not author, so it has to LOOK like a label — one line, and short
+ *  enough that clamping it would not be hiding most of it. */
+function isStepLabel(s: string): boolean {
+  return s.length > 0 && s.length <= MAX_CARD_TITLE * 2 && !s.includes('\n')
 }
 
 /** Escape interpolated labels before embedding them in Slack mrkdwn. `|` is a link-label
@@ -1275,7 +1286,7 @@ export class OutputConverger {
     if (!id || update.rawInput === undefined) return
     const description = rawInputField(update, 'description')
     const command = rawInputField(update, 'command')
-    if (description && !this.toolDescriptions.has(id)) this.toolDescriptions.set(id, description)
+    if (isStepLabel(description) && !this.toolDescriptions.has(id)) this.toolDescriptions.set(id, description)
     if (command && !this.toolCommands.has(id)) this.toolCommands.set(id, command)
   }
 
@@ -1414,7 +1425,12 @@ export class OutputConverger {
           // The card's BODY is HIGH only — medium keeps one line per step, matching the legacy
           // pipeline where tool output is a high-mode rung. The body cannot start collapsed
           // (Slack has no such field), so on medium a step stays a step.
-          if (terminal && this.mode === 'high') this.noteToolOutput(u)
+          //
+          // Tracked on EVERY update, not just the terminal one: ACP output arrives as deltas, so
+          // the text can land while the call is still `in_progress` and the update that finishes
+          // it carry nothing but the status. Reading only the last one writes a blank body — and
+          // on a streaming turn nothing else would carry that output.
+          if (this.mode === 'high') this.noteToolOutput(u)
           const body =
             terminal && this.mode === 'high'
               ? { command: this.cardCommand(u.toolCallId, label), output: this.toolOutputs.get(u.toolCallId) ?? '' }

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -321,6 +321,49 @@ describe('OutputConverger streaming axis', () => {
     ])
   })
 
+  it('never titles a card from a tool payload — a nested `description` is the TOOL’s field', () => {
+    // createCodeHostMergeRequest takes a whole merge-request body as `arguments.description`.
+    const converger = streaming('medium')
+    converger.onUpdate({
+      sessionUpdate: 'tool_call',
+      toolCallId: 't1',
+      title: 'createCodeHostMergeRequest',
+      status: 'pending',
+      rawInput: {
+        server: 'agentconnect',
+        tool: 'createCodeHostMergeRequest',
+        arguments: { title: 'Fix the thing', description: '## Summary\n\nA whole merge-request body.' }
+      }
+    } as never)
+    expect(cards(converger.streamUpdate())).toEqual([
+      { type: 'task_update', id: 't1', title: 'createCodeHostMergeRequest', status: 'in_progress' }
+    ])
+  })
+
+  it('ignores a top-level description that is prose rather than a label', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(bash('t1', 'ls -la', 'A description that runs on\nover several lines and is really a document'))
+    expect(cards(converger.streamUpdate())).toEqual([
+      { type: 'task_update', id: 't1', title: 'ls -la', status: 'in_progress' }
+    ])
+  })
+
+  it('keeps output that arrived before the terminal update — ACP sends deltas', () => {
+    // The finishing update can carry nothing but a status, so the body has to be tracked all
+    // along: reading only the last one writes a blank card, and no other message carries it.
+    const converger = streaming('high')
+    converger.onUpdate(toolDone('t1', 'Read file', 'read 42 lines', 'in_progress'))
+    converger.streamUpdate()
+    converger.onUpdate({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 't1',
+      status: 'completed'
+    } as never)
+    expect(cards(converger.streamUpdate())).toEqual([
+      { type: 'task_update', id: 't1', title: 'Read file', status: 'complete', output: 'read 42 lines' }
+    ])
+  })
+
   it('falls back to the tool title, clamped to one line, when the runtime described nothing', () => {
     const converger = streaming('medium')
     const command = `git log --since='2026-08-28' --pretty=format:'%h%x09%ad%x09%an%x09%s' --decorate --all -n 80`


### PR DESCRIPTION
Two follow-ups to #1576, both raised in review after it merged. Both are real: confirmed
against the tool definitions and the ACP update shape before fixing.

## A nested `rawInput.arguments` is the tool's field, not presentation metadata

`rawInputField` fell back to `rawInput.arguments.description` when the top level had none. But
that object holds the TOOL's arguments, where the key means whatever that tool says it means —
`createCodeHostMergeRequest` takes a whole merge-request body as `arguments.description`
(`packages/daemon/src/mcp/tools.ts`). A step that opened an MR was therefore titled with the
first 72 characters of its body.

Only the top level of `rawInput` is read now: the envelope a runtime writes about its own call,
which is where Claude Code's shell tools put theirs, and where an MCP-shaped call has nothing to
offer. Even a top-level description is a string the daemon did not author, so it stands as a
title only if it reads as a label — one line, short enough that clamping would not be hiding
most of it. Anything else falls back to the ACP title, which is what a card without a
description has always used.

## Tool output is a delta, and was being sampled once

The streaming path called `noteToolOutput` only on the terminal update. ACP sends output as
deltas: the text can arrive while the call is still `in_progress` and the update that finishes
it carry nothing but a status. That wrote a blank body — and since #1576 stopped a streaming
turn posting the separate tool-output code block, nothing else carried that output either.

The newest output is now tracked on every update, which is what the legacy path already did
through its own drain (`drainToolOutput` notes on each call and emits at the terminal one).

## Reviewer notes

- Both fixes are pinned by tests that **fail on the previous commit** — verified by running the
  new cases against the pre-fix source: an MCP-shaped call whose `arguments.description` is a
  merge-request body, a top-level description that is prose, and output landing before a
  status-only terminal update.
- 65 tests in `slack-streaming.test.ts` and 100 in `render.test.ts` pass; typecheck, lint and
  format are clean.
- The design doc gains both rules, next to the title and body rules they qualify.
