### PR TITLE
feat(daemon): let a Slack thinking card carry its run, and drop the message repeating it

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -232,8 +232,10 @@ The two said the same thing: every line of that message is a card title in the c
 directly above it, and a runtime that emits headings without prose made it a verbatim copy of
 the step list. So the card takes the console's shape for a reasoning row — the clamped first
 line as the title, the WHOLE run as the body, including that first line, because the title is a
-truncation and expanding must show what was truncated. A single-line run has nothing beyond its
-title and gets no body, which is the console's own test for an expandable row. `medium` keeps
+truncation and expanding must show what was truncated. The body is dropped only when the TITLE
+shows the run whole — "it has no newline" is not that test, or an unbroken thought longer than
+the clamp would survive as its own first 72 characters and nothing else. A run that outgrows the
+body cap keeps its truncation mark, so a card never presents a cut-off run as a complete one. `medium` keeps
 neither, as it keeps no other body.
 
 A turn off the axis is untouched — it still posts the in-place Thinking message it always did.

--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -32,8 +32,8 @@ in order to move an answer between transports is gone with it (§9).
 **Goals.** Replace the in-place `progress` message with a native collapsed plan card on
 medium/high turns; change **nothing** about the body (post / live-reply / final-live-reply,
 response finalization by edit, the attribution footer, the transcript, the status bar, the
-transient status text, permission and elicitation cards, attachments, the ACP plan message, the
-high-mode Thinking message); degrade to today's `progress` message
+transient status text, permission and elicitation cards, attachments, the ACP plan message);
+degrade to today's `progress` message
 wherever streaming is unavailable, from Slack's own errors, with no config knob and no environment
 kill switch; and leave Layer 0's stop seam, `setSessionLifecycle`, the manifest, the relay, the
 control plane, the protocol, and every other platform alone.
@@ -179,14 +179,14 @@ that an oversized field comes back `ok: true` with the field SILENTLY EMPTY. Car
 therefore take the same 2,800-character cap as the legacy tool-output block, and titles a much
 tighter one (below).
 
-| ACP `session/update`             | today                                              | with the chrome stream                                                                                                                                                                           |
-| -------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `agent_message_chunk`            | buffered → `post` / `live-reply`                   | **unchanged**                                                                                                                                                                                    |
-| `tool_call` / `tool_call_update` | in-place `progress` message + rotating status text | `task_update` keyed by `toolCallId`; ACP `pending`/`in_progress` → `in_progress`, `completed` → `complete`, `failed` → `error`. The status text is unchanged; the `progress` message is replaced |
-| `agent_thought_chunk`            | `high`: in-place Thinking message; status text     | plus ONE `task_update` per thinking run, titled by the run's FIRST LINE, status only. `high` keeps its full in-place Thinking message, which is where 2,800 characters belong                    |
-| `plan`                           | in-place `plan` message                            | **unchanged** — an ACP plan is a full entry list with per-entry statuses, i.e. a checklist, not a one-line container label                                                                       |
-| tool output, terminal (`high`)   | separate code-block message                        | the command and its result become the card's body (`details` + `output`, high only); the separate code-block message is **dropped on a streaming turn**, which would otherwise say it twice      |
-| `usage_update`                   | dropped                                            | dropped                                                                                                                                                                                          |
+| ACP `session/update`             | today                                              | with the chrome stream                                                                                                                                                                                 |
+| -------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `agent_message_chunk`            | buffered → `post` / `live-reply`                   | **unchanged**                                                                                                                                                                                          |
+| `tool_call` / `tool_call_update` | in-place `progress` message + rotating status text | `task_update` keyed by `toolCallId`; ACP `pending`/`in_progress` → `in_progress`, `completed` → `complete`, `failed` → `error`. The status text is unchanged; the `progress` message is replaced       |
+| `agent_thought_chunk`            | `high`: in-place Thinking message; status text     | ONE `task_update` per thinking run, titled by the run's FIRST LINE, carrying the run itself as its body on `high`. The separate Thinking message is **dropped on a streaming turn** — the cards are it |
+| `plan`                           | in-place `plan` message                            | **unchanged** — an ACP plan is a full entry list with per-entry statuses, i.e. a checklist, not a one-line container label                                                                             |
+| tool output, terminal (`high`)   | separate code-block message                        | the command and its result become the card's body (`details` + `output`, high only); the separate code-block message is **dropped on a streaming turn**, which would otherwise say it twice            |
+| `usage_update`                   | dropped                                            | dropped                                                                                                                                                                                                |
 
 **`task_display_mode: 'plan'`, fixed, never configurable.** Every task card is collected into
 ONE collapsed-by-default container, and `{ type: 'plan_update', title }` is the line printed on
