### PR TITLE
fix(slack): list every missing scope at once, required and optional

### DIFF
--- a/packages/web/src/components/console/platforms/slack/refresh-notice.test.ts
+++ b/packages/web/src/components/console/platforms/slack/refresh-notice.test.ts
@@ -45,6 +45,31 @@ describe('slackRefreshNoticeState: optional capabilities', () => {
     expect(state.needsAttention).toBe(false)
   })
 
+  // The gap this fixes: an install predating a release is short on BOTH sets, `reinstall_required`
+  // won the branch, and the capability half was never mentioned — so the operator added the
+  // required scopes, reinstalled, and came back to find the tools still off.
+  it('names both halves when required and optional scopes are missing', () => {
+    const state = slackRefreshNoticeState({
+      ...healthy,
+      authorization: 'reinstall_required',
+      missingScopes: ['commands', 'im:write'],
+      missingCapabilityScopes: ['search:read.public']
+    } as never)
+    expect(state.message).toContain('required and optional')
+    expect(state.needsAttention).toBe(true)
+  })
+
+  it('tells an unsynced both-missing install to add every scope first', () => {
+    const state = slackRefreshNoticeState({
+      ...healthy,
+      manifest: 'manual_update_required',
+      authorization: 'reinstall_required',
+      missingScopes: ['commands'],
+      missingCapabilityScopes: ['canvases:write']
+    } as never)
+    expect(state.message).toContain('every missing scope below')
+  })
+
   it('sends an unsynced manifest to the permissions page instead', () => {
     const state = slackRefreshNoticeState({
       ...healthy,

--- a/packages/web/src/components/console/platforms/slack/refresh-notice.ts
+++ b/packages/web/src/components/console/platforms/slack/refresh-notice.ts
@@ -53,6 +53,14 @@ export function slackRefreshNoticeState(result: SlackBotRefreshDto): SlackRefres
       'Slack rejected the stored bot token. Reinstall the app if needed, then recreate this integration with the current Bot User OAuth Token.'
   } else if (result.authorization === 'app_mismatch') {
     message = 'The stored bot token belongs to a different Slack app. Recreate this integration with matching tokens.'
+  } else if (result.authorization === 'reinstall_required' && capabilityGap) {
+    // Both halves missing — the common case for an install predating a release. Ahead of the
+    // plain reinstall branches so it actually wins, and worded so the required scopes do not
+    // read as the whole list: the scope line beside this message now carries the union.
+    message =
+      result.manifest === 'synced'
+        ? 'Slack app configuration is synced. Reinstall it to grant every missing scope, required and optional.'
+        : 'Add every missing scope below in Slack’s OAuth & Permissions page, then reinstall the app.'
   } else if (result.authorization === 'reinstall_required' && result.manifest === 'synced') {
     message = 'Slack app configuration is synced. Reinstall it to grant the missing scopes.'
   } else if (result.authorization === 'reinstall_required') {

--- a/packages/web/src/components/console/platforms/slack/settings.tsx
+++ b/packages/web/src/components/console/platforms/slack/settings.tsx
@@ -272,6 +272,10 @@ function SlackRefreshNotice({
     builtin && result.authorization === 'invalid'
       ? 'Slack rejected this workspace authorization. Reinstall the app to reconnect it.'
       : defaultMessage
+  // ONE list. Required and capability scopes are separate fields because they mean different
+  // things to `authorization`, but an operator adding them in Slack does it in a single pass —
+  // and reporting only the required half sent them back for a second round.
+  const missingScopes = [...result.missingScopes, ...(result.missingCapabilityScopes ?? [])]
 
   return (
     <div
@@ -283,9 +287,7 @@ function SlackRefreshNotice({
     >
       <span className="min-w-0">
         <span>{message}</span>
-        {result.missingScopes.length > 0 && (
-          <span className="mono ml-1 text-[11px]">Missing: {result.missingScopes.join(', ')}</span>
-        )}
+        {missingScopes.length > 0 && <span className="mono ml-1 text-[11px]">Missing: {missingScopes.join(', ')}</span>}
       </span>
       {action?.label === 'Reinstall workspace' && onReinstall ? (
         <button


### PR DESCRIPTION
#1651 reported the capability gap only when the required set was already complete. The common case is neither: an install predating a release is short on **both**, `reinstall_required` wins the branch, and the capability half goes unmentioned.

The operator adds the required scopes, reinstalls, and comes back to find the tools still off — a second round for something one pass should have covered.

Found on a live install whose console said:

```
Missing: commands, im:write, mpim:history, mpim:read
```

…while nine capability scopes were also absent and never named.

## The change

The scope line now renders the **union** of both fields.

They stay separate in the API on purpose — they mean different things to `authorization`: one decides whether the install is broken, the other only what is switched off. But an operator adding them in Slack's OAuth & Permissions page does it in a single pass, so the display is the right place to join them, not the contract.

A combined message goes ahead of the plain reinstall branches, worded so the required scopes no longer read as the whole list: *"Reinstall it to grant every missing scope, required and optional."*

## Verification

`typecheck`, `lint`, `format:check` clean. Two new cases in `refresh-notice.test.ts` — both halves missing on a synced manifest, and the add-them-first variant when it is unsynced — alongside the existing 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
