### PR TITLE
fix(daemon): carve back the host executable a runtime hint points at

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -29,6 +29,7 @@ import {
   type ClaudeProtectedSettings,
   ULTRACODE_EFFORT
 } from '../runtime-defs/claude-runtime.js'
+import { runtimeExecutableHints } from '../runtime-defs/executable-hints.js'
 import {
   LocalDriver,
   type AcpSandboxLaunch,
@@ -601,18 +602,9 @@ export class AcpHost {
     }
   ) {}
 
-  /** A Claude Code runtime (its command/args reference `claude`) — these embed the
-   *  @anthropic-ai/claude-agent-sdk, which needs a Claude Code executable. The one
-   *  predicate lives in claude-runtime.ts, shared with the model-catalog path. */
+  /** A Claude Code runtime — the one predicate lives in claude-runtime.ts, shared with the model-catalog path. */
   private isClaudeRuntime(): boolean {
     return isClaudeRuntimeDef(this.runtime)
-  }
-
-  /** codex-acp accepts CODEX_PATH to reuse the operator-installed Codex CLI instead of its bundled fallback. */
-  private isCodexRuntime(): boolean {
-    return [this.runtime.command, ...this.runtime.args].some((part) =>
-      /(?:^|[\\/@])codex-acp(?:@[^\\/]*)?$/i.test(part)
-    )
   }
 
   async start(): Promise<void> {
@@ -652,19 +644,12 @@ export class AcpHost {
     // --disable-builtin-mcps) that must reach the adapter as CLI args.
     const spawnArgs = [...this.runtime.args, ...(isolateAccountApps ? appIsolation.appendArgs : [])]
     const driver = this.opts.driver ?? new LocalDriver({ log: this.opts.log })
-    const hints = [
-      ...(this.isClaudeRuntime() ? [{ envVar: 'CLAUDE_CODE_EXECUTABLE', command: 'claude' }] : []),
-      ...(this.isCodexRuntime() ? [{ envVar: 'CODEX_PATH', command: 'codex' }] : [])
-    ]
+    const hints = runtimeExecutableHints(this.runtime)
     const spawned = await driver.launch({
       command: this.runtime.command,
       args: spawnArgs,
       env: env as Record<string, string>,
-      // The claude-agent-sdk resolves the Claude Code binary from its own bundled
-      // native package (an OPTIONAL npm dep, often missing under npx / --omit=optional)
-      // OR from `CLAUDE_CODE_EXECUTABLE`. If nothing set it but a `claude` CLI is on
-      // PATH, point at it so an out-of-the-box Claude Code install just works. The
-      // lookup belongs to the driver: only it knows the filesystem the runtime sees.
+      // Resolving a hint belongs to the driver: only it knows the filesystem the runtime sees.
       ...(hints.length > 0 ? { hints } : {}),
       ...(this.opts.files?.length ? { files: this.opts.files } : {}),
       ...(this.opts.suppressChildStderr !== undefined ? { suppressChildStderr: this.opts.suppressChildStderr } : {}),

--- a/packages/daemon/src/launch/compose.ts
+++ b/packages/daemon/src/launch/compose.ts
@@ -22,6 +22,7 @@ import {
 import { MemoryProviderUnavailableError, type MemoryProviderKind } from '../memory/provider.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { CLAUDE_PROFILE_ENV, isClaudeRuntimeDef } from '../runtime-defs/claude-runtime.js'
+import { runtimeExecutableHints } from '../runtime-defs/executable-hints.js'
 import { resolveCommandPath } from '../runtimes/probe.js'
 import { resolveTrustedExecutable, trustedRuntimeReadRoots } from '../runtimes/read-roots.js'
 
@@ -33,23 +34,26 @@ export interface ComposedRuntimeLaunch {
 export function runtimeSandboxReadRoots(
   runtime: RuntimeDef,
   stateSourceEnv: NodeJS.ProcessEnv = process.env
-): { readRoots: string[]; runtimeExecutable: string; claudeExecutable?: string } {
+): { readRoots: string[]; runtimeExecutable: string; hintExecutables: Record<string, string> } {
   const trustedRuntimeEnv: NodeJS.ProcessEnv = {
     ...stateSourceEnv,
     ...Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
   }
-  const claudeCommand = isClaudeRuntimeDef(runtime)
-    ? trustedRuntimeEnv.CLAUDE_CODE_EXECUTABLE || resolveCommandPath('claude', trustedRuntimeEnv)
-    : undefined
-  const claudeExecutable = claudeCommand ? resolveTrustedExecutable(claudeCommand, trustedRuntimeEnv) : undefined
+  // A hint resolves against the host PATH, so carve it back or the child spawns a path the sandbox hides.
+  const hintCommands = runtimeExecutableHints(runtime).flatMap(({ envVar, command }) => {
+    const effective = trustedRuntimeEnv[envVar] || resolveCommandPath(command, trustedRuntimeEnv)
+    return effective ? [{ envVar, command: effective }] : []
+  })
   return {
     readRoots: trustedRuntimeReadRoots({
       runtime,
       hostEnv: stateSourceEnv,
-      ...(claudeCommand ? { executableCommands: [claudeCommand] } : {})
+      executableCommands: hintCommands.map(({ command }) => command)
     }),
     runtimeExecutable: resolveTrustedExecutable(runtime.command, trustedRuntimeEnv),
-    ...(claudeExecutable ? { claudeExecutable } : {})
+    hintExecutables: Object.fromEntries(
+      hintCommands.map(({ envVar, command }) => [envVar, resolveTrustedExecutable(command, trustedRuntimeEnv)])
+    )
   }
 }
 
@@ -201,8 +205,9 @@ export function composeRuntimeLaunch(opts: {
     allowModelToolUnixSockets: opts.allowModelToolUnixSockets,
     ...(opts.hostPackageCache ? { hostPackageCache: true as const } : {})
   })
-  if (sandboxAccess?.claudeExecutable && !launch.env.CLAUDE_CODE_EXECUTABLE) {
-    launch.env.CLAUDE_CODE_EXECUTABLE = sandboxAccess.claudeExecutable
+  // Pin each carved-back executable so the child never resolves a hint to a path outside the sandbox.
+  for (const [envVar, executable] of Object.entries(sandboxAccess?.hintExecutables ?? {})) {
+    if (!launch.env[envVar]) launch.env[envVar] = executable
   }
   const composed: RuntimeDef = {
     ...opts.runtime,

--- a/packages/daemon/src/runtime-defs/executable-hints.ts
+++ b/packages/daemon/src/runtime-defs/executable-hints.ts
@@ -1,0 +1,23 @@
+import type { RuntimeDef } from '../config/config-schema.js'
+import { isClaudeRuntimeDef } from './claude-runtime.js'
+
+/** An env pointer at a host executable the adapter needs, resolved by whoever knows its filesystem. */
+export interface RuntimeExecutableHint {
+  envVar: string
+  command: string
+}
+
+/** A codex-acp runtime (its command/args reference `codex-acp`), including the managed npx fork. */
+function isCodexRuntimeDef(runtime: RuntimeDef): boolean {
+  return [runtime.command, ...runtime.args].some((part) => /(?:^|[\\/@])codex-acp(?:@[^\\/]*)?$/i.test(part))
+}
+
+/** The hints a runtime accepts, shared so the sandbox carves back exactly the executables a launch injects. */
+export function runtimeExecutableHints(runtime: RuntimeDef): RuntimeExecutableHint[] {
+  return [
+    // The claude-agent-sdk finds its CLI in a bundled OPTIONAL npm dep (often absent under npx) or here.
+    ...(isClaudeRuntimeDef(runtime) ? [{ envVar: 'CLAUDE_CODE_EXECUTABLE', command: 'claude' }] : []),
+    // codex-acp reuses an installed Codex CLI at CODEX_PATH instead of its bundled fallback.
+    ...(isCodexRuntimeDef(runtime) ? [{ envVar: 'CODEX_PATH', command: 'codex' }] : [])
+  ]
+}

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -682,8 +682,38 @@ describe('composeRuntimeLaunch', () => {
         PATH: `${bin}${delimiter}${dirname(process.execPath)}`
       })
 
-      expect(sandboxAccess.claudeExecutable).toBe(realpathSync(executable))
+      expect(sandboxAccess.hintExecutables.CLAUDE_CODE_EXECUTABLE).toBe(realpathSync(executable))
       expect(coveredBy(sandboxAccess.readRoots, join(bin, 'claude'))).toBe(true)
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true })
+    }
+  })
+
+  // Issue #1689: CODEX_PATH pointed the sandboxed adapter at a global npm install the HOME deny hid.
+  it('keeps a Codex executable hint under the host HOME readable', () => {
+    const testRoot = mkdtempSync(join(tmpdir(), 'ac-codex-launch-roots-'))
+    const hostHome = join(testRoot, 'home')
+    const bin = join(hostHome, '.npm-global', 'bin')
+    const pkg = join(hostHome, '.npm-global', 'lib', 'node_modules', '@openai', 'codex')
+    const executable = join(pkg, 'bin', 'codex.js')
+    mkdirSync(bin, { recursive: true })
+    mkdirSync(dirname(executable), { recursive: true })
+    writeFileSync(join(pkg, 'package.json'), '{"name":"@openai/codex"}')
+    writeFileSync(executable, '#!/usr/bin/env node\n')
+    chmodSync(executable, 0o755)
+    symlinkSync(executable, join(bin, 'codex'))
+
+    try {
+      const sandboxAccess = runtimeSandboxReadRoots(
+        runtime(process.execPath, ['-y', '@agentconnect.md/codex-acp@agentconnect']),
+        {
+          HOME: hostHome,
+          PATH: [bin, dirname(process.execPath)].join(delimiter)
+        }
+      )
+
+      expect(sandboxAccess.hintExecutables.CODEX_PATH).toBe(realpathSync(executable))
+      expect(coveredBy(sandboxAccess.readRoots, join(bin, 'codex'))).toBe(true)
     } finally {
       rmSync(testRoot, { recursive: true, force: true })
     }


### PR DESCRIPTION
## The bug

A sandboxed `codex-acp` runtime probe always failed with `ACP connection closed`, so the runtime was stored with no models and the console disabled the model selector. The probe is sandboxed whenever a mechanism exists (`runtimes/facts-registry.ts`, `runInSandbox: launch.sandboxMechanism !== undefined`).

The credential carve-back was never the problem. `AcpHost.start()` emits a `CODEX_PATH` hint, and `LocalDriver` (`acp/spawn-driver.ts`) resolves it against the **host** PATH — yielding a path under the host HOME, such as a global npm install at `/home/agent/.npm-global/bin/codex`. The sandbox hides that with its broad deny-read.

Nothing added it back. `runtimeSandboxReadRoots` (`launch/compose.ts`) turned a hint executable into a trusted read carve-back **only for Claude** (`claudeCommand` → `resolveTrustedExecutable`); there was no Codex branch. So inside the jail the adapter honored `CODEX_PATH` and crashed:

```
Error: spawn /home/agent/.npm-global/bin/codex ENOENT
```

The probe runs with `suppressChildStderr: true`, so a plain ENOENT surfaced only as the generic `ACP connection closed`. That asymmetry is also why `claude-acp` probes fine sandboxed on the same host while `codex-acp` never does.

## The fix

Extract the executable-hint definitions (`CLAUDE_CODE_EXECUTABLE`/`claude`, `CODEX_PATH`/`codex`) into one shared module, `packages/daemon/src/runtime-defs/executable-hints.ts`, and have both sides read it:

- `AcpHost` builds its `hints` from `runtimeExecutableHints(runtime)` instead of an inline list.
- `runtimeSandboxReadRoots` derives its `executableCommands` from the same definitions, and returns `hintExecutables` (a `Record<envVar, canonical path>`) in place of the single `claudeExecutable`. `composeRuntimeLaunch` pins each one into the launch env when unset.

So the host Codex installation behind `CODEX_PATH` becomes readable without reopening the host HOME — `trustedRuntimeReadRoots`'s existing `nearestPackageRoot`/`nodeInstallationRoot` logic already collapses a global npm tree to one auditable root. The credential carve-back is untouched.

The point of routing both sides through one definition is that the gap closes by construction: any future hint is carved back and pinned automatically, rather than depending on someone remembering to add a second branch in a second file.

## Test

`packages/daemon/test/runtime-launch.test.ts` gains a regression test building a global npm Codex install beneath a fixture HOME (`.npm-global/bin/codex` → `.npm-global/lib/node_modules/@openai/codex/bin/codex.js`) and asserting both that `hintExecutables.CODEX_PATH` resolves to the real executable and that the read roots cover it.

**Mutation-checked**: restricting the hint list back to `CLAUDE_CODE_EXECUTABLE` (the pre-fix behavior) makes exactly this new test fail — `expected undefined to be '…/codex.js'` — while the existing Claude carve-back test still passes. Restoring the fix returns all 32 to green.

## What was and was not verified

Verified locally: `tsc -p tsconfig.typecheck.json --noEmit` clean; `runtime-launch` (32), `acp-host` (52) and `spawn-driver` (8) suites green; prettier and eslint clean on the four touched files. `spawn-driver`'s existing assertions on the hints `AcpHost` emits still pass unchanged, which is the check that the extraction is behavior-preserving on the spawn side.

**Not verified here:** this was developed on macOS, which has no bwrap, so the real Linux sandbox was not exercised. The evidence for the end-to-end behavior is the issue author's one-variable A/B run through the daemon's own sandbox provider on Linux — adding the Codex install root to `allowRead` takes the probe from `spawn … ENOENT` to a successful `initialize` plus a full model catalog. My own evidence is the unit test above plus the code reading; I have not reproduced the jail behavior.

## Notes

- The change originated in an agent session on the issue that could not commit (its sandbox refused every Git write); it has been carried over and rebased onto current `main`.
- One deliberate deviation from that draft: it resolved a configured `CLAUDE_CODE_EXECUTABLE`/`CODEX_PATH` through `resolveCommandPath` and silently dropped the hint when that failed. The pre-existing Claude branch instead passed the configured value straight to `resolveTrustedExecutable`, which **throws** when the executable is missing. This PR keeps that fail-fast, so a misconfigured pointer still refuses the launch with `trusted runtime executable is not available: …` rather than degrading into the very ENOENT-behind-suppressed-stderr failure this issue is about.
- The issue's second suggestion — surfacing the sandboxed probe child's exit code and stderr tail, and reporting `authRequired` distinctly — is a diagnosability change with a wider blast radius and is deliberately left out of this fix.

Closes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)
