### PR TITLE
measure: run the suite's temp root on both runner disks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,18 +238,10 @@ jobs:
   #
   # No `prisma:generate` step: neither package imports the generated client.
   unit-windows:
-    # MEASUREMENT ONLY — not for merge. Both arms in one run, three samples each: this job's
-    # `tests` total swings 1326-1951 s between runs of identical content, so a single A/B pair
-    # cannot resolve a 20% effect. Running them together pins the time window and runner pool.
-    name: Unit Test (Windows) ${{ matrix.sync }}-${{ matrix.sample }}
+    name: Unit Test (Windows)
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        sync: [FULL, NORMAL]
-        sample: [1, 2, 3]
     # The daemon suite alone runs ~20 min here against ~3 on Linux — Windows filesystem and
     # process-spawn cost, not extra work — so the cap is set well clear of it rather than near it.
     timeout-minutes: 45
@@ -308,8 +300,6 @@ jobs:
           GITHUB_STEP_SUMMARY: ${{ runner.temp }}/windows-unit-test-summary.md
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
-          # MEASUREMENT ONLY. FULL is what the store keeps today, so that arm is the control.
-          AC_STORE_SYNCHRONOUS: ${{ matrix.sync }}
         run: pnpm --filter @agentconnect.md/daemon test:unit
       - name: CLI unit tests
         if: ${{ !cancelled() }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,10 +238,19 @@ jobs:
   #
   # No `prisma:generate` step: neither package imports the generated client.
   unit-windows:
-    name: Unit Test (Windows)
+    # MEASUREMENT ONLY — not for merge. `os.tmpdir()` resolves onto C:, the runner's network-attached
+    # OS disk, while D: is storage local to the host. The suite creates ~1400 stores and their temp
+    # roots there. Both arms in one run, three samples each: this job's `tests` total swings 1326-1951 s
+    # between runs of identical content, so a single pair cannot resolve anything this size.
+    name: Unit Test (Windows) ${{ matrix.tmp }}-${{ matrix.sample }}
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tmp: [C, D]
+        sample: [1, 2, 3]
     # The daemon suite alone runs ~20 min here against ~3 on Linux — Windows filesystem and
     # process-spawn cost, not extra work — so the cap is set well clear of it rather than near it.
     timeout-minutes: 45
@@ -295,6 +304,13 @@ jobs:
       #
       # One step per package, the second running even after the first fails: a recursive `pnpm run`
       # aborts its siblings on the first failure, which would hide one package behind the other.
+      # MEASUREMENT ONLY. The C arm sets nothing, so it is the runner as it comes; Node reads TEMP
+      # first on win32, and both are set because other tooling reads TMP.
+      - name: Point the suite's temp root at the host-local disk
+        if: ${{ matrix.tmp == 'D' }}
+        run: |
+          echo "TMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
+          echo "TEMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
       - name: Daemon unit tests
         env:
           GITHUB_STEP_SUMMARY: ${{ runner.temp }}/windows-unit-test-summary.md

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,10 +238,18 @@ jobs:
   #
   # No `prisma:generate` step: neither package imports the generated client.
   unit-windows:
-    name: Unit Test (Windows)
+    # MEASUREMENT ONLY — not for merge. Both arms in one run, three samples each: this job's
+    # `tests` total swings 1326-1951 s between runs of identical content, so a single A/B pair
+    # cannot resolve a 20% effect. Running them together pins the time window and runner pool.
+    name: Unit Test (Windows) ${{ matrix.sync }}-${{ matrix.sample }}
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sync: [FULL, NORMAL]
+        sample: [1, 2, 3]
     # The daemon suite alone runs ~20 min here against ~3 on Linux — Windows filesystem and
     # process-spawn cost, not extra work — so the cap is set well clear of it rather than near it.
     timeout-minutes: 45
@@ -300,6 +308,8 @@ jobs:
           GITHUB_STEP_SUMMARY: ${{ runner.temp }}/windows-unit-test-summary.md
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
+          # MEASUREMENT ONLY. FULL is what the store keeps today, so that arm is the control.
+          AC_STORE_SYNCHRONOUS: ${{ matrix.sync }}
         run: pnpm --filter @agentconnect.md/daemon test:unit
       - name: CLI unit tests
         if: ${{ !cancelled() }}

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1051,6 +1051,9 @@ export class LocalStore {
         orgForAgent: undefined
       })
       await store.db.exec('PRAGMA journal_mode = WAL')
