### PR TITLE
fix(control-plane): stop guessing a schedule's timezone from the server

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2368,8 +2368,9 @@ export const UpsertCronBody = z.object({
   // never delivered to the daemon. Optional for API/legacy compatibility.
   name: z.string().trim().min(1).max(120).optional(),
   schedule: cronerSchedule,
-  // Omitted on create ⇒ the CP process timezone; edits from the console always
-  // resend the stored value so a non-default timezone is never reset silently.
+  // Omitted ⇒ UTC on create, and on an edit the zone the schedule already has. The server never
+  // guesses one: a caller states the zone its user lives in, and omission is never a way to move a
+  // live schedule. Required by the MCP tool, where the caller has a person to ask.
   timezone: ianaTimezone.optional(),
   // The MEMBERS track the registry; the DEFAULT does not, and must not. A cron
   // created before `targetPlatform` existed reads back as Slack, so `'slack'`

--- a/packages/control-plane/src/http/mcp/tools.test.ts
+++ b/packages/control-plane/src/http/mcp/tools.test.ts
@@ -58,7 +58,7 @@ const ARGS: Record<string, Record<string, unknown>> = {
   updateAgent: { agentId: AGENT_UUID, model: 'opus' },
   deleteAgent: { agentId: AGENT_UUID, confirm: 'my-agent' },
   renameDaemon: { daemonId: 'daemon-1', name: 'edge-1' },
-  upsertCron: { agentId: AGENT_UUID, schedule: '0 9 * * *', trigger: 'do the thing' },
+  upsertCron: { agentId: AGENT_UUID, schedule: '0 9 * * *', trigger: 'do the thing', timezone: 'Asia/Shanghai' },
   runCron: { cronId: 'cron-1' },
   deleteCron: { cronId: 'cron-1', confirm: 'my-agent' },
   setChannelTrigger: { integrationId: 'integ-1', channelId: 'C123', trigger: 'any' },
@@ -265,6 +265,15 @@ describe('MCP write tools — bodies and upsert semantics', () => {
     const create = await run('upsertCron')
     const minted = create.calls[0]!.path.slice(`/orgs/${ORG_ID}/crons/`.length)
     expect(minted).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+  })
+
+  // A caller that omitted the zone used to inherit the CP process's own, so "every morning at 9"
+  // silently meant 9am somewhere else. There is no zone to guess from here, so the tool asks.
+  it('upsertCron refuses a schedule with no timezone rather than choosing one', async () => {
+    const { timezone: _omitted, ...withoutZone } = ARGS.upsertCron!
+    const tool = findTool('upsertCron')!
+    expect(tool.schema.safeParse(withoutZone).success).toBe(false)
+    expect(tool.schema.safeParse(ARGS.upsertCron).success).toBe(true)
   })
 })
 

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -387,7 +387,7 @@ export const MCP_TOOLS: McpToolDef[] = [
           .string()
           .min(1)
           .describe(
-            'IANA timezone the schedule is interpreted in, e.g. "Asia/Shanghai". Use the timezone the person asking lives in — ask them if you do not know it. There is no default.'
+            'IANA timezone the schedule is interpreted in, e.g. "Asia/Shanghai". Use the timezone the person asking lives in — ask them if you do not know it. There is no default. When editing an existing schedule, pass back its current timezone (from getCron) unless the user is changing it: this is a full replace, so a guess here MOVES the schedule.'
           ),
         trigger: z.string().min(1).describe('The prompt sent to the agent on each firing'),
         // Same cron target vocabulary the REST body accepts (`dto/index.ts`

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -380,7 +380,15 @@ export const MCP_TOOLS: McpToolDef[] = [
         agentId: z.string().uuid().describe('The agent this schedule drives (from listAgents)'),
         name: z.string().trim().min(1).max(120).optional().describe('Display name shown in the console'),
         schedule: z.string().min(1).describe('Cron expression, croner syntax (e.g. "0 9 * * MON-FRI")'),
-        timezone: z.string().min(1).optional().describe('IANA timezone name (e.g. "Asia/Shanghai")'),
+        // Required, and deliberately so: the schedule fires by this, and a caller that omitted it used
+        // to inherit whatever zone the control plane process happened to run in — UTC in a container.
+        // "Every morning at 9" then meant 9am somewhere the user has never been.
+        timezone: z
+          .string()
+          .min(1)
+          .describe(
+            'IANA timezone the schedule is interpreted in, e.g. "Asia/Shanghai". Use the timezone the person asking lives in — ask them if you do not know it. There is no default.'
+          ),
         trigger: z.string().min(1).describe('The prompt sent to the agent on each firing'),
         // Same cron target vocabulary the REST body accepts (`dto/index.ts`
         // `Platform`), from the one registry declaration rather than a fourth copy.

--- a/packages/control-plane/src/http/routes/crons.ts
+++ b/packages/control-plane/src/http/routes/crons.ts
@@ -183,7 +183,10 @@ export function cronRoutes(deps: HttpDeps) {
             agentId: agent.id,
             ...(req.body.name ? { name: req.body.name } : {}),
             schedule: req.body.schedule,
-            timezone: req.body.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+            // The server never guesses a zone. This used to fall back to the CP PROCESS's own zone —
+            // UTC in a container — so an omission put a schedule on a clock nobody chose, and an edit
+            // that omitted it moved an existing schedule off the one it was authored on.
+            timezone: req.body.timezone ?? existing?.timezone ?? 'UTC',
             targetPlatform,
             ...(req.body.targetChannel ? { targetChannel: req.body.targetChannel } : {}),
             ...(targetIntegrationId ? { targetIntegrationId } : {}),

--- a/packages/control-plane/src/platforms/ids.test.ts
+++ b/packages/control-plane/src/platforms/ids.test.ts
@@ -84,6 +84,8 @@ describe('the cron / hook target vocabulary (F10)', () => {
       agentId: '00000000-0000-4000-8000-000000000001',
       schedule: '0 9 * * *',
       trigger: 'go',
+      // Required by the tool; this case is about the platform vocabulary, not the clock.
+      timezone: 'UTC',
       targetPlatform
     })
     for (const id of CP_PLATFORM_IDS) expect(tool.schema.safeParse(args(id)).success).toBe(true)

--- a/packages/control-plane/test/integration/crons.route.test.ts
+++ b/packages/control-plane/test/integration/crons.route.test.ts
@@ -103,13 +103,15 @@ describe('cron replication CP→daemon (REST → cron/upsert·remove)', () => {
     })
   })
 
-  it('defaults an omitted timezone to the control-plane timezone and rejects invalid IANA names', async () => {
+  // A schedule fires by its timezone, so the server never picks one: it used to inherit the CP
+  // PROCESS's zone, which is UTC in a container and the developer's laptop zone in a test — so an
+  // omission put the schedule on a clock nobody chose, and it varied with where the CP ran.
+  it('creates an omitted timezone as UTC rather than the control-plane process zone, and rejects invalid IANA names', async () => {
     await seedDaemon(prisma, DAEMON)
     const agentId = randomUUID()
     await seedAgent(prisma, agentId, { daemonId: DAEMON })
     const { app, spy } = withSpy()
     const defaultedId = randomUUID()
-    const expectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
     const defaulted = await app.app.inject({
       method: 'PUT',
@@ -117,9 +119,9 @@ describe('cron replication CP→daemon (REST → cron/upsert·remove)', () => {
       payload: body(agentId, { timezone: undefined })
     })
     expect(defaulted.statusCode).toBe(200)
-    expect((defaulted.json() as { timezone: string }).timezone).toBe(expectedTimezone)
-    expect(spy.upserts[0]!.u.timezone).toBe(expectedTimezone)
-    expect((await prisma.cronDef.findUnique({ where: { id: defaultedId } }))?.timezone).toBe(expectedTimezone)
+    expect((defaulted.json() as { timezone: string }).timezone).toBe('UTC')
+    expect(spy.upserts[0]!.u.timezone).toBe('UTC')
+    expect((await prisma.cronDef.findUnique({ where: { id: defaultedId } }))?.timezone).toBe('UTC')
 
     for (const timezone of ['Mars/Olympus_Mons', '+01:00']) {
       const invalidId = randomUUID()
@@ -132,6 +134,31 @@ describe('cron replication CP→daemon (REST → cron/upsert·remove)', () => {
       expect(await prisma.cronDef.findUnique({ where: { id: invalidId } })).toBeNull()
     }
     expect(spy.upserts).toHaveLength(1)
+  })
+
+  // An edit that omits the zone used to REPLACE the stored one with the process zone, quietly moving
+  // a live schedule off the clock it was authored on. Omitting it now means "leave it alone".
+  it('an edit that omits the timezone keeps the one the schedule was created with', async () => {
+    const agentId = randomUUID()
+    await seedAgent(prisma, agentId)
+    const cronId = randomUUID()
+    const { app } = withSpy()
+
+    const created = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/crons/${cronId}`,
+      payload: body(agentId, { timezone: 'America/New_York' })
+    })
+    expect(created.statusCode).toBe(200)
+
+    const edited = await app.app.inject({
+      method: 'PUT',
+      url: `${ORG}/crons/${cronId}`,
+      payload: body(agentId, { timezone: undefined, trigger: 'a different prompt' })
+    })
+    expect(edited.statusCode).toBe(200)
+    expect((edited.json() as { timezone: string }).timezone).toBe('America/New_York')
+    expect((await prisma.cronDef.findUnique({ where: { id: cronId } }))?.timezone).toBe('America/New_York')
   })
 
   it('stamps creator + createdAt on create; an edit never reassigns the creator but advances last-modified', async () => {

--- a/packages/control-plane/test/integration/mcp.route.test.ts
+++ b/packages/control-plane/test/integration/mcp.route.test.ts
@@ -701,7 +701,7 @@ describe('POST /api/v1/mcp — tools act with the caller’s own authority', () 
       updateAgent: { agentId: randomUUID(), model: 'm' },
       deleteAgent: { agentId: randomUUID(), confirm: 'x' },
       renameDaemon: { daemonId: randomUUID(), name: 'edge' },
-      upsertCron: { agentId: randomUUID(), schedule: '0 9 * * *', trigger: 't' },
+      upsertCron: { agentId: randomUUID(), schedule: '0 9 * * *', timezone: 'UTC', trigger: 't' },
       runCron: { cronId: randomUUID() },
       deleteCron: { cronId: randomUUID(), confirm: 'x' },
       setChannelTrigger: { integrationId: randomUUID(), channelId: 'C1', trigger: 'any' },
@@ -794,19 +794,29 @@ describe('POST /api/v1/mcp — write tools (P1, §6.2 ✎)', () => {
       agentId,
       name: 'daily-digest',
       schedule: '0 9 * * *',
+      // Required: the tool refuses to let a schedule inherit a clock nobody chose.
+      timezone: 'Asia/Shanghai',
       trigger: 'post the digest',
       enabled: false
     })
     expect(created.isError).toBeUndefined()
-    const cron = JSON.parse(toolText(created)) as { id: string; name: string | null; enabled: boolean }
+    const cron = JSON.parse(toolText(created)) as {
+      id: string
+      name: string | null
+      enabled: boolean
+      timezone: string
+    }
     expect(cron.name).toBe('daily-digest')
     expect(cron.enabled).toBe(false)
+    // The zone the caller stated is the zone that gets stored — never the CP process's own.
+    expect(cron.timezone).toBe('Asia/Shanghai')
 
     const edited = await callTool(app, key, 'upsertCron', {
       cronId: cron.id,
       agentId,
       name: 'daily-digest',
       schedule: '0 10 * * *',
+      timezone: 'Asia/Shanghai',
       trigger: 'post the digest',
       enabled: true
     })

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -685,7 +685,7 @@ export interface UpsertCronInput {
   agentId: string // the agent this cron drives — required
   name?: string // console display name
   schedule: string
-  timezone?: string // omitted on create ⇒ control-plane process timezone
+  timezone?: string // omitted ⇒ UTC on create, the schedule's existing zone on an edit
   targetPlatform: string // §6.8 open id — derived from the anchor integration
   targetChannel?: string // optional — absent ⇒ headless fire
   targetIntegrationId?: string // the agent integration posting the anchor (platform derives from it)


### PR DESCRIPTION
## What was wrong

A schedule fires by its timezone, and the server picked one for any caller that did not send it:

```ts
timezone: req.body.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone
```

That reads like "the user's timezone". It is the **control-plane process's** timezone — UTC in a container, the developer's own zone in a test run. Two consequences:

- "Every morning at 9" could mean 9am somewhere the person asking has never been, with nothing anywhere saying so.
- What a stored schedule *means* depended on where the CP ran. Setting `TZ` on the deployment would silently change the meaning of every schedule created without one.

And on an **edit**, the same expression overwrote the stored zone: a caller that sent everything except `timezone` moved a live schedule off the clock it was authored on.

The console has always sent the browser's zone (`AddCronModal` seeds the picker from `Intl.DateTimeFormat().resolvedOptions().timeZone`, and `cronUpdateInput` exists to keep every edit path from dropping it). The gap was the agent-facing surface: MCP `upsertCron` had `timezone` optional with a bare `'IANA timezone name (e.g. "Asia/Shanghai")'` description, so a model asked through the connector for "a daily 9am job" had no reason to send one.

## What this does

**`upsertCron`'s `timezone` is required**, and its description says whose zone it must be:

> IANA timezone the schedule is interpreted in, e.g. `"Asia/Shanghai"`. Use the timezone the person asking lives in — ask them if you do not know it. There is no default.

**The server never guesses**, at the one place a zone is decided:

| | before | after |
| --- | --- | --- |
| create, omitted | the CP process's zone | `UTC` |
| edit, omitted | the CP process's zone (overwrote the stored one) | the zone the schedule already had |

`UTC` as a constant rather than the ambient process zone is the point: a schedule now means the same thing wherever the control plane runs.

The REST body stays optional, so existing callers keep working. It is the agent-facing tool that is strict — that is the caller with a person to ask.

## Breaking

`upsertCron` will now reject a call that omits `timezone`, where it used to accept one and store the server's zone. That is the intended change: a loud failure the model can fix by asking, instead of a schedule quietly running on the wrong clock.

## Verification

- `src/http/mcp/tools.test.ts` — the tool refuses a schedule with no timezone and accepts one with it.
- `test/integration/crons.route.test.ts` — an omitted zone on create stores `UTC` (was: asserted the process zone, which also made the test's expectation depend on the runner's `TZ`); an edit that omits it keeps `America/New_York`; invalid IANA names are still rejected with 400.
- `src/platforms/ids.test.ts` — its `upsertCron` fixture gained a timezone; that case is about the platform vocabulary, not the clock.
- control-plane unit suite 181 files / 2096 tests, plus the cron route integration file (19) against real Postgres. `typecheck`, `lint`, `prettier` clean.
