### PR TITLE
docs(slack): correct the comments the cancel removal left stale

### DIFF
--- a/packages/daemon/src/commands/handlers.ts
+++ b/packages/daemon/src/commands/handlers.ts
@@ -172,7 +172,8 @@ export class CommandHandlers {
   }
 
   /** Cancel the in-flight turn for a local session key — the `!cancel` core (interrupt,
-   *  NO mute) shared by the Slack status-bar Cancel button. No-op if nothing is running. */
+   *  NO mute) shared by Slack's native Stop and webchat's cancel frame. No-op if nothing
+   *  is running. */
   async cancelSessionByKey(key: string): Promise<boolean> {
     const rec = await this.host.store().getSession(key)
     // Cancel a gate-owned/queued session even if it has no live ACP turn yet (§6.9 #390):
@@ -285,9 +286,9 @@ export class CommandHandlers {
     await this.refreshStatusBarForKey(key)
     return true // reports whether the override was recorded (nothing else reads it)
   }
-  /** Route a Slack status-bar Block Kit interaction (model / effort / fast select or the
-   *  Cancel button) to the shared key-based cores. `sessionKey` rides the block; no-op on
-   *  an unknown key. */
+  /** Route a Slack status-bar Block Kit interaction (the model / effort / fast selects, or
+   *  a cancel raised by the native Stop) to the shared key-based cores. `sessionKey` rides
+   *  the block; no-op on an unknown key. */
   async handleStatusAction(a: {
     kind: 'set-model' | 'set-effort' | 'set-permission-mode' | 'set-fast' | 'set-output' | 'cancel'
     sessionKey: string

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -814,7 +814,7 @@ export class Daemon {
         // §5.5: re-stamp the delivered answer as this response's one `final` event.
         closeResponse: (p) => this.closeSlackResponse(p),
         // Suppression teardown: stop the append timer and settle the chrome stream mid-flight
-        // (native Stop, status-bar Cancel, displacement, loop protection, shutdown). Slack
+        // (native Stop, an explicit cancel, displacement, loop protection, shutdown). Slack
         // does NOT end the stream itself on a Stop click, so this is what closes it.
         onSuppress: (p) => {
           this.clearSlackStream(p)

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -269,9 +269,10 @@ export interface SlackDeps {
   /** Fired when the bot's channel membership changes (invited to / removed from a
    *  channel), so the daemon can re-list + re-report the membership snapshot. */
   onChannelsChanged?: () => void
-  /** Fired when a user interacts with the status modal's controls (the model
-   *  `static_select` or the Cancel button). `sessionKey` comes from the modal's
-   *  `private_metadata`; payload fields are present only for their matching action. */
+  /** Fired when a user interacts with the status modal's selects, or raises a cancel —
+   *  Slack's native Stop, or a status row posted while the overflow still rendered one.
+   *  `sessionKey` comes from the modal's `private_metadata`; payload fields are present
+   *  only for their matching action. */
   onStatusAction?: (a: {
     kind: 'set-model' | 'set-effort' | 'set-permission-mode' | 'set-fast' | 'set-output' | 'cancel'
     sessionKey: string
@@ -905,9 +906,8 @@ export class SlackConnection implements PlatformConnection {
     })
     // Status-bar interactivity (Block Kit block_actions over Socket Mode). Each handler
     // MUST ack() promptly (Slack drops the interaction / trigger_id after ~3s). Configure
-    // opens the controls modal; the modal's select/Cancel carry the session key in
-    // `view.private_metadata`. No-op when
-    // interactivity is unsubscribed (the handler never fires).
+    // opens the controls modal; its selects carry the session key in `view.private_metadata`.
+    // No-op when interactivity is unsubscribed (the handler never fires).
     this.app.action(STATUS_ACTION.more, async ({ ack, action, body }) => {
       await ack()
       const choice = action.selected_option?.value ? decodeSlackStatusOverflowValue(action.selected_option.value) : null

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -610,8 +610,8 @@ export interface SharedStatusActions {
 
 /** Build the compact in-thread status message. Both dedicated and shared bots use one
  *  overflow accessory so the status stays on a single row; a SHAREABLE (multi-agent) bot
- *  also exposes Switch agent. Interrupting a turn is Slack's own Stop control or Session
- *  options' Cancel turn — the overflow carries no cancel item. */
+ *  also exposes Switch agent. Interrupting a turn is Slack's own Stop control — the
+ *  overflow carries no cancel item. */
 export function buildStatusBlocks(
   info: StatusBarInfo,
   sessionKey: string,


### PR DESCRIPTION
Follow-up to #1575, which removed both of Slack's chrome cancel controls but left five comments describing them as if they were still rendered.

- `buildStatusBlocks`' doc pointed the reader at Session options' `Cancel turn` — the button the same PR deleted one commit later.
- `SlackDeps.onStatusAction`, the `ac_more` registration comment, `cancelSessionByKey` and `handleStatusAction` all still called the cancel "the status-bar Cancel button".
- The Slack suppression-teardown list named "status-bar Cancel" among its causes.

The verb itself is unchanged and still very much alive: it reaches those call sites from Slack's native Stop, from webchat's cancel frame, and from a status row posted while the overflow still rendered its option. The comments now say so.

Comments only — no behavior change. `typecheck`, `lint` and `format` are clean.
