### PR TITLE
feat(relay): Linear platform ingress plugin

### DIFF
--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -355,9 +355,36 @@ describe('toBotAssignment (§6.7 open secrets reader)', () => {
     expect(f?.secrets).toEqual({ verificationToken: 'v', encryptKey: 'k' })
   })
 
-  it('refuses (null) a secret bag neither typed shape matches — log-and-skip, never a throw', () => {
+  it('refuses (null) a secret bag no shape matches — log-and-skip, never a throw', () => {
+    // No botToken, no verificationToken, no signingSecret: nothing here is a credential the
+    // relay knows how to verify with, so the bot is skipped rather than half-installed.
     expect(toBotAssignment({ ...base, secrets: { apiKey: 'k-1' } } as never)).toBeNull()
+    expect(toBotAssignment({ ...base, secrets: {} } as never)).toBeNull()
+  })
+
+  it('refuses a HALF-FILLED Slack bag rather than promoting it to the signing-secret shape', () => {
+    // A present-but-unusable botToken means the projector meant the Slack pair and lost half of
+    // it. Falling through to the third shape would install an ingest that can never post.
     expect(toBotAssignment({ ...base, secrets: { botToken: 'xoxb-only' } } as never)).toBeNull()
+    expect(toBotAssignment({ ...base, secrets: { botToken: null, signingSecret: 'sig' } } as never)).toBeNull()
+  })
+
+  it('maps the signing-secret-ONLY shape, carrying the generic ingress slots the plugin reads', () => {
+    // A relay-verified platform whose every write lives on the daemon hands the relay no provider
+    // token — only the webhook signing secret, plus the identity core indexes and fences on.
+    const a = toBotAssignment({
+      ...base,
+      platform: 'linear',
+      secrets: { signingSecret: 'sig' },
+      ingress: { apiAppId: 'client-1', teamId: 'org-1', botUserId: 'app-user-1' }
+    } as never)
+    expect(a?.secrets).toEqual({ signingSecret: 'sig' })
+    expect(a).toMatchObject({ apiAppId: 'client-1', teamId: 'org-1', botUserId: 'app-user-1' })
+  })
+
+  it('refuses a signingSecret that is not a string — never a demux key the mapper guessed', () => {
+    expect(toBotAssignment({ ...base, secrets: { signingSecret: 42 } } as never)).toBeNull()
+    expect(toBotAssignment({ ...base, secrets: { signingSecret: null } } as never)).toBeNull()
   })
 
   // §6.7: the opaque ingress bag is the ONE carrier of the demux identity. The

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -24,7 +24,12 @@ export interface BotAssignment {
   // S1a open reader (protocol route.ts Platform policy): the wire field is an
   // open string; the assign handler refuses an unsupported platform gracefully.
   platform: string
-  secrets: { botToken: string; signingSecret: string } | { verificationToken: string; encryptKey?: string }
+  // The third shape is the signing-secret-ONLY bag: a relay-verified platform whose every write
+  // lives on the daemon has no provider token to hand the relay, only the webhook signing secret.
+  secrets:
+    | { botToken: string; signingSecret: string }
+    | { verificationToken: string; encryptKey?: string }
+    | { signingSecret: string }
   /** Provider app id — the O(1) HTTP demux key when present. */
   apiAppId?: string
   /** Slack workspace id (== Events API `team_id`). Present ⇒ this bot is one
@@ -597,7 +602,12 @@ export function toBotAssignment(a: RcBotAssign): BotAssignment | null {
             verificationToken: a.secrets.verificationToken,
             ...(typeof a.secrets.encryptKey === 'string' ? { encryptKey: a.secrets.encryptKey } : {})
           }
-        : null
+        : // §6.7 third shape — signing secret alone, from a platform whose egress is entirely the
+          // daemon's. The ABSENT `botToken` is what separates it from a half-filled Slack bag: a
+          // present-but-unusable token must still fail closed rather than fall through to here.
+          !('botToken' in a.secrets) && 'signingSecret' in a.secrets && typeof a.secrets.signingSecret === 'string'
+          ? { signingSecret: a.secrets.signingSecret }
+          : null
   if (!secrets) return null
   // §6.7: the opaque ingress bag is the ONE carrier of the demux identity. The
   // named top-level twins left the wire schema with the S3 protocol cleanup

--- a/packages/relay/src/hooks/rate-limit.ts
+++ b/packages/relay/src/hooks/rate-limit.ts
@@ -27,8 +27,10 @@ export class HookRateLimiter {
   private readonly refillPerSec: number
   private readonly maxEntries: number
 
+  // Only `now()` is read — narrowed so a caller holding a read-only clock (the platform
+  // ingress host, which exposes no timers) can reuse this limiter instead of forking one.
   constructor(
-    private readonly clock: Clock,
+    private readonly clock: Pick<Clock, 'now'>,
     opts: HookRateLimiterOpts = {}
   ) {
     this.capacity = opts.capacity ?? 10

--- a/packages/relay/src/platforms/linear/http-ingest.ts
+++ b/packages/relay/src/platforms/linear/http-ingest.ts
@@ -6,7 +6,8 @@ import type { WireNormalizedMessage } from '@agentconnect.md/protocol'
 import { truncateUtf8 } from '../../hooks/github-ingress.js'
 import { HookRateLimiter } from '../../hooks/rate-limit.js'
 
-/** Replay window on the `Linear-Timestamp` header, which carries epoch MILLISECONDS. */
+// Replay window on the SIGNED `webhookTimestamp` (epoch MILLISECONDS). The `Linear-Timestamp`
+// header mirrors it but sits outside the HMAC, so only the body's copy can bound a replay.
 export const LINEAR_TIMESTAMP_WINDOW_MS = 60_000
 
 /** Hard cap on one delivery's raw body (§6.1). */
@@ -58,6 +59,8 @@ const LinearAgentActivity = z.object({
   signal: z.string().nullish(),
   sourceCommentId: z.string().nullish(),
   content: z.object({ type: z.string().optional(), body: z.string().optional() }).nullish(),
+  // Live deliveries nest the prompt under `content`; Linear's docs describe a top-level `body`.
+  body: z.string().nullish(),
   user: z.object({ id: z.string().optional(), name: z.string().optional() }).nullish()
 })
 
@@ -113,10 +116,18 @@ function signatureIsValid(signingSecret: string, rawBody: Buffer, header: string
   return presented.length === expected.length && timingSafeEqual(presented, expected)
 }
 
-function timestampInWindow(header: string | undefined, now: number): boolean {
-  if (!header || !/^\d+$/.test(header)) return false
-  const ms = Number(header)
-  return Number.isSafeInteger(ms) && Math.abs(now - ms) <= LINEAR_TIMESTAMP_WINDOW_MS
+// Freshness is decided by the SIGNED timestamp alone. An absent or non-integer one is stale by
+// definition: without it a captured body replays forever under whatever header the attacker sends.
+function freshSignedTimestamp(signedMs: number | undefined, now: number): number | undefined {
+  if (signedMs === undefined || !Number.isSafeInteger(signedMs)) return undefined
+  return Math.abs(now - signedMs) <= LINEAR_TIMESTAMP_WINDOW_MS ? signedMs : undefined
+}
+
+// The unsigned header is a CROSS-CHECK, never an authority: it can only reject a delivery the
+// signed timestamp already admitted, and its absence is fine because it proves nothing either way.
+function headerContradictsSignedTimestamp(header: string | undefined, signedMs: number): boolean {
+  if (header === undefined) return false
+  return !/^\d+$/.test(header) || Number(header) !== signedMs
 }
 
 /** Content-derived dedup identity (§4.5) — stable across Linear's 1 min/1 h/6 h redeliveries. */
@@ -182,7 +193,10 @@ function budgetContext(
 // The member's instruction must be readable as TEXT, never only inside the fenced prompt
 // context (§6.3): the follow-up body verbatim, else the delegation line the session opened with.
 function instructionText(event: LinearAgentSessionEvent): string {
-  if (event.action === 'prompted') return event.agentActivity?.content?.body ?? ''
+  // Tolerant reader: live deliveries nest the prompt under `content`, the docs name a top-level
+  // `body`. Either wire shape must yield the instruction, so read both rather than picking one.
+  const activity = event.agentActivity
+  if (event.action === 'prompted') return activity?.content?.body ?? activity?.body ?? ''
   const session = event.agentSession
   return session.comment?.body?.trim() || session.issue?.title || session.summary || ''
 }
@@ -267,9 +281,10 @@ export class LinearHttpIngest {
     return this.limiter.allow(this.botId)
   }
 
-  // Authenticate one delivery and derive its typed product exactly once: signature over the exact
-  // request bytes, then the replay window on the `Linear-Timestamp` HEADER. The body's
-  // `webhookTimestamp` mirrors that header but is only ever read for reporting, never to verify.
+  // Authenticate one delivery and derive its typed product exactly once. The order is the whole
+  // security argument: HMAC over the exact request bytes, THEN parse, THEN bound replay on the
+  // signed `webhookTimestamp` — the only timestamp an attacker replaying a captured body and
+  // signature cannot refresh. Everything the branch reads afterwards is signed material.
   decode(
     rawBody: Buffer,
     body: unknown,
@@ -277,9 +292,11 @@ export class LinearHttpIngest {
     now: number
   ): VerifiedLinearDelivery | undefined {
     if (!signatureIsValid(this.signingSecret, rawBody, headerString(headers['linear-signature']))) return undefined
-    if (!timestampInWindow(headerString(headers['linear-timestamp']), now)) return undefined
     const envelope = LinearEnvelope.safeParse(body)
     if (!envelope.success) return undefined
+    const signedMs = freshSignedTimestamp(envelope.data.webhookTimestamp, now)
+    if (signedMs === undefined) return undefined
+    if (headerContradictsSignedTimestamp(headerString(headers['linear-timestamp']), signedMs)) return undefined
     // Tenant-scoped demux (§6.1/§12): every sibling install of the deployment app shares this
     // signing secret, so the payload's own identity is the only thing separating workspaces.
     if (envelope.data.organizationId !== this.identity.organizationId) return undefined
@@ -288,9 +305,7 @@ export class LinearHttpIngest {
     }
     // `Linear-Event` is outside the HMAC, so the branch is taken on the SIGNED body's own type.
     if (envelope.data.type === 'OAuthApp' && envelope.data.action === 'revoked') {
-      const at = envelope.data.webhookTimestamp
-      const eventAtMs = typeof at === 'number' && Number.isFinite(at) ? Math.trunc(at) : undefined
-      return { kind: 'revoked', ...(eventAtMs !== undefined && eventAtMs >= 0 ? { eventAtMs } : {}) }
+      return { kind: 'revoked', ...(signedMs >= 0 ? { eventAtMs: signedMs } : {}) }
     }
     if (envelope.data.type !== 'AgentSessionEvent') return { kind: 'ignored' }
     const parsed = LinearAgentSessionEvent.safeParse(body)

--- a/packages/relay/src/platforms/linear/http-ingest.ts
+++ b/packages/relay/src/platforms/linear/http-ingest.ts
@@ -1,0 +1,299 @@
+// Linear's per-bot HTTP ingest (linear-integration.md §6.1) — a PURE decoder: no socket to
+// open, no provider API calls, and no relay-side egress; the daemon owns every Linear write.
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import { z } from 'zod'
+import type { WireNormalizedMessage } from '@agentconnect.md/protocol'
+import { truncateUtf8 } from '../../hooks/github-ingress.js'
+import { HookRateLimiter } from '../../hooks/rate-limit.js'
+
+/** Replay window on the `Linear-Timestamp` header, which carries epoch MILLISECONDS. */
+export const LINEAR_TIMESTAMP_WINDOW_MS = 60_000
+
+/** Hard cap on one delivery's raw body (§6.1). */
+export const LINEAR_BODY_LIMIT = 1024 * 1024
+
+/** Byte budget shared by `promptContext` + `previousComments` in the adapter bag (§6.1). */
+export const LINEAR_CONTEXT_BUDGET_BYTES = 32 * 1024
+
+const LinearTeam = z.object({
+  id: z.string().optional(),
+  key: z.string().optional(),
+  name: z.string().optional()
+})
+
+const LinearIssue = z.object({
+  id: z.string(),
+  identifier: z.string().optional(),
+  title: z.string().optional(),
+  url: z.string().optional(),
+  team: LinearTeam.nullish()
+})
+
+// Only the fields the relay actually forwards survive parsing: the adapter bag is
+// model-visible on the daemon, so an unlisted field (a commenter's email) never rides along.
+const LinearPreviousComment = z.object({
+  id: z.string().optional(),
+  body: z.string().optional(),
+  userId: z.string().optional(),
+  createdAt: z.string().optional()
+})
+export type LinearPreviousComment = z.infer<typeof LinearPreviousComment>
+
+const LinearAgentSession = z.object({
+  id: z.string(),
+  creatorId: z.string().nullish(),
+  commentId: z.string().nullish(),
+  sourceCommentId: z.string().nullish(),
+  status: z.string().nullish(),
+  summary: z.string().nullish(),
+  url: z.string().nullish(),
+  comment: z.object({ id: z.string().optional(), body: z.string().optional() }).nullish(),
+  // Nullable by Linear's own schema — `app:mentionable` also covers documents (§4.5).
+  issue: LinearIssue.nullish()
+})
+
+const LinearAgentActivity = z.object({
+  id: z.string(),
+  // A STOP arrives as `prompted` with `signal: "stop"`, never as an action of its own.
+  signal: z.string().nullish(),
+  sourceCommentId: z.string().nullish(),
+  content: z.object({ type: z.string().optional(), body: z.string().optional() }).nullish(),
+  user: z.object({ id: z.string().optional(), name: z.string().optional() }).nullish()
+})
+
+export const LinearAgentSessionEvent = z.object({
+  type: z.literal('AgentSessionEvent'),
+  action: z.string(),
+  organizationId: z.string(),
+  oauthClientId: z.string(),
+  appUserId: z.string().nullish(),
+  agentSession: LinearAgentSession,
+  agentActivity: LinearAgentActivity.nullish(),
+  previousComments: z.array(LinearPreviousComment).nullish(),
+  guidance: z.string().nullish(),
+  promptContext: z.string().nullish(),
+  webhookTimestamp: z.number().nullish(),
+  webhookId: z.string().nullish()
+})
+export type LinearAgentSessionEvent = z.infer<typeof LinearAgentSessionEvent>
+
+// The pre-discrimination envelope: type/action pick the branch, and the identity pair is the
+// tenant-scoped demux the signature alone cannot perform.
+const LinearEnvelope = z.object({
+  type: z.string().optional(),
+  action: z.string().optional(),
+  organizationId: z.string().optional(),
+  oauthClientId: z.string().optional(),
+  webhookTimestamp: z.number().optional()
+})
+
+/** The plugin's typed verified product — derived exactly once, in `verify`. */
+export type VerifiedLinearDelivery =
+  | { kind: 'agent-session'; event: LinearAgentSessionEvent }
+  | { kind: 'revoked'; eventAtMs?: number }
+  | { kind: 'ignored' }
+
+/** Identity + credentials one workspace bot's ingest is built from (§6.2's two opaque bags). */
+export interface LinearIngestIdentity {
+  clientId: string
+  organizationId: string
+  appUserId?: string
+}
+
+function headerString(value: string | string[] | undefined): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+// Linear signs the exact request bytes as bare lowercase hex (no scheme prefix), so neither
+// shared primitive fits verbatim — the discipline is theirs: decode, length-check, compare.
+function signatureIsValid(signingSecret: string, rawBody: Buffer, header: string | undefined): boolean {
+  if (!header || !/^[0-9a-fA-F]+$/.test(header)) return false
+  const expected = createHmac('sha256', signingSecret).update(rawBody).digest()
+  const presented = Buffer.from(header, 'hex')
+  return presented.length === expected.length && timingSafeEqual(presented, expected)
+}
+
+function timestampInWindow(header: string | undefined, now: number): boolean {
+  if (!header || !/^\d+$/.test(header)) return false
+  const ms = Number(header)
+  return Number.isSafeInteger(ms) && Math.abs(now - ms) <= LINEAR_TIMESTAMP_WINDOW_MS
+}
+
+/** Content-derived dedup identity (§4.5) — stable across Linear's 1 min/1 h/6 h redeliveries. */
+export function linearDedupId(event: LinearAgentSessionEvent): string | undefined {
+  if (event.action === 'created') return `linear:${event.agentSession.id}:created`
+  if (event.action === 'prompted' && event.agentActivity) return `linear:${event.agentActivity.id}`
+  return undefined
+}
+
+/** True iff this `prompted` is the native stop signal rather than a follow-up message. */
+export function linearIsStop(event: LinearAgentSessionEvent): boolean {
+  return event.action === 'prompted' && event.agentActivity?.signal === 'stop'
+}
+
+/** §6.4 adapter-extension bag: opaque to relay core, round-tripped to the daemon's linear module. */
+export interface LinearAdapterExt {
+  agentSessionId: string
+  issueIdentifier?: string
+  issueTitle?: string
+  promptContext?: string
+  guidance?: string
+  previousComments?: LinearPreviousComment[]
+  truncated?: boolean
+}
+
+// Spend one shared byte budget on the two attacker-authored context fields, longest-lived
+// first: the prompt context, then as many previous comments as the remainder still affords.
+function budgetContext(
+  promptContext: string | undefined,
+  previousComments: LinearPreviousComment[] | undefined,
+  budgetBytes: number
+): { promptContext?: string; previousComments?: LinearPreviousComment[]; truncated: boolean } {
+  let remaining = budgetBytes
+  let truncated = false
+  let context: string | undefined
+  if (promptContext !== undefined) {
+    const cut = truncateUtf8(promptContext, remaining)
+    context = cut.text
+    truncated ||= cut.truncated
+    remaining -= Buffer.byteLength(cut.text, 'utf8')
+  }
+  let comments: LinearPreviousComment[] | undefined
+  if (previousComments && previousComments.length > 0) {
+    comments = []
+    for (const comment of previousComments) {
+      if (remaining <= 0) {
+        truncated = true
+        break
+      }
+      const cut = truncateUtf8(comment.body ?? '', remaining)
+      truncated ||= cut.truncated
+      remaining -= Buffer.byteLength(cut.text, 'utf8')
+      comments.push({ ...comment, body: cut.text })
+    }
+  }
+  return {
+    ...(context !== undefined ? { promptContext: context } : {}),
+    ...(comments !== undefined ? { previousComments: comments } : {}),
+    truncated
+  }
+}
+
+// The member's instruction must be readable as TEXT, never only inside the fenced prompt
+// context (§6.3): the follow-up body verbatim, else the delegation line the session opened with.
+function instructionText(event: LinearAgentSessionEvent): string {
+  if (event.action === 'prompted') return event.agentActivity?.content?.body ?? ''
+  const session = event.agentSession
+  return session.comment?.body?.trim() || session.issue?.title || session.summary || ''
+}
+
+// The human who delegated, mentioned, or replied. An unattributed session falls back to its own
+// id so the sender is never fabricated, never shared, and never `linear:undefined`.
+function actorId(event: LinearAgentSessionEvent): string {
+  const session = event.agentSession
+  return event.agentActivity?.user?.id ?? session.creatorId ?? session.id
+}
+
+// One verified `created`/`prompted` event as the message relay core arbitrates: `channel` is the
+// immutable issue UUID, falling back to the session UUID for the issue-less surfaces (§4.5).
+export function normalizeLinearEvent(
+  event: LinearAgentSessionEvent,
+  msgId: string,
+  appUserId: string | undefined
+): WireNormalizedMessage {
+  const session = event.agentSession
+  const issue = session.issue ?? undefined
+  const context = budgetContext(
+    event.promptContext ?? undefined,
+    event.previousComments ?? undefined,
+    LINEAR_CONTEXT_BUDGET_BYTES
+  )
+  const adapterExt: LinearAdapterExt = {
+    agentSessionId: session.id,
+    ...(issue?.identifier ? { issueIdentifier: issue.identifier } : {}),
+    ...(issue?.title ? { issueTitle: issue.title } : {}),
+    ...(context.promptContext !== undefined ? { promptContext: context.promptContext } : {}),
+    ...(event.guidance ? { guidance: event.guidance } : {}),
+    ...(context.previousComments !== undefined ? { previousComments: context.previousComments } : {}),
+    ...(context.truncated ? { truncated: true } : {})
+  }
+  const senderName = event.agentActivity?.user?.name
+  const eventAtMs = typeof event.webhookTimestamp === 'number' ? Math.trunc(event.webhookTimestamp) : undefined
+  return {
+    msgId,
+    traceId: msgId,
+    source: 'user',
+    platform: 'linear',
+    channel: issue?.id ?? session.id,
+    thread: session.id,
+    ...(issue?.url?.startsWith('https://') ? { threadUrl: issue.url } : {}),
+    sender: {
+      id: `linear:${actorId(event)}`,
+      isBot: false,
+      ...(senderName ? { name: senderName } : {})
+    },
+    text: instructionText(event),
+    // Every Linear event exists because the app was delegated to or mentioned (§6.1), so the
+    // arbitration ladder's "explicitly addressed" gate is satisfied by construction.
+    mentionedBots: appUserId ? [appUserId] : [],
+    isDm: false,
+    trigger: 'mention',
+    ...(eventAtMs !== undefined && eventAtMs > 0 ? { platformTimeMs: eventAtMs } : {}),
+    adapterExt: { linear: adapterExt }
+  }
+}
+
+// One workspace bot's callback verifier: it holds the deployment app's webhook signing secret
+// and nothing else — no access token, no client secret, no refresh token (§12).
+export class LinearHttpIngest {
+  private readonly limiter: HookRateLimiter
+
+  constructor(
+    readonly botId: string,
+    readonly identity: LinearIngestIdentity,
+    private readonly signingSecret: string,
+    private readonly now: () => number,
+    /** The generation THIS ingest was built from — the fence a revocation report carries. */
+    readonly credentialRevision?: number
+  ) {
+    this.limiter = new HookRateLimiter({ now: () => this.now() })
+  }
+
+  /** §8 RelayBotIngress: a pure decoder has nothing to release. */
+  stop(): void {}
+
+  /** Take one token from this bot's ingress bucket; false ⇒ drop the delivery (still 200). */
+  allow(): boolean {
+    return this.limiter.allow(this.botId)
+  }
+
+  // Authenticate one delivery and derive its typed product exactly once: signature over the exact
+  // request bytes, then the replay window on the `Linear-Timestamp` HEADER. The body's
+  // `webhookTimestamp` mirrors that header but is only ever read for reporting, never to verify.
+  decode(
+    rawBody: Buffer,
+    body: unknown,
+    headers: Record<string, string | string[] | undefined>,
+    now: number
+  ): VerifiedLinearDelivery | undefined {
+    if (!signatureIsValid(this.signingSecret, rawBody, headerString(headers['linear-signature']))) return undefined
+    if (!timestampInWindow(headerString(headers['linear-timestamp']), now)) return undefined
+    const envelope = LinearEnvelope.safeParse(body)
+    if (!envelope.success) return undefined
+    // Tenant-scoped demux (§6.1/§12): every sibling install of the deployment app shares this
+    // signing secret, so the payload's own identity is the only thing separating workspaces.
+    if (envelope.data.organizationId !== this.identity.organizationId) return undefined
+    if (envelope.data.oauthClientId !== undefined && envelope.data.oauthClientId !== this.identity.clientId) {
+      return undefined
+    }
+    // `Linear-Event` is outside the HMAC, so the branch is taken on the SIGNED body's own type.
+    if (envelope.data.type === 'OAuthApp' && envelope.data.action === 'revoked') {
+      const at = envelope.data.webhookTimestamp
+      const eventAtMs = typeof at === 'number' && Number.isFinite(at) ? Math.trunc(at) : undefined
+      return { kind: 'revoked', ...(eventAtMs !== undefined && eventAtMs >= 0 ? { eventAtMs } : {}) }
+    }
+    if (envelope.data.type !== 'AgentSessionEvent') return { kind: 'ignored' }
+    const parsed = LinearAgentSessionEvent.safeParse(body)
+    return parsed.success ? { kind: 'agent-session', event: parsed.data } : { kind: 'ignored' }
+  }
+}

--- a/packages/relay/src/platforms/linear/http-ingress.test.ts
+++ b/packages/relay/src/platforms/linear/http-ingress.test.ts
@@ -1,0 +1,168 @@
+import { createHmac } from 'node:crypto'
+import Fastify, { type FastifyInstance } from 'fastify'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { WireNormalizedMessage } from '@agentconnect.md/protocol'
+import { LinearHttpIngest, LINEAR_BODY_LIMIT } from './http-ingest.js'
+import { linearIngressPlugin } from './ingress-plugin.js'
+import { registerLinearHttpIngress } from './http-ingress.js'
+import type { RelayIngressHost, RelayInboundSeam } from '../contract.js'
+
+const NOW = 1_788_249_909_143
+const SIGNING_SECRET = 'lin_wh_00000000000000000000000000000000'
+const CLIENT_ID = '00000000000000000000000000000001'
+const ORG_ID = '00000000-0000-4000-8000-000000000001'
+const SIBLING_ORG_ID = '00000000-0000-4000-8000-000000000002'
+const SESSION_ID = '00000000-0000-4000-8000-0000000000s1'
+const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+function eventBody(sessionId = SESSION_ID, organizationId = ORG_ID) {
+  return {
+    type: 'AgentSessionEvent',
+    action: 'created',
+    organizationId,
+    oauthClientId: CLIENT_ID,
+    appUserId: '00000000-0000-4000-8000-0000000000a1',
+    agentSession: {
+      id: sessionId,
+      creatorId: '00000000-0000-4000-8000-0000000000u1',
+      comment: { body: 'please take a look' },
+      issue: { id: '00000000-0000-4000-8000-0000000000i1', identifier: 'AGE-5', title: 'Probe' }
+    },
+    previousComments: null,
+    guidance: null,
+    promptContext: '<issue identifier="AGE-5"/>',
+    webhookTimestamp: NOW
+  }
+}
+
+// Drive the REAL plugin (verify → handle) behind the route so the shipped 200/401 contract is
+// exercised end to end. Two ingests share ONE signing secret — the sibling-install shape.
+function makeApp(forward: (msg: WireNormalizedMessage) => Promise<void> = async () => {}) {
+  const messages: WireNormalizedMessage[] = []
+  const host = {
+    forward: async (_botId: string, msg: WireNormalizedMessage) => {
+      messages.push(msg)
+      await forward(msg)
+    },
+    dedupSeen: () => false,
+    reportRevoked: vi.fn(),
+    log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    clock: { now: () => NOW }
+  } as unknown as RelayIngressHost
+  const pool = [
+    new LinearHttpIngest('bot-1', { clientId: CLIENT_ID, organizationId: ORG_ID }, SIGNING_SECRET, () => NOW),
+    new LinearHttpIngest('bot-2', { clientId: CLIENT_ID, organizationId: SIBLING_ORG_ID }, SIGNING_SECRET, () => NOW)
+  ]
+  const served: string[] = []
+  const resolver: RelayInboundSeam = {
+    handleInbound: async (_platformId, rawBody, body, headers) => {
+      for (const ingest of pool) {
+        const verified = linearIngressPlugin.verify(
+          ingest,
+          rawBody,
+          body,
+          headers as Record<string, string | string[] | undefined>,
+          NOW
+        )
+        if (verified === undefined) continue
+        served.push(ingest.botId)
+        return linearIngressPlugin.handle(ingest, verified, host)
+      }
+      return undefined
+    }
+  }
+  const app = Fastify()
+  registerLinearHttpIngress(app, { manager: () => resolver, log })
+  return { app, messages, served }
+}
+
+function post(app: FastifyInstance, body: unknown, over: { secret?: string; timestamp?: number } = {}) {
+  const payload = JSON.stringify(body)
+  const signature = createHmac('sha256', over.secret ?? SIGNING_SECRET)
+    .update(Buffer.from(payload))
+    .digest('hex')
+  return app.inject({
+    method: 'POST',
+    url: '/linear/events',
+    headers: {
+      'content-type': 'application/json',
+      'linear-event': 'AgentSessionEvent',
+      'linear-delivery': '00000000-0000-4000-8000-0000000000d1',
+      'linear-signature': signature,
+      'linear-timestamp': String(over.timestamp ?? NOW)
+    },
+    payload
+  })
+}
+
+describe('Linear HTTP ingress route', () => {
+  let app: FastifyInstance | undefined
+
+  afterEach(async () => {
+    await app?.close()
+    app = undefined
+  })
+
+  it('answers 200 and forwards one normalized message', async () => {
+    const h = makeApp()
+    app = h.app
+    const response = await post(app, eventBody())
+    expect(response.statusCode).toBe(200)
+    await vi.waitFor(() => expect(h.messages).toHaveLength(1))
+    expect(h.messages[0]).toMatchObject({ platform: 'linear', thread: SESSION_ID })
+  })
+
+  it('serves each workspace from its OWN bot even though both verify the same signature', async () => {
+    const h = makeApp()
+    app = h.app
+    await post(app, eventBody(SESSION_ID, ORG_ID))
+    await post(app, eventBody(SESSION_ID, SIBLING_ORG_ID))
+    expect(h.served).toEqual(['bot-1', 'bot-2'])
+  })
+
+  it('answers 401 for a delivery no assigned bot owns — no oracle', async () => {
+    const h = makeApp()
+    app = h.app
+    const forged = await post(app, eventBody(), { secret: 'another-apps-secret' })
+    const unknownWorkspace = await post(app, eventBody(SESSION_ID, '00000000-0000-4000-8000-00000000000f'))
+    expect(forged.statusCode).toBe(401)
+    expect(unknownWorkspace.statusCode).toBe(401)
+    expect(forged.json()).toEqual(unknownWorkspace.json())
+    expect(h.messages).toHaveLength(0)
+  })
+
+  it('answers 400 for a body that is not JSON at all', async () => {
+    const h = makeApp()
+    app = h.app
+    const response = await app.inject({
+      method: 'POST',
+      url: '/linear/events',
+      headers: { 'content-type': 'application/json' },
+      payload: 'not-json'
+    })
+    expect(response.statusCode).toBe(400)
+  })
+
+  it('returns 200 BEFORE daemon delivery resolves (§6.1)', async () => {
+    let release = (): void => {}
+    const pending = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const h = makeApp(() => pending)
+    app = h.app
+    const response = await post(app, eventBody())
+    expect(response.statusCode).toBe(200)
+    release()
+    await pending
+  })
+
+  it('refuses a body over the 1 MiB cap', async () => {
+    const h = makeApp()
+    app = h.app
+    const oversized = eventBody()
+    ;(oversized.agentSession as Record<string, unknown>).comment = { body: 'x'.repeat(LINEAR_BODY_LIMIT) }
+    const response = await post(app, oversized)
+    expect(response.statusCode).toBe(413)
+    expect(h.messages).toHaveLength(0)
+  })
+})

--- a/packages/relay/src/platforms/linear/http-ingress.ts
+++ b/packages/relay/src/platforms/linear/http-ingress.ts
@@ -1,0 +1,32 @@
+// Linear's public callback route (§6.1). ONE static, shared URL: a Linear app configures
+// exactly one webhook URL, and the signature authenticates while the payload identity demuxes.
+import type { FastifyInstance } from 'fastify'
+import { LINEAR_BODY_LIMIT } from './http-ingest.js'
+import type { RelayIngressRouteDeps } from '../contract.js'
+
+export function registerLinearHttpIngress(app: FastifyInstance, deps: RelayIngressRouteDeps): void {
+  void app.register(async (scope) => {
+    // Raw buffer: the HMAC covers the exact request bytes, so the parser must not reserialize.
+    scope.addContentTypeParser(
+      'application/json',
+      { parseAs: 'buffer', bodyLimit: LINEAR_BODY_LIMIT },
+      (_req, body, done) => done(null, body)
+    )
+
+    scope.post('/linear/events', { bodyLimit: LINEAR_BODY_LIMIT }, async (req, reply) => {
+      const rawBody = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0)
+      let body: unknown
+      try {
+        body = JSON.parse(rawBody.toString('utf8'))
+      } catch {
+        return reply.code(400).send({ error: 'Bad Request', statusCode: 400 })
+      }
+      // A delivery no assigned bot owns answers 401 — no oracle, and Linear retries it.
+      const handled = await deps.manager()?.handleInbound('linear', rawBody, body, req.headers)
+      if (!handled) return reply.code(401).send({ error: 'Unauthorized', statusCode: 401 })
+      // Always 200 once the signature verified, BEFORE daemon delivery resolves (§6.1): Linear's
+      // 1 min/1 h/6 h ladder is too slow and too dangerous to use as our queue.
+      return reply.code(200).send({})
+    })
+  })
+}

--- a/packages/relay/src/platforms/linear/ingress-plugin.test.ts
+++ b/packages/relay/src/platforms/linear/ingress-plugin.test.ts
@@ -116,13 +116,20 @@ function promptedEvent(over: Record<string, unknown> = {}, activityOver: Record<
   }
 }
 
-function delivery(body: unknown, over: { secret?: string; timestamp?: number; signature?: string } = {}) {
+// `timestampHeader` absent ⇒ the header mirrors the SIGNED timestamp, as a real delivery does;
+// `null` ⇒ no header at all; a number ⇒ the attacker's freely chosen unsigned value.
+function delivery(
+  body: unknown,
+  over: { secret?: string; signature?: string; timestampHeader?: number | string | null } = {}
+) {
   const raw = Buffer.from(JSON.stringify(body))
   const signature =
     over.signature ??
     createHmac('sha256', over.secret ?? SIGNING_SECRET)
       .update(raw)
       .digest('hex')
+  const signed = (body as { webhookTimestamp?: number } | undefined)?.webhookTimestamp
+  const headerValue = over.timestampHeader === undefined ? signed : over.timestampHeader
   return {
     raw,
     body,
@@ -130,7 +137,7 @@ function delivery(body: unknown, over: { secret?: string; timestamp?: number; si
       'linear-event': 'AgentSessionEvent',
       'linear-delivery': '00000000-0000-4000-8000-0000000000d1',
       'linear-signature': signature,
-      'linear-timestamp': String(over.timestamp ?? NOW)
+      ...(headerValue === null || headerValue === undefined ? {} : { 'linear-timestamp': String(headerValue) })
     } as Record<string, string | string[] | undefined>
   }
 }
@@ -160,19 +167,51 @@ describe('linear ingress plugin — signature and replay window', () => {
     expect(h.forward).not.toHaveBeenCalled()
   })
 
-  it('reads Linear-Timestamp as epoch MILLISECONDS, not seconds', async () => {
+  it('rejects a STALE signed body even when the unsigned header is fresh', async () => {
+    // The signature covers the body only, so a captured body + signature replays for as long as
+    // the attacker keeps minting fresh `Linear-Timestamp` headers. The signed timestamp is the
+    // only freshness authority; a header-only skew check admits the replay.
     const h = host()
-    // The same instant expressed in seconds is ~1 788 249 909 ms after the epoch — far outside
-    // the window. Treating the header as seconds would accept it and reject every real delivery.
-    expect((await run(h, createdEvent(), { timestamp: Math.floor(NOW / 1000) })).verified).toBeUndefined()
-    expect((await run(h, createdEvent(), { timestamp: NOW })).verified).toMatchObject({ kind: 'agent-session' })
+    const captured = createdEvent({ webhookTimestamp: NOW - 6 * 60 * 60 * 1000 })
+    expect((await run(h, captured, { timestampHeader: NOW })).verified).toBeUndefined()
+    expect(h.forward).not.toHaveBeenCalled()
   })
 
-  it('rejects a timestamp more than 60 s from the host clock, in either direction', async () => {
+  it('accepts a fresh signed body with NO timestamp header at all', async () => {
     const h = host()
-    expect((await run(h, createdEvent(), { timestamp: NOW - 60_001 })).verified).toBeUndefined()
-    expect((await run(h, createdEvent(), { timestamp: NOW + 60_001 })).verified).toBeUndefined()
-    expect((await run(h, createdEvent(), { timestamp: NOW - 59_000 })).verified).toMatchObject({
+    expect((await run(h, createdEvent(), { timestampHeader: null })).verified).toMatchObject({
+      kind: 'agent-session'
+    })
+  })
+
+  it('rejects a body carrying no signed timestamp — nothing would bound its replay', async () => {
+    const h = host()
+    const undated = createdEvent()
+    delete (undated as Record<string, unknown>).webhookTimestamp
+    expect((await run(h, undated, { timestampHeader: NOW })).verified).toBeUndefined()
+  })
+
+  it('rejects an unsigned header that CONTRADICTS the signed timestamp', async () => {
+    // The header can only ever reject; a mismatch means one of the two was tampered with.
+    const h = host()
+    expect((await run(h, createdEvent(), { timestampHeader: NOW - 5_000 })).verified).toBeUndefined()
+    expect((await run(h, createdEvent(), { timestampHeader: 'not-a-number' })).verified).toBeUndefined()
+  })
+
+  it('reads webhookTimestamp as epoch MILLISECONDS, not seconds', async () => {
+    const h = host()
+    // The same instant expressed in seconds is ~1 788 249 909 ms after the epoch — far outside
+    // the window. A seconds reading would accept it and reject every real delivery.
+    const seconds = createdEvent({ webhookTimestamp: Math.floor(NOW / 1000) })
+    expect((await run(h, seconds)).verified).toBeUndefined()
+    expect((await run(h, createdEvent())).verified).toMatchObject({ kind: 'agent-session' })
+  })
+
+  it('rejects a signed timestamp more than 60 s from the host clock, in either direction', async () => {
+    const h = host()
+    expect((await run(h, createdEvent({ webhookTimestamp: NOW - 60_001 }))).verified).toBeUndefined()
+    expect((await run(h, createdEvent({ webhookTimestamp: NOW + 60_001 }))).verified).toBeUndefined()
+    expect((await run(h, createdEvent({ webhookTimestamp: NOW - 59_000 }))).verified).toMatchObject({
       kind: 'agent-session'
     })
   })
@@ -302,6 +341,14 @@ describe('linear ingress plugin — normalized message', () => {
     expect(forwarded?.sender).toMatchObject({ id: `linear:${USER_ID}`, name: 'Example Person' })
   })
 
+  it('also reads the DOCUMENTED prompted shape, where the body sits on the activity itself', async () => {
+    // Live deliveries nest the prompt under `content`; the docs describe `agentActivity.body`.
+    // Reading only one shape would forward an empty instruction for the other.
+    const h = host()
+    const documented = promptedEvent({}, { content: null, body: 'Documented-shape follow-up' })
+    expect((await run(h, documented)).forwarded?.text).toBe('Documented-shape follow-up')
+  })
+
   it('keys a session with NO issue on the session UUID — never `linear:undefined`', async () => {
     const h = host()
     const noIssue = createdEvent()
@@ -408,7 +455,12 @@ describe('linear ingress plugin — stop, revocation, and non-session events', (
 
   it('drops any other verified event category without forwarding or reporting', async () => {
     const h = host()
-    const { verified } = await run(h, { type: 'Issue', action: 'update', organizationId: ORG_ID })
+    const { verified } = await run(h, {
+      type: 'Issue',
+      action: 'update',
+      organizationId: ORG_ID,
+      webhookTimestamp: NOW
+    })
     expect(verified).toEqual({ kind: 'ignored' })
     expect(h.forward).not.toHaveBeenCalled()
     expect(h.reportRevoked).not.toHaveBeenCalled()
@@ -420,7 +472,8 @@ describe('linear ingress plugin — stop, revocation, and non-session events', (
       type: 'AgentSessionEvent',
       action: 'created',
       organizationId: ORG_ID,
-      oauthClientId: CLIENT_ID
+      oauthClientId: CLIENT_ID,
+      webhookTimestamp: NOW
     })
     expect(verified).toEqual({ kind: 'ignored' })
   })

--- a/packages/relay/src/platforms/linear/ingress-plugin.test.ts
+++ b/packages/relay/src/platforms/linear/ingress-plugin.test.ts
@@ -4,6 +4,7 @@ import type { WireNormalizedMessage } from '@agentconnect.md/protocol'
 import { linearIngressPlugin } from './ingress-plugin.js'
 import { LINEAR_CONTEXT_BUDGET_BYTES, type LinearAdapterExt } from './http-ingest.js'
 import type { RelayIngressHost } from '../contract.js'
+import { toBotAssignment } from '../../bot-arbitration.js'
 import type { BotAssignment, RouteTarget } from '../../bot-arbitration.js'
 
 const NOW = 1_788_249_909_143
@@ -218,6 +219,32 @@ describe('linear ingress plugin — demux and tenant isolation', () => {
     expect(
       linearIngressPlugin.buildIngest(assignment({ teamId: undefined, workspaceId: undefined }), h)
     ).toBeUndefined()
+  })
+
+  it('builds from the WIRE frame end to end, so the mapper and the plugin cannot drift', async () => {
+    // The plugin reads exactly the slots core indexes (`indexAssign`) and fences on, and the
+    // mapper is the only thing between the frame and those slots — so pin the pair together.
+    const h = host()
+    const mapped = toBotAssignment({
+      botId: '11111111-1111-4111-8111-111111111111',
+      platform: 'linear',
+      secrets: { signingSecret: SIGNING_SECRET },
+      ingress: { apiAppId: CLIENT_ID, teamId: ORG_ID, botUserId: APP_USER_ID },
+      members: [],
+      agents: [],
+      routes: [],
+      gatedAgentIds: [],
+      mutedChannels: [],
+      gatedOffChannels: [],
+      noticedDmConversations: []
+    } as never)
+    const ingest = linearIngressPlugin.buildIngest(mapped!, h)!
+    expect(ingest.identity).toEqual({ clientId: CLIENT_ID, organizationId: ORG_ID, appUserId: APP_USER_ID })
+    const d = delivery(createdEvent())
+    const verified = linearIngressPlugin.verify(ingest, d.raw, d.body, d.headers, NOW)!
+    await linearIngressPlugin.handle(ingest, verified, h)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(vi.mocked(h.forward).mock.calls[0]?.[1].mentionedBots).toEqual([APP_USER_ID])
   })
 })
 

--- a/packages/relay/src/platforms/linear/ingress-plugin.test.ts
+++ b/packages/relay/src/platforms/linear/ingress-plugin.test.ts
@@ -1,0 +1,427 @@
+import { createHmac } from 'node:crypto'
+import { describe, it, expect, vi } from 'vitest'
+import type { WireNormalizedMessage } from '@agentconnect.md/protocol'
+import { linearIngressPlugin } from './ingress-plugin.js'
+import { LINEAR_CONTEXT_BUDGET_BYTES, type LinearAdapterExt } from './http-ingest.js'
+import type { RelayIngressHost } from '../contract.js'
+import type { BotAssignment, RouteTarget } from '../../bot-arbitration.js'
+
+const NOW = 1_788_249_909_143
+const SIGNING_SECRET = 'lin_wh_00000000000000000000000000000000'
+const CLIENT_ID = '00000000000000000000000000000001'
+const ORG_ID = '00000000-0000-4000-8000-000000000001'
+const SIBLING_ORG_ID = '00000000-0000-4000-8000-000000000002'
+const APP_USER_ID = '00000000-0000-4000-8000-0000000000a1'
+const ISSUE_ID = '00000000-0000-4000-8000-0000000000i1'
+const SESSION_ID = '00000000-0000-4000-8000-0000000000s1'
+const ACTIVITY_ID = '00000000-0000-4000-8000-0000000000c1'
+const USER_ID = '00000000-0000-4000-8000-0000000000u1'
+
+const ROUTE: RouteTarget = {
+  agentId: '44444444-4444-4444-8444-444444444444',
+  daemonId: '33333333-3333-4333-8333-333333333333',
+  integrationId: '66666666-6666-4666-8666-666666666666'
+}
+
+const host = (over: Partial<RelayIngressHost> = {}): RelayIngressHost => ({
+  forward: vi.fn(async () => {}),
+  forwardAction: vi.fn(async (msg) => ({ msgId: msg.msgId, accepted: true })),
+  reportChannels: () => {},
+  reportRevoked: vi.fn(),
+  directory: {
+    agents: () => [],
+    channelOwner: () => undefined,
+    targetForAgentId: () => undefined,
+    resolveTarget: () => ROUTE,
+    conversationParticipants: () => [],
+    targetForAgent: () => ROUTE,
+    integrationTarget: () => ROUTE,
+    soleTarget: () => ROUTE
+  },
+  canDeliver: () => true,
+  dedupSeen: () => false,
+  setChannelAgent: () => {},
+  selectThreadAgent: () => {},
+  reportBotUserId: () => {},
+  clock: { now: () => NOW },
+  log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+  ...over
+})
+
+// The §6.2 bags as the assignment's platform-free identity slots carry them: Linear's
+// `clientId` is the provider app id, `organizationId` the tenant, `appUserId` the bot identity.
+const assignment = (over: Partial<BotAssignment> = {}): BotAssignment =>
+  ({
+    botId: '11111111-1111-4111-8111-111111111111',
+    platform: 'linear',
+    secrets: { signingSecret: SIGNING_SECRET },
+    apiAppId: CLIENT_ID,
+    teamId: ORG_ID,
+    botUserId: APP_USER_ID,
+    credentialRevision: 7,
+    members: [],
+    agents: [],
+    routes: [],
+    ...over
+  }) as unknown as BotAssignment
+
+const issue = {
+  id: ISSUE_ID,
+  identifier: 'AGE-5',
+  title: 'Probe: agent session activity rendering',
+  url: 'https://linear.app/example-workspace/issue/AGE-5/probe',
+  team: { id: '00000000-0000-4000-8000-0000000000t1', key: 'AGE', name: 'Example' }
+}
+
+function createdEvent(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: 'AgentSessionEvent',
+    action: 'created',
+    organizationId: ORG_ID,
+    oauthClientId: CLIENT_ID,
+    appUserId: APP_USER_ID,
+    agentSession: {
+      id: SESSION_ID,
+      creatorId: USER_ID,
+      commentId: '00000000-0000-4000-8000-0000000000m1',
+      sourceCommentId: null,
+      status: 'active',
+      url: 'https://linear.app/example-workspace/issue/AGE-5/probe#agent-session',
+      comment: { id: '00000000-0000-4000-8000-0000000000m1', body: 'example-agent please look at this' },
+      issue
+    },
+    previousComments: null,
+    guidance: 'Always open a draft PR.',
+    promptContext: '<issue identifier="AGE-5"><title>Probe</title></issue>',
+    webhookTimestamp: NOW,
+    webhookId: '00000000-0000-4000-8000-0000000000w1',
+    ...over
+  }
+}
+
+function promptedEvent(over: Record<string, unknown> = {}, activityOver: Record<string, unknown> = {}) {
+  return {
+    ...createdEvent(),
+    action: 'prompted',
+    agentActivity: {
+      id: ACTIVITY_ID,
+      signal: null,
+      sourceCommentId: '00000000-0000-4000-8000-0000000000m2',
+      content: { type: 'prompt', body: 'Follow-up: does this reopen the session?' },
+      user: { id: USER_ID, name: 'Example Person' },
+      ...activityOver
+    },
+    ...over
+  }
+}
+
+function delivery(body: unknown, over: { secret?: string; timestamp?: number; signature?: string } = {}) {
+  const raw = Buffer.from(JSON.stringify(body))
+  const signature =
+    over.signature ??
+    createHmac('sha256', over.secret ?? SIGNING_SECRET)
+      .update(raw)
+      .digest('hex')
+  return {
+    raw,
+    body,
+    headers: {
+      'linear-event': 'AgentSessionEvent',
+      'linear-delivery': '00000000-0000-4000-8000-0000000000d1',
+      'linear-signature': signature,
+      'linear-timestamp': String(over.timestamp ?? NOW)
+    } as Record<string, string | string[] | undefined>
+  }
+}
+
+async function run(h: RelayIngressHost, body: unknown, opts: Parameters<typeof delivery>[1] = {}, now = NOW) {
+  const ingest = linearIngressPlugin.buildIngest(assignment(), h)!
+  const d = delivery(body, opts)
+  const verified = linearIngressPlugin.verify(ingest, d.raw, d.body, d.headers, now)
+  if (verified === undefined) return { verified, forwarded: undefined }
+  await linearIngressPlugin.handle(ingest, verified, h)
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  return { verified, forwarded: vi.mocked(h.forward).mock.calls[0]?.[1] as WireNormalizedMessage | undefined }
+}
+
+describe('linear ingress plugin — signature and replay window', () => {
+  it('accepts a delivery signed with the workspace bot signing secret', async () => {
+    const h = host()
+    const { verified } = await run(h, createdEvent())
+    expect(verified).toMatchObject({ kind: 'agent-session' })
+  })
+
+  it('rejects a forged signature, a truncated one, and a non-hex one', async () => {
+    const h = host()
+    expect((await run(h, createdEvent(), { secret: 'another-apps-secret' })).verified).toBeUndefined()
+    expect((await run(h, createdEvent(), { signature: '0'.repeat(63) })).verified).toBeUndefined()
+    expect((await run(h, createdEvent(), { signature: 'not-hex' })).verified).toBeUndefined()
+    expect(h.forward).not.toHaveBeenCalled()
+  })
+
+  it('reads Linear-Timestamp as epoch MILLISECONDS, not seconds', async () => {
+    const h = host()
+    // The same instant expressed in seconds is ~1 788 249 909 ms after the epoch — far outside
+    // the window. Treating the header as seconds would accept it and reject every real delivery.
+    expect((await run(h, createdEvent(), { timestamp: Math.floor(NOW / 1000) })).verified).toBeUndefined()
+    expect((await run(h, createdEvent(), { timestamp: NOW })).verified).toMatchObject({ kind: 'agent-session' })
+  })
+
+  it('rejects a timestamp more than 60 s from the host clock, in either direction', async () => {
+    const h = host()
+    expect((await run(h, createdEvent(), { timestamp: NOW - 60_001 })).verified).toBeUndefined()
+    expect((await run(h, createdEvent(), { timestamp: NOW + 60_001 })).verified).toBeUndefined()
+    expect((await run(h, createdEvent(), { timestamp: NOW - 59_000 })).verified).toMatchObject({
+      kind: 'agent-session'
+    })
+  })
+
+  it('verifies against the RAW bytes, so a reserialized body no longer matches', async () => {
+    const h = host()
+    const ingest = linearIngressPlugin.buildIngest(assignment(), h)!
+    const d = delivery(createdEvent())
+    const reserialized = Buffer.from(JSON.stringify(JSON.parse(d.raw.toString('utf8')), null, 2))
+    expect(linearIngressPlugin.verify(ingest, reserialized, d.body, d.headers, NOW)).toBeUndefined()
+  })
+})
+
+describe('linear ingress plugin — demux and tenant isolation', () => {
+  it('extracts the tenant-scoped composite from the body identity pair', () => {
+    expect(linearIngressPlugin.extractDemuxHints(Buffer.alloc(0), createdEvent(), {})).toEqual({
+      appId: CLIENT_ID,
+      tenantId: ORG_ID
+    })
+  })
+
+  it('extracts nothing from a body carrying no identity — never a guessed key', () => {
+    expect(linearIngressPlugin.extractDemuxHints(Buffer.alloc(0), { type: 'AgentSessionEvent' }, {})).toEqual({})
+  })
+
+  it('a sibling install VERIFIES the signature yet is refused: the payload workspace decides', async () => {
+    // Every install of the deployment app shares one signing secret, so the HMAC is valid for a
+    // sibling's delivery too. Only the payload's organizationId separates the two workspaces.
+    const h = host()
+    const sibling = createdEvent({ organizationId: SIBLING_ORG_ID })
+    expect((await run(h, sibling)).verified).toBeUndefined()
+    expect(h.forward).not.toHaveBeenCalled()
+  })
+
+  it('refuses a validly signed delivery from another OAuth app of the same deployment', async () => {
+    const h = host()
+    expect((await run(h, createdEvent({ oauthClientId: 'a-different-client-id' }))).verified).toBeUndefined()
+  })
+
+  it('refuses to build an ingest without the signing secret or either identity half', () => {
+    const h = host()
+    expect(linearIngressPlugin.buildIngest(assignment({ secrets: {} as never }), h)).toBeUndefined()
+    expect(linearIngressPlugin.buildIngest(assignment({ apiAppId: undefined }), h)).toBeUndefined()
+    expect(
+      linearIngressPlugin.buildIngest(assignment({ teamId: undefined, workspaceId: undefined }), h)
+    ).toBeUndefined()
+  })
+})
+
+describe('linear ingress plugin — dedup identity', () => {
+  it('derives created from the session id and prompted from the activity id (§4.5)', async () => {
+    const created = host()
+    expect((await run(created, createdEvent())).forwarded?.msgId).toBe(`linear:${SESSION_ID}:created`)
+    const prompted = host()
+    expect((await run(prompted, promptedEvent())).forwarded?.msgId).toBe(`linear:${ACTIVITY_ID}`)
+  })
+
+  it('drops a redelivery before any forward', async () => {
+    const h = host({ dedupSeen: () => true })
+    await run(h, createdEvent())
+    expect(h.forward).not.toHaveBeenCalled()
+    expect(h.forwardAction).not.toHaveBeenCalled()
+  })
+
+  it('forwards nothing for an action that mints no content-derived identity', async () => {
+    const h = host()
+    await run(h, createdEvent({ action: 'unknown-future-action' }))
+    expect(h.forward).not.toHaveBeenCalled()
+  })
+})
+
+describe('linear ingress plugin — normalized message', () => {
+  it('maps a created event onto issue/session coordinates with the adapter bag', async () => {
+    const h = host()
+    const { forwarded } = await run(h, createdEvent())
+    expect(forwarded).toMatchObject({
+      platform: 'linear',
+      channel: ISSUE_ID,
+      thread: SESSION_ID,
+      threadUrl: issue.url,
+      sender: { id: `linear:${USER_ID}`, isBot: false },
+      text: 'example-agent please look at this',
+      mentionedBots: [APP_USER_ID],
+      isDm: false
+    })
+    const bag = forwarded!.adapterExt!.linear as LinearAdapterExt
+    expect(bag).toMatchObject({
+      agentSessionId: SESSION_ID,
+      issueIdentifier: 'AGE-5',
+      issueTitle: issue.title,
+      guidance: 'Always open a draft PR.'
+    })
+    expect(bag.promptContext).toContain('AGE-5')
+    expect(bag.truncated).toBeUndefined()
+  })
+
+  it('carries the follow-up body VERBATIM for a prompted event', async () => {
+    const h = host()
+    const { forwarded } = await run(h, promptedEvent())
+    expect(forwarded?.text).toBe('Follow-up: does this reopen the session?')
+    expect(forwarded?.sender).toMatchObject({ id: `linear:${USER_ID}`, name: 'Example Person' })
+  })
+
+  it('keys a session with NO issue on the session UUID — never `linear:undefined`', async () => {
+    const h = host()
+    const noIssue = createdEvent()
+    ;(noIssue.agentSession as Record<string, unknown>).issue = null
+    const { forwarded } = await run(h, noIssue)
+    expect(forwarded?.channel).toBe(SESSION_ID)
+    expect(forwarded?.thread).toBe(SESSION_ID)
+    expect(forwarded?.threadUrl).toBeUndefined()
+    expect(JSON.stringify(forwarded)).not.toContain('undefined')
+  })
+
+  it('falls back to the session id for an unattributed sender rather than fabricating one', async () => {
+    const h = host()
+    const unattributed = createdEvent()
+    ;(unattributed.agentSession as Record<string, unknown>).creatorId = null
+    expect((await run(h, unattributed)).forwarded?.sender.id).toBe(`linear:${SESSION_ID}`)
+  })
+
+  it('never lets the instruction live only inside the fenced context', async () => {
+    const h = host()
+    const bare = createdEvent()
+    ;(bare.agentSession as Record<string, unknown>).comment = null
+    // A bare delegation has no comment line; the issue title is the member's instruction.
+    expect((await run(h, bare)).forwarded?.text).toBe(issue.title)
+  })
+})
+
+describe('linear ingress plugin — truncation budget', () => {
+  it('cuts promptContext to the 32 KiB budget and flags the bag', async () => {
+    const h = host()
+    const huge = 'a'.repeat(LINEAR_CONTEXT_BUDGET_BYTES * 2)
+    const { forwarded } = await run(h, createdEvent({ promptContext: huge }))
+    const bag = forwarded!.adapterExt!.linear as LinearAdapterExt
+    expect(Buffer.byteLength(bag.promptContext!, 'utf8')).toBe(LINEAR_CONTEXT_BUDGET_BYTES)
+    expect(bag.truncated).toBe(true)
+  })
+
+  it('cuts on a code-point boundary, so a multi-byte body never rides at 3x the cap', async () => {
+    const h = host()
+    // A 3-byte code point does not divide the budget evenly, so a naive byte cut would split one.
+    const { forwarded } = await run(h, createdEvent({ promptContext: '€'.repeat(LINEAR_CONTEXT_BUDGET_BYTES) }))
+    const bag = forwarded!.adapterExt!.linear as LinearAdapterExt
+    expect(Buffer.byteLength(bag.promptContext!, 'utf8')).toBeLessThanOrEqual(LINEAR_CONTEXT_BUDGET_BYTES)
+    expect(bag.promptContext).not.toContain('�')
+  })
+
+  it('spends ONE budget across promptContext and previousComments, dropping the overflow', async () => {
+    const h = host()
+    const previousComments = [
+      { id: 'c1', body: 'b'.repeat(LINEAR_CONTEXT_BUDGET_BYTES) },
+      { id: 'c2', body: 'this one no longer fits' }
+    ]
+    const { forwarded } = await run(h, createdEvent({ promptContext: 'x'.repeat(1024), previousComments }))
+    const bag = forwarded!.adapterExt!.linear as LinearAdapterExt
+    const spent =
+      Buffer.byteLength(bag.promptContext!, 'utf8') +
+      bag.previousComments!.reduce((sum, c) => sum + Buffer.byteLength(c.body ?? '', 'utf8'), 0)
+    expect(spent).toBeLessThanOrEqual(LINEAR_CONTEXT_BUDGET_BYTES)
+    expect(bag.previousComments).toHaveLength(1)
+    expect(bag.truncated).toBe(true)
+  })
+
+  it('keeps only the listed comment fields, so a commenter email can never ride the bag', async () => {
+    const h = host()
+    const previousComments = [{ id: 'c1', body: 'hello', userId: USER_ID, email: 'person@example.test' }]
+    const { forwarded } = await run(h, createdEvent({ previousComments }))
+    const bag = forwarded!.adapterExt!.linear as LinearAdapterExt
+    expect(bag.previousComments).toEqual([{ id: 'c1', body: 'hello', userId: USER_ID }])
+  })
+})
+
+describe('linear ingress plugin — stop, revocation, and non-session events', () => {
+  it('routes a stop signal as a platform_action, not a message', async () => {
+    const h = host()
+    await run(h, promptedEvent({}, { signal: 'stop' }))
+    expect(h.forward).not.toHaveBeenCalled()
+    expect(h.forwardAction).toHaveBeenCalledTimes(1)
+    const [msg, route] = vi.mocked(h.forwardAction).mock.calls[0]!
+    expect(msg).toMatchObject({
+      source: 'platform_action',
+      platformId: 'linear',
+      agentId: ROUTE.agentId,
+      integrationId: ROUTE.integrationId,
+      msgId: `linear:${ACTIVITY_ID}`,
+      userId: USER_ID,
+      payload: { kind: 'stop', agentSessionId: SESSION_ID }
+    })
+    expect(route).toEqual(ROUTE)
+  })
+
+  it('drops a stop the directory can no longer place', async () => {
+    const h = host({
+      directory: { ...host().directory, resolveTarget: () => undefined }
+    })
+    await run(h, promptedEvent({}, { signal: 'stop' }))
+    expect(h.forwardAction).not.toHaveBeenCalled()
+  })
+
+  it('rings the revocation doorbell with the OBSERVING assignment revision', async () => {
+    const h = host()
+    await run(h, { type: 'OAuthApp', action: 'revoked', organizationId: ORG_ID, webhookTimestamp: NOW })
+    expect(h.reportRevoked).toHaveBeenCalledWith('11111111-1111-4111-8111-111111111111', 'tokens_revoked', NOW, 7)
+  })
+
+  it('drops any other verified event category without forwarding or reporting', async () => {
+    const h = host()
+    const { verified } = await run(h, { type: 'Issue', action: 'update', organizationId: ORG_ID })
+    expect(verified).toEqual({ kind: 'ignored' })
+    expect(h.forward).not.toHaveBeenCalled()
+    expect(h.reportRevoked).not.toHaveBeenCalled()
+  })
+
+  it('drops a malformed AgentSessionEvent as ignored rather than answering 401', async () => {
+    const h = host()
+    const { verified } = await run(h, {
+      type: 'AgentSessionEvent',
+      action: 'created',
+      organizationId: ORG_ID,
+      oauthClientId: CLIENT_ID
+    })
+    expect(verified).toEqual({ kind: 'ignored' })
+  })
+})
+
+describe('linear ingress plugin — per-bot ingress bucket', () => {
+  it('throttles a burst without marking the dropped deliveries seen', async () => {
+    const seen = new Set<string>()
+    const h = host({
+      dedupSeen: (identity) => {
+        if (identity === undefined) return false
+        if (seen.has(identity)) return true
+        seen.add(identity)
+        return false
+      }
+    })
+    const ingest = linearIngressPlugin.buildIngest(assignment(), h)!
+    for (let i = 0; i < 20; i++) {
+      const body = createdEvent()
+      ;(body.agentSession as Record<string, unknown>).id = `${SESSION_ID}-${i}`
+      const d = delivery(body)
+      const verified = linearIngressPlugin.verify(ingest, d.raw, d.body, d.headers, NOW)!
+      await linearIngressPlugin.handle(ingest, verified, h)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    // Default bucket: capacity 10, and the throttled half never entered the dedup table, so
+    // Linear's retry ladder can still deliver them.
+    expect(vi.mocked(h.forward).mock.calls).toHaveLength(10)
+    expect(seen.size).toBe(10)
+  })
+})

--- a/packages/relay/src/platforms/linear/ingress-plugin.ts
+++ b/packages/relay/src/platforms/linear/ingress-plugin.ts
@@ -1,0 +1,130 @@
+// Linear's relay ingress plugin (linear-integration.md §6.1): a pure HTTP decoder — no `start`,
+// a no-op `stop`, and no `egress` facet, because every Linear write belongs to the daemon (§4.6).
+import type { RdMsgPlatformAction } from '@agentconnect.md/protocol'
+import {
+  LinearHttpIngest,
+  linearDedupId,
+  linearIsStop,
+  normalizeLinearEvent,
+  type LinearAgentSessionEvent,
+  type VerifiedLinearDelivery
+} from './http-ingest.js'
+import { registerLinearHttpIngress } from './http-ingress.js'
+import { sessionKeyOf } from '../../bot-arbitration.js'
+import type { BotAssignment } from '../../bot-arbitration.js'
+import type { DemuxHints, HandledDelivery, RelayIngressHost, RelayPlatformIngressPlugin } from '../contract.js'
+
+/** The stop payload the daemon's linear module decodes into `interruptTurn` (§6.3). */
+export interface LinearStopAction {
+  kind: 'stop'
+  agentSessionId: string
+}
+
+// A stop is an interaction, not a message: it takes the directory ladder, and because a Linear
+// session is bound to one agent at creation (§4.5) the conversation's own target is the holder.
+export function forwardLinearStop(
+  host: RelayIngressHost,
+  botId: string,
+  event: LinearAgentSessionEvent,
+  msgId: string
+): void {
+  const session = event.agentSession
+  const channelId = session.issue?.id ?? session.id
+  const route = host.directory.resolveTarget(botId, { channelId, threadTs: session.id })
+  if (!route) {
+    host.log.warn(`relay-ingress(${botId}): Linear stop for session ${session.id} has no current target`)
+    return
+  }
+  const payload: LinearStopAction = { kind: 'stop', agentSessionId: session.id }
+  const rd: RdMsgPlatformAction = {
+    source: 'platform_action',
+    platformId: 'linear',
+    agentId: route.agentId,
+    integrationId: route.integrationId,
+    sessionKey: sessionKeyOf({ channel: channelId, thread: session.id }),
+    msgId,
+    botId,
+    ...(event.agentActivity?.user?.id ? { userId: event.agentActivity.user.id } : {}),
+    payload
+  }
+  void host
+    .forwardAction(rd, route)
+    .then((ack) => {
+      if (!ack.accepted) host.log.warn(`relay-ingress(${botId}): daemon rejected Linear stop (${ack.reason ?? '?'})`)
+    })
+    .catch((err) => host.log.warn(`relay-ingress(${botId}): Linear stop forward failed: ${(err as Error).message}`))
+}
+
+export const linearIngressPlugin: RelayPlatformIngressPlugin<LinearHttpIngest, VerifiedLinearDelivery> = {
+  platformId: 'linear',
+
+  // `POST /linear/events`, declared by the module that owns it and pinned by route-mounts.test.ts.
+  installRoutes: registerLinearHttpIngress,
+
+  buildIngest(a: BotAssignment, host: RelayIngressHost): LinearHttpIngest | undefined {
+    // §6.2's opaque bags, read through the assignment's platform-free identity slots: Linear's
+    // `clientId` is the provider app id, `organizationId` the tenant, `appUserId` the bot identity.
+    const secrets = a.secrets as { signingSecret?: unknown }
+    const signingSecret = typeof secrets.signingSecret === 'string' ? secrets.signingSecret : ''
+    const clientId = a.apiAppId
+    const organizationId = a.teamId ?? a.workspaceId
+    if (!signingSecret || !clientId || !organizationId) {
+      host.log.warn(`relay-ingress(${a.botId}): incomplete Linear assignment`)
+      return undefined
+    }
+    return new LinearHttpIngest(
+      a.botId,
+      { clientId, organizationId, ...(a.botUserId ? { appUserId: a.botUserId } : {}) },
+      signingSecret,
+      () => host.clock.now(),
+      a.credentialRevision
+    )
+  },
+
+  extractDemuxHints(_rawBody: Buffer, body: unknown, _headers): DemuxHints {
+    // Pre-verify HINTS only. Every Linear assignment is tenant-scoped, so the composite
+    // `(oauthClientId, organizationId)` is the only demux that cannot leak across workspaces.
+    const b = body as { oauthClientId?: string; organizationId?: string } | undefined
+    return {
+      ...(b?.oauthClientId ? { appId: b.oauthClientId } : {}),
+      ...(b?.organizationId ? { tenantId: b.organizationId } : {})
+    }
+  },
+
+  verify(ingest, rawBody, body, headers, now): VerifiedLinearDelivery | undefined {
+    return ingest.decode(rawBody, body, headers, now)
+  },
+
+  async handle(ingest, verified, host): Promise<HandledDelivery> {
+    const botId = ingest.botId
+    if (verified.kind === 'ignored') return {}
+    if (verified.kind === 'revoked') {
+      host.log.warn(`relay-ingress(${botId}): workspace revoked the Linear app`)
+      // The revision is the OBSERVING assignment's, captured at buildIngest — a fire-and-forget
+      // older ingest must never revoke a credential a re-connect has since replaced.
+      host.reportRevoked(botId, 'tokens_revoked', verified.eventAtMs, ingest.credentialRevision)
+      return {}
+    }
+    const event = verified.event
+    const msgId = linearDedupId(event)
+    // An action this build does not handle (or a `prompted` with no activity) is bounded loss, not
+    // an unkeyed forward: without a content-derived identity a redelivery could never converge.
+    if (!msgId) return {}
+    // The bucket is taken BEFORE the dedup mark so a throttled delivery stays unseen and Linear's
+    // retry can still land; a redelivery of an already-forwarded event costs one token and stops.
+    if (!ingest.allow()) {
+      host.log.warn(`relay-ingress(${botId}): Linear ingress rate limit exhausted — dropped ${msgId}`)
+      return {}
+    }
+    if (host.dedupSeen(msgId)) return {}
+    if (linearIsStop(event)) {
+      forwardLinearStop(host, botId, event, msgId)
+      return {}
+    }
+    const message = normalizeLinearEvent(event, msgId, ingest.identity.appUserId)
+    void host
+      .forward(botId, message)
+      .catch((err) => host.log.warn(`linear ingress: event handler error: ${(err as Error).message}`))
+    return {}
+  }
+}

--- a/packages/relay/src/platforms/registry.ts
+++ b/packages/relay/src/platforms/registry.ts
@@ -20,6 +20,7 @@
 import type { RelayBotIngress, RelayPlatformIngressPlugin } from './contract.js'
 import { slackIngressPlugin } from './slack/ingress-plugin.js'
 import { feishuIngressPlugin } from './feishu/ingress-plugin.js'
+import { linearIngressPlugin } from './linear/ingress-plugin.js'
 
 /**
  * **The one place a relay platform id is written down.** Adding a platform is
@@ -37,7 +38,11 @@ import { feishuIngressPlugin } from './feishu/ingress-plugin.js'
  * asks each pool in turn. That is the order the two hand-named pools were
  * asked in before the registry drove it (audit F2/F4), so nothing moved.
  */
-export const relayIngressPlugins: readonly RelayPlatformIngressPlugin[] = [slackIngressPlugin, feishuIngressPlugin]
+export const relayIngressPlugins: readonly RelayPlatformIngressPlugin[] = [
+  slackIngressPlugin,
+  feishuIngressPlugin,
+  linearIngressPlugin
+]
 
 /** One platform's pool of live per-bot ingests. Purely keyed by botId — the
  *  identity questions live in {@link DemuxIndex}, not here. */

--- a/packages/relay/src/platforms/route-mounts.test.ts
+++ b/packages/relay/src/platforms/route-mounts.test.ts
@@ -32,7 +32,9 @@ import type { RelayIngressRouteDeps } from './contract.js'
  *  omitted; there are no GETs on this seam. */
 const EXPECTED_MOUNTS: Record<string, string[]> = {
   slack: ['POST /slack/events', 'POST /slack/interactions'],
-  feishu: ['POST /feishu/events']
+  feishu: ['POST /feishu/events'],
+  // One static, shared URL — a Linear app configures exactly one webhook endpoint.
+  linear: ['POST /linear/events']
 }
 
 const routeDeps = (): RelayIngressRouteDeps => ({


### PR DESCRIPTION
Implements the Linear relay ingress plugin per docs/designs/linear-integration.md §6.1/§6.3 (first commit), plus the assignment-mapper arm it needs to ever receive an assignment (second commit).

**Plugin** (`packages/relay/src/platforms/linear/` + one registry line):
- `POST /linear/events` (raw-body parser, 1 MiB cap), pinned in `route-mounts.test.ts`.
- `verify`: timing-safe HMAC over raw bytes + the `Linear-Timestamp` header's 60 s replay window (checked before body parse), parsed exactly once.
- `handle`: `created`/`prompted` → normalized `im` (channel = issue UUID with AgentSession-UUID fallback, thread = AgentSession UUID, `adapterExt.linear` context bag with a 32 KiB budget); `prompted` + `signal: "stop"` → `platform_action` routed via the directory; `OAuthApp revoked` → the revocation doorbell; other events dropped with 200. Content-derived dedup ids (`linear:<sessionId>:created` / `linear:<activityId>`) absorb the 1 min/1 h/6 h redelivery ladder.
- `previousComments` is strip-parsed to `{id, body, userId, createdAt}` so unlisted fields (e.g. commenter emails) never reach the model-visible bag. Events are stamped `mentionedBots: [appUserId]` — every Linear event is explicitly addressed by construction.

**Mapper**: `toBotAssignment` accepts a third, signing-secret-only secrets shape (a platform whose egress is entirely the daemon's). Absence of `botToken` is checked by key so a half-filled Slack bag still fails closed; demux identity rides the existing generic slots (`apiAppId`/`teamId`/`botUserId`), which is what the assign index and tenant fence already consume.

Event shapes follow live captures from a scratch workspace probe (see the §15 revision); fixtures are synthetic.

Tests: relay suite 606 passing (34 new: signature/timestamp vectors, demux + sibling-install isolation, truncation budgets, dedup derivation, stop routing, revoked doorbell, wire-frame end-to-end pairing, mapper shape claims); typecheck + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
