### PR TITLE
fix(daemon): name the Linear delegator and keep the channel label on the workspace

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1163,7 +1163,8 @@ tile.
     unnecessary — the agent surface is four mutations and two queries); token
     cache + `linearcred` renewal; `PlatformSendQueue`; self-echo guard on
     `appUserId`. The read port answers what Linear affords — `getChannelInfo`
-    resolves the issue, `getUserProfile` the Linear user — and returns
+    names the connected workspace (the channel, §4.5), `getUserProfile` the
+    Linear user behind a `linear:`-prefixed sender id — and returns
     empty/`null` elsewhere (no `listBotChannels`, no `leaveChannel`,
     `downloadFile` deferred).
   - `turn-output.ts` — the streaming Layer-2 surface + `LinearConverger` +

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -610,6 +610,9 @@ function acpUpdateChainKey(agentId: string, sessionId: string): string {
 // One agent-discovery pass: what this daemon will serve, plus the whole active fleet on disk.
 type AgentListSnapshot = { agents: LoadedAgent[]; activeFleet: LoadedAgent[] }
 
+/** How long a Linear delivery waits for the delegator's name before dispatching with the id. */
+const LINEAR_ACTOR_LOOKUP_MS = 1500
+
 export class Daemon {
   // This daemon's workspace execution plane. Owned per instance, so two daemons in one process
   // (the test suite, and a k8s daemon beside a local one) cannot inherit each other's git runner,
@@ -6632,12 +6635,40 @@ export class Daemon {
       this.log.info(`linear: session ${ext.agentSessionId} has no issue — answered without starting a turn`)
       return 'settled'
     }
+    const conn = this.lnConnByIntegration.get(msg.integrationId)
+    if (conn) {
+      // Sender and mentions resolve off the hot path, as on every platform whose messages carry
+      // ids alone — the session list and its avatars read the cache this fills.
+      this.channelNameResolver?.noteMessage(conn, normalized)
+      // The §8 header names the delegator, and a `created` event carries only `creatorId`: a
+      // bounded lookup fills the name the relay could not, the cache first. A miss keeps the id.
+      if (!normalized.sender.name) {
+        const name = await this.linearActorName(conn, normalized.sender.id)
+        if (name) normalized.sender = { ...normalized.sender, name }
+      }
+    }
     applyLinearMessageStrategy(normalized)
     // No per-event channel name: the channel is the WORKSPACE, so its label is install-scoped and
     // already written when the connection reported the workspace (§4.5). Writing the issue here
     // would thrash the one display slot and relabel every sibling session in the workspace; the
     // issue rides `threadUrl` and the §8 trusted header, which are session-scoped.
     return 'dispatch'
+  }
+
+  /** The delegator's display name for the §8 header: the cache, else one lookup bounded by
+   *  {@link LINEAR_ACTOR_LOOKUP_MS} so a slow provider never holds the delivery. */
+  private async linearActorName(conn: LinearConnection, senderId: string): Promise<string | undefined> {
+    const cached = (await this.store.getDisplayNames([senderId])).get(senderId)
+    if (cached) return cached
+    const lookup = conn
+      .getUserProfile(senderId)
+      .then((p) => p.name || p.realName || undefined)
+      .catch(() => undefined)
+    const deadline = new Promise<undefined>((resolve) => {
+      const timer = setTimeout(() => resolve(undefined), LINEAR_ACTOR_LOOKUP_MS)
+      timer.unref?.()
+    })
+    return await Promise.race([lookup, deadline])
   }
 
   /** Has this daemon already served this exact Linear delivery? A read failure answers NO:

--- a/packages/daemon/src/platforms/linear/connection.ts
+++ b/packages/daemon/src/platforms/linear/connection.ts
@@ -14,9 +14,10 @@
  * cached token keeps serving until it actually expires, and only then does a send fail.
  * Token material never reaches a log line.
  *
- * The read port answers what Linear affords: `getChannelInfo` resolves the issue and
- * `getUserProfile` the Linear user; everything else answers empty. There is no bot
- * channel enumeration, no leave affordance, and attachment download is deferred.
+ * The read port answers what Linear affords: `getChannelInfo` names the connected
+ * workspace — the channel (§4.5) — and `getUserProfile` the Linear user, whose id the
+ * relay prefixes `linear:`; everything else answers empty. There is no bot channel
+ * enumeration, no leave affordance, and attachment download is deferred.
  */
 import { randomUUID } from 'node:crypto'
 import type { IntegrationLinearConfig, LinearCredGrant } from '@agentconnect.md/protocol'
@@ -192,6 +193,11 @@ const defaultSetTimer = (fn: () => void, ms: number): unknown => {
   return t
 }
 
+/** The relay's sender id is `linear:<userId>` (§6.1); Linear's API wants the bare id. */
+export function bareLinearUserId(id: string): string {
+  return id.startsWith('linear:') ? id.slice('linear:'.length) : id
+}
+
 export class LinearConnection implements PlatformConnection {
   /** All outbound writes funnel through one queue so activities land in converger order. */
   private readonly queue: PlatformSendQueue
@@ -343,42 +349,34 @@ export class LinearConnection implements PlatformConnection {
 
   // ── 3. read / query port ──
 
-  /** The issue behind a session's channel id. `channel` is the issue UUID, or — for a
-   *  session with no issue (§4.5) — the AgentSession UUID, which resolves nothing and
-   *  answers the bare id rather than throwing. */
+  /** The channel is the connected workspace (§4.5), whose name the spec already carries — no
+   *  lookup, and never an issue: the one display slot is shared by every session in it. */
   async getChannelInfo(channel: string): Promise<PlatformChannelInfo> {
-    try {
-      const data = await this.graphql<{
-        issue?: { id?: string; identifier?: string; title?: string } | null
-      }>(ISSUE_QUERY, { id: channel })
-      const issue = data.issue
-      if (!issue) return { id: channel, isIm: false }
-      const name = [issue.identifier, issue.title].filter((p) => p !== undefined && p !== '').join(' · ')
-      return { id: channel, ...(name ? { name } : {}), isIm: false }
-    } catch (err) {
-      this.deps.log?.debug(`linear: issue lookup failed (${channel}): ${(err as Error).message}`)
-      return { id: channel, isIm: false }
-    }
+    const name = this.workspaceName?.trim()
+    return { id: channel, ...(name ? { name } : {}), isIm: false }
   }
 
+  /** Answers under the caller's own key: the relay hands out `linear:<userId>`, Linear wants the
+   *  bare id, and the display cache is keyed by whatever the message carried. */
   async getUserProfile(user: string): Promise<PlatformUserProfile> {
+    const id = bareLinearUserId(user)
     try {
       const data = await this.graphql<{
         user?: { id?: string; name?: string; displayName?: string; avatarUrl?: string | null } | null
-      }>(USER_QUERY, { id: user })
+      }>(USER_QUERY, { id })
       const u = data.user
-      if (!u) return { id: user, isBot: this.isSelfAuthored(user) }
+      if (!u) return { id: user, isBot: this.isSelfAuthored(id) }
       return {
-        id: u.id ?? user,
+        id: user,
         ...(u.displayName ? { name: u.displayName } : {}),
         ...(u.name ? { realName: u.name } : {}),
         ...(u.avatarUrl ? { avatarUrl: u.avatarUrl } : {}),
         // A plain user read carries no bot flag; the app's own id is the one we can name (§7.2).
-        isBot: this.isSelfAuthored(u.id ?? user)
+        isBot: this.isSelfAuthored(u.id ?? id)
       }
     } catch (err) {
-      this.deps.log?.debug(`linear: user lookup failed (${user}): ${(err as Error).message}`)
-      return { id: user, isBot: this.isSelfAuthored(user) }
+      this.deps.log?.debug(`linear: user lookup failed (${id}): ${(err as Error).message}`)
+      return { id: user, isBot: this.isSelfAuthored(id) }
     }
   }
 
@@ -588,10 +586,6 @@ const AGENT_ACTIVITY_CREATE = `mutation AgentActivityCreate($input: AgentActivit
 
 const AGENT_SESSION_UPDATE = `mutation AgentSessionUpdate($id: String!, $input: AgentSessionUpdateInput!) {
   agentSessionUpdate(id: $id, input: $input) { success }
-}`
-
-const ISSUE_QUERY = `query Issue($id: String!) {
-  issue(id: $id) { id identifier title url }
 }`
 
 const USER_QUERY = `query User($id: String!) {

--- a/packages/daemon/test/linear-connection.test.ts
+++ b/packages/daemon/test/linear-connection.test.ts
@@ -749,20 +749,32 @@ describe('linear graphql client (§9.4)', () => {
 })
 
 describe('linear read port (§9.4 — what Linear affords)', () => {
-  it('resolves the issue behind a channel id into identifier · title', async () => {
-    const { conn, calls } = harness({
-      respond: () => jsonResponse({ data: { issue: { id: ISSUE, identifier: 'TEAM-123', title: 'Fix the parser' } } })
-    })
-    expect(await conn.getChannelInfo(ISSUE)).toEqual({ id: ISSUE, name: 'TEAM-123 · Fix the parser', isIm: false })
-    expect(calls[0]!.query).toContain('issue(')
-    expect(calls[0]!.variables).toEqual({ id: ISSUE })
+  it('names the channel after the connected workspace, with no lookup and never an issue', async () => {
+    // The one display slot is shared by every session in the workspace (§4.5): an issue-derived
+    // answer here would relabel all of them with whichever issue was read last.
+    const { conn, calls } = harness()
+    expect(await conn.getChannelInfo(WORKSPACE)).toEqual({ id: WORKSPACE, name: 'Example Workspace', isIm: false })
+    expect(calls).toHaveLength(0)
   })
 
-  it('answers the bare id for a session with no issue, and for a failed lookup', async () => {
-    const missing = harness({ respond: () => jsonResponse({ data: { issue: null } }) })
-    expect(await missing.conn.getChannelInfo(SESSION)).toEqual({ id: SESSION, isIm: false })
-    const failing = harness({ respond: () => jsonResponse({}, 500) })
-    expect(await failing.conn.getChannelInfo(SESSION)).toEqual({ id: SESSION, isIm: false })
+  it('omits the channel name when the spec carried none, still without a lookup', async () => {
+    const config = { ...linearConfig() } as Record<string, unknown>
+    delete config.workspaceName
+    const { conn, calls } = harness({ config })
+    expect(await conn.getChannelInfo(WORKSPACE)).toEqual({ id: WORKSPACE, isIm: false })
+    expect(calls).toHaveLength(0)
+  })
+
+  it('strips the relay’s linear: prefix for the user query and answers under the caller’s key', async () => {
+    const { conn, calls } = harness({
+      respond: () => jsonResponse({ data: { user: { id: 'user-9', name: 'Ada Lovelace', displayName: 'ada' } } })
+    })
+    // The display cache is keyed by the id the message carried, so the answer keeps it.
+    expect(await conn.getUserProfile('linear:user-9')).toMatchObject({ id: 'linear:user-9', name: 'ada' })
+    expect(calls[0]!.variables).toEqual({ id: 'user-9' })
+    // The self-echo guard compares bare ids on both sides.
+    const self = harness({ respond: () => jsonResponse({ data: { user: { id: 'app-user-1', name: 'Agent' } } }) })
+    expect((await self.conn.getUserProfile('linear:app-user-1')).isBot).toBe(true)
   })
 
   it('resolves a Linear user, preferring the display name and keeping the full name', async () => {

--- a/packages/daemon/test/linear-ingress.test.ts
+++ b/packages/daemon/test/linear-ingress.test.ts
@@ -372,6 +372,42 @@ describe('§10.1 the pre-spawn acknowledgement', () => {
     await daemon.stop()
   })
 
+  it('names the delegator in the §8 header when the event carried only an id', async () => {
+    // A `created` event has no activity user — only `creatorId` — so the relay ships the id
+    // alone and the daemon fills the name with one bounded lookup, keyed as the relay keyed it.
+    const { daemon } = await boot()
+    const asked: string[] = []
+    ;(daemon as any).lnConnByIntegration.get(INTEGRATION).getUserProfile = async (id: string) => {
+      asked.push(id)
+      return { id, name: 'ada', isBot: false }
+    }
+    const dispatched: { text: string }[] = []
+    ;(daemon as any).dispatch = vi.fn(async (_a: string, msg: any) => {
+      dispatched.push(msg)
+      return null
+    })
+    await im(daemon, delivery({ sender: { id: 'linear:user-1', isBot: false } }))
+    expect(dispatched[0]!.text.split('\n')[0]).toBe('Linear TEAM-123 "Ship the thing" — delegated by ada')
+    expect(asked).toContain('linear:user-1')
+    await daemon.stop()
+  })
+
+  it('reads the delegator’s name from the display cache before asking Linear', async () => {
+    const { daemon, store } = await boot()
+    await store.setDisplayName('linear:user-1', 'Dana (cached)', Date.now())
+    ;(daemon as any).lnConnByIntegration.get(INTEGRATION).getUserProfile = async () => {
+      throw new Error('the cache should have answered')
+    }
+    const dispatched: { text: string }[] = []
+    ;(daemon as any).dispatch = vi.fn(async (_a: string, msg: any) => {
+      dispatched.push(msg)
+      return null
+    })
+    await im(daemon, delivery({ sender: { id: 'linear:user-1', isBot: false } }))
+    expect(dispatched[0]!.text.split('\n')[0]).toBe('Linear TEAM-123 "Ship the thing" — delegated by Dana (cached)')
+    await daemon.stop()
+  })
+
   it('rewrites the dispatched text into the §8 prompt', async () => {
     const { daemon } = await boot()
     const dispatched: { text: string; headless?: boolean }[] = []


### PR DESCRIPTION
## Summary
- **Sender identity never resolved.** The relay ships sender ids as `linear:<userId>` and the connection passed that prefixed id straight to Linear's `user(id:)` query, so the session list showed the raw id with a letter avatar. `getUserProfile` now strips the prefix for the query and answers under the caller's key (how the display cache is keyed); the self-echo guard compares bare ids.
- **"delegated by <uuid>".** A `created` event carries only `creatorId`. `prepareLinearDelivery` now resolves the delegator's name before the §8 header is assembled — the display cache first, else one lookup bounded at 1.5 s — and notes the message with the channel-name resolver so senders and mentions resolve off the hot path like every other observed platform.
- **`getChannelInfo` answered an issue.** A leftover of the issue-is-channel model: the channel is the workspace (§4.5) and its one display slot is shared by every session in it, so the read port now names the workspace from the spec with no lookup. Design §9.4 wording updated to match.

## Testing
- `vitest` over `linear-connection`, `linear-ingress`, `linear-message-strategy`: 103 tests green, including the new cases (prefix stripped + caller's key kept; workspace name with zero calls; header named from a lookup and from the cache).
- `pnpm --filter @agentconnect.md/daemon typecheck` and eslint on the touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)