### PR TITLE
build: pin the pnpm version the workflows install, and move to 11.19.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -332,6 +332,9 @@ jobs:
       - uses: pnpm/action-setup@v6
         if: matrix.verify == 'runtime-sandbox'
         with:
+          # Pinned so the action installs this once; unpinned it fetches npm's latest first.
+          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
+          version: 11.19.0
           cache: true
       - uses: actions/setup-node@v6
         if: matrix.verify == 'runtime-sandbox'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,6 +74,9 @@ jobs:
       # placeholder that setup-node writes to .npmrc); 11.9.0 satisfies this.
       - uses: pnpm/action-setup@v6
         with:
+          # Pinned so the action installs this once; unpinned it fetches npm's latest first.
+          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
+          version: 11.19.0
           cache: true
       # registry-url makes pnpm publish target npmjs; no token is set, so pnpm
       # authenticates via the OIDC id-token granted above.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,10 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
+          # Pinned so the action installs this once. Unpinned it fetches npm's latest, then reads
+          # `packageManager` and downloads the pinned one too — 11 s and 13 s of a 26 s step.
+          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
+          version: 11.19.0
           cache: true
       - uses: actions/setup-node@v6
         with:
@@ -89,6 +93,10 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
+          # Pinned so the action installs this once. Unpinned it fetches npm's latest, then reads
+          # `packageManager` and downloads the pinned one too — 11 s and 13 s of a 26 s step.
+          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
+          version: 11.19.0
           cache: true
       - uses: actions/setup-node@v6
         with:
@@ -140,6 +148,10 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
+          # Pinned so the action installs this once. Unpinned it fetches npm's latest, then reads
+          # `packageManager` and downloads the pinned one too — 11 s and 13 s of a 26 s step.
+          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
+          version: 11.19.0
           cache: true
       - uses: actions/setup-node@v6
         with:
@@ -269,6 +281,10 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
+          # Pinned so the action installs this once. Unpinned it fetches npm's latest, then reads
+          # `packageManager` and downloads the pinned one too — 11 s and 13 s of a 26 s step.
+          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
+          version: 11.19.0
           cache: true
           # Its own primary key, keyed by the closure it stores rather than by the lockfile alone.
           # Nothing shares this OS today, but the rule is the one the two narrowed Linux jobs
@@ -352,6 +368,10 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
+          # Pinned so the action installs this once. Unpinned it fetches npm's latest, then reads
+          # `packageManager` and downloads the pinned one too — 11 s and 13 s of a 26 s step.
+          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
+          version: 11.19.0
           cache: true
       - uses: actions/setup-node@v6
         with:
@@ -387,6 +407,10 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
+          # Pinned so the action installs this once. Unpinned it fetches npm's latest, then reads
+          # `packageManager` and downloads the pinned one too — 11 s and 13 s of a 26 s step.
+          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
+          version: 11.19.0
           cache: true
           # Its own PRIMARY key. The default one is shared by every job on this runner OS, so the
           # filtered subset this job stores would otherwise be what `build`, `check` and `unit`
@@ -449,6 +473,10 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
+          # Pinned so the action installs this once. Unpinned it fetches npm's latest, then reads
+          # `packageManager` and downloads the pinned one too — 11 s and 13 s of a 26 s step.
+          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
+          version: 11.19.0
           cache: true
           # Its own primary key, for the reason the sandbox job gives.
           cache_dependency_path: |
@@ -490,6 +518,10 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
+          # Pinned so the action installs this once. Unpinned it fetches npm's latest, then reads
+          # `packageManager` and downloads the pinned one too — 11 s and 13 s of a 26 s step.
+          # `scripts/pnpm-version.test.mjs` fails if this drifts from package.json.
+          version: 11.19.0
           cache: true
       - uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
   "engines": {
     "node": ">=24.12.0"
   },
-  "packageManager": "pnpm@11.9.0"
+  "packageManager": "pnpm@11.19.0"
 }

--- a/scripts/pnpm-version.test.mjs
+++ b/scripts/pnpm-version.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+// The workflows pin `version:` so `pnpm/action-setup` installs once instead of fetching npm's
+// latest and then downloading the pinned one as well. That pin duplicates what `packageManager`
+// already declares, and a duplicate that can drift is only safe if something notices.
+const declared = JSON.parse(readFileSync('package.json', 'utf8')).packageManager
+const expected = declared.replace(/^pnpm@/, '')
+
+test('every workflow pins the pnpm version package.json declares', () => {
+  assert.match(declared, /^pnpm@\d+\.\d+\.\d+$/)
+  const dir = '.github/workflows'
+  const offenders = []
+  for (const name of readdirSync(dir).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))) {
+    const body = readFileSync(join(dir, name), 'utf8')
+    const uses = body.split('\n').filter((line) => line.includes('pnpm/action-setup')).length
+    const pinned = [...body.matchAll(/^\s*version:\s*(\S+)\s*$/gm)].map((m) => m[1])
+    const wrong = pinned.filter((v) => /^\d+\.\d+\.\d+$/.test(v) && v !== expected)
+    if (uses > 0 && pinned.filter((v) => v === expected).length < uses)
+      offenders.push(`${name}: ${uses} uses, ${pinned.filter((v) => v === expected).length} pinned to ${expected}`)
+    if (wrong.length) offenders.push(`${name}: pins ${wrong.join(', ')}`)
+  }
+  assert.deepEqual(offenders, [])
+})


### PR DESCRIPTION
## Why

`pnpm/action-setup` installs pnpm **twice** when the version is not pinned. The Windows log spells it out:

```
00:28:54  Running self-installer...
00:29:05  added 5 packages                          ← 11 s, npm fetches latest (11.19.0)
00:29:07  Switching pnpm from v11.19.0 to v11.9.0   ← reads packageManager
00:29:20  Successfully updated pnpm to v11.9.0      ← 13 s, downloads it again
```

Half of a 26 s step spent installing a version that is then thrown away, on every job of every run.

## What

**Pin `version:` at all ten `pnpm/action-setup` uses**, and move `packageManager` to **11.19.0** — the version npm already serves as latest, so the first fetch is the right one either way.

**`scripts/pnpm-version.test.mjs`** reads `packageManager` and every workflow, and fails if any use is unpinned or pinned to something else. The pin duplicates a fact `package.json` already owns, and a duplicate that can drift is only safe if something notices. It runs in the existing `node --test scripts/*.test.mjs` leg of `test:unit`.

## Lockfile

Unchanged. `pnpm@11.19.0 install --frozen-lockfile` against the current tree resolves to `Already up to date`, and `lockfileVersion` stays `9.0`.

## Scope

`CLAUDE.md` says "pnpm 11" without a minor, so it needs no edit.

This is the last of the setup-overhead findings; the other two came out smaller than estimated — `fetch-depth` at 2 s (#1632) and `standalone: true` at zero, since the action logged it and ran the npm installer anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
