### PR TITLE
refactor(cp,web): split the daemon read by how fast each half changes

### DIFF
--- a/docs/designs/agent-assistant.md
+++ b/docs/designs/agent-assistant.md
@@ -215,7 +215,8 @@ Tools **call the CP service layer directly or reuse route-handler logic**, prese
 | `listWorkspaceFiles` / `readWorkspaceFile`                     | GET /agents/:id/workspace/files(file) (proxied, unstored)  | –       |
 | `createAgent` / `updateAgent`                                  | POST /agents · PATCH /agents/:id                           | ✎       |
 | `deleteAgent`                                                  | DELETE /agents/:id                                         | ✎🔥     |
-| `listDaemons` / `renameDaemon`                                 | GET /daemons · PATCH /daemons/:id                          | –/✎     |
+| `listDaemons` / `renameDaemon`                                 | GET /daemons (liveness) · PATCH /daemons/:id               | –/✎     |
+| `listDaemonCapabilities` / `getDaemon`                         | GET /daemons/capabilities · GET /daemons/:id               | –       |
 | `listCrons` / `getCron` / `listCronRuns`                       | GET /crons…                                                | –       |
 | `upsertCron` / `runCron` / `deleteCron`                        | PUT /crons/:id · POST /crons/:id/run · DELETE              | ✎(🔥)   |
 | `listSessions` / `getSession`                                  | GET /sessions(:id) (body policy is Open Question 1 in §15) | –       |

--- a/docs/designs/control-plane-implementation.md
+++ b/docs/designs/control-plane-implementation.md
@@ -97,7 +97,7 @@ packages/control-plane/src/
 │   ├── routes/
 │   │   ├── health.ts         # GET /health   (the existing handler moves here)
 │   │   ├── agents.ts         # CRUD /agents, PATCH spec (name/description/model/runtime/caps), /agents/:id/integrations
-│   │   ├── daemons.ts        # GET /daemons, POST /daemons/token (onboard)
+│   │   ├── daemons.ts        # GET /daemons (liveness), /daemons/capabilities, /daemons/:id, POST /daemons/token
 │   │   ├── keys.ts           # POST/GET /daemons/:id/keys, DELETE /daemons/:id/keys/:keyRowId (mint/list/revoke)
 │   │   ├── sessions.ts       # GET /sessions, /sessions/:id  (metadata only)
 │   │   ├── crons.ts          # CRUD /crons

--- a/docs/designs/runtime-model-catalog.md
+++ b/docs/designs/runtime-model-catalog.md
@@ -82,14 +82,22 @@ flowchart LR
     M[runtime_model_catalog<br/>SQLite last-good cache] --> R[facts/daemon-runtimes<br/>modelCatalog field]
   end
   R --> CP[(CP runtime_profile<br/>modelCatalog JSONB)]
-  CP --> W[Web /daemons<br/>Add/Edit Agent]
+  CP --> W[Web GET /daemons/:id<br/>Add/Edit Agent]
 ```
 
-Key point: **the UI gets no new read channel**. Matrix data follows the existing
-facts push pipeline, is persisted by the CP, and is read through the console's
-normal `GET /daemons` polling (SWR every 15 seconds). "Use the cache table when
-the UI requests before discovery completes" is not a runtime branch; the
-structure guarantees it. The daemon synchronously hydrates the cache at startup,
+Key point: **the matrix rides the existing push pipeline**. It follows the facts
+frames, is persisted by the CP, and is read back through an ordinary console read —
+no side channel, no bespoke fetch protocol. "Use the cache table when the UI
+requests before discovery completes" is not a runtime branch; the structure
+guarantees it.
+
+Which read carries it is a separate question, answered by size: a matrix is per
+`(daemon, runtime)` and does not repeat across daemons, so a fleet-wide read pays
+for every daemon's matrix while its readers — the Add/Edit Agent pickers, the
+session runtime controls — each look at exactly one daemon. It therefore rides
+`GET /daemons/:id`, which the console fetches for the daemon it is configuring,
+and neither `GET /daemons` (polled for liveness) nor `GET /daemons/capabilities`
+(the fleet's runtime inventory) carries it. The daemon synchronously hydrates the cache at startup,
 so its first facts frame includes the last-good matrix. It sends another
 replacement frame after discovery completes. At every moment, the CP contains
 the newest value known by that daemon, and the UI renders whatever it reads.
@@ -563,7 +571,7 @@ sequenceDiagram
   B--)B: Discovery gate matches → phase 2 (driver or enumeration)
   B->>L: Upsert per model / full catalog
   B->>C: Re-emit facts (complete catalog)
-  W->>C: GET /daemons (at any time)
+  W->>C: GET /daemons/:id (when configuring that daemon)
   C-->>W: Latest persisted value (cached or fresh)
 ```
 

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -237,7 +237,26 @@ export const DaemonViewDto = z.object({
    *  Gates the console's lifecycle controls so non-owners never see an action they'd 403 on. */
   canManageLifecycle: z.boolean()
 })
-export const DaemonListDto = z.array(DaemonViewDto)
+// The fleet read splits by CHANGE RATE, not by "summary vs detail": the console polls
+// liveness every few seconds, while a daemon's capability moves only when it connects,
+// upgrades, or re-probes, and its per-model matrix is read one daemon at a time.
+
+/** `GET /daemons` — the liveness row. Capability lives at `/daemons/capabilities`. */
+export const DaemonFleetDto = DaemonViewDto.omit({ capabilities: true, runtimeProfiles: true, mcpServers: true })
+export const DaemonFleetListDto = z.array(DaemonFleetDto)
+
+/** A runtime profile minus the per-model matrix — everything a reader that needs EVERY
+ *  daemon at once uses: the pickers' runtime list, `authRequired`, MCP transports. */
+export const RuntimeProfileSummaryDto = RuntimeProfileDto.omit({ modelCatalog: true })
+
+/** `GET /daemons/capabilities` — what each daemon can run, for the whole fleet. */
+export const DaemonCapabilityDto = z.object({
+  daemonId: z.string(),
+  capabilities: DaemonCapabilitiesDto,
+  runtimeProfiles: z.array(RuntimeProfileSummaryDto),
+  mcpServers: z.array(McpServerFactDto)
+})
+export const DaemonCapabilityListDto = z.array(DaemonCapabilityDto)
 
 // ── member sets (docs/designs/daemon-groups.md) ──
 // A named set of this organization's daemons within which an agent's duty may be claimed. The
