### PR TITLE
fix(daemon): let the retention GC reclaim review-snapshot worktrees despite scratch state

### DIFF
--- a/docs/designs/multi-repository-workspaces.md
+++ b/docs/designs/multi-repository-workspaces.md
@@ -131,7 +131,8 @@ secondary's token.
 The CP re-projects the spec without the row; the daemon marks the root retired
 and drops it from every future session immediately. At idle sweep, and only
 when no session or turn holds the root (rechecked under the workspace admission
-fence), its worktrees go through the existing dirty/unique-commit rules; the
+fence), its worktrees go through the existing dirty/unique-commit rules (with
+the review-snapshot exemption those rules carry); the
 checkout is removed only once no worktree remains and it is itself clean,
 otherwise retained and reported. Re-adding the row un-retires the root in place.
 

--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -441,7 +441,12 @@ used only after its object ID and ordered parents are proven to be the trusted
 base and head; otherwise the exact head is used.
 Reused formal-review worktrees are hard-reset and cleaned including ignored
 untracked content before they are presented as exact snapshots. Ordinary session
-worktrees continue to preserve their working state between turns.
+worktrees continue to preserve their working state between turns. The retention
+GC reads the same distinction from the fetched review refs: a worktree whose
+root holds `refs/agentconnect/reviews/<id>/*` is a daemon-owned snapshot whose
+scratch state and local commits the next delivery would discard anyway, so the
+GC's dirty and unique-commit protections do not retain it — they keep guarding
+ordinary session worktrees only.
 
 Repository hooks are not a reason to reject a workspace. Every daemon-managed
 Git command disables hooks and fsmonitor at command scope, and every configured

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -14224,9 +14224,11 @@ export class Daemon {
    *  worktree first. Runs at startup and hourly on the idle sweep. Auto-deletion
    *  requires ALL of: no active turn (durable state + serial gate + pending map +
    *  durable inbox + SDK background-task lease), no dirty/untracked files, and no
-   *  commit unreachable from every remote ref. A worktree that fails the Git
-   *  safety checks is only reported — its session row is kept so the working
-   *  state stays reachable through the same logical session. */
+   *  commit unreachable from every remote ref (a review-snapshot worktree is
+   *  exempt from the last two — daemon-owned and reset on every delivery, its
+   *  state is disposable). A worktree that fails the Git safety checks is only
+   *  reported — its session row is kept so the working state stays reachable
+   *  through the same logical session. */
   /** The retention sweep's active-turn exclusion, beyond the durable-state filter:
    *  a claimed serial gate (owns cold dispatch + queued arrivals), a live Pending
    *  turn, pending durable inbox work, or unsettled SDK background tasks. All are

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -1388,7 +1388,20 @@ export class WorkspaceManager {
         return { outcome: 'removed' }
       }
       const worktreeGit = this.runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
-      if ((await worktreeGit.raw(['status', '--porcelain'])).trim() !== '') {
+      // Fetched review refs mark this root's worktree as a daemon-owned review snapshot: every
+      // delivery re-fetches the exact revision and resets the tree (`reset --hard` + `clean -ffdx`),
+      // so dirty state and local commits alike are disposable by construction and retaining on them
+      // protects nothing. Probed lazily — only when a protection would otherwise keep the worktree —
+      // and at most once; a probe failure conservatively reads as "not a snapshot".
+      let snapshot: boolean | undefined
+      const isReviewSnapshot = async () =>
+        (snapshot ??=
+          (
+            await rootGit()
+              .raw(['for-each-ref', '--count=1', `refs/agentconnect/reviews/${id}`])
+              .catch(() => '')
+          ).trim() !== '')
+      if ((await worktreeGit.raw(['status', '--porcelain'])).trim() !== '' && !(await isReviewSnapshot())) {
         return { outcome: 'retained', reason: 'dirty' }
       }
       // The generated branch this worktree checks out, read BEFORE the removal that
@@ -1407,15 +1420,15 @@ export class WorkspaceManager {
           `--glob=refs/agentconnect/reviews/${id}`
         ])
       ).trim()
-      if (unique !== '0') return { outcome: 'retained', reason: 'unique-commits' }
-      // No --force: if the tree went dirty between the check and here, Git refuses
-      // and the failure keeps the session.
-      await rootGit().raw(['worktree', 'remove', cwd])
+      if (unique !== '0' && !(await isReviewSnapshot())) return { outcome: 'retained', reason: 'unique-commits' }
+      // --force only for a probed snapshot, whose dirt was judged disposable above. Otherwise none:
+      // if the tree went dirty between the check and here, Git refuses and the failure keeps the session.
+      await rootGit().raw(['worktree', 'remove', ...(snapshot ? ['--force'] : []), cwd])
       await cleanupRegistrations()
-      // Only a branch this daemon generated for a session worktree, and only after
-      // the check above proved every commit on it is reachable from a remote — so
-      // the forced delete can drop no work. Best-effort: a surviving ref is clutter,
-      // not a reason to report a removed worktree as retained.
+      // Only a branch this daemon generated for a session worktree, and only when dropping it can
+      // drop no work: either every commit on it was proven reachable from a remote, or the worktree
+      // was a review snapshot whose commits the next delivery's reset would discard anyway.
+      // Best-effort: a surviving ref is clutter, not a reason to report a removed worktree as retained.
       if (isSessionBranch(branch)) {
         await rootGit()
           .raw(['branch', '-D', branch])
@@ -2589,11 +2602,14 @@ export type SessionWorktreeRemoval = (
 /** Retention GC (#485): remove one logical session's worktree, but only when it
  * is provably safe — no dirty/untracked files and no commit unreachable from
  * every remote ref (daemon-owned review refs count as remote-backed: they were
- * fetched verbatim). Safe candidates go through Git-aware cleanup
- * (`worktree remove` → `worktree prune`) and their review refs are deleted;
- * anything else is reported as retained/failed so the caller keeps the session.
- * The active-turn exclusion is the caller's job — this function only judges the
- * on-disk state. */
+ * fetched verbatim). One exemption: a worktree whose root holds fetched review
+ * refs at its id is a daemon-owned review snapshot, hard-reset and cleaned on
+ * every delivery — its dirt and local commits are disposable by construction,
+ * so both protections are skipped and the removal is forced. Safe candidates go
+ * through Git-aware cleanup (`worktree remove` → `worktree prune`) and their
+ * review refs are deleted; anything else is reported as retained/failed so the
+ * caller keeps the session. The active-turn exclusion is the caller's job —
+ * this function only judges the on-disk state. */
 
 /** Replace any earlier checkout with an empty stable cwd. This lets a formal
  * review continue through revision-addressed GitHub tools without exposing a

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -570,18 +570,69 @@ describe('workspaces.removeSessionWorktree(#485 retention GC)', () => {
   })
 
   it('retains a worktree with dirty/untracked files and never calls worktree remove', async () => {
-    const { agent } = fixture()
+    const { agent, id } = fixture()
     rawMock.mockImplementation(async (args: string[]) => {
       if (args[0] === 'status') return ' M src/app.ts\n?? notes.md\n'
+      if (args[0] === 'for-each-ref') return ''
       return '0\n'
     })
 
     expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'retained', reason: 'dirty' })
     expect(gitCalls().some((args) => args[0] === 'worktree')).toBe(false)
+    // The exemption probe DID run — dirt on an ordinary worktree is kept only after
+    // proving the worktree is not a review snapshot.
+    expect(gitCalls()).toContainEqual(['for-each-ref', '--count=1', `refs/agentconnect/reviews/${id}`])
+  })
+
+  it('removes a DIRTY review-snapshot worktree — its refs mark it daemon-owned and reset on delivery', async () => {
+    const { agent, cwd, id } = fixture()
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'status') return '?? scratch/analysis.md\n M src/app.ts\n'
+      if (args[0] === 'for-each-ref') return `${'c'.repeat(40)} commit\trefs/agentconnect/reviews/${id}/head\n`
+      if (args[0] === 'rev-list') return '0\n'
+      return ''
+    })
+
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+
+    // Forced, because the dirt Git would refuse over was judged disposable — and the
+    // snapshot's review refs still go through the normal post-removal deletion.
+    expect(gitCalls()).toContainEqual(['worktree', 'remove', '--force', cwd])
+    for (const name of ['base', 'head', 'merge']) {
+      expect(gitCalls()).toContainEqual(['update-ref', '-d', `refs/agentconnect/reviews/${id}/${name}`])
+    }
+  })
+
+  it('removes a review-snapshot worktree with unpushed commits, dropping its branch with them', async () => {
+    const { agent, cwd, id } = fixture()
+    rawMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-list') return '3\n'
+      if (args[0] === 'for-each-ref') return `${'c'.repeat(40)} commit\trefs/agentconnect/reviews/${id}/head\n`
+      if (args[0] === 'symbolic-ref') return 'dev/yulong/brave-otter\n'
+      return ''
+    })
+
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(gitCalls()).toContainEqual(['worktree', 'remove', '--force', cwd])
+    // The next delivery's reset would discard these commits anyway; the generated branch goes too.
+    expect(gitCalls()).toContainEqual(['branch', '-D', 'dev/yulong/brave-otter'])
+  })
+
+  it('never probes for review refs on a clean fully-pushed worktree', async () => {
+    const { agent } = fixture()
+    rawMock.mockImplementation(async (args: string[]) => (args[0] === 'rev-list' ? '0\n' : ''))
+
+    expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
+    expect(gitCalls().some((args) => args[0] === 'for-each-ref')).toBe(false)
+    // And absent the probe, the removal is not forced.
+    expect(gitCalls().some((args) => args[0] === 'worktree' && args[1] === 'remove' && args[2] === '--force')).toBe(
+      false
+    )
   })
 
   it('retains a worktree whose HEAD has commits unreachable from every remote ref', async () => {
     const { agent } = fixture()
+    // '' for for-each-ref: no review refs, so the snapshot exemption must not apply.
     rawMock.mockImplementation(async (args: string[]) => (args[0] === 'rev-list' ? '2\n' : ''))
 
     expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({


### PR DESCRIPTION
## What

Second item on #1603's mitigation list. The retention GC's dirty/unique-commit protections exist to guard user work in **ordinary** session worktrees — but they were also retaining **formal-review worktrees**, which are daemon-owned snapshots: every delivery re-fetches the exact revision and hard-resets the tree (`reset --hard` + `clean -ffdx`, `prepareRootSessionWorktree`). Scratch files an agent writes during a review were pinning those worktrees forever, even though the very next delivery would discard them — feeding the registration pile-up that ends in the E2BIG outage.

`removeRootSessionWorktree` now reads the distinction the preparation path already encodes: a worktree whose root holds fetched review refs (`refs/agentconnect/reviews/<id>/*`) is a review snapshot. For those, both protections are skipped and the removal passes `--force`; the generated session branch is dropped with it, since the next reset would discard its commits regardless.

## Why this predicate

- **Per-root and on-disk**, so it is exactly as precise as the reset behavior it mirrors: the refs are fetched only into the root the review is about. The reference-root worktrees riding along the same review session hold no such refs and keep the full protections, as does every webhook-triggered hook session doing ordinary work.
- **Lazy** — probed only when a protection would otherwise retain, so clean fully-pushed worktrees (the common case) pay zero extra git calls; probed at most once; a probe failure conservatively reads as "not a snapshot".
- No API or session-record change: the aggregate `removeSessionWorktree` semantics (`retained`/`partial`) are untouched, so a review session whose reference root holds real user work is still kept.

## Tests

New cases in the retention-GC suite: a dirty snapshot is removed with `--force` and its review refs still go through post-removal deletion; a snapshot with unpushed commits is removed and its generated branch dropped; a dirty ordinary worktree is retained only after the probe proves no refs exist; a clean fully-pushed worktree never probes and is never force-removed. The pre-existing retain cases now pin the no-refs side of the predicate.

Design docs reconciled in the same change: the review-snapshot paragraph in `webhook-triggers-and-github-events.md` now states the GC exemption, and `multi-repository-workspaces.md` §C notes the rules carry it.

`typecheck`, `lint`, and the workspace/review/exclude suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
