### PR TITLE
fix(daemon): decorate a DM's plan card with the agent identity — a bare stream has no fallback

### DIFF
--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -119,10 +119,14 @@ contradict the published documentation, and two of them changed the design.
    every non-recipient sees an italic "Thinking…" placeholder that flips to the full plan card
    at stop. Body posts are real-time for everyone throughout — which is exactly the property
    that makes chrome-only viable and body streaming not (§1).
-8. **`username` / `icon_url` / `icon_emoji` are accepted on `chat.startStream`.** The stream
-   therefore takes the same identity policy as today's chrome rows — the agent's name and icon
-   in a channel, the app's own in a DM — reusing the existing `customUsernameRetryAt` cooldown
-   for a workspace without `chat:write.customize` (retry undecorated, re-probe in five minutes).
+8. **`username` / `icon_url` / `icon_emoji` are accepted on `chat.startStream` — in DMs too.**
+   The stream carries the agent's name and icon on EVERY surface, unlike the chrome rows it
+   replaces (agent identity in a channel, app default in a DM): an undecorated `postMessage`
+   falls back to the app's own profile, but an undecorated STREAM renders a placeholder avatar
+   instead (verified live 2026-08-29), so a DM stream left undecorated shows a grey silhouette
+   beside body messages that show the app. The existing `customUsernameRetryAt` cooldown still
+   governs a workspace without `chat:write.customize` (retry undecorated, re-probe in five
+   minutes).
 9. **Recipient.** Channel only; a DM passes none. A human-initiated turn names the initiating
    human's Slack user id plus the team id. A turn with no human initiator — agent-to-agent,
    cron, hook, dream — names the bot's OWN user id and its team id, which Slack accepts. There

--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -120,13 +120,13 @@ contradict the published documentation, and two of them changed the design.
    at stop. Body posts are real-time for everyone throughout — which is exactly the property
    that makes chrome-only viable and body streaming not (§1).
 8. **`username` / `icon_url` / `icon_emoji` are accepted on `chat.startStream` — in DMs too.**
-   The stream takes the BODY rows' identity source (the agent's name and icon everywhere),
-   not the chrome rows' (which exempt DMs). The chrome exemption is survivable for a
-   `postMessage` — undecorated, it falls back to the app's own profile — but an undecorated
-   STREAM renders a placeholder avatar with no fallback (verified live 2026-08-29), so a DM
-   plan card left on the chrome policy sat as a grey silhouette beside body rows carrying the
-   agent's own icon. The existing `customUsernameRetryAt` cooldown still governs a workspace
-   without `chat:write.customize` (retry undecorated, re-probe in five minutes).
+   There is ONE identity policy: every Slack row — body, chrome, status bar, stream — carries
+   the agent's name and icon, on every surface. A DM exemption used to exist for chrome rows
+   and produced a mixed DM (decorated bodies beside app-identity chrome) plus a broken stream:
+   an undecorated `chat.startStream` renders a placeholder avatar with NO app-profile fallback
+   (verified live 2026-08-29), unlike an undecorated `postMessage`. The existing
+   `customUsernameRetryAt` cooldown still governs a workspace without `chat:write.customize`
+   (retry undecorated, re-probe in five minutes).
 9. **Recipient.** Channel only; a DM passes none. A human-initiated turn names the initiating
    human's Slack user id plus the team id. A turn with no human initiator — agent-to-agent,
    cron, hook, dream — names the bot's OWN user id and its team id, which Slack accepts. There

--- a/docs/designs/slack-streaming-turn-output.md
+++ b/docs/designs/slack-streaming-turn-output.md
@@ -120,13 +120,13 @@ contradict the published documentation, and two of them changed the design.
    at stop. Body posts are real-time for everyone throughout — which is exactly the property
    that makes chrome-only viable and body streaming not (§1).
 8. **`username` / `icon_url` / `icon_emoji` are accepted on `chat.startStream` — in DMs too.**
