### PR TITLE
fix(daemon): never rebuild a Linear conversation row from session history

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1427,6 +1427,14 @@ tile.
     install. Seeding the dispatch default from a daemon report would have
     made it depend on a live daemon and on report timing, and the window
     that opens is exactly the one a bare delegation arrives in.
+    **Session history never yields a Linear row.** The daemon's observed-
+    conversation rebuild (the `membershipEnumeration: 'observed'` arm) folds
+    Linear's history to nothing (`platforms/linear/observed-channels.ts`),
+    and the team report **retracts the workspace id** with a durable
+    tombstone — otherwise a session keyed on the issue-less channel, or one
+    from before the team model, would resurrect the workspace row the CP's
+    migration deleted, seeded Off, on the daemon's next start (observed live
+    on the test environment, 2026-09-02).
     **Landed** as two seats, and **neither is on a critical path**: the
     reconcile FIRES the `listChannels` refresh (one `observePlatformChats`
     frame per integration) without joining it, because the reconcile is

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -138,6 +138,7 @@ import { offersReadPort } from './platforms/read-ports.js'
 import { registerObservedChannels } from './platforms/observed-channels.js'
 import { ObservedChannelsSync, type ObservedChannelsSyncHost } from './platforms/observed-channels-sync.js'
 import { discordObservedChannels } from './platforms/discord/observed-channels.js'
+import { linearObservedChannels } from './platforms/linear/observed-channels.js'
 import { connectionIdentityFor, tenantScopeFor, type TenantScopeHost } from './platforms/transport-identity.js'
 import { conversationAudienceFor } from './platforms/session-audience.js'
 import { turnChromeFor } from './platforms/turn-chrome.js'
