### PR TITLE
fix(daemon): carve back the owner checkout's Git metadata for session worktrees

### DIFF
--- a/packages/daemon/src/acp/sandbox.ts
+++ b/packages/daemon/src/acp/sandbox.ts
@@ -46,6 +46,9 @@ export interface SrtSandboxPolicy {
   writable: string[]
   denyRead: string[]
   allowRead: string[]
+  /** Carve-outs inside a write root. SRT's own mandatory protection is derived from the cwd, so a
+   *  write root the cwd does not contain (a session worktree's owner `.git`) needs its own. */
+  denyWrite?: string[]
   gitSafeDirectories?: string[]
   /** No network or Unix-domain socket access and no dynamic approval callback.
    * Used for audited daemon helpers such as local skills installation. */
@@ -304,7 +307,7 @@ export function writeSandboxSettings(agentDir: string, policy: SrtSandboxPolicy)
       denyRead,
       allowRead: canonical(policy.allowRead),
       allowWrite: canonical(policy.writable),
-      denyWrite: canonical(['/tmp/claude', '/private/tmp/claude']),
+      denyWrite: canonical([...(policy.denyWrite ?? []), '/tmp/claude', '/private/tmp/claude']),
       // Daemon-managed Git writes the credential-helper entries outside the
       // sandbox. A confined runtime must not redirect later host-side Git via
       // core.hooksPath, core.fsmonitor, filter.*, or similar settings.

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -12,7 +12,7 @@ import {
   runtimeHomePath
 } from '../runtimes/runtime-home.js'
 import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
-import { secondaryCheckoutsIn } from '../workspace/secondary-layout.js'
+import { primaryCheckoutIn, secondaryCheckoutsIn } from '../workspace/secondary-layout.js'
 import {
   CLAUDE_PROFILE_ENV,
   claudeProtectedSettings,
@@ -375,6 +375,21 @@ export function prepareRuntimeLaunch(opts: {
       return trusted
     })
   )
+  // An isolated session's cwd is its own worktree, but that worktree's index — and every ref and
+  // object its commits write — live in the OWNER checkout's `.git`, which no other carve-back
+  // covers. Without these the confined runtime cannot even run `git status` in its own worktree.
+  const gitMetadataWriteRoots = compactReadRoots(
+    [primaryCheckoutIn(agentRoot), ...secondaryCheckoutsIn(agentRoot)]
+      .map((checkout) => join(checkout, '.git'))
+      .filter((gitDir) => existsSync(gitDir) && lstatSync(gitDir).isDirectory())
+      .map((gitDir) => {
+        const trusted = safeRoot(gitDir, 'git metadata root')
+        if (trusted === agentRoot || !inside(agentRoot, trusted)) {
+          throw new Error(`git metadata root "${trusted}" is outside the agent root`)
+        }
+        return trusted
+      })
+  )
   const claudeRuntime = Boolean(opts.runtime && isClaudeRuntimeDef(opts.runtime))
   if (claudeRuntime) {
     // Anthropic profile JSON may live in the agent-writable private HOME and may
@@ -412,7 +427,12 @@ export function prepareRuntimeLaunch(opts: {
     runtimeHome,
     mcpSocketPath: opts.mcpSocketPath,
     trustedReadRoots: [...trustedRuntimeReadRoots, ...providerCredentialReadRoots],
-    trustedWriteRoots: [...credentialWritableRoots, ...trustedWorkspaceWriteRoots, ...packageCacheWriteRoots]
+    trustedWriteRoots: [
+      ...credentialWritableRoots,
+      ...trustedWorkspaceWriteRoots,
+      ...packageCacheWriteRoots,
+      ...gitMetadataWriteRoots
+    ]
   })
   // SRT write roots must exist before spawn.
   // This also initializes workspace/memory for a newly-created agent.
@@ -433,6 +453,10 @@ export function prepareRuntimeLaunch(opts: {
     // plus trusted executable/package roots above; never an agent-provided path.
     denyRead: denyReadRoots,
     allowRead: boundary.allowRead,
+    // A Git metadata root is opened for the index, refs, and objects alone. SRT's own mandatory
+    // protection only covers a `.git` DIRECTORY below the cwd, which an isolated worktree's link
+    // file is not, so hooks and config are closed here instead.
+    denyWrite: gitMetadataWriteRoots.flatMap((gitDir) => [join(gitDir, 'hooks'), join(gitDir, 'config')]),
     gitSafeDirectories: boundary.gitSafeDirectories
   })
   const protectedCredentialRoots = compactReadRoots([
@@ -442,17 +466,12 @@ export function prepareRuntimeLaunch(opts: {
     ...privateCodexStateRoots
   ])
   if (credentialProfile === 'codex') {
-    // Codex's :workspace profile protects `.git`. Re-open only the canonical
-    // metadata directory already covered by the outer sandbox's writable root;
-    // session worktree indexes and refs live below this main checkout directory.
-    // A secondary root materialized after this spawn is reopened on the next one.
-    const gitMetadataOwners = [...boundary.gitSafeDirectories, ...secondaryCheckoutsIn(agentRoot)]
-    const writableGitMetadataRoots = gitMetadataOwners.flatMap((workspaceRoot) => {
-      const gitDir = join(workspaceRoot, '.git')
-      if (!existsSync(gitDir) || !lstatSync(gitDir).isDirectory()) return []
-      const canonical = realpathSync(gitDir)
-      return boundary.writable.some((root) => inside(root, canonical)) ? [canonical] : []
-    })
+    // Codex's :workspace profile protects `.git`. Re-open exactly the metadata directories the
+    // outer sandbox already made writable — the outer boundary stays the one that closes hooks and
+    // config. A secondary root materialized after this spawn is reopened on the next one.
+    const writableGitMetadataRoots = gitMetadataWriteRoots.filter((gitDir) =>
+      boundary.writable.some((root) => inside(root, gitDir))
+    )
     applyCodexPermissionProfile(env, {
       protectedRoots: protectedCredentialRoots,
       writableGitMetadataRoots,

--- a/packages/daemon/src/workspace/secondary-layout.ts
+++ b/packages/daemon/src/workspace/secondary-layout.ts
@@ -2,10 +2,12 @@ import { lstatSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import type { WorkspaceFs } from './workspace-fs.js'
 
-// The on-disk shape of an agent's secondary roots (multi-repository-workspaces.md §"Directory
+// The on-disk shape of an agent's workspace roots (multi-repository-workspaces.md §"Directory
 // layout"), separate from the manager so the launch path can read it without the whole workspace
 // module: a sandboxed runtime's boundary is computed from these paths before any session exists.
 
+/** The agent's own checkout, the root every session worktree is cut from. */
+export const PRIMARY_CHECKOUT_DIR = 'workspace'
 /** Secondary roots live under one agent-owned parent, one subtree per authorized repository. */
 export const SECONDARY_ROOTS_DIR = 'repos'
 /** What a secondary root's subtree records about the checkout beside it. */
@@ -22,6 +24,11 @@ const REPO_SEGMENT = /^[A-Za-z0-9._-]+$/
 /** A plain path segment that is also a legal GitHub owner or repository name. */
 export function isRepoSegment(value: string | undefined): value is string {
   return value !== undefined && value !== '.' && value !== '..' && REPO_SEGMENT.test(value)
+}
+
+/** `<agentRoot>/workspace` — the primary checkout, whether or not it holds a repository. */
+export function primaryCheckoutIn(agentRoot: string): string {
+  return join(agentRoot, PRIMARY_CHECKOUT_DIR)
 }
 
 /** `<agentRoot>/repos` — the parent every secondary root's subtree hangs off. */

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -349,6 +349,43 @@ describe('prepareRuntimeLaunch', () => {
     expect(writes.some((value) => value.includes(`"${realpathSync(join(cwd, '.git'))}" = "write"`))).toBe(true)
   })
 
+  // An isolated session's `.git` is a link FILE, so the checkout that owns its index, refs, and
+  // objects sits outside the cwd — and outside every other carve-back, which left a confined
+  // runtime unable to run any Git write in its own worktree.
+  it('carves back the owner checkout .git for a session worktree cwd, hooks and config excepted', () => {
+    const { scopeDir, hostHome } = fixture()
+    const primaryGit = join(scopeDir, 'workspace', '.git')
+    const worktrees = join(scopeDir, 'worktrees')
+    const cwd = join(worktrees, 'session-1')
+    mkdirSync(join(primaryGit, 'worktrees', 'session-1'), { recursive: true })
+    mkdirSync(cwd, { recursive: true })
+    writeFileSync(join(cwd, '.git'), `gitdir: ${join(primaryGit, 'worktrees', 'session-1')}\n`)
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      trustedWorkspaceWriteRoots: [worktrees, join(scopeDir, 'repos')],
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const policy = JSON.parse(readFileSync(launch.sandbox!.settingsPath, 'utf8'))
+    expect(coveredBy(policy.filesystem.allowWrite, realpathSync(primaryGit))).toBe(true)
+    // The working tree beside it stays outside the boundary: isolation is the point of the worktree.
+    expect(coveredBy(policy.filesystem.allowWrite, realpathSync(join(scopeDir, 'workspace')))).toBe(false)
+    // SRT's own mandatory protection is derived from the cwd, which holds no `.git` DIRECTORY here.
+    expect(policy.filesystem.denyWrite).toContain(join(realpathSync(primaryGit), 'hooks'))
+    expect(policy.filesystem.denyWrite).toContain(join(realpathSync(primaryGit), 'config'))
+    const profile = JSON.parse(launch.env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]!) as { configOverrides: string[] }
+    const writes = profile.configOverrides.filter((value) => value.includes('filesystem='))
+    expect(writes.some((value) => value.includes(`"${realpathSync(primaryGit)}" = "write"`))).toBe(true)
+  })
+
   it('rejects root-level protected paths instead of generating an ineffective policy', () => {
     const { scopeDir, cwd, hostHome } = fixture()
     expect(() =>


### PR DESCRIPTION
## The bug

A sandboxed agent with `workspaceIsolation: session` cannot perform a single Git write in its own
session worktree. `git add` fails with

```
fatal: Unable to create '<checkout>/.git/worktrees/<sid>/index.lock': Read-only file system
```

and even `git status` fails. The practical effect: such an agent can implement a change but can
never commit, push, or open a pull request from it.

## Why

An isolated session's cwd is `<agentRoot>/worktrees/<sid>`, but a worktree owns none of its own Git
metadata. Its index lives in `<checkout>/.git/worktrees/<sid>`, and every ref and object its commits
write lands in `<checkout>/.git` — all outside the cwd, and outside every carve-back the launch
composes:

- **Outer sandbox.** The write set is `{cwd, runtime HOME, memory} ∪ trustedWorkspaceWriteRoots`,
  and the latter only supplies the `worktrees` and `repos` parents. The primary checkout was only
  ever writable *by accident of containment* — in a non-isolated session it IS the cwd. Moving the
  cwd to a worktree silently dropped it.
- **Inner Codex profile.** `prepare.ts` already meant to re-open `.git` for Codex's `:workspace`
  profile, but it tested `lstat(join(owner, '.git')).isDirectory()` against the cwd. In a worktree
  `.git` is a link *file*, so that list was always empty there.

The same asymmetry is why this survived review, and why `claude-acp` agents on the same host were
unaffected in the obvious ways.

## The change

Derive the Git metadata roots from the trusted agent layout — the primary checkout plus every
materialized secondary checkout — rather than from the cwd, and:

1. add them to the sandbox write set, so the index, refs, and objects a worktree commit needs are
   writable;
2. close `hooks` and `config` inside them explicitly, via a new `denyWrite` on `SrtSandboxPolicy`.
   The sandbox runtime's own mandatory protection is derived from the cwd, where an isolated
   worktree's `.git` is a link file rather than a directory, so it never covers these;
3. feed the same roots to the inner Codex profile, replacing the check that could not pass for a
   worktree cwd.

No new plumbing: `prepareRuntimeLaunch` already has the trusted `scopeDir` and already scans the
secondary checkouts, so `daemon.ts` and the CLI are untouched. The primary checkout's *working
tree* stays outside the boundary — isolation is preserved; only its Git metadata is opened.

## Verification

New regression test in `runtime-launch.test.ts` for a session-worktree cwd (a `.git` link file):
asserts the owner `.git` is writable, the working tree beside it is not, `hooks`/`config` are in
`denyWrite`, and the Codex profile lists the same root. Mutation-checked — dropping the primary
checkout from the derivation turns two tests red.

End-to-end against a real Linux `bwrap` sandbox, driven through the daemon's own sandbox provider
with the policy shape this change emits (throwaway fixture repository, primary checkout plus one
worktree):

```
ADD_OK / COMMIT_OK / REF_WRITE_OK
HOOK_WRITE_BLOCKED     (.git/hooks   -> Read-only file system)
CONFIG_WRITE_BLOCKED   (.git/config  -> Read-only file system)
```

## Known remaining gap (not in this PR)

An **unsandboxed** Codex agent with managed credentials takes the early-return path in
`prepare.ts`, which applies the `:workspace` profile with no Git metadata carve-back at all — so
session isolation blocks commits there for the same reason. Closing it means opening `.git` with no
outer boundary underneath, which needs `hooks`/`config` denied inside the Codex profile itself.
That is a separate security judgement and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