-   The stream carries the agent's name and icon on EVERY surface, unlike the chrome rows it
-   replaces (agent identity in a channel, app default in a DM): an undecorated `postMessage`
-   falls back to the app's own profile, but an undecorated STREAM renders a placeholder avatar
-   instead (verified live 2026-08-29), so a DM stream left undecorated shows a grey silhouette
-   beside body messages that show the app. The existing `customUsernameRetryAt` cooldown still
-   governs a workspace without `chat:write.customize` (retry undecorated, re-probe in five
-   minutes).
+   The stream takes the BODY rows' identity source (the agent's name and icon everywhere),
+   not the chrome rows' (which exempt DMs). The chrome exemption is survivable for a
+   `postMessage` — undecorated, it falls back to the app's own profile — but an undecorated
+   STREAM renders a placeholder avatar with no fallback (verified live 2026-08-29), so a DM
+   plan card left on the chrome policy sat as a grey silhouette beside body rows carrying the
+   agent's own icon. The existing `customUsernameRetryAt` cooldown still governs a workspace
+   without `chat:write.customize` (retry undecorated, re-probe in five minutes).
 9. **Recipient.** Channel only; a DM passes none. A human-initiated turn names the initiating
    human's Slack user id plus the team id. A turn with no human initiator — agent-to-agent,
    cron, hook, dream — names the bot's OWN user id and its team id, which Slack accepts. There

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -155,8 +155,8 @@ import {
   clearStaleSlackReplyFooters as clearStaleSlackReplyFootersExternal,
   finalizeSlackResponse,
   isSlackStatusBarText,
+  slackAgentIdentityOptions,
   slackAgentPostOptions,
-  slackPostOptions,
   slackStreamRecipient,
   type SlackTurnState
 } from './platforms/slack/turn-output.js'
