### PR TITLE
fix(daemon): name the Linear delegator by full name, as the list does

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6664,9 +6664,11 @@ export class Daemon {
   private async linearActorName(conn: LinearConnection, senderId: string): Promise<string | undefined> {
     const cached = (await this.store.getDisplayNames([senderId])).get(senderId)
     if (cached) return cached
+    // The full name first, as the resolver caches it for the session list — one spelling
+    // in the header and the list, not the handle in one and the name in the other.
     const lookup = conn
       .getUserProfile(senderId)
-      .then((p) => p.name || p.realName || undefined)
+      .then((p) => p.realName || p.name || undefined)
       .catch(() => undefined)
     const deadline = new Promise<undefined>((resolve) => {
       const timer = setTimeout(() => resolve(undefined), LINEAR_ACTOR_LOOKUP_MS)

--- a/packages/daemon/test/linear-ingress.test.ts
+++ b/packages/daemon/test/linear-ingress.test.ts
@@ -383,7 +383,8 @@ describe('§10.1 the pre-spawn acknowledgement', () => {
     const asked: string[] = []
     ;(daemon as any).lnConnByIntegration.get(INTEGRATION).getUserProfile = async (id: string) => {
       asked.push(id)
-      return { id, name: 'ada', isBot: false }
+      // The full name wins over the handle, matching what the session list shows.
+      return { id, name: 'ada', realName: 'Ada Lovelace', isBot: false }
     }
     const dispatched: { text: string }[] = []
     ;(daemon as any).dispatch = vi.fn(async (_a: string, msg: any) => {
@@ -391,7 +392,7 @@ describe('§10.1 the pre-spawn acknowledgement', () => {
       return null
     })
     await im(daemon, delivery({ sender: { id: 'linear:user-1', isBot: false } }))
-    expect(dispatched[0]!.text.split('\n')[0]).toBe('Linear TEAM-123 "Ship the thing" — delegated by ada')
+    expect(dispatched[0]!.text.split('\n')[0]).toBe('Linear TEAM-123 "Ship the thing" — delegated by Ada Lovelace')
     expect(asked).toContain('linear:user-1')
     await daemon.stop()
   })


### PR DESCRIPTION
## Summary
- The §8 header resolved the delegator to Linear's display handle (`fuyaoz`) while the channel-name resolver caches the full name (`Fuyao Zhao`) for the session list — one person, two spellings. The header now prefers the full name too.

## Testing
- `linear-ingress` tests green; the lookup case now returns both fields and expects the full name in the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)