### PR TITLE
fix(linear): close each permission gate with its own decision, and keep the mobile card header readable

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1586,10 +1586,11 @@ none` skips it along with everything else Linear-visible. There is **no
    sanitizer the §8 header uses — next to the console deep link, and one
    non-ephemeral `thought` when the decision lands ("Approved — continuing."
    / "Denied — the step was skipped."), so an append-only feed never ends on
-   an open question. Gates are tracked one by one, so overlapping ones each
-   get their own decision reported; two gates reading identically collapse
-   onto one row only while both are open, and an identical gate that arrives
-   after the first closed opens a fresh row. The follow-through rides
+   an open question. A gate is one row and one closure, keyed by its request
+   id: overlapping gates each report their own decision, two gates that read
+   alike still get a row each because they are two things a human must
+   decide, and only a re-announcement of a gate already open collapses. A
+   gate that goes away undecided closes quietly. The follow-through rides
    progress chrome, so `minimal` posts the pointer alone and `none` neither.
    A request nobody answers is settled by the turn's own `response`/`error`
    instead, and is never re-posted. True interactive approval (Linear reply →

--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -515,7 +515,7 @@ coalesce aggressively, post meaningfully.
 | a pull/merge-request URL anywhere in the agent's message text            | `external-urls` (`addedExternalUrls`)          | Collected over the whole turn, each URL once, labelled `PR #123` / `MR !45`; published once, immediately before the settling `response` (§10.3)                                                                                                                                             |
 | turn end                                                                 | `response`                                     | The accumulated final answer (final-answer selection reuses the GitHub Layer-2 heuristics: `_meta.codex.phase === 'final_answer'`, else message grouping, else last text run). Attribution footer appended per `output.showFooter`, Markdown-safe via the shared fence-aware chrome helpers |
 | turn failure (quota / auth / crash)                                      | `error`                                        | Reuses `turnFailureReason`/`turnFailureCode`; converger buffer flushed first so runtime-narrated errors are not duplicated                                                                                                                                                                  |
-| permission gate would block the turn                                     | `elicitation`, then one `thought`              | v1 posts `This step needs approval — <action>: "<input>" · open in session`, the summary sanitized like the §8 header and the pointer carrying the console deep link; one non-ephemeral `thought` follows the decision. Interactive approval from Linear is out of scope (§13)              |
+| permission gate would block the turn                                     | `elicitation`, then one `thought`              | v1 posts `This step needs approval — <action>: "<input>" · open in session`, the summary sanitized like the §8 header and the pointer carrying the console deep link; one non-ephemeral `thought` follows EACH gate's own decision. Interactive approval from Linear is out of scope (§13)  |
 | `session_info_update` (title)                                            | —                                              | Persisted locally for the console; Linear names sessions itself                                                                                                                                                                                                                             |
 | stop (`prompted` + `signal: "stop"`)                                     | `response` "Stopped — reply here to continue." | After `interruptTurn` completes; a `response` settles the Linear session state instead of leaving it `active`                                                                                                                                                                               |
 
