### PR TITLE
feat(console): approval bell fed by a revived agent/activity frame

### DIFF
--- a/docs/designs/slack-approval-dm.md
+++ b/docs/designs/slack-approval-dm.md
@@ -354,7 +354,10 @@ guards keep the column honest: the CP resets a daemon's `awaiting_permission`
 rows to `idle` when that daemon's connection closes and when a session's `end`
 milestone lands, and the daemon re-asserts its live waits from the
 coordinator's in-memory set on every (re)connect, after its durable session
-metadata outbox has drained, so every replayed wait has a row to land on.
+metadata outbox has drained, and again for one session whenever that
+session's metadata snapshot is acknowledged — the CP has no row to flag until
+then, so a wait reported earlier was dropped, and the drain's own retry path
+is what makes the acknowledgement the reliable trigger.
 Every approval-state write on the CP — the handler's persist, the close
 clear, and a silent clear on `register` — runs on one per-daemon tail in the
 connection registry, so the last mutation a connection makes is always its

--- a/docs/designs/slack-approval-dm.md
+++ b/docs/designs/slack-approval-dm.md
@@ -353,10 +353,13 @@ publishes a `session-state` event on the org SSE stream after commit. Two
 guards keep the column honest: the CP resets a daemon's `awaiting_permission`
 rows to `idle` when that daemon's connection closes and when a session's `end`
 milestone lands, and the daemon re-asserts its live waits from the
-coordinator's in-memory set on every (re)connect. The disconnect clear is
-queued per daemon in the connection registry and the `agent/activity` handler
-waits for that queue, so a fast reconnect's replay always writes after the
-old socket's clear rather than under it.
+coordinator's in-memory set on every (re)connect, after its durable session
+metadata outbox has drained, so every replayed wait has a row to land on.
+Every approval-state write on the CP — the handler's persist, the close
+clear, and a silent clear on `register` — runs on one per-daemon tail in the
+connection registry, so the last mutation a connection makes is always its
+clear, a fast reconnect's replay always writes after it, and a superseded
+socket's leftovers cannot outlive the connection that made them.
 
 **Feed.** `GET /orgs/:orgId/sessions?view=flat&activityState=awaiting_permission`
 — an activity-state filter on the existing list route, whose rows now carry

--- a/docs/designs/slack-approval-dm.md
+++ b/docs/designs/slack-approval-dm.md
@@ -334,19 +334,47 @@ acting-user field on the relay frame, and the §6.3 checks in
 `handleElicitChoice` for DM-originated cards — so both request kinds get
 identical interactive DMs; the two runtimes must not diverge here.
 
-## 7. Console notification states — deferred
+## 7. Console notification states
 
