### PR TITLE
fix(linear): work the ticket as written — the convention in five sentences

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1129,19 +1129,18 @@ by <actor>` + issue URL, with `sanitizeTitle` flattening.
   message from stored coordinates without the bag, and a cold resume or a
   failed-load recreate must still re-assert the coordinates that the
   transcript, by design, no longer holds. That is what keeps the console's user bubble to the header, the URL
-  and the member's own words. The convention: the plan is already live in the
-  session — the converger pushes the runtime's ACP plan entries onto the
-  AgentSession itself (§5) — so it is never a comment, and
-  `createIssueComment` is for the OUTCOME once work is done, or for the scope
-  the agent had to decide itself on an empty ticket, which is a deliverable
-  rather than a step list; an ambiguous ticket earns a clarifying response
-  before work; the branch and the PR carry the identifier so Linear links
-  them; `updateIssue` takes `state` by workflow state NAME
-  (`listIssueStatuses`); current state, assignee and labels are `getIssue`'s
-  answer. The convention also tells the model NOT to sign a comment: the
-  earlier wording invited both a "here is my plan" comment the feed already
-  rendered and a free-text `— <agent>` signature, and the tool now appends
-  the standard footer itself (§12). Mutable issue state is deliberately NOT
+  and the member's own words. The convention is five short sentences: work
+  the ticket as written, picking sensible defaults and asking only when the
+  agent cannot proceed; comment only with the outcome — the plan is
+  already live in the session, since the converger pushes the runtime's ACP
+  plan entries onto the AgentSession itself (§5) — and never sign it (the
+  tool appends the standard footer itself, §12); name the branch and the
+  PR after the identifier so Linear links them; `updateIssue` takes `state`
+  by workflow state NAME (`listIssueStatuses`); current state, assignee and
+  labels are `getIssue`'s answer. It is kept that short on purpose: an
+  earlier, more cautious wording had the agent treat a clear ticket as
+  ambiguous and ask before working, and a longer one written to correct
+  that over-explained the brief. Mutable issue state is deliberately NOT
   rendered anywhere: a snapshot goes stale within the session, and standing context
   is composed once, so the block is built from the bag alone — no
   `issueFacts` read, no deadline, nothing to degrade. Being daemon-authored
@@ -1924,11 +1923,11 @@ none` skips it along with everything else Linear-visible. There is **no
   3. **A daemon-authored Linear standing block** (§8, **landed**; moved
      from the per-turn prompt to standing context 2026-09-02): the issue's
      UUID, identifier, title, URL and team (the coordinates the tools take),
-     plus a few lines of working convention — the issue is the record, so
-     plans and outcomes go into its description or a comment; branch and PR
-     names carry the identifier so Linear's own GitHub integration links
-     them; an empty ticket earns a clarifying `response` before work; state,
-     assignee and labels are read live with `getIssue`, never snapshotted.
+     plus five sentences of working convention — work the ticket as written
+     with sensible defaults; comment only with the outcome, never a plan,
+     never signed; branch and PR names carry the identifier so Linear's own
+     GitHub integration links them; state, assignee and labels are read live
+     with `getIssue`, never snapshotted.
      **Not a skill**: the tools only exist in Linear sessions, so the
      session's standing context is the deterministic seat, and the
      customer-side customization seat is Linear's own admin `guidance`,

