### PR TITLE
fix(daemon): stop the skill installer's own bundles from pinning session worktrees

### DIFF
--- a/docs/designs/shared-skills.md
+++ b/docs/designs/shared-skills.md
@@ -546,10 +546,20 @@ any other local source.
 - `--copy` is mandatory. The snapshot walker and CLI-cell scanner reject source
   or output links, and the generic publisher copies only receipt-bound ordinary
   files.
-- The installer does not edit `.gitignore`, `.git/info/exclude`, or any other
-  repository ignore configuration. Runtime-visible skill directories are
-  ordinary workspace changes governed only by the trusted receipt/ledger;
-  repository owners may choose their own ignore policy.
+- The installer itself still edits no ignore configuration, and `.gitignore` or
+  any other tracked ignore file is never touched — repository owners keep ignore
+  policy for everything that is theirs. What changed: after installation,
+  workspace preparation declares the ledger-owned bundle roots in the checkout's
+  common `.git/info/exclude` (`workspace/git-exclude.ts`), inside one marked
+  block that is replaced wholesale so it always mirrors the ledger — a bundle
+  the agent stops installing stops being excluded, and human-authored entries
+  outside the block survive verbatim.
+- The exclusion exists because "ordinary workspace changes" was the bug, not a
+  neutral stance: untracked daemon-owned bundles read as user work to the
+  session-retention GC, which then refuses to reclaim any worktree the installer
+  touched. Registrations grow until the runtime's Bash sandbox profile — sized
+  per registered worktree — overflows the OS exec argument limit and every
+  command in the agent fails to spawn (issue #1603).
 
 ### 6.7 Runtime without a CLI identity
 
@@ -634,9 +644,9 @@ The implemented surface follows `McpServersCard`:
 
 ## 9. Main change index
 
-| Package       | Files                                                                                                                                                                                                                                                                                                                                                                  | Change                                                                                                       |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| protocol      | `frames/agent.ts` for strict and rolling-compatible inline skill entries; `git-url.ts` for bounded GitHub normalization                                                                                                                                                                                                                                                | **No** `skillsource/*` frame and **no** `RegisterOk.skillSources`; sources are inline in `AgentSpec.skills`. |
-| control-plane | `prisma/schema.prisma` for the `SkillSource` registry and `Agent.skills`; `http/routes/skill-sources.ts`; `orchestrator/skillSource.ts` for per-row projection/filtering and source-change fan-out; `github/service.ts` for best-effort preview scanning                                                                                                               | Section 4                                                                                                    |
-| daemon        | `src/skills/install-skills.ts`, `skills-cli-cell.ts`, `skill-source-snapshot.ts`, `skill-git-source.ts`, `skill-install-ledger.ts`, `skill-workspace-mutation-cli.ts`, `skill-workspace-mutator.ts`, `offline-sandbox.ts`, `dream-skills.ts`, and `runtimes/skills-capability.ts`; `workspace/workspace-manager.ts` as the cold-host trigger; exact bundled dependency | Section 6                                                                                                    |
-| web           | `SkillSourcesCard.tsx`, `ManagedSkillTile.tsx`, `ToolsHubView.tsx`, `lib/api.ts`, `lib/data-context.tsx`, and the agent editor                                                                                                                                                                                                                                         | Section 7                                                                                                    |
+| Package       | Files                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Change                                                                                                       |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| protocol      | `frames/agent.ts` for strict and rolling-compatible inline skill entries; `git-url.ts` for bounded GitHub normalization                                                                                                                                                                                                                                                                                                                               | **No** `skillsource/*` frame and **no** `RegisterOk.skillSources`; sources are inline in `AgentSpec.skills`. |
+| control-plane | `prisma/schema.prisma` for the `SkillSource` registry and `Agent.skills`; `http/routes/skill-sources.ts`; `orchestrator/skillSource.ts` for per-row projection/filtering and source-change fan-out; `github/service.ts` for best-effort preview scanning                                                                                                                                                                                              | Section 4                                                                                                    |
+| daemon        | `src/skills/install-skills.ts`, `skills-cli-cell.ts`, `skill-source-snapshot.ts`, `skill-git-source.ts`, `skill-install-ledger.ts`, `skill-workspace-mutation-cli.ts`, `skill-workspace-mutator.ts`, `offline-sandbox.ts`, `dream-skills.ts`, and `runtimes/skills-capability.ts`; `workspace/workspace-manager.ts` as the cold-host trigger; `workspace/git-exclude.ts` for the managed-bundle exclude block (section 6.6); exact bundled dependency | Section 6                                                                                                    |
+| web           | `SkillSourcesCard.tsx`, `ManagedSkillTile.tsx`, `ToolsHubView.tsx`, `lib/api.ts`, `lib/data-context.tsx`, and the agent editor                                                                                                                                                                                                                                                                                                                        | Section 7                                                                                                    |

--- a/packages/daemon/src/skills/install-skills.ts
+++ b/packages/daemon/src/skills/install-skills.ts
@@ -142,6 +142,8 @@ export interface InstallSkillsResult {
   installed: string[]
   removed: string[]
   skipped: 'unchanged' | null
+  /** Checkout-relative roots this daemon owns after the run — what git must be told to ignore. */
+  owned: string[]
   errors: Array<{ source: string; error: string }>
 }
 
@@ -176,7 +178,7 @@ async function installSkillsLocked(
   cwd: string,
   opts: InstallSkillsOptions
 ): Promise<InstallSkillsResult> {
-  const result: InstallSkillsResult = { installed: [], removed: [], skipped: null, errors: [] }
+  const result: InstallSkillsResult = { installed: [], removed: [], skipped: null, owned: [], errors: [] }
   const wireGitSources = agent.skills ?? []
   const localSources = opts.localSkills ?? []
   if (localSources.length > MAX_LOCAL_SKILL_SOURCES) throw new Error('too many local skill sources')
@@ -276,6 +278,7 @@ async function installSkillsLocked(
       (await installedBundlesIntact(cwd, ledger.owned, location.workspaceIdentity))
     ) {
       result.skipped = 'unchanged'
+      result.owned = ledger.owned.map((bundle) => bundle.relativeRoot)
       return result
     }
 
@@ -294,6 +297,7 @@ async function installSkillsLocked(
         warn: opts.warn
       })
       result.removed.push(...reconciled.removed)
+      result.owned = reconciled.owned.map((bundle) => bundle.relativeRoot)
       return result
     }
 
