### PR TITLE
feat(linear): print a team's key beside its name, and link the name to Linear

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -421,8 +421,9 @@ install.
 name>`, e.g. `Acme / Engineering`: the two NAMES a member says out loud,
     the workspace first because a session list spans every connected
     workspace. The team **key** is an identifier, not a label, so it never
-    leads and never appears here at all; it reaches the agent on the §8
-    context block instead, and reaches an operator through Linear itself. The
+    leads and never appears in this string at all; it reaches the agent on the
+    §8 context block, and an operator through the row's own `key` field
+    (below) — never by being parsed back out of the label. The
     label degrades one name at a time — an unnamed workspace leaves the
     team's own name, an unnamed team falls back to its key and then to its
     bare id. It is the display slot of the `channel` coordinate — one label shared by
@@ -452,6 +453,24 @@ name>`, e.g. `Acme / Engineering`: the two NAMES a member says out loud,
     The console does **not** vendor Linear's icon set: an emoji is rendered as
     itself, and a named icon falls back to the team's initial on the team's own
     color (§9.5).
+  - **A team carries its key and its page, as fields.** `IntegrationChannel.key`
+    / `.url` and `integration_channel.key` / `.url` hold the team's short handle
+    (`ENG`) and `https://linear.app/<workspace urlKey>/team/<KEY>`, on exactly
+    the glyph's terms: display-only, bounded on the wire (`key` ≤ 32 chars,
+    `url` an `https` origin ≤ 512), narrowed at the source through the contract's
+    own `conversationLink`, and on the same tri-state, so the enumerating `teams`
+    pass may clear what a daemon observation may only add. The console prints the
+    key after the team name in muted text and links the NAME to the page (§9.5).
+    They are FIELDS and not a richer label for one reason: the label is one
+    string two hosts write and a third takes apart, so a reader that recovered
+    `ENG` by parsing `Acme / Engineering ENG` would break the first time a team
+    was named after its key. The `url`'s other half is the workspace's own
+    `urlKey`, which neither side stores: the CP asks for it in the same round
+    trip as `teams`, and the daemon in the same round trip as `team`/`teams`,
+    caching it on the connection beside `workspaceName` so the §9.2 fast path
+    can link a team off the event bag alone. A workspace read that named no
+    segment simply leaves the row unlinked — half a link is not a link — and the
+    row still prints its key.
   - **The issue is display metadata, not a coordinate.** `TEAM-123` is a
     human identifier that changes when an issue moves teams, and its
     immutable UUID would be stable but buys nothing, because nothing is ever
@@ -1227,7 +1246,11 @@ tile.
   `color`, the conversation's own display glyph and tint (§4.5). Bounded
   (`icon` ≤ 64 chars, `color` matching `#?[0-9a-fA-F]{6}`) so one oddly spelled
   team cannot cost a whole `integration/channels` report, and absent on every
-  platform without the notion.
+  platform without the notion. It gains `key` and `url` on the same terms — the
+  conversation's short platform handle and the page it opens there (`key` ≤ 32
+  chars, `url` an `https` origin ≤ 512) — with `conversationLink` as
+  `conversationGlyph`'s sibling, so every writer narrows THROUGH the contract
+  rather than restating its bounds.
 - The opaque integration-config payload shape (§7.2) is documented beside its
   peers in `frames/integration.ts`.
 - `frames/cron.ts` — **not** extended in v1 (no cron target).
@@ -1253,13 +1276,16 @@ tile.
     workspace display metadata in `platformConfig`).
   - **The install paths write the team conversation rows**, synchronously
     and before any traffic: the connect tail (§7.1) asks Linear for the
-    workspace's teams with the fresh token (`teams { id key name icon color }`,
-    through the provider's `api.ts`) and creates `(integrationId, teamId)` for
+    workspace's teams with the fresh token (`viewer { organization { urlKey } }`
+    plus `teams { id key name icon color }` in ONE round trip, through the
+    provider's `api.ts`) and creates `(integrationId, teamId)` for
     each, named `<Workspace name> / <Team name>` — the same string the daemon
     writes, since both sides write this one `integration_channel.name`, and
     the workspace half comes from the bot's own stored workspace name — and
-    stamped with the team's own glyph (§4.5), so a seeded row is drawn before
-    any daemon has reported; with the linking agent as owner; each
+    stamped with the team's own glyph, its key and its page (§4.5), so a seeded
+    row is drawn and linked before any daemon has reported; the URL segment is
+    read rather than stored, because only the row it builds outlives the call;
+    with the linking agent as owner; each
     add-member writes its sibling rows, the shared-bot shape where every
     active integration repeats a conversation's state and exactly one row
     per team carries the owner. The trigger is one per team for the whole bot: born `mention` when the
@@ -1354,10 +1380,11 @@ tile.
     conversation row, and a team row is one.
 - Prisma: new `linear_token` and `linear_install_state` tables — Bot identity
   rides the existing D6 columns, and `platform` columns are already text —
-  plus nullable `integration_channel.icon` / `.color` for the team's glyph
-  (§4.5), which every other platform leaves null. The channel DTO exposes both
-  (a Fastify/Zod response schema silently drops what it does not declare, so
-  the pair is declared as well as projected).
+  plus nullable `integration_channel.icon` / `.color` for the team's glyph and
+  `.key` / `.url` for its handle and page (§4.5), which every other platform
+  leaves null. The channel DTO exposes all four (a Fastify/Zod response schema
+  silently drops what it does not declare, so they are declared as well as
+  projected).
 - Tests: provider unit (schema guards, projector shapes incl. keyword
   routes); connect-funnel + OAuth callback + broker integration tests
   against a fake Linear token endpoint; workspace-claim and
@@ -1459,7 +1486,14 @@ tile.
     both reads, narrowed to the wire's bounds at this edge (`linearTeamGlyph`)
     so one over-long icon or oddly spelled color costs its own field and never
     the report, and reaches the conversation row through `observeLinearTeams`
-    and, off the event bag, `noteLinearTeam`'s §9.2 fast path.
+    and, off the event bag, `noteLinearTeam`'s §9.2 fast path. Both reads also
+    carry `viewer { organization { urlKey } }`, and the connection REMEMBERS the
+    answer beside `workspaceName` — the reconcile's `listChannels` fills it, and
+    `linearTeamLink` then builds the team's page from it plus the key, on the
+    read path and on the fast path, which has only the bag. It is never
+    unlearned: a later response that omits it leaves the links already built
+    standing, and a connection that has not learned it yet reports a key with no
+    page rather than a broken one.
   - `turn-output.ts` — the streaming Layer-2 surface + `LinearConverger` +
     `LinearAction` (§5).
   - message strategy — `adapterExt.linear` → prompt assembly and fencing
@@ -1652,11 +1686,31 @@ tile.
     explicit union (pictographic base | regional-indicator pair | keycap
     sequence) for an engine without `v`-mode sequence properties. Direct rows never
     take it — their label is a person, and the `@`/`@@` markers already lead
-    them — and every other platform declares none, so its rows are untouched. Linear's `roomGlyph` is empty, and the
+    them — and every other platform declares none, so its rows are untouched. A
+    seventh, `RowName`, is how the row prints that label: the team's NAME, which
+    OPENS the team in Linear, then its **key** in muted text after it (§4.5).
+    Only the name is the anchor — a key beside a link is an identifier a reader
+    can take, while a key inside one is a second thing to click by accident —
+    and the member renders a fragment into the host's own baseline row, so the
+    key sits on the same 6 px gap a label hint would and both hosts (the agent
+    card's list, the org roster) get it from one place. A row whose workspace
+    URL segment is not known prints the key with a plain name. Linear's
+    `roomGlyph` is empty, and the
     session list reads the same per-platform sigil, so no Linear conversation
     is ever written with a channel's `#`. The org Bots row expands to the same team rows: the
     workspace-shaped "Default dispatch" line it used to show is gone with the
-    flag, and Reconnect / Disconnect stay row actions. Both surfaces drop the
+    flag, and Reconnect / Disconnect stay row actions. That expanded roster's
+    column header is the platform's own noun, pluralised (`roomPlural` beside
+    `roomArticle`), so a Linear workspace heads its rows **Teams** where a Slack
+    bot heads its **Channels** — the header was the last place the host still
+    said "Conversation" over rows the module had already named. Two conventions
+    of the console at large were fixed here for the same reason a mark is
+    per-platform but a CONTROL is not: the per-conversation default-dispatch
+    button now leads with a FIXED glyph (`corner-down-right`, the console's word
+    for a hand-off) and the current default's NAME, the way the trigger leads
+    with a bell. It led with the current agent's avatar, so the control changed
+    shape per agent and could be read as whatever that mark suggested; the
+    avatars stay in the menu, where they identify rows rather than the control. Both surfaces drop the
     per-team dispatch selector while the workspace has a single member — with
     one agent it names that agent and offers nothing to pick. The session list
     needed nothing: it already buckets by the session's channel, which is the

--- a/packages/control-plane/prisma/migrations/20260925000000_integration_channel_key_url/migration.sql
+++ b/packages/control-plane/prisma/migrations/20260925000000_integration_channel_key_url/migration.sql
@@ -1,0 +1,9 @@
+-- A conversation's short platform handle and the page it opens there
+-- (docs/designs/linear-integration.md §4.5): a Linear team has a key ("ENG") and a team URL, and
+-- the console prints the key after the team name and links the name to that page.
+--
+-- Additive and nullable, and carried as their own fields rather than parsed back out of the
+-- stored label. Linear rows are stamped by the connect tail, the credential reconciler's team
+-- pass, and the daemon's next conversation report. No other platform ever writes them.
+ALTER TABLE "integration_channel" ADD COLUMN "key" TEXT;
+ALTER TABLE "integration_channel" ADD COLUMN "url" TEXT;

