### PR TITLE
fix(daemon): stop the shutdown duty drain retrying a permanently closed CP client

### DIFF
--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -343,6 +343,12 @@ export class CpClient {
     this.state = 'CLOSED'
   }
 
+  /** True once this client will never dial again — stop() ran, a fatal auth close latched, or a
+   *  bootstrap upgrade retired the connection — so a retry loop waiting on it should give up now. */
+  terminallyClosed(): boolean {
+    return this.stopped || this.fatal
+  }
+
   private beginConnect(): void {
     if (this.stopped || this.fatal) return
     if (this.connectRun) {

--- a/packages/daemon/src/cp/duty-coordinator.ts
+++ b/packages/daemon/src/cp/duty-coordinator.ts
@@ -969,6 +969,13 @@ export class DutyCoordinator {
         if (outcome === 'timeout') throw new Error('no acknowledgement before the drain deadline')
         return true
       } catch (err) {
+        // A terminally closed client never dials again (a bootstrap upgrade retires the connection
+        // before this drain runs), so no retry can deliver the release — lapse now, not at the deadline.
+        const cp = this.host.cpClient()
+        if (!cp || cp.terminallyClosed()) {
+          this.log.warn(`duty: releasing ${groupId} abandoned — the CP client is permanently closed, its lease lapses`)
+          return false
+        }
         if (this.host.clock().now() + backoffMs >= deadlineAt) {
           this.log.warn(`duty: releasing ${groupId} was not acknowledged before the drain deadline: ${err}`)
           return false

--- a/packages/daemon/test/cp/client-handshake.test.ts
+++ b/packages/daemon/test/cp/client-handshake.test.ts
@@ -628,9 +628,11 @@ describe('CpClient handshake', () => {
     const client = new CpClient(makeDeps(t))
     client.start()
     await tick()
+    expect(client.terminallyClosed()).toBe(false)
     await client.stop()
     expect(t.closed?.code).toBe(1000)
     expect(client.state).toBe('CLOSED')
+    expect(client.terminallyClosed()).toBe(true)
   })
 
   it('token-only (no daemonId): omits daemonId from auth, adopts the id from auth/ok', async () => {
@@ -703,6 +705,8 @@ describe('CpClient handshake', () => {
     t.pushInbound(JSON.stringify(buildEnvelope('ack', { ok: true }, { corr: result.id })))
     await tick()
     expect(restart).toHaveBeenCalledOnce()
+    // Terminal BEFORE restart() runs its drain: shutdown retry loops must give up, not spin.
+    expect(client.terminallyClosed()).toBe(true)
     expect(t.closed).toEqual({ code: 1000, reason: 'bootstrap upgrade installed' })
     expect(t.sent.map((text) => JSON.parse(text).type)).not.toContain('register')
   })

--- a/packages/daemon/test/cp/client-reconnect.test.ts
+++ b/packages/daemon/test/cp/client-reconnect.test.ts
@@ -78,6 +78,8 @@ describe('CpClient reconnect', () => {
     const t1 = (await connect.mock.results[0]!.value) as FakeTransport
     t1.simulateClose(1012, 'restarting')
     expect(client.state).toBe('DEGRADED')
+    // A redial is coming, so shutdown retry loops may still hope for delivery.
+    expect(client.terminallyClosed()).toBe(false)
     // A reconnect timer is armed (~1000ms with jitter()=0).
     expect(clock.pending()).toContain(1000)
 
@@ -153,6 +155,7 @@ describe('CpClient reconnect', () => {
     await tick()
     const t1 = (await connect.mock.results[0]!.value) as FakeTransport
     t1.simulateClose(4401, 'AUTH_FAILED')
+    expect(client.terminallyClosed()).toBe(true)
     expect(clock.pending()).not.toContain(1000)
     clock.advance(60000)
     await tick()

--- a/packages/daemon/test/daemon-duty-drain.test.ts
+++ b/packages/daemon/test/daemon-duty-drain.test.ts
@@ -67,6 +67,7 @@ async function boot(opts: { releaseDuties?: (groupIds: string[]) => Promise<void
   ;(daemon as any).cpClient = {
     organizationScope: () => 'frame',
     memberSet: () => ({ setId: '9f11e5e7-0000-4000-8000-000000000001', name: 'Cloud' }),
+    terminallyClosed: () => false,
     stop,
     releaseDuties,
     reportDutiesNow,
@@ -391,6 +392,30 @@ describe('shutdown drain of a duty-holding member', () => {
     expect(summary).toMatch(/released 2 group\(s\) covering 2 agent\(s\)/)
     expect(summary).toMatch(/0 acknowledged, 2 left to lapse/)
     // Locally withdrawn regardless: nothing here still serves what the CP will hand on.
+    expect(duties(daemon).size()).toBe(0)
+  })
+
+  it('a permanently closed CP client is not retried against — every lease lapses at once, not at the deadline', async () => {
+    // The bootstrap-upgrade shape: the client is retired (stopped, socket closed, no redial)
+    // BEFORE Daemon.stop() runs, so no retry can ever deliver a release.
+    const { daemon, clock, releaseDuties } = await boot({
+      releaseDuties: async () => {
+        throw new Error('control plane unreachable (client CLOSED)')
+      }
+    })
+    ;(daemon as any).cpClient.terminallyClosed = () => true
+    const info = vi.spyOn((daemon as any).log, 'info')
+    const warn = vi.spyOn((daemon as any).log, 'warn')
+
+    const startedAt = clock.now()
+    await runVirtual(clock, daemon.stop())
+
+    // One attempt per group, no backoff ladder, and nowhere near the 300s pool drain budget.
+    expect(releaseDuties).toHaveBeenCalledTimes(2)
+    expect(clock.now() - startedAt).toBeLessThan(5_000)
+    expect(warn.mock.calls.some(([m]) => /permanently closed, its lease lapses/.test(String(m)))).toBe(true)
+    const summary = info.mock.calls.map(([m]) => String(m)).find((m) => m.startsWith('duty: shutdown drain released'))
+    expect(summary).toMatch(/0 acknowledged, 2 left to lapse/)
     expect(duties(daemon).size()).toBe(0)
   })
 


### PR DESCRIPTION
## Problem

A bootstrap-delivered upgrade (the auth-time `lifecycle` directive) retires the CP connection before the daemon's shutdown drain runs: the client latches `stopped`, closes the transport, and never redials. The drain's acknowledged-release loop then retries `duty/release` every 5s against `control plane unreachable (client CLOSED)` until the full pool drain budget (300s) elapses — five minutes spent on releases that can never be delivered, while the duty self-fence interrupts the surviving turns at its 90s horizon anyway.

Observed on a real upgrade op that took 5m30s end to end: the install itself (download, extract, symlink flip) finished in 0.8s; the old process then sat in the retry ladder for the remaining five minutes. The live path (control frame on a READY connection) is unaffected — the same daemon's previous upgrade released all 14 groups acknowledged in 2s.

## Fix

- `CpClient.terminallyClosed()`: true once this client will never dial again — `stop()` ran, or a fatal auth close latched. The bootstrap path sets `stopped` before invoking the restart, so the predicate already holds when the drain starts.
- `releaseDutyAcknowledged` gives up immediately when the client is terminally closed (or absent): the lease lapses now instead of at the drain deadline — the same outcome, five minutes sooner. A DEGRADED client still retries, since a redial may yet deliver the release.

Turn draining is untouched: a busy group still waits for its turn to settle before being withdrawn, so nothing is cancelled to move faster.

## Tests

- drain: a permanently closed client short-circuits the release retries — one attempt per group, no backoff ladder, the drain ends nowhere near the 300s budget, and the summary counts the groups as lapsing.
- client: `terminallyClosed()` pinned false when dialing/DEGRADED, true after `stop()`, after a 4401 close, and at the moment the bootstrap-installed `restart()` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
