### PR TITLE
fix: align Codex permission modes with codex-acp 1.7.0

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -90,7 +90,7 @@ FROM node:24-bookworm-slim AS runtime-sandbox
 
 # Exact pins keep the published runtime table truthful.
 ARG CLAUDE_ACP_VERSION=0.70.0
-ARG CODEX_ACP_VERSION=1.6.2-agentconnect.1
+ARG CODEX_ACP_VERSION=1.7.0-agentconnect.2
 ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.16
 
 # git and ca-certificates are load-bearing — the workspace surface runs git IN here over the

--- a/packages/daemon/src/acp/permission-modes.ts
+++ b/packages/daemon/src/acp/permission-modes.ts
@@ -1,9 +1,11 @@
 // Labels for the runtime-owned ACP `mode` values shown in session-control surfaces
 // (Slack status modal, Telegram/Discord select cards, `/permission` text lists).
+// Copied verbatim from codex-acp's own AgentMode names so these surfaces read the same
+// as the console, which renders the names the runtime reports in its catalog.
 const CODEX_MODE_LABELS: Record<string, string> = {
-  'read-only': 'Read Only', // the daemon's permission profile keeps this sandbox read-only
-  agent: 'Approve for me', // on-request approvals, reviewed by codex-acp's own reviewer
-  'agent-full-access': 'Full Access'
+  'read-only': 'Ask for approval', // always asks before editing external files or using the network
+  agent: 'Approve for me', // only asks for actions the runtime's own reviewer flags as unsafe
+  'agent-full-access': 'Full access'
 }
 
 /** Codex's own name for a mode; unknown values (Claude's `default`/`plan`) pass through. */

