### PR TITLE
feat(web): fold the facts behind a delivery bubble under "more"

### DIFF
--- a/docs/designs/integration-plugin-architecture.md
+++ b/docs/designs/integration-plugin-architecture.md
@@ -714,6 +714,7 @@ interface WebPlatformModule {
   settingsFragments?: { botCard?; lifecycleActions? }
   apiBindings: { ... }                   // typed CP client calls
   textRenderer?: (text, ctx) => ReactNode
+  turnFacts?: ComponentType<{ body: UserTurnBody }> // the facts a delivery bubble folds behind "more"
   Mark: ComponentType                    // inline SVG
 }
 

--- a/docs/designs/transcript-full-tool-body.md
+++ b/docs/designs/transcript-full-tool-body.md
@@ -285,8 +285,12 @@ The Linear and code-host strategies put the console's short form on the row's
 naming what happened (`Delegated ENG-3 · title`, `Opened PR #42 · title`) —
 and the assembled prompt on `prompt`, so the model reads exactly what it did
 before while the bubble shows what a person would say. A turn without a body
-still has its text as its prompt. The remaining step is the console: the facts
-fold behind a "more" control with one formatter per platform.
+still has its text as its prompt. The console folds the facts behind a bare
+"more" under the bubble text (`UserTurnDetails`): a Linear row renders its
+module's `turnFacts` formatter (issue, team, delegator, the description as the
+markdown it is), a code-host row the host's own (subject, author, revision,
+how it is answered, the body), and a body no formatter claims stays the plain
+bubble. The prompt is never rendered — it is the model's, not the reader's.
 
 ## 10. Compatibility
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -35,6 +35,12 @@
       "types": "./dist/frames/runtime-command.d.ts",
       "import": "./dist/frames/runtime-command.js",
       "default": "./dist/frames/runtime-command.js"
+    },
+    "./user-turn-body": {
+      "development": "./src/user-turn-body.ts",
+      "types": "./dist/user-turn-body.d.ts",
+      "import": "./dist/user-turn-body.js",
+      "default": "./dist/user-turn-body.js"
     }
   },
   "main": "dist/index.js",

--- a/packages/protocol/src/frames/session.ts
+++ b/packages/protocol/src/frames/session.ts
@@ -99,64 +99,9 @@ export type ToolBody = z.infer<typeof ToolBody>
 export const PlanBody = z.object({ entries: z.array(PlanEntry) })
 export type PlanBody = z.infer<typeof PlanBody>
 
-/** The Linear facts behind one delegated or prompted turn — what the console formats, never instructions. */
-export const LinearTurnFacts = z.object({
-  event: z.enum(['created', 'prompted']).optional(),
-  issue: z.object({
-    identifier: z.string().optional(),
-    id: z.string().optional(),
-    title: z.string().optional(),
-    url: z.string().optional()
-  }),
-  team: z.object({ id: z.string().optional(), key: z.string().optional(), name: z.string().optional() }).optional(),
-  delegatedBy: z.string().optional(),
-  /** The issue as Linear formatted it for the agent (`promptContext`), verbatim. */
-  description: z.string().optional(),
-  comments: z
-    .array(z.object({ userId: z.string().optional(), body: z.string().optional(), createdAt: z.string().optional() }))
-    .optional(),
-  guidance: z.string().optional(),
-  truncated: z.boolean().optional()
-})
-export type LinearTurnFacts = z.infer<typeof LinearTurnFacts>
-
-/** The code-host facts behind one GitHub or GitLab delivery turn. */
-export const CodehostTurnFacts = z.object({
-  provider: z.enum(['github', 'gitlab']),
-  event: z.string(),
-  action: z.string().optional(),
-  subject: z.object({
-    kind: z.string().optional(), // issue | pull_request | merge_request | push
-    repo: z.string().optional(),
-    number: z.number().int().optional(),
-    title: z.string().optional(),
-    url: z.string().optional()
-  }),
-  author: z.object({ login: z.string().optional(), association: z.string().optional() }).optional(),
-  labels: z.array(z.string()).optional(),
-  revision: z.object({ base: z.string().optional(), head: z.string().optional() }).optional(),
-  draft: z.boolean().optional(),
-  ref: z.string().optional(),
-  /** The event body as delivered (an issue/PR description or a comment), already relay-bounded. */
-  body: z.string().optional(),
-  truncated: z.boolean().optional(),
-  /** How this delivery is answered: a formal review generation, an inline review thread, or a plain reply. */
-  review: z.enum(['generation', 'inline', 'conversation']).optional()
-})
-export type CodehostTurnFacts = z.infer<typeof CodehostTurnFacts>
-
-/**
- * What lies behind one user-turn `text` row, transported as a JSON STRING in `SessionMessage.body`.
- * `prompt` is the text the model actually received when it differs from the row's `text` (replay
- * reads it); the platform facts are what the console renders behind the bubble. Absent on rows
- * from before it existed and on turns whose prompt IS the text.
- */
-export const UserTurnBody = z.object({
-  prompt: z.string().optional(),
-  linear: LinearTurnFacts.optional(),
-  codehost: CodehostTurnFacts.optional()
-})
-export type UserTurnBody = z.infer<typeof UserTurnBody>
+// The user-turn body schemas live in a bundler-safe leaf (the console validates with them);
+// re-exported here so every wire consumer keeps finding them beside the tool and plan bodies.
+export { CodehostTurnFacts, LinearTurnFacts, UserTurnBody } from '../user-turn-body.js'
 
 /** One bounded webchat image persisted only in the daemon-local transcript. */
 export const SessionImageAttachment = WebchatImageAttachment

