### PR TITLE
ci: drop the Windows Defender exclusion step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -254,22 +254,13 @@ jobs:
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
-    # The daemon suite alone runs ~20 min here against ~3 on Linux — Windows filesystem and
+    # The daemon suite alone runs ~5 min here against ~3 on Linux — Windows filesystem and
     # process-spawn cost, not extra work — so the cap is set well clear of it rather than near it.
     timeout-minutes: 45
     defaults:
       run:
         shell: bash
     steps:
-      # The daemon suite creates and deletes a temporary root, a SQLite database and its two WAL
-      # siblings per store, thousands of times over, and real-time scanning charges for each write.
-      # Advisory, so `continue-on-error`: a runner image without Defender must not fail the job here.
-      - name: Exempt the workspace from real-time scanning
-        continue-on-error: true
-        shell: pwsh
-        run: |
-          Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE", "$env:RUNNER_TEMP", "$env:TEMP"
-          Add-MpPreference -ExclusionProcess 'node.exe', 'git.exe'
       # Before checkout: the runner's Git installs with `core.autocrlf=true`, which would rewrite
       # every fixture's line endings and diverge golden files from the Linux jobs' bytes.
       - name: Keep line endings as committed


### PR DESCRIPTION
Removes the `Add-MpPreference` step from `Unit Test (Windows)`.

The step was added on the theory that real-time scanning charges for every write the
suite makes. Measured, it does not pay: two matrix runs on `windows-latest`, three arms
— both exclusions, `-ExclusionPath` only, and no step at all — at 3-4 samples each.

| arm | n | median | mean | sd |
| --- | --- | --- | --- | --- |
| both exclusions (before) | 7 | 283 s | 267 s | 30 |
| `-ExclusionPath` only | 4 | 286 s | 264 s | 54 |
| no step | 7 | 282 s | 259 s | 55 |

The medians are indistinguishable and all 18 samples fall in 175-330 s, so the
within-arm spread is larger than anything between the arms. At n=7 this resolves nothing
smaller than ~30 s, so the honest claim is "no effect above the noise floor", not "no
effect" — but the step's own 19 s is certain either way, which is the whole change here.

That matches what the repo already recorded for this candidate; an earlier 3-sample read
that appeared to favour dropping it did not survive the second run.

Also refreshes the adjacent `timeout-minutes` comment, which still quoted the
pre-optimization ~20 min for a job that now runs ~5.
