### PR TITLE
fix(daemon): one tool-output extractor for four platforms, honest fold caps, live de-bold

### DIFF
--- a/packages/daemon/src/discord/render.ts
+++ b/packages/daemon/src/discord/render.ts
@@ -2,6 +2,7 @@ import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
+import { extractToolOutput } from '../session/tool-output.js'
 
 /**
  * The mode-aware ACP→Discord intermediate representation — the Discord analog of
@@ -116,23 +117,6 @@ function mdPre(s: string): string {
 function capOutput(s: string): string {
   const t = s.trim()
   return t.length > MAX_TOOL_OUTPUT ? `${t.slice(0, MAX_TOOL_OUTPUT - 1)}…` : t
-}
-
-/** Pull human-readable output text out of an ACP tool_call/_update (content[] text
- *  blocks preferred; string rawOutput fallback). Mirrors telegram/render's extractor. */
-function extractToolOutput(update: { content?: unknown; rawOutput?: unknown }): string {
-  const content = update.content
-  if (Array.isArray(content)) {
-    const parts: string[] = []
-    for (const item of content) {
-      if (!item || typeof item !== 'object') continue
-      if ((item as { type?: string }).type !== 'content') continue
-      const block = (item as { content?: { type?: string; text?: string } }).content
-      if (block?.type === 'text' && block.text) parts.push(block.text)
-    }
-    if (parts.length) return parts.join('\n').trim()
-  }
-  return typeof update.rawOutput === 'string' ? update.rawOutput.trim() : ''
 }
 
 type PlanEntry = { content?: string; status?: 'pending' | 'in_progress' | 'completed' }

--- a/packages/daemon/src/feishu/render.ts
+++ b/packages/daemon/src/feishu/render.ts
@@ -2,6 +2,7 @@ import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import type { WireFeishuCardActionTarget } from '@agentconnect.md/protocol'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
+import { extractToolOutput } from '../session/tool-output.js'
 
 /**
  * The mode-aware ACP→Feishu intermediate representation — the Feishu analog of
@@ -325,23 +326,6 @@ function fencedPre(s: string): string {
 function capOutput(s: string): string {
   const t = s.trim()
   return t.length > MAX_TOOL_OUTPUT ? `${t.slice(0, MAX_TOOL_OUTPUT - 1)}…` : t
-}
-
-/** Pull human-readable output text out of an ACP tool_call/_update (content[] text
- *  blocks preferred; string rawOutput fallback). Mirrors telegram/discord render's extractor. */
-function extractToolOutput(update: { content?: unknown; rawOutput?: unknown }): string {
-  const content = update.content
-  if (Array.isArray(content)) {
-    const parts: string[] = []
-    for (const item of content) {
-      if (!item || typeof item !== 'object') continue
-      if ((item as { type?: string }).type !== 'content') continue
-      const block = (item as { content?: { type?: string; text?: string } }).content
-      if (block?.type === 'text' && block.text) parts.push(block.text)
-    }
-    if (parts.length) return parts.join('\n').trim()
-  }
-  return typeof update.rawOutput === 'string' ? update.rawOutput.trim() : ''
 }
 
 type PlanEntry = { content?: string; status?: 'pending' | 'in_progress' | 'completed' }

--- a/packages/daemon/src/session/terminal-output-folder.ts
+++ b/packages/daemon/src/session/terminal-output-folder.ts
@@ -13,8 +13,11 @@
  * not carry output of its own.
  */
 
-/** Head-cap per call, matching the transcript's own single-body ceiling. */
-const MAX_TERMINAL_OUTPUT_BYTES = 1024 * 1024
+/** Head-cap per call, WELL below the transcript's 1 MiB body ceiling: that ceiling measures
+ *  the serialized whole ToolBody in UTF-8 bytes and sheds `rawOutput` entirely when over, so
+ *  a fold near the ceiling would erase itself. 256 KiB of UTF-16 code units stays under it
+ *  even at 3 bytes per unit, with room for rawInput/content and JSON escaping. */
+const MAX_TERMINAL_OUTPUT_UNITS = 256 * 1024
 
 type MetaOutput = { data?: unknown; terminal_id?: unknown }
 
