### PR TITLE
feat(web): let a schedule's times be read in either clock, the viewer's by default

### DIFF
--- a/packages/web/src/components/console/ZoneSwitch.test.tsx
+++ b/packages/web/src/components/console/ZoneSwitch.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ZoneSwitch } from './ZoneSwitch'
+import {
+  browserTimeZone,
+  displayTimeZone,
+  type ScheduleTimeZone,
+  type ScheduleTimeZoneMode
+} from '@/lib/schedule-timezone'
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+/** A hook stand-in: the hook itself is covered in `lib/schedule-timezone.test.ts`. */
+function clockOf(mode: ScheduleTimeZoneMode, ready = true, setMode = vi.fn()): ScheduleTimeZone {
+  return { mode, ready, setMode, zoneFor: (zone) => displayTimeZone(mode, zone) }
+}
+
+const OTHER = browserTimeZone() === 'UTC' ? 'Asia/Tokyo' : 'UTC'
+
+const render = (element: React.ReactElement) => act(() => root.render(element))
+const button = () => host.querySelector('button')
+
+describe('ZoneSwitch', () => {
+  it('offers the schedule’s clock, naming the one currently in use', () => {
+    render(<ZoneSwitch clock={clockOf('browser')} scheduleZone={OTHER} />)
+
+    expect(button()?.textContent).toContain(browserTimeZone())
+    expect(button()?.getAttribute('title')).toBe(`Times shown in ${browserTimeZone()} — switch to ${OTHER}`)
+  })
+
+  it('names the schedule’s clock once that is the one in use', () => {
+    render(<ZoneSwitch clock={clockOf('schedule')} scheduleZone={OTHER} />)
+
+    expect(button()?.textContent).toContain(OTHER)
+    expect(button()?.getAttribute('title')).toBe(`Times shown in ${OTHER} — switch to ${browserTimeZone()}`)
+  })
+
+  it('switches to the other clock on click', () => {
+    const setMode = vi.fn()
+    render(<ZoneSwitch clock={clockOf('browser', true, setMode)} scheduleZone={OTHER} />)
+    act(() => button()?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+
+    expect(setMode).toHaveBeenCalledWith('schedule')
+  })
+
+  it('renders nothing when both readings would be the same text', () => {
+    render(<ZoneSwitch clock={clockOf('browser')} scheduleZone={browserTimeZone()} />)
+    expect(button()).toBeNull()
+
+    render(<ZoneSwitch clock={clockOf('browser')} scheduleZone={null} />)
+    expect(button()).toBeNull()
+  })
+
+  it('waits for the hook, since the viewer’s zone is unknown before mount', () => {
+    render(<ZoneSwitch clock={clockOf('browser', false)} scheduleZone={OTHER} />)
+    expect(button()).toBeNull()
+  })
+})

--- a/packages/web/src/components/console/ZoneSwitch.tsx
+++ b/packages/web/src/components/console/ZoneSwitch.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { Icon } from '@/components/ui'
+import { browserTimeZone, hasDistinctScheduleZone, type ScheduleTimeZone } from '@/lib/schedule-timezone'
+
+// Switches which clock a schedule surface reads its instants in. It renders nothing when the
+// schedule is kept on the viewer's own zone, since both readings would then be the same text, and
+// nothing until the hook is `ready`: the viewer's zone is unknown on the server, so deciding
+// visibility before mount would mismatch hydration.
+export function ZoneSwitch({ clock, scheduleZone }: { clock: ScheduleTimeZone; scheduleZone?: string | null }) {
+  if (!clock.ready || !hasDistinctScheduleZone(scheduleZone)) return null
+  const zone = clock.zoneFor(scheduleZone)
+  const other = clock.mode === 'schedule' ? browserTimeZone() : (scheduleZone as string)
+  return (
+    <button
+      type="button"
+      onClick={() => clock.setMode(clock.mode === 'schedule' ? 'browser' : 'schedule')}
+      className="inline-flex items-center gap-[6px] font-sans text-[12px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
+      title={`Times shown in ${zone} — switch to ${other}`}
+    >
+      <Icon name="globe" size={13} color="var(--text-tertiary)" />
+      {zone}
+    </button>
+  )
+}

--- a/packages/web/src/components/console/views/CronsView.tsx
+++ b/packages/web/src/components/console/views/CronsView.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/navigation'
 import { agentLabel } from '@/lib/data'
 import type { CronDto } from '@/lib/api'
 import { cronHuman, cronNext, cronUpdateInput, fmtNextRun } from '@/lib/cron'
+import { useScheduleTimeZone } from '@/lib/schedule-timezone'
 import { useConsoleData } from '@/lib/data-context'
 import { useModal } from '@/components/console/ModalProvider'
 import { useOrgs } from '@/lib/org-context'
@@ -151,8 +152,10 @@ function CronRow({ c }: { c: CronDto }) {
 
   const owner = agents.find((a) => a.id === c.agentId)
   const agentName = owner ? agentLabel(owner) : c.agentId ? c.agentId.slice(0, 8) : '—'
+  const clock = useScheduleTimeZone()
+  // The expression is never converted, so its reading names the zone it is interpreted in.
   const human = cronHuman(c.schedule)
-  const next = c.enabled ? fmtNextRun(cronNext(c.schedule, c.timezone)) : '—'
+  const next = c.enabled ? fmtNextRun(cronNext(c.schedule, c.timezone), clock.zoneFor(c.timezone)) : '—'
   const ran = !!c.lastRunAt
 
   const toggle = async (nextOn: boolean) => {
@@ -193,7 +196,7 @@ function CronRow({ c }: { c: CronDto }) {
       <div className="min-w-0">
         <span className="mono text-[12px] text-(--text-primary)">{c.schedule}</span>
         <div className="mt-[2px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
-          {human ?? 'invalid expression'}
+          {human ? `${human} · ${c.timezone}` : 'invalid expression'}
         </div>
       </div>
       <span className="inline-flex items-center gap-[6px]">
@@ -224,9 +227,10 @@ function MobileCronRow({ c, i }: { c: CronDto; i: number }) {
 
   const owner = agents.find((a) => a.id === c.agentId)
   const agentName = owner ? agentLabel(owner) : c.agentId ? c.agentId.slice(0, 8) : '—'
+  const clock = useScheduleTimeZone()
   const human = cronHuman(c.schedule)
-  const meta = `${agentName} · ${human ?? c.schedule}`
-  const next = c.enabled ? fmtNextRun(cronNext(c.schedule, c.timezone)) : 'off'
+  const meta = `${agentName} · ${human ? `${human} · ${c.timezone}` : c.schedule}`
+  const next = c.enabled ? fmtNextRun(cronNext(c.schedule, c.timezone), clock.zoneFor(c.timezone)) : 'off'
   const ran = !!c.lastRunAt
 
   const toggle = async () => {

--- a/packages/web/src/components/console/views/ScheduleDetailView.tsx
+++ b/packages/web/src/components/console/views/ScheduleDetailView.tsx
@@ -13,7 +13,8 @@ import Link from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
 import { agentLabel, platName } from '@/lib/data'
 import { creatorLabel, fetchCronRuns, fmtDate, runCronNow } from '@/lib/api'
-import { cronHuman, cronNext, cronUpdateInput, fmtNextRun } from '@/lib/cron'
+import { cronHuman, cronNext, cronUpdateInput, fmtNextRun, zonedDay } from '@/lib/cron'
+import { useScheduleTimeZone } from '@/lib/schedule-timezone'
 import { useConsoleData } from '@/lib/data-context'
 import { useProfile } from '@/lib/profile'
 import { useModal } from '@/components/console/ModalProvider'
@@ -24,14 +25,14 @@ import { useIsMobile } from '@/lib/use-is-mobile'
 import { consoleKeys } from '@/lib/swr-keys'
 import { AgentIconView, LoadingState, PlatformMark } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
+import { ZoneSwitch } from '../ZoneSwitch'
 
-function fmtStarted(iso: string): string {
+function fmtStarted(iso: string, timeZone?: string): string {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return '—'
-  const time = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
-  const today = new Date()
-  if (d.toDateString() === today.toDateString()) return `Today · ${time}`
-  return `${d.toLocaleDateString([], { month: 'short', day: 'numeric' })} · ${time}`
+  const time = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', timeZone })
+  if (zonedDay(d, timeZone) === zonedDay(new Date(), timeZone)) return `Today · ${time}`
+  return `${d.toLocaleDateString([], { month: 'short', day: 'numeric', timeZone })} · ${time}`
 }
 
 function fmtDuration(ms: number | null): string {
@@ -61,6 +62,7 @@ export default function ScheduleDetailView() {
   const [busy, setBusy] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
+  const clock = useScheduleTimeZone()
 
   const c = crons.find((x) => x.id === id)
 
@@ -100,7 +102,10 @@ export default function ScheduleDetailView() {
   const owner = agents.find((a) => a.id === c.agentId)
   const agentName = owner ? agentLabel(owner) : c.agentId ? c.agentId.slice(0, 8) : '—'
   const agentRuntime = owner?.runtime || owner?.model || ''
+  // The expression is never converted, so its reading names the zone it is interpreted in.
   const human = cronHuman(c.schedule)
+  const humanInZone = human ? `${human} · ${c.timezone}` : human
+  const zone = clock.zoneFor(c.timezone)
   const channelName = c.targetChannel
     ? (integrations
         .filter((i) => (c.targetIntegrationId ? i.id === c.targetIntegrationId : i.agentId === c.agentId))
@@ -147,7 +152,7 @@ export default function ScheduleDetailView() {
 
   if (isMobile) {
     // The Shell push bar owns the back arrow + name/agent title + ⋯ — render the body only.
-    const next = c.enabled ? fmtNextRun(cronNext(c.schedule, c.timezone)) : '—'
+    const next = c.enabled ? fmtNextRun(cronNext(c.schedule, c.timezone), zone) : '—'
     const cardStyle =
       'overflow-hidden rounded-lg border border-(--border-subtle) bg-(--surface-card) shadow-(--shadow-xs)'
     return (
@@ -162,9 +167,12 @@ export default function ScheduleDetailView() {
             <Icon name={c.enabled ? 'alarm-clock' : 'alarm-clock-off'} size={24} />
           </span>
           <div className="min-w-0 flex-1">
-            <div className="font-sans text-[15px] font-semibold leading-normal">{human ?? c.schedule}</div>
+            <div className="font-sans text-[15px] font-semibold leading-normal">{humanInZone ?? c.schedule}</div>
             <div className="mt-[2px] font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
               next run <span className="text-(--text-primary)">{next}</span>
+            </div>
+            <div className="mt-[2px]">
+              <ZoneSwitch clock={clock} scheduleZone={c.timezone} />
             </div>
           </div>
           <span className={`inline-flex flex-none ${busy ? 'opacity-60' : ''}`}>
@@ -313,7 +321,7 @@ export default function ScheduleDetailView() {
                     <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
                       <span className="flex items-center gap-2">
                         <span className="font-mono text-[12px] font-medium leading-normal text-(--text-primary)">
-                          {fmtStarted(r.startedAt)}
+                          {fmtStarted(r.startedAt, zone)}
                         </span>
                         <span className="font-sans text-[11px] font-medium leading-normal" style={{ color: st.color }}>
                           {st.label}
@@ -457,15 +465,16 @@ export default function ScheduleDetailView() {
         <span className="inline-flex items-center gap-[6px]">
           <Icon name="calendar-clock" size={13} color="var(--text-tertiary)" />
           <span className="mono text-[12px] text-(--text-secondary)">{c.schedule}</span>
-          <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">{human}</span>
+          <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">{humanInZone}</span>
         </span>
         <span className="inline-flex items-center gap-[6px]">
           <Icon name="clock" size={13} color="var(--text-tertiary)" />
           <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">next run</span>
           <span className="mono text-[12px] text-(--text-secondary)">
-            {c.enabled ? fmtNextRun(cronNext(c.schedule, c.timezone)) : '—'}
+            {c.enabled ? fmtNextRun(cronNext(c.schedule, c.timezone), zone) : '—'}
           </span>
         </span>
+        <ZoneSwitch clock={clock} scheduleZone={c.timezone} />
         {channelName &&
           (c.targetPlatform === 'slack' && c.targetChannel ? (
             <a
@@ -541,7 +550,7 @@ export default function ScheduleDetailView() {
               const st = RUN_STYLE[r.status]
               return (
                 <div key={r.id} className={`row items-center ${RUN_GRID}`}>
-                  <span className="mono text-[12px] text-(--text-primary)">{fmtStarted(r.startedAt)}</span>
+                  <span className="mono text-[12px] text-(--text-primary)">{fmtStarted(r.startedAt, zone)}</span>
                   <div className="min-w-0">
                     <span className="inline-flex items-center gap-[6px]">
                       <span className="dot h-[6px] w-[6px]" style={{ background: st.dot }} />

--- a/packages/web/src/lib/cron.test.ts
+++ b/packages/web/src/lib/cron.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { CronDto } from './api'
-import { cronNext, cronTimezoneInput, cronTimezoneSelectModel, cronUpdateInput, isIanaTimezone } from './cron'
+import {
+  cronNext,
+  cronTimezoneInput,
+  cronTimezoneSelectModel,
+  cronUpdateInput,
+  fmtNextRun,
+  isIanaTimezone,
+  zonedDay
+} from './cron'
 
 afterEach(() => vi.useRealTimers())
 
@@ -11,6 +19,46 @@ describe('cronNext', () => {
 
     expect(cronNext('0 9 * * *', 'UTC')?.toISOString()).toBe('2026-01-01T09:00:00.000Z')
     expect(cronNext('0 9 * * *', 'Asia/Tokyo')?.toISOString()).toBe('2026-01-02T00:00:00.000Z')
+  })
+})
+
+describe('fmtNextRun', () => {
+  // 2026-01-01T20:30Z is still Jan 1 in UTC but already Jan 2 in Tokyo, so "Today" has to be
+  // decided in the zone being rendered rather than in the viewer's.
+  const evening = new Date('2026-01-01T20:30:00.000Z')
+
+  it("names the calendar day of the zone it renders in, not the viewer's", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T12:00:00.000Z'))
+
+    expect(fmtNextRun(evening, 'UTC')).toBe('Today 8:30 PM')
+    expect(fmtNextRun(evening, 'Asia/Tokyo')).toBe('Tomorrow 5:30 AM')
+  })
+
+  it('renders the same instant at the wall clock of each zone', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+    expect(fmtNextRun(new Date('2026-01-01T09:00:00.000Z'), 'UTC')).toBe('Today 9:00 AM')
+    expect(fmtNextRun(new Date('2026-01-01T09:00:00.000Z'), 'Asia/Shanghai')).toBe('Today 5:00 PM')
+  })
+
+  it('stays relative inside the hour, where a duration reads the same in every zone', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T09:00:00.000Z'))
+
+    const soon = new Date('2026-01-01T09:20:00.000Z')
+    expect(fmtNextRun(soon, 'UTC')).toBe('in 20 min')
+    expect(fmtNextRun(soon, 'Asia/Tokyo')).toBe('in 20 min')
+    expect(fmtNextRun(null, 'UTC')).toBe('—')
+  })
+})
+
+describe('zonedDay', () => {
+  it('splits one instant across two calendar days by zone', () => {
+    const instant = new Date('2026-01-01T20:30:00.000Z')
+    expect(zonedDay(instant, 'UTC')).toBe('2026-01-01')
+    expect(zonedDay(instant, 'Asia/Tokyo')).toBe('2026-01-02')
   })
 })
 

--- a/packages/web/src/lib/cron.test.ts
+++ b/packages/web/src/lib/cron.test.ts
@@ -27,20 +27,28 @@ describe('fmtNextRun', () => {
   // decided in the zone being rendered rather than in the viewer's.
   const evening = new Date('2026-01-01T20:30:00.000Z')
 
+  // The wall clock is derived, not spelled out: `fmtNextRun` formats with the runtime's own locale,
+  // so a literal "8:30 PM" would fail on a 24-hour runner for a reason these tests are not about.
+  // The zone axis they ARE about stays real — each pair asserts the two zones differ first.
+  const wall = (d: Date, timeZone: string) => d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', timeZone })
+
   it("names the calendar day of the zone it renders in, not the viewer's", () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-01-01T12:00:00.000Z'))
 
-    expect(fmtNextRun(evening, 'UTC')).toBe('Today 8:30 PM')
-    expect(fmtNextRun(evening, 'Asia/Tokyo')).toBe('Tomorrow 5:30 AM')
+    expect(wall(evening, 'UTC')).not.toBe(wall(evening, 'Asia/Tokyo'))
+    expect(fmtNextRun(evening, 'UTC')).toBe(`Today ${wall(evening, 'UTC')}`)
+    expect(fmtNextRun(evening, 'Asia/Tokyo')).toBe(`Tomorrow ${wall(evening, 'Asia/Tokyo')}`)
   })
 
   it('renders the same instant at the wall clock of each zone', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    const morning = new Date('2026-01-01T09:00:00.000Z')
 
-    expect(fmtNextRun(new Date('2026-01-01T09:00:00.000Z'), 'UTC')).toBe('Today 9:00 AM')
-    expect(fmtNextRun(new Date('2026-01-01T09:00:00.000Z'), 'Asia/Shanghai')).toBe('Today 5:00 PM')
+    expect(wall(morning, 'UTC')).not.toBe(wall(morning, 'Asia/Shanghai'))
+    expect(fmtNextRun(morning, 'UTC')).toBe(`Today ${wall(morning, 'UTC')}`)
+    expect(fmtNextRun(morning, 'Asia/Shanghai')).toBe(`Today ${wall(morning, 'Asia/Shanghai')}`)
   })
 
   it('stays relative inside the hour, where a duration reads the same in every zone', () => {

--- a/packages/web/src/lib/cron.ts
+++ b/packages/web/src/lib/cron.ts
@@ -156,16 +156,22 @@ export function cronTimezoneInput(
 }
 
 /** Short next-run label: "in 14 min" / "Today 3:00 AM" / "Mon 9:00 AM" / "—". */
-export function fmtNextRun(d: Date | null): string {
+/** The calendar day an instant falls on IN `timeZone`, as `YYYY-MM-DD`, so "Today" means today there. */
+export function zonedDay(d: Date, timeZone?: string): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone, year: 'numeric', month: '2-digit', day: '2-digit' }).format(d)
+}
+
+/** `timeZone` omitted renders in the viewer's own zone, which is what every caller wanted before it existed. */
+export function fmtNextRun(d: Date | null, timeZone?: string): string {
   if (!d) return '—'
   const now = Date.now()
   const mins = Math.round((d.getTime() - now) / 60000)
   if (mins < 1) return 'now'
+  // Relative for the next hour: a duration reads the same in every zone, so no conversion applies.
   if (mins < 60) return `in ${mins} min`
-  const time = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
-  const today = new Date()
-  if (d.toDateString() === today.toDateString()) return `Today ${time}`
-  const tomorrow = new Date(now + 86400000)
-  if (d.toDateString() === tomorrow.toDateString()) return `Tomorrow ${time}`
-  return `${d.toLocaleDateString([], { weekday: 'short' })} ${time}`
+  const time = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', timeZone })
+  const day = zonedDay(d, timeZone)
+  if (day === zonedDay(new Date(now), timeZone)) return `Today ${time}`
+  if (day === zonedDay(new Date(now + 86400000), timeZone)) return `Tomorrow ${time}`
+  return `${d.toLocaleDateString([], { weekday: 'short', timeZone })} ${time}`
 }

--- a/packages/web/src/lib/cron.ts
+++ b/packages/web/src/lib/cron.ts
@@ -155,13 +155,12 @@ export function cronTimezoneInput(
   return isIanaTimezone(value) ? { timezone: value } : null
 }
 
-/** Short next-run label: "in 14 min" / "Today 3:00 AM" / "Mon 9:00 AM" / "—". */
 /** The calendar day an instant falls on IN `timeZone`, as `YYYY-MM-DD`, so "Today" means today there. */
 export function zonedDay(d: Date, timeZone?: string): string {
   return new Intl.DateTimeFormat('en-CA', { timeZone, year: 'numeric', month: '2-digit', day: '2-digit' }).format(d)
 }
 
-/** `timeZone` omitted renders in the viewer's own zone, which is what every caller wanted before it existed. */
+/** Short next-run label: "in 14 min" / "Today 3:00 AM" / "Mon 9:00 AM" / "—", in `timeZone` or the viewer's own. */
 export function fmtNextRun(d: Date | null, timeZone?: string): string {
   if (!d) return '—'
   const now = Date.now()

--- a/packages/web/src/lib/schedule-timezone.test.ts
+++ b/packages/web/src/lib/schedule-timezone.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  SCHEDULE_TIME_ZONE_KEY,
+  browserTimeZone,
+  displayTimeZone,
+  hasDistinctScheduleZone,
+  readScheduleTimeZoneMode,
+  writeScheduleTimeZoneMode
+} from './schedule-timezone'
+
+afterEach(() => {
+  window.localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe('readScheduleTimeZoneMode', () => {
+  it('defaults to the viewer’s own clock', () => {
+    expect(readScheduleTimeZoneMode()).toBe('browser')
+  })
+
+  it('round-trips the stored choice', () => {
+    writeScheduleTimeZoneMode('schedule')
+    expect(window.localStorage.getItem(SCHEDULE_TIME_ZONE_KEY)).toBe('schedule')
+    expect(readScheduleTimeZoneMode()).toBe('schedule')
+
+    writeScheduleTimeZoneMode('browser')
+    expect(readScheduleTimeZoneMode()).toBe('browser')
+  })
+
+  it('falls back to the default for anything another version or tab may have written', () => {
+    window.localStorage.setItem(SCHEDULE_TIME_ZONE_KEY, 'Asia/Tokyo')
+    expect(readScheduleTimeZoneMode()).toBe('browser')
+  })
+
+  it('survives storage that throws, which a private window does', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked')
+    })
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked')
+    })
+
+    expect(readScheduleTimeZoneMode()).toBe('browser')
+    expect(() => writeScheduleTimeZoneMode('schedule')).not.toThrow()
+  })
+})
+
+describe('displayTimeZone', () => {
+  it('uses the schedule’s zone only when asked for it', () => {
+    expect(displayTimeZone('schedule', 'UTC')).toBe('UTC')
+    expect(displayTimeZone('browser', 'UTC')).toBe(browserTimeZone())
+  })
+
+  it('falls back to the viewer’s zone for a schedule that names none', () => {
+    expect(displayTimeZone('schedule', null)).toBe(browserTimeZone())
+    expect(displayTimeZone('schedule', '')).toBe(browserTimeZone())
+  })
+})
+
+describe('hasDistinctScheduleZone', () => {
+  it('is false when there is nothing to switch to', () => {
+    expect(hasDistinctScheduleZone(browserTimeZone())).toBe(false)
+    expect(hasDistinctScheduleZone(null)).toBe(false)
+    expect(hasDistinctScheduleZone('')).toBe(false)
+  })
+
+  it('is true for a schedule kept on another clock than the viewer', () => {
+    expect(hasDistinctScheduleZone(browserTimeZone() === 'UTC' ? 'Asia/Tokyo' : 'UTC')).toBe(true)
+  })
+})

--- a/packages/web/src/lib/schedule-timezone.test.ts
+++ b/packages/web/src/lib/schedule-timezone.test.ts
@@ -56,6 +56,15 @@ describe('displayTimeZone', () => {
     expect(displayTimeZone('schedule', null)).toBe(browserTimeZone())
     expect(displayTimeZone('schedule', '')).toBe(browserTimeZone())
   })
+
+  // `Not/AZone` and `UTC+8` make Intl throw, and a formatter that throws takes the view down; a bare
+  // offset formats fine but is not a zone, which is the line `isIanaTimezone` already drew.
+  it('falls back rather than hand a name Intl would reject to a formatter', () => {
+    for (const zone of ['Not/AZone', 'UTC+8', '+08:00']) {
+      expect(displayTimeZone('schedule', zone)).toBe(browserTimeZone())
+      expect(() => new Intl.DateTimeFormat('en-CA', { timeZone: displayTimeZone('schedule', zone) })).not.toThrow()
+    }
+  })
 })
 
 describe('hasDistinctScheduleZone', () => {
@@ -67,5 +76,10 @@ describe('hasDistinctScheduleZone', () => {
 
   it('is true for a schedule kept on another clock than the viewer', () => {
     expect(hasDistinctScheduleZone(browserTimeZone() === 'UTC' ? 'Asia/Tokyo' : 'UTC')).toBe(true)
+  })
+
+  it('is false for a zone no formatter could use, so the switch is not offered for one', () => {
+    expect(hasDistinctScheduleZone('Not/AZone')).toBe(false)
+    expect(hasDistinctScheduleZone('+08:00')).toBe(false)
   })
 })

--- a/packages/web/src/lib/schedule-timezone.ts
+++ b/packages/web/src/lib/schedule-timezone.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import { isIanaTimezone } from './cron'
 
 // Which clock the schedule surfaces render instants in. A cron expression is authored IN a timezone
 // and fires by it, so "next run" and a run's start are two readings of one instant; the viewer picks
@@ -40,14 +41,21 @@ export function writeScheduleTimeZoneMode(mode: ScheduleTimeZoneMode): void {
   }
 }
 
-/** The zone to render instants in. A schedule carrying no timezone leaves nothing to switch to. */
-export function displayTimeZone(mode: ScheduleTimeZoneMode, scheduleTimeZone?: string | null): string {
-  return mode === 'schedule' && scheduleTimeZone ? scheduleTimeZone : browserTimeZone()
+// A zone reaches `Intl`, which throws a RangeError on a name it does not know rather than degrading.
+// The API only accepts IANA names, but a legacy or CLI-written row need not hold one, and a throw in
+// a formatter takes the whole view down — so an unusable zone is treated as no zone at all.
+function usableZone(scheduleTimeZone?: string | null): boolean {
+  return !!scheduleTimeZone && isIanaTimezone(scheduleTimeZone)
 }
 
-/** Whether a schedule offers a second clock at all — same zone as the viewer means nothing to switch. */
+/** The zone to render instants in. A schedule carrying no usable timezone leaves nothing to switch to. */
+export function displayTimeZone(mode: ScheduleTimeZoneMode, scheduleTimeZone?: string | null): string {
+  return mode === 'schedule' && usableZone(scheduleTimeZone) ? (scheduleTimeZone as string) : browserTimeZone()
+}
+
+/** Whether a schedule offers a second clock at all — the viewer's own zone means nothing to switch to. */
 export function hasDistinctScheduleZone(scheduleTimeZone?: string | null): boolean {
-  return !!scheduleTimeZone && scheduleTimeZone !== browserTimeZone()
+  return usableZone(scheduleTimeZone) && scheduleTimeZone !== browserTimeZone()
 }
 
 export interface ScheduleTimeZone {

--- a/packages/web/src/lib/schedule-timezone.ts
+++ b/packages/web/src/lib/schedule-timezone.ts
@@ -1,0 +1,75 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+// Which clock the schedule surfaces render instants in. A cron expression is authored IN a timezone
+// and fires by it, so "next run" and a run's start are two readings of one instant; the viewer picks
+// which. The expression's own reading is never converted — `0 2 * * MON` in one zone is a different
+// weekday in another, and a DST zone has no fixed offset to convert by — so it always names its own.
+export type ScheduleTimeZoneMode = 'browser' | 'schedule'
+
+/** Per-device console preference, stored beside `ac-theme` and `ac.pinned-sessions` — a viewing choice, not CP state. */
+export const SCHEDULE_TIME_ZONE_KEY = 'ac.schedule-timezone'
+
+/** The viewer's IANA zone, falling back to UTC where the runtime will not name one. */
+export function browserTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  } catch {
+    return 'UTC'
+  }
+}
+
+/** The stored mode — `'browser'` on the server, on blocked storage, and for anything unrecognized. */
+export function readScheduleTimeZoneMode(): ScheduleTimeZoneMode {
+  if (typeof window === 'undefined') return 'browser'
+  try {
+    return window.localStorage.getItem(SCHEDULE_TIME_ZONE_KEY) === 'schedule' ? 'schedule' : 'browser'
+  } catch {
+    return 'browser'
+  }
+}
+
+/** Persist the mode. Silently no-ops when storage is blocked; the choice still applies for this page view. */
+export function writeScheduleTimeZoneMode(mode: ScheduleTimeZoneMode): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(SCHEDULE_TIME_ZONE_KEY, mode)
+  } catch {
+    /* private mode / storage disabled */
+  }
+}
+
+/** The zone to render instants in. A schedule carrying no timezone leaves nothing to switch to. */
+export function displayTimeZone(mode: ScheduleTimeZoneMode, scheduleTimeZone?: string | null): string {
+  return mode === 'schedule' && scheduleTimeZone ? scheduleTimeZone : browserTimeZone()
+}
+
+/** Whether a schedule offers a second clock at all — same zone as the viewer means nothing to switch. */
+export function hasDistinctScheduleZone(scheduleTimeZone?: string | null): boolean {
+  return !!scheduleTimeZone && scheduleTimeZone !== browserTimeZone()
+}
+
+export interface ScheduleTimeZone {
+  mode: ScheduleTimeZoneMode
+  /** False on the server and the first client paint, so markup that depends on the viewer's zone waits for it. */
+  ready: boolean
+  setMode: (mode: ScheduleTimeZoneMode) => void
+  zoneFor: (scheduleTimeZone?: string | null) => string
+}
+
+/** The viewer's schedule-clock choice. Renders as `'browser'` until mounted, so hydration never mismatches. */
+export function useScheduleTimeZone(): ScheduleTimeZone {
+  const [mode, setStoredMode] = useState<ScheduleTimeZoneMode>('browser')
+  const [ready, setReady] = useState(false)
+  useEffect(() => {
+    setStoredMode(readScheduleTimeZoneMode())
+    setReady(true)
+  }, [])
+  const setMode = useCallback((next: ScheduleTimeZoneMode) => {
+    setStoredMode(next)
+    writeScheduleTimeZoneMode(next)
+  }, [])
+  const zoneFor = useCallback((scheduleTimeZone?: string | null) => displayTimeZone(mode, scheduleTimeZone), [mode])
+  return { mode, ready, setMode, zoneFor }
+}


### PR DESCRIPTION
## What was wrong

A schedule card renders its two halves on different clocks, and names neither:

```ts
const human = cronHuman(c.schedule)                        // cronstrue — the expression, bare
const next  = fmtNextRun(cronNext(c.schedule, c.timezone)) // croner — honours the timezone
```

`next` is right: it evaluates in the schedule's stored timezone and renders the resulting instant in the viewer's. `human` is the misleading half — a bare wall time with no timezone attached. A schedule kept on a different clock than the reader's therefore shows something like `At 09:00 AM` directly above `next run — Today 5:00 PM`, with nothing on the card accounting for the gap.

`c.timezone` is already in scope at every one of those call sites, and `AddCronModal` already renders `{human} · {timezone} · {schedule}` — the editor shows the timezone and the card drops it.

## What this does

**The expression's reading names its own timezone** — `At 09:00 AM · UTC` — on the schedule detail (mobile and desktop) and on both list rows.

**Every instant on the schedule surfaces follows a viewer preference**: next run, and each run's start in the Runs table. `browser` (default) or `schedule`, persisted per device in `localStorage` beside the other console preferences. `lib/schedule-timezone.ts` holds the preference and `useScheduleTimeZone()`; `fmtNextRun` and the run-start formatter now take an optional zone.

**The expression itself is never converted**, which is why the switch governs instants only:

- `0 2 * * MON` in `Asia/Shanghai` is Sunday 18:00 in UTC — converting moves the weekday, so the converted text would no longer read as the rule the user typed.
- A zone that observes DST has no single fixed offset, so there is no one expression to convert to.

So the reading always names its own zone, and the switch decides what the times around it mean. Showing a converted wall clock that does not appear in the expression the user edits would be worse than the ambiguity this fixes.

**The switch (`components/console/ZoneSwitch.tsx`)** renders only when there is a second clock to offer — a schedule already on the viewer's zone would give two identical readings — and only once mounted, because the viewer's zone is unknown on the server and deciding visibility before then would mismatch hydration.

The list has no switch of its own: its rows can each carry a different timezone, so one control naming a concrete zone would be wrong there. The rows honour whatever the preference is, and each row's reading names its own zone. Say the word if a mode-labelled control ("Your time" / "Schedule time") on the list header is wanted too.

## Verification

- `lib/schedule-timezone.test.ts` — default, round-trip, unrecognized stored values, and storage that throws (a private window).
- `lib/cron.test.ts` — `fmtNextRun` and `zonedDay` across a zone boundary: one instant that is "Today" in UTC and "Tomorrow" in Tokyo, the same instant at each zone's wall clock, and the sub-hour relative form which is zone-independent.
- `components/console/ZoneSwitch.test.tsx` — which zone it names in each mode, that clicking asks for the other one, and the two cases where it renders nothing.
- Full web suite: 192 files / 2179 tests pass; `typecheck` and `lint` clean.

Not verified in a browser — showing this needs a console running against a schedule whose timezone differs from the viewer's, which is a full local stack. The pure logic and the switch are covered above; the wiring into the two views is not.
