### PR TITLE
feat(cp): gate pool claims on the member's platform capabilities

### DIFF
--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -567,6 +567,22 @@ platform ids it lacks. Deliberately NOT folded into the placement fence: a
 capability read that failed closed at fence time would tear down live service,
 where the same read at claim time only delays a placement.
 
+**The gate rides each grant statement, at that statement's own scope.** A duty
+group is a connected component, so it can hold several agents joined through a
+shared socket bot: what a member must serve to take one is the whole group's
+requirement, never the requirement of whichever agent a trigger happened to
+name. So the vacancy claim and the rendezvous's take of an existing group both
+carry the **group-wise** predicate, and only the one place that mints a fresh
+singleton — the rendezvous's fallback for an agent no sweep has grouped yet —
+carries the **agent-wise** one, because there the group is that agent. Gating
+the rendezvous at its entry instead, on the triggered agent alone, would let an
+old image that serves that agent take a group containing a peer it cannot, which
+is the dead surface this gate exists to prevent; it would also answer before
+reading the group, and a refusal that names no incumbent costs the relay the
+one-hop re-route the rendezvous below is built on. An idempotent re-claim by
+the member already holding the lease takes nothing and is not gated, for the
+same reason the placement fence is not.
+
 ### The activation rendezvous
 
 A trigger for an _unheld_ group has nowhere to go — the ledger names no holder

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -546,6 +546,27 @@ gate filters those rows out inside `claimVacant` — a machine-placed agent has
 exactly one eligible holder and it is never a pool member — so they consume no
 grant budget.
 
+**Placement says who MAY hold a group; capability says who CAN serve it, and
+both gate every claim.** A daemon resolves an integration's config through its
+own platform-module registry and fails closed on an id it has no module for: it
+skips the integration and opens no connection. So a member running an older
+image that claims an agent whose integrations name a newly added platform takes
+that surface dark with no error anywhere, until the group moves again — a
+window every new platform's rollout opens. The claim paths therefore also
+require the group's active-integration platform set to be a **subset of the
+member's advertised `capabilities.platforms`** (the register handshake's list,
+the same one the install-time gate reads), stated once as SQL and carried by
+`claimVacant` and the rendezvous alike. It is fail-closed on both sides: a
+member whose capabilities carry no platform list advertises nothing, and a group
+no live member can serve stays vacant rather than being served by a member that
+would silently drop it. An agent with no active integration requires nothing, so
+webchat, cron and A2A singletons never meet the gate. Passing an agent over is
+otherwise invisible — the claim simply matches fewer rows — so a member that
+left claim budget unspent logs one line per passed-over agent naming the
+platform ids it lacks. Deliberately NOT folded into the placement fence: a
+capability read that failed closed at fence time would tear down live service,
+where the same read at claim time only delays a placement.
+
 ### The activation rendezvous
 
 A trigger for an _unheld_ group has nowhere to go — the ledger names no holder
@@ -933,6 +954,17 @@ CP never load-balances, never schedules, never picks; it only refuses invalid
 claims and **alarms on vacant-duty age**. A human scales the Deployment. No
 scheduler exists anywhere — deliberate continuity with the current system,
 where the session-placement scheduler was built but never armed.
+
+**The alarm's eligibility is the claim's eligibility, or it fires on work no
+pool size can take.** The vacancy gauges read `duty_group` through the very
+predicates the claim statements carry, and a vacancy whose remediation is not
+"scale the Deployment" is split into a series of its own rather than folded into
+the demand count: an oversized group is undeliverable on this wire at any size
+(D16), and a group needing a platform **no live member of the set advertises**
+(§6) is cleared by rolling the image forward, not by adding replicas of the same
+one. Both would otherwise pin the capacity alarm high indefinitely. A set with
+no live member at all proves neither — that is the member-count gauge's signal —
+so its vacancies stay ordinary demand.
 
 Per-org resource quota is deliberately not implemented here: a shared sandbox
 namespace keeps one namespace-wide `ResourceQuota`/`LimitRange` as the cluster

--- a/packages/control-plane/src/domain/platform-capability.test.ts
+++ b/packages/control-plane/src/domain/platform-capability.test.ts
@@ -1,0 +1,44 @@
+// The platform-capability predicate: the subset rule the install-time gate and the duty ledger's
+// claim gate both state. Pure — the SQL that mirrors it row-wise is pinned in the repo tests.
+import { describe, it, expect } from 'vitest'
+import { missingPlatforms, servesPlatform, servesPlatforms } from './platform-capability.js'
+
+const OLD_IMAGE = ['slack', 'telegram', 'discord', 'feishu']
+const NEW_IMAGE = [...OLD_IMAGE, 'linear']
+
+describe('servesPlatforms — the subset rule', () => {
+  it('an exact match, and any subset of it, is served', () => {
+    expect(servesPlatforms(NEW_IMAGE, NEW_IMAGE)).toBe(true)
+    expect(servesPlatforms(NEW_IMAGE, ['slack', 'linear'])).toBe(true)
+    expect(servesPlatforms(NEW_IMAGE, ['linear'])).toBe(true)
+  })
+
+  // The whole point of the gate: one platform short is ineligible, not degraded. The daemon skips
+  // an integration whose platform it has no module for, so a partial match serves a dead surface.
+  it('missing ONE platform makes the whole requirement unserved', () => {
+    expect(servesPlatforms(OLD_IMAGE, ['linear'])).toBe(false)
+    expect(servesPlatforms(OLD_IMAGE, ['slack', 'linear'])).toBe(false)
+    expect(missingPlatforms(OLD_IMAGE, ['slack', 'linear'])).toEqual(['linear'])
+  })
+
+  // An agent with no integrations at all — webchat, cron, A2A — requires nothing, so the gate is
+  // invisible to it. Without this the singleton every agent owns would stop being claimable.
+  it('an empty requirement is served by anyone, including a member advertising nothing', () => {
+    expect(servesPlatforms(OLD_IMAGE, [])).toBe(true)
+    expect(servesPlatforms([], [])).toBe(true)
+  })
+
+  it('a member advertising nothing serves no requirement at all', () => {
+    expect(servesPlatforms([], ['slack'])).toBe(false)
+    expect(missingPlatforms([], ['slack', 'linear'])).toEqual(['slack', 'linear'])
+  })
+
+  it('missingPlatforms dedupes and keeps first-seen order — it is a log payload', () => {
+    expect(missingPlatforms(OLD_IMAGE, ['linear', 'gitlab', 'linear', 'slack'])).toEqual(['linear', 'gitlab'])
+  })
+
+  it('servesPlatform is the one-element case the install gate asks', () => {
+    expect(servesPlatform(NEW_IMAGE, 'linear')).toBe(true)
+    expect(servesPlatform(OLD_IMAGE, 'linear')).toBe(false)
+  })
+})

--- a/packages/control-plane/src/domain/platform-capability.ts
+++ b/packages/control-plane/src/domain/platform-capability.ts
@@ -1,0 +1,34 @@
+/**
+ * The ONE answer to "can this daemon actually serve this platform?" — the predicate behind both the
+ * install-time gate (`http/daemon-platform-capability.ts`) and the duty ledger's claim gate.
+ *
+ * A daemon resolves an integration's config through its own platform-module registry
+ * (`daemon/src/platforms/integration-config.ts`) and fails CLOSED on an id it has no module for:
+ * it skips the integration and opens no connection. So a claim that ignores capabilities does not
+ * degrade gracefully — the agent's whole surface on that platform goes dead on that member, with
+ * no error anywhere, until the group moves again. Every rollout that adds a platform has that
+ * window, so the gate belongs on the claim, not only on the install.
+ *
+ * `platform` is an OPEN id (integration-plugin-architecture.md §9): the ids stored on integration
+ * rows come from the CP's platform registry, and the daemon's advertised list is the authority for
+ * what it can run. Nothing here parses either — a fifth registered platform needs no edit.
+ */
+
+/** What a member advertised on register — `RegisterReq.capabilities.platforms`. */
+export type AdvertisedPlatforms = readonly string[]
+
+/** Does this member advertise a module for one platform? The install-time gate's whole question. */
+export function servesPlatform(advertised: AdvertisedPlatforms, platform: string): boolean {
+  return advertised.includes(platform)
+}
+
+/** The platforms a member would have to skip, in first-seen order and deduped — the log's payload. */
+export function missingPlatforms(advertised: AdvertisedPlatforms, required: Iterable<string>): string[] {
+  return [...new Set(required)].filter((platform) => !servesPlatform(advertised, platform))
+}
+
+/** Subset: a member may serve this surface only when it advertises EVERY platform it needs.
+ *  An empty requirement is served by anyone, which is what keeps a botless agent claimable. */
+export function servesPlatforms(advertised: AdvertisedPlatforms, required: Iterable<string>): boolean {
+  return missingPlatforms(advertised, required).length === 0
+}

