### PR TITLE
fix(linear): the plan lives in the session, and the daemon signs a comment

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1088,14 +1088,20 @@ by <actor>` + issue URL, with `sanitizeTitle` flattening.
   message from stored coordinates without the bag, and a cold resume or a
   failed-load recreate must still re-assert the coordinates that the
   transcript, by design, no longer holds. That is what keeps the console's user bubble to the header, the URL
-  and the member's own words. The convention: the issue is the record, so
-  the plan and the outcome go into its description or a comment
-  (`updateIssue` / `createIssueComment`); the branch and the PR carry the
-  identifier so Linear links them; an empty or ambiguous ticket earns a
-  clarifying response before work; `updateIssue` takes `state` by workflow
-  state NAME (`listIssueStatuses`); current state, assignee and labels are
-  `getIssue`'s answer. Mutable issue state is deliberately NOT rendered
-  anywhere: a snapshot goes stale within the session, and standing context
+  and the member's own words. The convention: the plan is already live in the
+  session — the converger pushes the runtime's ACP plan entries onto the
+  AgentSession itself (§5) — so it is never a comment, and
+  `createIssueComment` is for the OUTCOME once work is done, or for the scope
+  the agent had to decide itself on an empty ticket, which is a deliverable
+  rather than a step list; an ambiguous ticket earns a clarifying response
+  before work; the branch and the PR carry the identifier so Linear links
+  them; `updateIssue` takes `state` by workflow state NAME
+  (`listIssueStatuses`); current state, assignee and labels are `getIssue`'s
+  answer. The convention also tells the model NOT to sign a comment: the
+  earlier wording invited both a "here is my plan" comment the feed already
+  rendered and a free-text `— <agent>` signature, and the tool now appends
+  the standard footer itself (§12). Mutable issue state is deliberately NOT
+  rendered anywhere: a snapshot goes stale within the session, and standing context
   is composed once, so the block is built from the bag alone — no
   `issueFacts` read, no deadline, nothing to degrade. Being daemon-authored
   is a claim the block has to earn, so every provider string on it (title,
@@ -1463,8 +1469,9 @@ tile.
     Progress" is one call. Results are bounded (8 000-char description on a
     full read, 300-char snippets in lists, 4 000-char comments, ≤50 rows a
     page) and every read tool's description says the text is data, not
-    instructions. Writes act as the app (§4.3) — the comment tool tells the
-    model to sign if the reader must know which agent wrote it.
+    instructions. Writes act as the app (§4.3), so `createIssueComment`
+    appends the turn's own attribution footer and strips a hand-written
+    signature instead of asking the model to sign (§12).
   - **The conversation report is a name refresh and a new-team backstop, not
     the seeder.** The connection reports the workspace's teams as its
     conversations — one `integration/channels` row per team, `id` = the team
@@ -1703,6 +1710,23 @@ none` skips it along with everything else Linear-visible. There is **no
   is attributed to the deployment app (§4.3), reaches Linear only through the
   session's own connection (a session on another platform is refused at call
   time), and shares the app's hourly budget through the paced queue.
+
+- **A comment's attribution is daemon-authored, like the response footer.**
+  Linear posts every agent's comment as the one deployment app (§4.3), so a
+  reader can only tell the agents apart from the content — and a model asked
+  to name itself will write whatever it likes. `createIssueComment` therefore
+  appends the SAME muted footer the settling `response` activity carries
+  (`linearAttributionFooter`: agent link, runtime · model, session link),
+  built from the turn's own attribution record rather than from any tool
+  argument, and honouring the same per-agent `showFooter` switch — off means
+  no footer here either. The facts reach the tool as a lazy resolver on the
+  session-tool environment (`PlatformSessionToolEnv.attribution`, wired from
+  `daemon.ts` as `sessionToolAttributionFor`), so a tool that publishes
+  nothing pays no lookup and identity stays a daemon fact on a path the model
+  cannot address. A trailing signature line naming the acting agent is
+  stripped from the body first, since agents that had seen the response
+  footer copied it by hand. Descriptions are untouched: an issue's
+  description is the ticket's own text, not the agent's post.
 
 - Signing secret: relay-only, via the `rc/bot-assign` secrets bag — never in
   daemon specs, logs, or DTOs. Client secret: CP-only. Refresh token:

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -54,7 +54,7 @@ import { TerminalOutputFolder } from './session/terminal-output-folder.js'
 import { attachmentMention, sniffImageMimeType } from './session/attachment-block.js'
 import { McpControlServer } from './mcp/control-server.js'
 import { RemoteWebchatGrantManager } from './mcp/remote-webchat-grant.js'
