### PR TITLE
fix(daemon): strip the approval-gated plan exits from headless passes

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -382,7 +382,8 @@ export function claudeSessionMeta(
   memoryAppend?: string,
   protectedCredentialRoots?: readonly string[],
   protectedSettings?: ClaudeProtectedSettings,
-  allowModelToolUnixSockets = false
+  allowModelToolUnixSockets = false,
+  extraDisallowedTools: readonly string[] = []
 ):
   | {
       claudeCode: {
@@ -412,7 +413,7 @@ export function claudeSessionMeta(
         thinking: { type: 'adaptive', display: 'summarized' },
         // #998: the built-in agent-teams SendMessage is a live misdelivery channel;
         // adapters spread this into SDK query() options (older ones ignore it).
-        disallowedTools: CLAUDE_DISALLOWED_BUILTIN_TOOLS,
+        disallowedTools: [...CLAUDE_DISALLOWED_BUILTIN_TOOLS, ...extraDisallowedTools],
         ...(protectedCredentialRoots
           ? { sandbox: claudeInnerSandboxSettings(protectedCredentialRoots, allowModelToolUnixSockets) }
           : {}),
@@ -834,7 +835,8 @@ export class AcpHost {
     effortOverride?: string,
     systemAppend?: string,
     additionalDirectories: string[] = [],
-    announce?: (sessionId: string) => void
+    announce?: (sessionId: string) => void,
+    extraDisallowedTools: readonly string[] = []
   ): Promise<string> {
     const _meta = claudeSessionMeta(
       effortOverride ?? this.opts.configPrefs?.reasoningEffort,
@@ -843,7 +845,8 @@ export class AcpHost {
       systemAppend,
       this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined,
       this.opts.sandbox?.claudeProtectedSettings,
-      this.opts.sandbox?.allowModelToolUnixSockets
+      this.opts.sandbox?.allowModelToolUnixSockets,
+      extraDisallowedTools
     )
     const activeAdditionalDirectories = this.canUseAdditionalDirectories ? additionalDirectories : []
     const res = await this.conn!.agent.request(methods.agent.session.new, {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -87,6 +87,7 @@ import { MEMORY_TOOL_NAMES, MEMORY_TOOLS } from './memory/tools.js'
 import { DREAM_TOPIC_RE, MAX_DREAM_FILES } from './dream/dreamer.js'
 import { isSessionTitleToolCall } from './mcp/session-title-tool.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT, readOnlyExtractionMode } from './memory/distill.js'
+import { CLAUDE_HEADLESS_DISALLOWED_TOOLS } from './runtime-defs/claude-runtime.js'
 import {
   DREAM_MODEL_READABLE_CREDENTIALS_REASON,
   DreamRunner,
@@ -4401,8 +4402,24 @@ export class Daemon {
         this.memoryExtractionTokens.set(cacheKey, mcpToken)
         const mcpServers = this.mcpToolServerSpec(mcpToken)
         sessionId = trusted
-          ? await host.newSession(cwd, mcpServers, undefined, MEMORY_DISTILLATION_SYSTEM_PROMPT)
-          : await host.newSession(cwd, mcpServers)
+          ? await host.newSession(
+              cwd,
+              mcpServers,
+              undefined,
+              MEMORY_DISTILLATION_SYSTEM_PROMPT,
+              [],
+              undefined,
+              CLAUDE_HEADLESS_DISALLOWED_TOOLS
+            )
+          : await host.newSession(
+              cwd,
+              mcpServers,
+              undefined,
+              undefined,
+              [],
+              undefined,
+              CLAUDE_HEADLESS_DISALLOWED_TOOLS
+            )
         // Synchronous on purpose: the runtime advertises its commands on a timer right after this
         // resolves, and a registration behind one more await loses that race (#1310 review).
         const passKey = pendingTurnKey(agentId, sessionId)
@@ -4513,8 +4530,8 @@ export class Daemon {
         this.commitMessageDirs.set(agentId, cwd)
       }
       const sessionId = trusted
-        ? await host.newSession(cwd, [], undefined, systemPrompt)
-        : await host.newSession(cwd, [])
+        ? await host.newSession(cwd, [], undefined, systemPrompt, [], undefined, CLAUDE_HEADLESS_DISALLOWED_TOOLS)
+        : await host.newSession(cwd, [], undefined, undefined, [], undefined, CLAUDE_HEADLESS_DISALLOWED_TOOLS)
       const key = pendingTurnKey(agentId, sessionId)
       // Synchronous on purpose: see the distillation pass — the advertisement is already on a timer.
       this.internalPassSessions.add(internalPassSlot.commit(agentId, sessionId), key)
@@ -4819,8 +4836,16 @@ export class Daemon {
     const mcpServers = this.mcpToolServerSpec(mcpToken)
     try {
       const sessionId = trusted
-        ? await host.newSession(cwd, mcpServers, undefined, systemPrompt)
-        : await host.newSession(cwd, mcpServers)
+        ? await host.newSession(
+            cwd,
+            mcpServers,
+            undefined,
+            systemPrompt,
+            [],
+            undefined,
+            CLAUDE_HEADLESS_DISALLOWED_TOOLS
+          )
+        : await host.newSession(cwd, mcpServers, undefined, undefined, [], undefined, CLAUDE_HEADLESS_DISALLOWED_TOOLS)
       ref.sessionId = sessionId
       // Redundant while the dream owns a dedicated host the gate already excludes, but it keeps one
       // rule: every session the daemon opens for itself is registered, synchronously, right here.

--- a/packages/daemon/src/runtime-defs/claude-runtime.ts
+++ b/packages/daemon/src/runtime-defs/claude-runtime.ts
@@ -162,6 +162,13 @@ export function claudeInnerSandboxSettings(
  * owns all inter-session messaging for its sessions, so the built-in is always wrong. */
 export const CLAUDE_DISALLOWED_BUILTIN_TOOLS = ['SendMessage'] as const
 
+/** Additionally suppressed on the daemon's OWN headless passes (distillation, dream,
+ * commit-message). Those run under a non-mutating mode (`read-only`, else `plan`), and
+ * in plan mode Claude Code can only END a turn through `ExitPlanMode` / `AskUserQuestion`
+ * — both of which need an approver that a headless pass does not have. The call is
+ * aborted, the model retries, and the pass burns its context instead of returning. */
+export const CLAUDE_HEADLESS_DISALLOWED_TOOLS = ['ExitPlanMode', 'AskUserQuestion'] as const
+
 /** A Claude Code runtime (its command/args reference `claude`) — these embed the
  *  @anthropic-ai/claude-agent-sdk, which needs a Claude Code executable. The ONE
  *  Claude predicate: AcpHost and the model-catalog path both delegate here, matching

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -205,6 +205,21 @@ describe('AcpHost.usesMetaSystemPrompt (system-prompt routing per runtime)', () 
 })
 
 describe('claudeSessionMeta (system prompt + memory index over _meta)', () => {
+  it('suppresses only the built-in SendMessage on an ordinary session', () => {
+    expect(claudeSessionMeta(undefined, true)?.claudeCode.options.disallowedTools).toEqual(['SendMessage'])
+  })
+
+  it('also suppresses the approval-gated plan exits on a headless pass', () => {
+    // A headless pass (distillation, dream, commit-message) runs under `plan` when the
+    // runtime advertises no `read-only`, and plan mode can only END through
+    // ExitPlanMode / AskUserQuestion — which no headless caller can approve.
+    const meta = claudeSessionMeta(undefined, true, undefined, undefined, undefined, undefined, false, [
+      'ExitPlanMode',
+      'AskUserQuestion'
+    ])
+    expect(meta?.claudeCode.options.disallowedTools).toEqual(['SendMessage', 'ExitPlanMode', 'AskUserQuestion'])
+  })
+
   it('returns undefined for a non-Claude runtime', () => {
     expect(claudeSessionMeta(undefined, false, 'seed', 'mem')).toBeUndefined()
   })

--- a/packages/daemon/test/daemon-evaluation.test.ts
+++ b/packages/daemon/test/daemon-evaluation.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ORGANIZATION_SUGGESTION_REVIEW_FEATURE } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT } from '../src/memory/distill.js'
+import { CLAUDE_HEADLESS_DISALLOWED_TOOLS } from '../src/runtime-defs/claude-runtime.js'
 import { EvaluationEventCollector } from '../src/evaluation/index.js'
 import { WAIT } from './wait-support.js'
 
@@ -650,7 +651,15 @@ describe('managed memory auto-distillation runtime support (#653)', () => {
     // Untrusted system-prompt channel: no system prompt at session creation…
     // Distillation now carries the shared memory tools (#41), so the session is
     // created WITH an MCP server rather than the old tool-less shape.
-    expect(host.newSession).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining([expect.anything()]))
+    expect(host.newSession).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining([expect.anything()]),
+      undefined,
+      undefined,
+      [],
+      undefined,
+      CLAUDE_HEADLESS_DISALLOWED_TOOLS
+    )
     // …the policy is prepended inline to the prompt instead, still leading the turn.
     const text = host.prompt.mock.calls[0]![1][0]!.text as string
     expect(text.startsWith(MEMORY_DISTILLATION_SYSTEM_PROMPT)).toBe(true)
@@ -666,7 +675,10 @@ describe('managed memory auto-distillation runtime support (#653)', () => {
       expect.any(String),
       expect.arrayContaining([expect.anything()]),
       undefined,
-      MEMORY_DISTILLATION_SYSTEM_PROMPT
+      MEMORY_DISTILLATION_SYSTEM_PROMPT,
+      [],
+      undefined,
+      CLAUDE_HEADLESS_DISALLOWED_TOOLS
     )
     // Trusted: the prompt carries only the turn data, not the inline policy.
     expect(host.prompt.mock.calls[0]![1][0]!.text).toBe('DISTILL THIS')


### PR DESCRIPTION
## Problem

The daemon's own headless passes — distillation, dream, and commit-message — resolve their permission mode through `readOnlyExtractionMode()`, which prefers `read-only` and falls back to `plan`:

```ts
return modes.find((mode) => mode === 'read-only') ?? modes.find((mode) => mode === 'plan')
```

`claude-agent-acp` advertises no `read-only` mode — only `default`, `acceptEdits`, `bypassPermissions`, and `plan`. So **every Claude-runtime headless pass lands in `plan`**.

In plan mode Claude Code can only end a turn through `ExitPlanMode` or `AskUserQuestion`, and both need an approver that a headless pass does not have. The call is aborted, the model reconsiders and retries, and the pass burns its context instead of returning its proposal.

The model's own reasoning from a failed dream, verbatim:

> I notice a real conflict here: this task wants me to write memories and return JSON, but plan mode restricts me to read-only actions plus the plan file. […] Since plan mode explicitly supersedes other instructions, I'll […] draft a plan for the rebuilt store, write it to the plan file, then call ExitPlanMode for approval before making any actual writes.

and after the call was aborted:

> The ExitPlanMode call got aborted, likely rejected by the user or harness. Since I'm restricted to ending only via AskUserQuestion or ExitPlanMode, I need to reconsider rather than retry the same call blindly.

### Observed impact

A single manual dream on a self-hosted 1.51.0 daemon:

| | before | after this patch |
| --- | --- | --- |
| dream status | `failed` | `adopted` |
| error | `unparseable_proposal` — "the dream reply carried no valid store proposal" | none |
| context used | ran until `ACP connection closed` | 208K / 1M |

The `unparseable_proposal` error is the tell: the reply was a *plan file*, never the store proposal the distillation contract asks for.

## Fix

Suppress `ExitPlanMode` and `AskUserQuestion` on those three call sites, through the `_meta.claudeCode.options.disallowedTools` channel that already carries `SendMessage`.

- `CLAUDE_HEADLESS_DISALLOWED_TOOLS` — new constant next to `CLAUDE_DISALLOWED_BUILTIN_TOOLS`.
- `claudeSessionMeta()` / `AcpHost.newSession()` take an optional `extraDisallowedTools`, defaulting to `[]`.
- Passed only by the distillation, commit-message, and dream passes — the same three sites that call `readOnlyExtractionMode()`.

**Interactive sessions are unaffected.** The parameter defaults to empty, so a user-selected plan mode keeps its exits.

This makes `plan` behave like the `read-only` mode the code actually wants. If `claude-agent-acp` ever advertises a real `read-only` mode, `readOnlyExtractionMode()` will prefer it and this suppression becomes a no-op for that runtime.

## Tests

- Two existing assertions in `daemon-evaluation.test.ts` updated for the new argument list.
- Two new `claudeSessionMeta` cases: an ordinary session still suppresses only `SendMessage`; a headless pass suppresses all three.
- `pnpm --filter @agentconnect.md/daemon test` — 5142 passed, 0 failed.
- `pnpm lint`, `pnpm format:check`, `pnpm --filter @agentconnect.md/daemon typecheck` all clean.

## Verified live

Built from this branch and run as the daemon on a self-hosted stack; the manual dream that previously failed now reaches `adopted`, and all ten memory topic files were rewritten through the normal adoption swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
