### PR TITLE
ci: put the Windows suite's temp root on the host-local disk

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -290,6 +290,16 @@ jobs:
       # store saved by one would cost the full-install jobs a re-download on every run.
       - name: Install
         run: pnpm install --frozen-lockfile --filter "@agentconnect.md/daemon..." --filter "@agentconnect.md/cli..."
+      # `os.tmpdir()` resolves onto C:, this runner's network-attached OS disk, while the workspace,
+      # the pnpm store and `RUNNER_TEMP` already sit on D:, which is storage local to the host. The
+      # suite builds ~1400 stores and every fixture root through that name, so the one thing writing
+      # the most small files was the one thing left on the slower disk. Measured three samples per
+      # arm in one run: 1399 s of test time on C against 857 s on D, ranges disjoint. Node reads
+      # TEMP first on win32; TMP is set too because other tooling reads that one.
+      - name: Put the suite's temp root on the host-local disk
+        run: |
+          echo "TMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
+          echo "TEMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
       # POSIX-only files self-skip via `it.skipIf(process.platform === 'win32')`, or — when every
       # case in the file is POSIX-only — via `WINDOWS_EXCLUDED` in that package's vitest.config.ts.
       #


### PR DESCRIPTION
## What

The Windows job's tests write their temporary roots to the host-local disk instead of the network-attached one.

```yaml
- name: Put the suite's temp root on the host-local disk
  run: |
    echo "TMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
    echo "TEMP=$RUNNER_TEMP" >> "$GITHUB_ENV"
```

## Why

`os.tmpdir()` resolves onto **C:**, this runner's network-attached OS disk. Everything else the job touches is already on **D:**, storage local to the host:

```
C:\Users\RUNNER~1\AppData\Local\Temp\ac-*      ← ~1,400 stores, their WAL siblings, every fixture root
D:\a\agentconnect\agentconnect                 ← the workspace
D:\.pnpm-store\v11                             ← the pnpm store
D:\a\_temp                                     ← RUNNER_TEMP
```

The one thing writing the most small files was the one thing left on the slower disk.

## Measured

Both arms in one run, three samples each — this job's test time swings **1326–1951 s** between runs of identical content, so a single pair resolves nothing at this scale ([the matrix](https://github.com/agentconnect-md/agentconnect/actions/runs/33258582062)):

| arm | `tests` totals | mean |
|---|---|---|
| **C** (current) | 1231.9 / 1744.5 / 1219.9 s | **1398.8 s** |
| **D** (host-local) | 850.0 / 696.3 / 1025.5 s | **857.3 s** |

**−39%, ranges disjoint** — `max(D) = 1025.5 < min(C) = 1219.9`. The daemon step follows: 328/457/325 s against 232/191/278 s.

## No coverage question

This is the rare one with nothing traded away. **No file operation is removed and nothing is skipped** — every mkdir, rename onto an open handle, deletion and WAL sibling the Windows job exists to catch happens exactly as before, on a different volume.

## Notes

Node reads `TEMP` first on win32; `TMP` is set as well because other tooling reads that one. The step sits after install, so the two test steps are the only ones it governs.

Measured on top of #1612, so the fsyncs that change removes were already gone and what this moves is the create/write/delete underneath. The two are not additive — see the discussion there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
