### PR TITLE
refactor(daemon): inject port-gated platform tools only into sessions on the declaring platform

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -1050,9 +1050,15 @@ A second group is gated by a **declared port** rather than by a platform name
 [integration-plugin-architecture.md](integration-plugin-architecture.md)): the bounded reads
 `getChannelHistory` and `getThreadHistory`, the reactions `addReaction` / `getReactions`,
 `createConversation`, `scheduleMessage`, and the canvas trio `createCanvas` / `readCanvas` /
-`updateCanvas`. Slack declares all of them today and is the only platform that does, so an
-agent with no Slack integration is injected none of them and each tool's `platform` enum
-narrows to the declaring platforms. Two rules keep this group honest. It is not a second
+`updateCanvas`. Slack declares all of them today and is the only platform that does. The gate
+is the **session's** platform, not the agent's integration list: a session on a declaring
+platform is injected the tools, and the same agent answering on Telegram, Discord, Feishu, or
+webchat is injected none — so these tools carry no `platform` selector at all, only the
+`integrationId` that picks another of the agent's bots on the same platform. The
+platform-neutral reads (`listChannels`, `listChannelMembers`, `getUserProfile`,
+`listKnownUsers`) and `sendMessage` keep their cross-platform `platform` argument; a
+platform-shaped capability reached from another platform's session was never asked for, and
+it cost every other session the descriptors. Two rules keep this group honest. It is not a second
 delivery path — `sendMessage` and `shareFile` remain the only two, and `scheduleMessage` is
 channel-root only for the same reason `sendMessage` is
 ([send-message-routing-rework.md](send-message-routing-rework.md) §2.2). And unlike the turn

--- a/docs/designs/integration-plugin-architecture.md
+++ b/docs/designs/integration-plugin-architecture.md
@@ -453,11 +453,13 @@ told `missing_scope` rather than handed a silent success.
 The optional facets an AGENT can reach are declared per platform in
 `platforms/read-ports.ts`, the same pre-connection registry that decides which attachment tool
 to inject: `channelHistory`, `threadHistory`, `reactions`, `conversationCreate`,
-`scheduledMessages`, `canvas`. A declaration gates tool INJECTION (before any connection
-exists) and narrows the tool's `platform` enum; the live `typeof conn.x === 'function'` probe
-still decides whether this connection can serve the call. Fail-closed by absence, so a
-platform that declares nothing is injected nothing. Slack declares all six today; adding a
-second implementer is a registry line plus the adapter members, not a core edit.
+`scheduledMessages`, `canvas`, `bookmarks`, `lists`. A declaration gates tool INJECTION
+(before any connection exists) for a session ON that platform — the tools carry no `platform`
+selector and never appear in the same agent's sessions elsewhere; the live
+`typeof conn.x === 'function'` probe still decides whether this connection can serve the call.
+Fail-closed by absence, so a platform that declares nothing is injected nothing. Slack
+declares all of them today; adding a second implementer is a registry line plus the adapter
+members, not a core edit.
 
 ### 7.2 Host services
 

--- a/packages/daemon/src/mcp/ops/platform-actions.ts
+++ b/packages/daemon/src/mcp/ops/platform-actions.ts
@@ -2,12 +2,12 @@
  * The platform tools that CHANGE something without posting a message: reactions,
  * conversation creation, scheduled sends, and canvases.
  *
- * They are routed exactly like the reads in `platform-reads.ts` — a `platform` argument
- * (defaulting to the current conversation's) resolved against the trusted session snapshot,
- * never tool input — and gated exactly like them, by a port the platform DECLARES rather
- * than by its name. What is different is the failure mode: a read that finds nothing is an
- * empty list, while these either did the thing or did not, so each one lets the platform's
- * own refusal (`missing_scope`, `name_taken`, `not_in_channel`) reach the agent verbatim.
+ * They act on THIS session's platform only — `integrationId` may pick another of the agent's
+ * bots there, resolved against the trusted session snapshot, never tool input — and are
+ * gated by a port the platform DECLARES rather than by its name: injected for a session on
+ * a declaring platform, absent everywhere else. What is different is the failure mode: a read
+ * that finds nothing is an empty list, while these either did the thing or did not, so each one
+ * lets the platform's own refusal (`missing_scope`, `name_taken`, `not_in_channel`) reach the agent verbatim.
  *
  * NONE of them is a delivery path for the agent's own voice. `sendMessage` and `shareFile`
  * remain the only two, and `scheduleMessage` is deliberately channel-root only for the same
@@ -24,42 +24,39 @@ import { optionalBoolean, optionalBoundedInt, optionalString, parseArgs, require
 const MIN_SCHEDULE_LEAD_MS = 2 * 60 * 1000
 const MAX_SCHEDULE_HORIZON_MS = 120 * 24 * 60 * 60 * 1000
 
-const platformTarget = {
-  platform: optionalString('platform'),
-  integrationId: optionalString('integrationId')
-}
+const botSelector = { integrationId: optionalString('integrationId') }
 
 export const ADD_REACTION_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   channel: optionalString('channel'),
   messageTs: requiredString('messageTs'),
   emoji: requiredString('emoji')
 })
 
 export const GET_REACTIONS_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   channel: optionalString('channel'),
   messageTs: requiredString('messageTs')
 })
 
 export const CREATE_CONVERSATION_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   name: optionalString('name'),
   isPrivate: optionalBoolean('isPrivate'),
   users: z.array(requiredString('users')).max(100, 'users accepts at most 100 ids').optional()
 })
 
 export const SCHEDULE_MESSAGE_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   channel: optionalString('channel'),
   message: requiredString('message'),
   postAt: requiredString('postAt')
 })
 
