### PR TITLE
docs(web): replace a non-English design-note quote with English prose

### DIFF
--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -376,8 +376,8 @@ export function conversationOwners(botId: string, integrations: IntegrationRow[]
  *  conversation has exactly one owner: the agent that answers whatever its
  *  routing rules don't hand to someone else.
  *
- *  The design keeps this strictly apart from the trigger toggle ("切换 default 和
- *  trigger 是两类控制，不要混一起") — a compact avatar + chevron whose popover
+ *  The design keeps this strictly apart from the trigger toggle (the two are separate
+ *  controls, never merged) — a compact avatar + chevron whose popover
  *  READS the current default and offers exactly one action, claiming the channel
  *  for the agent whose page this is. Handing a conversation to some third agent stays
  *  in Settings → Bots, where the whole roster is in view. */


### PR DESCRIPTION
## What changed

`DefaultAgentPicker` in `packages/web/src/components/console/IntegrationChannelList.tsx` carried a
doc comment that quoted a design note verbatim in Chinese. The quote is replaced with an English
paraphrase that says the same thing: the default-agent picker and the trigger toggle are two
separate controls and must not be merged. Nothing else in the comment or the code changes.

## Why

Source in this repository is English-only. This was the last unintentional non-English string in
`packages/web/src` — a sweep for CJK characters over that tree now returns only
`lib/conversation-addressing.ts` and its test, where the CJK is deliberate: those are fixtures for
mention parsing of non-ASCII agent names (the `\b` word-boundary regression), and they are left
untouched.

## For the reviewer

- Comment-only change; no behavior, no types, no rendered output.
- `pnpm --filter @agentconnect.md/web typecheck` and `pnpm lint` both pass.
- The related `model名` typo in `packages/web/src/lib/data.ts` was already fixed in #1685; this PR
  is the remaining instance of the same class found by sweeping the package.
