### PR TITLE
ci: install only what the daemon jobs run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -270,9 +270,9 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           cache: true
-          # Its own cache namespace, keyed by the closure it stores rather than by the lockfile
-          # alone. Nothing shares this OS today, but the rule is the same one the two narrowed
-          # Linux jobs follow: a job that installs a subset never writes the shared entry.
+          # Its own primary key, keyed by the closure it stores rather than by the lockfile alone.
+          # Nothing shares this OS today, but the rule is the one the two narrowed Linux jobs
+          # follow: a job that installs a subset never saves under the shared key.
           cache_dependency_path: |
             pnpm-lock.yaml
             packages/daemon/package.json
@@ -378,9 +378,11 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           cache: true
-          # Its own cache namespace. The default key is shared by every job on this runner OS, and
-          # this job stores a filtered subset — under the shared key that subset would cost the
-          # full-install jobs a re-download on every run after a lockfile change.
+          # Its own PRIMARY key. The default one is shared by every job on this runner OS, so the
+          # filtered subset this job stores would otherwise be what `build`, `check` and `unit`
+          # restore on every run. Only the primary: the action's restore-key prefix stops before the
+          # hash, so on the one run after a lockfile change a full-install job can still fall back
+          # onto this store and re-fetch what it misses.
           cache_dependency_path: |
             pnpm-lock.yaml
             packages/daemon/package.json
@@ -438,7 +440,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           cache: true
-          # Its own cache namespace, for the reason the sandbox job gives.
+          # Its own primary key, for the reason the sandbox job gives.
           cache_dependency_path: |
             pnpm-lock.yaml
             packages/daemon/package.json

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -270,6 +270,13 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           cache: true
+          # Its own cache namespace, keyed by the closure it stores rather than by the lockfile
+          # alone. Nothing shares this OS today, but the rule is the same one the two narrowed
+          # Linux jobs follow: a job that installs a subset never writes the shared entry.
+          cache_dependency_path: |
+            pnpm-lock.yaml
+            packages/daemon/package.json
+            packages/cli/package.json
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -371,13 +378,20 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           cache: true
+          # Its own cache namespace. The default key is shared by every job on this runner OS, and
+          # this job stores a filtered subset — under the shared key that subset would cost the
+          # full-install jobs a re-download on every run after a lockfile change.
+          cache_dependency_path: |
+            pnpm-lock.yaml
+            packages/daemon/package.json
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+      # Only the daemon and its workspace closure — this job runs nothing else. No Prisma step
+      # either, for the reason the Windows job gives: the daemon never imports the generated client,
+      # and `pnpm -r` would now reach a control plane this install deliberately left out.
       - name: Install
-        run: pnpm install --frozen-lockfile
-      - name: Generate Prisma client
-        run: pnpm -r prisma:generate
+        run: pnpm install --frozen-lockfile --filter "@agentconnect.md/daemon..."
       # The only apt on the critical path. A runner's regional mirror can black-hole a fetch for
       # hours, and the acquire timeouts below do NOT rescue that: apt falls through to upstream,
       # but per index file, so the step cap expires before the fallbacks finish. Drop the mirror
@@ -424,11 +438,16 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           cache: true
+          # Its own cache namespace, for the reason the sandbox job gives.
+          cache_dependency_path: |
+            pnpm-lock.yaml
+            packages/daemon/package.json
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+      # Only the daemon and its workspace closure — this job runs nothing else.
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter "@agentconnect.md/daemon..."
       - name: Daemon store suites on PostgreSQL
         run: pnpm --filter @agentconnect.md/daemon test:store:postgres
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -273,8 +273,16 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+      # Only what this job runs, plus its workspace closure — 7 of the 14 projects. A full install
+      # also fetches the console's Next.js and the control plane's Prisma, which this job can never
+      # reach, and Windows pays for every one of those files twice: extracting the store cache, then
+      # materializing node_modules. Safe to narrow because the three imports that leave these two
+      # packages — `evals/games/mcp-client.ts` and the two `docker/runtime-sandbox` helpers — use
+      # only Node built-ins, as do the summary scripts, and both packages carry their own vitest.
+      # The other jobs keep the full install: every Linux job shares one cache key, so a partial
+      # store saved by one would cost the full-install jobs a re-download on every run.
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter "@agentconnect.md/daemon..." --filter "@agentconnect.md/cli..."
       # POSIX-only files self-skip via `it.skipIf(process.platform === 'win32')`, or — when every
       # case in the file is POSIX-only — via `WINDOWS_EXCLUDED` in that package's vitest.config.ts.
       #


