### PR TITLE
feat(daemon): translate an ACP turn into Linear agent activities

### DIFF
--- a/packages/daemon/src/platforms/linear/turn-output.ts
+++ b/packages/daemon/src/platforms/linear/turn-output.ts
@@ -83,9 +83,10 @@ export interface LinearTurn {
   }
 }
 
-/** Linear's opaque per-turn state (§5): the hard activity budget and the last plan
+/** Linear's opaque per-turn state (§5): the hard chrome budget and the last plan
  *  actually pushed, so an unchanged plan costs no `agentSessionUpdate`. */
 export interface LinearTurnState {
+  /** Remaining non-settling activities; a settling `response`/`error` never draws on it. */
   activityBudget: number
   lastPlanHash?: string
 }
@@ -134,7 +135,8 @@ export const MAX_ACTION_RESULT = 2800
 export const MAX_ACTION_PARAMETER = 500
 /** Soft per-turn action cap; the overflow is reported once as "… and N more". */
 export const MAX_TURN_ACTIONS = 40
-/** Hard per-turn activity budget enforced at the egress edge, under every soft cap. */
+/** Hard per-turn CHROME budget enforced at the egress edge, under every soft cap. The settling
+ *  `response`/`error` is exempt: the cap bounds progress noise, never the turn's one answer. */
 export const MAX_TURN_ACTIVITIES = 200
 /** Message-text tail kept for sentinel detection — far more than the sentinel's own line needs. */
 const SENTINEL_TAIL_CHARS = 512
@@ -515,10 +517,14 @@ export class LinearConverger {
     return [...this.takePending(), { kind: 'activity', type: 'thought', body: text.trim() }]
   }
 
+  /** Emit the reasoning accumulated SINCE THE LAST FLUSH. The in-place renderers keep a
+   *  cumulative buffer because they edit one message; an append-only feed must send deltas,
+   *  or every flush re-posts the whole turn's thinking. */
   private drainReasoning(): LinearAction[] {
     if (!this.reasoningDirty) return []
     this.reasoningDirty = false
     const trimmed = this.reasoning.trim()
+    this.reasoning = ''
     if (!trimmed) return []
     const tail = trimmed.length > MAX_REASONING ? `…${trimmed.slice(-MAX_REASONING)}` : trimmed
     return [{ kind: 'activity', type: 'thought', body: tail, ephemeral: true }]
@@ -560,6 +566,11 @@ function toActivityInput(action: Extract<LinearAction, { kind: 'activity' }>): L
   }
 }
 
