### PR TITLE
feat(daemon): deliver the drain-cycle narration instead of dropping it

### DIFF
--- a/docs/designs/background-task-aware-reclaim.md
+++ b/docs/designs/background-task-aware-reclaim.md
@@ -158,11 +158,8 @@ Delivery follows these rules:
   (§5.1): the runtime hands the result to the model in that loop, and the
   turn's own chrome already shows the step. Auto-backgrounded commands
   (sleeps, watchers) settle this way every time. Both conditions are required:
-  `running` without a pending dispatch is an invisible self-drain cycle, and a
-  pending dispatch past `idle` is finalization the model has already left. A
-  settle that races the loop's very end may forfeit the runtime's follow-up
-  narration; its MCP side effects still land, and that narrow loss is accepted
-  over announcing every in-turn completion twice.
+  `running` without a pending dispatch is a self-drain cycle (§5.2), and a
+  pending dispatch past `idle` is finalization the model has already left.
 
 The message is daemon-authored system output, not an agent reply, so it has no
 agent-attribution footer. On platforms that mark notices it is posted as
@@ -171,13 +168,11 @@ keeps the bot's own identity, per the conversational-authorship rule — so
 thread backfill skips it instead of re-ingesting it as something the agent
 said.
 
-The runtime's own unsolicited follow-up narration is not routed when no
-foreground turn is pending. This is not a stylistic choice — `onAcpUpdate`
-returns early on `!pending`, so **every** content-bearing update from such a
-cycle (message chunks, tool renders, transcript rows, the webchat sink) is
-discarded. Its MCP tool calls are unaffected: that socket is not `Pending`-gated,
-so side effects a self-drain performs — including a `sendMessage` report — do
-land. §5.1 depends on both halves of this.
+The runtime's own drain-cycle narration is captured and delivered — §5.2. Its
+non-text updates (tool renders, the webchat sink) are still not routed, and
+its MCP tool calls still land: that socket is not `Pending`-gated, so side
+effects a self-drain performs — including a `sendMessage` report — do land.
+§5.1 and §5.2 depend on these halves.
 
 ### 5.1 Waking the session
 
@@ -195,9 +190,12 @@ The daemon therefore delivers it, as a new turn into the same session:
 
 - The turn is `source: "agent"` with sender `background-task:<task_id>`. Its text
   states plainly that it is a daemon notification rather than a message from
-  anyone, names the task id to read output from, says that THIS turn is the one
-  actually delivered, tells the model not to repeat a report it already sent after
-  the task finished, and permits silence when the result needs no action.
+  anyone, names the task id to read output from, carries the runtime's own
+  completion summary when `task_notification` supplied one, and permits silence
+  when the result needs no action. When no drain narration was delivered (§5.2)
+  it says THIS turn is the one actually delivered and asks for the report; when
+  one was, it says that narration WAS delivered and asks only for what is still
+  owed — without that split the model re-says the whole thing or loses half of it.
 - It carries **no** `CallMeta`. It is not an agent call and must not look like
   one. A child woken this way still reaches its parent, because
   `replyToSession` authorizes against the origin persisted on the session
@@ -261,11 +259,12 @@ the host mid-initialization.
 A wake turn that never settles keeps the fence indefinitely; the absolute
 `agentMaxLifetimeMs` ceiling (§4) remains the backstop, as it is for a hung task.
 
-The `running` case is a **wait, not a stand-down**. The self-drain cycle delivers
-nothing (see §5), so treating it as the delivery is what strands the session; the
-wake only defers to it so an injected turn does not race the runtime's own work,
-then delivers regardless. `MAX_BG_TASK_WAKE_REARMS` (15, ≈1 minute) bounds that
-wait so a cycle that never returns to `idle` is not polled forever.
+The `running` case is a **wait, not a stand-down**. A self-drain cycle may
+produce nothing observable (its narration, when any, is delivered by §5.2), so
+treating it as the delivery is what strands the session; the wake only defers to
+it so an injected turn does not race the runtime's own work, then delivers
+regardless. `MAX_BG_TASK_WAKE_REARMS` (15, ≈1 minute) bounds that wait so a
+cycle that never returns to `idle` is not polled forever.
 
 Observed sequence for a `sleep 30` in `run_in_background` (Claude
 claude-agent-acp 0.63.0), which is what this design is calibrated against:
