### PR TITLE
feat(linear): auto-start a delegated issue and link the turn's pull requests on the session

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1285,7 +1285,9 @@ tile.
    issue's state and the team's workflow, then at most one `issueUpdate`).
    Skipped for triage-status issues so Linear-side automation delegations
    keep human triage, and for a team with no `started` state. It runs from
-   the same post-admission hook as the ack, so the receipt CAS that collapses
+   the same post-admission hook as the ack, **after the ack has posted** —
+   both ride the connection's one FIFO queue, so the state read must not sit
+   ahead of the ≤10 s acknowledgement — and the receipt CAS that collapses
    redeliveries also keeps the issue from moving twice; a follow-up
    `prompted` never touches the state the humans left it in. `output.mode:
 none` skips it along with everything else Linear-visible. There is **no

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -497,6 +497,7 @@ coalesce aggressively, post meaningfully.
 | `agent_message_chunk` (intermediate, flushed at a tool boundary or idle) | `thought` (non-ephemeral)                      | Progress narration between tool calls stays visible in the feed                                                                                                                                                                                                                             |
 | `tool_call` → terminal `tool_call_update`                                | `action`                                       | Emitted once at terminal status: `action` = tool title, `parameter` = input summary, `result` = head-clamped output (~2 800 chars). Consecutive same-title calls collapse; per-turn cap with a final "… and N more" thought                                                                 |
 | ACP `plan` update                                                        | `plan`                                         | Both sides are full-array replace — direct mapping                                                                                                                                                                                                                                          |
+| a pull/merge-request URL anywhere in the agent's message text            | `external-urls` (`addedExternalUrls`)          | Collected over the whole turn, each URL once, labelled `PR #123` / `MR !45`; published once, immediately before the settling `response` (§10.3)                                                                                                                                             |
 | turn end                                                                 | `response`                                     | The accumulated final answer (final-answer selection reuses the GitHub Layer-2 heuristics: `_meta.codex.phase === 'final_answer'`, else message grouping, else last text run). Attribution footer appended per `output.showFooter`, Markdown-safe via the shared fence-aware chrome helpers |
 | turn failure (quota / auth / crash)                                      | `error`                                        | Reuses `turnFailureReason`/`turnFailureCode`; converger buffer flushed first so runtime-narrated errors are not duplicated                                                                                                                                                                  |
 | permission gate would block the turn                                     | `elicitation`                                  | v1 posts "This step needs approval — open the session in the console" + deep link; interactive approval from Linear is out of scope (§13)                                                                                                                                                   |
@@ -708,10 +709,13 @@ No new `rd/msg` union member. Events ride `RdMsgIm` with a
   comment's own text for a mention-created session (extracted so it is
   **never only inside fenced context**), or the follow-up
   `agentActivity.body` verbatim.
-- `adapterExt.linear` = `{ agentSessionId, issueIdentifier?, issueTitle?,
-promptContext?, guidance?, previousComments?, truncated? }` — the §6.4
-  adapter-extension bag: opaque to core, round-tripped to the daemon's linear
-  module, which owns fencing and prompt assembly (§8).
+- `adapterExt.linear` = `{ agentSessionId, event?, issueId?, issueIdentifier?,
+issueTitle?, promptContext?, guidance?, previousComments?, truncated? }` — the
+  §6.4 adapter-extension bag: opaque to core, round-tripped to the daemon's
+  linear module, which owns fencing and prompt assembly (§8). `event` names
+  the webhook that opened the turn (`created` | `prompted`) so the daemon can
+  tell the session-opening delegation from a follow-up (§10.2); `issueId` is
+  the issue UUID the issue-scoped writes key on (Resources, state).
 
 Stop rides `RdMsgPlatformAction` (`platformId: 'linear'`, payload
 `{ kind: 'stop', agentSessionId }`): the daemon-side linear module decodes it,
@@ -1174,7 +1178,12 @@ tile.
   - message strategy — `adapterExt.linear` → prompt assembly and fencing
     (§8); no-issue unsupported-surface response (§4.5); stop decoder for the
     `platform_action` payload → `interruptTurn` + settling response.
-  - The ≤10 s ack at `rd/msg` admission, after inbox dedup (§10.1).
+  - The ≤10 s ack at `rd/msg` admission, after inbox dedup (§10.1), and from
+    the same hook the §10.2 auto-start (`LinearConnection.startIssue`, one
+    state read + at most one `issueUpdate`, both on the paced queue) when the
+    bag says the turn is the session-opening `created` and names an issue.
+  - `codeHostLinks` in `turn-output.ts`: the §10.3 collector over the turn's
+    message text, emitted as one `external-urls` action before the response.
   - **The conversation report is a name refresh, not the seeder.** The
     connection reports the workspace as its single conversation — one
     `integration/channels` row, `id` = the `organizationId`, `name` = the
@@ -1269,15 +1278,31 @@ tile.
    `(sessionKey, msgId)` first, ack second; concurrent or replayed deliveries
    of the same `msgId` collapse before any feed row is written. This is the
    only activity ever posted outside the converger.
