### PR TITLE
feat(daemon): Linear Layer-1 connection and config schema

### DIFF
--- a/packages/daemon/src/agents/agent-schema.ts
+++ b/packages/daemon/src/agents/agent-schema.ts
@@ -5,6 +5,7 @@ import {
   IntegrationCoreEnvelope,
   IntegrationDiscordConfig,
   IntegrationFeishuConfig,
+  IntegrationLinearConfig,
   IntegrationSlackConfig,
   IntegrationTelegramConfig,
   ManagedSkillEntry
@@ -47,6 +48,11 @@ export type DiscordConfig = z.infer<typeof DiscordConfigSchema>
 
 export const FeishuConfigSchema = IntegrationFeishuConfig
 export type FeishuConfig = z.infer<typeof FeishuConfigSchema>
+
+/** Linear carries a SHORT-LIVED credential, not a durable bot token: the spec's ≤24 h
+ *  access-token snapshot plus its expiry, refreshed over `linearcred` (§4.4/§7.2). */
+export const LinearConfigSchema = IntegrationLinearConfig
+export type LinearConfig = z.infer<typeof LinearConfigSchema>
 
 /**
  * One integration entry — §6.4 FINAL SHAPE, migrated together with the protocol

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -38,6 +38,8 @@ import type {
   CodeHostReviewResultReport,
   GitCredRequest,
   GitCredGrant,
+  LinearCredRequest,
+  LinearCredGrant,
   ChannelAgentsReq,
   ChannelAgentsOk,
   ChildSessionStatus,
@@ -926,6 +928,23 @@ export class CpClient {
       throw new WireError('INTERNAL', `expected gitcred/grant, got ${rep.type}`, false)
     }
     return rep.payload as GitCredGrant
+  }
+
+  /** Request a fresh Linear access token (linear-integration.md §7.3) — same posture as
+   *  `requestGitCred`: connected only, one send, a 10s timeout, and never a logged payload. */
+  async requestLinearCred(payload: LinearCredRequest): Promise<LinearCredGrant> {
+    if ((this.state !== 'READY' && this.state !== 'DRAINING') || !this.transport) {
+      throw new WireError('INTERNAL', `control plane unreachable (client ${this.state})`, true)
+    }
+    const frame = this.scopedFrame('linearcred/request', payload)
+    const rep = await this.correlator.request(frame, (e) => this.transport!.send(e), {
+      maxTries: 1,
+      ackTimeoutMs: 10_000
+    })
+    if (rep.type !== 'linearcred/grant') {
+      throw new WireError('INTERNAL', `expected linearcred/grant, got ${rep.type}`, false)
+    }
+    return rep.payload as LinearCredGrant
   }
 
   /**

--- a/packages/daemon/src/platforms/integration-config.ts
+++ b/packages/daemon/src/platforms/integration-config.ts
@@ -27,6 +27,7 @@ import type { BindRuleConfig, Integration } from '../agents/agent-schema.js'
 import {
   DiscordConfigSchema,
   FeishuConfigSchema,
+  LinearConfigSchema,
   SlackConfigSchema,
   TelegramConfigSchema
 } from '../agents/agent-schema.js'
@@ -38,7 +39,8 @@ const CONFIG_SCHEMAS = {
   slack: SlackConfigSchema,
   telegram: TelegramConfigSchema,
   discord: DiscordConfigSchema,
-  feishu: FeishuConfigSchema
+  feishu: FeishuConfigSchema,
+  linear: LinearConfigSchema
 } as const
 
 /** The union of every platform's validated config, derived from the registry

--- a/packages/daemon/src/platforms/linear/connection.ts
+++ b/packages/daemon/src/platforms/linear/connection.ts
@@ -43,6 +43,12 @@ export const LINEAR_SEND_INTERVAL_MS = 1_000
 /** How far past a renewal failure we retry rather than hammering the broker. */
 const RENEW_RETRY_MS = 60_000
 
+/** §11 bounded send retry: attempts per enqueued write, and the spacing between them. */
+const SEND_MAX_ATTEMPTS = 3
+const SEND_RETRY_BASE_MS = 1_000
+/** Caps a provider-supplied `Retry-After` so one write cannot eat the queue's task budget. */
+const SEND_RETRY_CAP_MS = 5_000
+
 /** One agent activity's content (§5 `LinearAction`, the content half). */
 export type LinearActivityContent =
   | { type: 'thought'; body: string }
@@ -75,10 +81,12 @@ export interface LinearSessionUpdate {
 export class LinearApiError extends Error {
   constructor(
     message: string,
-    /** Worth another attempt (5xx, 429, transport). A rejected token or a bad input is not. */
+    /** Worth another attempt (5xx, 429, transport, `RATELIMITED`). A rejected token or a bad input is not. */
     readonly retryable: boolean,
     /** Linear's `extensions.code` on the first error, when it reported one. */
-    readonly code?: string
+    readonly code?: string,
+    /** The provider's own `Retry-After`, when it sent one — preferred over our backoff. */
+    readonly retryAfterMs?: number
   ) {
     super(message)
     this.name = 'LinearApiError'
@@ -175,6 +183,7 @@ export class LinearConnection implements PlatformConnection {
   private readonly endpoint: string
   private readonly fetchImpl: typeof fetch
   private readonly now: () => number
+  private readonly sleep: (ms: number) => Promise<void>
   private readonly setTimer: (fn: () => void, ms: number) => unknown
   private readonly clearTimer: (handle: unknown) => void
   private cached: CachedToken
@@ -207,6 +216,7 @@ export class LinearConnection implements PlatformConnection {
     this.endpoint = deps.endpoint ?? LINEAR_GRAPHQL_ENDPOINT
     this.fetchImpl = deps.fetchImpl ?? ((...args: Parameters<typeof fetch>) => fetch(...args))
     this.now = deps.now ?? (() => Date.now())
+    this.sleep = deps.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)))
     this.setTimer = deps.setTimer ?? defaultSetTimer
     this.clearTimer = deps.clearTimer ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>))
     this.cached = { token: config.accessToken, expiresAtMs: Date.parse(config.accessTokenExpiresAt) }
@@ -357,7 +367,14 @@ export class LinearConnection implements PlatformConnection {
   async token(): Promise<string> {
     const now = this.now()
     if (!this.needsRenewal(now)) return this.cached.token
-    if (now < this.renewBlockedUntil && this.stillValid(now)) return this.cached.token
+    // The backoff holds whether or not the cached token outlived it: an expired token is
+    // exactly when a per-send retry would hammer the broker through an outage.
+    if (now < this.renewBlockedUntil) {
+      if (this.stillValid(now)) return this.cached.token
+      throw new LinearTokenUnavailableError(
+        `linear access token for integration ${this.integrationId} expired and renewal is backing off`
+      )
+    }
     try {
       return (await this.renew()).token
     } catch (err) {
@@ -399,6 +416,9 @@ export class LinearConnection implements PlatformConnection {
       })
       .catch((err: unknown) => {
         this.renewBlockedUntil = this.now() + RENEW_RETRY_MS
+        // Re-arm on the failure path too: without this a transient refusal leaves an idle
+        // integration with no timer at all, so recovery is only ever found by a live send.
+        this.scheduleRefresh()
         throw err
       })
       .finally(() => {
@@ -416,17 +436,37 @@ export class LinearConnection implements PlatformConnection {
       this.refreshTimer = undefined
     }
     if (this.stopped || Number.isNaN(this.cached.expiresAtMs)) return
-    const delay = Math.max(RENEW_RETRY_MS, this.cached.expiresAtMs - RENEW_MARGIN_MS - this.now())
+    // Due at the margin, or at the end of a renewal backoff — whichever is later.
+    const dueAt = Math.max(this.cached.expiresAtMs - RENEW_MARGIN_MS, this.renewBlockedUntil)
+    const delay = Math.max(RENEW_RETRY_MS, dueAt - this.now())
     this.refreshTimer = this.setTimer(() => {
       this.refreshTimer = undefined
-      void this.token().catch(() => undefined)
+      // Re-arm whatever the outcome, so no single failure ends the refresh chain.
+      void this.token()
+        .catch(() => undefined)
+        .finally(() => this.scheduleRefresh())
     }, delay)
   }
 
   // ── GraphQL transport ──
 
-  private enqueueGraphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
-    return this.queue.enqueue(() => this.graphql<T>(query, variables))
+  /** The paced egress path, with the §11 bounded retry: activities are droppable chrome, so a
+   *  retryable refusal gets a few spaced attempts inside the caller's one queue slot (order is
+   *  preserved) and a terminal one fails at once. Read-port calls do not retry — they already
+   *  degrade to a default. */
+  private async enqueueGraphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+    return this.queue.enqueue(async () => {
+      for (let attempt = 1; ; attempt += 1) {
+        try {
+          return await this.graphql<T>(query, variables)
+        } catch (err) {
+          const retryable = err instanceof LinearApiError && err.retryable
+          if (!retryable || attempt >= SEND_MAX_ATTEMPTS) throw err
+          const backoff = (err as LinearApiError).retryAfterMs ?? SEND_RETRY_BASE_MS * 2 ** (attempt - 1)
+          await this.sleep(Math.min(backoff, SEND_RETRY_CAP_MS))
+        }
+      }
+    })
   }
 
   private async graphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
@@ -441,23 +481,47 @@ export class LinearConnection implements PlatformConnection {
     } catch (err) {
       throw new LinearApiError(`linear request failed: ${(err as Error).message}`, true)
     }
-    if (!res.ok) {
-      throw new LinearApiError(`linear responded ${res.status}`, res.status === 429 || res.status >= 500)
-    }
-    let body: { data?: T; errors?: { message?: string; extensions?: { code?: string } }[] }
+    // Parse BEFORE branching on the status: Linear reports a rate limit as HTTP 400 carrying
+    // `RATELIMITED` in the GraphQL errors, so a status-only verdict would call it terminal.
+    let body: { data?: T; errors?: { message?: string; extensions?: { code?: string } }[] } | undefined
     try {
       body = (await res.json()) as typeof body
-    } catch (err) {
-      throw new LinearApiError(`linear returned an unreadable body: ${(err as Error).message}`, true)
+    } catch {
+      body = undefined
     }
-    if (body.errors && body.errors.length > 0) {
+    if (body?.errors && body.errors.length > 0) {
       const code = body.errors[0]?.extensions?.code
       const message = body.errors.map((e) => e.message ?? 'unknown error').join('; ')
-      throw new LinearApiError(`linear rejected the request: ${message}`, code === 'RATELIMITED', code)
+      const retryable = code === 'RATELIMITED' || retryableStatus(res.status)
+      throw new LinearApiError(`linear rejected the request: ${message}`, retryable, code, retryAfterMs(res))
     }
+    if (!res.ok) {
+      throw new LinearApiError(
+        `linear responded ${res.status}`,
+        retryableStatus(res.status),
+        undefined,
+        retryAfterMs(res)
+      )
+    }
+    if (body === undefined) throw new LinearApiError('linear returned an unreadable body', true)
     if (body.data === undefined) throw new LinearApiError('linear returned no data', true)
     return body.data
   }
+}
+
+/** Status-only verdict, the fallback when the body names no code of its own. */
+function retryableStatus(status: number): boolean {
+  return status === 429 || status >= 500
+}
+
+/** `Retry-After`, as delta-seconds or an HTTP date. Absent/unparseable ⇒ the caller's own backoff. */
+function retryAfterMs(res: Response): number | undefined {
+  const raw = res.headers?.get?.('retry-after')
+  if (!raw) return undefined
+  const seconds = Number(raw)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000)
+  const at = Date.parse(raw)
+  return Number.isNaN(at) ? undefined : Math.max(0, at - Date.now())
 }
 
 // The four documents this connection sends. Shapes follow Linear's published agent API

--- a/packages/daemon/src/platforms/linear/connection.ts
+++ b/packages/daemon/src/platforms/linear/connection.ts
@@ -18,6 +18,7 @@
  * `getUserProfile` the Linear user; everything else answers empty. There is no bot
  * channel enumeration, no leave affordance, and attachment download is deferred.
  */
+import { randomUUID } from 'node:crypto'
 import type { IntegrationLinearConfig, LinearCredGrant } from '@agentconnect.md/protocol'
 import type { Agent } from '../../agents/agent-schema.js'
 import type { Logger } from '../../log.js'
@@ -42,6 +43,17 @@ export const LINEAR_SEND_INTERVAL_MS = 1_000
 
 /** How far past a renewal failure we retry rather than hammering the broker. */
 const RENEW_RETRY_MS = 60_000
+
+/**
+ * A retry of `agentActivityCreate` is only safe because the input carries our own id: creation
+ * is append-only (§15), so an indeterminate failure — transport loss, 5xx after the write
+ * committed — would otherwise post the same thought twice under two server ids. Linear refuses
+ * the second write on the id instead, which we read as "the first attempt landed".
+ *
+ * Only these say that clearly. Anything else surfaces: swallowing an ambiguous refusal would
+ * silently drop a real activity, which is the worse failure of the two.
+ */
+const DUPLICATE_ID_REFUSAL = /already exists|already been taken|duplicate|unique constraint/i
 
 /** §11 bounded send retry: attempts per enqueued write, and the spacing between them. */
 const SEND_MAX_ATTEMPTS = 3
@@ -163,6 +175,8 @@ export interface LinearDeps {
   /** Refresh-ahead timer, injectable for tests. Defaults to unref'd `setTimeout`. */
   setTimer?: (fn: () => void, ms: number) => unknown
   clearTimer?: (handle: unknown) => void
+  /** Idempotency key per activity; injectable so tests are deterministic. Defaults to `randomUUID`. */
+  newActivityId?: () => string
 }
 
 interface CachedToken {
@@ -186,6 +200,7 @@ export class LinearConnection implements PlatformConnection {
   private readonly sleep: (ms: number) => Promise<void>
   private readonly setTimer: (fn: () => void, ms: number) => unknown
   private readonly clearTimer: (handle: unknown) => void
+  private readonly newActivityId: () => string
   private cached: CachedToken
   /** Single-flight: concurrent sends inside the margin issue ONE `linearcred/request`. */
   private renewal: Promise<CachedToken> | undefined
@@ -219,6 +234,7 @@ export class LinearConnection implements PlatformConnection {
     this.sleep = deps.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)))
     this.setTimer = deps.setTimer ?? defaultSetTimer
     this.clearTimer = deps.clearTimer ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>))
