### PR TITLE
feat(daemon): stand the wake down for drain-covered settles, retire the completion notice

### DIFF
--- a/docs/designs/background-task-aware-reclaim.md
+++ b/docs/designs/background-task-aware-reclaim.md
@@ -137,46 +137,34 @@ The same pending-turn and live-lease checks protect idle removal of materialized
 config-file secrets. Once the agent is quiet, those files may be removed after
 `configFilesIdleMs` and are materialized again before the next turn.
 
-## 5. Completion Notifications
+## 5. Completion Delivery
 
-When a tracked non-subagent task settles, the daemon may post:
+A settle edge posts nothing to the channel by itself. The completion reaches
+the human through the model's own words — the drain-cycle narration (§5.2)
+when the runtime produced one, or the wake turn's reply (§5.1) when it did
+not. An earlier daemon-authored "🔔 Background task finished" notice was
+retired once both paths existed: every post-turn settle is covered by them,
+and the notice had become a worse restatement of the narration that followed
+it seconds later. A wake-turn model that stays silent is the model judging
+that nothing is owed — the same judgment the no-response sentinel already
+trusts.
 
-```text
-🔔 Background task finished: <description> (<status>)
-```
+One rule gates both paths at the settle edge: a task that settles inside the
+session's own live foreground loop — a `running` SDK cycle with a pending
+dispatch — arms no wake. The runtime hands the result to the model in that
+loop and the turn's own chrome already shows the step; auto-backgrounded
+commands (sleeps, watchers) settle this way every time. Both conditions are
+required: `running` without a pending dispatch is a self-drain cycle (§5.2),
+and a pending dispatch past `idle` is finalization the model has already left.
 
-Delivery follows these rules:
-
-- The effective output mode must be `medium` or `high`.
-- The session must still exist and must not be closed.
-- A usable integration connection must be available.
-- Internal subagents never produce this notification.
-- `task_updated` can supply a terminal status; a completion edge without a
-  status uses the description alone.
-- A task that settles inside the session's own live foreground loop — a
-  `running` SDK cycle with a pending dispatch — is neither announced nor woken
-  (§5.1): the runtime hands the result to the model in that loop, and the
-  turn's own chrome already shows the step. Auto-backgrounded commands
-  (sleeps, watchers) settle this way every time. Both conditions are required:
-  `running` without a pending dispatch is a self-drain cycle (§5.2), and a
-  pending dispatch past `idle` is finalization the model has already left.
-
-The message is daemon-authored system output, not an agent reply, so it has no
-agent-attribution footer. On platforms that mark notices it is posted as
-chrome with the agent's visual identity (name and icon) in channels — a DM
-keeps the bot's own identity, per the conversational-authorship rule — so
-thread backfill skips it instead of re-ingesting it as something the agent
-said.
-
-The runtime's own drain-cycle narration is captured and delivered — §5.2. Its
-non-text updates (tool renders, the webchat sink) are still not routed, and
-its MCP tool calls still land: that socket is not `Pending`-gated, so side
-effects a self-drain performs — including a `sendMessage` report — do land.
-§5.1 and §5.2 depend on these halves.
+A drain cycle's non-text updates (tool renders, the webchat sink) are still
+not routed, and its MCP tool calls still land: that socket is not
+`Pending`-gated, so side effects a self-drain performs — including a
+`sendMessage` report — do land. §5.1 and §5.2 depend on these halves.
 
 ### 5.1 Waking the session
 
-The notification above tells the human. The model needs the completion too.
+The model needs the completion delivered into a turn it can act from.
 
 `run_in_background` promises the model that it "will be notified when the task
 completes" — a **harness** guarantee, not an SDK one. Interactive Claude Code
@@ -191,11 +179,10 @@ The daemon therefore delivers it, as a new turn into the same session:
 - The turn is `source: "agent"` with sender `background-task:<task_id>`. Its text
   states plainly that it is a daemon notification rather than a message from
   anyone, names the task id to read output from, carries the runtime's own
