### PR TITLE
fix(daemon): keep background-task delivery out of the live foreground turn

### DIFF
--- a/docs/designs/background-task-aware-reclaim.md
+++ b/docs/designs/background-task-aware-reclaim.md
@@ -153,9 +153,21 @@ Delivery follows these rules:
 - Internal subagents never produce this notification.
 - `task_updated` can supply a terminal status; a completion edge without a
   status uses the description alone.
+- A task that settles inside the session's own live foreground loop — a
+  `running` SDK cycle with a pending dispatch — is neither announced nor woken
+  (§5.1): the runtime hands the result to the model in that loop, and the
+  turn's own chrome already shows the step. Auto-backgrounded commands
+  (sleeps, watchers) settle this way every time. Both conditions are required:
+  `running` without a pending dispatch is an invisible self-drain cycle, and a
+  pending dispatch past `idle` is finalization the model has already left. A
+  settle that races the loop's very end may forfeit the runtime's follow-up
+  narration; its MCP side effects still land, and that narrow loss is accepted
+  over announcing every in-turn completion twice.
 
 The message is daemon-authored system output, not an agent reply, so it has no
-agent-attribution footer.
+agent-attribution footer. On platforms that mark notices it is posted as
+chrome with the agent's visual identity (name and icon), so thread backfill
+skips it instead of re-ingesting it as something the agent said.
 
 The runtime's own unsolicited follow-up narration is not routed when no
 foreground turn is pending. This is not a stylistic choice — `onAcpUpdate`
@@ -194,6 +206,8 @@ The daemon therefore delivers it, as a new turn into the same session:
 - The reply transport is resolved from the **session's** transport scope, not the
   agent's default integration.
 
+No wake is armed for a task that settled inside the session's own live
+foreground loop (§5) — the loop already delivered the completion to the model.
 The wake is armed on a `BG_TASK_WAKE_GRACE_MS` (4s) delay and every precondition
 is re-checked when it fires, never captured when it is armed:
 

--- a/docs/designs/background-task-aware-reclaim.md
+++ b/docs/designs/background-task-aware-reclaim.md
@@ -166,8 +166,10 @@ Delivery follows these rules:
 
 The message is daemon-authored system output, not an agent reply, so it has no
 agent-attribution footer. On platforms that mark notices it is posted as
-chrome with the agent's visual identity (name and icon), so thread backfill
-skips it instead of re-ingesting it as something the agent said.
+chrome with the agent's visual identity (name and icon) in channels — a DM
+keeps the bot's own identity, per the conversational-authorship rule — so
+thread backfill skips it instead of re-ingesting it as something the agent
+said.
 
 The runtime's own unsolicited follow-up narration is not routed when no
 foreground turn is pending. This is not a stylistic choice — `onAcpUpdate`

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13847,7 +13847,13 @@ export class Daemon {
       // turn re-delivering it — auto-backgrounded commands (sleeps, watchers) settle here every
       // time. Both conditions are required: `running` without a Pending is an invisible
       // self-drain cycle, and a Pending past `idle` is finalization the model has already left.
-      if (lease.sdkState === 'running' && this.pending.has(pendingTurnKey(agentId, acpSessionId))) return
+      if (lease.sdkState === 'running' && this.pending.has(pendingTurnKey(agentId, acpSessionId))) {
+        this.log.debug(
+          `bg-task delivery skipped (settled inside the live foreground turn): ` +
+            `"${rec.description?.trim() || 'background task'}" on ${acpSessionId}`
+        )
+        return
+      }
       await this.announceBackgroundTaskDone(agentId, acpSessionId, rec.description, status)
       this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, rec.description, status)
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13841,6 +13841,13 @@ export class Daemon {
       lease.settled.push({ id: taskId, ...rec, endedAt: this.clock.now(), status })
       if (lease.settled.length > MAX_SETTLED_TASKS_PER_SESSION) lease.settled.shift()
       if (rec.isSubagent) return
+      // Settled inside this session's own live foreground loop (running SDK cycle + pending
+      // dispatch): the runtime hands the result to the model in that loop and the turn's chrome
+      // already shows the step, so the announce would say it twice and the wake would burn a
+      // turn re-delivering it — auto-backgrounded commands (sleeps, watchers) settle here every
+      // time. Both conditions are required: `running` without a Pending is an invisible
+      // self-drain cycle, and a Pending past `idle` is finalization the model has already left.
+      if (lease.sdkState === 'running' && this.pending.has(pendingTurnKey(agentId, acpSessionId))) return
       await this.announceBackgroundTaskDone(agentId, acpSessionId, rec.description, status)
       this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, rec.description, status)
     }
