### PR TITLE
fix(daemon): read a workspace path dropped mid-resolve as absent, not an escape

### DIFF
--- a/packages/daemon/src/workspace/workspace-files.ts
+++ b/packages/daemon/src/workspace/workspace-files.ts
@@ -96,6 +96,19 @@ function isErrno(err: unknown, code: string): boolean {
   return (err as NodeJS.ErrnoException | null)?.code === code
 }
 
+/** Dropped by a concurrent rm: ENOENT, or the EPERM Windows answers while an unlinked entry is delete-pending. */
+function vanished(err: unknown): boolean {
+  return isErrno(err, 'ENOENT') || (process.platform === 'win32' && isErrno(err, 'EPERM'))
+}
+
+/** A failed containment check is an escape only while the path is STILL there: Windows resolves one a
+ *  concurrent rm already unlinked to a path outside the root, and that race is absence, not a violation.
+ *  Re-probe and let the probe's own error travel, so absence keeps the caller's `exists:false` answer. */
+async function rejectEscape(p: string): Promise<never> {
+  await fs.lstat(p)
+  throw new WorkspaceViolationError('path resolves outside the workspace root', 'path-escape')
+}
+
 function under(root: string, p: string): boolean {
   return p === root || p.startsWith(root + path.sep)
 }
@@ -134,15 +147,13 @@ export async function canonicalWorkspacePath(root: string, relPath: string): Pro
   }
   try {
     const canon = await fs.realpath(resolved)
-    if (!under(realRoot, canon)) {
-      throw new WorkspaceViolationError('path resolves outside the workspace root', 'path-escape')
-    }
+    if (!under(realRoot, canon)) return await rejectEscape(resolved)
     if (containsGitInternals(path.relative(realRoot, canon))) {
       throw new WorkspaceViolationError('git internals are not readable', 'git-internals')
     }
     return canon
   } catch (err) {
-    if (!isErrno(err, 'ENOENT')) throw err
+    if (!vanished(err)) throw err
   }
   // The leaf is absent, which is data — but the CHAIN above it still has to be checked, or
   // "outside and present" (rejected) and "outside and absent" (exists:false) remain two
