### PR TITLE
feat(daemon): add OpenClaw as a curated ACP runtime with an external-execution sandbox exception

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -417,6 +417,19 @@ logs a warning and runs that agent without confinement. With
 daemon startup. macOS and Windows always follow this unsupported-host behavior;
 this rollout intentionally adds no runtime-specific Keychain integration.
 
+A curated or operator runtime may declare `externalExecution` on its RuntimeDef:
+its launched process is a thin bridge to a machine-local service that actually
+executes the agent (OpenClaw's `openclaw acp` and its Gateway), so kernel
+confinement of the bridge contains nothing while SRT's isolated network
+namespace severs the loopback dial the bridge exists for. Such a runtime
+launches exactly like any unsandboxed runtime — inherited daemon environment,
+real host HOME — while its curated admission probe still runs in a disposable
+isolated HOME. An agent's optional sandbox request is downgraded with a
+warning, and `security.requireSandbox` keeps the launch and its admission probe
+failing loudly, so the runtime is not advertised on hosts that demand
+confinement. Agent configuration cannot set the flag; it lives on the
+daemon/registry-owned runtime definition alongside `readRoots`.
+
 `security.workspaceGitAllowedOrigins` is a daemon-local remote-origin policy. Tenant
 workspace configuration cannot widen it, and the control plane intentionally
 keeps only transport/credential validation because different daemons may permit

--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -779,7 +779,7 @@ For cron, Scheduler constructs a `source:"cron"` synthetic `NormalizedMessage` a
 | agent -> client | `session/request_permission`              | Dangerous-operation authorization mapped to permissions policy / Web confirmation.                                                                  |
 | agent -> client | `fs/read_text_file`, `fs/write_text_file` | Workspace files with Workspace Manager `PathGuard`.                                                                                                 |
 
-Names and shapes follow ACP and `@agentclientprotocol/claude-agent-acp`. Internally, the adapter implements the wire methods `session/new`, `session/prompt`, and `session/update` as `newSession`, `prompt`, and `sessionUpdate`. Declaring `mcpServers` in `session/new` is the tool-injection point.
+Names and shapes follow ACP and `@agentclientprotocol/claude-agent-acp`. Internally, the adapter implements the wire methods `session/new`, `session/prompt`, and `session/update` as `newSession`, `prompt`, and `sessionUpdate`. Declaring `mcpServers` in `session/new` is the tool-injection point. A RuntimeDef declaring `sessionMcpServers: 'unsupported'` (OpenClaw's bridge rejects any non-empty list on `session/new` and `session/load`) skips the injection at dispatch and is clamped to `[]` inside `AcpHost` for every other session creator — those sessions run without the AgentConnect tool server or configured MCP servers, the same degraded shape as a session with no reachable bridge.
 
 ### 7.6 Built-in Preset Webchat Admin MCP
 

--- a/packages/daemon/src/acp/account-apps.ts
+++ b/packages/daemon/src/acp/account-apps.ts
@@ -196,6 +196,7 @@ const NOT_APPLICABLE = new Set<string>([
   'hermes-agent', // Nous Research — local HERMES_HOME config only
   'kiro-cli', // local settings + explicitly configured MCP only
   'maki', // local Lua/configured MCP only
+  'openclaw', // tools come from the machine-local Gateway's own config — no cloud-account connector sync
   'zeroclaw', // local config + ACP-supplied MCP only
   'omp', // local config + explicitly configured MCP only
   'cursor', // Team MCP only via enterprise dashboard (default-off flag) — not on a clean machine

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -828,6 +828,14 @@ export class AcpHost {
    *   SYNCHRONOUS on purpose: a runtime can emit the instant it has answered, and anything awaited
    *   here would widen the response-to-ownership gap into a window where that update is dropped.
    */
+  /** Safety net below every caller (dispatch, distill, dream): a runtime that
+   * rejects non-empty session mcpServers gets [] instead of a failed session. */
+  private clampSessionMcpServers(mcpServers: McpServer[]): McpServer[] {
+    if (this.runtime.sessionMcpServers !== 'unsupported' || mcpServers.length === 0) return mcpServers
+    this.opts.log?.debug(`acp: dropping ${mcpServers.length} session MCP server(s) — the runtime rejects them`)
+    return []
+  }
+
   async newSession(
     cwd: string,
     mcpServers: McpServer[] = [],
@@ -849,7 +857,7 @@ export class AcpHost {
     const res = await this.conn!.agent.request(methods.agent.session.new, {
       cwd,
       ...(activeAdditionalDirectories.length > 0 ? { additionalDirectories: activeAdditionalDirectories } : {}),
-      mcpServers,
+      mcpServers: this.clampSessionMcpServers(mcpServers),
       ...(_meta ? { _meta } : {})
     })
     announce?.(res.sessionId)
@@ -1085,7 +1093,7 @@ export class AcpHost {
         sessionId,
         cwd,
         ...(activeAdditionalDirectories.length > 0 ? { additionalDirectories: activeAdditionalDirectories } : {}),
-        mcpServers,
+        mcpServers: this.clampSessionMcpServers(mcpServers),
         ...(_meta ? { _meta } : {})
       })
       this.live.add(sessionId)

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -828,8 +828,7 @@ export class AcpHost {
    *   SYNCHRONOUS on purpose: a runtime can emit the instant it has answered, and anything awaited
    *   here would widen the response-to-ownership gap into a window where that update is dropped.
    */
-  /** Safety net below every caller (dispatch, distill, dream): a runtime that
-   * rejects non-empty session mcpServers gets [] instead of a failed session. */
+  /** A runtime that rejects non-empty session mcpServers gets [] instead of a failed session — covers every creator. */
   private clampSessionMcpServers(mcpServers: McpServer[]): McpServer[] {
     if (this.runtime.sessionMcpServers !== 'unsupported' || mcpServers.length === 0) return mcpServers
     this.opts.log?.debug(`acp: dropping ${mcpServers.length} session MCP server(s) — the runtime rejects them`)

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -81,7 +81,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   // sandbox decision (and the explicit operator requireSandbox), never a forced
   // skill-authority requirement — so chat runs on hosts with or without an OS
   // sandbox instead of failing closed.
-  const runInSandbox = effectiveRunInSandbox(cfg.security.requireSandbox, agent.runInSandbox, sandboxMechanism)
+  const runInSandbox = effectiveRunInSandbox(cfg.security.requireSandbox, agent.runInSandbox, sandboxMechanism, runtime)
   if (entry?.source === 'curated') {
     const admission = new CuratedRuntimeAdmission()
     const probe = opts.probeRuntimes ?? probeAllRuntimes
@@ -91,6 +91,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
         curated: true,
         hostFactory: defaultProbeHostFactory({ isolateAccountApps: cfg.security.isolateAccountApps }),
         runInSandbox,
+        requireSandbox: cfg.security.requireSandbox,
         daemonRoot: root,
         agentsRoot: cfg.agentsDir,
         sandboxMechanism,

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -32,7 +32,11 @@ export const RuntimeDefSchema = z.object({
   // and netns isolation would sever the bridge's loopback dial — so the bridge
   // launches like any unsandboxed runtime (admission probes still use a
   // disposable isolated HOME). `security.requireSandbox` refuses it outright.
-  externalExecution: z.boolean().optional()
+  externalExecution: z.boolean().optional(),
+  // 'unsupported': the runtime rejects any non-empty session/new|load mcpServers
+  // list (OpenClaw's bridge does), so the daemon must not inject the AgentConnect
+  // bridge or configured MCP servers — such sessions run without those tools.
+  sessionMcpServers: z.literal('unsupported').optional()
 })
 export type RuntimeDef = z.infer<typeof RuntimeDefSchema>
 

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -26,7 +26,13 @@ export const RuntimeDefSchema = z.object({
   // whose executable or dependencies live below a host path hidden from the
   // sandbox (most commonly HOME). Agent configuration can select a runtime but
   // cannot add entries here.
-  readRoots: z.array(z.string()).optional()
+  readRoots: z.array(z.string()).optional(),
+  // Reviewed exception for thin bridges (e.g. `openclaw acp`): agent execution
+  // lives in a machine-local external service the OS sandbox cannot contain,
+  // and netns isolation would sever the bridge's loopback dial — so the bridge
+  // launches like any unsandboxed runtime (admission probes still use a
+  // disposable isolated HOME). `security.requireSandbox` refuses it outright.
+  externalExecution: z.boolean().optional()
 })
 export type RuntimeDef = z.infer<typeof RuntimeDefSchema>
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2694,6 +2694,14 @@ export class Daemon {
       // The agent's enabled daemon-configured MCP servers are appended AFTER the bridge entry, gated
       // on the runtime's probed transport caps.
       mcpServersFor: ({ agent, platform, channel, thread, integrationId, transportScope, isDm }) => {
+        // An OpenClaw-style bridge rejects any non-empty session mcpServers list —
+        // skip tool/bridge assembly instead of failing every session/new.
+        if (this.runtimes[agent.runtime]?.sessionMcpServers === 'unsupported') {
+          this.log.info(
+            `acp: runtime "${agent.runtime}" rejects per-session MCP servers — agent "${agent.id}" runs without AgentConnect tools and configured MCP servers`
+          )
+          return []
+        }
         const servers: McpServer[] = []
         let tools = toolsForIntegrations(agent.integrations, {
           organizationKnowledge: this.cpClient?.supportsServerFeature?.(ORGANIZATION_KNOWLEDGE_FEATURE) === true,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3329,7 +3329,12 @@ export class Daemon {
     // `security.requireSandbox` still forces confinement; a trusted/unsandboxed
     // agent runs (and installs/uses skills) unsandboxed, and the daemon never
     // fails closed on a host with no OS sandbox.
-    return effectiveRunInSandbox(this.cfg.security.requireSandbox, agent.runInSandbox, this.sandboxMechanism)
+    return effectiveRunInSandbox(
+      this.cfg.security.requireSandbox,
+      agent.runInSandbox,
+      this.sandboxMechanism,
+      this.runtimes[agent.runtime]
+    )
   }
 
   /**
@@ -3798,7 +3803,9 @@ export class Daemon {
     const runInSandbox = opts.runInSandbox
     if (agent.runInSandbox && !runInSandbox && opts.warnOnSandboxDowngrade) {
       this.log.warn(
-        `acp: agent "${agentId}" requested Run in sandbox but this host has no supported Linux sandbox — running without it (#312)`
+        runtime.externalExecution
+          ? `acp: agent "${agentId}" requested Run in sandbox but runtime "${agent.runtime}" executes in an external machine-local service — running without it`
+          : `acp: agent "${agentId}" requested Run in sandbox but this host has no supported Linux sandbox — running without it (#312)`
       )
     }
     const memoryAgent =
@@ -16440,6 +16447,7 @@ export class Daemon {
         fakeHosts: this.opts.hostFactory !== undefined,
         ...(this.opts.probeRuntimes ? { probe: this.opts.probeRuntimes } : {}),
         ...(this.sandboxMechanism ? { sandboxMechanism: this.sandboxMechanism } : {}),
+        requireSandbox: this.cfg.security.requireSandbox,
         daemonRoot: this.root,
         agentsRoot: this.cfg.agentsDir,
         isolateAccountApps: this.cfg.security.isolateAccountApps

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2694,10 +2694,9 @@ export class Daemon {
       // The agent's enabled daemon-configured MCP servers are appended AFTER the bridge entry, gated
       // on the runtime's probed transport caps.
       mcpServersFor: ({ agent, platform, channel, thread, integrationId, transportScope, isDm }) => {
-        // An OpenClaw-style bridge rejects any non-empty session mcpServers list —
-        // skip tool/bridge assembly instead of failing every session/new.
+        // An OpenClaw-style bridge rejects non-empty session mcpServers — skip assembly instead of failing session/new.
         if (this.runtimes[agent.runtime]?.sessionMcpServers === 'unsupported') {
-          this.log.info(
+          this.log.debug(
             `acp: runtime "${agent.runtime}" rejects per-session MCP servers — agent "${agent.id}" runs without AgentConnect tools and configured MCP servers`
           )
           return []

--- a/packages/daemon/src/launch/compose.ts
+++ b/packages/daemon/src/launch/compose.ts
@@ -173,7 +173,12 @@ export function composeRuntimeLaunch(opts: {
 
   const protectedMemory = opts.provider !== 'native'
   const stateSourceEnv = opts.stateSourceEnv ?? opts.hostEnv ?? process.env
-  const sandboxAccess = opts.runInSandbox ? runtimeSandboxReadRoots(opts.runtime, stateSourceEnv) : undefined
+  // externalExecution can never launch sandboxed — skip executable resolution so
+  // prepareRuntimeLaunch reports the refusal instead of a resolution failure.
+  const sandboxAccess =
+    opts.runInSandbox && opts.runtime.externalExecution !== true
+      ? runtimeSandboxReadRoots(opts.runtime, stateSourceEnv)
+      : undefined
   const launch = prepareRuntimeLaunch({
     ...(opts.k8s === true ? { k8s: true } : {}),
     runtimeId: opts.runtimeId,

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -131,13 +131,16 @@ export interface PreparedRuntimeLaunch {
 }
 
 /** Daemon policy overrides the per-agent preference. Without an available host
- * mechanism, an optional sandbox request is ineffective. */
+ * mechanism, an optional sandbox request is ineffective. An externalExecution
+ * runtime downgrades an optional request (its execution lives outside any local
+ * sandbox), while requireSandbox stays true so the launch is refused loudly. */
 export function effectiveRunInSandbox(
   requireSandbox: boolean,
   requested: boolean,
-  mechanism: SandboxMechanism | undefined
+  mechanism: SandboxMechanism | undefined,
+  runtime?: Pick<RuntimeDef, 'externalExecution'>
 ): boolean {
-  return requireSandbox || (requested && mechanism !== undefined)
+  return requireSandbox || (requested && mechanism !== undefined && runtime?.externalExecution !== true)
 }
 
 /** Prepare one ACP adapter launch. A private HOME is normally part of sandbox
@@ -194,6 +197,11 @@ export function prepareRuntimeLaunch(opts: {
     // different machine. Inheriting it sent this daemon's HOME across, and the runtime then tried
     // to open its state under a path that exists only here. The pod supplies its own basics.
     return { env, inheritProcessEnv: opts.k8s !== true }
+  }
+  if (opts.runInSandbox && opts.runtime?.externalExecution) {
+    throw new Error(
+      `runtime "${opts.runtimeId}" executes in an external machine-local service the OS sandbox cannot contain — it can only launch unconfined`
+    )
   }
   if (opts.runInSandbox && !opts.sandboxMechanism) {
     throw new Error('OS sandbox requested but this host has no supported Linux SRT/bwrap mechanism')

--- a/packages/daemon/src/runtimes/curated.ts
+++ b/packages/daemon/src/runtimes/curated.ts
@@ -71,9 +71,18 @@ export const CURATED_RUNTIME_CATALOG: Readonly<Record<string, CuratedRuntimeEntr
   // machine-local OpenClaw Gateway (ws://127.0.0.1:18789 by default), and the
   // bridge reads the gateway address + token from ~/.openclaw/openclaw.json.
   // externalExecution: sandboxing the bridge would contain nothing (the Gateway
-  // executes) while netns isolation severs its loopback dial.
+  // executes) while netns isolation severs its loopback dial. The bridge also
+  // rejects any non-empty per-session mcpServers list, so sessions run without
+  // the AgentConnect bridge tools (MCP belongs on the Gateway's own config).
   openclaw: {
     name: 'OpenClaw',
-    runtime: { command: 'openclaw', args: ['acp'], env: [], skillsAgentId: 'openclaw', externalExecution: true }
+    runtime: {
+      command: 'openclaw',
+      args: ['acp'],
+      env: [],
+      skillsAgentId: 'openclaw',
+      externalExecution: true,
+      sessionMcpServers: 'unsupported'
+    }
   }
 })

--- a/packages/daemon/src/runtimes/curated.ts
+++ b/packages/daemon/src/runtimes/curated.ts
@@ -66,5 +66,14 @@ export const CURATED_RUNTIME_CATALOG: Readonly<Record<string, CuratedRuntimeEntr
       env: [],
       skillsAgentId: 'universal'
     }
+  },
+  // `openclaw acp` (OpenClaw 2.0+) is a thin stdio bridge: execution lives in the
+  // machine-local OpenClaw Gateway (ws://127.0.0.1:18789 by default), and the
+  // bridge reads the gateway address + token from ~/.openclaw/openclaw.json.
+  // externalExecution: sandboxing the bridge would contain nothing (the Gateway
+  // executes) while netns isolation severs its loopback dial.
+  openclaw: {
+    name: 'OpenClaw',
+    runtime: { command: 'openclaw', args: ['acp'], env: [], skillsAgentId: 'openclaw', externalExecution: true }
   }
 })

--- a/packages/daemon/src/runtimes/facts-registry.ts
+++ b/packages/daemon/src/runtimes/facts-registry.ts
@@ -14,7 +14,7 @@ import type { CuratedRuntimeAdmission } from './curated-admission.js'
 import type { K8sRuntimeAcpSnapshot } from './k8s-runtimes.js'
 import { probeAllRuntimes, type ProbeOptions, type RuntimeProbeResult } from './runtime-prober.js'
 import { defaultProbeHostFactory } from '../acp/probe-host-factory.js'
-import { prepareRuntimeLaunch } from '../launch/prepare.js'
+import { effectiveRunInSandbox, prepareRuntimeLaunch } from '../launch/prepare.js'
 import { runtimeSandboxReadRoots } from '../launch/compose.js'
 import { capsFromConfigOptions, augmentEffortOptions } from './config-caps.js'
 import { isClaudeRuntimeDef } from '../runtime-defs/claude-runtime.js'
@@ -45,6 +45,8 @@ export interface RuntimeProbeLaunchContext {
   fakeHosts: boolean
   probe?: (runtimes: Record<string, RuntimeDef>, opts: ProbeOptions) => Promise<RuntimeProbeResult[]>
   sandboxMechanism?: SandboxMechanism
+  /** Operator policy: an externalExecution runtime is then refused, not downgraded. */
+  requireSandbox?: boolean
   daemonRoot: string
   agentsRoot: string | undefined
   isolateAccountApps: boolean
@@ -394,23 +396,29 @@ export class RuntimeFactsRegistry {
             log,
             hostFactory: probeHostFactory,
             onResult,
-            launchFor: (id, runtime, scopeDir, cwd) =>
-              prepareRuntimeLaunch({
+            launchFor: (id, runtime, scopeDir, cwd) => {
+              const runInSandbox = effectiveRunInSandbox(
+                launch.requireSandbox ?? false,
+                launch.sandboxMechanism !== undefined,
+                launch.sandboxMechanism,
+                runtime
+              )
+              return prepareRuntimeLaunch({
                 runtimeId: id,
                 runtime,
                 scopeDir,
                 cwd,
-                runInSandbox: launch.sandboxMechanism !== undefined,
+                runInSandbox,
                 daemonRoot: launch.daemonRoot,
                 agentsRoot: launch.agentsRoot,
-                trustedRuntimeReadRoots:
-                  launch.sandboxMechanism !== undefined
-                    ? runtimeSandboxReadRoots(runtime, process.env).readRoots
-                    : undefined,
+                trustedRuntimeReadRoots: runInSandbox
+                  ? runtimeSandboxReadRoots(runtime, process.env).readRoots
+                  : undefined,
                 explicitEnv: Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value])),
                 sandboxMechanism: launch.sandboxMechanism,
                 hostPackageCache: true
               })
+            }
           })
         )
       }
@@ -422,6 +430,7 @@ export class RuntimeFactsRegistry {
             hostFactory: probeHostFactory,
             onResult,
             runInSandbox: launch.sandboxMechanism !== undefined,
+            requireSandbox: launch.requireSandbox,
             daemonRoot: launch.daemonRoot,
             agentsRoot: launch.agentsRoot,
             sandboxMechanism: launch.sandboxMechanism,

--- a/packages/daemon/src/runtimes/model-enumerator.ts
+++ b/packages/daemon/src/runtimes/model-enumerator.ts
@@ -53,6 +53,12 @@ export function makeModelEnumerator(deps: ModelEnumeratorDeps): EnumerateFn {
       deps.log?.debug(`catalog: ${runtimeId} skipped because no supported OS sandbox is available`)
       return undefined
     }
+    // Enumeration runs only under the OS sandbox; an externalExecution runtime
+    // cannot be confined, so it keeps its probe-derived model list instead.
+    if (rt.externalExecution) {
+      deps.log?.debug(`catalog: ${runtimeId} skipped because its execution lives outside the OS sandbox`)
+      return undefined
+    }
     const scope = mkdtempSync(join(tmpdir(), 'ac-catalog-'))
     const cwd = join(scope, 'workspace')
     mkdirSync(cwd, { recursive: true })

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -176,6 +176,8 @@ const QODER_SEED = (brand: string): readonly string[] => [
 const CLAUDE_MODEL_CACHE_KEYS = ['additionalModelOptionsCache'] as const
 /** DeepSeek Harness auth: the managed 0600 credential store plus its .env fallback. */
 const DSH_SEED = ['.credentials.yaml', '.env'] as const
+/** OpenClaw acp bridge inputs: gateway address + token config and its .env fallback. */
+const OPENCLAW_SEED = ['openclaw.json', '.env'] as const
 
 export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // Anthropic Claude Code — seed only the rollout-model cache from ~/.claude.json.
@@ -347,6 +349,17 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // only the managed credential store and its .env fallback; sessions and logs
   // in the same directory stay agent-private.
   'dsh-acp': (env) => [...state(env.DSH_HOME, '.dsh', DSH_SEED), ...state(join(home(env), '.dsh'), '.dsh', DSH_SEED)],
+
+  // OpenClaw — ~/.openclaw, relocatable via $OPENCLAW_STATE_DIR (the dir itself),
+  // $OPENCLAW_HOME (the home base), or $OPENCLAW_CONFIG_PATH (the config file
+  // alone). The `acp` bridge is stateless; seed only the gateway config it
+  // reads, gateway-side sessions/state stay agent-private.
+  openclaw: (env) => [
+    ...state(env.OPENCLAW_CONFIG_PATH, join('.openclaw', 'openclaw.json')),
+    ...state(env.OPENCLAW_STATE_DIR, '.openclaw', OPENCLAW_SEED),
+    ...state(env.OPENCLAW_HOME ? join(env.OPENCLAW_HOME, '.openclaw') : undefined, '.openclaw', OPENCLAW_SEED),
+    ...state(join(home(env), '.openclaw'), '.openclaw', OPENCLAW_SEED)
+  ],
 
   // Cognition Devin (for Terminal) — XDG config + data dirs.
   devin: (env) => [

--- a/packages/daemon/src/runtimes/runtime-home.ts
+++ b/packages/daemon/src/runtimes/runtime-home.ts
@@ -239,7 +239,12 @@ const AMBIENT_STATE_ENV = new Set([
   'GEMINI_CLI_HOME',
   // DeepSeek Harness state root; $DSH_PATH (the harness install location) is not
   // user state and stays inherited.
-  'DSH_HOME'
+  'DSH_HOME',
+  // OpenClaw state/config roots. The gateway connection overrides
+  // ($OPENCLAW_GATEWAY_URL/_TOKEN/_PASSWORD) are credentials, not state — inherited.
+  'OPENCLAW_HOME',
+  'OPENCLAW_STATE_DIR',
+  'OPENCLAW_CONFIG_PATH'
 ])
 
 function inheritedEnvironment(source: NodeJS.ProcessEnv): Record<string, string> {
@@ -311,6 +316,7 @@ const RUNTIME_PRIVATE_ENV: Record<string, RuntimePrivateEnv> = {
     return env
   },
   'dsh-acp': (home) => ({ DSH_HOME: join(home, '.dsh') }),
+  openclaw: (home) => ({ OPENCLAW_STATE_DIR: join(home, '.openclaw') }),
   kimi: (home, hostEnv) => {
     const env: Record<string, string> = {}
     if (hostEnv.KIMI_CODE_HOME) env.KIMI_CODE_HOME = join(home, '.kimi-code')

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -20,7 +20,7 @@ import type { AcpProbeClient } from '../acp/probe-client.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
 import type { SandboxMechanism } from '../acp/sandbox.js'
-import type { PreparedRuntimeLaunch } from '../launch/prepare.js'
+import { effectiveRunInSandbox, type PreparedRuntimeLaunch } from '../launch/prepare.js'
 import { composeRuntimeLaunch } from '../launch/compose.js'
 import { PACKAGE_LAUNCHERS } from './probe.js'
 
@@ -47,7 +47,12 @@ const PROVIDER_ENV_KEYS = new Set([
   'MOONSHOT_API_KEY',
   'KIMI_API_KEY',
   'XAI_API_KEY',
-  'OPENROUTER_API_KEY'
+  'OPENROUTER_API_KEY',
+  // The OpenClaw acp bridge's gateway connection overrides — credentials for a
+  // host configured via env instead of ~/.openclaw/openclaw.json.
+  'OPENCLAW_GATEWAY_URL',
+  'OPENCLAW_GATEWAY_TOKEN',
+  'OPENCLAW_GATEWAY_PASSWORD'
 ])
 
 /** Minimal ambient environment for an untrusted disposable compatibility probe. */
@@ -165,6 +170,9 @@ export interface ProbeOptions {
   /** Full host environment used for allowlisted credential seeding and redaction. */
   hostEnv?: NodeJS.ProcessEnv
   runInSandbox?: boolean
+  /** Operator policy: keeps an externalExecution runtime's probe sandboxed so it
+   *  fails loudly instead of admitting a runtime that later refuses to launch. */
+  requireSandbox?: boolean
   daemonRoot?: string
   agentsRoot?: string
   sandboxMechanism?: SandboxMechanism
@@ -403,19 +411,21 @@ function collectOmpCredentialValues(path: string, out: Set<string>): void {
 
 /** Collect only values from reviewed credential seeds in the already-private
  * probe home. They remain transient and are never passed to the child policy. */
+function collectDotEnvValues(path: string, out: Set<string>): void {
+  if (!existsSync(path)) return
+  for (const line of readFileSync(path, 'utf8').split(/\r?\n/)) {
+    const match = line.match(/^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=\s*(.*)$/)
+    const value = match?.[1]?.replace(/^(?:"(.*)"|'(.*)')$/, '$1$2')
+    if (value) collectStringValues(value, out)
+  }
+}
+
 function probeCredentialRedactions(id: string, launch: PreparedRuntimeLaunch): string[] {
   const out = new Set<string>()
   if (id === 'hermes-agent' || id === 'hermes') {
     const root = launch.env.HERMES_HOME
     if (root) {
-      const dotEnv = join(root, '.env')
-      if (existsSync(dotEnv)) {
-        for (const line of readFileSync(dotEnv, 'utf8').split(/\r?\n/)) {
-          const match = line.match(/^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=\s*(.*)$/)
-          const value = match?.[1]?.replace(/^(?:"(.*)"|'(.*)')$/, '$1$2')
-          if (value) collectStringValues(value, out)
-        }
-      }
+      collectDotEnvValues(join(root, '.env'), out)
       collectJsonCredentialValues(join(root, '.anthropic_oauth.json'), out)
       collectJsonCredentialValues(join(root, 'auth.json'), out)
     }
@@ -425,6 +435,13 @@ function probeCredentialRedactions(id: string, launch: PreparedRuntimeLaunch): s
   } else if (id === 'omp') {
     const root = launch.env.PI_CODING_AGENT_DIR
     if (root) collectOmpCredentialValues(join(root, 'agent.db'), out)
+  } else if (id === 'openclaw') {
+    // Both seeded files can carry the local gateway auth token.
+    const root = launch.env.OPENCLAW_STATE_DIR
+    if (root) {
+      collectJsonCredentialValues(join(root, 'openclaw.json'), out)
+      collectDotEnvValues(join(root, '.env'), out)
+    }
   }
   return [...out]
 }
@@ -485,7 +502,12 @@ export function preparedProbeLaunch(
     scopeDir,
     cwd,
     isolateHome: true,
-    runInSandbox: opts.runInSandbox ?? false,
+    runInSandbox: effectiveRunInSandbox(
+      opts.requireSandbox ?? false,
+      opts.runInSandbox ?? false,
+      opts.sandboxMechanism,
+      runtime
+    ),
     daemonRoot: opts.daemonRoot,
     agentsRoot: opts.agentsRoot,
     sandboxMechanism: opts.sandboxMechanism,

--- a/packages/daemon/src/runtimes/skills-capability.ts
+++ b/packages/daemon/src/runtimes/skills-capability.ts
@@ -48,6 +48,8 @@ export const AUDITED_RUNTIME_SKILLS_AGENTS: Readonly<Record<string, string>> = O
   // cross-agent `<projectRoot>/.agents/skills` root the CLI's `universal` identity writes.
   'dsh-acp': 'universal',
   'kiro-cli': 'kiro-cli',
+  // skills@1.5.21 `openclaw` identity — global ~/.openclaw/skills, project `skills/`.
+  openclaw: 'openclaw',
   'qoder-cli': 'qoder',
   'qoder-cli-cn': 'qoder-cn'
 })

--- a/packages/daemon/test/account-apps.test.ts
+++ b/packages/daemon/test/account-apps.test.ts
@@ -81,6 +81,7 @@ describe('accountAppIsolation — not-applicable (clean machine inherits nothing
     'hermes-agent',
     'kiro-cli',
     'maki',
+    'openclaw',
     'zeroclaw',
     'omp',
     'cursor',

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -35,6 +35,30 @@ describe('AcpHost (against a fake ACP agent)', () => {
     await host.stop()
   })
 
+  it('clamps session mcpServers to [] for a runtime that rejects them, and only then', async () => {
+    const bridge = { name: 'agentconnect', command: process.execPath, args: ['-e', ''], env: [] }
+    const rejectingEnv = [{ name: 'AC_REJECT_MCP_SERVERS', value: '1' }]
+
+    // Without the declaration the fixture's OpenClaw-style rejection surfaces.
+    const bare = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: rejectingEnv },
+      { onUpdate: () => {} }
+    )
+    await bare.start()
+    await expect(bare.newSession('/tmp', [bridge])).rejects.toThrow(/per-session MCP servers/)
+    await bare.stop()
+
+    // With it, the host drops the list and the session opens.
+    const clamped = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: rejectingEnv, sessionMcpServers: 'unsupported' },
+      { onUpdate: () => {} }
+    )
+    await clamped.start()
+    const sessionId = await clamped.newSession('/tmp', [bridge])
+    expect(sessionId).toBeTruthy()
+    await clamped.stop()
+  })
+
   // A runtime can advertise from inside `newSession()`: the host makes the session ownable and
   // then awaits its configuration round trips. Whatever the daemon needs in order to name that
   // session must therefore be handed over at the RAW response, before it is reachable.

--- a/packages/daemon/test/fixtures/fake-acp-agent.mjs
+++ b/packages/daemon/test/fixtures/fake-acp-agent.mjs
@@ -45,6 +45,18 @@ const acceptsAdditionalDirectories = (id, params) => {
   return false
 }
 
+// `AC_REJECT_MCP_SERVERS=1` mirrors OpenClaw's bridge: any non-empty session
+// mcpServers list is rejected outright on session/new and session/load.
+const acceptsMcpServers = (id, params) => {
+  if (process.env.AC_REJECT_MCP_SERVERS !== '1' || !(params.mcpServers?.length > 0)) return true
+  send({
+    jsonrpc: '2.0',
+    id,
+    error: { code: -32602, message: 'ACP bridge mode does not support per-session MCP servers' }
+  })
+  return false
+}
+
 // Optional MCP transport capabilities advertised at initialize. `AC_MCP_CAPS`
 // (comma list) turns them on; unset ⇒ no mcpCapabilities key at all.
 const mcpCaps = (process.env.AC_MCP_CAPS ?? '')
@@ -101,6 +113,7 @@ rl.on('line', async (line) => {
     send({ jsonrpc: '2.0', id, result: { protocolVersion: 1, agentCapabilities: agentCapabilities() } })
   } else if (method === 'session/new') {
     if (!acceptsAdditionalDirectories(id, params)) return
+    if (!acceptsMcpServers(id, params)) return
     const sessionId = `s${++sessionCounter}`
     sessionModels.set(sessionId, modelList[0])
     sessionPermissionModes.set(sessionId, permissionModeList[0])
@@ -113,6 +126,7 @@ rl.on('line', async (line) => {
     send({ jsonrpc: '2.0', id, result: { configOptions: configOptions(params.sessionId) } })
   } else if (method === 'session/load') {
     if (!acceptsAdditionalDirectories(id, params)) return
+    if (!acceptsMcpServers(id, params)) return
     if (process.env.AC_LOAD_PERMISSION_MODE)
       sessionPermissionModes.set(params.sessionId, process.env.AC_LOAD_PERMISSION_MODE)
     if (process.env.AC_LOAD_UPDATES) {

--- a/packages/daemon/test/probe.test.ts
+++ b/packages/daemon/test/probe.test.ts
@@ -238,6 +238,32 @@ describe('isRuntimeAvailable / custom probes', () => {
     ).toBe(true)
   })
 
+  it('openclaw needs ~/.openclaw even when openclaw is on PATH', () => {
+    makeExecutable(binDir, 'openclaw')
+    const rt: RuntimeDef = { command: 'openclaw', args: ['acp'], env: [] }
+    expect(isRuntimeAvailable('openclaw', rt, env())).toBe(false)
+    mkdirSync(join(home, '.openclaw'))
+    expect(isRuntimeAvailable('openclaw', rt, env())).toBe(true)
+  })
+
+  it('openclaw honors $OPENCLAW_STATE_DIR and $OPENCLAW_HOME overrides', () => {
+    makeExecutable(binDir, 'openclaw')
+    const rt: RuntimeDef = { command: 'openclaw', args: ['acp'], env: [] }
+    const cleanHome = mkdtempSync(join(tmpdir(), 'ac-openclaw-home-'))
+
+    const stateDir = mkdtempSync(join(tmpdir(), 'ac-openclaw-state-'))
+    expect(isRuntimeAvailable('openclaw', rt, env({ HOME: cleanHome }))).toBe(false)
+    expect(isRuntimeAvailable('openclaw', rt, env({ HOME: cleanHome, OPENCLAW_STATE_DIR: stateDir }))).toBe(true)
+
+    const openclawHome = mkdtempSync(join(tmpdir(), 'ac-openclaw-base-'))
+    mkdirSync(join(openclawHome, '.openclaw'))
+    expect(isRuntimeAvailable('openclaw', rt, env({ HOME: cleanHome, OPENCLAW_HOME: openclawHome }))).toBe(true)
+
+    const configPath = join(mkdtempSync(join(tmpdir(), 'ac-openclaw-cfg-')), 'openclaw.json')
+    writeFileSync(configPath, '{}')
+    expect(isRuntimeAvailable('openclaw', rt, env({ HOME: cleanHome, OPENCLAW_CONFIG_PATH: configPath }))).toBe(true)
+  })
+
   it('dsh-acp is fetched by npx, so ~/.dsh (or $DSH_HOME) is the only install signal', () => {
     makeExecutable(binDir, 'npx')
     const rt: RuntimeDef = {

--- a/packages/daemon/test/registry.test.ts
+++ b/packages/daemon/test/registry.test.ts
@@ -239,7 +239,7 @@ describe('resolveRuntimes', () => {
 })
 
 describe('curated native ACP runtimes', () => {
-  it('declares the nine reviewed native ACP commands', () => {
+  it('declares the ten reviewed native ACP commands', () => {
     expect(CURATED_RUNTIME_CATALOG).toEqual({
       'hermes-agent': {
         name: 'Hermes Agent',
@@ -281,6 +281,10 @@ describe('curated native ACP runtimes', () => {
           env: [],
           skillsAgentId: 'universal'
         }
+      },
+      openclaw: {
+        name: 'OpenClaw',
+        runtime: { command: 'openclaw', args: ['acp'], env: [], skillsAgentId: 'openclaw', externalExecution: true }
       }
     })
   })

--- a/packages/daemon/test/registry.test.ts
+++ b/packages/daemon/test/registry.test.ts
@@ -284,7 +284,14 @@ describe('curated native ACP runtimes', () => {
       },
       openclaw: {
         name: 'OpenClaw',
-        runtime: { command: 'openclaw', args: ['acp'], env: [], skillsAgentId: 'openclaw', externalExecution: true }
+        runtime: {
+          command: 'openclaw',
+          args: ['acp'],
+          env: [],
+          skillsAgentId: 'openclaw',
+          externalExecution: true,
+          sessionMcpServers: 'unsupported'
+        }
       }
     })
   })

--- a/packages/daemon/test/runtime-home.test.ts
+++ b/packages/daemon/test/runtime-home.test.ts
@@ -131,6 +131,49 @@ describe('private runtime HOME', () => {
     expect(env.DSH_HOME).toBe(join(home, '.dsh'))
   })
 
+  it('seeds the OpenClaw gateway config and pins $OPENCLAW_STATE_DIR into the private home', () => {
+    const { hostHome, scopeDir } = fixture()
+    const openclaw = join(hostHome, '.openclaw')
+    mkdirSync(join(openclaw, 'sessions'), { recursive: true })
+    writeFileSync(join(openclaw, 'openclaw.json'), '{"gateway":{"url":"ws://127.0.0.1:18789","token":"host-token"}}')
+    writeFileSync(join(openclaw, '.env'), 'OPENCLAW_GATEWAY_TOKEN=host-token')
+    writeFileSync(join(openclaw, 'sessions', 'old.jsonl'), 'do-not-copy')
+
+    const home = prepareRuntimeHome('openclaw', scopeDir, { HOME: hostHome })
+    expect(readFileSync(join(home, '.openclaw', 'openclaw.json'), 'utf8')).toContain('18789')
+    expect(existsSync(join(home, '.openclaw', '.env'))).toBe(true)
+    expect(existsSync(join(home, '.openclaw', 'sessions'))).toBe(false)
+
+    const env = runtimeHomeEnvironment(
+      'openclaw',
+      home,
+      {},
+      {
+        HOME: hostHome,
+        OPENCLAW_STATE_DIR: '/host/leak',
+        OPENCLAW_HOME: '/host/leak-home',
+        OPENCLAW_CONFIG_PATH: '/host/leak.json',
+        OPENCLAW_GATEWAY_URL: 'ws://127.0.0.1:19000'
+      }
+    )
+    expect(env.OPENCLAW_STATE_DIR).toBe(join(home, '.openclaw'))
+    expect(env.OPENCLAW_HOME).toBeUndefined()
+    expect(env.OPENCLAW_CONFIG_PATH).toBeUndefined()
+    // Gateway connection overrides are credentials, not user state — inherited.
+    expect(env.OPENCLAW_GATEWAY_URL).toBe('ws://127.0.0.1:19000')
+  })
+
+  it('seeds a relocated $OPENCLAW_CONFIG_PATH config ahead of the stale state-dir copy', () => {
+    const { root, hostHome, scopeDir } = fixture()
+    mkdirSync(join(hostHome, '.openclaw'), { recursive: true })
+    writeFileSync(join(hostHome, '.openclaw', 'openclaw.json'), '{"gateway":{"url":"ws://stale.invalid"}}')
+    const configPath = join(root, 'etc-openclaw.json')
+    writeFileSync(configPath, '{"gateway":{"url":"ws://127.0.0.1:18789"}}')
+
+    const home = prepareRuntimeHome('openclaw', scopeDir, { HOME: hostHome, OPENCLAW_CONFIG_PATH: configPath })
+    expect(readFileSync(join(home, '.openclaw', 'openclaw.json'), 'utf8')).toContain('18789')
+  })
+
   it('seeds Cline provider auth from its data directory without copying databases', () => {
     const { hostHome, scopeDir } = fixture()
     const clineDir = join(hostHome, '.cline')

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -15,7 +15,7 @@ import {
 import { tmpdir } from 'node:os'
 import { delimiter, dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { parse as parseYaml } from 'yaml'
-import { prepareRuntimeLaunch } from '../src/launch/prepare.js'
+import { effectiveRunInSandbox, prepareRuntimeLaunch } from '../src/launch/prepare.js'
 import { composeRuntimeLaunch, runtimeSandboxReadRoots } from '../src/launch/compose.js'
 import { CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV } from '../src/acp/codex-permission-profiles.js'
 import { runtimeMemoryCapabilities } from '../src/memory/runtime/capabilities.js'
@@ -371,6 +371,32 @@ describe('prepareRuntimeLaunch', () => {
       /no supported Linux SRT\/bwrap/
     )
     expect(existsSync(join(scopeDir, 'home'))).toBe(false)
+  })
+
+  it('refuses to sandbox an externalExecution runtime instead of confining a bridge it cannot contain', () => {
+    const { scopeDir, cwd } = fixture()
+
+    expect(() =>
+      prepareRuntimeLaunch({
+        runtimeId: 'openclaw',
+        runtime: { command: 'openclaw', args: ['acp'], env: [], externalExecution: true },
+        scopeDir,
+        cwd,
+        runInSandbox: true,
+        daemonRoot: '/srv/agentconnect',
+        sandboxMechanism: 'bwrap'
+      })
+    ).toThrow(/external machine-local service/)
+    expect(existsSync(join(scopeDir, 'home'))).toBe(false)
+  })
+
+  it('downgrades an optional sandbox request for an externalExecution runtime but keeps requireSandbox loud', () => {
+    const external: RuntimeDef = { command: 'openclaw', args: ['acp'], env: [], externalExecution: true }
+    const ordinary: RuntimeDef = { command: 'hermes', args: ['acp'], env: [] }
+    expect(effectiveRunInSandbox(false, true, 'bwrap', external)).toBe(false)
+    expect(effectiveRunInSandbox(false, true, 'bwrap', ordinary)).toBe(true)
+    // requireSandbox stays true so the launch above throws instead of silently unconfining.
+    expect(effectiveRunInSandbox(true, false, 'bwrap', external)).toBe(true)
   })
 
   it('can isolate HOME for a disposable probe without enabling an OS sandbox', () => {

--- a/packages/daemon/test/runtime-prober.test.ts
+++ b/packages/daemon/test/runtime-prober.test.ts
@@ -304,6 +304,9 @@ describe('curatedProbeEnvironment', () => {
       OPENAI_API_KEY: 'openai-key',
       ANTHROPIC_API_KEY: 'anthropic-key',
       KIRO_API_KEY: 'kiro-key',
+      OPENCLAW_GATEWAY_URL: 'ws://127.0.0.1:18789',
+      OPENCLAW_GATEWAY_TOKEN: 'gateway-token',
+      OPENCLAW_STATE_DIR: '/host/openclaw',
       AWS_SHARED_CREDENTIALS_FILE: '/host/aws',
       GOOGLE_APPLICATION_CREDENTIALS: '/host/google.json',
       KUBECONFIG: '/host/kube',
@@ -323,7 +326,9 @@ describe('curatedProbeEnvironment', () => {
       NODE_EXTRA_CA_CERTS: '/etc/extra.pem',
       OPENAI_API_KEY: 'openai-key',
       ANTHROPIC_API_KEY: 'anthropic-key',
-      KIRO_API_KEY: 'kiro-key'
+      KIRO_API_KEY: 'kiro-key',
+      OPENCLAW_GATEWAY_URL: 'ws://127.0.0.1:18789',
+      OPENCLAW_GATEWAY_TOKEN: 'gateway-token'
     })
   })
 })
@@ -481,6 +486,57 @@ describe('probeTimeoutMs', () => {
     expect(readFileSync(hostDotEnv, 'utf8')).toContain('GOOGLE_APPLICATION_CREDENTIALS=/host/google.json')
     expect(existsSync(privateHome)).toBe(false)
     expect(existsSync(privateConfig)).toBe(false)
+  })
+
+  it('probes an externalExecution runtime unsandboxed but still with an isolated HOME', async () => {
+    const hostHome = mkdtempSync(join(tmpdir(), 'ac-probe-openclaw-'))
+    mkdirSync(join(hostHome, '.openclaw'))
+    writeFileSync(join(hostHome, '.openclaw', 'openclaw.json'), '{"gateway":{"url":"ws://127.0.0.1:18789"}}')
+
+    const results = await probeAllRuntimes(
+      { openclaw: { command: 'openclaw', args: ['acp'], env: [], externalExecution: true } },
+      {
+        curated: true,
+        runInSandbox: true,
+        sandboxMechanism: 'bwrap',
+        daemonRoot: '/srv/agentconnect',
+        hostEnv: { HOME: hostHome, PATH: '/usr/bin' },
+        hostFactory: (_runtime, _id, _cwd, policy) => {
+          expect(policy.sandbox).toBeUndefined()
+          expect(policy.inheritProcessEnv).toBe(false)
+          expect(existsSync(join(policy.env!.HOME!, '.openclaw', 'openclaw.json'))).toBe(true)
+          expect(policy.env!.OPENCLAW_STATE_DIR).toBe(join(policy.env!.HOME!, '.openclaw'))
+          return successfulHost()
+        }
+      }
+    )
+
+    expect(results[0]?.ok).toBe(true)
+  })
+
+  it('fails the externalExecution probe under requireSandbox instead of admitting an unlaunchable runtime', async () => {
+    const hostHome = mkdtempSync(join(tmpdir(), 'ac-probe-openclaw-req-'))
+    const binDir = join(hostHome, 'bin')
+    mkdirSync(binDir)
+    writeFileSync(join(binDir, 'openclaw'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+
+    const results = await probeAllRuntimes(
+      { openclaw: { command: 'openclaw', args: ['acp'], env: [], externalExecution: true } },
+      {
+        curated: true,
+        runInSandbox: true,
+        requireSandbox: true,
+        sandboxMechanism: 'bwrap',
+        daemonRoot: '/srv/agentconnect',
+        hostEnv: { HOME: hostHome, PATH: binDir },
+        hostFactory: () => {
+          throw new Error('a refused launch must never construct a probe host')
+        }
+      }
+    )
+
+    expect(results[0]?.ok).toBe(false)
+    expect(results[0]?.error).toMatch(/external machine-local service/)
   })
 
   it('removes copied Maki MCP declarations from disposable probes', async () => {

--- a/packages/daemon/test/skills.test.ts
+++ b/packages/daemon/test/skills.test.ts
@@ -11,6 +11,7 @@ describe('skillsAgentIdForRuntime', () => {
     expect(skillsAgentIdForRuntime('factory-droid')).toBe('droid')
     expect(skillsAgentIdForRuntime('qoder-cli-cn')).toBe('qoder-cn')
     expect(skillsAgentIdForRuntime('dsh-acp')).toBe('universal')
+    expect(skillsAgentIdForRuntime('openclaw')).toBe('openclaw')
     expect(skillsAgentIdForRuntime('qwen-code')).toBe('qwen-code')
     expect(skillsAgentIdForRuntime('some-exotic-agent')).toBeUndefined()
   })

--- a/packages/web/src/app/api/acp-registry/route.ts
+++ b/packages/web/src/app/api/acp-registry/route.ts
@@ -36,6 +36,10 @@ const CURATED_AGENTS: Record<string, { name: string; icon: string | null }> = {
   'dsh-acp': {
     name: 'DeepSeek Harness',
     icon: 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/deepseek-color.svg'
+  },
+  openclaw: {
+    name: 'OpenClaw',
+    icon: 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/openclaw-color.svg'
   }
 }
 

--- a/packages/web/src/lib/acp-registry.test.ts
+++ b/packages/web/src/lib/acp-registry.test.ts
@@ -37,6 +37,10 @@ describe('ACP Registry metadata', () => {
       name: 'Kiro CLI',
       icon: 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/kiro-color.svg'
     })
+    expect(agents.openclaw).toEqual({
+      name: 'OpenClaw',
+      icon: 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/openclaw-color.svg'
+    })
   })
 
   it('serves curated marks even when the upstream registry fetch fails', async () => {


### PR DESCRIPTION
## What

Adds OpenClaw 2.0 (`openclaw acp`) to the daemon's curated native ACP runtime catalog, so hosts with an installed, initialized OpenClaw advertise it automatically — no per-daemon `config.json` `runtimes.openclaw` registration needed.

- **Curated entry + probe** (`curated.ts`, `probe.ts`): availability requires the real `openclaw` binary on PATH **and** an initialized state root — `~/.openclaw`, honoring `$OPENCLAW_STATE_DIR`, `$OPENCLAW_HOME`, and `$OPENCLAW_CONFIG_PATH` (verified against OpenClaw's environment docs). No false positives from node/npx being present.
- **Private probe HOME** (`probe.ts`, `runtime-home.ts`): seeds only `openclaw.json` + `.env` (the gateway address/token the stateless bridge reads); gateway-side sessions stay private. `$OPENCLAW_STATE_DIR` is pinned into the private HOME; the three state-root env vars are stripped from isolated launches, while `OPENCLAW_GATEWAY_URL/_TOKEN/_PASSWORD` are treated as provider credentials (inherited by launches, allowlisted for probes, values redacted from probe diagnostics — both seeded files).
- **`RuntimeDef.externalExecution`** (`config-schema.ts`, `prepare.ts`, `daemon.ts`, `facts-registry.ts`, `runtime-prober.ts`, `model-enumerator.ts`, `cli/chat.ts`): the bridge only shuttles ACP frames — execution happens in the machine-local OpenClaw Gateway (`ws://127.0.0.1:18789`), which the OS sandbox cannot contain, while SRT's `--unshare-net` severs the loopback dial the bridge exists for. A runtime declaring this flag launches like any unsandboxed runtime; an agent's optional sandbox request is downgraded with a distinct warning; `security.requireSandbox` makes the launch **and** the curated admission probe fail loudly, so the runtime is not advertised on hosts that demand confinement. Without this flag, the admission probe on any bwrap-capable host would launch the bridge inside the netns and openclaw could never be admitted. Model-catalog enumeration (sandbox-only by design) skips such runtimes; the probe-derived model list stands. Documented in `docs/designs/daemon-detailed-design.md` §"Linux ACP runtime sandbox".
- **Skills**: `skillsAgentId: 'openclaw'` — audited against the pinned skills@1.5.21, which carries a native `openclaw` identity (global `~/.openclaw/skills`, project `skills/`); also added to `AUDITED_RUNTIME_SKILLS_AGENTS`.
- **Account apps**: classified `not-applicable` — tools come from the local Gateway's own config, not a cloud-account connector sync.
- **Web**: OpenClaw display mark in `/api/acp-registry` (lobehub CDN icon, fetched and verified).

## Why

OpenClaw is not in the public ACP registry (cdn.agentclientprotocol.com), so the curated catalog is the right home. The test-env daemon `agent-0` currently runs a manual `runtimes.openclaw` config entry; after this merges and rolls out, that manual entry should be deleted (a user-source entry would otherwise shadow the curated definition).

## Reviewer notes

- The `externalExecution` semantics are the main design decision: confining the thin bridge is security theater (the Gateway executes on the host regardless), so the honest behavior is an unconfined launch plus a loud `requireSandbox` refusal — not a per-runtime SRT network exception, which the codebase deliberately defers (issue #312).
- If the public ACP registry ever publishes an `openclaw` id, the registry entry takes over the curated id and (by the catalog's deliberate metadata non-inheritance) drops `externalExecution`; that would need revisiting then.
- A console-side follow-up (disable/annotate the "Run in sandbox" toggle for such runtimes, instead of a log-only downgrade warning) is intentionally out of scope.
- Verified: daemon + web typecheck, eslint, prettier; all touched suites pass (probe, registry, runtime-home, runtime-launch, runtime-prober, skills, account-apps, curated-admission, web acp-registry). Full local daemon suite: 5206 passed; the 14 failures (3 shim files + acp-matrix) are pre-existing macOS-local environment issues with no import-graph overlap with this diff, identical across two runs.
- End-to-end on `agent-0` (openclaw 2026.8.1 + gateway on loopback:18789) still needs a build/rollout: confirm `openclaw` in `RegisterReq.capabilities`, the console Runtimes list, and a live chat turn through `openclaw acp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)