@@ -8072,7 +8072,7 @@ export class Daemon {
       this.settleSlackSlot(ctx.replyConn, ctx.channel, ctx.statusThread, ctx.sessionKey)
       if (turnChromeFor(ctx.platform).chromeMarkedNotices)
         void (ctx.replyConn as SlackConnection).postMessage(ctx.channel, notice, ctx.thread, {
-          ...(slackPostOptions(ctx) ?? {}),
+          ...(slackAgentIdentityOptions(ctx) ?? {}),
           chrome: true
         })
       else void ctx.replyConn.postMessage(ctx.channel, notice, ctx.thread)
@@ -13973,9 +13973,8 @@ export class Daemon {
     const agent = this.agents.get(agentId)
     const post = turnChromeFor(rec.platform).chromeMarkedNotices
       ? (conn as SlackConnection).postMessage(rec.channel, text, rec.thread || undefined, {
-          ...(slackPostOptions({
+          ...(slackAgentIdentityOptions({
             platform: rec.platform,
-            isDm: rec.conversationKind === 'dm',
             agentName: agent?.displayName?.trim() || agent?.name || agentId,
             ...(agent?.iconUrl ? { iconUrl: agent.iconUrl } : {})
           }) ?? {}),

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -24,7 +24,7 @@ import {
   buildPermissionResolvedCard,
   elicitTarget
 } from '../slack/render.js'
-import { slackPostOptions } from '../platforms/slack/turn-output.js'
+import { slackAgentIdentityOptions } from '../platforms/slack/turn-output.js'
 import { turnChromeFor } from '../platforms/turn-chrome.js'
 import { formatErr } from '../daemon/text.js'
 import {
@@ -326,7 +326,7 @@ export class PermissionCoordinator {
     const fallback = `Permission requested: ${params.toolCall?.title ?? 'a tool call'}`
     const ts = await this.host.postCardSerialized(p, (slack) =>
       slack.postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
-        ...(slackPostOptions(p.plan) ?? {}),
+        ...(slackAgentIdentityOptions(p.plan) ?? {}),
         chrome: true
       })
     )
@@ -776,7 +776,7 @@ export class PermissionCoordinator {
     }
     const ts = await this.host.postCardSerialized(p, (sc) =>
       sc.postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
-        ...(slackPostOptions(p.plan) ?? {}),
+        ...(slackAgentIdentityOptions(p.plan) ?? {}),
         chrome: true
       })
     )

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -583,9 +583,7 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     case 'stream-start': {
       if (state.stream || state.streamDead || state.streamDegraded) return
       if (p.plan.thread) {
-        // Same identity as every other row (see slackAgentIdentityOptions) — the stream is
-        // the row that made a DM exemption untenable: undecorated `chat.startStream` renders
-        // a placeholder avatar with no app-profile fallback (verified live 2026-08-29).
+        // Same identity as every row — an undecorated stream has no app-profile fallback.
         state.stream = await conn.startTurnStream(p.plan.channel, p.plan.thread, {
           isDm: p.plan.isDm,
           ...(state.recipient ? { recipientUserId: state.recipient } : {}),

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -592,12 +592,15 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     case 'stream-start': {
       if (state.stream || state.streamDead || state.streamDegraded) return
       if (p.plan.thread) {
-        // Exactly the identity today's `progress` message carries: the agent's name and icon
-        // in a channel, nothing in a DM, under the connection's customize cooldown.
+        // The agent's name and icon in DMs TOO, unlike the `progress` message this replaces:
+        // an undecorated postMessage falls back to the app's own profile, but an undecorated
+        // STREAM renders a placeholder avatar instead (verified live 2026-08-29) — so the DM
+        // stream is the one chrome row that must always carry the identity, under the
+        // connection's customize cooldown like every other decorated send.
         state.stream = await conn.startTurnStream(p.plan.channel, p.plan.thread, {
           isDm: p.plan.isDm,
           ...(state.recipient ? { recipientUserId: state.recipient } : {}),
-          ...(postOptions ? { identity: postOptions } : {})
+          ...(statusBarPostOptions ? { identity: statusBarPostOptions } : {})
         })
         if (state.stream) return
       }

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -172,19 +172,11 @@ export interface SlackTurnHost<TTurn> {
   debug(message: string): void
 }
 
-/** Conversational authorship for Slack rows: the agent's name and icon, applied
- *  only in channels. A DM is already a one-to-one surface, so overriding the
- *  author there would replace the bot's own identity for no gain. */
-export function slackPostOptions(
-  p: Pick<SlackTurnPlan, 'platform' | 'isDm' | 'agentName' | 'iconUrl'>
-): SlackPostOptions | undefined {
-  if (p.platform !== 'slack' || p.isDm) return undefined
-  return { username: p.agentName, ...(p.iconUrl ? { icon_url: p.iconUrl } : {}) }
-}
-
-/** Visual identity for Slack rows owned by the selected agent. Kept separate from
- *  conversational authorship because status/chrome rows must retain their chrome
- *  metadata marker instead of masquerading as transcript messages. */
+/** The ONE identity policy for Slack rows: the agent's name and icon, on every surface —
+ *  channel and DM, body and chrome alike. A DM exemption used to exist for chrome rows and
+ *  produced a mixed DM (decorated bodies beside app-identity chrome) plus a broken stream
+ *  (an undecorated `chat.startStream` renders a placeholder avatar, no fallback). A
+ *  customize-less workspace still degrades per send via the connection's cooldown. */
 export function slackAgentIdentityOptions(
   p: Pick<SlackTurnPlan, 'platform' | 'agentName' | 'iconUrl'>
 ): SlackPostOptions | undefined {
@@ -517,11 +509,10 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     }
     return
   }
-  const postOptions = slackPostOptions(p.plan)
-  const statusBarPostOptions = slackAgentIdentityOptions(p.plan)
-  // Chrome variant of the post options: marks status/progress/plan/reasoning/notice/card
+  const identity = slackAgentIdentityOptions(p.plan)
+  // Chrome variant of the identity: marks status/progress/plan/reasoning/notice/card
   // messages so a peer daemon's thread backfill skips them (they are not conversation).
-  const chromeOptions: SlackPostOptions = { ...(postOptions ?? {}), chrome: true }
+  const chromeOptions: SlackPostOptions = { ...(identity ?? {}), chrome: true }
   switch (action.kind) {
     case 'set-status':
       if (p.plan.statusThread)
@@ -592,16 +583,13 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     case 'stream-start': {
       if (state.stream || state.streamDead || state.streamDegraded) return
       if (p.plan.thread) {
-        // The AGENT identity (the body rows' source), not the chrome policy: `slackPostOptions`
-        // exempts DMs, which is survivable for chrome postMessages (undecorated falls back to
-        // the app profile) but not for a stream — undecorated `chat.startStream` renders a
-        // placeholder avatar, no fallback (verified live 2026-08-29). So the DM plan card sat
-        // as a grey silhouette beside body rows carrying the agent's own icon. Same customize
-        // cooldown as every other decorated send.
+        // Same identity as every other row (see slackAgentIdentityOptions) — the stream is
+        // the row that made a DM exemption untenable: undecorated `chat.startStream` renders
+        // a placeholder avatar with no app-profile fallback (verified live 2026-08-29).
         state.stream = await conn.startTurnStream(p.plan.channel, p.plan.thread, {
           isDm: p.plan.isDm,
           ...(state.recipient ? { recipientUserId: state.recipient } : {}),
-          ...(statusBarPostOptions ? { identity: statusBarPostOptions } : {})
+          ...(identity ? { identity } : {})
         })
         if (state.stream) return
       }
@@ -767,7 +755,7 @@ export async function applySlackAction<TTurn extends SlackTurn>(
         // The session status line represents the selected agent, so keep its author
         // identity aligned with the native loading state and the eventual reply.
         const posted = await conn.postBlocks(p.plan.channel, action.blocks, action.text, p.plan.thread, {
-          ...(statusBarPostOptions ?? {}),
+          ...(identity ?? {}),
           chrome: true,
           chromeOwnerAgentId: p.plan.agentId
         })

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -592,11 +592,12 @@ export async function applySlackAction<TTurn extends SlackTurn>(
     case 'stream-start': {
       if (state.stream || state.streamDead || state.streamDegraded) return
       if (p.plan.thread) {
-        // The agent's name and icon in DMs TOO, unlike the `progress` message this replaces:
-        // an undecorated postMessage falls back to the app's own profile, but an undecorated
-        // STREAM renders a placeholder avatar instead (verified live 2026-08-29) — so the DM
-        // stream is the one chrome row that must always carry the identity, under the
-        // connection's customize cooldown like every other decorated send.
+        // The AGENT identity (the body rows' source), not the chrome policy: `slackPostOptions`
+        // exempts DMs, which is survivable for chrome postMessages (undecorated falls back to
+        // the app profile) but not for a stream — undecorated `chat.startStream` renders a
+        // placeholder avatar, no fallback (verified live 2026-08-29). So the DM plan card sat
+        // as a grey silhouette beside body rows carrying the agent's own icon. Same customize
+        // cooldown as every other decorated send.
         state.stream = await conn.startTurnStream(p.plan.channel, p.plan.thread, {
           isDm: p.plan.isDm,
           ...(state.recipient ? { recipientUserId: state.recipient } : {}),

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -1570,10 +1570,9 @@ describe('Daemon idle sweep — background-task lease', () => {
     expect(thread).toBe('T1')
     expect(text).toContain('Sleep for 15 seconds')
     expect(text).toContain('completed')
-    // Chrome-marked so thread backfill never re-ingests the notice as agent speech;
-    // a DM keeps the bot's own identity (no username/icon override), per slackPostOptions.
-    expect(options).toMatchObject({ chrome: true })
-    expect(options.username).toBeUndefined()
+    // Chrome-marked so thread backfill never re-ingests the notice as agent speech, and
+    // carrying the ONE identity policy — the agent's name on every surface, DMs included.
+    expect(options).toMatchObject({ chrome: true, username: 'bot-a' })
 
     // The near-simultaneous task_notification for the same task must NOT double-post.
     await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -834,9 +834,11 @@ describe('Daemon transcript records the agent reply', () => {
     await (daemon as any).dispatch('bot-a', dm('100', 'q'), 'int-a')
 
     // High mode still posts tool-progress chrome, but that is not an agent reply body
-    // and must not become the attribution target. It's marked `chrome` so the backfill skips it.
+    // and must not become the attribution target. It's marked `chrome` so the backfill skips
+    // it, and carries the one identity policy (agent name on every surface, DMs included).
     expect(conn.postMessage).toHaveBeenCalledWith('C1', expect.stringContaining('Read file.ts'), 'T1', {
-      chrome: true
+      chrome: true,
+      username: 'bot-a'
     })
     expect(conn.postMessage.mock.calls.some((call) => call[3]?.trailingBlocks)).toBe(false)
     await daemon.stop()

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -748,10 +748,16 @@ describe('applySlackAction — chrome stream actions', () => {
     expect(state.stream).toEqual({ channel: 'C1', threadTs: 'T1', ts: '900.1' })
   })
 
-  it('carries no identity in a DM, exactly like the progress message it replaces', async () => {
+  it('carries the agent identity in a DM too — an undecorated stream renders a placeholder', async () => {
+    // Unlike the progress message it replaces: an undecorated postMessage falls back to the
+    // app's own profile, but an undecorated STREAM does not (verified live 2026-08-29).
     const { apply, conn } = fixture({}, { isDm: true })
     await apply({ kind: 'stream-start' })
-    expect(conn.startTurnStream).toHaveBeenCalledWith('C1', 'T1', { isDm: true, recipientUserId: 'U1' })
+    expect(conn.startTurnStream).toHaveBeenCalledWith('C1', 'T1', {
+      isDm: true,
+      recipientUserId: 'U1',
+      identity: { username: 'Bot A', icon_url: 'https://icons.example.test/a.png' }
+    })
   })
 
   it('refuses to open a second stream beside a live one', async () => {

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -749,8 +749,6 @@ describe('applySlackAction — chrome stream actions', () => {
   })
 
   it('carries the agent identity in a DM too — an undecorated stream renders a placeholder', async () => {
-    // Unlike the progress message it replaces: an undecorated postMessage falls back to the
-    // app's own profile, but an undecorated STREAM does not (verified live 2026-08-29).
     const { apply, conn } = fixture({}, { isDm: true })
     await apply({ kind: 'stream-start' })
     expect(conn.startTurnStream).toHaveBeenCalledWith('C1', 'T1', {


### PR DESCRIPTION
In a DM, the streaming plan card rendered with a grey placeholder avatar while the body
messages right beside it showed the agent's own icon. Channels were fine. Chasing it exposed
that the identity policy itself was the problem, so this PR ends with ONE policy instead of a
patched fork.

## The fork

Two identity sources, split on one axis:

- **Body rows** (`slackAgentPostOptions` → `slackAgentIdentityOptions`): agent name and icon
  **everywhere, DMs included** — why the replies show the agent's icon.
- **Chrome rows** (`slackPostOptions`): agent identity in a channel, **nothing in a DM** — and
  the stream inherited this one.

The chrome exemption's rationale ("a DM already shows the bot's identity") described a world
where bodies were undecorated too. Once bodies decorated, the exemption bought nothing and
produced a mixed DM — decorated bodies beside app-identity chrome. For most chrome that was
merely inconsistent, because an undecorated `postMessage` falls back to the app profile. For
the stream it was broken: verified live, side by side in a real DM, an undecorated
`chat.startStream` renders a **placeholder avatar with no fallback**, while a decorated one in
a DM is accepted and renders fully.

## What changed

`slackPostOptions` is **deleted**. Every Slack row — body, chrome, permission and elicitation
cards, failure and background-task notices, status bar, stream — takes the agent identity from
the single `slackAgentIdentityOptions`, degrading per send via the existing
`customUsernameRetryAt` cooldown.

Visible change beyond the stream fix: DM chrome rows now carry the agent's name and icon
instead of the app's own, consistent with the bodies beside them. Dedicated-bot installs
render identically either way.

## Verification

- Live DM probe: undecorated postMessage → app profile; undecorated startStream → placeholder;
  decorated startStream → renders name and icon.
- 336 tests across slack-streaming, lifecycle, permission-autoallow, render, smoke; typecheck,
  lint, format clean. §4 fact 8 in the design doc now states the single policy.