-  completion summary when `task_notification` supplied one, and permits silence
-  when the result needs no action. When no drain narration was delivered (§5.2)
-  it says THIS turn is the one actually delivered and asks for the report; when
-  one was, it says that narration WAS delivered and asks only for what is still
-  owed — without that split the model re-says the whole thing or loses half of it.
+  completion summary when `task_notification` supplied one, says THIS turn is
+  the one actually delivered, and permits silence when the result needs no
+  action. A completion the drain narration already covered never reaches this
+  text — its wake is skipped at fire time (§5.2).
 - It carries **no** `CallMeta`. It is not an agent call and must not look like
   one. A child woken this way still reaches its parent, because
   `replyToSession` authorizes against the origin persisted on the session
@@ -217,6 +204,7 @@ is re-checked when it fires, never captured when it is armed:
 | Another timer still armed   | Several tasks settled on one edge; the last one delivers for all. Skip.                   |
 | `sdkState == "running"`     | The runtime's self-drain cycle is in flight. **Re-arm**, up to `MAX_BG_TASK_WAKE_REARMS`. |
 | `tasks.size > 0`            | Another task is still live; its completion carries the session forward. Skip.             |
+| Drain covered this settle   | `drainDeliveredAt` ≥ this task's settle: the narration already said it (§5.2). Skip.      |
 | Budget exhausted            | Warn and skip (see below).                                                                |
 | A turn is in flight         | **Defer** — retry this attempt once the active dispatch settles.                          |
 | Session missing or not idle | Closed. Skip.                                                                             |