@@ -226,6 +226,21 @@ and on a streaming turn there is no separate code-block message left to carry it
 the agent is thinking about rather than the bare word "Thinking". The card is opened before
 that line has arrived and renamed once it has, which is free: `title` REPLACES per id. A run
 whose head yields nothing keeps the placeholder.
+
+**On `high` the card carries the run itself, and the separate Thinking message is dropped.**
+The two said the same thing: every line of that message is a card title in the container
+directly above it, and a runtime that emits headings without prose made it a verbatim copy of
+the step list. So the card takes the console's shape for a reasoning row — the clamped first
+line as the title, the WHOLE run as the body, including that first line, because the title is a
+truncation and expanding must show what was truncated. A single-line run has nothing beyond its
+title and gets no body, which is the console's own test for an expandable row. `medium` keeps
+neither, as it keeps no other body.
+
+A turn off the axis is untouched — it still posts the in-place Thinking message it always did.
+A turn that took the axis and then DEGRADED does not, because the converger never learns that
+it degraded (§7: the applier owns the whole degrade), so it loses the reasoning message exactly
+as it loses the tool-output block. Both are chrome, and this design accepts chrome as lossy;
+the reasoning still reaches the transcript either way.
 
 **Output modes.** `none`, `minimal` and `low` have no tool chrome today and gain none: they
 never take the axis. `medium` gets card titles and statuses — one line per step; `high` adds

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -928,6 +928,7 @@ export class OutputConverger {
   private thinkingHead = ''
   private thinkingTitle = ''
   private thinkingBody = ''
+  private thinkingBodyTruncated = false
   /** The container's label, so an unchanged one is never re-sent, plus the one awaiting the
    *  next append and the legacy `progress` text that append would degrade to. */
   private planTitle = ''
@@ -1105,6 +1106,15 @@ export class OutputConverger {
     return `thinking-${this.thinkingRun}`
   }
 
+  /** Accumulate a run's body under the card-body cap, REMEMBERING that the cap was reached.
+   *  Silently slicing to the cap hands `capOutput` a value that already looks whole, so the
+   *  card would present a run missing its ending as if that were the ending. */
+  private appendThinkingBody(thought: string): void {
+    const room = MAX_TOOL_OUTPUT - this.thinkingBody.length
+    if (room <= 0 || thought.length > room) this.thinkingBodyTruncated = true
+    if (room > 0) this.thinkingBody += thought.slice(0, room)
+  }
+
   /**
    * Title a thinking run from its FIRST LINE. Runtimes open a thought with a short
    * `**heading**` — the same line the web console shows as the step's title — so the card can
@@ -1140,24 +1150,31 @@ export class OutputConverger {
    *  high mode's in-place Thinking message, which is where 2,800 characters fit. */
   private closeThinkingRun(status: 'complete' | 'error' = 'complete'): void {
     if (!this.thinkingActive) return
-    this.queueTask(this.thinkingId(), this.thinkingTitleFrom(true) || THINKING_CARD, status, {
-      details: this.thinkingRunBody()
-    })
+    const title = this.thinkingTitleFrom(true) || THINKING_CARD
+    this.queueTask(this.thinkingId(), title, status, { details: this.thinkingRunBody(title) })
     this.thinkingActive = false
     this.thinkingRun += 1
     this.thinkingHead = ''
     this.thinkingTitle = ''
     this.thinkingBody = ''
+    this.thinkingBodyTruncated = false
   }
 
-  /** What a settled thinking card shows under its title on `high`: the WHOLE run, exactly as
-   *  the web console's work rows do — the title is a clamped first line, so expanding must show
-   *  it in full rather than a headless remainder. A single-line run has nothing beyond its
-   *  title and gets no body, which is the console's own test for an expandable row. */
-  private thinkingRunBody(): string {
+  /**
+   * What a settled thinking card shows under its title on `high`: the WHOLE run, exactly as the
+   * web console's work rows do — the title is a clamped first line, so expanding must show it in
+   * full rather than a headless remainder.
+   *
+   * The body is dropped only when the TITLE already shows the run whole. "Has no newline" is not
+   * that test: a single unbroken line longer than the title clamp would then survive only as its
+   * own first 72 characters, and with the reasoning message gone there is nothing else holding
+   * the rest.
+   */
+  private thinkingRunBody(title: string): string {
     if (this.mode !== 'high') return ''
     const body = this.thinkingBody.trim()
-    return body.includes('\n') ? body : ''
+    if (!body || plainCardText(body) === title) return ''
+    return this.thinkingBodyTruncated ? `${body}…` : body
   }
 
   /** Flush pending output for the idle timer: in high mode one in-place `reasoning` update
@@ -1401,7 +1418,7 @@ export class OutputConverger {
             this.queueTask(this.thinkingId(), THINKING_CARD, 'in_progress')
           }
           this.noteThinkingTitle(thought)
-          if (this.mode === 'high') this.thinkingBody = (this.thinkingBody + thought).slice(0, MAX_REASONING)
+          if (this.mode === 'high') this.appendThinkingBody(thought)
         }
         // minimal: keep the streamed reply intact (thinking mid-reply doesn't close a
         // segment) — only surface the transient status.

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -927,6 +927,7 @@ export class OutputConverger {
   private thinkingRun = 0
   private thinkingHead = ''
   private thinkingTitle = ''
+  private thinkingBody = ''
   /** The container's label, so an unchanged one is never re-sent, plus the one awaiting the
    *  next append and the legacy `progress` text that append would degrade to. */
   private planTitle = ''
@@ -1045,18 +1046,20 @@ export class OutputConverger {
    * Queue one task card, keyed by id so streamed updates edit the same card and an unchanged
    * repeat emits nothing. `title` and `status` may be re-sent freely — Slack REPLACES them per
    * id. The body may not: `details` and `output` both append, so they are written together
-   * exactly once, at completion. Callers pass the command and result RAW — the cap and the
-   * code fence belong here, where the wire limit is known.
+   * exactly once, at completion. Callers pass their text RAW — the cap and the code fence
+   * belong here, where the wire limit is known. `command` is fenced into a code block;
+   * `details` is prose (a thinking run) and takes the same slot unfenced.
    */
   private queueTask(
     id: string,
     title: string,
     status: 'in_progress' | 'complete' | 'error',
-    body: { command?: string; output?: string } = {}
+    body: { command?: string; details?: string; output?: string } = {}
   ): void {
     const clamped = clampTo(plainCardText(title), MAX_CARD_TITLE) || 'tool'
     const fresh = !this.outputWritten.has(id)
-    const details = fresh && body.command ? codeSpan(capOutput(body.command), true) : ''
+    const above = body.command ? codeSpan(capOutput(body.command), true) : capOutput(body.details ?? '')
+    const details = fresh ? above : ''
     const output = fresh && body.output ? capOutput(body.output) : ''
     const chunk: Extract<SlackStreamChunk, { type: 'task_update' }> = {
       type: 'task_update',
@@ -1137,11 +1140,24 @@ export class OutputConverger {
    *  high mode's in-place Thinking message, which is where 2,800 characters fit. */
   private closeThinkingRun(status: 'complete' | 'error' = 'complete'): void {
     if (!this.thinkingActive) return
-    this.queueTask(this.thinkingId(), this.thinkingTitleFrom(true) || THINKING_CARD, status)
+    this.queueTask(this.thinkingId(), this.thinkingTitleFrom(true) || THINKING_CARD, status, {
+      details: this.thinkingRunBody()
+    })
     this.thinkingActive = false
     this.thinkingRun += 1
     this.thinkingHead = ''
     this.thinkingTitle = ''
+    this.thinkingBody = ''
+  }
+
+  /** What a settled thinking card shows under its title on `high`: the WHOLE run, exactly as
+   *  the web console's work rows do — the title is a clamped first line, so expanding must show
+   *  it in full rather than a headless remainder. A single-line run has nothing beyond its
+   *  title and gets no body, which is the console's own test for an expandable row. */
+  private thinkingRunBody(): string {
+    if (this.mode !== 'high') return ''
+    const body = this.thinkingBody.trim()
+    return body.includes('\n') ? body : ''
   }
 
   /** Flush pending output for the idle timer: in high mode one in-place `reasoning` update
@@ -1212,7 +1228,9 @@ export class OutputConverger {
    *  high mode ever sets `reasoningDirty`). Callers place it before the body flush so the
    *  Thinking block posts above the reply. */
   private drainReasoning(): SlackAction[] {
-    if (!this.reasoningDirty) return []
+    // A streaming turn's thinking cards ARE this message — posting it too would repeat every
+    // line of it under the container that already holds them.
+    if (this.streaming || !this.reasoningDirty) return []
     this.reasoningDirty = false
     return [{ kind: 'reasoning', text: renderReasoning(this.reasoningBuf) }]
   }
@@ -1363,8 +1381,9 @@ export class OutputConverger {
         // dirty; the actual in-place `reasoning` update is deferred to flushBuffered()
         // (idle timer) / onFinal so a token-by-token stream doesn't flood chat.update.
         // low + medium keep only the transient status — no reasoning in the channel.
+        // A STREAMING turn keeps none of this: its cards are the Thinking message (§5).
         const thought = (update as { content?: { text?: string } }).content?.text ?? ''
-        if (this.mode === 'high' && thought) {
+        if (this.mode === 'high' && thought && !this.streaming) {
           this.reasoningBuf += thought
           // Soft-cap the raw buffer so a very long turn can't grow it unbounded;
           // renderReasoning tail-clamps again for the message body.
@@ -1373,15 +1392,16 @@ export class OutputConverger {
           }
           this.reasoningDirty = true
         }
-        // streaming: ONE card per thinking run, opened once and settled once — title and
-        // status only, the title being the run's own first line (§5). high keeps its full
-        // in-place Thinking message, which is where 2,800 characters belong anyway (§4).
+        // streaming: ONE card per thinking run, opened once and settled once. Its title is the
+        // run's own first line and, on high, its body is the rest of the run — so the card IS
+        // the Thinking message and the separate one is not posted (§5).
         if (this.streaming && thought) {
           if (!this.thinkingActive) {
             this.thinkingActive = true
             this.queueTask(this.thinkingId(), THINKING_CARD, 'in_progress')
           }
           this.noteThinkingTitle(thought)
+          if (this.mode === 'high') this.thinkingBody = (this.thinkingBody + thought).slice(0, MAX_REASONING)
         }
         // minimal: keep the streamed reply intact (thinking mid-reply doesn't close a
         // segment) — only surface the transient status.

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -505,6 +505,27 @@ describe('OutputConverger streaming axis', () => {
     })
   })
 
+  it('keeps a single-line run that its title had to clamp', () => {
+    // "Has no newline" is not the same as "the title shows it whole": a long unbroken thought
+    // would otherwise survive only as its own first 72 characters.
+    const converger = streaming('high')
+    const run = `Weighing whether the ${'very '.repeat(20)}long branch settles the same way`
+    converger.onUpdate(think(run))
+    converger.onUpdate(tool('t1', 'Read file'))
+    const card = cards(converger.streamUpdate()).find((c) => c.type === 'task_update' && c.id === 'thinking-0')
+    expect(card?.type === 'task_update' && card.title.endsWith('…')).toBe(true)
+    expect(card?.type === 'task_update' && card.details).toBe(run)
+  })
+
+  it('marks a run that outgrew the body cap instead of presenting it as whole', () => {
+    const converger = streaming('high')
+    converger.onUpdate(think('**A long think**\n'))
+    converger.onUpdate(think('x'.repeat(4000)))
+    converger.onUpdate(tool('t1', 'Read file'))
+    const card = cards(converger.streamUpdate()).find((c) => c.type === 'task_update' && c.id === 'thinking-0')
+    expect(card?.type === 'task_update' && card.details?.endsWith('…')).toBe(true)
+  })
+
   it('keeps the ACP plan on its own message — a checklist is not a container label', () => {
     const converger = streaming('medium')
     const actions = converger.onUpdate({

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -85,8 +85,11 @@ describe('OutputConverger streaming axis', () => {
       }
       const streamedFinal = streamed.onFinal(attribution())
       const legacyFinal = legacy.onFinal(attribution())
+      // CHROME is what the stream replaces — the `progress` message, the Thinking message and
+      // the tool-output block all move onto the cards. The ANSWER is what must not move.
+      const chromeKinds = new Set(['progress', 'reasoning', 'tool-output'])
       const bodyOnly = (actions: SlackAction[]): SlackAction[] =>
-        actions.filter((a) => !a.kind.startsWith('stream-') && a.kind !== 'progress')
+        actions.filter((a) => !a.kind.startsWith('stream-') && !chromeKinds.has(a.kind))
       expect(bodyOnly(streamedFinal)).toEqual(bodyOnly(legacyFinal))
       // …and every `post` is a real post, never demoted to a transcript-only copy.
       expect(streamedFinal.some((a) => a.kind === 'post' && a.recordOnly)).toBe(false)
@@ -455,10 +458,51 @@ describe('OutputConverger streaming axis', () => {
     })
   })
 
-  it('keeps high mode its own in-place Thinking message beside the card', () => {
-    const converger = streaming('high')
-    converger.onUpdate(think('weighing the options'))
-    expect(converger.flushBuffered().some((a) => a.kind === 'reasoning')).toBe(true)
+  it('drops high mode’s in-place Thinking message — the cards ARE it', () => {
+    // Every line of that message is a card title in the container right above it.
+    const streamed = streaming('high')
+    streamed.onUpdate(think('**Weighing the options**\nthe body'))
+    expect(streamed.flushBuffered().some((a) => a.kind === 'reasoning')).toBe(false)
+    expect(streamed.onFinal(attribution()).some((a) => a.kind === 'reasoning')).toBe(false)
+
+    const legacy = new OutputConverger('high')
+    legacy.onUpdate(think('**Weighing the options**\nthe body'))
+    expect(legacy.flushBuffered().some((a) => a.kind === 'reasoning')).toBe(true)
+  })
+
+  it('gives a high thinking card the whole run as its body, as the console’s work rows do', () => {
+    const high = streaming('high')
+    high.onUpdate(think('**Weighing the options**\n\nboth branches settle the same way.'))
+    high.onUpdate(tool('t1', 'Read file'))
+    expect(cards(high.streamUpdate())).toContainEqual({
+      type: 'task_update',
+      id: 'thinking-0',
+      title: 'Weighing the options',
+      status: 'complete',
+      // The title is a clamped first line, so expanding shows the run in full, not a remainder.
+      details: '**Weighing the options**\n\nboth branches settle the same way.'
+    })
+
+    // A single-line run has nothing beyond its title, and medium has no body at all.
+    const oneLine = streaming('high')
+    oneLine.onUpdate(think('**Weighing the options**'))
+    oneLine.onUpdate(tool('t1', 'Read file'))
+    expect(cards(oneLine.streamUpdate())).toContainEqual({
+      type: 'task_update',
+      id: 'thinking-0',
+      title: 'Weighing the options',
+      status: 'complete'
+    })
+
+    const medium = streaming('medium')
+    medium.onUpdate(think('**Weighing the options**\n\nboth branches settle the same way.'))
+    medium.onUpdate(tool('t1', 'Read file'))
+    expect(cards(medium.streamUpdate())).toContainEqual({
+      type: 'task_update',
+      id: 'thinking-0',
+      title: 'Weighing the options',
+      status: 'complete'
+    })
   })
 
   it('keeps the ACP plan on its own message — a checklist is not a container label', () => {


### PR DESCRIPTION
On `high`, a streaming turn posted the plan card and then the in-place Thinking message
underneath it. Every line of that message is a card title in the container directly above — and
a runtime that emits headings without prose made it a verbatim copy of the step list.

## What changed

The card becomes the message. A thinking card on `high` now carries the **whole run** as its
body, which is the shape the web console's reasoning rows already have:

- the clamped first line as the title;
- the run in full underneath, **including that first line** — the title is a truncation, so
  expanding has to show what was truncated;
- a single-line run has nothing beyond its title and gets no body, which is the console's own
  test for whether a row expands at all.

`medium` keeps neither, as it keeps no other body — a step there stays one line.

## Reviewer notes

- **A turn off the axis is untouched** and still posts the Thinking message exactly as before.
  A turn that took the axis and then degraded does not: the converger never learns that it
  degraded (the applier owns the whole degrade), so it loses the reasoning message the same way
  it already loses the tool-output block. Both are chrome, and this design accepts chrome as
  lossy.
- **The console view is unaffected.** Reasoning rows reach the transcript through
  `TranscriptRecorder`, which records them independently of the Slack output mode — dropping
  the channel message does not drop the transcript row.
- Verified by rendering a real converger turn in a workspace: the cards read as the console
  does, `**headings**` included, and nothing follows the container.
- 66 tests in `slack-streaming.test.ts` and 100 in `render.test.ts` pass; typecheck, lint and
  format are clean. The "body is byte-identical" guard now names `progress`, `reasoning` and
  `tool-output` as the chrome the stream is allowed to move — the answer is still what it pins.
