### PR TITLE
ci: drop the history fetch and the pnpm self-installer from the Windows job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -270,9 +270,6 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
-          # The self-installer runs npm to fetch pnpm and cost 16 s of this job's 40 s setup step;
-          # standalone downloads the binary instead.
-          standalone: true
           cache: true
           # Its own primary key, keyed by the closure it stores rather than by the lockfile alone.
           # Nothing shares this OS today, but the rule is the one the two narrowed Linux jobs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -262,13 +262,17 @@ jobs:
       # every fixture's line endings and diverge golden files from the Linux jobs' bytes.
       - name: Keep line endings as committed
         run: git config --global core.autocrlf false
+      # No history: this job runs two packages' unit suites and one Node script, none of which read
+      # it. `windows-scope` is the only job here that does, for its `git diff BASE...HEAD`.
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
+          # The self-installer runs npm to fetch pnpm and cost 16 s of this job's 40 s setup step;
+          # standalone downloads the binary instead.
+          standalone: true
           cache: true
           # Its own primary key, keyed by the closure it stores rather than by the lockfile alone.
           # Nothing shares this OS today, but the rule is the one the two narrowed Linux jobs


### PR DESCRIPTION
## Why

Setup is **88 s of this job's 329 s**, and two pieces of it are avoidable:

```
40 s  pnpm/action-setup   ├ 16 s  self-installer (runs npm to fetch pnpm)
                          ├  4 s  cache download
                          └ 18 s  tar extract
22 s  Install
10 s  Checkout            ← 7.6 s of it is the full-history fetch
 8 s  setup-node
```

## What

**`fetch-depth: 0` → default.** This job runs two packages' unit suites and `merge-vitest-summaries.mjs`, which imports Node built-ins only. None read git history. `windows-scope` is the only job in this workflow that does — its `git diff BASE...HEAD` — and it keeps its full clone.

**`standalone: true`.** Downloads the pnpm binary instead of running the npm-based self-installer, which is the 16 s between `Running self-installer...` and `Installation Completed!` in the log.

## Scope

The other jobs keep `fetch-depth: 0`. The release path's `publish-*-if-changed.sh` read tags, and although they run from a different workflow, checking that per job is a separate change from this one.

## Reading the run

Expect checkout and setup to fall; the test step is untouched. Together these are ~20 s against a job whose four-worker baseline has reproduced within 7 s across four runs, so one run should show it.

## Related, not in this PR

The 558 MB store cache carries ~519 MB it no longer needs — `@openai/codex` and `@anthropic-ai/claude-agent-sdk`, both outside the daemon closure per `pnpm why`. They are there because a fallback restore once handed this job the full store and it was saved under the narrowed key; the primary has hit ever since, so it never shrinks. Clearing the Windows cache entries once would rebuild it from an empty store and take most of the 4 s download and 18 s extract with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
