### PR TITLE
measure: read what PRAGMA synchronous costs on the Windows runner

### DIFF
--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1051,6 +1051,7 @@ export class LocalStore {
         orgForAgent: undefined
       })
       await store.db.exec('PRAGMA journal_mode = WAL')
+      await store.db.exec('PRAGMA synchronous = NORMAL')
       // WAL mode publishes two siblings alongside the database; they carry the same
       // rows, so restricting only the main file would leave the content readable.
       for (const p of [source, `${source}-wal`, `${source}-shm`]) restrictPath(p, 0o600)


### PR DESCRIPTION
## Do not merge — this is a measurement

One line on top of #1589, so the only difference between this run and that branch's is the pragma, and the Windows job's number is the answer.

```diff
       await store.db.exec('PRAGMA journal_mode = WAL')
+      await store.db.exec('PRAGMA synchronous = NORMAL')
```

(The diff against `main` also shows #1589's contents, because that is what this branches from. The one line above is the whole change under test.)

## The question

WAL keeps `synchronous = FULL`, which fsyncs the WAL on every commit. #1598 removed 57 of those per store by creating the schema in one transaction, and the Windows job went from 22 min to 11.7. But every session row and transcript row a test writes is still its own commit, so the same cost is now spread through the test bodies instead of concentrated at open. Bucketing what is left says the 63 files that construct a `Daemon` still carry 1138 s of the 1650 s, at 786 ms per case over Linux.

macOS says NORMAL is worth ~8% on top of the transaction. macOS also said the transaction was worth 1-2 min on Windows, and it was worth ten: a flush on APFS and a flush through the NTFS filter stack are an order of magnitude apart. So the macOS figure is not evidence about Windows in either direction, and running it there is the only way to know.

## What the answer decides

`synchronous = NORMAL` under WAL cannot corrupt the database; it can lose the most recent commits to a power cut or OS crash (an application crash is still safe). This store holds the durable inbox, whose whole promise is surviving a restart, so that trade needs a real argument — and is worth having only if the number comes back large. Small, and this PR closes with the question settled.

Baseline to compare against: #1589's run — Windows job 9.5 min, daemon step 434 s, vitest `tests` total 1650.3 s, four workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
