### PR TITLE
fix(web): let the default-dispatch menu escape its card

### DIFF
--- a/packages/web/src/components/console/DefaultDispatchPicker.tsx
+++ b/packages/web/src/components/console/DefaultDispatchPicker.tsx
@@ -3,10 +3,13 @@
 // Per-conversation default dispatch for a SHARED bot — who takes its unmatched messages.
 // Picking one PATCHes the conversation's explicit owner (`setChannelAgent`). Shared by the
 // org Bots roster and the agent page's Linear rows, so the two cannot drift apart.
+// The menu is an <AnchoredFlyout>: the agent page wraps each integration card in
+// `overflow-hidden`, which cut an in-row menu after its first option, and the flyout also
+// flips above the trigger near the bottom of the viewport instead of running off it.
 
-import { useEffect, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { useState } from 'react'
 import { Icon } from '@/components/ui'
+import { AnchoredFlyout } from '@/components/ui/AnchoredFlyout'
 import { AgentIconView } from '@/components/marks'
 import type { AgentIcon } from '@/lib/agent-icon'
 
@@ -19,6 +22,10 @@ export interface DefaultDispatchOption {
   icon?: AgentIcon | null
 }
 
+const MENU_WIDTH = 240
+const MENU_HEADER_HEIGHT = 34
+const MENU_ROW_HEIGHT = 34
+
 export function DefaultDispatchPicker({
   options,
   activeId,
@@ -30,88 +37,71 @@ export function DefaultDispatchPicker({
   disabled: boolean
   onPick: (agentId: string) => Promise<void>
 }) {
-  const [open, setOpen] = useState(false)
   const [saving, setSaving] = useState(false)
-  const button = useRef<HTMLButtonElement>(null)
-  // Where the menu goes, measured when it opens: it is portaled to <body> and fixed-positioned,
-  // so an `overflow-hidden` card around the picker (the agent page's integration cards) cannot
-  // clip it. Right-anchored, because the picker sits in its row's right-most column.
-  const [anchor, setAnchor] = useState<{ top: number; right: number } | null>(null)
-  const toggle = () => {
-    if (disabled) return
-    if (open) return setOpen(false)
-    const rect = button.current?.getBoundingClientRect()
-    setAnchor(rect ? { top: rect.bottom + 5, right: Math.max(0, window.innerWidth - rect.right) } : null)
-    setOpen(true)
-  }
-  // The menu is measured once; a scroll or resize would strand it, so either just closes it.
-  useEffect(() => {
-    if (!open) return
-    const close = () => setOpen(false)
-    window.addEventListener('scroll', close, true)
-    window.addEventListener('resize', close)
-    return () => {
-      window.removeEventListener('scroll', close, true)
-      window.removeEventListener('resize', close)
-    }
-  }, [open])
   const active = options.find((o) => o.id === activeId) ?? options[0]
   const pick = (id: string) => {
-    setOpen(false)
     if (disabled || saving || id === active?.id) return
     setSaving(true)
     onPick(id).finally(() => setSaving(false))
   }
   return (
-    <span className="relative justify-self-end" onClick={(e) => e.stopPropagation()}>
-      <button
-        ref={button}
-        onClick={toggle}
-        title="Default dispatch — the agent this conversation's unmatched messages go to"
-        className={`flex items-center gap-2 rounded-[7px] border-0 bg-transparent px-[5px] py-1 hover:bg-(--surface-hover) ${
-          disabled ? 'cursor-default' : 'cursor-pointer'
-        } ${saving ? 'opacity-60' : ''}`}
-      >
-        <span className="av h-5 w-5 rounded-[5px]">
-          <AgentIconView icon={active?.icon} runtime={active?.runtime ?? active?.model ?? ''} size={20} />
-        </span>
-        <span className="mono text-[12.5px] text-(--text-primary)">{active?.name ?? '—'}</span>
-        <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
-      </button>
-      {open &&
-        createPortal(
-          <>
-            <span className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
-            <div
-              className="fixed z-40 min-w-[230px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
-              style={anchor ? { top: anchor.top, right: anchor.right } : undefined}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div className="px-[9px] pb-[5px] pt-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
-                Default dispatch
-              </div>
-              {options.map((o) => (
-                <button
-                  key={o.id}
-                  onClick={() => pick(o.id)}
-                  className="flex w-full cursor-pointer items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[6px] text-left hover:bg-(--surface-hover)"
-                >
-                  <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
-                    <AgentIconView icon={o.icon} runtime={o.runtime} size={22} />
-                  </span>
-                  <span className="mono min-w-0 flex-1 truncate text-[12.5px] text-(--text-primary)">{o.name}</span>
-                  <Icon
-                    name="check"
-                    size={13}
-                    color={o.id === active?.id ? 'var(--brand)' : 'transparent'}
-                    className="flex-none"
-                  />
-                </button>
-              ))}
-            </div>
-          </>,
-          document.body
+    <span className="justify-self-end" onClick={(e) => e.stopPropagation()}>
+      <AnchoredFlyout
+        ariaLabel="Default dispatch"
+        align="end"
+        width={MENU_WIDTH}
+        estimatedHeight={MENU_HEADER_HEIGHT + options.length * MENU_ROW_HEIGHT}
+        trigger={({ open, menuId, toggle }) => (
+          <button
+            type="button"
+            onClick={() => !disabled && toggle()}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            aria-controls={open ? menuId : undefined}
+            title="Default dispatch — the agent this conversation's unmatched messages go to"
+            className={`flex items-center gap-2 rounded-[7px] border-0 bg-transparent px-[5px] py-1 hover:bg-(--surface-hover) ${
+              disabled ? 'cursor-default' : 'cursor-pointer'
+            } ${saving ? 'opacity-60' : ''}`}
+          >
+            <span className="av h-5 w-5 rounded-[5px]">
+              <AgentIconView icon={active?.icon} runtime={active?.runtime ?? active?.model ?? ''} size={20} />
+            </span>
+            <span className="mono text-[12.5px] text-(--text-primary)">{active?.name ?? '—'}</span>
+            <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
+          </button>
         )}
+      >
+        {({ close }) => (
+          <>
+            <div className="px-[9px] pb-[5px] pt-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+              Default dispatch
+            </div>
+            {options.map((o) => (
+              <button
+                key={o.id}
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  close(true)
+                  pick(o.id)
+                }}
+                className="flex w-full cursor-pointer items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[6px] text-left hover:bg-(--surface-hover)"
+              >
+                <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
+                  <AgentIconView icon={o.icon} runtime={o.runtime} size={22} />
+                </span>
+                <span className="mono min-w-0 flex-1 truncate text-[12.5px] text-(--text-primary)">{o.name}</span>
+                <Icon
+                  name="check"
+                  size={13}
+                  color={o.id === active?.id ? 'var(--brand)' : 'transparent'}
+                  className="flex-none"
+                />
+              </button>
+            ))}
+          </>
+        )}
+      </AnchoredFlyout>
     </span>
   )
 }

--- a/packages/web/src/components/console/DefaultDispatchPicker.tsx
+++ b/packages/web/src/components/console/DefaultDispatchPicker.tsx
@@ -4,7 +4,8 @@
 // Picking one PATCHes the conversation's explicit owner (`setChannelAgent`). Shared by the
 // org Bots roster and the agent page's Linear rows, so the two cannot drift apart.
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Icon } from '@/components/ui'
 import { AgentIconView } from '@/components/marks'
 import type { AgentIcon } from '@/lib/agent-icon'
@@ -31,6 +32,29 @@ export function DefaultDispatchPicker({
 }) {
   const [open, setOpen] = useState(false)
   const [saving, setSaving] = useState(false)
+  const button = useRef<HTMLButtonElement>(null)
+  // Where the menu goes, measured when it opens: it is portaled to <body> and fixed-positioned,
+  // so an `overflow-hidden` card around the picker (the agent page's integration cards) cannot
+  // clip it. Right-anchored, because the picker sits in its row's right-most column.
+  const [anchor, setAnchor] = useState<{ top: number; right: number } | null>(null)
+  const toggle = () => {
+    if (disabled) return
+    if (open) return setOpen(false)
+    const rect = button.current?.getBoundingClientRect()
+    setAnchor(rect ? { top: rect.bottom + 5, right: Math.max(0, window.innerWidth - rect.right) } : null)
+    setOpen(true)
+  }
+  // The menu is measured once; a scroll or resize would strand it, so either just closes it.
+  useEffect(() => {
+    if (!open) return
+    const close = () => setOpen(false)
+    window.addEventListener('scroll', close, true)
+    window.addEventListener('resize', close)
+    return () => {
+      window.removeEventListener('scroll', close, true)
+      window.removeEventListener('resize', close)
+    }
+  }, [open])
   const active = options.find((o) => o.id === activeId) ?? options[0]
   const pick = (id: string) => {
     setOpen(false)
@@ -41,7 +65,8 @@ export function DefaultDispatchPicker({
   return (
     <span className="relative justify-self-end" onClick={(e) => e.stopPropagation()}>
       <button
-        onClick={() => !disabled && setOpen((v) => !v)}
+        ref={button}
+        onClick={toggle}
         title="Default dispatch — the agent this conversation's unmatched messages go to"
         className={`flex items-center gap-2 rounded-[7px] border-0 bg-transparent px-[5px] py-1 hover:bg-(--surface-hover) ${
           disabled ? 'cursor-default' : 'cursor-pointer'
@@ -53,36 +78,40 @@ export function DefaultDispatchPicker({
         <span className="mono text-[12.5px] text-(--text-primary)">{active?.name ?? '—'}</span>
         <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
       </button>
-      {open && (
-        <>
-          <span className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
-          {/* right-anchored: the picker sits in the roster's right-most column, so a
-              left-anchored menu (wider than its button) would clip past the card edge */}
-          <div className="absolute right-0 top-[calc(100%+5px)] z-40 min-w-[230px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)">
-            <div className="px-[9px] pb-[5px] pt-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
-              Default dispatch
+      {open &&
+        createPortal(
+          <>
+            <span className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
+            <div
+              className="fixed z-40 min-w-[230px] rounded-[10px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg)"
+              style={anchor ? { top: anchor.top, right: anchor.right } : undefined}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="px-[9px] pb-[5px] pt-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+                Default dispatch
+              </div>
+              {options.map((o) => (
+                <button
+                  key={o.id}
+                  onClick={() => pick(o.id)}
+                  className="flex w-full cursor-pointer items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[6px] text-left hover:bg-(--surface-hover)"
+                >
+                  <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
+                    <AgentIconView icon={o.icon} runtime={o.runtime} size={22} />
+                  </span>
+                  <span className="mono min-w-0 flex-1 truncate text-[12.5px] text-(--text-primary)">{o.name}</span>
+                  <Icon
+                    name="check"
+                    size={13}
+                    color={o.id === active?.id ? 'var(--brand)' : 'transparent'}
+                    className="flex-none"
+                  />
+                </button>
+              ))}
             </div>
-            {options.map((o) => (
-              <button
-                key={o.id}
-                onClick={() => pick(o.id)}
-                className="flex w-full cursor-pointer items-center gap-[9px] rounded-[6px] border-0 bg-transparent px-[9px] py-[6px] text-left hover:bg-(--surface-hover)"
-              >
-                <span className="av h-[22px] w-[22px] flex-none rounded-[6px]">
-                  <AgentIconView icon={o.icon} runtime={o.runtime} size={22} />
-                </span>
-                <span className="mono min-w-0 flex-1 truncate text-[12.5px] text-(--text-primary)">{o.name}</span>
-                <Icon
-                  name="check"
-                  size={13}
-                  color={o.id === active?.id ? 'var(--brand)' : 'transparent'}
-                  className="flex-none"
-                />
-              </button>
-            ))}
-          </div>
-        </>
-      )}
+          </>,
+          document.body
+        )}
     </span>
   )
 }

--- a/packages/web/src/components/console/platforms/linear/card.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/card.test.tsx
@@ -83,7 +83,8 @@ let host: HTMLDivElement
 let root: Root
 
 const text = () => host.textContent ?? ''
-const buttons = () => [...host.querySelectorAll('button')]
+// The dispatch menu is portaled to <body>, so its options live outside the mount host.
+const buttons = () => [...document.querySelectorAll('button')]
 const buttonWithLabel = (label: string) =>
   buttons().find((b) => b.getAttribute('aria-label')?.includes(label)) as HTMLButtonElement | undefined
 const buttonWithTitle = (title: string) =>


### PR DESCRIPTION
## Summary
- `DefaultDispatchPicker`'s menu was absolutely positioned inside its row, and the agent page wraps every integration card in `overflow-hidden` — on the Linear workspace row the menu was cut off after its first option.
- The menu now renders through a portal to `<body>`, fixed at the trigger's measured position (still right-anchored, since the picker sits in its row's right-most column), and closes on scroll or resize instead of keeping a stale anchor.
- The Linear card test queries the document for the option buttons, since they no longer live under the mount host.

## Testing
- `vitest` over the Linear module + IntegrationsView: 63 tests green.
- `pnpm --filter @agentconnect.md/web typecheck` and eslint on the picker: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)