--- a/packages/daemon/src/platforms/linear/message-strategy.ts
+++ b/packages/daemon/src/platforms/linear/message-strategy.ts
@@ -221,12 +221,11 @@ function trustedHeader(msg: Pick<NormalizedMessage, 'sender' | 'threadUrl'>, ext
 
 /** The working convention the standing block closes with — the tool names are the model's entry points. */
 const LINEAR_WORKING_CONVENTION =
-  'Working here: your plan is already live in this session, so never post it as a comment — ' +
-  '`createIssueComment` is for the OUTCOME once work is done, or for the scope you had to decide yourself on ' +
-  'an empty ticket, and you never sign it (attribution is appended for you); if the ticket is ambiguous, ask ' +
-  'in your response before working. Name the branch and the PR after the identifier so Linear links them; ' +
-  'the team’s workflow state NAMES are what `updateIssue` takes for `state` (`listIssueStatuses`); read ' +
-  'the current state, assignee and labels with `getIssue` rather than assuming them.'
+  'Work the ticket as written: pick sensible defaults, and ask only if you cannot proceed. ' +
+  'Comment (`createIssueComment`) only with the outcome — never a plan, the session already shows it — ' +
+  'and never sign it. Name the branch and the PR after the identifier so Linear links them. ' +
+  '`updateIssue` takes the team’s workflow state NAMES for `state` (`listIssueStatuses`); read the ' +
+  'current state, assignee and labels with `getIssue` rather than assuming them.'
 
 /** `- Key: value`, or nothing at all — the block omits an absent fact instead of printing a dash. */
 function fact(key: string, value: string): string {

--- a/packages/daemon/test/linear-ingress.test.ts
+++ b/packages/daemon/test/linear-ingress.test.ts
@@ -628,10 +628,10 @@ describe('§10.1 the pre-spawn acknowledgement', () => {
     // Standing: the issue UUID and the team, read once on the system-prompt channel, never a row.
     expect(dispatched[0]!.standingContext).toContain('- Issue: TEAM-123 (id issue-uuid)')
     expect(dispatched[0]!.standingContext).toContain('- Team: Engineering (key ENG')
-    expect(dispatched[0]!.standingContext).toContain('Working here:')
+    expect(dispatched[0]!.standingContext).toContain('Work the ticket as written')
     // Per turn: what the console transcript shows is the header, the URL and the member's words.
     expect(dispatched[0]!.turnBody!.prompt!).not.toContain('issue-uuid')
-    expect(dispatched[0]!.turnBody!.prompt!).not.toContain('Working here:')
+    expect(dispatched[0]!.turnBody!.prompt!).not.toContain('Work the ticket as written')
     expect(dispatched[0]!.turnBody!.prompt!.split('\n')[0]).toBe('Linear TEAM-123 "Ship the thing" — delegated by Dana')
     await daemon.stop()
   })

--- a/packages/daemon/test/linear-message-strategy.test.ts
+++ b/packages/daemon/test/linear-message-strategy.test.ts
@@ -211,7 +211,7 @@ describe('§8 daemon-authored standing block', () => {
       `- Issue: TEAM-123 (id ${ISSUE_UUID}) — "Ship the thing" — ${ISSUE_URL}`,
       `- Team: Engineering (key ENG, id ${TEAM})`,
       '',
-      expect.stringContaining('Working here: your plan is already live in this session')
+      expect.stringContaining('Work the ticket as written: pick sensible defaults')
     ])
   })
 
@@ -225,9 +225,12 @@ describe('§8 daemon-authored standing block', () => {
   // renders, and signed their comments by hand because they had seen the response footer.
   it('sends the plan to the session and the outcome to a comment, and forbids a hand-written signature', () => {
     const convention = lines().at(-1) ?? ''
-    expect(convention).toContain('never post it as a comment')
-    expect(convention).toContain('OUTCOME')
-    expect(convention).toContain('you never sign it')
+    expect(convention).toContain('never a plan, the session already shows it')
+    // The brief is worked as written: no standing invitation to ask before starting.
+    expect(convention).toContain('ask only if you cannot proceed')
+    expect(convention).not.toContain('ask in your response before working')
+    expect(convention).toContain('only with the outcome')
+    expect(convention).toContain('never sign it')
     expect(convention).not.toContain('put the plan')
   })
 
@@ -257,7 +260,7 @@ describe('§8 daemon-authored standing block', () => {
   it('is standing, not prompt: the per-turn text is the header, the instruction and the fence alone', () => {
     const text = buildLinearPromptText(message(), ext({ issueId: ISSUE_UUID }))
     expect(text).not.toContain('# Linear')
-    expect(text).not.toContain('Working here')
+    expect(text).not.toContain('Work the ticket as written')
     expect(text).not.toContain(ISSUE_UUID)
     expect(text.split('\n\n')).toEqual([
       `Linear TEAM-123 "Ship the thing" — delegated by Dana\n${ISSUE_URL}`,


### PR DESCRIPTION
## Why

The Linear standing convention (§8) told the agent: "if the ticket is ambiguous, ask in your response before working." Agents took that as a standing invitation — a ticket titled "investigate agentconnect's capabilities" with the repository link as its description was answered with a three-option menu instead of the investigation. A hook-driven GitHub issue carries no such nudge and gets worked as written.

This is the prompt half of #1746 on its own, as asked; the comment-footer change is a separate PR.

## What

`message-strategy.ts`: the convention is five sentences — work the ticket as written with sensible defaults, ask only if you cannot proceed; comment only with the outcome, never a plan, never signed; name the branch and PR after the identifier; `updateIssue` takes workflow state names; read state, assignee and labels with `getIssue`. A first rewrite that explained "the title and description are the brief" was itself too much prose; the rules alone are enough. Design doc §8 and the §13 summary say the same.

## Tests

`linear-message-strategy.test.ts` and `linear-ingress.test.ts` assert the new wording and that the ask-first clause is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
