### PR TITLE
feat(web): Linear platform console module

### DIFF
--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -305,6 +305,9 @@ describe('IntegrationChannelList footer', () => {
   it('names the room with the platform noun throughout', () => {
     expect(footer('telegram')).toContain('A group appears here once the bot is added to it')
     expect(footer('slack')).toContain('A channel appears here once the bot is added to it')
+    // The article follows the module's noun rather than being a literal — one of
+    // them starts with a vowel.
+    expect(footer('linear')).toContain('An issue appears here once the bot is added to it')
   })
 })
 

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -200,6 +200,10 @@ const canLeaveConversation = (platform?: string): boolean => channelListSemantic
  */
 const roomNoun = (platform?: string): string => channelListSemantics(platform).roomNoun
 
+/** "A"/"An" for a noun a module supplies. The room noun is the platform's own word,
+ *  and one of them starts with a vowel ("issue"), so the article cannot be a literal. */
+const roomArticle = (noun: string): string => (/^[aeiou]/i.test(noun) ? 'An' : 'A')
+
 /** The noun for ONE row: a DM is never a channel or a group, whatever the platform. */
 const rowNoun = (kind: IntegrationChannelRow['kind'], platform?: string): string =>
   kind === 'im' ? 'conversation' : kind === 'mpim' ? 'group chat' : roomNoun(platform)
@@ -692,7 +696,7 @@ export function IntegrationChannelList({
               where leaving is done instead. It deliberately no longer narrates the
               menu's own items: those explain themselves on screen, and repeating them
               here in different words was most of what made this card read oddly. */}
-          {`A ${roomNoun(platform)} appears here once the bot is added to it, and its trigger is set per conversation.`}
+          {`${roomArticle(roomNoun(platform))} ${roomNoun(platform)} appears here once the bot is added to it, and its trigger is set per conversation.`}
           {' Direct messages appear when someone writes to the bot.'}
           {shareable && ' Default dispatch is the agent who handles unmatched messages in the conversation.'}
           {/* The platform's own tail, when it has one: Discord's servers-not-channels

--- a/packages/web/src/components/console/MessageText.test.tsx
+++ b/packages/web/src/components/console/MessageText.test.tsx
@@ -138,7 +138,7 @@ const PLATFORM_KEYS = [
   'hook',
   'github',
   'lark',
-  'linear',
+  'zulip',
   'Slack',
   'constructor',
   '__proto__'

--- a/packages/web/src/components/console/modals/AddIntegrationModal.sharing.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.sharing.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+/**
+ * The wizard's "Shared bot" opt-in, per platform. It is a decision on Slack and a
+ * non-decision on Linear: a Bot row there IS one connected workspace and the provider
+ * stamps `shareable` itself (linear-integration.md §4.3), so the reuse path must admit
+ * members WITHOUT the console offering a flag it has no business moving.
+ *
+ * Rendered here rather than asserted on the predicate alone, because "supports sharing"
+ * and "offers a control for it" are the two facts that used to be one value.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { BotDto } from '@/lib/api'
+import type { Agent, DaemonRow } from '@/lib/data'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const mocks = vi.hoisted(() => ({ bots: [] as BotDto[] }))
+
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, orgPath: (path: string) => path })
+}))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    get bots() {
+      return mocks.bots
+    },
+    daemons: [
+      {
+        daemonId: 'd1',
+        pool: false,
+        memberSetId: null,
+        name: 'edge-1',
+        status: 'online',
+        caps: { platforms: ['slack', 'linear'], runtimes: ['claude'], acp: true, features: [] },
+        runtimeModels: [],
+        mcpServers: []
+      } as unknown as DaemonRow
+    ],
+    daemonsLoading: false,
+    memberSets: [],
+    createIntegration: vi.fn(),
+    createHook: vi.fn(),
+    createGithubHook: vi.fn(),
+    createGitlabHook: vi.fn(),
+    refresh: vi.fn(),
+    updateAgent: vi.fn()
+  })
+}))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchAgentHooks: vi.fn(async () => []),
+  fetchAgentRepos: vi.fn(async () => []),
+  fetchSlackConfig: vi.fn(async () => ({
+    configured: false,
+    durable: false,
+    funnelEnabled: false,
+    autoAvailable: false,
+    accessExpiresAt: null,
+    relayAvailable: true,
+    relayPublicUrl: 'https://relay.example.test',
+    platformInstallAvailable: false,
+    updatedAt: null
+  })),
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
+  fetchGithubInstallUrl: vi.fn(async () => null),
+  fetchGitlabProjects: vi.fn(async () => []),
+  fetchGitlabConnections: vi.fn(async () => ({ enabled: false, connections: [] })),
+  searchGitlabProjects: vi.fn(async () => ({ projects: [], nextPage: null }))
+}))
+
+const AddIntegrationModal = (await import('./AddIntegrationModal')).default
+
+const agent = {
+  id: 'agent-a',
+  name: 'pilot',
+  daemon: 'd1',
+  placementKind: 'daemon',
+  setId: null,
+  canEdit: true,
+  workspace: { mode: 'scratch', files: [] }
+} as unknown as Agent
+
+/** A free, http, already-shared bot — what both platforms' reuse lists offer. */
+function bot(over: Partial<BotDto>): BotDto {
+  return {
+    id: 'b1',
+    name: 'workspace',
+    platform: 'slack',
+    prebuilt: false,
+    slackAppId: null,
+    discordAppId: null,
+    createdBy: null,
+    transport: 'http',
+    shareable: true,
+    inUseByAgentId: null,
+    agentIds: [],
+    lastUsedAt: null,
+    freedFromAgent: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...over
+  }
+}
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+const clickByText = async (selector: string, text: string) => {
+  const found = [...document.querySelectorAll<HTMLElement>(selector)].find((el) => el.textContent?.includes(text))
+  if (!found) throw new Error(`no ${selector} containing "${text}"`)
+  await act(async () => found.click())
+}
+
+async function settle(): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  }
+}
+
+/** Open the wizard on `tile` and switch it to the reuse path. */
+async function reusePane(tile: string): Promise<void> {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(<AddIntegrationModal agent={agent} onClose={() => undefined} />)
+  })
+  await settle()
+  await clickByText('.ptile', tile)
+  await clickByText('.ptile', 'Use an existing bot')
+  await settle()
+}
+
+const shareOptIn = () =>
+  [...document.querySelectorAll<HTMLLabelElement>('label')].find((l) => l.textContent?.includes('Shared bot'))
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+  mocks.bots = []
+})
+
+describe('the wizard’s Shared bot opt-in', () => {
+  it('is not offered for a Linear workspace, which is shared structurally', async () => {
+    mocks.bots = [bot({ id: 'ws-1', platform: 'linear', name: 'Example Workspace' })]
+    await reusePane('Linear')
+
+    // The workspace is still offered for reuse — membership is the whole point.
+    expect(document.body.textContent).toContain('Example Workspace')
+    expect(shareOptIn()).toBeUndefined()
+  })
+
+  it('is still offered for Slack, unchanged', async () => {
+    mocks.bots = [bot({ id: 'sl-1', platform: 'slack' })]
+    await reusePane('Slack')
+
+    const optIn = shareOptIn()
+    expect(optIn).toBeDefined()
+    expect(optIn?.textContent).toContain('This bot is already shared.')
+  })
+})

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -661,9 +661,11 @@ export default function AddIntegrationModal({
     setIdentityChrome
   ])
 
