### PR TITLE
fix(web): bound the default-dispatch name the way the agent-page picker does

### DIFF
--- a/packages/web/src/components/console/DefaultDispatchPicker.tsx
+++ b/packages/web/src/components/console/DefaultDispatchPicker.tsx
@@ -72,7 +72,9 @@ export function DefaultDispatchPicker({
                 agent's avatar, so the control changed shape per agent and read as whatever
                 that mark suggested. The avatars stay in the menu, where they identify rows. */}
             <Icon name={DISPATCH_ICON} size={13} color="var(--text-tertiary)" className="flex-none" />
-            <span className="mono text-[12.5px] text-(--text-primary)">{active?.name ?? '—'}</span>
+            <span className="mono max-w-[180px] truncate text-[12.5px] text-(--text-primary)">
+              {active?.name ?? '—'}
+            </span>
             <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
           </button>
         )}


### PR DESCRIPTION
## Why

Review on #1747 (non-blocking): the roster's default-dispatch control now prints the active agent's name, and it was the only active-name rendering without a width bound. Agent display names are free-form, and the control sits in the `auto` track of a `grid-cols-[1fr_auto]` row, so a long name could squeeze the conversation column.

## What

`DefaultDispatchPicker.tsx`: the name span gets the same `max-w-[180px] truncate` the agent-page picker in `IntegrationChannelList.tsx` already applies. Nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
