### PR TITLE
perf(daemon): create the store schema in one transaction, not 58

### DIFF
--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1075,7 +1075,7 @@ export class LocalStore {
       ((await this.db.prepare("SELECT COUNT(*) AS n FROM sqlite_master WHERE type = 'table'").get()) as { n: number })
         .n === 0
     await this.upgradeSchema(freshDatabase)
-    await this.db.exec(`
+    const schema = `
       CREATE TABLE IF NOT EXISTS sessions (
         key TEXT PRIMARY KEY, agentId TEXT, platform TEXT, channel TEXT, thread TEXT,
         transportScope TEXT, acpSessionId TEXT, sessionId TEXT, state TEXT, lastDeliveredTs TEXT, updatedAt INTEGER,
@@ -1609,10 +1609,13 @@ export class LocalStore {
       );
       CREATE INDEX IF NOT EXISTS code_host_review_intent_pending
         ON code_host_review_intent (daemonId, updatedAt);
-    `)
-    // Stamped only once the CREATE block above has actually emitted that schema, so
-    // a store that failed halfway through creation is not left claiming to be current.
-    if (freshDatabase) await this.db.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`)
+    `
+    // One transaction, not 58: a multi-statement script commits — and so flushes — each statement.
+    // The stamp joins it, so a creation that fails halfway leaves no schema to claim it is current.
+    await this.transaction(async (tx) => {
+      await tx.exec(schema)
+      if (freshDatabase) await tx.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`)
+    })
     // The revision counter is in-memory but the rows it numbers are durable, so it
     // must resume from the database on every open — starting a restarted daemon back
     // at 0 would hand already-issued revisions to new rows. Deliberately unfenced: it

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1612,10 +1612,15 @@ export class LocalStore {
     `
     // One transaction, not 58: a multi-statement script commits — and so flushes — each statement.
     // The stamp joins it, so a creation that fails halfway leaves no schema to claim it is current.
-    await this.transaction(async (tx) => {
-      await tx.exec(schema)
-      if (freshDatabase) await tx.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`)
-    })
+    // Creation only: an established store re-runs this block as pure IF NOT EXISTS, so it saves
+    // nothing there, and BEGIN IMMEDIATE held across 58 statements would collide with any peer
+    // holding the same file open — every boot, not just the first.
+    if (freshDatabase)
+      await this.transaction(async (tx) => {
+        await tx.exec(schema)
+        await tx.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`)
+      })
+    else await this.db.exec(schema)
     // The revision counter is in-memory but the rows it numbers are durable, so it
     // must resume from the database on every open — starting a restarted daemon back
     // at 0 would hand already-issued revisions to new rows. Deliberately unfenced: it


### PR DESCRIPTION
## What

`initializeSchema` hands 58 `CREATE TABLE` / `CREATE INDEX` statements to a single `exec`. A multi-statement script commits each statement separately, so under WAL with `synchronous = FULL` — the `node:sqlite` default this store keeps — bringing up an empty database costs 58 flushes. Every daemon pays them the first time it boots.

This creates the schema in one transaction instead, **only when the database is fresh**:

```js
if (freshDatabase)
  await this.transaction(async (tx) => {
    await tx.exec(schema)
    await tx.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`)
  })
else await this.db.exec(schema)
```

The SQL moves to a local `const` purely so the template literal keeps its indentation — the 535 DDL lines are untouched.

**`synchronous` is not touched.** This removes commits, not durability: every commit still waits for the disk, there is just one instead of 58. Those 57 flushes bought nothing — a half-created schema is useless, which is exactly why the stamp was held back until after the block. Now the stamp joins the transaction and creation is genuinely all-or-nothing, so the concern the old comment worked around no longer exists.

**Why the `freshDatabase` guard, and not just always.** The first commit here did wrap it unconditionally, and `daemon-duty-inbox-replay` failed with `database is locked`. It was right to: `transaction()` opens `BEGIN IMMEDIATE`, so the wrap took a write lock across all 58 statements on *every* boot, not just the first, and that suite's fixture symlinks one daemon's `local.sqlite` into a peer's root — two connections that used to interleave between 58 short locks now collide over one long one. An established store re-runs the block as pure `IF NOT EXISTS` and commits nothing, so the transaction saves nothing there anyway. Guarding on `freshDatabase` keeps the entire win and leaves an existing store byte-for-byte as it was, lock window included.

## Why

Chasing the Windows unit job, which runs ~22 min against ~3 for the slowest Linux job. Splitting that suite by what each file does shows the tax is filesystem work, not CPU — 164 files that touch no files run at x1.1, while files that open a store run at x11. This is one of the few levers that reduces the work rather than redistributing it.

Measured on macOS, `tests` time, stable to ±10 ms across runs (identical before and after the `freshDatabase` guard, since every test creates a fresh store):

| suite | before | after |
|---|---|---|
| `local-store.test.ts` (103 cases) | 1.21 s | **0.65 s** |
| `session-manager.test.ts` (97 cases) | 2.24 s | **1.49 s** |
| `daemon-commands.test.ts` (63 cases, boots a daemon) | ~6.4 s | ~6.15 s |

The third row is what macOS can see: a daemon-booting file opens one store per case and spends its
time elsewhere, so on APFS the schema flushes vanish into the noise.

**On Windows they do not.** This job's own run, against the same 2 workers as the baseline:

| | vitest `tests` total | daemon step | job |
|---|---|---|---|
| baseline | 2374.7 s | 1211 s | 22 min |
| baseline + the real-time-scanning exemption | 2244.7 s | 1144 s | 21.8 min |
| **this branch** | **1099.9 s** | **575 s** | **11.7 min** |

Summed test time falls 51%. I had predicted 1-2 minutes from the macOS numbers and was wrong by an
order of magnitude: 58 `FlushFileBuffers` through the NTFS filter stack cost hundreds of milliseconds,
where 58 `fsync` on APFS cost about eleven. That gap is most of the ~1199 ms per case that
daemon-booting files pay on Windows over Linux — the store is opened lazily on first dispatch, so
every one of those cases was paying the schema flushes too.

I also measured the alternative, a test-only `PRAGMA synchronous = OFF`: 0.68 s / 1.45 s, no better than this. So there is no case for a knob that makes tests run a configuration production does not.

## Reviewer notes

**Postgres is behaviorally unchanged.** A multi-statement script already ran inside one implicit transaction there, and schema creation is serialized regardless — `PostgresDataPlane` holds the schema advisory lock across `LocalStore.open` and releases it only in `finishSchemaInitialization()`. `tx.exec` and `exec` funnel into the same `runStatement`, both taking the one pool client through `withClient`, so a max-1 pool sees no extra pressure. With the guard, a second pool member joining an existing shared schema now takes the plain path.

`this.transaction` rather than a hand-written `BEGIN;` in the SQL: `upgradeSchema` already runs each migration step that way, and it is the seam both backends implement. Its tool-write drain is a no-op at open time.

## Verification

- `daemon-duty-inbox-replay.test.ts` — 6 passed (the regression the first commit introduced).
- `test:store:postgres` — 7 files, 134 passed, 12 skipped, against a real `postgres:16-alpine`.
- `local-store` / `session-manager` / `session-reader` / `daemon-commands` — 287 passed.
- `typecheck`, `eslint`, `prettier` clean.

Full daemon suite re-running locally; its known local-only failures (`acp-matrix`, LOCAL-ONLY by its own header, and three sandbox-pod shim suites that are POSIX-by-construction) are unrelated. CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
