### PR TITLE
feat(daemon): default the workspace clone-origin policy to any origin

### DIFF
--- a/charts/agentconnect/values.yaml
+++ b/charts/agentconnect/values.yaml
@@ -203,18 +203,18 @@ daemonPool:
     successThreshold: 1
     failureThreshold: 3
   # Clone origins this pool's members will serve a workspace from — the OPERATOR's policy, which
-  # is why a tenant cannot widen it and why an install that runs a self-managed code host has to
-  # state it here. Empty ⇒ the daemon's own default, which is GitHub and GitLab.com only, and a
-  # self-managed GitLab is then refused with `git clone origin … is not allowed by this daemon`.
-  # Exact scheme + host + port, no path, no credentials:
+  # is why a tenant cannot widen it. Empty ⇒ the daemon's own default, which admits ANY valid
+  # https/ssh origin ('*'). State exact scheme + host + port entries (no path, no credentials) to
+  # tighten it — a repository elsewhere is then refused with
+  # `git clone origin … is not allowed by this daemon`:
   #
   #   workspaceGitAllowedOrigins:
   #     - https://github.com
   #     - ssh://github.com
   #     - https://gitlab.example.test
   #
-  # Stating any origin REPLACES the default list rather than adding to it, so an install that also
-  # uses the public hosts names them here too. A malformed entry fails the member at startup.
+  # Stating any origin REPLACES the default rather than adding to it. A malformed entry fails the
+  # member at startup.
   workspaceGitAllowedOrigins: []
   # Install-wide model credentials, referenced BY NAME like every other secret here — the chart
   # never holds the value. Create the Secret with one entry per variable the daemon reads:

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -320,9 +320,10 @@ The layout keeps machine configuration, per-agent desired state, durable runtime
     // Linux SRT/bwrap sandbox. macOS and Windows are not supported in this rollout.
     "requireSandbox": false,
 
