### PR TITLE
feat(daemon): keep a failed step from failing the whole Slack plan card

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -256,10 +256,32 @@ the container itself is still collapsed by default, but no chunk field sets the 
 **DM and channel take the same code path.** The only difference is the recipient argument
 (§4 fact 9).
 
-**A turn that fails** settles its cards like a finished one — `complete` and the counted
-summary. The tool calls did not necessarily fail; the turn did, and the `⚠️ Agent failed to
-respond` notice carries that in the body where it belongs. Marking them `error` would blame the
-tools for the runtime.
+### 5.1 What `error` means, and how a failure is said
+
+**The container icon is DERIVED, continuously, from the cards.** Any `error` card in the final
+task list renders the whole plan under a red warning — order-independent, and with no override
+anywhere: `plan_update` carries only `title` (every plausible extra field is accepted and
+silently discarded), no stream call takes an overall state, the finalized `plan` block has no
+state member, and flipping a card to `error` by `chat.update` AFTER the stop reddens the
+container just the same (all verified live 2026-08-29). The status enum is closed —
+`pending | in_progress | complete | error`, everything else rejected — and `pending` renders
+identically to `error` AND reddens the container too, so it is never sent. There is no yellow,
+no skipped, and no per-card glyph: the `icon` chunk field documented upstream is rejected, a
+title parses neither markdown nor emoji shortcodes, and card text has no color styles.
+
+So `error` is spent where red is the truth about the TURN, not about one step:
+
+- **A failed TOOL is `complete` + a plain `(failed)` title prefix**, counted into the closing
+  label (`Completed 41 steps · 1 failed`). Agents fail commands routinely — a grep without a
+  match, a probing run — and one non-zero exit must not present a completed turn as a failed
+  one. Plain text, deliberately: a Unicode ❌ renders as a large color emoji everywhere, and
+  shortcodes don't render on mobile card bodies at all.
+- **A cancelled turn settles in-flight cards as `error` under `Stopped`** — the reader stopped
+  it; red is accurate.
+- **A crashed turn settles in-flight cards as `error` under `Failed`** — the step still open
+  did not finish because the runtime died, steps already finished keep their state, and the
+  `⚠️ Agent failed to respond` notice carries the reason in the body. A crash with nothing in
+  flight rewrites no card: the label alone says how the turn ended.
 
 ## 6. Stop
 
@@ -400,6 +422,6 @@ Two cosmetic questions stay open. **Does the counted label read well after a lon
 `Completed 41 steps` is honest but not informative; a model-narrated label was rejected (a second
 call, and a label that can disagree with the cards), and the next candidate is the last tool's
 title. **Should a `failed` card carry its error text as `output` on medium?** Today the body is a
-high-only rung, matching the legacy pipeline; the card already says `error`, and a body cannot
-start collapsed (§4 fact 10), so granting one to medium would cost every medium step its single
-line — the failed one included.
+high-only rung, matching the legacy pipeline; the card already says `(failed)`, and a body
+cannot start collapsed (§4 fact 10), so granting one to medium would cost every medium step its
+single line — the failed one included.

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -158,6 +158,13 @@ const MAX_THINKING_HEAD = 400
 const STREAM_PLAN_WORKING = 'Working…'
 /** …and after a cancel, a user Stop, or suppression — the in-flight cards settle as errors. */
 const STREAM_PLAN_STOPPED = 'Stopped'
