### PR TITLE
feat(relay): key Linear on the team and add the per-conversation default rung

### DIFF
--- a/docs/designs/shared-bot-relay.md
+++ b/docs/designs/shared-bot-relay.md
@@ -380,7 +380,11 @@ conversation settings. The relay applies the shared routing ladder:
 1. an explicit agent selection or scoped conversation owner;
 2. existing thread affinity;
 3. agent-slug keyword disambiguation;
-4. the bot's default agent for a bare mention or direct message.
+4. the conversation's own default agent, where the platform compiles a row's
+   owner to a default rather than to a scoped ownership route
+   ([linear-integration.md](linear-integration.md) §6.2 — empty elsewhere, so
+   the rung is invisible on every platform that does not use it);
+5. the bot's default agent for a bare mention or direct message.
 
 Before compiling routes, CP converges each observed conversation to one canonical
 owner row and replicates its effective trigger across the sibling membership rows,

--- a/packages/activation-policy/src/index.ts
+++ b/packages/activation-policy/src/index.ts
@@ -457,7 +457,31 @@ export interface SharedBotAssignmentFacts {
    *  no missing route can suppress (continuity, the unscoped keyword slug,
    *  `defaultAgentId`), so a muted channel resolves to nothing. */
   mutedChannels?: string[] | undefined
+  /** Per-conversation defaults (linear-integration.md §6.2): a channel's own
+   *  default agent, consulted after keyword and thread continuity and before the
+   *  group's `defaultAgentId`. Also the grant a gated agent holds on such a
+   *  platform — the affinity gate honours a binding while its agent is the
+   *  channel's default. Empty ⇒ the ladder behaves exactly as before. */
+  conversationDefaults?: readonly SharedBotConversationDefault[] | undefined
+  /** True where a conversation row's owner compiles to the default rung above
+   *  rather than to a channel-scoped ownership route. On such an assignment a
+   *  gated binding the affinity gate rejects is TERMINAL (`grant-withdrawn`),
+   *  never a miss that falls through to the channel's new default. */
+  ownerAsDefault?: boolean | undefined
 }
