### PR TITLE
fix(daemon): split a reply where the runtime says one message ended

### DIFF
--- a/docs/designs/turn-final-context-refresh.md
+++ b/docs/designs/turn-final-context-refresh.md
@@ -254,6 +254,16 @@ updates (usage, session titles) are deliberately not boundaries, so the closing
 segment — the text after the model's last tool or thinking step — stays staged
 until the final context fence.
 
+A **staged segment is not always one message.** Those four boundaries are
+boundaries in the WORK, and a run that only speaks has none of them — a runtime
+composing several messages back to back stays inside one segment. The convergers
+therefore carry a second, finer boundary of their own: the runtime's `messageId`,
+which changes where one message ends and the next begins. Since a commit replays
+the original updates through the converger, that boundary applies identically to
+a live turn and to a replayed staged one, and a segment can commit as more than
+one message. A runtime that names no message is unaffected — its reply stays one
+message however many chunks it streams in.
+
 Discard semantics narrow accordingly: a segment committed at a boundary is
 already said, exactly like any other message in the thread that precedes a
 late-arriving event; only the closing segment is regenerable. Token-by-token

--- a/packages/daemon/src/discord/render.ts
+++ b/packages/daemon/src/discord/render.ts
@@ -1,6 +1,7 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
 import { flattenUnsafeLinks } from '../messages/agent-links.js'
+import { AgentMessageRun } from '../messages/message-boundary.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
 import { extractToolOutput } from '../session/tool-output.js'
