### PR TITLE
feat(cp): let the MCP read an agent's workspace

### DIFF
--- a/docs/designs/agent-assistant.md
+++ b/docs/designs/agent-assistant.md
@@ -212,6 +212,7 @@ Tools **call the CP service layer directly or reuse route-handler logic**, prese
 | -------------------------------------------------------------- | ---------------------------------------------------------- | ------- |
 | `whoami`                                                       | GET /me + GET /orgs/:orgId (credential identity/role)      | –       |
 | `listAgents` / `getAgent`                                      | GET /agents(:id)                                           | –       |
+| `listWorkspaceFiles` / `readWorkspaceFile`                     | GET /agents/:id/workspace/files(file) (proxied, unstored)  | –       |
 | `createAgent` / `updateAgent`                                  | POST /agents · PATCH /agents/:id                           | ✎       |
 | `deleteAgent`                                                  | DELETE /agents/:id                                         | ✎🔥     |
 | `listDaemons` / `renameDaemon`                                 | GET /daemons · PATCH /daemons/:id                          | –/✎     |

--- a/packages/control-plane/src/http/mcp/tools.test.ts
+++ b/packages/control-plane/src/http/mcp/tools.test.ts
@@ -49,6 +49,8 @@ const AGENT_UUID = '5e0f8a25-31c8-4a1a-bb0e-9a8f6a2b1c22'
 /** Minimal happy-path args per tool (tools with no args pass {}). */
 const ARGS: Record<string, Record<string, unknown>> = {
   getAgent: { agentId: 'agent-1' },
+  listWorkspaceFiles: { agentId: 'agent-1', path: 'scripts' },
+  readWorkspaceFile: { agentId: 'agent-1', path: 'scripts/build.sh' },
   getCron: { cronId: 'cron-1' },
   listCronRuns: { cronId: 'cron-1' },
   getSession: { sessionId: 'sess-1' },
@@ -204,6 +206,29 @@ describe('MCP tool registry — §6.2 invariants', () => {
     const scopedCall = scoped.calls[0] as { query: Record<string, string> }
     expect(scopedCall.query.source).toBe('gateway')
     expect(Date.parse(scopedCall.query.to!) - Date.parse(scopedCall.query.from!)).toBe(30 * 24 * 60 * 60 * 1000)
+  })
+
+  it('workspace reads carry the scope and the byte slice as query parameters', async () => {
+    const { ctx, calls } = recordingCtx()
+    await findTool('listWorkspaceFiles')!.call(ctx, { agentId: 'a1', path: 'src', limit: 50 })
+    expect(calls[0]).toEqual({
+      method: 'GET',
+      path: `/orgs/${ORG_ID}/agents/a1/workspace/files`,
+      query: { path: 'src', sessionId: undefined, repo: undefined, cursor: undefined, limit: 50 }
+    })
+    // `offset` is the answer's own nextOffset fed back, so it must survive verbatim.
+    const file = recordingCtx()
+    await findTool('readWorkspaceFile')!.call(file.ctx, {
+      agentId: 'a1',
+      path: 'src/index.ts',
+      sessionId: 's1',
+      offset: 65536
+    })
+    expect(file.calls[0]).toEqual({
+      method: 'GET',
+      path: `/orgs/${ORG_ID}/agents/a1/workspace/file`,
+      query: { path: 'src/index.ts', sessionId: 's1', repo: undefined, offset: 65536, limit: undefined }
+    })
   })
 
   it('listSessions filters by every canonical platform — the /sessions route accepts the same set', () => {

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -171,6 +171,72 @@ export const MCP_TOOLS: McpToolDef[] = [
     schema: z.object({ agentId: z.string().min(1).describe('The agent id (from listAgents)') }).strict(),
     call: (ctx, a) => ctx.get(org(ctx, `/agents/${seg(a.agentId)}`))
   },
+  // `getAgent` answers WHERE an agent works; these two answer what is in there.
+  // Both proxy live from the owning daemon and the CP persists nothing.
+  {
+    name: 'listWorkspaceFiles',
+    description:
+      'List one directory of an agent’s workspace, proxied live from the owning daemon. A missing directory is data (exists:false), not an error; the answer pages through nextCursor. 503 while the agent is unplaced or its daemon is offline.',
+    schema: z
+      .object({
+        agentId: z.string().min(1).describe('The agent id (from listAgents)'),
+        path: z.string().optional().describe('Workspace-relative POSIX path; omit for the workspace root'),
+        sessionId: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Browse an authorized isolated session worktree instead of the primary checkout'),
+        repo: z
+          .string()
+          .min(1)
+          .max(256)
+          .optional()
+          .describe('owner/repo of one of the agent’s authorized additional repositories'),
+        cursor: z.string().min(1).optional().describe('Continue a listing from a previous nextCursor'),
+        limit: z.number().int().positive().max(500).optional().describe('Page size (default 200)')
+      })
+      .strict(),
+    call: (ctx, a) =>
+      ctx.get(org(ctx, `/agents/${seg(a.agentId)}/workspace/files`), {
+        path: a.path as string | undefined,
+        sessionId: a.sessionId as string | undefined,
+        repo: a.repo as string | undefined,
+        cursor: a.cursor as string | undefined,
+        limit: a.limit as number | undefined
+      })
+  },
+  {
+    name: 'readWorkspaceFile',
+    description:
+      'Read one byte slice of a file in an agent’s workspace, proxied live from the owning daemon (64 KiB per call). Page by passing the answer’s nextOffset back as offset while truncated is true — never recompute it from the content. A missing file is data (exists:false); a binary file answers encoding:none with no content.',
+    schema: z
+      .object({
+        agentId: z.string().min(1).describe('The agent id (from listAgents)'),
+        path: z.string().min(1).describe('Workspace-relative POSIX path to a file (from listWorkspaceFiles)'),
+        sessionId: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Read an authorized isolated session worktree instead of the primary checkout'),
+        repo: z
+          .string()
+          .min(1)
+          .max(256)
+          .optional()
+          .describe('owner/repo of one of the agent’s authorized additional repositories'),
+        offset: z.number().int().nonnegative().optional().describe('Byte offset to start at (default 0)'),
+        limit: z.number().int().positive().max(65536).optional().describe('Bytes per slice (default 65536)')
+      })
+      .strict(),
+    call: (ctx, a) =>
+      ctx.get(org(ctx, `/agents/${seg(a.agentId)}/workspace/file`), {
+        path: a.path as string,
+        sessionId: a.sessionId as string | undefined,
+        repo: a.repo as string | undefined,
+        offset: a.offset as number | undefined,
+        limit: a.limit as number | undefined
+      })
+  },
   {
     name: 'listDaemons',
     description: 'List the daemons (edge execution units) in the organization that are visible to you, with status.',


### PR DESCRIPTION
## Why

`getCron` and `getAgent` both hand out workspace paths — a scheduled task's prompt naming
a script, an agent's `workspace` pointer — and nothing in the MCP tool catalog could then
read one. The catalog dead-ended at the pointer: an assistant that found a path had no way
to see what was at it.

## What

Two read-only tools over the proxy routes that already exist:

| Tool | Route |
| --- | --- |
| `listWorkspaceFiles` | `GET /agents/:id/workspace/files` |
| `readWorkspaceFile` | `GET /agents/:id/workspace/file` |

Both expose the routes' own scopes (`sessionId` for an authorized isolated worktree, `repo`
for an authorized additional repository) and their paging: `cursor`/`limit` for listings,
`offset`/`limit` for the 64 KiB byte slices. The read tool's description says to feed
`nextOffset` back rather than recomputing an offset from the content, which is the one way
a caller can silently corrupt a paged read.

Like every other tool these are thin adapters: GET-only, authorization inherited from the
routes verbatim, and the control plane stores nothing — the bytes come live from the owning
daemon and a missing path stays data (`exists:false`) rather than an error.

## Boundary

Neither tool belongs to a deny-listed family in §6.3 (credentials, members, organization,
access control, bots), so this is catalog coverage, not a boundary change. The §6.2 table
gains its row.

## Test

`tools.test.ts` gains fixtures for both — so they are carried by the existing GET-only,
org-subtree and path-encoding invariants — plus a case asserting the scope and byte-slice
arguments reach the route as query parameters.