+    this.newActivityId = deps.newActivityId ?? (() => randomUUID())
     this.cached = { token: config.accessToken, expiresAtMs: Date.parse(config.accessTokenExpiresAt) }
     this.queue = new PlatformSendQueue(deps.sendIntervalMs ?? LINEAR_SEND_INTERVAL_MS, this.now, deps.sleep)
   }
@@ -268,23 +284,27 @@ export class LinearConnection implements PlatformConnection {
 
   // ── 2. egress (§4.6 single writer) ──
 
-  /** `agentActivityCreate` — one row in the Linear agent-session feed. Returns the new
-   *  activity id when Linear reported one. */
+  /** `agentActivityCreate` — one row in the Linear agent-session feed. Returns the activity id,
+   *  which is OURS: minted once here, before the first attempt, and reused by every retry so an
+   *  indeterminate failure cannot append the same activity twice. */
   async createActivity(
     agentSessionId: string,
     content: LinearActivityContent,
     opts: { ephemeral?: boolean; signal?: string } = {}
   ): Promise<string | undefined> {
-    const input: Record<string, unknown> = { agentSessionId, content }
+    const id = this.newActivityId()
+    const input: Record<string, unknown> = { id, agentSessionId, content }
     if (opts.ephemeral !== undefined) input.ephemeral = opts.ephemeral
     if (opts.signal !== undefined) input.signal = opts.signal
-    const data = await this.enqueueGraphql<{
-      agentActivityCreate?: { success?: boolean; agentActivity?: { id?: string } | null }
-    }>(AGENT_ACTIVITY_CREATE, { input })
-    return data.agentActivityCreate?.agentActivity?.id ?? undefined
+    type CreatePayload = { agentActivityCreate?: { success?: boolean; agentActivity?: { id?: string } | null } }
+    const data = await this.enqueueGraphql<CreatePayload>(AGENT_ACTIVITY_CREATE, { input }, () => ({
+      agentActivityCreate: { agentActivity: { id } }
+    }))
+    return data.agentActivityCreate?.agentActivity?.id ?? id
   }
 
-  /** `agentSessionUpdate` — the session-level surfaces: plan and external URLs (§2). */
+  /** `agentSessionUpdate` — the session-level surfaces (§2). Needs no idempotency key: `plan` and
+   *  `externalUrls` are full-array replaces, so a retry converges on the same state. */
   async updateSession(agentSessionId: string, update: LinearSessionUpdate): Promise<void> {
     await this.enqueueGraphql<{ agentSessionUpdate?: { success?: boolean } }>(AGENT_SESSION_UPDATE, {
       id: agentSessionId,
@@ -454,12 +474,24 @@ export class LinearConnection implements PlatformConnection {
    *  retryable refusal gets a few spaced attempts inside the caller's one queue slot (order is
    *  preserved) and a terminal one fails at once. Read-port calls do not retry — they already
    *  degrade to a default. */
-  private async enqueueGraphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  private async enqueueGraphql<T>(
+    query: string,
+    variables: Record<string, unknown>,
+    /** Present when the write carries an idempotency key: the value to resolve with if a RETRY is
+     *  refused because that key already exists, which means the earlier attempt committed. */
+    onDuplicateKey?: () => T
+  ): Promise<T> {
     return this.queue.enqueue(async () => {
       for (let attempt = 1; ; attempt += 1) {
         try {
           return await this.graphql<T>(query, variables)
         } catch (err) {
+          // Only ever on a RETRY: a first-attempt duplicate means the caller reused a key across
+          // two logical writes, which is a bug to surface rather than a success to invent.
+          if (attempt > 1 && onDuplicateKey && isDuplicateKeyRefusal(err)) {
+            this.deps.log?.debug('linear: retry refused on an existing id — the earlier attempt committed')
+            return onDuplicateKey()
+          }
           const retryable = err instanceof LinearApiError && err.retryable
           if (!retryable || attempt >= SEND_MAX_ATTEMPTS) throw err
           const backoff = (err as LinearApiError).retryAfterMs ?? SEND_RETRY_BASE_MS * 2 ** (attempt - 1)
@@ -507,6 +539,12 @@ export class LinearConnection implements PlatformConnection {
     if (body.data === undefined) throw new LinearApiError('linear returned no data', true)
     return body.data
   }
+}
+
+/** Does this refusal clearly say our idempotency key is already committed? Conservative by
+ *  construction — an ambiguous error is surfaced, never read as a silent success. */
+function isDuplicateKeyRefusal(err: unknown): boolean {
+  return err instanceof LinearApiError && DUPLICATE_ID_REFUSAL.test(err.message)
 }
 
 /** Status-only verdict, the fallback when the body names no code of its own. */

--- a/packages/daemon/src/platforms/linear/connection.ts
+++ b/packages/daemon/src/platforms/linear/connection.ts
@@ -1,0 +1,479 @@
+/**
+ * The Linear **Layer-1 connection** (linear-integration.md §9.4): one per-integration
+ * egress client over plain GraphQL `fetch`.
+ *
+ * Linear has no socket — ingress is relay-terminated webhooks (§4.2) — so `start()` only
+ * warms the access token and `stop()` clears the refresh timer. Egress is daemon-direct
+ * (§4.6, single writer per session): activities and session updates, paced by one
+ * `PlatformSendQueue` per integration (§5.3).
+ *
+ * TOKEN CUSTODY (§4.4/§7.3). The CP owns the client secret and the rotating refresh token
+ * and is the single durable writer; the daemon starts from the ≤24 h snapshot the spec
+ * carries and re-requests over `linearcred/request` once it is within
+ * {@link RENEW_MARGIN_MS} of expiry. Renewal failure DEGRADES rather than breaks: the
+ * cached token keeps serving until it actually expires, and only then does a send fail.
+ * Token material never reaches a log line.
+ *
+ * The read port answers what Linear affords: `getChannelInfo` resolves the issue and
+ * `getUserProfile` the Linear user; everything else answers empty. There is no bot
+ * channel enumeration, no leave affordance, and attachment download is deferred.
+ */
+import type { IntegrationLinearConfig, LinearCredGrant } from '@agentconnect.md/protocol'
+import type { Agent } from '../../agents/agent-schema.js'
+import type { Logger } from '../../log.js'
+import type {
+  PlatformChannelInfo,
+  PlatformChannelRef,
+  PlatformConnection,
+  PlatformMemberRef,
+  PlatformUserProfile
+} from '../contract.js'
+import { platformIntegrationConfig } from '../integration-config.js'
+import { PlatformSendQueue } from '../send-queue.js'
+
+/** Linear's single GraphQL endpoint (§2). Overridable per connection for tests only. */
+export const LINEAR_GRAPHQL_ENDPOINT = 'https://api.linear.app/graphql'
+
+/** Renew once the cached token is within this of expiry (§4.4 names 2 h). */
+export const RENEW_MARGIN_MS = 2 * 60 * 60 * 1000
+
+/** Minimum spacing between outbound writes — 5 000 req/h per app per workspace (§5.3). */
+export const LINEAR_SEND_INTERVAL_MS = 1_000
+
+/** How far past a renewal failure we retry rather than hammering the broker. */
+const RENEW_RETRY_MS = 60_000
+
+/** One agent activity's content (§5 `LinearAction`, the content half). */
+export type LinearActivityContent =
+  | { type: 'thought'; body: string }
+  | { type: 'action'; action: string; parameter: string; result?: string }
+  | { type: 'response'; body: string }
+  | { type: 'error'; body: string }
+  | { type: 'elicitation'; body: string }
+
+/** One entry of the session plan; both sides are full-array replace (§5.1). */
+export interface LinearPlanEntry {
+  content: string
+  status: 'pending' | 'inProgress' | 'completed' | 'canceled'
+}
+
+/** One labelled link on the session. */
+export interface LinearExternalUrl {
+  label: string
+  url: string
+}
+
+/** The `agentSessionUpdate` input this connection is allowed to send (§2). */
+export interface LinearSessionUpdate {
+  plan?: LinearPlanEntry[]
+  externalUrls?: LinearExternalUrl[]
+  addedExternalUrls?: LinearExternalUrl[]
+  removedExternalUrls?: LinearExternalUrl[]
+}
+
+/** A Linear API refusal — GraphQL `errors[]` or a non-2xx response. */
+export class LinearApiError extends Error {
+  constructor(
+    message: string,
+    /** Worth another attempt (5xx, 429, transport). A rejected token or a bad input is not. */
+    readonly retryable: boolean,
+    /** Linear's `extensions.code` on the first error, when it reported one. */
+    readonly code?: string
+  ) {
+    super(message)
+    this.name = 'LinearApiError'
+  }
+}
+
+/** No usable token: the snapshot expired and renewal did not answer (§11 "token refresh fails"). */
+export class LinearTokenUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LinearTokenUnavailableError'
+  }
+}
+
+/** One connection's worth of consolidated integrations (§7.5 registry group shape). */
+export interface ConsolidatedLinearGroup {
+  key: string
+  agentId: string
+  integrationId: string
+  config: IntegrationLinearConfig
+  integrations: { agentId: string; integrationId: string }[]
+}
+
+/**
+ * §7.5 opaque identity of one Linear egress client. Keyed by the INTEGRATION, because the
+ * spec token is per-integration and §5.3 paces per integration — the workspace is carried
+ * so a re-pointed integration reconnects instead of silently writing to another workspace.
+ * The token itself is deliberately absent: it rotates, the identity does not.
+ */
+export function linearConnKey(c: { integrationId: string; workspaceId: string }): string {
+  return `${c.integrationId}\u0000${c.workspaceId}`
+}
+
+/** Group an agent set's Linear integrations, one connection each. A config the module's
+ *  schema rejects is skipped with a warning — fail closed, never half-served (§6.4). */
+export function consolidateLinear(agents: Agent[], log?: Logger): Map<string, ConsolidatedLinearGroup> {
+  const groups = new Map<string, ConsolidatedLinearGroup>()
+  for (const a of agents) {
+    for (const int of a.integrations) {
+      if (int.platform !== 'linear') continue
+      const config = platformIntegrationConfig('linear', int)
+      if (!config) {
+        log?.warn(`linear: integration ${int.id} skipped — config failed the linear schema`)
+        continue
+      }
+      const key = linearConnKey({ integrationId: int.id, workspaceId: config.workspaceId })
+      groups.set(key, {
+        key,
+        agentId: a.id,
+        integrationId: int.id,
+        config,
+        integrations: [{ agentId: a.id, integrationId: int.id }]
+      })
+    }
+  }
+  return groups
+}
+
+export interface LinearDeps {
+  group: ConsolidatedLinearGroup
+  /** D→C `linearcred/request` — the CP resolves integration → bot → workspace token itself. */
+  requestToken: (payload: { integrationId: string }) => Promise<LinearCredGrant>
+  log?: Logger
+  /** GraphQL endpoint; tests point it at a fake. */
+  endpoint?: string
+  /** Injected so tests need no network. Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch
+  /** Min spacing (ms) between outbound writes. Tests pass 0. */
+  sendIntervalMs?: number
+  /** Wall clock, injectable for tests. Token expiry is absolute time, not a TTL. */
+  now?: () => number
+  /** Send-queue sleep, injectable so a fake clock does not wait in real time. */
+  sleep?: (ms: number) => Promise<void>
+  /** Refresh-ahead timer, injectable for tests. Defaults to unref'd `setTimeout`. */
+  setTimer?: (fn: () => void, ms: number) => unknown
+  clearTimer?: (handle: unknown) => void
+}
+
+interface CachedToken {
+  token: string
+  /** Absolute wall-clock expiry (ms). `NaN` when the source string did not parse. */
+  expiresAtMs: number
+}
+
+const defaultSetTimer = (fn: () => void, ms: number): unknown => {
+  const t = setTimeout(fn, ms)
+  ;(t as { unref?: () => void }).unref?.()
+  return t
+}
+
+export class LinearConnection implements PlatformConnection {
+  /** All outbound writes funnel through one queue so activities land in converger order. */
+  private readonly queue: PlatformSendQueue
+  private readonly endpoint: string
+  private readonly fetchImpl: typeof fetch
+  private readonly now: () => number
+  private readonly setTimer: (fn: () => void, ms: number) => unknown
+  private readonly clearTimer: (handle: unknown) => void
+  private cached: CachedToken
+  /** Single-flight: concurrent sends inside the margin issue ONE `linearcred/request`. */
+  private renewal: Promise<CachedToken> | undefined
+  /** Wall-clock deadline before which a failed renewal is not retried. */
+  private renewBlockedUntil = 0
+  private refreshTimer: unknown
+  private stopped = false
+
+  readonly integrationId: string
+  readonly agentId: string
+  /** The Linear organization id — this connection's durable tenant, surviving token rotation. */
+  private readonly organizationId: string
+  readonly workspaceName?: string
+  /** The app's own Linear user id: Linear's app user IS this connection's bot identity,
+   *  so it answers the contract's `botUserId` and backs the ingress self-echo guard (§7.2). */
+  readonly botUserId?: string
+  /** Linear exposes no per-workspace permalink base here, so the daemon's deep-link base
+   *  falls through to the configured Web App URL — same posture as Feishu. */
+  readonly workspaceUrl = ''
+
+  constructor(private readonly deps: LinearDeps) {
+    const { config } = deps.group
+    this.integrationId = deps.group.integrationId
+    this.agentId = deps.group.agentId
+    this.organizationId = config.workspaceId
+    if (config.workspaceName !== undefined) this.workspaceName = config.workspaceName
+    if (config.appUserId !== undefined) this.botUserId = config.appUserId
+    this.endpoint = deps.endpoint ?? LINEAR_GRAPHQL_ENDPOINT
+    this.fetchImpl = deps.fetchImpl ?? ((...args: Parameters<typeof fetch>) => fetch(...args))
+    this.now = deps.now ?? (() => Date.now())
+    this.setTimer = deps.setTimer ?? defaultSetTimer
+    this.clearTimer = deps.clearTimer ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>))
+    this.cached = { token: config.accessToken, expiresAtMs: Date.parse(config.accessTokenExpiresAt) }
+    this.queue = new PlatformSendQueue(deps.sendIntervalMs ?? LINEAR_SEND_INTERVAL_MS, this.now, deps.sleep)
+  }
+
+  workspaceId(): string {
+    return this.organizationId
+  }
+
+  /** Is this Linear user the app itself? The ingress self-echo guard (§7.2 `appUserId`). */
+  isSelfAuthored(userId: string | undefined): boolean {
+    return userId !== undefined && this.botUserId !== undefined && userId === this.botUserId
+  }
+
+  /** Adopt a re-pushed spec's token without reconnecting — the identity key is unchanged
+   *  by rotation, so a CP refresh converges here rather than through a teardown. */
+  applySnapshot(config: IntegrationLinearConfig): void {
+    const expiresAtMs = Date.parse(config.accessTokenExpiresAt)
+    if (Number.isNaN(expiresAtMs) || expiresAtMs <= this.cached.expiresAtMs) return
+    this.cached = { token: config.accessToken, expiresAtMs }
+    this.renewBlockedUntil = 0
+    this.scheduleRefresh()
+  }
+
+  // ── 1. transport lifecycle ──
+
+  /** No socket to open: warm the token so the first activity does not pay a broker
+   *  round-trip inside Linear's ≤10 s ack budget (§10.1). Best-effort by contract. */
+  async start(): Promise<void> {
+    this.stopped = false
+    try {
+      await this.token()
+    } catch (err) {
+      this.deps.log?.warn(
+        `linear: token warm-up failed for integration ${this.integrationId}: ${(err as Error).message}`
+      )
+    }
+    this.scheduleRefresh()
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true
+    if (this.refreshTimer !== undefined) {
+      this.clearTimer(this.refreshTimer)
+      this.refreshTimer = undefined
+    }
+  }
+
+  // ── 2. egress (§4.6 single writer) ──
+
+  /** `agentActivityCreate` — one row in the Linear agent-session feed. Returns the new
+   *  activity id when Linear reported one. */
+  async createActivity(
+    agentSessionId: string,
+    content: LinearActivityContent,
+    opts: { ephemeral?: boolean; signal?: string } = {}
+  ): Promise<string | undefined> {
+    const input: Record<string, unknown> = { agentSessionId, content }
+    if (opts.ephemeral !== undefined) input.ephemeral = opts.ephemeral
+    if (opts.signal !== undefined) input.signal = opts.signal
+    const data = await this.enqueueGraphql<{
+      agentActivityCreate?: { success?: boolean; agentActivity?: { id?: string } | null }
+    }>(AGENT_ACTIVITY_CREATE, { input })
+    return data.agentActivityCreate?.agentActivity?.id ?? undefined
+  }
+
+  /** `agentSessionUpdate` — the session-level surfaces: plan and external URLs (§2). */
+  async updateSession(agentSessionId: string, update: LinearSessionUpdate): Promise<void> {
+    await this.enqueueGraphql<{ agentSessionUpdate?: { success?: boolean } }>(AGENT_SESSION_UPDATE, {
+      id: agentSessionId,
+      input: update
+    })
+  }
+
+  /** Full-array plan replace — both sides have the same semantics (§5.1). */
+  async updateSessionPlan(agentSessionId: string, entries: LinearPlanEntry[]): Promise<void> {
+    await this.updateSession(agentSessionId, { plan: entries })
+  }
+
+  /** Additive link publication, so a later turn never drops an earlier turn's links. */
+  async addSessionExternalUrls(agentSessionId: string, urls: LinearExternalUrl[]): Promise<void> {
+    if (urls.length === 0) return
+    await this.updateSession(agentSessionId, { addedExternalUrls: urls })
+  }
+
+  // ── 3. read / query port ──
+
+  /** The issue behind a session's channel id. `channel` is the issue UUID, or — for a
+   *  session with no issue (§4.5) — the AgentSession UUID, which resolves nothing and
+   *  answers the bare id rather than throwing. */
+  async getChannelInfo(channel: string): Promise<PlatformChannelInfo> {
+    try {
+      const data = await this.graphql<{
+        issue?: { id?: string; identifier?: string; title?: string } | null
+      }>(ISSUE_QUERY, { id: channel })
+      const issue = data.issue
+      if (!issue) return { id: channel, isIm: false }
+      const name = [issue.identifier, issue.title].filter((p) => p !== undefined && p !== '').join(' · ')
+      return { id: channel, ...(name ? { name } : {}), isIm: false }
+    } catch (err) {
+      this.deps.log?.debug(`linear: issue lookup failed (${channel}): ${(err as Error).message}`)
+      return { id: channel, isIm: false }
+    }
+  }
+
+  async getUserProfile(user: string): Promise<PlatformUserProfile> {
+    try {
+      const data = await this.graphql<{
+        user?: { id?: string; name?: string; displayName?: string; avatarUrl?: string | null } | null
+      }>(USER_QUERY, { id: user })
+      const u = data.user
+      if (!u) return { id: user, isBot: this.isSelfAuthored(user) }
+      return {
+        id: u.id ?? user,
+        ...(u.displayName ? { name: u.displayName } : {}),
+        ...(u.name ? { realName: u.name } : {}),
+        ...(u.avatarUrl ? { avatarUrl: u.avatarUrl } : {}),
+        // A plain user read carries no bot flag; the app's own id is the one we can name (§7.2).
+        isBot: this.isSelfAuthored(u.id ?? user)
+      }
+    } catch (err) {
+      this.deps.log?.debug(`linear: user lookup failed (${user}): ${(err as Error).message}`)
+      return { id: user, isBot: this.isSelfAuthored(user) }
+    }
+  }
+
+  /** Linear issues have no member roster core can enumerate. */
+  async listMembers(_channel: string): Promise<PlatformMemberRef[]> {
+    return []
+  }
+
+  /** No conversation enumeration: an agent session is created by Linear, never joined. */
+  async listChannels(): Promise<PlatformChannelRef[]> {
+    return []
+  }
+
+  /** Attachment download is deferred (§9.4) — `null` is "unavailable", never a throw. */
+  async downloadFile(_ref: string, _maxBytes?: number): Promise<Buffer | null> {
+    return null
+  }
+
+  // ── token cache (§4.4) ──
+
+  /** The live access token: the cached one while it is outside the safety margin, else a
+   *  single-flight `linearcred` renewal. A failed renewal keeps serving the cached token
+   *  until it actually expires; past expiry the caller gets a hard error. */
+  async token(): Promise<string> {
+    const now = this.now()
+    if (!this.needsRenewal(now)) return this.cached.token
+    if (now < this.renewBlockedUntil && this.stillValid(now)) return this.cached.token
+    try {
+      return (await this.renew()).token
+    } catch (err) {
+      if (this.stillValid(this.now())) {
+        this.deps.log?.warn(
+          `linear: token renewal failed for integration ${this.integrationId} — serving the cached token (${(err as Error).message})`
+        )
+        return this.cached.token
+      }
+      throw new LinearTokenUnavailableError(
+        `linear access token for integration ${this.integrationId} expired and renewal failed: ${(err as Error).message}`
+      )
+    }
+  }
+
+  private needsRenewal(now: number): boolean {
+    return Number.isNaN(this.cached.expiresAtMs) || this.cached.expiresAtMs - now <= RENEW_MARGIN_MS
+  }
+
+  private stillValid(now: number): boolean {
+    return !Number.isNaN(this.cached.expiresAtMs) && this.cached.expiresAtMs > now
+  }
+
+  private renew(): Promise<CachedToken> {
+    if (this.renewal) return this.renewal
+    const pending = this.deps
+      .requestToken({ integrationId: this.integrationId })
+      .then((grant) => {
+        const expiresAtMs = Date.parse(grant.expiresAt)
+        // A grant we cannot date is still fresh: give it one margin rather than forever.
+        const next: CachedToken = {
+          token: grant.accessToken,
+          expiresAtMs: Number.isNaN(expiresAtMs) ? this.now() + RENEW_MARGIN_MS : expiresAtMs
+        }
+        this.cached = next
+        this.renewBlockedUntil = 0
+        this.scheduleRefresh()
+        return next
+      })
+      .catch((err: unknown) => {
+        this.renewBlockedUntil = this.now() + RENEW_RETRY_MS
+        throw err
+      })
+      .finally(() => {
+        this.renewal = undefined
+      })
+    this.renewal = pending
+    return pending
+  }
+
+  /** Refresh AHEAD of the margin so an idle integration's next activity is not the thing
+   *  that discovers an expired token. One timer, replaced on every token swap. */
+  private scheduleRefresh(): void {
+    if (this.refreshTimer !== undefined) {
+      this.clearTimer(this.refreshTimer)
+      this.refreshTimer = undefined
+    }
+    if (this.stopped || Number.isNaN(this.cached.expiresAtMs)) return
+    const delay = Math.max(RENEW_RETRY_MS, this.cached.expiresAtMs - RENEW_MARGIN_MS - this.now())
+    this.refreshTimer = this.setTimer(() => {
+      this.refreshTimer = undefined
+      void this.token().catch(() => undefined)
+    }, delay)
+  }
+
+  // ── GraphQL transport ──
+
+  private enqueueGraphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+    return this.queue.enqueue(() => this.graphql<T>(query, variables))
+  }
+
+  private async graphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+    const token = await this.token()
+    let res: Response
+    try {
+      res = await this.fetchImpl(this.endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+        body: JSON.stringify({ query, variables })
+      })
+    } catch (err) {
+      throw new LinearApiError(`linear request failed: ${(err as Error).message}`, true)
+    }
+    if (!res.ok) {
+      throw new LinearApiError(`linear responded ${res.status}`, res.status === 429 || res.status >= 500)
+    }
+    let body: { data?: T; errors?: { message?: string; extensions?: { code?: string } }[] }
+    try {
+      body = (await res.json()) as typeof body
+    } catch (err) {
+      throw new LinearApiError(`linear returned an unreadable body: ${(err as Error).message}`, true)
+    }
+    if (body.errors && body.errors.length > 0) {
+      const code = body.errors[0]?.extensions?.code
+      const message = body.errors.map((e) => e.message ?? 'unknown error').join('; ')
+      throw new LinearApiError(`linear rejected the request: ${message}`, code === 'RATELIMITED', code)
+    }
+    if (body.data === undefined) throw new LinearApiError('linear returned no data', true)
+    return body.data
+  }
+}
+
+// The four documents this connection sends. Shapes follow Linear's published agent API
+// (linear-integration.md §2); anything beyond them is a Layer-2 or later concern.
+const AGENT_ACTIVITY_CREATE = `mutation AgentActivityCreate($input: AgentActivityCreateInput!) {
+  agentActivityCreate(input: $input) { success agentActivity { id } }
+}`
+
+const AGENT_SESSION_UPDATE = `mutation AgentSessionUpdate($id: String!, $input: AgentSessionUpdateInput!) {
+  agentSessionUpdate(id: $id, input: $input) { success }
+}`
+
+const ISSUE_QUERY = `query Issue($id: String!) {
+  issue(id: $id) { id identifier title url }
+}`
+
+const USER_QUERY = `query User($id: String!) {
+  user(id: $id) { id name displayName avatarUrl }
+}`

--- a/packages/daemon/test/linear-connection.test.ts
+++ b/packages/daemon/test/linear-connection.test.ts
@@ -1,0 +1,574 @@
+/**
+ * The Linear Layer-1 connection (linear-integration.md §9.4): config-schema fail-closed
+ * reads, the `linearcred` token cache, send-queue pacing, the GraphQL request shapes, and
+ * the deliberately narrow read port.
+ *
+ * Everything here is platform-neutral: no filesystem paths, no real timers, and a fake
+ * wall clock for the token margin and the queue's spacing.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Agent, Integration } from '../src/agents/agent-schema.js'
+import { platformIntegrationConfig } from '../src/platforms/integration-config.js'
+import {
+  consolidateLinear,
+  LinearApiError,
+  LinearConnection,
+  LinearTokenUnavailableError,
+  linearConnKey,
+  RENEW_MARGIN_MS,
+  type ConsolidatedLinearGroup,
+  type LinearDeps
+} from '../src/platforms/linear/connection.js'
+
+const WORKSPACE = 'a2f2f0d4-0e33-4c4b-9a4b-4f7a0f1f0001'
+const SESSION = 'c3f1e0aa-4d2f-4f0a-9b1e-2b6d5c4a0002'
+const ISSUE = 'd7c2b1aa-6e5f-4a3b-8c9d-1e2f3a4b0003'
+const START = Date.parse('2026-09-01T00:00:00.000Z')
+/** Comfortably outside the 2 h renewal margin. */
+const FRESH_EXPIRY = new Date(START + 20 * 60 * 60 * 1000).toISOString()
+/** Inside the margin, so the very next token read renews. */
+const NEAR_EXPIRY = new Date(START + 30 * 60 * 1000).toISOString()
+
+function linearConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    workspaceId: WORKSPACE,
+    workspaceName: 'Example Workspace',
+    appUserId: 'app-user-1',
+    accessToken: 'snapshot-token',
+    accessTokenExpiresAt: FRESH_EXPIRY,
+    ...overrides
+  }
+}
+
+function linearIntegration(config: unknown, id = 'int-1'): Integration {
+  return {
+    id,
+    platform: 'linear',
+    core: { mode: 'shared', bindRules: [], mutedChannels: [], gated: false },
+    config
+  } as Integration
+}
+
+function linearAgent(id: string, config: unknown, integrationId = `int-${id}`): Agent {
+  return { id, integrations: [linearIntegration(config, integrationId)] } as unknown as Agent
+}
+
+/** A wall clock the test drives; `sleep` advances it instead of waiting. */
+function fakeClock(start = START) {
+  let t = start
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms
+    },
+    sleep: async (ms: number) => {
+      t += ms
+    }
+  }
+}
+
+interface RecordedCall {
+  url: string
+  authorization: string
+  query: string
+  variables: Record<string, unknown>
+  at: number
+}
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  ({ ok: status >= 200 && status < 300, status, json: async () => body }) as unknown as Response
+
+function group(config: Record<string, unknown> = linearConfig()): ConsolidatedLinearGroup {
+  const parsed = platformIntegrationConfig('linear', linearIntegration(config))
+  if (!parsed) throw new Error('fixture config must pass the linear schema')
+  return {
+    key: linearConnKey({ integrationId: 'int-1', workspaceId: WORKSPACE }),
+    agentId: 'agent-1',
+    integrationId: 'int-1',
+    config: parsed,
+    integrations: [{ agentId: 'agent-1', integrationId: 'int-1' }]
+  }
+}
+
+/** A connection over a scripted fake fetch, with every timer and clock injected. */
+function harness(
+  opts: {
+    config?: Record<string, unknown>
+    respond?: (call: RecordedCall) => Response
+    requestToken?: LinearDeps['requestToken']
+    sendIntervalMs?: number
+  } = {}
+) {
+  const clock = fakeClock()
+  const calls: RecordedCall[] = []
+  const timers: { fired: boolean; cleared: boolean }[] = []
+  const warnings: string[] = []
+  const fetchImpl = (async (url: unknown, init: unknown) => {
+    const request = init as { headers: Record<string, string>; body: string }
+    const parsed = JSON.parse(request.body) as { query: string; variables: Record<string, unknown> }
+    const call: RecordedCall = {
+      url: String(url),
+      authorization: request.headers.authorization ?? '',
+      query: parsed.query,
+      variables: parsed.variables,
+      at: clock.now()
+    }
+    calls.push(call)
+    return opts.respond ? opts.respond(call) : jsonResponse({ data: { ok: true } })
+  }) as unknown as typeof fetch
+
+  const conn = new LinearConnection({
+    group: group(opts.config ?? linearConfig()),
+    requestToken: opts.requestToken ?? (async () => ({ accessToken: 'renewed', expiresAt: FRESH_EXPIRY })),
+    fetchImpl,
+    endpoint: 'https://linear.example.test/graphql',
+    sendIntervalMs: opts.sendIntervalMs ?? 0,
+    now: clock.now,
+    sleep: clock.sleep,
+    setTimer: () => {
+      const handle = { fired: false, cleared: false }
+      timers.push(handle)
+      return handle
+    },
+    clearTimer: (handle) => {
+      ;(handle as { cleared: boolean }).cleared = true
+    },
+    log: {
+      trace: () => {},
+      debug: () => {},
+      info: () => {},
+      warn: (m) => warnings.push(m),
+      error: () => {}
+    }
+  })
+  return { conn, calls, clock, timers, warnings }
+}
+
+describe('linear config schema (§6.4 fail-closed)', () => {
+  it('accepts a full spec payload and narrows it to the linear module', () => {
+    const parsed = platformIntegrationConfig('linear', linearIntegration(linearConfig()))
+    expect(parsed).toEqual({
+      workspaceId: WORKSPACE,
+      workspaceName: 'Example Workspace',
+      appUserId: 'app-user-1',
+      accessToken: 'snapshot-token',
+      accessTokenExpiresAt: FRESH_EXPIRY
+    })
+  })
+
+  it('accepts the minimal payload: workspace, token and expiry', () => {
+    const minimal = { workspaceId: WORKSPACE, accessToken: 't', accessTokenExpiresAt: FRESH_EXPIRY }
+    expect(platformIntegrationConfig('linear', linearIntegration(minimal))).toEqual(minimal)
+  })
+
+  it('fails closed on a missing token, a missing expiry and a non-datetime expiry', () => {
+    const cases = [
+      { workspaceId: WORKSPACE, accessTokenExpiresAt: FRESH_EXPIRY },
+      { workspaceId: WORKSPACE, accessToken: 't' },
+      { workspaceId: WORKSPACE, accessToken: 't', accessTokenExpiresAt: '2026-09-01' },
+      { accessToken: 't', accessTokenExpiresAt: FRESH_EXPIRY },
+      { workspaceId: WORKSPACE, accessToken: 42, accessTokenExpiresAt: FRESH_EXPIRY }
+    ]
+    for (const config of cases) {
+      expect(platformIntegrationConfig('linear', linearIntegration(config))).toBeUndefined()
+    }
+  })
+
+  it('refuses to read a linear entry as another platform, and an absent config at all', () => {
+    expect(platformIntegrationConfig('slack', linearIntegration(linearConfig()))).toBeUndefined()
+    expect(platformIntegrationConfig('linear', linearIntegration(undefined))).toBeUndefined()
+  })
+})
+
+describe('consolidateLinear (§7.5 groups)', () => {
+  it('emits one group per integration, keyed by integration and workspace', () => {
+    const groups = consolidateLinear([linearAgent('a', linearConfig()), linearAgent('b', linearConfig())])
+    expect([...groups.keys()]).toEqual([
+      linearConnKey({ integrationId: 'int-a', workspaceId: WORKSPACE }),
+      linearConnKey({ integrationId: 'int-b', workspaceId: WORKSPACE })
+    ])
+    expect(groups.get(linearConnKey({ integrationId: 'int-a', workspaceId: WORKSPACE }))?.agentId).toBe('a')
+  })
+
+  it('skips a config the schema rejects, with a warning naming the integration', () => {
+    const warnings: string[] = []
+    const log = {
+      trace: () => {},
+      debug: () => {},
+      info: () => {},
+      warn: (m: string) => warnings.push(m),
+      error: () => {}
+    }
+    const groups = consolidateLinear([linearAgent('a', { workspaceId: WORKSPACE })], log)
+    expect(groups.size).toBe(0)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('int-a')
+  })
+
+  it('keys on the workspace too, so a re-pointed integration is a different connection', () => {
+    const other = 'b9e1d2c3-1111-4222-8333-444455550004'
+    expect(linearConnKey({ integrationId: 'int-1', workspaceId: WORKSPACE })).not.toBe(
+      linearConnKey({ integrationId: 'int-1', workspaceId: other })
+    )
+  })
+})
+
+describe('linear token cache (§4.4)', () => {
+  it('serves the spec snapshot without a broker request while outside the margin', async () => {
+    let requests = 0
+    const { conn } = harness({
+      requestToken: async () => {
+        requests += 1
+        return { accessToken: 'renewed', expiresAt: FRESH_EXPIRY }
+      }
+    })
+    await conn.start()
+    expect(await conn.token()).toBe('snapshot-token')
+    expect(requests).toBe(0)
+  })
+
+  it('renews once inside the margin and swaps the cached token', async () => {
+    let requests = 0
+    const { conn, calls } = harness({
+      config: linearConfig({ accessTokenExpiresAt: NEAR_EXPIRY }),
+      requestToken: async () => {
+        requests += 1
+        return { accessToken: 'renewed', expiresAt: FRESH_EXPIRY }
+      }
+    })
+    expect(await conn.token()).toBe('renewed')
+    expect(requests).toBe(1)
+    // The swapped token is now outside the margin, so a second read asks nobody.
+    expect(await conn.token()).toBe('renewed')
+    expect(requests).toBe(1)
+    await conn.createActivity(SESSION, { type: 'thought', body: 'hi' })
+    expect(calls[0]?.authorization).toBe('Bearer renewed')
+  })
+
+  it('collapses concurrent reads inside the margin into a single broker request', async () => {
+    let requests = 0
+    const { conn } = harness({
+      config: linearConfig({ accessTokenExpiresAt: NEAR_EXPIRY }),
+      requestToken: async () => {
+        requests += 1
+        return { accessToken: 'renewed', expiresAt: FRESH_EXPIRY }
+      }
+    })
+    const tokens = await Promise.all([conn.token(), conn.token(), conn.token()])
+    expect(tokens).toEqual(['renewed', 'renewed', 'renewed'])
+    expect(requests).toBe(1)
+  })
+
+  it('issues one request for concurrent sends inside the margin', async () => {
+    let requests = 0
+    const { conn, calls } = harness({
+      config: linearConfig({ accessTokenExpiresAt: NEAR_EXPIRY }),
+      requestToken: async () => {
+        requests += 1
+        return { accessToken: 'renewed', expiresAt: FRESH_EXPIRY }
+      }
+    })
+    await Promise.all([
+      conn.createActivity(SESSION, { type: 'thought', body: 'a' }),
+      conn.createActivity(SESSION, { type: 'thought', body: 'b' })
+    ])
+    expect(requests).toBe(1)
+    expect(calls.map((c) => c.authorization)).toEqual(['Bearer renewed', 'Bearer renewed'])
+  })
+
+  it('keeps serving the cached token when renewal fails but the snapshot has not expired', async () => {
+    const { conn, warnings } = harness({
+      config: linearConfig({ accessTokenExpiresAt: NEAR_EXPIRY }),
+      requestToken: async () => {
+        throw new Error('LEASE_DENIED')
+      }
+    })
+    expect(await conn.token()).toBe('snapshot-token')
+    expect(warnings.some((w) => w.includes('serving the cached token'))).toBe(true)
+  })
+
+  it('does not re-ask the broker on every read after a failure, then retries after the backoff', async () => {
+    let requests = 0
+    const { conn, clock } = harness({
+      config: linearConfig({ accessTokenExpiresAt: NEAR_EXPIRY }),
+      requestToken: async () => {
+        requests += 1
+        throw new Error('RATE_LIMITED')
+      }
+    })
+    await conn.token()
+    await conn.token()
+    expect(requests).toBe(1)
+    clock.advance(61_000)
+    await conn.token()
+    expect(requests).toBe(2)
+  })
+
+  it('surfaces a send error once the cached token has actually expired', async () => {
+    const { conn, calls, clock } = harness({
+      config: linearConfig({ accessTokenExpiresAt: NEAR_EXPIRY }),
+      requestToken: async () => {
+        throw new Error('LEASE_DENIED')
+      }
+    })
+    // Past the snapshot's own expiry: the degradation window is over, the failure is real.
+    clock.advance(31 * 60 * 1000)
+    await expect(conn.createActivity(SESSION, { type: 'response', body: 'x' })).rejects.toBeInstanceOf(
+      LinearTokenUnavailableError
+    )
+    expect(calls).toHaveLength(0)
+  })
+
+  it('adopts a re-pushed spec snapshot without a broker round-trip', async () => {
+    let requests = 0
+    const { conn, calls } = harness({
+      config: linearConfig({ accessTokenExpiresAt: NEAR_EXPIRY }),
+      requestToken: async () => {
+        requests += 1
+        return { accessToken: 'renewed', expiresAt: FRESH_EXPIRY }
+      }
+    })
+    conn.applySnapshot({
+      workspaceId: WORKSPACE,
+      accessToken: 'pushed',
+      accessTokenExpiresAt: new Date(START + 23 * 60 * 60 * 1000).toISOString()
+    })
+    await conn.createActivity(SESSION, { type: 'thought', body: 'hi' })
+    expect(requests).toBe(0)
+    expect(calls[0]?.authorization).toBe('Bearer pushed')
+  })
+
+  it('warms the token on start and clears the refresh timer on stop', async () => {
+    const { conn, timers } = harness()
+    await conn.start()
+    expect(timers).toHaveLength(1)
+    await conn.stop()
+    expect(timers[0]?.cleared).toBe(true)
+  })
+})
+
+describe('linear send queue (§5.3)', () => {
+  it('spaces activity posts by the minimum interval, in FIFO order', async () => {
+    const clock = fakeClock()
+    const calls: RecordedCall[] = []
+    const fetchImpl = (async (url: unknown, init: unknown) => {
+      const request = init as { headers: Record<string, string>; body: string }
+      const parsed = JSON.parse(request.body) as { query: string; variables: Record<string, unknown> }
+      calls.push({
+        url: String(url),
+        authorization: request.headers.authorization ?? '',
+        query: parsed.query,
+        variables: parsed.variables,
+        at: clock.now()
+      })
+      return jsonResponse({ data: { agentActivityCreate: { success: true, agentActivity: { id: 'act' } } } })
+    }) as unknown as typeof fetch
+    const conn = new LinearConnection({
+      group: group(),
+      requestToken: async () => ({ accessToken: 'renewed', expiresAt: FRESH_EXPIRY }),
+      fetchImpl,
+      endpoint: 'https://linear.example.test/graphql',
+      sendIntervalMs: 1_000,
+      now: clock.now,
+      sleep: clock.sleep,
+      setTimer: () => undefined,
+      clearTimer: () => {}
+    })
+    await Promise.all([
+      conn.createActivity(SESSION, { type: 'thought', body: 'first' }),
+      conn.createActivity(SESSION, { type: 'thought', body: 'second' }),
+      conn.createActivity(SESSION, { type: 'thought', body: 'third' })
+    ])
+    const bodies = calls.map((c) => (c.variables.input as { content: { body: string } }).content.body)
+    expect(bodies).toEqual(['first', 'second', 'third'])
+    expect(calls[1]!.at - calls[0]!.at).toBeGreaterThanOrEqual(1_000)
+    expect(calls[2]!.at - calls[1]!.at).toBeGreaterThanOrEqual(1_000)
+  })
+})
+
+describe('linear graphql client (§9.4)', () => {
+  it('posts agentActivityCreate with the session, content and ephemeral flag', async () => {
+    const { conn, calls } = harness({
+      respond: () => jsonResponse({ data: { agentActivityCreate: { success: true, agentActivity: { id: 'act-1' } } } })
+    })
+    const id = await conn.createActivity(SESSION, { type: 'thought', body: 'reading' }, { ephemeral: true })
+    expect(id).toBe('act-1')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.url).toBe('https://linear.example.test/graphql')
+    expect(calls[0]!.authorization).toBe('Bearer snapshot-token')
+    expect(calls[0]!.query).toContain('agentActivityCreate')
+    expect(calls[0]!.variables).toEqual({
+      input: { agentSessionId: SESSION, content: { type: 'thought', body: 'reading' }, ephemeral: true }
+    })
+  })
+
+  it('carries an action activity’s action/parameter/result verbatim', async () => {
+    const { conn, calls } = harness()
+    await conn.createActivity(SESSION, { type: 'action', action: 'Read', parameter: 'src/app.ts', result: 'ok' })
+    expect(calls[0]!.variables).toEqual({
+      input: {
+        agentSessionId: SESSION,
+        content: { type: 'action', action: 'Read', parameter: 'src/app.ts', result: 'ok' }
+      }
+    })
+  })
+
+  it('omits ephemeral and signal when the caller names neither', async () => {
+    const { conn, calls } = harness()
+    await conn.createActivity(SESSION, { type: 'response', body: 'done' })
+    expect(calls[0]!.variables).toEqual({
+      input: { agentSessionId: SESSION, content: { type: 'response', body: 'done' } }
+    })
+  })
+
+  it('sends the plan as a full-array replace on agentSessionUpdate', async () => {
+    const { conn, calls } = harness()
+    await conn.updateSessionPlan(SESSION, [
+      { content: 'read the issue', status: 'completed' },
+      { content: 'write the patch', status: 'inProgress' }
+    ])
+    expect(calls[0]!.query).toContain('agentSessionUpdate')
+    expect(calls[0]!.variables).toEqual({
+      id: SESSION,
+      input: {
+        plan: [
+          { content: 'read the issue', status: 'completed' },
+          { content: 'write the patch', status: 'inProgress' }
+        ]
+      }
+    })
+  })
+
+  it('publishes external URLs additively, and sends nothing for an empty set', async () => {
+    const { conn, calls } = harness()
+    await conn.addSessionExternalUrls(SESSION, [{ label: 'PR #123', url: 'https://code.example.test/pr/123' }])
+    await conn.addSessionExternalUrls(SESSION, [])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.variables).toEqual({
+      id: SESSION,
+      input: { addedExternalUrls: [{ label: 'PR #123', url: 'https://code.example.test/pr/123' }] }
+    })
+  })
+
+  it('propagates a GraphQL errors[] refusal, with the extensions code', async () => {
+    const { conn } = harness({
+      respond: () =>
+        jsonResponse({ errors: [{ message: 'Entity not found', extensions: { code: 'ENTITY_NOT_FOUND' } }] })
+    })
+    const err = await conn.createActivity(SESSION, { type: 'thought', body: 'x' }).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(LinearApiError)
+    expect((err as LinearApiError).code).toBe('ENTITY_NOT_FOUND')
+    expect((err as LinearApiError).retryable).toBe(false)
+    expect((err as LinearApiError).message).toContain('Entity not found')
+  })
+
+  it('marks a rate-limit refusal and a 5xx retryable, and a 400 not', async () => {
+    const limited = harness({ respond: () => jsonResponse({ errors: [{ extensions: { code: 'RATELIMITED' } }] }) })
+    const server = harness({ respond: () => jsonResponse({}, 503) })
+    const client = harness({ respond: () => jsonResponse({}, 400) })
+    for (const [h, retryable] of [
+      [limited, true],
+      [server, true],
+      [client, false]
+    ] as const) {
+      const err = await h.conn.createActivity(SESSION, { type: 'thought', body: 'x' }).catch((e: unknown) => e)
+      expect(err).toBeInstanceOf(LinearApiError)
+      expect((err as LinearApiError).retryable).toBe(retryable)
+    }
+  })
+
+  it('treats a transport throw as retryable rather than leaking the raw error', async () => {
+    const conn = new LinearConnection({
+      group: group(),
+      requestToken: async () => ({ accessToken: 'renewed', expiresAt: FRESH_EXPIRY }),
+      fetchImpl: (async () => {
+        throw new Error('ECONNRESET')
+      }) as unknown as typeof fetch,
+      sendIntervalMs: 0,
+      now: () => START,
+      setTimer: () => undefined,
+      clearTimer: () => {}
+    })
+    const err = await conn.createActivity(SESSION, { type: 'thought', body: 'x' }).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(LinearApiError)
+    expect((err as LinearApiError).retryable).toBe(true)
+  })
+})
+
+describe('linear read port (§9.4 — what Linear affords)', () => {
+  it('resolves the issue behind a channel id into identifier · title', async () => {
+    const { conn, calls } = harness({
+      respond: () => jsonResponse({ data: { issue: { id: ISSUE, identifier: 'TEAM-123', title: 'Fix the parser' } } })
+    })
+    expect(await conn.getChannelInfo(ISSUE)).toEqual({ id: ISSUE, name: 'TEAM-123 · Fix the parser', isIm: false })
+    expect(calls[0]!.query).toContain('issue(')
+    expect(calls[0]!.variables).toEqual({ id: ISSUE })
+  })
+
+  it('answers the bare id for a session with no issue, and for a failed lookup', async () => {
+    const missing = harness({ respond: () => jsonResponse({ data: { issue: null } }) })
+    expect(await missing.conn.getChannelInfo(SESSION)).toEqual({ id: SESSION, isIm: false })
+    const failing = harness({ respond: () => jsonResponse({}, 500) })
+    expect(await failing.conn.getChannelInfo(SESSION)).toEqual({ id: SESSION, isIm: false })
+  })
+
+  it('resolves a Linear user, preferring the display name and keeping the full name', async () => {
+    const { conn, calls } = harness({
+      respond: () =>
+        jsonResponse({
+          data: {
+            user: {
+              id: 'user-9',
+              name: 'Ada Lovelace',
+              displayName: 'ada',
+              avatarUrl: 'https://cdn.example.test/a.png'
+            }
+          }
+        })
+    })
+    expect(await conn.getUserProfile('user-9')).toEqual({
+      id: 'user-9',
+      name: 'ada',
+      realName: 'Ada Lovelace',
+      avatarUrl: 'https://cdn.example.test/a.png',
+      isBot: false
+    })
+    expect(calls[0]!.query).toContain('user(')
+  })
+
+  it('reports the app’s own user id as a bot — the self-echo guard', async () => {
+    const { conn } = harness({ respond: () => jsonResponse({ data: { user: { id: 'app-user-1', name: 'Agent' } } }) })
+    expect((await conn.getUserProfile('app-user-1')).isBot).toBe(true)
+    expect(conn.isSelfAuthored('app-user-1')).toBe(true)
+    expect(conn.isSelfAuthored('user-9')).toBe(false)
+    expect(conn.isSelfAuthored(undefined)).toBe(false)
+  })
+
+  it('never claims self-authorship when the spec carried no app user id', () => {
+    const { conn } = harness({ config: linearConfig({ appUserId: undefined }) })
+    expect(conn.botUserId).toBeUndefined()
+    expect(conn.isSelfAuthored('anything')).toBe(false)
+  })
+
+  it('answers empty for the ports Linear has no surface for, without a request', async () => {
+    const { conn, calls } = harness()
+    expect(await conn.listMembers(ISSUE)).toEqual([])
+    expect(await conn.listChannels()).toEqual([])
+    expect(await conn.downloadFile('anything')).toBeNull()
+    expect(calls).toHaveLength(0)
+  })
+
+  it('declares no bot-channel enumeration, no leave affordance and no thread history', () => {
+    const proto = LinearConnection.prototype as unknown as Record<string, unknown>
+    for (const member of ['listBotChannels', 'leaveChannel', 'leaveSpace', 'getThreadReplies', 'getChannelHistory']) {
+      expect(typeof proto[member], member).toBe('undefined')
+    }
+  })
+
+  it('exposes the workspace as its durable tenant and no permalink base', () => {
+    const { conn } = harness()
+    expect(conn.workspaceId()).toBe(WORKSPACE)
+    expect(conn.workspaceUrl).toBe('')
+    expect(RENEW_MARGIN_MS).toBe(2 * 60 * 60 * 1000)
+  })
+})

