### PR TITLE
fix(web): fold the Linear card's workspace chrome into the integration header

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1491,15 +1491,17 @@ tile.
   - `apiBindings` — connect-funnel, connect-status, reconnect, and member
     calls. The dispatch default is the generic conversation-owner PATCH, not
     a Linear binding.
-  - `settingsFragments` — the agent's **Linear card**: one block per linked
-    workspace, carrying the workspace name, connection status with an inline
-    **Reconnect** when the grant is dead or deliveries have gone silent
-    (§7.4, §15), **unlink this agent**, which removes exactly one membership
-    and nothing else, and beneath it the workspace's **team rows** — the
-    generic conversation list, one row per team with the **dispatch
-    selector** (the row's owner, over any member — §6.2) and the trigger
-    control (Mention / Off). No issue list: there is no per-issue state to
-    show (§4.3).
+  - `agentCard` — the agent page's **Linear card**. The host's own card header
+    already carries the workspace name, the connected badge and **unlink this
+    agent** (the generic integration delete, which removes exactly one
+    membership and nothing else), so the module adds only **Reconnect** to
+    that header's action track — with the `grant expired` badge that lights it
+    (§7.4, §15) — over one card-scoped `CardProvider` the button and the
+    body's status band share. There is **no second chrome row**: the card body
+    is the workspace's **team rows** — the generic conversation list, one row
+    per team with the **dispatch selector** (the row's owner, over any member
+    — §6.2) and the trigger control (Mention / Off). No issue list: there is
+    no per-issue state to show (§4.3).
   - **Whole-workspace teardown lives in the org-level Bots card
     (`IntegrationsView`), not on the agent card.** A connected workspace is
     an **ordinary bot row** there — no Linear-shaped panel — with
@@ -1509,8 +1511,8 @@ tile.
     makes "unlink" and "disconnect" impossible to confuse.
   - `channelList` — `roomNoun: 'team'`, no leave affordance (a team is left
     by turning its row Off or unlinking the workspace). The generic
-    conversation card renders the team rows; the module's own card draws
-    only the workspace-level chrome above them. The module's
+    conversation card renders the team rows; the module's own card adds only
+    Reconnect to the host header above them. The module's
     `soleConversation` flag is gone. **Landed** with the team-as-channel
     change, and the three reads core needed are capabilities rather than a
     platform name: `roster: 'derived'` (the row list is the workspace's own,
@@ -1523,7 +1525,10 @@ tile.
     rows and the org Bots roster) when a move takes a team's default off a
     **restricted** agent — its live sessions there can be stopped but will
     not answer again, and a new mention or delegation opens a session with
-    the new default. The org Bots row expands to the same team rows: the
+    the new default. A fourth, `gatedNote`, carries the one-clause
+    private-agent banner: a gated member acts in a team only as its default,
+    so the host's "enable each row below" would promise a per-member switch
+    this model has not got. The org Bots row expands to the same team rows: the
     workspace-shaped "Default dispatch" line it used to show is gone with the
     flag, and Reconnect / Disconnect stay row actions. The session list needed
     nothing: it already buckets by the session's channel, which is the team.

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -329,6 +329,47 @@ describe('IntegrationChannelList footer', () => {
   })
 })
 
