### PR TITLE
fix(daemon): read a memory component dropped mid-walk as absent, not an escape

### DIFF
--- a/packages/daemon/src/memory/fs.ts
+++ b/packages/daemon/src/memory/fs.ts
@@ -127,6 +127,21 @@ function sameFileVersion(a: Stats, b: Stats): boolean {
 }
 
 /**
+ * A failed containment check is an escape only when the path is still there. Windows resolves a
+ * component a concurrent rm already unlinked to a path outside the root, so re-probe before calling
+ * a benign race a violation; a dropped component is absence, which is data on the read side.
+ */
+async function rejectEscape(path: string, create: boolean): Promise<null> {
+  try {
+    await fsp.lstat(path)
+  } catch (err) {
+    if (!vanished(err) || create) throw err
+    return null
+  }
+  throw new MemoryPathError('path resolves outside the memory root')
+}
+
+/**
  * Canonicalise `parts` under `root` one component at a time, refusing symlink components; with
  * `create` missing components are made along the way. `null` when a component is absent (read side).
  */
@@ -167,7 +182,7 @@ async function walkContained(root: string, parts: string[], create: boolean): Pr
       if (!vanished(err) || create) throw err
       return null
     }
-    if (!under(realRoot, parent)) throw new MemoryPathError('path resolves outside the memory root')
+    if (!under(realRoot, parent)) return rejectEscape(candidate, create)
   }
   return parent
 }