--- a/packages/protocol/src/user-turn-body.ts
+++ b/packages/protocol/src/user-turn-body.ts
@@ -1,0 +1,61 @@
+// ⚠️ NO RELATIVE IMPORTS — a bundler compiles this from source; web's protocol-imports.leaf.test.ts enforces it.
+import { z } from 'zod'
+
+/** The Linear facts behind one delegated or prompted turn — what the console formats, never instructions. */
+export const LinearTurnFacts = z.object({
+  event: z.enum(['created', 'prompted']).optional(),
+  issue: z.object({
+    identifier: z.string().optional(),
+    id: z.string().optional(),
+    title: z.string().optional(),
+    url: z.string().optional()
+  }),
+  team: z.object({ id: z.string().optional(), key: z.string().optional(), name: z.string().optional() }).optional(),
+  delegatedBy: z.string().optional(),
+  /** The issue as Linear formatted it for the agent (`promptContext`), verbatim. */
+  description: z.string().optional(),
+  comments: z
+    .array(z.object({ userId: z.string().optional(), body: z.string().optional(), createdAt: z.string().optional() }))
+    .optional(),
+  guidance: z.string().optional(),
+  truncated: z.boolean().optional()
+})
+export type LinearTurnFacts = z.infer<typeof LinearTurnFacts>
+
+/** The code-host facts behind one GitHub or GitLab delivery turn. */
+export const CodehostTurnFacts = z.object({
+  provider: z.enum(['github', 'gitlab']),
+  event: z.string(),
+  action: z.string().optional(),
+  subject: z.object({
+    kind: z.string().optional(), // issue | pull_request | merge_request | push
+    repo: z.string().optional(),
+    number: z.number().int().optional(),
+    title: z.string().optional(),
+    url: z.string().optional()
+  }),
+  author: z.object({ login: z.string().optional(), association: z.string().optional() }).optional(),
+  labels: z.array(z.string()).optional(),
+  revision: z.object({ base: z.string().optional(), head: z.string().optional() }).optional(),
+  draft: z.boolean().optional(),
+  ref: z.string().optional(),
+  /** The event body as delivered (an issue/PR description or a comment), already relay-bounded. */
+  body: z.string().optional(),
+  truncated: z.boolean().optional(),
+  /** How this delivery is answered: a formal review generation, an inline review thread, or a plain reply. */
+  review: z.enum(['generation', 'inline', 'conversation']).optional()
+})
+export type CodehostTurnFacts = z.infer<typeof CodehostTurnFacts>
+
+/**
+ * What lies behind one user-turn `text` row, transported as a JSON STRING in `SessionMessage.body`.
+ * `prompt` is the text the model actually received when it differs from the row's `text` (replay
+ * reads it); the platform facts are what the console renders behind the bubble. Absent on rows
+ * from before it existed and on turns whose prompt IS the text.
+ */
+export const UserTurnBody = z.object({
+  prompt: z.string().optional(),
+  linear: LinearTurnFacts.optional(),
+  codehost: CodehostTurnFacts.optional()
+})
+export type UserTurnBody = z.infer<typeof UserTurnBody>

--- a/packages/web/src/components/console/MessageText.tsx
+++ b/packages/web/src/components/console/MessageText.tsx
@@ -84,6 +84,37 @@ export const SlackMrkdwnText: ComponentType<{ text: string }> = function SlackMr
   )
 }
 
+/** CommonMark as written — a GitHub or GitLab body — with the same link policy and the same
+ *  `.mdtxt` styling, and none of the Slack control-syntax normalization the default applies. */
+export const MarkdownText: ComponentType<{ text: string }> = function MarkdownText({ text }) {
+  if (text.length > MAX_PARSE) {
+    return (
+      <div className="mdtxt">
+        <p className="whitespace-pre-wrap">{text}</p>
+      </div>
+    )
+  }
+  return (
+    <div className="mdtxt">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a: ({ children, node: _node, ...props }) =>
+            WEB_HREF.test(props.href ?? '') ? (
+              <a {...props} target="_blank" rel="noopener noreferrer">
+                {children}
+              </a>
+            ) : (
+              <>{children}</>
+            )
+        }}
+      >
+        {text}
+      </ReactMarkdown>
+    </div>
+  )
+}
+
 // memo: the transcript re-renders on every unrelated state change in
 // SessionDetailView (composer keystrokes, the 1s duration tick, expanding one turn's
 // work), and without this EVERY row re-runs the resolved renderer's whole pipeline.

