### PR TITLE
feat(daemon): commit staged answer segments at tool boundaries

### DIFF
--- a/docs/designs/turn-final-context-refresh.md
+++ b/docs/designs/turn-final-context-refresh.md
@@ -236,18 +236,29 @@ Masked ACP updates still feed usage, title handling, approval/elicitation handli
 and the private activity recorder. Answer-bearing `agent_message_chunk` updates feed
 the attempt buffer, not the platform converger's send path.
 
-The first version should allow only non-answer chrome to remain live:
+Non-answer chrome remains live:
 
 - Slack status, Discord/Telegram typing, and a Feishu "Thinking" card may be shown.
 - Permission or elicitation UI must remain interactive.
 - Tool/plan/reasoning messages may remain visible according to output mode, but they
   must be tagged as trusted chrome and excluded from context refresh.
-- No candidate answer body or answer attribution footer is published until commit.
 
-This changes the perceived streaming behavior: answer text arrives at commit rather
-than token-by-token. That tradeoff is required for genuine discard semantics. A future
-platform-specific implementation may stream into a private/draft surface, but public
-messages must obey the same commit rule.
+Answer text commits per **segment**, not per turn. A boundary the live renderer
+flushes buffered text on — `tool_call`, `tool_call_update`, `agent_thought_chunk`,
+`plan` — commits the staged text ahead of it: the staged chunks replay in order
+through the platform converger (which still applies its own mode semantics), the
+text appends to the turn's canonical reply, and the stage clears. Interleaved
+"say → work → say more" therefore reaches the channel as it happens, as separate
+messages, instead of collapsing into one body at turn end. Turn-end housekeeping
+updates (usage, session titles) are deliberately not boundaries, so the closing
+segment — the text after the model's last tool or thinking step — stays staged
+until the final context fence.
+
+Discard semantics narrow accordingly: a segment committed at a boundary is
+already said, exactly like any other message in the thread that precedes a
+late-arriving event; only the closing segment is regenerable. Token-by-token
+streaming of the closing segment is still withheld until commit — that remains
+required for its discard semantics.
 
 ### 5.3 Final refresh and regeneration
 
@@ -255,9 +266,9 @@ After `host.prompt()` resolves, the workflow performs another refresh using the
 generation's revision and provider checkpoint. If no invalidating event exists, it
 enters the commit protocol in section 7.
 
-If new events exist, the workflow drops the `AttemptBuffer` and sends one replacement
-prompt to the same ACP session. The daemon-generated prefix should be stable and
-provider-neutral:
+If new events exist, the workflow drops the `AttemptBuffer` — which by then holds
+only the closing segment (§5.2) — and sends one replacement prompt to the same ACP
+session. The daemon-generated prefix should be stable and provider-neutral:
 
 ```text
 (AgentConnect context update: the conversation changed while you were working.
@@ -269,6 +280,12 @@ unless it matters to the user.)
 (new thread messages, oldest to newest)
 [sender-id] message text
 ```