+describe('IntegrationChannelList private-agent banner', () => {
+  const banner = (platform?: string) =>
+    renderToStaticMarkup(
+      createElement(IntegrationChannelList, {
+        platform,
+        gated: true,
+        channels: [{ channelId: 'C1', name: 'deploys', kind: 'channel', trigger: 'mention' }]
+      })
+    )
+
+  it('states the gate in one clause, in the platform’s noun', () => {
+    expect(banner('slack')).toContain('Private agent: it answers only in a channel or direct message enabled below.')
+    expect(banner('telegram')).toContain('only in a group or direct message enabled below')
+  })
+
+  it('lets a platform whose gate is more than the row say so itself', () => {
+    // §4.3: a gated Linear member acts in a team only as its default, so the host's
+    // "enable it below" would promise a per-member switch the model does not have.
+    const html = banner('linear')
+    expect(html).toContain('Private agent: it answers in a team only where it is the default and the team is not off.')
+    expect(html).not.toContain('enabled below')
+    expect(html).not.toContain('direct message')
+  })
+})
+
+describe('IntegrationChannelList trigger control', () => {
+  it('does not repeat the lightning glyph an agent avatar may already carry', () => {
+    // `zap` is one of the agent icon glyphs, so a row whose dispatch avatar is a bolt read
+    // as two of one control. The trigger keeps a neutral bell and its own label.
+    const html = renderToStaticMarkup(
+      createElement(IntegrationChannelList, {
+        platform: 'slack',
+        gated: false,
+        channels: [{ channelId: 'C1', name: 'deploys', kind: 'channel', trigger: 'mention' }]
+      })
+    )
+    expect(html).toContain('lucide-bell')
+    expect(html).not.toContain('lucide-zap')
+  })
+})
+
 describe('rowLabel', () => {
   it('strips the stored @ from a direct conversation and leaves a channel alone', () => {
     expect(rowLabel({ kind: 'im', name: '@Alice' })).toBe('Alice')

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -545,6 +545,10 @@ export function IntegrationChannelList({
   const derivedRoster = channelListSemantics(platform).roster === 'derived'
   // Where rows come from, plus the platform's tail — which on a derived roster IS the arrival sentence, so it leads.
   const footerNote = channelListSemantics(platform).footerNote
+  // Why a private agent's rows start off. A platform whose gate is more than the row's own says so itself.
+  const gatedNote =
+    channelListSemantics(platform).gatedNote ??
+    `Private agent: it answers only in a ${roomNoun(platform)}${derivedRoster ? '' : ' or direct message'} enabled below.`
   const footerSentences = [
     ...(derivedRoster
       ? footerNote
@@ -695,9 +699,7 @@ export function IntegrationChannelList({
           style={{ padding: `9px ${padX}px` }}
         >
           <Icon name="lock" size={13} className="mt-[2px] flex-none" />
-          <span>
-            {`This agent is private: conversations start off. Enable each ${roomNoun(platform)}${derivedRoster ? '' : ' or direct message'} below before the agent responds there.`}
-          </span>
+          <span>{gatedNote}</span>
         </div>
       )}
       {error && (

--- a/packages/web/src/components/console/TriggerSelect.tsx
+++ b/packages/web/src/components/console/TriggerSelect.tsx
@@ -11,7 +11,7 @@ export interface TriggerOption<T extends string> {
 }
 
 /**
- * The ⚡ + dropdown that says when an agent runs here — one control for every trigger surface
+ * The bell + dropdown that says when an agent runs here — one control for every trigger surface
  * (conversations, watched repositories, watched projects), because they are one decision worded
  * per platform. It states the current choice and keeps the rest behind a menu, so a row that also
  * carries event pills doesn't read as one long bar of segments.
@@ -34,7 +34,7 @@ export function TriggerSelect<T extends string>({
   onChange: (value: T) => void
   /** Names the control for assistive tech — "Trigger for #deploys". */
   ariaLabel: string
-  /** What ⚡ means on this surface, in this platform's nouns. */
+  /** What the glyph means on this surface, in this platform's nouns. */
   hint: string
   /** Demo rows (no live integration) render the control inert. */
   disabled?: boolean
@@ -48,7 +48,7 @@ export function TriggerSelect<T extends string>({
   return (
     <span className={`inline-flex items-center gap-[7px] ${className}`}>
       <span title={hint} className="flex-none leading-none">
-        <Icon name="zap" size={14} color="var(--text-tertiary)" />
+        <Icon name="bell" size={14} color="var(--text-tertiary)" />
       </span>
       <AnchoredFlyout
         ariaLabel={ariaLabel}

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -583,6 +583,9 @@ export interface WebChannelListSemantics {
     /** Bare verb — the console's modal convention. */
     confirmLabel: string
   }
+  /** The private-agent banner's sentence, where enabling a row is not the whole gate —
+   *  Linear's gated member acts in a team only as its default (§4.3). Absent ⇒ the host's. */
+  gatedNote?: string
 }
 
 /**
@@ -590,16 +593,22 @@ export interface WebChannelListSemantics {
  * of the host's generic conversation list.
  *
  * The generic list assumes the platform's rooms are enumerable things the bot was
- * ADDED to, each with a trigger and a way out. A module whose card needs chrome ABOVE
- * that list — Linear's connected workspace, with its grant status, Reconnect and
- * unlink — supplies a Body that draws the chrome and mounts the generic list itself,
- * so the rows keep the console's one dispatch selector and trigger control.
+ * ADDED to, each with a trigger and a way out. A module whose card has a repair of its
+ * own — Linear's Reconnect, which restores a workspace grant — puts it in the header's
+ * action track and keeps the rows beneath it generic.
  *
- * The host keeps the card CHROME (mark, name, connected badge, delete). The Body gets
- * the integration row — which names its own agent, so there is no second prop for the
+ * The host keeps the card CHROME (mark, name, connected badge, unlink) and never draws
+ * a second one: the workspace name is the header's, not the body's. The Body gets the
+ * integration row — which names its own agent, so there is no second prop for the
  * page's — and reaches the console data layer itself, exactly as the list does.
  */
 export interface WebAgentIntegrationCardFacet {
+  /** Mounts card-scope state around BOTH the header actions and the body — the
+   *  {@link WebBotSettingsFragments.lifecycleActions} idiom: a state carrier, not chrome. */
+  CardProvider?: ComponentType<{ integration: IntegrationRow; children: ReactNode }>
+  /** Controls for the header's action track, beside the host's own unlink — Linear's
+   *  Reconnect and the badge that says why it is lit. Absent ⇒ the host's actions alone. */
+  HeaderActions?: ComponentType<{ integration: IntegrationRow }>
   /** `padX` lines the rows up with the host card that mounts them (16 mobile / 14
    *  desktop detail), the generic list's own prop. */
   Body: ComponentType<{ integration: IntegrationRow; padX: number }>

--- a/packages/web/src/components/console/platforms/linear/card.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/card.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
 
-// The AGENT page's Linear card: the connected workspace as chrome — name, grant status,
-// Reconnect, unlink — over the generic conversation list of its TEAM rows (§4.3, §9.5).
-// What must NOT be there matters as much: no Disconnect (that ends the workspace for every
-// agent, so it is the org view's), no "any message" trigger (the platform emits no
-// unaddressed traffic) and no way to leave or drop a team (the roster is the workspace's).
+// The AGENT page's Linear card: Reconnect in the host header's action track, over the
+// generic conversation list of the workspace's TEAM rows (§4.3, §9.5). What must NOT be
+// there matters as much: no second workspace name or unlink (both are the host header's),
+// no Disconnect (that ends the workspace for every agent, so it is the org view's), no
+// "any message" trigger (the platform emits no unaddressed traffic) and no way to leave
+// or drop a team (the roster is the workspace's).
 
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -52,7 +53,7 @@ vi.mock('@/lib/data-context', () => ({
   })
 }))
 
-import { LinearWorkspaceRows } from './card'
+import { LinearWorkspaceCard, LinearWorkspaceHeaderActions, LinearWorkspaceRows } from './card'
 
 function bot(over: Partial<BotDto> = {}): BotDto {
   return {
@@ -118,8 +119,16 @@ async function settle(): Promise<void> {
   }
 }
 
+/** The host's shape: one card-scoped provider around the header actions and the team rows. */
 async function render(row: IntegrationRow = integration()): Promise<void> {
-  await act(async () => root.render(<LinearWorkspaceRows integration={row} padX={14} />))
+  await act(async () =>
+    root.render(
+      <LinearWorkspaceCard integration={row}>
+        <LinearWorkspaceHeaderActions />
+        <LinearWorkspaceRows integration={row} padX={14} />
+      </LinearWorkspaceCard>
+    )
+  )
 }
 
 /** The rows' dispatch pickers, in row order — the picker names its OWNER, not its row. */
@@ -176,10 +185,12 @@ afterEach(async () => {
 })
 
 describe('the workspace chrome', () => {
-  it('names the workspace above the team rows', async () => {
+  it('leaves the workspace name to the host header and prints only the team rows', async () => {
     await render()
 
-    expect(text()).toContain('Example Workspace')
+    // The header above this card already names the workspace; repeating it here is the
+    // duplicate row this card no longer draws.
+    expect(text()).not.toContain('Example Workspace')
     expect(text()).toContain('ENG · Engineering')
     expect(text()).toContain('DES · Design')
   })
@@ -324,33 +335,12 @@ describe('the workspace’s repairs', () => {
     expect(text()).toContain('no relay is connected')
   })
 
-  it('unlinks through the generic integration delete, after confirming', async () => {
+  it('offers no unlink of its own — the host header carries the one control', async () => {
     await render()
-    await act(async () => buttonWithLabel('Remove Example Workspace from this agent')!.click())
-    await settle()
 
-    expect(window.confirm).toHaveBeenCalled()
-    expect(mocks.deleteIntegration).toHaveBeenCalledWith('int-a')
-  })
-
-  it('does nothing when the unlink is not confirmed', async () => {
-    vi.stubGlobal(
-      'confirm',
-      vi.fn(() => false)
-    )
-    await render()
-    await act(async () => buttonWithLabel('Remove Example Workspace from this agent')!.click())
-
+    expect(buttonWithLabel('Remove Example Workspace from this agent')).toBeUndefined()
+    expect(buttonWithLabel('from this agent')).toBeUndefined()
     expect(mocks.deleteIntegration).not.toHaveBeenCalled()
-  })
-
-  it('shows a refused unlink instead of leaving the row looking gone', async () => {
-    mocks.deleteIntegration.mockRejectedValue(new Error('daemon is offline'))
-    await render()
-    await act(async () => buttonWithLabel('Remove Example Workspace from this agent')!.click())
-    await settle()
-
-    expect(text()).toContain('daemon is offline')
   })
 })
 
@@ -361,8 +351,10 @@ describe('a private agent’s own card', () => {
     ] as unknown as Agent[]
     await render()
 
-    expect(text()).toContain('This agent is private: conversations start off.')
-    expect(text()).toContain('Enable each team below')
+    // §4.3: a gated member acts in a team only as its default, so the banner promises no
+    // per-member enabling the model does not have.
+    expect(text()).toContain('Private agent: it answers in a team only where it is the default')
+    expect(text()).toContain('the team is not off')
     // Linear has no direct messages to promise.
     expect(text()).not.toContain('or direct message')
   })

--- a/packages/web/src/components/console/platforms/linear/card.tsx
+++ b/packages/web/src/components/console/platforms/linear/card.tsx
@@ -1,103 +1,95 @@
 'use client'
 
-// The AGENT page's Linear card body ({@link WebAgentIntegrationCardFacet}): the connected
-// workspace as chrome — its name, its grant status, Reconnect, and unlink this agent — over
-// the generic conversation list of the workspace's TEAM rows (§4.3, §9.5). The team is the
-// channel, so the dispatch selector and the trigger live on those rows, not up here.
+// The AGENT page's Linear card ({@link WebAgentIntegrationCardFacet}). The host header
+// already names the connected workspace and carries the unlink, so the module adds only
+// what is Linear's: Reconnect in that header's action track (§7.4) and, beneath it, the
+// generic conversation list of the workspace's TEAM rows (§4.3, §9.5). The team is the
+// channel, so the dispatch selector and the trigger live on those rows.
 // Disconnecting ends the workspace for every agent, so that action is the org view's.
 
-import { useState } from 'react'
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
 import { Icon } from '@/components/ui'
 import { IntegrationChannelList } from '@/components/console/IntegrationChannelList'
 import { type IntegrationRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { linearApi } from './api'
-import { useLinearConnect } from './connect'
+import { useLinearConnect, type LinearConnectFlow } from './connect'
 
-export function LinearWorkspaceRows({ integration, padX }: { integration: IntegrationRow; padX: number }) {
-  const { bots, getAgent, deleteIntegration, refresh } = useConsoleData()
-  const [err, setErr] = useState<string | null>(null)
-  const [leaving, setLeaving] = useState(false)
+/** One reconnect round trip per card, shared by the header button that starts it and the
+ *  band that reports it — two halves the host renders in places that share no state. */
+interface LinearCardState {
+  flow: LinearConnectFlow
+  /** A funnel that could not start, as a sentence — the header button has nowhere to put it. */
+  err: string | null
+  /** The grant is known dead (`rc/bot-revoked`), so the repair is the lit one. */
+  dead: boolean
+}
+
+const CardCtx = createContext<LinearCardState | null>(null)
+
+/** Card-scope state carrier, not chrome: it renders its children unchanged. */
+export function LinearWorkspaceCard({ integration, children }: { integration: IntegrationRow; children: ReactNode }) {
+  const { bots, refresh } = useConsoleData()
   const botId = integration.botId ?? ''
   const bot = bots.find((b) => b.id === botId)
   const flow = useLinearConnect(
     () => linearApi.reconnect(botId),
     () => void refresh()
   )
-
-  const name = bot?.workspaceName || bot?.name || integration.name
   const dead = !!bot?.revokedAt
-  const reconnecting = flow.phase === 'authorizing'
-  const connectErr = flow.appMissing ? 'Linear isn’t set up on this deployment.' : flow.err
+  const value = useMemo<LinearCardState>(
+    () => ({ flow, err: flow.appMissing ? 'Linear isn’t set up on this deployment.' : flow.err, dead }),
+    [dead, flow]
+  )
+  return <CardCtx.Provider value={value}>{children}</CardCtx.Provider>
+}
+
+/** The workspace's one repair, in the header's action track beside the host's unlink.
+ *  Haloed while the grant is known dead — the same needs-attention shape Slack's refresh uses. */
+export function LinearWorkspaceHeaderActions() {
+  const card = useContext(CardCtx)
+  if (!card) return null
+  const reconnecting = card.flow.phase === 'authorizing'
+  return (
+    <>
+      {card.dead && (
+        <span className="badge flex-none bg-(--status-error-soft) text-(--status-error)">grant expired</span>
+      )}
+      <button
+        type="button"
+        disabled={reconnecting}
+        title={reconnecting ? 'Waiting for Linear…' : 'Reconnect this workspace'}
+        aria-label="Reconnect this workspace"
+        onClick={card.flow.start}
+        className={`iconbtn h-7 w-7 flex-none ${card.dead ? 'border-(--status-error) text-(--status-error)' : ''} ${
+          reconnecting ? 'cursor-default opacity-55' : 'cursor-pointer'
+        }`}
+      >
+        <Icon name={reconnecting ? 'loader' : 'refresh-cw'} size={13} className={reconnecting ? 'animate-spin' : ''} />
+      </button>
+    </>
+  )
+}
+
+export function LinearWorkspaceRows({ integration, padX }: { integration: IntegrationRow; padX: number }) {
+  const { getAgent } = useConsoleData()
+  const card = useContext(CardCtx)
+  const reconnecting = card?.flow.phase === 'authorizing'
   // The page's agent — a private one starts every team row off, as on any platform.
   const agent = integration.agentId ? getAgent(integration.agentId) : undefined
 
-  const unlink = () => {
-    if (leaving || !integration.id) return
-    if (!window.confirm(`Remove ${name} from this agent? It stays connected for the organization's other agents.`)) {
-      return
-    }
-    setLeaving(true)
-    setErr(null)
-    void (async () => {
-      try {
-        await deleteIntegration(integration.id!)
-      } catch (cause) {
-        setErr(cause instanceof Error ? cause.message : String(cause))
-        setLeaving(false)
-      }
-    })()
-  }
-
   return (
     <>
-      {(err || connectErr) && (
+      {card?.err && (
         <div
           role="alert"
           className="flex items-start gap-2 border-t border-(--border-subtle) bg-(--surface-sunken) font-sans text-[12px] font-normal leading-[1.5] text-(--status-error)"
           style={{ padding: `9px ${padX}px` }}
         >
           <Icon name="triangle-alert" size={13} className="mt-[2px] flex-none" />
-          <span>{err ?? connectErr}</span>
+          <span>{card.err}</span>
         </div>
       )}
-      <div
-        className="flex flex-wrap items-center gap-x-[10px] gap-y-2 border-t border-(--border-subtle) bg-(--surface-app)"
-        style={{ padding: `10px ${padX}px` }}
-      >
-        <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)" title={name}>
-          {name}
-        </span>
-        {dead && <span className="badge flex-none bg-(--status-error-soft) text-(--status-error)">grant expired</span>}
-        <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-start">
-          <button
-            type="button"
-            disabled={reconnecting || !botId}
-            title={reconnecting ? 'Waiting for Linear…' : 'Reconnect this workspace'}
-            aria-label="Reconnect this workspace"
-            onClick={flow.start}
-            className={`iconbtn h-7 w-7 flex-none ${dead ? 'border-(--status-error) text-(--status-error)' : ''} ${
-              reconnecting ? 'cursor-default opacity-55' : 'cursor-pointer'
-            }`}
-          >
-            <Icon
-              name={reconnecting ? 'loader' : 'refresh-cw'}
-              size={13}
-              className={reconnecting ? 'animate-spin' : ''}
-            />
-          </button>
-          <button
-            type="button"
-            disabled={leaving || !integration.id}
-            title="Remove this workspace from this agent"
-            aria-label={`Remove ${name} from this agent`}
-            onClick={unlink}
-            className={`iconbtn h-7 w-7 flex-none ${leaving ? 'cursor-default opacity-60' : 'cursor-pointer'}`}
-          >
-            <Icon name="x" size={14} color="var(--text-tertiary)" />
-          </button>
-        </div>
-      </div>
       {reconnecting && (
         <div
           className="flex items-start gap-2 border-t border-(--border-subtle) bg-(--surface-app) font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-tertiary)"

--- a/packages/web/src/components/console/platforms/linear/index.tsx
+++ b/packages/web/src/components/console/platforms/linear/index.tsx
@@ -3,7 +3,7 @@
 import type { WebPlatformModule } from '../contract'
 import { linearApi, type LinearApi } from './api'
 import { LinearWizardBody } from './Body'
-import { LinearWorkspaceRows } from './card'
+import { LinearWorkspaceCard, LinearWorkspaceHeaderActions, LinearWorkspaceRows } from './card'
 import { linearLinkInput } from './link'
 import { LinearMark } from './mark'
 import { linearSettingsFragments } from './settings'
@@ -53,7 +53,9 @@ export const linearModule: WebPlatformModule<LinearApi> = {
     // No `any`: every Linear event is addressed by construction (§6.1), so nothing would match it.
     triggers: ['off', 'mention'],
     footerNote:
-      'Every team of this workspace is listed here. Sessions start when someone delegates an issue to the app or mentions it, in a team that is not off.',
+      'Every team of this workspace is listed here; a delegation or a mention starts a session in one that is not off.',
+    // §4.3: a gated member acts in a team only as its default, so enabling the row is half the gate.
+    gatedNote: 'Private agent: it answers in a team only where it is the default and the team is not off.',
     // §6.2: the default seat IS a gated agent's grant, and a Linear AgentSession has one writer (§4.6).
     ownerChangeWarning: {
       title: 'Move this team’s default?',
@@ -62,8 +64,13 @@ export const linearModule: WebPlatformModule<LinearApi> = {
       confirmLabel: 'Move'
     }
   },
-  // The card draws the workspace chrome and mounts the generic list of team rows beneath it.
-  agentCard: { Body: LinearWorkspaceRows },
+  // The host header names the workspace and unlinks it; the module adds Reconnect there and
+  // mounts the generic list of team rows beneath, both reading one card-scoped round trip.
+  agentCard: {
+    CardProvider: LinearWorkspaceCard,
+    HeaderActions: LinearWorkspaceHeaderActions,
+    Body: LinearWorkspaceRows
+  },
   // Agent activities are append-only rows with their own ids (§15), so a duplicate
   // across sources is the same activity; anything else never dedupes.
   messageIdentity: (row) => (LINEAR_ACTIVITY_ID.test(row.ts) ? `ts:${row.ts}` : null),

--- a/packages/web/src/components/console/platforms/linear/module.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/module.test.tsx
@@ -107,6 +107,27 @@ describe('the linear transcript and card semantics', () => {
     }
   })
 
+  it('puts its one repair in the header’s action track, over card-scoped state', () => {
+    // The header already names the workspace and unlinks it, so the module adds Reconnect
+    // there rather than drawing a second row — and the provider is what lets the button and
+    // the body's band report one round trip.
+    expect(platformAgentCard('linear')?.HeaderActions).toBeDefined()
+    expect(platformAgentCard('linear')?.CardProvider).toBeDefined()
+  })
+
+  it('says why a private agent stays quiet in a team, in one clause', () => {
+    // §4.3: a gated member acts in a team only as its default; the host's generic banner
+    // would promise a per-member enable the model does not have.
+    const note = channelListSemantics('linear').gatedNote
+    expect(note).toBe('Private agent: it answers in a team only where it is the default and the team is not off.')
+  })
+
+  it('keeps the footer to what the rows do not already say', () => {
+    const footerNote = channelListSemantics('linear').footerNote ?? ''
+    expect(footerNote).toContain('Every team of this workspace is listed here')
+    expect(footerNote.split('. ').length).toBe(1)
+  })
+
   it('is the only module whose roster is derived, or whose triggers are narrowed', () => {
     // Both are capabilities core reads; neither may become "the platform is Linear".
     for (const m of platformRegistry.all()) {
@@ -114,6 +135,7 @@ describe('the linear transcript and card semantics', () => {
       expect(m.channelList?.roster, m.platformId).toBeUndefined()
       expect(m.channelList?.triggers, m.platformId).toBeUndefined()
       expect(m.channelList?.ownerChangeWarning, m.platformId).toBeUndefined()
+      expect(m.channelList?.gatedNote, m.platformId).toBeUndefined()
     }
   })
 

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import useSWR from 'swr'
 import Link from 'next/link'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
@@ -143,6 +143,11 @@ const HOOK_REFRESH_MS = 30_000
 // triggers: always offered. Their one-liners (`INTEGRATION_BLURB`) are a host
 // projection over the same axis, drift-tested beside the picker's tiles.
 const HOOK_RUN_REFRESH_MS = 10_000
+
+// A module with no card-scope state still renders through a wrapper, so the card is written once.
+function PlainCardScope({ children }: { integration: IntegrationRow; children: ReactNode }) {
+  return <>{children}</>
+}
 
 function FeishuRegionBadge({ integration }: { integration: Pick<IntegrationRow, 'platform' | 'region'> }) {
   if (integration.platform !== 'feishu') return null
@@ -1373,70 +1378,84 @@ export default function AgentDetailView() {
             </div>
             {hasInt ? (
               <>
-                {/* Dual-rendered lists: mobile flat rows (no delete, padX 16) vs
-                    desktop bordered sub-cards (delete iconbtn, padX 14). */}
+                {/* Dual-rendered lists: mobile flat rows (padX 16) vs desktop
+                    bordered sub-cards (padX 14); both unlink from the header. */}
                 <div className="desktop:hidden">
                   {agentInts.map((g, i) => {
                     // A module with its own card body replaces the generic conversation
                     // list — and, with it, the header's first-channel subline.
-                    const AgentCardBody = platformAgentCard(g.platform)?.Body
+                    const card = platformAgentCard(g.platform)
+                    const AgentCardBody = card?.Body
+                    const HeaderActions = card?.HeaderActions
+                    const CardScope = card?.CardProvider ?? PlainCardScope
                     return (
                       <div key={i} className={i > 0 ? 'border-t border-(--border-subtle)' : undefined}>
-                        <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3">
-                          <Link
-                            href={botSettingsHref(g.botId)}
-                            className="group flex min-w-0 flex-1 items-center gap-3"
-                          >
-                            <span className="imark h-9 w-9 flex-none rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
-                              <PlatformMark platform={g.platform} />
-                            </span>
-                            <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
-                              <span className="flex min-w-0 items-center gap-2">
-                                <span className="truncate font-sans text-[14px] font-semibold leading-normal group-hover:underline">
-                                  {g.name}
-                                </span>
-                                <FeishuRegionBadge integration={g} />
-                              </span>
-                              {!AgentCardBody && g.channels[0] && (
-                                <span className="font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                                  {roomGlyph(g.channels[0].kind, g.platform)}
-                                  {rowLabel(g.channels[0])}
-                                </span>
-                              )}
-                            </span>
-                          </Link>
-                          <span className="inline-flex flex-none items-center gap-[5px] rounded-full bg-(--brand-soft) px-[10px] py-[3px] font-sans text-[12px] font-semibold leading-normal text-(--brand-soft-text)">
-                            <span className="h-[6px] w-[6px] rounded-full bg-(--status-online)" />
-                            connected
-                          </span>
-                          {g.platform === 'discord' && g.discordAppId && (
-                            <a
-                              href={discordBotInviteUrl(g.discordAppId)}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              title="Invite this bot to a Discord server — preset scopes &amp; permissions"
-                              aria-label="Add this bot to a Discord server"
-                              className="iconbtn h-7 w-7 flex-none"
-                              onClick={(e) => e.stopPropagation()}
+                        <CardScope integration={g}>
+                          <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3">
+                            <Link
+                              href={botSettingsHref(g.botId)}
+                              className="group flex min-w-0 flex-1 items-center gap-3"
                             >
-                              <Icon name="external-link" size={12} />
-                            </a>
+                              <span className="imark h-9 w-9 flex-none rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
+                                <PlatformMark platform={g.platform} />
+                              </span>
+                              <span className="flex min-w-0 flex-1 flex-col gap-[2px]">
+                                <span className="flex min-w-0 items-center gap-2">
+                                  <span className="truncate font-sans text-[14px] font-semibold leading-normal group-hover:underline">
+                                    {g.name}
+                                  </span>
+                                  <FeishuRegionBadge integration={g} />
+                                </span>
+                                {!AgentCardBody && g.channels[0] && (
+                                  <span className="font-mono text-[12px] font-normal leading-normal text-(--text-tertiary)">
+                                    {roomGlyph(g.channels[0].kind, g.platform)}
+                                    {rowLabel(g.channels[0])}
+                                  </span>
+                                )}
+                              </span>
+                            </Link>
+                            <span className="inline-flex flex-none items-center gap-[5px] rounded-full bg-(--brand-soft) px-[10px] py-[3px] font-sans text-[12px] font-semibold leading-normal text-(--brand-soft-text)">
+                              <span className="h-[6px] w-[6px] rounded-full bg-(--status-online)" />
+                              connected
+                            </span>
+                            {g.platform === 'discord' && g.discordAppId && (
+                              <a
+                                href={discordBotInviteUrl(g.discordAppId)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                title="Invite this bot to a Discord server — preset scopes &amp; permissions"
+                                aria-label="Add this bot to a Discord server"
+                                className="iconbtn h-7 w-7 flex-none"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <Icon name="external-link" size={12} />
+                              </a>
+                            )}
+                            {HeaderActions && <HeaderActions integration={g} />}
+                            <button
+                              className="iconbtn h-7 w-7 flex-none"
+                              title="Delete integration"
+                              aria-label={`Delete the ${g.name} integration`}
+                              onClick={() => openModal('deleteIntegration', g)}
+                            >
+                              <Icon name="unplug" size={14} />
+                            </button>
+                          </div>
+                          {AgentCardBody ? (
+                            <AgentCardBody integration={g} padX={16} />
+                          ) : (
+                            <IntegrationChannelList
+                              integrationId={g.id}
+                              channels={g.channels}
+                              botId={g.botId}
+                              agentId={da.id}
+                              platform={g.platform}
+                              shareable={g.shareable}
+                              gated={da.visibility === 'restricted'}
+                              padX={16}
+                            />
                           )}
-                        </div>
-                        {AgentCardBody ? (
-                          <AgentCardBody integration={g} padX={16} />
-                        ) : (
-                          <IntegrationChannelList
-                            integrationId={g.id}
-                            channels={g.channels}
-                            botId={g.botId}
-                            agentId={da.id}
-                            platform={g.platform}
-                            shareable={g.shareable}
-                            gated={da.visibility === 'restricted'}
-                            padX={16}
-                          />
-                        )}
+                        </CardScope>
                       </div>
                     )
                   })}
@@ -1606,74 +1625,81 @@ export default function AgentDetailView() {
                 </div>
                 <div className="hidden flex-col gap-3 px-4 py-[14px] desktop:flex">
                   {agentInts.map((g, i) => {
-                    const AgentCardBody = platformAgentCard(g.platform)?.Body
+                    const card = platformAgentCard(g.platform)
+                    const AgentCardBody = card?.Body
+                    const HeaderActions = card?.HeaderActions
+                    const CardScope = card?.CardProvider ?? PlainCardScope
                     return (
                       <div key={i} className="overflow-hidden rounded-[9px] border border-(--border-subtle)">
-                        <div className="flex items-center gap-3 px-[14px] py-3">
-                          <Link
-                            href={botSettingsHref(g.botId)}
-                            className="group flex min-w-0 flex-1 items-center gap-3"
-                          >
-                            <span className="imark h-[34px] w-[34px] rounded-md">
-                              <PlatformMark platform={g.platform} />
-                            </span>
-                            <div className="min-w-0 flex-1">
-                              <div className="flex items-center gap-2">
-                                <span className="truncate font-sans text-[13.5px] font-semibold leading-normal group-hover:underline">
-                                  {g.name}
-                                </span>
-                                <FeishuRegionBadge integration={g} />
-                                <span className="badge bg-(--brand-soft) text-(--brand-soft-text)">
-                                  <span className="dot h-[6px] w-[6px] bg-(--status-online)" />
-                                  connected
-                                </span>
-                                {g.shareable && (
-                                  <span
-                                    className="badge bg-(--surface-app) text-(--text-tertiary)"
-                                    title="Shared bot — used by multiple agents, inbound via a relay. Each channel dispatches to one of them by default."
-                                  >
-                                    <Icon name="users" size={11} />
-                                    shared · {g.agentCount} {g.agentCount === '1' ? 'agent' : 'agents'}
-                                  </span>
-                                )}
-                              </div>
-                            </div>
-                          </Link>
-                          {g.platform === 'discord' && g.discordAppId && (
-                            <a
-                              href={discordBotInviteUrl(g.discordAppId)}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              title="Invite this bot to a Discord server — preset scopes &amp; permissions"
-                              aria-label="Add this bot to a Discord server"
-                              className="iconbtn flex-none"
-                              onClick={(e) => e.stopPropagation()}
+                        <CardScope integration={g}>
+                          <div className="flex items-center gap-3 px-[14px] py-3">
+                            <Link
+                              href={botSettingsHref(g.botId)}
+                              className="group flex min-w-0 flex-1 items-center gap-3"
                             >
-                              <Icon name="external-link" size={14} />
-                            </a>
+                              <span className="imark h-[34px] w-[34px] rounded-md">
+                                <PlatformMark platform={g.platform} />
+                              </span>
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-center gap-2">
+                                  <span className="truncate font-sans text-[13.5px] font-semibold leading-normal group-hover:underline">
+                                    {g.name}
+                                  </span>
+                                  <FeishuRegionBadge integration={g} />
+                                  <span className="badge bg-(--brand-soft) text-(--brand-soft-text)">
+                                    <span className="dot h-[6px] w-[6px] bg-(--status-online)" />
+                                    connected
+                                  </span>
+                                  {g.shareable && (
+                                    <span
+                                      className="badge bg-(--surface-app) text-(--text-tertiary)"
+                                      title="Shared bot — used by multiple agents, inbound via a relay. Each channel dispatches to one of them by default."
+                                    >
+                                      <Icon name="users" size={11} />
+                                      shared · {g.agentCount} {g.agentCount === '1' ? 'agent' : 'agents'}
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+                            </Link>
+                            {g.platform === 'discord' && g.discordAppId && (
+                              <a
+                                href={discordBotInviteUrl(g.discordAppId)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                title="Invite this bot to a Discord server — preset scopes &amp; permissions"
+                                aria-label="Add this bot to a Discord server"
+                                className="iconbtn flex-none"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <Icon name="external-link" size={14} />
+                              </a>
+                            )}
+                            {HeaderActions && <HeaderActions integration={g} />}
+                            <button
+                              className="iconbtn"
+                              title="Delete integration"
+                              aria-label={`Delete the ${g.name} integration`}
+                              onClick={() => openModal('deleteIntegration', g)}
+                            >
+                              <Icon name="unplug" size={15} />
+                            </button>
+                          </div>
+                          {AgentCardBody ? (
+                            <AgentCardBody integration={g} padX={14} />
+                          ) : (
+                            <IntegrationChannelList
+                              integrationId={g.id}
+                              channels={g.channels}
+                              botId={g.botId}
+                              agentId={da.id}
+                              platform={g.platform}
+                              shareable={g.shareable}
+                              gated={da.visibility === 'restricted'}
+                              padX={14}
+                            />
                           )}
-                          <button
-                            className="iconbtn"
-                            title="Delete integration"
-                            onClick={() => openModal('deleteIntegration', g)}
-                          >
-                            <Icon name="unplug" size={15} />
-                          </button>
-                        </div>
-                        {AgentCardBody ? (
-                          <AgentCardBody integration={g} padX={14} />
-                        ) : (
-                          <IntegrationChannelList
-                            integrationId={g.id}
-                            channels={g.channels}
-                            botId={g.botId}
-                            agentId={da.id}
-                            platform={g.platform}
-                            shareable={g.shareable}
-                            gated={da.visibility === 'restricted'}
-                            padX={14}
-                          />
-                        )}
+                        </CardScope>
                       </div>
                     )
                   })}


### PR DESCRIPTION
The agent page's Linear card drew its own chrome row directly under the host's
integration header: the workspace name a second time, a Reconnect button, and an
unlink next to the header's own unlink. The workspace was named three times on
one card and there were two ways to remove it.

## What changed

**The chrome folds into the header.** `WebAgentIntegrationCardFacet` gains two
members:

- `HeaderActions` — controls for the header's action track, beside the host's
  own unlink. Linear contributes Reconnect and the `grant expired` badge that
  lights it, and nothing else.
- `CardProvider` — card-scope state around both the header and the body, the
  same idiom `WebBotSettingsFragments.lifecycleActions` already uses, so the
  header button and the body's "approve it in the Linear tab" band report one
  reconnect round trip.

The card body is now the team rows plus that band. Unlinking is the header's
existing integration delete; the mobile tree gains that button too, so both form
factors carry exactly one unlink instead of one tree having two and the other
having Linear's only.

**Copy.** The private-agent banner is one clause
(`Private agent: it answers only in a channel or direct message enabled below.`)
and platforms whose gate is more than the row's own can say so through a new
`channelList.gatedNote`. Linear uses it: a gated member acts in a team only as
its default (§4.3), so the host's "enable each team below" promised a per-member
switch the model has not got. Linear's footer note is now one sentence, leaving
the card's footer at two.

**Trigger glyph.** `TriggerSelect` shows a neutral bell instead of the lightning
bolt. `zap` is one of the agent icon glyphs, so a row whose dispatch avatar was a
bolt showed two bolts side by side and read as one control.

§9.5 of the Linear design is updated to match.

## Verification

- `pnpm --filter @agentconnect.md/web typecheck` — clean
- `pnpm --filter @agentconnect.md/web lint` — clean
- `pnpm exec vitest run` in `packages/web` — 205 files, 2299 tests passing
- `prettier --write` on every touched file

Tests updated: the Linear card tests render the host's shape (provider around
header actions and rows) and pin that the body never repeats the workspace name
and offers no unlink of its own; the module tests pin the two new facet members
and the two copy strings; the shared list tests cover both banner arms and the
glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
