### PR TITLE
measure: price the pnpm store cache on the Windows runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -238,10 +238,20 @@ jobs:
   #
   # No `prisma:generate` step: neither package imports the generated client.
   unit-windows:
-    name: Unit Test (Windows)
+    # MEASUREMENT ONLY — not for merge. On a cache hit this job spends 22 s restoring the store
+    # and 22 s installing from it; on a miss it spends 35 s installing from the registry and
+    # nothing restoring. Extracting 554 packages' files costs more here than fetching them does,
+    # which is the same thing every other finding on this runner has said: Windows charges for
+    # creating files. Three samples per arm, because 9 s is inside a single run's noise.
+    name: Unit Test (Windows) ${{ matrix.cache }}-${{ matrix.sample }}
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cache: ['on', 'off']
+        sample: [1, 2, 3]
     # The daemon suite alone runs ~20 min here against ~3 on Linux — Windows filesystem and
     # process-spawn cost, not extra work — so the cap is set well clear of it rather than near it.
     timeout-minutes: 45
@@ -269,7 +279,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@v6
         with:
-          cache: true
+          cache: ${{ matrix.cache == 'on' }}
           # Its own primary key, keyed by the closure it stores rather than by the lockfile alone.
           # Nothing shares this OS today, but the rule is the one the two narrowed Linux jobs
           # follow: a job that installs a subset never saves under the shared key.


### PR DESCRIPTION
measure: price the pnpm store cache on the Windows runner

Not for merge. The cache may be costing this job rather than saving it.

From two runs that differ only in whether the cache was there — the second because the Windows
entries had just been cleared:

    hit    restore+extract 22 s   install 22 s   save  0 s     44 s
    miss   restore          0 s   install 35 s   save 17 s     35 s of steady-state work

Extracting 557 MB into 554 packages' worth of files costs more here than fetching those packages
from the registry does. That is the same sentence every other finding on this runner has
produced: Windows charges for creating files, and the cache's job is to create a lot of them at
once. On Linux the trade goes the other way, which is why nobody notices.

Three samples per arm, because 9 s sits inside a single run's noise.

If it holds, turning the cache off also retires the machinery around it — the per-closure
`cache_dependency_path` namespace, and the residual review flagged on #1606 where a lockfile
change can still fall back onto another job's store.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
