### PR TITLE
fix(daemon): carry a Codex command's real output, and de-bold the thinking bodies

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -221,6 +221,15 @@ output as deltas: the text can arrive while the call is still `in_progress` and 
 finishes it carry nothing but a status. Sampling only the terminal update writes a blank body,
 and on a streaming turn there is no separate code-block message left to carry it.
 
+**codex-acp's output arrives by other roads, and both are read.** It sends no `content[]` text
+for a finished call: an MCP tool's result is wrapped as `rawOutput.result.content[]`, and a
+shell command's output does not ride the update AT ALL — it streams as
+`_meta.terminal_output_delta` chunks while the completing update says
+`rawOutput.formatted_output: ""`. The extractor reads both rawOutput shapes, and the daemon
+folds the out-of-band terminal stream back into the owning call at ACP ingress
+(`TerminalOutputFolder`, next to the `maskAgentSecrets` precedent), so the transcript, the web
+console and every platform renderer see the same repaired call — not just this card.
+
 **A thinking card is titled by its run's first line.** Runtimes open a thought with a short
 `**heading**` — the same line the web console shows as the step title — so the card says what
 the agent is thinking about rather than the bare word "Thinking". The card is opened before
@@ -231,11 +240,14 @@ whose head yields nothing keeps the placeholder.
 The two said the same thing: every line of that message is a card title in the container
 directly above it, and a runtime that emits headings without prose made it a verbatim copy of
 the step list. So the card takes the console's shape for a reasoning row — the clamped first
-line as the title, the WHOLE run as the body, including that first line, because the title is a
-truncation and expanding must show what was truncated. The body is dropped only when the TITLE
-shows the run whole — "it has no newline" is not that test, or an unbroken thought longer than
-the clamp would survive as its own first 72 characters and nothing else. A run that outgrows the
-body cap keeps its truncation mark, so a card never presents a cut-off run as a complete one. `medium` keeps
+line as the title, the run as the body. The body is dropped only when the TITLE shows the run
+whole — "it has no newline" is not that test, or an unbroken thought longer than the clamp would
+survive as its own first 72 characters and nothing else; when the title DID show the first line
+whole, that line is dropped from the body instead of being repeated directly under itself. A run
+that outgrows the body cap keeps its truncation mark, so a card never presents a cut-off run as
+a complete one. Bold markers are stripped from the body — runtimes emit every thought heading as
+`**heading**`, so a heading-only run rendered as a slab of bold; the web console strips the same
+marks (`stripBoldMarks`, shared rule, two implementations). `medium` keeps
 neither, as it keeps no other body.
 
 A turn off the axis is untouched — it still posts the in-place Thinking message it always did.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -50,6 +50,7 @@ import { maskableSecrets, maskSecretsDeep } from './session/secret-mask.js'
 import { monotonicTs } from './store/monotonic-ts.js'
 import { StoreRetentionSweeper, resolveStoreRetentionSettings } from './store/retention.js'
 import { TranscriptRecorder, type TranscriptEvent } from './session/transcript-recorder.js'
+import { TerminalOutputFolder } from './session/terminal-output-folder.js'
 import { attachmentMention, sniffImageMimeType } from './session/attachment-block.js'
 import { McpControlServer } from './mcp/control-server.js'
 import { RemoteWebchatGrantManager } from './mcp/remote-webchat-grant.js'