+      // MEASUREMENT ONLY — not for merge. Read from an allowlist so the value can never be argv.
+      const measured = { FULL: 'FULL', NORMAL: 'NORMAL' }[process.env.AC_STORE_SYNCHRONOUS ?? '']
+      if (measured !== undefined) await store.db.exec(`PRAGMA synchronous = ${measured}`)
       // WAL mode publishes two siblings alongside the database; they carry the same
       // rows, so restricting only the main file would leave the content readable.
       for (const p of [source, `${source}-wal`, `${source}-shm`]) restrictPath(p, 0o600)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1051,9 +1051,14 @@ export class LocalStore {
         orgForAgent: undefined
       })
       await store.db.exec('PRAGMA journal_mode = WAL')
-      // MEASUREMENT ONLY — not for merge. Read from an allowlist so the value can never be argv.
-      const measured = { FULL: 'FULL', NORMAL: 'NORMAL' }[process.env.AC_STORE_SYNCHRONOUS ?? '']
-      if (measured !== undefined) await store.db.exec(`PRAGMA synchronous = ${measured}`)
+      // A test suite's only knob on this store, and the suites set it to NORMAL — see the daemon's
+      // `vitest.config.ts`. WAL keeps `synchronous = FULL`, an fsync per commit, and the suite pays
+      // ~22k of them a run; NORMAL cannot corrupt the database and survives a process crash intact,
+      // it only risks losing recent commits to a power cut, which no test asserts. Never set this
+      // in production: the durable inbox's whole promise is being there after the machine died.
+      // Read through an allowlist so the value can never reach the statement as argv.
+      const synchronous = { NORMAL: 'NORMAL', FULL: 'FULL' }[process.env.AGENTCONNECT_TEST_STORE_SYNCHRONOUS ?? '']
+      if (synchronous !== undefined) await store.db.exec(`PRAGMA synchronous = ${synchronous}`)
       // WAL mode publishes two siblings alongside the database; they carry the same
       // rows, so restricting only the main file would leave the content readable.
       for (const p of [source, `${source}-wal`, `${source}-shm`]) restrictPath(p, 0o600)

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -67,6 +67,12 @@ export const BASE_TEST_TIMEOUT = 30_000
 export default defineConfig({
   test: {
     environment: 'node',
+    // The suite creates ~1.4k stores and commits ~22k times across them, and WAL fsyncs every one.
+    // Measured on the Windows runner, three samples per arm in one run: 1813 s of test time at the
+    // shipped FULL against 1372 s at NORMAL, ranges that do not overlap. NORMAL removes no file
+    // operation — every Win32 rename, handle and deletion the suite exercises is untouched — and
+    // nothing here asserts what survives a power cut, which is the only thing FULL buys.
+    env: { AGENTCONNECT_TEST_STORE_SYNCHRONOUS: 'NORMAL' },
     // Keep process-heavy, integration-shaped unit files from oversubscribing available test-worker
     // resources. Four on Windows too: the halving there bought time for inline per-test budgets that
     // no longer exist, and the polls those budgets never governed now scale in `test/wait-support.ts`.


### PR DESCRIPTION
## Do not merge — this is a measurement

The suite's temporary roots land on **C:**, the runner's network-attached OS disk:

```
C:\Users\RUNNER~1\AppData\Local\Temp\ac-cpagent-...     ← ~1,400 stores, their WAL siblings, every fixture root
D:\a\agentconnect\agentconnect                          ← the workspace
D:\.pnpm-store\v11                                      ← the pnpm store
D:\a\_temp                                              ← RUNNER_TEMP
```

`os.tmpdir()` resolves to C:; everything else the job touches is already on D:, which on a hosted runner is storage local to the host rather than attached over the network. So the one thing writing the most small files is the one thing on the slower disk.

## What the arms are

The same suite writing the same files to two different disks. **No file operation is removed and nothing is skipped** — every mkdir, rename, handle and delete the Windows job exists to catch happens exactly as before. The `C` arm sets nothing at all, so it is the runner as it comes.

Three samples per arm in one run, for the reason the last matrix had: this job's `tests` total came back **1326 / 1650 / 1692 / 1951 s** on runs of identical content, so a single pair resolves nothing at this scale.

Branched off #1612 rather than `main`, so the fsyncs that change removes are already gone and what remains is the create/write/delete this one targets.

## The interaction worth stating up front

`synchronous = NORMAL` and this both attack disk latency, from different ends. **Their gains will not simply add** — a faster disk also makes the fsyncs that remain cheaper, and NORMAL already removed most of them. Measuring D: on top of NORMAL is the right order for the decision actually at hand: given NORMAL, is D: also worth taking?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
