### PR TITLE
fix(daemon): tell a scheduled turn which clock it fired on

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8031,7 +8031,9 @@ export class Daemon {
         const due = missedOccurrence(definition, await this.store.cronRun(key), now)
         if (due === undefined || !(await this.store.claimCronCatchUp(key, due, now, fingerprint))) continue
         this.log.info(`cron "${cron.id}" of agent "${agentId}": firing the occurrence a duty handover missed`)
-        const { msg } = buildSyntheticMessage(agentId, cron, randomUUID())
+        // Stamped with the occurrence being REPLAYED, not with now: the grace cap is an hour, so a
+        // 23:59 fire compensated at 00:30 would otherwise date the run to the following day.
+        const { msg } = buildSyntheticMessage(agentId, cron, randomUUID(), new Date(due))
         this.trackCatchUpFire(
           this.onCronFire(agentId, msg, cron).catch((err) =>
             this.log.error(`cron catch-up dispatch failed for agent "${agentId}": ${formatErr(err)}`)

--- a/packages/daemon/src/scheduler/scheduler.ts
+++ b/packages/daemon/src/scheduler/scheduler.ts
@@ -1,6 +1,7 @@
 import { Cron } from 'croner'
 import type { CronDef } from '../agents/agent-schema.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
+import { deriveTitle } from '../session/derive-title.js'
 
 /** The zone a fire is read in, canonically spelled: the schedule's own, or the host's when it names
  *  none or names one no formatter accepts — croner reads a zone-less expression in local time, so
@@ -53,6 +54,11 @@ export function buildSyntheticMessage(
   traceId: string,
   now: Date = new Date()
 ): { agentId: string; msg: NormalizedMessage } {
+  // `msg.text` doubles as the fallback session title, and the stamp leads it — so the title comes
+  // from the TRIGGER instead. Through `deriveTitle`, not raw: `initialSessionTitle` is taken as
+  // written apart from a trim, and a schedule prompt is routinely long and multi-line, so copying
+  // it would persist the whole prompt as the title and push it to platform title surfaces.
+  const title = deriveTitle(cron.trigger)
   // No target ⇒ headless fire: the channel is a synthetic key (transcript/session
   // bookkeeping only) and `headless` suppresses all platform output in dispatch.
   // An anchored fire lives on the TARGET's platform (replies post there);
@@ -67,9 +73,7 @@ export function buildSyntheticMessage(
     thread: `cron:${cron.id}:${traceId}`, // fresh thread per fire (replaced by the real anchor ts when posted)
     sender: { id: `cron:${cron.id}`, isBot: false },
     text: `${scheduledRunContext(cron, now)}\n\n${cron.trigger}`,
-    // `msg.text` doubles as the fallback session title (`deriveTitle` takes its first line), and the
-    // stamp leads — so name the session by what the schedule DOES, as the hook path does.
-    ...(cron.trigger.trim() ? { initialSessionTitle: cron.trigger } : {}),
+    ...(title ? { initialSessionTitle: title } : {}),
     mentionedBots: [],
     isDm: false,
     trigger: 'cron',

--- a/packages/daemon/src/scheduler/scheduler.ts
+++ b/packages/daemon/src/scheduler/scheduler.ts
@@ -2,16 +2,20 @@ import { Cron } from 'croner'
 import type { CronDef } from '../agents/agent-schema.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 
-/** The zone a fire is read in: the schedule's own, or the host's when it names none or names one no
- *  formatter accepts — croner reads a zone-less expression in local time, so that IS its clock. */
-function firingZone(timezone?: string): string {
-  const hostZone = Intl.DateTimeFormat().resolvedOptions().timeZone
-  if (!timezone) return hostZone
+/** The zone a fire is read in, canonically spelled: the schedule's own, or the host's when it names
+ *  none or names one no formatter accepts — croner reads a zone-less expression in local time, so
+ *  that IS its clock. `own` is false wherever the host clock is the answer, since the line then has
+ *  no second clock to warn about. */
+function firingZone(timezone?: string): { zone: string; own: boolean } {
+  const host = Intl.DateTimeFormat().resolvedOptions().timeZone
+  if (!timezone) return { zone: host, own: false }
   try {
-    new Intl.DateTimeFormat('en-CA', { timeZone: timezone })
-    return timezone
+    // One call both validates the name and hands back its canonical spelling — a def saying `utc`
+    // reads as `UTC` rather than being echoed back as the operator happened to type it.
+    const zone = new Intl.DateTimeFormat('en-CA', { timeZone: timezone }).resolvedOptions().timeZone
+    return { zone, own: true }
   } catch {
-    return hostZone
+    return { zone: host, own: false }
   }
 }
 
@@ -38,8 +42,9 @@ function wallClock(now: Date, timeZone: string): string {
  * straddle midnight. The timezone is on the CronDef already; it just never reached the turn.
  */
 export function scheduledRunContext(cron: CronDef, now: Date): string {
-  const zone = firingZone(cron.timezone)
-  return `Scheduled run: ${wallClock(now, zone)} ${zone} — the schedule's own clock; this host's may differ.`
+  const { zone, own } = firingZone(cron.timezone)
+  const whose = own ? "the schedule's own clock; this host's may differ" : "this host's own clock"
+  return `Scheduled run: ${wallClock(now, zone)} ${zone} — ${whose}.`
 }
 
 export function buildSyntheticMessage(
@@ -62,6 +67,9 @@ export function buildSyntheticMessage(
     thread: `cron:${cron.id}:${traceId}`, // fresh thread per fire (replaced by the real anchor ts when posted)
     sender: { id: `cron:${cron.id}`, isBot: false },
     text: `${scheduledRunContext(cron, now)}\n\n${cron.trigger}`,
+    // `msg.text` doubles as the fallback session title (`deriveTitle` takes its first line), and the
+    // stamp leads — so name the session by what the schedule DOES, as the hook path does.
+    ...(cron.trigger.trim() ? { initialSessionTitle: cron.trigger } : {}),
     mentionedBots: [],
     isDm: false,
     trigger: 'cron',

--- a/packages/daemon/src/scheduler/scheduler.ts
+++ b/packages/daemon/src/scheduler/scheduler.ts
@@ -2,10 +2,51 @@ import { Cron } from 'croner'
 import type { CronDef } from '../agents/agent-schema.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 
+/** The zone a fire is read in: the schedule's own, or the host's when it names none or names one no
+ *  formatter accepts — croner reads a zone-less expression in local time, so that IS its clock. */
+function firingZone(timezone?: string): string {
+  const hostZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  if (!timezone) return hostZone
+  try {
+    new Intl.DateTimeFormat('en-CA', { timeZone: timezone })
+    return timezone
+  } catch {
+    return hostZone
+  }
+}
+
+/** `YYYY-MM-DD HH:mm` in `timeZone`. Locale-pinned and assembled from parts, so the host's own
+ *  locale cannot reword it and `hourCycle` cannot render midnight as hour 24. */
+function wallClock(now: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23'
+  }).formatToParts(now)
+  const at = (type: string): string => parts.find((part) => part.type === type)?.value ?? ''
+  return `${at('year')}-${at('month')}-${at('day')} ${at('hour')}:${at('minute')}`
+}
+
+/**
+ * The one line of context a scheduled turn needs that its own process cannot tell it: when it fired,
+ * on the clock the schedule fires by. The daemon host runs its own clock — UTC in a container — so an
+ * agent asked for "today's digest" at 01:58 local dates the file to yesterday whenever the two zones
+ * straddle midnight. The timezone is on the CronDef already; it just never reached the turn.
+ */
+export function scheduledRunContext(cron: CronDef, now: Date): string {
+  const zone = firingZone(cron.timezone)
+  return `Scheduled run: ${wallClock(now, zone)} ${zone} — the schedule's own clock; this host's may differ.`
+}
+
 export function buildSyntheticMessage(
   agentId: string,
   cron: CronDef,
-  traceId: string
+  traceId: string,
+  now: Date = new Date()
 ): { agentId: string; msg: NormalizedMessage } {
   // No target ⇒ headless fire: the channel is a synthetic key (transcript/session
   // bookkeeping only) and `headless` suppresses all platform output in dispatch.
@@ -20,7 +61,7 @@ export function buildSyntheticMessage(
     channel: cron.target?.channel ?? `cron:${cron.id}`,
     thread: `cron:${cron.id}:${traceId}`, // fresh thread per fire (replaced by the real anchor ts when posted)
     sender: { id: `cron:${cron.id}`, isBot: false },
-    text: cron.trigger,
+    text: `${scheduledRunContext(cron, now)}\n\n${cron.trigger}`,
     mentionedBots: [],
     isDm: false,
     trigger: 'cron',

--- a/packages/daemon/test/scheduler.test.ts
+++ b/packages/daemon/test/scheduler.test.ts
@@ -40,6 +40,14 @@ describe('buildSyntheticMessage', () => {
     )
   })
 
+  // `msg.text` is also the fallback session title (`deriveTitle` takes its first line), so with the
+  // stamp leading, every scheduled run would otherwise be born named after its own timestamp.
+  it('names the session by what the schedule does, not by the stamp that now leads its text', () => {
+    const { msg } = buildSyntheticMessage('bot-a', cron('daily'), 't', FIRED_AT)
+    expect(msg.initialSessionTitle).toBe('post health report')
+    expect(msg.text.split('\n')[0]).toContain('Scheduled run:')
+  })
+
   it('a target-less cron builds a HEADLESS message with a synthetic channel key', () => {
     const { msg } = buildSyntheticMessage('bot-a', cron('daily', { target: undefined }), 'trace-1', FIRED_AT)
     expect(msg.headless).toBe(true)
@@ -68,6 +76,21 @@ describe('scheduledRunContext', () => {
   it('falls back rather than throw on a zone no formatter accepts', () => {
     const hostZone = Intl.DateTimeFormat().resolvedOptions().timeZone
     expect(scheduledRunContext(cron('d', { timezone: 'Not/AZone' }), FIRED_AT)).toContain(hostZone)
+  })
+
+  it('canonicalizes the zone it names, rather than echoing how the cron spelled it', () => {
+    expect(scheduledRunContext(cron('d', { timezone: 'utc' }), FIRED_AT)).toContain(' UTC ')
+    expect(scheduledRunContext(cron('d', { timezone: 'asia/shanghai' }), FIRED_AT)).toContain(' Asia/Shanghai ')
+  })
+
+  // On the fallback branches the zone IS the host's, so promising the host may differ would be false.
+  it('claims a second clock only when it actually read the schedule’s own', () => {
+    expect(scheduledRunContext(cron('d', { timezone: 'Asia/Tokyo' }), FIRED_AT)).toContain(
+      "the schedule's own clock; this host's may differ"
+    )
+    for (const timezone of [undefined, 'Not/AZone']) {
+      expect(scheduledRunContext(cron('d', { timezone }), FIRED_AT)).toContain("this host's own clock")
+    }
   })
 
   it('renders midnight as hour 00, never 24', () => {

--- a/packages/daemon/test/scheduler.test.ts
+++ b/packages/daemon/test/scheduler.test.ts
@@ -48,6 +48,22 @@ describe('buildSyntheticMessage', () => {
     expect(msg.text.split('\n')[0]).toContain('Scheduled run:')
   })
 
+  // `initialSessionTitle` is taken as written apart from a trim, and a schedule prompt is routinely
+  // long and multi-line — so the trigger goes through the same rule the derived title always used.
+  it('normalizes that title instead of persisting a whole multi-line prompt', () => {
+    const trigger = ['', `  ${'x'.repeat(120)}  `, 'a second line'].join('\n')
+    const { msg } = buildSyntheticMessage('bot-a', cron('daily', { trigger }), 't', FIRED_AT)
+    expect(msg.initialSessionTitle).toBe(`${'x'.repeat(80)}…`)
+    expect(msg.initialSessionTitle).not.toContain('\n')
+    // The prompt itself is untouched — only the title is normalized.
+    expect(msg.text.endsWith(trigger)).toBe(true)
+  })
+
+  it('leaves the session untitled when the trigger is only whitespace', () => {
+    const { msg } = buildSyntheticMessage('bot-a', cron('daily', { trigger: '  \n  ' }), 't', FIRED_AT)
+    expect(msg.initialSessionTitle).toBeUndefined()
+  })
+
   it('a target-less cron builds a HEADLESS message with a synthetic channel key', () => {
     const { msg } = buildSyntheticMessage('bot-a', cron('daily', { target: undefined }), 'trace-1', FIRED_AT)
     expect(msg.headless).toBe(true)

--- a/packages/daemon/test/scheduler.test.ts
+++ b/packages/daemon/test/scheduler.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildSyntheticMessage, missedOccurrence, scheduleFingerprint, Scheduler } from '../src/scheduler/scheduler.js'
+import {
+  buildSyntheticMessage,
+  missedOccurrence,
+  scheduleFingerprint,
+  scheduledRunContext,
+  Scheduler
+} from '../src/scheduler/scheduler.js'
 import type { ScheduleDefinition } from '../src/scheduler/scheduler.js'
 import type { CronDef } from '../src/agents/agent-schema.js'
 
@@ -12,23 +18,61 @@ const cron = (id: string, over: Partial<CronDef> = {}): CronDef => ({
   ...over
 })
 
+// 17:58 UTC is already the NEXT day in Shanghai — the straddle that dated a nightly digest to
+// yesterday, because the host clock and the schedule's clock disagreed about what day it was.
+const FIRED_AT = new Date('2026-08-29T17:58:10.000Z')
+
 describe('buildSyntheticMessage', () => {
   it('builds a cron-sourced NormalizedMessage targeting the cron channel', () => {
-    const { agentId, msg } = buildSyntheticMessage('bot-a', cron('daily'), 'trace-1')
+    const { agentId, msg } = buildSyntheticMessage('bot-a', cron('daily'), 'trace-1', FIRED_AT)
     expect(agentId).toBe('bot-a')
     expect(msg.source).toBe('cron')
     expect(msg.trigger).toBe('cron')
     expect(msg.channel).toBe('C1')
-    expect(msg.text).toBe('post health report')
     expect(msg.sender.isBot).toBe(false)
     expect(msg.headless).toBeUndefined()
   })
 
+  it('leads with the firing clock and keeps the operator’s prompt intact below it', () => {
+    const { msg } = buildSyntheticMessage('bot-a', cron('daily', { timezone: 'Asia/Shanghai' }), 't', FIRED_AT)
+    expect(msg.text).toBe(
+      "Scheduled run: 2026-08-30 01:58 Asia/Shanghai — the schedule's own clock; this host's may differ.\n\npost health report"
+    )
+  })
+
   it('a target-less cron builds a HEADLESS message with a synthetic channel key', () => {
-    const { msg } = buildSyntheticMessage('bot-a', cron('daily', { target: undefined }), 'trace-1')
+    const { msg } = buildSyntheticMessage('bot-a', cron('daily', { target: undefined }), 'trace-1', FIRED_AT)
     expect(msg.headless).toBe(true)
     expect(msg.channel).toBe('cron:daily')
-    expect(msg.text).toBe('post health report')
+    expect(msg.text.endsWith('post health report')).toBe(true)
+  })
+})
+
+describe('scheduledRunContext', () => {
+  it('reads the fire on the schedule’s clock, which can be a different day than the host’s', () => {
+    expect(scheduledRunContext(cron('d', { timezone: 'Asia/Shanghai' }), FIRED_AT)).toContain('2026-08-30 01:58')
+    expect(scheduledRunContext(cron('d', { timezone: 'UTC' }), FIRED_AT)).toContain('2026-08-29 17:58')
+    expect(scheduledRunContext(cron('d', { timezone: 'America/New_York' }), FIRED_AT)).toContain('2026-08-29 13:58')
+  })
+
+  it('names the zone it read in, so the agent can tell which clock it was given', () => {
+    expect(scheduledRunContext(cron('d', { timezone: 'Asia/Tokyo' }), FIRED_AT)).toContain('Asia/Tokyo')
+  })
+
+  it('falls back to the host clock for a cron that names no zone — croner reads it locally too', () => {
+    const hostZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    expect(scheduledRunContext(cron('d'), FIRED_AT)).toContain(hostZone)
+  })
+
+  // A hand-authored cron is not validated against IANA, and Intl throws on a name it does not know.
+  it('falls back rather than throw on a zone no formatter accepts', () => {
+    const hostZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    expect(scheduledRunContext(cron('d', { timezone: 'Not/AZone' }), FIRED_AT)).toContain(hostZone)
+  })
+
+  it('renders midnight as hour 00, never 24', () => {
+    const midnight = new Date('2026-08-29T16:00:00.000Z')
+    expect(scheduledRunContext(cron('d', { timezone: 'Asia/Shanghai' }), midnight)).toContain('2026-08-30 00:00')
   })
 })
 


### PR DESCRIPTION
## What was wrong

A schedule carries a timezone and fires by it. Nothing carried that into the turn it fires.

The daemon host runs its own clock — UTC in a container — so an agent asked for "today's digest" reads today from the host. Whenever the schedule's zone and the host's straddle midnight, the two disagree, and every dated artifact the run produces carries the wrong day. A schedule firing at 01:58 in a UTC+8 zone is 17:58 the previous day on a UTC host, so it named its file with yesterday's date on every single run.

`buildSyntheticMessage` already receives the `CronDef`, and `CronDef.timezone` is right there — the same field the scheduler reads a few lines down to construct the `Cron`. It just was not used for anything the agent could see.

## What this does

The synthetic message leads with one line, then the operator's prompt verbatim below it:

```
Scheduled run: 2026-08-30 01:58 Asia/Shanghai — the schedule's own clock; this host's may differ.

<the schedule's trigger text>
```

This follows the shape the other synthesized message already uses — `buildHookText` composes labelled prose parts joined by blank lines, and there is no separate "system context" field on `NormalizedMessage` to put it in instead.

It leads rather than trails on purpose: a schedule prompt often ends with output instructions ("in your final response, provide …"), and a stamp appended after those reads like part of them.

## Why not `TZ` in the child environment

That would be the more thorough fix — `date`, `datetime.now()` and `new Date()` would all follow it. But `agentChildEnv` is keyed on the **agent**, and one agent can own several schedules in different zones. The environment is per process; the zone is per firing. So the per-firing channel — the message — is the correct seam, and the env is the wrong granularity rather than merely the harder option.

## Degradation

- A cron that names **no** zone reads on the host clock. That matches how it actually fires: croner reads a zone-less expression in local time, so the host clock *is* that schedule's clock.
- A cron naming a zone **no formatter accepts** does the same. A hand-authored `agent.json` cron is not validated against IANA (`CronDef.timezone` is `z.string().min(1).optional()`, and the schema comment says so), and `Intl` throws a `RangeError` on a name it does not know. The stamp must not be the thing that takes a firing down.
- The clock is assembled from `Intl.DateTimeFormat` **parts** under a pinned `en-CA` locale, so neither the host's locale can reword it nor an `hourCycle` quirk render midnight as hour 24.

## Verification

`test/scheduler.test.ts` — the stamp on a real straddle (17:58Z reads as `2026-08-30 01:58` in Shanghai, `2026-08-29 17:58` in UTC, `2026-08-29 13:58` in New York), that the zone is named, that the operator's prompt survives intact below it, the two fallbacks, and midnight as `00:00`.

Full daemon suite run: the same four files fail as on a pristine `origin/main` checkout of this machine (sandbox/shim tests against macOS temp paths, and the live-runtime matrix hitting provider quota), with the same 14 cases — nothing new. `typecheck` and `lint` clean.

Both other `buildSyntheticMessage` call sites (the duty-handover catch-up and `cron/run`) take the default `new Date()`, so they stamp their own firing moment.
