### PR TITLE
feat(daemon): log the Git metadata a host launch reopened

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4030,6 +4030,12 @@ export class Daemon {
       }
       launch = assembled.launch
       launchRuntime = assembled.runtime
+      // The grant is computed once per host and lives only in the child's argv; name it here so a
+      // session that later fails a Git write can be matched against what its host was given.
+      const reopened = launch.gitMetadataWriteRoots.length > 0 ? launch.gitMetadataWriteRoots.join(', ') : 'none'
+      this.log.info(
+        `acp: agent "${agentId}" host launch — sandbox ${runInSandbox ? 'on' : 'off'}, cwd ${opts.cwd}, git metadata reopened: ${reopened}`
+      )
     } catch (err) {
       if (err instanceof SandboxError) {
         throw new Error(

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -149,6 +149,9 @@ export interface PreparedRuntimeLaunch {
   env: Record<string, string>
   /** Sandboxed launches carry a sanitized environment; unsandboxed launches inherit the daemon environment. */
   inheritProcessEnv: boolean
+  /** The `.git` directories this launch reopened for the runtime's Git writes — empty when nothing
+   *  was confined or nothing was found. Logged at spawn so a stale grant is visible after the fact. */
+  gitMetadataWriteRoots: string[]
   runtimeHome?: string
   sandbox?: {
     mechanism: SandboxMechanism
@@ -227,12 +230,14 @@ export function prepareRuntimeLaunch(opts: {
   if (!opts.runInSandbox && !opts.isolateHome) {
     const env = { ...(opts.explicitEnv ?? {}) }
     // No outer boundary here: the Codex profile must both reopen the Git metadata and close hooks/config.
+    const gitMetadataWriteRoots =
+      credentialProfile === 'codex' ? unsandboxedGitMetadataRoots(opts.scopeDir, opts.trustedPrimaryCheckout) : []
     if (credentialProfile === 'codex') {
       applyCodexPermissionProfile(
         env,
         {
           protectedRoots: [],
-          writableGitMetadataRoots: unsandboxedGitMetadataRoots(opts.scopeDir, opts.trustedPrimaryCheckout),
+          writableGitMetadataRoots: gitMetadataWriteRoots,
           allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true
         },
         (opts.hostEnv ?? process.env).CODEX_CONFIG
@@ -241,7 +246,7 @@ export function prepareRuntimeLaunch(opts: {
     // NOT in k8s: the runtime runs in a sandbox pod, so the daemon's own environment describes a
     // different machine. Inheriting it sent this daemon's HOME across, and the runtime then tried
     // to open its state under a path that exists only here. The pod supplies its own basics.
-    return { env, inheritProcessEnv: opts.k8s !== true }
+    return { env, inheritProcessEnv: opts.k8s !== true, gitMetadataWriteRoots }
   }
   if (opts.runInSandbox && opts.runtime?.externalExecution) {
     throw new Error(
@@ -341,15 +346,17 @@ export function prepareRuntimeLaunch(opts: {
   if (opts.runInSandbox) isolateHostSocketEnvironment(env, runtimeHome)
 
   if (!opts.runInSandbox) {
+    const gitMetadataWriteRoots =
+      credentialProfile === 'codex' ? unsandboxedGitMetadataRoots(opts.scopeDir, opts.trustedPrimaryCheckout) : []
     if (credentialProfile === 'codex') {
       const privateCodex = join(runtimeHome, '.codex')
       applyCodexPermissionProfile(env, {
         protectedRoots: existsSync(privateCodex) ? [realpathSync(privateCodex)] : [],
-        writableGitMetadataRoots: unsandboxedGitMetadataRoots(opts.scopeDir, opts.trustedPrimaryCheckout),
+        writableGitMetadataRoots: gitMetadataWriteRoots,
         allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true
       })
     }
-    return { env, inheritProcessEnv: false, runtimeHome }
+    return { env, inheritProcessEnv: false, runtimeHome, gitMetadataWriteRoots }
   }
 
   // PATH entries supplied by version managers are commonly symlinks below the
@@ -514,6 +521,7 @@ export function prepareRuntimeLaunch(opts: {
     env,
     inheritProcessEnv: false,
     runtimeHome,
+    gitMetadataWriteRoots,
     sandbox: {
       mechanism: opts.sandboxMechanism!,
       writable: boundary.writable,

--- a/packages/daemon/src/runtimes/cluster-probe.ts
+++ b/packages/daemon/src/runtimes/cluster-probe.ts
@@ -120,7 +120,7 @@ export async function probeClusterRuntimes(opts: ClusterProbeOptions): Promise<R
       timeoutMs: opts.timeoutMs ?? CLUSTER_PROBE_TIMEOUT_MS,
       // The pod is the isolation boundary AND a different filesystem: there is no private HOME to
       // compose here, and inheriting this daemon's environment would describe another machine.
-      launchFor: () => ({ env, inheritProcessEnv: false, redactValues })
+      launchFor: () => ({ env, inheritProcessEnv: false, redactValues, gitMetadataWriteRoots: [] })
     })
     // Marked on the result rather than left to the caller, because an adopting member reads the
     // published result and has no other way to know what the prober launched with.

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -48,6 +48,31 @@ function coveredBy(paths: string[], target: string): boolean {
 }
 
 describe('prepareRuntimeLaunch', () => {
+  // The grant only exists in the child's argv otherwise; a spawn log line reads it from here.
+  it('reports the Git metadata it reopened, on every launch shape', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const base = {
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      daemonRoot: dirname(scopeDir),
+      credentialPlatform: 'linux' as const,
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    }
+    // A scratch workspace has no `.git`: nothing to reopen, and the field says so rather than lying.
+    expect(prepareRuntimeLaunch({ ...base, runInSandbox: false }).gitMetadataWriteRoots).toEqual([])
+
+    const primaryGit = join(cwd, '.git')
+    mkdirSync(primaryGit)
+    expect(prepareRuntimeLaunch({ ...base, runInSandbox: false }).gitMetadataWriteRoots).toEqual([
+      realpathSync(primaryGit)
+    ])
+    expect(
+      prepareRuntimeLaunch({ ...base, runInSandbox: true, sandboxMechanism: 'bwrap' }).gitMetadataWriteRoots
+    ).toEqual([realpathSync(primaryGit)])
+  })
+
   it('inherits the daemon environment and creates no private HOME when the effective sandbox is off', () => {
     const { scopeDir, cwd, hostHome } = fixture()
     const launch = prepareRuntimeLaunch({
@@ -60,7 +85,7 @@ describe('prepareRuntimeLaunch', () => {
       hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
     })
 
-    expect(launch).toEqual({ env: { AGENT_VALUE: 'yes' }, inheritProcessEnv: true })
+    expect(launch).toEqual({ env: { AGENT_VALUE: 'yes' }, inheritProcessEnv: true, gitMetadataWriteRoots: [] })
     expect(existsSync(join(scopeDir, 'home'))).toBe(false)
   })
 


### PR DESCRIPTION
Observability follow-up to #1695, #1698 and #1703.

## Why

The grant that lets a runtime write its session worktrees' index, refs, and objects — the owner
checkout's `.git`, reopened with `hooks` and `config` still closed — is computed once per ACP host
and then exists only in the child's argv. A host is per-agent and long-lived, so when a session
later fails a Git write there is no record of what its host was actually given: the process may
have been replaced by the time anyone looks. That is exactly what happened with the failure that
motivated the three PRs above — by the time it was investigated the host was gone, the live
replacement carried the expected grant, and the original could no longer be settled either way.

## What changed

- `PreparedRuntimeLaunch` gains `gitMetadataWriteRoots`, set on every launch shape: the sandboxed
  path reports the outer write grant, the two unsandboxed paths report what the Codex profile
  reopened, and a launch that confined nothing reports an empty list — which is the truth rather
  than a gap, since nothing was closed.
- `Daemon.buildAcpHost` logs one line at host spawn naming the sandbox state, the cwd, and the
  reopened directories (or `none`), so a later failure can be matched against the grant instead of
  reconstructed.
- One test pins the field across the scratch, unsandboxed-Codex, and sandboxed shapes.

## Reviewer notes

- No behavior change: the field is read only by the log line. The grant computation itself is
  untouched.
- The line carries local paths, which the daemon log already does for other spawn diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
