### PR TITLE
docs(daemon): correct prepareClusterWorkspace's stale skills note

### DIFF
--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -2630,9 +2630,12 @@ export type SessionWorktreeRemoval = (
  * `rmSync`. Sharing the body would mean a conditional at each of those, and the local path — the one
  * every self-hosted daemon runs — is the one that must not acquire new ways to be wrong.
  *
- * Skills are NOT installed here. Their acquisition, ledger and executable-content removal are all
- * local-filesystem work, and pointing them at a pod path would write them onto this daemon's disk;
- * that migration is its own change, so a cluster agent runs with none.
+ * Skills are not installed here, but a cluster agent still gets them. What cannot be reused is the
+ * LOCAL installer: its acquisition, ledger and executable-content removal are local-filesystem work,
+ * and pointing them at a pod path would write onto this daemon's disk. So the daemon acquires and pins
+ * the sources itself, then uploads immutable snapshots over the shim's `skills` capability, which
+ * publishes them on the pod with the workspace mount as cwd and records ownership in the daemon's
+ * `cluster_skill_ledger`. `reconcileClusterSkills` drives that immediately after this function returns.
  */
 
 /** Cluster preparation's marker write: best-effort, because the volume IS prepared and failing a


### PR DESCRIPTION
## What changed

The trailing doc comment for `prepareClusterWorkspace` in
`packages/daemon/src/workspace/workspace-manager.ts` ended with:

> that migration is its own change, so a cluster agent runs with none.

That conclusion has been false since #1545 and its follow-ups. Cluster sandbox
agents do get skills. The paragraph is rewritten to describe the path that
actually runs.

## Why

The comment's *rationale* was still correct and is kept: the local installer is
not reused because its acquisition, ledger, and executable-content removal are
local-filesystem work that would land on the daemon's own disk if pointed at a
pod path. Only the conclusion drawn from it was stale, so the fix re-points the
reasoning at the local installer specifically rather than at skills in general —
it now explains why *this function* stays out of skill installation, instead of
implying that nothing installs them at all.

## For the reviewer

Every claim in the new wording was checked against the code rather than taken
from the PR description that introduced the behavior:

- `reconcileSkillBundles({ cwd: this.deps.workspaceRoot, ... })` —
  `shim/skill-handler.ts`, so publication runs on the pod with the workspace
  mount as cwd.
- The `'skills'` shim capability — `shim/protocol.ts`.
- The `cluster_skill_ledger` table — `store/local-store.ts`.
- `reconcileClusterSkills` is called on the line directly after
  `prepareClusterWorkspace`, inside the same `withAgentVolume` block
  (`daemon.ts`), which is what "immediately after this function returns" refers
  to.

Wording follows the **Cluster sandbox** bullet in §1 "Implementation state" of
`docs/designs/shared-skills.md`.

On comment style: the repo prefers one-line comments, but this is an existing
multi-paragraph JSDoc block whose neighbours all run several lines. I kept it as
a tightened paragraph in the same register rather than forcing a one-liner that
would have had to drop the mechanism.

## Verification

Doc comment only — no behavior change, no code paths touched. `prettier --check`
and `eslint` both pass on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
