### PR TITLE
feat(web): Linear workspaces as rows on the agent card

### DIFF
--- a/packages/control-plane/src/http/platform-route-mounts.test.ts
+++ b/packages/control-plane/src/http/platform-route-mounts.test.ts
@@ -76,7 +76,8 @@ const EXPECTED_MOUNTS: Record<CpRouteScope, Record<string, string[]>> = {
     linearConnectRoutesPlugin: [
       'POST /integrations/linear/connect',
       'GET /integrations/linear/connect/:id',
-      'POST /bots/:id/linear/reconnect'
+      'POST /bots/:id/linear/reconnect',
+      'POST /bots/:id/linear/disconnect'
     ]
   },
   'public-callback': {

--- a/packages/control-plane/src/http/routes/bots.ts
+++ b/packages/control-plane/src/http/routes/bots.ts
@@ -20,6 +20,7 @@ import { orgOf, denyViewerWrite } from '../rbac.js'
 import { BotDto, BotListDto, UpdateBotBody, ErrorDto, IdParam, type BotDtoT } from '../dto/index.js'
 import { Tag } from '../plugins/openapi.js'
 import { multiAgentUnsupportedMessage } from '../../platforms/sharing.js'
+import { deleteBotIdentity } from '../uninstall.js'
 
 function toDto(b: BotRecord): BotDtoT {
   return {
@@ -121,21 +122,10 @@ export function botRoutes(deps: HttpDeps) {
             .code(409)
             .send({ error: 'Conflict', statusCode: 409, message: 'bot is installed on an agent — uninstall first' })
         }
-        // Platform-owned teardown the cascade cannot reach (contract §9 `onBotDelete`): read the
-        // secret row BEFORE the delete cascades it away, then run the declared side effect AFTER
-        // the row is gone, so a refused delete never tears down a live install's upstream state.
-        // Best-effort by contract — a failure is logged and the delete stands (Linear's own
-        // backstop is its orphan-token sweep).
-        const onBotDelete = deps.platforms.get(bot.platform)?.sideEffects?.onBotDelete
-        const secrets = onBotDelete ? await deps.repos.botSecret.get(orgOf(req), bot.id) : null
-        await deps.repos.bot.delete(orgOf(req), bot.id)
-        if (onBotDelete) {
-          try {
-            await onBotDelete(bot, secrets)
-          } catch (err) {
-            req.log.warn({ err, botId: bot.id, platform: bot.platform }, 'bot delete side effect failed')
-          }
-        }
+        // The row + the platform-owned teardown the cascade cannot reach are the shared
+        // skeleton (`http/uninstall.ts`), so this path and Linear's workspace disconnect
+        // cannot drift on which side effects a deleted identity fires.
+        await deleteBotIdentity(deps, req.log, orgOf(req), bot)
         return reply.code(204).send(null)
       }
     )

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -32,6 +32,7 @@ import { integrationToSpec, isGatedAgent } from '../../orchestrator/placement.js
 import { conversationOwnerRow, pickConversationOwner } from '../../orchestrator/httpBot.js'
 import { NoConnection } from '../../orchestrator/outbound.js'
 import { installNewBot } from '../install-bot.js'
+import { removeIntegrationRow } from '../uninstall.js'
 import { BotExternalIdentityTaken } from '../../persistence/errors.js'
 import { integrationPlatformAvailability } from '../daemon-platform-capability.js'
 import { relayIngress } from '../relay-ingress.js'
@@ -158,19 +159,6 @@ export function integrationRoutes(deps: HttpDeps) {
         ...(refusal.code ? { code: refusal.code } : {}),
         message: refusal.message
       })
-
-    const replicateRemove = async (
-      i: Pick<IntegrationRecord, 'id' | 'agentId' | 'orgId'>,
-      owningAgent: ResolvableAgent
-    ): Promise<void> => {
-      const { id: integrationId } = i
-      // The row's own org rides the send: `integration/remove` carries only an id,
-      // so a holder that never registered this integration has nothing to resolve.
-      await deps.agentDelivery.integrationRemove(owningAgent, i.id, i.orgId, (err, target) => {
-        if (!(err instanceof NoConnection)) throw err
-        app.log.debug({ integrationId, daemonId: target }, 'integration/remove skipped: daemon offline')
-      })
-    }
 
     r.post(
       '/integrations',
@@ -1170,16 +1158,9 @@ export function integrationRoutes(deps: HttpDeps) {
           if (botBefore?.transport === 'http') {
             await deps.httpBot.prepareIntegrationRemoval(existing.botId)
           }
-          await deps.repos.integration.delete(orgIdOf(req), existing.id)
-          deps.recomputeDuties?.(orgIdOf(req))
-          // "Freed" now means NO active integration remains (a shareable bot may still
-          // serve other agents — don't stamp it freed while it does, §6).
-          const remaining = await deps.repos.integration.listForBot(existing.botId)
-          if (remaining.length === 0) {
-            await deps.repos.bot.markFreed(orgIdOf(req), existing.botId, new Date(), agent.name ?? null)
-          }
-          // Tell the removed agent's daemon to drop the spec either way.
-          await replicateRemove(existing, agent)
+          // The row-scoped half is the shared skeleton (`http/uninstall.ts`): delete,
+          // re-derive the freed stamp, and tell the agent's daemons to drop the spec.
+          await removeIntegrationRow(deps, app.log, { orgId: orgIdOf(req), integration: existing, agent })
           // HTTP bot: recompute the relay's routes + members (or release it if this
           // was the last install).
           if (botBefore?.transport === 'http') await deps.httpBot.syncBot(existing.botId)

--- a/packages/control-plane/src/http/uninstall.ts
+++ b/packages/control-plane/src/http/uninstall.ts
@@ -1,0 +1,84 @@
+/**
+ * The teardown skeletons — `installNewBot`'s counterparts, and core for the same
+ * reason it is: the steps are identical wherever an install or an identity goes away,
+ * and only the CALLER's policy differs.
+ *
+ * They landed here when Linear needed a workspace disconnect. That route removes every
+ * member install of one bot and then the bot, which is exactly `DELETE /integrations/:id`
+ * followed by `DELETE /bots/:id` — so it either reuses those bodies or grows a second
+ * copy of the freed-stamping, the duty recompute, the `integration/remove` fan-out and
+ * the declared `onBotDelete` side effect. A second copy of a teardown is how one path
+ * quietly stops firing a step the other still does.
+ *
+ * The BOT-SCOPED half stays with the caller on purpose: `prepareIntegrationRemoval` and
+ * `syncBot` are per-bot, not per-install, so a caller removing N installs of one bot
+ * spends them once around the loop rather than N times inside it.
+ */
+import type { HttpDeps } from './deps.js'
+import type { AgentRecord, BotRecord, IntegrationRecord } from '../persistence/ports.js'
+import type { OrgId } from '../domain/ids.js'
+import { NoConnection } from '../orchestrator/outbound.js'
+
+/** Minimal log surface (Fastify logger in prod). */
+interface TeardownLog {
+  debug(obj: unknown, msg?: string): void
+  warn(obj: unknown, msg?: string): void
+}
+
+/**
+ * Remove ONE install: drop the row, re-derive the bot's freed stamp, and tell the
+ * owning agent's daemons to drop the spec.
+ *
+ * The caller owns authorization, the agent-mutation lease, and the bot-scoped
+ * `prepareIntegrationRemoval` / `syncBot` pair around it.
+ */
+export async function removeIntegrationRow(
+  deps: HttpDeps,
+  log: TeardownLog,
+  args: {
+    orgId: OrgId
+    integration: IntegrationRecord
+    /** The install's owning agent, resolved under the caller's lease. Absent ⇒ the row
+     *  outlived its agent, so there is no placement to notify and only the row goes. */
+    agent: AgentRecord | null
+  }
+): Promise<void> {
+  const { orgId, integration, agent } = args
+  await deps.repos.integration.delete(orgId, integration.id)
+  deps.recomputeDuties?.(orgId)
+  // "Freed" means NO active install remains — a shareable bot may still serve others.
+  const remaining = await deps.repos.integration.listForBot(integration.botId)
+  if (remaining.length === 0) {
+    await deps.repos.bot.markFreed(orgId, integration.botId, new Date(), agent?.name ?? null)
+  }
+  if (!agent) return
+  // The row's own org rides the send: `integration/remove` carries only an id, so a
+  // holder that never registered this integration has nothing to resolve.
+  await deps.agentDelivery.integrationRemove(agent, integration.id, integration.orgId, (err, target) => {
+    if (!(err instanceof NoConnection)) throw err
+    log.debug({ integrationId: integration.id, daemonId: target }, 'integration/remove skipped: daemon offline')
+  })
+}
+
+/**
+ * Delete one bot identity and run the platform teardown the cascade cannot reach
+ * (provider contract §9 `onBotDelete` — Linear's upstream grant revoke).
+ *
+ * The secret row is read BEFORE the delete cascades it away and the side effect runs
+ * AFTER the row is gone, so a refused delete never tears down a live install's upstream
+ * state. Best-effort by contract: a failing side effect is logged and the delete stands,
+ * because the row is already gone and each platform owns a sweeper as its backstop.
+ *
+ * The caller owns authorization and the "no install remains" precondition.
+ */
+export async function deleteBotIdentity(deps: HttpDeps, log: TeardownLog, orgId: OrgId, bot: BotRecord): Promise<void> {
+  const onBotDelete = deps.platforms.get(bot.platform)?.sideEffects?.onBotDelete
+  const secrets = onBotDelete ? await deps.repos.botSecret.get(orgId, bot.id) : null
+  await deps.repos.bot.delete(orgId, bot.id)
+  if (!onBotDelete) return
+  try {
+    await onBotDelete(bot, secrets)
+  } catch (err) {
+    log.warn({ err, botId: bot.id, platform: bot.platform }, 'bot delete side effect failed')
+  }
+}

--- a/packages/control-plane/src/platforms/linear/routes.ts
+++ b/packages/control-plane/src/platforms/linear/routes.ts
@@ -32,6 +32,7 @@ import { resolveWebAppUrl } from '../../config/env.js'
 import { relayIngress } from '../../http/relay-ingress.js'
 import { integrationPlatformAvailability } from '../../http/daemon-platform-capability.js'
 import { installNewBot } from '../../http/install-bot.js'
+import { deleteBotIdentity, removeIntegrationRow } from '../../http/uninstall.js'
 import { BotExternalIdentityTaken, BotWorkspaceClaimed } from '../../persistence/errors.js'
 import { ErrorDto, IdParam } from '../../http/dto/index.js'
 import type { LinearRouteSeams } from '../../http/platform-route-seams.js'
@@ -248,6 +249,94 @@ export function linearConnectRoutes(deps: HttpDeps, linear: LinearRouteSeams) {
           id: install.id,
           connectUrl: linear.api.authorizeUrl({ clientId: platform.clientId, redirectUri, state: install.id })
         })
+      }
+    )
+
+    /**
+     * Disconnect a workspace for the whole organization (§7.4) — every member install and
+     * then the bot, as ONE call.
+     *
+     * It exists because the console cannot do this piecewise. `GET /integrations` is
+     * VISIBILITY-FILTERED, so a member on a restricted agent outside the caller's audience
+     * is invisible to it: a client loop would remove what it can see, and the bot delete
+     * behind it would 409 on the member it never knew about — leaving the workspace half
+     * unlinked after the operator confirmed a full disconnect. The authoritative member set
+     * is `listForBot` under the bot's own org fence, and only the server holds it.
+     *
+     * NO per-agent `canEdit`, deliberately — that is the same filter in another costume.
+     * Disconnecting is an act on the org's bot identity, gated exactly as `DELETE /bots/:id`
+     * is: a non-viewer member of the owning organization. A member the caller may not edit
+     * is precisely the one that must still go, or the refusal above comes back.
+     */
+    r.post(
+      '/bots/:id/linear/disconnect',
+      {
+        schema: {
+          tags: [Tag.Bots],
+          summary: 'Disconnect a Linear workspace',
+          description:
+            'Remove a connected Linear workspace for the whole organization: every agent’s membership of it, then the bot identity itself, whose deletion revokes the upstream grant. Atomic from the caller’s side — a partial teardown is reported as a conflict naming what is still linked, never as success.',
+          operationId: 'disconnectLinearWorkspace',
+          params: IdParam,
+          response: { 204: z.null(), 401: ErrorDto, 403: ErrorDto, 404: ErrorDto, 409: ErrorDto }
+        }
+      },
+      async (req, reply) => {
+        if (denyViewerWrite(req, reply)) return
+        const orgId = req.orgCtx!.orgId
+        const bot = await deps.repos.bot.get(orgId, BotId(req.params.id))
+        if (!bot) {
+          return reply.code(404).send({ error: 'Not Found', statusCode: 404, message: 'bot not found' })
+        }
+        // Same identity fence the reconnect arm uses: a row from another deployment app is
+        // not this app's to tear down, and only a completed connect has a grant to revoke.
+        if (bot.platform !== 'linear' || bot.externalAppId !== platform.clientId || !bot.externalTenantId) {
+          return reply.code(409).send({
+            error: 'Conflict',
+            statusCode: 409,
+            message: 'only a connected Linear workspace can be disconnected'
+          })
+        }
+        // The AUTHORITATIVE member set — org-fenced through the bot, never viewer-filtered.
+        const installs = await deps.repos.integration.listForBot(bot.id)
+        const memberAgentIds = [...new Set(installs.map((install) => install.agentId))]
+        // Every member joins the lease: removing an install while its agent is being moved
+        // is the same race the per-integration route fences, once per member here.
+        const release = deps.agentMutations.tryBeginMutation(memberAgentIds)
+        if (!release) {
+          return reply
+            .code(409)
+            .send({ error: 'Conflict', statusCode: 409, message: 'agent move is in progress; retry the disconnect' })
+        }
+        try {
+          // Bot-scoped, so it runs once around the loop rather than once per member.
+          await deps.httpBot.prepareIntegrationRemoval(bot.id)
+          for (const install of installs) {
+            const agent = await deps.repos.agent.get(OrgId(bot.orgId), install.agentId)
+            try {
+              await removeIntegrationRow(deps, req.log, { orgId, integration: install, agent: agent ?? null })
+            } catch (err) {
+              // No silent partial success: re-read what is actually left and say so, so the
+              // operator retries a disconnect rather than believing one happened.
+              req.log.error({ err, botId: bot.id, integrationId: install.id }, 'linear disconnect: removal failed')
+              const left = await deps.repos.integration.listForBot(bot.id)
+              await deps.httpBot.syncBot(bot.id)
+              return reply.code(409).send({
+                error: 'Conflict',
+                statusCode: 409,
+                message: `disconnect stopped partway: ${left.length} of ${installs.length} agents are still linked to this workspace — retry the disconnect`
+              })
+            }
+          }
+          // Zero members now, so this releases the workspace from the relay pool.
+          await deps.httpBot.syncBot(bot.id)
+          // The shared identity teardown — the same one `DELETE /bots/:id` spends, so the
+          // upstream grant revoke (§7.4 `onBotDelete`) fires on both paths.
+          await deleteBotIdentity(deps, req.log, orgId, bot)
+          return reply.code(204).send(null)
+        } finally {
+          release()
+        }
       }
     )
   }

--- a/packages/control-plane/test/integration/linear-connect.route.test.ts
+++ b/packages/control-plane/test/integration/linear-connect.route.test.ts
@@ -17,6 +17,7 @@ import { seedAgent, seedDaemon } from '../fixtures/seed.js'
 import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
 import { trackedTestClock } from '../fakes/tracked-clock.js'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { PgUserRepo } from '../../src/persistence/repositories/user.repo.js'
 import { BotId, OrgId } from '../../src/domain/ids.js'
 import { createLinearCpProvider } from '../../src/platforms/linear/provider.js'
 import { LinearApiClient } from '../../src/platforms/linear/api.js'
