### PR TITLE
feat(web): make the Linear team the channel in the console

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1511,7 +1511,22 @@ tile.
     by turning its row Off or unlinking the workspace). The generic
     conversation card renders the team rows; the module's own card draws
     only the workspace-level chrome above them. The module's
-    `soleConversation` flag is gone.
+    `soleConversation` flag is gone. **Landed** with the team-as-channel
+    change, and the three reads core needed are capabilities rather than a
+    platform name: `roster: 'derived'` (the row list is the workspace's own,
+    so no row offers a way out and the module's `footerNote` replaces the
+    host's "appears here once the bot is added to it"), `triggers` (the room
+    row's vocabulary — `['off', 'mention']` here, because the platform emits
+    nothing for `any` to match), and `ownerChangeWarning`, the §6.2 copy the
+    two owner selectors confirm through
+    (`components/console/OwnerChangeGuard.tsx`, shared by the agent card's
+    rows and the org Bots roster) when a move takes a team's default off a
+    **restricted** agent — its live sessions there can be stopped but will
+    not answer again, and a new mention or delegation opens a session with
+    the new default. The org Bots row expands to the same team rows: the
+    workspace-shaped "Default dispatch" line it used to show is gone with the
+    flag, and Reconnect / Disconnect stay row actions. The session list needed
+    nothing: it already buckets by the session's channel, which is the team.
   - `messageIdentity` — agent-activity id, else `null` (never dedupes).
   - `transcriptOrdering` — default `'seq'`.
 
@@ -1686,10 +1701,14 @@ none` skips it along with everything else Linear-visible. There is **no
   compile) → daemon (coordinates, report) → web (team rows under the Bots
   row). Unreleased, so nothing is rewritten: one migration deletes the
   workspace-keyed conversation rows and sessions.
-  **Landed:** the protocol + relay rung, and the control-plane half — the
-  renamed axis, the team rows from the connect tail and the reconciler tick,
-  and the retirement of `soleConversation.ts` / `allowsTriggerControl` /
-  `gatesNewConversations`. Daemon and web remain.
+  **Landed, all four stages:** the protocol + relay rung; the control-plane
+  half — the renamed axis, the team rows from the connect tail and the
+  reconciler tick, and the retirement of `soleConversation.ts` /
+  `allowsTriggerControl` / `gatesNewConversations`; the daemon's team
+  coordinates and its team-list report; and the console, as §9.5 records —
+  the `soleConversation` axis gone from the web contract, both card surfaces
+  rendering the generic team rows, and the owner selector confirming a move
+  off a private agent.
 - **P3 — breadth.** Label → skill playbook mapping; per-team dispatch
   defaults, which did reopen §15's granularity argument and became P2.5
   above; proactive

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -312,11 +312,20 @@ describe('IntegrationChannelList footer', () => {
     expect(roomArticle('channel')).toBe('A')
   })
 
-  it('falls back to the generic noun for a platform that renders its own card', () => {
-    // Linear declares no channel-list semantics, because this list is never rendered
-    // for it (its module supplies the agent card's whole body). The lookup still has
-    // to be total, and what it answers is the host default — never a borrowed noun.
-    expect(footer('linear')).toContain('A channel appears here once the bot is added to it')
+  it('lets a DERIVED roster replace the arrival sentences with its own note', () => {
+    // Linear's team rows are the workspace's own list, upserted by the control plane, so
+    // "appears here once the bot is added to it" would describe something that never
+    // happens — and there are no direct messages to promise either.
+    const html = footer('linear')
+    expect(html).not.toContain('appears here once the bot is added to it')
+    expect(html).not.toContain('Direct messages appear when someone writes to the bot')
+    expect(html).toContain('Every team of this workspace is listed here')
+  })
+
+  it('falls back to the generic noun for a platform no module claims', () => {
+    // The lookup has to be total — an integration row carries whatever platform the CP
+    // sent — and what it answers is the host default, never a borrowed noun.
+    expect(footer('not-a-platform')).toContain('A channel appears here once the bot is added to it')
   })
 })
 

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -8,6 +8,7 @@ import { Icon } from '@/components/ui'
 import { AgentIconView } from '@/components/marks'
 import { channelListSemantics } from '@/components/console/platforms/registry'
 import { TriggerSelect, type TriggerOption } from '@/components/console/TriggerSelect'
+import { useOwnerChangeGuard } from '@/components/console/OwnerChangeGuard'
 import type { AgentIcon } from '@/lib/agent-icon'
 import { chatPlatformName } from '@/lib/platform-labels'
 
@@ -39,21 +40,24 @@ function TriggerToggle({
   // else to say so. A GROUP DM takes the channel's choice, not the DM's: several people
   // share it, so "every message" must stay opt-in.
   const here = `this ${rowNoun(channel.kind, platform)}`
+  // The room's vocabulary is the platform's: nothing matches "any message" where no unaddressed traffic exists.
+  const allowed = channelListSemantics(platform).triggers
+  const roomOptions: TriggerOption<IntegrationChannelRow['trigger']>[] = [
+    { value: 'off', label: 'off', hint: `The agent doesn't respond in ${here}, even when @-mentioned.` },
+    { value: 'any', label: 'any message', hint: `The agent responds to every message in ${here}.` },
+    {
+      value: 'mention',
+      label: '@-mention',
+      hint: "The agent responds when @-mentioned. Follow-ups in a thread it has joined don't need another mention."
+    }
+  ]
   const options: TriggerOption<IntegrationChannelRow['trigger']>[] =
     channel.kind === 'im'
       ? [
           { value: 'off', label: 'off', hint: "The agent doesn't respond in this conversation." },
           { value: 'any', label: 'on', hint: 'The agent responds to messages in this conversation.' }
         ]
-      : [
-          { value: 'off', label: 'off', hint: `The agent doesn't respond in ${here}, even when @-mentioned.` },
-          { value: 'any', label: 'any message', hint: `The agent responds to every message in ${here}.` },
-          {
-            value: 'mention',
-            label: '@-mention',
-            hint: "The agent responds when @-mentioned. Follow-ups in a thread it has joined don't need another mention."
-          }
-        ]
+      : roomOptions.filter((o) => !allowed || allowed.includes(o.value))
   return (
     <TriggerSelect
       options={options}
@@ -161,8 +165,9 @@ function groupHeader(label: string, padX: number, action?: ReactNode) {
   )
 }
 
-/** One agent that shares the bot — the shape the default-dispatch popover renders. */
-type MemberAgent = { id: string; label: string; runtime: string; icon?: AgentIcon | null }
+/** One agent that shares the bot — the shape the default-dispatch popover renders.
+ *  `restricted` is what makes a default move consequential (§6.2), so it travels with it. */
+type MemberAgent = { id: string; label: string; runtime: string; restricted: boolean; icon?: AgentIcon | null }
 
 // Per-platform display semantics come from the platform modules
 // ({@link WebChannelListSemantics}, §10); the ALGORITHMS below — grouping, the