@@ -59,11 +62,15 @@ export class TerminalOutputFolder {
           ? ((full ?? delta)!.terminal_id as string)
           : ''
     if (!id) return update
-    if (typeof full?.data === 'string') this.buffers.set(id, full.data.slice(0, MAX_TERMINAL_OUTPUT_BYTES))
-    else if (typeof delta?.data === 'string') {
+    // BOTH meta spellings carry deltas: codex-acp routes every chunk through the same
+    // stream and `terminal_output` merely renames the key when the client advertises that
+    // capability — `createTerminalOutputMeta` is handed `event.delta` either way, never the
+    // aggregate. Treating it as a replacement would collapse a command to its last chunk.
+    const data = typeof full?.data === 'string' ? full.data : typeof delta?.data === 'string' ? delta.data : ''
+    if (data) {
       const held = this.buffers.get(id) ?? ''
-      if (held.length < MAX_TERMINAL_OUTPUT_BYTES) {
-        this.buffers.set(id, held + delta.data.slice(0, MAX_TERMINAL_OUTPUT_BYTES - held.length))
+      if (held.length < MAX_TERMINAL_OUTPUT_UNITS) {
+        this.buffers.set(id, held + data.slice(0, MAX_TERMINAL_OUTPUT_UNITS - held.length))
       }
     }
     if (u.status !== 'completed' && u.status !== 'failed') return update

--- a/packages/daemon/src/session/terminal-output-folder.ts
+++ b/packages/daemon/src/session/terminal-output-folder.ts
@@ -2,9 +2,8 @@
  * Folds codex-acp's out-of-band terminal output back into the tool call it belongs to.
  *
  * For a shell command, codex-acp sends no `content[]` text at all: the output streams as
- * `_meta.terminal_output_delta` chunks on status-less `tool_call_update`s (or one
- * `_meta.terminal_output` replacement), and the completing update carries only
- * `rawOutput.formatted_output: ""`. Nothing downstream reads `_meta`, so the transcript, the
+ * `_meta.terminal_output*` delta chunks on status-less `tool_call_update`s, and the completing
+ * update carries only `rawOutput.formatted_output: ""`. Nothing downstream reads `_meta`, so the transcript, the
  * web console and every platform renderer showed a command with an empty result.
  *
  * This runs ONCE at the daemon's ACP ingress — the `maskAgentSecrets` precedent — so every
@@ -15,8 +14,9 @@
 
 /** Head-cap per call, WELL below the transcript's 1 MiB body ceiling: that ceiling measures
  *  the serialized whole ToolBody in UTF-8 bytes and sheds `rawOutput` entirely when over, so
- *  a fold near the ceiling would erase itself. 256 KiB of UTF-16 code units stays under it
- *  even at 3 bytes per unit, with room for rawInput/content and JSON escaping. */
+ *  a fold near the ceiling would erase itself. 256 KiB of UTF-16 code units leaves ample
+ *  room in practice (JSON-escaped control characters can reach 6 bytes per unit, but terminal
+ *  output is overwhelmingly printable), plus headroom for rawInput/content. */
 const MAX_TERMINAL_OUTPUT_UNITS = 256 * 1024
 
 type MetaOutput = { data?: unknown; terminal_id?: unknown }

--- a/packages/daemon/src/session/tool-output.ts
+++ b/packages/daemon/src/session/tool-output.ts
@@ -1,0 +1,40 @@
+/**
+ * Pull human-readable output text out of an ACP tool_call/_update — the ONE copy every
+ * platform renderer uses, so a runtime's shape learned once is learned everywhere.
+ *
+ * Prefers the `content[]` text blocks (the tool's reported output); diff / terminal blocks are
+ * skipped — they have no compact inline text. `rawOutput` is the fallback, and it is not one
+ * shape: codex-acp sends NO content for a finished shell command — the output rides
+ * `rawOutput.formatted_output` (folded there at ACP ingress by `TerminalOutputFolder`) — and
+ * wraps an MCP tool's result as `rawOutput.result.content[]` text blocks.
+ */
+export function extractToolOutput(update: { content?: unknown; rawOutput?: unknown }): string {
+  const content = update.content
+  if (Array.isArray(content)) {
+    const parts: string[] = []
+    for (const item of content) {
+      if (!item || typeof item !== 'object') continue
+      if ((item as { type?: string }).type !== 'content') continue
+      const block = (item as { content?: { type?: string; text?: string } }).content
+      if (block?.type === 'text' && block.text) parts.push(block.text)
+    }
+    if (parts.length) return parts.join('\n').trim()
+  }
+  const raw = update.rawOutput
+  if (typeof raw === 'string') return raw.trim()
+  if (raw && typeof raw === 'object') {
+    const r = raw as { formatted_output?: unknown; result?: { content?: unknown } }
+    if (typeof r.formatted_output === 'string') return r.formatted_output.trim()
+    const nested = r.result?.content
+    if (Array.isArray(nested)) {
+      const parts = nested
+        .filter((b): b is { type: string; text: string } => {
+          const x = b as { type?: unknown; text?: unknown } | null
+          return !!x && x.type === 'text' && typeof x.text === 'string'
+        })
+        .map((b) => b.text)
+      if (parts.length) return parts.join('\n').trim()
+    }
+  }
+  return ''
+}

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -19,6 +19,7 @@ import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
 import { splitIntoSections } from './formatter.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
+import { extractToolOutput } from '../session/tool-output.js'
 
 /**
  * The mode-aware ACP→Slack intermediate representation (§9.1). The daemon's
@@ -301,47 +302,6 @@ export function buildAttributionBlocks(info: SlackAttributionInfo): { text: stri
     text: attributionText(info),
     blocks: [{ type: 'context', elements: [{ type: 'mrkdwn', text: attributionMrkdwn(info) }] }]
   }
-}
-
-/**
- * Pull human-readable output text out of an ACP tool_call/_update. Prefers the `content[]`
- * text blocks (the tool's reported output); diff / terminal blocks are skipped — they have no
- * compact inline text.
- *
- * `rawOutput` is the fallback, and it is not one shape: codex-acp sends NO content for a
- * finished shell command — the output rides `rawOutput.formatted_output` — and wraps an MCP
- * tool's result as `rawOutput.result.content[]` text blocks. Both are read here, or a Codex
- * turn's cards and tool-output blocks carry commands with no results at all.
- */
-function extractToolOutput(update: { content?: unknown; rawOutput?: unknown }): string {
-  const content = update.content
-  if (Array.isArray(content)) {
-    const parts: string[] = []
-    for (const item of content) {
-      if (!item || typeof item !== 'object') continue
-      if ((item as { type?: string }).type !== 'content') continue
-      const block = (item as { content?: { type?: string; text?: string } }).content
-      if (block?.type === 'text' && block.text) parts.push(block.text)
-    }
-    if (parts.length) return parts.join('\n').trim()
-  }
-  const raw = update.rawOutput
-  if (typeof raw === 'string') return raw.trim()
-  if (raw && typeof raw === 'object') {
-    const r = raw as { formatted_output?: unknown; result?: { content?: unknown } }
-    if (typeof r.formatted_output === 'string') return r.formatted_output.trim()
-    const nested = r.result?.content
-    if (Array.isArray(nested)) {
-      const parts = nested
-        .filter((b): b is { type: string; text: string } => {
-          const x = b as { type?: unknown; text?: unknown } | null
-          return !!x && x.type === 'text' && typeof x.text === 'string'
-        })
-        .map((b) => b.text)
-      if (parts.length) return parts.join('\n').trim()
-    }
-  }
-  return ''
 }
 
 type PlanEntry = { content?: string; status?: 'pending' | 'in_progress' | 'completed' }

--- a/packages/daemon/src/telegram/render.ts
+++ b/packages/daemon/src/telegram/render.ts
@@ -2,6 +2,7 @@ import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import { splitIntoSections } from '../messages/split-sections.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
+import { extractToolOutput } from '../session/tool-output.js'
 
 /**
  * The mode-aware ACP→Telegram intermediate representation — the Telegram analog of
@@ -100,23 +101,6 @@ function htmlPre(s: string): string {
 function capOutput(s: string): string {
   const t = s.trim()
   return t.length > MAX_TOOL_OUTPUT ? `${t.slice(0, MAX_TOOL_OUTPUT - 1)}…` : t
-}
-
-/** Pull human-readable output text out of an ACP tool_call/_update (content[] text
- *  blocks preferred; string rawOutput fallback). Mirrors slack/render's extractor. */
-function extractToolOutput(update: { content?: unknown; rawOutput?: unknown }): string {
-  const content = update.content
-  if (Array.isArray(content)) {
-    const parts: string[] = []
-    for (const item of content) {
-      if (!item || typeof item !== 'object') continue
-      if ((item as { type?: string }).type !== 'content') continue
-      const block = (item as { content?: { type?: string; text?: string } }).content
-      if (block?.type === 'text' && block.text) parts.push(block.text)
-    }
-    if (parts.length) return parts.join('\n').trim()
-  }
-  return typeof update.rawOutput === 'string' ? update.rawOutput.trim() : ''
 }
 
 type PlanEntry = { content?: string; status?: 'pending' | 'in_progress' | 'completed' }

--- a/packages/daemon/test/terminal-output-folder.test.ts
+++ b/packages/daemon/test/terminal-output-folder.test.ts
@@ -30,15 +30,18 @@ describe('TerminalOutputFolder', () => {
     })
   })
 
-  it('treats terminal_output as a whole replacement', () => {
+  it('treats terminal_output as the same delta stream under another key', () => {
+    // codex-acp routes every chunk through one stream; `terminal_output` only renames the
+    // meta key when the client advertises the capability. A replacement reading would
+    // collapse a command's output to its last chunk.
     const folder = new TerminalOutputFolder()
-    folder.fold(delta('t1', 'partial'))
+    folder.fold(delta('t1', 'first chunk\n'))
     folder.fold({
       sessionUpdate: 'tool_call_update',
       toolCallId: 't1',
-      _meta: { terminal_output: { data: 'the whole thing', terminal_id: 't1' } }
+      _meta: { terminal_output: { data: 'second chunk', terminal_id: 't1' } }
     })
-    expect(folder.fold(done('t1'))).toMatchObject({ rawOutput: { formatted_output: 'the whole thing' } })
+    expect(folder.fold(done('t1'))).toMatchObject({ rawOutput: { formatted_output: 'first chunk\nsecond chunk' } })
   })
 
   it('never clobbers output the update carries itself', () => {
@@ -75,10 +78,12 @@ describe('TerminalOutputFolder', () => {
     expect(folder.fold(chunk)).toBe(chunk)
   })
 
-  it('caps a runaway stream at the transcript body ceiling', () => {
+  it('caps a runaway stream well below the transcript body ceiling', () => {
+    // The transcript sheds rawOutput ENTIRELY when the serialized body tops 1 MiB, so a
+    // fold near that ceiling would erase itself — the cap has to leave serialization room.
     const folder = new TerminalOutputFolder()
     for (let i = 0; i < 24; i++) folder.fold(delta('t1', 'y'.repeat(64 * 1024)))
     const folded = folder.fold(done('t1')) as { rawOutput: { formatted_output: string } }
-    expect(folded.rawOutput.formatted_output.length).toBe(1024 * 1024)
+    expect(folded.rawOutput.formatted_output.length).toBe(256 * 1024)
   })
 })

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -545,7 +545,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             if ((step.agentId ?? undefined) !== agentId) continue
             if (step.turnId !== turnId) break
             if (step.boundary) break
-            if (step.kind === 'done') collapsed[i] = { ...step, kind: 'plan' }
+            if (step.kind === 'done') collapsed[i] = { ...step, kind: 'plan', demoted: true }
           }
           // The marker lives INSIDE the collapsible work lane ('plan'), at the
           // chronological point the update happened — it is live-only chrome (a

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -715,7 +715,9 @@ function fmtStep(stp: SessionStep, platform?: string): FmtStep {
     weight: L.weight,
     textColor: L.textColor,
     codeColor: L.codeColor,
-    text: stp.text,
+    // Live reasoning ('plan' steps) de-bolds exactly as the persisted THINK rows do — the
+    // same run must not read bold while streaming and plain once re-read from history.
+    text: stp.kind === 'plan' ? stripBoldMarks(stp.text) : stp.text,
     code: stp.code ?? '',
     files: (stp.files ?? []).map((f) => ({ tag: f.tag, path: f.path, color: fileColor(f.tag) })),
     time: stp.time ?? '',

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -716,8 +716,10 @@ function fmtStep(stp: SessionStep, platform?: string): FmtStep {
     textColor: L.textColor,
     codeColor: L.codeColor,
     // Live reasoning ('plan' steps) de-bolds exactly as the persisted THINK rows do — the
-    // same run must not read bold while streaming and plain once re-read from history.
-    text: stp.kind === 'plan' ? stripBoldMarks(stp.text) : stp.text,
+    // same run must not read bold while streaming and plain once re-read from history. A
+    // DEMOTED step is a superseded answer collapsed into this lane, still message text, and
+    // keeps its emphasis.
+    text: stp.kind === 'plan' && !stp.demoted ? stripBoldMarks(stp.text) : stp.text,
     code: stp.code ?? '',
     files: (stp.files ?? []).map((f) => ({ tag: f.tag, path: f.path, color: fileColor(f.tag) })),
     time: stp.time ?? '',

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1090,6 +1090,9 @@ export interface SessionStep {
    *  step's lane never merges across it, so a replacement generation starts
    *  fresh blocks while the marker stays a visible part of the conversation. */
   boundary?: boolean
+  /** A superseded answer's streamed `done` blocks, re-tagged 'plan' to collapse into the work
+   *  lane. Still MESSAGE text — renderers must not apply reasoning-only treatment to it. */
+  demoted?: boolean
   /** Display timestamp for live/mock-only steps. Persisted transcripts use their raw ts. */
   time?: string
   text: string


### PR DESCRIPTION
Four review findings on #1586's own additions, raised after it merged — each verified against
the sources before fixing.

## One extractor for four platforms

Only Slack had learned codex-acp's rawOutput shapes; `telegram/render.ts`,
`discord/render.ts` and `feishu/render.ts` still dropped any non-string `rawOutput`, so a
folded Codex command rendered there with no output — the very symptom #1586 fixed — and the
three "mirror" copies had silently diverged. The extractor now lives once in
`session/tool-output.ts`, imported by all four renderers.

## An honest fold cap

The transcript ceiling measures the serialized **whole** ToolBody in UTF-8 bytes, and
`serializeBody` sheds `rawOutput` entirely when over — so a fold near 1 MiB erased itself:
capped output arrived as *no* output, plus the UTF-16/UTF-8 unit mismatch. The cap drops to
256 KiB of code units, which stays under the ceiling even at 3 bytes per unit with room for
`rawInput`/`content` and JSON escaping.

## `terminal_output` is the same delta stream

Confirmed in codex-acp: every chunk routes through one stream and the meta key is merely
renamed by client capability — `createTerminalOutputMeta` is handed `event.delta`, never the
aggregate. The folder now appends under both keys; the old replacement reading would have
collapsed a command's output to its last chunk the day `terminal_output: true` is ever
advertised.

## Live reasoning de-bolds too

The console's live path ('plan' steps from the playground stream) bypassed the persisted-row
de-bold, so the same run read bold while streaming and plain after a re-read from history.
`fmtStep` now strips the same marks — at render, never in the accumulator, so bold pairs
split across stream chunks still resolve once complete.

## Verification

282 daemon tests across the four renderer suites, the folder (updated delta/cap cases), and
the permission-autoallow suite; web typecheck; lint and format clean.
