### PR TITLE
fix(daemon): quote the source message in approval DMs and keep the intro on rewrites

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -104,6 +104,9 @@ interface DmNotice {
   conn: SlackConnection
   channel: string
   ts: string
+  /** The §5.2 context header (session link, source quote/permalink). Every in-place
+   *  rewrite prepends it — a resolved card must not lose the links (issue feedback). */
+  intro: unknown[]
   propName?: string
   valueKind?: 'enum' | 'boolean'
 }
@@ -441,15 +444,20 @@ export class PermissionCoordinator {
       rec.kind === 'permission'
         ? buildPermissionCard(requestId, rec.params, sessionTarget)
         : (buildElicitationCard(requestId, rec.params, sessionTarget) ?? [])
+    const fromSlack = p.plan.platform === 'slack'
     const sourceUrl =
-      p.plan.platform === 'slack' && p.conn instanceof SlackConnection
+      fromSlack && p.conn instanceof SlackConnection
         ? slackThreadUrl(p.conn.workspaceUrl, p.plan.channel, p.plan.thread ?? p.plan.statusThread)
         : undefined
+    // Quote the triggering Slack message itself (§5.2 "forwarded message") — the
+    // recipient decides from the DM, so the ask must be readable without a hop.
+    const sourceText = fromSlack ? p.entry.msg.text : undefined
     const intro = buildApprovalDmIntro({
       agentName: p.plan.agentName,
       requesterName,
       sessionUrl: this.host.sessionLink(p.outwardSessionId, 'slack'),
-      ...(sourceUrl ? { sourceUrl } : {})
+      ...(sourceUrl ? { sourceUrl } : {}),
+      ...(sourceText ? { sourceText } : {})
     })
     const ts = await conn.postBlocks(
       channel,
@@ -474,7 +482,7 @@ export class PermissionCoordinator {
         rec.kind === 'permission'
           ? buildPermissionResolvedCard(rec.params, 'Already decided', undefined)
           : buildElicitationResolvedCard(rec.params, ':hourglass: Already decided')
-      void conn.updateBlocks(channel, ts, resolved, 'Permission resolved', true).catch(() => {})
+      void conn.updateBlocks(channel, ts, [...intro, ...resolved], 'Permission resolved', true).catch(() => {})
       if (handleStored)
         void this.host
           .store()
@@ -488,6 +496,7 @@ export class PermissionCoordinator {
       conn,
       channel,
       ts,
+      intro,
       ...(elicit ? { propName: elicit.propName, valueKind: elicit.kind } : {})
     }
   }
@@ -555,11 +564,14 @@ export class PermissionCoordinator {
           .updateBlocks(
             notify.channel,
             notify.ts,
-            buildPermissionResolvedCard(
-              rec.params,
-              'No longer authorized — decide it from the Agent or Session page',
-              undefined
-            ),
+            [
+              ...notify.intro,
+              ...buildPermissionResolvedCard(
+                rec.params,
+                'No longer authorized — decide it from the Agent or Session page',
+                undefined
+              )
+            ],
             'Permission requires an Agent editor',
             true
           )
@@ -579,11 +591,14 @@ export class PermissionCoordinator {
       .updateBlocks(
         notify.channel,
         notify.ts,
-        buildPermissionResolvedCard(
-          rec.params,
-          verdict.name ? `${option.name} — ${verdict.name}` : option.name,
-          allowed
-        ),
+        [
+          ...notify.intro,
+          ...buildPermissionResolvedCard(
+            rec.params,
+            verdict.name ? `${option.name} — ${verdict.name}` : option.name,
+            allowed
+          )
+        ],
         'Permission resolved',
         true
       )
@@ -610,7 +625,10 @@ export class PermissionCoordinator {
           .updateBlocks(
             notify.channel,
             notify.ts,
-            buildElicitationResolvedCard(rec.params, ':lock: No longer authorized — decide it from the console'),
+            [
+              ...notify.intro,
+              ...buildElicitationResolvedCard(rec.params, ':lock: No longer authorized — decide it from the console')
+            ],
             'Permission requires an Agent editor',
             true
           )
@@ -639,7 +657,10 @@ export class PermissionCoordinator {
       .updateBlocks(
         notify.channel,
         notify.ts,
-        buildElicitationResolvedCard(rec.params, verdict.name ? `${decision} — ${verdict.name}` : decision),
+        [
+          ...notify.intro,
+          ...buildElicitationResolvedCard(rec.params, verdict.name ? `${decision} — ${verdict.name}` : decision)
+        ],
         'Permission resolved',
         true
       )
@@ -769,7 +790,13 @@ export class PermissionCoordinator {
               `${req.decision === 'allow' ? ':white_check_mark:' : ':no_entry_sign:'} ${label}`
             )
       void pending.notify.conn
-        .updateBlocks(pending.notify.channel, pending.notify.ts, blocks, 'Permission resolved', true)
+        .updateBlocks(
+          pending.notify.channel,
+          pending.notify.ts,
+          [...pending.notify.intro, ...blocks],
+          'Permission resolved',
+          true
+        )
         .catch(() => {})
       void this.host
         .store()
@@ -905,7 +932,13 @@ export class PermissionCoordinator {
             ? buildPermissionResolvedCard(pending.params, 'Cancelled', undefined)
             : buildElicitationResolvedCard(pending.params, ':hourglass: Cancelled')
         void pending.notify.conn
-          .updateBlocks(pending.notify.channel, pending.notify.ts, blocks, 'Permission cancelled', true)
+          .updateBlocks(
+            pending.notify.channel,
+            pending.notify.ts,
+            [...pending.notify.intro, ...blocks],
+            'Permission cancelled',
+            true
+          )
           .catch(() => {})
         void this.host
           .store()

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -449,9 +449,15 @@ export class PermissionCoordinator {
       fromSlack && p.conn instanceof SlackConnection
         ? slackThreadUrl(p.conn.workspaceUrl, p.plan.channel, p.plan.thread ?? p.plan.statusThread)
         : undefined
-    // Quote the triggering Slack message itself (§5.2 "forwarded message") — the
-    // recipient decides from the DM, so the ask must be readable without a hop.
-    const sourceText = fromSlack ? p.entry.msg.text : undefined
+    // Quote the triggering Slack message only for its own author (§5.2): routing proves
+    // canEdit, not that the recipient may read the source conversation — a private
+    // channel's text must not ride a DM past Slack's ACL. Same integration ⇒ same
+    // workspace, so the member-id comparison is sound; everyone else keeps the
+    // permalink, where Slack enforces access itself.
+    const sourceText =
+      fromSlack && target.integrationId === p.plan.integrationId && target.userId === p.plan.requesterId
+        ? p.entry.msg.text
+        : undefined
     const intro = buildApprovalDmIntro({
       agentName: p.plan.agentName,
       requesterName,

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -528,22 +528,30 @@ export function buildPermissionResolvedCard(
 }
 
 /** Context header for an approval DM (slack-approval-dm.md §5.2): which agent is
- * asking, who triggered the turn, the console session deep link, and — for a
- * Slack-triggered turn — a permalink to the source thread. Pure. */
+ * asking, who triggered the turn, a quote of the triggering Slack message, the
+ * console session deep link, and a permalink to the source thread. Pure. */
 export function buildApprovalDmIntro(info: {
   agentName: string
   requesterName?: string | null
   sessionUrl: string
   sourceUrl?: string
+  sourceText?: string
 }): unknown[] {
   const requester = info.requesterName ? ` for *${clampTo(info.requesterName, 60)}*` : ''
+  // Quoted on every line so a multi-line message stays one visual quote block.
+  const quote = info.sourceText?.trim()
+    ? `\n${clampTo(info.sourceText.trim(), 300)
+        .split('\n')
+        .map((line) => `> ${line}`)
+        .join('\n')}`
+    : ''
   const links = [`<${info.sessionUrl}|Open session>`, ...(info.sourceUrl ? [`<${info.sourceUrl}|Source thread>`] : [])]
   return [
     {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*${clampTo(info.agentName, 60)}* is waiting on an approval${requester}.\n${links.join(' · ')}`
+        text: `*${clampTo(info.agentName, 60)}* is waiting on an approval${requester}.${quote}\n${links.join(' · ')}`
       }
     }
   ]

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -32,7 +32,7 @@ function permissionParams(): RequestPermissionRequest {
   } as unknown as RequestPermissionRequest
 }
 
-async function world(over?: { route?: ReturnType<typeof vi.fn>; noChannel?: boolean }) {
+async function world(over?: { route?: ReturnType<typeof vi.fn>; noChannel?: boolean; platform?: string }) {
   const store = await LocalStore.open({ database: SqliteAsyncDatabase.adopt(new DatabaseSync(':memory:')) })
   const conn = fakeSlackConn()
   const route =
@@ -48,7 +48,7 @@ async function world(over?: { route?: ReturnType<typeof vi.fn>; noChannel?: bool
       sessionKey: 'sess-key',
       agentId: AGENT,
       agentName: 'Butler',
-      platform: 'webchat',
+      platform: over?.platform ?? 'webchat',
       channel: 'C0',
       requesterId: undefined,
       approvalSurfaceSuppressed: false
@@ -56,7 +56,8 @@ async function world(over?: { route?: ReturnType<typeof vi.fn>; noChannel?: bool
     approval: { waitMs: 0, depth: 0 },
     acpSessionId: ACP_SESSION,
     outwardSessionId: 'outward-1',
-    builtinSystemToolCallIds: new Set<string>()
+    builtinSystemToolCallIds: new Set<string>(),
+    entry: { msg: { text: 'please run ls /' } }
   } as unknown as Pending
   pending.set(pendingTurnKey(AGENT, ACP_SESSION), p)
   const host: PermissionHost = {
@@ -88,16 +89,23 @@ const requestIdOf = (route: ReturnType<typeof vi.fn>): string =>
 
 describe('approval DM (slack-approval-dm.md §5–§6)', () => {
   it('routes, DMs the target, and resolves on the verified target click', async () => {
-    const w = await world()
+    const w = await world({ platform: 'slack' })
     const decided = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
     await vi.waitFor(() => expect(w.conn.postBlocks).toHaveBeenCalledTimes(1))
     expect(w.conn.openDirectMessage).toHaveBeenCalledWith('U1')
     // Top-level message: no thread ts.
     expect((w.conn.postBlocks.mock.calls[0] as unknown[])[3]).toBeUndefined()
+    // §5.2 intro: session deep link plus a quote of the triggering Slack message.
+    const posted = JSON.stringify((w.conn.postBlocks.mock.calls[0] as unknown[])[1])
+    expect(posted).toContain('https://console.example/sessions/outward-1')
+    expect(posted).toContain('> please run ls /')
     const requestId = requestIdOf(w.route)
 
     await w.coordinator.handlePermissionChoice({ requestId, optionId: 'o-allow', actor: { userId: 'U1' } })
     await expect(decided).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'o-allow' } })
+    // The resolved rewrite keeps the intro — the links must survive the decision.
+    const rewritten = JSON.stringify((w.conn.updateBlocks.mock.calls[0] as unknown[])[2])
+    expect(rewritten).toContain('https://console.example/sessions/outward-1')
     // The verify form named the addressed console user.
     const verify = (w.route.mock.calls[1]![0] as { verify?: { consoleUserId: string } }).verify
     expect(verify?.consoleUserId).toBe('cu-1')

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -32,7 +32,12 @@ function permissionParams(): RequestPermissionRequest {
   } as unknown as RequestPermissionRequest
 }
 
-async function world(over?: { route?: ReturnType<typeof vi.fn>; noChannel?: boolean; platform?: string }) {
+async function world(over?: {
+  route?: ReturnType<typeof vi.fn>
+  noChannel?: boolean
+  platform?: string
+  requesterId?: string
+}) {
   const store = await LocalStore.open({ database: SqliteAsyncDatabase.adopt(new DatabaseSync(':memory:')) })
   const conn = fakeSlackConn()
   const route =
@@ -50,7 +55,8 @@ async function world(over?: { route?: ReturnType<typeof vi.fn>; noChannel?: bool
       agentName: 'Butler',
       platform: over?.platform ?? 'webchat',
       channel: 'C0',
-      requesterId: undefined,
+      integrationId: over?.platform === 'slack' ? 'int-1' : undefined,
+      requesterId: over?.requesterId,
       approvalSurfaceSuppressed: false
     },
     approval: { waitMs: 0, depth: 0 },
@@ -89,16 +95,25 @@ const requestIdOf = (route: ReturnType<typeof vi.fn>): string =>
 
 describe('approval DM (slack-approval-dm.md §5–§6)', () => {
   it('routes, DMs the target, and resolves on the verified target click', async () => {
-    const w = await world({ platform: 'slack' })
+    const w = await world({ platform: 'slack', requesterId: 'U1' })
     const decided = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
     await vi.waitFor(() => expect(w.conn.postBlocks).toHaveBeenCalledTimes(1))
     expect(w.conn.openDirectMessage).toHaveBeenCalledWith('U1')
     // Top-level message: no thread ts.
     expect((w.conn.postBlocks.mock.calls[0] as unknown[])[3]).toBeUndefined()
-    // §5.2 intro: session deep link plus a quote of the triggering Slack message.
+    // §5.2 intro: session deep link plus — for the message's own author — its quote.
     const posted = JSON.stringify((w.conn.postBlocks.mock.calls[0] as unknown[])[1])
     expect(posted).toContain('https://console.example/sessions/outward-1')
     expect(posted).toContain('> please run ls /')
+    // A recipient who is NOT the author never receives the text (Slack ACL stays intact).
+    const other = await world({ platform: 'slack', requesterId: 'U-someone-else' })
+    void other.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    await vi.waitFor(() => expect(other.conn.postBlocks).toHaveBeenCalledTimes(1))
+    const otherPosted = JSON.stringify((other.conn.postBlocks.mock.calls[0] as unknown[])[1])
+    expect(otherPosted).toContain('https://console.example/sessions/outward-1')
+    expect(otherPosted).not.toContain('please run ls /')
+    await other.coordinator.releaseEditorPermissions(AGENT, ACP_SESSION)
+    await other.store.close()
     const requestId = requestIdOf(w.route)
 
     await w.coordinator.handlePermissionChoice({ requestId, optionId: 'o-allow', actor: { userId: 'U1' } })


### PR DESCRIPTION
## Summary

Live feedback on #1648's approval DMs, verified against the actual message blocks on the test workspace:

- **The DM never carried the triggering Slack message** — the design's §5.2 "forwarded message" was only a permalink. The intro now quotes the triggering message (clamped, per-line `>` so multi-line stays one quote block) alongside the session deep link and source-thread permalink.
- **Every in-place rewrite dropped the intro entirely**: `buildPermissionResolvedCard` replaced the whole message, so after a click/console decision/cancel the DM shrank to `🔒 Permission — ls / ✅ Allow Once — draco` with **no session link at all** (observed via `conversations.history`). The intro now rides `DmNotice` and all six rewrite paths (DM click resolve/refusal for both kinds, console decision, release, settled-while-posting) prepend it.

## Test plan

- `approval-dm.test.ts` now asserts the posted blocks carry the session deep link and the quoted source text, and that the resolved rewrite retains the link. 171 tests across `approval-dm` / `daemon-commands` / `local-store` pass; daemon typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)