### PR TITLE
test(control-plane): stop gitlab follow-up timers leaking across tests

### DIFF
--- a/packages/control-plane/test/fakes/tracked-clock.ts
+++ b/packages/control-plane/test/fakes/tracked-clock.ts
@@ -1,0 +1,34 @@
+// Real-time `Clock` for integration harnesses whose services arm background
+// timers (e.g. the gitlab provisioner's 30s converge follow-up): identical to
+// `SystemClock`, except an `afterEach` cancels every still-pending timer.
+// A survivor would fire during a LATER test and — because the seed re-creates
+// the same org id and fixtures reuse constant project ids — resolve that test's
+// freshly created rows and race its leases, a leak the per-test DB sweep cannot
+// stop. Call once at test-file module scope and share the instance.
+import { afterEach } from 'vitest'
+import type { Clock, TimerHandle } from '../../src/domain/clock.js'
+
+type Handle = ReturnType<typeof globalThis.setTimeout>
+
+export function trackedTestClock(): Clock {
+  const pending = new Set<Handle>()
+  afterEach(() => {
+    for (const h of pending) globalThis.clearTimeout(h)
+    pending.clear()
+  })
+  return {
+    now: () => Date.now(),
+    setTimeout(fn: () => void, ms: number): TimerHandle {
+      const h = globalThis.setTimeout(() => {
+        pending.delete(h)
+        fn()
+      }, ms)
+      pending.add(h)
+      return h
+    },
+    clearTimeout(h: TimerHandle): void {
+      pending.delete(h as Handle)
+      globalThis.clearTimeout(h as Handle)
+    }
+  }
+}

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -34,7 +34,7 @@ import {
   PgHookRepo
 } from '../../src/persistence/index.js'
 import { makeSecretCipher } from '../../src/secrets/cipher.js'