@@ -9949,6 +9950,7 @@ export class Daemon {
       entry,
       conv,
       rec,
+      termOut: new TerminalOutputFolder(),
       chrome: {},
       reply: {
         text: '',
@@ -12604,6 +12606,11 @@ export class Daemon {
     // drop the whole burst before any platform renderer, live webchat stream, GitHub
     // collector, or persisted transcript sees it. The tool callback independently
     // persists and streams the resulting session_info_update.
+    // codex-acp streams a shell command's output as `_meta.terminal_output_delta` chunks and
+    // completes the call with an empty `formatted_output` — fold the buffered text back into
+    // the terminal update HERE, before any consumer, so the transcript (web console), the
+    // GitHub collector and every platform renderer see the same repaired call.
+    update = p.termOut.fold(update)
     const toolCallId = typeof update?.toolCallId === 'string' ? update.toolCallId : ''
     if (toolCallId && isBuiltinSystemToolCall(update)) p.builtinSystemToolCallIds.add(toolCallId)
     if (isSessionTitleToolCall(update)) {

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -9,6 +9,7 @@ import type { ApprovalWait } from '../permissions/coordinator.js'
 import type { GithubTurnState } from '../platforms/github/turn-output.js'
 import type { ModelProviderTarget } from '../runtimes/model-provider-config.js'
 import type { TranscriptRecorder } from '../session/transcript-recorder.js'
+import type { TerminalOutputFolder } from '../session/terminal-output-folder.js'
 import type { OutputConverger, SlackAction } from '../slack/render.js'
 import type { TelegramAction, TelegramConverger } from '../telegram/render.js'
 import type { DiscordAction, DiscordConverger } from '../discord/render.js'
@@ -523,6 +524,9 @@ export interface Pending {
   /** Captures the full activity log (tool/reasoning) from the raw ACP stream,
    *  independent of output mode. Text/result rows are recorded at send time. */
   rec: TranscriptRecorder
+  /** Folds codex-acp's out-of-band `_meta.terminal_output*` stream back into the owning tool
+   *  call at ingress, so every consumer sees the command's real output. */
+  termOut: TerminalOutputFolder
   /** Tool-call ids structurally identified as this daemon's own MCP tools. Approval
    *  requests may carry only this opaque id, regardless of which ACP path is used. */
   builtinSystemToolCallIds: Set<string>

--- a/packages/daemon/src/session/terminal-output-folder.ts
+++ b/packages/daemon/src/session/terminal-output-folder.ts
@@ -1,0 +1,76 @@
+/**
+ * Folds codex-acp's out-of-band terminal output back into the tool call it belongs to.
+ *
+ * For a shell command, codex-acp sends no `content[]` text at all: the output streams as
+ * `_meta.terminal_output_delta` chunks on status-less `tool_call_update`s (or one
+ * `_meta.terminal_output` replacement), and the completing update carries only
+ * `rawOutput.formatted_output: ""`. Nothing downstream reads `_meta`, so the transcript, the
+ * web console and every platform renderer showed a command with an empty result.
+ *
+ * This runs ONCE at the daemon's ACP ingress — the `maskAgentSecrets` precedent — so every
+ * consumer sees the same repaired update: the accumulated text is injected as
+ * `rawOutput.formatted_output` on the call's terminal update, and only when that update did
+ * not carry output of its own.
+ */
+
+/** Head-cap per call, matching the transcript's own single-body ceiling. */
+const MAX_TERMINAL_OUTPUT_BYTES = 1024 * 1024
+
+type MetaOutput = { data?: unknown; terminal_id?: unknown }
+
+type ToolUpdate = {
+  sessionUpdate?: unknown
+  toolCallId?: unknown
+  status?: unknown
+  content?: unknown
+  rawOutput?: unknown
+  _meta?: { terminal_output?: MetaOutput; terminal_output_delta?: MetaOutput }
+}
+
+/** Whether the update already carries readable output — folded text must never clobber it. */
+function carriesOwnOutput(u: ToolUpdate): boolean {
+  if (Array.isArray(u.content)) {
+    for (const item of u.content) {
+      const block = (item as { type?: string; content?: { type?: string; text?: string } } | null)?.content
+      if (block?.type === 'text' && block.text) return true
+    }
+  }
+  if (typeof u.rawOutput === 'string' && u.rawOutput.trim()) return true
+  const formatted = (u.rawOutput as { formatted_output?: unknown } | undefined)?.formatted_output
+  return typeof formatted === 'string' && formatted.trim().length > 0
+}
+
+export class TerminalOutputFolder {
+  private buffers = new Map<string, string>()
+
+  /** Absorb one raw ACP update. Returns the update every downstream consumer should see —
+   *  the same object when there is nothing to fold, a shallow copy with the repaired
+   *  `rawOutput` on the call's terminal update. */
+  fold(update: unknown): unknown {
+    const u = update as ToolUpdate
+    if (u?.sessionUpdate !== 'tool_call' && u?.sessionUpdate !== 'tool_call_update') return update
+    const meta = u._meta
+    const full = meta?.terminal_output
+    const delta = meta?.terminal_output_delta
+    const id =
+      typeof u.toolCallId === 'string' && u.toolCallId
+        ? u.toolCallId
+        : typeof (full ?? delta)?.terminal_id === 'string'
+          ? ((full ?? delta)!.terminal_id as string)
+          : ''
+    if (!id) return update
+    if (typeof full?.data === 'string') this.buffers.set(id, full.data.slice(0, MAX_TERMINAL_OUTPUT_BYTES))
+    else if (typeof delta?.data === 'string') {
+      const held = this.buffers.get(id) ?? ''
+      if (held.length < MAX_TERMINAL_OUTPUT_BYTES) {
+        this.buffers.set(id, held + delta.data.slice(0, MAX_TERMINAL_OUTPUT_BYTES - held.length))
+      }
+    }
+    if (u.status !== 'completed' && u.status !== 'failed') return update
+    const buffered = this.buffers.get(id)
+    this.buffers.delete(id)
+    if (!buffered?.trim() || carriesOwnOutput(u)) return update
+    const rawOutput = u.rawOutput && typeof u.rawOutput === 'object' ? u.rawOutput : {}
+    return { ...u, rawOutput: { ...rawOutput, formatted_output: buffered } }
+  }
+}

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -171,6 +171,13 @@ function clampTo(s: string, max: number): string {
   return t.length > max ? `${t.slice(0, max - 1)}…` : t
 }
 
+/** Drop paired bold markers, keeping every other kind of markdown. Card bodies parse markdown,
+ *  and runtimes write each thought heading as `**heading**` — content worth keeping, shouting
+ *  not. Bounded to a line so a stray `**` cannot swallow text across paragraphs. */
+function stripBoldMarks(s: string): string {
+  return s.replace(/\*\*([^\n]+?)\*\*/g, '$1').replace(/__([^\n]+?)__/g, '$1')
+}
+
 /** Flatten markdown emphasis for a card field. Task titles and plan labels render as PLAIN
  *  text, so `**bold**` would arrive as literal punctuation rather than styling. */
 function plainCardText(s: string): string {
@@ -296,9 +303,16 @@ export function buildAttributionBlocks(info: SlackAttributionInfo): { text: stri
   }
 }
 
-/** Pull human-readable output text out of an ACP tool_call/_update. Prefers the `content[]`
- *  text blocks (the tool's reported output); falls back to a string `rawOutput`. diff /
- *  terminal blocks and non-string rawOutput are skipped — they have no compact inline text. */
+/**
+ * Pull human-readable output text out of an ACP tool_call/_update. Prefers the `content[]`
+ * text blocks (the tool's reported output); diff / terminal blocks are skipped — they have no
+ * compact inline text.
+ *
+ * `rawOutput` is the fallback, and it is not one shape: codex-acp sends NO content for a
+ * finished shell command — the output rides `rawOutput.formatted_output` — and wraps an MCP
+ * tool's result as `rawOutput.result.content[]` text blocks. Both are read here, or a Codex
+ * turn's cards and tool-output blocks carry commands with no results at all.
+ */
 function extractToolOutput(update: { content?: unknown; rawOutput?: unknown }): string {
   const content = update.content
   if (Array.isArray(content)) {
@@ -311,7 +325,23 @@ function extractToolOutput(update: { content?: unknown; rawOutput?: unknown }): 
     }
     if (parts.length) return parts.join('\n').trim()
   }
-  return typeof update.rawOutput === 'string' ? update.rawOutput.trim() : ''
+  const raw = update.rawOutput
+  if (typeof raw === 'string') return raw.trim()
+  if (raw && typeof raw === 'object') {
+    const r = raw as { formatted_output?: unknown; result?: { content?: unknown } }
+    if (typeof r.formatted_output === 'string') return r.formatted_output.trim()
+    const nested = r.result?.content
+    if (Array.isArray(nested)) {
+      const parts = nested
+        .filter((b): b is { type: string; text: string } => {
+          const x = b as { type?: unknown; text?: unknown } | null
+          return !!x && x.type === 'text' && typeof x.text === 'string'
+        })
+        .map((b) => b.text)
+      if (parts.length) return parts.join('\n').trim()
+    }
+  }
+  return ''
 }
 
 type PlanEntry = { content?: string; status?: 'pending' | 'in_progress' | 'completed' }
@@ -1171,19 +1201,30 @@ export class OutputConverger {
   }
 
   /**
-   * What a settled thinking card shows under its title on `high`: the WHOLE run, exactly as the
-   * web console's work rows do — the title is a clamped first line, so expanding must show it in
-   * full rather than a headless remainder.
+   * What a settled thinking card shows under its title on `high`: the run, as the web console's
+   * work rows show it — de-bolded, and without re-saying a title that was shown whole.
    *
    * The body is dropped only when the TITLE already shows the run whole. "Has no newline" is not
    * that test: a single unbroken line longer than the title clamp would then survive only as its
    * own first 72 characters, and with the reasoning message gone there is nothing else holding
-   * the rest.
+   * the rest. When the title DID show the first line whole, that line is dropped from the body
+   * instead — repeating it directly under itself says nothing.
+   *
+   * Bold markers are stripped: runtimes emit every thought heading as `**heading**`, so a
+   * heading-only run rendered as a slab of bold. The headings are the content; the shouting is
+   * not. Other markdown is left alone.
    */
   private thinkingRunBody(title: string): string {
     if (this.mode !== 'high') return ''
-    const body = this.thinkingBody.trim()
+    let body = stripBoldMarks(this.thinkingBody.trim())
     if (!body || plainCardText(body) === title) return ''
+    // Unclamped comparison on purpose: a truncated title differs from its full first line, and
+    // a body under a truncated title must keep that line — it is what the title could not show.
+    const nl = body.indexOf('\n')
+    if (nl >= 0 && plainCardText(body.slice(0, nl)) === title) {
+      body = body.slice(nl + 1).trim()
+      if (!body) return ''
+    }
     return this.thinkingBodyTruncated ? `${body}…` : body
   }
 

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import type { CreateElicitationRequest, RequestPermissionRequest } from '@agentclientprotocol/sdk'
 import { Daemon, noneSuppressedApprovalSurface, isBuiltinSystemTool, isBuiltinSystemToolCall } from '../src/daemon.js'
 import { ALL_TOOL_NAMES } from '../src/mcp/tools.js'
+import { TerminalOutputFolder } from '../src/session/terminal-output-folder.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -134,7 +135,8 @@ function installPending(daemon: Daemon): {
     builtinSystemToolCallIds: new Set<string>(),
     hiddenSessionTitleToolCallIds: new Set<string>(),
     conv: { onUpdate: () => [], hasBuffered: () => false },
-    rec: { onUpdate: () => [] }
+    rec: { onUpdate: () => [] },
+    termOut: new TerminalOutputFolder()
   }
   ;(daemon as any).pending.set(JSON.stringify(['agent-1', 's1']), pending)
   return pending

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -192,6 +192,53 @@ describe('OutputConverger streaming axis', () => {
     expect(all).toContainEqual({ type: 'plan_update', title: 'Completed 2 steps · 1 failed' })
   })
 
+  it('reads codex-shaped rawOutput — formatted_output and nested MCP result content', () => {
+    // codex-acp sends no content[] text: a shell command's output rides rawOutput.formatted_output
+    // and an MCP tool's rides rawOutput.result.content[]. Without both, a Codex turn's cards
+    // carry commands with no results.
+    const shell = streaming('high')
+    shell.onUpdate({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 't1',
+      title: 'git log --oneline -1',
+      status: 'completed',
+      rawOutput: { formatted_output: 'fc380b458 docs(design): …', exit_code: 0 }
+    } as never)
+    expect(cards(shell.streamUpdate())[0]).toMatchObject({ output: 'fc380b458 docs(design): …' })
+
+    const mcp = streaming('high')
+    mcp.onUpdate({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 't2',
+      title: 'getCurrentChannel',
+      status: 'failed',
+      rawOutput: { result: { content: [{ type: 'text', text: 'no live platform connection' }] }, error: null }
+    } as never)
+    expect(cards(mcp.streamUpdate())[0]).toMatchObject({ output: 'no live platform connection' })
+  })
+
+  it('de-bolds a thinking body and drops a first line its title already shows whole', () => {
+    const converger = streaming('high')
+    converger.onUpdate(think('**Weighing the options**\n\n**Charting the next step**'))
+    converger.onUpdate(tool('t1', 'Read file'))
+    expect(cards(converger.streamUpdate())).toContainEqual({
+      type: 'task_update',
+      id: 'thinking-0',
+      title: 'Weighing the options',
+      status: 'complete',
+      // No bold markers, and no repeat of the title line the reader can already see.
+      details: 'Charting the next step'
+    })
+
+    // A truncated title keeps its first line — that line is what the title could not show.
+    const clamped = streaming('high')
+    const long = `Weighing whether the ${'very '.repeat(20)}long branch settles`
+    clamped.onUpdate(think(`**${long}**\nbody`))
+    clamped.onUpdate(tool('t1', 'Read file'))
+    const card = cards(clamped.streamUpdate()).find((c) => c.type === 'task_update' && c.id === 'thinking-0')
+    expect(card?.type === 'task_update' && card.details?.startsWith(long)).toBe(true)
+  })
+
   it('keeps the (failed) prefix through the title clamp, and the body on high', () => {
     const converger = streaming('high')
     const long = `Weighing whether the ${'very '.repeat(20)}long command settles`
@@ -511,7 +558,7 @@ describe('OutputConverger streaming axis', () => {
     expect(legacy.flushBuffered().some((a) => a.kind === 'reasoning')).toBe(true)
   })
 
-  it('gives a high thinking card the whole run as its body, as the console’s work rows do', () => {
+  it('gives a high thinking card the run as its body, as the console’s work rows do', () => {
     const high = streaming('high')
     high.onUpdate(think('**Weighing the options**\n\nboth branches settle the same way.'))
     high.onUpdate(tool('t1', 'Read file'))
@@ -520,8 +567,8 @@ describe('OutputConverger streaming axis', () => {
       id: 'thinking-0',
       title: 'Weighing the options',
       status: 'complete',
-      // The title is a clamped first line, so expanding shows the run in full, not a remainder.
-      details: '**Weighing the options**\n\nboth branches settle the same way.'
+      // De-bolded, and without the first line — the title already shows it whole.
+      details: 'both branches settle the same way.'
     })
 
     // A single-line run has nothing beyond its title, and medium has no body at all.

--- a/packages/daemon/test/terminal-output-folder.test.ts
+++ b/packages/daemon/test/terminal-output-folder.test.ts
@@ -1,0 +1,84 @@
+/**
+ * codex-acp sends a shell command's output OUT OF BAND — `_meta.terminal_output_delta`
+ * chunks on status-less updates, then a terminal update whose own `formatted_output` is
+ * empty. The folder repairs the terminal update at ACP ingress so every consumer (the
+ * transcript, the web console, the Slack card) sees the command's real output.
+ */
+import { describe, expect, it } from 'vitest'
+import { TerminalOutputFolder } from '../src/session/terminal-output-folder.js'
+
+const delta = (id: string, data: string) => ({
+  sessionUpdate: 'tool_call_update',
+  toolCallId: id,
+  _meta: { terminal_output_delta: { data, terminal_id: id } }
+})
+const done = (id: string, rawOutput: unknown = { formatted_output: '', exit_code: 0 }) => ({
+  sessionUpdate: 'tool_call_update',
+  toolCallId: id,
+  status: 'completed',
+  rawOutput
+})
+
+describe('TerminalOutputFolder', () => {
+  it('accumulates deltas and injects them into the terminal update', () => {
+    const folder = new TerminalOutputFolder()
+    expect(folder.fold(delta('t1', 'line one\n'))).toEqual(delta('t1', 'line one\n'))
+    folder.fold(delta('t1', 'line two'))
+    expect(folder.fold(done('t1'))).toMatchObject({
+      status: 'completed',
+      rawOutput: { formatted_output: 'line one\nline two', exit_code: 0 }
+    })
+  })
+
+  it('treats terminal_output as a whole replacement', () => {
+    const folder = new TerminalOutputFolder()
+    folder.fold(delta('t1', 'partial'))
+    folder.fold({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 't1',
+      _meta: { terminal_output: { data: 'the whole thing', terminal_id: 't1' } }
+    })
+    expect(folder.fold(done('t1'))).toMatchObject({ rawOutput: { formatted_output: 'the whole thing' } })
+  })
+
+  it('never clobbers output the update carries itself', () => {
+    const folder = new TerminalOutputFolder()
+    folder.fold(delta('t1', 'buffered'))
+    const own = done('t1', { formatted_output: 'already here', exit_code: 0 })
+    expect(folder.fold(own)).toBe(own)
+    const withContent = {
+      ...done('t2'),
+      content: [{ type: 'content', content: { type: 'text', text: 'tool said this' } }]
+    }
+    folder.fold(delta('t2', 'buffered'))
+    expect(folder.fold(withContent)).toBe(withContent)
+  })
+
+  it('drops the buffer once the call settles, and keeps calls separate', () => {
+    const folder = new TerminalOutputFolder()
+    folder.fold(delta('t1', 'first call'))
+    folder.fold(delta('t2', 'second call'))
+    expect(folder.fold(done('t1'))).toMatchObject({ rawOutput: { formatted_output: 'first call' } })
+    // A repeated terminal update finds nothing left to inject.
+    const again = done('t1')
+    expect(folder.fold(again)).toBe(again)
+    expect(folder.fold(done('t2'))).toMatchObject({ rawOutput: { formatted_output: 'second call' } })
+  })
+
+  it('leaves failed calls repaired too, and non-tool updates alone', () => {
+    const folder = new TerminalOutputFolder()
+    folder.fold(delta('t1', 'exit 1 detail'))
+    expect(folder.fold({ ...delta('t1', ''), status: 'failed' })).toMatchObject({
+      rawOutput: { formatted_output: 'exit 1 detail' }
+    })
+    const chunk = { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hi' } }
+    expect(folder.fold(chunk)).toBe(chunk)
+  })
+
+  it('caps a runaway stream at the transcript body ceiling', () => {
+    const folder = new TerminalOutputFolder()
+    for (let i = 0; i < 24; i++) folder.fold(delta('t1', 'y'.repeat(64 * 1024)))
+    const folded = folder.fold(done('t1')) as { rawOutput: { formatted_output: string } }
+    expect(folded.rawOutput.formatted_output.length).toBe(1024 * 1024)
+  })
+})

--- a/packages/web/src/components/console/session-work.test.ts
+++ b/packages/web/src/components/console/session-work.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { sessionTurnInFlight, toggleWorkPanel, workCounts, workPanelOpen, workSummary } from './session-work'
+import {
+  sessionTurnInFlight,
+  stripBoldMarks,
+  toggleWorkPanel,
+  workCounts,
+  workPanelOpen,
+  workSummary
+} from './session-work'
 
 const step = (lane: string, files: string[] = []) => ({ lane, files: files.map((path) => ({ path })) })
 
@@ -95,5 +102,18 @@ describe('work panel visibility', () => {
   it('an explicit open during streaming survives the turn completing', () => {
     const opened = toggleWorkPanel(new Map(), 'turn-a', workPanelOpen(undefined))
     expect(workPanelOpen(opened.get('turn-a'))).toBe(true)
+  })
+})
+
+describe('stripBoldMarks', () => {
+  it('drops paired bold markers and keeps everything else', () => {
+    expect(stripBoldMarks('**Planning peer polling**\n\n**Testing retrieval**')).toBe(
+      'Planning peer polling\n\nTesting retrieval'
+    )
+    expect(stripBoldMarks('keep `code` and _italics_ and __under__')).toBe('keep `code` and _italics_ and under')
+  })
+
+  it('never pairs markers across lines — a stray ** cannot swallow a paragraph', () => {
+    expect(stripBoldMarks('a stray ** here\nand ** another line')).toBe('a stray ** here\nand ** another line')
   })
 })

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -64,6 +64,14 @@ export function toggleWorkPanel(
   return next
 }
 
+/** Drop paired bold markers from reasoning text, keeping every other kind of markdown.
+ *  Runtimes write each thought heading as `**heading**`, so a heading-only run renders as a
+ *  slab of bold — the headings are the content, the shouting is not. Bounded to a line so a
+ *  stray `**` cannot swallow text across paragraphs. The Slack plan card does the same. */
+export function stripBoldMarks(s: string): string {
+  return s.replace(/\*\*([^\n]+?)\*\*/g, '$1').replace(/__([^\n]+?)__/g, '$1')
+}
+
 const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`
 
 /** One-line label for the collapsed work: reasoning steps, tool commands, and file

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -97,6 +97,7 @@ import {
   NOTICE_LANE,
   WORK_LANES,
   sessionTurnInFlight,
+  stripBoldMarks,
   toggleWorkPanel,
   workCounts,
   workPanelOpen,
@@ -418,7 +419,9 @@ function msgStep(m: SessionMessageDto, toolSessionId?: string, platform?: string
       weight: 500,
       textColor: 'var(--text-tertiary)',
       codeColor: 'var(--text-secondary)',
-      text: m.text,
+      // De-bolded: runtimes write every thought heading as `**heading**`, and a heading-only
+      // run rendered as a slab of bold. The Slack plan card strips the same marks.
+      text: stripBoldMarks(m.text),
       code: '',
       files: [],
       time: formatTranscriptRowTime(m),
@@ -500,7 +503,7 @@ function thinkStep(text: string, time?: string, platform?: string): FmtStep {
     weight: 500,
     textColor: 'var(--text-tertiary)',
     codeColor: 'var(--text-secondary)',
-    text,
+    text: stripBoldMarks(text),
     code: '',
     files: [],
     ...(time ? { time } : {}),


### PR DESCRIPTION
Three fixes from reading a live Codex turn's plan card: the card's expanded steps carried
commands with no output, and the thinking bodies rendered as a slab of bold that repeated their
own titles.

## A Codex shell command's output reached nobody

codex-acp sends no `content[]` text for a finished call. An MCP tool's result is wrapped as
`rawOutput.result.content[]`; a shell command's output does not ride the update at all — it
streams as `_meta.terminal_output_delta` chunks (confirmed against the adapter source), and the
completing update says `rawOutput.formatted_output: ""`. Nothing consumed that meta, so the
transcript, the web console's OUTPUT box, and the Slack card all showed the command with an
empty result.

- A new `TerminalOutputFolder` folds the buffered stream back into the owning call's terminal
  update **at ACP ingress** — the `maskAgentSecrets` precedent: one transform on the entry
  point, and every consumer (transcript → web, converger → Slack, GitHub collector) sees the
  same repaired call. It never clobbers output an update carries itself, caps at the
  transcript's own 1 MiB body ceiling, and drops each buffer once its call settles.
- The Slack extractor also learns both rawOutput shapes (`formatted_output`, nested MCP
  `result.content[]`) for the updates that do carry them.

## Thinking bodies were a slab of bold, repeating their titles

Runtimes emit every thought heading as `**heading**`, and card bodies parse markdown, so a
heading-only run rendered all-bold — identically on the web console. Both surfaces now strip
paired bold markers (line-bounded so a stray `**` cannot swallow a paragraph); all other
markdown is left alone. And the body now drops its first line when the title already shows it
whole — keeping it when the title was truncated, because then it is exactly what the title
could not show.

## Reviewer notes

- The folder lives on the pending turn and runs in the platform dispatch path only; memory
  extraction / dream transcripts are unchanged.
- `stripBoldMarks` exists twice (daemon render, web session-work) by design — the packages
  share no utility dependency, and each copy is one two-line function beside its tests.
- Verified: 179 daemon tests (5 new folder cases + 2 new converger cases), 2144 web tests,
  typecheck / lint / format clean.