@@ -451,6 +455,7 @@ async function installSkillsLocked(
     result.installed.push(...reconciled.installed)
     result.removed.push(...reconciled.removed)
     result.skipped = reconciled.skipped
+    result.owned = reconciled.owned.map((bundle) => bundle.relativeRoot)
     for (const conflict of reconciled.conflicts) {
       result.errors.push({ source: conflict, error: 'destination is not owned by this daemon ledger; skill skipped' })
     }
@@ -484,6 +489,7 @@ async function installSkillsLocked(
         warn: opts.warn
       })
       result.removed.push(...cleared.removed)
+      result.owned = cleared.owned.map((bundle) => bundle.relativeRoot)
       return result
     } catch (cleanupError) {
       throw new Error(

--- a/packages/daemon/src/workspace/git-exclude.ts
+++ b/packages/daemon/src/workspace/git-exclude.ts
@@ -1,0 +1,69 @@
+/**
+ * Keep the daemon's own installed content out of `git status`.
+ *
+ * Skill bundles are written INTO the checkout (`.claude/skills/<bundle>/`) and are untracked, so
+ * every session worktree reports dirty forever — and the session-retention GC, which promises never
+ * to auto-delete untracked work, then refuses to reclaim any of them. The registrations accumulate
+ * until the runtime's own sandbox profile (one deny path per registered worktree) overflows the OS
+ * exec argument limit and no command can spawn at all. These are the daemon's files, not a user's,
+ * so it is the daemon's job to declare them uninteresting.
+ *
+ * The patterns go in `info/exclude` of the COMMON directory — Git resolves that path there rather
+ * than per worktree, which is what we want: every worktree of a clone installs the same bundles.
+ */
+import { promises as fsp } from 'node:fs'
+import { dirname, join, relative, sep } from 'node:path'
+
+const BEGIN = '# BEGIN agentconnect-managed skills'
+const END = '# END agentconnect-managed skills'
+
+/**
+ * Re-express bundle roots, which the installer reports relative to the ACP cwd, against the
+ * checkout root that an exclude pattern anchors to. The two differ for an `agentDir` agent, whose
+ * cwd sits below the checkout. A root that escapes the checkout is dropped rather than anchored
+ * wrong — the worktree stays dirty, which is the behaviour we already had.
+ */
+export function bundlePathsFromCheckoutRoot(checkoutRoot: string, cwd: string, relativeRoots: string[]): string[] {
+  return relativeRoots
+    .map((root) => relative(checkoutRoot, join(cwd, root)).split(sep).join('/'))
+    .filter((root) => root !== '' && !root.startsWith('../'))
+}
+
+/** Escape the gitignore metacharacters so a bundle directory can never act as a pattern. */
+function excludePattern(relativeRoot: string): string {
+  return `/${relativeRoot.replace(/[\\!#*?[\]]/g, (char) => `\\${char}`)}/`
+}
+
+/** Everything outside our marked block, which the daemon must preserve verbatim. */
+function stripBlock(content: string): string {
+  const begin = content.indexOf(BEGIN)
+  if (begin < 0) return content
+  const end = content.indexOf(END, begin)
+  if (end < 0) return content.slice(0, begin)
+  return content.slice(0, begin) + content.slice(end + END.length).replace(/^\r?\n/, '')
+}
+
+/**
+ * Declare `relativeRoots` (checkout-relative bundle directories) daemon-owned in `commonDir`.
+ *
+ * Idempotent and total: the block is REPLACED, so a bundle the agent no longer installs stops being
+ * excluded. Written through a rename so a concurrent reader never sees a partial file; two sessions
+ * of one agent write identical content, and a lost update self-heals on the next preparation.
+ */
+export async function excludeManagedSkillBundles(commonDir: string, relativeRoots: string[]): Promise<void> {
+  const file = join(commonDir, 'info', 'exclude')
+  const current = await fsp.readFile(file, 'utf8').catch(() => '')
+  const kept = stripBlock(current)
+  const patterns = [...new Set(relativeRoots.map(excludePattern))].sort()
+  const block = patterns.length === 0 ? '' : `${[BEGIN, ...patterns, END].join('\n')}\n`
+  const head = kept === '' || kept.endsWith('\n') ? kept : `${kept}\n`
+  const next = block === '' ? kept : `${head}${block}`
+  if (next === current) return
+  await fsp.mkdir(dirname(file), { recursive: true })
+  const tmp = `${file}.agentconnect-${process.pid}`
+  await fsp.writeFile(tmp, next, { mode: 0o644 })
+  await fsp.rename(tmp, file).catch(async (err: unknown) => {
+    await fsp.rm(tmp, { force: true }).catch(() => undefined)
+    throw err
+  })
+}

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -26,6 +26,7 @@ import { formatErr } from '../daemon/text.js'
 import { makeLogger } from '../log.js'
 import { installSkills, type LocalSkillSource } from '../skills/install-skills.js'
 import { acceptedDreamSkillSources } from '../skills/dream-skills.js'
+import { bundlePathsFromCheckoutRoot, excludeManagedSkillBundles } from './git-exclude.js'
 import {
   assertSafeWorkspaceGitConfig,
   canonicalWorkspaceGitUrl,
@@ -267,14 +268,35 @@ export class WorkspaceManager {
     // be removed or the ledger cannot be proven coherent. Those must block host
     // startup rather than launch ACP with stale/incoherent executable skills, so
     // let them propagate (design: docs/designs/shared-skills.md §2).
-    await installSkills(agent, acpCwd, {
+    const installed = await installSkills(agent, acpCwd, {
       ...(opts.skillsStateDir ? { stateDir: opts.skillsStateDir } : {}),
       ...(opts.skillsAgentId === undefined ? {} : { skillsAgentId: opts.skillsAgentId }),
       localSkills: [...managedSkills, ...acceptedSkills],
       useGitCredential: this.usesGithubApp(agent),
       warn: (msg) => skillsLog.warn(msg)
     })
+    await this.excludeInstalledSkills(agent, acpCwd, installed.owned)
     return acpCwd
+  }
+
+  /** Tell Git the bundles we just wrote are ours, so the retention GC never reads them as the
+   *  user's untracked work and pins this worktree forever (see workspace/git-exclude.ts). */
+  private async excludeInstalledSkills(agent: Agent, acpCwd: string, owned: string[]): Promise<void> {
+    // Cluster bundles live on the pod OUTSIDE the checkout and never dirty a worktree; worse, the
+    // shim would answer rev-parse with pod paths this local write would then create on daemon disk.
+    if (this.sandboxMode) return
+    try {
+      const git = this.runnerFor(agent.id, acpCwd).withEnv(workspaceGitLocalEnv())
+      const [commonDir = '', checkoutRoot = ''] = (await git.raw(['rev-parse', '--git-common-dir', '--show-toplevel']))
+        .split('\n')
+        .map((line) => line.trim())
+      if (commonDir === '' || checkoutRoot === '') return
+      const roots = bundlePathsFromCheckoutRoot(checkoutRoot, acpCwd, owned)
+      await excludeManagedSkillBundles(isAbsolute(commonDir) ? commonDir : join(acpCwd, commonDir), roots)
+    } catch (err) {
+      // A from-scratch workspace has no repository to exclude in, and bookkeeping must not fail a launch.
+      skillsLog.debug(`skills: could not record managed bundles as ignored: ${(err as Error).message}`)
+    }
   }
 
   usesGithubApp(agent: Agent): boolean {

--- a/packages/daemon/test/git-exclude.test.ts
+++ b/packages/daemon/test/git-exclude.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { workspaceGitLocalEnv } from '../src/workspace/git-injection.js'
+import { bundlePathsFromCheckoutRoot, excludeManagedSkillBundles } from '../src/workspace/git-exclude.js'
+
+const env = {
+  ...workspaceGitLocalEnv(),
+  GIT_AUTHOR_NAME: 'Ada Lovelace',
+  GIT_AUTHOR_EMAIL: 'ada@example.invalid',
+  GIT_COMMITTER_NAME: 'Ada Lovelace',
+  GIT_COMMITTER_EMAIL: 'ada@example.invalid'
+}
+// No background maintenance: its detached child races this file's fixture teardown.
+const git = (root: string, ...args: string[]) =>
+  execFileSync('git', ['-C', root, '-c', 'maintenance.auto=false', '-c', 'gc.auto=0', ...args], {
+    env,
+    encoding: 'utf8'
+  })
+
+const BUNDLE = '.claude/skills/corepack-checks'
+
+/** A checkout plus one session worktree, the shape the daemon prepares. `trackedSkill` is the
+ *  difference that decides what `status` reports: with one, Git descends into `.claude/skills` and
+ *  names the bundle; without, it collapses the whole tree to `?? .claude/`. Both must go clean. */
+function fixture(name: string, trackedSkill: boolean) {
+  const base = mkdtempSync(join(tmpdir(), `ac-git-exclude-${name}-`))
+  const repo = join(base, 'repo')
+  const worktree = join(base, 'worktrees', 'session-1')
+  mkdirSync(repo, { recursive: true })
+  git(repo, 'init', '-b', 'main')
+  writeFileSync(join(repo, 'README.md'), 'hello\n')
+  if (trackedSkill) {
+    mkdirSync(join(repo, '.claude', 'skills', 'repo-skill'), { recursive: true })
+    writeFileSync(join(repo, '.claude', 'skills', 'repo-skill', 'SKILL.md'), '# in the repo\n')
+  }
+  git(repo, 'add', '-A')
+  git(repo, 'commit', '-m', 'first commit')
+  git(repo, 'worktree', 'add', '--detach', worktree)
+  const commonDir = git(worktree, 'rev-parse', '--path-format=absolute', '--git-common-dir').trim()
+  return { base, repo, worktree, commonDir, excludeFile: join(commonDir, 'info', 'exclude') }
+}
+
+/** What the daemon's skill installer leaves behind in a session worktree. */
+function installBundle(worktree: string, relativeRoot: string): void {
+  const dir = join(worktree, ...relativeRoot.split('/'))
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'SKILL.md'), '# installed by the daemon\n')
+}
+
+let repoWithSkills: ReturnType<typeof fixture>
+
+beforeAll(() => {
+  repoWithSkills = fixture('tracked', true)
+  installBundle(repoWithSkills.worktree, BUNDLE)
+})
+
+afterAll(() => rmSync(repoWithSkills.base, { recursive: true, force: true }))
+
+const readExclude = () => readFileSync(repoWithSkills.excludeFile, 'utf8')
+
+describe('excludeManagedSkillBundles', () => {
+  it('clears the dirty status a daemon-installed bundle leaves in a session worktree', async () => {
+    const { worktree, repo, commonDir } = repoWithSkills
+    // The regression: the GC reads this as the user's untracked work and keeps the worktree forever.
+    expect(git(worktree, 'status', '--porcelain').trim()).toBe(`?? ${BUNDLE}/`)
+
+    await excludeManagedSkillBundles(commonDir, [BUNDLE])
+
+    expect(git(worktree, 'status', '--porcelain').trim()).toBe('')
+    // The main checkout shares the common dir, so one write covers every worktree of the clone.
+    expect(git(repo, 'status', '--porcelain').trim()).toBe('')
+  })
+
+  it('clears it in a repository that tracks no skills of its own', async () => {
+    const plain = fixture('plain', false)
+    try {
+      installBundle(plain.worktree, BUNDLE)
+      // Git collapses a wholly untracked tree, so the reported path is not the bundle's.
+      expect(git(plain.worktree, 'status', '--porcelain').trim()).toBe('?? .claude/')
+
+      await excludeManagedSkillBundles(plain.commonDir, [BUNDLE])
+
+      expect(git(plain.worktree, 'status', '--porcelain').trim()).toBe('')
+    } finally {
+      rmSync(plain.base, { recursive: true, force: true })
+    }
+  })
+
+  it('lets the retention GC reclaim the worktree without forcing', async () => {
+    const gc = fixture('gc', true)
+    try {
+      installBundle(gc.worktree, BUNDLE)
+      // What the GC does today: refuses, because the daemon's own bundle reads as user work.
+      expect(() => git(gc.repo, 'worktree', 'remove', gc.worktree)).toThrow()
+
+      await excludeManagedSkillBundles(gc.commonDir, [BUNDLE])
+
+      // No --force, exactly as removeRootSessionWorktree runs it.
+      git(gc.repo, 'worktree', 'remove', gc.worktree)
+      expect(git(gc.repo, 'worktree', 'list')).not.toContain(gc.worktree)
+    } finally {
+      rmSync(gc.base, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps entries a human wrote and replaces only its own block', async () => {
+    writeFileSync(repoWithSkills.excludeFile, `# my own notes\n/scratch/\n${readExclude()}`)
+
+    await excludeManagedSkillBundles(repoWithSkills.commonDir, ['.claude/skills/renamed'])
+
+    const content = readExclude()
+    expect(content).toContain('# my own notes')
+    expect(content).toContain('/scratch/')
+    expect(content).toContain('/.claude/skills/renamed/')
+    expect(content).not.toContain('corepack-checks')
+    expect(content.match(/# BEGIN agentconnect-managed skills/g)).toHaveLength(1)
+    // A bundle the agent stopped installing stops being excluded, so its files show up again.
+    expect(git(repoWithSkills.worktree, 'status', '--porcelain').trim()).toBe(`?? ${BUNDLE}/`)
+  })
+
+  it('is idempotent for an unchanged bundle set', async () => {
+    await excludeManagedSkillBundles(repoWithSkills.commonDir, [BUNDLE])
+    const first = readExclude()
+    await excludeManagedSkillBundles(repoWithSkills.commonDir, [BUNDLE])
+    expect(readExclude()).toBe(first)
+  })
+
+  it('drops the block entirely when the agent installs no bundles', async () => {
+    await excludeManagedSkillBundles(repoWithSkills.commonDir, [])
+
+    const content = readExclude()
+    expect(content).toContain('# my own notes')
+    expect(content).not.toContain('agentconnect-managed')
+    expect(content).not.toContain('/.claude/skills/')
+  })
+
+  it('anchors an agentDir agent’s bundles at the checkout root, not at its cwd', () => {
+    // The installer reports roots relative to the ACP cwd; `agentDir` puts that below the checkout.
+    expect(bundlePathsFromCheckoutRoot('/repo', '/repo/services/api', [BUNDLE])).toEqual([`services/api/${BUNDLE}`])
+    expect(bundlePathsFromCheckoutRoot('/repo', '/repo', [BUNDLE])).toEqual([BUNDLE])
+    // Anchoring a root that is not in the checkout would exclude an unrelated path.
+    expect(bundlePathsFromCheckoutRoot('/repo', '/elsewhere', [BUNDLE])).toEqual([])
+  })
+
+  it('escapes a name that would otherwise act as a gitignore pattern', async () => {
+    const odd = '.claude/skills/a[b]*c'
+    installBundle(repoWithSkills.worktree, odd)
+
+    await excludeManagedSkillBundles(repoWithSkills.commonDir, [BUNDLE, odd])
+
+    expect(readExclude()).toContain('/.claude/skills/a\\[b\\]\\*c/')
+    expect(git(repoWithSkills.worktree, 'status', '--porcelain').trim()).toBe('')
+  })
+})

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -22,7 +22,12 @@ vi.mock('node:fs/promises', () => ({ rename: renameMock }))
 // reassignable per test (success / failure / slow) via `cloneImpl`.
 let cloneImpl: (...args: any[]) => Promise<unknown>
 let lastGitEnv: Record<string, string> | undefined
-const pullMock = vi.fn().mockResolvedValue(undefined)
+// The env in effect when the PULL ran. `lastGitEnv` alone would name whichever git preparation
+// happens to run last, which is not what the credential-injection assertions are about.
+let pullGitEnv: Record<string, string> | undefined
+const pullMock = vi.fn().mockImplementation(async () => {
+  pullGitEnv = lastGitEnv
+})
 const rawMock = vi.fn().mockResolvedValue('')
 vi.mock('simple-git', () => ({
   simpleGit: (options?: string | { baseDir?: string }) => {
@@ -110,6 +115,7 @@ beforeEach(() => {
   cloneImpl = vi.fn().mockResolvedValue(undefined)
   renameMock.mockReset().mockImplementation(realRename)
   lastGitEnv = undefined
+  pullGitEnv = undefined
   pullMock.mockClear()
   rawMock.mockReset().mockResolvedValue('')
 })
@@ -202,7 +208,7 @@ describe('prepareWorkspace', () => {
       '+refs/heads/main:refs/remotes/origin/main',
       ['--ff-only', '--no-recurse-submodules']
     )
-    expect(Object.values(lastGitEnv ?? {})).toContain('https://github.com/acme/repo.git')
+    expect(Object.values(pullGitEnv ?? {})).toContain('https://github.com/acme/repo.git')
   })
 
   it('ignores a checkout-controlled upstream when pulling an existing workspace', async () => {
@@ -221,7 +227,7 @@ describe('prepareWorkspace', () => {
       '+refs/heads/release/v2:refs/remotes/origin/release/v2',
       ['--ff-only', '--no-recurse-submodules']
     )
-    expect(Object.values(lastGitEnv ?? {})).toContain('https://github.com/acme/repo.git')
+    expect(Object.values(pullGitEnv ?? {})).toContain('https://github.com/acme/repo.git')
   })
 
   it('returns the canonical configured repository subdirectory', async () => {


### PR DESCRIPTION
## What

Skill bundles the installer writes into a checkout (`.claude/skills/<bundle>/`) are untracked, so every session worktree reports dirty forever. The session-retention GC — which rightly never auto-deletes untracked work — then refuses to reclaim any worktree the installer touched. Registrations grow without bound until the runtime's Bash sandbox profile (roughly two deny paths per registered worktree) overflows the OS exec argument limit, and **every shell command in that agent fails with E2BIG** (observed at 261 registered worktrees; part of #1603).

These are the daemon's files, not a user's, so the daemon now declares them:

- `workspace/git-exclude.ts` — writes the installer-owned bundle roots into the checkout's `info/exclude`, in a marked block that is replaced wholesale (a bundle the agent stops installing stops being excluded). The file lives in the **common** git dir, so one write covers every worktree of the clone. Human-authored entries outside the block are preserved; gitignore metacharacters in bundle names are escaped.
- `installSkills` now reports the ledger's live `owned` roots on every path (unchanged fast path, no-CLI reconcile, success, and failure cleanup), so the exclude block always mirrors what the ledger actually owns.
- `WorkspaceManager.withSkills` applies the exclusion after installation. Bundle roots are re-anchored from the ACP cwd to the checkout root (`--show-toplevel`), because an `agentDir` agent's cwd sits below the checkout and a cwd-relative pattern would anchor wrong; roots that escape the checkout are dropped (previous behavior: they just stay visible). Best-effort — a from-scratch workspace has no repository, and bookkeeping must not fail a launch.
- Guarded off in sandbox mode: cluster bundles land outside the pod checkout and never dirty a worktree, and the shim would answer `rev-parse` with pod paths that this local write would then create on the daemon's own disk.

## Why not change the GC instead

The GC's dirty-tree protection is correct — it must keep guarding real user work. The bug is that the daemon's own bookkeeping files masqueraded as user work; telling git whose they are fixes the misclassification without touching the GC's semantics.

## Tests

`test/git-exclude.test.ts` covers the regression end to end against real git: a daemon-installed bundle makes `git worktree remove` (no `--force`) refuse, and succeed after the exclusion — the exact call the retention GC makes. Also: both `status` shapes (a repo that tracks `.claude/skills` content descends and names the bundle; one that doesn't collapses to `?? .claude/`), block replacement around human-authored entries, idempotence, empty-set removal, metacharacter escaping, and the checkout-root re-anchoring.

The two credential-injection assertions in `test/workspace.test.ts` now read the env the *pull* ran under rather than whichever git preparation happened to run last — the new `rev-parse` was displacing what they meant to assert.

`typecheck`, `lint`, and the daemon suites pass; the full-suite failures on this machine (shim `/var` → `/private/var` realpath cases and the live acp-matrix) reproduce identically on `main`.

## Notes for review

This makes the GC able to reclaim; it does not shrink what a busy agent holds at steady state. The remaining headroom work (review-snapshot reclamation, a possible hard cap) is tracked in #1603.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
