### PR TITLE
feat(console): read a Linear team row the way Linear does, and drop two redundant controls

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1547,10 +1547,17 @@ tile.
     the new default. A fourth, `gatedNote`, carries the one-clause
     private-agent banner: a gated member acts in a team only as its default,
     so the host's "enable each row below" would promise a per-member switch
-    this model has not got. The org Bots row expands to the same team rows: the
+    this model has not got. A fifth, `splitRowLabel`, takes the stored
+    `<KEY> · <Team name>` apart so the row reads the way Linear's own team
+    picker does — the team's name, then its key dimmed behind it; the label
+    itself is unchanged, and the host keeps the whole of it as the row's
+    accessible name. The org Bots row expands to the same team rows: the
     workspace-shaped "Default dispatch" line it used to show is gone with the
-    flag, and Reconnect / Disconnect stay row actions. The session list needed
-    nothing: it already buckets by the session's channel, which is the team.
+    flag, and Reconnect / Disconnect stay row actions. Both surfaces drop the
+    per-team dispatch selector while the workspace has a single member — with
+    one agent it names that agent and offers nothing to pick. The session list
+    needed nothing: it already buckets by the session's channel, which is the
+    team.
   - `messageIdentity` — agent-activity id, else `null` (never dedupes).
   - `transcriptOrdering` — default `'seq'`.
 

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -9,6 +9,7 @@ import {
   roomArticle,
   roomGlyph,
   rowLabel,
+  rowLabelParts,
   rowMenuAction
 } from './IntegrationChannelList'
 import type { IntegrationChannelRow, IntegrationRow } from '@/lib/data'
