### PR TITLE
feat(linear): the workspace is the channel

### DIFF
--- a/packages/control-plane/src/http/install-bot.ts
+++ b/packages/control-plane/src/http/install-bot.ts
@@ -24,6 +24,7 @@ import type { AgentRecord, BotRecord, IntegrationRecord, SlackTransport } from '
 import { BotId, IntegrationId, type OrgId } from '../domain/ids.js'
 import { integrationToSpec, isGatedAgent } from '../orchestrator/placement.js'
 import { NoConnection } from '../orchestrator/outbound.js'
+import { seedSoleConversationOwner } from '../orchestrator/soleConversation.js'
 import type { CpNewBotInstall } from '../platforms/provider.js'
 import { BotWorkspaceClaimed } from '../persistence/errors.js'
 
@@ -114,6 +115,8 @@ export async function installNewBot(
   // push the send-only spec to the daemon (HttpBotOrchestrator does both). No
   // long-lived platform connection opens on the daemon.
   if (transport === 'http') {
+    // Before the sync, so the routes this publishes already carry the workspace default (§5).
+    await seedSoleConversationOwner(deps.repos.integrationChannel, integration, bot)
     await deps.httpBot.syncBot(botId)
     return { integration, bot }
   }

--- a/packages/control-plane/src/http/mcp/tools.ts
+++ b/packages/control-plane/src/http/mcp/tools.ts
@@ -516,7 +516,7 @@ export const MCP_TOOLS: McpToolDef[] = [
   {
     name: 'setChannelTrigger',
     description:
-      'Change how an integration behaves in one conversation: the trigger mode (off / mention-only / any message; off disables the conversation) and/or the conversation’s owning agent (null clears the override).',
+      'Change how an integration behaves in one conversation: the trigger mode (off / mention-only / any message; off disables the conversation) and/or the conversation’s owning agent (null clears the override). Some platforms have a single conversation per install whose trigger IS the link — there a `trigger` write is refused and removing the integration is the way to stop the agent, while an owner change still works.',
     write: true,
     schema: z
       .object({

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -28,8 +28,9 @@ import type { ResolvableAgent } from '../../orchestrator/placementResolver.js'
 import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { refreshMutationAgent as refreshAgentUnderMutation } from '../mutation-agent.js'
 import { canView, canEdit } from '../../authorization/policy.js'
-import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
+import { gatesNewConversations, integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
 import { conversationOwnerRow, pickConversationOwner } from '../../orchestrator/httpBot.js'
+import { seedSoleConversationMember } from '../../orchestrator/soleConversation.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewBot } from '../install-bot.js'
 import { BotExternalIdentityTaken } from '../../persistence/errors.js'
@@ -356,6 +357,9 @@ export function integrationRoutes(deps: HttpDeps) {
                   message: 'bot sharing was just disabled; refresh and retry the integration change'
                 })
               }
+              // The added member's own row for the conversation this install names (§5),
+              // ownerless so joining never takes the workspace default from the first member.
+              await seedSoleConversationMember(deps.repos.integrationChannel, admission.integration, bot)
               // Relay owns the ingest — (re)assign the bot + push send-only specs to
               // every member daemon (including any that were direct before promotion).
               await deps.httpBot.syncBot(bot.id)
@@ -559,7 +563,9 @@ export function integrationRoutes(deps: HttpDeps) {
               effective.set(`${state.botId}\u0000${channelId}`, {
                 ...channel,
                 agentId: owner.agentId,
-                ...(ownerAgent && isGatedAgent(ownerAgent) ? { trigger: 'off' as const } : {})
+                // The same §14 rule the seeding seats take, so the console never shows a
+                // conversation Off while the compile is emitting its enabled route.
+                ...(ownerAgent && gatesNewConversations(owner.platform, ownerAgent) ? { trigger: 'off' as const } : {})
               })
             }
           }

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -28,7 +28,13 @@ import type { ResolvableAgent } from '../../orchestrator/placementResolver.js'
 import { denyViewerWrite, ctxOf, orgOf } from '../rbac.js'
 import { refreshMutationAgent as refreshAgentUnderMutation } from '../mutation-agent.js'
 import { canView, canEdit } from '../../authorization/policy.js'
-import { gatesNewConversations, integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js'
+import {
+  allowsTriggerControl,
+  gatesNewConversations,
+  integrationToSpec,
+  isGatedAgent,
+  TRIGGER_CONTROL_REFUSAL
+} from '../../orchestrator/placement.js'
 import { conversationOwnerRow, pickConversationOwner } from '../../orchestrator/httpBot.js'
 import { seedSoleConversationMember } from '../../orchestrator/soleConversation.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
@@ -777,6 +783,13 @@ export function integrationRoutes(deps: HttpDeps) {
         const bot = await deps.repos.bot.get(orgIdOf(req), integration.botId)
         if (!bot) {
           return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
+        }
+        // §5: where the install names the ONE conversation it can reach, that conversation's
+        // trigger is the link itself. Refuse rather than silently canonicalize — an Off accepted
+        // here would silence a still-linked agent through the mute fences, and a caller that
+        // asked for it has a bug worth surfacing. An `agentId`-only patch is untouched.
+        if (req.body.trigger !== undefined && !allowsTriggerControl(bot.platform)) {
+          return reply.code(400).send({ error: 'Bad Request', statusCode: 400, message: TRIGGER_CONTROL_REFUSAL })
         }
         const botScopedConversation = bot.transport === 'http'
         let effectiveOwner: AgentRecord | null = null

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -1473,4 +1473,86 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     expect(removals).toEqual([]) // nothing left to pull
     expect(ch.sends).toEqual([{ type: 'rc/bot-unassign', payload: { botId: BOT, credentialRevision: 1 } }]) // re-stamp only
   })
+
+  describe('a sole-conversation platform (§5 soleConversation)', () => {
+    // A connected Linear workspace: the install names the ONE conversation it can reach, so its
+    // row is the workspace default rather than a channel-scoped route.
+    const WORKSPACE = 'org-linear-1'
+    // The real Linear provider needs a token service and a live app config; this compile reads
+    // nothing from it but the relay projection's existence, so a relabelled stub is enough.
+    const LINEAR_PLATFORMS = buildCpPlatformRegistry([
+      { ...createSlackCpProvider({}), platformId: 'linear' } as CpPlatformProvider
+    ])
+
+    beforeEach(() => {
+      botRow = bot({ platform: 'linear' } as Partial<BotRecord>)
+      integrations = [
+        { ...integration(INT_A, ALICE), platform: 'linear' },
+        { ...integration(INT_B, BOB), platform: 'linear' }
+      ]
+      channels = [channel({ integrationId: INT_B, channelId: WORKSPACE, agentId: BOB, trigger: 'mention' })]
+    })
+
+    it('emits NO channel-scoped route and makes the row owner the group default', async () => {
+      await makeOrch(LINEAR_PLATFORMS).syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign
+
+      // The whole correction: a scoped `mention` rule here would be the FIRST rung, and every
+      // Linear event marks the app as mentioned — so it would swallow keyword selection and
+      // thread continuity alike.
+      expect(assign.routes.some((r) => r.scope !== undefined)).toBe(false)
+      const keywords = assign.routes
+        .filter((r) => r.match.kind === 'keyword')
+        .map((r) => (r.match as { value: string }).value)
+        .sort()
+      expect(keywords).toEqual(['alice', 'bob'])
+      // The ROW outranks the earliest-member derivation (ALICE installs first): the workspace
+      // conversation's owner IS the default.
+      expect(assign.defaultAgentId).toBe(BOB)
+      expect(assign.defaultDaemonId).toBe(D2)
+    })
+
+    it('carries a RESTRICTED member as UNGATED, so a private linking agent is routable at all', async () => {
+      // §14's fail-open worry presumes conversations the install never granted. Here the install
+      // granted the only one, so the member is not conversation-gated ON THIS BOT — which is what
+      // keeps the relay's three gated fences (the keyword rung, the default derivation, and the
+      // scoped-route requirement `agentTarget`/thread continuity impose) from stranding it.
+      gatedAgents = new Set([BOB])
+      await makeOrch(LINEAR_PLATFORMS).syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign
+
+      expect(assign.gatedAgentIds).toEqual([])
+      expect(assign.defaultAgentId).toBe(BOB)
+      expect(assign.routes.some((r) => r.agentId === BOB && r.match.kind === 'keyword' && r.scope === undefined)).toBe(
+        true
+      )
+      // The daemon's own last-hop backstop must agree, or it would refuse what the relay routed.
+      expect(upserts.every((u) => u.spec.core?.mode === 'shared')).toBe(true)
+    })
+
+    it('still gates that same agent on an ORDINARY bot, so its name leaks nowhere', async () => {
+      // The de-gating is per BOT, derived from that bot's platform — a restricted agent that is
+      // also on a Slack bot keeps every §14 fence there.
+      gatedAgents = new Set([BOB])
+      botRow = bot()
+      integrations = [integration(INT_A, ALICE), integration(INT_B, BOB)]
+      channels = [channel({ integrationId: INT_B, channelId: 'C1', agentId: BOB, trigger: 'mention' })]
+      await makeOrch().syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign
+
+      expect(assign.gatedAgentIds).toEqual([BOB])
+      expect(assign.defaultAgentId).toBe(ALICE)
+      expect(assign.routes.some((r) => r.agentId === BOB && r.match.kind === 'keyword')).toBe(false)
+    })
+
+    it('mutes an Off workspace and leaves the group without a default', async () => {
+      channels = [channel({ integrationId: INT_B, channelId: WORKSPACE, agentId: BOB, trigger: 'off' })]
+      await makeOrch(LINEAR_PLATFORMS).syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign
+
+      expect(assign.mutedChannels).toContain(WORKSPACE)
+      // No enabled row, so no workspace default — the bot preference does not resurrect one.
+      expect(assign.defaultAgentId).toBe(ALICE)
+    })
+  })
 })

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -45,7 +45,7 @@ import type {
 } from '../persistence/ports.js'
 import type { RelayChannel, RelayRegistry } from '../ws/relay-registry.js'
 import { ControlSender, NoConnection } from './outbound.js'
-import { isGatedAgent, httpIntegrationToSpec } from './placement.js'
+import { gatesNewConversations, isGatedAgent, httpIntegrationToSpec } from './placement.js'
 import type { GatedDmSeedResolver } from './linkedDm.js'
 import type { AgentDelivery } from './agentDelivery.js'
 import { PLACEMENT_ONLY, type PlacementResolver } from './placementResolver.js'
@@ -554,7 +554,7 @@ export class HttpBotOrchestrator {
       // Conversation gating (§14): a gated install's fresh channels start Off — an
       // editor must enable them in the console before the compiler emits a route.
       const owner = await this.agents.getUnscoped(integration.agentId)
-      const defaultTrigger = owner && isGatedAgent(owner) ? ('off' as const) : undefined
+      const defaultTrigger = owner && gatesNewConversations(bot.platform, owner) ? ('off' as const) : undefined
       await this.channels.replaceSnapshot(integration.id, channels, defaultTrigger ? { defaultTrigger } : undefined)
     }
     await this.syncRoutes(botId)
@@ -638,7 +638,7 @@ export class HttpBotOrchestrator {
       const reported = { ...conversation, kind }
       // Resolved per install, because a shared bot's installs are different agents with
       // different audiences — the same DM may be open for one and Off for the next.
-      const defaultTrigger = isGatedAgent(agent)
+      const defaultTrigger = gatesNewConversations(bot.platform, agent)
         ? await this.gatedConversationTrigger(agent, bot, reported)
         : kind === 'im'
           ? ('any' as const)
@@ -743,7 +743,8 @@ export class HttpBotOrchestrator {
     template?: IntegrationChannelRecord
   ): Promise<IntegrationChannelRecord> {
     const ownerAgent = await this.agents.getUnscoped(owner.agentId)
-    const defaultTrigger = ownerAgent && isGatedAgent(ownerAgent) ? ('off' as const) : undefined
+    const defaultTrigger =
+      ownerAgent && gatesNewConversations(owner.platform, ownerAgent) ? ('off' as const) : undefined
     const updated = await this.channels.upsertAgent(owner.id, channelId, owner.agentId, {
       ...(defaultTrigger ? { defaultTrigger } : {}),
       ...(template ? { kind: template.kind } : {})
@@ -856,7 +857,7 @@ export class HttpBotOrchestrator {
         // §14.8's one exception, re-derived here rather than trusted from the row: the
         // audience may have changed since the row was seeded, and this is the write
         // that would otherwise freeze a stale answer in as the owner's trigger.
-        if (ownerAgent && isGatedAgent(ownerAgent)) {
+        if (ownerAgent && gatesNewConversations(owner.platform, ownerAgent)) {
           if (bot === undefined) bot = await this.bots.getUnscoped(botId)
           const direct = conversationRows.find((row) => row.kind === 'im' && row.dmUserId)
           trigger = bot
@@ -901,9 +902,15 @@ export class HttpBotOrchestrator {
       if (!agent) continue
       const daemonId = await this.placement.routableDaemon(agent)
       if (!daemonId) continue
-      placed.push({ integration, agent, daemonId, gated: isGatedAgent(agent) })
+      // §14 gating is vacuous where the install names the one conversation it can reach, so the
+      // ONE predicate decides the keyword rung, the default, and `gatedAgentIds` together.
+      placed.push({ integration, agent, daemonId, gated: gatesNewConversations(bot.platform, agent) })
     }
     if (placed.length === 0) return null
+    // §5: the install IS the conversation, so its owner rides the default rung instead of a
+    // channel-scoped route — which would otherwise shadow keyword selection and thread
+    // continuity on a platform whose every event marks the app as mentioned.
+    const soleConversation = manifestFor(bot.platform).soleConversation
 
     // members: daemonId → agentIds (the daemon connections the relay expects).
     const memberMap = new Map<string, Set<string>>()
@@ -935,7 +942,7 @@ export class HttpBotOrchestrator {
         .filter((c) => c.trigger === 'off')
         .filter((c) => {
           const agent = c.agentId ? agentById.get(c.agentId) : undefined
-          return !!agent && isGatedAgent(agent)
+          return !!agent && gatesNewConversations(bot.platform, agent)
         })
         .map((c) => c.channelId)
     )
@@ -945,6 +952,9 @@ export class HttpBotOrchestrator {
       const p = byAgent.get(c.agentId)
       if (!p) continue
       if (c.trigger === 'off') continue
+      // The sole conversation's owner is delivered as the group default below; emitting a scoped
+      // rule for it too would make the FIRST rung swallow every addressed message.
+      if (soleConversation) continue
       const match: BindMatch = c.trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }
       routes.push({
         agentId: p.integration.agentId,
@@ -963,9 +973,10 @@ export class HttpBotOrchestrator {
     for (const p of placed) {
       const a = agentById.get(p.integration.agentId)
       if (!a) continue
-      // Conversation gating (§14): no UNSCOPED rung may name a gated agent — the
-      // keyword slug would make "@bot <slug>" fail-open in every conversation.
-      if (isGatedAgent(a)) continue
+      // Conversation gating (§14): no UNSCOPED rung may name a gated agent — the keyword slug
+      // would make "@bot <slug>" fail-open in every conversation. Where the install granted the
+      // only conversation there are no others to fail open into, so `p.gated` is already false.
+      if (p.gated) continue
       routes.push({
         agentId: p.integration.agentId,
         daemonId: p.daemonId,
@@ -979,7 +990,16 @@ export class HttpBotOrchestrator {
     //    rung), not a route, so it never pre-empts keyword/channel arbitration. A
     //    gated agent must never be the fallback (§14: the bare-@bot/DM rungs are
     //    what make an HTTP bot fail-open); a group of only gated agents has none.
-    const first = placed.find((p) => !p.gated)
+    // On a sole-conversation platform the ROW is the durable choice: its owner is the workspace
+    // default. The Off guard is defence for a row seeded before the trigger-write gate existed —
+    // no write surface can reach that state now.
+    const soleOwner = soleConversation
+      ? chans
+          .flatMap((c) => (c.agentId !== null && c.trigger !== 'off' ? [c.agentId] : []))
+          .map((agentId) => byAgent.get(agentId))
+          .find((p) => p !== undefined)
+      : undefined
+    const first = soleOwner ?? placed.find((p) => !p.gated)
     const agents = placed.map((p) => {
       const a = agentById.get(p.integration.agentId)
       return {

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
-import { httpIntegrationToSpec, integrationToSpec } from './placement.js'
+import { gatesNewConversations, httpIntegrationToSpec, integrationToSpec } from './placement.js'
 import { agentRecordToSpec } from './agentSpecAssembler.js'
 import type { AgentRecord, BotRecord, IntegrationChannelRecord, IntegrationRecord } from '../persistence/ports.js'
 import { AgentId, BotId, IntegrationId, OrgId } from '../domain/ids.js'
@@ -657,5 +657,25 @@ describe('agentRecordToSpec runtime overrides', () => {
 
     expect(agentRecordToSpec(base, { API_KEY: 'sk-1' })).toMatchObject({ secrets: { API_KEY: 'sk-1' } })
     expect(agentRecordToSpec(base, {})).toMatchObject({ secrets: {} })
+  })
+})
+
+describe('gatesNewConversations (resource-visibility §14 × the §5 manifest)', () => {
+  const restricted = { visibility: 'restricted' } as Pick<AgentRecord, 'visibility'>
+  const org = { visibility: 'org' } as Pick<AgentRecord, 'visibility'>
+
+  it('starts a restricted agent’s fresh conversations Off on every ordinary platform', () => {
+    for (const p of ['slack', 'telegram', 'discord', 'feishu', 'some-future-platform'])
+      expect(gatesNewConversations(p, restricted), p).toBe(true)
+  })
+
+  it('never gates a conversation on Linear, where the install IS the consent', () => {
+    // Linking an agent to a workspace is the act of enabling it there, and the workspace is the
+    // only conversation — so a restricted agent's row is born enabled like any other.
+    expect(gatesNewConversations('linear', restricted)).toBe(false)
+  })
+
+  it('gates nothing for a non-restricted agent, whatever the platform', () => {
+    for (const p of ['slack', 'linear', 'some-future-platform']) expect(gatesNewConversations(p, org), p).toBe(false)
   })
 })

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -181,6 +181,18 @@ export const isGatedAgent = (a: { visibility: AgentRecord['visibility'] }): bool
 export const gatesNewConversations = (platform: string, agent: { visibility: AgentRecord['visibility'] }): boolean =>
   isGatedAgent(agent) && !manifestFor(platform).soleConversation
 
+/** May a caller CHOOSE a conversation's trigger here? Not where the install names the one
+ *  conversation it can reach (§5 `soleConversation`): that conversation's trigger IS the link, so
+ *  an Off would silence a still-linked agent behind the mute fences while the console still shows
+ *  it installed. Removing the integration is the supported way to stop it. Owner (`agentId`)
+ *  changes stay available — that is WHICH member answers, not whether the workspace answers. */
+export const allowsTriggerControl = (platform: string): boolean => !manifestFor(platform).soleConversation
+
+/** The refusal a trigger write earns there — one message, so the HTTP route and every surface
+ *  layered on it name the same escape hatch. */
+export const TRIGGER_CONTROL_REFUSAL =
+  'this platform has one conversation per install, so its trigger cannot be changed; remove the integration to stop the agent'
+
 /**
  * Conversation-scoped bind rules for a GATED integration (resource-visibility.md
  * §14.3): only explicitly enabled conversations produce rules — a Mention channel

--- a/packages/control-plane/src/orchestrator/placement.ts
+++ b/packages/control-plane/src/orchestrator/placement.ts
@@ -36,7 +36,7 @@ import type {
   McpServerSpec,
   MemoryConnectionSpec
 } from '@agentconnect.md/protocol'
-import { SessionRetentionSetting } from '@agentconnect.md/protocol'
+import { manifestFor, SessionRetentionSetting } from '@agentconnect.md/protocol'
 import type {
   AgentRepo,
   AgentRecord,
@@ -173,6 +173,13 @@ const DEFAULT_BIND_RULES: IntegrationBindRule[] = [{ match: { kind: 'mention' } 
 /** Conversation gating (resource-visibility.md §14): derived from restricted
  *  visibility at spec-assembly time — no stored toggle, no identities on the wire. */
 export const isGatedAgent = (a: { visibility: AgentRecord['visibility'] }): boolean => a.visibility === 'restricted'
+
+/** Does a NEWLY reported conversation start Off because its owner is gated? Only on a platform
+ *  whose install does not already grant it (§5 `soleConversation`) — where it does,
+ *  linking the agent WAS the per-conversation consent and there is nothing left for an editor
+ *  to enable. Every seat that seeds a fresh conversation's trigger reads this, not `isGatedAgent`. */
+export const gatesNewConversations = (platform: string, agent: { visibility: AgentRecord['visibility'] }): boolean =>
+  isGatedAgent(agent) && !manifestFor(platform).soleConversation
 
 /**
  * Conversation-scoped bind rules for a GATED integration (resource-visibility.md

--- a/packages/control-plane/src/orchestrator/soleConversation.ts
+++ b/packages/control-plane/src/orchestrator/soleConversation.ts
@@ -1,0 +1,67 @@
+/**
+ * The install-time conversation row for a platform whose install NAMES the one conversation it
+ * can reach (§5 `soleConversation`) — today a connected Linear workspace.
+ *
+ * Written SYNCHRONOUSLY by the install paths, so the caller's own `syncBot` publishes the routes
+ * that follow from it and there is no window where an agent is linked but unroutable. The daemon's
+ * later observed report is a NAME refresh and a backstop only: the `integration/channels` wire
+ * report carries no trigger and `replaceSnapshot` preserves the stored one, so a report can never
+ * undo this seed.
+ *
+ * Born 'mention', restricted agent or not: linking the agent to the workspace IS the
+ * per-conversation consent, which is the same rule `gatesNewConversations` states for every other
+ * seat that seeds a trigger.
+ */
+import type { AgentId, IntegrationId } from '../domain/ids.js'
+import { manifestFor } from '@agentconnect.md/protocol'
+import type { BotRecord, IntegrationChannelRepo, IntegrationRecord } from '../persistence/ports.js'
+
+/** The conversation an install names, or undefined when this platform names none. */
+export function soleConversationOf(
+  bot: Pick<BotRecord, 'platform' | 'workspaceId' | 'workspaceName'>
+): { id: string; name?: string } | undefined {
+  if (!manifestFor(bot.platform).soleConversation) return undefined
+  const id = bot.workspaceId
+  if (!id) return undefined
+  return { id, ...(bot.workspaceName ? { name: bot.workspaceName } : {}) }
+}
+
+/**
+ * Seed the row for an ADDED member. Deliberately ownerless: the conversation already has an owner
+ * and adding a member must not steal it — the new row exists so the console can show and configure
+ * the workspace for this install too.
+ */
+export async function seedSoleConversationMember(
+  channels: IntegrationChannelRepo,
+  integration: Pick<IntegrationRecord, 'id'>,
+  bot: Pick<BotRecord, 'platform' | 'workspaceId' | 'workspaceName'>
+): Promise<void> {
+  const conversation = soleConversationOf(bot)
+  if (!conversation) return
+  await channels.upsertConversation(
+    integration.id as IntegrationId,
+    { ...conversation, kind: 'channel' },
+    { defaultTrigger: 'mention' }
+  )
+}
+
+/**
+ * Seed the row for a FIRST member — the install that minted the bot. It takes ownership, so the
+ * compile has a workspace default to publish on this same request.
+ */
+export async function seedSoleConversationOwner(
+  channels: IntegrationChannelRepo,
+  integration: Pick<IntegrationRecord, 'id' | 'agentId'>,
+  bot: Pick<BotRecord, 'platform' | 'workspaceId' | 'workspaceName'>
+): Promise<void> {
+  const conversation = soleConversationOf(bot)
+  if (!conversation) return
+  // Two writes because they carry different halves: `upsertConversation` is the only one that
+  // takes the workspace NAME, `upsertAgent` the only one that marks the owner. Ordered so the
+  // row is born with its trigger, which the ownership write then preserves.
+  await seedSoleConversationMember(channels, integration, bot)
+  await channels.upsertAgent(integration.id as IntegrationId, conversation.id, integration.agentId as AgentId, {
+    defaultTrigger: 'mention',
+    kind: 'channel'
+  })
+}

--- a/packages/control-plane/src/ws/handlers/integration-channels.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.ts
@@ -20,7 +20,7 @@
  */
 import { isFrame } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId, OrgId } from '../../domain/ids.js'
-import { isGatedAgent } from '../../orchestrator/placement.js'
+import { gatesNewConversations } from '../../orchestrator/placement.js'
 import { servedAgents } from '../../orchestrator/servedAgents.js'
 import type { DaemonWsDeps } from '../deps.js'
 import type { AgentRecord, ChannelTrigger, IntegrationRecord } from '../../persistence/ports.js'
@@ -67,10 +67,11 @@ export const handleIntegrationChannels: Handler = async (frame, conn, deps) => {
     }
     // Conversation gating (resource-visibility.md §14): a gated (restricted-agent)
     // integration's fresh conversations start Off — an editor must enable them in
-    // the console. Known rows keep their operator-chosen trigger either way.
+    // the console — unless the platform's install already granted them (§5). Known
+    // rows keep their operator-chosen trigger either way.
     // Fenced on the org of the integration row this daemon just proved it owns.
     owner = await deps.agent.get(OrgId(integration.orgId), AgentId(integration.agentId))
-    const defaultTrigger = owner && isGatedAgent(owner) ? ('off' as const) : undefined
+    const defaultTrigger = owner && gatesNewConversations(integration.platform, owner) ? ('off' as const) : undefined
     // §14.8: a gated DM whose counterpart is already in the agent's audience seeds to
     // the ordinary DM default instead. Only the gated arm asks — a public install has
     // no Off to override — and a resolver that answers nothing leaves §14.2 intact.

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -17,6 +17,7 @@ import { prisma } from '../setup.db.js'
 import { seedDaemon, seedAgent, seedDutyGroup } from '../fixtures/seed.js'
 import { seedPoolMember } from '../fakes/member-set.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { installNewBot } from '../../src/http/install-bot.js'
 import {
   PgAgentRepo,
   PgBotRepo,
@@ -61,6 +62,8 @@ const CAROL_SUB = 'oidc-carol'
 const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
 const OTHER_DAEMON = 'd2d2d2d2-dddd-4ddd-8ddd-dddddddddddd'
 const SLACK = { botToken: 'xoxb-abc-123', appToken: 'xapp-1-def-456' }
+/** The connected Linear organization — the channel itself, since the workspace IS the channel. */
+const LINEAR_WORKSPACE = '5f3a0c9e-1c2b-4a7d-9e10-6b5c4d3e2f10'
 
 class SpyControl {
   readonly upserts: Array<{ daemonId: string; u: IntegrationUpsert }> = []
@@ -104,6 +107,35 @@ async function install(app: HttpApp): Promise<string> {
   })
   expect(res.statusCode).toBe(201)
   return (res.json() as { id: string }).id
+}
+
+/** Connect a LINEAR workspace through the REAL create tail the OAuth callback uses
+ *  (`installNewBot`) — that is the seat that seeds the workspace conversation row. */
+async function installLinear(app: HttpApp, opts: { restricted?: boolean } = {}): Promise<string> {
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, { daemonId: DAEMON, createdByUserId: DEFAULT_OWNER_ID })
+  if (opts.restricted) {
+    await prisma.agent.update({
+      where: { id: agentId },
+      data: { visibility: 'restricted', sharedWith: [DEFAULT_OWNER_ID] }
+    })
+  }
+  const agent = await prisma.agent.findUniqueOrThrow({ where: { id: agentId } })
+  const { integration } = await installNewBot(app.deps, { debug: () => {} }, {
+    orgId: DEFAULT_ORG_ID as never,
+    agent: agent as never,
+    platform: 'linear',
+    name: 'Acme',
+    transport: 'http',
+    secrets: { botToken: 'client-secret', appToken: null, signingSecret: 'lin_wh_secret' },
+    bot: {
+      shareable: true,
+      workspaceId: LINEAR_WORKSPACE,
+      workspaceName: 'Acme',
+      botUserId: 'lin-app-user'
+    }
+  } as never)
+  return integration.id
 }
 
 /** Install a TELEGRAM integration — the platform whose rows are session-derived, so
@@ -334,6 +366,68 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     ;[dto] = res.json() as { channels: { channelId: string; kind: string; trigger: string }[] }[]
     expect(dto!.channels.find((c) => c.channelId === 'D1')).toMatchObject({ kind: 'im' })
+  })
+
+  it('seeds the Linear workspace row AT INSTALL, born enabled even under a restricted agent', async () => {
+    // Linking the agent to the workspace IS the per-conversation consent, and the workspace is
+    // the only conversation — so nothing is left for an editor to switch on. The row is written
+    // by the install path itself, so the install's own syncBot already publishes the routes: the
+    // daemon's later observed report is a name refresh, never the thing that opens the agent up.
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const restricted = await installLinear(running, { restricted: true })
+    const open = await installLinear(running)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const rows = (res.json() as { id: string; channels: { channelId: string; trigger: string }[] }[]).filter((d) =>
+      [restricted, open].includes(d.id)
+    )
+    expect(rows).toHaveLength(2)
+    for (const dto of rows)
+      expect(dto.channels).toEqual([
+        expect.objectContaining({ channelId: LINEAR_WORKSPACE, name: 'Acme', trigger: 'mention' })
+      ])
+  })
+
+  it("a daemon's observed report refreshes the workspace name without touching the seeded trigger", async () => {
+    // The wire report carries no trigger and `replaceSnapshot` preserves the stored one, so the
+    // backstop cannot fight the seed — including for the restricted agent it would otherwise Off.
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await installLinear(running, { restricted: true })
+
+    await report(DAEMON, id, [{ id: LINEAR_WORKSPACE, name: 'Acme Renamed' }], undefined, undefined, false)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const dto = (res.json() as { id: string; channels: { channelId: string; name: string; trigger: string }[] }[]).find(
+      (d) => d.id === id
+    )
+    expect(dto!.channels).toEqual([
+      expect.objectContaining({ channelId: LINEAR_WORKSPACE, name: 'Acme Renamed', trigger: 'mention' })
+    ])
+  })
+
+  it('still starts a restricted agent OFF on a platform whose install grants nothing', async () => {
+    // The Linear arm above must not have widened the §14 default for everyone else.
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+    const integration = await prisma.integration.findUniqueOrThrow({ where: { id } })
+    await prisma.agent.update({
+      where: { id: integration.agentId },
+      data: { visibility: 'restricted', sharedWith: [DEFAULT_OWNER_ID] }
+    })
+
+    await report(DAEMON, id, [{ id: 'C1', name: 'deploys' }])
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const dto = (res.json() as { id: string; channels: { channelId: string; trigger: string }[] }[]).find(
+      (d) => d.id === id
+    )
+    expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'C1', trigger: 'off' })])
   })
 
   /** §14.8 fixture: a private agent shared with `audience`, on a bot in workspace T_ACME.

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -27,6 +27,7 @@ import {
 } from '../../src/persistence/index.js'
 import { PgOrgRepo } from '../../src/persistence/repositories/org.repo.js'
 import { gatedDmSeeds, type GatedDmSeedResolver } from '../../src/orchestrator/linkedDm.js'
+import { seedSoleConversationMember } from '../../src/orchestrator/soleConversation.js'
 import { reconcileAgentLinkedDms, reconcileLinkedDms } from '../../src/orchestrator/linkedDmReconcile.js'
 import type { SlackIdentity } from '../../src/github/logto-identity.js'
 import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
@@ -111,7 +112,10 @@ async function install(app: HttpApp): Promise<string> {
 
 /** Connect a LINEAR workspace through the REAL create tail the OAuth callback uses
  *  (`installNewBot`) — that is the seat that seeds the workspace conversation row. */
-async function installLinear(app: HttpApp, opts: { restricted?: boolean } = {}): Promise<string> {
+async function installLinear(
+  app: HttpApp,
+  opts: { restricted?: boolean } = {}
+): Promise<{ integrationId: string; botId: string; agentId: string }> {
   const agentId = randomUUID()
   await seedAgent(prisma, agentId, { daemonId: DAEMON, createdByUserId: DEFAULT_OWNER_ID })
   if (opts.restricted) {
@@ -135,7 +139,26 @@ async function installLinear(app: HttpApp, opts: { restricted?: boolean } = {}):
       botUserId: 'lin-app-user'
     }
   } as never)
-  return integration.id
+  return { integrationId: integration.id, botId: integration.botId, agentId }
+}
+
+/** Add a SECOND agent to a connected Linear workspace, exactly as the add-member route does:
+ *  the membership row plus this install's own (ownerless) copy of the workspace conversation. */
+async function addLinearMember(app: HttpApp, botId: string): Promise<{ integrationId: string; agentId: string }> {
+  const agentId = randomUUID()
+  await seedAgent(prisma, agentId, { daemonId: DAEMON, createdByUserId: DEFAULT_OWNER_ID })
+  const admission = await app.deps.repos.integration.addBotMembership({
+    id: IntegrationId(randomUUID()),
+    orgId: DEFAULT_ORG_ID as never,
+    agentId: agentId as never,
+    botId: botId as never,
+    platform: 'linear',
+    name: 'Acme'
+  } as never)
+  if (!('integration' in admission)) throw new Error(`unexpected membership outcome: ${admission.outcome}`)
+  const bot = await app.deps.repos.bot.getUnscoped(botId as never)
+  await seedSoleConversationMember(app.deps.repos.integrationChannel, admission.integration, bot!)
+  return { integrationId: admission.integration.id, agentId }
 }
 
 /** Install a TELEGRAM integration — the platform whose rows are session-derived, so
@@ -376,8 +399,8 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     await seedDaemon(prisma, DAEMON)
     const spy = new SpyControl()
     running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
-    const restricted = await installLinear(running, { restricted: true })
-    const open = await installLinear(running)
+    const restricted = (await installLinear(running, { restricted: true })).integrationId
+    const open = (await installLinear(running)).integrationId
 
     const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
     const rows = (res.json() as { id: string; channels: { channelId: string; trigger: string }[] }[]).filter((d) =>
@@ -396,7 +419,7 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     await seedDaemon(prisma, DAEMON)
     const spy = new SpyControl()
     running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
-    const id = await installLinear(running, { restricted: true })
+    const id = (await installLinear(running, { restricted: true })).integrationId
 
     await report(DAEMON, id, [{ id: LINEAR_WORKSPACE, name: 'Acme Renamed' }], undefined, undefined, false)
 
@@ -1179,6 +1202,72 @@ describe('integration/channels EVT → integration_channel convergence', () => {
 
     await handleIntegrationChannels(frame, { daemonId: DAEMON } as DaemonConnection, deps)
     expect(await prisma.integrationChannel.count()).toBe(0)
+  })
+})
+
+describe('PATCH /integrations/:id/channels/:channelId — a sole-conversation platform', () => {
+  const patch = async (integrationId: string, body: Record<string, unknown>) =>
+    await running!.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${integrationId}/channels/${LINEAR_WORKSPACE}`,
+      payload: body
+    })
+
+  it('refuses a TRIGGER write on a Linear workspace and names the unlink path', async () => {
+    // Accepting `off` here would silence a still-linked agent through the mute fences while the
+    // console keeps showing it installed — the contradiction of "no trigger control / no Off".
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const { integrationId } = await installLinear(running)
+
+    for (const trigger of ['off', 'any', 'mention']) {
+      const res = await patch(integrationId, { trigger })
+      expect(res.statusCode, trigger).toBe(400)
+      expect((res.json() as { message: string }).message).toContain('remove the integration')
+    }
+    // The stored row is untouched, so no fence anywhere saw an Off.
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const dto = (res.json() as { id: string; channels: { trigger: string }[] }[]).find((d) => d.id === integrationId)
+    expect(dto!.channels).toEqual([expect.objectContaining({ trigger: 'mention' })])
+  })
+
+  it('still accepts an OWNER change on that same conversation', async () => {
+    // Which member answers is a real choice; whether the workspace answers at all is not.
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const first = await installLinear(running)
+    const second = await addLinearMember(running, first.botId)
+
+    const res = await patch(first.integrationId, { agentId: second.agentId })
+    expect(res.statusCode).toBe(200)
+    const list = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const rows = (list.json() as { id: string; channels: { agentId: string; trigger: string }[] }[]).filter((d) =>
+      [first.integrationId, second.integrationId].includes(d.id)
+    )
+    for (const dto of rows)
+      expect(dto.channels).toEqual([expect.objectContaining({ agentId: second.agentId, trigger: 'mention' })])
+  })
+
+  it('leaves both writes working on an ordinary platform', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+    await report(DAEMON, id, [{ id: 'C1', name: 'deploys' }])
+
+    const res = await running.app.inject({
+      method: 'PATCH',
+      url: `${ORG}/integrations/${id}/channels/C1`,
+      payload: { trigger: 'off' }
+    })
+    expect(res.statusCode).toBe(200)
+    const list = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const dto = (list.json() as { id: string; channels: { channelId: string; trigger: string }[] }[]).find(
+      (d) => d.id === id
+    )
+    expect(dto!.channels).toEqual([expect.objectContaining({ channelId: 'C1', trigger: 'off' })])
   })
 })
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -420,7 +420,6 @@ import {
   applyLinearMessageStrategy,
   isLinearIssuelessSurface,
   linearAckBody,
-  linearChannelName,
   linearDeliveryReceiptId,
   linearFailureBody,
   readLinearExt,
@@ -1480,6 +1479,8 @@ export class Daemon {
       waitForConnectionUses: (conn) => this.waitForConnectionUses(conn),
       observeTelegramChat: (chat, integrationIds) =>
         this.observedChannelsSync.observeTelegramChat(chat, integrationIds),
+      observePlatformChat: (platform, chat, integrationIds) =>
+        this.observedChannelsSync.observePlatformChat(platform, chat, integrationIds),
       refreshObservedChannels: () => this.observedChannelsSync.refreshObservedChannels(),
       retractChannels: (integrationId, channelIds) =>
         this.observedChannelsSync.retractChannels(integrationId, channelIds),
@@ -6609,10 +6610,10 @@ export class Daemon {
       this.log.info(`linear: delivery ${msg.msgId} was already served — no turn, no activity`)
       return 'settled'
     }
-    // §4.5: no issue, so the channel fell back to the AgentSession UUID. Answer once, start no
-    // turn — and answer only AFTER the durable receipt is minted, exactly like the
-    // acknowledgement (§10.1).
-    if (isLinearIssuelessSurface(normalized, ext)) {
+    // §4.5: the bag carries no issue, so this session sits on a surface v1 cannot serve. Answer
+    // once, start no turn — and answer only AFTER the durable receipt is minted, exactly like
+    // the acknowledgement (§10.1).
+    if (isLinearIssuelessSurface(ext)) {
       let minted: boolean
       try {
         minted = await this.mintLinearDeliveryReceipt(msg, normalized)
@@ -6632,13 +6633,10 @@ export class Daemon {
       return 'settled'
     }
     applyLinearMessageStrategy(normalized)
-    // §4.5 session metadata: `TEAM-123 · <title>` comes straight off the bag, so the console
-    // labels the issue without a provider round-trip. (`threadUrl` already rides the message.)
-    const channelName = linearChannelName(ext)
-    if (channelName) {
-      await this.store.setDisplayName(normalized.channel, channelName, this.clock.now())
-      await this.sessionMetadataOutbox.emitSessionMetadataSnapshotsForDisplayName(normalized.channel)
-    }
+    // No per-event channel name: the channel is the WORKSPACE, so its label is install-scoped and
+    // already written when the connection reported the workspace (§4.5). Writing the issue here
+    // would thrash the one display slot and relabel every sibling session in the workspace; the
+    // issue rides `threadUrl` and the §8 trusted header, which are session-scoped.
     return 'dispatch'
   }
 
@@ -6797,7 +6795,15 @@ export class Daemon {
       return { msgId: msg.msgId, accepted: false, reason: 'unavailable' }
     }
     const transportScope = this.transportScopeForIntegrationIds([msg.integrationId])
-    const rec = await this.store.latestSessionForThread(msg.agentId, 'linear', payload.agentSessionId, transportScope)
+    // The workspace is the channel (§4.5), so the connection's own tenant is the coordinate —
+    // never the relay's `sessionKey`, which this daemon has not verified.
+    const rec = await this.store.latestSessionForThread(
+      msg.agentId,
+      'linear',
+      conn.workspaceId(),
+      payload.agentSessionId,
+      transportScope
+    )
     if (rec) {
       await this.interruptTurn(msg.agentId, rec.key, 'stop', rec.acpSessionId ?? undefined, {
         ...(msg.userId ? { actor: { userId: msg.userId } } : {})

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -51,6 +51,8 @@ import {
 import { consolidateDiscord, discordConnKey, DiscordConnection, type DiscordDeps } from '../discord/connection.js'
 import { consolidateFeishu, feishuConnKey, FeishuConnection } from '../feishu/connection.js'
 import { consolidateLinear, linearConnKey, LinearConnection } from './linear/connection.js'
+import { linearChannelName } from './linear/message-strategy.js'
+import type { ObservedChat } from './observed-channels.js'
 import { ConnectionPool, type ConnectionKey } from './registry.js'
 
 /** Any live platform client this lifecycle opens, prunes or binds. */
@@ -133,6 +135,8 @@ export interface ConnectionReconcilerHost extends PlatformActionSink {
   /** Drain the in-flight turns holding `conn` before it is stopped. */
   waitForConnectionUses(conn: PlatformConnection): Promise<void>
   observeTelegramChat(chat: TelegramObservedChat, integrationIds: readonly string[]): Promise<void>
+  /** Report one conversation a connection knows it reaches, ahead of any session row. */
+  observePlatformChat(platform: string, chat: ObservedChat, integrationIds: readonly string[]): Promise<void>
   refreshObservedChannels(): Promise<void>
   retractChannels(integrationId: string, channelIds: readonly string[]): Promise<void>
   integrationConfigById(integrationId: string): Integration | undefined
@@ -741,6 +745,11 @@ export class ConnectionReconciler {
    * must still leave the integration bound, or the session's own retry ladder would have
    * nothing to send through. A re-pushed spec converges through `applySnapshot` rather than a
    * teardown, because rotation does not change the connection's identity (§7.5).
+   *
+   * Every client also REPORTS its workspace as the one conversation it observes (§4.5): the
+   * workspace IS the channel, so the console row — and the CP dispatch row the compile turns
+   * into this integration's channel-scoped route — must exist before the first delegation, not
+   * after the first session lands in history.
    */
   async reconcileLinearConnections(): Promise<void> {
     for (const group of consolidateLinear(this.host.transportAgents(), this.log).values()) {
@@ -754,6 +763,7 @@ export class ConnectionReconciler {
             this.log.info(`linear: bound integration ${integrationId} onto existing workspace client`)
           }
         }
+        await this.observeLinearWorkspace(existing, group.integrations)
         continue
       }
       if (!this.linearPool.beginConnect(group.key)) continue
@@ -782,6 +792,28 @@ export class ConnectionReconciler {
       } finally {
         this.linearPool.endConnect(group.key)
       }
+      // Outside the try: the report describes the INSTALL, not the token, so a warm-up that
+      // failed must still mint the conversation row every later delegation routes through.
+      await this.observeLinearWorkspace(conn, group.integrations)
+    }
+  }
+
+  /** The connected workspace as this integration's single observed conversation. The name
+   *  degrades to the organization id — a row the console cannot label still routes. */
+  private async observeLinearWorkspace(
+    conn: LinearConnection,
+    integrations: readonly { integrationId: string }[]
+  ): Promise<void> {
+    const id = conn.workspaceId()
+    const chat: ObservedChat = { id, name: linearChannelName(conn), isPrivate: false }
+    try {
+      await this.host.observePlatformChat(
+        'linear',
+        chat,
+        integrations.map((i) => i.integrationId)
+      )
+    } catch (err) {
+      this.log.warn(`linear: reporting workspace ${id} as an observed conversation failed: ${formatErr(err)}`)
     }
   }
 

--- a/packages/daemon/src/platforms/linear/message-strategy.ts
+++ b/packages/daemon/src/platforms/linear/message-strategy.ts
@@ -97,20 +97,22 @@ export function readLinearExt(msg: Pick<NormalizedMessage, 'adapterExt'>): Linea
   return parsed.success ? parsed.data : undefined
 }
 
-/** §4.5 session `channelName`: `TEAM-123 · <title>`, degrading to whichever half exists. */
-export function linearChannelName(ext: LinearAdapterExt): string | undefined {
-  const identifier = ext.issueIdentifier?.trim()
-  const title = ext.issueTitle ? sanitizeTitle(ext.issueTitle) : ''
-  const parts = [identifier, title].filter((part): part is string => !!part)
-  return parts.length ? parts.join(' · ') : undefined
+/** §4.5 session `channelName`: the connected WORKSPACE, since the workspace is the channel.
+ *  Degrades to the organization id — a session labelled by its tenant beats one labelled
+ *  `undefined`, and the issue rides `threadUrl` plus the §8 header either way. */
+export function linearChannelName(conn: { workspaceName?: string; workspaceId(): string }): string {
+  const name = conn.workspaceName ? sanitizeTitle(conn.workspaceName) : ''
+  return name || conn.workspaceId()
 }
 
 /**
- * §4.5: the session Linear opened carries no issue, so its `channel` fell back to the
- * AgentSession UUID. v1 answers such a surface once and starts no turn.
+ * §4.5: the session Linear opened carries no issue — `app:mentionable` also covers documents
+ * and other editor surfaces. v1 answers such a surface once and starts no turn. Read off the
+ * ABSENCE of issue metadata in the bag: the channel is the workspace now, so the coordinates
+ * no longer say anything about which surface the session was opened on.
  */
-export function isLinearIssuelessSurface(msg: Pick<NormalizedMessage, 'channel'>, ext: LinearAdapterExt): boolean {
-  return msg.channel === ext.agentSessionId
+export function isLinearIssuelessSurface(ext: LinearAdapterExt): boolean {
+  return ext.issueIdentifier === undefined && ext.issueTitle === undefined
 }
 
 /** The actor as the trusted header names them: the provider's display name when the event

--- a/packages/daemon/src/platforms/observed-channels-sync.ts
+++ b/packages/daemon/src/platforms/observed-channels-sync.ts
@@ -16,7 +16,12 @@ import type { CpClient } from '../cp/client.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
 import type { LocalStore } from '../store/local-store.js'
 import type { TelegramObservedChat } from '../telegram/connection.js'
-import { observedChannelsFor, observedMembershipPlatforms, type ObservedChannelsHost } from './observed-channels.js'
+import {
+  observedChannelsFor,
+  observedMembershipPlatforms,
+  type ObservedChannelsHost,
+  type ObservedChat
+} from './observed-channels.js'
 
 /** Exactly what the sync engine touches on the Daemon — nothing wider. */
 export interface ObservedChannelsSyncHost extends ObservedChannelsHost {
@@ -188,11 +193,7 @@ export class ObservedChannelsSync {
   /** Record one observed chat row for a platform that cannot enumerate its bot's
    *  chats. The event's own platform filters the fan-out — a caller is already
    *  platform-specific and names it as data, not a branch. */
-  async observePlatformChat(
-    platform: string,
-    chat: TelegramObservedChat,
-    integrationIds: readonly string[]
-  ): Promise<void> {
+  async observePlatformChat(platform: string, chat: ObservedChat, integrationIds: readonly string[]): Promise<void> {
     if (chat.name) {
       await this.host.store().setDisplayName(chat.id, chat.name, Date.now())
       await this.host.emitSessionMetadataSnapshotsForDisplayName(chat.id)

--- a/packages/daemon/src/platforms/observed-channels.ts
+++ b/packages/daemon/src/platforms/observed-channels.ts
@@ -45,6 +45,13 @@ export function observedMembershipPlatforms(): readonly string[] {
   return OBSERVED_MEMBERSHIP_PLATFORMS
 }
 
+/** One conversation a connection reports having observed, ahead of any session row. */
+export interface ObservedChat {
+  id: string
+  name?: string
+  isPrivate: boolean
+}
+
 /** One observed conversation row, as the snapshot pipeline carries it. */
 export interface ObservedChannelRow {
   id: string

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -2032,22 +2032,25 @@ export class LocalStore {
       .get(...args)) as SessionRecord | undefined
   }
 
-  /** The agent's session on one platform THREAD, whatever channel it sits in. Exists for a
-   *  platform action that addresses a session by the provider's own session id (Linear's
-   *  AgentSession) and therefore has no channel coordinate to look up by. */
+  /** The agent's session on one platform THREAD inside one channel. Exists for a platform
+   *  action that addresses a session by the provider's own session id (Linear's AgentSession):
+   *  unlike `latestSessionForTransport` it does not require an ACP id, so a stop still reaches
+   *  a turn that has not spawned yet. */
   async latestSessionForThread(
     agentId: string,
     platform: string,
+    channel: string,
     thread: string,
     transportScope?: string
   ): Promise<SessionRecord | undefined> {
     return (await this.db
       .prepare(
         `SELECT * FROM sessions
-         WHERE agentId = ? AND platform = ? AND thread = ? AND COALESCE(transportScope, '') = ?
+         WHERE agentId = ? AND platform = ? AND channel = ? AND thread = ?
+           AND COALESCE(transportScope, '') = ?
          ORDER BY updatedAt DESC LIMIT 1`
       )
-      .get(agentId, platform, thread, transportScope ?? '')) as SessionRecord | undefined
+      .get(agentId, platform, channel, thread, transportScope ?? '')) as SessionRecord | undefined
   }
 
   /** The most recently active addressable session (has an ACP id) in a channel, across

--- a/packages/daemon/test/linear-ingress.test.ts
+++ b/packages/daemon/test/linear-ingress.test.ts
@@ -27,7 +27,6 @@ const INTEGRATION = 'int-linear'
 const BOT = '8f0a1c62-9a0f-4c6e-8b2b-7d3f5a1c0001'
 const WORKSPACE = 'a2f2f0d4-0e33-4c4b-9a4b-4f7a0f1f0001'
 const SESSION = 'c3f1e0aa-4d2f-4f0a-9b1e-2b6d5c4a0002'
-const ISSUE = 'd7c2b1aa-6e5f-4a3b-8c9d-1e2f3a4b0003'
 const ISSUE_URL = 'https://linear.app/example/issue/TEAM-123/ship-the-thing'
 const FAR_FUTURE = new Date(Date.now() + 20 * 60 * 60 * 1000).toISOString()
 
@@ -111,6 +110,7 @@ async function boot(opts: BootOpts = {}) {
     integrationId: INTEGRATION,
     botUserId: 'app-user-1',
     workspaceId: () => WORKSPACE,
+    workspaceName: 'Example Workspace',
     async postActivity(sessionId: string, activity: LinearActivityInput) {
       // The ordering assertion itself: read the durable inbox AT POST TIME, so a row that
       // only lands later cannot make an out-of-order first activity look admitted.
@@ -171,14 +171,14 @@ function delivery(payloadOver: Record<string, unknown> = {}, extOver: Record<str
     agentId: AGENT,
     botId: BOT,
     integrationId: INTEGRATION,
-    sessionKey: `${ISSUE}/${SESSION}`,
+    sessionKey: `${WORKSPACE}/${SESSION}`,
     msgId,
     payload: {
       msgId,
       traceId: msgId,
       source: 'user' as const,
       platform: 'linear' as const,
-      channel: ISSUE,
+      channel: WORKSPACE,
       thread: SESSION,
       threadUrl: ISSUE_URL,
       sender: { id: 'linear:user-1', isBot: false, name: 'Dana' },
@@ -203,6 +203,31 @@ const acks = (posted: Posted[]) => posted.filter((p) => p.activity.type === 'tho
 const responses = (posted: Posted[]) => posted.filter((p) => p.activity.type === 'response')
 
 const im = async (daemon: Daemon, msg: unknown) => await (daemon as any).handleRelayIm(msg)
+
+describe('§4.5 the workspace as the one observed conversation', () => {
+  it('reports it at reconcile, before any delivery has landed', async () => {
+    // The CP dispatch row — and the channel-scoped route the compile makes of it — has to exist
+    // BEFORE the first delegation, so the report cannot wait for a session to reach history.
+    const { daemon } = await boot()
+    const snapshot = (daemon as any).channelSnapshots.get(INTEGRATION)
+    expect(snapshot).toMatchObject({ authoritative: false })
+    expect(snapshot.channels).toEqual([{ id: WORKSPACE, name: 'Example Workspace', isPrivate: false, kind: 'channel' }])
+    await daemon.stop()
+  })
+
+  it('labels the workspace id so the console never shows a bare organization UUID', async () => {
+    const { daemon, store } = await boot()
+    expect((await store.getDisplayNames([WORKSPACE])).get(WORKSPACE)).toBe('Example Workspace')
+    await daemon.stop()
+  })
+
+  it('re-reports on a reconcile that only rebinds, without duplicating the row', async () => {
+    const { daemon } = await boot()
+    await (daemon as any).connections.reconcileLinearConnections()
+    expect((daemon as any).channelSnapshots.get(INTEGRATION).channels).toHaveLength(1)
+    await daemon.stop()
+  })
+})
 
 describe('§10.1 the pre-spawn acknowledgement', () => {
   it('names the acting agent and the issue, after the durable inbox admitted the delivery', async () => {
@@ -258,7 +283,7 @@ describe('§10.1 the pre-spawn acknowledgement', () => {
     // a genuinely concurrent arrival would be blinded.
     await store.appendInbox({
       id: linearDeliveryReceiptId(stableMessageId(normalized)),
-      sessionKey: sessionKey('linear', ISSUE, SESSION, AGENT, transportScope(daemon)),
+      sessionKey: sessionKey('linear', WORKSPACE, SESSION, AGENT, transportScope(daemon)),
       agentId: AGENT,
       msg: '{}',
       completedAt: 1,
@@ -323,7 +348,7 @@ describe('§10.1 the pre-spawn acknowledgement', () => {
 
   it('marks the queued variant when the session is already working', async () => {
     const { daemon, posted } = await boot()
-    const key = sessionKey('linear', ISSUE, SESSION, AGENT, transportScope(daemon))
+    const key = sessionKey('linear', WORKSPACE, SESSION, AGENT, transportScope(daemon))
     ;(daemon as any).inflight.add(key)
     await im(daemon, delivery())
     await vi.waitFor(() => expect(acks(posted).length).toBe(1))
@@ -339,10 +364,11 @@ describe('§10.1 the pre-spawn acknowledgement', () => {
     await daemon.stop()
   })
 
-  it('records the issue name as the session channel name', async () => {
+  it('records the WORKSPACE name as the session channel name', async () => {
+    // The channel is the workspace, so the issue lives on `threadUrl` and the §8 header instead.
     const { daemon, store } = await boot()
     await im(daemon, delivery())
-    expect((await store.getDisplayNames([ISSUE])).get(ISSUE)).toBe('TEAM-123 · Ship the thing')
+    expect((await store.getDisplayNames([WORKSPACE])).get(WORKSPACE)).toBe('Example Workspace')
     await daemon.stop()
   })
 
@@ -405,8 +431,8 @@ describe('§5 the Layer-2 surface', () => {
 })
 
 describe('§4.5 the issue-less surface', () => {
-  const issueless = () =>
-    delivery({ channel: SESSION, threadUrl: undefined }, { issueIdentifier: undefined, issueTitle: undefined })
+  // The channel stays the workspace; only the BAG loses its issue metadata.
+  const issueless = () => delivery({ threadUrl: undefined }, { issueIdentifier: undefined, issueTitle: undefined })
 
   it('answers once and starts NO turn', async () => {
     const { daemon, posted } = await boot()
@@ -420,12 +446,12 @@ describe('§4.5 the issue-less surface', () => {
     await daemon.stop()
   })
 
-  it('keys the session on the AgentSession UUID and admits it durably before answering', async () => {
+  it('keys the session on the workspace + AgentSession UUID and admits it durably before answering', async () => {
     const { daemon, posted, store } = await boot()
     ;(daemon as any).dispatch = vi.fn(async () => null)
     await im(daemon, issueless())
     expect(posted[0]!.inboxAdmitted).toBe(true)
-    const key = sessionKey('linear', SESSION, SESSION, AGENT, transportScope(daemon))
+    const key = sessionKey('linear', WORKSPACE, SESSION, AGENT, transportScope(daemon))
     const rows = await store.listInboxBySessionKeyFifo()
     expect(rows.map((row: { sessionKey: string }) => row.sessionKey)).toEqual([key])
     await daemon.stop()
@@ -446,7 +472,7 @@ describe('§6.3 the stop decoder', () => {
     source: 'platform_action' as const,
     platformId: 'linear',
     agentId: AGENT,
-    sessionKey: `${ISSUE}/${SESSION}`,
+    sessionKey: `${WORKSPACE}/${SESSION}`,
     msgId: 'linear:activity-stop',
     botId: BOT,
     integrationId: INTEGRATION,
@@ -457,13 +483,13 @@ describe('§6.3 the stop decoder', () => {
 
   it('interrupts the addressed session and settles it with a `response`', async () => {
     const { daemon, posted, store } = await boot()
-    const key = sessionKey('linear', ISSUE, SESSION, AGENT, transportScope(daemon))
+    const key = sessionKey('linear', WORKSPACE, SESSION, AGENT, transportScope(daemon))
     await store.upsertSession({
       key,
       sessionId: 'sess-1',
       agentId: AGENT,
       platform: 'linear',
-      channel: ISSUE,
+      channel: WORKSPACE,
       thread: SESSION,
       transportScope: transportScope(daemon),
       acpSessionId: 'acp-1',

--- a/packages/daemon/test/linear-message-strategy.test.ts
+++ b/packages/daemon/test/linear-message-strategy.test.ts
@@ -22,7 +22,7 @@ import {
 } from '../src/platforms/linear/message-strategy.js'
 
 const SESSION = 'c3f1e0aa-4d2f-4f0a-9b1e-2b6d5c4a0002'
-const ISSUE = 'd7c2b1aa-6e5f-4a3b-8c9d-1e2f3a4b0003'
+const WORKSPACE = 'a2f2f0d4-0e33-4c4b-9a4b-4f7a0f1f0001'
 const ISSUE_URL = 'https://linear.app/example/issue/TEAM-123/ship-the-thing'
 
 function ext(over: Partial<LinearAdapterExt> = {}): LinearAdapterExt {
@@ -35,7 +35,7 @@ function message(over: Partial<NormalizedMessage> = {}): NormalizedMessage {
     traceId: `linear:${SESSION}:created`,
     source: 'user',
     platform: 'linear',
-    channel: ISSUE,
+    channel: WORKSPACE,
     thread: SESSION,
     threadUrl: ISSUE_URL,
     sender: { id: 'linear:user-1', isBot: false, name: 'Dana' },
@@ -65,11 +65,13 @@ describe('linear adapter-extension reads', () => {
     expect(sanitizeTitle('x'.repeat(500)).endsWith('…')).toBe(true)
   })
 
-  it('names the channel TEAM-123 · <title>, degrading to whichever half exists', () => {
-    expect(linearChannelName(ext())).toBe('TEAM-123 · Ship the thing')
-    expect(linearChannelName(ext({ issueTitle: undefined }))).toBe('TEAM-123')
-    expect(linearChannelName(ext({ issueIdentifier: undefined }))).toBe('Ship the thing')
-    expect(linearChannelName({ agentSessionId: SESSION })).toBeUndefined()
+  it('names the channel after the WORKSPACE, degrading to the organization id', () => {
+    expect(linearChannelName({ workspaceName: 'Example Workspace', workspaceId: () => WORKSPACE })).toBe(
+      'Example Workspace'
+    )
+    expect(linearChannelName({ workspaceId: () => WORKSPACE })).toBe(WORKSPACE)
+    // Attacker-authored only in the sense that a workspace admin picked it — flattened all the same.
+    expect(linearChannelName({ workspaceName: ' Multi\nline ', workspaceId: () => WORKSPACE })).toBe('Multi line')
   })
 })
 
@@ -160,9 +162,12 @@ describe('the turn shape §8 names', () => {
 })
 
 describe('§4.5 issue-less surface', () => {
-  it('is exactly the delivery whose channel fell back to the AgentSession UUID', () => {
-    expect(isLinearIssuelessSurface(message(), ext())).toBe(false)
-    expect(isLinearIssuelessSurface(message({ channel: SESSION }), ext({ issueIdentifier: undefined }))).toBe(true)
+  it('is exactly the delivery whose bag carries no issue metadata', () => {
+    expect(isLinearIssuelessSurface(ext())).toBe(false)
+    // Half the metadata is still an issue: only a bag with NEITHER half names an unsupported surface.
+    expect(isLinearIssuelessSurface(ext({ issueTitle: undefined }))).toBe(false)
+    expect(isLinearIssuelessSurface(ext({ issueIdentifier: undefined }))).toBe(false)
+    expect(isLinearIssuelessSurface({ agentSessionId: SESSION })).toBe(true)
   })
 })
 

--- a/packages/protocol/src/platform-manifest.test.ts
+++ b/packages/protocol/src/platform-manifest.test.ts
@@ -63,10 +63,20 @@ describe('platform manifest', () => {
     expect(DEFAULT_MANIFEST.multiAgentShareable).toBe(false)
   })
 
+  it('declares a sole conversation on Linear, and nowhere else', () => {
+    // Two CP reads hang off this before any route or owner exists: the route projection (owner →
+    // `defaultAgentId`, no scoped route) and the install-time seed. Linear is the whole behavior —
+    // its install NAMES the one conversation it reaches, so linking the agent IS the consent.
+    expect(manifestFor('linear').soleConversation).toBe(true)
+    for (const p of ['slack', 'telegram', 'discord', 'feishu']) expect(manifestFor(p).soleConversation, p).toBe(false)
+    expect(manifestFor('some-future-platform').soleConversation).toBe(false)
+    expect(DEFAULT_MANIFEST.soleConversation).toBe(false)
+  })
+
   it('keeps Linear on the fail-closed arm of every axis it did not earn', () => {
-    // Linear's row exists for `multiAgentShareable` alone: no membership
-    // snapshot API, no bot-sender admission, nothing but a conversation to
-    // leave. Pin it so the row cannot pick up a Slack-shaped path in passing.
+    // Linear's row exists for `multiAgentShareable` and `soleConversation` alone: no
+    // membership snapshot API, no bot-sender admission, nothing but a conversation to leave.
+    // Pin it so the row cannot pick up a Slack-shaped path in passing.
     const m = manifestFor('linear')
     expect(m.membershipEnumeration).toBe(DEFAULT_MANIFEST.membershipEnumeration)
     expect(m.botSenderRouting).toBe(DEFAULT_MANIFEST.botSenderRouting)

--- a/packages/protocol/src/platform-manifest.ts
+++ b/packages/protocol/src/platform-manifest.ts
@@ -86,6 +86,26 @@ export interface PlatformManifest {
    *  Fail-closed: an unknown platform serves one agent per bot, so a flag no
    *  install path honors can never be set. */
   readonly multiAgentShareable: boolean
+  /** Whether one install here NAMES the single conversation it can reach — a
+   *  connected Linear workspace, where there is no second conversation and
+   *  linking an agent IS consenting to that one. Two PRE-DISPATCH reads, both
+   *  made before a route, an owner, or a turn exists:
+   *
+   *   1. ROUTE PROJECTION — the conversation row's owner maps to the group's
+   *      `defaultAgentId` (§10.3, the ladder's last and addressed-gated rung) and
+   *      the HTTP-bot compile emits NO channel-scoped route for it. A scoped
+   *      `mention` rule would be the FIRST rung, and every event on such a
+   *      platform marks the app as mentioned, so it would shadow `@<agent-name>`
+   *      selection and hijack a bound session's follow-ups.
+   *   2. INSTALL-TIME SEED — the connect tail and each add-member synchronously
+   *      write the conversation row, born `mention` because link-is-consent
+   *      overrides §14's restricted-agent `off` seed (resource-visibility.md).
+   *      Gating is vacuous here for the same reason, so a restricted linking
+   *      agent keeps the default and its keyword rung; §14's fail-open worry
+   *      presumes conversations the install never granted.
+   *
+   *  Fail-closed `false` keeps both on the ordinary §10/§14 arms. */
+  readonly soleConversation: boolean
 }
 
 /** The conservative arm of every axis — see the fail-closed note above. */
@@ -97,7 +117,9 @@ export const DEFAULT_MANIFEST: Omit<PlatformManifest, 'platform'> = {
   // is refused rather than dispatched at a platform that cannot serve it.
   leaveGranularity: 'conversation',
   // The arm the retired Slack-only predicate took for every other id: one agent per bot.
-  multiAgentShareable: false
+  multiAgentShareable: false,
+  // The arm §14 already took everywhere: an install grants no conversation on its own.
+  soleConversation: false
 }
 
 /**
@@ -118,7 +140,8 @@ const MANIFESTS = new Map<string, Omit<PlatformManifest, 'platform'>>([
       dmChannelPattern: /^D/,
       botSenderRouting: true,
       leaveGranularity: 'conversation',
-      multiAgentShareable: true
+      multiAgentShareable: true,
+      soleConversation: false
     }
   ],
   [
@@ -127,7 +150,8 @@ const MANIFESTS = new Map<string, Omit<PlatformManifest, 'platform'>>([
       membershipEnumeration: 'observed',
       botSenderRouting: false,
       leaveGranularity: 'conversation',
-      multiAgentShareable: false
+      multiAgentShareable: false,
+      soleConversation: false
     }
   ],
   // A Discord bot is added to a GUILD, not to a channel — there is no
@@ -138,7 +162,8 @@ const MANIFESTS = new Map<string, Omit<PlatformManifest, 'platform'>>([
       membershipEnumeration: 'observed',
       botSenderRouting: false,
       leaveGranularity: 'space',
-      multiAgentShareable: false
+      multiAgentShareable: false,
+      soleConversation: false
     }
   ],
   [
@@ -147,7 +172,8 @@ const MANIFESTS = new Map<string, Omit<PlatformManifest, 'platform'>>([
       membershipEnumeration: 'observed',
       botSenderRouting: false,
       leaveGranularity: 'conversation',
-      multiAgentShareable: false
+      multiAgentShareable: false,
+      soleConversation: false
     }
   ],
   // A connected Linear workspace IS a shared bot: the deployment's one OAuth app
@@ -158,7 +184,9 @@ const MANIFESTS = new Map<string, Omit<PlatformManifest, 'platform'>>([
       membershipEnumeration: 'observed',
       botSenderRouting: false,
       leaveGranularity: 'conversation',
-      multiAgentShareable: true
+      multiAgentShareable: true,
+      // The workspace IS the conversation, and enabling an agent on it is the install itself.
+      soleConversation: true
     }
   ]
 ])

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -451,3 +451,114 @@ describe('toBotAssignment (§6.7 open secrets reader)', () => {
     expect(a && 'botUserId' in a).toBe(false)
   })
 })
+
+/**
+ * Linear rides this ladder UNCHANGED (linear-integration.md §4.5). The workspace is the channel,
+ * but its conversation row compiles to the group's `defaultAgentId` — the LAST rung — and to no
+ * channel-scoped route: every Linear event marks the app as mentioned, so a scoped `mention` rule
+ * would fire FIRST on every delivery and shadow both keyword selection and thread continuity.
+ * Nothing below is Linear-aware; these are the same rungs Slack takes.
+ */
+describe('Linear workspace-as-channel arbitration', () => {
+  const WORKSPACE = '00000000-0000-4000-8000-000000000001'
+  const APP_USER = '00000000-0000-4000-8000-0000000000a1'
+  const empty = () => new Map<string, RouteTarget>()
+
+  /** The compile's output for a workspace whose conversation row is owned by ALICE: the keyword
+   *  rung per member, the owner as `defaultAgentId`, and NO scoped route at all. */
+  const linear = (): BotAssignment => ({
+    ...assignment(),
+    platform: 'linear',
+    botUserId: APP_USER,
+    routes: [
+      { agentId: ALICE, daemonId: D1, integrationId: 'iA', match: { kind: 'keyword', value: 'alice' } },
+      { agentId: BOB, daemonId: D2, integrationId: 'iB', match: { kind: 'keyword', value: 'bob' } }
+    ],
+    defaultAgentId: ALICE,
+    defaultDaemonId: D1
+  })
+
+  /** Every Linear delivery exists because the app was delegated to or mentioned (§6.1), so it
+   *  carries the app user id and is "explicitly addressed" by construction. */
+  const delegation = (text: string, thread = 'agent-session-1'): WireNormalizedMessage =>
+    msg({ platform: 'linear', channel: WORKSPACE, thread, text, mentionedBots: [APP_USER] })
+
+  it('routes a bare delegation to the workspace owner, through the default rung', () => {
+    const t = arbitrate(linear(), delegation('take a look at the failing job'), empty())
+    expect(t).toEqual({ agentId: ALICE, daemonId: D1, integrationId: 'iA' })
+  })
+
+  it('routes a NAMED delegation to the slug, not to the workspace owner', () => {
+    // The whole reason the owner is not a scoped route: §4.3's `@<agent-name>` selection has to
+    // beat the workspace default, and the unscoped keyword rung sits directly above it.
+    const t = arbitrate(linear(), delegation('bob please ship it'), empty())
+    expect(t).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
+  })
+
+  it('keeps a bound session with its agent when the workspace owner changes mid-session', () => {
+    // A Linear session is bound to one agent at creation (§4.5), and every follow-up `prompted`
+    // still marks the app as mentioned. Thread continuity outranks the default, so re-pointing
+    // the workspace at ALICE cannot hijack the session BOB already holds.
+    const affinity = new Map<string, RouteTarget>([
+      [`${WORKSPACE}/agent-session-1`, { agentId: BOB, daemonId: D2, integrationId: 'iB' }]
+    ])
+    const bound = arbitrate(linear(), delegation('does this reopen the session?'), affinity)
+    expect(bound).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
+    // A different session in the same workspace is unaffected and still falls to the owner.
+    expect(arbitrate(linear(), delegation('a fresh delegation', 'agent-session-2'), affinity)).toEqual({
+      agentId: ALICE,
+      daemonId: D1,
+      integrationId: 'iA'
+    })
+  })
+
+  it('refuses a workspace switched Off, ahead of every rung', () => {
+    const off = { ...linear(), mutedChannels: [WORKSPACE] }
+    expect(arbitrate(off, delegation('take a look'), empty())).toBeNull()
+  })
+
+  /**
+   * A PRIVATE (restricted) agent that linked the workspace. The compile carries it as UNGATED on
+   * this bot — link-is-consent already satisfied §14 here — which is what keeps the ladder's three
+   * gated fences from stranding it: the default rung skips gated agents, `contGateOk` demands a
+   * channel-scoped route for a gated agent, and so does `agentTarget`. None of those routes exist
+   * under the corrected shape, so leaving the member gated would make it unreachable outright.
+   */
+  describe('a private linking agent', () => {
+    const privateOwner = (): BotAssignment => ({ ...linear(), gatedAgentIds: [] })
+
+    it('receives a bare delegation through the default rung', () => {
+      expect(arbitrate(privateOwner(), delegation('take a look'), empty())).toEqual({
+        agentId: ALICE,
+        daemonId: D1,
+        integrationId: 'iA'
+      })
+    })
+
+    it('keeps its session across a workspace-owner change', () => {
+      // BOB now owns the workspace, but ALICE still holds the session it was bound to.
+      const reowned: BotAssignment = { ...privateOwner(), defaultAgentId: BOB, defaultDaemonId: D2 }
+      const affinity = new Map<string, RouteTarget>([
+        [`${WORKSPACE}/agent-session-1`, { agentId: ALICE, daemonId: D1, integrationId: 'iA' }]
+      ])
+      expect(arbitrate(reowned, delegation('a follow-up'), affinity)).toEqual({
+        agentId: ALICE,
+        daemonId: D1,
+        integrationId: 'iA'
+      })
+    })
+
+    it('is still fenced by the gate on a bot that DID keep it gated', () => {
+      // The same agent on an ordinary bot: the compile leaves it in `gatedAgentIds` and emits no
+      // keyword rung, so neither continuity nor a name reaches it without a scoped route.
+      const slackBot: BotAssignment = {
+        ...assignment(),
+        gatedAgentIds: [BOB],
+        routes: [{ agentId: ALICE, daemonId: D1, integrationId: 'iA', match: { kind: 'keyword', value: 'alice' } }]
+      }
+      const affinity = new Map<string, RouteTarget>([['CX/ts1', { agentId: BOB, daemonId: D2, integrationId: 'iB' }]])
+      const named = msg({ channel: 'CX', text: '<@UBOT> bob ship it', mentionedBots: [BOTUSER] })
+      expect(arbitrate(slackBot, named, affinity)).toEqual({ agentId: ALICE, daemonId: D1, integrationId: 'iA' })
+    })
+  })
+})

--- a/packages/relay/src/platforms/linear/http-ingest.ts
+++ b/packages/relay/src/platforms/linear/http-ingest.ts
@@ -209,11 +209,12 @@ function actorId(event: LinearAgentSessionEvent): string {
 }
 
 // One verified `created`/`prompted` event as the message relay core arbitrates: `channel` is the
-// immutable issue UUID, falling back to the session UUID for the issue-less surfaces (§4.5).
+// connected WORKSPACE (§4.5), read off the ingest identity rather than the payload — `decode`
+// already refused every delivery whose `organizationId` differs, so the two cannot disagree.
 export function normalizeLinearEvent(
   event: LinearAgentSessionEvent,
   msgId: string,
-  appUserId: string | undefined
+  identity: LinearIngestIdentity
 ): WireNormalizedMessage {
   const session = event.agentSession
   const issue = session.issue ?? undefined
@@ -238,7 +239,7 @@ export function normalizeLinearEvent(
     traceId: msgId,
     source: 'user',
     platform: 'linear',
-    channel: issue?.id ?? session.id,
+    channel: identity.organizationId,
     thread: session.id,
     ...(issue?.url?.startsWith('https://') ? { threadUrl: issue.url } : {}),
     sender: {
@@ -249,7 +250,7 @@ export function normalizeLinearEvent(
     text: instructionText(event),
     // Every Linear event exists because the app was delegated to or mentioned (§6.1), so the
     // arbitration ladder's "explicitly addressed" gate is satisfied by construction.
-    mentionedBots: appUserId ? [appUserId] : [],
+    mentionedBots: identity.appUserId ? [identity.appUserId] : [],
     isDm: false,
     trigger: 'mention',
     ...(eventAtMs !== undefined && eventAtMs > 0 ? { platformTimeMs: eventAtMs } : {}),

--- a/packages/relay/src/platforms/linear/ingress-plugin.test.ts
+++ b/packages/relay/src/platforms/linear/ingress-plugin.test.ts
@@ -4,7 +4,7 @@ import type { WireNormalizedMessage } from '@agentconnect.md/protocol'
 import { linearIngressPlugin } from './ingress-plugin.js'
 import { LINEAR_CONTEXT_BUDGET_BYTES, type LinearAdapterExt } from './http-ingest.js'
 import type { RelayIngressHost } from '../contract.js'
-import { toBotAssignment } from '../../bot-arbitration.js'
+import { sessionKeyOf, toBotAssignment } from '../../bot-arbitration.js'
 import type { BotAssignment, RouteTarget } from '../../bot-arbitration.js'
 
 const NOW = 1_788_249_909_143
@@ -310,12 +310,12 @@ describe('linear ingress plugin — dedup identity', () => {
 })
 
 describe('linear ingress plugin — normalized message', () => {
-  it('maps a created event onto issue/session coordinates with the adapter bag', async () => {
+  it('maps a created event onto workspace/session coordinates with the adapter bag', async () => {
     const h = host()
     const { forwarded } = await run(h, createdEvent())
     expect(forwarded).toMatchObject({
       platform: 'linear',
-      channel: ISSUE_ID,
+      channel: ORG_ID,
       thread: SESSION_ID,
       threadUrl: issue.url,
       sender: { id: `linear:${USER_ID}`, isBot: false },
@@ -349,14 +349,19 @@ describe('linear ingress plugin — normalized message', () => {
     expect((await run(h, documented)).forwarded?.text).toBe('Documented-shape follow-up')
   })
 
-  it('keys a session with NO issue on the session UUID — never `linear:undefined`', async () => {
+  it('keeps a session with NO issue on the workspace channel, minus the issue metadata', async () => {
+    // The workspace is the channel whatever surface the session sits on, so an issue-less
+    // session is just a thread whose bag and `threadUrl` carry nothing about an issue.
     const h = host()
     const noIssue = createdEvent()
     ;(noIssue.agentSession as Record<string, unknown>).issue = null
     const { forwarded } = await run(h, noIssue)
-    expect(forwarded?.channel).toBe(SESSION_ID)
+    expect(forwarded?.channel).toBe(ORG_ID)
     expect(forwarded?.thread).toBe(SESSION_ID)
     expect(forwarded?.threadUrl).toBeUndefined()
+    const bag = forwarded!.adapterExt!.linear as LinearAdapterExt
+    expect(bag.issueIdentifier).toBeUndefined()
+    expect(bag.issueTitle).toBeUndefined()
     expect(JSON.stringify(forwarded)).not.toContain('undefined')
   })
 
@@ -421,17 +426,22 @@ describe('linear ingress plugin — truncation budget', () => {
 })
 
 describe('linear ingress plugin — stop, revocation, and non-session events', () => {
-  it('routes a stop signal as a platform_action, not a message', async () => {
-    const h = host()
+  it('routes a stop signal as a platform_action on the WORKSPACE coordinates', async () => {
+    const resolveTarget = vi.fn(() => ROUTE)
+    const h = host({ directory: { ...host().directory, resolveTarget } })
     await run(h, promptedEvent({}, { signal: 'stop' }))
     expect(h.forward).not.toHaveBeenCalled()
     expect(h.forwardAction).toHaveBeenCalledTimes(1)
+    // The directory is asked for the workspace channel, never the issue: a stop has to land on
+    // the same conversation the delegation that opened the session routed through.
+    expect(resolveTarget).toHaveBeenCalledWith(expect.any(String), { channelId: ORG_ID, threadTs: SESSION_ID })
     const [msg, route] = vi.mocked(h.forwardAction).mock.calls[0]!
     expect(msg).toMatchObject({
       source: 'platform_action',
       platformId: 'linear',
       agentId: ROUTE.agentId,
       integrationId: ROUTE.integrationId,
+      sessionKey: sessionKeyOf({ channel: ORG_ID, thread: SESSION_ID }),
       msgId: `linear:${ACTIVITY_ID}`,
       userId: USER_ID,
       payload: { kind: 'stop', agentSessionId: SESSION_ID }

--- a/packages/relay/src/platforms/linear/ingress-plugin.ts
+++ b/packages/relay/src/platforms/linear/ingress-plugin.ts
@@ -24,12 +24,13 @@ export interface LinearStopAction {
 // session is bound to one agent at creation (§4.5) the conversation's own target is the holder.
 export function forwardLinearStop(
   host: RelayIngressHost,
-  botId: string,
+  ingest: LinearHttpIngest,
   event: LinearAgentSessionEvent,
   msgId: string
 ): void {
+  const botId = ingest.botId
   const session = event.agentSession
-  const channelId = session.issue?.id ?? session.id
+  const channelId = ingest.identity.organizationId
   const route = host.directory.resolveTarget(botId, { channelId, threadTs: session.id })
   if (!route) {
     host.log.warn(`relay-ingress(${botId}): Linear stop for session ${session.id} has no current target`)
@@ -118,10 +119,10 @@ export const linearIngressPlugin: RelayPlatformIngressPlugin<LinearHttpIngest, V
     }
     if (host.dedupSeen(msgId)) return {}
     if (linearIsStop(event)) {
-      forwardLinearStop(host, botId, event, msgId)
+      forwardLinearStop(host, ingest, event, msgId)
       return {}
     }
-    const message = normalizeLinearEvent(event, msgId, ingest.identity.appUserId)
+    const message = normalizeLinearEvent(event, msgId, ingest.identity)
     void host
       .forward(botId, message)
       .catch((err) => host.log.warn(`linear ingress: event handler error: ${(err as Error).message}`))


### PR DESCRIPTION
Implements the corrected Linear model (companion docs PR #1690): **the workspace is the channel.** `channel` = the Linear organizationId, `thread` = the AgentSession UUID, and the issue is display metadata only (`threadUrl` + the prompt's trusted header; `channelName` is the workspace name — one label per channel, never per-event issue text).

- **Protocol**: one new manifest axis, `soleConversation` (`linear: true`, fail-closed default), carrying three co-varying pre-dispatch reads — the conversation row's owner compiles to the group's `defaultAgentId` with NO channel-scoped route (the scoped mention rung is the ladder's first and would shadow `@agent-name` and hijack bound sessions); conversation rows are born `mention` (linking is the consent act); and a restricted member of such a bot is not conversation-gated (link-is-consent — computed at the compile's single `placed` seat, which fixes the keyword rung, default derivation, `gatedAgentIds`, continuity gating, `agentTarget`, and the daemon's spec-side backstop together; the same agent stays gated on its Slack bots, pinned by a test).
- **Control plane**: the install paths (connect tail + add-member) synchronously seed the workspace conversation row — owner = the linking agent on the first write — and publish through the `syncBot` they already end in; every seat that re-derives or projects a row's trigger reads the same `gatesNewConversations` predicate, so a gated owner can neither be seeded `off` nor reverted to it by a later compile or read-side projection.
- **Relay**: `channel` comes from the ingest identity's organizationId; the issue-less channel fallback is gone (an issue-less session is just a thread with absent issue metadata); stop resolves on the workspace channel.
- **Daemon**: the connection eagerly reports the workspace conversation as a name refresh (the CP seed is the source of truth); session metadata and the stop lookup follow the new coordinates.

Routing order, pinned by tests: named create → the member keyword route (despite a different owner); bound follow-up → thread affinity (an owner change never moves a live session); bare create → the row's owner via the default rung; pre-row backstop → earliest non-gated member. A private linking agent receives bare delegations and keeps affinity.

Gates: relay 618, CP unit 2222 + int 1902, daemon suite green outside the four known environment-dependent files, full lint/format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
