### PR TITLE
feat(linear): post a comment on the session's own issue without the footer

### DIFF
--- a/docs/designs/linear-integration.md
+++ b/docs/designs/linear-integration.md
@@ -1826,22 +1826,33 @@ none` skips it along with everything else Linear-visible. There is **no
   session's own connection (a session on another platform is refused at call
   time), and shares the app's hourly budget through the paced queue.
 
-- **A comment's attribution is daemon-authored, like the response footer.**
-  Linear posts every agent's comment as the one deployment app (§4.3), so a
-  reader can only tell the agents apart from the content — and a model asked
-  to name itself will write whatever it likes. `createIssueComment` therefore
-  appends the SAME muted footer the settling `response` activity carries
-  (`linearAttributionFooter`: agent link, runtime · model, session link),
-  built from the turn's own attribution record rather than from any tool
-  argument, and honouring the same per-agent `showFooter` switch — off means
-  no footer here either. The facts reach the tool as a lazy resolver on the
-  session-tool environment (`PlatformSessionToolEnv.attribution`, wired from
-  `daemon.ts` as `sessionToolAttributionFor`), so a tool that publishes
-  nothing pays no lookup and identity stays a daemon fact on a path the model
-  cannot address. A trailing signature line naming the acting agent is
-  stripped from the body first, since agents that had seen the response
-  footer copied it by hand. Descriptions are untouched: an issue's
-  description is the ticket's own text, not the agent's post.
+- **A comment on the session's own issue carries no footer; anywhere else it
+  carries the response footer.** Linear posts every agent's comment as the
+  one deployment app (§4.3), so the reader's only way to tell who wrote one is
+  an association the daemon made. On the issue the session was opened on that
+  association already exists: the Resources entry links the session (§10.2),
+  and the agent, runtime, model and transcript are one click away, so a
+  footer would only repeat that row under every post. `createIssueComment`
+  can address any issue in the workspace, though, and a comment on another
+  issue has no such entry — nor does a session whose issue this daemon never
+  saw delivered — so there the tool appends the same muted footer the settling
+  `response` carries (`linearAttributionFooter`, built from the turn's own
+  attribution record and honouring `showFooter`). The association is a
+  confirmed one, not an inferred one: the applier calls the connection's
+  `noteSessionIssue(thread, issueId)` only after the `attachment` action's
+  `attachmentCreate` returned, so a Resources write that failed (the apply
+  chain logs and swallows it) leaves the session unlinked and its comments
+  footered; the tool compares the resolved target with
+  `issueOfSession(thread)`. Several sessions on one issue — different agents
+  delegated in turn — each add their own Resources entry, titled with the
+  agent, runtime and model, and a comment there is not pinned to one of them
+  by its body; that is accepted as the same reading Linear's own agent
+  integrations give (the session feeds show which one posted it), and it is
+  the trade the no-footer decision makes on purpose. In both cases a
+  trailing signature line naming the acting agent is stripped first (agents
+  that had seen the response footer copied it by hand), and the §8 convention
+  tells the model not to sign. Descriptions are untouched: an issue's
+  description is the ticket's own text.
 
 - Signing secret: relay-only, via the `rc/bot-assign` secrets bag — never in
   daemon specs, logs, or DTOs. Client secret: CP-only. Refresh token:

--- a/packages/daemon/src/platforms/linear/agent-tools.ts
+++ b/packages/daemon/src/platforms/linear/agent-tools.ts
@@ -25,6 +25,8 @@ import { linearAttributionFooter, linearAttributionOf } from './turn-output.js'
  *  indeterminate retry can recognise "the first attempt committed" instead of creating twice. */
 export interface LinearToolClient {
   request<T>(query: string, variables: Record<string, unknown>, opts?: { onDuplicateKey?: () => T }): Promise<T>
+  /** The issue an AgentSession was opened on, when this connection has seen a delivery for it. */
+  issueOfSession?(sessionId: string): string | undefined
 }
 
 /** List page bounds — Linear's own `first` cap is 250; 50 keeps a page inside a tool result. */
@@ -240,8 +242,8 @@ export const LINEAR_TOOLS: ToolDescriptor[] = [
     name: 'createIssueComment',
     description:
       'Comment on an issue, Markdown; `parent` replies inside a comment thread. Post the OUTCOME of finished ' +
-      'work, never a plan — the session already shows that. Do not sign the comment: your attribution footer ' +
-      'is appended for you.',
+      'work, never a plan — the session already shows that. Do not sign the comment: on this session’s issue ' +
+      'its Resources already link the session, and elsewhere your attribution is appended for you.',
     inputSchema: obj({ issue: issueRef, body: str('Comment body, Markdown.'), parent: str('Parent comment id.') }, [
       'issue',
       'body'
@@ -835,6 +837,8 @@ async function updateIssue(client: LinearToolClient, args: Record<string, unknow
 /** What a write tool knows about the acting turn beyond its arguments — daemon facts only. */
 interface LinearToolCall {
   agentName?: string
+  /** The Linear AgentSession UUID this turn runs in — the normalized `thread` coordinate. */
+  sessionThread?: string
   attribution?: () => Promise<ReplyAttributionInfo | undefined>
 }
 
@@ -842,7 +846,7 @@ interface LinearToolCall {
  *  write, and still reaches for. A single `-` is never matched: that is a list item. */
 const SIGNATURE_LINE = /^\s*[*_]{0,2}\s*(?:\u2014|\u2013|--)\s*(.+?)\s*[*_]{0,2}\s*$/
 
-/** Drop that line so the appended footer is the comment's only attribution. */
+/** Drop that line: attribution is the daemon's — the Resources link, or the footer it appends. */
 export function stripAgentSignature(body: string, names: readonly (string | undefined)[]): string {
   const wanted = names.flatMap((n) => (n?.trim() ? [n.trim().toLowerCase()] : []))
   if (wanted.length === 0) return body
@@ -863,10 +867,11 @@ async function createIssueComment(client: LinearToolClient, args: Record<string,
   const a = parseArgs(CREATE_ISSUE_COMMENT_ARGS, args)
   const target = await resolveIssue(client, a.issue)
   const id = randomUUID()
-  const info = await call.attribution?.()
-  // Attribution is the DAEMON's line, not the model's: strip whatever it signed with, then append
-  // the same muted footer the turn's `response` activity carries (§5) — every agent posts through
-  // the one deployment app, so identity can live nowhere but the content.
+  // Once the issue's Resources link this session (§12) a comment there reads as the app's post;
+  // anywhere else — another issue, or a session whose Resources write never landed — the footer
+  // is the only association a reader gets, every agent posting as one app.
+  const own = call.sessionThread ? client.issueOfSession?.(call.sessionThread) : undefined
+  const info = own === target.id ? undefined : await call.attribution?.()
   const body = appendGithubMarkdownChrome(
     stripAgentSignature(a.body, [call.agentName, info?.botName]),
     info ? linearAttributionFooter(linearAttributionOf(info)) : ''
@@ -1212,6 +1217,7 @@ export const LINEAR_SESSION_TOOLS: PlatformSessionTools = {
     if (!tool) throw new Error(`unknown tool: ${name}`)
     return await tool(asClient(env.connection), args, {
       ...(ctx.agentName ? { agentName: ctx.agentName } : {}),
+      ...(ctx.thread ? { sessionThread: ctx.thread } : {}),
       ...(env.attribution ? { attribution: env.attribution } : {})
     })
   }

--- a/packages/daemon/src/platforms/linear/connection.ts
+++ b/packages/daemon/src/platforms/linear/connection.ts
@@ -213,6 +213,9 @@ export function bareLinearUserId(id: string): string {
   return id.startsWith('linear:') ? id.slice('linear:'.length) : id
 }
 
+/** Sessions remembered per connection — a bound, not a budget; a follow-up re-learns its issue. */
+const SESSION_ISSUE_CACHE_MAX = 4096
+
 export class LinearConnection implements PlatformConnection {
   /** All outbound writes funnel through one queue so activities land in converger order. */
   private readonly queue: PlatformSendQueue
@@ -221,6 +224,8 @@ export class LinearConnection implements PlatformConnection {
   private readonly now: () => number
   private readonly sleep: (ms: number) => Promise<void>
   private readonly setTimer: (fn: () => void, ms: number) => unknown
+  /** The issue each AgentSession was opened on, learned off every delivery (§12). */
+  private readonly issueBySession = new Map<string, string>()
   private readonly clearTimer: (handle: unknown) => void
   private readonly newActivityId: () => string
   private cached: CachedToken
@@ -358,6 +363,19 @@ export class LinearConnection implements PlatformConnection {
       id: agentSessionId,
       input: update
     })
+  }
+
+  /** Remember which issue a session sits on; the newest entry is the last evicted. */
+  noteSessionIssue(sessionId: string, issueId: string): void {
+    this.issueBySession.delete(sessionId)
+    this.issueBySession.set(sessionId, issueId)
+    if (this.issueBySession.size > SESSION_ISSUE_CACHE_MAX)
+      this.issueBySession.delete(this.issueBySession.keys().next().value!)
+  }
+
+  /** The issue a session was opened on, when a delivery on this connection has said so. */
+  issueOfSession(sessionId: string): string | undefined {
+    return this.issueBySession.get(sessionId)
   }
 
   /** `attachmentCreate` — the issue's Resources entry. Needs no idempotency key of ours: Linear

--- a/packages/daemon/src/platforms/linear/turn-output.ts
+++ b/packages/daemon/src/platforms/linear/turn-output.ts
@@ -84,6 +84,8 @@ export interface LinearEgressPort {
   updateSession(sessionId: string, update: LinearSessionUpdateInput): Promise<void>
   /** Add (or refresh, by URL) one entry in the issue's Resources. */
   createIssueAttachment(input: LinearAttachmentInput): Promise<void>
+  /** Record that the issue's Resources now link this session — only ever after that write landed (§12). */
+  noteSessionIssue(sessionId: string, issueId: string): void
 }
 
 /** The core turn, as Linear's applier sees it. `Pending` satisfies it structurally. */
@@ -790,6 +792,9 @@ export async function applyLinearAction<TTurn extends LinearTurn>(
     case 'attachment': {
       // Issue-scoped, not feed chrome: it never draws on the activity budget.
       await port.createIssueAttachment(action.input)
+      // The association the comment tool checks exists from here on, not from the delivery
+      // that named the issue: a swallowed failure above leaves the session unlinked.
+      if (turn.plan.thread) port.noteSessionIssue(turn.plan.thread, action.input.issueId)
       return
     }
   }

--- a/packages/daemon/test/linear-agent-tools.test.ts
+++ b/packages/daemon/test/linear-agent-tools.test.ts
@@ -506,28 +506,55 @@ describe('createIssueComment', () => {
     expect(res).toEqual({ posted: true, issue: 'ENG-42', commentId: 'c-9', url: 'u9', createdAt: 't9' })
   })
 
-  it('appends the turn’s standard footer — once, and only to what the model wrote', async () => {
+  /** The same client, on a connection that saw this session opened on `issueId`. */
+  const sessionOn = (c: ReturnType<typeof commenting>, issueId: string): LinearToolClient => ({
+    ...c.impl,
+    issueOfSession: (sessionId) => (sessionId === ctx.thread ? issueId : undefined)
+  })
+
+  it('posts no footer on the session’s own issue — its Resources already link the session', async () => {
     const c = commenting()
-    await run('createIssueComment', { issue: 'ENG-42', body: 'Fixed the retry path.' }, c.impl, {
+    await run('createIssueComment', { issue: 'ENG-42', body: 'Fixed the retry path.' }, sessionOn(c, ISSUE_ID), {
+      attribution: async () => attribution
+    })
+    expect(posted(c)).toBe('Fixed the retry path.')
+  })
+
+  it('still strips the signature the model wrote on the session’s own issue', async () => {
+    for (const signature of ['— atlas', '-- atlas', '— atlas (Claude Code · opus-5)', '*— atlas*']) {
+      const c = commenting()
+      await run(
+        'createIssueComment',
+        { issue: 'ENG-42', body: `Shipped it.\n\n${signature}` },
+        sessionOn(c, ISSUE_ID),
+        {
+          attribution: async () => attribution
+        }
+      )
+      expect(posted(c), signature).toBe('Shipped it.')
+    }
+  })
+
+  it('appends the turn’s standard footer on any OTHER issue — once, and only to what the model wrote', async () => {
+    const c = commenting()
+    await run('createIssueComment', { issue: 'ENG-42', body: 'Fixed the retry path.' }, sessionOn(c, 'issue-other'), {
       attribution: async () => attribution
     })
     expect(posted(c)).toBe(`Fixed the retry path.${FOOTER}`)
     expect(posted(c).match(/sent by/g)).toHaveLength(1)
   })
 
-  it('strips the signature the model wrote before appending the footer', async () => {
-    for (const signature of ['— atlas', '-- atlas', '— atlas (Claude Code · opus-5)', '*— atlas*']) {
-      const c = commenting()
-      await run('createIssueComment', { issue: 'ENG-42', body: `Shipped it.\n\n${signature}` }, c.impl, {
-        attribution: async () => attribution
-      })
-      expect(posted(c), signature).toBe(`Shipped it.${FOOTER}`)
-    }
-  })
-
-  it('posts no footer when the agent’s footer chrome is off', async () => {
+  it('appends the footer when the connection never saw which issue this session sits on', async () => {
     const c = commenting()
     await run('createIssueComment', { issue: 'ENG-42', body: 'Shipped it.\n\n— atlas' }, c.impl, {
+      attribution: async () => attribution
+    })
+    expect(posted(c)).toBe(`Shipped it.${FOOTER}`)
+  })
+
+  it('posts no footer anywhere when the agent’s footer chrome is off', async () => {
+    const c = commenting()
+    await run('createIssueComment', { issue: 'ENG-42', body: 'Shipped it.\n\n— atlas' }, sessionOn(c, 'issue-other'), {
       attribution: async () => undefined
     })
     // The signature still goes: the model was told not to sign, footer or no footer.
@@ -542,7 +569,7 @@ describe('createIssueComment', () => {
 
   it('closes an unterminated code fence before the footer', async () => {
     const c = commenting()
-    await run('createIssueComment', { issue: 'ENG-42', body: '```\nnot closed' }, c.impl, {
+    await run('createIssueComment', { issue: 'ENG-42', body: '```\nnot closed' }, sessionOn(c, 'issue-other'), {
       attribution: async () => attribution
     })
     expect(posted(c)).toBe(`\`\`\`\nnot closed\n\`\`\`${FOOTER}`)

