### PR TITLE
feat(daemon): launch managed ACP adapters from a daemon-owned tree, not npx into the agent HOME

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -2222,7 +2222,9 @@ export class Daemon {
         this.log.info(`runtimes: "${id}" launches ${launch.name}@${installed.version} from ${installed.tree}`)
       } catch (err) {
         delete entries[id]
-        this.runtimeStoreFailures.set(id, formatErr(err))
+        // This detail reaches a console reader through the refusal, so it is the bounded, path-free
+        // line the convention requires; the full diagnostic stays in the daemon log beside it.
+        this.runtimeStoreFailures.set(id, startFailureDetail(err))
         this.log.warn(`runtimes: "${id}" has no daemon-owned install — ${formatErr(err)}`)
       }
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -231,7 +231,7 @@ import {
   type HookQueueCandidate,
   type RevisionAdmissionPlan
 } from './codehost/hook-admission.js'
-import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from './runtimes/registry.js'
+import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog, type RuntimeSource } from './runtimes/registry.js'
 import {
   internalPassSlot,
   InternalPassSessions,
@@ -262,7 +262,8 @@ import { ModelCatalogService } from './runtimes/model-catalog.js'
 import { makeModelEnumerator } from './runtimes/model-enumerator.js'
 import { clusterProbeHostFactory, defaultProbeHostFactory } from './acp/probe-host-factory.js'
 import { runtimeHomePath } from './runtimes/runtime-home.js'
-import { npmRepairEnv, planRuntimeInstallRepair, repairRuntimeInstall } from './runtimes/runtime-install-repair.js'
+import { planRuntimeInstallRepair, repairRuntimeInstall } from './runtimes/runtime-install-repair.js'
+import { RuntimeStore, parseNpxLaunch, storedRuntimeDef } from './runtimes/runtime-store.js'
 import {
   applyCodexSessionFloor,
   applyModelCredential,
@@ -772,9 +773,9 @@ export class Daemon {
     string,
     { agentDir: string; childEnv?: Record<string, string | undefined>; materialized: boolean }
   >()
-  // HOME the last built host launched with, so a start failure can be diagnosed against the exact
-  // package tree the child resolved — private for an isolated runtime, the daemon's own otherwise.
-  private hostRuntimeHome = new Map<string, string>()
+  // Why a daemon-supplied adapter has no install in the runtime store, so a refusal can name its tree.
+  private runtimeStoreFailures = new Map<string, string>()
+  private runtimeStore?: Pick<RuntimeStore, 'ensure'>
   // Terminal ACP start failure per agent, so a later refusal can say the runtime did not start
   // instead of reporting the agent as absent. Cleared once the agent starts or leaves the roster.
   private lastStartFailure = new Map<string, string>()
@@ -1301,6 +1302,8 @@ export class Daemon {
       /** Test seams for local catalog resolution and executable/state filtering. */
       resolveCatalog?: typeof resolveRuntimeCatalog
       installed?: typeof installedRuntimes
+      /** Test seam for the daemon-owned adapter store; production builds one over the daemon root. */
+      runtimeStore?: Pick<RuntimeStore, 'ensure'>
       /** Test seam: null simulates a host without Linux SRT/bwrap. */
       sandboxMechanism?: SandboxMechanism | null
       /** `--k8s`: runtimes live in sandbox pods, not on this host. Disables runtime
@@ -2165,8 +2168,14 @@ export class Daemon {
       : this.k8s
         ? this.declaredPoolCatalog(root, resolvedCatalog)
         : installedRuntimeCatalog(resolvedCatalog)
-    const { runtimes: installed, entries: installedEntries } = installedCatalog
-    this.runtimeCatalog = installedCatalog
+    // Only what this daemon's agents actually run: a runtime assigned later is installed before its
+    // first host start instead, so a host with six logged-in harnesses does not fetch all six here.
+    const storedCatalog = await this.installManagedRuntimePackages(
+      installedCatalog,
+      discoveredAgents.map((agent) => agent.runtime)
+    )
+    const { runtimes: installed, entries: installedEntries } = storedCatalog
+    this.runtimeCatalog = storedCatalog
     this.refreshAdmittedRuntimes()
     this.runtimeFacts.setInstalled(installedEntries)
     this.log.info(`runtimes ready: ${Object.keys(this.runtimes).join(', ') || '(none)'}`)
@@ -2174,6 +2183,69 @@ export class Daemon {
     if (pendingCurated.length) this.log.info(`runtimes pending ACP admission: ${pendingCurated.join(', ')}`)
     const skipped = Object.keys(resolvedCatalog.runtimes).filter((id) => !installed[id])
     if (skipped.length) this.log.info(`runtimes not installed (skipped): ${skipped.join(', ')}`)
+  }
+
+  // Sources whose launch spec the daemon itself supplies. Explicit `user` config is the operator's
+  // final authority, and `image` is declared by a sandbox image this daemon does not install into.
+  private static readonly STORE_MANAGED_SOURCES: ReadonlySet<RuntimeSource> = new Set([
+    'curated',
+    'registry',
+    'managed'
+  ])
+
+  /** The store this daemon installs adapters into. A pool launch resolves its packages inside the
+   *  sandbox pod and an injected host factory never spawns a runtime child, so neither gets one. */
+  private adapterStore(root: string): Pick<RuntimeStore, 'ensure'> | undefined {
+    if (this.k8s || this.opts.hostFactory) return undefined
+    this.runtimeStore ??= this.opts.runtimeStore ?? new RuntimeStore({ root, log: this.log })
+    return this.runtimeStore
+  }
+
+  /** Install each id's daemon-supplied `npx` adapter into the daemon-owned store and launch it from
+   *  there, so no agent launch resolves a package and none loads adapter code out of a writable HOME.
+   *  An adapter with no install leaves the catalog: {@link runtimeUnavailableMessage} names its tree. */
+  private async installManagedRuntimePackages(
+    catalog: ResolvedRuntimeCatalog,
+    ids: Iterable<string>
+  ): Promise<ResolvedRuntimeCatalog> {
+    const store = this.adapterStore(this.root)
+    if (!store) return catalog
+    const entries = { ...catalog.entries }
+    for (const id of new Set(ids)) {
+      const entry = entries[id]
+      const launch = entry && Daemon.STORE_MANAGED_SOURCES.has(entry.source) ? parseNpxLaunch(entry.runtime) : undefined
+      if (!entry || !launch) continue
+      try {
+        const installed = await store.ensure(launch)
+        entries[id] = { ...entry, runtime: storedRuntimeDef(entry.runtime, launch, installed) }
+        this.runtimeStoreFailures.delete(id)
+        this.log.info(`runtimes: "${id}" launches ${launch.name}@${installed.version} from ${installed.tree}`)
+      } catch (err) {
+        delete entries[id]
+        this.runtimeStoreFailures.set(id, formatErr(err))
+        this.log.warn(`runtimes: "${id}" has no daemon-owned install — ${formatErr(err)}`)
+      }
+    }
+    return {
+      entries,
+      runtimes: Object.fromEntries(Object.entries(entries).map(([id, entry]) => [id, entry.runtime]))
+    }
+  }
+
+  /** Install the adapter for a runtime the start-time sweep did not cover — an agent the CP assigned
+   *  after boot. The store memoizes, so this resolves once for the runtime and never once per spawn. */
+  private async ensureRuntimeInstalled(runtimeId: string): Promise<void> {
+    const entry = this.runtimeCatalog.entries[runtimeId]
+    if (!entry || !Daemon.STORE_MANAGED_SOURCES.has(entry.source) || !parseNpxLaunch(entry.runtime)) return
+    this.runtimeCatalog = await this.installManagedRuntimePackages(this.runtimeCatalog, [runtimeId])
+    this.refreshAdmittedRuntimes()
+  }
+
+  /** Why a runtime cannot launch: a failed daemon-owned install names its tree, else it is simply absent. */
+  private runtimeUnavailableMessage(id: string): string {
+    const failure = this.runtimeStoreFailures.get(id)
+    if (failure) return `runtime "${id}" has no daemon-owned install: ${failure}`
+    return `runtime "${id}" not available: not installed on this host, or absent from config.runtimes / the ACP registry`
   }
 
   /** Phase 14 — strip the reserved bridge key ONCE, so every consumer sees a clean MCP server map. */
@@ -3229,7 +3301,6 @@ export class Daemon {
       this.drainingAgents.add(id)
       await this.interruptAgentTurns(id, 'stop')
       this.agents.delete(id)
-      this.hostRuntimeHome.delete(id)
       // A stage-out leaves the roster for exactly the reason a later refusal must explain, so the
       // recorded cause survives it. A genuine removal clears it where the tombstone is taken.
       if (!this.moveStagedAgents.has(id)) this.lastStartFailure.delete(id)
@@ -3848,7 +3919,6 @@ export class Daemon {
     this.hosts.set(agentId, built.host)
     this.hostStartedAt.set(agentId, this.clock.now())
     this.hostConfigFiles.set(agentId, { agentDir: agent.dir, ...built.configFileState })
-    if (built.runtimeHome) this.hostRuntimeHome.set(agentId, built.runtimeHome)
     return built.host
   }
 
@@ -3879,8 +3949,6 @@ export class Daemon {
   ): {
     host: AcpHost
     configFileState: { childEnv?: Record<string, string | undefined>; materialized: boolean }
-    /** HOME the child resolves its packages under; absent only for an injected host factory. */
-    runtimeHome?: string
   } {
     const agentId = agent.id
     const onUpdate = (sid: string, u: any) => this.enqueueAcpUpdate(agentId, sid, u)
@@ -3909,10 +3977,7 @@ export class Daemon {
       return { host: this.opts.hostFactory(agent, onUpdate), configFileState }
     }
     const runtime = this.runtimes[agent.runtime]
-    if (!runtime)
-      throw new Error(
-        `runtime "${agent.runtime}" not available: not installed on this host, or absent from config.runtimes / the ACP registry`
-      )
+    if (!runtime) throw new Error(this.runtimeUnavailableMessage(agent.runtime))
     // A dream reads only its materialized inputs to produce a memory proposal, so
     // it never needs the agent's TOOL credentials (github-app git helper, gh
     // wrapper, or materialized `*_DATA` config-file secrets like KUBECONFIG /
@@ -4140,10 +4205,7 @@ export class Daemon {
       log: this.log
     })
     constructed.host = host
-    // What HOME the child actually got, since that is where it resolves its packages: the private
-    // runtime home when isolated, otherwise whatever the inherited daemon environment points at.
-    const runtimeHome = launch.env.HOME ?? (launch.inheritProcessEnv ? process.env.HOME : undefined)
-    return { host, configFileState, ...(runtimeHome ? { runtimeHome } : {}) }
+    return { host, configFileState }
   }
 
   /**
@@ -13666,6 +13728,7 @@ export class Daemon {
       // immutable skill receipts after it is fully reaped and before constructing
       // its replacement, rather than trusting the first attempt's gate.
       await this.prepareAgentWorkspace(agent, undefined, undefined, allowAgentDrain)
+      await this.ensureRuntimeInstalled(agent.runtime)
       if (this.hostStartGeneration.get(agentId) !== generation) {
         throw new Error(`host start superseded for ${agentId}`)
       }
@@ -13690,7 +13753,6 @@ export class Daemon {
         // resting on disk. Generation-fenced above, so this can't touch a
         // superseding host's files; the next attempt re-materializes its own.
         const failedSpawnDir = this.hostConfigFiles.get(agentId)?.agentDir
-        const failedRuntimeHome = this.hostRuntimeHome.get(agentId)
         this.hostConfigFiles.delete(agentId)
         if (failedSpawnDir) {
           const cleanupErr = cleanupConfigFiles(failedSpawnDir)
@@ -13699,8 +13761,8 @@ export class Daemon {
         // Retrying an incomplete package tree just reproduces the same crash, so repair it once and
         // let the loop try again rather than burning every attempt and staging the agent out. An
         // attempt that failed for some other reason must not spend the one repair.
-        if (!repairTried && failedRuntimeHome) {
-          const outcome = await this.repairAgentRuntimeInstall(agentId, failedRuntimeHome, err)
+        if (!repairTried) {
+          const outcome = await this.repairAgentRuntimeInstall(agentId, err)
           if (outcome !== 'declined') repairTried = true
           if (outcome === 'repaired') extraAttempts = 1
         }
@@ -13720,22 +13782,17 @@ export class Daemon {
     throw lastErr
   }
 
-  // Agents on a non-isolated runtime share one npx tree, so their simultaneous failures would
+  // Every agent on a runtime shares its one store tree, so their simultaneous failures would
   // otherwise run concurrent installs in the same directory and leave it worse than they found it.
   private readonly runtimeInstallRepairs = new Map<string, Promise<boolean>>()
 
-  /** Reinstall a runtime package the adapter reported missing, in the tree the child resolved.
-   *  Repairs only what an installed lockfile already declares, and never runs npm lifecycle
-   *  scripts — the tree sits in the agent's own writable HOME. Cluster launches resolve their
-   *  packages inside the agent's pod, so there is nothing here to repair. `declined` means no
-   *  repair was applicable, and leaves the one repair a start sequence gets unspent. */
-  private async repairAgentRuntimeInstall(
-    agentId: string,
-    home: string,
-    err: unknown
-  ): Promise<'declined' | 'failed' | 'repaired'> {
+  /** Reinstall a runtime package the adapter reported missing, in the daemon-owned store tree it
+   *  launched from. Repairs only what an installed lockfile already declares. Cluster launches
+   *  resolve their packages inside the agent's pod, so there is nothing here to repair. `declined`
+   *  means no repair was applicable, and leaves the one repair a start sequence gets unspent. */
+  private async repairAgentRuntimeInstall(agentId: string, err: unknown): Promise<'declined' | 'failed' | 'repaired'> {
     if (this.k8sPlane) return 'declined'
-    const plan = planRuntimeInstallRepair(home, (err as { message?: string })?.message ?? '')
+    const plan = planRuntimeInstallRepair(this.root, (err as { message?: string })?.message ?? '')
     if (!plan) return 'declined'
     const inFlight = this.runtimeInstallRepairs.get(plan.tree)
     if (inFlight) {
@@ -13743,7 +13800,7 @@ export class Daemon {
       return (await inFlight.catch(() => false)) ? 'repaired' : 'failed'
     }
     this.log.warn(`acp: agent "${agentId}" is missing runtime package "${plan.pkg}" — reinstalling ${plan.tree}`)
-    const run = repairRuntimeInstall(plan, npmRepairEnv(home))
+    const run = repairRuntimeInstall(plan)
     this.runtimeInstallRepairs.set(plan.tree, run)
     try {
       const repaired = await run

--- a/packages/daemon/src/paths.ts
+++ b/packages/daemon/src/paths.ts
@@ -30,6 +30,11 @@ export function defaultAgentsDir(root: string): string {
   return join(root, 'agents')
 }
 
+/** Daemon-owned ACP adapter installs — never under a HOME, because the adapter is the runtime's parent. */
+export function runtimeStoreDir(root: string): string {
+  return join(root, 'runtimes')
+}
+
 export function registryPath(root: string): string {
   return join(root, 'acp_registry.json')
 }

--- a/packages/daemon/src/runtimes/managed.ts
+++ b/packages/daemon/src/runtimes/managed.ts
@@ -6,8 +6,9 @@ export interface ManagedRuntimeEntry {
   runtime: RuntimeDef
 }
 
-/** AgentConnect-maintained runtime builds that intentionally override the
- * public ACP registry. Explicit operator config remains the final authority. */
+/** AgentConnect-maintained runtime builds that intentionally override the public ACP registry.
+ *  Explicit operator config remains the final authority. The daemon installs each `npx` spec below
+ *  into its own runtime store at start and launches from there, never through `npx` (runtime-store.ts). */
 export const MANAGED_RUNTIME_CATALOG: Readonly<Record<string, ManagedRuntimeEntry>> = Object.freeze({
   'codex-acp': {
     name: 'Codex',

--- a/packages/daemon/src/runtimes/runtime-install-repair.ts
+++ b/packages/daemon/src/runtimes/runtime-install-repair.ts
@@ -1,9 +1,9 @@
-import { execFile } from 'node:child_process'
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
-import { resolveCommandPath } from './probe.js'
+import { runtimeStoreDir } from '../paths.js'
+import { execFileNpmCommand, type NpmCommandRunner } from './runtime-store.js'
 
-// npm can leave an `npx` tree whose lockfile names a platform package that node_modules lacks:
+// npm can leave an install tree whose lockfile names a platform package that node_modules lacks:
 // reifying an in-place upgrade removes the old aliased optional package without adding the new one.
 // The adapter then starts fine and dies the moment it spawns its real binary, and every retry fails
 // identically, so the daemon stages the agent out of its roster over a repairable install.
@@ -12,12 +12,11 @@ const MISSING_PACKAGE_RE = /Missing optional dependency\s+(\S+)/i
 // npm's own name grammar, so a crafted error string can never name a URL, a path, or an alias spec.
 const PACKAGE_NAME_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/
 
-const NPX_CACHE = ['.npm', '_npx']
-
-// Cap the scan: a private HOME holds one tree per npx package spec, never thousands.
+// Cap the scan: the store holds one tree per adapter, never thousands. A scope is its own level.
 const MAX_TREES = 64
+const MAX_DEPTH = 2
 
-/** One repairable npx tree: `pkg` is declared by `tree`'s lockfile but missing from its node_modules. */
+/** One repairable tree: `pkg` is declared by `tree`'s lockfile but missing from its node_modules. */
 export interface RuntimeInstallRepair {
   tree: string
   pkg: string
@@ -38,98 +37,48 @@ function declaresPackage(tree: string, pkg: string): boolean {
   }
 }
 
-/** Locate the npx trees under `home` that declare `pkg` in their lockfile but have not installed it. */
-export function findRepairableTrees(home: string, pkg: string): string[] {
-  const root = join(home, ...NPX_CACHE)
-  let entries: string[]
-  try {
-    entries = readdirSync(root, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .slice(0, MAX_TREES)
-      .map((entry) => join(root, entry.name))
-  } catch {
-    return []
+function storeTrees(root: string): string[] {
+  const found: string[] = []
+  const walk = (dir: string, depth: number): void => {
+    let entries: import('node:fs').Dirent[]
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || found.length >= MAX_TREES) continue
+      const path = join(dir, entry.name)
+      if (existsSync(join(path, 'package-lock.json'))) found.push(path)
+      else if (depth < MAX_DEPTH) walk(path, depth + 1)
+    }
   }
-  return entries.filter((tree) => !existsSync(join(tree, 'node_modules', pkg)) && declaresPackage(tree, pkg))
+  walk(runtimeStoreDir(root), 1)
+  return found
+}
+
+/** Locate the daemon-owned trees under `root` that declare `pkg` in their lockfile but never installed it. */
+export function findRepairableTrees(root: string, pkg: string): string[] {
+  return storeTrees(root).filter((tree) => !existsSync(join(tree, 'node_modules', pkg)) && declaresPackage(tree, pkg))
 }
 
 /** Plan the repair for one failed start, or undefined when nothing on disk matches the reported fault. */
-export function planRuntimeInstallRepair(home: string, message: string): RuntimeInstallRepair | undefined {
+export function planRuntimeInstallRepair(root: string, message: string): RuntimeInstallRepair | undefined {
   const pkg = missingRuntimePackage(message)
   if (!pkg) return undefined
-  const tree = findRepairableTrees(home, pkg)[0]
+  const tree = findRepairableTrees(root, pkg)[0]
   return tree ? { tree, pkg } : undefined
 }
 
-// npm reads `.npmrc` from the HOME we point it at — a directory the agent can write — and npm
-// interpolates `${VAR}` in config values from the environment. Handing it the daemon's whole env
-// would let an agent-authored `_authToken=${SOME_DAEMON_KEY}` ship a daemon secret to a registry of
-// its choosing, no lifecycle script required. So pass an allowlist: what npm needs to reach a
-// registry through this host's network, and nothing that is worth stealing.
-const NPM_ENV_ALLOWLIST = [
-  'PATH',
-  'Path',
-  'LANG',
-  'LC_ALL',
-  'HTTP_PROXY',
-  'HTTPS_PROXY',
-  'NO_PROXY',
-  'http_proxy',
-  'https_proxy',
-  'no_proxy',
-  'NODE_EXTRA_CA_CERTS',
-  'SSL_CERT_DIR',
-  'SSL_CERT_FILE',
-  // A git-backed dependency reaches its remote through git's own bundle (§24.5).
-  'GIT_SSL_CAINFO',
-  'SystemRoot',
-  'ComSpec',
-  'PATHEXT',
-  'APPDATA',
-  'LOCALAPPDATA'
-]
-
-/** The minimum env npm needs, pointed at the child's HOME so the reinstall lands in the very cache
- *  and lockfile the adapter's own `npx` resolves. */
-export function npmRepairEnv(home: string, source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {}
-  for (const name of NPM_ENV_ALLOWLIST) {
-    const value = source[name]
-    if (value !== undefined) env[name] = value
-  }
-  env.HOME = home
-  if (process.platform === 'win32') env.USERPROFILE = home
-  return env
-}
-
-export type NpmRunner = (tree: string, args: string[], env: NodeJS.ProcessEnv) => Promise<void>
-
-// Bounded because a start waits on it: generous enough for a cold fetch of a large platform
-// binary, short enough that a hung registry fails the start instead of parking a turn.
-const REPAIR_TIMEOUT_MS = 5 * 60_000
-
-/** Reify one tree with the child's own env, so npm resolves the same HOME, cache, and registry.
- *  Resolves the executable against that same env — `execFile` does no PATH/PATHEXT search of its
- *  own, so a bare `npm` would be ENOENT on Windows, where it ships as `npm.cmd`. */
-export const execFileNpmRunner: NpmRunner = (tree, args, env) =>
-  new Promise((resolve, reject) => {
-    const npm = resolveCommandPath('npm', env) ?? 'npm'
-    execFile(npm, args, { cwd: tree, env, timeout: REPAIR_TIMEOUT_MS, windowsHide: true }, (err) =>
-      err ? reject(err) : resolve()
-    )
-  })
-
-// `--ignore-scripts` is the security boundary, not an optimization: the tree and its lockfile sit in
-// the agent's own writable HOME, so running lifecycle scripts here would execute agent-authored code
-// as the daemon, outside the sandbox the adapter itself is confined to.
+// `--ignore-scripts`: a repair only reifies an optional payload the lockfile already declares, so it
+// never needs package lifecycle code that the install this repairs would already have run.
 const REPAIR_ARGS = ['install', '--include=optional', '--ignore-scripts', '--no-audit', '--no-fund']
 
 /** Reinstall the missing package in place. Resolves true only when it is present afterwards. */
 export async function repairRuntimeInstall(
   plan: RuntimeInstallRepair,
-  env: NodeJS.ProcessEnv,
-  runner: NpmRunner = execFileNpmRunner
+  run: NpmCommandRunner = execFileNpmCommand()
 ): Promise<boolean> {
-  await runner(plan.tree, REPAIR_ARGS, env)
+  await run(REPAIR_ARGS, { cwd: plan.tree })
   return existsSync(join(plan.tree, 'node_modules', plan.pkg))
 }

--- a/packages/daemon/src/runtimes/runtime-store.ts
+++ b/packages/daemon/src/runtimes/runtime-store.ts
@@ -1,0 +1,299 @@
+import { execFile } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import type { RuntimeDef } from '../config/config-schema.js'
+import { runtimeStoreDir } from '../paths.js'
+import { resolveCommandPath } from './probe.js'
+
+// An ACP adapter is the runtime's PARENT process, outside every inner tool sandbox, so it must not
+// load its code from anywhere the model can write. `npx -y <spec>` did exactly that: it resolved and
+// installed into `$HOME/.npm/_npx/<hash>` under the agent's own private HOME, at every host spawn.
+// This store installs the same package once, under the daemon root, and launches its declared bin.
+
+/** One `npx` launch decomposed into the package the store installs and the arguments the adapter gets. */
+export interface NpxPackageLaunch {
+  name: string
+  range: string
+  /** The bin `npx -p <pkg> <bin>` named; absent means the package's own default. */
+  bin?: string
+  args: string[]
+}
+
+/** One installed package: the tree, the version it holds, and the bin to launch. */
+export interface StoredRuntimePackage {
+  tree: string
+  version: string
+  bin: string
+}
+
+export type NpmCommandRunner = (args: string[], opts?: { cwd?: string }) => Promise<string>
+
+const NPX_PASSTHROUGH_FLAGS = new Set(['-y', '--yes', '-q', '--quiet', '--silent'])
+const PACKAGE_SPEC_RE = /^((?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?)(?:@([^@\s]+))?$/
+// A registry answer becomes a directory name, so refuse anything that is not plainly a version.
+const VERSION_RE = /^[0-9][0-9A-Za-z.+-]*$/
+
+/** Decompose an `npx` launch into the package the store can install, or undefined when it is not one. */
+export function parseNpxLaunch(runtime: RuntimeDef): NpxPackageLaunch | undefined {
+  if (runtime.command !== 'npx') return undefined
+  const argv = [...runtime.args]
+  let spec: string | undefined
+  let bin: string | undefined
+  while (argv.length > 0) {
+    const arg = argv.shift()!
+    if (NPX_PASSTHROUGH_FLAGS.has(arg)) continue
+    if (arg === '-p' || arg === '--package') {
+      spec = argv.shift()
+      continue
+    }
+    if (arg.startsWith('--package=')) {
+      spec = arg.slice('--package='.length)
+      continue
+    }
+    // Any other flag can change what npx resolves, so leave the whole launch alone rather than guess.
+    if (arg.startsWith('-')) return undefined
+    if (spec) bin = arg
+    else spec = arg
+    break
+  }
+  const matched = spec ? PACKAGE_SPEC_RE.exec(spec) : null
+  if (!matched) return undefined
+  return { name: matched[1]!, range: matched[2] ?? 'latest', ...(bin ? { bin } : {}), args: argv }
+}
+
+/** `<root>/runtimes/<package>@<version>`, with a package scope kept as its own directory level. */
+export function runtimePackageTree(root: string, name: string, version: string): string {
+  const parts = name.split('/')
+  return join(runtimeStoreDir(root), ...parts.slice(0, -1), `${parts.at(-1)}@${version}`)
+}
+
+// Highest first: numeric segments compare as numbers, and a prerelease sorts below its own release.
+function compareVersionsDesc(a: string, b: string): number {
+  const split = (version: string): [string, string] => {
+    const dash = version.indexOf('-')
+    return dash < 0 ? [version, ''] : [version.slice(0, dash), version.slice(dash + 1)]
+  }
+  const [aRelease, aPre] = split(a)
+  const [bRelease, bPre] = split(b)
+  const aParts = aRelease.split('.')
+  const bParts = bRelease.split('.')
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+    const delta = (Number(bParts[i] ?? 0) || 0) - (Number(aParts[i] ?? 0) || 0)
+    if (delta !== 0) return delta
+  }
+  if (aPre === bPre) return 0
+  if (!aPre) return -1
+  if (!bPre) return 1
+  return bPre.localeCompare(aPre)
+}
+
+/** Versions of `name` already installed in the store, newest first. */
+export function installedRuntimeVersions(root: string, name: string): string[] {
+  const parts = name.split('/')
+  const leaf = parts.pop()!
+  try {
+    return readdirSync(join(runtimeStoreDir(root), ...parts), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith(`${leaf}@`))
+      .map((entry) => entry.name.slice(leaf.length + 1))
+      .filter((version) => VERSION_RE.test(version))
+      .sort(compareVersionsDesc)
+  } catch {
+    return []
+  }
+}
+
+function declaredBin(manifestBin: unknown, name: string, bin: string | undefined): string | undefined {
+  const own = name.split('/').pop()!
+  if (typeof manifestBin === 'string') return !bin || bin === own || bin === name ? manifestBin : undefined
+  if (!manifestBin || typeof manifestBin !== 'object') return undefined
+  const table = manifestBin as Record<string, string>
+  if (bin) return table[bin]
+  return table[own] ?? Object.values(table)[0]
+}
+
+/** The launchable bin inside an installed tree, or undefined when the tree is absent or incomplete. */
+export function installedRuntimeBin(tree: string, launch: NpxPackageLaunch): string | undefined {
+  const packageDir = join(tree, 'node_modules', ...launch.name.split('/'))
+  let manifest: { bin?: unknown }
+  try {
+    manifest = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8')) as { bin?: unknown }
+  } catch {
+    return undefined
+  }
+  const relative = declaredBin(manifest.bin, launch.name, launch.bin)
+  if (!relative) return undefined
+  const path = join(packageDir, relative)
+  return existsSync(path) ? path : undefined
+}
+
+/** Launch the store's own install directly: no `npx`, so nothing resolves or downloads at spawn. */
+export function storedRuntimeDef(
+  runtime: RuntimeDef,
+  launch: NpxPackageLaunch,
+  installed: StoredRuntimePackage,
+  node: string = process.execPath
+): RuntimeDef {
+  return {
+    ...runtime,
+    command: node,
+    args: [installed.bin, ...launch.args],
+    // The outer sandbox denies the daemon root; this is how the store tree is carved back read-only.
+    readRoots: [...(runtime.readRoots ?? []), installed.tree]
+  }
+}
+
+// npm interpolates `${VAR}` in `.npmrc` values from its environment, so a full daemon env is one
+// crafted config line away from shipping a daemon secret to a registry of the author's choosing.
+const NPM_ENV_ALLOWLIST = [
+  'PATH',
+  'Path',
+  'LANG',
+  'LC_ALL',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'no_proxy',
+  'NODE_EXTRA_CA_CERTS',
+  'SSL_CERT_DIR',
+  'SSL_CERT_FILE',
+  // A git-backed dependency reaches its remote through git's own bundle (§24.5).
+  'GIT_SSL_CAINFO',
+  'SystemRoot',
+  'ComSpec',
+  'PATHEXT',
+  'APPDATA',
+  'LOCALAPPDATA'
+]
+
+/** The minimum env npm needs. HOME stays the daemon's own, so the `.npmrc` it reads is the operator's. */
+export function npmStoreEnv(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {}
+  for (const name of [...NPM_ENV_ALLOWLIST, 'HOME', 'USERPROFILE']) {
+    const value = source[name]
+    if (value !== undefined) env[name] = value
+  }
+  return env
+}
+
+// Bounded because a daemon start waits on it: generous enough for a cold fetch of a large platform
+// binary, short enough that a hung registry fails the install instead of parking startup forever.
+const NPM_TIMEOUT_MS = 5 * 60_000
+
+/** Run one npm command, resolving the executable against the same env — `execFile` does no PATH search. */
+export function execFileNpmCommand(env: NodeJS.ProcessEnv = npmStoreEnv()): NpmCommandRunner {
+  return (args, opts = {}) =>
+    new Promise((resolve, reject) => {
+      const npm = resolveCommandPath('npm', env) ?? 'npm'
+      const options = { cwd: opts.cwd, env, timeout: NPM_TIMEOUT_MS, windowsHide: true, maxBuffer: 16 * 1024 * 1024 }
+      execFile(npm, args, options, (err, stdout, stderr) =>
+        err
+          ? reject(new Error(`npm ${args[0] ?? ''} failed: ${(String(stderr) || err.message).trim().slice(0, 400)}`))
+          : resolve(String(stdout))
+      )
+    })
+}
+
+export interface RuntimeStoreOptions {
+  root: string
+  run?: NpmCommandRunner
+  log?: { info(message: string): void; warn(message: string): void }
+}
+
+/** Installs daemon-supplied ACP adapters under the daemon root and reports where to launch them. */
+export class RuntimeStore {
+  private readonly inFlight = new Map<string, Promise<StoredRuntimePackage>>()
+  private readonly run: NpmCommandRunner
+
+  constructor(private readonly opts: RuntimeStoreOptions) {
+    this.run = opts.run ?? execFileNpmCommand()
+  }
+
+  /** One install per package for this daemon's lifetime: two hosts starting at once share this promise. */
+  ensure(launch: NpxPackageLaunch): Promise<StoredRuntimePackage> {
+    const key = `${launch.name}@${launch.range}${launch.bin ? `:${launch.bin}` : ''}`
+    const existing = this.inFlight.get(key)
+    if (existing) return existing
+    const run = this.install(launch)
+    this.inFlight.set(key, run)
+    void run.catch(() => {})
+    return run
+  }
+
+  private async install(launch: NpxPackageLaunch): Promise<StoredRuntimePackage> {
+    const resolved = await this.resolveVersion(launch)
+    const version = resolved ?? installedRuntimeVersions(this.opts.root, launch.name)[0]
+    if (!version) {
+      const store = runtimeStoreDir(this.opts.root)
+      throw new Error(`${launch.name}@${launch.range} could not be resolved and nothing is installed under ${store}`)
+    }
+    const tree = runtimePackageTree(this.opts.root, launch.name, version)
+    const present = installedRuntimeBin(tree, launch)
+    if (present) return { tree, version, bin: present }
+    // No resolution means an unreachable registry, and the store never installs a version it did not resolve.
+    if (!resolved) throw new Error(`${launch.name}@${version} is not installed at ${tree}`)
+    await this.installInto(tree, `${launch.name}@${version}`)
+    const bin = installedRuntimeBin(tree, launch)
+    const named = launch.bin ? ` "${launch.bin}"` : ''
+    if (!bin) throw new Error(`${launch.name}@${version} installed at ${tree} declares no bin${named}`)
+    this.prune(launch.name, version)
+    return { tree, version, bin }
+  }
+
+  /** Resolve the dist-tag ONCE per daemon start — an upgrade restarts the process, and a spawn never
+   *  re-resolves; an unreachable registry falls back to whatever the store already holds. */
+  private async resolveVersion(launch: NpxPackageLaunch): Promise<string | undefined> {
+    let output: string
+    try {
+      output = await this.run(['view', `${launch.name}@${launch.range}`, 'version', '--json'])
+    } catch (err) {
+      this.opts.log?.warn(`runtimes: could not resolve ${launch.name}@${launch.range} — ${(err as Error).message}`)
+      return undefined
+    }
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(output.trim() || 'null')
+    } catch {
+      return undefined
+    }
+    // A range answers with every matching version; npm prints them lowest first, so take the last.
+    const version = Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === 'string').at(-1)
+      : typeof parsed === 'string'
+        ? parsed
+        : undefined
+    return version && VERSION_RE.test(version) ? version : undefined
+  }
+
+  /** Install into a staging directory and rename, so a partial tree is never visible as an install. */
+  private async installInto(tree: string, spec: string): Promise<void> {
+    const staging = join(runtimeStoreDir(this.opts.root), `.staging-${randomUUID().slice(0, 8)}`)
+    mkdirSync(staging, { recursive: true })
+    try {
+      // Without a manifest of its own npm walks up and installs into whatever tree it finds first.
+      const manifest = { name: 'agentconnect-runtime-store', version: '0.0.0', private: true }
+      writeFileSync(join(staging, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+      await this.run(['install', spec, '--no-audit', '--no-fund'], { cwd: staging })
+      mkdirSync(dirname(tree), { recursive: true })
+      rmSync(tree, { recursive: true, force: true })
+      renameSync(staging, tree)
+    } catch (err) {
+      rmSync(staging, { recursive: true, force: true })
+      throw err
+    }
+  }
+
+  /** Drop versions this daemon no longer launches; the store resolves before any host is running. */
+  private prune(name: string, keep: string): void {
+    for (const version of installedRuntimeVersions(this.opts.root, name)) {
+      if (version === keep) continue
+      try {
+        rmSync(runtimePackageTree(this.opts.root, name, version), { recursive: true, force: true })
+      } catch (err) {
+        this.opts.log?.warn(`runtimes: could not remove ${name}@${version} — ${(err as Error).message}`)
+      }
+    }
+  }
+}

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -237,7 +237,6 @@ describe('Daemon session lifecycle (#118)', () => {
     const factory = vi.fn().mockReturnValueOnce(failing).mockReturnValueOnce(started)
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: factory })
     await daemon.start()
-    ;(daemon as any).hostRuntimeHome.set('bot-a', join(root, 'agents', 'bot-a', 'home'))
     const repair = vi.spyOn(daemon as any, 'repairAgentRuntimeInstall').mockResolvedValue('repaired')
 
     await expect((daemon as any).ensureHostAsync('bot-a')).resolves.toBe(started)
@@ -256,7 +255,6 @@ describe('Daemon session lifecycle (#118)', () => {
     const factory = vi.fn().mockReturnValueOnce(unrelated).mockReturnValueOnce(missing).mockReturnValueOnce(started)
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: factory })
     await daemon.start()
-    ;(daemon as any).hostRuntimeHome.set('bot-a', join(root, 'agents', 'bot-a', 'home'))
     const repair = vi
       .spyOn(daemon as any, 'repairAgentRuntimeInstall')
       .mockResolvedValueOnce('declined')
@@ -279,7 +277,6 @@ describe('Daemon session lifecycle (#118)', () => {
       hostFactory: vi.fn(() => failing as any)
     })
     await daemon.start()
-    ;(daemon as any).hostRuntimeHome.set('bot-a', join(root, 'agents', 'bot-a', 'home'))
     const repair = vi.spyOn(daemon as any, 'repairAgentRuntimeInstall').mockResolvedValue('failed')
 
     await expect((daemon as any).ensureHostAsync('bot-a')).rejects.toThrow('Missing optional dependency')
@@ -298,14 +295,11 @@ describe('Daemon session lifecycle (#118)', () => {
       hostFactory: vi.fn(() => quietHost() as any)
     })
     await daemon.start()
-    const home = join(root, 'agents', 'bot-a', 'home')
 
-    expect(await (daemon as any).repairAgentRuntimeInstall('bot-a', home, new Error('initialize failed'))).toBe(
-      'declined'
-    )
+    expect(await (daemon as any).repairAgentRuntimeInstall('bot-a', new Error('initialize failed'))).toBe('declined')
     ;(daemon as any).k8sPlane = { stop: async () => {} }
     const missing = new Error('Error: Missing optional dependency @openai/codex-linux-x64')
-    expect(await (daemon as any).repairAgentRuntimeInstall('bot-a', home, missing)).toBe('declined')
+    expect(await (daemon as any).repairAgentRuntimeInstall('bot-a', missing)).toBe('declined')
     await daemon.stop()
   })
 

--- a/packages/daemon/test/runtime-install-repair-collapse.test.ts
+++ b/packages/daemon/test/runtime-install-repair-collapse.test.ts
@@ -3,13 +3,12 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-// Agents on a non-isolated runtime share one npx tree, so their simultaneous start failures all
-// plan the same repair. This file owns the module mock that lets two of them race in one process.
+// Every agent on a runtime shares its one store tree, so their simultaneous start failures all plan
+// the same repair. This file owns the module mock that lets two of them race in one process.
 const repairRuntimeInstall = vi.fn()
 vi.mock('../src/runtimes/runtime-install-repair.js', () => ({
-  planRuntimeInstallRepair: (home: string) => ({ tree: join(home, '.npm', '_npx', 'shared'), pkg: 'pkg' }),
-  repairRuntimeInstall: (...args: unknown[]) => repairRuntimeInstall(...args),
-  npmRepairEnv: (home: string) => ({ HOME: home })
+  planRuntimeInstallRepair: (root: string) => ({ tree: join(root, 'runtimes', 'shared@1.0.0'), pkg: 'pkg' }),
+  repairRuntimeInstall: (...args: unknown[]) => repairRuntimeInstall(...args)
 }))
 
 const { Daemon } = await import('../src/daemon.js')
@@ -47,13 +46,12 @@ describe('concurrent runtime install repair', () => {
     const root = scaffold()
     const daemon = new Daemon({ root, hostFactory: () => ({ start: async () => {}, stop: async () => {} }) as never })
     await daemon.start()
-    const home = join(root, 'shared-home')
     let release: (value: boolean) => void = () => {}
     repairRuntimeInstall.mockImplementation(() => new Promise<boolean>((resolve) => (release = resolve)))
 
     const missing = new Error('Error: Missing optional dependency pkg')
-    const first = (daemon as any).repairAgentRuntimeInstall('bot-a', home, missing)
-    const second = (daemon as any).repairAgentRuntimeInstall('bot-b', home, missing)
+    const first = (daemon as any).repairAgentRuntimeInstall('bot-a', missing)
+    const second = (daemon as any).repairAgentRuntimeInstall('bot-b', missing)
     release(true)
 
     expect(await first).toBe('repaired')
@@ -62,7 +60,7 @@ describe('concurrent runtime install repair', () => {
 
     // The entry is released afterwards, so a later genuine break is repaired again.
     repairRuntimeInstall.mockResolvedValue(true)
-    expect(await (daemon as any).repairAgentRuntimeInstall('bot-a', home, missing)).toBe('repaired')
+    expect(await (daemon as any).repairAgentRuntimeInstall('bot-a', missing)).toBe('repaired')
     expect(repairRuntimeInstall).toHaveBeenCalledTimes(2)
     await daemon.stop()
   })

--- a/packages/daemon/test/runtime-install-repair.test.ts
+++ b/packages/daemon/test/runtime-install-repair.test.ts
@@ -5,7 +5,6 @@ import { join } from 'node:path'
 import {
   findRepairableTrees,
   missingRuntimePackage,
-  npmRepairEnv,
   planRuntimeInstallRepair,
   repairRuntimeInstall
 } from '../src/runtimes/runtime-install-repair.js'
@@ -24,8 +23,9 @@ const CODEX_FAILURE = [
   '    at findCodexExecutable (file:///home/dev/.npm/_npx/8b5/node_modules/@openai/codex/bin/codex.js:105:9)'
 ].join('\n')
 
-function tree(home: string, name: string, opts: { declares?: boolean; installed?: boolean }): string {
-  const dir = join(home, '.npm', '_npx', name)
+// The store nests a scoped package one level deeper, which is the depth the repair scan must reach.
+function tree(root: string, name: string, opts: { declares?: boolean; installed?: boolean }): string {
+  const dir = join(root, 'runtimes', '@agentconnect.md', name)
   mkdirSync(dir, { recursive: true })
   if (opts.declares) {
     writeFileSync(
@@ -49,60 +49,55 @@ describe('runtime install repair', () => {
     expect(missingRuntimePackage('Missing optional dependency @openai/codex@file:/tmp/x')).toBeUndefined()
   })
 
-  it('repairs only a tree that declares the package and has not installed it', () => {
-    const home = mkdtempSync(join(tmpdir(), 'ac-repair-'))
-    const broken = tree(home, 'broken', { declares: true })
-    tree(home, 'healthy', { declares: true, installed: true })
-    tree(home, 'unrelated', {})
-    expect(findRepairableTrees(home, PKG)).toEqual([broken])
-    expect(planRuntimeInstallRepair(home, CODEX_FAILURE)).toEqual({ tree: broken, pkg: PKG })
+  it('repairs only a daemon-owned tree that declares the package and has not installed it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-repair-'))
+    const broken = tree(root, 'broken@1.0.0', { declares: true })
+    tree(root, 'healthy@1.0.0', { declares: true, installed: true })
+    tree(root, 'unrelated@1.0.0', {})
+    expect(findRepairableTrees(root, PKG)).toEqual([broken])
+    expect(planRuntimeInstallRepair(root, CODEX_FAILURE)).toEqual({ tree: broken, pkg: PKG })
+  })
+
+  it('looks in the daemon-owned store, never in an agent HOME', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-repair-'))
+    const home = join(root, 'agents', 'a', 'home')
+    const npx = join(home, '.npm', '_npx', 'deadbeef')
+    mkdirSync(npx, { recursive: true })
+    writeFileSync(
+      join(npx, 'package-lock.json'),
+      JSON.stringify({ packages: { [`node_modules/${PKG}`]: { optional: true } } })
+    )
+    expect(findRepairableTrees(root, PKG)).toEqual([])
+    expect(planRuntimeInstallRepair(root, CODEX_FAILURE)).toBeUndefined()
   })
 
   it('plans nothing when the failure is unrelated or the tree is already whole', () => {
-    const home = mkdtempSync(join(tmpdir(), 'ac-repair-'))
-    tree(home, 'healthy', { declares: true, installed: true })
-    expect(planRuntimeInstallRepair(home, CODEX_FAILURE)).toBeUndefined()
-    expect(planRuntimeInstallRepair(home, 'ECONNREFUSED')).toBeUndefined()
+    const root = mkdtempSync(join(tmpdir(), 'ac-repair-'))
+    tree(root, 'healthy@1.0.0', { declares: true, installed: true })
+    expect(planRuntimeInstallRepair(root, CODEX_FAILURE)).toBeUndefined()
+    expect(planRuntimeInstallRepair(root, 'ECONNREFUSED')).toBeUndefined()
   })
 
-  it('never lets npm run lifecycle scripts, and reports whether the package landed', async () => {
-    const home = mkdtempSync(join(tmpdir(), 'ac-repair-'))
-    const broken = tree(home, 'broken', { declares: true })
+  it('reifies the tree in place and reports whether the package landed', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-repair-'))
+    const broken = tree(root, 'broken@1.0.0', { declares: true })
     const plan = { tree: broken, pkg: PKG }
-    const seen: string[][] = []
-    const installing = await repairRuntimeInstall(plan, {}, async (dir, args) => {
-      seen.push(args)
-      mkdirSync(join(dir, 'node_modules', PKG), { recursive: true })
+    const seen: { args: string[]; cwd?: string }[] = []
+    const installing = await repairRuntimeInstall(plan, async (args, opts) => {
+      seen.push({ args, cwd: opts?.cwd })
+      mkdirSync(join(opts!.cwd!, 'node_modules', PKG), { recursive: true })
+      return ''
     })
     expect(installing).toBe(true)
-    expect(seen[0]).toContain('--ignore-scripts')
-    expect(seen[0]).toContain('--include=optional')
+    expect(seen[0]!.cwd).toBe(broken)
+    expect(seen[0]!.args).toContain('--ignore-scripts')
+    expect(seen[0]!.args).toContain('--include=optional')
 
     const idle = await repairRuntimeInstall(
-      { tree: tree(home, 'other', { declares: true }), pkg: PKG },
-      {},
-      async () => {}
+      { tree: tree(root, 'other@1.0.0', { declares: true }), pkg: PKG },
+      async () => ''
     )
     expect(idle).toBe(false)
-  })
-
-  it('hands npm an allowlist, so an agent-authored .npmrc has no daemon secret to interpolate', () => {
-    const env = npmRepairEnv('/agents/a/home', {
-      PATH: '/bin',
-      HTTPS_PROXY: 'http://proxy:3128',
-      npm_config_cache: '/elsewhere',
-      NPM_CONFIG_PREFIX: '/x',
-      ANTHROPIC_API_KEY: 'sk-secret',
-      GITHUB_TOKEN: 'ghp_secret',
-      HOME: '/root'
-    })
-    // The repair env pins USERPROFILE alongside HOME on Windows, where that is the one `~` reads.
-    expect(env).toEqual({
-      PATH: '/bin',
-      HTTPS_PROXY: 'http://proxy:3128',
-      HOME: '/agents/a/home',
-      ...(process.platform === 'win32' ? { USERPROFILE: '/agents/a/home' } : {})
-    })
   })
 })
 

--- a/packages/daemon/test/runtime-store-daemon.test.ts
+++ b/packages/daemon/test/runtime-store-daemon.test.ts
@@ -47,6 +47,10 @@ function daemonWith(root: string, ensure: (launch: NpxPackageLaunch) => Promise<
   })
 }
 
+function refusal(daemon: Daemon): string {
+  return (daemon as unknown as { runtimeUnavailableMessage(id: string): string }).runtimeUnavailableMessage('codex-acp')
+}
+
 function tree(root: string): { tree: string; bin: string } {
   const dir = runtimePackageTree(root, NAME, '1.4.2')
   return { tree: dir, bin: join(dir, 'node_modules', '@agentconnect.md', 'codex-acp', 'dist', 'index.js') }
@@ -102,10 +106,23 @@ describe('daemon-owned adapter store', () => {
     await daemon.start()
 
     expect((daemon as unknown as { runtimes: Record<string, unknown> }).runtimes['codex-acp']).toBeUndefined()
-    const message = (daemon as unknown as { runtimeUnavailableMessage(id: string): string }).runtimeUnavailableMessage(
-      'codex-acp'
-    )
-    expect(message).toContain(dir)
+    expect(refusal(daemon)).toContain('codex-acp@1.4.2')
+    await daemon.stop()
+  })
+
+  it('keeps that refusal to one line with no absolute path, however the failure was thrown', async () => {
+    const root = scaffold('codex-acp')
+    const { tree: dir } = tree(root)
+    // An ordinary Error carries a multi-line stack of absolute daemon paths; only its message may travel.
+    const daemon = daemonWith(root, async () => {
+      throw new Error(`${NAME}@1.4.2 is not installed at ${dir}`)
+    })
+    await daemon.start()
+
+    const message = refusal(daemon)
+    expect(message).not.toContain('\n')
+    expect(message).not.toContain(root)
+    expect(message).toContain('codex-acp@1.4.2')
     await daemon.stop()
   })
 })

--- a/packages/daemon/test/runtime-store-daemon.test.ts
+++ b/packages/daemon/test/runtime-store-daemon.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Daemon } from '../src/daemon.js'
+import { MANAGED_RUNTIME_CATALOG } from '../src/runtimes/managed.js'
+import { runtimePackageTree } from '../src/runtimes/runtime-store.js'
+import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
+import type { NpxPackageLaunch, StoredRuntimePackage } from '../src/runtimes/runtime-store.js'
+
+const RUNTIME = MANAGED_RUNTIME_CATALOG['codex-acp']!.runtime
+const NAME = '@agentconnect.md/codex-acp'
+
+type Probe = { runtimes: Record<string, { command: string; args: string[] }> }
+
+function scaffold(agentRuntime?: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-store-daemon-'))
+  writeFileSync(join(root, 'config.json'), JSON.stringify({ version: 1, controlPlane: { enabled: false } }))
+  if (!agentRuntime) return root
+  const dir = join(root, 'agents', 'bot-a')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'agent.json'),
+    JSON.stringify({
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: agentRuntime,
+      workspace: { mode: 'from-scratch', path: join(dir, 'workspace') },
+      integrations: []
+    })
+  )
+  return root
+}
+
+function catalog(): ResolvedRuntimeCatalog {
+  const entry = { runtime: RUNTIME, source: 'managed' as const, name: 'Codex', version: '', skillsAgentId: null }
+  return { entries: { 'codex-acp': entry }, runtimes: { 'codex-acp': RUNTIME } }
+}
+
+function daemonWith(root: string, ensure: (launch: NpxPackageLaunch) => Promise<StoredRuntimePackage>): Daemon {
+  return new Daemon({
+    root,
+    resolveCatalog: async () => catalog(),
+    installed: (runtimes) => runtimes,
+    runtimeStore: { ensure }
+  })
+}
+
+function tree(root: string): { tree: string; bin: string } {
+  const dir = runtimePackageTree(root, NAME, '1.4.2')
+  return { tree: dir, bin: join(dir, 'node_modules', '@agentconnect.md', 'codex-acp', 'dist', 'index.js') }
+}
+
+describe('daemon-owned adapter store', () => {
+  it('resolves and installs at start, and launches the tree rather than npx', async () => {
+    const root = scaffold('codex-acp')
+    const { tree: dir, bin } = tree(root)
+    const seen: NpxPackageLaunch[] = []
+    const daemon = daemonWith(root, async (launch) => {
+      seen.push(launch)
+      return { tree: dir, version: '1.4.2', bin }
+    })
+    await daemon.start()
+
+    // One resolution for the whole daemon lifetime — a host spawn re-reads this def, never re-resolves.
+    expect(seen).toHaveLength(1)
+    expect(seen[0]!.name).toBe(NAME)
+    const runtime = (daemon as unknown as Probe).runtimes['codex-acp']!
+    expect(runtime.command).toBe(process.execPath)
+    expect(runtime.args).toEqual([bin])
+    expect([runtime.command, ...runtime.args].some((part) => part.includes('npx'))).toBe(false)
+    await daemon.stop()
+  })
+
+  it('installs nothing at start for a runtime no agent uses, and localizes it once on first start', async () => {
+    const root = scaffold()
+    const { tree: dir, bin } = tree(root)
+    let calls = 0
+    const daemon = daemonWith(root, async () => {
+      calls += 1
+      return { tree: dir, version: '1.4.2', bin }
+    })
+    await daemon.start()
+    expect(calls).toBe(0)
+    expect((daemon as unknown as Probe).runtimes['codex-acp']!.command).toBe('npx')
+
+    const localize = (daemon as unknown as { ensureRuntimeInstalled(id: string): Promise<void> }).ensureRuntimeInstalled
+    await localize.call(daemon, 'codex-acp')
+    await localize.call(daemon, 'codex-acp')
+    expect(calls).toBe(1)
+    expect((daemon as unknown as Probe).runtimes['codex-acp']!.args).toEqual([bin])
+    await daemon.stop()
+  })
+
+  it('refuses to launch a runtime with no daemon-owned install, naming the tree', async () => {
+    const root = scaffold('codex-acp')
+    const { tree: dir } = tree(root)
+    const daemon = daemonWith(root, async () => {
+      throw new Error(`${NAME}@1.4.2 is not installed at ${dir}`)
+    })
+    await daemon.start()
+
+    expect((daemon as unknown as { runtimes: Record<string, unknown> }).runtimes['codex-acp']).toBeUndefined()
+    const message = (daemon as unknown as { runtimeUnavailableMessage(id: string): string }).runtimeUnavailableMessage(
+      'codex-acp'
+    )
+    expect(message).toContain(dir)
+    await daemon.stop()
+  })
+})

--- a/packages/daemon/test/runtime-store.test.ts
+++ b/packages/daemon/test/runtime-store.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest'
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  RuntimeStore,
+  installedRuntimeVersions,
+  npmStoreEnv,
+  parseNpxLaunch,
+  runtimePackageTree,
+  storedRuntimeDef,
+  type NpmCommandRunner
+} from '../src/runtimes/runtime-store.js'
+import { runtimeStoreDir } from '../src/paths.js'
+import { trustedRuntimeReadRoots } from '../src/runtimes/read-roots.js'
+import { MANAGED_RUNTIME_CATALOG } from '../src/runtimes/managed.js'
+import { CURATED_RUNTIME_CATALOG } from '../src/runtimes/curated.js'
+
+const CODEX = MANAGED_RUNTIME_CATALOG['codex-acp']!.runtime
+
+function root(): string {
+  return mkdtempSync(join(tmpdir(), 'ac-store-'))
+}
+
+/** Write the tree npm would have produced, so the store finds a real bin to launch. */
+function install(dir: string, name: string, bin: Record<string, string>): void {
+  const packageDir = join(dir, 'node_modules', ...name.split('/'))
+  mkdirSync(packageDir, { recursive: true })
+  writeFileSync(join(packageDir, 'package.json'), JSON.stringify({ name, bin }))
+  for (const relative of Object.values(bin)) {
+    const path = join(packageDir, relative)
+    mkdirSync(join(path, '..'), { recursive: true })
+    writeFileSync(path, '#!/usr/bin/env node\n')
+  }
+  writeFileSync(join(dir, 'package-lock.json'), JSON.stringify({ packages: {} }))
+}
+
+/** A runner that answers `npm view` with `version` and materializes what `npm install` would leave. */
+function fakeNpm(
+  version: string | undefined,
+  name: string,
+  bin: Record<string, string>,
+  calls: string[][] = []
+): { run: NpmCommandRunner; calls: string[][] } {
+  const run: NpmCommandRunner = async (args, opts) => {
+    calls.push(args)
+    if (args[0] === 'view') {
+      if (!version) throw new Error('ENOTFOUND registry.example.test')
+      return `${JSON.stringify(version)}\n`
+    }
+    install(opts!.cwd!, name, bin)
+    return ''
+  }
+  return { run, calls }
+}
+
+describe('parseNpxLaunch', () => {
+  it('decomposes the managed codex-acp launch', () => {
+    expect(parseNpxLaunch(CODEX)).toEqual({ name: '@agentconnect.md/codex-acp', range: 'agentconnect', args: [] })
+  })
+
+  it('keeps the bin an `npx -p <pkg> <bin>` launch names, and the arguments after it', () => {
+    expect(parseNpxLaunch(CURATED_RUNTIME_CATALOG['dsh-acp']!.runtime)).toEqual({
+      name: '@openma/deepseek-harness-acp',
+      range: '^0.4',
+      bin: 'dsh-acp',
+      args: []
+    })
+    expect(parseNpxLaunch({ command: 'npx', args: ['-y', 'pkg', 'acp', '--flag'], env: [] })).toEqual({
+      name: 'pkg',
+      range: 'latest',
+      args: ['acp', '--flag']
+    })
+  })
+
+  it('leaves alone anything that is not a plain registry package launch', () => {
+    expect(parseNpxLaunch({ command: 'codex', args: ['acp'], env: [] })).toBeUndefined()
+    expect(parseNpxLaunch({ command: 'npx', args: ['-y', 'file:/tmp/evil.tgz'], env: [] })).toBeUndefined()
+    expect(parseNpxLaunch({ command: 'npx', args: ['-y', 'https://evil.test/x.tgz'], env: [] })).toBeUndefined()
+    expect(parseNpxLaunch({ command: 'npx', args: ['--call', 'pkg'], env: [] })).toBeUndefined()
+  })
+})
+
+describe('RuntimeStore', () => {
+  it('resolves the dist-tag once and never again, however many hosts ask', async () => {
+    const dir = root()
+    const { run, calls } = fakeNpm('1.4.2', '@agentconnect.md/codex-acp', { 'codex-acp': 'dist/index.js' })
+    const store = new RuntimeStore({ root: dir, run })
+    const launch = parseNpxLaunch(CODEX)!
+
+    const [first, second] = await Promise.all([store.ensure(launch), store.ensure(launch)])
+    const third = await store.ensure(launch)
+
+    expect(first).toEqual(second)
+    expect(third).toEqual(first)
+    expect(calls.filter((args) => args[0] === 'view')).toHaveLength(1)
+    expect(calls.filter((args) => args[0] === 'install')).toHaveLength(1)
+    expect(first.version).toBe('1.4.2')
+    expect(first.tree).toBe(runtimePackageTree(dir, '@agentconnect.md/codex-acp', '1.4.2'))
+    expect(first.bin).toBe(join(first.tree, 'node_modules', '@agentconnect.md', 'codex-acp', 'dist', 'index.js'))
+  })
+
+  it('launches the installed bin with node, never through npx', async () => {
+    const dir = root()
+    const { run } = fakeNpm('1.4.2', '@agentconnect.md/codex-acp', { 'codex-acp': 'dist/index.js' })
+    const launch = parseNpxLaunch(CODEX)!
+    const installed = await new RuntimeStore({ root: dir, run }).ensure(launch)
+
+    const def = storedRuntimeDef(CODEX, launch, installed)
+    expect(def.command).toBe(process.execPath)
+    expect(def.args).toEqual([installed.bin])
+    expect([def.command, ...def.args].some((part) => part.includes('npx'))).toBe(false)
+    expect(def.readRoots).toContain(installed.tree)
+  })
+
+  it('falls back to the newest install when the registry cannot be reached', async () => {
+    const dir = root()
+    const name = '@agentconnect.md/codex-acp'
+    for (const version of ['1.4.2', '1.10.0', '1.10.0-rc.1']) {
+      install(runtimePackageTree(dir, name, version), name, { 'codex-acp': 'dist/index.js' })
+    }
+    expect(installedRuntimeVersions(dir, name)).toEqual(['1.10.0', '1.10.0-rc.1', '1.4.2'])
+
+    const { run, calls } = fakeNpm(undefined, name, { 'codex-acp': 'dist/index.js' })
+    const installedPackage = await new RuntimeStore({ root: dir, run }).ensure(parseNpxLaunch(CODEX)!)
+    expect(installedPackage.version).toBe('1.10.0')
+    // Unresolved means the store never installs: it launches what it already holds, or nothing.
+    expect(calls.filter((args) => args[0] === 'install')).toHaveLength(0)
+  })
+
+  it('refuses the launch and names the store when the registry is unreachable and nothing is installed', async () => {
+    const dir = root()
+    const { run } = fakeNpm(undefined, '@agentconnect.md/codex-acp', {})
+    await expect(new RuntimeStore({ root: dir, run }).ensure(parseNpxLaunch(CODEX)!)).rejects.toThrow(
+      runtimeStoreDir(dir)
+    )
+  })
+
+  it('drops the versions it no longer launches once a new one is installed', async () => {
+    const dir = root()
+    const name = '@agentconnect.md/codex-acp'
+    install(runtimePackageTree(dir, name, '1.0.0'), name, { 'codex-acp': 'dist/index.js' })
+    const { run } = fakeNpm('1.4.2', name, { 'codex-acp': 'dist/index.js' })
+    await new RuntimeStore({ root: dir, run }).ensure(parseNpxLaunch(CODEX)!)
+    expect(installedRuntimeVersions(dir, name)).toEqual(['1.4.2'])
+  })
+
+  it('hands npm an allowlist, so no daemon secret is left for an .npmrc to interpolate', () => {
+    expect(
+      npmStoreEnv({
+        PATH: '/bin',
+        HTTPS_PROXY: 'http://proxy.example.test:3128',
+        HOME: '/var/lib/agentconnect',
+        ANTHROPIC_API_KEY: 'sk-secret',
+        GITHUB_TOKEN: 'ghp_secret'
+      })
+    ).toEqual({ PATH: '/bin', HTTPS_PROXY: 'http://proxy.example.test:3128', HOME: '/var/lib/agentconnect' })
+  })
+})
+
+describe('sandbox read roots', () => {
+  it('carves the store tree back, so the denied daemon root still exposes the adapter', async () => {
+    const dir = root()
+    const { run } = fakeNpm('1.4.2', '@agentconnect.md/codex-acp', { 'codex-acp': 'dist/index.js' })
+    const launch = parseNpxLaunch(CODEX)!
+    const installed = await new RuntimeStore({ root: dir, run }).ensure(launch)
+
+    const roots = trustedRuntimeReadRoots({ runtime: storedRuntimeDef(CODEX, launch, installed) })
+    expect(roots).toContain(realpathSync(installed.tree))
+  })
+})


### PR DESCRIPTION
The managed ACP adapter is the runtime's **parent** process — it sits outside every inner tool
sandbox — and today it loads its code from `$HOME/.npm/_npx/<hash>` under the agent's own private,
model-writable HOME, re-resolved by `npx -y` at every host spawn. One session can plant code there
that the next session's runtime parent executes.

This moves the adapter into a daemon-owned tree. It is also step 1 of the
`docs/designs/git-workspace-model.md` §11 rollout: once HOME becomes per-session, an `npx` launch
would re-download and re-install the adapter for every session.

## What changed

- **New `packages/daemon/src/runtimes/runtime-store.ts`.** Installs an adapter into
  `<daemonRoot>/runtimes/<package>@<resolved-version>/` — an ordinary `npm install` tree — and
  reports the package's declared bin.
- **Launch** is `node <tree>/node_modules/<package>/<declared bin>` directly. No `npx` on any agent
  launch path.
- **Version resolution happens once, at daemon start**, not per spawn — `npm view <spec> version`
  resolves the dist-tag, the tree is installed if missing, and the catalog entry is rewritten to
  point at it. A daemon upgrade restarts the process, so it re-resolves there and nowhere else. The
  decision is recorded in a one-line comment at `RuntimeStore.resolveVersion`.
- **Registry unreachable at start:** fall back to the newest tree already installed. With none, the
  runtime leaves the catalog and the launch is refused with an error naming the tree — it never
  silently falls back to `npx`.
- **Concurrency:** one in-flight promise per package, so two hosts starting at once produce one
  install and one wait (same shape as the existing `runtimeInstallRepairs` map).
- **Repair** (`runtime-install-repair.ts`) now scans the daemon-owned store instead of
  `<home>/.npm/_npx`, and reifies the tree it launched from.
- **Sandbox read carve-back:** the outer sandbox denies the daemon root, so the store tree is added
  to the runtime's trusted `readRoots` and carved back read-only, exactly like the other trusted
  executable roots.
- **Prune:** after installing a newly resolved version, older trees of the same package are
  removed. `npx` reused one hash directory per spec, so without this an upgrade would grow the
  daemon root without bound.

### Scope of "managed"

Every launch spec the daemon itself supplies — `curated`, ACP `registry` and `managed` sources —
whose command is `npx`. That is the same rule for `codex-acp` (managed, `@agentconnect` dist-tag),
`claude-acp` (ACP registry, `npx -y <pkg>`) and `dsh-acp` (curated, `npx -y -p <pkg> <bin>`).
Explicit operator `config.runtimes` stays the final authority and is never rewritten, and a pool
member still resolves its packages inside its own sandbox pod — untouched, as asked.

### One deviation from the brief, and why

Installing *every* adapter whose state probe passes turned out to be too expensive: on a
development host with six logged-in harnesses, daemon start fetched all six (measured: 5 daemon
test files went from 27 s to 6 min 48 s, installing seven packages per temporary root). The store
therefore installs at start only the adapters this daemon's own agents run, and a runtime assigned
after boot is installed once, on the path to its first host start — memoized by the store, so it is
still never per spawn. `npx` also fetched only what actually launched, so this keeps the startup
cost where it was.

## Verified

Unit level, on this machine:

- `parseNpxLaunch` over both `npx` forms, and refusal of a `file:`/URL spec or an unknown flag.
- Resolution happens once and never at spawn: three `ensure` calls (two concurrent) produce one
  `npm view` and one `npm install`.
- Missing-tree behaviour both ways — unreachable registry with trees installed picks the newest and
  installs nothing; with none it throws naming the store directory.
- Daemon level: the catalog is rewritten at start for an agent's runtime and the launch carries no
  `npx`; a runtime no agent uses is left alone at start and localized once on first start; a failed
  install drops the runtime and the refusal names the tree.
- Repair plans against the daemon-owned store (including the extra directory level a scoped package
  gets) and finds nothing in an agent HOME's `_npx` tree.
- The sandbox read carve-back contains the tree.
- Prune leaves only the resolved version.

**Mutation-checked**: restoring `command: 'npx'` in `storedRuntimeDef` turns the three launch-path
tests red (`RuntimeStore > launches the installed bin with node, never through npx`, and both
daemon-level launch assertions); reverting turns them green again.

Gates run: `tsc -p tsconfig.typecheck.json --noEmit` for the daemon package, prettier and eslint on
every touched file, and `vitest run` over the affected files —
`runtime-store`, `runtime-store-daemon`, `runtime-install-repair`,
`runtime-install-repair-collapse`, `daemon-lifecycle`, `read-roots`, `probe`, `registry`,
`runtime-launch` (195 passed, 1 skipped). The full daemon suite was not run: it exhausts memory on
this machine and carries pre-existing local failures unrelated to this change.

## Not verified

- **No live daemon spawn.** Nothing here has run against a real adapter on Linux: the actual
  `npm view` / `npm install` against the registry, the real tree layout for
  `@agentconnect.md/codex-acp`, the spawned adapter starting from the store tree, and the sandbox
  carve-back as the kernel applies it are all untested outside unit fakes. I cannot deploy.
- The `agentconnect-daemon chat` debug CLI resolves the catalog on its own and still launches
  through `npx`. It runs no agent session, so it is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
