### PR TITLE
fix(control-plane): name a session's channel from the org directory when the daemon never did

### DIFF
--- a/packages/control-plane/src/http/routes/sessions.channel-name.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.channel-name.test.ts
@@ -1,0 +1,135 @@
+/**
+ * A session's channel label when the reporting daemon never supplied one.
+ *
+ * `session_meta.channelName` is a snapshot the daemon captures from its local name
+ * cache as it emits `event/session`. That cache learns a Slack channel from the bot's
+ * membership listing, so a conversation the agent only ever POSTS into — a schedule
+ * firing at a channel nobody has messaged the bot from — can leave the column null
+ * permanently, and the console fell back to printing the raw platform id. The org's
+ * own conversation directory already holds the name (it is what the Schedules view
+ * resolves its target channel through), so the row DTO reads it as a fallback.
+ */
+import Fastify, { type FastifyInstance } from 'fastify'
+import { describe, expect, it, vi } from 'vitest'
+import type { HttpDeps } from '../deps.js'
+import type { ConversationCoordinate, SessionPageQuery, SessionPageRecord } from '../../persistence/ports.js'
+import { installZod } from '../plugins/zod.js'
+import { sessionRoutes } from './sessions.js'
+
+const ORG_ID = 'org-1'
+const AGENT_ID = 'agent-1'
+const HOOK_ID = '11111111-1111-4111-8111-111111111111'
+const CRON_ID = '22222222-2222-4222-8222-222222222222'
+const at = new Date('2026-08-30T02:00:00Z')
+
+/** A directory entry the daemon's own cache is missing — the case under test. */
+const DIRECTORY = [{ platform: 'slack', channelId: 'C0AAA0AAA00', name: 'deploys' }]
+
+function row(overrides: Record<string, unknown>) {
+  return {
+    id: 'sess-1',
+    agentId: AGENT_ID,
+    platform: 'slack',
+    channel: 'C0AAA0AAA00',
+    thread: null,
+    triggeredBy: `cron:${CRON_ID}`,
+    channelName: null,
+    triggeredByName: null,
+    hookKind: null,
+    lastActivityAt: at,
+    startedAt: at,
+    visibility: 'org',
+    externalProvider: null,
+    externalResolution: null,
+    ...overrides
+  }
+}
+
+function fakeDeps(sessions: ReturnType<typeof row>[]) {
+  const namesForOrg = vi.fn(async (_orgId: string, conversations: readonly ConversationCoordinate[]) =>
+    DIRECTORY.filter((entry) =>
+      conversations.some((c) => c.platform === entry.platform && c.channelId === entry.channelId)
+    )
+  )
+  const listPage = vi.fn<(q: SessionPageQuery) => Promise<SessionPageRecord>>(async () => ({
+    sessions: sessions as unknown as SessionPageRecord['sessions'],
+    total: sessions.length,
+    hasMore: false
+  }))
+  const deps = {
+    repos: {
+      agent: { list: vi.fn(async () => [{ id: AGENT_ID, name: 'build-agent', orgId: ORG_ID }]) },
+      session: {
+        listPage,
+        listFacets: vi.fn(async () => ({ agents: [], integrations: [], channels: [], triggers: [] })),
+        listConversationPage: vi.fn(async () => ({ conversations: [], total: 0, hasMore: false })),
+        orgHasAny: vi.fn(async () => true),
+        listExternalScopes: vi.fn(async () => []),
+        getExternalScopes: vi.fn(async () => []),
+        getExternalAccessPolicy: vi.fn(async () => null)
+      },
+      hook: {
+        getMany: vi.fn(async () => [
+          { id: HOOK_ID, agentId: AGENT_ID, kind: 'webhook', name: 'nightly', repoId: null }
+        ]),
+        listIdsForOrgKind: vi.fn(async () => []),
+        listForOrgKind: vi.fn(async () => [])
+      },
+      integrationChannel: { namesForOrg }
+    },
+    clock: { now: () => Date.now() }
+  } as unknown as HttpDeps
+  return { deps, namesForOrg }
+}
+
+async function app(deps: HttpDeps): Promise<FastifyInstance> {
+  const instance = Fastify()
+  installZod(instance)
+  instance.addHook('onRequest', async (req) => {
+    req.principal = { userId: 'user-1' }
+    req.orgCtx = { orgId: ORG_ID, role: 'collaborator', userId: 'user-1' } as never
+  })
+  await instance.register(sessionRoutes(deps))
+  return instance
+}
+
+async function channelNames(deps: HttpDeps): Promise<Array<string | null>> {
+  const res = await (await app(deps)).inject({ method: 'GET', url: '/sessions?view=flat' })
+  expect(res.statusCode).toBe(200)
+  return (res.json() as { sessions: Array<{ channelName: string | null }> }).sessions.map((s) => s.channelName)
+}
+
+describe('session channel label falls back to the org conversation directory', () => {
+  it('names a channel the reporting daemon never labeled', async () => {
+    const { deps } = fakeDeps([row({})])
+    expect(await channelNames(deps)).toEqual(['deploys'])
+  })
+
+  it('leaves the daemon’s own snapshot alone', async () => {
+    // The daemon reports what it observed at the time; a later rename in the directory
+    // must not rewrite what a historical row says it ran in.
+    const { deps, namesForOrg } = fakeDeps([row({ channelName: 'as-reported' })])
+    expect(await channelNames(deps)).toEqual(['as-reported'])
+    expect(namesForOrg).not.toHaveBeenCalled()
+  })
+
+  it('stays null for a conversation the directory does not know', async () => {
+    const { deps } = fakeDeps([row({ channel: 'C0ZZZ9ZZZ99' })])
+    expect(await channelNames(deps)).toEqual([null])
+  })
+
+  it('never asks the directory about a hook session, whose channel is its hook id', async () => {
+    const { deps, namesForOrg } = fakeDeps([
+      row({ platform: 'hook', channel: HOOK_ID, triggeredBy: `hook:${HOOK_ID}` })
+    ])
+    expect(await channelNames(deps)).toEqual(['nightly'])
+    expect(namesForOrg).not.toHaveBeenCalled()
+  })
+
+  it('asks once per conversation, not once per session', async () => {
+    const { deps, namesForOrg } = fakeDeps([row({ id: 'sess-1' }), row({ id: 'sess-2', thread: 't-2' })])
+    expect(await channelNames(deps)).toEqual(['deploys', 'deploys'])
+    expect(namesForOrg).toHaveBeenCalledTimes(1)
+    expect(namesForOrg.mock.calls[0]?.[1]).toEqual([{ platform: 'slack', channelId: 'C0AAA0AAA00' }])
+  })
+})

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -25,6 +25,7 @@ import {
   AutoMergeErrorReason,
   CODE_HOST_PROVIDERS,
   isCodeHostHookKind,
+  isSessionIdentityPlatform,
   SANDBOX_KEEP_ALIVE_FEATURE,
   originKindOf,
   type CodeHostProvider,
@@ -38,7 +39,7 @@ import { ConnectionClosed } from '../../ws/registry.js'
 import { sessionContentReaders } from '../../domain/session-content.js'
 import { visibilityStateOf } from '../../orchestrator/visibilityPush.js'
 import type { PullRequestView } from '../../github/pull-request-view.service.js'
-import type { SessionMetaRecord } from '../../persistence/ports.js'
+import type { ConversationCoordinate, SessionMetaRecord } from '../../persistence/ports.js'
 import { GithubApiError } from '../../github/api.js'
 import { GitCredDeniedError } from '../../github/service.js'
 import { ProtocolError } from '../../domain/errors.js'
@@ -251,9 +252,48 @@ function sessionIntegration(s: HookSessionRow, hook: HookSessionMetadata | undef
  *  GitLab did — adding one to the shared union fails this file's type-check first. */
 const HOOK_KIND_LABEL: Record<HookKind, string> = { webhook: 'Webhook', github: 'GitHub', gitlab: 'GitLab' }
 
+/** A channel id is only unique within its platform, so the label cache keys on both.
+ *  The space is safe: no platform conversation id we store contains one. */
+function conversationNameKey(platform: string | null, channel: string): string {
+  return `${platform ?? 'slack'} ${channel}`
+}
+
+/**
+ * Names for the conversations in these rows the reporting daemon never labeled, read
+ * from the org's channel directory — the same source a schedule's target channel is
+ * named through.
+ *
+ * `channelName` is a snapshot of the daemon's own name cache at the moment it emitted
+ * `event/session`, and that cache learns a channel from the bot's membership listing.
+ * A conversation the agent only ever POSTS into can therefore leave the column null for
+ * good, leaving the console to print a raw platform id. The directory is durable and
+ * already holds the name, so reading it here repairs existing rows too.
+ */
+async function channelNamesForSessions(
+  deps: HttpDeps,
+  sessions: readonly (HookSessionRow & { channelName: string | null })[],
+  orgId: OrgId
+): Promise<Map<string, string>> {
+  const wanted = new Map<string, ConversationCoordinate>()
+  for (const s of sessions) {
+    const platform = s.platform ?? 'slack'
+    // A session-identity platform holds no conversation of its own here — a hook
+    // session's `channel` is its hook id, and webchat's is its conversation id.
+    if (s.channelName || !s.channel || isSessionIdentityPlatform(platform)) continue
+    wanted.set(conversationNameKey(platform, s.channel), { platform, channelId: s.channel })
+  }
+  const names = new Map<string, string>()
+  if (wanted.size === 0) return names
+  for (const row of await deps.repos.integrationChannel.namesForOrg(orgId, [...wanted.values()])) {
+    names.set(conversationNameKey(row.platform, row.channelId), row.name)
+  }
+  return names
+}
+
 function sessionDisplayMetadata(
   s: HookSessionRow & { channelName: string | null; triggeredByName: string | null },
-  hook: HookSessionMetadata | undefined
+  hook: HookSessionMetadata | undefined,
+  channelNames: ReadonlyMap<string, string>
 ) {
   // Hook kind remains valid after reassignment, but the current name only
   // describes historical rows while the hook still belongs to the same agent.
@@ -262,7 +302,11 @@ function sessionDisplayMetadata(
   const kind = sessionHookKind(s, hook)
   const sourceLabel = HOOK_KIND_LABEL[kind ?? 'webhook']
   return {
-    channelName: s.platform === 'hook' ? (hookName ?? s.channelName ?? null) : (s.channelName ?? null),
+    channelName:
+      s.platform === 'hook'
+        ? (hookName ?? s.channelName ?? null)
+        : (s.channelName ??
+          (s.channel ? (channelNames.get(conversationNameKey(s.platform, s.channel)) ?? null) : null)),
     triggeredByName: s.triggeredBy?.startsWith(HOOK_TRIGGER_PREFIX)
       ? (hookName ?? s.triggeredByName ?? sourceLabel)
       : (s.triggeredByName ?? null)
@@ -272,7 +316,8 @@ function sessionDisplayMetadata(
 function sessionFacets(
   index: SessionFacetIndex,
   hookMetadata: Map<string, HookSessionMetadata>,
-  agentNames: ReadonlyMap<string, string>
+  agentNames: ReadonlyMap<string, string>,
+  channelNames: ReadonlyMap<string, string>
 ) {
   const integrations = new Set<string>()
   const facetAgentNames: Record<string, string> = {}
@@ -308,7 +353,7 @@ function sessionFacets(
   for (const session of index.channels) {
     const channel = session.channel!
     const hook = hookMetadataForSession(hookMetadata, session)
-    const display = sessionDisplayMetadata(session, hook)
+    const display = sessionDisplayMetadata(session, hook, channelNames)
     channels.set(channel, {
       value: channel,
       platform: session.platform ?? 'slack',
@@ -320,7 +365,7 @@ function sessionFacets(
   for (const session of index.triggers) {
     const triggeredBy = session.triggeredBy!
     const hook = hookMetadataForSession(hookMetadata, session)
-    const display = sessionDisplayMetadata(session, hook)
+    const display = sessionDisplayMetadata(session, hook, channelNames)
     const githubRepoId = hook?.kind === 'github' ? (hook.repoId?.toString() ?? null) : null
     triggers.set(triggeredBy, {
       value: triggeredBy,
@@ -343,10 +388,11 @@ function sessionFacets(
 function sessionDto(
   s: SessionPageRow,
   hookMetadata: Map<string, HookSessionMetadata>,
-  agentNames: ReadonlyMap<string, string>
+  agentNames: ReadonlyMap<string, string>,
+  channelNames: ReadonlyMap<string, string>
 ) {
   const hook = hookMetadataForSession(hookMetadata, s)
-  const display = sessionDisplayMetadata(s, hook)
+  const display = sessionDisplayMetadata(s, hook, channelNames)
   return {
     sessionId: s.id,
     sessionKey: {
@@ -668,8 +714,11 @@ export function sessionRoutes(deps: HttpDeps) {
         const { viewer } = await viewerForQuery(req, { agentIds: orgAgentIds.map(AgentId) })
         const index = await deps.repos.session.listFacets({ ...query, viewer })
         const metadataRows = [...index.integrations, ...index.channels, ...index.triggers]
-        const hookMetadata = await hookMetadataForSessions(deps, metadataRows, orgOf(req))
-        return sessionFacets(index, hookMetadata, agentNames)
+        const [hookMetadata, channelNames] = await Promise.all([
+          hookMetadataForSessions(deps, metadataRows, orgOf(req)),
+          channelNamesForSessions(deps, metadataRows, orgOf(req))
+        ])
+        return sessionFacets(index, hookMetadata, agentNames, channelNames)
       }
     )
 
@@ -777,7 +826,10 @@ export function sessionRoutes(deps: HttpDeps) {
           )
           const selected = new Set<string>(selectedAgentIds)
           const rows = members.filter((session) => selected.has(session.agentId))
-          const hookMetadata = await hookMetadataForSessions(deps, rows, orgOf(req))
+          const [hookMetadata, channelNames] = await Promise.all([
+            hookMetadataForSessions(deps, rows, orgOf(req)),
+            channelNamesForSessions(deps, rows, orgOf(req))
+          ])
           return {
             conversations:
               rows.length > 0
@@ -787,7 +839,7 @@ export function sessionRoutes(deps: HttpDeps) {
                       platform: conversationKey.platform,
                       channel: conversationKey.channel,
                       thread: conversationKey.thread,
-                      sessions: rows.map((session) => sessionDto(session, hookMetadata, agentNames)),
+                      sessions: rows.map((session) => sessionDto(session, hookMetadata, agentNames, channelNames)),
                       memberSessionIds: members.map((session) => session.id)
                     }
                   ]
@@ -801,10 +853,13 @@ export function sessionRoutes(deps: HttpDeps) {
 
         if (!grouped) {
           const page = await deps.repos.session.listPage({ ...query, viewer })
-          const hookMetadata = await hookMetadataForSessions(deps, page.sessions, orgOf(req))
+          const [hookMetadata, channelNames] = await Promise.all([
+            hookMetadataForSessions(deps, page.sessions, orgOf(req)),
+            channelNamesForSessions(deps, page.sessions, orgOf(req))
+          ])
           const nextCursor = page.hasMore ? encodeSessionCursor(page.sessions[page.sessions.length - 1]!) : null
           return {
-            sessions: page.sessions.map((session) => sessionDto(session, hookMetadata, agentNames)),
+            sessions: page.sessions.map((session) => sessionDto(session, hookMetadata, agentNames, channelNames)),
             total: page.total,
             nextCursor,
             accessSyncDegraded: access.degraded,
@@ -815,7 +870,10 @@ export function sessionRoutes(deps: HttpDeps) {
 
         const page = await deps.repos.session.listConversationPage({ ...query, viewer })
         const allRows = page.conversations.flatMap((c) => c.sessions)
-        const hookMetadata = await hookMetadataForSessions(deps, allRows, orgOf(req))
+        const [hookMetadata, channelNames] = await Promise.all([
+          hookMetadataForSessions(deps, allRows, orgOf(req)),
+          channelNamesForSessions(deps, allRows, orgOf(req))
+        ])
         // The grouped cursor is the last conversation's REPRESENTATIVE row —
         // emit-at-max makes resumption stateless (§5.2).
         const lastRep = page.conversations[page.conversations.length - 1]?.sessions[0]
@@ -826,7 +884,7 @@ export function sessionRoutes(deps: HttpDeps) {
             platform: c.key.platform,
             channel: c.key.channel,
             thread: c.key.thread,
-            sessions: c.sessions.map((session) => sessionDto(session, hookMetadata, agentNames)),
+            sessions: c.sessions.map((session) => sessionDto(session, hookMetadata, agentNames, channelNames)),
             memberSessionIds: c.memberSessionIds
           })),
           total: page.total,
@@ -869,20 +927,22 @@ export function sessionRoutes(deps: HttpDeps) {
         const orgAgentIdSet = new Set<string>(orgAgentIds)
         const agentNames = new Map(orgAgents.map((agent) => [agent.id, agentDisplayName(agent)]))
         const ctx = ctxOf(req)
-        const [parent, children, siblingCandidates, usage, webchatRoster, hookMetadata] = await Promise.all([
-          s.parentSessionId ? deps.repos.session.get(orgOf(req), s.parentSessionId) : Promise.resolve(null),
-          deps.repos.session.listChildren(SessionId(s.id), orgAgentIds),
-          s.parentSessionId ? deps.repos.session.listChildren(s.parentSessionId, orgAgentIds) : Promise.resolve([]),
-          deps.repos.sessionUsage.get(s.agentId, s.id),
-          // A webchat session's channel IS its conversation id; the roster feeds
-          // the adopted-session composer/header, which has no relay socket.
-          s.platform === 'webchat' && s.channel
-            ? deps.repos.webchatConversation.participants(orgOf(req), s.channel)
-            : Promise.resolve([]),
-          hookMetadataForSessions(deps, [s], orgOf(req))
-        ])
+        const [parent, children, siblingCandidates, usage, webchatRoster, hookMetadata, channelNames] =
+          await Promise.all([
+            s.parentSessionId ? deps.repos.session.get(orgOf(req), s.parentSessionId) : Promise.resolve(null),
+            deps.repos.session.listChildren(SessionId(s.id), orgAgentIds),
+            s.parentSessionId ? deps.repos.session.listChildren(s.parentSessionId, orgAgentIds) : Promise.resolve([]),
+            deps.repos.sessionUsage.get(s.agentId, s.id),
+            // A webchat session's channel IS its conversation id; the roster feeds
+            // the adopted-session composer/header, which has no relay socket.
+            s.platform === 'webchat' && s.channel
+              ? deps.repos.webchatConversation.participants(orgOf(req), s.channel)
+              : Promise.resolve([]),
+            hookMetadataForSessions(deps, [s], orgOf(req)),
+            channelNamesForSessions(deps, [s], orgOf(req))
+          ])
         const hook = hookMetadataForSession(hookMetadata, s)
-        const display = sessionDisplayMetadata(s, hook)
+        const display = sessionDisplayMetadata(s, hook, channelNames)
         // Continuation gate (webchat-cross-integration-continuation.md §6.5):
         // the same predicate + state checks the mint route applies, projected as
         // one server-computed flag + bounded product-language reason.

--- a/packages/control-plane/src/http/routes/sessions.viewer-identity.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.viewer-identity.test.ts
@@ -98,7 +98,8 @@ function fakeDeps(overrides: {
         listFacets: vi.fn(async () => ({ agents: [], integrations: [], channels: [], triggers: [] }))
       },
       sessionUsage: { get: vi.fn(async () => null) },
-      hook: { getMany: vi.fn(async () => []) }
+      hook: { getMany: vi.fn(async () => []) },
+      integrationChannel: { namesForOrg: vi.fn(async () => []) }
     },
     clock: { now: () => Date.now() },
     ...(overrides.slackIdentityFor

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4620,6 +4620,25 @@ export interface IntegrationChannelRepo {
     agentId: AgentId,
     opts?: { defaultTrigger?: ChannelTrigger; kind?: ConversationKind }
   ): Promise<IntegrationChannelRecord>
+  /**
+   * The org's conversation-name directory for the given coordinates — the read a
+   * surface makes when it holds a platform conversation id and wants the human name
+   * for it. Org-fenced through the owning integration (§3.6), so a foreign org's
+   * conversation is simply absent. Unnamed rows are omitted rather than returned null:
+   * the caller wants a name or nothing.
+   */
+  namesForOrg(orgId: OrgId, conversations: readonly ConversationCoordinate[]): Promise<IntegrationChannelNameRecord[]>
+}
+
+/** One conversation addressed the way a session key addresses it, not by integration. */
+export interface ConversationCoordinate {
+  platform: string
+  channelId: string
+}
+
+/** A named conversation from the org's directory, keyed by its platform coordinates. */
+export interface IntegrationChannelNameRecord extends ConversationCoordinate {
+  name: string
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -28,6 +28,8 @@ import type {
   IntegrationStatus,
   IntegrationChannelRepo,
   IntegrationChannelRecord,
+  IntegrationChannelNameRecord,
+  ConversationCoordinate,
   ReportedChannel,
   ChannelTrigger,
   ConversationKind,
@@ -923,5 +925,35 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
       where: { integrationId_channelId: { integrationId, channelId } }
     })
     return row ? toChannelRecord(row) : null
+  }
+
+  async namesForOrg(
+    orgId: OrgId,
+    conversations: readonly ConversationCoordinate[]
+  ): Promise<IntegrationChannelNameRecord[]> {
+    if (conversations.length === 0) return []
+    const platforms = [...new Set(conversations.map((c) => c.platform))]
+    const channelIds = [...new Set(conversations.map((c) => c.channelId))]
+    // The org fence rides on the parent integration (§3.6); the platform narrows the
+    // cross-product this coarse `IN` pair admits, and the caller keys on both anyway.
+    const rows = await this.db.integrationChannel.findMany({
+      where: {
+        channelId: { in: channelIds },
+        name: { not: null },
+        integration: { orgId, platform: { in: platforms } }
+      },
+      select: { channelId: true, name: true, integration: { select: { platform: true } } },
+      orderBy: [{ integrationId: 'asc' }, { channelId: 'asc' }]
+    })
+    const wanted = new Set(conversations.map((c) => `${c.platform} ${c.channelId}`))
+    const named = new Map<string, IntegrationChannelNameRecord>()
+    for (const row of rows) {
+      const key = `${row.integration.platform} ${row.channelId}`
+      // Shared-bot siblings repeat the conversation; the ordered first row wins so the
+      // answer is stable across requests rather than whichever row the planner emits.
+      if (!wanted.has(key) || named.has(key)) continue
+      named.set(key, { platform: row.integration.platform, channelId: row.channelId, name: row.name! })
+    }
+    return [...named.values()]
   }
 }

--- a/packages/control-plane/test/integration/tenant-isolation.route.test.ts
+++ b/packages/control-plane/test/integration/tenant-isolation.route.test.ts
@@ -18,7 +18,11 @@ import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgAgentRepo } from '../../src/persistence/repositories/agent.repo.js'
 import { PgDaemonRepo } from '../../src/persistence/repositories/daemon.repo.js'
-import { PgBotRepo, PgIntegrationRepo } from '../../src/persistence/repositories/integration.repo.js'
+import {
+  PgBotRepo,
+  PgIntegrationChannelRepo,
+  PgIntegrationRepo
+} from '../../src/persistence/repositories/integration.repo.js'
 import { PgCronRepo } from '../../src/persistence/repositories/cron.repo.js'
 import { PgHookRepo } from '../../src/persistence/repositories/hook.repo.js'
 import { PgMcpProviderRepo } from '../../src/persistence/repositories/mcp.repo.js'
@@ -793,6 +797,16 @@ describe('tenant isolation — Integration and its conversation rows over the RE
     })
     expect(leave.statusCode).toBe(404)
     await foreignIntegrationUnmodified()
+  })
+
+  it('the conversation-name directory answers for the caller’s org only', async () => {
+    const channels = new PgIntegrationChannelRepo(prisma)
+    const coordinates = [{ platform: 'slack', channelId: foreignChannelId }]
+    expect(await channels.namesForOrg(CALLER_ORG, coordinates)).toEqual([])
+    // Proof the row is genuinely there — it is the FENCE that hides it, not a bad id.
+    expect(await channels.namesForOrg(OrgId(foreignOrgId), coordinates)).toEqual([
+      { platform: 'slack', channelId: foreignChannelId, name: 'foreign-channel' }
+    ])
   })
 })
 


### PR DESCRIPTION
## The bug

A session whose channel the reporting daemon never labeled rendered the **raw platform conversation id** — in the session list rows and in the detail header chip — while the schedule that created it rendered the same channel by name.

## Why the two views disagreed

They read different sources.

- The schedule view resolves its target channel against the org's **conversation directory** (`integration_channel`), which is durable and keeps the name.
- The session view had no lookup at all. `session_meta.channelName` is a *snapshot* the daemon captures from its own local name cache at the moment it emits `event/session`, and the control plane passes it straight through.

That cache learns a chat channel from the bot's **membership listing**. A conversation an agent only ever *posts into* — a schedule firing at a channel nobody has messaged the bot from — may never enter it, so the column stays null for the session's whole life and nothing ever repairs it. The directory, meanwhile, is already holding the name the console wants.

## The change

Give the sessions read path the same fallback the schedule view already had: when the daemon supplied no name, resolve the conversation through the org directory.

- New `IntegrationChannelRepo.namesForOrg(orgId, coordinates)` — org-fenced through the owning integration (`org-scoped-data-layer.md` §3.6), keyed by `(platform, channelId)` because a channel id is only unique within its platform.
- One batched lookup per page, and only for rows that actually need it: a row the daemon named is never looked up, and neither is a session-identity platform, whose `channel` is a hook id or a conversation id rather than a conversation.
- The daemon's own snapshot still wins where it exists, so a historical row keeps the name it ran under. Rows already stored without one are repaired **on read** — no backfill or migration.

Applies to every session surface at once, since all of them funnel through `sessionDisplayMetadata`: the flat list, the grouped conversation list, the detail header, and the channel facet.

## Tests

- `sessions.channel-name.test.ts` — names an unlabeled channel; leaves a daemon-supplied name alone (and skips the lookup entirely); stays null for a conversation the directory doesn't know; never queries for a hook session; asks once per conversation rather than once per session.
- `tenant-isolation.route.test.ts` — the new directory read answers for the caller's org only, with the foreign row proven present under its own org so it is the fence being tested, not a bad id.

`pnpm typecheck`, `pnpm lint`, `pnpm format:check`, control-plane unit (2100) and integration (1825) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
