### PR TITLE
feat(daemon): shape a command-derived card title to one line of the thread panel

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -205,8 +205,12 @@ into a paragraph instead of truncating it, offers no hover and no per-title disc
 raw shell command as a title buries the step list — which is what a title straight off ACP is,
 because a shell tool's ACP title IS its command. Two sources, in order: the runtime's own
 one-line description when it sent one (`rawInput.description`, which Claude Code's shell tools
-carry), else the title clamped to 72 characters. The verbatim command is not lost — it is the
-card's code block on `high`, and it is skipped when the title already showed it whole.
+carry), else the title SHAPED as a command label: cut at its first shell separator
+(`&&` / `||` / `|` / `;`) and clamped to 48 characters — roughly one line of Slack's thread
+panel — so a chain reads as its opening command (`git status --short --branch …`) instead of a
+72-character run-on. Thinking titles keep the wider 72 clamp; they are prose. The verbatim
+command is not lost — it is the card's code block on `high`, and it is skipped when the title
+already shows it whole.
 
 **Only the TOP LEVEL of `rawInput` is read, and only when it looks like a label.** A nested
 `arguments` object holds the TOOL's own fields, where the same key means whatever that tool

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -150,6 +150,12 @@ const MAX_STREAM_TASK = 256
 // a long title into a paragraph of shell instead of truncating it, and there is no hover or
 // per-title disclosure to recover the rest. The verbatim command rides the card's code block.
 const MAX_CARD_TITLE = 72
+// A COMMAND standing in for a missing description is clamped tighter still — Slack's thread
+// panel fits roughly this much on one line (the channel view fits more, mobile less) — and cut
+// at its first shell separator first: the opening command of a `&&` chain is a far better
+// label than 72 characters of run-on shell. The full chain rides the card's code block.
+const MAX_COMMAND_TITLE = 48
+const SHELL_SEPARATOR = / (?:&&|\|\||;|\|) /
 /** The card that stands for one thinking run until its first line names it. */
 const THINKING_CARD = 'Thinking'
 // How much of a thinking run to hold while waiting for its first line to end. A runtime opens
@@ -1339,11 +1345,16 @@ export class OutputConverger {
   }
 
   /** A card's one-line step label: the runtime's own description when it gave one, else the
-   *  tool title clamped. An ACP title for a shell tool IS the command, which reads as a
-   *  paragraph of shell on a card; a description ("List files in working directory") is the
-   *  line a reader actually wants, and is what the web console shows too. */
+   *  tool title SHAPED. An ACP title for a shell tool IS the command (codex-acp sends no
+   *  description at all), which reads as a paragraph of shell on a card — so a command-shaped
+   *  fallback is cut at its first shell separator and clamped tighter than a prose title:
+   *  `git status --short --branch …` labels the step; the full chain rides the code block. */
   private cardTitle(id: string, label: string): string {
-    return this.toolDescriptions.get(id) || label
+    const description = this.toolDescriptions.get(id)
+    if (description) return description
+    const head = label.split(SHELL_SEPARATOR, 1)[0] ?? label
+    if (head.length < label.length) return `${clampTo(head, MAX_COMMAND_TITLE - 2)} …`
+    return clampTo(label, MAX_COMMAND_TITLE)
   }
 
   /** What the card's code block shows: the verbatim command, or the full title when that is
@@ -1351,8 +1362,7 @@ export class OutputConverger {
    *  one-line label needs no code block repeating it. */
   private cardCommand(id: string, label: string): string {
     const command = this.toolCommands.get(id) || label
-    const title = clampTo(plainCardText(this.cardTitle(id, label)), MAX_CARD_TITLE)
-    return plainCardText(command) === title ? '' : command
+    return plainCardText(command) === plainCardText(this.cardTitle(id, label)) ? '' : command
   }
 
   /** Refresh the newest output for one tool call. content/rawOutput are a whole replacement

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -455,12 +455,26 @@ describe('OutputConverger streaming axis', () => {
     ])
   })
 
-  it('falls back to the tool title, clamped to one line, when the runtime described nothing', () => {
+  it('falls back to the tool title, cut at the first shell separator, when nothing was described', () => {
+    // codex-acp sends no description, so the raw `&&` chain would be the label. Its opening
+    // command names the step better than 72 characters of run-on shell.
     const converger = streaming('medium')
+    converger.onUpdate(tool('t1', 'git status --short --branch && git branch --show-current && git log -n 20'))
+    const chained = cards(converger.streamUpdate())[0]
+    expect(chained?.type === 'task_update' && chained.title).toBe('git status --short --branch …')
+
+    // No separator: plain clamp, at the tighter command width.
+    const single = streaming('medium')
     const command = `git log --since='2026-08-28' --pretty=format:'%h%x09%ad%x09%an%x09%s' --decorate --all -n 80`
-    converger.onUpdate(tool('t1', command))
-    const card = cards(converger.streamUpdate())[0]
-    expect(card?.type === 'task_update' && card.title).toBe(`${command.slice(0, 71)}…`)
+    single.onUpdate(tool('t1', command))
+    const card = cards(single.streamUpdate())[0]
+    expect(card?.type === 'task_update' && card.title).toBe(`${command.slice(0, 47)}…`)
+
+    // A pipe inside quotes is prose, not a separator boundary… but a spaced pipe is.
+    const piped = streaming('medium')
+    piped.onUpdate(tool('t1', 'grep -rn pattern src | head -5'))
+    const pcard = cards(piped.streamUpdate())[0]
+    expect(pcard?.type === 'task_update' && pcard.title).toBe('grep -rn pattern src …')
   })
 
   it('keeps the command out of a card whose title already shows it whole', () => {
@@ -487,7 +501,7 @@ describe('OutputConverger streaming axis', () => {
     const converger = streaming('high')
     converger.onUpdate(toolDone('t1', 'x'.repeat(400), 'y'.repeat(4000)))
     const card = cards(converger.streamUpdate())[0]
-    expect(card?.type === 'task_update' && card.title.length).toBe(72)
+    expect(card?.type === 'task_update' && card.title.length).toBe(48)
     expect(card?.type === 'task_update' && card.output?.length).toBe(2800)
   })
 


### PR DESCRIPTION
A tool card without a runtime description is titled by its ACP title — which for a shell tool
IS the command. The 72-character clamp still wrapped a `&&` chain into two lines of run-on
shell in Slack's thread panel, burying the step list it was meant to label (codex-acp sends no
`rawInput.description`, so every Codex shell step hit this).

## What changed

A command-shaped fallback title is now:

1. **cut at its first shell separator** (`&&` / `||` / `|` / `;`), so a chain reads as its
   opening command — `git status --short --branch …`;
2. **clamped to 48 characters** — roughly one line of Slack's thread panel (the channel view
   fits more, mobile less).

Runtime descriptions and thinking titles are untouched; prose keeps the wider 72 clamp.

## Reviewer notes

- A separator inside quotes is prose to this rule (naive split, no shell parsing) — but a
  mislabeled cut costs nothing: the label is a pointer, and the verbatim command still rides
  the card's code block on `high`. `cardCommand`'s skip-if-title-shows-it-whole dedupe is
  aligned to the shaped title.
- Verified rendered in a live workspace with codex-shaped calls: chains and long single
  commands both sit on one thread-panel line.
- 172 daemon tests pass (fallback test now covers chain-cut, plain-clamp, and pipe cases).
