### PR TITLE
perf(daemon): run the test suites' store at synchronous = NORMAL

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,10 +238,18 @@ jobs:
   #
   # No `prisma:generate` step: neither package imports the generated client.
   unit-windows:
-    name: Unit Test (Windows)
+    # MEASUREMENT ONLY — not for merge. Both arms in one run, three samples each: this job's
+    # `tests` total swings 1326-1951 s between runs of identical content, so a single A/B pair
+    # cannot resolve a 20% effect. Running them together pins the time window and runner pool.
+    name: Unit Test (Windows) ${{ matrix.sync }}-${{ matrix.sample }}
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sync: [FULL, NORMAL]
+        sample: [1, 2, 3]
     # The daemon suite alone runs ~20 min here against ~3 on Linux — Windows filesystem and
     # process-spawn cost, not extra work — so the cap is set well clear of it rather than near it.
     timeout-minutes: 45
@@ -310,6 +318,8 @@ jobs:
           GITHUB_STEP_SUMMARY: ${{ runner.temp }}/windows-unit-test-summary.md
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
+          # MEASUREMENT ONLY. FULL is what the store keeps today, so that arm is the control.
+          AC_STORE_SYNCHRONOUS: ${{ matrix.sync }}
         run: pnpm --filter @agentconnect.md/daemon test:unit
       - name: CLI unit tests
         if: ${{ !cancelled() }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,18 +238,10 @@ jobs:
   #
   # No `prisma:generate` step: neither package imports the generated client.
   unit-windows:
-    # MEASUREMENT ONLY — not for merge. Both arms in one run, three samples each: this job's
-    # `tests` total swings 1326-1951 s between runs of identical content, so a single A/B pair
-    # cannot resolve a 20% effect. Running them together pins the time window and runner pool.
-    name: Unit Test (Windows) ${{ matrix.sync }}-${{ matrix.sample }}
+    name: Unit Test (Windows)
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        sync: [FULL, NORMAL]
-        sample: [1, 2, 3]
     # The daemon suite alone runs ~20 min here against ~3 on Linux — Windows filesystem and
     # process-spawn cost, not extra work — so the cap is set well clear of it rather than near it.
     timeout-minutes: 45
@@ -318,8 +310,6 @@ jobs:
           GITHUB_STEP_SUMMARY: ${{ runner.temp }}/windows-unit-test-summary.md
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
-          # MEASUREMENT ONLY. FULL is what the store keeps today, so that arm is the control.
-          AC_STORE_SYNCHRONOUS: ${{ matrix.sync }}
         run: pnpm --filter @agentconnect.md/daemon test:unit
       - name: CLI unit tests
         if: ${{ !cancelled() }}

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1051,6 +1051,9 @@ export class LocalStore {
         orgForAgent: undefined
       })
       await store.db.exec('PRAGMA journal_mode = WAL')
+      // MEASUREMENT ONLY — not for merge. Read from an allowlist so the value can never be argv.
+      const measured = { FULL: 'FULL', NORMAL: 'NORMAL' }[process.env.AC_STORE_SYNCHRONOUS ?? '']
+      if (measured !== undefined) await store.db.exec(`PRAGMA synchronous = ${measured}`)
       // WAL mode publishes two siblings alongside the database; they carry the same
       // rows, so restricting only the main file would leave the content readable.
       for (const p of [source, `${source}-wal`, `${source}-shm`]) restrictPath(p, 0o600)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1051,9 +1051,14 @@ export class LocalStore {
         orgForAgent: undefined
       })
       await store.db.exec('PRAGMA journal_mode = WAL')