@@ -290,6 +289,39 @@ exhausting it logs a warning and leaves the completion undelivered.
 A wake is **not** gated on output mode. The channel notification in §5 is for the
 human and stays gated at `medium`; the wake is for the model and must happen at
 every output mode, including `low` and `none`.
+
+### 5.2 Delivering the drain narration
+
+When a task settles after the turn, the Claude runtime keeps its own
+"you will be notified" promise in-process: it self-wakes a drain cycle and the
+model narrates the completion there. That cycle has no `Pending`, so its updates
+used to be discarded wholesale — the narration (often the very output the human
+asked for) was lost, and the wake had to ask the model to say everything again,
+which it does only probabilistically.
+
+The daemon now captures that narration. While the lease reads `running` with no
+pending dispatch, `agent_message_chunk` text accumulates on the lease (capped at
+`MAX_DRAIN_TEXT_CHARS`); the `running → idle` edge — or the next real dispatch
+for the session, whichever comes first — delivers it:
+
+- Delivered as **agent speech**, with the agent's conversational identity
+  (name, icon, author id) and a transcript row — not as a chrome notice: the
+  model authored it.
+- The no-response sentinel, a closed session, and `none` output mode keep their
+  usual semantics (sentinel drops; `none` records without posting).
+- Capture is gated on the lease saying `running`, so a straggler chunk after
+  `idle` stays dropped and stale text can never leak into a later flush; a real
+  dispatch claims the buffer synchronously before taking the session over.
+- Deliveries spend the same per-session cap as wakes
+  (`MAX_BG_TASK_WAKES_PER_SESSION`, counted separately), bounding a model that
+  keeps self-continuing by starting new tasks from each drain — a loop the wake
+  budget alone cannot bound, since drains need no wake to keep going.
+- A drain with nowhere to deliver (no platform connection) keeps the old drop
+  and does **not** stamp `drainDeliveredAt`, so the wake still asks for a full
+  report.
+
+The wake stays armed either way (§5.1) — a drain may narrate nothing — and reads
+`drainDeliveredAt` at fire time to pick its wording.
 
 ## 6. Fallback and Runtime Limits
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -14069,12 +14069,35 @@ export class Daemon {
     const rec = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
     if (!rec || rec.state === 'closed') return
     const mode = (await this.store.getOutputModeOverride(rec.key)) ?? this.agents.get(agentId)?.output?.mode ?? 'low'
-    const conn = this.replyConnFor(agentId, this.sessionDeliveryBindings.get(rec.key)?.integrationId)
+    // Resolved against the SESSION's platform (delivery binding first) — never replyConnFor's
+    // any-integration fallback, which hands a webchat/hook/dream session another platform's
+    // client that throws on the session's channel id after having claimed delivery.
+    const integrationId =
+      this.sessionDeliveryBindings.get(rec.key)?.integrationId ??
+      this.integrationIdForTransportScope(agentId, rec.platform, rec.transportScope)
+    const conn = integrationId ? this.connForIntegration(integrationId) : undefined
     // No surface at all ⇒ keep today's drop, and do NOT claim delivery to the wake.
     if (mode !== 'none' && !conn) return
-    lease.drainDeliveries += 1
-    lease.drainDeliveredAt = this.clock.now()
-    // Recorded like a reply row, so the console reads the narration back even in `none` mode.
+    if (mode !== 'none' && conn) {
+      this.log.info(`drain delivery: ${text.length} chars → ${rec.key}`)
+      const agent = this.agents.get(agentId)
+      // The same conversational authorship an agent reply carries (name, icon, author id —
+      // no responseId: authorship only, it closes no response); undefined off Slack.
+      const options = slackAgentPostOptions({
+        platform: rec.platform,
+        agentId,
+        agentName: agent?.displayName?.trim() || agent?.name || agentId,
+        ...(agent?.iconUrl ? { iconUrl: agent.iconUrl } : {})
+      })
+      if (options) {
+        for (const section of splitIntoSections(text))
+          await (conn as SlackConnection).postMessage(rec.channel, section, rec.thread || undefined, options)
+      } else {
+        await conn.postMessage(rec.channel, text, rec.thread || undefined)
+      }
+    }
+    // Claimed only past the post: a throwing post above leaves no stamp, so the wake still
+    // asks for the full report. Recorded like a reply row, so the console reads it back.
     if (rec.thread) {
       await this.store.appendTranscript({
         channel: transcriptChannelKey(rec.channel, rec.transportScope),
@@ -14085,22 +14108,8 @@ export class Daemon {
         text
       })
     }
-    if (mode === 'none' || !conn) return
-    this.log.info(`drain delivery: ${text.length} chars → ${rec.key}`)
-    const agent = this.agents.get(agentId)
-    if (rec.platform === 'slack') {
-      // The same conversational authorship an agent reply carries — name, icon, author id —
-      // so peers and backfill attribute it to the agent, not to the shared bot.
-      const options = {
-        username: agent?.displayName?.trim() || agent?.name || agentId,
-        ...(agent?.iconUrl ? { icon_url: agent.iconUrl } : {}),
-        agentAuthorId: agentId
-      }
-      for (const section of splitIntoSections(text))
-        await (conn as SlackConnection).postMessage(rec.channel, section, rec.thread || undefined, options)
-      return
-    }
-    await conn.postMessage(rec.channel, text, rec.thread || undefined)
+    lease.drainDeliveries += 1
+    lease.drainDeliveredAt = this.clock.now()
   }
 
   /** Arm the deferred wake for a settled background task. Deliberately NOT immediate: the

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -118,6 +118,7 @@ import { TelegramConnection } from './telegram/connection.js'
 import { DiscordConnection } from './discord/connection.js'
 import { FeishuConnection } from './feishu/connection.js'
 import { SlackNameResolver } from './slack/name-resolver.js'
+import { splitIntoSections } from './slack/formatter.js'
 import {
   integrationConfig,
   integrationCore,
@@ -525,6 +526,7 @@ import {
   IDLE_FLUSH_MS,
   MAX_BG_TASK_WAKE_REARMS,
   MAX_BG_TASK_WAKES_PER_SESSION,
+  MAX_DRAIN_TEXT_CHARS,
   MAX_QUEUED_PER_SESSION,
   MAX_SESSION_PURGE_BATCH,
   MAX_SETTLED_TASKS_PER_SESSION,
@@ -773,6 +775,16 @@ export class Daemon {
        *  task's completion: once `host.prompt()` has returned the model is no longer running,
        *  yet the dispatch stays pending through renderer/finalization. */
       deliveringWakes: number
+      /** Narration captured from the CURRENT runtime-initiated cycle (`running` with no
+       *  Pending) instead of being dropped — delivered on the idle edge or ahead of the
+       *  next real dispatch. Capped at {@link MAX_DRAIN_TEXT_CHARS}. */
+      drainText: string
+      /** Clock ms of the last delivered drain narration — the wake reads it to say the
+       *  follow-up WAS delivered instead of asking the model to repeat it. */
+      drainDeliveredAt?: number
+      /** Drain deliveries spent on this session — bounds the model's self-continuation
+       *  loop the way {@link MAX_BG_TASK_WAKES_PER_SESSION} bounds wakes (same cap). */
+      drainDeliveries: number
     }
   >()
   /** Armed background-task wake checks (one per settled non-subagent task), tracked so
@@ -9998,6 +10010,11 @@ export class Daemon {
           }
         : {})
     }
+    // A real turn takes over the session — flush any drain narration first (delivered, not
+    // dropped), so buffered text can neither leak into this turn nor go stale behind it.
+    void this.deliverDrainNarration(agentId, sessionId).catch((err) =>
+      this.log.warn(`drain delivery failed for "${agentId}": ${(err as Error).message}`)
+    )
     this.pending.set(pendingTurnKey(agentId, sessionId), p)
     return p
   }
@@ -12597,7 +12614,18 @@ export class Daemon {
         }
       }
     }
-    if (!p) return
+    if (!p) {
+      // A runtime-initiated cycle (Claude's bg-task self-drain) narrates into a turn nobody
+      // owns. Capture the text instead of dropping it — the idle edge delivers it (§5.2 of
+      // background-task-aware-reclaim.md). Gated on a lease saying `running`: a straggler
+      // chunk after idle stays dropped, so stale text can never leak into a later flush.
+      if (update?.sessionUpdate === 'agent_message_chunk' && update.content?.type === 'text') {
+        const lease = this.sdkLease.get(sdkLeaseKey(agentId, sessionId))
+        if (lease?.sdkState === 'running')
+          lease.drainText = (lease.drainText + String(update.content.text ?? '')).slice(0, MAX_DRAIN_TEXT_CHARS)
+      }
+      return
+    }
     const isAnswerChunk = update?.sessionUpdate === 'agent_message_chunk' && update.content?.type === 'text'
     if (isAnswerChunk) {
       const text = String(update.content.text ?? '')
@@ -13809,6 +13837,7 @@ export class Daemon {
       task_id?: unknown
       subagent_type?: unknown
       description?: unknown
+      summary?: unknown
       patch?: { status?: unknown }
       tasks?: unknown
     } | null
@@ -13832,28 +13861,29 @@ export class Daemon {
       sdkState: 'idle' as const,
       bgWakes: 0,
       armedWakes: 0,
-      deliveringWakes: 0
+      deliveringWakes: 0,
+      drainText: '',
+      drainDeliveries: 0
     }
     // Release a task from the lease and, if it's a real background task (not an
     // internal subagent), announce its completion when the agent is verbose enough
     // and hand the completion back to the model so the work is not stranded.
-    const settle = async (taskId: string, status?: string) => {
+    const settle = async (taskId: string, status?: string, summary?: string) => {
       const rec = lease.tasks.get(taskId)
       if (!rec) {
-        // Already settled: still dedup announce + wake, but let a later terminal edge fill in the
-        // outcome the first one could not carry — the snapshot and task_notification paths supply
-        // no status, so this is how `failed` becomes reachable at all. Display only.
-        if (status) {
-          const prior = lease.settled.find((t) => t.id === taskId) // at most one: retention dedups by id
-          if (prior && !prior.status) prior.status = status
-        }
+        // Already settled: still dedup announce + wake, but let a later terminal edge fill in
+        // what the first one could not carry — the snapshot path supplies no status, so this is
+        // how `failed` and the runtime's summary become reachable at all. Display/wake only.
+        const prior = lease.settled.find((t) => t.id === taskId) // at most one: retention dedups by id
+        if (prior && status && !prior.status) prior.status = status
+        if (prior && summary && !prior.summary) prior.summary = summary
         return
       }
       lease.tasks.delete(taskId) // liveness removal FIRST — see the `tasks` field docblock
       // Retained OUTSIDE the liveness set, and before the subagent bail so the panel's data set
       // equals the set that fences reclaim (subagents are filtered at render, never at the source).
       lease.settled = lease.settled.filter((t) => t.id !== taskId)
-      lease.settled.push({ id: taskId, ...rec, endedAt: this.clock.now(), status })
+      lease.settled.push({ id: taskId, ...rec, endedAt: this.clock.now(), status, ...(summary ? { summary } : {}) })
       if (lease.settled.length > MAX_SETTLED_TASKS_PER_SESSION) lease.settled.shift()
       if (rec.isSubagent) return
       // Settled inside this session's own live foreground loop (running SDK cycle + pending
@@ -13877,7 +13907,16 @@ export class Daemon {
         // Top-level Claude cycle. `idle` alone is NOT an end signal — it fires at
         // end_turn while a background task is still running (verified); the lease's
         // task set closes that gap.
-        if (m.state === 'idle' || m.state === 'running') lease.sdkState = m.state
+        if (m.state === 'idle' || m.state === 'running') {
+          const wasRunning = lease.sdkState === 'running'
+          lease.sdkState = m.state
+          // The cycle ended — deliver whatever a Pending-less drain narrated (no-op after a
+          // real turn, whose chunks were never buffered). Fire-and-forget like the announce.
+          if (m.state === 'idle' && wasRunning)
+            void this.deliverDrainNarration(agentId, acpSessionId).catch((err) =>
+              this.log.warn(`drain delivery failed for "${agentId}": ${(err as Error).message}`)
+            )
+        }
         break
       case 'task_started':
         if (typeof m.task_id === 'string')
@@ -13889,8 +13928,10 @@ export class Daemon {
           })
         break
       case 'task_notification':
-        // The task settled (no status carried) — release + announce as finished.
-        if (typeof m.task_id === 'string') await settle(m.task_id)
+        // The task settled — release + announce as finished, keeping the runtime's own
+        // completion summary for the wake prompt (this edge carries no usable status).
+        if (typeof m.task_id === 'string')
+          await settle(m.task_id, undefined, typeof m.summary === 'string' ? m.summary : undefined)
         break
       case 'task_updated': {
         // The terminal patch is guaranteed per transition even if a task_notification
@@ -14002,6 +14043,64 @@ export class Daemon {
     void Promise.resolve(post).catch((err) =>
       this.log.warn(`bg-task announce failed for "${agentId}": ${(err as Error).message}`)
     )
+  }
+
+  /** Deliver the narration a runtime-initiated drain cycle produced (§5.2 of
+   *  background-task-aware-reclaim.md) — the text the model wrote right after a background
+   *  task finished, which previously had no Pending to ride and was dropped. The buffer is
+   *  claimed synchronously, so the idle-edge and dispatch-time callers can never double-post.
+   *  Agent speech, not a notice: it posts with the agent's conversational identity and lands
+   *  in the transcript. The completion wake stays armed; {@link wakeOnBackgroundTaskDone}
+   *  reads `drainDeliveredAt` to tell the model this narration WAS delivered. */
+  private async deliverDrainNarration(agentId: string, acpSessionId: string): Promise<void> {
+    const lease = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
+    if (!lease?.drainText) return
+    const text = lease.drainText.trim()
+    lease.drainText = ''
+    // The sentinel is a control marker, never chat; past the budget the narration drops as
+    // it always did — the cap is what bounds a model that keeps self-continuing via tasks.
+    if (!text || isNoResponseBody(text)) return
+    if (lease.drainDeliveries >= MAX_BG_TASK_WAKES_PER_SESSION) {
+      this.log.warn(
+        `drain delivery budget exhausted (${MAX_BG_TASK_WAKES_PER_SESSION}) on ${acpSessionId} — narration dropped`
+      )
+      return
+    }
+    const rec = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+    if (!rec || rec.state === 'closed') return
+    const mode = (await this.store.getOutputModeOverride(rec.key)) ?? this.agents.get(agentId)?.output?.mode ?? 'low'
+    const conn = this.replyConnFor(agentId, this.sessionDeliveryBindings.get(rec.key)?.integrationId)
+    // No surface at all ⇒ keep today's drop, and do NOT claim delivery to the wake.
+    if (mode !== 'none' && !conn) return
+    lease.drainDeliveries += 1
+    lease.drainDeliveredAt = this.clock.now()
+    // Recorded like a reply row, so the console reads the narration back even in `none` mode.
+    if (rec.thread) {
+      await this.store.appendTranscript({
+        channel: transcriptChannelKey(rec.channel, rec.transportScope),
+        thread: rec.thread,
+        ts: monotonicTs(),
+        sender: agentId,
+        kind: 'text',
+        text
+      })
+    }
+    if (mode === 'none' || !conn) return
+    this.log.info(`drain delivery: ${text.length} chars → ${rec.key}`)
+    const agent = this.agents.get(agentId)
+    if (rec.platform === 'slack') {
+      // The same conversational authorship an agent reply carries — name, icon, author id —
+      // so peers and backfill attribute it to the agent, not to the shared bot.
+      const options = {
+        username: agent?.displayName?.trim() || agent?.name || agentId,
+        ...(agent?.iconUrl ? { icon_url: agent.iconUrl } : {}),
+        agentAuthorId: agentId
+      }
+      for (const section of splitIntoSections(text))
+        await (conn as SlackConnection).postMessage(rec.channel, section, rec.thread || undefined, options)
+      return
+    }
+    await conn.postMessage(rec.channel, text, rec.thread || undefined)
   }
 
   /** Arm the deferred wake for a settled background task. Deliberately NOT immediate: the
@@ -14148,6 +14247,14 @@ export class Daemon {
     const integrationId = this.integrationIdForSessionTransport(agentId, platform, rec.transportScope)
     if (rec.transportScope && !integrationId) return skip('integration for the session scope is gone')
 
+    // Read at fire time from the settled record, never captured at arm: the runtime's own
+    // completion summary, and whether a drain narration already landed at-or-after this settle
+    // (drains follow settles, so >= only ties on the same clock ms).
+    const settledRec = lease.settled.find((t) => t.id === taskId)
+    const summary = settledRec?.summary?.trim().slice(0, 500)
+    const drainDelivered =
+      settledRec !== undefined && lease.drainDeliveredAt !== undefined && lease.drainDeliveredAt >= settledRec.endedAt
+
     // No CallMeta: this is not an agent call, it carries no hop chain, and it must not look
     // like one. A child woken this way still reaches its parent — `replyToSession` falls back
     // to the origin PERSISTED on the session for exactly this kind of turn (§5.3), and the
@@ -14166,12 +14273,19 @@ export class Daemon {
       sender: { id: `background-task:${taskId}`, isBot: true },
       text:
         `[background task finished] ${what}${status ? ` — ${status}` : ''}\n\n` +
-        `This is a daemon notification, not a message from anyone. A background task you started ` +
-        `settled after your turn had already ended, so nothing you said about it reached anyone. Read its ` +
-        `output now (its task id is \`${taskId}\`) and finish what you were waiting on it for — this turn ` +
-        `is the one that is actually delivered. If you owe a report to another session, send it, unless ` +
-        `you already sent it after the task finished; do not report the same result twice. If the result ` +
-        `needs no action at all, stay silent.`,
+        (summary ? `Task summary: ${summary}\n\n` : '') +
+        (drainDelivered
+          ? `This is a daemon notification, not a message from anyone. A background task you started ` +
+            `settled after your turn had already ended. The follow-up you produced after it finished WAS ` +
+            `delivered to the conversation this time — do not repeat it. Check whether anything is still ` +
+            `owed (unread output — the task id is \`${taskId}\` — or a report to another session not yet ` +
+            `sent) and do only that. If nothing is owed, stay silent.`
+          : `This is a daemon notification, not a message from anyone. A background task you started ` +
+            `settled after your turn had already ended, so nothing you said about it reached anyone. Read its ` +
+            `output now (its task id is \`${taskId}\`) and finish what you were waiting on it for — this turn ` +
+            `is the one that is actually delivered. If you owe a report to another session, send it, unless ` +
+            `you already sent it after the task finished; do not report the same result twice. If the result ` +
+            `needs no action at all, stay silent.`),
       mentionedBots: integrationId && this.botUserIds[integrationId] ? [this.botUserIds[integrationId]!] : [],
       isDm: rec.conversationKind === 'dm',
       ...(rec.conversationKind === 'group_dm' ? { isGroupDm: true } : {})

--- a/packages/daemon/src/daemon/constants.ts
+++ b/packages/daemon/src/daemon/constants.ts
@@ -78,6 +78,9 @@ export const MAX_BG_TASK_WAKE_REARMS = 15
  *  budget is the only backstop against a self-feeding wake loop. Counted over the
  *  lease's life (i.e. until the host is reclaimed), not per turn. */
 export const MAX_BG_TASK_WAKES_PER_SESSION = 20