-import { systemClock } from '../../src/domain/clock.js'
+import { trackedTestClock } from '../fakes/tracked-clock.js'
 import { AgentId, HookId, OrgId } from '../../src/domain/ids.js'
 import {
   CODEHOST_NOTE_PROJECTION_V1_FEATURE,
@@ -54,6 +54,8 @@ import type { RelayChannel } from '../../src/ws/relay-registry.js'
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 const PROJECT = 4455667n
 const RELAY_URL = 'https://relay.example.test'
+// Real-time clock whose pending timers die with the test — see fakes/tracked-clock.ts.
+const clock = trackedTestClock()
 const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
 
 let running: HttpApp | undefined
@@ -78,7 +80,7 @@ async function harness(options: FakeGitlabOptions = {}, agentDelivery?: AgentDel
     states: new PgGitlabOauthStateStore(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
     cipher,
-    clock: systemClock,
+    clock,
     publicCpUrl: 'https://api.example.test',
     api: fake.api
   })
@@ -91,7 +93,7 @@ async function harness(options: FakeGitlabOptions = {}, agentDelivery?: AgentDel
     agents: new PgAgentRepo(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
     cipher,
-    clock: systemClock,
+    clock,
     api: fake.api
   })
   const provisioner = new GitlabProvisioner({
@@ -101,7 +103,7 @@ async function harness(options: FakeGitlabOptions = {}, agentDelivery?: AgentDel
     webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
     catalog: new PgCodeHostRepositoryRepo(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
-    clock: systemClock,
+    clock,
     publicRelayUrl: RELAY_URL,
     // The production union + rebroadcast (container wiring): the enabled
     // gitlab hook set, recompiled through the app's HookService after runs.
@@ -797,7 +799,7 @@ describe('rc/codehost-membership-authz (§12.2)', () => {
       accounts: h.accounts,
       credentials: new PgGitlabProjectCredentialRepo(prisma),
       credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, cipher),
-      clock: systemClock,
+      clock,
       api: h.fake.api
     })
     const base = {
@@ -1157,7 +1159,7 @@ describe('gitlab run projection — the fence follows the agent account (§7.2/�
       agents: new PgAgentRepo(prisma),
       bindings: new PgGitlabProjectBindingRepo(prisma),
       accounts: new PgGitlabAgentAccountRepo(prisma),
-      clock: systemClock,
+      clock,
       sender: {
         daemonFeatures: () => [CODEHOST_NOTE_PROJECTION_V1_FEATURE],
         send: (_daemonId: string, desired: CodeHostNoteDesired) => sent.push(desired)

--- a/packages/control-plane/test/integration/gitlab-host-axis.test.ts
+++ b/packages/control-plane/test/integration/gitlab-host-axis.test.ts
@@ -35,7 +35,7 @@ import {
   type DeploymentConfigValuesV1
 } from '../../src/persistence/deployment-config.js'
 import { makeSecretCipher } from '../../src/secrets/cipher.js'
-import { systemClock } from '../../src/domain/clock.js'
+import { trackedTestClock } from '../fakes/tracked-clock.js'
 import { AgentId, HookId, OrgId } from '../../src/domain/ids.js'
 import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
 
@@ -44,6 +44,8 @@ const PUBLIC_CP = 'https://api.example.test'
 const PROJECT = 4455667n
 /** A relative URL root on a non-default port — the shape prefix loss shows up in. */
 const PREFIXED = 'https://gitlab.example.test:8443/gitlab'
+// Real-time clock whose pending timers die with the test — see fakes/tracked-clock.ts.
+const clock = trackedTestClock()
 const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
 
 let running: HttpApp | undefined
@@ -67,7 +69,7 @@ function app(baseUrl: string): HttpApp & { fake: FakeGitlab; settled: () => Prom
     states: new PgGitlabOauthStateStore(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
     cipher,
-    clock: systemClock,
+    clock,
     publicCpUrl: PUBLIC_CP,
     webAppUrl: 'https://console.example.test',
     api: fake.api
@@ -80,7 +82,7 @@ function app(baseUrl: string): HttpApp & { fake: FakeGitlab; settled: () => Prom
     agents: new PgAgentRepo(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
     cipher,
-    clock: systemClock,
+    clock,
     api: fake.api
   })
   const provisioner = new GitlabProvisioner({
@@ -90,7 +92,7 @@ function app(baseUrl: string): HttpApp & { fake: FakeGitlab; settled: () => Prom
     webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
     catalog: new PgCodeHostRepositoryRepo(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
-    clock: systemClock,
+    clock,
     publicRelayUrl: 'https://relay.example.test',
     desiredWebhookEvents: async () => null,
     syncWorkspacePaths: async (orgId, projectId, projectPath, cloneUrl) => {

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -28,8 +28,10 @@ import {
 } from '../../src/persistence/repositories/gitlab.repo.js'
 import { PgCodeHostRepositoryRepo } from '../../src/persistence/repositories/code-host-repository.repo.js'
 import { makeSecretCipher } from '../../src/secrets/cipher.js'
-import { systemClock } from '../../src/domain/clock.js'
+import { trackedTestClock } from '../fakes/tracked-clock.js'
 
+// Real-time clock whose pending timers die with the test — see fakes/tracked-clock.ts.
+const clock = trackedTestClock()
 const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
 const PROJECT = 4455667n
 /** A second project under the SAME top-level group — the retarget's other half. */
@@ -73,7 +75,7 @@ async function harness(
     states: new PgGitlabOauthStateStore(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
     cipher,
-    clock: systemClock,
+    clock,
     publicCpUrl: 'https://api.example.test',
     api: fake.api
   })
@@ -85,7 +87,7 @@ async function harness(
     agents: new PgAgentRepo(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
     cipher,
-    clock: systemClock,
+    clock,
     avatarPng: async (agent) => {
       avatarRenders.push(agent.id)
       return AVATAR_PNG
@@ -101,7 +103,7 @@ async function harness(
       webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
       catalog: new PgCodeHostRepositoryRepo(prisma),
       instanceState: new PgGitlabInstanceStateStore(prisma),
-      clock: systemClock,
+      clock,
       publicRelayUrl: 'https://relay.example.test',
       desiredWebhookEvents: async () => webhookEvents,
       api: fake.api
@@ -655,7 +657,7 @@ describe('GitlabProvisioner (§10.2) — per-agent identity', () => {
       agents: new PgAgentRepo(prisma),
       instanceState: new PgGitlabInstanceStateStore(prisma),
       cipher,
-      clock: systemClock,
+      clock,
       api: new GitlabApiClient(h.fake.opts.baseUrl, async () => {
         throw new Error('connect ECONNREFUSED')
       })

--- a/packages/control-plane/test/integration/gitlab-version-floor.test.ts
+++ b/packages/control-plane/test/integration/gitlab-version-floor.test.ts
@@ -30,7 +30,7 @@ import {
   PgGitlabWebhookSecretStore
 } from '../../src/persistence/index.js'
 import { makeSecretCipher } from '../../src/secrets/cipher.js'
-import { systemClock } from '../../src/domain/clock.js'
+import { trackedTestClock } from '../fakes/tracked-clock.js'
 import { OrgId } from '../../src/domain/ids.js'
 import { INSTANCE_VERSION_UNSUPPORTED_REASON } from '../../src/gitlab/version.js'
 
@@ -42,6 +42,8 @@ const PROJECT = 4455667n
 const OTHER_PROJECT = 4455668n
 const AT_FLOOR = '18.11.0-ee'
 const BELOW_FLOOR = '18.10.9-ee'
+// Real-time clock whose pending timers die with the test — see fakes/tracked-clock.ts.
+const clock = trackedTestClock()
 const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
 
 let running: HttpApp | undefined
@@ -77,7 +79,7 @@ function app(version: string): HttpApp & {
     states: new PgGitlabOauthStateStore(prisma),
     instanceState,
     cipher,
-    clock: systemClock,
+    clock,
     publicCpUrl: PUBLIC_CP,
     webAppUrl: 'https://console.example.test',
     api: fake.api
@@ -90,7 +92,7 @@ function app(version: string): HttpApp & {
     agents: new PgAgentRepo(prisma),
     instanceState,
     cipher,
-    clock: systemClock,
+    clock,
     api: fake.api
   })
   const provisioner = new GitlabProvisioner({
@@ -100,7 +102,7 @@ function app(version: string): HttpApp & {
     webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
     catalog: new PgCodeHostRepositoryRepo(prisma),
     instanceState,
-    clock: systemClock,
+    clock,
     publicRelayUrl: 'https://relay.example.test',
     desiredWebhookEvents: async () => null,
     syncWorkspacePaths: async (orgId, projectId, projectPath, cloneUrl) => {

--- a/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-workspace.route.test.ts
@@ -32,7 +32,7 @@ import {
 } from '../../src/persistence/index.js'
 import type { AgentRecord } from '../../src/persistence/ports.js'
 import { makeSecretCipher } from '../../src/secrets/cipher.js'
-import { systemClock } from '../../src/domain/clock.js'
+import { trackedTestClock } from '../fakes/tracked-clock.js'
 import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import type { DaemonLiveness } from '../../src/ports.js'
 import { OrgId } from '../../src/domain/ids.js'
@@ -49,6 +49,8 @@ const SECOND_PATH = 'example-group/example-second'
 const glRepo = (path: string, base: string = GITLAB_DEFAULT_BASE_URL): string => `${base}/${path}`
 /** The agent whose own account (§7.2) backs every grant assertion below. */
 const AGENT = '11111111-1111-4111-8111-111111111111'
+// Real-time clock whose pending timers die with the test — see fakes/tracked-clock.ts.
+const clock = trackedTestClock()
 const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
 
 let running: HttpApp | undefined
@@ -77,7 +79,7 @@ async function harness(liveness?: DaemonLiveness, baseUrl?: string) {
     states: new PgGitlabOauthStateStore(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
     cipher,
-    clock: systemClock,
+    clock,
     publicCpUrl: 'https://api.example.test',
     api: fake.api
   })
@@ -90,7 +92,7 @@ async function harness(liveness?: DaemonLiveness, baseUrl?: string) {
     agents: new PgAgentRepo(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
     cipher,
-    clock: systemClock,
+    clock,
     api: fake.api
   })
   const provisioner = new GitlabProvisioner({
@@ -100,7 +102,7 @@ async function harness(liveness?: DaemonLiveness, baseUrl?: string) {
     webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
     catalog: new PgCodeHostRepositoryRepo(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
-    clock: systemClock,
+    clock,
     publicRelayUrl: 'https://relay.example.test',
     desiredWebhookEvents: async () => null,
     // Mirrors the container: the durable clone-URL convergence is AWAITED
@@ -163,7 +165,7 @@ function credService(bindings: PgGitlabProjectBindingRepo, baseUrl = GITLAB_DEFA
     credentials: new PgGitlabProjectCredentialRepo(prisma),
     credentialSecrets: new PgGitlabProjectCredentialSecretStore(prisma, cipher),
     repoAuths: new PgAgentRepoAuthorizationRepo(prisma),
-    clock: systemClock,
+    clock,
     baseUrl
   })
 }

--- a/packages/control-plane/test/integration/gitlab.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab.route.test.ts
@@ -32,11 +32,13 @@ import { GitlabAccountService } from '../../src/gitlab/account.service.js'
 import { gitlabAgentAccountUsername } from '../../src/gitlab/api.js'
 import { FakeGitlab, type FakeGitlabOptions } from '../fakes/gitlab-api.js'
 import { makeSecretCipher } from '../../src/secrets/cipher.js'
-import { systemClock } from '../../src/domain/clock.js'
+import { trackedTestClock } from '../fakes/tracked-clock.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 const PUBLIC_CP = 'https://api.example.test'
 
+// Real-time clock whose pending timers die with the test — see fakes/tracked-clock.ts.
+const clock = trackedTestClock()
 const cipher = makeSecretCipher({ SECRET_CIPHER: 'none' } as never)
 
 let running: HttpApp | undefined
@@ -59,7 +61,7 @@ function gitlabApp(
     states: new PgGitlabOauthStateStore(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
     cipher,
-    clock: systemClock,
+    clock,
     publicCpUrl: PUBLIC_CP,
     webAppUrl: 'https://console.example.test',
     api: fake.api
@@ -72,7 +74,7 @@ function gitlabApp(
     agents: new PgAgentRepo(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
     cipher,
-    clock: systemClock,
+    clock,
     api: fake.api
   })
   const provisioner = new GitlabProvisioner({
@@ -82,7 +84,7 @@ function gitlabApp(
     webhookSecrets: new PgGitlabWebhookSecretStore(prisma, cipher),
     catalog: new PgCodeHostRepositoryRepo(prisma),
     instanceState: new PgGitlabInstanceStateStore(prisma),
-    clock: systemClock,
+    clock,
     publicRelayUrl: deployment.publicRelayUrl ?? 'https://relay.example.test',
     // The same authority container.ts wires: an enabled gitlab hook on the project wants ingress.
     desiredWebhookEvents: async (orgId, projectId) =>


### PR DESCRIPTION
## What

Fixes the intermittent CI failure in `gitlab-provision.test.ts` — "a binding entering cleanup owes no more convergence" failing with `AssertionError: expected false to be true` on `beginCleanup` / `claimLease`, even on PRs whose diff never touched the control plane.

- New `test/fakes/tracked-clock.ts`: `trackedTestClock()` — a real-time `Clock` identical to `SystemClock`, except an `afterEach` cancels every timer still pending when a test ends.
- All six gitlab integration files now inject it in place of `systemClock`.

## Why

Every contended provisioner pass arms a 30s converge follow-up via `clock.setTimeout` (`markConvergeOwed` + timer). With the real `systemClock` in the harness, that timer outlives its test. When it fires — during whatever test runs ~30s later in the same worker — it re-resolves the binding by `(orgId, projectId)`, and both are constants: the seed re-creates the same org id before every test, and the fixtures reuse one project id. The per-test DB sweep therefore cannot isolate it: the leaked background converge lands on the **current** test's freshly created rows and races its leases. `beginCleanup`'s CAS (`opOwner` null-or-expired) meets the leaked run's live op lease and returns false; `claimLease` can likewise meet a leaked run holding the account lease. CI-only because landing in the few-ms vulnerable window is a timing lottery that slow runners lose more often.

The production lease logic is correct — the race exists only in the test environment, which resurrects identically-keyed rows under a live process's timers.

## Verification

- Reproduced the exact CI assertion deterministically before the fix by shrinking `FOLLOW_UP_DELAY_MS` and stretching the leaked run's lease-held window with per-page fake latency (`onListPage`). Those repro edits are not part of this PR.
- After the fix: full `test:int` green (115 files / 1824 tests), the target file green in four consecutive standalone runs, `typecheck` + lint + prettier clean.
- No test approaches 30s, so in-test timer behavior (e.g. the backoff-driven contention tests) is unchanged; cross-test firing becomes structurally impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