-import type { CodeHostEffectReq, SetSessionTitleReq } from './mcp/ops.js'
+import type { CodeHostEffectReq, SessionContext, SetSessionTitleReq } from './mcp/ops.js'
 import { GitCredentialCache } from './cp/git-credential.js'
 import { GitlabBroker } from './gitlab/broker.js'
 import { gitlabApiBaseUrl } from './gitlab/api-base.js'
@@ -164,6 +164,7 @@ import {
   slackStreamRecipient,
   type SlackTurnState
 } from './platforms/slack/turn-output.js'
+import type { ReplyAttributionInfo } from './messages/attribution.js'
 import { ChannelNameResolver } from './messages/channel-name-resolver.js'
 import { mentionedUserIds, substituteUserMentions } from './slack/mentions.js'
 import {
@@ -2421,6 +2422,9 @@ export class Daemon {
       // A platform's own session tools act through ANY platform's connection — including the one
       // the reply-surface registry above omits (Linear, §4.6).
       sessionToolConnectionFor: (integrationId) => this.anyConnForIntegration(integrationId),
+      // The footer a session tool appends to text it publishes as the agent (Linear comments):
+      // the SAME identity the turn's response carries, resolved from the trusted session context.
+      sessionToolAttributionFor: (ctx) => this.sessionToolAttribution(ctx),
       // History-backed discovery for platforms whose bot API can't enumerate chats/users
       // (Telegram): only the sole current physical bot's scoped history is reachable.
       observedChannels: async (agentId, platform) => {
@@ -4786,6 +4790,25 @@ export class Daemon {
     // Cancellation is latched on the exact active key; absence of an active turn
     // fails closed (the token outlives nothing).
     return active !== undefined && !active.cancelledReason
+  }
+
+  /** The footer identity for a platform session tool that publishes agent-authored text
+   *  (Linear's `createIssueComment`): the same facts the turn's response footer carries, read
+   *  from the trusted session context. Undefined when the agent's footer chrome is off. */
+  private async sessionToolAttribution(ctx: SessionContext): Promise<ReplyAttributionInfo | undefined> {
+    const agent = this.agents.get(ctx.agentId)
+    if (!agent?.output.showFooter) return undefined
+    const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
+    const rec = await this.store?.getSession(key)
+    return {
+      botName: agent.name,
+      botUrl: this.agentLink(ctx.agentId),
+      runtime: this.runtimeFacts.runtimeNames()[agent.runtime] ?? agent.runtime,
+      model: (await this.store?.getObservedModel(key)) ?? 'default',
+      sessionUrl: rec?.sessionId
+        ? this.sessionLink(rec.sessionId, this.sessionLinkSource(ctx.platform, ctx.integrationId))
+        : ''
+    }
   }
 
   private async runDreamExtraction(

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -1,5 +1,6 @@
 import { z, type ZodType } from 'zod'
 import { MEMORY_ACCESS_BLOCKED } from '../memory/tools.js'
+import type { ReplyAttributionInfo } from '../messages/attribution.js'
 import { allAttachmentReadTools, isAttachmentReadTool, sessionToolOwner } from '../platforms/read-ports.js'
 import type { SessionContext, ToolHandler } from './ops/context.js'
 import { listAgents, LIST_AGENTS_ARGS, type DirectoryDeps } from './ops/directory.js'
@@ -168,6 +169,9 @@ export interface OpsDeps
    *  through — ANY platform's, unlike `gatewayFor`, whose reply-surface registry deliberately
    *  omits a platform with no free-text surface (Linear). Absent ⇒ those tools cannot run. */
   sessionToolConnectionFor?: (integrationId: string) => unknown
+  /** This turn's footer identity for a session tool that publishes agent-authored text
+   *  (Linear's `createIssueComment`). Undefined when the agent's footer chrome is off. */
+  sessionToolAttributionFor?: (ctx: SessionContext) => Promise<ReplyAttributionInfo | undefined>
   /** Collaboration Arena §6: resolve + execute an evaluation-registry tool.
    *  Returns undefined when `name` is not an evaluation tool. Visibility and
    *  role-aware authorization live behind this seam (the daemon guarantees
@@ -342,7 +346,11 @@ export async function executeTool(
     if (!deps.sessionToolConnectionFor) throw new Error(`${name} is not wired on this daemon`)
     const conn = ctx.integrationId ? deps.sessionToolConnectionFor(ctx.integrationId) : undefined
     if (!conn) throw new Error(`no live ${owner.label} connection for integration ${ctx.integrationId ?? '(none)'}`)
-    return await owner.sessionTools.execute(name, ctx, args, conn)
+    const attribution = deps.sessionToolAttributionFor
+    return await owner.sessionTools.execute(name, ctx, args, {
+      connection: conn,
+      ...(attribution ? { attribution: () => attribution(ctx) } : {})
+    })
   }
 
   // Past this point are the session-bound read tools — they need the session's message

--- a/packages/daemon/src/platforms/linear/agent-tools.ts
+++ b/packages/daemon/src/platforms/linear/agent-tools.ts
@@ -12,10 +12,13 @@
  */
 import { randomUUID } from 'node:crypto'
 import { z, type ZodType } from 'zod'
+import { appendGithubMarkdownChrome } from '../../github/poster.js'
 import { optionalBoundedInt, optionalNumber, optionalString, parseArgs, requiredString } from '../../mcp/ops/args.js'
 import type { SessionContext } from '../../mcp/ops/context.js'
+import type { ReplyAttributionInfo } from '../../messages/attribution.js'
 import { obj, type ToolDescriptor } from '../../tool-schema/descriptor.js'
-import type { PlatformSessionTools } from '../read-ports.js'
+import type { PlatformSessionTools, PlatformSessionToolEnv } from '../read-ports.js'
+import { linearAttributionFooter, linearAttributionOf } from './turn-output.js'
 
 /** The slice of the connection these tools need: one paced, authenticated GraphQL request. A
  *  create passes `onDuplicateKey` with a client-minted id in its input, so the connection's
@@ -236,8 +239,9 @@ export const LINEAR_TOOLS: ToolDescriptor[] = [
   {
     name: 'createIssueComment',
     description:
-      'Comment on an issue, Markdown; `parent` replies inside a comment thread. The comment is posted as the ' +
-      'AgentConnect app — sign it if the reader should know which agent wrote it.',
+      'Comment on an issue, Markdown; `parent` replies inside a comment thread. Post the OUTCOME of finished ' +
+      'work, never a plan — the session already shows that. Do not sign the comment: your attribution footer ' +
+      'is appended for you.',
     inputSchema: obj({ issue: issueRef, body: str('Comment body, Markdown.'), parent: str('Parent comment id.') }, [
       'issue',
       'body'
@@ -828,11 +832,46 @@ async function updateIssue(client: LinearToolClient, args: Record<string, unknow
   return { updated: Object.keys(input), issue: projectIssue(updated, SNIPPET_MAX) }
 }
 
-async function createIssueComment(client: LinearToolClient, args: Record<string, unknown>) {
+/** What a write tool knows about the acting turn beyond its arguments — daemon facts only. */
+interface LinearToolCall {
+  agentName?: string
+  attribution?: () => Promise<ReplyAttributionInfo | undefined>
+}
+
+/** A trailing dash line naming the acting agent — the signature the model used to be told to
+ *  write, and still reaches for. A single `-` is never matched: that is a list item. */
+const SIGNATURE_LINE = /^\s*[*_]{0,2}\s*(?:\u2014|\u2013|--)\s*(.+?)\s*[*_]{0,2}\s*$/
+
+/** Drop that line so the appended footer is the comment's only attribution. */
+export function stripAgentSignature(body: string, names: readonly (string | undefined)[]): string {
+  const wanted = names.flatMap((n) => (n?.trim() ? [n.trim().toLowerCase()] : []))
+  if (wanted.length === 0) return body
+  const lines = body.split('\n')
+  let last = lines.length - 1
+  while (last >= 0 && lines[last]!.trim() === '') last--
+  const signed = last >= 0 ? SIGNATURE_LINE.exec(lines[last]!) : null
+  if (!signed) return body
+  const claimed = signed[1]!
+    .replace(/\s*\([^()]*\)$/, '')
+    .trim()
+    .toLowerCase()
+  if (!wanted.includes(claimed)) return body
+  return lines.slice(0, last).join('\n').trimEnd()
+}
+
+async function createIssueComment(client: LinearToolClient, args: Record<string, unknown>, call: LinearToolCall) {
   const a = parseArgs(CREATE_ISSUE_COMMENT_ARGS, args)
   const target = await resolveIssue(client, a.issue)
   const id = randomUUID()
-  const input = { id, issueId: target.id, body: a.body, ...(a.parent ? { parentId: a.parent.trim() } : {}) }
+  const info = await call.attribution?.()
+  // Attribution is the DAEMON's line, not the model's: strip whatever it signed with, then append
+  // the same muted footer the turn's `response` activity carries (§5) — every agent posts through
+  // the one deployment app, so identity can live nowhere but the content.
+  const body = appendGithubMarkdownChrome(
+    stripAgentSignature(a.body, [call.agentName, info?.botName]),
+    info ? linearAttributionFooter(linearAttributionOf(info)) : ''
+  )
+  const input = { id, issueId: target.id, body, ...(a.parent ? { parentId: a.parent.trim() } : {}) }
   type Payload = {
     commentCreate?: { success?: boolean; comment?: { id?: string; url?: string; createdAt?: string } | null }
   }
@@ -1127,7 +1166,10 @@ async function updateInitiative(client: LinearToolClient, args: Record<string, u
   return { updated: Object.keys(input), initiative: projectInitiative(updated) }
 }
 
-const TOOLS: Record<string, (client: LinearToolClient, args: Record<string, unknown>) => Promise<unknown>> = {
+const TOOLS: Record<
+  string,
+  (client: LinearToolClient, args: Record<string, unknown>, call: LinearToolCall) => Promise<unknown>
+> = {
   getIssue,
   listIssues,
   listIssueComments,
@@ -1162,12 +1204,15 @@ export const LINEAR_SESSION_TOOLS: PlatformSessionTools = {
   argSchemas: LINEAR_TOOL_ARG_SCHEMAS,
   async execute(
     name: string,
-    _ctx: SessionContext,
+    ctx: SessionContext,
     args: Record<string, unknown>,
-    connection: unknown
+    env: PlatformSessionToolEnv
   ): Promise<unknown> {
     const tool = TOOLS[name]
     if (!tool) throw new Error(`unknown tool: ${name}`)
-    return await tool(asClient(connection), args)
+    return await tool(asClient(env.connection), args, {
+      ...(ctx.agentName ? { agentName: ctx.agentName } : {}),
+      ...(env.attribution ? { attribution: env.attribution } : {})
+    })
   }
 }

--- a/packages/daemon/src/platforms/linear/message-strategy.ts
+++ b/packages/daemon/src/platforms/linear/message-strategy.ts
@@ -179,11 +179,12 @@ function trustedHeader(msg: Pick<NormalizedMessage, 'sender' | 'threadUrl'>, ext
 
 /** The working convention the standing block closes with — the tool names are the model's entry points. */
 const LINEAR_WORKING_CONVENTION =
-  'Working here: the issue is the record — put the plan and the outcome into its description or a comment ' +
-  '(`updateIssue` / `createIssueComment`); name the branch and the PR after the identifier so Linear links ' +
-  'them; if the ticket is empty or ambiguous, ask in your response before working; the team’s workflow ' +
-  'state NAMES are what `updateIssue` takes for `state` (`listIssueStatuses`); read the current state, ' +
-  'assignee and labels with `getIssue` rather than assuming them.'
+  'Working here: your plan is already live in this session, so never post it as a comment — ' +
+  '`createIssueComment` is for the OUTCOME once work is done, or for the scope you had to decide yourself on ' +
+  'an empty ticket, and you never sign it (attribution is appended for you); if the ticket is ambiguous, ask ' +
+  'in your response before working. Name the branch and the PR after the identifier so Linear links them; ' +
+  'the team’s workflow state NAMES are what `updateIssue` takes for `state` (`listIssueStatuses`); read ' +
+  'the current state, assignee and labels with `getIssue` rather than assuming them.'
 
 /** `- Key: value`, or nothing at all — the block omits an absent fact instead of printing a dash. */
 function fact(key: string, value: string): string {

--- a/packages/daemon/src/platforms/read-ports.ts
+++ b/packages/daemon/src/platforms/read-ports.ts
@@ -39,6 +39,7 @@
  */
 import type { ZodType } from 'zod'
 import type { SessionContext } from '../mcp/ops/context.js'
+import type { ReplyAttributionInfo } from '../messages/attribution.js'
 import type { ToolDescriptor } from '../tool-schema/descriptor.js'
 import { LINEAR_SESSION_TOOLS } from './linear/agent-tools.js'
 import { SLACK_ATTACHMENT_TOOL } from './slack/attachments.js'
@@ -74,7 +75,21 @@ export interface PlatformSessionTools {
   readonly descriptors: readonly ToolDescriptor[]
   /** The dispatch-boundary validator per tool name; the parity test holds both sides together. */
   readonly argSchemas: ReadonlyMap<string, ZodType>
-  execute(name: string, ctx: SessionContext, args: Record<string, unknown>, connection: unknown): Promise<unknown>
+  execute(
+    name: string,
+    ctx: SessionContext,
+    args: Record<string, unknown>,
+    env: PlatformSessionToolEnv
+  ): Promise<unknown>
+}
+
+/** What a session tool acts through beyond its own arguments — daemon facts, never model input. */
+export interface PlatformSessionToolEnv {
+  /** The session's own live platform connection (`sessionToolConnectionFor`). */
+  readonly connection: unknown
+  /** This turn's footer identity, for a tool that publishes text the agent must be named on.
+   *  Lazy because most tools never render it; undefined when the agent's footer chrome is off. */
+  readonly attribution?: () => Promise<ReplyAttributionInfo | undefined>
 }
 
 /** One platform's read-port declaration — the pre-connection half of the ask. */

--- a/packages/daemon/test/linear-agent-tools.test.ts
+++ b/packages/daemon/test/linear-agent-tools.test.ts
@@ -4,8 +4,14 @@
  * Driven through a scripted client, so every request the tools make is asserted verbatim.
  */
 import { describe, it, expect } from 'vitest'
-import { LINEAR_SESSION_TOOLS, LINEAR_TOOLS, type LinearToolClient } from '../src/platforms/linear/agent-tools.js'
+import {
+  LINEAR_SESSION_TOOLS,
+  LINEAR_TOOLS,
+  stripAgentSignature,
+  type LinearToolClient
+} from '../src/platforms/linear/agent-tools.js'
 import type { SessionContext } from '../src/mcp/ops/context.js'
+import type { PlatformSessionToolEnv } from '../src/platforms/read-ports.js'
 
 const TEAM_ID = '11111111-1111-4111-8111-111111111111'
 const ISSUE_ID = '22222222-2222-4222-8222-222222222222'
@@ -18,6 +24,7 @@ const ctx: SessionContext = {
   isDm: false,
   channel: 'org-uuid',
   thread: 'session-uuid',
+  agentName: 'atlas',
   tools: []
 }
 
@@ -47,8 +54,24 @@ function client(script: Record<string, unknown | ((vars: Record<string, unknown>
   return { impl, calls }
 }
 
-const run = (name: string, args: Record<string, unknown>, c: LinearToolClient) =>
-  LINEAR_SESSION_TOOLS.execute(name, ctx, args, c)
+const run = (
+  name: string,
+  args: Record<string, unknown>,
+  c: LinearToolClient,
+  env: Omit<PlatformSessionToolEnv, 'connection'> = {}
+) => LINEAR_SESSION_TOOLS.execute(name, ctx, args, { connection: c, ...env })
+
+/** The turn's footer identity, as `sessionToolAttributionFor` resolves it in `daemon.ts`. */
+const attribution = {
+  botName: 'atlas',
+  botUrl: 'https://console.example.test/acme/agents/agent-1',
+  runtime: 'Claude Code',
+  model: 'opus-5',
+  sessionUrl: 'https://console.example.test/acme/sessions/s-1'
+}
+const FOOTER =
+  '\n\nsent by [atlas](https://console.example.test/acme/agents/agent-1) (Claude Code · opus-5) · ' +
+  '[open in session](https://console.example.test/acme/sessions/s-1)'
 
 const issueNode = (over: Record<string, unknown> = {}) => ({
   id: ISSUE_ID,
@@ -464,11 +487,16 @@ describe('updateIssue', () => {
 })
 
 describe('createIssueComment', () => {
-  it('posts on the resolved issue, threading under `parent` when given', async () => {
-    const c = client({
+  const commenting = () =>
+    client({
       IssueRef: { issue: { id: ISSUE_ID, identifier: 'ENG-42', team: { id: TEAM_ID } } },
       CommentCreate: { commentCreate: { success: true, comment: { id: 'c-9', url: 'u9', createdAt: 't9' } } }
     })
+  /** The body as it reached Linear. */
+  const posted = (c: ReturnType<typeof commenting>) => (c.calls.at(-1)!.variables.input as { body: string }).body
+
+  it('posts on the resolved issue, threading under `parent` when given', async () => {
+    const c = commenting()
     const res = await run('createIssueComment', { issue: 'ENG-42', body: 'Done — see PR', parent: 'c-1' }, c.impl)
     expect(c.calls.at(-1)).toEqual({
       op: 'CommentCreate',
@@ -476,6 +504,72 @@ describe('createIssueComment', () => {
       variables: { input: { id: expect.any(String), issueId: ISSUE_ID, body: 'Done — see PR', parentId: 'c-1' } }
     })
     expect(res).toEqual({ posted: true, issue: 'ENG-42', commentId: 'c-9', url: 'u9', createdAt: 't9' })
+  })
+
+  it('appends the turn’s standard footer — once, and only to what the model wrote', async () => {
+    const c = commenting()
+    await run('createIssueComment', { issue: 'ENG-42', body: 'Fixed the retry path.' }, c.impl, {
+      attribution: async () => attribution
+    })
+    expect(posted(c)).toBe(`Fixed the retry path.${FOOTER}`)
+    expect(posted(c).match(/sent by/g)).toHaveLength(1)
+  })
+
+  it('strips the signature the model wrote before appending the footer', async () => {
+    for (const signature of ['— atlas', '-- atlas', '— atlas (Claude Code · opus-5)', '*— atlas*']) {
+      const c = commenting()
+      await run('createIssueComment', { issue: 'ENG-42', body: `Shipped it.\n\n${signature}` }, c.impl, {
+        attribution: async () => attribution
+      })
+      expect(posted(c), signature).toBe(`Shipped it.${FOOTER}`)
+    }
+  })
+
+  it('posts no footer when the agent’s footer chrome is off', async () => {
+    const c = commenting()
+    await run('createIssueComment', { issue: 'ENG-42', body: 'Shipped it.\n\n— atlas' }, c.impl, {
+      attribution: async () => undefined
+    })
+    // The signature still goes: the model was told not to sign, footer or no footer.
+    expect(posted(c)).toBe('Shipped it.')
+  })
+
+  it('posts no footer when the daemon wired no attribution at all', async () => {
+    const c = commenting()
+    await run('createIssueComment', { issue: 'ENG-42', body: 'Shipped it.' }, c.impl)
+    expect(posted(c)).toBe('Shipped it.')
+  })
+
+  it('closes an unterminated code fence before the footer', async () => {
+    const c = commenting()
+    await run('createIssueComment', { issue: 'ENG-42', body: '```\nnot closed' }, c.impl, {
+      attribution: async () => attribution
+    })
+    expect(posted(c)).toBe(`\`\`\`\nnot closed\n\`\`\`${FOOTER}`)
+  })
+
+  it('leaves an issue DESCRIPTION unsigned and unfootered — it is the ticket’s own text', async () => {
+    const c = client({
+      IssueRef: { issue: { id: ISSUE_ID, identifier: 'ENG-42', team: { id: TEAM_ID } } },
+      IssueUpdate: { issueUpdate: { success: true, issue: issueNode() } }
+    })
+    await run('updateIssue', { issue: 'ENG-42', description: 'Scope: the retry path.' }, c.impl, {
+      attribution: async () => attribution
+    })
+    expect((c.calls.at(-1)!.variables.input as { description: string }).description).toBe('Scope: the retry path.')
+  })
+})
+
+describe('stripAgentSignature', () => {
+  it('takes only a dash line naming the acting agent', () => {
+    expect(stripAgentSignature('done\n\n— atlas', ['atlas'])).toBe('done')
+    expect(stripAgentSignature('done\n\n— someone else', ['atlas'])).toBe('done\n\n— someone else')
+    expect(stripAgentSignature('done\n\n— atlas', [undefined])).toBe('done\n\n— atlas')
+  })
+
+  it('never eats a list item or an em-dash sentence in the body', () => {
+    expect(stripAgentSignature('done\n\n- atlas reviewed it', ['atlas'])).toBe('done\n\n- atlas reviewed it')
+    expect(stripAgentSignature('— atlas asked for this\n\ndone', ['atlas'])).toBe('— atlas asked for this\n\ndone')
   })
 })
 

--- a/packages/daemon/test/linear-message-strategy.test.ts
+++ b/packages/daemon/test/linear-message-strategy.test.ts
@@ -209,7 +209,7 @@ describe('§8 daemon-authored standing block', () => {
       `- Issue: TEAM-123 (id ${ISSUE_UUID}) — "Ship the thing" — ${ISSUE_URL}`,
       `- Team: Engineering (key ENG, id ${TEAM})`,
       '',
-      expect.stringContaining('Working here: the issue is the record')
+      expect.stringContaining('Working here: your plan is already live in this session')
     ])
   })
 
@@ -217,6 +217,16 @@ describe('§8 daemon-authored standing block', () => {
     const convention = lines().at(-1) ?? ''
     for (const tool of ['`updateIssue`', '`createIssueComment`', '`listIssueStatuses`', '`getIssue`'])
       expect(convention).toContain(tool)
+  })
+
+  // Two live corrections: agents posted a step-list "plan" comment the session already
+  // renders, and signed their comments by hand because they had seen the response footer.
+  it('sends the plan to the session and the outcome to a comment, and forbids a hand-written signature', () => {
+    const convention = lines().at(-1) ?? ''
+    expect(convention).toContain('never post it as a comment')
+    expect(convention).toContain('OUTCOME')
+    expect(convention).toContain('you never sign it')
+    expect(convention).not.toContain('put the plan')
   })
 
   it('carries no mutable issue state — that is `getIssue`’s answer, not a snapshot', () => {

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -2306,6 +2306,43 @@ describe('executeTool: platform session tools', () => {
       /no live Linear connection for integration int-ln/
     )
   })
+
+  /** A Linear connection that answers the two calls a comment makes, recording the body posted. */
+  const commenting = () => {
+    const seen: { body?: string } = {}
+    const request = vi.fn(async (query: string, variables: Record<string, unknown>) => {
+      if (/IssueRef/.test(query)) return { issue: { id: 'i-1', identifier: 'ENG-1', team: { id: 't-1' } } }
+      seen.body = (variables.input as { body: string }).body
+      return { commentCreate: { success: true, comment: { id: 'c-1' } } }
+    })
+    return { request, seen }
+  }
+
+  it('hands the tool this turn’s footer identity, resolved against the trusted context', async () => {
+    const { request, seen } = commenting()
+    const sessionToolAttributionFor = vi.fn(async () => ({
+      botName: 'agent-one',
+      botUrl: 'https://console.example.test/agents/a1',
+      runtime: 'Claude Code',
+      model: 'opus-5',
+      sessionUrl: 'https://console.example.test/sessions/s1'
+    }))
+    const d = makeDeps({ sessionToolConnectionFor: () => ({ request }), sessionToolAttributionFor })
+    await executeTool(linearCtx, 'createIssueComment', { issue: 'ENG-1', body: 'shipped' }, d)
+    // Resolved from the SESSION context, never from a tool argument.
+    expect(sessionToolAttributionFor).toHaveBeenCalledWith(linearCtx)
+    expect(seen.body).toBe(
+      'shipped\n\nsent by [agent-one](https://console.example.test/agents/a1) (Claude Code · opus-5) · ' +
+        '[open in session](https://console.example.test/sessions/s1)'
+    )
+  })
+
+  it('leaves the comment unfootered when no attribution resolver is wired', async () => {
+    const { request, seen } = commenting()
+    const d = makeDeps({ sessionToolConnectionFor: () => ({ request }) })
+    await executeTool(linearCtx, 'createIssueComment', { issue: 'ENG-1', body: 'shipped' }, d)
+    expect(seen.body).toBe('shipped')
+  })
 })
 
 describe('executeTool: searchPublicMessages', () => {


### PR DESCRIPTION
Two product corrections observed on a live Linear session.

## 1. No "plan" comments

The §8 working convention told the agent that "the issue is the record — put
the plan and the outcome into its description or a comment". Agents obeyed it
literally and posted an `Investigation plan: 1. 2. 3.` comment on the issue
before doing any work — while the AgentSession was already rendering that exact
plan, pushed by the converger from the runtime's ACP plan entries
(`agentSessionUpdate.plan`, §5).

The convention now says the plan is live in the session and is never a comment.
`createIssueComment` is for the OUTCOME once work is done, or for the scope the
agent had to decide itself on an empty ticket — that write-up is a deliverable,
not a step list. An ambiguous ticket still earns a question in the response
before any work (unchanged). The block stays two sentences: it is a budgeted
trusted block paid on every session.

## 2. One standard footer, never a model-written signature

The `createIssueComment` description ended with "sign it if the reader should
know which agent wrote it", so agents appended a free-text `— <name>` line
copied from the response footer they had seen.

Attribution still matters — every agent comments as the workspace's one app
user — but it is the daemon's line, not the model's. `createIssueComment` now
appends the SAME muted footer the `response` activity carries
(`linearAttributionFooter`: agent link, runtime · model, session link), strips
a trailing signature line naming the acting agent first, and tells the model in
both the tool description and the §8 convention not to sign.

### How attribution reaches the tool

`PlatformSessionToolEnv` is a new session-tool environment on the
`read-ports.ts` contract, replacing the bare `connection` argument:

- `connection` — unchanged, from `sessionToolConnectionFor`.
- `attribution?: () => Promise<ReplyAttributionInfo | undefined>` — lazy, so a
  tool that publishes nothing pays no lookup.

`mcp/ops.ts` builds it from a new `OpsDeps.sessionToolAttributionFor`, which
`daemon.ts` wires to `sessionToolAttribution(ctx)`: agent name and console
link, runtime display name, the session's observed model, and the session link
— resolved from the trusted `SessionContext`, never from a tool argument, and
returning `undefined` when the agent's `showFooter` is off. It is the same
record `flushPlatformFinals` hands `linearAttributionOf` for the response
footer.

Descriptions are deliberately untouched: an issue's description is the ticket's
own text, not the agent's post.

## Tests

- `linear-message-strategy.test.ts` — the new convention wording, and that the
  old "put the plan" phrasing is gone.
- `linear-agent-tools.test.ts` — footer appended once; signature stripped
  (`—`, `--`, with a parenthetical, emphasised); no footer when `showFooter` is
  off; no footer when the daemon wired no resolver; an unterminated code fence
  closed before the footer; `updateIssue` descriptions left alone; plus unit
  coverage that `stripAgentSignature` never eats a list item or an em-dash
  sentence.
- `mcp-ops.test.ts` — the resolver is called with the trusted session context
  and its facts reach the posted body; absent resolver ⇒ bare body.

`pnpm --filter @agentconnect.md/daemon typecheck`, the Linear daemon tests, and
lint/format are green. The four failing suites in a full daemon run
(`shim-*`, `acp-matrix`) fail identically on `origin/main` in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
