### PR TITLE
measure: back the test suite's store with an in-memory database

### DIFF
--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import type { SQLInputValue } from 'node:sqlite'
+import { DatabaseSync, type SQLInputValue } from 'node:sqlite'
 import { chmodSync, mkdirSync, statSync } from 'node:fs'
 import { dirname } from 'node:path'
 import {
@@ -825,6 +825,10 @@ export interface RuntimeModelCapRecord {
  * path that vanished (WAL siblings appear lazily) is not an error worth failing a
  * daemon boot over.
  */
+// MEASUREMENT ONLY — not for merge. One in-memory database per store path, so a reopen finds
+// what the first open wrote. Shared across a worker because `isolate: false` shares this module.
+const memoryStores = new Map<string, StoreDatabase>()
+
 function restrictPath(path: string, mode: number): void {
   try {
     if ((statSync(path).mode & 0o777) !== mode) chmodSync(path, mode)
@@ -1045,6 +1049,29 @@ export class LocalStore {
       const dir = dirname(source)
       mkdirSync(dir, { recursive: true, mode: 0o700 })
       restrictPath(dir, 0o700)
+      // MEASUREMENT ONLY — not for merge. Same directory work, database in RAM: what this arm
+      // prices is the store's own file I/O and nothing else. Keyed by path so a reopen — the
+      // suite's daemon-restart shape — still finds the rows the first open wrote; a reopen from
+      // another PROCESS does not, which is why this can only ever be a measurement.
+      if (process.env.AGENTCONNECT_TEST_STORE_MEMORY === '1') {
+        let database = memoryStores.get(source)
+        if (database === undefined) {
+          const owned = SqliteAsyncDatabase.adopt(new DatabaseSync(':memory:'))
+          // A suite closes its store and reopens the same path — a daemon restart. The file store
+          // survives that; a closed in-memory one would not, so the handle ignores `close`.
+          database = {
+            exec: (sql) => owned.exec(sql),
+            query: (sql, params) => owned.query(sql, params),
+            batch: (statements) => owned.batch(statements),
+            transaction: (fn) => owned.transaction(fn),
+            close: async () => undefined
+          }
+          memoryStores.set(source, database)
+        }
+        store = new LocalStore(database, { shared: false, ownerId: undefined, orgForAgent: undefined })
+        await store.initializeSchema()
+        return store
+      }
       store = new LocalStore(SqliteAsyncDatabase.open(source), {
         shared: false,
         ownerId: undefined,

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -55,7 +55,9 @@ const dropTranscriptOrg = (db: DatabaseSync): void => {
   `)
 }
 
-describe.skipIf(pg)('LocalStore schema versioning', () => {
+// MEASUREMENT ONLY: these seed an old schema into a FILE and reopen it by path, which the
+// in-memory override cannot represent — they are the cases that genuinely need a file.
+describe.skipIf(pg || process.env.AGENTCONNECT_TEST_STORE_MEMORY === '1')('LocalStore schema versioning', () => {
   const userVersion = (path: string): number => {
     const db = new DatabaseSync(path)
     const v = (db.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
@@ -2505,56 +2507,59 @@ describe('code-host note projection ledger (gitlab-com-integration.md §16)', ()
   })
 })
 
-describe.skipIf(pg)('transcript org migration from a v10 store', () => {
-  const v10Store = async (prefix: string): Promise<string> => {
-    const path = join(mkdtempSync(join(tmpdir(), prefix)), 'local.sqlite')
-    await (await LocalStore.open(path)).close()
-    const old = new DatabaseSync(path)
-    dropTranscriptOrg(old)
-    old.exec(`INSERT INTO transcript (channel, thread, ts, sender, kind, text, recipient, eventTimeUs, revision)
+describe.skipIf(pg || process.env.AGENTCONNECT_TEST_STORE_MEMORY === '1')(
+  'transcript org migration from a v10 store',
+  () => {
+    const v10Store = async (prefix: string): Promise<string> => {
+      const path = join(mkdtempSync(join(tmpdir(), prefix)), 'local.sqlite')
+      await (await LocalStore.open(path)).close()
+      const old = new DatabaseSync(path)
+      dropTranscriptOrg(old)
+      old.exec(`INSERT INTO transcript (channel, thread, ts, sender, kind, text, recipient, eventTimeUs, revision)
       VALUES ('C1', 'T1', '1', 'U', 'text', 'kept', 'agent-a', 1000000, 1)`)
-    old.exec("INSERT INTO transcript_recipient (channel, thread, ts, agentId) VALUES ('C1', 'T1', '1', 'agent-b')")
-    old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
-    old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
-    old.exec('PRAGMA user_version = 10')
-    old.close()
-    return path
-  }
+      old.exec("INSERT INTO transcript_recipient (channel, thread, ts, agentId) VALUES ('C1', 'T1', '1', 'agent-b')")
+      old.exec('ALTER TABLE sessions DROP COLUMN sessionId')
+      old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
+      old.exec('PRAGMA user_version = 10')
+      old.close()
+      return path
+    }
 
-  it('backfills a store no pool shares with its single partition, keeping every row', async () => {
-    const path = await v10Store('ac-transcript-v10-')
-    const upgraded = await LocalStore.open(path)
-    expect((await upgraded.threadTranscript('C1', 'T1')).map((r) => r.text)).toEqual(['kept'])
-    // The delivery table came across too, so the co-hosted recipient still sees the row.
-    expect((await upgraded.transcriptPageForAgent('C1', 'T1', 'agent-b', null, 10)).rows.map((r) => r.text)).toEqual([
-      'kept'
-    ])
-    await upgraded.close()
+    it('backfills a store no pool shares with its single partition, keeping every row', async () => {
+      const path = await v10Store('ac-transcript-v10-')
+      const upgraded = await LocalStore.open(path)
+      expect((await upgraded.threadTranscript('C1', 'T1')).map((r) => r.text)).toEqual(['kept'])
+      // The delivery table came across too, so the co-hosted recipient still sees the row.
+      expect((await upgraded.transcriptPageForAgent('C1', 'T1', 'agent-b', null, 10)).rows.map((r) => r.text)).toEqual([
+        'kept'
+      ])
+      await upgraded.close()
 
-    const after = new DatabaseSync(path)
-    const recipientKey = (
-      after.prepare('PRAGMA table_info(transcript_recipient)').all() as { name: string; pk: number }[]
-    )
-      .filter((column) => column.pk > 0)
-      .sort((first, second) => first.pk - second.pk)
-      .map((column) => column.name)
-    expect(recipientKey).toEqual(['orgId', 'channel', 'thread', 'ts', 'agentId'])
-    after.close()
-  })
-
-  it('drops what a shared store cannot attribute, because no org survives in its rows', async () => {
-    // Nothing here records an agent's org — the daemon learns it from the CP at runtime — so
-    // sessions → agent → org resolves to nothing and a kept row would be readable by whichever
-    // org reused the channel/thread ids.
-    const path = await v10Store('ac-transcript-v10-shared-')
-    const shared = await LocalStore.open({
-      database: SqliteAsyncDatabase.adopt(new DatabaseSync(path)),
-      shared: true,
-      ownerId: 'member-1',
-      orgForAgent: () => 'org-a'
+      const after = new DatabaseSync(path)
+      const recipientKey = (
+        after.prepare('PRAGMA table_info(transcript_recipient)').all() as { name: string; pk: number }[]
+      )
+        .filter((column) => column.pk > 0)
+        .sort((first, second) => first.pk - second.pk)
+        .map((column) => column.name)
+      expect(recipientKey).toEqual(['orgId', 'channel', 'thread', 'ts', 'agentId'])
+      after.close()
     })
-    expect(await shared.threadTranscript('C1', 'T1', 'agent-a')).toEqual([])
-    expect((await shared.transcriptPageForAgent('C1', 'T1', 'agent-b', null, 10)).rows).toEqual([])
-    await shared.close()
-  })
-})
+
+    it('drops what a shared store cannot attribute, because no org survives in its rows', async () => {
+      // Nothing here records an agent's org — the daemon learns it from the CP at runtime — so
+      // sessions → agent → org resolves to nothing and a kept row would be readable by whichever
+      // org reused the channel/thread ids.
+      const path = await v10Store('ac-transcript-v10-shared-')
+      const shared = await LocalStore.open({
+        database: SqliteAsyncDatabase.adopt(new DatabaseSync(path)),
+        shared: true,
+        ownerId: 'member-1',
+        orgForAgent: () => 'org-a'
+      })
+      expect(await shared.threadTranscript('C1', 'T1', 'agent-a')).toEqual([])
+      expect((await shared.transcriptPageForAgent('C1', 'T1', 'agent-b', null, 10)).rows).toEqual([])
+      await shared.close()
+    })
+  }
+)

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -67,6 +67,9 @@ export const BASE_TEST_TIMEOUT = 30_000
 export default defineConfig({
   test: {
     environment: 'node',
+    // MEASUREMENT ONLY — not for merge. Prices the store's own file I/O: same directories, same
+    // fixture files, database in RAM.
+    env: { AGENTCONNECT_TEST_STORE_MEMORY: '1' },
     // Keep process-heavy, integration-shaped unit files from oversubscribing available test-worker
     // resources. Four on Windows too: the halving there bought time for inline per-test budgets that
     // no longer exist, and the polls those budgets never governed now scale in `test/wait-support.ts`.


### PR DESCRIPTION
## Do not merge — this is a measurement

Prices the store's **own file I/O** and nothing else: the same directories are created and restricted, the same fixture files are written, only the database lives in RAM. Keyed by path so a reopen — the suite's daemon-restart shape — still finds what the first open wrote, and the handle ignores `close` so that reopen gets a live connection.

## Local result: it does not pay

| | `tests` total, full suite, same machine |
|---|---|
| file store | 578–606 s |
| **in-memory** | **625.0 s** |

Not faster, and the earlier split already predicted it: the 16 files that open a store directly had fallen to **32 s total** once #1598 removed the schema flush storm and #1618 moved the temp root to the host-local disk. Their ceiling was 8 s.

## It also does not run clean

Nine files fail, **28 cases beyond the four that fail on this machine anyway** — permission bits, cross-process sharing, dialect emulation, and the migration cases that seed an old schema into a file and reopen it by path.

Two of those describes are skipped here; the rest are not. **So the number on this run is a floor, not a figure** — failing cases exit early — and a real version of this change would mean rewriting them.

Pushed to read the Windows number rather than infer it, since every cross-platform inference in this series has been wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
