### PR TITLE
fix(daemon): keep Git's config readable and open the worktrees subtree in the Codex profile

### DIFF
--- a/packages/daemon/src/acp/codex-permission-profiles.ts
+++ b/packages/daemon/src/acp/codex-permission-profiles.ts
@@ -69,12 +69,15 @@ export function codexPermissionProfileConfig(
           )}`
         ]
       : []
-  // A writable hooks/config would run model-authored code under host-side Git; most-specific match wins.
+  // Most-specific match wins. `read` on hooks/config: `deny` also hides them, and Git cannot run at
+  // all without reading its config. `worktrees/**`: Codex's :workspace pins a session worktree's own
+  // admin dir read-only at a depth the parent grant cannot reach, so the subtree is named explicitly.
   const agentFilesystemEntries: Array<[string, string]> = [
     ...writableGitMetadataRoots.map((root): [string, string] => [root, 'write']),
     ...writableGitMetadataRoots.flatMap((root): Array<[string, string]> => [
-      [join(root, 'hooks'), 'deny'],
-      [join(root, 'config'), 'deny']
+      [join(root, 'worktrees', '**'), 'write'],
+      [join(root, 'hooks'), 'read'],
+      [join(root, 'config'), 'read']
     ]),
     ...protectedRoots.map((root): [string, string] => [root, 'deny'])
   ]

--- a/packages/daemon/test/codex-permission-profiles.test.ts
+++ b/packages/daemon/test/codex-permission-profiles.test.ts
@@ -61,7 +61,8 @@ describe.skipIf(process.platform === 'win32')('Codex permission profile launch c
     expect(config.configOverrides).toContain('features.unified_exec=false')
     expect(config.configOverrides).toContain(
       'permissions.agentconnect-protected-workspace.filesystem={ "/agent/workspace/.git" = "write", ' +
-        '"/agent/workspace/.git/hooks" = "deny", "/agent/workspace/.git/config" = "deny", ' +
+        '"/agent/workspace/.git/worktrees/**" = "write", ' +
+        '"/agent/workspace/.git/hooks" = "read", "/agent/workspace/.git/config" = "read", ' +
         '"/agent/home/.codex" = "deny" }'
     )
     expect(
@@ -71,8 +72,10 @@ describe.skipIf(process.platform === 'win32')('Codex permission profile launch c
     ).not.toContain('/agent/workspace/.git')
   })
 
-  // Verified against the vendored Codex: without the nested deny a shell command can plant a Git hook.
-  it('denies hooks and config inside every Git metadata root it opens for writing', () => {
+  // Verified against the vendored Codex on Linux: `deny` hides hooks/config from READS too, and Git
+  // cannot run without its config; `read` keeps a shell from planting a hook while Git keeps working.
+  // The worktrees subtree is named because :workspace pins a session's own admin dir read-only.
+  it('keeps hooks and config read-only, and opens the worktrees subtree, in every Git metadata root', () => {
     const config = codexPermissionProfileConfig({
       protectedRoots: [],
       writableGitMetadataRoots: ['/agent/workspace/.git', '/agent/repos/acme/infra/checkout/.git']
@@ -83,8 +86,10 @@ describe.skipIf(process.platform === 'win32')('Codex permission profile launch c
     )!
     for (const root of ['/agent/workspace/.git', '/agent/repos/acme/infra/checkout/.git']) {
       expect(agent).toContain(`"${root}" = "write"`)
-      expect(agent).toContain(`"${root}/hooks" = "deny"`)
-      expect(agent).toContain(`"${root}/config" = "deny"`)
+      expect(agent).toContain(`"${root}/worktrees/**" = "write"`)
+      expect(agent).toContain(`"${root}/hooks" = "read"`)
+      expect(agent).toContain(`"${root}/config" = "read"`)
+      expect(agent).not.toContain(`"${root}/hooks" = "deny"`)
     }
   })
 

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -488,8 +488,9 @@ describe('prepareRuntimeLaunch', () => {
     expect(launch.sandbox).toBeUndefined()
     const owner = realpathSync(primaryGit)
     expect(agentFilesystem(launch.env)).toContain(`"${owner}" = "write"`)
-    expect(agentFilesystem(launch.env)).toContain(`"${join(owner, 'hooks')}" = "deny"`)
-    expect(agentFilesystem(launch.env)).toContain(`"${join(owner, 'config')}" = "deny"`)
+    expect(agentFilesystem(launch.env)).toContain(`"${join(owner, 'worktrees', '**')}" = "write"`)
+    expect(agentFilesystem(launch.env)).toContain(`"${join(owner, 'hooks')}" = "read"`)
+    expect(agentFilesystem(launch.env)).toContain(`"${join(owner, 'config')}" = "read"`)
   })
 
   it('follows the daemon-named checkout and every secondary root when the sandbox is off', () => {


### PR DESCRIPTION
Two defects in the Codex agent permission profile, each settled empirically against the vendored
Codex on Linux by driving a real session worktree through `codex sandbox` with the daemon's own
emitted profile.

## 1. `deny` on `hooks`/`config` took Git down entirely (regression from #1703)

Codex's `deny` removes read access too. Git cannot run any command without reading its config, so
after #1703 every Codex session with a Git workspace failed on
`warning: unable to access '.git/config': Permission denied` — in the checkout as much as in a
worktree. The intent was "not writable"; Codex spells that `read`. With `read`, `git status` works
and a shell still cannot plant a hook or rewrite config (verified: writes to both are refused).

## 2. The parent `.git` grant never reached a session worktree's admin dir

This is the original failure behind #1695/#1698/#1703: `git add` in an isolated session dying on
`.git/worktrees/<sid>/index.lock: Read-only file system`. Codex's `:workspace` profile pins the
cwd's *resolved* gitdir read-only — for a worktree that is `<checkout>/.git/worktrees/<sid>` — and
resolves by most-specific match, so the daemon's grant on `<checkout>/.git` lost to it. `objects/`
was writable; the admin dir was not. An exact per-session path would need a per-session host; a
`worktrees/*` glob is rejected by Codex ("only supports `deny`"); a `worktrees/**` subtree grant is
what Codex honors, and it covers worktrees created after the host spawned.

## Verification

On a Linux host, with the exact profile line this code emits and the live host's other flags,
cwd = a real session worktree:

| probe | result |
|---|---|
| `git status` (needs config read) | ok |
| `git update-index --refresh` (real index write in the admin dir) | ok |
| write into `.git/objects/` | ok |
| `git branch -f` (ref write) | ok |
| write into `.git/hooks/` | refused |
| append to `.git/config` | refused |

Mutation-checked both halves: reverting `read`→`deny` and dropping the `worktrees/**` entry each turn
three tests red. Not exercised: a live model turn.

Independent of the outer sandbox, which already carved these directories back (#1695) and keeps its
own `denyWrite` on hooks/config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