@@ -606,6 +607,7 @@ type DreamExtractionContext = {
 // every Daemon instance (including test constructions) sees the same registry.
 registerThreadPromotion(discordThreadPromotion)
 registerObservedChannels(discordObservedChannels)
+registerObservedChannels(linearObservedChannels)
 
 /** Chain key for one agent's view of one ACP session — see `Daemon.enqueueAcpUpdate`. */
 function acpUpdateChainKey(agentId: string, sessionId: string): string {

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -842,6 +842,9 @@ export class ConnectionReconciler {
         chats,
         integrations.map((i) => i.integrationId)
       )
+      // The workspace id is the issue-less channel and the pre-team coordinate: it never earns a
+      // row (§4.5), so retire one that session history or an older build put there — durably.
+      for (const { integrationId } of integrations) await this.host.retractChannels(integrationId, [conn.workspaceId()])
     } catch (err) {
       this.log.warn(`linear: reporting the team list as observed conversations failed: ${formatErr(err)}`)
     }

--- a/packages/daemon/src/platforms/linear/observed-channels.ts
+++ b/packages/daemon/src/platforms/linear/observed-channels.ts
@@ -1,0 +1,12 @@
+// Linear's observed-channels strategy (linear-integration.md §4.5, §9.2): a Linear conversation
+// is a TEAM, and the team rows are seeded by the CP's install paths and reconciler tick and
+// refreshed by the connection's own team report — never rebuilt from session history. Folding
+// history to nothing is what keeps the workspace-keyed channel of an issue-less session (and any
+// pre-team-model session) from earning a row the CP's migration just deleted.
+import type { ObservedChannelsStrategy } from '../observed-channels.js'
+
+export const linearObservedChannels: ObservedChannelsStrategy = {
+  platform: 'linear',
+  collapse: async () => [],
+  spaceFor: async () => undefined
+}

--- a/packages/daemon/test/linear-ingress.test.ts
+++ b/packages/daemon/test/linear-ingress.test.ts
@@ -279,6 +279,23 @@ const responses = (posted: Posted[]) => posted.filter((p) => p.activity.type ===
 const im = async (daemon: Daemon, msg: unknown) => await (daemon as any).handleRelayIm(msg)
 
 describe('§4.5 the teams as the observed conversations', () => {
+  it('retires the workspace-keyed row after the team report, durably, so history cannot resurrect it', async () => {
+    const { daemon, reports } = await boot()
+    // The retraction rides the detached refresh; the tombstone is what a later history rebuild reads.
+    await vi.waitFor(async () =>
+      expect(await (daemon as any).store.retractedConversations(INTEGRATION)).toContain(WORKSPACE)
+    )
+    expect((daemon as any).channelSnapshots.get(INTEGRATION)?.channels.map((c: { id: string }) => c.id)).not.toContain(
+      WORKSPACE
+    )
+    // A later reconcile, with the report capture in place, retracts it again on the wire.
+    await (daemon as any).connections.reconcileLinearConnections()
+    await vi.waitFor(() =>
+      expect(reports).toContainEqual(expect.objectContaining({ integrationId: INTEGRATION, removed: [WORKSPACE] }))
+    )
+    await daemon.stop()
+  })
+
   it('reports the team list at reconcile, as a name refresh over the rows the CP already wrote', async () => {
     const { daemon } = await boot()
     // The refresh is detached from the reconcile (it may not block convergence), so wait for it

--- a/packages/daemon/test/observed-channels.test.ts
+++ b/packages/daemon/test/observed-channels.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { observedChannelsFor, registerObservedChannels } from '../src/platforms/observed-channels.js'
 import { discordObservedChannels } from '../src/platforms/discord/observed-channels.js'
+import { linearObservedChannels } from '../src/platforms/linear/observed-channels.js'
 import type { ObservedChannelsHost } from '../src/platforms/observed-channels.js'
 
 registerObservedChannels(discordObservedChannels)
+registerObservedChannels(linearObservedChannels)
 
 /** A host over fixed scope/name tables. */
 const host = (
@@ -15,11 +17,19 @@ const host = (
 })
 
 describe('observed-channels strategies', () => {
-  it('is registered for Discord only; other platforms pass rows through', () => {
+  it('is registered for Discord and Linear only; other platforms pass rows through', () => {
     for (const p of ['telegram', 'feishu', 'slack', 'some-future-platform']) {
       expect(observedChannelsFor(p)).toBeUndefined()
     }
     expect(observedChannelsFor('discord')).toBe(discordObservedChannels)
+    expect(observedChannelsFor('linear')).toBe(linearObservedChannels)
+  })
+
+  it('Linear folds session history to nothing — a team row comes from the CP or the team report, never a session', async () => {
+    const h = host({}, { 'a2f2f0d4-0e33-4c4b-9a4b-4f7a0f1f0001': 'AgentConnect' })
+    // The workspace-keyed channel of an issue-less (or pre-team-model) session must not earn a row.
+    expect(await linearObservedChannels.collapse(h, [{ id: 'a2f2f0d4-0e33-4c4b-9a4b-4f7a0f1f0001' }])).toEqual([])
+    expect(await linearObservedChannels.spaceFor(h, 'a2f2f0d4-0e33-4c4b-9a4b-4f7a0f1f0001')).toBeUndefined()
   })
 
   it('collapses thread rows onto their enclosing channel, labeled with the guild', async () => {


### PR DESCRIPTION
## What

A Linear conversation row must never be rebuilt from session history, and the workspace id is retracted with a durable tombstone after each team report.

## Why

Observed live on the test environment after the team-is-the-channel rollout: the migration deleted the workspace-keyed Linear rows at 06:59:24, and at 06:59:59 they were back — seeded `off` — together with four sessions from the earlier live run. The daemon's observed-conversation rebuild (`membershipEnumeration: 'observed'` arm, which Linear sits on) reads the local session history, and those sessions still name the workspace id as their channel; every daemon start re-reported it as a conversation. Design §4.5 says that channel never earns a row.

## How

- `platforms/linear/observed-channels.ts`: a strategy whose `collapse` folds history to nothing (team rows come from the CP's install paths and reconciler tick, refreshed by the team report), registered next to Discord's.
- `connection-reconciler.ts` `observeLinearTeams`: after the team report, `retractChannels(integrationId, [workspaceId])` per integration — the `removed` frame deletes the row on the CP and the store tombstone keeps a later rebuild from restoring it.
- Design §9.4 records the rule and the live observation.

## Tests

- `observed-channels.test.ts`: Linear is registered; its collapse answers nothing for a workspace-keyed history row.
- `linear-ingress.test.ts`: the reconcile's team report leaves the workspace id tombstoned and out of the snapshot, and a later reconcile retracts it on the wire (`removed: [workspace]`).

Daemon typecheck, eslint, and the three affected files pass (114 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
