### PR TITLE
feat(console): show the turn's plan — recorded in the transcript and streamed live

### DIFF
--- a/docs/designs/session-concept.md
+++ b/docs/designs/session-concept.md
@@ -170,7 +170,7 @@ typing, or status. The session is the complete truth; IM is one projection.
 Independent of source `type`, content has a shape:
 
 ```text
-type: 'text' | 'tool' | 'reasoning' | ...
+type: 'text' | 'tool' | 'reasoning' | 'plan' | ...
 ```
 
 - `text` is a text segment.
@@ -178,6 +178,10 @@ type: 'text' | 'tool' | 'reasoning' | ...
   cross-platform sending, and replying to a parent all use the one
   `sendMessage` tool.
 - `reasoning` is reasoning work.
+- `plan` is the turn's task list. An ACP plan update carries the whole list
+  every time, so this is the one shape that is a SNAPSHOT rather than an
+  append: a turn holds exactly one plan row, rewritten in place as the agent
+  revises it, keeping the position it took when first published.
 - More shapes may be added.
 
 A source message with `{ type: agent }` may contain text or a tool call. The

--- a/docs/designs/transcript-full-tool-body.md
+++ b/docs/designs/transcript-full-tool-body.md
@@ -233,6 +233,22 @@ so a plan is a snapshot, not a stream of deltas.
   never replayed into a prompt: only `text` and `tool` rows rebuild model
   context.
 
+**The live stream carries the same list.** Recording alone would surface the plan
+only on the read that switches a page to history — a live turn would show tool
+rows for work whose plan it was hiding. `WebchatEvent` therefore has a `plan`
+kind carrying the same entries, emitted from the same normalizer the transcript
+row uses (`daemon/src/session/plan-entries.ts`), so the two can never disagree.
+It is the one event kind in that union that is a snapshot: the client REPLACES
+its block rather than appending, keeping the position the block first took.
+
+The compatibility cost is real and deliberate. A relay predating the kind fails
+that one frame's decode, answers with an error frame, and keeps the connection —
+so the chunk is dropped, every other chunk still flows, and the turn degrades to
+showing its plan only after the fact. There is no relay capability echo to gate
+on: `rd/hello` advertises the DAEMON's capabilities and `rd/hello/ok` returns
+only `relayId`. Gating would mean adding that echo first, which buys nothing
+until relays upgrade anyway.
+
 ---
 
 ## 9. Compatibility
@@ -259,6 +275,8 @@ Tests cover:
 - end-to-end complete-body retrieval;
 - title-only compatibility;
 - exclusion of tool bodies from transcript replay;
-- one upserted plan row per turn, holding its position and the latest entries; and
+- one upserted plan row per turn, holding its position and the latest entries;
 - a plan row rendering outside the collapsed work panel, and falling back to its
-  summary when no body arrives.
+  summary when no body arrives; and
+- each live plan revision streaming as a whole-list snapshot that replaces the
+  browser's block in place rather than appending a second one.

--- a/docs/designs/transcript-full-tool-body.md
+++ b/docs/designs/transcript-full-tool-body.md
@@ -4,7 +4,8 @@
 
 The daemon records the complete evolving body of each ACP tool call for session
 audit and Console display. Tool bodies remain daemon-local and are fetched
-through frame-budgeted, on-demand reads.
+through frame-budgeted, on-demand reads. §8 covers the one other row that
+carries a body — the turn's plan — which reuses this chain end to end.
 
 ---
 