@@ -13941,9 +13948,10 @@ export class Daemon {
   }
 
   /** Proactively announce a completed background task to its session's channel/thread
-   *  (a plain system notice, like the loop-guard warning — not an agent response, so
-   *  no attribution footer). Gated on output mode ≥ medium; skipped for closed
-   *  sessions, missing bindings, or non-Claude sessions with no lease. */
+   *  (a system notice, like the gating notice — not an agent response, so no attribution
+   *  footer). Chrome-marked with the agent's identity where the platform supports it, so
+   *  thread backfill never re-ingests it as something the agent said. Gated on output mode
+   *  ≥ medium; skipped for closed sessions, missing bindings, or sessions with no lease. */
   private async announceBackgroundTaskDone(
     agentId: string,
     acpSessionId: string,
@@ -13959,7 +13967,19 @@ export class Daemon {
     if (!conn) return
     const what = description?.trim() || 'background task'
     const text = `🔔 Background task finished: ${what}${status ? ` (${status})` : ''}`
-    void Promise.resolve(conn.postMessage(rec.channel, text, rec.thread || undefined)).catch((err) =>
+    const agent = this.agents.get(agentId)
+    const post = turnChromeFor(rec.platform).chromeMarkedNotices
+      ? (conn as SlackConnection).postMessage(rec.channel, text, rec.thread || undefined, {
+          ...(slackPostOptions({
+            platform: rec.platform,
+            isDm: rec.conversationKind === 'dm',
+            agentName: agent?.displayName?.trim() || agent?.name || agentId,
+            ...(agent?.iconUrl ? { iconUrl: agent.iconUrl } : {})
+          }) ?? {}),
+          chrome: true
+        })
+      : conn.postMessage(rec.channel, text, rec.thread || undefined)
+    void Promise.resolve(post).catch((err) =>
       this.log.warn(`bg-task announce failed for "${agentId}": ${(err as Error).message}`)
     )
   }

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -1565,15 +1565,62 @@ describe('Daemon idle sweep — background-task lease', () => {
     )
 
     expect(conn.postMessage).toHaveBeenCalledTimes(1)
-    const [channel, text, thread] = (conn.postMessage as any).mock.calls[0]
+    const [channel, text, thread, options] = (conn.postMessage as any).mock.calls[0]
     expect(channel).toBe('C1')
     expect(thread).toBe('T1')
     expect(text).toContain('Sleep for 15 seconds')
     expect(text).toContain('completed')
+    // Chrome-marked so thread backfill never re-ingests the notice as agent speech;
+    // a DM keeps the bot's own identity (no username/icon override), per slackPostOptions.
+    expect(options).toMatchObject({ chrome: true })
+    expect(options.username).toBeUndefined()
 
     // The near-simultaneous task_notification for the same task must NOT double-post.
     await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
     expect(conn.postMessage).toHaveBeenCalledTimes(1)
+    await daemon.stop()
+  })
+
+  it('neither announces nor wakes a task that settles inside a live foreground turn', async () => {
+    const clock = new FakeClock()
+    const { host, release } = blockingHost()
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold({ agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 }),
+      hostFactory: () => host as any,
+      clock
+    })
+    await daemon.start()
+    const conn = makeRoutable(daemon)
+    const turn = (daemon as any).dispatch('bot-a', dm('100', 'hello'), 'int-a')
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(1), WAIT)
+
+    // The loop is live (running SDK cycle + pending dispatch): the runtime hands the result
+    // to the model in-turn and the turn's chrome shows the step — the daemon stays quiet.
+    await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+    await (daemon as any).onSdkLifecycle(
+      'bot-a',
+      'acp-1',
+      evt('task_started', { task_id: 't1', description: 'Wait 5 seconds' })
+    )
+    await (daemon as any).onSdkLifecycle(
+      'bot-a',
+      'acp-1',
+      evt('task_updated', { task_id: 't1', patch: { status: 'completed' } })
+    )
+
+    expect(JSON.stringify((conn.postMessage as any).mock.calls)).not.toContain('Background task finished')
+    expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(0)
+    expect((daemon as any).bgWakeTimers.size).toBe(0)
+    // Still retained for the tasks panel — only the delivery is skipped.
+    expect((daemon as any).sdkLease.get(LEASE_KEY)?.settled?.length).toBe(1)
+
+    await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+    release()
+    await turn
+    clock.advance(10_000)
+    await new Promise((r) => setImmediate(r))
+    expect(host.prompt).toHaveBeenCalledTimes(1) // no wake turn either
     await daemon.stop()
   })
 


### PR DESCRIPTION
## Problem

Observed live on Slack: a turn that ran two `sleep 5` commands produced two mid-turn `🔔 Background task finished: …` messages **while the turn was still streaming its own plan card** (which already showed those exact steps), and then a post-turn completion wake burned a whole extra model turn that correctly concluded there was nothing to do. The announces also rendered under the bot's default identity — no agent name or icon — because the post carried no options at all.

Mechanism: the Claude runtime reports auto-backgrounded commands (sleeps, watchers) through the task lifecycle feed even though it hands their results back to the model inside the same loop. The daemon's `settle()` treated every non-subagent settle as a stranded completion.

## Fix

- **Settle gate**: a task that settles while the session's own foreground loop is live — `sdkState === 'running'` **and** a pending dispatch for that (agent, ACP session) — is neither announced nor woken. Both conditions are required: `running` without a Pending is an invisible self-drain cycle (announce/wake are the only visible signals there), and a Pending past `idle` is finalization the model has already left. The settled record is still retained for the tasks panel.
- **Announce identity**: the announce now posts like the other daemon-authored notices (`surfaceTurnFailure`, the gating notice): chrome-marked, with the agent's name and icon in channels (DMs keep the bot's own identity, per `slackPostOptions`). Chrome-marking also stops thread backfill from re-ingesting the notice into the transcript and later model context as something the agent said — which is exactly how these lines were ending up in the session transcript.

Accepted tradeoff (documented in the design doc): a settle that races the loop's very end may forfeit the runtime's invisible follow-up narration; its MCP side effects still land. That narrow loss is taken over double-announcing every in-turn completion.

## Tests

- New: a task settling inside a live foreground turn (blocking prompt) produces no announce, arms no wake, spends no wake budget, and still retains the settled record.
- Extended: the existing announce test now pins `chrome: true` and no username override in a DM.
- `daemon-lifecycle.test.ts` 71/71, package typecheck, lint, prettier all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
