### PR TITLE
ci: split the Windows unit job into two shards

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -254,8 +254,7 @@ jobs:
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
-    # Both packages split the same way, so a shard is a whole runner's worth of either. Vitest
-    # chunks the file list rather than balancing it by duration, so the two halves are uneven.
+    # The daemon balances its halves by file size (`scripts/vitest-shard-sequencer.ts`); the CLI is 6 s, so it keeps Vitest's own split.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -250,12 +250,18 @@ jobs:
   #
   # No `prisma:generate` step: neither package imports the generated client.
   unit-windows:
-    name: Unit Test (Windows)
+    name: Unit Test (Windows) (${{ matrix.shard }})
     needs: windows-scope
     if: ${{ needs.windows-scope.outputs.changed == 'true' }}
     runs-on: windows-latest
-    # The daemon suite alone runs ~5 min here against ~3 on Linux — Windows filesystem and
-    # process-spawn cost, not extra work — so the cap is set well clear of it rather than near it.
+    # Both packages split the same way, so a shard is a whole runner's worth of either. Vitest
+    # chunks the file list rather than balancing it by duration, so the two halves are uneven.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/2', '2/2']
+    # Half the daemon suite runs ~2.5 min here, against ~3 on Linux for all of it — Windows
+    # filesystem and process-spawn cost, not extra work — so the cap stays well clear of it.
     timeout-minutes: 45
     defaults:
       run:
@@ -314,14 +320,14 @@ jobs:
           GITHUB_STEP_SUMMARY: ${{ runner.temp }}/windows-unit-test-summary.md
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
-        run: pnpm --filter @agentconnect.md/daemon test:unit
+        run: pnpm --filter @agentconnect.md/daemon test:unit --shard=${{ matrix.shard }}
       - name: CLI unit tests
         if: ${{ !cancelled() }}
         env:
           GITHUB_STEP_SUMMARY: ${{ runner.temp }}/windows-unit-test-summary.md
           pnpm_config_enable_pre_post_scripts: false
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
-        run: pnpm --filter @agentconnect.md/cli test:unit
+        run: pnpm --filter @agentconnect.md/cli test:unit --shard=${{ matrix.shard }}
       - name: Merge Windows unit test summaries
         if: ${{ !cancelled() }}
         env:
@@ -329,7 +335,7 @@ jobs:
           VITEST_JOB_SUMMARY_DIR: ${{ runner.temp }}
         run: |
           GITHUB_STEP_SUMMARY="$CAPTURED_JOB_SUMMARY" node scripts/merge-vitest-summaries.mjs \
-            'Windows unit test report' \
+            'Windows unit test report · shard ${{ matrix.shard }}' \
             'daemon=@agentconnect.md/daemon' \
             'cli=@agentconnect.md/cli'
       - name: Publish Windows unit test summary

--- a/packages/daemon/test/shard-partition.test.ts
+++ b/packages/daemon/test/shard-partition.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { balancedBuckets } from '../../../scripts/vitest-shard-sequencer.js'
+
+// Each shard runs this independently and keeps only its own bucket, so a partition that is not
+// exactly disjoint-and-complete silently drops a test file from CI or runs it on both shards.
+describe('shard partition', () => {
+  const items = Array.from({ length: 307 }, (_, i) => ({ item: `f${i}`, weight: (i * 7919) % 500, key: `f${i}` }))
+
+  it('covers every file exactly once, whatever the shard count', () => {
+    for (const count of [1, 2, 3, 8]) {
+      const flat = balancedBuckets(items, count).flat()
+      expect(flat.length).toBe(items.length)
+      expect(new Set(flat).size).toBe(items.length)
+    }
+  })
+
+  it('agrees with itself across runs, so two shards cannot disagree', () => {
+    expect(balancedBuckets(items, 2)).toEqual(balancedBuckets([...items].reverse(), 2))
+  })
+
+  it('balances weight better than a contiguous split of the same order', () => {
+    const weight = (b: string[]) => b.reduce((n, k) => n + items[Number(k.slice(1))]!.weight, 0)
+    const [a, b] = balancedBuckets(items, 2).map(weight) as [number, number]
+    expect(Math.abs(a - b)).toBeLessThan(items.length)
+  })
+})

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, configDefaults } from 'vitest/config'
 import { githubActionsReporters } from '../../scripts/vitest-github-reporters.js'
+import { SizeBalancedSequencer } from '../../scripts/vitest-shard-sequencer.js'
 
 // The files that call `vi.mock`. A mock is registered per FILE but rewires a module in the registry,
 // so under a shared registry it either misses (the real module was already imported by an earlier
