### PR TITLE
test(cp): make the seeded agent name collision-proof

### DIFF
--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -48,6 +48,11 @@ export async function seedDaemon(
   return DaemonId(id)
 }
 
+/** `seedAgent`'s derived name — the WHOLE id, so two agents seeded into one org can never collide on (orgId, name). */
+export function defaultAgentName(id: string): string {
+  return `agent-${id}`
+}
+
 export async function seedAgent(
   prisma: PrismaClient,
   id: string,
@@ -77,7 +82,7 @@ export async function seedAgent(
     data: {
       id,
       orgId: opts.orgId ?? DEFAULT_ORG_ID,
-      name: opts.name ?? `agent-${id.slice(0, 4)}`,
+      name: opts.name ?? defaultAgentName(id),
       runtime: opts.runtime ?? 'claude',
       daemonId: opts.daemonId,
       ...(opts.setId ? { placementKind: 'set' as const, setId: opts.setId } : {}),

--- a/packages/control-plane/test/integration/agents.replication.route.test.ts
+++ b/packages/control-plane/test/integration/agents.replication.route.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, seedDutyGroup, defaultAgentName } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender, NoConnection } from '../../src/orchestrator/outbound.js'
 import type { AgentUpsert, AgentRemove, CollabRoutesSnapshot } from '@agentconnect.md/protocol'
@@ -155,7 +155,7 @@ describe('agent config replication CP→daemon (REST → agent/upsert·remove)',
       spec: {
         agentId,
         orgId: DEFAULT_ORG_ID,
-        name: `agent-${agentId.slice(0, 4)}`, // seeded slug (name is immutable)
+        name: defaultAgentName(agentId), // seeded slug (name is immutable)
         displayName: null,
         // Always shipped value-or-null (like displayName): null here — the agent has no
         // icon and no PUBLIC_CP_URL is configured in the test, so no avatar URL resolves.

--- a/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
+++ b/packages/control-plane/test/integration/gitlab-hooks.route.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
-import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, defaultAgentName } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { FakeGitlab, type FakeGitlabOptions } from '../fakes/gitlab-api.js'
 import { GitlabOauthService } from '../../src/gitlab/oauth.service.js'
@@ -297,7 +297,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
         expect(rule.gitlab?.projectId).toBe(PROJECT.toString())
         expect(rule.gitlab?.sessionKeyPrefix).toBe(`gitlab:${PROJECT}`)
         expect(rule.gitlab?.serviceAccountUsername).toBe(
-          gitlabAgentAccountUsername(h.agentId, `agent-${h.agentId.slice(0, 4)}`, 900n)
+          gitlabAgentAccountUsername(h.agentId, defaultAgentName(h.agentId), 900n)
         )
         // §12.1 veto set: every account bound to the project (§7.2).
         expect(rule.gitlab?.boundServiceAccountUserIds).toEqual([rule.gitlab!.serviceAccountUserId])
@@ -324,7 +324,7 @@ describe('gitlab hooks — routes, compile, webhook converge (§8.3/§11.1/§11.
     // own account, so the account has to exist by the time the write happens.
     const account = (await h.accounts.byAgentRoot(DEFAULT_ORG_ID, h.agentId, 900n))!
     expect(account.state).toBe('ready')
-    expect(account.username).toBe(gitlabAgentAccountUsername(h.agentId, `agent-${h.agentId.slice(0, 4)}`, 900n))
+    expect(account.username).toBe(gitlabAgentAccountUsername(h.agentId, defaultAgentName(h.agentId), 900n))
     expect((await h.accounts.membershipsForBinding(h.binding.id)).map((m) => m.accountId)).toEqual([account.id])
     expect(h.fake.members.get(Number(account.serviceAccountUserId))).toBe(30)
   })

--- a/packages/control-plane/test/integration/gitlab-provision.test.ts
+++ b/packages/control-plane/test/integration/gitlab-provision.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { prisma } from '../setup.db.js'
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
-import { seedAgent } from '../fixtures/seed.js'
+import { seedAgent, defaultAgentName } from '../fixtures/seed.js'
 import { FakeGitlab, type FakeGitlabOptions } from '../fakes/gitlab-api.js'
 import { GitlabOauthService } from '../../src/gitlab/oauth.service.js'
 import { GitlabProvisioner } from '../../src/gitlab/provisioner.js'
@@ -128,7 +128,7 @@ async function harness(
   })
   for (const agent of agents) {
     await seedAgent(prisma, agent.id, {
-      name: agent.name ?? `agent-${agent.id.slice(0, 4)}`,
+      name: agent.name ?? defaultAgentName(agent.id),
       gitlabProjectId: PROJECT,
       ...(agent.gitAccess ? { gitAccess: agent.gitAccess } : {})
     })

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -14,7 +14,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, seedDutyGroup, defaultAgentName } from '../fixtures/seed.js'
 import { seedPoolMember } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { ControlSender } from '../../src/orchestrator/outbound.js'