--- a/packages/control-plane/src/http/daemon-platform-capability.ts
+++ b/packages/control-plane/src/http/daemon-platform-capability.ts
@@ -9,6 +9,7 @@ import { DaemonId, type OrgId } from '../domain/ids.js'
 import type { ViewCtx } from '../persistence/ports.js'
 import type { HttpDeps } from './deps.js'
 import { canView } from '../authorization/policy.js'
+import { servesPlatform } from '../domain/platform-capability.js'
 
 export type DaemonPlatformAvailability = 'available' | 'not_found' | 'unsupported'
 
@@ -24,6 +25,10 @@ export type DaemonPlatformAvailability = 'available' | 'not_found' | 'unsupporte
  * (one of the audit's six, Appendix A) added no safety: it could only ever
  * re-state the registry's ids, and a fifth registered platform would have needed
  * an edit here to be checkable at all.
+ *
+ * The predicate itself lives in `domain/platform-capability.ts` because the duty ledger's claim
+ * gate asks the same question of a whole group — install-time and claim-time must never disagree
+ * about what "this daemon can run that platform" means.
  */
 export async function integrationPlatformAvailability(
   deps: HttpDeps,
@@ -32,5 +37,5 @@ export async function integrationPlatformAvailability(
   // Availability admits this org's visible daemons and install-wide pool members, never another org's daemon.
   const daemon = await deps.registry.getAvailable(input.orgId, DaemonId(input.daemonId))
   if (!daemon || !canView(daemon, input.viewer)) return 'not_found'
-  return daemon.capabilities.platforms.includes(input.platform) ? 'available' : 'unsupported'
+  return servesPlatform(daemon.capabilities.platforms, input.platform) ? 'available' : 'unsupported'
 }

--- a/packages/control-plane/src/observability/pool-metrics.test.ts
+++ b/packages/control-plane/src/observability/pool-metrics.test.ts
@@ -14,6 +14,7 @@ const row = (over: Partial<PoolTelemetryRow> = {}): PoolTelemetryRow => ({
   dutyAgents: 20,
   vacantGroups: 0,
   oversizedVacantGroups: 0,
+  capabilityBlockedVacantGroups: 0,
   oldestVacancySec: 0,
   ...over
 })

--- a/packages/control-plane/src/observability/pool-metrics.ts
+++ b/packages/control-plane/src/observability/pool-metrics.ts
@@ -35,7 +35,15 @@ export interface PoolMetricsDeps {
 }
 
 export type PoolMetricName =
-  'members' | 'unbounded' | 'capacity' | 'used' | 'headroom' | 'vacantGroups' | 'vacantAge' | 'undeliverable'
+  | 'members'
+  | 'unbounded'
+  | 'capacity'
+  | 'used'
+  | 'headroom'
+  | 'vacantGroups'
+  | 'vacantAge'
+  | 'undeliverable'
+  | 'capabilityBlocked'
 
 export interface PoolObservation {
   metric: PoolMetricName
@@ -63,7 +71,8 @@ export function poolObservations(rows: readonly PoolTelemetryRow[]): PoolObserva
       at('used', row.dutyAgents),
       at('vacantGroups', row.vacantGroups),
       at('vacantAge', row.oldestVacancySec),
-      at('undeliverable', row.oversizedVacantGroups)
+      at('undeliverable', row.oversizedVacantGroups),
+      at('capabilityBlocked', row.capabilityBlockedVacantGroups)
     ]
   })
 }
@@ -126,6 +135,11 @@ function createGauges(): Record<PoolMetricName, ObservableGauge> {
     undeliverable: meter.createObservableGauge('agentconnect.duty.undeliverable.groups', {
       unit: '{group}',
       description: 'Vacant groups over the wire member cap — never claimable at any pool size; needs a dedicated daemon'
+    }),
+    capabilityBlocked: meter.createObservableGauge('agentconnect.duty.capability_blocked.groups', {
+      unit: '{group}',
+      description:
+        'Vacant groups needing a platform no live member of the set advertises — scaling cannot clear it; roll the image forward'
     })
   }
 }

--- a/packages/control-plane/src/orchestrator/dutyLease.test.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.test.ts
@@ -4,7 +4,13 @@
 // predicate lives in the repo tests; this pins what the service does with the bit.
 import { describe, it, expect, vi } from 'vitest'
 import { DutyLeaseService, DUTY_LEASE_DEFAULTS } from './dutyLease.js'
-import type { DutyGroupRepo, DutyGroupRecord, DutyGrantRecord, AgentHomeClaim } from '../persistence/ports.js'
+import type {
+  AgentHomeClaim,
+  CapabilityBlockedVacancy,
+  DutyGrantRecord,
+  DutyGroupRecord,
+  DutyGroupRepo
+} from '../persistence/ports.js'
 import { AgentId, DaemonId, OrgId } from '../domain/ids.js'
 import { FakeClock } from '../../test/fakes/fake-clock.js'
 
@@ -14,7 +20,13 @@ const AGENT = AgentId('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1')
 const GROUP = '00000000-0000-4000-8000-000000000001'
 
 /** A ledger with one vacant group covering one agent, and every claim path instrumented. */
