### PR TITLE
fix(web): put the ⚡ trigger and the avatar dispatch control back on every platform

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1707,14 +1707,13 @@ tile.
     column header is the platform's own noun, pluralised (`roomPlural` beside
     `roomArticle`), so a Linear workspace heads its rows **Teams** where a Slack
     bot heads its **Channels** — the header was the last place the host still
-    said "Conversation" over rows the module had already named. Two conventions
-    of the console at large were fixed here for the same reason a mark is
-    per-platform but a CONTROL is not: the per-conversation default-dispatch
-    button now leads with a FIXED glyph (`corner-down-right`, the console's word
-    for a hand-off) and the current default's NAME, the way the trigger leads
-    with a bell. It led with the current agent's avatar, so the control changed
-    shape per agent and could be read as whatever that mark suggested; the
-    avatars stay in the menu, where they identify rows rather than the control. Both surfaces drop the
+    said "Conversation" over rows the module had already named. The two
+    CONTROLS on a row are the console's own and identical on every platform: the
+    trigger leads with ⚡ and the default-dispatch button with the current
+    default's avatar and a chevron. Two detours were reverted here — a bell in
+    place of ⚡, argued from the glyph an agent's avatar might happen to use,
+    and a fixed hand-off glyph in place of the avatar — because a control's
+    shape is not derived from what any agent looks like. Both surfaces drop the
     per-team dispatch selector while the workspace has a single member — with
     one agent it names that agent and offers nothing to pick. The session list
     needed nothing: it already buckets by the session's channel, which is the

--- a/packages/web/src/components/console/DefaultDispatchPicker.tsx
+++ b/packages/web/src/components/console/DefaultDispatchPicker.tsx
@@ -22,11 +22,6 @@ export interface DefaultDispatchOption {
   icon?: AgentIcon | null
 }
 
-/** The default-dispatch control's own glyph — FIXED, so the control has one shape wherever it
- *  appears, the way the trigger's bell does. "Leads to" is already this console's word for a
- *  hand-off. Shared with the agent page's own per-conversation picker. */
-export const DISPATCH_ICON = 'corner-down-right'
-
 const MENU_WIDTH = 240
 const MENU_HEADER_HEIGHT = 34
 const MENU_ROW_HEIGHT = 34
@@ -68,10 +63,9 @@ export function DefaultDispatchPicker({
               disabled ? 'cursor-default' : 'cursor-pointer'
             } ${saving ? 'opacity-60' : ''}`}
           >
-            {/* A FIXED glyph, the way the trigger's bell is: the trigger used the active
-                agent's avatar, so the control changed shape per agent and read as whatever
-                that mark suggested. The avatars stay in the menu, where they identify rows. */}
-            <Icon name={DISPATCH_ICON} size={13} color="var(--text-tertiary)" className="flex-none" />
+            <span className="av h-5 w-5 rounded-[5px]">
+              <AgentIconView icon={active?.icon} runtime={active?.runtime ?? ''} size={20} />
+            </span>
             <span className="mono max-w-[180px] truncate text-[12.5px] text-(--text-primary)">
               {active?.name ?? '—'}
             </span>

--- a/packages/web/src/components/console/IntegrationChannelList.test.ts
+++ b/packages/web/src/components/console/IntegrationChannelList.test.ts
@@ -361,9 +361,7 @@ describe('IntegrationChannelList private-agent banner', () => {
 })
 
 describe('IntegrationChannelList trigger control', () => {
-  it('does not repeat the lightning glyph an agent avatar may already carry', () => {
-    // `zap` is one of the agent icon glyphs, so a row whose dispatch avatar is a bolt read
-    // as two of one control. The trigger keeps a neutral bell and its own label.
+  it('leads with ⚡ on every platform — the console’s one trigger glyph', () => {
     const html = renderToStaticMarkup(
       createElement(IntegrationChannelList, {
         platform: 'slack',
@@ -371,8 +369,8 @@ describe('IntegrationChannelList trigger control', () => {
         channels: [{ channelId: 'C1', name: 'deploys', kind: 'channel', trigger: 'mention' }]
       })
     )
-    expect(html).toContain('lucide-bell')
-    expect(html).not.toContain('lucide-zap')
+    expect(html).toContain('lucide-zap')
+    expect(html).not.toContain('lucide-bell')
   })
 })
 
@@ -498,16 +496,15 @@ describe('IntegrationChannelList default dispatch control', () => {
       })
     )
 
-  it('reads as a FIXED glyph plus the current default’s NAME, on every agent', () => {
-    const alice = render('alice')
-    const bob = render('bob')
-    for (const html of [alice, bob]) expect(html).toContain('lucide-corner-down-right')
-    expect(alice).toContain('>Alice</span>')
-    expect(bob).toContain('>Bob</span>')
+  it('leads with the current default’s avatar and a chevron, the way every platform’s does', () => {
+    for (const html of [render('alice'), render('bob')]) {
+      expect(html).not.toContain('lucide-corner-down-right')
+      expect(html).toContain('lucide-chevron-down')
+    }
   })
 
-  it('prints the name on the desktop row too, rather than hiding it behind a mark', () => {
-    expect(render('alice')).not.toContain('desktop:hidden')
+  it('names the default only on the mobile row, where a bare mark says nothing', () => {
+    expect(render('alice')).toContain('desktop:hidden')
   })
 })
 

--- a/packages/web/src/components/console/IntegrationChannelList.tsx
+++ b/packages/web/src/components/console/IntegrationChannelList.tsx
@@ -5,7 +5,6 @@ import { createPortal } from 'react-dom'
 import { agentLabel, isDirectConversation, type IntegrationChannelRow, type IntegrationRow } from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import { Icon } from '@/components/ui'
-import { DISPATCH_ICON } from '@/components/console/DefaultDispatchPicker'
 import { AgentIconView } from '@/components/marks'
 import { channelListSemantics } from '@/components/console/platforms/registry'
 import { TriggerSelect, type TriggerOption } from '@/components/console/TriggerSelect'
@@ -414,12 +413,10 @@ export function conversationOwners(botId: string, integrations: IntegrationRow[]
  *  routing rules don't hand to someone else.
  *
  *  The design keeps this strictly apart from the trigger toggle (the two are separate
- *  controls, never merged) — a fixed control glyph, the current default's NAME and a chevron,
- *  whose popover READS that default and offers exactly one action, claiming the channel
- *  for the agent whose page this is. The glyph is FIXED, the way the trigger's bell is: an
- *  avatar there varied per agent, so the control had no stable shape to recognise, and one
- *  agent's mark could read as a different control entirely. Handing a conversation to some
- *  third agent stays in Settings → Bots, where the whole roster is in view. */
+ *  controls, never merged) — a compact avatar + chevron whose popover
+ *  READS the current default and offers exactly one action, claiming the channel
+ *  for the agent whose page this is. Handing a conversation to some third agent stays
+ *  in Settings → Bots, where the whole roster is in view. */
 function DefaultAgentPicker({
   current,
   viewer,
@@ -479,8 +476,13 @@ function DefaultAgentPicker({
           saving ? 'opacity-60' : ''
         }`}
       >
