### PR TITLE
feat(daemon): give every chat session the console's fallback title, and push it to Slack

### DIFF
--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -1108,7 +1108,7 @@ model SessionMeta {
   phase               SessionPhase        @default(start)
   link                String? // deep-link (NOT a body)
   summary             String?             @db.Text // short milestone text (NOT the stream)
-  title               String?             @db.Text // daemon-derived display title (NOT a body)
+  title               String?             @db.Text // display title: runtime/ingress, else a capped first-message excerpt
   status              String?
   triggeredBy         String?
   channelName         String?

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -34,7 +34,6 @@ import type {
   DreamFilesPage,
   DreamFileReadContent
 } from '@agentconnect.md/protocol'
-import { gitlabWorkspaceAccessLevel } from '../../gitlab/api.js'
 import type { GitlabLiveProject } from '../../gitlab/provisioner.js'
 import { gitlabAccountUnavailableMessage } from '../../gitlab/account.service.js'
 import {
@@ -212,7 +211,7 @@ import { provisionDaemonConnect } from '../onboarding.js'
 import { Tag } from '../plugins/openapi.js'
 import { buildAgentMoves } from '../agent-moves.js'
 import { GithubApiError } from '../../github/api.js'
-import { GitlabApiError } from '../../gitlab/api.js'
+import { GitlabApiError, gitlabWorkspaceAccessLevel } from '../../gitlab/api.js'
 import { LogtoApiError } from '../../github/logto-identity.js'
 import { UserAuthzDeniedError } from '../../github/user-authz.js'
 import { syncAgentBotIcons } from '../agent-bot-icon-sync.js'

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -31,6 +31,7 @@ import {
 } from '../store/local-store.js'
 import { mentionedUserIds, substituteUserMentions } from '../slack/mentions.js'
 import { hasNativeMessageOrder } from '../platforms/message-ordering.js'
+import { deriveTitle } from '../session/derive-title.js'
 
 /** Encoded-payload ceiling, leaving headroom under MAX_FRAME_BYTES for the
  *  envelope (id/ts/type/corr + fencing ext, well under 4 KiB). */
@@ -112,24 +113,6 @@ function utf8Boundary(buf: Buffer, len: number): number {
   const seqLen =
     lead < 0x80 ? 1 : (lead & 0xe0) === 0xc0 ? 2 : (lead & 0xf0) === 0xe0 ? 3 : (lead & 0xf8) === 0xf0 ? 4 : 1
   return start + seqLen <= len ? len : start
-}
-
-/** Cap for a first-message-derived session title (chars). Runtime-pushed titles are
- *  already short; a raw user message can be long, so the fallback is trimmed. */
-const TITLE_MAX_CHARS = 80
-
-/** A short, single-line session title from a raw message body: the first non-empty
- *  line, trimmed and capped at TITLE_MAX_CHARS (a trailing `…` marks truncation).
- *  Returns undefined for empty/whitespace input. Used as the session/list fallback
- *  when the runtime never pushed a title. */
-function deriveTitle(text: string | undefined): string | undefined {
-  if (!text) return undefined
-  const line = text
-    .split('\n')
-    .map((l) => l.trim())
-    .find((l) => l.length > 0)
-  if (!line) return undefined
-  return line.length > TITLE_MAX_CHARS ? line.slice(0, TITLE_MAX_CHARS).trimEnd() + '…' : line
 }
 
 /** Parse a session row's `usage` JSON into the wire shape. Returns undefined when

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12330,7 +12330,6 @@ export class Daemon {
     }
   }
 
-  /** Persist one authoritative title and push the CP metadata projection. */
   /** A title for DISPLAY on a platform surface: raw `<@U…>` mentions rewritten to `@name`,
    *  exactly as the console's session reader does at read time. */
   private async displayTitle(title: string): Promise<string> {
@@ -12339,6 +12338,7 @@ export class Daemon {
     return substituteUserMentions(title, await this.store.getDisplayNames(ids))
   }
 
+  /** Persist one authoritative title and push the CP metadata projection. */
   private async persistSessionTitle(rec: SessionRecord, title: string | null): Promise<void> {
     await this.store.setSessionTitle(rec.key, title)
     if (!rec.acpSessionId) return

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -9563,6 +9563,12 @@ export class Daemon {
       this.clock.now()
     )
     const p = this.buildPending(run, { conv, rec, sessionId, outwardSessionId, webchat: pendingWebchat })
+    // Every turn re-stashes the stored title (fallback or runtime): the connection dedupes
+    // repeats, and re-pushing heals a rename lost to a restart or an unregistered thread.
+    if (turnChromeFor(run.plan.platform).sessionTitle) {
+      const storedTitle = (await this.store.getSession(run.plan.sessionKey))?.title?.trim()
+      if (storedTitle) p.chrome.sessionTitleToPush = storedTitle
+    }
     const activeTurn = await this.installActiveTurnContext(run, sessionId)
     const settlement: TurnSettlement = { finalPhase: 'end', propagatingTurnError: false }
     let turnModel: string | undefined

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -161,6 +161,7 @@ import {
   type SlackTurnState
 } from './platforms/slack/turn-output.js'
 import { ChannelNameResolver } from './messages/channel-name-resolver.js'
+import { mentionedUserIds, substituteUserMentions } from './slack/mentions.js'
 import {
   WorkspaceManager,
   type PrepareSessionWorkspaceRequest,
@@ -9565,9 +9566,11 @@ export class Daemon {
     const p = this.buildPending(run, { conv, rec, sessionId, outwardSessionId, webchat: pendingWebchat })
     // Every turn re-stashes the stored title (fallback or runtime): the connection dedupes
     // repeats, and re-pushing heals a rename lost to a restart or an unregistered thread.
+    // Substituted at push time — a first-message fallback carries raw `<@U…>` mentions, and
+    // the stored value stays canonical so a display-name change converges on the next turn.
     if (turnChromeFor(run.plan.platform).sessionTitle) {
       const storedTitle = (await this.store.getSession(run.plan.sessionKey))?.title?.trim()
-      if (storedTitle) p.chrome.sessionTitleToPush = storedTitle
+      if (storedTitle) p.chrome.sessionTitleToPush = await this.displayTitle(storedTitle)
     }
     const activeTurn = await this.installActiveTurnContext(run, sessionId)
     const settlement: TurnSettlement = { finalPhase: 'end', propagatingTurnError: false }
@@ -11922,7 +11925,7 @@ export class Daemon {
     const info = await this.statusInfoFrom(rec.agentId, sessionKey, rec.acpSessionId ?? undefined, { breakdown: true })
     const agent = this.agents.get(rec.agentId)
     const name = agent?.displayName?.trim() || agent?.name || rec.agentId
-    const sessionTitle = rec.title?.trim()
+    const sessionTitle = rec.title?.trim() ? await this.displayTitle(rec.title.trim()) : undefined
     const iconUrl = agent?.iconUrl?.trim()
     const identity: StatusModalIdentity = {
       name,
@@ -12328,6 +12331,14 @@ export class Daemon {
   }
 
   /** Persist one authoritative title and push the CP metadata projection. */
+  /** A title for DISPLAY on a platform surface: raw `<@U…>` mentions rewritten to `@name`,
+   *  exactly as the console's session reader does at read time. */
+  private async displayTitle(title: string): Promise<string> {
+    const ids = mentionedUserIds(title)
+    if (ids.length === 0) return title
+    return substituteUserMentions(title, await this.store.getDisplayNames(ids))
+  }
+
   private async persistSessionTitle(rec: SessionRecord, title: string | null): Promise<void> {
     await this.store.setSessionTitle(rec.key, title)
     if (!rec.acpSessionId) return

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -411,6 +411,11 @@ export function turnState<S extends object>(p: Pending): S {
  *  message id of a single row, and its `*Attempted` sibling records that the first post was
  *  tried so a failed post cannot spam a duplicate on the next action. */
 export interface TurnChromeCursors {
+  /** The session's stored (fallback or runtime) title, pushed onto the thread after the
+   *  turn's FIRST status write — which is what registers the thread as an agent session, so
+   *  an earlier rename would be refused. Cleared once flushed or superseded by a live
+   *  runtime title. */
+  sessionTitleToPush?: string
   /** ts of the single in-place "main progress" message, once posted (medium/high). */
   progressTs?: string
   /** Whether the progress message's first post was attempted. */

--- a/packages/daemon/src/platforms/slack/turn-output.ts
+++ b/packages/daemon/src/platforms/slack/turn-output.ts
@@ -78,6 +78,8 @@ export interface SlackTurn {
   plan: SlackTurnPlan
   /** The in-place message anchors this applier edits rather than re-posts. */
   chrome: {
+    /** Stored session title awaiting the turn's first registering write (status/stream). */
+    sessionTitleToPush?: string
     liveReplyTs?: string
     liveReplyText?: string
     liveReplyAttempted?: boolean
@@ -428,6 +430,15 @@ async function postSlackReply<TTurn extends SlackTurn>(
   return ts
 }
 
+/** Push the turn's stored session title once its thread is a registered agent session — the
+ *  status/stream write that just landed is what registered it (an earlier rename is refused). */
+async function flushSessionTitle(conn: SlackConnection, p: SlackTurn): Promise<void> {
+  const title = p.chrome.sessionTitleToPush
+  if (!title || !p.plan.statusThread) return
+  p.chrome.sessionTitleToPush = undefined
+  await conn.setTitle(p.plan.channel, p.plan.statusThread, title)
+}
+
 /** The single in-place tool-activity message: post once, then edit. Shared by the legacy
  *  `progress` action and by a streaming turn whose stream never opened. If the first post
  *  rejects or returns no ts, mark it attempted and skip later edits rather than duplicating. */
@@ -515,15 +526,19 @@ export async function applySlackAction<TTurn extends SlackTurn>(
   const chromeOptions: SlackPostOptions = { ...(identity ?? {}), chrome: true }
   switch (action.kind) {
     case 'set-status':
-      if (p.plan.statusThread)
+      if (p.plan.statusThread) {
         await conn.setStatus(
           p.plan.channel,
           p.plan.statusThread,
           action.text,
           slackStatusOptions(p.plan.platform, p.plan.agentName, p.plan.iconUrl, p.plan.sessionKey)
         )
+        await flushSessionTitle(conn, p)
+      }
       return
     case 'set-title':
+      // A live runtime title supersedes any stored title still waiting on its first status.
+      p.chrome.sessionTitleToPush = undefined
       if (p.plan.statusThread) await conn.setTitle(p.plan.channel, p.plan.statusThread, action.text)
       return
     case 'post': {
@@ -589,7 +604,11 @@ export async function applySlackAction<TTurn extends SlackTurn>(
           ...(state.recipient ? { recipientUserId: state.recipient } : {}),
           ...(identity ? { identity } : {})
         })
-        if (state.stream) return
+        if (state.stream) {
+          // The stream registered the thread, so the stored title can land now too.
+          await flushSessionTitle(conn, p)
+          return
+        }
       }
       // The stream could not open, so this turn's chrome falls back to today's in-place
       // message. Chrome degrades ALONE — the body never rode the stream, so nothing moves.

--- a/packages/daemon/src/session/derive-title.ts
+++ b/packages/daemon/src/session/derive-title.ts
@@ -1,0 +1,23 @@
+/** Cap for a first-message-derived session title (chars). Runtime-pushed titles are
+ *  already short; a raw user message can be long, so the fallback is trimmed. */
+const TITLE_MAX_CHARS = 80
+
+/**
+ * A short, single-line session title from a raw message body: the first non-empty line,
+ * trimmed and capped at TITLE_MAX_CHARS (a trailing `…` marks truncation). Returns undefined
+ * for empty/whitespace input.
+ *
+ * THE fallback-title rule: the console's session list applies it at read time for legacy
+ * untitled rows, and the session manager applies it at creation so every new chat session is
+ * born with the same title the console would derive — persisted, synced to the CP, and pushed
+ * to platform surfaces (Slack thread headers) that a runtime title later overwrites.
+ */
+export function deriveTitle(text: string | undefined): string | undefined {
+  if (!text) return undefined
+  const line = text
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0)
+  if (!line) return undefined
+  return line.length > TITLE_MAX_CHARS ? line.slice(0, TITLE_MAX_CHARS).trimEnd() + '…' : line
+}

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -570,6 +570,9 @@ export class SessionManager {
           usesMeta
         }))())
 
+    // Born titled: the ingress title when the platform minted one (GitHub/GitLab hooks), else
+    // the console's first-message rule — a later runtime title stays authoritative.
+    const fallbackTitle = msg.initialSessionTitle?.trim() || deriveTitle(msg.text)
     // Create or re-attach the runtime session (turn/runtime-session.ts). `created` drives the
     // daemon's one-shot `event/session` start emit; the additional-MCP outcome is reported back
     // rather than written into a shared mutable.
@@ -590,11 +593,7 @@ export class SessionManager {
         workspaceIsolation,
         ...(effectiveOriginSessionId ? { originSessionId: effectiveOriginSessionId } : {}),
         ...(needsReplyToParent ? { needsParentReply: true } : {}),
-        // Born titled: the ingress title when the platform minted one (GitHub/GitLab hooks),
-        // else the console's first-message rule — a later runtime title stays authoritative.
-        ...(isNewLogicalSession && (msg.initialSessionTitle?.trim() || deriveTitle(msg.text))
-          ? { initialTitle: msg.initialSessionTitle?.trim() || deriveTitle(msg.text)! }
-          : {})
+        ...(isNewLogicalSession && fallbackTitle ? { initialTitle: fallbackTitle } : {})
       },
       store: this.deps.store,
       ...(this.deps.prepareOutwardBinding

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -23,6 +23,7 @@ import { openRuntimeSession } from './turn/runtime-session.js'
 import { ingestInboundTranscript } from './turn/transcript-ingest.js'
 import { matchSkillInvocation, renderSkillInvocation } from './skill-invocation.js'
 import type { RuntimeCommand } from '@agentconnect.md/protocol'
+import { deriveTitle } from './derive-title.js'
 
 // The recall lifecycle contract lives with the collaborator that emits it; re-exported
 // here because SessionManagerDeps is the seam production wires its observer through.
@@ -589,8 +590,10 @@ export class SessionManager {
         workspaceIsolation,
         ...(effectiveOriginSessionId ? { originSessionId: effectiveOriginSessionId } : {}),
         ...(needsReplyToParent ? { needsParentReply: true } : {}),
-        ...(isNewLogicalSession && msg.initialSessionTitle?.trim()
-          ? { initialTitle: msg.initialSessionTitle.trim() }
+        // Born titled: the ingress title when the platform minted one (GitHub/GitLab hooks),
+        // else the console's first-message rule — a later runtime title stays authoritative.
+        ...(isNewLogicalSession && (msg.initialSessionTitle?.trim() || deriveTitle(msg.text))
+          ? { initialTitle: msg.initialSessionTitle?.trim() || deriveTitle(msg.text)! }
           : {})
       },
       store: this.deps.store,

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -2255,11 +2255,16 @@ export class SlackConnection implements PlatformConnection {
     }
   }
 
+  /** Last title written per thread — every turn re-pushes the stored title, so unchanged
+   *  repeats must not spend an API call. */
+  private lastTitles = new Map<string, string>()
+
   /** Best-effort agent-session title, DMs and channels alike: Slack renders it as the thread
    *  panel's header once the thread is a registered agent session — which every turn's
    *  lifecycle `setStatus` (and any card stream) makes it. Unregistered threads answer
    *  `not_authorized` and degrade here. */
   async setTitle(channel: string, threadTs: string, title: string): Promise<void> {
+    if (this.lastTitles.get(`${channel}:${threadTs}`) === title) return
     try {
       await this.queue.enqueue(() =>
         this.app.client.agents.sessions.rename({
@@ -2268,6 +2273,7 @@ export class SlackConnection implements PlatformConnection {
           title
         })
       )
+      this.lastTitles.set(`${channel}:${threadTs}`, title)
     } catch (err) {
       this.rememberMissingScopes(err)
       await this.postPermissionUpdateCard(channel, threadTs)

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -743,6 +743,9 @@ export class SlackConnection implements PlatformConnection {
   private queue: PlatformSendQueue
   /** Cooldown after Slack proves this installation lacks chat:write.customize. */
   private customUsernameRetryAt = 0
+  /** Last title written per `channel:thread` — every turn re-pushes the stored title, so
+   *  unchanged repeats must not spend an API call. Grows like sessionLifecycle: unevicted. */
+  private lastTitles = new Map<string, string>()
   /** Slack app/workspace ids are public metadata used only for the OAuth settings link. */
   private appId = ''
   private teamId = ''
@@ -2254,10 +2257,6 @@ export class SlackConnection implements PlatformConnection {
       )
     }
   }
-
-  /** Last title written per thread — every turn re-pushes the stored title, so unchanged
-   *  repeats must not spend an API call. */
-  private lastTitles = new Map<string, string>()
 
   /** Best-effort agent-session title, DMs and channels alike: Slack renders it as the thread
    *  panel's header once the thread is a registered agent session — which every turn's

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -2321,9 +2321,17 @@ describe('Slack interactive status bar', () => {
       agentUrl: 'https://console.example.com/agents/bot-a',
       iconUrl: AGENT_IDENTITY.iconUrl
     })
-    expect(data.identity.sessionTitle).toBeUndefined()
+    // Born with the first-message fallback; a runtime title then replaces it.
+    expect(data.identity.sessionTitle).toBe('hi')
     await (daemon as any).store.setSessionTitle(SESSION_KEY, 'Fix login flow')
     expect((await (daemon as any).statusInfoForKey(SESSION_KEY)).identity.sessionTitle).toBe('Fix login flow')
+    // A stored title can carry raw `<@U…>` mentions (the first-message fallback does whenever
+    // the message opens with a mention) — the DISPLAYED title rewrites them to `@name`.
+    await (daemon as any).store.setDisplayName('U7', 'Fuyao', Date.now())
+    await (daemon as any).store.setSessionTitle(SESSION_KEY, '<@U7> please review the auth change')
+    expect((await (daemon as any).statusInfoForKey(SESSION_KEY)).identity.sessionTitle).toBe(
+      '@Fuyao please review the auth change'
+    )
     release()
     await t1
     await daemon.stop()

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -955,7 +955,8 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       sessionUpdate: 'session_info_update',
       title: 'Wrong agent title'
     })
-    expect((await (daemon as any).store.getSessionByAcpId('acp-title-late'))?.title).toBeNull()
+    // Born with the first-message fallback; the wrong agent's rename must not replace it.
+    expect((await (daemon as any).store.getSessionByAcpId('acp-title-late'))?.title).toBe('fix session titles')
     await await (daemon as any).stopHost('bot-a')
 
     await vi.waitFor(() => expect(connB.setTitle).toHaveBeenCalledWith('D1', '210.1', 'Fix session titles'), WAIT)

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -691,6 +691,7 @@ describe('applySlackAction — chrome stream actions', () => {
       updateMessage: vi.fn(async (_c: string, _ts: string, _text: string, _chrome?: boolean) => true),
       postMessage: vi.fn(async (_channel: string, _text: string, _thread?: string, _options?: unknown) => 'p1'),
       setStatus: vi.fn(async () => {}),
+      setTitle: vi.fn(async () => {}),
       ...over
     }
     const turn: SlackTurn = {
@@ -735,6 +736,34 @@ describe('applySlackAction — chrome stream actions', () => {
     id,
     title: 'Read file',
     status
+  })
+
+  it('flushes the stored session title after the first registering write, exactly once', async () => {
+    // An earlier rename is refused (`not_authorized` until the thread is a registered agent
+    // session), so the title rides the queue BEHIND the status/stream write that registers it.
+    const { apply, conn, turn } = fixture()
+    turn.chrome.sessionTitleToPush = 'Summarize today’s changes'
+    await apply({ kind: 'set-status', text: 'is thinking…' })
+    expect(conn.setStatus).toHaveBeenCalled()
+    expect(conn.setTitle).toHaveBeenCalledWith('C1', 'T1', 'Summarize today’s changes')
+    await apply({ kind: 'set-status', text: 'is working…' })
+    expect(conn.setTitle).toHaveBeenCalledOnce()
+  })
+
+  it('flushes the stored title on stream-start too — the stream registers the thread as well', async () => {
+    const { apply, conn, turn } = fixture()
+    turn.chrome.sessionTitleToPush = 'Summarize today’s changes'
+    await apply({ kind: 'stream-start' })
+    expect(conn.setTitle).toHaveBeenCalledWith('C1', 'T1', 'Summarize today’s changes')
+  })
+
+  it('lets a live runtime title supersede a stored title still waiting to flush', async () => {
+    const { apply, conn, turn } = fixture()
+    turn.chrome.sessionTitleToPush = 'first message fallback'
+    await apply({ kind: 'set-title', text: 'Runtime summary' })
+    expect(conn.setTitle).toHaveBeenCalledWith('C1', 'T1', 'Runtime summary')
+    await apply({ kind: 'set-status', text: 'is thinking…' })
+    expect(conn.setTitle).toHaveBeenCalledOnce()
   })
 
   it('opens the stream with the recipient and the agent identity, and records the handle', async () => {


### PR DESCRIPTION
A session whose runtime never titles it showed a title in the console but never on Slack. That
is every Codex session today: the 1.1.4-era prompt-echo "fallback title" is deliberately
dropped (issue #659 / PR #821), and codex-acp ≥1.7 emits a title only on `thread/name/updated`,
which the app server does not fire for our sessions. The console looked titled because it
derives a first-message fallback at read time; the Slack push was runtime-only, so it had
nothing to send.

## What changed

**The fallback moves to creation, owned by the daemon.** `deriveTitle` — the console's
first-message rule (first non-empty line, 80 chars, `…`) — is extracted to
`session/derive-title.ts` and now titles every new chat session at birth. Ingress titles from
code-host hooks still win, and a later runtime title stays authoritative. The same title the
console shows is now persisted, synced to the CP, and available to push.

**The push rides the apply queue behind the first registering write.** Probed live:
`agents.sessions.rename` answers `not_authorized` until the thread is a registered agent
session, and the lifecycle status write (or the card stream's open) is what registers it. So
the stored title is stashed on the turn and flushed right after the first `set-status` or
`stream-start` — same queue, guaranteed order, no retry machinery. A live runtime title
supersedes a stored title still waiting, and the connection skips unchanged re-pushes so later
turns cost no API call (re-stashing every turn heals a restart).

## Also

Merges a duplicate `gitlab/api.js` import in the CP's agents route that was failing
`pnpm lint` repo-wide (`import-x/no-duplicates`).

## Verification

- Apply-level pins: flush lands after `set-status` / `stream-start`, exactly once; a runtime
  `set-title` supersedes the pending fallback.
- Creation pin: the late-title smoke case now asserts the session is BORN with the derived
  fallback and that a wrong agent's rename cannot replace it.
- 337 tests across streaming/smoke/connection/lifecycle/session-manager/session-reader;
  typecheck, lint, format clean.

Upstream tracking for the Codex-native path (found while investigating): issue #427 (closed)
asked to map client-supplied titles to `thread/name/set`; PR #338 (open) and PR #392 (open, AI
title generation + `/rename`) would give Codex sessions real native titles — this PR's
fallback remains the floor either way.
