### PR TITLE
feat(web): gate the Git URL workspace tile behind a git-url feature flag

### DIFF
--- a/packages/web/src/components/console/WorkspaceFormFields.test.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.test.tsx
@@ -28,6 +28,7 @@ afterEach(async () => {
   container?.remove()
   root = undefined
   container = undefined
+  delete window.__AC_ENV
 })
 
 describe('WorkspaceFormFields', () => {
@@ -42,6 +43,7 @@ describe('WorkspaceFormFields', () => {
   })
 
   it('uses one workspace source picker for create and edit flows', async () => {
+    window.__AC_ENV = { FEATURE_FLAGS: 'git-url' }
     const onChange = vi.fn()
     await render(<WorkspaceModeField value="scratch" onChange={onChange} />)
 
@@ -68,6 +70,23 @@ describe('WorkspaceFormFields', () => {
     expect(onChange).toHaveBeenCalledWith('gitlab')
     await act(async () => buttons[3]?.click())
     expect(onChange).toHaveBeenCalledWith('giturl')
+  })
+
+  it('offers the Git URL tile only where the git-url flag is on', async () => {
+    window.__AC_ENV = {}
+    await render(<WorkspaceModeField value="scratch" onChange={vi.fn()} />)
+
+    const labels = Array.from(container?.querySelectorAll('button') ?? []).map((button) => button.textContent)
+    expect(labels).toEqual(['Scratch', 'GitHub', 'GitLab'])
+  })
+
+  it('keeps the Git URL tile for a workspace already on one, flag or not', async () => {
+    window.__AC_ENV = {}
+    await render(<WorkspaceModeField value="giturl" onChange={vi.fn()} />)
+
+    const buttons = Array.from(container?.querySelectorAll('button') ?? [])
+    expect(buttons.map((button) => button.textContent)).toEqual(['Scratch', 'GitHub', 'GitLab', 'Git URL'])
+    expect(buttons[3]?.getAttribute('aria-pressed')).toBe('true')
   })
 
   it('returns the shared repository access vocabulary', async () => {

--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import type { KeyboardEvent, ReactNode } from 'react'
 import { GithubMark, GitlabMark } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
+import { featureFlagEnabled } from '@/lib/feature-flags'
 import { GITLAB_PROJECT_STATE, gitlabChoiceSelectable, type GitlabProjectChoice } from '@/lib/gitlab-projects'
 import type { RepoAccess } from '@/lib/api'
 
@@ -75,12 +76,16 @@ export function WorkspaceModeField({
   label?: string | null
 }) {
   const fieldClassName = className ? `fld ${className}` : 'fld'
+  // Fixed at mount: a workspace already on a git URL keeps its tile even where the flag is off
+  // (live state stays representable — and reversible while the modal is open), new picks don't.
+  const [withGitUrl] = useState(() => featureFlagEnabled('git-url') || value === 'giturl')
+  const options = withGitUrl ? WORKSPACE_MODE_OPTIONS : WORKSPACE_MODE_OPTIONS.filter((o) => o.value !== 'giturl')
 
   return (
     <div className={fieldClassName}>
       {label !== null && <span className="fldlbl">{label}</span>}
       <div className="flex flex-wrap gap-[10px]">
-        {WORKSPACE_MODE_OPTIONS.map((option) => {
+        {options.map((option) => {
           const selected = value === option.value
           return (
             <button

--- a/packages/web/src/lib/feature-flags.ts
+++ b/packages/web/src/lib/feature-flags.ts
@@ -32,6 +32,12 @@ export type FeatureFlagId =
    *  nothing to point it at. `BILLING_URL` then says WHERE that service is; this says WHETHER to
    *  offer the page, so a missing endpoint is a misconfiguration rather than a silent opt-out. */
   | 'billing'
+  /** The "Git URL" workspace tile — anonymous clones from arbitrary Git servers. A standing
+   *  switch: the tile is only usable where the deployment widens the daemons' clone-origin
+   *  allowlist past the managed hosts, so the environment that does that turns it on here. A
+   *  workspace ALREADY on a git URL still renders its tile — hiding live state is not hiding an
+   *  entry point. */
+  | 'git-url'
 
 function enabledIds(): ReadonlySet<string> {
   // The server must read the SAME value `PublicEnvScript` injects, in the same precedence, or a


### PR DESCRIPTION
The Git URL tile is only usable where the deployment widens the daemons' clone-origin allowlist past the managed hosts; everywhere else it is an entry point into a guaranteed refusal. This makes it a standing console flag — `git-url` in `FEATURE_FLAGS` — off by default like every flag, so an environment offers the tile exactly when its fleet can serve it.

Two details:

- A workspace already on a git URL still renders its tile with the flag off — hiding live state is not hiding an entry point — and the row is fixed at mount so the tile stays for the life of the modal, keeping the choice reversible while editing.
- Display of existing git-URL workspaces (workspace card, derived source mark) is untouched; only the picker entry point is gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)