-        <Icon name={DISPATCH_ICON} size={13} color="var(--text-tertiary)" className="flex-none" />
-        <span className="mono max-w-[180px] truncate text-[12px] text-(--text-tertiary)">{current.label}</span>
+        <span className="av h-[22px] w-[22px] rounded-[6px]">
+          <AgentIconView icon={current.icon} runtime={current.runtime} size={22} />
+        </span>
+        {/* The desktop row reads the avatar in context; the mobile row breaks it onto its own line, so it is named there. */}
+        <span className="mono max-w-[180px] truncate text-[12px] text-(--text-tertiary) desktop:hidden">
+          {current.label}
+        </span>
         <Icon name="chevron-down" size={13} color="var(--text-tertiary)" />
       </button>
       {box &&

--- a/packages/web/src/components/console/TriggerSelect.tsx
+++ b/packages/web/src/components/console/TriggerSelect.tsx
@@ -11,7 +11,7 @@ export interface TriggerOption<T extends string> {
 }
 
 /**
- * The bell + dropdown that says when an agent runs here — one control for every trigger surface
+ * The ⚡ + dropdown that says when an agent runs here — one control for every trigger surface
  * (conversations, watched repositories, watched projects), because they are one decision worded
  * per platform. It states the current choice and keeps the rest behind a menu, so a row that also
  * carries event pills doesn't read as one long bar of segments.
@@ -34,7 +34,7 @@ export function TriggerSelect<T extends string>({
   onChange: (value: T) => void
   /** Names the control for assistive tech — "Trigger for #deploys". */
   ariaLabel: string
-  /** What the glyph means on this surface, in this platform's nouns. */
+  /** What ⚡ means on this surface, in this platform's nouns. */
   hint: string
   /** Demo rows (no live integration) render the control inert. */
   disabled?: boolean
@@ -48,7 +48,7 @@ export function TriggerSelect<T extends string>({
   return (
     <span className={`inline-flex items-center gap-[7px] ${className}`}>
       <span title={hint} className="flex-none leading-none">
-        <Icon name="bell" size={14} color="var(--text-tertiary)" />
+        <Icon name="zap" size={14} color="var(--text-tertiary)" />
       </span>
       <AnchoredFlyout
         ariaLabel={ariaLabel}


### PR DESCRIPTION
## Why

Two row controls drifted away from what every platform had, and both drifts were argued from the wrong thing:

- #1727 swapped the trigger's ⚡ for a bell because ⚡ is also one of the glyphs an agent avatar can use.
- #1747 replaced the default-dispatch button's avatar + chevron with a fixed hand-off glyph plus the agent's name.

A control's shape is the console's own. It does not derive from what any agent happens to look like, and it is the same on every platform.

## What

- `TriggerSelect.tsx`: ⚡ (`zap`) again.
- `DefaultDispatchPicker.tsx` (org roster) and `IntegrationChannelList.tsx` (agent page): the current default's avatar and a chevron again; the agent page names the default only on the mobile row, as before. `DISPATCH_ICON` is gone.
- Tests assert ⚡ and the avatar-led control; the design doc's §9 note records the reversal.

Nothing else from #1747 changes: the team name link, the muted key, the **Teams** header and the single-member collapse stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