@@ -232,7 +247,7 @@ export async function atomicWriteContainedMemoryFile(
   }
   const temp = join(parent, `.agentconnect-memory-${randomUUID()}.tmp`)
   try {
-    if ((await fsp.realpath(parent)) !== parent) throw new MemoryPathError('path resolves outside the memory root')
+    if ((await fsp.realpath(parent)) !== parent) await rejectEscape(parent, true)
     await fsp.writeFile(temp, content, { encoding: 'utf8', flag: 'wx', ...(mode === undefined ? {} : { mode }) })
     if (ifMatchMtime && current.stat) {
       let latest: Stats
@@ -248,7 +263,7 @@ export async function atomicWriteContainedMemoryFile(
         throw new MemoryConflictError('the memory file changed since it was read; reload and retry')
       }
     }
-    if ((await fsp.realpath(parent)) !== parent) throw new MemoryPathError('path resolves outside the memory root')
+    if ((await fsp.realpath(parent)) !== parent) await rejectEscape(parent, true)
     await publishOverTarget(temp, target)
   } finally {
     await fsp.rm(temp, { force: true }).catch(() => {})

--- a/packages/daemon/test/memory-fs.test.ts
+++ b/packages/daemon/test/memory-fs.test.ts
@@ -1,7 +1,7 @@
-import { afterAll, describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it, vi } from 'vitest'
 import { promises as fsp, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, parse } from 'node:path'
 import {
   LocalMemoryFs,
   MemoryConflictError,
@@ -74,6 +74,30 @@ describe('LocalMemoryFs (the port over this disk)', () => {
       await expect(fs.writeFile('linked/x', 'y')).rejects.toBeInstanceOf(MemoryPathError)
     }
   )
+
+  // A cancel-wins dream drops its staging while the review screen is listing it, and Windows resolves
+  // the already-unlinked directory to a path OUTSIDE the root instead of failing with ENOENT. The
+  // realpath stub stands in for that, with and without the rm, since only the still-present one escaped.
+  it('reads a component dropped mid-walk as absent, and still refuses one that resolves outside the root', async () => {
+    const root = tempRoot()
+    const fs = new LocalMemoryFs(root)
+    await fs.writeFile('staged/memory/MEMORY.md', '# idx')
+    const staged = join(await fsp.realpath(root), 'staged')
+    let dropOnResolve = false
+    const realpath = fsp.realpath
+    const spy = vi.spyOn(fsp, 'realpath').mockImplementation((async (path: string) => {
+      if (path !== staged) return realpath(path)
+      if (dropOnResolve) rmSync(staged, { recursive: true, force: true })
+      return parse(staged).root
+    }) as unknown as typeof fsp.realpath)
+    try {
+      await expect(fs.readdir('staged/memory')).rejects.toBeInstanceOf(MemoryPathError)
+      dropOnResolve = true
+      expect(await fs.readdir('staged/memory')).toEqual([])
+    } finally {
+      spy.mockRestore()
+    }
+  })
 
   it('renames (false when absent), removes recursively, sets mtimes, and round-trips bytes as base64', async () => {
     const fs = new LocalMemoryFs(tempRoot())


### PR DESCRIPTION
## The failure

`Unit Test (Windows)` fails intermittently in
`packages/daemon/test/dream-runner.test.ts` > "cancel-wins when it lands during
staging: no completed status, staging removed":

```
MemoryPathError: path resolves outside the memory root
  ❯ walkContained src/memory/fs.ts:170:41
  ❯ LocalMemoryFs.readdir src/memory/fs.ts:320:17
  ❯ resolveStagedDir src/dream/runner.ts:262:8
  ❯ DreamRunner.stagedFiles src/dream/runner.ts:1737:17
```

It is a flake, not a regression: it failed on a PR whose diff touches no file
under `packages/daemon` (the job runs because `protocol` is in that package's
dependency closure), and a re-run of the identical commit passed.

## Cause

`walkContained` canonicalises the parent chain one component at a time and
rejects anything whose `realpath` lands outside the memory root. The check
assumed the only way to resolve outside the root is to escape it.

On Windows a component a concurrent `rm` has already unlinked can still
`realpath` successfully — to the volume root rather than to an `ENOENT` — so the
containment check fires on a benign deletion race. The `ENOENT`/`EPERM` catch one
line above it already handles the case where `realpath` fails; nothing handled
the case where it succeeds with a meaningless answer.

The cancel-wins test is exactly that race: cancel removes the dream's staging
while `stagedFiles()` is resolving it. Missing staging is *data* there — the
review screen wants `null`, which is the correct answer once cancel won — but the
containment check threw before the absence could be reported.

## Fix

A failed containment check is re-probed with `lstat` before it is called a
violation. Only a path that is still present has escaped; a dropped one is
absence, which stays data on the read side. A non-vanish `lstat` error is
rethrown as itself, so the strict answer is never traded for a swallowed one.

The write side's two re-verifications in `atomicWriteContainedMemoryFile` go
through the same helper — same shape of race (a cancel removing staging while the
dream writes into it), same wrong label — so a concurrent `rm` during a publish
now surfaces as its own errno instead of a false security signal.

The security property is unchanged: symlink components are still refused by the
`lstat` above, and a component that resolves outside the root *and is still there*
still raises `MemoryPathError`.

## On the normalisation question

Both sides of the comparison were already symmetric, so no change was needed
there: `realRoot` and each `parent` are both `fsp.realpath` outputs (canonical
long form, on-disk case), the root is resolved once per walk rather than cached
(a cached root could go stale under a rename), and `path.win32.relative` is
case-insensitive. Verified against `path.win32`: differing case is contained,
while the volume root, a short-form (`8.3`) path and another drive are not. The
vanished component was the whole defect.

## Test

`test/memory-fs.test.ts` gains a case that stubs `realpath` to stand in for the
Windows resolution, asserting both directions — a component dropped mid-walk
reads as absent, one that is still present still raises `MemoryPathError`. It
runs on Windows too (the file is not in `WINDOWS_EXCLUDED`).

Against the unfixed source it reproduces CI exactly, down to the frames and
columns:

```
MemoryPathError: path resolves outside the memory root
 ❯ walkContained src/memory/fs.ts:170:41
 ❯ LocalMemoryFs.readdir src/memory/fs.ts:320:17
```

## Verification

`typecheck`, `eslint` and `prettier` clean. Full daemon unit suite run locally on
macOS: 5168 passed. The 14 failures are pre-existing — the identical set fails on
an unmodified tree at the same commit (`shim-cancellation`, `shim-exec-handler`
and `shim-workspace-files`, all sandbox-pod-plane files, plus `acp-matrix`, which
needs live runtimes and failed on an upstream billing error).

I could not reach a Windows runner locally, so the Windows behaviour itself rests
on CI.
