### PR TITLE
feat(daemon): record an operator-raised interrupt in the transcript

### DIFF
--- a/packages/daemon/src/commands/handlers.ts
+++ b/packages/daemon/src/commands/handlers.ts
@@ -67,7 +67,13 @@ export interface CommandHost {
   hostForStoredSession(agentId: string, acpSessionId: string): Promise<AcpHost | undefined>
   statusInfoFrom(agentId: string, sessionKey: string, acpSessionId?: string): Promise<StatusBarInfo>
   emitStatusBar(p: Pending): Promise<void>
-  interruptTurn(agentId: string, key: string, reason: TurnInterruptReason, acpSessionId?: string): Promise<void>
+  interruptTurn(
+    agentId: string,
+    key: string,
+    reason: TurnInterruptReason,
+    acpSessionId?: string,
+    opts?: { actor?: InteractionActor }
+  ): Promise<void>
   /** `!queue` admission through the unified per-sessionKey gate — it decides run-now vs enqueue. */
   dispatchQueueCommand(agentId: string, msg: NormalizedMessage, integrationId: string): Promise<void>
   replyConnFor(agentId: string, integrationId?: string): PlatformConnection | undefined
@@ -87,6 +93,12 @@ export interface CommandHost {
 }
 
 /** Everything `handleCommand`'s shared pre-dispatch resolves once, handed to the per-kind handler. */
+/** The human behind a chat command, in the same shape a Block Kit click reports. */
+function senderActor(msg: NormalizedMessage): InteractionActor {
+  const name = msg.sender.name?.trim()
+  return { userId: msg.sender.id, isBot: msg.sender.isBot, ...(name ? { name } : {}) }
+}
+
 interface CommandContext {
   msg: NormalizedMessage
   target: { agentId: string; integrationId: string; via: RouteVia }
@@ -174,7 +186,7 @@ export class CommandHandlers {
   /** Cancel the in-flight turn for a local session key — the `!cancel` core (interrupt,
    *  NO mute) shared by Slack's native Stop and webchat's cancel frame. No-op if nothing
    *  is running. */
-  async cancelSessionByKey(key: string): Promise<boolean> {
+  async cancelSessionByKey(key: string, actor?: InteractionActor): Promise<boolean> {
     const rec = await this.host.store().getSession(key)
     // Cancel a gate-owned/queued session even if it has no live ACP turn yet (§6.9 #390):
     // interruptTurn drains the queue by key and cancels the ACP turn only if one exists.
@@ -183,7 +195,9 @@ export class CommandHandlers {
     const agentId =
       rec?.agentId ?? this.host.activeGateEntries().get(key)?.agentId ?? this.host.serialQueue().get(key)?.[0]?.agentId
     if (!agentId) return false
-    await this.host.interruptTurn(agentId, key, 'cancel', rec?.acpSessionId ?? undefined)
+    await this.host.interruptTurn(agentId, key, 'cancel', rec?.acpSessionId ?? undefined, {
+      ...(actor ? { actor } : {})
+    })
     return true // reports whether a turn was actually interrupted (nothing else reads it)
   }
 
@@ -304,7 +318,7 @@ export class CommandHandlers {
     // at the one point every ingress funnels through — but only when the verb actually
     // applied, so a refused or no-op click never reads as a change someone made.
     let applied = false
-    if (a.kind === 'cancel') applied = await this.cancelSessionByKey(a.sessionKey)
+    if (a.kind === 'cancel') applied = await this.cancelSessionByKey(a.sessionKey, a.actor)
     else if (a.kind === 'set-model') {
       if (a.model) applied = await this.setModelByKey(a.sessionKey, a.model)
     } else if (a.kind === 'set-effort') {
@@ -642,7 +656,9 @@ export class CommandHandlers {
       reply(rec ? `🔇 Nothing is running. ${muteNote}` : 'Nothing is running to stop.')
       return true
     }
-    await this.host.interruptTurn(target.agentId, key, 'stop', acpSessionId ?? undefined)
+    await this.host.interruptTurn(target.agentId, key, 'stop', acpSessionId ?? undefined, {
+      actor: senderActor(ctx.msg)
+    })
     reply(`🛑 Stopped. ${muteNote}`)
     return true
   }
@@ -656,7 +672,9 @@ export class CommandHandlers {
       reply('Nothing is running to cancel.')
       return true
     }
-    await this.host.interruptTurn(target.agentId, key, 'cancel', acpSessionId ?? undefined)
+    await this.host.interruptTurn(target.agentId, key, 'cancel', acpSessionId ?? undefined, {
+      actor: senderActor(ctx.msg)
+    })
     reply('🛑 Cancelled.')
     return true
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -11324,7 +11324,9 @@ export class Daemon {
       )
     }
     this.log.info(`command: ${reason} → agent "${agentId}" session ${key}${liveSessionId ? ` (${liveSessionId})` : ''}`)
-    await this.recordOperatorInterrupt(agentId, reason, opts.actor, live ?? activeEntry ?? queued?.[0])
+    // The audit row is written only once the cancellation fence below stands: it is
+    // presentation, and must never be what an operator's Stop waits on or trips over.
+    const anchor = live ?? activeEntry ?? queued?.[0]
     // Only a live ACP turn can be cancelled at the host; a purely-queued/cold session has
     // nothing running to cancel (the queue drop above already handled it).
     if (!liveSessionId || !live) {
@@ -11333,6 +11335,7 @@ export class Daemon {
       // dispatch and force-stop its host if it still has not yielded.
       const active = this.activeDispatchDoneByKey.get(key)
       if (activeEntry && active) this.armColdCancelBackstop(agentId, key, reason, active)
+      await this.recordOperatorInterrupt(agentId, reason, opts.actor, anchor)
       return
     }
     // Release any card the user hasn't answered: ACP requires pending permission /
@@ -11349,6 +11352,7 @@ export class Daemon {
       ?.cancel(liveSessionId)
       .catch((err) => this.log.error(`command ${reason}: cancel failed: ${(err as Error).message}`))
     this.armCancelBackstop(agentId, liveSessionId, key, reason)
+    await this.recordOperatorInterrupt(agentId, reason, opts.actor, anchor)
   }
 
   /** Record an operator-raised interrupt in the transcript, so a cancel is visible in the
@@ -11372,13 +11376,15 @@ export class Daemon {
           }
     const who = actor?.name?.trim() || actor?.userId
     const by = who ? ` by ${who}` : ''
-    await this.store.appendTranscript({
-      ...coords,
-      ts: monotonicTs(),
-      sender: agentId,
-      kind: 'text',
-      text: reason === 'stop' ? `🛑 Turn stopped${by} — muted in this thread.` : `🛑 Turn cancelled${by}.`
-    })
+    await this.store
+      .appendTranscript({
+        ...coords,
+        ts: monotonicTs(),
+        sender: agentId,
+        kind: 'text',
+        text: reason === 'stop' ? `🛑 Turn stopped${by} — muted in this thread.` : `🛑 Turn cancelled${by}.`
+      })
+      .catch((err) => this.log.warn(`transcript: ${reason} row not recorded for ${agentId}: ${formatErr(err)}`))
   }
 
   /** Interrupt every logical session owned by an agent for a lifecycle gate (pause,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -124,6 +124,7 @@ import {
   platformIds,
   platformIntegrationConfig
 } from './platforms/integration-config.js'
+import type { InteractionActor } from './platforms/contract.js'
 import { compoundMentionAddressesFor } from './platforms/mention-address.js'
 import { rootPostNeedsThreadMaterialization, rootPostThreadName, threadKeyForPost } from './platforms/thread-keys.js'
 import { isMalformedPlatformTurn } from './platforms/malformed-turn.js'
@@ -1344,7 +1345,8 @@ export class Daemon {
       statusInfoFrom: async (agentId, sessionKey, acpSessionId) =>
         await this.statusInfoFrom(agentId, sessionKey, acpSessionId),
       emitStatusBar: (p) => this.emitStatusBar(p),
-      interruptTurn: (agentId, key, reason, acpSessionId) => this.interruptTurn(agentId, key, reason, acpSessionId),
+      interruptTurn: (agentId, key, reason, acpSessionId, opts) =>
+        this.interruptTurn(agentId, key, reason, acpSessionId, opts),
       dispatchQueueCommand: async (agentId, msg, integrationId) => {
         await this.dispatch(agentId, msg, integrationId, undefined, undefined, { isQueueCmd: true })
       },
@@ -11240,6 +11242,8 @@ export class Daemon {
       allowReviewLane?: string
       /** Duty handoff: stop running the work here, but leave its durable rows for the successor. */
       handoffInbox?: boolean
+      /** The human who raised it, when one did — recorded in the transcript. */
+      actor?: InteractionActor
     } = {}
   ): Promise<void> {
     // The force-cancel fallback is host-wide. Hold NEW admissions until this exact
@@ -11320,6 +11324,7 @@ export class Daemon {
       )
     }
     this.log.info(`command: ${reason} → agent "${agentId}" session ${key}${liveSessionId ? ` (${liveSessionId})` : ''}`)
+    await this.recordOperatorInterrupt(agentId, reason, opts.actor, live ?? activeEntry ?? queued?.[0])
     // Only a live ACP turn can be cancelled at the host; a purely-queued/cold session has
     // nothing running to cancel (the queue drop above already handled it).
     if (!liveSessionId || !live) {
@@ -11344,6 +11349,36 @@ export class Daemon {
       ?.cancel(liveSessionId)
       .catch((err) => this.log.error(`command ${reason}: cancel failed: ${(err as Error).message}`))
     this.armCancelBackstop(agentId, liveSessionId, key, reason)
+  }
+
+  /** Record an operator-raised interrupt in the transcript, so a cancel is visible in the
+   *  console wherever it came from — a chat command, Slack's native Stop, or the webchat
+   *  frame. `stop` shares its reason with internal interrupts (host respawn, agent removal),
+   *  so only an ATTRIBUTED stop is one a person raised; `cancel` has no such caller. */
+  private async recordOperatorInterrupt(
+    agentId: string,
+    reason: TurnInterruptReason,
+    actor: InteractionActor | undefined,
+    anchor: Pending | QueueEntry | undefined
+  ): Promise<void> {
+    if (reason !== 'cancel' && !(reason === 'stop' && actor)) return
+    if (!anchor) return
+    const coords =
+      'plan' in anchor
+        ? { channel: anchor.plan.transcriptChannel, thread: anchor.plan.statusThread }
+        : {
+            channel: transcriptChannelKey(anchor.msg.channel, anchor.msg.transportScope),
+            thread: transcriptCoords(anchor.msg).thread
+          }
+    const who = actor?.name?.trim() || actor?.userId
+    const by = who ? ` by ${who}` : ''
+    await this.store.appendTranscript({
+      ...coords,
+      ts: monotonicTs(),
+      sender: agentId,
+      kind: 'text',
+      text: reason === 'stop' ? `🛑 Turn stopped${by} — muted in this thread.` : `🛑 Turn cancelled${by}.`
+    })
   }
 
   /** Interrupt every logical session owned by an agent for a lifecycle gate (pause,

--- a/packages/daemon/src/platforms/contract.ts
+++ b/packages/daemon/src/platforms/contract.ts
@@ -43,6 +43,8 @@ export interface InteractionActor {
   /** Only set where the platform reports it on the interaction (Discord does; a Slack
    *  `block_actions` payload carries no bot flag on its `user`). */
   isBot?: boolean
+  /** Provider-observed display label. Presentation only — never an identity or auth input. */
+  name?: string
 }
 
 /**

--- a/packages/daemon/src/platforms/slack/command-chrome.ts
+++ b/packages/daemon/src/platforms/slack/command-chrome.ts
@@ -17,7 +17,9 @@ export const slackCommandChrome: CommandChromeSurface<unknown, StatusBarInfo> = 
     // Cast rather than instanceof so duck-typed fakes (and the non-Slack origins
     // that render through this core surface) keep working — their postMessage is
     // structurally compatible.
-    void (conn as SlackConnection).postMessage(ctx.channel, text, ctx.replyThread)
+    // Chrome-marked: a control reply is not conversation, so thread backfill skips it and
+    // the transcript's one record of an interrupt is the row the daemon writes itself.
+    void (conn as SlackConnection).postMessage(ctx.channel, text, ctx.replyThread, { chrome: true })
   },
 
   status(conn: unknown, msg: unknown, ctx: CommandChromeContext, info: StatusBarInfo, link?: string): void {

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -344,7 +344,7 @@ type BlockActionArgs = {
     trigger_id?: string
     view?: { id?: string; private_metadata?: string }
     actions?: { block_id?: string }[]
-    user?: { id?: string }
+    user?: { id?: string; username?: string; name?: string }
   }
 }
 
@@ -360,7 +360,10 @@ type MessageShortcutArgs = {
 
 /** The clicking user off a `block_actions` payload, for the action's audit record. */
 function actorOf(body: BlockActionArgs['body']): InteractionActor | undefined {
-  return body?.user?.id ? { userId: body.user.id } : undefined
+  const user = body?.user
+  if (!user?.id) return undefined
+  const name = (user.username ?? user.name)?.trim()
+  return { userId: user.id, ...(name ? { name } : {}) }
 }
 
 /** The Slack surface `SlackConnection` drives. Exported so a caller can supply its own — see

--- a/packages/daemon/test/command-chrome.test.ts
+++ b/packages/daemon/test/command-chrome.test.ts
@@ -86,7 +86,8 @@ describe('per-platform reply anchoring', () => {
     const calls: unknown[][] = []
     const conn = { postMessage: (...a: unknown[]) => void calls.push(a) }
     slackCommandChrome.reply(conn, undefined, ctx, 'ok')
-    expect(calls[0]).toEqual(['C1', 'ok', '1700000000.001'])
+    // Chrome-marked: a control reply is not conversation, so thread backfill skips it.
+    expect(calls[0]).toEqual(['C1', 'ok', '1700000000.001', { chrome: true }])
   })
 
   it('discord renders the select card only under its 25-button ceiling', () => {

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -729,6 +729,30 @@ describe('Daemon in-conversation commands', () => {
     await daemon.stop()
   })
 
+  it('cancels the turn even when the audit row cannot be written', async () => {
+    const blocked = blockingHost()
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
+    await daemon.start()
+    makeRoutable(daemon)
+
+    const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
+    // The row is presentation: a store that refuses it must not leave the runtime running
+    // after someone pressed Stop, with output already suppressed and the drain begun.
+    vi.spyOn((daemon as any).store, 'appendTranscript').mockRejectedValue(new Error('disk full'))
+
+    await (daemon as any).onInboundOutcome(dm('200', '!cancel'))
+    expect(blocked.host.cancel).toHaveBeenCalledWith('acp-1')
+
+    blocked.release()
+    await turn
+    await daemon.stop()
+  })
+
   it('!cancel with no in-flight turn just reports (no mute)', async () => {
     const blocked = blockingHost()
     const daemon = new Daemon({

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -119,6 +119,9 @@ function makeRoutable(daemon: Daemon) {
   return conn
 }
 
+/** Every command reply is chrome-marked, so thread backfill skips it. */
+const CHROME_REPLY = { chrome: true }
+
 const dm = (ts: string, text: string) => ({
   msgId: `slack:C1:${ts}`,
   traceId: ts,
@@ -153,7 +156,7 @@ describe('Daemon in-conversation commands', () => {
 
     await (daemon as any).onInboundOutcome(dm('200', '!resume'))
     expect(await (daemon as any).store.isLoopGuardOpen(scope)).toBe(false)
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Resumed'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Resumed'), 'T1', CHROME_REPLY)
     expect(blocked.prompts).toHaveLength(0) // the control command never becomes a prompt
     await daemon.stop()
   })
@@ -191,7 +194,7 @@ describe('Daemon in-conversation commands', () => {
 
     await (daemon as any).onInboundOutcome(resume('U1'))
     expect(await (daemon as any).store.isLoopGuardOpen(scope)).toBe(false)
-    expect(conn.postMessage).toHaveBeenCalledWith('C-top', expect.stringContaining('Resumed'), '9')
+    expect(conn.postMessage).toHaveBeenCalledWith('C-top', expect.stringContaining('Resumed'), '9', CHROME_REPLY)
     expect(blocked.prompts).toHaveLength(0)
     await daemon.stop()
   })
@@ -236,7 +239,7 @@ describe('Daemon in-conversation commands', () => {
       accepted: true
     })
     expect(await (daemon as any).store.isLoopGuardOpen(scope)).toBe(false)
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Resumed'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Resumed'), 'T1', CHROME_REPLY)
     expect(blocked.prompts).toHaveLength(0)
     await daemon.stop()
   })
