### PR TITLE
feat(cp): broker Linear access tokens on the daemon socket

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -798,10 +798,19 @@ export const LinearCredGrant = z.object({
 ```
 
 The CP handler follows the `gitcred` shape — core owns the frame family and
-the placement scope check (`agent.daemonId === conn.daemonId`); the
+the scope check, which is `gitcred`'s own service-scope predicate rather than
+a placement equality: a pool member serves agents its row does not name, so
+"may this connection act for that agent?" is placement OR a duty it holds; the
 provider's token service owns the work: single-flight refresh when the stored
 token is near expiry, durable persist of the rotated pair **before**
-replying, then a spec re-push so `agent.json` converges.
+replying, then a spec re-push so `agent.json` converges. That re-push is the
+SHARED integration converge, not a new mechanism: the token service reports
+whether the answer it returned is newer than the stored pair the caller read,
+and a rotated grant runs the same converge a visibility flip runs, whose
+http-bot arm re-syncs the workspace bot — so every member's spec is re-pushed,
+not only the requesting agent's. It is best-effort and follows the reply: a
+grant that already landed must not fail on a fan-out, and the reconcile roster
+carries the spec to any daemon the push missed.
 
 ### 7.4 Membership, disconnect, revocation
 

--- a/packages/control-plane/src/container.ts
+++ b/packages/control-plane/src/container.ts
@@ -1941,6 +1941,9 @@ export function buildContainer(
           })
         }
       : {}),
+    // The SAME token service the funnel, the disconnect edge and the sweep hold — the `linearcred`
+    // broker must not become a second opinion on when a grant is stale (linear-integration.md §4.4).
+    linearTokens: linearTokenService,
     ...(githubReviewBroker ? { githubReviewBroker } : {}),
     ...(codeHostReviewBroker ? { codeHostReviewBroker } : {}),
     ...(githubRunCoordinator ? { githubRunCoordinator } : {}),

--- a/packages/control-plane/src/persistence/linear-identity-lock.ts
+++ b/packages/control-plane/src/persistence/linear-identity-lock.ts
@@ -8,8 +8,14 @@
  * Linear `POST /oauth/revoke` acts on the app↔workspace grant, not on one tenant's copy of it. An
  * org-keyed lock would let two organizations answer that question at the same time and both act.
  *
- * TWO HOLDERS, and they must derive the key identically or the fence does not exist:
+ * THREE HOLDERS, and they must derive the key identically or the fence does not exist:
  *
+ *  - the broker's refresh write ({@link LinearTokenStore.rotate}, §7.3), which is a compare-and-set
+ *    rather than an upsert precisely because it cannot hold this lock across its upstream call: the
+ *    refresh is on a daemon-driven path that fans out with the fleet, and pinning a pool connection
+ *    per refreshing workspace across a call to Linear would turn a slow provider into control-plane
+ *    connection starvation. It takes the lock only for the write, and the write is safe on its own
+ *    terms — an UPDATE cannot create a row;
  *  - the connect callback's §7.1 STEP 1 token upsert ({@link LinearTokenStore.put}), which is the
  *    first durable trace of an organization laying claim to an identity — and, because §7.1 fixes
  *    that write BEFORE the create tail, locking it also fences bot admission: no Bot can exist for

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4388,6 +4388,18 @@ export interface LinearTokenRecord extends LinearTokenMaterial {
 }
 
 /**
+ * What {@link LinearTokenStore.rotate}'s compare-and-set found. `gone` and `superseded` are not
+ * failures — they are the world having moved on, and each names what it moved to.
+ */
+export type LinearTokenRotation =
+  /** The rotation landed on the row the flight read. */
+  | { outcome: 'rotated' }
+  /** A newer grant is in place (a reconnect, or a peer instance's rotate); the rotation was discarded. */
+  | { outcome: 'superseded'; current: LinearTokenRecord }
+  /** The row is gone — disconnected or swept. Nothing was written, and nothing may be. */
+  | { outcome: 'gone' }
+
+/**
  * A `linear_token` row no Bot in its OWN organization references any more (§7.1) — the sweeper's
  * unit of work. Selection is org-scoped and revocation is not, so the row carries both answers.
  */
@@ -4448,8 +4460,30 @@ export interface LinearOrphanTokenRow {
 
 export interface LinearTokenStore {
   get(identity: LinearConnectionIdentity): Promise<LinearTokenRecord | null>
-  /** Upsert the workspace's grant — the callback's step-1 write and every rotate. */
+  /** Upsert the workspace's grant — the connect callback's step-1 write and the §7.4 reconnect. */
   put(identity: LinearConnectionIdentity, material: LinearTokenMaterial): Promise<void>
+  /**
+   * The REFRESH path's write, and the reason it is not {@link LinearTokenStore.put}: a rotation is
+   * issued upstream long before it can be stored, and the world can move underneath it in between.
+   *
+   * So it is a compare-and-set on the row the flight actually read — an UPDATE, never an upsert,
+   * matching only while the row still carries `expectedUpdatedAt`, the same CAS token
+   * {@link LinearIdentitySection.claim} guards with. Two hazards die on that shape at once:
+   *
+   *  - a disconnect (locked revoke + remove) that completed while the refresh was in flight leaves
+   *    NOTHING to update, and an UPDATE cannot create a row — so a late rotation can never
+   *    resurrect a grant for a workspace that was disconnected, however long it was delayed;
+   *  - a reconnect that stored a brand-new grant in the meantime moved `updatedAt`, so the older
+   *    rotation matches nothing instead of overwriting the fresher pair.
+   *
+   * The caller learns which happened and adopts the world as it now is, rather than retrying into
+   * it. Takes the same lock {@link LinearTokenStore.put} does, on the same waiter budget.
+   */
+  rotate(
+    identity: LinearConnectionIdentity,
+    expectedUpdatedAt: Date,
+    material: LinearTokenMaterial
+  ): Promise<LinearTokenRotation>
   delete(identity: LinearConnectionIdentity): Promise<void>
   /**
    * Rows of the deployment app older than `staleBefore` whose own organization has no Bot for the

--- a/packages/control-plane/src/persistence/repositories/linear.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/linear.repo.ts
@@ -26,6 +26,7 @@ import type {
   LinearOrphanTokenRow,
   LinearTokenMaterial,
   LinearTokenRecord,
+  LinearTokenRotation,
   LinearTokenStore
 } from '../ports.js'
 import type { SecretCipher } from '../../secrets/cipher.js'
@@ -119,6 +120,54 @@ export class PgLinearTokenStore implements LinearTokenStore {
       },
       IDENTITY_WAIT_TX
     )
+  }
+
+  /**
+   * The refresh path's compare-and-set (§7.3), under the same lock and the same waiter budget as
+   * {@link PgLinearTokenStore.put} — it is one short write that may queue behind a sweep, not a
+   * holder that keeps others waiting.
+   *
+   * `updateMany`, deliberately NOT `upsert`: an UPDATE cannot create a row, so this is safe against
+   * a disconnect that completed while the rotation was in flight EVEN IF that remover never took
+   * the lock. The lock still matters — it makes the "what is there instead?" read below part of the
+   * same decision rather than a second, already-stale question — but the no-resurrection property
+   * does not depend on it.
+   *
+   * Cipher work stays outside the transaction on both sides (seal before, open after), for the
+   * reason {@link PgLinearTokenStore.put} spells out: the cipher may be a remote round trip.
+   */
+  async rotate(
+    identity: LinearConnectionIdentity,
+    expectedUpdatedAt: Date,
+    material: LinearTokenMaterial
+  ): Promise<LinearTokenRotation> {
+    const scope = orgScope(identity.orgId)
+    const tokens = {
+      accessToken: await this.cipher.seal(material.accessToken, scope),
+      refreshToken: material.refreshToken ? await this.cipher.seal(material.refreshToken, scope) : null,
+      expiresAt: material.expiresAt
+    }
+    const found = await withAmbientTx(
+      this.prisma,
+      async (tx) => {
+        await lockLinearIdentity(tx, identity.clientId, identity.organizationId)
+        const applied = await tx.linearToken.updateMany({
+          where: {
+            orgId: identity.orgId,
+            clientId: identity.clientId,
+            organizationId: identity.organizationId,
+            updatedAt: expectedUpdatedAt
+          },
+          data: tokens
+        })
+        if (applied.count > 0) return 'rotated' as const
+        return tx.linearToken.findUnique({ where: PgLinearTokenStore.key(identity) })
+      },
+      IDENTITY_WAIT_TX
+    )
+    if (found === 'rotated') return { outcome: 'rotated' }
+    if (!found) return { outcome: 'gone' }
+    return { outcome: 'superseded', current: await this.toRecord(identity, found) }
   }
 
   async delete(identity: LinearConnectionIdentity): Promise<void> {

--- a/packages/control-plane/src/platforms/linear/provider.test.ts
+++ b/packages/control-plane/src/platforms/linear/provider.test.ts
@@ -35,6 +35,7 @@ import type {
   LinearIdentitySection,
   LinearTokenMaterial,
   LinearTokenRecord,
+  LinearTokenRotation,
   LinearTokenStore
 } from '../../persistence/ports.js'
 import { AgentId, BotId, IntegrationId, OrgId } from '../../domain/ids.js'
@@ -58,6 +59,21 @@ class MemoryTokens implements LinearTokenStore {
   put(identity: LinearConnectionIdentity, material: LinearTokenMaterial): Promise<void> {
     this.rows.set(MemoryTokens.key(identity), { ...identity, ...material, updatedAt: new Date() })
     return Promise.resolve()
+  }
+  /** The broker's CAS write. Never reached from this suite — no provider member refreshes — but it
+   *  is the store's contract, so the fake honors it rather than pretending. */
+  rotate(
+    identity: LinearConnectionIdentity,
+    expectedUpdatedAt: Date,
+    material: LinearTokenMaterial
+  ): Promise<LinearTokenRotation> {
+    const current = this.rows.get(MemoryTokens.key(identity))
+    if (!current) return Promise.resolve({ outcome: 'gone' })
+    if (current.updatedAt.getTime() !== expectedUpdatedAt.getTime()) {
+      return Promise.resolve({ outcome: 'superseded', current })
+    }
+    this.rows.set(MemoryTokens.key(identity), { ...identity, ...material, updatedAt: new Date() })
+    return Promise.resolve({ outcome: 'rotated' })
   }
   delete(identity: LinearConnectionIdentity): Promise<void> {
     this.rows.delete(MemoryTokens.key(identity))

--- a/packages/control-plane/src/platforms/linear/provider.ts
+++ b/packages/control-plane/src/platforms/linear/provider.ts
@@ -15,8 +15,8 @@
  *    workspace's ≤24 h access token from this provider's own `linear_token` table by the bot's D6
  *    identity. That is the case the contract made both projectors async for (§4.4).
  *
- * SCOPE OF THIS MODULE. The `linearcred` broker lands with the WS handler; everything else the
- * registry reads is here — the deployment config slice, the refusal, the secret shape, the two
+ * SCOPE OF THIS MODULE. The `linearcred` broker is core's (`ws/handlers/linearcred.ts`), reading
+ * the token service and {@link linearConnectionIdentity}; everything else the registry reads is here — the deployment config slice, the refusal, the secret shape, the two
  * projectors, the D6 identity projection, the connect funnel's routes and TTL reaper, the
  * orphan-token sweep, and the disconnect side effect.
  */
@@ -24,7 +24,12 @@ import { z } from 'zod'
 import type { ZodRawShape } from 'zod'
 import type { FastifyPluginAsync } from 'fastify'
 import type { IntegrationLinearConfig } from '@agentconnect.md/protocol'
-import type { BotRecord, BotSecretMaterial, LinearTokenStore } from '../../persistence/ports.js'
+import type {
+  BotRecord,
+  BotSecretMaterial,
+  LinearConnectionIdentity,
+  LinearTokenStore
+} from '../../persistence/ports.js'
 import type { LinearPlatformAppConfig } from '../../config/linear-platform.js'
 import type { LinearCredentialReconciler } from './credential-reconciler.js'
 import type {
@@ -206,14 +211,21 @@ export interface LinearCpProviderDeps {
  *  only has to be shorter than "a human forgot about the tab". */
 export const LINEAR_CONNECT_TTL_MS = 30 * 60 * 1000
 
+/**
+ * The workspace bot's connection identity (§4.4), or null when the row carries no complete D6 pair.
+ * Exported because the `linearcred` broker resolves the same identity from the same columns (§7.3),
+ * and "what a Linear grant is keyed by" must have exactly one description.
+ */
+export function linearConnectionIdentity(
+  bot: Pick<BotRecord, 'orgId' | 'externalAppId' | 'externalTenantId'>
+): LinearConnectionIdentity | null {
+  return bot.externalAppId && bot.externalTenantId
+    ? { orgId: bot.orgId, clientId: bot.externalAppId, organizationId: bot.externalTenantId }
+    : null
+}
+
 export function createLinearCpProvider(deps: LinearCpProviderDeps): CpPlatformProvider<LinearCreateCredentials> {
   const { tokens, tokenService, funnelRoutes, pendingInstalls, orphanTokenSweeper, credentialReconciler } = deps
-
-  /** The bot's connection identity (§4.4), or null when the row carries no complete D6 pair. */
-  const connectionOf = (bot: BotRecord) =>
-    bot.externalAppId && bot.externalTenantId
-      ? { orgId: bot.orgId, clientId: bot.externalAppId, organizationId: bot.externalTenantId }
-      : null
 
   return {
     platformId: 'linear',
@@ -373,7 +385,7 @@ export function createLinearCpProvider(deps: LinearCpProviderDeps): CpPlatformPr
       ? {
           sideEffects: {
             onBotDelete: async (bot) => {
-              const connection = connectionOf(bot)
+              const connection = linearConnectionIdentity(bot)
               if (!connection) return
               await tokens.withIdentityLock(connection, async (section) => {
                 if (tokenService && !(await section.owned())) await tokenService.revoke(connection)
@@ -392,7 +404,7 @@ export function createLinearCpProvider(deps: LinearCpProviderDeps): CpPlatformPr
      * this runs the row is already durable. Token-bearing — NEVER log.
      */
     async projectIntegrationConfig(_integration, bot) {
-      const connection = connectionOf(bot)
+      const connection = linearConnectionIdentity(bot)
       if (!connection || !tokens) return undefined
       const token = await tokens.get(connection)
       if (!token) return undefined

--- a/packages/control-plane/src/platforms/linear/token-service.test.ts
+++ b/packages/control-plane/src/platforms/linear/token-service.test.ts
@@ -121,7 +121,13 @@ describe('accessToken — refresh only when the stored grant is near expiry', ()
   it('uses a fresh token as-is, without touching Linear', async () => {
     const { tokens, linear, service } = build()
     await seed(tokens, LINEAR_REFRESH_MARGIN_MS + 60_000)
-    expect(await service.accessToken(IDENTITY)).toMatchObject({ ok: true, accessToken: 'access_1' })
+    // `rotated: false` is what tells the broker no spec re-push is owed (§7.3).
+    expect(await service.accessToken(IDENTITY)).toEqual({
+      ok: true,
+      accessToken: 'access_1',
+      expiresAt: expect.any(Date),
+      rotated: false
+    })
     expect(linear.calls).toHaveLength(0)
   })
 
@@ -130,7 +136,8 @@ describe('accessToken — refresh only when the stored grant is near expiry', ()
     await seed(tokens, LINEAR_REFRESH_MARGIN_MS - 60_000)
     linear.reply(() => rotated(2))
 
-    expect(await service.accessToken(IDENTITY)).toMatchObject({ ok: true, accessToken: 'access_2' })
+    // `rotated` is the broker's re-push signal: every spec projecting the old pair is now stale.
+    expect(await service.accessToken(IDENTITY)).toMatchObject({ ok: true, accessToken: 'access_2', rotated: true })
     expect(linear.calls).toHaveLength(1)
     expect(linear.calls[0]!.body).toContain('grant_type=refresh_token')
     // The rotated REFRESH half is persisted too — Linear invalidates the old one.
@@ -177,7 +184,8 @@ describe('rotate-and-retry — a rejected rotate may just mean someone else rota
       return { status: 400, body: { error: 'invalid_grant' } }
     })
 
-    expect(await service.accessToken(IDENTITY)).toMatchObject({ ok: true, accessToken: 'access_peer' })
+    // A peer's pair is just as new to this caller, so it re-pushes too.
+    expect(await service.accessToken(IDENTITY)).toMatchObject({ ok: true, accessToken: 'access_peer', rotated: true })
     // Exactly one upstream attempt: the retry is a RELOAD, not a second rotate.
     expect(linear.calls).toHaveLength(1)
   })

--- a/packages/control-plane/src/platforms/linear/token-service.test.ts
+++ b/packages/control-plane/src/platforms/linear/token-service.test.ts
@@ -14,6 +14,7 @@ import type {
   LinearIdentitySection,
   LinearTokenMaterial,
   LinearTokenRecord,
+  LinearTokenRotation,
   LinearTokenStore
 } from '../../persistence/ports.js'
 import { LinearApiClient } from './api.js'
@@ -26,8 +27,10 @@ const NOW = Date.parse('2026-03-01T00:00:00.000Z')
 
 class MemoryTokens implements LinearTokenStore {
   readonly rows = new Map<string, LinearTokenRecord>()
-  /** Every `put`, in order — the persist-before-reply assertion reads this. */
+  /** Every durable write, in order — the persist-before-reply assertion reads this. */
   readonly writes: LinearTokenMaterial[] = []
+  /** A distinct `updatedAt` per write, so the CAS token behaves as Postgres's does. */
+  private stamp = 0
   private static key(i: LinearConnectionIdentity) {
     return `${i.orgId} ${i.clientId} ${i.organizationId}`
   }
@@ -36,8 +39,24 @@ class MemoryTokens implements LinearTokenStore {
   }
   put(identity: LinearConnectionIdentity, material: LinearTokenMaterial): Promise<void> {
     this.writes.push(material)
-    this.rows.set(MemoryTokens.key(identity), { ...identity, ...material, updatedAt: new Date(NOW) })
+    this.rows.set(MemoryTokens.key(identity), { ...identity, ...material, updatedAt: new Date(NOW + ++this.stamp) })
     return Promise.resolve()
+  }
+  /** The real CAS, in memory: update ONLY the row still carrying `expectedUpdatedAt`, and never
+   *  create one — the two properties the Postgres statement is written for. */
+  rotate(
+    identity: LinearConnectionIdentity,
+    expectedUpdatedAt: Date,
+    material: LinearTokenMaterial
+  ): Promise<LinearTokenRotation> {
+    const current = this.rows.get(MemoryTokens.key(identity))
+    if (!current) return Promise.resolve({ outcome: 'gone' })
+    if (current.updatedAt.getTime() !== expectedUpdatedAt.getTime()) {
+      return Promise.resolve({ outcome: 'superseded', current })
+    }
+    this.writes.push(material)
+    this.rows.set(MemoryTokens.key(identity), { ...identity, ...material, updatedAt: new Date(NOW + ++this.stamp) })
+    return Promise.resolve({ outcome: 'rotated' })
   }
   delete(identity: LinearConnectionIdentity): Promise<void> {
     this.rows.delete(MemoryTokens.key(identity))
@@ -188,6 +207,41 @@ describe('rotate-and-retry — a rejected rotate may just mean someone else rota
     expect(await service.accessToken(IDENTITY)).toMatchObject({ ok: true, accessToken: 'access_peer', rotated: true })
     // Exactly one upstream attempt: the retry is a RELOAD, not a second rotate.
     expect(linear.calls).toHaveLength(1)
+  })
+
+  it('discards a rotation whose row was removed while the refresh was upstream', async () => {
+    const { tokens, linear, service } = build()
+    await seed(tokens, 0)
+    // The disconnect edge's locked removal completes inside the upstream call.
+    linear.reply(() => {
+      void tokens.delete(IDENTITY)
+      return rotated(2)
+    })
+
+    expect(await service.accessToken(IDENTITY)).toEqual({ ok: false, reason: 'not_connected' })
+    // An upsert here would hand a live grant back to a workspace whose install is gone.
+    expect(await tokens.get(IDENTITY)).toBeNull()
+    expect(tokens.writes).toEqual([])
+  })
+
+  it('adopts a grant stored while the refresh was upstream instead of overwriting it', async () => {
+    const { tokens, linear, service } = build()
+    await seed(tokens, 0)
+    // The §7.4 reconnect's upsert lands mid-flight; its pair is the one Linear now honors.
+    linear.reply(() => {
+      void tokens.put(IDENTITY, {
+        accessToken: 'access_reconnect',
+        refreshToken: 'refresh_reconnect',
+        expiresAt: new Date(NOW + 86_400_000)
+      })
+      return rotated(2)
+    })
+
+    expect(await service.accessToken(IDENTITY)).toMatchObject({ ok: true, accessToken: 'access_reconnect' })
+    expect(await tokens.get(IDENTITY)).toMatchObject({
+      accessToken: 'access_reconnect',
+      refreshToken: 'refresh_reconnect'
+    })
   })
 
   it('flips to reconnect_required when the reload finds nothing fresher', async () => {

--- a/packages/control-plane/src/platforms/linear/token-service.ts
+++ b/packages/control-plane/src/platforms/linear/token-service.ts
@@ -33,7 +33,15 @@ import type { LinearApiClient, LinearGrant, LinearViewer } from './api.js'
 export const LINEAR_REFRESH_MARGIN_MS = 2 * 60 * 60 * 1000
 
 export type LinearTokenResolution =
-  | { ok: true; accessToken: string; expiresAt: Date }
+  | {
+      ok: true
+      accessToken: string
+      expiresAt: Date
+      /** True when this call reached the refresh path and it produced a pair NEWER than the one the
+       *  stored row held on entry — either this rotate's or a peer's. The `linearcred` broker reads
+       *  it as "every spec projecting this grant is now stale" and re-pushes (§7.3). */
+      rotated: boolean
+    }
   | {
       ok: false
       /** `not_connected` — no grant for this identity (never connected, or swept).
@@ -97,7 +105,7 @@ export class LinearTokenService {
   async accessToken(identity: LinearConnectionIdentity): Promise<LinearTokenResolution> {
     const row = await this.deps.tokens.get(identity)
     if (!row) return { ok: false, reason: 'not_connected' }
-    if (this.fresh(row)) return { ok: true, accessToken: row.accessToken, expiresAt: row.expiresAt }
+    if (this.fresh(row)) return { ok: true, accessToken: row.accessToken, expiresAt: row.expiresAt, rotated: false }
     return this.refresh(identity)
   }
 
@@ -149,7 +157,8 @@ export class LinearTokenService {
     // fresh pair, and rotating again would spend a token nobody needed spent.
     const row = await this.deps.tokens.get(identity)
     if (!row) return { ok: false, reason: 'not_connected' }
-    if (this.fresh(row)) return { ok: true, accessToken: row.accessToken, expiresAt: row.expiresAt }
+    // Fresh HERE but stale to the caller's read ⇒ a peer rotated between them; the answer is new to it.
+    if (this.fresh(row)) return { ok: true, accessToken: row.accessToken, expiresAt: row.expiresAt, rotated: true }
     if (!row.refreshToken) return { ok: false, reason: 'reconnect_required' }
 
     const rotated = await this.deps.api.refresh({
@@ -160,7 +169,7 @@ export class LinearTokenService {
     if (rotated.ok) {
       // Durable BEFORE the reply — see the single-writer note at the top of this file.
       await this.put(identity, rotated.result)
-      return { ok: true, accessToken: rotated.result.accessToken, expiresAt: rotated.result.expiresAt }
+      return { ok: true, accessToken: rotated.result.accessToken, expiresAt: rotated.result.expiresAt, rotated: true }
     }
     if (rotated.error === 'unreachable') return { ok: false, reason: 'unreachable' }
 
@@ -168,7 +177,7 @@ export class LinearTokenService {
     // persisted the rotated pair — reload once and use what it wrote.
     const reloaded = await this.deps.tokens.get(identity)
     if (reloaded && this.fresh(reloaded)) {
-      return { ok: true, accessToken: reloaded.accessToken, expiresAt: reloaded.expiresAt }
+      return { ok: true, accessToken: reloaded.accessToken, expiresAt: reloaded.expiresAt, rotated: true }
     }
     this.deps.log?.warn(
       { orgId: identity.orgId, organizationId: identity.organizationId },

--- a/packages/control-plane/src/platforms/linear/token-service.ts
+++ b/packages/control-plane/src/platforms/linear/token-service.ts
@@ -15,15 +15,26 @@
  *    collapses them into one upstream call, and each joiner gets the winner's answer.
  *  - PERSIST BEFORE REPLY. The rotated pair is written durably before any caller sees it. Replying
  *    first and persisting after is how a crash mid-rotation strands a workspace with a token only
- *    the daemon has and a refresh token Linear has already spent.
+ *    the daemon has and a refresh token Linear has already spent. That write is a COMPARE-AND-SET
+ *    on the row the flight read ({@link LinearTokenStore.rotate}), not an upsert: an upstream call
+ *    takes real time, and a disconnect or a reconnect can complete inside it. An upsert would
+ *    resurrect a workspace that was disconnected mid-refresh, or overwrite a reconnect's newer
+ *    grant with an older rotation; an UPDATE that matches nothing does neither.
  *
  * ROTATE-AND-RETRY is the Slack config-token precedent (`http/slack-user-config.ts`): a rotate that
  * Linear DEFINITIVELY rejects may simply mean a peer CP instance rotated first, so the row is
  * reloaded once and a fresh pair found there is used. Only after that does the workspace count as
  * needing a reconnect. An unreachable Linear never spends the retry and never flips the state —
- * a blip is not proof the grant is dead.
+ * a blip is not proof the grant is dead. A LOST CAS takes the same arm on purpose: "someone else
+ * moved this identity on" is one event, and whether it surfaces as a rejected rotate or as an
+ * update that matched nothing is only a question of when this flight noticed.
  */
-import type { LinearConnectionIdentity, LinearTokenRecord, LinearTokenStore } from '../../persistence/ports.js'
+import type {
+  LinearConnectionIdentity,
+  LinearTokenRecord,
+  LinearTokenRotation,
+  LinearTokenStore
+} from '../../persistence/ports.js'
 import type { LinearPlatformAppConfig } from '../../config/linear-platform.js'
 import { systemClock, type Clock } from '../../domain/clock.js'
 import type { LinearApiClient, LinearGrant, LinearViewer } from './api.js'
@@ -167,17 +178,42 @@ export class LinearTokenService {
       refreshToken: row.refreshToken
     })
     if (rotated.ok) {
-      // Durable BEFORE the reply — see the single-writer note at the top of this file.
-      await this.put(identity, rotated.result)
-      return { ok: true, accessToken: rotated.result.accessToken, expiresAt: rotated.result.expiresAt, rotated: true }
+      // Durable BEFORE the reply — see the single-writer note at the top of this file — and as a
+      // CAS on the row this flight read, never an upsert: the world may have moved while the call
+      // above was in flight, and this write must not be able to undo it.
+      const applied = await this.deps.tokens.rotate(identity, row.updatedAt, rotated.result)
+      if (applied.outcome === 'rotated') {
+        return { ok: true, accessToken: rotated.result.accessToken, expiresAt: rotated.result.expiresAt, rotated: true }
+      }
+      return this.adopt(identity, applied)
     }
     if (rotated.error === 'unreachable') return { ok: false, reason: 'unreachable' }
 
     // Rejected. The refresh token may simply have been spent by another CP instance that already
     // persisted the rotated pair — reload once and use what it wrote.
     const reloaded = await this.deps.tokens.get(identity)
-    if (reloaded && this.fresh(reloaded)) {
-      return { ok: true, accessToken: reloaded.accessToken, expiresAt: reloaded.expiresAt, rotated: true }
+    return this.adopt(identity, reloaded ? { outcome: 'superseded', current: reloaded } : { outcome: 'gone' })
+  }
+
+  /**
+   * The world as it is after a rotation this flight could not apply — the SAME rule the rejected
+   * rotate takes, because a lost CAS and a spent refresh token are one event seen at two moments.
+   *
+   * `gone` is a workspace that was disconnected or swept out from under the refresh: there is
+   * nothing to serve and nothing may be written, which is precisely what stops a delayed rotation
+   * from resurrecting it. `superseded` is a newer grant — a reconnect, or a peer instance — and it
+   * is adopted when it is usable rather than re-rotated into.
+   */
+  private adopt(identity: LinearConnectionIdentity, applied: LinearTokenRotation): LinearTokenResolution {
+    if (applied.outcome === 'superseded' && this.fresh(applied.current)) {
+      return { ok: true, accessToken: applied.current.accessToken, expiresAt: applied.current.expiresAt, rotated: true }
+    }
+    if (applied.outcome === 'gone') {
+      this.deps.log?.warn(
+        { orgId: identity.orgId, organizationId: identity.organizationId },
+        'linear: the workspace grant was removed while its token was being refreshed'
+      )
+      return { ok: false, reason: 'not_connected' }
     }
     this.deps.log?.warn(
       { orgId: identity.orgId, organizationId: identity.organizationId },

--- a/packages/control-plane/src/ws/deps.ts
+++ b/packages/control-plane/src/ws/deps.ts
@@ -32,6 +32,7 @@ import type { SessionVisibilityPushService } from '../orchestrator/visibilityPus
 import type { DutyAgentBundle, RelayRosterEntry } from '@agentconnect.md/protocol'
 import type { GithubService } from '../github/service.js'
 import type { GitlabGitcredService } from '../gitlab/gitcred.service.js'
+import type { LinearTokenService } from '../platforms/linear/token-service.js'
 import type { CodeHostReviewBrokerService } from '../codehost/review-lease.service.js'
 import type { GithubReviewBrokerService } from '../github/review-broker.service.js'
 import type { GithubRunCoordinator } from '../github/run-reporter.js'
@@ -90,8 +91,8 @@ export interface DaemonWsDeps {
   events: SessionEventSink
   /** Ownership check for the `integration/channels` EVT (integration → daemon scope). */
   integration: IntegrationRepo
-  /** Validates a daemon-reported external credential locator before a Session
-   *  is bound to its immutable provider scope. */
+  /** Validates a daemon-reported external credential locator before a Session is bound to its
+   *  immutable provider scope, and resolves the workspace bot behind a `linearcred/request`. */
   bot?: BotRepo
   /** Resolves a trusted GitHub delivery's installation id to this org's
    * durable credential locator before binding a repository ExternalScope. */
@@ -150,6 +151,9 @@ export interface DaemonWsDeps {
   github?: GithubService
   /** gitcred v2 GitLab grants (§13.1); absent ⇒ gitlab workspaces disabled. */
   gitlabGitcred?: GitlabGitcredService
+  /** Linear workspace token custody (linear-integration.md §7.3) — the one seam the `linearcred`
+   *  broker calls; absent ⇒ `linearcred/request` answers SCOPE_DENIED. */
+  linearTokens?: Pick<LinearTokenService, 'accessToken'>
   /** R1 action-time formal-review broker; absent ⇒ review/start REQs fail closed. */
   githubReviewBroker?: GithubReviewBrokerService
   /** Provider-neutral formal reviews: publication lease, operation ledger, outcome

--- a/packages/control-plane/src/ws/handlers/index.ts
+++ b/packages/control-plane/src/ws/handlers/index.ts
@@ -38,6 +38,7 @@ import { handleEventSession, handleEventSessionSync } from './event-session.js'
 import { handleSessionActivity } from './event-session-activity.js'
 import { handleSessionPurged } from './event-session-purged.js'
 import { handleGitCredRequest } from './gitcred.js'
+import { handleLinearCredRequest } from './linearcred.js'
 import { handleHookStart } from './hook-start.js'
 import { handleApprovalRoute } from './approval-route.js'
 import { handleGithubReviewAuthorize } from './github-review-authorize.js'
@@ -101,6 +102,7 @@ export class FrameRouter {
       'event/session-activity': handleSessionActivity,
       'event/session-purged': handleSessionPurged,
       'gitcred/request': handleGitCredRequest,
+      'linearcred/request': handleLinearCredRequest,
       'webchat/mcp-grant/issue': handleWebchatMcpGrantIssue,
       'webchat/mcp-grant/accept': handleWebchatMcpGrantAccept,
       'webchat/mcp-grant/revoke': handleWebchatMcpGrantRevoke,

--- a/packages/control-plane/src/ws/handlers/linearcred.test.ts
+++ b/packages/control-plane/src/ws/handlers/linearcred.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AnyFrame } from '@agentconnect.md/protocol'
+import type { DaemonConnection } from '../connection.js'
+import type { DaemonWsDeps } from '../deps.js'
+import { handleLinearCredRequest } from './linearcred.js'
+
+const DAEMON_ID = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
+const OTHER_DAEMON_ID = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
+const AGENT_ID = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const BOT_ID = 'b0b0b0b0-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const INTEGRATION_ID = 'c0c0c0c0-cccc-4ccc-8ccc-cccccccccccc'
+const ORG_ID = 'org-a'
+const EXPIRES = new Date('2026-09-02T00:00:00.000Z')
+
+/** An agent placed on DAEMON_ID — passes the handler's placement scope check. */
+const PLACED_AGENT = { id: AGENT_ID, orgId: ORG_ID, daemonId: DAEMON_ID }
+const LINEAR_INTEGRATION = { id: INTEGRATION_ID, orgId: ORG_ID, agentId: AGENT_ID, botId: BOT_ID, platform: 'linear' }
+/** The connected workspace's D6 pair — what the grant is keyed by (§4.4). */
+const WORKSPACE_BOT = { orgId: ORG_ID, externalAppId: 'lin_client_id', externalTenantId: 'org_alpha' }
+
+function linearcredFrame(): AnyFrame {
+  return {
+    v: 1,
+    id: crypto.randomUUID(),
+    ts: '2026-09-01T00:00:00.000Z',
+    type: 'linearcred/request',
+    payload: { integrationId: INTEGRATION_ID }
+  } as AnyFrame
+}
+
+function fakeConn() {
+  return {
+    daemonId: DAEMON_ID,
+    orgId: ORG_ID,
+    replyTo: vi.fn(),
+    sendError: vi.fn()
+  } as unknown as DaemonConnection & { replyTo: ReturnType<typeof vi.fn>; sendError: ReturnType<typeof vi.fn> }
+}
+
+/** The whole graph the handler reads, with the token service's answer as the one variable. */
+function fakeDeps(
+  accessToken: () => unknown,
+  overrides: Partial<Record<'integration' | 'agent' | 'bot' | 'integrationConverge', unknown>> = {}
+): DaemonWsDeps {
+  return {
+    log: { error: vi.fn() },
+    integration: { get: async () => LINEAR_INTEGRATION },
+    agent: { get: async () => PLACED_AGENT },
+    bot: { get: async () => WORKSPACE_BOT },
+    linearTokens: { accessToken },
+    ...overrides
+  } as unknown as DaemonWsDeps
+}
+
+const GRANTED = () => ({ ok: true, accessToken: 'lin_access_2', expiresAt: EXPIRES, rotated: false })
+
+describe('handleLinearCredRequest — the broker seam (linear-integration.md §7.3)', () => {
+  it('answers a placed agent with the token service’s grant, keyed by the bot’s connection identity', async () => {
+    const accessToken = vi.fn(GRANTED)
+    const deps = fakeDeps(accessToken)
+    const conn = fakeConn()
+    const frame = linearcredFrame()
+
+    await handleLinearCredRequest(frame, conn, deps)
+
+    expect(accessToken).toHaveBeenCalledWith({
+      orgId: ORG_ID,
+      clientId: 'lin_client_id',
+      organizationId: 'org_alpha'
+    })
+    expect(conn.replyTo).toHaveBeenCalledWith(frame, 'linearcred/grant', {
+      accessToken: 'lin_access_2',
+      expiresAt: EXPIRES.toISOString()
+    })
+    expect(conn.sendError).not.toHaveBeenCalled()
+  })
+
+  it('refuses a daemon that does not serve the integration’s agent — terminal, so it stops asking', async () => {
+    const accessToken = vi.fn(GRANTED)
+    const conn = fakeConn()
+    const deps = fakeDeps(accessToken, {
+      agent: { get: async () => ({ ...PLACED_AGENT, daemonId: OTHER_DAEMON_ID }) }
+    })
+
+    await handleLinearCredRequest(linearcredFrame(), conn, deps)
+
+    expect(accessToken).not.toHaveBeenCalled()
+    expect(conn.sendError).toHaveBeenCalledWith(
+      expect.any(String),
+      'SCOPE_DENIED',
+      'this daemon does not serve that agent',
+      false
+    )
+  })
+
+  it('refuses a missing or non-linear integration before it resolves any credential', async () => {
+    for (const integration of [null, { ...LINEAR_INTEGRATION, platform: 'slack' }]) {
+      const accessToken = vi.fn(GRANTED)
+      const conn = fakeConn()
+      await handleLinearCredRequest(
+        linearcredFrame(),
+        conn,
+        fakeDeps(accessToken, { integration: { get: async () => integration } })
+      )
+      expect(accessToken).not.toHaveBeenCalled()
+      expect(conn.sendError).toHaveBeenCalledWith(expect.any(String), 'SCOPE_DENIED', expect.any(String), false)
+    }
+  })
+
+  it('refuses everything when the control plane composes no token service', async () => {
+    const conn = fakeConn()
+    const deps = {
+      log: { error: vi.fn() },
+      integration: { get: async () => LINEAR_INTEGRATION }
+    } as unknown as DaemonWsDeps
+
+    await handleLinearCredRequest(linearcredFrame(), conn, deps)
+
+    expect(conn.sendError).toHaveBeenCalledWith(
+      expect.any(String),
+      'SCOPE_DENIED',
+      'linear workspaces are not enabled on this control plane',
+      false
+    )
+  })
+
+  it('reads an incomplete D6 pair as a connection only an operator can repair', async () => {
+    const accessToken = vi.fn(GRANTED)
+    const conn = fakeConn()
+    const deps = fakeDeps(accessToken, { bot: { get: async () => ({ orgId: ORG_ID }) } })
+
+    await handleLinearCredRequest(linearcredFrame(), conn, deps)
+
+    expect(accessToken).not.toHaveBeenCalled()
+    expect(conn.sendError).toHaveBeenCalledWith(expect.any(String), 'LEASE_DENIED', expect.any(String), false)
+  })
+
+  it('separates a dead grant from an unreachable Linear — only the first is terminal', async () => {
+    for (const reason of ['reconnect_required', 'not_connected'] as const) {
+      const conn = fakeConn()
+      await handleLinearCredRequest(
+        linearcredFrame(),
+        conn,
+        fakeDeps(() => ({ ok: false, reason }))
+      )
+      expect(conn.sendError).toHaveBeenCalledWith(
+        expect.any(String),
+        'LEASE_DENIED',
+        'this Linear workspace needs reconnecting',
+        false
+      )
+      expect(conn.replyTo).not.toHaveBeenCalled()
+    }
+
+    const conn = fakeConn()
+    await handleLinearCredRequest(
+      linearcredFrame(),
+      conn,
+      fakeDeps(() => ({ ok: false, reason: 'unreachable' }))
+    )
+    expect(conn.sendError).toHaveBeenCalledWith(expect.any(String), 'INTERNAL', 'linear is unreachable', true)
+  })
+
+  it('answers a thrown token resolution as retryable rather than letting it close the socket', async () => {
+    const conn = fakeConn()
+    const deps = fakeDeps(() => {
+      throw new Error('postgres is down')
+    })
+
+    await expect(handleLinearCredRequest(linearcredFrame(), conn, deps)).resolves.toBeUndefined()
+
+    expect(conn.sendError).toHaveBeenCalledWith(expect.any(String), 'INTERNAL', 'linear token resolution failed', true)
+  })
+})
+
+describe('handleLinearCredRequest — the spec re-push (§7.3)', () => {
+  it('re-pushes only when the grant rotated, so an unchanged token costs no fan-out', async () => {
+    const integrationConverge = vi.fn(async () => {})
+    const conn = fakeConn()
+
+    await handleLinearCredRequest(linearcredFrame(), conn, fakeDeps(GRANTED, { integrationConverge }))
+    expect(integrationConverge).not.toHaveBeenCalled()
+
+    await handleLinearCredRequest(
+      linearcredFrame(),
+      conn,
+      fakeDeps(() => ({ ...GRANTED(), rotated: true }), { integrationConverge })
+    )
+    expect(integrationConverge).toHaveBeenCalledWith(PLACED_AGENT)
+  })
+
+  it('keeps a grant that already landed when the re-push fails — the roster converges it later', async () => {
+    const integrationConverge = vi.fn(async () => {
+      throw new Error('no connection')
+    })
+    const conn = fakeConn()
+    const deps = fakeDeps(() => ({ ...GRANTED(), rotated: true }), { integrationConverge })
+
+    await expect(handleLinearCredRequest(linearcredFrame(), conn, deps)).resolves.toBeUndefined()
+
+    expect(conn.replyTo).toHaveBeenCalledWith(expect.anything(), 'linearcred/grant', expect.anything())
+    expect(conn.sendError).not.toHaveBeenCalled()
+  })
+})

--- a/packages/control-plane/src/ws/handlers/linearcred.ts
+++ b/packages/control-plane/src/ws/handlers/linearcred.ts
@@ -1,0 +1,102 @@
+/**
+ * `linearcred/request` handler — D→C REQ → `linearcred/grant` REP
+ * (docs/designs/linear-integration.md §4.4, §7.3).
+ *
+ * The split the design names: CORE owns the frame family and the scope check — the named
+ * integration must be a Linear one of the frame's org, and the requesting daemon must currently
+ * serve its agent — while the PROVIDER's token service owns the work (single-flight refresh,
+ * durable persist of the rotated pair before it answers). Nothing here re-implements either.
+ *
+ * DATA-PLANE path, exactly as `gitcred` is (resource-visibility §9 exemption): the reads are the
+ * viewer-free point reads plus a placement comparison, never canView / visibilityWhere. A
+ * restricted-but-active agent still posts activities into its workspace.
+ *
+ * Retransmit idempotency comes from the same place gitcred's does — the daemon re-sends one frame
+ * id and the CP does not dedupe, so duplicates are absorbed by the token service's single-flight
+ * and collapse onto one upstream rotate.
+ *
+ * A rotation invalidates the token EVERY member's `agent.json` holds, so a rotated grant rides
+ * `integrationConverge` — the same re-push a gating flip takes, whose http-bot arm re-broadcasts
+ * the workspace bot and re-pushes its specs. Best-effort: a failed push self-heals from the
+ * reconcile roster on the daemon's next connect, and must never fail the grant that already landed.
+ *
+ * The grant payload carries the token MATERIAL — never log it.
+ */
+import { isFrame } from '@agentconnect.md/protocol'
+import { PLACEMENT_ONLY } from '../../orchestrator/placementResolver.js'
+import { linearConnectionIdentity } from '../../platforms/linear/provider.js'
+import { AgentId, IntegrationId } from '../../domain/ids.js'
+import { frameOrgId } from './frame-org.js'
+import type { Handler } from './index.js'
+
+export const handleLinearCredRequest: Handler = async (frame, conn, deps) => {
+  if (!isFrame('linearcred/request')(frame)) return
+  const { integrationId } = frame.payload
+
+  if (!deps.linearTokens || !deps.bot) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'linear workspaces are not enabled on this control plane', false)
+    return
+  }
+
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'organization is required', false)
+    return
+  }
+
+  // Org-fenced, so a foreign-org integration is indistinguishable from a missing one. A non-linear
+  // row is refused rather than resolved: the grant would be a credential for another platform.
+  const integration = await deps.integration.get(orgId, IntegrationId(integrationId))
+  if (!integration || integration.platform !== 'linear') {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'not a linear integration of this organization', false)
+    return
+  }
+
+  // Service scope (§7.3): the requesting daemon must serve the integration's agent — its placement,
+  // or a duty it holds. One that lost it gets a terminal SCOPE_DENIED and stops asking.
+  const agent = await deps.agent.get(orgId, AgentId(integration.agentId))
+  if (!agent || !(await (deps.placementResolver ?? PLACEMENT_ONLY).mayAct(agent, conn.daemonId))) {
+    conn.sendError(frame.id, 'SCOPE_DENIED', 'this daemon does not serve that agent', false)
+    return
+  }
+
+  // The grant belongs to the connection identity, not the bot row (§4.4) — an incomplete D6 pair is
+  // an install that never finished, which only an operator reconnect repairs.
+  const bot = await deps.bot.get(orgId, integration.botId)
+  const identity = bot ? linearConnectionIdentity(bot) : null
+  if (!identity) {
+    conn.sendError(frame.id, 'LEASE_DENIED', 'this Linear workspace connection is incomplete', false)
+    return
+  }
+
+  let resolution
+  try {
+    resolution = await deps.linearTokens.accessToken(identity)
+  } catch {
+    conn.sendError(frame.id, 'INTERNAL', 'linear token resolution failed', true)
+    return
+  }
+  if (!resolution.ok) {
+    // `unreachable` is a blip, never proof the grant is dead — retryable, and it leaves the daemon
+    // running on the token it still has. The other two need an operator reconnect.
+    if (resolution.reason === 'unreachable') {
+      conn.sendError(frame.id, 'INTERNAL', 'linear is unreachable', true)
+      return
+    }
+    conn.sendError(frame.id, 'LEASE_DENIED', 'this Linear workspace needs reconnecting', false)
+    return
+  }
+
+  conn.replyTo(frame, 'linearcred/grant', {
+    accessToken: resolution.accessToken,
+    expiresAt: resolution.expiresAt.toISOString()
+  })
+
+  if (resolution.rotated && deps.integrationConverge) {
+    try {
+      await deps.integrationConverge(agent)
+    } catch (err) {
+      deps.log.error({ integrationId, err: (err as Error).message }, 'linearcred: spec re-push failed')
+    }
+  }
+}

--- a/packages/control-plane/test/fakes/build-ws.ts
+++ b/packages/control-plane/test/fakes/build-ws.ts
@@ -74,7 +74,12 @@ import { createTelegramCpProvider } from '../../src/platforms/telegram/provider.
 import { createDiscordCpProvider } from '../../src/platforms/discord/provider.js'
 import { createFeishuCpProvider } from '../../src/platforms/feishu/provider.js'
 import { createLinearCpProvider } from '../../src/platforms/linear/provider.js'
+import { LinearApiClient } from '../../src/platforms/linear/api.js'
+import { LinearTokenService } from '../../src/platforms/linear/token-service.js'
 import { PgLinearTokenStore } from '../../src/persistence/repositories/linear.repo.js'
+import { AgentDelivery } from '../../src/orchestrator/agentDelivery.js'
+import { convergeIntegrationGating } from '../../src/orchestrator/integrationPush.js'
+import type { FetchLike } from '../../src/github/api.js'
 
 /** The deployment Linear app this harness composes — a test seeds a bot identity matching it. */
 export const TEST_LINEAR_APP = {
@@ -96,6 +101,10 @@ export interface WsHarness {
   visibilityReplays: string[]
   /** Every relay-facing collab-routes push, in order — the peer directory as a relay would hold it. */
   collabSnapshots: CollabRoutesSnapshot[]
+  /** Bots the integration converge re-synced, in order — the http-bot spec re-push as an effect. */
+  httpBotSyncs: string[]
+  /** Linear's OAuth edge, stubbed. Read THROUGH on every call, so a suite swaps it after building. */
+  linearStubs: { fetch?: FetchLike }
   /** The resolver the projections read through — lets a test ask what the peer directory would
    *  publish right now without reaching through the orchestrator. */
   placement: PlacementResolver
@@ -134,6 +143,21 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
   const clock = new FakeClock(opts.startMs ?? 1_700_000_000_000)
 
   const cipher = new PlaintextSecretCipher()
+  const linearTokenStore = new PgLinearTokenStore(prisma, cipher)
+  // Read THROUGH on every call rather than captured, so a suite can script Linear after building.
+  const linearStubs: { fetch?: FetchLike } = {}
+  // ONE token service over the harness's own store, as the container composes one (§4.4).
+  const linearTokens = new LinearTokenService({
+    app: TEST_LINEAR_APP,
+    tokens: linearTokenStore,
+    api: new LinearApiClient({
+      clock,
+      fetchImpl: (url, init) =>
+        linearStubs.fetch ? linearStubs.fetch(url, init) : Promise.reject(new Error('linear is not stubbed'))
+    }),
+    clock,
+    log: { warn: () => undefined }
+  })
   // §9: reconcile projects every `IntegrationSpec.config` through the platform registry, so the WS
   // fake composes the same providers prod registers. Their verify seams are offline stubs — the
   // projectors call none of them — but Linear's projector DOES read its own store, so it gets the
@@ -143,7 +167,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     createTelegramCpProvider({ verifyBot: async () => ({ status: 'unreachable' }) }),
     createDiscordCpProvider({ ensureMessageContentIntent: async () => 'ready' }),
     createFeishuCpProvider({}),
-    createLinearCpProvider({ app: TEST_LINEAR_APP, tokens: new PgLinearTokenStore(prisma, cipher) })
+    createLinearCpProvider({ app: TEST_LINEAR_APP, tokens: linearTokenStore, tokenService: linearTokens })
   ])
   const repos = {
     daemon: new PgDaemonRepo(prisma),
@@ -229,6 +253,18 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     dutyGroupRepo,
     clock
   )
+  const specs = new AgentSpecAssembler(
+    repos.agentSecret,
+    {},
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    new PgAgentRepoAuthorizationRepo(prisma),
+    opts.gitlabBaseUrl,
+    repos.hook
+  )
   const orchestrator = new Placement(
     repos.daemon,
     repos.agent,
@@ -237,18 +273,7 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     repos.lease,
     repos.integration,
     repos.botSecret,
-    new AgentSpecAssembler(
-      repos.agentSecret,
-      {},
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      new PgAgentRepoAuthorizationRepo(prisma),
-      opts.gitlabBaseUrl,
-      repos.hook
-    ),
+    specs,
     repos.integrationChannel,
     repos.bot,
     PLATFORMS,
@@ -289,10 +314,14 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     } as unknown as RelayControlSender,
     placementResolver
   )
+  // The http-bot converge as an observable effect: `syncBot` is where a Linear workspace's specs
+  // are re-pushed, so a test asserts on the bot ids rather than on an internal seam.
+  const httpBotSyncs: string[] = []
+  const httpBot = { syncBot: async (botId: string) => void httpBotSyncs.push(botId) }
   const agentRouting = new AgentRoutingConverger({
     hooks: hookService,
     collabRoutes,
-    httpBot: { syncBot: async () => {} },
+    httpBot,
     agents: repos.agent,
     integrations: repos.integration,
     bots: repos.bot,
@@ -339,6 +368,24 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     usageWriter: new SessionUsageWriter(repos.sessionUsage),
     integration: repos.integration,
     integrationChannel: repos.integrationChannel,
+    bot: repos.bot,
+    linearTokens,
+    // The REAL converge a rotated `linearcred` grant rides — its http-bot arm reaches `syncBot`.
+    integrationConverge: (agent) =>
+      convergeIntegrationGating(
+        {
+          repos: {
+            integration: repos.integration,
+            bot: repos.bot,
+            botSecret: repos.botSecret,
+            integrationChannel: repos.integrationChannel
+          },
+          agentDelivery: new AgentDelivery({ control: sender, specs, placement: placementResolver }),
+          httpBot,
+          platforms: PLATFORMS
+        },
+        agent
+      ),
     agentMutations: new AgentMutationGate(),
     recoverStagedAgent: async () => {},
     collabRoutes,
@@ -365,6 +412,8 @@ export function buildWsHarness(prisma: PrismaClient, opts: HarnessOpts = {}): Ws
     hookRemovals,
     visibilityReplays,
     collabSnapshots,
+    httpBotSyncs,
+    linearStubs,
     placement: placementResolver,
     codec,
     mintPoolMember: async (daemonId: string) => {

--- a/packages/control-plane/test/integration/linear-connect.route.test.ts
+++ b/packages/control-plane/test/integration/linear-connect.route.test.ts
@@ -154,6 +154,7 @@ function storeWith(base: LinearTokenStore, overrides: Partial<LinearTokenStore>)
   return {
     get: (i) => base.get(i),
     put: (i, m) => base.put(i, m),
+    rotate: (i, u, m) => base.rotate(i, u, m),
     delete: (i) => base.delete(i),
     listOrphans: (c, s, l) => base.listOrphans(c, s, l),
     withIdentityLock: (i, act) => base.withIdentityLock(i, act),

--- a/packages/control-plane/test/protocol/linearcred.handler.test.ts
+++ b/packages/control-plane/test/protocol/linearcred.handler.test.ts
@@ -1,0 +1,237 @@
+/**
+ * The `linearcred` broker over the real daemon WS edge, real Postgres, and a scripted Linear
+ * (linear-integration.md §4.4, §7.3).
+ *
+ * Three claims the unit tests cannot make, because each is about a durable row:
+ *
+ *  - PERSIST BEFORE REPLY. A near-expiry grant rotates upstream, and the rotated pair is written
+ *    durably BEFORE the daemon sees the token. Replying first would strand a workspace holding a
+ *    refresh token Linear has already spent, so the ordering is asserted as an ordering — not as
+ *    "the row happens to be right afterwards".
+ *  - THE RE-PUSH RIDES THE SHARED CONVERGE. One rotation invalidates the token in every member's
+ *    `agent.json`, so the grant is followed by the same integration converge a gating flip takes,
+ *    whose http-bot arm re-syncs the workspace bot.
+ *  - THE SCOPE CHECK IS PLACEMENT, NOT POSSESSION. A daemon that does not serve the integration's
+ *    agent is refused terminally even though the grant it asked for exists and is perfectly live.
+ */
+import { describe, it, expect } from 'vitest'
+import { isFrame } from '@agentconnect.md/protocol'
+import { prisma } from '../setup.db.js'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { buildWsHarness, TEST_LINEAR_APP } from '../fakes/build-ws.js'
+import { InMemoryDaemonStub } from '../fakes/daemon-stub.js'
+import { PgLinearTokenStore } from '../../src/persistence/repositories/linear.repo.js'
+import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
+import { LinearApiClient } from '../../src/platforms/linear/api.js'
+import { LinearTokenService } from '../../src/platforms/linear/token-service.js'
+import { OrgId } from '../../src/domain/ids.js'
+import type { LinearTokenStore } from '../../src/persistence/ports.js'
+
+const DAEMON = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const FOREIGN_DAEMON = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+const AGENT = 'a1a1a1a1-a1a1-4a1a-8a1a-a1a1a1a1a1a1'
+const BOT = 'e5e5e5e5-e5e5-4e5e-8e5e-e5e5e5e5e5e5'
+const INTEGRATION = 'f6f6f6f6-f6f6-4f6f-8f6f-f6f6f6f6f6f6'
+const WORKSPACE = 'org_alpha'
+
+const identity = { orgId: OrgId(DEFAULT_ORG_ID), clientId: TEST_LINEAR_APP.clientId, organizationId: WORKSPACE }
+const store = () => new PgLinearTokenStore(prisma, new PlaintextSecretCipher())
+
+/** The harness clock's now, so "fresh" and "near expiry" are stated against the same clock the
+ *  refresh margin is measured on rather than against wall time. */
+const NOW = 1_700_000_000_000
+const FRESH = new Date(NOW + 20 * 60 * 60 * 1000)
+const NEAR_EXPIRY = new Date(NOW + 30 * 60 * 1000)
+
+/** A connected workspace with one enabled agent placed on `daemonId`, and a stored grant. */
+async function seedConnectedWorkspace(expiresAt: Date, daemonId = DAEMON): Promise<void> {
+  for (const id of new Set([daemonId, DAEMON])) {
+    await prisma.daemon.create({
+      data: { id, orgId: DEFAULT_ORG_ID, sessionEpoch: 1n, routingEpoch: 1n, maxAgents: 4, status: 'ready' }
+    })
+  }
+  await prisma.agent.create({
+    data: { id: AGENT, orgId: DEFAULT_ORG_ID, name: 'agent-1', runtime: 'claude', daemonId }
+  })
+  await prisma.bot.create({
+    data: {
+      id: BOT,
+      orgId: DEFAULT_ORG_ID,
+      platform: 'linear',
+      name: 'Acme Engineering',
+      transport: 'http',
+      shareable: true,
+      workspaceId: WORKSPACE,
+      workspaceName: 'Acme Engineering',
+      botUserId: 'user_app_1',
+      externalAppId: TEST_LINEAR_APP.clientId,
+      externalTenantId: WORKSPACE
+    }
+  })
+  await prisma.botSecret.create({
+    data: { botId: BOT, botToken: TEST_LINEAR_APP.clientSecret, signingSecret: TEST_LINEAR_APP.signingSecret }
+  })
+  await prisma.integration.create({
+    data: {
+      id: INTEGRATION,
+      orgId: DEFAULT_ORG_ID,
+      agentId: AGENT,
+      botId: BOT,
+      platform: 'linear',
+      name: 'Acme Engineering',
+      status: 'active'
+    }
+  })
+  await store().put(identity, { accessToken: 'lin_access_1', refreshToken: 'lin_refresh_1', expiresAt })
+}
+
+/** A Linear whose `/oauth/token` answer is the test's variable, with a log of what was asked. */
+function fakeLinear(answer: () => { status: number; body: unknown }) {
+  const calls: string[] = []
+  return {
+    calls,
+    fetchImpl: (url: string, init?: RequestInit): Promise<Response> => {
+      calls.push(String(url))
+      const { status, body } = answer()
+      return Promise.resolve(
+        new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+      )
+    }
+  }
+}
+
+const ROTATED = () => ({
+  status: 200,
+  body: { access_token: 'lin_access_2', refresh_token: 'lin_refresh_2', expires_in: 86400 }
+})
+
+async function ready(h: ReturnType<typeof buildWsHarness>, daemonId: string, stub = new InMemoryDaemonStub()) {
+  const token = await h.mintToken(daemonId)
+  h.connect(stub)
+  stub.inject('auth', { apiKey: token, daemonId, agentVersion: '1.4.0' })
+  await stub.expectFrame('auth/ok')
+  stub.inject('register', {
+    host: 'daemon-1',
+    capabilities: { platforms: ['linear'], runtimes: ['claude'], acp: true, features: [] },
+    maxAgents: 4,
+    localState: { assignments: [], crons: [], leases: [], agents: [], integrations: [], stagedAgents: [] }
+  })
+  await stub.expectFrame('register/ok')
+  return stub
+}
+
+function grantOf(stub: InMemoryDaemonStub, id: string) {
+  const rep = stub.sent.find((f) => f.corr === id && f.type === 'linearcred/grant')
+  return rep && isFrame('linearcred/grant')(rep) ? rep.payload : undefined
+}
+
+function errorOf(stub: InMemoryDaemonStub, id: string) {
+  const rep = stub.sent.find((f) => f.corr === id && f.type === 'error')
+  return rep && isFrame('error')(rep) ? rep.payload : undefined
+}
+
+describe('linearcred/request over the daemon WS edge', () => {
+  it('grants the stored token to the placed daemon without touching Linear', async () => {
+    await seedConnectedWorkspace(FRESH)
+    const h = buildWsHarness(prisma, { startMs: NOW })
+    const linear = fakeLinear(ROTATED)
+    h.linearStubs.fetch = linear.fetchImpl
+    const stub = await ready(h, DAEMON)
+
+    const id = stub.inject('linearcred/request', { integrationId: INTEGRATION })
+    await stub.settled()
+
+    expect(grantOf(stub, id)).toEqual({ accessToken: 'lin_access_1', expiresAt: FRESH.toISOString() })
+    // A token that is nowhere near expiry is not a reason to spend a refresh token.
+    expect(linear.calls).toEqual([])
+    expect(h.httpBotSyncs).toEqual([])
+  })
+
+  it('refuses a daemon that does not serve the agent, however live the grant is', async () => {
+    await seedConnectedWorkspace(FRESH)
+    const h = buildWsHarness(prisma, { startMs: NOW })
+    h.linearStubs.fetch = fakeLinear(ROTATED).fetchImpl
+    const stub = await ready(h, FOREIGN_DAEMON)
+
+    const id = stub.inject('linearcred/request', { integrationId: INTEGRATION })
+    await stub.settled()
+
+    expect(grantOf(stub, id)).toBeUndefined()
+    expect(errorOf(stub, id)).toMatchObject({ code: 'SCOPE_DENIED', retryable: false })
+  })
+
+  it('answers a refresh Linear definitively rejects with a terminal LEASE_DENIED', async () => {
+    await seedConnectedWorkspace(NEAR_EXPIRY)
+    const h = buildWsHarness(prisma, { startMs: NOW })
+    h.linearStubs.fetch = fakeLinear(() => ({ status: 400, body: { error: 'invalid_grant' } })).fetchImpl
+    const stub = await ready(h, DAEMON)
+
+    const id = stub.inject('linearcred/request', { integrationId: INTEGRATION })
+    await stub.settled()
+
+    expect(grantOf(stub, id)).toBeUndefined()
+    // Terminal: only an operator reconnect can repair it, so the daemon must stop asking.
+    expect(errorOf(stub, id)).toMatchObject({ code: 'LEASE_DENIED', retryable: false })
+    expect(h.httpBotSyncs).toEqual([])
+  })
+
+  it('leaves an unreachable Linear retryable — a blip is not proof the grant is dead', async () => {
+    await seedConnectedWorkspace(NEAR_EXPIRY)
+    const h = buildWsHarness(prisma, { startMs: NOW })
+    h.linearStubs.fetch = () => Promise.reject(new Error('connect ECONNREFUSED'))
+    const stub = await ready(h, DAEMON)
+
+    const id = stub.inject('linearcred/request', { integrationId: INTEGRATION })
+    await stub.settled()
+
+    expect(errorOf(stub, id)).toMatchObject({ code: 'INTERNAL', retryable: true })
+    // The stored grant is untouched: the daemon keeps running on the token it still holds.
+    expect(await store().get(identity)).toMatchObject({ accessToken: 'lin_access_1' })
+  })
+
+  it('persists the rotated pair BEFORE the grant frame, then re-pushes the workspace bot’s specs', async () => {
+    await seedConnectedWorkspace(NEAR_EXPIRY)
+    const h = buildWsHarness(prisma, { startMs: NOW })
+    const linear = fakeLinear(ROTATED)
+
+    // The ordering is observed on the two events themselves — the durable write and the frame —
+    // rather than by reading the row after the fact, which cannot tell the two orders apart.
+    const order: string[] = []
+    const base = store()
+    const observed: LinearTokenStore = {
+      get: (i) => base.get(i),
+      put: async (i, m) => {
+        await base.put(i, m)
+        order.push('persisted')
+      },
+      delete: (i) => base.delete(i),
+      listOrphans: (c, s, l) => base.listOrphans(c, s, l),
+      withIdentityLock: (i, act) => base.withIdentityLock(i, act)
+    }
+    h.deps.linearTokens = new LinearTokenService({
+      app: TEST_LINEAR_APP,
+      tokens: observed,
+      api: new LinearApiClient({ clock: h.clock, fetchImpl: linear.fetchImpl }),
+      clock: h.clock
+    })
+    const stub = new InMemoryDaemonStub()
+    const send = stub.send.bind(stub)
+    stub.send = (text: string) => {
+      if (text.includes('linearcred/grant')) order.push('granted')
+      send(text)
+    }
+    await ready(h, DAEMON, stub)
+
+    const id = stub.inject('linearcred/request', { integrationId: INTEGRATION })
+    await stub.settled()
+
+    expect(order).toEqual(['persisted', 'granted'])
+    expect(grantOf(stub, id)).toMatchObject({ accessToken: 'lin_access_2' })
+    expect(await store().get(identity)).toMatchObject({
+      accessToken: 'lin_access_2',
+      refreshToken: 'lin_refresh_2'
+    })
+    // The rotation invalidated the token in every member's `agent.json`, so the shared converge runs.
+    expect(h.httpBotSyncs).toEqual([BOT])
+  })
+})

--- a/packages/control-plane/test/protocol/linearcred.handler.test.ts
+++ b/packages/control-plane/test/protocol/linearcred.handler.test.ts
@@ -24,7 +24,8 @@ import { PgLinearTokenStore } from '../../src/persistence/repositories/linear.re
 import { PlaintextSecretCipher } from '../../src/secrets/cipher.js'
 import { LinearApiClient } from '../../src/platforms/linear/api.js'
 import { LinearTokenService } from '../../src/platforms/linear/token-service.js'
-import { OrgId } from '../../src/domain/ids.js'
+import { createLinearCpProvider } from '../../src/platforms/linear/provider.js'
+import { BotId, OrgId } from '../../src/domain/ids.js'
 import type { LinearTokenStore } from '../../src/persistence/ports.js'
 
 const DAEMON = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
@@ -85,17 +86,35 @@ async function seedConnectedWorkspace(expiresAt: Date, daemonId = DAEMON): Promi
   await store().put(identity, { accessToken: 'lin_access_1', refreshToken: 'lin_refresh_1', expiresAt })
 }
 
-/** A Linear whose `/oauth/token` answer is the test's variable, with a log of what was asked. */
+/**
+ * A Linear whose `/oauth/token` answer is the test's variable, with a log of what was asked.
+ *
+ * `park()` makes the upstream call block until `release()`, which is what turns "the world moved
+ * while the refresh was in flight" from a race into a schedule: the test does the disconnect or the
+ * reconnect while the call is parked, and the rotation's write lands strictly after it.
+ */
 function fakeLinear(answer: () => { status: number; body: unknown }) {
   const calls: string[] = []
+  let gate: Promise<void> | undefined
+  let open: (() => void) | undefined
+  let entered: (() => void) | undefined
+  const arrived = new Promise<void>((resolve) => (entered = resolve))
   return {
     calls,
-    fetchImpl: (url: string, init?: RequestInit): Promise<Response> => {
+    arrived,
+    park(): void {
+      gate = new Promise<void>((resolve) => (open = resolve))
+    },
+    release(): void {
+      open?.()
+      gate = undefined
+    },
+    fetchImpl: async (url: string, init?: RequestInit): Promise<Response> => {
       calls.push(String(url))
+      entered?.()
       const { status, body } = answer()
-      return Promise.resolve(
-        new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
-      )
+      if (gate) await gate
+      return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
     }
   }
 }
@@ -200,9 +219,11 @@ describe('linearcred/request over the daemon WS edge', () => {
     const base = store()
     const observed: LinearTokenStore = {
       get: (i) => base.get(i),
-      put: async (i, m) => {
-        await base.put(i, m)
-        order.push('persisted')
+      put: (i, m) => base.put(i, m),
+      rotate: async (i, e, m) => {
+        const applied = await base.rotate(i, e, m)
+        if (applied.outcome === 'rotated') order.push('persisted')
+        return applied
       },
       delete: (i) => base.delete(i),
       listOrphans: (c, s, l) => base.listOrphans(c, s, l),
@@ -232,6 +253,76 @@ describe('linearcred/request over the daemon WS edge', () => {
       refreshToken: 'lin_refresh_2'
     })
     // The rotation invalidated the token in every member's `agent.json`, so the shared converge runs.
+    expect(h.httpBotSyncs).toEqual([BOT])
+  })
+})
+
+/**
+ * The refresh issues its rotation upstream and can only store it a round trip later, so the world
+ * it read is not necessarily the world it writes into. Both hazards below are that gap, and both
+ * die on the same property: the write is a compare-and-set on the row the flight read, so it
+ * matches nothing once someone else has moved the identity on — and an UPDATE cannot create a row.
+ */
+describe('a refresh whose world moved while it was in flight', () => {
+  it('never resurrects a workspace disconnected mid-refresh, and answers LEASE_DENIED', async () => {
+    await seedConnectedWorkspace(NEAR_EXPIRY)
+    const h = buildWsHarness(prisma, { startMs: NOW })
+    const linear = fakeLinear(ROTATED)
+    h.linearStubs.fetch = linear.fetchImpl
+    const stub = await ready(h, DAEMON)
+
+    linear.park()
+    const id = stub.inject('linearcred/request', { integrationId: INTEGRATION })
+    await linear.arrived
+
+    // The real disconnect edge, on the real bot row: `onBotDelete` removes the grant inside ONE
+    // hold of the identity's advisory lock. It completes while the rotation is still upstream.
+    const bot = await h.deps.bot!.get(OrgId(DEFAULT_ORG_ID), BotId(BOT))
+    const provider = createLinearCpProvider({ app: TEST_LINEAR_APP, tokens: store() })
+    await provider.sideEffects!.onBotDelete!(bot!, null)
+    expect(await store().get(identity)).toBeNull()
+
+    linear.release()
+    await stub.settled()
+
+    // The delayed write found nothing to update and created nothing. Had it been an upsert, the
+    // row would be back here — a live grant for a workspace whose install is gone.
+    expect(await store().get(identity)).toBeNull()
+    expect(grantOf(stub, id)).toBeUndefined()
+    expect(errorOf(stub, id)).toMatchObject({ code: 'LEASE_DENIED', retryable: false })
+    // Nothing to converge: no spec projects a grant that no longer exists.
+    expect(h.httpBotSyncs).toEqual([])
+  })
+
+  it('adopts a reconnect’s newer grant instead of overwriting it with the older rotation', async () => {
+    await seedConnectedWorkspace(NEAR_EXPIRY)
+    const h = buildWsHarness(prisma, { startMs: NOW })
+    const linear = fakeLinear(ROTATED)
+    h.linearStubs.fetch = linear.fetchImpl
+    const stub = await ready(h, DAEMON)
+
+    linear.park()
+    const id = stub.inject('linearcred/request', { integrationId: INTEGRATION })
+    await linear.arrived
+
+    // The §7.4 reconnect's step-1 upsert lands while the rotation is still upstream. Its pair is
+    // the one Linear now honors; the rotation in flight belongs to the generation it replaced.
+    await store().put(identity, {
+      accessToken: 'lin_access_reconnect',
+      refreshToken: 'lin_refresh_reconnect',
+      expiresAt: FRESH
+    })
+
+    linear.release()
+    await stub.settled()
+
+    // Not clobbered — and the daemon is handed the grant that actually works, not the discarded one.
+    expect(await store().get(identity)).toMatchObject({
+      accessToken: 'lin_access_reconnect',
+      refreshToken: 'lin_refresh_reconnect'
+    })
+    expect(grantOf(stub, id)).toEqual({ accessToken: 'lin_access_reconnect', expiresAt: FRESH.toISOString() })
+    // Newer than what the specs project, so it still owes the re-push.
     expect(h.httpBotSyncs).toEqual([BOT])
   })
 })


### PR DESCRIPTION
The last control-plane leg for Linear (docs/designs/linear-integration.md §7.3): the `linearcred/request` handler on the daemon WS, mirroring the `gitcred` seam.

- Resolution chain: org-fenced integration read → non-Linear/foreign-org refused (`SCOPE_DENIED`) → placement checked via `placementResolver.mayAct` (the gitcred predicate — a pool member serves agents its row does not name, so the design's literal daemon-id equality was corrected in §7.3) → the bot's D6 connection identity → `LinearTokenService.accessToken`, which already single-flights and persists the rotated pair before returning.
- Error vocabulary per the frame module's header: terminal refresh death (`reconnect_required`/`not_connected`, incomplete D6 pair) → `LEASE_DENIED`; transient upstream unavailability → retryable `INTERNAL`; thrown resolutions never close the socket.
- Spec re-push rides the existing `integrationConverge` seam (container-wired to the http-bot `syncBot`), gated on a new `rotated` flag the token service's ok resolution now carries — one rotation stales every workspace member's `agent.json`, and the workspace-wide re-push is exactly what `syncBot` already does. No new mechanism.
- The WS test harness now composes a real `LinearTokenService` over a scriptable fetch, so the integration tests drive the full edge: grant round-trip, foreign-daemon denial, terminal denial, durable-persist-before-reply asserted as an ordering (not an after-the-fact read), and the post-rotation re-push.

Tests: 9 handler unit + 5 WS integration cases; CP typecheck, `test:unit` 2213, `test:int` 1897, lint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