@@ -286,8 +274,7 @@ start further background tasks. `MAX_BG_TASK_WAKES_PER_SESSION` (20, counted ove
 the lease's life) is therefore the only backstop against a self-feeding loop;
 exhausting it logs a warning and leaves the completion undelivered.
 
-A wake is **not** gated on output mode. The channel notification in §5 is for the
-human and stays gated at `medium`; the wake is for the model and must happen at
+A wake is **not** gated on output mode. It is for the model and must happen at
 every output mode, including `low` and `none`.
 
 ### 5.2 Delivering the drain narration
@@ -321,7 +308,10 @@ for the session, whichever comes first — delivers it:
   report.
 
 The wake stays armed either way (§5.1) — a drain may narrate nothing — and reads
-`drainDeliveredAt` at fire time to pick its wording.
+`drainDeliveredAt` at fire time: a wake whose settle the narration already
+covered (delivered at-or-after that settle) is skipped, saving the model round
+trip and the extra turn chrome; a drain that narrated nothing leaves the wake
+to deliver as before.
 
 ## 6. Fallback and Runtime Limits
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -779,8 +779,8 @@ export class Daemon {
        *  Pending) instead of being dropped — delivered on the idle edge or ahead of the
        *  next real dispatch. Capped at {@link MAX_DRAIN_TEXT_CHARS}. */
       drainText: string
-      /** Clock ms of the last delivered drain narration — the wake reads it to say the
-       *  follow-up WAS delivered instead of asking the model to repeat it. */
+      /** Clock ms of the last delivered drain narration — the wake reads it at fire time
+       *  and stands down for the completions the narration already covered. */
       drainDeliveredAt?: number
       /** Drain deliveries spent on this session — bounds the model's self-continuation
        *  loop the way {@link MAX_BG_TASK_WAKES_PER_SESSION} bounds wakes (same cap). */
@@ -13866,8 +13866,8 @@ export class Daemon {
       drainDeliveries: 0
     }
     // Release a task from the lease and, if it's a real background task (not an
-    // internal subagent), announce its completion when the agent is verbose enough
-    // and hand the completion back to the model so the work is not stranded.
+    // internal subagent), hand the completion back to the model so the work is not
+    // stranded; §5.2's drain narration is what reaches the human.
     const settle = async (taskId: string, status?: string, summary?: string) => {
       const rec = lease.tasks.get(taskId)
       if (!rec) {
@@ -13888,18 +13888,17 @@ export class Daemon {
       if (rec.isSubagent) return
       // Settled inside this session's own live foreground loop (running SDK cycle + pending
       // dispatch): the runtime hands the result to the model in that loop and the turn's chrome
-      // already shows the step, so the announce would say it twice and the wake would burn a
-      // turn re-delivering it — auto-backgrounded commands (sleeps, watchers) settle here every
-      // time. Both conditions are required: `running` without a Pending is an invisible
-      // self-drain cycle, and a Pending past `idle` is finalization the model has already left.
+      // already shows the step, so a wake would burn a turn re-delivering it — auto-backgrounded
+      // commands (sleeps, watchers) settle here every time. Both conditions are required:
+      // `running` without a Pending is a self-drain cycle (§5.2 delivers its narration), and a
+      // Pending past `idle` is finalization the model has already left.
       if (lease.sdkState === 'running' && this.pending.has(pendingTurnKey(agentId, acpSessionId))) {
         this.log.debug(
-          `bg-task delivery skipped (settled inside the live foreground turn): ` +
+          `bg-task wake skipped (settled inside the live foreground turn): ` +
             `"${rec.description?.trim() || 'background task'}" on ${acpSessionId}`
         )
         return
       }
-      await this.announceBackgroundTaskDone(agentId, acpSessionId, rec.description, status)
       this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, rec.description, status)
     }
     switch (m.subtype) {
@@ -14009,49 +14008,13 @@ export class Daemon {
     }
   }
 
-  /** Proactively announce a completed background task to its session's channel/thread
-   *  (a system notice, like the gating notice — not an agent response, so no attribution
-   *  footer). Chrome-marked with the agent's identity where the platform supports it, so
-   *  thread backfill never re-ingests it as something the agent said. Gated on output mode
-   *  ≥ medium; skipped for closed sessions, missing bindings, or sessions with no lease. */
-  private async announceBackgroundTaskDone(
-    agentId: string,
-    acpSessionId: string,
-    description?: string,
-    status?: string
-  ): Promise<void> {
-    const rec = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
-    if (!rec || rec.state === 'closed') return
-    const mode = (await this.store.getOutputModeOverride(rec.key)) ?? this.agents.get(agentId)?.output?.mode ?? 'low'
-    const rank = { none: -1, minimal: 0, low: 1, medium: 2, high: 3 }
-    if ((rank[mode] ?? 0) < rank.medium) return
-    const conn = this.replyConnFor(agentId, this.sessionDeliveryBindings.get(rec.key)?.integrationId)
-    if (!conn) return
-    const what = description?.trim() || 'background task'
-    const text = `🔔 Background task finished: ${what}${status ? ` (${status})` : ''}`
-    const agent = this.agents.get(agentId)
-    const post = turnChromeFor(rec.platform).chromeMarkedNotices
-      ? (conn as SlackConnection).postMessage(rec.channel, text, rec.thread || undefined, {
-          ...(slackAgentIdentityOptions({
-            platform: rec.platform,
-            agentName: agent?.displayName?.trim() || agent?.name || agentId,
-            ...(agent?.iconUrl ? { iconUrl: agent.iconUrl } : {})
-          }) ?? {}),
-          chrome: true
-        })
-      : conn.postMessage(rec.channel, text, rec.thread || undefined)
-    void Promise.resolve(post).catch((err) =>
-      this.log.warn(`bg-task announce failed for "${agentId}": ${(err as Error).message}`)
-    )
-  }
-
   /** Deliver the narration a runtime-initiated drain cycle produced (§5.2 of
    *  background-task-aware-reclaim.md) — the text the model wrote right after a background
    *  task finished, which previously had no Pending to ride and was dropped. The buffer is
    *  claimed synchronously, so the idle-edge and dispatch-time callers can never double-post.
    *  Agent speech, not a notice: it posts with the agent's conversational identity and lands
-   *  in the transcript. The completion wake stays armed; {@link wakeOnBackgroundTaskDone}
-   *  reads `drainDeliveredAt` to tell the model this narration WAS delivered. */
+   *  in the transcript. {@link wakeOnBackgroundTaskDone} reads `drainDeliveredAt` at fire
+   *  time and stands down for the completions this narration already covered. */
   private async deliverDrainNarration(agentId: string, acpSessionId: string): Promise<void> {
     const lease = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
     if (!lease?.drainText) return
@@ -14218,6 +14181,14 @@ export class Daemon {
       return skip(`runtime cycle still running, re-armed ${attempt + 1}/${MAX_BG_TASK_WAKE_REARMS}`)
     }
     if (lease.tasks.size > 0) return skip('other background tasks still live')
+    // Per-settle precision, read at fire time: a drain narration delivered at-or-after this
+    // settle already carried the completion to the conversation (drains follow settles, so >=
+    // only ties on the same clock ms). Waking anyway would burn a turn asking the model to
+    // confirm what it just said. A drain that narrated nothing stamps nothing and the wake
+    // delivers as before.
+    const settledRec = lease.settled.find((t) => t.id === taskId)
+    if (settledRec && lease.drainDeliveredAt !== undefined && lease.drainDeliveredAt >= settledRec.endedAt)
+      return skip('drain narration already delivered this completion')
     if (lease.bgWakes >= MAX_BG_TASK_WAKES_PER_SESSION) {
       release()
       this.log.warn(
@@ -14256,13 +14227,8 @@ export class Daemon {
     const integrationId = this.integrationIdForSessionTransport(agentId, platform, rec.transportScope)
     if (rec.transportScope && !integrationId) return skip('integration for the session scope is gone')
 
-    // Read at fire time from the settled record, never captured at arm: the runtime's own
-    // completion summary, and whether a drain narration already landed at-or-after this settle
-    // (drains follow settles, so >= only ties on the same clock ms).
-    const settledRec = lease.settled.find((t) => t.id === taskId)
+    // The runtime's own completion summary, so the report comes from the result, not memory.
     const summary = settledRec?.summary?.trim().slice(0, 500)
-    const drainDelivered =
-      settledRec !== undefined && lease.drainDeliveredAt !== undefined && lease.drainDeliveredAt >= settledRec.endedAt
 
     // No CallMeta: this is not an agent call, it carries no hop chain, and it must not look
     // like one. A child woken this way still reaches its parent — `replyToSession` falls back
@@ -14283,18 +14249,12 @@ export class Daemon {
       text:
         `[background task finished] ${what}${status ? ` — ${status}` : ''}\n\n` +
         (summary ? `Task summary: ${summary}\n\n` : '') +
-        (drainDelivered
-          ? `This is a daemon notification, not a message from anyone. A background task you started ` +
-            `settled after your turn had already ended. The follow-up you produced after it finished WAS ` +
-            `delivered to the conversation this time — do not repeat it. Check whether anything is still ` +
-            `owed (unread output — the task id is \`${taskId}\` — or a report to another session not yet ` +
-            `sent) and do only that. If nothing is owed, stay silent.`
-          : `This is a daemon notification, not a message from anyone. A background task you started ` +
-            `settled after your turn had already ended, so nothing you said about it reached anyone. Read its ` +
-            `output now (its task id is \`${taskId}\`) and finish what you were waiting on it for — this turn ` +
-            `is the one that is actually delivered. If you owe a report to another session, send it, unless ` +
-            `you already sent it after the task finished; do not report the same result twice. If the result ` +
-            `needs no action at all, stay silent.`),
+        `This is a daemon notification, not a message from anyone. A background task you started ` +
+        `settled after your turn had already ended, so nothing you said about it reached anyone. Read its ` +
+        `output now (its task id is \`${taskId}\`) and finish what you were waiting on it for — this turn ` +
+        `is the one that is actually delivered. If you owe a report to another session, send it, unless ` +
+        `you already sent it after the task finished; do not report the same result twice. If the result ` +
+        `needs no action at all, stay silent.`,
       mentionedBots: integrationId && this.botUserIds[integrationId] ? [this.botUserIds[integrationId]!] : [],
       isDm: rec.conversationKind === 'dm',
       ...(rec.conversationKind === 'group_dm' ? { isGroupDm: true } : {})

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -1544,40 +1544,28 @@ describe('Daemon idle sweep — background-task lease', () => {
     await daemon.stop()
   })
 
-  it('announces a completed background task to the thread when output mode ≥ medium', async () => {
+  // A settle posts NOTHING of its own: the human-visible signal is the drain narration
+  // (§5.2) or the wake turn's reply, so a settle edge must not touch the channel directly.
+  it('a post-turn settle posts nothing to the channel by itself', async () => {
     const clock = new FakeClock()
     const { daemon, conn } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
-    await (daemon as any).store.setOutputModeOverride(KEY, 'medium')
-
+    await (daemon as any).store.setOutputModeOverride(KEY, 'high')
     await (daemon as any).onSdkLifecycle(
       'bot-a',
       'acp-1',
       evt('task_started', { task_id: 't1', description: 'Sleep for 15 seconds' })
     )
-    expect(conn.postMessage).not.toHaveBeenCalled() // nothing on start
     await (daemon as any).onSdkLifecycle(
       'bot-a',
       'acp-1',
       evt('task_updated', { task_id: 't1', patch: { status: 'completed' } })
     )
-
-    expect(conn.postMessage).toHaveBeenCalledTimes(1)
-    const [channel, text, thread, options] = (conn.postMessage as any).mock.calls[0]
-    expect(channel).toBe('C1')
-    expect(thread).toBe('T1')
-    expect(text).toContain('Sleep for 15 seconds')
-    expect(text).toContain('completed')
-    // Chrome-marked so thread backfill never re-ingests the notice as agent speech, and
-    // carrying the ONE identity policy — the agent's name on every surface, DMs included.
-    expect(options).toMatchObject({ chrome: true, username: 'bot-a' })
-
-    // The near-simultaneous task_notification for the same task must NOT double-post.
-    await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
-    expect(conn.postMessage).toHaveBeenCalledTimes(1)
+    expect(conn.postMessage).not.toHaveBeenCalled()
+    expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(1) // the wake carries it instead
     await daemon.stop()
   })
 
-  it('neither announces nor wakes a task that settles inside a live foreground turn', async () => {
+  it('does not wake a task that settles inside a live foreground turn', async () => {
     const clock = new FakeClock()
     const { host, release } = blockingHost()
     const daemon = new Daemon({
@@ -1605,10 +1593,10 @@ describe('Daemon idle sweep — background-task lease', () => {
       evt('task_updated', { task_id: 't1', patch: { status: 'completed' } })
     )
 
-    expect(JSON.stringify((conn.postMessage as any).mock.calls)).not.toContain('Background task finished')
+    expect(conn.postMessage).not.toHaveBeenCalled()
     expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes).toBe(0)
     expect((daemon as any).bgWakeTimers.size).toBe(0)
-    // Still retained for the tasks panel — only the delivery is skipped.
+    // Still retained for the tasks panel — only the wake is skipped.
     expect((daemon as any).sdkLease.get(LEASE_KEY)?.settled?.length).toBe(1)
 
     await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
@@ -1617,36 +1605,6 @@ describe('Daemon idle sweep — background-task lease', () => {
     clock.advance(10_000)
     await new Promise((r) => setImmediate(r))
     expect(host.prompt).toHaveBeenCalledTimes(1) // no wake turn either
-    await daemon.stop()
-  })
-
-  it('does not announce when output mode is below medium', async () => {
-    const clock = new FakeClock()
-    const { daemon, conn } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
-    await (daemon as any).store.setOutputModeOverride(KEY, 'low')
-
-    await (daemon as any).onSdkLifecycle(
-      'bot-a',
-      'acp-1',
-      evt('task_started', { task_id: 't1', description: 'Sleep for 15 seconds' })
-    )
-    await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
-    expect(conn.postMessage).not.toHaveBeenCalled()
-    await daemon.stop()
-  })
-
-  it('does not announce an internal subagent task', async () => {
-    const clock = new FakeClock()
-    const { daemon, conn } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
-    await (daemon as any).store.setOutputModeOverride(KEY, 'high')
-
-    await (daemon as any).onSdkLifecycle(
-      'bot-a',
-      'acp-1',
-      evt('task_started', { task_id: 's1', subagent_type: 'general', description: 'a subagent' })
-    )
-    await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 's1' }))
-    expect(conn.postMessage).not.toHaveBeenCalled() // subagents are internal — not announced
     await daemon.stop()
   })
 
@@ -1947,12 +1905,38 @@ describe('Daemon idle sweep — background-task lease', () => {
       // Recorded like a reply row, so the console reads it back.
       const rows = await (daemon as any).store.transcriptSince(transcriptChannelKey('C1', TRANSPORT_SCOPE), 'T1', null)
       expect(rows.some((row: any) => row.sender === 'bot-a' && row.text === 'first sleep done')).toBe(true)
-      // The wake still fires, but now says the narration WAS delivered instead of re-asking.
+      // The narration covered this settle, so the wake stands down entirely — no extra turn,
+      // and the fence slot is released so the session can quiesce.
       clock.advance(4000)
+      await vi.waitFor(() => expect((daemon as any).sdkLease.get(LEASE_KEY)?.armedWakes ?? 0).toBe(0), WAIT)
+      expect(host.prompt).toHaveBeenCalledTimes(1)
+      await daemon.stop()
+    })
+
+    it('a settle AFTER the drain delivery still wakes — per-settle precision, not a latch', async () => {
+      const clock = new FakeClock()
+      const { daemon, host, conn } = await bootWithTurn(clock, {
+        agentIdleTimeoutMs: 10_000_000,
+        idleSweepMs: 10_000_000
+      })
+      await (daemon as any).store.setOutputModeOverride(KEY, 'low')
+      // t1 settles and its drain narrates — covered, no wake.
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't1' }))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-1', chunk('t1 result said here'))
+      clock.advance(10)
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+      await vi.waitFor(() => expect(conn.postMessage).toHaveBeenCalledTimes(1), WAIT)
+      // t2 settles later and its drain narrates NOTHING — the old delivery must not cover it.
+      clock.advance(2000)
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_started', { task_id: 't2' }))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't2' }))
+      clock.advance(8000)
       await vi.waitFor(() => expect(host.prompt).toHaveBeenCalledTimes(2), WAIT)
       const woken = JSON.stringify((host.prompt as any).mock.calls[1])
-      expect(woken).toContain('WAS delivered')
-      expect(woken).not.toContain('nothing you said')
+      expect(woken).toContain('nothing you said')
+      expect(woken).toContain('t2')
       await daemon.stop()
     })
 
@@ -2082,8 +2066,8 @@ describe('Daemon idle sweep — background-task lease', () => {
 
   // `task/list` needs settled tasks to exist at all, and the ONLY safe place to keep them is
   // outside `lease.tasks`: every reclaim decision reads that map as the liveness set. These four
-  // cases pin that the retained record is inert — it neither announces, nor wakes, nor spends the
-  // wake budget, nor keeps a session or a host or a workspace mutation fenced.
+  // cases pin that the retained record is inert — it neither wakes, nor spends the wake budget,
+  // nor keeps a session or a host or a workspace mutation fenced.
   it('retains a settled task for the panel while keeping it out of every liveness read', async () => {
     const clock = new FakeClock()
     const { daemon, host, conn } = await bootWithTurn(clock, {
@@ -2093,8 +2077,6 @@ describe('Daemon idle sweep — background-task lease', () => {
     })
     await (daemon as any).store.setOutputModeOverride(KEY, 'medium')
     const lease = () => (daemon as any).sdkLease.get(LEASE_KEY)
-    const announces = () =>
-      (conn.postMessage as any).mock.calls.filter((call: any[]) => String(call[1]).includes('Sleep 15')).length
 
     await (daemon as any).onSdkLifecycle(
       'bot-a',
@@ -2108,7 +2090,7 @@ describe('Daemon idle sweep — background-task lease', () => {
     await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('task_notification', { task_id: 't1' }))
     expect(lease().tasks.size).toBe(0)
     expect(lease().settled.map((t: any) => t.id)).toEqual(['t1'])
-    expect(announces()).toBe(1)
+    expect(conn.postMessage).not.toHaveBeenCalled() // a settle posts nothing of its own
 
     // Its wake delivers once; the fence clears with the retained record still in place.
     clock.advance(4000)
@@ -2116,11 +2098,11 @@ describe('Daemon idle sweep — background-task lease', () => {
     expect(lease().bgWakes).toBe(1)
 
     // The next authoritative snapshot no longer lists it. Re-settling a retained record is what
-    // would re-announce, re-wake, and burn the 20-wake budget on EVERY subsequent snapshot.
+    // would re-wake and burn the 20-wake budget on EVERY subsequent snapshot.
     await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('background_tasks_changed', { tasks: [] }))
     expect(lease().bgWakes).toBe(1)
     expect(wakeFenceHeld(daemon)).toBe(false)
-    expect(announces()).toBe(1)
+    expect(conn.postMessage).not.toHaveBeenCalled()
     expect(lease().settled).toHaveLength(1)
 
     // Quiescent WITH the record retained, so the session TTL-closes and the host is reclaimed.
@@ -2204,7 +2186,7 @@ describe('Daemon idle sweep — background-task lease', () => {
     const clock = new FakeClock()
     const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
     const list = async () => await (daemon as any).listBackgroundTasks({ agentId: 'bot-a', sessionId: 'acp-1' })
-    // Subagent tasks, so the sweep of settles below neither announces nor wakes — they are retained
+    // Subagent tasks, so the sweep of settles below never wakes — they are retained
     // and counted as live exactly like any other task, which is the point.
     const ids = Array.from({ length: MAX_TASK_LIST_TASKS + 1 }, (_unused, i) => `t${i}`)
     for (const id of ids) {


### PR DESCRIPTION
## Context

Phase 2 of the drain-narration work, after live validation of the delivery path. With the narration delivered (and the wake as its fallback), a post-turn settle currently produces THREE voices for one completion: the daemon's "🔔 Background task finished" notice, the model's own narration saying the same thing better seconds later, and a wake turn burning a model round trip to confirm what was just said.

## Changes

**Wake stands down for drain-covered settles.** `wakeOnBackgroundTaskDone` reads `drainDeliveredAt` at fire time and skips any settle the narration already covered — per-settle precision (delivered at-or-after that settle's edge), so a later settle whose drain narrated nothing still wakes with the full prompt (which keeps the `task_notification` summary it gained). The now-unreachable "WAS delivered" prompt variant is deleted; the skip releases the fence slot like every other exit, so quiescence is unaffected.

**The daemon-authored notice is retired.** A settle edge now posts nothing to the channel by itself: the completion reaches the human through the model's own words — the drain narration, or the wake turn's reply. A wake-turn model that stays silent is the model judging nothing is owed, the same judgment the no-response sentinel already trusts. Design doc §5 renamed to "Completion Delivery" and records the reasoning; the fire-time table gains the drain-covered row.

Net: the validated background scenario goes from notice + narration + wake-turn chrome down to the narration alone — one voice, one model round trip saved per completion.

## Tests

- New: a drain-covered settle skips the wake entirely (no extra turn, fence released).
- New: per-settle precision — an earlier drain delivery does not cover a later settle; that wake fires with the full prompt.
- Reworked: "a post-turn settle posts nothing to the channel by itself" replaces the three notice tests (deleted per the no-legacy-assertions rule); the settled-record inertness test now pins zero direct posts.
- `daemon-lifecycle.test.ts` 76/76; package typecheck/lint/format green; full daemon suite identical to the pre-change baseline (the same 13 sandbox-transport failures + 1 real-provider matrix failure + 1 pre-existing error, all reproduced on clean `main` in this environment) — zero new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
