### PR TITLE
fix(relay): answer an undecodable forward with an error instead of silence

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1588,7 +1588,11 @@ none` skips it along with everything else Linear-visible. There is **no
    `linear:receipt` / `linear:actor-name` / `linear:issue-facts`, `dispatch`,
    `admitted`, or `duty-claim`), and again with the elapsed time when the ack
    finally lands, so a stall names its step instead of surfacing only as the
-   relay's "no ack after 5 tries" drop.
+   relay's "no ack after 5 tries" drop. A frame the daemon cannot decode at all
+   is not silent either: the daemon logs the frame type, id, size and the
+   schema reason, and answers the relay with a correlated `error` so the
+   forward fails at once with that reason; the relay's timeout message carries
+   the frame size for the case where nothing comes back.
 3. **PR links.** The converger collects pull/merge-request URLs from the
    agent's own message text over the turn (`codeHostLinks`: `PR #123` for a
    GitHub pull, `MR !45` for a GitLab merge request, each URL once) and

--- a/packages/daemon/src/cp/relay-client.ts
+++ b/packages/daemon/src/cp/relay-client.ts
@@ -14,6 +14,7 @@
 import {
   buildRelayDaemonFrame,
   decodeRelayDaemonFrame,
+  NIL_UUID,
   RD_HEADLESS_AGENT_DELIVERY_V1,
   RD_AGENT_IMPLICIT_ROUTING_V1,
   RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2,
@@ -199,22 +200,47 @@ export class RelayClient {
     return this.correlator.request(frame, (e) => this.transport!.send(e))
   }
 
+  /** The `type` of a frame that failed to decode, for the log line — never its payload. */
+  private static frameTypeOf(text: string): string {
+    try {
+      const type = (JSON.parse(text) as { type?: unknown }).type
+      return typeof type === 'string' ? type : 'untyped'
+    } catch {
+      return 'non-JSON'
+    }
+  }
+
   private async onText(text: string): Promise<void> {
     const decoded = decodeRelayDaemonFrame(text)
     if (!decoded.ok) {
+      const code =
+        decoded.msg === 'FRAME_TOO_LARGE'
+          ? 'FRAME_TOO_LARGE'
+          : decoded.msg === 'UNKNOWN_FRAME'
+            ? 'UNKNOWN_FRAME'
+            : 'BAD_PAYLOAD'
       if (decoded.corr) {
-        const code =
-          decoded.msg === 'FRAME_TOO_LARGE'
-            ? 'FRAME_TOO_LARGE'
-            : decoded.msg === 'UNKNOWN_FRAME'
-              ? 'UNKNOWN_FRAME'
-              : 'BAD_PAYLOAD'
         this.correlator.reject(decoded.corr, new WireError(code, `invalid correlated reply: ${decoded.msg}`, false))
+        return
+      }
+      // A request this build cannot read: say so here AND answer the relay with a correlated
+      // `error`, so its forward fails at once with the reason instead of timing out in silence.
+      const reason = decoded.msg.slice(0, 300)
+      this.deps.log.warn(
+        `relay(${this.relayId}): dropping undecodable ${RelayClient.frameTypeOf(text)} frame ${decoded.id} (${Buffer.byteLength(text)} bytes): ${reason}`
+      )
+      if (decoded.id !== NIL_UUID) {
+        this.transport?.send(
+          JSON.stringify(
+            buildRelayDaemonFrame('error', { code, message: reason, retryable: false }, { corr: decoded.id })
+          )
+        )
       }
       return
     }
     const frame = decoded.frame
     if (frame.corr && this.correlator.settle(frame)) return
+    this.deps.log.debug(`relay(${this.relayId}): ← ${frame.type} ${frame.id} (${Buffer.byteLength(text)} bytes)`)
     if (frame.type === 'rd/msg') {
       await this.handleMsg(frame.id, frame.payload)
       return

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6584,7 +6584,9 @@ export class Daemon {
     // CP ships a gated install's enabled set even in relay-managed mode).
     if (!this.gatedAdmission(msg.integrationId, normalized)) {
       this.maybeGatedNotice(normalized, [msg.integrationId])
-      this.log.debug(`relay: dropped ${msg.msgId} for gated integration ${msg.integrationId} (conversation off)`)
+      this.log.debug(
+        `relay: dropped ${msg.msgId} for gated integration ${msg.integrationId} (${normalized.platform} conversation ${normalized.channel} off)`
+      )
       return { msgId: msg.msgId, accepted: true }
     }
     // HTTP-bot IM bypasses onInbound() because the relay already arbitrated the

--- a/packages/daemon/test/cp/relay-client.test.ts
+++ b/packages/daemon/test/cp/relay-client.test.ts
@@ -231,3 +231,42 @@ describe('RelayClient (daemon → one relay)', () => {
     expect(seqs()).toEqual([1, 2, 1, 2])
   })
 })
+
+describe('RelayClient — an inbound frame that fails to decode', () => {
+  it('logs the drop with its type, id and size, and answers a correlated error so the relay fails fast', async () => {
+    const warn = vi.fn()
+    const log = { ...silentLog, warn } as unknown as Logger
+    const clock = new FakeClock()
+    const transports: FakeTransport[] = []
+    const onRelayMsg = vi.fn((msg: RdMsg) => ({ msgId: msg.msgId, accepted: true }))
+    const client = new RelayClient(RELAY_ID, URL, {
+      apiKey: () => 'daemon-key',
+      daemonId: () => DAEMON_ID,
+      clock,
+      connect: vi.fn(async () => {
+        const t = new FakeTransport()
+        transports.push(t)
+        return t
+      }),
+      log,
+      jitter: () => 0,
+      onRelayMsg
+    } as unknown as RelayClientDeps)
+    const t = await toReady(client, transports)
+    // A relay-minted `rd/msg` whose payload the schema rejects (no `source`, no `payload`).
+    const bad = buildRelayDaemonFrame('rd/msg', { msgId: 'm-1' } as never)
+    t.inject(bad)
+    await flush()
+    expect(onRelayMsg).not.toHaveBeenCalled()
+    expect(t.lastReq('rd/ack')).toBeUndefined()
+    // The relay learns the reason at once: a correlated `error` settles its request instead of
+    // five silent retries.
+    const nak = t.lastReq('error')!
+    expect(nak.corr).toBe(bad.id)
+    expect(nak.payload).toMatchObject({ code: 'BAD_PAYLOAD', retryable: false })
+    expect(String((nak.payload as { message: string }).message)).toContain('source')
+    const line = warn.mock.calls.map((c) => String(c[0])).find((l) => l.includes('undecodable'))
+    expect(line).toContain(`dropping undecodable rd/msg frame ${bad.id}`)
+    expect(line).toMatch(/\(\d+ bytes\)/)
+  })
+})

--- a/packages/relay/src/relay-daemon-connection.ts
+++ b/packages/relay/src/relay-daemon-connection.ts
@@ -113,7 +113,19 @@ export class RelayDaemonConnection {
   async sendMsg(payload: RdMsg): Promise<RdAck> {
     if (this.state !== 'READY') throw new WireError('INTERNAL', `rd link not ready (${this.state})`, true)
     const frame = buildRelayDaemonFrame('rd/msg', payload)
-    const rep = await this.correlator.request(frame, (e) => this.transport.send(e))
+    let bytes = 0
+    let rep: RelayDaemonFrame
+    try {
+      rep = await this.correlator.request(frame, (e) => {
+        bytes = Buffer.byteLength(e)
+        this.transport.send(e)
+      })
+    } catch (err) {
+      // The daemon drops an undecodable or oversized frame without a reply, so the size is the one
+      // fact the sender can add to a timeout.
+      if (err instanceof WireError) throw new WireError(err.code, `${err.message} (${bytes} bytes)`, err.retryable)
+      throw err
+    }
     if (rep.type !== 'rd/ack') throw new WireError('INTERNAL', `expected rd/ack, got ${rep.type}`, false)
     return rep.payload
   }


### PR DESCRIPTION
## Why

A Linear follow-up (`prompted`) delivered through the relay never reached a turn: the relay forwarded it, got no `rd/ack` in 5 tries × 5 s, and dropped it — while the daemon, even at debug level, logged nothing at all. Hook and Slack forwards over the same links worked, and the same daemon served a `created` delivery seconds earlier, so the link was fine and the frame itself was what the daemon refused. The one path that can drop an inbound relay request in complete silence is a frame that fails to decode: the daemon returned without a log line and without a reply.

## What

- **Daemon** (`cp/relay-client.ts`): an undecodable inbound frame is logged at warn with its type, id, byte size and the schema reason, and the daemon answers the relay with a correlated `error` (`BAD_PAYLOAD` / `FRAME_TOO_LARGE` / `UNKNOWN_FRAME`, not retryable) so the relay's forward fails immediately with that reason instead of timing out. Every decoded relay frame is traced at debug (type, id, bytes).
- **Relay** (`relay-daemon-connection.ts`): the `sendMsg` timeout error carries the frame size, for the case where nothing comes back at all.
- **Daemon** (`daemon.ts`): the gated-conversation drop on the relay path now names the platform and channel it refused.
- Design doc §10.1 records the behaviour next to the slow-ack watchdog.

## Tests

- `test/cp/relay-client.test.ts`: an `rd/msg` whose payload fails the schema produces no dispatch, no `rd/ack`, a correlated `error` naming the missing field, and the warn line with size.
- Relay connection and ingress suites unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
