### PR TITLE
fix(chart): route /linear/events to the relay pool

### DIFF
--- a/charts/agentconnect/templates/httproute.yaml
+++ b/charts/agentconnect/templates/httproute.yaml
@@ -184,6 +184,7 @@ the relay host (relay.host, else apiHost, else the website host):
   /slack/events                 → relay pool (Slack Events API, http transport)
   /slack/interactions           → relay pool (Slack interactivity + block_suggestion)
   /feishu/events                → relay pool (Feishu/Lark HTTP event callback)
+  /linear/events                → relay pool (Linear app webhook)
   /relays/<ordinal>/rd/ws       → that exact relay pod, rewritten to /rd/ws
 When the relay host == apiHost / the website host, Gateway API merges these rules with
 that host's existing route (ranked by path specificity) — no new listener needed. A
@@ -252,6 +253,9 @@ spec:
         - path:
             type: PathPrefix
             value: /feishu/events
+        - path:
+            type: PathPrefix
+            value: /linear/events
       backendRefs:
         - name: {{ include "agentconnect.fullname" . }}-relay
           port: {{ .Values.relay.port }}

--- a/scripts/test-chart-render.rb
+++ b/scripts/test-chart-render.rb
@@ -497,7 +497,7 @@ relay_route = public_documents.find { |doc| doc['kind'] == 'HTTPRoute' && doc.di
 relay_paths = relay_route.dig('spec', 'rules').flat_map { |rule| rule['matches'].to_a }.map { |match| match.dig('path', 'value') }
 # Every HTTP ingress path the relay registry mounts; a path the route omits falls through to
 # the web catch-all (or the gateway 404) and that platform's ingress silently receives nothing.
-%w[/mcp /memory /webchat /webhooks/in /webhooks/github /webhooks/gitlab /slack/events /slack/interactions /feishu/events].each do |path|
+%w[/mcp /memory /webchat /webhooks/in /webhooks/github /webhooks/gitlab /slack/events /slack/interactions /feishu/events /linear/events].each do |path|
   abort("relay route must forward #{path}") unless relay_paths.include?(path)
 end
 


### PR DESCRIPTION
## Summary
- The relay registry mounts `POST /linear/events` (Linear app webhook), but the chart's relay HTTPRoute never forwarded the path, so every Linear delivery died at the gateway as a 404 before reaching the relay.
- Add `/linear/events` to the relay rule's match list and to the chart render contract that pins the forwarded path set.

## Testing
- `ruby scripts/test-chart-render.rb` → `chart render contract: ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)