### PR TITLE
docs: list Linear among the platforms in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   <a href="https://www.larksuite.com"><img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/lark.svg" width="16" height="16" alt="Lark and Feishu" title="Lark / Feishu" /></a>&nbsp;&nbsp;
   <a href="https://github.com"><img src="https://cdn.simpleicons.org/github/181717/e6edf3" width="16" height="16" alt="GitHub" title="GitHub" /></a>&nbsp;&nbsp;
   <a href="https://gitlab.com"><img src="https://api.iconify.design/logos/gitlab-icon.svg" width="16" height="16" alt="GitLab" title="GitLab" /></a>&nbsp;&nbsp;
+  <a href="https://linear.app"><img src="https://cdn.simpleicons.org/linear" width="16" height="16" alt="Linear" title="Linear" /></a>&nbsp;&nbsp;
   <a href="https://en.wikipedia.org/wiki/Webhook"><img src="https://api.iconify.design/logos/webhooks.svg" width="16" height="16" alt="Webhook" title="Webhook" /></a>
   &nbsp;&nbsp;&nbsp;&nbsp;
   <strong>WITH</strong>&nbsp;&nbsp;
@@ -55,9 +56,9 @@
 </p>
 
 AgentConnect is an open-source platform where teams and multiple AI agents work
-together across Slack, Telegram, Discord, Lark, GitHub, and GitLab. Bring Claude
-Code, Codex, Grok Build, DeepSeek, Pi, or any ACP-compatible agent into the
-conversations and workflows your team already has open.
+together across Slack, Telegram, Discord, Lark, GitHub, GitLab, and Linear.
+Bring Claude Code, Codex, Grok Build, DeepSeek, Pi, or any ACP-compatible agent
+into the conversations and workflows your team already has open.
 
 Give each agent a role, then let people and agents collaborate in shared
 conversations. Agents can call one another and remember what they learn, and
@@ -112,7 +113,8 @@ Teams use it to:
   other ACP-compatible runtime run side by side, and changing one does not
   rebuild the workflow around it.
 - **Keep work where it happens.** Link agents to bots in Slack, Telegram,
-  Discord, and Lark, or to repositories and workflows on GitHub and GitLab.
+  Discord, and Lark, or to repositories, issues, and workflows on GitHub,
+  GitLab, and Linear.
 - **Choose the right agent for every job.** Configure each agent's runtime,
   model, workspace, tools, and machine independently.
 - **Carry context forward.** Give each agent its own memory and skills, and


### PR DESCRIPTION
Linear ingress ships, but the README still stopped at GitLab, so a reader
counting the platforms we bridge came up one short.

## What changed

- The `FROM` icon row gains Linear, placed after GitLab and before the generic
  webhook, linking to `linear.app`.
- The two prose lists that enumerate platforms name it as well: the opening
  paragraph, and the "Keep work where it happens" bullet, which now reads
  "repositories, issues, and workflows on GitHub, GitLab, and Linear".

## Notes for a reviewer

- The icon comes from `cdn.simpleicons.org/linear`, the same CDN family the
  Telegram, Discord and GitHub marks already use. It serves the Linear brand
  color `#5E6AD2`, which stays legible on both the light and dark README
  backgrounds, so no per-theme color override was needed.
- Both prose paragraphs were re-wrapped to keep the existing line width, which
  is why the diff touches three lines instead of one in each.
- The "Ask ChatGPT / Claude / Perplexity / Google AI" badges further down carry
  their own URL-encoded platform list, which already omitted Lark. Left alone
  here rather than widening a README typo fix into those encoded strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