@@ -535,6 +540,23 @@ export function IntegrationChannelList({
 }) {
   const { setChannelTrigger, setChannelAgent, forgetChannel, leaveConversation, bots, agents, integrations } =
     useConsoleData()
+  const ownerGuard = useOwnerChangeGuard()
+  // A derived roster is the platform's own list — nothing is observed into it, and nothing is dropped from here.
+  const derivedRoster = channelListSemantics(platform).roster === 'derived'
+  // Where rows come from, plus the platform's tail — which on a derived roster IS the arrival sentence, so it leads.
+  const footerNote = channelListSemantics(platform).footerNote
+  const footerSentences = [
+    ...(derivedRoster
+      ? footerNote
+        ? [footerNote]
+        : []
+      : [
+          `${roomArticle(roomNoun(platform))} ${roomNoun(platform)} appears here once the bot is added to it, and its trigger is set per conversation.`,
+          'Direct messages appear when someone writes to the bot.'
+        ]),
+    ...(shareable ? ['Default dispatch is the agent who handles unmatched messages in the conversation.'] : []),
+    ...(!derivedRoster && footerNote ? [footerNote] : [])
+  ]
   // A platform refusal is the useful half of a failed Leave — a missing scope or a
   // last-member channel tells the operator what to do — so it is shown verbatim
   // rather than collapsed into "something went wrong".
@@ -551,7 +573,13 @@ export function IntegrationChannelList({
   const memberIds = shareable && botId ? (bots.find((b) => b.id === botId)?.agentIds ?? []) : []
   const member = (id: string): MemberAgent => {
     const a = agents.find((x) => x.id === id)
-    return { id, label: a ? agentLabel(a) : id, runtime: a?.runtime ?? a?.model ?? '', icon: a?.icon }
+    return {
+      id,
+      label: a ? agentLabel(a) : id,
+      runtime: a?.runtime ?? a?.model ?? '',
+      restricted: a?.visibility === 'restricted',
+      icon: a?.icon
+    }
   }
   // The agents that share this bot. A conversation's default is its explicit owner —
   // this row's when the CP stamped it, else whichever sibling install of the bot
@@ -625,7 +653,11 @@ export function IntegrationChannelList({
                 current={def}
                 viewer={viewer}
                 disabled={!integrationId}
-                onClaim={(id) => setChannelAgent(integrationId!, c.channelId, id)}
+                onClaim={(id) =>
+                  ownerGuard.guard({ platform, from: def, toId: id, room: rowLabel(c) }, () =>
+                    setChannelAgent(integrationId!, c.channelId, id)
+                  )
+                }
               />
               {/* The design separates the two controls with a hairline — default
                   dispatch and trigger are different decisions, not one bar. */}
@@ -638,10 +670,9 @@ export function IntegrationChannelList({
             disabled={!integrationId}
             onChange={(trigger) => setChannelTrigger(integrationId!, c.channelId, trigger)}
           />
-          {/* Demo rows have no integration to act on, so they carry no button at all rather than an
-              inert one. Both callbacks are always wired; which ONE the row spends is `rowMenuAction`'s
-              call, so that rule lives in one place. */}
-          {integrationId && (
+          {/* Demo rows carry no button rather than an inert one, and a derived roster none at all — the
+              platform owns the list. Which of the two callbacks a row spends is `rowMenuAction`'s call. */}
+          {integrationId && !derivedRoster && (
             <RowAction
               channel={c}
               platform={platform}
@@ -665,7 +696,7 @@ export function IntegrationChannelList({
         >
           <Icon name="lock" size={13} className="mt-[2px] flex-none" />
           <span>
-            {`This agent is private: conversations start off. Enable each ${roomNoun(platform)} or direct message below before the agent responds there.`}
+            {`This agent is private: conversations start off. Enable each ${roomNoun(platform)}${derivedRoster ? '' : ' or direct message'} below before the agent responds there.`}
           </span>
         </div>
       )}
@@ -692,20 +723,9 @@ export function IntegrationChannelList({
         style={{ padding: `10px ${padX}px` }}
       >
         <Icon name="info" size={14} className="mt-[3px] flex-none" />
-        <span>
-          {/* Says where rows COME FROM, and — only where the row menu cannot do it —
-              where leaving is done instead. It deliberately no longer narrates the
-              menu's own items: those explain themselves on screen, and repeating them
-              here in different words was most of what made this card read oddly. */}
-          {`${roomArticle(roomNoun(platform))} ${roomNoun(platform)} appears here once the bot is added to it, and its trigger is set per conversation.`}
-          {' Direct messages appear when someone writes to the bot.'}
-          {shareable && ' Default dispatch is the agent who handles unmatched messages in the conversation.'}
-          {/* The platform's own tail, when it has one: Discord's servers-not-channels
-              note, Slack's remove-it-in-Slack note (which encodes an authoritative
-              membership snapshot — the list updates by itself). */}
-          {channelListSemantics(platform).footerNote && ` ${channelListSemantics(platform).footerNote}`}
-        </span>
+        <span>{footerSentences.join(' ')}</span>
       </div>
+      {ownerGuard.dialog}
     </>
   )
 }

--- a/packages/web/src/components/console/OwnerChangeGuard.test.ts
+++ b/packages/web/src/components/console/OwnerChangeGuard.test.ts
@@ -1,0 +1,30 @@
+// When a conversation-owner move has to be confirmed. Three conditions, and each one on
+// its own is a reason to write straight through: the platform must declare the warning
+// (owner-as-default, linear-integration.md §6.2), the outgoing owner must be resolvable
+// AND private, and the incoming one must actually differ.
+
+import { describe, expect, it } from 'vitest'
+import { ownerChangeNeedsWarning } from './OwnerChangeGuard'
+
+const priv = { id: 'agent-b', label: 'triage-bot', restricted: true }
+const open = { id: 'agent-c', label: 'docs-bot', restricted: false }
+
+describe('ownerChangeNeedsWarning', () => {
+  it('warns when a declaring platform moves a team off a private agent', () => {
+    expect(ownerChangeNeedsWarning({ platform: 'linear', from: priv, toId: 'agent-a', room: 'ENG' })).toBe(true)
+  })
+
+  it('stays silent for an unrestricted owner, an unchanged one, or an unknown one', () => {
+    expect(ownerChangeNeedsWarning({ platform: 'linear', from: open, toId: 'agent-a', room: 'ENG' })).toBe(false)
+    expect(ownerChangeNeedsWarning({ platform: 'linear', from: priv, toId: priv.id, room: 'ENG' })).toBe(false)
+    expect(ownerChangeNeedsWarning({ platform: 'linear', toId: 'agent-a', room: 'ENG' })).toBe(false)
+  })
+
+  it('stays silent on a platform whose owner compiles to a route', () => {
+    // Slack's gated grant is the owner's channel-scoped route, which the move rewrites —
+    // there is nothing to warn about, and no module declares the copy.
+    for (const platform of ['slack', 'telegram', 'discord', 'feishu', 'not-a-platform', undefined]) {
+      expect(ownerChangeNeedsWarning({ platform, from: priv, toId: 'agent-a', room: '#deploys' }), platform).toBe(false)
+    }
+  })
+})

--- a/packages/web/src/components/console/OwnerChangeGuard.tsx
+++ b/packages/web/src/components/console/OwnerChangeGuard.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+// Holds a conversation-owner move behind the platform's own warning when the move takes
+// the default off a RESTRICTED agent. On a platform whose owner compiles to a
+// per-conversation DEFAULT rather than an ownership route, that seat is the only grant a
+// gated agent holds in the room, so moving it withdraws the grant and the agent's bound
+// sessions there become stoppable but not continuable (linear-integration.md §6.2).
+// Both owner selectors — the agent page's rows and the org Bots roster — run through
+// this, so the two cannot warn differently about the same write.
+
+import { useCallback, useState, type ReactNode } from 'react'
+import { ConfirmationDialog } from './ConfirmationDialog'
+import { channelListSemantics } from './platforms/registry'
+
+/** One owner move, as the caller knows it. */
+export interface OwnerChangeMove {
+  /** The bot's platform — carried per move, because one Bots card lists several. */
+  platform?: string
+  /** The row's current owner; absent when the console cannot resolve one. */
+  from?: { id: string; label: string; restricted: boolean }
+  toId: string
+  /** The row, named the way the operator reads it. */
+  room: string
+}
+
+/** A move waiting on its confirmation: the copy it renders, the write, and the caller's resolve. */
+interface Pending {
+  copy: NonNullable<ReturnType<typeof channelListSemantics>['ownerChangeWarning']>
+  owner: string
+  room: string
+  apply: () => Promise<void>
+  done: () => void
+}
+
+/**
+ * Whether this move needs the platform's confirmation at all. Exported because the rule —
+ * a declared warning, a resolvable outgoing owner that is restricted, and a genuinely
+ * different incoming one — is the whole design and belongs in a test.
+ */
+export function ownerChangeNeedsWarning(move: OwnerChangeMove): boolean {
+  if (!channelListSemantics(move.platform).ownerChangeWarning) return false
+  return !!move.from && move.from.restricted && move.from.id !== move.toId
+}
+
+export function useOwnerChangeGuard(): {
+  /** Applies the write, or holds it until the warning is confirmed. Resolves either way. */
+  guard(move: OwnerChangeMove, apply: () => Promise<void>): Promise<void>
+  dialog: ReactNode
+} {
+  const [pending, setPending] = useState<Pending | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const guard = useCallback((move: OwnerChangeMove, apply: () => Promise<void>): Promise<void> => {
+    const copy = channelListSemantics(move.platform).ownerChangeWarning
+    const from = move.from
+    if (!copy || !ownerChangeNeedsWarning(move) || !from) return apply()
+    return new Promise<void>((done) => setPending({ copy, owner: from.label, room: move.room, apply, done }))
+  }, [])
+
+  // Cancelling resolves the caller's promise without writing — its picker stops spinning
+  // and the row keeps the owner it had.
+  const close = () => {
+    if (busy) return
+    pending?.done()
+    setPending(null)
+    setError(null)
+  }
+  const confirm = () => {
+    if (!pending || busy) return
+    setBusy(true)
+    setError(null)
+    pending
+      .apply()
+      .then(() => {
+        pending.done()
+        setPending(null)
+      })
+      .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : String(cause)))
+      .finally(() => setBusy(false))
+  }
+
+  return {
+    guard,
+    dialog: pending ? (
+      <ConfirmationDialog
+        title={pending.copy.title}
+        confirmLabel={pending.copy.confirmLabel}
+        busy={busy}
+        busyLabel="Moving…"
+        error={error}
+        onConfirm={confirm}
+        onClose={close}
+      >
+        {pending.copy.body({ owner: pending.owner, room: pending.room })}
+      </ConfirmationDialog>
+    ) : null
+  }
+}

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -556,6 +556,33 @@ export interface WebChannelListSemantics {
    *  encodes `membershipEnumeration: 'authoritative'` — the list updates by
    *  itself). Absent ⇒ no extra sentence. */
   footerNote?: string
+  /**
+   * Where the rows come from. `'observed'` (the default) — each row records a room the
+   * bot was seen in, so it can be dropped from the list and the footer says how rows
+   * appear. `'derived'` — the roster is the platform's own and the console neither adds
+   * to it nor removes from it, so no row carries a way out and the footer's arrival
+   * sentence is the module's {@link footerNote} instead of the host's.
+   */
+  roster?: 'observed' | 'derived'
+  /**
+   * The room row's trigger vocabulary, host order preserved. Absent ⇒ all three
+   * (`off` / `any` / `mention`). A platform that emits no unaddressed traffic drops
+   * `any`, because nothing would ever match it. DM rows keep their binary control.
+   */
+  triggers?: readonly ('off' | 'mention' | 'any')[]
+  /**
+   * Confirmation shown before a row's default dispatch moves OFF a RESTRICTED agent.
+   * Where an owner compiles to a per-conversation default rather than an ownership
+   * route, that seat is the only grant a gated agent holds in the room, so moving it
+   * withdraws the grant. Absent ⇒ the move applies straight away, which is every
+   * platform whose owner compiles to a route.
+   */
+  ownerChangeWarning?: {
+    title: string
+    body(ctx: { owner: string; room: string }): string
+    /** Bare verb — the console's modal convention. */
+    confirmLabel: string
+  }
 }
 
 /**
@@ -563,12 +590,10 @@ export interface WebChannelListSemantics {
  * of the host's generic conversation list.
  *
  * The generic list assumes the platform's rooms are enumerable things the bot was
- * ADDED to, each with a trigger and a way out. Linear has no such axis: linking a
- * workspace IS the consent act, muting is unlinking, and the "room" the card
- * configures is the workspace itself. Rather than teach
- * {@link WebChannelListSemantics} to describe a list that must not render, a module
- * with a different card body supplies one — and declares no `channelList`, so the
- * generic one is not reached at all.
+ * ADDED to, each with a trigger and a way out. A module whose card needs chrome ABOVE
+ * that list — Linear's connected workspace, with its grant status, Reconnect and
+ * unlink — supplies a Body that draws the chrome and mounts the generic list itself,
+ * so the rows keep the console's one dispatch selector and trigger control.
  *
  * The host keeps the card CHROME (mark, name, connected badge, delete). The Body gets
  * the integration row — which names its own agent, so there is no second prop for the
@@ -663,20 +688,14 @@ export interface WebPlatformModule<TApi = unknown> {
   /** Out-of-wizard install polling (Slack today). */
   installPolling?: WebInstallPollingFacet
   /** Channel-list display semantics. Absent ⇒ the host defaults: `channel`
-   *  noun, `#` glyph, `leave: 'none'`, generic copy — which a platform declaring
-   *  {@link agentCard} never spends, because the generic list is not rendered
-   *  for it at all. */
+   *  noun, `#` glyph, `leave: 'none'`, generic copy. A module with its own
+   *  {@link agentCard} still spends these, because that card mounts the same
+   *  generic list under its chrome. */
   channelList?: WebChannelListSemantics
-  /** The agent page's card body, replacing the generic conversation list.
-   *  Absent ⇒ that list, which is every platform whose rooms are enumerable. */
+  /** The agent page's card body, wrapping the generic conversation list in the
+   *  platform's own chrome. Absent ⇒ the bare list, which is every platform
+   *  with nothing to say above its rooms. */
   agentCard?: WebAgentIntegrationCardFacet
-  /**
-   * The console's mirror of the §5 manifest's `soleConversation`: the bot IS its one
-   * conversation (Linear — a workspace is the channel), so the Settings → Bots row
-   * expands to that conversation's default dispatch alone, never to a roster that
-   * would list the workspace beneath itself. Absent ⇒ the generic roster.
-   */
-  soleConversation?: true
   /**
    * Per-platform transcript text renderer — the §14 defect-3 seam, ADOPTED:
    * `MessageText` resolves it from the ROW's platform key

--- a/packages/web/src/components/console/platforms/linear/card.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/card.test.tsx
@@ -1,19 +1,25 @@
 // @vitest-environment happy-dom
 
-// The AGENT page's Linear card: one row per linked workspace, with its owner, a reconnect
-// and a way out. What must NOT be there matters as much: no trigger, no issue list, and no
-// Disconnect — that one ends the workspace for every agent, so it is the org view's.
+// The AGENT page's Linear card: the connected workspace as chrome — name, grant status,
+// Reconnect, unlink — over the generic conversation list of its TEAM rows (§4.3, §9.5).
+// What must NOT be there matters as much: no Disconnect (that ends the workspace for every
+// agent, so it is the org view's), no "any message" trigger (the platform emits no
+// unaddressed traffic) and no way to leave or drop a team (the roster is the workspace's).
 
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BotDto } from '@/lib/api'
-import type { Agent, IntegrationRow } from '@/lib/data'
+import type { Agent, IntegrationChannelRow, IntegrationRow } from '@/lib/data'
 
 const mocks = vi.hoisted(() => ({
   bots: [] as BotDto[],
   agents: [] as Agent[],
+  integrations: [] as IntegrationRow[],
   setChannelAgent: vi.fn(),
+  setChannelTrigger: vi.fn(),
+  forgetChannel: vi.fn(),
+  leaveConversation: vi.fn(),
   deleteIntegration: vi.fn(),
   refresh: vi.fn(),
   reconnectLinearWorkspace: vi.fn(),
@@ -30,8 +36,17 @@ vi.mock('@/lib/data-context', () => ({
     get bots() {
       return mocks.bots
     },
+    get agents() {
+      return mocks.agents
+    },
+    get integrations() {
+      return mocks.integrations
+    },
     getAgent: (id: string) => mocks.agents.find((a) => a.id === id),
     setChannelAgent: mocks.setChannelAgent,
+    setChannelTrigger: mocks.setChannelTrigger,
+    forgetChannel: mocks.forgetChannel,
+    leaveConversation: mocks.leaveConversation,
     deleteIntegration: mocks.deleteIntegration,
     refresh: mocks.refresh
   })
@@ -51,7 +66,7 @@ function bot(over: Partial<BotDto> = {}): BotDto {
     transport: 'http',
     shareable: true,
     inUseByAgentId: null,
-    agentIds: ['agent-a', 'agent-b'],
+    agentIds: ['agent-a', 'agent-b', 'agent-c'],
     lastUsedAt: null,
     freedFromAgent: null,
     workspaceName: 'Example Workspace',
@@ -60,7 +75,12 @@ function bot(over: Partial<BotDto> = {}): BotDto {
   }
 }
 
-/** The workspace's conversation row — the seeded `IntegrationChannel` the PATCH addresses. */
+/** The workspace's team rows — one `IntegrationChannel` per Linear team, as the CP upserts them. */
+const TEAMS: IntegrationChannelRow[] = [
+  { channelId: 'team-eng', name: 'ENG · Engineering', kind: 'channel', trigger: 'mention', agentId: 'agent-b' },
+  { channelId: 'team-des', name: 'DES · Design', kind: 'channel', trigger: 'off', agentId: 'agent-c' }
+]
+
 function integration(over: Partial<IntegrationRow> = {}): IntegrationRow {
   return {
     id: 'int-a',
@@ -73,8 +93,8 @@ function integration(over: Partial<IntegrationRow> = {}): IntegrationRow {
     workspace: 'Example Workspace',
     daemon: 'edge-1',
     status: 'online',
-    agentCount: '2',
-    channels: [{ channelId: 'ws-1', name: 'Example Workspace', trigger: 'any', agentId: 'agent-b' }],
+    agentCount: '3',
+    channels: TEAMS,
     ...over
   }
 }
@@ -82,13 +102,13 @@ function integration(over: Partial<IntegrationRow> = {}): IntegrationRow {
 let host: HTMLDivElement
 let root: Root
 
-const text = () => host.textContent ?? ''
-// The dispatch menu is portaled to <body>, so its options live outside the mount host.
+const text = () => document.body.textContent ?? ''
+// The dispatch and trigger menus are portaled, so their options live outside the mount host.
 const buttons = () => [...document.querySelectorAll('button')]
 const buttonWithLabel = (label: string) =>
   buttons().find((b) => b.getAttribute('aria-label')?.includes(label)) as HTMLButtonElement | undefined
-const buttonWithTitle = (title: string) =>
-  buttons().find((b) => b.getAttribute('title')?.includes(title)) as HTMLButtonElement | undefined
+const buttonWithText = (label: string) =>
+  buttons().find((b) => b.textContent?.includes(label)) as HTMLButtonElement | undefined
 
 async function settle(): Promise<void> {
   for (let attempt = 0; attempt < 10; attempt += 1) {
@@ -102,19 +122,38 @@ async function render(row: IntegrationRow = integration()): Promise<void> {
   await act(async () => root.render(<LinearWorkspaceRows integration={row} padX={14} />))
 }
 
+/** The rows' dispatch pickers, in row order — the picker names its OWNER, not its row. */
+const dispatchPickers = () => buttons().filter((b) => b.getAttribute('aria-label')?.startsWith('Default dispatch'))
+
+/** Opens the nth team's dispatch menu and claims that row for the page's own agent. */
+async function claimRow(index: number): Promise<void> {
+  await act(async () => dispatchPickers()[index]!.click())
+  await act(async () => buttonWithText('Make')!.click())
+}
+
 beforeEach(() => {
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
   mocks.bots = [bot()]
   mocks.agents = [
-    { id: 'agent-a', name: 'deploy-bot', runtime: 'claude' },
-    { id: 'agent-b', name: 'triage-bot', runtime: 'codex' }
+    { id: 'agent-a', name: 'deploy-bot', runtime: 'claude', visibility: 'org' },
+    { id: 'agent-b', name: 'triage-bot', runtime: 'codex', visibility: 'restricted' },
+    { id: 'agent-c', name: 'docs-bot', runtime: 'claude', visibility: 'org' }
   ] as unknown as Agent[]
-  mocks.setChannelAgent.mockReset()
-  mocks.deleteIntegration.mockReset()
-  mocks.refresh.mockReset()
-  mocks.reconnectLinearWorkspace.mockReset()
-  mocks.getLinearConnect.mockReset()
+  mocks.integrations = [integration()]
+  for (const fn of [
+    mocks.setChannelAgent,
+    mocks.setChannelTrigger,
+    mocks.forgetChannel,
+    mocks.leaveConversation,
+    mocks.deleteIntegration,
+    mocks.refresh,
+    mocks.reconnectLinearWorkspace,
+    mocks.getLinearConnect
+  ]) {
+    fn.mockReset()
+  }
   mocks.setChannelAgent.mockResolvedValue(undefined)
+  mocks.setChannelTrigger.mockResolvedValue(undefined)
   mocks.deleteIntegration.mockResolvedValue(undefined)
   mocks.getLinearConnect.mockResolvedValue({ id: 'c1', status: 'pending', failureReason: null, botId: null })
   vi.stubGlobal(
@@ -136,15 +175,20 @@ afterEach(async () => {
   vi.unstubAllGlobals()
 })
 
-describe('the workspace row', () => {
-  it('names the workspace and says where sessions come from — no issue list, no trigger', async () => {
+describe('the workspace chrome', () => {
+  it('names the workspace above the team rows', async () => {
     await render()
 
     expect(text()).toContain('Example Workspace')
-    expect(text()).toContain('Sessions start when someone delegates or mentions the app on an issue in this workspace.')
-    // Linking is the consent act and unlinking is the mute, so no trigger belongs here.
-    expect(text()).not.toContain('@-mention')
-    expect(buttonWithLabel('Trigger for')).toBeUndefined()
+    expect(text()).toContain('ENG · Engineering')
+    expect(text()).toContain('DES · Design')
+  })
+
+  it('says the roster is the workspace’s own, not something the bot was added to', async () => {
+    await render()
+
+    expect(text()).toContain('Every team of this workspace is listed here')
+    expect(text()).not.toContain('appears here once the bot is added to it')
   })
 
   it('never offers Disconnect — that removes the workspace for every agent', async () => {
@@ -155,45 +199,104 @@ describe('the workspace row', () => {
   })
 })
 
-describe('the default-dispatch selector', () => {
-  it('reads the workspace’s current owner off the ordinary conversation row', async () => {
+describe('the team rows', () => {
+  it('carries a trigger per team, Mention or Off and nothing else', async () => {
     await render()
+    await act(async () => buttonWithLabel('Trigger for ENG · Engineering')!.click())
 
-    // The owner the CP stamped, not this agent just because it is the page's.
-    expect(buttonWithTitle('Default dispatch')?.textContent).toContain('triage-bot')
+    const menu = [...document.querySelectorAll('[role="menuitemradio"]')].map((o) => o.textContent)
+    expect(menu).toEqual(['off', '@-mention'])
+    // The platform emits no unaddressed traffic (§6.1), so nothing would match "any message".
+    expect(menu).not.toContain('any message')
   })
 
-  it('drives the existing conversation-owner PATCH, addressed to the workspace row', async () => {
+  it('writes a team’s trigger through the generic per-conversation PATCH', async () => {
     await render()
-    await act(async () => buttonWithTitle('Default dispatch')!.click())
-    const option = buttons().find((b) => b.textContent?.includes('deploy-bot'))!
-    await act(async () => option.click())
+    await act(async () => buttonWithLabel('Trigger for DES · Design')!.click())
+    await act(async () =>
+      [...document.querySelectorAll('[role="menuitemradio"]')]
+        .at(-1)!
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    )
     await settle()
 
-    expect(mocks.setChannelAgent).toHaveBeenCalledWith('int-a', 'ws-1', 'agent-a')
+    expect(mocks.setChannelTrigger).toHaveBeenCalledWith('int-a', 'team-des', 'mention')
   })
 
-  it('offers every member of the workspace as a candidate owner', async () => {
+  it('offers no way out of a team — the roster is upserted, not observed', async () => {
     await render()
-    await act(async () => buttonWithTitle('Default dispatch')!.click())
 
-    expect(buttons().filter((b) => b.textContent?.includes('deploy-bot')).length).toBeGreaterThan(0)
-    expect(buttons().filter((b) => b.textContent?.includes('triage-bot')).length).toBeGreaterThan(0)
+    expect(buttonWithLabel('Leave team')).toBeUndefined()
+    expect(buttonWithLabel('Remove from this list')).toBeUndefined()
+    expect(text()).not.toContain('Remove from this list')
   })
 
-  it('falls back to the earliest member, inert, until the conversation row is seeded', async () => {
-    // An install reporting no seeded row has no address to PATCH, so the selector is inert.
-    await render(integration({ channels: [] }))
+  it('names the room the way Linear does — the trigger copy says team, never channel', async () => {
+    await render()
 
-    expect(text()).toContain('Example Workspace')
-    const picker = buttonWithTitle('Default dispatch')!
-    expect(picker.textContent).toContain('deploy-bot')
-    await act(async () => picker.click())
-    expect(buttons().filter((b) => b.textContent?.includes('triage-bot'))).toHaveLength(0)
+    const markup = document.body.innerHTML
+    expect(markup).toContain('this team')
+    expect(markup).not.toContain('this channel')
   })
 })
 
-describe('the row’s repairs', () => {
+describe('the default-dispatch selector', () => {
+  it('reads each team’s current owner off its own row', async () => {
+    await render()
+
+    expect(dispatchPickers()[0]?.textContent).toContain('triage-bot')
+    expect(dispatchPickers()[1]?.textContent).toContain('docs-bot')
+  })
+
+  it('moves an unrestricted owner straight away, addressed to the team row', async () => {
+    await render()
+    await claimRow(1)
+    await settle()
+
+    expect(mocks.setChannelAgent).toHaveBeenCalledWith('int-a', 'team-des', 'agent-a')
+  })
+
+  it('warns before taking a team off a PRIVATE agent, and writes once confirmed', async () => {
+    await render()
+    await claimRow(0)
+
+    // §6.2: the default seat IS the gated agent's grant, and a Linear AgentSession has one
+    // writer — so its bound sessions are stoppable but never handed to the new default.
+    expect(text()).toContain('Move this team’s default?')
+    expect(text()).toContain('triage-bot is a private agent')
+    expect(text()).toContain('can still be stopped, but it will not answer in them again')
+    expect(mocks.setChannelAgent).not.toHaveBeenCalled()
+
+    await act(async () => buttonWithText('Move')!.click())
+    await settle()
+
+    expect(mocks.setChannelAgent).toHaveBeenCalledWith('int-a', 'team-eng', 'agent-a')
+    expect(text()).not.toContain('Move this team’s default?')
+  })
+
+  it('leaves the owner alone when the warning is cancelled', async () => {
+    await render()
+    await claimRow(0)
+    await act(async () => buttonWithText('Cancel')!.click())
+    await settle()
+
+    expect(mocks.setChannelAgent).not.toHaveBeenCalled()
+    expect(text()).not.toContain('Move this team’s default?')
+  })
+
+  it('keeps the warning up when the write is refused', async () => {
+    mocks.setChannelAgent.mockRejectedValue(new Error('daemon is offline'))
+    await render()
+    await claimRow(0)
+    await act(async () => buttonWithText('Move')!.click())
+    await settle()
+
+    expect(text()).toContain('daemon is offline')
+    expect(text()).toContain('Move this team’s default?')
+  })
+})
+
+describe('the workspace’s repairs', () => {
   it('reconnects THIS workspace and says the tab is open', async () => {
     mocks.reconnectLinearWorkspace.mockResolvedValue({ id: 'c1', connectUrl: 'https://linear.app/oauth/authorize' })
     await render()
@@ -248,5 +351,19 @@ describe('the row’s repairs', () => {
     await settle()
 
     expect(text()).toContain('daemon is offline')
+  })
+})
+
+describe('a private agent’s own card', () => {
+  it('says its team rows start off', async () => {
+    mocks.agents = [
+      { id: 'agent-a', name: 'deploy-bot', runtime: 'claude', visibility: 'restricted' }
+    ] as unknown as Agent[]
+    await render()
+
+    expect(text()).toContain('This agent is private: conversations start off.')
+    expect(text()).toContain('Enable each team below')
+    // Linear has no direct messages to promise.
+    expect(text()).not.toContain('or direct message')
   })
 })

--- a/packages/web/src/components/console/platforms/linear/card.tsx
+++ b/packages/web/src/components/console/platforms/linear/card.tsx
@@ -1,19 +1,21 @@
 'use client'
 
-// The AGENT page's Linear card body ({@link WebAgentIntegrationCardFacet}). Linking is the
-// consent act and unlinking is the mute, so the row carries no trigger and no issue list.
+// The AGENT page's Linear card body ({@link WebAgentIntegrationCardFacet}): the connected
+// workspace as chrome — its name, its grant status, Reconnect, and unlink this agent — over
+// the generic conversation list of the workspace's TEAM rows (§4.3, §9.5). The team is the
+// channel, so the dispatch selector and the trigger live on those rows, not up here.
 // Disconnecting ends the workspace for every agent, so that action is the org view's.
 
 import { useState } from 'react'
 import { Icon } from '@/components/ui'
-import { DefaultDispatchPicker } from '@/components/console/DefaultDispatchPicker'
-import { agentLabel, type IntegrationRow } from '@/lib/data'
+import { IntegrationChannelList } from '@/components/console/IntegrationChannelList'
+import { type IntegrationRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { linearApi } from './api'
 import { useLinearConnect } from './connect'
 
 export function LinearWorkspaceRows({ integration, padX }: { integration: IntegrationRow; padX: number }) {
-  const { bots, getAgent, setChannelAgent, deleteIntegration, refresh } = useConsoleData()
+  const { bots, getAgent, deleteIntegration, refresh } = useConsoleData()
   const [err, setErr] = useState<string | null>(null)
   const [leaving, setLeaving] = useState(false)
   const botId = integration.botId ?? ''
@@ -23,25 +25,12 @@ export function LinearWorkspaceRows({ integration, padX }: { integration: Integr
     () => void refresh()
   )
 
-  // The seeded workspace row: the default rides the same PATCH a Slack row makes.
-  const channel = integration.channels[0]
-  const memberIds = bot?.agentIds ?? []
-  const options = memberIds.map((id) => {
-    const a = getAgent(id)
-    return {
-      id,
-      name: a ? agentLabel(a) : id,
-      model: a?.model || a?.runtime || '',
-      runtime: a?.runtime || a?.model || '',
-      icon: a?.icon
-    }
-  })
-  // The CP-stamped owner; unclaimed falls back to the earliest member, as the CP does.
-  const owner = channel?.agentId ?? memberIds[0] ?? null
   const name = bot?.workspaceName || bot?.name || integration.name
   const dead = !!bot?.revokedAt
   const reconnecting = flow.phase === 'authorizing'
   const connectErr = flow.appMissing ? 'Linear isn’t set up on this deployment.' : flow.err
+  // The page's agent — a private one starts every team row off, as on any platform.
+  const agent = integration.agentId ? getAgent(integration.agentId) : undefined
 
   const unlink = () => {
     if (leaving || !integration.id) return
@@ -81,17 +70,6 @@ export function LinearWorkspaceRows({ integration, padX }: { integration: Integr
         </span>
         {dead && <span className="badge flex-none bg-(--status-error-soft) text-(--status-error)">grant expired</span>}
         <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-start">
-          {options.length > 0 && (
-            <>
-              <DefaultDispatchPicker
-                options={options}
-                activeId={owner}
-                disabled={!integration.id || !channel}
-                onPick={(id) => setChannelAgent(integration.id!, channel!.channelId, id)}
-              />
-              <span className="hidden h-[18px] w-px flex-none bg-(--border-subtle) desktop:block" />
-            </>
-          )}
           <button
             type="button"
             disabled={reconnecting || !botId}
@@ -120,16 +98,26 @@ export function LinearWorkspaceRows({ integration, padX }: { integration: Integr
           </button>
         </div>
       </div>
-      <div
-        className="flex items-start gap-2 border-t border-(--border-subtle) bg-(--surface-app) font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)"
-        style={{ padding: `10px ${padX}px` }}
-      >
-        <Icon name="info" size={14} className="mt-[3px] flex-none" />
-        <span>
-          Sessions start when someone delegates or mentions the app on an issue in this workspace.
-          {reconnecting && ' Approve the workspace in the Linear tab — this card updates once it lands.'}
-        </span>
-      </div>
+      {reconnecting && (
+        <div
+          className="flex items-start gap-2 border-t border-(--border-subtle) bg-(--surface-app) font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)"
+          style={{ padding: `10px ${padX}px` }}
+        >
+          <Icon name="info" size={14} className="mt-[3px] flex-none" />
+          <span>Approve the workspace in the Linear tab — this card updates once it lands.</span>
+        </div>
+      )}
+      {/* Sharing is structural on a Linear bot (§4.3), so every team row carries the dispatch selector. */}
+      <IntegrationChannelList
+        integrationId={integration.id}
+        channels={integration.channels}
+        botId={integration.botId}
+        agentId={integration.agentId}
+        platform={integration.platform}
+        shareable={integration.shareable ?? true}
+        gated={agent?.visibility === 'restricted'}
+        padX={padX}
+      />
     </>
   )
 }

--- a/packages/web/src/components/console/platforms/linear/index.tsx
+++ b/packages/web/src/components/console/platforms/linear/index.tsx
@@ -42,15 +42,28 @@ export const linearModule: WebPlatformModule<LinearApi> = {
   },
   settingsFragments: linearSettingsFragments,
   apiBindings: linearApi,
-  // NO `channelList`. The generic list enumerates rooms a bot was added to, each with
-  // a trigger and a way out; a Linear workspace has none of those — linking is the
-  // consent act and unlinking is how an agent goes quiet — and its issues are not a
-  // roster the console keeps. The card body below renders the workspace instead, so
-  // the generic list is never reached and its semantics would describe nothing.
+  // The TEAM is the channel (§4.3): one row per team, each with its dispatch default and an Off.
+  // The roster is the workspace's own, so nothing is left or dropped from here — a team goes
+  // quiet by turning its row Off, or the whole workspace by unlinking the agent.
+  channelList: {
+    roomNoun: 'team',
+    roomGlyph: '',
+    leave: 'none',
+    roster: 'derived',
+    // No `any`: every Linear event is addressed by construction (§6.1), so nothing would match it.
+    triggers: ['off', 'mention'],
+    footerNote:
+      'Every team of this workspace is listed here. Sessions start when someone delegates an issue to the app or mentions it, in a team that is not off.',
+    // §6.2: the default seat IS a gated agent's grant, and a Linear AgentSession has one writer (§4.6).
+    ownerChangeWarning: {
+      title: 'Move this team’s default?',
+      body: ({ owner, room }) =>
+        `${owner} is a private agent, and being ${room}’s default is what lets it act there. Its live sessions in this team can still be stopped, but it will not answer in them again. A new mention or delegation opens a session with the new default.`,
+      confirmLabel: 'Move'
+    }
+  },
+  // The card draws the workspace chrome and mounts the generic list of team rows beneath it.
   agentCard: { Body: LinearWorkspaceRows },
-  // The workspace is the channel (§4.5): the Bots row expands to its default dispatch
-  // alone, never to a roster naming the workspace beneath itself.
-  soleConversation: true,
   // Agent activities are append-only rows with their own ids (§15), so a duplicate
   // across sources is the same activity; anything else never dedupes.
   messageIdentity: (row) => (LINEAR_ACTIVITY_ID.test(row.ts) ? `ts:${row.ts}` : null),

--- a/packages/web/src/components/console/platforms/linear/module.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/module.test.tsx
@@ -5,6 +5,8 @@
 
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import { sessionFromDto, type SessionDto } from '@/lib/api'
+import { sessionChannelFilterValue } from '@/lib/data'
 import { PLATFORM_MARK_IDS } from '../marks'
 import { BOT_PLATFORMS, INTEGRATION_BLURB, isCoreTriggerKind } from '../host-projections'
 import {
@@ -66,27 +68,52 @@ describe('the linear mark', () => {
 })
 
 describe('the linear transcript and card semantics', () => {
-  it('declares NO channel list, and its own agent-card body instead', () => {
-    // The generic list enumerates rooms a bot was added to, each with a trigger and a
-    // way out. A Linear workspace has none of those, and its issues are not a roster
-    // the console keeps — so the module renders the workspace itself and the list is
-    // never reached. Declaring semantics for it would describe a list that must not
-    // exist; absence is the declaration.
-    expect(linearModule.channelList).toBeUndefined()
-    expect(linearModule.agentCard?.Body).toBeDefined()
-    expect(platformAgentCard('linear')?.Body).toBe(linearModule.agentCard?.Body)
-    // Falling back to the host defaults is what "never rendered" looks like from the
-    // lookup's side — no borrowed noun, no invented issue vocabulary.
-    expect(channelListSemantics('linear')).toEqual(DEFAULT_CHANNEL_LIST)
+  it('calls the room a team, with no glyph and no way out of one', () => {
+    // The TEAM is the channel (§4.3): the generic list renders one row per team, and the
+    // roster is the workspace's own — the CP upserts it — so nothing here is left or
+    // dropped. A team goes quiet by turning its row Off, or the workspace by unlinking.
+    const semantics = channelListSemantics('linear')
+    expect(semantics.roomNoun).toBe('team')
+    expect(semantics.roomGlyph).toBe('')
+    expect(semantics.leave).toBe('none')
+    expect(semantics.roster).toBe('derived')
+    expect(semantics).not.toEqual(DEFAULT_CHANNEL_LIST)
   })
 
-  it('is the only module that replaces the agent card', () => {
+  it('offers Mention and Off, never "any message"', () => {
+    // Every Linear event is addressed by construction (§6.1), so an "any message" arm
+    // would match nothing an operator could ever observe.
+    expect(channelListSemantics('linear').triggers).toEqual(['off', 'mention'])
+  })
+
+  it('warns before a team’s default leaves a private agent', () => {
+    // §6.2: on an owner-as-default platform the seat IS the gated agent's grant.
+    const warning = channelListSemantics('linear').ownerChangeWarning
+    expect(warning).toBeDefined()
+    // A bare verb, per the console's modal convention — never "Yes, move it".
+    expect(warning?.confirmLabel).toBe('Move')
+    const body = warning!.body({ owner: 'triage-bot', room: 'ENG · Engineering' })
+    expect(body).toContain('triage-bot is a private agent')
+    expect(body).toContain('can still be stopped, but it will not answer in them again')
+  })
+
+  it('wraps that list in its own card body, and is the only module that does', () => {
+    expect(linearModule.agentCard?.Body).toBeDefined()
+    expect(platformAgentCard('linear')?.Body).toBe(linearModule.agentCard?.Body)
     const withOwnCard = platformRegistry.all().filter((m) => m.agentCard)
     expect(withOwnCard.map((m) => m.platformId)).toEqual(['linear'])
-    // Every other platform keeps the generic list, so each still declares — or
-    // defaults — its own room semantics.
     for (const m of platformRegistry.all()) {
       if (m.platformId !== 'linear') expect(platformAgentCard(m.platformId), m.platformId).toBeUndefined()
+    }
+  })
+
+  it('is the only module whose roster is derived, or whose triggers are narrowed', () => {
+    // Both are capabilities core reads; neither may become "the platform is Linear".
+    for (const m of platformRegistry.all()) {
+      if (m.platformId === 'linear') continue
+      expect(m.channelList?.roster, m.platformId).toBeUndefined()
+      expect(m.channelList?.triggers, m.platformId).toBeUndefined()
+      expect(m.channelList?.ownerChangeWarning, m.platformId).toBeUndefined()
     }
   })
 
@@ -111,5 +138,38 @@ describe('the linear api bindings', () => {
     // console could loop over is visibility-filtered; only the server sees every member.
     expect(Object.keys(linearApi).sort()).toEqual(['disconnect', 'getConnect', 'reconnect', 'startConnect'])
     expect(module().apiBindings).toBe(linearApi)
+  })
+})
+
+describe('the linear session list', () => {
+  // The daemon keys a session on its issue's TEAM and labels it `<KEY> · <Team name>`
+  // (§4.3), so the console's generic per-channel grouping buckets by team with no
+  // Linear arm anywhere: nothing collapses a workspace into one group.
+  const session = (channel: string, channelName: string): SessionDto =>
+    ({
+      sessionId: `s-${channel}`,
+      sessionKey: { platform: 'linear', channel, thread: 'issue-1' },
+      agentId: 'agent-a',
+      title: 'Ship it',
+      status: 'running',
+      lastActivityAt: '2026-09-01T00:00:00.000Z',
+      usage: null,
+      triggeredBy: 'u1',
+      triggeredByName: 'Dana Reyes',
+      hookKind: null,
+      channelName,
+      threadUrl: null,
+      visibility: 'org'
+    }) as unknown as SessionDto
+
+  it('buckets a workspace’s sessions by their team, not into one group', () => {
+    const eng = sessionFromDto(session('team-eng', 'ENG · Engineering'))
+    const des = sessionFromDto(session('team-des', 'DES · Design'))
+
+    expect(eng.channel).toContain('ENG · Engineering')
+    expect(des.channel).toContain('DES · Design')
+    expect(sessionChannelFilterValue(eng)).toBe('team-eng')
+    expect(sessionChannelFilterValue(des)).toBe('team-des')
+    expect(sessionChannelFilterValue(eng)).not.toBe(sessionChannelFilterValue(des))
   })
 })

--- a/packages/web/src/components/console/platforms/registry.ts
+++ b/packages/web/src/components/console/platforms/registry.ts
@@ -56,7 +56,7 @@ export function channelListSemantics(platformId?: string): WebChannelListSemanti
 }
 
 /**
- * This platform's own agent-page card body, or `undefined` for the generic
+ * This platform's own agent-page card body, or `undefined` for the bare
  * conversation list. Total for the same reason every lookup here is — an
  * integration row carries whatever platform the CP sent.
  */
@@ -130,12 +130,6 @@ export function platformSupportsSharing(platformId?: string): boolean {
  */
 export function platformSharingFixed(platformId?: string): boolean {
   return (platformId ? platformRegistry.get(platformId)?.wizard.affordances.share : undefined) === 'fixed'
-}
-
-/** Whether the bot IS its one conversation (`WebPlatformModule.soleConversation`), so
- *  Settings → Bots offers the default dispatch on the row instead of a roster. */
-export function platformSoleConversation(platformId?: string): boolean {
-  return (platformId ? platformRegistry.get(platformId)?.soleConversation : undefined) === true
 }
 
 /**

--- a/packages/web/src/components/console/views/IntegrationsView.linear-teams.test.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.linear-teams.test.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment happy-dom
+/**
+ * The org Bots row for a connected Linear workspace expands to the workspace's TEAM rows,
+ * the way a Slack bot's row expands to its channels (linear-integration.md §4.3, §9.5).
+ * It used to expand to one "Default dispatch" line for the workspace as a whole; the team
+ * is the channel now, so the roster is the generic one and the dispatch selector sits on
+ * each row. Moving a team's default off a PRIVATE agent is confirmed first (§6.2).
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BotDto } from '@/lib/api'
+import type { Agent, IntegrationRow } from '@/lib/data'
+
+const mocks = vi.hoisted(() => ({
+  bots: [] as BotDto[],
+  integrations: [] as IntegrationRow[],
+  agents: [] as Agent[],
+  setChannelAgent: vi.fn()
+}))
+
+vi.mock('next/navigation', () => ({ useSearchParams: () => new URLSearchParams() }))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: vi.fn() }) }))
+vi.mock('@/lib/org-context', () => {
+  const orgs = { activeOrg: { id: 'org-1' }, myRole: 'owner', orgPath: (path: string) => path }
+  return { useOrgs: () => orgs }
+})
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    get bots() {
+      return mocks.bots
+    },
+    get integrations() {
+      return mocks.integrations
+    },
+    get agents() {
+      return mocks.agents
+    },
+    loading: false,
+    getAgent: (id: string) => mocks.agents.find((a) => a.id === id) ?? null,
+    refresh: vi.fn(),
+    deleteIntegration: vi.fn(),
+    setBotShareable: vi.fn(),
+    setChannelAgent: mocks.setChannelAgent
+  })
+}))
+vi.mock('@/components/console/GitlabCard', () => ({ default: () => <div /> }))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
+  fetchGithubInstallUrl: vi.fn(async () => null),
+  syncGithubInstallations: vi.fn(async () => [])
+}))
+
+const IntegrationsView = (await import('./IntegrationsView')).default
+
+const WORKSPACE: BotDto = {
+  id: 'ws-1',
+  name: 'Example Workspace',
+  platform: 'linear',
+  prebuilt: false,
+  slackAppId: null,
+  discordAppId: null,
+  createdBy: null,
+  transport: 'http',
+  shareable: true,
+  inUseByAgentId: null,
+  agentIds: ['agent-a', 'agent-b'],
+  lastUsedAt: null,
+  freedFromAgent: null,
+  workspaceName: 'Example Workspace',
+  createdAt: '2026-01-01T00:00:00.000Z'
+}
+
+const INSTALL: IntegrationRow = {
+  id: 'int-a',
+  agentId: 'agent-a',
+  botId: 'ws-1',
+  shareable: true,
+  name: 'Example Workspace',
+  platform: 'linear',
+  kind: 'Workspace',
+  workspace: 'Example Workspace',
+  daemon: 'edge-1',
+  status: 'online',
+  agentCount: '2',
+  channels: [
+    { channelId: 'team-des', name: 'DES · Design', kind: 'channel', trigger: 'off', agentId: 'agent-b' },
+    { channelId: 'team-eng', name: 'ENG · Engineering', kind: 'channel', trigger: 'mention', agentId: 'agent-a' }
+  ]
+}
+
+let host: HTMLDivElement
+let root: Root
+
+const buttons = () => [...document.querySelectorAll('button')]
+const buttonWithText = (label: string) =>
+  buttons().find((b) => b.textContent?.includes(label)) as HTMLButtonElement | undefined
+// The picker's trigger carries no aria-label of its own — its title names the control.
+const pickers = (view: HTMLElement) => [...view.querySelectorAll<HTMLButtonElement>('[title^="Default dispatch"]')]
+const menuItem = (label: string) =>
+  [...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')].find((b) => b.textContent?.includes(label))
+
+/** Render, switch to the Linear tab, and expand the workspace's row. */
+async function expandWorkspace(): Promise<HTMLElement> {
+  await act(async () => root.render(<IntegrationsView />))
+  const tab = [...host.querySelectorAll('button[role="tab"]')].find((b) => b.textContent?.includes('Linear'))
+  if (!tab) throw new Error('no Linear Bots tab')
+  await act(async () => (tab as HTMLButtonElement).click())
+  const row = host.querySelector<HTMLElement>('#integration-bot-ws-1')
+  if (!row) throw new Error('no bot row for the workspace')
+  await act(async () => row.click())
+  return host
+}
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  mocks.bots = [WORKSPACE]
+  mocks.integrations = [INSTALL]
+  mocks.agents = [
+    { id: 'agent-a', name: 'deploy-bot', runtime: 'claude', visibility: 'org' },
+    { id: 'agent-b', name: 'triage-bot', runtime: 'codex', visibility: 'restricted' }
+  ] as unknown as Agent[]
+  mocks.setChannelAgent.mockReset()
+  mocks.setChannelAgent.mockResolvedValue(undefined)
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+})
+
+describe('the Linear workspace’s Bots row', () => {
+  it('expands to the workspace’s team rows, each with its own dispatch selector', async () => {
+    const view = await expandWorkspace()
+
+    expect(view.textContent).toContain('DES · Design')
+    expect(view.textContent).toContain('ENG · Engineering')
+    // Not the retired single line that stood for the whole workspace.
+    expect(pickers(view)).toHaveLength(2)
+  })
+
+  it('names the room with Linear’s own noun for assistive tech', async () => {
+    const view = await expandWorkspace()
+
+    expect(view.textContent).toContain('Team:')
+    expect(view.textContent).not.toContain('Channel:')
+  })
+
+  it('keeps the workspace-level actions on the row itself', async () => {
+    const view = await expandWorkspace()
+
+    expect(view.querySelector('[aria-label="Reconnect this workspace"]')).not.toBeNull()
+    expect(view.querySelector('[aria-label="Disconnect this workspace"]')).not.toBeNull()
+  })
+
+  it('confirms before a team’s default leaves a private agent, then writes', async () => {
+    const view = await expandWorkspace()
+    // DES sorts first and is owned by the restricted agent.
+    await act(async () => pickers(view)[0]!.click())
+    await act(async () => menuItem('deploy-bot')!.click())
+
+    expect(document.body.textContent).toContain('Move this team’s default?')
+    expect(mocks.setChannelAgent).not.toHaveBeenCalled()
+
+    await act(async () => buttonWithText('Move')!.click())
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+    }
+
+    expect(mocks.setChannelAgent).toHaveBeenCalledWith('int-a', 'team-des', 'agent-a')
+  })
+
+  it('moves an unrestricted owner without a confirmation', async () => {
+    const view = await expandWorkspace()
+    await act(async () => pickers(view)[1]!.click())
+    await act(async () => menuItem('triage-bot')!.click())
+
+    expect(document.body.textContent).not.toContain('Move this team’s default?')
+    expect(mocks.setChannelAgent).toHaveBeenCalledWith('int-a', 'team-eng', 'agent-b')
+  })
+})

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -32,11 +32,12 @@ import { agentLabel, isDirectConversation, type IntegrationRow } from '@/lib/dat
 import {
   botCardCopy,
   botSharingEditable,
+  channelListSemantics,
   platformRegistry,
-  platformSharingFixed,
-  platformSoleConversation
+  platformSharingFixed
 } from '@/components/console/platforms/registry'
 import { BOT_PLATFORM_TABS, botMatchesPlatformTab } from '@/components/console/platforms/host-projections'
+import { useOwnerChangeGuard } from '@/components/console/OwnerChangeGuard'
 import DeleteBotModal from '@/components/console/modals/DeleteBotModal'
 import UninstallGithubInstallationModal from '@/components/console/modals/UninstallGithubInstallationModal'
 import GitlabCard from '@/components/console/GitlabCard'
@@ -223,6 +224,8 @@ function BotsCard({
 }) {
   const { orgPath } = useOrgs()
   const { bots, integrations, getAgent, setBotShareable, setChannelAgent, loading: dataLoading } = useConsoleData()
+  // On an owner-as-default platform the seat IS a private agent's grant, so moving it is confirmed first.
+  const ownerGuard = useOwnerChangeGuard()
   const [platformTabKey, setPlatformTabKey] = useState<string>(BOT_PLATFORM_TABS[0]?.key ?? '')
   // Bot row expanded to its channel roster (one at a time), the bot whose
   // shareable PATCH is in flight, and the last toggle denial to surface (the CP
@@ -393,6 +396,13 @@ function BotsCard({
               icon: ag?.icon
             }
           })
+          const roomNoun = channelListSemantics(b.platform).roomNoun
+          const roomLabel = roomNoun.charAt(0).toUpperCase() + roomNoun.slice(1)
+          // The outgoing owner, as the owner-change warning reads it — private is what costs.
+          const owner = (id: string | null) => {
+            const ag = id ? getAgent(id) : undefined
+            return ag ? { id: ag.id, label: agentLabel(ag), restricted: ag.visibility === 'restricted' } : undefined
+          }
           return (
             <Fragment key={b.id}>
               <div
@@ -509,24 +519,7 @@ function BotsCard({
               {CardNotice && <CardNotice bot={b} />}
               {open && (
                 <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-4 pb-[14px] pl-10 pt-3">
-                  {/* The bot IS its one conversation: the row expands to that conversation's
-                      default dispatch alone — listing the workspace beneath itself would
-                      name the same thing twice. */}
-                  {platformSoleConversation(b.platform) && showDefaultDispatch ? (
-                    <div className="flex items-center justify-between gap-[11px] rounded-lg border border-(--border-subtle) bg-(--surface-card) px-3 py-2">
-                      <span className="font-mono text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
-                        Default dispatch
-                      </span>
-                      <DefaultDispatchPicker
-                        options={agentOptions}
-                        activeId={channels[0]!.agentId ?? b.agentIds[0] ?? null}
-                        disabled={!canWrite || !channels[0]!.integrationId}
-                        onPick={(agentId) =>
-                          setChannelAgent(channels[0]!.integrationId!, channels[0]!.channelId, agentId)
-                        }
-                      />
-                    </div>
-                  ) : channels.length > 0 ? (
+                  {channels.length > 0 ? (
                     <>
                       <div
                         className={`grid ${chanGrid} gap-[11px] px-3 pb-[7px] font-mono text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)`}
@@ -552,8 +545,9 @@ function BotsCard({
                                   color="var(--text-tertiary)"
                                   className="flex-none"
                                 />
+                                {/* The room's noun is the platform's own; the two direct kinds are platform-free. */}
                                 <span className="sr-only">
-                                  {c.kind === 'mpim' ? 'Group DM' : c.kind === 'im' ? 'Direct message' : 'Channel'}
+                                  {c.kind === 'mpim' ? 'Group DM' : c.kind === 'im' ? 'Direct message' : roomLabel}
                                   :{' '}
                                 </span>
                                 <span className="truncate">
@@ -565,7 +559,17 @@ function BotsCard({
                                   options={agentOptions}
                                   activeId={c.agentId ?? b.agentIds[0] ?? null}
                                   disabled={!canWrite || !c.integrationId}
-                                  onPick={(agentId) => setChannelAgent(c.integrationId!, c.channelId, agentId)}
+                                  onPick={(agentId) =>
+                                    ownerGuard.guard(
+                                      {
+                                        platform: b.platform,
+                                        from: owner(c.agentId ?? b.agentIds[0] ?? null),
+                                        toId: agentId,
+                                        room: c.name
+                                      },
+                                      () => setChannelAgent(c.integrationId!, c.channelId, agentId)
+                                    )
+                                  }
                                 />
                               )}
                             </div>
@@ -575,7 +579,7 @@ function BotsCard({
                     </>
                   ) : (
                     <div className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
-                      No conversations observed yet — invite the bot to a channel or message it directly.
+                      No conversations yet — the roster fills in once the bot reaches its first {roomNoun}.
                     </div>
                   )}
                 </div>
@@ -602,6 +606,7 @@ function BotsCard({
             </div>
           </div>
         ))}
+      {ownerGuard.dialog}
     </div>
   )
 }


### PR DESCRIPTION
Step 4 of "the team is the channel" (`docs/designs/linear-integration.md` §15,
change inventory item 4): the web console. Relay, control plane and daemon
already key a Linear conversation on the team; this is the surface that shows it.

## What changed

**The `soleConversation` axis is gone.** `WebPlatformModule.soleConversation` and
`platformSoleConversation` are removed, along with the org Bots row's
workspace-shaped "Default dispatch" line. A connected workspace expands to its
team rows like any other bot's roster, with Reconnect / Disconnect still as row
actions.

**The agent card wraps the generic list rather than replacing it.** It keeps the
workspace chrome — name, grant status, Reconnect, unlink this agent — and mounts
`IntegrationChannelList` beneath it, so each team row's dispatch selector and
trigger control are the console's one pair rather than a second implementation.

**Three capability reads carry what core used to hardcode**, none of them a
platform name:

- `channelList.roster: 'derived'` — the roster is the platform's own, so no row
  offers a way out, and the module's `footerNote` replaces the host's "appears
  here once the bot is added to it".
- `channelList.triggers: ['off', 'mention']` — every Linear event is addressed by
  construction, so nothing would match "any message".
- `channelList.ownerChangeWarning` — the §6.2 copy, behind a new
  `OwnerChangeGuard`: both owner selectors confirm before a move takes a team's
  default off a **restricted** agent (its live sessions there can be stopped but
  will not answer again; a new mention or delegation opens a session with the new
  default), and write straight through everywhere else. Primary button is a bare
  verb, per the console's modal convention.

The org roster's room noun and empty state now come from the platform instead of
naming Slack's channel.

The session list needed no change and none was made: it already buckets by the
session's channel, which the daemon keys on the team. A test pins that.

## Tests

The module's channel-list declaration and its capability reads; the agent card's
team rows with the Mention/Off trigger, no leave or removal control, and the
private-agent warning across confirm, cancel and a refused write; the Bots row
expanding to team rows with a per-row selector; the derived footer; the guard
predicate; per-team session bucketing. Every assertion that pinned the one-row
workspace behaviour was deleted or rewritten.

`typecheck`, `lint` and the full `packages/web` suite (205 files, 2295 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