-export const LIST_BOOKMARKS_ARGS = z.object({ ...platformTarget, channel: optionalString('channel') })
+export const LIST_BOOKMARKS_ARGS = z.object({ ...botSelector, channel: optionalString('channel') })
 
 export const ADD_BOOKMARK_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   channel: optionalString('channel'),
   title: requiredString('title'),
   link: requiredString('link'),
@@ -67,13 +64,13 @@ export const ADD_BOOKMARK_ARGS = z.object({
 })
 
 export const REMOVE_BOOKMARK_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   channel: optionalString('channel'),
   bookmarkId: requiredString('bookmarkId')
 })
 
 export const READ_LIST_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   listId: requiredString('listId'),
   cursor: optionalString('cursor'),
   limit: optionalBoundedInt('limit', 1, 200)
@@ -91,29 +88,29 @@ const listFields = z
   .min(1, 'fields must name at least one column')
 
 export const ADD_LIST_ITEM_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   listId: requiredString('listId'),
   fields: listFields
 })
 
 export const UPDATE_LIST_ITEM_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   listId: requiredString('listId'),
   itemId: requiredString('itemId'),
   fields: listFields
 })
 
 export const CREATE_CANVAS_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   title: requiredString('title').max(255, 'title must be at most 255 characters'),
   markdown: requiredString('markdown'),
   channel: optionalString('channel')
 })
 