@@ -59,8 +60,9 @@ interface ToolBody {
 }
 ```
 
-Text and reasoning rows leave these columns null. Existing databases add the
-columns and index through the daemon's idempotent local-store migration.
+Text and reasoning rows leave these columns null; a plan row reuses both (§8).
+Existing databases add the columns and index through the daemon's idempotent
+local-store migration.
 
 ---
 
@@ -200,7 +202,40 @@ control channel unless requested.
 
 ---
 
-## 8. Compatibility
+## 8. The plan row
+
+The turn's task list rides the same machinery, with one difference that shapes
+everything else: an ACP `plan` update carries the WHOLE entry list every time,
+so a plan is a snapshot, not a stream of deltas.
+
+- **One row per turn, rewritten in place.** `TranscriptRecorder` mints a
+  namespaced `plan:<uuid>` id per turn — a recorder is built per turn — and the
+  store's `upsertPlan` claims the row on first sight and overwrites it on every
+  later update. `seq` and `ts` keep their first-seen values, so the plan holds
+  the position it took when the agent first published it, ahead of the work it
+  planned. Both statements are fenced on `kind = 'plan'`, so a session-local
+  tool id can never address a plan row.
+- **`text` is the summary, `body` is the list.** The row's text is
+  `Plan · <completed>/<total>`; `body` is serialized `PlanBody`
+  (`{ entries: { content, status, priority? }[] }`, protocol
+  `frames/session.ts`). A reader that has only the text — an older Console, or a
+  Control Plane that forwards no plan body — still shows that a plan existed and
+  how far it got.
+- **Inline or not at all.** A plan body has no complete-body fetch behind it, so
+  the reader passes it through verbatim under the 32 KiB preview cap and drops
+  an implausibly larger one rather than serving a truncated list.
+- **Console placement is the point.** The plan renders as its own checklist
+  above the answer, NOT inside the collapsed "Thought through N steps" panel:
+  it is what the agent set out to do, not a step it took. `PLAN_LANE` is
+  deliberately a distinct lane value from the work-lane `PLAN` the playground's
+  live stream uses.
+- Like tool and reasoning rows, plan rows are recorded in every output mode and
+  never replayed into a prompt: only `text` and `tool` rows rebuild model
+  context.
+
+---
+
+## 9. Compatibility
 
 - New transcript columns are nullable, so existing title-only rows continue to
   render.
@@ -211,7 +246,7 @@ control channel unless requested.
 
 ---
 
-## 9. Validation requirements
+## 10. Validation requirements
 
 Tests cover:
 
@@ -222,5 +257,8 @@ Tests cover:
 - frame-budgeted history pagination;
 - UTF-8-safe body chunks and offsets;
 - end-to-end complete-body retrieval;
-- title-only compatibility; and
-- exclusion of tool bodies from transcript replay.
+- title-only compatibility;
+- exclusion of tool bodies from transcript replay;
+- one upserted plan row per turn, holding its position and the latest entries; and
+- a plan row rendering outside the collapsed work panel, and falling back to its
+  summary when no body arrives.

--- a/packages/daemon/src/cp/session-reader.ts
+++ b/packages/daemon/src/cp/session-reader.ts
@@ -350,7 +350,15 @@ export function createSessionReader(
           text: substituteUserMentions(withoutAttachmentMention(r.text, attachments), names),
           ...(attachments.length ? { attachments } : {})
         }
-        if (r.kind !== 'tool' || !r.body) return base
+        if (!r.body) return base
+        // A plan body is the turn's whole task list and has no full-body fetch behind it, so
+        // it rides inline or not at all — an implausibly large one is dropped rather than
+        // previewed, leaving the row's `Plan · n/m` summary to stand alone.
+        if (r.kind === 'plan') {
+          if (Buffer.byteLength(r.body) <= PREVIEW_CAP) base.body = r.body
+          return base
+        }
+        if (r.kind !== 'tool') return base
         // Enrich a tool row: surface toolCallId/status/kind + an inline body (verbatim
         // when ≤ 32 KiB, else a valid-JSON preview with bodyTruncated + full byte length).
         let full: ToolBody

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -12702,9 +12702,21 @@ export class Daemon {
       await this.recordEvent(p.plan.agentId, p.plan.transcriptChannel, p.plan.statusThread, ev)
   }
 
-  /** Persist one internal activity event (tool/reasoning). Ordered by row `seq`, so its
+  /** Persist one internal activity event (tool/reasoning/plan). Ordered by row `seq`, so its
    *  `ts` is just a wall-clock stamp for display — never used for replay/sorting. */
   private async recordEvent(agentId: string, channel: string, thread: string, ev: TranscriptEvent): Promise<void> {
+    if (ev.kind === 'plan') {
+      await this.store.upsertPlan({
+        channel,
+        thread,
+        ts: String(Date.now()),
+        sender: agentId,
+        planId: ev.planId,
+        title: ev.text,
+        body: ev.body
+      })
+      return
+    }
     if (ev.kind === 'tool') {
       if (ev.op === 'insert') {
         await this.store.insertToolCall({

--- a/packages/daemon/src/session/plan-entries.ts
+++ b/packages/daemon/src/session/plan-entries.ts
@@ -1,0 +1,31 @@
+import type { PlanEntry } from '@agentconnect.md/protocol'
+
+/** The shape an ACP `plan` update arrives in — every field optional on the wire. */
+type RawPlanEntry = { content?: string; status?: string; priority?: string }
+
+/**
+ * Normalize one ACP `plan` update into the entry list. Both consumers read it through here
+ * so the persisted transcript row and the live webchat stream can never disagree about what
+ * the turn's plan was: an entry with no text of its own is dropped rather than rendered as a
+ * blank line, and a missing status reads as not-yet-started.
+ */
+export function planEntriesOf(update: unknown): PlanEntry[] {
+  const raw = (update as { entries?: RawPlanEntry[] } | null)?.entries
+  if (!Array.isArray(raw)) return []
+  const entries: PlanEntry[] = []
+  for (const entry of raw) {
+    const content = typeof entry?.content === 'string' ? entry.content : ''
+    if (!content.trim()) continue
+    entries.push({
+      content,
+      status: typeof entry.status === 'string' && entry.status ? entry.status : 'pending',
+      ...(typeof entry.priority === 'string' && entry.priority ? { priority: entry.priority } : {})
+    })
+  }
+  return entries
+}
+
+/** The plan row's one-line label: `Plan · <completed>/<total>`. */
+export function planSummary(entries: PlanEntry[]): string {
+  return `Plan · ${entries.filter((entry) => entry.status === 'completed').length}/${entries.length}`
+}

--- a/packages/daemon/src/session/transcript-recorder.ts
+++ b/packages/daemon/src/session/transcript-recorder.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import type { PlanBody, ToolBody } from '@agentconnect.md/protocol'
+import { planEntriesOf, planSummary } from './plan-entries.js'
 
 /**
  * A transcript event to persist. Reasoning is a flat coalesced block; tool events
@@ -17,10 +18,6 @@ export type TranscriptEvent =
 /** Single-body write ceiling (protects the daemon DB from a huge rawOutput/content);
  *  separate from the read-side 32 KiB inline preview cap. */
 const MAX_TOOL_BODY_BYTES = 1024 * 1024
-
-/** One entry of an ACP `plan` update, as the runtimes send it (Claude's TodoWrite and
- *  Codex's update_plan both land here). Every field is optional on the wire. */
-type PlanEntry = { content?: string; status?: string; priority?: string }
 
 /**
  * Turns the raw ACP `session/update` stream into the *full* activity log — tool calls,
@@ -85,17 +82,12 @@ export class TranscriptRecorder {
         // reads before it. The plan itself is a full-list replace, so every update rewrites
         // this turn's one row — `text` is the summary an old console (or a control plane that
         // forwards no body) can still show, `body` the entries this one renders.
-        const entries = ((update as { entries?: PlanEntry[] }).entries ?? []).map((entry) => ({
-          content: entry.content ?? '',
-          status: entry.status ?? 'pending',
-          ...(entry.priority ? { priority: entry.priority } : {})
-        }))
+        const entries = planEntriesOf(update)
         if (entries.length === 0) return this.flushThought()
-        const done = entries.filter((entry) => entry.status === 'completed').length
         const body: PlanBody = { entries }
         return [
           ...this.flushThought(),
-          { kind: 'plan', planId: this.planId, text: `Plan · ${done}/${entries.length}`, body: JSON.stringify(body) }
+          { kind: 'plan', planId: this.planId, text: planSummary(entries), body: JSON.stringify(body) }
         ]
       }
       // A reply starting means the preceding thinking run is over — close the block.

--- a/packages/daemon/src/session/transcript-recorder.ts
+++ b/packages/daemon/src/session/transcript-recorder.ts
@@ -1,24 +1,31 @@
+import { randomUUID } from 'node:crypto'
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
-import type { ToolBody } from '@agentconnect.md/protocol'
+import type { PlanBody, ToolBody } from '@agentconnect.md/protocol'
 
 /**
  * A transcript event to persist. Reasoning is a flat coalesced block; tool events
  * carry the full merged ToolBody (as a serialized JSON string, already capped at the
  * single-body write ceiling) plus an `op` telling the daemon whether this is the
  * first sight of the call (INSERT a row) or a later update (UPDATE the same row).
+ * A plan event is a whole-list SNAPSHOT that rewrites this turn's single plan row.
  */
 export type TranscriptEvent =
   | { kind: 'reasoning'; text: string }
   | { kind: 'tool'; op: 'insert' | 'update'; toolCallId: string; text: string; body: string }
+  | { kind: 'plan'; planId: string; text: string; body: string }
 
 /** Single-body write ceiling (protects the daemon DB from a huge rawOutput/content);
  *  separate from the read-side 32 KiB inline preview cap. */
 const MAX_TOOL_BODY_BYTES = 1024 * 1024
 
+/** One entry of an ACP `plan` update, as the runtimes send it (Claude's TodoWrite and
+ *  Codex's update_plan both land here). Every field is optional on the wire. */
+type PlanEntry = { content?: string; status?: string; priority?: string }
+
 /**
- * Turns the raw ACP `session/update` stream into the *full* activity log — tool calls
- * and reasoning — independent of the agent's Slack `output.mode`. (Output mode only
- * decides what reaches the platform; the transcript records everything.)
+ * Turns the raw ACP `session/update` stream into the *full* activity log — tool calls,
+ * reasoning, and the plan — independent of the agent's Slack `output.mode`. (Output mode
+ * only decides what reaches the platform; the transcript records everything.)
  *
  * It deliberately does NOT emit `text`: conversational rows are recorded at the
  * platform-send boundary instead, where the real message `ts` is known (so they sort
@@ -32,6 +39,14 @@ export class TranscriptRecorder {
   private readonly tools = new Map<string, ToolBody>()
   // Last non-null title seen per toolCallId — updates that omit `title` keep the prior one.
   private readonly titles = new Map<string, string>()
+  /** This turn's plan row. A recorder is built per turn, so a per-recorder id gives the
+   *  plan one row per turn — every ACP plan update overwrites it, and the next turn's plan
+   *  is a new row instead of trampling this one. */
+  private readonly planId: string
+
+  constructor(planId = `plan:${randomUUID()}`) {
+    this.planId = planId
+  }
 
   onUpdate(update: SessionUpdate): TranscriptEvent[] {
     switch (update.sessionUpdate) {
@@ -63,6 +78,24 @@ export class TranscriptRecorder {
         return [
           ...flushed,
           { kind: 'tool', op: first ? 'insert' : 'update', toolCallId: id, text: title, body: serializeBody(body) }
+        ]
+      }
+      case 'plan': {
+        // Flush first for the same reason a tool does: the thinking that produced the plan
+        // reads before it. The plan itself is a full-list replace, so every update rewrites
+        // this turn's one row — `text` is the summary an old console (or a control plane that
+        // forwards no body) can still show, `body` the entries this one renders.
+        const entries = ((update as { entries?: PlanEntry[] }).entries ?? []).map((entry) => ({
+          content: entry.content ?? '',
+          status: entry.status ?? 'pending',
+          ...(entry.priority ? { priority: entry.priority } : {})
+        }))
+        if (entries.length === 0) return this.flushThought()
+        const done = entries.filter((entry) => entry.status === 'completed').length
+        const body: PlanBody = { entries }
+        return [
+          ...this.flushThought(),
+          { kind: 'plan', planId: this.planId, text: `Plan · ${done}/${entries.length}`, body: JSON.stringify(body) }
         ]
       }
       // A reply starting means the preceding thinking run is over — close the block.

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -347,10 +347,12 @@ export interface SessionListRow extends SessionRecord {
  *                  the ONLY kind replayed as cross-agent context (§8.5).
  *  - `tool`      — an agent tool invocation (label). Audit/UI only.
  *  - `reasoning` — an agent's coalesced thinking block. Audit/UI only.
- * `tool`/`reasoning` are recorded for EVERY turn regardless of the agent's Slack
+ *  - `plan`      — the turn's task list (one upserted row, `Plan · n/m` label). Audit/UI only.
+ * `tool`/`reasoning`/`plan` are recorded for EVERY turn regardless of the agent's Slack
  * output mode — output mode only gates what reaches the platform, never the transcript.
+ * Only `text` and `tool` rows ever rebuild model context; the other two are read-only history.
  */
-export type TranscriptKind = 'text' | 'tool' | 'reasoning'
+export type TranscriptKind = 'text' | 'tool' | 'reasoning' | 'plan'
 
 export interface TranscriptEntry {
   channel: string
@@ -3907,6 +3909,69 @@ export class LocalStore {
         [e.sender, e.recipient, ...sharedRecipients],
         this.transcriptRevision
       )
+    }
+  }
+
+  /** Write this turn's plan row (summary in `text`, the serialized PlanBody in `body`).
+   *  An ACP plan update replaces the WHOLE list, so this is an upsert rather than an append:
+   *  the insert claims the row on first sight and the update overwrites it on every later
+   *  one, keeping `seq`/`ts` at their first-seen values so the plan holds its place in the
+   *  turn. Shares the tool row's `tool_call_id` column as its identity — `planId` is minted
+   *  per turn and namespaced, and both statements are fenced on kind so a tool id can never
+   *  collide with one. */
+  upsertPlan(e: {
+    channel: string
+    thread: string
+    ts: string
+    sender: string
+    planId: string
+    title: string
+    body: string
+  }): Promise<void> {
+    const orgId = this.orgFor(e.sender)
+    return this.transcriptMutex.run(() => this.upsertPlanLocked(e, orgId))
+  }
+
+  /** The upsert itself, under {@link transcriptMutex} — see {@link appendTranscriptLocked}. */
+  private async upsertPlanLocked(
+    e: { channel: string; thread: string; ts: string; sender: string; planId: string; title: string; body: string },
+    orgId: string
+  ): Promise<void> {
+    const revision = this.transcriptRevision + 1
+    const written = await this.writeTranscriptRows(orgId, e.channel, e.thread, [
+      {
+        kind: 'run',
+        sql: `INSERT OR IGNORE INTO transcript
+           (orgId, channel, thread, ts, sender, kind, text, tool_call_id, body, eventTimeUs, revision)
+         VALUES (@orgId, @channel, @thread, @ts, @sender, 'plan', @text, @planId, @body, @eventTimeUs, @revision)`,
+        params: [
+          {
+            orgId,
+            channel: e.channel,
+            thread: e.thread,
+            ts: e.ts,
+            sender: e.sender,
+            text: e.title,
+            planId: e.planId,
+            body: e.body,
+            eventTimeUs: transcriptEventTimeUs(e.ts),
+            revision
+          }
+        ]
+      },
+      {
+        kind: 'run',
+        sql: `UPDATE transcript SET text = ?, body = ?, revision = ?
+         WHERE orgId = ? AND channel = ? AND thread = ? AND sender = ? AND tool_call_id = ? AND kind = 'plan'
+           AND (text IS NOT ? OR body IS NOT ?)`,
+        params: [e.title, e.body, revision, orgId, e.channel, e.thread, e.sender, e.planId, e.title, e.body]
+      }
+    ])
+    // Either statement changing a row means this thread moved; an unchanged re-send changes
+    // neither and must not bump the revision a live console polls on.
+    if (written.changes.some((changed) => changed > 0)) {
+      this.transcriptRevision = written.revision
+      this.notifyTranscriptMutation(e.channel, e.thread, [e.sender], this.transcriptRevision)
     }
   }
 

--- a/packages/daemon/src/webchat/turn-output.ts
+++ b/packages/daemon/src/webchat/turn-output.ts
@@ -8,6 +8,7 @@ import type { SessionImageAttachment, WebchatEvent } from '@agentconnect.md/prot
 import type { LocalStore } from '../store/local-store.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
 import { isNoResponsePrefix } from '../session/no-response.js'
+import { planEntriesOf } from '../session/plan-entries.js'
 import { chunkText } from './chunk.js'
 import type { Pending } from '../daemon/turn-types.js'
 
@@ -16,8 +17,8 @@ export type WebchatTurnOutput = NonNullable<Pending['webchat']>
 
 /**
  * Map one ACP SessionUpdate to a WebchatEvent and stream it through the sink (→ relay
- * `rd/chat`, webchat's "send"). Only the streamable chunk kinds map; usage/plan/
- * session_info are handled elsewhere or dropped. A single event whose inline text would
+ * `rd/chat`, webchat's "send"). Only the streamable kinds map; usage and the rest are
+ * handled elsewhere or dropped. A single event whose inline text would
  * blow the 256 KiB frame cap is split across multiple chunks, each with its own `index`.
  */
 export function emitWebchatUpdate(wc: WebchatTurnOutput, update: any): void {
@@ -89,8 +90,17 @@ export function emitWebchatUpdate(wc: WebchatTurnOutput, update: any): void {
       if (title) emit({ kind: 'session_info', title })
       return
     }
+    case 'plan': {
+      // A SNAPSHOT, not a chunk: ACP resends the whole list on each revision, so the browser
+      // replaces its copy rather than appending. Same entries the transcript row records, so
+      // a live turn shows the plan it is working through instead of only revealing it on the
+      // reload that switches the page to history.
+      const entries = planEntriesOf(update)
+      if (entries.length) emit({ kind: 'plan', entries })
+      return
+    }
     default:
-      return // plan/usage/etc. are not part of the webchat reply stream
+      return // usage/etc. are not part of the webchat reply stream
   }
 }
 

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -76,6 +76,7 @@ function replyingHost(reply: string) {
 const text = (t: string) => ({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: t } })
 const thought = (t: string) => ({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: t } })
 const tool = (toolCallId: string, title: string) => ({ sessionUpdate: 'tool_call', toolCallId, title })
+const plan = (entries: { content: string; status: string }[]) => ({ sessionUpdate: 'plan', entries })
 
 function makeRoutable(daemon: Daemon) {
   const a = (daemon as any).agents.get('bot-a')
@@ -932,14 +933,15 @@ describe('Daemon transcript captures the full activity log (mode-independent)', 
   const turn = [
     thought('let me think about'),
     thought(' this problem'),
+    plan([{ content: 'read the file', status: 'in_progress' }]),
     tool('t1', 'Read file.ts'),
     text('here is the answer')
   ]
 
-  // The agent's tool calls + reasoning must land in the transcript in EVERY output
-  // mode — output mode only gates what reaches Slack, never what is recorded.
+  // The agent's tool calls, reasoning, and plan must land in the transcript in EVERY
+  // output mode — output mode only gates what reaches Slack, never what is recorded.
   for (const mode of ['low', 'medium', 'high'] as const) {
-    it(`${mode} mode: tool + reasoning + text are all recorded with their kind`, async () => {
+    it(`${mode} mode: tool + reasoning + plan + text are all recorded with their kind`, async () => {
       const { factory } = streamingHost(turn)
       const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root: scaffold(mode), hostFactory: factory })
       await daemon.start()
@@ -950,12 +952,54 @@ describe('Daemon transcript captures the full activity log (mode-independent)', 
       expect(await activity(daemon)).toEqual([
         { kind: 'text', sender: 'U1', text: 'go' },
         { kind: 'reasoning', sender: 'bot-a', text: 'let me think about this problem' },
+        { kind: 'plan', sender: 'bot-a', text: 'Plan · 0/1' },
         { kind: 'tool', sender: 'bot-a', text: 'Read file.ts' },
         { kind: 'text', sender: 'bot-a', text: 'here is the answer' }
       ])
       await daemon.stop()
     })
   }
+
+  // An ACP plan update carries the WHOLE list every time, so a turn that revises its plan
+  // ten times must still read as one plan — the row is rewritten in place, keeping the
+  // position it took when the agent first published it.
+  it('rewrites ONE plan row per turn as the plan is revised', async () => {
+    const { factory } = streamingHost([
+      plan([
+        { content: 'read the file', status: 'in_progress' },
+        { content: 'fix the bug', status: 'pending' }
+      ]),
+      tool('t1', 'Read file.ts'),
+      plan([
+        { content: 'read the file', status: 'completed' },
+        { content: 'fix the bug', status: 'in_progress' }
+      ]),
+      text('done')
+    ])
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold('medium'),
+      hostFactory: factory
+    })
+    await daemon.start()
+    makeRoutable(daemon)
+
+    await (daemon as any).dispatch('bot-a', dm('100', 'go'), 'int-a')
+
+    const rows = await (daemon as any).store.threadTranscript(TRANSCRIPT_CHANNEL, 'T1')
+    const plans = rows.filter((r: TranscriptEntry) => r.kind === 'plan')
+    expect(plans).toHaveLength(1)
+    // Still ahead of the tool it planned, and carrying the LATEST statuses.
+    expect(rows.map((r: TranscriptEntry) => r.kind)).toEqual(['text', 'plan', 'tool', 'text'])
+    expect(plans[0].text).toBe('Plan · 1/2')
+    expect(JSON.parse(plans[0].body as string)).toEqual({
+      entries: [
+        { content: 'read the file', status: 'completed' },
+        { content: 'fix the bug', status: 'in_progress' }
+      ]
+    })
+    await daemon.stop()
+  })
 
   it('tool/reasoning rows are excluded from §8.5 catch-up replay', async () => {
     const { factory } = streamingHost(turn)

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -126,6 +126,7 @@ const toolCall = (toolCallId: string, title: string, status = 'pending') => ({
   title,
   status
 })
+const plan = (entries: { content: string; status: string }[]) => ({ sessionUpdate: 'plan', entries })
 const toolUpdate = (toolCallId: string, status: string) => ({
   sessionUpdate: 'tool_call_update',
   toolCallId,
@@ -204,6 +205,65 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
 
     // The turn closes with exactly one webchat/done carrying the stop reason.
     expect(cp.dones).toEqual([{ conversationId: CONV, turnId, stopReason: 'end_turn' }])
+    await daemon.stop()
+  })
+
+  // Without this the console only learns the plan on the reload that switches the page to
+  // history — the live turn shows tool rows for work whose plan it is hiding.
+  it('streams each plan revision as a whole-list snapshot', async () => {
+    const { factory } = streamingHost([
+      plan([
+        { content: 'read the file', status: 'in_progress' },
+        { content: 'fix the bug', status: 'pending' }
+      ]),
+      // No text and no status: dropped rather than streamed as an empty checklist.
+      plan([{ content: '   ', status: 'pending' }]),
+      plan([
+        { content: 'read the file', status: 'completed' },
+        { content: 'fix the bug', status: 'in_progress' }
+      ]),
+      text('done')
+    ])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    const cp = fakeCpClient()
+    ;(daemon as any).cpClient = cp
+
+    const turnId = '77777777-7777-4777-8777-777777777777'
+    await (daemon as any).dispatch(
+      AGENT_ID,
+      {
+        msgId: `webchat:${CONV}:${turnId}`,
+        traceId: turnId,
+        source: 'user' as const,
+        platform: 'webchat' as const,
+        channel: CONV,
+        sender: { id: 'alice', isBot: false },
+        text: 'go',
+        mentionedBots: [] as string[],
+        isDm: true,
+        trigger: 'dm' as const
+      },
+      undefined,
+      { conversationId: CONV, turnId, sink: cp.sink }
+    )
+
+    expect(cp.outputs.filter((o) => o.event?.kind === 'plan').map((o) => o.event)).toEqual([
+      {
+        kind: 'plan',
+        entries: [
+          { content: 'read the file', status: 'in_progress' },
+          { content: 'fix the bug', status: 'pending' }
+        ]
+      },
+      {
+        kind: 'plan',
+        entries: [
+          { content: 'read the file', status: 'completed' },
+          { content: 'fix the bug', status: 'in_progress' }
+        ]
+      }
+    ])
     await daemon.stop()
   })
 

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { SessionKey } from './route.js'
-import { WebchatImageAttachment } from './webchat.js'
+import { PlanEntry, WebchatImageAttachment } from './webchat.js'
 
 /**
  * Session read-back (C→D REQ → REP) — the console's on-demand pulls.
@@ -93,17 +93,10 @@ export type ToolBody = z.infer<typeof ToolBody>
 /**
  * The agent's task list for ONE turn, transported as a JSON STRING in `SessionMessage.body`
  * on a `plan` row. An ACP plan update carries the WHOLE entry list every time, so this is a
- * snapshot, not a delta — the daemon rewrites one row per turn rather than appending.
+ * snapshot, not a delta — the daemon rewrites one row per turn rather than appending. The
+ * live webchat stream carries the same entries as they change (`WebchatEvent` kind `plan`).
  */
-export const PlanBody = z.object({
-  entries: z.array(
-    z.object({
-      content: z.string(),
-      status: z.string(), // ACP PlanEntryStatus: pending|in_progress|completed
-      priority: z.string().optional() // ACP PlanEntryPriority: high|medium|low
-    })
-  )
-})
+export const PlanBody = z.object({ entries: z.array(PlanEntry) })
 export type PlanBody = z.infer<typeof PlanBody>
 
 /** One bounded webchat image persisted only in the daemon-local transcript. */

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -90,6 +90,22 @@ export const ToolBody = z.object({
 })
 export type ToolBody = z.infer<typeof ToolBody>
 
+/**
+ * The agent's task list for ONE turn, transported as a JSON STRING in `SessionMessage.body`
+ * on a `plan` row. An ACP plan update carries the WHOLE entry list every time, so this is a
+ * snapshot, not a delta — the daemon rewrites one row per turn rather than appending.
+ */
+export const PlanBody = z.object({
+  entries: z.array(
+    z.object({
+      content: z.string(),
+      status: z.string(), // ACP PlanEntryStatus: pending|in_progress|completed
+      priority: z.string().optional() // ACP PlanEntryPriority: high|medium|low
+    })
+  )
+})
+export type PlanBody = z.infer<typeof PlanBody>
+
 /** One bounded webchat image persisted only in the daemon-local transcript. */
 export const SessionImageAttachment = WebchatImageAttachment
 export type SessionImageAttachment = z.infer<typeof SessionImageAttachment>
@@ -112,14 +128,14 @@ export const SessionMessage = z.object({
   // at origin and identical on every participant's copy, independent of a
   // collision-bumped `ts`. Absent on non-webchat rows and pre-upgrade rows.
   postId: z.string().uuid().optional(),
-  kind: z.string(), // "text" / tool / … (daemon transcript kind)
+  kind: z.string(), // "text" / tool / reasoning / plan / … (daemon transcript kind)
   text: z.string(),
   attachments: z.array(SessionImageAttachment).max(1).optional(),
-  // ── tool-body enrichment (optional ⇒ text/reasoning rows and old daemons omit these) ──
+  // ── body enrichment (optional ⇒ text/reasoning rows and old daemons omit these) ──
   toolCallId: z.string().optional(), // parsed from the ToolBody (tool rows only)
   toolStatus: z.string().optional(), // ACP ToolCallStatus, surfaced for the console badge
   toolKind: z.string().optional(), // ACP ToolKind, surfaced for the console icon
-  body: z.string().optional(), // JSON.stringify(ToolBody); may be a truncated-but-VALID-JSON preview
+  body: z.string().optional(), // JSON.stringify(ToolBody) on a tool row, PlanBody on a plan row; a tool body may be a truncated-but-VALID-JSON preview
   bodyTruncated: z.boolean().optional(), // preview was shrunk for the frame; full body via session/tool-body
   bodyBytes: z.number().int().optional() // full (untruncated) body byte length
 })

--- a/packages/protocol/src/frames/webchat.test.ts
+++ b/packages/protocol/src/frames/webchat.test.ts
@@ -15,6 +15,23 @@ describe('WebchatOutput — event / status framing', () => {
     expect(r.success).toBe(true)
   })
 
+  it('accepts a plan snapshot, priority and all', () => {
+    const r = WebchatOutput.safeParse({
+      conversationId: CONV,
+      turnId: TURN,
+      index: 2,
+      event: {
+        kind: 'plan',
+        entries: [
+          { content: 'read the file', status: 'completed' },
+          { content: 'fix the bug', status: 'in_progress', priority: 'high' }
+        ]
+      }
+    })
+    expect(r.success).toBe(true)
+    if (r.success && r.data.event?.kind === 'plan') expect(r.data.event.entries).toHaveLength(2)
+  })
+
   it('accepts a status-only frame (no event)', () => {
     const r = WebchatOutput.safeParse({
       conversationId: CONV,

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -103,6 +103,18 @@ export type WebchatPost = z.infer<typeof WebchatPost>
 
 // One structured chunk of the agent's reply stream. Ordered per-connection (TCP);
 // 'index' is a per-turn monotonic counter for client-side assembly (NOT a global fence).
+/**
+ * One entry of an agent's task list, as ACP `plan` sends it. Defined HERE rather than
+ * beside `PlanBody` in session.ts because both the live stream and the persisted row carry
+ * it and session.ts already imports this module — the other direction would be a cycle.
+ */
+export const PlanEntry = z.object({
+  content: z.string(),
+  status: z.string(), // ACP PlanEntryStatus: pending|in_progress|completed
+  priority: z.string().optional() // ACP PlanEntryPriority: high|medium|low
+})
+export type PlanEntry = z.infer<typeof PlanEntry>
+
 export const WebchatEvent = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('message'), text: z.string() }), // from agent_message_chunk
   z.object({ kind: z.literal('thinking'), text: z.string() }), // from agent_thought_chunk
@@ -132,7 +144,18 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('superseded'), generation: z.number().int() }),
   // Live-only chrome for a wait the user cannot otherwise see (a cluster sandbox pod coming up).
   // Never persisted — a refresh rebuilds from the transcript, which does not record it.
-  z.object({ kind: z.literal('notice'), text: z.string() })
+  z.object({ kind: z.literal('notice'), text: z.string() }),
+  // The turn's task list (ACP `plan`). Unlike every other kind here it is a SNAPSHOT: ACP
+  // resends the whole list on each revision, so the client keeps the latest and never
+  // appends. Streamed because the same block already lands in the persisted transcript
+  // (transcript-full-tool-body.md §8) — without it a live turn hides its plan until the
+  // page is re-read from history, which is exactly the gap this closes.
+  // COMPAT: a relay predating this kind fails that ONE frame's decode and drops the chunk.
+  // Non-fatal by construction — the relay answers with an error frame and keeps the
+  // connection, so every other chunk still flows and the turn degrades to showing its plan
+  // only after the fact. There is no relay capability echo to gate on (`rd/hello/ok` carries
+  // only `relayId`), so this is the tradeoff rather than an oversight.
+  z.object({ kind: z.literal('plan'), entries: z.array(PlanEntry) })
 ])
 export type WebchatEvent = z.infer<typeof WebchatEvent>
 

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -236,6 +236,7 @@ type WebchatEvent =
   | { kind: 'session_info'; title: string }
   | { kind: 'superseded'; generation: number }
   | { kind: 'notice'; text: string }
+  | { kind: 'plan'; entries: { content: string; status: string; priority?: string }[] }
 
 /** The session status snapshot carried in a relay `rd/chat` WebchatOutput payload
  *  (mirrors protocol WebchatStatus). Partial: context/cost stream live, token
@@ -548,6 +549,22 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             ...collapsed,
             lane({ kind: 'plan', text: 'The conversation moved on — updating this answer…', boundary: true })
           ]
+        }
+        if (ev.kind === 'plan') {
+          // A snapshot: ACP resends the whole list, so this REPLACES the lane's existing
+          // block instead of appending a second one. Scanned back under the same fences as
+          // tool_update — never across a user message, a foreign turn, or a supersession —
+          // so the block keeps the position it first took, ahead of the work it planned,
+          // exactly as the persisted plan row keeps its `seq`.
+          for (let i = steps.length - 1; i >= 0; i--) {
+            const step = steps[i]!
+            if (step.kind === 'msg' && step.agentId === undefined) break
+            if ((step.agentId ?? undefined) !== agentId) continue
+            if (step.turnId !== turnId) break
+            if (step.boundary) break
+            if (step.kind === 'planblock') return replaceAt(i, { ...step, plan: ev.entries, observedAtMs })
+          }
+          return [...steps, lane({ kind: 'planblock', text: '', plan: ev.entries })]
         }
         if (ev.kind === 'notice') {
           // Daemon chrome for a wait with nothing else to show (a sandbox pod coming up).

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -552,16 +552,20 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         }
         if (ev.kind === 'plan') {
           // A snapshot: ACP resends the whole list, so this REPLACES the lane's existing
-          // block instead of appending a second one. Scanned back under the same fences as
-          // tool_update — never across a user message, a foreign turn, or a supersession —
-          // so the block keeps the position it first took, ahead of the work it planned,
-          // exactly as the persisted plan row keeps its `seq`.
+          // block instead of appending a second one, keeping the position it first took —
+          // ahead of the work it planned, exactly as the persisted plan row keeps its `seq`.
+          // Fenced by agent and turn like tool_update, but deliberately NOT by `boundary`:
+          // the daemon builds ONE TranscriptRecorder per turn, so a context-refresh
+          // replacement generation rewrites the SAME row. Stopping at the supersession
+          // marker would append a second checklist and leave the live view showing both the
+          // discarded plan and the current one, where a reload shows only the latter. The
+          // boundary exists to stop streamed TEXT merging across generations; a plan is a
+          // snapshot keyed to the turn, so it crosses.
           for (let i = steps.length - 1; i >= 0; i--) {
             const step = steps[i]!
             if (step.kind === 'msg' && step.agentId === undefined) break
             if ((step.agentId ?? undefined) !== agentId) continue
             if (step.turnId !== turnId) break
-            if (step.boundary) break
             if (step.kind === 'planblock') return replaceAt(i, { ...step, plan: ev.entries, observedAtMs })
           }
           return [...steps, lane({ kind: 'planblock', text: '', plan: ev.entries })]

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -436,6 +436,36 @@ describe('stream text delta batching', () => {
     ])
   })
 
+  // The daemon builds ONE TranscriptRecorder per turn, so a replacement generation rewrites
+  // the SAME plan row. Appending here instead would leave the live view showing the
+  // discarded plan next to the current one, where a reload shows only the latter.
+  it('rewrites the same plan block across a supersession instead of stacking a second', async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    act(() => {
+      for (const output of [
+        {
+          agentId: 'agent-1',
+          index: 0,
+          event: { kind: 'plan', entries: [{ content: 'first attempt', status: 'in_progress' }] }
+        },
+        { agentId: 'agent-1', index: 1, event: { kind: 'superseded', generation: 1 } },
+        {
+          agentId: 'agent-1',
+          index: 2,
+          event: { kind: 'plan', entries: [{ content: 'second attempt', status: 'in_progress' }] }
+        }
+      ]) {
+        socket.onmessage?.({ data: JSON.stringify({ type: 'output', output: { turnId, ...output } }) })
+      }
+    })
+    act(runFrame)
+
+    const blocks = getLiveSteps('s1').filter((step) => step.kind === 'planblock')
+    expect(blocks).toMatchObject([{ plan: [{ content: 'second attempt', status: 'in_progress' }] }])
+  })
+
   it("retires only the streaming lane's notice — a lane still waiting keeps its own", async () => {
     const runFrame = captureAnimationFrames()
     const { socket, turnId } = await openStream()

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -381,6 +381,61 @@ describe('stream text delta batching', () => {
     ])
   })
 
+  // ACP resends the WHOLE list on every revision, so a live plan must be one block that is
+  // rewritten — appending would stack a fresh checklist per keystroke of progress.
+  it("replaces the lane's plan block on each revision instead of appending another", async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    act(() => {
+      for (const output of [
+        {
+          agentId: 'agent-1',
+          index: 0,
+          event: {
+            kind: 'plan',
+            entries: [
+              { content: 'read the file', status: 'in_progress' },
+              { content: 'fix the bug', status: 'pending' }
+            ]
+          }
+        },
+        {
+          agentId: 'agent-1',
+          index: 1,
+          event: { kind: 'tool_call', toolCallId: 't1', title: 'cat a.ts', status: 'pending' }
+        },
+        {
+          agentId: 'agent-1',
+          index: 2,
+          event: {
+            kind: 'plan',
+            entries: [
+              { content: 'read the file', status: 'completed' },
+              { content: 'fix the bug', status: 'in_progress' }
+            ]
+          }
+        }
+      ]) {
+        socket.onmessage?.({ data: JSON.stringify({ type: 'output', output: { turnId, ...output } }) })
+      }
+    })
+    act(runFrame)
+
+    // One block, holding the position it first took — ahead of the tool it planned — and
+    // carrying the latest statuses.
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toMatchObject([
+      {
+        kind: 'planblock',
+        plan: [
+          { content: 'read the file', status: 'completed' },
+          { content: 'fix the bug', status: 'in_progress' }
+        ]
+      },
+      { kind: 'tool', text: 'cat a.ts' }
+    ])
+  })
+
   it("retires only the streaming lane's notice — a lane still waiting keeps its own", async () => {
     const runFrame = captureAnimationFrames()
     const { socket, turnId } = await openStream()

--- a/packages/web/src/components/console/session-work.test.ts
+++ b/packages/web/src/components/console/session-work.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  PLAN_LANE,
+  WORK_LANES,
+  planEntries,
   sessionTurnInFlight,
   stripBoldMarks,
   toggleWorkPanel,
@@ -128,5 +131,44 @@ describe('stripBoldMarks', () => {
 
   it('never pairs markers across lines — a stray ** cannot swallow a paragraph', () => {
     expect(stripBoldMarks('a stray ** here\nand ** another line')).toBe('a stray ** here\nand ** another line')
+  })
+})
+
+describe('planEntries', () => {
+  it('reads the entries a plan row carries', () => {
+    const body = JSON.stringify({
+      entries: [
+        { content: 'read the file', status: 'completed' },
+        { content: 'fix the bug', status: 'in_progress', priority: 'high' }
+      ]
+    })
+    expect(planEntries(body)).toEqual([
+      { content: 'read the file', status: 'completed' },
+      { content: 'fix the bug', status: 'in_progress', priority: 'high' }
+    ])
+  })
+
+  // Each of these reaches the console as a row whose `Plan · n/m` text still stands —
+  // the checklist is what is missing, not the fact that the agent planned.
+  it('yields nothing for a body that is absent, malformed, or entry-less', () => {
+    expect(planEntries(undefined)).toEqual([])
+    expect(planEntries('')).toEqual([])
+    expect(planEntries('{"entries":')).toEqual([])
+    expect(planEntries('{}')).toEqual([])
+  })
+
+  it('drops an entry with no text rather than rendering a blank line', () => {
+    const body = JSON.stringify({ entries: [{ status: 'pending' }, { content: 'real', status: 'pending' }] })
+    expect(planEntries(body)).toEqual([{ content: 'real', status: 'pending' }])
+  })
+})
+
+describe('PLAN_LANE', () => {
+  // The plan renders as its own block above the answer. Were it a work lane it would be
+  // counted as a reasoning step and hidden behind the "Thought through…" toggle — which is
+  // the state it was in when the console did not record plans at all.
+  it('is not a work lane, and does not collide with the playground live PLAN lane', () => {
+    expect(WORK_LANES.has(PLAN_LANE)).toBe(false)
+    expect(PLAN_LANE).not.toBe('PLAN')
   })
 })

--- a/packages/web/src/components/console/session-work.test.ts
+++ b/packages/web/src/components/console/session-work.test.ts
@@ -3,6 +3,7 @@ import {
   PLAN_LANE,
   WORK_LANES,
   planEntries,
+  planLabel,
   sessionTurnInFlight,
   stripBoldMarks,
   toggleWorkPanel,
@@ -157,9 +158,29 @@ describe('planEntries', () => {
     expect(planEntries('{}')).toEqual([])
   })
 
-  it('drops an entry with no text rather than rendering a blank line', () => {
-    const body = JSON.stringify({ entries: [{ status: 'pending' }, { content: 'real', status: 'pending' }] })
+  it('drops an entry with no text of its own rather than rendering a blank line', () => {
+    const body = JSON.stringify({
+      entries: [{ status: 'pending' }, { content: '   ', status: 'pending' }, { content: 'real', status: 'pending' }]
+    })
     expect(planEntries(body)).toEqual([{ content: 'real', status: 'pending' }])
+  })
+})
+
+describe('planLabel', () => {
+  // Computed from the entries on BOTH surfaces — a live block and the same block re-read
+  // from history must never disagree about the count.
+  it('counts the completed entries', () => {
+    expect(
+      planLabel([
+        { content: 'a', status: 'completed' },
+        { content: 'b', status: 'in_progress' },
+        { content: 'c', status: 'pending' }
+      ])
+    ).toBe('Plan · 1/3')
+  })
+
+  it('reads n/n once every entry is done', () => {
+    expect(planLabel([{ content: 'a', status: 'completed' }])).toBe('Plan · 1/1')
   })
 })
 

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -18,6 +18,13 @@ export const PLAN_LANE = 'PLAN_BLOCK'
 
 export type PlanEntry = PlanBody['entries'][number]
 
+/** The plan block's one-line label. Computed from the entries wherever they are present —
+ *  live and persisted alike — so the two surfaces can never disagree about the count; the
+ *  daemon writes the same string onto the row for readers that get no entries at all. */
+export function planLabel(entries: PlanEntry[]): string {
+  return `Plan · ${entries.filter((entry) => entry.status === 'completed').length}/${entries.length}`
+}
+
 /** Parse a plan row's `body` into its entries. Everything that is not a readable list —
  *  no body at all (an older daemon, or a control plane that forwards none), malformed
  *  JSON, an entry without text — yields nothing, and the caller falls back to the row's
@@ -26,7 +33,7 @@ export function planEntries(body: string | undefined): PlanEntry[] {
   if (!body) return []
   try {
     const parsed = JSON.parse(body) as Partial<PlanBody>
-    return (parsed.entries ?? []).filter((entry) => typeof entry?.content === 'string')
+    return (parsed.entries ?? []).filter((entry) => typeof entry?.content === 'string' && entry.content.trim() !== '')
   } catch {
     return []
   }

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -1,3 +1,5 @@
+import type { PlanBody } from '@/lib/api'
+
 // 2b chat style: an agent turn shows its spoken answer (MSG/DONE lanes) as plain
 // text and collapses its "work" — reasoning (THINK/PLAN), tool calls (TOOL), and
 // file edits (EDIT) — behind a per-turn "Thought through…" toggle.
@@ -7,6 +9,28 @@ export const WORK_LANES = new Set(['THINK', 'PLAN', 'TOOL', 'EDIT'])
  *  it is not something the agent thought or did, so it renders as its own standalone
  *  line instead of being counted and hidden as a reasoning step. */
 export const NOTICE_LANE = 'NOTICE'
+
+/** A persisted ACP plan row — the turn's task list. Also NOT a work lane: the plan is
+ *  what the agent set out to do, not a step it took, so it renders as its own checklist
+ *  above the answer rather than collapsing into "Thought through N steps". The name is
+ *  deliberately not `'PLAN'` — that one is a WORK lane, the playground's live re-tag. */
+export const PLAN_LANE = 'PLAN_BLOCK'
+
+export type PlanEntry = PlanBody['entries'][number]
+
+/** Parse a plan row's `body` into its entries. Everything that is not a readable list —
+ *  no body at all (an older daemon, or a control plane that forwards none), malformed
+ *  JSON, an entry without text — yields nothing, and the caller falls back to the row's
+ *  `Plan · n/m` summary rather than rendering a broken checklist. */
+export function planEntries(body: string | undefined): PlanEntry[] {
+  if (!body) return []
+  try {
+    const parsed = JSON.parse(body) as Partial<PlanBody>
+    return (parsed.entries ?? []).filter((entry) => typeof entry?.content === 'string')
+  } catch {
+    return []
+  }
+}
 
 /** Split an agent turn's collapsed work steps into the counts the summary reports:
  *  reasoning STEPS (THINK/PLAN), tool-command STEPS (TOOL), and edited FILES — the

--- a/packages/web/src/components/console/views/SessionDetailView.plan.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.plan.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment happy-dom
+
+// The turn's PLAN on the real session page. The point of the block is where it is, not that
+// it exists: the plan is what the agent set out to do, so it must be readable without opening
+// the "Thought through…" panel — and it must not be counted as one of those steps either.
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent, Session } from '@/lib/data'
+import type { SessionMessageDto } from '@/lib/api'
+
+const wire = vi.hoisted(() => ({ messages: [] as unknown[] }))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'session-1' }),
+  usePathname: () => '/acme/sessions/session-1',
+  useSearchParams: () => new URLSearchParams(''),
+  useRouter: () => ({
+    replace: () => {},
+    push: () => {},
+    prefetch: () => {},
+    back: () => {},
+    forward: () => {},
+    refresh: () => {}
+  })
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>
+}))
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    fetchSessionMessages: vi.fn(() => Promise.resolve({ messages: wire.messages, nextCursor: null })),
+    fetchSessionDetail: vi.fn(() => Promise.reject(new Error('no detail'))),
+    fetchMySessionIdentity: vi.fn(() => Promise.reject(new Error('no identity'))),
+    fetchConversationByKey: vi.fn(() => Promise.reject(new Error('no conversation'))),
+    fetchAgentTasks: vi.fn(() =>
+      Promise.resolve({ sessionId: 'session-1', tracked: true, tasks: [], truncated: false })
+    ),
+    fetchSessionPullRequest: vi.fn(() => Promise.reject(new actual.ApiError('pull request not found', 404))),
+    fetchWorkspaceFiles: vi.fn((_agentId: string, opts: { path: string }) =>
+      Promise.resolve({ path: opts.path, exists: true, entries: [], nextCursor: null })
+    ),
+    fetchWorkspaceGitStatus: vi.fn(() => Promise.resolve({ isRepo: false })),
+    fetchWorkspaceGitLog: vi.fn(() => Promise.resolve({ isRepo: false, commits: [], truncated: false, tracking: null }))
+  }
+})
+
+const agent = {
+  id: 'agent-1',
+  name: 'Ops bot',
+  runtime: 'claude',
+  model: 'sonnet',
+  status: 'online',
+  statusLabel: 'online',
+  icon: 'bot',
+  daemon: 'daemon-1',
+  workdir: './services/api',
+  workspace: { mode: 'scratch' },
+  canEdit: false
+} as unknown as Agent
+
+const session = {
+  id: 'session-1',
+  title: 'Upgrade the node',
+  status: 'idle',
+  statusLabel: 'completed',
+  platform: 'slack',
+  channel: '#ops',
+  user: 'sam',
+  agentId: 'agent-1',
+  agentName: 'Ops bot',
+  // Empty, which is what puts the page on the REAL transcript (`wantTranscript`) instead of
+  // the mock step list a list-only session carries.
+  steps: []
+} as unknown as Session
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    agents: [agent],
+    allSessions: [session],
+    getSessions: () => [session],
+    sessionsLoading: false,
+    crons: [],
+    daemons: [],
+    members: [],
+    sessionActivityVersionById: {},
+    sessionStreamGeneration: 0,
+    revalidateSessionLists: () => {}
+  })
+}))
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({
+    activeOrg: { id: 'org-1', slug: 'acme' },
+    myRole: 'collaborator',
+    orgPath: (p: string) => `/acme${p}`
+  })
+}))
+
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ user: { name: 'Sam' }, me: null }) }))
+vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
+vi.mock('@/lib/stick-to-bottom', () => ({ useStickToBottom: () => () => {} }))
+vi.mock('@/lib/auth', () => ({ isAuthConfigured: () => false }))
+vi.mock('@/lib/use-session-list', () => ({
+  useSessionList: () => ({ sessions: [], total: 0, isLoading: false, nextCursor: null, loadingMore: false })
+}))
+
+vi.mock('@/components/console/Shell', () => ({
+  useCrumbSlot: () => ({ register: () => {} }),
+  useMobileActionSlot: () => ({ action: null, register: () => {} })
+}))
+
+// One frozen object, not a fresh one per render: the transcript effect keys on
+// `reconcileLiveSteps` by identity, so a new closure each render refetches, re-renders, and
+// spins forever. (The viewer suite never sees this — its session carries mock steps, which
+// turns the real transcript off.)
+vi.mock('@/components/console/PlaygroundProvider', () => {
+  const playground = {
+    getPgSession: () => undefined,
+    getLiveSteps: () => [],
+    getBusyLaneAgentIds: () => [],
+    reconcileLiveSteps: () => {},
+    getPgImage: () => null,
+    getPgWorktree: () => false,
+    isPgBusy: () => false,
+    setPgImage: () => {},
+    openPlayground: () => 'pg_new',
+    pgSend: () => {},
+    pgAttach: () => {},
+    getPgQueue: () => [],
+    pgCancelQueued: () => {},
+    pgAddAgent: () => {},
+    pgSetModel: () => {},
+    pgSetEffort: () => {},
+    pgSetPermissionPreset: () => {},
+    pgSetFast: () => {},
+    pgSetWorktree: () => {},
+    pgCancel: () => {},
+    setPgInput: () => {}
+  }
+  return { usePlayground: () => playground, usePgDraft: () => '', usePgDraftHasText: () => false }
+})
+
+import SessionDetailView from './SessionDetailView'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let container: HTMLDivElement | undefined
+let root: ReturnType<typeof createRoot> | undefined
+
+const row = (m: Partial<SessionMessageDto> & { seq: number; sender: string; kind: string; text: string }) => ({
+  ts: String(1_700_000_000 + m.seq),
+  ...m
+})
+
+const PLAN = JSON.stringify({
+  entries: [
+    { content: 'Roll base-testnet-reth-a', status: 'completed' },
+    { content: 'Roll base-testnet-reth-b', status: 'in_progress' }
+  ]
+})
+
+async function render() {
+  await act(async () => {
+    root?.render(<SessionDetailView />)
+    await Promise.resolve()
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+const text = () => container?.textContent ?? ''
+
+beforeEach(() => {
+  wire.messages = [
+    row({ seq: 1, sender: 'sam', kind: 'text', text: 'upgrade base testnet' }),
+    row({ seq: 2, sender: 'agent-1', kind: 'reasoning', text: 'weighing the rollout order' }),
+    row({ seq: 3, sender: 'agent-1', kind: 'plan', text: 'Plan · 1/2', body: PLAN }),
+    row({ seq: 4, sender: 'agent-1', kind: 'text', text: 'both replicas are on v1.2.0' })
+  ]
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    onchange: null,
+    dispatchEvent: () => false
+  })) as unknown as typeof window.matchMedia
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container?.remove()
+  container = undefined
+  root = undefined
+})
+
+describe('the turn plan on the session page', () => {
+  it('shows the checklist without opening the work panel, and does not count it as a step', async () => {
+    await render()
+
+    // Every entry is on screen while the work panel is still collapsed…
+    expect(text()).toContain('Roll base-testnet-reth-a')
+    expect(text()).toContain('Roll base-testnet-reth-b')
+    expect(text()).toContain('Plan · 1/2')
+    // …and the reasoning row that IS collapsed work is not, which is what proves the two
+    // are rendered by different paths rather than the panel happening to be open.
+    expect(text()).not.toContain('weighing the rollout order')
+    // One reasoning step, not two: the plan is not folded into the count.
+    expect(text()).toContain('Thought through 1 step')
+  })
+
+  it('falls back to the summary when the row arrives without a body', async () => {
+    wire.messages = [
+      row({ seq: 1, sender: 'sam', kind: 'text', text: 'go' }),
+      row({ seq: 2, sender: 'agent-1', kind: 'plan', text: 'Plan · 3/6' }),
+      row({ seq: 3, sender: 'agent-1', kind: 'text', text: 'done' })
+    ]
+    await render()
+
+    expect(text()).toContain('Plan · 3/6')
+    expect(text()).toContain('done')
+  })
+})

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -95,13 +95,16 @@ import { useRuntimeCommands } from '@/components/console/useRuntimeCommands'
 import type { AgentIcon } from '@/lib/agent-icon'
 import {
   NOTICE_LANE,
+  PLAN_LANE,
   WORK_LANES,
+  planEntries,
   sessionTurnInFlight,
   stripBoldMarks,
   toggleWorkPanel,
   workCounts,
   workPanelOpen,
-  workSummary
+  workSummary,
+  type PlanEntry
 } from '@/components/console/session-work'
 import { ApprovalRequestsCard } from '@/components/console/ApprovalRequestsCard'
 import { SessionVisibilityControl } from '@/components/console/SessionVisibilityControl'
@@ -389,9 +392,25 @@ function ComposerSendButton({
 }
 
 // One agent-turn step rendered from a real transcript message. Maps the daemon
-// transcript kind (text | tool | reasoning) onto the existing lane styling.
+// transcript kind (text | tool | reasoning | plan) onto the existing lane styling.
 function msgStep(m: SessionMessageDto, toolSessionId?: string, platform?: string): FmtStep {
   const k = (m.kind || 'text').toLowerCase()
+  if (k === 'plan') {
+    return {
+      lane: PLAN_LANE,
+      laneColor: 'var(--text-tertiary)',
+      dot: 'var(--text-disabled)',
+      weight: 400,
+      textColor: 'var(--text-secondary)',
+      codeColor: 'var(--text-secondary)',
+      text: m.text,
+      code: '',
+      files: [],
+      plan: planEntries(m.body),
+      time: formatTranscriptRowTime(m),
+      ...(platform ? { platform } : {})
+    }
+  }
   if (k === 'tool') {
     return {
       lane: 'TOOL',
@@ -454,6 +473,9 @@ interface FmtStep {
   code: string
   files: { tag: string; path: string; color: string }[]
   time?: string
+  // The turn's task list — present only on a PLAN_LANE step, and empty when the row
+  // arrived without a readable body.
+  plan?: PlanEntry[]
   // A superseded answer collapsed into this lane — carried so the summary can skip it.
   demoted?: boolean
   // A peer participant's message attachment (rendered like the user bubble's).
@@ -557,6 +579,51 @@ function StepExtras({ step, sessionId, autoOpenTool }: { step: FmtStep; sessionI
       )}
       {step.msg && toolSessionId && <ToolBodyDetail msg={step.msg} sessionId={toolSessionId} autoOpen={autoOpenTool} />}
     </>
+  )
+}
+
+// How one plan entry reads: ACP's three statuses, and an unknown one treated as
+// not-yet-started rather than dropped.
+const PLAN_PENDING = { icon: 'circle', color: 'var(--text-disabled)', text: 'text-(--text-secondary)' }
+const PLAN_MARK: Record<string, typeof PLAN_PENDING> = {
+  completed: { icon: 'circle-check', color: 'var(--green-500)', text: 'text-(--text-tertiary)' },
+  in_progress: { icon: 'circle-dot', color: 'var(--blue-500)', text: 'text-(--text-primary) font-medium' },
+  pending: PLAN_PENDING
+}
+
+/**
+ * The turn's task list, rendered as its own block above the answer — deliberately not
+ * inside the collapsed work panel: the plan is what the agent set out to do, and burying
+ * it under "Thought through N steps" is what the console did by not recording it at all.
+ * A row whose body did not survive the trip shows just its `Plan · n/m` summary.
+ */
+function PlanBlock({ step }: { step: FmtStep }) {
+  const entries = step.plan ?? []
+  if (entries.length === 0) {
+    return (
+      <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">{step.text}</span>
+    )
+  }
+  return (
+    <div className="overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
+      <div className="flex items-center gap-[6px] px-[14px] py-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+        <Icon name="list-checks" size={13} color="var(--text-tertiary)" />
+        {step.text}
+      </div>
+      <div className="flex flex-col gap-[7px] border-t border-(--border-subtle) px-[14px] py-[10px]">
+        {entries.map((entry, ei) => {
+          const mark = PLAN_MARK[entry.status] ?? PLAN_PENDING
+          return (
+            <div key={ei} className="flex min-w-0 items-start gap-[8px]">
+              <span className="mt-[2px] flex-none">
+                <Icon name={mark.icon} size={13} color={mark.color} />
+              </span>
+              <span className={`min-w-0 font-sans text-[13px] leading-[1.5] ${mark.text}`}>{entry.content}</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
   )
 }
 
@@ -4007,8 +4074,12 @@ export default function SessionDetailView() {
                             // A daemon notice (a sandbox pod coming up) is neither: it renders
                             // as its own standalone line above the answer.
                             const noticeSteps = turn.steps.filter((s) => s.lane === NOTICE_LANE)
+                            // The turn's plan: its own block, so it is neither a spoken answer nor
+                            // collapsed work. A turn carries at most one (the row is upserted), but
+                            // a merged conversation interleaves turns from several sources.
+                            const planSteps = turn.steps.filter((s) => s.lane === PLAN_LANE)
                             const textSteps = turn.steps.filter(
-                              (s) => !WORK_LANES.has(s.lane) && s.lane !== NOTICE_LANE
+                              (s) => !WORK_LANES.has(s.lane) && s.lane !== NOTICE_LANE && s.lane !== PLAN_LANE
                             )
                             const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
                             // Reasoning steps / tool commands / edited FILES (distinct paths across
@@ -4108,6 +4179,15 @@ export default function SessionDetailView() {
                                         >
                                           {st.text}
                                         </span>
+                                      ))}
+                                    </div>
+                                  )}
+                                  {planSteps.length > 0 && (
+                                    <div
+                                      className={`flex min-w-0 flex-col gap-2 ${textSteps.length > 0 || workSteps.length > 0 ? 'mb-2' : ''}`}
+                                    >
+                                      {planSteps.map((st, si) => (
+                                        <PlanBlock key={`p:${si}`} step={st} />
                                       ))}
                                     </div>
                                   )}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -98,6 +98,7 @@ import {
   PLAN_LANE,
   WORK_LANES,
   planEntries,
+  planLabel,
   sessionTurnInFlight,
   stripBoldMarks,
   toggleWorkPanel,
@@ -600,15 +601,17 @@ const PLAN_MARK: Record<string, typeof PLAN_PENDING> = {
 function PlanBlock({ step }: { step: FmtStep }) {
   const entries = step.plan ?? []
   if (entries.length === 0) {
-    return (
+    // No entries survived the trip: show whatever label the row carried, and nothing if it
+    // carried none (a live block always has entries — it is only created by an update).
+    return step.text ? (
       <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">{step.text}</span>
-    )
+    ) : null
   }
   return (
     <div className="overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
       <div className="flex items-center gap-[6px] px-[14px] py-2 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
         <Icon name="list-checks" size={13} color="var(--text-tertiary)" />
-        {step.text}
+        {planLabel(entries)}
       </div>
       <div className="flex flex-col gap-[7px] border-t border-(--border-subtle) px-[14px] py-[10px]">
         {entries.map((entry, ei) => {
@@ -792,6 +795,7 @@ function fmtStep(stp: SessionStep, platform?: string): FmtStep {
     code: stp.code ?? '',
     files: (stp.files ?? []).map((f) => ({ tag: f.tag, path: f.path, color: fileColor(f.tag) })),
     time: stp.time ?? '',
+    ...(stp.kind === 'planblock' ? { plan: stp.plan ?? [] } : {}),
     ...(stp.demoted ? { demoted: true } : {}),
     ...(platform ? { platform } : {}),
     // The live wire frame carries no body (kept off the hot path); attach just

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -616,10 +616,17 @@ export interface ToolBody {
   truncated?: boolean // daemon capped the stored body at write time
 }
 
+// The agent's task list for one turn (protocol `PlanBody`), transported as a JSON
+// STRING in `SessionMessageDto.body` on a `kind === 'plan'` row. An ACP plan update
+// carries the whole list every time, so one row per turn holds the latest snapshot.
+export interface PlanBody {
+  entries: { content: string; status: string; priority?: string }[]
+}
+
 // One transcript message (`GET /sessions/:id/messages`, proxied live from the
-// owning daemon). `kind` is the daemon transcript kind: text | tool | reasoning.
-// The tool-body fields are present only on `kind === 'tool'` rows from a daemon
-// that captures bodies (all optional ⇒ old daemons / text rows omit them).
+// owning daemon). `kind` is the daemon transcript kind: text | tool | reasoning | plan.
+// `body` carries a ToolBody on a tool row and a PlanBody on a plan row; it is absent
+// on text/reasoning rows, and on plan rows from a daemon or CP predating them.
 export interface SessionMessageDto {
   seq: number
   sender: string

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -4,7 +4,7 @@
 import type { AgentIcon } from '@/lib/agent-icon'
 import { gitRepoHostname, managedGitlabRepoPath } from './git-url-tile'
 import { isCodeHostHookKind, type HookKind } from '@agentconnect.md/protocol/code-host'
-import type { DaemonSessionRetention, ManagedMemoryScope, MemoryDreamingConfig } from '@/lib/api'
+import type { DaemonSessionRetention, ManagedMemoryScope, MemoryDreamingConfig, PlanBody } from '@/lib/api'
 import { featureFlagEnabled } from '@/lib/feature-flags'
 import { platformLabel } from '@/lib/platform-labels'
 import { randomUuid } from '@/lib/random-uuid'
@@ -273,7 +273,10 @@ export function agentIsPlaced(agent: Pick<Agent, 'daemon' | 'runtime' | 'placeme
   return (isPoolPlacementKind(agent.placementKind) || agent.daemon !== '—') && agent.runtime !== ''
 }
 
-export type LaneKind = 'msg' | 'plan' | 'tool' | 'edit' | 'done' | 'notice'
+// `plan` is REASONING, for historical reasons — the ACP task list is `planblock`, which is
+// not a work lane at all. Renaming `plan` to `think` would be the honest fix; it is left
+// alone here so this change stays about the task list.
+export type LaneKind = 'msg' | 'plan' | 'tool' | 'edit' | 'done' | 'notice' | 'planblock'
 
 export interface LaneInfo {
   lane: string
@@ -328,6 +331,18 @@ const LANE_MAP: Record<LaneKind, LaneInfo> = {
     weight: 400,
     textColor: 'var(--text-tertiary)',
     codeColor: 'var(--text-tertiary)'
+  },
+  // The turn's ACP task list. Like `notice` and for the same reason, NOT a work lane: it is
+  // what the agent set out to do, so it renders as its own checklist above the answer rather
+  // than being counted and hidden as a reasoning step. The row colors are unused — PlanBlock
+  // paints each entry from its status.
+  planblock: {
+    lane: 'PLAN_BLOCK', // = session-work.ts PLAN_LANE (kept literal here, as NOTICE is)
+    laneColor: 'var(--text-tertiary)',
+    dot: 'var(--text-disabled)',
+    weight: 400,
+    textColor: 'var(--text-secondary)',
+    codeColor: 'var(--text-secondary)'
   },
   // An assistant's completed reply — rendered neutrally, identical to a real transcript
   // text row (see SessionDetailView.msgStep). Keeping this in sync means a live playground
@@ -1041,6 +1056,9 @@ export interface SessionStep {
   /** Display timestamp for live/mock-only steps. Persisted transcripts use their raw ts. */
   time?: string
   text: string
+  /** The turn's task list — present only on a `planblock` step, replaced wholesale on each
+   *  ACP plan revision (never merged). */
+  plan?: PlanBody['entries']
   code?: string
   files?: SessionFile[]
   image?: SessionImage


### PR DESCRIPTION
The console's session view is the one place a session can be read end to end, and it was missing the agent's task list. `TranscriptRecorder` handled `agent_thought_chunk`, `tool_call` and `tool_call_update`, and let an ACP `plan` update fall through its `default` case; `emitWebchatUpdate` dropped it too. So the plan existed only as platform chrome — Slack, Discord, Telegram, Feishu — and nowhere in AgentConnect's own surfaces.

Two commits, in the order they were found: record it, then stream it.

## Record it

One property shapes everything else: an ACP plan update carries the WHOLE entry list every time, so the row is a snapshot, not an append. The recorder mints a namespaced `plan:<uuid>` per turn (a recorder is built per turn) and the store upserts that row, so a turn that revises its plan twenty times still reads as one plan, holding the position it took when the agent first published it — ahead of the work it planned. Both statements are fenced on `kind`, so a session-local tool id can never address a plan row.

`text` is `Plan · n/m` and `body` is the serialized `PlanBody`, which keeps the row useful when only the summary survives the trip (an older console, or a control plane that forwards no plan body). The reader passes a plan body through inline under the existing preview cap; there is no complete-body fetch behind it, so an implausibly large one is dropped rather than truncated into an unparseable list.

Plan rows stay out of model context for free — every replay and delivery-scope query already filters on `text`/`tool`. There is a test pinning that rather than a new guard.

## Stream it

Recording alone closed half the gap: the console still learned the plan on the read that switches a page to history, so a live turn showed tool rows for work whose plan it was hiding. `WebchatEvent` gains a `plan` kind carrying the same entries.

It is the one kind in that union that is a snapshot, so the browser REPLACES its block instead of appending, under the same lane fences `tool_update` uses. Both sides normalize through one function (`daemon/src/session/plan-entries.ts`) and the label is computed from the entries wherever they are present, so a live block and the same block re-read from history cannot drift.

## Where it renders

Its own checklist above the answer, never inside the collapsed "Thought through N steps" panel: the plan is what the agent set out to do, not a step it took. Completed entries carry a green check and dim; the current one is bold with a blue dot; the rest are outline circles.

## What a reviewer should weigh

**The relay compatibility cost is deliberate.** The relay hard-validates: `RdChat.event` → `WebchatOutput.event` → the `WebchatEvent` union, all parsed in `decodeRelayDaemonFrame`. A relay predating this kind fails that ONE frame's decode, answers with an error frame, and keeps the connection (no close) — so the chunk is dropped, every other chunk still flows, and the turn degrades to showing its plan only after the fact. Gating on a capability is not available: `rd/hello` advertises the DAEMON's capabilities and `rd/hello/ok` returns only `relayId`. Adding that echo would be its own protocol change and buys nothing until relays upgrade anyway. The tradeoff is written into the schema comment.

**A naming trap.** The live `plan` LaneKind is REASONING, for historical reasons, so the task list had to become `planblock`. Renaming the old one to `think` is the honest fix — mechanical, and it removes a footgun that bit this change once mid-flight — but it is scope creep here, so there is only a comment at the definition. Happy to do it as a follow-up.

## Verification

Beyond the suites, this ran end to end against a local stack (control plane + relay + daemon + console, a real Codex runtime): the live block advanced `Plan · 1/5` → `2/5` → `5/5` mid-turn as one block, and a reload — which re-reads from the transcript — rendered an identical block in the same position. The daemon's SQLite held exactly one `plan` row per turn, sitting ahead of the tool rows it planned.

Suites: protocol 460, web 2190, daemon 5119 passed. The daemon's 14 failures (13 shim/workspace, 1 live ACP matrix on an upstream billing error) reproduce identically on a pristine `main` worktree — confirmed rather than assumed.

New tests cover: the protocol accepting a plan snapshot; the daemon recording one upserted row per turn with the latest entries and its position held; plan rows excluded from replay; each live revision streaming as a whole-list snapshot with whitespace-only entries dropped; the playground reducer replacing rather than appending; `planEntries` degrading on an absent/malformed/entry-less body; `planLabel` counting; and a render test asserting the block is on screen while the collapsed reasoning row is not, with the work summary not counting the plan as a step.

Docs: `transcript-full-tool-body.md` §8 (it owns the recorder → store → proxy → console chain, which the plan row reuses end to end) and the content-type list in `session-concept.md` §2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