### PR DESCRIPTION
## Why

Setup and install cost the Windows job **94 s of its 7.8 min**, against 36-46 s for a Linux job running the same three steps. Inside `pnpm/action-setup`'s 61 s:

```
15s  self-installing pnpm
 6s  downloading the store cache — 752 MB at 168 MB/s, so not the network
39s  tar + zstd extracting those 752 MB onto NTFS      <- the cost
```

Then `Install` spends another 37 s materializing node_modules from that store. Windows pays for the same files twice, and file writes are where it charges most.

Three jobs run daemon (and, on Windows, CLI) suites and nothing else, and all three installed all fourteen projects to do it. The heaviest things they fetch are ones they cannot reach:

| | size | reachable from daemon? |
|---|---|---|
| `onnxruntime-node` | 211 MB | no |
| `next` | 199 MB | no |
| `react-icons` | 85 MB | no |
| `@next/swc` | 85 MB | no |
| `@prisma/client` (+ `prisma`, `@prisma/studio-core`) | 156 MB | no |

`pnpm why` from the daemon package puts every one of them outside its closure.

## What

| job | install |
|---|---|
| `Unit Test (Windows)` | `--filter "@agentconnect.md/daemon..." --filter "@agentconnect.md/cli..."` — 7 of 14 projects |
| `Sandbox (Linux)` | `--filter "@agentconnect.md/daemon..."` |
| `Daemon Store (PostgreSQL)` | `--filter "@agentconnect.md/daemon..."` |
| `build` / `check` / `unit` / `evals` / `integration` | unchanged — they genuinely need the workspace |

All three are configured identically, so a reader never has to work out why one daemon job installs the console's Next.js and another does not.

**The sandbox job's `pnpm -r prisma:generate` goes.** Only the control plane defines that script, and `pnpm -r` would now reach a package this install deliberately left out. It was never needed there either — the daemon does not import the generated client, which is why the Windows job has no such step.

**Each narrowed job gets its own cache namespace.** `pnpm/action-setup` keys on `pnpm-cache-<os>-<arch>-<lockfile>`, so every Linux job shares one entry — a partial store saved by whichever narrowed job reached it first would cost `build`, `check` and `unit` a re-download on every run until the lockfile moved. Keying on the closure instead of the lockfile alone keeps the two daemon jobs sharing one store with each other and out of the full-install jobs' way. The Windows job gets the same treatment though nothing shares its OS today: the rule is easier to keep than the exception.

## Why it is safe to narrow

- The only imports leaving these packages are `evals/games/mcp-client.ts` and the two `docker/runtime-sandbox` helpers — all three use Node built-ins alone, as does `merge-vitest-summaries.mjs`.
- Each package carries its own `vitest`, so nothing here depends on the workspace root the filter drops.
- The Postgres job's needs are the daemon package's own dependencies (`pg`, `@testcontainers/postgresql`), and `vitest.postgres.config.ts` reaches outside the package only for the summary reporter.

## What to read on this run

`pnpm/action-setup` prints `Cache Size: ~752 MB` today; the number on this run is the measurement, and the extract and install steps should fall with it.

Every narrowed job changes its cache key here, so all three miss on this run and save fresh — the second run is the one that shows the steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
