### PR TITLE
feat(linear): list the session in the issue's Resources

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -60,21 +60,22 @@ rather than inventing a Linear-shaped side channel.
 
 ### Feature checklist
 
-| Linear agent experience                             | This design                                                  | Phase |
-| --------------------------------------------------- | ------------------------------------------------------------ | ----- |
-| Assign/delegate an issue to the app                 | `created` → session with the workspace's dispatch default    | P1    |
-| Address a specific agent with instructions          | Same webhook; `@<agent-name>` in the mention text routes     | P1    |
-| Instant acknowledgement in the feed                 | Daemon-side auto-ack `thought` before the turn starts        | P1    |
-| Real-time activity feed (commands, files, progress) | `LinearConverger` → `agentActivityCreate`                    | P1    |
-| Follow-up messages in the session thread            | `prompted` → same AgentConnect session                       | P1    |
-| Stop signal puts the agent to sleep                 | `prompted` + `signal:"stop"` → `interruptTurn`               | P1    |
-| Link to the agent's own session view                | `externalUrls` → console session deep link                   | P1    |
-| Todo list synced to Linear's plan UI                | ACP `plan` updates → `agentSessionUpdate.plan`               | P2    |
-| PR URL attached to the session                      | Detected PR links → `addedExternalUrls`                      | P2    |
-| Moves the issue into a started status               | Workflow-state transition on delegation (config toggle)      | P2    |
-| Playbook labels (`!plan`, `!implement`, …)          | Label → skill/prompt-preset mapping                          | P3    |
-| Repo suggestions for multi-repo orgs                | `issueRepositorySuggestions`                                 | P3    |
-| Linear-side automation triggers delegate issues     | Free — automation delegation raises the same `created` event | P1    |
+| Linear agent experience                             | This design                                                                          | Phase |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------ | ----- |
+| Assign/delegate an issue to the app                 | `created` → session with the workspace's dispatch default                            | P1    |
+| Address a specific agent with instructions          | Same webhook; `@<agent-name>` in the mention text routes                             | P1    |
+| Instant acknowledgement in the feed                 | Daemon-side auto-ack `thought` before the turn starts                                | P1    |
+| Real-time activity feed (commands, files, progress) | `LinearConverger` → `agentActivityCreate`                                            | P1    |
+| Follow-up messages in the session thread            | `prompted` → same AgentConnect session                                               | P1    |
+| Stop signal puts the agent to sleep                 | `prompted` + `signal:"stop"` → `interruptTurn`                                       | P1    |
+| Link to the agent's own session view                | `externalUrls` → console session deep link                                           | P1    |
+| Session listed in the issue's Resources             | `attachmentCreate` at the first turn (URL-idempotent per issue) → the same deep link | P1    |
+| Todo list synced to Linear's plan UI                | ACP `plan` updates → `agentSessionUpdate.plan`                                       | P2    |
+| PR URL attached to the session                      | Detected PR links → `addedExternalUrls`                                              | P2    |
+| Moves the issue into a started status               | Workflow-state transition on delegation (config toggle)                              | P2    |
+| Playbook labels (`!plan`, `!implement`, …)          | Label → skill/prompt-preset mapping                                                  | P3    |
+| Repo suggestions for multi-repo orgs                | `issueRepositorySuggestions`                                                         | P3    |
+| Linear-side automation triggers delegate issues     | Free — automation delegation raises the same `created` event                         | P1    |
 
 **Non-goals for v1:** working document/project mentions without an attached
 issue (they receive a bounded unsupported-surface response, §4.5 — never a

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1014,6 +1014,9 @@ export class Daemon {
   // integrationId -> the LinearConnection that owns it. Linear's only reply surface is the
   // agent activity feed (§4.6), so this is the egress port every Linear write resolves through.
   private lnConnByIntegration = new Map<string, LinearConnection>()
+  // Sessions whose console link already sits in the issue's Resources (Linear keys the entry
+  // on the URL, so a restart re-sending it refreshes rather than duplicates).
+  private readonly linearResourcesAttached = new Set<string>()
   // agentId → the in-flight (or resolved) host-startup promise. Resolves to the
   // STARTED host (startHostWithRetry may build several across retries — the last,
   // successful one wins). `.has()` doubles as "is this agent starting / started?".
@@ -10826,6 +10829,20 @@ export class Daemon {
     // replace that same card. `none` mode returns no start action.
     if (p.conv instanceof FeishuConverger) {
       for (const action of p.conv.onStart()) this.enqueueApply(p, action)
+    }
+    // Linear: the session shows up in the issue's Resources from the first turn on — the same
+    // console deep link the footer carries, keyed on the issue UUID the relay put in the bag.
+    if (p.conv instanceof LinearConverger && !this.linearResourcesAttached.has(run.key)) {
+      const issueId = readLinearExt(entry.msg)?.issueId
+      if (issueId) {
+        const info = await currentAttributionInfo()
+        const subtitle = [info.botName, info.runtime, info.model].filter((s) => s.trim()).join(' · ')
+        this.linearResourcesAttached.add(run.key)
+        this.enqueueApply(p, {
+          kind: 'attachment',
+          input: { issueId, url: info.sessionUrl, title: 'AgentConnect session', ...(subtitle ? { subtitle } : {}) }
+        })
+      }
     }
     // The pod wait ENDED inside openSession, so its label must not outlive it: a bootstrap turn
     // transitions to "is thinking…" here even when its host was already running (a suspended pod

--- a/packages/daemon/src/platforms/linear/connection.ts
+++ b/packages/daemon/src/platforms/linear/connection.ts
@@ -20,6 +20,7 @@
  * enumeration, no leave affordance, and attachment download is deferred.
  */
 import { randomUUID } from 'node:crypto'
+import type { LinearAttachmentInput, LinearActivityInput } from './turn-output.js'
 import type { IntegrationLinearConfig, LinearCredGrant } from '@agentconnect.md/protocol'
 import type { Agent } from '../../agents/agent-schema.js'
 import type { Logger } from '../../log.js'
@@ -32,7 +33,6 @@ import type {
 } from '../contract.js'
 import { platformIntegrationConfig } from '../integration-config.js'
 import { PlatformSendQueue } from '../send-queue.js'
-import type { LinearActivityInput } from './turn-output.js'
 
 /** Linear's single GraphQL endpoint (§2). Overridable per connection for tests only. */
 export const LINEAR_GRAPHQL_ENDPOINT = 'https://api.linear.app/graphql'
@@ -336,6 +336,12 @@ export class LinearConnection implements PlatformConnection {
     })
   }
 
+  /** `attachmentCreate` — the issue's Resources entry. Needs no idempotency key of ours: Linear
+   *  treats the URL as one per issue, so a retry or a later turn refreshes the same entry. */
+  async createIssueAttachment(input: LinearAttachmentInput): Promise<void> {
+    await this.enqueueGraphql<{ attachmentCreate?: { success?: boolean } }>(ATTACHMENT_CREATE, { input })
+  }
+
   /** Full-array plan replace — both sides have the same semantics (§5.1). */
   async updateSessionPlan(agentSessionId: string, entries: LinearPlanEntry[]): Promise<void> {
     await this.updateSession(agentSessionId, { plan: entries })
@@ -586,6 +592,10 @@ const AGENT_ACTIVITY_CREATE = `mutation AgentActivityCreate($input: AgentActivit
 
 const AGENT_SESSION_UPDATE = `mutation AgentSessionUpdate($id: String!, $input: AgentSessionUpdateInput!) {
   agentSessionUpdate(id: $id, input: $input) { success }
+}`
+
+const ATTACHMENT_CREATE = `mutation AttachmentCreate($input: AttachmentCreateInput!) {
+  attachmentCreate(input: $input) { success }
 }`
 
 const USER_QUERY = `query User($id: String!) {

--- a/packages/daemon/src/platforms/linear/message-strategy.ts
+++ b/packages/daemon/src/platforms/linear/message-strategy.ts
@@ -32,6 +32,7 @@ const LinearPreviousComment = z.object({
  *  older relay may omit any optional field, and none of them is load-bearing for the turn. */
 export const LinearAdapterExtSchema = z.object({
   agentSessionId: z.string().min(1),
+  issueId: z.string().optional(),
   issueIdentifier: z.string().optional(),
   issueTitle: z.string().optional(),
   promptContext: z.string().optional(),

--- a/packages/daemon/src/platforms/linear/turn-output.ts
+++ b/packages/daemon/src/platforms/linear/turn-output.ts
@@ -40,6 +40,16 @@ export type LinearAction =
   | { kind: 'activity'; type: 'elicitation'; body: string }
   | { kind: 'plan'; entries: LinearPlanEntry[] }
   | { kind: 'external-urls'; add: LinearExternalUrl[] }
+  | { kind: 'attachment'; input: LinearAttachmentInput }
+
+/** One `attachmentCreate` input — the issue's Resources entry. Linear keys it on `(issueId, url)`,
+ *  so re-sending the same URL updates the entry rather than adding a second one. */
+export interface LinearAttachmentInput {
+  issueId: string
+  url: string
+  title: string
+  subtitle?: string
+}
 
 /** One `agentActivityCreate` input, flattened. The egress port owns the GraphQL shape. */
 export interface LinearActivityInput {
@@ -69,6 +79,8 @@ export interface LinearEgressPort {
   postActivity(sessionId: string, activity: LinearActivityInput): Promise<void>
   /** Patch the AgentSession's plan / external URLs. */
   updateSession(sessionId: string, update: LinearSessionUpdateInput): Promise<void>
+  /** Add (or refresh, by URL) one entry in the issue's Resources. */
+  createIssueAttachment(input: LinearAttachmentInput): Promise<void>
 }
 
 /** The core turn, as Linear's applier sees it. `Pending` satisfies it structurally. */
@@ -635,6 +647,11 @@ export async function applyLinearAction<TTurn extends LinearTurn>(
     case 'external-urls': {
       if (action.add.length === 0) return
       await port.updateSession(sessionId, { addedExternalUrls: action.add })
+      return
+    }
+    case 'attachment': {
+      // Issue-scoped, not feed chrome: it never draws on the activity budget.
+      await port.createIssueAttachment(action.input)
       return
     }
   }

--- a/packages/daemon/test/linear-connection.test.ts
+++ b/packages/daemon/test/linear-connection.test.ts
@@ -719,6 +719,18 @@ describe('linear graphql client (§9.4)', () => {
     expect(calls[0]!.variables).toEqual({ id: SESSION, input: { plan: [{ content: 'step', status: 'pending' }] } })
   })
 
+  it('sends the issue resource as one attachmentCreate, keyed by Linear on the URL', async () => {
+    const { conn, calls } = harness()
+    const input = {
+      issueId: 'issue-uuid',
+      url: 'https://console.example.test/sessions/s1',
+      title: 'AgentConnect session'
+    }
+    await conn.createIssueAttachment(input)
+    expect(calls[0]!.query).toContain('attachmentCreate(')
+    expect(calls[0]!.variables).toEqual({ input })
+  })
+
   it('never retries a terminal refusal', async () => {
     const { conn, calls } = harness({
       respond: () =>

--- a/packages/daemon/test/linear-ingress.test.ts
+++ b/packages/daemon/test/linear-ingress.test.ts
@@ -105,6 +105,7 @@ async function boot(opts: BootOpts = {}) {
   // then take the binding over with a recording fake — no GraphQL leaves this test.
   await (daemon as any).connections.reconcileLinearConnections()
   const posted: Posted[] = []
+  const attached: { issueId: string; url: string; title: string; subtitle?: string }[] = []
   const store = (daemon as any).store
   const conn = {
     integrationId: INTEGRATION,
@@ -117,7 +118,10 @@ async function boot(opts: BootOpts = {}) {
       const rows = await store.listInboxBySessionKeyFifo()
       posted.push({ sessionId, activity, inboxAdmitted: rows.length > 0 })
     },
-    async updateSession() {}
+    async updateSession() {},
+    async createIssueAttachment(input: { issueId: string; url: string; title: string; subtitle?: string }) {
+      attached.push(input)
+    }
   }
   ;(daemon as any).lnConnByIntegration.set(INTEGRATION, conn)
   /** Rows for work still owed. A born-completed receipt is excluded — outliving the turn is
@@ -158,7 +162,7 @@ async function boot(opts: BootOpts = {}) {
     for (let i = 0; i < 4; i += 1) await pendingRows()
     expect(await pendingRows()).toBe(0)
   }
-  return { daemon, posted, store, pendingRows, turnSettled }
+  return { daemon, posted, attached, store, pendingRows, turnSettled }
 }
 
 const transportScope = (daemon: Daemon): string | undefined =>
@@ -405,6 +409,28 @@ describe('§10.1 the pre-spawn acknowledgement', () => {
     })
     await im(daemon, delivery({ sender: { id: 'linear:user-1', isBot: false } }))
     expect(dispatched[0]!.text.split('\n')[0]).toBe('Linear TEAM-123 "Ship the thing" — delegated by Dana (cached)')
+    await daemon.stop()
+  })
+
+  it('puts the console session in the issue’s Resources at the first turn, once per session', async () => {
+    const { daemon, attached, turnSettled } = await boot()
+    await im(daemon, delivery({}, { issueId: 'issue-uuid' }))
+    await turnSettled()
+    expect(attached).toHaveLength(1)
+    expect(attached[0]).toMatchObject({ issueId: 'issue-uuid', title: 'AgentConnect session' })
+    expect(attached[0]!.url).toMatch(/^https?:\/\/.+\/sessions\//)
+    // The follow-up on the same session does not re-send it.
+    await im(daemon, delivery({ msgId: 'linear:activity-2' }, { issueId: 'issue-uuid' }))
+    await turnSettled()
+    expect(attached).toHaveLength(1)
+    await daemon.stop()
+  })
+
+  it('skips the resource when the bag names no issue', async () => {
+    const { daemon, attached, turnSettled } = await boot()
+    await im(daemon, delivery())
+    await turnSettled()
+    expect(attached).toEqual([])
     await daemon.stop()
   })
 

--- a/packages/daemon/test/linear-turn-output.test.ts
+++ b/packages/daemon/test/linear-turn-output.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import {
   applyLinearAction,
+  type LinearAttachmentInput,
   createLinearConverger,
   initialLinearTurnState,
   LinearConverger,
@@ -486,6 +487,10 @@ class FakePort {
   async updateSession(sessionId: string, update: LinearSessionUpdateInput): Promise<void> {
     this.updates.push({ sessionId, update })
   }
+  readonly attachments: LinearAttachmentInput[] = []
+  async createIssueAttachment(input: LinearAttachmentInput): Promise<void> {
+    this.attachments.push(input)
+  }
 }
 
 const turnFor = (port: FakePort | undefined, thread: string | undefined) => ({
@@ -540,6 +545,22 @@ describe('applyLinearAction', () => {
       { plan: [{ content: 'ship it', status: 'completed' }] },
       { addedExternalUrls: [{ label: 'PR #123', url: 'https://code.example.test/pr/123' }] }
     ])
+  })
+
+  it('adds the issue resource through attachmentCreate without spending the activity budget', async () => {
+    const port = new FakePort()
+    const turn = linearTurn(port)
+    const state = initialLinearTurnState()
+    const before = state.activityBudget
+    const input = {
+      issueId: 'issue-uuid',
+      url: 'https://console.example.test/sessions/s1',
+      title: 'AgentConnect session'
+    }
+    await applyLinearAction(turn, state, { kind: 'attachment', input })
+    expect(port.attachments).toEqual([input])
+    expect(port.activities).toEqual([])
+    expect(state.activityBudget).toBe(before)
   })
 
   it('enforces the per-turn activity budget as the hard egress backstop', async () => {

--- a/packages/relay/src/platforms/linear/http-ingest.ts
+++ b/packages/relay/src/platforms/linear/http-ingest.ts
@@ -145,6 +145,8 @@ export function linearIsStop(event: LinearAgentSessionEvent): boolean {
 /** §6.4 adapter-extension bag: opaque to relay core, round-tripped to the daemon's linear module. */
 export interface LinearAdapterExt {
   agentSessionId: string
+  /** The issue's UUID — what `attachmentCreate` keys on; the identifier is display-only. */
+  issueId?: string
   issueIdentifier?: string
   issueTitle?: string
   promptContext?: string
@@ -225,6 +227,7 @@ export function normalizeLinearEvent(
   )
   const adapterExt: LinearAdapterExt = {
     agentSessionId: session.id,
+    ...(issue?.id ? { issueId: issue.id } : {}),
     ...(issue?.identifier ? { issueIdentifier: issue.identifier } : {}),
     ...(issue?.title ? { issueTitle: issue.title } : {}),
     ...(context.promptContext !== undefined ? { promptContext: context.promptContext } : {}),

--- a/packages/relay/src/platforms/linear/ingress-plugin.test.ts
+++ b/packages/relay/src/platforms/linear/ingress-plugin.test.ts
@@ -326,6 +326,7 @@ describe('linear ingress plugin — normalized message', () => {
     const bag = forwarded!.adapterExt!.linear as LinearAdapterExt
     expect(bag).toMatchObject({
       agentSessionId: SESSION_ID,
+      issueId: issue.id,
       issueIdentifier: 'AGE-5',
       issueTitle: issue.title,
       guidance: 'Always open a draft PR.'


### PR DESCRIPTION
## Summary
Delegating an issue now shows the AgentConnect session in the issue's **Resources**, the way Linear's own integrations surface theirs.

- **Daemon**: at the first turn of a session the Linear surface emits one `attachment` action → `attachmentCreate(issueId, url, title, subtitle)` with the console session deep link (the footer's), titled `AgentConnect session`, subtitled `<agent> · <runtime> · <model>`. Linear keys the entry on `(issueId, url)`, so a retry or restart refreshes it; the daemon also remembers attached sessions and skips follow-up turns. The action is issue chrome and never draws on the per-turn activity budget.
- **Relay**: the §6.4 adapter bag now carries `issueId` (the UUID the mutation keys on); `issueIdentifier` stays display-only.
- **Design**: feature table row for the Resources entry.

## Testing
- relay `platforms/linear`: 40 tests green (bag carries `issueId`).
- daemon `linear-connection` / `linear-turn-output` / `linear-ingress` / `linear-message-strategy`: 152 tests green, including: the mutation shape; the executor leaves the activity budget untouched; the resource lands once per session at the first turn and not on the follow-up; no issue in the bag ⇒ no resource.
- `typecheck` for daemon + relay and eslint on the touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)