--- a/packages/daemon/test/command-chrome.test.ts
+++ b/packages/daemon/test/command-chrome.test.ts
@@ -51,7 +51,7 @@ describe('telegram select encoding', () => {
     const buttons = telegramSelectButtons('permission', 'agent-full-access', ['agent-full-access'])
     // Raw mode ids render through the shared display alias, exactly as the
     // pre-seam buildSelectCard did via selectDisplay.
-    expect(buttons[0]![0]!.text).toBe('✅ Full Access')
+    expect(buttons[0]![0]!.text).toBe('✅ Full access')
   })
 
   it('rejects callback data this scheme did not mint', () => {

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1079,9 +1079,9 @@ describe('Daemon in-conversation commands', () => {
     // bare /permission lists Codex's own mode names, not the raw wire ids.
     await (daemon as any).onInboundOutcome(dm('200', '/permission'))
     const listed = conn.postMessage.mock.calls.at(-1)![1] as string
-    expect(listed).toContain('Read Only')
+    expect(listed).toContain('Ask for approval')
     expect(listed).toContain('Approve for me')
-    expect(listed).toContain('Full Access')
+    expect(listed).toContain('Full access')
     expect(listed).not.toContain('agent-full-access')
 
     // choose by label ("full access") → resolves to the raw wire id, applied live
@@ -1092,7 +1092,7 @@ describe('Daemon in-conversation commands', () => {
     }, WAIT)
     expect(conn.postMessage).toHaveBeenCalledWith(
       'C1',
-      expect.stringContaining('Permission mode set to Full Access'),
+      expect.stringContaining('Permission mode set to Full access'),
       'T1',
       CHROME_REPLY
     )

--- a/packages/daemon/test/evaluation-runner.test.ts
+++ b/packages/daemon/test/evaluation-runner.test.ts
@@ -185,7 +185,7 @@ describe('EvaluationRunner', () => {
             type: 'select',
             currentValue: 'read-only',
             options: [
-              { value: 'read-only', name: 'Read Only' },
+              { value: 'read-only', name: 'Ask for approval' },
               { value: 'agent', name: 'Approve for me' }
             ]
           }

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -1099,11 +1099,11 @@ describe('buildStatusModal (Configure controls modal)', () => {
     expect(select.initial_option.value).toBe('agent-full-access')
     // Display text is Codex's own name for each mode (agent = "Approve for me").
     expect(select.options.map((o: any) => o.text.text)).toEqual([
-      'Permission · Read Only',
+      'Permission · Ask for approval',
       'Permission · Approve for me',
-      'Permission · Full Access'
+      'Permission · Full access'
     ])
-    expect(select.initial_option.text.text).toBe('Permission · Full Access')
+    expect(select.initial_option.text.text).toBe('Permission · Full access')
   })
 
   it('prepends a current effort the advertised list omits (e.g. a pending ultracode override)', () => {

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -332,9 +332,9 @@ describe('permissionModeChoicesFor', () => {
 describe('Codex permission modes', () => {
   it("offers exactly the modes the runtime owns, under Codex's own names", () => {
     expect(permissionModeOptions('codex')).toEqual([
-      { v: 'read-only', l: 'Read Only' },
+      { v: 'read-only', l: 'Ask for approval' },
       { v: 'agent', l: 'Approve for me' },
-      { v: 'agent-full-access', l: 'Full Access' }
+      { v: 'agent-full-access', l: 'Full access' }
     ])
   })
 })
@@ -557,7 +557,7 @@ describe('literal ACP default model surfacing', () => {
 // Read-only config surfaces (detail card, list rows) must show the SAME effective
 // values the Add/Edit pickers do — a blank model resolves to the daemon default,
 // and effort/permission use the runtime catalog's own names. Reproduces the Codex
-// mismatch that motivated these helpers (card "Default / Extra High / Full Access"
+// mismatch that motivated these helpers (card "Default / Extra High / Full access"
 // vs editor "gpt-5.6-sol / Xhigh / Agent (full access)").
 describe('agent config display helpers (card ↔ editor parity)', () => {
   // A Codex daemon whose catalog names differ from the static tables.
@@ -656,7 +656,7 @@ describe('agent config display helpers (card ↔ editor parity)', () => {
       expect(agentPermissionDisplay(codexDaemon, 'codex', '')).toBe('Ask for approval')
     })
     it('falls back to the static permission table without a catalog', () => {
-      expect(agentPermissionDisplay(undefined, 'codex', 'agent-full-access')).toBe('Full Access')
+      expect(agentPermissionDisplay(undefined, 'codex', 'agent-full-access')).toBe('Full access')
     })
   })
 })

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -692,15 +692,15 @@ export function effortLabel(runtime: string, v: string): string {
 
 export function permissionModeOptions(runtime: string): { v: string; l: string }[] {
   if (runtimeLabel(runtime) === 'Codex') {
-    // Labels are matched to Codex's own names by policy, not menu position, so the
-    // console can't misrepresent them. Values are codex-acp's runtime-owned ids: `agent`
-    // is Codex's default (on-request approvals, reviewed by the runtime itself), and
-    // `agent-full-access` is danger-full-access — out-of-workspace + network. `read-only`
-    // keeps the daemon's read-only sandbox profile.
+    // Labels are copied verbatim from codex-acp's own AgentMode names, so this fallback reads
+    // the same as the catalog path that prefers what the runtime reports. Values are codex-acp's
+    // runtime-owned ids: `agent` is Codex's default (its own reviewer approves what it judges
+    // safe), `agent-full-access` is danger-full-access — out-of-workspace + network, and
+    // `read-only` runs the daemon's read-only sandbox profile.
     return [
-      { v: 'read-only', l: 'Read Only' },
+      { v: 'read-only', l: 'Ask for approval' },
       { v: 'agent', l: 'Approve for me' },
-      { v: 'agent-full-access', l: 'Full Access' }
+      { v: 'agent-full-access', l: 'Full access' }
     ]
   }
   // Labels mirror claude-agent-acp's own mode names so the console can't misrepresent
@@ -938,7 +938,7 @@ export function resolvedPermissionMode(
 // default and label effort/permission with the runtime's OWN catalog names
 // (runtime-model-catalog.md §7). The read-only surfaces (detail card rows, list
 // sub-labels) must reproduce that exact resolution, or the same placed agent
-// reads "Default / Extra High / Full Access" in the card yet "gpt-5.6-sol /
+// reads "Default / Extra High / Full access" in the card yet "gpt-5.6-sol /
 // Xhigh / Agent (full access)" in the editor. Each helper degrades to the static
 // tables when the owning daemon reports no catalog (offline / unplaced / a
 // pre-catalog daemon), so nothing regresses where the catalog is absent.


### PR DESCRIPTION
Moves the Codex runtime to codex-acp `1.7.0-agentconnect.2` and makes every
surface call its permission modes what the runtime calls them.

## Why both halves are one change

`#1592` removed the `_approvals_reviewer` selector end to end, because 1.7.0
binds the reviewer to the ACP mode itself. But the runtime image still
installed `1.6.2-agentconnect.1`, which does advertise that selector — I
checked both published tarballs, and the string is present in 1.6.2 and
absent in 1.7.0. So sandboxes minted from that image ran a runtime whose
approval surface no longer matched what the daemon sends.

Self-hosted daemons launch codex-acp through the floating `agentconnect`
channel and had already moved; only the image pin was left behind.

The labels are the same story from the other end. 1.7.0 renamed the modes,
and the console renders whatever names the runtime reports in its catalog —
so it already showed "Ask for approval" for `read-only` while the chat
surfaces, which read a static table, still said "Read Only". Two names for
one mode is the misrepresentation those tables exist to prevent.

## What changed

- `docker/runtime-sandbox.Dockerfile`: `CODEX_ACP_VERSION` `1.6.2-agentconnect.1`
  → `1.7.0-agentconnect.2`.
- The static label tables in daemon and web now copy codex-acp's own
  `AgentMode` names verbatim: `read-only` is "Ask for approval", `agent` is
  "Approve for me", `agent-full-access` is "Full access". The catalog path
  and the static fallback now render identical strings.

## Not changed, deliberately

- **Mode ids.** `read-only` / `agent` / `agent-full-access` are byte-identical
  between the two versions, so stored values, wire ids and the default `agent`
  all stay valid. Nothing to migrate.
- **The daemon-owned permission profiles.** `PROFILE_IDS` maps each mode to an
  `agentconnect-protected-*` Codex profile that extends the stock preset and
  then denies the daemon's protected roots. That is a different axis from the
  reviewer, and 1.7.0 still consumes it — the profile config env var and
  `modeProfiles` both survive in the new build.
- **The `features.unified_exec=false` workaround.** Both versions depend on
  the same `@openai/codex` range, so this bump does not settle whether that
  can go.
- **The label matcher.** `/permission full access` still resolves; the match
  is case-insensitive.

## Verification

- Compared the two published tarballs directly: mode ids identical, display
  names changed, the reviewer selector gone, the `TokenCount` → ACP usage
  mapping byte-identical (so token accounting and the cost fallback are
  unaffected), and the bin name still `codex-acp`, which is what the image's
  runtime-table generator looks for.
- web: 2144 tests pass. daemon: the four suites this touches pass.
- The daemon suite also has 14 pre-existing local failures in `acp-matrix`
  (a live real-runtime suite CI skips) and three `shim-*` files. None of them
  import the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