@@ -482,7 +485,7 @@ describe('Daemon in-conversation commands', () => {
     // queue a follow-up while the turn is in flight
     await (daemon as any).onInboundOutcome(dm('200', '!queue do it'))
     await vi.waitFor(() => expect((daemon as any).serialQueue.get(SESSION_KEY)).toHaveLength(1), WAIT)
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Queued'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Queued'), 'T1', CHROME_REPLY)
     expect(blocked.prompts).toHaveLength(1) // the 2nd message is queued, not dispatched yet
     expect(blocked.prompts[0]).toContain('hello') // (prefixed by the injected memory block)
 
@@ -533,7 +536,7 @@ describe('Daemon in-conversation commands', () => {
     await vi.waitFor(() => expect((daemon as any).serialQueue.get(SESSION_KEY)).toHaveLength(10), WAIT)
     await (daemon as any).onInboundOutcome(dm('999', '!queue overflow')) // 11th → rejected
     await vi.waitFor(() => expect((daemon as any).serialQueue.get(SESSION_KEY)).toHaveLength(10), WAIT)
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('full'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('full'), 'T1', CHROME_REPLY)
 
     blocked.release()
     await turn
@@ -555,7 +558,7 @@ describe('Daemon in-conversation commands', () => {
 
     await (daemon as any).onInboundOutcome(dm('200', '!stop'))
     expect(blocked.host.cancel).toHaveBeenCalledWith('acp-1')
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Stopped'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Stopped'), 'T1', CHROME_REPLY)
 
     blocked.release()
     await turn
@@ -710,10 +713,16 @@ describe('Daemon in-conversation commands', () => {
 
     await (daemon as any).onInboundOutcome(dm('200', '!cancel'))
     expect(blocked.host.cancel).toHaveBeenCalledWith('acp-1')
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Cancelled'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Cancelled'), 'T1', CHROME_REPLY)
     // unlike !stop, the session is NOT muted — follow-ups keep dispatching.
     const store = (daemon as any).store
     expect(await store.isSessionMuted(SESSION_KEY)).toBe(false)
+    // The interrupt is recorded ONCE, naming who raised it — the chrome-marked reply above
+    // never reaches the transcript, so the console's only row is this one.
+    const rows = await store.transcriptSince(transcriptChannelKey('C1', TRANSPORT_SCOPE), 'T1', null)
+    expect(rows.filter((row: any) => row.text.includes('Turn cancelled')).map((row: any) => row.text)).toEqual([
+      '🛑 Turn cancelled by U1.'
+    ])
 
     blocked.release()
     await turn
@@ -731,7 +740,7 @@ describe('Daemon in-conversation commands', () => {
     const conn = makeRoutable(daemon)
 
     await (daemon as any).onInboundOutcome({ ...dm('400', '!cancel'), thread: 'T9' })
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', 'Nothing is running to cancel.', 'T9')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', 'Nothing is running to cancel.', 'T9', CHROME_REPLY)
     expect(await (daemon as any).store.isSessionMuted('slack:C1:T9:bot-a')).toBe(false)
     await daemon.stop()
   })
@@ -841,7 +850,12 @@ describe('Daemon in-conversation commands', () => {
 
     // A top-level channel command (no thread) still reaches the channel's active session.
     await (daemon as any).onInboundOutcome({ ...channelStop, msgId: 'slack:C1:300', thread: undefined })
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Nothing is running'), 'slack:C1:300')
+    expect(conn.postMessage).toHaveBeenCalledWith(
+      'C1',
+      expect.stringContaining('Nothing is running'),
+      'slack:C1:300',
+      CHROME_REPLY
+    )
 
     await daemon.stop()
   })
@@ -861,7 +875,7 @@ describe('Daemon in-conversation commands', () => {
     await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
     await (daemon as any).onInboundOutcome(dm('200', '!stop'))
     expect(await store.isSessionMuted(SESSION_KEY)).toBe(true)
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Muted'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Muted'), 'T1', CHROME_REPLY)
 
     // follow-up in the muted thread does not start a turn
     await (daemon as any).onInboundOutcome(dm('300', 'follow up'))
@@ -871,7 +885,12 @@ describe('Daemon in-conversation commands', () => {
     // a bare !stop from a thread with no session of its own now targets the channel's
     // latest session (T1): reports it's idle + (re)mutes T1, but still replies in T9.
     await (daemon as any).onInboundOutcome({ ...dm('400', '!stop'), thread: 'T9' })
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Nothing is running'), 'T9')
+    expect(conn.postMessage).toHaveBeenCalledWith(
+      'C1',
+      expect.stringContaining('Nothing is running'),
+      'T9',
+      CHROME_REPLY
+    )
     expect(await store.isSessionMuted(SESSION_KEY)).toBe(true)
 
     await daemon.stop()
@@ -889,12 +908,12 @@ describe('Daemon in-conversation commands', () => {
     // open a session in T1, then query it
     await (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
     await (daemon as any).onInboundOutcome(dm('200', '!status'))
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining(':bar_chart:'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining(':bar_chart:'), 'T1', CHROME_REPLY)
 
     // another thread in the SAME channel with no session of its own → falls back to the
     // channel's latest session (still reports the status line, not "nothing here")
     await (daemon as any).onInboundOutcome({ ...dm('400', '!status'), thread: 'T9' })
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining(':bar_chart:'), 'T9')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining(':bar_chart:'), 'T9', CHROME_REPLY)
 
     // a channel with no session at all → a "nothing here" note
     await (daemon as any).onInboundOutcome({
@@ -903,7 +922,12 @@ describe('Daemon in-conversation commands', () => {
       thread: 'T2',
       msgId: 'slack:C2:500'
     })
-    expect(conn.postMessage).toHaveBeenCalledWith('C2', expect.stringContaining('No active session'), 'T2')
+    expect(conn.postMessage).toHaveBeenCalledWith(
+      'C2',
+      expect.stringContaining('No active session'),
+      'T2',
+      CHROME_REPLY
+    )
 
     await daemon.stop()
   })
@@ -924,13 +948,13 @@ describe('Daemon in-conversation commands', () => {
 
     await (daemon as any).onInboundOutcome(dm('200', '!fast on'))
     expect(await store.getFastModeOverride(key)).toBe(true)
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Fast mode on'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Fast mode on'), 'T1', CHROME_REPLY)
 
     await (daemon as any).onInboundOutcome(dm('300', '!fast off'))
     expect(await store.getFastModeOverride(key)).toBe(false)
 
     await (daemon as any).onInboundOutcome(dm('400', '!fast'))
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Usage:'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Usage:'), 'T1', CHROME_REPLY)
 
     await daemon.stop()
   })
