### PR TITLE
fix(slack): tell the operator when optional permissions are missing

### DIFF
--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -1740,6 +1740,9 @@ export const SlackBotRefreshDto = z.object({
   manifest: z.enum(['synced', 'manual_update_required', 'unknown']),
   authorization: z.enum(['current', 'reinstall_required', 'invalid', 'app_mismatch', 'unknown']),
   missingScopes: z.array(z.string()),
+  /** Optional-capability scopes this install lacks. Never affects `authorization` — the install
+   *  works, but the tools those scopes back will refuse until someone reinstalls. */
+  missingCapabilityScopes: z.array(z.string()).default([]),
   settingsUrl: z.string(),
   manifestUrl: z.string(),
   /** Slack's OAuth & Permissions editor for changing requested scopes. */

--- a/packages/control-plane/src/http/routes/slack-bot-refresh.ts
+++ b/packages/control-plane/src/http/routes/slack-bot-refresh.ts
@@ -27,7 +27,12 @@ import { BotId } from '../../domain/ids.js'
 import { denyViewerWrite, orgOf } from '../rbac.js'
 import { SlackBotRefreshDto, ErrorDto, IdParam, type SlackBotRefreshDtoT } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
-import { checkSlackBotScopes, mergeManagedSlackManifest, slackOAuthRedirectUri } from '../slack-manifest.js'
+import {
+  checkSlackBotScopes,
+  mergeManagedSlackManifest,
+  missingSlackCapabilityScopes,
+  slackOAuthRedirectUri
+} from '../slack-manifest.js'
 import { relayHttpBase } from '../relay-ingress.js'
 
 /** Slack errors from the manifest export/update that mean "this app is not
@@ -166,6 +171,10 @@ export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
 
         let authorization: SlackBotRefreshDtoT['authorization'] = 'unknown'
         let missingScopes: string[] = []
+        // Reported alongside, never folded into `authorization`: a missing capability scope
+        // does not make an install broken, but silence let the console say "up to date" while
+        // every optional tool answered `missing_scope`.
+        let missingCapabilityScopes: string[] = []
         if (checked?.status === 'invalid') {
           authorization = 'invalid'
         } else if (checked?.status === 'ok' && checked.appId && checked.appId !== bot.slackAppId) {
@@ -173,6 +182,7 @@ export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
         } else if (checked?.status === 'ok') {
           // The same shared diff both install funnels fence on. A grant Slack
           // declined to report stays `unknown` — silence is not a shortfall.
+          missingCapabilityScopes = missingSlackCapabilityScopes(checked.scopes)
           const grant = checkSlackBotScopes(checked.scopes)
           if (grant.status === 'short') {
             missingScopes = grant.missing
@@ -186,6 +196,7 @@ export function slackBotRefreshRoutes(deps: HttpDeps, slack: SlackRouteSeams) {
           manifest,
           authorization,
           missingScopes,
+          missingCapabilityScopes,
           ...slackAppLinks(bot.slackAppId, appIdentityMatches && checked?.status === 'ok' ? checked.teamId : null)
         }
       }

--- a/packages/control-plane/src/http/slack-manifest.ts
+++ b/packages/control-plane/src/http/slack-manifest.ts
@@ -56,6 +56,22 @@ export type SlackBotScopeGrant = { status: 'unknown' } | { status: 'complete' } 
  * app's manifest declares — the app installs cleanly and the shortfall surfaces
  * much later, as a scoped call failing with `missing_scope`.
  */
+/**
+ * The CAPABILITY scopes an installation is missing — informational, never a fence.
+ *
+ * `checkSlackBotScopes` answers "is this install broken?" and must stay on the required set:
+ * a workspace that installed before a capability existed is not broken. But that silence went
+ * one step too far — the console reported "permissions are up to date" for an install whose
+ * every optional tool answers `missing_scope`, and nothing told the operator that one reinstall
+ * would light them up. This is the other half of the question, asked separately so neither
+ * answer distorts the other.
+ */
+export function missingSlackCapabilityScopes(granted: readonly string[] | null | undefined): string[] {
+  if (!granted) return [] // unknown is not a shortfall, same rule as the fence
+  const held = new Set(granted)
+  return SLACK_CAPABILITY_BOT_SCOPES.filter((scope) => !held.has(scope))
+}
+
 export function checkSlackBotScopes(granted: readonly string[] | null | undefined): SlackBotScopeGrant {
   if (!granted) return { status: 'unknown' }
   const held = new Set(granted)

--- a/packages/control-plane/test/integration/integrations.route.test.ts
+++ b/packages/control-plane/test/integration/integrations.route.test.ts
@@ -22,7 +22,12 @@ import type { IntegrationUpsert, IntegrationRemove } from '@agentconnect.md/prot
 import { DEFAULT_ORG_ID, DEFAULT_OWNER_ID } from '../../prisma/seed.js'
 import { OrgId } from '../../src/domain/ids.js'
 import type { SlackConfigApi } from '../../src/http/slack-config-api.js'
-import { SLACK_BOT_EVENTS, SLACK_BOT_SCOPES } from '../../src/http/slack-manifest.js'
+import {
+  SLACK_BOT_EVENTS,
+  SLACK_BOT_SCOPES,
+  SLACK_CAPABILITY_BOT_SCOPES,
+  SLACK_MANIFEST_BOT_SCOPES
+} from '../../src/http/slack-manifest.js'
 import type { RelayChannel } from '../../src/ws/relay-registry.js'
 import { SlackBotIdentityReconciler } from '../../src/orchestrator/slackBotIdentityReconciler.js'
 import { systemClock } from '../../src/domain/clock.js'
@@ -1410,7 +1415,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       appId: 'A0TESTAPP1',
       teamId: 'T0TESTTEAM1',
       teamName: 'Acme',
-      scopes: [...SLACK_BOT_SCOPES]
+      scopes: [...SLACK_MANIFEST_BOT_SCOPES]
     })
 
     const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${created.botId}/slack/refresh` })
@@ -1419,6 +1424,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       manifest: 'synced',
       authorization: 'current',
       missingScopes: [],
+      missingCapabilityScopes: [],
       settingsUrl: 'https://api.slack.com/apps/A0TESTAPP1',
       manifestUrl: 'https://app.slack.com/app-settings/T0TESTTEAM1/A0TESTAPP1/app-manifest',
       permissionsUrl: 'https://app.slack.com/app-settings/T0TESTTEAM1/A0TESTAPP1/oauth',
@@ -1456,7 +1462,7 @@ describe('bot roster (GET/DELETE /bots)', () => {
       appId: 'A0MANUAL01',
       teamId: 'T0MANUAL01',
       teamName: 'Acme',
-      scopes: [...SLACK_BOT_SCOPES]
+      scopes: [...SLACK_MANIFEST_BOT_SCOPES]
     })
 
     const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${created.botId}/slack/refresh` })
