### PR TITLE
measure: price six workers and the recursive agent watcher on Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,10 +238,17 @@ jobs:
   #
   # No `prisma:generate` step: neither package imports the generated client.
   unit-windows:
-    name: Unit Test (Windows)
+    # MEASUREMENT ONLY — not for merge. Three arms, three samples each, one run: the job's `tests`
+    # total swings 1326-1951 s between runs of identical content, so a single pair resolves nothing.
+    name: Unit Test (Windows) ${{ matrix.arm }}-${{ matrix.sample }}
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arm: [baseline, workers6, nowatch]
+        sample: [1, 2, 3]
     # The daemon suite alone runs ~20 min here against ~3 on Linux — Windows filesystem and
     # process-spawn cost, not extra work — so the cap is set well clear of it rather than near it.
     timeout-minutes: 45
@@ -310,6 +317,9 @@ jobs:
           GITHUB_STEP_SUMMARY: ${{ runner.temp }}/windows-unit-test-summary.md
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
+          # MEASUREMENT ONLY. baseline sets neither, so it is the job as it ships.
+          AGENTCONNECT_MEASURE_WORKERS: ${{ matrix.arm == 'workers6' && '6' || '' }}
+          AGENTCONNECT_MEASURE_NO_WATCHER: ${{ matrix.arm == 'nowatch' && '1' || '' }}
         run: pnpm --filter @agentconnect.md/daemon test:unit
       - name: CLI unit tests
         if: ${{ !cancelled() }}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2820,6 +2820,9 @@ export class Daemon {
 
   /** Phase 29 — watch the discoverable agent config tree (not runtime homes/workspaces) and debounce it into reconcile. */
   private watchAgentConfigs(): void {
+    // MEASUREMENT ONLY — not for merge. Prices the recursive watcher: on Windows chokidar walks
+    // the tree and attaches ReadDirectoryChangesW per directory, once per daemon start, ~1005 times.
+    if (process.env.AGENTCONNECT_MEASURE_NO_WATCHER === '1') return
     // Watch the discoverable agent config tree, not runtime homes/workspaces.
     this.watcher = chokidarWatch(this.agentsDir, {
       ignoreInitial: true,

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -70,7 +70,8 @@ export default defineConfig({
     // Keep process-heavy, integration-shaped unit files from oversubscribing available test-worker
     // resources. Four on Windows too: the halving there bought time for inline per-test budgets that
     // no longer exist, and the polls those budgets never governed now scale in `test/wait-support.ts`.
-    maxWorkers: 4,
+    // MEASUREMENT ONLY — not for merge.
+    maxWorkers: Number(process.env.AGENTCONNECT_MEASURE_WORKERS ?? 4),
     // The async store pays a microtask hop per statement; on a loaded CI box the IO-heavy store files
     // drift past vitest's 5 s default without being hung. Windows I/O is slower again by enough that
     // the same files need double the budget.


### PR DESCRIPTION
Three arms, three samples each, one run — the method the earlier matrices used, because this job's `tests` total swings 1326-1951 s between runs of identical content.

| arm | what it changes |
|---|---|
| `baseline` | nothing — the job as it ships |
| `workers6` | `maxWorkers` 4 → 6 |
| `nowatch` | skips the chokidar watcher in `watchAgentConfigs` |

## What is being chased

~1005 daemon starts, each carrying **~601 ms** of Windows excess over Linux — 604 s, 58% of the Windows test phase. Of that, an in-memory store is worth roughly 270 ms per start (measured: 1037 s → 767 s), leaving **~330 ms unaccounted**. The watcher and the gitcred named pipe are what a boot's own log shows; this prices the watcher.

The worker arm rides along because it is one line and has no coverage cost: this work blocks on filesystem metadata, not CPU, and 2 → 4 already bought a 31% fall in wall clock for a 37% rise in summed time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)