### PR TITLE
fix(web): webhook tile last, smaller Lark / Feishu label

### DIFF
--- a/packages/web/src/components/LarkFeishuSwitcher.tsx
+++ b/packages/web/src/components/LarkFeishuSwitcher.tsx
@@ -34,11 +34,11 @@ export default function LarkFeishuSwitcher({
   const activeClassName =
     variant === 'login'
       ? 'font-sans text-[14px] font-semibold leading-normal text-(--text-primary)'
-      : 'font-sans text-[13px] font-semibold leading-normal text-(--text-primary)'
+      : 'font-sans text-[12px] font-semibold leading-normal text-(--text-primary)'
   const alternateClassName =
     variant === 'login'
       ? 'pointer-events-auto cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[12px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
-      : 'cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[11px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
+      : 'cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[10px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
 
   return (
     <span className="inline-flex items-baseline whitespace-nowrap">
@@ -49,7 +49,7 @@ export default function LarkFeishuSwitcher({
       {/* The slash hugs both words: spaced out, the label reached the install tile's edge. */}
       <span
         aria-hidden="true"
-        className="mx-[1px] font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)"
+        className={`mx-[1px] font-sans font-normal leading-normal text-(--text-tertiary) ${variant === 'login' ? 'text-[11px]' : 'text-[10px]'}`}
       >
         /
       </span>

--- a/packages/web/src/components/console/platforms/host-projections.ts
+++ b/packages/web/src/components/console/platforms/host-projections.ts
@@ -60,9 +60,10 @@ export const BOT_PLATFORMS: readonly PlatformTile[] = platformTiles(platformRegi
  *  code host the deployment has not configured says so in its own pane. */
 export const PLATFORMS: readonly PlatformTile[] = [
   ...BOT_PLATFORMS,
-  { key: 'webhook', label: 'Webhook' },
   { key: 'github', label: 'GitHub' },
-  { key: 'gitlab', label: 'GitLab' }
+  { key: 'gitlab', label: 'GitLab' },
+  // The generic trigger closes the row: chat platforms and code hosts are the named products.
+  { key: 'webhook', label: 'Webhook' }
 ]
 
 /** The core trigger kinds — every picker choice that is NOT a registry platform.

--- a/packages/web/src/components/console/platforms/platform-set.test.tsx
+++ b/packages/web/src/components/console/platforms/platform-set.test.tsx
@@ -35,7 +35,8 @@ const ALIASES = ['lark']
 
 /** Not modules and never will be: picking one mints an inbound trigger, not a
  *  bot identity (contract, registry doc). The picker still offers them. */
-const CORE_TRIGGER_KINDS = ['webhook', 'github', 'gitlab']
+// The code hosts follow the chat platforms; the generic webhook closes the row.
+const CORE_TRIGGER_KINDS = ['github', 'gitlab', 'webhook']
 
 describe('platform set', () => {
   it('gives every registered module a mark and a label', () => {


### PR DESCRIPTION
## Summary
- Add integration: the generic **Webhook** tile now closes the platform row, after GitHub and GitLab — chat platforms and code hosts are the named products, the trigger is the catch-all.
- The **Lark / Feishu** switcher in the tile drops to the tile label size (12px active, 10px alternate and slash), so the two-word label no longer runs to the tile edges in the one-row grid.

## Testing
- `vitest` over platform-set, modals, the switcher and the Feishu module: green (the order pin updated to `github, gitlab, webhook`).
- `pnpm --filter @agentconnect.md/web typecheck` and eslint on the touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)