### PR TITLE
fix(web): size the alternate cloud at two-thirds of the active word

### DIFF
--- a/packages/web/src/components/LarkFeishuSwitcher.tsx
+++ b/packages/web/src/components/LarkFeishuSwitcher.tsx
@@ -35,10 +35,11 @@ export default function LarkFeishuSwitcher({
     variant === 'login'
       ? 'font-sans text-[14px] font-semibold leading-normal text-(--text-primary)'
       : 'font-sans text-[12px] font-semibold leading-normal text-(--text-primary)'
+  // The alternate cloud rides at two-thirds of the active word — present, never competing with it.
   const alternateClassName =
     variant === 'login'
-      ? 'pointer-events-auto cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[12px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
-      : 'cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[10px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
+      ? 'pointer-events-auto cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[9px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
+      : 'cursor-pointer rounded-[2px] border-0 bg-transparent p-0 font-sans text-[8px] font-medium leading-normal text-(--text-tertiary) hover:text-(--brand) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--brand) disabled:cursor-not-allowed disabled:opacity-50'
 
   return (
     <span className="inline-flex items-baseline whitespace-nowrap">
@@ -49,7 +50,7 @@ export default function LarkFeishuSwitcher({
       {/* The slash hugs both words: spaced out, the label reached the install tile's edge. */}
       <span
         aria-hidden="true"
-        className={`mx-[1px] font-sans font-normal leading-normal text-(--text-tertiary) ${variant === 'login' ? 'text-[11px]' : 'text-[10px]'}`}
+        className={`mx-[1px] font-sans font-normal leading-normal text-(--text-tertiary) ${variant === 'login' ? 'text-[9px]' : 'text-[8px]'}`}
       >
         /
       </span>


### PR DESCRIPTION
The install tile's regional label reads "Lark / Feishu", and the second brand is a switch, not a second title. Two earlier passes shrank it by eye and stopped at 10px against a 12px active word, which still reads as a peer rather than an alternative.

## What changed

One ratio instead of hand-tuned numbers: the alternate cloud — and the slash that binds it to the active word — rides at two-thirds of the active size.

| Surface | Active | Alternate | Slash |
| --- | --- | --- | --- |
| Install tile (`platform`) | 12px | 10px → **8px** | 10px → 8px |
| Login button (`login`) | 14px | 12px → **9px** | 11px → 9px |

The `login` variant is included because its 12px-against-14px alternate had drifted furthest from the intended hierarchy; both variants now express the same rule. A one-line comment records the ratio, so the next adjustment moves a rule rather than two independent numbers.

## Notes for review

- Behavior, roles and labels are untouched — the alternate stays a real `button` with its `Switch to …` accessible name, and the slash stays `aria-hidden`.
- Purely presentational, so no test changes; `lint` and `typecheck` pass for the web package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
