### PR TITLE
test: give a root-level vitest run the same budget as the package it runs

### DIFF
--- a/packages/daemon/test/no-shortened-test-budget.test.ts
+++ b/packages/daemon/test/no-shortened-test-budget.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { BASE_TEST_TIMEOUT } from '../vitest.config.js'
+import { BASE_TEST_TIMEOUT } from '../../../scripts/vitest-test-budget.js'
 
 const testRoot = fileURLToPath(new URL('.', import.meta.url))
 const budget = /^\s*\}, ([0-9_]+)\)$/gm

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, configDefaults } from 'vitest/config'
 import { githubActionsReporters } from '../../scripts/vitest-github-reporters.js'
+import { BASE_TEST_TIMEOUT } from '../../scripts/vitest-test-budget.js'
 
 // The files that call `vi.mock`. A mock is registered per FILE but rewires a module in the registry,
 // so under a shared registry it either misses (the real module was already imported by an earlier
@@ -58,11 +59,6 @@ export const WINDOWS_EXCLUDED = [
 ]
 
 const platformExcluded = process.platform === 'win32' ? WINDOWS_EXCLUDED : []
-
-// The budget every test gets before the platform scaling below. A per-test override can only
-// SHORTEN what this grants, never extend it, so one written at or under this value is dead weight
-// that fails first on the slowest platform. `test/no-shortened-test-budget.test.ts` rejects those.
-export const BASE_TEST_TIMEOUT = 30_000
 
 export default defineConfig({
   test: {

--- a/scripts/vitest-test-budget.ts
+++ b/scripts/vitest-test-budget.ts
@@ -1,0 +1,4 @@
+// The budget every test gets before a config scales it. A per-test override can only SHORTEN what
+// this grants, never extend it, so one written at or under this value is dead weight that fails
+// first on the slowest platform. `packages/daemon/test/no-shortened-test-budget.test.ts` rejects those.
+export const BASE_TEST_TIMEOUT = 30_000

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitest/config'
-import { BASE_TEST_TIMEOUT } from './packages/daemon/vitest.config.js'
+import { BASE_TEST_TIMEOUT } from './scripts/vitest-test-budget.js'
 
 // `eval:gates` and its four siblings run daemon test files with `vitest run` from HERE, where
 // nothing set a budget — so the same file got vitest's 5 s default instead of the 30 s its own

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+import { BASE_TEST_TIMEOUT } from './packages/daemon/vitest.config.js'
+
+// `eval:gates` and its four siblings run daemon test files with `vitest run` from HERE, where
+// nothing set a budget — so the same file got vitest's 5 s default instead of the 30 s its own
+// package grants it, and `daemon-evaluation.test.ts` timed out on a loaded runner starting a daemon.
+export default defineConfig({ test: { testTimeout: BASE_TEST_TIMEOUT } })


### PR DESCRIPTION
`daemon-evaluation.test.ts` failed CI with `Test timed out in 5000ms` — vitest's default, not the 30 s `packages/daemon/vitest.config.ts` grants it.

The file gets two different budgets depending on who runs it:

| runner | config found | budget |
| --- | --- | --- |
| `pnpm --filter @agentconnect.md/daemon test:unit` | the package's | 30 s |
| `pnpm eval:gates` (`vitest run <files>` from the repo root) | none | 5 s |

Five scripts run that way — `eval:gates`, `eval:contracts`, `eval:collab:contracts`, `eval:collab:routing`, `eval:parity` — so all of them ran daemon tests at a budget six times tighter than the suite those tests belong to. The case that failed stands up a daemon against a fully faked host: the only real work is scaffolding a root and opening the store, which is not 5 s of work until the box is loaded enough that imports alone take 64 s.

`BASE_TEST_TIMEOUT` moves to `scripts/`, next to the reporter helper both configs already share, and the root config and the package config each take it from there. The root does not reach into a package, and there is one budget rather than a literal that can drift.

Nothing else is set at the root, so discovery is unchanged; verified by temporarily setting it to 1 ms and watching the same file fail.