--- a/packages/web/src/components/console/UserTurnDetails.test.tsx
+++ b/packages/web/src/components/console/UserTurnDetails.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+// The fold under a delivery bubble: a bare "more", and under it the facts — formatted, never the
+// prompt. A code-host body renders through the host's own formatter; a Linear body through the
+// module's; a body no formatter claims renders nothing at all.
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { UserTurnBody } from '@agentconnect.md/protocol'
+import { UserTurnDetails } from './UserTurnDetails'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+async function render(node: React.ReactNode) {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(node)
+  })
+  return host
+}
+
+async function click(el: Element) {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  host?.remove()
+})
+
+const codehost: UserTurnBody = {
+  codehost: {
+    provider: 'github',
+    event: 'pull_request:opened',
+    action: 'opened',
+    subject: {
+      kind: 'pull_request',
+      repo: 'acme/infra',
+      number: 42,
+      title: 'fix relay',
+      url: 'https://github.com/acme/infra/pull/42'
+    },
+    author: { login: 'zfy', association: 'CONTRIBUTOR' },
+    revision: { base: 'b'.repeat(40), head: 'a'.repeat(40) },
+    draft: false,
+    review: 'generation',
+    body: '## Why\n\nEvery follow-up was dropped.'
+  }
+}
+
+describe('UserTurnDetails', () => {
+  it('folds a code-host body behind "more" and shows the facts, not the prompt, on demand', async () => {
+    const el = await render(<UserTurnDetails body={{ ...codehost, prompt: 'THE PROMPT' }} platform="hook" />)
+    const toggle = el.querySelector('button')!
+    expect(toggle.textContent).toBe('more')
+    expect(el.textContent).not.toContain('zfy')
+    await click(toggle)
+    expect(toggle.textContent).toBe('less')
+    const text = el.textContent ?? ''
+    expect(text).toContain('acme/infra · #42')
+    expect(text).toContain('zfy · contributor')
+    expect(text).toContain('bbbbbbb → aaaaaaa')
+    expect(text).toContain('requested for this revision')
+    expect(text).toContain('Every follow-up was dropped.')
+    expect(text).not.toContain('THE PROMPT')
+    expect(text).not.toContain('Draft')
+    expect(el.querySelector('a.lnk')?.getAttribute('href')).toBe('https://github.com/acme/infra/pull/42')
+    await click(toggle)
+    expect(el.textContent).not.toContain('zfy')
+  })
+
+  it('renders the Linear module’s formatter for a Linear row', async () => {
+    const body: UserTurnBody = {
+      linear: {
+        issue: { identifier: 'ENG-3', title: 'investigate', url: 'https://linear.app/example/issue/ENG-3/investigate' },
+        team: { key: 'ENG', name: 'Engineering' },
+        delegatedBy: 'Fuyao Zhao',
+        description:
+          '<issue identifier="ENG-3"><title>investigate</title><description>Look at **the repo**.</description></issue>'
+      }
+    }
+    const el = await render(<UserTurnDetails body={body} platform="linear" />)
+    await click(el.querySelector('button')!)
+    const text = el.textContent ?? ''
+    expect(text).toContain('ENG-3 · investigate')
+    expect(text).toContain('Engineering (ENG)')
+    expect(text).toContain('Fuyao Zhao')
+    expect(text).toContain('Look at the repo.')
+    expect(text).not.toContain('<description>')
+  })
+
+  it('renders nothing when no formatter claims the body', async () => {
+    const el = await render(<UserTurnDetails body={{ linear: { issue: { identifier: 'ENG-1' } } }} platform="slack" />)
+    expect(el.querySelector('[data-turn-details]')).toBeNull()
+  })
+})