@@ -961,7 +985,12 @@ describe('Daemon in-conversation commands', () => {
     await (daemon as any).onInboundOutcome(dm('210', '/models 2'))
     expect(await store.getModelOverride(key)).toBe('sonnet')
     expect(host.setSessionModel).toHaveBeenCalledWith('acp-1', 'sonnet')
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Model set to sonnet'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith(
+      'C1',
+      expect.stringContaining('Model set to sonnet'),
+      'T1',
+      CHROME_REPLY
+    )
 
     // select by name (case-insensitive substring)
     await (daemon as any).onInboundOutcome(dm('220', '/effort HIGH'))
@@ -972,14 +1001,19 @@ describe('Daemon in-conversation commands', () => {
 
     // an unknown value is rejected with the option list, no override written
     await (daemon as any).onInboundOutcome(dm('240', '/models haiku'))
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Unknown model'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Unknown model'), 'T1', CHROME_REPLY)
     expect(await store.getModelOverride(key)).toBe('sonnet')
 
     // a bare command from a DIFFERENT thread still targets the channel's latest session
     // (T1) — the override lands on T1's key, and the reply goes to the sender's thread.
     await (daemon as any).onInboundOutcome({ ...dm('250', '/models 1'), thread: 'T9' })
     expect(await store.getModelOverride(key)).toBe('opus')
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Model set to opus'), 'T9')
+    expect(conn.postMessage).toHaveBeenCalledWith(
+      'C1',
+      expect.stringContaining('Model set to opus'),
+      'T9',
+      CHROME_REPLY
+    )
 
     await daemon.stop()
   })