@@ -1465,11 +1471,47 @@ describe('bot roster (GET/DELETE /bots)', () => {
       manifest: 'manual_update_required',
       authorization: 'current',
       missingScopes: [],
+      missingCapabilityScopes: [],
       settingsUrl: 'https://api.slack.com/apps/A0MANUAL01',
       manifestUrl: 'https://app.slack.com/app-settings/T0MANUAL01/A0MANUAL01/app-manifest',
       permissionsUrl: 'https://app.slack.com/app-settings/T0MANUAL01/A0MANUAL01/oauth',
       reinstallUrl: 'https://api.slack.com/apps/A0MANUAL01/install-on-team?'
     })
+  })
+
+  // The console used to report an install like this as fully up to date, while every tool
+  // behind a capability scope answered `missing_scope`. The install IS healthy — `authorization`
+  // must stay `current` — but the gap has to be visible, which is the whole point of the split.
+  it('reports missing capability scopes without calling the install broken', async () => {
+    const agentId = await placedAgent()
+    const { app } = withSpy()
+    const created = (
+      await app.app.inject({
+        method: 'POST',
+        url: `${ORG}/integrations`,
+        payload: {
+          name: 'capability-gap',
+          platform: 'slack',
+          agentId,
+          slack: { botToken: SLACK.botToken, appToken: 'xapp-1-A0CAPGAP01-123-abcdef' }
+        }
+      })
+    ).json() as { botId: string }
+    app.platformStubs.verifySlackBot = async () => ({
+      status: 'ok',
+      name: 'capability-gap',
+      appId: 'A0CAPGAP01',
+      teamId: 'T0CAPGAP01',
+      teamName: 'Acme',
+      scopes: [...SLACK_BOT_SCOPES]
+    })
+
+    const res = await app.app.inject({ method: 'POST', url: `${ORG}/bots/${created.botId}/slack/refresh` })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { authorization: string; missingScopes: string[]; missingCapabilityScopes: string[] }
+    expect(body.authorization).toBe('current')
+    expect(body.missingScopes).toEqual([])
+    expect(body.missingCapabilityScopes).toEqual([...SLACK_CAPABILITY_BOT_SCOPES])
   })
 
   it('POST Slack refresh never updates an app when the stored bot token belongs to another app', async () => {

--- a/packages/web/src/components/console/platforms/slack/refresh-notice.test.ts
+++ b/packages/web/src/components/console/platforms/slack/refresh-notice.test.ts
@@ -13,6 +13,51 @@ const refreshResult = (overrides: Partial<SlackBotRefreshDto> = {}): SlackBotRef
   ...overrides
 })
 