@@ -1586,7 +1586,10 @@ none` skips it along with everything else Linear-visible. There is **no
    sanitizer the §8 header uses — next to the console deep link, and one
    non-ephemeral `thought` when the decision lands ("Approved — continuing."
    / "Denied — the step was skipped."), so an append-only feed never ends on
-   an open question. Identical gates collapse; the follow-through rides
+   an open question. Gates are tracked one by one, so overlapping ones each
+   get their own decision reported; two gates reading identically collapse
+   onto one row only while both are open, and an identical gate that arrives
+   after the first closed opens a fresh row. The follow-through rides
    progress chrome, so `minimal` posts the pointer alone and `none` neither.
    A request nobody answers is settled by the turn's own `response`/`error`
    instead, and is never re-posted. True interactive approval (Linear reply →

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8400,8 +8400,8 @@ export class Daemon {
       maskAgentSecrets: <T>(agentId: string, payload: T): T => this.maskAgentSecrets(agentId, payload),
       logSessionAction: (verb, sessionKey, actor) => this.commands.logSessionAction(verb, sessionKey, actor),
       emitApprovalActivity: (agentId, acpSessionId, state) => this.emitApprovalActivity(agentId, acpSessionId, state),
-      approvalGateOpened: (p, request) => this.openApprovalGateSurface(p, request),
-      approvalGateResolved: (p, allowed) => this.settleApprovalGateSurface(p, allowed),
+      approvalGateOpened: (p, gateId, request) => this.openApprovalGateSurface(p, gateId, request),
+      approvalGateClosed: (p, gateId, allowed) => this.settleApprovalGateSurface(p, gateId, allowed),
       // ── approval-DM routing (slack-approval-dm.md §4–§6) ──
       cpApprovalRoute: () =>
         this.cpClient?.supportsServerFeature?.(APPROVAL_DM_ROUTE_V1_FEATURE) === true ? this.cpClient : undefined,
@@ -8421,25 +8421,18 @@ export class Daemon {
     }
   }
 
-  /**
-   * The turn's OWN permission-gate notice (linear-integration.md §5.1, §10.4).
-   *
-   * Only Linear has one: its feed is the whole surface, with no chat transport for the neutral
-   * notice to ride, so a gated turn used to post nothing and the session sat active until it went
-   * stale. The elicitation names what needs approving and deep-links the console. Returns false
-   * everywhere else, where the neutral chat notice is still the right answer.
-   */
-  private openApprovalGateSurface(p: Pending, request: ApprovalRequestParts): boolean {
+  /** The turn's OWN gate notice — only Linear has one; false means post the neutral chat notice (§5.1, §10.4). */
+  private openApprovalGateSurface(p: Pending, gateId: string, request: ApprovalRequestParts): boolean {
     if (!(p.conv instanceof LinearConverger)) return false
     const url = this.sessionLink(p.outwardSessionId, this.sessionLinkSource(p.plan.platform, p.plan.integrationId))
-    for (const action of p.conv.onPermissionBlocked(url, request)) this.enqueueApply(p, action)
+    for (const action of p.conv.onPermissionBlocked(gateId, url, request)) this.enqueueApply(p, action)
     return true
   }
 
-  /** The gate closed on a human decision: follow it through on the same surface, once (§10.4). */
-  private settleApprovalGateSurface(p: Pending, allowed: boolean): void {
+  /** One gate closed: follow a human decision through on the same surface, once per gate (§10.4). */
+  private settleApprovalGateSurface(p: Pending, gateId: string, allowed?: boolean): void {
     if (!(p.conv instanceof LinearConverger)) return
-    for (const action of p.conv.onPermissionResolved(allowed)) this.enqueueApply(p, action)
+    for (const action of p.conv.onPermissionResolved(gateId, allowed)) this.enqueueApply(p, action)
   }
 
   /** Serializes `agent/activity` emits: two flips on one session must reach the CP in order. */

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -74,6 +74,12 @@ export interface ApprovalRouteChannel {
   approvalRoute(payload: AgentApprovalRoute, orgId?: string): Promise<AgentApprovalRouted>
 }
 
+/** A gate that just left the pending maps; `allowed` is set only when a human decided it. */
+interface ClosedGate {
+  id: string
+  allowed?: boolean
+}
+
 /** The turn's platform surfaces a permission or elicitation card renders through. */
 export interface PermissionSurfaceHost {
   enqueueApply(p: Pending, action: DaemonRenderAction): void
@@ -88,9 +94,9 @@ export interface PermissionSurfaceHost {
   /** Tell the CP a session started or stopped waiting on a human (slack-approval-dm.md §7); fire-and-forget. */
   emitApprovalActivity(agentId: string, acpSessionId: string, state: 'awaiting_permission' | 'idle'): void
   /** Render the gate on the turn's OWN surface; false when the platform has none and the neutral chat notice should post. */
-  approvalGateOpened(p: Pending, request: ApprovalRequestParts): boolean
-  /** The gate closed on a human decision — the same surface reports it, once per gate. */
-  approvalGateResolved(p: Pending, allowed: boolean): void
+  approvalGateOpened(p: Pending, gateId: string, request: ApprovalRequestParts): boolean
+  /** One gate went away — `allowed` is set only for a human decision, which the surface reports. */
+  approvalGateClosed(p: Pending, gateId: string, allowed?: boolean): void
   // ── approval-DM routing (slack-approval-dm.md §4–§6) ──
   cpApprovalRoute(): ApprovalRouteChannel | undefined
   orgForAgent(agentId: string): string | undefined
@@ -197,18 +203,15 @@ export class PermissionCoordinator {
     return false
   }
 
-  /** Re-derive the session's wait state after a map write and report it when it flipped (§7).
-   *  `decision` is passed only by a human decision, and only its LAST gate reports the outcome
-   *  on the turn's surface — an abandoned or cancelled request settles through the turn instead. */
-  private syncApprovalActivity(agentId: string, sessionId: string, decision?: 'allowed' | 'denied'): void {
+  /** Re-derive the session's wait state after a map write and report it when it flipped (§7). `closed`
+   *  names the gate this write removed, so the turn's surface closes that one gate, not the session. */
+  private syncApprovalActivity(agentId: string, sessionId: string, closed?: ClosedGate): void {
+    if (closed) this.reportGateClosed(agentId, sessionId, closed)
     const key = pendingTurnKey(agentId, sessionId)
     const awaiting = this.hasPendingApproval(agentId, sessionId)
     if (awaiting === this.awaitingApproval.has(key)) return
     if (awaiting) this.awaitingApproval.set(key, { agentId, sessionId })
-    else {
-      this.awaitingApproval.delete(key)
-      if (decision) this.reportGateResolved(agentId, sessionId, decision === 'allowed')
-    }
+    else this.awaitingApproval.delete(key)
     try {
       this.host.emitApprovalActivity(agentId, sessionId, awaiting ? 'awaiting_permission' : 'idle')
     } catch (err) {
@@ -216,12 +219,12 @@ export class PermissionCoordinator {
     }
   }
 
-  /** Follow the gate through on the turn's own surface, if the turn is still live. */
-  private reportGateResolved(agentId: string, sessionId: string, allowed: boolean): void {
+  /** Close one gate on the turn's own surface, if the turn is still live. */
+  private reportGateClosed(agentId: string, sessionId: string, closed: ClosedGate): void {
     const p = this.host.pending().get(pendingTurnKey(agentId, sessionId))
     if (!p) return
     try {
-      this.host.approvalGateResolved(p, allowed)
+      this.host.approvalGateClosed(p, closed.id, closed.allowed)
     } catch (err) {
       this.host.log().warn(`approval follow-through not rendered: ${formatErr(err)}`)
     }
@@ -284,7 +287,7 @@ export class PermissionCoordinator {
       // surface owns that notice where it has one — Linear's feed has no chat transport at all,
       // so without this the gate would be invisible until the session went stale.
       if (!p.webchat || p.webchat.continuation) {
-        if (!this.host.approvalGateOpened(p, request) && p.conn) this.host.enqueueApply(p, { kind: 'notice', text })
+        if (!this.host.approvalGateOpened(p, id, request) && p.conn) this.host.enqueueApply(p, { kind: 'notice', text })
       }
     } catch (err) {
       // The durable editor request is authoritative. A best-effort chat notice
@@ -359,7 +362,7 @@ export class PermissionCoordinator {
       requesterName = (await recorded).requesterName
     } catch (err) {
       this.pendingEditorPermissions.delete(id)
-      this.syncApprovalActivity(agentId, sessionId)
+      this.syncApprovalActivity(agentId, sessionId, { id })
       this.recordedWrites.delete(id)
       resolveResult({ outcome: { outcome: 'cancelled' } })
       await wait
@@ -395,7 +398,7 @@ export class PermissionCoordinator {
       requesterName = (await recorded).requesterName
     } catch (err) {
       this.pendingEditorPermissions.delete(id)
-      this.syncApprovalActivity(agentId, sessionId)
+      this.syncApprovalActivity(agentId, sessionId, { id })
       this.recordedWrites.delete(id)
       resolveResult({ action: 'cancel' })
       await wait
@@ -440,7 +443,7 @@ export class PermissionCoordinator {
       await recorded
     } catch (err) {
       this.pendingChatPermissions.delete(requestId)
-      this.syncApprovalActivity(agentId, sessionId)
+      this.syncApprovalActivity(agentId, sessionId, { id: requestId })
       this.recordedWrites.delete(requestId)
       throw err
     }
@@ -472,7 +475,7 @@ export class PermissionCoordinator {
     }
     if (!ts) {
       this.pendingChatPermissions.delete(requestId)
-      this.syncApprovalActivity(agentId, sessionId)
+      this.syncApprovalActivity(agentId, sessionId, { id: requestId })
       await this.resolveStoredPermissionRequest(agentId, requestId, 'expired')
       this.permissionEvaluationDetails.set(evaluationParams, { reason: 'permission_card_failed' })
       live.resolve({ outcome: { outcome: 'cancelled' } })
@@ -671,7 +674,7 @@ export class PermissionCoordinator {
     if (!(await this.resolveStoredPermissionRequest(rec.agentId, requestId, allowed ? 'allowed' : 'denied', by))) return
     this.host.logSessionAction(`permission:${allowed ? 'allowed' : 'denied'}`, rec.sessionId, actor)
     this.pendingEditorPermissions.delete(requestId)
-    this.syncApprovalActivity(rec.agentId, rec.sessionId, allowed ? 'allowed' : 'denied')
+    this.syncApprovalActivity(rec.agentId, rec.sessionId, { id: requestId, allowed })
     this.permissionEvaluationDetails.set(rec.evaluationParams, { reason: 'agent_editor' })
     void notify.conn
       .updateBlocks(
@@ -739,7 +742,7 @@ export class PermissionCoordinator {
       return
     this.host.logSessionAction(`permission:${value === null ? 'denied' : 'allowed'}`, rec.sessionId, actor)
     this.pendingEditorPermissions.delete(requestId)
-    this.syncApprovalActivity(rec.agentId, rec.sessionId, value === null ? 'denied' : 'allowed')
+    this.syncApprovalActivity(rec.agentId, rec.sessionId, { id: requestId, allowed: value !== null })
     void notify.conn
       .updateBlocks(
         notify.channel,
@@ -761,7 +764,7 @@ export class PermissionCoordinator {
 
   async decideEditorPermission(req: AgentPermissionDecision): Promise<Ack> {
     const decidedBy = { resolvedBy: req.decidedBy ?? null, resolvedByName: req.decidedByName ?? null }
-    const decidedStatus = req.decision === 'allow' ? 'allowed' : 'denied'
+    const decidedAllow = req.decision === 'allow'
     const pending = this.pendingEditorPermissions.get(req.requestId)
     if (!pending || pending.agentId !== req.agentId) {
       const chat = this.pendingChatPermissions.get(req.requestId)
@@ -781,7 +784,10 @@ export class PermissionCoordinator {
           return { ok: false, reason: 'permission request is no longer pending' }
         }
         this.pendingElicits.delete(req.requestId)
-        this.syncApprovalActivity(elicitation.agentId, elicitation.sessionId, decidedStatus)
+        this.syncApprovalActivity(elicitation.agentId, elicitation.sessionId, {
+          id: req.requestId,
+          allowed: decidedAllow
+        })
         if (elicitation.ts) {
           const decision =
             req.decision === 'allow'
@@ -818,7 +824,7 @@ export class PermissionCoordinator {
         return { ok: false, reason: 'permission request is no longer pending' }
       }
       this.pendingChatPermissions.delete(req.requestId)
-      this.syncApprovalActivity(chat.agentId, chat.sessionId, decidedStatus)
+      this.syncApprovalActivity(chat.agentId, chat.sessionId, { id: req.requestId, allowed: decidedAllow })
       this.permissionEvaluationDetails.set(chat.evaluationParams, { reason: 'agent_editor' })
       if (chat.ts) {
         void chat.conn
@@ -870,7 +876,7 @@ export class PermissionCoordinator {
       return { ok: false, reason: 'permission request is no longer pending' }
     }
     this.pendingEditorPermissions.delete(req.requestId)
-    this.syncApprovalActivity(pending.agentId, pending.sessionId, decidedStatus)
+    this.syncApprovalActivity(pending.agentId, pending.sessionId, { id: req.requestId, allowed: decidedAllow })
     if (pending.notify) {
       const label = `${req.decision === 'allow' ? 'Allowed' : 'Denied'} by ${req.decidedByName ?? 'an Agent editor'}`
       const blocks =
@@ -946,7 +952,7 @@ export class PermissionCoordinator {
     // whose click changed nothing.
     this.host.logSessionAction(`permission:${allowed ? 'allowed' : 'denied'}`, pending.sessionId, input.actor)
     this.pendingChatPermissions.delete(input.requestId)
-    this.syncApprovalActivity(pending.agentId, pending.sessionId, allowed ? 'allowed' : 'denied')
+    this.syncApprovalActivity(pending.agentId, pending.sessionId, { id: input.requestId, allowed })
     this.permissionEvaluationDetails.set(pending.evaluationParams, { reason: 'chat_user' })
     if (pending.ts) {
       void pending.conn
@@ -995,7 +1001,7 @@ export class PermissionCoordinator {
     for (const [id, pending] of this.pendingChatPermissions) {
       if (pending.agentId !== agentId || pending.sessionId !== sessionId) continue
       this.pendingChatPermissions.delete(id)
-      this.syncApprovalActivity(agentId, sessionId)
+      this.syncApprovalActivity(agentId, sessionId, { id })
       await this.resolveStoredPermissionRequest(agentId, id, 'expired')
       this.permissionEvaluationDetails.set(pending.evaluationParams, { reason: 'turn_cancelled' })
       if (pending.ts) {
@@ -1017,7 +1023,7 @@ export class PermissionCoordinator {
     for (const [id, pending] of this.pendingEditorPermissions) {
       if (pending.agentId !== agentId || pending.sessionId !== sessionId) continue
       this.pendingEditorPermissions.delete(id)
-      this.syncApprovalActivity(agentId, sessionId)
+      this.syncApprovalActivity(agentId, sessionId, { id })
       await this.resolveStoredPermissionRequest(agentId, id, 'expired')
       // Dead buttons must not survive the request (§5.4): retire the DM card in place.
       if (pending.notify) {
@@ -1240,7 +1246,7 @@ export class PermissionCoordinator {
         await recorded
       } catch (err) {
         this.pendingElicits.delete(requestId)
-        this.syncApprovalActivity(agentId, sessionId)
+        this.syncApprovalActivity(agentId, sessionId, { id: requestId })
         this.recordedWrites.delete(requestId)
         throw err
       }
@@ -1269,7 +1275,7 @@ export class PermissionCoordinator {
     }
     if (!ts) {
       this.pendingElicits.delete(requestId)
-      this.syncApprovalActivity(agentId, sessionId)
+      this.syncApprovalActivity(agentId, sessionId, { id: requestId })
       if (isApproval) await this.resolveStoredPermissionRequest(agentId, requestId, 'expired')
       live.resolve({ action: 'cancel' })
       return await result
@@ -1329,7 +1335,7 @@ export class PermissionCoordinator {
         return
     }
     this.pendingElicits.delete(a.requestId)
-    this.syncApprovalActivity(rec.agentId, rec.sessionId, a.value === null ? 'denied' : 'allowed')
+    this.syncApprovalActivity(rec.agentId, rec.sessionId, { id: a.requestId, allowed: a.value !== null })
     if (rec.ts)
       void rec.conn
         .updateBlocks(rec.channel, rec.ts, buildElicitationResolvedCard(rec.params, decision), 'Input received', true)
@@ -1343,7 +1349,7 @@ export class PermissionCoordinator {
     for (const [id, rec] of this.pendingElicits) {
       if (rec.agentId !== agentId || rec.sessionId !== sessionId) continue
       this.pendingElicits.delete(id)
-      this.syncApprovalActivity(agentId, sessionId)
+      this.syncApprovalActivity(agentId, sessionId, { id })
       if (rec.approval) await this.resolveStoredPermissionRequest(agentId, id, 'expired')
       if (rec.ts)
         void rec.conn

--- a/packages/daemon/src/platforms/linear/turn-output.ts
+++ b/packages/daemon/src/platforms/linear/turn-output.ts
@@ -398,7 +398,7 @@ export class LinearConverger {
   private planEntries?: LinearPlanEntry[]
   private planDirty = false
   private lastPlanKey?: string
-  private readonly openGates = new Map<string, string>()
+  private readonly openGates = new Set<string>()
   private settled = false
 
   constructor(
@@ -526,34 +526,24 @@ export class LinearConverger {
   }
 
   /** A permission gate blocks the turn: name what is being approved and point at the console (§10.4).
-   *  Gates are tracked by id, so overlapping ones each get their own closure; two open gates reading
-   *  identically collapse onto one row, because an append-only feed would stack them. */
+   *  One row per gate id — two gates that read the same are two things a human must decide, so each
+   *  owns a row and a closure; only a RE-announcement of a gate already open collapses. */
   onPermissionBlocked(gateId: string, sessionUrl?: string, request?: LinearApprovalRequest): LinearAction[] {
     if (this.settled || !this.policy.response || this.openGates.has(gateId)) return []
     const link = httpUrl(sessionUrl)
     const pointer = link ? markdownLink(PERMISSION_ELICITATION_POINTER, link) : PERMISSION_ELICITATION_FALLBACK
     const body = `${PERMISSION_ELICITATION_BODY}${elicitationRequestClause(request)} · ${pointer}`
-    const collapsed = this.gateBodyOpen(body)
-    this.openGates.set(gateId, body)
-    if (collapsed) return []
+    this.openGates.add(gateId)
     return [...this.flushNarration(true), ...this.takePending(), { kind: 'activity', type: 'elicitation', body }]
   }
 
   /** One gate closed: a human decision is announced so the feed never stops at the question, while a
-   *  gate that went away without one just frees its row for a later identical gate. Progress chrome,
-   *  so `minimal` posts the response only (§5.2). */
+   *  gate that went away without one (turn cancelled, request abandoned) closes quietly. Progress
+   *  chrome, so `minimal` posts the response only (§5.2). */
   onPermissionResolved(gateId: string, allowed?: boolean): LinearAction[] {
-    const body = this.openGates.get(gateId)
-    if (body === undefined) return []
-    this.openGates.delete(gateId)
-    if (allowed === undefined || this.settled || !this.policy.progress || this.gateBodyOpen(body)) return []
+    if (!this.openGates.delete(gateId)) return []
+    if (allowed === undefined || this.settled || !this.policy.progress) return []
     return [{ kind: 'activity', type: 'thought', body: allowed ? PERMISSION_APPROVED_BODY : PERMISSION_DENIED_BODY }]
-  }
-
-  /** Is some still-open gate already showing this exact row? */
-  private gateBodyOpen(body: string): boolean {
-    for (const open of this.openGates.values()) if (open === body) return true
-    return false
   }
 
   private discard(): LinearAction[] {

--- a/packages/daemon/src/platforms/linear/turn-output.ts
+++ b/packages/daemon/src/platforms/linear/turn-output.ts
@@ -398,7 +398,7 @@ export class LinearConverger {
   private planEntries?: LinearPlanEntry[]
   private planDirty = false
   private lastPlanKey?: string
-  private lastElicitation?: string
+  private readonly openGates = new Map<string, string>()
   private settled = false
 
   constructor(
@@ -525,23 +525,35 @@ export class LinearConverger {
     return [...deduped, { kind: 'activity', type: 'error', body: reason }]
   }
 
-  /** A permission gate would block the turn: name what is being approved and point at the console
-   *  (§10.4). Repeated identical gates collapse, because an append-only feed would stack them. */
-  onPermissionBlocked(sessionUrl?: string, request?: LinearApprovalRequest): LinearAction[] {
-    if (this.settled || !this.policy.response) return []
+  /** A permission gate blocks the turn: name what is being approved and point at the console (§10.4).
+   *  Gates are tracked by id, so overlapping ones each get their own closure; two open gates reading
+   *  identically collapse onto one row, because an append-only feed would stack them. */
+  onPermissionBlocked(gateId: string, sessionUrl?: string, request?: LinearApprovalRequest): LinearAction[] {
+    if (this.settled || !this.policy.response || this.openGates.has(gateId)) return []
     const link = httpUrl(sessionUrl)
     const pointer = link ? markdownLink(PERMISSION_ELICITATION_POINTER, link) : PERMISSION_ELICITATION_FALLBACK
     const body = `${PERMISSION_ELICITATION_BODY}${elicitationRequestClause(request)} · ${pointer}`
-    if (this.lastElicitation === body) return []
-    this.lastElicitation = body
+    const collapsed = this.gateBodyOpen(body)
+    this.openGates.set(gateId, body)
+    if (collapsed) return []
     return [...this.flushNarration(true), ...this.takePending(), { kind: 'activity', type: 'elicitation', body }]
   }
 
-  /** The gate closed on a human decision: say so once, so the feed does not stop at the question.
-   *  It is progress chrome, not the turn's answer — `minimal` posts the response only (§5.2). */
-  onPermissionResolved(allowed: boolean): LinearAction[] {
-    if (this.settled || !this.policy.progress || this.lastElicitation === undefined) return []
+  /** One gate closed: a human decision is announced so the feed never stops at the question, while a
+   *  gate that went away without one just frees its row for a later identical gate. Progress chrome,
+   *  so `minimal` posts the response only (§5.2). */
+  onPermissionResolved(gateId: string, allowed?: boolean): LinearAction[] {
+    const body = this.openGates.get(gateId)
+    if (body === undefined) return []
+    this.openGates.delete(gateId)
+    if (allowed === undefined || this.settled || !this.policy.progress || this.gateBodyOpen(body)) return []
     return [{ kind: 'activity', type: 'thought', body: allowed ? PERMISSION_APPROVED_BODY : PERMISSION_DENIED_BODY }]
+  }
+
+  /** Is some still-open gate already showing this exact row? */
+  private gateBodyOpen(body: string): boolean {
+    for (const open of this.openGates.values()) if (open === body) return true
+    return false
   }
 
   private discard(): LinearAction[] {

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -82,7 +82,7 @@ async function world(over?: {
     logSessionAction: vi.fn(),
     emitApprovalActivity: over?.activity ?? vi.fn(),
     approvalGateOpened: () => false,
-    approvalGateResolved: vi.fn(),
+    approvalGateClosed: vi.fn(),
     cpApprovalRoute: () => ({ approvalRoute: route as never }),
     orgForAgent: () => 'org-1',
     sessionLink: (sessionId) => `https://console.example/sessions/${sessionId}`,

