### PR TITLE
fix(daemon): open Git metadata to an unsandboxed Codex launch, hooks and config excepted

### DIFF
--- a/packages/daemon/src/acp/codex-permission-profiles.ts
+++ b/packages/daemon/src/acp/codex-permission-profiles.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, normalize } from 'node:path'
+import { isAbsolute, join, normalize } from 'node:path'
 
 export const CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV = 'CODEX_ACP_PERMISSION_PROFILE_CONFIG'
 
@@ -69,8 +69,13 @@ export function codexPermissionProfileConfig(
           )}`
         ]
       : []
+  // A writable hooks/config would run model-authored code under host-side Git; most-specific match wins.
   const agentFilesystemEntries: Array<[string, string]> = [
     ...writableGitMetadataRoots.map((root): [string, string] => [root, 'write']),
+    ...writableGitMetadataRoots.flatMap((root): Array<[string, string]> => [
+      [join(root, 'hooks'), 'deny'],
+      [join(root, 'config'), 'deny']
+    ]),
     ...protectedRoots.map((root): [string, string] => [root, 'deny'])
   ]
   const agentFilesystem =

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4011,7 +4011,8 @@ export class Daemon {
               this.sandboxRuntimeReadRoots(agent, runtime, launchEnv, githubAppCredentials, gitlabCredentials)
           : undefined,
         trustedWorkspaceWriteRoots: runInSandbox ? this.workspaces.trustedWorkspaceWriteRoots(agent) : undefined,
-        trustedPrimaryCheckout: runInSandbox ? this.workspaces.localPrimaryCheckoutFor(agent) : undefined,
+        // Not sandbox-gated: an unconfined Codex launch needs it too, its own profile protects `.git`.
+        trustedPrimaryCheckout: this.workspaces.localPrimaryCheckoutFor(agent),
         sandboxMechanism: this.sandboxMechanism,
         mcpSocketPath: mcpSocketPath(this.root),
         // Inner tool sandboxes must CONNECT to the daemon socket for either

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -27,6 +27,45 @@ import {
   type CodexPermissionProfileOptions
 } from '../acp/codex-permission-profiles.js'
 
+/** Canonicalize the deepest existing prefix, so a path below a symlink still reads as the kernel sees it. */
+function existingRealpath(path: string): string {
+  let current = resolve(path)
+  const missing: string[] = []
+  for (;;) {
+    try {
+      return resolve(realpathSync(current), ...missing.reverse())
+    } catch {
+      const parent = dirname(current)
+      if (parent === current) return resolve(path)
+      missing.push(basename(current))
+      current = parent
+    }
+  }
+}
+
+function inside(root: string, path: string): boolean {
+  const rel = relative(root, path)
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+}
+
+/** Every `.git` DIRECTORY this agent's checkouts own — where a worktree's index, refs, and objects land. */
+function gitMetadataDirsIn(agentRoot: string, primaryCheckout: string): string[] {
+  return [primaryCheckout, ...secondaryCheckoutsIn(agentRoot)]
+    .map((checkout) => join(checkout, '.git'))
+    .filter((gitDir) => existsSync(gitDir) && lstatSync(gitDir).isDirectory())
+}
+
+/** The same roots with NO outer boundary: one escaping the agent tree is left protected, not refused. */
+function unsandboxedGitMetadataRoots(scopeDir: string, trustedPrimaryCheckout?: string): string[] {
+  const agentRoot = existingRealpath(scopeDir)
+  const primaryCheckout = existingRealpath(trustedPrimaryCheckout ?? primaryCheckoutIn(agentRoot))
+  return compactReadRoots(
+    gitMetadataDirsIn(agentRoot, primaryCheckout)
+      .map((gitDir) => realpathSync(gitDir))
+      .filter((gitDir) => gitDir !== agentRoot && inside(agentRoot, gitDir))
+  )
+}
+
 function applyCodexPermissionProfile(
   env: Record<string, string>,
   opts: CodexPermissionProfileOptions,
@@ -187,10 +226,15 @@ export function prepareRuntimeLaunch(opts: {
   const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
   if (!opts.runInSandbox && !opts.isolateHome) {
     const env = { ...(opts.explicitEnv ?? {}) }
-    if (credentialProfile === 'codex' && opts.allowModelToolUnixSockets) {
+    // No outer boundary here: the Codex profile must both reopen the Git metadata and close hooks/config.
+    if (credentialProfile === 'codex') {
       applyCodexPermissionProfile(
         env,
-        { protectedRoots: [], allowModelToolUnixSockets: true },
+        {
+          protectedRoots: [],
+          writableGitMetadataRoots: unsandboxedGitMetadataRoots(opts.scopeDir, opts.trustedPrimaryCheckout),
+          allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true
+        },
         (opts.hostEnv ?? process.env).CODEX_CONFIG
       )
     }
@@ -212,29 +256,11 @@ export function prepareRuntimeLaunch(opts: {
   }
 
   const stateSourceEnv = opts.stateSourceEnv ?? opts.hostEnv ?? process.env
-  const existingRealpath = (path: string): string => {
-    let current = resolve(path)
-    const missing: string[] = []
-    for (;;) {
-      try {
-        return resolve(realpathSync(current), ...missing.reverse())
-      } catch {
-        const parent = dirname(current)
-        if (parent === current) return resolve(path)
-        missing.push(basename(current))
-        current = parent
-      }
-    }
-  }
   const safeRoot = (path: string, label: string): string => {
     if (!isAbsolute(path)) throw new Error(`unsafe ${label} for sandboxing: ${path}`)
     const real = existingRealpath(path)
     if (real === sep) throw new Error(`unsafe ${label} for sandboxing: ${path}`)
     return real
-  }
-  const inside = (root: string, path: string): boolean => {
-    const rel = relative(root, path)
-    return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
   }
 
   // Validate every broad boundary and the current-agent layout before touching
@@ -315,11 +341,12 @@ export function prepareRuntimeLaunch(opts: {
   if (opts.runInSandbox) isolateHostSocketEnvironment(env, runtimeHome)
 
   if (!opts.runInSandbox) {
-    if (credentialProfile === 'codex' && opts.allowModelToolUnixSockets) {
+    if (credentialProfile === 'codex') {
       const privateCodex = join(runtimeHome, '.codex')
       applyCodexPermissionProfile(env, {
         protectedRoots: existsSync(privateCodex) ? [realpathSync(privateCodex)] : [],
-        allowModelToolUnixSockets: true
+        writableGitMetadataRoots: unsandboxedGitMetadataRoots(opts.scopeDir, opts.trustedPrimaryCheckout),
+        allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true
       })
     }
     return { env, inheritProcessEnv: false, runtimeHome }
@@ -388,16 +415,13 @@ export function prepareRuntimeLaunch(opts: {
     throw new Error(`trusted primary checkout "${primaryCheckout}" is outside the agent root`)
   }
   const gitMetadataWriteRoots = compactReadRoots(
-    [primaryCheckout, ...secondaryCheckoutsIn(agentRoot)]
-      .map((checkout) => join(checkout, '.git'))
-      .filter((gitDir) => existsSync(gitDir) && lstatSync(gitDir).isDirectory())
-      .map((gitDir) => {
-        const trusted = safeRoot(gitDir, 'git metadata root')
-        if (trusted === agentRoot || !inside(agentRoot, trusted)) {
-          throw new Error(`git metadata root "${trusted}" is outside the agent root`)
-        }
-        return trusted
-      })
+    gitMetadataDirsIn(agentRoot, primaryCheckout).map((gitDir) => {
+      const trusted = safeRoot(gitDir, 'git metadata root')
+      if (trusted === agentRoot || !inside(agentRoot, trusted)) {
+        throw new Error(`git metadata root "${trusted}" is outside the agent root`)
+      }
+      return trusted
+    })
   )
   const claudeRuntime = Boolean(opts.runtime && isClaudeRuntimeDef(opts.runtime))
   if (claudeRuntime) {
@@ -475,9 +499,7 @@ export function prepareRuntimeLaunch(opts: {
     ...privateCodexStateRoots
   ])
   if (credentialProfile === 'codex') {
-    // Codex's :workspace profile protects `.git`. Re-open exactly the metadata directories the
-    // outer sandbox already made writable — the outer boundary stays the one that closes hooks and
-    // config. A secondary root materialized after this spawn is reopened on the next one.
+    // Codex's :workspace protects `.git`: re-open what the outer sandbox made writable, hooks/config excepted.
     const writableGitMetadataRoots = gitMetadataWriteRoots.filter((gitDir) =>
       boundary.writable.some((root) => inside(root, gitDir))
     )

--- a/packages/daemon/test/codex-permission-profiles.test.ts
+++ b/packages/daemon/test/codex-permission-profiles.test.ts
@@ -60,12 +60,45 @@ describe.skipIf(process.platform === 'win32')('Codex permission profile launch c
 
     expect(config.configOverrides).toContain('features.unified_exec=false')
     expect(config.configOverrides).toContain(
-      'permissions.agentconnect-protected-workspace.filesystem={ "/agent/workspace/.git" = "write", "/agent/home/.codex" = "deny" }'
+      'permissions.agentconnect-protected-workspace.filesystem={ "/agent/workspace/.git" = "write", ' +
+        '"/agent/workspace/.git/hooks" = "deny", "/agent/workspace/.git/config" = "deny", ' +
+        '"/agent/home/.codex" = "deny" }'
     )
     expect(
       config.configOverrides.find((value) =>
         value.startsWith('permissions.agentconnect-protected-read-only.filesystem=')
       )
     ).not.toContain('/agent/workspace/.git')
+  })
+
+  // Verified against the vendored Codex: without the nested deny a shell command can plant a Git hook.
+  it('denies hooks and config inside every Git metadata root it opens for writing', () => {
+    const config = codexPermissionProfileConfig({
+      protectedRoots: [],
+      writableGitMetadataRoots: ['/agent/workspace/.git', '/agent/repos/acme/infra/checkout/.git']
+    })!
+
+    const agent = config.configOverrides.find((value) =>
+      value.startsWith('permissions.agentconnect-protected-workspace.filesystem=')
+    )!
+    for (const root of ['/agent/workspace/.git', '/agent/repos/acme/infra/checkout/.git']) {
+      expect(agent).toContain(`"${root}" = "write"`)
+      expect(agent).toContain(`"${root}/hooks" = "deny"`)
+      expect(agent).toContain(`"${root}/config" = "deny"`)
+    }
+  })
+
+  // agent-full-access is deliberately unconfined; the paired deny belongs only where the write was granted.
+  it('leaves the full-access profile untouched by the Git metadata grant', () => {
+    const config = codexPermissionProfileConfig({
+      protectedRoots: [],
+      writableGitMetadataRoots: ['/agent/workspace/.git']
+    })!
+
+    const fullAccess = config.configOverrides.find((value) =>
+      value.startsWith('permissions.agentconnect-protected-full-access.filesystem=')
+    )!
+    expect(fullAccess).toContain('"/.git" = "write"')
+    expect(fullAccess).not.toContain('deny')
   })
 })

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -32,6 +32,14 @@ function fixture(): { scopeDir: string; cwd: string; hostHome: string } {
   return { scopeDir, cwd, hostHome }
 }
 
+/** The inner Codex agent profile's filesystem table, which is also its exec sandbox's writable set. */
+function agentFilesystem(env: Record<string, string>): string {
+  const profile = JSON.parse(env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]!) as { configOverrides: string[] }
+  return profile.configOverrides.find((value) =>
+    value.startsWith('permissions.agentconnect-protected-workspace.filesystem=')
+  )!
+}
+
 function coveredBy(paths: string[], target: string): boolean {
   return paths.some((root) => {
     const rel = relative(root, target)
@@ -431,6 +439,92 @@ describe('prepareRuntimeLaunch', () => {
         hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
       })
     ).toThrow(/trusted primary checkout .* is outside the agent root/)
+  })
+
+  // Unsandboxed, Codex's own profile is the whole boundary and it confines exec to the SESSION cwd.
+  it('opens the owner checkout .git to an unsandboxed Codex launch, hooks and config excepted', () => {
+    const { scopeDir, hostHome } = fixture()
+    const primaryGit = join(scopeDir, 'workspace', '.git')
+    const cwd = join(scopeDir, 'worktrees', 'session-1')
+    mkdirSync(join(primaryGit, 'worktrees', 'session-1'), { recursive: true })
+    mkdirSync(cwd, { recursive: true })
+    writeFileSync(join(cwd, '.git'), `gitdir: ${join(primaryGit, 'worktrees', 'session-1')}\n`)
+
+    // No credential channel: the carve-back is owed to every unsandboxed Codex launch, not only a wired one.
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: false,
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    expect(launch.sandbox).toBeUndefined()
+    const owner = realpathSync(primaryGit)
+    expect(agentFilesystem(launch.env)).toContain(`"${owner}" = "write"`)
+    expect(agentFilesystem(launch.env)).toContain(`"${join(owner, 'hooks')}" = "deny"`)
+    expect(agentFilesystem(launch.env)).toContain(`"${join(owner, 'config')}" = "deny"`)
+  })
+
+  it('follows the daemon-named checkout and every secondary root when the sandbox is off', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const legacyGit = join(scopeDir, 'legacy-checkout', '.git')
+    const secondaryGit = join(scopeDir, 'repos', 'acme', 'infra', 'checkout', '.git')
+    mkdirSync(legacyGit, { recursive: true })
+    mkdirSync(secondaryGit, { recursive: true })
+    mkdirSync(join(cwd, '.git'), { recursive: true })
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: false,
+      trustedPrimaryCheckout: join(scopeDir, 'legacy-checkout'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const table = agentFilesystem(launch.env)
+    expect(table).toContain(`"${realpathSync(legacyGit)}" = "write"`)
+    expect(table).toContain(`"${realpathSync(secondaryGit)}" = "write"`)
+    // The default-layout `.git` beside it was never the agent's checkout, so it stays protected.
+    expect(table).not.toContain(realpathSync(join(cwd, '.git')))
+  })
+
+  it('leaves a checkout outside the agent root protected rather than opening it unconfined', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const outsideGit = join(dirname(scopeDir), 'elsewhere', '.git')
+    mkdirSync(outsideGit, { recursive: true })
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: false,
+      allowModelToolUnixSockets: true,
+      trustedPrimaryCheckout: join(dirname(scopeDir), 'elsewhere'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const profile = JSON.parse(launch.env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]!) as { configOverrides: string[] }
+    expect(profile.configOverrides.join('\n')).not.toContain(realpathSync(outsideGit))
+  })
+
+  // The gate widened to "is Codex", so pin that a launch with nothing to carve back still gets no profile.
+  it('adds no Codex profile unsandboxed without Git metadata or the credential channel', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: false,
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    expect(launch.env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]).toBeUndefined()
   })
 
   it('rejects root-level protected paths instead of generating an ineffective policy', () => {


### PR DESCRIPTION
## The gap

Codex's `:workspace` permission profile makes each session's own cwd writable and protects `.git`. An agent with `workspaceIsolation: session` runs each session in its own worktree, whose `.git` is a link *file* — the index it writes, and every ref and object its commits create, live in the **owner checkout's** `.git`, which is outside that cwd. Reads keep working; every Git write fails.

#1695 / #1698 fixed this for sandboxed launches. The unsandboxed path in `prepareRuntimeLaunch` never got it: it applied the Codex permission profile with `protectedRoots` only, and only when the agent-scoped credential channel happened to be enabled.

## What changed

`packages/daemon/src/launch/prepare.ts` now carves the same metadata directories back on both unsandboxed branches, computed from the agent root plus the daemon-named primary checkout — not from the cwd, which is the primary checkout for every session a host serves, since the ACP host is per-agent and session worktrees arrive later on `newSession`. `packages/daemon/src/daemon.ts` therefore stops gating `trustedPrimaryCheckout` on the sandbox.

Two things differ from the sandboxed path, both because there is no outer boundary to fall back on:

- **The profile itself denies `hooks` and `config` inside every root it opens** (`packages/daemon/src/acp/codex-permission-profiles.ts`). On the sandboxed path the outer boundary closes them; here the profile is the whole confinement, so a bare write grant would let model-authored code plant a hook that a later host-side Git invocation executes. The deny is emitted beside the write on the agent profile alone — `agent-full-access`, the deliberately unconfined mode, is untouched, and a test pins that.
- **A checkout resolving outside the agent root is skipped, not refused.** The sandboxed path throws; refusing here would break a launch the operator already chose to run unconfined.

The sandboxed path picks up the paired denies too, so both layers now agree rather than the inner one relying on the outer.

### One deliberate widening

The trigger moves from `credentialProfile === 'codex' && allowModelToolUnixSockets` to just `credentialProfile === 'codex'`. The bug does not depend on that channel — an agent on a Git workspace with no managed credentials has exactly the same broken Git writes — and leaving the gate would have shipped a fix that silently misses them.

Nothing changes for a launch with nothing to carve back: `codexPermissionProfileConfig` still returns `undefined` and no profile is applied. There is a regression test for that. The population that newly receives a profile is "unsandboxed Codex agent with a Git workspace"; for them `agent-full-access` also gains this repo's usual full-access network flags, which is a real if narrow change and the reason it is called out here.

## Verification

**What I could verify.** The vendored Codex ships a `codex sandbox -P <profile> -C <dir> -- <cmd>` subcommand that runs a real command under the same OS sandbox a session gets. Against a real fixture (`<agentRoot>/workspace` checkout + `<agentRoot>/worktrees/session-1` worktree):

| profile | probe | result |
| --- | --- | --- |
| `extends=":workspace"` | read owner `.git/HEAD` | succeeds |
| `extends=":workspace"` | write owner `.git/worktrees/session-1/index.lock` | **denied** |
| config generated by this change | same write | succeeds |
| config generated by this change | write `.git/refs/heads/...` | succeeds |
| config generated by this change | write `.git/hooks/pre-commit` | **denied** |
| config generated by this change | write `.git/config` | **denied** |
| write grant, denies removed | write `.git/hooks/pre-commit` | succeeds |

The probe was an ordinary exec'd binary, not an editing tool — so the `permissions.*.filesystem` table governs the exec sandbox, not merely Codex's own file edits. The last row is why the paired denies exist. Declaring the denies before the write instead of after gives identical results, which matches Codex resolving the table by most-specific path rather than by declaration order.

The config in those rows was emitted by the patched code itself, not hand-written.

**What I could not verify.** That run was macOS/seatbelt. Deployments run Linux/landlock — same config-to-policy derivation, different enforcement backend, which this machine cannot exercise. And I have not driven a real Codex model turn end to end through a daemon; proving that needs a live paid runtime. Everything above is the sandbox layer in isolation plus unit coverage, so treat "a real agent can now commit from an isolated session" as strongly indicated rather than demonstrated.

## Tests

New regression tests in `packages/daemon/test/runtime-launch.test.ts` (unsandboxed carve-back with hooks/config denied, the daemon-named checkout and secondary roots, an out-of-root checkout left protected, and no profile when there is nothing to carve back) and in `packages/daemon/test/codex-permission-profiles.test.ts` (paired denies, full-access untouched).

Mutation-checked, three ways:

- Drop `writableGitMetadataRoots` from the unsandboxed branch → the two carve-back tests fail; every sandboxed test stays green, confirming they target the right path.
- Remove the `hooks`/`config` denies → 3 tests fail across both files.
- Route the deny through `protectedRoots` so it leaks into `agent-full-access` → the full-access guard test fails.

All three restored afterwards. `tsc -p tsconfig.typecheck.json --noEmit`, prettier, and eslint are clean; `runtime-launch`, `codex-permission-profiles`, `runtime-credentials`, `sandbox`, `codex-config`, `skill-sandbox-policy` and `sandbox-credential-helper` all pass. The full daemon suite was not run — it OOMs on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
