### PR TITLE
fix(daemon): a headless cron fire binds no conversation audience

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13893,6 +13893,9 @@ export class Daemon {
       }
     | undefined
   > {
+    // Daemon-minted coordinates reach no conversation, so they can bind no audience. `headless` is not that fact:
+    // a channel-root seed and a channel intro are headless turns in a REAL channel, and both must still bind.
+    if (msg.syntheticChannel === true) return undefined
     // Which platforms bind sessions to a conversation audience, which of their
     // conversations qualify, and what identifies the realm are platform facts
     // (§7.4 conversation-audience strategy). No registered audience — Telegram,
@@ -13911,11 +13914,7 @@ export class Daemon {
       integrationId,
       integration
     )
-    // Cron and daemon-owned continuation turns can create or resume a real shared
-    // conversation, while synthetic/headless callers may use platform-shaped
-    // coordinates with no connection. Bind those trusted system turns only when
-    // the destination is attributable. Human ingress keeps the incomplete tuple
-    // so the caller below fails closed instead of treating an unverified turn as local.
+    // A system turn binds only when its destination is attributable; human ingress keeps the tuple and fails closed.
     if (msg.source !== 'user' && (!integrationId || !realmKey)) return undefined
     return {
       externalProvider: msg.platform,

--- a/packages/daemon/src/scheduler/scheduler.ts
+++ b/packages/daemon/src/scheduler/scheduler.ts
@@ -59,11 +59,7 @@ export function buildSyntheticMessage(
   // written apart from a trim, and a schedule prompt is routinely long and multi-line, so copying
   // it would persist the whole prompt as the title and push it to platform title surfaces.
   const title = deriveTitle(cron.trigger)
-  // No target ⇒ headless fire: the channel is a synthetic key (transcript/session
-  // bookkeeping only) and `headless` suppresses all platform output in dispatch.
-  // An anchored fire lives on the TARGET's platform (replies post there);
-  // headless fires keep the legacy 'slack' key so existing synthetic sessions
-  // stay continuous across this change.
+  // No target ⇒ headless fire: a minted key on the legacy 'slack' platform, so existing sessions stay continuous.
   const msg: NormalizedMessage = {
     msgId: `cron:${cron.id}:${traceId}`,
     traceId,
@@ -77,7 +73,7 @@ export function buildSyntheticMessage(
     mentionedBots: [],
     isDm: false,
     trigger: 'cron',
-    ...(cron.target ? {} : { headless: true })
+    ...(cron.target ? {} : { headless: true, syntheticChannel: true })
   }
   return { agentId, msg }
 }

--- a/packages/daemon/test/daemon-agent-mention-routing.test.ts
+++ b/packages/daemon/test/daemon-agent-mention-routing.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { MAX_AGENT_CALL_HOPS } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
+import { buildSyntheticMessage } from '../src/scheduler/scheduler.js'
+import type { CronDef } from '../src/agents/agent-schema.js'
 import { sessionKey, type InboxRow } from '../src/store/local-store.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import type { NormalizedMessage } from '../src/messages/normalized.js'
@@ -334,6 +336,68 @@ describe('agent-authored platform mentions (send-message-routing-rework.md §6)'
     const postlessWake = { callFrom: 'bot-a', hopCount: 1, deliveryId: 'd-2' }
     await (daemon as any).classifyNewSessionOrThrow('bot-b', postlessKey, 'acp-1', msg, postlessWake, undefined, false)
     expect(await (daemon as any).store.getSession(postlessKey)).toMatchObject({ sourceBindingKind: 'local' })
+    await daemon.stop()
+  })
+
+  it('keeps a HEADLESS cron fire local while an anchored one still binds its channel', async () => {
+    // A headless fire keeps the legacy `slack` session key for continuity, but `cron:<id>` is a
+    // synthetic coordinate rather than a channel. Binding it as a conversation audience minted a
+    // scope no Slack member can ever satisfy, so once the org followed Slack access the run's
+    // session was invisible to everyone — while the anchored fire beside it, which does post to a
+    // real channel, must go on binding.
+    const { daemon } = await boot([{ id: 'bot-b' }])
+    ;(daemon as any).connByIntegration.set('int-bot-b', { workspaceId: () => 'T-TEST' })
+    const cron = (over: Partial<CronDef>): CronDef => ({
+      id: 'cron-1',
+      schedule: '0 9 * * *',
+      trigger: 'post health report',
+      enabled: true,
+      ...over
+    })
+
+    // The fire carries no transport scope, yet an agent with ONE Slack integration resolves one from
+    // the absent scope anyway — attributable, which is why the guard has to be the minted coordinate
+    // itself rather than the completeness of the tuple below it.
+    const { msg: headless } = buildSyntheticMessage('bot-b', cron({}), 'trace-1')
+    expect(headless.channel).toBe('cron:cron-1')
+    expect(headless.syntheticChannel).toBe(true)
+    expect((daemon as any).integrationIdForTransportScope('bot-b', 'slack', undefined)).toBe('int-bot-b')
+    expect(await (daemon as any).conversationExternalSource('bot-b', headless, false)).toBeUndefined()
+
+    const key = sessionKey('slack', headless.channel, headless.thread!, 'bot-b')
+    await (daemon as any).store.upsertSession({
+      key,
+      agentId: 'bot-b',
+      platform: 'slack',
+      channel: headless.channel,
+      thread: headless.thread!,
+      acpSessionId: 'acp-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    await (daemon as any).classifyNewSessionOrThrow('bot-b', key, 'acp-1', headless, undefined, undefined, false)
+    // `local` is what keeps the CP off its mixed-version Slack fallback, so the row stays an
+    // ordinary org session instead of an external candidate that can never settle.
+    expect(await (daemon as any).store.getSession(key)).toMatchObject({
+      sourceBindingKind: 'local',
+      externalProvider: null
+    })
+
+    const anchored = buildSyntheticMessage('bot-b', cron({ target: { platform: 'slack', channel: 'C1' } }), 't2').msg
+    expect(anchored.syntheticChannel).toBeUndefined()
+    const bound = {
+      externalProvider: 'slack',
+      externalRealmKey: 'T-TEST',
+      externalResourceKind: 'conversation',
+      externalResourceKey: 'C1',
+      externalIntegrationId: 'int-bot-b'
+    }
+    expect(await (daemon as any).conversationExternalSource('bot-b', anchored, false)).toMatchObject(bound)
+    // And headlessness alone must never be read as the minted coordinate: a channel-root seed and a
+    // channel intro are headless turns that DO live in a real channel and have to keep binding it.
+    const headlessInChannel = { ...anchored, headless: true }
+    expect(await (daemon as any).conversationExternalSource('bot-b', headlessInChannel, false)).toMatchObject(bound)
     await daemon.stop()
   })
 

--- a/packages/daemon/test/scheduler.test.ts
+++ b/packages/daemon/test/scheduler.test.ts
@@ -68,7 +68,16 @@ describe('buildSyntheticMessage', () => {
     const { msg } = buildSyntheticMessage('bot-a', cron('daily', { target: undefined }), 'trace-1', FIRED_AT)
     expect(msg.headless).toBe(true)
     expect(msg.channel).toBe('cron:daily')
+    // The key is platform-shaped for continuity, so the message has to SAY it reaches no conversation.
+    expect(msg.syntheticChannel).toBe(true)
     expect(msg.text.endsWith('post health report')).toBe(true)
+  })
+
+  it('an anchored cron posts to a real channel, so it mints nothing', () => {
+    const { msg } = buildSyntheticMessage('bot-a', cron('daily'), 'trace-1', FIRED_AT)
+    expect(msg.channel).toBe('C1')
+    expect(msg.headless).toBeUndefined()
+    expect(msg.syntheticChannel).toBeUndefined()
   })
 })
 

--- a/packages/protocol/src/normalized-message.ts
+++ b/packages/protocol/src/normalized-message.ts
@@ -182,6 +182,8 @@ export const NormalizedPlatformMessageSchema = z.object({
    *  so cross-source merges order correctly (merged-conversation-view.md §6). */
   platformTimeMs: z.number().int().positive().optional(),
   headless: z.boolean().optional(),
+  /** Daemon-minted coordinates, not a platform destination: a headless cron keeps a key it never posts to. */
+  syntheticChannel: z.literal(true).optional(),
   /** UNTRUSTED provider authorship claim for an agent-authored platform message
    *  (see {@link AgentAuthorshipClaimSchema}). Absent on human and third-party-bot
    *  traffic. Kept as one nested object so a consumer can never mistake a verified


### PR DESCRIPTION
## The bug

A schedule with **no target channel** fires headless. The synthetic message keeps a platform-shaped session key — `platform: 'slack'`, `channel: 'cron:<id>'` — deliberately, so existing synthetic sessions stay continuous.

Nothing on that message said the key reaches no conversation. So `conversationExternalSource` treated it like any non-DM Slack coordinate:

- `applies(msg)` is `!msg.isDm`, which a cron fire satisfies;
- `integrationIdForTransportScope` falls back to the agent's first Slack integration when the transport scope is absent, which a cron fire's is;
- the realm resolved from that integration's live connection.

The tuple was complete, so the fire bound `cron:<id>` as a Slack **conversation audience**. The control plane accepted it and settled an external scope for a channel that does not exist, so no workspace member could ever satisfy it. With the organization following Slack access, the session matched none of the viewer arms and every link to it answered 404 — including the one on the schedule's own run row.

Agents with no Slack integration were unaffected: the fallback found nothing, the tuple stayed incomplete, and the fire classified local.

## The fix

`headless` is not the fact to guard on — a channel-root seed and a channel intro are headless turns that *do* live in a real channel and have to keep binding it. So the message carries the fact itself: `syntheticChannel` marks daemon-minted coordinates, set at the one place that mints them and read at the one place that decides an audience.

Anchored schedules are unchanged; they keep following their target channel's audience.

## Scope

- Classification at ingest only. Rows already bound keep their binding.
- A daemon that predates the marker reports neither it nor an origin, so the control plane's mixed-version fallback goes on classifying its target-less fires the old way until it upgrades. That fallback is deliberately untouched — it is the fail-closed path for exactly that case.

## Tests

- `daemon-agent-mention-routing`: a headless fire on an agent that *has* a Slack integration classifies `local` with no external provider, while the anchored fire beside it still binds — and a headless turn in a real channel keeps binding, which pins why `headless` is the wrong discriminator.
- `scheduler`: the marker is set on a target-less fire and absent on an anchored one.

Counterfactually verified: reverting the guard alone turns the first assertion red with the exact production shape (`externalProvider: 'slack'`, `externalResourceKey: 'cron:<id>'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