-function fakeRepo(opts: { heldByMember?: DutyGroupRecord[]; heldBack?: (holder: string) => boolean } = {}) {
+function fakeRepo(
+  opts: {
+    heldByMember?: DutyGroupRecord[]
+    heldBack?: (holder: string) => boolean
+    capabilityBlocked?: CapabilityBlockedVacancy[]
+  } = {}
+) {
   const vacant: DutyGrantRecord = {
     groupId: GROUP,
     orgId: ORG,
@@ -30,8 +42,12 @@ function fakeRepo(opts: { heldByMember?: DutyGroupRecord[]; heldBack?: (holder: 
   }))
   const release = vi.fn(async () => undefined)
   const newerGenerationLive = vi.fn(async (holder: string) => opts.heldBack?.(holder) ?? false)
+  const capabilityBlockedVacancies = vi.fn(
+    async (): Promise<CapabilityBlockedVacancy[]> => opts.capabilityBlocked ?? []
+  )
   const repo = {
     newerGenerationLive,
+    capabilityBlockedVacancies,
     renewHeld: async () => [],
     listHeldBy: async () => opts.heldByMember ?? [],
     confirmHeld: async () => [],
@@ -43,7 +59,7 @@ function fakeRepo(opts: { heldByMember?: DutyGroupRecord[]; heldBack?: (holder: 
     claimAgentHome,
     release
   } as unknown as DutyGroupRepo
-  return { repo, claimVacant, claimAgentHome, release, newerGenerationLive }
+  return { repo, claimVacant, claimAgentHome, release, newerGenerationLive, capabilityBlockedVacancies }
 }
 
 function service(repo: DutyGroupRepo, clock = new FakeClock(0), warn = vi.fn()) {
@@ -190,5 +206,48 @@ describe('DutyLeaseService — the double-move line', () => {
     claimAgentHome.mockResolvedValueOnce({ granted: true, groupId: GROUP, term: 2n, holder: other })
     await svc.claimAgentHome(ORG, AGENT, other)
     expect(warn).not.toHaveBeenCalled()
+  })
+})
+
+describe('DutyLeaseService — the capability-gap line', () => {
+  // A capability refusal is silent on the wire: the claim statement simply matches fewer rows, so
+  // an agent stops placing mid-rollout with nothing anywhere naming the platform that is missing.
+  it('names every passed-over agent and the platforms the member lacks, once per pass', async () => {
+    const warn = vi.fn()
+    const { repo, capabilityBlockedVacancies } = fakeRepo({
+      capabilityBlocked: [{ groupId: GROUP, agentId: AGENT, missingPlatforms: ['linear'] }]
+    })
+    const svc = service(repo, new FakeClock(0), warn)
+
+    await beat(svc, MEMBER, { held: [], headroom: 4 })
+    const lines = warn.mock.calls.filter(([, m]) => /advertises no module/.test(String(m)))
+    expect(lines).toHaveLength(1)
+    expect(lines[0]?.[0]).toMatchObject({ daemonId: MEMBER, agentId: AGENT, missingPlatforms: ['linear'] })
+    // Read under the same deliverability cap the claim carries, so it can only report what claim saw.
+    expect(capabilityBlockedVacancies).toHaveBeenCalledWith(
+      MEMBER,
+      expect.any(Date),
+      expect.objectContaining({ maxMembers: expect.any(Number) })
+    )
+  })
+
+  // The diagnostic costs a read, so it must not run on a claim that already spent its whole budget.
+  it('is not read when the claim filled the budget it asked for', async () => {
+    const { repo, capabilityBlockedVacancies } = fakeRepo()
+    const svc = service(repo)
+    await beat(svc, MEMBER, { held: [], headroom: 1 })
+    expect(capabilityBlockedVacancies).not.toHaveBeenCalled()
+  })
+
+  // Diagnostics for a claim that already happened: a failure here must never fail the exchange.
+  it('a failing diagnostic read still lets the beat confirm renewal', async () => {
+    const warn = vi.fn()
+    const { repo, capabilityBlockedVacancies } = fakeRepo()
+    capabilityBlockedVacancies.mockRejectedValueOnce(new Error('connection terminated'))
+    const svc = service(repo, new FakeClock(0), warn)
+
+    const send = await beat(svc, MEMBER, { held: [], headroom: 4 })
+    expect(send.mock.calls.map(([type]) => type)).toContain('duty/renewed')
+    expect(warn.mock.calls.filter(([, m]) => /diagnostics failed/.test(String(m)))).toHaveLength(1)
   })
 })

--- a/packages/control-plane/src/orchestrator/dutyLease.ts
+++ b/packages/control-plane/src/orchestrator/dutyLease.ts
@@ -299,6 +299,27 @@ export class DutyLeaseService {
         if (nowMs - g.atMs >= this.config.doubleMoveWindowMs) this.lastGrant.delete(id)
   }
 
+  /** One line per (agent, pass) for the agents this member was passed over for on capability
+   *  grounds alone. A capability refusal is silent by construction — the claim statement matches
+   *  fewer rows — so mid-rollout an agent stops placing with nothing naming the platform behind it.
+   *  Best-effort and never fatal: diagnostics for a claim that already happened. */
+  private async reportCapabilityGaps(daemonId: DaemonId, now: Date): Promise<void> {
+    try {
+      const blocked = await this.repo.capabilityBlockedVacancies(daemonId, now, {
+        maxMembers: DUTY_GRANT_MEMBERS_MAX,
+        excludeGroupIds: this.backedOff(daemonId)
+      })
+      for (const entry of blocked) {
+        this.log?.warn(
+          { daemonId, groupId: entry.groupId, agentId: entry.agentId, missingPlatforms: entry.missingPlatforms },
+          'duty vacancy skipped: this member advertises no module for these platforms, so the agent will not place here until it runs an image that has them'
+        )
+      }
+    } catch (err) {
+      this.log?.warn({ daemonId, err }, 'capability-gap diagnostics failed')
+    }
+  }
+
   /** Chain `fn` on the daemon's lane so operations never interleave. */
   private serialize<T>(daemonId: string, fn: () => Promise<T>): Promise<T> {
     const lane = this.lanes.get(daemonId) ?? { pending: 0, tail: Promise.resolve() }
@@ -416,14 +437,15 @@ export class DutyLeaseService {
     ) {
       // Oversized groups are excluded at the claim boundary (the size gate), so
       // a claim never lands on a group it would immediately have to release.
-      granted = await this.repo.claimVacant(
-        daemonId,
-        Math.min(budget, this.config.grantMaxPerTick),
-        now,
-        this.config.leaseMs,
-        { maxMembers: DUTY_GRANT_MEMBERS_MAX, excludeGroupIds: this.backedOff(daemonId) }
-      )
+      const wanted = Math.min(budget, this.config.grantMaxPerTick)
+      granted = await this.repo.claimVacant(daemonId, wanted, now, this.config.leaseMs, {
+        maxMembers: DUTY_GRANT_MEMBERS_MAX,
+        excludeGroupIds: this.backedOff(daemonId)
+      })
       this.noteGranted(granted, daemonId)
+      // Budget left unspent CAN be a capability gap, and a gap is invisible on the wire: the claim
+      // just returns fewer rows. So ask why, once per beat, only when there was room to take more.
+      if (granted.length < wanted) await this.reportCapabilityGaps(daemonId, now)
       // Not a route yet (routable reads confirmations), but a state change: the directory must stop
       // naming the expired holder and carry the agents as PENDING now, or a peer wake in the
       // grant→digest window sees a terminal `offline` instead of the retryable `not_ready` (#987).

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -6306,7 +6306,9 @@ export interface AgentHomeClaim {
    *  claimant, which has no group to name and must not learn of one. */
   groupId?: string
   term?: bigint
-  /** The live holder — the caller when granted, the incumbent for a `not_holder` answer otherwise. */
+  /** The LIVE holder — the caller when granted, the incumbent for a `not_holder` answer otherwise,
+   *  and null when the group has none. Never a lapsed lease's leftover `holder`: the re-route it
+   *  would send acknowledged ingress to is a member that has stopped serving, so a drop. */
   holder: DaemonId | null
 }
 

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -6313,6 +6313,14 @@ export interface AgentHomeClaim {
 /** Pure plan callback run inside the reconcile transaction's org snapshot (orchestrator/dutyGroup.ts). */
 export type DutyReconcilePlanner = (existing: DutyGroupRecord[]) => DutyReconcilePlan
 
+/** One agent a member was passed over for, and the platform ids it does not advertise. */
+export interface CapabilityBlockedVacancy {
+  groupId: string
+  agentId: AgentId
+  /** The platforms this member is missing for that agent — never the full requirement. */
+  missingPlatforms: string[]
+}
+
 /** One member set's capacity and unmet demand, as {@link DutyGroupRepo.poolTelemetry} reads it. */
 export interface PoolTelemetryRow {
   setId: string
@@ -6333,6 +6341,11 @@ export interface PoolTelemetryRow {
   vacantGroups: number
   /** Vacant, eligible, but over the wire's member cap: never claimable at any pool size (D16). */
   oversizedVacantGroups: number
+  /** Vacant and eligible, but no LIVE member of the set advertises every platform the group's
+   *  integrations need — the mid-rollout gap. Split out of
+   *  {@link PoolTelemetryRow.vacantGroups} for the same reason oversized groups are: scaling the
+   *  pool cannot clear it, so it must not pin the capacity alarm. Rolling the image forward can. */
+  capabilityBlockedVacantGroups: number
   /** Age of the oldest {@link PoolTelemetryRow.vacantGroups} entry. Sustained ⇒ nothing could take it. */
   oldestVacancySec: number
 }
@@ -6368,6 +6381,16 @@ export interface DutyGroupRepo {
     leaseMs: number,
     opts?: { maxMembers?: number; excludeGroupIds?: readonly string[] }
   ): Promise<DutyGrantRecord[]>
+  /** Why a claim came up short of its budget: vacancies this member is placement-eligible for and
+   *  could deliver, but whose integrations name a platform its advertised `capabilities.platforms`
+   *  is missing. Read-only diagnostics for the claim path's log line — the SAME capability
+   *  predicate {@link DutyGroupRepo.claimVacant} gates on, so it can only ever report groups that
+   *  claim actually refused. Bounded by `limit`. */
+  capabilityBlockedVacancies(
+    holder: DaemonId,
+    now: Date,
+    opts?: { maxMembers?: number; excludeGroupIds?: readonly string[]; limit?: number }
+  ): Promise<CapabilityBlockedVacancy[]>
   /** The group-computation inputs for one org: every agent as a node, plus
    *  active integrations on daemon-held (socket, unrevoked) bots as edges. */
   computeInputs(orgId: OrgId): Promise<{ edges: DutyEdge[]; agents: AgentSeed[] }>

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -6,6 +6,7 @@ import { Prisma, type PrismaClient } from '../../generated/prisma/client.js'
 import type { DutyMemberKey, DutyReconcilePlan, DutyEdge, AgentSeed } from '../../domain/duty.js'
 import type {
   AgentHomeClaim,
+  CapabilityBlockedVacancy,
   DutyDigestEntry,
   DutyGrantRecord,
   DutyGroupRecord,
@@ -67,6 +68,49 @@ function noIneligibleAgent(group: Prisma.Sql, holder: Prisma.Sql): Prisma.Sql {
     JOIN "agent" a ON a.id = m."refId"
     WHERE m."groupId" = ${group} AND m."kind" = 'agent'
       AND NOT ${eligibleAgent(Prisma.sql`a`, holder)}
+  )`
+}
+
+/** One member's advertised `capabilities.platforms`, as jsonb. NULL for a row that never
+ *  registered, or one whose capabilities carry no list — every caller reads that as fail-closed. */
+function advertisedPlatforms(holder: Prisma.Sql): Prisma.Sql {
+  return Prisma.sql`(SELECT d."capabilities"->'platforms' FROM "daemon" d WHERE d.id = ${holder})`
+}
+
+/**
+ * The CAPABILITY gate — the row-wise mirror of `domain/platform-capability.ts#servesPlatforms`,
+ * and the claim-time half of the install-time gate in `http/daemon-platform-capability.ts`.
+ *
+ * May `holder` serve every platform this agent's active integrations name? A daemon reads an
+ * integration's config through its own platform-module registry and fails CLOSED on an id it has
+ * no module for — it skips the integration silently — so a member of an older image that claims an
+ * agent using a newly added platform takes that agent's whole surface there dark until the group
+ * moves again. That window opens on EVERY platform's rollout, which is why this rides the claim
+ * rather than the install alone.
+ *
+ * Fail-closed on the daemon read too: a missing row, or capabilities carrying no `platforms` list,
+ * yields NULL, `COALESCE` reads it as "does not advertise", and the claim is refused. An agent
+ * with no active integration requires nothing and is claimable by anyone, which is what keeps
+ * botless agents (webchat, cron, A2A) out of the gate entirely.
+ */
+function servesAgentPlatforms(agentId: Prisma.Sql, holder: Prisma.Sql): Prisma.Sql {
+  return Prisma.sql`NOT EXISTS (
+    SELECT 1 FROM "integration" i
+    WHERE i."agentId" = ${agentId} AND i."status" = 'active'
+      AND NOT COALESCE(${advertisedPlatforms(holder)} @> to_jsonb(i."platform"), false)
+  )`
+}
+
+/** The group-wise reading of the capability gate, stated like {@link noIneligibleAgent}: a group is
+ *  claimable only when EVERY agent in it is one the holder can serve. Deliberately NOT folded into
+ *  the placement predicate — placement says who MAY hold, capability says who CAN serve, and only
+ *  the second may be answered by a stale image. Keeping them apart is also what keeps
+ *  `vacateIneligible` from tearing down live service over a capability read. */
+function servesGroupPlatforms(group: Prisma.Sql, holder: Prisma.Sql): Prisma.Sql {
+  return Prisma.sql`NOT EXISTS (
+    SELECT 1 FROM "duty_group_member" m
+    WHERE m."groupId" = ${group} AND m."kind" = 'agent'
+      AND NOT ${servesAgentPlatforms(Prisma.sql`m."refId"`, holder)}
   )`
 }
 
@@ -320,6 +364,11 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
     // left: what a member may claim follows from the agents' placement, not from where their state
     // happens to already be.
     const eligibilityGate = Prisma.sql`AND ${noIneligibleAgent(Prisma.sql`"duty_group".id`, Prisma.sql`${holder}::uuid`)}`
+    // The capability gate: placement says this member MAY hold the group, this says it CAN serve
+    // it. Fail-closed by design — a group needing a platform no live member advertises simply
+    // stays vacant, and the pool gauges report it under its own series rather than as scale-up
+    // demand nothing could satisfy.
+    const capabilityGate = Prisma.sql`AND ${servesGroupPlatforms(Prisma.sql`"duty_group".id`, Prisma.sql`${holder}::uuid`)}`
     // The caller's refusal backoff: a group this member has just failed to install is skipped so
     // it can reach one that can serve it, instead of being re-taken on the very next beat.
     const backoffGate =
@@ -340,7 +389,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       const granted = await tx.$queryRaw<Row[]>(Prisma.sql`
         WITH picked AS (
           SELECT id FROM "duty_group"
-          WHERE ("holder" IS NULL OR "expiresAt" IS NULL OR "expiresAt" < ${now}) ${sizeGate} ${eligibilityGate} ${backoffGate} ${generationGate}
+          WHERE ("holder" IS NULL OR "expiresAt" IS NULL OR "expiresAt" < ${now}) ${sizeGate} ${eligibilityGate} ${capabilityGate} ${backoffGate} ${generationGate}
           ORDER BY "orgId", id
           LIMIT ${max}
           FOR UPDATE SKIP LOCKED
@@ -365,6 +414,45 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
         members: members.get(r.id) ?? []
       }))
     })
+  }
+
+  async capabilityBlockedVacancies(
+    holder: DaemonId,
+    now: Date,
+    opts: { maxMembers?: number; excludeGroupIds?: readonly string[]; limit?: number } = {}
+  ): Promise<CapabilityBlockedVacancy[]> {
+    // The claim's own gates, minus the capability one — which is negated instead, so this reports
+    // exactly the groups the claim refused FOR CAPABILITY and nothing else. The generation barrier
+    // is deliberately out: a held-back member still deserves to know what it could not have served.
+    const sizeGate =
+      opts.maxMembers === undefined
+        ? Prisma.empty
+        : Prisma.sql`AND (SELECT count(*) FROM "duty_group_member" m WHERE m."groupId" = g.id) <= ${opts.maxMembers}`
+    const backoffGate =
+      opts.excludeGroupIds && opts.excludeGroupIds.length > 0
+        ? Prisma.sql`AND g.id <> ALL(${opts.excludeGroupIds as string[]}::uuid[])`
+        : Prisma.empty
+    const rows = await this.prisma.$queryRaw<{ groupId: string; agentId: string; platform: string }[]>(Prisma.sql`
+      SELECT DISTINCT g.id AS "groupId", m."refId" AS "agentId", i."platform" AS platform
+      FROM "duty_group" g
+      JOIN "duty_group_member" m ON m."groupId" = g.id AND m."kind" = 'agent'
+      JOIN "integration" i ON i."agentId" = m."refId" AND i."status" = 'active'
+      WHERE (g."holder" IS NULL OR g."expiresAt" IS NULL OR g."expiresAt" < ${now})
+        ${sizeGate} ${backoffGate}
+        AND ${noIneligibleAgent(Prisma.sql`g.id`, Prisma.sql`${holder}::uuid`)}
+        AND NOT COALESCE(${advertisedPlatforms(Prisma.sql`${holder}::uuid`)} @> to_jsonb(i."platform"), false)
+      ORDER BY "groupId", "agentId", platform
+      LIMIT ${opts.limit ?? 100}
+    `)
+    // Folded per (group, agent) so the caller logs one line naming every platform it is missing.
+    const byAgent = new Map<string, CapabilityBlockedVacancy>()
+    for (const row of rows) {
+      const key = `${row.groupId}/${row.agentId}`
+      const entry = byAgent.get(key) ?? { groupId: row.groupId, agentId: row.agentId as AgentId, missingPlatforms: [] }
+      entry.missingPlatforms.push(row.platform)
+      byAgent.set(key, entry)
+    }
+    return [...byAgent.values()]
   }
 
   async renewHeld(holder: DaemonId, now: Date, leaseMs: number): Promise<string[]> {
@@ -470,15 +558,35 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
         HAVING count(*) FILTER (WHERE a."placementKind" <> 'set' OR a."setId" IS NULL) = 0
            AND count(DISTINCT a."setId") = 1
       ),
+      -- The capability gate, restated set-wise from the very predicate claimVacant carries: a
+      -- vacancy is blocked when NO live member of its set advertises every platform the group's
+      -- integrations name. Mid-rollout that is a real gap, and it is split out for the same reason
+      -- oversized groups are — scaling the pool cannot clear it, so it must not pin the capacity
+      -- alarm; rolling the image forward is the remediation, and the series says so.
+      -- A set with NO live member at all is a liveness signal, not an image gap: the members gauge
+      -- already reports it, and reading every vacancy as blocked there would mute the claimable
+      -- demand a quiet or scaled-to-zero pool still has. Only members present can prove a gap.
+      blocked AS (
+        SELECT v.*,
+               (EXISTS (SELECT 1 FROM live l WHERE l."setId" = v."setId")
+                AND NOT EXISTS (
+                  SELECT 1 FROM live l
+                  WHERE l."setId" = v."setId" AND ${servesGroupPlatforms(Prisma.sql`v.id`, Prisma.sql`l.id`)}
+                )) AS "capabilityBlocked"
+        FROM vacant v
+      ),
       -- Oversized groups are split out, never folded into the claimable count: they are
       -- undeliverable on this wire at any pool size (§5), so counting them as unmet demand would
       -- pin a capacity alert high forever. They are their own signal — D16, a dedicated daemon.
       vac AS (
         SELECT "setId",
-               count(*) FILTER (WHERE size <= ${maxMembers})::int AS groups,
+               count(*) FILTER (WHERE size <= ${maxMembers} AND NOT "capabilityBlocked")::int AS groups,
                count(*) FILTER (WHERE size > ${maxMembers})::int AS oversized,
-               COALESCE(max(age) FILTER (WHERE size <= ${maxMembers}), 0)::double precision AS oldest
-        FROM vacant GROUP BY "setId"
+               count(*) FILTER (WHERE size <= ${maxMembers} AND "capabilityBlocked")::int AS "capabilityBlocked",
+               COALESCE(
+                 max(age) FILTER (WHERE size <= ${maxMembers} AND NOT "capabilityBlocked"), 0
+               )::double precision AS oldest
+        FROM blocked GROUP BY "setId"
       )
       SELECT s.id AS "setId", s.name AS "setName", (s."orgId" IS NULL) AS "installWide",
              COALESCE(cap.members, 0)::int AS "liveMembers",
@@ -487,6 +595,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
              COALESCE(used.agents, 0)::int AS "dutyAgents",
              COALESCE(vac.groups, 0)::int AS "vacantGroups",
              COALESCE(vac.oversized, 0)::int AS "oversizedVacantGroups",
+             COALESCE(vac."capabilityBlocked", 0)::int AS "capabilityBlockedVacantGroups",
              COALESCE(vac.oldest, 0)::double precision AS "oldestVacancySec"
       FROM "member_set" s
       LEFT JOIN cap ON cap."setId" = s.id
@@ -582,9 +691,13 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       await lockDaemonMembership(tx, holder)
       // The rendezvous is a claim path, so it takes the same eligibility gate — inside the
       // transaction, against the live row, because this path can MINT a group and a check made
-      // before the lock would let a member reach through it for an agent it may not hold.
+      // before the lock would let a member reach through it for an agent it may not hold. The
+      // capability gate rides with it, per agent, exactly as `claimVacant` carries it per group: a
+      // trigger reaching a member of an older image is not authority to serve a platform it has no
+      // module for.
       const [eligible] = await tx.$queryRaw<{ ok: boolean }[]>(Prisma.sql`
-        SELECT ${eligibleAgent(Prisma.sql`a`, Prisma.sql`${holder}::uuid`)} AS ok
+        SELECT (${eligibleAgent(Prisma.sql`a`, Prisma.sql`${holder}::uuid`)}
+                AND ${servesAgentPlatforms(Prisma.sql`a.id`, Prisma.sql`${holder}::uuid`)}) AS ok
         FROM "agent" a WHERE a.id = ${agentId}::uuid
       `)
       if (eligible?.ok !== true) return { granted: false, holder: null }

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -28,6 +28,21 @@ async function lockOrgDutyScope(tx: Prisma.TransactionClient, orgId: string): Pr
 type Row = { id: string; orgId: string; holder: string | null; term: bigint; expiresAt: Date | null }
 
 /**
+ * Is this row a LIVE hold — someone is serving it right now? The row-wise complement of the
+ * vacancy predicate every claim statement carries (`holder IS NULL OR expiresAt IS NULL OR
+ * expiresAt < now`), stated once so a read and a write can never disagree about who is serving.
+ *
+ * Both sides fail closed at the exact boundary (`expiresAt = now` is neither vacant nor live), which
+ * is the safe direction on each: a claim refuses rather than double-serves, and a refusal reports no
+ * incumbent rather than a stale one. Only a live holder is ever named as one — a lapsed lease leaves
+ * `holder` standing on the row, and handing that back as a re-route target sends ingress that was
+ * already acknowledged upstream to a member that stopped serving it.
+ */
+function liveHold(row: { holder: string | null; expiresAt: Date | null }, now: Date): boolean {
+  return row.holder !== null && row.expiresAt !== null && row.expiresAt > now
+}
+
+/**
  * The eligibility predicate, once, as SQL — the row-wise mirror of `domain/placement.ts#mayHold`.
  * May `holder` hold the duty of the agent row `agent`? A `set` placement is claimable by the
  * members of that set, which is ONE join to `member_set_member` on `(agent.setId, holder)`; a
@@ -718,7 +733,7 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       }
       const row = await lockDutyRow(tx, member.groupId)
       if (row === null) throw new Error(`duty group ${member.groupId} vanished under its member row`)
-      const live = row.holder !== null && row.expiresAt !== null && row.expiresAt > now
+      const live = liveHold(row, now)
       if (live && row.holder === holder) {
         // Idempotent re-claim: refresh the horizon, never churn the term — ungated on capability,
         // which takes nothing and would only strand a group this member already serves.
@@ -751,12 +766,16 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
         }
       }
       const after = await tx.dutyGroup.findUniqueOrThrow({ where: { id: row.id } })
-      const stillMine = after.holder === holder && after.expiresAt !== null && after.expiresAt > now
+      // `holder` is the LIVE incumbent or nothing, read through the same predicate as `live` above.
+      // A refused take leaves the row's stale holder column standing over a lapsed lease, and
+      // naming that as the incumbent points the relay's one-hop re-route at a member that stopped
+      // serving — a drop, since the ingress it carries was acknowledged upstream and never re-sent.
+      const heldLive = liveHold(after, now)
       return {
-        granted: stillMine,
+        granted: heldLive && after.holder === holder,
         groupId: after.id,
         term: after.term,
-        holder: after.holder as DaemonId | null
+        holder: heldLive ? (after.holder as DaemonId) : null
       }
     })
   }

--- a/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/duty-group.repo.ts
@@ -691,24 +691,26 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       await lockDaemonMembership(tx, holder)
       // The rendezvous is a claim path, so it takes the same eligibility gate — inside the
       // transaction, against the live row, because this path can MINT a group and a check made
-      // before the lock would let a member reach through it for an agent it may not hold. The
-      // capability gate rides with it, per agent, exactly as `claimVacant` carries it per group: a
-      // trigger reaching a member of an older image is not authority to serve a platform it has no
-      // module for.
+      // before the lock would let a member reach through it for an agent it may not hold.
       const [eligible] = await tx.$queryRaw<{ ok: boolean }[]>(Prisma.sql`
-        SELECT (${eligibleAgent(Prisma.sql`a`, Prisma.sql`${holder}::uuid`)}
-                AND ${servesAgentPlatforms(Prisma.sql`a.id`, Prisma.sql`${holder}::uuid`)}) AS ok
+        SELECT ${eligibleAgent(Prisma.sql`a`, Prisma.sql`${holder}::uuid`)} AS ok
         FROM "agent" a WHERE a.id = ${agentId}::uuid
       `)
       if (eligible?.ok !== true) return { granted: false, holder: null }
+      // The capability gate rides the statements that GRANT below, each at its own scope, never the
+      // entry: a group can hold several agents behind a shared socket bot, so gating on the
+      // TRIGGERED agent alone would take a group containing a peer this member cannot serve, and an
+      // answer given before the group is read cannot name the incumbent the re-route needs.
       const member = await tx.dutyGroupMember.findUnique({ where: { kind_refId: { kind: 'agent', refId: agentId } } })
       if (!member) {
         // Claiming creates the lease: the first trigger for a botless agent — gated like a claim.
+        // It mints a SINGLETON, so the agent-wise predicate is the exact requirement, and it rides
+        // the INSERT's own WHERE beside the barrier so nothing commits between check and write.
         const groupId = this.mintId()
         const minted = await tx.$executeRaw(Prisma.sql`
           INSERT INTO "duty_group" (id, "orgId", "holder", "term", "expiresAt", "createdAt", "updatedAt")
           SELECT ${groupId}::uuid, ${orgId}, ${holder}::uuid, 1, ${expiresAt}, ${now}, ${now}
-          WHERE ${generationGate}
+          WHERE ${generationGate} AND ${servesAgentPlatforms(Prisma.sql`${agentId}::uuid`, Prisma.sql`${holder}::uuid`)}
         `)
         if (minted !== 1) return { granted: false, holder: null }
         await tx.dutyGroupMember.create({ data: { kind: 'agent', refId: agentId, groupId, orgId } })
@@ -718,8 +720,9 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
       if (row === null) throw new Error(`duty group ${member.groupId} vanished under its member row`)
       const live = row.holder !== null && row.expiresAt !== null && row.expiresAt > now
       if (live && row.holder === holder) {
-        // Idempotent re-claim: refresh the horizon, never churn the term. CAS on
-        // (holder, term) besides the row lock, so a moved lease can never be
+        // Idempotent re-claim: refresh the horizon, never churn the term — ungated on capability,
+        // which takes nothing and would only strand a group this member already serves.
+        // CAS on (holder, term) besides the row lock, so a moved lease can never be
         // extended by a stale reader; a miss falls through to report the row as
         // it now stands.
         const refreshed = await tx.dutyGroup.updateMany({
@@ -733,10 +736,14 @@ export class PgDutyGroupRepo implements DutyGroupRepo {
         // Vacancy re-asserted in the write despite the row lock — belt and braces — and the
         // rollout barrier in the same statement. Same rule as `claimVacant`: the term bump leaves
         // the grant unconfirmed by construction, including for the member that just lost it.
+        // This TAKES an existing group, so the gate here is the GROUP-wise one `claimVacant`
+        // carries: what the whole group needs, not what the trigger named. A refusal matches no
+        // row and falls through to report the row as it stands.
         const won = await tx.$executeRaw(Prisma.sql`
           UPDATE "duty_group" SET "holder" = ${holder}::uuid, "term" = "term" + 1, "expiresAt" = ${expiresAt}, "updatedAt" = ${now}
           WHERE id = ${row.id}::uuid AND ("holder" IS NULL OR "expiresAt" IS NULL OR "expiresAt" < ${now})
             AND ${generationGate}
+            AND ${servesGroupPlatforms(Prisma.sql`${row.id}::uuid`, Prisma.sql`${holder}::uuid`)}
         `)
         if (won === 1) {
           const granted = await tx.dutyGroup.findUniqueOrThrow({ where: { id: row.id } })

--- a/packages/control-plane/test/fixtures/seed.ts
+++ b/packages/control-plane/test/fixtures/seed.ts
@@ -11,7 +11,9 @@ import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { AgentId, DaemonId, OrgId, type Epoch } from '../../src/domain/ids.js'
 
 export const DEF_ORG = OrgId(DEFAULT_ORG_ID)
-const DEFAULT_DAEMON_CAPABILITIES = {
+/** What a registered stock daemon advertises. Exported because the duty ledger's claim paths gate
+ *  on it now: a fixture daemon with no platform list can claim nothing that has an integration. */
+export const DEFAULT_DAEMON_CAPABILITIES = {
   platforms: ['slack', 'telegram', 'discord'],
   runtimes: ['claude'],
   acp: true,

--- a/packages/control-plane/test/repo/duty-group.repo.test.ts
+++ b/packages/control-plane/test/repo/duty-group.repo.test.ts
@@ -880,6 +880,32 @@ describe('DutyGroupRepo — the platform-capability claim gate (real Postgres)',
     })
   })
 
+  // …and only a LIVE one. A lapsed lease leaves its `holder` column standing, so a refused take
+  // would otherwise hand back a member that has stopped serving as the sole re-route target — and
+  // the relay drops the ingress there, having acknowledged it upstream already.
+  it('a capability-refused vacancy names no incumbent, stale holder column and all', async () => {
+    await member(M1, OLD_IMAGE)
+    await member(M2, NEW_IMAGE)
+    const setId = await joinPool(prisma, M1, M2)
+    await pooledAgent(A1, setId, 'needs-linear')
+    await integrate(I1, A1, B1, 'linear')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+
+    const won = await repo.claimAgentHome(ORG, AgentId(A1), M2, T0, LEASE_MS)
+    // The lease lapses; the row still carries M2 in `holder`, which is what makes this a trap.
+    const lapsed = after(LEASE_MS + 1)
+    expect(await prisma.dutyGroup.findUniqueOrThrow({ where: { id: won.groupId! } })).toMatchObject({ holder: M2 })
+
+    expect(await repo.claimAgentHome(ORG, AgentId(A1), M1, lapsed, LEASE_MS)).toEqual({
+      granted: false,
+      groupId: won.groupId,
+      term: 1n,
+      holder: null
+    })
+    // The gate is what refused it, not the ledger: the member that carries the platform takes it.
+    expect((await repo.claimAgentHome(ORG, AgentId(A1), M2, lapsed, LEASE_MS)).granted).toBe(true)
+  })
+
   // The claim's own diagnostic — negating the very predicate the claim carries, so it can only
   // ever name groups the claim actually refused, and only the platforms this member is missing.
   it('capabilityBlockedVacancies names the passed-over agent and only the platforms it lacks', async () => {

--- a/packages/control-plane/test/repo/duty-group.repo.test.ts
+++ b/packages/control-plane/test/repo/duty-group.repo.test.ts
@@ -604,3 +604,236 @@ describe('DutyGroupRepo — pool telemetry (real Postgres)', () => {
     expect(await poolRow(repo, after(600_000))).toMatchObject({ vacantGroups: 0, oversizedVacantGroups: 0 })
   })
 })
+
+// The capability gate: a member may claim a group only when it advertises a module for every
+// platform the group's active integrations name. A daemon fails CLOSED on an unregistered platform
+// — it skips the integration and opens no connection — so an old image claiming a newly-integrated
+// agent takes that surface dark silently. This is the rollout window every new platform opens.
+describe('DutyGroupRepo — the platform-capability claim gate (real Postgres)', () => {
+  const MAX_MEMBERS = 1000
+  /** The image before a platform lands, and the one that carries it. */
+  const OLD_IMAGE = ['slack', 'telegram', 'discord', 'feishu']
+  const NEW_IMAGE = [...OLD_IMAGE, 'linear']
+  const A3 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3'
+  const I1 = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1'
+  const I2 = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc2'
+
+  const poolRow = async (repo: PgDutyGroupRepo, now = T0) =>
+    (await repo.poolTelemetry(now, LEASE_MS, MAX_MEMBERS)).find((r) => r.installWide)!
+
+  async function member(id: string, platforms: string[], lastSeenAt: Date | null = T0) {
+    await prisma.daemon.create({
+      data: {
+        id,
+        orgId: null,
+        maxAgents: 8,
+        status: 'ready',
+        lastSeenAt,
+        capabilities: { platforms, runtimes: ['claude'], acp: true, features: [] }
+      }
+    })
+  }
+
+  async function pooledAgent(id: string, setId: string, name: string) {
+    await prisma.agent.create({
+      data: { id, orgId: DEFAULT_ORG_ID, name, runtime: 'claude', placementKind: 'set', setId }
+    })
+  }
+
+  /** One active integration on its own bot — the edge the recompute reads and the platform requirement. */
+  async function integrate(integrationId: string, agentId: string, botId: string, platform: string) {
+    await prisma.bot.create({ data: { id: botId, orgId: DEFAULT_ORG_ID, platform, name: `${platform}-bot` } })
+    await prisma.integration.create({
+      data: { id: integrationId, orgId: DEFAULT_ORG_ID, agentId, botId, platform, name: `${platform}-bot` }
+    })
+  }
+
+  it('a member whose image lacks the platform is passed over; the one that carries it claims', async () => {
+    await member(M1, OLD_IMAGE)
+    await member(M2, NEW_IMAGE)
+    const setId = await joinPool(prisma, M1, M2)
+    await pooledAgent(A1, setId, 'needs-linear')
+    await integrate(I1, A1, B1, 'linear')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
+
+    expect(await repo.claimVacant(M1, 10, T0, LEASE_MS, { maxMembers: MAX_MEMBERS })).toEqual([])
+    const granted = await repo.claimVacant(M2, 10, T0, LEASE_MS, { maxMembers: MAX_MEMBERS })
+    expect(granted).toHaveLength(1)
+    expect(await repo.holdsAgent(M2, AgentId(A1), T0)).toBe(true)
+  })
+
+  // Fail-closed is the point: unserved and visible beats served-and-silently-dead.
+  it('stays vacant when NO live member advertises the platform, and the alert says why', async () => {
+    await member(M1, OLD_IMAGE)
+    const setId = await joinPool(prisma, M1)
+    await pooledAgent(A1, setId, 'needs-linear')
+    await integrate(I1, A1, B1, 'linear')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
+
+    expect(await repo.claimVacant(M1, 10, T0, LEASE_MS, { maxMembers: MAX_MEMBERS })).toEqual([])
+    // Made an hour old, so "the alarm cannot be pinned by it" is an assertion rather than a tautology.
+    await prisma.$executeRaw`UPDATE "duty_group" SET "updatedAt" = ${after(-3_600_000)}`
+
+    // Reported apart from the claimable demand, like an oversized group: scaling the pool cannot
+    // clear it, so it must not pin the capacity alarm — rolling the image forward is the fix.
+    expect(await poolRow(repo, after(60_000))).toMatchObject({
+      vacantGroups: 0,
+      capabilityBlockedVacantGroups: 1,
+      oldestVacancySec: 0
+    })
+
+    // A member that carries the platform joins: the same group becomes ordinary demand and places.
+    await member(M2, NEW_IMAGE)
+    await joinPool(prisma, M2)
+    const row = await poolRow(repo, after(60_000))
+    expect(row).toMatchObject({ vacantGroups: 1, capabilityBlockedVacantGroups: 0 })
+    expect(row.oldestVacancySec).toBeGreaterThan(3_600)
+    expect(await repo.claimVacant(M2, 10, T0, LEASE_MS, { maxMembers: MAX_MEMBERS })).toHaveLength(1)
+  })
+
+  // A quiet or scaled-to-zero set has no live member to prove an image gap against, so its
+  // vacancies stay ordinary demand — "the pool is empty" is what `members` reports, not this.
+  it('a set with no live member reports demand, not a capability gap', async () => {
+    await member(M1, OLD_IMAGE)
+    const setId = await joinPool(prisma, M1)
+    await pooledAgent(A1, setId, 'needs-linear')
+    await integrate(I1, A1, B1, 'linear')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
+
+    const quiet = after(LEASE_MS + 1)
+    expect(await poolRow(repo, quiet)).toMatchObject({
+      liveMembers: 0,
+      vacantGroups: 1,
+      capabilityBlockedVacantGroups: 0
+    })
+  })
+
+  // The parity rule the pool gauges live under: the alert's eligibility must state what the claim
+  // decides, or it alarms on work no pool size could take. With one live member the set-wise
+  // predicate reduces to that member's own, so the two counts are directly comparable.
+  it('parity: with one live member the alert counts exactly what that member claims and refuses', async () => {
+    await member(M1, OLD_IMAGE)
+    const setId = await joinPool(prisma, M1)
+    await pooledAgent(A1, setId, 'needs-linear')
+    await pooledAgent(A2, setId, 'needs-slack')
+    await pooledAgent(A3, setId, 'botless')
+    await integrate(I1, A1, B1, 'linear')
+    await integrate(I2, A2, B2, 'slack')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(
+      repo,
+      [
+        { agentId: A1, botId: B1 },
+        { agentId: A2, botId: B2 }
+      ],
+      [A3],
+      T0
+    )
+
+    const before = await poolRow(repo)
+    expect(before).toMatchObject({ vacantGroups: 2, capabilityBlockedVacantGroups: 1 })
+
+    const granted = await repo.claimVacant(M1, 10, T0, LEASE_MS, { maxMembers: MAX_MEMBERS })
+    expect(granted).toHaveLength(before.vacantGroups)
+    expect(await poolRow(repo, after(1000))).toMatchObject({
+      vacantGroups: 0,
+      capabilityBlockedVacantGroups: before.capabilityBlockedVacantGroups
+    })
+  })
+
+  // No behavior change where every member runs the same image — the pool's normal state.
+  it('a homogeneous pool claims exactly what it claimed before the gate existed', async () => {
+    await member(M1, NEW_IMAGE)
+    await member(M2, NEW_IMAGE)
+    const setId = await joinPool(prisma, M1, M2)
+    await pooledAgent(A1, setId, 'needs-linear')
+    await pooledAgent(A2, setId, 'needs-slack')
+    await pooledAgent(A3, setId, 'botless')
+    await integrate(I1, A1, B1, 'linear')
+    await integrate(I2, A2, B2, 'slack')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(
+      repo,
+      [
+        { agentId: A1, botId: B1 },
+        { agentId: A2, botId: B2 }
+      ],
+      [A3],
+      T0
+    )
+
+    expect(await repo.claimVacant(M1, 10, T0, LEASE_MS, { maxMembers: MAX_MEMBERS })).toHaveLength(3)
+    expect(await poolRow(repo, after(1000))).toMatchObject({ vacantGroups: 0, capabilityBlockedVacantGroups: 0 })
+  })
+
+  // The gate reads the same rows the install-time one does: an integration that is no longer
+  // active asks nothing of the member holding its agent.
+  it('a revoked integration stops requiring its platform', async () => {
+    await member(M1, OLD_IMAGE)
+    const setId = await joinPool(prisma, M1)
+    await pooledAgent(A1, setId, 'needs-linear')
+    await integrate(I1, A1, B1, 'linear')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
+    expect(await repo.claimVacant(M1, 10, T0, LEASE_MS, { maxMembers: MAX_MEMBERS })).toEqual([])
+
+    await prisma.integration.update({ where: { id: I1 }, data: { status: 'revoked' } })
+    expect(await repo.claimVacant(M1, 10, T0, LEASE_MS, { maxMembers: MAX_MEMBERS })).toHaveLength(1)
+  })
+
+  // The rendezvous is a claim path too: a trigger reaching the wrong member is not authority to
+  // serve a platform that member has no module for.
+  it('the activation rendezvous takes the same gate', async () => {
+    await member(M1, OLD_IMAGE)
+    await member(M2, NEW_IMAGE)
+    const setId = await joinPool(prisma, M1, M2)
+    await pooledAgent(A1, setId, 'needs-linear')
+    await integrate(I1, A1, B1, 'linear')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+
+    expect(await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)).toEqual({ granted: false, holder: null })
+    expect(await prisma.dutyGroup.count()).toBe(0)
+    expect((await repo.claimAgentHome(ORG, AgentId(A1), M2, T0, LEASE_MS)).granted).toBe(true)
+  })
+
+  // The claim's own diagnostic — negating the very predicate the claim carries, so it can only
+  // ever name groups the claim actually refused, and only the platforms this member is missing.
+  it('capabilityBlockedVacancies names the passed-over agent and only the platforms it lacks', async () => {
+    await member(M1, OLD_IMAGE)
+    const setId = await joinPool(prisma, M1)
+    await pooledAgent(A1, setId, 'needs-both')
+    await integrate(I1, A1, B1, 'linear')
+    await integrate(I2, A1, B2, 'slack')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [], T0)
+
+    const blocked = await repo.capabilityBlockedVacancies(M1, T0, { maxMembers: MAX_MEMBERS })
+    expect(blocked).toHaveLength(1)
+    expect(blocked[0]).toMatchObject({ agentId: A1, missingPlatforms: ['linear'] })
+
+    // Nothing to report once the group is claimable — the member that carries the platform sees none.
+    await member(M2, NEW_IMAGE)
+    await joinPool(prisma, M2)
+    expect(await repo.capabilityBlockedVacancies(M2, T0, { maxMembers: MAX_MEMBERS })).toEqual([])
+  })
+
+  // Fail-closed on the daemon read itself: a row whose capabilities carry no list advertises
+  // nothing, rather than reading as "no restriction".
+  it('a member whose capabilities name no platform list claims nothing that needs one', async () => {
+    await prisma.daemon.create({ data: { id: M1, orgId: null, maxAgents: 8, status: 'ready', lastSeenAt: T0 } })
+    const setId = await joinPool(prisma, M1)
+    await pooledAgent(A1, setId, 'needs-slack')
+    await pooledAgent(A2, setId, 'botless')
+    await integrate(I1, A1, B1, 'slack')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(repo, [{ agentId: A1, botId: B1 }], [A2], T0)
+
+    // Only the botless singleton, which requires nothing at all.
+    const granted = await repo.claimVacant(M1, 10, T0, LEASE_MS, { maxMembers: MAX_MEMBERS })
+    expect(granted).toHaveLength(1)
+    expect(granted[0]!.members).toEqual([{ kind: 'agent', refId: A2 }])
+  })
+})

--- a/packages/control-plane/test/repo/duty-group.repo.test.ts
+++ b/packages/control-plane/test/repo/duty-group.repo.test.ts
@@ -617,6 +617,7 @@ describe('DutyGroupRepo — the platform-capability claim gate (real Postgres)',
   const A3 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3'
   const I1 = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1'
   const I2 = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc2'
+  const I3 = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc3'
 
   const poolRow = async (repo: PgDutyGroupRepo, now = T0) =>
     (await repo.poolTelemetry(now, LEASE_MS, MAX_MEMBERS)).find((r) => r.installWide)!
@@ -643,6 +644,12 @@ describe('DutyGroupRepo — the platform-capability claim gate (real Postgres)',
   /** One active integration on its own bot — the edge the recompute reads and the platform requirement. */
   async function integrate(integrationId: string, agentId: string, botId: string, platform: string) {
     await prisma.bot.create({ data: { id: botId, orgId: DEFAULT_ORG_ID, platform, name: `${platform}-bot` } })
+    await shareBot(integrationId, agentId, botId, platform)
+  }
+
+  /** A second agent installed on a bot that already exists — the shared socket bot that joins two
+   *  agents into one duty group, which is what makes a group's requirement wider than any agent's. */
+  async function shareBot(integrationId: string, agentId: string, botId: string, platform: string) {
     await prisma.integration.create({
       data: { id: integrationId, orgId: DEFAULT_ORG_ID, agentId, botId, platform, name: `${platform}-bot` }
     })
@@ -785,7 +792,8 @@ describe('DutyGroupRepo — the platform-capability claim gate (real Postgres)',
   })
 
   // The rendezvous is a claim path too: a trigger reaching the wrong member is not authority to
-  // serve a platform that member has no module for.
+  // serve a platform that member has no module for. Minting is the path here — no sweep has run —
+  // so the requirement is the triggered agent's own.
   it('the activation rendezvous takes the same gate', async () => {
     await member(M1, OLD_IMAGE)
     await member(M2, NEW_IMAGE)
@@ -797,6 +805,79 @@ describe('DutyGroupRepo — the platform-capability claim gate (real Postgres)',
     expect(await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)).toEqual({ granted: false, holder: null })
     expect(await prisma.dutyGroup.count()).toBe(0)
     expect((await repo.claimAgentHome(ORG, AgentId(A1), M2, T0, LEASE_MS)).granted).toBe(true)
+  })
+
+  // Scope is the whole finding: a duty group is a connected component, so a shared socket bot puts
+  // several agents in it, and TAKING it is a take of every one of them. Gating the rendezvous on
+  // the triggered agent alone would let this member through on A1 and hand it A2 as well — the
+  // dead surface `claimVacant` already refuses.
+  it('the rendezvous gates an existing group on every agent in it, not the triggered one', async () => {
+    await member(M1, OLD_IMAGE)
+    await member(M2, NEW_IMAGE)
+    const setId = await joinPool(prisma, M1, M2)
+    await pooledAgent(A1, setId, 'needs-slack')
+    await pooledAgent(A2, setId, 'also-needs-linear')
+    await integrate(I1, A1, B1, 'slack')
+    await shareBot(I3, A2, B1, 'slack') // the shared socket bot that joins them into ONE group
+    await integrate(I2, A2, B2, 'linear')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+    await reconcile(
+      repo,
+      [
+        { agentId: A1, botId: B1 },
+        { agentId: A2, botId: B1 }
+      ],
+      [],
+      T0
+    )
+    expect(await prisma.dutyGroup.count()).toBe(1)
+
+    // A1 on its own needs only slack, which this member advertises — the group does not.
+    const refused = await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)
+    expect(refused.granted).toBe(false)
+    expect(await repo.holdsAgent(M1, AgentId(A1), T0)).toBe(false)
+    expect((await repo.listForOrg(ORG))[0]).toMatchObject({ holder: null, term: 0n })
+
+    // Same rendezvous, the member that carries both platforms: granted.
+    expect((await repo.claimAgentHome(ORG, AgentId(A1), M2, T0, LEASE_MS)).granted).toBe(true)
+  })
+
+  // The other half of the scope rule: the gate belongs on the OPERATION, so the member refused a
+  // group it cannot serve whole still mints the singleton it can — the fallback for an agent no
+  // sweep has grouped yet is a group of exactly that agent.
+  it('the same member still mints a singleton for an agent it can serve', async () => {
+    await member(M1, OLD_IMAGE)
+    const setId = await joinPool(prisma, M1)
+    await pooledAgent(A1, setId, 'needs-slack')
+    await pooledAgent(A2, setId, 'needs-linear')
+    await integrate(I1, A1, B1, 'slack')
+    await integrate(I2, A2, B2, 'linear')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+
+    expect((await repo.claimAgentHome(ORG, AgentId(A1), M1, T0, LEASE_MS)).granted).toBe(true)
+    expect(await repo.holdsAgent(M1, AgentId(A1), T0)).toBe(true)
+    // Its peer needs a platform this image has no module for, and that one is still refused.
+    expect(await repo.claimAgentHome(ORG, AgentId(A2), M1, T0, LEASE_MS)).toEqual({ granted: false, holder: null })
+  })
+
+  // A refusal must not cost the relay its one-hop re-route: the answer names the live incumbent,
+  // which is only knowable by reading the group — so the gate cannot sit at the entry.
+  it('a capability-refused rendezvous still names the live incumbent', async () => {
+    await member(M1, OLD_IMAGE)
+    await member(M2, NEW_IMAGE)
+    const setId = await joinPool(prisma, M1, M2)
+    await pooledAgent(A1, setId, 'needs-linear')
+    await integrate(I1, A1, B1, 'linear')
+    const repo = new PgDutyGroupRepo(prisma, minter())
+
+    const won = await repo.claimAgentHome(ORG, AgentId(A1), M2, T0, LEASE_MS)
+    expect(won.granted).toBe(true)
+    expect(await repo.claimAgentHome(ORG, AgentId(A1), M1, after(1000), LEASE_MS)).toEqual({
+      granted: false,
+      groupId: won.groupId,
+      term: 1n,
+      holder: M2
+    })
   })
 
   // The claim's own diagnostic — negating the very predicate the claim carries, so it can only

--- a/packages/control-plane/test/repo/duty-recompute.test.ts
+++ b/packages/control-plane/test/repo/duty-recompute.test.ts
@@ -7,6 +7,7 @@ import { PgDutyGroupRepo } from '../../src/persistence/index.js'
 import { DutyRecomputeSweep } from '../../src/orchestrator/dutyRecompute.js'
 import type { DutyReconcilePlan } from '../../src/domain/duty.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { DEFAULT_DAEMON_CAPABILITIES } from '../fixtures/seed.js'
 import { joinPool, poolSetId } from '../fakes/member-set.js'
 import { AgentId, DaemonId, OrgId } from '../../src/domain/ids.js'
 import { FakeClock } from '../fakes/fake-clock.js'
@@ -63,11 +64,13 @@ function sweep(clock = new FakeClock(1_700_000_000_000)) {
   }
 }
 
+// Registered stock daemons: the capability list is load-bearing now, because the claim paths gate
+// on it — a member advertising no platform may claim nothing whose integrations name one.
 async function seedDaemons(): Promise<void> {
   await prisma.daemon.createMany({
     data: [
-      { id: M1, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' },
-      { id: M2, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready' }
+      { id: M1, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready', capabilities: DEFAULT_DAEMON_CAPABILITIES },
+      { id: M2, orgId: DEFAULT_ORG_ID, maxAgents: 8, status: 'ready', capabilities: DEFAULT_DAEMON_CAPABILITIES }
     ]
   })
 }
@@ -89,8 +92,8 @@ async function seedPoolAgent(id: string, name: string): Promise<void> {
 async function seedMembers(): Promise<void> {
   await prisma.daemon.createMany({
     data: [
-      { id: POOL_A, orgId: null, maxAgents: 8, status: 'ready' },
-      { id: POOL_B, orgId: null, maxAgents: 8, status: 'ready' }
+      { id: POOL_A, orgId: null, maxAgents: 8, status: 'ready', capabilities: DEFAULT_DAEMON_CAPABILITIES },
+      { id: POOL_B, orgId: null, maxAgents: 8, status: 'ready', capabilities: DEFAULT_DAEMON_CAPABILITIES }
     ]
   })
   await joinPool(prisma, POOL_A, POOL_B)


### PR DESCRIPTION
Pool members claimed vacant agents with no regard for their advertised platform capabilities — the capability gate existed only at install time. During a rolling upgrade with heterogeneous images, an agent whose integrations include a newly added platform could be claimed by an old member whose image lacks the module; the daemon's fail-closed config read then silently skips that integration, and the agent's platform surface goes dead on that member until it moves. Every new platform's rollout window hits this; Linear is the next.

- One predicate, two layers, mirroring the file's `mayHold` → `eligibleAgent` pattern: pure `domain/platform-capability.ts` (`servesPlatform` — the install-time gate now calls it too, so install and claim cannot drift) and its row-wise SQL mirror in `duty-group.repo.ts`, carried as a new conjunct by `claimVacant` and per-agent by the rendezvous. Fail-closed both sides; agents with no active integrations require nothing, so webchat/cron singletons never meet the gate.
- Alerting parity by construction, not by copy: the pool telemetry's blocked CTE calls the same `servesGroupPlatforms`, restated set-wise. A capability-blocked vacancy leaves the scale-up series and gets its own `capability_blocked.groups` gauge (the `undeliverable` precedent — scaling cannot clear an image gap, and leaving it in `vacantGroups` would pin the capacity alarm forever). Parity pinned by a one-live-member test where the two forms must agree exactly.
- Surfacing: when a claim under-fills its budget, one warn per (agent, pass) names the missing platform ids — what an operator mid-rollout needs.
- Deliberately NOT folded into `noIneligibleAgent`: `vacateIneligible` shares that predicate, and a capability read failing closed must delay a placement, never tear down live service.
- Homogeneous pools behave byte-identically (pinned); no schema change, no new env, no migration.

Tests: capability truth table, heterogeneous-pool claim routing, blocked-vacancy accounting + parity, recompute fixtures now registering realistic capabilities. CP typecheck, `test:unit` 2213, `test:int` 1901, lint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