+
+When earlier segments of the answer were already committed at a boundary, the
+heading instead says that everything before the model's last tool or thinking step
+was delivered and stands, and asks for a replacement of the undelivered closing
+part alone (`contextUpdateText`'s `deliveredPrefix` variant) — otherwise the model
+reasonably re-says the whole answer.
 
 The replacement prompt contains only events after the previous generation fence; the
 ACP session already contains the original prompt and prior candidate. The workflow then

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -531,6 +531,7 @@ import {
   MAX_TURN_CONTEXT_REGENERATIONS,
   PROBE_ROOT_SWEEP_INTERVAL_MS,
   SANDBOX_BOOTSTRAP_NOTICE,
+  SEGMENT_BOUNDARY_UPDATES,
   SESSION_RETENTION_SWEEP_INTERVAL_MS
 } from './daemon/constants.js'
 import type {
@@ -7700,11 +7701,17 @@ export class Daemon {
     }
   }
 
-  /** Move only the accepted generation through the existing renderer. This call and
-   * the first enqueue performed by the caller form the local answer commit point. */
-  private acceptStagedAttempt(pending: Pending): void {
-    pending.reply.text = pending.reply.attemptText
-    for (const update of pending.reply.attemptAnswerUpdates) {
+  /** Commit the staged segment through the existing renderer: append it to the turn's
+   * canonical text, replay its chunks in order, and clear the stage. Called at each
+   * tool/thought/plan boundary (mid-turn segment) and by the final context fence (the
+   * closing tail) — this call and the first enqueue performed by the caller form the
+   * local answer commit point for the segment. */
+  private commitStagedSegment(pending: Pending): void {
+    pending.reply.text += pending.reply.attemptText
+    const updates = pending.reply.attemptAnswerUpdates
+    pending.reply.attemptText = ''
+    pending.reply.attemptAnswerUpdates = []
+    for (const update of updates) {
       for (const action of pending.conv.onUpdate(update)) this.enqueueApply(pending, action)
     }
   }
@@ -10517,7 +10524,7 @@ export class Daemon {
       )
 
       if (invalidatingEvents.length === 0) {
-        if (p.plan.stageAnswer) this.acceptStagedAttempt(p)
+        if (p.plan.stageAnswer) this.commitStagedSegment(p)
         if (generation > 0) defaultTurnOutputMetrics.regeneration(p.plan.platform, 'accepted')
         defaultTurnOutputMetrics.generations(generation + 1)
         baseRevision = finalRevision
@@ -10623,7 +10630,11 @@ export class Daemon {
       promptBlocks = [
         {
           type: 'text',
-          text: contextUpdateText(invalidatingEvents, (event) => this.observedQuoteBlock(event, invalidatingEvents))
+          // Segments already committed at a boundary were delivered and stand; the model
+          // must be told so, or it regenerates (and re-says) the whole answer.
+          text: contextUpdateText(invalidatingEvents, (event) => this.observedQuoteBlock(event, invalidatingEvents), {
+            deliveredPrefix: p.plan.stageAnswer && p.reply.text.length > 0
+          })
         }
       ]
       finalCaptureInput = recallQueryFromBlocks([{ type: 'text', text: finalCaptureInput }, ...promptBlocks])
@@ -12629,6 +12640,13 @@ export class Daemon {
     // A continuation turn drives BOTH: the browser sink and the platform renderer (§5.2).
     if (p.webchat) webchatTurnOutput.emitWebchatUpdate(p.webchat, update)
     if ((!p.webchat || p.webchat.continuation) && !isHeadlessGithubFinal && !(p.plan.stageAnswer && isAnswerChunk)) {
+      // Segment commit: a boundary the live renderer flushes on delivers the staged text
+      // ahead of it, so "say → work → say more" reaches the channel as it happens (the
+      // renderer still applies its own mode semantics to the replayed chunks). Turn-end
+      // housekeeping (usage, titles) is NOT a boundary — the closing segment stays staged
+      // for the final context fence, which is what regeneration can still replace.
+      if (p.plan.stageAnswer && SEGMENT_BOUNDARY_UPDATES.has(String(update?.sessionUpdate)) && p.reply.attemptText)
+        this.commitStagedSegment(p)
       for (const action of p.conv.onUpdate(update)) this.enqueueApply(p, action)
       this.armIdle(p)
       this.armFeishuStream(p)

--- a/packages/daemon/src/daemon/constants.ts
+++ b/packages/daemon/src/daemon/constants.ts
@@ -4,6 +4,11 @@ import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 // grow `queued` without bound. Past the cap we reject with a clear message.
 export const MAX_QUEUED_PER_SESSION = 10
 export const MAX_TURN_CONTEXT_REGENERATIONS = 3
+/** Updates the live renderer flushes buffered text on. A staged turn commits its current
+ *  segment ahead of one of these, so interleaved "say → work → say more" posts as it
+ *  happens; turn-end housekeeping (usage, titles) is deliberately absent so the closing
+ *  segment stays staged for the final context fence. */
+export const SEGMENT_BOUNDARY_UPDATES = new Set(['tool_call', 'tool_call_update', 'agent_thought_chunk', 'plan'])
 /** How many absorbed transcript `ts` values one session key remembers — enough to cover every
  *  activation still travelling to the gate while a turn folds context, and no more. */
 export const ABSORBED_CONTEXT_TS_MEMORY = 64

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -446,9 +446,11 @@ export interface TurnChromeCursors {
 export interface ReplyAccumulator {
   /** Complete raw assistant text, used only as input to opt-in memory distillation. */
   text: string
-  /** IM answer text is generation-local until the final context fence accepts it. */
+  /** IM answer text staged since the last committed segment boundary; the final
+   *  context fence commits the closing segment (the only regenerable one). */
   attemptText: string
-  /** Answer-bearing ACP updates withheld from the platform converger until commit. */
+  /** Answer-bearing ACP updates withheld from the platform converger until their
+   *  segment commits — at a tool/thought/plan boundary, or at the final fence. */
   attemptAnswerUpdates: any[]
   /** Current successfully-delivered agent reply message. `footerKey` records which footer
    *  it owns; progress/tool/reasoning chrome never replaces this pointer. */

--- a/packages/daemon/src/session/thread-context.ts
+++ b/packages/daemon/src/session/thread-context.ts
@@ -119,19 +119,28 @@ export class ThreadContextCoordinator {
 }
 
 /** Stable, provider-neutral replacement prompt. The bounded newest suffix matches
- * the daemon's existing replay cap and keeps chronological order inside the suffix. */
+ * the daemon's existing replay cap and keeps chronological order inside the suffix.
+ * `deliveredPrefix`: segments of the answer already committed at a tool/thought
+ * boundary were delivered and stand — only the closing segment is regenerable. */
 export function contextUpdateText(
   events: readonly TranscriptRow[],
-  quoteFor?: (event: TranscriptRow) => string | undefined
+  quoteFor?: (event: TranscriptRow) => string | undefined,
+  opts?: { deliveredPrefix?: boolean }
 ): string {
   const suffix = events.slice(-MAX_CONTEXT_REFRESH_EVENTS)
   const elided = events.length - suffix.length
-  const heading =
-    '(AgentConnect context update: the conversation changed while you were working.\n' +
-    'Your previous candidate answer was not delivered. Re-evaluate the task using the new\n' +
-    'thread messages below and produce a replacement final answer. Preserve useful work\n' +
-    'already completed, do not repeat side effects blindly, and do not mention this retry\n' +
-    'unless it matters to the user.)'
+  const heading = opts?.deliveredPrefix
+    ? '(AgentConnect context update: the conversation changed while you were working.\n' +
+      'The parts of your answer written before your last tool or thinking step were\n' +
+      'already delivered and stand; only the text after them was not. Re-evaluate with\n' +
+      'the new thread messages below and produce a replacement for that undelivered part\n' +
+      'alone — do not repeat what was already delivered, do not repeat side effects\n' +
+      'blindly, and do not mention this retry unless it matters to the user.)'
+    : '(AgentConnect context update: the conversation changed while you were working.\n' +
+      'Your previous candidate answer was not delivered. Re-evaluate the task using the new\n' +
+      'thread messages below and produce a replacement final answer. Preserve useful work\n' +
+      'already completed, do not repeat side effects blindly, and do not mention this retry\n' +
+      'unless it matters to the user.)'
   const deltaHeading =
     elided > 0 ? `(new thread messages — ${elided} earlier message(s) elided)` : '(new thread messages)'
   const rows = suffix.flatMap((event) => {

--- a/packages/daemon/test/turn-output-workflow.test.ts
+++ b/packages/daemon/test/turn-output-workflow.test.ts
@@ -213,6 +213,122 @@ describe('TurnOutputWorkflow', () => {
     await daemon.stop()
   })
 
+  it('commits a staged segment at a tool boundary, as its own message, while the turn is still running', async () => {
+    let onUpdate!: (sessionId: string, update: unknown) => void
+    let releasePrompt!: () => void
+    const blocked = new Promise<void>((resolve) => (releasePrompt = resolve))
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-1'),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sessionId: string) => {
+        onUpdate(sessionId, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hi' } })
+        onUpdate(sessionId, {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-1',
+          title: 'sleep 5',
+          status: 'in_progress'
+        })
+        await blocked // the boundary has arrived; the turn itself is far from over
+        onUpdate(sessionId, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hi again' } })
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: (_agent, update) => {
+        onUpdate = update
+        return host as any
+      }
+    })
+    await daemon.start()
+    const conn = connect(daemon)
+
+    const turn = (daemon as any).dispatch('bot-a', msg('100.1', 'say hi twice'), 'int-a')
+    // The first segment posts when the tool boundary arrives — mid-turn, not at commit.
+    await vi.waitFor(() => {
+      expect(conn.postMessage.mock.calls.map((call) => String(call[1]))).toContain('hi')
+    }, WAIT)
+    releasePrompt()
+    await turn
+
+    const bodies = conn.postMessage.mock.calls.map((call) => String(call[1]))
+    expect(bodies.filter((body) => body === 'hi')).toHaveLength(1)
+    expect(bodies).toContain('hi again') // the closing segment commits at the fence
+    await daemon.stop()
+  })
+
+  it('keeps a committed segment through regeneration and replaces only the closing segment', async () => {
+    let onUpdate!: (sessionId: string, update: unknown) => void
+    let releaseFirst!: () => void
+    const firstBlocked = new Promise<void>((resolve) => (releaseFirst = resolve))
+    const prompts: string[] = []
+    const host = {
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-1'),
+      hasSession: vi.fn(() => true),
+      prompt: vi.fn(async (sessionId: string, blocks: { text?: string }[]) => {
+        prompts.push(blocks.map((block) => block.text ?? '').join('\n'))
+        if (prompts.length === 1) {
+          onUpdate(sessionId, {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'committed lead' }
+          })
+          onUpdate(sessionId, {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'tc-1',
+            title: 'check',
+            status: 'in_progress'
+          })
+          onUpdate(sessionId, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'stale tail' } })
+          await firstBlocked
+        } else {
+          onUpdate(sessionId, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'fresh tail' } })
+        }
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(async () => {}),
+      stop: vi.fn(async () => {})
+    }
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: (_agent, update) => {
+        onUpdate = update
+        return host as any
+      }
+    })
+    await daemon.start()
+    const conn = connect(daemon)
+
+    const firstMessage = msg('100.1', 'original request')
+    const first = (daemon as any).dispatch('bot-a', firstMessage, 'int-a')
+    await vi.waitFor(() => {
+      expect(conn.postMessage.mock.calls.map((call) => String(call[1]))).toContain('committed lead')
+    }, WAIT)
+
+    const clarification = (daemon as any).dispatch('bot-a', msg('100.2', 'important clarification'), 'int-a')
+    const key = sessionKey('slack', 'C1', 'T1', 'bot-a', firstMessage.transportScope)
+    await vi.waitFor(() => expect((daemon as any).serialQueue.get(key)).toHaveLength(1))
+    releaseFirst()
+
+    await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
+    await expect(first).resolves.toBe('acp-1')
+    await expect(clarification).resolves.toBe('acp-1')
+
+    // The replacement prompt admits the delivered prefix instead of claiming nothing landed.
+    expect(prompts[1]).toContain('already delivered and stand')
+    expect(prompts[1]).not.toContain('Your previous candidate answer was not delivered')
+    const bodies = conn.postMessage.mock.calls.map((call) => String(call[1]))
+    expect(bodies.filter((body) => body === 'committed lead')).toHaveLength(1) // stands, never re-posted
+    expect(bodies).toContain('fresh tail')
+    expect(bodies.join('\n')).not.toContain('stale tail') // only the closing segment was regenerable
+    await daemon.stop()
+  })
+
   it('coalesces a clarification represented in the first prompt before initiating it', async () => {
     let onUpdate!: (sessionId: string, update: unknown) => void
     let release!: () => void


### PR DESCRIPTION
## Problem

A staged chat turn (`stageAnswer`, the turn-final context-refresh path) held **every** answer chunk until the final fence and replayed them in one consecutive burst. The tool boundaries the live renderer splits messages on were long gone by replay time, so a turn that said something, ran tools, then said more collapsed into one merged body at turn end — "hi" + "hi" arrived as a single "hihi", and the model's composed pacing was erased. The reference behavior (interactive harness surfaces) posts each text block as its own message, as it happens.

## Fix: per-segment commit

When a boundary the live renderer flushes on (`tool_call`, `tool_call_update`, `agent_thought_chunk`, `plan`) arrives while staged text is pending, the staged chunks replay in order through the platform converger **ahead of it**, append to the turn's canonical text, and the stage clears (`commitStagedSegment`, which the final fence's accept now also uses). The converger still applies its own mode semantics to the replayed stream, so per-platform rendering (minimal's segment-replace, the no-response sentinel hold, footer migration) is untouched — zero renderer changes. Turn-end housekeeping (usage, session titles, the hidden title tool-call burst) is deliberately not a boundary, so the closing segment stays staged for the fence.

Interleaved "say → work → say more" now posts as separate messages at the moment each boundary lands, mid-turn.

## Regeneration narrows to the closing segment

A committed segment is already said — like any thread message that precedes a late-arriving event — so the generation loop's discard (which already runs at each iteration head) now only drops the still-staged closing segment. The replacement prompt gains a `deliveredPrefix` variant telling the model everything before its last tool/thinking step was delivered and stands, and to regenerate only the undelivered part; without that it reasonably re-says the whole answer. Turns with no boundary (single-segment answers) keep the exact old behavior and old prompt text.

Design doc §5.2/§5.3 rewritten to the new semantics.

## Tests

- New: a segment posts at its tool boundary while the turn is still running; the closing segment commits at the fence — two separate messages.
- New: with a mid-turn clarification, the committed segment stands un-reposted, only the stale closing segment is replaced, and the replacement prompt uses the delivered-prefix heading.
- Existing whole-turn regeneration test passes unchanged (no boundary → old path, old prompt).
- `turn-output-workflow.test.ts` 9/9; package typecheck, eslint, prettier green. Full daemon suite: the only failures (13 sandbox-transport tests + the real-provider runtime matrix) reproduce identically on clean `main` in this environment — zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