+// The gap that prompted this: eight tools shipped behind capability scopes, and an install
+// predating them reported "up to date" while every one of those tools answered `missing_scope`.
+describe('slackRefreshNoticeState: optional capabilities', () => {
+  const healthy = {
+    manifest: 'synced' as const,
+    authorization: 'current' as const,
+    missingScopes: [],
+    reinstallUrl: 'https://slack.example.test/reinstall',
+    permissionsUrl: 'https://slack.example.test/permissions',
+    manifestUrl: 'https://slack.example.test/manifest',
+    settingsUrl: 'https://slack.example.test/settings'
+  }
+
+  it('says nothing extra when every capability scope is granted', () => {
+    const state = slackRefreshNoticeState({ ...healthy, missingCapabilityScopes: [] } as never)
+    expect(state.message).toContain('up to date')
+    expect(state.needsAttention).toBe(false)
+    expect(state.action).toBeNull()
+  })
+
+  it('names the gap and offers the reinstall that closes it', () => {
+    const state = slackRefreshNoticeState({
+      ...healthy,
+      missingCapabilityScopes: ['search:read.public', 'canvases:write']
+    } as never)
+    expect(state.message).toContain('2 optional permissions are not')
+    expect(state.message).toContain('Reinstall to enable')
+    expect(state.action).toEqual({ href: healthy.reinstallUrl, label: 'Reinstall workspace' })
+    // Healthy, not broken: the install works, so this must not read as a failure.
+    expect(state.needsAttention).toBe(false)
+  })
+
+  it('sends an unsynced manifest to the permissions page instead', () => {
+    const state = slackRefreshNoticeState({
+      ...healthy,
+      manifest: 'manual_update_required',
+      missingCapabilityScopes: ['reactions:read']
+    } as never)
+    expect(state.message).toContain('1 optional permission is not')
+    // An unsynced manifest cannot be fixed by reinstalling alone — the scopes must be added first.
+    expect(state.message).toContain('OAuth & Permissions')
+    expect(state.action).toEqual({ href: healthy.permissionsUrl, label: 'Update permissions' })
+  })
+})
+
 describe('slackRefreshNoticeState', () => {
   it('does not request manifest review when workspace permissions already match', () => {
     expect(slackRefreshNoticeState(refreshResult({ manifest: 'manual_update_required' }))).toEqual({

--- a/packages/web/src/components/console/platforms/slack/refresh-notice.ts
+++ b/packages/web/src/components/console/platforms/slack/refresh-notice.ts
@@ -17,6 +17,9 @@ export interface SlackRefreshNoticeState {
  * actionable, and authorization failures always take priority over manifest UI.
  */
 export function slackRefreshNoticeState(result: SlackBotRefreshDto): SlackRefreshNoticeState {
+  // An install missing only capability scopes is HEALTHY, so it is not "attention" — the tools
+  // those scopes back simply stay off until someone reinstalls, and saying nothing was the bug.
+  const capabilityGap = (result.missingCapabilityScopes ?? []).length > 0
   const needsAttention = result.authorization !== 'current' || result.manifest === 'unknown'
   let action: SlackRefreshNoticeState['action'] = null
 
@@ -25,6 +28,12 @@ export function slackRefreshNoticeState(result: SlackBotRefreshDto): SlackRefres
   } else if (result.authorization === 'app_mismatch') {
     action = { href: result.settingsUrl, label: 'Open Slack' }
   } else if (result.authorization === 'reinstall_required') {
+    action = {
+      href: result.manifest === 'synced' ? result.reinstallUrl : result.permissionsUrl,
+      label: result.manifest === 'synced' ? 'Reinstall workspace' : 'Update permissions'
+    }
+  } else if (result.authorization === 'current' && capabilityGap) {
+    // The install works; a reinstall is what turns the optional tools on.
     action = {
       href: result.manifest === 'synced' ? result.reinstallUrl : result.permissionsUrl,
       label: result.manifest === 'synced' ? 'Reinstall workspace' : 'Update permissions'
@@ -48,6 +57,17 @@ export function slackRefreshNoticeState(result: SlackBotRefreshDto): SlackRefres
     message = 'Slack app configuration is synced. Reinstall it to grant the missing scopes.'
   } else if (result.authorization === 'reinstall_required') {
     message = 'Add the missing scopes in Slack’s OAuth & Permissions page, then reinstall the app.'
+  } else if (result.authorization === 'current' && capabilityGap) {
+    // Ahead of the manifest branches on purpose: an install short of capability scopes used to
+    // be told its permissions "match AgentConnect's requirements", which is the reassurance
+    // this case exists to withdraw. What the operator does next depends on the manifest —
+    // a synced app only needs reinstalling, an unsynced one needs the scopes added first.
+    const n = (result.missingCapabilityScopes ?? []).length
+    const count = `${n} optional permission${n === 1 ? ' is' : 's are'} not`
+    message =
+      result.manifest === 'synced'
+        ? `Everything required is granted; ${count}. Reinstall to enable the agent tools that need them.`
+        : `Everything required is granted; ${count}. Add them in Slack’s OAuth & Permissions page, then reinstall.`
   } else if (result.authorization === 'current' && result.manifest === 'manual_update_required') {
     message = 'Workspace permissions match AgentConnect’s requirements.'
   } else if (result.manifest === 'manual_update_required') {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -916,6 +916,9 @@ export interface SlackBotRefreshDto {
   manifest: 'synced' | 'manual_update_required' | 'unknown'
   authorization: 'current' | 'reinstall_required' | 'invalid' | 'app_mismatch' | 'unknown'
   missingScopes: string[]
+  /** Optional-capability scopes this install lacks. The integration is healthy without them;
+   *  the agent tools they back stay unavailable until someone reinstalls. */
+  missingCapabilityScopes?: string[]
   settingsUrl: string
   manifestUrl: string
   /** Slack's OAuth & Permissions editor for changing requested scopes. */


### PR DESCRIPTION
The console reports **"Slack app configuration and workspace permissions are up to date"** for an installation that is missing every capability scope — while the eight agent tools those scopes back answer `missing_scope`. Nothing tells the operator that one reinstall would enable them.

Reported from a live workspace: an install predating #1644 shows the green up-to-date line, and `reactions`, canvases, scheduled sends and conversation creation are all quietly unavailable.

## Why it happened

This is a hole in the capability-scope design, not an oversight in the console.

Declaring a scope without fencing on it is right for **refusing an install** — a workspace that installed before a capability existed is not broken, and marking it so would demand a reinstall for a feature nobody asked for. But the refresh path shares `checkSlackBotScopes`, so *not fencing* also silenced the *report*. Two different questions were being answered by one function:

- **Is this install broken?** → required scopes only. Unchanged.
- **Is anything switched off?** → capability scopes. Was never asked.

## The fix

`missingSlackCapabilityScopes` answers the second question separately, and the refresh route returns it beside `missingScopes` **without touching `authorization`**.

The notice places it *ahead of* the manifest branches, because the message it displaces is the precise false reassurance at issue: an install short of these scopes was being told its permissions "match AgentConnect's requirements". What it says next depends on the manifest — a synced app only needs reinstalling, an unsynced one needs the scopes added in Slack first, and the action button already distinguishes those.

It deliberately stays out of `needsAttention`. The integration is healthy; some tools are simply off. Dressing that as a fault would train operators to ignore the banner that means something is actually wrong.

## Verification

`typecheck`, `lint`, `format:check` clean. Three new cases in `refresh-notice.test.ts` — no message when nothing is missing, the count plus a reinstall action when scopes are, and the add-them-first wording when the manifest is unsynced — plus the existing 6 and the CP's 18 manifest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