-2. **Issue status transition (P2)** follows Linear's best practice: on a
-   delegated `created`, if the issue is not in a `started/completed/canceled`
-   state, move it to the team's lowest-position `started` state — behind an
-   integration-level toggle (default on), skipped for triage-status issues so
-   Linear-side automation delegations keep human triage.
-3. **PR links (P2).** The daemon already computes PR/commit links for GitHub
-   attribution; a turn-scoped URL collector feeds `addedExternalUrls`
-   (label `PR #123`), alongside the console session link added at session
-   start.
+2. **Issue status transition** follows Linear's best practice: on the
+   session-opening `created` (the bag's `event`), if the issue is not in a
+   `started/completed/canceled` state, move it to the team's lowest-position
+   `started` state (`LinearConnection.startIssue`: one paced read of the
+   issue's state and the team's workflow, then at most one `issueUpdate`).
+   Skipped for triage-status issues so Linear-side automation delegations
+   keep human triage, and for a team with no `started` state. It runs from
+   the same post-admission hook as the ack, so the receipt CAS that collapses
+   redeliveries also keeps the issue from moving twice; a follow-up
+   `prompted` never touches the state the humans left it in. `output.mode:
+none` skips it along with everything else Linear-visible. There is **no
+   toggle**: the earlier "integration-level toggle (default on)" was dropped
+   for the smaller surface — an integration that must not move issues has no
+   such case today, and one can be added when it does.
+3. **PR links.** The converger collects pull/merge-request URLs from the
+   agent's own message text over the turn (`codeHostLinks`: `PR #123` for a
+   GitHub pull, `MR !45` for a GitLab merge request, each URL once) and
+   publishes them as `addedExternalUrls` immediately before the settling
+   `response`, in every mode from `low` up. Reading the agent's text rather
+   than a tool hook is deliberate: `gh pr create` prints the URL and every
+   runtime's model repeats it in the answer, so this catches the PR on every
+   runtime without knowing any tool. The console session link is separate —
+   it lands in the issue's **Resources** (`attachmentCreate`, keyed by URL)
+   on the first turn, so it is visible from the issue itself, not only inside
+   the session panel.
 4. **`elicitation` is a pointer, not a protocol, in v1.** True interactive
    approval (Linear reply → permission grant) needs an approval-card
    equivalent over activities; deferred (§13). Until then the agent's
@@ -1349,9 +1374,45 @@ tile.
   (`attachmentCreate`, §5 table), and the delegator is named in the §8 header
   and the session list (a `created` event carries only `creatorId`, so the
   daemon resolves the name itself, full name first).