--- a/packages/daemon/test/linear-connection.test.ts
+++ b/packages/daemon/test/linear-connection.test.ts
@@ -1109,3 +1109,17 @@ describe('linear auto-start (§10.2)', () => {
     await expect(conn.startIssue(ISSUE)).rejects.toBeInstanceOf(LinearApiError)
   })
 })
+
+describe('the session → issue association (§12)', () => {
+  it('answers the issue a delivery said the session sits on, and nothing for a session never seen', () => {
+    const { conn } = harness()
+    expect(conn.issueOfSession('session-1')).toBeUndefined()
+    conn.noteSessionIssue('session-1', 'issue-a')
+    conn.noteSessionIssue('session-2', 'issue-b')
+    expect(conn.issueOfSession('session-1')).toBe('issue-a')
+    expect(conn.issueOfSession('session-2')).toBe('issue-b')
+    // A later delivery for the same session wins; the map never holds two issues for one session.
+    conn.noteSessionIssue('session-1', 'issue-c')
+    expect(conn.issueOfSession('session-1')).toBe('issue-c')
+  })
+})

--- a/packages/daemon/test/linear-ingress.test.ts
+++ b/packages/daemon/test/linear-ingress.test.ts
@@ -175,6 +175,7 @@ async function boot(opts: BootOpts = {}) {
   )
   const posted: Posted[] = []
   const attached: { issueId: string; url: string; title: string; subtitle?: string }[] = []