@@ -305,6 +306,8 @@ export class DiscordConverger {
   // minimal mode only — see the OutputConverger (Slack) for the segment/record contract.
   private segmentReset = false
   private recordDirty = false
+  // The runtime's own message identity, which is the only boundary a speak-only run offers.
+  private readonly messages = new AgentMessageRun()
 
   constructor(private mode: 'none' | 'minimal' | 'low' | 'medium' | 'high') {}
 
@@ -447,13 +450,16 @@ export class DiscordConverger {
       case 'agent_message_chunk': {
         const content = (update as { content?: { type?: string; text?: string } }).content
         const text = content?.type === 'text' ? (content.text ?? '') : ''
+        // A new message closes the one before it exactly as a tool boundary would — same mode
+        // semantics, same actions. Without this the two arrive as one post, run together.
+        const closed = this.messages.opens(update) ? (this.mode === 'minimal' ? this.closeSegment() : this.flush()) : []
         if (this.mode === 'minimal' && this.segmentReset && text) {
           this.buf = ''
           this.segmentReset = false
         }
         this.buf += text
         if (this.mode === 'minimal' && text.trim()) this.recordDirty = true
-        return []
+        return closed
       }
       case 'agent_thought_chunk': {
         if (this.mode === 'high') {

--- a/packages/daemon/src/feishu/render.ts
+++ b/packages/daemon/src/feishu/render.ts
@@ -1,5 +1,6 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import type { WireFeishuCardActionTarget } from '@agentconnect.md/protocol'
+import { AgentMessageRun } from '../messages/message-boundary.js'
 import { flattenUnsafeLinks } from '../messages/agent-links.js'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
@@ -409,6 +410,8 @@ export class FeishuConverger {
   // minimal mode only — see OutputConverger (Slack) for the segment/record contract.
   private segmentReset = false
   private recordDirty = false
+  // The runtime's own message identity, which is the only boundary a speak-only run offers.
+  private readonly messages = new AgentMessageRun()
 
   constructor(private mode: 'none' | 'minimal' | 'low' | 'medium' | 'high') {}
 
@@ -530,6 +533,13 @@ export class FeishuConverger {
       case 'agent_message_chunk': {
         const content = (update as { content?: { type?: string; text?: string } }).content
         const text = content?.type === 'text' ? (content.text ?? '') : ''
+        // A new message closes the one before it exactly as a tool boundary would — same mode
+        // semantics, same actions. Without this the two arrive as one post, run together.
+        const closed = this.messages.opens(update)
+          ? this.mode === 'minimal'
+            ? this.closeSegment()
+            : this.flush(true)
+          : []
         if (this.mode === 'minimal' && this.segmentReset && text) {
           this.buf = ''
           this.cardText = ''
@@ -541,7 +551,7 @@ export class FeishuConverger {
         this.buf += text
         this.cardText += text
         if (this.mode === 'minimal' && text.trim()) this.recordDirty = true
-        return []
+        return closed
       }
       case 'agent_thought_chunk': {
         if (this.mode === 'high') {

--- a/packages/daemon/src/messages/message-boundary.ts
+++ b/packages/daemon/src/messages/message-boundary.ts
@@ -1,0 +1,29 @@
+// A runtime may compose SEVERAL messages inside one uninterrupted answer run — Codex does, and names
+// each one with `messageId`. Nothing else in the stream marks where one ends: the boundaries a
+// converger already flushes on (tool call, thought, plan) are boundaries in the WORK, and a run that
+// only speaks has none. So without reading the id, "say, say, say" reaches the channel as one post
+// with the messages run together — and a leading `# heading` on the second one is swallowed into the
+// first one's paragraph, which stops it rendering as a heading at all.
+//
+// Only the GitHub reply collector read this id before; every chat converger appended blindly.
+
+/** The runtime's own id for the message a chunk belongs to, or `''` where it names none. */
+export function agentMessageId(update: unknown): string {
+  const id = (update as { messageId?: unknown } | undefined)?.messageId
+  return typeof id === 'string' ? id : ''
+}
+
+/** Tracks that id across the chunks of one turn, reporting where a new message begins. */
+export class AgentMessageRun {
+  private current = ''
+
+  /** True only where a NAMED id replaces a different named one. A runtime that names nothing never
+   *  reports a boundary, and neither does the first message of a run — both keep prior behavior. */
+  opens(update: unknown): boolean {
+    const id = agentMessageId(update)
+    if (!id) return false
+    const opens = this.current !== '' && id !== this.current
+    this.current = id
+    return opens
+  }
+}

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -16,6 +16,7 @@ export {
 } from '@agentconnect.md/protocol'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { flattenUnsafeLinks } from '../messages/agent-links.js'
+import { AgentMessageRun } from '../messages/message-boundary.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { permissionModeDisplayLabel } from '../acp/permission-modes.js'
 import { splitIntoSections } from './formatter.js'
@@ -909,6 +910,8 @@ export class OutputConverger {
   // isn't re-pushed to chat.update every idle window).
   private segmentReset = false
   private recordDirty = false
+  // The runtime's own message identity, which is the only boundary a speak-only run offers.
+  private readonly messages = new AgentMessageRun()
   // ── Native tool-call chrome (slack-streaming-turn-output.md §3) ──────────────
   // The axis, plus the one stream's card bookkeeping. Nothing here touches the body.
   private streaming = false
@@ -1408,6 +1411,9 @@ export class OutputConverger {
       case 'agent_message_chunk': {
         const content = (update as { content?: { type?: string; text?: string } }).content
         const text = content?.type === 'text' ? (content.text ?? '') : ''
+        // A new message closes the one before it exactly as a tool boundary would — same mode
+        // semantics, same actions. Without this the two arrive as one post, run together.
+        const closed = this.messages.opens(update) ? (this.mode === 'minimal' ? this.closeSegment() : this.flush()) : []
         // minimal: a chunk arriving after a tool boundary opens a new segment that REPLACES
         // the previous one in the single live message (the previous was already recorded).
         if (this.mode === 'minimal' && this.segmentReset && text) {
@@ -1416,7 +1422,7 @@ export class OutputConverger {
         }
         this.buf += text
         if (this.mode === 'minimal' && text.trim()) this.recordDirty = true
-        return []
+        return closed
       }
       case 'agent_thought_chunk': {
         // high: accumulate the streamed thought into the reasoning buffer and mark it

--- a/packages/daemon/src/telegram/render.ts
+++ b/packages/daemon/src/telegram/render.ts
@@ -1,6 +1,7 @@
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import { splitIntoSections } from '../messages/split-sections.js'
 import { flattenUnsafeLinks } from '../messages/agent-links.js'
+import { AgentMessageRun } from '../messages/message-boundary.js'
 import { splitAtParagraphBoundary } from '../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../session/no-response.js'
 import { extractToolOutput } from '../session/tool-output.js'
@@ -177,6 +178,8 @@ export class TelegramConverger {
   // minimal mode only — see the OutputConverger (Slack) for the segment/record contract.
   private segmentReset = false
   private recordDirty = false
+  // The runtime's own message identity, which is the only boundary a speak-only run offers.
+  private readonly messages = new AgentMessageRun()
   /** Whether this turn has already SENT a body post — the message a turn-end
    *  `continue-hint` edit would land on when no body is left to flush. */
   private postedBody = false
@@ -361,13 +364,16 @@ export class TelegramConverger {
       case 'agent_message_chunk': {
         const content = (update as { content?: { type?: string; text?: string } }).content
         const text = content?.type === 'text' ? (content.text ?? '') : ''
+        // A new message closes the one before it exactly as a tool boundary would — same mode
+        // semantics, same actions. Without this the two arrive as one post, run together.
+        const closed = this.messages.opens(update) ? (this.mode === 'minimal' ? this.closeSegment() : this.flush()) : []
         if (this.mode === 'minimal' && this.segmentReset && text) {
           this.buf = ''
           this.segmentReset = false
         }
         this.buf += text
         if (this.mode === 'minimal' && text.trim()) this.recordDirty = true
-        return []
+        return closed
       }
       case 'agent_thought_chunk': {
         if (this.mode === 'high') {

--- a/packages/daemon/test/discord-render.test.ts
+++ b/packages/daemon/test/discord-render.test.ts
@@ -96,3 +96,30 @@ describe('DiscordConverger minimal mode', () => {
     expect(c.onFinal()).toEqual([])
   })
 })
+
+// A run that speaks more than once has no tool/thought/plan boundary between its messages, so the
+// runtime's own `messageId` is the only thing separating them — see test/message-boundary.test.ts.
+describe('DiscordConverger message boundaries', () => {
+  const named = (messageId: string, text: string): SessionUpdate =>
+    ({ sessionUpdate: 'agent_message_chunk', messageId, content: { type: 'text', text } }) as unknown as SessionUpdate
+
+  const postsOf = (c: DiscordConverger, updates: SessionUpdate[]): string[] => {
+    const out: string[] = []
+    const take = (actions: { kind: string; text?: string }[]): void => {
+      for (const a of actions) if (a.kind === 'post' && a.text !== undefined) out.push(a.text)
+    }
+    for (const u of updates) take(c.onUpdate(u))
+    take(c.onFinal())
+    return out
+  }
+
+  it('delivers each named message on its own', () => {
+    const posts = postsOf(new DiscordConverger('low'), [named('m1', 'first thing'), named('m2', 'second thing')])
+    expect(posts).toEqual(['first thing', 'second thing'])
+  })
+
+  it('keeps an unnamed run one message, however many chunks it streams in', () => {
+    const posts = postsOf(new DiscordConverger('low'), [chunk('Hello '), chunk('there.')])
+    expect(posts).toEqual(['Hello there.'])
+  })
+})

--- a/packages/daemon/test/feishu-render.test.ts
+++ b/packages/daemon/test/feishu-render.test.ts
@@ -173,3 +173,30 @@ describe('Lark CardKit reply lifecycle', () => {
     )
   })
 })
+
+// A run that speaks more than once has no tool/thought/plan boundary between its messages, so the
+// runtime's own `messageId` is the only thing separating them — see test/message-boundary.test.ts.
+describe('FeishuConverger message boundaries', () => {
+  const named = (messageId: string, text: string): SessionUpdate =>
+    ({ sessionUpdate: 'agent_message_chunk', messageId, content: { type: 'text', text } }) as unknown as SessionUpdate
+
+  const postsOf = (c: FeishuConverger, updates: SessionUpdate[]): string[] => {
+    const out: string[] = []
+    const take = (actions: { kind: string; text?: string }[]): void => {
+      for (const a of actions) if (a.kind === 'post' && a.text !== undefined) out.push(a.text)
+    }
+    for (const u of updates) take(c.onUpdate(u))
+    take(c.onFinal())
+    return out
+  }
+
+  it('delivers each named message on its own', () => {
+    const posts = postsOf(new FeishuConverger('low'), [named('m1', 'first thing'), named('m2', 'second thing')])
+    expect(posts).toEqual(['first thing', 'second thing'])
+  })
+
+  it('keeps an unnamed run one message, however many chunks it streams in', () => {
+    const posts = postsOf(new FeishuConverger('low'), [chunk('Hello '), chunk('there.')])
+    expect(posts).toEqual(['Hello there.'])
+  })
+})

--- a/packages/daemon/test/message-boundary.test.ts
+++ b/packages/daemon/test/message-boundary.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { agentMessageId, AgentMessageRun } from '../src/messages/message-boundary.js'
+
+const chunk = (messageId?: string) => ({
+  sessionUpdate: 'agent_message_chunk',
+  content: { type: 'text', text: 'x' },
+  ...(messageId === undefined ? {} : { messageId })
+})
+
+describe('agentMessageId', () => {
+  it('reads the runtime’s id and treats anything else as unnamed', () => {
+    expect(agentMessageId(chunk('m1'))).toBe('m1')
+    expect(agentMessageId(chunk())).toBe('')
+    expect(agentMessageId({ messageId: 7 })).toBe('')
+    expect(agentMessageId({ messageId: '' })).toBe('')
+    expect(agentMessageId(undefined)).toBe('')
+    expect(agentMessageId(null)).toBe('')
+  })
+})
+
+describe('AgentMessageRun', () => {
+  it('opens on a change of named id, and never on the first message', () => {
+    const run = new AgentMessageRun()
+    expect(run.opens(chunk('m1'))).toBe(false)
+    expect(run.opens(chunk('m1'))).toBe(false)
+    expect(run.opens(chunk('m2'))).toBe(true)
+    expect(run.opens(chunk('m2'))).toBe(false)
+    expect(run.opens(chunk('m3'))).toBe(true)
+  })
+
+  // The pre-existing behavior for every runtime that names nothing, which is what keeps a reply
+  // that merely streams in pieces from being split into one message per chunk.
+  it('never opens for a runtime that names no message', () => {
+    const run = new AgentMessageRun()
+    for (let i = 0; i < 5; i++) expect(run.opens(chunk())).toBe(false)
+  })
+
+  it('holds the last NAMED id across unnamed chunks rather than forgetting it', () => {
+    const run = new AgentMessageRun()
+    run.opens(chunk('m1'))
+    expect(run.opens(chunk())).toBe(false)
+    expect(run.opens(chunk('m1'))).toBe(false)
+    expect(run.opens(chunk('m2'))).toBe(true)
+  })
+
+  it('reports a return to an earlier id as a new message — the buffer holds only the last one', () => {
+    const run = new AgentMessageRun()
+    run.opens(chunk('m1'))
+    expect(run.opens(chunk('m2'))).toBe(true)
+    expect(run.opens(chunk('m1'))).toBe(true)
+  })
+})

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -112,6 +112,71 @@ describe('OutputConverger', () => {
     expect(c.onFinal().find((a) => a.kind === 'post')?.text).toBe(text)
   })
 
+  // The shape this exists for: a run that speaks three times with NO tool call between, so none of
+  // the boundaries the converger already flushes on (tool, thought, plan) is there to separate them.
+  describe('a run that speaks more than once', () => {
+    const posts = (c: OutputConverger, runs: Array<[string | undefined, string]>): string[] => {
+      const out: string[] = []
+      const take = (actions: SlackAction[]): void => {
+        for (const a of actions) if (a.kind === 'post') out.push(a.text)
+      }
+      for (const [messageId, text] of runs) {
+        take(
+          c.onUpdate({
+            sessionUpdate: 'agent_message_chunk',
+            ...(messageId ? { messageId } : {}),
+            content: { type: 'text', text }
+          } as any)
+        )
+      }
+      take(c.onFinal())
+      return out
+    }
+
+    it('delivers each named message on its own instead of running them together', () => {
+      expect(
+        posts(new OutputConverger('low'), [
+          ['m1', 'I’ll run the collector.'],
+          ['m2', 'It returned 46 candidates.'],
+          ['m3', 'Created the digest.']
+        ])
+      ).toEqual(['I’ll run the collector.', 'It returned 46 candidates.', 'Created the digest.'])
+    })
+
+    // The damage beyond the run-on sentence: a `#` swallowed into the previous paragraph stops
+    // being a heading at all, which is how a digest lost its title.
+    it('leaves a heading at the START of its own message, where it still parses as one', () => {
+      const out = posts(new OutputConverger('low'), [
+        ['m1', 'so the drafts stay non-promotional.'],
+        ['m2', '# Reddit Engagement Digest\n\nThese are drafts.']
+      ])
+      expect(out[0]).toBe('so the drafts stay non-promotional.')
+      expect(out[1]?.startsWith('# Reddit Engagement Digest')).toBe(true)
+    })
+
+    it('joins the chunks of ONE message, however many arrive', () => {
+      expect(
+        posts(new OutputConverger('low'), [
+          ['m1', 'Hello '],
+          ['m1', 'there '],
+          ['m1', 'friend.']
+        ])
+      ).toEqual(['Hello there friend.'])
+    })
+
+    // §323: a reply that merely streams in pieces is one message. A runtime naming nothing keeps
+    // exactly the old behavior — this pass must never be what splits a reply mid-sentence.
+    it('still delivers an unnamed run as one message', () => {
+      expect(
+        posts(new OutputConverger('low'), [
+          [undefined, 'Hello '],
+          [undefined, 'there '],
+          [undefined, 'friend.']
+        ])
+      ).toEqual(['Hello there friend.'])
+    })
+  })
+
   it('low mode: tool_call with no title falls back to the toolCallId', () => {
     const c = new OutputConverger('low')
     const actions = c.onUpdate({ sessionUpdate: 'tool_call', toolCallId: 't9', status: 'pending' } as any)

--- a/packages/daemon/test/telegram-render.test.ts
+++ b/packages/daemon/test/telegram-render.test.ts
@@ -332,3 +332,30 @@ describe('status text (/status reply)', () => {
     expect(renderStatusReply({}, 'https://app/s/a&b')).toBe('📊 —\n🔗 <a href="https://app/s/a&amp;b">View session</a>')
   })
 })
+
+// A run that speaks more than once has no tool/thought/plan boundary between its messages, so the
+// runtime's own `messageId` is the only thing separating them — see test/message-boundary.test.ts.
+describe('TelegramConverger message boundaries', () => {
+  const named = (messageId: string, text: string): SessionUpdate =>
+    ({ sessionUpdate: 'agent_message_chunk', messageId, content: { type: 'text', text } }) as unknown as SessionUpdate
+
+  const postsOf = (c: TelegramConverger, updates: SessionUpdate[]): string[] => {
+    const out: string[] = []
+    const take = (actions: { kind: string; text?: string }[]): void => {
+      for (const a of actions) if (a.kind === 'post' && a.text !== undefined) out.push(a.text)
+    }
+    for (const u of updates) take(c.onUpdate(u))
+    take(c.onFinal())
+    return out
+  }
+
+  it('delivers each named message on its own', () => {
+    const posts = postsOf(new TelegramConverger('low'), [named('m1', 'first thing'), named('m2', 'second thing')])
+    expect(posts).toEqual(['first thing', 'second thing'])
+  })
+
+  it('keeps an unnamed run one message, however many chunks it streams in', () => {
+    const posts = postsOf(new TelegramConverger('low'), [chunk('Hello '), chunk('there.')])
+    expect(posts).toEqual(['Hello there.'])
+  })
+})


### PR DESCRIPTION
## What was wrong

A runtime may compose **several messages inside one uninterrupted answer run**. Codex does, and names each with `messageId`. The convergers appended every `agent_message_chunk` into one buffer and flushed it at a boundary — `tool_call`, `tool_call_update`, `agent_thought_chunk`, `plan`. Those are boundaries in the **work**, so a run that only speaks has none, and its messages arrive glued:

```
…without any Reddit account activity.The collector returned 46 candidates…
…so I'm not padding the list.Created today's digest.
```

Note `activity.The` and `list.Created` — no space, no newline.

The run-on sentence is the visible half. The damaging half is that a leading `#` on the next message lands inside the previous paragraph and **stops being a heading**:

```
…so the drafts stay non-promotional.# Reddit Engagement Digest — 2026-08-29
```

That digest reached its channel with its title rendered as literal text.

## Why the existing boundaries could not catch it

I pulled the turn's transcript rows in order before touching anything. Every tool and reasoning row is timestamped `…296`–`…364`; the single text row is `…366` — **after all of them**. The three messages were emitted back to back at the end of the run, so there was no `tool_call`, no `agent_thought_chunk`, no `plan` between them for either the live renderer or [#1594](https://github.com/agentconnect-md/agentconnect/pull/1594)'s staged-segment commit to act on.

This is also not a recent regression: `this.buf += text` dates to the initial commit, and the only nearby change in this area — `fix(messages): never split a streamed reply mid-sentence` (#323) — pushes the *other* way, guarding against over-splitting. Any fix here has to leave that guarantee intact.

## What this does

The id was already on the wire and already read on exactly one path: `GithubReplyCollector` groups chunks by `messageId` to pick a turn's final answer. The same `update` object reaches the chat convergers — `daemon.ts` hands it to `onGithubUpdate(...)` and `p.conv.onUpdate(...)` in the same block — and they ignored it.

`messages/message-boundary.ts` reads that id and reports where a message ends. Each converger closes the current message where a **named** id replaces a **different named** one, through the same `flush()` / `closeSegment()` a tool boundary already uses — so per-platform mode semantics (minimal's segment-replace, the no-response sentinel hold, Feishu's card paragraph break) are unchanged. Slack, Telegram, Discord and Feishu.

**A runtime that names nothing keeps today's behavior exactly.** That is what keeps this from undoing #323 — a reply that merely streams in pieces stays one message, not one per chunk. Same for the first message of a run, which has nothing before it to close.

## Interaction with #1594

Complementary, not overlapping. #1594 splits `say → work → say more`; this splits `say, say, say`, which #1594 structurally cannot see.

Staged turns come along for free: `commitStagedSegment` replays the **original update objects** through the same converger, so the boundary applies to a replayed turn identically to a live one — no divergence between what a channel sees live and after a context refresh. The consequence is that a staged segment can now commit as more than one message, which §5.2 of `turn-final-context-refresh.md` now states.

## Verification

- `test/message-boundary.test.ts` — the id reader (non-string, empty, absent) and the run tracker: opens on a change, never on the first message, never for an unnamed runtime, holds the last named id across unnamed chunks, and treats a return to an earlier id as new.
- `test/render.test.ts` — the incident shape as three separate posts; the heading case asserting `#` starts its own message; chunks of one message still joined; an unnamed run still one message.
- `test/telegram-render.test.ts`, `discord-render.test.ts`, `feishu-render.test.ts` — the same two claims per platform.
- Full daemon suite: the same four files fail as on a pristine `origin/main` checkout of this machine (sandbox/shim against macOS temp paths, live-runtime matrix on provider quota), same 14 cases, nothing new. `typecheck` and `lint` clean.

Not verified against a live Codex stream — the wire shape is taken from `GithubReplyCollector` and its tests, which were written against real Codex behavior. If `messageId` turned out to be absent in practice, this degrades to exactly the current behavior rather than misbehaving.
