### PR TITLE
feat(linear): surface a blocked permission gate in the issue feed

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -515,7 +515,7 @@ coalesce aggressively, post meaningfully.
 | a pull/merge-request URL anywhere in the agent's message text            | `external-urls` (`addedExternalUrls`)          | Collected over the whole turn, each URL once, labelled `PR #123` / `MR !45`; published once, immediately before the settling `response` (§10.3)                                                                                                                                             |
 | turn end                                                                 | `response`                                     | The accumulated final answer (final-answer selection reuses the GitHub Layer-2 heuristics: `_meta.codex.phase === 'final_answer'`, else message grouping, else last text run). Attribution footer appended per `output.showFooter`, Markdown-safe via the shared fence-aware chrome helpers |
 | turn failure (quota / auth / crash)                                      | `error`                                        | Reuses `turnFailureReason`/`turnFailureCode`; converger buffer flushed first so runtime-narrated errors are not duplicated                                                                                                                                                                  |
-| permission gate would block the turn                                     | `elicitation`                                  | v1 posts "This step needs approval — open the session in the console" + deep link; interactive approval from Linear is out of scope (§13)                                                                                                                                                   |
+| permission gate would block the turn                                     | `elicitation`, then one `thought`              | v1 posts `This step needs approval — <action>: "<input>" · open in session`, the summary sanitized like the §8 header and the pointer carrying the console deep link; one non-ephemeral `thought` follows the decision. Interactive approval from Linear is out of scope (§13)              |
 | `session_info_update` (title)                                            | —                                              | Persisted locally for the console; Linear names sessions itself                                                                                                                                                                                                                             |
 | stop (`prompted` + `signal: "stop"`)                                     | `response` "Stopped — reply here to continue." | After `interruptTurn` completes; a `response` settles the Linear session state instead of leaving it `active`                                                                                                                                                                               |
 
@@ -1567,10 +1567,19 @@ none` skips it along with everything else Linear-visible. There is **no
    it lands in the issue's **Resources** (`attachmentCreate`, keyed by URL)
    on the first turn, so it is visible from the issue itself, not only inside
    the session panel.
-4. **`elicitation` is a pointer, not a protocol, in v1.** True interactive
-   approval (Linear reply → permission grant) needs an approval-card
-   equivalent over activities; deferred (§13). Until then the agent's
-   configured `permissionMode` governs, exactly like GitHub hook turns.
+4. **`elicitation` is a pointer, not a protocol, in v1.** A gate that would
+   block the turn posts one `elicitation` naming the action and its one-line
+   input — provider text, so it is flattened by the same fence-inert
+   sanitizer the §8 header uses — next to the console deep link, and one
+   non-ephemeral `thought` when the decision lands ("Approved — continuing."
+   / "Denied — the step was skipped."), so an append-only feed never ends on
+   an open question. Identical gates collapse; the follow-through rides
+   progress chrome, so `minimal` posts the pointer alone and `none` neither.
+   A request nobody answers is settled by the turn's own `response`/`error`
+   instead, and is never re-posted. True interactive approval (Linear reply →
+   permission grant) needs an approval-card equivalent over activities;
+   deferred (§13). Until then the agent's configured `permissionMode`
+   governs, exactly like GitHub hook turns.
 5. **No Linear-side title push.** Linear names agent sessions from the issue;
    AgentConnect's session titles remain console-local.
 6. **Signing-secret rotation is a deployment action**: update the deployment
@@ -1655,7 +1664,7 @@ none` skips it along with everything else Linear-visible. There is **no
   moves to In Progress on delegation, the PR is linked, the plan is posted,
   an empty ticket gets clarifying questions) and against Linear's own MCP
   server (~25 tools: issue list/get/create/update, statuses, labels,
-  comments, projects, teams, users, cycles, documents). Three layers, in
+  comments, projects, teams, users, cycles, documents). Four layers, in
   merge order:
   1. **Automatic behavior, no agent involvement** (done): plan sync (§5.1),
      the auto-start transition (§10.2), PR links plus the console Resources
