### PR TITLE
feat(web): label session isolation by its effective boundary, not the stored flag

### DIFF
--- a/packages/web/src/components/console/WorkspaceFormFields.tsx
+++ b/packages/web/src/components/console/WorkspaceFormFields.tsx
@@ -457,6 +457,7 @@ export function GitUrlTileFields({
   agentDir,
   agentDirError,
   worktree,
+  worktreeLabel,
   onUrlChange,
   onBranchChange,
   onAgentDirChange,
@@ -468,6 +469,8 @@ export function GitUrlTileFields({
   agentDir: string
   agentDirError?: string | null
   worktree: boolean
+  /** What the session-isolation toggle is called here — see `WorktreeField`. */
+  worktreeLabel: string
   onUrlChange: (value: string) => void
   onBranchChange: (value: string) => void
   onAgentDirChange: (value: string) => void
@@ -505,7 +508,7 @@ export function GitUrlTileFields({
           onChange={onBranchChange}
         />
         <WorkingSubdirectoryField value={agentDir} error={agentDirError ?? null} onChange={onAgentDirChange} />
-        <WorktreeField checked={worktree} onChange={onWorktreeChange} />
+        <WorktreeField label={worktreeLabel} checked={worktree} onChange={onWorktreeChange} />
       </div>
       <div className="flex items-start gap-2 rounded-[9px] border border-(--border-subtle) bg-(--surface-sunken) px-3 py-[11px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary) desktop:col-span-2">
         <Icon name="info" size={14} className="mt-[1px] flex-none" />
@@ -879,12 +882,21 @@ export function WorkingSubdirectoryField({
   )
 }
 
-export function WorktreeField({ checked, onChange }: { checked: boolean; onChange: (checked: boolean) => void }) {
+/** `label` names the isolation by its EFFECTIVE boundary (git-workspace-model.md §11) — "Worktree" only where nothing encloses the runtime, "Session isolation" under a sandbox or a pool pod. */
+export function WorktreeField({
+  label,
+  checked,
+  onChange
+}: {
+  label: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+}) {
   return (
     <div className="fld min-w-0">
-      <span className="fldlbl">Worktree</span>
+      <span className="fldlbl">{label}</span>
       <div className="inp min-w-0 justify-end">
-        <Toggle checked={checked} onChange={onChange} ariaLabel="Worktree" />
+        <Toggle checked={checked} onChange={onChange} ariaLabel={label} />
       </div>
     </div>
   )

--- a/packages/web/src/components/console/WorkspaceScopePicker.test.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.test.tsx
@@ -15,6 +15,21 @@ vi.mock('next/link', () => ({
 
 import { WorkspaceScopePicker, worktreeIdentity } from './WorkspaceScopePicker'
 import type { Session } from '@/lib/data'
+import { sessionIsolationLabel } from '@/lib/session-isolation'
+
+// Built by the helper, never spelled out here, so the picker's copy cannot drift from the labels the helper decides.
+const UNCONFINED = sessionIsolationLabel({
+  pool: false,
+  runInSandbox: false,
+  sandboxSupported: false,
+  sandboxRequired: false
+})
+const CONFINED = sessionIsolationLabel({
+  pool: false,
+  runInSandbox: true,
+  sandboxSupported: true,
+  sandboxRequired: false
+})
 
 let root: Root | undefined
 let container: HTMLDivElement | undefined
@@ -67,6 +82,7 @@ describe('WorkspaceScopePicker', () => {
       root?.render(
         <WorkspaceScopePicker
           primaryBranch="release/2026-08"
+          isolationLabel={UNCONFINED}
           sessions={[
             session({}),
             session({ id: 'session-568', title: 'PR #568: bind the conversation audience', time: '3:10 PM' }),
@@ -98,7 +114,8 @@ describe('WorkspaceScopePicker', () => {
     const menu = container.querySelector<HTMLElement>('[role="menu"]')!
     expect(menu.textContent).toContain('release/2026-08')
     expect(menu.textContent).not.toContain('Primary checkout')
-    expect(menu.textContent).toContain('Worktrees·2')
+    // The heading is the label verbatim; `.eyebrow` is what uppercases it on screen, so the DOM text is lower case.
+    expect(menu.textContent).toContain('worktrees·2')
     expect(menu.textContent).toContain('PR #568')
     expect(menu.textContent).not.toContain('3:10 PM')
     expect(menu.textContent).toContain('Showing 2 recent worktrees')
@@ -120,6 +137,36 @@ describe('WorkspaceScopePicker', () => {
     expect(onChange).toHaveBeenCalledOnce()
   })
 
+  it('drops the worktree vocabulary where a boundary encloses the runtime', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () =>
+      root?.render(
+        <WorkspaceScopePicker
+          primaryBranch="main"
+          isolationLabel={CONFINED}
+          sessions={[session({}), session({ id: 'session-568', title: 'PR #568: bind the audience' })]}
+          selectedSessionId={null}
+          loading={false}
+          hasMore={false}
+          loadingMore={false}
+          onChange={vi.fn()}
+          onLoadMore={vi.fn()}
+          orgPath={(path) => `/agentconnect${path}`}
+        />
+      )
+    )
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-label^="Workspace checkout:"]')!
+    await act(async () => trigger.click())
+
+    const menu = container.querySelector<HTMLElement>('[role="menu"]')!
+    expect(menu.textContent).toContain('session checkouts·2')
+    expect(menu.textContent).toContain('Showing 2 recent session checkouts')
+    expect(menu.textContent).not.toContain('worktree')
+  })
+
   it('shows the branch without a menu when no worktrees are available', async () => {
     container = document.createElement('div')
     document.body.append(container)
@@ -128,6 +175,7 @@ describe('WorkspaceScopePicker', () => {
       root?.render(
         <WorkspaceScopePicker
           primaryBranch="main"
+          isolationLabel={UNCONFINED}
           sessions={[]}
           selectedSessionId={null}
           loading={false}
@@ -153,6 +201,7 @@ describe('WorkspaceScopePicker', () => {
       root?.render(
         <WorkspaceScopePicker
           primaryBranch="main"
+          isolationLabel={UNCONFINED}
           sessions={[]}
           selectedSessionId={null}
           loading={false}

--- a/packages/web/src/components/console/WorkspaceScopePicker.tsx
+++ b/packages/web/src/components/console/WorkspaceScopePicker.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
 import { Icon } from '@/components/ui'
 import type { Session } from '@/lib/data'
+import type { SessionIsolationLabel } from '@/lib/session-isolation'
 
 type WorktreeIdentity = {
   context?: string
@@ -34,6 +35,7 @@ function worktreeTooltip(identity: WorktreeIdentity, time: string | undefined): 
 
 export function WorkspaceScopePicker({
   primaryBranch,
+  isolationLabel,
   sessions,
   selectedSessionId,
   selectedSession,
@@ -45,6 +47,8 @@ export function WorkspaceScopePicker({
   orgPath
 }: {
   primaryBranch: string
+  /** What this agent's session isolation is CALLED, from its effective boundary (git-workspace-model.md §11) — a worktree only where nothing encloses the runtime. */
+  isolationLabel: SessionIsolationLabel
   sessions: Session[]
   selectedSessionId: string | null
   selectedSession?: Session
@@ -243,7 +247,7 @@ export function WorkspaceScopePicker({
 
               <div className="border-t border-(--border-subtle)">
                 <div className="eyebrow flex h-9 items-center gap-2 px-4 text-[10.5px]">
-                  <span>Worktrees</span>
+                  <span>{isolationLabel.checkouts}</span>
                   <span aria-hidden>·</span>
                   <span>{menuWorktrees.length}</span>
                 </div>
@@ -305,11 +309,11 @@ export function WorkspaceScopePicker({
                   })}
                   {loading && menuWorktrees.length === 0 ? (
                     <div className="px-4 py-5 text-center font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                      Loading worktrees…
+                      Loading {isolationLabel.checkouts}…
                     </div>
                   ) : !hasMore && menuWorktrees.length === 0 ? (
                     <div className="px-4 py-5 text-center font-sans text-[12px] font-normal leading-normal text-(--text-tertiary)">
-                      No session worktrees yet.
+                      No {isolationLabel.checkouts} yet.
                     </div>
                   ) : null}
                 </div>
@@ -318,7 +322,8 @@ export function WorkspaceScopePicker({
               {(menuWorktrees.length > 0 || hasMore) && (
                 <div className="flex min-h-10 items-center gap-3 border-t border-(--border-subtle) bg-(--surface-app) px-4 py-2">
                   <span className="font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                    Showing {menuWorktrees.length} recent worktree{menuWorktrees.length === 1 ? '' : 's'}
+                    Showing {menuWorktrees.length} recent{' '}
+                    {menuWorktrees.length === 1 ? isolationLabel.checkout : isolationLabel.checkouts}
                   </span>
                   {hasMore ? (
                     <button

--- a/packages/web/src/components/console/dock/FilesPanel.test.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.test.tsx
@@ -723,12 +723,12 @@ describe('FilesPanel degraded states', () => {
     expect(container?.querySelector('input')).not.toBeNull()
   })
 
-  it('explains a daemon too old for session worktrees, and does not blame the network', async () => {
+  it('explains a daemon too old for session-scoped browsing, and does not blame the network', async () => {
     // The CP's 409 is `workspace-session-read-v1` missing, which the offline copy would misdescribe.
     wire.failures = { '': 409 }
     await render()
 
-    expect(text()).toContain('cannot browse a session worktree')
+    expect(text()).toContain('cannot browse a session checkout')
     expect(text()).not.toContain('may be offline')
   })
 

--- a/packages/web/src/components/console/dock/FilesPanel.tsx
+++ b/packages/web/src/components/console/dock/FilesPanel.tsx
@@ -38,11 +38,11 @@ function rootNoticeText(status: number | null, scoped: boolean, code?: string | 
   // in fact the files are fine and reachable again on the agent's next turn.
   if (code === SANDBOX_ASLEEP_CODE) return SANDBOX_ASLEEP_NOTICE
   if (status === 409) {
-    return 'This agent runs a daemon version that cannot browse a session worktree. Update the agent, or read the files from its workspace page.'
+    return 'This agent runs a daemon version that cannot browse a session checkout. Update the agent, or read the files from its workspace page.'
   }
   if (status === 404) {
     return scoped
-      ? "This session's worktree is not available to browse — it may have been cleaned up, or this session may not have one of its own."
+      ? "This session's checkout is not available to browse — it may have been cleaned up, or this session may not have one of its own."
       : 'This workspace is not available to browse.'
   }
   return "Couldn't browse the workspace — the owning daemon may be offline. Files live only on that machine and are read live from it, so they are unavailable while it is disconnected."

--- a/packages/web/src/components/console/dock/GitPanel.test.tsx
+++ b/packages/web/src/components/console/dock/GitPanel.test.tsx
@@ -463,7 +463,7 @@ describe('GitPanel', () => {
 
   it('draws a clean tree as data', async () => {
     await render()
-    expect(text()).toContain('Nothing has changed in this worktree')
+    expect(text()).toContain('Nothing has changed in this checkout')
   })
 
   it('says the status list was capped rather than implying the tree is that small', async () => {

--- a/packages/web/src/components/console/dock/GitPanel.tsx
+++ b/packages/web/src/components/console/dock/GitPanel.tsx
@@ -72,8 +72,8 @@ function logNoticeText(status: number | null, code: string | null): string {
   if (status === 409 && code === 'DAEMON_FEATURE_MISSING') {
     return 'This agent runs a daemon version that cannot list commits. Update the agent to review its history here.'
   }
-  if (status === 409) return 'This agent runs a daemon version that cannot read a session worktree.'
-  if (status === 404) return 'This worktree is not available to read.'
+  if (status === 409) return 'This agent runs a daemon version that cannot read a session checkout.'
+  if (status === 404) return 'This checkout is not available to read.'
   return 'Commits are unavailable — the owning daemon may be offline.'
 }
 
@@ -395,7 +395,7 @@ export function GitPanel({
       return (
         <PanelNotice
           warn
-          text="Couldn't read this worktree's git status — the owning daemon may be offline. Status is read live from that machine, so it is unavailable while it is disconnected."
+          text="Couldn't read this checkout's git status — the owning daemon may be offline. Status is read live from that machine, so it is unavailable while it is disconnected."
         />
       )
     }
@@ -405,7 +405,7 @@ export function GitPanel({
       )
     }
     if (sections.staged.length === 0 && sections.changes.length === 0) {
-      return <PanelNotice text="Nothing has changed in this worktree — every tracked file matches the last commit." />
+      return <PanelNotice text="Nothing has changed in this checkout — every tracked file matches the last commit." />
     }
     return (
       <>

--- a/packages/web/src/components/console/dock/git-write.test.ts
+++ b/packages/web/src/components/console/dock/git-write.test.ts
@@ -54,8 +54,8 @@ describe('gitWriteRequestFailureText', () => {
   it('tells a busy agent from a daemon too old to write', () => {
     expect(gitWriteRequestFailureText(409, 'WORKSPACE_STALE')).toContain('Try again when it is idle')
     expect(gitWriteRequestFailureText(409, 'DAEMON_FEATURE_MISSING')).toContain('Update the agent')
-    // A 409 with neither code is the session-worktree version answer.
-    expect(gitWriteRequestFailureText(409, null)).toContain('session worktree')
+    // A 409 with neither code is the session-scoped version answer.
+    expect(gitWriteRequestFailureText(409, null)).toContain('session checkout')
   })
 
   it('reads a role denial and a missing worktree as themselves', () => {

--- a/packages/web/src/components/console/dock/git-write.ts
+++ b/packages/web/src/components/console/dock/git-write.ts
@@ -37,9 +37,9 @@ export function gitWriteRequestFailureText(status: number | null, code: string |
   if (status === 409 && code === 'WORKSPACE_STALE') {
     return 'The agent is working in this workspace right now. Try again when it is idle.'
   }
-  if (status === 409) return 'This agent runs a daemon version that cannot write to a session worktree.'
+  if (status === 409) return 'This agent runs a daemon version that cannot write to a session checkout.'
   if (status === 403) return 'Your role in this organization cannot change this agent’s checkout.'
-  if (status === 404) return 'This worktree is not available to write to.'
+  if (status === 404) return 'This checkout is not available to write to.'
   if (status === 400) return 'The daemon refused that request. Try a smaller selection.'
   return 'Couldn’t reach the checkout — the owning daemon may be offline. Git runs on that machine, so nothing can be staged or committed while it is disconnected.'
 }

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -30,6 +30,7 @@ import {
   type AgentCallPolicy,
   supportsModes
 } from '@/lib/data'
+import { sessionIsolationLabel } from '@/lib/session-isolation'
 import { addAgentDaemonChoice } from './add-agent-daemon-choice'
 import {
   fetchGithubBranches,
@@ -320,6 +321,13 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
   const sandboxRequired = daemon?.caps.features.includes('sandbox-required') ?? false
   const sandboxSupported = sandboxRequired || (daemon?.caps.features.includes('sandbox') ?? false)
   const effectiveRunInSandbox = sandboxRequired || (sandboxSupported && runInSandbox)
+  // The pool advertises no `sandbox` capability, so its pod — not the triple above — is what encloses a session there.
+  const isolationLabel = sessionIsolationLabel({
+    pool: placement?.kind === 'pool',
+    runInSandbox,
+    sandboxSupported,
+    sandboxRequired
+  })
   // Runtime ids come from the selected daemon's reported profiles — the registry ids
   // that round-trip back to the launch key — so a created agent actually resolves.
   // No daemon (or none reported) ⇒ the static fallback list.
@@ -1174,7 +1182,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                     />
 
                     <WorkingSubdirectoryField value={agentDir} onChange={setAgentDir} />
-                    <WorktreeField checked={worktree} onChange={setWorktree} />
+                    <WorktreeField label={isolationLabel.mode} checked={worktree} onChange={setWorktree} />
                   </div>
                 </div>
               )}
@@ -1210,7 +1218,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                       onChange={setBranch}
                     />
                     <WorkingSubdirectoryField value={agentDir} onChange={setAgentDir} />
-                    <WorktreeField checked={worktree} onChange={setWorktree} />
+                    <WorktreeField label={isolationLabel.mode} checked={worktree} onChange={setWorktree} />
                   </div>
                 </>
               )}
@@ -1319,7 +1327,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                         onChange={setBranch}
                       />
                       <WorkingSubdirectoryField value={agentDir} onChange={setAgentDir} />
-                      <WorktreeField checked={worktree} onChange={setWorktree} />
+                      <WorktreeField label={isolationLabel.mode} checked={worktree} onChange={setWorktree} />
                     </div>
                   </div>
                 ))}
@@ -1331,6 +1339,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                   branch={branch}
                   agentDir={agentDir}
                   worktree={worktree}
+                  worktreeLabel={isolationLabel.mode}
                   onUrlChange={setUrlInput}
                   onBranchChange={setBranch}
                   onAgentDirChange={setAgentDir}

--- a/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
+++ b/packages/web/src/components/console/modals/EditWorkspaceModal.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { GithubMark, GitlabMark, LoadingState } from '@/components/marks'
 import { Button, Icon } from '@/components/ui'
 import { agentLabel, isPoolPlacementKind, workspaceSourceOf, type Agent } from '@/lib/data'
+import { sessionIsolationLabel } from '@/lib/session-isolation'
 import { useConsoleData } from '@/lib/data-context'
 import { useOrgs } from '@/lib/org-context'
 import { matchGitlabProjects, type GitlabProjectChoice } from '@/lib/gitlab-projects'
@@ -93,6 +94,13 @@ export default function EditWorkspaceModal({
   const { orgSetIds } = useConsoleData()
   // Pool placements do not materialize secondary roots yet, so they keep the authorization-only wording.
   const poolPlaced = isPoolPlacementKind(agent.placementKind, agent.setId, orgSetIds)
+  // Session isolation is named by its EFFECTIVE boundary (git-workspace-model.md §11), and a pool pod is one whether or not a sandbox is.
+  const isolationLabel = sessionIsolationLabel({
+    pool: poolPlaced,
+    runInSandbox: agent.runInSandbox,
+    sandboxSupported: agent.sandboxSupported,
+    sandboxRequired: agent.sandboxRequired
+  })
   // The tile an existing workspace edits under is DERIVED from host + credential
   // (git-workspace-model.md §7) — no source is stored.
   const currentSource = workspaceSourceOf(agent.workspace)
@@ -721,7 +729,7 @@ export default function EditWorkspaceModal({
                         setErr(null)
                       }}
                     />
-                    <WorktreeField checked={worktree} onChange={setWorktree} />
+                    <WorktreeField label={isolationLabel.mode} checked={worktree} onChange={setWorktree} />
                   </div>
                 </>
               )}
@@ -873,7 +881,7 @@ export default function EditWorkspaceModal({
                       setErr(null)
                     }}
                   />
-                  <WorktreeField checked={worktree} onChange={setWorktree} />
+                  <WorktreeField label={isolationLabel.mode} checked={worktree} onChange={setWorktree} />
                 </div>
 
                 {uncovered && (
@@ -896,6 +904,7 @@ export default function EditWorkspaceModal({
 
           {mode === 'giturl' && (
             <GitUrlTileFields
+              worktreeLabel={isolationLabel.mode}
               url={urlInput}
               urlHint={urlTileHint}
               branch={branch}

--- a/packages/web/src/components/console/viewer/SessionViewer.test.tsx
+++ b/packages/web/src/components/console/viewer/SessionViewer.test.tsx
@@ -300,21 +300,21 @@ describe('SessionViewer degraded reads', () => {
     wire.failure = 'network'
     await render()
     expect(text()).toContain('the owning daemon may be offline')
-    expect(text()).not.toContain('cannot read a session worktree')
+    expect(text()).not.toContain('cannot read a session checkout')
     expect(text()).not.toContain('not available to read')
   })
 
-  it('tells a daemon too old for worktree reads apart from an offline one', async () => {
+  it('tells a daemon too old for session-scoped reads apart from an offline one', async () => {
     wire.failure = 409
     await render()
-    expect(text()).toContain('cannot read a session worktree')
+    expect(text()).toContain('cannot read a session checkout')
     expect(text()).not.toContain('may be offline')
   })
 
-  it('says whose worktree is missing when the scope itself is refused', async () => {
+  it('says whose checkout is missing when the scope itself is refused', async () => {
     wire.failure = 404
     await render()
-    expect(text()).toContain("This session's worktree is not available to read")
+    expect(text()).toContain("This session's checkout is not available to read")
 
     await act(() => root?.unmount())
     container?.remove()

--- a/packages/web/src/components/console/viewer/SessionViewer.tsx
+++ b/packages/web/src/components/console/viewer/SessionViewer.tsx
@@ -83,11 +83,11 @@ function readNoticeText(status: number | null, code: string | null, scoped: bool
   if (status === 409) {
     return code === 'DAEMON_FEATURE_MISSING'
       ? 'This agent runs a daemon version that cannot read diffs. Update the agent to review its changes here; the file itself still opens.'
-      : 'This agent runs a daemon version that cannot read a session worktree. Update the agent, or open the file from its workspace page.'
+      : 'This agent runs a daemon version that cannot read a session checkout. Update the agent, or open the file from its workspace page.'
   }
   if (status === 404) {
     return scoped
-      ? "This session's worktree is not available to read — it may have been cleaned up, or this session may not have one of its own."
+      ? "This session's checkout is not available to read — it may have been cleaned up, or this session may not have one of its own."
       : 'This workspace is not available to read.'
   }
   if (status === 400 && code === 'WORKSPACE_GIT_INTERNALS') {

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -2125,7 +2125,7 @@ export default function AgentDetailView() {
                 isGitWorkspace(da.workspace) ? (
                   <WorkspaceScopePicker
                     primaryBranch={primaryBranch ?? da.workspace.branch}
-                    isolationLabel={agentSessionIsolationLabel(da)}
+                    isolationLabel={agentSessionIsolationLabel(da, orgSetIds)}
                     sessions={workspaceSessions}
                     selectedSessionId={selectedWorktreeSessionId}
                     selectedSession={selectedWorktreeSession}
@@ -2157,7 +2157,7 @@ export default function AgentDetailView() {
                   <div className="flex w-1/4 min-w-0 flex-none items-center gap-2 max-desktop:w-[min(210px,56vw)]">
                     <WorkspaceScopePicker
                       primaryBranch={ws.branch}
-                      isolationLabel={agentSessionIsolationLabel(da)}
+                      isolationLabel={agentSessionIsolationLabel(da, orgSetIds)}
                       sessions={[]}
                       selectedSessionId={null}
                       loading={false}

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -27,6 +27,7 @@ import {
   type IntegrationRow,
   workspaceSourceOf
 } from '@/lib/data'
+import { agentSessionIsolationLabel } from '@/lib/session-isolation'
 import {
   createGithubHook,
   createGitlabHook,
@@ -2124,6 +2125,7 @@ export default function AgentDetailView() {
                 isGitWorkspace(da.workspace) ? (
                   <WorkspaceScopePicker
                     primaryBranch={primaryBranch ?? da.workspace.branch}
+                    isolationLabel={agentSessionIsolationLabel(da)}
                     sessions={workspaceSessions}
                     selectedSessionId={selectedWorktreeSessionId}
                     selectedSession={selectedWorktreeSession}
@@ -2155,6 +2157,7 @@ export default function AgentDetailView() {
                   <div className="flex w-1/4 min-w-0 flex-none items-center gap-2 max-desktop:w-[min(210px,56vw)]">
                     <WorkspaceScopePicker
                       primaryBranch={ws.branch}
+                      isolationLabel={agentSessionIsolationLabel(da)}
                       sessions={[]}
                       selectedSessionId={null}
                       loading={false}

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -51,6 +51,7 @@ import {
   type Agent,
   type SessionImage
 } from '@/lib/data'
+import { agentSessionIsolationLabel } from '@/lib/session-isolation'
 import { cronNext, cronHuman, fmtNextRun } from '@/lib/cron'
 import { useDaemonDetail } from '@/lib/use-daemon-detail'
 
@@ -222,6 +223,10 @@ export default function HomeView() {
   const gitWorkspace = agent?.workspace && isGitWorkspace(agent.workspace) ? agent.workspace : undefined
   const defaultWorktree = gitWorkspace?.worktree === true
   const worktree = worktreeOverride ?? defaultWorktree
+  // What that toggle is CALLED follows the agent's effective boundary, not its stored sandbox flag (git-workspace-model.md §11).
+  const isolationLabel = agentSessionIsolationLabel(
+    agent ?? { runInSandbox: false, sandboxSupported: false, sandboxRequired: false }
+  )
 
   // Overrides are per-agent; drop them when the agent changes so the new agent's
   // own defaults show through.
@@ -716,7 +721,7 @@ export default function HomeView() {
                       onChange={(event) => setWorktreeOverride(event.target.checked)}
                       className="h-4 w-4 flex-none accent-(--brand)"
                     />
-                    <span className="truncate">Worktree</span>
+                    <span className="truncate">{isolationLabel.mode}</span>
                   </label>
                 )}
               </>

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -120,7 +120,7 @@ export default function HomeView() {
   const { user } = useProfile()
   const firstName = user.name.trim().split(/\s+/)[0] ?? ''
   const { orgPath } = useOrgs()
-  const { agents, daemons, crons, allSessions, usage24h, getAgent, loading, memberSets } = useConsoleData()
+  const { agents, daemons, crons, allSessions, usage24h, getAgent, loading, memberSets, orgSetIds } = useConsoleData()
   const { openPlayground, pgSend, pgSetModel, pgSetEffort, pgSetPermissionPreset } = usePlayground()
   // Home is the default landing, so it owns the fresh-org bounce to /onboarding.
   const holdForOnboarding = useOnboardingRedirect()
@@ -225,7 +225,8 @@ export default function HomeView() {
   const worktree = worktreeOverride ?? defaultWorktree
   // What that toggle is CALLED follows the agent's effective boundary, not its stored sandbox flag (git-workspace-model.md §11).
   const isolationLabel = agentSessionIsolationLabel(
-    agent ?? { runInSandbox: false, sandboxSupported: false, sandboxRequired: false }
+    agent ?? { runInSandbox: false, sandboxSupported: false, sandboxRequired: false },
+    orgSetIds
   )
 
   // Overrides are per-agent; drop them when the agent changes so the new agent's

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -1606,6 +1606,7 @@ export default function SessionDetailView() {
     crons,
     daemons,
     memberSets,
+    orgSetIds,
     members,
     sessionActivityVersionById,
     sessionStreamGeneration,
@@ -2735,7 +2736,8 @@ export default function SessionDetailView() {
   const focusedAgentLabel = focusedAgent ? agentLabel(focusedAgent) : (headerFocusOption?.label ?? 'agent')
   // Named by the focused agent's effective boundary, so a confined session is not offered a "worktree" it does not get (git-workspace-model.md §11).
   const focusedIsolation = agentSessionIsolationLabel(
-    focusedAgent ?? { runInSandbox: false, sandboxSupported: false, sandboxRequired: false }
+    focusedAgent ?? { runInSandbox: false, sandboxSupported: false, sandboxRequired: false },
+    orgSetIds
   )
   const workspaceTitle = hasSessionWorktree
     ? `Open ${focusedAgentLabel}’s ${focusedIsolation.checkout}`
@@ -2849,7 +2851,8 @@ export default function SessionDetailView() {
     (!!owner?.workspace && isGitWorkspace(owner.workspace) && owner.workspace.worktree === true)
   // The chip names the isolation by the owner's EFFECTIVE boundary (git-workspace-model.md §11), never by its stored sandbox flag.
   const isolationLabel = agentSessionIsolationLabel(
-    owner ?? { runInSandbox: false, sandboxSupported: false, sandboxRequired: false }
+    owner ?? { runInSandbox: false, sandboxSupported: false, sandboxRequired: false },
+    orgSetIds
   )
   const canChooseWorktree =
     isPg &&

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -42,6 +42,7 @@ import {
   type SessionImage,
   type SessionStep
 } from '@/lib/data'
+import { agentSessionIsolationLabel } from '@/lib/session-isolation'
 import {
   ApiError,
   fetchConversationByKey,
@@ -2732,8 +2733,12 @@ export default function SessionDetailView() {
       : null
   const workspaceIcon = focusedAgent && isGitWorkspace(focusedAgent.workspace) ? 'git-branch' : 'folder'
   const focusedAgentLabel = focusedAgent ? agentLabel(focusedAgent) : (headerFocusOption?.label ?? 'agent')
+  // Named by the focused agent's effective boundary, so a confined session is not offered a "worktree" it does not get (git-workspace-model.md §11).
+  const focusedIsolation = agentSessionIsolationLabel(
+    focusedAgent ?? { runInSandbox: false, sandboxSupported: false, sandboxRequired: false }
+  )
   const workspaceTitle = hasSessionWorktree
-    ? `Open ${focusedAgentLabel}’s session worktree`
+    ? `Open ${focusedAgentLabel}’s ${focusedIsolation.checkout}`
     : `Open ${focusedAgentLabel}’s workspace`
   // Scoped to this session's OWN worktree only where it has one. `hasSessionWorktree` is the same gate the Workspace link above uses, and it is load-bearing for the reads: the daemon answers a shared workspace's sessionId with BAD_PAYLOAD, which the CP maps to a 503 that reads as "the daemon may be offline".
   const filesSessionId = hasSessionWorktree && headerFocusSessionId ? headerFocusSessionId : undefined
@@ -2842,6 +2847,10 @@ export default function SessionDetailView() {
     worktreeSelections[session.id] ??
     getPgWorktree(session.id) ??
     (!!owner?.workspace && isGitWorkspace(owner.workspace) && owner.workspace.worktree === true)
+  // The chip names the isolation by the owner's EFFECTIVE boundary (git-workspace-model.md §11), never by its stored sandbox flag.
+  const isolationLabel = agentSessionIsolationLabel(
+    owner ?? { runInSandbox: false, sandboxSupported: false, sandboxRequired: false }
+  )
   const canChooseWorktree =
     isPg &&
     !multiLive &&
@@ -4761,7 +4770,7 @@ export default function SessionDetailView() {
                                   }}
                                   className="h-4 w-4 flex-none accent-(--brand)"
                                 />
-                                <span className="truncate">Worktree</span>
+                                <span className="truncate">{isolationLabel.mode}</span>
                               </label>
                             )}
                           </div>

--- a/packages/web/src/components/console/workspace-tree.tsx
+++ b/packages/web/src/components/console/workspace-tree.tsx
@@ -241,11 +241,12 @@ export type WorkspaceGitOutcome = 'pending' | 'repo' | 'none' | 'asleep' | 'unav
 /** The CP's code for "this agent's sandbox is not running". A 503 like an offline daemon — the code is the only thing that separates the two, and a plain 503 keeps the offline story. */
 export const SANDBOX_ASLEEP_CODE = 'WORKSPACE_SANDBOX_UNAVAILABLE'
 
-/** What both file surfaces say when a read SUCCEEDS and reports a session-scoped root that is not there. Named no cause on purpose: a worktree the daemon reclaimed and one this session was never given are the same answer from here, and the sentence this replaced asserted the first and promised a recreation the second never gets. */
-// `repo` names the SELECTED root, because with one chosen the missing worktree is that root's and a bare "its worktree" reads as the session's primary one.
+/** What both file surfaces say when a read SUCCEEDS and reports a session-scoped root that is not there. Named no cause on purpose: a checkout the daemon reclaimed and one this session was never given are the same answer from here, and the sentence this replaced asserted the first and promised a recreation the second never gets. */
+// It names no MECHANISM either: whether a session's directory is a worktree or its own clone follows the effective boundary (git-workspace-model.md §11), which this read cannot see.
+// `repo` names the SELECTED root, because with one chosen the missing checkout is that root's and a bare "it" reads as the session's primary one.
 export function sessionWorktreeAbsentNotice(repo?: string): string {
   const of = repo ? ` of ${repo}` : ''
-  return `No checkout${of} for this session — its worktree may have been cleaned up, or this session may not have one${repo ? ' for this repository' : ' of its own'}.`
+  return `No checkout${of} for this session — it may have been cleaned up, or this session may not have one${repo ? ' for this repository' : ' of its own'}.`
 }
 
 /** Whether a failed workspace read was the sandbox being asleep rather than anything being wrong. */

--- a/packages/web/src/lib/session-isolation.test.ts
+++ b/packages/web/src/lib/session-isolation.test.ts
@@ -37,17 +37,28 @@ describe('sessionIsolationLabel', () => {
 
 describe('agentSessionIsolationLabel', () => {
   const agent = { runInSandbox: false, sandboxSupported: false, sandboxRequired: false }
+  // The org's own groups. The pool is org-less, so its set id is never in this list — that is the whole test.
+  const orgSetIds = new Set(['set_group_a'])
 
   it('reads a pool placement as enclosed even though the pool advertises no sandbox capability', () => {
-    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'pool' }).mode).toBe('Session isolation')
+    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'pool' }, orgSetIds).mode).toBe('Session isolation')
     // What the CP actually stores for the pool is `set` (daemon-groups.md §2); both spellings are the pool here.
-    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'set' }).mode).toBe('Session isolation')
+    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'set', setId: 'set_pool' }, orgSetIds).mode).toBe(
+      'Session isolation'
+    )
+  })
+
+  it('reads an ORG-OWNED set through the sandbox triple, because a group is machines and not the pool', () => {
+    const group = { ...agent, placementKind: 'set' as const, setId: 'set_group_a' }
+    // Nothing encloses an unsandboxed group member, so §11 gives it a plain linked worktree.
+    expect(agentSessionIsolationLabel(group, orgSetIds).mode).toBe('Worktree')
+    expect(agentSessionIsolationLabel({ ...group, sandboxRequired: true }, orgSetIds).mode).toBe('Session isolation')
   })
 
   it('reads a machine placement through its projected sandbox triple', () => {
-    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'daemon' }).mode).toBe('Worktree')
-    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'daemon', sandboxRequired: true }).mode).toBe(
-      'Session isolation'
-    )
+    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'daemon' }, orgSetIds).mode).toBe('Worktree')
+    expect(
+      agentSessionIsolationLabel({ ...agent, placementKind: 'daemon', sandboxRequired: true }, orgSetIds).mode
+    ).toBe('Session isolation')
   })
 })

--- a/packages/web/src/lib/session-isolation.test.ts
+++ b/packages/web/src/lib/session-isolation.test.ts
@@ -1,0 +1,53 @@
+// The three rows of git-workspace-model.md §11: the label follows the EFFECTIVE boundary, not the stored flag.
+import { describe, it, expect } from 'vitest'
+import { agentSessionIsolationLabel, hasRuntimeBoundary, sessionIsolationLabel } from '@/lib/session-isolation'
+
+const selfHosted = { pool: false, runInSandbox: false, sandboxSupported: false, sandboxRequired: false }
+
+describe('sessionIsolationLabel', () => {
+  it('names a worktree when nothing encloses the runtime — self-hosted daemon, sandbox not effective', () => {
+    expect(sessionIsolationLabel(selfHosted)).toEqual({
+      mode: 'Worktree',
+      checkout: 'worktree',
+      checkouts: 'worktrees'
+    })
+  })
+
+  it('names session isolation on a self-hosted daemon whose sandbox is effective', () => {
+    expect(sessionIsolationLabel({ ...selfHosted, sandboxSupported: true, runInSandbox: true }).mode).toBe(
+      'Session isolation'
+    )
+    // Forced on by daemon policy is just as effective, whatever the stored preference says.
+    expect(sessionIsolationLabel({ ...selfHosted, sandboxRequired: true }).mode).toBe('Session isolation')
+  })
+
+  it('names session isolation on a managed-pool runtime, which the pod encloses whatever the sandbox triple says', () => {
+    expect(sessionIsolationLabel({ ...selfHosted, pool: true })).toEqual({
+      mode: 'Session isolation',
+      checkout: 'session checkout',
+      checkouts: 'session checkouts'
+    })
+  })
+
+  it('ignores a stored preference the daemon cannot honour — that is the flag/effective split', () => {
+    expect(sessionIsolationLabel({ ...selfHosted, runInSandbox: true }).mode).toBe('Worktree')
+    expect(hasRuntimeBoundary({ ...selfHosted, runInSandbox: true })).toBe(false)
+  })
+})
+
+describe('agentSessionIsolationLabel', () => {
+  const agent = { runInSandbox: false, sandboxSupported: false, sandboxRequired: false }
+
+  it('reads a pool placement as enclosed even though the pool advertises no sandbox capability', () => {
+    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'pool' }).mode).toBe('Session isolation')
+    // What the CP actually stores for the pool is `set` (daemon-groups.md §2); both spellings are the pool here.
+    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'set' }).mode).toBe('Session isolation')
+  })
+
+  it('reads a machine placement through its projected sandbox triple', () => {
+    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'daemon' }).mode).toBe('Worktree')
+    expect(agentSessionIsolationLabel({ ...agent, placementKind: 'daemon', sandboxRequired: true }).mode).toBe(
+      'Session isolation'
+    )
+  })
+})

--- a/packages/web/src/lib/session-isolation.ts
+++ b/packages/web/src/lib/session-isolation.ts
@@ -1,5 +1,5 @@
 // How the console NAMES `workspaceIsolation: 'session'` — git-workspace-model.md §11.
-import { isPoolPlacementKind, type Agent, type PlacementKindValue } from '@/lib/data'
+import { isPoolPlacementKind, type Agent } from '@/lib/data'
 
 /** What decides whether an OS boundary encloses the runtime a session will use. */
 export interface RuntimeBoundary {
@@ -41,11 +41,13 @@ export function sessionIsolationLabel(boundary: RuntimeBoundary): SessionIsolati
 }
 
 /** The same label for an agent the console already holds, whose sandbox triple the CP projected against the daemon it is placed on. */
+// `orgSetIds` is REQUIRED, like `agentDaemonLabel`'s `groups` and for the same reason: the pool is the set that is NOT the org's, so a caller that omits the list reads every group placement as Cloud and labels an unsandboxed group agent — which gets a plain worktree — "Session isolation".
 export function agentSessionIsolationLabel(
-  agent: Pick<Agent, 'runInSandbox' | 'sandboxSupported' | 'sandboxRequired'> & { placementKind?: PlacementKindValue }
+  agent: Pick<Agent, 'placementKind' | 'setId' | 'runInSandbox' | 'sandboxSupported' | 'sandboxRequired'>,
+  orgSetIds: ReadonlySet<string>
 ): SessionIsolationLabel {
   return sessionIsolationLabel({
-    pool: isPoolPlacementKind(agent.placementKind),
+    pool: isPoolPlacementKind(agent.placementKind, agent.setId, orgSetIds),
     runInSandbox: agent.runInSandbox,
     sandboxSupported: agent.sandboxSupported,
     sandboxRequired: agent.sandboxRequired

--- a/packages/web/src/lib/session-isolation.ts
+++ b/packages/web/src/lib/session-isolation.ts
@@ -1,0 +1,53 @@
+// How the console NAMES `workspaceIsolation: 'session'` — git-workspace-model.md §11.
+import { isPoolPlacementKind, type Agent, type PlacementKindValue } from '@/lib/data'
+
+/** What decides whether an OS boundary encloses the runtime a session will use. */
+export interface RuntimeBoundary {
+  /** A managed-pool runtime: its own pod is the boundary, so the daemon offers no `sandbox` capability and `runInSandbox` is not a knob there at all. */
+  pool: boolean
+  /** The agent's stored Run in sandbox preference — never the label's input on its own. */
+  runInSandbox: boolean
+  /** Whether the daemon this will run on can provide the sandbox. */
+  sandboxSupported: boolean
+  /** Whether that daemon's policy forces the sandbox on. */
+  sandboxRequired: boolean
+}
+
+/** Is an OS boundary in effect? The same `sandboxRequired || (sandboxSupported && runInSandbox)` the agent modals gate their toggle on, with a pool runtime always confined by its own pod. */
+export function hasRuntimeBoundary(boundary: RuntimeBoundary): boolean {
+  return boundary.pool || boundary.sandboxRequired || (boundary.sandboxSupported && boundary.runInSandbox)
+}
+
+/** The nouns one effective boundary earns: `mode` names the setting, `checkout`/`checkouts` the per-session directory it produces. */
+export interface SessionIsolationLabel {
+  mode: string
+  checkout: string
+  checkouts: string
+}
+
+/** No boundary — the per-session directory is a linked worktree of the primary, and saying so is the most useful thing the console can say. */
+const WORKTREE_LABEL: SessionIsolationLabel = { mode: 'Worktree', checkout: 'worktree', checkouts: 'worktrees' }
+
+/** Boundary present — the directory is a per-session clone, so the console names the promise instead of an implementation the reader cannot act on. */
+const CONFINED_LABEL: SessionIsolationLabel = {
+  mode: 'Session isolation',
+  checkout: 'session checkout',
+  checkouts: 'session checkouts'
+}
+
+/** The label for one effective boundary — the only place the two vocabularies are chosen between. */
+export function sessionIsolationLabel(boundary: RuntimeBoundary): SessionIsolationLabel {
+  return hasRuntimeBoundary(boundary) ? CONFINED_LABEL : WORKTREE_LABEL
+}
+
+/** The same label for an agent the console already holds, whose sandbox triple the CP projected against the daemon it is placed on. */
+export function agentSessionIsolationLabel(
+  agent: Pick<Agent, 'runInSandbox' | 'sandboxSupported' | 'sandboxRequired'> & { placementKind?: PlacementKindValue }
+): SessionIsolationLabel {
+  return sessionIsolationLabel({
+    pool: isPoolPlacementKind(agent.placementKind),
+    runInSandbox: agent.runInSandbox,
+    sandboxSupported: agent.sandboxSupported,
+    sandboxRequired: agent.sandboxRequired
+  })
+}


### PR DESCRIPTION
`workspaceIsolation: 'session'` promises each session its own directory. How that directory is made depends on whether an OS boundary encloses the runtime — `docs/designs/git-workspace-model.md` §11 decides it is a linked worktree when nothing does, and a per-session clone when something does. The console called it a "worktree" either way.

That is wrong in both confined cases, and worst in the one that matters most: a managed-pool runtime is enclosed by its own pod, so the daemon keeps the in-process sandbox off there and advertises no `sandbox` capability at all — the stored flag reads "no sandbox" exactly where the boundary is strongest.

| Effective boundary | Label |
| --- | --- |
| none — self-hosted daemon, sandbox not effective | Worktree |
| self-hosted daemon, sandbox effective | Session isolation |
| managed pool | Session isolation |

## The helper

`packages/web/src/lib/session-isolation.ts` is the one place that decides:

- `sessionIsolationLabel({ pool, runInSandbox, sandboxSupported, sandboxRequired })` — folds in the same `sandboxRequired || (sandboxSupported && runInSandbox)` the agent modals already gate their toggle on, with `pool` short-circuiting it, and returns the `mode` / `checkout` / `checkouts` nouns.
- `agentSessionIsolationLabel(agent)` — the form for an agent the console already holds, whose sandbox triple the control plane projected against the daemon it is placed on. Pool detection reuses `isPoolPlacementKind`, so a `set` placement naming one of the org's own groups still goes through the sandbox triple rather than being read as the pool.

Both entry points exist because the create/edit modals label a *pending* placement — the daemon in the form may not be the one the agent is on yet — while every read-only surface labels the placement the agent already has.

## What changed on screen

Driven by the helper, where the console **names the mode**:

- the workspace form's isolation toggle (label and `aria-label`), in the create and edit modals and the Git URL tile;
- the checkout picker: section heading, footer count, loading and empty states;
- the composer chips on the landing page and on session detail, and session detail's "open this session's checkout" tooltip.

Reworded without the helper, where the copy merely refers to the session's own directory and the surface cannot see the boundary from where it stands — the file viewer, the files and git panels, and the git-write failures now say "checkout" instead of "worktree".

Left alone on purpose, in two groups:

- sentences that assert something true only of a *linked* worktree — a detached HEAD, a `.git` shared with the primary. They describe the unconfined tier's real behavior and change with the runtime work, not with a label.
- the pull-request panel's fix-up instructions, which are turn text handed to the agent rather than console copy. Rewording a prompt is a behavior change and does not belong in a labeling PR.

Identifiers, props, state and URL parameters keep their existing names; this is a wording change plus the one new helper.

## Verification

Unit and component level only — no browser verification.

- `packages/web/src/lib/session-isolation.test.ts` covers the three rows of the table above, both spellings of a pool placement, and the flag-vs-effective split (a stored `runInSandbox` the daemon cannot honour still reads as a worktree).
- **Mutation check**: swapping the helper's two labels turns all 6 of its tests red; restored, all 6 pass.
- `WorkspaceScopePicker.test.tsx` builds its labels *through* the helper rather than spelling them out, so the picker's copy cannot drift from what the helper decides, and gains a case asserting the confined vocabulary appears and the word "worktree" does not.
- `pnpm --filter @agentconnect.md/web typecheck` clean; full web suite 2348 passed / 211 files; prettier and eslint clean on everything touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
