### PR TITLE
feat(daemon): push native Slack session titles onto channel threads too

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12335,8 +12335,8 @@ export class Daemon {
     })
   }
 
-  /** Rename a Slack app-DM through the exact integration that delivered this
-   *  session. The connection lease prevents reconcile from closing it mid-call. */
+  /** Rename a Slack thread via the exact integration that delivered this session; the
+   *  connection lease prevents reconcile from closing it mid-call. */
   private async setSlackTitleForBinding(
     rec: SessionRecord,
     binding: SessionDeliveryBinding,
@@ -12570,9 +12570,7 @@ export class Daemon {
       // both before touching another logical session if two adapters reuse an id.
       if (rec?.agentId === agentId && rec.acpSessionId === sessionId) {
         await this.persistSessionTitle(rec, update.title)
-        // Slack's Agents feature renders native titles only for app-DM threads. Reuse
-        // the runtime's title verbatim (apart from surrounding whitespace); do not
-        // invent one from the first-message fallback used by the console session list.
+        // Runtime title verbatim (trimmed) — never the console's first-message fallback.
         const slackTitle = typeof update.title === 'string' ? update.title.trim() : ''
         if (p && turnChromeFor(p.plan.platform).sessionTitle && slackTitle) {
           this.enqueueApply(p, { kind: 'set-title', text: slackTitle })

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12346,7 +12346,6 @@ export class Daemon {
       binding.agentId !== rec.agentId ||
       binding.platform !== 'slack' ||
       rec.platform !== 'slack' ||
-      !binding.isDm ||
       !binding.integrationId ||
       !title
     )
@@ -12391,7 +12390,7 @@ export class Daemon {
       if (p.webchat) {
         webchatTurnOutput.emitWebchatUpdate(p.webchat, { sessionUpdate: 'session_info_update', title: req.title })
       }
-      if (turnChromeFor(p.plan.platform).dmSessionTitle && p.plan.isDm && p.conn) {
+      if (turnChromeFor(p.plan.platform).sessionTitle && p.conn) {
         this.enqueueApply(p, { kind: 'set-title', text: req.title })
         await p.signals.applyChain
         return
@@ -12575,7 +12574,7 @@ export class Daemon {
         // the runtime's title verbatim (apart from surrounding whitespace); do not
         // invent one from the first-message fallback used by the console session list.
         const slackTitle = typeof update.title === 'string' ? update.title.trim() : ''
-        if (p && turnChromeFor(p.plan.platform).dmSessionTitle && p.plan.isDm && slackTitle) {
+        if (p && turnChromeFor(p.plan.platform).sessionTitle && slackTitle) {
           this.enqueueApply(p, { kind: 'set-title', text: slackTitle })
         } else if (!p && slackTitle) {
           const binding = this.sessionDeliveryBindings.get(rec.key)

--- a/packages/daemon/src/platforms/turn-chrome.ts
+++ b/packages/daemon/src/platforms/turn-chrome.ts
@@ -31,9 +31,10 @@ export interface TurnChrome {
   /** Attribution footer lifecycle: blocks pre-built at prompt start so reply
    *  sections are born with them, refreshed once more at final. */
   readonly attributionFooter?: boolean
-  /** Live session titles pushed onto DM threads (Slack's Agents feature
-   *  renders native titles only for app-DM threads). */
-  readonly dmSessionTitle?: boolean
+  /** Live session titles pushed onto the platform's threads. Slack renders them as the
+   *  thread panel's header in DMs AND channels — a thread becomes eligible once any
+   *  agents.sessions call or a card stream registers it (verified live 2026-08-29). */
+  readonly sessionTitle?: boolean
   /** In-chat human-input cards: permission approvals, MCP-approval
    *  elicitations, and the generic elicitation card. */
   readonly chatInputCards?: boolean
@@ -48,7 +49,7 @@ const CHROME = new Map<string, TurnChrome>([
     {
       statusSurface: 'turn-bar',
       attributionFooter: true,
-      dmSessionTitle: true,
+      sessionTitle: true,
       chatInputCards: true,
       chromeMarkedNotices: true
     }

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -2255,7 +2255,10 @@ export class SlackConnection implements PlatformConnection {
     }
   }
 
-  /** Best-effort agent-session title; only valid for Agents-feature threads, so the daemon gates it to DMs. */
+  /** Best-effort agent-session title, DMs and channels alike: Slack renders it as the thread
+   *  panel's header once the thread is a registered agent session — which every turn's
+   *  lifecycle `setStatus` (and any card stream) makes it. Unregistered threads answer
+   *  `not_authorized` and degrade here. */
   async setTitle(channel: string, threadTs: string, title: string): Promise<void> {
     try {
       await this.queue.enqueue(() =>

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -712,17 +712,20 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     const emitEventSession = vi.fn()
     ;(daemon as any).cpClient = { emitEventSession, emitUsageReport: vi.fn(), stop: vi.fn() }
 
+    // A CHANNEL thread on purpose: the native title is no longer DM-gated — every turn's
+    // lifecycle setStatus registers the thread as an agent session, and Slack renders the
+    // title as the thread panel's header in channels too (verified live 2026-08-29).
     await (daemon as any).dispatch('bot-a', {
       msgId: 'slack:C1:200.1',
       traceId: 'title',
-      source: 'user',
+      source: 'cron',
       platform: 'slack',
       channel: 'C1',
       thread: '200.1',
       sender: { id: 'U1', isBot: false },
       text: 'first fallback',
       mentionedBots: [],
-      isDm: true
+      isDm: false
     })
 
     expect(emitEventSession.mock.calls.map(([payload]) => payload.phase)).toEqual(['start', 'plan', 'end'])
@@ -1046,10 +1049,12 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     await daemon.stop()
   })
 
+  // No non-DM row here any more: the title gate no longer branches on the surface (channels
+  // are eligible — every turn's lifecycle setStatus registers the thread as an agent session,
+  // and the positive channel case is pinned above), so blank/cleared cover the whole gate.
   it.each([
-    { scenario: 'a non-DM thread', title: 'Channel summary', isDm: false },
-    { scenario: 'a blank DM title', title: '   ', isDm: true },
-    { scenario: 'a cleared DM title', title: null, isDm: true }
+    { scenario: 'a blank title', title: '   ', isDm: true },
+    { scenario: 'a cleared title', title: null, isDm: true }
   ])(
     'does not set a native Slack title for $scenario',
     async ({ title, isDm }) => {

--- a/packages/daemon/test/turn-chrome.test.ts
+++ b/packages/daemon/test/turn-chrome.test.ts
@@ -6,7 +6,7 @@ describe('turn chrome facet', () => {
     expect(turnChromeFor('slack')).toEqual({
       statusSurface: 'turn-bar',
       attributionFooter: true,
-      dmSessionTitle: true,
+      sessionTitle: true,
       chatInputCards: true,
       chromeMarkedNotices: true
     })


### PR DESCRIPTION
Session renames looked like they did nothing. Probed with raw API calls in a real workspace,
DM and channel side by side, and the belief behind the DM gate turned out to be out of date on
both ends.

## What the probes established

| call | plain thread | after `agents.sessions.setStatus` | after a card stream | after legacy `assistant.threads.setStatus` |
| --- | --- | --- | --- | --- |
| `agents.sessions.rename` | `not_authorized` (DM too) | **ok** | **ok** | `not_authorized` |

And once a rename lands, the title renders as the **thread panel's header** — in channels
exactly as in DMs (screenshots verified for both).

So the two halves of "renames have no visible effect" were:

1. **channels never tried** — the daemon gated `set-title` on `isDm`, citing "Slack renders
   native titles only for app-DM threads", which no longer holds;
2. **eligibility is not about the surface at all** — it is registration, and every turn
   already registers the thread via the lifecycle `agents.sessions.setStatus`.

## What changed

- The `isDm` conditions fall away at both title sites (in-turn and late-arriving), plus the
  binding-path guard; a runtime title now lands on any Slack thread with a status thread.
- The `dmSessionTitle` chrome flag is renamed `sessionTitle` — the old name encoded the
  disproven premise.
- `SlackConnection.setTitle`'s comment now states the real eligibility rule (registration),
  and the unregistered case still degrades silently (`not_authorized` → debug log).
- The positive smoke case now pins a **channel** turn; blank/cleared titles still never call
  the API.
