### PR TITLE
fix(web): Linear workspace row, official mark, one-row platform tiles

### DIFF
--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -1244,14 +1244,16 @@ export default function AddIntegrationModal({
           </div>
         )}
         <div className="fldlbl mb-2">Platform</div>
-        {/* One column per offered tile — complete literal strings, so the flagged
-            GitLab tile widens the row instead of wrapping a lone tile below it. */}
+        {/* One column per offered tile — complete literal strings, so every tile shares
+            the one row (the flagged GitLab tile widens it rather than wrapping below). */}
         <div
-          className={
-            platformTiles.length > 6
-              ? 'mb-[18px] grid grid-cols-2 gap-[10px] desktop:grid-cols-7'
-              : 'mb-[18px] grid grid-cols-2 gap-[10px] desktop:grid-cols-6'
-          }
+          className={`mb-[18px] grid grid-cols-2 gap-2 ${
+            platformTiles.length > 7
+              ? 'desktop:grid-cols-8'
+              : platformTiles.length > 6
+                ? 'desktop:grid-cols-7'
+                : 'desktop:grid-cols-6'
+          }`}
         >
           {platformTiles.map((candidate) => {
             const available = isPlatformAvailable(candidate.key)
@@ -1259,7 +1261,7 @@ export default function AddIntegrationModal({
             return (
               <div
                 key={candidate.key}
-                className={`${on ? 'ptile on' : 'ptile'} desktop:flex-col desktop:justify-center desktop:gap-[6px] desktop:px-2 desktop:text-center ${
+                className={`${on ? 'ptile on' : 'ptile'} desktop:flex-col desktop:justify-center desktop:gap-[5px] desktop:px-1.5 desktop:py-[9px] desktop:text-center ${
                   available ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'
                 }`}
                 aria-disabled={!available}
@@ -1267,11 +1269,11 @@ export default function AddIntegrationModal({
                 onClick={available ? () => pickPlatform(candidate.key) : undefined}
               >
                 {candidate.key === 'github' ? (
-                  <span className="flex h-[26px] w-[26px] flex-none items-center justify-center [&>svg]:h-full [&>svg]:w-full">
+                  <span className="flex h-[22px] w-[22px] flex-none items-center justify-center [&>svg]:h-full [&>svg]:w-full">
                     <GithubMark />
                   </span>
                 ) : (
-                  <span className="flex h-[26px] w-[26px] flex-none items-center justify-center">
+                  <span className="flex h-[22px] w-[22px] flex-none items-center justify-center">
                     <PlatformMark platform={candidate.key} fillPct={100} />
                   </span>
                 )}
@@ -1288,7 +1290,7 @@ export default function AddIntegrationModal({
                     }}
                   />
                 ) : (
-                  <span className="font-sans text-[13px] font-semibold leading-normal">{candidate.label}</span>
+                  <span className="font-sans text-[12px] font-semibold leading-normal">{candidate.label}</span>
                 )}
               </div>
             )

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -671,6 +671,13 @@ export interface WebPlatformModule<TApi = unknown> {
    *  Absent ⇒ that list, which is every platform whose rooms are enumerable. */
   agentCard?: WebAgentIntegrationCardFacet
   /**
+   * The console's mirror of the §5 manifest's `soleConversation`: the bot IS its one
+   * conversation (Linear — a workspace is the channel), so the Settings → Bots row
+   * expands to that conversation's default dispatch alone, never to a roster that
+   * would list the workspace beneath itself. Absent ⇒ the generic roster.
+   */
+  soleConversation?: true
+  /**
    * Per-platform transcript text renderer — the §14 defect-3 seam, ADOPTED:
    * `MessageText` resolves it from the ROW's platform key
    * (`MergedRow.sourcePlatform`, falling back to the session's platform) on

--- a/packages/web/src/components/console/platforms/linear/index.tsx
+++ b/packages/web/src/components/console/platforms/linear/index.tsx
@@ -48,6 +48,9 @@ export const linearModule: WebPlatformModule<LinearApi> = {
   // roster the console keeps. The card body below renders the workspace instead, so
   // the generic list is never reached and its semantics would describe nothing.
   agentCard: { Body: LinearWorkspaceRows },
+  // The workspace is the channel (§4.5): the Bots row expands to its default dispatch
+  // alone, never to a roster naming the workspace beneath itself.
+  soleConversation: true,
   // Agent activities are append-only rows with their own ids (§15), so a duplicate
   // across sources is the same activity; anything else never dedupes.
   messageIdentity: (row) => (LINEAR_ACTIVITY_ID.test(row.ts) ? `ts:${row.ts}` : null),

--- a/packages/web/src/components/console/platforms/linear/mark.tsx
+++ b/packages/web/src/components/console/platforms/linear/mark.tsx
@@ -1,27 +1,22 @@
 // No 'use client' here: every consumer is already inside a client boundary —
 // `PlatformMark` (components/marks.tsx) and the module tree under ModalProvider.
 
-import { DEFAULT_MARK_FILL_PCT, markBox } from '@/components/mark-box'
+import { DEFAULT_MARK_FILL_PCT, squareMarkBox } from '@/components/mark-box'
 
 /** Linear's brand purple — the one literal color in this module (STYLE.md rule 1:
  *  a brand value has no design token and stays literal). */
 const LINEAR_PURPLE = '#5e6ad2'
 
 /**
- * Linear's brand mark ({@link WebPlatformModule.Mark}) — four parallel diagonal
- * bars whose ends ride a circle, drawn here as paths rather than imported as an
- * asset. The bar cluster spans ~68% of the viewBox, so the artwork carries its own
- * padding and honours a full-bleed box uncapped, like Telegram's and Lark's.
+ * Linear's official logomark ({@link WebPlatformModule.Mark}): the circle sliced by
+ * diagonal bands that shorten toward the lower-left, as published in the brand kit
+ * (the Simple Icons tracing of it). It fills its viewBox edge to edge like Slack's and
+ * Discord's, so it takes the same capped box a full-bleed square glyph does.
  */
 export function LinearMark({ fillPct = DEFAULT_MARK_FILL_PCT }: { fillPct?: number }) {
   return (
-    <svg viewBox="0 0 100 100" style={markBox(fillPct)} fill="none" aria-hidden>
-      <g stroke={LINEAR_PURPLE} strokeWidth="9" strokeLinecap="round">
-        <path d="M16.1 47.9 47.9 16.1" />
-        <path d="M20.7 67.3 67.3 20.7" />
-        <path d="M32.7 79.3 79.3 32.7" />
-        <path d="M52.1 83.9 83.9 52.1" />
-      </g>
+    <svg viewBox="0 0 24 24" style={squareMarkBox(fillPct)} fill={LINEAR_PURPLE} aria-hidden>
+      <path d="M2.886 4.18A11.982 11.982 0 0 1 11.99 0C18.624 0 24 5.376 24 12.009c0 3.64-1.62 6.903-4.18 9.105L2.887 4.18ZM1.817 5.626l16.556 16.556c-.524.33-1.075.62-1.65.866L.951 7.277c.247-.575.537-1.126.866-1.65ZM.322 9.163l14.515 14.515c-.71.172-1.443.282-2.195.322L0 11.358a12 12 0 0 1 .322-2.195Zm-.17 4.862 9.823 9.824a12.02 12.02 0 0 1-9.824-9.824Z" />
     </svg>
   )
 }

--- a/packages/web/src/components/console/platforms/linear/module.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/module.test.tsx
@@ -53,15 +53,15 @@ describe('the linear registry row', () => {
 })
 
 describe('the linear mark', () => {
-  it('renders inline SVG that honours the fill box uncapped', () => {
-    // The artwork carries its own padding (the bar cluster spans ~68% of the
-    // viewBox), so a full-bleed caller gets 100% rather than the square-glyph cap.
+  it('renders the official glyph inline, capped like the other full-bleed marks', () => {
+    // The logomark fills its viewBox edge to edge, so a full-bleed caller gets the
+    // 80% square-glyph cap rather than outsizing the marks beside it.
     expect(renderToStaticMarkup(<LinearMark />)).toContain('width:60%')
-    expect(renderToStaticMarkup(<LinearMark fillPct={100} />)).toContain('width:100%')
+    expect(renderToStaticMarkup(<LinearMark fillPct={100} />)).toContain('width:80%')
     const markup = renderToStaticMarkup(<LinearMark />)
     expect(markup.startsWith('<svg')).toBe(true)
-    // Four bars, drawn here rather than imported as an asset.
-    expect(markup.match(/<path /g)).toHaveLength(4)
+    // One traced path, drawn here rather than imported as an asset.
+    expect(markup.match(/<path /g)).toHaveLength(1)
   })
 })
 

--- a/packages/web/src/components/console/platforms/registry.ts
+++ b/packages/web/src/components/console/platforms/registry.ts
@@ -132,6 +132,12 @@ export function platformSharingFixed(platformId?: string): boolean {
   return (platformId ? platformRegistry.get(platformId)?.wizard.affordances.share : undefined) === 'fixed'
 }
 
+/** Whether the bot IS its one conversation (`WebPlatformModule.soleConversation`), so
+ *  Settings → Bots offers the default dispatch on the row instead of a roster. */
+export function platformSoleConversation(platformId?: string): boolean {
+  return (platformId ? platformRegistry.get(platformId)?.soleConversation : undefined) === true
+}
+
 /**
  * Whether the Settings → Bots Sharable toggle may be OPERATED for this bot —
  * the platform half of its `disabled` predicate (the viewer's write access and

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -33,7 +33,8 @@ import {
   botCardCopy,
   botSharingEditable,
   platformRegistry,
-  platformSharingFixed
+  platformSharingFixed,
+  platformSoleConversation
 } from '@/components/console/platforms/registry'
 import { BOT_PLATFORM_TABS, botMatchesPlatformTab } from '@/components/console/platforms/host-projections'
 import DeleteBotModal from '@/components/console/modals/DeleteBotModal'
@@ -508,7 +509,24 @@ function BotsCard({
               {CardNotice && <CardNotice bot={b} />}
               {open && (
                 <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 pb-[14px] pl-10 pt-3">
-                  {channels.length > 0 ? (
+                  {/* The bot IS its one conversation: the row expands to that conversation's
+                      default dispatch alone — listing the workspace beneath itself would
+                      name the same thing twice. */}
+                  {platformSoleConversation(b.platform) && showDefaultDispatch ? (
+                    <div className="flex items-center justify-between gap-[11px] rounded-lg border border-(--border-subtle) bg-(--surface-card) px-3 py-2">
+                      <span className="font-mono text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+                        Default dispatch
+                      </span>
+                      <DefaultDispatchPicker
+                        options={agentOptions}
+                        activeId={channels[0]!.agentId ?? b.agentIds[0] ?? null}
+                        disabled={!canWrite || !channels[0]!.integrationId}
+                        onPick={(agentId) =>
+                          setChannelAgent(channels[0]!.integrationId!, channels[0]!.channelId, agentId)
+                        }
+                      />
+                    </div>
+                  ) : channels.length > 0 ? (
                     <>
                       <div
                         className={`grid ${chanGrid} gap-[11px] px-3 pb-[7px] font-mono text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)`}

--- a/packages/web/src/components/marks.test.tsx
+++ b/packages/web/src/components/marks.test.tsx
@@ -130,7 +130,7 @@ describe('PlatformMark', () => {
 
   it('caps the square brand glyphs at 80% while other marks honour a full-bleed box', () => {
     // No padding inside this artwork, so an uncapped fillPct=100 would outsize the marks beside it.
-    for (const platform of ['github', 'gitlab', 'discord']) {
+    for (const platform of ['github', 'gitlab', 'discord', 'linear']) {
       // Slack belongs here too, but renders without `ssr`, so SSR gives it an empty <span>.
       const markup = renderToStaticMarkup(<PlatformMark platform={platform} fillPct={100} />)
       expect(markup, platform).toContain('width:80%')


### PR DESCRIPTION
## Summary
- **Settings → Bots**: a Linear workspace row expanded to a conversation roster that listed the workspace beneath itself. The Linear module now declares `soleConversation` (the console mirror of the §5 manifest fact, read by a new `platformSoleConversation` registry helper) and the row expands to that conversation's default dispatch alone — no `Conversation` header, no self-referential row.
- **Mark**: the Linear glyph was a hand-drawn approximation. It is now the official logomark, one traced path, capped at 80% like the other full-bleed square glyphs.
- **Add integration**: eight platform tiles wrapped onto two rows. The grid picks `grid-cols-8` for eight tiles and the tiles shrink in step (22px icon, 12px label, tighter padding) so every platform shares one row.

## Testing
- `vitest` over the Linear module, marks, IntegrationsView, modals and registry: 19 files / 151 tests green.
- `pnpm --filter @agentconnect.md/web typecheck` and eslint on the touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)