@@ -1691,7 +1700,11 @@ none` skips it along with everything else Linear-visible. There is **no
      tools only exist in Linear turns, so a per-turn prompt block is the
      deterministic seat, and the customer-side customization seat is
      Linear's own admin `guidance`, which §8 already passes through.
-     Still in P2: the elicitation deep-link card.
+  4. **The permission-gate `elicitation`** (**landed**, §10.4): the gate now
+     reaches the feed instead of leaving the session active until it goes
+     stale — the deep-link card naming what needs approving, plus the
+     follow-through `thought` on the decision. Interactive approval from
+     Linear (reply → grant) stays out of scope; it is P3.
 - **P2.5 — the team is the channel** (decided 2026-09-02, §15): one
   conversation row per Linear team instead of one per workspace, each with
   its own dispatch default and an Off, compiled onto a new per-conversation

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -471,7 +471,7 @@ import type {
   TaskListReq
 } from '@agentconnect.md/protocol'
 import { formatErr, startFailureDetail } from './daemon/text.js'
-import { isBuiltinSystemToolCall } from './daemon/tool-classification.js'
+import { isBuiltinSystemToolCall, type ApprovalRequestParts } from './daemon/tool-classification.js'
 import { buildTurnPlan, type TurnPlan } from './daemon/turn-plan.js'
 import { turnEvaluationReporter, type TurnEvaluationReporter } from './daemon/turn-evaluation.js'
 import {
@@ -8398,6 +8398,8 @@ export class Daemon {
       maskAgentSecrets: <T>(agentId: string, payload: T): T => this.maskAgentSecrets(agentId, payload),
       logSessionAction: (verb, sessionKey, actor) => this.commands.logSessionAction(verb, sessionKey, actor),
       emitApprovalActivity: (agentId, acpSessionId, state) => this.emitApprovalActivity(agentId, acpSessionId, state),
+      approvalGateOpened: (p, request) => this.openApprovalGateSurface(p, request),
+      approvalGateResolved: (p, allowed) => this.settleApprovalGateSurface(p, allowed),
       // ── approval-DM routing (slack-approval-dm.md §4–§6) ──
       cpApprovalRoute: () =>
         this.cpClient?.supportsServerFeature?.(APPROVAL_DM_ROUTE_V1_FEATURE) === true ? this.cpClient : undefined,
@@ -8415,6 +8417,27 @@ export class Daemon {
       slackDmSessionTarget: (p, integrationId) =>
         encodeSharedSlackStatusTarget({ agentId: p.plan.agentId, integrationId, sessionKey: p.plan.sessionKey })
     }
+  }
+
+  /**
+   * The turn's OWN permission-gate notice (linear-integration.md §5.1, §10.4).
+   *
+   * Only Linear has one: its feed is the whole surface, with no chat transport for the neutral
+   * notice to ride, so a gated turn used to post nothing and the session sat active until it went
+   * stale. The elicitation names what needs approving and deep-links the console. Returns false
+   * everywhere else, where the neutral chat notice is still the right answer.
+   */
+  private openApprovalGateSurface(p: Pending, request: ApprovalRequestParts): boolean {
+    if (!(p.conv instanceof LinearConverger)) return false
+    const url = this.sessionLink(p.outwardSessionId, this.sessionLinkSource(p.plan.platform, p.plan.integrationId))
+    for (const action of p.conv.onPermissionBlocked(url, request)) this.enqueueApply(p, action)
+    return true
+  }
+
+  /** The gate closed on a human decision: follow it through on the same surface, once (§10.4). */
+  private settleApprovalGateSurface(p: Pending, allowed: boolean): void {
+    if (!(p.conv instanceof LinearConverger)) return
+    for (const action of p.conv.onPermissionResolved(allowed)) this.enqueueApply(p, action)
   }
 
   /** Serializes `agent/activity` emits: two flips on one session must reach the CP in order. */

--- a/packages/daemon/src/daemon/tool-classification.ts
+++ b/packages/daemon/src/daemon/tool-classification.ts
@@ -94,14 +94,26 @@ function approvalInputSummary(value: unknown): string {
   return ''
 }
 
-export function permissionRequestSummary(params: RequestPermissionRequest): string {
-  const label = approvalSummary(params.toolCall?.title ?? params.toolCall?.kind, 'Tool permission request')
-  const input = approvalInputSummary(params.toolCall?.rawInput)
-  return approvalSummary(input ? `${label}: ${input}` : label, 'Tool permission request')
+/** One approval request, split the way a surface renders it: the action, then its one-line input. */
+export interface ApprovalRequestParts {
+  tool: string
+  detail: string
 }
 
-export function elicitationApprovalSummary(params: CreateElicitationRequest): string {
-  return approvalSummary((params as { message?: unknown }).message, 'MCP tool permission request')
+export function permissionRequestParts(params: RequestPermissionRequest): ApprovalRequestParts {
+  return {
+    tool: approvalSummary(params.toolCall?.title ?? params.toolCall?.kind, 'Tool permission request'),
+    detail: approvalSummary(approvalInputSummary(params.toolCall?.rawInput), '')
+  }
+}
+
+export function elicitationApprovalParts(params: CreateElicitationRequest): ApprovalRequestParts {
+  return { tool: approvalSummary((params as { message?: unknown }).message, 'MCP tool permission request'), detail: '' }
+}
+
+/** The same request as the one line the durable permission row stores. */
+export function approvalRequestSummary(parts: ApprovalRequestParts): string {
+  return approvalSummary(parts.detail ? `${parts.tool}: ${parts.detail}` : parts.tool, 'Tool permission request')
 }
 
 /**

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -36,11 +36,13 @@ import { slackAgentIdentityOptions } from '../platforms/slack/turn-output.js'
 import { turnChromeFor } from '../platforms/turn-chrome.js'
 import { formatErr } from '../daemon/text.js'
 import {
-  elicitationApprovalSummary,
+  approvalRequestSummary,
+  elicitationApprovalParts,
   isBuiltinSystemTool,
   isBuiltinSystemToolElicitation,
   isMcpToolApprovalElicitation,
-  permissionRequestSummary
+  permissionRequestParts,
+  type ApprovalRequestParts
 } from '../daemon/tool-classification.js'
 import { pendingTurnKey, type DaemonRenderAction, type Pending } from '../daemon/turn-types.js'
 
@@ -85,6 +87,10 @@ export interface PermissionSurfaceHost {
   logSessionAction(verb: string, sessionKey: string, actor?: InteractionActor): void
   /** Tell the CP a session started or stopped waiting on a human (slack-approval-dm.md §7); fire-and-forget. */
   emitApprovalActivity(agentId: string, acpSessionId: string, state: 'awaiting_permission' | 'idle'): void
+  /** Render the gate on the turn's OWN surface; false when the platform has none and the neutral chat notice should post. */
+  approvalGateOpened(p: Pending, request: ApprovalRequestParts): boolean
+  /** The gate closed on a human decision — the same surface reports it, once per gate. */
+  approvalGateResolved(p: Pending, allowed: boolean): void
   // ── approval-DM routing (slack-approval-dm.md §4–§6) ──
   cpApprovalRoute(): ApprovalRouteChannel | undefined
   orgForAgent(agentId: string): string | undefined
@@ -191,17 +197,33 @@ export class PermissionCoordinator {
     return false
   }
 
-  /** Re-derive the session's wait state after a map write and report it when it flipped (§7). */
-  private syncApprovalActivity(agentId: string, sessionId: string): void {
+  /** Re-derive the session's wait state after a map write and report it when it flipped (§7).
+   *  `decision` is passed only by a human decision, and only its LAST gate reports the outcome
+   *  on the turn's surface — an abandoned or cancelled request settles through the turn instead. */
+  private syncApprovalActivity(agentId: string, sessionId: string, decision?: 'allowed' | 'denied'): void {
     const key = pendingTurnKey(agentId, sessionId)
     const awaiting = this.hasPendingApproval(agentId, sessionId)
     if (awaiting === this.awaitingApproval.has(key)) return
     if (awaiting) this.awaitingApproval.set(key, { agentId, sessionId })
-    else this.awaitingApproval.delete(key)
+    else {
+      this.awaitingApproval.delete(key)
+      if (decision) this.reportGateResolved(agentId, sessionId, decision === 'allowed')
+    }
     try {
       this.host.emitApprovalActivity(agentId, sessionId, awaiting ? 'awaiting_permission' : 'idle')
     } catch (err) {
       this.host.log().warn(`approval activity not reported: ${formatErr(err)}`)
+    }
+  }
+
+  /** Follow the gate through on the turn's own surface, if the turn is still live. */
+  private reportGateResolved(agentId: string, sessionId: string, allowed: boolean): void {
+    const p = this.host.pending().get(pendingTurnKey(agentId, sessionId))
+    if (!p) return
+    try {
+      this.host.approvalGateResolved(p, allowed)
+    } catch (err) {
+      this.host.log().warn(`approval follow-through not rendered: ${formatErr(err)}`)
     }
   }
 
@@ -226,10 +248,11 @@ export class PermissionCoordinator {
     id: string,
     agentId: string,
     sessionId: string,
-    command: string,
+    request: ApprovalRequestParts,
     p: Pending,
     notifyChat = true
   ): Promise<{ requesterName: string | null }> {
+    const command = approvalRequestSummary(request)
     const store = this.host.store()
     const session = await store.getSessionByAcpIdForAgent(agentId, sessionId)
     const requesterId = p.plan.requesterId ?? session?.triggeredBy ?? null
@@ -257,9 +280,11 @@ export class PermissionCoordinator {
           event: { kind: 'message', text }
         })
       }
-      // A continuation turn notifies the origin platform thread too (§5.2).
-      if ((!p.webchat || p.webchat.continuation) && p.conn) {
-        this.host.enqueueApply(p, { kind: 'notice', text })
+      // A continuation turn notifies the origin platform thread too (§5.2). The turn's own
+      // surface owns that notice where it has one — Linear's feed has no chat transport at all,
+      // so without this the gate would be invisible until the session went stale.
+      if (!p.webchat || p.webchat.continuation) {
+        if (!this.host.approvalGateOpened(p, request) && p.conn) this.host.enqueueApply(p, { kind: 'notice', text })
       }
     } catch (err) {
       // The durable editor request is authoritative. A best-effort chat notice
@@ -327,7 +352,7 @@ export class PermissionCoordinator {
     // The human wait starts when the request becomes answerable, not when its row lands — the
     // write used to be synchronous, and billing it to the turn's retry budget would shrink it.
     const wait = this.trackHumanApprovalWait(p, result)
-    const recorded = this.noteEditorPermissionRequest(id, agentId, sessionId, permissionRequestSummary(params), p)
+    const recorded = this.noteEditorPermissionRequest(id, agentId, sessionId, permissionRequestParts(params), p)
     this.recordedWrites.set(id, recorded)
     let requesterName: string | null = null
     try {
@@ -363,7 +388,7 @@ export class PermissionCoordinator {
     })
     this.syncApprovalActivity(agentId, sessionId)
     const wait = this.trackHumanApprovalWait(p, result)
-    const recorded = this.noteEditorPermissionRequest(id, agentId, sessionId, elicitationApprovalSummary(params), p)
+    const recorded = this.noteEditorPermissionRequest(id, agentId, sessionId, elicitationApprovalParts(params), p)
     this.recordedWrites.set(id, recorded)
     let requesterName: string | null = null
     try {
@@ -406,7 +431,7 @@ export class PermissionCoordinator {
       requestId,
       agentId,
       sessionId,
-      permissionRequestSummary(params),
+      permissionRequestParts(params),
       p,
       false
     )
@@ -646,7 +671,7 @@ export class PermissionCoordinator {
     if (!(await this.resolveStoredPermissionRequest(rec.agentId, requestId, allowed ? 'allowed' : 'denied', by))) return
     this.host.logSessionAction(`permission:${allowed ? 'allowed' : 'denied'}`, rec.sessionId, actor)
     this.pendingEditorPermissions.delete(requestId)
-    this.syncApprovalActivity(rec.agentId, rec.sessionId)
+    this.syncApprovalActivity(rec.agentId, rec.sessionId, allowed ? 'allowed' : 'denied')
     this.permissionEvaluationDetails.set(rec.evaluationParams, { reason: 'agent_editor' })
     void notify.conn
       .updateBlocks(
@@ -714,7 +739,7 @@ export class PermissionCoordinator {
       return
     this.host.logSessionAction(`permission:${value === null ? 'denied' : 'allowed'}`, rec.sessionId, actor)
     this.pendingEditorPermissions.delete(requestId)
-    this.syncApprovalActivity(rec.agentId, rec.sessionId)
+    this.syncApprovalActivity(rec.agentId, rec.sessionId, value === null ? 'denied' : 'allowed')
     void notify.conn
       .updateBlocks(
         notify.channel,
@@ -736,6 +761,7 @@ export class PermissionCoordinator {
 
   async decideEditorPermission(req: AgentPermissionDecision): Promise<Ack> {
     const decidedBy = { resolvedBy: req.decidedBy ?? null, resolvedByName: req.decidedByName ?? null }
+    const decidedStatus = req.decision === 'allow' ? 'allowed' : 'denied'
     const pending = this.pendingEditorPermissions.get(req.requestId)
     if (!pending || pending.agentId !== req.agentId) {
       const chat = this.pendingChatPermissions.get(req.requestId)
@@ -755,7 +781,7 @@ export class PermissionCoordinator {
           return { ok: false, reason: 'permission request is no longer pending' }
         }
         this.pendingElicits.delete(req.requestId)
-        this.syncApprovalActivity(elicitation.agentId, elicitation.sessionId)
+        this.syncApprovalActivity(elicitation.agentId, elicitation.sessionId, decidedStatus)
         if (elicitation.ts) {
           const decision =
             req.decision === 'allow'
@@ -792,7 +818,7 @@ export class PermissionCoordinator {
         return { ok: false, reason: 'permission request is no longer pending' }
       }
       this.pendingChatPermissions.delete(req.requestId)
-      this.syncApprovalActivity(chat.agentId, chat.sessionId)
+      this.syncApprovalActivity(chat.agentId, chat.sessionId, decidedStatus)
       this.permissionEvaluationDetails.set(chat.evaluationParams, { reason: 'agent_editor' })
       if (chat.ts) {
         void chat.conn
@@ -844,7 +870,7 @@ export class PermissionCoordinator {
       return { ok: false, reason: 'permission request is no longer pending' }
     }
     this.pendingEditorPermissions.delete(req.requestId)
-    this.syncApprovalActivity(pending.agentId, pending.sessionId)
+    this.syncApprovalActivity(pending.agentId, pending.sessionId, decidedStatus)
     if (pending.notify) {
       const label = `${req.decision === 'allow' ? 'Allowed' : 'Denied'} by ${req.decidedByName ?? 'an Agent editor'}`
       const blocks =
@@ -920,7 +946,7 @@ export class PermissionCoordinator {
     // whose click changed nothing.
     this.host.logSessionAction(`permission:${allowed ? 'allowed' : 'denied'}`, pending.sessionId, input.actor)
     this.pendingChatPermissions.delete(input.requestId)
-    this.syncApprovalActivity(pending.agentId, pending.sessionId)
+    this.syncApprovalActivity(pending.agentId, pending.sessionId, allowed ? 'allowed' : 'denied')
     this.permissionEvaluationDetails.set(pending.evaluationParams, { reason: 'chat_user' })
     if (pending.ts) {
       void pending.conn
@@ -1205,7 +1231,7 @@ export class PermissionCoordinator {
         requestId,
         agentId,
         sessionId,
-        elicitationApprovalSummary(params),
+        elicitationApprovalParts(params),
         p,
         false
       )
@@ -1303,7 +1329,7 @@ export class PermissionCoordinator {
         return
     }
     this.pendingElicits.delete(a.requestId)
-    this.syncApprovalActivity(rec.agentId, rec.sessionId)
+    this.syncApprovalActivity(rec.agentId, rec.sessionId, a.value === null ? 'denied' : 'allowed')
     if (rec.ts)
       void rec.conn
         .updateBlocks(rec.channel, rec.ts, buildElicitationResolvedCard(rec.params, decision), 'Input received', true)

--- a/packages/daemon/src/platforms/linear/turn-output.ts
+++ b/packages/daemon/src/platforms/linear/turn-output.ts
@@ -15,6 +15,7 @@ import { splitAtParagraphBoundary } from '../../messages/stream-boundary.js'
 import { isNoResponseBody, isNoResponsePrefix } from '../../session/no-response.js'
 import { extractToolOutput } from '../../session/tool-output.js'
 import type { TurnOutputContext } from '../turn-output.js'
+import { sanitizeTitle } from './message-strategy.js'
 
 /** Linear's plan-entry vocabulary. `canceled` has no ACP source today; it exists because
  *  the plan array is a full replace and a future entry may need it. */
@@ -242,7 +243,22 @@ const SENTINEL_TAIL_CHARS = 512
 /** Posted when the turn produced no final text but still owes Linear a settling `response`. */
 export const EMPTY_RESPONSE_BODY = 'Done.'
 /** v1 elicitation copy (§10.4): a pointer to the console, not an approval protocol. */
-export const PERMISSION_ELICITATION_BODY = 'This step needs approval — open the session in the console.'
+export const PERMISSION_ELICITATION_BODY = 'This step needs approval'
+/** The pointer's label — a link when the turn knows its console URL, a plain sentence when it does not. */
+export const PERMISSION_ELICITATION_POINTER = 'open in session'
+const PERMISSION_ELICITATION_FALLBACK = 'open the session in the console'
+/** The gate's follow-through, so an append-only feed never ends on an open question (§10.4). */
+export const PERMISSION_APPROVED_BODY = 'Approved — continuing.'
+export const PERMISSION_DENIED_BODY = 'Denied — the step was skipped.'
+/** Caps on the elicitation's request clause: the action's name, then its one-line input. */
+const MAX_ELICITATION_TOOL = 80
+const MAX_ELICITATION_DETAIL = 200
+
+/** What needs approving, as an approval surface names it: the action, and its one-line input. */
+export interface LinearApprovalRequest {
+  tool: string
+  detail?: string
+}
 
 export function linearModePolicy(mode: LinearOutputMode): LinearModePolicy {
   return MODE_POLICY[mode]
@@ -295,6 +311,15 @@ export function linearAttributionFooter(attribution?: LinearAttribution): string
     ...(sessionUrl ? { renderSession: (label: string) => markdownLink(label, sessionUrl) } : {})
   })
   return `\n\n${message}`
+}
+
+/** The request as one fence-inert, Markdown-inert clause: the action, and its input in quotes when
+ *  the runtime gave one. Provider text, so it is flattened by the same sanitizer the header uses. */
+function elicitationRequestClause(request?: LinearApprovalRequest): string {
+  const tool = escapeMarkdown(sanitizeTitle(request?.tool ?? '', MAX_ELICITATION_TOOL))
+  if (!tool) return ''
+  const detail = escapeMarkdown(sanitizeTitle(request?.detail ?? '', MAX_ELICITATION_DETAIL))
+  return detail ? ` — ${tool}: "${detail}"` : ` — ${tool}`
 }
 
 /** Pull a compact input summary out of a tool call's `rawInput` for the `parameter` field. */
@@ -500,17 +525,23 @@ export class LinearConverger {
     return [...deduped, { kind: 'activity', type: 'error', body: reason }]
   }
 
-  /** A permission gate would block the turn: point at the console (§10.4). Repeated identical
-   *  gates collapse, because an append-only feed would otherwise stack them. */
-  onPermissionBlocked(sessionUrl?: string): LinearAction[] {
+  /** A permission gate would block the turn: name what is being approved and point at the console
+   *  (§10.4). Repeated identical gates collapse, because an append-only feed would stack them. */
+  onPermissionBlocked(sessionUrl?: string, request?: LinearApprovalRequest): LinearAction[] {
     if (this.settled || !this.policy.response) return []
     const link = httpUrl(sessionUrl)
-    const body = link
-      ? `${PERMISSION_ELICITATION_BODY} ${markdownLink('open in session', link)}`
-      : PERMISSION_ELICITATION_BODY
+    const pointer = link ? markdownLink(PERMISSION_ELICITATION_POINTER, link) : PERMISSION_ELICITATION_FALLBACK
+    const body = `${PERMISSION_ELICITATION_BODY}${elicitationRequestClause(request)} · ${pointer}`
     if (this.lastElicitation === body) return []
     this.lastElicitation = body
     return [...this.flushNarration(true), ...this.takePending(), { kind: 'activity', type: 'elicitation', body }]
+  }
+
+  /** The gate closed on a human decision: say so once, so the feed does not stop at the question.
+   *  It is progress chrome, not the turn's answer — `minimal` posts the response only (§5.2). */
+  onPermissionResolved(allowed: boolean): LinearAction[] {
+    if (this.settled || !this.policy.progress || this.lastElicitation === undefined) return []
+    return [{ kind: 'activity', type: 'thought', body: allowed ? PERMISSION_APPROVED_BODY : PERMISSION_DENIED_BODY }]
   }
 
   private discard(): LinearAction[] {

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -81,6 +81,8 @@ async function world(over?: {
     maskAgentSecrets: (_agentId, payload) => payload,
     logSessionAction: vi.fn(),
     emitApprovalActivity: over?.activity ?? vi.fn(),
+    approvalGateOpened: () => false,
+    approvalGateResolved: vi.fn(),
     cpApprovalRoute: () => ({ approvalRoute: route as never }),
     orgForAgent: () => 'org-1',
     sessionLink: (sessionId) => `https://console.example/sessions/${sessionId}`,