-      // MEASUREMENT ONLY — not for merge. Read from an allowlist so the value can never be argv.
-      const measured = { FULL: 'FULL', NORMAL: 'NORMAL' }[process.env.AC_STORE_SYNCHRONOUS ?? '']
-      if (measured !== undefined) await store.db.exec(`PRAGMA synchronous = ${measured}`)
+      // A test suite's only knob on this store, and the suites set it to NORMAL — see the daemon's
+      // `vitest.config.ts`. WAL keeps `synchronous = FULL`, an fsync per commit, and the suite pays
+      // ~22k of them a run; NORMAL cannot corrupt the database and survives a process crash intact,
+      // it only risks losing recent commits to a power cut, which no test asserts. Never set this
+      // in production: the durable inbox's whole promise is being there after the machine died.
+      // Read through an allowlist so the value can never reach the statement as argv.
+      const synchronous = { NORMAL: 'NORMAL', FULL: 'FULL' }[process.env.AGENTCONNECT_TEST_STORE_SYNCHRONOUS ?? '']
+      if (synchronous !== undefined) await store.db.exec(`PRAGMA synchronous = ${synchronous}`)
       // WAL mode publishes two siblings alongside the database; they carry the same
       // rows, so restricting only the main file would leave the content readable.
       for (const p of [source, `${source}-wal`, `${source}-shm`]) restrictPath(p, 0o600)

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -67,6 +67,12 @@ export const BASE_TEST_TIMEOUT = 30_000
 export default defineConfig({
   test: {
     environment: 'node',
+    // The suite creates ~1.4k stores and commits ~22k times across them, and WAL fsyncs every one.
+    // Measured on the Windows runner, three samples per arm in one run: 1813 s of test time at the
+    // shipped FULL against 1372 s at NORMAL, ranges that do not overlap. NORMAL removes no file
+    // operation — every Win32 rename, handle and deletion the suite exercises is untouched — and
+    // nothing here asserts what survives a power cut, which is the only thing FULL buys.
+    env: { AGENTCONNECT_TEST_STORE_SYNCHRONOUS: 'NORMAL' },
     // Keep process-heavy, integration-shaped unit files from oversubscribing available test-worker
     // resources. Four on Windows too: the halving there bought time for inline per-test budgets that
     // no longer exist, and the polls those budgets never governed now scale in `test/wait-support.ts`.


### PR DESCRIPTION
## What

The daemon's test suites open their store at `PRAGMA synchronous = NORMAL`. Production is untouched and keeps `FULL`.

```diff
+ env: { AGENTCONNECT_TEST_STORE_SYNCHRONOUS: 'NORMAL' },      // packages/daemon/vitest.config.ts
```

`LocalStore.open` reads that name through an allowlist, so the value can never reach the statement as argv. Unset — which is every non-test process — nothing runs and the store keeps SQLite's default.

## Why

WAL keeps `synchronous = FULL`, so every commit is an fsync. Counting at the store seam across the whole suite: **~1,400 stores created, ~21,900 commits**. On the Windows runner that is most of what the store-touching files cost.

## Measured, not argued

Three samples per arm in one run — same time window, same runner pool, pragma the only difference ([the matrix that produced it](https://github.com/agentconnect-md/agentconnect/actions/runs/33256149403)):

| arm | `tests` totals | mean | range |
|---|---|---|---|
| `FULL` (shipped) | 1512.0 / 1829.2 / 2098.8 s | **1813.3 s** | 587 s |
| `NORMAL` | 1313.8 / 1342.4 / 1461.2 s | **1372.5 s** | **147 s** |

**−24%, and the ranges are disjoint** — `max(NORMAL) = 1461.2 < min(FULL) = 1512.0`.

The single-pair version of this measurement (#1605) came back 15% the *wrong* way, which is impossible for a setting that only removes fsyncs. That job's test time swings **1326–1951 s** between runs of identical content; three-and-three is what it took to see through that.

Worth noting on its own: **NORMAL's spread is 147 s against FULL's 587 s.** Removing the fsyncs removes most of the run-to-run noise as well — and the single failure across all six jobs was a timing-sensitive case in the slowest `FULL` sample.

## Why this is safe, and why it stays in tests

Under WAL, `NORMAL` **cannot corrupt the database** and survives an application crash intact. What it risks is losing the most recent commits to a power cut or a kernel crash. Nothing in the suite asserts that.

Production keeps `FULL`, because the durable inbox's whole promise is being there after the machine died. That trade is a product question, not a CI one, and this PR does not open it.

**It removes no file operation.** Every Win32 path the suite exists to cover — renames onto open handles, deletions, the WAL siblings, concurrent opens — happens exactly as before. Only the barrier that waits for the disk goes.

## Verification

- The store's own connection reports `synchronous = 1` under vitest (checked on the connection, not a fresh one — the pragma is per-connection and is not stored in the file).
- `local-store` / `session-manager` / `daemon-lifecycle` / `durable-inbox`: 305 passed.
- `test:store:postgres`: 7 files, 134 passed — the pragma sits in the file-backed branch and never reaches the pool store.
- `typecheck`, `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
