### PR TITLE
test(daemon): skip the gitignore-escaping case on Windows, where its name is illegal

### DIFF
--- a/packages/daemon/test/git-exclude.test.ts
+++ b/packages/daemon/test/git-exclude.test.ts
@@ -145,13 +145,18 @@ describe('excludeManagedSkillBundles', () => {
     expect(bundlePathsFromCheckoutRoot('/repo', '/elsewhere', [BUNDLE])).toEqual([])
   })
 
-  it('escapes a name that would otherwise act as a gitignore pattern', async () => {
-    const odd = '.claude/skills/a[b]*c'
-    installBundle(repoWithSkills.worktree, odd)
+  // Win32 forbids `*` in a filename outright, so the directory this needs cannot exist there — and
+  // a bundle that cannot exist needs no escaping. The escaping itself is platform-independent.
+  it.skipIf(process.platform === 'win32')(
+    'escapes a name that would otherwise act as a gitignore pattern',
+    async () => {
+      const odd = '.claude/skills/a[b]*c'
+      installBundle(repoWithSkills.worktree, odd)
 
-    await excludeManagedSkillBundles(repoWithSkills.commonDir, [BUNDLE, odd])
+      await excludeManagedSkillBundles(repoWithSkills.commonDir, [BUNDLE, odd])
 
-    expect(readExclude()).toContain('/.claude/skills/a\\[b\\]\\*c/')
-    expect(git(repoWithSkills.worktree, 'status', '--porcelain').trim()).toBe('')
-  })
+      expect(readExclude()).toContain('/.claude/skills/a\\[b\\]\\*c/')
+      expect(git(repoWithSkills.worktree, 'status', '--porcelain').trim()).toBe('')
+    }
+  )
 })


### PR DESCRIPTION
## The Windows job is red on main

`Unit Test (Windows)` is failing for every daemon PR right now, this one included, because #1604 merged with that check already failing ([its run](https://github.com/agentconnect-md/agentconnect/actions/runs/33253747711/job/99103872485), 13m29s, fail).

The case it added installs a bundle at `.claude/skills/a[b]*c`. Win32 forbids `*` in a filename outright — `[` and `]` are fine, `*` is not — so the directory the case needs cannot be created there at all.

## Fix

`it.skipIf(process.platform === 'win32')`, with the reason, which is the idiom this suite already uses for a single non-portable case.

Nothing is lost by skipping it. A bundle that cannot exist on the platform needs no escaping, and the escaping under test is platform-independent, so the POSIX runs are what gate it.

## Scope

Deliberately its own PR rather than folded into whichever branch noticed: it unblocks every daemon PR, and it has nothing to do with what any of them change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
