### PR TITLE
docs(readme): use staging contributors image

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ conventions, the monorepo layout, and the deeper design documentation.
 Thanks to everyone who has already contributed:
 
 <a href="https://github.com/agentconnect-md/agentconnect/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=agentconnect-md/agentconnect" height="40" alt="AgentConnect contributors" />
+  <img src="https://stg.contrib.rocks/image?repo=agentconnect-md/agentconnect" height="40" alt="AgentConnect contributors" />
 </a>
 
 ## Architecture


### PR DESCRIPTION
## Summary

- switch the README contributor image to `stg.contrib.rocks` as a workaround for the stale production cache
- keep the contributor graph link and rendered layout unchanged

## Validation

- staging SVG returns all eight human contributors
- `git diff --check`
- pre-commit Prettier
- pre-push `eslint .`

Created by Codex . gpt-5.6-sol