-- **P2 — workflow polish.** Plan sync; `externalUrls` (PR + console links);
-  issue auto-start transition; daemon-local Linear read tool (bounded
-  `getIssue`/comments via the connection token); elicitation deep-link card.
+- **P2 — working inside the issue.** Re-scoped 2026-09 against what a
+  delegated issue looks like when a competing agent handles it (the issue
+  moves to In Progress on delegation, the PR is linked, the plan is posted,
+  an empty ticket gets clarifying questions) and against Linear's own MCP
+  server (~25 tools: issue list/get/create/update, statuses, labels,
+  comments, projects, teams, users, cycles, documents). Three layers, in
+  merge order:
+  1. **Automatic behavior, no agent involvement** (done): plan sync (§5.1),
+     the auto-start transition (§10.2), PR links plus the console Resources
+     entry (§10.3).
+  2. **A Linear tool family for the agent**, self-built on the connection's
+     brokered app token — never Linear's hosted MCP server, which is a
+     user-token identity that would bypass §4.4 custody and single-app
+     attribution. Names follow the official MCP's vocabulary in camelCase so
+     models need no learning (`listIssues`, `getIssue`, `createIssue`,
+     `updateIssue`, `listIssueStatuses`, `listIssueLabels`,
+     `createIssueComment`, `listIssueComments`, `listProjects`, `getProject`,
+     `listTeams`, `listUsers`, `listCycles`, `listDocuments`, `getDocument`).
+     `updateIssue` accepts state, assignee and labels **by name** and
+     resolves them against the team, so the agent can "move it to In
+     Progress" without a second lookup. **Injected only into a session ON
+     the Linear platform** — the daemon's port-gated tools are
+     session-platform-scoped, so a Linear-connected agent's Slack sessions
+     carry none of these; cross-platform reach ("open a Linear issue from
+     Slack") was considered and deferred until someone asks, because no other
+     platform offers it either. Not in the first cut: initiatives, project
+     updates, milestones, Linear's own documentation search, image loading
+     (attachment download stays deferred, §9.4).
+  3. **A daemon-authored Linear context block** in the §8 trusted header:
+     the issue's UUID, identifier, team, current state, assignee and labels
+     (the coordinates the tools take), plus a few lines of working convention
+     — the issue is the record, so plans and outcomes go into its description
+     or a comment; branch and PR names carry the identifier so Linear's own
+     GitHub integration links them; an empty ticket earns a clarifying
+     `response` before work. **Not a skill**: the tools only exist in Linear
+     turns, so a per-turn prompt block is the deterministic seat, and the
+     customer-side customization seat is Linear's own admin `guidance`,
+     which §8 already passes through.
+     Still in P2: the elicitation deep-link card.
 - **P3 — breadth.** Label → skill playbook mapping; per-team dispatch
   defaults — the one upgrade that would split a workspace into several
   conversations, so it reopens §15's granularity argument rather than merely
@@ -1462,6 +1523,11 @@ tile.
    into via OAuth (multi-workspace still needs `authorization_code`), and
    whether a 30-day non-rotating token is an acceptable custody trade-off.
    Evaluate before P2; the broker seam (§7.3) is unchanged either way.
+5. **`addedExternalUrls` across turns** — the §10.3 collector dedups within
+   a turn, but a follow-up turn that names the same PR sends it again. Whether
+   Linear collapses an `addedExternalUrls` entry on URL (as `attachmentCreate`
+   does) or stacks a second one is unverified; if it stacks, the fix is a
+   per-session set on the daemon, not a change to the IR.
 
 ### Live-probe corrections to earlier assumptions (2026-09)
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6586,7 +6586,7 @@ export class Daemon {
       'linear',
       {
         prepare: async (msg, normalized) => await this.prepareLinearDelivery(msg, normalized),
-        onAdmitted: async (msg, normalized, busy) => this.postLinearAck(msg, normalized, busy),
+        onAdmitted: async (msg, normalized, busy) => this.onLinearAdmitted(msg, normalized, busy),
         requireDurable: true,
         receiptId: (normalized) => linearDeliveryReceiptId(stableMessageId(normalized))
       }
@@ -6723,14 +6723,16 @@ export class Daemon {
 
   /**
    * The ≤10 s pre-spawn acknowledgement (§10.1) — the ONE activity posted outside the
-   * converger, and the reason a suppressed turn can still be ack-only. Fire-and-forget: it is
-   * chrome, and the turn it precedes must never wait on a Linear write.
+   * converger, and the reason a suppressed turn can still be ack-only — plus the §10.2
+   * auto-start of a freshly delegated issue. Fire-and-forget: both are chrome, and the turn
+   * they precede must never wait on a Linear write.
    *
    * Reached only on an admission that WON the receipt CAS, so the strict order §10.1 asks for
    * holds by construction: the admission row and the permanent receipt were committed together
-   * before this can run, and a losing copy of the delivery never reaches it at all.
+   * before this can run, and a losing copy of the delivery never reaches it at all — which is
+   * also what keeps a redelivered `created` from moving the issue twice.
    */
-  private postLinearAck(msg: RdMsgIm, normalized: NormalizedMessage, busy: boolean): void {
+  private onLinearAdmitted(msg: RdMsgIm, normalized: NormalizedMessage, busy: boolean): void {
     const conn = this.lnConnByIntegration.get(msg.integrationId)
     const ext = readLinearExt(normalized)
     if (!conn || !ext) return
@@ -6744,9 +6746,25 @@ export class Daemon {
         msg.agentId,
         normalized.transportScope
       )
-      // `none` is truly silent (§5.2): no ack, no activities, transcript only.
+      // `none` is truly silent (§5.2): no ack, no activities, no issue write — transcript only.
       const mode = (await this.store.getOutputModeOverride(key)) ?? agent?.output?.mode ?? 'low'
       if (mode === 'none') return
+      // The session opened on this delivery: the issue moves to "started" alongside the ack,
+      // and a follow-up on an existing session leaves the state where the humans put it.
+      if (ext.event === 'created' && ext.issueId) {
+        const issue = ext.issueIdentifier ?? ext.issueId
+        conn
+          .startIssue(ext.issueId)
+          .then((result) => {
+            if (result.outcome === 'moved')
+              this.log.info(`linear: moved ${issue} from "${result.from}" to "${result.state}" on delegation`)
+            else
+              this.log.debug(
+                `linear: left ${issue} alone on delegation (${result.outcome}: ${'reason' in result ? result.reason : result.state})`
+              )
+          })
+          .catch((err: unknown) => this.log.warn(`linear: auto-start of ${issue} failed: ${formatErr(err)}`))
+      }
       await conn.postActivity(ext.agentSessionId, {
         type: 'thought',
         body: linearAckBody(agentName, ext, { queued: busy }),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6749,8 +6749,15 @@ export class Daemon {
       // `none` is truly silent (§5.2): no ack, no activities, no issue write — transcript only.
       const mode = (await this.store.getOutputModeOverride(key)) ?? agent?.output?.mode ?? 'low'
       if (mode === 'none') return
-      // The session opened on this delivery: the issue moves to "started" alongside the ack,
-      // and a follow-up on an existing session leaves the state where the humans put it.
+      await conn.postActivity(ext.agentSessionId, {
+        type: 'thought',
+        body: linearAckBody(agentName, ext, { queued: busy }),
+        ephemeral: true
+      })
+      // The session opened on this delivery: the issue moves to "started" once the ack is OUT —
+      // both ride the connection's one FIFO queue, so enqueuing the state read first would let a
+      // slow or retried read eat the ≤10 s acknowledgement budget (§10.1). A follow-up on an
+      // existing session leaves the state where the humans put it.
       if (ext.event === 'created' && ext.issueId) {
         const issue = ext.issueIdentifier ?? ext.issueId
         conn
@@ -6765,11 +6772,6 @@ export class Daemon {
           })
           .catch((err: unknown) => this.log.warn(`linear: auto-start of ${issue} failed: ${formatErr(err)}`))
       }
-      await conn.postActivity(ext.agentSessionId, {
-        type: 'thought',
-        body: linearAckBody(agentName, ext, { queued: busy }),
-        ephemeral: true
-      })
     })().catch((err: unknown) => this.log.warn(`linear: acknowledgement failed: ${formatErr(err)}`))
   }
 

--- a/packages/daemon/src/platforms/linear/connection.ts
+++ b/packages/daemon/src/platforms/linear/connection.ts
@@ -83,6 +83,12 @@ export interface LinearExternalUrl {
   url: string
 }
 
+/** What §10.2 auto-start did to the issue: one write, or a stated reason for none. */
+export type LinearIssueStartOutcome =
+  | { outcome: 'moved'; from: string; state: string }
+  | { outcome: 'unchanged'; state: string }
+  | { outcome: 'skipped'; reason: string }
+
 /** The `agentSessionUpdate` input this connection is allowed to send (§2). */
 export interface LinearSessionUpdate {
   plan?: LinearPlanEntry[]
@@ -353,6 +359,39 @@ export class LinearConnection implements PlatformConnection {
     await this.updateSession(agentSessionId, { addedExternalUrls: urls })
   }
 
+  /**
+   * §10.2 auto-start: move a freshly delegated issue into its team's first `started` state.
+   *
+   * Reads the issue's current state and the team's workflow, then writes at most once. An issue
+   * already `started`/`completed`/`canceled` is left alone; one in `triage` is skipped so a
+   * Linear-side automation that delegates out of triage keeps human triage; a team with no
+   * `started` state has nothing to move to. Both requests ride the paced queue: the read is the
+   * first half of one write, not a read-port answer that may degrade to a default.
+   */
+  async startIssue(issueId: string): Promise<LinearIssueStartOutcome> {
+    type StatePayload = {
+      issue?: {
+        state?: { id?: string; name?: string; type?: string } | null
+        team?: { states?: { nodes?: { id?: string; name?: string; type?: string; position?: number }[] } | null } | null
+      } | null
+    }
+    const data = await this.enqueueGraphql<StatePayload>(ISSUE_STATE_QUERY, { id: issueId })
+    const current = data.issue?.state
+    if (!current?.type) return { outcome: 'skipped', reason: 'issue or its state is unreadable' }
+    if (current.type === 'started' || current.type === 'completed' || current.type === 'canceled')
+      return { outcome: 'unchanged', state: current.name ?? current.type }
+    if (current.type === 'triage') return { outcome: 'skipped', reason: 'issue is in triage' }
+    const target = (data.issue?.team?.states?.nodes ?? [])
+      .filter((s) => s.type === 'started' && s.id)
+      .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))[0]
+    if (!target?.id) return { outcome: 'skipped', reason: 'team has no started state' }
+    await this.enqueueGraphql<{ issueUpdate?: { success?: boolean } }>(ISSUE_UPDATE, {
+      id: issueId,
+      input: { stateId: target.id }
+    })
+    return { outcome: 'moved', from: current.name ?? current.type, state: target.name ?? target.id }
+  }
+
   // ── 3. read / query port ──
 
   /** The channel is the connected workspace (§4.5), whose name the spec already carries — no
@@ -596,6 +635,17 @@ const AGENT_SESSION_UPDATE = `mutation AgentSessionUpdate($id: String!, $input: 
 
 const ATTACHMENT_CREATE = `mutation AttachmentCreate($input: AttachmentCreateInput!) {
   attachmentCreate(input: $input) { success }
+}`
+
+const ISSUE_STATE_QUERY = `query IssueState($id: String!) {
+  issue(id: $id) {
+    state { id name type }
+    team { states(first: 50) { nodes { id name type position } } }
+  }
+}`
+
+const ISSUE_UPDATE = `mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
+  issueUpdate(id: $id, input: $input) { success }
 }`
 
 const USER_QUERY = `query User($id: String!) {

--- a/packages/daemon/src/platforms/linear/message-strategy.ts
+++ b/packages/daemon/src/platforms/linear/message-strategy.ts
@@ -32,6 +32,7 @@ const LinearPreviousComment = z.object({
  *  older relay may omit any optional field, and none of them is load-bearing for the turn. */
 export const LinearAdapterExtSchema = z.object({
   agentSessionId: z.string().min(1),
+  event: z.enum(['created', 'prompted']).optional(),
   issueId: z.string().optional(),
   issueIdentifier: z.string().optional(),
   issueTitle: z.string().optional(),

--- a/packages/daemon/src/platforms/linear/turn-output.ts
+++ b/packages/daemon/src/platforms/linear/turn-output.ts
@@ -152,18 +152,77 @@ export interface LinearModePolicy {
   /** Tool output carried on the action's `result` field. */
   readonly actionResults: boolean
   readonly plan: boolean
+  /** §10.3: the pull/merge requests the agent's text named, as the session's external links. */
+  readonly links: boolean
   /** The settling `response` — and, with it, `error` and `elicitation`: `none` is truly silent. */
   readonly response: boolean
 }
 
-// The default is `low`, and it already includes actions and plan: an agent-session feed is
-// FOR progress visibility, which is the opposite of a chat channel's default.
+// The default is `low`, and it already includes actions, plan and links: an agent-session feed
+// is FOR progress visibility, which is the opposite of a chat channel's default.
 const MODE_POLICY: Record<LinearOutputMode, LinearModePolicy> = {
-  none: { reasoning: false, progress: false, actions: false, actionResults: false, plan: false, response: false },
-  minimal: { reasoning: false, progress: false, actions: false, actionResults: false, plan: false, response: true },
-  low: { reasoning: false, progress: true, actions: true, actionResults: false, plan: true, response: true },
-  medium: { reasoning: true, progress: true, actions: true, actionResults: false, plan: true, response: true },
-  high: { reasoning: true, progress: true, actions: true, actionResults: true, plan: true, response: true }
+  none: {
+    reasoning: false,
+    progress: false,
+    actions: false,
+    actionResults: false,
+    plan: false,
+    links: false,
+    response: false
+  },
+  minimal: {
+    reasoning: false,
+    progress: false,
+    actions: false,
+    actionResults: false,
+    plan: false,
+    links: false,
+    response: true
+  },
+  low: {
+    reasoning: false,
+    progress: true,
+    actions: true,
+    actionResults: false,
+    plan: true,
+    links: true,
+    response: true
+  },
+  medium: {
+    reasoning: true,
+    progress: true,
+    actions: true,
+    actionResults: false,
+    plan: true,
+    links: true,
+    response: true
+  },
+  high: { reasoning: true, progress: true, actions: true, actionResults: true, plan: true, links: true, response: true }
+}
+
+/** How much agent text the link collector keeps: a turn's PR link lives near its end. */
+const MAX_LINK_SCAN_CHARS = 64_000
+
+const GITHUB_PULL_URL = /https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/(\d+)\b/g
+const GITLAB_MERGE_REQUEST_URL = /https?:\/\/[\w.-]+(?::\d+)?\/[\w./-]+?\/-\/merge_requests\/(\d+)\b/g
+
+/**
+ * §10.3: the pull/merge-request links in the agent's own text, labelled the way the code host
+ * would (`PR #123`, `MR !45`), each URL once. The collector reads what the agent SAID, not what
+ * it did: a `gh pr create` prints the URL and a model repeats it in the answer, so the text is
+ * where a turn's PR shows up on every runtime without a tool-specific hook.
+ */
+export function codeHostLinks(text: string): LinearExternalUrl[] {
+  const seen = new Set<string>()
+  const out: LinearExternalUrl[] = []
+  const add = (url: string, label: string) => {
+    if (seen.has(url)) return
+    seen.add(url)
+    out.push({ label, url })
+  }
+  for (const match of text.matchAll(GITHUB_PULL_URL)) add(match[0], `PR #${match[1]}`)
+  for (const match of text.matchAll(GITLAB_MERGE_REQUEST_URL)) add(match[0], `MR !${match[1]}`)
+  return out
 }
 
 /** Reasoning tail clamp, matching every other renderer's `MAX_REASONING`. */
@@ -298,6 +357,8 @@ export class LinearConverger {
   // The collector reports a suppressed turn as "no final answer", which is indistinguishable
   // from a silent one — so the sentinel is detected here, on a mode-independent message tail.
   private sentinelTail = ''
+  // Every message chunk, mode-independent, for the §10.3 link collector at turn end.
+  private messageText = ''
   private narration = ''
   private reasoning = ''
   private reasoningDirty = false
@@ -349,6 +410,7 @@ export class LinearConverger {
         if (u.content?.type !== 'text') return []
         const text = u.content.text ?? ''
         this.sentinelTail = (this.sentinelTail + text).slice(-SENTINEL_TAIL_CHARS)
+        this.messageText = (this.messageText + text).slice(-MAX_LINK_SCAN_CHARS)
         if (this.policy.progress) this.narration += text
         return []
       }
@@ -411,6 +473,9 @@ export class LinearConverger {
     this.narration = ''
     this.reasoningDirty = false
     const out: LinearAction[] = [...this.takePending(), ...this.drainPlan()]
+    // Links land before the response, so the session panel shows the PR by the time it settles.
+    const links = this.policy.links ? codeHostLinks(this.messageText) : []
+    if (links.length > 0) out.push({ kind: 'external-urls', add: links })
     if (this.droppedActions > 0) {
       out.push({ kind: 'activity', type: 'thought', body: `… and ${this.droppedActions} more tool calls` })
     }

--- a/packages/daemon/test/linear-connection.test.ts
+++ b/packages/daemon/test/linear-connection.test.ts
@@ -849,3 +849,74 @@ describe('linear read port (§9.4 — what Linear affords)', () => {
     expect(RENEW_MARGIN_MS).toBe(2 * 60 * 60 * 1000)
   })
 })
+
+describe('linear auto-start (§10.2)', () => {
+  const ISSUE = 'issue-uuid-1'
+  const states = [
+    { id: 'st-done', name: 'Done', type: 'completed', position: 4 },
+    { id: 'st-review', name: 'In Review', type: 'started', position: 3 },
+    { id: 'st-progress', name: 'In Progress', type: 'started', position: 2 },
+    { id: 'st-todo', name: 'Todo', type: 'unstarted', position: 1 },
+    { id: 'st-backlog', name: 'Backlog', type: 'backlog', position: 0 }
+  ]
+  const issueIn =
+    (state: { id: string; name: string; type: string }, nodes = states) =>
+    (call: RecordedCall) =>
+      call.query.includes('issueUpdate')
+        ? jsonResponse({ data: { issueUpdate: { success: true } } })
+        : jsonResponse({ data: { issue: { state, team: { states: { nodes } } } } })
+
+  it('moves a backlog issue to the team’s LOWEST-position started state', async () => {
+    const { conn, calls } = harness({ respond: issueIn(states[4]!) })
+    const result = await conn.startIssue(ISSUE)
+    expect(result).toEqual({ outcome: 'moved', from: 'Backlog', state: 'In Progress' })
+    expect(calls.map((c) => c.variables)).toEqual([{ id: ISSUE }, { id: ISSUE, input: { stateId: 'st-progress' } }])
+    expect(calls[0]!.query).toContain('issue(id: $id)')
+    expect(calls[1]!.query).toContain('issueUpdate(id: $id, input: $input)')
+  })
+
+  it('moves an unstarted issue too — the delegation is the start of work', async () => {
+    const { conn, calls } = harness({ respond: issueIn(states[3]!) })
+    expect(await conn.startIssue(ISSUE)).toEqual({ outcome: 'moved', from: 'Todo', state: 'In Progress' })
+    expect(calls).toHaveLength(2)
+  })
+
+  it('leaves a started, completed or canceled issue exactly where it is', async () => {
+    for (const state of [
+      { id: 'st-review', name: 'In Review', type: 'started' },
+      { id: 'st-done', name: 'Done', type: 'completed' },
+      { id: 'st-nope', name: 'Canceled', type: 'canceled' }
+    ]) {
+      const { conn, calls } = harness({ respond: issueIn(state) })
+      expect(await conn.startIssue(ISSUE)).toEqual({ outcome: 'unchanged', state: state.name })
+      expect(calls).toHaveLength(1)
+    }
+  })
+
+  it('skips a triage issue, so an automation delegating out of triage keeps human triage', async () => {
+    const { conn, calls } = harness({ respond: issueIn({ id: 'st-triage', name: 'Triage', type: 'triage' }) })
+    expect(await conn.startIssue(ISSUE)).toEqual({ outcome: 'skipped', reason: 'issue is in triage' })
+    expect(calls).toHaveLength(1)
+  })
+
+  it('skips a team with no started state, and an issue it cannot read', async () => {
+    const noStarted = harness({ respond: issueIn(states[4]!, [states[0]!, states[3]!]) })
+    expect(await noStarted.conn.startIssue(ISSUE)).toEqual({ outcome: 'skipped', reason: 'team has no started state' })
+    expect(noStarted.calls).toHaveLength(1)
+    const unreadable = harness({ respond: () => jsonResponse({ data: { issue: null } }) })
+    expect(await unreadable.conn.startIssue(ISSUE)).toEqual({
+      outcome: 'skipped',
+      reason: 'issue or its state is unreadable'
+    })
+  })
+
+  it('surfaces a refused state write as the API error it is', async () => {
+    const { conn } = harness({
+      respond: (call) =>
+        call.query.includes('issueUpdate')
+          ? jsonResponse({ errors: [{ message: 'no', extensions: { code: 'FORBIDDEN' } }] })
+          : issueIn(states[4]!)(call)
+    })
+    await expect(conn.startIssue(ISSUE)).rejects.toBeInstanceOf(LinearApiError)
+  })
+})

--- a/packages/daemon/test/linear-message-strategy.test.ts
+++ b/packages/daemon/test/linear-message-strategy.test.ts
@@ -53,6 +53,14 @@ describe('linear adapter-extension reads', () => {
     expect(readLinearExt(message())).toEqual(ext())
   })
 
+  it('reads which webhook opened the turn, and tolerates a relay that does not say', () => {
+    expect(readLinearExt(message({ adapterExt: { linear: ext({ event: 'created' }) } }))?.event).toBe('created')
+    expect(readLinearExt(message({ adapterExt: { linear: ext({ event: 'prompted' }) } }))?.event).toBe('prompted')
+    expect(readLinearExt(message())?.event).toBeUndefined()
+    // An unknown kind is a malformed bag, not a third kind of turn.
+    expect(readLinearExt(message({ adapterExt: { linear: { ...ext(), event: 'closed' } } }))).toBeUndefined()
+  })
+
   it('fails closed on an absent or malformed bag', () => {
     expect(readLinearExt(message({ adapterExt: undefined }))).toBeUndefined()
     expect(readLinearExt(message({ adapterExt: { linear: { issueIdentifier: 'TEAM-1' } } }))).toBeUndefined()

--- a/packages/daemon/test/linear-turn-output.test.ts
+++ b/packages/daemon/test/linear-turn-output.test.ts
@@ -3,6 +3,7 @@ import type { SessionUpdate } from '@agentclientprotocol/sdk'
 import {
   applyLinearAction,
   type LinearAttachmentInput,
+  codeHostLinks,
   createLinearConverger,
   initialLinearTurnState,
   LinearConverger,
@@ -211,10 +212,13 @@ describe('LinearConverger — §5.2 output modes', () => {
       actions: false,
       actionResults: false,
       plan: false,
+      links: false,
       response: false
     })
     expect(linearModePolicy('low').actions).toBe(true)
     expect(linearModePolicy('low').plan).toBe(true)
+    expect(linearModePolicy('low').links).toBe(true)
+    expect(linearModePolicy('minimal').links).toBe(false)
     expect(linearModePolicy('low').reasoning).toBe(false)
     expect(linearModePolicy('medium').reasoning).toBe(true)
     expect(linearModePolicy('high').actionResults).toBe(true)
@@ -608,5 +612,44 @@ describe('applyLinearAction', () => {
     await applyLinearAction(turnFor(port, undefined), state, { kind: 'activity', type: 'response', body: 'x' })
     expect(port.activities).toEqual([])
     expect(state.activityBudget).toBe(initialLinearTurnState().activityBudget)
+  })
+})
+
+describe('LinearConverger — §10.3 code-host links', () => {
+  it('labels GitHub pull requests and GitLab merge requests the way their hosts do, each URL once', () => {
+    const text =
+      'Opened https://github.com/example-org/example-repo/pull/123 and https://github.com/example-org/example-repo/pull/123. ' +
+      'Also https://gitlab.example.test/group/sub/project/-/merge_requests/45, plus an issue ' +
+      'https://github.com/example-org/example-repo/issues/9 that is not a PR.'
+    expect(codeHostLinks(text)).toEqual([
+      { label: 'PR #123', url: 'https://github.com/example-org/example-repo/pull/123' },
+      { label: 'MR !45', url: 'https://gitlab.example.test/group/sub/project/-/merge_requests/45' }
+    ])
+  })
+
+  it('publishes the links named anywhere in the turn’s text, ahead of the settling response', () => {
+    const c = conv('low')
+    // Chunk boundaries split the URL; the collector reads the joined text, not the pieces.
+    c.onUpdate(chunk('Working on it — see https://github.com/example-org/'))
+    c.onUpdate(chunk('example-repo/pull/7 for the diff.'))
+    c.onUpdate(toolCall({ toolCallId: 't1', title: 'Bash', rawInput: { command: 'gh pr view 7' } }))
+    c.onUpdate(toolDone({ toolCallId: 't1' }))
+    c.onUpdate(chunk('Done: https://github.com/example-org/example-repo/pull/7'))
+    const actions = c.onFinal()
+    expect(types(actions)).toEqual(['action', 'external-urls', 'response'])
+    const links = actions.find((a) => a.kind === 'external-urls')
+    expect(links).toEqual({
+      kind: 'external-urls',
+      add: [{ label: 'PR #7', url: 'https://github.com/example-org/example-repo/pull/7' }]
+    })
+  })
+
+  it('emits no link update when the turn named none, and none at all in minimal mode', () => {
+    const quiet = conv('low')
+    quiet.onUpdate(chunk('nothing to link here'))
+    expect(types(quiet.onFinal())).toEqual(['response'])
+    const minimal = conv('minimal')
+    minimal.onUpdate(chunk('see https://github.com/example-org/example-repo/pull/7'))
+    expect(types(minimal.onFinal())).toEqual(['response'])
   })
 })

--- a/packages/relay/src/platforms/linear/http-ingest.ts
+++ b/packages/relay/src/platforms/linear/http-ingest.ts
@@ -145,6 +145,9 @@ export function linearIsStop(event: LinearAgentSessionEvent): boolean {
 /** §6.4 adapter-extension bag: opaque to relay core, round-tripped to the daemon's linear module. */
 export interface LinearAdapterExt {
   agentSessionId: string
+  /** Which webhook opened this turn: `created` is the delegation or mention that opened the
+   *  session (§10.2 auto-start reads it), `prompted` a follow-up on one that already exists. */
+  event?: 'created' | 'prompted'
   /** The issue's UUID — what `attachmentCreate` keys on; the identifier is display-only. */
   issueId?: string
   issueIdentifier?: string
@@ -227,6 +230,7 @@ export function normalizeLinearEvent(
   )
   const adapterExt: LinearAdapterExt = {
     agentSessionId: session.id,
+    ...(event.action === 'created' || event.action === 'prompted' ? { event: event.action } : {}),
     ...(issue?.id ? { issueId: issue.id } : {}),
     ...(issue?.identifier ? { issueIdentifier: issue.identifier } : {}),
     ...(issue?.title ? { issueTitle: issue.title } : {}),

--- a/packages/relay/src/platforms/linear/http-ingress.test.ts
+++ b/packages/relay/src/platforms/linear/http-ingress.test.ts
@@ -112,6 +112,26 @@ describe('Linear HTTP ingress route', () => {
     expect(h.messages[0]).toMatchObject({ platform: 'linear', thread: SESSION_ID })
   })
 
+  it('tells the daemon which webhook opened the turn — the session-opening created, or a follow-up', async () => {
+    const h = makeApp()
+    app = h.app
+    await post(app, eventBody())
+    const prompted = {
+      ...eventBody(),
+      action: 'prompted',
+      agentActivity: {
+        id: '00000000-0000-4000-8000-0000000000p1',
+        content: { type: 'prompt', body: 'and the tests?' },
+        user: { id: '00000000-0000-4000-8000-0000000000u1', name: 'Dana' }
+      }
+    }
+    await post(app, prompted)
+    await vi.waitFor(() => expect(h.messages).toHaveLength(2))
+    const bags = h.messages.map((m) => (m.adapterExt as { linear: { event?: string; issueId?: string } }).linear)
+    expect(bags.map((b) => b.event)).toEqual(['created', 'prompted'])
+    expect(bags[0]!.issueId).toBe('00000000-0000-4000-8000-0000000000i1')
+  })
+
   it('serves each workspace from its OWN bot even though both verify the same signature', async () => {
     const h = makeApp()
     app = h.app


### PR DESCRIPTION
## What

The two Linear behaviors a delegated issue gets without the agent lifting a finger (design §10.2 / §10.3):

- **Auto-start on delegation.** When the webhook that opened the turn is `created` and it names an issue, the daemon moves the issue to its team's lowest-position `started` state (`LinearConnection.startIssue`: one paced state read, at most one `issueUpdate`). Already `started`/`completed`/`canceled` → untouched. `triage` → skipped so a Linear automation delegating out of triage keeps human triage. A team with no `started` state → skipped. A follow-up `prompted` never moves anything. `output.mode: none` skips it along with everything else Linear-visible.
- **PR links on the session.** The converger collects GitHub pull and GitLab merge-request URLs from the agent's own message text across the turn and publishes them once as `addedExternalUrls` (`PR #123`, `MR !45`) immediately before the settling `response`, in every mode from `low` up.

Plan sync (§5.1) was already in place; the design now records it as done.

## How

- **relay** `platforms/linear/http-ingest.ts`: the adapter bag gains `event: 'created' | 'prompted'` so the daemon can tell the session-opening delegation from a follow-up. Read tolerantly on the daemon side — an older relay simply never triggers auto-start.
- **daemon** `platforms/linear/connection.ts`: `startIssue(issueId)` plus the `IssueState` query and `IssueUpdate` mutation, both on the paced queue with the existing bounded retry.
- **daemon** `daemon.ts`: the post-admission hook (renamed `onLinearAdmitted`) fires the auto-start next to the ≤10 s ack. It runs only on an admission that won the receipt CAS, so a redelivered `created` cannot move the issue twice.
- **daemon** `platforms/linear/turn-output.ts`: `codeHostLinks(text)`, a `links` column in the mode matrix, a mode-independent text buffer, and the `external-urls` emit in `onFinal`.
- **design** `linear-integration.md`: §5.1 row, §6.3 bag fields, §9.4 inventory, §10.2/§10.3 as built (the "integration-level toggle" is dropped for the smaller surface — stated there), §13 P2 re-scoped into three layers (this PR is layer 1; the Linear tool family and the header context block follow), §15 open question on `addedExternalUrls` dedup across turns.

## Tests

- `linear-connection.test.ts`: backlog → In Progress picks the lowest-position started state and sends exactly one `issueUpdate`; unstarted moves too; started/completed/canceled unchanged with no write; triage and no-started-state skipped; a refused write surfaces as `LinearApiError`.
- `linear-turn-output.test.ts`: `codeHostLinks` labels and dedups; a URL split across chunks is still found; the link update precedes the response; nothing when no URL, nothing in `minimal`.
- `linear-message-strategy.test.ts`: `event` round-trips and an unknown kind fails closed.
- relay `http-ingress.test.ts`: `created` and `prompted` deliveries carry their kind and the issue UUID.

Daemon and relay typecheck, lint and Linear suites pass; the full relay suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