@@ -518,7 +518,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       payload: { platform: 'discord', agentId: agentId2, discord: { botToken: 'MTA1-bot.token.abc' } }
     })
     expect(unreachable.statusCode).toBe(201)
-    expect((unreachable.json() as { name: string }).name).toBe(`agent-${agentId2.slice(0, 4)}`)
+    expect((unreachable.json() as { name: string }).name).toBe(defaultAgentName(agentId2))
   })
 
   it('POST feishu defaults omitted region to Lark, stores the credential pair, and pushes a feishu-shaped upsert', async () => {
@@ -882,7 +882,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
       payload: { platform: 'feishu', agentId: agentId2, feishu: { appId: 'cli_b', appSecret: 's' } }
     })
     expect(unreachable.statusCode).toBe(201)
-    expect((unreachable.json() as { name: string }).name).toBe(`agent-${agentId2.slice(0, 4)}`)
+    expect((unreachable.json() as { name: string }).name).toBe(defaultAgentName(agentId2))
   })
 
   it('POST rejects a mismatched credential block (platform telegram + slack tokens) with 400', async () => {
@@ -899,7 +899,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
   it('POST without a name falls back to the owning agent name (no resolver wired)', async () => {
     const agentId = await placedAgent()
     const { app } = withSpy() // buildHttpApp wires no resolveSlackBotName ⇒ offline fallback
-    const agentName = `agent-${agentId.slice(0, 4)}` // seedAgent's naming
+    const agentName = defaultAgentName(agentId)
 
     const res = await app.app.inject({
       method: 'POST',
@@ -1049,7 +1049,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     })
     expect(res.statusCode).toBe(201)
     // Name falls back to the owning agent when auth.test couldn't derive one.
-    expect((res.json() as { name: string }).name).toBe(`agent-${agentId.slice(0, 4)}`)
+    expect((res.json() as { name: string }).name).toBe(defaultAgentName(agentId))
   })
 
   it('POST on an UNPLACED agent is refused with 409 and stores nothing', async () => {
@@ -1128,7 +1128,7 @@ describe('integration install flow (REST → integration/upsert·remove)', () =>
     // The bot SURVIVES with its tokens, stamped with the freed-from hints.
     const bot = await prisma.bot.findUnique({ where: { id: created.botId } })
     expect(bot?.lastUsedAt).not.toBeNull()
-    expect(bot?.lastAgentName).toBe(`agent-${agentId.slice(0, 4)}`)
+    expect(bot?.lastAgentName).toBe(defaultAgentName(agentId))
     expect(await prisma.botSecret.findUnique({ where: { botId: created.botId } })).not.toBeNull()
     // The org rides every removal now: the payload is a bare id, so the send has
     // nothing else to scope on when the connection is install-wide.

--- a/packages/control-plane/test/integration/session-conversations.route.test.ts
+++ b/packages/control-plane/test/integration/session-conversations.route.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, defaultAgentName } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgAgentRepo, PgHookRepo, PgSessionRepo, PgWebchatConversationRepo } from '../../src/persistence/index.js'
 import { AgentId, OrgId, SessionId } from '../../src/domain/ids.js'
@@ -193,7 +193,7 @@ describe('GET /sessions — grouped conversations', () => {
     expect(facets.statusCode).toBe(200)
     expect(facets.json()).toMatchObject({
       agents: expect.arrayContaining([AGENT_A, AGENT_B]),
-      agentNames: { [AGENT_A]: 'agent-a1a1', [AGENT_B]: 'agent-b1b1' }
+      agentNames: { [AGENT_A]: defaultAgentName(AGENT_A), [AGENT_B]: defaultAgentName(AGENT_B) }
     })
   })
 

--- a/packages/control-plane/test/integration/session-metadata.route.test.ts
+++ b/packages/control-plane/test/integration/session-metadata.route.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { randomUUID } from 'node:crypto'
 import { prisma } from '../setup.db.js'
-import { seedDaemon, seedAgent, seedLaunch } from '../fixtures/seed.js'
+import { seedDaemon, seedAgent, seedLaunch, defaultAgentName } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { PgAgentRepo, PgHookRepo, PgSessionRepo, PgWebchatConversationRepo } from '../../src/persistence/index.js'
 import { AgentId, OrgId } from '../../src/domain/ids.js'
@@ -278,8 +278,20 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
         }
       ).childSessions
     ).toEqual([
-      { id: firstChild, agentId: AGENT, agentName: 'agent-a0a0', platform: 'telegram', title: 'Check the database' },
-      { id: secondChild, agentId: AGENT, agentName: 'agent-a0a0', platform: 'discord', title: 'Check the API' }
+      {
+        id: firstChild,
+        agentId: AGENT,
+        agentName: defaultAgentName(AGENT),
+        platform: 'telegram',
+        title: 'Check the database'
+      },
+      {
+        id: secondChild,
+        agentId: AGENT,
+        agentName: defaultAgentName(AGENT),
+        platform: 'discord',
+        title: 'Check the API'
+      }
     ])
     expect((parentRes.json() as { parentSession: unknown }).parentSession).toBeNull()
     expect((parentRes.json() as { siblingSessions: unknown[] }).siblingSessions).toEqual([])
