### PR TITLE
fix(slack): declare im:read — conversations.info needs it for a DM

### DIFF
--- a/packages/control-plane/src/http/slack-manifest.test.ts
+++ b/packages/control-plane/src/http/slack-manifest.test.ts
@@ -114,6 +114,7 @@ describe('buildInstallManifest', () => {
       'groups:history',
       'groups:read',
       'im:history',
+      'im:read',
       'im:write',
       'mpim:history',
       'mpim:read',

--- a/packages/protocol/src/slack-app-manifest.ts
+++ b/packages/protocol/src/slack-app-manifest.ts
@@ -36,6 +36,12 @@ export const SLACK_BOT_SCOPES = [
   'groups:history',
   'groups:read',
   'im:history',
+  // `conversations.info` needs one of channels/groups/im/mpim `:read` PER CONVERSATION TYPE,
+  // and this one was the gap: the other three were declared and the DM arm was not. It is not
+  // cosmetic — `sendMessage` into a DM asks `getChannelInfo` whether the target is one, and a
+  // refused lookup falls back to "not a DM", which keys the outbound session as a channel
+  // thread while the inbound messages key it as a DM, so the conversation forks.
+  'im:read',
   'im:write',
   'mpim:history',
   'mpim:read',

--- a/packages/web/src/components/console/platforms/slack/manifest.test.ts
+++ b/packages/web/src/components/console/platforms/slack/manifest.test.ts
@@ -27,6 +27,7 @@ describe('manifest parity with the Control Plane', () => {
       'groups:history',
       'groups:read',
       'im:history',
+      'im:read',
       'im:write',
       'mpim:history',
       'mpim:read',


### PR DESCRIPTION
`conversations.info` takes one of `channels:read` / `groups:read` / `im:read` / `mpim:read` depending on the conversation type. The manifest declared three of the four and omitted the DM arm.

**Not cosmetic.** `sendMessage` into a DM asks `getChannelInfo` whether the target is one, and that lookup is deliberately written to fall back rather than fail a send that already happened — so a refused call reads as *not a DM*. The outbound session is then keyed as a channel thread while the inbound messages key it as a DM, and the conversation forks. `getCurrentChannel` in a DM also loses its `name` and `isIm`.

Found by diffing our scope list against two comparable Slack apps. Three signals agreed: Slack's own scope table for the method, our test workspace app which someone had already added `im:read` to by hand, and both of those apps carrying it.

This is the scope-arrives-with-its-feature rule from #1655 holding rather than bending — the consumer shipped long ago and only the grant was missed.

Verification: `typecheck`, `lint`, `format:check` clean; CP manifest unit 18, web console platform 21, both drift guards updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)