--- a/packages/daemon/test/linear-connection.test.ts
+++ b/packages/daemon/test/linear-connection.test.ts
@@ -107,6 +107,9 @@ function harness(
     sendIntervalMs?: number
   } = {}
 ) {
+  // Deterministic idempotency keys: a real UUID would make every request assertion unpinnable.
+  let minted = 0
+  const activityIds: string[] = []
   const clock = fakeClock()
   const calls: RecordedCall[] = []
   const timers: { fn: () => void; delay: number; cleared: boolean }[] = []
@@ -133,6 +136,12 @@ function harness(
     sendIntervalMs: opts.sendIntervalMs ?? 0,
     now: clock.now,
     sleep: clock.sleep,
+    newActivityId: () => {
+      minted += 1
+      const id = `activity-${minted}`
+      activityIds.push(id)
+      return id
+    },
     setTimer: (fn, delay) => {
       const handle = { fn, delay, cleared: false }
       timers.push(handle)
@@ -159,8 +168,11 @@ function harness(
     timer.fn()
     await settle()
   }
-  return { conn, calls, clock, timers, warnings, armed, fireTimer }
+  return { conn, calls, clock, timers, warnings, armed, fireTimer, activityIds }
 }
+
+/** The idempotency key the connection put on one recorded `agentActivityCreate`. */
+const sentActivityId = (call: RecordedCall): unknown => (call.variables.input as { id?: unknown }).id
 
 describe('linear config schema (§6.4 fail-closed)', () => {
   it('accepts a full spec payload and narrows it to the linear module', () => {
@@ -488,7 +500,12 @@ describe('linear graphql client (§9.4)', () => {
     expect(calls[0]!.authorization).toBe('Bearer snapshot-token')
     expect(calls[0]!.query).toContain('agentActivityCreate')
     expect(calls[0]!.variables).toEqual({
-      input: { agentSessionId: SESSION, content: { type: 'thought', body: 'reading' }, ephemeral: true }
+      input: {
+        id: 'activity-1',
+        agentSessionId: SESSION,
+        content: { type: 'thought', body: 'reading' },
+        ephemeral: true
+      }
     })
   })
 
@@ -497,6 +514,7 @@ describe('linear graphql client (§9.4)', () => {
     await conn.createActivity(SESSION, { type: 'action', action: 'Read', parameter: 'src/app.ts', result: 'ok' })
     expect(calls[0]!.variables).toEqual({
       input: {
+        id: 'activity-1',
         agentSessionId: SESSION,
         content: { type: 'action', action: 'Read', parameter: 'src/app.ts', result: 'ok' }
       }
@@ -507,7 +525,7 @@ describe('linear graphql client (§9.4)', () => {
     const { conn, calls } = harness()
     await conn.createActivity(SESSION, { type: 'response', body: 'done' })
     expect(calls[0]!.variables).toEqual({
-      input: { agentSessionId: SESSION, content: { type: 'response', body: 'done' } }
+      input: { id: 'activity-1', agentSessionId: SESSION, content: { type: 'response', body: 'done' } }
     })
   })
 
@@ -606,6 +624,99 @@ describe('linear graphql client (§9.4)', () => {
     expect(err).toBeInstanceOf(LinearApiError)
     expect((err as LinearApiError).code).toBe('RATELIMITED')
     expect(calls).toHaveLength(3)
+  })
+
+  it('reuses one caller-supplied id across a retry, so an append-only create cannot double-post', async () => {
+    // The retry made this reachable: activities are append-only, and a 5xx after the write
+    // committed is indeterminate — without our own id the retry appends a second row.
+    let attempts = 0
+    const { conn, calls } = harness({
+      respond: () => {
+        attempts += 1
+        return attempts === 1
+          ? jsonResponse({}, 500)
+          : jsonResponse({ data: { agentActivityCreate: { agentActivity: { id: 'activity-1' } } } })
+      }
+    })
+    expect(await conn.createActivity(SESSION, { type: 'response', body: 'final' })).toBe('activity-1')
+    expect(calls).toHaveLength(2)
+    expect(sentActivityId(calls[0]!)).toBe('activity-1')
+    expect(sentActivityId(calls[1]!)).toBe('activity-1')
+  })
+
+  it('treats a duplicate-id refusal on a retry as the earlier attempt having committed', async () => {
+    let attempts = 0
+    const { conn, calls } = harness({
+      respond: () => {
+        attempts += 1
+        return attempts === 1
+          ? jsonResponse({}, 503)
+          : jsonResponse({ errors: [{ message: 'A record with that id already exists' }] }, 400)
+      }
+    })
+    expect(await conn.createActivity(SESSION, { type: 'response', body: 'final' })).toBe('activity-1')
+    expect(calls).toHaveLength(2)
+  })
+
+  it('surfaces a duplicate-id refusal on the FIRST attempt — that is a reused key, not a retry', async () => {
+    const { conn, calls } = harness({
+      respond: () => jsonResponse({ errors: [{ message: 'A record with that id already exists' }] }, 400)
+    })
+    await expect(conn.createActivity(SESSION, { type: 'response', body: 'final' })).rejects.toBeInstanceOf(
+      LinearApiError
+    )
+    expect(calls).toHaveLength(1)
+  })
+
+  it('surfaces an ambiguous refusal on a retry rather than inventing a success', async () => {
+    let attempts = 0
+    const { conn } = harness({
+      respond: () => {
+        attempts += 1
+        return attempts === 1 ? jsonResponse({}, 500) : jsonResponse({ errors: [{ message: 'Invalid input' }] }, 400)
+      }
+    })
+    const err = await conn.createActivity(SESSION, { type: 'response', body: 'final' }).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(LinearApiError)
+    expect((err as LinearApiError).message).toContain('Invalid input')
+  })
+
+  it('gives every logical activity its own id', async () => {
+    const { conn, calls, activityIds } = harness()
+    await conn.createActivity(SESSION, { type: 'thought', body: 'one' })
+    await conn.createActivity(SESSION, { type: 'thought', body: 'two' })
+    await conn.createActivity(SESSION, { type: 'response', body: 'three' })
+    const sent = calls.map(sentActivityId)
+    expect(sent).toEqual(['activity-1', 'activity-2', 'activity-3'])
+    expect(new Set(sent).size).toBe(3)
+    expect(activityIds).toEqual(['activity-1', 'activity-2', 'activity-3'])
+  })
+
+  it('mints a real UUID when no factory is injected', async () => {
+    const sent: { input?: { id?: unknown } }[] = []
+    const conn = new LinearConnection({
+      group: group(),
+      requestToken: async () => ({ accessToken: 'renewed', expiresAt: FRESH_EXPIRY }),
+      fetchImpl: (async (_url: unknown, init: unknown) => {
+        const request = init as { body: string }
+        sent.push((JSON.parse(request.body) as { variables: { input?: { id?: unknown } } }).variables)
+        return jsonResponse({ data: { agentActivityCreate: { agentActivity: {} } } })
+      }) as unknown as typeof fetch,
+      sendIntervalMs: 0,
+      now: () => START,
+      sleep: async () => {},
+      setTimer: () => undefined,
+      clearTimer: () => {}
+    })
+    await conn.createActivity(SESSION, { type: 'thought', body: 'x' })
+    expect(sent[0]?.input?.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+  })
+
+  it('sends no idempotency key on agentSessionUpdate, whose replaces converge on their own', async () => {
+    const { conn, calls } = harness()
+    await conn.updateSessionPlan(SESSION, [{ content: 'step', status: 'pending' }])
+    expect(calls[0]!.variables).not.toHaveProperty('input.id')
+    expect(calls[0]!.variables).toEqual({ id: SESSION, input: { plan: [{ content: 'step', status: 'pending' }] } })
   })
 
   it('never retries a terminal refusal', async () => {

--- a/packages/daemon/test/linear-connection.test.ts
+++ b/packages/daemon/test/linear-connection.test.ts
@@ -75,8 +75,16 @@ interface RecordedCall {
   at: number
 }
 
-const jsonResponse = (body: unknown, status = 200): Response =>
-  ({ ok: status >= 200 && status < 300, status, json: async () => body }) as unknown as Response
+const jsonResponse = (body: unknown, status = 200, headers: Record<string, string> = {}): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+    json: async () => body
+  }) as unknown as Response
+
+/** Let the timer callback's async chain settle before asserting on what it re-armed. */
+const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
 
 function group(config: Record<string, unknown> = linearConfig()): ConsolidatedLinearGroup {
   const parsed = platformIntegrationConfig('linear', linearIntegration(config))
@@ -101,7 +109,7 @@ function harness(
 ) {
   const clock = fakeClock()
   const calls: RecordedCall[] = []
-  const timers: { fired: boolean; cleared: boolean }[] = []
+  const timers: { fn: () => void; delay: number; cleared: boolean }[] = []
   const warnings: string[] = []
   const fetchImpl = (async (url: unknown, init: unknown) => {
     const request = init as { headers: Record<string, string>; body: string }
@@ -125,8 +133,8 @@ function harness(
     sendIntervalMs: opts.sendIntervalMs ?? 0,
     now: clock.now,
     sleep: clock.sleep,
-    setTimer: () => {
-      const handle = { fired: false, cleared: false }
+    setTimer: (fn, delay) => {
+      const handle = { fn, delay, cleared: false }
       timers.push(handle)
       return handle
     },
@@ -141,7 +149,17 @@ function harness(
       error: () => {}
     }
   })
-  return { conn, calls, clock, timers, warnings }
+  /** The one timer currently armed — `scheduleRefresh` clears the old before setting the new. */
+  const armed = (): { fn: () => void; delay: number; cleared: boolean }[] => timers.filter((t) => !t.cleared)
+  /** Run the armed timer's callback and let its async chain settle. */
+  const fireTimer = async (): Promise<void> => {
+    const timer = armed().at(-1)
+    if (!timer) throw new Error('no timer is armed')
+    timer.cleared = true
+    timer.fn()
+    await settle()
+  }
+  return { conn, calls, clock, timers, warnings, armed, fireTimer }
 }
 
 describe('linear config schema (§6.4 fail-closed)', () => {
@@ -339,11 +357,83 @@ describe('linear token cache (§4.4)', () => {
   })
 
   it('warms the token on start and clears the refresh timer on stop', async () => {
-    const { conn, timers } = harness()
+    const { conn, timers, armed } = harness()
     await conn.start()
     expect(timers).toHaveLength(1)
     await conn.stop()
-    expect(timers[0]?.cleared).toBe(true)
+    expect(armed()).toHaveLength(0)
+  })
+
+  it('re-arms the refresh timer with backoff after a failed renewal', async () => {
+    // Without the re-arm a transient refusal ends the refresh chain: the integration then
+    // discovers recovery only on a live send, inside Linear's ≤10 s ack budget.
+    let requests = 0
+    const { conn, clock, armed, fireTimer } = harness({
+      config: linearConfig({ accessTokenExpiresAt: NEAR_EXPIRY }),
+      requestToken: async () => {
+        requests += 1
+        throw new Error('RATE_LIMITED')
+      }
+    })
+    await conn.start()
+    expect(requests).toBe(1)
+    expect(armed()).toHaveLength(1)
+    expect(armed()[0]!.delay).toBeGreaterThanOrEqual(60_000)
+
+    // Firing inside the backoff must not re-drive the broker — but must leave a timer armed.
+    await fireTimer()
+    expect(requests).toBe(1)
+    expect(armed()).toHaveLength(1)
+
+    // …and once the backoff has elapsed, the timer alone recovers the credential.
+    clock.advance(61_000)
+    await fireTimer()
+    expect(requests).toBe(2)
+    expect(armed()).toHaveLength(1)
+  })
+
+  it('stops re-arming once the connection is stopped', async () => {
+    const { conn, armed } = harness({
+      config: linearConfig({ accessTokenExpiresAt: NEAR_EXPIRY }),
+      requestToken: async () => {
+        throw new Error('LEASE_DENIED')
+      }
+    })
+    await conn.start()
+    const pending = armed()[0]!
+    await conn.stop()
+    expect(armed()).toHaveLength(0)
+    // A callback already in flight when stop() lands must not resurrect the chain.
+    pending.fn()
+    await settle()
+    expect(armed()).toHaveLength(0)
+  })
+
+  it('holds the renewal backoff even once the cached token expired, so sends do not hammer the broker', async () => {
+    // The bug this pins: the backoff used to be conditional on the cached token still being
+    // valid, so an expired token meant every single send re-drove a `linearcred` REQ.
+    let requests = 0
+    const { conn, calls, clock } = harness({
+      config: linearConfig({ accessTokenExpiresAt: NEAR_EXPIRY }),
+      requestToken: async () => {
+        requests += 1
+        throw new Error('LEASE_DENIED')
+      }
+    })
+    clock.advance(31 * 60 * 1000)
+    for (let i = 0; i < 4; i += 1) {
+      await expect(conn.createActivity(SESSION, { type: 'thought', body: `x${i}` })).rejects.toBeInstanceOf(
+        LinearTokenUnavailableError
+      )
+    }
+    expect(requests).toBe(1)
+    expect(calls).toHaveLength(0)
+
+    clock.advance(61_000)
+    await expect(conn.createActivity(SESSION, { type: 'thought', body: 'after' })).rejects.toBeInstanceOf(
+      LinearTokenUnavailableError
+    )
+    expect(requests).toBe(2)
   })
 })
 
@@ -462,7 +552,7 @@ describe('linear graphql client (§9.4)', () => {
     expect((err as LinearApiError).message).toContain('Entity not found')
   })
 
-  it('marks a rate-limit refusal and a 5xx retryable, and a 400 not', async () => {
+  it('marks a rate-limit refusal and a 5xx retryable, and a bare 400 terminal', async () => {
     const limited = harness({ respond: () => jsonResponse({ errors: [{ extensions: { code: 'RATELIMITED' } }] }) })
     const server = harness({ respond: () => jsonResponse({}, 503) })
     const client = harness({ respond: () => jsonResponse({}, 400) })
@@ -477,6 +567,56 @@ describe('linear graphql client (§9.4)', () => {
     }
   })
 
+  it('reads the GraphQL code on an HTTP 400, so a rate limit retries and then succeeds', async () => {
+    // Linear reports a rate limit as HTTP 400 carrying `RATELIMITED` in the body. Classifying
+    // on the status alone called that terminal and dropped the write — a final `response`
+    // would simply never land.
+    let attempts = 0
+    const { conn, calls } = harness({
+      respond: () => {
+        attempts += 1
+        return attempts === 1
+          ? jsonResponse({ errors: [{ message: 'Rate limit exceeded', extensions: { code: 'RATELIMITED' } }] }, 400)
+          : jsonResponse({ data: { agentActivityCreate: { success: true, agentActivity: { id: 'act-2' } } } })
+      }
+    })
+    expect(await conn.createActivity(SESSION, { type: 'response', body: 'final' })).toBe('act-2')
+    expect(calls).toHaveLength(2)
+  })
+
+  it('waits the provider’s Retry-After before the retry rather than its own backoff', async () => {
+    let attempts = 0
+    const { conn, calls } = harness({
+      respond: () => {
+        attempts += 1
+        return attempts === 1
+          ? jsonResponse({ errors: [{ extensions: { code: 'RATELIMITED' } }] }, 400, { 'retry-after': '2' })
+          : jsonResponse({ data: { agentActivityCreate: { agentActivity: { id: 'act-3' } } } })
+      }
+    })
+    await conn.createActivity(SESSION, { type: 'response', body: 'final' })
+    expect(calls[1]!.at - calls[0]!.at).toBe(2_000)
+  })
+
+  it('gives up after the bounded attempts and surfaces the rate-limit error', async () => {
+    const { conn, calls } = harness({
+      respond: () => jsonResponse({ errors: [{ message: 'Rate limit', extensions: { code: 'RATELIMITED' } }] }, 400)
+    })
+    const err = await conn.createActivity(SESSION, { type: 'response', body: 'final' }).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(LinearApiError)
+    expect((err as LinearApiError).code).toBe('RATELIMITED')
+    expect(calls).toHaveLength(3)
+  })
+
+  it('never retries a terminal refusal', async () => {
+    const { conn, calls } = harness({
+      respond: () =>
+        jsonResponse({ errors: [{ message: 'Entity not found', extensions: { code: 'ENTITY_NOT_FOUND' } }] })
+    })
+    await conn.createActivity(SESSION, { type: 'thought', body: 'x' }).catch(() => undefined)
+    expect(calls).toHaveLength(1)
+  })
+
   it('treats a transport throw as retryable rather than leaking the raw error', async () => {
     const conn = new LinearConnection({
       group: group(),
@@ -486,6 +626,8 @@ describe('linear graphql client (§9.4)', () => {
       }) as unknown as typeof fetch,
       sendIntervalMs: 0,
       now: () => START,
+      // Injected so the bounded retry's backoff costs the suite no real time.
+      sleep: async () => {},
       setTimer: () => undefined,
       clearTimer: () => {}
     })

--- a/packages/daemon/test/platform-registry-drift.test.ts
+++ b/packages/daemon/test/platform-registry-drift.test.ts
@@ -32,12 +32,22 @@ function bareRoot(): string {
   return root
 }
 
+/**
+ * Platforms whose Layer-1 connection and config schema have landed but whose Layer-2
+ * surface, command chrome and connection pool arrive with a later change
+ * (linear-integration.md §9.4 lists the enumerated `daemon.ts` composition lines).
+ *
+ * NOT a compat gate: the set is asserted exactly, so the moment Linear's wiring lands the
+ * drift assertion below starts passing WITHOUT the exemption and this list must be emptied.
+ */
+const AWAITING_COMPOSITION = ['linear']
+
 describe('daemon platform registry (audit F16)', () => {
   it('advertises exactly the platforms it has a module for', () => {
-    // The pin on today's true set. A fifth platform makes this fail — deliberately: the
+    // The pin on today's true set. A sixth platform makes this fail — deliberately: the
     // reviewer should confirm the CP/console gating is what they intended, not discover
     // it from a failed install.
-    expect(platformIds()).toEqual(['slack', 'telegram', 'discord', 'feishu'])
+    expect(platformIds()).toEqual(['slack', 'telegram', 'discord', 'feishu', 'linear'])
   })
 
   it('sends the derived list, not a copy, in the CP registration handshake', () => {
@@ -52,9 +62,12 @@ describe('daemon platform registry (audit F16)', () => {
     // half-served platform, which is what this catches.
     const daemon = new Daemon({ root: bareRoot() }) as any
     const sorted = (ids: string[]): string[] => [...ids].sort()
+    // The composed set: registered platforms minus the ones still awaiting their
+    // composition lines. Emptying AWAITING_COMPOSITION restores the plain equality.
+    const composed = sorted(platformIds().filter((id) => !AWAITING_COMPOSITION.includes(id)))
 
-    expect(sorted(daemon.turnSurfaces.ids())).toEqual(sorted(platformIds()))
-    expect(sorted(daemon.commandChrome.ids())).toEqual(sorted(platformIds()))
+    expect(sorted(daemon.turnSurfaces.ids())).toEqual(composed)
+    expect(sorted(daemon.commandChrome.ids())).toEqual(composed)
     // Pools are per (platform, MODE) — Slack runs a socket pool beside a send-only
     // shared one — so the mode suffix is dropped before comparing.
     const poolPlatforms = [
@@ -64,13 +77,20 @@ describe('daemon platform registry (audit F16)', () => {
       daemon.connections.discordPool,
       daemon.connections.feishuPool
     ].map((pool: { name: string }) => pool.name.split('/')[0]!)
-    expect(sorted([...new Set(poolPlatforms)])).toEqual(sorted(platformIds()))
+    expect(sorted([...new Set(poolPlatforms)])).toEqual(composed)
+  })
+
+  it('names every platform still awaiting its composition lines', () => {
+    // The forcing function: an entry here is a platform the daemon ADVERTISES but cannot
+    // yet render a turn for, so it must be short-lived and visible in review.
+    expect(AWAITING_COMPOSITION).toEqual(['linear'])
+    for (const id of AWAITING_COMPOSITION) expect(platformIds()).toContain(id)
   })
 })
 
 describe('observed-membership platforms (audit F17)', () => {
   it('is the registry filtered by the manifest, not a hand list', () => {
-    expect([...observedMembershipPlatforms()]).toEqual(['telegram', 'discord', 'feishu'])
+    expect([...observedMembershipPlatforms()]).toEqual(['telegram', 'discord', 'feishu', 'linear'])
     for (const platform of platformIds()) {
       expect(observedMembershipPlatforms().includes(platform)).toBe(
         manifestFor(platform).membershipEnumeration === 'observed'


### PR DESCRIPTION
The daemon's Layer-1 Linear connection (docs/designs/linear-integration.md §9.4): a per-integration egress client over plain fetch — no SDK dependency; the agent surface is four mutations and two queries — plus the `linear` `CONFIG_SCHEMAS` line that flips `capabilities.platforms`.

- Token custody per §4.4/§7.3: starts from the spec's ≤24 h snapshot, renews over a `linearcred/request` on the control WS (a 12-line `CpClient.requestLinearCred` mirroring `requestGitCred`) within a 2 h margin, single-flight, plus one injectable proactive refresh timer so an idle integration doesn't meet an expired token inside the ≤10 s ack budget. Renewal failure degrades to the cached token. Rotation adopts in place (`applySnapshot`) — the conn key is `(integrationId, workspaceId)`, never the token, so a re-pushed spec doesn't tear the connection down.
- `PlatformSendQueue` with a ~1 s activity interval (§5.3); read port answers what Linear affords (issue, user) and empty elsewhere; self-echo guard on the app user id.
- `consolidateLinear` owns the fail-closed schema read ("a spec that fails the schema is skipped with a warning") and the group shape the composition wiring will register.
- The registry drift test gains an exact `AWAITING_COMPOSITION = ['linear']` exemption — a forcing function: the composition change's registrations make plain equality pass again and delete the exemption. Until then `linear` is advertised with no renderer, inert without a control-plane provider deployment.

Tests: 33 new cases (schema fail-closed, snapshot/renewal/single-flight/degradation with injected clock+timers, queue pacing, GraphQL request shapes against a fake fetch, read port, self-echo). Daemon typecheck + lint green; the suite's 14 failing cases are pre-existing environment failures, verified identical on an untouched origin/main worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