@@ -292,12 +304,18 @@ describe('event/session sync → SessionMeta → GET /sessions/:id', () => {
     ).toEqual({
       id: parent,
       agentId: AGENT,
-      agentName: 'agent-a0a0',
+      agentName: defaultAgentName(AGENT),
       platform: 'slack',
       title: 'Coordinate the rollout'
     })
     expect((childRes.json() as { siblingSessions: unknown[] }).siblingSessions).toEqual([
-      { id: secondChild, agentId: AGENT, agentName: 'agent-a0a0', platform: 'discord', title: 'Check the API' }
+      {
+        id: secondChild,
+        agentId: AGENT,
+        agentName: defaultAgentName(AGENT),
+        platform: 'discord',
+        title: 'Check the API'
+      }
     ])
     expect((childRes.json() as { childSessions: unknown[] }).childSessions).toEqual([])
   })


### PR DESCRIPTION
`seedAgent` named an agent `agent-<first 4 hex of its id>` when a test did not
pass a name. Four hex characters are 65,536 names, and the constraint the name
answers to is `agent_orgId_name_key` on `(orgId, name)`, so every test that
seeds two agents into one org had a ~1/65536 chance per run of failing with
P2002 instead of running. It is a latent flake in several suites — it surfaced
in CI on `integrations.route.test.ts`, on the case that seeds a second agent
right after `placedAgent()`.

The derived name now carries the whole id. The id is the primary key, so
uniqueness of the name follows from uniqueness of the row: the collision is not
made unlikely, it is made unreachable.

The format was restated at eleven assertion sites, which would have started
failing deterministically the moment the fixture changed — five in
`integrations.route.test.ts`, two each in `gitlab-hooks.route.test.ts` and
`session-metadata.route.test.ts` (those two carried the name as a literal), and
one each in `agents.replication.route.test.ts`, `gitlab-provision.test.ts`, and
`session-conversations.route.test.ts`. All of them now call the exported
`defaultAgentName()`, so the fixture and its assertions cannot drift again.

The name stays a legal agent slug (`agent-` plus a lowercase-hex UUID is 42
characters against the DTO's 63-character limit and its
`^[a-z0-9]+(-[a-z0-9]+)*$` shape), and the GitLab account username derived from
it truncates through the same helper the assertions call.

Verified: `test:int` 115 files / 1826 tests, `test:unit` 182 files / 2103 tests,
plus `typecheck`, `lint`, and `format:check` across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