@@ -3737,6 +3756,8 @@ export const SlackInstallErrorDto = ErrorDto.extend({
 // Inferred response types — route handlers return these so the zod type provider
 // type-checks the handler's payload against its declared response schema.
 export type DaemonViewDtoT = z.infer<typeof DaemonViewDto>
+export type DaemonFleetDtoT = z.infer<typeof DaemonFleetDto>
+export type DaemonCapabilityDtoT = z.infer<typeof DaemonCapabilityDto>
 export type ApiKeyDtoT = z.infer<typeof ApiKeyDto>
 export type AgentDtoT = z.infer<typeof AgentDto>
 export type IntegrationDtoT = z.infer<typeof IntegrationDto>

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -245,9 +245,20 @@ export const DaemonViewDto = z.object({
 export const DaemonFleetDto = DaemonViewDto.omit({ capabilities: true, runtimeProfiles: true, mcpServers: true })
 export const DaemonFleetListDto = z.array(DaemonFleetDto)
 
-/** A runtime profile minus the per-model matrix — everything a reader that needs EVERY
+/** The catalog a fleet-wide read carries: its runtime-level answers — default model,
+ *  permission modes and their default, which the console's read-only model/permission
+ *  labels resolve against for EVERY agent at once — and an empty `models`, because that
+ *  per-model matrix is 75% of a catalog and its only readers configure one daemon.
+ *  Enforced here rather than trusted: the response schema rejects a populated list. */
+export const RuntimeModelCatalogSummaryDto = RuntimeModelCatalogDto.extend({
+  models: z.array(RuntimeModelCapabilityDto).max(0)
+})
+
+/** A runtime profile whose catalog is that summary — everything a reader that needs EVERY
  *  daemon at once uses: the pickers' runtime list, `authRequired`, MCP transports. */
-export const RuntimeProfileSummaryDto = RuntimeProfileDto.omit({ modelCatalog: true })
+export const RuntimeProfileSummaryDto = RuntimeProfileDto.extend({
+  modelCatalog: RuntimeModelCatalogSummaryDto.nullable()
+})
 
 /** `GET /daemons/capabilities` — what each daemon can run, for the whole fleet. */
 export const DaemonCapabilityDto = z.object({

--- a/packages/control-plane/src/http/mcp/tools.test.ts
+++ b/packages/control-plane/src/http/mcp/tools.test.ts
@@ -49,6 +49,7 @@ const AGENT_UUID = '5e0f8a25-31c8-4a1a-bb0e-9a8f6a2b1c22'
 /** Minimal happy-path args per tool (tools with no args pass {}). */
 const ARGS: Record<string, Record<string, unknown>> = {
   getAgent: { agentId: 'agent-1' },
+  getDaemon: { daemonId: 'daemon-1' },
   listWorkspaceFiles: { agentId: 'agent-1', path: 'scripts' },
   readWorkspaceFile: { agentId: 'agent-1', path: 'scripts/build.sh' },
   getCron: { cronId: 'cron-1' },

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -239,9 +239,24 @@ export const MCP_TOOLS: McpToolDef[] = [
   },
   {
     name: 'listDaemons',
-    description: 'List the daemons (edge execution units) in the organization that are visible to you, with status.',
+    description:
+      'List the daemons (edge execution units) in the organization that are visible to you, with status and load. This is the liveness view — what each daemon can RUN is listDaemonCapabilities, and one runtime’s model catalog is getDaemon.',
     schema: NoArgs,
     call: (ctx) => ctx.get(org(ctx, '/daemons'))
+  },
+  {
+    name: 'listDaemonCapabilities',
+    description:
+      'What each daemon in the fleet can run: the platforms and features it supports, the runtimes installed on it with their available model ids, and its configured MCP servers. Use this to choose a placement — which daemon offers the runtime an agent needs. Per-model detail (efforts, permission modes) is not here; read one daemon with getDaemon for that.',
+    schema: NoArgs,
+    call: (ctx) => ctx.get(org(ctx, '/daemons/capabilities'))
+  },
+  {
+    name: 'getDaemon',
+    description:
+      'One daemon in full: liveness, capabilities, and each installed runtime’s complete model catalog — the model ids it offers and, per model, the reasoning efforts and permission modes it accepts. This is the only read carrying that catalog, so consult it before setting an agent’s model, reasoningEffort or permissionMode, whose valid values are whatever the serving daemon reports.',
+    schema: z.object({ daemonId: z.string().min(1).describe('The daemon id (from listDaemons)') }).strict(),
+    call: (ctx, a) => ctx.get(org(ctx, `/daemons/${seg(a.daemonId)}`))
   },
   {
     name: 'listCrons',
@@ -358,7 +373,7 @@ export const MCP_TOOLS: McpToolDef[] = [
         name: AgentSlug.describe('Immutable slug identifier (lowercase letters, digits, hyphens)'),
         displayName: z.string().min(1).optional().describe('Human-friendly label shown in chat and the console'),
         description: z.string().optional(),
-        runtime: z.string().min(1).describe('Runtime id — pick from the runtimes reported by listDaemons'),
+        runtime: z.string().min(1).describe('Runtime id — pick from the runtimes reported by listDaemonCapabilities'),
         model: z.string().min(1).optional(),
         reasoningEffort: z.string().min(1).optional(),
         outputMode: OutputMode.optional(),

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -22,7 +22,8 @@ import { orgOf, denyViewerWrite, ctxOf } from '../rbac.js'
 import { canView, canEdit, canManageSharing, type ViewCtx } from '../../authorization/policy.js'
 import { resolveShareSet } from '../sharing.js'
 import {
-  DaemonListDto,
+  DaemonFleetListDto,
+  DaemonCapabilityListDto,
   DaemonViewDto,
   DaemonLifecycleOpDto,
   UpdateDaemonBody,
@@ -32,7 +33,7 @@ import {
   IdParam,
   ErrorDto
 } from '../dto/index.js'
-import type { DaemonViewDtoT } from '../dto/index.js'
+import type { DaemonViewDtoT, DaemonFleetDtoT, DaemonCapabilityDtoT } from '../dto/index.js'
 import type { DaemonLifecycleOpRecord, DaemonLifecycleOpRepo } from '../../persistence/ports.js'
 import { provisionDaemonConnect } from '../onboarding.js'
 import { detachDaemon } from '../daemon-removal.js'
@@ -179,6 +180,27 @@ function toDto(
   }
 }
 
+// The two halves of a daemon row, split by how often each changes. `toDto` still builds
+// the whole thing once; these decide what a given read is allowed to be about.
+
+/** The liveness half — everything the console's few-second poll is actually watching. */
+function fleetOf(d: DaemonViewDtoT): DaemonFleetDtoT {
+  const { capabilities: _c, runtimeProfiles: _r, mcpServers: _m, ...fleet } = d
+  return fleet
+}
+
+/** The capability half, minus each runtime's per-model matrix: this read answers for the
+ *  WHOLE fleet, and the matrix is the one part every reader wants a single daemon at a
+ *  time — it stays on `GET /daemons/:id`. */
+function capabilityOf(d: DaemonViewDtoT): DaemonCapabilityDtoT {
+  return {
+    daemonId: d.daemonId,
+    capabilities: d.capabilities,
+    runtimeProfiles: d.runtimeProfiles.map(({ modelCatalog: _catalog, ...profile }) => profile),
+    mcpServers: d.mcpServers
+  }
+}
+
 export function daemonRoutes(deps: HttpDeps) {
   // How long after its last heartbeat a disconnected daemon still reads `connecting`
   // rather than `offline` (0 ⇒ disabled — the pre-grace behavior). Set from
@@ -213,9 +235,9 @@ export function daemonRoutes(deps: HttpDeps) {
           tags: [Tag.Daemons],
           summary: 'List daemons',
           description:
-            'The org’s available daemon fleet, including install-wide pool members, overlaid with live connection status.',
+            'The org’s available daemon fleet, including install-wide pool members, overlaid with live connection status. Liveness only — what each daemon can run is GET /daemons/capabilities, and a runtime’s model catalog is GET /daemons/:id.',
           operationId: 'listDaemons',
-          response: { 200: DaemonListDto }
+          response: { 200: DaemonFleetListDto }
         }
       },
       async (req) => {
@@ -224,7 +246,48 @@ export function daemonRoutes(deps: HttpDeps) {
         // One batched latest-op query for the whole fleet (no N+1), grouped by daemon.
         const ops = await deps.repos.daemonLifecycleOp.latestForDaemons(rows.map((d) => DaemonId(d.daemonId)))
         const byDaemon = new Map(ops.map((o) => [o.daemonId as string, o]))
-        return rows.map((d) => dtoWith(d, ctx, byDaemon.get(d.daemonId) ?? null))
+        return rows.map((d) => fleetOf(dtoWith(d, ctx, byDaemon.get(d.daemonId) ?? null)))
+      }
+    )
+
+    // Static segment, so it is matched ahead of `/daemons/:id` whatever the order here.
+    r.get(
+      '/daemons/capabilities',
+      {
+        schema: {
+          tags: [Tag.Daemons],
+          summary: 'List daemon capabilities',
+          description:
+            'What each daemon in the fleet can run: platform/feature capabilities, the installed runtime profiles, and the daemon-configured MCP servers. This half of a daemon row changes only when it connects, upgrades, or re-probes, so it is read separately from the liveness poll. A runtime’s per-model catalog is not here — read one daemon with GET /daemons/:id for that.',
+          operationId: 'listDaemonCapabilities',
+          response: { 200: DaemonCapabilityListDto }
+        }
+      },
+      async (req) => {
+        const ctx = ctxOf(req)
+        const rows = await deps.registry.listAvailable(orgOf(req), ctx)
+        // Capability needs no lifecycle op, so this read skips that query entirely.
+        return rows.map((d) => capabilityOf(toDto(d, deps.liveness, ctx, graceMs, Date.now(), release(), null)))
+      }
+    )
+
+    r.get(
+      '/daemons/:id',
+      {
+        schema: {
+          tags: [Tag.Daemons],
+          summary: 'Get a daemon',
+          description:
+            'One daemon in full: its liveness row plus its capabilities and complete runtime profiles, including each runtime’s discovered model × configuration catalog. This is the only read that carries the catalog — its readers all want a single daemon at a time.',
+          operationId: 'getDaemon',
+          params: IdParam,
+          response: { 200: DaemonViewDto, 404: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        const view = await getOrgDaemon(req, req.params.id)
+        if (!view) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
+        return dto(view, ctxOf(req))
       }
     )
 

--- a/packages/control-plane/src/http/routes/daemons.ts
+++ b/packages/control-plane/src/http/routes/daemons.ts
@@ -196,7 +196,12 @@ function capabilityOf(d: DaemonViewDtoT): DaemonCapabilityDtoT {
   return {
     daemonId: d.daemonId,
     capabilities: d.capabilities,
-    runtimeProfiles: d.runtimeProfiles.map(({ modelCatalog: _catalog, ...profile }) => profile),
+    // The catalog's runtime-level answers survive (read-only labels resolve every agent
+    // against them); only its per-model matrix is dropped.
+    runtimeProfiles: d.runtimeProfiles.map((p) => ({
+      ...p,
+      modelCatalog: p.modelCatalog ? { ...p.modelCatalog, models: [] } : null
+    })),
     mcpServers: d.mcpServers
   }
 }
@@ -235,7 +240,7 @@ export function daemonRoutes(deps: HttpDeps) {
           tags: [Tag.Daemons],
           summary: 'List daemons',
           description:
-            'The org’s available daemon fleet, including install-wide pool members, overlaid with live connection status. Liveness only — what each daemon can run is GET /daemons/capabilities, and a runtime’s model catalog is GET /daemons/:id.',
+            'The org’s available daemon fleet, including install-wide pool members, overlaid with live connection status. Liveness only — what each daemon can run is GET /daemons/capabilities, and a runtime’s per-model catalog is GET /daemons/:id.',
           operationId: 'listDaemons',
           response: { 200: DaemonFleetListDto }
         }
@@ -258,7 +263,7 @@ export function daemonRoutes(deps: HttpDeps) {
           tags: [Tag.Daemons],
           summary: 'List daemon capabilities',
           description:
-            'What each daemon in the fleet can run: platform/feature capabilities, the installed runtime profiles, and the daemon-configured MCP servers. This half of a daemon row changes only when it connects, upgrades, or re-probes, so it is read separately from the liveness poll. A runtime’s per-model catalog is not here — read one daemon with GET /daemons/:id for that.',
+            'What each daemon in the fleet can run: platform/feature capabilities, the installed runtime profiles, and the daemon-configured MCP servers. This half of a daemon row changes only when it connects, upgrades, or re-probes, so it is read separately from the liveness poll. Each runtime’s catalog carries its runtime-level answers (default model, permission modes) but an empty models list: that per-model matrix is GET /daemons/:id.',
           operationId: 'listDaemonCapabilities',
           response: { 200: DaemonCapabilityListDto }
         }
@@ -278,14 +283,14 @@ export function daemonRoutes(deps: HttpDeps) {
           tags: [Tag.Daemons],
           summary: 'Get a daemon',
           description:
-            'One daemon in full: its liveness row plus its capabilities and complete runtime profiles, including each runtime’s discovered model × configuration catalog. This is the only read that carries the catalog — its readers all want a single daemon at a time.',
+            'One daemon in full: its liveness row plus its capabilities and complete runtime profiles, including each runtime’s discovered model × configuration catalog. This is the only read carrying the per-model matrix — its readers all configure a single daemon at a time.',
           operationId: 'getDaemon',
           params: IdParam,
           response: { 200: DaemonViewDto, 404: ErrorDto }
         }
       },
       async (req, reply) => {
-        const view = await getOrgDaemon(req, req.params.id)
+        const view = await getAvailableDaemon(req, req.params.id)
         if (!view) return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'daemon not found' })
         return dto(view, ctxOf(req))
       }
@@ -298,6 +303,15 @@ export function daemonRoutes(deps: HttpDeps) {
     // gate lives here (and in list).
     const getOrgDaemon = async (req: FastifyRequest, id: string) => {
       const view = await deps.registry.get(orgOf(req), DaemonId(id))
+      if (!view) return null
+      return canView(view, ctxOf(req)) ? view : null
+    }
+
+    // The read twin of the one above: `registry.get` is the ORG-OWNED fleet, so it cannot
+    // see a shared pool member. The fleet reads list those (`listAvailable`), so the point
+    // read has to resolve them too or every Cloud daemon id they hand out 404s here.
+    const getAvailableDaemon = async (req: FastifyRequest, id: string) => {
+      const view = await deps.registry.getAvailable(orgOf(req), DaemonId(id))
       if (!view) return null
       return canView(view, ctxOf(req)) ? view : null
     }

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -109,10 +109,9 @@ type DaemonDto = {
   canManageLifecycle: boolean
 }
 
-/** `GET /daemons/capabilities` row — the capability half, minus each runtime's catalog. */
-type CapabilityDto = Pick<DaemonDto, 'daemonId' | 'capabilities' | 'mcpServers'> & {
-  runtimeProfiles: Omit<DaemonDto['runtimeProfiles'][number], 'modelCatalog'>[]
-}
+/** `GET /daemons/capabilities` row — the capability half. Catalogs keep their
+ *  runtime-level answers; only their per-model matrix is emptied. */
+type CapabilityDto = Pick<DaemonDto, 'daemonId' | 'capabilities' | 'runtimeProfiles' | 'mcpServers'>
 
 const listCapabilities = async (): Promise<CapabilityDto[]> =>
   (await running!.app.inject({ method: 'GET', url: `${ORG}/daemons/capabilities` })).json() as CapabilityDto[]
@@ -255,8 +254,8 @@ describe('GET /daemons — live-status overlay', () => {
     expect(d.runtimeProfiles[0]!.contextWindow).toBe(200000)
     // Never probed for MCP transports ⇒ explicit null (assume stdio-only), not undefined.
     expect(d.runtimeProfiles[0]!.mcpCapabilities).toBeNull()
-    // The catalog is not on this read at all; an unreported modelsSource is an explicit null.
-    expect(d.runtimeProfiles[0]!).not.toHaveProperty('modelCatalog')
+    // No catalog reported ⇒ explicit nulls (the console falls back to its static tables).
+    expect(d.runtimeProfiles[0]!.modelCatalog).toBeNull()
     expect(d.runtimeProfiles[0]!.modelsSource).toBeNull()
     // No login warning reported ⇒ explicit false (older daemons never send it).
     expect(d.runtimeProfiles[0]!.authRequired).toBe(false)
@@ -413,6 +412,7 @@ describe('GET /daemons — live-status overlay', () => {
         toolCalling: true,
         modelCatalog: {
           models: [{ id: 'claude-opus-4' }],
+          defaultModel: 'claude-opus-4',
           source: 'acp' as const,
           observedAt: '2026-07-18T00:00:00.000Z'
         }
@@ -426,12 +426,34 @@ describe('GET /daemons — live-status overlay', () => {
     expect(row.status).toBe('offline') // it IS the liveness row
     for (const half of ['capabilities', 'runtimeProfiles', 'mcpServers']) expect(row).not.toHaveProperty(half)
 
+    // The catalog's runtime-level answers survive the fleet read — the read-only model and
+    // permission labels resolve every agent against them — but the matrix does not.
     const caps = (await listCapabilities()).find((r) => r.daemonId === DAEMON)!
     expect(caps.runtimeProfiles[0]!.models).toEqual(['claude-opus-4'])
-    expect(caps.runtimeProfiles[0]!).not.toHaveProperty('modelCatalog')
+    expect(caps.runtimeProfiles[0]!.modelCatalog!.defaultModel).toBe('claude-opus-4')
+    expect(caps.runtimeProfiles[0]!.modelCatalog!.models).toEqual([])
 
     const one = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons/${DAEMON}` })).json() as DaemonDto
     expect(one.runtimeProfiles[0]!.modelCatalog!.models).toEqual([{ id: 'claude-opus-4' }])
+  })
+
+  // `registry.get` is the org-owned fleet, so resolving this read with it would 404 every
+  // daemon the fleet reads DO list from the shared pool.
+  it('serves the single-daemon read for an install-wide pool member', async () => {
+    const poolMember = await new PgDaemonRepo(prisma).resolvePoolClusterIdentity(
+      'system:serviceaccount:agentconnect:ac-cloud-daemon',
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    )
+    running = buildHttpApp(prisma)
+
+    const listed = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })).json() as DaemonDto[]
+    expect(listed.some((r) => r.daemonId === poolMember.id)).toBe(true)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/daemons/${poolMember.id}` })
+    expect(res.statusCode).toBe(200)
+    const one = res.json() as DaemonDto & { cloud: boolean; canEdit: boolean }
+    expect(one.cloud).toBe(true)
+    expect(one.canEdit).toBe(false) // visible, but not this org's to mutate
   })
 
   it('404s the single-daemon read for an unknown id', async () => {

--- a/packages/control-plane/test/integration/daemons.route.test.ts
+++ b/packages/control-plane/test/integration/daemons.route.test.ts
@@ -109,6 +109,14 @@ type DaemonDto = {
   canManageLifecycle: boolean
 }
 
+/** `GET /daemons/capabilities` row — the capability half, minus each runtime's catalog. */
+type CapabilityDto = Pick<DaemonDto, 'daemonId' | 'capabilities' | 'mcpServers'> & {
+  runtimeProfiles: Omit<DaemonDto['runtimeProfiles'][number], 'modelCatalog'>[]
+}
+
+const listCapabilities = async (): Promise<CapabilityDto[]> =>
+  (await running!.app.inject({ method: 'GET', url: `${ORG}/daemons/capabilities` })).json() as CapabilityDto[]
+
 describe('GET /daemons — live-status overlay', () => {
   it('reads `offline` for a registered daemon with no live connection (the exited-but-connected bug)', async () => {
     await seedDaemon()
@@ -207,16 +215,18 @@ describe('GET /daemons — live-status overlay', () => {
     expect(d.lastModifiedBy).toBeNull()
     expect(Date.parse(d.lastModifiedAt)).not.toBeNaN()
 
-    expect(d.capabilities.runtimes).toEqual(['claude', 'codex'])
-    expect(d.capabilities.platforms).toEqual(['slack'])
-    expect(d.capabilities.acp).toBe(true)
+    // Capability is its own read now; the liveness row carries none of it.
+    expect(d).not.toHaveProperty('capabilities')
+    const caps = (await listCapabilities()).find((r) => r.daemonId === DAEMON)!
+    expect(caps.capabilities.runtimes).toEqual(['claude', 'codex'])
+    expect(caps.capabilities.platforms).toEqual(['slack'])
+    expect(caps.capabilities.acp).toBe(true)
   })
 
   it('defaults runtimeProfiles + mcpServers to [] for a daemon that has reported none', async () => {
     await seedDaemon()
     running = buildHttpApp(prisma)
-    const rows = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })).json() as DaemonDto[]
-    const d = rows.find((r) => r.daemonId === DAEMON)!
+    const d = (await listCapabilities()).find((r) => r.daemonId === DAEMON)!
     expect(d.runtimeProfiles).toEqual([])
     expect(d.mcpServers).toEqual([])
   })
@@ -237,9 +247,7 @@ describe('GET /daemons — live-status overlay', () => {
       new Date()
     )
     running = buildHttpApp(prisma)
-    const rows = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })).json() as DaemonDto[]
-
-    const d = rows.find((r) => r.daemonId === DAEMON)!
+    const d = (await listCapabilities()).find((r) => r.daemonId === DAEMON)!
     expect(d.runtimeProfiles).toHaveLength(1)
     expect(d.runtimeProfiles[0]!.runtime).toBe('claude')
     expect(d.runtimeProfiles[0]!.models).toEqual(['claude-opus-4', 'claude-sonnet-4-5'])
@@ -247,8 +255,8 @@ describe('GET /daemons — live-status overlay', () => {
     expect(d.runtimeProfiles[0]!.contextWindow).toBe(200000)
     // Never probed for MCP transports ⇒ explicit null (assume stdio-only), not undefined.
     expect(d.runtimeProfiles[0]!.mcpCapabilities).toBeNull()
-    // No catalog reported ⇒ explicit nulls (the console falls back to its static tables).
-    expect(d.runtimeProfiles[0]!.modelCatalog).toBeNull()
+    // The catalog is not on this read at all; an unreported modelsSource is an explicit null.
+    expect(d.runtimeProfiles[0]!).not.toHaveProperty('modelCatalog')
     expect(d.runtimeProfiles[0]!.modelsSource).toBeNull()
     // No login warning reported ⇒ explicit false (older daemons never send it).
     expect(d.runtimeProfiles[0]!.authRequired).toBe(false)
@@ -269,8 +277,7 @@ describe('GET /daemons — live-status overlay', () => {
       new Date()
     )
     running = buildHttpApp(prisma)
-    const rows = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })).json() as DaemonDto[]
-    expect(rows.find((r) => r.daemonId === DAEMON)!.runtimeProfiles[0]!.authRequired).toBe(true)
+    expect((await listCapabilities()).find((r) => r.daemonId === DAEMON)!.runtimeProfiles[0]!.authRequired).toBe(true)
   })
 
   it('serves the reported modelCatalog, modelsSource and observedAt per runtime profile', async () => {
@@ -301,11 +308,11 @@ describe('GET /daemons — live-status overlay', () => {
     )
 
     running = buildHttpApp(prisma)
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/daemons/${DAEMON}` })
     expect(res.statusCode).toBe(200)
-    const d = (res.json() as DaemonDto[]).find((r) => r.daemonId === DAEMON)!
+    const d = res.json() as DaemonDto
 
-    // One shape wire → JSONB → DTO: the catalog comes back verbatim.
+    // One shape wire → JSONB → DTO: the catalog comes back verbatim, and only from here.
     expect(d.runtimeProfiles[0]!.modelCatalog).toEqual(catalog)
     expect(d.runtimeProfiles[0]!.modelsSource).toBe('cached')
     expect(d.runtimeProfiles[0]!.observedAt).toBe(at.toISOString())
@@ -332,9 +339,7 @@ describe('GET /daemons — live-status overlay', () => {
     ])
 
     running = buildHttpApp(prisma)
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })
-    expect(res.statusCode).toBe(200)
-    const d = (res.json() as DaemonDto[]).find((r) => r.daemonId === DAEMON)!
+    const d = (await listCapabilities()).find((r) => r.daemonId === DAEMON)!
 
     expect(d.runtimeProfiles[0]!.mcpCapabilities).toEqual({ http: true, sse: false })
     expect(d.mcpServers).toEqual([
@@ -355,10 +360,7 @@ describe('GET /daemons — live-status overlay', () => {
       new Date()
     )
     running = buildHttpApp(prisma)
-    const res = await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })
-    expect(res.statusCode).toBe(200)
-    const rows = res.json() as DaemonDto[]
-    expect(rows.find((r) => r.daemonId === DAEMON)!.runtimeProfiles[0]!.contextWindow).toBeNull()
+    expect((await listCapabilities()).find((r) => r.daemonId === DAEMON)!.runtimeProfiles[0]!.contextWindow).toBeNull()
   })
 
   it('groups runtime profiles per daemon (multiple runtimes on one daemon; no cross-daemon bleed)', async () => {
@@ -386,7 +388,7 @@ describe('GET /daemons — live-status overlay', () => {
     )
 
     running = buildHttpApp(prisma)
-    const rows = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })).json() as DaemonDto[]
+    const rows = await listCapabilities()
 
     const a = rows.find((r) => r.daemonId === DAEMON)!
     expect(a.runtimeProfiles.map((p) => p.runtime)).toEqual(['claude', 'codex']) // ordered by runtime
@@ -395,6 +397,47 @@ describe('GET /daemons — live-status overlay', () => {
     const b = rows.find((r) => r.daemonId === DAEMON_B)!
     expect(b.runtimeProfiles).toHaveLength(1) // only its own — no bleed from A
     expect(b.runtimeProfiles[0]!.models).toEqual(['claude-haiku-4-5'])
+  })
+
+  // The split's whole point: the poll pays for liveness only, and the per-model matrix —
+  // which every reader wants one daemon at a time — is on neither fleet-wide read.
+  it('keeps capability off the liveness row and the model catalog off both fleet reads', async () => {
+    await seedDaemon()
+    await new PgRuntimeProfileRepo(prisma).record(
+      DaemonId(DAEMON),
+      {
+        runtime: 'claude',
+        version: '1.4.0',
+        models: ['claude-opus-4'],
+        acpSupport: 'full',
+        toolCalling: true,
+        modelCatalog: {
+          models: [{ id: 'claude-opus-4' }],
+          source: 'acp' as const,
+          observedAt: '2026-07-18T00:00:00.000Z'
+        }
+      },
+      new Date()
+    )
+    running = buildHttpApp(prisma)
+
+    const fleet = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons` })).json() as DaemonDto[]
+    const row = fleet.find((r) => r.daemonId === DAEMON)!
+    expect(row.status).toBe('offline') // it IS the liveness row
+    for (const half of ['capabilities', 'runtimeProfiles', 'mcpServers']) expect(row).not.toHaveProperty(half)
+
+    const caps = (await listCapabilities()).find((r) => r.daemonId === DAEMON)!
+    expect(caps.runtimeProfiles[0]!.models).toEqual(['claude-opus-4'])
+    expect(caps.runtimeProfiles[0]!).not.toHaveProperty('modelCatalog')
+
+    const one = (await running.app.inject({ method: 'GET', url: `${ORG}/daemons/${DAEMON}` })).json() as DaemonDto
+    expect(one.runtimeProfiles[0]!.modelCatalog!.models).toEqual([{ id: 'claude-opus-4' }])
+  })
+
+  it('404s the single-daemon read for an unknown id', async () => {
+    running = buildHttpApp(prisma)
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/daemons/${randomUUID()}` })
+    expect(res.statusCode).toBe(404)
   })
 })
 

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -94,6 +94,7 @@ import {
 import { matchGitlabProjects, type GitlabProjectChoice } from '@/lib/gitlab-projects'
 import { gitRepoUrlTileHint } from '@/lib/git-url-tile'
 import { useGitlabProjects } from '@/lib/use-gitlab-projects'
+import { useDaemonDetail } from '@/lib/use-daemon-detail'
 
 type WsMode = WorkspaceMode
 
@@ -274,11 +275,13 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
     poolAvailable,
     availableGroups,
     offeredGroups,
-    daemon,
+    daemon: fleetDaemon,
     localDaemons,
     placement,
     value: effectiveDaemonId
   } = daemonChoice
+  // The model catalogs live on the single-daemon read; until it lands this is the fleet row.
+  const daemon = useDaemonDetail(fleetDaemon)
   const daemonOptions: DaemonSelectOption[] = [
     ...(poolAvailable
       ? [

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -57,6 +57,7 @@ import { OutputModeField } from '@/components/console/OutputModeField'
 import { RuntimeChatField } from '@/components/console/RuntimeChatField'
 import { SandboxField } from '@/components/console/SandboxField'
 import { isOutputMode, type OutputMode } from '@/lib/output-mode'
+import { useDaemonDetail } from '@/lib/use-daemon-detail'
 
 // The edit dialog mirrors the Add-agent modal: a single scrolling form with a
 // section rail beside it. Every group card on the Configuration page opens this
@@ -360,7 +361,8 @@ export default function EditAgentModal({
   )
   // The daemon whose reported CAPABILITIES the form reads — one live member for a set target, and
   // never the placement itself.
-  const daemon = editAgentCapabilitySource(daemons, daemonId, memberSets, daemonChoices.poolChoice)
+  // The model catalogs live on the single-daemon read; until it lands this is the fleet row.
+  const daemon = useDaemonDetail(editAgentCapabilitySource(daemons, daemonId, memberSets, daemonChoices.poolChoice))
   const sourceDaemon = daemons.find((d) => d.daemonId === initialDaemonId.current)
   const daemonChanged = daemonId !== initialDaemonId.current
   const initialPlacement = daemonChanged && !initialDaemonId.current

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -131,6 +131,7 @@ import {
   type HookReportingMode,
   type HookReviewPolicy
 } from '@/lib/github-review-settings'
+import { useDaemonDetail } from '@/lib/use-daemon-detail'
 
 type DetailTab = 'config' | 'integrations' | 'workspace' | 'memory' | 'tools'
 const HOOK_REFRESH_MS = 30_000
@@ -563,6 +564,10 @@ export default function AgentDetailView() {
   const agentReach = useMemo(() => buildAgentReachabilityGraph(agents), [agents])
 
   const da = getAgent(id)
+  // Hoisted above the not-found return below — a hook may not be called conditionally, and
+  // a deep link renders this before the agents pull settles. The effort row reads the
+  // selected model's own effort vocabulary, which only the single-daemon read carries.
+  const capabilitySource = useDaemonDetail(da ? agentCapabilitySource(da, daemons, memberSets) : undefined)
   // Unknown id (a stale deep link, or a demo agent that's hidden outside mock mode) —
   // show a not-found notice rather than crash on the `da.*` reads below. While the
   // agents pull is still in flight, though, it's not "not found" yet — spin instead.
@@ -590,11 +595,11 @@ export default function AgentDetailView() {
   // The owning daemon (if placed in the live fleet). Gates the agent's "online" —
   // an agent can't be online when its daemon is offline — and names the daemon.
   const owningDaemon = daemons.find((d) => d.daemonId === da.daemon)
-  // Whose reported catalog the config rows read — resolved through the PLACEMENT, so a pool or
-  // group agent reads its set's real catalog via one serving member instead of the static tables.
-  // `owningDaemon` cannot answer that: a set placement names no member, and the nothing it found
-  // is what showed every such agent an em-dash model even when one was explicitly saved.
-  const capabilitySource = agentCapabilitySource(da, daemons, memberSets)
+  // `capabilitySource` above is whose reported catalog the config rows read — resolved through
+  // the PLACEMENT, so a pool or group agent reads its set's real catalog via one serving member
+  // instead of the static tables. `owningDaemon` cannot answer that: a set placement names no
+  // member, and the nothing it found is what showed every such agent an em-dash model even when
+  // one was explicitly saved.
   const runtimeMeta = acpRuntime(acpRegistry, da.runtime)
   // Config rows read the daemon-advertised runtime-model catalog so a placed
   // agent shows the SAME effective model / effort / permission the Edit modal

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -52,6 +52,7 @@ import {
   type SessionImage
 } from '@/lib/data'
 import { cronNext, cronHuman, fmtNextRun } from '@/lib/cron'
+import { useDaemonDetail } from '@/lib/use-daemon-detail'
 
 // Design composer selectors: agent/model are "pills" (rounded, with a leading
 // mark), effort/permission are plain "chips". Full literal strings so Tailwind's
@@ -231,7 +232,8 @@ export default function HomeView() {
 
   // What the selected agent RUNS ON supplies the model catalog + defaults — resolved through the
   // placement, so a pool or group agent reads its set's real catalog instead of the static tables.
-  const owningDaemon = agent ? agentCapabilitySource(agent, daemons, memberSets) : undefined
+  // The model catalogs live on the single-daemon read; until it lands this is the fleet row.
+  const owningDaemon = useDaemonDetail(agent ? agentCapabilitySource(agent, daemons, memberSets) : undefined)
   // What to CALL it, and where to send the reader: a set is named and opened as itself, never as
   // the member standing in for it — a pool member is a Pod that no longer exists after a roll.
   const placementKind = agent ? agentPlacementKind(agent, memberSets) : undefined

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -135,6 +135,7 @@ import {
 import { useSessionList } from '@/lib/use-session-list'
 import { isFlatSessionView } from '@/lib/session-list-view'
 import { WebchatMcpApprovalCard } from '@/components/console/WebchatMcpApprovalCard'
+import { useDaemonDetail } from '@/lib/use-daemon-detail'
 import {
   sessionEffortAfterModelChange,
   sessionEffortChoicesForSelection,
@@ -3296,8 +3297,10 @@ export default function SessionDetailView() {
   // resolve it to the daemon's display name — never surface the raw id/host
   // (short-id fallback when it isn't in the fleet), matching the Agents list.
   const owningDaemonId = session.daemon && session.daemon !== '—' ? session.daemon : owner?.daemon
-  const owningDaemon =
+  // The model catalogs live on the single-daemon read; until it lands this is the fleet row.
+  const owningDaemon = useDaemonDetail(
     owningDaemonId && owningDaemonId !== '—' ? daemons.find((d) => d.daemonId === owningDaemonId) : undefined
+  )
   const focusedDaemonId =
     focusedSession?.daemon && focusedSession.daemon !== '—' ? focusedSession.daemon : focusedAgent?.daemon
   const focusedDaemon =

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1820,6 +1820,14 @@ export default function SessionDetailView() {
         }
       : sessionBase
   const agentRuntime = session?.runtime || owner?.runtime || ''
+  // Hoisted above this component's loading / not-found returns: a deep link renders it
+  // before `session` resolves, and a hook called only on the later render would change the
+  // hook count between renders. The model catalogs live on the single-daemon read; until
+  // it lands this is the fleet row.
+  const owningDaemonId = session?.daemon && session.daemon !== '—' ? session.daemon : owner?.daemon
+  const owningDaemon = useDaemonDetail(
+    owningDaemonId && owningDaemonId !== '—' ? daemons.find((d) => d.daemonId === owningDaemonId) : undefined
+  )
 
   // A real (CP) session arrives with an empty `steps` — its transcript is a separate on-demand pull
   // from the owning daemon. Playground + mock sessions carry their own steps, so they never fetch.
@@ -3296,11 +3304,6 @@ export default function SessionDetailView() {
   // The session's `daemon` is the owning agent's daemonId (or '—' when unplaced);
   // resolve it to the daemon's display name — never surface the raw id/host
   // (short-id fallback when it isn't in the fleet), matching the Agents list.
-  const owningDaemonId = session.daemon && session.daemon !== '—' ? session.daemon : owner?.daemon
-  // The model catalogs live on the single-daemon read; until it lands this is the fleet row.
-  const owningDaemon = useDaemonDetail(
-    owningDaemonId && owningDaemonId !== '—' ? daemons.find((d) => d.daemonId === owningDaemonId) : undefined
-  )
   const focusedDaemonId =
     focusedSession?.daemon && focusedSession.daemon !== '—' ? focusedSession.daemon : focusedAgent?.daemon
   const focusedDaemon =

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1044,6 +1044,18 @@ export interface McpServerDto {
   transport: 'stdio' | 'http' | 'sse'
 }
 
+/** `GET /daemons` — the liveness half, without anything that only moves on connect/upgrade. */
+export type DaemonFleetDto = Omit<DaemonViewDto, 'capabilities' | 'runtimeProfiles' | 'mcpServers'>
+
+/** `GET /daemons/capabilities` — what each daemon can run, minus the per-model matrix. */
+export interface DaemonCapabilityDto {
+  daemonId: string
+  capabilities: DaemonCapabilitiesDto
+  runtimeProfiles: Omit<RuntimeProfileDto, 'modelCatalog'>[]
+  mcpServers: McpServerDto[]
+}
+
+/** `GET /daemons/:id` — both halves, catalog included. */
 export interface DaemonViewDto {
   daemonId: string
   host: string | null
@@ -2077,7 +2089,32 @@ export function mergeSessionDetailUsage(local: Session, detail: Session | null):
   })
 }
 
-export function daemonFromDto(d: DaemonViewDto): DaemonRow {
+/** What a liveness row knows before its capability read lands: nothing yet. Views gate on
+ *  `daemonsLoading` rather than reading this as "the daemon can do nothing". */
+const EMPTY_DAEMON_CAPS: DaemonCapabilitiesDto = { platforms: [], runtimes: [], acp: false, features: [] }
+
+/** Stitch a capability row onto its liveness row. The catalog is deliberately absent —
+ *  `modelCatalog` stays undefined until someone reads that one daemon in full. */
+export function withDaemonCapability(row: DaemonRow, cap: DaemonCapabilityDto | undefined): DaemonRow {
+  if (!cap) return row
+  return {
+    ...row,
+    caps: cap.capabilities,
+    runtimeModels: cap.runtimeProfiles.map((p) => ({
+      runtime: p.runtime,
+      version: p.version,
+      models: p.models,
+      acpProtocolVersion: p.acpProtocolVersion,
+      mcpCapabilities: p.mcpCapabilities ?? null,
+      authRequired: p.authRequired ?? false
+    })),
+    mcpServers: cap.mcpServers
+  }
+}
+
+export function daemonFromDto(
+  d: DaemonFleetDto & Partial<Pick<DaemonViewDto, 'capabilities' | 'runtimeProfiles' | 'mcpServers'>>
+): DaemonRow {
   // `cloud` is the CP DTO's field name (a REST contract); the console's own word is `pool`.
   const pool = d.cloud ?? false
   return {
@@ -2107,7 +2144,7 @@ export function daemonFromDto(d: DaemonViewDto): DaemonRow {
     cpu: d.load ? Math.round(d.load.cpu * 100) : 0,
     mem: d.load ? Math.round(d.load.mem * 100) : 0,
     loadAgents: d.load?.agents ?? 0,
-    caps: d.capabilities,
+    caps: d.capabilities ?? EMPTY_DAEMON_CAPS,
     // Per-runtime available models, observed from the daemon's runtime profiles.
     runtimeModels: (d.runtimeProfiles ?? []).map((p) => ({
       runtime: p.runtime,
@@ -3686,8 +3723,23 @@ export async function updateAgentCallPolicy(agentId: string, body: AgentCallPoli
   return agentFromDto(await apiPut<AgentDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/call-policy`, body))
 }
 
+// The fleet reads split by change rate: `/daemons` is polled for liveness, `/daemons/
+// capabilities` moves only when a daemon connects/upgrades/re-probes, and a runtime's
+// model catalog is read one daemon at a time. `DaemonRow` is stitched back together in
+// the data context, so views still see one object.
 export async function fetchDaemons(orgId?: string): Promise<DaemonRow[]> {
-  return (await apiGet<DaemonViewDto[]>(`${orgBase(orgId)}/daemons`)).map(daemonFromDto)
+  return (await apiGet<DaemonFleetDto[]>(`${orgBase(orgId)}/daemons`)).map(daemonFromDto)
+}
+
+/** Fleet-wide capability, keyed by daemon id — merged onto the liveness rows. */
+export async function fetchDaemonCapabilities(orgId?: string): Promise<Map<string, DaemonCapabilityDto>> {
+  const rows = await apiGet<DaemonCapabilityDto[]>(`${orgBase(orgId)}/daemons/capabilities`)
+  return new Map(rows.map((r) => [r.daemonId, r]))
+}
+
+/** One daemon in full — the only read that carries each runtime's model catalog. */
+export async function fetchDaemon(daemonId: string): Promise<DaemonRow> {
+  return daemonFromDto(await apiGet<DaemonViewDto>(`${orgBase()}/daemons/${encodeURIComponent(daemonId)}`))
 }
 
 // Assign a human-friendly display name to a connected daemon.

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1047,11 +1047,14 @@ export interface McpServerDto {
 /** `GET /daemons` — the liveness half, without anything that only moves on connect/upgrade. */
 export type DaemonFleetDto = Omit<DaemonViewDto, 'capabilities' | 'runtimeProfiles' | 'mcpServers'>
 
-/** `GET /daemons/capabilities` — what each daemon can run, minus the per-model matrix. */
+/** `GET /daemons/capabilities` — what each daemon can run. Each catalog keeps its
+ *  runtime-level answers (`defaultModel`, `permissionModes`) so the read-only model and
+ *  permission labels resolve for every agent, but its `models` matrix is empty: that part
+ *  is 75% of a catalog and only a surface configuring one daemon reads it. */
 export interface DaemonCapabilityDto {
   daemonId: string
   capabilities: DaemonCapabilitiesDto
-  runtimeProfiles: Omit<RuntimeProfileDto, 'modelCatalog'>[]
+  runtimeProfiles: RuntimeProfileDto[]
   mcpServers: McpServerDto[]
 }
 
@@ -2093,8 +2096,9 @@ export function mergeSessionDetailUsage(local: Session, detail: Session | null):
  *  `daemonsLoading` rather than reading this as "the daemon can do nothing". */
 const EMPTY_DAEMON_CAPS: DaemonCapabilitiesDto = { platforms: [], runtimes: [], acp: false, features: [] }
 
-/** Stitch a capability row onto its liveness row. The catalog is deliberately absent —
- *  `modelCatalog` stays undefined until someone reads that one daemon in full. */
+/** Stitch a capability row onto its liveness row. The catalog arrives with an empty
+ *  `models` list — `modelCapability()` then reads as "not discovered" and falls back to the
+ *  static tables, which is exactly what a surface that has not read one daemon should see. */
 export function withDaemonCapability(row: DaemonRow, cap: DaemonCapabilityDto | undefined): DaemonRow {
   if (!cap) return row
   return {
@@ -2106,6 +2110,7 @@ export function withDaemonCapability(row: DaemonRow, cap: DaemonCapabilityDto | 
       models: p.models,
       acpProtocolVersion: p.acpProtocolVersion,
       mcpCapabilities: p.mcpCapabilities ?? null,
+      modelCatalog: p.modelCatalog ?? null,
       authRequired: p.authRequired ?? false
     })),
     mcpServers: cap.mcpServers

--- a/packages/web/src/lib/daemon-read-split.test.ts
+++ b/packages/web/src/lib/daemon-read-split.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The fleet read is split by change rate: `GET /daemons` is polled for liveness, its
+ * capability half is read separately, and a runtime's model catalog only comes from the
+ * single-daemon read. `DaemonRow` is stitched back together here so views never learn
+ * that happened — these tests pin the stitching and the deliberately absent catalog.
+ */
+import { describe, expect, it } from 'vitest'
+import { daemonFromDto, withDaemonCapability, type DaemonCapabilityDto, type DaemonFleetDto } from '@/lib/api'
+
+const fleetRow: DaemonFleetDto = {
+  daemonId: 'd-1',
+  host: 'edge-1',
+  name: 'edge-1',
+  agentVersion: '1.51.0',
+  releaseChannel: 'latest',
+  latestVersion: '1.51.0',
+  availableVersions: ['1.51.0'],
+  lifecycleOp: null,
+  status: 'ready',
+  health: 'ok',
+  load: { cpu: 0.5, mem: 0.25, agents: 2 },
+  sessionEpoch: 3,
+  maxAgents: 32,
+  activeSessions: 1,
+  lastSeenAt: '2026-08-30T00:00:00.000Z',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  createdBy: null,
+  lastModifiedAt: '2026-08-01T00:00:00.000Z',
+  lastModifiedBy: null,
+  sessionRetention: '7d',
+  visibility: 'org',
+  sharedWith: [],
+  canEdit: true,
+  canManageSharing: true,
+  canManageLifecycle: true
+} as DaemonFleetDto
+
+const capability: DaemonCapabilityDto = {
+  daemonId: 'd-1',
+  capabilities: { platforms: ['slack'], runtimes: ['claude-acp'], acp: true, features: ['sandbox'] },
+  runtimeProfiles: [
+    {
+      runtime: 'claude-acp',
+      version: '0.70.0',
+      models: ['opus', 'sonnet'],
+      contextWindow: null,
+      acpSupport: 'full',
+      acpProtocolVersion: 1,
+      toolCalling: true,
+      mcpCapabilities: { http: true, sse: true },
+      modelsSource: 'probed',
+      authRequired: true
+    }
+  ],
+  mcpServers: [{ name: 'github', transport: 'stdio' }]
+}
+
+describe('daemon read split', () => {
+  it('maps a liveness row on its own, with capability still unknown', () => {
+    const row = daemonFromDto(fleetRow)
+    expect(row.status).toBe('online') // the console's word for a ready daemon
+    expect(row.loadAgents).toBe(2)
+    // Empty rather than wrong: views gate on `daemonsLoading` until capability lands.
+    expect(row.caps).toEqual({ platforms: [], runtimes: [], acp: false, features: [] })
+    expect(row.runtimeModels).toEqual([])
+    expect(row.mcpServers).toEqual([])
+  })
+
+  it('stitches capability onto the liveness row without disturbing liveness', () => {
+    const row = withDaemonCapability(daemonFromDto(fleetRow), capability)
+    expect(row.status).toBe('online') // the console's word for a ready daemon
+    expect(row.caps.features).toEqual(['sandbox'])
+    expect(row.mcpServers).toEqual([{ name: 'github', transport: 'stdio' }])
+    expect(row.runtimeModels).toHaveLength(1)
+    expect(row.runtimeModels[0]!.models).toEqual(['opus', 'sonnet'])
+    expect(row.runtimeModels[0]!.mcpCapabilities).toEqual({ http: true, sse: true })
+    // The login warning is fleet-wide information, so it survives the split.
+    expect(row.runtimeModels[0]!.authRequired).toBe(true)
+    // The catalog is not on either fleet read — `useDaemonDetail` fetches the one daemon.
+    expect(row.runtimeModels[0]!.modelCatalog).toBeUndefined()
+  })
+
+  it('leaves the row alone when that daemon has no capability row yet', () => {
+    const row = daemonFromDto(fleetRow)
+    expect(withDaemonCapability(row, undefined)).toBe(row)
+  })
+})

--- a/packages/web/src/lib/daemon-read-split.test.ts
+++ b/packages/web/src/lib/daemon-read-split.test.ts
@@ -49,6 +49,14 @@ const capability: DaemonCapabilityDto = {
       toolCalling: true,
       mcpCapabilities: { http: true, sse: true },
       modelsSource: 'probed',
+      // The fleet read keeps the runtime-level answers and empties the matrix.
+      modelCatalog: {
+        models: [],
+        defaultModel: 'sonnet',
+        permissionModes: [{ value: 'auto', name: 'Auto' }],
+        source: 'acp',
+        observedAt: '2026-08-30T00:00:00.000Z'
+      },
       authRequired: true
     }
   ],
@@ -76,8 +84,11 @@ describe('daemon read split', () => {
     expect(row.runtimeModels[0]!.mcpCapabilities).toEqual({ http: true, sse: true })
     // The login warning is fleet-wide information, so it survives the split.
     expect(row.runtimeModels[0]!.authRequired).toBe(true)
-    // The catalog is not on either fleet read — `useDaemonDetail` fetches the one daemon.
-    expect(row.runtimeModels[0]!.modelCatalog).toBeUndefined()
+    // The runtime-level answers survive, so the read-only model/permission labels resolve
+    // for every agent; the per-model matrix is empty until `useDaemonDetail` reads one daemon.
+    expect(row.runtimeModels[0]!.modelCatalog!.defaultModel).toBe('sonnet')
+    expect(row.runtimeModels[0]!.modelCatalog!.permissionModes).toEqual([{ value: 'auto', name: 'Auto' }])
+    expect(row.runtimeModels[0]!.modelCatalog!.models).toEqual([])
   })
 
   it('leaves the row alone when that daemon has no capability row yet', () => {

--- a/packages/web/src/lib/daemon-read-split.test.ts
+++ b/packages/web/src/lib/daemon-read-split.test.ts
@@ -6,6 +6,8 @@
  */
 import { describe, expect, it } from 'vitest'
 import { daemonFromDto, withDaemonCapability, type DaemonCapabilityDto, type DaemonFleetDto } from '@/lib/api'
+import { mergeDaemonCatalogs } from '@/lib/use-daemon-detail'
+import type { DaemonRow } from '@/lib/data'
 
 const fleetRow: DaemonFleetDto = {
   daemonId: 'd-1',
@@ -94,5 +96,37 @@ describe('daemon read split', () => {
   it('leaves the row alone when that daemon has no capability row yet', () => {
     const row = daemonFromDto(fleetRow)
     expect(withDaemonCapability(row, undefined)).toBe(row)
+  })
+})
+
+describe('mergeDaemonCatalogs — the detail read owns catalogs, the fleet row owns the rest', () => {
+  const fleet = [
+    { runtime: 'claude-acp', version: '0.70.0', models: ['opus'], authRequired: true, modelCatalog: null }
+  ] as DaemonRow['runtimeModels']
+  const detail = [
+    {
+      runtime: 'claude-acp',
+      version: '0.70.0',
+      models: ['opus', 'sonnet'],
+      authRequired: false,
+      modelCatalog: { models: [{ id: 'opus' }], source: 'acp', observedAt: '2026-08-30T00:00:00.000Z' }
+    },
+    { runtime: 'codex-acp', version: '1.0.0', models: ['gpt-5'], modelCatalog: null }
+  ] as DaemonRow['runtimeModels']
+
+  it('takes the catalog from detail and everything else from the fleet row', () => {
+    const [merged] = mergeDaemonCatalogs(fleet, detail)
+    expect(merged!.modelCatalog!.models).toEqual([{ id: 'opus' }])
+    // A slower detail response must not resurrect a stale runtime inventory or login state.
+    expect(merged!.models).toEqual(['opus'])
+    expect(merged!.authRequired).toBe(true)
+  })
+
+  it('never adds a runtime the fleet row no longer reports', () => {
+    expect(mergeDaemonCatalogs(fleet, detail).map((p) => p.runtime)).toEqual(['claude-acp'])
+  })
+
+  it('falls back to the detail profiles before the fleet capability read lands', () => {
+    expect(mergeDaemonCatalogs([], detail)).toBe(detail)
   })
 })

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -809,8 +809,16 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   // liveness key would show a freshly connected daemon as running nothing until the slow
   // capability backstop, so every existing `mutateDaemons()` refreshes the pair.
   const mutateDaemons = useCallback(
-    () => Promise.all([mutateDaemonLiveness(), mutateDaemonCapabilities()]).then(() => undefined),
-    [mutateDaemonLiveness, mutateDaemonCapabilities]
+    () =>
+      Promise.all([
+        mutateDaemonLiveness(),
+        mutateDaemonCapabilities(),
+        // Every mounted single-daemon read too: an upgrade or re-probe replaces the model
+        // catalogs those hold, and their own interval would otherwise decide when a picker
+        // notices.
+        mutateCache((key) => Array.isArray(key) && key[0] === 'console' && key[2] === 'daemon')
+      ]).then(() => undefined),
+    [mutateDaemonLiveness, mutateDaemonCapabilities, mutateCache]
   )
   const {
     data: realCrons = [],

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -96,6 +96,9 @@ import {
   type AgentCallPolicyInput,
   fetchAgents,
   fetchDaemons,
+  fetchDaemonCapabilities,
+  withDaemonCapability,
+  type DaemonCapabilityDto,
   fetchSessionFacets,
   subscribeSessionEvents,
   fetchCrons,
@@ -291,6 +294,9 @@ interface ConsoleData {
 const Ctx = createContext<ConsoleData | null>(null)
 const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 500
 const DAEMON_REFRESH_MS = 15_000
+/** Capability changes on connect/upgrade/re-probe, all of which already revalidate the
+ *  fleet, so this is a backstop rather than the way a change is noticed. */
+const DAEMON_CAPABILITY_REFRESH_MS = 300_000
 const RESOURCE_REFRESH_MS = 30_000
 const EMPTY_SESSION_FACETS: SessionFacets = {
   agentIds: [],
@@ -786,6 +792,14 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   } = useSWR<DaemonRow[]>(consoleKeys.daemons(orgKey), ([, orgId]) => fetchDaemons(orgId as string), {
     refreshInterval: DAEMON_REFRESH_MS
   })
+  // Capability moves only when a daemon connects, upgrades, or re-probes, so it is read
+  // apart from the liveness poll and stitched back on below. Its own revalidation is slow;
+  // the events that actually change it already refresh the fleet through `mutateDaemons`.
+  const { data: daemonCapabilities, isLoading: capabilitiesIsLoading } = useSWR<Map<string, DaemonCapabilityDto>>(
+    consoleKeys.daemonCapabilities(orgKey),
+    ([, orgId]) => fetchDaemonCapabilities(orgId as string),
+    { refreshInterval: DAEMON_CAPABILITY_REFRESH_MS }
+  )
   const {
     data: realCrons = [],
     error: cronsError,
@@ -996,7 +1010,12 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     })
     return [...realAgents, ...demo]
   }, [realAgents, mockCallPolicy])
-  const daemons = realDaemons
+  // One `DaemonRow` again: views never learn the read was split. `modelCatalog` is absent
+  // here by design — `useDaemonDetail` fetches the one daemon that needs it.
+  const daemons = useMemo(
+    () => realDaemons.map((d) => withDaemonCapability(d, daemonCapabilities?.get(d.daemonId))),
+    [realDaemons, daemonCapabilities]
+  )
 
   // Resolve an agent by id. Falls back to a demo agent only in mock mode; a live
   // console returns undefined for an unknown id (e.g. a stale deep link).
@@ -1530,7 +1549,9 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
   const error = coreError ? (coreError instanceof Error ? coreError.message : String(coreError)) : null
   const agentsLoading = waitingForOrg || agentsIsLoading
   const sessionsLoading = waitingForOrg || sessionsIsLoading || sessionFacetsIsLoading
-  const daemonsLoading = waitingForOrg || daemonsIsLoading
+  // Capability is part of a complete daemon row here, so a view that gates on this never
+  // renders a fleet row as "runs nothing" in the window before that read lands.
+  const daemonsLoading = waitingForOrg || daemonsIsLoading || capabilitiesIsLoading
   const cronsLoading = waitingForOrg || cronsIsLoading
   // Mock mode never waits: the demo registries are always there, so the tiles render
   // immediately instead of sitting on a spinner while a CP that isn't running fails.
@@ -1544,6 +1565,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     sessionsIsLoading ||
     sessionFacetsIsLoading ||
     daemonsIsLoading ||
+    capabilitiesIsLoading ||
     cronsIsLoading ||
     integrationsIsLoading ||
     botsIsLoading ||

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -788,17 +788,29 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     data: realDaemons = [],
     error: daemonsError,
     isLoading: daemonsIsLoading,
-    mutate: mutateDaemons
+    mutate: mutateDaemonLiveness
   } = useSWR<DaemonRow[]>(consoleKeys.daemons(orgKey), ([, orgId]) => fetchDaemons(orgId as string), {
     refreshInterval: DAEMON_REFRESH_MS
   })
   // Capability moves only when a daemon connects, upgrades, or re-probes, so it is read
   // apart from the liveness poll and stitched back on below. Its own revalidation is slow;
   // the events that actually change it already refresh the fleet through `mutateDaemons`.
-  const { data: daemonCapabilities, isLoading: capabilitiesIsLoading } = useSWR<Map<string, DaemonCapabilityDto>>(
+  const {
+    data: daemonCapabilities,
+    isLoading: capabilitiesIsLoading,
+    mutate: mutateDaemonCapabilities
+  } = useSWR<Map<string, DaemonCapabilityDto>>(
     consoleKeys.daemonCapabilities(orgKey),
     ([, orgId]) => fetchDaemonCapabilities(orgId as string),
     { refreshInterval: DAEMON_CAPABILITY_REFRESH_MS }
+  )
+  // The two halves are one row to every caller, and the events that refresh daemons —
+  // connect, upgrade, re-probe, onboarding polling — change BOTH. Revalidating only the
+  // liveness key would show a freshly connected daemon as running nothing until the slow
+  // capability backstop, so every existing `mutateDaemons()` refreshes the pair.
+  const mutateDaemons = useCallback(
+    () => Promise.all([mutateDaemonLiveness(), mutateDaemonCapabilities()]).then(() => undefined),
+    [mutateDaemonLiveness, mutateDaemonCapabilities]
   )
   const {
     data: realCrons = [],

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -10,6 +10,11 @@ function consoleKey<const Resource extends string, const Parts extends readonly 
 export const consoleKeys = {
   agents: (orgId: string | null | undefined) => consoleKey(orgId, 'agents'),
   daemons: (orgId: string | null | undefined) => consoleKey(orgId, 'daemons'),
+  /** Fleet capability — split off the liveness poll because it only moves when a daemon
+   *  connects, upgrades, or re-probes. */
+  daemonCapabilities: (orgId: string | null | undefined) => consoleKey(orgId, 'daemon-capabilities'),
+  /** One daemon in full — the only read carrying a runtime's model catalog. */
+  daemon: (orgId: string | null | undefined, daemonId: string) => consoleKey(orgId, 'daemon', daemonId),
   crons: (orgId: string | null | undefined) => consoleKey(orgId, 'crons'),
   integrations: (orgId: string | null | undefined) => consoleKey(orgId, 'integrations'),
   bots: (orgId: string | null | undefined) => consoleKey(orgId, 'bots'),

--- a/packages/web/src/lib/use-daemon-detail.ts
+++ b/packages/web/src/lib/use-daemon-detail.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import useSWR from 'swr'
+import { consoleKeys } from '@/lib/swr-keys'
+import { fetchDaemon } from '@/lib/api'
+import { useOrgs } from '@/lib/org-context'
+import type { DaemonRow } from '@/lib/data'
+
+/**
+ * The one daemon a config surface is configuring, read in full so its runtime profiles
+ * carry their model catalogs. The fleet reads deliberately omit those — every reader of a
+ * catalog wants a single daemon at a time, so paying for the whole fleet's matrices on a
+ * poll bought nothing.
+ *
+ * Returns the fleet row unchanged while the read is in flight or if it fails, so a picker
+ * degrades to "no catalog" (the static tables) instead of going blank.
+ */
+export function useDaemonDetail(daemon: DaemonRow | undefined): DaemonRow | undefined {
+  const { activeOrg } = useOrgs()
+  const { data } = useSWR<DaemonRow>(
+    daemon && activeOrg?.id ? consoleKeys.daemon(activeOrg.id, daemon.daemonId) : null,
+    () => fetchDaemon(daemon!.daemonId)
+  )
+  return data ?? daemon
+}

--- a/packages/web/src/lib/use-daemon-detail.ts
+++ b/packages/web/src/lib/use-daemon-detail.ts
@@ -6,20 +6,47 @@ import { fetchDaemon } from '@/lib/api'
 import { useOrgs } from '@/lib/org-context'
 import type { DaemonRow } from '@/lib/data'
 
+/** Catalog discovery finishes asynchronously after a daemon starts, so an open picker has
+ *  to pick the matrix up on its own (runtime-model-catalog.md §7) rather than only on a
+ *  remount. Matches the fleet poll: this read is one daemon, and only while a surface that
+ *  needs the matrix is mounted. */
+const DAEMON_DETAIL_REFRESH_MS = 15_000
+
+/** Overlay the detail read's catalogs onto the fleet row's profiles. The fleet row wins on
+ *  everything else — it is the one being polled — so a runtime that has since disappeared
+ *  or flipped `authRequired` is not resurrected by a slower detail response. Before the
+ *  fleet capability read lands there are no profiles to overlay onto, and the detail's own
+ *  are strictly better than none. */
+export function mergeDaemonCatalogs(
+  fleet: DaemonRow['runtimeModels'],
+  detail: DaemonRow['runtimeModels']
+): DaemonRow['runtimeModels'] {
+  if (fleet.length === 0) return detail
+  return fleet.map((profile) => {
+    const catalog = detail.find((d) => d.runtime === profile.runtime)?.modelCatalog
+    return catalog ? { ...profile, modelCatalog: catalog } : profile
+  })
+}
+
 /**
- * The one daemon a config surface is configuring, read in full so its runtime profiles
- * carry their model catalogs. The fleet reads deliberately omit those — every reader of a
- * catalog wants a single daemon at a time, so paying for the whole fleet's matrices on a
- * poll bought nothing.
+ * The one daemon a config surface is configuring, with its runtime profiles' model
+ * catalogs. The fleet reads deliberately omit that matrix — every reader of one wants a
+ * single daemon at a time, so paying for the whole fleet's matrices on a poll bought
+ * nothing.
  *
- * Returns the fleet row unchanged while the read is in flight or if it fails, so a picker
- * degrades to "no catalog" (the static tables) instead of going blank.
+ * Only the catalogs come from this read. Liveness stays the fleet row's, because callers
+ * decide things like move/repair eligibility from the same value and a detail response
+ * captured minutes ago must not make an offline daemon look serving.
  */
 export function useDaemonDetail(daemon: DaemonRow | undefined): DaemonRow | undefined {
   const { activeOrg } = useOrgs()
   const { data } = useSWR<DaemonRow>(
     daemon && activeOrg?.id ? consoleKeys.daemon(activeOrg.id, daemon.daemonId) : null,
-    () => fetchDaemon(daemon!.daemonId)
+    () => fetchDaemon(daemon!.daemonId),
+    { refreshInterval: DAEMON_DETAIL_REFRESH_MS }
   )
-  return data ?? daemon
+  if (!daemon) return undefined
+  // SWR can still hold the previous key's answer for a render after the daemon changes.
+  if (!data || data.daemonId !== daemon.daemonId) return daemon
+  return { ...daemon, runtimeModels: mergeDaemonCatalogs(daemon.runtimeModels, data.runtimeModels) }
 }


### PR DESCRIPTION
## Why

`GET /daemons` returned three things with completely different change rates in one
payload, and the console polls it every 15 seconds (`DAEMON_REFRESH_MS`). Measured on a
nine-daemon fleet, 103,902 characters per poll:

| | share |
| --- | --- |
| `runtimeProfiles` | 92% |
| ↳ of which `modelCatalog` | 68% |
| `capabilities` | 6% |
| liveness — status, health, load, activeSessions, lastSeenAt, lifecycleOp | ~1% |

Everything but that last 1% changes only when a daemon connects, upgrades, or re-probes.
The poll pays for all of it four times a minute, per open tab, and the payload grows with
fleet size times installed runtimes.

## What

Split by change rate, not by "summary vs detail" — the shape follows how each half is read:

| Read | Carries | Why there |
| --- | --- | --- |
| `GET /daemons` | liveness | what the poll is watching |
| `GET /daemons/capabilities` | capabilities, runtime profiles, MCP servers | readers need **every** daemon at once — the pickers' runtime list, the per-agent login warning, a member set's runtime union — so it stays fleet-wide, it just leaves the fast poll |
| `GET /daemons/:id` (new) | the above plus each runtime's model catalog | every catalog reader already looks at exactly **one** daemon: the Add/Edit Agent pickers and the session runtime controls |

Two things worth stating because they rule out cheaper-looking options:

- **The catalog cannot be shared or deduplicated.** It is probed from the ACP binary on
  each host, so two daemons running the same runtime version legitimately report different
  catalogs — measured on this fleet, `claude-acp@0.70.0` on five daemons gave three
  distinct catalogs, and content-deduplicating the whole payload saves 12%.
- **No `detail` parameter.** One resource with two shapes behind a flag is what produced
  this; each read now has one shape.

There is no behavior change in the console. `data-context` reads the two fleet halves and
stitches them back into one `DaemonRow`, so views are untouched; `daemonsLoading` covers
both so nothing renders a daemon as "runs nothing" in between. Only the four surfaces that
read a catalog changed, resolving the daemon they are configuring through the new
`useDaemonDetail`, which falls back to the fleet row while that read is in flight.

## Test

- `daemons.route.test.ts` — existing capability assertions moved to the read that now owns
  them, plus a case pinning the split itself: the liveness row carries no capability half,
  the capability read carries no catalog, and the single-daemon read does. The
  cross-org "point-GET of a foreign daemon id reads as absent" case in
  `tenant-isolation.route.test.ts` was passing vacuously against a nonexistent route and
  now exercises the policy gate.
- `daemon-read-split.test.ts` — the liveness row maps on its own, capability stitches on
  without disturbing it, and the catalog is absent from the stitched row.


---

## MCP surface

Added in the second commit, because the split otherwise makes the tool catalog worse.
`listDaemons` now answers liveness only, and nothing else in the catalog said what a
daemon can run — while `createAgent`'s `runtime` argument still told callers to pick from
what `listDaemons` reports. Two read-only tools restore it, matched to how each is used:

- `listDaemonCapabilities` — placement: which daemon offers the runtime an agent needs.
- `getDaemon` — the one daemon whose model catalog decides the valid `model`,
  `reasoningEffort` and `permissionMode`.

The fat catalog is now something a caller asks for about a single daemon instead of
something every fleet listing pays for: this fleet's liveness listing is 8.3 KB where the
old combined one was 104 KB, and the largest single daemon in full is 37 KB.