-The issue also asks the notification bell to show a pending approval as
-unread and a resolved one as read ("_X_ has approved/declined"). Deferred
-out of this delivery: the console has **no cross-agent pending signal** to
-feed a bell — the only live source is the per-agent daemon proxy (polled
-on detail pages), and the protocol's `agent/activity` frame with
-`ActivityState.awaiting_permission` is declared but never emitted by any
-daemon nor handled by the CP. A future effort can revive that frame (emit
-on park/release, persist the enum `SessionMeta.activityState` already has
-a column for) and hang a client-local `approval` category off it. Until
-then the decider's name lands on the approval cards themselves (§6), which
-is where an editor already looks — tracked in a follow-up issue.
+The console bell shows a session that is waiting on a human as an **unread**
+item and flips it to a **read** "Approval resolved" item once the wait ends.
+Delivered after the DM work as its own change (#1704); this section records
+the shape that shipped, which is narrower than the issue's original ask.
+
+**Signal.** The daemon's permission coordinator emits the protocol's
+`agent/activity` frame — revived for this purpose, and now carrying the
+session's outward id — with `awaiting_permission` when the **first**
+answerable request parks on a session and `idle` when the **last** one
+settles, whatever path it took: an editor-path permission or elicitation, or
+an in-conversation chat card (all three are decidable from the console).
+`thinking` and `tool_call` remain declared but unemitted. The CP persists the
+enum into `SessionMeta.activityState`, fenced to the reporting agent, and
+publishes a `session-state` event on the org SSE stream after commit. Two
+guards keep the column honest: the CP resets a daemon's `awaiting_permission`
+rows to `idle` when that daemon's connection closes and when a session's `end`
+milestone lands, and the daemon re-asserts its live waits from the
+coordinator's in-memory set on every (re)connect.
+
+**Feed.** `GET /orgs/:orgId/sessions?view=flat&activityState=awaiting_permission`
+— an activity-state filter on the existing list route, whose rows now carry
+`activityState`. The console holds one shell-wide read of it, revalidated on
+the `session-state` SSE event and on stream reconnect; there is no poll.
+Client-side, the bell keeps only sessions whose agent carries the caller's
+`canEdit` flag — the predicate the decision route enforces (§2) — so a viewer
+never sees an item it cannot act on. The session list itself shows no marker.
+
+**Bell.** A client-local `approval` category driven by the notification
+center's snapshot reconciler, keyed per session. Pending: an unread item
+("Approval needed", agent name, session title) that raises a toast and
+deep-links to the session page. Resolved: when the session leaves the pending
+set the item flips to read and renders "Approval resolved" — with **no decider
+name and no decision**, and no distinction between allowed, denied, and
+expired, because the CP never sees any of those and the browser makes no
+per-agent lookup to learn them. The decider stays on the approval cards (§6).
+A decision made from the current tab flips its item to read immediately. A
+tab that was closed while a request was pending sees the same read item on
+its first snapshot after reload. Read state stays per-browser, and §8 still
+holds: nothing about approvals is stored server-side beyond the enum.
 
 ## 8. Explicit non-goal: a server-side notification store
 

--- a/docs/designs/slack-approval-dm.md
+++ b/docs/designs/slack-approval-dm.md
@@ -353,7 +353,10 @@ publishes a `session-state` event on the org SSE stream after commit. Two
 guards keep the column honest: the CP resets a daemon's `awaiting_permission`
 rows to `idle` when that daemon's connection closes and when a session's `end`
 milestone lands, and the daemon re-asserts its live waits from the
-coordinator's in-memory set on every (re)connect.
+coordinator's in-memory set on every (re)connect. The disconnect clear is
+queued per daemon in the connection registry and the `agent/activity` handler
+waits for that queue, so a fast reconnect's replay always writes after the
+old socket's clear rather than under it.
 
 **Feed.** `GET /orgs/:orgId/sessions?view=flat&activityState=awaiting_permission`
 — an activity-state filter on the existing list route, whose rows now carry

--- a/packages/control-plane/src/events/sink.ts
+++ b/packages/control-plane/src/events/sink.ts
@@ -6,19 +6,22 @@
  * in-process pub/sub for the co-process MVP; the Go split replaces the
  * implementation behind this port (e.g. a broker) without touching either edge.
  */
-import type { EventSession, SessionActivity } from '@agentconnect.md/protocol'
+import type { AgentActivity, EventSession, SessionActivity } from '@agentconnect.md/protocol'
 import type { DaemonId } from '../domain/ids.js'
 
 /** A metadata event as relayed to subscribers, stamped with its reporting daemon. */
 export type SessionEventEnvelope =
-  | { daemonId: DaemonId; event: EventSession; activity?: never }
-  | { daemonId: DaemonId; activity: SessionActivity; event?: never }
+  | { daemonId: DaemonId; event: EventSession; activity?: never; state?: never }
+  | { daemonId: DaemonId; activity: SessionActivity; event?: never; state?: never }
+  | { daemonId: DaemonId; state: AgentActivity; event?: never; activity?: never }
 
 export interface SessionEventSink {
   /** Fan a converged milestone out to all current subscribers. */
   publish(daemonId: DaemonId, ev: EventSession): void
   /** Fan a body-free transcript invalidation out to current subscribers. */
   publishActivity(daemonId: DaemonId, activity: SessionActivity): void
+  /** Fan a session's live wait-state change out (slack-approval-dm.md §7). */
+  publishState(daemonId: DaemonId, state: AgentActivity): void
   /** Subscribe; returns an unsubscribe fn. */
   subscribe(cb: (e: SessionEventEnvelope) => void): () => void
 }
@@ -34,6 +37,10 @@ export class InMemorySessionEventSink implements SessionEventSink {
 
   publishActivity(daemonId: DaemonId, activity: SessionActivity): void {
     this.fanOut({ daemonId, activity })
+  }
+
+  publishState(daemonId: DaemonId, state: AgentActivity): void {
+    this.fanOut({ daemonId, state })
   }
 
   private fanOut(envelope: SessionEventEnvelope): void {

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2707,6 +2707,8 @@ export const SessionUsageDto = z.object({
   costAmount: z.number().optional(),
   costCurrency: z.string().optional()
 })
+/** `SessionMeta.activityState`; only `awaiting_permission`/`idle` are emitted today (slack-approval-dm.md §7). */
+export const ActivityStateEnum = z.enum(['thinking', 'tool_call', 'awaiting_permission', 'idle'])
 export const SessionDto = z.object({
   sessionId: z.string(),
   sessionKey: SessionKeyDto,
@@ -2749,7 +2751,9 @@ export const SessionDto = z.object({
   /** Retention GC (#485): when the owning daemon deleted this session's local
    *  content. Non-null ⇒ the transcript is gone for good; this metadata is all
    *  that remains, and the console marks the row instead of offering a replay. */
-  contentPurgedAt: z.string().nullable()
+  contentPurgedAt: z.string().nullable(),
+  /** Live wait state from `agent/activity` (slack-approval-dm.md §7); `awaiting_permission` feeds the console bell. */
+  activityState: ActivityStateEnum
 })
 export const SessionListDto = z.array(SessionDto)
 export const SessionFacetsDto = z.object({

--- a/packages/control-plane/src/http/routes/sessions.channel-name.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.channel-name.test.ts
@@ -41,6 +41,7 @@ function row(overrides: Record<string, unknown>) {
     visibility: 'org',
     externalProvider: null,
     externalResolution: null,
+    activityState: 'idle',
     ...overrides
   }
 }

--- a/packages/control-plane/src/http/routes/sessions.code-host-facets.test.ts
+++ b/packages/control-plane/src/http/routes/sessions.code-host-facets.test.ts
@@ -67,7 +67,8 @@ function pageRow(hookId: string, id: string, hookKind: string | null = null) {
     hookKind,
     visibility: 'org',
     externalProvider: null,
-    externalResolution: null
+    externalResolution: null,
+    activityState: 'idle'
   }
 }
 

--- a/packages/control-plane/src/http/routes/sessions.ts
+++ b/packages/control-plane/src/http/routes/sessions.ts
@@ -45,6 +45,7 @@ import { GitCredDeniedError } from '../../github/service.js'
 import { ProtocolError } from '../../domain/errors.js'
 import {
   SessionListPageDto,
+  ActivityStateEnum,
   SessionFacetsDto,
   SessionDetailDto,
   SessionHistoryDto,
@@ -94,7 +95,9 @@ const SessionQueryDto = SessionFilterQueryDto.extend({
   view: z.enum(['grouped', 'flat']).default('grouped'),
   // §5.2 key-addressed member resolver: resolves one conversation's current
   // visible member sessions without paging the grouped list.
-  conversationKey: z.string().min(1).max(512).optional()
+  conversationKey: z.string().min(1).max(512).optional(),
+  // Live wait state (slack-approval-dm.md §7): the console bell asks for `awaiting_permission`.
+  activityState: ActivityStateEnum.optional()
 })
 
 type SessionCursor = { activityMs: number; startedMs: number; id: string }
@@ -423,7 +426,8 @@ function sessionDto(
     visibility: s.visibility,
     externalProvider: s.externalProvider,
     externalResolution: s.externalResolution,
-    contentPurgedAt: s.contentPurgedAt ? s.contentPurgedAt.toISOString() : null
+    contentPurgedAt: s.contentPurgedAt ? s.contentPurgedAt.toISOString() : null,
+    activityState: s.activityState
   }
 }
 
@@ -802,6 +806,7 @@ export function sessionRoutes(deps: HttpDeps) {
           ...(req.query.integration ? { integration: req.query.integration } : {}),
           ...(req.query.channel ? { channel: req.query.channel } : {}),
           ...(req.query.triggeredBy ? { triggeredBy: req.query.triggeredBy } : {}),
+          ...(req.query.activityState ? { activityState: req.query.activityState } : {}),
           ...(Object.keys(codeHostHookIds).length > 0 ? { codeHostHookIds } : {}),
           ...(repoHookIds ? { hookTriggerIds: repoHookIds } : {}),
           ...(cursor ? { cursor } : {}),

--- a/packages/control-plane/src/http/routes/stream.ts
+++ b/packages/control-plane/src/http/routes/stream.ts
@@ -21,10 +21,10 @@ import { DaemonId, SessionId, type OrgId } from '../../domain/ids.js'
 const KEEPALIVE_MS = 25_000
 
 /**
- * Session-level gate for the live feed (session-visibility.md §5). BOTH envelope
- * variants are session-scoped and both must pass it: the milestone carries a
- * content-derived `summary`, and the activity invalidation still exposes the
- * session's existence, revision, and live activity.
+ * Session-level gate for the live feed (session-visibility.md §5). Every envelope
+ * variant is session-scoped and must pass it: the milestone carries a
+ * content-derived `summary`, and the activity invalidation and wait-state change
+ * still expose the session's existence, revision, and live activity.
  *
  * A row that cannot be read is dropped — an activity event whose milestone never
  * committed has no visibility to check, so it fails closed.
@@ -40,12 +40,10 @@ export function canStreamSession(
 }
 
 function writeEvent(reply: FastifyReply, envelope: SessionEventEnvelope): void {
-  const activity = envelope.activity
-  const payload = JSON.stringify(
-    activity ? { daemonId: envelope.daemonId, activity } : { daemonId: envelope.daemonId, event: envelope.event }
-  )
-  reply.raw.write(`event: ${activity ? 'session-activity' : 'session'}\n`)
-  reply.raw.write(`data: ${payload}\n\n`)
+  const { daemonId, activity, state } = envelope
+  const payload = activity ? { daemonId, activity } : state ? { daemonId, state } : { daemonId, event: envelope.event }
+  reply.raw.write(`event: ${activity ? 'session-activity' : state ? 'session-state' : 'session'}\n`)
+  reply.raw.write(`data: ${JSON.stringify(payload)}\n\n`)
 }
 
 export function streamRoutes(deps: HttpDeps) {
@@ -119,8 +117,8 @@ export function streamRoutes(deps: HttpDeps) {
             if (!(await inOrg(envelope.daemonId))) return
             const ctx = await currentCtx()
             if (!ctx) return
-            const agentId = envelope.activity?.agentId ?? envelope.event?.agentId
-            const sessionId = envelope.activity?.sessionId ?? envelope.event?.sessionId
+            const agentId = envelope.activity?.agentId ?? envelope.state?.agentId ?? envelope.event?.agentId
+            const sessionId = envelope.activity?.sessionId ?? envelope.state?.sessionId ?? envelope.event?.sessionId
             if (!agentId || !sessionId || !(await canSeeSession(agentId, sessionId, ctx))) return
             writeEvent(reply, envelope)
           })()

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -1227,6 +1227,8 @@ export interface SessionQuery {
 export interface SessionFilterQuery extends SessionQuery {
   integration?: Platform | CodeHostProvider
   triggeredBy?: string
+  /** Live wait state (slack-approval-dm.md §7) — the console bell asks for `awaiting_permission`. */
+  activityState?: ActivityState
   /** Code-host hook ids keyed by provider: each provider is promoted out of the generic
    *  hook bucket into its own integration, and `integration: 'hook'` excludes them all.
    *  Keyed rather than one field per host, so a new provider needs no new field here. */
@@ -1349,6 +1351,10 @@ export interface SessionRepo {
   /** Filter, keyset-page, and order in Postgres; usage is hydrated only for the
    *  returned page. `total` is computed only when explicitly requested. */
   listPage(q: SessionPageQuery): Promise<SessionPageRecord>
+  /** Persist one session's `agent/activity` state, fenced to its reporting agent (slack-approval-dm.md §7); false ⇒ no such row. */
+  setActivityState(sessionId: SessionId, agentId: AgentId, state: ActivityState): Promise<boolean>
+  /** Reset a gone daemon's `awaiting_permission` rows to `idle`, returning them so the SSE feed can be told. */
+  clearAwaitingPermissionForDaemon(daemonId: DaemonId): Promise<Array<{ id: SessionId; agentId: AgentId }>>
   /** The grouped list (merged-conversation-view.md §5.2): one row per
    *  conversation, newest-first, emit-at-max pagination — a scanned row yields
    *  its conversation only when it is the newest same-key row under the full

--- a/packages/control-plane/src/persistence/repositories/session.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/session.repo.ts
@@ -339,6 +339,7 @@ function pageWhereSql(
   if (integration) filters.push(integration)
   if (q.channel) filters.push(Prisma.sql`${a}."channel" = ${q.channel}`)
   if (q.triggeredBy) filters.push(Prisma.sql`${a}."triggeredBy" = ${q.triggeredBy}`)
+  if (q.activityState) filters.push(Prisma.sql`${a}."activityState" = ${q.activityState}::"ActivityState"`)
   if (q.hookTriggerIds) filters.push(hookTriggerSql(q.hookTriggerIds, a))
   filters.push(...conversationParticipantsSql(q, a, probePrefix))
   if (includeCursor && q.cursor) {
@@ -1115,6 +1116,27 @@ export class PgSessionRepo implements SessionRepo {
       `)
     }
     return { recorded: true, session, settled, ...(cls.parentUnsettled ? { parentUnsettled: true } : {}) }
+  }
+
+  async setActivityState(sessionId: SessionId, agentId: AgentId, state: ActivityState): Promise<boolean> {
+    const result = await this.db.sessionMeta.updateMany({
+      where: { id: sessionId, agentId },
+      data: { activityState: state }
+    })
+    return result.count === 1
+  }
+
+  async clearAwaitingPermissionForDaemon(daemonId: DaemonId): Promise<Array<{ id: SessionId; agentId: AgentId }>> {
+    const rows = await this.db.sessionMeta.findMany({
+      where: { daemonId, activityState: 'awaiting_permission' },
+      select: { id: true, agentId: true }
+    })
+    if (rows.length === 0) return []
+    await this.db.sessionMeta.updateMany({
+      where: { id: { in: rows.map((row) => row.id) }, activityState: 'awaiting_permission' },
+      data: { activityState: 'idle' }
+    })
+    return rows.map((row) => ({ id: SessionId(row.id), agentId: AgentId(row.agentId) }))
   }
 
   async listPage(q: SessionPageQuery): Promise<SessionPageRecord> {

--- a/packages/control-plane/src/ws/approval-waits.ts
+++ b/packages/control-plane/src/ws/approval-waits.ts
@@ -1,0 +1,20 @@
+// Reset a daemon's approval waits (slack-approval-dm.md §7); every caller queues this on the registry's per-daemon tail.
+import { DaemonId } from '../domain/ids.js'
+import type { DaemonWsDeps } from './deps.js'
+
+/** Clear the daemon's `awaiting_permission` rows; `publish` tells SSE, which a register-time clear skips so the replay that follows in milliseconds does not flap the bell. */
+export async function clearAwaitingApprovals(
+  deps: Pick<DaemonWsDeps, 'session' | 'events' | 'clock'>,
+  daemonId: string,
+  publish: boolean
+): Promise<void> {
+  try {
+    const ts = new Date(deps.clock.now()).toISOString()
+    for (const row of await deps.session.clearAwaitingPermissionForDaemon(DaemonId(daemonId))) {
+      if (!publish) continue
+      deps.events.publishState(DaemonId(daemonId), { agentId: row.agentId, sessionId: row.id, state: 'idle', ts })
+    }
+  } catch {
+    // Best-effort: a refused write only delays the bell until the daemon's replay or the next reset.
+  }
+}

--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -337,7 +337,9 @@ export class DaemonConnection implements ConnChannel {
     // connection (the fleet would read `offline` while heartbeats keep flowing).
     if (this.daemonId && this.deps.connReg.get(this.daemonId)?.conn === this) {
       this.deps.connReg.remove(this.daemonId)
-      void this.clearAwaitingApprovals(this.daemonId)
+      // Queued, not fired: a reconnect's `agent/activity` replay waits for this chain, so an old
+      // socket's late `idle` can never land on top of the new connection's `awaiting_permission`.
+      this.deps.connReg.runApprovalClear(this.daemonId, () => this.clearAwaitingApprovals(this.daemonId))
     }
   }
 

--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -28,6 +28,7 @@ import type { Transport } from './transport.js'
 import { ConnectionClosed, type ConnChannel, type LifecycleState } from './registry.js'
 import type { DaemonWsDeps } from './deps.js'
 import type { FrameRouter } from './handlers/index.js'
+import { DaemonId } from '../domain/ids.js'
 import { FencingState, checkFencing } from '../orchestrator/fencing.js'
 import { ProtocolError } from '../domain/errors.js'
 
@@ -336,6 +337,24 @@ export class DaemonConnection implements ConnChannel {
     // connection (the fleet would read `offline` while heartbeats keep flowing).
     if (this.daemonId && this.deps.connReg.get(this.daemonId)?.conn === this) {
       this.deps.connReg.remove(this.daemonId)
+      void this.clearAwaitingApprovals(this.daemonId)
+    }
+  }
+
+  /** A gone daemon releases nothing: clear its approval waits; its reconnect replay re-asserts live ones (slack-approval-dm.md §7). */
+  private async clearAwaitingApprovals(daemonId: string): Promise<void> {
+    try {
+      const ts = new Date(this.deps.clock.now()).toISOString()
+      for (const row of await this.deps.session.clearAwaitingPermissionForDaemon(DaemonId(daemonId))) {
+        this.deps.events.publishState(DaemonId(daemonId), {
+          agentId: row.agentId,
+          sessionId: row.id,
+          state: 'idle',
+          ts
+        })
+      }
+    } catch {
+      // Best-effort: a refused write only delays the bell until the daemon's replay or the next reset.
     }
   }
 }

--- a/packages/control-plane/src/ws/connection.ts
+++ b/packages/control-plane/src/ws/connection.ts
@@ -28,7 +28,7 @@ import type { Transport } from './transport.js'
 import { ConnectionClosed, type ConnChannel, type LifecycleState } from './registry.js'
 import type { DaemonWsDeps } from './deps.js'
 import type { FrameRouter } from './handlers/index.js'
-import { DaemonId } from '../domain/ids.js'
+import { clearAwaitingApprovals } from './approval-waits.js'
 import { FencingState, checkFencing } from '../orchestrator/fencing.js'
 import { ProtocolError } from '../domain/errors.js'
 
@@ -337,26 +337,10 @@ export class DaemonConnection implements ConnChannel {
     // connection (the fleet would read `offline` while heartbeats keep flowing).
     if (this.daemonId && this.deps.connReg.get(this.daemonId)?.conn === this) {
       this.deps.connReg.remove(this.daemonId)
-      // Queued, not fired: a reconnect's `agent/activity` replay waits for this chain, so an old
-      // socket's late `idle` can never land on top of the new connection's `awaiting_permission`.
-      this.deps.connReg.runApprovalClear(this.daemonId, () => this.clearAwaitingApprovals(this.daemonId))
-    }
-  }
-
-  /** A gone daemon releases nothing: clear its approval waits; its reconnect replay re-asserts live ones (slack-approval-dm.md §7). */
-  private async clearAwaitingApprovals(daemonId: string): Promise<void> {
-    try {
-      const ts = new Date(this.deps.clock.now()).toISOString()
-      for (const row of await this.deps.session.clearAwaitingPermissionForDaemon(DaemonId(daemonId))) {
-        this.deps.events.publishState(DaemonId(daemonId), {
-          agentId: row.agentId,
-          sessionId: row.id,
-          state: 'idle',
-          ts
-        })
-      }
-    } catch {
-      // Best-effort: a refused write only delays the bell until the daemon's replay or the next reset.
+      // Queued on the per-daemon tail behind this socket's own in-flight `agent/activity` writes, so the
+      // clear is its last mutation, and ahead of a reconnect's replay, which waits on the same tail (§7).
+      const daemonId = this.daemonId
+      void this.deps.connReg.runApprovalMutation(daemonId, () => clearAwaitingApprovals(this.deps, daemonId, true))
     }
   }
 }

--- a/packages/control-plane/src/ws/handlers/agent-activity.ts
+++ b/packages/control-plane/src/ws/handlers/agent-activity.ts
@@ -11,6 +11,8 @@ export const handleAgentActivity: Handler = async (frame, conn, deps) => {
   if (!orgId) return
   const { agentId, sessionId, state } = frame.payload
   const daemonId = DaemonId(conn.daemonId)
+  // Order behind the previous connection's disconnect clear: its late `idle` must not outlive this replay.
+  await deps.connReg.approvalClearsSettled(conn.daemonId)
   await runForReportingAgent(orgId, AgentId(agentId), daemonId, deps, async () => {
     // A row that never committed has no visibility to check, so it is not published either.
     if (await deps.session.setActivityState(SessionId(sessionId), AgentId(agentId), state)) {

--- a/packages/control-plane/src/ws/handlers/agent-activity.ts
+++ b/packages/control-plane/src/ws/handlers/agent-activity.ts
@@ -1,0 +1,20 @@
+// `agent/activity` (D→C EVT): persist the session's wait state and fan it to SSE — the approval bell's signal (slack-approval-dm.md §7).
+import { isFrame } from '@agentconnect.md/protocol'
+import { AgentId, DaemonId, SessionId } from '../../domain/ids.js'
+import { frameOrgId } from './frame-org.js'
+import type { Handler } from './index.js'
+import { runForReportingAgent } from './reporting-agent.js'
+
+export const handleAgentActivity: Handler = async (frame, conn, deps) => {
+  if (!isFrame('agent/activity')(frame)) return
+  const orgId = frameOrgId(frame, conn)
+  if (!orgId) return
+  const { agentId, sessionId, state } = frame.payload
+  const daemonId = DaemonId(conn.daemonId)
+  await runForReportingAgent(orgId, AgentId(agentId), daemonId, deps, async () => {
+    // A row that never committed has no visibility to check, so it is not published either.
+    if (await deps.session.setActivityState(SessionId(sessionId), AgentId(agentId), state)) {
+      deps.events.publishState(daemonId, frame.payload)
+    }
+  })
+}

--- a/packages/control-plane/src/ws/handlers/agent-activity.ts
+++ b/packages/control-plane/src/ws/handlers/agent-activity.ts
@@ -11,12 +11,15 @@ export const handleAgentActivity: Handler = async (frame, conn, deps) => {
   if (!orgId) return
   const { agentId, sessionId, state } = frame.payload
   const daemonId = DaemonId(conn.daemonId)
-  // Order behind the previous connection's disconnect clear: its late `idle` must not outlive this replay.
-  await deps.connReg.approvalClearsSettled(conn.daemonId)
-  await runForReportingAgent(orgId, AgentId(agentId), daemonId, deps, async () => {
-    // A row that never committed has no visibility to check, so it is not published either.
-    if (await deps.session.setActivityState(SessionId(sessionId), AgentId(agentId), state)) {
-      deps.events.publishState(daemonId, frame.payload)
-    }
+  // On the per-daemon tail: behind a predecessor socket's close clear and this socket's register
+  // clear, and ahead of its own close clear, so the last mutation a connection makes is its clear.
+  await deps.connReg.runApprovalMutation(conn.daemonId, async () => {
+    if (conn.state === 'CLOSED') return
+    await runForReportingAgent(orgId, AgentId(agentId), daemonId, deps, async () => {
+      // A row that never committed has no visibility to check, so it is not published either.
+      if (await deps.session.setActivityState(SessionId(sessionId), AgentId(agentId), state)) {
+        deps.events.publishState(daemonId, frame.payload)
+      }
+    })
   })
 }

--- a/packages/control-plane/src/ws/handlers/event-session.ts
+++ b/packages/control-plane/src/ws/handlers/event-session.ts
@@ -230,6 +230,12 @@ async function recordEventSession(
   // invalidation signal and immediately re-read `/sessions`; publishing first
   // would race that GET against the upsert and leave the new row invisible.
   deps.events.publish(daemonId, p)
+  // A finished session waits on nobody: clear a wait its daemon never got to release (§7).
+  if (p.phase === 'end' && session?.activityState === 'awaiting_permission') {
+    if (await deps.session.setActivityState(SessionId(p.sessionId), agentId, 'idle')) {
+      deps.events.publishState(daemonId, { agentId: p.agentId, sessionId: p.sessionId, state: 'idle', ts: p.ts })
+    }
+  }
   // Fire-and-forget §4.1 activity poke, after commit-then-publish: external
   // sessions only, carrying nothing but the committed scope coordinates.
   if (session?.visibility === 'external' && session.externalScopeId) {

--- a/packages/control-plane/src/ws/handlers/index.ts
+++ b/packages/control-plane/src/ws/handlers/index.ts
@@ -36,6 +36,7 @@ import { handleChannelAgents } from './channel-agents.js'
 import { handleChildSessionStatus } from './child-session-status.js'
 import { handleEventSession, handleEventSessionSync } from './event-session.js'
 import { handleSessionActivity } from './event-session-activity.js'
+import { handleAgentActivity } from './agent-activity.js'
 import { handleSessionPurged } from './event-session-purged.js'
 import { handleGitCredRequest } from './gitcred.js'
 import { handleLinearCredRequest } from './linearcred.js'
@@ -100,6 +101,7 @@ export class FrameRouter {
       'event/session': handleEventSession,
       'event/session-sync': handleEventSessionSync,
       'event/session-activity': handleSessionActivity,
+      'agent/activity': handleAgentActivity,
       'event/session-purged': handleSessionPurged,
       'gitcred/request': handleGitCredRequest,
       'linearcred/request': handleLinearCredRequest,
@@ -149,6 +151,7 @@ export {
   handleEventSession,
   handleEventSessionSync,
   handleSessionActivity,
+  handleAgentActivity,
   handleSessionPurged,
   handleWebchatMcpGrantIssue,
   handleWebchatMcpGrantAccept,

--- a/packages/control-plane/src/ws/handlers/register.ts
+++ b/packages/control-plane/src/ws/handlers/register.ts
@@ -27,6 +27,7 @@ import {
 } from '@agentconnect.md/protocol'
 import { AgentId, DaemonId } from '../../domain/ids.js'
 import type { Handler } from './index.js'
+import { clearAwaitingApprovals } from '../approval-waits.js'
 
 export const handleRegister: Handler = async (frame, conn, deps) => {
   if (!isFrame('register')(frame)) return
@@ -47,6 +48,9 @@ export const handleRegister: Handler = async (frame, conn, deps) => {
   await deps.registry.upsertOnRegister(did, req)
   // A fresh registration clears the member's draining declaration (frames/duty.ts).
   deps.dutyLease.onRegister(did)
+  // Silent reset of the daemon's approval waits ahead of its replay (§7): a superseded socket's
+  // late `awaiting_permission` or a skipped close clear must not outlive the connection that made it.
+  void deps.connReg.runApprovalMutation(conn.daemonId, () => clearAwaitingApprovals(deps, conn.daemonId, false))
   const snap = await deps.orchestrator.reconcile(did, req)
 
   // Update the live index: capabilities/maxAgents + the bound session set.

--- a/packages/control-plane/src/ws/registry.approval-clear.test.ts
+++ b/packages/control-plane/src/ws/registry.approval-clear.test.ts
@@ -1,49 +1,54 @@
 import { describe, expect, it } from 'vitest'
 import { ConnectionRegistry } from './registry.js'
 
-describe('ConnectionRegistry approval-clear chain (slack-approval-dm.md §7)', () => {
+describe('ConnectionRegistry approval-state tail (slack-approval-dm.md §7)', () => {
   it('settles immediately when nothing is in flight', async () => {
     const reg = new ConnectionRegistry()
-    await expect(reg.approvalClearsSettled('d1')).resolves.toBeUndefined()
+    await expect(reg.approvalMutationsSettled('d1')).resolves.toBeUndefined()
   })
 
-  it('waiters resolve only after every queued clear ran, in order, per daemon', async () => {
+  it('runs mutations in arrival order per daemon and hands each caller its own result', async () => {
     const reg = new ConnectionRegistry()
     const order: string[] = []
     let releaseFirst!: () => void
     const first = new Promise<void>((resolve) => (releaseFirst = resolve))
-    reg.runApprovalClear('d1', async () => {
+    const a = reg.runApprovalMutation('d1', async () => {
       await first
       order.push('first')
+      return 'a'
     })
-    reg.runApprovalClear('d1', async () => {
+    const b = reg.runApprovalMutation('d1', async () => {
       order.push('second')
+      return 'b'
     })
-    reg.runApprovalClear('d2', async () => {
+    await reg.runApprovalMutation('d2', async () => {
       order.push('other-daemon')
     })
     let settled = false
-    const waiter = reg.approvalClearsSettled('d1').then(() => (settled = true))
-    await reg.approvalClearsSettled('d2')
+    const waiter = reg.approvalMutationsSettled('d1').then(() => (settled = true))
     expect(order).toEqual(['other-daemon'])
     expect(settled).toBe(false)
     releaseFirst()
+    await expect(a).resolves.toBe('a')
+    await expect(b).resolves.toBe('b')
     await waiter
     expect(order).toEqual(['other-daemon', 'first', 'second'])
-    // The chain is released once drained, so the next waiter does not wait on history.
-    await expect(reg.approvalClearsSettled('d1')).resolves.toBeUndefined()
+    // The tail is released once drained, so the next waiter does not wait on history.
+    await expect(reg.approvalMutationsSettled('d1')).resolves.toBeUndefined()
   })
 
-  it('a failing clear does not wedge the chain or reject waiters', async () => {
+  it('a failing mutation rejects only its own caller and never wedges the tail', async () => {
     const reg = new ConnectionRegistry()
-    reg.runApprovalClear('d1', async () => {
+    const failed = reg.runApprovalMutation('d1', async () => {
       throw new Error('pool closed')
     })
     let ran = false
-    reg.runApprovalClear('d1', async () => {
+    const next = reg.runApprovalMutation('d1', async () => {
       ran = true
     })
-    await expect(reg.approvalClearsSettled('d1')).resolves.toBeUndefined()
+    await expect(failed).rejects.toThrow('pool closed')
+    await expect(next).resolves.toBeUndefined()
+    await expect(reg.approvalMutationsSettled('d1')).resolves.toBeUndefined()
     expect(ran).toBe(true)
   })
 })

--- a/packages/control-plane/src/ws/registry.approval-clear.test.ts
+++ b/packages/control-plane/src/ws/registry.approval-clear.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { ConnectionRegistry } from './registry.js'
+
+describe('ConnectionRegistry approval-clear chain (slack-approval-dm.md §7)', () => {
+  it('settles immediately when nothing is in flight', async () => {
+    const reg = new ConnectionRegistry()
+    await expect(reg.approvalClearsSettled('d1')).resolves.toBeUndefined()
+  })
+
+  it('waiters resolve only after every queued clear ran, in order, per daemon', async () => {
+    const reg = new ConnectionRegistry()
+    const order: string[] = []
+    let releaseFirst!: () => void
+    const first = new Promise<void>((resolve) => (releaseFirst = resolve))
+    reg.runApprovalClear('d1', async () => {
+      await first
+      order.push('first')
+    })
+    reg.runApprovalClear('d1', async () => {
+      order.push('second')
+    })
+    reg.runApprovalClear('d2', async () => {
+      order.push('other-daemon')
+    })
+    let settled = false
+    const waiter = reg.approvalClearsSettled('d1').then(() => (settled = true))
+    await reg.approvalClearsSettled('d2')
+    expect(order).toEqual(['other-daemon'])
+    expect(settled).toBe(false)
+    releaseFirst()
+    await waiter
+    expect(order).toEqual(['other-daemon', 'first', 'second'])
+    // The chain is released once drained, so the next waiter does not wait on history.
+    await expect(reg.approvalClearsSettled('d1')).resolves.toBeUndefined()
+  })
+
+  it('a failing clear does not wedge the chain or reject waiters', async () => {
+    const reg = new ConnectionRegistry()
+    reg.runApprovalClear('d1', async () => {
+      throw new Error('pool closed')
+    })
+    let ran = false
+    reg.runApprovalClear('d1', async () => {
+      ran = true
+    })
+    await expect(reg.approvalClearsSettled('d1')).resolves.toBeUndefined()
+    expect(ran).toBe(true)
+  })
+})

--- a/packages/control-plane/src/ws/registry.ts
+++ b/packages/control-plane/src/ws/registry.ts
@@ -105,6 +105,23 @@ export class ConnectionRegistry {
     return this.byDaemon.has(daemonId)
   }
 
+  /** Per-daemon chain of disconnect clears of approval waits; a reconnect's replay writes only after it (slack-approval-dm.md §7). */
+  private readonly approvalClears = new Map<string, Promise<void>>()
+
+  /** Queue a clear behind any still in flight for the daemon, so two closes never interleave their writes. */
+  runApprovalClear(daemonId: string, clear: () => Promise<void>): void {
+    const chained = (this.approvalClears.get(daemonId) ?? Promise.resolve()).then(clear).catch(() => undefined)
+    const tracked: Promise<void> = chained.finally(() => {
+      if (this.approvalClears.get(daemonId) === tracked) this.approvalClears.delete(daemonId)
+    })
+    this.approvalClears.set(daemonId, tracked)
+  }
+
+  /** Resolves once every queued clear for the daemon has committed; immediately when none is in flight. */
+  approvalClearsSettled(daemonId: string): Promise<void> {
+    return this.approvalClears.get(daemonId) ?? Promise.resolve()
+  }
+
   /** Publish the point at which a newly-authenticated connection may accept
    * control frames, waking idempotent commands interrupted on an older epoch. */
   markReady(daemonId: string, conn: ConnChannel): DaemonConnState | undefined {

--- a/packages/control-plane/src/ws/registry.ts
+++ b/packages/control-plane/src/ws/registry.ts
@@ -105,21 +105,27 @@ export class ConnectionRegistry {
     return this.byDaemon.has(daemonId)
   }
 
-  /** Per-daemon chain of disconnect clears of approval waits; a reconnect's replay writes only after it (slack-approval-dm.md §7). */
-  private readonly approvalClears = new Map<string, Promise<void>>()
+  /** Per-daemon tail of approval-state writes — `agent/activity` persists and the register/close clears — so they commit in arrival order (slack-approval-dm.md §7). */
+  private readonly approvalMutations = new Map<string, Promise<unknown>>()
 
-  /** Queue a clear behind any still in flight for the daemon, so two closes never interleave their writes. */
-  runApprovalClear(daemonId: string, clear: () => Promise<void>): void {
-    const chained = (this.approvalClears.get(daemonId) ?? Promise.resolve()).then(clear).catch(() => undefined)
-    const tracked: Promise<void> = chained.finally(() => {
-      if (this.approvalClears.get(daemonId) === tracked) this.approvalClears.delete(daemonId)
+  /** Run one approval-state mutation after every earlier one for the daemon; a failed predecessor never blocks the next. */
+  runApprovalMutation<T>(daemonId: string, mutate: () => Promise<T>): Promise<T> {
+    const prior = this.approvalMutations.get(daemonId) ?? Promise.resolve()
+    const run = prior.then(mutate, mutate)
+    const tracked: Promise<unknown> = run.then(
+      () => undefined,
+      () => undefined
+    )
+    void tracked.then(() => {
+      if (this.approvalMutations.get(daemonId) === tracked) this.approvalMutations.delete(daemonId)
     })
-    this.approvalClears.set(daemonId, tracked)
+    this.approvalMutations.set(daemonId, tracked)
+    return run
   }
 
-  /** Resolves once every queued clear for the daemon has committed; immediately when none is in flight. */
-  approvalClearsSettled(daemonId: string): Promise<void> {
-    return this.approvalClears.get(daemonId) ?? Promise.resolve()
+  /** Resolves once every queued approval-state mutation for the daemon has settled; immediately when none is in flight. */
+  approvalMutationsSettled(daemonId: string): Promise<void> {
+    return (this.approvalMutations.get(daemonId) ?? Promise.resolve()).then(() => undefined)
   }
 
   /** Publish the point at which a newly-authenticated connection may accept

--- a/packages/control-plane/test/integration/session-activity-state.route.test.ts
+++ b/packages/control-plane/test/integration/session-activity-state.route.test.ts
@@ -13,6 +13,7 @@ import type { AnyFrame } from '@agentconnect.md/protocol'
 import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { InMemorySessionEventSink, type SessionEventEnvelope } from '../../src/events/sink.js'
 import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
+import { ConnectionRegistry } from '../../src/ws/registry.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 
@@ -32,8 +33,9 @@ function frame(type: string, payload: Record<string, unknown>): AnyFrame {
   return { v: 1, id: randomUUID(), ts: new Date().toISOString(), type, payload } as AnyFrame
 }
 
-function deps(events: InMemorySessionEventSink): DaemonWsDeps {
+function deps(events: InMemorySessionEventSink, connReg = new ConnectionRegistry()): DaemonWsDeps {
   return {
+    connReg,
     agent: new PgAgentRepo(prisma),
     agentMutations: new AgentMutationGate(),
     hook: new PgHookRepo(prisma),
@@ -61,11 +63,16 @@ async function reportSession(events: InMemorySessionEventSink, phase: 'start' | 
   )
 }
 
-async function reportActivity(events: InMemorySessionEventSink, state: string, daemonId = DAEMON) {
+async function reportActivity(
+  events: InMemorySessionEventSink,
+  state: string,
+  daemonId = DAEMON,
+  connReg = new ConnectionRegistry()
+) {
   await handleAgentActivity(
     frame('agent/activity', { agentId: AGENT, sessionId: SESSION, state, ts: '2026-07-05T00:00:01.000Z' }),
     { daemonId, orgId: DEFAULT_ORG_ID } as DaemonConnection,
-    deps(events)
+    deps(events, connReg)
   )
 }
 
@@ -144,6 +151,36 @@ describe('agent/activity → SessionMeta.activityState → GET /sessions?activit
     await reportSession(events, 'end')
     expect(await storedState()).toBe('idle')
     expect(seen.filter((e) => e.state).map((e) => e.state?.state)).toEqual(['awaiting_permission', 'idle'])
+  })
+
+  it('a reconnect replay lands after a still-running disconnect clear, never under it', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    await seedLaunch(prisma, LAUNCH, AGENT, DAEMON)
+    const events = new InMemorySessionEventSink()
+    const connReg = new ConnectionRegistry()
+    const repo = new PgSessionRepo(prisma)
+    await reportSession(events, 'start')
+    await reportActivity(events, 'awaiting_permission')
+
+    // The old socket's clear is queued but stalls mid-flight while the daemon reconnects and replays.
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => (release = resolve))
+    let cleared: Array<{ id: string }> = []
+    connReg.runApprovalClear(DAEMON, async () => {
+      await gate
+      cleared = await repo.clearAwaitingPermissionForDaemon(DaemonId(DAEMON))
+    })
+    const replay = reportActivity(events, 'awaiting_permission', DAEMON, connReg)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    // Still waiting on the clear: nothing has been written by the replay yet.
+    expect(cleared).toEqual([])
+    release()
+    await replay
+    expect(cleared.map((row) => row.id)).toEqual([SESSION])
+    // The clear committed `idle` first; the replay's `awaiting_permission` is the final word.
+    expect(await storedState()).toBe('awaiting_permission')
+    await connReg.approvalClearsSettled(DAEMON)
   })
 
   it('a disconnected daemon has its waits cleared, and only its own', async () => {

--- a/packages/control-plane/test/integration/session-activity-state.route.test.ts
+++ b/packages/control-plane/test/integration/session-activity-state.route.test.ts
@@ -14,6 +14,8 @@ import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
 import { InMemorySessionEventSink, type SessionEventEnvelope } from '../../src/events/sink.js'
 import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
 import { ConnectionRegistry } from '../../src/ws/registry.js'
+import { FakeClock } from '../fakes/fake-clock.js'
+import { clearAwaitingApprovals } from '../../src/ws/approval-waits.js'
 
 const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
 
@@ -67,13 +69,18 @@ async function reportActivity(
   events: InMemorySessionEventSink,
   state: string,
   daemonId = DAEMON,
-  connReg = new ConnectionRegistry()
+  connReg = new ConnectionRegistry(),
+  connState: 'READY' | 'CLOSED' = 'READY'
 ) {
   await handleAgentActivity(
     frame('agent/activity', { agentId: AGENT, sessionId: SESSION, state, ts: '2026-07-05T00:00:01.000Z' }),
-    { daemonId, orgId: DEFAULT_ORG_ID } as DaemonConnection,
+    { daemonId, orgId: DEFAULT_ORG_ID, state: connState } as DaemonConnection,
     deps(events, connReg)
   )
+}
+
+function clearDeps(events: InMemorySessionEventSink) {
+  return { session: new PgSessionRepo(prisma), events, clock: new FakeClock(Date.parse('2026-07-05T00:00:02.000Z')) }
 }
 
 async function awaitingSessions(app: HttpApp): Promise<string[]> {
@@ -167,7 +174,7 @@ describe('agent/activity → SessionMeta.activityState → GET /sessions?activit
     let release!: () => void
     const gate = new Promise<void>((resolve) => (release = resolve))
     let cleared: Array<{ id: string }> = []
-    connReg.runApprovalClear(DAEMON, async () => {
+    void connReg.runApprovalMutation(DAEMON, async () => {
       await gate
       cleared = await repo.clearAwaitingPermissionForDaemon(DaemonId(DAEMON))
     })
@@ -180,7 +187,47 @@ describe('agent/activity → SessionMeta.activityState → GET /sessions?activit
     expect(cleared.map((row) => row.id)).toEqual([SESSION])
     // The clear committed `idle` first; the replay's `awaiting_permission` is the final word.
     expect(await storedState()).toBe('awaiting_permission')
-    await connReg.approvalClearsSettled(DAEMON)
+    await connReg.approvalMutationsSettled(DAEMON)
+  })
+
+  it('a closing socket’s in-flight write is outlived by its own close clear, never the reverse', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    await seedLaunch(prisma, LAUNCH, AGENT, DAEMON)
+    const events = new InMemorySessionEventSink()
+    const connReg = new ConnectionRegistry()
+    await reportSession(events, 'start')
+
+    // The write was accepted before the close; the close clear queues behind it on the same tail.
+    const write = reportActivity(events, 'awaiting_permission', DAEMON, connReg)
+    const clear = connReg.runApprovalMutation(DAEMON, () => clearAwaitingApprovals(clearDeps(events), DAEMON, true))
+    await Promise.all([write, clear])
+    expect(await storedState()).toBe('idle')
+
+    // A frame whose connection already closed before its turn on the tail writes nothing at all.
+    const publishState = vi.spyOn(events, 'publishState')
+    await reportActivity(events, 'awaiting_permission', DAEMON, connReg, 'CLOSED')
+    expect(await storedState()).toBe('idle')
+    expect(publishState).not.toHaveBeenCalled()
+  })
+
+  it('the register-time clear resets silently; the replay that follows publishes the live wait', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    await seedLaunch(prisma, LAUNCH, AGENT, DAEMON)
+    const events = new InMemorySessionEventSink()
+    const connReg = new ConnectionRegistry()
+    await reportSession(events, 'start')
+    await reportActivity(events, 'awaiting_permission', DAEMON, connReg)
+
+    const seen: SessionEventEnvelope[] = []
+    events.subscribe((e) => seen.push(e))
+    await connReg.runApprovalMutation(DAEMON, () => clearAwaitingApprovals(clearDeps(events), DAEMON, false))
+    expect(await storedState()).toBe('idle')
+    expect(seen).toEqual([])
+    await reportActivity(events, 'awaiting_permission', DAEMON, connReg)
+    expect(await storedState()).toBe('awaiting_permission')
+    expect(seen.map((e) => e.state?.state)).toEqual(['awaiting_permission'])
   })
 
   it('a disconnected daemon has its waits cleared, and only its own', async () => {

--- a/packages/control-plane/test/integration/session-activity-state.route.test.ts
+++ b/packages/control-plane/test/integration/session-activity-state.route.test.ts
@@ -1,0 +1,169 @@
+// `agent/activity` → `SessionMeta.activityState` → `GET /sessions?activityState=…` (slack-approval-dm.md §7).
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { prisma } from '../setup.db.js'
+import { seedDaemon, seedAgent, seedLaunch } from '../fixtures/seed.js'
+import { buildHttpApp, type HttpApp } from '../fakes/build-http.js'
+import { PgAgentRepo, PgHookRepo, PgSessionRepo, PgWebchatConversationRepo } from '../../src/persistence/index.js'
+import { AgentId, DaemonId, SessionId } from '../../src/domain/ids.js'
+import { handleAgentActivity, handleEventSession } from '../../src/ws/handlers/index.js'
+import type { DaemonConnection } from '../../src/ws/connection.js'
+import type { DaemonWsDeps } from '../../src/ws/deps.js'
+import type { AnyFrame } from '@agentconnect.md/protocol'
+import { DEFAULT_ORG_ID } from '../../prisma/seed.js'
+import { InMemorySessionEventSink, type SessionEventEnvelope } from '../../src/events/sink.js'
+import { AgentMutationGate } from '../../src/orchestrator/agentMutationGate.js'
+
+const ORG = `/api/v1/orgs/${DEFAULT_ORG_ID}`
+
+let running: HttpApp | undefined
+afterEach(async () => {
+  await running?.close()
+  running = undefined
+})
+
+const DAEMON = 'd1d1d1d1-dddd-4ddd-8ddd-dddddddddddd'
+const OTHER_DAEMON = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+const AGENT = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const LAUNCH = '10101010-1111-4111-8111-111111111111'
+const SESSION = '4691f21b-3911-4d7f-a45d-28ce75d79337'
+
+function frame(type: string, payload: Record<string, unknown>): AnyFrame {
+  return { v: 1, id: randomUUID(), ts: new Date().toISOString(), type, payload } as AnyFrame
+}
+
+function deps(events: InMemorySessionEventSink): DaemonWsDeps {
+  return {
+    agent: new PgAgentRepo(prisma),
+    agentMutations: new AgentMutationGate(),
+    hook: new PgHookRepo(prisma),
+    session: new PgSessionRepo(prisma),
+    webchatConversation: new PgWebchatConversationRepo(prisma),
+    events
+  } as unknown as DaemonWsDeps
+}
+
+async function reportSession(events: InMemorySessionEventSink, phase: 'start' | 'end', daemonId = DAEMON) {
+  await handleEventSession(
+    frame('event/session', {
+      sessionId: SESSION,
+      agentId: AGENT,
+      launchId: LAUNCH,
+      phase,
+      platform: 'slack',
+      channel: 'C123',
+      thread: 'T9',
+      title: 'Roll out api@1.4.2',
+      ts: '2026-07-05T00:00:00.000Z'
+    }),
+    { daemonId, orgId: DEFAULT_ORG_ID } as DaemonConnection,
+    deps(events)
+  )
+}
+
+async function reportActivity(events: InMemorySessionEventSink, state: string, daemonId = DAEMON) {
+  await handleAgentActivity(
+    frame('agent/activity', { agentId: AGENT, sessionId: SESSION, state, ts: '2026-07-05T00:00:01.000Z' }),
+    { daemonId, orgId: DEFAULT_ORG_ID } as DaemonConnection,
+    deps(events)
+  )
+}
+
+async function awaitingSessions(app: HttpApp): Promise<string[]> {
+  const res = await app.app.inject({
+    method: 'GET',
+    url: `${ORG}/sessions?view=flat&activityState=awaiting_permission&limit=50`
+  })
+  expect(res.statusCode).toBe(200)
+  return (res.json() as { sessions: Array<{ sessionId: string }> }).sessions.map((s) => s.sessionId)
+}
+
+async function storedState(): Promise<string | undefined> {
+  return (await prisma.sessionMeta.findUnique({ where: { id: SESSION } }))?.activityState
+}
+
+describe('agent/activity → SessionMeta.activityState → GET /sessions?activityState (§7)', () => {
+  it('persists the wait, lists it under the filter, publishes it, and clears it on idle', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    await seedLaunch(prisma, LAUNCH, AGENT, DAEMON)
+    running = buildHttpApp(prisma)
+    const events = new InMemorySessionEventSink()
+    const seen: SessionEventEnvelope[] = []
+    events.subscribe((e) => seen.push(e))
+
+    await reportSession(events, 'start')
+    expect(await storedState()).toBe('idle')
+    expect(await awaitingSessions(running)).toEqual([])
+
+    await reportActivity(events, 'awaiting_permission')
+    expect(await storedState()).toBe('awaiting_permission')
+    expect(await awaitingSessions(running)).toEqual([SESSION])
+    expect(seen.filter((e) => e.state).map((e) => e.state?.state)).toEqual(['awaiting_permission'])
+
+    // The unfiltered list carries the state too, so the console reads one shape everywhere.
+    const flat = await running.app.inject({ method: 'GET', url: `${ORG}/sessions?view=flat` })
+    expect((flat.json() as { sessions: Array<{ activityState: string }> }).sessions[0]?.activityState).toBe(
+      'awaiting_permission'
+    )
+
+    await reportActivity(events, 'idle')
+    expect(await storedState()).toBe('idle')
+    expect(await awaitingSessions(running)).toEqual([])
+    expect(seen.filter((e) => e.state).map((e) => e.state?.state)).toEqual(['awaiting_permission', 'idle'])
+  })
+
+  it('drops a frame from a daemon that does not serve the agent, and one for an unknown session', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, OTHER_DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    await seedLaunch(prisma, LAUNCH, AGENT, DAEMON)
+    const events = new InMemorySessionEventSink()
+    const publishState = vi.spyOn(events, 'publishState')
+
+    // No session row yet: nothing to flag, nothing to publish.
+    await reportActivity(events, 'awaiting_permission')
+    expect(publishState).not.toHaveBeenCalled()
+
+    await reportSession(events, 'start')
+    await reportActivity(events, 'awaiting_permission', OTHER_DAEMON)
+    expect(await storedState()).toBe('idle')
+    expect(publishState).not.toHaveBeenCalled()
+  })
+
+  it('a finished session waits on nobody: the end milestone resets a stale wait', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    await seedLaunch(prisma, LAUNCH, AGENT, DAEMON)
+    const events = new InMemorySessionEventSink()
+    const seen: SessionEventEnvelope[] = []
+    events.subscribe((e) => seen.push(e))
+
+    await reportSession(events, 'start')
+    await reportActivity(events, 'awaiting_permission')
+    await reportSession(events, 'end')
+    expect(await storedState()).toBe('idle')
+    expect(seen.filter((e) => e.state).map((e) => e.state?.state)).toEqual(['awaiting_permission', 'idle'])
+  })
+
+  it('a disconnected daemon has its waits cleared, and only its own', async () => {
+    await seedDaemon(prisma, DAEMON)
+    await seedDaemon(prisma, OTHER_DAEMON)
+    await seedAgent(prisma, AGENT, { daemonId: DAEMON })
+    await seedLaunch(prisma, LAUNCH, AGENT, DAEMON)
+    const events = new InMemorySessionEventSink()
+    await reportSession(events, 'start')
+    await reportActivity(events, 'awaiting_permission')
+
+    const repo = new PgSessionRepo(prisma)
+    expect(await repo.clearAwaitingPermissionForDaemon(DaemonId(OTHER_DAEMON))).toEqual([])
+    expect(await storedState()).toBe('awaiting_permission')
+
+    expect(await repo.clearAwaitingPermissionForDaemon(DaemonId(DAEMON))).toEqual([
+      { id: SessionId(SESSION), agentId: AgentId(AGENT) }
+    ])
+    expect(await storedState()).toBe('idle')
+    // Idempotent: nothing left to clear.
+    expect(await repo.clearAwaitingPermissionForDaemon(DaemonId(DAEMON))).toEqual([])
+  })
+})

--- a/packages/control-plane/test/protocol/fencing.test.ts
+++ b/packages/control-plane/test/protocol/fencing.test.ts
@@ -104,6 +104,7 @@ function readyConn(opts: { sessionEpoch: number }) {
 function agentActivity() {
   return {
     agentId: AGENT,
+    sessionId: 'session-1',
     launchId: LAUNCH,
     state: 'thinking' as const,
     ts: new Date().toISOString()

--- a/packages/daemon/src/cp/client.ts
+++ b/packages/daemon/src/cp/client.ts
@@ -16,6 +16,7 @@ import type {
   UsageReport,
   EventSession,
   SessionActivity,
+  AgentActivity,
   SessionPurged,
   IntegrationChannels,
   CronReport,
@@ -737,6 +738,12 @@ export class CpClient {
       throw new WireError('INTERNAL', `expected event/session-purged ack, got ${rep.type}`, false)
     }
     return 'acknowledged'
+  }
+
+  /** D→C `agent/activity` EVT, fire-and-forget — the approval bell's signal (slack-approval-dm.md §7); every CP knows the frame. */
+  emitAgentActivity(activity: AgentActivity): void {
+    if (this.state !== 'READY' && this.state !== 'DRAINING') return
+    this.transport?.send(encode(this.scopedFrame('agent/activity', activity)))
   }
 
   /** Signal a durable transcript mutation without putting message content on the control WS. */

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -265,10 +265,12 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       host.cpClient()?.emitMemoryConnectionFacts(host.memoryConnections()?.facts() ?? [])
       await host.replayHookTerminalReports()
       await host.replayChannelSnapshots()
-      host.replayApprovalActivity()
       // Only snapshots written to the durable outbox by this build are
       // replayed. Historical session rows are never scanned or backfilled.
-      void host.sessionMetadataOutbox().drainSessionMetadataSnapshots()
+      // The approval replay follows the drain: a wait for a session whose `start` snapshot is still in
+      // the outbox would be dropped by the CP (no row to flag) and never re-asserted (§7).
+      const replayApprovals = () => host.replayApprovalActivity()
+      void host.sessionMetadataOutbox().drainSessionMetadataSnapshots().then(replayApprovals, replayApprovals)
       // Replay remote MCP revocations that could not reach the CP (revokes
       // queued while disconnected or left over from a previous process).
       void host.webchatMcpRevocations().drainWebchatMcpRevocations()

--- a/packages/daemon/src/cp/cp-client-deps.ts
+++ b/packages/daemon/src/cp/cp-client-deps.ts
@@ -111,6 +111,8 @@ export interface CpClientReadyHost {
   memoryConnections(): CpMemoryConnectionRegistry | undefined
   replayHookTerminalReports(): Promise<void>
   replayChannelSnapshots(): Promise<void>
+  /** Re-assert every live approval wait: the CP cleared them when this daemon dropped (slack-approval-dm.md §7). */
+  replayApprovalActivity(): void
   sessionMetadataOutbox(): SessionMetadataOutbox
   webchatMcpRevocations(): WebchatMcpRevocations
   drainSessionPurges(): Promise<void>
@@ -263,6 +265,7 @@ export function buildCpClientDeps(host: CpClientDepsHost): CpClientDeps {
       host.cpClient()?.emitMemoryConnectionFacts(host.memoryConnections()?.facts() ?? [])
       await host.replayHookTerminalReports()
       await host.replayChannelSnapshots()
+      host.replayApprovalActivity()
       // Only snapshots written to the durable outbox by this build are
       // replayed. Historical session rows are never scanned or backfilled.
       void host.sessionMetadataOutbox().drainSessionMetadataSnapshots()

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8264,6 +8264,7 @@ export class Daemon {
       httpSlackSessionTarget: (p) => this.httpSlackSessionTarget(p),
       maskAgentSecrets: <T>(agentId: string, payload: T): T => this.maskAgentSecrets(agentId, payload),
       logSessionAction: (verb, sessionKey, actor) => this.commands.logSessionAction(verb, sessionKey, actor),
+      emitApprovalActivity: (agentId, acpSessionId, state) => this.emitApprovalActivity(agentId, acpSessionId, state),
       // ── approval-DM routing (slack-approval-dm.md §4–§6) ──
       cpApprovalRoute: () =>
         this.cpClient?.supportsServerFeature?.(APPROVAL_DM_ROUTE_V1_FEATURE) === true ? this.cpClient : undefined,
@@ -8281,6 +8282,21 @@ export class Daemon {
       slackDmSessionTarget: (p, integrationId) =>
         encodeSharedSlackStatusTarget({ agentId: p.plan.agentId, integrationId, sessionKey: p.plan.sessionKey })
     }
+  }
+
+  /** Serializes `agent/activity` emits: two flips on one session must reach the CP in order. */
+  private approvalActivityChain: Promise<void> = Promise.resolve()
+
+  /** D→C `agent/activity` for the approval bell (slack-approval-dm.md §7); best-effort, the reconnect replay converges it. */
+  private emitApprovalActivity(agentId: string, acpSessionId: string, state: 'awaiting_permission' | 'idle'): void {
+    this.approvalActivityChain = this.approvalActivityChain.then(async () => {
+      try {
+        const sessionId = (await this.outwardSessionIdForAcp(agentId, acpSessionId)) ?? acpSessionId
+        this.cpClient?.emitAgentActivity?.({ agentId, sessionId, state, ts: new Date(this.clock.now()).toISOString() })
+      } catch (err) {
+        this.log.warn(`approval activity for agent "${agentId}" not reported: ${formatErr(err)}`)
+      }
+    })
   }
 
   /** Everything the collaboration coordinator touches on the Daemon — turn state, the CP/relay seam, dispatch. */
@@ -16518,6 +16534,7 @@ export class Daemon {
       memoryConnections: () => this.memoryConnections,
       replayHookTerminalReports: () => this.replayHookTerminalReports(),
       replayChannelSnapshots: () => this.replayChannelSnapshots(),
+      replayApprovalActivity: () => this.permissions.replayApprovalActivity(),
       sessionMetadataOutbox: () => this.sessionMetadataOutbox,
       webchatMcpRevocations: () => this.webchatMcpRevocations,
       drainSessionPurges: () => this.drainSessionPurges(),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1378,7 +1378,21 @@ export class Daemon {
       agents: () => this.agents,
       servesAgent: (agentId) => this.servesAgent(agentId),
       sessionLink: (acpSessionId) => this.sessionLink(acpSessionId),
-      sessionThreadUrl: (session) => this.sessionThreadUrl(session)
+      sessionThreadUrl: (session) => this.sessionThreadUrl(session),
+      onSessionMetadataCommitted: (agentId, sessionId) => void this.reassertApprovalWait(agentId, sessionId)
+    }
+  }
+
+  /** The session's row now exists at the CP: re-assert a live wait it may have dropped for lack of one (§7). */
+  private async reassertApprovalWait(agentId: string, outwardSessionId: string): Promise<void> {
+    try {
+      for (const wait of this.permissions.liveApprovalWaits()) {
+        if (wait.agentId !== agentId) continue
+        const outward = (await this.outwardSessionIdForAcp(agentId, wait.sessionId)) ?? wait.sessionId
+        if (outward === outwardSessionId) this.emitApprovalActivity(agentId, wait.sessionId, 'awaiting_permission')
+      }
+    } catch (err) {
+      this.log.warn(`approval wait for session "${outwardSessionId}" not re-asserted: ${formatErr(err)}`)
     }
   }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1389,6 +1389,7 @@ export class Daemon {
       for (const wait of this.permissions.liveApprovalWaits()) {
         if (wait.agentId !== agentId) continue
         const outward = (await this.outwardSessionIdForAcp(agentId, wait.sessionId)) ?? wait.sessionId
+        // The snapshot above is stale by now; the emit itself re-checks the wait is still live.
         if (outward === outwardSessionId) this.emitApprovalActivity(agentId, wait.sessionId, 'awaiting_permission')
       }
     } catch (err) {
@@ -8306,6 +8307,9 @@ export class Daemon {
     this.approvalActivityChain = this.approvalActivityChain.then(async () => {
       try {
         const sessionId = (await this.outwardSessionIdForAcp(agentId, acpSessionId)) ?? acpSessionId
+        // Re-checked after the lookup with no await before the send: a settle that landed meanwhile
+        // already queued its `idle` ahead of this task, and a stale `awaiting_permission` must not follow it.
+        if (state === 'awaiting_permission' && !this.permissions.isAwaitingApproval(agentId, acpSessionId)) return
         this.cpClient?.emitAgentActivity?.({ agentId, sessionId, state, ts: new Date(this.clock.now()).toISOString() })
       } catch (err) {
         this.log.warn(`approval activity for agent "${agentId}" not reported: ${formatErr(err)}`)

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -83,6 +83,8 @@ export interface PermissionSurfaceHost {
   httpSlackSessionTarget(p: Pick<Pending, 'plan'>): string | undefined
   maskAgentSecrets<T>(agentId: string, payload: T): T
   logSessionAction(verb: string, sessionKey: string, actor?: InteractionActor): void
+  /** Tell the CP a session started or stopped waiting on a human (slack-approval-dm.md §7); fire-and-forget. */
+  emitApprovalActivity(agentId: string, acpSessionId: string, state: 'awaiting_permission' | 'idle'): void
   // ── approval-DM routing (slack-approval-dm.md §4–§6) ──
   cpApprovalRoute(): ApprovalRouteChannel | undefined
   orgForAgent(agentId: string): string | undefined
@@ -173,7 +175,42 @@ export class PermissionCoordinator {
     }
   >()
 
+  /** Sessions the CP currently believes are waiting, keyed by `pendingTurnKey` — emit only on a change. */
+  private readonly awaitingApproval = new Map<string, { agentId: string; sessionId: string }>()
+
   constructor(private readonly host: PermissionHost) {}
+
+  /** Any answerable request for the session across the three pending maps (approval elicitations only). */
+  private hasPendingApproval(agentId: string, sessionId: string): boolean {
+    for (const e of this.pendingEditorPermissions.values())
+      if (e.agentId === agentId && e.sessionId === sessionId) return true
+    for (const e of this.pendingChatPermissions.values())
+      if (e.agentId === agentId && e.sessionId === sessionId) return true
+    for (const e of this.pendingElicits.values())
+      if (e.approval && e.agentId === agentId && e.sessionId === sessionId) return true
+    return false
+  }
+
+  /** Re-derive the session's wait state after a map write and report it when it flipped (§7). */
+  private syncApprovalActivity(agentId: string, sessionId: string): void {
+    const key = pendingTurnKey(agentId, sessionId)
+    const awaiting = this.hasPendingApproval(agentId, sessionId)
+    if (awaiting === this.awaitingApproval.has(key)) return
+    if (awaiting) this.awaitingApproval.set(key, { agentId, sessionId })
+    else this.awaitingApproval.delete(key)
+    try {
+      this.host.emitApprovalActivity(agentId, sessionId, awaiting ? 'awaiting_permission' : 'idle')
+    } catch (err) {
+      this.host.log().warn(`approval activity not reported: ${formatErr(err)}`)
+    }
+  }
+
+  /** Re-assert every live wait after a (re)connect: the CP reset them when this daemon dropped (§7). */
+  replayApprovalActivity(): void {
+    for (const { agentId, sessionId } of this.awaitingApproval.values()) {
+      this.host.emitApprovalActivity(agentId, sessionId, 'awaiting_permission')
+    }
+  }
 
   private async noteEditorPermissionRequest(
     id: string,
@@ -276,6 +313,7 @@ export class PermissionCoordinator {
       evaluationParams,
       resolve: resolveResult
     })
+    this.syncApprovalActivity(agentId, sessionId)
     // The human wait starts when the request becomes answerable, not when its row lands — the
     // write used to be synchronous, and billing it to the turn's retry budget would shrink it.
     const wait = this.trackHumanApprovalWait(p, result)
@@ -286,6 +324,7 @@ export class PermissionCoordinator {
       requesterName = (await recorded).requesterName
     } catch (err) {
       this.pendingEditorPermissions.delete(id)
+      this.syncApprovalActivity(agentId, sessionId)
       this.recordedWrites.delete(id)
       resolveResult({ outcome: { outcome: 'cancelled' } })
       await wait
@@ -312,6 +351,7 @@ export class PermissionCoordinator {
       params,
       resolve: resolveResult
     })
+    this.syncApprovalActivity(agentId, sessionId)
     const wait = this.trackHumanApprovalWait(p, result)
     const recorded = this.noteEditorPermissionRequest(id, agentId, sessionId, elicitationApprovalSummary(params), p)
     this.recordedWrites.set(id, recorded)
@@ -320,6 +360,7 @@ export class PermissionCoordinator {
       requesterName = (await recorded).requesterName
     } catch (err) {
       this.pendingEditorPermissions.delete(id)
+      this.syncApprovalActivity(agentId, sessionId)
       this.recordedWrites.delete(id)
       resolveResult({ action: 'cancel' })
       await wait
@@ -350,6 +391,7 @@ export class PermissionCoordinator {
       channel: p.plan.channel,
       resolve: resolveResult
     })
+    this.syncApprovalActivity(agentId, sessionId)
     const recorded = this.noteEditorPermissionRequest(
       requestId,
       agentId,
@@ -363,6 +405,7 @@ export class PermissionCoordinator {
       await recorded
     } catch (err) {
       this.pendingChatPermissions.delete(requestId)
+      this.syncApprovalActivity(agentId, sessionId)
       this.recordedWrites.delete(requestId)
       throw err
     }
@@ -394,6 +437,7 @@ export class PermissionCoordinator {
     }
     if (!ts) {
       this.pendingChatPermissions.delete(requestId)
+      this.syncApprovalActivity(agentId, sessionId)
       await this.resolveStoredPermissionRequest(agentId, requestId, 'expired')
       this.permissionEvaluationDetails.set(evaluationParams, { reason: 'permission_card_failed' })
       live.resolve({ outcome: { outcome: 'cancelled' } })
@@ -592,6 +636,7 @@ export class PermissionCoordinator {
     if (!(await this.resolveStoredPermissionRequest(rec.agentId, requestId, allowed ? 'allowed' : 'denied', by))) return
     this.host.logSessionAction(`permission:${allowed ? 'allowed' : 'denied'}`, rec.sessionId, actor)
     this.pendingEditorPermissions.delete(requestId)
+    this.syncApprovalActivity(rec.agentId, rec.sessionId)
     this.permissionEvaluationDetails.set(rec.evaluationParams, { reason: 'agent_editor' })
     void notify.conn
       .updateBlocks(
@@ -659,6 +704,7 @@ export class PermissionCoordinator {
       return
     this.host.logSessionAction(`permission:${value === null ? 'denied' : 'allowed'}`, rec.sessionId, actor)
     this.pendingEditorPermissions.delete(requestId)
+    this.syncApprovalActivity(rec.agentId, rec.sessionId)
     void notify.conn
       .updateBlocks(
         notify.channel,
@@ -699,6 +745,7 @@ export class PermissionCoordinator {
           return { ok: false, reason: 'permission request is no longer pending' }
         }
         this.pendingElicits.delete(req.requestId)
+        this.syncApprovalActivity(elicitation.agentId, elicitation.sessionId)
         if (elicitation.ts) {
           const decision =
             req.decision === 'allow'
@@ -735,6 +782,7 @@ export class PermissionCoordinator {
         return { ok: false, reason: 'permission request is no longer pending' }
       }
       this.pendingChatPermissions.delete(req.requestId)
+      this.syncApprovalActivity(chat.agentId, chat.sessionId)
       this.permissionEvaluationDetails.set(chat.evaluationParams, { reason: 'agent_editor' })
       if (chat.ts) {
         void chat.conn
@@ -786,6 +834,7 @@ export class PermissionCoordinator {
       return { ok: false, reason: 'permission request is no longer pending' }
     }
     this.pendingEditorPermissions.delete(req.requestId)
+    this.syncApprovalActivity(pending.agentId, pending.sessionId)
     if (pending.notify) {
       const label = `${req.decision === 'allow' ? 'Allowed' : 'Denied'} by ${req.decidedByName ?? 'an Agent editor'}`
       const blocks =
@@ -861,6 +910,7 @@ export class PermissionCoordinator {
     // whose click changed nothing.
     this.host.logSessionAction(`permission:${allowed ? 'allowed' : 'denied'}`, pending.sessionId, input.actor)
     this.pendingChatPermissions.delete(input.requestId)
+    this.syncApprovalActivity(pending.agentId, pending.sessionId)
     this.permissionEvaluationDetails.set(pending.evaluationParams, { reason: 'chat_user' })
     if (pending.ts) {
       void pending.conn
@@ -909,6 +959,7 @@ export class PermissionCoordinator {
     for (const [id, pending] of this.pendingChatPermissions) {
       if (pending.agentId !== agentId || pending.sessionId !== sessionId) continue
       this.pendingChatPermissions.delete(id)
+      this.syncApprovalActivity(agentId, sessionId)
       await this.resolveStoredPermissionRequest(agentId, id, 'expired')
       this.permissionEvaluationDetails.set(pending.evaluationParams, { reason: 'turn_cancelled' })
       if (pending.ts) {
@@ -930,6 +981,7 @@ export class PermissionCoordinator {
     for (const [id, pending] of this.pendingEditorPermissions) {
       if (pending.agentId !== agentId || pending.sessionId !== sessionId) continue
       this.pendingEditorPermissions.delete(id)
+      this.syncApprovalActivity(agentId, sessionId)
       await this.resolveStoredPermissionRequest(agentId, id, 'expired')
       // Dead buttons must not survive the request (§5.4): retire the DM card in place.
       if (pending.notify) {
@@ -1137,6 +1189,7 @@ export class PermissionCoordinator {
       channel: p.plan.channel,
       resolve: resolveResult
     })
+    this.syncApprovalActivity(agentId, sessionId)
     if (isApproval) {
       const recorded = this.noteEditorPermissionRequest(
         requestId,
@@ -1151,6 +1204,7 @@ export class PermissionCoordinator {
         await recorded
       } catch (err) {
         this.pendingElicits.delete(requestId)
+        this.syncApprovalActivity(agentId, sessionId)
         this.recordedWrites.delete(requestId)
         throw err
       }
@@ -1179,6 +1233,7 @@ export class PermissionCoordinator {
     }
     if (!ts) {
       this.pendingElicits.delete(requestId)
+      this.syncApprovalActivity(agentId, sessionId)
       if (isApproval) await this.resolveStoredPermissionRequest(agentId, requestId, 'expired')
       live.resolve({ action: 'cancel' })
       return await result
@@ -1238,6 +1293,7 @@ export class PermissionCoordinator {
         return
     }
     this.pendingElicits.delete(a.requestId)
+    this.syncApprovalActivity(rec.agentId, rec.sessionId)
     if (rec.ts)
       void rec.conn
         .updateBlocks(rec.channel, rec.ts, buildElicitationResolvedCard(rec.params, decision), 'Input received', true)
@@ -1251,6 +1307,7 @@ export class PermissionCoordinator {
     for (const [id, rec] of this.pendingElicits) {
       if (rec.agentId !== agentId || rec.sessionId !== sessionId) continue
       this.pendingElicits.delete(id)
+      this.syncApprovalActivity(agentId, sessionId)
       if (rec.approval) await this.resolveStoredPermissionRequest(agentId, id, 'expired')
       if (rec.ts)
         void rec.conn

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -210,6 +210,11 @@ export class PermissionCoordinator {
     return [...this.awaitingApproval.values()]
   }
 
+  /** Whether the session still has an answerable request — the emit-time check behind every `awaiting_permission`. */
+  isAwaitingApproval(agentId: string, sessionId: string): boolean {
+    return this.awaitingApproval.has(pendingTurnKey(agentId, sessionId))
+  }
+
   /** Re-assert every live wait after a (re)connect: the CP reset them when this daemon dropped (§7). */
   replayApprovalActivity(): void {
     for (const { agentId, sessionId } of this.awaitingApproval.values()) {

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -205,6 +205,11 @@ export class PermissionCoordinator {
     }
   }
 
+  /** The sessions currently waiting on a human, by runtime session id. */
+  liveApprovalWaits(): ReadonlyArray<{ agentId: string; sessionId: string }> {
+    return [...this.awaitingApproval.values()]
+  }
+
   /** Re-assert every live wait after a (re)connect: the CP reset them when this daemon dropped (§7). */
   replayApprovalActivity(): void {
     for (const { agentId, sessionId } of this.awaitingApproval.values()) {

--- a/packages/daemon/src/store/session-metadata-outbox.ts
+++ b/packages/daemon/src/store/session-metadata-outbox.ts
@@ -41,6 +41,8 @@ export interface SessionMetadataHost {
   servesAgent(agentId: string): boolean
   sessionLink(acpSessionId: string): string
   sessionThreadUrl(session: SessionRecord): string | undefined
+  /** The CP acknowledged this session's snapshot: a live approval wait on it can be re-asserted now (slack-approval-dm.md §7). */
+  onSessionMetadataCommitted?(agentId: string, outwardSessionId: string): void
 }
 
 export interface SessionMetadataSnapshotInput {
@@ -317,6 +319,7 @@ export class SessionMetadataOutbox {
         // Revision fencing: an event produced while this request was in flight
         // remains pending instead of being cleared by the older ACK.
         await store.acknowledgeSessionMetadataSnapshot(row.agentId, row.sessionId, row.revision, daemonId)
+        this.host.onSessionMetadataCommitted?.(row.agentId, row.sessionId)
       } catch (err) {
         if (!row) {
           this.host.warn(`event/session outbox read failed (${formatErr(err)})`)

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -37,6 +37,7 @@ async function world(over?: {
   noChannel?: boolean
   platform?: string
   requesterId?: string
+  activity?: PermissionHost['emitApprovalActivity']
 }) {
   const store = await LocalStore.open({ database: SqliteAsyncDatabase.adopt(new DatabaseSync(':memory:')) })
   const conn = fakeSlackConn()
@@ -79,6 +80,7 @@ async function world(over?: {
     httpSlackSessionTarget: () => undefined,
     maskAgentSecrets: (_agentId, payload) => payload,
     logSessionAction: vi.fn(),
+    emitApprovalActivity: over?.activity ?? vi.fn(),
     cpApprovalRoute: () => ({ approvalRoute: route as never }),
     orgForAgent: () => 'org-1',
     sessionLink: (sessionId) => `https://console.example/sessions/${sessionId}`,
@@ -193,6 +195,57 @@ describe('approval DM (slack-approval-dm.md §5–§6)', () => {
     await expect(decided).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
     expect(w.conn.updateBlocks).toHaveBeenCalledTimes(1)
     expect((await w.store.listPermissionRequests(AGENT))[0]!.status).toBe('expired')
+    await w.store.close()
+  })
+})
+
+describe('approval activity (slack-approval-dm.md §7)', () => {
+  it('flips awaiting_permission on the first park, idle on the last release, and never in between', async () => {
+    const activity = vi.fn()
+    const w = await world({ activity })
+    const first = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    await vi.waitFor(() => expect(w.route).toHaveBeenCalledTimes(1))
+    expect(activity).toHaveBeenCalledTimes(1)
+    expect(activity).toHaveBeenLastCalledWith(AGENT, ACP_SESSION, 'awaiting_permission')
+
+    const second = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    await vi.waitFor(() => expect(w.route).toHaveBeenCalledTimes(2))
+    // A second request on an already-waiting session is not news to the console.
+    expect(activity).toHaveBeenCalledTimes(1)
+
+    const [firstId, secondId] = w.route.mock.calls.map((call) => (call[0] as { requestId: string }).requestId)
+    await w.coordinator.decideEditorPermission({ agentId: AGENT, requestId: firstId!, decision: 'allow' })
+    await expect(first).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'o-allow' } })
+    // One request settled, one still parked: the session is still waiting.
+    expect(activity).toHaveBeenCalledTimes(1)
+
+    await w.coordinator.decideEditorPermission({ agentId: AGENT, requestId: secondId!, decision: 'deny' })
+    await expect(second).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'o-deny' } })
+    expect(activity).toHaveBeenCalledTimes(2)
+    expect(activity).toHaveBeenLastCalledWith(AGENT, ACP_SESSION, 'idle')
+    await w.store.close()
+  })
+
+  it('clears the wait when the turn is cancelled, and replays only live waits on reconnect', async () => {
+    const activity = vi.fn()
+    const w = await world({ activity })
+    const parked = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    await vi.waitFor(() => expect(activity).toHaveBeenCalledWith(AGENT, ACP_SESSION, 'awaiting_permission'))
+
+    // The CP forgot this daemon's waits on disconnect: the replay re-asserts the live one.
+    activity.mockClear()
+    w.coordinator.replayApprovalActivity()
+    expect(activity).toHaveBeenCalledTimes(1)
+    expect(activity).toHaveBeenLastCalledWith(AGENT, ACP_SESSION, 'awaiting_permission')
+
+    await w.coordinator.releaseEditorPermissions(AGENT, ACP_SESSION)
+    await expect(parked).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+    expect(activity).toHaveBeenLastCalledWith(AGENT, ACP_SESSION, 'idle')
+
+    // Nothing is waiting any more, so a reconnect replays nothing.
+    activity.mockClear()
+    w.coordinator.replayApprovalActivity()
+    expect(activity).not.toHaveBeenCalled()
     await w.store.close()
   })
 })

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -232,6 +232,9 @@ describe('approval activity (slack-approval-dm.md §7)', () => {
     const parked = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
     await vi.waitFor(() => expect(activity).toHaveBeenCalledWith(AGENT, ACP_SESSION, 'awaiting_permission'))
 
+    expect(w.coordinator.isAwaitingApproval(AGENT, ACP_SESSION)).toBe(true)
+    expect(w.coordinator.isAwaitingApproval(AGENT, 'acp-other')).toBe(false)
+
     // The CP forgot this daemon's waits on disconnect: the replay re-asserts the live one.
     activity.mockClear()
     w.coordinator.replayApprovalActivity()
@@ -241,6 +244,7 @@ describe('approval activity (slack-approval-dm.md §7)', () => {
     await w.coordinator.releaseEditorPermissions(AGENT, ACP_SESSION)
     await expect(parked).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
     expect(activity).toHaveBeenLastCalledWith(AGENT, ACP_SESSION, 'idle')
+    expect(w.coordinator.isAwaitingApproval(AGENT, ACP_SESSION)).toBe(false)
 
     // Nothing is waiting any more, so a reconnect replays nothing.
     activity.mockClear()

--- a/packages/daemon/test/session-metadata-outbox-commit-hook.test.ts
+++ b/packages/daemon/test/session-metadata-outbox-commit-hook.test.ts
@@ -1,0 +1,68 @@
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, it, vi } from 'vitest'
+import { SessionMetadataOutbox, type SessionMetadataHost } from '../src/store/session-metadata-outbox.js'
+import { LocalStore } from '../src/store/local-store.js'
+import { SqliteAsyncDatabase } from '../src/store/sqlite-async-database.js'
+
+const AGENT = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const SESSION = 'outward-1'
+const DAEMON = 'd1'
+
+async function world() {
+  const store = await LocalStore.open({ database: SqliteAsyncDatabase.adopt(new DatabaseSync(':memory:')) })
+  let now = 1_000_000
+  const sync = vi.fn<(event: unknown) => Promise<'acknowledged' | 'unsupported'>>(async () => 'acknowledged')
+  const committed = vi.fn()
+  const cp = { state: 'READY', supportsServerFeature: () => true, syncEventSession: sync }
+  const host: SessionMetadataHost = {
+    store: () => store,
+    warn: vi.fn(),
+    debug: vi.fn(),
+    // Retry timers are real but cleared by `dispose()`; only `now` is steered.
+    clock: () => ({ now: () => now, setTimeout, clearTimeout }) as never,
+    daemonId: () => DAEMON,
+    controlPlaneConfigured: () => true,
+    draining: () => false,
+    cpClient: () => cp as never,
+    agents: () => new Map([[AGENT, { id: AGENT } as never]]),
+    servesAgent: () => true,
+    sessionLink: (id) => `https://console.example/sessions/${id}`,
+    sessionThreadUrl: () => undefined,
+    onSessionMetadataCommitted: committed
+  }
+  const outbox = new SessionMetadataOutbox(host)
+  const save = () =>
+    store.saveSessionMetadataSnapshot(
+      AGENT,
+      SESSION,
+      JSON.stringify({ sessionId: SESSION, agentId: AGENT, phase: 'start', ts: new Date(now).toISOString() }),
+      true,
+      now,
+      DAEMON
+    )
+  return { store, outbox, sync, committed, save, advance: (ms: number) => (now += ms) }
+}
+
+describe('session-metadata outbox → approval wait re-assert (slack-approval-dm.md §7)', () => {
+  it('fires only once the CP has acknowledged the snapshot, not on a failed attempt', async () => {
+    const w = await world()
+    await w.save()
+    w.sync.mockRejectedValueOnce(Object.assign(new Error('cp unreachable'), { retryable: true }))
+    await w.outbox.drainSessionMetadataSnapshots()
+    // The drain resolved, but nothing committed: a replay now would be dropped by the CP.
+    expect(w.sync).toHaveBeenCalledTimes(1)
+    expect(w.committed).not.toHaveBeenCalled()
+
+    w.advance(60_000)
+    await w.outbox.drainSessionMetadataSnapshots()
+    expect(w.sync).toHaveBeenCalledTimes(2)
+    expect(w.committed).toHaveBeenCalledTimes(1)
+    expect(w.committed).toHaveBeenCalledWith(AGENT, SESSION)
+
+    // Nothing pending: an idle drain re-asserts nothing.
+    await w.outbox.drainSessionMetadataSnapshots()
+    expect(w.committed).toHaveBeenCalledTimes(1)
+    w.outbox.dispose()
+    await w.store.close()
+  })
+})

--- a/packages/protocol/src/frames/agent.ts
+++ b/packages/protocol/src/frames/agent.ts
@@ -574,14 +574,19 @@ export const AgentStop = z.object({
 })
 export type AgentStop = z.infer<typeof AgentStop>
 
+// Live per-session activity (§7.4): only `awaiting_permission`/`idle` are emitted today, as approvals park and settle (slack-approval-dm.md §7).
 export const AgentActivity = z.object({
-  // D→C, EVT — activity-probe (§7.4)
+  // D→C, EVT
   agentId: z.string().uuid(),
-  launchId: z.string().uuid(),
+  // Outward session id (session-concept.md §1.1) — the state is stored per session.
+  sessionId: z.string().min(1),
+  // Optional: the daemon keeps no durable launch handle; fencing reads ControlExt, not this.
+  launchId: z.string().uuid().optional(),
   state: z.enum(['thinking', 'tool_call', 'awaiting_permission', 'idle']),
   ts: z.string().datetime()
 })
 export type AgentActivity = z.infer<typeof AgentActivity>
+export type AgentActivityState = AgentActivity['state']
 
 export const AgentScopeDenied = z.object({
   // D→C, EVT — capability-scope audit (§8.1)

--- a/packages/web/src/components/console/ApprovalRequestsCard.tsx
+++ b/packages/web/src/components/console/ApprovalRequestsCard.tsx
@@ -6,6 +6,8 @@ import { decideAgentPermissionRequest, fetchAgentPermissionRequests, type AgentP
 import { MOCK_MODE } from '@/lib/data'
 import { useOrgs } from '@/lib/org-context'
 import { consoleKeys } from '@/lib/swr-keys'
+import { useOptionalNotifications } from '@/lib/notifications'
+import { approvalSourceKey } from '@/lib/approval-notifications'
 import { Button, Icon } from '@/components/ui'
 
 export function ApprovalRequestsCard({
@@ -24,6 +26,7 @@ export function ApprovalRequestsCard({
   className?: string
 }) {
   const { activeOrg } = useOrgs()
+  const notifications = useOptionalNotifications()
   const requestsKey = MOCK_MODE ? null : consoleKeys.agentPermissionRequests(activeOrg?.id, agentId)
   const {
     data: allRequests,
@@ -61,6 +64,8 @@ export function ApprovalRequestsCard({
     setDecisionError(null)
     try {
       await decideAgentPermissionRequest(agentId, request.id, decision)
+      // A decision made here needs no bell item to say so (slack-approval-dm.md §7).
+      if (request.sessionId) notifications?.markSourceRead(approvalSourceKey(request.sessionId))
       void mutate(
         (rows) =>
           rows?.map((row) =>

--- a/packages/web/src/components/console/Shell.tsx
+++ b/packages/web/src/components/console/Shell.tsx
@@ -38,6 +38,7 @@ import { NotificationProvider } from '@/lib/notifications'
 import { NotificationBell, NotificationToastContainer } from './NotificationCenter'
 import { useDaemonNotifier } from '@/lib/daemon-notifications'
 import { useSessionAccessNotifier } from '@/lib/session-access-notifier'
+import { useApprovalNotifier } from '@/lib/approval-notifier'
 import { MOBILE_NAV, MORE_ROWS, NAV_GROUPS, SECTIONS, navVisible } from './nav'
 
 // Top-level routes own the tab-bar + list app bar (no back button, bottom nav shown);
@@ -334,10 +335,20 @@ function ShellChromeInner({ children }: { children: ReactNode }) {
   const params = useParams<{ slug?: string }>()
   const { orgPath, orgs, activeOrg, setActiveOrg, loading: orgsLoading, error: orgsError } = useOrgs()
   const { openModal } = useModal()
-  const { daemons, agents, crons, allSessions, memberSets, sessionAccessSnapshot, usageAccessSnapshot } =
-    useConsoleData()
+  const {
+    daemons,
+    agents,
+    agentsLoading,
+    crons,
+    allSessions,
+    memberSets,
+    sessionAccessSnapshot,
+    usageAccessSnapshot,
+    pendingApprovalSessions
+  } = useConsoleData()
   useDaemonNotifier(daemons)
   useSessionAccessNotifier({ sessionAccessSnapshot, usageAccessSnapshot, orgPath })
+  useApprovalNotifier({ pendingApprovalSessions, agents, agentsLoading, orgPath })
   // Mobile-only chrome state: which bottom sheet is open, and the full-screen search.
   const [mobileSheet, setMobileSheet] = useState<'more' | 'org' | null>(null)
   const [mobileSearch, setMobileSearch] = useState(false)

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -398,6 +398,8 @@ export interface SessionDto {
   // Absent/null on a CP that predates session visibility — treated as 'org'
   // (matching the server-side backfill of legacy rows).
   visibility?: SessionVisibility | null
+  /** Live wait state (slack-approval-dm.md §7); absent on a CP that predates it. */
+  activityState?: SessionActivityState | null
   externalProvider?: string | null
   externalResolution?: 'pending' | 'settled' | 'invalid' | null
   triggeredBy: string | null
@@ -1391,10 +1393,22 @@ export interface SessionActivityDto {
   ts: string
 }
 
+export type SessionActivityState = 'thinking' | 'tool_call' | 'awaiting_permission' | 'idle'
+
+/** A session's live wait-state change (`session-state` SSE event, slack-approval-dm.md §7). */
+export interface SessionStateDto {
+  sessionId: string
+  agentId: string
+  state: SessionActivityState
+  ts: string
+}
+
 export interface SessionEventHandlers {
   onConnect: () => void
   onSession: () => void
   onActivity: (activity: SessionActivityDto) => void
+  /** Optional: a wait-state flip invalidates only the pending-approvals read. */
+  onState?: (state: SessionStateDto) => void
 }
 
 // Reopen the stream periodically so each cycle asks the SDK for a current OIDC
@@ -1448,6 +1462,17 @@ async function readSessionEventStream(
     const parser = createSseParser((event) => {
       if (event.event === 'session') {
         handlers.onSession()
+        return
+      }
+      if (event.event === 'session-state') {
+        try {
+          const state = (JSON.parse(event.data) as { state?: SessionStateDto }).state
+          if (state && typeof state.sessionId === 'string' && typeof state.agentId === 'string') {
+            handlers.onState?.(state)
+          }
+        } catch {
+          // A malformed optional signal is ignored; reconnect/focus refresh heals it.
+        }
         return
       }
       if (event.event !== 'session-activity') return
@@ -2220,6 +2245,26 @@ export async function fetchSessions(
     ...(page.accessSyncDegraded !== undefined ? { accessSyncDegraded: page.accessSyncDegraded } : {}),
     ...(page.accessIssues !== undefined ? { accessIssues: page.accessIssues } : {})
   }
+}
+
+/** A session parked on a human approval, as the bell needs it (slack-approval-dm.md §7). */
+export interface PendingApprovalSession {
+  sessionId: string
+  agentId: string
+  agentName: string | null
+  title: string | null
+}
+
+/** The org's sessions waiting on an approval — the bell's one cross-agent read. Flat rows, newest first. */
+export async function fetchPendingApprovalSessions(orgId?: string): Promise<PendingApprovalSession[]> {
+  const q = new URLSearchParams({ view: 'flat', activityState: 'awaiting_permission', limit: '200' })
+  const page = await apiGet<SessionListPageDto>(`${orgBase(orgId)}/sessions?${q.toString()}`)
+  return (page.sessions ?? []).map((s) => ({
+    sessionId: s.sessionId,
+    agentId: s.agentId,
+    agentName: s.agentName ?? null,
+    title: s.title
+  }))
 }
 
 /** What the key-addressed resolver answered for one conversation. */

--- a/packages/web/src/lib/approval-notifications.test.ts
+++ b/packages/web/src/lib/approval-notifications.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { approvalNotifications, approvalSourceKey } from '@/lib/approval-notifications'
+
+const orgPath = (path: string) => `/acme${path}`
+const agents = [
+  { id: 'agent-a', name: 'Butler', canEdit: true },
+  { id: 'agent-b', name: 'Viewer-only', canEdit: false }
+]
+
+describe('approvalNotifications (slack-approval-dm.md §7)', () => {
+  it('projects an editable agent’s waiting session into one unread, deep-linked item', () => {
+    const [item, ...rest] = approvalNotifications(
+      [{ sessionId: 's/1', agentId: 'agent-a', agentName: 'Butler', title: 'Roll out api@1.4.2' }],
+      agents,
+      orgPath
+    )
+    expect(rest).toEqual([])
+    expect(item).toMatchObject({
+      category: 'approval',
+      severity: 'warning',
+      sourceKey: approvalSourceKey('s/1'),
+      title: 'Approval needed',
+      message: 'Butler is waiting for permission in “Roll out api@1.4.2”.',
+      action: { label: 'Open session', href: '/acme/sessions/s%2F1', external: false },
+      resolution: { title: 'Approval resolved', read: true }
+    })
+  })
+
+  it('drops sessions of agents the viewer cannot edit, and unknown agents', () => {
+    expect(
+      approvalNotifications(
+        [
+          { sessionId: 's1', agentId: 'agent-b', agentName: null, title: null },
+          { sessionId: 's2', agentId: 'agent-gone', agentName: 'Ghost', title: null }
+        ],
+        agents,
+        orgPath
+      )
+    ).toEqual([])
+  })
+
+  it('falls back to the roster name and omits the title clause when the row has neither', () => {
+    const [item] = approvalNotifications(
+      [{ sessionId: 's1', agentId: 'agent-a', agentName: '  ', title: '' }],
+      agents,
+      orgPath
+    )
+    expect(item?.message).toBe('Butler is waiting for permission.')
+    expect(item?.resolution?.message).toBe('Butler is no longer waiting for permission.')
+  })
+})

--- a/packages/web/src/lib/approval-notifications.ts
+++ b/packages/web/src/lib/approval-notifications.ts
@@ -1,0 +1,50 @@
+import type { PendingApprovalSession } from '@/lib/api'
+import type { NotificationSnapshotInput } from '@/lib/notifications'
+
+/** One bell item per waiting session (slack-approval-dm.md §7). */
+export function approvalSourceKey(sessionId: string): string {
+  return `approval:${sessionId}`
+}
+
+/** The agents whose approvals the viewer may act on — the same `canEdit` the decision route enforces. */
+export interface ApprovalAgentView {
+  id: string
+  name: string
+  canEdit: boolean
+}
+
+// The bell is a "you can act" signal: sessions of agents the viewer cannot edit are dropped, not shown read-only.
+// Resolution text is fixed here — the browser never learns who decided or how; that stays on the approval card (§7).
+export function approvalNotifications(
+  pending: readonly PendingApprovalSession[],
+  agents: readonly ApprovalAgentView[],
+  orgPath: (path: string) => string
+): NotificationSnapshotInput[] {
+  const editable = new Map(agents.filter((agent) => agent.canEdit).map((agent) => [agent.id, agent]))
+  const items: NotificationSnapshotInput[] = []
+  for (const session of pending) {
+    const agent = editable.get(session.agentId)
+    if (!agent) continue
+    const agentName = session.agentName?.trim() || agent.name
+    const where = session.title?.trim() ? ` in “${session.title.trim()}”` : ''
+    items.push({
+      category: 'approval',
+      severity: 'warning',
+      sourceKey: approvalSourceKey(session.sessionId),
+      title: 'Approval needed',
+      message: `${agentName} is waiting for permission${where}.`,
+      action: {
+        label: 'Open session',
+        href: orgPath(`/sessions/${encodeURIComponent(session.sessionId)}`),
+        external: false
+      },
+      resolution: {
+        title: 'Approval resolved',
+        message: `${agentName} is no longer waiting for permission${where}.`,
+        severity: 'info',
+        read: true
+      }
+    })
+  }
+  return items
+}

--- a/packages/web/src/lib/approval-notifier.ts
+++ b/packages/web/src/lib/approval-notifier.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect } from 'react'
+import type { PendingApprovalSession } from '@/lib/api'
+import { approvalNotifications, type ApprovalAgentView } from '@/lib/approval-notifications'
+import { useNotifications } from '@/lib/notifications'
+
+interface ApprovalNotifierInputs {
+  /** The org's waiting sessions; null until the first pull settles (or in mock mode). */
+  pendingApprovalSessions: readonly PendingApprovalSession[] | null
+  agents: readonly ApprovalAgentView[]
+  /** While the agent roster is loading, an empty roster must not resolve every item. */
+  agentsLoading: boolean
+  orgPath: (path: string) => string
+}
+
+/** Keep the bell's `approvals` scope equal to the sessions the viewer can act on (slack-approval-dm.md §7). */
+export function useApprovalNotifier({
+  pendingApprovalSessions,
+  agents,
+  agentsLoading,
+  orgPath
+}: ApprovalNotifierInputs) {
+  const { syncSourceSnapshot } = useNotifications()
+  useEffect(() => {
+    if (!pendingApprovalSessions || agentsLoading) return
+    syncSourceSnapshot('approvals', approvalNotifications(pendingApprovalSessions, agents, orgPath))
+  }, [pendingApprovalSessions, agents, agentsLoading, orgPath, syncSourceSnapshot])
+}

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -100,6 +100,8 @@ import {
   withDaemonCapability,
   type DaemonCapabilityDto,
   fetchSessionFacets,
+  fetchPendingApprovalSessions,
+  type PendingApprovalSession,
   subscribeSessionEvents,
   fetchCrons,
   fetchUsage,
@@ -207,6 +209,8 @@ interface ConsoleData {
   /** Trustworthy unfiltered access snapshots; null while loading, validating, failed, or absent on an older server. */
   sessionAccessSnapshot: AccessNotificationSnapshot | null
   usageAccessSnapshot: AccessNotificationSnapshot | null
+  /** Sessions waiting on a human approval (slack-approval-dm.md §7); null until loaded or in mock mode. */
+  pendingApprovalSessions: PendingApprovalSession[] | null
   /** Resolve an agent by id; undefined for an unknown id (live console, no demo fallback). */
   getAgent: (id: string) => Agent | undefined
   getSessions: (id: string) => Session[]
@@ -869,6 +873,12 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
     isLoading: membersIsLoading,
     mutate: mutateMembers
   } = useSWR<MemberDto[]>(MOCK_MODE ? null : consoleKeys.members(orgKey), ([, orgId]) => fetchMembers(orgId as string))
+  // No interval: the SSE `session-state` event and the reconnect revalidation are the only triggers.
+  const { data: pendingApprovalSessionsData, mutate: mutatePendingApprovals } = useSWR<PendingApprovalSession[]>(
+    MOCK_MODE ? null : consoleKeys.pendingApprovals(orgKey),
+    ([, orgId]) => fetchPendingApprovalSessions(orgId as string)
+  )
+  const pendingApprovalSessions = pendingApprovalSessionsData ?? null
   const {
     data: usage24hData,
     error: usage24hError,
@@ -904,7 +914,10 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
         Array.isArray(key) &&
         ((key[0] === 'console' &&
           key[1] === orgKey &&
-          (key[2] === 'sessions' || key[2] === 'session-facets' || key[2] === 'session-detail')) ||
+          (key[2] === 'sessions' ||
+            key[2] === 'session-facets' ||
+            key[2] === 'session-detail' ||
+            key[2] === 'session-approvals')) ||
           (key[0] === 'conversation-by-key' && key[1] === orgKey))
     )
   }, [mutateCache, orgKey])
@@ -991,7 +1004,8 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
         setSessionActivityVersionById((current) => ({
           ...current,
           [sessionId]: (current[sessionId] ?? 0) + 1
-        }))
+        })),
+      onState: () => void mutatePendingApprovals()
     })
     return () => {
       sessionRefreshGenerationRef.current++
@@ -1002,7 +1016,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
         sessionRefreshTimerRef.current = null
       }
     }
-  }, [orgLoading, activeOrg?.id, drainSessionRefreshes])
+  }, [orgLoading, activeOrg?.id, drainSessionRefreshes, mutatePendingApprovals])
 
   const members = MOCK_MODE ? MOCK_MEMBERS : (fetchedMembers ?? [])
   const membersLoaded = MOCK_MODE || fetchedMembers !== undefined
@@ -1632,6 +1646,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       usage24h,
       sessionAccessSnapshot,
       usageAccessSnapshot,
+      pendingApprovalSessions,
       getAgent,
       getSessions,
       createAgent,
@@ -1713,6 +1728,7 @@ export function ConsoleDataProvider({ children }: { children: ReactNode }) {
       usage24h,
       sessionAccessSnapshot,
       usageAccessSnapshot,
+      pendingApprovalSessions,
       getAgent,
       getSessions,
       createAgent,

--- a/packages/web/src/lib/notifications.test.tsx
+++ b/packages/web/src/lib/notifications.test.tsx
@@ -39,6 +39,49 @@ function memoryStorage() {
 }
 
 describe('syncNotificationSourceSnapshot', () => {
+  it('applies the item’s own resolution text and read flip when its source vanishes', () => {
+    const approval = {
+      category: 'approval' as const,
+      severity: 'warning' as const,
+      sourceKey: 'approval:s1',
+      title: 'Approval needed',
+      message: 'Butler is waiting for permission.',
+      action: { label: 'Open session', href: '/acme/sessions/s1', external: false },
+      resolution: {
+        title: 'Approval resolved',
+        message: 'Butler is no longer waiting.',
+        severity: 'info' as const,
+        read: true
+      }
+    }
+    const pending = syncNotificationSourceSnapshot(
+      emptyNotificationState(),
+      'approvals',
+      [approval],
+      '2026-08-06T01:00:00.000Z',
+      () => 'approval-1'
+    )
+    expect(pending.added).toHaveLength(1)
+    expect(pending.state.notifications[0]).toMatchObject({ read: false, title: 'Approval needed' })
+
+    const resolved = syncNotificationSourceSnapshot(pending.state, 'approvals', [], '2026-08-06T02:00:00.000Z')
+    expect(resolved.added).toEqual([])
+    expect(resolved.state.notifications[0]).toMatchObject({
+      id: 'approval-1',
+      read: true,
+      severity: 'info',
+      title: 'Approval resolved',
+      message: 'Butler is no longer waiting.',
+      resolvedAt: '2026-08-06T02:00:00.000Z'
+    })
+    expect(resolved.state.notifications[0]?.action).toBeUndefined()
+    expect(resolved.state.activeSources.approvals).toEqual([])
+    // The other scopes keep the original behavior: a vanished source only gains `resolvedAt`.
+    const access = syncNotificationSourceSnapshot(emptyNotificationState(), 'sessions-access', [quotaItem])
+    const accessResolved = syncNotificationSourceSnapshot(access.state, 'sessions-access', [])
+    expect(accessResolved.state.notifications[0]).toMatchObject({ read: false, title: quotaItem.title })
+  })
+
   it('adds once, then updates the active row without changing read state or timestamp', () => {
     const first = syncNotificationSourceSnapshot(
       emptyNotificationState(),

--- a/packages/web/src/lib/notifications.tsx
+++ b/packages/web/src/lib/notifications.tsx
@@ -1,14 +1,21 @@
 'use client'
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
-import type {
-  SessionAccessNotificationAction,
-  SessionAccessNotificationInput
-} from '@/lib/session-access-notifications'
+import type { SessionAccessNotificationAction } from '@/lib/session-access-notifications'
 
 export type NotificationSeverity = 'info' | 'success' | 'warning' | 'error'
-export type NotificationCategory = 'daemon_lifecycle' | 'session_retention' | 'session_access'
-export type NotificationSourceScope = 'sessions-access' | 'usage-access'
+export type NotificationCategory = 'daemon_lifecycle' | 'session_retention' | 'session_access' | 'approval'
+export type NotificationSourceScope = 'sessions-access' | 'usage-access' | 'approvals'
+const SOURCE_SCOPES: readonly NotificationSourceScope[] = ['sessions-access', 'usage-access', 'approvals']
+
+/** What a snapshot item becomes once its source vanishes; absent ⇒ it keeps its text and read state and only gains `resolvedAt`. */
+export interface NotificationResolution {
+  title: string
+  message: string
+  severity?: NotificationSeverity
+  /** Flip to read on resolution — for an item whose only job was to get someone to act. */
+  read?: boolean
+}
 
 export interface NotificationItem {
   id: string
@@ -20,9 +27,15 @@ export interface NotificationItem {
   daemonName?: string
   sourceKey?: string
   action?: SessionAccessNotificationAction
+  resolution?: NotificationResolution
   resolvedAt?: string
   timestamp: string
   read: boolean
+}
+
+/** One active condition in a snapshot scope, keyed by `sourceKey`; the reconciler mints the rest. */
+export type NotificationSnapshotInput = Omit<NotificationItem, 'id' | 'timestamp' | 'read' | 'resolvedAt'> & {
+  sourceKey: string
 }
 
 export interface NotificationStoreState {
@@ -38,8 +51,10 @@ interface NotificationContextValue {
   unreadCount: number
   toasts: NotificationItem[]
   addNotification: (item: AddNotificationInput) => void
-  syncSourceSnapshot: (scope: NotificationSourceScope, items: SessionAccessNotificationInput[]) => void
+  syncSourceSnapshot: (scope: NotificationSourceScope, items: NotificationSnapshotInput[]) => void
   markAsRead: (id: string) => void
+  /** Mark every item of one snapshot source read — for a resolution the user made themselves. */
+  markSourceRead: (sourceKey: string) => void
   markAllAsRead: () => void
   clearAll: () => void
   dismissToast: (id: string) => void
@@ -64,10 +79,7 @@ function browserStorage(storage?: NotificationStorage): NotificationStorage | un
 export function emptyNotificationState(): NotificationStoreState {
   return {
     notifications: [],
-    activeSources: {
-      'sessions-access': [],
-      'usage-access': []
-    }
+    activeSources: { 'sessions-access': [], 'usage-access': [], approvals: [] }
   }
 }
 
@@ -80,16 +92,14 @@ export function loadNotificationState(orgId?: string | null, storage?: Notificat
     const history = historyRaw ? (JSON.parse(historyRaw) as unknown) : []
     const active = activeRaw ? (JSON.parse(activeRaw) as unknown) : {}
     const activeRecord = active && typeof active === 'object' ? (active as Record<string, unknown>) : {}
+    const activeSources = emptyNotificationState().activeSources
+    for (const scope of SOURCE_SCOPES) {
+      const keys = activeRecord[scope]
+      if (Array.isArray(keys)) activeSources[scope] = keys.filter((key): key is string => typeof key === 'string')
+    }
     return {
       notifications: Array.isArray(history) ? (history as NotificationItem[]).slice(0, MAX_NOTIFICATIONS) : [],
-      activeSources: {
-        'sessions-access': Array.isArray(activeRecord['sessions-access'])
-          ? activeRecord['sessions-access'].filter((key): key is string => typeof key === 'string')
-          : [],
-        'usage-access': Array.isArray(activeRecord['usage-access'])
-          ? activeRecord['usage-access'].filter((key): key is string => typeof key === 'string')
-          : []
-      }
+      activeSources
     }
   } catch {
     return emptyNotificationState()
@@ -121,7 +131,7 @@ function defaultNotificationId(): string {
 export function syncNotificationSourceSnapshot(
   state: NotificationStoreState,
   scope: NotificationSourceScope,
-  items: SessionAccessNotificationInput[],
+  items: NotificationSnapshotInput[],
   now = new Date().toISOString(),
   makeId: () => string = defaultNotificationId
 ): { state: NotificationStoreState; added: NotificationItem[] } {
@@ -162,7 +172,19 @@ export function syncNotificationSourceSnapshot(
     const index = notifications.findIndex((item) => item.sourceKey === sourceKey && !item.resolvedAt)
     if (index >= 0) {
       const { action: _action, ...current } = notifications[index]!
-      notifications[index] = { ...current, resolvedAt: now }
+      const resolution = current.resolution
+      notifications[index] = {
+        ...current,
+        resolvedAt: now,
+        ...(resolution
+          ? {
+              title: resolution.title,
+              message: resolution.message,
+              ...(resolution.severity ? { severity: resolution.severity } : {}),
+              ...(resolution.read ? { read: true } : {})
+            }
+          : {})
+      }
     }
   }
 
@@ -225,7 +247,7 @@ export function NotificationProvider({ orgId, children }: { orgId?: string | nul
     }))
   }, [])
 
-  const syncSourceSnapshot = useCallback((scope: NotificationSourceScope, items: SessionAccessNotificationInput[]) => {
+  const syncSourceSnapshot = useCallback((scope: NotificationSourceScope, items: NotificationSnapshotInput[]) => {
     setProviderState((prev) => {
       const nextKeys = new Set(items.map((item) => item.sourceKey))
       const resolvedKeys = new Set(prev.store.activeSources[scope].filter((key) => !nextKeys.has(key)))
@@ -255,6 +277,19 @@ export function NotificationProvider({ orgId, children }: { orgId?: string | nul
     }))
   }, [])
 
+  const markSourceRead = useCallback((sourceKey: string) => {
+    setProviderState((prev) => ({
+      ...prev,
+      store: {
+        ...prev.store,
+        notifications: prev.store.notifications.map((item) =>
+          item.sourceKey === sourceKey && !item.read ? { ...item, read: true } : item
+        )
+      },
+      toasts: prev.toasts.filter((toast) => toast.sourceKey !== sourceKey)
+    }))
+  }, [])
+
   const markAllAsRead = useCallback(() => {
     setProviderState((prev) => ({
       ...prev,
@@ -280,6 +315,7 @@ export function NotificationProvider({ orgId, children }: { orgId?: string | nul
       addNotification,
       syncSourceSnapshot,
       markAsRead,
+      markSourceRead,
       markAllAsRead,
       clearAll,
       dismissToast
@@ -291,6 +327,7 @@ export function NotificationProvider({ orgId, children }: { orgId?: string | nul
       addNotification,
       syncSourceSnapshot,
       markAsRead,
+      markSourceRead,
       markAllAsRead,
       clearAll,
       dismissToast
@@ -306,4 +343,9 @@ export function useNotifications(): NotificationContextValue {
     throw new Error('useNotifications must be used within a NotificationProvider')
   }
   return ctx
+}
+
+/** The notification center if one is mounted — for a component that also renders without the shell. */
+export function useOptionalNotifications(): NotificationContextValue | null {
+  return useContext(NotificationContext)
 }

--- a/packages/web/src/lib/swr-keys.ts
+++ b/packages/web/src/lib/swr-keys.ts
@@ -118,6 +118,8 @@ export const consoleKeys = {
     consoleKey(orgId, 'gitlab-accounts', bindings),
   agentPermissionRequests: (orgId: string | null | undefined, agentId: string | null | undefined) =>
     agentId ? consoleKey(orgId, 'agent-permission-requests', agentId) : null,
+  /** The org's sessions waiting on an approval — the bell's feed (slack-approval-dm.md §7). */
+  pendingApprovals: (orgId: string | null | undefined) => consoleKey(orgId, 'session-approvals'),
   hookRuns: (orgId: string | null | undefined, hookId: string) => consoleKey(orgId, 'hook-runs', hookId)
 }
 


### PR DESCRIPTION
Closes #1704.

The notification bell shows a session waiting on a human approval as an **unread** "Approval needed" item and flips it to a **read** "Approval resolved" item when the wait ends. The console had no cross-agent pending signal, so this revives the protocol's dead `agent/activity` frame end to end. Design recorded in [slack-approval-dm.md §7](docs/designs/slack-approval-dm.md#7-console-notification-states), rewritten in place.

## Scope
Narrower than the issue's original wording, by decision recorded on the issue: the resolved item carries **no decider name and no decision** (the CP never sees them, and the browser makes no per-agent lookup). Expired waits render the same resolved item. The decider stays on the approval cards. The session list shows no marker.

## Changes
- **protocol**: `agent/activity` gains a required outward `sessionId`; `launchId` becomes optional. Only `awaiting_permission`/`idle` are emitted; `thinking`/`tool_call` stay declared but unemitted.
- **daemon**: `PermissionCoordinator` re-derives the session's wait state after every pending-map write and emits only on a flip — first park ⇒ `awaiting_permission`, last settle ⇒ `idle` — across editor-path permissions, editor-path elicitations, and in-conversation chat cards. Live waits are re-asserted from the coordinator's in-memory set on every (re)connect. Emits are serialized so two flips on one session reach the CP in order.
- **control-plane**: new `agent/activity` handler persists `SessionMeta.activityState` (fenced through `runForReportingAgent`) and publishes a `session-state` SSE event. Waits are reset to `idle` when the daemon's connection closes (guarded so a stale close cannot clobber a reconnected daemon) and on the session `end` milestone. `GET /sessions` accepts `activityState=…`; `SessionDto` carries `activityState`.
- **web**: one shell-wide SWR read of `?view=flat&activityState=awaiting_permission`, revalidated on `session-state` and on stream reconnect, no interval. Client-side filter to agents with `canEdit` (the predicate the decision route enforces). New client-local `approval` category driven by the snapshot reconciler, which now supports a per-item `resolution` (text, severity, read flip) applied when the source vanishes. Pending ⇒ unread + toast, deep-link to the session page; resolved ⇒ read "Approval resolved". A decision made from the current tab marks its item read immediately.

## Tests
- daemon: `approval-dm.test.ts` — flip semantics across parallel requests, cancel release, replay of live waits only.
- control-plane: `session-activity-state.route.test.ts` (integration) — persist/list/publish/clear, foreign-daemon and unknown-session frames dropped, end-milestone reset, per-daemon disconnect clear. Fencing fixture and two route unit fixtures updated for the new field.
- web: reconciler resolution test, `approval-notifications` projection tests.

`typecheck` green on protocol, daemon, control-plane, web. CP unit + integration suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
