### PR TITLE
fix(daemon): migrate the attribution footer onto the drain narration

### DIFF
--- a/docs/designs/background-task-aware-reclaim.md
+++ b/docs/designs/background-task-aware-reclaim.md
@@ -294,6 +294,14 @@ for the session, whichever comes first — delivers it:
 - Delivered as **agent speech**, with the agent's conversational identity
   (name, icon, author id) and a transcript row — not as a chrome notice: the
   model authored it.
+- The attribution footer **migrates** onto the narration's last section, the
+  way it migrates onto each new in-turn reply section: turn teardown records
+  the footer-carrying reply (with the §5.5 closure metadata a clearing edit
+  must re-supply — chat.update replaces it wholesale), the narration posts
+  born-with-footer, and the previous holder is edited footer-less,
+  best-effort. A turn that left no footer clears the record instead, so a
+  drain never steals an older response's footer; a daemon restart in between
+  loses the record and the old footer simply stays put.
 - The no-response sentinel, a closed session, and `none` output mode keep their
   usual semantics (sentinel drops; `none` records without posting).
 - Capture is gated on the lease saying `running`, so a straggler chunk after

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -791,6 +791,21 @@ export class Daemon {
    *  daemon drain cannot leave a timer behind. The callback re-validates everything it
    *  needs, so a lease dropped by stopHost simply makes the wake a no-op. */
   private bgWakeTimers = new Set<TimerHandle>()
+  /** Per-session footer holder — the reply the attribution footer currently sits on,
+   *  captured at turn teardown so a drain narration (§5.2) can migrate the footer onto
+   *  itself the way an in-turn reply section does. `closure` re-supplies the §5.5 response
+   *  metadata a clearing edit must not drop (chat.update replaces it wholesale); absent ⇒
+   *  an authorship-only re-stamp suffices. In-memory on purpose: a restart loses it and
+   *  the old footer simply stays put — a cosmetic, not a correctness, loss. */
+  private lastFooterReply = new Map<
+    string,
+    {
+      channel: string
+      ts: string
+      text: string
+      closure?: { responseId: string; hopCount: number; mentionedAgentIds: string[]; addressedAnyone: boolean }
+    }
+  >()
   // §7.5 platform connection lifecycle: pools, openers, the prune pass and the Slack startup retries.
   private readonly connections: ConnectionReconciler
   /**
@@ -11166,6 +11181,7 @@ export class Daemon {
     // fence, so release them only after the exact selected cleanup.
     const cleanupOutcome = await this.waitForTurnLifecycleCleanup(entry, key, p.selectedHost)
     if (!cleanupOutcome.blocked) {
+      this.recordFooterHolder(p)
       this.pending.delete(pendingTurnKey(agentId, sessionId))
       // §7.3 prompting/cancelling → idle: the turn is over (cleanly, on error, or
       // cancelled), so the session is idle again. Without this the row stayed
@@ -11623,6 +11639,8 @@ export class Daemon {
       prepared?.mentionedAgentIds ??
       resolveSlackMentionedAgents(p.reply.text, mentionDir).filter((id) => id !== p.plan.agentId)
     const addressedAnyone = prepared?.addressedAnyone ?? slackTextAddressesAnyone(p.reply.text)
+    // Recorded for §5.2's footer migration, which must re-supply this closure on any later edit.
+    p.reply.closedRouting = { mentionedAgentIds: recipients, addressedAnyone }
     // What this response RESOLVED to, at the one place the author still knows it.
     // Everything downstream (relay arbitration, the target's ladder) sees only the
     // outcome, so without this a response that addressed a peer but resolved to no
@@ -14053,8 +14071,27 @@ export class Daemon {
         ...(agent?.iconUrl ? { iconUrl: agent.iconUrl } : {})
       })
       if (options) {
-        for (const section of splitIntoSections(text))
-          await (conn as SlackConnection).postMessage(rec.channel, section, rec.thread || undefined, options)
+        // Footer migration: the narration is the response's newest words, so its last section
+        // is born with the attribution footer and the previous holder's footer is cleared —
+        // exactly what a new in-turn reply section does, carried over the turn boundary.
+        const footer = await this.drainAttributionBlocks(agentId, rec, integrationId)
+        const previous = footer ? this.lastFooterReply.get(rec.key) : undefined
+        const sections = splitIntoSections(text)
+        let lastTs: string | undefined
+        for (const [i, section] of sections.entries()) {
+          lastTs = await (conn as SlackConnection).postMessage(rec.channel, section, rec.thread || undefined, {
+            ...options,
+            ...(footer && i === sections.length - 1 ? { trailingBlocks: footer.blocks } : {})
+          })
+        }
+        if (footer) {
+          await this.clearMigratedFooter(conn as SlackConnection, agentId, previous)
+          // Track the new holder so a follow-up drain can migrate again; an unknown ts
+          // (a connection that returns none) drops the entry rather than mistracking.
+          if (lastTs)
+            this.lastFooterReply.set(rec.key, { channel: rec.channel, ts: lastTs, text: sections.at(-1) ?? text })
+          else this.lastFooterReply.delete(rec.key)
+        }
       } else {
         await conn.postMessage(rec.channel, text, rec.thread || undefined)
       }
@@ -14073,6 +14110,90 @@ export class Daemon {
     }
     lease.drainDeliveries += 1
     lease.drainDeliveredAt = this.clock.now()
+  }
+
+  /** Capture the turn's footer-carrying reply at teardown (§5.2 footer migration). Slack-only
+   *  by construction — `footerKey` is set by the Slack applier. A turn whose reply carried no
+   *  footer CLEARS the entry: the previous response's footer belongs to that response forever,
+   *  and a drain continuing THIS turn must not steal it. */
+  private recordFooterHolder(p: Pending): void {
+    const lastReply = p.reply.lastReply
+    if (!lastReply?.footerKey) {
+      this.lastFooterReply.delete(p.plan.sessionKey)
+      return
+    }
+    const routing = p.reply.closedRouting ?? p.reply.finalRouting
+    const closed = p.reply.responseId !== '' && p.reply.lastResponse?.ts === lastReply.ts
+    this.lastFooterReply.set(p.plan.sessionKey, {
+      channel: p.plan.channel,
+      ts: lastReply.ts,
+      text: lastReply.text,
+      ...(closed
+        ? {
+            closure: {
+              responseId: p.reply.responseId,
+              hopCount: p.plan.sourceHopCount ?? 0,
+              mentionedAgentIds: routing?.mentionedAgentIds ?? [],
+              addressedAnyone: routing?.addressedAnyone ?? false
+            }
+          }
+        : {})
+    })
+  }
+
+  /** Attribution footer for a drain narration — the turn builder without a Pending: agent
+   *  identity, runtime display name, the session's last observed model, and the console
+   *  session link. Undefined when footers are off for the agent or absent on the platform. */
+  private async drainAttributionBlocks(
+    agentId: string,
+    rec: SessionRecord,
+    integrationId: string | undefined
+  ): Promise<{ text: string; blocks: unknown[] } | undefined> {
+    const agent = this.agents.get(agentId)
+    if (!agent || !agent.output.showFooter || !turnChromeFor(rec.platform).attributionFooter) return undefined
+    return buildAttributionBlocks({
+      botName: agent.name,
+      botUrl: this.agentLink(agentId),
+      runtime: this.runtimeFacts.runtimeNames()[agent.runtime] ?? agent.runtime,
+      model: (await this.store.getObservedModel(rec.key)) ?? 'default',
+      sessionUrl: rec.sessionId
+        ? this.sessionLink(rec.sessionId, this.sessionLinkSource(rec.platform, integrationId))
+        : ''
+    })
+  }
+
+  /** Clear the previous footer holder behind the migrated one — best-effort, like the
+   *  in-turn stale-footer sweep. A closure-stamped terminal message is re-finalized with
+   *  the SAME §5.5 metadata (chat.update replaces it wholesale — dropping it would unroute
+   *  the closed response); anything else takes the authorship-only re-stamp. Duck-typed:
+   *  a connection without the edit surface simply leaves the old footer standing. */
+  private async clearMigratedFooter(
+    conn: SlackConnection,
+    agentId: string,
+    previous?: {
+      channel: string
+      ts: string
+      text: string
+      closure?: { responseId: string; hopCount: number; mentionedAgentIds: string[]; addressedAnyone: boolean }
+    }
+  ): Promise<void> {
+    if (!previous) return
+    const body = [{ type: 'markdown', text: previous.text }]
+    try {
+      if (previous.closure && typeof conn.finalizeResponse === 'function') {
+        await conn.finalizeResponse(previous.channel, previous.ts, body, previous.text, agentId, {
+          responseId: previous.closure.responseId,
+          deliveryState: 'final',
+          hopCount: previous.closure.hopCount,
+          mentionedAgentIds: previous.closure.mentionedAgentIds,
+          ...(previous.closure.addressedAnyone ? { addressedAnyone: true } : {})
+        })
+      } else if (typeof conn.updateBlocks === 'function') {
+        await conn.updateBlocks(previous.channel, previous.ts, body, undefined, false, agentId)
+      }
+    } catch (err) {
+      this.log.debug(`drain footer clear failed (ts=${previous.ts}): ${(err as Error).message}`)
+    }
   }
 
   /** Arm the deferred wake for a settled background task. Deliberately NOT immediate: the

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -14084,14 +14084,13 @@ export class Daemon {
             ...(footer && i === sections.length - 1 ? { trailingBlocks: footer.blocks } : {})
           })
         }
-        if (footer) {
+        // Clear ONLY once the replacement landed: postMessage returns undefined without
+        // throwing when the thread is gone, and stripping the old footer then would leave
+        // the response with no attribution at all — worse than the old footer staying put.
+        if (footer && lastTs) {
           await this.clearMigratedFooter(conn as SlackConnection, agentId, previous)
-          // Track the new holder so a follow-up drain can migrate again; an unknown ts
-          // (a connection that returns none) drops the entry rather than mistracking.
-          if (lastTs)
-            this.lastFooterReply.set(rec.key, { channel: rec.channel, ts: lastTs, text: sections.at(-1) ?? text })
-          else this.lastFooterReply.delete(rec.key)
-        }
+          this.lastFooterReply.set(rec.key, { channel: rec.channel, ts: lastTs, text: sections.at(-1) ?? text })
+        } else if (footer) this.lastFooterReply.delete(rec.key)
       } else {
         await conn.postMessage(rec.channel, text, rec.thread || undefined)
       }
@@ -14123,7 +14122,14 @@ export class Daemon {
       return
     }
     const routing = p.reply.closedRouting ?? p.reply.finalRouting
-    const closed = p.reply.responseId !== '' && p.reply.lastResponse?.ts === lastReply.ts
+    // "Closed" must mean THIS message actually carries final metadata: born-final on this ts,
+    // or a closure edit that ran (`closedRouting` is set only on that path) against this ts.
+    // A no-peers conversation deliberately leaves the reply `streaming` — recording a closure
+    // there would make the clearing edit PROMOTE it to final, minting a routable event for a
+    // message that never had one. A dropped `streaming` block costs nothing: never routed.
+    const closed =
+      p.reply.finalStamped === lastReply.ts ||
+      (p.reply.closedRouting !== undefined && p.reply.lastResponse?.ts === lastReply.ts)
     this.lastFooterReply.set(p.plan.sessionKey, {
       channel: p.plan.channel,
       ts: lastReply.ts,
@@ -14861,6 +14867,7 @@ export class Daemon {
             )
         }
       }
+      this.lastFooterReply.delete(row.key) // the session is gone — release its footer record
       if (!row.acpSessionId) continue
       this.sdkLease.delete(sdkLeaseKey(row.agentId, row.acpSessionId)) // the session is gone — drop its lease
       await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -491,6 +491,9 @@ export interface ReplyAccumulator {
    *  finalization with the closing metadata already aboard, so `closeResponse` skips its
    *  content-identical edit (which would mark the visible reply "(edited)"). */
   finalStamped?: string
+  /** What the closure actually resolved to, recorded when `closeSlackResponse` computes it
+   *  locally — §5.2's footer migration must re-supply it if it later edits that message. */
+  closedRouting?: { mentionedAgentIds: string[]; addressedAnyone: boolean }
 }
 
 /** The turn's completion machinery: what settles it, what defers it, and the once-only

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -124,11 +124,14 @@ function makeRoutable(daemon: Daemon) {
       config: { botToken: 'b', appToken: 'p' }
     }
   ]
+  let post = 0
   const conn = {
     workspaceId: vi.fn(() => 'T1'),
     setStatus: vi.fn(async () => {}),
     setTitle: vi.fn(async () => {}),
-    postMessage: vi.fn(async () => {})
+    postMessage: vi.fn(async () => `ts-${++post}`),
+    updateBlocks: vi.fn(async () => true),
+    finalizeResponse: vi.fn(async () => true)
   }
   ;(daemon as any).connByIntegration.set('int-a', conn)
   return conn
@@ -1966,6 +1969,92 @@ describe('Daemon idle sweep — background-task lease', () => {
       await new Promise((r) => setImmediate(r))
       const bodies = (conn.postMessage as any).mock.calls.map((call: any[]) => String(call[1]))
       expect(bodies.filter((body: string) => body === 'early words')).toHaveLength(1)
+      await daemon.stop()
+    })
+
+    it('migrates the attribution footer onto the narration and clears the previous holder', async () => {
+      const clock = new FakeClock()
+      const { daemon, conn } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+      await (daemon as any).store.setOutputModeOverride(KEY, 'low')
+      // The turn's last reply currently holds the footer — recorded at teardown.
+      ;(daemon as any).lastFooterReply.set(KEY, { channel: 'C1', ts: '111.222', text: 'old body' })
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-1', chunk('narration words'))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+      await vi.waitFor(() => expect(conn.postMessage).toHaveBeenCalledTimes(1), WAIT)
+      // Born with the footer: the last (only) section carries the attribution context block.
+      const options = (conn.postMessage as any).mock.calls[0][3]
+      expect(JSON.stringify(options.trailingBlocks)).toContain('sent by')
+      // The previous holder loses its footer via the authorship-only re-stamp (no closure).
+      await vi.waitFor(() => expect(conn.updateBlocks).toHaveBeenCalledTimes(1), WAIT)
+      expect((conn.updateBlocks as any).mock.calls[0].slice(0, 3)).toEqual([
+        'C1',
+        '111.222',
+        [{ type: 'markdown', text: 'old body' }]
+      ])
+      expect(conn.finalizeResponse).not.toHaveBeenCalled()
+      // The narration is the new holder, tracked for the next migration.
+      expect((daemon as any).lastFooterReply.get(KEY)).toMatchObject({ ts: 'ts-1', text: 'narration words' })
+      await daemon.stop()
+    })
+
+    it('re-supplies the §5.5 closure when clearing a closure-stamped holder', async () => {
+      const clock = new FakeClock()
+      const { daemon, conn } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+      await (daemon as any).store.setOutputModeOverride(KEY, 'low')
+      const closure = { responseId: 'resp-9', hopCount: 2, mentionedAgentIds: ['peer-1'], addressedAnyone: true }
+      ;(daemon as any).lastFooterReply.set(KEY, { channel: 'C1', ts: '111.333', text: 'closed body', closure })
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'running' }))
+      await (daemon as any).onAcpUpdate('bot-a', 'acp-1', chunk('follow-up'))
+      await (daemon as any).onSdkLifecycle('bot-a', 'acp-1', evt('session_state_changed', { state: 'idle' }))
+      await vi.waitFor(() => expect(conn.finalizeResponse).toHaveBeenCalledTimes(1), WAIT)
+      // chat.update replaces metadata wholesale — the closure must ride the clearing edit.
+      expect((conn.finalizeResponse as any).mock.calls[0]).toEqual([
+        'C1',
+        '111.333',
+        [{ type: 'markdown', text: 'closed body' }],
+        'closed body',
+        'bot-a',
+        {
+          responseId: 'resp-9',
+          deliveryState: 'final',
+          hopCount: 2,
+          mentionedAgentIds: ['peer-1'],
+          addressedAnyone: true
+        }
+      ])
+      expect(conn.updateBlocks).not.toHaveBeenCalled()
+      await daemon.stop()
+    })
+
+    it('records the footer holder at teardown, and clears it for a footerless turn', async () => {
+      const clock = new FakeClock()
+      const { daemon } = await bootWithTurn(clock, { agentIdleTimeoutMs: 10_000_000, idleSweepMs: 10_000_000 })
+      const base = {
+        plan: { sessionKey: KEY, channel: 'C1', sourceHopCount: 1 },
+        reply: {
+          lastReply: { ts: '5.5', text: 'reply body', footerKey: 'fk' },
+          lastResponse: { ts: '5.5', text: 'reply body' },
+          responseId: 'resp-1',
+          closedRouting: { mentionedAgentIds: ['peer-2'], addressedAnyone: false }
+        }
+      }
+      ;(daemon as any).recordFooterHolder(base)
+      expect((daemon as any).lastFooterReply.get(KEY)).toEqual({
+        channel: 'C1',
+        ts: '5.5',
+        text: 'reply body',
+        closure: { responseId: 'resp-1', hopCount: 1, mentionedAgentIds: ['peer-2'], addressedAnyone: false }
+      })
+      // Footer on a NON-terminal message ⇒ no closure to re-supply.
+      ;(daemon as any).recordFooterHolder({
+        ...base,
+        reply: { ...base.reply, lastResponse: { ts: '9.9', text: 'other' } }
+      })
+      expect((daemon as any).lastFooterReply.get(KEY)?.closure).toBeUndefined()
+      // A footerless turn CLEARS the record — a drain must not steal an older response's footer.
+      ;(daemon as any).recordFooterHolder({ ...base, reply: { ...base.reply, lastReply: undefined } })
+      expect((daemon as any).lastFooterReply.get(KEY)).toBeUndefined()
       await daemon.stop()
     })
 

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -2052,6 +2052,29 @@ describe('Daemon idle sweep — background-task lease', () => {
         reply: { ...base.reply, lastResponse: { ts: '9.9', text: 'other' } }
       })
       expect((daemon as any).lastFooterReply.get(KEY)?.closure).toBeUndefined()
+      // A no-peers conversation skips the closure edit and stays `streaming` on purpose —
+      // recording one would let the clearing edit PROMOTE the reply to final.
+      ;(daemon as any).recordFooterHolder({
+        ...base,
+        reply: { ...base.reply, closedRouting: undefined }
+      })
+      expect((daemon as any).lastFooterReply.get(KEY)?.closure).toBeUndefined()
+      // Born-final terminal section: closed on this ts, closure metadata from finalRouting.
+      ;(daemon as any).recordFooterHolder({
+        ...base,
+        reply: {
+          ...base.reply,
+          closedRouting: undefined,
+          finalStamped: '5.5',
+          finalRouting: { mentionedAgentIds: ['peer-3'], addressedAnyone: true, hasPeers: true, peerSharesBot: false }
+        }
+      })
+      expect((daemon as any).lastFooterReply.get(KEY)?.closure).toEqual({
+        responseId: 'resp-1',
+        hopCount: 1,
+        mentionedAgentIds: ['peer-3'],
+        addressedAnyone: true
+      })
       // A footerless turn CLEARS the record — a drain must not steal an older response's footer.
       ;(daemon as any).recordFooterHolder({ ...base, reply: { ...base.reply, lastReply: undefined } })
       expect((daemon as any).lastFooterReply.get(KEY)).toBeUndefined()


### PR DESCRIPTION
## Problem

Observed live after the drain-narration delivery landed: the attribution footer ("sent by … · open in session") sits **mid-run** — under the turn's last in-turn sentence — while the response's actual closing words (the drain-delivered narration) post bare. The footer's contract is to ride the newest reply of a response: each in-turn section is born with it and the previous holder is edited footer-less. The drain posts bypassed that lifecycle entirely.

## Fix: carry the footer migration over the turn boundary

- **Teardown records the holder.** When a turn's Pending is released, `recordFooterHolder` stores the footer-carrying reply per session — `{channel, ts, text}` plus, when the footer sits on the closure-stamped terminal message, the §5.5 closure metadata (`closeSlackResponse` now records the recipients/addressedAnyone it actually resolved). The closure matters because chat.update replaces metadata wholesale: a clearing edit that dropped it would unroute the closed response. A turn that left **no** footer clears the record instead — a drain must never steal an older response's footer.
- **The narration is born with the footer.** `drainAttributionBlocks` rebuilds the turn's attribution without a Pending (agent identity, runtime display name, the session's observed model, the console session link), gated on `showFooter` and the platform's `attributionFooter` chrome. The last section posts with it as trailing blocks.
- **The previous holder is cleared, best-effort.** With a recorded closure it goes through `finalizeResponse` re-supplying the same metadata (footer blocks omitted); otherwise the authorship-only `updateBlocks` re-stamp — both duck-typed, and a failed edit just leaves the old footer standing.
- Consecutive drains hand the footer along (the map tracks the new holder's ts). Known degradations, both cosmetic: a daemon restart between turn and drain loses the in-memory record (old footer stays; the drain still gets its own), and the cleared message picks up Slack's "(edited)" mark — the same cost the in-turn footer sweep already pays on older sections.

## Tests

Three new cases: migration posts the footer on the narration and clears the plain holder via the authorship re-stamp; a closure-stamped holder is cleared through `finalizeResponse` with the exact recorded metadata; teardown records with/without closure and clears for a footerless turn. `daemon-lifecycle.test.ts` 79/79; package typecheck/lint/format green; full daemon suite identical to the environmental baseline (same 13 sandbox-transport failures + 1 real-provider matrix failure + 1 pre-existing error) — zero new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
