### PR TITLE
fix(cp): anchor approval-DM identity on workspaceId for token-installed bots

### DIFF
--- a/docs/designs/slack-approval-dm.md
+++ b/docs/designs/slack-approval-dm.md
@@ -86,8 +86,12 @@ wins (§4.2). Every rung must pass both standing gates before it can win:
 
 - **Authority:** the candidate's console user satisfies `canEdit(agent)`.
 - **Identity:** the candidate has linked a Slack identity **in the bot's own
-  workspace** — `slackIdentityFor(sub).teamId === bot.teamId`, keyed on the
-  `(teamId, userId)` pair per [slack-identity.md](slack-identity.md).
+  workspace** — `slackIdentityFor(sub).teamId` equals the bot's workspace
+  anchor, keyed on the `(teamId, userId)` pair per
+  [slack-identity.md](slack-identity.md). The anchor is `Bot.teamId` when
+  present (platform-app installs) and otherwise the auth.test-reported
+  `Bot.workspaceId` — the provenance `ownerIdentity`'s transport scope
+  already carries; a token-installed bot has no `teamId` at all.
 
 The rungs, in order (from the issue discussion):
 

--- a/packages/control-plane/src/orchestrator/approvalRoute.test.ts
+++ b/packages/control-plane/src/orchestrator/approvalRoute.test.ts
@@ -156,6 +156,28 @@ describe('resolveApprovalRoute — route form', () => {
     expect(routed.target).toBeUndefined()
   })
 
+  it('a token-installed bot anchors on its reported workspaceId — teamId is platform-app-only', async () => {
+    const routed = await resolveApprovalRoute(
+      routeReq({ requesterId: 'U0OWNER' }),
+      deps({
+        members: [{ userId: 'u-owner', displayName: 'Owner' }],
+        links: { 'u-owner': linked('U0OWNER') },
+        bots: { 'bot-a': { teamId: null, workspaceId: TEAM_A } }
+      })
+    )
+    expect(routed.target).toMatchObject({ teamId: TEAM_A, userId: 'U0OWNER', consoleUserId: 'u-owner' })
+    // …and with neither, the integration is skipped fail-closed.
+    const anchorless = await resolveApprovalRoute(
+      routeReq({ requesterId: 'U0OWNER' }),
+      deps({
+        members: [{ userId: 'u-owner' }],
+        links: { 'u-owner': linked('U0OWNER') },
+        bots: { 'bot-a': { teamId: null, workspaceId: null } }
+      })
+    )
+    expect(anchorless.target).toBeUndefined()
+  })
+
   it('an identity linked to another workspace never matches', async () => {
     const routed = await resolveApprovalRoute(
       routeReq({ requesterId: 'U0OWNER' }),
@@ -233,6 +255,18 @@ describe('resolveApprovalRoute — verify form', () => {
     for (const world of worlds) {
       expect((await resolveApprovalRoute(verifyReq(), deps(world))).allowed).toBe(false)
     }
+  })
+
+  it('allows through a token-installed bot anchored on workspaceId', async () => {
+    const routed = await resolveApprovalRoute(
+      verifyReq(),
+      deps({
+        members: [{ userId: 'u-owner' }],
+        links: { 'u-owner': linked('U0OWNER') },
+        bots: { 'bot-a': { teamId: null, workspaceId: TEAM_A } }
+      })
+    )
+    expect(routed.allowed).toBe(true)
   })
 
   it('refuses a workspace that does not match the integration bot', async () => {

--- a/packages/control-plane/src/orchestrator/approvalRoute.ts
+++ b/packages/control-plane/src/orchestrator/approvalRoute.ts
@@ -22,7 +22,6 @@ import type { AgentApprovalRoute, AgentApprovalRouted, ApprovalRouteTarget } fro
 import type { SlackIdentity } from '../github/logto-identity.js'
 import type {
   AgentRepo,
-  BotRecord,
   BotRepo,
   IntegrationRepo,
   OrgMemberRecord,
@@ -66,12 +65,16 @@ export async function resolveApprovalRoute(
 
   const owned = await deps.integration.activeForAgents([req.agentId])
   const slackOwned = new Map(owned.filter((i) => i.platform === 'slack').map((i) => [String(i.id), i]))
-  // A revoked bot cannot open a DM, and its workspace no longer asserts anything.
-  const botFor = async (integrationId: string): Promise<BotRecord | null> => {
+  // The integration's workspace anchor. `teamId` is written by platform-app installs only;
+  // a token-installed (direct) bot carries the same fact as `workspaceId`, reported by the
+  // owning daemon's auth.test — the provenance `ownerIdentity`'s transportScope already has,
+  // and session visibility already matches on. A revoked bot's workspace asserts nothing.
+  const workspaceFor = async (integrationId: string): Promise<string | null> => {
     const integration = slackOwned.get(integrationId)
     if (!integration) return null
     const bot = await deps.bot.get(OrgId(integration.orgId), integration.botId)
-    return bot?.teamId && !bot.revokedAt ? bot : null
+    if (!bot || bot.revokedAt) return null
+    return bot.teamId ?? bot.workspaceId ?? null
   }
   // One member's lookup failing costs that member a match, never the whole answer.
   const pairOf = async (userId: string): Promise<SlackIdentity | null> => {
@@ -86,8 +89,8 @@ export async function resolveApprovalRoute(
 
   if (req.verify) {
     const v = req.verify
-    const bot = await botFor(v.integrationId)
-    if (!bot || bot.teamId !== v.teamId) return none
+    const workspace = await workspaceFor(v.integrationId)
+    if (!workspace || workspace !== v.teamId) return none
     // Membership + role + visibility re-checked live: left org / demoted / unshared all refuse.
     const member = editors.find((m) => m.userId === v.consoleUserId)
     if (!member) return none
@@ -108,9 +111,8 @@ export async function resolveApprovalRoute(
   }
 
   for (const integrationId of req.integrationIds) {
-    const bot = await botFor(integrationId)
-    if (!bot) continue
-    const teamId = bot.teamId!
+    const teamId = await workspaceFor(integrationId)
+    if (!teamId) continue
     // The one forward scan (§3): editors linked to THIS workspace, both directions.
     let bySlackUid: Map<string, OrgMemberRecord> | null = null
     let uidByConsole: Map<string, string> | null = null


### PR DESCRIPTION
## Summary

Live-debugging #1648 on the test stack surfaced this: no approval DM ever arrived because `resolveApprovalRoute`'s workspace gate required `Bot.teamId`, which **only platform-app installs write** — a token-installed (direct/socket-mode) Slack bot always has `teamId: null`, so every integration was skipped fail-closed and the CP answered "no target" for every route query.

The daemon-reported `Bot.workspaceId` (from auth.test over the authenticated WS) carries the same workspace fact with the same provenance that `ownerIdentity`'s transport scope already has — and session visibility already trusts for authorization matching. The resolver now anchors on `teamId ?? workspaceId`, skipping fail-closed only when neither exists; the verify form uses the same anchor. Design doc §3 updated to record the anchor definition.

Verified against the failing case: test bot `eb678726…` has `teamId: null`, `workspaceId: T038JQ2G4KX` (matching the session's `ownerIdentity`).

## Test plan

- New resolver cases: token bot (teamId null + workspaceId) routes and verifies; neither anchor ⇒ skipped fail-closed. 15/15 pass, CP typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)