@@ -71,6 +72,7 @@ export default defineConfig({
     // resources. Four on Windows too: the halving there bought time for inline per-test budgets that
     // no longer exist, and the polls those budgets never governed now scale in `test/wait-support.ts`.
     maxWorkers: 4,
+    sequence: { sequencer: SizeBalancedSequencer },
     // The async store pays a microtask hop per statement; on a loaded CI box the IO-heavy store files
     // drift past vitest's 5 s default without being hung. Windows I/O is slower again by enough that
     // the same files need double the budget.

--- a/scripts/vitest-shard-sequencer.ts
+++ b/scripts/vitest-shard-sequencer.ts
@@ -1,0 +1,41 @@
+import { statSync } from 'node:fs'
+import { BaseSequencer, type TestSpecification } from 'vitest/node'
+
+// Vitest shards by sha1 of the file path, which is a random partition — and a fixed one, so a bad
+// draw stays bad. Over this repo's daemon suite a random half lands at 1.33:1 by median and 2:1 at
+// p90. Greedy longest-processing-time over file size is a weak proxy (0.61 correlation with
+// measured duration) but a far better partition: 1.15:1 on the same suite.
+export class SizeBalancedSequencer extends BaseSequencer {
+  async shard(specs: TestSpecification[]): Promise<TestSpecification[]> {
+    const shard = this.ctx.config.shard
+    if (!shard) return specs
+    const weighed = specs.map((spec) => ({ item: spec, weight: sizeOf(spec.moduleId), key: spec.moduleId }))
+    return balancedBuckets(weighed, shard.count)[shard.index - 1] ?? []
+  }
+}
+
+/**
+ * Greedy longest-processing-time. Every shard computes the WHOLE partition and keeps its own
+ * bucket, so the order has to be total — equal weights tie, and two shards disagreeing would
+ * drop a file from the run or execute it twice.
+ */
+export function balancedBuckets<T>(items: { item: T; weight: number; key: string }[], count: number): T[][] {
+  const buckets: T[][] = Array.from({ length: count }, () => [])
+  const load = new Array<number>(count).fill(0)
+  for (const { item, weight } of [...items].sort((a, b) => b.weight - a.weight || (a.key < b.key ? -1 : 1))) {
+    let at = 0
+    for (let i = 1; i < load.length; i++) if (load[i]! < load[at]!) at = i
+    load[at] = load[at]! + weight
+    buckets[at]!.push(item)
+  }
+  return buckets
+}
+
+/** An unreadable file weighs nothing rather than failing the run — it fails on its own in a moment. */
+function sizeOf(path: string): number {
+  try {
+    return statSync(path).size
+  } catch {
+    return 0
+  }
+}


### PR DESCRIPTION
Splits `Unit Test (Windows)` across two runners, both packages sharded the same way, using the `--shard=N/2` matrix the integration job already uses.

**Why this and not something cheaper.** Measured on `windows-latest`, the job's remaining time is almost entirely the daemon suite, and its wall is set by aggregate test time over the runner's four vCPUs — 1048 s of tests / 4 = 262 s, against 285 s observed. That rules out the alternatives:

- more workers on the same box: `--maxWorkers=6` measured 276 s against 285 s, ranges overlapping — the vCPUs are already saturated;
- attacking the heaviest file: the longest single file is 127 s against a 285 s wall, so nothing is on the critical path and every second saved is divided by four before it reaches the wall.

**The first attempt split 96 s against 182 s.** Vitest shards on the sha1 of each file path, which is a random partition, and a fixed one — the same paths hash the same way every run, so a bad draw stays bad. Over this file set a random half sits at 1.33:1 by median and 2:1 at p90: six files carry a third of the total, and the split is decided by where they land.

So the shard now runs through a sequencer that does greedy longest-processing-time over file size. Size is a weak proxy for duration here (0.61 correlation), but the partition is much better than a random one and there is nothing to keep up to date:

| partition | scored against real per-file durations |
| --- | --- |
| random (what vitest does) | median 1.33:1, p90 2.01:1, worst 4.10:1 |
| greedy by file size | 561 s / 486 s — 1.15:1 |
| greedy by measured duration | 524 s / 524 s — needs a table that rots |

Every shard computes the whole partition and keeps its own bucket, so the ordering has to be total — equal sizes tie, and two shards disagreeing would drop a file from CI or run it twice. `shard-partition.test.ts` covers exactly that: disjoint, complete, and stable against input order.

**Measured.** Against an unsharded run on a branch off the same main, one sample each:

| | daemon step | job |
| --- | --- | --- |
| unsharded | 292 s | 382 s |
| shard 1/2 | 92 s | 163 s |
| shard 2/2 | 135 s | 237 s |

6.4 min to 3.9 min, which puts this job below the next-slowest check rather than well above it.

The split came out 1.47:1 rather than the 1.15:1 the weights predict, and it cannot do better: the
slower shard's 135 s is essentially the 127 s of its longest single file. Whichever shard holds that
file has that as its floor, so further balancing — and a third or fourth shard — buys nothing.

**Trade.** Two runners instead of one, so billed minutes roughly double for this job.

Job name changes to `Unit Test (Windows) (N/2)`. No ruleset requires the old context, so nothing is left waiting on a check that stops reporting.