--- a/packages/daemon/test/linear-ingress.test.ts
+++ b/packages/daemon/test/linear-ingress.test.ts
@@ -1074,4 +1074,51 @@ describe('§5.1 the permission gate reaches the feed', () => {
     expect(follow).toBeLessThan(booted.posted.findIndex((p) => p.activity.type === 'response'))
     await booted.daemon.stop()
   })
+
+  it('closes each overlapping gate with its own decision', async () => {
+    const live: { daemon?: Daemon } = {}
+    const gate = (id: string, title: string, command: string) => ({
+      sessionId: 'acp-1',
+      toolCall: { toolCallId: id, title, rawInput: { command } },
+      options: [
+        { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
+        { optionId: 'reject', name: 'Deny', kind: 'reject_once' }
+      ]
+    })
+    const gatedHost = () => ({
+      __started: true,
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-1'),
+      prompt: vi.fn(async () => {
+        const permissions = (live.daemon as any).permissions
+        const store = (live.daemon as any).store
+        const first = permissions.onAcpPermission(AGENT, 'acp-1', gate('call-1', 'Bash', 'rm -rf build'))
+        const second = permissions.onAcpPermission(AGENT, 'acp-1', gate('call-2', 'Write', 'src/index.ts'))
+        const ids = await vi.waitFor(async () => {
+          const rows = await store.listPermissionRequests(AGENT)
+          expect(rows).toHaveLength(2)
+          return Object.fromEntries(rows.map((r: any) => [(r.command as string).split(':')[0]!.trim(), r.id]))
+        })
+        // Denied first, allowed second: the aggregate wait only goes idle on the second decision.
+        await permissions.decideEditorPermission({ agentId: AGENT, requestId: ids.Bash, decision: 'deny' })
+        await permissions.decideEditorPermission({ agentId: AGENT, requestId: ids.Write, decision: 'allow' })
+        await first
+        await second
+        return 'end_turn'
+      }),
+      cancel: vi.fn(),
+      stop: vi.fn()
+    })
+    const booted = await boot({ host: gatedHost })
+    live.daemon = booted.daemon
+
+    await im(booted.daemon, delivery())
+    await booted.turnSettled()
+
+    const bodies = booted.posted.map((p) => p.activity.body as string)
+    expect(bodies.filter((b) => b.includes('This step needs approval'))).toHaveLength(2)
+    expect(bodies.filter((b) => b === 'Denied — the step was skipped.')).toHaveLength(1)
+    expect(bodies.filter((b) => b === 'Approved — continuing.')).toHaveLength(1)
+    await booted.daemon.stop()
+  })
 })