--- a/packages/daemon/test/linear-ingress.test.ts
+++ b/packages/daemon/test/linear-ingress.test.ts
@@ -1000,3 +1000,61 @@ describe('§7.5 the leased transport and the emitting port are one object', () =
     await daemon.stop()
   })
 })
+
+describe('§5.1 the permission gate reaches the feed', () => {
+  it('posts one elicitation naming the gated action, then the follow-through on the decision', async () => {
+    // Linear's feed IS the surface — there is no chat transport for the neutral notice to ride,
+    // so a gated turn that posts nothing leaves the session active until it goes stale.
+    // A holder, not a binding: the host factory runs inside `boot`, before it can return one.
+    const live: { daemon?: Daemon } = {}
+    const permissionParams = {
+      sessionId: 'acp-1',
+      toolCall: { toolCallId: 'call-1', title: 'Bash', rawInput: { command: 'pnpm publish' } },
+      options: [
+        { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
+        { optionId: 'reject', name: 'Deny', kind: 'reject_once' }
+      ]
+    }
+    const gatedHost = () => ({
+      __started: true,
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-1'),
+      prompt: vi.fn(async () => {
+        const permissions = (live.daemon as any).permissions
+        const store = (live.daemon as any).store
+        const decided = permissions.onAcpPermission(AGENT, 'acp-1', permissionParams)
+        // The durable row is what an Agent editor decides against, so it is also how this test
+        // learns the request id the daemon minted.
+        const requestId = await vi.waitFor(async () => {
+          const [row] = await store.listPermissionRequests(AGENT)
+          expect(row?.status).toBe('pending')
+          return row.id as string
+        })
+        expect(await permissions.decideEditorPermission({ agentId: AGENT, requestId, decision: 'allow' })).toEqual({
+          ok: true
+        })
+        expect(await decided).toEqual({ outcome: { outcome: 'selected', optionId: 'allow' } })
+        return 'end_turn'
+      }),
+      cancel: vi.fn(),
+      stop: vi.fn()
+    })
+    const booted = await boot({ host: gatedHost })
+    live.daemon = booted.daemon
+
+    await im(booted.daemon, delivery())
+    await booted.turnSettled()
+
+    const elicitations = booted.posted.filter((p) => p.activity.type === 'elicitation')
+    expect(elicitations).toHaveLength(1)
+    expect(elicitations[0]!.sessionId).toBe(SESSION)
+    expect(elicitations[0]!.activity.body).toContain('This step needs approval — Bash: "pnpm publish"')
+    expect(elicitations[0]!.activity.body).toContain('open in session')
+    // The follow-through closes the question, non-ephemeral, between the gate and the response.
+    const follow = booted.posted.findIndex((p) => p.activity.body === 'Approved — continuing.')
+    expect(follow).toBeGreaterThan(booted.posted.indexOf(elicitations[0]!))
+    expect(booted.posted[follow]!.activity.ephemeral).toBeUndefined()
+    expect(follow).toBeLessThan(booted.posted.findIndex((p) => p.activity.type === 'response'))
+    await booted.daemon.stop()
+  })
+})

--- a/packages/daemon/test/linear-turn-output.test.ts
+++ b/packages/daemon/test/linear-turn-output.test.ts
@@ -13,6 +13,8 @@ import {
   MAX_ACTION_RESULT,
   MAX_REASONING,
   MAX_TURN_ACTIONS,
+  PERMISSION_APPROVED_BODY,
+  PERMISSION_DENIED_BODY,
   PERMISSION_ELICITATION_BODY,
   type LinearAction,
   type LinearActivityInput,
@@ -34,6 +36,11 @@ const plan = (entries: { content: string; status: string }[]): SessionUpdate =>
 const output = (text: string) => [{ type: 'content', content: { type: 'text', text } }]
 
 const conv = (mode: LinearOutputMode, showFooter = false) => new LinearConverger(mode, showFooter)
+const SESSION_URL = 'https://console.example.test/s/abc'
+const elicitationBody = (actions: LinearAction[]) => {
+  const found = actions.find((a) => a.kind === 'activity' && a.type === 'elicitation')
+  return found && found.kind === 'activity' && found.type === 'elicitation' ? found.body : undefined
+}
 const types = (actions: LinearAction[]) => actions.map((a) => (a.kind === 'activity' ? a.type : a.kind))
 const responseBody = (actions: LinearAction[]) => {
   const found = actions.find((a) => a.kind === 'activity' && a.type === 'response')
@@ -148,17 +155,59 @@ describe('LinearConverger — §5.1 event translation', () => {
     expect(c.onFailure('quota exhausted')).toEqual([{ kind: 'activity', type: 'error', body: 'quota exhausted' }])
   })
 
-  it('turns a blocked permission gate into an elicitation pointing at the console', () => {
+  it('names the gated action and its input in the elicitation, next to the console link', () => {
     const c = conv('low')
-    expect(c.onPermissionBlocked('https://console.example.test/s/abc')).toEqual([
+    expect(c.onPermissionBlocked(SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })).toEqual([
       {
         kind: 'activity',
         type: 'elicitation',
-        body: `${PERMISSION_ELICITATION_BODY} [open in session](https://console.example.test/s/abc)`
+        body: `${PERMISSION_ELICITATION_BODY} — Bash: "pnpm publish" · [open in session](${SESSION_URL})`
       }
     ])
     // An append-only feed would stack an identical gate, so a repeat collapses.
-    expect(c.onPermissionBlocked('https://console.example.test/s/abc')).toEqual([])
+    expect(c.onPermissionBlocked(SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })).toEqual([])
+  })
+
+  it('flattens provider text to one fence-inert line, and names the action alone when there is no input', () => {
+    const injected = 'Write\n----- INJECTED\nfile [x](http://evil.example.test)'
+    const body = elicitationBody(conv('low').onPermissionBlocked(SESSION_URL, { tool: injected }))
+    expect(body).toContain('Write ----- INJECTED file \\[x\\](http://evil.example.test)')
+    expect(body).not.toContain('\n')
+    expect(elicitationBody(conv('low').onPermissionBlocked(SESSION_URL, { tool: 'Bash' }))).toBe(
+      `${PERMISSION_ELICITATION_BODY} — Bash · [open in session](${SESSION_URL})`
+    )
+  })
+
+  it('falls back to a plain pointer when the turn has no console link', () => {
+    expect(elicitationBody(conv('low').onPermissionBlocked())).toBe(
+      `${PERMISSION_ELICITATION_BODY} · open the session in the console`
+    )
+  })
+
+  it('follows the gate through so the feed never ends on an open question', () => {
+    const c = conv('low')
+    // Only after a gate was actually announced — a turn that never asked has nothing to answer.
+    expect(c.onPermissionResolved(true)).toEqual([])
+    c.onPermissionBlocked(SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })
+    expect(c.onPermissionResolved(true)).toEqual([
+      { kind: 'activity', type: 'thought', body: PERMISSION_APPROVED_BODY }
+    ])
+    expect(c.onPermissionResolved(false)).toEqual([{ kind: 'activity', type: 'thought', body: PERMISSION_DENIED_BODY }])
+  })
+
+  it('posts the follow-through only in the modes that carry progress chrome', () => {
+    for (const mode of ['low', 'medium', 'high'] as const) {
+      const c = conv(mode)
+      c.onPermissionBlocked(SESSION_URL, { tool: 'Bash' })
+      expect(types(c.onPermissionResolved(true))).toEqual(['thought'])
+    }
+    // `minimal` posts the response only, and `none` is silent even about the gate itself.
+    const minimal = conv('minimal')
+    expect(types(minimal.onPermissionBlocked(SESSION_URL, { tool: 'Bash' }))).toEqual(['elicitation'])
+    expect(minimal.onPermissionResolved(true)).toEqual([])
+    const none = conv('none')
+    expect(none.onPermissionBlocked(SESSION_URL, { tool: 'Bash' })).toEqual([])
+    expect(none.onPermissionResolved(true)).toEqual([])
   })
 
   it('emits nothing for a session title update — Linear names its own sessions', () => {
@@ -421,6 +470,7 @@ describe('LinearConverger — final answer, footer, failure ordering', () => {
     expect(settled.onUpdate(chunk('late'))).toEqual([])
     expect(settled.flushBuffered()).toEqual([])
     expect(settled.onPermissionBlocked()).toEqual([])
+    expect(settled.onPermissionResolved(true)).toEqual([])
 
     const failed = conv('low')
     expect(failed.onFailure('boom')).toHaveLength(1)


### PR DESCRIPTION
Closes the last P2 item of the Linear integration: the permission-gate elicitation.

## The bug

`LinearConverger.onPermissionBlocked` has produced the `elicitation` action since the surface landed, and `applyLinearAction` has always been able to post it — but **nothing ever called it**. A Linear turn that hit a permission gate posted nothing at all: the feed has no chat transport for the neutral "🔒 Permission requested" notice to ride (a Linear turn has no reply connection, only its egress port), so the notice was dropped, the Linear session sat `active`, went stale after ~30 min, and the human never learned an approval was waiting.

## What changed

**The gate is wired.** `PermissionSurfaceHost` gains two members — `approvalGateOpened(p, request)` / `approvalGateResolved(p, allowed)` — and the coordinator asks the turn's own surface to render the gate first, falling back to the neutral chat notice where the platform has one. The daemon implements them behind the same `p.conv instanceof LinearConverger` check every other converger hook uses, so the coordinator stays free of platform names.

**The elicitation says what it is approving.** `onPermissionBlocked(sessionUrl, request)` now renders `This step needs approval — Bash: "pnpm publish" · open in session`. The action name and its one-line input come from the already-masked `RequestPermissionRequest` (`tool-classification.ts` now exposes them as `ApprovalRequestParts` instead of only the joined summary string the durable row stores), and both go through `sanitizeTitle` — the same single-line, delimiter-neutralizing sanitizer the trusted header uses — plus the surface's Markdown escape. The once-per-identical-gate dedup is unchanged.

**The gate closes.** `onPermissionResolved(allowed)` posts one non-ephemeral `thought` ("Approved — continuing." / "Denied — the step was skipped.") so an append-only feed does not end on an open question. It is progress chrome, not the turn's answer, so it follows `policy.progress`: present in `low`/`medium`/`high`, absent in `minimal` (which posts the response only) and `none`. It draws on the ordinary activity budget, and only fires when a gate was actually announced. `syncApprovalActivity` carries the decision, so the follow-through lands once per gate close, on the human-decision paths only.

**Timeout and abandon are unchanged.** A request nobody answers still expires through `releaseEditorPermissions` / `releaseChatPermissions` / `releaseElicits`, which pass no decision — nothing is posted, nothing is left pending, and the turn's own `response`/`error` settles the session. The elicitation is never re-posted by the final or failure paths.

Interactive approval from Linear (reply → grant) stays out of scope; §13 already lists it under P3.

`docs/designs/linear-integration.md`: the §5.1 row, §10.4 item 4, and §13 (the elicitation card is now a landed fourth P2 layer rather than the one open item).

## Tests

- `test/linear-turn-output.test.ts` — the enriched body, injected provider text flattened to one fence-inert Markdown-inert line, the no-link fallback, dedup of an identical gate, the follow-through in `low`/`medium`/`high` and its absence in `minimal`/`none`, and nothing after the turn settles.
- `test/linear-ingress.test.ts` — on the real reconciler + dispatch harness, a permission request raised inside a live Linear turn posts exactly one `elicitation` through the connection, and deciding it through the Agent-editor path posts the follow-through `thought` between the gate and the settling `response`.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean
- eslint + prettier on every touched file — clean
- `pnpm --filter @agentconnect.md/daemon test` — 5510 passed; the only failures are the environment-only ones that also fail on `main` here (`shim-cancellation`, `shim-exec-handler`, `shim-workspace-files`, `acp-matrix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