-export const READ_CANVAS_ARGS = z.object({ ...platformTarget, canvasId: requiredString('canvasId') })
+export const READ_CANVAS_ARGS = z.object({ ...botSelector, canvasId: requiredString('canvasId') })
 
 export const UPDATE_CANVAS_ARGS = z.object({
-  ...platformTarget,
+  ...botSelector,
   canvasId: requiredString('canvasId'),
   edits: z
     .array(
@@ -138,19 +135,18 @@ export const UPDATE_CANVAS_ARGS = z.object({
 export type PlatformActionDeps = GatewayDeps
 
 /** Resolve the target gateway plus the channel the call acts on, with the current
- *  conversation's channel defaulting in only for a same-platform call — a different
- *  platform has no meaningful "current channel", exactly as `listChannelMembers` has it. */
+ *  conversation's channel defaulting in only for this session's own bot — another bot has no
+ *  meaningful "current channel", exactly as `listChannelMembers` has it. */
 function resolveTarget(
   ctx: SessionContext,
   deps: PlatformActionDeps,
-  parsed: { platform?: string; integrationId?: string; channel?: string },
+  parsed: { integrationId?: string; channel?: string },
   what: string
 ) {
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw, sameConvo } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   const channel = parsed.channel ?? (sameConvo ? ctx.channel : undefined)
-  if (!channel)
-    throw new Error(`channel is required to ${what} on ${platform} (a different platform than this session)`)
+  if (!channel) throw new Error(`channel is required to ${what} on ${platform} (another bot than this session's)`)
   return { platform, gw, channel }
 }
 
@@ -188,14 +184,14 @@ export async function getReactions(
 /**
  * The conversation a bookmark tool acts on.
  *
- * `ctx.channel` is a default ONLY for this session's own integration. A Telegram session whose
- * agent also has Slack can call these with `platform: 'slack'`, and handing Slack a Telegram
- * channel id just fails with `channel_not_found` — the shared selector contract already says a
- * different platform must name its channel, and `sameConvo` is how the resolver reports it.
+ * `ctx.channel` is a default ONLY for this session's own integration. A call that picks another
+ * bot by `integrationId` may not be in this channel at all, and handing it the id just fails
+ * with `channel_not_found` — the shared selector contract already says another bot must name
+ * its channel, and `sameConvo` is how the resolver reports it.
  */
 function bookmarkChannel(ctx: SessionContext, named: string | undefined, sameConvo: boolean): string {
   if (named) return named
-  if (!sameConvo) throw new Error('channel is required when the bookmark is on another platform or bot')
+  if (!sameConvo) throw new Error('channel is required when the bookmark is on another bot')
   return ctx.channel
 }
 
@@ -205,7 +201,7 @@ export async function listBookmarks(
   deps: PlatformActionDeps
 ): Promise<unknown> {
   const parsed = parseArgs(LIST_BOOKMARKS_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw, sameConvo } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   if (!gw.listBookmarks) throw unsupported(platform, 'bookmarks')
   const channel = bookmarkChannel(ctx, parsed.channel, sameConvo)
@@ -218,7 +214,7 @@ export async function addBookmark(
   deps: PlatformActionDeps
 ): Promise<unknown> {
   const parsed = parseArgs(ADD_BOOKMARK_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw, sameConvo } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   if (!gw.addBookmark) throw unsupported(platform, 'bookmarks')
   const channel = bookmarkChannel(ctx, parsed.channel, sameConvo)
@@ -236,7 +232,7 @@ export async function removeBookmark(
   deps: PlatformActionDeps
 ): Promise<unknown> {
   const parsed = parseArgs(REMOVE_BOOKMARK_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw, sameConvo } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   if (!gw.removeBookmark) throw unsupported(platform, 'bookmarks')
   const channel = bookmarkChannel(ctx, parsed.channel, sameConvo)
@@ -250,7 +246,7 @@ export async function readList(
   deps: PlatformActionDeps
 ): Promise<unknown> {
   const parsed = parseArgs(READ_LIST_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   if (!gw.readList) throw unsupported(platform, 'lists')
   const page = await gw.readList(parsed.listId, {
@@ -266,7 +262,7 @@ export async function addListItem(
   deps: PlatformActionDeps
 ): Promise<unknown> {
   const parsed = parseArgs(ADD_LIST_ITEM_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   if (!gw.addListItem) throw unsupported(platform, 'lists')
   return { platform, listId: parsed.listId, item: await gw.addListItem(parsed.listId, parsed.fields) }
@@ -278,7 +274,7 @@ export async function updateListItem(
   deps: PlatformActionDeps
 ): Promise<unknown> {
   const parsed = parseArgs(UPDATE_LIST_ITEM_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   if (!gw.updateListItem) throw unsupported(platform, 'lists')
   await gw.updateListItem(parsed.listId, parsed.itemId, parsed.fields)
@@ -291,7 +287,7 @@ export async function createConversation(
   deps: PlatformActionDeps
 ): Promise<unknown> {
   const parsed = parseArgs(CREATE_CONVERSATION_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   if (!gw.createConversation) throw unsupported(platform, 'creating conversations')
   const users = parsed.users ?? []
@@ -332,7 +328,7 @@ export async function createCanvas(
   deps: PlatformActionDeps
 ): Promise<unknown> {
   const parsed = parseArgs(CREATE_CANVAS_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   if (!gw.createCanvas) throw unsupported(platform, 'canvases')
   return { platform, canvas: await gw.createCanvas(parsed.title, parsed.markdown, parsed.channel) }
@@ -344,7 +340,7 @@ export async function readCanvas(
   deps: PlatformActionDeps
 ): Promise<unknown> {
   const parsed = parseArgs(READ_CANVAS_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   if (!gw.readCanvas) throw unsupported(platform, 'canvases')
   return { platform, canvas: await gw.readCanvas(parsed.canvasId) }
@@ -356,7 +352,7 @@ export async function updateCanvas(
   deps: PlatformActionDeps
 ): Promise<unknown> {
   const parsed = parseArgs(UPDATE_CANVAS_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   if (!gw.updateCanvas) throw unsupported(platform, 'canvases')
   // Reject here rather than at the provider: an anchored edit with no section, or a

--- a/packages/daemon/src/mcp/ops/platform-reads.ts
+++ b/packages/daemon/src/mcp/ops/platform-reads.ts
@@ -45,7 +45,6 @@ export const GET_CHANNEL_HISTORY_ARGS = z.object({
 
 /** `getThreadHistory` arguments; `channel` defaults to the current one on the same platform. */
 export const GET_THREAD_HISTORY_ARGS = z.object({
-  platform: optionalString('platform'),
   integrationId: optionalString('integrationId'),
   channel: optionalString('channel'),
   thread: requiredString('thread'),
@@ -229,11 +228,10 @@ export async function getThreadHistory(
   deps: PlatformReadDeps
 ): Promise<unknown> {
   const parsed = parseArgs(GET_THREAD_HISTORY_ARGS, args)
-  const platform = parsed.platform ?? ctx.platform
+  const platform = ctx.platform
   const { gw, sameConvo } = resolveGatewayForPlatform(ctx, deps, platform, parsed.integrationId)
   const channel = parsed.channel ?? (sameConvo ? ctx.channel : undefined)
-  if (!channel)
-    throw new Error(`channel is required to read a thread on ${platform} (a different platform than this session)`)
+  if (!channel) throw new Error(`channel is required to read a thread on ${platform} (another bot than this session's)`)
   if (!gw.getThreadReplies)
     throw new Error(`thread history is unavailable on this ${platformLabel(platform)} connection`)
   const readState = { truncated: false }

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -4,8 +4,8 @@ import { SESSION_TITLE_TOOL_NAME } from './session-title-tool.js'
 import {
   allAttachmentReadTools,
   allPortPlatforms,
+  declaresPort,
   attachmentReadToolsFor,
-  platformsWithPort,
   type PlatformToolPort
 } from '../platforms/read-ports.js'
 import { EXTERNAL_MEMORY_TOOL_NAMES, MEMORY_TOOLS } from '../memory/tools.js'
@@ -311,7 +311,9 @@ function buildSendMessageTool(platforms: string[]): ToolDescriptor {
  * The enum is narrowed at build time to the agent's own platforms. Sending is
  * handled separately by {@link buildSendMessageTool}; per-platform credentialed
  * file downloads by whichever platforms declare that read port
- * ({@link attachmentReadToolsFor}).
+ * ({@link attachmentReadToolsFor}). The port-gated tools (thread history, reactions,
+ * bookmarks, lists, canvases, …) are the opposite: platform-shaped, so they carry no
+ * `platform` selector and are injected only into a session ON a declaring platform.
  */
 /**
  * `shareFile` — post a workspace image into the CURRENT conversation
@@ -366,16 +368,17 @@ function buildReadTools(platforms: string[], currentPlatform?: string): ToolDesc
     type: 'string',
     description: 'Optional. Pick a specific bot when the agent has multiple integrations on the target platform.'
   }
-  // Channel history has no target selector, so only the current session platform may enable it.
-  const historyPlatform = currentPlatform ?? (platforms.length === 1 ? platforms[0] : undefined)
-  const hasChannelHistory =
-    historyPlatform !== undefined && platformsWithPort('channelHistory', [historyPlatform]).length > 0
-  // Everything else routes by `platform`, so the gate is "any of this agent's platforms
-  // declares the port" and the enum narrows to exactly those. No declarer ⇒ no tool.
-  const portPlatform = (port: PlatformToolPort) => {
-    const declaring = platformsWithPort(port, platforms)
-    return declaring.length === 0 ? undefined : { ...platform, enum: declaring }
+  // The port-gated tools below act on THIS session's platform only, so their bot selector
+  // never crosses platforms: another bot of this agent on the same platform, nothing else.
+  const sameBotSelector = {
+    type: 'string',
+    description: 'Optional. Pick another of this agent’s bots on this platform when it has several.'
   }
+  // Port-gated tools have no platform selector: a session on a platform that declares the port
+  // gets the tool, any other session does not — cross-platform reach of a platform-shaped
+  // capability was never asked for, and it cost every other session the descriptors.
+  const sessionPlatform = currentPlatform ?? (platforms.length === 1 ? platforms[0] : undefined)
+  const offered = (port: PlatformToolPort) => sessionPlatform !== undefined && declaresPort(sessionPlatform, port)
   return [
     {
       name: 'getCurrentChannel',
@@ -394,7 +397,7 @@ function buildReadTools(platforms: string[], currentPlatform?: string): ToolDesc
         'has multiple bots on the platform (history is not attributable to one bot).',
       inputSchema: obj({ platform, integrationId })
     },
-    ...(hasChannelHistory
+    ...(offered('channelHistory')
       ? [
           {
             name: 'getChannelHistory',
@@ -461,13 +464,13 @@ function buildReadTools(platforms: string[], currentPlatform?: string): ToolDesc
         ['user']
       )
     },
-    ...buildThreadHistoryTool(portPlatform('threadHistory'), integrationId),
-    ...buildReactionTools(portPlatform('reactions'), integrationId),
-    ...buildConversationCreateTool(portPlatform('conversationCreate'), integrationId),
-    ...buildBookmarkTools(portPlatform('bookmarks'), integrationId),
-    ...buildListTools(portPlatform('lists'), integrationId),
-    ...buildScheduleMessageTool(portPlatform('scheduledMessages'), integrationId),
-    ...buildCanvasTools(portPlatform('canvas'), integrationId)
+    ...buildThreadHistoryTool(offered('threadHistory'), sameBotSelector),
+    ...buildReactionTools(offered('reactions'), sameBotSelector),
+    ...buildConversationCreateTool(offered('conversationCreate'), sameBotSelector),
+    ...buildBookmarkTools(offered('bookmarks'), sameBotSelector),
+    ...buildListTools(offered('lists'), sameBotSelector),
+    ...buildScheduleMessageTool(offered('scheduledMessages'), sameBotSelector),
+    ...buildCanvasTools(offered('canvas'), sameBotSelector)
   ]
 }
 
@@ -475,19 +478,19 @@ function buildReadTools(platforms: string[], currentPlatform?: string): ToolDesc
  *  `integrationId` selectors are, and what a port gate hands the builders below. */
 type SchemaProp = Record<string, JsonValue>
 
-/** The channel selector shared by every platform-routed tool below: the current
- *  conversation's channel by default, and required once `platform` names another one. */
+/** The channel selector shared by the port-gated tools below: the current conversation's
+ *  channel by default, and required once `integrationId` names another bot. */
 const targetChannel = {
   type: 'string',
   description:
-    'Channel/chat id. Defaults to this conversation’s channel; required when `platform` names a different platform.'
+    'Channel/chat id. Defaults to this conversation’s channel; required when `integrationId` names another bot.'
 }
 
 /** `getThreadHistory` — the same provider thread read the daemon already uses to rebuild
  *  mid-thread context, handed to the agent. Reads a thread the agent is NOT answering,
  *  which is the one thing the ordinary turn context cannot show it. */
-function buildThreadHistoryTool(platform: SchemaProp | undefined, integrationId: SchemaProp): ToolDescriptor[] {
-  if (!platform) return []
+function buildThreadHistoryTool(offered: boolean, integrationId: SchemaProp): ToolDescriptor[] {
+  if (!offered) return []
   return [
     {
       name: 'getThreadHistory',
@@ -498,7 +501,6 @@ function buildThreadHistoryTool(platform: SchemaProp | undefined, integrationId:
         'when the thread is longer than `limit`. Your own status chrome is filtered out.',
       inputSchema: obj(
         {
-          platform,
           integrationId,
           channel: targetChannel,
           thread: { type: 'string', description: 'Root message id of the thread (Slack thread_ts).' },
@@ -519,8 +521,8 @@ function buildThreadHistoryTool(platform: SchemaProp | undefined, integrationId:
 
 /** `addReaction` / `getReactions` — the emoji comes from the MODEL, which knows what platform
  *  it is on, unlike the turn-chrome `react` intent core names for it. */
-function buildReactionTools(platform: SchemaProp | undefined, integrationId: SchemaProp): ToolDescriptor[] {
-  if (!platform) return []
+function buildReactionTools(offered: boolean, integrationId: SchemaProp): ToolDescriptor[] {
+  if (!offered) return []
   const messageTs = { type: 'string', description: 'Id of the message to act on (Slack ts).' }
   return [
     {
@@ -531,7 +533,6 @@ function buildReactionTools(platform: SchemaProp | undefined, integrationId: Sch
         'the same emoji is not an error. This reacts as the bot, not under your agent identity.',
       inputSchema: obj(
         {
-          platform,
           integrationId,
           channel: targetChannel,
           messageTs,
@@ -545,7 +546,7 @@ function buildReactionTools(platform: SchemaProp | undefined, integrationId: Sch
       description:
         'List the emoji reactions already on one message, each with its count and — where the platform reports them ' +
         '— the users who reacted. Use it to read a poll or a lightweight approval someone ran with emoji.',
-      inputSchema: obj({ platform, integrationId, channel: targetChannel, messageTs }, ['messageTs'])
+      inputSchema: obj({ integrationId, channel: targetChannel, messageTs }, ['messageTs'])
     }
   ]
 }
@@ -555,13 +556,13 @@ function buildReactionTools(platform: SchemaProp | undefined, integrationId: Sch
  * conversation. Small, durable, and visible to everyone in the channel, which is why the write
  * says so: a bookmark outlives the task the way a canvas does, not the way a reply does.
  */
-function buildBookmarkTools(platform: SchemaProp | undefined, integrationId: SchemaProp): ToolDescriptor[] {
-  if (!platform) return []
+function buildBookmarkTools(offered: boolean, integrationId: SchemaProp): ToolDescriptor[] {
+  if (!offered) return []
   const channel = {
     type: 'string',
     description:
-      'Channel id. Defaults to the conversation you are in — but REQUIRED when `platform` or ' +
-      '`integrationId` names anything else, since this conversation’s id means nothing there.'
+      'Channel id. Defaults to the conversation you are in — but REQUIRED when `integrationId` names ' +
+      'another bot, since this conversation’s id means nothing there.'
   }
   return [
     {
@@ -570,7 +571,7 @@ function buildBookmarkTools(platform: SchemaProp | undefined, integrationId: Sch
         'List the links pinned at the top of a conversation, each with its id, title and URL. Read this before ' +
         'changing anything: `removeBookmark` needs an id, and it is also how you tell whether the link you were ' +
         'about to pin is already there.',
-      inputSchema: obj({ platform, integrationId, channel })
+      inputSchema: obj({ integrationId, channel })
     },
     {
       name: 'addBookmark',
@@ -581,7 +582,6 @@ function buildBookmarkTools(platform: SchemaProp | undefined, integrationId: Sch
         'Slack allows 100 per channel.',
       inputSchema: obj(
         {
-          platform,
           integrationId,
           channel,
           title: { type: 'string', minLength: 1, description: 'Short label shown on the bookmark.' },
@@ -598,7 +598,6 @@ function buildBookmarkTools(platform: SchemaProp | undefined, integrationId: Sch
         'a shared channel — do it when asked, not as tidying.',
       inputSchema: obj(
         {
-          platform,
           integrationId,
           channel,
           bookmarkId: { type: 'string', minLength: 1, description: 'Bookmark id from `listBookmarks`.' }
@@ -616,8 +615,8 @@ function buildBookmarkTools(platform: SchemaProp | undefined, integrationId: Sch
  * without them: a value is addressed by `columnId` and keyed by that column's type, and the
  * platform publishes no schema endpoint. Same shape as the canvas section ids.
  */
-function buildListTools(platform: SchemaProp | undefined, integrationId: SchemaProp): ToolDescriptor[] {
-  if (!platform) return []
+function buildListTools(offered: boolean, integrationId: SchemaProp): ToolDescriptor[] {
+  if (!offered) return []
   const listId = { type: 'string', minLength: 1, description: 'List id (a Slack List `F…` id).' }
   const fields = {
     type: 'array',
@@ -650,7 +649,6 @@ function buildListTools(platform: SchemaProp | undefined, integrationId: SchemaP
         'computes as `readOnly`. Page with `cursor`.',
       inputSchema: obj(
         {
-          platform,
           integrationId,
           listId,
           cursor: { type: 'string', description: 'Cursor from a previous page.' },
@@ -664,7 +662,7 @@ function buildListTools(platform: SchemaProp | undefined, integrationId: SchemaP
       description:
         'Append a row to a list. Get `columns` from `readList` first; a column id this list does not have is ' +
         'refused rather than guessed at. The row is visible to everyone with access to the list.',
-      inputSchema: obj({ platform, integrationId, listId, fields }, ['listId', 'fields'])
+      inputSchema: obj({ integrationId, listId, fields }, ['listId', 'fields'])
     },
     {
       name: 'updateListItem',
@@ -673,7 +671,6 @@ function buildListTools(platform: SchemaProp | undefined, integrationId: SchemaP
         'columns you name are touched, the rest of the row is left alone.',
       inputSchema: obj(
         {
-          platform,
           integrationId,
           listId,
           itemId: { type: 'string', minLength: 1, description: 'Row id from `readList`.' },
@@ -686,8 +683,8 @@ function buildListTools(platform: SchemaProp | undefined, integrationId: SchemaP
 }
 
 /** `createConversation` — the one tool here that creates durable workspace state. */
-function buildConversationCreateTool(platform: SchemaProp | undefined, integrationId: SchemaProp): ToolDescriptor[] {
-  if (!platform) return []
+function buildConversationCreateTool(offered: boolean, integrationId: SchemaProp): ToolDescriptor[] {
+  if (!offered) return []
   return [
     {
       name: 'createConversation',
@@ -698,7 +695,6 @@ function buildConversationCreateTool(platform: SchemaProp | undefined, integrati
         'workspace state that outlives the task and everyone can see, so only do it when someone asked for it — ' +
         'to reach people who already share a channel with you, post there instead.',
       inputSchema: obj({
-        platform,
         integrationId,
         name: {
           type: 'string',
@@ -718,8 +714,8 @@ function buildConversationCreateTool(platform: SchemaProp | undefined, integrati
 
 /** `scheduleMessage` — a channel-root post the PLATFORM delivers later. Deliberately has no
  *  thread form, for the same reason `sendMessage` has none (send-message-routing-rework.md §2.2). */
-function buildScheduleMessageTool(platform: SchemaProp | undefined, integrationId: SchemaProp): ToolDescriptor[] {
-  if (!platform) return []
+function buildScheduleMessageTool(offered: boolean, integrationId: SchemaProp): ToolDescriptor[] {
+  if (!offered) return []
   return [
     {
       name: 'scheduleMessage',
@@ -732,7 +728,6 @@ function buildScheduleMessageTool(platform: SchemaProp | undefined, integrationI
         'can be replied into; a reply reaches you as an ordinary new message.',
       inputSchema: obj(
         {
-          platform,
           integrationId,
           channel: targetChannel,
           message: { type: 'string', minLength: 1, description: 'The message body, as CommonMark/GFM.' },
@@ -746,8 +741,8 @@ function buildScheduleMessageTool(platform: SchemaProp | undefined, integrationI
 
 /** `createCanvas` / `readCanvas` / `updateCanvas` — the platform's own rich-text page, which
  *  outlives a message and can be edited in place (Slack Canvas). */
-function buildCanvasTools(platform: SchemaProp | undefined, integrationId: SchemaProp): ToolDescriptor[] {
-  if (!platform) return []
+function buildCanvasTools(offered: boolean, integrationId: SchemaProp): ToolDescriptor[] {
+  if (!offered) return []
   const canvasId = { type: 'string', description: 'Id of the canvas (Slack F0123ABC).' }
   const markdownRules =
     'Markdown is the platform’s own dialect: headings `#`/`##`/`###` only, no headings or code blocks inside list ' +
@@ -762,7 +757,6 @@ function buildCanvasTools(platform: SchemaProp | undefined, integrationId: Schem
         markdownRules,
       inputSchema: obj(
         {
-          platform,
           integrationId,
           title: { type: 'string', minLength: 1, maxLength: 255, description: 'Canvas title.' },
           markdown: { type: 'string', minLength: 1, description: 'Canvas body.' },
@@ -779,7 +773,7 @@ function buildCanvasTools(platform: SchemaProp | undefined, integrationId: Schem
         'one from an earlier turn is stale and must never be reused. Two limits worth knowing: only HEADING ' +
         'sections get an id, so an anchored edit can address a heading but not an arbitrary paragraph, and the body ' +
         'is absent (rather than empty) when the platform would not serve it — the canvas still exists.',
-      inputSchema: obj({ platform, integrationId, canvasId }, ['canvasId'])
+      inputSchema: obj({ integrationId, canvasId }, ['canvasId'])
     },
     {
       name: 'updateCanvas',
@@ -791,7 +785,6 @@ function buildCanvasTools(platform: SchemaProp | undefined, integrationId: Schem
         markdownRules,
       inputSchema: obj(
         {
-          platform,
           integrationId,
           canvasId,
           edits: {
@@ -1255,10 +1248,10 @@ export const ALL_TOOL_NAMES = [
       // are stable and belong in the permission auto-allow set.
       buildSendMessageTool([]),
       buildShareFileTool(),
-      // Built against EVERY registered platform so every port gate opens: the auto-allow
-      // set is about names, and a name some platform can inject must be listed even for
-      // an agent that will never see it.
-      ...buildReadTools(allPortPlatforms(), platformsWithPort('channelHistory').at(0)),
+      // Built once per registered platform AS the session platform so every port gate opens:
+      // the auto-allow set is about names, and a name some platform can inject must be listed
+      // even for an agent that will never see it.
+      ...allPortPlatforms().flatMap((platform) => buildReadTools(allPortPlatforms(), platform)),
       // Every platform's credentialed attachment tool, whatever this agent has:
       // the auto-allow set is about NAMES, and a name a platform can inject must
       // be listed even for an agent that will never see it.

--- a/packages/daemon/src/platforms/read-ports.ts
+++ b/packages/daemon/src/platforms/read-ports.ts
@@ -221,13 +221,10 @@ export type PlatformToolPort =
   | 'bookmarks'
   | 'lists'
 
-/** The platforms declaring `port`, in registry order — every one when `platforms` is
- *  omitted (the permission auto-allow set needs the names an agent will never see). */
-export function platformsWithPort(port: PlatformToolPort, platforms?: Iterable<string>): string[] {
-  const wanted = platforms === undefined ? undefined : new Set(platforms)
-  return [...READ_PORTS.values()]
-    .filter((d) => d[port] && (wanted === undefined || wanted.has(d.platform)))
-    .map((d) => d.platform)
+/** Does `platform` declare `port`? The session-platform gate every port-gated tool sits
+ *  behind: a tool is injected for a session ON a declaring platform, never reached across. */
+export function declaresPort(platform: string, port: PlatformToolPort): boolean {
+  return READ_PORTS.get(platform)?.[port] === true
 }
 
 /** Every registered platform, in registry order. Building the tool list against this

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -1146,21 +1146,32 @@ describe('executeTool: getThreadHistory', () => {
     ])
   })
 
-  it('needs an explicit channel across platforms, and refuses a connection without the port', async () => {
-    const tgGw = fakeGateway()
+  it('needs an explicit channel on another bot, and refuses a connection without the port', async () => {
+    const otherBot = fakeGateway()
     const { deps: base } = deps(fakeGateway({ getThreadReplies: vi.fn(async () => []) }))
     const d: OpsDeps = {
       ...base,
-      gatewayFor: (id) => (id === 'int-tg' ? tgGw : fakeGateway({ getThreadReplies: vi.fn(async () => []) }))
+      gatewayFor: (id) => (id === 'int-1b' ? otherBot : fakeGateway({ getThreadReplies: vi.fn(async () => []) }))
     }
-    const dual = { ...ctx, integrations: [...ctx.integrations!, { id: 'int-tg', platform: 'telegram' }] }
+    const twoBots = { ...ctx, integrations: [...ctx.integrations!, { id: 'int-1b', platform: 'slack' }] }
 
-    await expect(executeTool(dual, 'getThreadHistory', { platform: 'telegram', thread: '1' }, d)).rejects.toThrow(
+    await expect(executeTool(twoBots, 'getThreadHistory', { integrationId: 'int-1b', thread: '1' }, d)).rejects.toThrow(
       /channel is required/
     )
     await expect(
-      executeTool(dual, 'getThreadHistory', { platform: 'telegram', channel: '-100', thread: '1' }, d)
+      executeTool(twoBots, 'getThreadHistory', { integrationId: 'int-1b', channel: 'C_OTHER', thread: '1' }, d)
     ).rejects.toThrow(/thread history is unavailable/)
+  })
+
+  it('has no platform selector: the read stays on the session platform whatever the agent bridges', async () => {
+    const { deps: d } = deps(fakeGateway({ getThreadReplies: vi.fn(async () => []) }))
+    const dual = { ...ctx, integrations: [...ctx.integrations!, { id: 'int-tg', platform: 'telegram' }] }
+    // A stray `platform` is not an argument this tool takes — nothing routes on it.
+    const res = (await executeTool(dual, 'getThreadHistory', { platform: 'telegram', thread: '1' }, d)) as {
+      platform: string
+      channel: string
+    }
+    expect(res).toMatchObject({ platform: 'slack', channel: 'C_CURRENT' })
   })
 })
 
@@ -1226,13 +1237,37 @@ describe('executeTool: bookmarks', () => {
     expect(res).toMatchObject({ removed: 'Bk1' })
   })
 
-  // `ctx.channel` belongs to the SESSION's platform. Defaulting to it for a cross-platform call
-  // hands Slack a Telegram id, which fails as `channel_not_found` well away from the cause.
-  it('requires an explicit channel when the target is not this conversation', async () => {
+  // `ctx.channel` belongs to the SESSION's bot. Defaulting to it for another bot hands that
+  // bot a channel it may not be in, which fails as `channel_not_found` well away from the cause.
+  it('requires an explicit channel when the target is another bot', async () => {
     const add = vi.fn(async () => ({ id: 'Bk1', title: 't' }))
     const { deps: d } = deps(fakeGateway({ addBookmark: add }))
-    // A Telegram session whose agent also has Slack: the resolved target is a different
-    // integration, so `ctx.channel` is a Telegram id that Slack would reject.
+    const twoBots: SessionContext = {
+      ...ctx,
+      integrations: [
+        { id: 'int-1', platform: 'slack' },
+        { id: 'int-1b', platform: 'slack' }
+      ]
+    }
+
+    await expect(
+      executeTool(twoBots, 'addBookmark', { integrationId: 'int-1b', title: 't', link: 'https://x.test' }, d)
+    ).rejects.toThrow(/channel is required/)
+    expect(add).not.toHaveBeenCalled()
+
+    // Naming one is all it takes.
+    await executeTool(twoBots, 'addBookmark', { integrationId: 'int-1b', channel: 'C_OTHER', title: 't', link: 'l' }, d)
+    expect(add).toHaveBeenCalledWith('C_OTHER', { title: 't', link: 'l' })
+  })
+
+  it('never reaches a Slack bot from a session on another platform — there is no selector for it', async () => {
+    const add = vi.fn(async () => ({ id: 'Bk1', title: 't' }))
+    const { deps: base } = deps(fakeGateway({ addBookmark: add }))
+    // The Slack bot CAN pin; the session's Telegram bot cannot — and only the latter is reachable.
+    const d: OpsDeps = {
+      ...base,
+      gatewayFor: (id) => (id === 'int-1' ? fakeGateway({ addBookmark: add }) : fakeGateway())
+    }
     const elsewhere: SessionContext = {
       ...ctx,
       platform: 'telegram',
@@ -1243,15 +1278,11 @@ describe('executeTool: bookmarks', () => {
         { id: 'int-1', platform: 'slack' }
       ]
     }
-
+    // The session's own (Telegram) gateway is the only one in reach, and it pins nothing.
     await expect(
-      executeTool(elsewhere, 'addBookmark', { platform: 'slack', title: 't', link: 'https://x.test' }, d)
-    ).rejects.toThrow(/channel is required/)
+      executeTool(elsewhere, 'addBookmark', { platform: 'slack', channel: 'C_SLACK', title: 't', link: 'l' }, d)
+    ).rejects.toThrow(/bookmarks is unavailable on this Telegram connection/)
     expect(add).not.toHaveBeenCalled()
-
-    // Naming one is all it takes.
-    await executeTool(elsewhere, 'addBookmark', { platform: 'slack', channel: 'C_SLACK', title: 't', link: 'l' }, d)
-    expect(add).toHaveBeenCalledWith('C_SLACK', { title: 't', link: 'l' })
   })
 
   it('refuses on a platform that does not pin links', async () => {

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -74,47 +74,72 @@ describe('toolsForIntegrations', () => {
     expect(sendPlatformEnum([slackInt])).toEqual(['slack'])
   })
 
-  it('injects each port-gated tool for exactly the platforms that declare the port', () => {
-    const PORT_GATED = [
-      'getThreadHistory',
-      'addReaction',
-      'getReactions',
-      'createConversation',
-      'scheduleMessage',
-      'createCanvas',
-      'readCanvas',
-      'updateCanvas',
-      'listBookmarks',
-      'addBookmark',
-      'removeBookmark',
-      'readList',
-      'addListItem',
-      'updateListItem'
-    ]
-    const slackNames = toolsForIntegrations([slackInt]).map((t) => t.name)
+  const PORT_GATED = [
+    'getThreadHistory',
+    'addReaction',
+    'getReactions',
+    'createConversation',
+    'scheduleMessage',
+    'createCanvas',
+    'readCanvas',
+    'updateCanvas',
+    'listBookmarks',
+    'addBookmark',
+    'removeBookmark',
+    'readList',
+    'addListItem',
+    'updateListItem'
+  ]
+
+  it('injects each port-gated tool only into a session ON a platform that declares the port', () => {
+    const slackNames = toolsForIntegrations([slackInt], { currentPlatform: 'slack' }).map((t) => t.name)
     expect(slackNames).toEqual(expect.arrayContaining(PORT_GATED))
+    // A single-platform agent's only platform is its session platform when none is named.
+    expect(toolsForIntegrations([slackInt]).map((t) => t.name)).toEqual(expect.arrayContaining(PORT_GATED))
     // Telegram/Discord/Feishu declare none of them, so an agent without Slack sees none —
     // the gate is the DECLARATION, not the platform name.
     for (const other of [telegramInt, discordInt, feishuInt]) {
-      const names = toolsForIntegrations([other]).map((t) => t.name)
+      const names = toolsForIntegrations([other], { currentPlatform: other.platform }).map((t) => t.name)
       for (const gated of PORT_GATED) expect(names).not.toContain(gated)
     }
   })
 
-  it('narrows a port-gated tool to the declaring platform even on a bridged agent', () => {
-    const bridged = toolsForIntegrations([slackInt, telegramInt])
-    const enumOf = (name: string) =>
-      (
-        (bridged.find((t) => t.name === name)!.inputSchema as Record<string, unknown>).properties as Record<
-          string,
-          { enum?: string[] }
-        >
-      ).platform?.enum
-    // The neutral reads span both; a port only Slack declares must not offer Telegram.
-    expect(enumOf('listChannels')).toEqual(['slack', 'telegram'])
-    expect(enumOf('getThreadHistory')).toEqual(['slack'])
-    expect(enumOf('addReaction')).toEqual(['slack'])
-    expect(enumOf('createCanvas')).toEqual(['slack'])
+  it('keeps a bridged agent’s Slack-shaped tools out of its sessions on every other platform', () => {
+    const bridged = [slackInt, telegramInt, discordInt, feishuInt]
+    const namesOn = (currentPlatform?: string) =>
+      toolsForIntegrations(bridged, currentPlatform ? { currentPlatform } : {}).map((t) => t.name)
+    expect(namesOn('slack')).toEqual(expect.arrayContaining(PORT_GATED))
+    // The same agent, answering elsewhere: the tools are gone, not merely narrowed. Having
+    // Slack does not make a Telegram turn a place to create a canvas.
+    for (const elsewhere of ['telegram', 'discord', 'feishu', 'webchat']) {
+      for (const gated of PORT_GATED) expect(namesOn(elsewhere)).not.toContain(gated)
+    }
+    // No session platform at all (a multi-platform agent built without one) opens no gate.
+    for (const gated of PORT_GATED) expect(namesOn(undefined)).not.toContain(gated)
+    // The neutral reads still span every platform the agent has.
+    const listChannels = toolsForIntegrations(bridged, { currentPlatform: 'telegram' }).find(
+      (t) => t.name === 'listChannels'
+    )!
+    expect((listChannels.inputSchema.properties as Record<string, { enum?: string[] }>).platform?.enum).toEqual([
+      'slack',
+      'telegram',
+      'discord',
+      'feishu'
+    ])
+  })
+
+  it('gives a port-gated tool a bot selector but no platform selector — it acts where the session is', () => {
+    const props = (name: string) =>
+      Object.keys(
+        (
+          toolsForIntegrations([slackInt, telegramInt], { currentPlatform: 'slack' }).find((t) => t.name === name)!
+            .inputSchema as Record<string, unknown>
+        ).properties as Record<string, unknown>
+      )
+    for (const gated of PORT_GATED) {
+      expect(props(gated), gated).not.toContain('platform')
+      expect(props(gated), gated).toContain('integrationId')
+    }
   })
 
   it('injects the platform-neutral read tools + the unified send tool for a Telegram integration', () => {


### PR DESCRIPTION
## What

The port-gated platform tools — `getThreadHistory`, `addReaction`/`getReactions`, `createConversation`, `scheduleMessage`, the canvas trio, the bookmark trio, and the list trio — are now injected **only into a session on a platform that declares the port**, the same gate `getChannelHistory` already used. They lose their `platform` selector and keep `integrationId` for another of the agent's bots on the same platform. The platform-neutral reads (`listChannels`, `listChannelMembers`, `getUserProfile`, `listKnownUsers`) and `sendMessage` keep their cross-platform `platform` argument unchanged.

## Why

The old gate was "any of the agent's platforms declares the port", so an agent with Slack plus anything else carried all fourteen Slack-shaped descriptors into every Telegram, Discord, Feishu, and webchat session — each with a `platform` selector that let a Telegram turn create a Slack canvas. Nobody asked for that reach, and it cost every non-Slack session the descriptors on every turn. Only Slack declares any of these ports today, so in practice this removes Slack-specific tools from non-Slack sessions and changes nothing inside a Slack session beyond the dropped argument.

This is also the gate the upcoming Linear tool family will sit behind, so a Linear-connected agent's Slack sessions stay clean.

## How

- `platforms/read-ports.ts`: `declaresPort(platform, port)` replaces `platformsWithPort` (now callerless).
- `mcp/tools.ts`: `buildReadTools` gates every port-gated builder on the session platform; the builders take `offered: boolean` and emit no `platform` property. `ALL_TOOL_NAMES` builds the read tools once per registered platform as the session platform so every name stays reserved.
- `mcp/ops/platform-actions.ts`, `mcp/ops/platform-reads.ts`: the zod schemas drop `platform`; every op resolves against `ctx.platform`. A stray `platform` argument is ignored, not routed on.
- Design docs (`daemon-detailed-design.md` §9.4, `integration-plugin-architecture.md` §7.1) restated for the session-platform rule.

## Tests

- `mcp-tools.test.ts`: a bridged Slack+Telegram+Discord+Feishu agent sees the fourteen tools on Slack and none on any other platform (or with no session platform); the neutral reads still span every platform; port-gated descriptors carry `integrationId` but no `platform`.
- `mcp-ops.test.ts`: another bot on the same platform still needs an explicit channel; a Telegram session cannot reach a Slack bot's bookmarks by naming `platform: 'slack'`.
- `mcp-tool-args.test.ts` parity holds with the argument dropped on both sides.

`pnpm typecheck`, eslint, and the MCP test files pass. The full daemon unit run has 14 failures in `shim-*` and `acp-matrix` tests that need the sandbox and installed runtimes; none touch this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