@@ -152,13 +163,11 @@ export async function canonicalWorkspacePath(root: string, relPath: string): Pro
   for (;;) {
     try {
       const canon = await fs.realpath(ancestor)
-      if (!under(realRoot, canon) && canon !== realRoot) {
-        throw new WorkspaceViolationError('path resolves outside the workspace root', 'path-escape')
-      }
+      if (!under(realRoot, canon) && canon !== realRoot) return await rejectEscape(ancestor)
       return null
     } catch (err) {
       if (err instanceof WorkspaceViolationError) throw err
-      if (!isErrno(err, 'ENOENT')) throw err
+      if (!vanished(err)) throw err
       const up = path.dirname(ancestor)
       // Ran out of chain without finding anything real: nothing to escape through.
       if (up === ancestor) return null
@@ -188,8 +197,7 @@ async function resolveContained(root: string, relPath: string): Promise<{ resolv
  *  out and is rejected here). Returns the canonical path used for I/O. */
 async function canonicalUnder(realRoot: string, abs: string): Promise<string> {
   const canon = await fs.realpath(abs)
-  if (!under(realRoot, canon))
-    throw new WorkspaceViolationError('path resolves outside the workspace root', 'path-escape')
+  if (!under(realRoot, canon)) return rejectEscape(abs)
   if (containsGitInternals(path.relative(realRoot, canon))) {
     throw new WorkspaceViolationError('git internals are not readable', 'git-internals')
   }
@@ -267,7 +275,7 @@ export const localWorkspaceFiles: WorkspaceFiles = {
     try {
       target = await canonicalUnder(realRoot, resolved)
     } catch (err) {
-      if (isErrno(err, 'ENOENT')) return notFound
+      if (vanished(err)) return notFound
       throw err
     }
 
@@ -451,7 +459,7 @@ export const localWorkspaceFiles: WorkspaceFiles = {
     try {
       target = await canonicalUnder(realRoot, resolved)
     } catch (err) {
-      if (isErrno(err, 'ENOENT')) throw changedFile()
+      if (vanished(err)) throw changedFile()
       throw err
     }
 
@@ -518,7 +526,7 @@ export const localWorkspaceFiles: WorkspaceFiles = {
     try {
       target = await canonicalUnder(realRoot, resolved)
     } catch (err) {
-      if (isErrno(err, 'ENOENT')) throw changedFile()
+      if (vanished(err)) throw changedFile()
       throw err
     }
 

--- a/packages/daemon/src/workspace/workspace-files.ts
+++ b/packages/daemon/src/workspace/workspace-files.ts
@@ -332,13 +332,23 @@ export const localWorkspaceFiles: WorkspaceFiles = {
     // made a `?file=` naming a directory indistinguishable from an offline daemon.
     // Every OTHER non-regular target keeps the violation — a final-component
     // symlink is a containment matter and must not read as an ordinary answer.
+    if (!st.isDirectory() && !st.isFile()) throw new WorkspaceViolationError('not a regular file', 'not-a-file')
+
+    // Canonicalise FIRST, for BOTH answers, and re-verify (this catches an intermediate component
+    // swapped to a symlink after resolveContained). `lstat` follows intermediate components, so a
+    // symlinked directory inside the workspace would otherwise let the dir branch report the
+    // existence and mtime of a host directory outside it — the same oracle the git-diff seam had,
+    // reopened by making directories an ordinary answer. A target dropped under us here is absence.
+    let target: string
+    try {
+      target = await canonicalUnder(realRoot, resolved)
+    } catch (err) {
+      if (vanished(err)) return notFound
+      throw err
+    }
+
     if (st.isDirectory()) {
-      // Canonicalise FIRST. `lstat` follows intermediate components, so a symlinked
-      // directory inside the workspace would otherwise let this branch report the
-      // existence and mtime of a host directory outside it — the same oracle the
-      // git-diff seam had, reopened by making directories an ordinary answer.
-      const dir = await canonicalUnder(realRoot, resolved)
-      const canonSt = await fs.lstat(dir)
+      const canonSt = await fs.lstat(target)
       return {
         agentId: req.agentId,
         path: req.path,
@@ -347,11 +357,7 @@ export const localWorkspaceFiles: WorkspaceFiles = {
         mtime: canonSt.mtime.toISOString()
       }
     }
-    if (!st.isFile()) throw new WorkspaceViolationError('not a regular file', 'not-a-file')
 
-    // Canonicalise and re-verify (catches an intermediate component swapped to
-    // a symlink after resolveContained), then read the canonical path.
-    const target = await canonicalUnder(realRoot, resolved)
     const size = st.size
     const mtime = st.mtime.toISOString()
     const fh = await fs.open(target, 'r')

--- a/packages/daemon/test/shim-workspace-files.test.ts
+++ b/packages/daemon/test/shim-workspace-files.test.ts
@@ -197,11 +197,18 @@ describe('the shim read capability', () => {
       return parse(src).root
     }) as unknown as typeof fsp.realpath)
     const listSrc = () => localWorkspaceFiles.list(checkout, { agentId: AGENT, path: 'src', limit: 50 })
+    const readSrc = () => localWorkspaceFiles.read(checkout, { agentId: AGENT, path: 'src', offset: 0, limit: 50 })
+    const escape = { name: 'WorkspaceViolationError', reason: 'path-escape' }
     try {
-      await expect(listSrc()).rejects.toMatchObject({ name: 'WorkspaceViolationError', reason: 'path-escape' })
-      await expect(canonicalWorkspacePath(checkout, 'src')).rejects.toMatchObject({ reason: 'path-escape' })
+      await expect(listSrc()).rejects.toMatchObject(escape)
+      await expect(readSrc()).rejects.toMatchObject(escape)
+      await expect(canonicalWorkspacePath(checkout, 'src')).rejects.toMatchObject(escape)
+      // The stub drops the directory as it resolves it, so put it back for each of the three.
       dropOnResolve = true
       await expect(listSrc()).resolves.toMatchObject({ exists: false, entries: [] })
+      mkdirSync(src)
+      await expect(readSrc()).resolves.toMatchObject({ exists: false })
+      mkdirSync(src)
       expect(await canonicalWorkspacePath(checkout, 'src')).toBeNull()
     } finally {
       spy.mockRestore()

--- a/packages/daemon/test/shim-workspace-files.test.ts
+++ b/packages/daemon/test/shim-workspace-files.test.ts
@@ -1,7 +1,7 @@
-import { afterAll, describe, expect, it } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync, rmSync } from 'node:fs'
+import { afterAll, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, promises as fsp, readFileSync, symlinkSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, parse } from 'node:path'
 import type { WorkspaceListPage, WorkspaceReadContent, WorkspaceWriteOk } from '@agentconnect.md/protocol'
 import { createExecHandler } from '../src/shim/exec-handler.js'
 import {
@@ -11,6 +11,7 @@ import {
 } from '../src/shim/workspace-files-channel.js'
 import type { ShimRequester } from '../src/shim/channels.js'
 import {
+  canonicalWorkspacePath,
   localWorkspaceFiles,
   WorkspaceConflictError,
   WorkspaceViolationError
@@ -178,6 +179,33 @@ describe('the shim read capability', () => {
         })
       )
     expect(await ask('PRESENT.env')).toEqual(await ask('ABSENT.env'))
+  })
+
+  // Worktree cleanup and workspace conversion delete the tree under a reader, and Windows resolves an
+  // already-unlinked directory to a path OUTSIDE the root instead of failing with ENOENT — the realpath
+  // stub stands in for that. A deletion race is absence, so both directions are pinned: only a path
+  // that is still there is an escape.
+  it('reads a dropped directory as absent, and still refuses one that resolves outside the checkout', async () => {
+    const root = await fsp.realpath(volume().mount)
+    const checkout = join(root, 'repo')
+    const src = join(checkout, 'src')
+    let dropOnResolve = false
+    const realpath = fsp.realpath
+    const spy = vi.spyOn(fsp, 'realpath').mockImplementation((async (target: string) => {
+      if (target !== src) return realpath(target)
+      if (dropOnResolve) rmSync(src, { recursive: true, force: true })
+      return parse(src).root
+    }) as unknown as typeof fsp.realpath)
+    const listSrc = () => localWorkspaceFiles.list(checkout, { agentId: AGENT, path: 'src', limit: 50 })
+    try {
+      await expect(listSrc()).rejects.toMatchObject({ name: 'WorkspaceViolationError', reason: 'path-escape' })
+      await expect(canonicalWorkspacePath(checkout, 'src')).rejects.toMatchObject({ reason: 'path-escape' })
+      dropOnResolve = true
+      await expect(listSrc()).resolves.toMatchObject({ exists: false, entries: [] })
+      expect(await canonicalWorkspacePath(checkout, 'src')).toBeNull()
+    } finally {
+      spy.mockRestore()
+    }
   })
 
   it('enforces the scratch gate again where the write lands', async () => {


### PR DESCRIPTION
`canonicalWorkspacePath` and `canonicalUnder` in `packages/daemon/src/workspace/workspace-files.ts`
both treated a failed containment check as proof of an escape. On Windows, `realpath` can answer for
a path a concurrent `rm` has already unlinked with one **outside** the root — the volume root —
instead of failing with `ENOENT`. The `under()` check then fires, and a benign deletion race
(worktree cleanup, a workspace conversion) surfaces as a `path-escape` violation instead of
"not found". The identical shape produced an intermittent Windows-only failure in the daemon memory
suite; this file has not been observed failing, but the workspace tree is deleted concurrently in
normal operation.

## The fix

Re-probe with `lstat` before calling it an escape. Only a path that is **still there** is an escape;
one that has vanished is absence, and keeps the caller's existing "absent is data" answer:

- `canonicalWorkspacePath` falls through to the ancestor walk exactly as an `ENOENT` from `realpath`
  already did, so the chain above the leaf is still verified and "outside and present" versus
  "outside and absent" stay one answer.
- `canonicalUnder` lets the probe's own error travel, so a listing answers `exists:false` and an
  edit or delete answers with a conflict, as they do for any other missing path.

A non-vanish `lstat` error is rethrown as itself. The three catches around `canonicalUnder` now read
a vanish through one predicate (`ENOENT`, plus the `EPERM` Windows gives while an unlinked entry is
delete-pending), so the delete-pending case lands as absence too.

## Test

`reads a dropped directory as absent, and still refuses one that resolves outside the checkout` in
`packages/daemon/test/shim-workspace-files.test.ts` stubs `realpath` to return an out-of-root path —
with and without deleting the directory first — and pins both directions, for the exported
`canonicalWorkspacePath` and for a listing through `canonicalUnder`. It fails on the old code (the
dropped directory rejects with `path-escape`) and passes on the new.

`packages/daemon/src/skills/skill-source-snapshot.ts` was checked for the same pattern:
`assertExpectedRealPath` does compare a `realpath` result against an expected path and raise a
link-shaped refusal, but every disappearing entry already aborts the snapshot through the
surrounding `lstat`/`readdir`, and no caller distinguishes the error. There is no "absent is data"
answer to preserve there, so it is left alone.

Verified: `pnpm --filter @agentconnect.md/daemon typecheck`, eslint and prettier on both files, and
the workspace/memory suites. The 7 failures in `shim-workspace-files.test.ts` on this machine are
pre-existing on `main` (macOS-only, the fd descent through the `/var` symlink) and are unchanged by
this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
