### PR TITLE
measure: four samples each at four and six workers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,10 +238,18 @@ jobs:
   #
   # No `prisma:generate` step: neither package imports the generated client.
   unit-windows:
-    name: Unit Test (Windows)
+    # MEASUREMENT ONLY — not for merge. Four samples per arm: the question is not the mean, which
+    # already looked like -19%, but whether six workers on four vCPUs reproduce the one failure the
+    # last matrix saw — 1590 s of summed test time against a 873 s baseline, contention losing control.
+    name: Unit Test (Windows) w${{ matrix.workers }}-${{ matrix.sample }}
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        workers: [4, 6]
+        sample: [1, 2, 3, 4]
     # The daemon suite alone runs ~20 min here against ~3 on Linux — Windows filesystem and
     # process-spawn cost, not extra work — so the cap is set well clear of it rather than near it.
     timeout-minutes: 45
@@ -310,6 +318,7 @@ jobs:
           GITHUB_STEP_SUMMARY: ${{ runner.temp }}/windows-unit-test-summary.md
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
+          AGENTCONNECT_MEASURE_WORKERS: ${{ matrix.workers }}
         run: pnpm --filter @agentconnect.md/daemon test:unit
       - name: CLI unit tests
         if: ${{ !cancelled() }}

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -70,7 +70,8 @@ export default defineConfig({
     // Keep process-heavy, integration-shaped unit files from oversubscribing available test-worker
     // resources. Four on Windows too: the halving there bought time for inline per-test budgets that
     // no longer exist, and the polls those budgets never governed now scale in `test/wait-support.ts`.
-    maxWorkers: 4,
+    // MEASUREMENT ONLY — not for merge.
+    maxWorkers: Number(process.env.AGENTCONNECT_MEASURE_WORKERS ?? 4),
     // The async store pays a microtask hop per statement; on a loaded CI box the IO-heavy store files
     // drift past vitest's 5 s default without being hung. Windows I/O is slower again by enough that
     // the same files need double the budget.


### PR DESCRIPTION
## Do not merge — this is a measurement

The [last matrix](https://github.com/agentconnect-md/agentconnect/pull/1624) put six workers at **258 / 193 / 302 s** of daemon-step wall against a baseline of **312 / 306 / 311** — roughly −19% on the mean — but **one of the three failed**, with 1590 s of summed test time against the baseline's 873. That is contention losing control, and it is the same failure mode that made this job drop to two workers in the first place.

**The mean is not the question; whether that failure reproduces is.** Four samples per arm, both arms in one run, `maxWorkers` the only difference.

- Reproduces → six is out, and the −19% goes with it.
- Four clean runs → it is one constant with **no coverage cost at all**, the only remaining lever with that property.

The runner has four vCPUs, but this work blocks on filesystem metadata rather than the CPU: 2 → 4 already traded a 37% rise in summed test time for a 31% fall in wall clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)