-    // Exact origins that daemon-managed workspace clone/pull may target.
-    // Scheme and non-default port are part of the match; no wildcards or paths.
-    // Add self-managed Git origins explicitly. [] disables remote Git workspaces.
+    // Origins that daemon-managed workspace clone/pull may target. Default ["*"]
+    // admits any valid https/ssh origin; exact entries (scheme and non-default
+    // port are part of the match, no partial wildcards or paths) tighten it, and
+    // [] disables remote Git workspaces entirely.
     "workspaceGitAllowedOrigins": ["https://github.com", "ssh://github.com"]
   },
 

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -72,7 +72,7 @@ export const WorkspaceGitOrigin = z.string().transform((value, ctx) => {
   } catch {
     ctx.addIssue({
       code: 'custom',
-      message: 'workspace Git origins must be exact credential-free HTTPS or SSH origins without a path'
+      message: 'workspace Git origins must be "*" or exact credential-free HTTPS or SSH origins without a path'
     })
     return z.NEVER
   }
@@ -159,8 +159,9 @@ export const ConfigSchema = z.object({
       // Linux SRT/bwrap is available and every agent runs sandboxed; the
       // console locks the per-agent option on. false leaves it agent-selectable.
       requireSandbox: z.boolean().default(false),
-      // Operator-owned remote-origin policy for daemon-managed workspace clone/pull.
-      // Exact scheme + host + port only; [] disables remote Git workspaces.
+      // Operator-owned remote-origin policy for daemon-managed workspace clone/pull. Default
+      // ['*'] admits any https/ssh origin; exact scheme+host+port entries tighten it, and []
+      // disables remote Git workspaces entirely.
       workspaceGitAllowedOrigins: z.array(WorkspaceGitOrigin).default([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS])
     })
     .default({

--- a/packages/daemon/src/config/load-config.ts
+++ b/packages/daemon/src/config/load-config.ts
@@ -118,7 +118,7 @@ export function loadConfig(
       )
     if (!parsed.success) {
       throw new Error(
-        `${WORKSPACE_GIT_ORIGINS_ENV} must be a comma-separated list of exact credential-free https/ssh origins`
+        `${WORKSPACE_GIT_ORIGINS_ENV} must be a comma-separated list of exact credential-free https/ssh origins (or '*')`
       )
     }
     cfg.security.workspaceGitAllowedOrigins = parsed.data

--- a/packages/daemon/src/workspace/git-origin-policy.ts
+++ b/packages/daemon/src/workspace/git-origin-policy.ts
@@ -2,7 +2,8 @@ import {
   DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
   normalizeAllowedWorkspaceGitUrl,
   normalizeWorkspaceGitOrigin,
-  workspaceGitOriginOf
+  workspaceGitOriginOf,
+  WORKSPACE_GIT_ANY_ORIGIN
 } from '@agentconnect.md/protocol'
 import { gitlabManagedHost } from '../gitcred/managed-hosts.js'
 
@@ -69,9 +70,11 @@ export function unauthorizedWorkspaceGitOrigin(repository: string, deploymentCod
   }
 }
 
-/** True when the OPERATOR list carries no HTTPS origin. Managed GitLab is HTTPS-only (§13.2), so
- *  such a daemon serves no GitLab instance beyond the one its own deployment names — which is a
- *  per-agent answer this startup-time check cannot have. */
+/** True when the OPERATOR list carries no HTTPS origin (`*` carries them all). Managed GitLab is
+ *  HTTPS-only (§13.2), so such a daemon serves no GitLab instance beyond the one its own
+ *  deployment names — which is a per-agent answer this startup-time check cannot have. */
 export function permitsNoHttpsOrigin(): boolean {
-  return !allowedOrigins.some((origin) => origin.toLowerCase().startsWith('https://'))
+  return !allowedOrigins.some(
+    (origin) => origin === WORKSPACE_GIT_ANY_ORIGIN || origin.toLowerCase().startsWith('https://')
+  )
 }

--- a/packages/daemon/test/config.test.ts
+++ b/packages/daemon/test/config.test.ts
@@ -32,6 +32,11 @@ describe('loadConfig', () => {
       expect(cfg.security.workspaceGitAllowedOrigins).toEqual(['https://gitlab.example.test'])
     })
 
+    it("accepts the bare '*' wildcard entry", () => {
+      const cfg = withEnv('*', () => loadConfig({ root: tmpRoot({ version: 1 }) }))
+      expect(cfg.security.workspaceGitAllowedOrigins).toEqual(['*'])
+    })
+
     it('takes a list, trimming the spacing a values file is likely to hand it', () => {
       const cfg = withEnv(' https://github.com , https://gitlab.example.test:8443 ', () =>
         loadConfig({ root: tmpRoot({ version: 1 }) })
@@ -57,11 +62,7 @@ describe('loadConfig', () => {
 
     it('is ignored when blank', () => {
       const cfg = withEnv('   ', () => loadConfig({ root: tmpRoot({ version: 1 }) }))
-      expect(cfg.security.workspaceGitAllowedOrigins).toEqual([
-        'https://github.com',
-        'ssh://github.com',
-        'https://gitlab.com'
-      ])
+      expect(cfg.security.workspaceGitAllowedOrigins).toEqual(['*'])
     })
   })
 
@@ -75,11 +76,7 @@ describe('loadConfig', () => {
     expect(cfg.version).toBe(1)
     expect(cfg.runtimes!.claude!.command).toBe('npx')
     expect(cfg.security.isolateAccountApps).toBe(true)
-    expect(cfg.security.workspaceGitAllowedOrigins).toEqual([
-      'https://github.com',
-      'ssh://github.com',
-      'https://gitlab.com'
-    ])
+    expect(cfg.security.workspaceGitAllowedOrigins).toEqual(['*'])
     expect(cfg.features.turnFinalContextRefresh).toBe(true)
     expect(cfg.limits.maxAgents).toBe(32)
     expect(cfg.agentsDir).toContain('agents')

--- a/packages/daemon/test/git-origin-policy.test.ts
+++ b/packages/daemon/test/git-origin-policy.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS } from '@agentconnect.md/protocol'
 import {
   authorizeWorkspaceGitUrl,
@@ -9,11 +9,22 @@ import {
 afterEach(() => configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS))
 
 describe('workspace Git origin policy', () => {
-  it('denies an unconfigured host at the daemon boundary', () => {
+  it('admits any valid origin under the wildcard default', () => {
+    expect(authorizeWorkspaceGitUrl('https://code.example.test/acme/repo.git')).toBe(
+      'https://code.example.test/acme/repo.git'
+    )
+    expect(authorizeWorkspaceGitUrl('https://gitlab.com/example-group/example-project.git')).toBe(
+      'https://gitlab.com/example-group/example-project.git'
+    )
+    expect(permitsNoHttpsOrigin()).toBe(false)
+  })
+
+  it('denies a host outside a stated exact list at the daemon boundary', () => {
+    configureWorkspaceGitOrigins(['https://github.com', 'ssh://github.com', 'https://gitlab.com'])
     expect(() => authorizeWorkspaceGitUrl('https://code.example.test/acme/repo.git')).toThrow(
       'is not allowed by this daemon'
     )
-    // §13.2: managed GitLab is HTTPS-only and part of the default policy now.
+    // §13.2: managed GitLab stays HTTPS-only under an exact list.
     expect(authorizeWorkspaceGitUrl('https://gitlab.com/example-group/example-project.git')).toBe(
       'https://gitlab.com/example-group/example-project.git'
     )
@@ -39,10 +50,13 @@ describe('workspace Git origin policy', () => {
 
 describe("the deployment's own code host", () => {
   const INSTANCE = 'https://gitlab.example.test'
+  // The implicit code-host admission only matters under a TIGHTENED list — the
+  // wildcard default admits everything already.
+  beforeEach(() => configureWorkspaceGitOrigins(['https://github.com', 'ssh://github.com', 'https://gitlab.com']))
 
   // It is deployment configuration, and this daemon already trusts it to decide where an agent's
   // git credential may go. Making an operator restate it bought nothing and drifted.
-  it('is cloneable when the spec in hand names it, with nothing configured locally', () => {
+  it('is cloneable when the spec in hand names it, without being stated in the list', () => {
     expect(authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`, INSTANCE)).toBe(`${INSTANCE}/team/repo.git`)
     // ...and only for the spec that names it: no process state leaks to the next caller.
     expect(() => authorizeWorkspaceGitUrl(`${INSTANCE}/team/repo.git`)).toThrow('is not allowed by this daemon')

--- a/packages/daemon/test/skill-git-source.test.ts
+++ b/packages/daemon/test/skill-git-source.test.ts
@@ -177,7 +177,8 @@ describe('Git skill source policy boundary', () => {
     )
   })
 
-  it('rejects disallowed hosts, private addresses, and custom ports', () => {
+  it('rejects disallowed hosts, private addresses, and custom ports under an exact list', () => {
+    configureWorkspaceGitOrigins(['https://github.com', 'ssh://github.com', 'https://gitlab.com'])
     for (const source of [
       'https://code.example.test/acme/skills.git',
       'https://127.0.0.1/acme/skills.git',
@@ -189,11 +190,11 @@ describe('Git skill source policy boundary', () => {
   })
 
   it('honors an operator-authorized exact non-default origin', () => {
-    configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS, 'https://git.example.test'])
+    configureWorkspaceGitOrigins(['https://github.com', 'https://git.example.test'])
     expect(parseGitSkillSource(entry('https://git.example.test/acme/skills.git')).cloneUrl).toBe(
       'https://git.example.test/acme/skills.git'
     )
-    // §13.2: gitlab.com is a DEFAULT origin now — skill sources may name it
+    // The wildcard default admits any origin — skill sources may name gitlab.com
     // without operator opt-in (credentialed acquisition stays GitHub-only).
     configureWorkspaceGitOrigins([...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS])
     expect(parseGitSkillSource(entry('https://gitlab.com/acme/skills.git')).cloneUrl).toBe(
@@ -202,6 +203,7 @@ describe('Git skill source policy boundary', () => {
   })
 
   it('rejects a disallowed acquisition before creating its destination or invoking Git', async () => {
+    configureWorkspaceGitOrigins(['https://github.com', 'ssh://github.com', 'https://gitlab.com'])
     const root = await mkdtemp(join(tmpdir(), 'ac-skill-git-policy-'))
     const destination = join(root, 'acquired')
     try {

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -13,6 +13,8 @@ import {
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import type { Agent } from '../src/agents/agent-schema.js'
+import { configureWorkspaceGitOrigins } from '../src/workspace/git-origin-policy.js'
+import { DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS } from '@agentconnect.md/protocol'
 
 const { rename: realRename } = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
 const renameMock = vi.fn(realRename)
@@ -160,6 +162,8 @@ describe('prepareWorkspace', () => {
   })
 
   it('rejects a hand-edited transport or unconfigured origin before clone or pull', async () => {
+    // An unconfigured origin only exists under a stated exact list; the wildcard default admits it.
+    configureWorkspaceGitOrigins(['https://github.com', 'ssh://github.com', 'https://gitlab.com'])
     for (const gitRepo of ['file:///var/lib/agentconnect/other-workspace', 'https://git.example/acme/repo.git']) {
       const fresh = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'fresh')
       const existing = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'existing')
@@ -173,6 +177,7 @@ describe('prepareWorkspace', () => {
 
     expect(cloneImpl).not.toHaveBeenCalled()
     expect(pullMock).not.toHaveBeenCalled()
+    configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
   })
 
   it('single-flights concurrent clones into the same cwd (dedupe)', async () => {

--- a/packages/protocol/src/git-url.test.ts
+++ b/packages/protocol/src/git-url.test.ts
@@ -161,19 +161,32 @@ describe('workspace git origin policy', () => {
     expect(workspaceGitOriginOf('ssh://git@git.example:2222/acme/infra.git')).toBe('ssh://git.example:2222')
   })
 
-  it('requires an exact allowed scheme, host, and port', () => {
+  it('admits every valid origin under the wildcard default, still normalizing the URL', () => {
+    expect(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS).toEqual(['*'])
     expect(normalizeAllowedWorkspaceGitUrl('acme/infra', DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)).toBe(
       'https://github.com/acme/infra'
     )
     expect(
-      normalizeAllowedWorkspaceGitUrl('git@github.com:acme/infra.git', DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
-    ).toBe('git@github.com:acme/infra.git')
+      normalizeAllowedWorkspaceGitUrl('https://code.example.test/acme/infra', DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
+    ).toBe('https://code.example.test/acme/infra')
+    // The wildcard waives the origin check, never URL validation itself.
+    expect(() => normalizeAllowedWorkspaceGitUrl('ext::sh -c id', DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)).toThrow(
+      GitCloneUrlError
+    )
+  })
 
-    // §13.2: https://gitlab.com is a DEFAULT origin now (HTTPS only) — ssh
+  it('requires an exact allowed scheme, host, and port once origins are stated', () => {
+    const exact = ['https://github.com', 'ssh://github.com', 'https://gitlab.com']
+    expect(normalizeAllowedWorkspaceGitUrl('acme/infra', exact)).toBe('https://github.com/acme/infra')
+    expect(normalizeAllowedWorkspaceGitUrl('git@github.com:acme/infra.git', exact)).toBe(
+      'git@github.com:acme/infra.git'
+    )
+
+    // §13.2: https://gitlab.com stays HTTPS-only under an exact list — ssh
     // gitlab and lookalike/port-widened hosts still refuse.
-    expect(
-      normalizeAllowedWorkspaceGitUrl('https://gitlab.com/group/repo', DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
-    ).toBe('https://gitlab.com/group/repo')
+    expect(normalizeAllowedWorkspaceGitUrl('https://gitlab.com/group/repo', exact)).toBe(
+      'https://gitlab.com/group/repo'
+    )
     for (const url of [
       'ssh://git@gitlab.com/group/repo',
       'https://gitlab.com.evil.example/group/repo',
@@ -181,10 +194,13 @@ describe('workspace git origin policy', () => {
       'https://github.com:8443/acme/infra',
       'ssh://git@github.com:2222/acme/infra'
     ]) {
-      expect(() => normalizeAllowedWorkspaceGitUrl(url, DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS), url).toThrow(
-        'is not allowed by this daemon'
-      )
+      expect(() => normalizeAllowedWorkspaceGitUrl(url, exact), url).toThrow('is not allowed by this daemon')
     }
+  })
+
+  it('accepts the bare wildcard entry and nothing containing it', () => {
+    expect(normalizeWorkspaceGitOrigin('*')).toBe('*')
+    expect(normalizeWorkspaceGitOrigin(' * ')).toBe('*')
   })
 
   it('rejects ambiguous allowlist entries', () => {

--- a/packages/protocol/src/git-url.ts
+++ b/packages/protocol/src/git-url.ts
@@ -19,15 +19,12 @@ const SCP_RE = /^[\w.-]+@[\w.-]+:(.+)$/
 const SCP_PARTS_RE = /^([\w.-]+)@([\w.-]+):(.+)$/
 const CONTROL_RE = /[\u0000-\u001f\u007f]/
 
-/** Conservative daemon default. Operators may explicitly add exact origins
- * for GitLab, Bitbucket, or self-managed Git services. */
-// gitlab-com-integration.md §13.2: managed GitLab workspaces are HTTPS-only and
-// exactly this origin. An operator-supplied allowlist stays authoritative.
-export const DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS = [
-  'https://github.com',
-  'ssh://github.com',
-  'https://gitlab.com'
-] as const
+/** Wildcard allowlist entry: a policy containing it admits every valid clone origin. */
+export const WORKSPACE_GIT_ANY_ORIGIN = '*'
+
+/** Ease-of-use daemon default: any valid https/ssh origin. An operator tightens by
+ * stating exact origins — which REPLACE this — or disables remote Git with []. */
+export const DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS = [WORKSPACE_GIT_ANY_ORIGIN] as const
 
 /**
  * Hard cap on an untrusted repo reference. Real clone addresses are far under
@@ -264,12 +261,14 @@ function canonicalGitOrigin(protocol: 'https:' | 'ssh:', hostname: string, port:
 
 /**
  * Normalize an operator-owned allowlist entry to an exact scheme/host/port
- * origin. Paths, credentials, wildcards, queries, and fragments are not policy
- * syntax: repository paths remain tenant-selected within an allowed origin.
+ * origin, or the bare `*` wildcard. Partial wildcards, paths, credentials,
+ * queries, and fragments are not policy syntax: repository paths remain
+ * tenant-selected within an allowed origin.
  */
 export function normalizeWorkspaceGitOrigin(input: string): string {
   if (CONTROL_RE.test(input)) invalidCloneUrl('git origin must not contain control characters')
   const raw = input.trim()
+  if (raw === WORKSPACE_GIT_ANY_ORIGIN) return WORKSPACE_GIT_ANY_ORIGIN
   if (!raw || /\s/.test(raw) || raw.includes('\\') || raw.includes('*')) {
     invalidCloneUrl('git origin must be an exact https or ssh origin')
   }
@@ -312,12 +311,13 @@ export function workspaceGitOriginOf(input: string): string {
 
 /**
  * Normalize a clone URL and require its exact scheme/host/port origin to be in
- * the deployment policy. The caller owns the list; tenant input can never add
- * to it.
+ * the deployment policy; a policy carrying `*` admits every valid origin. The
+ * caller owns the list; tenant input can never add to it.
  */
 export function normalizeAllowedWorkspaceGitUrl(input: string, allowedOrigins: readonly string[]): string {
   const normalized = normalizeGitCloneUrl(input)
   const allowed = new Set(allowedOrigins.map(normalizeWorkspaceGitOrigin))
+  if (allowed.has(WORKSPACE_GIT_ANY_ORIGIN)) return normalized
   const origin = workspaceGitOriginOf(normalized)
   if (!allowed.has(origin)) {
     // The refusal names the origin and the operator knob: the reader is usually a tenant whose

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -157,6 +157,7 @@ export type { DecodeResultOf } from './wire.js'
 // ── git repo address helpers (normalize on write, shorten for display) ──
 export {
   DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS,
+  WORKSPACE_GIT_ANY_ORIGIN,
   MAX_GIT_REPO_LENGTH,
   GitCloneUrlError,
   normalizeAllowedWorkspaceGitUrl,


### PR DESCRIPTION
Ease of use wins the default: a fresh install clones a workspace (or a git skill source) from any valid https/ssh origin — `workspaceGitAllowedOrigins` now defaults to the one-entry wildcard `['*']`.

The knob keeps its whole expressive range:

- stating exact origins REPLACES the wildcard and tightens the daemon to those hosts;
- `[]` still disables remote Git workspaces entirely;
- the wildcard waives only the origin membership check — URL validation (transports, credentials-in-URL, local paths, control characters) is unchanged, and partial wildcards (`https://*.example.com`) remain invalid policy syntax.

The deployment's own code host stays implicitly admitted under a tightened list, as before. A deployment that wants the previous conservative posture states the managed hosts explicitly — the chart's values comment and the daemon design doc describe the new default. A follow-up adds a chart-level feature switch that pins a deployment to the managed hosts and hides the console's Git URL tile in one move.

Stacked on #1614 (same function carries the refusal message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)