+
+/** One channel's default agent — already attributed, like a route. */
+export interface SharedBotConversationDefault {
+  channel: string
+  agentId: string
+  daemonId: string
+  integrationId: string
+}
+
+/** The ladder's verdict. `refused` is terminal: the caller drops the delivery
+ *  instead of continuing down the ladder or re-arbitrating (§6.2). */
+export type SharedBotArbitration =
+  { kind: 'target'; target: SharedBotRouteTarget } | { kind: 'refused'; reason: 'grant-withdrawn' } | { kind: 'none' }
 
 /** `channel/thread` — the per-conversation affinity + rc/assign key. */
 export function sharedBotSessionKey(msg: { channel: string; thread?: string | undefined }): string {
@@ -506,8 +530,9 @@ const sharedBotTarget = (r: SharedBotRoute): SharedBotRouteTarget => ({
  *    gate-checked (§14), never through a binding that points at the author;
  *  - there is NO unscoped mention rung (it would starve keyword
  *    disambiguation, §10.4) — the bare @bot / DM fallback is the unscoped
- *    keyword slug (§10.2) and then the group's `defaultAgentId` (§10.3), both
- *    gated on the bot actually being ADDRESSED;
+ *    keyword slug (§10.2), then the CHANNEL's own default
+ *    (`conversationDefaults`, linear-integration.md §6.2), then the group's
+ *    `defaultAgentId` (§10.3), all gated on the bot actually being ADDRESSED;
  *  - bot senders are admitted by the platform manifest's `botSenderRouting`
  *    (equivalent today to the daemon ladder's Slack-only admission), and only
  *    through an explicit mention;
@@ -524,23 +549,38 @@ export function arbitrateSharedBot(
   affinity: ReadonlyMap<string, SharedBotRouteTarget>,
   verifiedAgentAuthor?: string
 ): SharedBotRouteTarget | null {
+  const result = arbitrateSharedBotResult(a, msg, affinity, verifiedAgentAuthor)
+  return result.kind === 'target' ? result.target : null
+}
+
+/** {@link arbitrateSharedBot} with the terminal `grant-withdrawn` refusal kept
+ *  distinguishable from an ordinary miss — the shape a caller needs to drop a
+ *  delivery rather than let the next rung answer it (§6.2). */
+export function arbitrateSharedBotResult(
+  a: SharedBotAssignmentFacts,
+  msg: SharedBotMessageFacts,
+  affinity: ReadonlyMap<string, SharedBotRouteTarget>,
+  verifiedAgentAuthor?: string
+): SharedBotArbitration {
+  const hit = (target: SharedBotRouteTarget): SharedBotArbitration => ({ kind: 'target', target })
+  const none: SharedBotArbitration = { kind: 'none' }
   // Own echoes never route. A third-party bot may enter only through an explicit
   // mention, and only on a platform whose manifest admits bot senders at all
   // (§5 botSenderRouting — fail-closed for unknown ids); AgentConnect-managed app
   // messages are removed by the manager using the collaboration snapshot before
   // forwarding.
-  if (a.botUserId !== undefined && msg.sender.id === a.botUserId && verifiedAgentAuthor === undefined) return null
+  if (a.botUserId !== undefined && msg.sender.id === a.botUserId && verifiedAgentAuthor === undefined) return none
   const explicitlyMentioned = a.botUserId !== undefined && msg.mentionedBots.includes(a.botUserId)
   if (
     msg.sender.isBot &&
     verifiedAgentAuthor === undefined &&
     (!manifestFor(msg.platform).botSenderRouting || !explicitlyMentioned)
   ) {
-    return null
+    return none
   }
   // A channel switched Off resolves to no target at all — ahead of every rung, so
   // neither an @-mention nor an existing thread binding can reach into it.
-  if (a.mutedChannels?.includes(msg.channel)) return null
+  if (a.mutedChannels?.includes(msg.channel)) return none
 
   // The author is removed ONCE, so every rung below inherits the exclusion — an agent
   // matching its own route would wake itself on its own reply, an unconditional self-loop.
@@ -559,14 +599,19 @@ export function arbitrateSharedBot(
     verifiedAgentAuthor === undefined
       ? scoped.find((r) => r.match.kind === 'mention' && sharedBotKindMatches(r, msg, a.botUserId))
       : undefined
-  if (ownedMention) return sharedBotTarget(ownedMention)
+  if (ownedMention) return hit(sharedBotTarget(ownedMention))
   // Conversation-scoped keyword (§14.3): slug disambiguation inside a multi-agent DM
   // enabled for several gated agents — outranks the scoped auto so "<slug> …"
   // names its agent; an unslugged message falls through to the first auto route.
   const ownedKeyword = scoped.find((r) => r.match.kind === 'keyword' && sharedBotKindMatches(r, msg, a.botUserId))
-  if (ownedKeyword) return sharedBotTarget(ownedKeyword)
+  if (ownedKeyword) return hit(sharedBotTarget(ownedKeyword))
   const ownedAuto = scoped.find((r) => r.match.kind === 'auto')
-  if (ownedAuto) return sharedBotTarget(ownedAuto)
+  if (ownedAuto) return hit(sharedBotTarget(ownedAuto))
+
+  // This channel's own default (linear-integration.md §6.2) — read here for the gate
+  // below, applied as a rung further down. On an `ownerAsDefault` platform it is also
+  // the only grant a gated agent can hold, the fact the scoped route carries on Slack.
+  const channelDefault = a.conversationDefaults?.find((d) => d.channel === msg.channel)
 
   // 2. Thread continuity: an un-mentioned follow-up in a thread the relay already
   //    routed continues to that agent, provided it is still a member — and, for a
@@ -579,14 +624,25 @@ export function arbitrateSharedBot(
   const cont = remembered && remembered.agentId === verifiedAgentAuthor ? undefined : remembered
   const directControlOk =
     !cont || (!msg.isDm && msg.isGroupDm !== true) || scoped.some((r) => r.agentId === cont.agentId)
-  const contGateOk =
-    directControlOk &&
-    (!cont || !a.gatedAgentIds?.includes(cont.agentId) || scoped.some((r) => r.agentId === cont.agentId))
+  // The gate reads the SAME fact from both carriers: on Slack a gated agent's grant is
+  // its channel-scoped route, on an `ownerAsDefault` platform it is the default seat.
+  const contGrantOk =
+    !cont ||
+    !a.gatedAgentIds?.includes(cont.agentId) ||
+    scoped.some((r) => r.agentId === cont.agentId) ||
+    channelDefault?.agentId === cont.agentId
+  // Terminal, not a miss: a Linear AgentSession has one writer (§4.6), so letting the
+  // channel's new default answer inside a session another runtime still holds would put
+  // two daemons on one feed. Slack, with no such axis, keeps its fall-through.
+  if (cont && directControlOk && !contGrantOk && a.ownerAsDefault === true) {
+    return { kind: 'refused', reason: 'grant-withdrawn' }
+  }
+  const contGateOk = directControlOk && contGrantOk
   if (cont && contGateOk && a.members.some((m) => m.daemonId === cont.daemonId && m.agentIds.includes(cont.agentId))) {
-    if (cont.integrationId) return cont
+    if (cont.integrationId) return hit(cont)
     const route = a.routes.find((r) => r.agentId === cont.agentId)
-    if (route) return { ...cont, integrationId: route.integrationId }
-    return cont
+    if (route) return hit({ ...cont, integrationId: route.integrationId })
+    return hit(cont)
   }
 
   // 3. Keyword disambiguation (§10.2): "@bot <slug> …" → that agent. Only when the
@@ -595,15 +651,33 @@ export function arbitrateSharedBot(
   const addressed = msg.isDm || (verifiedAgentAuthor === undefined && explicitlyMentioned)
   if (addressed) {
     const kw = routes.find((r) => r.match.kind === 'keyword' && !r.scope && sharedBotKindMatches(r, msg, a.botUserId))
-    if (kw) return sharedBotTarget(kw)
+    if (kw) return hit(sharedBotTarget(kw))
 
-    // 4. Default agent (§10.3): a bare @bot / DM with no slug → the group default.
+    // 4. Per-conversation default (linear-integration.md §6.2): the channel's own row
+    //    owner, already attributed. Above the group default and below everything that
+    //    names an agent, which is what keeps a mention and a bound session out of it.
+    if (channelDefault && channelDefault.agentId !== verifiedAgentAuthor) {
+      const member = a.members.some(
+        (m) => m.daemonId === channelDefault.daemonId && m.agentIds.includes(channelDefault.agentId)
+      )
+      if (member) {
+        return hit({
+          agentId: channelDefault.agentId,
+          daemonId: channelDefault.daemonId,
+          integrationId: channelDefault.integrationId
+        })
+      }
+    }
+
+    // 5. Default agent (§10.3): a bare @bot / DM with no slug → the group default.
     if (a.defaultAgentId && a.defaultDaemonId && a.defaultAgentId !== verifiedAgentAuthor) {
       // Resolve the default's integrationId from its (keyword) route.
       const def = routes.find((r) => r.agentId === a.defaultAgentId)
-      if (def) return { agentId: a.defaultAgentId, daemonId: a.defaultDaemonId, integrationId: def.integrationId }
+      if (def) {
+        return hit({ agentId: a.defaultAgentId, daemonId: a.defaultDaemonId, integrationId: def.integrationId })
+      }
     }
   }
 
-  return null
+  return none
 }

--- a/packages/control-plane/src/orchestrator/httpBot.test.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.test.ts
@@ -4,7 +4,7 @@ import { AgentDelivery } from './agentDelivery.js'
 import type { PlacementResolver } from './placementResolver.js'
 import type { GatedDmSeedResolver } from './linkedDm.js'
 import { RelayRegistry, type RelayChannel } from '../ws/relay-registry.js'
-import type { RcBotAssign, RelayCpFrameType } from '@agentconnect.md/protocol'
+import type { RcBotAssign, RcRoutes, RelayCpFrameType } from '@agentconnect.md/protocol'
 import { AgentId, BotId, DaemonId, IntegrationId, OrgId } from '../domain/ids.js'
 import type {
   BotRepo,
@@ -1156,6 +1156,34 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       const res = await makeOrch().lookupThread({ botId: BOT, sessionKey: 'C1/123.456' })
       expect(res.target).toEqual({ agentId: ALICE, daemonId: D1 })
     })
+
+    it('answers a STOP-mode lookup GRANT-BLIND, with the holder install attached', async () => {
+      // linear-integration.md §9.3: a stop can only end work, so it must still reach the runtime
+      // that holds the session after the conversation's default moved off its gated holder.
+      gatedAgents = new Set([ALICE])
+      threadBinding = { agentId: ALICE, daemonId: DaemonId(D1) }
+      channels = [] // no enabled row for ALICE in C1 — the ordinary mode refuses this exact case
+      const res = await makeOrch().lookupThread({ botId: BOT, sessionKey: 'C1/123.456', mode: 'stop' })
+      expect(res.target).toEqual({ agentId: ALICE, daemonId: D1, integrationId: INT_A })
+      // A stop is delivered to the one holder, never fanned across a room.
+      expect(res.participants).toEqual([])
+    })
+
+    it('answers a STOP-mode affinity miss from session_meta, still grant-blind', async () => {
+      gatedAgents = new Set([ALICE])
+      threadBinding = null
+      threadOwner = { agentId: ALICE }
+      channels = []
+      const res = await makeOrch().lookupThread({ botId: BOT, sessionKey: 'C1/123.456', mode: 'stop' })
+      expect(res.target).toEqual({ agentId: ALICE, daemonId: D1, integrationId: INT_A })
+    })
+
+    it('answers a STOP-mode lookup with nobody when no member is routable for the holder', async () => {
+      threadBinding = { agentId: ALICE, daemonId: DaemonId(D1) }
+      const orch = makeOrch(PLATFORMS, { routableDaemon: async () => null })
+      const res = await orch.lookupThread({ botId: BOT, sessionKey: 'C1/123.456', mode: 'stop' })
+      expect(res.target).toBeNull()
+    })
   })
 
   it('releases the bot (rc/bot-unassign) when transport is socket (no relay ingress)', async () => {
@@ -1474,10 +1502,11 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
     expect(ch.sends).toEqual([{ type: 'rc/bot-unassign', payload: { botId: BOT, credentialRevision: 1 } }]) // re-stamp only
   })
 
-  describe('a sole-conversation platform (§5 soleConversation)', () => {
-    // A connected Linear workspace: the install names the ONE conversation it can reach, so its
-    // row is the workspace default rather than a channel-scoped route.
-    const WORKSPACE = 'org-linear-1'
+  describe('an ownerAsDefault platform (§5, read through soleConversation)', () => {
+    // A connected Linear workspace: each team row's owner is that CONVERSATION's default rather
+    // than a channel-scoped route, which would outrank the keyword and continuity rungs.
+    const TEAM_A = 'team-linear-a'
+    const TEAM_B = 'team-linear-b'
     // The real Linear provider needs a token service and a live app config; this compile reads
     // nothing from it but the relay projection's existence, so a relabelled stub is enough.
     const LINEAR_PLATFORMS = buildCpPlatformRegistry([
@@ -1490,44 +1519,84 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
         { ...integration(INT_A, ALICE), platform: 'linear' },
         { ...integration(INT_B, BOB), platform: 'linear' }
       ]
-      channels = [channel({ integrationId: INT_B, channelId: WORKSPACE, agentId: BOB, trigger: 'mention' })]
+      channels = [
+        channel({ integrationId: INT_B, channelId: TEAM_A, agentId: BOB, trigger: 'mention' }),
+        channel({ integrationId: INT_A, channelId: TEAM_B, agentId: ALICE, trigger: 'mention' })
+      ]
     })
 
-    it('emits NO channel-scoped route and makes the row owner the group default', async () => {
+    it('emits NO channel-scoped route and projects each row owner into conversationDefaults', async () => {
       await makeOrch(LINEAR_PLATFORMS).syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign
 
       // The whole correction: a scoped `mention` rule here would be the FIRST rung, and every
       // Linear event marks the app as mentioned — so it would swallow keyword selection and
-      // thread continuity alike.
+      // thread continuity alike. The owner rides the per-conversation default rung instead.
       expect(assign.routes.some((r) => r.scope !== undefined)).toBe(false)
       const keywords = assign.routes
         .filter((r) => r.match.kind === 'keyword')
         .map((r) => (r.match as { value: string }).value)
         .sort()
       expect(keywords).toEqual(['alice', 'bob'])
-      // The ROW outranks the earliest-member derivation (ALICE installs first): the workspace
-      // conversation's owner IS the default.
-      expect(assign.defaultAgentId).toBe(BOB)
-      expect(assign.defaultDaemonId).toBe(D2)
+      expect(assign.ownerAsDefault).toBe(true)
+      expect([...assign.conversationDefaults].sort((a, b) => a.channel.localeCompare(b.channel))).toEqual([
+        { channel: TEAM_A, agentId: BOB, daemonId: D2, integrationId: INT_B },
+        { channel: TEAM_B, agentId: ALICE, daemonId: D1, integrationId: INT_A }
+      ])
+      // The group default keeps its GENERIC earliest-non-gated derivation as the backstop for a
+      // team that has no row yet — ALICE installs first.
+      expect(assign.defaultAgentId).toBe(ALICE)
+      expect(assign.defaultDaemonId).toBe(D1)
+    })
+
+    it('leaves an Off row out of the defaults, so a muted team resolves to nothing', async () => {
+      channels = [
+        channel({ integrationId: INT_B, channelId: TEAM_A, agentId: BOB, trigger: 'off' }),
+        channel({ integrationId: INT_A, channelId: TEAM_B, agentId: ALICE, trigger: 'mention' })
+      ]
+      await makeOrch(LINEAR_PLATFORMS).syncBot(BOT)
+      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign
+      expect(assign.conversationDefaults.map((d) => d.channel)).toEqual([TEAM_B])
+      expect(assign.mutedChannels).toContain(TEAM_A)
+      // The generic backstop is untouched by the mute — it is what a team with no row falls to.
+      expect(assign.defaultAgentId).toBe(ALICE)
     })
 
     it('carries a RESTRICTED member as UNGATED, so a private linking agent is routable at all', async () => {
-      // §14's fail-open worry presumes conversations the install never granted. Here the install
-      // granted the only one, so the member is not conversation-gated ON THIS BOT — which is what
-      // keeps the relay's three gated fences (the keyword rung, the default derivation, and the
-      // scoped-route requirement `agentTarget`/thread continuity impose) from stranding it.
+      // §14's fail-open worry presumes conversations the install never granted. Today's de-gating
+      // arm still applies on this platform, which is what keeps the relay's gated fences (the
+      // keyword rung, the default derivation, the scoped-route requirement) from stranding it.
       gatedAgents = new Set([BOB])
       await makeOrch(LINEAR_PLATFORMS).syncBot(BOT)
       const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign
 
       expect(assign.gatedAgentIds).toEqual([])
-      expect(assign.defaultAgentId).toBe(BOB)
+      // Its seat is the team's own default, not the group's.
+      expect(assign.conversationDefaults).toContainEqual({
+        channel: TEAM_A,
+        agentId: BOB,
+        daemonId: D2,
+        integrationId: INT_B
+      })
       expect(assign.routes.some((r) => r.agentId === BOB && r.match.kind === 'keyword' && r.scope === undefined)).toBe(
         true
       )
       // The daemon's own last-hop backstop must agree, or it would refuse what the relay routed.
       expect(upserts.every((u) => u.spec.core?.mode === 'shared')).toBe(true)
+    })
+
+    it('carries the defaults on the rc/routes HOT UPDATE, so an owner edit converges', async () => {
+      // An owner edit persists and converges through syncRoutes — without the field on the hot
+      // update every connected relay would keep the old default, and with it the old grant.
+      await makeOrch(LINEAR_PLATFORMS).setChannelAgent(BOT, TEAM_A, ALICE)
+      const routes = ch.sends.filter((s) => s.type === 'rc/routes').at(-1)!.payload as RcRoutes
+      expect(routes.conversationDefaults).toContainEqual({
+        channel: TEAM_A,
+        agentId: ALICE,
+        daemonId: D1,
+        integrationId: INT_A
+      })
+      expect(routes.routes.some((r) => r.scope !== undefined)).toBe(false)
     })
 
     it('still gates that same agent on an ORDINARY bot, so its name leaks nowhere', async () => {
@@ -1543,16 +1612,6 @@ describe('HttpBotOrchestrator — attributed route compilation (§10)', () => {
       expect(assign.gatedAgentIds).toEqual([BOB])
       expect(assign.defaultAgentId).toBe(ALICE)
       expect(assign.routes.some((r) => r.agentId === BOB && r.match.kind === 'keyword')).toBe(false)
-    })
-
-    it('mutes an Off workspace and leaves the group without a default', async () => {
-      channels = [channel({ integrationId: INT_B, channelId: WORKSPACE, agentId: BOB, trigger: 'off' })]
-      await makeOrch(LINEAR_PLATFORMS).syncBot(BOT)
-      const assign = ch.sends.find((s) => s.type === 'rc/bot-assign')?.payload as RcBotAssign
-
-      expect(assign.mutedChannels).toContain(WORKSPACE)
-      // No enabled row, so no workspace default — the bot preference does not resurrect one.
-      expect(assign.defaultAgentId).toBe(ALICE)
     })
   })
 })

--- a/packages/control-plane/src/orchestrator/httpBot.ts
+++ b/packages/control-plane/src/orchestrator/httpBot.ts
@@ -18,6 +18,7 @@
 import type {
   AttributedRoute,
   RcBotAssign,
+  RcConversationDefault,
   BindMatch,
   RcThreadAssign,
   RcThreadParticipant,
@@ -87,6 +88,13 @@ interface Compiled {
   noticedDmConversations: string[]
   /** Placed member integrations (spec push targets: daemonId + integration). */
   placed: { integration: IntegrationRecord; agent: AgentRecord; daemonId: string; gated: boolean }[]
+  /** Per-conversation defaults (linear-integration.md §6.2): each row's owner, on a
+   *  platform whose rows compile to the relay's default rung instead of to an ownership
+   *  route. Empty everywhere else, where the owner is a channel-scoped route. */
+  conversationDefaults: RcConversationDefault[]
+  /** Whether that projection is what this platform does with a row's owner — carried on
+   *  the assignment so the relay picks the terminal affinity refusal without a platform name. */
+  ownerAsDefault: boolean
 }
 
 /** Resolve a persisted owner marker to its active integration, falling back to
@@ -230,6 +238,9 @@ export class HttpBotOrchestrator {
         mutedChannels: compiled.mutedChannels,
         gatedOffChannels: compiled.gatedOffChannels,
         noticedDmConversations: compiled.noticedDmConversations,
+        // An owner edit converges here without a re-assign, so the defaults must ride the hot
+        // update too — otherwise a connected relay keeps the old default, and the old grant.
+        conversationDefaults: compiled.conversationDefaults,
         ...(this.noticeAuthorityFor(bot.id) ? { noticeAuthority: this.noticeAuthorityFor(bot.id) } : {})
       })
     )
@@ -409,8 +420,15 @@ export class HttpBotOrchestrator {
    *  persisted binding (`target: null` ⇒ the CP holds none). A binding to a GATED
    *  agent is honoured only while its conversation is still enabled (§14) — a
    *  thread bound before the gate was applied must not keep re-seeding relay
-   *  affinity forever. */
+   *  affinity forever.
+   *
+   *  `mode: 'stop'` answers GRANT-BLIND (linear-integration.md §9.3): a stop can only end
+   *  work, so it must still reach the runtime that holds the session after a conversation's
+   *  default moved off its gated holder. It also carries the holder's `integrationId` on
+   *  this bot, because the relay pre-addresses the interaction it builds from the answer.
+   *  Participants stay out of it: a stop is delivered to the one holder, never fanned. */
   async lookupThread(m: RcThreadLookup): Promise<RcThreadLookupOk> {
+    if (m.mode === 'stop') return this.lookupBoundThread(m)
     const channel = m.sessionKey.slice(0, Math.max(m.sessionKey.indexOf('/'), 0)) || m.sessionKey
     const participants = (
       await Promise.all(
@@ -464,6 +482,39 @@ export class HttpBotOrchestrator {
       }
     }
     return { botId: m.botId, sessionKey: m.sessionKey, target: null, participants }
+  }
+
+  /** The Stop-mode answer: the same affinity → `session_meta` ladder, with the §14 grant
+   *  check skipped and the holder's install on this bot attached. */
+  private async lookupBoundThread(m: RcThreadLookup): Promise<RcThreadLookupOk> {
+    const bound = await this.threads.get(BotId(m.botId), m.sessionKey)
+    let agentId: string | undefined = bound?.agentId
+    if (agentId === undefined) {
+      // sessionKey is `channel/thread` (relay `sessionKeyOf`); split on the FIRST '/'.
+      const slash = m.sessionKey.indexOf('/')
+      if (slash <= 0) return { botId: m.botId, sessionKey: m.sessionKey, target: null, participants: [] }
+      const owner = await this.sessions.findThreadOwner(
+        BotId(m.botId),
+        m.sessionKey.slice(0, slash),
+        m.sessionKey.slice(slash + 1)
+      )
+      // The cross-bot ambiguity guard survives the grant-blind mode: it protects against
+      // naming the wrong bot's holder, which no stop may do either.
+      if (!owner || (await this.sessionOwnerHasSiblingBot(m.botId, owner.agentId))) {
+        return { botId: m.botId, sessionKey: m.sessionKey, target: null, participants: [] }
+      }
+      agentId = owner.agentId
+    }
+    const agent = await this.agents.getUnscoped(AgentId(agentId))
+    const daemonId = agent ? await this.placement.routableDaemon({ ...agent, id: agent.id }) : null
+    if (!daemonId) return { botId: m.botId, sessionKey: m.sessionKey, target: null, participants: [] }
+    const install = (await this.integrations.listForBot(BotId(m.botId))).find((i) => i.agentId === agentId)
+    return {
+      botId: m.botId,
+      sessionKey: m.sessionKey,
+      target: { agentId, daemonId, ...(install ? { integrationId: install.id } : {}) },
+      participants: []
+    }
   }
 
   /** Refuse a bot-agnostic SessionMeta fallback when another live bot can route the same agent in this tenant. */
@@ -907,10 +958,12 @@ export class HttpBotOrchestrator {
       placed.push({ integration, agent, daemonId, gated: gatesNewConversations(bot.platform, agent) })
     }
     if (placed.length === 0) return null
-    // §5: the install IS the conversation, so its owner rides the default rung instead of a
-    // channel-scoped route — which would otherwise shadow keyword selection and thread
-    // continuity on a platform whose every event marks the app as mentioned.
-    const soleConversation = manifestFor(bot.platform).soleConversation
+    // linear-integration.md §6.2: a row's owner rides the relay's PER-CONVERSATION default
+    // rung instead of a channel-scoped route — which would otherwise shadow keyword selection
+    // and thread continuity on a platform whose every event marks the app as mentioned.
+    // (Still read through the manifest's `soleConversation` name; the rename lands with the
+    // arms it retires.)
+    const ownerAsDefault = manifestFor(bot.platform).soleConversation
 
     // members: daemonId → agentIds (the daemon connections the relay expects).
     const memberMap = new Map<string, Set<string>>()
@@ -952,9 +1005,9 @@ export class HttpBotOrchestrator {
       const p = byAgent.get(c.agentId)
       if (!p) continue
       if (c.trigger === 'off') continue
-      // The sole conversation's owner is delivered as the group default below; emitting a scoped
-      // rule for it too would make the FIRST rung swallow every addressed message.
-      if (soleConversation) continue
+      // Such an owner is delivered as this conversation's default below; emitting a scoped rule
+      // for it too would make the FIRST rung swallow every addressed message.
+      if (ownerAsDefault) continue
       const match: BindMatch = c.trigger === 'any' ? { kind: 'auto' } : { kind: 'mention' }
       routes.push({
         agentId: p.integration.agentId,
@@ -990,16 +1043,25 @@ export class HttpBotOrchestrator {
     //    rung), not a route, so it never pre-empts keyword/channel arbitration. A
     //    gated agent must never be the fallback (§14: the bare-@bot/DM rungs are
     //    what make an HTTP bot fail-open); a group of only gated agents has none.
-    // On a sole-conversation platform the ROW is the durable choice: its owner is the workspace
-    // default. The Off guard is defence for a row seeded before the trigger-write gate existed —
-    // no write surface can reach that state now.
-    const soleOwner = soleConversation
-      ? chans
-          .flatMap((c) => (c.agentId !== null && c.trigger !== 'off' ? [c.agentId] : []))
-          .map((agentId) => byAgent.get(agentId))
-          .find((p) => p !== undefined)
-      : undefined
-    const first = soleOwner ?? placed.find((p) => !p.gated)
+    const first = placed.find((p) => !p.gated)
+    // Each row's owner as the relay's per-conversation default (§6.2) — the rung between the
+    // keyword slug and `defaultAgentId`, and, for a gated owner, its grant in that channel.
+    // An Off row contributes none: a muted channel resolves to nothing at every rung.
+    const conversationDefaults: RcConversationDefault[] = ownerAsDefault
+      ? chans.flatMap((c) => {
+          if (!c.agentId || c.trigger === 'off') return []
+          const p = byAgent.get(c.agentId)
+          if (!p) return []
+          return [
+            {
+              channel: c.channelId,
+              agentId: p.integration.agentId,
+              daemonId: p.daemonId,
+              integrationId: p.integration.id
+            }
+          ]
+        })
+      : []
     const agents = placed.map((p) => {
       const a = agentById.get(p.integration.agentId)
       return {
@@ -1029,6 +1091,8 @@ export class HttpBotOrchestrator {
       mutedChannels,
       gatedOffChannels,
       noticedDmConversations,
+      conversationDefaults,
+      ownerAsDefault,
       botChannels: chans,
       placed: placed.map((p) => ({
         integration: p.integration,
@@ -1147,6 +1211,8 @@ export class HttpBotOrchestrator {
       mutedChannels: compiled.mutedChannels,
       gatedOffChannels: compiled.gatedOffChannels,
       noticedDmConversations: compiled.noticedDmConversations,
+      conversationDefaults: compiled.conversationDefaults,
+      ownerAsDefault: compiled.ownerAsDefault,
       ...(this.noticeAuthorityFor(bot.id) ? { noticeAuthority: this.noticeAuthorityFor(bot.id) } : {})
     }
   }

--- a/packages/daemon/src/platforms/linear/message-strategy.ts
+++ b/packages/daemon/src/platforms/linear/message-strategy.ts
@@ -33,6 +33,9 @@ const LinearPreviousComment = z.object({
 export const LinearAdapterExtSchema = z.object({
   agentSessionId: z.string().min(1),
   event: z.enum(['created', 'prompted']).optional(),
+  // The issue's team — the channel coordinate itself (§4.5). Read tolerantly here; the
+  // coordinates, `channelName` and the §8 header adopt it in their own change.
+  team: z.object({ id: z.string(), key: z.string().optional(), name: z.string().optional() }).optional(),
   issueId: z.string().optional(),
   issueIdentifier: z.string().optional(),
   issueTitle: z.string().optional(),

--- a/packages/protocol/src/frames/relay-cp.test.ts
+++ b/packages/protocol/src/frames/relay-cp.test.ts
@@ -472,6 +472,58 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
     expect(r.frame.payload.secrets.signingSecret).toBe('sign-x')
   })
 
+  it('round-trips the per-conversation default rung on rc/bot-assign and rc/routes', () => {
+    // linear-integration.md §6.2 — the table the relay consults between the keyword slug and
+    // `defaultAgentId`, plus the axis that makes a rejected gated affinity terminal there.
+    const conversationDefaults = [
+      { channel: 'team-a', agentId: AGENT_ID, daemonId: DAEMON_ID, integrationId: INTEGRATION_ID }
+    ]
+    const assign = decodeRelayCpFrame(
+      envelope('rc/bot-assign', {
+        botId: DAEMON_ID,
+        platform: 'linear',
+        secrets: { signingSecret: 'sign-x' },
+        members: [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID] }],
+        routes: [],
+        conversationDefaults,
+        ownerAsDefault: true
+      })
+    )
+    expect(assign.ok).toBe(true)
+    if (!assign.ok || assign.frame.type !== 'rc/bot-assign') throw new Error('narrow')
+    expect(assign.frame.payload.conversationDefaults).toEqual(conversationDefaults)
+    expect(assign.frame.payload.ownerAsDefault).toBe(true)
+
+    // The owner edit converges over the HOT update, so the same table rides rc/routes.
+    const routes = decodeRelayCpFrame(
+      envelope('rc/routes', {
+        botId: DAEMON_ID,
+        members: [{ daemonId: DAEMON_ID, agentIds: [AGENT_ID] }],
+        routes: [],
+        conversationDefaults
+      })
+    )
+    expect(routes.ok).toBe(true)
+    if (!routes.ok || routes.frame.type !== 'rc/routes') throw new Error('narrow')
+    expect(routes.frame.payload.conversationDefaults).toEqual(conversationDefaults)
+  })
+
+  it('defaults the per-conversation rung to empty and the axis to false on every other platform', () => {
+    const r = decodeRelayCpFrame(
+      envelope('rc/bot-assign', {
+        botId: DAEMON_ID,
+        platform: 'slack',
+        secrets: { botToken: 'xoxb-x', signingSecret: 'sign-x' },
+        members: [],
+        routes: []
+      })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok || r.frame.type !== 'rc/bot-assign') throw new Error('narrow')
+    expect(r.frame.payload.conversationDefaults).toEqual([])
+    expect(r.frame.payload.ownerAsDefault).toBe(false)
+  })
+
   it('round-trips a Feishu HTTP assignment without provider API credentials', () => {
     const r = decodeRelayCpFrame(
       envelope('rc/bot-assign', {
@@ -668,6 +720,28 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
     if (hit.frame.type !== 'rc/thread-lookup/ok') throw new Error('narrow')
     expect(hit.frame.payload.target?.agentId).toBe(AGENT_ID)
     expect(hit.frame.payload.participants).toEqual([{ agentId: AGENT_ID, daemonId: DAEMON_ID }])
+    // Stop mode (§9.3): the request names it, and the reply pre-addresses the holder's install
+    // so the relay can build the `platform_action` without a second resolution.
+    const stop = decodeRelayCpFrame(
+      envelope('rc/thread-lookup', { botId: DAEMON_ID, sessionKey: 'C1/ts', mode: 'stop' })
+    )
+    expect(stop.ok).toBe(true)
+    if (!stop.ok || stop.frame.type !== 'rc/thread-lookup') throw new Error('narrow')
+    expect(stop.frame.payload.mode).toBe('stop')
+    const bound = decodeRelayCpFrame(
+      envelope('rc/thread-lookup/ok', {
+        botId: DAEMON_ID,
+        sessionKey: 'C1/ts',
+        target: { agentId: AGENT_ID, daemonId: DAEMON_ID, integrationId: INTEGRATION_ID }
+      })
+    )
+    expect(bound.ok).toBe(true)
+    if (!bound.ok || bound.frame.type !== 'rc/thread-lookup/ok') throw new Error('narrow')
+    expect(bound.frame.payload.target?.integrationId).toBe(INTEGRATION_ID)
+    // An absent mode is the ORDINARY, gated lookup — not a third state.
+    const plain = decodeRelayCpFrame(envelope('rc/thread-lookup', { botId: DAEMON_ID, sessionKey: 'C1/ts' }))
+    if (!plain.ok || plain.frame.type !== 'rc/thread-lookup') throw new Error('narrow')
+    expect(plain.frame.payload.mode).toBeUndefined()
     // reply leg — a miss (no binding)
     expect(
       decodeRelayCpFrame(envelope('rc/thread-lookup/ok', { botId: DAEMON_ID, sessionKey: 'C1/ts', target: null })).ok

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -730,6 +730,19 @@ export const RcAgentDirEntry = z.object({
 })
 export type RcAgentDirEntry = z.infer<typeof RcAgentDirEntry>
 
+// One conversation's DEFAULT agent — the ladder rung consulted after keyword and
+// thread continuity and before the group's `defaultAgentId` (linear-integration.md
+// §6.2). It is what a conversation row's owner compiles to on a platform whose every
+// event already addresses the bot, where a channel-scoped route would instead outrank
+// the keyword and continuity rungs. Empty on every platform without that axis.
+export const RcConversationDefault = z.object({
+  channel: z.string().min(1),
+  agentId: z.string().uuid(),
+  daemonId: z.string().uuid(),
+  integrationId: z.string().uuid()
+})
+export type RcConversationDefault = z.infer<typeof RcConversationDefault>
+
 // C→R EVT — load a shared bot's INBOUND routing + credentials onto this relay:
 // inbound arrives over the shared HTTP Events API endpoints (`/slack/events`,
 // `/slack/interactions`) and is arbitrated against `routes`. Whole-pool: the CP
@@ -803,7 +816,14 @@ export const RcBotAssign = z.object({
   // conversation rows: a row can exist from mere discovery (a mixed bot's DM
   // routed to its public default) with no notice ever posted, and the
   // conversation must still get one if it later becomes unroutable.
-  noticedDmConversations: z.array(z.string()).default([])
+  noticedDmConversations: z.array(z.string()).default([]),
+  // linear-integration.md §6.2 — the per-conversation default rung's table, keyed by
+  // channel id, and the fact the thread-affinity gate reads for a gated agent on an
+  // `ownerAsDefault` platform (its grant is the default seat it holds). Empty elsewhere.
+  conversationDefaults: z.array(RcConversationDefault).default([]),
+  // §9.1's platform axis, projected so the relay can pick the terminal `grant-withdrawn`
+  // affinity refusal over Slack's fall-through without ever reading a platform name.
+  ownerAsDefault: z.boolean().default(false)
 })
 export type RcBotAssign = z.infer<typeof RcBotAssign>
 
@@ -836,7 +856,12 @@ export const RcRoutes = z.object({
   mutedChannels: z.array(z.string()).default([]), // Off channels — see RcBotAssign.mutedChannels
   gatedOffChannels: z.array(z.string()).default([]), // notice-keeping subset — see RcBotAssign.gatedOffChannels
   noticeAuthority: z.string().uuid().optional(), // §14.3 — see RcBotAssign.noticeAuthority
-  noticedDmConversations: z.array(z.string()).default([]) // §14.3 — see RcBotAssign.noticedDmConversations
+  noticedDmConversations: z.array(z.string()).default([]), // §14.3 — see RcBotAssign.noticedDmConversations
+  // Rides the hot update too: an owner edit converges through `syncRoutes` without a
+  // re-assign, so an already-connected relay would otherwise keep the old default —
+  // and with it the old grant fact — after exactly the edit this rung exists for.
+  // The immutable `ownerAsDefault` axis stays assignment-scoped.
+  conversationDefaults: z.array(RcConversationDefault).default([])
 })
 export type RcRoutes = z.infer<typeof RcRoutes>
 
@@ -985,7 +1010,11 @@ export type RcThreadParticipant = z.infer<typeof RcThreadParticipant>
 // persisted owner rather than dropping the message. The relay caches the result.
 export const RcThreadLookup = z.object({
   botId: z.string().uuid(),
-  sessionKey: z.string().min(1)
+  sessionKey: z.string().min(1),
+  // `stop` makes the answer GRANT-BLIND (linear-integration.md §9.3): a stop can only
+  // end work, so it must reach the runtime that holds the session even after the
+  // conversation's default moved off a gated holder. Absent ⇒ the ordinary gated mode.
+  mode: z.literal('stop').optional()
 })
 export type RcThreadLookup = z.infer<typeof RcThreadLookup>
 
@@ -994,7 +1023,12 @@ export type RcThreadLookup = z.infer<typeof RcThreadLookup>
 export const RcThreadLookupOk = z.object({
   botId: z.string().uuid(),
   sessionKey: z.string().min(1),
-  target: z.object({ agentId: z.string().uuid(), daemonId: z.string().uuid() }).nullable(),
+  // `integrationId` is the holder's install ON THIS BOT — carried so a pre-addressed
+  // interaction (the Stop-mode lookup, §9.3) needs no second resolution. Optional:
+  // an older CP omits it and the relay backfills from its own member directory.
+  target: z
+    .object({ agentId: z.string().uuid(), daemonId: z.string().uuid(), integrationId: z.string().uuid().optional() })
+    .nullable(),
   // Durable room membership is independent of the compatibility owner. Default
   // keeps new relays able to read replies from an older CP during rollout.
   participants: z.array(z.object({ agentId: z.string().uuid(), daemonId: z.string().uuid() })).default([])

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -459,14 +459,16 @@ describe('toBotAssignment (§6.7 open secrets reader)', () => {
  * would fire FIRST on every delivery and shadow both keyword selection and thread continuity.
  * Nothing below is Linear-aware; these are the same rungs Slack takes.
  */
-describe('Linear workspace-as-channel arbitration', () => {
-  const WORKSPACE = '00000000-0000-4000-8000-000000000001'
+describe('Linear team-as-channel arbitration (the per-conversation default rung)', () => {
+  const TEAM_A = '00000000-0000-4000-8000-0000000000t1'
+  const TEAM_B = '00000000-0000-4000-8000-0000000000t2'
   const APP_USER = '00000000-0000-4000-8000-0000000000a1'
   const empty = () => new Map<string, RouteTarget>()
 
-  /** The compile's output for a workspace whose conversation row is owned by ALICE: the keyword
-   *  rung per member, the owner as `defaultAgentId`, and NO scoped route at all. */
-  const linear = (): BotAssignment => ({
+  /** The compile's output for two team rows — TEAM_A owned by ALICE, TEAM_B by BOB: the keyword
+   *  rung per member, each owner as that CONVERSATION's default, and NO scoped route at all.
+   *  `defaultAgentId` stays the generic earliest-non-gated backstop for a team with no row. */
+  const linear = (over: Partial<BotAssignment> = {}): BotAssignment => ({
     ...assignment(),
     platform: 'linear',
     botUserId: APP_USER,
@@ -474,81 +476,202 @@ describe('Linear workspace-as-channel arbitration', () => {
       { agentId: ALICE, daemonId: D1, integrationId: 'iA', match: { kind: 'keyword', value: 'alice' } },
       { agentId: BOB, daemonId: D2, integrationId: 'iB', match: { kind: 'keyword', value: 'bob' } }
     ],
+    conversationDefaults: [
+      { channel: TEAM_A, agentId: ALICE, daemonId: D1, integrationId: 'iA' },
+      { channel: TEAM_B, agentId: BOB, daemonId: D2, integrationId: 'iB' }
+    ],
+    ownerAsDefault: true,
     defaultAgentId: ALICE,
-    defaultDaemonId: D1
+    defaultDaemonId: D1,
+    ...over
   })
 
   /** Every Linear delivery exists because the app was delegated to or mentioned (§6.1), so it
    *  carries the app user id and is "explicitly addressed" by construction. */
-  const delegation = (text: string, thread = 'agent-session-1'): WireNormalizedMessage =>
-    msg({ platform: 'linear', channel: WORKSPACE, thread, text, mentionedBots: [APP_USER] })
+  const delegation = (text: string, channel = TEAM_A, thread = 'agent-session-1'): WireNormalizedMessage =>
+    msg({ platform: 'linear', channel, thread, text, mentionedBots: [APP_USER] })
 
-  it('routes a bare delegation to the workspace owner, through the default rung', () => {
-    const t = arbitrate(linear(), delegation('take a look at the failing job'), empty())
-    expect(t).toEqual({ agentId: ALICE, daemonId: D1, integrationId: 'iA' })
+  it("routes a bare delegation to the TEAM's own default, not the group's", () => {
+    // The rung the design earns: TEAM_B's row owner answers there even though the group's
+    // `defaultAgentId` is ALICE — "review-bot handles ENG, docs-bot handles DOCS".
+    expect(arbitrate(linear(), delegation('take a look', TEAM_A), empty())).toEqual({
+      agentId: ALICE,
+      daemonId: D1,
+      integrationId: 'iA'
+    })
+    expect(arbitrate(linear(), delegation('take a look', TEAM_B), empty())).toEqual({
+      agentId: BOB,
+      daemonId: D2,
+      integrationId: 'iB'
+    })
   })
 
-  it('routes a NAMED delegation to the slug, not to the workspace owner', () => {
-    // The whole reason the owner is not a scoped route: §4.3's `@<agent-name>` selection has to
-    // beat the workspace default, and the unscoped keyword rung sits directly above it.
-    const t = arbitrate(linear(), delegation('bob please ship it'), empty())
-    expect(t).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
-  })
-
-  it('keeps a bound session with its agent when the workspace owner changes mid-session', () => {
-    // A Linear session is bound to one agent at creation (§4.5), and every follow-up `prompted`
-    // still marks the app as mentioned. Thread continuity outranks the default, so re-pointing
-    // the workspace at ALICE cannot hijack the session BOB already holds.
-    const affinity = new Map<string, RouteTarget>([
-      [`${WORKSPACE}/agent-session-1`, { agentId: BOB, daemonId: D2, integrationId: 'iB' }]
-    ])
-    const bound = arbitrate(linear(), delegation('does this reopen the session?'), affinity)
-    expect(bound).toEqual({ agentId: BOB, daemonId: D2, integrationId: 'iB' })
-    // A different session in the same workspace is unaffected and still falls to the owner.
-    expect(arbitrate(linear(), delegation('a fresh delegation', 'agent-session-2'), affinity)).toEqual({
+  it('falls to the group default for a team that has no row yet', () => {
+    const unknownTeam = '00000000-0000-4000-8000-0000000000t9'
+    expect(arbitrate(linear(), delegation('a first delegation', unknownTeam), empty())).toEqual({
       agentId: ALICE,
       daemonId: D1,
       integrationId: 'iA'
     })
   })
 
-  it('refuses a workspace switched Off, ahead of every rung', () => {
-    const off = { ...linear(), mutedChannels: [WORKSPACE] }
-    expect(arbitrate(off, delegation('take a look'), empty())).toBeNull()
+  it('LOSES to a keyword match: a named delegation reaches the slug, not the row owner', () => {
+    // The whole reason the owner is a default and not a scoped route: §4.3's `@<agent-name>`
+    // selection has to beat it, and the unscoped keyword rung sits directly above.
+    expect(arbitrate(linear(), delegation('bob please ship it', TEAM_A), empty())).toEqual({
+      agentId: BOB,
+      daemonId: D2,
+      integrationId: 'iB'
+    })
   })
 
-  /**
-   * A PRIVATE (restricted) agent that linked the workspace. The compile carries it as UNGATED on
-   * this bot — link-is-consent already satisfied §14 here — which is what keeps the ladder's three
-   * gated fences from stranding it: the default rung skips gated agents, `contGateOk` demands a
-   * channel-scoped route for a gated agent, and so does `agentTarget`. None of those routes exist
-   * under the corrected shape, so leaving the member gated would make it unreachable outright.
-   */
-  describe('a private linking agent', () => {
-    const privateOwner = (): BotAssignment => ({ ...linear(), gatedAgentIds: [] })
+  it('LOSES to thread affinity: a bound session survives an owner change mid-session', () => {
+    // A Linear session is bound to one agent at creation (§4.5), and every follow-up `prompted`
+    // still marks the app as mentioned. Continuity outranks the default rung, so re-pointing the
+    // team at ALICE cannot hijack the session BOB already holds.
+    const affinity = new Map<string, RouteTarget>([
+      [`${TEAM_A}/agent-session-1`, { agentId: BOB, daemonId: D2, integrationId: 'iB' }]
+    ])
+    expect(arbitrate(linear(), delegation('does this reopen the session?'), affinity)).toEqual({
+      agentId: BOB,
+      daemonId: D2,
+      integrationId: 'iB'
+    })
+    // A different session in the same team is unaffected and still falls to the row owner.
+    expect(arbitrate(linear(), delegation('a fresh delegation', TEAM_A, 'agent-session-2'), affinity)).toEqual({
+      agentId: ALICE,
+      daemonId: D1,
+      integrationId: 'iA'
+    })
+  })
 
-    it('receives a bare delegation through the default rung', () => {
-      expect(arbitrate(privateOwner(), delegation('take a look'), empty())).toEqual({
+  it('refuses a team switched Off, ahead of every rung', () => {
+    expect(arbitrate(linear({ mutedChannels: [TEAM_A] }), delegation('take a look'), empty())).toBeNull()
+  })
+
+  it('skips a default whose agent is no longer a member of the bot', () => {
+    const stale = linear({ members: [{ daemonId: D1, agentIds: [ALICE] }] })
+    // TEAM_B's default names BOB, whom no member entry holds any more — the group backstop answers.
+    expect(arbitrate(stale, delegation('take a look', TEAM_B), empty())).toEqual({
+      agentId: ALICE,
+      daemonId: D1,
+      integrationId: 'iA'
+    })
+  })
+
+  it('an assignment with an empty list and the flag false behaves exactly as today', () => {
+    // Platform-neutrality is the contract: nothing about Slack's ladder moves.
+    const slack = assignment()
+    expect(arbitrate(slack, msg({ channel: 'C1', text: '<@UBOT> deploy', mentionedBots: [BOTUSER] }), empty())).toEqual(
+      {
         agentId: ALICE,
         daemonId: D1,
         integrationId: 'iA'
-      })
-    })
+      }
+    )
+    expect(slack.conversationDefaults).toBeUndefined()
+    expect(slack.ownerAsDefault).toBeUndefined()
+  })
 
-    it('keeps its session across a workspace-owner change', () => {
-      // BOB now owns the workspace, but ALICE still holds the session it was bound to.
-      const reowned: BotAssignment = { ...privateOwner(), defaultAgentId: BOB, defaultDaemonId: D2 }
-      const affinity = new Map<string, RouteTarget>([
-        [`${WORKSPACE}/agent-session-1`, { agentId: ALICE, daemonId: D1, integrationId: 'iA' }]
+  it('updateRoutes REPLACES the defaults, so an owner edit converges without a re-assign', () => {
+    const router = new BotArbitrationRouter()
+    router.upsert(linear())
+    const a = linear()
+    router.updateRoutes('bot-1', {
+      members: a.members,
+      agents: a.agents,
+      routes: a.routes,
+      defaultAgentId: a.defaultAgentId,
+      defaultDaemonId: a.defaultDaemonId,
+      gatedAgentIds: [],
+      mutedChannels: [],
+      gatedOffChannels: [],
+      noticedDmConversations: [],
+      conversationDefaults: [{ channel: TEAM_A, agentId: BOB, daemonId: D2, integrationId: 'iB' }]
+    })
+    expect(router.route('bot-1', delegation('a fresh delegation', TEAM_A, 'agent-session-9'))).toEqual({
+      agentId: BOB,
+      daemonId: D2,
+      integrationId: 'iB'
+    })
+    // TEAM_B lost its row in the same update, so it falls to the group backstop.
+    expect(router.route('bot-1', delegation('a fresh delegation', TEAM_B, 'agent-session-8'))).toEqual({
+      agentId: ALICE,
+      daemonId: D1,
+      integrationId: 'iA'
+    })
+  })
+
+  describe("a GATED member, whose grant is the team's default seat", () => {
+    const gatedOwner = (over: Partial<BotAssignment> = {}): BotAssignment =>
+      linear({
+        gatedAgentIds: [ALICE],
+        // §14: a gated member gets no unscoped keyword rung and is never the group default.
+        routes: [{ agentId: BOB, daemonId: D2, integrationId: 'iB', match: { kind: 'keyword', value: 'bob' } }],
+        defaultAgentId: BOB,
+        defaultDaemonId: D2,
+        ...over
+      })
+    const bound = () =>
+      new Map<string, RouteTarget>([
+        [`${TEAM_A}/agent-session-1`, { agentId: ALICE, daemonId: D1, integrationId: 'iA' }]
       ])
-      expect(arbitrate(reowned, delegation('a follow-up'), affinity)).toEqual({
+
+    it("holds its binding while it is still the team's default", () => {
+      // The grant Slack carries on a channel-scoped route; on this platform the gate reads the
+      // same fact from `conversationDefaults`.
+      expect(arbitrate(gatedOwner(), delegation('a follow-up'), bound())).toEqual({
         agentId: ALICE,
         daemonId: D1,
         integrationId: 'iA'
       })
     })
 
-    it('is still fenced by the gate on a bot that DID keep it gated', () => {
+    it('REFUSES a follow-up once the default moves off it — never falling to the new default', () => {
+      // A Linear AgentSession has one writer (§4.6): letting BOB answer inside a session ALICE's
+      // runtime still holds would put two daemons on one feed.
+      const moved = gatedOwner({
+        conversationDefaults: [{ channel: TEAM_A, agentId: BOB, daemonId: D2, integrationId: 'iB' }]
+      })
+      const router = new BotArbitrationRouter()
+      router.upsert(moved)
+      router.setAffinity('bot-1', `${TEAM_A}/agent-session-1`, { agentId: ALICE, daemonId: D1, integrationId: 'iA' })
+      expect(router.routeResult('bot-1', delegation('a follow-up'))).toEqual({
+        kind: 'refused',
+        reason: 'grant-withdrawn'
+      })
+      expect(router.route('bot-1', delegation('a follow-up'))).toBeNull()
+    })
+
+    it('stays an ORDINARY miss on a plain assignment, so Slack keeps its fall-through', () => {
+      // Same rejected binding, `ownerAsDefault` false: the ladder continues and the new owner
+      // answers — the behaviour every non-Linear platform has today.
+      const slackShaped = gatedOwner({
+        ownerAsDefault: false,
+        conversationDefaults: [{ channel: TEAM_A, agentId: BOB, daemonId: D2, integrationId: 'iB' }]
+      })
+      expect(arbitrate(slackShaped, delegation('a follow-up'), bound())).toEqual({
+        agentId: BOB,
+        daemonId: D2,
+        integrationId: 'iB'
+      })
+    })
+
+    it("leaves an UNRESTRICTED agent's binding untouched by the same move", () => {
+      const moved = linear({
+        conversationDefaults: [{ channel: TEAM_A, agentId: BOB, daemonId: D2, integrationId: 'iB' }]
+      })
+      const affinity = new Map<string, RouteTarget>([
+        [`${TEAM_A}/agent-session-1`, { agentId: ALICE, daemonId: D1, integrationId: 'iA' }]
+      ])
+      expect(arbitrate(moved, delegation('a follow-up'), affinity)).toEqual({
+        agentId: ALICE,
+        daemonId: D1,
+        integrationId: 'iA'
+      })
+    })
+
+    it('is still fenced by the gate on a bot that carries no such axis', () => {
       // The same agent on an ordinary bot: the compile leaves it in `gatedAgentIds` and emits no
       // keyword rung, so neither continuity nor a name reaches it without a scoped route.
       const slackBot: BotAssignment = {
@@ -560,5 +683,49 @@ describe('Linear workspace-as-channel arbitration', () => {
       const named = msg({ channel: 'CX', text: '<@UBOT> bob ship it', mentionedBots: [BOTUSER] })
       expect(arbitrate(slackBot, named, affinity)).toEqual({ agentId: ALICE, daemonId: D1, integrationId: 'iA' })
     })
+  })
+})
+
+describe('boundTarget — the Stop-only, grant-blind affinity read', () => {
+  const TEAM_A = '00000000-0000-4000-8000-0000000000t1'
+  const KEY = `${TEAM_A}/agent-session-1`
+  const gated = (): BotAssignment => ({
+    ...assignment(),
+    platform: 'linear',
+    gatedAgentIds: [ALICE],
+    routes: [{ agentId: BOB, daemonId: D2, integrationId: 'iB', match: { kind: 'keyword', value: 'bob' } }],
+    conversationDefaults: [{ channel: TEAM_A, agentId: BOB, daemonId: D2, integrationId: 'iB' }],
+    ownerAsDefault: true,
+    defaultAgentId: BOB,
+    defaultDaemonId: D2
+  })
+
+  it('answers the HOLDER even after its grant was withdrawn — a stop can only end work', () => {
+    const router = new BotArbitrationRouter()
+    router.upsert(gated())
+    router.setAffinity('bot-1', KEY, { agentId: ALICE, daemonId: D1, integrationId: 'iA' })
+    expect(router.boundTarget('bot-1', KEY)).toEqual({ agentId: ALICE, daemonId: D1, integrationId: 'iA' })
+  })
+
+  it('is BOT-SCOPED: another bot holding the same session key answers nothing', () => {
+    const router = new BotArbitrationRouter()
+    router.upsert(gated())
+    router.upsert({ ...gated(), botId: 'bot-2' })
+    router.setAffinity('bot-1', KEY, { agentId: ALICE, daemonId: D1, integrationId: 'iA' })
+    expect(router.boundTarget('bot-2', KEY)).toBeUndefined()
+  })
+
+  it('drops a holder that is no longer a member, and never arbitrates a replacement', () => {
+    const router = new BotArbitrationRouter()
+    router.upsert({ ...gated(), members: [{ daemonId: D2, agentIds: [BOB] }] })
+    router.setAffinity('bot-1', KEY, { agentId: ALICE, daemonId: D1, integrationId: 'iA' })
+    // The team's default is BOB, and the miss must NOT resolve to him.
+    expect(router.boundTarget('bot-1', KEY)).toBeUndefined()
+  })
+
+  it('answers nothing for a session the relay holds no affinity for', () => {
+    const router = new BotArbitrationRouter()
+    router.upsert(gated())
+    expect(router.boundTarget('bot-1', `${TEAM_A}/agent-session-unseen`)).toBeUndefined()
   })
 })

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -7,15 +7,27 @@
  * The ladder mirrors the daemon's local arbitration (routing-table.ts) but over
  * ALREADY-ATTRIBUTED routes, and adapted for the multi-agent ambiguity (all agents
  * answer as one bot user id): channel ownership → thread continuity → keyword
- * (agent slug) → the group's default agent for a bare @bot / DM. There is NO
- * unscoped mention rule (it would starve keyword disambiguation, §10.4); the bare
- * @bot fallback is the `defaultAgentId` rung instead.
+ * (agent slug) → the channel's own default → the group's default agent for a bare
+ * @bot / DM. There is NO unscoped mention rule (it would starve keyword
+ * disambiguation, §10.4); the bare @bot fallback is the `defaultAgentId` rung instead.
  *
  * Pure data + a pure `arbitrate()` — no I/O, no Slack, no sockets — so it unit
  * tests without a live ingest.
  */
-import { arbitrateSharedBot, sharedBotScopeMatches, sharedBotSessionKey } from '@agentconnect.md/activation-policy'
-import type { AttributedRoute, RcAgentDirEntry, RcBotAssign, WireNormalizedMessage } from '@agentconnect.md/protocol'
+import {
+  arbitrateSharedBot,
+  arbitrateSharedBotResult,
+  sharedBotScopeMatches,
+  sharedBotSessionKey,
+  type SharedBotArbitration
+} from '@agentconnect.md/activation-policy'
+import type {
+  AttributedRoute,
+  RcAgentDirEntry,
+  RcBotAssign,
+  RcConversationDefault,
+  WireNormalizedMessage
+} from '@agentconnect.md/protocol'
 import { isThreadRootMessage } from '@agentconnect.md/message'
 
 /** A bot's full relay-side assignment (from `rc/bot-assign`). Secret material. */
@@ -76,6 +88,13 @@ export interface BotAssignment {
   /** §14.3: DM conversation ids whose notice was ACTUALLY DELIVERED (pool-wide
    *  latch for single-copy DM messages; never mere row discovery). */
   noticedDmConversations?: string[]
+  /** Per-conversation defaults (linear-integration.md §6.2): the ladder rung between
+   *  the unscoped keyword slug and `defaultAgentId`, and the grant a gated agent holds
+   *  where a conversation row's owner compiles to a default instead of a route. */
+  conversationDefaults?: RcConversationDefault[]
+  /** True where that projection is what the platform does with a row's owner. On such
+   *  an assignment the affinity gate's rejection of a gated binding is TERMINAL. */
+  ownerAsDefault?: boolean
 }
 
 /** Keep the directory shape identical on full assignments and `rc/routes` updates. */
@@ -177,6 +196,7 @@ export class BotArbitrationRouter {
       | 'gatedOffChannels'
       | 'noticeAuthority'
       | 'noticedDmConversations'
+      | 'conversationDefaults'
     >
   ): void {
     const a = this.bots.get(botId)
@@ -191,6 +211,9 @@ export class BotArbitrationRouter {
     a.gatedOffChannels = patch.gatedOffChannels
     a.noticeAuthority = patch.noticeAuthority
     a.noticedDmConversations = patch.noticedDmConversations
+    // An owner edit converges through here, so the defaults are replaced with the routes:
+    // otherwise a connected relay keeps the old default — and the old grant — forever.
+    a.conversationDefaults = patch.conversationDefaults
   }
 
   remove(botId: string): BotAssignment | undefined {
@@ -411,7 +434,7 @@ export class BotArbitrationRouter {
   seedLookupTarget(
     botId: string,
     sessionKey: string,
-    lookup: { agentId: string; daemonId: string }
+    lookup: { agentId: string; daemonId: string; integrationId?: string }
   ): RouteTarget | null {
     const a = this.bots.get(botId)
     if (!a) return null
@@ -420,7 +443,13 @@ export class BotArbitrationRouter {
     const tgt: RouteTarget = {
       agentId: lookup.agentId,
       daemonId: lookup.daemonId,
-      integrationId: route?.integrationId ?? ''
+      // The CP names the holder's install on this bot; the local directory is the backfill
+      // for an older CP that omits it, and the empty string for a route-less member.
+      integrationId:
+        lookup.integrationId ??
+        route?.integrationId ??
+        a.agents.find((x) => x.agentId === lookup.agentId)?.integrationId ??
+        ''
     }
     this.setAffinity(botId, sessionKey, tgt)
     return tgt
@@ -440,12 +469,38 @@ export class BotArbitrationRouter {
 
   /** Resolve one message; records live affinity for the resolved thread. */
   route(botId: string, msg: WireNormalizedMessage): RouteTarget | null {
+    const result = this.routeResult(botId, msg)
+    return result.kind === 'target' ? result.target : null
+  }
+
+  /** {@link route} keeping the terminal `grant-withdrawn` refusal distinguishable from
+   *  an ordinary miss, so the caller drops instead of continuing down the ladder. */
+  routeResult(botId: string, msg: WireNormalizedMessage): SharedBotArbitration {
     const a = this.bots.get(botId)
-    if (!a) return null
+    if (!a) return { kind: 'none' }
     const aff = this.affinity.get(botId) ?? this.affinity.set(botId, new Map()).get(botId)!
-    const tgt = arbitrate(a, msg, aff)
-    if (tgt) aff.set(sessionKeyOf(msg), tgt)
-    return tgt
+    const result = arbitrateSharedBotResult(a, msg, aff)
+    if (result.kind === 'target') aff.set(sessionKeyOf(msg), result.target)
+    return result
+  }
+
+  /**
+   * The STOP-only bound-target lookup (linear-integration.md §9.3): this bot's stored
+   * affinity for `sessionKey`, validated against current membership but NOT against the
+   * grant — a stop can only end work, so it must still reach a holder whose conversation
+   * default has since moved away. Never falls through to arbitration: the new default
+   * must not answer inside a session another runtime holds.
+   */
+  boundTarget(botId: string, sessionKey: string): RouteTarget | undefined {
+    const a = this.bots.get(botId)
+    const bound = this.affinity.get(botId)?.get(sessionKey)
+    if (!a || !bound) return undefined
+    if (!a.members.some((m) => m.daemonId === bound.daemonId && m.agentIds.includes(bound.agentId))) return undefined
+    if (bound.integrationId) return bound
+    const integrationId =
+      a.routes.find((r) => r.agentId === bound.agentId)?.integrationId ??
+      a.agents.find((x) => x.agentId === bound.agentId)?.integrationId
+    return integrationId ? { ...bound, integrationId } : undefined
   }
 
   /**
@@ -644,6 +699,8 @@ export function toBotAssignment(a: RcBotAssign): BotAssignment | null {
     mutedChannels: a.mutedChannels,
     gatedOffChannels: a.gatedOffChannels,
     noticedDmConversations: a.noticedDmConversations,
+    conversationDefaults: a.conversationDefaults,
+    ownerAsDefault: a.ownerAsDefault,
     ...(a.noticeAuthority ? { noticeAuthority: a.noticeAuthority } : {})
   }
 }

--- a/packages/relay/src/bot-arbitration.ts
+++ b/packages/relay/src/bot-arbitration.ts
@@ -26,6 +26,7 @@ import type {
   RcAgentDirEntry,
   RcBotAssign,
   RcConversationDefault,
+  RcRoutes,
   WireNormalizedMessage
 } from '@agentconnect.md/protocol'
 import { isThreadRootMessage } from '@agentconnect.md/message'
@@ -95,6 +96,43 @@ export interface BotAssignment {
   /** True where that projection is what the platform does with a row's owner. On such
    *  an assignment the affinity gate's rejection of a gated binding is TERMINAL. */
   ownerAsDefault?: boolean
+}
+
+/** The routing state an `rc/routes` hot update replaces — everything a re-assign would
+ *  carry except secrets, demux identity, and `botUserId`. One exported shape because the
+ *  CP frame, the ingress manager, and the router all have to agree on it: a field added to
+ *  the frame but forgotten in one of the hand-offs silently pins relays to the old value. */
+export type RoutesPatch = Pick<
+  BotAssignment,
+  | 'members'
+  | 'agents'
+  | 'routes'
+  | 'defaultAgentId'
+  | 'defaultDaemonId'
+  | 'gatedAgentIds'
+  | 'mutedChannels'
+  | 'gatedOffChannels'
+  | 'noticeAuthority'
+  | 'noticedDmConversations'
+  | 'conversationDefaults'
+>
+
+/** Map the CP's `rc/routes` frame to the hot-update patch (the `toBotAssignment` of the
+ *  routes-only leg). Sole assembler of the patch — see {@link RoutesPatch}. */
+export function toRoutesPatch(r: RcRoutes): RoutesPatch {
+  return {
+    members: r.members,
+    agents: mapAgentDirectory(r.agents),
+    routes: r.routes,
+    ...(r.defaultAgentId ? { defaultAgentId: r.defaultAgentId } : {}),
+    ...(r.defaultDaemonId ? { defaultDaemonId: r.defaultDaemonId } : {}),
+    gatedAgentIds: r.gatedAgentIds,
+    mutedChannels: r.mutedChannels,
+    gatedOffChannels: r.gatedOffChannels,
+    ...(r.noticeAuthority ? { noticeAuthority: r.noticeAuthority } : {}),
+    noticedDmConversations: r.noticedDmConversations,
+    conversationDefaults: r.conversationDefaults
+  }
 }
 
 /** Keep the directory shape identical on full assignments and `rc/routes` updates. */
@@ -182,23 +220,7 @@ export class BotArbitrationRouter {
   }
 
   /** Replace routes/members/agents/default WITHOUT touching secrets or botUserId (rc/routes). */
-  updateRoutes(
-    botId: string,
-    patch: Pick<
-      BotAssignment,
-      | 'members'
-      | 'agents'
-      | 'routes'
-      | 'defaultAgentId'
-      | 'defaultDaemonId'
-      | 'gatedAgentIds'
-      | 'mutedChannels'
-      | 'gatedOffChannels'
-      | 'noticeAuthority'
-      | 'noticedDmConversations'
-      | 'conversationDefaults'
-    >
-  ): void {
+  updateRoutes(botId: string, patch: RoutesPatch): void {
     const a = this.bots.get(botId)
     if (!a) return
     a.members = patch.members

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -28,7 +28,7 @@ import { RelayIngressManager } from './relay-ingress-manager.js'
 import { relayIngressPlugins } from './platforms/registry.js'
 import { CollaborationRouter } from './collaboration-router.js'
 import { createAgentMsgRouter } from './agent-msg-router.js'
-import { mapAgentDirectory, toBotAssignment } from './bot-arbitration.js'
+import { toBotAssignment, toRoutesPatch } from './bot-arbitration.js'
 import { HookTable } from './hooks/hook-table.js'
 import { HookRateLimiter } from './hooks/rate-limit.js'
 import { registerHookIngress } from './hooks/ingress.js'
@@ -159,19 +159,10 @@ async function main(): Promise<void> {
       void held.relayIngress
         ?.unassign(a.botId, a.credentialRevision)
         .catch((err) => log.error(`relay: bot-unassign failed: ${String(err)}`)),
-    onRoutes: (r) =>
-      held.relayIngress?.updateRoutes(r.botId, {
-        members: r.members,
-        agents: mapAgentDirectory(r.agents),
-        routes: r.routes,
-        ...(r.defaultAgentId ? { defaultAgentId: r.defaultAgentId } : {}),
-        ...(r.defaultDaemonId ? { defaultDaemonId: r.defaultDaemonId } : {}),
-        gatedAgentIds: r.gatedAgentIds,
-        mutedChannels: r.mutedChannels,
-        gatedOffChannels: r.gatedOffChannels,
-        noticeAuthority: r.noticeAuthority,
-        noticedDmConversations: r.noticedDmConversations
-      }),
+    // The patch is assembled by `toRoutesPatch` and nowhere else: a field the CP adds to
+    // the frame but a hand-written mapping here forgets pins every connected relay to the
+    // old value until a re-assign, which is exactly what a hot update exists to avoid.
+    onRoutes: (r) => held.relayIngress?.updateRoutes(r.botId, toRoutesPatch(r)),
     onAssign: (a) => {
       const target = { agentId: a.agentId, daemonId: a.daemonId, integrationId: '' }
       held.relayIngress?.setAffinity(a.botId, a.sessionKey, target)

--- a/packages/relay/src/platforms/contract.ts
+++ b/packages/relay/src/platforms/contract.ts
@@ -122,12 +122,19 @@ export interface RelayIngressSidecar {
   searchActionToken?: string
 }
 
+/** Core's verdict on one forwarded message. `refused` is the TERMINAL
+ *  `grant-withdrawn` result of linear-integration.md §6.2 — the channel's default
+ *  moved off the gated agent that holds this session, so nothing was forwarded and
+ *  nothing below the affinity rung was consulted. `accepted` means core handled the
+ *  message; it does not promise a daemon took it (delivery is bounded loss). */
+export type RelayForwardOutcome = 'accepted' | 'refused'
+
 export interface RelayIngressHost {
   /** Forward one NORMALIZED inbound message. Core owns arbitration: it resolves
    *  the owning agent/daemon and constructs the pre-addressed `rd/msg` — the
    *  plugin supplies conversation content, never target identity. The promise
    *  is the delivery attempt's completion (drop counting rides it). */
-  forward(botId: string, message: WireNormalizedMessage, sidecar?: RelayIngressSidecar): Promise<void>
+  forward(botId: string, message: WireNormalizedMessage, sidecar?: RelayIngressSidecar): Promise<RelayForwardOutcome>
   /** Forward one platform interaction as a §6.6 platform_action and return the
    *  daemon's ack — the sync-response race (see the module doc) awaits this.
    *  `msgId` is the DEDUP IDENTITY, and the plugin mints it (it derives from
@@ -164,6 +171,17 @@ export interface RelayIngressHost {
      * answers the platform accordingly and forwards nothing).
      */
     resolveTarget(botId: string, coords: { channelId: string; threadTs: string }): RouteTarget | undefined
+    /**
+     * The STOP-only bound-target lookup (linear-integration.md §9.3): the session's
+     * stored affinity target, validated against current membership and placement (the
+     * agent is still a member and its daemon is connected) but NOT against the grant,
+     * so a stop still reaches a holder whose conversation default has moved away. On a
+     * memory miss it asks the CP through the `rc/thread-lookup` pull-on-miss backstop
+     * in `stop` mode and caches a validated hit back. It NEVER arbitrates: a miss must
+     * resolve to nobody rather than to the channel's new default, which would put two
+     * daemons on one single-writer feed. `undefined` = nobody holds it.
+     */
+    resolveBoundTarget(botId: string, sessionKey: string): Promise<RouteTarget | undefined>
     /** The conversation's remembered participant set, re-resolved through the member
      *  directory with the mute/gate fences applied — the recipients of a session-level
      *  event that must reach EVERY participant (Slack's native Stop), where the

--- a/packages/relay/src/platforms/feishu/ingress-plugin.ts
+++ b/packages/relay/src/platforms/feishu/ingress-plugin.ts
@@ -106,7 +106,7 @@ export const feishuIngressPlugin: RelayPlatformIngressPlugin<FeishuHttpIngest, V
     }
     const botId = a.botId
     return new FeishuHttpIngest(botId, a.apiAppId, a.secrets, {
-      onMessage: (message) => host.forward(botId, message),
+      onMessage: async (message) => void (await host.forward(botId, message)),
       onCardAction: (action, eventId) => forwardFeishuCardAction(host, botId, action, eventId),
       now: () => host.clock.now()
     })

--- a/packages/relay/src/platforms/linear/http-ingest.ts
+++ b/packages/relay/src/platforms/linear/http-ingest.ts
@@ -145,6 +145,10 @@ export function linearIsStop(event: LinearAgentSessionEvent): boolean {
 /** §6.4 adapter-extension bag: opaque to relay core, round-tripped to the daemon's linear module. */
 export interface LinearAdapterExt {
   agentSessionId: string
+  /** The issue's team — the channel coordinate itself (§4.5), carried so the daemon can
+   *  label and head the session without a second Linear read. Absent on an issue-less
+   *  session, which keys on the workspace instead. */
+  team?: { id: string; key?: string; name?: string }
   /** Which webhook opened this turn: `created` is the delegation or mention that opened the
    *  session (§10.2 auto-start reads it), `prompted` a follow-up on one that already exists. */
   event?: 'created' | 'prompted'
@@ -213,9 +217,15 @@ function actorId(event: LinearAgentSessionEvent): string {
   return event.agentActivity?.user?.id ?? session.creatorId ?? session.id
 }
 
-// One verified `created`/`prompted` event as the message relay core arbitrates: `channel` is the
-// connected WORKSPACE (§4.5), read off the ingest identity rather than the payload — `decode`
-// already refused every delivery whose `organizationId` differs, so the two cannot disagree.
+/** The channel coordinate (§4.5): the issue's TEAM, or the workspace for an issue-less
+ *  session — a channel of its own that never earns a row. The workspace id is read off the
+ *  ingest identity rather than the payload; `decode` already refused every delivery whose
+ *  `organizationId` differs, so the two cannot disagree. */
+export function linearChannelOf(event: LinearAgentSessionEvent, identity: LinearIngestIdentity): string {
+  return event.agentSession.issue?.team?.id ?? identity.organizationId
+}
+
+// One verified `created`/`prompted` event as the message relay core arbitrates.
 export function normalizeLinearEvent(
   event: LinearAgentSessionEvent,
   msgId: string,
@@ -228,8 +238,12 @@ export function normalizeLinearEvent(
     event.previousComments ?? undefined,
     LINEAR_CONTEXT_BUDGET_BYTES
   )
+  const team = issue?.team ?? undefined
   const adapterExt: LinearAdapterExt = {
     agentSessionId: session.id,
+    ...(team?.id
+      ? { team: { id: team.id, ...(team.key ? { key: team.key } : {}), ...(team.name ? { name: team.name } : {}) } }
+      : {}),
     ...(event.action === 'created' || event.action === 'prompted' ? { event: event.action } : {}),
     ...(issue?.id ? { issueId: issue.id } : {}),
     ...(issue?.identifier ? { issueIdentifier: issue.identifier } : {}),
@@ -246,7 +260,7 @@ export function normalizeLinearEvent(
     traceId: msgId,
     source: 'user',
     platform: 'linear',
-    channel: identity.organizationId,
+    channel: linearChannelOf(event, identity),
     thread: session.id,
     ...(issue?.url?.startsWith('https://') ? { threadUrl: issue.url } : {}),
     sender: {

--- a/packages/relay/src/platforms/linear/ingress-plugin.test.ts
+++ b/packages/relay/src/platforms/linear/ingress-plugin.test.ts
@@ -15,6 +15,7 @@ const SIBLING_ORG_ID = '00000000-0000-4000-8000-000000000002'
 const APP_USER_ID = '00000000-0000-4000-8000-0000000000a1'
 const ISSUE_ID = '00000000-0000-4000-8000-0000000000i1'
 const SESSION_ID = '00000000-0000-4000-8000-0000000000s1'
+const TEAM_ID = '00000000-0000-4000-8000-0000000000t1'
 const ACTIVITY_ID = '00000000-0000-4000-8000-0000000000c1'
 const USER_ID = '00000000-0000-4000-8000-0000000000u1'
 
@@ -25,7 +26,7 @@ const ROUTE: RouteTarget = {
 }
 
 const host = (over: Partial<RelayIngressHost> = {}): RelayIngressHost => ({
-  forward: vi.fn(async () => {}),
+  forward: vi.fn(async () => 'accepted' as const),
   forwardAction: vi.fn(async (msg) => ({ msgId: msg.msgId, accepted: true })),
   reportChannels: () => {},
   reportRevoked: vi.fn(),
@@ -34,6 +35,7 @@ const host = (over: Partial<RelayIngressHost> = {}): RelayIngressHost => ({
     channelOwner: () => undefined,
     targetForAgentId: () => undefined,
     resolveTarget: () => ROUTE,
+    resolveBoundTarget: async () => ROUTE,
     conversationParticipants: () => [],
     targetForAgent: () => ROUTE,
     integrationTarget: () => ROUTE,
@@ -71,7 +73,7 @@ const issue = {
   identifier: 'AGE-5',
   title: 'Probe: agent session activity rendering',
   url: 'https://linear.app/example-workspace/issue/AGE-5/probe',
-  team: { id: '00000000-0000-4000-8000-0000000000t1', key: 'AGE', name: 'Example' }
+  team: { id: TEAM_ID, key: 'AGE', name: 'Example' }
 }
 
 function createdEvent(over: Record<string, unknown> = {}): Record<string, unknown> {
@@ -310,12 +312,12 @@ describe('linear ingress plugin — dedup identity', () => {
 })
 
 describe('linear ingress plugin — normalized message', () => {
-  it('maps a created event onto workspace/session coordinates with the adapter bag', async () => {
+  it('maps a created event onto TEAM/session coordinates with the adapter bag', async () => {
     const h = host()
     const { forwarded } = await run(h, createdEvent())
     expect(forwarded).toMatchObject({
       platform: 'linear',
-      channel: ORG_ID,
+      channel: TEAM_ID,
       thread: SESSION_ID,
       threadUrl: issue.url,
       sender: { id: `linear:${USER_ID}`, isBot: false },
@@ -329,7 +331,8 @@ describe('linear ingress plugin — normalized message', () => {
       issueId: issue.id,
       issueIdentifier: 'AGE-5',
       issueTitle: issue.title,
-      guidance: 'Always open a draft PR.'
+      guidance: 'Always open a draft PR.',
+      team: { id: TEAM_ID, key: 'AGE', name: 'Example' }
     })
     expect(bag.promptContext).toContain('AGE-5')
     expect(bag.truncated).toBeUndefined()
@@ -351,8 +354,8 @@ describe('linear ingress plugin — normalized message', () => {
   })
 
   it('keeps a session with NO issue on the workspace channel, minus the issue metadata', async () => {
-    // The workspace is the channel whatever surface the session sits on, so an issue-less
-    // session is just a thread whose bag and `threadUrl` carry nothing about an issue.
+    // An issue-less session has no team either (§4.5), so it keys on the workspace as a channel
+    // of its own — never `linear:undefined` — and its bag carries nothing about an issue.
     const h = host()
     const noIssue = createdEvent()
     ;(noIssue.agentSession as Record<string, unknown>).issue = null
@@ -427,22 +430,27 @@ describe('linear ingress plugin — truncation budget', () => {
 })
 
 describe('linear ingress plugin — stop, revocation, and non-session events', () => {
-  it('routes a stop signal as a platform_action on the WORKSPACE coordinates', async () => {
+  it('routes a stop through the BOUND-target lookup on the team coordinates', async () => {
+    const resolveBoundTarget = vi.fn(async () => ROUTE)
     const resolveTarget = vi.fn(() => ROUTE)
-    const h = host({ directory: { ...host().directory, resolveTarget } })
+    const h = host({ directory: { ...host().directory, resolveBoundTarget, resolveTarget } })
     await run(h, promptedEvent({}, { signal: 'stop' }))
     expect(h.forward).not.toHaveBeenCalled()
     expect(h.forwardAction).toHaveBeenCalledTimes(1)
-    // The directory is asked for the workspace channel, never the issue: a stop has to land on
-    // the same conversation the delegation that opened the session routed through.
-    expect(resolveTarget).toHaveBeenCalledWith(expect.any(String), { channelId: ORG_ID, threadTs: SESSION_ID })
+    // The bound lookup, never ordinary arbitration: a stop must reach the runtime that HOLDS
+    // the session, not whoever the team's default currently is (§9.3).
+    expect(resolveTarget).not.toHaveBeenCalled()
+    expect(resolveBoundTarget).toHaveBeenCalledWith(
+      expect.any(String),
+      sessionKeyOf({ channel: TEAM_ID, thread: SESSION_ID })
+    )
     const [msg, route] = vi.mocked(h.forwardAction).mock.calls[0]!
     expect(msg).toMatchObject({
       source: 'platform_action',
       platformId: 'linear',
       agentId: ROUTE.agentId,
       integrationId: ROUTE.integrationId,
-      sessionKey: sessionKeyOf({ channel: ORG_ID, thread: SESSION_ID }),
+      sessionKey: sessionKeyOf({ channel: TEAM_ID, thread: SESSION_ID }),
       msgId: `linear:${ACTIVITY_ID}`,
       userId: USER_ID,
       payload: { kind: 'stop', agentSessionId: SESSION_ID }
@@ -450,12 +458,28 @@ describe('linear ingress plugin — stop, revocation, and non-session events', (
     expect(route).toEqual(ROUTE)
   })
 
-  it('drops a stop the directory can no longer place', async () => {
+  it('drops a stop the bound lookup answers with nobody, and never falls back to arbitration', async () => {
+    const resolveTarget = vi.fn(() => ROUTE)
     const h = host({
-      directory: { ...host().directory, resolveTarget: () => undefined }
+      directory: { ...host().directory, resolveBoundTarget: async () => undefined, resolveTarget }
     })
     await run(h, promptedEvent({}, { signal: 'stop' }))
     expect(h.forwardAction).not.toHaveBeenCalled()
+    expect(resolveTarget).not.toHaveBeenCalled()
+  })
+
+  it('drops a delivery arbitration REFUSED, still answering Linear with a 200', async () => {
+    // §6.2: the team's default moved off the gated agent bound to this session, so the
+    // follow-up is refused rather than handed on. The plugin forwards, logs, and stops.
+    const debug = vi.fn()
+    const h = host({
+      forward: vi.fn(async () => 'refused' as const),
+      log: { debug, info: () => {}, warn: () => {}, error: () => {} }
+    })
+    const handled = await run(h, promptedEvent())
+    expect(handled.verified).toMatchObject({ kind: 'agent-session' })
+    expect(h.forwardAction).not.toHaveBeenCalled()
+    expect(debug).toHaveBeenCalledWith(expect.stringContaining('grant was withdrawn'))
   })
 
   it('rings the revocation doorbell with the OBSERVING assignment revision', async () => {

--- a/packages/relay/src/platforms/linear/ingress-plugin.ts
+++ b/packages/relay/src/platforms/linear/ingress-plugin.ts
@@ -3,6 +3,7 @@
 import type { RdMsgPlatformAction } from '@agentconnect.md/protocol'
 import {
   LinearHttpIngest,
+  linearChannelOf,
   linearDedupId,
   linearIsStop,
   normalizeLinearEvent,
@@ -20,20 +21,22 @@ export interface LinearStopAction {
   agentSessionId: string
 }
 
-// A stop is an interaction, not a message: it takes the directory ladder, and because a Linear
-// session is bound to one agent at creation (§4.5) the conversation's own target is the holder.
-export function forwardLinearStop(
+// A stop is an interaction, not a message, and a Linear session is bound to one agent at
+// creation (§4.5) — so it takes the BOUND-target lookup, never ordinary arbitration: reaching
+// the channel's current default instead would settle a session another runtime still holds.
+export async function forwardLinearStop(
   host: RelayIngressHost,
   ingest: LinearHttpIngest,
   event: LinearAgentSessionEvent,
   msgId: string
-): void {
+): Promise<void> {
   const botId = ingest.botId
   const session = event.agentSession
-  const channelId = ingest.identity.organizationId
-  const route = host.directory.resolveTarget(botId, { channelId, threadTs: session.id })
+  const channelId = linearChannelOf(event, ingest.identity)
+  const sessionKey = sessionKeyOf({ channel: channelId, thread: session.id })
+  const route = await host.directory.resolveBoundTarget(botId, sessionKey)
   if (!route) {
-    host.log.warn(`relay-ingress(${botId}): Linear stop for session ${session.id} has no current target`)
+    host.log.warn(`relay-ingress(${botId}): Linear stop for session ${session.id} reaches no bound agent — dropped`)
     return
   }
   const payload: LinearStopAction = { kind: 'stop', agentSessionId: session.id }
@@ -42,13 +45,13 @@ export function forwardLinearStop(
     platformId: 'linear',
     agentId: route.agentId,
     integrationId: route.integrationId,
-    sessionKey: sessionKeyOf({ channel: channelId, thread: session.id }),
+    sessionKey,
     msgId,
     botId,
     ...(event.agentActivity?.user?.id ? { userId: event.agentActivity.user.id } : {}),
     payload
   }
-  void host
+  await host
     .forwardAction(rd, route)
     .then((ack) => {
       if (!ack.accepted) host.log.warn(`relay-ingress(${botId}): daemon rejected Linear stop (${ack.reason ?? '?'})`)
@@ -119,12 +122,19 @@ export const linearIngressPlugin: RelayPlatformIngressPlugin<LinearHttpIngest, V
     }
     if (host.dedupSeen(msgId)) return {}
     if (linearIsStop(event)) {
-      forwardLinearStop(host, ingest, event, msgId)
+      void forwardLinearStop(host, ingest, event, msgId)
       return {}
     }
     const message = normalizeLinearEvent(event, msgId, ingest.identity)
     void host
       .forward(botId, message)
+      .then((outcome) => {
+        // §6.2's terminal refusal: the team's default moved off the gated agent bound to this
+        // session, so the delivery is dropped — Linear still gets its 200, and nothing answers.
+        if (outcome === 'refused') {
+          host.log.debug(`relay-ingress(${botId}): dropped Linear ${msgId} — the session's grant was withdrawn`)
+        }
+      })
       .catch((err) => host.log.warn(`linear ingress: event handler error: ${(err as Error).message}`))
     return {}
   }

--- a/packages/relay/src/platforms/slack/ingress-plugin.test.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.test.ts
@@ -11,7 +11,7 @@ const ROUTE: RouteTarget = {
 }
 
 const host = (over: Partial<RelayIngressHost> = {}): RelayIngressHost => ({
-  forward: async () => {},
+  forward: async () => 'accepted' as const,
   forwardAction: vi.fn(async (msg) => ({ msgId: msg.msgId, accepted: true })),
   reportChannels: () => {},
   reportRevoked: vi.fn(),
@@ -20,6 +20,7 @@ const host = (over: Partial<RelayIngressHost> = {}): RelayIngressHost => ({
     channelOwner: () => undefined,
     targetForAgentId: () => undefined,
     resolveTarget: () => ROUTE,
+    resolveBoundTarget: async () => ROUTE,
     conversationParticipants: () => [],
     targetForAgent: () => ROUTE,
     integrationTarget: () => ROUTE,
@@ -125,6 +126,7 @@ describe('slack ingress plugin — review-pinned regressions', () => {
         channelOwner: () => undefined,
         targetForAgentId: () => undefined,
         resolveTarget: () => ROUTE,
+        resolveBoundTarget: async () => ROUTE,
         conversationParticipants: () => [sameDaemonSibling, other],
         targetForAgent: () => ROUTE,
         integrationTarget: () => ROUTE,
@@ -150,6 +152,7 @@ describe('slack ingress plugin — review-pinned regressions', () => {
         channelOwner: () => undefined,
         targetForAgentId: () => undefined,
         resolveTarget: () => undefined,
+        resolveBoundTarget: async () => undefined,
         conversationParticipants: () => [ROUTE],
         targetForAgent: () => undefined,
         integrationTarget: () => undefined,

--- a/packages/relay/src/platforms/slack/ingress-plugin.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.ts
@@ -255,7 +255,7 @@ export const slackIngressPlugin: RelayPlatformIngressPlugin<SlackHttpIngest, Sla
       botId,
       { botToken: a.secrets.botToken, signingSecret: a.secrets.signingSecret },
       {
-        onMessage: (msg, sidecar) => host.forward(botId, msg, sidecar),
+        onMessage: async (msg, sidecar) => void (await host.forward(botId, msg, sidecar)),
         onBotUserId: (uid) => host.reportBotUserId(botId, uid),
         onChannelsChanged: (channels) => host.reportChannels({ botId, channels }),
         agents: () => host.directory.agents(botId),

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -1408,6 +1408,93 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     expect(reportThreadAssign).not.toHaveBeenCalled()
   })
 
+  describe('directory.resolveBoundTarget — the Stop-only lookup (linear-integration.md §9.3)', () => {
+    const SESSION_KEY = 'C123/agent-session-1'
+    const BOUND = { agentId: AGENT_ID, daemonId: DAEMON_ID, integrationId: INTEGRATION_ID }
+
+    it('answers the memory hit without ever asking the CP', async () => {
+      const { daemon } = online()
+      const lookupThread = vi.fn(async (): Promise<RcThreadLookupOk> => ({
+        botId: BOT_ID,
+        sessionKey: SESSION_KEY,
+        target: null,
+        participants: []
+      }))
+      const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, lookupThread }))
+      const internals = internalsOf(manager)
+      internals.router.upsert(channelOwned())
+      internals.router.setAffinity(BOT_ID, SESSION_KEY, BOUND)
+
+      expect(await internals.ingressHost.directory.resolveBoundTarget(BOT_ID, SESSION_KEY)).toEqual(BOUND)
+      expect(lookupThread).not.toHaveBeenCalled()
+    })
+
+    it('asks the CP in STOP mode on a memory miss and caches the validated hit back', async () => {
+      const { daemon } = online()
+      const lookupThread = vi.fn(async (): Promise<RcThreadLookupOk> => ({
+        botId: BOT_ID,
+        sessionKey: SESSION_KEY,
+        target: { agentId: AGENT_ID, daemonId: DAEMON_ID, integrationId: INTEGRATION_ID },
+        participants: []
+      }))
+      const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, lookupThread }))
+      const internals = internalsOf(manager)
+      internals.router.upsert(channelOwned())
+
+      expect(await internals.ingressHost.directory.resolveBoundTarget(BOT_ID, SESSION_KEY)).toEqual(BOUND)
+      expect(lookupThread).toHaveBeenCalledWith({ botId: BOT_ID, sessionKey: SESSION_KEY, mode: 'stop' })
+      // Cached: a second stop on the same session costs no round trip.
+      expect(await internals.ingressHost.directory.resolveBoundTarget(BOT_ID, SESSION_KEY)).toEqual(BOUND)
+      expect(lookupThread).toHaveBeenCalledTimes(1)
+    })
+
+    it('answers NOBODY when the CP holds no binding, and never arbitrates a replacement', async () => {
+      const { daemon } = online()
+      const lookupThread = vi.fn(async (): Promise<RcThreadLookupOk> => ({
+        botId: BOT_ID,
+        sessionKey: SESSION_KEY,
+        target: null,
+        participants: []
+      }))
+      const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, lookupThread }))
+      const internals = internalsOf(manager)
+      // The bot HAS a channel owner and a group default, both of which ordinary arbitration would
+      // happily return — a stop must reach the holder or nobody (§9.3).
+      internals.router.upsert(channelOwned())
+
+      expect(await internals.ingressHost.directory.resolveBoundTarget(BOT_ID, SESSION_KEY)).toBeUndefined()
+    })
+
+    it('drops a bound holder whose daemon is not connected to this relay', async () => {
+      const lookupThread = vi.fn(async (): Promise<RcThreadLookupOk> => ({
+        botId: BOT_ID,
+        sessionKey: SESSION_KEY,
+        target: null,
+        participants: []
+      }))
+      const manager = new RelayIngressManager(deps({ getDaemon: () => undefined, lookupThread }))
+      const internals = internalsOf(manager)
+      internals.router.upsert(channelOwned())
+      internals.router.setAffinity(BOT_ID, SESSION_KEY, BOUND)
+
+      // Placement is part of the validation, so an unplaced holder falls to the CP leg and then
+      // to nobody, rather than being handed a route no daemon on this pod can take.
+      expect(await internals.ingressHost.directory.resolveBoundTarget(BOT_ID, SESSION_KEY)).toBeUndefined()
+    })
+
+    it('answers nobody when the CP link is down', async () => {
+      const { daemon } = online()
+      const lookupThread = vi.fn(async (): Promise<RcThreadLookupOk> => {
+        throw new Error('cp link down')
+      })
+      const manager = new RelayIngressManager(deps({ getDaemon: () => daemon, lookupThread }))
+      const internals = internalsOf(manager)
+      internals.router.upsert(channelOwned())
+
+      expect(await internals.ingressHost.directory.resolveBoundTarget(BOT_ID, SESSION_KEY)).toBeUndefined()
+    })
+  })
+
   it('restores every durable participant from CP lookup after a relay restart', async () => {
     const first = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
     const second = vi.fn(async (m: RdMsgIm): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -11,7 +11,12 @@ import type {
   WireFeishuCardActionEvent,
   WireNormalizedMessage
 } from '@agentconnect.md/protocol'
-import { RD_ACK_NOT_HOLDER, MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
+import {
+  RD_ACK_NOT_HOLDER,
+  MAX_AGENT_CALL_HOPS,
+  buildRelayCpFrame,
+  decodeRelayCpFrame
+} from '@agentconnect.md/protocol'
 import { FakeClock } from '@agentconnect.md/connection'
 import { RelayIngressManager, type RelayIngressManagerDeps } from './relay-ingress-manager.js'
 // The dedup-id minters belong to their platform plugins (§8: the plugin mints
@@ -28,7 +33,7 @@ import {
 import { forwardFeishuCardAction, httpFeishuActionMsgId } from './platforms/feishu/ingress-plugin.js'
 import { DemuxIndex, relayIngressPlugins } from './platforms/registry.js'
 import type { RelayBotIngress, RelayPlatformIngressPlugin } from './platforms/contract.js'
-import { BotArbitrationRouter, mapAgentDirectory, type BotAssignment } from './bot-arbitration.js'
+import { BotArbitrationRouter, mapAgentDirectory, toRoutesPatch, type BotAssignment } from './bot-arbitration.js'
 import type {
   HttpSlackSessionAction,
   HttpSlackSessionShortcut,
@@ -1406,6 +1411,150 @@ describe('RelayIngressManager thread affinity (report + pull-on-miss)', () => {
     expect(sendMsg).toHaveBeenCalledTimes(1)
     // A CP-seeded route is NOT reported back to the CP.
     expect(reportThreadAssign).not.toHaveBeenCalled()
+  })
+
+  describe('rc/routes carries a conversation-default edit end to end', () => {
+    const TEAM = '00000000-0000-4000-8000-0000000000t1'
+    const APP_USER = '00000000-0000-4000-8000-0000000000a1'
+
+    /** Two placed members, TEAM defaulting to AGENT_ID, no scoped route — the compile's
+     *  output for an `ownerAsDefault` platform. */
+    const linearAssignment = (): BotAssignment => ({
+      botId: BOT_ID,
+      platform: 'linear',
+      secrets: { signingSecret: 'lin_wh_secret' },
+      botUserId: APP_USER,
+      members: [
+        { daemonId: DAEMON_ID, agentIds: [AGENT_ID] },
+        { daemonId: OTHER_DAEMON_ID, agentIds: [OTHER_AGENT_ID] }
+      ],
+      agents: [
+        { agentId: AGENT_ID, name: 'agent', daemonId: DAEMON_ID, integrationId: INTEGRATION_ID },
+        { agentId: OTHER_AGENT_ID, name: 'other', daemonId: OTHER_DAEMON_ID, integrationId: OTHER_INTEGRATION_ID }
+      ],
+      routes: [
+        {
+          agentId: AGENT_ID,
+          daemonId: DAEMON_ID,
+          integrationId: INTEGRATION_ID,
+          match: { kind: 'keyword', value: 'agent' }
+        },
+        {
+          agentId: OTHER_AGENT_ID,
+          daemonId: OTHER_DAEMON_ID,
+          integrationId: OTHER_INTEGRATION_ID,
+          match: { kind: 'keyword', value: 'other' }
+        }
+      ],
+      conversationDefaults: [{ channel: TEAM, agentId: AGENT_ID, daemonId: DAEMON_ID, integrationId: INTEGRATION_ID }],
+      ownerAsDefault: true
+    })
+
+    /** A bare delegation: no member named, so only the default rung can answer it. */
+    const delegation = (thread: string): WireNormalizedMessage => ({
+      msgId: `linear:${thread}:created`,
+      traceId: 't',
+      source: 'user',
+      platform: 'linear',
+      channel: TEAM,
+      thread,
+      sender: { id: 'linear:U1', isBot: false },
+      text: 'take a look at the failing job',
+      mentionedBots: [APP_USER],
+      isDm: false
+    })
+
+    /** The wire frame the CP's `syncRoutes` broadcasts after an owner edit, decoded through
+     *  the real codec so the test cannot pass on a field the schema does not carry. */
+    const routesFrame = (
+      owner: { agentId: string; daemonId: string; integrationId: string },
+      gatedAgentIds: string[] = []
+    ) => {
+      const a = linearAssignment()
+      const built = buildRelayCpFrame('rc/routes', {
+        botId: BOT_ID,
+        members: a.members,
+        agents: a.agents.map((entry) => ({
+          agentId: entry.agentId,
+          name: entry.name,
+          daemonId: entry.daemonId!,
+          integrationId: entry.integrationId!
+        })),
+        routes: a.routes,
+        gatedAgentIds,
+        conversationDefaults: [{ channel: TEAM, ...owner }]
+      })
+      const decoded = decodeRelayCpFrame(JSON.stringify(built))
+      if (!decoded.ok || decoded.frame.type !== 'rc/routes') throw new Error('expected a decodable rc/routes')
+      return decoded.frame.payload
+    }
+
+    it('re-targets the next bare delegation without a new rc/bot-assign', async () => {
+      // The bug this pins: the CP emits the edit on `rc/routes`, but if any hand-off between
+      // the frame and the router drops `conversationDefaults`, every connected relay keeps
+      // routing the team at its OLD default until a reassignment or a restart.
+      const first = vi.fn(async (m: { msgId: string }): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+      const second = vi.fn(async (m: { msgId: string }): Promise<RdAck> => ({ msgId: m.msgId, accepted: true }))
+      const daemons: Record<string, RelayDaemonConnection> = {
+        [DAEMON_ID]: { sendMsg: first } as unknown as RelayDaemonConnection,
+        [OTHER_DAEMON_ID]: { sendMsg: second } as unknown as RelayDaemonConnection
+      }
+      const manager = new RelayIngressManager(deps({ getDaemon: (id) => daemons[id] }))
+      const internals = internalsOf(manager)
+      internals.router.upsert(linearAssignment())
+
+      await internals.forward(BOT_ID, delegation('agent-session-1'))
+      expect(first).toHaveBeenCalledTimes(1)
+      expect(second).not.toHaveBeenCalled()
+
+      // The owner edit, through the exact path index.ts runs: frame → toRoutesPatch → manager.
+      manager.updateRoutes(
+        BOT_ID,
+        toRoutesPatch(
+          routesFrame({
+            agentId: OTHER_AGENT_ID,
+            daemonId: OTHER_DAEMON_ID,
+            integrationId: OTHER_INTEGRATION_ID
+          })
+        )
+      )
+
+      await internals.forward(BOT_ID, delegation('agent-session-2'))
+      expect(second).toHaveBeenCalledTimes(1)
+      expect(first).toHaveBeenCalledTimes(1)
+      const [sent] = second.mock.calls[0]! as [RdMsgIm]
+      expect(sent).toMatchObject({ agentId: OTHER_AGENT_ID, integrationId: OTHER_INTEGRATION_ID })
+    })
+
+    it('withdraws the old gated grant in the same update, so a bound follow-up is refused', async () => {
+      // The default seat IS the grant on such a platform, so the hot update has to move both
+      // facts together — a stale default would keep honouring a withdrawn binding.
+      const { daemon, sendMsg } = online()
+      const manager = new RelayIngressManager(deps({ getDaemon: () => daemon }))
+      const internals = internalsOf(manager)
+      internals.router.upsert({ ...linearAssignment(), gatedAgentIds: [AGENT_ID] })
+      internals.router.setAffinity(BOT_ID, `${TEAM}/agent-session-1`, {
+        agentId: AGENT_ID,
+        daemonId: DAEMON_ID,
+        integrationId: INTEGRATION_ID
+      })
+
+      expect(await internals.forward(BOT_ID, delegation('agent-session-1'))).toBe('accepted')
+      expect(sendMsg).toHaveBeenCalledTimes(1)
+
+      // The CP keeps emitting the gating fence on the hot update; only the seat moves.
+      manager.updateRoutes(
+        BOT_ID,
+        toRoutesPatch(
+          routesFrame({ agentId: OTHER_AGENT_ID, daemonId: OTHER_DAEMON_ID, integrationId: OTHER_INTEGRATION_ID }, [
+            AGENT_ID
+          ])
+        )
+      )
+
+      expect(await internals.forward(BOT_ID, delegation('agent-session-1'))).toBe('refused')
+      expect(sendMsg).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('directory.resolveBoundTarget — the Stop-only lookup (linear-integration.md §9.3)', () => {

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -40,6 +40,7 @@ import { DemuxIndex, IngressPool, relayIngressPlugins } from './platforms/regist
 import type {
   HandledDelivery,
   RelayBotIngress,
+  RelayForwardOutcome,
   RelayIngressHost,
   RelayIngressSidecar,
   RelayPlatformIngressPlugin
@@ -203,6 +204,7 @@ export class RelayIngressManager {
         channelOwner: (botId, channelId) => this.router.channelOwner(botId, channelId),
         targetForAgentId: (botId, agentId) => this.router.targetForAgentId(botId, agentId),
         resolveTarget: (botId, coords) => this.resolveConversationTarget(botId, coords),
+        resolveBoundTarget: (botId, sessionKey) => this.resolveBoundTarget(botId, sessionKey),
         conversationParticipants: (botId, coords) =>
           this.router.conversationParticipants(
             botId,
@@ -878,14 +880,14 @@ export class RelayIngressManager {
     botId: string,
     msg: import('@agentconnect.md/protocol').WireNormalizedMessage,
     sidecar?: RelayIngressSidecar
-  ): Promise<void> {
+  ): Promise<RelayForwardOutcome> {
     // send-message-routing-rework.md §2.3/§6: agent-authored traffic takes its OWN
     // ladder and never continues into the human one. Handled BEFORE arbitration for the
     // same reason the blanket filter used to be: an agent's platform copy must not mutate
     // thread affinity or produce a CP assignment report on its way through.
     if (this.isAgentBotMessage(botId, msg)) {
       await this.forwardVerifiedAgentMessage(botId, msg, sidecar)
-      return
+      return 'accepted'
     }
     const sessionKey = sessionKeyOf(msg)
     const assignment = this.router.get(botId)
@@ -900,7 +902,16 @@ export class RelayIngressManager {
     const addressesBot = msg.isDm || (msg.isGroupDm === true && namesThisBot)
     if (addressesBot && !msg.sender.isBot) await this.reportObservedConversation(botId, msg)
     const prior = this.router.peekAffinity(botId, sessionKey)
-    let tgt = this.router.route(botId, msg)
+    const arbitration = this.router.routeResult(botId, msg)
+    // Terminal (linear-integration.md §6.2): the channel's default moved off the gated
+    // agent this session is bound to, so the follow-up is refused rather than handed to
+    // the new default — a single-writer session must not gain a second runtime. Nothing
+    // below the affinity rung runs, including the CP backstop and the gating notice.
+    if (arbitration.kind === 'refused') {
+      this.deps.log.debug(`relay-ingress(${botId}): refused ${msg.msgId} in ${sessionKey} — ${arbitration.reason}`)
+      return 'refused'
+    }
+    let tgt: RouteTarget | null = arbitration.kind === 'target' ? arbitration.target : null
     // Third-party bots retain their strict explicit-mention-only behavior. Participant
     // fan-out is for humans and verified AgentConnect authors; treating an arbitrary bot
     // like a person in the room would let one mention wake unrelated joined agents.
@@ -948,18 +959,18 @@ export class RelayIngressManager {
           if (!this.ingestFor(botId)?.egress) tgt = this.router.soleGatedTarget(botId) ?? null
           if (!tgt) {
             await this.noticeGatedUnrouted(botId, msg)
-            return
+            return 'accepted'
           }
         }
       }
       // Backstop leg: only a real un-mentioned threaded follow-up is worth a CP lookup.
       if (!tgt) {
-        if (!this.router.isUnmentionedThreadFollowup(botId, msg)) return
+        if (!this.router.isUnmentionedThreadFollowup(botId, msg)) return 'accepted'
         let lookup: Awaited<ReturnType<RelayIngressManagerDeps['lookupThread']>>
         try {
           lookup = await this.deps.lookupThread({ botId, sessionKey })
         } catch {
-          return // CP down — drop (bounded loss); a mention re-anchors the thread.
+          return 'accepted' // CP down — drop (bounded loss); a mention re-anchors the thread.
         }
         for (const participant of lookup.participants) {
           const current = this.router.agentTarget(botId, participant.agentId, msg.channel)
@@ -969,12 +980,17 @@ export class RelayIngressManager {
         }
         if (!lookup.target && lookup.participants.length === 0) {
           this.router.rememberNoAffinity(botId, sessionKey)
-          return
+          return 'accepted'
         }
         // Seeded from the CP — do NOT report it back (it came from the CP).
         if (lookup.target) {
-          if (!this.router.seedLookupTarget(botId, sessionKey, lookup.target)) return
-          tgt = this.router.route(botId, msg)
+          if (!this.router.seedLookupTarget(botId, sessionKey, lookup.target)) return 'accepted'
+          const seeded = this.router.routeResult(botId, msg)
+          if (seeded.kind === 'refused') {
+            this.deps.log.debug(`relay-ingress(${botId}): refused ${msg.msgId} in ${sessionKey} — ${seeded.reason}`)
+            return 'refused'
+          }
+          tgt = seeded.kind === 'target' ? seeded.target : null
         }
         conversationTargets = msg.sender.isBot
           ? tgt
@@ -983,7 +999,7 @@ export class RelayIngressManager {
           : this.router.conversationTargets(botId, msg, tgt, undefined, [], (target) =>
               this.reportHumanParticipant(botId, sessionKey, msg.channel, tgt, target)
             )
-        if (!tgt && conversationTargets.length === 0) return
+        if (!tgt && conversationTargets.length === 0) return 'accepted'
       }
     }
     // A single-owner route is only the compatibility/reporting primary. Delivery is to
@@ -1039,6 +1055,7 @@ export class RelayIngressManager {
         )
       }
     }
+    return 'accepted'
   }
 
   /**
@@ -1118,6 +1135,32 @@ export class RelayIngressManager {
         `relay-ingress(${botId}): gating notice failed in ch=${msg.channel}: ${(err as Error).message}`
       )
     }
+  }
+
+  /**
+   * The Stop-only bound-target lookup (§8 directory.resolveBoundTarget,
+   * linear-integration.md §9.3). Bot-scoped and grant-blind: it answers with the
+   * runtime that HOLDS the session or with nobody, and never arbitrates — a miss
+   * resolving to the channel's current default would put a second daemon on a
+   * single-writer feed. The CP leg is the ordinary pull-on-miss backstop in `stop`
+   * mode, which makes the CP's own answer grant-blind too.
+   */
+  private async resolveBoundTarget(botId: string, sessionKey: string): Promise<RouteTarget | undefined> {
+    const placed = (candidate: RouteTarget | undefined): RouteTarget | undefined =>
+      candidate && this.deps.getDaemon(candidate.daemonId) ? candidate : undefined
+    const local = placed(this.router.boundTarget(botId, sessionKey))
+    if (local) return local
+    let lookup: Awaited<ReturnType<RelayIngressManagerDeps['lookupThread']>>
+    try {
+      lookup = await this.deps.lookupThread({ botId, sessionKey, mode: 'stop' })
+    } catch {
+      return undefined // CP down — nobody, rather than a guess at the holder.
+    }
+    if (!lookup.target) return undefined
+    // Cached back through the same validation a memory hit takes, so a second stop on
+    // the same session costs no CP round trip.
+    const seeded = this.router.seedLookupTarget(botId, sessionKey, lookup.target)
+    return placed(seeded?.integrationId ? seeded : undefined)
   }
 
   /**

--- a/packages/relay/src/relay-ingress-manager.ts
+++ b/packages/relay/src/relay-ingress-manager.ts
@@ -35,7 +35,13 @@ import type {
 } from '@agentconnect.md/protocol'
 import type { Clock } from '@agentconnect.md/connection'
 import type { Logger } from './log.js'
-import { BotArbitrationRouter, sessionKeyOf, type BotAssignment, type RouteTarget } from './bot-arbitration.js'
+import {
+  BotArbitrationRouter,
+  sessionKeyOf,
+  type BotAssignment,
+  type RouteTarget,
+  type RoutesPatch
+} from './bot-arbitration.js'
 import { DemuxIndex, IngressPool, relayIngressPlugins } from './platforms/registry.js'
 import type {
   HandledDelivery,
@@ -449,22 +455,7 @@ export class RelayIngressManager {
   }
 
   /** `rc/routes` — hot-update routes/members/default WITHOUT re-opening the ingest. */
-  updateRoutes(
-    botId: string,
-    patch: Pick<
-      BotAssignment,
-      | 'members'
-      | 'agents'
-      | 'routes'
-      | 'defaultAgentId'
-      | 'defaultDaemonId'
-      | 'gatedAgentIds'
-      | 'mutedChannels'
-      | 'gatedOffChannels'
-      | 'noticeAuthority'
-      | 'noticedDmConversations'
-    >
-  ): void {
+  updateRoutes(botId: string, patch: RoutesPatch): void {
     // A changed install set needs a fresh fan-out so every member gets the row.
     const prev = (this.router.get(botId)?.agents ?? []).map((agent) => agent.integrationId ?? agent.agentId).sort()
     const next = (patch.agents ?? []).map((agent) => agent.integrationId ?? agent.agentId).sort()


### PR DESCRIPTION
Item 1 of the change inventory in `docs/designs/linear-integration.md` §15, "the team is the channel (2026-09-02)", plus the control-plane side of the two frame changes it needs.

The team is the channel, so a conversation row's owner is that channel's **dispatch default** rather than an ownership route. A route would sit on the ladder's first rung and shadow both the `@<agent-name>` keyword slug and thread continuity on a platform whose every event already addresses the bot — so the ladder gains a rung instead.

## `packages/protocol`

- `RcBotAssign` gains `conversationDefaults` (`{ channel, agentId, daemonId, integrationId }[]`, default `[]`) and `ownerAsDefault: boolean` (default `false`).
- `conversationDefaults` also rides `RcRoutes`, the hot update an owner edit converges through — without it a connected relay keeps the old default, and with it the old grant, after exactly the edit the rung exists for. The immutable axis stays assignment-scoped.
- `rc/thread-lookup` gains `mode?: 'stop'`; its `ok` reply's target gains an optional `integrationId`.

**Not** renaming the `soleConversation` manifest axis here — that lands in step 2 with the control-plane arms it retires, so the compile still reads the old name for the new meaning.

## `packages/relay` (and the ladder in `packages/activation-policy`)

- The **per-conversation default rung**, between the unscoped keyword slug and the group's `defaultAgentId`. The ladder itself is package-owned since the relay fold-in, so the rung lands in `arbitrateSharedBot` with the assignment facts it reads; `bot-arbitration.ts` keeps the assignment shape, `updateRoutes`, and the stateful remainder.
- The thread-affinity gate honours a gated agent while it is the session channel's `conversationDefaults` entry, alongside the scoped-route test it applies today — the same grant, read from where it now lives.
- On an `ownerAsDefault` assignment a rejected gated binding is the terminal `{ kind: 'refused', reason: 'grant-withdrawn' }` rather than a miss: a Linear AgentSession has one writer, and the channel's new default must not answer inside a session another runtime still holds. On any other assignment it stays an ordinary miss and Slack's fall-through is unchanged. An empty list plus a false flag leaves the ladder exactly as it was.
- `RelayIngressHost.directory.resolveBoundTarget(botId, sessionKey)` — the Stop-only lookup: the stored affinity target validated against membership and placement but **not** the grant, backed on a memory miss by the existing `rc/thread-lookup` pull with the new stop mode, validated and cached back on a hit, and never falling through to arbitration.
- Linear plugin: `channel` = `issue.team.id`, the workspace id for an issue-less event; the adapter bag carries `team`; `forwardLinearStop` resolves through `resolveBoundTarget` and drops with a warning on nobody; `handle` drops a refused delivery with one debug log and still answers 200. The dedup identity is untouched.
- `RelayIngressHost.forward` now returns a `RelayForwardOutcome` so a plugin can see a refusal; Slack and Feishu ignore it.

## `packages/control-plane`

- The HTTP-bot compile projects each row owner (owner set, trigger not off) into `conversationDefaults` and sets `ownerAsDefault` from the manifest, for such platforms only; it still emits no ownership route for them, and `defaultAgentId` returns to its generic earliest-non-gated derivation as the backstop for a team with no row yet.
- `syncRoutes` emits `conversationDefaults` on `rc/routes`.
- The `rc/thread-lookup` handler answers a stop-mode request grant-blind from the affinity store or `session_meta` plus placement, with the holder's `integrationId` on that bot. The cross-bot ambiguity guard survives the mode — it protects against naming the wrong bot's holder, which no stop may do either.

No row, seed, or gating changes: those are step 2.

## `packages/daemon`

Only the tolerant read of the new bag field. Coordinates, `channelName` and the §8 header adopt the team in their own change.

## Tests

New: protocol codec round-trips for both new fields and the stop mode; relay — team-keyed `channel`, the default rung winning over the group's and losing to a keyword match and to thread affinity, `updateRoutes` replacing the defaults, a gated agent's affinity holding while it is the channel's default and refusing once the default moves (falling through on a plain assignment), `resolveBoundTarget` bot-scoped / grant-blind / never arbitrating, the stop drop on nobody, the refused-delivery drop; control plane — the compile's defaults and flag, an Off row excluded, the hot update carrying them, and the lookup handler's stop mode. The tests that pinned the old workspace-keyed shapes were rewritten rather than kept alongside.

```
pnpm --filter @agentconnect.md/{protocol,activation-policy,relay,control-plane,daemon} typecheck   # pass
pnpm --filter @agentconnect.md/protocol test          # 29 files, 476 tests
pnpm --filter @agentconnect.md/activation-policy test # 1 file, 12 tests
pnpm --filter @agentconnect.md/relay test             # 30 files, 635 tests
pnpm --filter @agentconnect.md/control-plane test:unit # 190 files, 2233 tests
pnpm --filter @agentconnect.md/control-plane test:int  # 121 files, 1920 tests
eslint + prettier on every touched file               # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