+/** …and after the RUNTIME dies mid-turn. Same error settle as a stop — the in-flight step did
+ *  not finish because the turn ended — under the label that says which way it ended. */
+const STREAM_PLAN_FAILED = 'Failed'
+/** A failed tool's title prefix — words, not card status: any `error` card reddens the whole
+ *  container (the icon is derived, verified live 2026-08-29), and the title parses no markdown
+ *  and no shortcodes, so plain text is the entire palette. */
+const FAILED_PREFIX = '(failed) '
 
 function clampTo(s: string, max: number): string {
   const t = s.trim()
@@ -918,7 +925,8 @@ export class OutputConverger {
   private openTasks = new Set<string>()
   /** Cards whose write-once body has been sent, so a later update cannot append a second. */
   private outputWritten = new Set<string>()
-  /** Cards that ended in error — the closing label counts these, never the model. */
+  /** Tool calls ACP reported failed — counted into the closing label, never the model's to
+   *  narrate, and deliberately NOT the cards' status (see FAILED_PREFIX). */
   private failedTasks = new Set<string>()
   // A tool call's own one-line label and verbatim command, remembered from whichever update
   // carried `rawInput` — a streamed `tool_call_update` usually carries none.
@@ -1010,19 +1018,20 @@ export class OutputConverger {
    * settle append is not cosmetic — it is what every stop is owed. Idempotent: the second
    * caller of a turn's settle gets nothing.
    */
-  settleStream(outcome: 'completed' | 'stopped'): SlackAction[] {
+  settleStream(outcome: 'completed' | 'stopped' | 'failed'): SlackAction[] {
     if (!this.streaming || this.streamClosed) return []
     this.streamClosed = true
     // A tool that started AND finished inside one coalescing window leaves cards pending with
     // no stream open yet. Opening it here is what keeps such a turn from ending with no tool
     // chrome at all; only a genuinely tool-free turn stays silent.
     if (!this.streamOpened && this.emittedTasks.size === 0) return []
-    const terminal = outcome === 'stopped' ? 'error' : 'complete'
+    const terminal = outcome === 'completed' ? 'complete' : 'error'
     this.closeThinkingRun(terminal)
     for (const id of [...this.openTasks]) this.queueTask(id, this.taskTitles.get(id) ?? 'tool', terminal)
     // Forced rather than queued: the container must always carry its closing label, even when
     // the working one happens to read the same.
-    this.planTitle = outcome === 'stopped' ? STREAM_PLAN_STOPPED : this.planSummary()
+    this.planTitle =
+      outcome === 'completed' ? this.planSummary() : outcome === 'stopped' ? STREAM_PLAN_STOPPED : STREAM_PLAN_FAILED
     this.pendingPlanTitle = this.planTitle
     const progressText = this.pendingProgress
     this.pendingProgress = ''
@@ -1078,8 +1087,6 @@ export class OutputConverger {
     if (details || output) this.outputWritten.add(id)
     this.emittedTasks.set(id, signature)
     this.taskTitles.set(id, clamped)
-    if (status === 'error') this.failedTasks.add(id)
-    else this.failedTasks.delete(id)
     if (status === 'in_progress') this.openTasks.add(id)
     else this.openTasks.delete(id)
     this.pendingTasks.set(id, chunk)
@@ -1200,9 +1207,11 @@ export class OutputConverger {
    *  dropped and replaced by the generic failure notice. */
   flushTerminal(): SlackAction[] {
     if (this.mode === 'minimal') return this.liveRefresh()
-    // A failed turn settles its cards like a finished one: the tool calls did not necessarily
-    // fail, the turn did, and the ⚠️ notice the caller appends carries that in the body.
-    return [...this.drainReasoning(), ...this.flush(), ...this.settleStream('completed')]
+    // A crashed turn settles like a stopped one: whatever was still in flight did not finish
+    // BECAUSE the turn died, so those cards are honestly `error` under a "Failed" label — while
+    // steps that already finished keep their state, (failed)-prefixed ones included. The ⚠️
+    // notice the caller appends still carries the reason in the body.
+    return [...this.drainReasoning(), ...this.flush(), ...this.settleStream('failed')]
   }
 
   /** minimal: refresh the single in-place `live-reply` with the current segment (display only;
@@ -1462,6 +1471,13 @@ export class OutputConverger {
         if (this.streaming && u.toolCallId) {
           this.closeThinkingRun()
           const terminal = u.status === 'completed' || u.status === 'failed'
+          // A failed TOOL never takes card status `error`: the container icon is derived from
+          // the cards (any error card reddens the whole plan, verified live 2026-08-29), so one
+          // non-zero exit would present a completed turn as a failed one. The failure is said
+          // in words instead — a plain "(failed)" prefix, counted into the closing label —
+          // and `error` is reserved for the cancel path, where a red container is the truth.
+          const failed = u.status === 'failed'
+          if (failed) this.failedTasks.add(u.toolCallId)
           // The card's BODY is HIGH only — medium keeps one line per step, matching the legacy
           // pipeline where tool output is a high-mode rung. The body cannot start collapsed
           // (Slack has no such field), so on medium a step stays a step.
@@ -1477,8 +1493,8 @@ export class OutputConverger {
               : {}
           this.queueTask(
             u.toolCallId,
-            this.cardTitle(u.toolCallId, label),
-            u.status === 'completed' ? 'complete' : u.status === 'failed' ? 'error' : 'in_progress',
+            (failed ? FAILED_PREFIX : '') + this.cardTitle(u.toolCallId, label),
+            terminal ? 'complete' : 'in_progress',
             body
           )
           if (terminal) this.toolOutputs.delete(u.toolCallId)

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -131,13 +131,16 @@ describe('OutputConverger streaming axis', () => {
   })
 
   it('turns tool calls into cards keyed by toolCallId', () => {
+    // A failed TOOL is `complete` + a plain "(failed)" prefix, never card status `error`: the
+    // container icon is derived from the cards, so one error card would present the whole turn
+    // as failed. `error` is reserved for the cancel path, where a red container is the truth.
     const converger = streaming('medium')
     converger.onUpdate(tool('t1', 'Read file'))
     converger.onUpdate(tool('t1', 'Read file', 'completed'))
     converger.onUpdate(tool('t2', 'Run tests', 'failed'))
     expect(cards(converger.streamUpdate())).toEqual([
       { type: 'task_update', id: 't1', title: 'Read file', status: 'complete' },
-      { type: 'task_update', id: 't2', title: 'Run tests', status: 'error' }
+      { type: 'task_update', id: 't2', title: '(failed) Run tests', status: 'complete' }
     ])
   })
 
@@ -172,6 +175,32 @@ describe('OutputConverger streaming axis', () => {
     expect(appends(converger.onFinal(attribution())).filter((c) => c.type === 'plan_update')).toEqual([
       { type: 'plan_update', title: 'Completed 2 steps · 1 failed' }
     ])
+  })
+
+  it('never lets a tool failure put an error card on the stream — that reddens the container', () => {
+    const converger = streaming('high')
+    converger.onUpdate(think('**Weighing it**'))
+    converger.onUpdate(tool('t1', 'Read file'))
+    const live = converger.streamUpdate()
+    converger.onUpdate(toolDone('t1', 'Read file', 'exit 1', 'failed'))
+    const all = [...appends(live), ...cards(converger.streamUpdate()), ...appends(converger.onFinal(attribution()))]
+    expect(all.filter((c) => c.type === 'task_update' && c.status === 'error')).toEqual([])
+    // …while the failure is still said: prefix on the card, count on the container.
+    expect(all).toContainEqual(
+      expect.objectContaining({ type: 'task_update', id: 't1', title: '(failed) Read file', status: 'complete' })
+    )
+    expect(all).toContainEqual({ type: 'plan_update', title: 'Completed 2 steps · 1 failed' })
+  })
+
+  it('keeps the (failed) prefix through the title clamp, and the body on high', () => {
+    const converger = streaming('high')
+    const long = `Weighing whether the ${'very '.repeat(20)}long command settles`
+    converger.onUpdate(bash('t1', long, ''))
+    converger.onUpdate(bash('t1', long, '', 'exit 1', 'failed'))
+    const card = cards(converger.streamUpdate()).find((c) => c.type === 'task_update' && c.id === 't1')
+    expect(card?.type === 'task_update' && card.title.startsWith('(failed) ')).toBe(true)
+    expect(card?.type === 'task_update' && card.title.length).toBeLessThanOrEqual(72)
+    expect(card?.type === 'task_update' && card.output).toBe('exit 1')
   })
 
   it('rides the terminal settle ON the stop, so the two can never be split', () => {
@@ -252,20 +281,32 @@ describe('OutputConverger streaming axis', () => {
     expect(converger.settleStream('stopped')).toEqual([])
   })
 
-  it('settles the stream on a terminal failure too, as a finished turn rather than a stopped one', () => {
+  it('settles a crashed turn as a stop would — the in-flight step died with the runtime', () => {
     const converger = streaming('medium')
     converger.onUpdate(chunk('partial answer'))
     converger.onUpdate(tool('t1', 'Read file'))
     converger.streamUpdate()
     const terminal = converger.flushTerminal()
-    // The tool calls did not fail; the turn did, and the ⚠️ notice carries that in the body.
+    // The step still open did not finish BECAUSE the turn died — `error` is the truth here,
+    // under the label that says which way the turn ended. The ⚠️ notice carries the reason.
     expect(terminal.at(-1)).toEqual({
       kind: 'stream-stop',
       settle: [
-        { type: 'task_update', id: 't1', title: 'Read file', status: 'complete' },
-        { type: 'plan_update', title: 'Completed 1 step' }
+        { type: 'task_update', id: 't1', title: 'Read file', status: 'error' },
+        { type: 'plan_update', title: 'Failed' }
       ]
     })
+  })
+
+  it('lets a crashed turn keep the steps that DID finish, (failed)-prefixed ones included', () => {
+    const converger = streaming('medium')
+    converger.onUpdate(tool('t1', 'Read file', 'completed'))
+    converger.onUpdate(tool('t2', 'Run tests', 'failed'))
+    converger.streamUpdate()
+    const settle = appends(converger.flushTerminal())
+    // Nothing was in flight, so no card is rewritten — only the label says the turn failed.
+    expect(settle.filter((c) => c.type === 'task_update')).toEqual([])
+    expect(settle).toContainEqual({ type: 'plan_update', title: 'Failed' })
   })
 
   it('settles a silent turn that still ran tools', () => {


### PR DESCRIPTION
One failed tool call rendered the entire plan card under a red warning. This PR spends `error`
where red is the truth about the **turn**, and says a step's failure in words instead.

## Why the container reddens, and why there is no other way

The container icon is **derived from the cards** — any `error` card in the final task list
reddens the plan, order-independent. Every possible override was probed against a live
workspace before settling on this design:

- `plan_update` carries only `title`; every plausible extra field (`status`, `state`, `icon`,
  `overall_status`, `plan_status`) is accepted and silently discarded.
- No stream call takes an overall state (`startStream` / `appendStream` / `stopStream`
  argument lists exhausted; SDK types agree).
- The finalized `plan` block is `{type, title, tasks, block_id}` — no state member, and the
  icon derivation is live: flipping a card to `error` via `chat.update` **after** the stop
  reddens the container just the same.
- The status enum is closed (`completed`, `failed`, `skipped`, `warning`, `cancelled`, `done`
  all rejected), `pending` renders identically to `error` **and also reddens**, a title parses
  neither markdown nor emoji shortcodes, and the documented per-card `icon` field is rejected.

## What changed

- **A failed tool is `complete` + a plain `(failed)` title prefix**, counted into the closing
  label (`Completed 41 steps · 1 failed`). Agents fail commands routinely — a grep without a
  match, a probing run — and one non-zero exit must not present a completed turn as failed.
- **A cancelled turn is unchanged**: in-flight cards settle `error` under `Stopped`.
- **A crashed turn now settles in-flight cards as `error` under `Failed`** — the open step did
  not finish because the runtime died; finished steps keep their state; the `⚠️ Agent failed
  to respond` notice still carries the reason in the body. Previously a crash settled as
  `Completed N steps`, which was not what happened.
- The failed count is decoupled from card status, fed by ACP `failed` directly.

## Reviewer notes

- Pinned by tests that **fail on the previous commit**: a failed tool emits no `error` card
  anywhere in the stream while the prefix and count still say it; the prefix survives the
  title clamp with the card body intact; a crash settles the in-flight card as `error` under
  `Failed` and rewrites nothing that had finished.
- Both terminal shapes verified rendered in a live workspace: ✓ `Completed 4 steps · 1 failed`
  with the `(failed)` step inside, and red `Failed` for the mid-step crash.
- The design doc gains §5.1 recording the derivation facts and the three terminal shapes.