@@ -1041,7 +1075,8 @@ describe('Daemon in-conversation commands', () => {
     expect(conn.postMessage).toHaveBeenCalledWith(
       'C1',
       expect.stringContaining('Permission mode set to Full Access'),
-      'T1'
+      'T1',
+      CHROME_REPLY
     )
 
     // the default preset resolves from its Codex label too ("ask for approval" → agent)
@@ -2355,6 +2390,31 @@ describe('Slack interactive status bar', () => {
     await daemon.stop()
   })
 
+  it('leaves no transcript row for an unattributed stop (host respawn / agent removal)', async () => {
+    const { host, release } = modelHost()
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => host as any
+    })
+    await daemon.start()
+    routableWithBlocks(daemon)
+
+    const turn = (daemon as any).dispatch('bot-a', dm('100', 'hi'), 'int-a')
+    await vi.waitFor(() => expect(hasPending(daemon, 'acp-1')).toBe(true), WAIT)
+    // `stop` is also the lifecycle reason for a respawn or a removal — no person raised it,
+    // so it must not narrate itself into the conversation.
+    await (daemon as any).interruptTurn('bot-a', SESSION_KEY, 'stop', 'acp-1')
+
+    const store = (daemon as any).store
+    const rows = await store.transcriptSince(transcriptChannelKey('C1', TRANSPORT_SCOPE), 'T1', null)
+    expect(rows.filter((row: any) => row.text.includes('Turn stopped'))).toEqual([])
+
+    release()
+    await turn
+    await daemon.stop()
+  })
+
   it('handleStatusAction routes set-model / cancel by session key', async () => {
     const { host, release } = modelHost()
     const daemon = new Daemon({
@@ -2376,10 +2436,19 @@ describe('Slack interactive status bar', () => {
     expect(await store.getModelOverride(key)).toBe('sonnet-5')
     expect(host.setSessionModel).toHaveBeenCalledWith('acp-1', 'sonnet-5')
 
-    // cancel: interrupts the in-flight turn WITHOUT muting.
-    await (daemon as any).commands.handleStatusAction({ kind: 'cancel', sessionKey: key })
+    // cancel: interrupts the in-flight turn WITHOUT muting, and records WHO — this is the
+    // native Stop's path (agentSessionStopped raises the same action with the clicker).
+    await (daemon as any).commands.handleStatusAction({
+      kind: 'cancel',
+      sessionKey: key,
+      actor: { userId: 'U7', name: 'Ada' }
+    })
     expect(host.cancel).toHaveBeenCalledWith('acp-1')
     expect(await store.isSessionMuted(key)).toBe(false)
+    const rows = await store.transcriptSince(transcriptChannelKey('C1', TRANSPORT_SCOPE), 'T1', null)
+    expect(rows.filter((row: any) => row.text.includes('Turn cancelled')).map((row: any) => row.text)).toEqual([
+      '🛑 Turn cancelled by Ada.'
+    ])
 
     release()
     await t1

--- a/packages/daemon/test/daemon-interrupt-safety.test.ts
+++ b/packages/daemon/test/daemon-interrupt-safety.test.ts
@@ -851,7 +851,9 @@ describe('Daemon interrupt safety gates', () => {
         { agentId: AGENT_ID, integrationId: 'int-a', via: 'mention' }
       )
       expect(await (daemon as any).store.isLoopGuardOpen('slack:C-loop:top-level')).toBe(false)
-      expect(conn.postMessage).toHaveBeenCalledWith('C-loop', expect.stringContaining('Resumed'), '9')
+      expect(conn.postMessage).toHaveBeenCalledWith('C-loop', expect.stringContaining('Resumed'), '9', {
+        chrome: true
+      })
     } finally {
       await daemon.stop()
     }

--- a/packages/daemon/test/durable-inbox.test.ts
+++ b/packages/daemon/test/durable-inbox.test.ts
@@ -1012,7 +1012,9 @@ describe('daemon durable inbox', () => {
     ;(daemon as any).connByIntegration.set('int-a', conn)
     await (daemon as any).onInboundOutcome(msg('10', '!resume'))
     expect(await loopGuard(root)).toMatchObject({ reason: 'automatic_turn_burst' })
-    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('still stopping'), 'T1')
+    expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('still stopping'), 'T1', {
+      chrome: true
+    })
 
     g.releaseOne()
     await expect(head).resolves.toBeNull()


### PR DESCRIPTION
A cancelled turn left nothing behind that the console could show. The session row kept `lastTurnOutcome: 'done'`, the CP snapshot kept `phase: 'end'`, and the transcript recorded no event at all — so a turn someone stopped was indistinguishable from one that simply ran short.

Only `!cancel` looked different, and only by accident: its chat reply was not chrome-marked, so a later thread backfill imported that one line, while the identical interrupt raised from Slack's native Stop imported nothing. That is the inconsistency this closes — in the direction of recording all of them.

## Where the row is written

Every operator path — `!cancel`, `!stop`, Slack's native Stop, a status row still carrying the old overflow option, and the webchat cancel frame — funnels through `interruptTurn`, so that is where the row goes. One line, naming who raised it, on the turn's own transcript coordinates.

**Which interrupts count.** `cancel` has no internal caller, so it always records. `stop` is also the lifecycle reason for a host respawn or an agent removal, so it records only when it carries an actor — an unattributed stop stays silent rather than narrating machinery into the conversation. A regression test pins that.

## Carrying the actor

`InteractionActor` gains the provider's display label (presentation only, never an identity or auth input); a Block Kit click reads `body.user.username`; a chat command projects `msg.sender` into the same shape. Slack's native Stop already raised a `kind: 'cancel'` status action carrying the clicker, so it needed no new plumbing — it simply had nowhere to put the name until now. The webchat frame carries no user, so its row is unsigned.

## Command replies are chrome

They always were — control chrome, not conversation. Marking them says so: thread backfill skips them, the interrupt keeps one record instead of two, and `/status`, `/models` and friends stop leaking their own output into the transcript and into the agent's context on the next turn.

## Verification

`typecheck`, `lint` and `format` are clean. The daemon suite is back to its pre-change baseline: the same 4 files fail for environmental reasons on this machine — the sandbox shim tests (no sandbox available) and `acp-matrix`, which drives live external runtimes that are out of quota or no longer serving.

Stacked on #1581 (comment-only); GitHub retargets this to `main` once that merges.