@@ -19,7 +20,10 @@ vi.mock('@/lib/data-context', () => ({
     setChannelAgent: vi.fn(),
     forgetChannel: vi.fn(),
     leaveConversation: vi.fn(),
-    bots: [{ id: 'bot_shared', agentIds: ['alice', 'bob'] }],
+    bots: [
+      { id: 'bot_shared', agentIds: ['alice', 'bob'] },
+      { id: 'bot_solo', agentIds: ['alice'] }
+    ],
     agents: [
       { id: 'alice', name: 'alice', displayName: 'Alice', runtime: 'claude' },
       { id: 'bob', name: 'bob', displayName: 'Bob', runtime: 'codex' }
@@ -49,7 +53,6 @@ describe('conversationOwners', () => {
     workspace: 'acme.example.test',
     daemon: 'edge-1',
     status: 'online',
-    agentCount: '3',
     channels
   })
   const chan = (channelId: string, agentId?: string | null): IntegrationChannelRow => ({
@@ -375,6 +378,52 @@ describe('rowLabel', () => {
     expect(rowLabel({ kind: 'im', name: '@Alice' })).toBe('Alice')
     expect(rowLabel({ kind: 'mpim', name: '@Alice, Bob' })).toBe('Alice, Bob')
     expect(rowLabel({ kind: 'channel', name: 'deploys' })).toBe('deploys')
+  })
+})
+
+describe('rowLabelParts', () => {
+  it('keeps the whole label as the name where the platform declares no split', () => {
+    expect(rowLabelParts({ kind: 'channel', name: 'deploys' }, 'slack')).toEqual({ name: 'deploys' })
+  })
+
+  it('reads a Linear team the way Linear does — the name, then its key', () => {
+    expect(rowLabelParts({ kind: 'channel', name: 'ENG · Engineering' }, 'linear')).toEqual({
+      name: 'Engineering',
+      hint: 'ENG'
+    })
+    // A team the daemon could only label by id has no key to dim.
+    expect(rowLabelParts({ kind: 'channel', name: 'team-9f2' }, 'linear')).toEqual({ name: 'team-9f2' })
+  })
+
+  it('never splits a direct row — that label is a person', () => {
+    expect(rowLabelParts({ kind: 'im', name: '@A · B' }, 'linear')).toEqual({ name: 'A · B' })
+  })
+})
+
+// One member is no choice: the picker would name that agent and offer nothing to pick.
+describe('IntegrationChannelList default dispatch on a one-member bot', () => {
+  const render = (botId: string) =>
+    renderToStaticMarkup(
+      createElement(IntegrationChannelList, {
+        integrationId: 'int_alice',
+        botId,
+        agentId: 'alice',
+        platform: 'slack',
+        shareable: true,
+        channels: [{ channelId: 'C1', name: 'deploys', kind: 'channel', trigger: 'mention', agentId: 'alice' }]
+      })
+    )
+
+  it('drops the picker and the sentence that explains it', () => {
+    const html = render('bot_solo')
+    expect(html).not.toContain('Default dispatch')
+    expect(html).not.toContain('the agent who handles unmatched messages')
+  })
+
+  it('keeps both once a second agent shares the bot', () => {
+    const html = render('bot_shared')
+    expect(html).toContain('Default dispatch — Alice')
+    expect(html).toContain('the agent who handles unmatched messages')
   })
 })
 

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -233,6 +233,20 @@ const platformName = (platform?: string): string => chatPlatformName(platform, '
 export const rowLabel = (row: Pick<IntegrationChannelRow, 'kind' | 'name'>): string =>
   isDirectConversation(row.kind) ? row.name.replace(/^@+/, '') : row.name
 
+/** The row's label as two pieces — the name it leads with, and the dim tail printed after it.
+ *  How a label comes apart is the platform's own (`splitRowLabel`); a module that declares none
+ *  keeps the whole label as the name. Direct rows are never split: their label is a person. */
+export function rowLabelParts(
+  row: Pick<IntegrationChannelRow, 'kind' | 'name'>,
+  platform?: string
+): { name: string; hint?: string } {
+  const label = rowLabel(row)
+  const split = channelListSemantics(platform).splitRowLabel
+  if (!split || isDirectConversation(row.kind)) return { name: label }
+  const parts = split(label)
+  return parts.name ? parts : { name: label }
+}
+
 /** Whether the bot can be made to leave THIS row from here — the platform must have a
  *  per-conversation leave, and the row must be somewhere membership applies at all. */
 export const canLeaveRow = (kind: IntegrationChannelRow['kind'], platform?: string): boolean =>
@@ -545,6 +559,10 @@ export function IntegrationChannelList({
   const derivedRoster = channelListSemantics(platform).roster === 'derived'
   // Where rows come from, plus the platform's tail — which on a derived roster IS the arrival sentence, so it leads.
   const footerNote = channelListSemantics(platform).footerNote
+  // The agents that share this bot — the candidate per-conversation defaults.
+  const memberIds = shareable && botId ? (bots.find((b) => b.id === botId)?.agentIds ?? []) : []
+  // Dispatch is a decision only where there are two agents to decide between.
+  const dispatchable = memberIds.length > 1
   // Why a private agent's rows start off. A platform whose gate is more than the row's own says so itself.
   const gatedNote =
     channelListSemantics(platform).gatedNote ??
@@ -558,7 +576,7 @@ export function IntegrationChannelList({
           `${roomArticle(roomNoun(platform))} ${roomNoun(platform)} appears here once the bot is added to it, and its trigger is set per conversation.`,
           'Direct messages appear when someone writes to the bot.'
         ]),
-    ...(shareable ? ['Default dispatch is the agent who handles unmatched messages in the conversation.'] : []),
+    ...(dispatchable ? ['Default dispatch is the agent who handles unmatched messages in the conversation.'] : []),
     ...(!derivedRoster && footerNote ? [footerNote] : [])
   ]
   // A platform refusal is the useful half of a failed Leave — a missing scope or a
@@ -573,8 +591,6 @@ export function IntegrationChannelList({
       setError(cause instanceof Error ? cause.message : String(cause))
     }
   }, [])
-  // The agents that share this bot — the candidate per-conversation defaults.
-  const memberIds = shareable && botId ? (bots.find((b) => b.id === botId)?.agentIds ?? []) : []
   const member = (id: string): MemberAgent => {
     const a = agents.find((x) => x.id === id)
     return {
@@ -633,7 +649,9 @@ export function IntegrationChannelList({
     )
   }
   const row = (c: IntegrationChannelRow) => {
-    const def = shareable ? defaultAgent(c) : undefined
+    // One member is no choice: the picker would name this agent and offer nothing, so the row drops it.
+    const def = dispatchable ? defaultAgent(c) : undefined
+    const label = rowLabelParts(c, platform)
     return (
       <div
         key={c.channelId}
@@ -643,7 +661,10 @@ export function IntegrationChannelList({
         <span className="font-mono text-[14px] font-medium leading-normal text-(--text-tertiary)">
           {roomGlyph(c.kind, platform)}
         </span>
-        <span className="mono min-w-0 flex-1 truncate text-[13px] text-(--text-primary)">{rowLabel(c)}</span>
+        <span className="mono flex min-w-0 flex-1 items-baseline gap-[6px] truncate text-[13px] text-(--text-primary)">
+          <span className="min-w-0 truncate">{label.name}</span>
+          {label.hint && <span className="flex-none text-(--text-tertiary)">{label.hint}</span>}
+        </span>
         <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-start">
           {def && (
             <>

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -586,6 +586,13 @@ export interface WebChannelListSemantics {
   /** The private-agent banner's sentence, where enabling a row is not the whole gate —
    *  Linear's gated member acts in a team only as its default (§4.3). Absent ⇒ the host's. */
   gatedNote?: string
+  /**
+   * Splits a stored row label into the name the platform leads with and the dim tail it
+   * prints after it. Linear stores a team as `<KEY> · <Team name>` and its own team picker
+   * reads the name first with the key dimmed behind it, so the module — never the host —
+   * knows how to take that label apart. Absent ⇒ the whole label is the name.
+   */
+  splitRowLabel?(label: string): { name: string; hint?: string }
 }
 
 /**

--- a/packages/web/src/components/console/platforms/linear/card.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/card.test.tsx
@@ -94,7 +94,6 @@ function integration(over: Partial<IntegrationRow> = {}): IntegrationRow {
     workspace: 'Example Workspace',
     daemon: 'edge-1',
     status: 'online',
-    agentCount: '3',
     channels: TEAMS,
     ...over
   }
@@ -191,8 +190,9 @@ describe('the workspace chrome', () => {
     // The header above this card already names the workspace; repeating it here is the
     // duplicate row this card no longer draws.
     expect(text()).not.toContain('Example Workspace')
-    expect(text()).toContain('ENG · Engineering')
-    expect(text()).toContain('DES · Design')
+    // Each team, named the way Linear names it — the name, then its key.
+    expect(text()).toContain('EngineeringENG')
+    expect(text()).toContain('DesignDES')
   })
 
   it('says the roster is the workspace’s own, not something the bot was added to', async () => {
@@ -211,6 +211,17 @@ describe('the workspace chrome', () => {
 })
 
 describe('the team rows', () => {
+  it('leads with the team’s name and dims its key behind it, as Linear’s own picker does', async () => {
+    await render()
+
+    const [eng] = [...host.querySelectorAll('span')].filter((el) => el.textContent === 'Engineering')
+    expect(eng).toBeDefined()
+    // The key is present but muted — the row reads "Engineering ENG", never "ENG · Engineering".
+    const dim = eng!.parentElement!.querySelector('.text-\\(--text-tertiary\\)')
+    expect(dim?.textContent).toBe('ENG')
+    expect(eng!.parentElement!.textContent).not.toContain('·')
+  })
+
   it('carries a trigger per team, Mention or Off and nothing else', async () => {
     await render()
     await act(async () => buttonWithLabel('Trigger for ENG · Engineering')!.click())

--- a/packages/web/src/components/console/platforms/linear/index.tsx
+++ b/packages/web/src/components/console/platforms/linear/index.tsx
@@ -12,6 +12,9 @@ import { linearSettingsFragments } from './settings'
  *  can never match it, and neither can any other platform's id shape. */
 const LINEAR_ACTIVITY_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+/** What the daemon joins a team's key and name with (`linearChannelName`, §4.5). */
+const TEAM_LABEL_SEPARATOR = ' · '
+
 export const linearModule: WebPlatformModule<LinearApi> = {
   platformId: 'linear',
   Mark: LinearMark,
@@ -56,6 +59,15 @@ export const linearModule: WebPlatformModule<LinearApi> = {
       'Every team of this workspace is listed here; a delegation or a mention starts a session in one that is not off.',
     // §4.3: a gated member acts in a team only as its default, so enabling the row is half the gate.
     gatedNote: 'Private agent: it answers in a team only where it is the default and the team is not off.',
+    // The daemon stores a team as "<KEY> · <Team name>" (§4.5); Linear's own team picker leads
+    // with the name and dims the key behind it, so the row reads the way the operator's Linear does.
+    splitRowLabel: (label) => {
+      const at = label.indexOf(TEAM_LABEL_SEPARATOR)
+      if (at < 0) return { name: label }
+      const key = label.slice(0, at).trim()
+      const name = label.slice(at + TEAM_LABEL_SEPARATOR.length).trim()
+      return name ? { name, ...(key ? { hint: key } : {}) } : { name: label }
+    },
     // §6.2: the default seat IS a gated agent's grant, and a Linear AgentSession has one writer (§4.6).
     ownerChangeWarning: {
       title: 'Move this team’s default?',

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1653,15 +1653,6 @@ export default function AgentDetailView() {
                                     <span className="dot h-[6px] w-[6px] bg-(--status-online)" />
                                     connected
                                   </span>
-                                  {g.shareable && (
-                                    <span
-                                      className="badge bg-(--surface-app) text-(--text-tertiary)"
-                                      title="Shared bot — used by multiple agents, inbound via a relay. Each channel dispatches to one of them by default."
-                                    >
-                                      <Icon name="users" size={11} />
-                                      shared · {g.agentCount} {g.agentCount === '1' ? 'agent' : 'agents'}
-                                    </span>
-                                  )}
                                 </div>
                               </div>
                             </Link>

--- a/packages/web/src/components/console/views/IntegrationsView.linear-teams.test.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.linear-teams.test.tsx
@@ -84,7 +84,6 @@ const INSTALL: IntegrationRow = {
   workspace: 'Example Workspace',
   daemon: 'edge-1',
   status: 'online',
-  agentCount: '2',
   channels: [
     { channelId: 'team-des', name: 'DES · Design', kind: 'channel', trigger: 'off', agentId: 'agent-b' },
     { channelId: 'team-eng', name: 'ENG · Engineering', kind: 'channel', trigger: 'mention', agentId: 'agent-a' }
@@ -138,10 +137,22 @@ describe('the Linear workspace’s Bots row', () => {
   it('expands to the workspace’s team rows, each with its own dispatch selector', async () => {
     const view = await expandWorkspace()
 
-    expect(view.textContent).toContain('DES · Design')
-    expect(view.textContent).toContain('ENG · Engineering')
+    // Named as Linear names a team: the name, then its key dimmed behind it.
+    expect(view.textContent).toContain('DesignDES')
+    expect(view.textContent).toContain('EngineeringENG')
     // Not the retired single line that stood for the whole workspace.
     expect(pickers(view)).toHaveLength(2)
+  })
+
+  it('drops the dispatch column when one agent is the only member', async () => {
+    // Nothing to pick between: the column would name that agent on every team row.
+    mocks.bots = [{ ...WORKSPACE, agentIds: ['agent-a'] }]
+    mocks.integrations = [{ ...INSTALL, channels: INSTALL.channels.map((c) => ({ ...c, agentId: 'agent-a' })) }]
+    const view = await expandWorkspace()
+
+    expect(view.textContent).toContain('EngineeringENG')
+    expect(view.textContent).not.toContain('Default dispatch')
+    expect(pickers(view)).toHaveLength(0)
   })
 
   it('names the room with Linear’s own noun for assistive tech', async () => {

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -29,6 +29,7 @@ import {
   type MeDto
 } from '@/lib/api'
 import { agentLabel, isDirectConversation, type IntegrationRow } from '@/lib/data'
+import { rowLabelParts } from '@/components/console/IntegrationChannelList'
 import {
   botCardCopy,
   botSharingEditable,
@@ -383,7 +384,8 @@ function BotsCard({
           const free = b.agentIds.length === 0
           const open = openBotId === b.id
           const channels = open ? botChannels(b, integrations) : []
-          const showDefaultDispatch = b.shareable && channels.length > 0
+          // One member is no choice — the column would name that agent on every row and offer nothing.
+          const showDefaultDispatch = b.shareable && channels.length > 0 && b.agentIds.length > 1
           const chanGrid = showDefaultDispatch ? 'grid-cols-[1fr_auto]' : 'grid-cols-[1fr]'
           // The picker's choices: every agent installed on the bot.
           const agentOptions = b.agentIds.map((id) => {
@@ -528,53 +530,59 @@ function BotsCard({
                         {showDefaultDispatch && <span className="justify-self-end">Default dispatch</span>}
                       </div>
                       <div className="overflow-visible rounded-lg border border-(--border-subtle) bg-(--surface-card)">
-                        {channels.map((c, index) => (
-                          <Fragment key={c.channelId}>
-                            {isDirectConversation(c.kind) && !isDirectConversation(channels[index - 1]?.kind) && (
-                              <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-3 py-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
-                                Direct messages
-                              </div>
-                            )}
-                            <div
-                              className={`grid ${chanGrid} items-center gap-[11px] border-b border-(--border-subtle) px-3 py-2 last:border-b-0`}
-                            >
-                              <span className="mono flex min-w-0 items-center gap-[7px] text-[12px]">
-                                <Icon
-                                  name={c.kind === 'mpim' ? 'users' : c.kind === 'im' ? 'at-sign' : 'hash'}
-                                  size={12}
-                                  color="var(--text-tertiary)"
-                                  className="flex-none"
-                                />
-                                {/* The room's noun is the platform's own; the two direct kinds are platform-free. */}
-                                <span className="sr-only">
-                                  {c.kind === 'mpim' ? 'Group DM' : c.kind === 'im' ? 'Direct message' : roomLabel}
-                                  :{' '}
-                                </span>
-                                <span className="truncate">
-                                  {isDirectConversation(c.kind) ? c.name.replace(/^@+/, '') : c.name}
-                                </span>
-                              </span>
-                              {showDefaultDispatch && (
-                                <DefaultDispatchPicker
-                                  options={agentOptions}
-                                  activeId={c.agentId ?? b.agentIds[0] ?? null}
-                                  disabled={!canWrite || !c.integrationId}
-                                  onPick={(agentId) =>
-                                    ownerGuard.guard(
-                                      {
-                                        platform: b.platform,
-                                        from: owner(c.agentId ?? b.agentIds[0] ?? null),
-                                        toId: agentId,
-                                        room: c.name
-                                      },
-                                      () => setChannelAgent(c.integrationId!, c.channelId, agentId)
-                                    )
-                                  }
-                                />
+                        {channels.map((c, index) => {
+                          const label = rowLabelParts(c, b.platform)
+                          return (
+                            <Fragment key={c.channelId}>
+                              {isDirectConversation(c.kind) && !isDirectConversation(channels[index - 1]?.kind) && (
+                                <div className="border-b border-(--border-subtle) bg-(--surface-sunken) px-3 py-[6px] font-sans text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)">
+                                  Direct messages
+                                </div>
                               )}
-                            </div>
-                          </Fragment>
-                        ))}
+                              <div
+                                className={`grid ${chanGrid} items-center gap-[11px] border-b border-(--border-subtle) px-3 py-2 last:border-b-0`}
+                              >
+                                <span className="mono flex min-w-0 items-center gap-[7px] text-[12px]">
+                                  <Icon
+                                    name={c.kind === 'mpim' ? 'users' : c.kind === 'im' ? 'at-sign' : 'hash'}
+                                    size={12}
+                                    color="var(--text-tertiary)"
+                                    className="flex-none"
+                                  />
+                                  {/* The room's noun is the platform's own; the two direct kinds are platform-free. */}
+                                  <span className="sr-only">
+                                    {c.kind === 'mpim' ? 'Group DM' : c.kind === 'im' ? 'Direct message' : roomLabel}
+                                    :{' '}
+                                  </span>
+                                  <span className="flex min-w-0 items-baseline gap-[6px] truncate">
+                                    <span className="min-w-0 truncate">{label.name}</span>
+                                    {label.hint && (
+                                      <span className="flex-none text-(--text-tertiary)">{label.hint}</span>
+                                    )}
+                                  </span>
+                                </span>
+                                {showDefaultDispatch && (
+                                  <DefaultDispatchPicker
+                                    options={agentOptions}
+                                    activeId={c.agentId ?? b.agentIds[0] ?? null}
+                                    disabled={!canWrite || !c.integrationId}
+                                    onPick={(agentId) =>
+                                      ownerGuard.guard(
+                                        {
+                                          platform: b.platform,
+                                          from: owner(c.agentId ?? b.agentIds[0] ?? null),
+                                          toId: agentId,
+                                          room: c.name
+                                        },
+                                        () => setChannelAgent(c.integrationId!, c.channelId, agentId)
+                                      )
+                                    }
+                                  />
+                                )}
+                              </div>
+                            </Fragment>
+                          )
+                        })}
                       </div>
                     </>
                   ) : (

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -336,8 +336,6 @@ function integrationRowFromDto(
     workspace: '—',
     daemon: agent?.daemon ?? '—',
     status: d.status === 'active' ? 'online' : 'offline',
-    // A shared bot may serve several agents; show the count so the UI reads right.
-    agentCount: bot?.shareable ? String(Math.max(bot.agentIds.length, 1)) : '1',
     channels: d.channels.map((c) => ({
       channelId: c.channelId,
       name: c.name || c.channelId,

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1975,7 +1975,6 @@ export interface IntegrationRow {
   workspace: string
   daemon: string
   status: StatusKey
-  agentCount: string
   channels: IntegrationChannelRow[]
 }
 
@@ -1988,7 +1987,6 @@ export const INTEGRATIONS: IntegrationRow[] = (
       workspace: 'acme.slack.com',
       daemon: 'edge-1',
       status: 'online',
-      agentCount: '3',
       channels: [
         { channelId: 'C-deploys', name: 'deploys', trigger: 'mention' },
         { channelId: 'C-pull-requests', name: 'pull-requests', trigger: 'mention' },
@@ -2002,7 +2000,6 @@ export const INTEGRATIONS: IntegrationRow[] = (
       workspace: 'acme guild',
       daemon: 'edge-1',
       status: 'online',
-      agentCount: '1',
       discordAppId: '900000000000000001',
       channels: [
         { channelId: 'C-ops', name: 'ops', trigger: 'mention' },
@@ -2016,7 +2013,6 @@ export const INTEGRATIONS: IntegrationRow[] = (
       workspace: '@acme_docs',
       daemon: 'edge-1',
       status: 'online',
-      agentCount: '1',
       channels: [{ channelId: 'acme_docs', name: 'acme_docs', trigger: 'mention' }]
     }
   ] satisfies IntegrationRow[]


### PR DESCRIPTION
Three changes to the integration card's conversation rows, driven by the Linear card.

## 1. A team row reads the way Linear reads it

The row led with the stored label verbatim -- `ENG - Engineering`. It now leads with
the team's **name** and prints its **key** after it in muted grey, which is how
Linear's own team picker shows a team.

Splitting a label is platform knowledge, not the host's, so it lands as a new
optional member on the web module contract:

```ts
splitRowLabel?(label: string): { name: string; hint?: string }
```

The Linear module implements it over the `<KEY> - <Team name>` the daemon writes
(`linearChannelName`); every other platform declares none and keeps its label whole.
Core's `rowLabelParts` consults the module, never the label's shape. Nothing changes
about the stored value, and the row's accessible name is still the full label, so a
screen reader keeps the key. Both surfaces that list team rows -- the agent page's
Linear card and the org Bots roster -- render it the same way.

**The team ICON was assessed and left out.** It cannot be reached without a wire and
schema change: Linear's `Team` exposes `icon` and `color`, but the observed-channel
path carries neither, and there is no field to borrow -- `space`/`spaceId` are the
grouping key, so reusing them would band every team under its own header. Shipping it
means, in order: two fields on the daemon's `TEAMS_QUERY` and `PlatformChannelRef`,
two optional fields on the protocol's `IntegrationChannel`, two nullable columns on
`integration_channel` with a migration, the control-plane DTO, then
`IntegrationChannelRow` and a glyph column in the row. That is a contract change in
its own right and does not belong in a rendering fix.

## 2. No dispatch selector where there is nothing to dispatch

The per-conversation default-dispatch picker showed on every row of a shared bot,
including a bot with exactly one member -- where it named that agent, offered no
second option, and cost a click to find that out. It is now dropped while the bot has
a single member, on both surfaces, and the footer sentence that explains default
dispatch goes with it. Two or more members: unchanged.

## 3. The shared-agent-count pill is gone

The header pill counting the bot's agents is removed for every platform, not hidden:
the header already links to the bot, whose own row lists its members with their
avatars. `IntegrationRow.agentCount` and the field that fed it are deleted, so the
type system rules out a second one. No test asserted the pill, so none was deleted --
the removed field is what keeps it gone.

## Checks

`pnpm --filter @agentconnect.md/web test` (206 files, 2309 tests), `typecheck`,
`eslint .`, `prettier --check .` -- all green. New coverage: `rowLabelParts` (default,
Linear split, direct rows never split), the one-member collapse on both surfaces, and
the Linear team row's name/key rendering. The design doc's console section records the
new member and the collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