--- a/packages/web/src/components/console/UserTurnDetails.tsx
+++ b/packages/web/src/components/console/UserTurnDetails.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+// What a delivery bubble folds behind "more": the facts the daemon read the turn from
+// (transcript-full-tool-body.md §9), formatted per platform. The bubble's text is what the
+// person said; this is where it came from. A Linear row resolves its module's formatter
+// through the registry; a code-host row uses the host's own, since GitHub and GitLab are
+// not platform modules. The raw prompt is never shown — it is the model's, not the reader's.
+
+import { useState, type ComponentType } from 'react'
+import type { CodehostTurnFacts as CodehostFacts, UserTurnBody } from '@agentconnect.md/protocol'
+import { shortSha } from '@/lib/user-turn-body'
+import { MarkdownText } from './MessageText'
+import { platformTurnFacts } from './platforms/registry'
+import { FactRow, FactRows } from './turn-facts-rows'
+
+/** How a code-host delivery is answered, as a person would say it. */
+const REVIEW_LABEL: Record<NonNullable<CodehostFacts['review']>, string> = {
+  generation: 'requested for this revision',
+  inline: 'reply in an inline review thread',
+  conversation: 'reply in the conversation'
+}
+
+/** GitHub and GitLab share one shape: who, which revision, how it is answered, then the body. */
+export function CodehostTurnFacts({ facts }: { facts: CodehostFacts }) {
+  const { author, revision, subject } = facts
+  const from = author?.login
+    ? `${author.login}${author.association ? ` · ${author.association.toLowerCase()}` : ''}`
+    : ''
+  const revisionText =
+    revision?.base && revision.head
+      ? `${shortSha(revision.base)} → ${shortSha(revision.head)}`
+      : revision?.head
+        ? shortSha(revision.head)
+        : ''
+  return (
+    <>
+      <FactRows>
+        <FactRow label="Subject">
+          {subject.url ? (
+            <a className="lnk" href={subject.url} target="_blank" rel="noopener noreferrer">
+              {subject.repo ?? subject.url}
+              {subject.number !== undefined ? ` · #${subject.number}` : ''}
+            </a>
+          ) : (
+            [subject.repo, subject.number !== undefined ? `#${subject.number}` : ''].filter(Boolean).join(' · ')
+          )}
+        </FactRow>
+        <FactRow label="Event">{facts.event}</FactRow>
+        <FactRow label="From">{from}</FactRow>
+        <FactRow label="Revision">
+          {revisionText ? <span className="font-mono text-[11.5px]">{revisionText}</span> : ''}
+        </FactRow>
+        <FactRow label="Ref">{facts.ref ?? ''}</FactRow>
+        <FactRow label="Draft">{facts.draft === true ? 'yes' : ''}</FactRow>
+        <FactRow label="Labels">{facts.labels?.length ? facts.labels.join(', ') : ''}</FactRow>
+        <FactRow label="Review">{facts.review ? REVIEW_LABEL[facts.review] : ''}</FactRow>
+      </FactRows>
+      {facts.body && (
+        <div className="mt-2">
+          <MarkdownText text={facts.body} />
+          {facts.truncated && (
+            <p className="mt-1 font-sans text-[11.5px] leading-normal text-(--text-tertiary)">
+              Body truncated by the relay.
+            </p>
+          )}
+        </div>
+      )}
+    </>
+  )
+}
+
+/** The formatter for this body, if any: the platform module's own, else the host's code-host one. */
+function factsRenderer(body: UserTurnBody, platform?: string): ComponentType<{ body: UserTurnBody }> | undefined {
+  const own = platformTurnFacts(platform)
+  if (own) return own
+  if (body.codehost) return CodehostFold
+  return undefined
+}
+
+function CodehostFold({ body }: { body: UserTurnBody }) {
+  return body.codehost ? <CodehostTurnFacts facts={body.codehost} /> : null
+}
+
+/**
+ * The fold itself: a bare "more" under the bubble text, and under it — on demand — the facts.
+ * Collapsed by default, per bubble, remembered only while the row is mounted. Renders nothing
+ * when no formatter claims the body, so a row from a platform with facts but no formatter
+ * stays exactly the bubble it was.
+ */
+export function UserTurnDetails({ body, platform }: { body: UserTurnBody; platform?: string }) {
+  const [open, setOpen] = useState(false)
+  const Facts = factsRenderer(body, platform)
+  if (!Facts) return null
+  return (
+    <div data-turn-details>
+      <button
+        type="button"
+        className="mt-[6px] cursor-pointer font-sans text-[12px] font-normal leading-normal text-(--text-tertiary) hover:text-(--text-secondary)"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {open ? 'less' : 'more'}
+      </button>
+      {open && (
+        <div className="mt-[10px] border-t border-(--border-subtle) pt-[10px]">
+          <Facts body={body} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/platforms/contract.ts
+++ b/packages/web/src/components/console/platforms/contract.ts
@@ -92,6 +92,7 @@
  * directories is exactly why D1 keeps modules in this tree (see
  * packages/web/STYLE.md).
  */
+import type { UserTurnBody } from '@agentconnect.md/protocol'
 import type { ComponentType, ReactNode } from 'react'
 import type { BotDto, CreateIntegrationInput, SessionMessageDto } from '@/lib/api'
 import type { Agent, IntegrationRow } from '@/lib/data'
@@ -756,6 +757,18 @@ export interface WebPlatformModule<TApi = unknown> {
    * call site has a `ctx` to pass.
    */
   textRenderer?: ComponentType<{ text: string }>
+  /**
+   * The formatter for the facts behind one of this platform's user turns
+   * (`UserTurnBody`, transcript-full-tool-body.md §9): what the console shows
+   * under a delivery bubble's "more" — the issue, the team, the delegator,
+   * the description — as a structured block rather than the raw prompt. The
+   * host (`UserTurnDetails`) resolves it from the row's platform through
+   * `platformTurnFacts` and mounts it under the divider; absent ⇒ the fold
+   * offers nothing for this platform's rows, which is every chat platform,
+   * whose rows carry no body at all. GitHub and GitLab are not modules, so
+   * their formatter is the host's own, keyed by `body.codehost`.
+   */
+  turnFacts?: ComponentType<{ body: UserTurnBody }>
   /**
    * Provider-native duplicate identity of one transcript row — the
    * per-platform arms of the merged-conversation dedupe (Slack decimal ts,

--- a/packages/web/src/components/console/platforms/linear/index.tsx
+++ b/packages/web/src/components/console/platforms/linear/index.tsx
@@ -9,6 +9,7 @@ import { LinearMark } from './mark'
 import { LinearTeamGlyph } from './team-glyph'
 import { LinearTeamName } from './team-name'
 import { linearSettingsFragments } from './settings'
+import { LinearTurnFacts } from './turn-facts'
 
 /** Linear's provider-native activity id: a v4 UUID. A daemon-local numeric stamp
  *  can never match it, and neither can any other platform's id shape. */
@@ -47,6 +48,8 @@ export const linearModule: WebPlatformModule<LinearApi> = {
   },
   settingsFragments: linearSettingsFragments,
   apiBindings: linearApi,
+  // What a delegation bubble folds behind "more": the issue, the team, the delegator, the description.
+  turnFacts: LinearTurnFacts,
   // The TEAM is the channel (§4.3): one row per team, each with its dispatch default and an Off.
   // The roster is the workspace's own, so nothing is left or dropped from here — a team goes
   // quiet by turning its row Off, or the whole workspace by unlinking the agent.

--- a/packages/web/src/components/console/platforms/linear/module.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/module.test.tsx
@@ -10,6 +10,7 @@ import { sessionChannelFilterValue } from '@/lib/data'
 import { PLATFORM_MARK_IDS } from '../marks'
 import { BOT_PLATFORMS, INTEGRATION_BLURB, isCoreTriggerKind } from '../host-projections'
 import {
+  platformTurnFacts,
   DEFAULT_CHANNEL_LIST,
   botSharingEditable,
   channelListSemantics,
@@ -95,6 +96,12 @@ describe('the linear transcript and card semantics', () => {
     const body = warning!.body({ owner: 'triage-bot', room: 'Acme / Engineering' })
     expect(body).toContain('triage-bot is a private agent')
     expect(body).toContain('can still be stopped, but it will not answer in them again')
+  })
+
+  it('formats the facts behind a delegation bubble, and is resolvable from the row’s platform', () => {
+    expect(linearModule.turnFacts).toBeDefined()
+    expect(platformTurnFacts('linear')).toBe(linearModule.turnFacts)
+    expect(platformTurnFacts('slack')).toBeUndefined()
   })
 
   it('wraps that list in its own card body, and is the only module that does', () => {

--- a/packages/web/src/components/console/platforms/linear/turn-facts.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/turn-facts.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { LinearTurnFacts } from './turn-facts'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let root: Root | undefined
+let host: HTMLDivElement | undefined
+
+async function render(node: React.ReactNode) {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(node)
+  })
+  return host
+}
+
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  host?.remove()
+})
+
+describe('LinearTurnFacts', () => {
+  it('prints the issue, the team and the delegator, and the description as markdown', async () => {
+    const el = await render(
+      <LinearTurnFacts
+        body={{
+          linear: {
+            event: 'created',
+            issue: { identifier: 'ENG-3', title: 'investigate', url: 'https://linear.app/example/issue/ENG-3/x' },
+            team: { key: 'ENG', name: 'Engineering' },
+            delegatedBy: 'Dana',
+            description: '<issue><description>Read the &lt;README&gt;.</description></issue>',
+            comments: [{ userId: 'user-9', body: 'earlier note' }],
+            guidance: 'Be terse.',
+            truncated: true
+          }
+        }}
+      />
+    )
+    const text = el.textContent ?? ''
+    for (const expected of [
+      'ENG-3 · investigate',
+      'Engineering (ENG)',
+      'Dana',
+      'Read the <README>.',
+      'earlier note',
+      'Be terse.',
+      'Context truncated'
+    ])
+      expect(text).toContain(expected)
+    expect(text).not.toContain('<description>')
+    expect(el.querySelector('a.lnk')?.getAttribute('href')).toBe('https://linear.app/example/issue/ENG-3/x')
+  })
+
+  it('omits what the delivery did not carry, and shows an unshaped context whole', async () => {
+    const el = await render(
+      <LinearTurnFacts body={{ linear: { issue: { identifier: 'ENG-1' }, description: 'plain words' } }} />
+    )
+    const text = el.textContent ?? ''
+    expect(text).toContain('ENG-1')
+    expect(text).toContain('plain words')
+    for (const absent of ['Team', 'Delegated by', 'Earlier comments', 'Workspace guidance'])
+      expect(text).not.toContain(absent)
+    expect(el.querySelector('pre')).not.toBeNull()
+  })
+
+  it('renders nothing for a body without Linear facts', async () => {
+    const el = await render(<LinearTurnFacts body={{}} />)
+    expect(el.textContent).toBe('')
+  })
+})

--- a/packages/web/src/components/console/platforms/linear/turn-facts.tsx
+++ b/packages/web/src/components/console/platforms/linear/turn-facts.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+// The facts behind a Linear delivery ({@link WebPlatformModule.turnFacts}): the issue, its team,
+// who delegated it, and the description Linear handed the agent — rendered as the markdown it
+// is, never as the XML-shaped context the prompt carries. Earlier comments and workspace
+// guidance follow when the delivery had them.
+
+import type { UserTurnBody } from '@agentconnect.md/protocol'
+import { linearDescriptionMarkdown } from '@/lib/user-turn-body'
+import { MarkdownText } from '../../MessageText'
+import { FactRow, FactRows } from '../../turn-facts-rows'
+
+export function LinearTurnFacts({ body }: { body: UserTurnBody }) {
+  const facts = body.linear
+  if (!facts) return null
+  const { issue, team } = facts
+  const issueLabel = [issue.identifier, issue.title].filter(Boolean).join(' · ')
+  const teamLabel = team?.name ? `${team.name}${team.key ? ` (${team.key})` : ''}` : (team?.key ?? '')
+  const description = facts.description ? linearDescriptionMarkdown(facts.description) : undefined
+  return (
+    <>
+      <FactRows>
+        <FactRow label="Issue">
+          {issue.url ? (
+            <a className="lnk" href={issue.url} target="_blank" rel="noopener noreferrer">
+              {issueLabel || issue.url}
+            </a>
+          ) : (
+            issueLabel
+          )}
+        </FactRow>
+        <FactRow label="Team">{teamLabel}</FactRow>
+        <FactRow label="Delegated by">{facts.delegatedBy ?? ''}</FactRow>
+      </FactRows>
+      {description && (
+        <div className="mt-2">
+          <p className="mb-[2px] font-sans text-[12px] leading-[1.6] text-(--text-tertiary)">Description</p>
+          {description.parsed ? (
+            <MarkdownText text={description.markdown || '_(empty)_'} />
+          ) : (
+            <pre className="whitespace-pre-wrap break-words font-mono text-[11.5px] leading-[1.5] text-(--text-primary)">
+              {description.markdown}
+            </pre>
+          )}
+        </div>
+      )}
+      {facts.comments?.length ? (
+        <div className="mt-2">
+          <p className="mb-[2px] font-sans text-[12px] leading-[1.6] text-(--text-tertiary)">Earlier comments</p>
+          {facts.comments.map((comment, index) => (
+            <div key={index} className="mt-1 border-l-2 border-(--border-subtle) pl-2 [border-radius:0]">
+              {comment.userId && (
+                <p className="font-sans text-[11.5px] leading-normal text-(--text-tertiary)">{comment.userId}</p>
+              )}
+              {comment.body && <MarkdownText text={comment.body} />}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {facts.guidance && (
+        <div className="mt-2">
+          <p className="mb-[2px] font-sans text-[12px] leading-[1.6] text-(--text-tertiary)">Workspace guidance</p>
+          <MarkdownText text={facts.guidance} />
+        </div>
+      )}
+      {facts.truncated && (
+        <p className="mt-1 font-sans text-[11.5px] leading-normal text-(--text-tertiary)">
+          Context truncated by the relay.
+        </p>
+      )}
+    </>
+  )
+}

--- a/packages/web/src/components/console/platforms/registry.ts
+++ b/packages/web/src/components/console/platforms/registry.ts
@@ -1,5 +1,6 @@
 // No 'use client' here: reached only from ModalProvider's tree (the client boundary).
 
+import type { UserTurnBody } from '@agentconnect.md/protocol'
 import type { ComponentType } from 'react'
 import type { BotDto, SessionMessageDto } from '@/lib/api'
 import type {
@@ -176,6 +177,12 @@ export function botSharingEditable(bot: Pick<BotDto, 'platform' | 'transport' | 
  */
 export function platformTextRenderer(platformId?: string): ComponentType<{ text: string }> | undefined {
   return platformId ? platformRegistry.get(platformId)?.textRenderer : undefined
+}
+
+/** The module's formatter for the facts behind one of its user turns, or undefined when it
+ *  declares none — see {@link WebPlatformModule.turnFacts}. */
+export function platformTurnFacts(platformId?: string): ComponentType<{ body: UserTurnBody }> | undefined {
+  return platformId ? platformRegistry.get(platformId)?.turnFacts : undefined
 }
 
 /**

--- a/packages/web/src/components/console/turn-facts-rows.tsx
+++ b/packages/web/src/components/console/turn-facts-rows.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react'
+
+/** The label · value grid every turn-facts formatter renders into: one row per fact, values wrap. */
+export function FactRows({ children }: { children: ReactNode }) {
+  return (
+    <div className="grid grid-cols-[76px_minmax(0,1fr)] gap-x-2 gap-y-[2px] font-sans text-[12px] font-normal leading-[1.6]">
+      {children}
+    </div>
+  )
+}
+
+/** One fact. A row with nothing to say renders nothing, so a formatter never prints a dash. */
+export function FactRow({ label, children }: { label: string; children: ReactNode }) {
+  if (children === undefined || children === null || children === '' || children === false) return null
+  return (
+    <>
+      <span className="text-(--text-tertiary)">{label}</span>
+      <span className="min-w-0 break-words text-(--text-primary)">{children}</span>
+    </>
+  )
+}

--- a/packages/web/src/components/console/views/SessionDetailView.plan.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.plan.test.tsx
@@ -233,3 +233,39 @@ describe('the turn plan on the session page', () => {
     expect(text()).toContain('done')
   })
 })
+
+describe('a delivery turn on the session page', () => {
+  it('shows the short text with a "more" that unfolds the facts, never the prompt', async () => {
+    wire.messages = [
+      row({
+        seq: 1,
+        sender: 'linear:user-1',
+        kind: 'text',
+        text: 'Delegated ENG-3 · investigate',
+        body: JSON.stringify({
+          prompt: 'Linear ENG-3 "investigate" — delegated by Dana\nTHE WHOLE PROMPT',
+          codehost: {
+            provider: 'github',
+            event: 'issues:opened',
+            subject: { repo: 'acme/infra', number: 7, title: 'db down' },
+            author: { login: 'mallory' },
+            body: 'please look'
+          }
+        })
+      }),
+      row({ seq: 2, sender: 'agent-1', kind: 'text', text: 'on it' })
+    ]
+    await render()
+    expect(text()).toContain('Delegated ENG-3 · investigate')
+    expect(text()).not.toContain('THE WHOLE PROMPT')
+    expect(text()).not.toContain('mallory')
+    const toggle = container?.querySelector('[data-turn-details] button') as HTMLButtonElement
+    expect(toggle?.textContent).toBe('more')
+    await act(async () => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(text()).toContain('mallory')
+    expect(text()).toContain('please look')
+    expect(text()).not.toContain('THE WHOLE PROMPT')
+  })
+})

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -66,6 +66,9 @@ import { useProfile } from '@/lib/profile'
 import { usePgDraft, usePgDraftHasText, usePlayground } from '@/components/console/PlaygroundProvider'
 import { AgentIconView, LoadingState, ModelMark, PlatformMark, SocialLoginMark, Spinner } from '@/components/marks'
 import { MessageText } from '@/components/console/MessageText'
+import { UserTurnDetails } from '../UserTurnDetails'
+import { parseUserTurnBody } from '@/lib/user-turn-body'
+import type { UserTurnBody } from '@agentconnect.md/protocol'
 import { NotFound } from '@/components/console/NotFound'
 import { Avatar, Button, Icon } from '@/components/ui'
 import { GitlabRerunButton } from '@/components/console/GitlabRerunButton'
@@ -1127,6 +1130,8 @@ type Turn =
       cronId: string | null
       /** The platform this message was authored on — see `FmtStep.platform`. */
       platform?: string
+      /** The facts behind a delivery turn (transcript-full-tool-body.md §9) — the bubble's "more". */
+      body?: UserTurnBody
     }
   // `wake` marks a block opened by a background-task wake that no reply has
   // merged into yet — the run that follows binds to it, then clears the flag.
@@ -3112,7 +3117,8 @@ export default function SessionDetailView() {
           image: m.attachments?.[0],
           isCron: !!cron,
           cronId: cron?.id ?? null,
-          platform: rowPlatform
+          platform: rowPlatform,
+          body: parseUserTurnBody(m.body)
         })
       }
     }
@@ -4051,6 +4057,7 @@ export default function SessionDetailView() {
                                   />
                                 )}
                                 {turn.text && <MessageText text={turn.text} platform={turn.platform} />}
+                                {turn.body && <UserTurnDetails body={turn.body} platform={turn.platform} />}
                               </div>
                               {/* Sent bubbles are complete by definition — the copy affordance
                         (hover-revealed, right-aligned under the bubble) always mounts.

--- a/packages/web/src/lib/user-turn-body.test.ts
+++ b/packages/web/src/lib/user-turn-body.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { linearDescriptionMarkdown, parseUserTurnBody, shortSha } from './user-turn-body'
+
+describe('parseUserTurnBody', () => {
+  it('keeps the facts and never the prompt', () => {
+    const body = JSON.stringify({
+      prompt: 'the whole prompt',
+      linear: { issue: { identifier: 'ENG-3', title: 'x' }, delegatedBy: 'Dana' },
+      codehost: { provider: 'github', event: 'issues:opened', subject: { number: 42 } }
+    })
+    expect(parseUserTurnBody(body)).toEqual({
+      linear: { issue: { identifier: 'ENG-3', title: 'x' }, delegatedBy: 'Dana' },
+      codehost: { provider: 'github', event: 'issues:opened', subject: { number: 42 } }
+    })
+  })
+
+  it('fails closed on anything that is not a turn body', () => {
+    expect(parseUserTurnBody(undefined)).toBeUndefined()
+    expect(parseUserTurnBody('')).toBeUndefined()
+    expect(parseUserTurnBody('{not json')).toBeUndefined()
+    expect(parseUserTurnBody('null')).toBeUndefined()
+    expect(parseUserTurnBody('[1]')).toBeUndefined()
+    // A tool body on a text row, or a prompt with no facts: nothing to fold.
+    expect(parseUserTurnBody(JSON.stringify({ toolCallId: 'tc-1', status: 'completed' }))).toBeUndefined()
+    expect(parseUserTurnBody(JSON.stringify({ prompt: 'only a prompt' }))).toBeUndefined()
+    // Facts of the wrong shape are dropped rather than rendered.
+    expect(parseUserTurnBody(JSON.stringify({ linear: 'ENG-3' }))).toBeUndefined()
+    expect(parseUserTurnBody(JSON.stringify({ codehost: { subject: {} } }))).toBeUndefined()
+  })
+})
+
+describe('linearDescriptionMarkdown', () => {
+  it('lifts the description out of the XML-shaped context and decodes its entities', () => {
+    const context =
+      '<issue identifier="ENG-3">\n<title>investigate</title> <description>See [the repo](https://example.test) &amp; the &lt;docs&gt;.</description> <team name="ENG"/> </issue>'
+    expect(linearDescriptionMarkdown(context)).toEqual({
+      markdown: 'See [the repo](https://example.test) & the <docs>.',
+      parsed: true
+    })
+  })
+
+  it('shows a context without a description element whole rather than guessing', () => {
+    expect(linearDescriptionMarkdown('plain words')).toEqual({ markdown: 'plain words', parsed: false })
+  })
+})
+
+describe('shortSha', () => {
+  it('is the seven characters a person quotes', () => {
+    expect(shortSha('7830b10b5bc939c5576324a06f8b60c05dccb161')).toBe('7830b10')
+  })
+})

--- a/packages/web/src/lib/user-turn-body.test.ts
+++ b/packages/web/src/lib/user-turn-body.test.ts
@@ -23,9 +23,22 @@ describe('parseUserTurnBody', () => {
     // A tool body on a text row, or a prompt with no facts: nothing to fold.
     expect(parseUserTurnBody(JSON.stringify({ toolCallId: 'tc-1', status: 'completed' }))).toBeUndefined()
     expect(parseUserTurnBody(JSON.stringify({ prompt: 'only a prompt' }))).toBeUndefined()
-    // Facts of the wrong shape are dropped rather than rendered.
+    // Facts of the wrong shape are dropped rather than rendered — validated whole, so a fold
+    // can never open onto a formatter that dereferences what is not there.
     expect(parseUserTurnBody(JSON.stringify({ linear: 'ENG-3' }))).toBeUndefined()
+    expect(parseUserTurnBody(JSON.stringify({ linear: { issue: null } }))).toBeUndefined()
+    expect(parseUserTurnBody(JSON.stringify({ linear: { issue: { identifier: 7 } } }))).toBeUndefined()
     expect(parseUserTurnBody(JSON.stringify({ codehost: { subject: {} } }))).toBeUndefined()
+    expect(parseUserTurnBody(JSON.stringify({ codehost: { provider: 'github' } }))).toBeUndefined()
+    expect(
+      parseUserTurnBody(JSON.stringify({ codehost: { provider: 'github', event: 'x', subject: null } }))
+    ).toBeUndefined()
+    // One bad fact does not take the other down with it.
+    expect(
+      parseUserTurnBody(
+        JSON.stringify({ linear: { issue: null }, codehost: { provider: 'gitlab', event: 'note', subject: {} } })
+      )
+    ).toEqual({ codehost: { provider: 'gitlab', event: 'note', subject: {} } })
   })
 })
 

--- a/packages/web/src/lib/user-turn-body.ts
+++ b/packages/web/src/lib/user-turn-body.ts
@@ -1,9 +1,11 @@
 import type { UserTurnBody } from '@agentconnect.md/protocol'
+import { CodehostTurnFacts, LinearTurnFacts } from '@agentconnect.md/protocol/user-turn-body'
 
 /**
- * The `UserTurnBody` behind a text row (transcript-full-tool-body.md §9), decoded fail-closed:
- * a row from before the body existed, a tool body, or a corrupt string yields nothing rather
- * than a fold with nothing sensible in it. The console never reads `prompt`; only the facts.
+ * The `UserTurnBody` behind a text row (transcript-full-tool-body.md §9), decoded fail-closed
+ * against the protocol's own schemas: a row from before the body existed, a tool body, a corrupt
+ * string, or a fact of the wrong shape yields no fold rather than one that throws when opened.
+ * The console never reads `prompt`; only the facts, each validated whole.
  */
 export function parseUserTurnBody(body: string | undefined): UserTurnBody | undefined {
   if (!body) return undefined
@@ -16,12 +18,10 @@ export function parseUserTurnBody(body: string | undefined): UserTurnBody | unde
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
   const { linear, codehost } = parsed as { linear?: unknown; codehost?: unknown }
   const facts: UserTurnBody = {}
-  if (linear && typeof linear === 'object' && typeof (linear as { issue?: unknown }).issue === 'object') {
-    facts.linear = linear as UserTurnBody['linear']
-  }
-  if (codehost && typeof codehost === 'object' && typeof (codehost as { provider?: unknown }).provider === 'string') {
-    facts.codehost = codehost as UserTurnBody['codehost']
-  }
+  const linearFacts = LinearTurnFacts.safeParse(linear)
+  if (linearFacts.success) facts.linear = linearFacts.data
+  const codehostFacts = CodehostTurnFacts.safeParse(codehost)
+  if (codehostFacts.success) facts.codehost = codehostFacts.data
   return facts.linear || facts.codehost ? facts : undefined
 }
 

--- a/packages/web/src/lib/user-turn-body.ts
+++ b/packages/web/src/lib/user-turn-body.ts
@@ -1,0 +1,45 @@
+import type { UserTurnBody } from '@agentconnect.md/protocol'
+
+/**
+ * The `UserTurnBody` behind a text row (transcript-full-tool-body.md §9), decoded fail-closed:
+ * a row from before the body existed, a tool body, or a corrupt string yields nothing rather
+ * than a fold with nothing sensible in it. The console never reads `prompt`; only the facts.
+ */
+export function parseUserTurnBody(body: string | undefined): UserTurnBody | undefined {
+  if (!body) return undefined
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    return undefined
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
+  const { linear, codehost } = parsed as { linear?: unknown; codehost?: unknown }
+  const facts: UserTurnBody = {}
+  if (linear && typeof linear === 'object' && typeof (linear as { issue?: unknown }).issue === 'object') {
+    facts.linear = linear as UserTurnBody['linear']
+  }
+  if (codehost && typeof codehost === 'object' && typeof (codehost as { provider?: unknown }).provider === 'string') {
+    facts.codehost = codehost as UserTurnBody['codehost']
+  }
+  return facts.linear || facts.codehost ? facts : undefined
+}
+
+/** `7830b10` — the seven characters a person quotes a commit by. */
+export function shortSha(sha: string): string {
+  return sha.slice(0, 7)
+}
+
+const XML_ENTITIES: Record<string, string> = { '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'", '&amp;': '&' }
+
+/**
+ * Linear hands the agent the issue as XML-shaped text (`promptContext`): `<issue …><title>…</title>
+ * <description>…</description> …</issue>`. The console shows the description as the markdown it is;
+ * a context without that element is shown whole, since guessing at its shape would hide it.
+ */
+export function linearDescriptionMarkdown(description: string): { markdown: string; parsed: boolean } {
+  const match = /<description>([\s\S]*?)<\/description>/i.exec(description)
+  if (!match) return { markdown: description, parsed: false }
+  const markdown = match[1]!.replace(/&(lt|gt|quot|#39|amp);/g, (entity) => XML_ENTITIES[entity] ?? entity).trim()
+  return { markdown, parsed: true }
+}


### PR DESCRIPTION
## Why

Last step of the session-readability split. #1744 persisted the facts behind a delivery turn on the transcript row's body, #1748 put the person's own words on the row's text. The console still showed only the text; this renders the facts behind a bare `more` inside the bubble, the design agreed on the mockup: no sections, no trust labels, one formatter per platform.

## What

- **`UserTurnDetails`** owns the fold: a `more` / `less` toggle under the bubble text, a divider, then the formatter. It resolves the row's platform module `turnFacts` through the registry, falls back to the host's code-host formatter for a `codehost` body, and renders nothing when no formatter claims the body, so every other row is the bubble it was. The prompt is never rendered.
- **Linear** declares `turnFacts` (new optional `WebPlatformModule` member, resolved by `platformTurnFacts`): issue linked to Linear, team as `name (KEY)`, delegator, then the description as the markdown it is — `linearDescriptionMarkdown` lifts it out of the XML-shaped context Linear hands the agent and decodes the entities; a context without that element is shown whole. Earlier comments and workspace guidance follow when present.
- **Code host** is the host's own formatter, since GitHub and GitLab are not modules: subject linked, event, author with association, revision as `base → head` short SHAs, ref, draft, labels, how the delivery is answered, then the body as CommonMark through a new `MarkdownText` (same link policy and `.mdtxt` styling as the default renderer, without the Slack control-syntax normalization).
- `parseUserTurnBody` decodes the body fail-closed: a tool body, a corrupt string, or facts of the wrong shape yield no fold.

Styling follows STYLE.md: tokens through var-shorthand utilities, `font-sans` + size + `leading-*`, the existing `lnk` and `.mdtxt` classes.

## Tests

Parser and description lifting; the fold on a code-host body (collapsed by default, facts on demand, no prompt, link target, collapse again) and on a Linear body through the registry, and nothing for an unclaimed body; the Linear formatter's rows, omissions and unshaped fallback; the module member and its registry resolution; and the real session page showing the short text with a `more` that unfolds the facts and never the prompt. Existing transcript-seam tests unchanged.

Not verified in a browser yet: the console needs a control plane behind it, so the pixels get their look on the test environment after the release syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