--- a/packages/daemon/test/linear-turn-output.test.ts
+++ b/packages/daemon/test/linear-turn-output.test.ts
@@ -157,7 +157,7 @@ describe('LinearConverger — §5.1 event translation', () => {
 
   it('names the gated action and its input in the elicitation, next to the console link', () => {
     const c = conv('low')
-    expect(c.onPermissionBlocked(SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })).toEqual([
+    expect(c.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })).toEqual([
       {
         kind: 'activity',
         type: 'elicitation',
@@ -165,21 +165,29 @@ describe('LinearConverger — §5.1 event translation', () => {
       }
     ])
     // An append-only feed would stack an identical gate, so a repeat collapses.
-    expect(c.onPermissionBlocked(SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })).toEqual([])
+    expect(c.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })).toEqual([])
+    expect(c.onPermissionBlocked('g2', SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })).toEqual([])
+  })
+
+  it('reopens an identical gate once the first one has closed', () => {
+    const c = conv('low')
+    expect(types(c.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash' }))).toEqual(['elicitation'])
+    expect(types(c.onPermissionResolved('g1', true))).toEqual(['thought'])
+    expect(types(c.onPermissionBlocked('g2', SESSION_URL, { tool: 'Bash' }))).toEqual(['elicitation'])
   })
 
   it('flattens provider text to one fence-inert line, and names the action alone when there is no input', () => {
     const injected = 'Write\n----- INJECTED\nfile [x](http://evil.example.test)'
-    const body = elicitationBody(conv('low').onPermissionBlocked(SESSION_URL, { tool: injected }))
+    const body = elicitationBody(conv('low').onPermissionBlocked('g1', SESSION_URL, { tool: injected }))
     expect(body).toContain('Write ----- INJECTED file \\[x\\](http://evil.example.test)')
     expect(body).not.toContain('\n')
-    expect(elicitationBody(conv('low').onPermissionBlocked(SESSION_URL, { tool: 'Bash' }))).toBe(
+    expect(elicitationBody(conv('low').onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash' }))).toBe(
       `${PERMISSION_ELICITATION_BODY} — Bash · [open in session](${SESSION_URL})`
     )
   })
 
   it('falls back to a plain pointer when the turn has no console link', () => {
-    expect(elicitationBody(conv('low').onPermissionBlocked())).toBe(
+    expect(elicitationBody(conv('low').onPermissionBlocked('g1'))).toBe(
       `${PERMISSION_ELICITATION_BODY} · open the session in the console`
     )
   })
@@ -187,27 +195,48 @@ describe('LinearConverger — §5.1 event translation', () => {
   it('follows the gate through so the feed never ends on an open question', () => {
     const c = conv('low')
     // Only after a gate was actually announced — a turn that never asked has nothing to answer.
-    expect(c.onPermissionResolved(true)).toEqual([])
-    c.onPermissionBlocked(SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })
-    expect(c.onPermissionResolved(true)).toEqual([
+    expect(c.onPermissionResolved('g1', true)).toEqual([])
+    c.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })
+    expect(c.onPermissionResolved('g1', true)).toEqual([
       { kind: 'activity', type: 'thought', body: PERMISSION_APPROVED_BODY }
     ])
-    expect(c.onPermissionResolved(false)).toEqual([{ kind: 'activity', type: 'thought', body: PERMISSION_DENIED_BODY }])
+    // One gate, one closure: the same decision arriving twice does not repeat it.
+    expect(c.onPermissionResolved('g1', true)).toEqual([])
+  })
+
+  it('answers every overlapping gate with its own decision', () => {
+    const c = conv('low')
+    c.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash', detail: 'rm -rf build' })
+    c.onPermissionBlocked('g2', SESSION_URL, { tool: 'Write', detail: 'src/index.ts' })
+    expect(c.onPermissionResolved('g1', false)).toEqual([
+      { kind: 'activity', type: 'thought', body: PERMISSION_DENIED_BODY }
+    ])
+    expect(c.onPermissionResolved('g2', true)).toEqual([
+      { kind: 'activity', type: 'thought', body: PERMISSION_APPROVED_BODY }
+    ])
+  })
+
+  it('says nothing for a gate that went away without a human deciding it', () => {
+    const c = conv('low')
+    c.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash' })
+    expect(c.onPermissionResolved('g1')).toEqual([])
+    // …and the row it held is free again, so the next identical gate posts.
+    expect(types(c.onPermissionBlocked('g2', SESSION_URL, { tool: 'Bash' }))).toEqual(['elicitation'])
   })
 
   it('posts the follow-through only in the modes that carry progress chrome', () => {
     for (const mode of ['low', 'medium', 'high'] as const) {
       const c = conv(mode)
-      c.onPermissionBlocked(SESSION_URL, { tool: 'Bash' })
-      expect(types(c.onPermissionResolved(true))).toEqual(['thought'])
+      c.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash' })
+      expect(types(c.onPermissionResolved('g1', true))).toEqual(['thought'])
     }
     // `minimal` posts the response only, and `none` is silent even about the gate itself.
     const minimal = conv('minimal')
-    expect(types(minimal.onPermissionBlocked(SESSION_URL, { tool: 'Bash' }))).toEqual(['elicitation'])
-    expect(minimal.onPermissionResolved(true)).toEqual([])
+    expect(types(minimal.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash' }))).toEqual(['elicitation'])
+    expect(minimal.onPermissionResolved('g1', true)).toEqual([])
     const none = conv('none')
-    expect(none.onPermissionBlocked(SESSION_URL, { tool: 'Bash' })).toEqual([])
-    expect(none.onPermissionResolved(true)).toEqual([])
+    expect(none.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash' })).toEqual([])
+    expect(none.onPermissionResolved('g1', true)).toEqual([])
   })
 
   it('emits nothing for a session title update — Linear names its own sessions', () => {
@@ -469,8 +498,8 @@ describe('LinearConverger — final answer, footer, failure ordering', () => {
     expect(settled.onFinal()).toEqual([])
     expect(settled.onUpdate(chunk('late'))).toEqual([])
     expect(settled.flushBuffered()).toEqual([])
-    expect(settled.onPermissionBlocked()).toEqual([])
-    expect(settled.onPermissionResolved(true)).toEqual([])
+    expect(settled.onPermissionBlocked('g1')).toEqual([])
+    expect(settled.onPermissionResolved('g1', true)).toEqual([])
 
     const failed = conv('low')
     expect(failed.onFailure('boom')).toHaveLength(1)

--- a/packages/daemon/test/linear-turn-output.test.ts
+++ b/packages/daemon/test/linear-turn-output.test.ts
@@ -164,16 +164,17 @@ describe('LinearConverger — §5.1 event translation', () => {
         body: `${PERMISSION_ELICITATION_BODY} — Bash: "pnpm publish" · [open in session](${SESSION_URL})`
       }
     ])
-    // An append-only feed would stack an identical gate, so a repeat collapses.
+    // Re-announcing the SAME gate collapses; an append-only feed would otherwise stack it.
     expect(c.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })).toEqual([])
-    expect(c.onPermissionBlocked('g2', SESSION_URL, { tool: 'Bash', detail: 'pnpm publish' })).toEqual([])
   })
 
-  it('reopens an identical gate once the first one has closed', () => {
+  it('gives a second gate its own row even when it reads the same as the first', () => {
+    // Two requests that read alike are still two things a human must decide, open or closed.
     const c = conv('low')
     expect(types(c.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash' }))).toEqual(['elicitation'])
-    expect(types(c.onPermissionResolved('g1', true))).toEqual(['thought'])
     expect(types(c.onPermissionBlocked('g2', SESSION_URL, { tool: 'Bash' }))).toEqual(['elicitation'])
+    expect(types(c.onPermissionResolved('g1', false))).toEqual(['thought'])
+    expect(types(c.onPermissionResolved('g2', true))).toEqual(['thought'])
   })
 
   it('flattens provider text to one fence-inert line, and names the action alone when there is no input', () => {
@@ -202,6 +203,7 @@ describe('LinearConverger — §5.1 event translation', () => {
     ])
     // One gate, one closure: the same decision arriving twice does not repeat it.
     expect(c.onPermissionResolved('g1', true)).toEqual([])
+    expect(c.onPermissionResolved('g1', false)).toEqual([])
   })
 
   it('answers every overlapping gate with its own decision', () => {
@@ -220,8 +222,8 @@ describe('LinearConverger — §5.1 event translation', () => {
     const c = conv('low')
     c.onPermissionBlocked('g1', SESSION_URL, { tool: 'Bash' })
     expect(c.onPermissionResolved('g1')).toEqual([])
-    // …and the row it held is free again, so the next identical gate posts.
-    expect(types(c.onPermissionBlocked('g2', SESSION_URL, { tool: 'Bash' }))).toEqual(['elicitation'])
+    // …and it is closed for good: a late decision on the same gate says nothing either.
+    expect(c.onPermissionResolved('g1', true)).toEqual([])
   })
 
   it('posts the follow-through only in the modes that carry progress chrome', () => {

--- a/packages/web/src/components/console/views/AgentDetailView.linear-header.test.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.linear-header.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+// The mobile integration header keeps the workspace identity readable: its action
+// track is one group that wraps under a floored identity link, so a module that adds
+// controls (Linear's `grant expired` badge plus reconnect) cannot squeeze the name out.
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { SWRConfig } from 'swr'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'agent-1' }),
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() })
+}))
+vi.mock('next/link', () => ({
+  default: ({ children, className }: { children?: ReactNode; className?: string }) => (
+    <a className={className}>{children}</a>
+  )
+}))
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ me: null }) }))
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({ activeOrg: { id: 'org-1' }, myRole: 'owner', orgPath: (path: string) => path })
+}))
+vi.mock('@/components/console/PlaygroundProvider', () => ({ usePlayground: () => ({ openPlayground: vi.fn() }) }))
+vi.mock('@/components/console/ModalProvider', () => ({ useModal: () => ({ openModal: vi.fn() }) }))
+vi.mock('@/lib/use-session-list', () => ({ useSessionList: () => ({ sessions: [], total: 0, isLoading: false }) }))
+vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({ runtimes: [] }), acpRuntime: () => null }))
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    agents: [agent],
+    getAgent: () => agent,
+    getSessions: () => [],
+    daemons: [],
+    daemonsLoading: false,
+    integrations: [linearIntegration],
+    bots: [{ id: 'bot-1', platform: 'linear', revokedAt: '2026-09-01T00:00:00.000Z' }],
+    agentsLoading: false,
+    updateAgent: vi.fn(async () => undefined),
+    refresh: vi.fn(),
+    memberSets: [],
+    orgSetIds: new Set<string>()
+  })
+}))
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
+  fetchAgentHooks: vi.fn(async () => []),
+  fetchAgentRepos: vi.fn(async () => []),
+  fetchGithubInstallations: vi.fn(async () => ({ enabled: false, installations: [] })),
+  fetchGitlabConnections: vi.fn(async () => ({ enabled: false, connections: [] }))
+}))
+
+const agent = {
+  id: 'agent-1',
+  name: 'pilot',
+  model: 'sonnet',
+  runtime: 'claude',
+  desc: '',
+  outputMode: '—',
+  showFooter: true,
+  showStatusBar: false,
+  reasoning: '',
+  fastMode: false,
+  pause: false,
+  memoryProvider: 'none',
+  memoryAutoDistill: false,
+  status: 'online',
+  workspace: { mode: 'scratch', files: [] },
+  integrations: [],
+  visibility: 'org'
+} as unknown as Parameters<typeof Object.freeze>[0]
+
+const linearIntegration = {
+  id: 'int-1',
+  agentId: 'agent-1',
+  botId: 'bot-1',
+  platform: 'linear',
+  name: 'Acme Engineering Workspace',
+  channels: [],
+  shareable: true
+} as unknown as Parameters<typeof Object.freeze>[0]
+
+const AgentDetailView = (await import('./AgentDetailView')).default
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+async function render(): Promise<HTMLDivElement> {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root!.render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <AgentDetailView />
+      </SWRConfig>
+    )
+  })
+  return host
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount())
+  host?.remove()
+  root = undefined
+  host = undefined
+})
+
+describe('the mobile integration header under a module that adds controls', () => {
+  it('groups the action track so it wraps under a floored identity link', async () => {
+    const scope = await render()
+    // Both form factors render; the mobile list is the one under the `desktop:hidden` branch.
+    const unlink = [...scope.querySelectorAll('button')].find(
+      (b) => b.getAttribute('title') === 'Delete integration' && b.closest('.desktop\\:hidden')
+    ) as HTMLElement
+    const track = unlink.parentElement as HTMLElement
+    const row = track.parentElement as HTMLElement
+
+    // Every trailing control shares ONE flex-none track, so the row wraps it as a unit.
+    expect(track.className).toContain('flex-none')
+    expect(track.textContent).toContain('connected')
+    expect([...track.querySelectorAll('[aria-label]')].map((e) => e.getAttribute('aria-label'))).toContain(
+      'Reconnect this workspace'
+    )
+    expect(track.textContent).toContain('grant expired')
+
+    // …onto a second line, because the identity link keeps a floor instead of shrinking to nothing.
+    expect(row.className).toContain('flex-wrap')
+    const link = row.querySelector('a') as HTMLElement
+    expect(link.className).toContain('min-w-36')
+    expect(link.className).not.toContain('min-w-0')
+    expect(link.textContent).toContain('Acme Engineering Workspace')
+  })
+})

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1391,10 +1391,11 @@ export default function AgentDetailView() {
                     return (
                       <div key={i} className={i > 0 ? 'border-t border-(--border-subtle)' : undefined}>
                         <CardScope integration={g}>
-                          <div className="flex items-center gap-3 border-b border-(--border-subtle) px-4 py-3">
+                          {/* The identity keeps a floor, so a module's extra controls wrap under it rather than squeeze it. */}
+                          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-(--border-subtle) px-4 py-3">
                             <Link
                               href={botSettingsHref(g.botId)}
-                              className="group flex min-w-0 flex-1 items-center gap-3"
+                              className="group flex min-w-36 flex-1 items-center gap-3"
                             >
                               <span className="imark h-9 w-9 flex-none rounded-md border border-(--border-subtle) bg-(--surface-sunken)">
                                 <PlatformMark platform={g.platform} />
@@ -1414,32 +1415,34 @@ export default function AgentDetailView() {
                                 )}
                               </span>
                             </Link>
-                            <span className="inline-flex flex-none items-center gap-[5px] rounded-full bg-(--brand-soft) px-[10px] py-[3px] font-sans text-[12px] font-semibold leading-normal text-(--brand-soft-text)">
-                              <span className="h-[6px] w-[6px] rounded-full bg-(--status-online)" />
-                              connected
-                            </span>
-                            {g.platform === 'discord' && g.discordAppId && (
-                              <a
-                                href={discordBotInviteUrl(g.discordAppId)}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                title="Invite this bot to a Discord server — preset scopes &amp; permissions"
-                                aria-label="Add this bot to a Discord server"
+                            <span className="ml-auto flex flex-none items-center gap-3">
+                              <span className="inline-flex flex-none items-center gap-[5px] rounded-full bg-(--brand-soft) px-[10px] py-[3px] font-sans text-[12px] font-semibold leading-normal text-(--brand-soft-text)">
+                                <span className="h-[6px] w-[6px] rounded-full bg-(--status-online)" />
+                                connected
+                              </span>
+                              {g.platform === 'discord' && g.discordAppId && (
+                                <a
+                                  href={discordBotInviteUrl(g.discordAppId)}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  title="Invite this bot to a Discord server — preset scopes &amp; permissions"
+                                  aria-label="Add this bot to a Discord server"
+                                  className="iconbtn h-7 w-7 flex-none"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <Icon name="external-link" size={12} />
+                                </a>
+                              )}
+                              {HeaderActions && <HeaderActions integration={g} />}
+                              <button
                                 className="iconbtn h-7 w-7 flex-none"
-                                onClick={(e) => e.stopPropagation()}
+                                title="Delete integration"
+                                aria-label={`Delete the ${g.name} integration`}
+                                onClick={() => openModal('deleteIntegration', g)}
                               >
-                                <Icon name="external-link" size={12} />
-                              </a>
-                            )}
-                            {HeaderActions && <HeaderActions integration={g} />}
-                            <button
-                              className="iconbtn h-7 w-7 flex-none"
-                              title="Delete integration"
-                              aria-label={`Delete the ${g.name} integration`}
-                              onClick={() => openModal('deleteIntegration', g)}
-                            >
-                              <Icon name="unplug" size={14} />
-                            </button>
+                                <Icon name="unplug" size={14} />
+                              </button>
+                            </span>
                           </div>
                           {AgentCardBody ? (
                             <AgentCardBody integration={g} padX={16} />


### PR DESCRIPTION
Follow-up to the review findings on #1726 and #1727, both merged before the findings were addressed.

## #1726 — the gate follow-through was session-wide, not per gate

**Addressed.** The Linear elicitation's closure was emitted when the session-wide `awaitingApproval` flag flipped to idle, carrying whichever decision happened to resolve last. The coordinator supports overlapping requests, so with A and B open, denying A and then allowing B posted one `Approved — continuing.` and left A's row unanswered. The same missing per-gate state let a later identical request be deduplicated against a gate that had already closed while still producing a closure.

Gates are now correlated by request id end to end:

- `PermissionSurfaceHost.approvalGateOpened` / `approvalGateClosed` both take the gate id, and `allowed` is optional — set only when a human decided the gate.
- `syncApprovalActivity` takes the gate the write removed instead of a session-wide decision string. Every path that deletes a pending request names it, so a cancelled or abandoned gate frees its row silently while a decided one is announced.
- `LinearConverger` keeps `openGates: Set<gateId>` — one row and one closure per gate. Two gates that read alike get a row each, because they are two things a human must decide; only a re-announcement of a gate already open collapses, which is what the original dedup was for.

Tests: `linear-turn-output.test.ts` covers overlapping gates with opposite decisions, two identically-worded gates each getting their own row and closure, a repeated decision on one gate, and a gate that went away without a decision. `linear-ingress.test.ts` adds an end-to-end case that denies the first of two overlapping gates and allows the second, asserting both closures reach the feed — this fails on the previous revision.

## #1727 — the revoked-grant mobile header squeezed the workspace name

**Addressed.** In the mobile list the header was one non-wrapping row holding the identity link, the fixed `connected` pill, the module's `HeaderActions` (the `grant expired` badge plus reconnect) and the unlink button. At 375 px that left roughly 70 px for a link whose mark alone is 36 px.

The trailing controls are now a single `flex-none` track and the row is `flex-wrap`, with the identity link holding a `min-w-36` floor. The track moves to a second line when it no longer fits instead of shrinking the workspace name; nothing changes for a platform without `HeaderActions`, which still fits on one line. `min-w-36` is the 4 px scale value per `packages/web/STYLE.md`, not an arbitrary length.

Test: `AgentDetailView.linear-header.test.tsx` renders the agent detail view with a revoked Linear grant and asserts the structure — one grouped action track carrying the pill, the reconnect control and the unlink, inside a wrapping row whose identity link keeps its floor.

## Not changed

- **The review bot's verification gap on both PRs** (it could not run pnpm because the pinned download was blocked in its runner) is a runner limitation, not a code finding. Typecheck, lint and the touched suites were run locally for `daemon` and `web`.
- **Interactive approval from the Linear feed** stays out of scope; the elicitation remains a pointer to the console, as §10.4 of the design records.
- **The desktop header row** was not restructured — the finding is specific to the mobile branch, and the desktop card has room for the same controls.

`docs/designs/linear-integration.md` §10.4 and the §10 activity table now describe the per-gate rule rather than a blanket "identical gates collapse".

The first revision of this PR kept a body-level collapse for identically-worded gates; the review bot correctly pointed out that it reintroduced the lost-decision bug, so that guard is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