--- a/packages/control-plane/prisma/schema.prisma
+++ b/packages/control-plane/prisma/schema.prisma
@@ -2460,6 +2460,10 @@ model IntegrationChannel {
   // team's icon (a provider icon name or an emoji) and hex color. Null on every other platform.
   icon          String?
   color         String?
+  // The conversation's short platform handle and the page it opens there — a Linear team's key
+  // and its team URL. Display metadata like the pair above; null on every other platform.
+  key           String?
+  url           String?
   isPrivate     Boolean          @default(false)
   kind          ConversationKind @default(channel)
   // The 1:1 DM counterpart's platform member id (resource-visibility.md §14.8). Control

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -863,6 +863,10 @@ export const IntegrationChannelDto = z.object({
    *  console draws a colored mark from the pair; null on every platform without the notion. */
   icon: z.string().nullable(),
   color: z.string().nullable(),
+  /** The conversation's short platform handle and the page it opens there — a Linear team's
+   *  key, printed after the name, and the team URL the name links to. Null elsewhere. */
+  key: z.string().nullable(),
+  url: z.string().nullable(),
   isPrivate: z.boolean(),
   kind: z.enum(['channel', 'im', 'mpim']),
   trigger: z.enum(['off', 'mention', 'any']),

--- a/packages/control-plane/src/http/routes/integrations.ts
+++ b/packages/control-plane/src/http/routes/integrations.ts
@@ -59,6 +59,8 @@ function toChannelDto(c: IntegrationChannelRecord): IntegrationChannelDtoT {
     space: c.space,
     icon: c.icon,
     color: c.color,
+    key: c.key,
+    url: c.url,
     isPrivate: c.isPrivate,
     kind: c.kind,
     trigger: c.trigger,

--- a/packages/control-plane/src/orchestrator/placement.test.ts
+++ b/packages/control-plane/src/orchestrator/placement.test.ts
@@ -96,6 +96,8 @@ const channel = (
   space: null,
   icon: null,
   color: null,
+  key: null,
+  url: null,
   isPrivate: false,
   kind,
   trigger,

--- a/packages/control-plane/src/persistence/ports.ts
+++ b/packages/control-plane/src/persistence/ports.ts
@@ -4763,6 +4763,10 @@ export interface IntegrationChannelRecord {
    *  Linear team's icon (a provider icon name or an emoji) and hex color. Null elsewhere. */
   icon: string | null
   color: string | null
+  /** The conversation's short platform handle and the page it opens there — a Linear team's
+   *  key and team URL. Display metadata, never a coordinate; null elsewhere. */
+  key: string | null
+  url: string | null
   isPrivate: boolean
   kind: ConversationKind
   /** Repeated across shared-bot sibling rows; per-integration for non-shared bots. */
@@ -4790,6 +4794,10 @@ export interface ReportedChannel {
    *  and clears it. Only a reporter that enumerates the platform's own state may send `null`. */
   icon?: string | null
   color?: string | null
+  /** The conversation's handle and the page it opens on the platform (a Linear team), on the
+   *  same tri-state as the glyph: absent is "unknown", `null` an enumerating "it has none". */
+  key?: string | null
+  url?: string | null
   isPrivate?: boolean
   /** Absent = 'channel' (wire compatibility). */
   kind?: ConversationKind

--- a/packages/control-plane/src/persistence/repositories/integration.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/integration.repo.ts
@@ -716,6 +716,8 @@ function toChannelRecord(c: IntegrationChannel): IntegrationChannelRecord {
     space: c.space,
     icon: c.icon,
     color: c.color,
+    key: c.key,
+    url: c.url,
     isPrivate: c.isPrivate,
     kind: c.kind as ConversationKind,
     trigger: c.trigger as ChannelTrigger,
@@ -780,11 +782,11 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         opts?.defaultTriggerByChannel?.get(c.id) ?? opts?.defaultTrigger ?? (c.kind === 'im' ? 'any' : 'mention')
       await this.db.$executeRaw`
         INSERT INTO "integration_channel"
-          ("integrationId", "channelId", "name", "spaceId", "space", "icon", "color", "isPrivate",
-           "kind", "trigger", "dmUserId", "firstSeenAt", "updatedAt")
+          ("integrationId", "channelId", "name", "spaceId", "space", "icon", "color", "key", "url",
+           "isPrivate", "kind", "trigger", "dmUserId", "firstSeenAt", "updatedAt")
         VALUES (
           ${integrationId}::uuid, ${c.id}, ${c.name ?? null}, ${c.spaceId ?? null}, ${c.space ?? null},
-          ${c.icon ?? null}, ${c.color ?? null},
+          ${c.icon ?? null}, ${c.color ?? null}, ${c.key ?? null}, ${c.url ?? null},
           ${c.isPrivate ?? false}, ${c.kind ?? 'channel'}::"ConversationKind",
           ${createTrigger}::"ChannelTrigger", ${c.dmUserId ?? null}, NOW(), NOW()
         )
@@ -800,6 +802,10 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
                         ELSE "integration_channel"."icon" END,
           "color" = CASE WHEN ${c.color !== undefined}::boolean THEN EXCLUDED."color"
                          ELSE "integration_channel"."color" END,
+          "key" = CASE WHEN ${c.key !== undefined}::boolean THEN EXCLUDED."key"
+                       ELSE "integration_channel"."key" END,
+          "url" = CASE WHEN ${c.url !== undefined}::boolean THEN EXCLUDED."url"
+                       ELSE "integration_channel"."url" END,
           "isPrivate" = CASE WHEN ${setPrivate}::boolean THEN EXCLUDED."isPrivate"
                              ELSE "integration_channel"."isPrivate" END,
           -- Learned once and never unlearned: an omitting report (a channel snapshot, an
@@ -862,6 +868,8 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         space: conversation.space ?? null,
         icon: conversation.icon ?? null,
         color: conversation.color ?? null,
+        key: conversation.key ?? null,
+        url: conversation.url ?? null,
         isPrivate: conversation.isPrivate ?? false,
         kind: conversation.kind ?? 'channel',
         dmUserId: conversation.dmUserId ?? null,
@@ -878,6 +886,8 @@ export class PgIntegrationChannelRepo implements IntegrationChannelRepo {
         // enumerates the platform's own state clears it.
         ...(conversation.icon !== undefined ? { icon: conversation.icon } : {}),
         ...(conversation.color !== undefined ? { color: conversation.color } : {}),
+        ...(conversation.key !== undefined ? { key: conversation.key } : {}),
+        ...(conversation.url !== undefined ? { url: conversation.url } : {}),
         ...(conversation.dmUserId ? { dmUserId: conversation.dmUserId } : {})
       }
     })

--- a/packages/control-plane/src/platforms/discord/provider.test.ts
+++ b/packages/control-plane/src/platforms/discord/provider.test.ts
@@ -85,6 +85,8 @@ const channel = (
   space: null,
   icon: null,
   color: null,
+  key: null,
+  url: null,
   isPrivate: false,
   kind,
   trigger,

--- a/packages/control-plane/src/platforms/feishu/provider.test.ts
+++ b/packages/control-plane/src/platforms/feishu/provider.test.ts
@@ -144,6 +144,8 @@ const channel = (
   space: null,
   icon: null,
   color: null,
+  key: null,
+  url: null,
   isPrivate: false,
   kind,
   trigger,

--- a/packages/control-plane/src/platforms/linear/api.ts
+++ b/packages/control-plane/src/platforms/linear/api.ts
@@ -10,7 +10,7 @@
  * only a rejection may spend the reload-retry, and only a rejection may flip a workspace to
  * "reconnect required".
  */
-import { conversationGlyph } from '@agentconnect.md/protocol'
+import { conversationGlyph, conversationLink } from '@agentconnect.md/protocol'
 import type { FetchLike } from '../../github/api.js'
 import { systemClock, type Clock } from '../../domain/clock.js'
 
@@ -43,16 +43,25 @@ export interface LinearGrant {
   expiresAt: Date
 }
 
+/** Where a Linear workspace lives on the web — the base every team link is built on. */
+const LINEAR_APP_BASE = 'https://linear.app'
+
 /** One team of a connected workspace — the conversation a Linear bot routes on (§4.5).
  *  `icon` is a Linear icon name ("Feather") or an emoji and `color` the team's hex tint;
- *  both are display metadata the console draws, and either may be absent. */
+ *  both are display metadata the console draws, and either may be absent. `url` is the team's
+ *  own page, absent when the workspace read did not name its URL segment. */
 export interface LinearTeam {
   id: string
   key: string
   name: string
   icon?: string
   color?: string
+  url?: string
 }
+
+/** A team's page in Linear — the workspace's URL segment plus the team's key (§4.5). */
+const linearTeamUrl = (urlKey: string | undefined, key: string): string | undefined =>
+  urlKey ? `${LINEAR_APP_BASE}/${encodeURIComponent(urlKey)}/team/${encodeURIComponent(key)}` : undefined
 
 /** The app's own identity inside the workspace that just authorized it. */
 export interface LinearViewer {
@@ -187,6 +196,9 @@ export class LinearApiClient {
    * conversations (§4.5). One page: a workspace past 100 teams keeps the rows it has and the
    * reconciler tick re-asks each pass, so the cap degrades to "the first hundred", never to a
    * failure. Called once per workspace per connect and per tick, never on the message path.
+   *
+   * It asks for the workspace's own URL segment in the same round trip, because that plus the
+   * team's key is the team's page — the link the console gives the row's name (§4.5).
    */
   async teams(accessToken: string): Promise<LinearApiResult<LinearTeam[]>> {
     let res: Response
@@ -196,7 +208,9 @@ export class LinearApiClient {
         withTimeout({
           method: 'POST',
           headers: { authorization: `Bearer ${accessToken}`, 'content-type': 'application/json' },
-          body: JSON.stringify({ query: 'query { teams(first: 100) { nodes { id key name icon color } } }' })
+          body: JSON.stringify({
+            query: 'query { viewer { organization { urlKey } } teams(first: 100) { nodes { id key name icon color } } }'
+          })
         })
       )
     } catch (err) {
@@ -204,7 +218,11 @@ export class LinearApiClient {
     }
     if (!res.ok)
       return { ok: false, error: res.status >= 500 ? 'unreachable' : 'rejected', detail: `http ${res.status}` }
-    const body = (await res.json().catch(() => undefined)) as { data?: { teams?: { nodes?: unknown } } } | undefined
+    const body = (await res.json().catch(() => undefined)) as
+      | { data?: { teams?: { nodes?: unknown }; viewer?: { organization?: { urlKey?: unknown } | null } | null } }
+      | undefined
+    const rawUrlKey = body?.data?.viewer?.organization?.urlKey
+    const urlKey = typeof rawUrlKey === 'string' && rawUrlKey.trim() ? rawUrlKey.trim() : undefined
     const nodes = body?.data?.teams?.nodes
     if (!Array.isArray(nodes)) return { ok: false, error: 'rejected', detail: 'teams query returned no nodes' }
     // A node missing any of the three cannot be keyed or named, so it is dropped rather than
@@ -213,7 +231,15 @@ export class LinearApiClient {
     const teams = nodes.flatMap((node) => {
       const n = node as { id?: unknown; key?: unknown; name?: unknown; icon?: unknown; color?: unknown }
       return typeof n?.id === 'string' && typeof n?.key === 'string' && typeof n?.name === 'string'
-        ? [{ id: n.id, key: n.key, name: n.name, ...conversationGlyph(n.icon, n.color) }]
+        ? [
+            {
+              id: n.id,
+              key: n.key,
+              name: n.name,
+              ...conversationGlyph(n.icon, n.color),
+              ...conversationLink(undefined, linearTeamUrl(urlKey, n.key))
+            }
+          ]
         : []
     })
     return { ok: true, result: teams }

--- a/packages/control-plane/src/platforms/linear/credential-reconciler.test.ts
+++ b/packages/control-plane/src/platforms/linear/credential-reconciler.test.ts
@@ -348,7 +348,14 @@ describe('LinearCredentialReconciler (§10.6)', () => {
 describe('LinearCredentialReconciler — the late-team seed (§15)', () => {
   const ALICE = '44444444-4444-4444-8444-444444444444'
   const BOB = '55555555-5555-4555-8555-555555555555'
-  const TEAM = { id: 'team_ops', key: 'OPS', name: 'Operations', icon: 'Feather', color: '#5E6AD2' }
+  const TEAM = {
+    id: 'team_ops',
+    key: 'OPS',
+    name: 'Operations',
+    icon: 'Feather',
+    color: '#5E6AD2',
+    url: 'https://linear.app/example-workspace/team/OPS'
+  }
 
   interface SeedHarness {
     reconciler: LinearCredentialReconciler
@@ -373,6 +380,8 @@ describe('LinearCredentialReconciler — the late-team seed (§15)', () => {
       name: string | null
       icon: string | null
       color: string | null
+      key: string | null
+      url: string | null
     }[] = [],
     /** What Linear answers for the team — overridden to drop a glyph the row still carries. */
     answer: LinearTeam = TEAM
@@ -437,7 +446,15 @@ describe('LinearCredentialReconciler — the late-team seed (§15)', () => {
 
     expect(h.upsertConversation).toHaveBeenCalledWith(
       'i-alice',
-      { id: TEAM.id, name: 'Acme / Operations', icon: 'Feather', color: '#5E6AD2', kind: 'channel' },
+      {
+        id: TEAM.id,
+        name: 'Acme / Operations',
+        icon: 'Feather',
+        color: '#5E6AD2',
+        key: 'OPS',
+        url: TEAM.url,
+        kind: 'channel'
+      },
       { defaultTrigger: 'mention' }
     )
     expect(h.upsertAgent).not.toHaveBeenCalled()
@@ -478,13 +495,25 @@ describe('LinearCredentialReconciler — the late-team seed (§15)', () => {
     expect(conversation).toMatchObject({ icon: 'Feather', color: '#5E6AD2' })
   })
 
+  it('seeds the row with the team’s key and its page in Linear, which the console links the name to', async () => {
+    const h = seedHarness([{ id: 'i-alice', agentId: ALICE }], [agent(ALICE)], new Set([ALICE]))
+
+    await h.reconciler.tick()
+
+    const [, conversation] = h.upsertConversation.mock.calls[0] as unknown as [string, { key?: string; url?: string }]
+    // The key is carried as its own field — it is never spliced into the label (§4.5).
+    expect(conversation).toMatchObject({ key: 'OPS', url: 'https://linear.app/example-workspace/team/OPS' })
+  })
+
   it('refreshes a KNOWN row whose glyph changed, and writes nothing when name and glyph already match', async () => {
     const row = (icon: string | null, color: string | null) => ({
       integrationId: 'i-alice',
       channelId: TEAM.id,
       name: 'Acme / Operations',
       icon,
-      color
+      color,
+      key: 'OPS',
+      url: TEAM.url
     })
     const stale = seedHarness([{ id: 'i-alice', agentId: ALICE }], [agent(ALICE)], new Set([ALICE]), {}, [
       row(null, null)
@@ -495,6 +524,8 @@ describe('LinearCredentialReconciler — the late-team seed (§15)', () => {
       name: 'Acme / Operations',
       icon: 'Feather',
       color: '#5E6AD2',
+      key: 'OPS',
+      url: TEAM.url,
       kind: 'channel'
     })
 
@@ -511,7 +542,15 @@ describe('LinearCredentialReconciler — the late-team seed (§15)', () => {
     // would leave the row carrying the old value and make this same mismatch true every tick.
     const bare = { id: TEAM.id, key: TEAM.key, name: TEAM.name }
     const rows = [
-      { integrationId: 'i-alice', channelId: TEAM.id, name: 'Acme / Operations', icon: 'Feather', color: '#5E6AD2' }
+      {
+        integrationId: 'i-alice',
+        channelId: TEAM.id,
+        name: 'Acme / Operations',
+        icon: 'Feather',
+        color: '#5E6AD2',
+        key: 'OPS',
+        url: TEAM.url
+      }
     ]
     const h = seedHarness([{ id: 'i-alice', agentId: ALICE }], [agent(ALICE)], new Set([ALICE]), {}, rows, bare)
 
@@ -522,6 +561,10 @@ describe('LinearCredentialReconciler — the late-team seed (§15)', () => {
       name: 'Acme / Operations',
       icon: null,
       color: null,
+      // The same enumerating clear reaches the link: this read named no URL segment for the
+      // workspace, so the team has no page to point at any more.
+      key: 'OPS',
+      url: null,
       kind: 'channel'
     })
 
@@ -531,7 +574,17 @@ describe('LinearCredentialReconciler — the late-team seed (§15)', () => {
       [agent(ALICE)],
       new Set([ALICE]),
       {},
-      [{ integrationId: 'i-alice', channelId: TEAM.id, name: 'Acme / Operations', icon: null, color: null }],
+      [
+        {
+          integrationId: 'i-alice',
+          channelId: TEAM.id,
+          name: 'Acme / Operations',
+          icon: null,
+          color: null,
+          key: 'OPS',
+          url: null
+        }
+      ],
       bare
     )
     await settled.reconciler.tick()

--- a/packages/control-plane/src/platforms/linear/credential-reconciler.ts
+++ b/packages/control-plane/src/platforms/linear/credential-reconciler.ts
@@ -49,7 +49,7 @@ import type {
 import type { LinearTeam } from './api.js'
 import { defaultMemberOf, placedMembers } from '../../orchestrator/placement.js'
 import { linearConnectionIdentity } from './provider.js'
-import { linearTeamChannelName, linearTeamSeedTrigger, seedLinearTeamRows } from './teams.js'
+import { linearTeamChannelName, linearTeamRowLink, linearTeamSeedTrigger, seedLinearTeamRows } from './teams.js'
 import type { LinearTokenService } from './token-service.js'
 
 export interface LinearCredentialReconcilerLog {
@@ -292,9 +292,9 @@ export class LinearCredentialReconciler {
     await this.deps.resync(bot.id)
   }
 
-  /** Display-only refresh, on every sibling row that carries the team — its label and the glyph
-   *  the console draws it with: `upsertConversation` preserves the stored trigger, and a row that
-   *  already matches on all three is not written.
+  /** Display-only refresh, on every sibling row that carries the team — its label, the glyph the
+   *  console draws it with, and the handle and page it links to: `upsertConversation` preserves
+   *  the stored trigger, and a row that already matches on all of them is not written.
    *
    *  AUTHORITATIVE, unlike a daemon observation: `teams` answered, so a team with no icon or color
    *  genuinely has none, and the row is CLEARED rather than left carrying a glyph Linear dropped.
@@ -308,19 +308,30 @@ export class LinearCredentialReconciler {
       name: string | null
       icon: string | null
       color: string | null
+      key: string | null
+      url: string | null
     }[],
     team: LinearTeam,
     workspaceName: string | null
   ): Promise<void> {
     const name = linearTeamChannelName(team, workspaceName)
+    const link = linearTeamRowLink(team)
     for (const row of rows) {
       if (row.channelId !== team.id) continue
-      if (row.name === name && row.icon === (team.icon ?? null) && row.color === (team.color ?? null)) continue
+      if (
+        row.name === name &&
+        row.icon === (team.icon ?? null) &&
+        row.color === (team.color ?? null) &&
+        row.key === link.key &&
+        row.url === link.url
+      )
+        continue
       await seams.channels.upsertConversation(row.integrationId, {
         id: team.id,
         name,
         icon: team.icon ?? null,
         color: team.color ?? null,
+        ...link,
         kind: 'channel'
       })
     }

--- a/packages/control-plane/src/platforms/linear/teams.ts
+++ b/packages/control-plane/src/platforms/linear/teams.ts
@@ -12,6 +12,7 @@
  * member's sibling rows are the shared-bot replication `HttpBot` already performs on the next
  * compile — one trigger per team for the whole bot, never a per-member value.
  */
+import { conversationLink } from '@agentconnect.md/protocol'
 import type { AgentId, IntegrationId } from '../../domain/ids.js'
 import { isGatedAgent } from '../../orchestrator/placement.js'
 import type { AgentRecord, ChannelTrigger, IntegrationChannelRepo } from '../../persistence/ports.js'
@@ -33,6 +34,13 @@ export const linearTeamChannelName = (team: LinearTeam, workspaceName?: string |
   return space ? `${space}${LINEAR_LABEL_SEPARATOR}${flat(team.name)}` : flat(team.name)
 }
 
+/** The team's handle and page as the row stores them (§4.5), narrowed through the wire
+ *  contract's own helper and stated as explicit nulls for `seedLinearTeamRows`' reason. */
+export const linearTeamRowLink = (team: LinearTeam): { key: string | null; url: string | null } => {
+  const link = conversationLink(team.key, team.url)
+  return { key: link.key ?? null, url: link.url ?? null }
+}
+
 /**
  * What a freshly seeded team row's trigger is — the same §14 arm every other conversation seat
  * takes, asked of the members that could own the row: `mention` when any of them is unrestricted,
@@ -45,9 +53,9 @@ export const linearTeamSeedTrigger = (candidates: readonly Pick<AgentRecord, 'vi
 /**
  * Write one row per team on one install — the connect tail's step (§7.1) and the reconciler tick's
  * seed for a team discovered later. Two writes per team when there is an owner, because they carry
- * different halves: `upsertConversation` is the only one that takes the team NAME and its glyph,
- * `upsertAgent` the only one that marks the owner. Ordered so the row is born with its trigger,
- * which the ownership write then preserves.
+ * different halves: `upsertConversation` is the only one that takes the team NAME, its glyph and
+ * its link; `upsertAgent` the only one that marks the owner. Ordered so the row is born with its
+ * trigger, which the ownership write then preserves.
  *
  * `owner` is OPTIONAL, and its absence is a real state rather than a failure: a row whose owner
  * would be a member the route compile cannot route to must be born ownerless instead, because the
@@ -71,6 +79,7 @@ export async function seedLinearTeamRows(
         // that carries no glyph says so — and an existing row that had one is cleared.
         icon: team.icon ?? null,
         color: team.color ?? null,
+        ...linearTeamRowLink(team),
         kind: 'channel'
       },
       { defaultTrigger: opts.trigger }

--- a/packages/control-plane/src/platforms/linear/token-service.test.ts
+++ b/packages/control-plane/src/platforms/linear/token-service.test.ts
@@ -371,4 +371,35 @@ describe('teams — the workspace’s conversations, with the glyph the console 
     })
     expect(linear.calls.at(-1)!.body).toContain('nodes { id key name icon color }')
   })
+
+  it('links each team to its page off the workspace URL segment the same read carries', async () => {
+    const { linear, service } = build()
+    linear.reply(() => ({
+      status: 200,
+      body: {
+        data: {
+          viewer: { organization: { urlKey: 'example-workspace' } },
+          teams: { nodes: [{ id: 't1', key: 'ENG', name: 'Engineering' }] }
+        }
+      }
+    }))
+    expect(await service.teams('tok')).toEqual({
+      ok: true,
+      result: [{ id: 't1', key: 'ENG', name: 'Engineering', url: 'https://linear.app/example-workspace/team/ENG' }]
+    })
+    expect(linear.calls.at(-1)!.body).toContain('viewer { organization { urlKey } }')
+  })
+
+  it('leaves the team unlinked when the workspace read names no URL segment', async () => {
+    // Half a link is not a link: the row keeps its key and prints it, and the name stays plain.
+    const { linear, service } = build()
+    linear.reply(() => ({
+      status: 200,
+      body: { data: { viewer: null, teams: { nodes: [{ id: 't1', key: 'ENG', name: 'Engineering' }] } } }
+    }))
+    expect(await service.teams('tok')).toEqual({
+      ok: true,
+      result: [{ id: 't1', key: 'ENG', name: 'Engineering' }]
+    })
+  })
 })

--- a/packages/control-plane/src/platforms/slack/provider.test.ts
+++ b/packages/control-plane/src/platforms/slack/provider.test.ts
@@ -135,6 +135,8 @@ const channel = (
   space: null,
   icon: null,
   color: null,
+  key: null,
+  url: null,
   isPrivate: false,
   kind,
   trigger,

--- a/packages/control-plane/src/platforms/telegram/provider.test.ts
+++ b/packages/control-plane/src/platforms/telegram/provider.test.ts
@@ -81,6 +81,8 @@ const channel = (
   space: null,
   icon: null,
   color: null,
+  key: null,
+  url: null,
   isPrivate: false,
   kind,
   trigger,

--- a/packages/control-plane/src/ws/handlers/integration-channels.test.ts
+++ b/packages/control-plane/src/ws/handlers/integration-channels.test.ts
@@ -76,6 +76,27 @@ describe('handleIntegrationChannels — isPrivate cross-check', () => {
     expect(dropPublicAudiences).not.toHaveBeenCalled()
   })
 
+  it('hands the row’s own handle and link to the write, so a team row reaches the console linked', async () => {
+    const { deps, replaceSnapshot } = fakeDeps('linear')
+    await handleIntegrationChannels(
+      frame([
+        {
+          id: 'team-1',
+          name: 'Acme / Engineering',
+          key: 'ENG',
+          url: 'https://linear.app/example-workspace/team/ENG'
+        },
+        { id: 'team-2', name: 'Acme / Design' }
+      ]),
+      conn,
+      deps
+    )
+    expect(replaceSnapshot.mock.calls[0]![1]).toEqual([
+      { id: 'team-1', name: 'Acme / Engineering', key: 'ENG', url: 'https://linear.app/example-workspace/team/ENG' },
+      { id: 'team-2', name: 'Acme / Design' }
+    ])
+  })
+
   it('hands the row’s own glyph to the write, so a Linear team reaches the console drawn', async () => {
     const { deps, replaceSnapshot } = fakeDeps('linear')
     await handleIntegrationChannels(

--- a/packages/control-plane/test/integration/integration-channels.test.ts
+++ b/packages/control-plane/test/integration/integration-channels.test.ts
@@ -325,6 +325,8 @@ describe('integration/channels EVT → integration_channel convergence', () => {
         space: null,
         icon: null,
         color: null,
+        key: null,
+        url: null,
         isPrivate: false,
         kind: 'channel',
         trigger: 'mention',
@@ -337,6 +339,8 @@ describe('integration/channels EVT → integration_channel convergence', () => {
         space: null,
         icon: null,
         color: null,
+        key: null,
+        url: null,
         isPrivate: true,
         kind: 'channel',
         trigger: 'mention',
@@ -398,6 +402,31 @@ describe('integration/channels EVT → integration_channel convergence', () => {
     expect(byId.get('team-2')).toMatchObject({ icon: null, color: null })
   })
 
+  it('keeps a reported handle and link, exposes both on the DTO, and never blanks them', async () => {
+    // The team's key and its page in Linear ride the row as their own fields (§4.5) — the
+    // console prints the key after the name and links the name — and are learned once.
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+
+    const linked = {
+      id: 'team-1',
+      name: 'Acme / Engineering',
+      key: 'ENG',
+      url: 'https://linear.app/example-workspace/team/ENG'
+    }
+    await report(DAEMON, id, [linked, { id: 'team-2', name: 'Acme / Design' }], undefined, undefined, false)
+    await report(DAEMON, id, [{ id: 'team-1', name: 'Acme / Engineering' }], undefined, undefined, false)
+
+    const res = await running.app.inject({ method: 'GET', url: `${ORG}/integrations` })
+    const [dto] = res.json() as { channels: { channelId: string; key: string | null; url: string | null }[] }[]
+    const byId = new Map(dto!.channels.map((c) => [c.channelId, c]))
+    expect(byId.get('team-1')).toMatchObject({ key: 'ENG', url: 'https://linear.app/example-workspace/team/ENG' })
+    // A row the platform gives neither reads as two nulls rather than an absent pair.
+    expect(byId.get('team-2')).toMatchObject({ key: null, url: null })
+  })
+
   it('lets an enumerating writer CLEAR a glyph, while an omission still leaves the row drawn', async () => {
     // The tri-state at the repository: absent is "unknown" (a daemon lookup that resolved
     // nothing), `null` is "the platform says it has none" — only the second may blank the row.
@@ -430,9 +459,45 @@ describe('integration/channels EVT → integration_channel convergence', () => {
       name: 'Acme / Eng',
       icon: null,
       color: null,
+      key: null,
+      url: null,
       kind: 'channel'
     })
     expect(await glyphOf()).toEqual({ icon: undefined, color: undefined })
+  })
+
+  it('puts the handle and link on the same tri-state — an omission keeps them, a null clears', async () => {
+    await seedDaemon(prisma, DAEMON)
+    const spy = new SpyControl()
+    running = buildHttpApp(prisma, undefined, undefined, spy as unknown as ControlSender)
+    const id = await install(running)
+    const channels = new PgIntegrationChannelRepo(prisma)
+    const linkOf = async () => {
+      const row = (await channels.listForIntegration(IntegrationId(id))).find((c) => c.channelId === 'team-1')
+      return { key: row?.key ?? undefined, url: row?.url ?? undefined }
+    }
+
+    const url = 'https://linear.app/example-workspace/team/ENG'
+    await channels.upsertConversation(IntegrationId(id), {
+      id: 'team-1',
+      name: 'Acme / Engineering',
+      key: 'ENG',
+      url,
+      kind: 'channel'
+    })
+    expect(await linkOf()).toEqual({ key: 'ENG', url })
+
+    await channels.upsertConversation(IntegrationId(id), { id: 'team-1', name: 'Acme / Eng', kind: 'channel' })
+    expect(await linkOf()).toEqual({ key: 'ENG', url })
+
+    await channels.upsertConversation(IntegrationId(id), {
+      id: 'team-1',
+      name: 'Acme / Eng',
+      key: null,
+      url: null,
+      kind: 'channel'
+    })
+    expect(await linkOf()).toEqual({ key: undefined, url: undefined })
   })
 
   it("a restricted agent's fresh conversations default to OFF, and DM rows survive a membership re-report (§14)", async () => {
@@ -1686,6 +1751,8 @@ describe('PATCH /integrations/:id/channels/:channelId', () => {
       space: null,
       icon: null,
       color: null,
+      key: null,
+      url: null,
       isPrivate: false,
       kind: 'channel',
       trigger: 'any',

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -429,6 +429,7 @@ import {
   linearDeliveryReceiptId,
   linearFailureBody,
   linearTeamGlyph,
+  linearTeamLink,
   readLinearExt,
   LinearStopActionSchema,
   type LinearAdapterExt,
@@ -6830,13 +6831,20 @@ export class Daemon {
     const key = `${integrationId}\u0000${team.id}`
     if (this.linearReportedTeams.has(key)) return
     this.linearReportedTeams.add(key)
-    // The connection carries the workspace name the label leads with; without it the row is
-    // still named, by its team alone, which is what the CP writes for the same team.
-    const name = linearChannelName(team, this.lnConnByIntegration.get(integrationId))
+    // The connection carries the workspace name the label leads with and the URL segment the
+    // team link is built on; without either the row is still named by its team alone.
+    const conn = this.lnConnByIntegration.get(integrationId)
+    const name = linearChannelName(team, conn)
     void this.observedChannelsSync
       .observePlatformChat(
         'linear',
-        { id: team.id, ...(name ? { name } : {}), ...linearTeamGlyph(team), isPrivate: false },
+        {
+          id: team.id,
+          ...(name ? { name } : {}),
+          ...linearTeamGlyph(team),
+          ...linearTeamLink(team, conn),
+          isPrivate: false
+        },
         [integrationId]
       )
       .catch((err: unknown) => {

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -837,6 +837,8 @@ export class ConnectionReconciler {
         ...(team.name ? { name: team.name } : {}),
         ...(team.icon ? { icon: team.icon } : {}),
         ...(team.color ? { color: team.color } : {}),
+        ...(team.key ? { key: team.key } : {}),
+        ...(team.url ? { url: team.url } : {}),
         isPrivate: false
       }))
       await this.host.observePlatformChats(

--- a/packages/daemon/src/platforms/contract.ts
+++ b/packages/daemon/src/platforms/contract.ts
@@ -72,6 +72,9 @@ export interface PlatformChannelInfo {
   /** Display glyph and tint where the platform gives the conversation one (a Linear team). */
   icon?: string
   color?: string
+  /** The conversation's short platform handle and the page it opens there (a Linear team). */
+  key?: string
+  url?: string
 }
 
 /** A conversation in an enumeration (`listChannels` / `listBotChannels`). */
@@ -82,6 +85,9 @@ export interface PlatformChannelRef {
   /** Display glyph and tint where the platform gives the conversation one (a Linear team). */
   icon?: string
   color?: string
+  /** The conversation's short platform handle and the page it opens there (a Linear team). */
+  key?: string
+  url?: string
 }
 
 /** A conversation member — enough to resolve a mention and drop bots. */

--- a/packages/daemon/src/platforms/linear/connection.ts
+++ b/packages/daemon/src/platforms/linear/connection.ts
@@ -21,7 +21,7 @@
  * affordance, and attachment download is deferred.
  */
 import { randomUUID } from 'node:crypto'
-import { linearChannelName, linearTeamGlyph } from './message-strategy.js'
+import { linearChannelName, linearTeamGlyph, linearTeamLink } from './message-strategy.js'
 import type { LinearTeamRef } from './message-strategy.js'
 import type { LinearAttachmentInput, LinearActivityInput } from './turn-output.js'
 import type { IntegrationLinearConfig, LinearCredGrant } from '@agentconnect.md/protocol'
@@ -242,6 +242,10 @@ export class LinearConnection implements PlatformConnection {
   /** Linear exposes no per-workspace permalink base here, so the daemon's deep-link base
    *  falls through to the configured Web App URL — same posture as Feishu. */
   readonly workspaceUrl = ''
+  /** The workspace's own URL segment, learned off the team reads and cached for the life of the
+   *  connection — it is what a team's Linear link is built on (§4.5), and the ingress fast path
+   *  has only the event bag to work from. Absent until the first team read answers. */
+  private urlKey: string | undefined
 
   constructor(private readonly deps: LinearDeps) {
     const { config } = deps.group
@@ -263,6 +267,11 @@ export class LinearConnection implements PlatformConnection {
 
   workspaceId(): string {
     return this.organizationId
+  }
+
+  /** Linear's URL segment for this workspace, once a team read has answered with it. */
+  get workspaceUrlKey(): string | undefined {
+    return this.urlKey
   }
 
   /** Is this Linear user the app itself? The ingress self-echo guard (§7.2 `appUserId`). */
@@ -434,9 +443,20 @@ export class LinearConnection implements PlatformConnection {
     }
     try {
       const signal = opts.signal ?? AbortSignal.timeout(LINEAR_READ_DEADLINE_MS)
-      const data = await this.graphql<{ team?: LinearTeamRef | null }>(TEAM_QUERY, { id: channel }, signal)
+      const data = await this.graphql<TeamPayload & { team?: LinearTeamRef | null }>(
+        TEAM_QUERY,
+        { id: channel },
+        signal
+      )
+      this.noteUrlKey(data)
       const name = data.team ? linearChannelName({ ...data.team, id: channel }, this) : ''
-      return { id: channel, ...(name && name !== channel ? { name } : {}), ...linearTeamGlyph(data.team), isIm: false }
+      return {
+        id: channel,
+        ...(name && name !== channel ? { name } : {}),
+        ...linearTeamGlyph(data.team),
+        ...linearTeamLink(data.team, this),
+        isIm: false
+      }
     } catch (err) {
       this.deps.log?.debug(`linear: team lookup failed (${channel}): ${(err as Error).message}`)
       return { id: channel, isIm: false }
@@ -482,7 +502,12 @@ export class LinearConnection implements PlatformConnection {
   async listChannels(opts: { signal?: AbortSignal } = {}): Promise<PlatformChannelRef[]> {
     try {
       const signal = opts.signal ?? AbortSignal.timeout(LINEAR_READ_DEADLINE_MS)
-      const data = await this.graphql<{ teams?: { nodes?: LinearTeamRef[] } | null }>(TEAMS_QUERY, {}, signal)
+      const data = await this.graphql<TeamPayload & { teams?: { nodes?: LinearTeamRef[] } | null }>(
+        TEAMS_QUERY,
+        {},
+        signal
+      )
+      this.noteUrlKey(data)
       return (data.teams?.nodes ?? [])
         .filter((node) => Boolean(node?.id))
         .map((node) => {
@@ -491,6 +516,7 @@ export class LinearConnection implements PlatformConnection {
             id: node.id,
             ...(name && name !== node.id ? { name } : {}),
             ...linearTeamGlyph(node),
+            ...linearTeamLink(node, this),
             isPrivate: false
           }
         })
@@ -498,6 +524,13 @@ export class LinearConnection implements PlatformConnection {
       this.deps.log?.debug(`linear: team list failed for integration ${this.integrationId}: ${(err as Error).message}`)
       return []
     }
+  }
+
+  /** Learn the workspace's URL segment off a team read, and never unlearn it: a response that
+   *  omits it leaves the links already built standing. */
+  private noteUrlKey(data: TeamPayload): void {
+    const urlKey = data.viewer?.organization?.urlKey
+    if (typeof urlKey === 'string' && urlKey.trim()) this.urlKey = urlKey.trim()
   }
 
   /** Attachment download is deferred (§9.4) — `null` is "unavailable", never a throw. */
@@ -753,10 +786,17 @@ const USER_QUERY = `query User($id: String!) {
   user(id: $id) { id name displayName avatarUrl }
 }`
 
+/** The workspace half both team reads ask for alongside the team — one round trip, not two. */
+interface TeamPayload {
+  viewer?: { organization?: { urlKey?: string } | null } | null
+}
+
 const TEAM_QUERY = `query Team($id: String!) {
+  viewer { organization { urlKey } }
   team(id: $id) { id key name icon color }
 }`
 
 const TEAMS_QUERY = `query Teams {
+  viewer { organization { urlKey } }
   teams(first: ${MAX_LISTED_TEAMS}) { nodes { id key name icon color } }
 }`

--- a/packages/daemon/src/platforms/linear/message-strategy.ts
+++ b/packages/daemon/src/platforms/linear/message-strategy.ts
@@ -19,7 +19,7 @@
  * `daemon.ts` decide when to run it; this module only decides what the turn reads.
  */
 import { z } from 'zod'
-import { conversationGlyph } from '@agentconnect.md/protocol'
+import { conversationGlyph, conversationLink } from '@agentconnect.md/protocol'
 import {
   neutralizeDelimiters,
   UNTRUSTED_CONTENT_BEGIN_LINEAR,
@@ -81,10 +81,29 @@ export const linearTeamGlyph = (
   team: Pick<LinearTeamRef, 'icon' | 'color'> | undefined | null
 ): { icon?: string; color?: string } => conversationGlyph(team?.icon, team?.color)
 
-/** The connected workspace: all that is left to label the issue-less channel (§4.5). */
+/** Where a Linear workspace lives on the web — the base every team link is built on. */
+const LINEAR_APP_BASE = 'https://linear.app'
+
+/** The connected workspace: all that is left to label the issue-less channel (§4.5).
+ *  `workspaceUrlKey` is Linear's own URL segment for it, which the team link is built on. */
 export interface LinearWorkspaceRef {
   workspaceName?: string
+  workspaceUrlKey?: string
   workspaceId(): string
+}
+
+/** The team's handle and the page it opens in Linear as the conversation row accepts them
+ *  (§4.5) — the key off the team, the link only once the workspace's URL segment is known,
+ *  and both narrowed through the wire contract's own helper for `linearTeamGlyph`'s reason. */
+export const linearTeamLink = (
+  team: Pick<LinearTeamRef, 'key'> | undefined | null,
+  workspace?: LinearWorkspaceRef
+): { key?: string; url?: string } => {
+  const key = team?.key?.trim()
+  const urlKey = workspace?.workspaceUrlKey?.trim()
+  const url =
+    key && urlKey ? `${LINEAR_APP_BASE}/${encodeURIComponent(urlKey)}/team/${encodeURIComponent(key)}` : undefined
+  return conversationLink(key, url)
 }
 
 /** The stop payload the relay puts on `platform_action` (§6.3). */

--- a/packages/daemon/src/platforms/observed-channels-sync.ts
+++ b/packages/daemon/src/platforms/observed-channels-sync.ts
@@ -223,9 +223,11 @@ export class ObservedChannelsSync {
           id: chat.id,
           ...(chat.name ? { name: chat.name } : {}),
           // Learned once and never unlearned: an observation that could not resolve the glyph
-          // keeps the one the row already carries rather than blanking a rendered row.
+          // or the link keeps the one the row already carries rather than blanking a drawn row.
           ...(chat.icon ? { icon: chat.icon } : {}),
           ...(chat.color ? { color: chat.color } : {}),
+          ...(chat.key ? { key: chat.key } : {}),
+          ...(chat.url ? { url: chat.url } : {}),
           isPrivate: chat.isPrivate,
           kind: 'channel'
         }
@@ -233,6 +235,8 @@ export class ObservedChannelsSync {
           current?.name === observed.name &&
           current?.icon === observed.icon &&
           current?.color === observed.color &&
+          current?.key === observed.key &&
+          current?.url === observed.url &&
           current?.isPrivate === observed.isPrivate &&
           current?.kind === observed.kind
         ) {

--- a/packages/daemon/src/platforms/observed-channels.ts
+++ b/packages/daemon/src/platforms/observed-channels.ts
@@ -46,14 +46,16 @@ export function observedMembershipPlatforms(): readonly string[] {
 }
 
 /** One conversation a connection reports having observed, ahead of any session row.
- *  `icon`/`color` are the row's own display glyph and tint on the platforms that give a
- *  conversation one (a Linear team); every other platform simply never sets them. */
+ *  `icon`/`color` are the row's own display glyph and tint, `key`/`url` its short platform
+ *  handle and the page it opens there (a Linear team); other platforms never set them. */
 export interface ObservedChat {
   id: string
   name?: string
   isPrivate: boolean
   icon?: string
   color?: string
+  key?: string
+  url?: string
 }
 
 /** One observed conversation row, as the snapshot pipeline carries it. */

--- a/packages/daemon/test/linear-connection.test.ts
+++ b/packages/daemon/test/linear-connection.test.ts
@@ -776,9 +776,13 @@ describe('linear read port (§9.4 — what Linear affords)', () => {
     expect(await conn.getChannelInfo(TEAM)).toEqual({
       id: TEAM,
       name: 'Example Workspace / Engineering',
+      // The key never enters the LABEL; it rides the row as its own field, for the console to
+      // print after the name (§4.5).
+      key: 'ENG',
       isIm: false
     })
     expect(calls[0]!.query).toContain('team(id: $id) { id key name icon color }')
+    expect(calls[0]!.query).toContain('viewer { organization { urlKey } }')
     expect(calls[0]!.variables).toEqual({ id: TEAM })
   })
 
@@ -814,8 +818,8 @@ describe('linear read port (§9.4 — what Linear affords)', () => {
         })
     })
     expect(await conn.listChannels()).toEqual([
-      { id: TEAM, name: 'Example Workspace / Engineering', isPrivate: false },
-      { id: OTHER_TEAM, name: 'Example Workspace / Docs', isPrivate: false },
+      { id: TEAM, name: 'Example Workspace / Engineering', key: 'ENG', isPrivate: false },
+      { id: OTHER_TEAM, name: 'Example Workspace / Docs', key: 'DOCS', isPrivate: false },
       { id: 'team-3', isPrivate: false }
     ])
     expect(calls[0]!.query).toContain('teams(first: 100) { nodes { id key name icon color } }')
@@ -842,11 +846,18 @@ describe('linear read port (§9.4 — what Linear affords)', () => {
         })
     })
     expect(await conn.listChannels()).toEqual([
-      { id: TEAM, name: 'Example Workspace / Engineering', icon: 'Feather', color: '#5E6AD2', isPrivate: false },
+      {
+        id: TEAM,
+        name: 'Example Workspace / Engineering',
+        icon: 'Feather',
+        color: '#5E6AD2',
+        key: 'ENG',
+        isPrivate: false
+      },
       // A color the wire row would refuse costs its own field, never the whole report.
-      { id: OTHER_TEAM, name: 'Example Workspace / Docs', icon: '📚', isPrivate: false },
+      { id: OTHER_TEAM, name: 'Example Workspace / Docs', icon: '📚', key: 'DOCS', isPrivate: false },
       // …and so does an over-long icon; a bare triplet is still a color.
-      { id: 'team-3', name: 'Example Workspace / Ops', color: '5E6AD2', isPrivate: false }
+      { id: 'team-3', name: 'Example Workspace / Ops', color: '5E6AD2', key: 'OPS', isPrivate: false }
     ])
   })
 
@@ -860,7 +871,54 @@ describe('linear read port (§9.4 — what Linear affords)', () => {
       name: 'Example Workspace / Engineering',
       icon: '🚀',
       color: '#5E6AD2',
+      key: 'ENG',
       isIm: false
+    })
+  })
+
+  it('links each team to its page in Linear, off the workspace URL segment the read carries', async () => {
+    const { conn } = harness({
+      respond: () =>
+        jsonResponse({
+          data: {
+            viewer: { organization: { urlKey: 'example-workspace' } },
+            teams: {
+              nodes: [
+                { id: TEAM, key: 'ENG', name: 'Engineering' },
+                // A team the workspace answered without a key has nothing to link, and no key
+                // to print — the row keeps its name alone.
+                { id: OTHER_TEAM, name: 'Docs' }
+              ]
+            }
+          }
+        })
+    })
+    expect(await conn.listChannels()).toEqual([
+      {
+        id: TEAM,
+        name: 'Example Workspace / Engineering',
+        key: 'ENG',
+        url: 'https://linear.app/example-workspace/team/ENG',
+        isPrivate: false
+      },
+      { id: OTHER_TEAM, name: 'Example Workspace / Docs', isPrivate: false }
+    ])
+  })
+
+  it('remembers the workspace URL segment, so a later read that omits it still links', async () => {
+    // The segment is the workspace's, not the team's: it is learned once and never unlearned,
+    // which is also what lets the ingress fast path link a team off the event bag alone.
+    let withUrlKey = true
+    const { conn } = harness({
+      respond: () => {
+        const viewer = withUrlKey ? { viewer: { organization: { urlKey: 'example-workspace' } } } : {}
+        return jsonResponse({ data: { ...viewer, team: { id: TEAM, key: 'ENG', name: 'Engineering' } } })
+      }
+    })
+    await conn.getChannelInfo(TEAM)
+    withUrlKey = false
+    expect(await conn.getChannelInfo(TEAM)).toMatchObject({
+      url: 'https://linear.app/example-workspace/team/ENG'
     })
   })
 

--- a/packages/daemon/test/linear-ingress.test.ts
+++ b/packages/daemon/test/linear-ingress.test.ts
@@ -99,6 +99,9 @@ interface BootOpts {
   expiresAt?: string
 }
 
+/** Linear's own URL segment for the connected workspace — half of every team link (§4.5). */
+const WORKSPACE_URL_KEY = 'example-workspace'
+
 /** The workspace's teams, as the reconcile-time `listChannels` read sees them (§9.4). */
 const TEAM_NODES = [
   { id: TEAM, key: 'ENG', name: 'Engineering', icon: 'Feather', color: '#5E6AD2' },
@@ -134,7 +137,10 @@ beforeEach(() => {
         signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true })
       })
     }
-    const data = teamList ? { teams: { nodes: TEAM_NODES } } : {}
+    // Both team reads ask for the workspace's URL segment alongside the team (§4.5).
+    const data = teamList
+      ? { viewer: { organization: { urlKey: WORKSPACE_URL_KEY } }, teams: { nodes: TEAM_NODES } }
+      : {}
     return {
       ok: true,
       status: 200,
@@ -175,6 +181,8 @@ async function boot(opts: BootOpts = {}) {
     botUserId: 'app-user-1',
     workspaceId: () => WORKSPACE,
     workspaceName: 'Example Workspace',
+    // What the real connection remembers off the reconcile's team read — the link's other half.
+    workspaceUrlKey: WORKSPACE_URL_KEY,
     async postActivity(sessionId: string, activity: LinearActivityInput) {
       // The ordering assertion itself: read the durable inbox AT POST TIME, so a row that
       // only lands later cannot make an out-of-order first activity look admitted.
@@ -304,6 +312,8 @@ describe('§4.5 the teams as the observed conversations', () => {
             name: 'Example Workspace / Engineering',
             icon: 'Feather',
             color: '#5E6AD2',
+            key: 'ENG',
+            url: 'https://linear.app/example-workspace/team/ENG',
             isPrivate: false,
             kind: 'channel'
           },
@@ -312,6 +322,8 @@ describe('§4.5 the teams as the observed conversations', () => {
             name: 'Example Workspace / Docs',
             icon: '📚',
             color: '#26B5CE',
+            key: 'DOCS',
+            url: 'https://linear.app/example-workspace/team/DOCS',
             isPrivate: false,
             kind: 'channel'
           }
@@ -362,9 +374,12 @@ describe('§4.5 the teams as the observed conversations', () => {
       expect(reports.at(-1)?.channels).toContainEqual({
         id: fresh.id,
         name: 'Example Workspace / New Team',
-        // The bag carries the team's glyph, so the fast-path row is born with it too.
+        // The bag carries the team's glyph and its key, and the connection remembers the
+        // workspace URL segment from the reconcile read: the fast-path row is born linked.
         icon: '🚀',
         color: '#F2994A',
+        key: 'NEW',
+        url: 'https://linear.app/example-workspace/team/NEW',
         isPrivate: false,
         kind: 'channel'
       })

--- a/packages/daemon/test/observed-channels-sync.test.ts
+++ b/packages/daemon/test/observed-channels-sync.test.ts
@@ -63,6 +63,27 @@ describe('observePlatformChats — the conversation row a platform reports as ob
     expect(reports).toHaveLength(1)
   })
 
+  it('carries the chat’s handle and link onto the row, learned once like the glyph', async () => {
+    const { sync, snapshots, reports } = harness()
+    const linked = {
+      id: 'team-1',
+      name: 'Acme / Engineering',
+      key: 'ENG',
+      url: 'https://linear.app/example-workspace/team/ENG',
+      isPrivate: false
+    }
+    await sync.observePlatformChats('linear', [linked], [INTEGRATION])
+    expect(rows(snapshots)[0]).toMatchObject({ key: 'ENG', url: 'https://linear.app/example-workspace/team/ENG' })
+    // A later observation that resolved neither leaves the linked row standing, and reports nothing.
+    await sync.observePlatformChats(
+      'linear',
+      [{ id: 'team-1', name: 'Acme / Engineering', isPrivate: false }],
+      [INTEGRATION]
+    )
+    expect(rows(snapshots)[0]).toMatchObject({ key: 'ENG', url: 'https://linear.app/example-workspace/team/ENG' })
+    expect(reports).toHaveLength(1)
+  })
+
   it('reports again when only the glyph changed — a renamed row is not the only thing the console redraws', async () => {
     const { sync, snapshots, reports } = harness()
     const chat = { id: 'team-1', name: 'Acme / Engineering', isPrivate: false }

--- a/packages/protocol/src/codec.test.ts
+++ b/packages/protocol/src/codec.test.ts
@@ -794,6 +794,49 @@ describe('integration frames (CP→daemon platform config distribution)', () => 
     expect(bare.ok).toBe(true)
   })
 
+  it('integration/channels round-trips the conversation’s own handle and link', () => {
+    const r = decodeEnvelope(
+      envelope('integration/channels', {
+        integrationId: INTEGRATION_ID,
+        channels: [
+          {
+            id: 'team-1',
+            name: 'Acme / Engineering',
+            key: 'ENG',
+            url: 'https://linear.app/example-workspace/team/ENG'
+          },
+          { id: 'C123', name: 'deploys' }
+        ]
+      })
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok || !isFrame('integration/channels')(r.frame)) throw new Error('expected integration/channels')
+    expect(r.frame.payload.channels[0]).toEqual({
+      id: 'team-1',
+      name: 'Acme / Engineering',
+      key: 'ENG',
+      url: 'https://linear.app/example-workspace/team/ENG'
+    })
+    // A platform without the notion sets neither, and the row decodes exactly as it always did.
+    expect(r.frame.payload.channels[1]).toEqual({ id: 'C123', name: 'deploys' })
+  })
+
+  it('integration/channels refuses an over-long key and a link that is not https', () => {
+    const long = decodeEnvelope(
+      envelope('integration/channels', {
+        integrationId: INTEGRATION_ID,
+        channels: [{ id: 'team-1', key: 'K'.repeat(33) }]
+      })
+    )
+    expect(long.ok).toBe(false)
+    for (const url of ['javascript:alert(1)', 'http://linear.app/example-workspace/team/ENG', 'not a url']) {
+      const bad = decodeEnvelope(
+        envelope('integration/channels', { integrationId: INTEGRATION_ID, channels: [{ id: 'team-1', url }] })
+      )
+      expect(bad.ok, url).toBe(false)
+    }
+  })
+
   it('register/ok defaults integrations[] to [] and round-trips a delivered integration', () => {
     const empty = decodeEnvelope(
       envelope('register/ok', {

--- a/packages/protocol/src/frames/integration.ts
+++ b/packages/protocol/src/frames/integration.ts
@@ -219,6 +219,29 @@ export function conversationGlyph(icon: unknown, color: unknown): { icon?: strin
   }
 }
 
+/** Cap on a conversation's platform key — a short handle such as a Linear team's `ENG`. */
+const CHANNEL_KEY_MAX = 32
+
+/** Cap on a conversation's own link — a permalink the console opens, never a payload. */
+const CHANNEL_URL_MAX = 512
+
+/** Only an `https` origin is a link here: the console opens it in a new tab. */
+const CHANNEL_URL = /^https:\/\/\S+$/
+
+/**
+ * A conversation's platform handle and permalink narrowed to what {@link IntegrationChannel}
+ * accepts — {@link conversationGlyph}'s sibling, and narrowed at the source for the same reason:
+ * one oddly spelled conversation costs its own field and never the report it rides in.
+ */
+export function conversationLink(key: unknown, url: unknown): { key?: string; url?: string } {
+  const k = typeof key === 'string' ? key.trim() : ''
+  const u = typeof url === 'string' ? url.trim() : ''
+  return {
+    ...(k && k.length <= CHANNEL_KEY_MAX ? { key: k } : {}),
+    ...(u && u.length <= CHANNEL_URL_MAX && CHANNEL_URL.test(u) ? { url: u } : {})
+  }
+}
+
 /**
  * One conversation the bot participates in (metadata only — no messages).
  * `kind` distinguishes member channels from direct conversations (resource-
@@ -240,7 +263,9 @@ export function conversationGlyph(icon: unknown, color: unknown): { icon?: strin
  *
  * `icon`/`color` are the conversation's own display glyph and tint where the platform
  * has one — a Linear team. Absent everywhere else, and never load-bearing: a row without
- * them renders exactly as it did before they existed.
+ * them renders exactly as it did before they existed. `key`/`url` are the same class of
+ * display metadata: the conversation's short platform handle and the page it opens on the
+ * platform, carried as their own fields so no reader ever parses them back out of `name`.
  */
 export const IntegrationChannel = z.object({
   id: z.string(), // platform conversation id (Slack "C…" / DM "D…")
@@ -254,6 +279,10 @@ export const IntegrationChannel = z.object({
   // Display only: bounded so a hostile provider cannot grow a row, and never parsed for routing.
   icon: z.string().max(CHANNEL_ICON_MAX).optional(),
   color: z.string().regex(CHANNEL_COLOR).optional(),
+  // The conversation's short platform handle (a Linear team's `ENG`) and the page it opens
+  // on the platform. Display only, bounded the same way, and never a coordinate: `id` is.
+  key: z.string().max(CHANNEL_KEY_MAX).optional(),
+  url: z.string().max(CHANNEL_URL_MAX).regex(CHANNEL_URL).optional(),
   // The 1:1 DM counterpart's platform member id (§14.8) — control metadata of the same
   // class as `name`, and the only thing that identifies WHO a private agent's DM row is
   // with. Absent on channels and group DMs, whose membership is a room, not a person.

--- a/packages/web/src/components/console/DefaultDispatchPicker.tsx
+++ b/packages/web/src/components/console/DefaultDispatchPicker.tsx
@@ -22,6 +22,11 @@ export interface DefaultDispatchOption {
   icon?: AgentIcon | null
 }
 
+/** The default-dispatch control's own glyph — FIXED, so the control has one shape wherever it
+ *  appears, the way the trigger's bell does. "Leads to" is already this console's word for a
+ *  hand-off. Shared with the agent page's own per-conversation picker. */
+export const DISPATCH_ICON = 'corner-down-right'
+
 const MENU_WIDTH = 240
 const MENU_HEADER_HEIGHT = 34
 const MENU_ROW_HEIGHT = 34
@@ -58,14 +63,15 @@ export function DefaultDispatchPicker({
             aria-haspopup="menu"
             aria-expanded={open}
             aria-controls={open ? menuId : undefined}
-            title="Default dispatch — the agent this conversation's unmatched messages go to"
+            title={`Default dispatch — ${active?.name ?? 'none'}`}
             className={`flex items-center gap-2 rounded-[7px] border-0 bg-transparent px-[5px] py-1 hover:bg-(--surface-hover) ${
               disabled ? 'cursor-default' : 'cursor-pointer'
             } ${saving ? 'opacity-60' : ''}`}
           >
-            <span className="av h-5 w-5 rounded-[5px]">
-              <AgentIconView icon={active?.icon} runtime={active?.runtime ?? active?.model ?? ''} size={20} />
-            </span>
+            {/* A FIXED glyph, the way the trigger's bell is: the trigger used the active
+                agent's avatar, so the control changed shape per agent and read as whatever
+                that mark suggested. The avatars stay in the menu, where they identify rows. */}
+            <Icon name={DISPATCH_ICON} size={13} color="var(--text-tertiary)" className="flex-none" />
             <span className="mono text-[12.5px] text-(--text-primary)">{active?.name ?? '—'}</span>
             <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
           </button>

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -8,10 +8,12 @@ import {
   placePopover,
   roomArticle,
   roomGlyph,
+  roomPlural,
   rowLabel,
   rowLabelParts,
   rowMark,
-  rowMenuAction
+  rowMenuAction,
+  rowName
 } from './IntegrationChannelList'
 import type { IntegrationChannelRow, IntegrationRow } from '@/lib/data'
 
@@ -407,6 +409,37 @@ describe('rowLabelParts', () => {
   })
 })
 
+describe('rowName', () => {
+  it('is the platform’s own, and only where the platform declares one', () => {
+    // Linear prints a team's key after its name and links the name; nobody else has either.
+    expect(rowName('channel', 'linear')).toBeDefined()
+    for (const platform of ['slack', 'discord', 'telegram', 'feishu', undefined]) {
+      expect(rowName('channel', platform)).toBeUndefined()
+    }
+  })
+
+  it('never renames a direct row — its label is a person, with no handle and no page', () => {
+    expect(rowName('im', 'linear')).toBeUndefined()
+    expect(rowName('mpim', 'linear')).toBeUndefined()
+  })
+})
+
+describe('roomPlural', () => {
+  it('heads a list of rows with the platform’s own noun, pluralised', () => {
+    // The three nouns the modules declare today.
+    expect(roomPlural('team')).toBe('teams')
+    expect(roomPlural('channel')).toBe('channels')
+    expect(roomPlural('chat')).toBe('chats')
+  })
+
+  it('keeps the sibilant arm honest for a noun no module declares yet', () => {
+    expect(roomPlural('inbox')).toBe('inboxes')
+    expect(roomPlural('branch')).toBe('branches')
+    // The host capitalises before pluralising, so the header reads "Teams", not "teamS".
+    expect(roomPlural('Team')).toBe('Teams')
+  })
+})
+
 describe('rowMark', () => {
   it('is the platform’s own, and only where the platform declares one', () => {
     expect(rowMark('channel', 'linear')).toBeDefined()
@@ -449,6 +482,35 @@ describe('IntegrationChannelList default dispatch on a one-member bot', () => {
   })
 })
 
+// A CONTROL has one shape wherever it appears — the trigger's bell, and this. The button used
+// to lead with the current agent's avatar, which varies per agent: the control had no
+// recognisable form, and one agent's mark could read as a different control entirely.
+describe('IntegrationChannelList default dispatch control', () => {
+  const render = (agentId: string) =>
+    renderToStaticMarkup(
+      createElement(IntegrationChannelList, {
+        integrationId: 'int_alice',
+        botId: 'bot_shared',
+        agentId: 'alice',
+        platform: 'slack',
+        shareable: true,
+        channels: [{ channelId: 'C1', name: 'deploys', kind: 'channel', trigger: 'mention', agentId }]
+      })
+    )
+
+  it('reads as a FIXED glyph plus the current default’s NAME, on every agent', () => {
+    const alice = render('alice')
+    const bob = render('bob')
+    for (const html of [alice, bob]) expect(html).toContain('lucide-corner-down-right')
+    expect(alice).toContain('>Alice</span>')
+    expect(bob).toContain('>Bob</span>')
+  })
+
+  it('prints the name on the desktop row too, rather than hiding it behind a mark', () => {
+    expect(render('alice')).not.toContain('desktop:hidden')
+  })
+})
+
 describe('IntegrationChannelList direct rows', () => {
   it('renders an Everyone DM with its on/off trigger dropdown', () => {
     const html = renderToStaticMarkup(
@@ -476,6 +538,50 @@ describe('IntegrationChannelList direct rows', () => {
       })
     )
     expect(html).toContain('Default dispatch — Bob')
+  })
+})
+
+// A platform may give a conversation more than a label: a Linear team has a KEY and a page.
+// Both ride the row as their own fields — neither is ever read back out of the stored label.
+describe('IntegrationChannelList row name, where the platform gives one', () => {
+  const render = (row: Partial<IntegrationChannelRow> = {}) =>
+    renderToStaticMarkup(
+      createElement(IntegrationChannelList, {
+        platform: 'linear',
+        gated: false,
+        channels: [
+          {
+            channelId: 'team-eng',
+            name: 'Acme / Engineering',
+            kind: 'channel',
+            trigger: 'mention',
+            key: 'ENG',
+            url: 'https://linear.app/example-workspace/team/ENG',
+            ...row
+          }
+        ]
+      })
+    )
+
+  it('prints the team’s key after its name and links the NAME to the team in Linear', () => {
+    const html = render()
+    expect(html).toContain('href="https://linear.app/example-workspace/team/ENG"')
+    expect(html).toContain('>Engineering</span>')
+    expect(html).toContain('>ENG<')
+    // The stored label still carries the workspace and never the key (§4.5).
+    expect(html).not.toContain('Acme / Engineering</span>')
+  })
+
+  it('leaves every other platform’s row exactly as it was', () => {
+    const slack = renderToStaticMarkup(
+      createElement(IntegrationChannelList, {
+        platform: 'slack',
+        gated: false,
+        channels: [{ channelId: 'C1', name: 'deploys', kind: 'channel', trigger: 'mention' }]
+      })
+    )
+    expect(slack).not.toContain('<a ')
+    expect(slack).toContain('>deploys</span>')
   })
 })
 

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom'
 import { agentLabel, isDirectConversation, type IntegrationChannelRow, type IntegrationRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
+import { DISPATCH_ICON } from '@/components/console/DefaultDispatchPicker'
 import { AgentIconView } from '@/components/marks'
 import { channelListSemantics } from '@/components/console/platforms/registry'
 import { TriggerSelect, type TriggerOption } from '@/components/console/TriggerSelect'
@@ -210,6 +211,10 @@ const roomNoun = (platform?: string): string => channelListSemantics(platform).r
  *  today's modules all take "A", so only a test keeps the other arm honest. */
 export const roomArticle = (noun: string): string => (/^[aeiou]/i.test(noun) ? 'An' : 'A')
 
+/** The plural of a noun a module supplies — what a column header over a list of rows reads.
+ *  Today's modules all take a bare "s", so only a test keeps the sibilant arm honest. */
+export const roomPlural = (noun: string): string => (/(?:s|x|z|ch|sh)$/i.test(noun) ? `${noun}es` : `${noun}s`)
+
 /** The noun for ONE row: a DM is never a channel or a group, whatever the platform. */
 const rowNoun = (kind: IntegrationChannelRow['kind'], platform?: string): string =>
   kind === 'im' ? 'conversation' : kind === 'mpim' ? 'group chat' : roomNoun(platform)
@@ -227,6 +232,12 @@ export const roomGlyph = (kind: IntegrationChannelRow['kind'], platform?: string
  *  Exported for the org Bots roster, which lists the same rows in its own chrome. */
 export const rowMark = (kind: IntegrationChannelRow['kind'], platform?: string) =>
   isDirectConversation(kind) ? undefined : channelListSemantics(platform).RowMark
+
+/** How the row prints its NAME, where the platform gives the conversation more than a label
+ *  (a Linear team's key and its page). Direct rows never take it, for `rowMark`'s reason, and
+ *  a module that declares none leaves the host printing the name. Exported for the same host. */
+export const rowName = (kind: IntegrationChannelRow['kind'], platform?: string) =>
+  isDirectConversation(kind) ? undefined : channelListSemantics(platform).RowName
 
 /** The place, named as the operator knows it. "on the platform" is our word for it,
  *  not theirs — a person deciding whether to remove a bot wants to read "in Telegram". */
@@ -403,10 +414,12 @@ export function conversationOwners(botId: string, integrations: IntegrationRow[]
  *  routing rules don't hand to someone else.
  *
  *  The design keeps this strictly apart from the trigger toggle (the two are separate
- *  controls, never merged) — a compact avatar + chevron whose popover
- *  READS the current default and offers exactly one action, claiming the channel
- *  for the agent whose page this is. Handing a conversation to some third agent stays
- *  in Settings → Bots, where the whole roster is in view. */
+ *  controls, never merged) — a fixed control glyph, the current default's NAME and a chevron,
+ *  whose popover READS that default and offers exactly one action, claiming the channel
+ *  for the agent whose page this is. The glyph is FIXED, the way the trigger's bell is: an
+ *  avatar there varied per agent, so the control had no stable shape to recognise, and one
+ *  agent's mark could read as a different control entirely. Handing a conversation to some
+ *  third agent stays in Settings → Bots, where the whole roster is in view. */
 function DefaultAgentPicker({
   current,
   viewer,
@@ -466,14 +479,8 @@ function DefaultAgentPicker({
           saving ? 'opacity-60' : ''
         }`}
       >
-        <span className="av h-[22px] w-[22px] rounded-[6px]">
-          <AgentIconView icon={current.icon} runtime={current.runtime} size={22} />
-        </span>
-        {/* Desktop rows read the avatar in the context of the row it sits on; the
-            mobile row breaks onto its own line, where a bare mark says nothing. */}
-        <span className="mono max-w-[180px] truncate text-[12px] text-(--text-tertiary) desktop:hidden">
-          {current.label}
-        </span>
+        <Icon name={DISPATCH_ICON} size={13} color="var(--text-tertiary)" className="flex-none" />
+        <span className="mono max-w-[180px] truncate text-[12px] text-(--text-tertiary)">{current.label}</span>
         <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
       </button>
       {box &&
@@ -659,6 +666,7 @@ export function IntegrationChannelList({
     const def = dispatchable ? defaultAgent(c) : undefined
     const label = rowLabelParts(c, platform)
     const Mark = rowMark(c.kind, platform)
+    const Name = rowName(c.kind, platform)
     return (
       <div
         key={c.channelId}
@@ -673,7 +681,11 @@ export function IntegrationChannelList({
           </span>
         )}
         <span className="mono flex min-w-0 flex-1 items-baseline gap-[6px] truncate text-[13px] text-(--text-primary)">
-          <span className="min-w-0 truncate">{label.name}</span>
+          {Name ? (
+            <Name name={label.name} channelKey={c.key} url={c.url} />
+          ) : (
+            <span className="min-w-0 truncate">{label.name}</span>
+          )}
           {label.hint && <span className="flex-none text-(--text-tertiary)">{label.hint}</span>}
         </span>
         <div className="ml-auto flex items-center gap-[10px] max-desktop:ml-0 max-desktop:w-full max-desktop:flex-col max-desktop:items-start">

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -602,6 +602,14 @@ export interface WebChannelListSemantics {
    * leads with {@link roomGlyph} alone, which is every other platform.
    */
   RowMark?: ComponentType<{ name: string; icon?: string; color?: string; size?: number }>
+  /**
+   * How a room row prints its NAME, where the platform gives the conversation more than a label
+   * — a Linear team is followed by its key and opens in Linear. It renders INTO the host's own
+   * baseline row (a fragment, not a box), taking the row's DISPLAYED name (post-{@link
+   * splitRowLabel}) plus the row's `key` and `url`. Absent ⇒ the host prints the name itself,
+   * which is every other platform; direct rows never take it, as with {@link RowMark}.
+   */
+  RowName?: ComponentType<{ name: string; channelKey?: string; url?: string }>
 }
 
 /**

--- a/packages/web/src/components/console/platforms/linear/card.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/card.test.tsx
@@ -83,6 +83,8 @@ const TEAMS: IntegrationChannelRow[] = [
     name: 'Acme / Engineering',
     icon: 'Feather',
     color: '#5E6AD2',
+    key: 'ENG',
+    url: 'https://linear.app/example-workspace/team/ENG',
     kind: 'channel',
     trigger: 'mention',
     agentId: 'agent-b'
@@ -92,6 +94,8 @@ const TEAMS: IntegrationChannelRow[] = [
     name: 'Acme / Design',
     icon: '🎨',
     color: '#26B5CE',
+    key: 'DES',
+    url: 'https://linear.app/example-workspace/team/DES',
     kind: 'channel',
     trigger: 'off',
     agentId: 'agent-c'
@@ -236,8 +240,23 @@ describe('the team rows', () => {
     // The row reads "Engineering" — never the team KEY, which is an identifier, never the
     // workspace prefix this card already prints above, and never a "#" Linear has no use for.
     expect(eng!.parentElement!.textContent).toContain('Engineering')
-    expect(host.textContent).not.toContain('ENG')
+    // The KEY is printed beside the name, never spliced into the label, and never a "#".
+    expect(eng!.textContent).toBe('Engineering')
     expect(host.textContent).not.toContain('#')
+  })
+
+  it('prints the team’s key after its name, and links the NAME to the team in Linear', async () => {
+    await render()
+
+    const links = [...host.querySelectorAll('a')].filter((a) => a.getAttribute('href')?.includes('linear.app'))
+    expect(links.map((a) => a.textContent)).toEqual(['Engineering', 'Design'])
+    expect(links[0]!.getAttribute('href')).toBe('https://linear.app/example-workspace/team/ENG')
+    expect(links[0]!.getAttribute('target')).toBe('_blank')
+    expect(links[0]!.getAttribute('rel')).toBe('noopener noreferrer')
+    // The key is muted text beside the link, not part of it.
+    const keys = [...host.querySelectorAll('span')].filter((el) => el.textContent === 'ENG')
+    expect(keys).toHaveLength(1)
+    expect(keys[0]!.closest('a')).toBeNull()
   })
 
   it('leads each team row with its own colored mark, the way Linear’s team picker does', async () => {

--- a/packages/web/src/components/console/platforms/linear/index.tsx
+++ b/packages/web/src/components/console/platforms/linear/index.tsx
@@ -7,6 +7,7 @@ import { LinearWorkspaceCard, LinearWorkspaceHeaderActions, LinearWorkspaceRows 
 import { linearLinkInput } from './link'
 import { LinearMark } from './mark'
 import { LinearTeamGlyph } from './team-glyph'
+import { LinearTeamName } from './team-name'
 import { linearSettingsFragments } from './settings'
 
 /** Linear's provider-native activity id: a v4 UUID. A daemon-local numeric stamp
@@ -66,6 +67,9 @@ export const linearModule: WebPlatformModule<LinearApi> = {
     // an identifier rather than a label and is not in the stored name at all.
     // A team leads with its own icon and color, the way Linear's own team picker draws it.
     RowMark: LinearTeamGlyph,
+    // …and prints its key after the name, off the row's own field, with the name linking to
+    // the team in Linear — neither is ever read back out of the label.
+    RowName: LinearTeamName,
     splitRowLabel: (label) => {
       const at = label.indexOf(TEAM_LABEL_SEPARATOR)
       if (at < 0) return { name: label }

--- a/packages/web/src/components/console/platforms/linear/team-name.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/team-name.test.tsx
@@ -1,0 +1,47 @@
+// How a team row prints its name: the team's NAME, linked to the team in Linear, then its KEY
+// in muted text. The rule this pins is that only the NAME is the anchor — the key sits outside
+// it, so it can be read and copied without being a navigation target.
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { LinearTeamName } from './team-name'
+
+const html = (props: Parameters<typeof LinearTeamName>[0]) => renderToStaticMarkup(<LinearTeamName {...props} />)
+
+const TEAM_URL = 'https://linear.app/example-workspace/team/ENG'
+
+describe('the Linear team row’s name', () => {
+  it('prints the key after the name, in the muted token', () => {
+    const out = html({ name: 'Engineering', channelKey: 'ENG', url: TEAM_URL })
+    expect(out).toContain('Engineering')
+    expect(out).toContain('>ENG<')
+    expect(out).toContain('text-(--text-tertiary)')
+  })
+
+  it('links only the NAME, never the key', () => {
+    const out = html({ name: 'Engineering', channelKey: 'ENG', url: TEAM_URL })
+    const anchor = out.slice(out.indexOf('<a'), out.indexOf('</a>'))
+    expect(anchor).toContain('Engineering')
+    expect(anchor).not.toContain('>ENG<')
+  })
+
+  it('opens the team in a new tab, without handing Linear the referrer or the opener', () => {
+    const out = html({ name: 'Engineering', channelKey: 'ENG', url: TEAM_URL })
+    expect(out).toContain(`href="${TEAM_URL}"`)
+    expect(out).toContain('target="_blank"')
+    expect(out).toContain('rel="noopener noreferrer"')
+    // The console's external-link affordance, so the row says where the name goes.
+    expect(out).toContain('lucide-external-link')
+  })
+
+  it('prints the name plainly when the row carries no link, and still prints the key', () => {
+    const out = html({ name: 'Engineering', channelKey: 'ENG' })
+    expect(out).not.toContain('<a')
+    expect(out).toContain('Engineering')
+    expect(out).toContain('>ENG<')
+  })
+
+  it('is the bare name where the platform gave neither', () => {
+    expect(html({ name: 'Engineering' })).toBe('<span class="min-w-0 truncate">Engineering</span>')
+  })
+})

--- a/packages/web/src/components/console/platforms/linear/team-name.tsx
+++ b/packages/web/src/components/console/platforms/linear/team-name.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+// How a team row prints its name ({@link WebChannelListSemantics.RowName}, §4.5): the team's
+// NAME, which opens the team in Linear, then its KEY in muted text. The key is an identifier
+// rather than a label, so it never entered the stored `<Workspace> / <Team>` string (§4.5) and
+// is not parsed back out of one — it rides the row as its own field, and so does the link.
+// Only the name is the anchor: the key sits beside it as plain text, so a reader can copy the
+// identifier without arming a navigation.
+
+import { Icon } from '@/components/ui'
+
+export function LinearTeamName({ name, channelKey, url }: { name: string; channelKey?: string; url?: string }) {
+  return (
+    <>
+      {url ? (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={`Open ${name} in Linear`}
+          // The row's own type and color, not a link's: this is the row's label, which happens
+          // to lead somewhere. The console's inline links read the same way (`GitlabCard`).
+          className="inline-flex min-w-0 items-center gap-[4px] text-inherit no-underline hover:underline"
+        >
+          <span className="min-w-0 truncate">{name}</span>
+          <Icon name="external-link" size={11} color="var(--text-tertiary)" className="flex-none" />
+        </a>
+      ) : (
+        // A workspace whose URL segment is not known yet still prints its name and its key.
+        <span className="min-w-0 truncate">{name}</span>
+      )}
+      {channelKey && <span className="mono flex-none text-(--text-tertiary)">{channelKey}</span>}
+    </>
+  )
+}

--- a/packages/web/src/components/console/views/IntegrationsView.linear-teams.test.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.linear-teams.test.tsx
@@ -90,6 +90,8 @@ const INSTALL: IntegrationRow = {
       name: 'Acme / Design',
       icon: '🎨',
       color: '#26B5CE',
+      key: 'DES',
+      url: 'https://linear.app/example-workspace/team/DES',
       kind: 'channel',
       trigger: 'off',
       agentId: 'agent-b'
@@ -99,6 +101,8 @@ const INSTALL: IntegrationRow = {
       name: 'Acme / Engineering',
       icon: 'Feather',
       color: '#5E6AD2',
+      key: 'ENG',
+      url: 'https://linear.app/example-workspace/team/ENG',
       kind: 'channel',
       trigger: 'mention',
       agentId: 'agent-a'
@@ -117,17 +121,24 @@ const pickers = (view: HTMLElement) => [...view.querySelectorAll<HTMLButtonEleme
 const menuItem = (label: string) =>
   [...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')].find((b) => b.textContent?.includes(label))
 
-/** Render, switch to the Linear tab, and expand the workspace's row. */
-async function expandWorkspace(): Promise<HTMLElement> {
+/** Render, switch to `tabLabel`'s platform, and expand that bot's row. */
+async function expandBot(tabLabel: string, botId: string): Promise<HTMLElement> {
   await act(async () => root.render(<IntegrationsView />))
-  const tab = [...host.querySelectorAll('button[role="tab"]')].find((b) => b.textContent?.includes('Linear'))
-  if (!tab) throw new Error('no Linear Bots tab')
+  const tab = [...host.querySelectorAll('button[role="tab"]')].find((b) => b.textContent?.includes(tabLabel))
+  if (!tab) throw new Error(`no ${tabLabel} Bots tab`)
   await act(async () => (tab as HTMLButtonElement).click())
-  const row = host.querySelector<HTMLElement>('#integration-bot-ws-1')
-  if (!row) throw new Error('no bot row for the workspace')
+  const row = host.querySelector<HTMLElement>(`#integration-bot-${botId}`)
+  if (!row) throw new Error(`no bot row for ${botId}`)
   await act(async () => row.click())
   return host
 }
+
+const expandWorkspace = (): Promise<HTMLElement> => expandBot('Linear', 'ws-1')
+
+/** The expanded roster's column header over the conversation rows. */
+const columnHeader = (view: HTMLElement): string | undefined =>
+  [...view.querySelectorAll('span')].find((el) => /^(Teams|Channels|Chats|Conversations?)$/.test(el.textContent ?? ''))
+    ?.textContent ?? undefined
 
 beforeEach(() => {
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -156,8 +167,7 @@ describe('the Linear workspace’s Bots row', () => {
     // Named the way an operator says it: the team alone, under the workspace's own row.
     expect(view.textContent).toContain('Design')
     expect(view.textContent).toContain('Engineering')
-    // Never the team KEY, and never the "#" of a platform whose rooms are channels.
-    expect(view.textContent).not.toContain('ENG')
+    // Never the "#" of a platform whose rooms are channels.
     expect(view.querySelector('.lucide-hash')).toBeNull()
     // Not the retired single line that stood for the whole workspace.
     expect(pickers(view)).toHaveLength(2)
@@ -174,6 +184,41 @@ describe('the Linear workspace’s Bots row', () => {
     expect(marks.map((el) => el.textContent)).toEqual(['🎨', 'E'])
     expect(marks[0]!.getAttribute('style')).toContain('#26B5CE')
     expect(marks[1]!.getAttribute('style')).toContain('#5E6AD2')
+  })
+
+  it('prints each team’s key after its name, and links the NAME to the team in Linear', async () => {
+    const view = await expandWorkspace()
+
+    const links = [...view.querySelectorAll('a')].filter((a) => a.getAttribute('href')?.includes('linear.app'))
+    expect(links.map((a) => a.textContent)).toEqual(['Design', 'Engineering'])
+    expect(links[1]!.getAttribute('href')).toBe('https://linear.app/example-workspace/team/ENG')
+    expect(links[1]!.getAttribute('rel')).toBe('noopener noreferrer')
+    // The key is muted text beside the link, never inside it and never inside the label.
+    const key = [...view.querySelectorAll('span')].filter((el) => el.textContent === 'ENG')
+    expect(key).toHaveLength(1)
+    expect(key[0]!.closest('a')).toBeNull()
+  })
+
+  it('heads the rows with Linear’s own noun, while Slack’s roster still reads Channels', async () => {
+    expect(columnHeader(await expandWorkspace())).toBe('Teams')
+
+    await act(async () => root.unmount())
+    host.remove()
+    host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+    mocks.bots = [{ ...WORKSPACE, id: 'sl-1', platform: 'slack', name: 'support', agentIds: ['agent-a'] }]
+    mocks.integrations = [
+      {
+        ...INSTALL,
+        id: 'int-slack',
+        botId: 'sl-1',
+        platform: 'slack',
+        channels: [{ channelId: 'C1', name: 'deploys', kind: 'channel', trigger: 'mention', agentId: 'agent-a' }]
+      }
+    ]
+
+    expect(columnHeader(await expandBot('Slack', 'sl-1'))).toBe('Channels')
   })
 
   it('drops the dispatch column when one agent is the only member', async () => {

--- a/packages/web/src/components/console/views/IntegrationsView.tsx
+++ b/packages/web/src/components/console/views/IntegrationsView.tsx
@@ -29,7 +29,7 @@ import {
   type MeDto
 } from '@/lib/api'
 import { agentLabel, isDirectConversation, type IntegrationRow } from '@/lib/data'
-import { roomGlyph, rowLabelParts, rowMark } from '@/components/console/IntegrationChannelList'
+import { roomGlyph, roomPlural, rowLabelParts, rowMark, rowName } from '@/components/console/IntegrationChannelList'
 import {
   botCardCopy,
   botSharingEditable,
@@ -96,6 +96,9 @@ interface BotChannelView {
   /** The conversation's own glyph and tint, where the platform gives it one (a Linear team). */
   icon?: string
   color?: string
+  /** Its handle and the page it opens on the platform, where it has them (a Linear team). */
+  key?: string
+  url?: string
   /** Effective per-conversation owner; null only before legacy state converges. */
   agentId: string | null
   /** Any integration whose snapshot row backs this channel; ownership PATCHes
@@ -119,6 +122,8 @@ function botChannels(bot: BotDto, integrations: IntegrationRow[]): BotChannelVie
           kind: c.kind ?? 'channel',
           ...(c.icon ? { icon: c.icon } : {}),
           ...(c.color ? { color: c.color } : {}),
+          ...(c.key ? { key: c.key } : {}),
+          ...(c.url ? { url: c.url } : {}),
           agentId: explicit,
           integrationId: i.id ?? null
         })
@@ -531,7 +536,9 @@ function BotsCard({
                       <div
                         className={`grid ${chanGrid} gap-[11px] px-3 pb-[7px] font-mono text-[10.5px] font-semibold uppercase leading-normal tracking-[0.08em] text-(--text-tertiary)`}
                       >
-                        <span>Conversation</span>
+                        {/* The platform's own noun for the room, not "conversation": these rows
+                            are a Linear workspace's teams and a Slack bot's channels. */}
+                        <span>{roomPlural(roomLabel)}</span>
                         {showDefaultDispatch && <span className="justify-self-end">Default dispatch</span>}
                       </div>
                       <div className="overflow-visible rounded-lg border border-(--border-subtle) bg-(--surface-card)">
@@ -545,6 +552,7 @@ function BotsCard({
                           // A platform that gives the conversation its own icon and tint draws that
                           // instead — a Linear team is told apart by its color, not by a room sigil.
                           const Mark = rowMark(c.kind, b.platform)
+                          const Name = rowName(c.kind, b.platform)
                           return (
                             <Fragment key={c.channelId}>
                               {isDirectConversation(c.kind) && !isDirectConversation(channels[index - 1]?.kind) && (
@@ -574,7 +582,11 @@ function BotsCard({
                                     :{' '}
                                   </span>
                                   <span className="flex min-w-0 items-baseline gap-[6px] truncate">
-                                    <span className="min-w-0 truncate">{label.name}</span>
+                                    {Name ? (
+                                      <Name name={label.name} channelKey={c.key} url={c.url} />
+                                    ) : (
+                                      <span className="min-w-0 truncate">{label.name}</span>
+                                    )}
                                     {label.hint && (
                                       <span className="flex-none text-(--text-tertiary)">{label.hint}</span>
                                     )}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -874,6 +874,8 @@ export interface IntegrationChannelDto {
   space: string | null // that server's display name; null elsewhere and until resolved
   icon: string | null // the conversation's own glyph — a Linear icon name or an emoji; null elsewhere
   color: string | null // that glyph's hex tint; null elsewhere
+  key: string | null // the conversation's short platform handle — a Linear team's "ENG"; null elsewhere
+  url: string | null // the page it opens on the platform; null elsewhere
   isPrivate: boolean
   kind: 'channel' | 'im' | 'mpim'
   trigger: ChannelTrigger

--- a/packages/web/src/lib/data-context.tsx
+++ b/packages/web/src/lib/data-context.tsx
@@ -343,6 +343,8 @@ function integrationRowFromDto(
       ...(c.space ? { space: c.space } : {}),
       ...(c.icon ? { icon: c.icon } : {}),
       ...(c.color ? { color: c.color } : {}),
+      ...(c.key ? { key: c.key } : {}),
+      ...(c.url ? { url: c.url } : {}),
       kind: c.kind,
       trigger: c.trigger,
       agentId: c.agentId

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1946,6 +1946,11 @@ export interface IntegrationChannelRow {
    *  draws a colored mark from the pair; absent on every platform without the notion. */
   icon?: string
   color?: string
+  /** The conversation's short platform handle and the page it opens there — a Linear team's
+   *  key, which the row prints after the name, and the team URL the name links to. Absent on
+   *  every platform without the notion. */
+  key?: string
+  url?: string
   /** 'im' = a DM conversation row, 'mpim' = a Slack group DM; absent = channel. */
   kind?: 'channel' | 'im' | 'mpim'
   trigger: 'off' | 'mention' | 'any'


### PR DESCRIPTION
A Linear team row read as a name and nothing else. An operator scanning a roster of
teams could not reach the team in Linear, and never saw the key every Linear identifier
is built from — `ENG-12` names a team the row did not spell.

The row now reads `Engineering ↗  ENG`: the **name** links to the team in Linear
(`https://linear.app/<workspace urlKey>/team/<KEY>`, new tab), and the **key** follows it
in muted text as plain, un-anchored text — a key beside a link is an identifier a reader
can take, while a key inside one is a second thing to click by accident. The team's
colored mark still leads the row.

The pair rides the conversation row as its own fields, end to end, on exactly the terms
the team glyph already rides on. They are FIELDS and not a richer label because the label
is one string two hosts write and a third takes apart — a reader that recovered the key by
parsing `Acme / Engineering ENG` would break the first time a team was named after its key.

## The four layers

- **protocol** — `IntegrationChannel` gains optional `key` (≤ 32 chars) and `url` (an
  `https` origin, ≤ 512), with `conversationLink` as `conversationGlyph`'s sibling, so
  every writer narrows THROUGH the contract rather than restating its bounds.
- **daemon** — both team reads carry `viewer { organization { urlKey } }`, and the
  connection remembers the answer beside `workspaceName`; that plus the key is the team's
  page. The read port, `ObservedChat` and the observed-channels sync carry the pair, and
  `noteLinearTeam`'s first-delivery fast path links a team off the event bag alone. A
  segment not learned yet leaves the row unlinked and still printing its key — half a link
  is not a link.
- **control plane** — nullable `integration_channel.key` / `.url`
  (`20260925000000_integration_channel_key_url`); one round trip fetches the URL segment
  beside `teams`, so the connect tail and the reconciler's team pass seed a linked row
  before any daemon reports, on the glyph's tri-state: an enumerating pass may clear what
  an observation may only add. The channel DTO declares as well as projects the pair.
- **web** — a seventh `RowName` on the channel-list contract, rendered by both hosts (the
  agent card's list and the org Bots roster). Absent on every other platform, whose rows
  are untouched; direct rows never take it.

## Two console conventions fixed alongside

A mark is per-platform; a CONTROL is not.

- The expanded bot roster's column header takes the platform's own noun, pluralised, so a
  Linear workspace heads its rows **Teams** where a Slack bot heads its **Channels**. It
  was the last place the host still said "Conversation" over rows the module had named.
- The per-conversation default-dispatch button leads with a **fixed** glyph and the current
  default's **name**, the way the trigger leads with a bell. It led with the current agent's
  avatar, so the control changed shape per agent and could read as whatever that mark
  happened to suggest — in one workspace it read as a lightning "trigger" toggle. The
  avatars stay in the menu, where they identify rows rather than the control.

## Tests

Mirroring #1742 at each layer: codec round-trip and the two refusals (over-long key,
non-`https` url); the daemon's team reads, the remembered segment, and the fast-path row;
the CP `teams` query, the seeded row, the refresh and the enumerating clear, plus the
tri-state against a real database and the DTO; and, in the console, the name component,
the `rowName` / `roomPlural` seams, both hosts' rendering, the header on Linear and Slack,
and the dispatch control's fixed glyph across two agents.

`docs/designs/linear-integration.md` §4.5 / §9.1 / §9.2 / §9.4 / §9.5 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
