### PR TITLE
feat(protocol,cp): route and revalidate approval-DM recipients (#1648)

### DIFF
--- a/docs/designs/slack-approval-dm.md
+++ b/docs/designs/slack-approval-dm.md
@@ -1,9 +1,9 @@
 # Slack Approval DM
 
-> **Status:** Proposed (issue
-> [#1648](https://github.com/agentconnect-md/agentconnect/issues/1648)).
-> Nothing here is implemented yet; file/line references describe the shipped
-> machinery this design composes.
+> **Status:** Accepted (issue
+> [#1648](https://github.com/agentconnect-md/agentconnect/issues/1648));
+> shipping as two stacked changes (§9). File/line references describe the
+> shipped machinery this design composes.
 >
 > **Scope:** protocol + control-plane + daemon + web. Slack only — it is the
 > one platform with a linked-identity **assertion** (see §4.4) and the one
@@ -47,13 +47,13 @@ hangs until someone wanders by.
 decide (can edit the agent) and (b) has proven the Slack account is theirs
 (linked identity). The DM carries the approval card, a console session deep
 link, and — when the triggering message came from Slack — a permalink to it.
-The approval itself keeps living on the web exactly as today; the console's
-notification bell learns to show it as unread while pending and as read
-("_name_ approved / declined") once resolved.
+The approval itself keeps living on the web exactly as today, and the
+console's approval cards learn to show **who** decided (§6).
 
 Non-goals: replacing the in-conversation chat card (it stays, unchanged
-behind its opt-in), a server-side notification store (§8), any platform
-other than Slack (§10), and a reverse Slack→console identity index (§4.4).
+behind its opt-in), console notifications (§7, deferred), a server-side
+notification store (§8), any platform other than Slack (§10), and a reverse
+Slack→console identity index (§4.4).
 
 ## 2. The trust model — why a DM is the editor path, not the chat path
 
@@ -78,8 +78,11 @@ So the DM surface is **the editor path delivered over Slack**, and:
 
 ## 3. Recipient selection — the preference chain
 
-One human is DM'd per pending request (no fan-out). Every rung must pass
-both standing gates before it can win:
+One human is DM'd per pending request (no fan-out, no escalation, no
+per-user or per-org opt-out — the console queue is the backstop). The chain
+is anchored to one Slack workspace at a time; when the agent is connected
+to more than one, it runs per workspace in a stable order and the first hit
+wins (§4.2). Every rung must pass both standing gates before it can win:
 
 - **Authority:** the candidate's console user satisfies `canEdit(agent)`.
 - **Identity:** the candidate has linked a Slack identity **in the bot's own
@@ -135,20 +138,29 @@ A synchronous daemon→CP request/reply over the existing WS, modeled on
 `github/review-authorize` → `github/review-authorized`:
 
 - **`agent/approval-route`** (daemon→CP):
-  `{ agentId, sessionId, requestId, requesterId?, integrationId }` —
+  `{ agentId, sessionId, requestId, requesterId?, integrationIds }` —
   `requesterId` is the turn owner's Slack member id when the turn came from
-  Slack; `integrationId` names the bot whose workspace anchors the identity
-  gate.
+  Slack; `integrationIds` are the agent's connected Slack integrations in
+  the order to try, the session's own bot first when the session is on
+  Slack. Each names a workspace that anchors its own identity gate.
 - **`agent/approval-routed`** (CP→daemon):
-  `{ requestId, target?: { teamId, userId, displayName?, consoleUserId } }` —
-  absent `target` means "no eligible recipient, keep today's behavior".
+  `{ requestId, target?: { integrationId, teamId, userId, displayName?,
+consoleUserId } }` — the CP evaluates the chain once per workspace in the
+  given order and answers with the first hit; absent `target` means "no
+  eligible recipient, keep today's behavior".
+
+Sessions **not** triggered from Slack (webchat, GitHub, webhook, Telegram…)
+are covered by the same shape — they are precisely the approvals with no
+chat surface at all, so the DM matters most there. The daemon simply lists
+every Slack integration the agent is connected to (almost always one) and
+lets the CP pick.
 
 The same pair also serves the decision-time revalidation of §6.3:
-`agent/approval-route` with `verify: { teamId, userId }` set asks not "whom
-should I DM" but "does this Slack pair, **right now**, map to a console
-user who can edit this agent" — answered by `{ requestId, allowed,
-consoleUserId? }`. Routing is best-effort (§4.3); verification is not — it
-authorizes an action, so an unanswerable verify fails closed.
+`agent/approval-route` with `verify: { integrationId, teamId, userId }` set
+asks not "whom should I DM" but "does this Slack pair, **right now**, map
+to a console user who can edit this agent" — answered by `{ requestId,
+allowed, consoleUserId? }`. Routing is best-effort (§4.3); verification is
+not — it authorizes an action, so an unanswerable verify fails closed.
 
 The CP evaluates the chain of §3 with the `linkedMemberIds` machinery
 (`packages/control-plane/src/orchestrator/linkedDm.ts`): the same
@@ -210,7 +222,7 @@ One message per pending request, containing:
   thread** — built locally from pieces the daemon already holds
   (`packages/daemon/src/platforms/slack/permalink.ts`), no
   `chat.getPermalink` round trip;
-- the Allow/Deny buttons (phase 2, §9) — `buildPermissionCard` /
+- the Allow/Deny buttons — `buildPermissionCard` /
   `buildElicitationCard` (`packages/daemon/src/slack/render.ts`) reused
   as-is, since their `action_id` / `value` encoding is
   channel-independent.
@@ -233,9 +245,10 @@ in a DM channel routes exactly like one in the session thread:
 
 ### 5.4 Lifecycle
 
-- **Coalescing:** at most one _live_ card per `(session, recipient)` DM. A
-  second approval arriving while one is pending threads under the first
-  message rather than stacking top-level pings.
+- **One top-level message per request**, no threading and no cross-request
+  coalescing: a DM thread is easy to miss, and every pending approval must
+  trip the recipient's unread badge on its own. Approvals are rare enough
+  that a burst is itself the signal something is wrong.
 - **Resolution:** whoever decides (DM click, console, or the in-thread chat
   card), the DM card is rewritten to the resolved state
   (`buildPermissionResolvedCard`) naming the decider — same treatment the
@@ -307,48 +320,48 @@ In-thread cards keep their existing gate unchanged.
 MCP approvals over `elicitation/create`) too — but the current elicit-choice
 path drops the actor on both transports: `onElicitChoice` has no actor
 parameter, the Socket Mode handler never calls `actorOf`, and the relay's
-`elicit-choice` frame omits the acting user. Interactive elicitation DMs
-therefore require extending that path first — actor on the Socket Mode
-handler, an acting-user field on the relay frame, and the §6.3 checks in
-`handleElicitChoice` for DM-originated cards. Until that lands, approval
-elicitations get **notify-only** DMs (§9 phase 1 content), never buttons.
+`elicit-choice` frame omits the acting user. That plumbing is therefore in
+scope for this delivery (§9) — actor on the Socket Mode handler, an
+acting-user field on the relay frame, and the §6.3 checks in
+`handleElicitChoice` for DM-originated cards — so both request kinds get
+identical interactive DMs; the two runtimes must not diverge here.
 
-## 7. Console notification states
+## 7. Console notification states — deferred
 
-The issue asks the notification system to show a pending approval as unread
-and a resolved one as read with "_X_ has approved/declined".
-
-The console's notification center is client-local
-(`packages/web/src/lib/notifications.tsx`, localStorage, categories
-`daemon_lifecycle | session_retention | session_access`). This design adds
-an `approval` category fed by the polling the console already does
-(`ApprovalRequestsCard`'s SWR key at a 3 s interval, plus a lightweight
-pending-count read on the shell): a request in `pending` surfaces as an
-unread notification deep-linking to the Agent/Session page; on resolution
-the same notification flips to read and renders `resolvedByName` +
-decision. Known limitation, accepted: read-state is per-browser, like every
-existing category.
+The issue also asks the notification bell to show a pending approval as
+unread and a resolved one as read ("_X_ has approved/declined"). Deferred
+out of this delivery: the console has **no cross-agent pending signal** to
+feed a bell — the only live source is the per-agent daemon proxy (polled
+on detail pages), and the protocol's `agent/activity` frame with
+`ActivityState.awaiting_permission` is declared but never emitted by any
+daemon nor handled by the CP. A future effort can revive that frame (emit
+on park/release, persist the enum `SessionMeta.activityState` already has
+a column for) and hang a client-local `approval` category off it. Until
+then the decider's name lands on the approval cards themselves (§6), which
+is where an editor already looks — tracked in a follow-up issue.
 
 ## 8. Explicit non-goal: a server-side notification store
 
 Cross-device unread state, digests, or push would need a CP-persisted
 notification model that does not exist for _any_ category today. That is an
 independent piece of infrastructure with its own design; bundling it here
-would couple a small routing feature to a large one. The client-local
-category of §7 satisfies the issue's stated behavior.
+would couple a small routing feature to a large one. Whatever revives §7
+stays client-local unless that infrastructure arrives first.
 
-## 9. Rollout phases
+## 9. Delivery
 
-1. **Notify-only DM** — frames of §4.2, CP chain evaluation, daemon posts a
-   _text_ DM (summary + session link + source permalink). No buttons: the
-   decision still happens on the web. Small, shippable, already most of the
-   user value.
-2. **Interactive DM card** — buttons in the DM, actor equality +
-   decision-time revalidation (§6.3), the elicitation actor plumbing or the
-   notify-only carve-out (§6.4), `resolvedBy` columns/frames (§6), card
-   lifecycle + restart survivability (§5.4), unconditional `block_id`
-   target on DM cards (§5.3).
-3. **Console notifications** — the `approval` category (§7).
+One delivery — notify **and** interactive DM together — as two stacked
+changes:
+
+1. **Protocol + CP** — the §4.2 frame pair, the CP chain evaluation, and
+   the decision-time verify.
+2. **Daemon + web** — DM delivery (§5), actor equality + revalidation
+   (§6.3), the elicitation actor plumbing (§6.4), `resolvedBy`
+   columns/frames (§6.1–6.2) with the console approval cards showing the
+   decider, card lifecycle + restart survivability (§5.4), and the
+   unconditional `block_id` target on DM cards (§5.3).
+
+Console notifications (§7) are deferred to a follow-up issue.
 
 ## 10. Out of scope / future
 

--- a/docs/designs/slack-approval-dm.md
+++ b/docs/designs/slack-approval-dm.md
@@ -156,11 +156,14 @@ every Slack integration the agent is connected to (almost always one) and
 lets the CP pick.
 
 The same pair also serves the decision-time revalidation of §6.3:
-`agent/approval-route` with `verify: { integrationId, teamId, userId }` set
-asks not "whom should I DM" but "does this Slack pair, **right now**, map
-to a console user who can edit this agent" — answered by `{ requestId,
-allowed, consoleUserId? }`. Routing is best-effort (§4.3); verification is
-not — it authorizes an action, so an unanswerable verify fails closed.
+`agent/approval-route` with `verify: { integrationId, teamId, userId,
+consoleUserId }` set asks not "whom should I DM" but "is this Slack pair,
+**right now**, still the linked identity of this console user, and can that
+user still edit this agent" — answered by `{ requestId, allowed,
+displayName? }`. Naming the addressed console user makes the check a single
+forward lookup instead of a scan. Routing is best-effort (§4.3);
+verification is not — it authorizes an action, so an unanswerable verify
+fails closed.
 
 The CP evaluates the chain of §3 with the `linkedMemberIds` machinery
 (`packages/control-plane/src/orchestrator/linkedDm.ts`): the same
@@ -309,8 +312,9 @@ gate is replaced by two checks, both required:
   console decision route evaluates at action time. The verify failing,
   answering `allowed: false`, or being unanswerable (CP down) all **fail
   closed**: the click is refused, the card is annotated "decide from the
-  console", and the request stays pending. The `consoleUserId` the verify
-  returns is what lands in `resolvedBy`.
+  console", and the request stays pending. The routed target's
+  `consoleUserId` plus the verify's fresh `displayName` are what land in
+  `resolvedBy` / `resolvedByName`.
 
 In-thread cards keep their existing gate unchanged.
 

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -148,6 +148,7 @@ import { RelayRoster } from './orchestrator/relayRoster.js'
 import { WebchatMcpOperationReaper } from './orchestrator/webchatMcpOperationReaper.js'
 import { HttpBotOrchestrator } from './orchestrator/httpBot.js'
 import { gatedDmSeeds, type GatedDmSeedResolver } from './orchestrator/linkedDm.js'
+import { resolveApprovalRoute, type ApprovalRouteResolver } from './orchestrator/approvalRoute.js'
 import { convergeIntegrationGating } from './orchestrator/integrationPush.js'
 import { SlackBotIdentityReconciler } from './orchestrator/slackBotIdentityReconciler.js'
 import { slackConfigApi } from './http/slack-config-api.js'
@@ -836,6 +837,23 @@ export function buildContainer(
       ...(logtoIdentity ? { identity: logtoIdentity } : {}),
       log: { debug: (o, m) => http.log.debug(o, m), warn: (o, m) => http.log.warn(o, m) }
     })
+
+  // slack-approval-dm.md §3–§4: pick / revalidate a pending approval's DM recipient.
+  // Lazy over `logtoIdentity` and `http.log` exactly like the gated-DM resolver above.
+  const approvalRoute: ApprovalRouteResolver = (req, expectedOrgId) =>
+    resolveApprovalRoute(
+      req,
+      {
+        agent: repos.agent,
+        session: repos.session,
+        integration: repos.integration,
+        bot: repos.bot,
+        users: repos.user,
+        ...(logtoIdentity ? { identity: logtoIdentity } : {}),
+        log: { debug: (o, m) => http.log.debug(o, m), warn: (o, m) => http.log.warn(o, m) }
+      },
+      expectedOrgId
+    )
 
   // HTTP-bot assignment + attributed-route compilation (shared-bot-relay.md §4.2/§10).
   // Its logger is lazy (a wrapper over `http.log`, which is created below) — only ever
@@ -1806,6 +1824,7 @@ export function buildContainer(
     integrationChannel: repos.integrationChannel,
     slackSessionAccess,
     gatedDmSeeds: gatedDmSeedResolver,
+    approvalRoute,
     // §14.8: the report path can now create an ENABLED row, so it needs the same
     // re-converge a visibility flip performs — the reporter's own bindRules predate it.
     integrationConverge: (agent) =>

--- a/packages/control-plane/src/orchestrator/approvalRoute.test.ts
+++ b/packages/control-plane/src/orchestrator/approvalRoute.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentApprovalRoute } from '@agentconnect.md/protocol'
+import type { SlackIdentity } from '../github/logto-identity.js'
+import type {
+  AgentRecord,
+  BotRecord,
+  IntegrationRecord,
+  OrgMemberRecord,
+  SessionMetaRecord
+} from '../persistence/ports.js'
+import { resolveApprovalRoute, type ApprovalRouteDeps } from './approvalRoute.js'
+
+const AGENT_ID = '11111111-1111-4111-8111-111111111111'
+const REQUEST_ID = '22222222-2222-4222-8222-222222222222'
+const INTEGRATION_A = '33333333-3333-4333-8333-333333333333'
+const INTEGRATION_B = '44444444-4444-4444-8444-444444444444'
+const ORG = 'org-1'
+const TEAM_A = 'T0AAA'
+const TEAM_B = 'T0BBB'
+
+interface World {
+  agent?: Partial<AgentRecord>
+  members?: Array<Partial<OrgMemberRecord> & { userId: string }>
+  session?: Partial<SessionMetaRecord> | null
+  // consoleUserId → linked Slack identity (null ⇒ unlinked)
+  links?: Record<string, SlackIdentity | null>
+  integrations?: Array<{ id: string; botId: string; platform?: string }>
+  bots?: Record<string, Partial<BotRecord>>
+  identityAbsent?: boolean
+}
+
+function deps(world: World): ApprovalRouteDeps {
+  const agent = {
+    id: AGENT_ID,
+    orgId: ORG,
+    visibility: 'org',
+    sharedWith: [],
+    createdByUserId: null,
+    ...world.agent
+  } as AgentRecord
+  const members = (world.members ?? []).map(
+    (m) => ({ role: 'collaborator', displayName: null, email: null, ...m }) as OrgMemberRecord
+  )
+  const integrations = (world.integrations ?? [{ id: INTEGRATION_A, botId: 'bot-a' }]).map(
+    (i) => ({ orgId: ORG, agentId: AGENT_ID, platform: 'slack', ...i }) as unknown as IntegrationRecord
+  )
+  const bots: Record<string, Partial<BotRecord>> = world.bots ?? { 'bot-a': { teamId: TEAM_A, revokedAt: null } }
+  return {
+    agent: { getUnscoped: async (id) => (String(id) === AGENT_ID ? agent : null) },
+    session: {
+      getUnscoped: async () =>
+        world.session === null || world.session === undefined
+          ? null
+          : ({ id: 'sess-1', agentId: AGENT_ID, ownerIdentity: null, ...world.session } as SessionMetaRecord)
+    },
+    integration: { activeForAgents: async () => integrations },
+    bot: {
+      get: async (_org, botId) => {
+        const bot = bots[String(botId)]
+        return bot ? ({ platform: 'slack', revokedAt: null, ...bot } as BotRecord) : null
+      }
+    },
+    users: {
+      listMembers: async () => members,
+      getOidcSubject: async (userId) => `sub:${userId}`
+    },
+    ...(world.identityAbsent
+      ? {}
+      : { identity: { slackIdentityFor: async (sub) => world.links?.[sub.slice(4)] ?? null } })
+  }
+}
+
+function routeReq(over: Partial<AgentApprovalRoute> = {}): AgentApprovalRoute {
+  return { agentId: AGENT_ID, requestId: REQUEST_ID, integrationIds: [INTEGRATION_A], ...over }
+}
+
+const linked = (userId: string, teamId = TEAM_A): SlackIdentity => ({ teamId, userId })
+
+describe('resolveApprovalRoute — route form', () => {
+  it('rung 1: the turn owner wins when linked and an editor', async () => {
+    const routed = await resolveApprovalRoute(
+      routeReq({ requesterId: 'U0OWNER' }),
+      deps({
+        members: [
+          { userId: 'u-other', displayName: 'Other' },
+          { userId: 'u-owner', displayName: 'Owner' }
+        ],
+        links: { 'u-other': linked('U0OTHER'), 'u-owner': linked('U0OWNER') }
+      })
+    )
+    expect(routed.target).toMatchObject({
+      integrationId: INTEGRATION_A,
+      teamId: TEAM_A,
+      userId: 'U0OWNER',
+      consoleUserId: 'u-owner',
+      displayName: 'Owner'
+    })
+  })
+
+  it('rung 2: a slack session owner wins only in the matching workspace', async () => {
+    const world: World = {
+      members: [{ userId: 'u-owner' }],
+      links: { 'u-owner': linked('U0OWNER') },
+      session: { ownerIdentity: `slack:${TEAM_A}:U0OWNER` }
+    }
+    const hit = await resolveApprovalRoute(routeReq({ sessionId: 'sess-1' }), deps(world))
+    expect(hit.target?.userId).toBe('U0OWNER')
+    const mismatch = await resolveApprovalRoute(
+      routeReq({ sessionId: 'sess-1' }),
+      deps({ ...world, session: { ownerIdentity: `slack:${TEAM_B}:U0OWNER` } })
+    )
+    expect(mismatch.target).toBeUndefined()
+  })
+
+  it('rung 2: a console-user session owner resolves through their own link', async () => {
+    const routed = await resolveApprovalRoute(
+      routeReq({ sessionId: 'sess-1' }),
+      deps({
+        members: [{ userId: 'u-web' }],
+        links: { 'u-web': linked('U0WEB') },
+        session: { ownerIdentity: 'user:u-web' }
+      })
+    )
+    expect(routed.target).toMatchObject({ userId: 'U0WEB', consoleUserId: 'u-web' })
+  })
+
+  it('rung 3: restricted audience picks in sharedWith order, skipping the unlinked', async () => {
+    const routed = await resolveApprovalRoute(
+      routeReq(),
+      deps({
+        agent: { visibility: 'restricted', sharedWith: ['u-first', 'u-second'] },
+        members: [{ userId: 'u-second', displayName: 'Second' }, { userId: 'u-first' }],
+        links: { 'u-second': linked('U0SECOND') }
+      })
+    )
+    expect(routed.target).toMatchObject({ userId: 'U0SECOND', consoleUserId: 'u-second' })
+  })
+
+  it('rung 4: the creator wins only as an ordinary editor', async () => {
+    const world: World = {
+      agent: { visibility: 'restricted', sharedWith: ['u-creator'], createdByUserId: 'u-creator' },
+      members: [{ userId: 'u-creator' }],
+      links: { 'u-creator': linked('U0CREATOR') }
+    }
+    expect((await resolveApprovalRoute(routeReq(), deps(world))).target?.userId).toBe('U0CREATOR')
+    // Creator dropped from sharedWith ⇒ no implicit right, no DM.
+    const unshared = deps({ ...world, agent: { ...world.agent, sharedWith: [] } })
+    expect((await resolveApprovalRoute(routeReq(), unshared)).target).toBeUndefined()
+  })
+
+  it('a viewer never receives the DM', async () => {
+    const routed = await resolveApprovalRoute(
+      routeReq({ requesterId: 'U0VIEWER' }),
+      deps({ members: [{ userId: 'u-viewer', role: 'viewer' }], links: { 'u-viewer': linked('U0VIEWER') } })
+    )
+    expect(routed.target).toBeUndefined()
+  })
+
+  it('an identity linked to another workspace never matches', async () => {
+    const routed = await resolveApprovalRoute(
+      routeReq({ requesterId: 'U0OWNER' }),
+      deps({ members: [{ userId: 'u-owner' }], links: { 'u-owner': linked('U0OWNER', TEAM_B) } })
+    )
+    expect(routed.target).toBeUndefined()
+  })
+
+  it('over the audience cap, Slack-id rungs are skipped but the creator still resolves', async () => {
+    const members = Array.from({ length: 201 }, (_, i) => ({ userId: `u-${i}` }))
+    const world: World = {
+      agent: { createdByUserId: 'u-7' },
+      members,
+      links: { 'u-0': linked('U0ZERO'), 'u-7': linked('U0CREATOR') }
+    }
+    const viaTurnOwner = await resolveApprovalRoute(routeReq({ requesterId: 'U0ZERO' }), deps({ ...world, agent: {} }))
+    expect(viaTurnOwner.target).toBeUndefined()
+    const viaCreator = await resolveApprovalRoute(routeReq(), deps(world))
+    expect(viaCreator.target).toMatchObject({ userId: 'U0CREATOR', consoleUserId: 'u-7' })
+  })
+
+  it('walks workspaces in the given order and takes the first hit', async () => {
+    const routed = await resolveApprovalRoute(
+      routeReq({ requesterId: 'U0B', integrationIds: [INTEGRATION_A, INTEGRATION_B] }),
+      deps({
+        members: [{ userId: 'u-b' }],
+        links: { 'u-b': linked('U0B', TEAM_B) },
+        integrations: [
+          { id: INTEGRATION_A, botId: 'bot-a' },
+          { id: INTEGRATION_B, botId: 'bot-b' }
+        ],
+        bots: { 'bot-a': { teamId: TEAM_A }, 'bot-b': { teamId: TEAM_B } }
+      })
+    )
+    expect(routed.target).toMatchObject({ integrationId: INTEGRATION_B, teamId: TEAM_B, userId: 'U0B' })
+  })
+
+  it('fails closed: no sign-in, unknown agent, revoked bot, foreign integration', async () => {
+    const base: World = { members: [{ userId: 'u-owner' }], links: { 'u-owner': linked('U0OWNER') } }
+    const req = routeReq({ requesterId: 'U0OWNER' })
+    expect((await resolveApprovalRoute(req, deps({ ...base, identityAbsent: true }))).target).toBeUndefined()
+    expect((await resolveApprovalRoute({ ...req, agentId: REQUEST_ID }, deps(base))).target).toBeUndefined()
+    expect(
+      (await resolveApprovalRoute(req, deps({ ...base, bots: { 'bot-a': { teamId: TEAM_A, revokedAt: new Date() } } })))
+        .target
+    ).toBeUndefined()
+    expect(
+      (await resolveApprovalRoute(routeReq({ requesterId: 'U0OWNER', integrationIds: [INTEGRATION_B] }), deps(base)))
+        .target
+    ).toBeUndefined()
+    expect((await resolveApprovalRoute(req, deps(base), 'org-other')).target).toBeUndefined()
+  })
+})
+
+describe('resolveApprovalRoute — verify form', () => {
+  const verifyReq = (consoleUserId = 'u-owner', userId = 'U0OWNER', teamId = TEAM_A) =>
+    routeReq({ verify: { integrationId: INTEGRATION_A, teamId, userId, consoleUserId } })
+
+  it('allows a still-eligible editor whose link matches the actor pair', async () => {
+    const routed = await resolveApprovalRoute(
+      verifyReq(),
+      deps({ members: [{ userId: 'u-owner', displayName: 'Owner' }], links: { 'u-owner': linked('U0OWNER') } })
+    )
+    expect(routed).toMatchObject({ allowed: true, displayName: 'Owner' })
+  })
+
+  it('refuses when the member left, was demoted, unlinked, or the pair moved', async () => {
+    const worlds: World[] = [
+      { members: [], links: { 'u-owner': linked('U0OWNER') } },
+      { members: [{ userId: 'u-owner', role: 'viewer' }], links: { 'u-owner': linked('U0OWNER') } },
+      { members: [{ userId: 'u-owner' }], links: {} },
+      { members: [{ userId: 'u-owner' }], links: { 'u-owner': linked('U0OTHER') } },
+      { members: [{ userId: 'u-owner' }], links: { 'u-owner': linked('U0OWNER', TEAM_B) } }
+    ]
+    for (const world of worlds) {
+      expect((await resolveApprovalRoute(verifyReq(), deps(world))).allowed).toBe(false)
+    }
+  })
+
+  it('refuses a workspace that does not match the integration bot', async () => {
+    const routed = await resolveApprovalRoute(
+      verifyReq('u-owner', 'U0OWNER', TEAM_B),
+      deps({ members: [{ userId: 'u-owner' }], links: { 'u-owner': linked('U0OWNER') } })
+    )
+    expect(routed.allowed).toBe(false)
+  })
+})

--- a/packages/control-plane/src/orchestrator/approvalRoute.ts
+++ b/packages/control-plane/src/orchestrator/approvalRoute.ts
@@ -1,0 +1,173 @@
+/**
+ * slack-approval-dm.md §3–§4 — pick, or revalidate, the one human a pending
+ * approval DMs.
+ *
+ * Both forms of `agent/approval-route` land here. The ROUTE form walks the §3
+ * preference chain — turn owner → session owner → restricted audience →
+ * creator — once per candidate Slack workspace, in the daemon's order, and
+ * answers with the first hit; every rung must name a console user who can
+ * edit the agent (§2's authority gate) AND whose Logto-linked Slack identity
+ * lives in that workspace (the identity gate). The VERIFY form re-asks both
+ * gates for one `(consoleUserId, teamId, userId)` binding at click time.
+ *
+ * There is deliberately no reverse Slack→console index (slack-identity.md),
+ * so Slack-id rungs resolve by the same forward scan linkedDm.ts uses,
+ * bounded by MAX_AUDIENCE over the eligible-editor set; past the cap those
+ * rungs are skipped fail-closed while console-user rungs (a `user:<id>`
+ * session owner, the creator) stay single lookups. Everything here fails
+ * CLOSED to "no DM" / "click refused" — no sign-in configured, an upstream
+ * that cannot answer, an unknown agent, a workspace mismatch.
+ */
+import type { AgentApprovalRoute, AgentApprovalRouted, ApprovalRouteTarget } from '@agentconnect.md/protocol'
+import type { SlackIdentity } from '../github/logto-identity.js'
+import type {
+  AgentRepo,
+  BotRecord,
+  BotRepo,
+  IntegrationRepo,
+  OrgMemberRecord,
+  SessionRepo,
+  UserRepo
+} from '../persistence/ports.js'
+import { AgentId, OrgId, SessionId } from '../domain/ids.js'
+import { AUDIENCE_CONCURRENCY, MAX_AUDIENCE, mapLimited } from './linkedDm.js'
+
+export interface ApprovalRouteDeps {
+  agent: Pick<AgentRepo, 'getUnscoped'>
+  session: Pick<SessionRepo, 'getUnscoped'>
+  integration: Pick<IntegrationRepo, 'activeForAgents'>
+  bot: Pick<BotRepo, 'get'>
+  users: Pick<UserRepo, 'listMembers' | 'getOidcSubject'>
+  /** Absent when the deployment has no sign-in configured — then nothing is linked. */
+  identity?: { slackIdentityFor(sub: string): Promise<SlackIdentity | null> }
+  log?: { debug(obj: object, msg: string): void; warn(obj: object, msg: string): void }
+}
+
+/** The seam the WS handler holds; the composition root knows it is Logto-backed. */
+export type ApprovalRouteResolver = (req: AgentApprovalRoute, expectedOrgId?: string) => Promise<AgentApprovalRouted>
+
+export async function resolveApprovalRoute(
+  req: AgentApprovalRoute,
+  deps: ApprovalRouteDeps,
+  expectedOrgId?: string
+): Promise<AgentApprovalRouted> {
+  const none: AgentApprovalRouted = req.verify
+    ? { requestId: req.requestId, allowed: false }
+    : { requestId: req.requestId }
+  const agent = await deps.agent.getUnscoped(AgentId(req.agentId))
+  if (!agent || (expectedOrgId && agent.orgId !== expectedOrgId) || !deps.identity) return none
+
+  const members = await deps.users.listMembers(agent.orgId)
+  // The eligible-editor set: canEdit(agent) inlined — non-viewer role plus visibility.
+  const editors = members.filter(
+    (m) => m.role !== 'viewer' && (agent.visibility === 'org' || agent.sharedWith.includes(m.userId))
+  )
+  if (editors.length === 0) return none
+
+  const owned = await deps.integration.activeForAgents([req.agentId])
+  const slackOwned = new Map(owned.filter((i) => i.platform === 'slack').map((i) => [String(i.id), i]))
+  // A revoked bot cannot open a DM, and its workspace no longer asserts anything.
+  const botFor = async (integrationId: string): Promise<BotRecord | null> => {
+    const integration = slackOwned.get(integrationId)
+    if (!integration) return null
+    const bot = await deps.bot.get(OrgId(integration.orgId), integration.botId)
+    return bot?.teamId && !bot.revokedAt ? bot : null
+  }
+  // One member's lookup failing costs that member a match, never the whole answer.
+  const pairOf = async (userId: string): Promise<SlackIdentity | null> => {
+    try {
+      const sub = await deps.users.getOidcSubject(userId)
+      return sub ? await deps.identity!.slackIdentityFor(sub) : null
+    } catch (err) {
+      deps.log?.warn({ err, userId }, 'approval route: linked-identity lookup failed — treating as unlinked')
+      return null
+    }
+  }
+
+  if (req.verify) {
+    const v = req.verify
+    const bot = await botFor(v.integrationId)
+    if (!bot || bot.teamId !== v.teamId) return none
+    // Membership + role + visibility re-checked live: left org / demoted / unshared all refuse.
+    const member = editors.find((m) => m.userId === v.consoleUserId)
+    if (!member) return none
+    const pair = await pairOf(member.userId)
+    const allowed = pair !== null && pair.teamId === v.teamId && pair.userId === v.userId
+    return {
+      requestId: req.requestId,
+      allowed,
+      ...(allowed && member.displayName ? { displayName: member.displayName } : {})
+    }
+  }
+
+  const session = req.sessionId ? await deps.session.getUnscoped(SessionId(req.sessionId)) : null
+  const ownerIdentity = session && session.agentId === req.agentId ? session.ownerIdentity : null
+  const capped = editors.length > MAX_AUDIENCE
+  if (capped) {
+    deps.log?.debug({ editors: editors.length }, 'approval route: editor set over cap — Slack-id rungs skipped')
+  }
+
+  for (const integrationId of req.integrationIds) {
+    const bot = await botFor(integrationId)
+    if (!bot) continue
+    const teamId = bot.teamId!
+    // The one forward scan (§3): editors linked to THIS workspace, both directions.
+    let bySlackUid: Map<string, OrgMemberRecord> | null = null
+    let uidByConsole: Map<string, string> | null = null
+    if (!capped) {
+      const linked = await mapLimited(editors, AUDIENCE_CONCURRENCY, async (m) => {
+        const pair = await pairOf(m.userId)
+        return pair && pair.teamId === teamId ? ([pair.userId, m] as const) : null
+      })
+      bySlackUid = new Map(linked.filter((entry): entry is readonly [string, OrgMemberRecord] => entry !== null))
+      uidByConsole = new Map([...bySlackUid].map(([uid, m]) => [m.userId, uid]))
+    }
+    const hit = (member: OrgMemberRecord, slackUid: string): AgentApprovalRouted => {
+      const target: ApprovalRouteTarget = {
+        integrationId,
+        teamId,
+        userId: slackUid,
+        consoleUserId: member.userId,
+        ...(member.displayName ? { displayName: member.displayName } : {})
+      }
+      return { requestId: req.requestId, target }
+    }
+    // Console-user rungs run even capped: resolve that one member's link directly.
+    const singleLookup = async (member: OrgMemberRecord): Promise<AgentApprovalRouted | null> => {
+      const uid = uidByConsole
+        ? (uidByConsole.get(member.userId) ?? null)
+        : await pairOf(member.userId).then((p) => (p && p.teamId === teamId ? p.userId : null))
+      return uid ? hit(member, uid) : null
+    }
+
+    // Rung 1 — conversation turn owner (a Slack member id; needs the scan).
+    const turnOwner = req.requesterId ? bySlackUid?.get(req.requesterId) : undefined
+    if (turnOwner && req.requesterId) return hit(turnOwner, req.requesterId)
+    // Rung 2 — session owner: `user:<id>` is a console user, `slack:T:U` needs the scan.
+    if (ownerIdentity) {
+      const parts = ownerIdentity.split(':')
+      if (parts.length === 2 && parts[0] === 'user') {
+        const member = editors.find((m) => m.userId === parts[1])
+        const routed = member ? await singleLookup(member) : null
+        if (routed) return routed
+      } else if (parts.length === 3 && parts[0] === 'slack' && parts[1] === teamId) {
+        const member = bySlackUid?.get(parts[2]!)
+        if (member) return hit(member, parts[2]!)
+      }
+    }
+    // Rung 3 — restricted audience, in sharedWith order (stable tie-break).
+    if (agent.visibility === 'restricted' && uidByConsole && bySlackUid) {
+      for (const userId of agent.sharedWith) {
+        const uid = uidByConsole.get(userId)
+        if (uid) return hit(bySlackUid.get(uid)!, uid)
+      }
+    }
+    // Rung 4 — agent creator (a console user; no implicit rights, must be an editor).
+    if (agent.createdByUserId) {
+      const member = editors.find((m) => m.userId === agent.createdByUserId)
+      const routed = member ? await singleLookup(member) : null
+      if (routed) return routed
+    }
+  }
+  return none
+}

--- a/packages/control-plane/src/orchestrator/linkedDm.ts
+++ b/packages/control-plane/src/orchestrator/linkedDm.ts
@@ -30,13 +30,13 @@ import type { AgentRecord, BotRecord, ChannelTrigger, ReportedChannel } from '..
 import { isGatedAgent } from './placement.js'
 
 /** Concurrent identity reads per resolve — the audience is small and every lookup is
- *  cached per subject, so this only bounds a cold burst. */
-const AUDIENCE_CONCURRENCY = 8
+ *  cached per subject, so this only bounds a cold burst. Shared with approvalRoute.ts. */
+export const AUDIENCE_CONCURRENCY = 8
 
 /** Audience size past which the scan is refused rather than fanned out upstream. An
  *  agent shared this widely is not the case §14.8 serves, and refusing keeps the
- *  §14.2 default. */
-const MAX_AUDIENCE = 200
+ *  §14.2 default. Shared with approvalRoute.ts (slack-approval-dm.md §4.2). */
+export const MAX_AUDIENCE = 200
 
 export interface LinkedDmDeps {
   users: { getOidcSubject(userId: string): Promise<string | null> }
@@ -46,7 +46,11 @@ export interface LinkedDmDeps {
 }
 
 /** Run `fn` over `values` with at most `limit` in flight, preserving order. */
-async function mapLimited<T, R>(values: readonly T[], limit: number, fn: (value: T) => Promise<R>): Promise<R[]> {
+export async function mapLimited<T, R>(
+  values: readonly T[],
+  limit: number,
+  fn: (value: T) => Promise<R>
+): Promise<R[]> {
   const out = new Array<R>(values.length)
   let next = 0
   const worker = async (): Promise<void> => {

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -44,6 +44,7 @@ import type { AgentMutationGate } from '../orchestrator/agentMutationGate.js'
 import type { PlacementResolver } from '../orchestrator/placementResolver.js'
 import type { CollabRoutesService } from '../orchestrator/collabRoutes.service.js'
 import type { GatedDmSeedResolver } from '../orchestrator/linkedDm.js'
+import type { ApprovalRouteResolver } from '../orchestrator/approvalRoute.js'
 import type { DutyLeaseService } from '../orchestrator/dutyLease.js'
 import type { AgentId, DaemonId } from '../domain/ids.js'
 import type { WebchatRemoteMcpService } from '../registry/webchatRemoteMcpService.js'
@@ -103,6 +104,9 @@ export interface DaemonWsDeps {
   /** §14.8: which of a gated install's reported DMs seed to the ordinary DM default
    *  because their counterpart is in the agent's own audience; absent ⇒ all stay Off. */
   gatedDmSeeds?: GatedDmSeedResolver
+  /** slack-approval-dm.md §4.2: pick / revalidate a pending approval's DM recipient;
+   *  absent ⇒ `agent/approval-route` fails closed and the daemon keeps today's behavior. */
+  approvalRoute?: ApprovalRouteResolver
   /** Republish the agent's integrations. Needed because §14.8 is the one path where a
    *  daemon REPORT creates an ENABLED row: the reporter is still holding bindRules that
    *  predate it, and it has already cached the conversation, so nothing re-reports and

--- a/packages/control-plane/src/ws/handlers/approval-route.test.ts
+++ b/packages/control-plane/src/ws/handlers/approval-route.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AnyFrame } from '@agentconnect.md/protocol'
+import type { DaemonConnection } from '../connection.js'
+import type { DaemonWsDeps } from '../deps.js'
+import { handleApprovalRoute } from './approval-route.js'
+
+const AGENT_ID = '11111111-1111-4111-8111-111111111111'
+const REQUEST_ID = '22222222-2222-4222-8222-222222222222'
+const INTEGRATION_ID = '33333333-3333-4333-8333-333333333333'
+
+function fakeConn() {
+  return {
+    daemonId: 'daemon-1',
+    orgId: 'org-a',
+    replyTo: vi.fn(),
+    sendError: vi.fn()
+  } as unknown as DaemonConnection & { replyTo: ReturnType<typeof vi.fn>; sendError: ReturnType<typeof vi.fn> }
+}
+
+function routeFrame(): AnyFrame {
+  return {
+    v: 1,
+    id: crypto.randomUUID(),
+    ts: new Date().toISOString(),
+    type: 'agent/approval-route',
+    orgId: 'org-a',
+    payload: { agentId: AGENT_ID, requestId: REQUEST_ID, integrationIds: [INTEGRATION_ID] }
+  } as AnyFrame
+}
+
+const baseDeps = (over: Partial<DaemonWsDeps>) => ({ log: { error: vi.fn() }, ...over }) as unknown as DaemonWsDeps
+
+describe('handleApprovalRoute', () => {
+  it('replies agent/approval-routed with the resolver answer', async () => {
+    const frame = routeFrame()
+    const conn = fakeConn()
+    const approvalRoute = vi.fn().mockResolvedValue({ requestId: REQUEST_ID })
+    await handleApprovalRoute(frame, conn, baseDeps({ approvalRoute }))
+    expect(approvalRoute).toHaveBeenCalledWith(frame.payload, 'org-a')
+    expect(conn.replyTo).toHaveBeenCalledWith(frame, 'agent/approval-routed', { requestId: REQUEST_ID })
+  })
+
+  it('fails closed when the resolver is absent', async () => {
+    const frame = routeFrame()
+    const conn = fakeConn()
+    await handleApprovalRoute(frame, conn, baseDeps({}))
+    expect(conn.sendError).toHaveBeenCalledWith(frame.id, 'SCOPE_DENIED', expect.any(String), false)
+    expect(conn.replyTo).not.toHaveBeenCalled()
+  })
+
+  it('maps a resolver throw to a retryable INTERNAL error', async () => {
+    const frame = routeFrame()
+    const conn = fakeConn()
+    const approvalRoute = vi.fn().mockRejectedValue(new Error('boom'))
+    await handleApprovalRoute(frame, conn, baseDeps({ approvalRoute }))
+    expect(conn.sendError).toHaveBeenCalledWith(frame.id, 'INTERNAL', expect.any(String), true)
+  })
+})

--- a/packages/control-plane/src/ws/handlers/approval-route.ts
+++ b/packages/control-plane/src/ws/handlers/approval-route.ts
@@ -1,0 +1,20 @@
+/** `agent/approval-route`: pick or revalidate a pending approval's DM recipient
+ *  (slack-approval-dm.md §4.2). Absent resolver fails closed — the daemon then
+ *  keeps today's notice-and-console behavior (route) or refuses the click (verify). */
+import { isFrame } from '@agentconnect.md/protocol'
+import type { Handler } from './index.js'
+
+export const handleApprovalRoute: Handler = async (frame, conn, deps) => {
+  if (!isFrame('agent/approval-route')(frame)) return
+  if (!deps.approvalRoute) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'approval routing is not enabled', false)
+    return
+  }
+  try {
+    const routed = await deps.approvalRoute(frame.payload, frame.orgId ?? conn.orgId ?? undefined)
+    conn.replyTo(frame, 'agent/approval-routed', routed)
+  } catch (error) {
+    deps.log.error({ error, agentId: frame.payload.agentId }, 'approval route failed')
+    conn.sendError(frame.id, 'INTERNAL', 'approval routing failed', true)
+  }
+}

--- a/packages/control-plane/src/ws/handlers/index.ts
+++ b/packages/control-plane/src/ws/handlers/index.ts
@@ -39,6 +39,7 @@ import { handleSessionActivity } from './event-session-activity.js'
 import { handleSessionPurged } from './event-session-purged.js'
 import { handleGitCredRequest } from './gitcred.js'
 import { handleHookStart } from './hook-start.js'
+import { handleApprovalRoute } from './approval-route.js'
 import { handleGithubReviewAuthorize } from './github-review-authorize.js'
 import { handleGithubReviewResult } from './github-review-result.js'
 import { handleCodeHostNoteResult } from './codehost-note-result.js'
@@ -85,6 +86,7 @@ export class FrameRouter {
       'agent/exists': handleAgentExists,
       'hook/report': handleHookReport,
       'hook/start': handleHookStart,
+      'agent/approval-route': handleApprovalRoute,
       'github/review-authorize': handleGithubReviewAuthorize,
       'github/review-result': handleGithubReviewResult,
       'codehost/note-result': handleCodeHostNoteResult,
@@ -132,6 +134,7 @@ export {
   handleCronReport,
   handleHookReport,
   handleHookStart,
+  handleApprovalRoute,
   handleGithubReviewAuthorize,
   handleGithubReviewResult,
   handleCodeHostNoteResult,

--- a/packages/control-plane/src/ws/handlers/register.ts
+++ b/packages/control-plane/src/ws/handlers/register.ts
@@ -13,6 +13,7 @@
 import {
   isFrame,
   AGENT_EXISTS_FEATURE,
+  APPROVAL_DM_ROUTE_V1_FEATURE,
   CODEHOST_NOTE_PROJECTION_V1_FEATURE,
   CODEHOST_REVIEW_V1_FEATURE,
   ORGANIZATION_KNOWLEDGE_FEATURE,
@@ -108,7 +109,9 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
       SESSION_PURGE_FEATURE,
       SESSION_VISIBILITY_FEATURE,
       ORGANIZATION_KNOWLEDGE_FEATURE,
-      AGENT_EXISTS_FEATURE
+      AGENT_EXISTS_FEATURE,
+      // slack-approval-dm.md §4.2: this CP resolves and revalidates approval-DM recipients.
+      APPROVAL_DM_ROUTE_V1_FEATURE
     ]
   })
   deps.connReg.markReady(conn.daemonId, conn)

--- a/packages/protocol/src/consts.ts
+++ b/packages/protocol/src/consts.ts
@@ -367,6 +367,11 @@ export const WORKSPACE_GIT_V1_FEATURE = 'workspace-git-v1'
  *  the gitlab arm of `hook/start` that records the started head and opens `running`. */
 export const CODEHOST_NOTE_PROJECTION_V1_FEATURE = 'codehost-note-projection-v1'
 
+/** CP resolves and revalidates approval-DM recipients (`agent/approval-route`,
+ *  slack-approval-dm.md §4.2). A daemon must not send that REQ before seeing this:
+ *  a new request type is frame-fatal to an older CP. */
+export const APPROVAL_DM_ROUTE_V1_FEATURE = 'approval-dm-route-v1'
+
 /** CP mints the §14.2 broker effect lease — `purpose: 'gitlab_effect'` on a gitcred v2 request,
  *  authorized by the agent's GitLab workspace binding or an enabled gitlab hook and clamped by the
  *  grant's echoed access. A daemon must not name that purpose before seeing this: a new enum value

--- a/packages/protocol/src/frame.ts
+++ b/packages/protocol/src/frame.ts
@@ -34,6 +34,7 @@ import {
   DutyFetchOk
 } from './frames/duty.js'
 import { CodeHostNoteDesired, CodeHostNoteResult, CodeHostNoteResultOk } from './frames/codehost-note.js'
+import { AgentApprovalRoute, AgentApprovalRouted } from './frames/approval-route.js'
 import {
   GithubReviewAuthorize,
   GithubReviewAuthorized,
@@ -249,6 +250,9 @@ export const FRAME_SCHEMAS = {
   'agent/permission-requests': AgentPermissionRequestList,
   'agent/permission-requests/page': AgentPermissionRequestPage,
   'agent/permission-decision': AgentPermissionDecision,
+  // ── approval-DM routing: pick / revalidate a Slack recipient (approval-route.ts).
+  'agent/approval-route': AgentApprovalRoute,
+  'agent/approval-routed': AgentApprovalRouted,
   // ── sandbox wake: a console-initiated resume with no turn (agent.ts `AgentWakeReq`).
   'agent/wake': AgentWakeReq,
   'agent/wake/ok': AgentWakeOk,
@@ -541,6 +545,8 @@ export const AnyFrame = z.discriminatedUnion('type', [
   frame('agent/permission-requests', FRAME_SCHEMAS['agent/permission-requests']),
   frame('agent/permission-requests/page', FRAME_SCHEMAS['agent/permission-requests/page']),
   frame('agent/permission-decision', FRAME_SCHEMAS['agent/permission-decision']),
+  frame('agent/approval-route', FRAME_SCHEMAS['agent/approval-route']),
+  frame('agent/approval-routed', FRAME_SCHEMAS['agent/approval-routed']),
   frame('agent/wake', FRAME_SCHEMAS['agent/wake']),
   frame('agent/wake/ok', FRAME_SCHEMAS['agent/wake/ok']),
   // ── routing and daemon control ──

--- a/packages/protocol/src/frames/approval-route.test.ts
+++ b/packages/protocol/src/frames/approval-route.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { buildEnvelope, decodeEnvelope } from '../index.js'
+
+const AGENT_ID = '11111111-1111-4111-8111-111111111111'
+const REQUEST_ID = '22222222-2222-4222-8222-222222222222'
+const INTEGRATION_ID = '33333333-3333-4333-8333-333333333333'
+
+describe('agent/approval-route frames', () => {
+  it('round-trips the route form and its reply', () => {
+    const route = buildEnvelope(
+      'agent/approval-route',
+      {
+        agentId: AGENT_ID,
+        requestId: REQUEST_ID,
+        sessionId: 'sess-1',
+        requesterId: 'U0TURNOWNER',
+        integrationIds: [INTEGRATION_ID]
+      },
+      { orgId: 'org-a' }
+    )
+    const decoded = decodeEnvelope(JSON.stringify(route))
+    expect(decoded.ok).toBe(true)
+    if (!decoded.ok) return
+    expect(decoded.frame.type).toBe('agent/approval-route')
+
+    const routed = buildEnvelope(
+      'agent/approval-routed',
+      {
+        requestId: REQUEST_ID,
+        target: {
+          integrationId: INTEGRATION_ID,
+          teamId: 'T0WORKSPACE',
+          userId: 'U0EDITOR',
+          consoleUserId: 'user-1',
+          displayName: 'Editor'
+        }
+      },
+      { corr: route.id, orgId: 'org-a' }
+    )
+    expect(decodeEnvelope(JSON.stringify(routed)).ok).toBe(true)
+  })
+
+  it('round-trips the verify form, a no-target reply, and a refusal', () => {
+    const verify = buildEnvelope(
+      'agent/approval-route',
+      {
+        agentId: AGENT_ID,
+        requestId: REQUEST_ID,
+        integrationIds: [INTEGRATION_ID],
+        verify: { integrationId: INTEGRATION_ID, teamId: 'T0WORKSPACE', userId: 'U0EDITOR', consoleUserId: 'user-1' }
+      },
+      { orgId: 'org-a' }
+    )
+    expect(decodeEnvelope(JSON.stringify(verify)).ok).toBe(true)
+    for (const payload of [
+      { requestId: REQUEST_ID },
+      { requestId: REQUEST_ID, allowed: false },
+      { requestId: REQUEST_ID, allowed: true, displayName: 'Editor' }
+    ]) {
+      const rep = buildEnvelope('agent/approval-routed', payload, { corr: verify.id, orgId: 'org-a' })
+      expect(decodeEnvelope(JSON.stringify(rep)).ok).toBe(true)
+    }
+  })
+
+  it('rejects an empty integration list', () => {
+    const bad = buildEnvelope(
+      'agent/approval-route',
+      { agentId: AGENT_ID, requestId: REQUEST_ID, integrationIds: [] },
+      { orgId: 'org-a' }
+    )
+    expect(decodeEnvelope(JSON.stringify(bad)).ok).toBe(false)
+  })
+})

--- a/packages/protocol/src/frames/approval-route.ts
+++ b/packages/protocol/src/frames/approval-route.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod'
+
+/**
+ * Approval-DM routing control frames (slack-approval-dm.md §4.2), gated by
+ * `approval-dm-route-v1`.
+ *
+ * One request/reply pair serves two questions. The ROUTE form ("whom should I
+ * DM about this pending approval") is best-effort: no target means the daemon
+ * keeps today's behavior. The VERIFY form (`verify` set — "does this Slack
+ * pair, right now, map to the console user I addressed, and can that user
+ * still edit this agent") authorizes an action and therefore fails closed:
+ * `allowed: false` or an unanswerable exchange both refuse the click.
+ *
+ * Approval content never rides these frames — only ids, a Slack member id,
+ * and a display name. Nothing here is `.strict()`, so an additive field
+ * degrades per-value instead of making a frame undecodable.
+ */
+
+/** The chosen recipient: a Slack `(teamId, userId)` pair — never `userId`
+ *  alone, per slack-identity.md — plus the console user it was verified
+ *  against and the integration whose workspace anchored the match. */
+export const ApprovalRouteTarget = z.object({
+  integrationId: z.string().uuid(),
+  teamId: z.string().min(1),
+  userId: z.string().min(1),
+  consoleUserId: z.string().min(1),
+  displayName: z.string().min(1).optional()
+})
+export type ApprovalRouteTarget = z.infer<typeof ApprovalRouteTarget>
+
+/** `agent/approval-route` (D→C REQ). */
+export const AgentApprovalRoute = z.object({
+  agentId: z.string().uuid(),
+  requestId: z.string().uuid(),
+  // The owning session, by its outward id — carries `ownerIdentity` for rung 2.
+  sessionId: z.string().min(1).optional(),
+  // Turn owner's Slack member id when the triggering turn came from Slack (rung 1).
+  requesterId: z.string().min(1).optional(),
+  // The agent's connected Slack integrations in the order to try, the session's
+  // own bot first when the session is on Slack (§3: one workspace at a time).
+  integrationIds: z.array(z.string().uuid()).min(1).max(8),
+  // Decision-time revalidation (§6.3): the clicking actor's pair and the console
+  // user the DM addressed. Present ⇒ the reply carries `allowed`, never `target`.
+  verify: z
+    .object({
+      integrationId: z.string().uuid(),
+      teamId: z.string().min(1),
+      userId: z.string().min(1),
+      consoleUserId: z.string().min(1)
+    })
+    .optional()
+})
+export type AgentApprovalRoute = z.infer<typeof AgentApprovalRoute>
+
+/** `agent/approval-routed` (C→D REP). Route form: `target` or nothing ("no
+ *  eligible recipient, keep today's behavior"). Verify form: `allowed`, with a
+ *  fresh `displayName` for the decision record when allowed. */
+export const AgentApprovalRouted = z.object({
+  requestId: z.string().uuid(),
+  target: ApprovalRouteTarget.optional(),
+  allowed: z.boolean().optional(),
+  displayName: z.string().min(1).optional()
+})
+export type AgentApprovalRouted = z.infer<typeof AgentApprovalRouted>

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -47,6 +47,7 @@ export {
   RUNTIME_COMMANDS_FEATURE,
   K8S_SUPERVISOR,
   AGENT_EXISTS_FEATURE,
+  APPROVAL_DM_ROUTE_V1_FEATURE,
   SESSION_LIVE_TAIL_FEATURE,
   SESSION_METADATA_ACK_FEATURE,
   SESSION_PURGE_FEATURE,
@@ -84,6 +85,7 @@ export * from './frames/duty.js'
 export * from './frames/hook.js'
 export * from './frames/codehost-note.js'
 export * from './frames/codehost-review.js'
+export * from './frames/approval-route.js'
 export * from './frames/integration.js'
 export * from './frames/mcpserver.js'
 export * from './frames/memory-connection.js'


### PR DESCRIPTION
## Summary

First of two stacked changes implementing [slack-approval-dm.md](docs/designs/slack-approval-dm.md) (#1648) — the protocol frames and the Control Plane half. The daemon/web half (DM delivery, click checks, elicitation actor plumbing, `resolvedBy`) follows stacked on this.

- **Design doc settled** per review discussion: each DM is its own top-level message, console notifications deferred to a follow-up issue (with the `awaiting_permission` revival path recorded), elicitation actor plumbing in scope, and non-Slack-triggered sessions route through the agent's connected Slack integrations with the CP picking the first workspace whose chain yields a target.
- **Protocol:** `agent/approval-route` → `agent/approval-routed` (org-scoped, modeled on `github/review-authorize`), gated by the new `approval-dm-route-v1` server feature. The `verify` form re-asks both gates for one console user at click time.
- **CP resolver** (`orchestrator/approvalRoute.ts`): the §3 preference chain — turn owner → session owner → restricted audience → creator — over the `canEdit`-eligible editor set, evaluated once per candidate Slack workspace; reuses `linkedDm`'s forward scan with its `MAX_AUDIENCE` cap (Slack-id rungs skip fail-closed past it, console-user rungs stay single lookups). No reverse Slack→console index, per `slack-identity.md`.
- **WS handler** follows the `github/review-authorize` pattern (absent resolver ⇒ `SCOPE_DENIED` fail-closed); composed lazily over `logtoIdentity` in `container.ts` like the gated-DM resolver.

## Test plan

- New protocol round-trip tests (frame pair, verify form, empty-list rejection) — pass.
- New CP unit tests: 13 resolver cases (all four rungs, viewer/workspace/cap/fail-closed matrices, verify allow/refuse matrix) + 3 handler cases — pass.
- `pnpm --filter @agentconnect.md/protocol test` (473), CP `test:unit` (2121), CP `test:int` (1829, Testcontainers Postgres) — all pass; protocol/CP/daemon typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)