### PR TITLE
fix(protocol): name the refused origin and the operator knob in the clone-origin refusal

### DIFF
--- a/charts/agentconnect/values.yaml
+++ b/charts/agentconnect/values.yaml
@@ -205,7 +205,7 @@ daemonPool:
   # Clone origins this pool's members will serve a workspace from — the OPERATOR's policy, which
   # is why a tenant cannot widen it and why an install that runs a self-managed code host has to
   # state it here. Empty ⇒ the daemon's own default, which is GitHub and GitLab.com only, and a
-  # self-managed GitLab is then refused with `git clone origin is not allowed by this daemon`.
+  # self-managed GitLab is then refused with `git clone origin … is not allowed by this daemon`.
   # Exact scheme + host + port, no path, no credentials:
   #
   #   workspaceGitAllowedOrigins:

--- a/packages/daemon/test/git-origin-policy.test.ts
+++ b/packages/daemon/test/git-origin-policy.test.ts
@@ -11,22 +11,20 @@ afterEach(() => configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGI
 describe('workspace Git origin policy', () => {
   it('denies an unconfigured host at the daemon boundary', () => {
     expect(() => authorizeWorkspaceGitUrl('https://code.example.test/acme/repo.git')).toThrow(
-      'git clone origin is not allowed'
+      'is not allowed by this daemon'
     )
     // §13.2: managed GitLab is HTTPS-only and part of the default policy now.
     expect(authorizeWorkspaceGitUrl('https://gitlab.com/example-group/example-project.git')).toBe(
       'https://gitlab.com/example-group/example-project.git'
     )
     expect(() => authorizeWorkspaceGitUrl('ssh://git@gitlab.com/example-group/example-project.git')).toThrow(
-      'git clone origin is not allowed'
+      'is not allowed by this daemon'
     )
   })
 
   it('treats an explicit empty policy as deny-all', () => {
     configureWorkspaceGitOrigins([])
-    expect(() => authorizeWorkspaceGitUrl('https://github.com/acme/repo.git')).toThrow(
-      'git clone origin is not allowed'
-    )
+    expect(() => authorizeWorkspaceGitUrl('https://github.com/acme/repo.git')).toThrow('is not allowed by this daemon')
   })
 
   it('allows an exact operator-configured origin without widening its port', () => {
@@ -35,9 +33,7 @@ describe('workspace Git origin policy', () => {
     expect(authorizeWorkspaceGitUrl('https://git.example:8443/acme/repo.git')).toBe(
       'https://git.example:8443/acme/repo.git'
     )
-    expect(() => authorizeWorkspaceGitUrl('https://git.example/acme/repo.git')).toThrow(
-      'git clone origin is not allowed'
-    )
+    expect(() => authorizeWorkspaceGitUrl('https://git.example/acme/repo.git')).toThrow('is not allowed by this daemon')
   })
 })
 
@@ -49,7 +45,7 @@ describe("the deployment's own code host", () => {
   it('is cloneable when the spec in hand names it, with nothing configured locally', () => {
     expect(authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`, INSTANCE)).toBe(`${INSTANCE}/team/repo.git`)
     // ...and only for the spec that names it: no process state leaks to the next caller.
-    expect(() => authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`)).toThrow('git clone origin is not allowed')
+    expect(() => authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`)).toThrow('is not allowed by this daemon')
   })
 
   it('admits that origin only, never anywhere else', () => {
@@ -58,7 +54,7 @@ describe("the deployment's own code host", () => {
       `${INSTANCE}/gitlab/team/repo.git`
     )
     expect(() => authorizeWorkspaceGitUrl('https://elsewhere.example.test/team/repo.git', prefixed)).toThrow(
-      'git clone origin is not allowed'
+      'is not allowed by this daemon'
     )
   })
 
@@ -66,7 +62,7 @@ describe("the deployment's own code host", () => {
   it('does not widen past an explicit deny-all', () => {
     configureWorkspaceGitOrigins([])
     expect(() => authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`, INSTANCE)).toThrow(
-      'git clone origin is not allowed'
+      'is not allowed by this daemon'
     )
     expect(permitsNoHttpsOrigin()).toBe(true)
   })
@@ -80,7 +76,7 @@ describe("the deployment's own code host", () => {
 
   it('ignores a host that is not addressable as an origin', () => {
     expect(() => authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`, 'not a url')).toThrow(
-      'git clone origin is not allowed'
+      'is not allowed by this daemon'
     )
   })
 })

--- a/packages/daemon/test/skill-git-source.test.ts
+++ b/packages/daemon/test/skill-git-source.test.ts
@@ -184,7 +184,7 @@ describe('Git skill source policy boundary', () => {
       'https://github.com:8443/acme/skills.git',
       'ssh://git@github.com:2222/acme/skills.git'
     ]) {
-      expect(() => parseGitSkillSource(entry(source)), source).toThrow(/origin is not allowed/i)
+      expect(() => parseGitSkillSource(entry(source)), source).toThrow(/is not allowed by this daemon/i)
     }
   })
 
@@ -211,7 +211,7 @@ describe('Git skill source policy boundary', () => {
           agentId: 'agent-1',
           useGitCredential: true
         })
-      ).rejects.toThrow(/origin is not allowed/i)
+      ).rejects.toThrow(/is not allowed by this daemon/i)
       expect(existsSync(destination)).toBe(false)
       // A default-allowed gitlab origin still refuses the CREDENTIALED path,
       // which remains canonical-GitHub-only, before any directory or Git work.

--- a/packages/protocol/src/git-url.test.ts
+++ b/packages/protocol/src/git-url.test.ts
@@ -182,7 +182,7 @@ describe('workspace git origin policy', () => {
       'ssh://git@github.com:2222/acme/infra'
     ]) {
       expect(() => normalizeAllowedWorkspaceGitUrl(url, DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS), url).toThrow(
-        'git clone origin is not allowed'
+        'is not allowed by this daemon'
       )
     }
   })

--- a/packages/protocol/src/git-url.ts
+++ b/packages/protocol/src/git-url.ts
@@ -8,6 +8,8 @@
  * with `gitRepoLabel`.
  */
 
+import { WORKSPACE_GIT_ORIGINS_ENV } from './consts.js'
+
 /** Scheme-full address: https://, ssh://, git://, file://, … */
 const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i
 /** Any URI scheme, including non-hierarchical forms such as `ext::…`. */
@@ -316,8 +318,13 @@ export function workspaceGitOriginOf(input: string): string {
 export function normalizeAllowedWorkspaceGitUrl(input: string, allowedOrigins: readonly string[]): string {
   const normalized = normalizeGitCloneUrl(input)
   const allowed = new Set(allowedOrigins.map(normalizeWorkspaceGitOrigin))
-  if (!allowed.has(workspaceGitOriginOf(normalized))) {
-    invalidCloneUrl('git clone origin is not allowed by this daemon')
+  const origin = workspaceGitOriginOf(normalized)
+  if (!allowed.has(origin)) {
+    // The refusal names the origin and the operator knob: the reader is usually a tenant whose
+    // fix is asking the daemon's operator, so the message must say what to ask for.
+    invalidCloneUrl(
+      `git clone origin ${origin} is not allowed by this daemon — its operator can allow it via security.workspaceGitAllowedOrigins in the daemon config (${WORKSPACE_GIT_ORIGINS_ENV} for a cluster member)`
+    )
   }
   return normalized
 }


### PR DESCRIPTION
The daemon's clone-origin refusal read `git clone origin is not allowed by this daemon` — true, but the reader is usually a tenant in the console, whose only fix is asking the daemon's operator, and the message said neither which origin was refused nor what to ask for.

It now names both: the canonical origin the URL selects, and the operator's allowlist knob — `security.workspaceGitAllowedOrigins` in the daemon config, or the `AC_WORKSPACE_GIT_ALLOWED_ORIGINS` env for a cluster member:

> git clone origin https://codeberg.org is not allowed by this daemon — its operator can allow it via security.workspaceGitAllowedOrigins in the daemon config (AC_WORKSPACE_GIT_ALLOWED_ORIGINS for a cluster member)

The origin is derived from the already-normalized URL, so it can never carry credentials. The chart's values comment quoting the old wording follows it, and the test assertions move to the stable `is not allowed by this daemon` fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)