-  // Deployment-level public-callback capability. Probed only for platforms that
-  // actually offer a transport choice — the same two panes that read it today.
-  const probe = useDeploymentConfig(wizard?.affordances.transport !== undefined)
+  // Deployment-level public-callback capability, probed for every platform module.
+  // It used to be gated on a transport CHOICE, which left `relayCapability` reading
+  // false for a platform whose single fixed transport is the relay-backed one — the
+  // opposite of the answer that platform needs most.
+  const probe = useDeploymentConfig(wizard !== undefined)
   const relayCapability = useMemo(
     () => ({ available: probe.config?.relayAvailable ?? false, publicUrl: probe.config?.relayPublicUrl ?? null }),
     [probe.config]

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -39,7 +39,11 @@ import {
   type FooterView,
   type IdentityChromeView
 } from '@/components/console/platforms/publish'
-import { platformRegistry, platformSupportsSharing } from '@/components/console/platforms/registry'
+import {
+  platformRegistry,
+  platformSharingFixed,
+  platformSupportsSharing
+} from '@/components/console/platforms/registry'
 import { BOT_PLATFORMS, PLATFORMS, isCoreTriggerKind } from '@/components/console/platforms/host-projections'
 import { agentCapabilitySource, agentLabel, MOCK_MODE, workspaceSourceOf, type Agent } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
@@ -714,9 +718,12 @@ export default function AddIntegrationModal({
   // transport. Existing: gate on the reused bot's own transport (the selector
   // isn't shown for reuse), so a socket bot never offers it. The platform half
   // goes through `platformSupportsSharing` (registry.ts), the same lookup the
-  // Settings → Bots toggle makes, so the two surfaces cannot disagree.
+  // Settings → Bots cell makes, so the two surfaces cannot disagree — including
+  // on a `share: 'fixed'` platform, where the provider stamps the flag and there
+  // is no opt-in to offer on either surface.
   const shareToggleAvailable =
     platformSupportsSharing(platform) &&
+    !platformSharingFixed(platform) &&
     (mode === 'existing' ? (selectedBot?.transport ?? 'socket') === 'http' : transport === 'http')
   // Reusing an already-shared bot is implicitly a shared install.
   const wantShared = shareToggleAvailable && (shared || (mode === 'existing' && !!selectedBot?.shareable))

--- a/packages/web/src/components/console/platforms/bot-card-copy.test.ts
+++ b/packages/web/src/components/console/platforms/bot-card-copy.test.ts
@@ -7,7 +7,11 @@ import { DEFAULT_BOT_CARD_COPY, botCardCopy, platformRegistry } from './registry
  * EVERY platform's rows, so what these pin is the split: Slack's wording
  * unchanged to the byte, and a provider-free default everywhere else.
  */
-const UNCLAIMED = ['linear', 'hook', 'github', 'playground', 'webchat', 'lark', 'Slack', 'constructor', '__proto__', '']
+const UNCLAIMED = ['zulip', 'hook', 'github', 'playground', 'webchat', 'lark', 'Slack', 'constructor', '__proto__', '']
+
+/** The modules that declare copy of their own — every other registered platform
+ *  falls all the way through to the provider-free defaults. */
+const DECLARES_COPY = ['slack', 'linear']
 
 /** Captured from `SettingsView.tsx` before the member existed. */
 const SLACK_REVOKED = 'The Slack workspace uninstalled this app or revoked its tokens — re-install to reconnect'
@@ -26,8 +30,17 @@ describe('Settings → Bots row copy', () => {
     expect(copy.shareHint.unavailable).toBe(SLACK_SHARE_UNAVAILABLE)
   })
 
+  it('names the revocation Linear can actually reach', () => {
+    // The `OAuthApp revoked` doorbell stamps `revokedAt` and flips every membership,
+    // and reconnecting is what repairs it — a lifecycle Linear can describe, unlike
+    // the platforms that can never reach the state at all.
+    const copy = botCardCopy('linear')
+    expect(copy.revokedHint).toBe('This workspace revoked the Linear app — reconnect to restore delivery')
+    expect(copy.identityNoun).toBe('workspace')
+  })
+
   it('gives every other registered platform the provider-free default', () => {
-    for (const id of platformRegistry.ids().filter((p) => p !== 'slack')) {
+    for (const id of platformRegistry.ids().filter((p) => !DECLARES_COPY.includes(p))) {
       const copy = botCardCopy(id)
       expect(copy.revokedHint, id).toBe(DEFAULT_BOT_CARD_COPY.revokedHint)
       expect(copy.shareHint, id).toEqual(DEFAULT_BOT_CARD_COPY.shareHint)
@@ -38,7 +51,7 @@ describe('Settings → Bots row copy', () => {
         .all()
         .filter((m) => m.settingsFragments?.copy)
         .map((m) => m.platformId)
-    ).toEqual(['slack'])
+    ).toEqual(DECLARES_COPY)
   })
 
   it('names no platform in any default', () => {
@@ -50,13 +63,14 @@ describe('Settings → Bots row copy', () => {
     expect(DEFAULT_BOT_CARD_COPY.identityNoun).not.toMatch(PLATFORM_WORDS)
   })
 
-  it('collapses both share arms for a platform that cannot share at all', () => {
-    // The host still picks an arm by transport, but multi-agent bots are
-    // Slack-only at the CP — so on every other platform the arm the host lands
-    // on is not the reason, and one sentence must serve both rather than
-    // promising that switching transport would help.
+  it('collapses both share arms wherever the transport is not the reason', () => {
+    // The host still picks an arm by transport, but Slack is the only platform
+    // where that is why the toggle is off — Telegram/Discord/Feishu cannot share
+    // at all, and a Linear workspace is shared structurally rather than by a
+    // transport choice. One sentence serves both arms rather than promising that
+    // switching transport would help.
     expect(DEFAULT_BOT_CARD_COPY.shareHint.available).toBe(DEFAULT_BOT_CARD_COPY.shareHint.unavailable)
-    for (const id of ['telegram', 'discord', 'feishu']) {
+    for (const id of ['telegram', 'discord', 'feishu', 'linear']) {
       const { available, unavailable } = botCardCopy(id).shareHint
       expect(available, id).toBe(unavailable)
     }

--- a/packages/web/src/components/console/platforms/bot-sharing.test.ts
+++ b/packages/web/src/components/console/platforms/bot-sharing.test.ts
@@ -17,7 +17,13 @@
 
 import { describe, expect, it } from 'vitest'
 import type { BotDto } from '@/lib/api'
-import { botCardCopy, botSharingEditable, platformRegistry, platformSupportsSharing } from './registry'
+import {
+  botCardCopy,
+  botSharingEditable,
+  platformRegistry,
+  platformSharingFixed,
+  platformSupportsSharing
+} from './registry'
 
 /** `platform`/`transport`/`shareable` are the only members either predicate
  *  reads; the rest is here so the fixture stays a real `BotDto`. */
@@ -50,6 +56,10 @@ const UNCLAIMED = ['webhook', 'github', 'playground', 'webchat', 'zulip', 'lark'
  *  `multiAgentShareable` set, mirrored one module at a time. */
 const SHARING_PLATFORMS = ['slack', 'linear']
 
+/** …and the ones where that is STRUCTURAL rather than an operator's opt-in: the
+ *  provider stamps `shareable`, so no console surface offers a control for it. */
+const FIXED_SHARING_PLATFORMS = ['linear']
+
 describe('platformSupportsSharing', () => {
   it('is true for the multi-agent platforms and false for every other registered one', () => {
     for (const id of SHARING_PLATFORMS) expect(platformSupportsSharing(id), id).toBe(true)
@@ -66,16 +76,37 @@ describe('platformSupportsSharing', () => {
   })
 
   it('reads the modules’ single declaration of the fact', () => {
-    // ONE declaration, so the wizard's shared opt-in and the Settings toggle
-    // cannot disagree about a platform. Named, so a module that starts declaring
-    // it is a visible diff here — and a reminder that the CP's own predicate has
-    // to move in the same change.
+    // ONE declaration, so the wizard's shared opt-in and the Settings cell cannot
+    // disagree about a platform. Named, so a module that starts declaring it is a
+    // visible diff here — and a reminder that the CP's own predicate has to move in
+    // the same change.
     expect(
       platformRegistry
         .all()
-        .filter((m) => m.wizard.affordances.share === true)
+        .filter((m) => m.wizard.affordances.share !== undefined)
         .map((m) => m.platformId)
     ).toEqual(SHARING_PLATFORMS)
+  })
+})
+
+describe('platformSharingFixed', () => {
+  it('separates structural sharing from the operator’s opt-in', () => {
+    // Slack's `true` is a decision someone makes; Linear's `'fixed'` is a fact the
+    // provider stamps. Both support sharing — only one is a control.
+    for (const id of FIXED_SHARING_PLATFORMS) {
+      expect(platformSharingFixed(id), id).toBe(true)
+      expect(platformSupportsSharing(id), id).toBe(true)
+    }
+    expect(platformSharingFixed('slack')).toBe(false)
+    expect(platformRegistry.get('slack')?.wizard.affordances.share).toBe(true)
+  })
+
+  it('never grants sharing on its own — it only ever suppresses a control', () => {
+    for (const id of platformRegistry.ids().filter((p) => !FIXED_SHARING_PLATFORMS.includes(p))) {
+      expect(platformSharingFixed(id), id).toBe(false)
+    }
+    for (const id of UNCLAIMED) expect(platformSharingFixed(id), id).toBe(false)
+    expect(platformSharingFixed(undefined)).toBe(false)
   })
 })
 
@@ -84,10 +115,13 @@ describe('botSharingEditable', () => {
     expect(botSharingEditable(bot({ platform: 'slack', transport: 'http' }))).toBe(true)
   })
 
-  it('lets a Linear workspace bot be shared — it is one workspace serving many agents', () => {
-    // The provider stamps `shareable: true` structurally on a connected workspace,
-    // so the toggle exists to turn multi-agent membership OFF, not to earn it.
-    expect(botSharingEditable(bot({ platform: 'linear', transport: 'http' }))).toBe(true)
+  it('never lets a Linear workspace’s structural sharing be operated', () => {
+    // The provider stamps `shareable: true` on every workspace bot (§4.3). A live
+    // toggle would let a one-member workspace be PATCHed back to `shareable: false`
+    // — a state the provider contract does not have, recoverable only by re-running
+    // the OAuth funnel. The `shareable` escape hatch must not reach these rows.
+    expect(botSharingEditable(bot({ platform: 'linear', transport: 'http', shareable: true }))).toBe(false)
+    expect(botSharingEditable(bot({ platform: 'linear', transport: 'http', shareable: false }))).toBe(false)
   })
 
   it('refuses a Feishu HTTP bot — the platform, not the transport, is the reason', () => {
@@ -131,7 +165,9 @@ describe('the disabled toggle and its tooltip agree', () => {
     // so a module cannot declare two different share sentences while the toggle
     // it explains is dead for a reason no transport change repairs.
     for (const id of platformRegistry.ids()) {
-      if (platformSupportsSharing(id)) continue
+      // A fixed-sharing platform renders no toggle at all, but its cell still carries
+      // this sentence as its title — so it is held to the same rule, not exempted.
+      if (platformSupportsSharing(id) && !platformSharingFixed(id)) continue
       const { available, unavailable } = botCardCopy(id).shareHint
       expect(available, id).toBe(unavailable)
     }

--- a/packages/web/src/components/console/platforms/bot-sharing.test.ts
+++ b/packages/web/src/components/console/platforms/bot-sharing.test.ts
@@ -44,12 +44,16 @@ function bot(over: Partial<BotDto> = {}): BotDto {
 /** Ids a bot row can carry that no module claims — core trigger kinds, a
  *  platform not built yet, and the prototype-pollution shapes a `Map` lookup
  *  must not answer for. */
-const UNCLAIMED = ['webhook', 'github', 'playground', 'webchat', 'linear', 'lark', 'Slack', '__proto__', '']
+const UNCLAIMED = ['webhook', 'github', 'playground', 'webchat', 'zulip', 'lark', 'Slack', '__proto__', '']
+
+/** The platforms whose bots may serve several agents — the §5 manifest's
+ *  `multiAgentShareable` set, mirrored one module at a time. */
+const SHARING_PLATFORMS = ['slack', 'linear']
 
 describe('platformSupportsSharing', () => {
-  it('is true for Slack and false for every other registered platform', () => {
-    expect(platformSupportsSharing('slack')).toBe(true)
-    for (const id of platformRegistry.ids().filter((p) => p !== 'slack')) {
+  it('is true for the multi-agent platforms and false for every other registered one', () => {
+    for (const id of SHARING_PLATFORMS) expect(platformSupportsSharing(id), id).toBe(true)
+    for (const id of platformRegistry.ids().filter((p) => !SHARING_PLATFORMS.includes(p))) {
       expect(platformSupportsSharing(id), id).toBe(false)
     }
   })
@@ -71,13 +75,19 @@ describe('platformSupportsSharing', () => {
         .all()
         .filter((m) => m.wizard.affordances.share === true)
         .map((m) => m.platformId)
-    ).toEqual(['slack'])
+    ).toEqual(SHARING_PLATFORMS)
   })
 })
 
 describe('botSharingEditable', () => {
   it('lets a Slack HTTP bot be shared', () => {
     expect(botSharingEditable(bot({ platform: 'slack', transport: 'http' }))).toBe(true)
+  })
+
+  it('lets a Linear workspace bot be shared — it is one workspace serving many agents', () => {
+    // The provider stamps `shareable: true` structurally on a connected workspace,
+    // so the toggle exists to turn multi-agent membership OFF, not to earn it.
+    expect(botSharingEditable(bot({ platform: 'linear', transport: 'http' }))).toBe(true)
   })
 
   it('refuses a Feishu HTTP bot — the platform, not the transport, is the reason', () => {

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -286,20 +286,33 @@ export interface WebWizardAffordances {
   /**
    * The platform supports multi-agent bots — the console's mirror of the §5
    * manifest's `multiAgentShareable`, which is what the CP's two gates read.
-   * The host still applies the http-only gate itself — create mode on the
-   * chosen transport, reuse mode on the reused bot's own (:1321-1326).
+   *
+   * THREE VALUES, because "supported" and "chosen by the operator" are different
+   * facts and collapsing them shipped a control for a decision that does not exist:
+   *  - absent ⇒ the platform has no multi-agent bot at all (Telegram, Discord,
+   *    Feishu). Neither surface offers sharing.
+   *  - `true` ⇒ multi-agent is an OPT-IN the operator makes (Slack). The host
+   *    still applies the http-only gate itself — create mode on the chosen
+   *    transport, reuse mode on the reused bot's own (:1321-1326).
+   *  - `'fixed'` ⇒ multi-agent is STRUCTURAL: the provider stamps `shareable`
+   *    itself and the flag is not a caller's to move (Linear — a Bot row IS one
+   *    connected workspace, and a workspace is definitionally multi-agent,
+   *    linear-integration.md §4.3). Reuse still admits members, but neither the
+   *    wizard opt-in nor the Settings toggle renders, because flipping it OFF is
+   *    a state the provider contract does not have and whose only recovery would
+   *    be re-running the OAuth funnel.
    *
    * Nested under `wizard` for where it is DECLARED, not for where it may be
-   * read: it is a platform fact, and the Settings → Bots Sharable toggle reads
-   * the same one through `platformSupportsSharing` (registry.ts). That toggle
-   * shipped gated on transport ALONE, which left a Feishu HTTP bot — the one
-   * non-shareable platform whose bots can be `transport: 'http'` — offering a
-   * live control for a capability the CP refuses. The fix is this member, not a
-   * second one on {@link WebBotSettingsFragments}: a Settings-side mirror could
-   * disagree with the wizard's about the same platform, and one declaration
-   * cannot.
+   * read: it is a platform fact, and the Settings → Bots Sharable cell reads the
+   * same one through `platformSupportsSharing` / `platformSharingFixed`
+   * (registry.ts). That toggle shipped gated on transport ALONE, which left a
+   * Feishu HTTP bot — a non-shareable platform whose bots can be
+   * `transport: 'http'` — offering a live control for a capability the CP
+   * refuses. The fix is this member, not a second one on
+   * {@link WebBotSettingsFragments}: a Settings-side mirror could disagree with
+   * the wizard's about the same platform, and one declaration cannot.
    */
-  share?: boolean
+  share?: boolean | 'fixed'
 }
 
 /**

--- a/packages/web/src/components/console/platforms/host-projections.ts
+++ b/packages/web/src/components/console/platforms/host-projections.ts
@@ -84,6 +84,7 @@ export const INTEGRATION_BLURB: Record<string, string> = {
   telegram: 'Reply in groups & chats',
   discord: 'Reply in servers',
   feishu: 'Reply in groups & chats',
+  linear: 'Work delegated issues',
   github: 'React to issues & PRs',
   gitlab: 'React to issues & MRs',
   webhook: 'Trigger by posting a URL'

--- a/packages/web/src/components/console/platforms/linear/Body.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/Body.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment happy-dom
+
+// The wizard pane's three availability conditions (§4.2, §7.1). The daemon-capability
+// leg is the host's picker gate and is pinned in `module.test.tsx`; the other two are
+// the pane's, and both fail CLOSED — a pane that offers "Connect Linear" without a
+// relay, or without the deployment's Linear app, sends the operator through an OAuth
+// round trip that cannot land.
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SlackConfigDto } from '@/lib/api'
+import type { Agent } from '@/lib/data'
+import type { WizardFooterState, WizardHost } from '../contract'
+
+const mocks = vi.hoisted(() => ({
+  probeConfig: null as SlackConfigDto | null,
+  probeFailed: false,
+  startLinearConnect: vi.fn(),
+  getLinearConnect: vi.fn()
+}))
+
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  startLinearConnect: mocks.startLinearConnect,
+  getLinearConnect: mocks.getLinearConnect
+}))
+vi.mock('../deployment-config', () => ({
+  useDeploymentConfig: () => ({ config: mocks.probeConfig, failed: mocks.probeFailed, apply: vi.fn() })
+}))
+
+import { ApiError } from '@/lib/api'
+import { LinearWizardBody } from './Body'
+
+const agent = { id: 'agent-a', name: 'deploy-bot' } as unknown as Agent
+
+let host: HTMLDivElement
+let root: Root
+let footer: WizardFooterState | null
+
+function wizardHost(over: Partial<WizardHost> = {}): WizardHost {
+  return {
+    createIntegration: vi.fn(async () => undefined),
+    relayCapability: { available: true, publicUrl: null },
+    mode: 'create',
+    selectedBot: null,
+    transport: 'http',
+    setTransport: vi.fn(),
+    shared: false,
+    mockMode: false,
+    setFooter: (state) => {
+      footer = state
+    },
+    setIdentityChrome: vi.fn(),
+    setRegionLocked: vi.fn(),
+    setError: vi.fn(),
+    close: vi.fn(),
+    invalidate: vi.fn(),
+    ...over
+  }
+}
+
+/** A probe answer — only `relayAvailable` matters here; the pane reads the VALUE
+ *  off the host so the two can never disagree. */
+const answered: SlackConfigDto = {
+  configured: true,
+  durable: true,
+  funnelEnabled: true,
+  autoAvailable: true,
+  accessExpiresAt: null,
+  relayAvailable: true,
+  relayPublicUrl: null,
+  platformInstallAvailable: true,
+  updatedAt: null
+}
+
+const text = () => host.textContent ?? ''
+
+function connectButton(): HTMLButtonElement | undefined {
+  return [...host.querySelectorAll('button')].find((b) => b.textContent?.includes('Connect Linear'))
+}
+
+async function settle(): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  }
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  footer = null
+  mocks.probeConfig = null
+  mocks.probeFailed = false
+  mocks.startLinearConnect.mockReset()
+  mocks.getLinearConnect.mockReset()
+  mocks.getLinearConnect.mockResolvedValue({ id: 'c1', status: 'pending', failureReason: null, botId: null })
+  vi.stubGlobal(
+    'open',
+    vi.fn(() => null)
+  )
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+  vi.unstubAllGlobals()
+})
+
+describe('the Linear connect hand-off', () => {
+  it('waits instead of offering the hand-off while the deployment probe is in flight', async () => {
+    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
+    expect(text()).toContain('Checking your Linear setup')
+    expect(connectButton()).toBeUndefined()
+  })
+
+  it('refuses without public callback delivery', async () => {
+    mocks.probeConfig = answered
+    const hostState = wizardHost({ relayCapability: { available: false, publicUrl: null } })
+    await act(async () => root.render(<LinearWizardBody agent={agent} host={hostState} />))
+
+    expect(text()).toContain('HTTP callbacks only')
+    expect(connectButton()).toBeUndefined()
+  })
+
+  it('reads a failed probe as no relay rather than as an answer it never got', async () => {
+    mocks.probeFailed = true
+    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
+    expect(text()).toContain('HTTP callbacks only')
+  })
+
+  it('offers the hand-off once a relay is connected, naming this agent as the default', async () => {
+    mocks.probeConfig = answered
+    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
+
+    expect(connectButton()).toBeDefined()
+    expect(text()).toContain('deploy-bot becomes its default agent')
+  })
+
+  it('self-disables when the deployment registered no Linear app', async () => {
+    // The funnel's 404 is the only signal there is — nothing advertises the
+    // deployment app to the console, so the pane learns it from the route.
+    mocks.probeConfig = answered
+    mocks.startLinearConnect.mockRejectedValue(new ApiError('not found', 404))
+    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
+    await act(async () => connectButton()!.click())
+    await settle()
+
+    expect(text()).toContain('isn’t set up on this deployment yet')
+    expect(connectButton()).toBeUndefined()
+  })
+
+  it('opens the authorize URL and waits for the round trip', async () => {
+    mocks.probeConfig = answered
+    mocks.startLinearConnect.mockResolvedValue({
+      id: 'c1',
+      connectUrl: 'https://linear.app/oauth/authorize?state=c1'
+    })
+    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
+    await act(async () => connectButton()!.click())
+    await settle()
+
+    expect(mocks.startLinearConnect).toHaveBeenCalledWith('agent-a')
+    expect(window.open).toHaveBeenCalledWith(
+      'https://linear.app/oauth/authorize?state=c1',
+      '_blank',
+      expect.any(String)
+    )
+    expect(text()).toContain('Waiting for Linear')
+  })
+
+  it('closes the modal once the funnel row settles', async () => {
+    mocks.probeConfig = answered
+    mocks.startLinearConnect.mockResolvedValue({ id: 'c1', connectUrl: 'https://linear.app/oauth/authorize' })
+    mocks.getLinearConnect.mockResolvedValue({ id: 'c1', status: 'completed', failureReason: null, botId: 'bot-9' })
+    const close = vi.fn()
+    const invalidate = vi.fn()
+    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost({ close, invalidate })} />))
+    await act(async () => connectButton()!.click())
+    await settle()
+
+    expect(invalidate).toHaveBeenCalled()
+    expect(close).toHaveBeenCalled()
+  })
+
+  it('shows the settled row’s refusal — the throwaway tab has no other channel back', async () => {
+    mocks.probeConfig = answered
+    mocks.startLinearConnect.mockResolvedValue({ id: 'c1', connectUrl: 'https://linear.app/oauth/authorize' })
+    mocks.getLinearConnect.mockResolvedValue({
+      id: 'c1',
+      status: 'failed',
+      failureReason: 'workspace_taken',
+      botId: null
+    })
+    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
+    await act(async () => connectButton()!.click())
+    await settle()
+
+    expect(text()).toContain('already connected to a different organization')
+    // Back to a clickable state rather than stuck waiting on a settled row.
+    expect(connectButton()).toBeDefined()
+  })
+
+  it('keeps the host’s create primary hidden — the pane commits with its own button', async () => {
+    mocks.probeConfig = answered
+    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
+    expect(footer?.hidden).toBe(true)
+  })
+
+  it('explains membership rather than the funnel in reuse mode', async () => {
+    mocks.probeConfig = answered
+    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost({ mode: 'existing' })} />))
+
+    expect(connectButton()).toBeUndefined()
+    expect(text()).toContain('joins this workspace as a member')
+  })
+})

--- a/packages/web/src/components/console/platforms/linear/Body.tsx
+++ b/packages/web/src/components/console/platforms/linear/Body.tsx
@@ -1,0 +1,125 @@
+// No 'use client' here: rendered only inside ModalProvider's tree (the client boundary).
+
+import { Icon } from '@/components/ui'
+import type { Agent } from '@/lib/data'
+import type { WizardHost } from '../contract'
+import { useDeploymentConfig } from '../deployment-config'
+import { usePublishedFooter } from '../publish'
+import { linearApi } from './api'
+import { linearConnectAvailability, useLinearConnect } from './connect'
+import { LinearMark } from './mark'
+
+/**
+ * Linear's pane — "enable this agent on a connected workspace"
+ * (linear-integration.md §4.3, §7.1).
+ *
+ * A Linear Bot row IS one connected workspace, and every agent on it is a member,
+ * so the wizard's two modes split differently here than on the other platforms:
+ * REUSE is the ordinary path (the host's free-bot list is the org's connected
+ * workspaces, and its own footer commits the membership unfenced, §7.4), while
+ * CREATE is a hand-off — there is nothing to paste, only an org-level OAuth round
+ * trip that mints the workspace bot server-side.
+ *
+ * The pane commits through its own inline button, like the Feishu deeplink flow, so
+ * the host's create primary stays hidden throughout.
+ */
+export function LinearWizardBody({ agent, host }: { agent: Agent; host: WizardHost }) {
+  // The chassis reads this same probe for its relay capability; one SWR key ⇒ one
+  // request. Only the "has it answered yet" bit is read here — the VALUE comes off
+  // the host, so the two can never disagree about the deployment.
+  const probe = useDeploymentConfig(true)
+  const { invalidate, close } = host
+  const flow = useLinearConnect(
+    () => linearApi.startConnect(agent.id),
+    () => {
+      invalidate()
+      close()
+    }
+  )
+
+  // An answer WINS over a later error: a transient revalidation failure must not
+  // retract a relay this pane already learned about (the Slack funnel's rule).
+  const relayAvailable: boolean | null = probe.config ? host.relayCapability.available : probe.failed ? false : null
+  const availability = linearConnectAvailability({
+    relayAvailable,
+    appConfigured: flow.appMissing ? false : null
+  })
+
+  // The commit is the pane's own button in every state, so the footer primary is
+  // suppressed rather than published — reuse mode has the host's own footer.
+  usePublishedFooter(host, { label: 'Connect', enabled: false, onSubmit: () => {}, hidden: true })
+
+  if (host.mode === 'existing') {
+    return (
+      <div className="mb-4 flex items-start gap-[10px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+        <Icon name="info" size={15} className="mt-[1px] flex-none" />
+        <span>
+          {agent.name} joins this workspace as a member. Mention the app on an issue and name it —{' '}
+          <span className="mono">@{agent.name}</span>&#32;— to reach it; bare delegations go to the workspace&rsquo;s
+          default agent.
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
+      {availability === 'checking' ? (
+        <div className="flex items-center gap-[10px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+          <Icon name="loader" size={15} className="flex-none animate-spin" />
+          Checking your Linear setup…
+        </div>
+      ) : availability === 'app_required' ? (
+        <div className="flex items-start gap-[10px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+          <Icon name="info" size={15} className="mt-[1px] flex-none" />
+          <span>
+            Linear isn&rsquo;t set up on this deployment yet. An administrator registers one Linear OAuth application
+            for the whole deployment before workspaces can be connected.
+          </span>
+        </div>
+      ) : availability === 'relay_required' ? (
+        <div className="flex items-start gap-[10px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+          <Icon name="info" size={15} className="mt-[1px] flex-none" />
+          <span>
+            Linear delivers over HTTP callbacks only, so it needs a public callback endpoint. Ask an administrator to
+            configure one, then connect a workspace here.
+          </span>
+        </div>
+      ) : (
+        <>
+          <div className="mb-[10px] font-sans text-[12.5px] font-medium leading-[1.45] text-(--text-secondary)">
+            Connect a Linear workspace. {agent.name} becomes its default agent — the one a bare delegation starts a
+            session with.
+          </div>
+          {flow.phase === 'authorizing' ? (
+            <div className="flex h-[46px] w-full items-center justify-center gap-[10px] rounded-[10px] bg-(--surface-inverse) font-sans text-[14px] font-semibold leading-normal text-white opacity-85">
+              <Icon name="loader" size={16} className="flex-none animate-spin" />
+              Waiting for Linear…
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={flow.start}
+              className="flex h-[46px] w-full cursor-pointer items-center justify-center gap-[10px] rounded-[10px] border-0 bg-(--surface-inverse) font-sans text-[14px] font-semibold leading-normal text-white"
+            >
+              <span className="imark h-[18px] w-[18px] border-0 bg-transparent">
+                <LinearMark fillPct={100} />
+              </span>
+              Connect Linear
+            </button>
+          )}
+          {flow.err && (
+            <div className="mt-2 font-sans text-[11.5px] font-normal leading-[1.4] text-(--status-error)">
+              {flow.err}
+            </div>
+          )}
+          <div className="mt-[10px] font-sans text-[12px] font-normal leading-[1.4] text-(--text-tertiary)">
+            {flow.phase === 'authorizing'
+              ? 'Approve the workspace in the Linear tab — this closes automatically once it lands.'
+              : 'Other agents join the same workspace later from their own Add integration.'}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/platforms/linear/api.test.ts
+++ b/packages/web/src/components/console/platforms/linear/api.test.ts
@@ -1,0 +1,87 @@
+// The bindings' wire shape. The CP routes are org-scoped and their DTOs are fixed
+// (control-plane/src/platforms/linear/routes.ts), so a drifted path or body here is
+// a 404/400 no type checks — the funnel start doubles as the console's ONLY signal
+// that the deployment registered a Linear app, and a wrong path fakes that answer.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, setApiOrgId } from '@/lib/api'
+import { linearApi } from './api'
+
+type Call = { url: string; method: string; body: unknown }
+
+let calls: Call[]
+
+function stubFetch(status = 200, payload: unknown = {}): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({
+        url,
+        method: init.method ?? 'GET',
+        body: typeof init.body === 'string' ? JSON.parse(init.body) : undefined
+      })
+      return new Response(JSON.stringify(payload), { status, headers: { 'content-type': 'application/json' } })
+    })
+  )
+}
+
+const pathOf = (call: Call) => new URL(call.url, 'http://cp.example.test').pathname
+
+beforeEach(() => {
+  calls = []
+  setApiOrgId('org-7')
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  setApiOrgId(null)
+})
+
+describe('linear api bindings', () => {
+  it('starts a connect against the org funnel, carrying the chosen default agent', async () => {
+    stubFetch(201, { id: 'connect-1', connectUrl: 'https://linear.app/oauth/authorize?state=connect-1' })
+    const started = await linearApi.startConnect('agent-a')
+
+    expect(pathOf(calls[0]!)).toBe('/api/v1/orgs/org-7/integrations/linear/connect')
+    expect(calls[0]!.method).toBe('POST')
+    expect(calls[0]!.body).toEqual({ agentId: 'agent-a' })
+    expect(started).toEqual({ id: 'connect-1', connectUrl: 'https://linear.app/oauth/authorize?state=connect-1' })
+  })
+
+  it('polls the funnel row by its id', async () => {
+    stubFetch(200, { id: 'connect-1', status: 'completed', failureReason: null, botId: 'bot-9' })
+    const row = await linearApi.getConnect('connect-1')
+
+    expect(pathOf(calls[0]!)).toBe('/api/v1/orgs/org-7/integrations/linear/connect/connect-1')
+    expect(calls[0]!.method).toBe('GET')
+    expect(row.botId).toBe('bot-9')
+  })
+
+  it('reconnects against the bot, not the org — the nonce is bound to that workspace', async () => {
+    stubFetch(201, { id: 'connect-2', connectUrl: 'https://linear.app/oauth/authorize?state=connect-2' })
+    await linearApi.reconnect('bot-9')
+
+    expect(pathOf(calls[0]!)).toBe('/api/v1/orgs/org-7/bots/bot-9/linear/reconnect')
+    expect(calls[0]!.method).toBe('POST')
+  })
+
+  it('moves the default agent through the generic bot patch', async () => {
+    stubFetch(200, { id: 'bot-9' })
+    await linearApi.setDefaultAgent('bot-9', 'agent-b')
+    expect(pathOf(calls[0]!)).toBe('/api/v1/orgs/org-7/bots/bot-9')
+    expect(calls[0]!.method).toBe('PATCH')
+    expect(calls[0]!.body).toEqual({ preferredAgentId: 'agent-b' })
+
+    // Null is a real value here — it restores the earliest-member derivation.
+    calls = []
+    await linearApi.setDefaultAgent('bot-9', null)
+    expect(calls[0]!.body).toEqual({ preferredAgentId: null })
+  })
+
+  it('surfaces the funnel’s 404 as an ApiError the pane can recognize', async () => {
+    // The self-disable signal: without the deployment app, both routes 404.
+    stubFetch(404, { error: 'Not Found', statusCode: 404, message: 'not found' })
+    await expect(linearApi.startConnect('agent-a')).rejects.toBeInstanceOf(ApiError)
+    await expect(linearApi.startConnect('agent-a')).rejects.toMatchObject({ status: 404 })
+  })
+})

--- a/packages/web/src/components/console/platforms/linear/api.ts
+++ b/packages/web/src/components/console/platforms/linear/api.ts
@@ -1,0 +1,37 @@
+// No 'use client' here: reached only from ModalProvider's tree (the client boundary).
+
+import {
+  getLinearConnect,
+  reconnectLinearWorkspace,
+  setBotPreferredAgent,
+  startLinearConnect,
+  type LinearConnectStartDto,
+  type LinearConnectStatusDto
+} from '@/lib/api'
+
+/**
+ * The Linear module's own CP client surface ({@link WebPlatformModule.apiBindings}) —
+ * the workspace connect funnel, its reconnect arm, and the workspace's default-agent
+ * move. OPAQUE to the chassis: the wizard pane and the settings workspace card share
+ * this one client seam.
+ *
+ * `setDefaultAgent` is `PATCH /bots/:id` with `preferredAgentId` — a generic bot route
+ * (any shared bot may name a default), named here because Linear is the surface that
+ * drives it: §7.4's rule that a bare delegation needs a default is the reason the
+ * workspace card can move one at all.
+ *
+ * Removing a member is deliberately ABSENT. It is the generic
+ * `DELETE /integrations/:id`, and the card commits it through
+ * `useConsoleData().deleteIntegration` so the console's integration/bot projections
+ * refresh with it — the same reason a create commits through
+ * {@link WizardHost.createIntegration}.
+ */
+export const linearApi = {
+  startConnect: startLinearConnect,
+  getConnect: getLinearConnect,
+  reconnect: reconnectLinearWorkspace,
+  setDefaultAgent: setBotPreferredAgent
+}
+
+export type LinearApi = typeof linearApi
+export type { LinearConnectStartDto, LinearConnectStatusDto }

--- a/packages/web/src/components/console/platforms/linear/connect.test.ts
+++ b/packages/web/src/components/console/platforms/linear/connect.test.ts
@@ -1,0 +1,58 @@
+// The two pure halves of the workspace connect round trip: what the hand-off may
+// offer right now, and how the funnel row's terminal codes read. Both are where a
+// silent behavior change would hide — the copy is the ONLY channel a settled row
+// has back to the operator, because the OAuth tab is a throwaway.
+
+import { describe, expect, it } from 'vitest'
+import { linearConnectAvailability, linearConnectFailure } from './connect'
+
+describe('linearConnectAvailability', () => {
+  it('waits rather than guessing while the deployment probe has no answer', () => {
+    expect(linearConnectAvailability({ relayAvailable: null, appConfigured: null })).toBe('checking')
+  })
+
+  it('offers the hand-off once a relay is connected', () => {
+    expect(linearConnectAvailability({ relayAvailable: true, appConfigured: null })).toBe('ready')
+  })
+
+  it('refuses without public callback delivery — Linear has no dial-out transport', () => {
+    expect(linearConnectAvailability({ relayAvailable: false, appConfigured: null })).toBe('relay_required')
+  })
+
+  it('puts a missing deployment app ahead of every other reason', () => {
+    // The one an operator cannot fix from this console at all, and the only one
+    // that stays true whatever the relay is doing.
+    expect(linearConnectAvailability({ relayAvailable: true, appConfigured: false })).toBe('app_required')
+    expect(linearConnectAvailability({ relayAvailable: false, appConfigured: false })).toBe('app_required')
+    expect(linearConnectAvailability({ relayAvailable: null, appConfigured: false })).toBe('app_required')
+  })
+})
+
+describe('linearConnectFailure', () => {
+  it('gives every settled code a sentence of its own', () => {
+    const codes = [
+      'denied',
+      'expired',
+      'workspace_taken',
+      'wrong_workspace',
+      'default_agent_required',
+      'agent_missing',
+      'error'
+    ]
+    const sentences = codes.map((code) => linearConnectFailure(code))
+    // 'error' shares the fallback, so only the six named codes must be distinct.
+    expect(new Set(sentences.slice(0, 6)).size).toBe(6)
+    for (const sentence of sentences) expect(sentence.length).toBeGreaterThan(0)
+  })
+
+  it('names the two refusals an operator has to act on elsewhere', () => {
+    expect(linearConnectFailure('workspace_taken')).toContain('already connected to a different organization')
+    expect(linearConnectFailure('wrong_workspace')).toContain('authorized a different workspace')
+  })
+
+  it('falls back for an unknown or absent code rather than showing one raw', () => {
+    const fallback = linearConnectFailure('error')
+    expect(linearConnectFailure(null)).toBe(fallback)
+    expect(linearConnectFailure('a_code_this_console_has_not_been_taught')).toBe(fallback)
+  })
+})

--- a/packages/web/src/components/console/platforms/linear/connect.ts
+++ b/packages/web/src/components/console/platforms/linear/connect.ts
@@ -1,0 +1,166 @@
+'use client'
+
+// The workspace connect round trip, shared by the two surfaces that start one:
+// the wizard's "connect a workspace" hand-off and the settings card's Reconnect
+// (linear-integration.md §7.1, §7.4). Both mint a one-shot state, open the
+// linear.app authorize URL in a popup, and poll the FUNNEL ROW to a terminal
+// state — never the bot list, because a reconnect replaces a grant in place and
+// creates no row for a list to grow by.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ApiError } from '@/lib/api'
+import { linearApi, type LinearConnectStartDto } from './api'
+
+/** What the connect hand-off may offer right now, from the two deployment
+ *  preconditions the console can see. */
+export type LinearConnectAvailability = 'checking' | 'ready' | 'relay_required' | 'app_required'
+
+/**
+ * Resolve the hand-off's availability.
+ *
+ * `relayAvailable: null` ⇒ the shared deployment probe has no answer yet. The
+ * deployment's own Linear app is NOT advertised anywhere the console can read, so
+ * `appConfigured` starts null and only ever turns false when the funnel answers
+ * 404 — the platform-app funnel's self-disable, learned from the route rather than
+ * from a flag. An absent app outranks a missing relay: it is the one an operator
+ * cannot fix from this console at all.
+ */
+export function linearConnectAvailability(input: {
+  relayAvailable: boolean | null
+  appConfigured: boolean | null
+}): LinearConnectAvailability {
+  if (input.appConfigured === false) return 'app_required'
+  if (input.relayAvailable === null) return 'checking'
+  return input.relayAvailable ? 'ready' : 'relay_required'
+}
+
+/** The funnel row's terminal failure codes, as sentences. The CP settles the row
+ *  with a short code because the OAuth tab is a throwaway and the console is the
+ *  only place the outcome can be read (§7.1). */
+export function linearConnectFailure(reason: string | null): string {
+  switch (reason) {
+    case 'denied':
+      return 'The connect was cancelled in Linear. Try again when you’re ready.'
+    case 'expired':
+      return 'That connect link expired or was already used. Start the connect again.'
+    case 'workspace_taken':
+      return 'This Linear workspace is already connected to a different organization. Disconnect it there first.'
+    case 'wrong_workspace':
+      return 'Linear authorized a different workspace. Try again and choose the workspace shown here.'
+    case 'default_agent_required':
+      return 'This workspace isn’t connected yet, so it needs a default agent. Start the connect from an agent.'
+    case 'agent_missing':
+      return 'The agent chosen for this workspace no longer exists. Start the connect again.'
+    default:
+      return 'Something went wrong finishing the connect. Try again.'
+  }
+}
+
+/** The connect the popup is not required to report back: closing the tab without
+ *  approving leaves the row pending forever, so the poll gives up on it. */
+const LINEAR_CONNECT_ABANDONED = 'The Linear tab closed before the connect finished. Try again.'
+
+export interface LinearConnectFlow {
+  phase: 'idle' | 'authorizing'
+  err: string | null
+  /** The deployment has no Linear app — the funnel answered 404 (see
+   *  {@link linearConnectAvailability}). */
+  appMissing: boolean
+  start(): void
+  clearError(): void
+}
+
+/**
+ * Drive one connect round trip. `mint` is the caller's own start call — the
+ * wizard's `startConnect(agentId)` or the card's `reconnect(botId)` — so the two
+ * flows share every step after it.
+ *
+ * `onCompleted` fires once the row settles `completed`.
+ */
+export function useLinearConnect(
+  mint: () => Promise<LinearConnectStartDto>,
+  onCompleted: (botId: string | null) => void
+): LinearConnectFlow {
+  const [phase, setPhase] = useState<'idle' | 'authorizing'>('idle')
+  const [err, setErr] = useState<string | null>(null)
+  const [appMissing, setAppMissing] = useState(false)
+  const [connectId, setConnectId] = useState<string | null>(null)
+  const busy = useRef(false)
+  // Kept WITHOUT `noopener` so `.closed` is observable — the standard OAuth-popup
+  // pattern against a trusted linear.app page.
+  const popup = useRef<Window | null>(null)
+  // `mint` and `onCompleted` are fresh closures on every render of the calling
+  // pane; a ref keeps the poll effect from restarting under a live round trip.
+  const latest = useRef({ mint, onCompleted })
+  latest.current = { mint, onCompleted }
+
+  const reset = useCallback(() => {
+    setPhase('idle')
+    setConnectId(null)
+    popup.current = null
+  }, [])
+
+  const clearError = useCallback(() => setErr(null), [])
+
+  const start = useCallback(() => {
+    if (busy.current) return
+    busy.current = true
+    setErr(null)
+    void (async () => {
+      try {
+        const started = await latest.current.mint()
+        setConnectId(started.id)
+        popup.current = window.open(started.connectUrl, '_blank', 'width=680,height=760')
+        setPhase('authorizing')
+      } catch (e) {
+        // 404 ⇒ this deployment registered no Linear app, so the routes are off.
+        if (e instanceof ApiError && e.status === 404) setAppMissing(true)
+        else setErr(e instanceof Error ? e.message : String(e))
+      } finally {
+        busy.current = false
+      }
+    })()
+  }, [])
+
+  useEffect(() => {
+    if (phase !== 'authorizing' || !connectId) return
+    let alive = true
+    let closeHandled = false
+    const stop = (message: string) => {
+      reset()
+      setErr(message)
+    }
+    // Read the row once and act on its terminal state; `whenPending` decides
+    // whether a closed popup means "landed" or "abandoned".
+    const check = async (whenPending?: () => void) => {
+      try {
+        const row = await linearApi.getConnect(connectId)
+        if (!alive) return
+        if (row.status === 'pending') return whenPending?.()
+        if (row.status === 'completed') {
+          reset()
+          latest.current.onCompleted(row.botId)
+          return
+        }
+        stop(linearConnectFailure(row.failureReason))
+      } catch (e) {
+        // 404 = the row was TTL-reaped, which is terminal; anything else is transient.
+        if (alive && e instanceof ApiError && e.status === 404) stop(linearConnectFailure('expired'))
+      }
+    }
+    const poll = setInterval(() => void check(), 2500)
+    const watch = setInterval(() => {
+      if (!alive || closeHandled || !popup.current?.closed) return
+      closeHandled = true
+      void check(() => alive && stop(LINEAR_CONNECT_ABANDONED))
+    }, 600)
+    void check()
+    return () => {
+      alive = false
+      clearInterval(poll)
+      clearInterval(watch)
+    }
+  }, [connectId, phase, reset])
+
+  return { phase, err, appMissing, start, clearError }
+}

--- a/packages/web/src/components/console/platforms/linear/default-agent.test.ts
+++ b/packages/web/src/components/console/platforms/linear/default-agent.test.ts
@@ -1,0 +1,160 @@
+// The card's default derivation against the cases `HttpBotOrchestrator.compile` actually
+// distinguishes. Membership order alone was wrong in both directions: it marked a member
+// the compiler skips, and — the part that loses data — left the real default's Remove
+// enabled, so removing it stranded every bare delegation on the workspace.
+
+import { describe, expect, it } from 'vitest'
+import { linearDefaultAgents, linearMemberEligibility, type LinearMemberAgent } from './default-agent'
+
+/** A placed, org-visible agent — the compiler's `placed && !gated`. */
+function placed(over: Partial<LinearMemberAgent> = {}): LinearMemberAgent {
+  return { visibility: 'org', placementKind: 'daemon', setId: null, daemon: 'daemon-1', ...over }
+}
+
+const restricted = () => placed({ visibility: 'restricted' })
+const unplaced = () => placed({ daemon: '—' })
+const onSet = () => placed({ placementKind: 'set', setId: 'set-1', daemon: 'pool' })
+
+const roster = (entries: Record<string, LinearMemberAgent | undefined>) => (id: string) => entries[id]
+
+describe('linearMemberEligibility', () => {
+  it('reads a placed org-visible agent as eligible whatever its daemon is doing', () => {
+    // `routableDaemon` is placement ∪ confirmed holders, NOT liveness: a placed agent
+    // on an offline daemon is still the member the compile routes to.
+    expect(linearMemberEligibility(placed())).toBe('eligible')
+  })
+
+  it('reads a restricted agent as ineligible — no unscoped rung may name a gated agent', () => {
+    expect(linearMemberEligibility(restricted())).toBe('ineligible')
+  })
+
+  it('reads an agent that is placed nowhere as ineligible', () => {
+    expect(linearMemberEligibility(unplaced())).toBe('ineligible')
+    // A set placement naming no set is the same "scope: none" the domain rule reports.
+    expect(linearMemberEligibility(placed({ placementKind: 'set', setId: null, daemon: 'pool' }))).toBe('ineligible')
+  })
+
+  it('reads a set placement as unknown — the confirmed duty hold is not exposed here', () => {
+    expect(linearMemberEligibility(onSet())).toBe('unknown')
+  })
+
+  it('reads a member it cannot resolve as unknown rather than as absent', () => {
+    // Still loading, or an agent this viewer cannot see. Assuming it away is the one
+    // direction that can delete the real default.
+    expect(linearMemberEligibility(undefined)).toBe('unknown')
+  })
+})
+
+describe('linearDefaultAgents', () => {
+  it('takes the persisted pointer when it is eligible, and stops there', () => {
+    const result = linearDefaultAgents(
+      { preferredAgentId: 'b', agentIds: ['a', 'b'] },
+      roster({ a: placed(), b: placed() })
+    )
+    expect(result).toEqual({ marked: 'b', candidates: ['b'] })
+  })
+
+  it('falls back to the earliest eligible member with no pointer set', () => {
+    const result = linearDefaultAgents(
+      { preferredAgentId: null, agentIds: ['a', 'b'] },
+      roster({ a: placed(), b: placed() })
+    )
+    expect(result).toEqual({ marked: 'a', candidates: ['a'] })
+  })
+
+  it('ignores a pointer at a restricted agent, exactly as the compile does', () => {
+    // `placed.find(p => p.agentId === preferred && !p.gated)` misses, so the fallback runs.
+    const result = linearDefaultAgents(
+      { preferredAgentId: 'a', agentIds: ['a', 'b'] },
+      roster({ a: restricted(), b: placed() })
+    )
+    expect(result).toEqual({ marked: 'b', candidates: ['b'] })
+  })
+
+  it('ignores a pointer at an unplaced agent', () => {
+    const result = linearDefaultAgents(
+      { preferredAgentId: 'a', agentIds: ['a', 'b'] },
+      roster({ a: unplaced(), b: placed() })
+    )
+    expect(result).toEqual({ marked: 'b', candidates: ['b'] })
+  })
+
+  it('ignores a pointer at an agent that is no longer a member', () => {
+    const result = linearDefaultAgents({ preferredAgentId: 'gone', agentIds: ['a'] }, roster({ a: placed() }))
+    expect(result).toEqual({ marked: 'a', candidates: ['a'] })
+  })
+
+  it('skips ineligible members when scanning for the fallback', () => {
+    // THE REVIEW'S CASE: A is first (and would be marked by a membership-order read)
+    // but is restricted, so B is the real default — and B is the one whose removal
+    // must be refused.
+    const result = linearDefaultAgents(
+      { preferredAgentId: null, agentIds: ['a', 'b', 'c'] },
+      roster({ a: restricted(), b: placed(), c: placed() })
+    )
+    expect(result).toEqual({ marked: 'b', candidates: ['b'] })
+    expect(result.candidates).not.toContain('a')
+  })
+
+  it('leaves a workspace of only ineligible members with no default at all', () => {
+    // The compile's own answer: a group of only gated agents has no fallback rung.
+    const result = linearDefaultAgents(
+      { preferredAgentId: 'a', agentIds: ['a', 'b'] },
+      roster({ a: restricted(), b: unplaced() })
+    )
+    expect(result).toEqual({ marked: null, candidates: [] })
+  })
+
+  it('has no default on a workspace with no members', () => {
+    expect(linearDefaultAgents({ preferredAgentId: null, agentIds: [] }, roster({}))).toEqual({
+      marked: null,
+      candidates: []
+    })
+  })
+})
+
+describe('linearDefaultAgents under an unknowable duty hold', () => {
+  it('protects a set-placed member AND the eligible member behind it', () => {
+    // A wins if its group has a confirmed holder; otherwise B does. The console cannot
+    // tell, so neither may be removed until a definite default is named.
+    const result = linearDefaultAgents(
+      { preferredAgentId: null, agentIds: ['a', 'b'] },
+      roster({ a: onSet(), b: placed() })
+    )
+    expect(result.marked).toBe('a')
+    expect(result.candidates).toEqual(['a', 'b'])
+  })
+
+  it('stops collecting at the first definitely-eligible member', () => {
+    // C can never win: B is eligible and earlier, so the scan ends there.
+    const result = linearDefaultAgents(
+      { preferredAgentId: null, agentIds: ['a', 'b', 'c'] },
+      roster({ a: onSet(), b: placed(), c: onSet() })
+    )
+    expect(result.candidates).toEqual(['a', 'b'])
+  })
+
+  it('keeps an unknown pointer as the marked default and still protects the fallback', () => {
+    const result = linearDefaultAgents(
+      { preferredAgentId: 'c', agentIds: ['a', 'b', 'c'] },
+      roster({ a: placed(), b: placed(), c: onSet() })
+    )
+    // The pointer might win; if it does not, the earliest eligible member does.
+    expect(result.marked).toBe('c')
+    expect(result.candidates).toEqual(['c', 'a'])
+  })
+
+  it('protects every member while the agent roster has not loaded', () => {
+    const result = linearDefaultAgents({ preferredAgentId: null, agentIds: ['a', 'b'] }, roster({}))
+    expect(result.candidates).toEqual(['a', 'b'])
+  })
+
+  it('collapses to one candidate once a definite default is named — the escape hatch', () => {
+    // What the blocked-removal copy tells the operator to do.
+    const members = { preferredAgentId: 'b', agentIds: ['a', 'b'] }
+    expect(linearDefaultAgents(members, roster({ a: onSet(), b: placed() }))).toEqual({
+      marked: 'b',
+      candidates: ['b']
+    })
+  })
+})

--- a/packages/web/src/components/console/platforms/linear/default-agent.ts
+++ b/packages/web/src/components/console/platforms/linear/default-agent.ts
@@ -1,0 +1,97 @@
+// Which member of a connected workspace catches a bare delegation — the question
+// the workspace card has to answer before it lets anyone remove a member (§7.4).
+//
+// It is NOT "the persisted pointer, else the earliest member". `HttpBotOrchestrator.compile`
+// builds its fallback from ELIGIBLE members only, and applies the same test to the
+// persisted preference:
+//
+//   placed = integrations whose agent resolves AND has a routable daemon
+//   preferred = placed.find(p => p.agentId === bot.preferredAgentId && !p.gated)
+//   default   = preferred ?? placed.find(p => !p.gated)
+//
+// so a pointer at a restricted or unplaced agent is IGNORED and the fallback runs on
+// past it. Reading membership order alone marks the wrong row "default" and — the part
+// that loses data — leaves the real default's Remove enabled.
+//
+// One input is genuinely not exposed to the console: whether a SET-placed agent has a
+// confirmed duty hold right now (`routableDaemons` = placement targets ∪ confirmed
+// holders, and a set placement names no target of its own). `placementReady` is not
+// that predicate — it is liveness, which is both too strict for a daemon placement
+// (placed-but-offline is still routable) and too loose for a set one (a live member
+// that has not confirmed a hold is not). So a set-placed member is `unknown`, and every
+// member that could be the default under that unknown is protected.
+
+import { isSetPlacementKind, type Agent } from '@/lib/data'
+import type { BotDto } from '@/lib/api'
+
+/** The `Agent` fields the compiler's two eligibility tests actually read. */
+export type LinearMemberAgent = Pick<Agent, 'visibility' | 'placementKind' | 'setId' | 'daemon'>
+
+/** What `placementValueOf` yields for an agent whose placement names nothing. */
+const UNPLACED_DAEMON = '—'
+
+/**
+ * Can this member be the compiler's default?
+ *
+ *  - `ineligible` — the compiler will never pick it: restricted (`isGatedAgent`, which
+ *    is excluded from every unscoped rung), or placed nowhere at all.
+ *  - `eligible` — a daemon placement that names a machine. Routable regardless of that
+ *    daemon's liveness, which is exactly what `routableDaemon` answers.
+ *  - `unknown` — a set placement (routable only while some member holds the duty), or a
+ *    member this console cannot resolve to an agent at all. Never assumed away.
+ */
+export function linearMemberEligibility(agent: LinearMemberAgent | undefined): 'eligible' | 'ineligible' | 'unknown' {
+  if (!agent) return 'unknown'
+  if (agent.visibility === 'restricted') return 'ineligible'
+  if (isSetPlacementKind(agent.placementKind)) return agent.setId ? 'unknown' : 'ineligible'
+  return agent.daemon && agent.daemon !== UNPLACED_DAEMON ? 'eligible' : 'ineligible'
+}
+
+export interface LinearDefaultAgents {
+  /** The member the card marks "default" — the compiler's most likely answer. Null when
+   *  no member can be it (a workspace of only restricted or unplaced agents, which the
+   *  compiler leaves with no fallback at all). */
+  marked: string | null
+  /** EVERY member that could be the effective default once the unknowns resolve. Removal
+   *  is refused for all of them; with no unknowns in play this is exactly `[marked]`. */
+  candidates: readonly string[]
+}
+
+/**
+ * The default, and everything it could be.
+ *
+ * Mirrors the compile in order: the persisted pointer first (and it WINS outright when
+ * it is definitely eligible — the fallback never runs), then the earliest eligible
+ * member. Every `unknown` member the scan passes on the way is collected, because it
+ * would have won had it been routable.
+ *
+ * Naming a definitely-eligible default is what collapses the set to one member: that is
+ * both the operator's escape hatch and why the block's copy tells them to do it.
+ */
+export function linearDefaultAgents(
+  bot: Pick<BotDto, 'preferredAgentId' | 'agentIds'>,
+  agentOf: (agentId: string) => LinearMemberAgent | undefined
+): LinearDefaultAgents {
+  const eligibility = (id: string) => linearMemberEligibility(agentOf(id))
+  const candidates: string[] = []
+
+  const pointer = bot.preferredAgentId
+  if (pointer && bot.agentIds.includes(pointer)) {
+    const pointerEligibility = eligibility(pointer)
+    // A definitely-eligible pointer is the answer, full stop — `preferred ?? …`.
+    if (pointerEligibility === 'eligible') return { marked: pointer, candidates: [pointer] }
+    // An unknown pointer might still win; an ineligible one is ignored exactly as the
+    // compiler ignores it, and the fallback below decides.
+    if (pointerEligibility === 'unknown') candidates.push(pointer)
+  }
+
+  for (const agentId of bot.agentIds) {
+    const memberEligibility = eligibility(agentId)
+    if (memberEligibility === 'ineligible') continue
+    if (!candidates.includes(agentId)) candidates.push(agentId)
+    // The first definitely-eligible member ends the scan: nothing after it can win.
+    if (memberEligibility === 'eligible') break
+  }
+
+  return { marked: candidates[0] ?? null, candidates }
+}

--- a/packages/web/src/components/console/platforms/linear/index.tsx
+++ b/packages/web/src/components/console/platforms/linear/index.tsx
@@ -1,0 +1,65 @@
+// No 'use client' here: reached only from ModalProvider's tree (the client boundary).
+
+import type { WebPlatformModule } from '../contract'
+import { linearApi, type LinearApi } from './api'
+import { LinearWizardBody } from './Body'
+import { LinearMark } from './mark'
+import { linearSettingsFragments } from './settings'
+
+/** Linear's provider-native activity id: a v4 UUID. A daemon-local numeric stamp
+ *  can never match it, and neither can any other platform's id shape. */
+const LINEAR_ACTIVITY_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export const linearModule: WebPlatformModule<LinearApi> = {
+  platformId: 'linear',
+  Mark: LinearMark,
+  wizard: {
+    Body: LinearWizardBody,
+    /**
+     * Every connected workspace of the org is offered, unfenced (§7.4): the Bot row
+     * IS the workspace, `shareable: true` is structural on it, and adding a member
+     * needs no reuse fence — the CP refuses nothing the list could show. The chassis
+     * predicate already drops revoked rows and other platforms'.
+     */
+    freeBotFilter: () => true,
+    buildReuseInput: (bot, ctx) => ({
+      platform: 'linear',
+      agentId: ctx.agentId,
+      botId: bot.id,
+      // Linear offers no dial-out transport, so a workspace bot is only ever http
+      // (§4.2); the CP treats the durable bot row as authoritative either way.
+      transport: 'http'
+    }),
+    affordances: {
+      // No transport CHOICE: `http` is the platform's single fixed transport, which
+      // is a different thing from offering two (contract: absent ⇒ fixed).
+      // A connected workspace is definitionally multi-agent — the §5 manifest's
+      // `multiAgentShareable`, mirrored here for the wizard's opt-in and the
+      // Settings toggle to read one declaration.
+      share: true
+    },
+    identityCards: () => ({ create: 'Connect a Linear workspace', existing: 'A connected Linear workspace' }),
+    // Not `inviteBotHint`: nobody invites the app to an issue. A Linear session starts
+    // by delegating the issue to the app or mentioning it, and neither is an invite.
+    inviteHint: () => 'delegate an issue to the app in Linear, or mention it to reach one agent by name.'
+  },
+  settingsFragments: linearSettingsFragments,
+  apiBindings: linearApi,
+  channelList: {
+    // A Linear issue is the room: several agents bind to it, one session each.
+    roomNoun: 'issue',
+    // Issues are titled, not `#name`-prefixed — the row shows the bare title.
+    roomGlyph: '',
+    // No console-driven leave: an issue's agent sessions end in Linear, and the app
+    // is removed from the workspace by disconnecting it here instead.
+    leave: 'none',
+    cannotLeaveRowHint: 'The app stays on the issue — end the agent session in Linear for that.',
+    footerNote: 'An issue lands here when the app is delegated to it or mentioned on it.'
+  },
+  // Agent activities are append-only rows with their own ids (§15), so a duplicate
+  // across sources is the same activity; anything else never dedupes.
+  messageIdentity: (row) => (LINEAR_ACTIVITY_ID.test(row.ts) ? `ts:${row.ts}` : null),
+  // Linear rows arrive over one relay-terminated ingress in daemon `seq` order and
+  // carry no provider send-time the display must follow.
+  transcriptOrdering: 'seq'
+}

--- a/packages/web/src/components/console/platforms/linear/index.tsx
+++ b/packages/web/src/components/console/platforms/linear/index.tsx
@@ -33,10 +33,10 @@ export const linearModule: WebPlatformModule<LinearApi> = {
     affordances: {
       // No transport CHOICE: `http` is the platform's single fixed transport, which
       // is a different thing from offering two (contract: absent ⇒ fixed).
-      // A connected workspace is definitionally multi-agent — the §5 manifest's
-      // `multiAgentShareable`, mirrored here for the wizard's opt-in and the
-      // Settings toggle to read one declaration.
-      share: true
+      // Multi-agent is STRUCTURAL, not an opt-in: the provider stamps
+      // `shareable: true` on every workspace bot (§4.3), so reuse admits members
+      // while neither the wizard nor Settings offers a flag to move.
+      share: 'fixed'
     },
     identityCards: () => ({ create: 'Connect a Linear workspace', existing: 'A connected Linear workspace' }),
     // Not `inviteBotHint`: nobody invites the app to an issue. A Linear session starts

--- a/packages/web/src/components/console/platforms/linear/mark.tsx
+++ b/packages/web/src/components/console/platforms/linear/mark.tsx
@@ -1,0 +1,27 @@
+// No 'use client' here: every consumer is already inside a client boundary —
+// `PlatformMark` (components/marks.tsx) and the module tree under ModalProvider.
+
+import { DEFAULT_MARK_FILL_PCT, markBox } from '@/components/mark-box'
+
+/** Linear's brand purple — the one literal color in this module (STYLE.md rule 1:
+ *  a brand value has no design token and stays literal). */
+const LINEAR_PURPLE = '#5e6ad2'
+
+/**
+ * Linear's brand mark ({@link WebPlatformModule.Mark}) — four parallel diagonal
+ * bars whose ends ride a circle, drawn here as paths rather than imported as an
+ * asset. The bar cluster spans ~68% of the viewBox, so the artwork carries its own
+ * padding and honours a full-bleed box uncapped, like Telegram's and Lark's.
+ */
+export function LinearMark({ fillPct = DEFAULT_MARK_FILL_PCT }: { fillPct?: number }) {
+  return (
+    <svg viewBox="0 0 100 100" style={markBox(fillPct)} fill="none" aria-hidden>
+      <g stroke={LINEAR_PURPLE} strokeWidth="9" strokeLinecap="round">
+        <path d="M16.1 47.9 47.9 16.1" />
+        <path d="M20.7 67.3 67.3 20.7" />
+        <path d="M32.7 79.3 79.3 32.7" />
+        <path d="M52.1 83.9 83.9 52.1" />
+      </g>
+    </svg>
+  )
+}

--- a/packages/web/src/components/console/platforms/linear/module.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/module.test.tsx
@@ -1,0 +1,90 @@
+// The Linear module as the registry sees it. A Linear Bot row IS one connected
+// workspace and its agents are members, which is a different shape from every other
+// platform's "one bot, one agent" — so what this pins is where that difference is
+// declared, and where it deliberately is not.
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { PLATFORM_MARK_IDS } from '../marks'
+import { BOT_PLATFORMS, INTEGRATION_BLURB, isCoreTriggerKind } from '../host-projections'
+import { channelListSemantics, platformRegistry, platformSupportsSharing } from '../registry'
+import { LinearMark } from './mark'
+import { linearApi } from './api'
+import { linearModule } from '.'
+
+const module = () => {
+  const found = platformRegistry.get('linear')
+  if (!found) throw new Error('no module registered for linear')
+  return found
+}
+
+describe('the linear registry row', () => {
+  it('registers the module once, last in picker order', () => {
+    expect(module()).toBe(linearModule)
+    expect(platformRegistry.ids().at(-1)).toBe('linear')
+    expect(PLATFORM_MARK_IDS).toContain('linear')
+  })
+
+  it('is a daemon-gated chat platform, not a relay-backed trigger kind', () => {
+    // The FIRST of the three availability conditions (§4.2). The picker gates a
+    // registry platform on the owning daemon's advertised adapters and must never
+    // gate a trigger kind that way — being in this list IS the gate.
+    expect(BOT_PLATFORMS.map((tile) => tile.key)).toContain('linear')
+    expect(isCoreTriggerKind('linear')).toBe(false)
+    expect(INTEGRATION_BLURB.linear).toBeTruthy()
+  })
+
+  it('declares multi-agent bots — a connected workspace serves every member', () => {
+    expect(platformSupportsSharing('linear')).toBe(true)
+    expect(module().wizard.affordances.share).toBe(true)
+  })
+})
+
+describe('the linear mark', () => {
+  it('renders inline SVG that honours the fill box uncapped', () => {
+    // The artwork carries its own padding (the bar cluster spans ~68% of the
+    // viewBox), so a full-bleed caller gets 100% rather than the square-glyph cap.
+    expect(renderToStaticMarkup(<LinearMark />)).toContain('width:60%')
+    expect(renderToStaticMarkup(<LinearMark fillPct={100} />)).toContain('width:100%')
+    const markup = renderToStaticMarkup(<LinearMark />)
+    expect(markup.startsWith('<svg')).toBe(true)
+    // Four bars, drawn here rather than imported as an asset.
+    expect(markup.match(/<path /g)).toHaveLength(4)
+  })
+})
+
+describe('the linear transcript and channel semantics', () => {
+  it('calls a room an issue and offers no leave affordance', () => {
+    const semantics = channelListSemantics('linear')
+    expect(semantics.roomNoun).toBe('issue')
+    expect(semantics.roomGlyph).toBe('')
+    expect(semantics.leave).toBe('none')
+    // Nobody is shown out of an issue from here, so the row hint names where the
+    // session actually ends instead of pointing at a control that does not exist.
+    expect(semantics.cannotLeaveRowHint).toContain('end the agent session in Linear')
+  })
+
+  it('dedupes on an agent-activity id and on nothing else', () => {
+    const row = (ts: string) => ({ seq: 1, sender: 'u', ts, kind: 'text', text: 'hi' })
+    const activity = '2f1c9c4e-0d3b-4f5a-8f31-9a2b6c7d8e90'
+    expect(linearModule.messageIdentity?.(row(activity))).toBe(`ts:${activity}`)
+    // Not a Slack decimal ts, not a snowflake, not a daemon-local millisecond stamp.
+    for (const ts of ['1754123456.000200', '1101111111111111111', '1754123457123', '', 'om_abc']) {
+      expect(linearModule.messageIdentity?.(row(ts)), ts).toBeNull()
+    }
+  })
+
+  it('orders pages by the daemon sequence', () => {
+    expect(linearModule.transcriptOrdering).toBe('seq')
+  })
+})
+
+describe('the linear api bindings', () => {
+  it('names the funnel, its reconnect arm and the default-agent move — and nothing else', () => {
+    // Removing a member is deliberately absent: it is the generic
+    // DELETE /integrations/:id, committed through the console's own data context so
+    // the integration/bot projections refresh with it.
+    expect(Object.keys(linearApi).sort()).toEqual(['getConnect', 'reconnect', 'setDefaultAgent', 'startConnect'])
+    expect(module().apiBindings).toBe(linearApi)
+  })
+})

--- a/packages/web/src/components/console/platforms/linear/module.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/module.test.tsx
@@ -7,7 +7,13 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import { PLATFORM_MARK_IDS } from '../marks'
 import { BOT_PLATFORMS, INTEGRATION_BLURB, isCoreTriggerKind } from '../host-projections'
-import { channelListSemantics, platformRegistry, platformSupportsSharing } from '../registry'
+import {
+  botSharingEditable,
+  channelListSemantics,
+  platformRegistry,
+  platformSharingFixed,
+  platformSupportsSharing
+} from '../registry'
 import { LinearMark } from './mark'
 import { linearApi } from './api'
 import { linearModule } from '.'
@@ -34,9 +40,13 @@ describe('the linear registry row', () => {
     expect(INTEGRATION_BLURB.linear).toBeTruthy()
   })
 
-  it('declares multi-agent bots — a connected workspace serves every member', () => {
+  it('declares multi-agent bots as STRUCTURAL — a workspace is not opted into sharing', () => {
+    // Reuse must still admit members, so the platform supports sharing; but the
+    // provider stamps the flag (§4.3), so neither surface offers a control for it.
+    expect(module().wizard.affordances.share).toBe('fixed')
     expect(platformSupportsSharing('linear')).toBe(true)
-    expect(module().wizard.affordances.share).toBe(true)
+    expect(platformSharingFixed('linear')).toBe(true)
+    expect(botSharingEditable({ platform: 'linear', transport: 'http', shareable: true })).toBe(false)
   })
 })
 

--- a/packages/web/src/components/console/platforms/linear/settings.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/settings.test.tsx
@@ -16,7 +16,9 @@ const mocks = vi.hoisted(() => ({
   setBotPreferredAgent: vi.fn(),
   deleteIntegration: vi.fn(),
   refresh: vi.fn(),
-  integrations: [] as { id?: string; botId?: string; agentId?: string }[]
+  integrations: [] as { id?: string; botId?: string; agentId?: string }[],
+  // Per-agent placement/visibility, which is what the default derivation reads.
+  agents: {} as Record<string, { visibility?: string; placementKind?: string; setId?: string | null; daemon?: string }>
 }))
 
 vi.mock('@/lib/api', async (importOriginal) => ({
@@ -35,12 +37,22 @@ vi.mock('@/lib/data-context', () => ({
       id,
       name: id,
       runtime: 'claude',
-      icon: { kind: 'glyph', glyph: 'bot', color: '#333' }
+      icon: { kind: 'glyph', glyph: 'bot', color: '#333' },
+      visibility: 'org',
+      placementKind: 'daemon',
+      setId: null,
+      daemon: 'daemon-1',
+      ...mocks.agents[id]
     })
   })
 }))
 
-import { linearDefaultAgentId, linearSettingsFragments, LINEAR_DEFAULT_REMOVE_BLOCKED } from './settings'
+import {
+  linearSettingsFragments,
+  LINEAR_DEFAULT_REMOVE_BLOCKED,
+  LINEAR_INELIGIBLE_DEFAULT,
+  LINEAR_MAYBE_DEFAULT_REMOVE_BLOCKED
+} from './settings'
 
 const fragments = linearSettingsFragments.lifecycleActions!
 const { CardProvider, RowActions } = fragments
@@ -102,6 +114,7 @@ beforeEach(() => {
   mocks.setBotPreferredAgent.mockReset()
   mocks.deleteIntegration.mockReset()
   mocks.refresh.mockReset()
+  mocks.agents = {}
   mocks.getLinearConnect.mockResolvedValue({ id: 'c1', status: 'pending', failureReason: null, botId: null })
   mocks.integrations = [
     { id: 'int-a', botId: 'bot-9', agentId: 'agent-a' },
@@ -120,19 +133,6 @@ afterEach(async () => {
   await act(async () => root.unmount())
   host.remove()
   vi.unstubAllGlobals()
-})
-
-describe('linearDefaultAgentId', () => {
-  it('honours the persisted pointer', () => {
-    expect(linearDefaultAgentId({ preferredAgentId: 'agent-b', agentIds: ['agent-a', 'agent-b'] })).toBe('agent-b')
-  })
-
-  it('falls back to the earliest member, which is what the compile does', () => {
-    expect(linearDefaultAgentId({ preferredAgentId: null, agentIds: ['agent-a', 'agent-b'] })).toBe('agent-a')
-    // A pointer at an agent that left degrades to the derivation rather than to nothing.
-    expect(linearDefaultAgentId({ preferredAgentId: 'agent-gone', agentIds: ['agent-a'] })).toBe('agent-a')
-    expect(linearDefaultAgentId({ preferredAgentId: null, agentIds: [] })).toBeNull()
-  })
 })
 
 describe('the workspace card, live', () => {
@@ -228,10 +228,48 @@ describe('removing a member', () => {
   })
 
   it('blocks whichever member is the EFFECTIVE default, pointer or not', async () => {
-    // With no persisted pointer the earliest member catches bare delegations, so it
-    // is the one that must not be removable.
+    // With no persisted pointer the earliest ELIGIBLE member catches bare delegations,
+    // so it is the one that must not be removable.
     await renderCard(bot({ preferredAgentId: null }))
     expect(buttonWithLabel('Remove agent-a')!.disabled).toBe(true)
     expect(buttonWithLabel('Remove agent-b')!.disabled).toBe(false)
+  })
+
+  it('follows the compiler past a member it would skip, and protects the real default', async () => {
+    // The regression: a membership-order read marks the restricted first member and
+    // leaves the routable one removable — deleting the workspace's actual default.
+    mocks.agents = { 'agent-a': { visibility: 'restricted' } }
+    await renderCard(bot({ preferredAgentId: 'agent-a' }))
+
+    expect(buttonWithLabel('Remove agent-a')!.disabled).toBe(false)
+    const realDefault = buttonWithLabel('Remove agent-b')!
+    expect(realDefault.disabled).toBe(true)
+    expect(realDefault.getAttribute('title')).toBe(LINEAR_DEFAULT_REMOVE_BLOCKED)
+  })
+
+  it('protects every member that could be the default while a duty hold is unknowable', async () => {
+    // A set placement is routable only while some member holds the duty, which the
+    // console cannot see — so both A and the member behind it stay protected.
+    mocks.agents = { 'agent-a': { placementKind: 'set', setId: 'set-1', daemon: 'pool' } }
+    await renderCard(bot({ preferredAgentId: null }))
+
+    expect(buttonWithLabel('Remove agent-a')!.disabled).toBe(true)
+    const behind = buttonWithLabel('Remove agent-b')!
+    expect(behind.disabled).toBe(true)
+    expect(behind.getAttribute('title')).toBe(LINEAR_MAYBE_DEFAULT_REMOVE_BLOCKED)
+  })
+})
+
+describe('naming a default', () => {
+  it('refuses a member the compile would ignore anyway', async () => {
+    // Persisting a pointer at a restricted agent writes a preference nothing honors.
+    mocks.agents = { 'agent-b': { visibility: 'restricted' } }
+    await renderCard(bot({ preferredAgentId: 'agent-a' }))
+    const make = buttonWithText('Make default') as HTMLButtonElement
+
+    expect(make.disabled).toBe(true)
+    expect(make.getAttribute('title')).toBe(LINEAR_INELIGIBLE_DEFAULT)
+    await act(async () => make.click())
+    expect(mocks.setBotPreferredAgent).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/console/platforms/linear/settings.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/settings.test.tsx
@@ -1,0 +1,237 @@
+// @vitest-environment happy-dom
+
+// The workspace card (§7.4). Three states it has to get right: a live workspace with
+// its members and their default, a dead grant whose repair is the reconnect funnel,
+// and the ONE removal the console must refuse — dropping the default member, which
+// would leave every bare delegation with nowhere to go.
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BotDto } from '@/lib/api'
+
+const mocks = vi.hoisted(() => ({
+  reconnectLinearWorkspace: vi.fn(),
+  getLinearConnect: vi.fn(),
+  setBotPreferredAgent: vi.fn(),
+  deleteIntegration: vi.fn(),
+  refresh: vi.fn(),
+  integrations: [] as { id?: string; botId?: string; agentId?: string }[]
+}))
+
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  reconnectLinearWorkspace: mocks.reconnectLinearWorkspace,
+  getLinearConnect: mocks.getLinearConnect,
+  setBotPreferredAgent: mocks.setBotPreferredAgent
+}))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    refresh: mocks.refresh,
+    deleteIntegration: mocks.deleteIntegration,
+    integrations: mocks.integrations,
+    // A glyph icon keeps the member rows from reaching for a runtime brand image.
+    getAgent: (id: string) => ({
+      id,
+      name: id,
+      runtime: 'claude',
+      icon: { kind: 'glyph', glyph: 'bot', color: '#333' }
+    })
+  })
+}))
+
+import { linearDefaultAgentId, linearSettingsFragments, LINEAR_DEFAULT_REMOVE_BLOCKED } from './settings'
+
+const fragments = linearSettingsFragments.lifecycleActions!
+const { CardProvider, RowActions } = fragments
+const CardNotice = fragments.CardNotice!
+
+function bot(over: Partial<BotDto> = {}): BotDto {
+  return {
+    id: 'bot-9',
+    name: 'Example Workspace',
+    platform: 'linear',
+    prebuilt: false,
+    slackAppId: null,
+    discordAppId: null,
+    createdBy: null,
+    transport: 'http',
+    shareable: true,
+    inUseByAgentId: null,
+    agentIds: ['agent-a', 'agent-b'],
+    lastUsedAt: null,
+    freedFromAgent: null,
+    workspaceName: 'Example Workspace',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...over
+  }
+}
+
+let host: HTMLDivElement
+let root: Root
+
+const text = () => host.textContent ?? ''
+const buttons = () => [...host.querySelectorAll('button')]
+const buttonWithText = (label: string) => buttons().find((b) => b.textContent?.includes(label))
+const buttonWithLabel = (label: string) =>
+  buttons().find((b) => b.getAttribute('aria-label')?.includes(label)) as HTMLButtonElement | undefined
+
+async function settle(): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  }
+}
+
+async function renderCard(row: BotDto): Promise<void> {
+  await act(async () =>
+    root.render(
+      <CardProvider>
+        <RowActions bot={row} canWrite />
+        <CardNotice bot={row} />
+      </CardProvider>
+    )
+  )
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  mocks.reconnectLinearWorkspace.mockReset()
+  mocks.getLinearConnect.mockReset()
+  mocks.setBotPreferredAgent.mockReset()
+  mocks.deleteIntegration.mockReset()
+  mocks.refresh.mockReset()
+  mocks.getLinearConnect.mockResolvedValue({ id: 'c1', status: 'pending', failureReason: null, botId: null })
+  mocks.integrations = [
+    { id: 'int-a', botId: 'bot-9', agentId: 'agent-a' },
+    { id: 'int-b', botId: 'bot-9', agentId: 'agent-b' }
+  ]
+  vi.stubGlobal(
+    'open',
+    vi.fn(() => null)
+  )
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+  vi.unstubAllGlobals()
+})
+
+describe('linearDefaultAgentId', () => {
+  it('honours the persisted pointer', () => {
+    expect(linearDefaultAgentId({ preferredAgentId: 'agent-b', agentIds: ['agent-a', 'agent-b'] })).toBe('agent-b')
+  })
+
+  it('falls back to the earliest member, which is what the compile does', () => {
+    expect(linearDefaultAgentId({ preferredAgentId: null, agentIds: ['agent-a', 'agent-b'] })).toBe('agent-a')
+    // A pointer at an agent that left degrades to the derivation rather than to nothing.
+    expect(linearDefaultAgentId({ preferredAgentId: 'agent-gone', agentIds: ['agent-a'] })).toBe('agent-a')
+    expect(linearDefaultAgentId({ preferredAgentId: null, agentIds: [] })).toBeNull()
+  })
+})
+
+describe('the workspace card, live', () => {
+  it('shows the workspace, its connect status and its members with the default marked', async () => {
+    await renderCard(bot({ preferredAgentId: 'agent-b' }))
+
+    expect(text()).toContain('connected')
+    expect(text()).toContain('Example Workspace')
+    expect(text()).toContain('agent-a')
+    expect(text()).toContain('agent-b')
+    // One default, and it is the persisted one — the other member offers the move.
+    expect(host.querySelectorAll('.badge')).toHaveLength(2) // status pill + default badge
+    expect(buttonWithText('Make default')).toBeDefined()
+  })
+
+  it('offers the reconnect CTA on a healthy workspace too — a silent one keeps a valid token', async () => {
+    // §15: enabling agent session events raises a new scope, and until every prior
+    // authorization re-consents the workspace receives nothing while looking fine.
+    await renderCard(bot())
+    expect(text()).toContain('Reconnect to re-consent')
+    expect(buttonWithLabel('Reconnect this workspace')).toBeDefined()
+  })
+
+  it('moves the default through the bot patch', async () => {
+    mocks.setBotPreferredAgent.mockResolvedValue(bot({ preferredAgentId: 'agent-b' }))
+    await renderCard(bot({ preferredAgentId: 'agent-a' }))
+    await act(async () => buttonWithText('Make default')!.click())
+    await settle()
+
+    expect(mocks.setBotPreferredAgent).toHaveBeenCalledWith('bot-9', 'agent-b')
+    expect(mocks.refresh).toHaveBeenCalled()
+  })
+
+  it('surfaces the CP’s refusal instead of pretending the move landed', async () => {
+    mocks.setBotPreferredAgent.mockRejectedValue(new Error('default agent must be an agent that uses this bot'))
+    await renderCard(bot({ preferredAgentId: 'agent-a' }))
+    await act(async () => buttonWithText('Make default')!.click())
+    await settle()
+
+    expect(text()).toContain('default agent must be an agent that uses this bot')
+  })
+})
+
+describe('the workspace card, dead grant', () => {
+  it('says the grant expired and points at the reconnect', async () => {
+    await renderCard(bot({ revokedAt: '2026-02-01T00:00:00.000Z' }))
+
+    expect(text()).toContain('grant expired')
+    expect(text()).toContain('reconnect to restore delivery')
+  })
+
+  it('restarts the funnel against THIS workspace, never the org-level connect', async () => {
+    // The nonce is bound to the bot, so a reconnect can only ever re-authorize the
+    // workspace it was minted for (§7.4).
+    mocks.reconnectLinearWorkspace.mockResolvedValue({ id: 'c1', connectUrl: 'https://linear.app/oauth/authorize' })
+    await renderCard(bot({ revokedAt: '2026-02-01T00:00:00.000Z' }))
+    await act(async () => buttonWithLabel('Reconnect this workspace')!.click())
+    await settle()
+
+    expect(mocks.reconnectLinearWorkspace).toHaveBeenCalledWith('bot-9')
+    expect(window.open).toHaveBeenCalled()
+    expect(text()).toContain('Approve the workspace in the Linear tab')
+  })
+
+  it('reports a funnel that cannot start at all', async () => {
+    mocks.reconnectLinearWorkspace.mockRejectedValue(new Error('no relay is connected'))
+    await renderCard(bot({ revokedAt: '2026-02-01T00:00:00.000Z' }))
+    await act(async () => buttonWithLabel('Reconnect this workspace')!.click())
+    await settle()
+
+    expect(text()).toContain('no relay is connected')
+  })
+})
+
+describe('removing a member', () => {
+  it('blocks the default member and says what to do first', async () => {
+    await renderCard(bot({ preferredAgentId: 'agent-a' }))
+    const remove = buttonWithLabel('Remove agent-a')!
+
+    expect(remove.disabled).toBe(true)
+    expect(remove.getAttribute('title')).toBe(LINEAR_DEFAULT_REMOVE_BLOCKED)
+    await act(async () => remove.click())
+    expect(mocks.deleteIntegration).not.toHaveBeenCalled()
+  })
+
+  it('removes a non-default member through its own integration', async () => {
+    mocks.deleteIntegration.mockResolvedValue(undefined)
+    await renderCard(bot({ preferredAgentId: 'agent-a' }))
+    await act(async () => buttonWithLabel('Remove agent-b')!.click())
+    await settle()
+
+    expect(mocks.deleteIntegration).toHaveBeenCalledWith('int-b')
+  })
+
+  it('blocks whichever member is the EFFECTIVE default, pointer or not', async () => {
+    // With no persisted pointer the earliest member catches bare delegations, so it
+    // is the one that must not be removable.
+    await renderCard(bot({ preferredAgentId: null }))
+    expect(buttonWithLabel('Remove agent-a')!.disabled).toBe(true)
+    expect(buttonWithLabel('Remove agent-b')!.disabled).toBe(false)
+  })
+})

--- a/packages/web/src/components/console/platforms/linear/settings.tsx
+++ b/packages/web/src/components/console/platforms/linear/settings.tsx
@@ -19,21 +19,20 @@ import { agentLabel } from '@/lib/data'
 import type { WebBotSettingsFragments } from '../contract'
 import { linearApi } from './api'
 import { useLinearConnect } from './connect'
-
-/**
- * The member a bare delegation reaches: the workspace's persisted pointer, or —
- * while none is set — the earliest member, which is what the orchestrator's compile
- * falls back to. Null on a workspace with no members left.
- */
-export function linearDefaultAgentId(bot: Pick<BotDto, 'preferredAgentId' | 'agentIds'>): string | null {
-  const preferred = bot.preferredAgentId
-  if (preferred && bot.agentIds.includes(preferred)) return preferred
-  return bot.agentIds[0] ?? null
-}
+import { linearDefaultAgents, linearMemberEligibility } from './default-agent'
 
 /** Why the default member's Remove control is inert (§7.4): a workspace with members
  *  but no default would strand every bare delegation. */
 export const LINEAR_DEFAULT_REMOVE_BLOCKED = 'Make another agent the default first'
+
+/** Why a member that is not MARKED default still cannot be removed: with a set-placed
+ *  member in the list the console cannot tell which one the compiler picks, so every
+ *  member that could be it is protected until a definite default is named. */
+export const LINEAR_MAYBE_DEFAULT_REMOVE_BLOCKED =
+  'This agent may be the workspace default — make a placed agent the default first'
+
+/** Why "Make default" is inert on a member the compiler would ignore anyway. */
+export const LINEAR_INELIGIBLE_DEFAULT = 'A restricted or unplaced agent cannot catch a bare delegation'
 
 interface LinearCardState {
   /** The workspace whose reconnect round trip is open, if any. */
@@ -171,7 +170,9 @@ function LinearCardNotice({ bot }: { bot: BotDto }) {
   // staleness signal not yet exposed — the CP publishes no `lastDeliveryAt`, so a
   // webhook-silent workspace is reachable only through the always-offered CTA below.
   const dead = !!bot.revokedAt
-  const defaultAgentId = linearDefaultAgentId(bot)
+  // The compiler's own eligibility, not membership order — and every member that could
+  // be the default while a set placement's duty holder is unknowable from here.
+  const { marked, candidates } = linearDefaultAgents(bot, getAgent)
   const open = card.reconnectingBotId === bot.id
   const busy = card.busyBotId === bot.id
   // Live rows carry an id; a demo row does not, and its member cannot be removed.
@@ -204,8 +205,17 @@ function LinearCardNotice({ bot }: { bot: BotDto }) {
         <div className="mt-[10px] overflow-hidden rounded-lg border border-(--border-subtle) bg-(--surface-card)">
           {bot.agentIds.map((agentId) => {
             const agent = getAgent(agentId)
-            const isDefault = agentId === defaultAgentId
+            const isDefault = agentId === marked
+            // Blocked for the marked default AND for every other member that could
+            // still turn out to be it — removing the real one strands bare delegations.
+            const blocked = candidates.includes(agentId)
+            const eligible = linearMemberEligibility(agent) !== 'ineligible'
             const integrationId = integrationIdOf(agentId)
+            const removeTitle = isDefault
+              ? LINEAR_DEFAULT_REMOVE_BLOCKED
+              : blocked
+                ? LINEAR_MAYBE_DEFAULT_REMOVE_BLOCKED
+                : 'Remove this agent from the workspace'
             return (
               <div
                 key={agentId}
@@ -225,21 +235,24 @@ function LinearCardNotice({ bot }: { bot: BotDto }) {
                 ) : (
                   <button
                     type="button"
-                    disabled={busy}
+                    // A restricted or unplaced agent is one the compile skips, so naming
+                    // it would persist a pointer nothing honors.
+                    disabled={busy || !eligible}
+                    title={eligible ? 'Bare delegations start a session with this agent' : LINEAR_INELIGIBLE_DEFAULT}
                     onClick={() => card.moveDefault(bot, agentId)}
-                    className={`chip flex-none px-[9px] py-[3px] text-[11.5px] ${busy ? 'cursor-default opacity-55' : 'cursor-pointer'}`}
+                    className={`chip flex-none px-[9px] py-[3px] text-[11.5px] ${busy || !eligible ? 'cursor-not-allowed opacity-55' : 'cursor-pointer'}`}
                   >
                     Make default
                   </button>
                 )}
                 <button
                   type="button"
-                  disabled={isDefault || busy || !integrationId}
-                  title={isDefault ? LINEAR_DEFAULT_REMOVE_BLOCKED : 'Remove this agent from the workspace'}
+                  disabled={blocked || busy || !integrationId}
+                  title={removeTitle}
                   aria-label={`Remove ${agent ? agentLabel(agent) : agentId} from the workspace`}
                   onClick={() => integrationId && card.removeMember(bot, integrationId)}
                   className={`iconbtn h-7 w-7 flex-none ${
-                    isDefault || busy || !integrationId ? 'cursor-not-allowed opacity-45' : 'cursor-pointer'
+                    blocked || busy || !integrationId ? 'cursor-not-allowed opacity-45' : 'cursor-pointer'
                   }`}
                 >
                   <Icon name="user-minus" size={13} />

--- a/packages/web/src/components/console/platforms/linear/settings.tsx
+++ b/packages/web/src/components/console/platforms/linear/settings.tsx
@@ -1,0 +1,282 @@
+'use client'
+
+// The Linear WORKSPACE CARD (linear-integration.md §7.4, §9.5). A Linear bot row IS
+// one connected workspace, so what the Settings → Bots card needs beside it is not a
+// bot adornment but a small membership surface: who is on the workspace, which member
+// catches a bare delegation, and how to repair a grant that stopped working.
+//
+// The state lives behind the module's own context (the contract's
+// `lifecycleActions.CardProvider`), mounted once per platform tab, because the row
+// action and the card notice drive the SAME reconnect round trip and must not each
+// open their own.
+
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react'
+import { AgentIconView } from '@/components/marks'
+import { Icon } from '@/components/ui'
+import type { BotDto } from '@/lib/api'
+import { useConsoleData } from '@/lib/data-context'
+import { agentLabel } from '@/lib/data'
+import type { WebBotSettingsFragments } from '../contract'
+import { linearApi } from './api'
+import { useLinearConnect } from './connect'
+
+/**
+ * The member a bare delegation reaches: the workspace's persisted pointer, or —
+ * while none is set — the earliest member, which is what the orchestrator's compile
+ * falls back to. Null on a workspace with no members left.
+ */
+export function linearDefaultAgentId(bot: Pick<BotDto, 'preferredAgentId' | 'agentIds'>): string | null {
+  const preferred = bot.preferredAgentId
+  if (preferred && bot.agentIds.includes(preferred)) return preferred
+  return bot.agentIds[0] ?? null
+}
+
+/** Why the default member's Remove control is inert (§7.4): a workspace with members
+ *  but no default would strand every bare delegation. */
+export const LINEAR_DEFAULT_REMOVE_BLOCKED = 'Make another agent the default first'
+
+interface LinearCardState {
+  /** The workspace whose reconnect round trip is open, if any. */
+  reconnectingBotId: string | null
+  connectErr: string | null
+  startReconnect(botId: string): void
+  /** The workspace whose membership write is in flight — one per card. */
+  busyBotId: string | null
+  rowErr: { botId: string; message: string } | null
+  moveDefault(bot: BotDto, agentId: string): void
+  removeMember(bot: BotDto, integrationId: string): void
+}
+
+const CardCtx = createContext<LinearCardState | null>(null)
+
+function useLinearCard(): LinearCardState {
+  const state = useContext(CardCtx)
+  if (!state) throw new Error('Linear settings fragment rendered outside its CardProvider')
+  return state
+}
+
+function LinearCardProvider({ children }: { children: ReactNode }) {
+  const { refresh, deleteIntegration } = useConsoleData()
+  const [reconnectingBotId, setReconnectingBotId] = useState<string | null>(null)
+  const [busyBotId, setBusyBotId] = useState<string | null>(null)
+  const [rowErr, setRowErr] = useState<{ botId: string; message: string } | null>(null)
+  // The bot the pending mint is for. A ref, not the state above: `start()` reads its
+  // mint closure in the same tick as the click, before a setState has landed.
+  const target = useRef<string | null>(null)
+
+  const flow = useLinearConnect(
+    () => linearApi.reconnect(target.current ?? ''),
+    () => {
+      setReconnectingBotId(null)
+      void refresh()
+    }
+  )
+
+  const { start, clearError } = flow
+  const startReconnect = useCallback(
+    (botId: string) => {
+      target.current = botId
+      setReconnectingBotId(botId)
+      setRowErr(null)
+      clearError()
+      start()
+    },
+    [clearError, start]
+  )
+
+  const write = useCallback(async (botId: string, run: () => Promise<unknown>) => {
+    setBusyBotId(botId)
+    setRowErr(null)
+    try {
+      await run()
+    } catch (e) {
+      setRowErr({ botId, message: e instanceof Error ? e.message : String(e) })
+    } finally {
+      setBusyBotId(null)
+    }
+  }, [])
+
+  const moveDefault = useCallback(
+    (bot: BotDto, agentId: string) => {
+      void write(bot.id, async () => {
+        await linearApi.setDefaultAgent(bot.id, agentId)
+        await refresh()
+      })
+    },
+    [refresh, write]
+  )
+
+  const removeMember = useCallback(
+    (bot: BotDto, integrationId: string) => {
+      void write(bot.id, () => deleteIntegration(integrationId))
+    },
+    [deleteIntegration, write]
+  )
+
+  // The round trip is not open once it settles, whichever way it went.
+  const openBotId = flow.phase === 'authorizing' ? reconnectingBotId : null
+  const value = useMemo<LinearCardState>(
+    () => ({
+      reconnectingBotId: openBotId,
+      connectErr: flow.appMissing ? 'Linear isn’t set up on this deployment.' : flow.err,
+      startReconnect,
+      busyBotId,
+      rowErr,
+      moveDefault,
+      removeMember
+    }),
+    [busyBotId, flow.appMissing, flow.err, moveDefault, openBotId, removeMember, rowErr, startReconnect]
+  )
+
+  return <CardCtx.Provider value={value}>{children}</CardCtx.Provider>
+}
+
+/** The row's Reconnect control, in the card's 100px action track. Haloed while the
+ *  grant is known dead — the same needs-attention shape Slack's refresh uses. */
+function LinearRowActions({ bot, canWrite }: { bot: BotDto; canWrite: boolean }) {
+  const card = useLinearCard()
+  const open = card.reconnectingBotId === bot.id
+  const dead = !!bot.revokedAt
+  return (
+    <button
+      type="button"
+      disabled={!canWrite || open}
+      title={open ? 'Waiting for Linear…' : 'Reconnect this workspace'}
+      aria-label="Reconnect this workspace"
+      onClick={() => card.startReconnect(bot.id)}
+      className={`iconbtn h-7 w-7 flex-none ${dead ? 'border-(--status-error) text-(--status-error)' : ''} ${
+        open ? 'cursor-default opacity-55' : 'cursor-pointer'
+      }`}
+    >
+      <Icon name={open ? 'loader' : 'refresh-cw'} size={13} className={open ? 'animate-spin' : ''} />
+    </button>
+  )
+}
+
+/**
+ * The workspace card body, under the bot row: connect status, the member agents with
+ * the default marked and movable, and the Reconnect CTA.
+ *
+ * The CTA is offered on a LIVE workspace too, not only a dead grant. Enabling agent
+ * session events on an already-installed Linear app raises a new scope, and until
+ * every prior authorization re-consents the workspace keeps a perfectly valid token
+ * while receiving nothing (§15) — so the repair has to be reachable from the healthy
+ * state as well.
+ */
+function LinearCardNotice({ bot }: { bot: BotDto }) {
+  const card = useLinearCard()
+  const { getAgent, integrations } = useConsoleData()
+  if (bot.platform !== 'linear') return null
+
+  // staleness signal not yet exposed — the CP publishes no `lastDeliveryAt`, so a
+  // webhook-silent workspace is reachable only through the always-offered CTA below.
+  const dead = !!bot.revokedAt
+  const defaultAgentId = linearDefaultAgentId(bot)
+  const open = card.reconnectingBotId === bot.id
+  const busy = card.busyBotId === bot.id
+  // Live rows carry an id; a demo row does not, and its member cannot be removed.
+  const integrationIdOf = (agentId: string): string | undefined =>
+    integrations.find((row) => row.botId === bot.id && row.agentId === agentId)?.id
+
+  return (
+    <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 py-[10px] pl-10">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <span
+          className={`badge ${dead ? 'bg-(--status-error-soft) text-(--status-error)' : 'bg-(--surface-active) text-(--text-tertiary)'}`}
+        >
+          {dead ? 'grant expired' : 'connected'}
+        </span>
+        <span className="mono min-w-0 truncate text-[12px] text-(--text-secondary)">
+          {bot.workspaceName || bot.name}
+        </span>
+        <span className="min-w-0 flex-1 font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
+          {dead
+            ? 'Linear no longer accepts this workspace’s grant — reconnect to restore delivery.'
+            : 'Delegations not arriving? Reconnect to re-consent the workspace’s event subscription.'}
+        </span>
+      </div>
+      {card.connectErr && card.reconnectingBotId === null && (
+        <div className="mt-[6px] font-sans text-[11.5px] font-normal leading-[1.4] text-(--status-error)">
+          {card.connectErr}
+        </div>
+      )}
+      {bot.agentIds.length > 0 && (
+        <div className="mt-[10px] overflow-hidden rounded-lg border border-(--border-subtle) bg-(--surface-card)">
+          {bot.agentIds.map((agentId) => {
+            const agent = getAgent(agentId)
+            const isDefault = agentId === defaultAgentId
+            const integrationId = integrationIdOf(agentId)
+            return (
+              <div
+                key={agentId}
+                className="flex items-center gap-[10px] border-b border-(--border-subtle) px-3 py-2 last:border-b-0"
+              >
+                <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
+                  <AgentIconView icon={agent?.icon} runtime={agent?.runtime || agent?.model || ''} size={22} />
+                </span>
+                <span className="mono min-w-0 flex-1 truncate text-[12px]">{agent ? agentLabel(agent) : agentId}</span>
+                {isDefault ? (
+                  <span
+                    className="badge flex-none bg-(--surface-active) text-(--text-secondary)"
+                    title="Bare delegations start a session with this agent"
+                  >
+                    default
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => card.moveDefault(bot, agentId)}
+                    className={`chip flex-none px-[9px] py-[3px] text-[11.5px] ${busy ? 'cursor-default opacity-55' : 'cursor-pointer'}`}
+                  >
+                    Make default
+                  </button>
+                )}
+                <button
+                  type="button"
+                  disabled={isDefault || busy || !integrationId}
+                  title={isDefault ? LINEAR_DEFAULT_REMOVE_BLOCKED : 'Remove this agent from the workspace'}
+                  aria-label={`Remove ${agent ? agentLabel(agent) : agentId} from the workspace`}
+                  onClick={() => integrationId && card.removeMember(bot, integrationId)}
+                  className={`iconbtn h-7 w-7 flex-none ${
+                    isDefault || busy || !integrationId ? 'cursor-not-allowed opacity-45' : 'cursor-pointer'
+                  }`}
+                >
+                  <Icon name="user-minus" size={13} />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+      {card.rowErr?.botId === bot.id && (
+        <div className="mt-[6px] font-sans text-[11.5px] font-normal leading-[1.4] text-(--status-error)">
+          {card.rowErr.message}
+        </div>
+      )}
+      {open && (
+        <div className="mt-[6px] font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
+          Approve the workspace in the Linear tab — this card updates once it lands.
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const linearSettingsFragments: WebBotSettingsFragments = {
+  lifecycleActions: { CardProvider: LinearCardProvider, RowActions: LinearRowActions, CardNotice: LinearCardNotice },
+  copy: {
+    // A Linear bot row is a connected WORKSPACE, so the card's heading, delete
+    // tooltip and empty state all read that word rather than "bot".
+    identityNoun: 'workspace',
+    // Linear can genuinely reach `revokedAt`: the `OAuthApp revoked` doorbell stamps
+    // it and flips every membership (§7.4), and reconnecting is what repairs it.
+    revokedHint: 'This workspace revoked the Linear app — reconnect to restore delivery',
+    // A connected workspace is definitionally multi-agent (§4.3): the provider stamps
+    // `shareable: true` structurally, so the toggle is never the operator's lever.
+    shareHint: {
+      available: 'Every connected Linear workspace serves all of its member agents',
+      unavailable: 'Every connected Linear workspace serves all of its member agents'
+    }
+  }
+}

--- a/packages/web/src/components/console/platforms/marks.ts
+++ b/packages/web/src/components/console/platforms/marks.ts
@@ -4,6 +4,7 @@
 import type { ComponentType } from 'react'
 import { DiscordMark } from './discord/mark'
 import { FeishuMark } from './feishu/mark'
+import { LinearMark } from './linear/mark'
 import { SlackMark } from './slack/mark'
 import { TelegramMark } from './telegram/mark'
 
@@ -32,6 +33,7 @@ const MARKS = new Map<string, PlatformMarkComponent>([
   ['telegram', TelegramMark],
   ['discord', DiscordMark],
   ['feishu', FeishuMark],
+  ['linear', LinearMark],
   // Lark and Feishu are one platform id (`feishu`) with the cloud on a separate
   // `region` field, so nothing in the console routes a bare 'lark' here today.
   // The alias is kept because the id IS the other cloud's brand name and the

--- a/packages/web/src/components/console/platforms/platform-set.test.tsx
+++ b/packages/web/src/components/console/platforms/platform-set.test.tsx
@@ -56,7 +56,7 @@ describe('platform set', () => {
     // picker names both so a Feishu user recognizes their own tile.
     expect(platformLabel('feishu')).toEqual({ name: 'Lark', picker: 'Lark/Feishu' })
     expect(platformLabel('lark')).toEqual(platformLabel('feishu'))
-    for (const id of ['slack', 'telegram', 'discord']) {
+    for (const id of ['slack', 'telegram', 'discord', 'linear']) {
       const label = platformLabel(id)!
       expect(label.name, id).toBe(label.picker)
     }
@@ -122,7 +122,14 @@ describe('platform set', () => {
         expect(tab.label, tab.key).toBe(larkFeishuBrand(tab.region))
       }
     }
-    expect(BOT_PLATFORM_TABS.map((tab) => tab.label)).toEqual(['Slack', 'Telegram', 'Discord', 'Lark', 'Feishu'])
+    expect(BOT_PLATFORM_TABS.map((tab) => tab.label)).toEqual([
+      'Slack',
+      'Telegram',
+      'Discord',
+      'Lark',
+      'Feishu',
+      'Linear'
+    ])
   })
 
   it('routes each bot to exactly one tab, region rows included', () => {
@@ -154,10 +161,11 @@ describe('platform set', () => {
   it('names the bot identity from the module, not from the tab table', () => {
     // The noun was the tab table's own column ('app' for Slack, 'bot' for the
     // rest). It is module copy now, so the card's heading, delete tooltip and
-    // empty state read one declaration.
-    expect(botCardCopy('slack').identityNoun).toBe('app')
-    for (const id of platformRegistry.ids().filter((p) => p !== 'slack')) {
-      expect(botCardCopy(id).identityNoun, id).toBe('bot')
+    // empty state read one declaration — and a row that is not a bot at all can
+    // say so ('workspace' on Linear, where the row IS one connected workspace).
+    const NOUNS: Record<string, string> = { slack: 'app', linear: 'workspace' }
+    for (const id of platformRegistry.ids()) {
+      expect(botCardCopy(id).identityNoun, id).toBe(NOUNS[id] ?? 'bot')
     }
     expect(botCardCopy('zulip').identityNoun).toBe('bot')
   })

--- a/packages/web/src/components/console/platforms/registry.ts
+++ b/packages/web/src/components/console/platforms/registry.ts
@@ -5,6 +5,7 @@ import type { BotDto, SessionMessageDto } from '@/lib/api'
 import type { WebBotCardCopy, WebChannelListSemantics, WebPlatformModule, WebPlatformRegistry } from './contract'
 import { discordModule } from './discord'
 import { feishuModule } from './feishu'
+import { linearModule } from './linear'
 import { slackModule } from './slack'
 import { telegramModule } from './telegram'
 
@@ -20,7 +21,7 @@ import { telegramModule } from './telegram'
  *
  * Order is the picker order.
  */
-const MODULES: readonly WebPlatformModule[] = [slackModule, telegramModule, discordModule, feishuModule]
+const MODULES: readonly WebPlatformModule[] = [slackModule, telegramModule, discordModule, feishuModule, linearModule]
 
 const BY_ID = new Map(MODULES.map((m) => [m.platformId, m]))
 const IDS: readonly string[] = MODULES.map((m) => m.platformId)
@@ -53,9 +54,9 @@ export function channelListSemantics(platformId?: string): WebChannelListSemanti
  * otherwise — provider-free by construction, because the strings these replace
  * described Slack's model on every platform's rows.
  *
- * `shareHint`'s two arms are the SAME sentence here on purpose. The host picks
- * an arm by transport, but multi-agent bots are Slack-only at the CP, so for a
- * platform that declares nothing the transport arm is not the reason sharing is
+ * `shareHint`'s two arms are the SAME sentence here on purpose. The host picks an
+ * arm by transport, but a platform that declares nothing supports no multi-agent
+ * bot at any transport, so the arm it lands on is not the reason sharing is
  * unavailable and a second sentence would promise a fix that does not exist.
  */
 export const DEFAULT_BOT_CARD_COPY: Required<WebBotCardCopy> = {

--- a/packages/web/src/components/console/platforms/registry.ts
+++ b/packages/web/src/components/console/platforms/registry.ts
@@ -98,7 +98,23 @@ export function botCardCopy(platformId?: string): Required<WebBotCardCopy> {
  * platforms that do not declare it here.
  */
 export function platformSupportsSharing(platformId?: string): boolean {
-  return (platformId ? platformRegistry.get(platformId)?.wizard.affordances.share : undefined) === true
+  const share = platformId ? platformRegistry.get(platformId)?.wizard.affordances.share : undefined
+  return share === true || share === 'fixed'
+}
+
+/**
+ * Whether multi-agent is STRUCTURAL here rather than an operator's opt-in
+ * (`share: 'fixed'`) — the provider stamps `shareable` itself and no console
+ * surface may move it.
+ *
+ * A second lookup rather than a second declaration: both read the one
+ * `affordances.share` value, so "supports sharing" and "the operator chooses it"
+ * cannot drift apart the way a mirrored flag would. Callers use it to SUPPRESS a
+ * control, never to grant one — a platform that answers true here already answers
+ * true to {@link platformSupportsSharing}.
+ */
+export function platformSharingFixed(platformId?: string): boolean {
+  return (platformId ? platformRegistry.get(platformId)?.wizard.affordances.share : undefined) === 'fixed'
 }
 
 /**
@@ -116,8 +132,15 @@ export function platformSupportsSharing(platformId?: string): boolean {
  * toggle was transport-gated only, the PATCH accepted the flip, so rows on a
  * non-sharing platform may already carry `shareable: true`. The CP still honors
  * turning those OFF, so the console must keep the control that does it.
+ *
+ * A `share: 'fixed'` platform is refused BEFORE that hatch, and the order is the
+ * whole point: its rows all carry `shareable: true` structurally, so the hatch
+ * would hand every one of them a live control for a flag the provider owns. The
+ * CP would accept a lone-member `shareable: false` PATCH, and the only way back
+ * is re-running the OAuth funnel.
  */
 export function botSharingEditable(bot: Pick<BotDto, 'platform' | 'transport' | 'shareable'>): boolean {
+  if (platformSharingFixed(bot.platform)) return false
   if (bot.shareable) return true
   return platformSupportsSharing(bot.platform) && (bot.transport ?? 'socket') === 'http'
 }

--- a/packages/web/src/components/console/platforms/reuse.test.ts
+++ b/packages/web/src/components/console/platforms/reuse.test.ts
@@ -180,8 +180,11 @@ describe('affordances', () => {
     }
   })
 
-  it('slack and linear offer multi-agent bots, nobody else does', () => {
-    for (const id of ['slack', 'linear']) expect(wizardOf(id).affordances.share, id).toBe(true)
+  it('slack and linear offer multi-agent bots, nobody else does — and differ in how', () => {
+    // Slack's is an opt-in the operator makes; Linear's is structural, stamped by the
+    // provider on every connected workspace, so no surface offers a control for it.
+    expect(wizardOf('slack').affordances.share).toBe(true)
+    expect(wizardOf('linear').affordances.share).toBe('fixed')
     for (const id of ['telegram', 'discord', 'feishu']) {
       expect(wizardOf(id).affordances.share, id).toBeUndefined()
     }

--- a/packages/web/src/components/console/platforms/reuse.test.ts
+++ b/packages/web/src/components/console/platforms/reuse.test.ts
@@ -42,9 +42,10 @@ const wizardOf = (id: string) => {
 }
 
 describe('platform registry', () => {
-  it('registers exactly the four chat platforms, in picker order', () => {
-    expect(platformRegistry.ids()).toEqual(['slack', 'telegram', 'discord', 'feishu'])
-    expect(platformRegistry.all().map((m) => m.platformId)).toEqual(['slack', 'telegram', 'discord', 'feishu'])
+  it('registers exactly the five chat platforms, in picker order', () => {
+    const ids = ['slack', 'telegram', 'discord', 'feishu', 'linear']
+    expect(platformRegistry.ids()).toEqual(ids)
+    expect(platformRegistry.all().map((m) => m.platformId)).toEqual(ids)
   })
 
   it('does not register the core trigger kinds — those are chassis fragments', () => {
@@ -77,6 +78,16 @@ describe('freeBotFilter', () => {
     const feishu = wizardOf('feishu')
     expect(feishu.freeBotFilter(bot({ platform: 'feishu', feishuRegion: null }), ctx({ region: 'feishu' }))).toBe(true)
     expect(feishu.freeBotFilter(bot({ platform: 'feishu' }), ctx({ region: 'lark' }))).toBe(false)
+  })
+
+  it('linear offers every connected workspace, unfenced', () => {
+    // The Bot row IS the workspace and `shareable: true` is structural on it, so
+    // adding a member needs no reuse fence — the CP refuses nothing the list shows.
+    const linear = wizardOf('linear')
+    expect(linear.freeBotFilter(bot({ platform: 'linear', transport: 'http', shareable: true }), ctx())).toBe(true)
+    expect(linear.freeBotFilter(bot({ platform: 'linear', transport: 'http', agentIds: ['a', 'b'] }), ctx())).toBe(true)
+    // Not even the Slack-shaped disqualifier: `teamId` is a Slack platform-app column.
+    expect(linear.freeBotFilter(bot({ platform: 'linear', teamId: 'T0EXAMPLE1' }), ctx())).toBe(true)
   })
 
   it('telegram and discord add nothing to the chassis predicate', () => {
@@ -130,6 +141,17 @@ describe('buildReuseInput', () => {
     ).toEqual({ platform: 'feishu', agentId: 'agent-1', botId: 'bot-1', transport: 'http' })
   })
 
+  it('linear pins http and never asks for shareable', () => {
+    // Linear has no dial-out transport, so a workspace bot is only ever http; and
+    // the provider stamps `shareable` structurally, so the caller never sends it.
+    expect(wizardOf('linear').buildReuseInput(bot({ id: 'ws-1', platform: 'linear' }), ctx({ shared: true }))).toEqual({
+      platform: 'linear',
+      agentId: 'agent-1',
+      botId: 'ws-1',
+      transport: 'http'
+    })
+  })
+
   it('telegram and discord carry neither transport nor shareable', () => {
     for (const id of ['telegram', 'discord']) {
       expect(wizardOf(id).buildReuseInput(bot({ id: 'b-2', platform: id }), ctx({ shared: true }))).toEqual({
@@ -151,14 +173,17 @@ describe('affordances', () => {
       labels: { socket: 'Long connection', http: 'HTTP callbacks' },
       httpByDefaultWhenRelayAvailable: false
     })
-    expect(wizardOf('telegram').affordances.transport).toBeUndefined()
-    expect(wizardOf('discord').affordances.transport).toBeUndefined()
+    // A SINGLE FIXED transport is the absent member, not a one-armed choice:
+    // Linear is http-only and Telegram/Discord socket-only.
+    for (const id of ['telegram', 'discord', 'linear']) {
+      expect(wizardOf(id).affordances.transport, id).toBeUndefined()
+    }
   })
 
-  it('only slack offers the shared-bot opt-in', () => {
-    expect(wizardOf('slack').affordances.share).toBe(true)
+  it('slack and linear offer multi-agent bots, nobody else does', () => {
+    for (const id of ['slack', 'linear']) expect(wizardOf(id).affordances.share, id).toBe(true)
     for (const id of ['telegram', 'discord', 'feishu']) {
-      expect(wizardOf(id).affordances.share).toBeUndefined()
+      expect(wizardOf(id).affordances.share, id).toBeUndefined()
     }
   })
 })
@@ -192,5 +217,14 @@ describe('region-parameterised copy', () => {
       create: 'Create with a Slack manifest',
       existing: 'An unused Slack app'
     })
+    // Linear's mode cards name a workspace, not a bot: create CONNECTS one and
+    // existing joins one the org already holds.
+    expect(wizardOf('linear').identityCards(undefined)).toEqual({
+      create: 'Connect a Linear workspace',
+      existing: 'A connected Linear workspace'
+    })
+    expect(wizardOf('linear').inviteHint(undefined)).toBe(
+      'delegate an issue to the app in Linear, or mention it to reach one agent by name.'
+    )
   })
 })

--- a/packages/web/src/components/console/platforms/text-renderer.test.tsx
+++ b/packages/web/src/components/console/platforms/text-renderer.test.tsx
@@ -83,7 +83,7 @@ describe('per-platform transcript text renderer', () => {
     // neighbours on their own renderers.
     const markup = renderTranscript([
       { text: 'a', platform: 'slack' },
-      { text: 'b', platform: 'linear' },
+      { text: 'b', platform: 'zulip' },
       { text: 'c', platform: 'discord' }
     ])
     expect(markup).toBe(

--- a/packages/web/src/components/console/platforms/transcript.test.ts
+++ b/packages/web/src/components/console/platforms/transcript.test.ts
@@ -10,7 +10,7 @@ import { platformMessageIdentity, platformRegistry, platformTextRenderer, platfo
  * everything unrecognized, while the contract says an absent member means the
  * platform opts out.
  */
-const UNCLAIMED = ['linear', 'hook', 'github', 'playground', 'webchat', 'lark', 'Slack', 'constructor', '__proto__', '']
+const UNCLAIMED = ['zulip', 'hook', 'github', 'playground', 'webchat', 'lark', 'Slack', 'constructor', '__proto__', '']
 
 let seq = 0
 function row(over: Partial<SessionMessageDto>): SessionMessageDto {
@@ -38,6 +38,10 @@ describe('transcript module members', () => {
     expect(platformMessageIdentity('discord', row({ ts: SNOWFLAKE }))).toBe(`ts:${SNOWFLAKE}`)
     expect(platformMessageIdentity('telegram', row({ ts: '4821' }))).toBe('ts:4821')
     expect(platformMessageIdentity('feishu', row({ ts: 'om_abc123' }))).toBe('ts:om_abc123')
+    const ACTIVITY = 'b0f4b1a2-6c1e-4a3f-9f21-7c0d5e8a1b34'
+    expect(platformMessageIdentity('linear', row({ ts: ACTIVITY }))).toBe(`ts:${ACTIVITY}`)
+    // A Slack-shaped decimal ts is not an agent-activity id, so Linear declines it.
+    expect(platformMessageIdentity('linear', row({ ts: '1754123456.000200' }))).toBeNull()
     // A daemon-local millisecond stamp is nobody's native id.
     for (const id of platformRegistry.ids()) {
       expect(platformMessageIdentity(id, row({ ts: '1754123457123' })), id).toBeNull()

--- a/packages/web/src/components/console/views/IntegrationsView.sharing.test.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.sharing.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+/**
+ * The Sharable cell, per platform. Slack's multi-agent mode is an operator opt-in and
+ * keeps its toggle; Linear's is structural — the provider stamps `shareable: true` on
+ * every connected workspace (linear-integration.md §4.3) — so the cell must STATE it
+ * rather than offer a control.
+ *
+ * A disabled toggle would not do: the CP accepts a `shareable: false` PATCH on a
+ * one-member bot, so the only thing standing between a workspace and a state its
+ * provider contract does not have is that no switch is rendered at all.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BotDto } from '@/lib/api'
+
+const mocks = vi.hoisted(() => ({ bots: [] as BotDto[] }))
+
+vi.mock('next/navigation', () => ({ useSearchParams: () => new URLSearchParams() }))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: vi.fn() }) }))
+vi.mock('@/lib/org-context', () => {
+  const orgs = { activeOrg: { id: 'org-1' }, myRole: 'owner', orgPath: (path: string) => path }
+  return { useOrgs: () => orgs }
+})
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    get bots() {
+      return mocks.bots
+    },
+    integrations: [],
+    agents: [],
+    loading: false,
+    getAgent: () => null,
+    refresh: vi.fn(),
+    deleteIntegration: vi.fn(),
+    setBotShareable: vi.fn(),
+    setChannelAgent: vi.fn()
+  })
+}))
+vi.mock('@/components/console/GitlabCard', () => ({ default: () => <div /> }))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
+  fetchGithubInstallUrl: vi.fn(async () => null),
+  syncGithubInstallations: vi.fn(async () => [])
+}))
+
+const IntegrationsView = (await import('./IntegrationsView')).default
+
+function bot(over: Partial<BotDto>): BotDto {
+  return {
+    id: 'bot-1',
+    name: 'support',
+    platform: 'slack',
+    prebuilt: false,
+    slackAppId: null,
+    discordAppId: null,
+    createdBy: null,
+    transport: 'http',
+    shareable: true,
+    inUseByAgentId: null,
+    agentIds: [],
+    lastUsedAt: null,
+    freedFromAgent: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...over
+  }
+}
+
+let host: HTMLDivElement
+let root: Root
+
+/**
+ * Render the view, switch the Bots card to `tabLabel`'s platform, and return that
+ * bot's ROW — scoped deliberately, because the card header carries a "Show in use"
+ * switch of its own that a document-wide query would find first.
+ */
+async function botRow(tabLabel: string, botId: string): Promise<HTMLElement> {
+  await act(async () => root.render(<IntegrationsView />))
+  const tab = [...host.querySelectorAll('button[role="tab"]')].find((b) => b.textContent?.includes(tabLabel))
+  if (!tab) throw new Error(`no Bots tab labeled "${tabLabel}"`)
+  await act(async () => (tab as HTMLButtonElement).click())
+  const row = host.querySelector<HTMLElement>(`#integration-bot-${botId}`)
+  if (!row) throw new Error(`no bot row for ${botId} under the ${tabLabel} tab`)
+  return row
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  mocks.bots = []
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+})
+
+describe('the Sharable cell', () => {
+  it('renders no switch at all for a Linear workspace', async () => {
+    mocks.bots = [
+      bot({ id: 'ws-1', platform: 'linear', name: 'Example Workspace', workspaceName: 'Example Workspace' })
+    ]
+    const row = await botRow('Linear', 'ws-1')
+
+    expect(row.querySelector('[role="switch"]')).toBeNull()
+    expect(row.textContent).toContain('Always')
+  })
+
+  it('keeps Slack’s toggle exactly as it was', async () => {
+    mocks.bots = [bot({ id: 'sl-1', platform: 'slack' })]
+    const row = await botRow('Slack', 'sl-1')
+
+    const toggle = row.querySelector('[role="switch"]')
+    expect(toggle).not.toBeNull()
+    expect(toggle?.getAttribute('aria-checked')).toBe('true')
+    expect((toggle as HTMLButtonElement).disabled).toBe(false)
+  })
+})

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -29,7 +29,12 @@ import {
   type MeDto
 } from '@/lib/api'
 import { agentLabel, isDirectConversation, type IntegrationRow } from '@/lib/data'
-import { botCardCopy, botSharingEditable, platformRegistry } from '@/components/console/platforms/registry'
+import {
+  botCardCopy,
+  botSharingEditable,
+  platformRegistry,
+  platformSharingFixed
+} from '@/components/console/platforms/registry'
 import { BOT_PLATFORM_TABS, botMatchesPlatformTab } from '@/components/console/platforms/host-projections'
 import DeleteBotModal from '@/components/console/modals/DeleteBotModal'
 import UninstallGithubInstallationModal from '@/components/console/modals/UninstallGithubInstallationModal'
@@ -505,11 +510,20 @@ function BotsCard({
                   }
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <Toggle
-                    checked={b.shareable}
-                    disabled={!canWrite || botBusyId === b.id || !botSharingEditable(b)}
-                    onChange={(next) => void flipShareable(b, next)}
-                  />
+                  {/* Structural sharing is not a control at all: the provider stamps
+                      the flag, so the cell states it rather than offering a toggle
+                      the CP would accept and the provider contract does not have. */}
+                  {platformSharingFixed(b.platform) ? (
+                    <span className="font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                      Always
+                    </span>
+                  ) : (
+                    <Toggle
+                      checked={b.shareable}
+                      disabled={!canWrite || botBusyId === b.id || !botSharingEditable(b)}
+                      onChange={(next) => void flipShareable(b, next)}
+                    />
+                  )}
                 </span>
                 <div className="flex min-w-0 items-center">
                   {b.agentIds.length > 0 ? (

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -752,6 +752,10 @@ export type CreateIntegrationInput =
         encryptKey?: string
       }
     })
+  // Linear carries no credential block from the console: a workspace bot only ever
+  // exists after the OAuth callback minted it, so the only create shape here is
+  // "add this agent as a member of a connected workspace" (linear-integration.md §7.1).
+  | (CreateIntegrationBase & { platform: 'linear'; transport?: 'http'; botId: string })
 
 export interface TelegramBotCheckDto {
   status: 'ready' | 'privacy_enabled' | 'invalid' | 'unreachable'
@@ -901,6 +905,9 @@ export interface BotDto {
   // callbacks. Only a Slack http bot may be shared. Missing (older CP) ⇒ socket.
   transport: 'socket' | 'http'
   shareable: boolean // shared-bot opt-in — when true it may serve many agents at once
+  // The member that catches a bare mention / DM / delegation; null ⇒ the compile's
+  // earliest-non-gated-member derivation. Optional while older control planes roll out.
+  preferredAgentId?: string | null
   inUseByAgentId: string | null // classic-bot occupancy; ALWAYS null for a shareable bot
   agentIds: string[] // every agent currently installed on the bot (a shared bot may have many)
   lastUsedAt: string | null // ISO-8601; stamped when last freed; null ⇒ never used
@@ -3932,6 +3939,48 @@ export async function deleteSlackConfig(): Promise<void> {
   await apiDelete<void>(`${orgBase()}/slack/config`)
 }
 
+// ── Linear workspace connect funnel (linear-integration.md §7.1, §7.4) ──
+// A Linear bot IS one connected workspace, and agents are members of it. The
+// funnel mints a one-shot OAuth state bound to this org and the workspace's chosen
+// default agent; no bot or integration row exists until the callback completes.
+
+/** A started connect round trip: the funnel row id (which IS the OAuth `state`)
+ *  and the linear.app authorize URL to open. */
+export interface LinearConnectStartDto {
+  id: string
+  connectUrl: string
+}
+
+/** Poll answer for one connect round trip. `failureReason` is a short server code
+ *  (`denied` / `expired` / `workspace_taken` / `wrong_workspace` /
+ *  `default_agent_required` / `agent_missing` / `error`), never prose. */
+export interface LinearConnectStatusDto {
+  id: string
+  status: 'pending' | 'completed' | 'failed'
+  failureReason: string | null
+  botId: string | null
+}
+
+// Start connecting a workspace. `agentId` becomes its default agent — the member a
+// bare delegation starts a session with. Throws ApiError(404) when the deployment
+// has no Linear app, which is the console's only signal that it is unconfigured.
+export async function startLinearConnect(agentId: string): Promise<LinearConnectStartDto> {
+  return apiPost<LinearConnectStartDto>(`${orgBase()}/integrations/linear/connect`, { agentId })
+}
+
+// Poll one connect row while the user authorizes in the other tab. The ROW's
+// terminal state is the signal: the OAuth tab is a throwaway, so a tail refusal
+// (workspace claimed elsewhere, wrong workspace) has no other channel back.
+export async function getLinearConnect(id: string): Promise<LinearConnectStatusDto> {
+  return apiGet<LinearConnectStatusDto>(`${orgBase()}/integrations/linear/connect/${encodeURIComponent(id)}`)
+}
+
+// Restart the funnel against an already-connected workspace whose grant died. The
+// nonce is bound to this bot, so authorizing a different workspace is refused.
+export async function reconnectLinearWorkspace(botId: string): Promise<LinearConnectStartDto> {
+  return apiPost<LinearConnectStartDto>(`${orgBase()}/bots/${encodeURIComponent(botId)}/linear/reconnect`, {})
+}
+
 // Uninstall an integration (`DELETE /integrations/:id`): drops the CP record and
 // tells the owning daemon to close the connection. The BOT survives (freed) — it
 // shows up in the Add-integration picker for reuse.
@@ -4164,6 +4213,12 @@ export async function leaveIntegrationConversation(
 /** Flip a bot's shared-bot opt-in (PATCH /bots/:id). */
 export async function updateBot(id: string, shareable: boolean): Promise<BotDto> {
   return apiPatch<BotDto>(`${orgBase()}/bots/${encodeURIComponent(id)}`, { shareable })
+}
+
+/** Move the bot's preferred default agent (PATCH /bots/:id); null restores the
+ *  compile's earliest-member default. The CP 409s an agent that is not a member. */
+export async function setBotPreferredAgent(id: string, agentId: string | null): Promise<BotDto> {
+  return apiPatch<BotDto>(`${orgBase()}/bots/${encodeURIComponent(id)}`, { preferredAgentId: agentId })
 }
 
 /** Sync one user-managed Slack app's manifest and re-check the scopes granted to

--- a/packages/web/src/lib/conversation-merge.test.ts
+++ b/packages/web/src/lib/conversation-merge.test.ts
@@ -57,7 +57,7 @@ describe('duplicateIdentity', () => {
     // the opposite — absent `messageIdentity` ⇒ never dedupe — and dedupe is
     // the only step here that can delete a row, so the guess goes the other
     // way now. A Slack-SHAPED ts under an unknown id is the case that changed.
-    for (const platform of ['linear', 'hook', 'github', 'playground', 'Slack', '']) {
+    for (const platform of ['zulip', 'hook', 'github', 'playground', 'Slack', '']) {
       expect(duplicateIdentity(platform, row({ ts: '1754123456.000200' })), platform).toBeNull()
       expect(duplicateIdentity(platform, row({ postId: POST })), platform).toBeNull()
     }
@@ -207,8 +207,8 @@ describe('mergeConversation', () => {
     // "toward a visible duplicate, never toward data loss" (§6).
     const platformTs = '1754123456.000200'
     const merged = mergeConversation([
-      src(A, 'linear', [row({ sender: 'U-HUMAN', ts: platformTs, text: 'hello' })]),
-      src(B, 'linear', [row({ sender: 'U-HUMAN', ts: platformTs, text: 'hello' })])
+      src(A, 'zulip', [row({ sender: 'U-HUMAN', ts: platformTs, text: 'hello' })]),
+      src(B, 'zulip', [row({ sender: 'U-HUMAN', ts: platformTs, text: 'hello' })])
     ])
     expect(merged).toHaveLength(2)
   })

--- a/packages/web/src/lib/platform-labels.ts
+++ b/packages/web/src/lib/platform-labels.ts
@@ -41,6 +41,7 @@ const LABELS = new Map<string, PlatformLabel>([
   // One platform id, two clouds. Prose picks the international brand; the picker
   // names both so a Feishu user recognizes their own tile.
   ['feishu', { name: 'Lark', picker: 'Lark/Feishu' }],
+  ['linear', { name: 'Linear', picker: 'Linear' }],
   // Nothing routes a bare 'lark' id today (the cloud rides on its own `region`
   // field), but the substring chains this replaces accepted it.
   ['lark', { name: 'Lark', picker: 'Lark/Feishu' }]


### PR DESCRIPTION
The web console module for Linear — the fourth and last host contract (docs/designs/linear-integration.md §9.5): `components/console/platforms/linear/` plus one registry line.

- **Wizard**: "enable on a connected workspace" — the existing-bot list offers the org's connected workspaces; a hand-off card runs the org-level connect flow (choose default agent → authorize popup → status polling with every settle outcome rendered, incl. `workspace_taken`/`wrong_workspace`). Tile availability = daemon capability (registry-automatic) ∧ relay availability (shared deployment probe) ∧ the deployment app being configured — the CP exposes no explicit signal for the last leg, so the pure predicate `linearConnectAvailability()` learns it from the funnel route's 404 and pins the precedence rules in unit tests; a comment records that the 404 is the only signal there is (candidate for a later runtime-config field).
- **Workspace card**: status pill, member agents with the default marked and movable (`PATCH /bots/:id` `preferredAgentId`), removal inert on the effective default (persisted pointer if still a member, else the compile's earliest-member fallback — the card follows the real default, not just the pointer), and Reconnect offered on live workspaces too per §15's webhook-silence case.
- **Semantics**: `roomNoun: 'issue'` (the channel-list copy now derives its article, fixing "A issue"), no leave affordance, agent-activity message identity, `'seq'` transcript ordering, share affordance read from the §5 manifest's `multiAgentShareable`.
- The mark is an original SVG in the brand's likeness (no licensed asset), verified at both sizes and on dark.
- Two deliberate host edits: the deployment probe now loads for any open wizard (gating on a transport *choice* read exactly backwards for a platform whose one fixed transport is relay-backed), and the channel-list article derivation above.

Tests: web suite 2243 passing (11 new/updated files; six existing suites that used `linear` as an unclaimed-id sentinel moved to a neutral id rather than losing coverage); typecheck + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
