### PR TITLE
feat(cp): block the gitlab and linear connectors now served natively

### DIFF
--- a/packages/control-plane/src/config/env.ts
+++ b/packages/control-plane/src/config/env.ts
@@ -246,10 +246,12 @@ const CoreConfigShape = {
   // otherwise a comma-separated list of `service` ids.
   OPEN_CONNECTOR_PROVIDER_WHITELIST: z.string().optional(),
   // Provider blocklist applied after the whitelist. Defaults to the exact open-connector
-  // service ids that overlap AgentConnect's native integrations.
+  // service ids that overlap AgentConnect's native integrations — CONVENTION: every new
+  // native integration (platform module or code host) adds its upstream service id here
+  // in the same change, so the catalog never offers a connector the product now owns.
   OPEN_CONNECTOR_PROVIDER_BLOCKLIST: z
     .string()
-    .default('github,slack,telegram,discord,discordbot,feishu,feishu_app_bot,feishu_custom_bot'),
+    .default('github,gitlab,linear,slack,telegram,discord,discordbot,feishu,feishu_app_bot,feishu_custom_bot'),
   // ── in-cluster Kubernetes access — opt-in by running a daemon pool ──
   // THE switch for the cluster surface, and the only access knob: turning it on asserts this
   // control plane runs inside the cluster, so the pod's ServiceAccount is the credential and a


### PR DESCRIPTION
The default open-connector blocklist exists to hide catalog entries that overlap a native integration. GitLab shipped on the code-host seam and Linear is landing as a platform module, so both join the set; a deployment that wants them back can still override the env.

Also spells out the convention in the comment: every new native integration adds its upstream service id here in the same change, so the catalog never offers a connector the product now owns.

Tests: connectors + config unit suites and CP typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