+/** Cap on buffered self-drain narration per runtime-initiated cycle — bounds memory, and
+ *  splitIntoSections keeps the delivered form readable at this size. */
+export const MAX_DRAIN_TEXT_CHARS = 16_000
 
 /** How many SETTLED background tasks one lease retains for the console's `task/list` read. The
  *  daemon keeps no task history anywhere else, so without this a finished task is unshowable;

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -82,6 +82,9 @@ export interface SettledSdkTask extends LiveSdkTask {
   id: string
   endedAt: number
   status?: string
+  /** The runtime's own completion summary (`task_notification.summary`), when it sent one —
+   *  carried into the wake prompt so the model reports from the result, not from memory. */
+  summary?: string
 }
 
 /**

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -8,7 +8,8 @@ import { Daemon } from '../src/daemon.js'
 import { TaskViolationError } from '../src/cp/task-reader.js'
 import { configFilesDir } from '../src/shim/config-file-env.js'
 import { readSkillLedger, skillLedgerLocation } from '../src/skills/skill-install-ledger.js'
-import { sessionKey } from '../src/store/local-store.js'
+import { sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
+import { NO_RESPONSE_SENTINEL } from '../src/session/no-response.js'
 import { FakeClock } from './cp/fake-clock.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import { WAIT, waitBudget } from './wait-support.js'
@@ -1917,6 +1918,116 @@ describe('Daemon idle sweep — background-task lease', () => {
   // ACP session ids are runtime-local: two agents can each expose `acp-1`. Sharing one lease
   // entry would let one agent's task overwrite the other's record, suppress its completion
   // wake (via `tasks.size`/`sdkState`), or spend its wake budget.
+  // §5.2: the narration a Pending-less runtime drain cycle produces is captured and
+  // delivered as agent speech instead of dropped, and the wake stops asking for a repeat.
+  describe('delivering the drain narration', () => {
+    const chunk = (text: string) => ({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } })
+
+    it('captures a Pending-less running cycle and posts it as agent speech on the idle edge', async () => {
+      const clock = new FakeClock()
+      const { daemon, host, conn } = await bootWithTurn(clock, {
+        agentIdleTimeoutMs: 10_000_000,
+        idleSweepMs: 10_000_000
+      })
+      await (daemon as any).store.setOutputModeOverride(KEY, 'low') // announce off; delivery is not mode-gated
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1' }))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-1', chunk('first sleep '))
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-1', chunk('done'))
+      expect(conn.postMessage).not.toHaveBeenCalled() // buffered, never streamed
+      clock.advance(10)
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+      await vi.waitFor(() => expect(conn.postMessage).toHaveBeenCalledTimes(1), WAIT)
+      const [channel, text, thread, options] = (conn.postMessage as any).mock.calls[0]
+      expect(channel).toBe('C1')
+      expect(text).toBe('first sleep done')
+      expect(thread).toBe('T1')
+      expect(options).toMatchObject({ username: 'bot-a', agentAuthorId: 'bot-a' })
+      // Recorded like a reply row, so the console reads it back.
+      const rows = await (daemon as any).store.transcriptSince(transcriptChannelKey('C1', TRANSPORT_SCOPE), 'T1', null)
+      expect(rows.some((row: any) => row.sender === 'bot-a' && row.text === 'first sleep done')).toBe(true)
+      // The wake still fires, but now says the narration WAS delivered instead of re-asking.
+      clock.advance(4000)
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
+      const woken = JSON.stringify((host.prompt as any).mock.calls[1])
+      expect(woken).toContain('WAS delivered')
+      expect(woken).not.toContain('nothing you said')
+      await daemon.stop()
+    })
+
+    it('drops a straggler chunk that arrives outside a running cycle', async () => {
+      const clock = new FakeClock()
+      const { daemon, conn } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+      await (daemon as any).store.setOutputModeOverride(KEY, 'low')
+      // Lease exists but the cycle is over — a late chunk must not be buffered.
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-1', chunk('stale tail'))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+      await new Promise((r) => setImmediate(r))
+      expect(conn.postMessage).not.toHaveBeenCalled()
+      await daemon.stop()
+    })
+
+    it('a real dispatch claims the buffer and delivers it exactly once', async () => {
+      const clock = new FakeClock()
+      const { daemon, conn } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+      await (daemon as any).store.setOutputModeOverride(KEY, 'low')
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-1', chunk('early words'))
+      await (daemon as any).dispatch('bot-a', dm('200', 'again'), 'int-a')
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+      await new Promise((r) => setImmediate(r))
+      const bodies = (conn.postMessage as any).mock.calls.map((call: any[]) => String(call[1]))
+      expect(bodies.filter((body: string) => body === 'early words')).toHaveLength(1)
+      await daemon.stop()
+    })
+
+    it('holds the no-response sentinel and an exhausted budget silent', async () => {
+      const clock = new FakeClock()
+      const { daemon, conn } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+      await (daemon as any).store.setOutputModeOverride(KEY, 'low')
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-1', chunk(NO_RESPONSE_SENTINEL))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+      await new Promise((r) => setImmediate(r))
+      expect(conn.postMessage).not.toHaveBeenCalled()
+      // Past the budget the narration drops as it always did — the self-continuation bound.
+      const lease = (daemon as any).sdkLease.get(LEASE_KEY)
+      lease.drainDeliveries = 20
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-1', chunk('over budget'))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+      await new Promise((r) => setImmediate(r))
+      expect(conn.postMessage).not.toHaveBeenCalled()
+      await daemon.stop()
+    })
+
+    it('carries the task_notification summary into the wake prompt', async () => {
+      const clock = new FakeClock()
+      const { daemon, host } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+      await (daemon as any).store.setOutputModeOverride(KEY, 'low')
+      await (daemon as any).onSdkLifecycle(
+        'bot-a',
+        'acp-1',
+        evt('task_started', { task_id: 't1', description: 'Sleep 5' })
+      )
+      await (daemon as any).onSdkLifecycle(
+        'bot-a',
+        'acp-1',
+        evt('task_notification', { task_id: 't1', summary: 'slept five seconds, printed done' })
+      )
+      clock.advance(4000)
+      await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
+      const woken = JSON.stringify((host.prompt as any).mock.calls[1])
+      expect(woken).toContain('Task summary: slept five seconds, printed done')
+      expect(woken).toContain('nothing you said') // no drain delivery happened
+      await daemon.stop()
+    })
+  })
+
   it('keys the lease per (agent, ACP session) so two agents sharing an id do not collide', async () => {
     const clock = new FakeClock()
     const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -1985,6 +1985,34 @@ describe('Daemon idle sweep — background-task lease', () => {
       await daemon.stop()
     })
 
+    it('a session whose platform has no integration neither posts nor claims delivery', async () => {
+      const clock = new FakeClock()
+      const { daemon, conn } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+      // A webchat-like session: platform backed by NO integration on this agent. The
+      // any-integration fallback used to hand it the Slack client, which would throw on the
+      // webchat channel id AFTER claiming delivery — the wake then wrongly said "delivered".
+      const webKey = sessionKey('webchat', 'chat-1', '', 'bot-a')
+      await (daemon as any).store.upsertSession({
+        key: webKey,
+        agentId: 'bot-a',
+        platform: 'webchat',
+        channel: 'chat-1',
+        thread: '',
+        acpSessionId: 'acp-w',
+        state: 'idle',
+        lastDeliveredTs: null,
+        updatedAt: clock.now()
+      })
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-w', evt('session_state_changed', { state: 'running' }))
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-w', chunk('webchat drain words'))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-w', evt('session_state_changed', { state: 'idle' }))
+      await new Promise((r) => setImmediate(r))
+      expect(conn.postMessage).not.toHaveBeenCalled() // the Slack conn is NOT this session's surface
+      const lease = (daemon as any).sdkLease.get(JSON.stringify(['bot-a', 'acp-w']))
+      expect(lease?.drainDeliveredAt).toBeUndefined() // and delivery is not claimed to the wake
+      await daemon.stop()
+    })
+
     it('holds the no-response sentinel and an exhausted budget silent', async () => {
       const clock = new FakeClock()
       const { daemon, conn } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })


### PR DESCRIPTION
## Problem

When a background task settles after its turn, the Claude runtime keeps its "you will be notified" promise in-process: it self-wakes a drain cycle and the model narrates the completion there. That cycle has no `Pending`, so **every content update it produced was discarded** — observed live: asked for two timed outputs, the model's drain-cycle "output 1" vanished, and the completion wake's "nothing you said reached anyone" prompt led it to re-send only output 2. The wake redelivery is probabilistic by construction: it asks the model to repeat itself from memory.

## Fix (phase 1: deliver, don't yet skip the wake)

- **Capture**: while the lease reads `running` with no pending dispatch, unsolicited `agent_message_chunk` text accumulates on the lease (capped at 16k). A straggler chunk after `idle` stays dropped, so stale text can never leak into a later flush.
- **Deliver**: on the `running → idle` edge — or at the next real dispatch, which claims the buffer synchronously before taking the session over — the narration posts as **agent speech** (name, icon, `agentAuthorId`) with a transcript row. The no-response sentinel drops; a closed session drops; `none` mode records without posting; a session with no platform connection keeps the old drop and does **not** claim delivery.
- **Bound**: deliveries spend their own counter against the wake cap (`MAX_BG_TASK_WAKES_PER_SESSION`) — a model that keeps self-continuing by starting tasks from each drain needs no wakes, so the wake budget alone cannot bound that loop.
- **Wake wording**: the wake stays armed (a drain may narrate nothing) and reads `drainDeliveredAt` at fire time — when the narration landed it says so and asks only for what is still owed, instead of asking for a full repeat. It also now carries the runtime's own `task_notification.summary` (the field was always there; the "no status carried" comment was wrong), so the fallback report comes from the result, not from memory.

Skipping the wake when a drain delivered is deliberately **not** in this change — it needs the per-settle precision to be validated against real traffic first; with delivery in place the wake degrades to a cheap "anything still owed?" check.

Non-Claude runtimes (no lease), webchat/hook/headless sessions (no platform connection), and adapters that do not forward `session_state_changed` all keep exactly today's behavior. Design doc §5.2 added; §5/§5.1 updated.

## Tests

Five new cases in `daemon-lifecycle.test.ts`: idle-edge delivery with identity + transcript row and the reworded wake; straggler chunks stay dropped; a real dispatch claims the buffer exactly once; sentinel and exhausted budget stay silent; the notification summary reaches the wake prompt. 76/76 in the file; package typecheck/lint/format green; full daemon suite matches the pre-change baseline exactly (the same 13 sandbox-transport failures + 1 real-provider matrix failure + 1 pre-existing error reproduce on clean `main` in this environment — zero new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