@@ -80,6 +81,8 @@ interface Harness {
   app: HttpApp
   linear: FakeLinear
   agentId: string
+  /** The daemon-facing frames this app emitted, when the caller asked for a spy. */
+  control: SpyControl
 }
 
 /** Captures the daemon-facing integration frames `syncBot` emits, so the fail-closed teardown and
@@ -105,10 +108,16 @@ async function harness(
   overrides: { relay?: boolean; onAssign?: (payload: { credentialRevision?: number }) => void } = {}
 ): Promise<Harness> {
   const linear = new FakeLinear()
-  const app = buildHttpApp(prisma, {
-    PUBLIC_RELAY_URL: 'https://relay.example.test',
-    PUBLIC_CP_URL: 'https://cp.example.test'
-  })
+  const control = new SpyControl()
+  const app = buildHttpApp(
+    prisma,
+    {
+      PUBLIC_RELAY_URL: 'https://relay.example.test',
+      PUBLIC_CP_URL: 'https://cp.example.test'
+    },
+    undefined,
+    control as unknown as ControlSender
+  )
   app.platformStubs.linearPlatformApp = APP
   app.platformStubs.linearFetch = linear.fetchImpl
   running = app
@@ -127,7 +136,7 @@ async function harness(
   })
   const agentId = randomUUID()
   await seedAgent(prisma, agentId, { daemonId: DAEMON })
-  return { app, linear, agentId }
+  return { app, linear, agentId, control }
 }
 
 const startConnect = (h: Harness, agentId = h.agentId) =>
@@ -211,7 +220,7 @@ describe('the connect funnel — nothing exists before the callback (§7.1)', ()
     const agentId = randomUUID()
     await seedAgent(prisma, agentId, { daemonId: DAEMON })
 
-    const res = await startConnect({ app, linear, agentId })
+    const res = await startConnect({ app, linear, agentId, control: new SpyControl() })
     expect(res.statusCode).toBe(409)
     expect(res.json().message).toMatch(/does not support linear/)
   })
@@ -511,7 +520,7 @@ describe('reconnect — a dead grant is replaced in place (§7.4)', () => {
     })
     const agentId = randomUUID()
     await seedAgent(prisma, agentId, { daemonId: DAEMON })
-    const h: Harness = { app, linear, agentId }
+    const h: Harness = { app, linear, agentId, control }
 
     const { id } = (await startConnect(h)).json() as { id: string }
     await callback(h, { code: 'the-code', state: id })
@@ -1115,6 +1124,127 @@ describe('disconnect — the bot delete revokes only what nobody holds (§7.4)',
 
     expect((await h.app.app.inject({ method: 'DELETE', url: `${ORG}/bots/${local.id}` })).statusCode).toBe(204)
     expect(await grantRow()).not.toBeNull()
+    expect(h.linear.count('/oauth/revoke')).toBe(0)
+  })
+})
+
+/**
+ * The workspace disconnect route (§7.4). It exists because the CONSOLE cannot do this
+ * piecewise: `GET /integrations` is visibility-filtered, so a member on a restricted
+ * agent outside the caller's audience is invisible to it — a client loop would lift
+ * what it can see, and the bot delete behind it would refuse on the one it never knew
+ * about, reporting a full disconnect over a half-unlinked workspace.
+ */
+describe('workspace disconnect — the whole organization, not the caller’s view of it (§7.4)', () => {
+  /** A connected workspace with two members, the second on an agent the caller cannot see. */
+  async function connectedWithHiddenMember(): Promise<{ h: Harness; botId: string; hiddenAgentId: string }> {
+    const h = await harness()
+    const { id } = (await startConnect(h)).json() as { id: string }
+    await callback(h, { code: 'the-code', state: id })
+    const bot = await prisma.bot.findFirstOrThrow({ where: { platform: 'linear' } })
+
+    // The membership is created through the ordinary reuse route while its agent is still
+    // org-visible, then the agent is restricted to an audience the caller is not in — the
+    // state an operator reaches by tightening an agent after installing it.
+    const hiddenAgentId = randomUUID()
+    await seedAgent(prisma, hiddenAgentId, { daemonId: DAEMON, name: 'hidden-agent' })
+    const added = await h.app.app.inject({
+      method: 'POST',
+      url: `${ORG}/integrations`,
+      payload: { platform: 'linear', agentId: hiddenAgentId, botId: bot.id }
+    })
+    expect(added.statusCode).toBe(201)
+    await prisma.agent.update({
+      where: { id: hiddenAgentId },
+      data: { visibility: 'restricted', sharedWith: [randomUUID()] }
+    })
+    return { h, botId: bot.id, hiddenAgentId }
+  }
+
+  it('the piecewise path a console could run leaves the workspace half unlinked', async () => {
+    // The PREMISE, pinned rather than described: the caller's own list omits the hidden
+    // membership, so a loop over it removes one of two and the bot delete then refuses —
+    // after the operator was told a full disconnect was happening.
+    const { h, botId } = await connectedWithHiddenMember()
+
+    const listed = await h.app.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const ids = (listed.json() as { id: string }[]).map((row) => row.id)
+    expect(await prisma.integration.count({ where: { botId } })).toBe(2)
+    expect(ids).toHaveLength(1)
+
+    for (const id of ids) {
+      expect((await h.app.app.inject({ method: 'DELETE', url: `${ORG}/integrations/${id}` })).statusCode).toBe(204)
+    }
+    const refused = await h.app.app.inject({ method: 'DELETE', url: `${ORG}/bots/${botId}` })
+    expect(refused.statusCode).toBe(409)
+    expect(refused.json().message).toMatch(/installed on an agent/)
+    // Half unlinked: the bot, its hidden member, and the upstream grant all survive.
+    expect(await prisma.integration.count({ where: { botId } })).toBe(1)
+    expect(await grantRow()).not.toBeNull()
+    expect(h.linear.count('/oauth/revoke')).toBe(0)
+  })
+
+  it('removes every member — the invisible one included — then the bot and the grant', async () => {
+    const { h, botId, hiddenAgentId } = await connectedWithHiddenMember()
+    h.control.reset()
+
+    const res = await h.app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/linear/disconnect` })
+    expect(res.statusCode).toBe(204)
+
+    expect(await prisma.integration.count({ where: { botId } })).toBe(0)
+    expect(await prisma.bot.count({ where: { id: botId } })).toBe(0)
+    // The identity teardown `DELETE /bots/:id` spends runs here too: nobody holds the
+    // workspace any more, so the grant is revoked upstream and its row goes.
+    expect(await grantRow()).toBeNull()
+    expect(h.linear.count('/oauth/revoke')).toBe(1)
+    // Each member got its own removal broadcast, the hidden one included…
+    expect(h.control.removes).toHaveLength(2)
+    // …and disconnecting a workspace removes memberships, never the agents themselves.
+    expect(await prisma.agent.count({ where: { id: hiddenAgentId } })).toBe(1)
+  })
+
+  it('is refused for an unknown bot, a row this app did not connect, and a viewer', async () => {
+    const { h, botId } = await connectedWithHiddenMember()
+
+    const unknown = await h.app.app.inject({ method: 'POST', url: `${ORG}/bots/${randomUUID()}/linear/disconnect` })
+    expect(unknown.statusCode).toBe(404)
+
+    // A Linear row belonging to another deployment app holds no grant this app may revoke.
+    await prisma.bot.update({ where: { id: botId }, data: { externalAppId: 'someone_elses_client_id' } })
+    const foreign = await h.app.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/linear/disconnect` })
+    expect(foreign.statusCode).toBe(409)
+    expect(foreign.json().message).toMatch(/only a connected Linear workspace/)
+    await prisma.bot.update({ where: { id: botId }, data: { externalAppId: APP.clientId } })
+
+    const users = new PgUserRepo(prisma)
+    const email = 'linear-disconnect-viewer@acme.dev'
+    const { userId } = await users.provisionOidcUser({
+      oidcSubject: 'linear-disconnect-viewer',
+      email,
+      emailVerified: true
+    })
+    await users.addMemberByEmail(DEFAULT_ORG_ID, email, 'viewer')
+    const viewerApp = buildHttpApp(
+      prisma,
+      {
+        PUBLIC_RELAY_URL: 'https://relay.example.test',
+        PUBLIC_CP_URL: 'https://cp.example.test',
+        DEFAULT_OWNER_ID: userId
+      },
+      undefined,
+      new SpyControl() as unknown as ControlSender
+    )
+    viewerApp.platformStubs.linearPlatformApp = APP
+    viewerApp.platformStubs.linearFetch = h.linear.fetchImpl
+    try {
+      const denied = await viewerApp.app.inject({ method: 'POST', url: `${ORG}/bots/${botId}/linear/disconnect` })
+      expect(denied.statusCode).toBe(403)
+    } finally {
+      await viewerApp.close()
+    }
+
+    // Nothing moved on any refusal.
+    expect(await prisma.integration.count({ where: { botId } })).toBe(2)
     expect(h.linear.count('/oauth/revoke')).toBe(0)
   })
 })

