### PR TITLE
fix(daemon): name the primary checkout rather than assuming the default layout

### DIFF
--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -141,6 +141,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     // Same sandbox write carve-back the daemon grants: without it a sandboxed chat run cannot write
     // its own session worktrees, nor read the secondary roots beside them.
     trustedWorkspaceWriteRoots: runInSandbox ? workspaces.trustedWorkspaceWriteRoots(agent) : undefined,
+    trustedPrimaryCheckout: runInSandbox ? workspaces.localPrimaryCheckoutFor(agent) : undefined,
     // No daemon here, so there is no MCP bridge socket, gh wrapper, or git-credential shim to carve
     // back: mcpSocketPath / allowModelToolUnixSockets / runtimeReadRoots stay genuinely unused.
     sandboxMechanism

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4005,6 +4005,7 @@ export class Daemon {
               this.sandboxRuntimeReadRoots(agent, runtime, launchEnv, githubAppCredentials, gitlabCredentials)
           : undefined,
         trustedWorkspaceWriteRoots: runInSandbox ? this.workspaces.trustedWorkspaceWriteRoots(agent) : undefined,
+        trustedPrimaryCheckout: runInSandbox ? this.workspaces.localPrimaryCheckoutFor(agent) : undefined,
         sandboxMechanism: this.sandboxMechanism,
         mcpSocketPath: mcpSocketPath(this.root),
         // Inner tool sandboxes must CONNECT to the daemon socket for either

--- a/packages/daemon/src/launch/assemble.ts
+++ b/packages/daemon/src/launch/assemble.ts
@@ -39,6 +39,7 @@ export interface AssembleRuntimeLaunchOptions {
   /** Daemon-owned code/socket/config carve-backs; a function receives the final launch env. */
   runtimeReadRoots?: string[] | ((launchEnv: Record<string, string>) => string[] | undefined)
   trustedWorkspaceWriteRoots?: string[]
+  trustedPrimaryCheckout?: string
   sandboxMechanism?: SandboxMechanism
   mcpSocketPath?: string
   allowModelToolUnixSockets?: boolean
@@ -89,6 +90,7 @@ export function assembleRuntimeLaunch(opts: AssembleRuntimeLaunchOptions): Assem
     explicitEnv: launchEnv,
     runtimeReadRoots,
     trustedWorkspaceWriteRoots: opts.trustedWorkspaceWriteRoots,
+    trustedPrimaryCheckout: opts.trustedPrimaryCheckout,
     sandboxMechanism: opts.sandboxMechanism,
     mcpSocketPath: opts.mcpSocketPath,
     allowModelToolUnixSockets: opts.allowModelToolUnixSockets,

--- a/packages/daemon/src/launch/compose.ts
+++ b/packages/daemon/src/launch/compose.ts
@@ -153,6 +153,7 @@ export function composeRuntimeLaunch(opts: {
    * descendants such as the AgentConnect MCP bridge. */
   runtimeReadRoots?: string[]
   trustedWorkspaceWriteRoots?: string[]
+  trustedPrimaryCheckout?: string
   sandboxMechanism?: SandboxMechanism
   mcpSocketPath?: string
   allowModelToolUnixSockets?: boolean
@@ -194,6 +195,7 @@ export function composeRuntimeLaunch(opts: {
     agentsRoot: opts.agentsRoot,
     trustedRuntimeReadRoots: [...(sandboxAccess?.readRoots ?? []), ...(opts.runtimeReadRoots ?? [])],
     trustedWorkspaceWriteRoots: opts.trustedWorkspaceWriteRoots,
+    trustedPrimaryCheckout: opts.trustedPrimaryCheckout,
     sandboxMechanism: opts.sandboxMechanism,
     mcpSocketPath: opts.mcpSocketPath,
     allowModelToolUnixSockets: opts.allowModelToolUnixSockets,

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -171,6 +171,7 @@ export function prepareRuntimeLaunch(opts: {
   /** Additional daemon-derived workspace parents (for session worktrees).
    * Every entry is revalidated as a strict descendant of scopeDir. */
   trustedWorkspaceWriteRoots?: string[]
+  trustedPrimaryCheckout?: string
   /** Test seam. Shared login remains Linux-only with the sandbox rollout. */
   credentialPlatform?: NodeJS.Platform
   sandboxMechanism?: SandboxMechanism
@@ -378,8 +379,16 @@ export function prepareRuntimeLaunch(opts: {
   // An isolated session's cwd is its own worktree, but that worktree's index — and every ref and
   // object its commits write — live in the OWNER checkout's `.git`, which no other carve-back
   // covers. Without these the confined runtime cannot even run `git status` in its own worktree.
+  // The primary checkout is the daemon's own record of it: a locally authored agent may keep a
+  // path the default layout does not name, and its worktrees still hang off THAT checkout.
+  const primaryCheckout = opts.trustedPrimaryCheckout
+    ? safeRoot(opts.trustedPrimaryCheckout, 'trusted primary checkout')
+    : primaryCheckoutIn(agentRoot)
+  if (primaryCheckout === agentRoot || !inside(agentRoot, primaryCheckout)) {
+    throw new Error(`trusted primary checkout "${primaryCheckout}" is outside the agent root`)
+  }
   const gitMetadataWriteRoots = compactReadRoots(
-    [primaryCheckoutIn(agentRoot), ...secondaryCheckoutsIn(agentRoot)]
+    [primaryCheckout, ...secondaryCheckoutsIn(agentRoot)]
       .map((checkout) => join(checkout, '.git'))
       .filter((gitDir) => existsSync(gitDir) && lstatSync(gitDir).isDirectory())
       .map((gitDir) => {

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -1114,6 +1114,12 @@ export class WorkspaceManager {
     return join(this.agentRootFor(agent), 'worktrees')
   }
 
+  /** The same disk's primary checkout — the one whose `.git` owns every session worktree's index,
+   *  refs, and objects. A locally authored agent may keep a path that is not the default one. */
+  localPrimaryCheckoutFor(agent: Agent): string {
+    return this.primaryCheckoutAt(agent, undefined)
+  }
+
   /** The primary root's worktrees parent, under the name the daemon and CLI already address it by. */
   sessionWorktreeRoot(agent: Agent): string {
     return this.worktreesPathFor(agent)

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -386,6 +386,53 @@ describe('prepareRuntimeLaunch', () => {
     expect(writes.some((value) => value.includes(`"${realpathSync(primaryGit)}" = "write"`))).toBe(true)
   })
 
+  // A locally authored agent may keep a checkout path the default layout does not name, and its
+  // session worktrees still hang off THAT checkout — so the daemon names it rather than assuming.
+  it('follows the daemon-supplied primary checkout rather than the default layout path', () => {
+    const { scopeDir, hostHome } = fixture()
+    const primaryGit = join(scopeDir, 'legacy-checkout', '.git')
+    const worktrees = join(scopeDir, 'worktrees')
+    const cwd = join(worktrees, 'session-1')
+    mkdirSync(primaryGit, { recursive: true })
+    mkdirSync(cwd, { recursive: true })
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      trustedWorkspaceWriteRoots: [worktrees],
+      trustedPrimaryCheckout: join(scopeDir, 'legacy-checkout'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const policy = JSON.parse(readFileSync(launch.sandbox!.settingsPath, 'utf8'))
+    expect(coveredBy(policy.filesystem.allowWrite, realpathSync(primaryGit))).toBe(true)
+    expect(policy.filesystem.denyWrite).toContain(join(realpathSync(primaryGit), 'hooks'))
+  })
+
+  it('refuses a primary checkout outside the agent root instead of carving it back', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    expect(() =>
+      prepareRuntimeLaunch({
+        runtimeId: 'codex-acp',
+        runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+        scopeDir,
+        cwd,
+        runInSandbox: true,
+        daemonRoot: dirname(scopeDir),
+        sandboxMechanism: 'bwrap',
+        credentialPlatform: 'linux',
+        trustedPrimaryCheckout: dirname(scopeDir),
+        hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+      })
+    ).toThrow(/trusted primary checkout .* is outside the agent root/)
+  })
+
   it('rejects root-level protected paths instead of generating an ineffective policy', () => {
     const { scopeDir, cwd, hostHome } = fixture()
     expect(() =>


### PR DESCRIPTION
Follow-up to #1695, addressing the compatibility warning left on its review.

## What was still wrong

#1695 derived the Git metadata carve-back from the default layout path, `<agentRoot>/workspace/.git`.
The daemon still honors a locally authored `workspace.path` that the default layout does not name:
`WorkspaceManager.primaryRootAt()` reads it, and `applySpecFields()` deliberately preserves it across
updates. Such an agent's session worktrees still hang off THAT checkout, under
`<agentRoot>/worktrees/<sid>` as usual — so the lookup found no `.git`, carved back nothing, and the
original failure survived for exactly those agents: `git add` dying on the index lock with
"Read-only file system", and `git status` failing outright.

Agents created through the control plane get the default path, so this was a latent gap rather than a
live one, but it is the same bug with a different address.

## What changed

The launch path is told which checkout is primary instead of assuming it. `WorkspaceManager` already
resolves it per host, so it gains `localPrimaryCheckoutFor()` beside the existing
`localWorktreesPathFor()`, and `prepareRuntimeLaunch` revalidates it as a strict descendant of the
agent root — the same rule every other trusted write root passes. The default layout path remains the
fallback for callers that have no agent to ask (probes, the model enumerator, the skills cells).

## Reviewer notes

- The containment check is the security-relevant part: a supplied checkout equal to or outside the
  agent root is refused rather than carved back, so this cannot become a way to widen the boundary.
- Two regression tests: a non-default checkout whose `.git` is carved back with `hooks` and `config`
  still closed, and the refusal above.
- Unchanged from #1695: `hooks` and `config` stay denied inside every metadata root, and the primary
  working tree itself is still outside the boundary — isolation is what the worktree is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
