### PR TITLE
fix(web): the instance is the GitLab card's fact, not each identity's

### DIFF
--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -2371,13 +2371,16 @@ The Setup Server card gains the instance URL with a staged probe (invalid
 shape blocks the save; unreachable, untrusted TLS, and not-an-API-root
 warn), host-aware application links, and one line of authority copy it is
 honest about not being able to verify. The connection DTO gains a non-secret
-`instanceUrl` and `instanceVersion`; the Console's host badge, its tooltip
-carrying the version, the below-floor row, and the bot rows' group-chip links
-follow it. A version that clears the floor is not news and takes no row of the
-card — the badge tooltip is where an operator reads it, and only a below-floor
-one earns a line, because only it has an action attached. Everything
-else is already host-correct because provider-supplied identity beats
-composed identity.
+`instanceUrl` and `instanceVersion`; the Console's instance hint, its
+below-floor banner, and the bot rows' group-chip links follow it. One
+deployment talks to one instance, and many identities connect to that one
+instance, so the instance is the CARD's fact and never an identity row's: the
+header carries the base URL and the observed version in a single hover hint,
+and the below-floor warning states itself once above the identities rather
+than once per identity. A version that clears the floor is not news and takes
+no row at all — only a below-floor one earns a line, because only it has an
+action attached. Everything else is already host-correct because
+provider-supplied identity beats composed identity.
 
 Merge order, GitLab.com green at every step:
 

--- a/docs/designs/gitlab-com-integration.md
+++ b/docs/designs/gitlab-com-integration.md
@@ -2371,8 +2371,11 @@ The Setup Server card gains the instance URL with a staged probe (invalid
 shape blocks the save; unreachable, untrusted TLS, and not-an-API-root
 warn), host-aware application links, and one line of authority copy it is
 honest about not being able to verify. The connection DTO gains a non-secret
-`instanceUrl` and `instanceVersion`; the Console's host badge, version row
-with floor status, and the bot rows' group-chip links follow it. Everything
+`instanceUrl` and `instanceVersion`; the Console's host badge, its tooltip
+carrying the version, the below-floor row, and the bot rows' group-chip links
+follow it. A version that clears the floor is not news and takes no row of the
+card — the badge tooltip is where an operator reads it, and only a below-floor
+one earns a line, because only it has an action attached. Everything
 else is already host-correct because provider-supplied identity beats
 composed identity.
 

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -221,6 +221,11 @@ async function clickIcon(title: string, scope: ParentNode = host): Promise<void>
   })
 }
 