+  const sessionIssues = new Map<string, string>()
   const store = (daemon as any).store
   const conn = {
     integrationId: INTEGRATION,
@@ -192,6 +193,10 @@ async function boot(opts: BootOpts = {}) {
     async updateSession() {},
     async createIssueAttachment(input: { issueId: string; url: string; title: string; subtitle?: string }) {
       attached.push(input)
+    },
+    sessionIssues,
+    noteSessionIssue(sessionId: string, issueId: string) {
+      sessionIssues.set(sessionId, issueId)
     }
   }
   ;(daemon as any).lnConnByIntegration.set(INTEGRATION, conn)
@@ -969,6 +974,7 @@ describe('§7.5 the turn holds its egress transport', () => {
       workspaceId: bound.workspaceId,
       postActivity: bound.postActivity,
       updateSession: bound.updateSession,
+      noteSessionIssue: bound.noteSessionIssue,
       stop: async () => {
         stoppedAfter = posted.length
       }

--- a/packages/daemon/test/linear-turn-output.test.ts
+++ b/packages/daemon/test/linear-turn-output.test.ts
@@ -576,8 +576,14 @@ class FakePort {
     this.updates.push({ sessionId, update })
   }
   readonly attachments: LinearAttachmentInput[] = []
+  attachmentFails?: Error
   async createIssueAttachment(input: LinearAttachmentInput): Promise<void> {
+    if (this.attachmentFails) throw this.attachmentFails
     this.attachments.push(input)
+  }
+  readonly sessionIssues = new Map<string, string>()
+  noteSessionIssue(sessionId: string, issueId: string): void {
+    this.sessionIssues.set(sessionId, issueId)
   }
 }
 
@@ -649,6 +655,25 @@ describe('applyLinearAction', () => {
     expect(port.attachments).toEqual([input])
     expect(port.activities).toEqual([])
     expect(state.activityBudget).toBe(before)
+  })
+
+  it('notes the session ↔ issue association only once the Resources write landed (§12)', async () => {
+    const port = new FakePort()
+    const turn = linearTurn(port)
+    const input = { issueId: 'issue-1', url: 'https://console.example.test/s/1', title: 'AgentConnect session' }
+    await applyLinearAction(turn, initialLinearTurnState(), { kind: 'attachment', input })
+    expect(port.sessionIssues.get(turn.plan.thread!)).toBe('issue-1')
+
+    const failing = new FakePort()
+    failing.attachmentFails = new Error('attachmentCreate: rate limited')
+    await expect(
+      applyLinearAction(linearTurn(failing), initialLinearTurnState(), {
+        kind: 'attachment',
+        input
+      })
+    ).rejects.toThrow('rate limited')
+    // No Resource, no association: the comment tool keeps its footer on this issue.
+    expect(failing.sessionIssues.size).toBe(0)
   })
 
   it('enforces the per-turn activity budget as the hard egress backstop', async () => {


### PR DESCRIPTION
## Why

Every Linear issue comment ended in the attribution footer (`sent by <agent> (<runtime> · <model>) · open in session`). On the issue the session was opened on, the Resources entry already links that session, so the footer only repeated the row under every post. The ask was to drop it there, the way Linear's own agent integrations read.

This is the footer half of #1746 on its own; the prompt change is #1753.

## What

- **No footer on the session's own issue** (`agent-tools.ts`): `createIssueComment` posts the body as written and strips only a hand-written signature line.
- **Footer everywhere else**: a comment on any other issue — or in a session whose Resources write never landed — keeps the response footer, since nothing else associates it with its writer (review finding on #1746).
- **The association is confirmed, not inferred**: the applier calls the connection's `noteSessionIssue(thread, issueId)` only after the Resources `attachmentCreate` returned (a swallowed failure leaves the session unlinked), and the tool compares the resolved target with `issueOfSession(thread)`.
- Several sessions on one issue each carry their own Resources entry and a comment there is not pinned to one by its body; §12 records that as the deliberate trade.

## Tests

- `linear-agent-tools.test.ts`: no footer on the session's own issue (signature still stripped); the footer on another issue and when the session's issue is unknown; none when the agent's footer chrome is off.
- `linear-turn-output.test.ts`: the association is noted after a successful Resources write and not after a failed one. `linear-connection.test.ts`: the association map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
