### PR TITLE
fix(daemon): stop a lost start gate from failing a finished skill helper

### DIFF
--- a/packages/daemon/src/skills/skill-workspace-mutator.ts
+++ b/packages/daemon/src/skills/skill-workspace-mutator.ts
@@ -204,10 +204,8 @@ async function runConfinedHelper(
     }
     child.stdout.on('data', (chunk: Buffer) => collect(stdout, chunk))
     child.stderr.on('data', (chunk: Buffer) => collect(stderr, chunk))
-    child.stdin.on('error', (error) => {
-      failure ??= error
-      killHelper()
-    })
+    // stdin only carries the start gate, which an ungated helper can outrun; close() kills whatever survives.
+    child.stdin.on('error', () => {})
     child.once('error', (error) => {
       failure ??= error
       killHelper()

--- a/packages/daemon/test/skill-workspace-mutator.test.ts
+++ b/packages/daemon/test/skill-workspace-mutator.test.ts
@@ -1,8 +1,16 @@
-import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { lstat, mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
-import { canonicalSkillMutationRoot } from '../src/skills/skill-workspace-mutator.js'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { canonicalSkillMutationRoot, runSkillWorkspaceMutation } from '../src/skills/skill-workspace-mutator.js'
+import { withSkillMutationHelperLease } from '../src/skills/skill-workspace-lock-lease.js'
+
+// The start gate only exists inside the sandbox wrapper; pin the ungated launch so every host runs the race.
+vi.mock('../src/skills/offline-sandbox.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/skills/offline-sandbox.js')>()),
+  probeOfflineSandboxHost: () => ({ available: false, reason: 'pinned off for this test' })
+}))
 
 const roots: string[] = []
 
@@ -12,6 +20,11 @@ async function workspace(): Promise<{ root: string; cwd: string }> {
   const cwd = join(root, 'workspace')
   await mkdir(cwd)
   return { root, cwd }
+}
+
+// Starve the event loop the way a loaded CI worker does: no stream teardown can run while we sleep.
+function blockEventLoop(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
 }
 
 afterEach(async () => {
@@ -46,4 +59,37 @@ describe('canonicalSkillMutationRoot', () => {
       /alias resolves outside workspace/
     )
   })
+})
+
+describe('runSkillWorkspaceMutation', () => {
+  // The race is POSIX pipe semantics: only there does writing to a dead reader raise on the parent.
+  it.skipIf(process.platform === 'win32')(
+    'keeps the result of an ungated helper that exited before its start gate was written',
+    async () => {
+      const { cwd } = await workspace()
+      const canonical = await realpath(cwd)
+      const stat = await lstat(canonical, { bigint: true })
+      const operationId = randomUUID()
+      // Hold the gate past the helper's own exit, so writing it can only ever break the pipe.
+      const lease = {
+        registerHelper: async () => blockEventLoop(2_000),
+        clearHelper: async () => {}
+      }
+
+      const result = await withSkillMutationHelperLease(lease, () =>
+        runSkillWorkspaceMutation({
+          action: 'reserve',
+          cwd: canonical,
+          workspaceIdentity: { dev: stat.dev.toString(), ino: stat.ino.toString() },
+          relativeRoot: '.claude/skills/audit',
+          operationId,
+          reservationName: `.agentconnect-skill-new-${operationId}`,
+          quarantineName: `.agentconnect-skill-old-${operationId}`
+        })
+      )
+
+      expect(result.identity).toMatchObject({ dev: expect.any(String), ino: expect.any(String) })
+      await expect(lstat(join(canonical, '.claude/skills/audit'))).resolves.toBeTruthy()
+    }
+  )
 })

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -15,6 +15,7 @@ export const MOCKING_TESTS = [
   'test/slack-upload-file.test.ts',
   'test/daemon-cp-onboarding.test.ts',
   'test/runtime-install-repair-collapse.test.ts',
+  'test/skill-workspace-mutator.test.ts',
   'test/telegram-connection.test.ts',
   'test/workspace-git.test.ts',
   'test/workspace.test.ts'


### PR DESCRIPTION
`Unit Test` went red on `main` with one failure out of 5625, and passed on re-run:

```
FAIL daemon test/shim-skill-handler.test.ts > cluster skill shim staging >
     uses the durable receipt to remove an owned root after pod-local state is lost
SkillLedgerSafetyError: confined skill workspace mutation was refused
Caused by: Error: write EPIPE  (src/skills/skill-workspace-mutator.ts:219)
```

## Why

`runConfinedHelper` hands the mutation helper a `GO` byte on stdin, but only
after `registerHelper` durably records its process group. That gate is real
only inside the sandbox wrapper. When the host has no sandbox the helper is
launched directly, never reads stdin, and starts work the moment it is spawned
— and this runner has none (`sandbox: unavailable — ripgrep (rg) not found,
bubblewrap (bwrap) not installed, socat not installed`).

`registerHelper` meanwhile runs a SQLite immediate transaction that sleeps 50 ms
per busy retry. Add the event-loop lag of four workers running 5600 cases and
the parent can get back to the write long after a helper that only had to
unlink one directory has exited. The write then lands on a closed pipe, and the
EPIPE was recorded as the run's failure — so a mutation that exited 0 with a
valid receipt was reported as refused.

Nothing about it is test-only: the same race refuses a real skill install on a
busy daemon whenever the sandbox is unavailable.

## Fix

The helper's own exit status and output are the verdict, so a failed gate write
is not itself a failure. A gated wrapper that never got its byte still exits
non-zero or hands back no receipt, and the `close` handler already kills
whatever survives.

Killing from the stdin error handler turned out to be wrong twice over —
signalling an already-exited process group answers `EPERM`, which `killHelper`
then recorded as the failure instead. The first draft of this fix, which
ignored the EPIPE but kept the kill, failed the new test on exactly that.

## Test

`skill-workspace-mutator.test.ts` reproduces the race deterministically: a lease
whose `registerHelper` blocks the event loop for 2 s, so the real helper
finishes and exits before the gate is written and no stream teardown can run in
between. It fails with the exact `write EPIPE` above on the unfixed source and
passes with it. The case is POSIX-only (`skipIf` win32), and the file joins
`MOCKING_TESTS` because it pins the sandbox probe off so every host takes the
ungated path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