--- a/packages/web/src/components/console/DefaultDispatchPicker.tsx
+++ b/packages/web/src/components/console/DefaultDispatchPicker.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+// Per-conversation default dispatch for a SHARED bot — who takes its unmatched messages.
+// Picking one PATCHes the conversation's explicit owner (`setChannelAgent`). Shared by the
+// org Bots roster and the agent page's Linear rows, so the two cannot drift apart.
+
+import { useState } from 'react'
+import { Icon } from '@/components/ui'
+import { AgentIconView } from '@/components/marks'
+import type { AgentIcon } from '@/lib/agent-icon'
+
+/** One candidate owner — an agent the bot is installed on. */
+export interface DefaultDispatchOption {
+  id: string
+  name: string
+  model: string
+  runtime: string
+  icon?: AgentIcon | null
+}
+
+export function DefaultDispatchPicker({
+  options,
+  activeId,
+  disabled,
+  onPick
+}: {
+  options: DefaultDispatchOption[]
+  activeId: string | null
+  disabled: boolean
+  onPick: (agentId: string) => Promise<void>
+}) {
+  const [open, setOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const active = options.find((o) => o.id === activeId) ?? options[0]
+  const pick = (id: string) => {
+    setOpen(false)
+    if (disabled || saving || id === active?.id) return
+    setSaving(true)
+    onPick(id).finally(() => setSaving(false))
+  }
+  return (
+    <span className="relative justify-self-end" onClick={(e) => e.stopPropagation()}>
+      <button
+        onClick={() => !disabled && setOpen((v) => !v)}
+        title="Default dispatch — the agent this conversation's unmatched messages go to"
+        className={`flex items-center gap-2 rounded-[7px] border-0 bg-transparent px-[5px] py-1 hover:bg-(--surface-hover) ${
+          disabled ? 'cursor-default' : 'cursor-pointer'
+        } ${saving ? 'opacity-60' : ''}`}
+      >
+        <span className="av h-5 w-5 rounded-[5px]">
+          <AgentIconView icon={active?.icon} runtime={active?.runtime ?? active?.model ?? ''} size={20} />
+        </span>
+        <span className="mono text-[12.5px] text-(--text-primary)">{active?.name ?? '—'}</span>
+        <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
+      </button>
+      {open && (
+        <>
+          <span className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
+          {/* right-anchored: the picker sits in the roster's right-most column, so a
+              left-anchored menu (wider than its button) would clip past the card edge */}
+          <div className="absolute right-0 top-[calc(100%+5px)] z-40 min-w-[230px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)">
+            <div className="px-[9px] pb-[5px] pt-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+              Default dispatch
+            </div>
+            {options.map((o) => (
+              <button
+                key={o.id}
+                onClick={() => pick(o.id)}
+                className="flex w-full cursor-pointer items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[6px] text-left hover:bg-(--surface-hover)"
+              >
+                <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
+                  <AgentIconView icon={o.icon} runtime={o.runtime} size={22} />
+                </span>
+                <span className="mono min-w-0 flex-1 truncate text-[12.5px] text-(--text-primary)">{o.name}</span>
+                <Icon
+                  name="check"
+                  size={13}
+                  color={o.id === active?.id ? 'var(--brand)' : 'transparent'}
+                  className="flex-none"
+                />
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </span>
+  )
+}

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -6,6 +6,7 @@ import {
   groupBySpace,
   IntegrationChannelList,
   placePopover,
+  roomArticle,
   roomGlyph,
   rowLabel,
   rowMenuAction
@@ -305,9 +306,17 @@ describe('IntegrationChannelList footer', () => {
   it('names the room with the platform noun throughout', () => {
     expect(footer('telegram')).toContain('A group appears here once the bot is added to it')
     expect(footer('slack')).toContain('A channel appears here once the bot is added to it')
-    // The article follows the module's noun rather than being a literal — one of
-    // them starts with a vowel.
-    expect(footer('linear')).toContain('An issue appears here once the bot is added to it')
+    // The article follows the module's noun rather than being a literal, so a module
+    // whose noun starts with a vowel reads correctly without the sentence changing.
+    expect(roomArticle('issue')).toBe('An')
+    expect(roomArticle('channel')).toBe('A')
+  })
+
+  it('falls back to the generic noun for a platform that renders its own card', () => {
+    // Linear declares no channel-list semantics, because this list is never rendered
+    // for it (its module supplies the agent card's whole body). The lookup still has
+    // to be total, and what it answers is the host default — never a borrowed noun.
+    expect(footer('linear')).toContain('A channel appears here once the bot is added to it')
   })
 })
 

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -200,9 +200,10 @@ const canLeaveConversation = (platform?: string): boolean => channelListSemantic
  */
 const roomNoun = (platform?: string): string => channelListSemantics(platform).roomNoun
 
-/** "A"/"An" for a noun a module supplies. The room noun is the platform's own word,
- *  and one of them starts with a vowel ("issue"), so the article cannot be a literal. */
-const roomArticle = (noun: string): string => (/^[aeiou]/i.test(noun) ? 'An' : 'A')
+/** "A"/"An" for a noun a module supplies. The room noun is the platform's own word and
+ *  may start with a vowel, so the article cannot be a literal. Exported for its test:
+ *  today's modules all take "A", so only a test keeps the other arm honest. */
+export const roomArticle = (noun: string): string => (/^[aeiou]/i.test(noun) ? 'An' : 'A')
 
 /** The noun for ONE row: a DM is never a channel or a group, whatever the platform. */
 const rowNoun = (kind: IntegrationChannelRow['kind'], platform?: string): string =>

--- a/packages/web/src/components/console/modals/AddIntegrationModal.sharing.test.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.sharing.test.tsx
@@ -121,8 +121,9 @@ async function settle(): Promise<void> {
   }
 }
 
-/** Open the wizard on `tile` and switch it to the reuse path. */
-async function reusePane(tile: string): Promise<void> {
+/** Open the wizard on `tile`. `existing` switches the HOST chassis to its reuse path —
+ *  a step Linear does not have, because its pane replaces that chassis outright. */
+async function openPane(tile: string, options: { existing?: boolean } = {}): Promise<void> {
   host = document.createElement('div')
   document.body.append(host)
   root = createRoot(host)
@@ -131,7 +132,7 @@ async function reusePane(tile: string): Promise<void> {
   })
   await settle()
   await clickByText('.ptile', tile)
-  await clickByText('.ptile', 'Use an existing bot')
+  if (options.existing) await clickByText('.ptile', 'Use an existing bot')
   await settle()
 }
 
@@ -149,16 +150,21 @@ afterEach(async () => {
 describe('the wizard’s Shared bot opt-in', () => {
   it('is not offered for a Linear workspace, which is shared structurally', async () => {
     mocks.bots = [bot({ id: 'ws-1', platform: 'linear', name: 'Example Workspace' })]
-    await reusePane('Linear')
+    await openPane('Linear')
 
-    // The workspace is still offered for reuse — membership is the whole point.
+    // The workspace is still offered — membership is the whole point — but it is the
+    // module's own list, reached without a mode card, and it carries no opt-in.
     expect(document.body.textContent).toContain('Example Workspace')
     expect(shareOptIn()).toBeUndefined()
+    // The whole identity chassis is replaced, so its mode cards are gone too.
+    expect([...document.querySelectorAll('.ptile')].some((t) => t.textContent?.includes('Use an existing bot'))).toBe(
+      false
+    )
   })
 
   it('is still offered for Slack, unchanged', async () => {
     mocks.bots = [bot({ id: 'sl-1', platform: 'slack' })]
-    await reusePane('Slack')
+    await openPane('Slack', { existing: true })
 
     const optIn = shareOptIn()
     expect(optIn).toBeDefined()

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -94,7 +94,7 @@
  */
 import type { ComponentType, ReactNode } from 'react'
 import type { BotDto, CreateIntegrationInput, SessionMessageDto } from '@/lib/api'
-import type { Agent } from '@/lib/data'
+import type { Agent, IntegrationRow } from '@/lib/data'
 
 /** Inbound transport chosen in the wizard — same value set the create DTOs
  *  carry (api.ts:654-672) and the CP persists. */
@@ -559,6 +559,28 @@ export interface WebChannelListSemantics {
 }
 
 /**
+ * What one integration card on the AGENT page renders under its header, in place
+ * of the host's generic conversation list.
+ *
+ * The generic list assumes the platform's rooms are enumerable things the bot was
+ * ADDED to, each with a trigger and a way out. Linear has no such axis: linking a
+ * workspace IS the consent act, muting is unlinking, and the "room" the card
+ * configures is the workspace itself. Rather than teach
+ * {@link WebChannelListSemantics} to describe a list that must not render, a module
+ * with a different card body supplies one — and declares no `channelList`, so the
+ * generic one is not reached at all.
+ *
+ * The host keeps the card CHROME (mark, name, connected badge, delete). The Body gets
+ * the integration row — which names its own agent, so there is no second prop for the
+ * page's — and reaches the console data layer itself, exactly as the list does.
+ */
+export interface WebAgentIntegrationCardFacet {
+  /** `padX` lines the rows up with the host card that mounts them (16 mobile / 14
+   *  desktop detail), the generic list's own prop. */
+  Body: ComponentType<{ integration: IntegrationRow; padX: number }>
+}
+
+/**
  * One platform's web console module (§10). TypeScript only — registering a
  * module is one line in the (future) registry file; no host component grows a
  * platform branch.
@@ -641,8 +663,13 @@ export interface WebPlatformModule<TApi = unknown> {
   /** Out-of-wizard install polling (Slack today). */
   installPolling?: WebInstallPollingFacet
   /** Channel-list display semantics. Absent ⇒ the host defaults: `channel`
-   *  noun, `#` glyph, `leave: 'none'`, generic copy. */
+   *  noun, `#` glyph, `leave: 'none'`, generic copy — which a platform declaring
+   *  {@link agentCard} never spends, because the generic list is not rendered
+   *  for it at all. */
   channelList?: WebChannelListSemantics
+  /** The agent page's card body, replacing the generic conversation list.
+   *  Absent ⇒ that list, which is every platform whose rooms are enumerable. */
+  agentCard?: WebAgentIntegrationCardFacet
   /**
    * Per-platform transcript text renderer — the §14 defect-3 seam, ADOPTED:
    * `MessageText` resolves it from the ROW's platform key

--- a/packages/web/src/components/console/platforms/linear/Body.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/Body.test.tsx
@@ -1,21 +1,27 @@
 // @vitest-environment happy-dom
 
-// The wizard pane's three availability conditions (§4.2, §7.1). The daemon-capability
-// leg is the host's picker gate and is pinned in `module.test.tsx`; the other two are
-// the pane's, and both fail CLOSED — a pane that offers "Connect Linear" without a
-// relay, or without the deployment's Linear app, sends the operator through an OAuth
-// round trip that cannot land.
+// The wizard pane. Two things it has to get right, and they are the two questions the
+// corrected model asks: WHICH connected workspace this agent joins (single-select, the
+// existing-bot reuse path), and — only when there is none, or the operator asks for
+// another — the zero-config connect hand-off.
+//
+// Its three availability conditions (§4.2, §7.1) both fail CLOSED: a pane that offers
+// a connect without a relay, or without the deployment's Linear app, sends the
+// operator through an OAuth round trip that cannot land. The daemon-capability leg is
+// the host's picker gate and is pinned in `module.test.tsx`.
 
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { SlackConfigDto } from '@/lib/api'
+import type { BotDto, SlackConfigDto } from '@/lib/api'
 import type { Agent } from '@/lib/data'
-import type { WizardFooterState, WizardHost } from '../contract'
+import type { WizardFooterState, WizardHost, WizardIdentityChromeState } from '../contract'
 
 const mocks = vi.hoisted(() => ({
   probeConfig: null as SlackConfigDto | null,
   probeFailed: false,
+  bots: [] as BotDto[],
+  loading: false,
   startLinearConnect: vi.fn(),
   getLinearConnect: vi.fn()
 }))
@@ -28,6 +34,16 @@ vi.mock('@/lib/api', async (importOriginal) => ({
 vi.mock('../deployment-config', () => ({
   useDeploymentConfig: () => ({ config: mocks.probeConfig, failed: mocks.probeFailed, apply: vi.fn() })
 }))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    get bots() {
+      return mocks.bots
+    },
+    get loading() {
+      return mocks.loading
+    }
+  })
+}))
 
 import { ApiError } from '@/lib/api'
 import { LinearWizardBody } from './Body'
@@ -37,6 +53,28 @@ const agent = { id: 'agent-a', name: 'deploy-bot' } as unknown as Agent
 let host: HTMLDivElement
 let root: Root
 let footer: WizardFooterState | null
+let identity: WizardIdentityChromeState | null
+
+function workspace(over: Partial<BotDto> = {}): BotDto {
+  return {
+    id: 'ws-1',
+    name: 'Example Workspace',
+    platform: 'linear',
+    prebuilt: false,
+    slackAppId: null,
+    discordAppId: null,
+    createdBy: null,
+    transport: 'http',
+    shareable: true,
+    inUseByAgentId: null,
+    agentIds: [],
+    lastUsedAt: null,
+    freedFromAgent: null,
+    workspaceName: 'Example Workspace',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...over
+  }
+}
 
 function wizardHost(over: Partial<WizardHost> = {}): WizardHost {
   return {
@@ -51,7 +89,9 @@ function wizardHost(over: Partial<WizardHost> = {}): WizardHost {
     setFooter: (state) => {
       footer = state
     },
-    setIdentityChrome: vi.fn(),
+    setIdentityChrome: (state) => {
+      identity = state
+    },
     setRegionLocked: vi.fn(),
     setError: vi.fn(),
     close: vi.fn(),
@@ -75,10 +115,8 @@ const answered: SlackConfigDto = {
 }
 
 const text = () => host.textContent ?? ''
-
-function connectButton(): HTMLButtonElement | undefined {
-  return [...host.querySelectorAll('button')].find((b) => b.textContent?.includes('Connect Linear'))
-}
+const buttons = () => [...host.querySelectorAll('button')]
+const buttonWith = (label: string) => buttons().find((b) => b.textContent?.includes(label))
 
 async function settle(): Promise<void> {
   for (let attempt = 0; attempt < 10; attempt += 1) {
@@ -88,14 +126,25 @@ async function settle(): Promise<void> {
   }
 }
 
+async function render(over: Partial<WizardHost> = {}): Promise<WizardHost> {
+  const state = wizardHost(over)
+  await act(async () => root.render(<LinearWizardBody agent={agent} host={state} />))
+  await settle()
+  return state
+}
+
 beforeEach(() => {
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
   footer = null
+  identity = null
   mocks.probeConfig = null
   mocks.probeFailed = false
+  mocks.bots = []
+  mocks.loading = false
   mocks.startLinearConnect.mockReset()
   mocks.getLinearConnect.mockReset()
   mocks.getLinearConnect.mockResolvedValue({ id: 'c1', status: 'pending', failureReason: null, botId: null })
+  mocks.startLinearConnect.mockResolvedValue({ id: 'c1', connectUrl: 'https://linear.app/oauth/authorize?state=c1' })
   vi.stubGlobal(
     'open',
     vi.fn(() => null)
@@ -111,34 +160,27 @@ afterEach(async () => {
   vi.unstubAllGlobals()
 })
 
-describe('the Linear connect hand-off', () => {
-  it('waits instead of offering the hand-off while the deployment probe is in flight', async () => {
-    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
+describe('the pane’s deployment conditions', () => {
+  it('waits instead of offering anything while the deployment probe is in flight', async () => {
+    mocks.bots = [workspace()]
+    await render()
+
     expect(text()).toContain('Checking your Linear setup')
-    expect(connectButton()).toBeUndefined()
+    expect(buttonWith('Example Workspace')).toBeUndefined()
   })
 
   it('refuses without public callback delivery', async () => {
     mocks.probeConfig = answered
-    const hostState = wizardHost({ relayCapability: { available: false, publicUrl: null } })
-    await act(async () => root.render(<LinearWizardBody agent={agent} host={hostState} />))
+    await render({ relayCapability: { available: false, publicUrl: null } })
 
     expect(text()).toContain('HTTP callbacks only')
-    expect(connectButton()).toBeUndefined()
+    expect(buttonWith('Connect Linear')).toBeUndefined()
   })
 
   it('reads a failed probe as no relay rather than as an answer it never got', async () => {
     mocks.probeFailed = true
-    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
+    await render()
     expect(text()).toContain('HTTP callbacks only')
-  })
-
-  it('offers the hand-off once a relay is connected, naming this agent as the default', async () => {
-    mocks.probeConfig = answered
-    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
-
-    expect(connectButton()).toBeDefined()
-    expect(text()).toContain('deploy-bot becomes its default agent')
   })
 
   it('self-disables when the deployment registered no Linear app', async () => {
@@ -146,22 +188,100 @@ describe('the Linear connect hand-off', () => {
     // deployment app to the console, so the pane learns it from the route.
     mocks.probeConfig = answered
     mocks.startLinearConnect.mockRejectedValue(new ApiError('not found', 404))
-    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
-    await act(async () => connectButton()!.click())
+    await render()
+    await act(async () => buttonWith('Connect Linear')!.click())
     await settle()
 
     expect(text()).toContain('isn’t set up on this deployment yet')
-    expect(connectButton()).toBeUndefined()
+  })
+})
+
+describe('the workspace picker', () => {
+  it('replaces the host identity chassis and its footer primary', async () => {
+    // The chassis asks "create an identity or reuse one" — a question Linear does not
+    // have. Hiding it is what keeps the mode cards, the free-bot list and the share
+    // toggle off a platform whose bot is a workspace.
+    mocks.probeConfig = answered
+    mocks.bots = [workspace()]
+    await render()
+
+    expect(identity?.hidden).toBe(true)
+    expect(footer?.hidden).toBe(true)
   })
 
-  it('opens the authorize URL and waits for the round trip', async () => {
+  it('lists the org’s connected workspaces by name, and nothing else', async () => {
     mocks.probeConfig = answered
-    mocks.startLinearConnect.mockResolvedValue({
-      id: 'c1',
-      connectUrl: 'https://linear.app/oauth/authorize?state=c1'
+    mocks.bots = [
+      workspace({ id: 'ws-1', workspaceName: 'Example Workspace' }),
+      workspace({ id: 'ws-2', workspaceName: 'Second Workspace' }),
+      // Another platform's bot is not this list's business.
+      workspace({ id: 'sl-1', platform: 'slack', name: 'acme', workspaceName: 'acme' })
+    ]
+    await render()
+
+    expect(text()).toContain('Example Workspace')
+    expect(text()).toContain('Second Workspace')
+    expect(text()).not.toContain('acme')
+  })
+
+  it('links this agent to the picked workspace and closes — one click, no footer step', async () => {
+    mocks.probeConfig = answered
+    mocks.bots = [workspace()]
+    const state = await render()
+    await act(async () => buttonWith('Example Workspace')!.click())
+    await settle()
+
+    expect(state.createIntegration).toHaveBeenCalledWith({
+      platform: 'linear',
+      agentId: 'agent-a',
+      botId: 'ws-1',
+      transport: 'http'
     })
-    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
-    await act(async () => connectButton()!.click())
+    expect(state.close).toHaveBeenCalled()
+  })
+
+  it('shows a workspace this agent already links as linked, and refuses to link it twice', async () => {
+    mocks.probeConfig = answered
+    mocks.bots = [workspace({ agentIds: ['agent-a', 'agent-b'] })]
+    const state = await render()
+
+    const row = buttonWith('Example Workspace')!
+    expect(row.textContent).toContain('linked')
+    expect(row.disabled).toBe(true)
+    await act(async () => row.click())
+    expect(state.createIntegration).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a refused link instead of closing on it', async () => {
+    mocks.probeConfig = answered
+    mocks.bots = [workspace()]
+    const state = await render({ createIntegration: vi.fn(async () => Promise.reject(new Error('bot is revoked'))) })
+    await act(async () => buttonWith('Example Workspace')!.click())
+    await settle()
+
+    expect(text()).toContain('bot is revoked')
+    expect(state.close).not.toHaveBeenCalled()
+  })
+})
+
+describe('the connect hand-off', () => {
+  it('lands on the hand-off when the org has connected none, and opens nothing unasked', async () => {
+    // Zero-config is "no fields", not "no button": the authorize tab is a popup, and a
+    // popup opened from an effect rather than from a click is blocked by default — a
+    // first run that would silently open nothing at all.
+    mocks.probeConfig = answered
+    await render()
+
+    expect(text()).toContain('There is nothing to fill in here')
+    expect(text()).toContain('becomes the workspace’s default agent')
+    expect(mocks.startLinearConnect).not.toHaveBeenCalled()
+    expect(window.open).not.toHaveBeenCalled()
+  })
+
+  it('opens the authorize tab from the operator’s own click', async () => {
+    mocks.probeConfig = answered
+    await render()
+    await act(async () => buttonWith('Connect Linear')!.click())
     await settle()
 
     expect(mocks.startLinearConnect).toHaveBeenCalledWith('agent-a')
@@ -173,49 +293,98 @@ describe('the Linear connect hand-off', () => {
     expect(text()).toContain('Waiting for Linear')
   })
 
-  it('closes the modal once the funnel row settles', async () => {
+  it('stays on the picker while the bot roster is still loading', async () => {
+    // An empty roster that has not answered yet is not "no workspaces" — landing on the
+    // hand-off would replace a picker the operator was one tick away from seeing.
     mocks.probeConfig = answered
-    mocks.startLinearConnect.mockResolvedValue({ id: 'c1', connectUrl: 'https://linear.app/oauth/authorize' })
+    mocks.loading = true
+    await render()
+
+    expect(text()).toContain('Pick the Linear workspace')
+    expect(buttonWith('Connect Linear')).toBeUndefined()
+  })
+
+  it('reaches the hand-off from the picker, still without starting one unasked', async () => {
+    mocks.probeConfig = answered
+    mocks.bots = [workspace()]
+    await render()
+    expect(mocks.startLinearConnect).not.toHaveBeenCalled()
+
+    await act(async () => buttonWith('Connect another workspace')!.click())
+    await settle()
+    expect(text()).toContain('There is nothing to fill in here')
+    expect(mocks.startLinearConnect).not.toHaveBeenCalled()
+
+    await act(async () => buttonWith('Connect Linear')!.click())
+    await settle()
+    expect(mocks.startLinearConnect).toHaveBeenCalledWith('agent-a')
+  })
+
+  it('goes back to the picker when there is one to go back to', async () => {
+    mocks.probeConfig = answered
+    mocks.bots = [workspace()]
+    const state = await render()
+    await act(async () => buttonWith('Connect another workspace')!.click())
+    await act(async () => buttonWith('Back')!.click())
+
+    expect(text()).toContain('Example Workspace')
+    expect(state.close).not.toHaveBeenCalled()
+  })
+
+  it('leaves the gate to the host footer when the hand-off is the whole pane', async () => {
+    // Nowhere to go back TO, and the modal chassis already renders its own Cancel — a
+    // second one beside the primary would be two words for one action.
+    mocks.probeConfig = answered
+    await render()
+
+    expect(buttonWith('Back')).toBeUndefined()
+    expect(buttonWith('Cancel')).toBeUndefined()
+  })
+
+  it('cancels a round trip in flight, closing the wizard it was the whole pane of', async () => {
+    mocks.probeConfig = answered
+    const state = await render()
+    await act(async () => buttonWith('Connect Linear')!.click())
+    await settle()
+    await act(async () => buttonWith('Cancel')!.click())
+
+    expect(state.close).toHaveBeenCalled()
+  })
+
+  it('names the settled success and the default agent it just made', async () => {
+    mocks.probeConfig = answered
     mocks.getLinearConnect.mockResolvedValue({ id: 'c1', status: 'completed', failureReason: null, botId: 'bot-9' })
-    const close = vi.fn()
-    const invalidate = vi.fn()
-    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost({ close, invalidate })} />))
-    await act(async () => connectButton()!.click())
+    // The refresh a completed round trip fires is what fills the roster in — the pane
+    // must stay on its terminal state instead of flipping to a picker behind it.
+    const state = await render({ invalidate: vi.fn(() => void (mocks.bots = [workspace()])) })
+    await act(async () => buttonWith('Connect Linear')!.click())
     await settle()
 
-    expect(invalidate).toHaveBeenCalled()
-    expect(close).toHaveBeenCalled()
+    expect(state.invalidate).toHaveBeenCalled()
+    expect(text()).toContain('Workspace connected')
+    expect(text()).toContain('is now its default agent')
+    await act(async () => buttonWith('Done')!.click())
+    expect(state.close).toHaveBeenCalled()
   })
 
   it('shows the settled row’s refusal — the throwaway tab has no other channel back', async () => {
     mocks.probeConfig = answered
-    mocks.startLinearConnect.mockResolvedValue({ id: 'c1', connectUrl: 'https://linear.app/oauth/authorize' })
     mocks.getLinearConnect.mockResolvedValue({
       id: 'c1',
       status: 'failed',
       failureReason: 'workspace_taken',
       botId: null
     })
-    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
-    await act(async () => connectButton()!.click())
+    await render()
+    await act(async () => buttonWith('Connect Linear')!.click())
     await settle()
 
     expect(text()).toContain('already connected to a different organization')
-    // Back to a clickable state rather than stuck waiting on a settled row.
-    expect(connectButton()).toBeDefined()
-  })
-
-  it('keeps the host’s create primary hidden — the pane commits with its own button', async () => {
-    mocks.probeConfig = answered
-    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost()} />))
-    expect(footer?.hidden).toBe(true)
-  })
-
-  it('explains membership rather than the funnel in reuse mode', async () => {
-    mocks.probeConfig = answered
-    await act(async () => root.render(<LinearWizardBody agent={agent} host={wizardHost({ mode: 'existing' })} />))
-
-    expect(connectButton()).toBeUndefined()
-    expect(text()).toContain('joins this workspace as a member')
+    // A settled failure is retryable rather than a dead end, and nothing restarts it
+    // behind the operator's back.
+    expect(mocks.startLinearConnect).toHaveBeenCalledTimes(1)
+    await act(async () => buttonWith('Try again')!.click())
+    await settle()
+    expect(mocks.startLinearConnect).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/web/src/components/console/platforms/linear/Body.tsx
+++ b/packages/web/src/components/console/platforms/linear/Body.tsx
@@ -1,41 +1,61 @@
 // No 'use client' here: rendered only inside ModalProvider's tree (the client boundary).
 
+import { useState, type ReactNode } from 'react'
 import { Icon } from '@/components/ui'
 import type { Agent } from '@/lib/data'
+import { useConsoleData } from '@/lib/data-context'
 import type { WizardHost } from '../contract'
 import { useDeploymentConfig } from '../deployment-config'
-import { usePublishedFooter } from '../publish'
+import { usePublishedFooter, usePublishedIdentityChrome } from '../publish'
 import { linearApi } from './api'
 import { linearConnectAvailability, useLinearConnect } from './connect'
+import { linearLinkInput } from './link'
 import { LinearMark } from './mark'
 
+// The pane's two button shapes. Literal class strings, never assembled — Tailwind's
+// scanner only sees full literals in the source text (STYLE.md §8).
+const PRIMARY =
+  'flex h-[46px] w-full items-center justify-center gap-[10px] rounded-[10px] border-0 bg-(--surface-inverse) font-sans text-[14px] font-semibold leading-normal text-white'
+const SECONDARY =
+  'flex h-8 flex-none cursor-pointer items-center rounded-[8px] border border-(--border-default) bg-(--surface-card) px-3 font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)'
+
 /**
- * Linear's pane — "enable this agent on a connected workspace"
+ * Linear's wizard pane — "which workspace does this agent work in?"
  * (linear-integration.md §4.3, §7.1).
  *
- * A Linear Bot row IS one connected workspace, and every agent on it is a member,
- * so the wizard's two modes split differently here than on the other platforms:
- * REUSE is the ordinary path (the host's free-bot list is the org's connected
- * workspaces, and its own footer commits the membership unfenced, §7.4), while
- * CREATE is a hand-off — there is nothing to paste, only an org-level OAuth round
- * trip that mints the workspace bot server-side.
+ * It REPLACES the host's identity chassis rather than filling a slot in it. The
+ * chassis asks a question Linear does not have: a Linear bot is not an identity you
+ * create with pasted credentials and then hand to one agent, it is a workspace the
+ * organization connected once, and every agent on it is a member. So the pane hides
+ * the mode cards, the free-bot list and the footer primary, and offers the two
+ * choices that do exist — link an already-connected workspace, or connect another.
  *
- * The pane commits through its own inline button, like the Feishu deeplink flow, so
- * the host's create primary stays hidden throughout.
+ * With none connected there is nothing to pick from, so the pane LANDS on the connect
+ * hand-off. It does not fire one: the authorize tab is a popup, and a popup opened
+ * from an effect rather than from a click is blocked by default in every major
+ * browser — a first run that silently opens nothing. Zero-config means no fields to
+ * fill, not no button to press.
  */
 export function LinearWizardBody({ agent, host }: { agent: Agent; host: WizardHost }) {
   // The chassis reads this same probe for its relay capability; one SWR key ⇒ one
   // request. Only the "has it answered yet" bit is read here — the VALUE comes off
   // the host, so the two can never disagree about the deployment.
   const probe = useDeploymentConfig(true)
-  const { invalidate, close } = host
+  const { bots, loading } = useConsoleData()
+  const { createIntegration, invalidate, close } = host
+  const [connecting, setConnecting] = useState(false)
+  const [connected, setConnected] = useState(false)
+  const [linkingBotId, setLinkingBotId] = useState<string | null>(null)
+  const [linkErr, setLinkErr] = useState<string | null>(null)
+
   const flow = useLinearConnect(
     () => linearApi.startConnect(agent.id),
     () => {
       invalidate()
-      close()
+      setConnected(true)
     }
   )
+  const { start, cancel } = flow
 
   // An answer WINS over a later error: a transient revalidation failure must not
   // retract a relay this pane already learned about (the Slack funnel's rule).
@@ -45,81 +65,212 @@ export function LinearWizardBody({ agent, host }: { agent: Agent; host: WizardHo
     appConfigured: flow.appMissing ? false : null
   })
 
-  // The commit is the pane's own button in every state, so the footer primary is
-  // suppressed rather than published — reuse mode has the host's own footer.
+  const workspaces = bots.filter((b) => b.platform === 'linear')
+  // No workspace to pick means no choice to present — the pane IS the connect
+  // hand-off then, and cancelling it leaves the wizard rather than an empty list.
+  const forcedConnect = !loading && workspaces.length === 0
+  // `connected` holds the pane on its terminal state: the refresh that lands with a
+  // completed round trip is exactly what would otherwise flip the roster from empty to
+  // one workspace and replace the success line with a picker.
+  const pane: 'picker' | 'connect' = connected || connecting || forcedConnect ? 'connect' : 'picker'
+
+  // The whole identity chassis is this pane's to replace: mode cards, free-bot list,
+  // the share toggle and the footer primary all describe a model Linear does not have.
+  usePublishedIdentityChrome(host, { hidden: true })
   usePublishedFooter(host, { label: 'Connect', enabled: false, onSubmit: () => {}, hidden: true })
 
-  if (host.mode === 'existing') {
-    return (
-      <div className="mb-4 flex items-start gap-[10px] rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-        <Icon name="info" size={15} className="mt-[1px] flex-none" />
-        <span>
-          {agent.name} joins this workspace as a member. Mention the app on an issue and name it —{' '}
-          <span className="mono">@{agent.name}</span>&#32;— to reach it; bare delegations go to the workspace&rsquo;s
-          default agent.
-        </span>
-      </div>
-    )
+  const link = (botId: string) => {
+    if (linkingBotId) return
+    setLinkingBotId(botId)
+    setLinkErr(null)
+    void (async () => {
+      try {
+        await createIntegration(linearLinkInput(agent.id, botId))
+        close()
+      } catch (e) {
+        setLinkErr(e instanceof Error ? e.message : String(e))
+        setLinkingBotId(null)
+      }
+    })()
   }
 
-  return (
-    <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">
-      {availability === 'checking' ? (
+  // Back from a pane the operator chose; from the forced one there is nowhere to go but
+  // out, and the host footer's own Cancel is what the gate leaves that job to.
+  const leaveConnect = () => {
+    cancel()
+    if (forcedConnect) close()
+    else setConnecting(false)
+  }
+
+  if (availability === 'checking') {
+    return (
+      <Frame>
         <div className="flex items-center gap-[10px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
           <Icon name="loader" size={15} className="flex-none animate-spin" />
           Checking your Linear setup…
         </div>
-      ) : availability === 'app_required' ? (
-        <div className="flex items-start gap-[10px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-          <Icon name="info" size={15} className="mt-[1px] flex-none" />
-          <span>
-            Linear isn&rsquo;t set up on this deployment yet. An administrator registers one Linear OAuth application
-            for the whole deployment before workspaces can be connected.
-          </span>
-        </div>
-      ) : availability === 'relay_required' ? (
-        <div className="flex items-start gap-[10px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
-          <Icon name="info" size={15} className="mt-[1px] flex-none" />
-          <span>
-            Linear delivers over HTTP callbacks only, so it needs a public callback endpoint. Ask an administrator to
-            configure one, then connect a workspace here.
-          </span>
-        </div>
-      ) : (
-        <>
-          <div className="mb-[10px] font-sans text-[12.5px] font-medium leading-[1.45] text-(--text-secondary)">
-            Connect a Linear workspace. {agent.name} becomes its default agent — the one a bare delegation starts a
-            session with.
-          </div>
-          {flow.phase === 'authorizing' ? (
-            <div className="flex h-[46px] w-full items-center justify-center gap-[10px] rounded-[10px] bg-(--surface-inverse) font-sans text-[14px] font-semibold leading-normal text-white opacity-85">
+      </Frame>
+    )
+  }
+
+  if (availability === 'app_required') {
+    return (
+      <Frame>
+        <Note>
+          Linear isn&rsquo;t set up on this deployment yet. An administrator registers one Linear OAuth application for
+          the whole deployment before workspaces can be connected.
+        </Note>
+      </Frame>
+    )
+  }
+
+  if (availability === 'relay_required') {
+    return (
+      <Frame>
+        <Note>
+          Linear delivers over HTTP callbacks only, so it needs a public callback endpoint. Ask an administrator to
+          configure one, then connect a workspace here.
+        </Note>
+      </Frame>
+    )
+  }
+
+  if (pane === 'connect') {
+    return (
+      <Frame>
+        {connected ? (
+          <>
+            <div className="flex items-start gap-[10px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
+              <Icon name="check" size={15} color="var(--status-online)" className="mt-[1px] flex-none" />
+              <span>
+                Workspace connected —&#32;<span className="mono">{agent.name}</span>&#32;is now its default agent, the
+                one a bare delegation starts a session with.
+              </span>
+            </div>
+            <button type="button" onClick={close} className={`${PRIMARY} mt-[12px] cursor-pointer`}>
+              Done
+            </button>
+          </>
+        ) : flow.err ? (
+          <>
+            <div className="flex items-start gap-[10px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--status-error)">
+              <Icon name="triangle-alert" size={15} className="mt-[1px] flex-none" />
+              <span>{flow.err}</span>
+            </div>
+            <div className="mt-[12px] flex items-center gap-2">
+              <button type="button" onClick={start} className={`${PRIMARY} cursor-pointer`}>
+                Try again
+              </button>
+              <button type="button" onClick={leaveConnect} className={SECONDARY}>
+                {forcedConnect ? 'Cancel' : 'Back'}
+              </button>
+            </div>
+          </>
+        ) : flow.phase === 'authorizing' ? (
+          <>
+            <div className={`${PRIMARY} opacity-85`}>
               <Icon name="loader" size={16} className="flex-none animate-spin" />
               Waiting for Linear…
             </div>
-          ) : (
-            <button
-              type="button"
-              onClick={flow.start}
-              className="flex h-[46px] w-full cursor-pointer items-center justify-center gap-[10px] rounded-[10px] border-0 bg-(--surface-inverse) font-sans text-[14px] font-semibold leading-normal text-white"
-            >
+            <div className="mt-[10px] flex items-center justify-between gap-2">
+              <span className="font-sans text-[12px] font-normal leading-[1.4] text-(--text-tertiary)">
+                Approve the workspace in the Linear tab.
+              </span>
+              <button type="button" onClick={leaveConnect} className={SECONDARY}>
+                Cancel
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="mb-[12px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
+              <span className="mono">{agent.name}</span>&#32;becomes the workspace&rsquo;s default agent — the one a
+              bare delegation starts a session with. There is nothing to fill in here: you approve the workspace in a
+              Linear popup.
+            </div>
+            {/* The popup opens from THIS click. Fired from an effect it is blocked. */}
+            <button type="button" onClick={start} className={`${PRIMARY} cursor-pointer`}>
               <span className="imark h-[18px] w-[18px] border-0 bg-transparent">
                 <LinearMark fillPct={100} />
               </span>
               Connect Linear
             </button>
-          )}
-          {flow.err && (
-            <div className="mt-2 font-sans text-[11.5px] font-normal leading-[1.4] text-(--status-error)">
-              {flow.err}
-            </div>
-          )}
-          <div className="mt-[10px] font-sans text-[12px] font-normal leading-[1.4] text-(--text-tertiary)">
-            {flow.phase === 'authorizing'
-              ? 'Approve the workspace in the Linear tab — this closes automatically once it lands.'
-              : 'Other agents join the same workspace later from their own Add integration.'}
-          </div>
-        </>
+            {!forcedConnect && (
+              <div className="mt-[10px] flex justify-end">
+                <button type="button" onClick={leaveConnect} className={SECONDARY}>
+                  Back
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </Frame>
+    )
+  }
+
+  return (
+    <div className="mb-4 overflow-hidden rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[6px]">
+      <div className="px-2 pb-[6px] pt-[5px] font-sans text-[12.5px] font-medium leading-[1.45] text-(--text-secondary)">
+        Pick the Linear workspace <span className="mono">{agent.name}</span> works in.
+      </div>
+      {workspaces.map((b) => {
+        const linked = b.agentIds.includes(agent.id)
+        return (
+          <button
+            key={b.id}
+            type="button"
+            disabled={linked || linkingBotId !== null}
+            title={linked ? 'Already linked to this agent' : b.workspaceName || b.name}
+            onClick={() => link(b.id)}
+            className={`fopt min-h-[42px] items-center gap-[10px] px-2 py-2 ${
+              linked || linkingBotId !== null ? 'cursor-default' : 'cursor-pointer'
+            } ${linked ? 'opacity-55' : ''}`}
+          >
+            <span className="imark h-4 w-4 flex-none border-0 bg-transparent">
+              <LinearMark fillPct={100} />
+            </span>
+            <span className="mono min-w-0 flex-1 truncate text-left text-[12.5px] font-semibold text-(--text-primary)">
+              {b.workspaceName || b.name}
+            </span>
+            {linked && <span className="badge flex-none bg-(--surface-active) text-(--text-tertiary)">linked</span>}
+            {linkingBotId === b.id && <Icon name="loader" size={14} className="flex-none animate-spin" />}
+          </button>
+        )
+      })}
+      <button
+        type="button"
+        disabled={linkingBotId !== null}
+        onClick={() => setConnecting(true)}
+        className={`fopt min-h-[42px] items-center gap-[10px] px-2 py-2 ${
+          linkingBotId !== null ? 'cursor-default opacity-55' : 'cursor-pointer'
+        }`}
+      >
+        <Icon name="plus" size={15} color="var(--text-tertiary)" className="flex-none" />
+        <span className="min-w-0 flex-1 truncate text-left font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+          Connect another workspace…
+        </span>
+      </button>
+      {linkErr && (
+        <div className="px-2 pb-[6px] pt-1 font-sans text-[11.5px] font-normal leading-[1.4] text-(--status-error)">
+          {linkErr}
+        </div>
       )}
+    </div>
+  )
+}
+
+/** The pane's own card, so every state sits in one box the wizard can measure. */
+function Frame({ children }: { children: ReactNode }) {
+  return (
+    <div className="mb-4 rounded-[9px] border border-(--border-subtle) bg-(--surface-app) p-[14px]">{children}</div>
+  )
+}
+
+function Note({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-start gap-[10px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)">
+      <Icon name="info" size={15} className="mt-[1px] flex-none" />
+      <span>{children}</span>
     </div>
   )
 }

--- a/packages/web/src/components/console/platforms/linear/api.ts
+++ b/packages/web/src/components/console/platforms/linear/api.ts
@@ -1,6 +1,7 @@
 // No 'use client' here: reached only from ModalProvider's tree (the client boundary).
 
 import {
+  disconnectLinearWorkspace,
   getLinearConnect,
   reconnectLinearWorkspace,
   startLinearConnect,
@@ -10,13 +11,15 @@ import {
 
 /**
  * The Linear module's own CP client surface ({@link WebPlatformModule.apiBindings}) —
- * the workspace connect funnel and its reconnect arm. OPAQUE to the chassis: the
- * wizard pane and the settings workspace card share this one client seam.
+ * the workspace connect funnel, its reconnect arm, and the org-wide disconnect.
+ * OPAQUE to the chassis: the wizard pane and the settings workspace card share this
+ * one client seam.
  */
 export const linearApi = {
   startConnect: startLinearConnect,
   getConnect: getLinearConnect,
-  reconnect: reconnectLinearWorkspace
+  reconnect: reconnectLinearWorkspace,
+  disconnect: disconnectLinearWorkspace
 }
 
 export type LinearApi = typeof linearApi

--- a/packages/web/src/components/console/platforms/linear/card.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/card.test.tsx
@@ -1,0 +1,251 @@
+// @vitest-environment happy-dom
+
+// The AGENT page's Linear card: one row per linked workspace, with its owner, a reconnect
+// and a way out. What must NOT be there matters as much: no trigger, no issue list, and no
+// Disconnect — that one ends the workspace for every agent, so it is the org view's.
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BotDto } from '@/lib/api'
+import type { Agent, IntegrationRow } from '@/lib/data'
+
+const mocks = vi.hoisted(() => ({
+  bots: [] as BotDto[],
+  agents: [] as Agent[],
+  setChannelAgent: vi.fn(),
+  deleteIntegration: vi.fn(),
+  refresh: vi.fn(),
+  reconnectLinearWorkspace: vi.fn(),
+  getLinearConnect: vi.fn()
+}))
+
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  reconnectLinearWorkspace: mocks.reconnectLinearWorkspace,
+  getLinearConnect: mocks.getLinearConnect
+}))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    get bots() {
+      return mocks.bots
+    },
+    getAgent: (id: string) => mocks.agents.find((a) => a.id === id),
+    setChannelAgent: mocks.setChannelAgent,
+    deleteIntegration: mocks.deleteIntegration,
+    refresh: mocks.refresh
+  })
+}))
+
+import { LinearWorkspaceRows } from './card'
+
+function bot(over: Partial<BotDto> = {}): BotDto {
+  return {
+    id: 'bot-9',
+    name: 'Example Workspace',
+    platform: 'linear',
+    prebuilt: false,
+    slackAppId: null,
+    discordAppId: null,
+    createdBy: null,
+    transport: 'http',
+    shareable: true,
+    inUseByAgentId: null,
+    agentIds: ['agent-a', 'agent-b'],
+    lastUsedAt: null,
+    freedFromAgent: null,
+    workspaceName: 'Example Workspace',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...over
+  }
+}
+
+/** The workspace's conversation row — the seeded `IntegrationChannel` the PATCH addresses. */
+function integration(over: Partial<IntegrationRow> = {}): IntegrationRow {
+  return {
+    id: 'int-a',
+    agentId: 'agent-a',
+    botId: 'bot-9',
+    shareable: true,
+    name: 'Example Workspace',
+    platform: 'linear',
+    kind: 'Workspace',
+    workspace: 'Example Workspace',
+    daemon: 'edge-1',
+    status: 'online',
+    agentCount: '2',
+    channels: [{ channelId: 'ws-1', name: 'Example Workspace', trigger: 'any', agentId: 'agent-b' }],
+    ...over
+  }
+}
+
+let host: HTMLDivElement
+let root: Root
+
+const text = () => host.textContent ?? ''
+const buttons = () => [...host.querySelectorAll('button')]
+const buttonWithLabel = (label: string) =>
+  buttons().find((b) => b.getAttribute('aria-label')?.includes(label)) as HTMLButtonElement | undefined
+const buttonWithTitle = (title: string) =>
+  buttons().find((b) => b.getAttribute('title')?.includes(title)) as HTMLButtonElement | undefined
+
+async function settle(): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  }
+}
+
+async function render(row: IntegrationRow = integration()): Promise<void> {
+  await act(async () => root.render(<LinearWorkspaceRows integration={row} padX={14} />))
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  mocks.bots = [bot()]
+  mocks.agents = [
+    { id: 'agent-a', name: 'deploy-bot', runtime: 'claude' },
+    { id: 'agent-b', name: 'triage-bot', runtime: 'codex' }
+  ] as unknown as Agent[]
+  mocks.setChannelAgent.mockReset()
+  mocks.deleteIntegration.mockReset()
+  mocks.refresh.mockReset()
+  mocks.reconnectLinearWorkspace.mockReset()
+  mocks.getLinearConnect.mockReset()
+  mocks.setChannelAgent.mockResolvedValue(undefined)
+  mocks.deleteIntegration.mockResolvedValue(undefined)
+  mocks.getLinearConnect.mockResolvedValue({ id: 'c1', status: 'pending', failureReason: null, botId: null })
+  vi.stubGlobal(
+    'open',
+    vi.fn(() => null)
+  )
+  vi.stubGlobal(
+    'confirm',
+    vi.fn(() => true)
+  )
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+  vi.unstubAllGlobals()
+})
+
+describe('the workspace row', () => {
+  it('names the workspace and says where sessions come from — no issue list, no trigger', async () => {
+    await render()
+
+    expect(text()).toContain('Example Workspace')
+    expect(text()).toContain('Sessions start when someone delegates or mentions the app on an issue in this workspace.')
+    // Linking is the consent act and unlinking is the mute, so no trigger belongs here.
+    expect(text()).not.toContain('@-mention')
+    expect(buttonWithLabel('Trigger for')).toBeUndefined()
+  })
+
+  it('never offers Disconnect — that removes the workspace for every agent', async () => {
+    await render()
+
+    expect(text()).not.toContain('Disconnect')
+    expect(buttonWithLabel('Disconnect this workspace')).toBeUndefined()
+  })
+})
+
+describe('the default-dispatch selector', () => {
+  it('reads the workspace’s current owner off the ordinary conversation row', async () => {
+    await render()
+
+    // The owner the CP stamped, not this agent just because it is the page's.
+    expect(buttonWithTitle('Default dispatch')?.textContent).toContain('triage-bot')
+  })
+
+  it('drives the existing conversation-owner PATCH, addressed to the workspace row', async () => {
+    await render()
+    await act(async () => buttonWithTitle('Default dispatch')!.click())
+    const option = buttons().find((b) => b.textContent?.includes('deploy-bot'))!
+    await act(async () => option.click())
+    await settle()
+
+    expect(mocks.setChannelAgent).toHaveBeenCalledWith('int-a', 'ws-1', 'agent-a')
+  })
+
+  it('offers every member of the workspace as a candidate owner', async () => {
+    await render()
+    await act(async () => buttonWithTitle('Default dispatch')!.click())
+
+    expect(buttons().filter((b) => b.textContent?.includes('deploy-bot')).length).toBeGreaterThan(0)
+    expect(buttons().filter((b) => b.textContent?.includes('triage-bot')).length).toBeGreaterThan(0)
+  })
+
+  it('falls back to the earliest member, inert, until the conversation row is seeded', async () => {
+    // An install reporting no seeded row has no address to PATCH, so the selector is inert.
+    await render(integration({ channels: [] }))
+
+    expect(text()).toContain('Example Workspace')
+    const picker = buttonWithTitle('Default dispatch')!
+    expect(picker.textContent).toContain('deploy-bot')
+    await act(async () => picker.click())
+    expect(buttons().filter((b) => b.textContent?.includes('triage-bot'))).toHaveLength(0)
+  })
+})
+
+describe('the row’s repairs', () => {
+  it('reconnects THIS workspace and says the tab is open', async () => {
+    mocks.reconnectLinearWorkspace.mockResolvedValue({ id: 'c1', connectUrl: 'https://linear.app/oauth/authorize' })
+    await render()
+    await act(async () => buttonWithLabel('Reconnect this workspace')!.click())
+    await settle()
+
+    expect(mocks.reconnectLinearWorkspace).toHaveBeenCalledWith('bot-9')
+    expect(text()).toContain('Approve the workspace in the Linear tab')
+  })
+
+  it('warns on the row while the grant is dead', async () => {
+    mocks.bots = [bot({ revokedAt: '2026-02-01T00:00:00.000Z' })]
+    await render()
+
+    expect(text()).toContain('grant expired')
+    expect(buttonWithLabel('Reconnect this workspace')?.className).toContain('border-(--status-error)')
+  })
+
+  it('surfaces a funnel that cannot start', async () => {
+    mocks.reconnectLinearWorkspace.mockRejectedValue(new Error('no relay is connected'))
+    await render()
+    await act(async () => buttonWithLabel('Reconnect this workspace')!.click())
+    await settle()
+
+    expect(text()).toContain('no relay is connected')
+  })
+
+  it('unlinks through the generic integration delete, after confirming', async () => {
+    await render()
+    await act(async () => buttonWithLabel('Remove Example Workspace from this agent')!.click())
+    await settle()
+
+    expect(window.confirm).toHaveBeenCalled()
+    expect(mocks.deleteIntegration).toHaveBeenCalledWith('int-a')
+  })
+
+  it('does nothing when the unlink is not confirmed', async () => {
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => false)
+    )
+    await render()
+    await act(async () => buttonWithLabel('Remove Example Workspace from this agent')!.click())
+
+    expect(mocks.deleteIntegration).not.toHaveBeenCalled()
+  })
+
+  it('shows a refused unlink instead of leaving the row looking gone', async () => {
+    mocks.deleteIntegration.mockRejectedValue(new Error('daemon is offline'))
+    await render()
+    await act(async () => buttonWithLabel('Remove Example Workspace from this agent')!.click())
+    await settle()
+
+    expect(text()).toContain('daemon is offline')
+  })
+})

--- a/packages/web/src/components/console/platforms/linear/card.tsx
+++ b/packages/web/src/components/console/platforms/linear/card.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+// The AGENT page's Linear card body ({@link WebAgentIntegrationCardFacet}). Linking is the
+// consent act and unlinking is the mute, so the row carries no trigger and no issue list.
+// Disconnecting ends the workspace for every agent, so that action is the org view's.
+
+import { useState } from 'react'
+import { Icon } from '@/components/ui'
+import { DefaultDispatchPicker } from '@/components/console/DefaultDispatchPicker'
+import { agentLabel, type IntegrationRow } from '@/lib/data'
+import { useConsoleData } from '@/lib/data-context'
+import { linearApi } from './api'
+import { useLinearConnect } from './connect'
+
+export function LinearWorkspaceRows({ integration, padX }: { integration: IntegrationRow; padX: number }) {
+  const { bots, getAgent, setChannelAgent, deleteIntegration, refresh } = useConsoleData()
+  const [err, setErr] = useState<string | null>(null)
+  const [leaving, setLeaving] = useState(false)
+  const botId = integration.botId ?? ''
+  const bot = bots.find((b) => b.id === botId)
+  const flow = useLinearConnect(
+    () => linearApi.reconnect(botId),
+    () => void refresh()
+  )
+
+  // The seeded workspace row: the default rides the same PATCH a Slack row makes.
+  const channel = integration.channels[0]
+  const memberIds = bot?.agentIds ?? []
+  const options = memberIds.map((id) => {
+    const a = getAgent(id)
+    return {
+      id,
+      name: a ? agentLabel(a) : id,
+      model: a?.model || a?.runtime || '',
+      runtime: a?.runtime || a?.model || '',
+      icon: a?.icon
+    }
+  })
+  // The CP-stamped owner; unclaimed falls back to the earliest member, as the CP does.
+  const owner = channel?.agentId ?? memberIds[0] ?? null
+  const name = bot?.workspaceName || bot?.name || integration.name
+  const dead = !!bot?.revokedAt
+  const reconnecting = flow.phase === 'authorizing'
+  const connectErr = flow.appMissing ? 'Linear isn’t set up on this deployment.' : flow.err
+
+  const unlink = () => {
+    if (leaving || !integration.id) return
+    if (!window.confirm(`Remove ${name} from this agent? It stays connected for the organization's other agents.`)) {
+      return
+    }
+    setLeaving(true)
+    setErr(null)
+    void (async () => {
+      try {
+        await deleteIntegration(integration.id!)
+      } catch (cause) {
+        setErr(cause instanceof Error ? cause.message : String(cause))
+        setLeaving(false)
+      }
+    })()
+  }
+
+  return (
+    <>
+      {(err || connectErr) && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 border-t border-(--border-subtle) bg-(--surface-sunken) font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)"
+          style={{ padding: `9px ${padX}px` }}
+        >
+          <Icon name="triangle-alert" size={13} className="mt-[2px] flex-none" />
+          <span>{err ?? connectErr}</span>
+        </div>
+      )}
+      <div
+        className="flex flex-wrap items-center gap-x-[10px] gap-y-2 border-t border-(--border-subtle) bg-(--surface-app)"
+        style={{ padding: `10px ${padX}px` }}
+      >
+        <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)" title={name}>
+          {name}
+        </span>
+        {dead && <span className="badge flex-none bg-(--status-error-soft) text-(--status-error)">grant expired</span>}
+        <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-start">
+          {options.length > 0 && (
+            <>
+              <DefaultDispatchPicker
+                options={options}
+                activeId={owner}
+                disabled={!integration.id || !channel}
+                onPick={(id) => setChannelAgent(integration.id!, channel!.channelId, id)}
+              />
+              <span className="hidden h-[18px] w-px flex-none bg-(--border-subtle) desktop:block" />
+            </>
+          )}
+          <button
+            type="button"
+            disabled={reconnecting || !botId}
+            title={reconnecting ? 'Waiting for Linear…' : 'Reconnect this workspace'}
+            aria-label="Reconnect this workspace"
+            onClick={flow.start}
+            className={`iconbtn h-7 w-7 flex-none ${dead ? 'border-(--status-error) text-(--status-error)' : ''} ${
+              reconnecting ? 'cursor-default opacity-55' : 'cursor-pointer'
+            }`}
+          >
+            <Icon
+              name={reconnecting ? 'loader' : 'refresh-cw'}
+              size={13}
+              className={reconnecting ? 'animate-spin' : ''}
+            />
+          </button>
+          <button
+            type="button"
+            disabled={leaving || !integration.id}
+            title="Remove this workspace from this agent"
+            aria-label={`Remove ${name} from this agent`}
+            onClick={unlink}
+            className={`iconbtn h-7 w-7 flex-none ${leaving ? 'cursor-default opacity-60' : 'cursor-pointer'}`}
+          >
+            <Icon name="x" size={14} color="var(--text-tertiary)" />
+          </button>
+        </div>
+      </div>
+      <div
+        className="flex items-start gap-2 border-t border-(--border-subtle) bg-(--surface-app) font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)"
+        style={{ padding: `10px ${padX}px` }}
+      >
+        <Icon name="info" size={14} className="mt-[3px] flex-none" />
+        <span>
+          Sessions start when someone delegates or mentions the app on an issue in this workspace.
+          {reconnecting && ' Approve the workspace in the Linear tab — this card updates once it lands.'}
+        </span>
+      </div>
+    </>
+  )
+}

--- a/packages/web/src/components/console/platforms/linear/connect.ts
+++ b/packages/web/src/components/console/platforms/linear/connect.ts
@@ -67,6 +67,10 @@ export interface LinearConnectFlow {
    *  {@link linearConnectAvailability}). */
   appMissing: boolean
   start(): void
+  /** Abandon a round trip the operator no longer wants. The funnel row is left to
+   *  its TTL — the nonce is one-shot, so the abandoned tab can still only settle
+   *  the row it was minted for. */
+  cancel(): void
   clearError(): void
 }
 
@@ -101,6 +105,18 @@ export function useLinearConnect(
   }, [])
 
   const clearError = useCallback(() => setErr(null), [])
+
+  // Cancel closes the tab we opened as well: leaving an orphan authorize page behind
+  // is how an operator re-approves into a round trip nothing is polling any more.
+  const cancel = useCallback(() => {
+    try {
+      popup.current?.close()
+    } catch {
+      // a cross-origin popup may refuse; the round trip is dropped either way
+    }
+    reset()
+    setErr(null)
+  }, [reset])
 
   const start = useCallback(() => {
     if (busy.current) return
@@ -162,5 +178,5 @@ export function useLinearConnect(
     }
   }, [connectId, phase, reset])
 
-  return { phase, err, appMissing, start, clearError }
+  return { phase, err, appMissing, start, cancel, clearError }
 }

--- a/packages/web/src/components/console/platforms/linear/index.tsx
+++ b/packages/web/src/components/console/platforms/linear/index.tsx
@@ -3,6 +3,8 @@
 import type { WebPlatformModule } from '../contract'
 import { linearApi, type LinearApi } from './api'
 import { LinearWizardBody } from './Body'
+import { LinearWorkspaceRows } from './card'
+import { linearLinkInput } from './link'
 import { LinearMark } from './mark'
 import { linearSettingsFragments } from './settings'
 
@@ -22,14 +24,7 @@ export const linearModule: WebPlatformModule<LinearApi> = {
      * predicate already drops revoked rows and other platforms'.
      */
     freeBotFilter: () => true,
-    buildReuseInput: (bot, ctx) => ({
-      platform: 'linear',
-      agentId: ctx.agentId,
-      botId: bot.id,
-      // Linear offers no dial-out transport, so a workspace bot is only ever http
-      // (§4.2); the CP treats the durable bot row as authoritative either way.
-      transport: 'http'
-    }),
+    buildReuseInput: (bot, ctx) => linearLinkInput(ctx.agentId, bot.id),
     affordances: {
       // No transport CHOICE: `http` is the platform's single fixed transport, which
       // is a different thing from offering two (contract: absent ⇒ fixed).
@@ -38,6 +33,8 @@ export const linearModule: WebPlatformModule<LinearApi> = {
       // while neither the wizard nor Settings offers a flag to move.
       share: 'fixed'
     },
+    // The pane replaces the identity chassis outright, so these two never render for
+    // Linear; the contract requires them of every module and they stay honest copy.
     identityCards: () => ({ create: 'Connect a Linear workspace', existing: 'A connected Linear workspace' }),
     // Not `inviteBotHint`: nobody invites the app to an issue. A Linear session starts
     // by delegating the issue to the app or mentioning it, and neither is an invite.
@@ -45,17 +42,12 @@ export const linearModule: WebPlatformModule<LinearApi> = {
   },
   settingsFragments: linearSettingsFragments,
   apiBindings: linearApi,
-  channelList: {
-    // A Linear issue is the room: several agents bind to it, one session each.
-    roomNoun: 'issue',
-    // Issues are titled, not `#name`-prefixed — the row shows the bare title.
-    roomGlyph: '',
-    // No console-driven leave: an issue's agent sessions end in Linear, and the app
-    // is removed from the workspace by disconnecting it here instead.
-    leave: 'none',
-    cannotLeaveRowHint: 'The app stays on the issue — end the agent session in Linear for that.',
-    footerNote: 'An issue lands here when the app is delegated to it or mentioned on it.'
-  },
+  // NO `channelList`. The generic list enumerates rooms a bot was added to, each with
+  // a trigger and a way out; a Linear workspace has none of those — linking is the
+  // consent act and unlinking is how an agent goes quiet — and its issues are not a
+  // roster the console keeps. The card body below renders the workspace instead, so
+  // the generic list is never reached and its semantics would describe nothing.
+  agentCard: { Body: LinearWorkspaceRows },
   // Agent activities are append-only rows with their own ids (§15), so a duplicate
   // across sources is the same activity; anything else never dedupes.
   messageIdentity: (row) => (LINEAR_ACTIVITY_ID.test(row.ts) ? `ts:${row.ts}` : null),

--- a/packages/web/src/components/console/platforms/linear/link.ts
+++ b/packages/web/src/components/console/platforms/linear/link.ts
@@ -1,0 +1,10 @@
+// No 'use client' here: a pure input builder, imported from both client trees.
+
+import type { CreateIntegrationInput } from '@/lib/api'
+
+/** Link one agent to an already-connected workspace — Linear's only create shape (§7.1):
+ *  the OAuth callback minted the bot, so no credentials, and no transport but `http`.
+ *  One builder for `buildReuseInput` and the pane that commits a pick itself. */
+export function linearLinkInput(agentId: string, botId: string): CreateIntegrationInput {
+  return { platform: 'linear', agentId, botId, transport: 'http' }
+}

--- a/packages/web/src/components/console/platforms/linear/module.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/module.test.tsx
@@ -8,8 +8,10 @@ import { describe, expect, it } from 'vitest'
 import { PLATFORM_MARK_IDS } from '../marks'
 import { BOT_PLATFORMS, INTEGRATION_BLURB, isCoreTriggerKind } from '../host-projections'
 import {
+  DEFAULT_CHANNEL_LIST,
   botSharingEditable,
   channelListSemantics,
+  platformAgentCard,
   platformRegistry,
   platformSharingFixed,
   platformSupportsSharing
@@ -63,15 +65,29 @@ describe('the linear mark', () => {
   })
 })
 
-describe('the linear transcript and channel semantics', () => {
-  it('calls a room an issue and offers no leave affordance', () => {
-    const semantics = channelListSemantics('linear')
-    expect(semantics.roomNoun).toBe('issue')
-    expect(semantics.roomGlyph).toBe('')
-    expect(semantics.leave).toBe('none')
-    // Nobody is shown out of an issue from here, so the row hint names where the
-    // session actually ends instead of pointing at a control that does not exist.
-    expect(semantics.cannotLeaveRowHint).toContain('end the agent session in Linear')
+describe('the linear transcript and card semantics', () => {
+  it('declares NO channel list, and its own agent-card body instead', () => {
+    // The generic list enumerates rooms a bot was added to, each with a trigger and a
+    // way out. A Linear workspace has none of those, and its issues are not a roster
+    // the console keeps — so the module renders the workspace itself and the list is
+    // never reached. Declaring semantics for it would describe a list that must not
+    // exist; absence is the declaration.
+    expect(linearModule.channelList).toBeUndefined()
+    expect(linearModule.agentCard?.Body).toBeDefined()
+    expect(platformAgentCard('linear')?.Body).toBe(linearModule.agentCard?.Body)
+    // Falling back to the host defaults is what "never rendered" looks like from the
+    // lookup's side — no borrowed noun, no invented issue vocabulary.
+    expect(channelListSemantics('linear')).toEqual(DEFAULT_CHANNEL_LIST)
+  })
+
+  it('is the only module that replaces the agent card', () => {
+    const withOwnCard = platformRegistry.all().filter((m) => m.agentCard)
+    expect(withOwnCard.map((m) => m.platformId)).toEqual(['linear'])
+    // Every other platform keeps the generic list, so each still declares — or
+    // defaults — its own room semantics.
+    for (const m of platformRegistry.all()) {
+      if (m.platformId !== 'linear') expect(platformAgentCard(m.platformId), m.platformId).toBeUndefined()
+    }
   })
 
   it('dedupes on an agent-activity id and on nothing else', () => {

--- a/packages/web/src/components/console/platforms/linear/module.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/module.test.tsx
@@ -106,8 +106,10 @@ describe('the linear transcript and card semantics', () => {
 })
 
 describe('the linear api bindings', () => {
-  it('names the funnel and its reconnect arm — and nothing else', () => {
-    expect(Object.keys(linearApi).sort()).toEqual(['getConnect', 'reconnect', 'startConnect'])
+  it('names the funnel, its reconnect arm and the org-wide disconnect — and nothing else', () => {
+    // `disconnect` is a route rather than a client loop because the membership list the
+    // console could loop over is visibility-filtered; only the server sees every member.
+    expect(Object.keys(linearApi).sort()).toEqual(['disconnect', 'getConnect', 'reconnect', 'startConnect'])
     expect(module().apiBindings).toBe(linearApi)
   })
 })

--- a/packages/web/src/components/console/platforms/linear/settings.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/settings.test.tsx
@@ -9,30 +9,30 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BotDto } from '@/lib/api'
-import type { IntegrationRow } from '@/lib/data'
 
 const mocks = vi.hoisted(() => ({
   reconnectLinearWorkspace: vi.fn(),
   getLinearConnect: vi.fn(),
+  disconnectLinearWorkspace: vi.fn(),
   refresh: vi.fn(),
   deleteIntegration: vi.fn(),
-  deleteBot: vi.fn(),
-  integrations: [] as IntegrationRow[]
+  deleteBot: vi.fn()
 }))
 
 vi.mock('@/lib/api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/api')>()),
   reconnectLinearWorkspace: mocks.reconnectLinearWorkspace,
-  getLinearConnect: mocks.getLinearConnect
+  getLinearConnect: mocks.getLinearConnect,
+  disconnectLinearWorkspace: mocks.disconnectLinearWorkspace
 }))
+// The piecewise teardown members stay on the mock so a test can catch the console
+// reaching for them: enumerating memberships client-side is exactly the bug this
+// dialog was rewritten to remove.
 vi.mock('@/lib/data-context', () => ({
   useConsoleData: () => ({
     refresh: mocks.refresh,
     deleteIntegration: mocks.deleteIntegration,
-    deleteBot: mocks.deleteBot,
-    get integrations() {
-      return mocks.integrations
-    }
+    deleteBot: mocks.deleteBot
   })
 }))
 
@@ -99,9 +99,8 @@ beforeEach(() => {
   mocks.refresh.mockReset()
   mocks.deleteIntegration.mockReset()
   mocks.deleteBot.mockReset()
-  mocks.deleteIntegration.mockResolvedValue(undefined)
-  mocks.deleteBot.mockResolvedValue(undefined)
-  mocks.integrations = []
+  mocks.disconnectLinearWorkspace.mockReset()
+  mocks.disconnectLinearWorkspace.mockResolvedValue(undefined)
   mocks.getLinearConnect.mockResolvedValue({ id: 'c1', status: 'pending', failureReason: null, botId: null })
   vi.stubGlobal(
     'open',
@@ -171,40 +170,42 @@ describe('disconnecting a workspace', () => {
     await act(async () => buttonWithLabel('Disconnect this workspace')!.click())
   }
 
-  it('confirms first, naming the consequence for every member', async () => {
+  it('confirms first, naming the consequence for every member — the invisible ones too', async () => {
     await openDialog()
 
     expect(text()).toContain('Disconnect workspace')
     expect(text()).toContain('all 2 agents that use it')
     expect(text()).toContain('forgets its Linear grant')
-    expect(mocks.deleteBot).not.toHaveBeenCalled()
+    expect(text()).toContain('Agents you cannot see are removed too')
+    expect(mocks.disconnectLinearWorkspace).not.toHaveBeenCalled()
   })
 
-  it('lifts every membership before the bot delete the CP would otherwise refuse', async () => {
-    // `DELETE /bots/:id` 409s while any agent is installed, so the memberships go
-    // first — in the order the dialog's own sentence describes.
-    mocks.integrations = [
-      { id: 'int-a', botId: 'bot-9' },
-      { id: 'int-b', botId: 'bot-9' },
-      { id: 'int-other', botId: 'bot-other' }
-    ] as unknown as IntegrationRow[]
+  it('tears the workspace down in ONE server call, never a client loop', async () => {
+    // `GET /integrations` is visibility-filtered, so a membership on an agent outside
+    // the caller's audience is not in the list a loop would walk — it would lift what
+    // it can see, the bot delete behind it would refuse on the hidden one, and the
+    // operator would be told a full disconnect happened. Only the server holds the
+    // authoritative member set, so only the server may spend it.
     await openDialog()
     await act(async () => buttonWithText('Disconnect')!.click())
     await settle()
 
-    expect(mocks.deleteIntegration.mock.calls.map(([id]) => id)).toEqual(['int-a', 'int-b'])
-    expect(mocks.deleteBot).toHaveBeenCalledWith('bot-9')
+    expect(mocks.disconnectLinearWorkspace).toHaveBeenCalledWith('bot-9')
+    expect(mocks.deleteIntegration).not.toHaveBeenCalled()
+    expect(mocks.deleteBot).not.toHaveBeenCalled()
+    expect(mocks.refresh).toHaveBeenCalled()
   })
 
-  it('stops on a refused membership rather than firing the delete behind it', async () => {
-    mocks.integrations = [{ id: 'int-a', botId: 'bot-9' }] as unknown as IntegrationRow[]
-    mocks.deleteIntegration.mockRejectedValue(new Error('daemon is offline'))
+  it('renders a partial teardown as the refusal it is, keeping the dialog open', async () => {
+    mocks.disconnectLinearWorkspace.mockRejectedValue(
+      new Error('disconnect stopped partway: 1 of 2 agents are still linked to this workspace — retry the disconnect')
+    )
     await openDialog()
     await act(async () => buttonWithText('Disconnect')!.click())
     await settle()
 
-    expect(text()).toContain('daemon is offline')
-    expect(mocks.deleteBot).not.toHaveBeenCalled()
+    expect(text()).toContain('1 of 2 agents are still linked')
+    expect(text()).toContain('Disconnect workspace')
   })
 
   it('closes without touching anything on cancel', async () => {
@@ -212,7 +213,6 @@ describe('disconnecting a workspace', () => {
     await act(async () => buttonWithText('Cancel')!.click())
 
     expect(text()).toBe('')
-    expect(mocks.deleteIntegration).not.toHaveBeenCalled()
-    expect(mocks.deleteBot).not.toHaveBeenCalled()
+    expect(mocks.disconnectLinearWorkspace).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/console/platforms/linear/settings.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/settings.test.tsx
@@ -1,18 +1,23 @@
 // @vitest-environment happy-dom
 
-// The workspace card (§7.4). Two states it has to get right: a live workspace, whose
-// reconnect CTA is offered anyway, and a dead grant whose repair is the reconnect
-// funnel — bound to that workspace and never to the org-level connect.
+// The org Bots view's Linear fragments (§7.4). The row carries the two actions that
+// belong to the workspace rather than to any one agent: reconnect the grant, and
+// disconnect it for the whole organization — the second of which the agent's own card
+// deliberately does not offer.
 
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BotDto } from '@/lib/api'
+import type { IntegrationRow } from '@/lib/data'
 
 const mocks = vi.hoisted(() => ({
   reconnectLinearWorkspace: vi.fn(),
   getLinearConnect: vi.fn(),
-  refresh: vi.fn()
+  refresh: vi.fn(),
+  deleteIntegration: vi.fn(),
+  deleteBot: vi.fn(),
+  integrations: [] as IntegrationRow[]
 }))
 
 vi.mock('@/lib/api', async (importOriginal) => ({
@@ -21,7 +26,14 @@ vi.mock('@/lib/api', async (importOriginal) => ({
   getLinearConnect: mocks.getLinearConnect
 }))
 vi.mock('@/lib/data-context', () => ({
-  useConsoleData: () => ({ refresh: mocks.refresh })
+  useConsoleData: () => ({
+    refresh: mocks.refresh,
+    deleteIntegration: mocks.deleteIntegration,
+    deleteBot: mocks.deleteBot,
+    get integrations() {
+      return mocks.integrations
+    }
+  })
 }))
 
 import { linearSettingsFragments } from './settings'
@@ -58,6 +70,8 @@ const text = () => host.textContent ?? ''
 const buttons = () => [...host.querySelectorAll('button')]
 const buttonWithLabel = (label: string) =>
   buttons().find((b) => b.getAttribute('aria-label')?.includes(label)) as HTMLButtonElement | undefined
+const buttonWithText = (label: string) =>
+  buttons().find((b) => b.textContent?.includes(label)) as HTMLButtonElement | undefined
 
 async function settle(): Promise<void> {
   for (let attempt = 0; attempt < 10; attempt += 1) {
@@ -67,11 +81,11 @@ async function settle(): Promise<void> {
   }
 }
 
-async function renderCard(row: BotDto): Promise<void> {
+async function renderCard(row: BotDto, canWrite = true): Promise<void> {
   await act(async () =>
     root.render(
       <CardProvider>
-        <RowActions bot={row} canWrite />
+        <RowActions bot={row} canWrite={canWrite} />
         <CardNotice bot={row} />
       </CardProvider>
     )
@@ -83,6 +97,11 @@ beforeEach(() => {
   mocks.reconnectLinearWorkspace.mockReset()
   mocks.getLinearConnect.mockReset()
   mocks.refresh.mockReset()
+  mocks.deleteIntegration.mockReset()
+  mocks.deleteBot.mockReset()
+  mocks.deleteIntegration.mockResolvedValue(undefined)
+  mocks.deleteBot.mockResolvedValue(undefined)
+  mocks.integrations = []
   mocks.getLinearConnect.mockResolvedValue({ id: 'c1', status: 'pending', failureReason: null, botId: null })
   vi.stubGlobal(
     'open',
@@ -99,29 +118,28 @@ afterEach(async () => {
   vi.unstubAllGlobals()
 })
 
-describe('the workspace card, live', () => {
-  it('shows the workspace and its connect status', async () => {
+describe('the workspace row’s lifecycle actions', () => {
+  it('offers reconnect and disconnect, and stays quiet otherwise', async () => {
     await renderCard(bot())
 
-    expect(text()).toContain('connected')
-    expect(text()).toContain('Example Workspace')
-  })
-
-  it('offers the reconnect CTA on a healthy workspace too — a silent one keeps a valid token', async () => {
-    // §15: enabling agent session events raises a new scope, and until every prior
-    // authorization re-consents the workspace receives nothing while looking fine.
-    await renderCard(bot())
-    expect(text()).toContain('Reconnect to re-consent')
     expect(buttonWithLabel('Reconnect this workspace')).toBeDefined()
+    expect(buttonWithLabel('Disconnect this workspace')).toBeDefined()
+    // A healthy workspace gets no standing band: the row already carries its state,
+    // and a permanent "delegations not arriving?" note reads as a problem report.
+    expect(text()).toBe('')
   })
-})
 
-describe('the workspace card, dead grant', () => {
-  it('says the grant expired and points at the reconnect', async () => {
+  it('gives a viewer neither write action', async () => {
+    await renderCard(bot(), false)
+
+    expect(buttonWithLabel('Reconnect this workspace')?.disabled).toBe(true)
+    expect(buttonWithLabel('Disconnect this workspace')).toBeUndefined()
+  })
+
+  it('haloes reconnect while the grant is known dead', async () => {
     await renderCard(bot({ revokedAt: '2026-02-01T00:00:00.000Z' }))
 
-    expect(text()).toContain('grant expired')
-    expect(text()).toContain('reconnect to restore delivery')
+    expect(buttonWithLabel('Reconnect this workspace')?.className).toContain('border-(--status-error)')
   })
 
   it('restarts the funnel against THIS workspace, never the org-level connect', async () => {
@@ -144,5 +162,57 @@ describe('the workspace card, dead grant', () => {
     await settle()
 
     expect(text()).toContain('no relay is connected')
+  })
+})
+
+describe('disconnecting a workspace', () => {
+  const openDialog = async (row: BotDto = bot()) => {
+    await renderCard(row)
+    await act(async () => buttonWithLabel('Disconnect this workspace')!.click())
+  }
+
+  it('confirms first, naming the consequence for every member', async () => {
+    await openDialog()
+
+    expect(text()).toContain('Disconnect workspace')
+    expect(text()).toContain('all 2 agents that use it')
+    expect(text()).toContain('forgets its Linear grant')
+    expect(mocks.deleteBot).not.toHaveBeenCalled()
+  })
+
+  it('lifts every membership before the bot delete the CP would otherwise refuse', async () => {
+    // `DELETE /bots/:id` 409s while any agent is installed, so the memberships go
+    // first — in the order the dialog's own sentence describes.
+    mocks.integrations = [
+      { id: 'int-a', botId: 'bot-9' },
+      { id: 'int-b', botId: 'bot-9' },
+      { id: 'int-other', botId: 'bot-other' }
+    ] as unknown as IntegrationRow[]
+    await openDialog()
+    await act(async () => buttonWithText('Disconnect')!.click())
+    await settle()
+
+    expect(mocks.deleteIntegration.mock.calls.map(([id]) => id)).toEqual(['int-a', 'int-b'])
+    expect(mocks.deleteBot).toHaveBeenCalledWith('bot-9')
+  })
+
+  it('stops on a refused membership rather than firing the delete behind it', async () => {
+    mocks.integrations = [{ id: 'int-a', botId: 'bot-9' }] as unknown as IntegrationRow[]
+    mocks.deleteIntegration.mockRejectedValue(new Error('daemon is offline'))
+    await openDialog()
+    await act(async () => buttonWithText('Disconnect')!.click())
+    await settle()
+
+    expect(text()).toContain('daemon is offline')
+    expect(mocks.deleteBot).not.toHaveBeenCalled()
+  })
+
+  it('closes without touching anything on cancel', async () => {
+    await openDialog()
+    await act(async () => buttonWithText('Cancel')!.click())
+
+    expect(text()).toBe('')
+    expect(mocks.deleteIntegration).not.toHaveBeenCalled()
+    expect(mocks.deleteBot).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/console/platforms/linear/settings.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/settings.test.tsx
@@ -193,7 +193,19 @@ describe('disconnecting a workspace', () => {
     expect(mocks.disconnectLinearWorkspace).toHaveBeenCalledWith('bot-9')
     expect(mocks.deleteIntegration).not.toHaveBeenCalled()
     expect(mocks.deleteBot).not.toHaveBeenCalled()
+  })
+
+  it('closes and refreshes once the call resolves — a 204 is a success, not a body to parse', async () => {
+    // The route answers 204 No Content, so the client helper must resolve on it. While
+    // it parsed unconditionally, every successful disconnect threw AFTER the workspace
+    // was gone: the dialog stayed open over deleted rows, the roster was never
+    // re-pulled, and the retry the error invited hit a bot that no longer existed.
+    await openDialog()
+    await act(async () => buttonWithText('Disconnect')!.click())
+    await settle()
+
     expect(mocks.refresh).toHaveBeenCalled()
+    expect(text()).toBe('')
   })
 
   it('renders a partial teardown as the refusal it is, keeping the dialog open', async () => {

--- a/packages/web/src/components/console/platforms/linear/settings.tsx
+++ b/packages/web/src/components/console/platforms/linear/settings.tsx
@@ -1,9 +1,14 @@
 'use client'
 
-// The Linear WORKSPACE CARD (linear-integration.md §7.4, §9.5). A Linear bot row IS
-// one connected workspace, so what the Settings → Bots card shows beside it is the
-// workspace's own identity and health, plus the way to repair a grant that stopped
-// working.
+// The ORG Bots view's Linear fragments (linear-integration.md §7.4, §9.5). A Linear
+// bot row IS one connected workspace, so what the row gains here are the two actions
+// that belong to the workspace as a whole rather than to any one agent: re-authorize
+// the grant, and disconnect it for the organization.
+//
+// Disconnect lives ONLY here. An agent's own card can unlink itself from a workspace;
+// removing the workspace for everyone is an org-level decision, and offering it beside
+// a single membership would let one member end every other member's access by
+// mistake.
 //
 // The state lives behind the module's own context (the contract's
 // `lifecycleActions.CardProvider`), mounted once per platform tab, because the row
@@ -11,7 +16,7 @@
 // open their own.
 
 import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Icon } from '@/components/ui'
+import { Button, Icon } from '@/components/ui'
 import type { BotDto } from '@/lib/api'
 import { useConsoleData } from '@/lib/data-context'
 import type { WebBotSettingsFragments } from '../contract'
@@ -23,6 +28,9 @@ interface LinearCardState {
   reconnectingBotId: string | null
   connectErr: string | null
   startReconnect(botId: string): void
+  /** The workspace whose disconnect confirmation is open, if any. */
+  disconnectingBotId: string | null
+  askDisconnect(botId: string | null): void
 }
 
 const CardCtx = createContext<LinearCardState | null>(null)
@@ -36,6 +44,7 @@ function useLinearCard(): LinearCardState {
 function LinearCardProvider({ children }: { children: ReactNode }) {
   const { refresh } = useConsoleData()
   const [reconnectingBotId, setReconnectingBotId] = useState<string | null>(null)
+  const [disconnectingBotId, setDisconnectingBotId] = useState<string | null>(null)
   // The bot the pending mint is for. A ref, not the state above: `start()` reads its
   // mint closure in the same tick as the click, before a setState has landed.
   const target = useRef<string | null>(null)
@@ -58,6 +67,7 @@ function LinearCardProvider({ children }: { children: ReactNode }) {
     },
     [clearError, start]
   )
+  const askDisconnect = useCallback((botId: string | null) => setDisconnectingBotId(botId), [])
 
   // The round trip is not open once it settles, whichever way it went.
   const openBotId = flow.phase === 'authorizing' ? reconnectingBotId : null
@@ -65,82 +75,160 @@ function LinearCardProvider({ children }: { children: ReactNode }) {
     () => ({
       reconnectingBotId: openBotId,
       connectErr: flow.appMissing ? 'Linear isn’t set up on this deployment.' : flow.err,
-      startReconnect
+      startReconnect,
+      disconnectingBotId,
+      askDisconnect
     }),
-    [flow.appMissing, flow.err, openBotId, startReconnect]
+    [askDisconnect, disconnectingBotId, flow.appMissing, flow.err, openBotId, startReconnect]
   )
 
   return <CardCtx.Provider value={value}>{children}</CardCtx.Provider>
 }
 
-/** The row's Reconnect control, in the card's 100px action track. Haloed while the
- *  grant is known dead — the same needs-attention shape Slack's refresh uses. */
+/** The workspace's two lifecycle actions, in the card's 100px action track. Reconnect
+ *  is haloed while the grant is known dead — the same needs-attention shape Slack's
+ *  refresh uses. */
 function LinearRowActions({ bot, canWrite }: { bot: BotDto; canWrite: boolean }) {
   const card = useLinearCard()
   const open = card.reconnectingBotId === bot.id
   const dead = !!bot.revokedAt
   return (
-    <button
-      type="button"
-      disabled={!canWrite || open}
-      title={open ? 'Waiting for Linear…' : 'Reconnect this workspace'}
-      aria-label="Reconnect this workspace"
-      onClick={() => card.startReconnect(bot.id)}
-      className={`iconbtn h-7 w-7 flex-none ${dead ? 'border-(--status-error) text-(--status-error)' : ''} ${
-        open ? 'cursor-default opacity-55' : 'cursor-pointer'
-      }`}
-    >
-      <Icon name={open ? 'loader' : 'refresh-cw'} size={13} className={open ? 'animate-spin' : ''} />
-    </button>
+    <>
+      <button
+        type="button"
+        disabled={!canWrite || open}
+        title={open ? 'Waiting for Linear…' : 'Reconnect this workspace'}
+        aria-label="Reconnect this workspace"
+        onClick={() => card.startReconnect(bot.id)}
+        className={`iconbtn h-7 w-7 flex-none ${dead ? 'border-(--status-error) text-(--status-error)' : ''} ${
+          open ? 'cursor-default opacity-55' : 'cursor-pointer'
+        }`}
+      >
+        <Icon name={open ? 'loader' : 'refresh-cw'} size={13} className={open ? 'animate-spin' : ''} />
+      </button>
+      {canWrite && (
+        <button
+          type="button"
+          title="Disconnect this workspace"
+          aria-label="Disconnect this workspace"
+          onClick={() => card.askDisconnect(bot.id)}
+          className="iconbtn h-7 w-7 flex-none cursor-pointer"
+        >
+          <Icon name="unplug" size={13} />
+        </button>
+      )}
+    </>
   )
 }
 
 /**
- * The workspace card body, under the bot row: connect status and the Reconnect CTA.
+ * Confirm disconnecting one workspace for the whole organization.
  *
- * The CTA is offered on a LIVE workspace too, not only a dead grant. Enabling agent
- * session events on an already-installed Linear app raises a new scope, and until
- * every prior authorization re-consents the workspace keeps a perfectly valid token
- * while receiving nothing (§15) — so the repair has to be reachable from the healthy
- * state as well.
+ * `DELETE /bots/:id` refuses while any agent is installed, so the memberships go
+ * first and the bot delete follows — which is also the order the copy describes. A
+ * membership that fails to lift stops the run with its own message rather than
+ * leaving the operator staring at the generic "installed on an agent" refusal.
+ */
+function DisconnectWorkspaceModal({ bot, onClose }: { bot: BotDto; onClose: () => void }) {
+  const { integrations, deleteIntegration, deleteBot } = useConsoleData()
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const name = bot.workspaceName || bot.name
+  // A workspace normally has members — the first connect makes one — but every one can
+  // be unlinked, and "all 0 agents" is not a sentence.
+  const members = bot.agentIds.length
+  const audience =
+    members === 0 ? 'this organization' : members === 1 ? 'the agent that uses it' : `all ${members} agents that use it`
+
+  const disconnect = async () => {
+    if (busy) return
+    setBusy(true)
+    setErr(null)
+    try {
+      for (const row of integrations) {
+        if (row.botId === bot.id && row.id) await deleteIntegration(row.id)
+      }
+      await deleteBot(bot.id)
+      onClose()
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+      setBusy(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="modalhead">
+        <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] bg-(--status-error-soft)">
+          <Icon name="unplug" size={16} color="var(--status-error)" />
+        </span>
+        <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">Disconnect workspace</span>
+        <button className="iconbtn" onClick={onClose}>
+          <Icon name="x" size={16} />
+        </button>
+      </div>
+      <div className="modalbody">
+        <p className="m-0 font-sans text-[13.5px] font-normal leading-[1.6] text-(--text-secondary)">
+          <span className="mono text-(--text-primary)">{name}</span>&#32;is removed for {audience}, and AgentConnect
+          forgets its Linear grant. Delegations in that workspace stop reaching any agent. Connecting it again is a
+          fresh authorization in Linear.
+        </p>
+        {err && (
+          <div className="mt-[10px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">{err}</div>
+        )}
+      </div>
+      <div className="modalfoot">
+        <div className="flex-1" />
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button variant="danger" onClick={disconnect} className={busy ? 'pointer-events-none opacity-50' : undefined}>
+          <Icon name="unplug" size={15} />
+          {busy ? 'Disconnecting…' : 'Disconnect'}
+        </Button>
+      </div>
+    </>
+  )
+}
+
+/**
+ * The card's per-bot band, rendered only when there is something to say: a reconnect
+ * waiting on the Linear tab, or a funnel that could not start. It also HOSTS the
+ * disconnect dialog its sibling row action opens — the action track is a `<span>`
+ * cell, while this fragment renders as a block row of the card.
+ *
+ * It deliberately no longer narrates a healthy workspace. The row already carries its
+ * connect state — the host's own `revoked` badge and the haloed Reconnect — and a
+ * standing "delegations not arriving?" band on every live workspace reads as a
+ * problem report rather than as chrome.
  */
 function LinearCardNotice({ bot }: { bot: BotDto }) {
   const card = useLinearCard()
   if (bot.platform !== 'linear') return null
-
-  // staleness signal not yet exposed — the CP publishes no `lastDeliveryAt`, so a
-  // webhook-silent workspace is reachable only through the always-offered CTA below.
-  const dead = !!bot.revokedAt
   const open = card.reconnectingBotId === bot.id
+  const err = card.reconnectingBotId === null ? card.connectErr : null
+  const disconnecting = card.disconnectingBotId === bot.id
+  if (!open && !err && !disconnecting) return null
 
   return (
-    <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 py-[10px] pl-10">
-      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-        <span
-          className={`badge ${dead ? 'bg-(--status-error-soft) text-(--status-error)' : 'bg-(--surface-active) text-(--text-tertiary)'}`}
-        >
-          {dead ? 'grant expired' : 'connected'}
-        </span>
-        <span className="mono min-w-0 truncate text-[12px] text-(--text-secondary)">
-          {bot.workspaceName || bot.name}
-        </span>
-        <span className="min-w-0 flex-1 font-sans text-[12px] font-normal leading-[1.45] text-(--text-tertiary)">
-          {dead
-            ? 'Linear no longer accepts this workspace’s grant — reconnect to restore delivery.'
-            : 'Delegations not arriving? Reconnect to re-consent the workspace’s event subscription.'}
-        </span>
-      </div>
-      {card.connectErr && card.reconnectingBotId === null && (
-        <div className="mt-[6px] font-sans text-[11.5px] font-normal leading-[1.4] text-(--status-error)">
-          {card.connectErr}
+    <>
+      {(open || err) && (
+        <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 py-[10px] pl-10">
+          <div
+            className={`font-sans text-[12px] font-normal leading-[1.45] ${err ? 'text-(--status-error)' : 'text-(--text-tertiary)'}`}
+          >
+            {err ?? 'Approve the workspace in the Linear tab — this card updates once it lands.'}
+          </div>
         </div>
       )}
-      {open && (
-        <div className="mt-[6px] font-sans text-[11.5px] font-normal leading-[1.4] text-(--text-tertiary)">
-          Approve the workspace in the Linear tab — this card updates once it lands.
+      {disconnecting && (
+        <div className="scrim" onClick={() => card.askDisconnect(null)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <DisconnectWorkspaceModal bot={bot} onClose={() => card.askDisconnect(null)} />
+          </div>
         </div>
       )}
-    </div>
+    </>
   )
 }
 

--- a/packages/web/src/components/console/platforms/linear/settings.tsx
+++ b/packages/web/src/components/console/platforms/linear/settings.tsx
@@ -124,18 +124,22 @@ function LinearRowActions({ bot, canWrite }: { bot: BotDto; canWrite: boolean })
 /**
  * Confirm disconnecting one workspace for the whole organization.
  *
- * `DELETE /bots/:id` refuses while any agent is installed, so the memberships go
- * first and the bot delete follows — which is also the order the copy describes. A
- * membership that fails to lift stops the run with its own message rather than
- * leaving the operator staring at the generic "installed on an agent" refusal.
+ * ONE server call, never a client loop over `integrations`: that list is
+ * visibility-filtered, so a member on an agent outside the caller's audience is
+ * invisible here — a loop would lift the memberships it can see and the bot delete
+ * behind it would refuse on the one it never knew about, leaving the workspace half
+ * unlinked after the operator confirmed a full disconnect. The authoritative member
+ * set only exists server-side, so the whole teardown does too; a partial one comes
+ * back as an error naming what is still linked.
  */
 function DisconnectWorkspaceModal({ bot, onClose }: { bot: BotDto; onClose: () => void }) {
-  const { integrations, deleteIntegration, deleteBot } = useConsoleData()
+  const { refresh } = useConsoleData()
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const name = bot.workspaceName || bot.name
   // A workspace normally has members — the first connect makes one — but every one can
-  // be unlinked, and "all 0 agents" is not a sentence.
+  // be unlinked, and "all 0 agents" is not a sentence. The count is the VISIBLE one, so
+  // it describes rather than bounds what the call removes.
   const members = bot.agentIds.length
   const audience =
     members === 0 ? 'this organization' : members === 1 ? 'the agent that uses it' : `all ${members} agents that use it`
@@ -145,10 +149,8 @@ function DisconnectWorkspaceModal({ bot, onClose }: { bot: BotDto; onClose: () =
     setBusy(true)
     setErr(null)
     try {
-      for (const row of integrations) {
-        if (row.botId === bot.id && row.id) await deleteIntegration(row.id)
-      }
-      await deleteBot(bot.id)
+      await linearApi.disconnect(bot.id)
+      await refresh()
       onClose()
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
@@ -172,6 +174,9 @@ function DisconnectWorkspaceModal({ bot, onClose }: { bot: BotDto; onClose: () =
           <span className="mono text-(--text-primary)">{name}</span>&#32;is removed for {audience}, and AgentConnect
           forgets its Linear grant. Delegations in that workspace stop reaching any agent. Connecting it again is a
           fresh authorization in Linear.
+        </p>
+        <p className="mt-[10px] mb-0 font-sans text-[12.5px] font-normal leading-[1.6] text-(--text-tertiary)">
+          Agents you cannot see are removed too — the workspace is disconnected for the whole organization.
         </p>
         {err && (
           <div className="mt-[10px] font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)">{err}</div>

--- a/packages/web/src/components/console/platforms/registry.ts
+++ b/packages/web/src/components/console/platforms/registry.ts
@@ -2,7 +2,13 @@
 
 import type { ComponentType } from 'react'
 import type { BotDto, SessionMessageDto } from '@/lib/api'
-import type { WebBotCardCopy, WebChannelListSemantics, WebPlatformModule, WebPlatformRegistry } from './contract'
+import type {
+  WebAgentIntegrationCardFacet,
+  WebBotCardCopy,
+  WebChannelListSemantics,
+  WebPlatformModule,
+  WebPlatformRegistry
+} from './contract'
 import { discordModule } from './discord'
 import { feishuModule } from './feishu'
 import { linearModule } from './linear'
@@ -47,6 +53,15 @@ export const DEFAULT_CHANNEL_LIST: WebChannelListSemantics = {
 /** One platform's channel-list display semantics, defaulted. */
 export function channelListSemantics(platformId?: string): WebChannelListSemantics {
   return (platformId ? platformRegistry.get(platformId)?.channelList : undefined) ?? DEFAULT_CHANNEL_LIST
+}
+
+/**
+ * This platform's own agent-page card body, or `undefined` for the generic
+ * conversation list. Total for the same reason every lookup here is — an
+ * integration row carries whatever platform the CP sent.
+ */
+export function platformAgentCard(platformId?: string): WebAgentIntegrationCardFacet | undefined {
+  return platformId ? platformRegistry.get(platformId)?.agentCard : undefined
 }
 
 /**

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -77,6 +77,7 @@ import { AgentMark, GithubMark, GitlabMark, LoadingState, PlatformMark } from '@
 import { buildAgentReachabilityGraph } from '@/lib/agent-reachability'
 import type { Platform } from '@/components/console/modals/AddIntegrationModal'
 import { INTEGRATION_BLURB, PLATFORMS, isCoreTriggerKind } from '@/components/console/platforms/host-projections'
+import { platformAgentCard } from '@/components/console/platforms/registry'
 import {
   GL_TRIGGER_MODES,
   GL_TRIGGER_PILL,
@@ -1375,58 +1376,70 @@ export default function AgentDetailView() {
                 {/* Dual-rendered lists: mobile flat rows (no delete, padX 16) vs
                     desktop bordered sub-cards (delete iconbtn, padX 14). */}
                 <div className="desktop:hidden">
-                  {agentInts.map((g, i) => (
-                    <div key={i} className={i > 0 ? 'border-t border-(--border-subtle)' : undefined}>
-                      <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3">
-                        <Link href={botSettingsHref(g.botId)} className="group flex min-w-0 flex-1 items-center gap-3">
-                          <span className="imark h-9 w-9 flex-none rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
-                            <PlatformMark platform={g.platform} />
-                          </span>
-                          <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
-                            <span className="flex min-w-0 items-center gap-2">
-                              <span className="truncate font-sans text-[14px] font-semibold leading-normal group-hover:underline">
-                                {g.name}
-                              </span>
-                              <FeishuRegionBadge integration={g} />
-                            </span>
-                            {g.channels[0] && (
-                              <span className="font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                                {roomGlyph(g.channels[0].kind, g.platform)}
-                                {rowLabel(g.channels[0])}
-                              </span>
-                            )}
-                          </span>
-                        </Link>
-                        <span className="inline-flex flex-none items-center gap-[5px] rounded-full bg-(--brand-soft) px-[10px] py-[3px] font-sans text-[12px] font-semibold leading-normal text-(--brand-soft-text)">
-                          <span className="h-[6px] w-[6px] rounded-full bg-(--status-online)" />
-                          connected
-                        </span>
-                        {g.platform === 'discord' && g.discordAppId && (
-                          <a
-                            href={discordBotInviteUrl(g.discordAppId)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            title="Invite this bot to a Discord server — preset scopes &amp; permissions"
-                            aria-label="Add this bot to a Discord server"
-                            className="iconbtn h-7 w-7 flex-none"
-                            onClick={(e) => e.stopPropagation()}
+                  {agentInts.map((g, i) => {
+                    // A module with its own card body replaces the generic conversation
+                    // list — and, with it, the header's first-channel subline.
+                    const AgentCardBody = platformAgentCard(g.platform)?.Body
+                    return (
+                      <div key={i} className={i > 0 ? 'border-t border-(--border-subtle)' : undefined}>
+                        <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3">
+                          <Link
+                            href={botSettingsHref(g.botId)}
+                            className="group flex min-w-0 flex-1 items-center gap-3"
                           >
-                            <Icon name="external-link" size={12} />
-                          </a>
+                            <span className="imark h-9 w-9 flex-none rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
+                              <PlatformMark platform={g.platform} />
+                            </span>
+                            <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
+                              <span className="flex min-w-0 items-center gap-2">
+                                <span className="truncate font-sans text-[14px] font-semibold leading-normal group-hover:underline">
+                                  {g.name}
+                                </span>
+                                <FeishuRegionBadge integration={g} />
+                              </span>
+                              {!AgentCardBody && g.channels[0] && (
+                                <span className="font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                                  {roomGlyph(g.channels[0].kind, g.platform)}
+                                  {rowLabel(g.channels[0])}
+                                </span>
+                              )}
+                            </span>
+                          </Link>
+                          <span className="inline-flex flex-none items-center gap-[5px] rounded-full bg-(--brand-soft) px-[10px] py-[3px] font-sans text-[12px] font-semibold leading-normal text-(--brand-soft-text)">
+                            <span className="h-[6px] w-[6px] rounded-full bg-(--status-online)" />
+                            connected
+                          </span>
+                          {g.platform === 'discord' && g.discordAppId && (
+                            <a
+                              href={discordBotInviteUrl(g.discordAppId)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              title="Invite this bot to a Discord server — preset scopes &amp; permissions"
+                              aria-label="Add this bot to a Discord server"
+                              className="iconbtn h-7 w-7 flex-none"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <Icon name="external-link" size={12} />
+                            </a>
+                          )}
+                        </div>
+                        {AgentCardBody ? (
+                          <AgentCardBody integration={g} padX={16} />
+                        ) : (
+                          <IntegrationChannelList
+                            integrationId={g.id}
+                            channels={g.channels}
+                            botId={g.botId}
+                            agentId={da.id}
+                            platform={g.platform}
+                            shareable={g.shareable}
+                            gated={da.visibility === 'restricted'}
+                            padX={16}
+                          />
                         )}
                       </div>
-                      <IntegrationChannelList
-                        integrationId={g.id}
-                        channels={g.channels}
-                        botId={g.botId}
-                        agentId={da.id}
-                        platform={g.platform}
-                        shareable={g.shareable}
-                        gated={da.visibility === 'restricted'}
-                        padX={16}
-                      />
-                    </div>
-                  ))}
+                    )
+                  })}
                   {webhookHooks.map((h, i) => (
                     <div
                       key={h.id}
@@ -1592,68 +1605,78 @@ export default function AgentDetailView() {
                   ))}
                 </div>
                 <div className="hidden flex-col gap-3 px-4 py-[14px] desktop:flex">
-                  {agentInts.map((g, i) => (
-                    <div key={i} className="overflow-hidden rounded-[9px] border border-(--border-subtle)">
-                      <div className="flex items-center gap-3 px-[14px] py-3">
-                        <Link href={botSettingsHref(g.botId)} className="group flex min-w-0 flex-1 items-center gap-3">
-                          <span className="imark h-[34px] w-[34px] rounded-md">
-                            <PlatformMark platform={g.platform} />
-                          </span>
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-center gap-2">
-                              <span className="truncate font-sans text-[13.5px] font-semibold leading-normal group-hover:underline">
-                                {g.name}
-                              </span>
-                              <FeishuRegionBadge integration={g} />
-                              <span className="badge bg-(--brand-soft) text-(--brand-soft-text)">
-                                <span className="dot h-[6px] w-[6px] bg-(--status-online)" />
-                                connected
-                              </span>
-                              {g.shareable && (
-                                <span
-                                  className="badge bg-(--surface-app) text-(--text-tertiary)"
-                                  title="Shared bot — used by multiple agents, inbound via a relay. Each channel dispatches to one of them by default."
-                                >
-                                  <Icon name="users" size={11} />
-                                  shared · {g.agentCount} {g.agentCount === '1' ? 'agent' : 'agents'}
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        </Link>
-                        {g.platform === 'discord' && g.discordAppId && (
-                          <a
-                            href={discordBotInviteUrl(g.discordAppId)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            title="Invite this bot to a Discord server — preset scopes &amp; permissions"
-                            aria-label="Add this bot to a Discord server"
-                            className="iconbtn flex-none"
-                            onClick={(e) => e.stopPropagation()}
+                  {agentInts.map((g, i) => {
+                    const AgentCardBody = platformAgentCard(g.platform)?.Body
+                    return (
+                      <div key={i} className="overflow-hidden rounded-[9px] border border-(--border-subtle)">
+                        <div className="flex items-center gap-3 px-[14px] py-3">
+                          <Link
+                            href={botSettingsHref(g.botId)}
+                            className="group flex min-w-0 flex-1 items-center gap-3"
                           >
-                            <Icon name="external-link" size={14} />
-                          </a>
+                            <span className="imark h-[34px] w-[34px] rounded-md">
+                              <PlatformMark platform={g.platform} />
+                            </span>
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-2">
+                                <span className="truncate font-sans text-[13.5px] font-semibold leading-normal group-hover:underline">
+                                  {g.name}
+                                </span>
+                                <FeishuRegionBadge integration={g} />
+                                <span className="badge bg-(--brand-soft) text-(--brand-soft-text)">
+                                  <span className="dot h-[6px] w-[6px] bg-(--status-online)" />
+                                  connected
+                                </span>
+                                {g.shareable && (
+                                  <span
+                                    className="badge bg-(--surface-app) text-(--text-tertiary)"
+                                    title="Shared bot — used by multiple agents, inbound via a relay. Each channel dispatches to one of them by default."
+                                  >
+                                    <Icon name="users" size={11} />
+                                    shared · {g.agentCount} {g.agentCount === '1' ? 'agent' : 'agents'}
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                          </Link>
+                          {g.platform === 'discord' && g.discordAppId && (
+                            <a
+                              href={discordBotInviteUrl(g.discordAppId)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              title="Invite this bot to a Discord server — preset scopes &amp; permissions"
+                              aria-label="Add this bot to a Discord server"
+                              className="iconbtn flex-none"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <Icon name="external-link" size={14} />
+                            </a>
+                          )}
+                          <button
+                            className="iconbtn"
+                            title="Delete integration"
+                            onClick={() => openModal('deleteIntegration', g)}
+                          >
+                            <Icon name="unplug" size={15} />
+                          </button>
+                        </div>
+                        {AgentCardBody ? (
+                          <AgentCardBody integration={g} padX={14} />
+                        ) : (
+                          <IntegrationChannelList
+                            integrationId={g.id}
+                            channels={g.channels}
+                            botId={g.botId}
+                            agentId={da.id}
+                            platform={g.platform}
+                            shareable={g.shareable}
+                            gated={da.visibility === 'restricted'}
+                            padX={14}
+                          />
                         )}
-                        <button
-                          className="iconbtn"
-                          title="Delete integration"
-                          onClick={() => openModal('deleteIntegration', g)}
-                        >
-                          <Icon name="unplug" size={15} />
-                        </button>
                       </div>
-                      <IntegrationChannelList
-                        integrationId={g.id}
-                        channels={g.channels}
-                        botId={g.botId}
-                        agentId={da.id}
-                        platform={g.platform}
-                        shareable={g.shareable}
-                        gated={da.visibility === 'restricted'}
-                        padX={14}
-                      />
-                    </div>
-                  ))}
+                    )
+                  })}
                   {webhookHooks.map((h) => (
                     <div key={h.id} className="overflow-hidden rounded-[9px] border border-(--border-subtle)">
                       <div className="flex items-center gap-3 px-[14px] py-3">

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -14,8 +14,8 @@ import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { Button, Icon, Toggle } from '@/components/ui'
 import { AgentIconView, GithubMark, LoadingState, PlatformMark } from '@/components/marks'
-import type { AgentIcon } from '@/lib/agent-icon'
 import { useModal } from '@/components/console/ModalProvider'
+import { DefaultDispatchPicker } from '@/components/console/DefaultDispatchPicker'
 import { useConsoleData } from '@/lib/data-context'
 import { useProfile } from '@/lib/profile'
 import { useOrgs } from '@/lib/org-context'
@@ -127,80 +127,6 @@ function botChannels(bot: BotDto, integrations: IntegrationRow[]): BotChannelVie
     if (rank(a.kind) !== rank(b.kind)) return rank(a.kind) - rank(b.kind)
     return a.name.localeCompare(b.name)
   })
-}
-
-/** Per-conversation default dispatch for a SHARED bot — the agent a conversation's
- *  unmatched messages go to.
- *  Shows the current one and opens a menu of every agent installed on the bot;
- *  picking one PATCHes the conversation's explicit owner. This is the full-roster
- *  picker: the agent page's own popover only claims it for the agent being viewed. */
-function DefaultDispatchPicker({
-  options,
-  activeId,
-  disabled,
-  onPick
-}: {
-  options: { id: string; name: string; model: string; runtime: string; icon?: AgentIcon | null }[]
-  activeId: string | null
-  disabled: boolean
-  onPick: (agentId: string) => Promise<void>
-}) {
-  const [open, setOpen] = useState(false)
-  const [saving, setSaving] = useState(false)
-  const active = options.find((o) => o.id === activeId) ?? options[0]
-  const pick = (id: string) => {
-    setOpen(false)
-    if (disabled || saving || id === active?.id) return
-    setSaving(true)
-    onPick(id).finally(() => setSaving(false))
-  }
-  return (
-    <span className="relative justify-self-end" onClick={(e) => e.stopPropagation()}>
-      <button
-        onClick={() => !disabled && setOpen((v) => !v)}
-        title="Default dispatch — the agent this conversation's unmatched messages go to"
-        className={`flex items-center gap-2 rounded-[7px] border-0 bg-transparent px-[5px] py-1 hover:bg-(--surface-hover) ${
-          disabled ? 'cursor-default' : 'cursor-pointer'
-        } ${saving ? 'opacity-60' : ''}`}
-      >
-        <span className="av h-5 w-5 rounded-[5px]">
-          <AgentIconView icon={active?.icon} runtime={active?.runtime ?? active?.model ?? ''} size={20} />
-        </span>
-        <span className="mono text-[12.5px] text-(--text-primary)">{active?.name ?? '—'}</span>
-        <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
-      </button>
-      {open && (
-        <>
-          <span className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
-          {/* right-anchored: the picker sits in the roster's right-most column, so a
-              left-anchored menu (wider than its button) would clip past the card edge */}
-          <div className="absolute right-0 top-[calc(100%+5px)] z-40 min-w-[230px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)">
-            <div className="px-[9px] pb-[5px] pt-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
-              Default dispatch
-            </div>
-            {options.map((o) => (
-              <button
-                key={o.id}
-                onClick={() => pick(o.id)}
-                className="flex w-full cursor-pointer items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[6px] text-left hover:bg-(--surface-hover)"
-              >
-                <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
-                  <AgentIconView icon={o.icon} runtime={o.runtime} size={22} />
-                </span>
-                <span className="mono min-w-0 flex-1 truncate text-[12.5px] text-(--text-primary)">{o.name}</span>
-                <Icon
-                  name="check"
-                  size={13}
-                  color={o.id === active?.id ? 'var(--brand)' : 'transparent'}
-                  className="flex-none"
-                />
-              </button>
-            ))}
-          </div>
-        </>
-      )}
-    </span>
-  )
 }
 
 /** The page's two section headings. Cards own no top margin here — the section

--- a/packages/web/src/lib/api.test.ts
+++ b/packages/web/src/lib/api.test.ts
@@ -4,6 +4,9 @@ import {
   listDreams,
   setAgentWorkspace,
   createGithubHook,
+  disconnectLinearWorkspace,
+  leaveIntegrationConversation,
+  reconnectLinearWorkspace,
   createMemoryRecord,
   deleteMemoryRecord,
   deleteOrgIcon,
@@ -963,5 +966,58 @@ describe('usage window', () => {
     expect(urls[0]).toContain('to=')
     expect(urls[0]).not.toContain('source=')
     expect(urls[1]).toContain('source=gateway')
+  })
+})
+
+describe('a POST that commands rather than creates', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const stub = (res: () => Response) => {
+    const calls: string[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        calls.push(url)
+        return res()
+      })
+    )
+    return calls
+  }
+
+  it('resolves on 204 No Content instead of failing on the body it does not have', async () => {
+    // The CP answers a no-content write with 204 (`response: { 204: z.null() }`) — the
+    // convention across two dozen of its routes. Parsing that unconditionally threw a
+    // SyntaxError on SUCCESS, so the caller reported a failure for work the server had
+    // already committed and its retry hit an already-deleted row.
+    stub(() => new Response(null, { status: 204 }))
+    await expect(disconnectLinearWorkspace('bot-9')).resolves.toBeUndefined()
+    await expect(
+      leaveIntegrationConversation('int-1', { kind: 'conversation', channel: 'C1' })
+    ).resolves.toBeUndefined()
+  })
+
+  it('still parses the body of a POST that returns a row', async () => {
+    stub(
+      () =>
+        new Response(JSON.stringify({ id: 'c1', connectUrl: 'https://linear.app/oauth/authorize' }), {
+          status: 201,
+          headers: { 'content-type': 'application/json' }
+        })
+    )
+    await expect(reconnectLinearWorkspace('bot-9')).resolves.toEqual({
+      id: 'c1',
+      connectUrl: 'https://linear.app/oauth/authorize'
+    })
+  })
+
+  it('still surfaces a refusal, with the server’s own sentence', async () => {
+    stub(
+      () =>
+        new Response(JSON.stringify({ message: 'only a connected Linear workspace can be disconnected' }), {
+          status: 409,
+          headers: { 'content-type': 'application/json' }
+        })
+    )
+    await expect(disconnectLinearWorkspace('bot-9')).rejects.toThrow(/only a connected Linear workspace/)
   })
 })

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1533,7 +1533,14 @@ async function apiPost<T>(path: string, body: unknown): Promise<T> {
     { 'content-type': 'application/json' }
   )
   if (!res.ok) throw await apiErrorFromResponse('POST', path, res)
-  return (await res.json()) as T
+  // Same split `apiDelete` makes, and for the same reason: a POST that COMMANDS rather
+  // than creates replies 204 No Content (leave a conversation, disconnect a workspace),
+  // while one that returns a row replies 200/201 with a body. Parsing unconditionally
+  // turned every SUCCESSFUL no-content write into a thrown SyntaxError — after the
+  // server had already done the thing.
+  if (res.status === 204) return undefined as T
+  const text = await res.text()
+  return (text ? JSON.parse(text) : undefined) as T
 }
 
 async function apiErrorFromResponse(method: string, path: string, res: Response): Promise<ApiError> {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3978,6 +3978,14 @@ export async function reconnectLinearWorkspace(botId: string): Promise<LinearCon
   return apiPost<LinearConnectStartDto>(`${orgBase()}/bots/${encodeURIComponent(botId)}/linear/reconnect`, {})
 }
 
+// Disconnect a workspace for the whole organization: every membership and then the bot
+// itself, in ONE call. The console must NOT loop `deleteIntegration` here — the list it
+// would loop over is visibility-filtered, so a member on an agent outside the caller's
+// audience is invisible to it and the workspace would be left half unlinked.
+export async function disconnectLinearWorkspace(botId: string): Promise<void> {
+  await apiPost<void>(`${orgBase()}/bots/${encodeURIComponent(botId)}/linear/disconnect`, {})
+}
+
 // Uninstall an integration (`DELETE /integrations/:id`): drops the CP record and
 // tells the owning daemon to close the connection. The BOT survives (freed) — it
 // shows up in the Add-integration picker for reuse.


### PR DESCRIPTION
Rewrites the Linear console module to the corrected model (docs PR #1690; coordinates PR #1692): the workspace behaves as one channel, and the console stops inventing Linear-specific machinery.

- **Agent card** (new `agentCard` facet on the platform contract — the agent page previously rendered the channel list unconditionally, and a list that must not render is the wrong thing to teach `channelList` to say): one row per linked workspace — name, the standard default-dispatch selector, inline Reconnect with a dead-grant warning, and unlink-self via the generic integration delete. No trigger control, no issue list; helper text explains that sessions start from delegations/mentions in Linear.
- **The dispatch selector is the org roster's own control, not a fork**: `DefaultDispatchPicker` is extracted from `IntegrationsView` into a shared component both surfaces render, driving the same per-conversation owner PATCH the Slack rows use. Until the CP-side row seeding (#1692) lands, a rowless install renders the selector read-only with the workspace named from the bot.
- **Add flow**: a GitHub-repo-picker-style single-select of connected workspaces (names only; already-linked rows disabled), one add = one link; "Connect another workspace…" hands off to the connect flow.
- **Connect flow**: zero-config with a one-click gate — the OAuth popup opens inside the user gesture (an effect-fired `window.open` is popup-blocked by default), then waiting → readable success ("this agent is now its default") or retryable failure, with the settle outcomes (`workspace_taken`, `wrong_workspace`) rendered distinctly.
- **Org Bots view**: Linear workspace rows stay ordinary, gaining Reconnect and Disconnect (confirm modal; lifts each membership first since bot deletion refuses while installed, then removes the bot). Disconnect lives only here — the agent card only unlinks self.
- `channelList` is omitted for Linear (host defaults pinned by test); the channel-list article derivation stays for the platforms that render it.

Tests: 2267 web tests green (30 new/updated across the card, pane, settings, and view suites); typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