+/** The two activities that drive the Linear session out of `active` — a turn owes exactly one. */
+function isSettlingActivity(action: Extract<LinearAction, { kind: 'activity' }>): boolean {
+  return action.type === 'response' || action.type === 'error'
+}
+
 /**
  * Apply one converger action to Linear, through the connection's own send queue.
  *
@@ -578,9 +589,12 @@ export async function applyLinearAction<TTurn extends LinearTurn>(
   switch (action.kind) {
     case 'activity': {
       // The hard backstop under every soft cap: a runaway turn cannot exhaust the workspace's
-      // hourly budget on one session's feed.
-      if (state.activityBudget <= 0) return
-      state.activityBudget -= 1
+      // hourly budget on one session's feed. It bounds CHROME only — a settling activity is
+      // exempt, because dropping it would lose the answer and leave the session active forever.
+      if (!isSettlingActivity(action)) {
+        if (state.activityBudget <= 0) return
+        state.activityBudget -= 1
+      }
       await port.postActivity(sessionId, toActivityInput(action))
       return
     }

--- a/packages/daemon/src/platforms/linear/turn-output.ts
+++ b/packages/daemon/src/platforms/linear/turn-output.ts
@@ -1,0 +1,600 @@
+/**
+ * Linear's **streaming turn-output surface** (linear-integration.md §5).
+ *
+ * Linear activities are APPEND-ONLY snapshots: `agentActivityCreate` never
+ * coalesces, so even identical `(action, parameter)` pairs stack in the feed.
+ * The converger therefore runs in a discrete-update posture — coalesce
+ * aggressively, post meaningfully — and every collapse rule below is ours, not
+ * the platform's. GitHub's turn-FINAL shape is deliberately not used: Linear's
+ * product is the live feed, so this surface emits as it goes.
+ */
+import type { SessionUpdate } from '@agentclientprotocol/sdk'
+import { appendGithubMarkdownChrome, GithubReplyCollector } from '../../github/poster.js'
+import { renderAttributionMessage } from '../../messages/attribution.js'
+import { splitAtParagraphBoundary } from '../../messages/stream-boundary.js'
+import { isNoResponseBody, isNoResponsePrefix } from '../../session/no-response.js'
+import { extractToolOutput } from '../../session/tool-output.js'
+import type { TurnOutputContext } from '../turn-output.js'
+
+/** Linear's plan-entry vocabulary. `canceled` has no ACP source today; it exists because
+ *  the plan array is a full replace and a future entry may need it. */
+export type LinearPlanStatus = 'pending' | 'inProgress' | 'completed' | 'canceled'
+
+export interface LinearPlanEntry {
+  content: string
+  status: LinearPlanStatus
+}
+
+export interface LinearExternalUrl {
+  label: string
+  url: string
+}
+
+/** The converger's Linear-shaped IR (§5). `activity` becomes `agentActivityCreate`;
+ *  `plan` / `external-urls` become `agentSessionUpdate`. */
+export type LinearAction =
+  | { kind: 'activity'; type: 'thought'; body: string; ephemeral?: boolean }
+  | { kind: 'activity'; type: 'action'; action: string; parameter: string; result?: string }
+  | { kind: 'activity'; type: 'response'; body: string }
+  | { kind: 'activity'; type: 'error'; body: string }
+  | { kind: 'activity'; type: 'elicitation'; body: string }
+  | { kind: 'plan'; entries: LinearPlanEntry[] }
+  | { kind: 'external-urls'; add: LinearExternalUrl[] }
+
+/** One `agentActivityCreate` input, flattened. The egress port owns the GraphQL shape. */
+export interface LinearActivityInput {
+  type: 'thought' | 'action' | 'response' | 'error' | 'elicitation'
+  body?: string
+  action?: string
+  parameter?: string
+  result?: string
+  ephemeral?: boolean
+}
+
+/** One `agentSessionUpdate` input. Both fields are full-array replace on Linear's side. */
+export interface LinearSessionUpdateInput {
+  plan?: LinearPlanEntry[]
+  addedExternalUrls?: LinearExternalUrl[]
+}
+
+/**
+ * What `apply` needs from Linear, and nothing more (§4.6 single-writer egress).
+ *
+ * The per-integration connection satisfies this structurally, and it — not this
+ * module — owns the send queue, the brokered token, and the retry ladder. Kept
+ * as a port so the surface can be tested without a connection at all.
+ */
+export interface LinearEgressPort {
+  /** Append one activity to the AgentSession's feed. */
+  postActivity(sessionId: string, activity: LinearActivityInput): Promise<void>
+  /** Patch the AgentSession's plan / external URLs. */
+  updateSession(sessionId: string, update: LinearSessionUpdateInput): Promise<void>
+}
+
+/** The core turn, as Linear's applier sees it. `Pending` satisfies it structurally. */
+export interface LinearTurn {
+  conn?: unknown
+  plan: {
+    /** The Linear AgentSession UUID — the normalized `thread` coordinate (§4.5). */
+    thread?: string
+    platform: string
+    agentId: string
+    sessionKey: string
+  }
+}
+
+/** Linear's opaque per-turn state (§5): the hard activity budget and the last plan
+ *  actually pushed, so an unchanged plan costs no `agentSessionUpdate`. */
+export interface LinearTurnState {
+  activityBudget: number
+  lastPlanHash?: string
+}
+
+/** Raw attribution identity for the response footer. Structurally the same record the
+ *  code-host posters take, so core resolves it once for every Markdown surface. */
+export interface LinearAttribution {
+  agentName: string
+  agentUrl: string
+  runtime: string
+  model: string
+  sessionUrl: string
+}
+
+export type LinearOutputMode = 'none' | 'minimal' | 'low' | 'medium' | 'high'
+
+/** What one output mode lets the converger emit (§5.2). */
+export interface LinearModePolicy {
+  /** `agent_thought_chunk` → ephemeral thought. */
+  readonly reasoning: boolean
+  /** Intermediate `agent_message_chunk` → non-ephemeral progress thought. */
+  readonly progress: boolean
+  readonly actions: boolean
+  /** Tool output carried on the action's `result` field. */
+  readonly actionResults: boolean
+  readonly plan: boolean
+  /** The settling `response` — and, with it, `error` and `elicitation`: `none` is truly silent. */
+  readonly response: boolean
+}
+
+// The default is `low`, and it already includes actions and plan: an agent-session feed is
+// FOR progress visibility, which is the opposite of a chat channel's default.
+const MODE_POLICY: Record<LinearOutputMode, LinearModePolicy> = {
+  none: { reasoning: false, progress: false, actions: false, actionResults: false, plan: false, response: false },
+  minimal: { reasoning: false, progress: false, actions: false, actionResults: false, plan: false, response: true },
+  low: { reasoning: false, progress: true, actions: true, actionResults: false, plan: true, response: true },
+  medium: { reasoning: true, progress: true, actions: true, actionResults: false, plan: true, response: true },
+  high: { reasoning: true, progress: true, actions: true, actionResults: true, plan: true, response: true }
+}
+
+/** Reasoning tail clamp, matching every other renderer's `MAX_REASONING`. */
+export const MAX_REASONING = 2800
+/** Head clamp on an action's `result` (§5.1). */
+export const MAX_ACTION_RESULT = 2800
+/** Clamp on an action's `parameter` summary. */
+export const MAX_ACTION_PARAMETER = 500
+/** Soft per-turn action cap; the overflow is reported once as "… and N more". */
+export const MAX_TURN_ACTIONS = 40
+/** Hard per-turn activity budget enforced at the egress edge, under every soft cap. */
+export const MAX_TURN_ACTIVITIES = 200
+/** Message-text tail kept for sentinel detection — far more than the sentinel's own line needs. */
+const SENTINEL_TAIL_CHARS = 512
+
+/** Posted when the turn produced no final text but still owes Linear a settling `response`. */
+export const EMPTY_RESPONSE_BODY = 'Done.'
+/** v1 elicitation copy (§10.4): a pointer to the console, not an approval protocol. */
+export const PERMISSION_ELICITATION_BODY = 'This step needs approval — open the session in the console.'
+
+export function linearModePolicy(mode: LinearOutputMode): LinearModePolicy {
+  return MODE_POLICY[mode]
+}
+
+function normalizeMode(mode: string): LinearOutputMode {
+  return mode in MODE_POLICY ? (mode as LinearOutputMode) : 'low'
+}
+
+function flatText(raw: string | undefined, max = 200): string {
+  return (raw ?? '').replace(/\s+/g, ' ').trim().slice(0, max)
+}
+
+/** Escape the Markdown punctuation that would otherwise break a link label. */
+function escapeMarkdown(raw: string): string {
+  return raw.replace(/([\\`*_[\]<>])/g, '\\$1')
+}
+
+function httpUrl(raw: string | undefined): string | undefined {
+  if (!raw) return undefined
+  try {
+    const url = new URL(raw)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined
+    return url.toString().replace(/\(/g, '%28').replace(/\)/g, '%29')
+  } catch {
+    return undefined
+  }
+}
+
+function markdownLink(label: string, raw: string | undefined): string {
+  const url = httpUrl(raw)
+  const text = escapeMarkdown(label)
+  return url ? `[${text}](${url})` : text
+}
+
+/**
+ * The response footer, in plain Markdown.
+ *
+ * The sentence itself is the platform-neutral one every surface shares; the code hosts'
+ * `<sub>`/`<img>` chrome is deliberately not reused, because Linear renders Markdown and
+ * not raw HTML.
+ */
+export function linearAttributionFooter(attribution?: LinearAttribution): string {
+  if (!attribution) return ''
+  const sessionUrl = httpUrl(attribution.sessionUrl)
+  const message = renderAttributionMessage({
+    agent: markdownLink(flatText(attribution.agentName) || 'unknown agent', attribution.agentUrl),
+    runtime: escapeMarkdown(flatText(attribution.runtime)),
+    model: escapeMarkdown(flatText(attribution.model)),
+    ...(sessionUrl ? { renderSession: (label: string) => markdownLink(label, sessionUrl) } : {})
+  })
+  return `\n\n${message}`
+}
+
+/** Pull a compact input summary out of a tool call's `rawInput` for the `parameter` field. */
+export function summarizeToolInput(rawInput: unknown): string {
+  if (typeof rawInput === 'string') return flatText(rawInput, MAX_ACTION_PARAMETER)
+  if (!rawInput || typeof rawInput !== 'object' || Array.isArray(rawInput)) return ''
+  const input = rawInput as Record<string, unknown>
+  for (const key of ['command', 'cmd', 'path', 'file_path', 'query', 'url', 'pattern', 'prompt']) {
+    const value = input[key]
+    if (typeof value === 'string' && value.trim()) return flatText(value, MAX_ACTION_PARAMETER)
+  }
+  const scalars = Object.entries(input)
+    .filter(([, value]) => typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean')
+    .map(([key, value]) => `${key}=${String(value)}`)
+  return flatText(scalars.join(' '), MAX_ACTION_PARAMETER)
+}
+
+/** Head-clamp a tool result: the head is where a command says what it did. */
+function clampResult(raw: string | undefined): string | undefined {
+  const text = raw?.trim()
+  if (!text) return undefined
+  return text.length > MAX_ACTION_RESULT ? `${text.slice(0, MAX_ACTION_RESULT)}\n…` : text
+}
+
+function toPlanEntry(entry: { content?: unknown; status?: unknown }): LinearPlanEntry {
+  const status = entry.status === 'in_progress' ? 'inProgress' : entry.status === 'completed' ? 'completed' : 'pending'
+  return { content: typeof entry.content === 'string' ? entry.content : '', status }
+}
+
+/** The subset of an ACP update this converger reads. */
+interface LinearUpdateView {
+  sessionUpdate?: string
+  content?: { type?: string; text?: string }
+  toolCallId?: string
+  title?: string
+  status?: string
+  rawInput?: unknown
+  rawOutput?: unknown
+  entries?: { content?: unknown; status?: unknown }[]
+}
+
+/** A run of consecutive same-title tool calls, held until something separates it from the next. */
+interface PendingAction {
+  title: string
+  parameters: string[]
+  result?: string
+  count: number
+}
+
+/**
+ * One turn's Linear production rules (§5.1).
+ *
+ * The idle WINDOW is core's (it re-arms the shared ~2 s timer on `hasBuffered()` and
+ * flushes through `flushBuffered()`), so this class holds no timers of its own and is
+ * deterministic under test on every platform.
+ */
+export class LinearConverger {
+  private readonly policy: LinearModePolicy
+  private readonly collector = new GithubReplyCollector()
+  // The collector reports a suppressed turn as "no final answer", which is indistinguishable
+  // from a silent one — so the sentinel is detected here, on a mode-independent message tail.
+  private sentinelTail = ''
+  private narration = ''
+  private reasoning = ''
+  private reasoningDirty = false
+  private readonly toolTitles = new Map<string, string>()
+  private readonly toolParameters = new Map<string, string>()
+  private readonly toolResults = new Map<string, string>()
+  private readonly openTools = new Set<string>()
+  private readonly settledTools = new Set<string>()
+  private pending?: PendingAction
+  private actionsEmitted = 0
+  private droppedActions = 0
+  private planEntries?: LinearPlanEntry[]
+  private planDirty = false
+  private lastPlanKey?: string
+  private lastElicitation?: string
+  private settled = false
+
+  constructor(
+    private readonly mode: LinearOutputMode,
+    private readonly showFooter: boolean
+  ) {
+    this.policy = MODE_POLICY[mode]
+  }
+
+  /** Diagnostic only; never parsed. */
+  outputMode(): LinearOutputMode {
+    return this.mode
+  }
+
+  /** True while anything is pending — core (re)arms the shared idle timer on it. */
+  hasBuffered(): boolean {
+    if (this.settled) return false
+    return (
+      this.pending !== undefined ||
+      this.reasoningDirty ||
+      this.planDirty ||
+      (this.openTools.size > 0 && this.narration.trim().length > 0)
+    )
+  }
+
+  onUpdate(update: SessionUpdate): LinearAction[] {
+    if (this.settled) return []
+    // The collector reads the WHOLE stream, independently of what this mode emits: it is
+    // what selects the one logical final answer at turn end.
+    this.collector.onUpdate(update)
+    const u = update as LinearUpdateView
+    switch (u.sessionUpdate) {
+      case 'agent_message_chunk': {
+        if (u.content?.type !== 'text') return []
+        const text = u.content.text ?? ''
+        this.sentinelTail = (this.sentinelTail + text).slice(-SENTINEL_TAIL_CHARS)
+        if (this.policy.progress) this.narration += text
+        return []
+      }
+      case 'agent_thought_chunk': {
+        if (!this.policy.reasoning) return []
+        const text = u.content?.text ?? ''
+        if (!text) return []
+        this.reasoning += text
+        if (this.reasoning.length > MAX_REASONING * 2) this.reasoning = this.reasoning.slice(-MAX_REASONING * 2)
+        this.reasoningDirty = true
+        return []
+      }
+      case 'tool_call':
+      case 'tool_call_update':
+        return this.onToolUpdate(u)
+      case 'plan': {
+        if (!this.policy.plan) return []
+        // Last write wins inside the window; the emit happens on the next flush (§5.3).
+        this.planEntries = (u.entries ?? []).map(toPlanEntry)
+        this.planDirty = true
+        return []
+      }
+      default:
+        return []
+    }
+  }
+
+  /** Idle-window flush. Narration is cut here only while a tool call is in flight — that is
+   *  the one proof the text is progress and not the closing answer the `response` will carry. */
+  flushBuffered(): LinearAction[] {
+    if (this.settled) return []
+    const narration = this.openTools.size > 0 ? this.flushNarration(false) : []
+    return [...narration, ...this.takePending(), ...this.drainReasoning(), ...this.drainPlan()]
+  }
+
+  /** Drain everything for a turn ending abnormally: the runtime narrated its terminal error
+   *  into the message stream and there is no later flush, so take the WHOLE buffer. */
+  flushTerminal(): LinearAction[] {
+    if (this.settled) return []
+    return [...this.flushNarration(true), ...this.takePending(), ...this.drainReasoning(), ...this.drainPlan()]
+  }
+
+  /**
+   * Turn end: the settling `response`.
+   *
+   * A `response` is what drives the Linear session to `complete`, so exactly one is emitted
+   * per turn — and it OPENS the settled state, after which this converger emits nothing.
+   * `AC_NO_RESPONSE` is the one exception: the pre-spawn ack already exists, so a suppressed
+   * turn is ack-only and no settling response follows (§5.1).
+   */
+  onFinal(attribution?: LinearAttribution): LinearAction[] {
+    if (this.settled) return []
+    this.settled = true
+    if (isNoResponseBody(this.sentinelTail.trim())) return this.discard()
+    if (!this.policy.response) return this.discard()
+    const final = this.collector.finalText(true)?.trim() ?? ''
+    // The residual narration IS the final answer on an append-only feed, so it is never
+    // re-posted as a thought here; the trailing ephemeral reasoning would be replaced by the
+    // response on arrival, so it is dropped rather than paying an API call.
+    this.narration = ''
+    this.reasoningDirty = false
+    const out: LinearAction[] = [...this.takePending(), ...this.drainPlan()]
+    if (this.droppedActions > 0) {
+      out.push({ kind: 'activity', type: 'thought', body: `… and ${this.droppedActions} more tool calls` })
+    }
+    out.push({ kind: 'activity', type: 'response', body: this.responseBody(final, attribution) })
+    return out
+  }
+
+  /**
+   * Turn failure: the settling `error`, carrying core's `turnFailureReason`.
+   *
+   * The buffer is flushed FIRST so a runtime that narrated its own terminal error into the
+   * message stream is not repeated — a flushed thought that already states the reason is
+   * dropped in favor of the `error` activity, which is what moves the Linear session to
+   * `error` rather than leaving it active.
+   */
+  onFailure(reason: string): LinearAction[] {
+    if (this.settled) return []
+    this.settled = true
+    if (!this.policy.response) return this.discard()
+    const flushed = [...this.flushNarration(true), ...this.takePending()]
+    const deduped = flushed.filter((a) => !(a.kind === 'activity' && a.type === 'thought' && a.body.includes(reason)))
+    return [...deduped, { kind: 'activity', type: 'error', body: reason }]
+  }
+
+  /** A permission gate would block the turn: point at the console (§10.4). Repeated identical
+   *  gates collapse, because an append-only feed would otherwise stack them. */
+  onPermissionBlocked(sessionUrl?: string): LinearAction[] {
+    if (this.settled || !this.policy.response) return []
+    const link = httpUrl(sessionUrl)
+    const body = link
+      ? `${PERMISSION_ELICITATION_BODY} ${markdownLink('open in session', link)}`
+      : PERMISSION_ELICITATION_BODY
+    if (this.lastElicitation === body) return []
+    this.lastElicitation = body
+    return [...this.flushNarration(true), ...this.takePending(), { kind: 'activity', type: 'elicitation', body }]
+  }
+
+  private discard(): LinearAction[] {
+    this.narration = ''
+    this.reasoning = ''
+    this.reasoningDirty = false
+    this.pending = undefined
+    this.planDirty = false
+    return []
+  }
+
+  private responseBody(final: string, attribution?: LinearAttribution): string {
+    const footer = this.showFooter ? linearAttributionFooter(attribution) : ''
+    return appendGithubMarkdownChrome(final || EMPTY_RESPONSE_BODY, footer)
+  }
+
+  private onToolUpdate(u: LinearUpdateView): LinearAction[] {
+    if (!this.policy.actions) return []
+    const id = u.toolCallId
+    const title = this.rememberTool(u)
+    if (id) {
+      if (u.rawInput !== undefined) {
+        const parameter = summarizeToolInput(u.rawInput)
+        if (parameter) this.toolParameters.set(id, parameter)
+      }
+      if (u.content !== undefined || u.rawOutput !== undefined) {
+        const output = extractToolOutput(u)
+        if (output) this.toolResults.set(id, output)
+      }
+    }
+    const terminal = u.status === 'completed' || u.status === 'failed'
+    if (id) {
+      if (terminal) this.openTools.delete(id)
+      else this.openTools.add(id)
+    }
+    // A tool boundary is a semantic boundary: whatever narration preceded it was progress.
+    const boundary = this.flushNarration(true)
+    // §15-1 is resolved live — Linear stacks every create, so an action is emitted ONCE, at
+    // terminal status. A start-status call contributes nothing but its title and input.
+    if (!terminal || !id || this.settledTools.has(id)) return boundary
+    this.settledTools.add(id)
+    const parameter = this.toolParameters.get(id) ?? ''
+    const result = this.policy.actionResults ? clampResult(this.toolResults.get(id)) : undefined
+    this.toolParameters.delete(id)
+    this.toolResults.delete(id)
+    if (this.pending?.title === title) {
+      this.pending.count += 1
+      if (parameter) this.pending.parameters.push(parameter)
+      if (result) this.pending.result = result
+      return boundary
+    }
+    const released = this.takePending()
+    this.pending = { title, parameters: parameter ? [parameter] : [], count: 1, ...(result ? { result } : {}) }
+    return [...boundary, ...released]
+  }
+
+  private rememberTool(u: LinearUpdateView): string {
+    const id = u.toolCallId
+    if (u.title) {
+      if (id) this.toolTitles.set(id, u.title)
+      return u.title
+    }
+    return (id && this.toolTitles.get(id)) ?? id ?? 'tool'
+  }
+
+  /** Release the held run as one action row. Over the cap it is counted, not emitted. */
+  private takePending(): LinearAction[] {
+    const held = this.pending
+    if (!held) return []
+    this.pending = undefined
+    if (this.actionsEmitted >= MAX_TURN_ACTIONS) {
+      this.droppedActions += 1
+      return []
+    }
+    this.actionsEmitted += 1
+    return [
+      {
+        kind: 'activity',
+        type: 'action',
+        action: held.count > 1 ? `${held.title} ×${held.count}` : held.title,
+        parameter: flatText(held.parameters.join('\n'), MAX_ACTION_PARAMETER),
+        ...(held.result ? { result: held.result } : {})
+      }
+    ]
+  }
+
+  /** Emit buffered narration as a progress thought. Always releases a held action first, so
+   *  the feed keeps the order the stream had — and so a run split by narration stops collapsing. */
+  private flushNarration(whole: boolean): LinearAction[] {
+    const trimmed = this.narration.trim()
+    if (!trimmed) {
+      this.narration = ''
+      return []
+    }
+    // Hold while the body could still become the bare sentinel, so a suppressed turn never
+    // leaks a partial thought before `onFinal` drops it.
+    if (isNoResponsePrefix(trimmed)) return []
+    let text: string
+    if (whole) {
+      text = this.narration
+      this.narration = ''
+    } else {
+      const { ready, tail } = splitAtParagraphBoundary(this.narration)
+      if (!ready.trim()) return []
+      this.narration = tail
+      text = ready
+    }
+    return [...this.takePending(), { kind: 'activity', type: 'thought', body: text.trim() }]
+  }
+
+  private drainReasoning(): LinearAction[] {
+    if (!this.reasoningDirty) return []
+    this.reasoningDirty = false
+    const trimmed = this.reasoning.trim()
+    if (!trimmed) return []
+    const tail = trimmed.length > MAX_REASONING ? `…${trimmed.slice(-MAX_REASONING)}` : trimmed
+    return [{ kind: 'activity', type: 'thought', body: tail, ephemeral: true }]
+  }
+
+  private drainPlan(): LinearAction[] {
+    if (!this.planDirty || !this.planEntries) return []
+    this.planDirty = false
+    const key = JSON.stringify(this.planEntries)
+    if (key === this.lastPlanKey) return []
+    this.lastPlanKey = key
+    return [{ kind: 'plan', entries: this.planEntries }]
+  }
+}
+
+/** Build this turn's converger. Fresh per turn, so a config change applies from the next one. */
+export function createLinearConverger(ctx: TurnOutputContext<unknown>): LinearConverger {
+  return new LinearConverger(normalizeMode(ctx.mode), ctx.showFooter)
+}
+
+/** Seed the opaque per-turn state slot core stores and never reads. */
+export function initialLinearTurnState(): LinearTurnState {
+  return { activityBudget: MAX_TURN_ACTIVITIES }
+}
+
+function toActivityInput(action: Extract<LinearAction, { kind: 'activity' }>): LinearActivityInput {
+  switch (action.type) {
+    case 'action':
+      return {
+        type: 'action',
+        action: action.action,
+        parameter: action.parameter,
+        ...(action.result ? { result: action.result } : {})
+      }
+    case 'thought':
+      return { type: 'thought', body: action.body, ...(action.ephemeral ? { ephemeral: true } : {}) }
+    default:
+      return { type: action.type, body: action.body }
+  }
+}
+
+/**
+ * Apply one converger action to Linear, through the connection's own send queue.
+ *
+ * Routed here only for the `linear` platform, so the turn's connection is a Linear egress
+ * port (or a test fake) — cast, not instanceof, matching the other surfaces. A headless turn
+ * or a session with no AgentSession coordinate no-ops.
+ */
+export async function applyLinearAction<TTurn extends LinearTurn>(
+  turn: TTurn,
+  state: LinearTurnState,
+  action: LinearAction
+): Promise<void> {
+  const port = turn.conn as LinearEgressPort | undefined
+  const sessionId = turn.plan.thread
+  if (!port || !sessionId) return
+  switch (action.kind) {
+    case 'activity': {
+      // The hard backstop under every soft cap: a runaway turn cannot exhaust the workspace's
+      // hourly budget on one session's feed.
+      if (state.activityBudget <= 0) return
+      state.activityBudget -= 1
+      await port.postActivity(sessionId, toActivityInput(action))
+      return
+    }
+    case 'plan': {
+      const hash = JSON.stringify(action.entries)
+      if (hash === state.lastPlanHash) return
+      state.lastPlanHash = hash
+      await port.updateSession(sessionId, { plan: action.entries })
+      return
+    }
+    case 'external-urls': {
+      if (action.add.length === 0) return
+      await port.updateSession(sessionId, { addedExternalUrls: action.add })
+      return
+    }
+  }
+}

--- a/packages/daemon/test/linear-turn-output.test.ts
+++ b/packages/daemon/test/linear-turn-output.test.ts
@@ -1,0 +1,551 @@
+import { describe, it, expect } from 'vitest'
+import type { SessionUpdate } from '@agentclientprotocol/sdk'
+import {
+  applyLinearAction,
+  createLinearConverger,
+  initialLinearTurnState,
+  LinearConverger,
+  linearModePolicy,
+  summarizeToolInput,
+  EMPTY_RESPONSE_BODY,
+  MAX_ACTION_RESULT,
+  MAX_REASONING,
+  MAX_TURN_ACTIONS,
+  PERMISSION_ELICITATION_BODY,
+  type LinearAction,
+  type LinearActivityInput,
+  type LinearAttribution,
+  type LinearOutputMode,
+  type LinearSessionUpdateInput
+} from '../src/platforms/linear/turn-output.js'
+
+const update = (u: Record<string, unknown>): SessionUpdate => u as unknown as SessionUpdate
+const chunk = (text: string, meta?: Record<string, unknown>): SessionUpdate =>
+  update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text }, ...(meta ?? {}) })
+const thought = (text: string): SessionUpdate =>
+  update({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text } })
+const toolCall = (o: Record<string, unknown>): SessionUpdate => update({ sessionUpdate: 'tool_call', ...o })
+const toolDone = (o: Record<string, unknown>): SessionUpdate =>
+  update({ sessionUpdate: 'tool_call_update', status: 'completed', ...o })
+const plan = (entries: { content: string; status: string }[]): SessionUpdate =>
+  update({ sessionUpdate: 'plan', entries })
+const output = (text: string) => [{ type: 'content', content: { type: 'text', text } }]
+
+const conv = (mode: LinearOutputMode, showFooter = false) => new LinearConverger(mode, showFooter)
+const types = (actions: LinearAction[]) => actions.map((a) => (a.kind === 'activity' ? a.type : a.kind))
+const responseBody = (actions: LinearAction[]) => {
+  const found = actions.find((a) => a.kind === 'activity' && a.type === 'response')
+  return found && found.kind === 'activity' && found.type === 'response' ? found.body : undefined
+}
+
+describe('LinearConverger — §5.1 event translation', () => {
+  it('turns reasoning chunks into ONE ephemeral thought per idle window', () => {
+    const c = conv('medium')
+    expect(c.onUpdate(thought('weighing '))).toEqual([])
+    expect(c.onUpdate(thought('the options'))).toEqual([])
+    expect(c.hasBuffered()).toBe(true)
+    expect(c.flushBuffered()).toEqual([
+      { kind: 'activity', type: 'thought', body: 'weighing the options', ephemeral: true }
+    ])
+    expect(c.hasBuffered()).toBe(false)
+    expect(c.flushBuffered()).toEqual([])
+  })
+
+  it('tail-clamps a long reasoning buffer', () => {
+    const c = conv('high')
+    c.onUpdate(thought('x'.repeat(MAX_REASONING * 3)))
+    const [action] = c.flushBuffered()
+    expect(action).toBeDefined()
+    if (action?.kind !== 'activity' || action.type !== 'thought') throw new Error('expected a thought')
+    expect(action.body.startsWith('…')).toBe(true)
+    expect(action.body.length).toBe(MAX_REASONING + 1)
+  })
+
+  it('turns intermediate message text into a NON-ephemeral thought at a tool boundary', () => {
+    const c = conv('low')
+    expect(c.onUpdate(chunk('reading the failing test'))).toEqual([])
+    expect(c.onUpdate(toolCall({ toolCallId: 't1', title: 'Read', status: 'pending' }))).toEqual([
+      { kind: 'activity', type: 'thought', body: 'reading the failing test' }
+    ])
+  })
+
+  it('emits an action ONCE at terminal status: action = title, parameter = input summary', () => {
+    const c = conv('low')
+    expect(c.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash', rawInput: { command: 'pnpm test' } }))).toEqual([])
+    expect(c.onUpdate(toolDone({ toolCallId: 't1', content: output('42 passed') }))).toEqual([])
+    expect(c.flushBuffered()).toEqual([{ kind: 'activity', type: 'action', action: 'Bash', parameter: 'pnpm test' }])
+  })
+
+  it('carries a head-clamped result only in high mode', () => {
+    const long = 'y'.repeat(MAX_ACTION_RESULT + 500)
+    const high = conv('high')
+    high.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash', rawInput: { command: 'cat big' } }))
+    high.onUpdate(toolDone({ toolCallId: 't1', content: output(long) }))
+    const [action] = high.flushBuffered()
+    if (action?.kind !== 'activity' || action.type !== 'action') throw new Error('expected an action')
+    expect(action.result).toBe(`${'y'.repeat(MAX_ACTION_RESULT)}\n…`)
+
+    const medium = conv('medium')
+    medium.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash', rawInput: { command: 'cat big' } }))
+    medium.onUpdate(toolDone({ toolCallId: 't1', content: output(long) }))
+    expect(medium.flushBuffered()).toEqual([{ kind: 'activity', type: 'action', action: 'Bash', parameter: 'cat big' }])
+  })
+
+  it('maps an ACP plan onto Linear plan entries (full-array replace, both sides)', () => {
+    const c = conv('low')
+    expect(
+      c.onUpdate(
+        plan([
+          { content: 'read the code', status: 'completed' },
+          { content: 'write the fix', status: 'in_progress' },
+          { content: 'run the tests', status: 'pending' }
+        ])
+      )
+    ).toEqual([])
+    expect(c.flushBuffered()).toEqual([
+      {
+        kind: 'plan',
+        entries: [
+          { content: 'read the code', status: 'completed' },
+          { content: 'write the fix', status: 'inProgress' },
+          { content: 'run the tests', status: 'pending' }
+        ]
+      }
+    ])
+  })
+
+  it('settles the turn with one response carrying the final answer', () => {
+    const c = conv('low')
+    c.onUpdate(chunk('The fix is in place.'))
+    expect(c.onFinal()).toEqual([{ kind: 'activity', type: 'response', body: 'The fix is in place.' }])
+  })
+
+  it('settles a silent turn with a bounded response — a response is what completes the session', () => {
+    expect(conv('low').onFinal()).toEqual([{ kind: 'activity', type: 'response', body: EMPTY_RESPONSE_BODY }])
+  })
+
+  it('turns a failure into an error activity carrying the reason', () => {
+    const c = conv('low')
+    expect(c.onFailure('quota exhausted')).toEqual([{ kind: 'activity', type: 'error', body: 'quota exhausted' }])
+  })
+
+  it('turns a blocked permission gate into an elicitation pointing at the console', () => {
+    const c = conv('low')
+    expect(c.onPermissionBlocked('https://console.example.test/s/abc')).toEqual([
+      {
+        kind: 'activity',
+        type: 'elicitation',
+        body: `${PERMISSION_ELICITATION_BODY} [open in session](https://console.example.test/s/abc)`
+      }
+    ])
+    // An append-only feed would stack an identical gate, so a repeat collapses.
+    expect(c.onPermissionBlocked('https://console.example.test/s/abc')).toEqual([])
+  })
+
+  it('emits nothing for a session title update — Linear names its own sessions', () => {
+    const c = conv('high')
+    expect(c.onUpdate(update({ sessionUpdate: 'session_info_update', title: 'Fix the flake' }))).toEqual([])
+    expect(c.hasBuffered()).toBe(false)
+  })
+})
+
+describe('LinearConverger — §5.2 output modes', () => {
+  const script = (c: LinearConverger): LinearAction[] => {
+    const out: LinearAction[] = []
+    out.push(...c.onUpdate(thought('weighing it')))
+    out.push(...c.onUpdate(chunk('reading the test')))
+    out.push(...c.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash', rawInput: { command: 'pnpm test' } })))
+    out.push(...c.onUpdate(toolDone({ toolCallId: 't1', content: output('42 passed') })))
+    out.push(...c.onUpdate(plan([{ content: 'ship it', status: 'in_progress' }])))
+    out.push(...c.flushBuffered())
+    out.push(...c.onUpdate(chunk('Fixed the flake.')))
+    out.push(...c.onFinal())
+    return out
+  }
+
+  it('none is truly silent — no activity of any kind, not even the settling response', () => {
+    expect(script(conv('none'))).toEqual([])
+  })
+
+  it('minimal posts the response only', () => {
+    expect(types(script(conv('minimal')))).toEqual(['response'])
+  })
+
+  it('low — the default — already includes progress thoughts, actions and plan', () => {
+    expect(types(script(conv('low')))).toEqual(['thought', 'action', 'plan', 'response'])
+  })
+
+  it('medium adds the ephemeral reasoning thought', () => {
+    expect(types(script(conv('medium')))).toEqual(['thought', 'action', 'thought', 'plan', 'response'])
+  })
+
+  it('high adds tool results to the action row', () => {
+    const actions = script(conv('high'))
+    const action = actions.find((a) => a.kind === 'activity' && a.type === 'action')
+    if (action?.kind !== 'activity' || action.type !== 'action') throw new Error('expected an action')
+    expect(action.result).toBe('42 passed')
+  })
+
+  it('publishes the mode matrix as data, so every switch reads the same row', () => {
+    expect(linearModePolicy('none')).toEqual({
+      reasoning: false,
+      progress: false,
+      actions: false,
+      actionResults: false,
+      plan: false,
+      response: false
+    })
+    expect(linearModePolicy('low').actions).toBe(true)
+    expect(linearModePolicy('low').plan).toBe(true)
+    expect(linearModePolicy('low').reasoning).toBe(false)
+    expect(linearModePolicy('medium').reasoning).toBe(true)
+    expect(linearModePolicy('high').actionResults).toBe(true)
+  })
+})
+
+describe('LinearConverger — coalescing', () => {
+  it('collapses consecutive same-title calls into one row with a count', () => {
+    const c = conv('low')
+    for (const [id, command] of [
+      ['t1', 'ls'],
+      ['t2', 'pwd'],
+      ['t3', 'whoami']
+    ]) {
+      c.onUpdate(toolCall({ toolCallId: id, title: 'Bash', rawInput: { command } }))
+      c.onUpdate(toolDone({ toolCallId: id }))
+    }
+    expect(c.flushBuffered()).toEqual([
+      { kind: 'activity', type: 'action', action: 'Bash ×3', parameter: 'ls pwd whoami' }
+    ])
+  })
+
+  it('stops collapsing when a different title, or narration, separates the run', () => {
+    const c = conv('low')
+    c.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash', rawInput: { command: 'ls' } }))
+    c.onUpdate(toolDone({ toolCallId: 't1' }))
+    c.onUpdate(toolCall({ toolCallId: 't2', title: 'Read', rawInput: { path: 'a.ts' } }))
+    const released = c.onUpdate(toolDone({ toolCallId: 't2' }))
+    expect(released).toEqual([{ kind: 'activity', type: 'action', action: 'Bash', parameter: 'ls' }])
+    // Narration between two same-title calls separates them in the feed too.
+    c.onUpdate(chunk('now checking the config'))
+    const boundary = c.onUpdate(toolCall({ toolCallId: 't3', title: 'Read', rawInput: { path: 'b.ts' } }))
+    expect(boundary).toEqual([
+      { kind: 'activity', type: 'action', action: 'Read', parameter: 'a.ts' },
+      { kind: 'activity', type: 'thought', body: 'now checking the config' }
+    ])
+  })
+
+  it('caps actions per turn and reports the overflow once as a closing thought', () => {
+    const c = conv('low')
+    const calls = MAX_TURN_ACTIONS + 5
+    const emitted: LinearAction[] = []
+    for (let i = 0; i < calls; i++) {
+      emitted.push(...c.onUpdate(toolCall({ toolCallId: `t${i}`, title: `Tool${i}`, rawInput: { path: `f${i}` } })))
+      emitted.push(...c.onUpdate(toolDone({ toolCallId: `t${i}` })))
+    }
+    expect(emitted.filter((a) => a.kind === 'activity' && a.type === 'action')).toHaveLength(MAX_TURN_ACTIONS)
+    expect(types(c.onFinal())).toEqual(['thought', 'response'])
+    const overflow = c.onFinal()
+    expect(overflow).toEqual([])
+  })
+
+  it('names the exact overflow count in the closing thought', () => {
+    const c = conv('low')
+    const calls = MAX_TURN_ACTIONS + 5
+    for (let i = 0; i < calls; i++) {
+      c.onUpdate(toolCall({ toolCallId: `t${i}`, title: `Tool${i}` }))
+      c.onUpdate(toolDone({ toolCallId: `t${i}` }))
+    }
+    expect(c.onFinal()[0]).toEqual({
+      kind: 'activity',
+      type: 'thought',
+      body: `… and ${calls - MAX_TURN_ACTIONS} more tool calls`
+    })
+  })
+
+  it('debounces the plan last-write-wins, and never repeats an unchanged one', () => {
+    const c = conv('low')
+    c.onUpdate(plan([{ content: 'ship it', status: 'pending' }]))
+    c.onUpdate(plan([{ content: 'ship it', status: 'in_progress' }]))
+    expect(c.flushBuffered()).toEqual([{ kind: 'plan', entries: [{ content: 'ship it', status: 'inProgress' }] }])
+    c.onUpdate(plan([{ content: 'ship it', status: 'in_progress' }]))
+    expect(c.flushBuffered()).toEqual([])
+    c.onUpdate(plan([{ content: 'ship it', status: 'completed' }]))
+    expect(c.flushBuffered()).toEqual([{ kind: 'plan', entries: [{ content: 'ship it', status: 'completed' }] }])
+  })
+
+  it('holds narration on the idle timer unless a tool call is in flight', () => {
+    const quiet = conv('low')
+    quiet.onUpdate(chunk('this is the answer.\n\n'))
+    // Nothing is in flight, so this text may still be the closing answer: the response owns it.
+    expect(quiet.hasBuffered()).toBe(false)
+    expect(quiet.flushBuffered()).toEqual([])
+    expect(responseBody(quiet.onFinal())).toBe('this is the answer.')
+
+    const working = conv('low')
+    working.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash', status: 'pending' }))
+    working.onUpdate(chunk('still grinding.\n\ntail'))
+    expect(working.hasBuffered()).toBe(true)
+    expect(working.flushBuffered()).toEqual([{ kind: 'activity', type: 'thought', body: 'still grinding.' }])
+  })
+})
+
+describe('LinearConverger — terminal-only actions', () => {
+  it('emits nothing for a start-status tool call, and nothing again for a repeat terminal', () => {
+    const c = conv('high')
+    expect(c.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash', status: 'pending' }))).toEqual([])
+    expect(c.onUpdate(update({ sessionUpdate: 'tool_call_update', toolCallId: 't1', status: 'in_progress' }))).toEqual(
+      []
+    )
+    expect(c.onUpdate(toolDone({ toolCallId: 't1', content: output('done') }))).toEqual([])
+    expect(c.onUpdate(toolDone({ toolCallId: 't1', content: output('done again') }))).toEqual([])
+    expect(c.flushBuffered()).toEqual([
+      { kind: 'activity', type: 'action', action: 'Bash', parameter: '', result: 'done' }
+    ])
+  })
+
+  it('emits an action for a failed call too — terminal is terminal', () => {
+    const c = conv('low')
+    c.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash', rawInput: { command: 'false' } }))
+    c.onUpdate(update({ sessionUpdate: 'tool_call_update', toolCallId: 't1', status: 'failed' }))
+    expect(c.flushBuffered()).toEqual([{ kind: 'activity', type: 'action', action: 'Bash', parameter: 'false' }])
+  })
+})
+
+describe('LinearConverger — final answer, footer, failure ordering', () => {
+  it('prefers the runtime explicit final phase over earlier commentary', () => {
+    const c = conv('low')
+    c.onUpdate(chunk('let me look', { messageId: 'm1', _meta: { codex: { phase: 'commentary' } } }))
+    c.onUpdate(chunk('All green.', { messageId: 'm2', _meta: { codex: { phase: 'final_answer' } } }))
+    expect(responseBody(c.onFinal())).toBe('All green.')
+  })
+
+  it('falls back to message grouping, then to the last text run', () => {
+    const grouped = conv('low')
+    grouped.onUpdate(chunk('thinking out loud', { messageId: 'm1', _meta: { codex: { phase: 'commentary' } } }))
+    grouped.onUpdate(chunk('Here is the ', { messageId: 'm2' }))
+    grouped.onUpdate(chunk('answer.', { messageId: 'm2' }))
+    expect(responseBody(grouped.onFinal())).toBe('Here is the answer.')
+
+    const runs = conv('low')
+    runs.onUpdate(chunk('first run'))
+    runs.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash' }))
+    runs.onUpdate(chunk('second run'))
+    expect(responseBody(runs.onFinal())).toBe('second run')
+  })
+
+  it('appends the attribution footer only when the turn shows chrome', () => {
+    const attribution: LinearAttribution = {
+      agentName: 'review-bot',
+      agentUrl: 'https://console.example.test/agents/review-bot',
+      runtime: 'claude',
+      model: 'sonnet',
+      sessionUrl: 'https://console.example.test/s/abc'
+    }
+    const shown = conv('low', true)
+    shown.onUpdate(chunk('Looks good.'))
+    expect(responseBody(shown.onFinal(attribution))).toBe(
+      'Looks good.\n\nsent by [review-bot](https://console.example.test/agents/review-bot) (claude · sonnet) · ' +
+        '[open in session](https://console.example.test/s/abc)'
+    )
+
+    const hidden = conv('low', false)
+    hidden.onUpdate(chunk('Looks good.'))
+    expect(responseBody(hidden.onFinal(attribution))).toBe('Looks good.')
+  })
+
+  it('closes an open code fence before the footer', () => {
+    const shown = conv('low', true)
+    shown.onUpdate(chunk('```ts\nconst a = 1'))
+    const body = responseBody(
+      shown.onFinal({
+        agentName: 'review-bot',
+        agentUrl: '',
+        runtime: 'claude',
+        model: 'sonnet',
+        sessionUrl: ''
+      })
+    )
+    expect(body).toBe('```ts\nconst a = 1\n```\n\nsent by review-bot (claude · sonnet)')
+  })
+
+  it('flushes the converger buffer before the error, dropping runtime narration that repeats it', () => {
+    const duplicated = conv('low')
+    duplicated.onUpdate(chunk('You have hit your usage limit.'))
+    expect(duplicated.onFailure('You have hit your usage limit.')).toEqual([
+      { kind: 'activity', type: 'error', body: 'You have hit your usage limit.' }
+    ])
+
+    const distinct = conv('low')
+    distinct.onUpdate(chunk('halfway through the refactor'))
+    expect(distinct.onFailure('connection reset')).toEqual([
+      { kind: 'activity', type: 'thought', body: 'halfway through the refactor' },
+      { kind: 'activity', type: 'error', body: 'connection reset' }
+    ])
+  })
+
+  it('releases a held action ahead of the error, keeping feed order', () => {
+    const c = conv('low')
+    c.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash', rawInput: { command: 'ls' } }))
+    c.onUpdate(toolDone({ toolCallId: 't1' }))
+    expect(types(c.onFailure('connection reset'))).toEqual(['action', 'error'])
+  })
+
+  it('settles once: nothing follows the response or the error', () => {
+    const settled = conv('low')
+    settled.onUpdate(chunk('done'))
+    expect(settled.onFinal()).toHaveLength(1)
+    expect(settled.onFinal()).toEqual([])
+    expect(settled.onUpdate(chunk('late'))).toEqual([])
+    expect(settled.flushBuffered()).toEqual([])
+    expect(settled.onPermissionBlocked()).toEqual([])
+
+    const failed = conv('low')
+    expect(failed.onFailure('boom')).toHaveLength(1)
+    expect(failed.onFinal()).toEqual([])
+  })
+
+  it('drains the whole buffer on an abnormal end, paragraph break or not', () => {
+    const c = conv('low')
+    c.onUpdate(chunk('no paragraph break here'))
+    expect(c.flushTerminal()).toEqual([{ kind: 'activity', type: 'thought', body: 'no paragraph break here' }])
+    expect(c.hasBuffered()).toBe(false)
+  })
+})
+
+describe('LinearConverger — AC_NO_RESPONSE is ack-only', () => {
+  it('emits nothing at all once the turn resolves to the sentinel', () => {
+    for (const mode of ['minimal', 'low', 'medium', 'high'] as const) {
+      const c = conv(mode)
+      expect(c.onUpdate(chunk('AC_NO'))).toEqual([])
+      expect(c.onUpdate(chunk('_RESPONSE'))).toEqual([])
+      expect(c.flushBuffered()).toEqual([])
+      expect(c.flushTerminal()).toEqual([])
+      expect(c.onFinal()).toEqual([])
+      expect(c.onFinal()).toEqual([])
+    }
+  })
+
+  it('suppresses a non-compliant model that explains itself and then emits the sentinel', () => {
+    const c = conv('low')
+    c.onUpdate(chunk('This message is not for me.\nAC_NO_RESPONSE'))
+    expect(c.onFinal()).toEqual([])
+  })
+
+  it('releases a body that merely starts like the sentinel', () => {
+    const c = conv('low')
+    c.onUpdate(chunk('AC_NO'))
+    expect(c.flushTerminal()).toEqual([])
+    c.onUpdate(chunk('T is a different acronym.'))
+    expect(responseBody(c.onFinal())).toBe('AC_NOT is a different acronym.')
+  })
+})
+
+describe('createLinearConverger', () => {
+  it('reads the turn context, and falls back to the default mode for an unknown one', () => {
+    const ctx = { isDm: false, showFooter: true, message: {} }
+    expect(createLinearConverger({ ...ctx, mode: 'high' }).outputMode()).toBe('high')
+    expect(createLinearConverger({ ...ctx, mode: 'nonsense' }).outputMode()).toBe('low')
+  })
+})
+
+describe('summarizeToolInput', () => {
+  it('prefers the well-known input keys, then falls back to scalar pairs', () => {
+    expect(summarizeToolInput({ command: 'pnpm test', cwd: '/repo' })).toBe('pnpm test')
+    expect(summarizeToolInput({ file_path: 'src/a.ts' })).toBe('src/a.ts')
+    expect(summarizeToolInput({ limit: 20, recursive: true })).toBe('limit=20 recursive=true')
+    expect(summarizeToolInput('a bare string')).toBe('a bare string')
+    expect(summarizeToolInput(undefined)).toBe('')
+    expect(summarizeToolInput([1, 2])).toBe('')
+  })
+})
+
+class FakePort {
+  readonly activities: { sessionId: string; activity: LinearActivityInput }[] = []
+  readonly updates: { sessionId: string; update: LinearSessionUpdateInput }[] = []
+  async postActivity(sessionId: string, activity: LinearActivityInput): Promise<void> {
+    this.activities.push({ sessionId, activity })
+  }
+  async updateSession(sessionId: string, update: LinearSessionUpdateInput): Promise<void> {
+    this.updates.push({ sessionId, update })
+  }
+}
+
+const turnFor = (port: FakePort | undefined, thread: string | undefined) => ({
+  conn: port,
+  plan: { thread, platform: 'linear', agentId: 'a1', sessionKey: 'k1' }
+})
+const linearTurn = (port: FakePort) => turnFor(port, 'agent-session-uuid')
+
+describe('applyLinearAction', () => {
+  it('maps each activity kind onto one agentActivityCreate input', async () => {
+    const port = new FakePort()
+    const turn = linearTurn(port)
+    const state = initialLinearTurnState()
+    const actions: LinearAction[] = [
+      { kind: 'activity', type: 'thought', body: 'thinking', ephemeral: true },
+      { kind: 'activity', type: 'thought', body: 'progress' },
+      { kind: 'activity', type: 'action', action: 'Bash ×2', parameter: 'ls', result: 'ok' },
+      { kind: 'activity', type: 'elicitation', body: 'approve me' },
+      { kind: 'activity', type: 'error', body: 'boom' },
+      { kind: 'activity', type: 'response', body: 'done' }
+    ]
+    for (const action of actions) await applyLinearAction(turn, state, action)
+    expect(port.activities.map((a) => a.activity)).toEqual([
+      { type: 'thought', body: 'thinking', ephemeral: true },
+      { type: 'thought', body: 'progress' },
+      { type: 'action', action: 'Bash ×2', parameter: 'ls', result: 'ok' },
+      { type: 'elicitation', body: 'approve me' },
+      { type: 'error', body: 'boom' },
+      { type: 'response', body: 'done' }
+    ])
+    expect(new Set(port.activities.map((a) => a.sessionId))).toEqual(new Set(['agent-session-uuid']))
+  })
+
+  it('sends plan and external URLs through agentSessionUpdate, skipping an unchanged plan', async () => {
+    const port = new FakePort()
+    const turn = linearTurn(port)
+    const state = initialLinearTurnState()
+    const entries = [{ content: 'ship it', status: 'inProgress' as const }]
+    await applyLinearAction(turn, state, { kind: 'plan', entries })
+    await applyLinearAction(turn, state, { kind: 'plan', entries: [...entries] })
+    await applyLinearAction(turn, state, {
+      kind: 'plan',
+      entries: [{ content: 'ship it', status: 'completed' }]
+    })
+    await applyLinearAction(turn, state, {
+      kind: 'external-urls',
+      add: [{ label: 'PR #123', url: 'https://code.example.test/pr/123' }]
+    })
+    await applyLinearAction(turn, state, { kind: 'external-urls', add: [] })
+    expect(port.updates.map((u) => u.update)).toEqual([
+      { plan: [{ content: 'ship it', status: 'inProgress' }] },
+      { plan: [{ content: 'ship it', status: 'completed' }] },
+      { addedExternalUrls: [{ label: 'PR #123', url: 'https://code.example.test/pr/123' }] }
+    ])
+  })
+
+  it('enforces the per-turn activity budget as the hard egress backstop', async () => {
+    const port = new FakePort()
+    const turn = linearTurn(port)
+    const state = { ...initialLinearTurnState(), activityBudget: 2 }
+    for (let i = 0; i < 5; i++) {
+      await applyLinearAction(turn, state, { kind: 'activity', type: 'thought', body: `n${i}` })
+    }
+    expect(port.activities).toHaveLength(2)
+    expect(state.activityBudget).toBe(0)
+  })
+
+  it('no-ops on a headless turn or a session with no Linear coordinate', async () => {
+    const port = new FakePort()
+    const state = initialLinearTurnState()
+    await applyLinearAction(turnFor(undefined, 'agent-session-uuid'), state, {
+      kind: 'activity',
+      type: 'response',
+      body: 'x'
+    })
+    await applyLinearAction(turnFor(port, undefined), state, { kind: 'activity', type: 'response', body: 'x' })
+    expect(port.activities).toEqual([])
+    expect(state.activityBudget).toBe(initialLinearTurnState().activityBudget)
+  })
+})

--- a/packages/daemon/test/linear-turn-output.test.ts
+++ b/packages/daemon/test/linear-turn-output.test.ts
@@ -61,6 +61,23 @@ describe('LinearConverger — §5.1 event translation', () => {
     expect(action.body.length).toBe(MAX_REASONING + 1)
   })
 
+  it('emits only the delta since the last flush, so consecutive windows never overlap', () => {
+    const c = conv('medium')
+    c.onUpdate(thought('first window '))
+    c.onUpdate(thought('of thinking'))
+    expect(c.flushBuffered()).toEqual([
+      { kind: 'activity', type: 'thought', body: 'first window of thinking', ephemeral: true }
+    ])
+    // Nothing new arrived, so the window that follows costs no activity at all.
+    expect(c.hasBuffered()).toBe(false)
+    expect(c.flushBuffered()).toEqual([])
+    c.onUpdate(thought('second window'))
+    const second = c.flushBuffered()
+    expect(second).toEqual([{ kind: 'activity', type: 'thought', body: 'second window', ephemeral: true }])
+    const body = second[0]?.kind === 'activity' && second[0].type === 'thought' ? second[0].body : ''
+    expect(body).not.toContain('first window')
+  })
+
   it('turns intermediate message text into a NON-ephemeral thought at a tool boundary', () => {
     const c = conv('low')
     expect(c.onUpdate(chunk('reading the failing test'))).toEqual([])
@@ -533,6 +550,29 @@ describe('applyLinearAction', () => {
       await applyLinearAction(turn, state, { kind: 'activity', type: 'thought', body: `n${i}` })
     }
     expect(port.activities).toHaveLength(2)
+    expect(state.activityBudget).toBe(0)
+  })
+
+  it('still posts the settling response once the hard cap is exhausted, and nothing else', async () => {
+    const port = new FakePort()
+    const turn = linearTurn(port)
+    const state = { ...initialLinearTurnState(), activityBudget: 0 }
+    await applyLinearAction(turn, state, { kind: 'activity', type: 'thought', body: 'chrome' })
+    await applyLinearAction(turn, state, { kind: 'activity', type: 'action', action: 'Bash', parameter: 'ls' })
+    await applyLinearAction(turn, state, { kind: 'activity', type: 'elicitation', body: 'approve me' })
+    await applyLinearAction(turn, state, { kind: 'activity', type: 'response', body: 'the answer' })
+    expect(port.activities.map((a) => a.activity)).toEqual([{ type: 'response', body: 'the answer' }])
+    // The settle draws nothing from the budget, so the cap can never be what drops it.
+    expect(state.activityBudget).toBe(0)
+  })
+
+  it('still posts the settling error once the hard cap is exhausted', async () => {
+    const port = new FakePort()
+    const turn = linearTurn(port)
+    const state = { ...initialLinearTurnState(), activityBudget: 0 }
+    await applyLinearAction(turn, state, { kind: 'activity', type: 'thought', body: 'chrome' })
+    await applyLinearAction(turn, state, { kind: 'activity', type: 'error', body: 'quota exhausted' })
+    expect(port.activities.map((a) => a.activity)).toEqual([{ type: 'error', body: 'quota exhausted' }])
     expect(state.activityBudget).toBe(0)
   })
 


### PR DESCRIPTION
The streaming Layer-2 turn-output surface for Linear (docs/designs/linear-integration.md §5): `LinearConverger` translates the ACP update stream into agent activities, and `applyLinearAction` maps the IR onto a minimal egress port (`postActivity`/`updateSession`) the connection class will satisfy structurally — no registry wiring yet, that lands with the composition set.

Built against the live-verified §15 semantics: `agentActivityCreate` is append-only and never coalesces, so every collapse is ours — tool calls emit ONCE at terminal status, consecutive same-title calls fold with a count, a soft 40-action cap closes with "… and N more" and a hard 200-activity budget backstops in apply. Thought chunks coalesce on core's idle window (no timers of our own); narration cuts at tool boundaries always but idle-flushes only while a tool is in flight, so the final answer is never posted twice on an append-only feed. Plan and external-urls updates debounce last-write-wins with a hash guard.

Turn end posts the `response` (GitHub final-answer heuristics; Markdown attribution footer via the shared fence-aware chrome — Linear renders Markdown, not HTML), which is what settles the session to complete; a silent turn still gets a bounded response, and the sole exception is `AC_NO_RESPONSE`, detected on a mode-independent tail so a suppressed turn stays ack-only. Failures flush buffered narration first and post one `error`; the §5.2 mode matrix gates every category (`none` emits nothing at all).

Tests: 42 new cases (translation table per mode, collapse/caps, terminal-only actions, plan debounce, no-response, footer, error ordering); daemon typecheck + lint green; the daemon suite's 14 failing cases are pre-existing local-environment failures (shim + live-runtime matrix), demonstrated unchanged with these files removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
