### PR TITLE
fix(daemon): a runtime title that is only the prompt read back is not a title

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13359,6 +13359,15 @@ export class Daemon {
       (isStandingContextTitleEcho(update.title) || isPromptEchoTitle(update.title, p?.promptEchoPrefix ?? ''))
     )
       return
+    // Clamp a surviving runtime title ONCE, here, to the one-line 80-character shape every
+    // other title source produces — like the secret mask above, so the persisted row, Slack,
+    // the live webchat stream, and the recorder cannot disagree. A whitespace-only push sets
+    // nothing anywhere. Must follow the echo test, which reads the unclamped title.
+    if (update?.sessionUpdate === 'session_info_update' && typeof update.title === 'string') {
+      const clamped = clampRuntimeTitle(update.title)
+      if (clamped === undefined) return
+      update = { ...update, title: clamped }
+    }
     const isEarlyMetadata =
       update?.sessionUpdate === 'usage_update' ||
       (update?.sessionUpdate === 'session_info_update' && update.title !== undefined)
@@ -13405,13 +13414,10 @@ export class Daemon {
       const rec = p ? await this.store.getSession(p.plan.sessionKey) : detachedRec
       // The callback is agent-bound, but ACP session ids are runtime-controlled. Match
       // both before touching another logical session if two adapters reuse an id.
-      // Clamped to the one-line, 80-character shape every other title source produces, so no
-      // runtime can persist a multi-paragraph title; a whitespace-only push sets nothing.
-      const title = typeof update.title === 'string' ? clampRuntimeTitle(update.title) : null
-      if (rec?.agentId === agentId && rec.acpSessionId === sessionId && title !== undefined) {
-        await this.persistSessionTitle(rec, title)
-        // Runtime title, never the console's first-message fallback.
-        const slackTitle = title ?? ''
+      if (rec?.agentId === agentId && rec.acpSessionId === sessionId) {
+        await this.persistSessionTitle(rec, update.title)
+        // The clamped runtime title — never the console's first-message fallback.
+        const slackTitle = typeof update.title === 'string' ? update.title : ''
         if (p && turnChromeFor(p.plan.platform).sessionTitle && slackTitle) {
           this.enqueueApply(p, { kind: 'set-title', text: slackTitle })
         } else if (!p && slackTitle) {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -36,6 +36,7 @@ import {
   slackTsForWallClock,
   quotedSourceBlock
 } from './session/session-manager.js'
+import { clampRuntimeTitle, isPromptEchoTitle, promptEchoPrefix } from './session/derive-title.js'
 import {
   ThreadContextCoordinator,
   contextUpdateText,
@@ -11225,6 +11226,11 @@ export class Daemon {
     while (true) {
       if (p.plan.stageAnswer) this.discardStagedAttempt(p)
 
+      // Fingerprint what this attempt sends, so a runtime fallback title that merely joins
+      // these blocks is recognized as an echo when it streams back (onAcpUpdate).
+      p.promptEchoPrefix = promptEchoPrefix(
+        promptBlocks.flatMap((b) => (b.type === 'text' && typeof b.text === 'string' ? [b.text] : []))
+      )
       // Start-fence linearization: no await occurs between queue coalescing above
       // (or the prior regeneration decision) and initiating this ACP request.
       const promptPromise = host.prompt(sessionId, promptBlocks)
@@ -13342,15 +13348,15 @@ export class Daemon {
     })
     if (p?.outputSuppressed) return
     // codex-acp >= 1.1.3 auto-titles an untitled session from its raw prompt text
-    // (all first-prompt text blocks joined, unbounded). For runtimes that carry the
-    // standing context inline as the first prompt block, that "title" is an echo of
-    // internal agent/memory context — drop the whole update before it is buffered,
-    // persisted, streamed to webchat, or recorded (issue #659). Real titles (a user
-    // rename, a semantic runtime summary) do not start with the agent-meta block.
+    // (all first-prompt text blocks joined, unbounded). Whatever that prompt led with, the
+    // "title" is an echo of what we just sent — internal agent/memory context on a session
+    // that inlined standing context, the caller's whole message on one that did not (a turn
+    // after `session/load`). Drop it before it is buffered, persisted, streamed to webchat,
+    // or recorded (issue #659). Real titles do not begin with the prompt we sent.
     if (
       update?.sessionUpdate === 'session_info_update' &&
       typeof update.title === 'string' &&
-      isStandingContextTitleEcho(update.title)
+      (isStandingContextTitleEcho(update.title) || isPromptEchoTitle(update.title, p?.promptEchoPrefix ?? ''))
     )
       return
     const isEarlyMetadata =
@@ -13399,10 +13405,13 @@ export class Daemon {
       const rec = p ? await this.store.getSession(p.plan.sessionKey) : detachedRec
       // The callback is agent-bound, but ACP session ids are runtime-controlled. Match
       // both before touching another logical session if two adapters reuse an id.
-      if (rec?.agentId === agentId && rec.acpSessionId === sessionId) {
-        await this.persistSessionTitle(rec, update.title)
-        // Runtime title verbatim (trimmed) — never the console's first-message fallback.
-        const slackTitle = typeof update.title === 'string' ? update.title.trim() : ''
+      // Clamped to the one-line, 80-character shape every other title source produces, so no
+      // runtime can persist a multi-paragraph title; a whitespace-only push sets nothing.
+      const title = typeof update.title === 'string' ? clampRuntimeTitle(update.title) : null
+      if (rec?.agentId === agentId && rec.acpSessionId === sessionId && title !== undefined) {
+        await this.persistSessionTitle(rec, title)
+        // Runtime title, never the console's first-message fallback.
+        const slackTitle = title ?? ''
         if (p && turnChromeFor(p.plan.platform).sessionTitle && slackTitle) {
           this.enqueueApply(p, { kind: 'set-title', text: slackTitle })
         } else if (!p && slackTitle) {

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -554,6 +554,9 @@ export interface Pending {
    *  session metadata, but housekeeping must not appear in platform/webchat output
    *  or the persisted user-visible activity log. */
   hiddenSessionTitleToolCallIds: Set<string>
+  /** Bounded fingerprint of the prompt text this turn sent, for recognizing a runtime
+   *  fallback title that is only that prompt read back (session/derive-title.ts). */
+  promptEchoPrefix?: string
   /** The live ACP session id for this turn (part of the `this.pending` map key). */
   acpSessionId: string
   /** The same session's OUTWARD id (session-concept.md §1.1) — what the console knows it by, so

--- a/packages/daemon/src/session/derive-title.ts
+++ b/packages/daemon/src/session/derive-title.ts
@@ -21,3 +21,45 @@ export function deriveTitle(text: string | undefined): string | undefined {
   if (!line) return undefined
   return line.length > TITLE_MAX_CHARS ? line.slice(0, TITLE_MAX_CHARS).trimEnd() + '…' : line
 }
+
+/** How much of a prompt is fingerprinted for the echo test below. Long enough that no real
+ *  title reaches it, short enough that a Pending turn does not retain a second prompt copy. */
+const PROMPT_ECHO_PREFIX_CHARS = 200
+/** Below this the prompt carries too little signal to call a title an echo of it. */
+const MIN_PROMPT_ECHO_CHARS = 40
+
+/** The comparison form both sides of an echo test are reduced to. */
+function collapse(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+/** Bounded fingerprint of the text blocks one turn actually sent, for {@link isPromptEchoTitle}. */
+export function promptEchoPrefix(texts: readonly string[]): string {
+  return collapse(texts.join(' ')).slice(0, PROMPT_ECHO_PREFIX_CHARS)
+}
+
+/**
+ * True when a runtime-pushed title is only this turn's prompt read back. codex-acp auto-titles an
+ * untitled session from its raw prompt text — every text block joined, whitespace collapsed, no
+ * length bound — so a session it re-titles after `session/load` (which carries no leading
+ * standing-context block) surfaces the caller's whole message as the title. Prefix, not equality:
+ * the echo is the WHOLE prompt while the fingerprint is bounded.
+ */
+export function isPromptEchoTitle(title: string, promptPrefix: string): boolean {
+  if (promptPrefix.length < MIN_PROMPT_ECHO_CHARS) return false
+  return collapse(title).startsWith(promptPrefix)
+}
+
+/** A runtime-pushed title reduced to the one-line, {@link TITLE_MAX_CHARS} shape every other title
+ *  source already produces; `undefined` when the push carries no title text at all. */
+export function clampRuntimeTitle(title: string): string | undefined {
+  const line = collapse(title)
+  if (!line) return undefined
+  const chars = [...line]
+  return chars.length > TITLE_MAX_CHARS
+    ? `${chars
+        .slice(0, TITLE_MAX_CHARS - 1)
+        .join('')
+        .trimEnd()}…`
+    : line
+}

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -893,6 +893,133 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     await daemon.stop()
   })
 
+  it('never persists a runtime title that is only this turn\u2019s prompt echoed back', async () => {
+    // A codex-shaped runtime auto-titles an untitled session by joining its prompt blocks.
+    // On a created session that join starts with the inlined standing context and is dropped
+    // as an agent-meta echo; on the NEXT turn nothing prepends standing context, so the join
+    // is the caller's whole message and used to be persisted verbatim as the title.
+    const root = scaffold()
+    let onUpdate!: (sid: string, update: unknown) => Promise<void> | void
+    const echoedTitles: string[] = []
+    const fakeHost = {
+      __started: true,
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-prompt-echo'),
+      hasSession: (id: string) => id === 'acp-prompt-echo',
+      prompt: vi.fn(async (sid: string, blocks: { type: string; text?: string }[]) => {
+        const title = blocks
+          .filter((b) => b.type === 'text' && typeof b.text === 'string')
+          .map((b) => b.text as string)
+          .join(' ')
+          .replace(/\s+/g, ' ')
+          .trim()
+        echoedTitles.push(title)
+        await onUpdate(sid, { sessionUpdate: 'session_info_update', title })
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(),
+      stop: vi.fn()
+    }
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      hostFactory: (_agent, update) => {
+        onUpdate = update
+        return fakeHost as any
+      }
+    })
+    await daemon.start()
+    vi.spyOn(daemon as any, 'replyConnFor').mockReturnValue({
+      setStatus: vi.fn(async () => {}),
+      setTitle: vi.fn(async () => {}),
+      postMessage: vi.fn(async () => undefined),
+      postContext: vi.fn(async () => {})
+    })
+
+    const deliver = async (ts: string, text: string): Promise<void> => {
+      await (daemon as any).dispatch('bot-a', {
+        msgId: `slack:D1:${ts}`,
+        traceId: `prompt-echo-${ts}`,
+        source: 'user',
+        platform: 'slack',
+        channel: 'D1',
+        thread: '300.1',
+        sender: { id: 'U1', isBot: false },
+        text,
+        mentionedBots: [],
+        isDm: true
+      })
+    }
+    const born = 'Review acme/infra#1729 and report the verdict'
+    await deliver('300.1', born)
+    // The second turn inlines no standing context, so its echo is the bare delivery text.
+    const followUp = 'GitHub pull_request:synchronize pushed a new revision of acme/infra#1729, re-review it'
+    await deliver('300.2', followUp)
+
+    expect(fakeHost.prompt).toHaveBeenCalledTimes(2)
+    expect(echoedTitles[0]).toContain('# Agent')
+    expect(echoedTitles[1]).not.toContain('# Agent')
+    expect(echoedTitles[1]).toContain('pull_request:synchronize')
+    // Both echoes were dropped: the session keeps the title it was born with.
+    expect((await (daemon as any).store.getSessionByAcpId('acp-prompt-echo'))?.title).toBe(born)
+    await daemon.stop()
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('clamps a runtime title to one line of at most 80 characters', async () => {
+    const root = scaffold()
+    let onUpdate!: (sid: string, update: unknown) => Promise<void> | void
+    const sprawling = `Reviewed the PR\n\n${'and considered every changed file '.repeat(8)}`
+    const fakeHost = {
+      __started: true,
+      start: vi.fn(async () => {}),
+      newSession: vi.fn(async () => 'acp-title-clamp'),
+      hasSession: (id: string) => id === 'acp-title-clamp',
+      prompt: vi.fn(async (sid: string) => {
+        await onUpdate(sid, { sessionUpdate: 'session_info_update', title: sprawling })
+        return { stopReason: 'end_turn' }
+      }),
+      cancel: vi.fn(),
+      stop: vi.fn()
+    }
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      hostFactory: (_agent, update) => {
+        onUpdate = update
+        return fakeHost as any
+      }
+    })
+    await daemon.start()
+    vi.spyOn(daemon as any, 'replyConnFor').mockReturnValue({
+      setStatus: vi.fn(async () => {}),
+      setTitle: vi.fn(async () => {}),
+      postMessage: vi.fn(async () => undefined),
+      postContext: vi.fn(async () => {})
+    })
+
+    await (daemon as any).dispatch('bot-a', {
+      msgId: 'slack:D1:301.1',
+      traceId: 'title-clamp',
+      source: 'user',
+      platform: 'slack',
+      channel: 'D1',
+      thread: '301.1',
+      sender: { id: 'U1', isBot: false },
+      text: 'summarize',
+      mentionedBots: [],
+      isDm: true
+    })
+
+    const stored = (await (daemon as any).store.getSessionByAcpId('acp-title-clamp'))?.title as string
+    expect([...stored].length).toBeLessThanOrEqual(80)
+    expect([...stored].length).toBeGreaterThan(60)
+    expect(stored).not.toContain('\n')
+    expect(stored.startsWith('Reviewed the PR and considered')).toBe(true)
+    await daemon.stop()
+    rmSync(root, { recursive: true, force: true })
+  })
+
   it('applies a late runtime title to the UI and the exact Slack DM integration', async () => {
     const root = scaffold()
     let onUpdate!: (sid: string, update: unknown) => void

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -424,6 +424,45 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
     await daemon.stop()
   })
 
+  it('streams the SAME clamped title it persists, so live and reloaded labels agree', async () => {
+    // The runtime title is clamped once at the update entry point, not per sink. Were it
+    // clamped only on the way to the store, a live playground would adopt the raw
+    // multi-line title and then silently change on the next reload.
+    const sprawling = `Roll back the deploy\n\n${'and audit every changed manifest '.repeat(8)}`
+    const { factory } = streamingHost([sessionInfo(sprawling), text('done')])
+    const daemon = new Daemon({ root: scaffold(), hostFactory: factory })
+    await daemon.start()
+    const cp = fakeCpClient()
+    ;(daemon as any).cpClient = cp
+
+    const turnId = '77777777-7777-4777-8777-777777777777'
+    await (daemon as any).dispatch(
+      AGENT_ID,
+      {
+        msgId: `webchat:${CONV}`,
+        traceId: turnId,
+        source: 'user' as const,
+        platform: 'webchat' as const,
+        channel: CONV,
+        sender: { id: 'alice', isBot: false },
+        text: 'go',
+        mentionedBots: [] as string[],
+        isDm: true,
+        trigger: 'dm' as const
+      },
+      undefined,
+      { conversationId: CONV, turnId, sink: cp.sink }
+    )
+
+    const streamed = cp.outputs.find((o) => o.event?.kind === 'session_info')?.event as { title: string }
+    const list = (await (daemon as any).store.listSessions(AGENT_ID)) as { title: string | null }[]
+    expect(streamed.title).toBe(list[0]?.title)
+    expect([...streamed.title].length).toBeLessThanOrEqual(80)
+    expect(streamed.title).not.toContain('\n')
+    expect(streamed.title.startsWith('Roll back the deploy and audit')).toBe(true)
+    await daemon.stop()
+  })
+
   it('streams a session title emitted during session initialization', async () => {
     const { factory } = streamingHost([text('done')], {
       initialUpdates: [sessionInfo('Inspect startup state')]

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local-store.js'
 import { SessionManager, isStandingContextTitleEcho } from '../src/session/session-manager.js'
+import { clampRuntimeTitle, isPromptEchoTitle, promptEchoPrefix } from '../src/session/derive-title.js'
+import { buildHookMessage } from '../src/messages/hook-message.js'
+import type { RdMsgHook } from '@agentconnect.md/protocol'
 import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
 import { createManagedMemoryProvider } from '../src/memory/provider.js'
 import { writeMemoryFile, MEMORY_INDEX, MAX_INDEX_INJECT_BYTES } from '../src/memory/store.js'
@@ -642,6 +645,74 @@ describe('SessionManager', () => {
     expect(isStandingContextTitleEcho('fix the login bug')).toBe(false)
     expect(isStandingContextTitleEcho('Fix session titles')).toBe(false)
     await (await store).close()
+  })
+
+  it('recognizes a codex-acp raw-prompt fallback title on a turn that inlines no standing context', async () => {
+    const store = await newStore()
+    // The reported bug: a GitHub `pull_request:synchronize` delivery landing on an ALREADY-OPEN
+    // session. Only a created session inlines the standing context, so the second turn's first
+    // block is the hook prompt itself — codex-acp's raw-prompt fallback title is then the whole
+    // delivery (subject line, untrusted-content fence, reply hint), which the agent-meta echo
+    // test cannot see. Recognize it against the prompt the daemon actually sent instead.
+    const host = { newSession: vi.fn(async () => 'acp-sync-1') } as any
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    const fire = (deliveryKey: string, action: string): RdMsgHook =>
+      ({
+        source: 'hook',
+        agentId: 'bot-a',
+        sessionKey: 'github:987654321#1729',
+        msgId: `hook-1:${deliveryKey}`,
+        hookId: 'hook-1',
+        deliveryKey,
+        firedAt: new Date().toISOString(),
+        github: { repoId: '987654321', repoFullName: 'acme/infra', subjectKind: 'pull_request', pullNumber: 1729 },
+        context: {
+          source: 'github',
+          event: 'pull_request',
+          action,
+          repo: 'acme/infra',
+          number: 1729,
+          title: 'feat(linear): record the answer in the console transcript',
+          body: 'Base SHA: ' + 'b'.repeat(40) + '\nHead SHA: ' + 'a'.repeat(40),
+          truncated: false
+        }
+      }) as unknown as RdMsgHook
+
+    // Turn 1 (`opened`) creates the session and is born with the ingress title.
+    const opened = await sm.handle('bot-a', buildHookMessage(fire('d-1', 'opened'), 't-open'))
+    expect(opened.created).toBe(true)
+    const key = (await (await store).getSessionByAcpId('acp-sync-1'))!.key
+    expect((await (await store).getSession(key))?.title).toBe(
+      'PR #1729: feat(linear): record the answer in the console transcript'
+    )
+
+    // Turn 2 (`synchronize`) reuses that session, so nothing prepends the standing context.
+    const sync = await sm.handle('bot-a', buildHookMessage(fire('d-2', 'synchronize'), 't-sync'))
+    expect(sync.created).toBe(false)
+    const promptTexts = sync.blocks.filter((b: any) => b.type === 'text').map((b: any) => b.text as string)
+    expect(promptTexts[0]).not.toContain('# Agent')
+    const upstreamFallbackTitle = promptTexts.join(' ').replace(/\s+/g, ' ').trim()
+    expect(upstreamFallbackTitle).toContain('pull_request:synchronize')
+
+    // The old agent-meta test misses it; the prompt-echo test is what catches it.
+    expect(isStandingContextTitleEcho(upstreamFallbackTitle)).toBe(false)
+    expect(isPromptEchoTitle(upstreamFallbackTitle, promptEchoPrefix(promptTexts))).toBe(true)
+    // A real runtime title on the same turn still gets through.
+    expect(isPromptEchoTitle('Review the Linear transcript change', promptEchoPrefix(promptTexts))).toBe(false)
+    await (await store).close()
+  })
+
+  it('bounds a runtime-pushed title to one line of at most 80 characters', async () => {
+    // Every other title source is capped (ingress clamp, first-message fallback, the
+    // setSessionTitle tool). A title should never be a multi-paragraph prompt.
+    const long = `GitHub pull_request:synchronize — acme/infra#1729\n\n${'context '.repeat(40)}`
+    const clamped = clampRuntimeTitle(long)!
+    expect([...clamped].length).toBeLessThanOrEqual(80)
+    expect([...clamped].length).toBeGreaterThan(60)
+    expect(clamped).not.toContain('\n')
+    expect(clamped.endsWith('…')).toBe(true)
+    expect(clampRuntimeTitle('  Fix   session\n titles  ')).toBe('Fix session titles')
+    expect(clampRuntimeTitle('   \n  ')).toBeUndefined()
   })
 
   it('injects session naming guidance for a whitelisted runtime and passes the exact delivery route to MCP setup', async () => {


### PR DESCRIPTION
## The bug

In the console session list, two sessions opened by GitHub `pull_request:synchronize`
deliveries showed their entire prompt as the session title: the event subject line, the
untrusted-content fence, and the trailing reply-hint paragraph, all of it. Sibling
sessions from `pull_request:opened` on the same pull request were titled normally.

## Root cause

A Codex runtime auto-titles an untitled session by joining its raw prompt text, and the
daemon recognized that echo only when the join began with the inlined standing context.
Standing context is inlined only on a turn that creates the session, so which path a
delivery takes decides whether the old filter could see the echo at all:

- **New session**, including one rebuilt after a failed resume. Standing context leads,
  the echo starts with the agent-meta block, and the old filter dropped it.
- **Warm session**, another delivery in the same process. The runtime already holds a
  title and pushes nothing.
- **Resumed session**, after a restart or a host eviction. This is not a create, so
  nothing prepends standing context, while the fresh runtime process sees a session with
  no title and builds one from the next prompt. That prompt is the hook delivery, and the
  old filter had no way to recognize it.

Only the third path is affected, which is why the same event was sometimes titled
correctly. A `review` agent hits it regularly because its sessions are often reclaimed
and resumed.

Two nearby suspects are not involved. The ingress title is never lost, since a GitHub
delivery always mints one and every new logical session is born with it. The
first-message fallback caps at 80 characters and takes only the first line, so it cannot
produce a multi-paragraph title either. The good title was written and then overwritten.

## The fix

Recognize the echo against the prompt the turn actually sent, rather than against a
guess at its shape. Each prompt attempt records a bounded fingerprint of its own text
blocks, and a pushed title that starts with that fingerprint is dropped whatever the
prompt led with. The agent-meta test stays for title updates that arrive with no live
turn, where there is no fingerprint to compare against.

Separately, an accepted runtime title is now clamped to the one-line, 80-character shape
that the ingress title, the first-message fallback, and the `setSessionTitle` tool all
already produce. A title can never again be a multi-paragraph prompt, even on a path
neither filter anticipates.

## Tests

Three regression tests, each verified to fail against pre-fix source:

- A daemon-level test reproducing the bug end to end. It runs two turns on one session
  with a host that echoes its prompt blocks back as a title, and asserts the session
  keeps the title it was born with. Pre-fix it stored the raw delivery text.
- A daemon-level test that a sprawling runtime title is clamped to one line.
- A session-manager test building a real `pull_request:synchronize` hook message,
  pinning that the second turn inlines no standing context and that the agent-meta test
  misses the resulting echo while the prompt-echo test catches it.

Full daemon suite passes apart from the live-provider matrix and the sandbox shim suites,
which fail identically on `main` in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
