### PR TITLE
fix(relay): name a Linear follow-up's install from the team seat, not an empty id

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -719,7 +719,12 @@ that grant compiles to the owner's channel-scoped route, and the relay's
 thread-affinity gate honours a gated agent while that route exists. An
 `ownerAsDefault` platform emits no such route, so the gate reads the same
 fact from where it now lives: a gated agent's binding is honoured while that
-agent is the channel's `conversationDefaults` entry. **Moving a team's
+agent is the channel's `conversationDefaults` entry. The seat also names the
+binding's install: the CP's `rc/assign` echo carries no `integrationId`, and
+where Slack backfills it from the owner's route, this platform has none — the
+continuity rung reads it from the `conversationDefaults` entry instead, or the
+follow-up would reach the daemon with an empty install id and be refused as an
+invalid delivery. **Moving a team's
 default away from a gated agent therefore withdraws its grant**, and its
 bound sessions become **stoppable but not continuable**: a `prompted`
 follow-up whose affinity is rejected on grant grounds is **refused, not

--- a/packages/activation-policy/src/index.ts
+++ b/packages/activation-policy/src/index.ts
@@ -640,8 +640,12 @@ export function arbitrateSharedBotResult(
   const contGateOk = directControlOk && contGrantOk
   if (cont && contGateOk && a.members.some((m) => m.daemonId === cont.daemonId && m.agentIds.includes(cont.agentId))) {
     if (cont.integrationId) return hit(cont)
+    // A CP-projected affinity names no install. Slack backfills from the agent's route; an
+    // `ownerAsDefault` platform has no route for its owner, so the seat itself names it — an
+    // empty id would reach the daemon as an invalid delivery and be dropped unanswered.
     const route = a.routes.find((r) => r.agentId === cont.agentId)
     if (route) return hit({ ...cont, integrationId: route.integrationId })
+    if (channelDefault?.agentId === cont.agentId) return hit({ ...cont, integrationId: channelDefault.integrationId })
     return hit(cont)
   }
 

--- a/packages/relay/src/bot-arbitration.test.ts
+++ b/packages/relay/src/bot-arbitration.test.ts
@@ -627,6 +627,19 @@ describe('Linear team-as-channel arbitration (the per-conversation default rung)
       })
     })
 
+    it("backfills a CP-projected binding's install from the seat, since the owner has no route", () => {
+      // `rc/assign` carries no integrationId, so the relay installs the echo of its own report
+      // with an empty one. Slack backfills from the agent's route; the owner here has none, and
+      // an empty id would reach the daemon as an invalid delivery, dropped without an answer.
+      const router = new BotArbitrationRouter()
+      router.upsert(gatedOwner())
+      router.setAffinity('bot-1', `${TEAM_A}/agent-session-1`, { agentId: ALICE, daemonId: D1, integrationId: '' })
+      expect(router.routeResult('bot-1', delegation('a follow-up'))).toEqual({
+        kind: 'target',
+        target: { agentId: ALICE, daemonId: D1, integrationId: 'iA' }
+      })
+    })
+
     it('REFUSES a follow-up once the default moves off it — never falling to the new default', () => {
       // A Linear AgentSession has one writer (§4.6): letting BOB answer inside a session ALICE's
       // runtime still holds would put two daemons on one feed.


### PR DESCRIPTION
## Why

Every Linear `prompted` follow-up delivered through the relay was dropped: the relay reported "no ack after 5 tries", and with #1733's diagnostics the daemon now says why — the forwarded `rd/msg` carried `integrationId: ''`, which fails the wire schema's uuid check.

The chain: the relay routes the session's first delivery (`created`), reports the thread binding to the CP, and the CP echoes it back to every relay as `rc/assign` — a frame that carries no `integrationId`, so the relay installs the affinity with an empty one. On the follow-up, the continuity rung backfills the install from the bound agent's route. Slack owners always have a route; a Linear owner never does (`ownerAsDefault` compiles the owner into `conversationDefaults`, not into a route), so the empty id survived into the forward. `created` deliveries were unaffected because they route through the default rung, which names the install.

## What

`packages/activation-policy/src/index.ts`: when the bound agent has no route and is the channel's `conversationDefaults` seat, the continuity rung takes the install from that seat. Nothing else in the ladder changes.

Design doc §6.2 records the rule.

## Tests

`bot-arbitration.test.ts`: a CP-projected binding with an empty install for the team's gated owner now routes with the seat's install; the existing refusal and unrestricted-owner cases are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
