### PR TITLE
fix(web): stop a superseded answer inflating the collapsed-work step count

### DIFF
--- a/packages/web/src/components/console/session-work.test.ts
+++ b/packages/web/src/components/console/session-work.test.ts
@@ -9,6 +9,7 @@ import {
 } from './session-work'
 
 const step = (lane: string, files: string[] = []) => ({ lane, files: files.map((path) => ({ path })) })
+const demotedStep = (lane: string) => ({ ...step(lane), demoted: true })
 
 describe('workCounts', () => {
   it('counts edited FILES by path, not EDIT-step count (one EDIT row, two files → 2)', () => {
@@ -33,6 +34,18 @@ describe('workCounts', () => {
       toolCount: 2,
       editCount: 0
     })
+  })
+
+  it('leaves a superseded answer demoted into the work lane out of the reasoning count', () => {
+    // The playground re-tags a superseded turn's streamed `done` blocks as PLAN — message text, not thoughts.
+    expect(workCounts([step('THINK'), demotedStep('PLAN'), demotedStep('PLAN')])).toEqual({
+      thinkCount: 1,
+      toolCount: 0,
+      editCount: 0
+    })
+    // A turn whose only work is the demoted answer reports no work at all.
+    const only = workCounts([demotedStep('PLAN')])
+    expect(workSummary(only.thinkCount, only.toolCount, only.editCount)).toBe('')
   })
 
   it('feeds the summary so one EDIT row with two files reads "edited 2 files"', () => {

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -12,25 +12,25 @@ export const NOTICE_LANE = 'NOTICE'
  *  reasoning STEPS (THINK/PLAN), tool-command STEPS (TOOL), and edited FILES — the
  *  DISTINCT file paths across all EDIT steps (a single EDIT row can touch several
  *  files), with a metadata-less EDIT row counting as one file. Files are counted by
- *  path, not by EDIT-row count, so "1 EDIT step touching a.ts + b.ts" reads "2 files". */
-export function workCounts(steps: { lane: string; files: { path: string }[] }[]): {
+ *  path, not by EDIT-row count, so "1 EDIT step touching a.ts + b.ts" reads "2 files".
+ *  A DEMOTED step — a superseded answer re-tagged into this lane — is skipped, not counted. */
+export function workCounts(steps: { lane: string; files: { path: string }[]; demoted?: boolean }[]): {
   thinkCount: number
   toolCount: number
   editCount: number
 } {
+  let thinkCount = 0
   let toolCount = 0
-  let editStepCount = 0
   let bareEdits = 0
   const editPaths = new Set<string>()
   for (const s of steps) {
     if (s.lane === 'TOOL') toolCount += 1
     else if (s.lane === 'EDIT') {
-      editStepCount += 1
       if (s.files.length === 0) bareEdits += 1
       else for (const f of s.files) editPaths.add(f.path)
-    }
+    } else if (!s.demoted) thinkCount += 1
   }
-  return { thinkCount: steps.length - toolCount - editStepCount, toolCount, editCount: editPaths.size + bareEdits }
+  return { thinkCount, toolCount, editCount: editPaths.size + bareEdits }
 }
 
 /** Is a turn in flight for this session? `rawState` is the session's RAW daemon

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -454,6 +454,8 @@ interface FmtStep {
   code: string
   files: { tag: string; path: string; color: string }[]
   time?: string
+  // A superseded answer collapsed into this lane — carried so the summary can skip it.
+  demoted?: boolean
   // A peer participant's message attachment (rendered like the user bubble's).
   image?: SessionImage
   // Present only on real-transcript tool rows that carry a captured body.
@@ -723,6 +725,7 @@ function fmtStep(stp: SessionStep, platform?: string): FmtStep {
     code: stp.code ?? '',
     files: (stp.files ?? []).map((f) => ({ tag: f.tag, path: f.path, color: fileColor(f.tag) })),
     time: stp.time ?? '',
+    ...(stp.demoted ? { demoted: true } : {}),
     ...(platform ? { platform } : {}),
     // The live wire frame carries no body (kept off the hot path); attach just
     // enough of a SessionMessageDto shape for ToolBodyDetail to pull the same


### PR DESCRIPTION
## What

The collapsed-work toggle line over-counted reasoning steps on a superseded turn.

`PlaygroundProvider` re-tags a superseded turn's streamed `done` blocks as `kind: 'plan'`
so they collapse into the work lane instead of standing as a stale answer. `workCounts`
credited every non-TOOL, non-EDIT step to the reasoning tally, so those demoted answer
blocks were counted as thoughts — a turn with one real thought and two demoted blocks read
"Thought through 3 steps".

Those blocks already carry the `demoted` marker, which is what keeps them out of the
reasoning-only de-bold in `fmtStep`. This reuses it:

- `fmtStep` carries `demoted` onto `FmtStep`, so the flag survives the lane mapping.
- `workCounts` skips a demoted step rather than counting it.
- `workCounts` also tallies reasoning **directly** in the loop instead of deriving it as
  `steps.length - toolCount - editStepCount`. That subtraction is what let an uncounted
  lane silently fall through into the think count in the first place; counting explicitly
  makes each lane's contribution local and visible.

## Why it is safe

Behaviour is unchanged for every step that is not demoted — the direct tally and the old
subtraction agree exactly when nothing is demoted.

A turn whose *only* work is the demoted answer now reports no work at all. That is already
handled at the render site, which falls back to `summary || 'Details'`.

Only `fmtStep` sets the flag. The other `FmtStep` producers (`msgStep`, `plainStep`,
`thinkStep`) deliberately do not: demotion is live-only chrome, not something persisted
transcripts carry.

## Testing

New unit case in `session-work.test.ts` covering one THINK plus two demoted PLAN steps
(expects `thinkCount: 1`) and the all-demoted turn (expects an empty summary). Verified it
is a real regression test by reverting just the guard — it fails with `thinkCount: 3`, the
exact over-count reported.

`typecheck`, `lint`, prettier all clean; full web suite passes (2145 tests, 189 files).

## Note for the reviewer

Flagged by review-bot on #1587 as pre-existing and out of that PR's scope. It depends on
the `demoted` marker #1587 added, so this is the follow-up; rebased onto main now that
#1587 has landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
