### PR TITLE
ci: exempt the Windows job's file churn from real-time scanning

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -249,6 +249,15 @@ jobs:
       run:
         shell: bash
     steps:
+      # The daemon suite creates and deletes a temporary root, a SQLite database and its two WAL
+      # siblings per store, thousands of times over, and real-time scanning charges for each write.
+      # Advisory, so `continue-on-error`: a runner image without Defender must not fail the job here.
+      - name: Exempt the workspace from real-time scanning
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE", "$env:RUNNER_TEMP", "$env:TEMP"
+          Add-MpPreference -ExclusionProcess 'node.exe', 'git.exe'
       # Before checkout: the runner's Git installs with `core.autocrlf=true`, which would rewrite
       # every fixture's line endings and diverge golden files from the Linux jobs' bytes.
       - name: Keep line endings as committed


### PR DESCRIPTION
## Why

`Unit Test (Windows)` runs ~22 min against ~3 for the slowest Linux job, and 1211 s of that is the daemon suite alone. The per-test tax over Linux is 5.9x (2374.7 s of test time against 400.8 s), and it is not evenly spread — it tracks filesystem churn:

```
local-store.test.ts        win 171.2s  linux  10.5s  x16.4
telegram-threading.test.ts win  38.0s  linux   2.0s  x19.4
daemon-duty-fence.test.ts  win  41.2s  linux   3.3s  x12.6
workspace-secondary-roots  win 172.9s  linux  58.3s   x3.0   <- real git, not store churn
```

That profile is what real-time scanning charges for. 148 of the suite's 308 files open a temporary root per case; each store there is a SQLite database plus the `-wal` and `-shm` siblings beside it, and `LocalStore.open` writes them thousands of times over a run.

## What

One step, first in the job so it covers checkout and install as well as the suite. It excludes both temp roots because they are different drives on this runner — `os.tmpdir()` resolves onto the OS drive while `RUNNER_TEMP` is the workspace drive — and the two binaries doing the writing.

`continue-on-error` is deliberate: this only ever buys time, so a runner image with no Defender to configure must not fail the job over a step that was never load-bearing.

## Expected effect

20-40% on a suite with this profile is the usual range, but the only measurement that counts is this job's own, so the number to read is the one this PR's run reports. This is orthogonal to #1589, which restores the worker count — the two touch disjoint files and each is measurable against its own base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
