### PR TITLE
docs(linear): add the daemon-pool leg to the live checklist

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1168,7 +1168,11 @@ tile.
   disconnect (bot delete) revoke convergence.
 - **Live checklist:** real OAuth app in a scratch Linear workspace —
   delegate, mention, follow-up, stop, redelivery replay (Linear's webhook
-  console), token refresh across the 24 h boundary, workspace revoke.
+  console), token refresh across the 24 h boundary, workspace revoke. Run the
+  loop once against an agent served by a managed daemon-pool member as well as
+  a self-hosted daemon — the pool leg additionally proves the deployment's
+  egress policy admits `api.linear.app` and that `linearcred` brokerage works
+  through pool placement.
 
 ## 15. Open questions
 


### PR DESCRIPTION
The §14 live checklist read as self-host-only. The pool leg is what proves the deployment's egress policy admits the Linear API and that `linearcred` brokerage works through pool placement — one extra pass of the same loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)