+/** The card's own instance hint — one deployment talks to exactly one instance (\u00a724.1). */
+function instanceHint(): HTMLElement | null {
+  return host.querySelector('[data-gitlab-instance]')
+}
+
 /** One connection row and everything the card renders under it. */
 function connectionRow(id: string): HTMLElement {
   const found = host.querySelector(`[data-gitlab-connection="${id}"]`)
@@ -419,7 +424,7 @@ describe('GitlabCard', () => {
     expect(refused.textContent).toContain('group 900')
   })
 
-  it('names the configured instance, not a gitlab.com literal, and links the bots there (\u00a724.1)', async () => {
+  it('names the configured instance on the card, not a gitlab.com literal, and links the bots there (\u00a724.1)', async () => {
     const SELF_MANAGED = {
       ...CONNECTION,
       instanceUrl: 'https://gitlab.example.test:8443/gitlab',
@@ -430,27 +435,48 @@ describe('GitlabCard', () => {
     roster = [BOT]
     await render()
 
-    const row = connectionRow('conn-1')
-    // Host and port, without the scheme or the install prefix — it is a badge.
-    expect(row.textContent).toContain('gitlab.example.test:8443')
-    expect(row.textContent).not.toContain('gitlab.com')
+    // The whole URL, prefix and port included, because the card has room for it exactly once.
+    expect(instanceHint()!.getAttribute('title')).toBe(
+      'https://gitlab.example.test:8443/gitlab \u00b7 GitLab 18.11.4-ee'
+    )
+    expect(host.textContent).not.toContain('gitlab.com')
     // The chip link keeps the prefix: every path on that instance lives under it.
     const link = botRow('agent-1').querySelector('a[href*="gitlab-pilot"]')
     expect(link!.getAttribute('href')).toBe('https://gitlab.example.test:8443/gitlab/gitlab-pilot-5b350c0aeba7-2bivoj')
   })
 
-  it('keeps a supported version off the card and in the instance tooltip (\u00a724.2)', async () => {
+  it('states the one instance once, however many identities are connected to it (\u00a724.1)', async () => {
+    const SECOND = { ...CONNECTION, id: 'conn-2', gitlabUserId: '4712', gitlabUsername: 'zfy0701', mine: false }
+    mocks.fetchConnections.mockResolvedValue({
+      enabled: true,
+      connections: [
+        { ...CONNECTION, instanceVersion: '18.4.1', instanceVersionSupported: false },
+        { ...SECOND, instanceVersion: '18.4.1', instanceVersionSupported: false }
+      ]
+    })
+    await render()
+
+    // An identity row carries the identity: no instance host, no instance version.
+    for (const id of ['conn-1', 'conn-2']) {
+      expect(connectionRow(id).textContent).not.toContain('gitlab.com')
+      expect(connectionRow(id).textContent).not.toContain('GitLab 18.4.1')
+    }
+    expect(host.querySelectorAll('[data-gitlab-instance]')).toHaveLength(1)
+    // And the floor warning is the instance's, so two stuck identities do not print it twice.
+    expect(host.textContent!.match(/below 18\.11/g)).toHaveLength(1)
+  })
+
+  it('keeps a supported version off the card body and in the instance hint (\u00a724.2)', async () => {
     mocks.fetchConnections.mockResolvedValue({
       enabled: true,
       connections: [{ ...CONNECTION, instanceVersion: '18.11.4-ee', instanceVersionSupported: true }]
     })
     await render()
-    const healthy = connectionRow('conn-1')
     // Nothing to act on, so it takes no line of the card at all.
-    expect(healthy.textContent).not.toContain('GitLab 18.11.4-ee')
-    expect(healthy.textContent).not.toContain('below 18.11')
-    // Still one hover away for an operator, on the badge that already names the instance.
-    expect(healthy.querySelector('[title]')!.getAttribute('title')).toBe('https://gitlab.com \u00b7 GitLab 18.11.4-ee')
+    expect(host.textContent).not.toContain('GitLab 18.11.4-ee')
+    expect(host.textContent).not.toContain('below 18.11')
+    // Still one hover away for an operator, on the header that already names the instance.
+    expect(instanceHint()!.getAttribute('title')).toBe('https://gitlab.com \u00b7 GitLab 18.11.4-ee')
   })
 
   it('says what a below-floor instance still serves (\u00a724.2)', async () => {
@@ -459,11 +485,10 @@ describe('GitlabCard', () => {
       connections: [{ ...CONNECTION, instanceVersion: '18.4.1', instanceVersionSupported: false }]
     })
     await render()
-    const old = connectionRow('conn-1')
-    expect(old.textContent).toContain('GitLab 18.4.1')
-    expect(old.textContent).toContain('below 18.11')
+    expect(host.textContent).toContain('GitLab 18.4.1')
+    expect(host.textContent).toContain('below 18.11')
     // Bounded degradation, said plainly: what is already set up keeps working.
-    expect(old.textContent).toContain('keep working until their credentials expire')
+    expect(host.textContent).toContain('keep working until their credentials expire')
   })
 
   it('says nothing about a version the deployment has not observed yet', async () => {
@@ -472,9 +497,15 @@ describe('GitlabCard', () => {
       connections: [{ ...CONNECTION, instanceVersion: null, instanceVersionSupported: null }]
     })
     await render()
-    const row = connectionRow('conn-1')
-    expect(row.textContent).not.toContain('GitLab 1')
-    expect(row.querySelector('[title]')!.getAttribute('title')).toBe('https://gitlab.com')
+    expect(host.textContent).not.toContain('GitLab 1')
+    expect(instanceHint()!.getAttribute('title')).toBe('https://gitlab.com')
+  })
+
+  it('has no instance to name before the first connection', async () => {
+    mocks.fetchConnections.mockResolvedValue({ enabled: true, connections: [] })
+    await render()
+    // The console learns the instance from a connection; without one it would be guessing gitlab.com.
+    expect(instanceHint()).toBeNull()
   })
 
   it('tells an operator how to grant withdrawn bot-creation authority (\u00a724.3)', async () => {

--- a/packages/web/src/components/console/GitlabCard.test.tsx
+++ b/packages/web/src/components/console/GitlabCard.test.tsx
@@ -439,17 +439,21 @@ describe('GitlabCard', () => {
     expect(link!.getAttribute('href')).toBe('https://gitlab.example.test:8443/gitlab/gitlab-pilot-5b350c0aeba7-2bivoj')
   })
 
-  it('reports the instance version, and says what a below-floor one still serves (\u00a724.2)', async () => {
+  it('keeps a supported version off the card and in the instance tooltip (\u00a724.2)', async () => {
     mocks.fetchConnections.mockResolvedValue({
       enabled: true,
       connections: [{ ...CONNECTION, instanceVersion: '18.11.4-ee', instanceVersionSupported: true }]
     })
     await render()
     const healthy = connectionRow('conn-1')
-    expect(healthy.textContent).toContain('GitLab 18.11.4-ee')
+    // Nothing to act on, so it takes no line of the card at all.
+    expect(healthy.textContent).not.toContain('GitLab 18.11.4-ee')
     expect(healthy.textContent).not.toContain('below 18.11')
+    // Still one hover away for an operator, on the badge that already names the instance.
+    expect(healthy.querySelector('[title]')!.getAttribute('title')).toBe('https://gitlab.com \u00b7 GitLab 18.11.4-ee')
+  })
 
-    document.body.innerHTML = ''
+  it('says what a below-floor instance still serves (\u00a724.2)', async () => {
     mocks.fetchConnections.mockResolvedValue({
       enabled: true,
       connections: [{ ...CONNECTION, instanceVersion: '18.4.1', instanceVersionSupported: false }]
@@ -468,7 +472,9 @@ describe('GitlabCard', () => {
       connections: [{ ...CONNECTION, instanceVersion: null, instanceVersionSupported: null }]
     })
     await render()
-    expect(connectionRow('conn-1').textContent).not.toContain('GitLab 1')
+    const row = connectionRow('conn-1')
+    expect(row.textContent).not.toContain('GitLab 1')
+    expect(row.querySelector('[title]')!.getAttribute('title')).toBe('https://gitlab.com')
   })
 
   it('tells an operator how to grant withdrawn bot-creation authority (\u00a724.3)', async () => {

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -502,8 +502,11 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                   </span>
                 </span>
                 <span className="mono min-w-0 truncate text-[12.5px]">{c.gitlabUsername}</span>
-                {/* The instance, not a literal: one deployment talks to exactly one. */}
-                <span className="badge bg-(--surface-active) text-(--text-tertiary)" title={c.instanceUrl}>
+                {/* The instance, not a literal: one deployment talks to exactly one; its version rides the tooltip. */}
+                <span
+                  className="badge bg-(--surface-active) text-(--text-tertiary)"
+                  title={c.instanceVersion === null ? c.instanceUrl : `${c.instanceUrl} · GitLab ${c.instanceVersion}`}
+                >
                   {gitlabInstanceHost(c.instanceUrl)}
                 </span>
                 {c.state === 'reauth_required' && (
@@ -557,22 +560,17 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                   : `This account still administers ${c.assignedProjects} projects below. Transfer those projects to your own GitLab account, or reconnect this one to keep managing them, before this row can go.`}
               </div>
             )}
-            {/* What the instance reports, and whether it clears the floor project
-                setup needs. Silent until the first credentialed contact answers. */}
-            {c.instanceVersion !== null && (
+            {/* A version that clears the floor is not news and takes no line; a below-floor one has something to say. */}
+            {c.instanceVersionSupported === false && (
               <div className="flex flex-wrap items-center gap-2 border-b border-(--border-subtle) px-4 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
                 <span>GitLab {c.instanceVersion}</span>
-                {c.instanceVersionSupported === false && (
-                  <>
-                    <span className="badge bg-(--status-paused-soft) text-(--amber-500)">
-                      below {c.instanceVersionFloor}
-                    </span>
-                    <span>
-                      Setting up new projects and bots needs {c.instanceVersionFloor} or later. Projects already set up
-                      keep working until their credentials expire.
-                    </span>
-                  </>
-                )}
+                <span className="badge bg-(--status-paused-soft) text-(--amber-500)">
+                  below {c.instanceVersionFloor}
+                </span>
+                <span>
+                  Setting up new projects and bots needs {c.instanceVersionFloor} or later. Projects already set up keep
+                  working until their credentials expire.
+                </span>
               </div>
             )}
             {c.state === 'reauth_required' && (

--- a/packages/web/src/components/console/GitlabCard.tsx
+++ b/packages/web/src/components/console/GitlabCard.tsx
@@ -23,7 +23,6 @@ import {
   GITLAB_CONVERGENCE_POLL_MS,
   GITLAB_DEFAULT_INSTANCE_URL,
   GITLAB_PROJECT_STATE,
-  gitlabInstanceHost,
   gitlabProfileUrl,
   gitlabStateReasonText,
   gitlabWebhookBadge
@@ -440,9 +439,12 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
     }
   }
 
-  // One deployment, one instance (§24.1), so any connection answers for all of
-  // them; before the first one there is nothing to link to anyway.
-  const instanceUrl = connections[0]?.instanceUrl ?? GITLAB_DEFAULT_INSTANCE_URL
+  // One deployment, one instance (§24.1): the instance is the CARD's fact, not a per-identity one, so any
+  // connection answers for all of them; before the first one there is nothing to link to anyway.
+  const instance = connections[0] ?? null
+  const instanceUrl = instance?.instanceUrl ?? GITLAB_DEFAULT_INSTANCE_URL
+  const instanceHint =
+    instance?.instanceVersion == null ? instanceUrl : `${instanceUrl} · GitLab ${instance.instanceVersion}`
   const accounts = bots?.accounts ?? []
   const rows = botRows(accounts)
   const orphans = orphanBindings(accounts, projects)
@@ -463,6 +465,12 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
             <GitlabMark />
           </span>
           GitLab
+          {/* Which instance, and what it runs — one line of hover on the card, not a badge on every identity. */}
+          {enabled === true && instance !== null && (
+            <span className="flex items-center text-(--text-tertiary)" data-gitlab-instance="" title={instanceHint}>
+              <Icon name="info" size={13} />
+            </span>
+          )}
         </span>
         {/* A takeover runs on the caller's OWN account, so connecting one stays reachable
             even when the organization already lists other people's connections. */}
@@ -473,6 +481,20 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
           </Button>
         )}
       </div>
+
+      {/* Below the floor every identity on the instance is equally stuck, so the card says it once. */}
+      {enabled === true && instance?.instanceVersionSupported === false && (
+        <div className="flex flex-wrap items-center gap-2 border-b border-(--border-subtle) px-4 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+          <span>GitLab {instance.instanceVersion}</span>
+          <span className="badge bg-(--status-paused-soft) text-(--amber-500)">
+            below {instance.instanceVersionFloor}
+          </span>
+          <span>
+            Setting up new projects and bots needs {instance.instanceVersionFloor} or later. Projects already set up
+            keep working until their credentials expire.
+          </span>
+        </div>
+      )}
 
       {enabled === null && <LoadingState size={22} padding={20} />}
       {enabled === false && (
@@ -502,13 +524,6 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                   </span>
                 </span>
                 <span className="mono min-w-0 truncate text-[12.5px]">{c.gitlabUsername}</span>
-                {/* The instance, not a literal: one deployment talks to exactly one; its version rides the tooltip. */}
-                <span
-                  className="badge bg-(--surface-active) text-(--text-tertiary)"
-                  title={c.instanceVersion === null ? c.instanceUrl : `${c.instanceUrl} · GitLab ${c.instanceVersion}`}
-                >
-                  {gitlabInstanceHost(c.instanceUrl)}
-                </span>
                 {c.state === 'reauth_required' && (
                   <span className="badge bg-(--status-paused-soft) text-(--amber-500)">reconnect needed</span>
                 )}
@@ -558,19 +573,6 @@ export default function GitlabCard({ canWrite }: { canWrite: boolean }) {
                 {c.assignedProjects === 1
                   ? 'This account still administers 1 project below. Transfer that project to your own GitLab account, or reconnect this one to keep managing it, before this row can go.'
                   : `This account still administers ${c.assignedProjects} projects below. Transfer those projects to your own GitLab account, or reconnect this one to keep managing them, before this row can go.`}
-              </div>
-            )}
-            {/* A version that clears the floor is not news and takes no line; a below-floor one has something to say. */}
-            {c.instanceVersionSupported === false && (
-              <div className="flex flex-wrap items-center gap-2 border-b border-(--border-subtle) px-4 py-[9px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
-                <span>GitLab {c.instanceVersion}</span>
-                <span className="badge bg-(--status-paused-soft) text-(--amber-500)">
-                  below {c.instanceVersionFloor}
-                </span>
-                <span>
-                  Setting up new projects and bots needs {c.instanceVersionFloor} or later. Projects already set up keep
-                  working until their credentials expire.
-                </span>
               </div>
             )}
             {c.state === 'reauth_required' && (


### PR DESCRIPTION
## What

One deployment talks to exactly one GitLab instance (§24.1), but any number of identities connect to that one instance. The card had it backwards: every connection row carried its own `gitlab.com` host badge, and the version — including the below-floor warning — was stamped once per identity. Three people connected meant the same instance stated three times, and a full-width `GitLab 19.4.0-pre` row under each of them saying nothing anyone could act on.

Instance facts now belong to the card:

- **Header hint.** An `info` icon after the card title carries the instance base URL and the observed version in one hover hint (`https://gitlab.example.test:8443/gitlab · GitLab 19.4.0-pre`) — the whole URL, prefix and port included, because the card has room for it exactly once. It renders only once a connection exists; before that the console would be guessing `gitlab.com`.
- **Below-floor banner.** The `below 18.11` line moves out of the per-connection map to card level, above the identities. Two stuck identities no longer print the same warning twice.
- **Identity rows carry the identity.** The host badge is gone from the connection row; what stays is the account, `reconnect needed` / `disconnected`, and its own actions.
- **A supported version takes no row at all.** It names no action, so the hint is where an operator reads it.

The bot rows' group-chip links are unaffected — they already composed from the card-level `instanceUrl`.

## Tests

`GitlabCard.test.tsx`, 50/50:

- §24.1 rewritten against the header hint, keeping its "names the configured instance, never a `gitlab.com` literal" assertion at card scope, plus a new case with **two** connections proving the instance is stated once — no host or version on either identity row, one `[data-gitlab-instance]`, one `below 18.11`.
- §24.2 split across supported / below-floor / unobserved, and a new case pinning that no hint renders before the first connection.

Full `@agentconnect.md/web` suite (205 files, 2298 tests), `typecheck`, and `eslint` green.

## Docs

`docs/designs/gitlab-com-integration.md` §24.6 records the rule: the instance is the card's fact and never an identity row's, so the header carries it once and only a below-floor version earns a line.

## Note on the earlier review

The a11y thread on the previous revision (a `title` hint is mouse-only) still applies to the header hint, and my answer is the same: `title` is how ~150 console controls hold hover hints, nothing actionable hides behind this one, and a tap-to-open path belongs in `TooltipLayer` rather than in one call site. The change does shrink the exposure — one hint on the card instead of one per identity row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2qj8PkZPs8UDHq2QPtWqb