### PR TITLE
feat(daemon): one ACP host per session for a confined self-hosted launch

### DIFF
--- a/packages/daemon/src/acp/host-key.ts
+++ b/packages/daemon/src/acp/host-key.ts
@@ -1,0 +1,42 @@
+import { createHash } from 'node:crypto'
+
+// The identity of one ACP host: the agent id alone for the agent's shared host, or the agent id
+// with the logical session key for a host that serves exactly one session (git-workspace-model §11).
+export type HostKey = string & { readonly __hostKey: unique symbol }
+
+// NUL never appears in an agent id (a directory name or a cuid), so the first one splits the key.
+const SESSION_SEPARATOR = String.fromCharCode(0)
+
+/** The key of the host every session of the agent shares. */
+export function agentHostKey(agentId: string): HostKey {
+  return agentId as HostKey
+}
+
+/** The key of the host bound to one logical session (`sessionKey` from store/local-store.ts). */
+export function sessionHostKey(agentId: string, sessionKey: string): HostKey {
+  return `${agentId}${SESSION_SEPARATOR}${sessionKey}` as HostKey
+}
+
+export function hostKeyAgentId(key: HostKey): string {
+  const at = key.indexOf(SESSION_SEPARATOR)
+  return at < 0 ? key : key.slice(0, at)
+}
+
+/** The bound session's key, or undefined for the agent's shared host. */
+export function hostKeySessionKey(key: HostKey): string | undefined {
+  const at = key.indexOf(SESSION_SEPARATOR)
+  return at < 0 ? undefined : key.slice(at + 1)
+}
+
+/** Leaf directory for daemon-owned per-host state under the agent dir; absent ⇒ the shared host. */
+export function hostKeyDirName(key: HostKey | undefined): string {
+  const sessionKey = key === undefined ? undefined : hostKeySessionKey(key)
+  if (sessionKey === undefined) return 'agent'
+  return `session-${createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)}`
+}
+
+/** Printable form for logs: the agent id, plus the session leaf for a session-bound host. */
+export function hostKeyLabel(key: HostKey): string {
+  const sessionKey = hostKeySessionKey(key)
+  return sessionKey === undefined ? key : `${hostKeyAgentId(key)} (${hostKeyDirName(key)})`
+}

--- a/packages/daemon/src/acp/sandbox.ts
+++ b/packages/daemon/src/acp/sandbox.ts
@@ -108,7 +108,7 @@ function probeSandbox(env: NodeJS.ProcessEnv): SandboxProbe {
     const privateHome = join(agentDir, 'home')
     mkdirSync(writable, { recursive: true })
     mkdirSync(privateHome)
-    const settingsPath = writeSandboxSettings(agentDir, {
+    const settingsPath = writeSandboxSettings(agentDir, 'probe', {
       writable: [writable, privateHome],
       denyRead: [],
       allowRead: [],
@@ -253,12 +253,20 @@ function canonical(paths: string[]): string[] {
   return [...out]
 }
 
-/**
- * Atomically publish the trusted SRT policy outside every agent-writable path.
- */
-export function writeSandboxSettings(agentDir: string, policy: SrtSandboxPolicy): string {
+/** Daemon-owned home of one host's SRT policy: `<agentDir>/.agentconnect/sandbox/<hostDir>`. */
+export function sandboxSettingsDir(agentDir: string, hostDir: string): string {
+  return join(agentDir, '.agentconnect', 'sandbox', hostDir)
+}
+
+/** Drop a stopped host's policy directory; a missing one is not an error. */
+export function removeSandboxSettings(agentDir: string, hostDir: string): void {
+  rmSync(sandboxSettingsDir(agentDir, hostDir), { recursive: true, force: true })
+}
+
+// Atomically publish the trusted SRT policy outside every agent-writable path, one directory per host.
+export function writeSandboxSettings(agentDir: string, hostDir: string, policy: SrtSandboxPolicy): string {
   const root = canonicalTarget(agentDir)
-  const settingsDir = join(root, '.agentconnect', 'sandbox')
+  const settingsDir = sandboxSettingsDir(root, hostDir)
   let current = root
   for (const part of relative(root, settingsDir).split(sep).filter(Boolean)) {
     current = join(current, part)

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -12,6 +12,7 @@ import { configureWorkspaceGitOrigins } from '../workspace/git-origin-policy.js'
 import { AcpHost } from '../acp/acp-host.js'
 import { effectiveRunInSandbox } from '../launch/prepare.js'
 import { detectSandbox } from '../acp/sandbox.js'
+import { agentHostKey } from '../acp/host-key.js'
 import { resolveRoot } from '../paths.js'
 import { runtimeHomePath } from '../runtimes/runtime-home.js'
 import { installedRuntimeCatalog } from '../runtimes/probe.js'
@@ -130,6 +131,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     runtimeId: agent.runtime,
     runtime,
     provider: memoryKindOf(agent),
+    hostKey: agentHostKey(agent.id),
     scopeDir: agent.dir,
     cwd: agent.workspace.path,
     runInSandbox,

--- a/packages/daemon/src/collab/coordinator.ts
+++ b/packages/daemon/src/collab/coordinator.ts
@@ -108,9 +108,10 @@ export interface CollabTurnHost {
     }
   ): Promise<string | null>
   webchatTransport(): WebchatTransport
+  /** The external audience of a session, by its logical key. */
   externalOriginForSession(
     agentId: string,
-    acpSessionId: string | undefined
+    sessionKey: string | undefined
   ): Promise<ExternalSessionAudience | undefined>
 }
 
@@ -409,9 +410,7 @@ export class CollabCoordinator {
     const originSessionId = callerSession
       ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId, this.host.clock().now())
       : undefined
-    // These two read the caller's LOCAL rows, which are keyed by the runtime's id.
-    const callerAcpSessionId = callerSession?.acpSessionId ?? undefined
-    const externalOrigin = await this.host.externalOriginForSession(req.callerAgentId, callerAcpSessionId)
+    const externalOrigin = await this.host.externalOriginForSession(req.callerAgentId, callerKey)
     const originCoordPlatform = platform
     const originCoords: CallMeta['originCoords'] = {
       platform: originCoordPlatform,
@@ -488,7 +487,7 @@ export class CollabCoordinator {
           sourceHopCount,
           correlationId,
           ...(originSessionId !== undefined ? { originSessionId } : {}),
-          ...(callerAcpSessionId !== undefined ? { originAcpSessionId: callerAcpSessionId } : {}),
+          originSessionKey: callerKey,
           originCoords,
           ...(externalOrigin ? { externalOrigin } : {})
         }
@@ -539,8 +538,7 @@ export class CollabCoordinator {
       ...(req.needsReply === true && originSessionId !== undefined ? { needsReply: true } : {}),
       // §5.1: seal the child's capture gate when the waking session is private.
       // Tighten-only — see CallMeta.parentPrivate.
-      ...(originSessionId !== undefined &&
-      (await this.host.store().isCaptureExcluded(req.callerAgentId, callerAcpSessionId))
+      ...(originSessionId !== undefined && (await this.host.store().isCaptureExcluded(req.callerAgentId, callerKey))
         ? { parentPrivate: true }
         : {})
     }
@@ -806,13 +804,10 @@ export class CollabCoordinator {
     // Hand the origin owner a turn whose origin points back at the REPLIER's session, so the
     // origin could reply again (symmetric lineage). callFrom = the replier.
     const replyCoordPlatform = platform
-    // Symmetric lineage: what we hand the origin is the REPLIER's outward id (§1.1), while the
-    // replier's own local rows stay keyed by the runtime's.
-    const replierAcpSessionId = callerRec?.acpSessionId ?? undefined
     const replierSessionId = callerRec
       ? await this.host.store().ensureOutwardSessionId(callerKey, req.callerAgentId, this.host.clock().now())
       : undefined
-    const externalOrigin = await this.host.externalOriginForSession(req.callerAgentId, replierAcpSessionId)
+    const externalOrigin = await this.host.externalOriginForSession(req.callerAgentId, callerKey)
     const replyOriginCoords: CallMeta['originCoords'] = {
       platform: replyCoordPlatform,
       channel: req.callerChannel,
@@ -828,8 +823,7 @@ export class CollabCoordinator {
       ...(externalOrigin ? { externalOrigin } : {}),
       // §5.1: seal the child's capture gate when the waking session is private.
       // Tighten-only — see CallMeta.parentPrivate.
-      ...(replierSessionId !== undefined &&
-      (await this.host.store().isCaptureExcluded(req.callerAgentId, replierAcpSessionId))
+      ...(replierSessionId !== undefined && (await this.host.store().isCaptureExcluded(req.callerAgentId, callerKey))
         ? { parentPrivate: true }
         : {})
     }
@@ -962,7 +956,7 @@ export class CollabCoordinator {
         sourceHopCount: inbound.hopCount,
         ...(correlationId !== undefined ? { correlationId } : {}),
         ...(replierSessionId !== undefined ? { originSessionId: replierSessionId } : {}),
-        ...(replierAcpSessionId !== undefined ? { originAcpSessionId: replierAcpSessionId } : {}),
+        originSessionKey: callerKey,
         originCoords: replyOriginCoords,
         ...(externalOrigin ? { externalOrigin } : {}),
         // §5.3: this is a REPLY into the validated origin session, not a wake — the
@@ -1382,7 +1376,6 @@ export class CollabCoordinator {
       return false
     }
     const originRec = await this.host.store().getSession(originKey)
-    const originAcpSessionId = originRec?.acpSessionId ?? undefined
     const originSessionId = originRec
       ? await this.host.store().ensureOutwardSessionId(originKey, req.agentId, this.host.clock().now())
       : undefined
@@ -1405,7 +1398,7 @@ export class CollabCoordinator {
       },
       // §5.1: seal the child's capture gate when the waking session is private.
       // Tighten-only — see CallMeta.parentPrivate.
-      ...(originSessionId && (await this.host.store().isCaptureExcluded(req.agentId, originAcpSessionId))
+      ...(originSessionId && (await this.host.store().isCaptureExcluded(req.agentId, originKey))
         ? { parentPrivate: true }
         : {})
     }
@@ -1470,8 +1463,8 @@ export class CollabCoordinator {
       /** §5.3: the caller's origin session, forwarded so the remote child can reply back — its
        *  OUTWARD id (§1.1), since it travels to another daemon. */
       originSessionId?: string
-      /** The same session's runtime-local id, for the gates this daemon keys by it. */
-      originAcpSessionId?: string
+      /** The same session's logical key, for the gates this daemon keys by it. */
+      originSessionKey?: string
       originCoords?: CallMeta['originCoords']
       externalOrigin?: CallMeta['externalOrigin']
       /** §5.3 lineage reply: the EXISTING target session this delivery replies into, by its
@@ -1499,8 +1492,8 @@ export class CollabCoordinator {
           // keyed by the runtime's id, so read it from the caller's own slot — `originSessionId`
           // is the lineage id, which is outward (§1.1).
           ...(ctx.originSessionId !== undefined &&
-          ctx.originAcpSessionId !== undefined &&
-          (await this.host.store().isCaptureExcluded(req.callerAgentId, ctx.originAcpSessionId))
+          ctx.originSessionKey !== undefined &&
+          (await this.host.store().isCaptureExcluded(req.callerAgentId, ctx.originSessionKey))
             ? { parentPrivate: true }
             : {}),
           toAgentId: req.toAgentId,

--- a/packages/daemon/src/collab/coordinator.ts
+++ b/packages/daemon/src/collab/coordinator.ts
@@ -2,6 +2,7 @@
 // orchestration, hoisted out of `Daemon` verbatim. Every delivery here is DIRECT (never a
 // visible channel post) and every ordering below — record-first, CAS, admission barrier — is
 // load-bearing against a fast worker replying before its record exists.
+import type { HostKey } from '../acp/host-key.js'
 import { randomUUID } from 'node:crypto'
 import type { Clock, TimerHandle } from '@agentconnect.md/connection'
 import {
@@ -57,6 +58,8 @@ export interface CollabCoreHost {
   evalHooks(): DaemonEvaluationHooks
   /** Live turns keyed by `pendingTurnKey(agentId, acpSessionId)`. */
   pending(): ReadonlyMap<string, Pending>
+  /** The owner key a session's pending/lease entries are filed under. */
+  sessionOwnerKey(agentId: string, sessionKey: string): HostKey
   /** Per-session call metadata of the turn running right now — the caller's live hop depth. */
   activeTurnCallMeta(): ReadonlyMap<string, CallMeta>
   /** Shutdown/pause: an A2A obligation must not be inferred while the daemon is draining. */
@@ -342,7 +345,9 @@ export class CollabCoordinator {
     ): Promise<MessageAgentResult> => {
       const caller = await this.host.store().getSession(callerKey)
       const pending = caller?.acpSessionId
-        ? this.host.pending().get(pendingTurnKey(req.callerAgentId, caller.acpSessionId))
+        ? this.host
+            .pending()
+            .get(pendingTurnKey(this.host.sessionOwnerKey(req.callerAgentId, callerKey), caller.acpSessionId))
         : undefined
       this.host.evalHooks().emit({
         type,
@@ -705,7 +710,10 @@ export class CollabCoordinator {
     // and that wake is deferred while this very dispatch finalizes — so a tasks-only
     // check would see zero and infer the narration while the bg wake is still owed.
     const sessionId = (await this.host.store().getSession(childKey))?.acpSessionId ?? undefined
-    const lease = sessionId !== undefined ? this.host.sdkLease().get(sdkLeaseKey(agentId, sessionId)) : undefined
+    const lease =
+      sessionId !== undefined
+        ? this.host.sdkLease().get(sdkLeaseKey(this.host.sessionOwnerKey(agentId, childKey), sessionId))
+        : undefined
     if (lease !== undefined && (lease.tasks.size > 0 || lease.armedWakes > 0)) return
     const finalOutput = p.reply.text.trim()
     const text =

--- a/packages/daemon/src/commands/handlers.ts
+++ b/packages/daemon/src/commands/handlers.ts
@@ -12,6 +12,7 @@
  * {@link CommandHost} — and the Daemon keeps thin same-name delegates for the
  * ingress paths (and the tests) that already call these by name.
  */
+import type { HostKey } from '../acp/host-key.js'
 import type { AcpHost } from '../acp/acp-host.js'
 import { applySelect, selectCardText, selectDisplay, selectLabel, selectOptions } from './select-projection.js'
 import type { SelectSetters } from './select-projection.js'
@@ -63,7 +64,10 @@ export interface CommandHost {
   /** True when this session runs on its own credential host rather than the shared static one. */
   hasModelSessionHost(key: string): boolean
   modelCrossesHostProvider(key: string, agentId: string, model: string): boolean
-  hostForStoredSession(agentId: string, acpSessionId: string): Promise<AcpHost | undefined>
+  /** The live host of a logical session, whatever kind of host serves it. */
+  hostForSession(agentId: string, sessionKey: string): AcpHost | undefined
+  /** The owner key a session's pending/lease entries are filed under. */
+  sessionOwnerKey(agentId: string, sessionKey: string): HostKey
   statusInfoFrom(agentId: string, sessionKey: string, acpSessionId?: string): Promise<StatusBarInfo>
   emitStatusBar(p: Pending): Promise<void>
   interruptTurn(
@@ -170,12 +174,12 @@ export class CommandHandlers {
       return true
     }
     const acpSessionId = rec.acpSessionId
-    const host = acpSessionId ? await this.host.hostForStoredSession(rec.agentId, acpSessionId) : undefined
+    const host = acpSessionId ? this.host.hostForSession(rec.agentId, rec.key) : undefined
     if (!acpSessionId || !host?.hasSession(acpSessionId)) return true // no live session — applies next turn
     void host
       .setSessionModel(acpSessionId, model)
       .then(async (applied) => {
-        const p = this.host.pending().get(pendingTurnKey(rec.agentId, acpSessionId))
+        const p = this.host.pending().get(pendingTurnKey(this.host.sessionOwnerKey(rec.agentId, rec.key), acpSessionId))
         if (applied && p) await this.host.emitStatusBar(p) // reflect the new model on the status bar
       })
       .catch((err) => this.host.log().warn(`set-model failed: ${(err as Error).message}`))
@@ -211,7 +215,7 @@ export class CommandHandlers {
     await this.host.store().setEffortOverride(key, effort)
     this.host.log().info(`session ${key} effort override → "${effort}"`)
     const acpSessionId = rec.acpSessionId
-    const host = acpSessionId ? await this.host.hostForStoredSession(rec.agentId, acpSessionId) : undefined
+    const host = acpSessionId ? this.host.hostForSession(rec.agentId, rec.key) : undefined
     if (!acpSessionId || !host?.hasSession(acpSessionId)) {
       await this.refreshStatusBarForKey(key)
       return true
@@ -232,7 +236,7 @@ export class CommandHandlers {
     await this.host.store().setPermissionModeOverride(key, permissionMode)
     this.host.log().info(`session ${key} permission mode override → "${permissionMode}"`)
     const acpSessionId = rec.acpSessionId
-    const host = acpSessionId ? await this.host.hostForStoredSession(rec.agentId, acpSessionId) : undefined
+    const host = acpSessionId ? this.host.hostForSession(rec.agentId, rec.key) : undefined
     if (!acpSessionId || !host?.hasSession(acpSessionId)) {
       await this.refreshStatusBarForKey(key)
       return true
@@ -253,7 +257,7 @@ export class CommandHandlers {
     await this.host.store().setFastModeOverride(key, fastMode)
     this.host.log().info(`session ${key} fast-mode override → ${fastMode}`)
     const acpSessionId = rec.acpSessionId
-    const host = acpSessionId ? await this.host.hostForStoredSession(rec.agentId, acpSessionId) : undefined
+    const host = acpSessionId ? this.host.hostForSession(rec.agentId, rec.key) : undefined
     if (!acpSessionId || !host?.hasSession(acpSessionId)) {
       await this.refreshStatusBarForKey(key)
       return true
@@ -269,7 +273,9 @@ export class CommandHandlers {
    *  (model / effort / fast) is reflected. No-op when the session is idle. */
   async refreshStatusBarForKey(key: string): Promise<void> {
     const rec = await this.host.store().getSession(key)
-    const p = rec?.acpSessionId ? this.host.pending().get(pendingTurnKey(rec.agentId, rec.acpSessionId)) : undefined
+    const p = rec?.acpSessionId
+      ? this.host.pending().get(pendingTurnKey(this.host.sessionOwnerKey(rec.agentId, rec.key), rec.acpSessionId))
+      : undefined
     if (p) await this.host.emitStatusBar(p)
   }
 

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -542,6 +542,7 @@ export function applyAgentActivate(host: ConfigApplyHost, activate: AgentActivat
     ) {
       return { ok: false, reason: 'agent/activate: staging fence is missing or superseded' }
     }
+    // Capacity counts agents, not hosts: a confined agent's per-session hosts are bounded by session admission.
     const capacityUsed = host.agents().size + host.activatingAgents().size
     if (host.cfg().limits.maxAgents > 0 && capacityUsed >= host.cfg().limits.maxAgents) {
       return {

--- a/packages/daemon/src/cp/config-apply-handlers.ts
+++ b/packages/daemon/src/cp/config-apply-handlers.ts
@@ -888,12 +888,14 @@ export async function applySessionVisibility(
   // there is none leave the gate closed (still ACKed).
   const agentId = p.agentId ?? (await host.store().soleAgentForAcpSession(p.sessionId))
   if (!agentId) return 'superseded'
-  // The push names the session outwardly; the gate is keyed by the runtime's id.
-  const slot = await host.store().getSessionByOutwardId(p.sessionId, agentId)
-  const acpSessionId = slot?.acpSessionId ?? p.sessionId
+  // The push names the session outwardly (a pre-v12 CP by the runtime's id); the gate is keyed by the logical session.
+  const slot =
+    (await host.store().getSessionByOutwardId(p.sessionId, agentId)) ??
+    (await host.store().getSessionByAcpIdForAgent(agentId, p.sessionId))
+  if (!slot) return 'superseded'
   return host
     .store()
-    .applyCpCaptureGate(agentId, acpSessionId, p.sharedMemoryExcluded ?? p.visibility === 'private', p.visibilityRev)
+    .applyCpCaptureGate(agentId, slot.key, p.sharedMemoryExcluded ?? p.visibility === 'private', p.visibilityRev)
 }
 
 /** Wire the handlers into the seam — member order mirrors the `ConfigApply` contract. */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -524,6 +524,7 @@ import {
   pendingSessionKey,
   pendingTurnAcpSessionId,
   pendingTurnKey,
+  pendingTurnOwner,
   QueueFullError,
   sdkLeaseKey,
   turnState,
@@ -630,8 +631,17 @@ registerObservedChannels(discordObservedChannels)
 registerObservedChannels(linearObservedChannels)
 
 /** Chain key for one agent's view of one ACP session — see `Daemon.enqueueAcpUpdate`. */
-function acpUpdateChainKey(agentId: string, sessionId: string): string {
-  return `${agentId}\u001f${sessionId}`
+function liveSdkLease(l: {
+  tasks: Map<string, unknown>
+  armedWakes: number
+  deliveringWakes: number
+  sdkState: string
+}): boolean {
+  return l.tasks.size > 0 || l.armedWakes > 0 || l.deliveringWakes > 0 || l.sdkState === 'running'
+}
+
+function acpUpdateChainKey(owner: HostKey, sessionId: string): string {
+  return `${owner}\u001f${sessionId}`
 }
 
 // One agent-discovery pass: what this daemon will serve, plus the whole active fleet on disk.
@@ -1430,9 +1440,9 @@ export class Daemon {
     try {
       for (const wait of this.permissions.liveApprovalWaits()) {
         if (wait.agentId !== agentId) continue
-        const outward = (await this.outwardSessionIdForAcp(agentId, wait.sessionId)) ?? wait.sessionId
+        const outward = (await this.outwardSessionIdForAcp(agentId, wait.sessionId, wait.owner)) ?? wait.sessionId
         // The snapshot above is stale by now; the emit itself re-checks the wait is still live.
-        if (outward === outwardSessionId) this.emitApprovalActivity(agentId, wait.sessionId, 'awaiting_permission')
+        if (outward === outwardSessionId) this.emitApprovalActivity(wait.owner, wait.sessionId, 'awaiting_permission')
       }
     } catch (err) {
       this.log.warn(`approval wait for session "${outwardSessionId}" not re-asserted: ${formatErr(err)}`)
@@ -1473,8 +1483,8 @@ export class Daemon {
       commandChrome: () => this.commandChrome,
       hasModelSessionHost: (key) => this.modelSessions.has(key),
       modelCrossesHostProvider: (key, agentId, model) => this.modelSessions.crossesHostProvider(key, agentId, model),
-      hostForStoredSession: async (agentId, acpSessionId) =>
-        await this.modelSessions.hostForStoredSession(agentId, acpSessionId),
+      hostForSession: (agentId, sessionKey) => this.hostForOwner(this.sessionOwnerKey(agentId, sessionKey)),
+      sessionOwnerKey: (agentId, sessionKey) => this.sessionOwnerKey(agentId, sessionKey),
       statusInfoFrom: async (agentId, sessionKey, acpSessionId) =>
         await this.statusInfoFrom(agentId, sessionKey, acpSessionId),
       emitStatusBar: (p) => this.emitStatusBar(p),
@@ -2324,7 +2334,8 @@ export class Daemon {
           if (!agent) throw new Error(`unknown agent ${agentId}`)
           await this.memory.recordTurnForBinding(
             {
-              ...(await this.memoryScopeForSession(agentId, turn.sessionId ?? '')),
+              // A replayed capture names its session by runtime id alone, so the shared owner's lookup serves it.
+              ...(await this.memoryScopeForSession(agentHostKey(agentId), turn.sessionId ?? '')),
               ...(turn.sessionId ? { sessionId: turn.sessionId } : {})
             },
             {
@@ -3596,17 +3607,6 @@ export class Daemon {
     return false
   }
 
-  /** The host owning an ACP session of the agent; without one, or unknown, the agent's shared host. */
-  private hostForAcpSession(agentId: string, acpSessionId?: string): AcpHost | undefined {
-    if (acpSessionId !== undefined) {
-      for (const [key, host] of this.hosts) {
-        if (hostKeyAgentId(key) !== agentId) continue
-        if (host.hasSession?.(acpSessionId) || host.isLoadingSession?.(acpSessionId)) return host
-      }
-    }
-    return this.hosts.get(agentHostKey(agentId))
-  }
-
   /** The agent's key for `host` — scoped to the agent, since a test factory may hand one object to several agents. */
   private hostKeyOfHost(agentId: string, host: AcpHost): HostKey | undefined {
     for (const [key, candidate] of this.hosts) if (candidate === host && hostKeyAgentId(key) === agentId) return key
@@ -3619,11 +3619,44 @@ export class Daemon {
     return latest
   }
 
-  /** Stop the host bound to one session, if any — its directory or its row is about to go. */
-  private async stopSessionHost(agentId: string, sessionKey: string, deadlineMs?: number): Promise<void> {
+  /** The owner of a logical session's pending/lease entries: the pool's host when it has one, else the host hostKeyFor names. */
+  private sessionOwnerKey(agentId: string, sessionKey: string): HostKey {
+    return this.modelSessions.has(sessionKey)
+      ? sessionHostKey(agentId, sessionKey)
+      : this.hostKeyFor(agentId, sessionKey)
+  }
+
+  /** The live host an owner key names: the daemon's own map, else the pool's entry for the session key. */
+  private hostForOwner(owner: HostKey): AcpHost | undefined {
+    const sessionKey = hostKeySessionKey(owner)
+    return (
+      this.hosts.get(owner) ?? (sessionKey === undefined ? undefined : this.modelSessions.hostForSessionKey(sessionKey))
+    )
+  }
+
+  /** The session row an ACP id names for THIS owner — a session-bound host answers only for its own session. */
+  private async sessionForAcp(owner: HostKey, acpSessionId: string): Promise<SessionRecord | undefined> {
+    const sessionKey = hostKeySessionKey(owner)
+    if (sessionKey === undefined) return await this.store.getSessionByAcpIdForAgent(hostKeyAgentId(owner), acpSessionId)
+    const rec = await this.store.getSession(sessionKey)
+    return rec?.acpSessionId === acpSessionId ? rec : undefined
+  }
+
+  // Stop the host bound to one session because its row or directory is going. `fence` is the host the
+  // cleanup decision saw: a replacement admitted for the same logical key since then is not the decision's to evict.
+  private async stopSessionHost(
+    agentId: string,
+    sessionKey: string,
+    fence?: { expected: AcpHost | undefined; row: { key: string; agentId: string; acpSessionId: string | null } }
+  ): Promise<void> {
     const key = sessionHostKey(agentId, sessionKey)
+    if (fence) {
+      if (this.hosts.get(key) !== fence.expected) return
+      if (await this.sessionRetentionActive(fence.row)) return
+      if (this.hosts.get(key) !== fence.expected) return
+    }
     if (!this.hosts.has(key) && !this.hostStarts.has(key) && !this.hostStopping.has(key)) return
-    await this.stopHostByKey(key, deadlineMs)
+    await this.stopHostByKey(key)
   }
 
   /**
@@ -4041,7 +4074,7 @@ export class Daemon {
     configFileState: { childEnv?: Record<string, string | undefined>; materialized: boolean }
   } {
     const agentId = agent.id
-    const onUpdate = (sid: string, u: any) => this.enqueueAcpUpdate(agentId, sid, u)
+    const onUpdate = (sid: string, u: any) => this.enqueueAcpUpdate(opts.hostKey, sid, u)
     const runtimeEntry = this.runtimeCatalog.entries[agent.runtime]
     if (runtimeEntry?.source === 'curated') {
       this.curatedRuntimeAdmission.assertLaunch(agent.runtime, runtimeEntry.source)
@@ -4260,15 +4293,15 @@ export class Daemon {
       // back to its LocalDriver, which is what a self-hosted daemon wants.
       ...(this.k8sPlane ? { driver: this.k8sPlane.driver } : {}),
       onUpdate,
-      onPermission: (sid, params) => this.permissions.onAcpPermission(agentId, sid, params),
+      onPermission: (sid, params) => this.permissions.onAcpPermission(opts.hostKey, sid, params),
       ...(this.evalHooks.enabled
         ? {
             onPermissionEvent: (sid, params, event) =>
-              this.permissions.onAcpPermissionEvent(agentId, sid, params, event)
+              this.permissions.onAcpPermissionEvent(opts.hostKey, sid, params, event)
           }
         : {}),
-      onElicit: (sid, params) => this.permissions.onAcpElicit(agentId, sid, params),
-      onSdkLifecycle: (sid, message) => this.onSdkLifecycle(agentId, sid, message),
+      onElicit: (sid, params) => this.permissions.onAcpElicit(opts.hostKey, sid, params),
+      onSdkLifecycle: (sid, message) => this.onSdkLifecycle(opts.hostKey, sid, message),
       // Pairs the runtime's terminal exit with the ordinary rebuild — see reapTerminalHost.
       onTerminal: () => this.reapTerminalHost(opts.hostKey, constructed.host),
       env: launch.env,
@@ -4415,6 +4448,7 @@ export class Daemon {
     let cleanup: Promise<void> | undefined
     return {
       host,
+      hostKey: key,
       stop: (deadlineMs) => (cleanup ??= this.stopHostByKey(key, deadlineMs)),
       waitForCleanup: () => cleanup ?? Promise.resolve()
     }
@@ -4431,12 +4465,10 @@ export class Daemon {
       acpSessionId: async (sessionKey) => (await this.store.getSession(sessionKey))?.acpSessionId,
       outwardSessionId: async (sessionKey, agentId) =>
         await this.store.ensureOutwardSessionId(sessionKey, agentId, this.clock.now()),
-      sessionKeyForAcpId: async (agentId, acpSessionId) =>
-        (await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId))?.key,
-      sessionSdkQuiescent: (agentId, acpSessionId) => this.sessionSdkQuiescent(agentId, acpSessionId),
-      releaseSdkLease: (agentId, acpSessionId) => void this.sdkLease.delete(sdkLeaseKey(agentId, acpSessionId)),
+      sessionSdkQuiescent: (owner, acpSessionId) => this.sessionSdkQuiescent(owner, acpSessionId),
+      releaseSdkLease: (owner, acpSessionId) => void this.sdkLease.delete(sdkLeaseKey(owner, acpSessionId)),
       startRuntime: async (agent, entry) => await this.startModelSessionRuntime(agent, entry),
-      ordinaryHost: (agentId, acpSessionId) => this.hostForAcpSession(agentId, acpSessionId),
+      hasDaemonHost: (agentId) => this.hasHostForAgent(agentId),
       cleanupAgentConfigFiles: (agentId) => this.cleanupModelSessionConfigFiles(agentId),
       hostStopped: (agentId, sessionKey) => this.releaseHostLaunch(sessionHostKey(agentId, sessionKey))
     }
@@ -4553,13 +4585,14 @@ export class Daemon {
 
   /** Memory scope for a running session, resolving its channel from the store by
    *  ACP session id (the capture path only carries the session id). */
-  private async memoryScopeForSession(agentId: string, acpSessionId: string): Promise<MemoryScope> {
-    const rec = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
-    return this.memoryScope(agentId, rec?.channel, rec?.transportScope)
+  private async memoryScopeForSession(owner: HostKey, acpSessionId: string): Promise<MemoryScope> {
+    const rec = await this.sessionForAcp(owner, acpSessionId)
+    return this.memoryScope(hostKeyAgentId(owner), rec?.channel, rec?.transportScope)
   }
 
   private async queueMemoryPostTurn(
     agentId: string,
+    owner: HostKey,
     sessionId: string,
     turnId: string,
     input: string,
@@ -4590,7 +4623,7 @@ export class Daemon {
       }
       try {
         await this.memory.recordTurnForBinding(
-          { ...(await this.memoryScopeForSession(agentId, sessionId)), sessionId },
+          { ...(await this.memoryScopeForSession(owner, sessionId)), sessionId },
           { turnId, sessionId, input, output },
           binding,
           captureTarget
@@ -4667,9 +4700,9 @@ export class Daemon {
     const agent = this.agents.get(agentId)
     if (!agent) throw new Error(`unknown agent ${agentId}`)
     const modelSessionKey = this.modelSessions.enabled ? internalSessionKey.memory(agentId) : undefined
-    const host = modelSessionKey
-      ? (await this.modelSessions.ensure(agent, modelSessionKey)).host
-      : await this.ensureHostAsync(agentHostKey(agentId))
+    const selected = modelSessionKey ? await this.modelSessions.ensure(agent, modelSessionKey) : undefined
+    const owner = selected?.hostKey ?? agentHostKey(agentId)
+    const host = selected?.host ?? (await this.ensureHostAsync(agentHostKey(agentId)))
     try {
       if (this.memoryExtractionUnavailable.has(host)) {
         throw new Error('memory extraction is unavailable for this runtime host')
@@ -4742,7 +4775,7 @@ export class Daemon {
             )
         // Synchronous on purpose: the runtime advertises its commands on a timer right after this
         // resolves, and a registration behind one more await loses that race (#1310 review).
-        const passKey = pendingTurnKey(agentId, sessionId)
+        const passKey = pendingTurnKey(owner, sessionId)
         this.internalPassSessions.add(internalPassSlot.distill(cacheKey), passKey)
         if (!(await host.setSessionPermissionMode(sessionId, readOnlyMode))) {
           host.discardSession(sessionId)
@@ -4752,7 +4785,7 @@ export class Daemon {
         }
         this.memoryExtractionSessions.set(cacheKey, sessionId)
       }
-      const key = pendingTurnKey(agentId, sessionId)
+      const key = pendingTurnKey(owner, sessionId)
       const chunks: string[] = []
       this.memoryExtractionQuarantines.delete(key)
       this.memoryExtractionCollectors.set(key, { chunks })
@@ -4766,7 +4799,7 @@ export class Daemon {
         await host.prompt(sessionId, [{ type: 'text', text }])
         // The runtime's notifications are handled off the prompt call, so drain this
         // session's update chain before the pass reads what they collected.
-        await this.acpUpdateChains.get(acpUpdateChainKey(agentId, sessionId))
+        await this.acpUpdateChains.get(acpUpdateChainKey(owner, sessionId))
         return chunks.join('')
       } catch (err) {
         if (this.memoryExtractionSessions.get(cacheKey) === sessionId) {
@@ -4786,7 +4819,7 @@ export class Daemon {
       if (modelSessionKey) {
         const extractionSessionId = this.memoryExtractionSessions.get(cacheKey)
         if (extractionSessionId) {
-          this.memoryExtractionQuarantines.delete(pendingTurnKey(agentId, extractionSessionId))
+          this.memoryExtractionQuarantines.delete(pendingTurnKey(owner, extractionSessionId))
         }
         this.memoryExtractionSessions.delete(cacheKey)
         await this.modelSessions.release(modelSessionKey)
@@ -4832,9 +4865,9 @@ export class Daemon {
     if (!agent) throw new Error(`unknown agent ${agentId}`)
     if (signal.aborted) throw new Error('commit-message pass canceled before dispatch')
     const modelSessionKey = this.modelSessions.enabled ? internalSessionKey.commit(agentId, randomUUID()) : undefined
-    const host = modelSessionKey
-      ? (await this.modelSessions.ensure(agent, modelSessionKey)).host
-      : await this.ensureHostAsync(agentHostKey(agentId))
+    const selected = modelSessionKey ? await this.modelSessions.ensure(agent, modelSessionKey) : undefined
+    const owner = selected?.hostKey ?? agentHostKey(agentId)
+    const host = selected?.host ?? (await this.ensureHostAsync(agentHostKey(agentId)))
     try {
       // OBSERVED, not gated (memory-dreaming.md §2): the policy rides `_meta.systemPrompt` where the
       // runtime has that channel and is prepended inline where it does not. The output contract lives
@@ -4852,7 +4885,7 @@ export class Daemon {
       const sessionId = trusted
         ? await host.newSession(cwd, [], undefined, systemPrompt, [], undefined, CLAUDE_HEADLESS_DISALLOWED_TOOLS)
         : await host.newSession(cwd, [], undefined, undefined, [], undefined, CLAUDE_HEADLESS_DISALLOWED_TOOLS)
-      const key = pendingTurnKey(agentId, sessionId)
+      const key = pendingTurnKey(owner, sessionId)
       // Synchronous on purpose: see the distillation pass — the advertisement is already on a timer.
       this.internalPassSessions.add(internalPassSlot.commit(agentId, sessionId), key)
       try {
@@ -5025,7 +5058,7 @@ export class Daemon {
     }
     const ref: { sessionId?: string } = {}
     try {
-      return await this.runDreamExtractionOnHost(host, agent, systemPrompt, prompt, signal, context, ref)
+      return await this.runDreamExtractionOnHost(host, dreamHostKey, agent, systemPrompt, prompt, signal, context, ref)
     } finally {
       // One-off host: discard the whole confined child so its process + huge,
       // attacker-influenced context never lingers (dreams are rare). Stopping the
@@ -5041,7 +5074,7 @@ export class Daemon {
       // clearMemoryExtractionQuarantines sweep, so without this a long-lived
       // daemon would leak one Map entry per dream. Scoped to THIS session so a
       // concurrent distiller quarantine on the warm host is untouched.
-      if (ref.sessionId) this.memoryExtractionQuarantines.delete(pendingTurnKey(agent.id, ref.sessionId))
+      if (ref.sessionId) this.memoryExtractionQuarantines.delete(pendingTurnKey(dreamHostKey, ref.sessionId))
     }
   }
 
@@ -5123,6 +5156,7 @@ export class Daemon {
    */
   private async runDreamExtractionOnHost(
     host: AcpHost,
+    owner: HostKey,
     agent: LoadedAgent,
     systemPrompt: string,
     prompt: string,
@@ -5193,9 +5227,10 @@ export class Daemon {
       ref.sessionId = sessionId
       // Redundant while the dream owns a dedicated host the gate already excludes, but it keeps one
       // rule: every session the daemon opens for itself is registered, synchronously, right here.
-      this.internalPassSessions.add(internalPassSlot.dream(agentId), pendingTurnKey(agentId, sessionId))
+      this.internalPassSessions.add(internalPassSlot.dream(agentId), pendingTurnKey(owner, sessionId))
       const result = await this.runDreamExtractionSession(
         host,
+        owner,
         agent,
         sessionId,
         prompt,
@@ -5217,6 +5252,7 @@ export class Daemon {
    *  for the session is always unregistered in the caller's finally. */
   private async runDreamExtractionSession(
     host: AcpHost,
+    owner: HostKey,
     agent: LoadedAgent,
     sessionId: string,
     prompt: string,
@@ -5310,7 +5346,7 @@ export class Daemon {
       // Final guard immediately before dispatch — abort during permission setup.
       if (signal.aborted) throw new Error('dream extraction canceled before dispatch')
 
-      const key = pendingTurnKey(agentId, sessionId)
+      const key = pendingTurnKey(owner, sessionId)
       const chunks: string[] = []
       collector = {
         chunks,
@@ -5350,7 +5386,7 @@ export class Daemon {
         promptCompleted = true
         // The runtime's notifications are handled off the prompt call, so drain this
         // session's update chain before the pass reads what they collected.
-        await this.acpUpdateChains.get(acpUpdateChainKey(agentId, sessionId))
+        await this.acpUpdateChains.get(acpUpdateChainKey(owner, sessionId))
         if (result.usage) {
           const counts = {
             totalTokens: result.usage.totalTokens,
@@ -5425,7 +5461,7 @@ export class Daemon {
         ...(extractionMode ? { permissionMode: extractionMode } : {})
       })
       host.discardSession(sessionId)
-      this.internalPassSessions.delete(pendingTurnKey(agentId, sessionId))
+      this.internalPassSessions.delete(pendingTurnKey(owner, sessionId))
     }
   }
 
@@ -6430,9 +6466,7 @@ export class Daemon {
    *  survive until the next message restores the Agent-level policy. */
   private async restoreConfiguredRuntimeSettings(agent: LoadedAgent): Promise<void> {
     for (const session of await this.store.listSessions(agent.id)) {
-      const host = session.acpSessionId
-        ? await this.modelSessions.hostForStoredSession(agent.id, session.acpSessionId)
-        : this.hosts.get(agentHostKey(agent.id))
+      const host = this.hostForOwner(this.sessionOwnerKey(agent.id, session.key))
       if (!session.acpSessionId || host?.hasSession?.(session.acpSessionId) !== true) continue
       const sessionId = session.acpSessionId
       void this.applyConfiguredRuntimeSettings(agent, host, sessionId)
@@ -7846,8 +7880,11 @@ export class Daemon {
       sessionLink: (sessionId, source) => this.sessionLink(sessionId, source),
       outwardSessionId: (agentId, acpSessionId) => this.outwardSessionIdForAcp(agentId, acpSessionId),
       runtimeNames: () => this.runtimeFacts.runtimeNames(),
-      hostForStoredSession: async (agentId, acpSessionId) =>
-        await this.modelSessions.hostForStoredSession(agentId, acpSessionId)
+      // A hook names its session by agent + runtime id; the row's logical key picks the owning host.
+      hostForStoredSession: async (agentId, acpSessionId) => {
+        const rec = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+        return rec ? this.hostForOwner(this.sessionOwnerKey(agentId, rec.key)) : this.hosts.get(agentHostKey(agentId))
+      }
     }
   }
 
@@ -8667,7 +8704,7 @@ export class Daemon {
       httpSlackSessionTarget: (p) => this.httpSlackSessionTarget(p),
       maskAgentSecrets: <T>(agentId: string, payload: T): T => this.maskAgentSecrets(agentId, payload),
       logSessionAction: (verb, sessionKey, actor) => this.commands.logSessionAction(verb, sessionKey, actor),
-      emitApprovalActivity: (agentId, acpSessionId, state) => this.emitApprovalActivity(agentId, acpSessionId, state),
+      emitApprovalActivity: (owner, acpSessionId, state) => this.emitApprovalActivity(owner, acpSessionId, state),
       approvalGateOpened: (p, gateId, request) => this.openApprovalGateSurface(p, gateId, request),
       approvalGateClosed: (p, gateId, allowed) => this.settleApprovalGateSurface(p, gateId, allowed),
       // ── approval-DM routing (slack-approval-dm.md §4–§6) ──
@@ -8707,13 +8744,14 @@ export class Daemon {
   private approvalActivityChain: Promise<void> = Promise.resolve()
 
   /** D→C `agent/activity` for the approval bell (slack-approval-dm.md §7); best-effort, the reconnect replay converges it. */
-  private emitApprovalActivity(agentId: string, acpSessionId: string, state: 'awaiting_permission' | 'idle'): void {
+  private emitApprovalActivity(owner: HostKey, acpSessionId: string, state: 'awaiting_permission' | 'idle'): void {
+    const agentId = hostKeyAgentId(owner)
     this.approvalActivityChain = this.approvalActivityChain.then(async () => {
       try {
-        const sessionId = (await this.outwardSessionIdForAcp(agentId, acpSessionId)) ?? acpSessionId
+        const sessionId = (await this.outwardSessionIdForAcp(agentId, acpSessionId, owner)) ?? acpSessionId
         // Re-checked after the lookup with no await before the send: a settle that landed meanwhile
         // already queued its `idle` ahead of this task, and a stale `awaiting_permission` must not follow it.
-        if (state === 'awaiting_permission' && !this.permissions.isAwaitingApproval(agentId, acpSessionId)) return
+        if (state === 'awaiting_permission' && !this.permissions.isAwaitingApproval(owner, acpSessionId)) return
         this.cpClient?.emitAgentActivity?.({ agentId, sessionId, state, ts: new Date(this.clock.now()).toISOString() })
       } catch (err) {
         this.log.warn(`approval activity for agent "${agentId}" not reported: ${formatErr(err)}`)
@@ -8730,6 +8768,7 @@ export class Daemon {
       agents: () => this.agents,
       evalHooks: () => this.evalHooks,
       pending: () => this.pending,
+      sessionOwnerKey: (agentId, sessionKey) => this.sessionOwnerKey(agentId, sessionKey),
       activeTurnCallMeta: () => this.activeTurnCallMeta,
       draining: () => this.draining,
       serialQueue: () => this.serialQueue,
@@ -10524,7 +10563,7 @@ export class Daemon {
     await this.applyStagedRuntime(run)
     await this.announceTurnStart(run, sessionId, created)
     if (handled.initializedOnly) {
-      await this.finishSessionInitialization(agentId, sessionId)
+      await this.finishSessionInitialization(agentId, { owner: this.sessionOwnerKey(agentId, key), sessionId })
       this.clearTurnActivity(run)
       releaseReplyConn()
       this.log.info(`dispatch: initialized session ${key} from self-authored channel root without a model turn`)
@@ -10733,8 +10772,7 @@ export class Daemon {
             // selectedHost is assigned only after handle() for ordinary warm
             // turns. Resolve the already-running agent host directly here so the
             // rotated descriptor forces session/load before this prompt.
-            const warmHost =
-              entry.selectedHost?.host ?? this.hostForAcpSession(agentId, existing?.acpSessionId ?? undefined)
+            const warmHost = entry.selectedHost?.host ?? this.hostForOwner(this.sessionOwnerKey(agentId, key))
             if (existing?.acpSessionId) warmHost?.forgetSession(existing.acpSessionId)
           }
         } catch (error) {
@@ -10907,7 +10945,9 @@ export class Daemon {
     try {
       // The one consumer is the CP's cron report, a console deep link — so the callback is
       // handed the session's outward id (§1.1), not the runtime's.
-      onSessionReady?.((await this.outwardSessionIdForAcp(agentId, sessionId)) ?? sessionId)
+      onSessionReady?.(
+        (await this.outwardSessionIdForAcp(agentId, sessionId, this.sessionOwnerKey(agentId, key))) ?? sessionId
+      )
     } catch (err) {
       this.log.warn(`dispatch: session-ready notification failed (${formatErr(err)})`)
     }
@@ -10937,6 +10977,7 @@ export class Daemon {
     const p: Pending = {
       plan,
       entry,
+      hostKey: entry.selectedHost?.hostKey ?? this.sessionOwnerKey(agentId, run.key),
       conv,
       rec,
       termOut: new TerminalOutputFolder(),
@@ -10980,10 +11021,10 @@ export class Daemon {
     }
     // A real turn takes over the session — flush any drain narration first (delivered, not
     // dropped), so buffered text can neither leak into this turn nor go stale behind it.
-    void this.deliverDrainNarration(agentId, sessionId).catch((err) =>
+    void this.deliverDrainNarration(p.hostKey, sessionId).catch((err) =>
       this.log.warn(`drain delivery failed for "${agentId}": ${(err as Error).message}`)
     )
-    this.pending.set(pendingTurnKey(agentId, sessionId), p)
+    this.pending.set(pendingTurnKey(p.hostKey, sessionId), p)
     return p
   }
 
@@ -11059,7 +11100,7 @@ export class Daemon {
     // session/new|load may emit title/usage metadata before the local row exists.
     // Replay only after Pending owns the live sink so persisted and streamed state
     // converge in the same turn instead of requiring a browser refresh.
-    await this.finishSessionInitialization(agentId, sessionId)
+    await this.finishSessionInitialization(agentId, { owner: this.sessionOwnerKey(agentId, key), sessionId })
     // §6.7 active-turn context: expose THIS turn's trusted callMeta by logical sessionKey so
     // a nested messageAgent made during the turn can auto-inherit hop/origin + reply-correlation.
     if (callMeta) this.activeTurnCallMeta.set(key, callMeta)
@@ -11449,7 +11490,7 @@ export class Daemon {
       const result = await promptPromise
       // The runtime's notifications are handled off the prompt call, so drain this
       // session's update chain before the turn reads what they wrote.
-      await this.acpUpdateChains.get(acpUpdateChainKey(agent.id, sessionId))
+      await this.acpUpdateChains.get(acpUpdateChainKey(p.hostKey, sessionId))
       stopReason = result.stopReason
       usage = result.usage
 
@@ -11861,6 +11902,7 @@ export class Daemon {
     // its conversation-stable message id.
     await this.queueMemoryPostTurn(
       agentId,
+      p.hostKey,
       sessionId,
       p.webchat?.turnId ?? handled.turnId ?? stableTurnId(agentId, msg),
       finalCaptureInput,
@@ -12076,7 +12118,7 @@ export class Daemon {
     // The ACP prompt is no longer capable of ignoring session/cancel once control
     // reaches cleanup. Clear its host-kill backstop BEFORE awaiting renderer I/O;
     // renderer drain is tracked separately by this dispatch/safety lease.
-    this.clearCancelBackstop(agentId, sessionId)
+    this.clearCancelBackstop(p.hostKey, sessionId)
     // Settle the status row before releasing the Slack transport. Suppressed turns still
     // allow this one terminal chrome update; ordinary queued output remains blocked.
     await this.settleStatusBar(p)
@@ -12094,9 +12136,9 @@ export class Daemon {
     this.clearFeishuStream(p)
     this.clearSlackStream(p)
     // Backstop: settle any permission / elicitation card still awaiting a tap.
-    await this.permissions.releaseElicits(agentId, sessionId)
-    await this.permissions.releaseChatPermissions(agentId, sessionId)
-    await this.permissions.releaseEditorPermissions(agentId, sessionId)
+    await this.permissions.releaseElicits(p.hostKey, sessionId)
+    await this.permissions.releaseChatPermissions(p.hostKey, sessionId)
+    await this.permissions.releaseEditorPermissions(p.hostKey, sessionId)
     // §6.7: this turn's active call context ends with the turn (a nested messageAgent can
     // only inherit while the turn is in flight). Only clear if THIS turn owns the entry —
     // the map is keyed by sessionKey and the gate guarantees one active turn per key.
@@ -12178,7 +12220,7 @@ export class Daemon {
     const cleanupOutcome = await this.waitForTurnLifecycleCleanup(entry, key, p.selectedHost)
     if (!cleanupOutcome.blocked) {
       this.recordFooterHolder(p)
-      this.pending.delete(pendingTurnKey(agentId, sessionId))
+      this.pending.delete(pendingTurnKey(p.hostKey, sessionId))
       // §7.3 prompting/cancelling → idle: the turn is over (cleanly, on error, or
       // cancelled), so the session is idle again. Without this the row stayed
       // `prompting` forever — the thread never went idle and TTL-close never fired.
@@ -12335,7 +12377,7 @@ export class Daemon {
       }
     }
     const live = acpSessionId
-      ? this.pending.get(pendingTurnKey(agentId, acpSessionId))
+      ? this.pending.get(pendingTurnKey(this.sessionOwnerKey(agentId, key), acpSessionId))
       : [...this.pending.values()].find((pending) => pending.plan.sessionKey === key)
     const liveSessionId = acpSessionId ?? live?.acpSessionId
     if (live) {
@@ -12384,17 +12426,17 @@ export class Daemon {
     // Release any card the user hasn't answered: ACP requires pending permission /
     // elicitation requests to resolve cancelled when a turn is cancelled, and this lets
     // the agent's prompt unwind (it's blocked awaiting our promise) so the finally runs.
-    await this.permissions.releaseElicits(agentId, liveSessionId)
-    await this.permissions.releaseChatPermissions(agentId, liveSessionId)
-    await this.permissions.releaseEditorPermissions(agentId, liveSessionId)
+    await this.permissions.releaseElicits(live.hostKey, liveSessionId)
+    await this.permissions.releaseChatPermissions(live.hostKey, liveSessionId)
+    await this.permissions.releaseEditorPermissions(live.hostKey, liveSessionId)
     // §7.3 idle→cancelling: send session/cancel, then arm a force backstop. The turn's
     // dispatch finally clears the timer + writes the terminal idle state when the agent
     // yields; if it never does, the backstop force-stops the host.
     await this.store.setSessionState(key, 'cancelling', this.clock.now())
-    void (live.selectedHost?.host ?? this.hostForAcpSession(agentId, liveSessionId))
+    void (live.selectedHost?.host ?? this.hostForOwner(live.hostKey))
       ?.cancel(liveSessionId)
       .catch((err) => this.log.error(`command ${reason}: cancel failed: ${(err as Error).message}`))
-    this.armCancelBackstop(agentId, liveSessionId, key, reason)
+    this.armCancelBackstop(live.hostKey, liveSessionId, key, reason)
     await this.recordOperatorInterrupt(agentId, reason, opts.actor, anchor)
   }
 
@@ -12470,10 +12512,11 @@ export class Daemon {
    *  cancel — force-stop its host (the only hard kill available) so the session
    *  can't be stuck in `cancelling` forever. dispatch's finally clears this timer
    *  the moment the turn yields on its own. */
-  private armCancelBackstop(agentId: string, acpSessionId: string, key: string, reason: string): void {
-    this.clearCancelBackstop(agentId, acpSessionId)
+  private armCancelBackstop(owner: HostKey, acpSessionId: string, key: string, reason: string): void {
+    const agentId = hostKeyAgentId(owner)
+    this.clearCancelBackstop(owner, acpSessionId)
     const ms = this.cfg.limits.cancelBackstopMs
-    const pendingKey = pendingTurnKey(agentId, acpSessionId)
+    const pendingKey = pendingTurnKey(owner, acpSessionId)
     this.cancelTimers.set(
       pendingKey,
       this.clock.setTimeout(() => {
@@ -12499,8 +12542,8 @@ export class Daemon {
     )
   }
 
-  private clearCancelBackstop(agentId: string, acpSessionId: string): void {
-    const key = pendingTurnKey(agentId, acpSessionId)
+  private clearCancelBackstop(owner: HostKey, acpSessionId: string): void {
+    const key = pendingTurnKey(owner, acpSessionId)
     const t = this.cancelTimers.get(key)
     if (t !== undefined) {
       this.clock.clearTimeout(t)
@@ -12777,17 +12820,30 @@ export class Daemon {
    *  hop's id: `newSession()` returns a live session that can stream updates before the row
    *  carrying the mapping is written, and one of those updates (an `available_commands_update`)
    *  is persisted durably. */
-  private async outwardSessionIdForAcp(agentId: string, acpSessionId: string): Promise<string | undefined> {
+  private async outwardSessionIdForAcp(
+    agentId: string,
+    acpSessionId: string,
+    owner?: HostKey
+  ): Promise<string | undefined> {
     // `store` is absent only in bare test harnesses constructed without start() — the same guard
     // the advertisement's own persist makes one line later.
-    const slot = await this.store?.getSessionByAcpIdForAgent(agentId, acpSessionId)
-    const turnKey = pendingTurnKey(agentId, acpSessionId)
+    const slot = this.store
+      ? owner
+        ? await this.sessionForAcp(owner, acpSessionId)
+        : await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+      : undefined
     // Once the row can answer, it is the authority and the binding has done its job.
     if (slot) {
-      this.openingOutwardSessionIds.delete(turnKey)
+      if (owner) this.openingOutwardSessionIds.delete(pendingTurnKey(owner, acpSessionId))
       return await this.store.ensureOutwardSessionId(slot.key, agentId, this.clock.now())
     }
-    return this.openingOutwardSessionIds.get(turnKey)
+    if (owner) return this.openingOutwardSessionIds.get(pendingTurnKey(owner, acpSessionId))
+    // A wire-level caller names the slot by agent + runtime id alone; find whichever host of the agent is opening it.
+    for (const [turnKey, outward] of this.openingOutwardSessionIds) {
+      if (hostKeyAgentId(pendingTurnOwner(turnKey)) === agentId && pendingTurnAcpSessionId(turnKey) === acpSessionId)
+        return outward
+    }
+    return undefined
   }
 
   /** Slots whose runtime session exists but whose row does not yet, by {@link pendingTurnKey}.
@@ -12802,7 +12858,7 @@ export class Daemon {
     const outward = await this.store.ensureOutwardSessionId(key, agentId, this.clock.now())
     return (acpSessionId) => {
       if (this.openingOutwardSessionIds.size >= 2000) this.openingOutwardSessionIds.clear()
-      this.openingOutwardSessionIds.set(pendingTurnKey(agentId, acpSessionId), outward)
+      this.openingOutwardSessionIds.set(pendingTurnKey(this.sessionOwnerKey(agentId, key), acpSessionId), outward)
     }
   }
 
@@ -12866,9 +12922,7 @@ export class Daemon {
       ? await this.store.ensureOutwardSessionId(sessionKey, agentId, this.clock.now())
       : undefined
     // `?.()` guards a host stub without the method (test fakes); real AcpHosts always have it.
-    const host = acpSessionId
-      ? await this.modelSessions.hostForStoredSession(agentId, acpSessionId)
-      : this.hosts.get(agentHostKey(agentId))
+    const host = this.hostForOwner(this.sessionOwnerKey(agentId, sessionKey))
     const model = host?.modelOptions?.(acpSessionId)
     // A persisted session can outlive the adapter process that created it. In that
     // cold state the exact session selector is unavailable, but the runtime probe has
@@ -13327,12 +13381,13 @@ export class Daemon {
   }
 
   private bufferEarlySessionMetadata(
-    agentId: string,
+    owner: HostKey,
     sessionId: string,
     update: { sessionUpdate: string; [key: string]: any }
   ): boolean {
+    const agentId = hostKeyAgentId(owner)
     if ((this.sessionInitializationsByAgent.get(agentId) ?? 0) === 0) return false
-    const key = pendingTurnKey(agentId, sessionId)
+    const key = pendingTurnKey(owner, sessionId)
     const entry = this.earlySessionMetadata.get(key) ?? { agentId, sessionId, updates: [] }
     const previous = entry.updates.findIndex((candidate) => candidate.sessionUpdate === update.sessionUpdate)
     if (previous >= 0) entry.updates[previous] = update
@@ -13344,12 +13399,15 @@ export class Daemon {
   /** Complete one SessionManager initialization and replay any metadata the ACP
    *  adapter emitted before its local session row existed. Leftover unknown ids
    *  are discarded once the agent has no other initialization in flight. */
-  private async finishSessionInitialization(agentId: string, sessionId?: string): Promise<void> {
-    if (sessionId) {
-      const key = pendingTurnKey(agentId, sessionId)
+  private async finishSessionInitialization(
+    agentId: string,
+    session?: { owner: HostKey; sessionId: string }
+  ): Promise<void> {
+    if (session) {
+      const key = pendingTurnKey(session.owner, session.sessionId)
       const entry = this.earlySessionMetadata.get(key)
       this.earlySessionMetadata.delete(key)
-      if (entry) for (const update of entry.updates) await this.onAcpUpdate(agentId, sessionId, update)
+      if (entry) for (const update of entry.updates) await this.onAcpUpdate(session.owner, session.sessionId, update)
     }
     const remaining = Math.max(0, (this.sessionInitializationsByAgent.get(agentId) ?? 1) - 1)
     if (remaining > 0) {
@@ -13434,7 +13492,7 @@ export class Daemon {
     }
     await this.persistSessionTitle(rec, req.title)
 
-    const p = this.pending.get(pendingTurnKey(rec.agentId, rec.acpSessionId))
+    const p = this.pending.get(pendingTurnKey(this.sessionOwnerKey(rec.agentId, rec.key), rec.acpSessionId))
     if (p && p.plan.sessionKey === key && !p.outputSuppressed) {
       if (p.webchat) {
         webchatTurnOutput.emitWebchatUpdate(p.webchat, { sessionUpdate: 'session_info_update', title: req.title })
@@ -13450,10 +13508,10 @@ export class Daemon {
 
   /** One ACP session's updates stay in arrival order: the async store would otherwise let
    *  a later update whose handler does less I/O emit ahead of an earlier one. */
-  private enqueueAcpUpdate(agentId: string, sessionId: string, update: unknown): Promise<void> {
-    const key = acpUpdateChainKey(agentId, sessionId)
+  private enqueueAcpUpdate(owner: HostKey, sessionId: string, update: unknown): Promise<void> {
+    const key = acpUpdateChainKey(owner, sessionId)
     const previous = this.acpUpdateChains.get(key) ?? Promise.resolve()
-    const done = previous.then(() => this.onAcpUpdate(agentId, sessionId, update))
+    const done = previous.then(() => this.onAcpUpdate(owner, sessionId, update))
     this.acpUpdateChains.set(
       key,
       done.catch((err) => this.log.error(`acp update failed for session ${sessionId}: ${formatErr(err)}`))
@@ -13461,14 +13519,15 @@ export class Daemon {
     return done
   }
 
-  private async onAcpUpdate(agentId: string, sessionId: string, update: any): Promise<void> {
+  private async onAcpUpdate(owner: HostKey, sessionId: string, update: any): Promise<void> {
+    const agentId = hostKeyAgentId(owner)
     // Write-only secret values (agent runtimeOverrides.secrets) are masked out of the
     // update BEFORE any consumer sees it — memory extraction, the reply accumulator,
     // the GitHub collector, the webchat stream, the platform converger, and the
     // transcript recorder (tool rawInput/rawOutput included) all hang off this entry
     // point, so this one transform keeps a leaked value out of every surface at once.
     update = this.maskAgentSecrets(agentId, update)
-    const extractionKey = pendingTurnKey(agentId, sessionId)
+    const extractionKey = pendingTurnKey(owner, sessionId)
     const extraction = this.memoryExtractionCollectors.get(extractionKey)
     if (extraction) {
       if (update?.sessionUpdate === 'agent_message_chunk' && update.content?.type === 'text') {
@@ -13502,7 +13561,7 @@ export class Daemon {
     const extractionQuarantineOwner = this.memoryExtractionQuarantines.get(extractionKey)
     if (extractionQuarantineOwner) {
       if (extractionQuarantineOwner === agentId && update?.sessionUpdate === 'usage_update') {
-        const rec = await this.store.getSessionByAcpIdForAgent(agentId, sessionId)
+        const rec = await this.sessionForAcp(owner, sessionId)
         if (rec?.platform === 'dream') {
           await this.store.setUsageSnapshot(rec.key, {
             contextUsed: update.used,
@@ -13523,14 +13582,14 @@ export class Daemon {
     // yet. And the session must not be one this daemon opened for a pass of its OWN: those run on
     // the agent's warm host over a temp dir, whose list is missing its project skills (#1310 review).
     if (isAvailableCommandsUpdate(update)) {
-      const host = this.hostForAcpSession(agentId, sessionId)
+      const host = this.hostForOwner(owner)
       const owned = host?.hasSession(sessionId) || host?.isLoadingSession(sessionId)
       if (owned && !this.internalPassSessions.has(extractionKey)) {
         // Recorded under the session's OUTWARD id (§1.1): the row survives the session, so a name
         // resolved later would change once retention drops the mapping.
         const entry = this.runtimeCommands.record(
           agentId,
-          (await this.outwardSessionIdForAcp(agentId, sessionId)) ?? sessionId,
+          (await this.outwardSessionIdForAcp(agentId, sessionId, owner)) ?? sessionId,
           update,
           this.clock.now()
         )
@@ -13548,7 +13607,7 @@ export class Daemon {
       }
       return
     }
-    const p = this.pending.get(pendingTurnKey(agentId, sessionId))
+    const p = this.pending.get(pendingTurnKey(owner, sessionId))
     this.evalHooks.emit({
       type: 'acp.update',
       agentId,
@@ -13583,9 +13642,8 @@ export class Daemon {
     const isEarlyMetadata =
       update?.sessionUpdate === 'usage_update' ||
       (update?.sessionUpdate === 'session_info_update' && update.title !== undefined)
-    const detachedRec =
-      !p && isEarlyMetadata ? await this.store.getSessionByAcpIdForAgent(agentId, sessionId) : undefined
-    if (!p && isEarlyMetadata && !detachedRec && this.bufferEarlySessionMetadata(agentId, sessionId, update)) return
+    const detachedRec = !p && isEarlyMetadata ? await this.sessionForAcp(owner, sessionId) : undefined
+    if (!p && isEarlyMetadata && !detachedRec && this.bufferEarlySessionMetadata(owner, sessionId, update)) return
     // Context-window + cost snapshot (latest-wins). Captured for telemetry only;
     // it's dropped from the channel by the renderer. Handle it even after a turn
     // leaves `pending`: a late native cost must replace any fallback we just
@@ -13644,7 +13702,7 @@ export class Daemon {
       // background-task-aware-reclaim.md). Gated on a lease saying `running`: a straggler
       // chunk after idle stays dropped, so stale text can never leak into a later flush.
       if (update?.sessionUpdate === 'agent_message_chunk' && update.content?.type === 'text') {
-        const lease = this.sdkLease.get(sdkLeaseKey(agentId, sessionId))
+        const lease = this.sdkLease.get(sdkLeaseKey(owner, sessionId))
         if (lease?.sdkState === 'running')
           lease.drainText = (lease.drainText + String(update.content.text ?? '')).slice(0, MAX_DRAIN_TEXT_CHARS)
       }
@@ -14810,6 +14868,14 @@ export class Daemon {
     const results = await Promise.allSettled(
       this.hostKeysForAgent(agentId).map((key) => this.stopHostByKey(key, deadlineMs))
     )
+    // With every host of the agent gone, nothing of its session state can be live: sweep it agent-wide.
+    for (const [sid, lease] of this.sdkLease) if (lease.agentId === agentId) this.sdkLease.delete(sid)
+    for (const [bindingKey, binding] of this.sessionDeliveryBindings) {
+      if (binding.agentId === agentId) this.sessionDeliveryBindings.delete(bindingKey)
+    }
+    for (const [quarantineKey, ownerAgentId] of this.memoryExtractionQuarantines) {
+      if (ownerAgentId === agentId) this.memoryExtractionQuarantines.delete(quarantineKey)
+    }
     const failed = results.find((result) => result.status === 'rejected')
     if (failed) throw failed.reason
   }
@@ -14844,26 +14910,19 @@ export class Daemon {
     // The shared config files go with the agent's LAST host; another live host still reads them.
     const agentDir = this.agentHasOtherHosts(agentId, key) ? undefined : this.hostConfigFiles.get(agentId)?.agentDir
     if (agentDir) this.hostConfigFiles.delete(agentId)
-    // Session-scoped state goes with the sessions this host served: all of the agent's for its shared host, else the child's own.
-    const served = (acpSessionId: string): boolean =>
-      sessionKey === undefined ||
-      host?.hasSession?.(acpSessionId) === true ||
-      host?.isLoadingSession?.(acpSessionId) === true
-    // The adapter's ACP sessions are going away — drop their background-task leases so they cannot defer a future host.
-    for (const [sid, lease] of this.sdkLease) {
-      if (lease.agentId === agentId && served(pendingTurnAcpSessionId(sid))) this.sdkLease.delete(sid)
-    }
+    // Session state is filed under its owning host, so this host drops exactly its own — a sibling
+    // session host of the same agent keeps its leases and bindings (the agent-wide sweep is stopHost's).
+    for (const sid of this.sdkLease.keys()) if (pendingTurnOwner(sid) === key) this.sdkLease.delete(sid)
     const clearDeliveryBindings = () => {
       for (const [bindingKey, binding] of this.sessionDeliveryBindings) {
-        if (binding.agentId !== agentId) continue
-        if (sessionKey === undefined || bindingKey === sessionKey) this.sessionDeliveryBindings.delete(bindingKey)
+        if (binding.agentId === agentId && this.sessionOwnerKey(agentId, bindingKey) === key) {
+          this.sessionDeliveryBindings.delete(bindingKey)
+        }
       }
     }
     const clearMemoryExtractionQuarantines = () => {
-      for (const [quarantineKey, ownerAgentId] of this.memoryExtractionQuarantines) {
-        if (ownerAgentId === agentId && served(pendingTurnAcpSessionId(quarantineKey))) {
-          this.memoryExtractionQuarantines.delete(quarantineKey)
-        }
+      for (const quarantineKey of this.memoryExtractionQuarantines.keys()) {
+        if (pendingTurnOwner(quarantineKey) === key) this.memoryExtractionQuarantines.delete(quarantineKey)
       }
     }
     // With the child gone the config-file secrets are unread; a host of the agent started meanwhile re-registered them and keeps them.
@@ -14933,7 +14992,8 @@ export class Daemon {
    *  are ignored so a future event-shape change degrades to plain-TTL behavior
    *  rather than throwing. Field names verified against the adapter (§4.2 of
    *  docs/designs/background-task-aware-reclaim.md). */
-  private async onSdkLifecycle(agentId: string, acpSessionId: string, message: unknown): Promise<void> {
+  private async onSdkLifecycle(owner: HostKey, acpSessionId: string, message: unknown): Promise<void> {
+    const agentId = hostKeyAgentId(owner)
     const m = message as {
       type?: unknown
       subtype?: unknown
@@ -14957,7 +15017,7 @@ export class Daemon {
         live: Array.isArray(m.tasks) ? m.tasks.length : undefined
       })} on ${acpSessionId}`
     )
-    const leaseKey = sdkLeaseKey(agentId, acpSessionId)
+    const leaseKey = sdkLeaseKey(owner, acpSessionId)
     const lease = this.sdkLease.get(leaseKey) ?? {
       agentId,
       tasks: new Map<string, LiveSdkTask>(),
@@ -14996,14 +15056,14 @@ export class Daemon {
       // commands (sleeps, watchers) settle here every time. Both conditions are required:
       // `running` without a Pending is a self-drain cycle (§5.2 delivers its narration), and a
       // Pending past `idle` is finalization the model has already left.
-      if (lease.sdkState === 'running' && this.pending.has(pendingTurnKey(agentId, acpSessionId))) {
+      if (lease.sdkState === 'running' && this.pending.has(pendingTurnKey(owner, acpSessionId))) {
         this.log.debug(
           `bg-task wake skipped (settled inside the live foreground turn): ` +
             `"${rec.description?.trim() || 'background task'}" on ${acpSessionId}`
         )
         return
       }
-      this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, rec.description, status)
+      this.scheduleBackgroundTaskWake(owner, acpSessionId, taskId, rec.description, status)
     }
     switch (m.subtype) {
       case 'session_state_changed':
@@ -15016,7 +15076,7 @@ export class Daemon {
           // The cycle ended — deliver whatever a Pending-less drain narrated (no-op after a
           // real turn, whose chunks were never buffered). Fire-and-forget like the announce.
           if (m.state === 'idle' && wasRunning)
-            void this.deliverDrainNarration(agentId, acpSessionId).catch((err) =>
+            void this.deliverDrainNarration(owner, acpSessionId).catch((err) =>
               this.log.warn(`drain delivery failed for "${agentId}": ${(err as Error).message}`)
             )
         }
@@ -15075,7 +15135,8 @@ export class Daemon {
     // id, so this read is where the two meet. An unresolvable id is passed through, which is what
     // a pre-v12 session was reported under.
     const slot = await this.store.getSessionByOutwardId(req.sessionId, req.agentId)
-    const lease = this.sdkLease.get(sdkLeaseKey(req.agentId, slot?.acpSessionId ?? req.sessionId))
+    const owner = slot ? this.sessionOwnerKey(req.agentId, slot.key) : agentHostKey(req.agentId)
+    const lease = this.sdkLease.get(sdkLeaseKey(owner, slot?.acpSessionId ?? req.sessionId))
     const iso = (ms: number) => new Date(ms).toISOString()
     // Model-authored, so bounded here rather than trusted; the row survives, the tail does not.
     const described = (description: string | undefined) =>
@@ -15119,8 +15180,9 @@ export class Daemon {
    *  Agent speech, not a notice: it posts with the agent's conversational identity and lands
    *  in the transcript. {@link wakeOnBackgroundTaskDone} reads `drainDeliveredAt` at fire
    *  time and stands down for the completions this narration already covered. */
-  private async deliverDrainNarration(agentId: string, acpSessionId: string): Promise<void> {
-    const lease = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
+  private async deliverDrainNarration(owner: HostKey, acpSessionId: string): Promise<void> {
+    const agentId = hostKeyAgentId(owner)
+    const lease = this.sdkLease.get(sdkLeaseKey(owner, acpSessionId))
     if (!lease?.drainText) return
     const text = lease.drainText.trim()
     lease.drainText = ''
@@ -15133,7 +15195,7 @@ export class Daemon {
       )
       return
     }
-    const rec = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+    const rec = await this.sessionForAcp(owner, acpSessionId)
     if (!rec || rec.state === 'closed') return
     const mode = (await this.store.getOutputModeOverride(rec.key)) ?? this.agents.get(agentId)?.output?.mode ?? 'low'
     // Resolved against the SESSION's platform (delivery binding first) — never replyConnFor's
@@ -15298,20 +15360,21 @@ export class Daemon {
    *  the session and drop the lease before the timer fires. {@link wakeOnBackgroundTaskDone}
    *  releases the count on every exit path. */
   private scheduleBackgroundTaskWake(
-    agentId: string,
+    owner: HostKey,
     acpSessionId: string,
     taskId: string,
     description?: string,
     status?: string,
     attempt = 0
   ): void {
+    const agentId = hostKeyAgentId(owner)
     if (this.draining) return
-    const armed = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
+    const armed = this.sdkLease.get(sdkLeaseKey(owner, acpSessionId))
     if (armed) armed.armedWakes += 1
     const handle = this.clock.setTimeout(async () => {
       this.bgWakeTimers.delete(handle)
       try {
-        await this.wakeOnBackgroundTaskDone(agentId, acpSessionId, taskId, description, status, attempt)
+        await this.wakeOnBackgroundTaskDone(owner, acpSessionId, taskId, description, status, attempt)
       } catch (err) {
         this.log.error(`bg-task wake failed for "${agentId}": ${formatErr(err)}`)
       }
@@ -15347,15 +15410,16 @@ export class Daemon {
    *    observe the task itself).
    */
   private async wakeOnBackgroundTaskDone(
-    agentId: string,
+    owner: HostKey,
     acpSessionId: string,
     taskId: string,
     description?: string,
     status?: string,
     attempt = 0
   ): Promise<void> {
+    const agentId = hostKeyAgentId(owner)
     if (this.draining) return
-    const lease = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
+    const lease = this.sdkLease.get(sdkLeaseKey(owner, acpSessionId))
     const what = description?.trim() || 'background task'
     if (!lease) {
       this.log.debug(`bg-task wake skipped (host reclaimed): "${what}" on ${acpSessionId}`)
@@ -15390,7 +15454,7 @@ export class Daemon {
         return
       }
       // Take the next attempt's fence BEFORE releasing this one so the count never dips to 0.
-      this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, description, status, attempt + 1)
+      this.scheduleBackgroundTaskWake(owner, acpSessionId, taskId, description, status, attempt + 1)
       return skip(`runtime cycle still running, re-armed ${attempt + 1}/${MAX_BG_TASK_WAKE_REARMS}`)
     }
     if (lease.tasks.size > 0) return skip('other background tasks still live')
@@ -15410,7 +15474,7 @@ export class Daemon {
       )
       return
     }
-    const rec = await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId)
+    const rec = await this.sessionForAcp(owner, acpSessionId)
     if (!rec) return skip('no session row')
     // A turn is in flight for this session. It must NOT absorb this completion: `sdkState` is
     // already idle above, so `host.prompt()` has returned and the model cannot observe the task
@@ -15423,7 +15487,7 @@ export class Daemon {
       lease.armedWakes += 1 // the deferred retry's slot, taken before this one is released
       const resume = (): void => {
         lease.armedWakes = Math.max(0, lease.armedWakes - 1)
-        this.scheduleBackgroundTaskWake(agentId, acpSessionId, taskId, description, status, attempt)
+        this.scheduleBackgroundTaskWake(owner, acpSessionId, taskId, description, status, attempt)
       }
       void active.then(resume, resume)
       return skip('a turn is in flight — deferred until it settles')
@@ -15494,9 +15558,9 @@ export class Daemon {
    *  behavior). An armed wake counts: the task it will deliver is already out of `tasks`,
    *  so without it a long-running task's session could be TTL-closed inside the grace
    *  window and the completion lost — the very thing §5.1 exists to prevent. */
-  private sessionSdkQuiescent(agentId: string, acpSessionId: string | null | undefined): boolean {
+  private sessionSdkQuiescent(owner: HostKey, acpSessionId: string | null | undefined): boolean {
     if (!acpSessionId) return true
-    const l = this.sdkLease.get(sdkLeaseKey(agentId, acpSessionId))
+    const l = this.sdkLease.get(sdkLeaseKey(owner, acpSessionId))
     return !l || (l.tasks.size === 0 && l.armedWakes === 0 && l.deliveringWakes === 0 && l.sdkState === 'idle')
   }
 
@@ -15505,16 +15569,13 @@ export class Daemon {
    *  self-initiated followup turn that carries no `this.pending` entry). Gates idle host
    *  reclaim. */
   private agentHasLiveSdkWork(agentId: string): boolean {
-    return this.hostHasLiveSdkWork(agentId)
+    for (const l of this.sdkLease.values()) if (l.agentId === agentId && liveSdkLease(l)) return true
+    return false
   }
 
-  /** Live background work on the agent, narrowed to the sessions `host` holds when one is given. */
-  private hostHasLiveSdkWork(agentId: string, host?: AcpHost): boolean {
-    for (const [leaseKey, l] of this.sdkLease) {
-      if (l.agentId !== agentId) continue
-      if (host && !host.hasSession?.(pendingTurnAcpSessionId(leaseKey))) continue
-      if (l.tasks.size > 0 || l.armedWakes > 0 || l.deliveringWakes > 0 || l.sdkState === 'running') return true
-    }
+  /** Live background work on the sessions one host owns — its leases are filed under its key. */
+  private hostHasLiveSdkWork(owner: HostKey): boolean {
+    for (const [leaseKey, l] of this.sdkLease) if (pendingTurnOwner(leaseKey) === owner && liveSdkLease(l)) return true
     return false
   }
 
@@ -15562,7 +15623,7 @@ export class Daemon {
       this.activeDispatchDoneByKey.has(rec.key) ||
       [...this.pending.values()].some((p) => p.plan.sessionKey === rec.key) ||
       (await this.store.sessionHasPendingInboxRows(rec.key)) ||
-      !this.sessionSdkQuiescent(rec.agentId, rec.acpSessionId)
+      !this.sessionSdkQuiescent(this.sessionOwnerKey(rec.agentId, rec.key), rec.acpSessionId)
     )
   }
 
@@ -15591,7 +15652,10 @@ export class Daemon {
         return { outcome: 'not_applicable' }
       }
       // A host bound to this session runs inside the directory about to go: stop it before the removal.
-      await this.stopSessionHost(rec.agentId, rec.key)
+      await this.stopSessionHost(rec.agentId, rec.key, {
+        expected: this.hosts.get(sessionHostKey(rec.agentId, rec.key)),
+        row: rec
+      })
       // The volume has to be up and bound for the removal, as it was for the preparation — and for
       // the question of WHICH roots exist, which is asked of the filesystem that holds them: on a
       // suspended sandbox this daemon's own disk would answer "none" for a scratch agent whose pod
@@ -15613,9 +15677,7 @@ export class Daemon {
         // the worktree and runs session/load/new before prompting in its cwd.
         const current = await this.store.getSession(rec.key)
         if (current?.acpSessionId === rec.acpSessionId) {
-          ;(await this.modelSessions.hostForStoredSession(rec.agentId, rec.acpSessionId))?.forgetSession(
-            rec.acpSessionId
-          )
+          this.hostForOwner(this.sessionOwnerKey(rec.agentId, rec.key))?.forgetSession(rec.acpSessionId)
         }
       }
       return result
@@ -15682,14 +15744,16 @@ export class Daemon {
         active += 1
         continue
       }
+      const sessionHost = this.hosts.get(sessionHostKey(rec.agentId, rec.key))
       // The purge receipt is written in deleteSession's transaction: the CP holds
       // the only surviving record of this session, and it must be told that the
       // content behind it is gone (drained below, durably, on ACK).
       if (await this.store.deleteSession(rec.key, { reason: 'retention', at: purgedAt, ownerId: this.cfg.daemonId })) {
         removed += 1
-        if (rec.acpSessionId) this.sdkLease.delete(sdkLeaseKey(rec.agentId, rec.acpSessionId))
+        if (rec.acpSessionId)
+          this.sdkLease.delete(sdkLeaseKey(this.sessionOwnerKey(rec.agentId, rec.key), rec.acpSessionId))
         await this.modelSessions.release(rec.key)
-        await this.stopSessionHost(rec.agentId, rec.key)
+        await this.stopSessionHost(rec.agentId, rec.key, { expected: sessionHost, row: rec })
       }
     }
     this.log.info(
@@ -15939,6 +16003,8 @@ export class Daemon {
     // §7.3 idle→closed: a thread untouched past the TTL stops catching up — UNLESS it
     // still has in-flight background work (the SDK lease), which keeps it open. The
     // lease is member-local, so on a pool only the agent's holder decides its rows.
+    // The hosts the close decision is taken against; a session re-admitted meanwhile has a newer one.
+    const hostsAtDecision = new Map(this.hosts)
     const closed = await this.store.closeIdleSessions(now, ttl, (agentId, acpSessionId, key) =>
       this.sessionRetentionActive({ key, agentId, acpSessionId })
     )
@@ -15961,12 +16027,13 @@ export class Daemon {
         }
       }
       this.lastFooterReply.delete(row.key) // the session is gone — release its footer record
-      // A host bound to the closed session has nothing left to serve.
-      void this.stopSessionHost(row.agentId, row.key).catch((error) =>
+      // A host bound to the closed session has nothing left to serve — unless a new turn reopened the key since.
+      const expected = hostsAtDecision.get(sessionHostKey(row.agentId, row.key))
+      void this.stopSessionHost(row.agentId, row.key, { expected, row }).catch((error) =>
         this.log.warn(`idle: stopping the host of closed session ${row.key} failed (${formatErr(error)})`)
       )
       if (!row.acpSessionId) continue
-      this.sdkLease.delete(sdkLeaseKey(row.agentId, row.acpSessionId)) // the session is gone — drop its lease
+      this.sdkLease.delete(sdkLeaseKey(this.sessionOwnerKey(row.agentId, row.key), row.acpSessionId)) // the session is gone
       await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({
         sessionId: row.acpSessionId,
         agentId: row.agentId,
@@ -16008,7 +16075,7 @@ export class Daemon {
     // §7.2 ready→provisioned: reclaim a host whose agent has no recent session
     // activity AND no in-flight turn (a long turn stamps no activity, so the
     // in-flight guard is load-bearing — see recordUnrouted).
-    for (const [key, host] of [...this.hosts]) {
+    for (const [key] of [...this.hosts]) {
       const agentId = hostKeyAgentId(key)
       const sessionKey = hostKeySessionKey(key)
       const label = hostKeyLabel(key)
@@ -16039,7 +16106,7 @@ export class Daemon {
       // SIGTERMs the adapter, and `claude` reaps its own background jobs on graceful
       // exit. Bounded by the absolute lifetime ceiling so a wedged / never-ending task
       // can't pin an idle host forever.
-      if (this.hostHasLiveSdkWork(agentId, sessionKey === undefined ? undefined : host)) {
+      if (this.hostHasLiveSdkWork(key)) {
         const age = now - (this.hostStartedAt.get(key) ?? now)
         if (age <= maxLifetime) {
           this.log.info(`idle: host "${label}" has in-flight background work — deferring reclaim`)
@@ -16221,9 +16288,7 @@ export class Daemon {
       for (const p of this.pending.values()) {
         if (!match(p)) continue
         this.log.warn(`drain[${scope.kind}]: cancelling straggler turn (session ${p.acpSessionId})`)
-        await (p.selectedHost?.host ?? this.hostForAcpSession(p.plan.agentId, p.acpSessionId))
-          ?.cancel(p.acpSessionId)
-          .catch(() => {})
+        await (p.selectedHost?.host ?? this.hostForOwner(p.hostKey))?.cancel(p.acpSessionId).catch(() => {})
       }
     }
     return { matched: [...matched.values()], drained: [...drained.values()], targets: targets.map(([, p]) => p) }
@@ -16633,12 +16698,10 @@ export class Daemon {
         p.outputSuppressed ??= 'shutdown'
         this.clearIdle(p)
         this.turnSurfaces.exact(p.plan.platform)?.onSuppress?.(p)
-        await this.permissions.releaseElicits(p.plan.agentId, p.acpSessionId)
-        await this.permissions.releaseChatPermissions(p.plan.agentId, p.acpSessionId)
-        await this.permissions.releaseEditorPermissions(p.plan.agentId, p.acpSessionId)
-        void (p.selectedHost?.host ?? this.hostForAcpSession(p.plan.agentId, p.acpSessionId))
-          ?.cancel(p.acpSessionId)
-          .catch(() => {})
+        await this.permissions.releaseElicits(p.hostKey, p.acpSessionId)
+        await this.permissions.releaseChatPermissions(p.hostKey, p.acpSessionId)
+        await this.permissions.releaseEditorPermissions(p.hostKey, p.acpSessionId)
+        void (p.selectedHost?.host ?? this.hostForOwner(p.hostKey))?.cancel(p.acpSessionId).catch(() => {})
       }
       return forceAgents
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -290,7 +290,12 @@ import {
   type ModelProviderTarget
 } from './runtimes/model-provider-config.js'
 import { KeyServerClient, type KeyGrant } from './key-server/client.js'
-import { internalSessionKey, ModelSessionHostPool, type ModelSessionHostPoolHost } from './key-server/session-hosts.js'
+import {
+  internalSessionKey,
+  isInternalSessionKey,
+  ModelSessionHostPool,
+  type ModelSessionHostPoolHost
+} from './key-server/session-hosts.js'
 import { CuratedRuntimeAdmission } from './runtimes/curated-admission.js'
 import { RuntimeFactsRegistry, PROBE_TTL_MS, type RuntimeFactsHost } from './runtimes/facts-registry.js'
 import { assembleRuntimeLaunch } from './launch/assemble.js'
@@ -3637,7 +3642,10 @@ export class Daemon {
   /** The session row an ACP id names for THIS owner — a session-bound host answers only for its own session. */
   private async sessionForAcp(owner: HostKey, acpSessionId: string): Promise<SessionRecord | undefined> {
     const sessionKey = hostKeySessionKey(owner)
-    if (sessionKey === undefined) return await this.store.getSessionByAcpIdForAgent(hostKeyAgentId(owner), acpSessionId)
+    // The shared host, and a daemon-internal pass (dream/memory/commit) whose key names no session row, answer by agent.
+    if (sessionKey === undefined || isInternalSessionKey(sessionKey)) {
+      return await this.store.getSessionByAcpIdForAgent(hostKeyAgentId(owner), acpSessionId)
+    }
     const rec = await this.store.getSession(sessionKey)
     return rec?.acpSessionId === acpSessionId ? rec : undefined
   }
@@ -4592,14 +4600,14 @@ export class Daemon {
 
   private async queueMemoryPostTurn(
     agentId: string,
-    owner: HostKey,
     sessionId: string,
     turnId: string,
     input: string,
     output: string,
     binding: Agent['memory'],
     captureTarget?: PreparedExternalMemoryCapture,
-    evaluationTurnId = turnId
+    evaluationTurnId = turnId,
+    owner: HostKey = agentHostKey(agentId)
   ): Promise<void> {
     if (this.evaluationProfile.memory === 'off') return
     if (!output.trim()) return
@@ -11902,14 +11910,14 @@ export class Daemon {
     // its conversation-stable message id.
     await this.queueMemoryPostTurn(
       agentId,
-      p.hostKey,
       sessionId,
       p.webchat?.turnId ?? handled.turnId ?? stableTurnId(agentId, msg),
       finalCaptureInput,
       p.reply.text,
       agent.memory,
       memoryCaptureTarget,
-      plan.evaluationTurnId
+      plan.evaluationTurnId,
+      p.hostKey
     )
     evaluation.finishEvaluation('turn.completed', {
       ...(stopReason ? { stopReason } : {}),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3607,8 +3607,9 @@ export class Daemon {
     return this.hosts.get(agentHostKey(agentId))
   }
 
-  private hostKeyOfHost(host: AcpHost): HostKey | undefined {
-    for (const [key, candidate] of this.hosts) if (candidate === host) return key
+  /** The agent's key for `host` — scoped to the agent, since a test factory may hand one object to several agents. */
+  private hostKeyOfHost(agentId: string, host: AcpHost): HostKey | undefined {
+    for (const [key, candidate] of this.hosts) if (candidate === host && hostKeyAgentId(key) === agentId) return key
     return undefined
   }
 
@@ -3888,8 +3889,8 @@ export class Daemon {
       throw new Error(`workspace preparation blocked for superseded agent authority (${agent.id})`)
     }
     if (expectedWarmHost) {
-      const key = this.hostKeyOfHost(expectedWarmHost)
-      if (key === undefined || hostKeyAgentId(key) !== agent.id || !this.readyHosts.has(key)) {
+      const key = this.hostKeyOfHost(agent.id, expectedWarmHost)
+      if (key === undefined || !this.readyHosts.has(key)) {
         throw new Error(`workspace preparation blocked for superseded warm host (${agent.id})`)
       }
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -290,12 +290,7 @@ import {
   type ModelProviderTarget
 } from './runtimes/model-provider-config.js'
 import { KeyServerClient, type KeyGrant } from './key-server/client.js'
-import {
-  internalSessionKey,
-  isInternalSessionKey,
-  ModelSessionHostPool,
-  type ModelSessionHostPoolHost
-} from './key-server/session-hosts.js'
+import { internalSessionKey, ModelSessionHostPool, type ModelSessionHostPoolHost } from './key-server/session-hosts.js'
 import { CuratedRuntimeAdmission } from './runtimes/curated-admission.js'
 import { RuntimeFactsRegistry, PROBE_TTL_MS, type RuntimeFactsHost } from './runtimes/facts-registry.js'
 import { assembleRuntimeLaunch } from './launch/assemble.js'
@@ -643,6 +638,11 @@ function liveSdkLease(l: {
   sdkState: string
 }): boolean {
   return l.tasks.size > 0 || l.armedWakes > 0 || l.deliveringWakes > 0 || l.sdkState === 'running'
+}
+
+/** The store row a memory dream executes under. */
+function dreamExecutionKey(agentId: string, dreamId: string): string {
+  return sessionKey('dream', 'memory', dreamId, agentId)
 }
 
 function acpUpdateChainKey(owner: HostKey, sessionId: string): string {
@@ -2339,8 +2339,7 @@ export class Daemon {
           if (!agent) throw new Error(`unknown agent ${agentId}`)
           await this.memory.recordTurnForBinding(
             {
-              // A replayed capture names its session by runtime id alone, so the shared owner's lookup serves it.
-              ...(await this.memoryScopeForSession(agentHostKey(agentId), turn.sessionId ?? '')),
+              ...(await this.memoryScopeForCapturedTurn(agentId, turn.sessionId ?? '')),
               ...(turn.sessionId ? { sessionId: turn.sessionId } : {})
             },
             {
@@ -2688,7 +2687,10 @@ export class Daemon {
         // refuses to distill a capture-excluded turn at all. The binding is never
         // model-supplied, so this cannot be forged from inside a session.
         if (ctx.memoryBinding) return true
-        return !(await this.store.isCaptureExcluded(ctx.agentId, await this.acpSessionIdForToolCall(ctx)))
+        return !(await this.store.isCaptureExcluded(
+          ctx.agentId,
+          sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
+        ))
       },
       memoryScope: (ctx) => this.memoryScope(ctx.agentId, ctx.channel, ctx.transportScope),
       resolveAttachment: async (ctx, name) => {
@@ -2727,7 +2729,11 @@ export class Daemon {
           sessionOf: (id, sessionId) => this.store.getSessionByOutwardId(sessionId, id),
           runtimeRootOf: (id) => this.k8sPlane?.workspaceRootFor(id)
         })
-        const acpSessionId = await this.acpSessionIdForToolCall(ctx).catch(() => undefined)
+        // The session by its logical key; the scope answers by the outward id the row carries.
+        const row = await this.store
+          .getSession(sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope))
+          .catch(() => undefined)
+        const acpSessionId = row?.sessionId ?? row?.acpSessionId ?? undefined
         // Session-worktree first (an isolated session's files live there), then the agent
         // root: `location(id, sessionId)` answers ONLY for git-repo agents on isolated
         // sessions, and the default config (shared isolation, from-scratch) is the other arm.
@@ -3639,29 +3645,58 @@ export class Daemon {
     )
   }
 
-  /** The session row an ACP id names for THIS owner — a session-bound host answers only for its own session. */
+  /** The dream host's owner: its execution row's key, so its ACP id resolves to that row and nothing else. */
+  private dreamOwnerKey(agentId: string, dreamId: string): HostKey {
+    return sessionHostKey(agentId, dreamExecutionKey(agentId, dreamId))
+  }
+
+  // The session row an ACP id names for THIS owner. A session-bound owner answers only for its own row —
+  // an internal pass with no row (memory/commit) answers nothing, never a sibling that minted the same id.
   private async sessionForAcp(owner: HostKey, acpSessionId: string): Promise<SessionRecord | undefined> {
     const sessionKey = hostKeySessionKey(owner)
-    // The shared host, and a daemon-internal pass (dream/memory/commit) whose key names no session row, answer by agent.
-    if (sessionKey === undefined || isInternalSessionKey(sessionKey)) {
-      return await this.store.getSessionByAcpIdForAgent(hostKeyAgentId(owner), acpSessionId)
-    }
+    if (sessionKey === undefined) return await this.store.getSessionByAcpIdForAgent(hostKeyAgentId(owner), acpSessionId)
     const rec = await this.store.getSession(sessionKey)
     return rec?.acpSessionId === acpSessionId ? rec : undefined
   }
 
-  // Stop the host bound to one session because its row or directory is going. `fence` is the host the
-  // cleanup decision saw: a replacement admitted for the same logical key since then is not the decision's to evict.
+  /** Admission the session holds right now, read with no await so a stop can decide against it in one tick. */
+  private sessionAdmitted(sessionKey: string, hostKey: HostKey): boolean {
+    return (
+      this.inflight.has(sessionKey) ||
+      this.activeDispatchDoneByKey.has(sessionKey) ||
+      this.hostStarts.has(hostKey) ||
+      [...this.pending.values()].some((p) => p.plan.sessionKey === sessionKey)
+    )
+  }
+
+  /** The host and start generation a session-host stop decision is taken against. */
+  private sessionHostFence(
+    agentId: string,
+    sessionKey: string
+  ): { expected: AcpHost | undefined; generation: number | undefined } {
+    const key = sessionHostKey(agentId, sessionKey)
+    return { expected: this.hosts.get(key), generation: this.hostStartGeneration.get(key) }
+  }
+
+  // Stop the host bound to one session because its row or directory is going. `fence` is what the cleanup
+  // decision saw; a replacement, a newer start generation, or a turn admitted meanwhile is not its to evict.
   private async stopSessionHost(
     agentId: string,
     sessionKey: string,
-    fence?: { expected: AcpHost | undefined; row: { key: string; agentId: string; acpSessionId: string | null } }
+    fence?: {
+      expected: AcpHost | undefined
+      generation: number | undefined
+      row: { key: string; agentId: string; acpSessionId: string | null }
+    }
   ): Promise<void> {
     const key = sessionHostKey(agentId, sessionKey)
     if (fence) {
       if (this.hosts.get(key) !== fence.expected) return
       if (await this.sessionRetentionActive(fence.row)) return
+      // Read again with no await between here and the stop: the probe above awaited a store query.
       if (this.hosts.get(key) !== fence.expected) return
+      if (this.hostStartGeneration.get(key) !== fence.generation) return
+      if (this.sessionAdmitted(sessionKey, key)) return
     }
     if (!this.hosts.has(key) && !this.hostStarts.has(key) && !this.hostStopping.has(key)) return
     await this.stopHostByKey(key)
@@ -4591,11 +4626,13 @@ export class Daemon {
     }
   }
 
-  /** Memory scope for a running session, resolving its channel from the store by
-   *  ACP session id (the capture path only carries the session id). */
-  private async memoryScopeForSession(owner: HostKey, acpSessionId: string): Promise<MemoryScope> {
-    const rec = await this.sessionForAcp(owner, acpSessionId)
-    return this.memoryScope(hostKeyAgentId(owner), rec?.channel, rec?.transportScope)
+  // Memory scope of a captured turn on replay: the capture names its session outwardly (§1.1); a row
+  // captured before that was named by the runtime's id, which is tried second.
+  private async memoryScopeForCapturedTurn(agentId: string, capturedSessionId: string): Promise<MemoryScope> {
+    const rec =
+      (await this.store.getSessionByOutwardId(capturedSessionId, agentId)) ??
+      (await this.store.getSessionByAcpIdForAgent(agentId, capturedSessionId))
+    return this.memoryScope(agentId, rec?.channel, rec?.transportScope)
   }
 
   private async queueMemoryPostTurn(
@@ -4607,7 +4644,8 @@ export class Daemon {
     binding: Agent['memory'],
     captureTarget?: PreparedExternalMemoryCapture,
     evaluationTurnId = turnId,
-    owner: HostKey = agentHostKey(agentId)
+    // The logical session and its outward id: the gate is keyed by the former, the capture names the latter.
+    session?: { key: string; outwardSessionId: string }
   ): Promise<void> {
     if (this.evaluationProfile.memory === 'off') return
     if (!output.trim()) return
@@ -4616,7 +4654,7 @@ export class Daemon {
     // launch-correlated one) must never be distilled into it. The gate is checked
     // HERE — before both the managed distillation and the external capture outbox
     // — and fails closed on unknown state.
-    if (await this.store.isCaptureExcluded(agentId, sessionId)) return
+    if (await this.store.isCaptureExcluded(agentId, session?.key)) return
     const provider = binding?.provider ?? 'managed'
     const observableCapture = provider === 'managed' || provider === 'external'
     const record = async () => {
@@ -4630,9 +4668,11 @@ export class Daemon {
         })
       }
       try {
+        const rec = session ? await this.store.getSession(session.key) : undefined
+        const capturedSessionId = session?.outwardSessionId ?? sessionId
         await this.memory.recordTurnForBinding(
-          { ...(await this.memoryScopeForSession(owner, sessionId)), sessionId },
-          { turnId, sessionId, input, output },
+          { ...this.memoryScope(agentId, rec?.channel, rec?.transportScope), sessionId: capturedSessionId },
+          { turnId, sessionId: capturedSessionId, input, output },
           binding,
           captureTarget
         )
@@ -5056,7 +5096,7 @@ export class Daemon {
       }
     }
     let host: AcpHost
-    const dreamHostKey = sessionHostKey(agent.id, internalSessionKey.dream(context.dreamId))
+    const dreamHostKey = this.dreamOwnerKey(agent.id, context.dreamId)
     try {
       host = await this.buildDreamHost(agent, context.inputDir, dreamHostKey, issued)
     } catch (error) {
@@ -5285,7 +5325,7 @@ export class Daemon {
     // apply, and persisting/pricing that override would be false observability.
     const model =
       modelOptions === null ? agent.runtimeOverrides?.model : selectedModel === 'default' ? undefined : selectedModel
-    const executionKey = sessionKey('dream', 'memory', context.dreamId, agentId)
+    const executionKey = dreamExecutionKey(agentId, context.dreamId)
     const now = this.clock.now()
     await this.store.upsertSession({
       key: executionKey,
@@ -5323,6 +5363,7 @@ export class Daemon {
     })
     await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({
       sessionId,
+      sessionKey: executionKey,
       agentId,
       phase: 'start',
       platform: 'dream',
@@ -5458,6 +5499,7 @@ export class Daemon {
       await this.store.setSessionState(executionKey, 'idle', this.clock.now())
       await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({
         sessionId,
+        sessionKey: executionKey,
         agentId,
         phase: promptCompleted ? 'end' : 'problem',
         platform: 'dream',
@@ -5551,6 +5593,7 @@ export class Daemon {
     await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({
       // The outbox takes the ACP hop's id and translates; the dream row holds the outward one.
       sessionId: rec.acpSessionId ?? dream.executionSessionId,
+      sessionKey: rec.key,
       agentId: dream.agentId,
       phase: event.type === 'memory.dream.failed' ? 'problem' : 'end',
       platform: 'dream',
@@ -8796,7 +8839,7 @@ export class Daemon {
       dispatch: (agentId, msg, integrationId, webchat, callMeta, opts) =>
         this.dispatch(agentId, msg, integrationId, webchat, callMeta, opts),
       webchatTransport: () => this.webchatTransport,
-      externalOriginForSession: (agentId, acpSessionId) => this.externalOriginForSession(agentId, acpSessionId)
+      externalOriginForSession: (agentId, sessionKey) => this.externalOriginForSession(agentId, sessionKey)
     }
   }
 
@@ -10934,6 +10977,7 @@ export class Daemon {
     // recordMilestone upserts, so a repeated 'start' phase is safe on the CP.
     await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({
       sessionId,
+      sessionKey: key,
       agentId,
       phase: 'start',
       platform: msg.platform,
@@ -11917,7 +11961,7 @@ export class Daemon {
       agent.memory,
       memoryCaptureTarget,
       plan.evaluationTurnId,
-      p.hostKey
+      { key, outwardSessionId: p.outwardSessionId }
     )
     evaluation.finishEvaluation('turn.completed', {
       ...(stopReason ? { stopReason } : {}),
@@ -12243,6 +12287,7 @@ export class Daemon {
       )
       await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({
         sessionId,
+        sessionKey: key,
         agentId,
         phase: settlement.finalPhase,
         platform: msg.platform,
@@ -13442,6 +13487,7 @@ export class Daemon {
     if (!rec.acpSessionId) return
     await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({
       sessionId: rec.acpSessionId,
+      sessionKey: rec.key,
       agentId: rec.agentId,
       phase: 'plan',
       platform: rec.platform as SessionKey['platform'],
@@ -14131,7 +14177,7 @@ export class Daemon {
       // Never let classification break a turn — but fail CLOSED: an unclassified
       // session keeps memory capture excluded until the CP confirms otherwise.
       this.log.warn(`session visibility: classification failed for ${acpSessionId} (${formatErr(err)})`)
-      await this.store.setLocalCaptureGate(agentId, acpSessionId, true)
+      await this.store.setLocalCaptureGate(agentId, key, true)
     }
   }
 
@@ -14140,13 +14186,12 @@ export class Daemon {
    * by the root session's agent, not part of the audience identity. */
   private async externalOriginForSession(
     agentId: string,
-    acpSessionId: string | undefined
+    sessionKey: string | undefined
   ): Promise<ExternalSessionAudience | undefined> {
-    if (!acpSessionId) return undefined
-    // ACP session ids are runtime-local and can collide across agents. Bind the
-    // lookup to the trusted caller agent so another runtime cannot lend this
-    // A2A wake its external audience by accident.
-    return this.externalAudienceForSessionRecord(await this.store.getSessionByAcpIdForAgent(agentId, acpSessionId))
+    if (!sessionKey) return undefined
+    // By the logical key, bound to the trusted caller agent so no other agent's row lends this wake its audience.
+    const rec = await this.store.getSession(sessionKey)
+    return this.externalAudienceForSessionRecord(rec?.agentId === agentId ? rec : undefined)
   }
 
   private externalAudienceForSessionRecord(rec: SessionRecord | undefined): ExternalSessionAudience | undefined {
@@ -14364,23 +14409,12 @@ export class Daemon {
     // stay private.
     const locallyPrivate =
       !isEvaluation && (isA2aChild || msg.isDm || msg.platform === 'webchat' || launchCorrelationId !== undefined)
-    await this.store.setLocalCaptureGate(agentId, acpSessionId, locallyPrivate)
+    await this.store.setLocalCaptureGate(agentId, key, locallyPrivate)
   }
 
   /** The ACP session id behind an MCP tool call, from the caller's trusted
    *  session coords. Undefined when no local row matches — the capture gate
    *  treats that as unknown, i.e. excluded. */
-  private async acpSessionIdForToolCall(ctx: {
-    agentId: string
-    platform: string
-    channel: string
-    thread: string
-    transportScope?: string
-  }): Promise<string | undefined> {
-    const key = sessionKey(ctx.platform, ctx.channel, ctx.thread, ctx.agentId, ctx.transportScope)
-    return (await this.store.getSession(key))?.acpSessionId ?? undefined
-  }
-
   /** Mint-once, persisted: stable across restarts and credential rotations. */
   private async mintedTenantScope(integrationId: string): Promise<string> {
     return (
@@ -15660,10 +15694,7 @@ export class Daemon {
         return { outcome: 'not_applicable' }
       }
       // A host bound to this session runs inside the directory about to go: stop it before the removal.
-      await this.stopSessionHost(rec.agentId, rec.key, {
-        expected: this.hosts.get(sessionHostKey(rec.agentId, rec.key)),
-        row: rec
-      })
+      await this.stopSessionHost(rec.agentId, rec.key, { ...this.sessionHostFence(rec.agentId, rec.key), row: rec })
       // The volume has to be up and bound for the removal, as it was for the preparation — and for
       // the question of WHICH roots exist, which is asked of the filesystem that holds them: on a
       // suspended sandbox this daemon's own disk would answer "none" for a scratch agent whose pod
@@ -15752,7 +15783,7 @@ export class Daemon {
         active += 1
         continue
       }
-      const sessionHost = this.hosts.get(sessionHostKey(rec.agentId, rec.key))
+      const sessionHost = this.sessionHostFence(rec.agentId, rec.key)
       // The purge receipt is written in deleteSession's transaction: the CP holds
       // the only surviving record of this session, and it must be told that the
       // content behind it is gone (drained below, durably, on ACK).
@@ -15761,7 +15792,7 @@ export class Daemon {
         if (rec.acpSessionId)
           this.sdkLease.delete(sdkLeaseKey(this.sessionOwnerKey(rec.agentId, rec.key), rec.acpSessionId))
         await this.modelSessions.release(rec.key)
-        await this.stopSessionHost(rec.agentId, rec.key, { expected: sessionHost, row: rec })
+        await this.stopSessionHost(rec.agentId, rec.key, { ...sessionHost, row: rec })
       }
     }
     this.log.info(
@@ -16011,8 +16042,9 @@ export class Daemon {
     // §7.3 idle→closed: a thread untouched past the TTL stops catching up — UNLESS it
     // still has in-flight background work (the SDK lease), which keeps it open. The
     // lease is member-local, so on a pool only the agent's holder decides its rows.
-    // The hosts the close decision is taken against; a session re-admitted meanwhile has a newer one.
+    // The hosts and start generations the close decision is taken against; a re-admitted session has newer ones.
     const hostsAtDecision = new Map(this.hosts)
+    const generationsAtDecision = new Map(this.hostStartGeneration)
     const closed = await this.store.closeIdleSessions(now, ttl, (agentId, acpSessionId, key) =>
       this.sessionRetentionActive({ key, agentId, acpSessionId })
     )
@@ -16036,14 +16068,20 @@ export class Daemon {
       }
       this.lastFooterReply.delete(row.key) // the session is gone — release its footer record
       // A host bound to the closed session has nothing left to serve — unless a new turn reopened the key since.
-      const expected = hostsAtDecision.get(sessionHostKey(row.agentId, row.key))
-      void this.stopSessionHost(row.agentId, row.key, { expected, row }).catch((error) =>
+      const closedHost = sessionHostKey(row.agentId, row.key)
+      const fence = {
+        expected: hostsAtDecision.get(closedHost),
+        generation: generationsAtDecision.get(closedHost),
+        row
+      }
+      void this.stopSessionHost(row.agentId, row.key, fence).catch((error) =>
         this.log.warn(`idle: stopping the host of closed session ${row.key} failed (${formatErr(error)})`)
       )
       if (!row.acpSessionId) continue
       this.sdkLease.delete(sdkLeaseKey(this.sessionOwnerKey(row.agentId, row.key), row.acpSessionId)) // the session is gone
       await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({
         sessionId: row.acpSessionId,
+        sessionKey: row.key,
         agentId: row.agentId,
         phase: 'end',
         platform: row.platform as SessionKey['platform'],

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -27,7 +27,22 @@ import {
   type StoredUsage
 } from './store/local-store.js'
 import { AcpHost, turnFailureCode, turnFailureReason } from './acp/acp-host.js'
-import { probeSandboxHost, SandboxError, type SandboxMechanism, type SandboxProbe } from './acp/sandbox.js'
+import {
+  probeSandboxHost,
+  removeSandboxSettings,
+  SandboxError,
+  type SandboxMechanism,
+  type SandboxProbe
+} from './acp/sandbox.js'
+import {
+  agentHostKey,
+  hostKeyAgentId,
+  hostKeyDirName,
+  hostKeyLabel,
+  hostKeySessionKey,
+  sessionHostKey,
+  type HostKey
+} from './acp/host-key.js'
 import { effectiveRunInSandbox, prepareRuntimeLaunch } from './launch/prepare.js'
 import {
   SessionManager,
@@ -507,6 +522,7 @@ import {
   FailStopError,
   LifecycleCleanupBlockedError,
   pendingSessionKey,
+  pendingTurnAcpSessionId,
   pendingTurnKey,
   QueueFullError,
   sdkLeaseKey,
@@ -755,13 +771,13 @@ export class Daemon {
   // mirrors only the loaded local files and is rebuilt each reconcile.
   private agents = new Map<string, LoadedAgent>()
   private fileAgents = new Map<string, LoadedAgent>()
-  private hosts = new Map<string, AcpHost>()
-  // agentId → when its current host was (re)built (clock ms). The idle reaper reads
-  // this so a freshly-started host that hasn't recorded session activity yet is NOT
-  // treated as idle-since-epoch (`agentLastActivityTs` is unset until the first turn
-  // stamps it) and reclaimed the instant it comes up, racing its own first dispatch.
-  private hostStartedAt = new Map<string, number>()
-  // agentId → config-file secret state for the current host (shim/config-file-env.ts).
+  // Every live ACP host by HostKey (agent id, or agent id + session key under perSessionHost); every per-host map below is keyed alike.
+  private hosts = new Map<HostKey, AcpHost>()
+  // Per-host launch facts: the agent dir (the roster entry is gone when a removed agent's host stops) and the launch cwd.
+  private hostLaunch = new Map<HostKey, { agentDir: string; cwd: string }>()
+  // host → when it was (re)built (clock ms), so the idle reaper gives a host with no recorded activity yet a full window.
+  private hostStartedAt = new Map<HostKey, number>()
+  // agentId → config-file secret state (shim/config-file-env.ts); the files are shared by the agent's hosts and go with its last one.
   // Recorded at spawn because the reconcile remove path drops the roster entry BEFORE
   // stopping the host — the agent dir can't be re-resolved there. `childEnv` is the
   // merged spawn env snapshot the materialization was planned from: the idle sweep
@@ -1045,15 +1061,15 @@ export class Daemon {
   // agentId → the in-flight (or resolved) host-startup promise. Resolves to the
   // STARTED host (startHostWithRetry may build several across retries — the last,
   // successful one wins). `.has()` doubles as "is this agent starting / started?".
-  private hostStarts = new Map<string, Promise<AcpHost>>()
+  private hostStarts = new Map<HostKey, Promise<AcpHost>>()
   // Monotonic per-agent fence. stop/evict increments it so an older async startup
   // (including its retry loop) can never publish or retry after teardown.
-  private hostStartGeneration = new Map<string, number>()
+  private hostStartGeneration = new Map<HostKey, number>()
   /** Hosts whose initialize handshake completed for the current generation. */
-  private readyHosts = new Set<string>()
+  private readyHosts = new Set<HostKey>()
   // Wakes a retry that is sleeping in backoff when its generation is invalidated.
   // Without this, shutdown could return while an old timer still owns executable work.
-  private hostStartAborts = new Map<string, AbortController>()
+  private hostStartAborts = new Map<HostKey, AbortController>()
   private watcher?: FSWatcher
   private debounceTimer?: NodeJS.Timeout
   private agentsDir = ''
@@ -1208,9 +1224,8 @@ export class Daemon {
     string,
     { agentId: string; sessionId: string; updates: { sessionUpdate: string; [key: string]: any }[] }
   >()
-  // In-progress host teardowns, keyed by agentId. ensureHostAsync awaits an entry
-  // before (re)spawning so a stop racing a new message can't leave two live hosts.
-  private hostStopping = new Map<string, Promise<void>>()
+  // In-progress host teardowns by HostKey; ensureHostAsync awaits an entry before (re)spawning so a stop racing a message leaves one host.
+  private hostStopping = new Map<HostKey, Promise<void>>()
   // Recurring idle sweep (reap idle hosts + TTL-close idle sessions).
   private idleSweepTimer?: TimerHandle
   private storeRetentionTimer?: TimerHandle
@@ -2843,11 +2858,17 @@ export class Daemon {
       store: this.store,
       // Must hand back a *started* host: handle() calls host.newSession() immediately,
       // which needs the ACP connection that start() establishes.
-      hostFor: (agentId) => this.ensureHostAsync(agentId),
+      hostFor: (agentId, request, cwd) =>
+        this.ensureHostAsync(this.hostKeyFor(agentId, request.sessionKey), { session: { workspace: request, cwd } }),
       // A constructed AcpHost is not yet running. Keep the session on the cold
       // path until initialize succeeds so concurrent waiters consume hostFor's
       // single preparation rather than starting a warm preparation afterward.
-      isHostRunning: (agentId) => this.readyHosts.has(agentId),
+      isHostRunning: (agentId, request) => this.readyHosts.has(this.hostKeyFor(agentId, request.sessionKey)),
+      // A session-bound host was launched in the session's directory; the runtime session opens there.
+      boundHostCwd: (agentId, request) => {
+        const key = this.hostKeyFor(agentId, request.sessionKey)
+        return hostKeySessionKey(key) === undefined ? undefined : this.hostLaunch.get(key)?.cwd
+      },
       agentById: (id) => this.agents.get(id),
       // Skill-invocation translation reads what the runtime itself advertised (runtime-commands.ts).
       advertisedCommandsFor: (agentId) => this.runtimeCommands.get(agentId).commands,
@@ -3548,6 +3569,62 @@ export class Daemon {
     )
   }
 
+  // git-workspace-model §11: a confined self-hosted session gets its own host; a pool launch dials the agent's one pod, so it keeps the shared host.
+  private perSessionHost(agent: Agent): boolean {
+    return !this.k8s && this.agentRunsInSandbox(agent)
+  }
+
+  /** The host that serves `sessionKey` of this agent: its own under perSessionHost, else the shared one. */
+  private hostKeyFor(agentId: string, sessionKey?: string): HostKey {
+    const agent = this.agents.get(agentId)
+    return sessionKey !== undefined && agent && this.perSessionHost(agent)
+      ? sessionHostKey(agentId, sessionKey)
+      : agentHostKey(agentId)
+  }
+
+  /** Every host key the agent has live, starting or stopping, plus its shared one (its start fence). */
+  private hostKeysForAgent(agentId: string): HostKey[] {
+    const keys = new Set<HostKey>([agentHostKey(agentId)])
+    for (const map of [this.hosts, this.hostStarts, this.hostStopping]) {
+      for (const key of map.keys()) if (hostKeyAgentId(key) === agentId) keys.add(key)
+    }
+    return [...keys]
+  }
+
+  private hasHostForAgent(agentId: string): boolean {
+    for (const key of this.hosts.keys()) if (hostKeyAgentId(key) === agentId) return true
+    return false
+  }
+
+  /** The host owning an ACP session of the agent; without one, or unknown, the agent's shared host. */
+  private hostForAcpSession(agentId: string, acpSessionId?: string): AcpHost | undefined {
+    if (acpSessionId !== undefined) {
+      for (const [key, host] of this.hosts) {
+        if (hostKeyAgentId(key) !== agentId) continue
+        if (host.hasSession?.(acpSessionId) || host.isLoadingSession?.(acpSessionId)) return host
+      }
+    }
+    return this.hosts.get(agentHostKey(agentId))
+  }
+
+  private hostKeyOfHost(host: AcpHost): HostKey | undefined {
+    for (const [key, candidate] of this.hosts) if (candidate === host) return key
+    return undefined
+  }
+
+  private hostStartedAtForAgent(agentId: string): number {
+    let latest = 0
+    for (const [key, at] of this.hostStartedAt) if (hostKeyAgentId(key) === agentId) latest = Math.max(latest, at)
+    return latest
+  }
+
+  /** Stop the host bound to one session, if any — its directory or its row is about to go. */
+  private async stopSessionHost(agentId: string, sessionKey: string, deadlineMs?: number): Promise<void> {
+    const key = sessionHostKey(agentId, sessionKey)
+    if (!this.hosts.has(key) && !this.hostStarts.has(key) && !this.hostStopping.has(key)) return
+    await this.stopHostByKey(key, deadlineMs)
+  }
+
   /**
    * Whether a bridge spawned for this daemon's tools can reach it at all.
    *
@@ -3810,8 +3887,11 @@ export class Daemon {
     if (!current || this.workspacePreparationAuthority(current) !== this.workspacePreparationAuthority(agent)) {
       throw new Error(`workspace preparation blocked for superseded agent authority (${agent.id})`)
     }
-    if (expectedWarmHost && (this.hosts.get(agent.id) !== expectedWarmHost || !this.readyHosts.has(agent.id))) {
-      throw new Error(`workspace preparation blocked for superseded warm host (${agent.id})`)
+    if (expectedWarmHost) {
+      const key = this.hostKeyOfHost(expectedWarmHost)
+      if (key === undefined || hostKeyAgentId(key) !== agent.id || !this.readyHosts.has(key)) {
+        throw new Error(`workspace preparation blocked for superseded warm host (${agent.id})`)
+      }
     }
   }
 
@@ -3909,17 +3989,22 @@ export class Daemon {
     await this.stopHost(agentId)
   }
 
-  private ensureHost(agentId: string, cfg: ReturnType<typeof loadConfig>): AcpHost {
-    const host = this.hosts.get(agentId)
+  /** Construct + memoize the host for `key`; `cwd` is the session directory for a session-bound host. */
+  private ensureHost(key: HostKey, cfg: ReturnType<typeof loadConfig>, cwd?: string): AcpHost {
+    const host = this.hosts.get(key)
     if (host) return host
+    const agentId = hostKeyAgentId(key)
     const agent = this.agents.get(agentId)!
+    const launchCwd = cwd ?? agent.workspace.path
     const built = this.buildAcpHost(agent, cfg, {
+      hostKey: key,
       runInSandbox: this.agentRunsInSandbox(agent),
-      cwd: agent.workspace.path,
+      cwd: launchCwd,
       warnOnSandboxDowngrade: true
     })
-    this.hosts.set(agentId, built.host)
-    this.hostStartedAt.set(agentId, this.clock.now())
+    this.hosts.set(key, built.host)
+    this.hostLaunch.set(key, { agentDir: agent.dir, cwd: launchCwd })
+    this.hostStartedAt.set(key, this.clock.now())
     this.hostConfigFiles.set(agentId, { agentDir: agent.dir, ...built.configFileState })
     return built.host
   }
@@ -3942,6 +4027,8 @@ export class Daemon {
     agent: LoadedAgent,
     cfg: ReturnType<typeof loadConfig>,
     opts: {
+      /** Names the host being built; its sandbox policy directory and terminal reap are keyed by it. */
+      hostKey: HostKey
       runInSandbox: boolean
       cwd: string
       warnOnSandboxDowngrade?: boolean
@@ -4107,6 +4194,7 @@ export class Daemon {
         provider: memoryKindOf(agent),
         scopeDir: agent.dir,
         cwd: opts.cwd,
+        hostKey: opts.hostKey,
         runInSandbox,
         daemonRoot: this.root,
         agentsRoot: cfg.agentsDir,
@@ -4181,7 +4269,7 @@ export class Daemon {
       onElicit: (sid, params) => this.permissions.onAcpElicit(agentId, sid, params),
       onSdkLifecycle: (sid, message) => this.onSdkLifecycle(agentId, sid, message),
       // Pairs the runtime's terminal exit with the ordinary rebuild — see reapTerminalHost.
-      onTerminal: () => this.reapTerminalHost(agentId, constructed.host),
+      onTerminal: () => this.reapTerminalHost(opts.hostKey, constructed.host),
       env: launch.env,
       ...(sandboxSessionGit
         ? {
@@ -4223,12 +4311,13 @@ export class Daemon {
    * A host that never became ready is deliberately left alone: `startHostWithRetry` reaps its
    * own failed child, and evicting the start generation here would cancel its remaining attempts.
    */
-  private reapTerminalHost(agentId: string, host?: AcpHost): void {
-    if (!host || this.hosts.get(agentId) !== host) return
-    if (!this.readyHosts.has(agentId)) return
-    this.log.warn(`acp: agent "${agentId}" runtime exited — reclaiming its host so the next message re-spawns it`)
-    void this.stopHost(agentId).catch((err) =>
-      this.log.warn(`acp: reclaiming the exited host for agent "${agentId}" failed: ${formatErr(err)}`)
+  private reapTerminalHost(key: HostKey, host?: AcpHost): void {
+    if (!host || this.hosts.get(key) !== host) return
+    if (!this.readyHosts.has(key)) return
+    const label = hostKeyLabel(key)
+    this.log.warn(`acp: agent "${label}" runtime exited — reclaiming its host so the next message re-spawns it`)
+    void this.stopHostByKey(key).catch((err) =>
+      this.log.warn(`acp: reclaiming the exited host for agent "${label}" failed: ${formatErr(err)}`)
     )
   }
 
@@ -4321,11 +4410,11 @@ export class Daemon {
     )
   }
 
-  private selectedOrdinaryTurnHost(agentId: string, host: AcpHost): SelectedTurnHost {
+  private selectedOrdinaryTurnHost(key: HostKey, host: AcpHost): SelectedTurnHost {
     let cleanup: Promise<void> | undefined
     return {
       host,
-      stop: (deadlineMs) => (cleanup ??= this.stopHost(agentId, deadlineMs)),
+      stop: (deadlineMs) => (cleanup ??= this.stopHostByKey(key, deadlineMs)),
       waitForCleanup: () => cleanup ?? Promise.resolve()
     }
   }
@@ -4346,8 +4435,9 @@ export class Daemon {
       sessionSdkQuiescent: (agentId, acpSessionId) => this.sessionSdkQuiescent(agentId, acpSessionId),
       releaseSdkLease: (agentId, acpSessionId) => void this.sdkLease.delete(sdkLeaseKey(agentId, acpSessionId)),
       startRuntime: async (agent, entry) => await this.startModelSessionRuntime(agent, entry),
-      ordinaryHost: (agentId) => this.hosts.get(agentId),
-      cleanupAgentConfigFiles: (agentId) => this.cleanupModelSessionConfigFiles(agentId)
+      ordinaryHost: (agentId, acpSessionId) => this.hostForAcpSession(agentId, acpSessionId),
+      cleanupAgentConfigFiles: (agentId) => this.cleanupModelSessionConfigFiles(agentId),
+      hostStopped: (agentId, sessionKey) => this.releaseHostLaunch(sessionHostKey(agentId, sessionKey))
     }
   }
 
@@ -4356,7 +4446,9 @@ export class Daemon {
     let lastError: unknown
     for (let attempt = 1; attempt <= attempts; attempt++) {
       const cwd = await this.prepareAgentWorkspace(agent, undefined, undefined)
+      const hostKey = sessionHostKey(agent.id, entry.sessionKey)
       const { host, configFileState } = this.buildAcpHost(agent, this.cfg, {
+        hostKey,
         runInSandbox: this.agentRunsInSandbox(agent),
         cwd,
         warnOnSandboxDowngrade: true,
@@ -4371,16 +4463,25 @@ export class Daemon {
       if (configFileState.childEnv) {
         this.hostConfigFiles.set(agent.id, { agentDir: agent.dir, ...configFileState })
       }
+      this.hostLaunch.set(hostKey, { agentDir: agent.dir, cwd })
       try {
         await host.start()
         return host
       } catch (error) {
         lastError = error
         await host.stop().catch(() => {})
+        this.releaseHostLaunch(hostKey)
         if (attempt < attempts) await this.sleep(this.cfg.limits.agentStartBackoffMs)
       }
     }
     throw lastError
+  }
+
+  /** Forget a host's launch facts and drop its sandbox policy directory, once its process is gone. */
+  private releaseHostLaunch(key: HostKey): void {
+    const launch = this.hostLaunch.get(key)
+    this.hostLaunch.delete(key)
+    if (launch) removeSandboxSettings(launch.agentDir, hostKeyDirName(key))
   }
 
   /** Drop an agent's config-file secrets once the pool's last host for it is gone. */
@@ -4567,7 +4668,7 @@ export class Daemon {
     const modelSessionKey = this.modelSessions.enabled ? internalSessionKey.memory(agentId) : undefined
     const host = modelSessionKey
       ? (await this.modelSessions.ensure(agent, modelSessionKey)).host
-      : await this.ensureHostAsync(agentId)
+      : await this.ensureHostAsync(agentHostKey(agentId))
     try {
       if (this.memoryExtractionUnavailable.has(host)) {
         throw new Error('memory extraction is unavailable for this runtime host')
@@ -4732,7 +4833,7 @@ export class Daemon {
     const modelSessionKey = this.modelSessions.enabled ? internalSessionKey.commit(agentId, randomUUID()) : undefined
     const host = modelSessionKey
       ? (await this.modelSessions.ensure(agent, modelSessionKey)).host
-      : await this.ensureHostAsync(agentId)
+      : await this.ensureHostAsync(agentHostKey(agentId))
     try {
       // OBSERVED, not gated (memory-dreaming.md §2): the policy rides `_meta.systemPrompt` where the
       // runtime has that channel and is prepended inline where it does not. The output contract lives
@@ -4913,9 +5014,11 @@ export class Daemon {
       }
     }
     let host: AcpHost
+    const dreamHostKey = sessionHostKey(agent.id, internalSessionKey.dream(context.dreamId))
     try {
-      host = await this.buildDreamHost(agent, context.inputDir, issued)
+      host = await this.buildDreamHost(agent, context.inputDir, dreamHostKey, issued)
     } catch (error) {
+      removeSandboxSettings(agent.dir, hostKeyDirName(dreamHostKey))
       if (issued) await this.modelSessions.revokeKeyQuietly(issued.grant.keyId)
       throw error
     }
@@ -4927,6 +5030,7 @@ export class Daemon {
       // attacker-influenced context never lingers (dreams are rare). Stopping the
       // child also kills a runtime that ignored `session/cancel`.
       await host.stop().catch(() => {})
+      removeSandboxSettings(agent.dir, hostKeyDirName(dreamHostKey))
       if (issued) {
         await this.modelSessions.revokeKey(issued.grant.keyId)
       }
@@ -4959,9 +5063,11 @@ export class Daemon {
   private async buildDreamHost(
     agent: LoadedAgent,
     cwd: string,
+    hostKey: HostKey,
     issued?: { target: ModelProviderTarget; grant: KeyGrant }
   ): Promise<AcpHost> {
     const { host } = this.buildAcpHost(agent, this.cfg, {
+      hostKey,
       runInSandbox: this.agentRunsInSandbox(agent),
       cwd,
       // A dream needs only its materialized inputs, never the agent's tool
@@ -6325,7 +6431,7 @@ export class Daemon {
     for (const session of await this.store.listSessions(agent.id)) {
       const host = session.acpSessionId
         ? await this.modelSessions.hostForStoredSession(agent.id, session.acpSessionId)
-        : this.hosts.get(agent.id)
+        : this.hosts.get(agentHostKey(agent.id))
       if (!session.acpSessionId || host?.hasSession?.(session.acpSessionId) !== true) continue
       const sessionId = session.acpSessionId
       void this.applyConfiguredRuntimeSettings(agent, host, sessionId)
@@ -7727,7 +7833,8 @@ export class Daemon {
         this.prepareAgentWorkspace(agent, expectedWarmHost, request),
       sessionHasReferenceDirectories: async (agent, request) =>
         (await this.workspaces.sessionAdditionalRoots(agent, request)).length > 0,
-      warmHostFor: (agentId) => (this.readyHosts.has(agentId) ? this.hosts.get(agentId) : undefined),
+      warmHostFor: (agentId) =>
+        this.readyHosts.has(agentHostKey(agentId)) ? this.hosts.get(agentHostKey(agentId)) : undefined,
       anchorTrigger: (agentId, msg, target, anchorText, label, safetyReviewLane) =>
         this.anchorTrigger(agentId, msg, target, anchorText, label, safetyReviewLane),
       dispatch: (agentId, msg, integrationId, webchat, callMeta, opts, githubReply, hookContext) =>
@@ -10329,7 +10436,7 @@ export class Daemon {
       evaluationTurnId,
       // Read here, not in the planner: the sticky override is live daemon state.
       stickyOutputMode: await this.store.getOutputModeOverride(key),
-      hostAlreadyRunning: this.hostStarts.has(agentId) || this.modelSessions.hasStartedHost(key),
+      hostAlreadyRunning: this.hostStarts.has(this.hostKeyFor(agentId, key)) || this.modelSessions.hasStartedHost(key),
       // Synchronous and exact: an attached shim session IS the pod being up, so no cluster read.
       clusterPodBootstrap: this.k8sPlane !== undefined && !this.k8sPlane.runsInSandbox(agentId),
       protectedAddresses: this.compoundMentionAddresses(agentId, msg),
@@ -10625,7 +10732,8 @@ export class Daemon {
             // selectedHost is assigned only after handle() for ordinary warm
             // turns. Resolve the already-running agent host directly here so the
             // rotated descriptor forces session/load before this prompt.
-            const warmHost = entry.selectedHost?.host ?? this.hosts.get(agentId)
+            const warmHost =
+              entry.selectedHost?.host ?? this.hostForAcpSession(agentId, existing?.acpSessionId ?? undefined)
             if (existing?.acpSessionId) warmHost?.forgetSession(existing.acpSessionId)
           }
         } catch (error) {
@@ -10821,8 +10929,9 @@ export class Daemon {
     let resolveDone!: () => void
     const done = new Promise<void>((r) => (resolveDone = r))
     if (!entry.selectedHost) {
-      const ordinaryHost = this.hosts.get(agentId)
-      if (ordinaryHost) entry.selectedHost = this.selectedOrdinaryTurnHost(agentId, ordinaryHost)
+      const hostKey = this.hostKeyFor(agentId, run.key)
+      const ordinaryHost = this.hosts.get(hostKey)
+      if (ordinaryHost) entry.selectedHost = this.selectedOrdinaryTurnHost(hostKey, ordinaryHost)
     }
     const p: Pending = {
       plan,
@@ -11061,8 +11170,14 @@ export class Daemon {
     const { entry, key, agent } = run
     const { agentId, webchat } = entry
     if (!p.selectedHost) {
-      const ordinaryHost = await this.ensureHostAsync(agentId)
-      p.selectedHost = this.selectedOrdinaryTurnHost(agentId, ordinaryHost)
+      const hostKey = this.hostKeyFor(agentId, key)
+      // Normally a join of the host handle() started; a session-bound host evicted since re-launches in its directory.
+      const ordinaryHost = await this.ensureHostAsync(hostKey, {
+        session: {
+          workspace: { sessionKey: key, isolation: (await this.store.getSession(key))?.workspaceIsolation ?? 'shared' }
+        }
+      })
+      p.selectedHost = this.selectedOrdinaryTurnHost(hostKey, ordinaryHost)
       entry.selectedHost = p.selectedHost
     }
     const host = p.selectedHost.host
@@ -12275,7 +12390,7 @@ export class Daemon {
     // dispatch finally clears the timer + writes the terminal idle state when the agent
     // yields; if it never does, the backstop force-stops the host.
     await this.store.setSessionState(key, 'cancelling', this.clock.now())
-    void (live.selectedHost?.host ?? this.hosts.get(agentId))
+    void (live.selectedHost?.host ?? this.hostForAcpSession(agentId, liveSessionId))
       ?.cancel(liveSessionId)
       .catch((err) => this.log.error(`command ${reason}: cancel failed: ${(err as Error).message}`))
     this.armCancelBackstop(agentId, liveSessionId, key, reason)
@@ -12752,7 +12867,7 @@ export class Daemon {
     // `?.()` guards a host stub without the method (test fakes); real AcpHosts always have it.
     const host = acpSessionId
       ? await this.modelSessions.hostForStoredSession(agentId, acpSessionId)
-      : this.hosts.get(agentId)
+      : this.hosts.get(agentHostKey(agentId))
     const model = host?.modelOptions?.(acpSessionId)
     // A persisted session can outlive the adapter process that created it. In that
     // cold state the exact session selector is unavailable, but the runtime probe has
@@ -13407,7 +13522,7 @@ export class Daemon {
     // yet. And the session must not be one this daemon opened for a pass of its OWN: those run on
     // the agent's warm host over a temp dir, whose list is missing its project skills (#1310 review).
     if (isAvailableCommandsUpdate(update)) {
-      const host = this.hosts.get(agentId)
+      const host = this.hostForAcpSession(agentId, sessionId)
       const owned = host?.hasSession(sessionId) || host?.isLoadingSession(sessionId)
       if (owned && !this.internalPassSessions.has(extractionKey)) {
         // Recorded under the session's OUTWARD id (§1.1): the row survives the session, so a name
@@ -13631,25 +13746,39 @@ export class Daemon {
     })
   }
 
-  private invalidateHostStart(agentId: string): void {
-    this.readyHosts.delete(agentId)
-    this.hostStartGeneration.set(agentId, (this.hostStartGeneration.get(agentId) ?? 0) + 1)
-    this.hostStarts.delete(agentId)
-    this.hostStartAborts.get(agentId)?.abort(new Error(`host start superseded for ${agentId}`))
-    this.hostStartAborts.delete(agentId)
+  private invalidateHostStart(key: HostKey): void {
+    this.readyHosts.delete(key)
+    this.hostStartGeneration.set(key, (this.hostStartGeneration.get(key) ?? 0) + 1)
+    this.hostStarts.delete(key)
+    this.hostStartAborts.get(key)?.abort(new Error(`host start superseded for ${hostKeyLabel(key)}`))
+    this.hostStartAborts.delete(key)
   }
 
-  private async ensureHostAsync(agentId: string, opts: { allowAgentDrain?: boolean } = {}): Promise<AcpHost> {
+  /** Whether another host of the agent is live or starting — the shared config files are still in use then. */
+  private agentHasOtherHosts(agentId: string, except: HostKey): boolean {
+    for (const map of [this.hosts, this.hostStarts]) {
+      for (const key of map.keys()) if (key !== except && hostKeyAgentId(key) === agentId) return true
+    }
+    return this.modelSessions.hasStartedHostForAgent(agentId)
+  }
+
+  // Start (or join the start of) the host `key` names; a session-bound key carries its session's workspace request or prepared cwd.
+  private async ensureHostAsync(
+    key: HostKey,
+    opts: { allowAgentDrain?: boolean; session?: { workspace: PrepareSessionWorkspaceRequest; cwd?: string } } = {}
+  ): Promise<AcpHost> {
+    const agentId = hostKeyAgentId(key)
+    const label = hostKeyLabel(key)
     const assertStartAllowed = (): void => {
-      if (this.draining) throw new Error(`host start blocked while daemon is draining (${agentId})`)
+      if (this.draining) throw new Error(`host start blocked while daemon is draining (${label})`)
       // Already-admitted work in another logical session may keep using the warm
       // host while a conversation-scoped interrupt drains. It may not allocate a
       // replacement after that host/start generation has been evicted.
-      if (this.safetyDrainingAgents.has(agentId) && !this.hostStarts.has(agentId)) {
-        throw new Error(`host start blocked while interrupted turns are stopping (${agentId})`)
+      if (this.safetyDrainingAgents.has(agentId) && !this.hostStarts.has(key)) {
+        throw new Error(`host start blocked while interrupted turns are stopping (${label})`)
       }
       if (!opts.allowAgentDrain && this.drainingAgents.has(agentId)) {
-        throw new Error(`host start blocked while agent is draining (${agentId})`)
+        throw new Error(`host start blocked while agent is draining (${label})`)
       }
     }
     // A workspace mutation is a transient exclusion, not a refusal: join the fence and re-read the
@@ -13667,23 +13796,23 @@ export class Daemon {
     // the lifecycle resource boundary so an already-admitted cold turn cannot spawn a
     // replacement child after reconcile/stop has begun.
     await admitStart()
-    // If this agent's previous host is mid-teardown, wait it out before (re)spawning
+    // If this host's previous incarnation is mid-teardown, wait it out before (re)spawning
     // — otherwise we'd boot a second child while the first is still SIGTERM-ing.
-    const stopping = this.hostStopping.get(agentId)
+    const stopping = this.hostStopping.get(key)
     if (stopping) {
       await stopping
       // A reconcile gate may have been installed while this call waited. Re-check at
       // the exact promise boundary before allocating a new start generation.
       await admitStart()
     }
-    let p = this.hostStarts.get(agentId)
+    let p = this.hostStarts.get(key)
     if (!p) {
-      const generation = (this.hostStartGeneration.get(agentId) ?? 0) + 1
-      this.hostStartGeneration.set(agentId, generation)
+      const generation = (this.hostStartGeneration.get(key) ?? 0) + 1
+      this.hostStartGeneration.set(key, generation)
       const startAbort = new AbortController()
-      this.hostStartAborts.set(agentId, startAbort)
-      p = this.startHostWithRetry(agentId, generation, startAbort.signal, opts.allowAgentDrain === true)
-      this.hostStarts.set(agentId, p)
+      this.hostStartAborts.set(key, startAbort)
+      p = this.startHostWithRetry(key, generation, startAbort.signal, opts.allowAgentDrain === true, opts.session)
+      this.hostStarts.set(key, p)
       // A total failure (all attempts exhausted) must NOT poison the cache: without
       // this the rejected promise stays memoized and every later message re-awaits the
       // same rejection, so the agent could never recover. startHostWithRetry already
@@ -13691,11 +13820,11 @@ export class Daemon {
       // identity in case a concurrent stopHost already replaced it).
       void p.then(
         () => {
-          if (this.hostStartAborts.get(agentId) === startAbort) this.hostStartAborts.delete(agentId)
+          if (this.hostStartAborts.get(key) === startAbort) this.hostStartAborts.delete(key)
         },
         () => {
-          if (this.hostStarts.get(agentId) === p) this.hostStarts.delete(agentId)
-          if (this.hostStartAborts.get(agentId) === startAbort) this.hostStartAborts.delete(agentId)
+          if (this.hostStarts.get(key) === p) this.hostStarts.delete(key)
+          if (this.hostStartAborts.get(key) === startAbort) this.hostStartAborts.delete(key)
         }
       )
     }
@@ -13708,57 +13837,73 @@ export class Daemon {
    *  next try. On success the started host is left memoized in `this.hosts`; when every
    *  attempt fails the last error is thrown (dispatch surfaces it to the session). */
   private async startHostWithRetry(
-    agentId: string,
+    key: HostKey,
     generation: number,
     signal: AbortSignal,
-    allowAgentDrain = false
+    allowAgentDrain = false,
+    session?: { workspace: PrepareSessionWorkspaceRequest; cwd?: string }
   ): Promise<AcpHost> {
     const attempts = Math.max(1, this.cfg.limits.agentStartAttempts)
-    if (this.hostStartGeneration.get(agentId) !== generation) throw new Error(`host start superseded for ${agentId}`)
+    const agentId = hostKeyAgentId(key)
+    const label = hostKeyLabel(key)
+    if (this.hostStartGeneration.get(key) !== generation) throw new Error(`host start superseded for ${label}`)
     const agent = this.agents.get(agentId)
     if (!agent) throw new Error(`unknown agent ${agentId}`)
+    // A session-bound host launches in its session's directory, so the cold gate below prepares it before the spawn.
+    const bound = hostKeySessionKey(key) === undefined ? undefined : session
+    if (hostKeySessionKey(key) !== undefined && !bound) {
+      throw new Error(`session host ${label} needs its session's workspace request`)
+    }
     let lastErr: unknown
     // A repaired runtime install earns one extra attempt, so a fault fixed on the last try still starts.
     let extraAttempts = 0
     let repairTried = false
     for (let i = 1; i <= attempts + extraAttempts; i++) {
-      if (this.hostStartGeneration.get(agentId) !== generation) {
-        throw new Error(`host start superseded for ${agentId}`)
+      if (this.hostStartGeneration.get(key) !== generation) {
+        throw new Error(`host start superseded for ${label}`)
       }
       // This is the cold-host gate for every daemon caller and every fresh spawn
       // attempt. A failed ACP child had workspace write authority; re-verify the
       // immutable skill receipts after it is fully reaped and before constructing
       // its replacement, rather than trusting the first attempt's gate.
-      await this.prepareAgentWorkspace(agent, undefined, undefined, allowAgentDrain)
+      const prepared = await this.prepareAgentWorkspace(
+        agent,
+        undefined,
+        bound && bound.cwd === undefined ? bound.workspace : undefined,
+        allowAgentDrain
+      )
       await this.ensureRuntimeInstalled(agent.runtime)
-      if (this.hostStartGeneration.get(agentId) !== generation) {
-        throw new Error(`host start superseded for ${agentId}`)
+      if (this.hostStartGeneration.get(key) !== generation) {
+        throw new Error(`host start superseded for ${label}`)
       }
-      const host = this.ensureHost(agentId, this.cfg) // constructs + memoizes into this.hosts
+      // Constructs + memoizes into this.hosts, in the session directory for a session-bound host.
+      const host = this.ensureHost(key, this.cfg, bound ? (bound.cwd ?? prepared) : undefined)
       try {
         await host.start()
-        if (this.hostStartGeneration.get(agentId) !== generation) {
-          throw new Error(`host start superseded for ${agentId}`)
+        if (this.hostStartGeneration.get(key) !== generation) {
+          throw new Error(`host start superseded for ${label}`)
         }
-        this.readyHosts.add(agentId)
+        this.readyHosts.add(key)
         this.lastStartFailure.delete(agentId)
         return host
       } catch (err) {
         lastErr = err
-        this.readyHosts.delete(agentId)
+        this.readyHosts.delete(key)
         // Reap the dead child and drop it so the next attempt spawns a fresh one.
-        if (this.hosts.get(agentId) === host) this.hosts.delete(agentId)
+        if (this.hosts.get(key) === host) this.hosts.delete(key)
         await host.stop().catch(() => {})
-        if (this.hostStartGeneration.get(agentId) !== generation) throw err
-        // The failed attempt's ensureHost already materialized the config-file
-        // secrets — remove them so a permanently-failing start doesn't leave them
-        // resting on disk. Generation-fenced above, so this can't touch a
-        // superseding host's files; the next attempt re-materializes its own.
-        const failedSpawnDir = this.hostConfigFiles.get(agentId)?.agentDir
-        this.hostConfigFiles.delete(agentId)
-        if (failedSpawnDir) {
-          const cleanupErr = cleanupConfigFiles(failedSpawnDir)
-          if (cleanupErr) this.log.warn(`config-files: cleanup for agent "${agentId}" failed — ${cleanupErr}`)
+        const failedLaunch = this.hostLaunch.get(key)
+        this.hostLaunch.delete(key)
+        if (failedLaunch) removeSandboxSettings(failedLaunch.agentDir, hostKeyDirName(key))
+        if (this.hostStartGeneration.get(key) !== generation) throw err
+        // Remove the failed attempt's materialized config-file secrets unless another host of the agent still reads them.
+        if (!this.agentHasOtherHosts(agentId, key)) {
+          const failedSpawnDir = this.hostConfigFiles.get(agentId)?.agentDir
+          this.hostConfigFiles.delete(agentId)
+          if (failedSpawnDir) {
+            const cleanupErr = cleanupConfigFiles(failedSpawnDir)
+            if (cleanupErr) this.log.warn(`config-files: cleanup for agent "${agentId}" failed — ${cleanupErr}`)
+          }
         }
         // Retrying an incomplete package tree just reproduces the same crash, so repair it once and
         // let the loop try again rather than burning every attempt and staging the agent out. An
@@ -13772,11 +13917,11 @@ export class Daemon {
         if (i < budget) {
           const backoff = this.cfg.limits.agentStartBackoffMs
           this.log.warn(
-            `acp: agent "${agentId}" start attempt ${i}/${budget} failed (${(err as Error).message}) — retrying in ${backoff}ms`
+            `acp: agent "${label}" start attempt ${i}/${budget} failed (${(err as Error).message}) — retrying in ${backoff}ms`
           )
           await this.sleep(backoff, signal)
         } else {
-          this.log.error(`acp: agent "${agentId}" failed to start after ${budget} attempt(s): ${formatErr(err)}`)
+          this.log.error(`acp: agent "${label}" failed to start after ${budget} attempt(s): ${formatErr(err)}`)
           this.lastStartFailure.set(agentId, startFailureDetail(err))
         }
       }
@@ -14658,53 +14803,71 @@ export class Daemon {
 
   // ── lifecycle: host reaping, drain, fleet exit (§2.5/§5.3/§7.2) ──────────────
 
-  /** Stop and evict an ACP adapter child, returning the agent to `provisioned`
-   *  (config kept; the next message lazily re-spawns it). Idempotent. The teardown
-   *  is registered in `hostStopping` so a concurrent ensureHostAsync waits for
-   *  both the adapter and any superseded cold workspace preparation instead of
-   *  spawning against a still-mutating old generation. */
+  /** Stop and evict every ACP adapter child of the agent — its shared host and any session-bound
+   *  ones — returning it to `provisioned` (config kept; the next message lazily re-spawns). Idempotent. */
   private async stopHost(agentId: string, deadlineMs?: number): Promise<void> {
+    const results = await Promise.allSettled(
+      this.hostKeysForAgent(agentId).map((key) => this.stopHostByKey(key, deadlineMs))
+    )
+    const failed = results.find((result) => result.status === 'rejected')
+    if (failed) throw failed.reason
+  }
+
+  /** Stop and evict one host. The teardown is registered in `hostStopping` so a concurrent
+   *  ensureHostAsync waits for both the adapter and any superseded cold workspace preparation
+   *  instead of spawning against a still-mutating old generation. */
+  private async stopHostByKey(key: HostKey, deadlineMs?: number): Promise<void> {
+    const agentId = hostKeyAgentId(key)
+    const sessionKey = hostKeySessionKey(key)
     const supersededStarts: Promise<AcpHost>[] = []
     const captureSupersededStart = (): void => {
-      const start = this.hostStarts.get(agentId)
+      const start = this.hostStarts.get(key)
       if (start && !supersededStarts.includes(start)) supersededStarts.push(start)
     }
     captureSupersededStart()
-    this.invalidateHostStart(agentId)
-    const alreadyStopping = this.hostStopping.get(agentId)
+    this.invalidateHostStart(key)
+    const alreadyStopping = this.hostStopping.get(key)
     if (alreadyStopping) {
       // A second teardown must not report success while the first child is still
       // alive. Once it settles, fence again before taking a fresh host snapshot:
       // an ensureHostAsync waiter may have resumed at the same promise boundary.
       await alreadyStopping
       captureSupersededStart()
-      this.invalidateHostStart(agentId)
+      this.invalidateHostStart(key)
     }
-    const host = this.hosts.get(agentId)
-    this.hosts.delete(agentId)
-    this.hostStartedAt.delete(agentId)
-    const agentDir = this.hostConfigFiles.get(agentId)?.agentDir
-    this.hostConfigFiles.delete(agentId)
-    // The adapter (and its in-memory ACP sessions) is going away — drop this agent's
-    // background-task leases so they can't leak or wrongly defer a future host.
-    for (const [sid, lease] of this.sdkLease) if (lease.agentId === agentId) this.sdkLease.delete(sid)
+    const host = this.hosts.get(key)
+    this.hosts.delete(key)
+    this.hostStartedAt.delete(key)
+    const launch = this.hostLaunch.get(key)
+    this.hostLaunch.delete(key)
+    // The shared config files go with the agent's LAST host; another live host still reads them.
+    const agentDir = this.agentHasOtherHosts(agentId, key) ? undefined : this.hostConfigFiles.get(agentId)?.agentDir
+    if (agentDir) this.hostConfigFiles.delete(agentId)
+    // Session-scoped state goes with the sessions this host served: all of the agent's for its shared host, else the child's own.
+    const served = (acpSessionId: string): boolean =>
+      sessionKey === undefined ||
+      host?.hasSession?.(acpSessionId) === true ||
+      host?.isLoadingSession?.(acpSessionId) === true
+    // The adapter's ACP sessions are going away — drop their background-task leases so they cannot defer a future host.
+    for (const [sid, lease] of this.sdkLease) {
+      if (lease.agentId === agentId && served(pendingTurnAcpSessionId(sid))) this.sdkLease.delete(sid)
+    }
     const clearDeliveryBindings = () => {
-      for (const [key, binding] of this.sessionDeliveryBindings) {
-        if (binding.agentId === agentId) this.sessionDeliveryBindings.delete(key)
+      for (const [bindingKey, binding] of this.sessionDeliveryBindings) {
+        if (binding.agentId !== agentId) continue
+        if (sessionKey === undefined || bindingKey === sessionKey) this.sessionDeliveryBindings.delete(bindingKey)
       }
     }
     const clearMemoryExtractionQuarantines = () => {
-      for (const [key, ownerAgentId] of this.memoryExtractionQuarantines) {
-        if (ownerAgentId === agentId) this.memoryExtractionQuarantines.delete(key)
+      for (const [quarantineKey, ownerAgentId] of this.memoryExtractionQuarantines) {
+        if (ownerAgentId === agentId && served(pendingTurnAcpSessionId(quarantineKey))) {
+          this.memoryExtractionQuarantines.delete(quarantineKey)
+        }
       }
     }
-    // Once the child (and its process group) is gone, nothing can read the
-    // materialized config-file secrets (KUBECONFIG & co.) — remove them so the
-    // secret material stops resting on disk between sessions. Safe against the
-    // re-spawn race: ensureHostAsync waits out `hostStopping`, and this teardown's
-    // continuation runs before any such waiter re-materializes.
+    // With the child gone the config-file secrets are unread; a host of the agent started meanwhile re-registered them and keeps them.
     const removeConfigFiles = () => {
-      if (!agentDir) return
+      if (!agentDir || this.agentHasOtherHosts(agentId, key)) return
       const err = cleanupConfigFiles(agentDir)
       if (err) this.log.warn(`config-files: cleanup for agent "${agentId}" failed — ${err}`)
     }
@@ -14718,9 +14881,9 @@ export class Daemon {
         if (hostResult?.status === 'rejected') throw hostResult.reason
       })
       .finally(() => {
-        if (this.hostStopping.get(agentId) === stop) this.hostStopping.delete(agentId)
+        if (this.hostStopping.get(key) === stop) this.hostStopping.delete(key)
       })
-    this.hostStopping.set(agentId, stop)
+    this.hostStopping.set(key, stop)
     try {
       await stop
     } finally {
@@ -14729,6 +14892,8 @@ export class Daemon {
       clearDeliveryBindings()
       clearMemoryExtractionQuarantines()
       removeConfigFiles()
+      // The policy the provider read for this child is daemon-owned per host; it goes with the child.
+      if (launch) removeSandboxSettings(launch.agentDir, hostKeyDirName(key))
     }
   }
 
@@ -15339,12 +15504,16 @@ export class Daemon {
    *  self-initiated followup turn that carries no `this.pending` entry). Gates idle host
    *  reclaim. */
   private agentHasLiveSdkWork(agentId: string): boolean {
-    for (const l of this.sdkLease.values())
-      if (
-        l.agentId === agentId &&
-        (l.tasks.size > 0 || l.armedWakes > 0 || l.deliveringWakes > 0 || l.sdkState === 'running')
-      )
-        return true
+    return this.hostHasLiveSdkWork(agentId)
+  }
+
+  /** Live background work on the agent, narrowed to the sessions `host` holds when one is given. */
+  private hostHasLiveSdkWork(agentId: string, host?: AcpHost): boolean {
+    for (const [leaseKey, l] of this.sdkLease) {
+      if (l.agentId !== agentId) continue
+      if (host && !host.hasSession?.(pendingTurnAcpSessionId(leaseKey))) continue
+      if (l.tasks.size > 0 || l.armedWakes > 0 || l.deliveringWakes > 0 || l.sdkState === 'running') return true
+    }
     return false
   }
 
@@ -15420,6 +15589,8 @@ export class Daemon {
       ) {
         return { outcome: 'not_applicable' }
       }
+      // A host bound to this session runs inside the directory about to go: stop it before the removal.
+      await this.stopSessionHost(rec.agentId, rec.key)
       // The volume has to be up and bound for the removal, as it was for the preparation — and for
       // the question of WHICH roots exist, which is asked of the filesystem that holds them: on a
       // suspended sandbox this daemon's own disk would answer "none" for a scratch agent whose pod
@@ -15517,6 +15688,7 @@ export class Daemon {
         removed += 1
         if (rec.acpSessionId) this.sdkLease.delete(sdkLeaseKey(rec.agentId, rec.acpSessionId))
         await this.modelSessions.release(rec.key)
+        await this.stopSessionHost(rec.agentId, rec.key)
       }
     }
     this.log.info(
@@ -15788,6 +15960,10 @@ export class Daemon {
         }
       }
       this.lastFooterReply.delete(row.key) // the session is gone — release its footer record
+      // A host bound to the closed session has nothing left to serve.
+      void this.stopSessionHost(row.agentId, row.key).catch((error) =>
+        this.log.warn(`idle: stopping the host of closed session ${row.key} failed (${formatErr(error)})`)
+      )
       if (!row.acpSessionId) continue
       this.sdkLease.delete(sdkLeaseKey(row.agentId, row.acpSessionId)) // the session is gone — drop its lease
       await this.sessionMetadataOutbox.emitSessionMetadataSnapshot({
@@ -15810,7 +15986,7 @@ export class Daemon {
       if (!entry.materialized || !entry.childEnv) continue
       if (this.drainingAgents.has(agentId)) continue // stopHost will remove them
       if ([...this.pending.values()].some((p) => p.plan.agentId === agentId)) continue
-      const last = Math.max((await this.store.agentLastActivityTs(agentId)) ?? 0, this.hostStartedAt.get(agentId) ?? 0)
+      const last = Math.max((await this.store.agentLastActivityTs(agentId)) ?? 0, this.hostStartedAtForAgent(agentId))
       if (now - last <= configFilesIdle) continue
       // The lease also covers the settle→followup gap of a background task: a
       // task-drain turn flips sdkState to running before any tool can fire.
@@ -15831,13 +16007,19 @@ export class Daemon {
     // §7.2 ready→provisioned: reclaim a host whose agent has no recent session
     // activity AND no in-flight turn (a long turn stamps no activity, so the
     // in-flight guard is load-bearing — see recordUnrouted).
-    for (const [agentId] of [...this.hosts]) {
+    for (const [key, host] of [...this.hosts]) {
+      const agentId = hostKeyAgentId(key)
+      const sessionKey = hostKeySessionKey(key)
+      const label = hostKeyLabel(key)
       if (this.drainingAgents.has(agentId)) continue
       // `pending` begins only after session/new|load. A warm dispatch can still
       // be assembling memory/context or preparing its workspace before that;
       // reclaiming its host here would detach a live initialization generation.
       if ((this.activeDispatchesByAgent.get(agentId)?.size ?? 0) > 0) continue
-      if ([...this.pending.values()].some((p) => p.plan.agentId === agentId)) continue
+      // A session-bound host is quiet when ITS session is; the shared host, when every session of the agent is.
+      const inFlight = (p: Pending): boolean =>
+        p.plan.agentId === agentId && (sessionKey === undefined || p.plan.sessionKey === sessionKey)
+      if ([...this.pending.values()].some(inFlight)) continue
       // A just-started host that hasn't served a turn yet has no recorded activity
       // (`agentLastActivityTs` unset ⇒ 0 ⇒ idle≈now), so without this it would be
       // reclaimed on the very next sweep — including WHILE it is still mid-startup
@@ -15845,27 +16027,31 @@ export class Daemon {
       // down underneath its own first dispatch (ACP "connection closed" → "already
       // started" → "Session not found"). Fall back to when the host came up so it
       // gets a full idle window from start, not an instant reclaim.
-      const last = Math.max((await this.store.agentLastActivityTs(agentId)) ?? 0, this.hostStartedAt.get(agentId) ?? 0)
+      const activity =
+        sessionKey === undefined
+          ? await this.store.agentLastActivityTs(agentId)
+          : await this.store.sessionLastActivityTs(sessionKey)
+      const last = Math.max(activity ?? 0, this.hostStartedAt.get(key) ?? 0)
       if (now - last <= ttl) continue
       // Background-task lease: don't reap a host that still has live background work
       // (a running SDK cycle / followup turn or unsettled background tasks) — reaping
       // SIGTERMs the adapter, and `claude` reaps its own background jobs on graceful
       // exit. Bounded by the absolute lifetime ceiling so a wedged / never-ending task
       // can't pin an idle host forever.
-      if (this.agentHasLiveSdkWork(agentId)) {
-        const age = now - (this.hostStartedAt.get(agentId) ?? now)
+      if (this.hostHasLiveSdkWork(agentId, sessionKey === undefined ? undefined : host)) {
+        const age = now - (this.hostStartedAt.get(key) ?? now)
         if (age <= maxLifetime) {
-          this.log.info(`idle: host "${agentId}" has in-flight background work — deferring reclaim`)
+          this.log.info(`idle: host "${label}" has in-flight background work — deferring reclaim`)
           continue
         }
         this.log.warn(
-          `idle: host "${agentId}" over max lifetime (${Math.round(age / 1000)}s) with background work still ` +
+          `idle: host "${label}" over max lifetime (${Math.round(age / 1000)}s) with background work still ` +
             `in flight — force-reclaiming (a wedged/long-lived background task may be terminated)`
         )
       }
-      this.log.info(`idle: reclaiming host "${agentId}" (idle ${Math.round((now - last) / 1000)}s) → provisioned`)
-      void this.stopHost(agentId).catch((err) =>
-        this.log.error(`idle: stop host "${agentId}" failed: ${formatErr(err)}`)
+      this.log.info(`idle: reclaiming host "${label}" (idle ${Math.round((now - last) / 1000)}s) → provisioned`)
+      void this.stopHostByKey(key).catch((err) =>
+        this.log.error(`idle: stop host "${label}" failed: ${formatErr(err)}`)
       )
     }
     await this.sweepIdleSandboxes(now, ttl)
@@ -15889,7 +16075,7 @@ export class Daemon {
       if (this.dutyCoordinator.dutyEnforced() && !this.duties.holdsAgent(agentId)) continue
       // A live host owns the decision above; suspending under it would pull the pod out from
       // beneath a runtime that is merely between turns.
-      if (this.hosts.has(agentId) || this.modelSessions.hasStartedHostForAgent(agentId)) continue
+      if (this.hasHostForAgent(agentId) || this.modelSessions.hasStartedHostForAgent(agentId)) continue
       if ((this.activeDispatchesByAgent.get(agentId)?.size ?? 0) > 0) continue
       if ([...this.pending.values()].some((p) => p.plan.agentId === agentId)) continue
       // Shared-store activity, floored at when this member took the launch: a full window, not epoch-idle.
@@ -16034,7 +16220,9 @@ export class Daemon {
       for (const p of this.pending.values()) {
         if (!match(p)) continue
         this.log.warn(`drain[${scope.kind}]: cancelling straggler turn (session ${p.acpSessionId})`)
-        await (p.selectedHost?.host ?? this.hosts.get(p.plan.agentId))?.cancel(p.acpSessionId).catch(() => {})
+        await (p.selectedHost?.host ?? this.hostForAcpSession(p.plan.agentId, p.acpSessionId))
+          ?.cancel(p.acpSessionId)
+          .catch(() => {})
       }
     }
     return { matched: [...matched.values()], drained: [...drained.values()], targets: targets.map(([, p]) => p) }
@@ -16062,7 +16250,7 @@ export class Daemon {
     let released: SessionKey[]
     if (drain.scope.kind === 'daemon') {
       await this.stopSelectedTurnHosts(targets)
-      for (const id of [...this.hosts.keys()]) await this.stopHost(id)
+      for (const key of [...this.hosts.keys()]) await this.stopHostByKey(key)
       for (const key of this.modelSessions.keys()) await this.modelSessions.release(key)
       await this.webchatMcpRevocations.revokeAllRemoteWebchatGrants('agent_detached')
       this.draining = false
@@ -16447,7 +16635,9 @@ export class Daemon {
         await this.permissions.releaseElicits(p.plan.agentId, p.acpSessionId)
         await this.permissions.releaseChatPermissions(p.plan.agentId, p.acpSessionId)
         await this.permissions.releaseEditorPermissions(p.plan.agentId, p.acpSessionId)
-        void (p.selectedHost?.host ?? this.hosts.get(p.plan.agentId))?.cancel(p.acpSessionId).catch(() => {})
+        void (p.selectedHost?.host ?? this.hostForAcpSession(p.plan.agentId, p.acpSessionId))
+          ?.cancel(p.acpSessionId)
+          .catch(() => {})
       }
       return forceAgents
     }
@@ -16799,7 +16989,7 @@ export class Daemon {
         this.webchatMcpRevocations.revokeRemoteWebchatGrantsForAgent(agentId, reason),
       stopAgent: (agentId) => this.stopAgent(agentId),
       stopHost: (agentId, deadlineMs) => this.stopHost(agentId, deadlineMs),
-      ensureHostAsync: (agentId, opts) => this.ensureHostAsync(agentId, opts),
+      ensureHostAsync: (agentId, opts) => this.ensureHostAsync(agentHostKey(agentId), opts),
       prepareAgentWorkspace: (agent, expectedWarmHost, request, allowAgentDrain) =>
         this.prepareAgentWorkspace(agent, expectedWarmHost, request, allowAgentDrain),
       enqueueAgentWorkspacePreparation: <T>(
@@ -16865,7 +17055,8 @@ export class Daemon {
       mcpServerFactsFromDefs: () => this.mcpServerFactsFromDefs(),
       cpLocalState: () => this.cpLocalState(),
       metrics: () => this.metrics,
-      hostCount: () => this.hosts.size,
+      // Load counts agents with a live host, not hosts: capacity gates count agents, and per-session hosts are bounded by session admission.
+      hostCount: () => new Set([...this.hosts.keys()].map(hostKeyAgentId)).size,
       activeSessions: () => this.pending.size,
       bootstrapUpgradeCapable: () => this.bootstrapUpgradeCapable(),
       runBootstrapFleetUpgrade: (targetVersion) => this.fleetUpgrade.runBootstrapFleetUpgrade(targetVersion),
@@ -17864,8 +18055,8 @@ export class Daemon {
     // teardown goes through the same generation fence/hostStopping path, and no async
     // starter is allowed to outlive the store/MCP boundary below.
     const hostStarts = [...this.hostStarts.values()]
-    const hostIds = new Set([...this.hosts.keys(), ...this.hostStarts.keys(), ...this.hostStopping.keys()])
-    for (const agentId of hostIds) await this.stopHost(agentId).catch((e) => errors.push(e))
+    const hostKeys = new Set([...this.hosts.keys(), ...this.hostStarts.keys(), ...this.hostStopping.keys()])
+    for (const key of hostKeys) await this.stopHostByKey(key).catch((e) => errors.push(e))
     for (const key of this.modelSessions.keys()) {
       await this.modelSessions.release(key).catch((e) => errors.push(e))
     }

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -62,6 +62,11 @@ export function pendingTurnKey(agentId: string, acpSessionId: string): string {
   return JSON.stringify([agentId, acpSessionId])
 }
 
+/** The ACP session id a pendingTurnKey / sdkLeaseKey names. */
+export function pendingTurnAcpSessionId(key: string): string {
+  return (JSON.parse(key) as [string, string])[1]
+}
+
 /** Background-task leases are per (agent, ACP session) for the same reason turns are: two
  *  agents can each expose an `acp-1`. Sharing one entry would let one agent's live task
  *  suppress the other's completion wake, or overwrite its task record under a colliding id. */

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -1,3 +1,4 @@
+import type { HostKey } from '../acp/host-key.js'
 import type { DutyGrantEntry, EventSession, ExternalSessionAudience, SessionKey } from '@agentconnect.md/protocol'
 import type { AcpHost } from '../acp/acp-host.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
@@ -58,8 +59,15 @@ export class LifecycleCleanupBlockedError extends Error {
 }
 
 /** ACP session ids are scoped to one agent runtime, not globally unique. */
-export function pendingTurnKey(agentId: string, acpSessionId: string): string {
-  return JSON.stringify([agentId, acpSessionId])
+// Keyed by the OWNING HOST, not the agent: ACP ids are runtime-local, and a confined agent runs one
+// host per session, so two of its children can both mint `acp-1`. The shared host's owner is the agent id.
+export function pendingTurnKey(owner: HostKey, acpSessionId: string): string {
+  return JSON.stringify([owner, acpSessionId])
+}
+
+/** The host a pendingTurnKey / sdkLeaseKey belongs to. */
+export function pendingTurnOwner(key: string): HostKey {
+  return (JSON.parse(key) as [HostKey, string])[0]
 }
 
 /** The ACP session id a pendingTurnKey / sdkLeaseKey names. */
@@ -70,8 +78,8 @@ export function pendingTurnAcpSessionId(key: string): string {
 /** Background-task leases are per (agent, ACP session) for the same reason turns are: two
  *  agents can each expose an `acp-1`. Sharing one entry would let one agent's live task
  *  suppress the other's completion wake, or overwrite its task record under a colliding id. */
-export function sdkLeaseKey(agentId: string, acpSessionId: string): string {
-  return pendingTurnKey(agentId, acpSessionId)
+export function sdkLeaseKey(owner: HostKey, acpSessionId: string): string {
+  return pendingTurnKey(owner, acpSessionId)
 }
 
 /** One LIVE background task — a member of the lease's liveness set. `startedAt` is when the
@@ -226,6 +234,8 @@ export type TurnInterruptDisposition = 'terminal' | 'handoff'
  */
 export interface SelectedTurnHost {
   host: AcpHost
+  /** The host's key — the owner every pending/lease entry of its sessions is filed under. */
+  hostKey: HostKey
   /** Full lifecycle cleanup for the exact process selected for this turn. */
   stop: (deadlineMs?: number) => Promise<void>
   /** The exact stop operation once lifecycle cleanup has begun, or an already
@@ -564,6 +574,8 @@ export interface Pending {
   promptEchoPrefix?: string
   /** The live ACP session id for this turn (part of the `this.pending` map key). */
   acpSessionId: string
+  /** The host that minted `acpSessionId` — the other half of the `this.pending` key. */
+  hostKey: HostKey
   /** The same session's OUTWARD id (session-concept.md §1.1) — what the console knows it by, so
    *  every deep link and status payload this turn produces addresses a row the CP actually has.
    *  Stamped once here because most of those producers are synchronous. */

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -1,3 +1,4 @@
+import { sessionHostKey, type HostKey } from '../acp/host-key.js'
 import type { AcpHost } from '../acp/acp-host.js'
 import type { LoadedAgent } from '../agents/load-agents.js'
 import type { RuntimeDef } from '../config/config-schema.js'
@@ -31,14 +32,13 @@ export interface ModelSessionHostPoolHost {
   acpSessionId(sessionKey: string): Promise<string | null | undefined>
   /** The slot's OUTWARD session id, minted on first ask — see session-concept.md §1.1. */
   outwardSessionId(sessionKey: string, agentId: string): Promise<string>
-  sessionKeyForAcpId(agentId: string, acpSessionId: string): Promise<string | undefined>
-  sessionSdkQuiescent(agentId: string, acpSessionId: string | null | undefined): boolean
-  releaseSdkLease(agentId: string, acpSessionId: string): void
+  sessionSdkQuiescent(owner: HostKey, acpSessionId: string | null | undefined): boolean
+  releaseSdkLease(owner: HostKey, acpSessionId: string): void
   /** Build + start the confined runtime for one entry, retries included (buildAcpHost seam). */
   startRuntime(agent: LoadedAgent, entry: ModelSessionHost): Promise<AcpHost>
   /** The agent's ordinary warm host, if any — the fallback for a session with no bound host. */
-  /** The daemon-owned host for the agent — the one owning `acpSessionId` when given, else its shared host. */
-  ordinaryHost(agentId: string, acpSessionId?: string): AcpHost | undefined
+  /** Whether the daemon itself still runs a host for the agent (its config files stay until the last one goes). */
+  hasDaemonHost(agentId: string): boolean
   /** A pool host's process is gone; per-host daemon state (its sandbox policy directory) goes with it. */
   hostStopped?(agentId: string, sessionKey: string): void
   /** Drop the agent's config-file secrets once it owns no host of any kind any more. */
@@ -203,6 +203,7 @@ export class ModelSessionHostPool {
     let cleanup: Promise<void> | undefined
     return {
       host,
+      hostKey: sessionHostKey(entry.agentId, entry.sessionKey),
       stop: (deadlineMs) => (cleanup ??= this.stopRuntime(entry, host, deadlineMs)),
       waitForCleanup: () => cleanup ?? Promise.resolve()
     }
@@ -329,7 +330,7 @@ export class ModelSessionHostPool {
 
   private async sdkQuiescent(entry: ModelSessionHost): Promise<boolean> {
     const acpSessionId = await this.host.acpSessionId(entry.sessionKey)
-    return this.host.sessionSdkQuiescent(entry.agentId, acpSessionId)
+    return this.host.sessionSdkQuiescent(sessionHostKey(entry.agentId, entry.sessionKey), acpSessionId)
   }
 
   async stopRuntime(entry: ModelSessionHost, expectedHost?: AcpHost, deadlineMs?: number): Promise<void> {
@@ -349,7 +350,7 @@ export class ModelSessionHostPool {
         if (entry.stopping === stopping) entry.stopping = undefined
         this.host.hostStopped?.(entry.agentId, entry.sessionKey)
         const sessionId = await this.host.acpSessionId(entry.sessionKey)
-        if (sessionId) this.host.releaseSdkLease(entry.agentId, sessionId)
+        if (sessionId) this.host.releaseSdkLease(sessionHostKey(entry.agentId, entry.sessionKey), sessionId)
       })
     entry.stopping = stopping
     await stopping
@@ -378,7 +379,7 @@ export class ModelSessionHostPool {
       this.entries.set(sessionKey, entry)
       this.log.warn(`session ${sessionKey}: model host stop failed — retained for a retry`)
     }
-    if (!this.host.ordinaryHost(entry.agentId) && !this.hasEntryForAgent(entry.agentId)) {
+    if (!this.host.hasDaemonHost(entry.agentId) && !this.hasEntryForAgent(entry.agentId)) {
       this.host.cleanupAgentConfigFiles(entry.agentId)
     }
     if (stopError) throw stopError
@@ -395,10 +396,8 @@ export class ModelSessionHostPool {
     await Promise.all(keys.map((key) => this.release(key, deadlineMs)))
   }
 
-  async hostForStoredSession(agentId: string, acpSessionId: string): Promise<AcpHost | undefined> {
-    const sessionKey = await this.host.sessionKeyForAcpId(agentId, acpSessionId)
-    return (
-      (sessionKey ? this.entries.get(sessionKey)?.host : undefined) ?? this.host.ordinaryHost(agentId, acpSessionId)
-    )
+  /** The pool's started host for a logical session, if it has one. */
+  hostForSessionKey(sessionKey: string): AcpHost | undefined {
+    return this.entries.get(sessionKey)?.host
   }
 }

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -16,6 +16,11 @@ import { DEFAULT_MODEL_KEY_TTL_SECONDS, KeyServerClient, type KeyGrant } from '.
 
 /** The daemon-internal session keys that address a credential lifecycle with no chat session
  *  behind it. Constructors rather than literals so the `internal:` namespace has one owner. */
+/** Whether a session key names a daemon-internal pass rather than a stored session. */
+export function isInternalSessionKey(key: string): boolean {
+  return key.startsWith('internal:')
+}
+
 export const internalSessionKey = {
   dream: (dreamId: string) => `internal:dream:${dreamId}`,
   memory: (agentId: string) => `internal:memory:${agentId}`,

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -16,11 +16,6 @@ import { DEFAULT_MODEL_KEY_TTL_SECONDS, KeyServerClient, type KeyGrant } from '.
 
 /** The daemon-internal session keys that address a credential lifecycle with no chat session
  *  behind it. Constructors rather than literals so the `internal:` namespace has one owner. */
-/** Whether a session key names a daemon-internal pass rather than a stored session. */
-export function isInternalSessionKey(key: string): boolean {
-  return key.startsWith('internal:')
-}
-
 export const internalSessionKey = {
   dream: (dreamId: string) => `internal:dream:${dreamId}`,
   memory: (agentId: string) => `internal:memory:${agentId}`,

--- a/packages/daemon/src/key-server/session-hosts.ts
+++ b/packages/daemon/src/key-server/session-hosts.ts
@@ -37,7 +37,10 @@ export interface ModelSessionHostPoolHost {
   /** Build + start the confined runtime for one entry, retries included (buildAcpHost seam). */
   startRuntime(agent: LoadedAgent, entry: ModelSessionHost): Promise<AcpHost>
   /** The agent's ordinary warm host, if any — the fallback for a session with no bound host. */
-  ordinaryHost(agentId: string): AcpHost | undefined
+  /** The daemon-owned host for the agent — the one owning `acpSessionId` when given, else its shared host. */
+  ordinaryHost(agentId: string, acpSessionId?: string): AcpHost | undefined
+  /** A pool host's process is gone; per-host daemon state (its sandbox policy directory) goes with it. */
+  hostStopped?(agentId: string, sessionKey: string): void
   /** Drop the agent's config-file secrets once it owns no host of any kind any more. */
   cleanupAgentConfigFiles(agentId: string): void
 }
@@ -344,6 +347,7 @@ export class ModelSessionHostPool {
       })
       .finally(async () => {
         if (entry.stopping === stopping) entry.stopping = undefined
+        this.host.hostStopped?.(entry.agentId, entry.sessionKey)
         const sessionId = await this.host.acpSessionId(entry.sessionKey)
         if (sessionId) this.host.releaseSdkLease(entry.agentId, sessionId)
       })
@@ -393,6 +397,8 @@ export class ModelSessionHostPool {
 
   async hostForStoredSession(agentId: string, acpSessionId: string): Promise<AcpHost | undefined> {
     const sessionKey = await this.host.sessionKeyForAcpId(agentId, acpSessionId)
-    return (sessionKey ? this.entries.get(sessionKey)?.host : undefined) ?? this.host.ordinaryHost(agentId)
+    return (
+      (sessionKey ? this.entries.get(sessionKey)?.host : undefined) ?? this.host.ordinaryHost(agentId, acpSessionId)
+    )
   }
 }

--- a/packages/daemon/src/launch/assemble.ts
+++ b/packages/daemon/src/launch/assemble.ts
@@ -1,6 +1,7 @@
 import { materializeConfigFiles, type MaterializeResult } from '../shim/config-file-env.js'
 import { composeRuntimeLaunch, type ComposedRuntimeLaunch } from './compose.js'
 import type { SandboxMechanism } from '../acp/sandbox.js'
+import type { HostKey } from '../acp/host-key.js'
 import type { MemoryProviderKind } from '../memory/provider.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 
@@ -25,6 +26,8 @@ export interface AssembleRuntimeLaunchOptions {
   provider: MemoryProviderKind
   scopeDir: string
   cwd: string
+  /** The host this launch builds; keys its sandbox policy directory under the agent dir. */
+  hostKey: HostKey
   runInSandbox: boolean
   daemonRoot?: string
   agentsRoot?: string
@@ -84,6 +87,7 @@ export function assembleRuntimeLaunch(opts: AssembleRuntimeLaunchOptions): Assem
     provider: opts.provider,
     scopeDir: opts.scopeDir,
     cwd: opts.cwd,
+    hostKey: opts.hostKey,
     runInSandbox: opts.runInSandbox,
     daemonRoot: opts.daemonRoot,
     agentsRoot: opts.agentsRoot,

--- a/packages/daemon/src/launch/compose.ts
+++ b/packages/daemon/src/launch/compose.ts
@@ -13,6 +13,7 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
 import { prepareRuntimeLaunch, type PreparedRuntimeLaunch } from './prepare.js'
 import type { SandboxMechanism } from '../acp/sandbox.js'
+import type { HostKey } from '../acp/host-key.js'
 import {
   describeRuntime,
   runtimeMemoryCapabilities,
@@ -146,6 +147,7 @@ export function composeRuntimeLaunch(opts: {
   provider: MemoryProviderKind
   scopeDir: string
   cwd: string
+  hostKey?: HostKey
   explicitEnv?: Record<string, string>
   stateSourceEnv?: NodeJS.ProcessEnv
   hostEnv?: NodeJS.ProcessEnv
@@ -190,6 +192,7 @@ export function composeRuntimeLaunch(opts: {
     runtime: opts.runtime,
     scopeDir: opts.scopeDir,
     cwd: opts.cwd,
+    hostKey: opts.hostKey,
     runInSandbox: opts.runInSandbox,
     isolateHome: opts.isolateHome || (protectedMemory && policyId === 'hermes-agent'),
     explicitEnv: opts.explicitEnv,

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -2,6 +2,7 @@ import { chmodSync, existsSync, lstatSync, mkdirSync, readdirSync, realpathSync 
 import { homedir } from 'node:os'
 import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { sandboxBoundary, writeSandboxSettings, type SandboxMechanism } from '../acp/sandbox.js'
+import { hostKeyDirName, type HostKey } from '../acp/host-key.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { compactReadRoots } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../runtimes/runtime-credentials.js'
@@ -193,6 +194,9 @@ export function prepareRuntimeLaunch(opts: {
   runtime?: RuntimeDef
   scopeDir: string
   cwd: string
+  /** Which host this launch is for; its sandbox policy lives in a per-host directory. Absent only for
+   *  a single-launch scope such as a probe, which then takes the shared host's leaf. */
+  hostKey?: HostKey
   runInSandbox: boolean
   isolateHome?: boolean
   explicitEnv?: Record<string, string>
@@ -487,7 +491,7 @@ export function prepareRuntimeLaunch(opts: {
     const projectClaudeDir = join(boundary.gitSafeDirectories[0]!, '.claude')
     if (!existsSync(projectClaudeDir)) mkdirSync(projectClaudeDir, { mode: 0o700 })
   }
-  const settingsPath = writeSandboxSettings(opts.scopeDir, {
+  const settingsPath = writeSandboxSettings(opts.scopeDir, hostKeyDirName(opts.hostKey), {
     writable: boundary.writable,
     // Host user data is default-denied. Re-open only the current agent surfaces
     // plus trusted executable/package roots above; never an agent-provided path.

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -1,6 +1,7 @@
 // ACP permission + elicitation policy — the human-approval half of a turn, hoisted out of
 // `Daemon` verbatim. Resolution here is a race between the runtime request, the chat card, the
 // Agent-editor decision, and turn cancellation: every await order and map write is load-bearing.
+import { hostKeyAgentId, type HostKey } from '../acp/host-key.js'
 import { randomUUID } from 'node:crypto'
 import type {
   CreateElicitationRequest,
@@ -92,7 +93,7 @@ export interface PermissionSurfaceHost {
   maskAgentSecrets<T>(agentId: string, payload: T): T
   logSessionAction(verb: string, sessionKey: string, actor?: InteractionActor): void
   /** Tell the CP a session started or stopped waiting on a human (slack-approval-dm.md §7); fire-and-forget. */
-  emitApprovalActivity(agentId: string, acpSessionId: string, state: 'awaiting_permission' | 'idle'): void
+  emitApprovalActivity(owner: HostKey, acpSessionId: string, state: 'awaiting_permission' | 'idle'): void
   /** Render the gate on the turn's OWN surface; false when the platform has none and the neutral chat notice should post. */
   approvalGateOpened(p: Pending, gateId: string, request: ApprovalRequestParts): boolean
   /** One gate went away — `allowed` is set only for a human decision, which the surface reports. */
@@ -127,6 +128,7 @@ interface DmNotice {
 
 interface EditorPermissionEntry {
   kind: 'permission'
+  owner: HostKey
   agentId: string
   sessionId: string
   params: RequestPermissionRequest
@@ -137,6 +139,7 @@ interface EditorPermissionEntry {
 
 interface EditorElicitationEntry {
   kind: 'elicitation'
+  owner: HostKey
   agentId: string
   sessionId: string
   params: CreateElicitationRequest
@@ -154,6 +157,7 @@ export class PermissionCoordinator {
   private pendingChatPermissions = new Map<
     string,
     {
+      owner: HostKey
       agentId: string
       sessionId: string
       params: RequestPermissionRequest
@@ -174,6 +178,7 @@ export class PermissionCoordinator {
   private pendingElicits = new Map<
     string,
     {
+      owner: HostKey
       agentId: string
       sessionId: string
       params: CreateElicitationRequest
@@ -188,40 +193,40 @@ export class PermissionCoordinator {
   >()
 
   /** Sessions the CP currently believes are waiting, keyed by `pendingTurnKey` — emit only on a change. */
-  private readonly awaitingApproval = new Map<string, { agentId: string; sessionId: string }>()
+  private readonly awaitingApproval = new Map<string, { owner: HostKey; agentId: string; sessionId: string }>()
 
   constructor(private readonly host: PermissionHost) {}
 
   /** Any answerable request for the session across the three pending maps (approval elicitations only). */
-  private hasPendingApproval(agentId: string, sessionId: string): boolean {
+  private hasPendingApproval(owner: HostKey, sessionId: string): boolean {
     for (const e of this.pendingEditorPermissions.values())
-      if (e.agentId === agentId && e.sessionId === sessionId) return true
+      if (e.owner === owner && e.sessionId === sessionId) return true
     for (const e of this.pendingChatPermissions.values())
-      if (e.agentId === agentId && e.sessionId === sessionId) return true
+      if (e.owner === owner && e.sessionId === sessionId) return true
     for (const e of this.pendingElicits.values())
-      if (e.approval && e.agentId === agentId && e.sessionId === sessionId) return true
+      if (e.approval && e.owner === owner && e.sessionId === sessionId) return true
     return false
   }
 
   /** Re-derive the session's wait state after a map write and report it when it flipped (§7). `closed`
    *  names the gate this write removed, so the turn's surface closes that one gate, not the session. */
-  private syncApprovalActivity(agentId: string, sessionId: string, closed?: ClosedGate): void {
-    if (closed) this.reportGateClosed(agentId, sessionId, closed)
-    const key = pendingTurnKey(agentId, sessionId)
-    const awaiting = this.hasPendingApproval(agentId, sessionId)
+  private syncApprovalActivity(owner: HostKey, sessionId: string, closed?: ClosedGate): void {
+    if (closed) this.reportGateClosed(owner, sessionId, closed)
+    const key = pendingTurnKey(owner, sessionId)
+    const awaiting = this.hasPendingApproval(owner, sessionId)
     if (awaiting === this.awaitingApproval.has(key)) return
-    if (awaiting) this.awaitingApproval.set(key, { agentId, sessionId })
+    if (awaiting) this.awaitingApproval.set(key, { owner, agentId: hostKeyAgentId(owner), sessionId })
     else this.awaitingApproval.delete(key)
     try {
-      this.host.emitApprovalActivity(agentId, sessionId, awaiting ? 'awaiting_permission' : 'idle')
+      this.host.emitApprovalActivity(owner, sessionId, awaiting ? 'awaiting_permission' : 'idle')
     } catch (err) {
       this.host.log().warn(`approval activity not reported: ${formatErr(err)}`)
     }
   }
 
   /** Close one gate on the turn's own surface, if the turn is still live. */
-  private reportGateClosed(agentId: string, sessionId: string, closed: ClosedGate): void {
-    const p = this.host.pending().get(pendingTurnKey(agentId, sessionId))
+  private reportGateClosed(owner: HostKey, sessionId: string, closed: ClosedGate): void {
+    const p = this.host.pending().get(pendingTurnKey(owner, sessionId))
     if (!p) return
     try {
       this.host.approvalGateClosed(p, closed.id, closed.allowed)
@@ -231,19 +236,19 @@ export class PermissionCoordinator {
   }
 
   /** The sessions currently waiting on a human, by runtime session id. */
-  liveApprovalWaits(): ReadonlyArray<{ agentId: string; sessionId: string }> {
+  liveApprovalWaits(): ReadonlyArray<{ owner: HostKey; agentId: string; sessionId: string }> {
     return [...this.awaitingApproval.values()]
   }
 
   /** Whether the session still has an answerable request — the emit-time check behind every `awaiting_permission`. */
-  isAwaitingApproval(agentId: string, sessionId: string): boolean {
-    return this.awaitingApproval.has(pendingTurnKey(agentId, sessionId))
+  isAwaitingApproval(owner: HostKey, sessionId: string): boolean {
+    return this.awaitingApproval.has(pendingTurnKey(owner, sessionId))
   }
 
   /** Re-assert every live wait after a (re)connect: the CP reset them when this daemon dropped (§7). */
   replayApprovalActivity(): void {
-    for (const { agentId, sessionId } of this.awaitingApproval.values()) {
-      this.host.emitApprovalActivity(agentId, sessionId, 'awaiting_permission')
+    for (const { owner, sessionId } of this.awaitingApproval.values()) {
+      this.host.emitApprovalActivity(owner, sessionId, 'awaiting_permission')
     }
   }
 
@@ -345,13 +350,14 @@ export class PermissionCoordinator {
     // that window must find this entry or the agent waits on a resolver nobody can reach.
     this.pendingEditorPermissions.set(id, {
       kind: 'permission',
+      owner: p.hostKey,
       agentId,
       sessionId,
       params,
       evaluationParams,
       resolve: resolveResult
     })
-    this.syncApprovalActivity(agentId, sessionId)
+    this.syncApprovalActivity(p.hostKey, sessionId)
     // The human wait starts when the request becomes answerable, not when its row lands — the
     // write used to be synchronous, and billing it to the turn's retry budget would shrink it.
     const wait = this.trackHumanApprovalWait(p, result)
@@ -362,7 +368,7 @@ export class PermissionCoordinator {
       requesterName = (await recorded).requesterName
     } catch (err) {
       this.pendingEditorPermissions.delete(id)
-      this.syncApprovalActivity(agentId, sessionId, { id })
+      this.syncApprovalActivity(p.hostKey, sessionId, { id })
       this.recordedWrites.delete(id)
       resolveResult({ outcome: { outcome: 'cancelled' } })
       await wait
@@ -384,12 +390,13 @@ export class PermissionCoordinator {
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
     this.pendingEditorPermissions.set(id, {
       kind: 'elicitation',
+      owner: p.hostKey,
       agentId,
       sessionId,
       params,
       resolve: resolveResult
     })
-    this.syncApprovalActivity(agentId, sessionId)
+    this.syncApprovalActivity(p.hostKey, sessionId)
     const wait = this.trackHumanApprovalWait(p, result)
     const recorded = this.noteEditorPermissionRequest(id, agentId, sessionId, elicitationApprovalParts(params), p)
     this.recordedWrites.set(id, recorded)
@@ -398,7 +405,7 @@ export class PermissionCoordinator {
       requesterName = (await recorded).requesterName
     } catch (err) {
       this.pendingEditorPermissions.delete(id)
-      this.syncApprovalActivity(agentId, sessionId, { id })
+      this.syncApprovalActivity(p.hostKey, sessionId, { id })
       this.recordedWrites.delete(id)
       resolveResult({ action: 'cancel' })
       await wait
@@ -421,6 +428,7 @@ export class PermissionCoordinator {
     let resolveResult!: (res: RequestPermissionResponse) => void
     const result = new Promise<RequestPermissionResponse>((resolve) => (resolveResult = resolve))
     this.pendingChatPermissions.set(requestId, {
+      owner: p.hostKey,
       agentId,
       sessionId,
       params,
@@ -429,7 +437,7 @@ export class PermissionCoordinator {
       channel: p.plan.channel,
       resolve: resolveResult
     })
-    this.syncApprovalActivity(agentId, sessionId)
+    this.syncApprovalActivity(p.hostKey, sessionId)
     const recorded = this.noteEditorPermissionRequest(
       requestId,
       agentId,
@@ -443,7 +451,7 @@ export class PermissionCoordinator {
       await recorded
     } catch (err) {
       this.pendingChatPermissions.delete(requestId)
-      this.syncApprovalActivity(agentId, sessionId, { id: requestId })
+      this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
       this.recordedWrites.delete(requestId)
       throw err
     }
@@ -475,7 +483,7 @@ export class PermissionCoordinator {
     }
     if (!ts) {
       this.pendingChatPermissions.delete(requestId)
-      this.syncApprovalActivity(agentId, sessionId, { id: requestId })
+      this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
       await this.resolveStoredPermissionRequest(agentId, requestId, 'expired')
       this.permissionEvaluationDetails.set(evaluationParams, { reason: 'permission_card_failed' })
       live.resolve({ outcome: { outcome: 'cancelled' } })
@@ -674,7 +682,7 @@ export class PermissionCoordinator {
     if (!(await this.resolveStoredPermissionRequest(rec.agentId, requestId, allowed ? 'allowed' : 'denied', by))) return
     this.host.logSessionAction(`permission:${allowed ? 'allowed' : 'denied'}`, rec.sessionId, actor)
     this.pendingEditorPermissions.delete(requestId)
-    this.syncApprovalActivity(rec.agentId, rec.sessionId, { id: requestId, allowed })
+    this.syncApprovalActivity(rec.owner, rec.sessionId, { id: requestId, allowed })
     this.permissionEvaluationDetails.set(rec.evaluationParams, { reason: 'agent_editor' })
     void notify.conn
       .updateBlocks(
@@ -742,7 +750,7 @@ export class PermissionCoordinator {
       return
     this.host.logSessionAction(`permission:${value === null ? 'denied' : 'allowed'}`, rec.sessionId, actor)
     this.pendingEditorPermissions.delete(requestId)
-    this.syncApprovalActivity(rec.agentId, rec.sessionId, { id: requestId, allowed: value !== null })
+    this.syncApprovalActivity(rec.owner, rec.sessionId, { id: requestId, allowed: value !== null })
     void notify.conn
       .updateBlocks(
         notify.channel,
@@ -784,7 +792,7 @@ export class PermissionCoordinator {
           return { ok: false, reason: 'permission request is no longer pending' }
         }
         this.pendingElicits.delete(req.requestId)
-        this.syncApprovalActivity(elicitation.agentId, elicitation.sessionId, {
+        this.syncApprovalActivity(elicitation.owner, elicitation.sessionId, {
           id: req.requestId,
           allowed: decidedAllow
         })
@@ -824,7 +832,7 @@ export class PermissionCoordinator {
         return { ok: false, reason: 'permission request is no longer pending' }
       }
       this.pendingChatPermissions.delete(req.requestId)
-      this.syncApprovalActivity(chat.agentId, chat.sessionId, { id: req.requestId, allowed: decidedAllow })
+      this.syncApprovalActivity(chat.owner, chat.sessionId, { id: req.requestId, allowed: decidedAllow })
       this.permissionEvaluationDetails.set(chat.evaluationParams, { reason: 'agent_editor' })
       if (chat.ts) {
         void chat.conn
@@ -876,7 +884,7 @@ export class PermissionCoordinator {
       return { ok: false, reason: 'permission request is no longer pending' }
     }
     this.pendingEditorPermissions.delete(req.requestId)
-    this.syncApprovalActivity(pending.agentId, pending.sessionId, { id: req.requestId, allowed: decidedAllow })
+    this.syncApprovalActivity(pending.owner, pending.sessionId, { id: req.requestId, allowed: decidedAllow })
     if (pending.notify) {
       const label = `${req.decision === 'allow' ? 'Allowed' : 'Denied'} by ${req.decidedByName ?? 'an Agent editor'}`
       const blocks =
@@ -952,7 +960,7 @@ export class PermissionCoordinator {
     // whose click changed nothing.
     this.host.logSessionAction(`permission:${allowed ? 'allowed' : 'denied'}`, pending.sessionId, input.actor)
     this.pendingChatPermissions.delete(input.requestId)
-    this.syncApprovalActivity(pending.agentId, pending.sessionId, { id: input.requestId, allowed })
+    this.syncApprovalActivity(pending.owner, pending.sessionId, { id: input.requestId, allowed })
     this.permissionEvaluationDetails.set(pending.evaluationParams, { reason: 'chat_user' })
     if (pending.ts) {
       void pending.conn
@@ -997,11 +1005,12 @@ export class PermissionCoordinator {
     }
   }
 
-  async releaseChatPermissions(agentId: string, sessionId: string): Promise<void> {
+  async releaseChatPermissions(owner: HostKey, sessionId: string): Promise<void> {
+    const agentId = hostKeyAgentId(owner)
     for (const [id, pending] of this.pendingChatPermissions) {
-      if (pending.agentId !== agentId || pending.sessionId !== sessionId) continue
+      if (pending.owner !== owner || pending.sessionId !== sessionId) continue
       this.pendingChatPermissions.delete(id)
-      this.syncApprovalActivity(agentId, sessionId, { id })
+      this.syncApprovalActivity(owner, sessionId, { id })
       await this.resolveStoredPermissionRequest(agentId, id, 'expired')
       this.permissionEvaluationDetails.set(pending.evaluationParams, { reason: 'turn_cancelled' })
       if (pending.ts) {
@@ -1019,11 +1028,12 @@ export class PermissionCoordinator {
     }
   }
 
-  async releaseEditorPermissions(agentId: string, sessionId: string): Promise<void> {
+  async releaseEditorPermissions(owner: HostKey, sessionId: string): Promise<void> {
+    const agentId = hostKeyAgentId(owner)
     for (const [id, pending] of this.pendingEditorPermissions) {
-      if (pending.agentId !== agentId || pending.sessionId !== sessionId) continue
+      if (pending.owner !== owner || pending.sessionId !== sessionId) continue
       this.pendingEditorPermissions.delete(id)
-      this.syncApprovalActivity(agentId, sessionId, { id })
+      this.syncApprovalActivity(owner, sessionId, { id })
       await this.resolveStoredPermissionRequest(agentId, id, 'expired')
       // Dead buttons must not survive the request (§5.4): retire the DM card in place.
       if (pending.notify) {
@@ -1055,12 +1065,13 @@ export class PermissionCoordinator {
   }
 
   onAcpPermissionEvent(
-    agentId: string,
+    owner: HostKey,
     sessionId: string,
     params: RequestPermissionRequest,
     event: AcpPermissionPolicyEvent
   ): void {
-    const pending = this.host.pending().get(pendingTurnKey(agentId, sessionId))
+    const agentId = hostKeyAgentId(owner)
+    const pending = this.host.pending().get(pendingTurnKey(owner, sessionId))
     const context = {
       agentId,
       sessionId,
@@ -1109,24 +1120,25 @@ export class PermissionCoordinator {
    * default. An editor may explicitly opt an agent into Slack chat-side decisions.
    */
   async onAcpPermission(
-    agentId: string,
+    owner: HostKey,
     sessionId: string,
     params: RequestPermissionRequest
   ): Promise<RequestPermissionResponse> {
     try {
-      return await this.resolveAcpPermission(agentId, sessionId, params)
+      return await this.resolveAcpPermission(owner, sessionId, params)
     } catch (err) {
       this.permissionEvaluationDetails.set(params, { reason: 'permission_policy_error' })
-      this.host.log().error(`permission policy failed closed for agent "${agentId}": ${formatErr(err)}`)
+      this.host.log().error(`permission policy failed closed for agent "${hostKeyAgentId(owner)}": ${formatErr(err)}`)
       return { outcome: { outcome: 'cancelled' } }
     }
   }
 
   private async resolveAcpPermission(
-    agentId: string,
+    owner: HostKey,
     sessionId: string,
     params: RequestPermissionRequest
   ): Promise<RequestPermissionResponse> {
+    const agentId = hostKeyAgentId(owner)
     const evaluationParams = params
     // The tool title/preview can embed a secret the agent interpolated into a command.
     // Mask before anything renders it (Slack card now, resolved-card edit later via
@@ -1134,7 +1146,7 @@ export class PermissionCoordinator {
     params = this.host.maskAgentSecrets(agentId, params)
     // Extraction is a silent background operation: it may never gain side effects
     // merely because the user agent normally runs in an auto-approval mode.
-    if (this.host.memoryExtractionInFlight(pendingTurnKey(agentId, sessionId))) {
+    if (this.host.memoryExtractionInFlight(pendingTurnKey(owner, sessionId))) {
       this.permissionEvaluationDetails.set(evaluationParams, { reason: 'memory_extraction' })
       return { outcome: { outcome: 'cancelled' } }
     }
@@ -1142,7 +1154,7 @@ export class PermissionCoordinator {
     // orchestration, memory, …) are always granted: a human should never
     // have to approve them per call. Auto-allow without rendering a card. Non-system tools
     // (incl. the runtime's dangerous built-ins) fall through to the interactive policy below.
-    const p = this.host.pending().get(pendingTurnKey(agentId, sessionId))
+    const p = this.host.pending().get(pendingTurnKey(owner, sessionId))
     if (isBuiltinSystemTool(params, p?.builtinSystemToolCallIds)) {
       const allow = params.options.find((o) => o.kind === 'allow_always' || o.kind === 'allow_once')
       if (allow) {
@@ -1185,14 +1197,15 @@ export class PermissionCoordinator {
    * taps a button (handleElicitChoice) or the turn ends/cancels (releaseElicits).
    */
   async onAcpElicit(
-    agentId: string,
+    owner: HostKey,
     sessionId: string,
     params: CreateElicitationRequest
   ): Promise<CreateElicitationResponse | undefined> {
+    const agentId = hostKeyAgentId(owner)
     // Same reason as onAcpPermission: the elicitation message/labels are agent-authored
     // text headed for a platform card — mask any embedded secret value first.
     params = this.host.maskAgentSecrets(agentId, params)
-    const p = this.host.pending().get(pendingTurnKey(agentId, sessionId))
+    const p = this.host.pending().get(pendingTurnKey(owner, sessionId))
     if (!p) return undefined
     if (p.outputSuppressed) return { action: 'cancel' }
     // Codex maps MCP approval to `elicitation/create` when form support is
@@ -1221,6 +1234,7 @@ export class PermissionCoordinator {
     let resolveResult!: (res: CreateElicitationResponse) => void
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
     this.pendingElicits.set(requestId, {
+      owner: p.hostKey,
       agentId,
       sessionId,
       params,
@@ -1231,7 +1245,7 @@ export class PermissionCoordinator {
       channel: p.plan.channel,
       resolve: resolveResult
     })
-    this.syncApprovalActivity(agentId, sessionId)
+    this.syncApprovalActivity(p.hostKey, sessionId)
     if (isApproval) {
       const recorded = this.noteEditorPermissionRequest(
         requestId,
@@ -1246,7 +1260,7 @@ export class PermissionCoordinator {
         await recorded
       } catch (err) {
         this.pendingElicits.delete(requestId)
-        this.syncApprovalActivity(agentId, sessionId, { id: requestId })
+        this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
         this.recordedWrites.delete(requestId)
         throw err
       }
@@ -1275,7 +1289,7 @@ export class PermissionCoordinator {
     }
     if (!ts) {
       this.pendingElicits.delete(requestId)
-      this.syncApprovalActivity(agentId, sessionId, { id: requestId })
+      this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
       if (isApproval) await this.resolveStoredPermissionRequest(agentId, requestId, 'expired')
       live.resolve({ action: 'cancel' })
       return await result
@@ -1335,7 +1349,7 @@ export class PermissionCoordinator {
         return
     }
     this.pendingElicits.delete(a.requestId)
-    this.syncApprovalActivity(rec.agentId, rec.sessionId, { id: a.requestId, allowed: a.value !== null })
+    this.syncApprovalActivity(rec.owner, rec.sessionId, { id: a.requestId, allowed: a.value !== null })
     if (rec.ts)
       void rec.conn
         .updateBlocks(rec.channel, rec.ts, buildElicitationResolvedCard(rec.params, decision), 'Input received', true)
@@ -1345,11 +1359,12 @@ export class PermissionCoordinator {
 
   /** Resolve every outstanding elicitation for a session as `cancel` — ACP's cancellation
    *  contract, and it unblocks a turn whose card the user abandoned. */
-  async releaseElicits(agentId: string, sessionId: string): Promise<void> {
+  async releaseElicits(owner: HostKey, sessionId: string): Promise<void> {
+    const agentId = hostKeyAgentId(owner)
     for (const [id, rec] of this.pendingElicits) {
-      if (rec.agentId !== agentId || rec.sessionId !== sessionId) continue
+      if (rec.owner !== owner || rec.sessionId !== sessionId) continue
       this.pendingElicits.delete(id)
-      this.syncApprovalActivity(agentId, sessionId, { id })
+      this.syncApprovalActivity(owner, sessionId, { id })
       if (rec.approval) await this.resolveStoredPermissionRequest(agentId, id, 'expired')
       if (rec.ts)
         void rec.conn

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -156,6 +156,9 @@ function abortable<T>(start: () => PromiseLike<T> | T, signal?: AbortSignal): Pr
   })
 }
 
+/** What a logical session asks of its workspace — also what keys its host where hosts are per session. */
+export type SessionWorkspaceRequest = { sessionKey: string; isolation: 'shared' | 'session'; initiatedBy?: string }
+
 export class SessionManager {
   /** The owning daemon's plane when it supplied one; otherwise a private plane, so two harnesses
    *  in one process still cannot see each other's registrations. */
@@ -170,10 +173,14 @@ export class SessionManager {
       /** Mint a slot's outward id (§1.1) and hand back the synchronous binder the runtime's raw
        *  `session/new` response calls — see the opener's `prepareOutwardBinding`. */
       prepareOutwardBinding?: (agentId: string, key: string) => Promise<(acpSessionId: string) => void>
-      hostFor: (agentId: string) => Promise<AcpHost>
+      /** The host for this logical session — per session where the daemon confines one, else the
+       *  agent's shared host. `cwd` is a daemon-verified directory a session-bound host must launch in. */
+      hostFor: (agentId: string, request: SessionWorkspaceRequest, cwd?: string) => Promise<AcpHost>
       /** Whether the runtime initialize handshake completed. A cold hostFor may
        * own preparation itself when resolvePreparedWorkspace is also supplied. */
-      isHostRunning?: (agentId: string) => boolean
+      isHostRunning?: (agentId: string, request: SessionWorkspaceRequest) => boolean
+      /** The cwd a session-bound host launched in, whatever the isolation; undefined for a shared host. */
+      boundHostCwd?: (agentId: string, request: SessionWorkspaceRequest) => string | undefined
       agentById: (id: string) => LoadedAgent | undefined
       /** The owning daemon's workspace plane. Absent only in lightweight harnesses, which get
        *  their own so nothing is shared between them. */
@@ -185,7 +192,7 @@ export class SessionManager {
       prepareWorkspace?: (
         agent: Agent,
         expectedWarmHost?: AcpHost,
-        request?: { sessionKey: string; isolation: 'shared' | 'session'; initiatedBy?: string }
+        request?: SessionWorkspaceRequest
       ) => Promise<string>
       /** Resolve the cwd produced by hostFor's cold preparation without
        * repeating pull/source acquisition/reconciliation. Production supplies
@@ -505,7 +512,7 @@ export class SessionManager {
     // Lightweight embedders without that contract retain the legacy pre-host fallback.
     // A warm turn on a live host does not prepare here; the per-branch preparation
     // below handles only warm-host new-session/resume cases.
-    const hostCold = options.host ? false : !(this.deps.isHostRunning?.(agentId) ?? false)
+    const hostCold = options.host ? false : !(this.deps.isHostRunning?.(agentId, workspaceRequest) ?? false)
     let preparedCwd =
       hostCold && !this.deps.resolvePreparedWorkspace
         ? await abortable(
@@ -515,11 +522,23 @@ export class SessionManager {
             signal
           )
         : undefined
-    const host = options.host ?? (await abortable(() => this.deps.hostFor(agentId), signal))
+    const host =
+      options.host ??
+      (await abortable(() => this.deps.hostFor(agentId, workspaceRequest, options.preparedWorkspaceCwd), signal))
     // Explicit private-cell hosts are not owned by the daemon's ordinary host
     // map. Only an ordinary warm host carries generation identity into the
     // preparation seam; its daemon can then reject a late post-stop mutation.
     const expectedWarmHost = options.host ? undefined : host
+    const hostBoundCwd = options.host ? undefined : this.deps.boundHostCwd?.(agentId, workspaceRequest)
+    if (
+      hostBoundCwd !== undefined &&
+      options.preparedWorkspaceCwd !== undefined &&
+      hostBoundCwd !== options.preparedWorkspaceCwd
+    ) {
+      throw new Error(
+        `session host launched in ${hostBoundCwd}, not the prepared workspace ${options.preparedWorkspaceCwd}`
+      )
+    }
     if (hostCold && this.deps.resolvePreparedWorkspace) {
       preparedCwd = await abortable(() => this.deps.resolvePreparedWorkspace!(agent), signal)
     }
@@ -612,6 +631,7 @@ export class SessionManager {
         ? { prepareOutwardBinding: () => this.deps.prepareOutwardBinding!(agentId, key) }
         : {}),
       ...(options.preparedWorkspaceCwd !== undefined ? { preparedWorkspaceCwd: options.preparedWorkspaceCwd } : {}),
+      ...(hostBoundCwd !== undefined ? { hostBoundCwd } : {}),
       ...(preparedCwd !== undefined ? { preparedCwd } : {}),
       ...(expectedWarmHost !== undefined ? { expectedWarmHost } : {}),
       prepareWorkspace: (a, warmHost) =>

--- a/packages/daemon/src/session/turn/runtime-session.ts
+++ b/packages/daemon/src/session/turn/runtime-session.ts
@@ -37,6 +37,8 @@ export interface OpenRuntimeSessionInput {
   store: OpenerStore
   /** Daemon-verified cwd prepared before handle() (GitHub exact-ref turns). */
   preparedWorkspaceCwd?: string
+  /** The cwd a host bound to this one session launched in — where its runtime session must open. */
+  hostBoundCwd?: string
   /** Pre-host preparation from a cold hostFor; only a shared workspace may consume it. */
   preparedCwd?: string
   /** Ordinary warm host carrying generation identity into the preparation seam. */
@@ -163,6 +165,7 @@ export async function openRuntimeSession(input: OpenRuntimeSessionInput): Promis
   // Use the pre-host preparation when the host was cold, else prepare now (warm host —
   // ordering vs spawn is moot). Only a shared workspace may consume the pre-host cwd.
   const resolveCwd = async (): Promise<string> =>
+    input.hostBoundCwd ??
     input.preparedWorkspaceCwd ??
     (identity.workspaceIsolation === 'shared' ? input.preparedCwd : undefined) ??
     (await abortable(() => input.prepareWorkspace(agent, input.expectedWarmHost), signal))

--- a/packages/daemon/src/skills/offline-sandbox.ts
+++ b/packages/daemon/src/skills/offline-sandbox.ts
@@ -130,7 +130,7 @@ export function offlineSandboxLaunch(opts: {
     ...systemReadRoots,
     ...opts.readRoots.map((path) => realpathSync(resolve(path)))
   ]
-  const settingsPath = writeSandboxSettings(scopeRoot, {
+  const settingsPath = writeSandboxSettings(scopeRoot, 'skills', {
     writable,
     denyRead: ['/'],
     allowRead,

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -476,6 +476,26 @@ export interface TranscriptMutation {
   revision: number
 }
 
+/** What the CP classifies a session's visibility from (session-visibility.md §4.1). */
+export interface SessionClassification {
+  conversationKind?: string
+  tenantScope?: string
+  launchCorrelationId?: string
+  externalProvider?: string
+  externalRealmKey?: string
+  externalResourceKind?: string
+  externalResourceKey?: string
+  externalIntegrationId?: string
+  externalOrigin?: ExternalSessionOrigin
+  sourceBindingKind?: 'local' | 'external'
+  directDestination?: boolean
+}
+
+const CLASSIFICATION_SELECT = `SELECT conversationKind, tenantScope, launchCorrelationId,
+                externalProvider, externalRealmKey, externalResourceKind,
+                externalResourceKey, externalIntegrationId, externalOriginJson,
+                sourceBindingKind, directDestination`
+
 export function sessionKey(
   platform: string,
   channel: string,
@@ -2719,34 +2739,20 @@ export class LocalStore {
   }
 
   /** Read them back by ACP session id, the key the telemetry emitter holds. */
-  async getSessionClassification(
-    agentId: string,
-    acpSessionId: string
-  ): Promise<
-    | {
-        conversationKind?: string
-        tenantScope?: string
-        launchCorrelationId?: string
-        externalProvider?: string
-        externalRealmKey?: string
-        externalResourceKind?: string
-        externalResourceKey?: string
-        externalIntegrationId?: string
-        externalOrigin?: ExternalSessionOrigin
-        sourceBindingKind?: 'local' | 'external'
-        directDestination?: boolean
-      }
-    | undefined
-  > {
-    const row = (await this.db
-      .prepare(
-        `SELECT conversationKind, tenantScope, launchCorrelationId,
-                externalProvider, externalRealmKey, externalResourceKind,
-                externalResourceKey, externalIntegrationId, externalOriginJson,
-                sourceBindingKind, directDestination
-         FROM sessions WHERE agentId = ? AND acpSessionId = ?`
-      )
-      .get(agentId, acpSessionId)) as
+  /** The classification a logical session carries — the read for anything that knows which row it means. */
+  async getSessionClassificationByKey(key: string): Promise<SessionClassification | undefined> {
+    return this.classificationOf(`${CLASSIFICATION_SELECT} FROM sessions WHERE key = ?`, [key])
+  }
+
+  async getSessionClassification(agentId: string, acpSessionId: string): Promise<SessionClassification | undefined> {
+    return this.classificationOf(`${CLASSIFICATION_SELECT} FROM sessions WHERE agentId = ? AND acpSessionId = ?`, [
+      agentId,
+      acpSessionId
+    ])
+  }
+
+  private async classificationOf(sql: string, params: string[]): Promise<SessionClassification | undefined> {
+    const row = (await this.db.prepare(sql).get(...params)) as
       | {
           conversationKind: string | null
           tenantScope: string | null

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -3014,6 +3014,14 @@ export class LocalStore {
     return row?.ts ?? null
   }
 
+  /** One session's own last activity (epoch ms), or null once closed or gone — reaps a session-bound host. */
+  async sessionLastActivityTs(key: string): Promise<number | null> {
+    const row = (await this.db
+      .prepare("SELECT updatedAt AS ts FROM sessions WHERE key = ? AND state != 'closed'")
+      .get(key)) as { ts: number | null } | undefined
+    return row?.ts ?? null
+  }
+
   /** Close expired idle sessions unless daemon-side work exempts them. */
   async closeIdleSessions(
     now: number,

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -3056,13 +3056,15 @@ export class LocalStore {
       ? await Promise.all(candidates.map((r) => isExempt(r.agentId, r.acpSessionId, r.key)))
       : undefined
     const rows = exempt ? candidates.filter((_, i) => !exempt[i]) : candidates
+    // Only the rows this call closed are reported: a candidate a new turn reopened meanwhile is not.
+    const closed: typeof rows = []
     if (rows.length) {
       await this.transaction(async (raw) => {
         const close = accessOf(raw).prepare("UPDATE sessions SET state = 'closed' WHERE key = ? AND state = 'idle'")
-        for (const r of rows) await close.run(r.key)
+        for (const r of rows) if (Number((await close.run(r.key)).changes) === 1) closed.push(r)
       })
     }
-    return rows
+    return closed
   }
 
   /** Retention-GC candidates (#485): sessions whose last activity (`updatedAt`)

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -878,7 +878,7 @@ function restrictPath(path: string, mode: number): void {
  * fresh databases and every established one fails at query time. `SCHEMA_MIGRATIONS`
  * asserts the two stay in lockstep for exactly that reason.
  */
-const SCHEMA_VERSION = 16
+const SCHEMA_VERSION = 17
 
 /**
  * Ordered in-place upgrades for a store created by an EARLIER daemon.
@@ -1026,7 +1026,34 @@ const SCHEMA_MIGRATIONS: ((db: StoreTx, store: { shared: boolean }) => Promise<v
       ALTER TABLE permission_requests ADD COLUMN notifyTs TEXT;
     `),
   // The platform standing block travels with the logical session, not only the message that opened it.
-  async (db) => await db.exec('ALTER TABLE sessions ADD COLUMN platformStanding TEXT')
+  async (db) => await db.exec('ALTER TABLE sessions ADD COLUMN platformStanding TEXT'),
+  // session_gates is keyed by the logical session: with one host per session, siblings of one agent can hold one ACP id.
+  async (db) =>
+    await db.exec(`
+      CREATE TABLE session_gates_by_key (
+        agentId TEXT NOT NULL,
+        sessionKey TEXT NOT NULL,
+        localExcluded INTEGER NOT NULL DEFAULT 1,
+        cpPrivate INTEGER,
+        cpRev INTEGER NOT NULL DEFAULT 0,
+        updatedAt INTEGER,
+        PRIMARY KEY (agentId, sessionKey)
+      );
+      INSERT INTO session_gates_by_key (agentId, sessionKey, localExcluded, cpPrivate, cpRev, updatedAt)
+      SELECT s.agentId, s.key, g.localExcluded, g.cpPrivate, g.cpRev, g.updatedAt
+      FROM session_gates g
+      JOIN sessions s ON s.agentId = g.agentId AND s.acpSessionId = g.acpSessionId;
+      UPDATE session_gates_by_key SET localExcluded = 1, cpPrivate = NULL, cpRev = 0
+      WHERE sessionKey IN (
+        SELECT s.key FROM sessions s
+        JOIN (
+          SELECT agentId, acpSessionId FROM sessions
+          WHERE acpSessionId IS NOT NULL GROUP BY agentId, acpSessionId HAVING COUNT(*) > 1
+        ) d ON d.agentId = s.agentId AND d.acpSessionId = s.acpSessionId
+      );
+      DROP TABLE session_gates;
+      ALTER TABLE session_gates_by_key RENAME TO session_gates;
+    `)
 ]
 
 // The list and the version are two halves of one fact: step `i` moves a database from
@@ -1160,12 +1187,12 @@ export class LocalStore {
       -- (localExcluded, not "excluded": SQLite's upsert pseudo-table owns that name.)
       CREATE TABLE IF NOT EXISTS session_gates (
         agentId TEXT NOT NULL,
-        acpSessionId TEXT NOT NULL,
+        sessionKey TEXT NOT NULL,
         localExcluded INTEGER NOT NULL DEFAULT 1,
         cpPrivate INTEGER,
         cpRev INTEGER NOT NULL DEFAULT 0,
         updatedAt INTEGER,
-        PRIMARY KEY (agentId, acpSessionId)
+        PRIMARY KEY (agentId, sessionKey)
       );
       -- Latest-wins session metadata awaiting a correlated CP persistence ACK.
       -- This is deliberately separate from sessions: an upgrade starts with an
@@ -2542,15 +2569,15 @@ export class LocalStore {
 
   /** Seed the local verdict for a session the daemon just created. Never lowers
    *  `cpRev`: a CP push that arrived first stays authoritative. */
-  async setLocalCaptureGate(agentId: string, acpSessionId: string, localExcluded: boolean): Promise<void> {
+  async setLocalCaptureGate(agentId: string, sessionKey: string, localExcluded: boolean): Promise<void> {
     await this.db
       .prepare(
-        `INSERT INTO session_gates (agentId, acpSessionId, localExcluded, cpRev, updatedAt)
+        `INSERT INTO session_gates (agentId, sessionKey, localExcluded, cpRev, updatedAt)
          VALUES (?, ?, ?, 0, ?)
-         ON CONFLICT(agentId, acpSessionId) DO UPDATE SET
+         ON CONFLICT(agentId, sessionKey) DO UPDATE SET
            localExcluded = excluded.localExcluded, updatedAt = excluded.updatedAt`
       )
-      .run(agentId, acpSessionId, localExcluded ? 1 : 0, Date.now())
+      .run(agentId, sessionKey, localExcluded ? 1 : 0, Date.now())
   }
 
   /**
@@ -2564,7 +2591,7 @@ export class LocalStore {
    */
   async applyCpCaptureGate(
     agentId: string,
-    acpSessionId: string,
+    sessionKey: string,
     isPrivate: boolean,
     rev: number
   ): Promise<'applied' | 'superseded'> {
@@ -2573,14 +2600,14 @@ export class LocalStore {
     const changes = (
       await this.db
         .prepare(
-          `INSERT INTO session_gates (agentId, acpSessionId, localExcluded, cpPrivate, cpRev, updatedAt)
+          `INSERT INTO session_gates (agentId, sessionKey, localExcluded, cpPrivate, cpRev, updatedAt)
          VALUES (?, ?, ?, ?, ?, ?)
-         ON CONFLICT(agentId, acpSessionId) DO UPDATE SET
+         ON CONFLICT(agentId, sessionKey) DO UPDATE SET
            cpPrivate = excluded.cpPrivate, cpRev = excluded.cpRev, updatedAt = excluded.updatedAt
          WHERE session_gates.cpRev < excluded.cpRev
             OR (excluded.cpRev = 0 AND session_gates.cpRev = 0)`
         )
-        .run(agentId, acpSessionId, isPrivate ? 1 : 0, isPrivate ? 1 : 0, rev, Date.now())
+        .run(agentId, sessionKey, isPrivate ? 1 : 0, isPrivate ? 1 : 0, rev, Date.now())
     ).changes
     return Number(changes) > 0 ? 'applied' : 'superseded'
   }
@@ -2602,8 +2629,8 @@ export class LocalStore {
    * we have one; otherwise the local verdict; otherwise excluded. An A2A child
    * therefore starts closed and only a CP-confirmed `org` state opens it.
    */
-  async isCaptureExcluded(agentId: string, acpSessionId: string | undefined): Promise<boolean> {
-    if (!acpSessionId) return true
+  async isCaptureExcluded(agentId: string, sessionKey: string | undefined): Promise<boolean> {
+    if (!sessionKey) return true
     // External-source binding (a Slack/Feishu channel = external identity domain)
     // no longer forces memory exclusion: such channels behave like any other
     // channel (Discord/Telegram already did), gated only by the local verdict and
@@ -2611,8 +2638,8 @@ export class LocalStore {
     // §5.1). DM / webchat / A2A / launch-correlated sessions stay private through
     // those same layers.
     const row = (await this.db
-      .prepare('SELECT localExcluded, cpPrivate FROM session_gates WHERE agentId = ? AND acpSessionId = ?')
-      .get(agentId, acpSessionId)) as { localExcluded: number; cpPrivate: number | null } | undefined
+      .prepare('SELECT localExcluded, cpPrivate FROM session_gates WHERE agentId = ? AND sessionKey = ?')
+      .get(agentId, sessionKey)) as { localExcluded: number; cpPrivate: number | null } | undefined
     if (!row) return true
     if (row.cpPrivate !== null) return row.cpPrivate === 1
     return row.localExcluded === 1
@@ -3149,9 +3176,7 @@ export class LocalStore {
         await tx
           .prepare('DELETE FROM session_metadata_outbox WHERE agentId = ? AND sessionId = ?')
           .run(rec.agentId, outward)
-        await tx
-          .prepare('DELETE FROM session_gates WHERE agentId = ? AND acpSessionId = ?')
-          .run(rec.agentId, rec.acpSessionId)
+        await tx.prepare('DELETE FROM session_gates WHERE agentId = ? AND sessionKey = ?').run(rec.agentId, rec.key)
         await tx
           .prepare('DELETE FROM permission_requests WHERE agentId = ? AND sessionId = ?')
           .run(rec.agentId, rec.acpSessionId)

--- a/packages/daemon/src/store/session-metadata-outbox.ts
+++ b/packages/daemon/src/store/session-metadata-outbox.ts
@@ -127,7 +127,9 @@ export class SessionMetadataOutbox {
     // Visibility-classification inputs (session-visibility.md §4.1), read from
     // the session row so every re-emit carries them. Absent fields make the CP
     // fail closed (no owner) rather than guess — never send a placeholder.
-    const classification = await store.getSessionClassification(input.agentId, input.sessionId)
+    // By the logical session, never the ACP pair: sibling session hosts can share one runtime-local id.
+    const classificationKey = input.sessionKey ?? slot?.key
+    const classification = classificationKey ? await store.getSessionClassificationByKey(classificationKey) : undefined
     if (classification?.conversationKind !== undefined) {
       event.conversationKind = classification.conversationKind as EventSession['conversationKind']
     }
@@ -465,6 +467,7 @@ export class SessionMetadataOutbox {
       if (row.channel !== id && row.triggeredBy !== id) continue
       await this.emitSessionMetadataSnapshot({
         sessionId: row.acpSessionId,
+        sessionKey: row.key,
         agentId: row.agentId,
         phase: 'plan',
         platform: row.platform as SessionKey['platform'],

--- a/packages/daemon/src/store/session-metadata-outbox.ts
+++ b/packages/daemon/src/store/session-metadata-outbox.ts
@@ -47,6 +47,8 @@ export interface SessionMetadataHost {
 
 export interface SessionMetadataSnapshotInput {
   sessionId: string
+  /** The logical session; with one host per session an ACP id alone can name a sibling's row. */
+  sessionKey?: string
   agentId: string
   phase: EventSession['phase']
   platform: SessionKey['platform']
@@ -101,7 +103,9 @@ export class SessionMetadataOutbox {
     if (!cpClient && !this.host.controlPlaneConfigured()) return
     const now = new Date(this.host.clock().now()).toISOString()
     // Callers hold the ACP hop's id; the wire carries the session's outward one (§1.1).
-    const slot = await store.getSessionByAcpIdForAgent(input.agentId, input.sessionId)
+    const slot = input.sessionKey
+      ? await store.getSession(input.sessionKey)
+      : await store.getSessionByAcpIdForAgent(input.agentId, input.sessionId)
     // An unresolvable slot keeps the id it was given — the same thing a pre-v12 daemon would have sent.
     const outwardSessionId =
       slot?.sessionId ??
@@ -174,7 +178,7 @@ export class SessionMetadataOutbox {
     const allowRuntimeChangesInChat = agent?.allowRuntimeChangesInChat === true
     if (input.runtime !== undefined) event.runtime = input.runtime
     else if (agent?.runtime) event.runtime = agent.runtime
-    const sessionRecord = await store.getSessionByAcpIdForAgent(input.agentId, input.sessionId)
+    const sessionRecord = slot
     if (sessionRecord?.workspaceIsolation) event.workspaceIsolation = sessionRecord.workspaceIsolation
     const storeKey = sessionRecord?.key
     const configuredModel =

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -1,3 +1,4 @@
+import { agentHostKey } from '../src/acp/host-key.js'
 import { DatabaseSync } from 'node:sqlite'
 import { describe, expect, it, vi } from 'vitest'
 import type { RequestPermissionRequest } from '@agentclientprotocol/sdk'
@@ -8,6 +9,7 @@ import { SqliteAsyncDatabase } from '../src/store/sqlite-async-database.js'
 import { pendingTurnKey, type Pending } from '../src/daemon/turn-types.js'
 
 const AGENT = 'bot-a'
+const OWNER = agentHostKey(AGENT)
 const ACP_SESSION = 'acp-1'
 const TARGET = { integrationId: 'int-1', teamId: 'T1', userId: 'U1', consoleUserId: 'cu-1', displayName: 'Ada' }
 
@@ -62,11 +64,12 @@ async function world(over?: {
     },
     approval: { waitMs: 0, depth: 0 },
     acpSessionId: ACP_SESSION,
+    hostKey: OWNER,
     outwardSessionId: 'outward-1',
     builtinSystemToolCallIds: new Set<string>(),
     entry: { msg: { text: 'please run ls /' } }
   } as unknown as Pending
-  pending.set(pendingTurnKey(AGENT, ACP_SESSION), p)
+  pending.set(pendingTurnKey(OWNER, ACP_SESSION), p)
   const host: PermissionHost = {
     log: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) as never,
     clock: () => ({ now: () => Date.now() }) as never,
@@ -100,7 +103,7 @@ const requestIdOf = (route: ReturnType<typeof vi.fn>): string =>
 describe('approval DM (slack-approval-dm.md §5–§6)', () => {
   it('routes, DMs the target, and resolves on the verified target click', async () => {
     const w = await world({ platform: 'slack', requesterId: 'U1' })
-    const decided = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    const decided = w.coordinator.onAcpPermission(OWNER, ACP_SESSION, permissionParams())
     await vi.waitFor(() => expect(w.conn.postBlocks).toHaveBeenCalledTimes(1))
     expect(w.conn.openDirectMessage).toHaveBeenCalledWith('U1')
     // Top-level message: no thread ts.
@@ -111,12 +114,12 @@ describe('approval DM (slack-approval-dm.md §5–§6)', () => {
     expect(posted).toContain('> please run ls /')
     // A recipient who is NOT the author never receives the text (Slack ACL stays intact).
     const other = await world({ platform: 'slack', requesterId: 'U-someone-else' })
-    void other.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    void other.coordinator.onAcpPermission(OWNER, ACP_SESSION, permissionParams())
     await vi.waitFor(() => expect(other.conn.postBlocks).toHaveBeenCalledTimes(1))
     const otherPosted = JSON.stringify((other.conn.postBlocks.mock.calls[0] as unknown[])[1])
     expect(otherPosted).toContain('https://console.example/sessions/outward-1')
     expect(otherPosted).not.toContain('please run ls /')
-    await other.coordinator.releaseEditorPermissions(AGENT, ACP_SESSION)
+    await other.coordinator.releaseEditorPermissions(OWNER, ACP_SESSION)
     await other.store.close()
     const requestId = requestIdOf(w.route)
 
@@ -136,7 +139,7 @@ describe('approval DM (slack-approval-dm.md §5–§6)', () => {
 
   it('refuses a wrong actor and an unanswerable verify without settling the request', async () => {
     const w = await world()
-    const decided = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    const decided = w.coordinator.onAcpPermission(OWNER, ACP_SESSION, permissionParams())
     await vi.waitFor(() => expect(w.conn.postBlocks).toHaveBeenCalledTimes(1))
     const requestId = requestIdOf(w.route)
 
@@ -180,7 +183,7 @@ describe('approval DM (slack-approval-dm.md §5–§6)', () => {
   it("leaves today's behavior intact when the CP answers no target", async () => {
     const route = vi.fn(async (payload: { requestId: string }) => ({ requestId: payload.requestId }))
     const w = await world({ route })
-    const decided = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    const decided = w.coordinator.onAcpPermission(OWNER, ACP_SESSION, permissionParams())
     await vi.waitFor(() => expect(route).toHaveBeenCalledTimes(1))
     expect(w.conn.openDirectMessage).not.toHaveBeenCalled()
     const requestId = requestIdOf(route)
@@ -191,9 +194,9 @@ describe('approval DM (slack-approval-dm.md §5–§6)', () => {
 
   it('release retires the DM card and cancels the request', async () => {
     const w = await world()
-    const decided = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    const decided = w.coordinator.onAcpPermission(OWNER, ACP_SESSION, permissionParams())
     await vi.waitFor(() => expect(w.conn.postBlocks).toHaveBeenCalledTimes(1))
-    await w.coordinator.releaseEditorPermissions(AGENT, ACP_SESSION)
+    await w.coordinator.releaseEditorPermissions(OWNER, ACP_SESSION)
     await expect(decided).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
     expect(w.conn.updateBlocks).toHaveBeenCalledTimes(1)
     expect((await w.store.listPermissionRequests(AGENT))[0]!.status).toBe('expired')
@@ -205,12 +208,12 @@ describe('approval activity (slack-approval-dm.md §7)', () => {
   it('flips awaiting_permission on the first park, idle on the last release, and never in between', async () => {
     const activity = vi.fn()
     const w = await world({ activity })
-    const first = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    const first = w.coordinator.onAcpPermission(OWNER, ACP_SESSION, permissionParams())
     await vi.waitFor(() => expect(w.route).toHaveBeenCalledTimes(1))
     expect(activity).toHaveBeenCalledTimes(1)
-    expect(activity).toHaveBeenLastCalledWith(AGENT, ACP_SESSION, 'awaiting_permission')
+    expect(activity).toHaveBeenLastCalledWith(OWNER, ACP_SESSION, 'awaiting_permission')
 
-    const second = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
+    const second = w.coordinator.onAcpPermission(OWNER, ACP_SESSION, permissionParams())
     await vi.waitFor(() => expect(w.route).toHaveBeenCalledTimes(2))
     // A second request on an already-waiting session is not news to the console.
     expect(activity).toHaveBeenCalledTimes(1)
@@ -224,29 +227,29 @@ describe('approval activity (slack-approval-dm.md §7)', () => {
     await w.coordinator.decideEditorPermission({ agentId: AGENT, requestId: secondId!, decision: 'deny' })
     await expect(second).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'o-deny' } })
     expect(activity).toHaveBeenCalledTimes(2)
-    expect(activity).toHaveBeenLastCalledWith(AGENT, ACP_SESSION, 'idle')
+    expect(activity).toHaveBeenLastCalledWith(OWNER, ACP_SESSION, 'idle')
     await w.store.close()
   })
 
   it('clears the wait when the turn is cancelled, and replays only live waits on reconnect', async () => {
     const activity = vi.fn()
     const w = await world({ activity })
-    const parked = w.coordinator.onAcpPermission(AGENT, ACP_SESSION, permissionParams())
-    await vi.waitFor(() => expect(activity).toHaveBeenCalledWith(AGENT, ACP_SESSION, 'awaiting_permission'))
+    const parked = w.coordinator.onAcpPermission(OWNER, ACP_SESSION, permissionParams())
+    await vi.waitFor(() => expect(activity).toHaveBeenCalledWith(OWNER, ACP_SESSION, 'awaiting_permission'))
 
-    expect(w.coordinator.isAwaitingApproval(AGENT, ACP_SESSION)).toBe(true)
-    expect(w.coordinator.isAwaitingApproval(AGENT, 'acp-other')).toBe(false)
+    expect(w.coordinator.isAwaitingApproval(OWNER, ACP_SESSION)).toBe(true)
+    expect(w.coordinator.isAwaitingApproval(OWNER, 'acp-other')).toBe(false)
 
     // The CP forgot this daemon's waits on disconnect: the replay re-asserts the live one.
     activity.mockClear()
     w.coordinator.replayApprovalActivity()
     expect(activity).toHaveBeenCalledTimes(1)
-    expect(activity).toHaveBeenLastCalledWith(AGENT, ACP_SESSION, 'awaiting_permission')
+    expect(activity).toHaveBeenLastCalledWith(OWNER, ACP_SESSION, 'awaiting_permission')
 
-    await w.coordinator.releaseEditorPermissions(AGENT, ACP_SESSION)
+    await w.coordinator.releaseEditorPermissions(OWNER, ACP_SESSION)
     await expect(parked).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
-    expect(activity).toHaveBeenLastCalledWith(AGENT, ACP_SESSION, 'idle')
-    expect(w.coordinator.isAwaitingApproval(AGENT, ACP_SESSION)).toBe(false)
+    expect(activity).toHaveBeenLastCalledWith(OWNER, ACP_SESSION, 'idle')
+    expect(w.coordinator.isAwaitingApproval(OWNER, ACP_SESSION)).toBe(false)
 
     // Nothing is waiting any more, so a reconnect replays nothing.
     activity.mockClear()

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { AGENT_WAKE_FEATURE, DAEMON_BOOTSTRAP_UPGRADE_FEATURE } from '@agentconnect.md/protocol'
 import { Daemon } from '../src/daemon.js'
+import { agentHostKey } from '../src/acp/host-key.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 import { LocalStore } from '../src/store/local-store.js'
 import { mcpSocketPath, statePath } from '../src/paths.js'
@@ -124,6 +125,32 @@ function daemon(opts: {
 }
 
 describe('daemon --k8s mode', () => {
+  it('keeps one ACP host per agent: a pool launch dials one sandbox pod, whatever mechanism this host has', async () => {
+    const instance = daemon({ root: root(), k8s: true })
+    try {
+      await instance.start()
+      // The mode never turns the in-process mechanism on; force it so the `!k8s` half of the
+      // per-session-host predicate is what keeps the shared host, not the mechanism rule.
+      ;(instance as any).sandboxMechanism = 'bwrap'
+      const agent = {
+        id: 'bot-a',
+        name: 'bot-a',
+        status: 'active',
+        runtime: 'claude',
+        runInSandbox: true,
+        workspace: { mode: 'from-scratch', path: '/agents/bot-a/workspace' },
+        integrations: [],
+        output: { mode: 'medium' }
+      }
+      ;(instance as any).agents.set('bot-a', agent)
+      expect((instance as any).agentRunsInSandbox(agent)).toBe(true)
+      expect((instance as any).perSessionHost(agent)).toBe(false)
+      expect((instance as any).hostKeyFor('bot-a', 'slack:C1:T1:bot-a')).toBe(agentHostKey('bot-a'))
+    } finally {
+      await instance.stop()
+    }
+  })
+
   it('does not inspect or open the PostgreSQL data plane outside k8s mode', async () => {
     const openDataPlane = vi.fn()
     const local = daemon({ root: root(), k8s: false, openDataPlane })

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -128,6 +128,7 @@ function installPending(daemon: Daemon): {
       statusThread: 'test',
       approvalSurfaceSuppressed: false
     },
+    hostKey: 'agent-1',
     chrome: {},
     reply: { text: '', attemptText: '', attemptAnswerUpdates: [] },
     signals: { applyChain: Promise.resolve() },

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -8,7 +8,9 @@ import { agentHostKey, hostKeyDirName, sessionHostKey } from '../src/acp/host-ke
 import { sandboxSettingsDir } from '../src/acp/sandbox.js'
 import { prepareRuntimeLaunch } from '../src/launch/prepare.js'
 import { sessionKey } from '../src/store/local-store.js'
+import { pendingTurnKey, sdkLeaseKey } from '../src/daemon/turn-types.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { WAIT } from './wait-support.js'
 
 /** git-workspace-model §11: a confined self-hosted session gets its own ACP host; nothing else does. */
 
@@ -293,5 +295,133 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     expect(sid).toBe(await persisted)
     expect(cwd).toBe((second.daemon as any).hostLaunch.get(key).cwd)
     await second.daemon.stop()
+  })
+
+  it('files turns, updates and cancellation under the owning host when two session hosts mint the same ACP id', async () => {
+    const root = scaffold()
+    const updates: ((sid: string, update: unknown) => void)[] = []
+    const releases: (() => void)[] = []
+    const hosts: { cancel: ReturnType<typeof vi.fn> }[] = []
+    const factory = vi.fn((_agent: unknown, onUpdate: (sid: string, update: unknown) => void) => {
+      updates.push(onUpdate)
+      let release!: () => void
+      const blocked = new Promise<void>((resolve) => (release = resolve))
+      releases.push(release)
+      const host = {
+        start: vi.fn(async () => {}),
+        // Runtime-local ids: every child of this agent answers `acp-1`.
+        newSession: vi.fn(async () => 'acp-1'),
+        hasSession: vi.fn((sid: string) => sid === 'acp-1'),
+        prompt: vi.fn(async () => {
+          await blocked
+          return { stopReason: 'end_turn' }
+        }),
+        cancel: vi.fn(async () => {}),
+        stop: vi.fn(async () => {})
+      }
+      hosts.push(host)
+      return host as never
+    })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      hostFactory: factory as never,
+      sandboxMechanism: 'bwrap'
+    })
+    await daemon.start()
+    makeRoutable(daemon)
+    const one = (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    const two = (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+    await vi.waitFor(() => expect((daemon as any).pending.size).toBe(2), WAIT)
+    const first = sessionHostKey('bot-a', KEY('T1'))
+    const second = sessionHostKey('bot-a', KEY('T2'))
+    expect((daemon as any).pending.get(pendingTurnKey(first, 'acp-1')).plan.sessionKey).toBe(KEY('T1'))
+    expect((daemon as any).pending.get(pendingTurnKey(second, 'acp-1')).plan.sessionKey).toBe(KEY('T2'))
+    // An update from a child lands on that child's session, never on the sibling that shares the id.
+    await updates[1]!('acp-1', { sessionUpdate: 'session_info_update', title: 'second' })
+    await updates[0]!('acp-1', { sessionUpdate: 'session_info_update', title: 'first' })
+    expect((await (daemon as any).store.getSession(KEY('T1')))?.title).toBe('first')
+    expect((await (daemon as any).store.getSession(KEY('T2')))?.title).toBe('second')
+    // Cancelling the second session reaches its own child.
+    await (daemon as any).interruptTurn('bot-a', KEY('T2'), 'stop', undefined, {})
+    expect(hosts[1]!.cancel).toHaveBeenCalledWith('acp-1')
+    expect(hosts[0]!.cancel).not.toHaveBeenCalled()
+    for (const release of releases) release()
+    await Promise.all([one, two])
+    await daemon.stop()
+  })
+
+  it('a stale idle-close decision does not evict the host a reopened session was admitted on', async () => {
+    const { daemon, hosts } = await startDaemon(scaffold())
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    const key = sessionHostKey('bot-a', KEY('T1'))
+    expect((daemon as any).hosts.get(key)).toBe(hosts[0])
+    const store = (daemon as any).store
+    // The sweep decides against the first host; before its stop runs, the key is reopened on a replacement.
+    const closeIdle = vi.spyOn(store, 'closeIdleSessions').mockImplementation(async () => {
+      await (daemon as any).stopHostByKey(key)
+      await (daemon as any).dispatch('bot-a', dm('200', 'again', 'T1'), 'int-a')
+      return [{ key: KEY('T1'), agentId: 'bot-a', platform: 'slack', channel: 'C1', thread: 'T1', acpSessionId: null }]
+    })
+    await (daemon as any).sweepIdle()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    closeIdle.mockRestore()
+    expect(hosts).toHaveLength(2)
+    expect(hosts[0]!.stop).toHaveBeenCalledTimes(1)
+    expect(hosts[1]!.stop).not.toHaveBeenCalled()
+    expect((daemon as any).hosts.get(key)).toBe(hosts[1])
+    await daemon.stop()
+  })
+
+  it('closeIdleSessions reports only the rows it closed, not a candidate a turn reopened meanwhile', async () => {
+    const { daemon } = await startDaemon(scaffold())
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    const store = (daemon as any).store
+    expect((await store.getSession(KEY('T1')))?.state).toBe('idle')
+    const closed = await store.closeIdleSessions(
+      Date.now() + 60_000,
+      1,
+      async (_agentId: string, _acp: unknown, key: string) => {
+        await store.setSessionState(key, 'prompting', Date.now())
+        return false
+      }
+    )
+    expect(closed).toEqual([])
+    expect((await store.getSession(KEY('T1')))?.state).toBe('prompting')
+    await daemon.stop()
+  })
+
+  it('reaping the shared utility host leaves a sibling session host its lease and binding', async () => {
+    const { daemon, hosts } = await startDaemon(scaffold())
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    await (daemon as any).ensureHostAsync(agentHostKey('bot-a'))
+    const sessionHost = sessionHostKey('bot-a', KEY('T1'))
+    const sid = (await hosts[0]!.newSession.mock.results[0]!.value) as string
+    const lease = {
+      agentId: 'bot-a',
+      tasks: new Map(),
+      settled: [],
+      sdkState: 'idle',
+      bgWakes: 0,
+      armedWakes: 0,
+      deliveringWakes: 0,
+      drainText: '',
+      drainDeliveries: 0
+    }
+    ;(daemon as any).sdkLease.set(sdkLeaseKey(sessionHost, sid), lease)
+    ;(daemon as any).sessionDeliveryBindings.set(KEY('T1'), { agentId: 'bot-a', platform: 'slack', isDm: true })
+
+    await (daemon as any).stopHostByKey(agentHostKey('bot-a'))
+    expect(hosts[1]!.stop).toHaveBeenCalledTimes(1)
+    expect(hosts[0]!.stop).not.toHaveBeenCalled()
+    expect((daemon as any).sdkLease.has(sdkLeaseKey(sessionHost, sid))).toBe(true)
+    expect((daemon as any).sessionDeliveryBindings.has(KEY('T1'))).toBe(true)
+
+    // The agent-wide teardown is where every session's state goes.
+    await (daemon as any).stopHost('bot-a')
+    expect(hosts[0]!.stop).toHaveBeenCalledTimes(1)
+    expect((daemon as any).sdkLease.size).toBe(0)
+    expect((daemon as any).sessionDeliveryBindings.has(KEY('T1'))).toBe(false)
+    await daemon.stop()
   })
 })

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { Daemon } from '../src/daemon.js'
+import { agentHostKey, hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
+import { sandboxSettingsDir } from '../src/acp/sandbox.js'
+import { prepareRuntimeLaunch } from '../src/launch/prepare.js'
+import { sessionKey } from '../src/store/local-store.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+
+/** git-workspace-model §11: a confined self-hosted session gets its own ACP host; nothing else does. */
+
+const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
+const KEY = (thread: string) => sessionKey('slack', 'C1', thread, 'bot-a', TRANSPORT_SCOPE)
+
+function scaffold(agent: Record<string, unknown> = {}): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-session-hosts-'))
+  writeFileSync(
+    join(root, 'config.json'),
+    JSON.stringify({
+      version: 1,
+      controlPlane: { enabled: false },
+      runtimes: { claude: { command: 'node', args: ['unused'] } }
+    })
+  )
+  const adir = join(root, 'agents', 'bot-a')
+  mkdirSync(adir, { recursive: true })
+  writeFileSync(
+    join(adir, 'agent.json'),
+    JSON.stringify({
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: 'claude',
+      runInSandbox: true,
+      workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+      integrations: [],
+      output: { mode: 'medium' },
+      ...agent
+    })
+  )
+  return root
+}
+
+/** A fake adapter that knows which ACP sessions it holds, so resume-after-restart takes the load path. */
+function fakeHost(id: number) {
+  const live = new Set<string>()
+  let minted = 0
+  return {
+    start: vi.fn(async () => {}),
+    newSession: vi.fn(async () => {
+      const sid = `acp-${id}-${++minted}`
+      live.add(sid)
+      return sid
+    }),
+    hasSession: vi.fn((sid: string) => live.has(sid)),
+    loadSupported: vi.fn(() => true),
+    loadSession: vi.fn(async (sid: string) => {
+      live.add(sid)
+    }),
+    prompt: vi.fn(async () => 'end_turn'),
+    cancel: vi.fn(async () => {}),
+    stop: vi.fn(async () => {})
+  }
+}
+
+function hostFactory() {
+  const hosts: ReturnType<typeof fakeHost>[] = []
+  const factory = vi.fn(() => {
+    const host = fakeHost(hosts.length + 1)
+    hosts.push(host)
+    return host as never
+  })
+  return { hosts, factory }
+}
+
+function makeRoutable(daemon: Daemon): void {
+  const agent = (daemon as any).agents.get('bot-a')
+  agent.integrations = [
+    {
+      id: 'int-a',
+      platform: 'slack',
+      core: { bindRules: [{ match: { kind: 'dm' } }] },
+      config: { botToken: 'b', appToken: 'p' }
+    }
+  ]
+  let post = 0
+  ;(daemon as any).connByIntegration.set('int-a', {
+    workspaceId: vi.fn(() => 'T1'),
+    setStatus: vi.fn(async () => {}),
+    setTitle: vi.fn(async () => {}),
+    postMessage: vi.fn(async () => `ts-${++post}`),
+    updateBlocks: vi.fn(async () => true),
+    finalizeResponse: vi.fn(async () => true)
+  })
+}
+
+const dm = (ts: string, text: string, thread: string) => ({
+  msgId: `slack:C1:${ts}`,
+  traceId: ts,
+  source: 'user' as const,
+  platform: 'slack' as const,
+  channel: 'C1',
+  thread,
+  transportScope: TRANSPORT_SCOPE,
+  sender: { id: 'U1', isBot: false },
+  text,
+  mentionedBots: [] as string[],
+  isDm: true,
+  trigger: 'dm' as const
+})
+
+async function startDaemon(root: string, opts: { sandboxMechanism?: 'bwrap' | null } = {}) {
+  const { hosts, factory } = hostFactory()
+  const daemon = new Daemon({
+    slackAppFactory: fakeSlackAppFactory(),
+    root,
+    hostFactory: factory,
+    sandboxMechanism: opts.sandboxMechanism === undefined ? 'bwrap' : opts.sandboxMechanism
+  })
+  await daemon.start()
+  makeRoutable(daemon)
+  return { daemon, hosts, factory }
+}
+
+describe('one ACP host per session under a confined self-hosted launch', () => {
+  it('keys the host by (agent, session) and launches it in the session directory prepared before the spawn', async () => {
+    const { daemon, hosts, factory } = await startDaemon(scaffold())
+    const prepare = vi.spyOn(daemon as any, 'runAgentWorkspacePreparation')
+    // What preparation had seen by the time each host was constructed — the session request must be there.
+    const requestsAtConstruction: unknown[][] = []
+    factory.mockImplementation(() => {
+      requestsAtConstruction.push(prepare.mock.calls.map((call) => call[1]))
+      const host = fakeHost(hosts.length + 1)
+      hosts.push(host)
+      return host as never
+    })
+
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    await (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+
+    const first = sessionHostKey('bot-a', KEY('T1'))
+    const second = sessionHostKey('bot-a', KEY('T2'))
+    expect(factory).toHaveBeenCalledTimes(2)
+    expect([...(daemon as any).hosts.keys()].sort()).toEqual([first, second].sort())
+    expect((daemon as any).hosts.get(agentHostKey('bot-a'))).toBeUndefined()
+    expect((daemon as any).hosts.get(first)).toBe(hosts[0])
+    expect((daemon as any).hosts.get(second)).toBe(hosts[1])
+    expect(hosts[0]!.newSession).toHaveBeenCalledTimes(1)
+    expect(hosts[1]!.newSession).toHaveBeenCalledTimes(1)
+    // Reordered for this shape only: the session workspace is prepared before its host exists.
+    expect(requestsAtConstruction[0]!.at(-1)).toMatchObject({ sessionKey: KEY('T1') })
+    expect(requestsAtConstruction[1]!.at(-1)).toMatchObject({ sessionKey: KEY('T2') })
+    // The runtime session opens exactly where its host launched.
+    for (const [index, key] of [first, second].entries()) {
+      const launch = (daemon as any).hostLaunch.get(key)
+      expect(launch.cwd).toBeTypeOf('string')
+      expect((hosts[index]!.newSession.mock.calls[0] as unknown as [string])[0]).toBe(launch.cwd)
+    }
+    await daemon.stop()
+  })
+
+  it('keeps one host per agent when the launch is not confined', async () => {
+    const { daemon, hosts, factory } = await startDaemon(scaffold({ runInSandbox: false }))
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    await (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+    expect(factory).toHaveBeenCalledTimes(1)
+    expect([...(daemon as any).hosts.keys()]).toEqual([agentHostKey('bot-a')])
+    expect(hosts[0]!.newSession).toHaveBeenCalledTimes(2)
+    await daemon.stop()
+  })
+
+  it('keeps one host per agent when the sandbox is requested but this host has no mechanism', async () => {
+    const { daemon, hosts, factory } = await startDaemon(scaffold(), { sandboxMechanism: null })
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    await (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+    expect(factory).toHaveBeenCalledTimes(1)
+    expect([...(daemon as any).hosts.keys()]).toEqual([agentHostKey('bot-a')])
+    expect(hosts[0]!.newSession).toHaveBeenCalledTimes(2)
+    await daemon.stop()
+  })
+
+  it('stops every host of the agent on stopHost and on a spawn-signature eviction', async () => {
+    const root = scaffold()
+    const { daemon, hosts, factory } = await startDaemon(root)
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    await (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+    expect((daemon as any).hosts.size).toBe(2)
+
+    await (daemon as any).stopHost('bot-a')
+    expect(hosts[0]!.stop).toHaveBeenCalledTimes(1)
+    expect(hosts[1]!.stop).toHaveBeenCalledTimes(1)
+    expect((daemon as any).hosts.size).toBe(0)
+    expect((daemon as any).hostLaunch.size).toBe(0)
+
+    await (daemon as any).dispatch('bot-a', dm('300', 'three', 'T1'), 'int-a')
+    await (daemon as any).dispatch('bot-a', dm('400', 'four', 'T2'), 'int-a')
+    expect(factory).toHaveBeenCalledTimes(4)
+    expect((daemon as any).hosts.size).toBe(2)
+    // The reconciler's hostSpawnSig eviction (description is in the signature) reaches every host too.
+    const path = join(root, 'agents', 'bot-a', 'agent.json')
+    writeFileSync(path, JSON.stringify({ ...JSON.parse(readFileSync(path, 'utf8')), description: 'respawn me' }))
+    await daemon.reconcile()
+    expect(hosts[2]!.stop).toHaveBeenCalledTimes(1)
+    expect(hosts[3]!.stop).toHaveBeenCalledTimes(1)
+    expect((daemon as any).hosts.size).toBe(0)
+    await daemon.stop()
+  })
+
+  it('gives each host its own sandbox policy directory and removes it with the host', async () => {
+    const root = scaffold()
+    const { daemon } = await startDaemon(root)
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    await (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+    const agentDir = join(root, 'agents', 'bot-a')
+    const first = sessionHostKey('bot-a', KEY('T1'))
+    const second = sessionHostKey('bot-a', KEY('T2'))
+    expect(hostKeyDirName(first)).not.toBe(hostKeyDirName(second))
+    // The injected host factory writes no policy; stand in for what a real launch leaves behind.
+    for (const key of [first, second]) {
+      mkdirSync(sandboxSettingsDir(agentDir, hostKeyDirName(key)), { recursive: true })
+      writeFileSync(join(sandboxSettingsDir(agentDir, hostKeyDirName(key)), 'settings.json'), '{}')
+    }
+    await (daemon as any).stopHostByKey(first)
+    expect(existsSync(sandboxSettingsDir(agentDir, hostKeyDirName(first)))).toBe(false)
+    expect(existsSync(join(sandboxSettingsDir(agentDir, hostKeyDirName(second)), 'settings.json'))).toBe(true)
+    expect((daemon as any).hosts.has(second)).toBe(true)
+    await daemon.stop()
+    expect(existsSync(sandboxSettingsDir(agentDir, hostKeyDirName(second)))).toBe(false)
+  })
+
+  it('launch preparation writes two concurrent session hosts two policies, each anchored on its session cwd', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-session-hosts-launch-'))
+    const scopeDir = join(root, 'agent')
+    const hostHome = join(root, 'host-home')
+    mkdirSync(hostHome)
+    const launches = ['s1', 's2'].map((session) => {
+      const cwd = join(scopeDir, 'sessions', session, 'workspace')
+      mkdirSync(cwd, { recursive: true })
+      const key = sessionHostKey('bot-a', `slack:C1:${session}:bot-a`)
+      const launch = prepareRuntimeLaunch({
+        runtimeId: 'claude',
+        runtime: { command: 'npx', args: ['claude-agent-acp'], env: [] },
+        scopeDir,
+        cwd,
+        hostKey: key,
+        runInSandbox: true,
+        daemonRoot: dirname(scopeDir),
+        sandboxMechanism: 'bwrap',
+        credentialPlatform: 'linux',
+        explicitEnv: {},
+        hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+      })
+      return { key, cwd: realpathSync(cwd), launch }
+    })
+    const [one, two] = launches as [(typeof launches)[number], (typeof launches)[number]]
+    expect(one.launch.sandbox!.settingsPath).not.toBe(two.launch.sandbox!.settingsPath)
+    for (const { key, cwd, launch } of launches) {
+      const sandbox = launch.sandbox!
+      expect(sandbox.settingsPath).toBe(
+        join(realpathSync(sandboxSettingsDir(scopeDir, hostKeyDirName(key))), 'settings.json')
+      )
+      expect(existsSync(sandbox.settingsPath)).toBe(true)
+      // The outer provider needs the launch cwd as a write root and Git safe directory: derived from cwd.
+      expect(sandbox.cwd).toBe(cwd)
+      expect(sandbox.writable).toContain(cwd)
+      const policy = JSON.parse(readFileSync(sandbox.settingsPath, 'utf8'))
+      expect(policy.filesystem.allowWrite).toContain(cwd)
+      expect(policy.git.safeDirectories).toContain(cwd)
+    }
+    // Neither write clobbered the other: both files still stand once both launches are prepared.
+    expect(existsSync(one.launch.sandbox!.settingsPath)).toBe(true)
+    expect(existsSync(two.launch.sandbox!.settingsPath)).toBe(true)
+  })
+
+  it('gives a resumed session its own host again after a daemon restart', async () => {
+    const root = scaffold()
+    const first = await startDaemon(root)
+    await (first.daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    const persisted = first.hosts[0]!.newSession.mock.results[0]!.value as Promise<string>
+    await first.daemon.stop()
+
+    const second = await startDaemon(root)
+    await (second.daemon as any).dispatch('bot-a', dm('200', 'again', 'T1'), 'int-a')
+    const key = sessionHostKey('bot-a', KEY('T1'))
+    expect(second.factory).toHaveBeenCalledTimes(1)
+    expect([...(second.daemon as any).hosts.keys()]).toEqual([key])
+    expect(second.hosts[0]!.newSession).not.toHaveBeenCalled()
+    expect(second.hosts[0]!.loadSession).toHaveBeenCalledTimes(1)
+    const [sid, cwd] = second.hosts[0]!.loadSession.mock.calls[0]! as unknown as [string, string]
+    expect(sid).toBe(await persisted)
+    expect(cwd).toBe((second.daemon as any).hostLaunch.get(key).cwd)
+    await second.daemon.stop()
+  })
+})

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -424,4 +424,98 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     expect((daemon as any).sessionDeliveryBindings.has(KEY('T1'))).toBe(false)
     await daemon.stop()
   })
+
+  it('an internal pass resolves an ACP id only to its own row: a dream to its execution row, a memory pass to none', async () => {
+    const { daemon } = await startDaemon(scaffold())
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    const store = (daemon as any).store
+    const sid = (await store.getSession(KEY('T1'))).acpSessionId as string
+    // A dream executing beside the chat session mints the same runtime-local id.
+    const dreamKey = sessionKey('dream', 'memory', 'd1', 'bot-a')
+    await store.upsertSession({
+      key: dreamKey,
+      agentId: 'bot-a',
+      platform: 'dream',
+      channel: 'memory',
+      thread: 'd1',
+      acpSessionId: sid,
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: Date.now()
+    })
+    const dreamOwner = (daemon as any).dreamOwnerKey('bot-a', 'd1')
+    expect((await (daemon as any).sessionForAcp(dreamOwner, sid))?.key).toBe(dreamKey)
+    expect((await (daemon as any).sessionForAcp(sessionHostKey('bot-a', KEY('T1')), sid))?.key).toBe(KEY('T1'))
+    // A memory pass has no row of its own and must never borrow a sibling's.
+    expect(await (daemon as any).sessionForAcp(sessionHostKey('bot-a', 'internal:memory:bot-a'), sid)).toBeUndefined()
+    await daemon.stop()
+  })
+
+  it('the capture gate is filed under the logical session, so a public sibling sharing an ACP id cannot open a private one', async () => {
+    const { daemon } = await startDaemon(scaffold())
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    await (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+    const store = (daemon as any).store
+    // Two session hosts can mint one runtime-local id; force the rows onto it.
+    const sid = (await store.getSession(KEY('T1'))).acpSessionId as string
+    await store.db.prepare('UPDATE sessions SET acpSessionId = ? WHERE key = ?').run(sid, KEY('T2'))
+    expect(await store.isCaptureExcluded('bot-a', KEY('T1'))).toBe(true)
+    expect(await store.isCaptureExcluded('bot-a', KEY('T2'))).toBe(true)
+    // The CP opens the SECOND session, naming it outwardly: the first stays private.
+    const outward = await store.ensureOutwardSessionId(KEY('T2'), 'bot-a')
+    const apply = (daemon as any).cpConfigApply()
+    expect(
+      await apply.applySessionVisibility({ sessionId: outward, agentId: 'bot-a', visibility: 'org', visibilityRev: 1 })
+    ).toBe('applied')
+    expect(await store.isCaptureExcluded('bot-a', KEY('T2'))).toBe(false)
+    expect(await store.isCaptureExcluded('bot-a', KEY('T1'))).toBe(true)
+    await daemon.stop()
+  })
+
+  it('a turn admitted while the stop probe awaits the store keeps its host', async () => {
+    const root = scaffold()
+    const hosts: ReturnType<typeof fakeHost>[] = []
+    let releaseSecondPrompt!: () => void
+    const secondPrompt = new Promise<void>((resolve) => (releaseSecondPrompt = resolve))
+    const factory = vi.fn(() => {
+      const host = fakeHost(hosts.length + 1)
+      let prompts = 0
+      host.prompt.mockImplementation(async () => {
+        if (++prompts === 2) await secondPrompt
+        return 'end_turn'
+      })
+      hosts.push(host)
+      return host as never
+    })
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      hostFactory: factory,
+      sandboxMechanism: 'bwrap'
+    })
+    await daemon.start()
+    makeRoutable(daemon)
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    const key = sessionHostKey('bot-a', KEY('T1'))
+    const store = (daemon as any).store
+    const row = { key: KEY('T1'), agentId: 'bot-a', acpSessionId: (await store.getSession(KEY('T1'))).acpSessionId }
+    const fence = { ...(daemon as any).sessionHostFence('bot-a', KEY('T1')), row }
+    let turn: Promise<unknown> | undefined
+    // A direct message claims the key on the same warm host while the probe's store query is out.
+    const probe = vi.spyOn(store, 'sessionHasPendingInboxRows').mockImplementation(async () => {
+      if (!turn) {
+        turn = (daemon as any).dispatch('bot-a', dm('200', 'again', 'T1'), 'int-a')
+        await vi.waitFor(() => expect((daemon as any).inflight.has(KEY('T1'))).toBe(true), WAIT)
+      }
+      return false
+    })
+    await (daemon as any).stopSessionHost('bot-a', KEY('T1'), fence)
+    probe.mockRestore()
+    releaseSecondPrompt()
+    await turn
+    expect(hosts[0]!.stop).not.toHaveBeenCalled()
+    expect((daemon as any).hosts.get(key)).toBe(hosts[0])
+    expect(hosts[0]!.prompt).toHaveBeenCalledTimes(2)
+    await daemon.stop()
+  })
 })

--- a/packages/daemon/test/daemon-transcript.test.ts
+++ b/packages/daemon/test/daemon-transcript.test.ts
@@ -12,6 +12,10 @@ import type { SlackPostOptions } from '../src/slack/connection.js'
 import { WAIT } from './wait-support.js'
 
 const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
+
+/** The capture gate is keyed by the logical session: the one row the runtime id names in these single-session tests. */
+const gateKeyOf = async (daemon: unknown): Promise<string> =>
+  (await (daemon as any).store.getSessionByAcpIdForAgent('bot-a', 'acp-1')).key
 const TRANSCRIPT_CHANNEL = transcriptChannelKey('C1', TRANSPORT_SCOPE)
 
 function scaffold(mode: 'minimal' | 'low' | 'medium' | 'high', agentExtra: Record<string, unknown> = {}): string {
@@ -217,7 +221,7 @@ describe('Daemon transcript records the agent reply', () => {
     await daemon.start()
     const conn = makeRoutable(daemon)
     await (daemon as any).dispatch('bot-a', dm('100', 'private question'), 'int-a')
-    expect(await (daemon as any).store.applyCpCaptureGate('bot-a', 'acp-1', false, 1)).toBe('applied')
+    expect(await (daemon as any).store.applyCpCaptureGate('bot-a', await gateKeyOf(daemon), false, 1)).toBe('applied')
 
     let releaseDelivery!: () => void
     const deliveryBlocked = new Promise<void>((resolve) => (releaseDelivery = resolve))
@@ -237,11 +241,13 @@ describe('Daemon transcript records the agent reply', () => {
     releaseDelivery()
     await turn
     await vi.waitFor(() => expect(recordTurn).toHaveBeenCalledOnce(), WAIT)
+    // The capture names the session outwardly (§1.1): a runtime id can be shared by sibling session hosts.
+    const outward = (await (daemon as any).store.getSessionByAcpIdForAgent('bot-a', 'acp-1')).sessionId as string
     expect(recordTurn).toHaveBeenCalledWith(
-      { agentId: 'bot-a', sessionId: 'acp-1' },
+      { agentId: 'bot-a', sessionId: outward },
       {
         turnId: stableTurnId('bot-a', dm('200', 'shared follow-up')),
-        sessionId: 'acp-1',
+        sessionId: outward,
         input: expect.stringContaining('shared follow-up'),
         output: 'here is my answer'
       },
@@ -268,7 +274,7 @@ describe('Daemon transcript records the agent reply', () => {
 
     await (daemon as any).dispatch('bot-a', channelMsg('100', 'question?'), 'int-a')
 
-    expect(await (daemon as any).store.isCaptureExcluded('bot-a', 'acp-1')).toBe(false)
+    expect(await (daemon as any).store.isCaptureExcluded('bot-a', await gateKeyOf(daemon))).toBe(false)
     await vi.waitFor(() => expect(recordTurn).toHaveBeenCalledOnce(), WAIT)
     await daemon.stop()
   })
@@ -404,7 +410,7 @@ describe('Daemon transcript records the agent reply', () => {
 
     await (daemon as any).dispatch('bot-a', dm('100', 'question?'), 'int-a')
 
-    expect(await (daemon as any).store.isCaptureExcluded('bot-a', 'acp-1')).toBe(true)
+    expect(await (daemon as any).store.isCaptureExcluded('bot-a', await gateKeyOf(daemon))).toBe(true)
     expect(recordTurn).not.toHaveBeenCalled()
     await daemon.stop()
   })

--- a/packages/daemon/test/local-store.test.ts
+++ b/packages/daemon/test/local-store.test.ts
@@ -43,6 +43,15 @@ const dropPlatformStanding = (db: DatabaseSync): void => {
   db.exec('ALTER TABLE sessions DROP COLUMN platformStanding')
 }
 
+/** Undo the v17 gate re-key, so a fixture's session_gates looks like the one an older daemon wrote. */
+const revertSessionGateKey = (db: DatabaseSync): void => {
+  db.exec('DROP TABLE session_gates')
+  db.exec(`CREATE TABLE session_gates (
+    agentId TEXT NOT NULL, acpSessionId TEXT NOT NULL, localExcluded INTEGER NOT NULL DEFAULT 1,
+    cpPrivate INTEGER, cpRev INTEGER NOT NULL DEFAULT 0, updatedAt INTEGER, PRIMARY KEY (agentId, acpSessionId)
+  )`)
+}
+
 /** Undo the v11 transcript fence, so a fixture looks like a store an older daemon wrote. */
 const dropTranscriptOrg = (db: DatabaseSync): void => {
   db.exec(`
@@ -102,6 +111,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE permission_requests DROP COLUMN ownerId')
     dropApprovalDmColumns(old)
     dropPlatformStanding(old)
+    revertSessionGateKey(old)
     old.exec('DROP INDEX session_metadata_outbox_attempt')
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN failedAttempts')
     old.exec('ALTER TABLE session_metadata_outbox DROP COLUMN nextAttemptAt')
@@ -148,7 +158,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     expect(cronColumns).toContain('definition')
     // Purge receipts are leased per pool member (#1032).
     expect(purgeColumns).toEqual(expect.arrayContaining(['ownerId', 'claimedAt']))
-    expect(userVersion(path)).toBe(16)
+    expect(userVersion(path)).toBe(17)
   })
 
   it.skipIf(pg)('never persists the CP routing map on a shared store, and still does on an owned one', async () => {
@@ -203,18 +213,18 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     old.close()
 
     const upgraded = await LocalStore.open(path)
-    // Attributable: the CP verdict follows the one agent that held the id.
-    expect(await upgraded.isCaptureExcluded('bot-a', 'acp-1')).toBe(false)
+    // Attributable: the CP verdict follows the one agent that held the id, filed under its session key.
+    expect(await upgraded.isCaptureExcluded('bot-a', 'a')).toBe(false)
     // Held by two agents: the stored verdict was never attributable to either, so
     // both start from the fail-closed state and wait for their own CP push.
-    expect(await upgraded.isCaptureExcluded('bot-b', 'acp-2')).toBe(true)
-    expect(await upgraded.isCaptureExcluded('bot-c', 'acp-2')).toBe(true)
-    expect(await upgraded.applyCpCaptureGate('bot-b', 'acp-2', false, 1)).toBe('applied')
-    expect(await upgraded.isCaptureExcluded('bot-b', 'acp-2')).toBe(false)
-    expect(await upgraded.isCaptureExcluded('bot-c', 'acp-2')).toBe(true)
+    expect(await upgraded.isCaptureExcluded('bot-b', 'b')).toBe(true)
+    expect(await upgraded.isCaptureExcluded('bot-c', 'c')).toBe(true)
+    expect(await upgraded.applyCpCaptureGate('bot-b', 'b', false, 1)).toBe('applied')
+    expect(await upgraded.isCaptureExcluded('bot-b', 'b')).toBe(false)
+    expect(await upgraded.isCaptureExcluded('bot-c', 'c')).toBe(true)
     await upgraded.close()
 
-    expect(userVersion(path)).toBe(16)
+    expect(userVersion(path)).toBe(17)
   })
 
   it('re-keys the runtime catalog cache on its owning member when upgrading a v7 store', async () => {
@@ -247,6 +257,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
     dropApprovalDmColumns(old)
     dropPlatformStanding(old)
+    revertSessionGateKey(old)
     old.exec('PRAGMA user_version = 7')
     old.close()
 
@@ -268,7 +279,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
         .map((column) => column.name)
     expect(primaryKey(metaColumns)).toEqual(['ownerId', 'runtimeId'])
     expect(primaryKey(capColumns)).toEqual(['ownerId', 'runtimeId', 'modelId'])
-    expect(userVersion(path)).toBe(16)
+    expect(userVersion(path)).toBe(17)
   })
 
   it('backfills a v11 store with the outward id its sessions were already reported under', async () => {
@@ -284,6 +295,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
     dropApprovalDmColumns(old)
     dropPlatformStanding(old)
+    revertSessionGateKey(old)
     old.exec('PRAGMA user_version = 11')
     old.close()
 
@@ -294,7 +306,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     expect((await upgraded.getSession('k2'))?.sessionId).toBeNull()
     expect(await upgraded.ensureOutwardSessionId('k2', 'bot-a')).toMatch(/^[0-9a-f-]{36}$/)
     await upgraded.close()
-    expect(userVersion(path)).toBe(16)
+    expect(userVersion(path)).toBe(17)
   })
 
   // The regression that made `directDestination` reachable on fresh databases only: the step was
@@ -309,6 +321,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
       VALUES ('k1', 'bot-a', 'slack', 'C1', 'T1', 'acp-1', 'idle', 100)`)
     dropApprovalDmColumns(old)
     dropPlatformStanding(old)
+    revertSessionGateKey(old)
     old.exec('PRAGMA user_version = 12')
     old.close()
 
@@ -318,7 +331,7 @@ describe.skipIf(pg)('LocalStore schema versioning', () => {
     await upgraded.setSessionClassification('k1', { sourceBindingKind: 'external', directDestination: true })
     expect(await upgraded.getSessionClassification('bot-a', 'acp-1')).toMatchObject({ directDestination: true })
     await upgraded.close()
-    expect(userVersion(path)).toBe(16)
+    expect(userVersion(path)).toBe(17)
   })
 
   it('refuses a store written by a newer daemon WITHOUT touching it first', async () => {
@@ -1549,7 +1562,7 @@ describe('LocalStore session retention GC (#485)', () => {
     const s = await store()
     await seed(s, 'gone', 'closed', 100)
     await s.setSessionMuted('gone', true)
-    await s.setLocalCaptureGate('bot-a', 'acp-gone', true)
+    await s.setLocalCaptureGate('bot-a', 'gone', true)
     await s.appendInbox({ id: 'm1', sessionKey: 'gone', agentId: 'bot-a', msg: '{}', enqueuedAt: '0000000001' })
     // An unacknowledged terminal hook report is an outbox toward the CP and must
     // survive the session delete (same rule as removeInboxByAgentId).
@@ -1622,16 +1635,16 @@ describe('LocalStore session retention GC (#485)', () => {
       })
     await put('a', 'bot-a')
     await put('b', 'bot-b')
-    await s.setLocalCaptureGate('bot-a', 'acp-shared', false) // capture open (not excluded)
-    await s.setLocalCaptureGate('bot-b', 'acp-shared', false)
+    await s.setLocalCaptureGate('bot-a', 'a', false) // capture open (not excluded)
+    await s.setLocalCaptureGate('bot-b', 'b', false)
 
     // bot-a's session expires: its own gate goes, bot-b's is untouched.
     expect(await s.deleteSession('a')).toBe(true)
-    expect(await s.isCaptureExcluded('bot-a', 'acp-shared')).toBe(true) // no row ⇒ excluded-by-default
-    expect(await s.isCaptureExcluded('bot-b', 'acp-shared')).toBe(false)
+    expect(await s.isCaptureExcluded('bot-a', 'a')).toBe(true) // no row ⇒ excluded-by-default
+    expect(await s.isCaptureExcluded('bot-b', 'b')).toBe(false)
 
     expect(await s.deleteSession('b')).toBe(true)
-    expect(await s.isCaptureExcluded('bot-b', 'acp-shared')).toBe(true)
+    expect(await s.isCaptureExcluded('bot-b', 'b')).toBe(true)
     await s.close()
   })
 
@@ -2621,6 +2634,7 @@ describe.skipIf(pg)('transcript org migration from a v10 store', () => {
     old.exec('ALTER TABLE sessions DROP COLUMN directDestination')
     dropApprovalDmColumns(old)
     dropPlatformStanding(old)
+    revertSessionGateKey(old)
     old.exec('PRAGMA user_version = 10')
     old.close()
     return path

--- a/packages/daemon/test/model-key-session.test.ts
+++ b/packages/daemon/test/model-key-session.test.ts
@@ -1,3 +1,5 @@
+import { sessionHostKey } from '../src/acp/host-key.js'
+import { sdkLeaseKey } from '../src/daemon/turn-types.js'
 import { describe, expect, it, vi } from 'vitest'
 import { FakeClock } from '@agentconnect.md/connection'
 import { Daemon } from '../src/daemon.js'
@@ -80,7 +82,7 @@ describe('daemon model-key session lifecycle', () => {
     ])
     await h.daemon.modelSessions.ensure(agent, 'session-a')
     h.daemon.store.getSession = () => ({ acpSessionId: 'acp-1' })
-    h.daemon.sdkLease.set(JSON.stringify(['agent-a', 'acp-1']), {
+    h.daemon.sdkLease.set(sdkLeaseKey(sessionHostKey('agent-a', 'session-a'), 'acp-1'), {
       agentId: 'agent-a',
       tasks: new Map([['task-1', {}]]),
       settled: [],
@@ -109,7 +111,7 @@ describe('daemon model-key session lifecycle', () => {
     ])
     await h.daemon.modelSessions.ensure(agent, 'session-a')
     h.daemon.store.getSession = () => ({ acpSessionId: 'acp-1' })
-    h.daemon.sdkLease.set(JSON.stringify(['agent-a', 'acp-1']), {
+    h.daemon.sdkLease.set(sdkLeaseKey(sessionHostKey('agent-a', 'session-a'), 'acp-1'), {
       agentId: 'agent-a',
       tasks: new Map([['task-1', {}]]),
       settled: [],
@@ -146,7 +148,7 @@ describe('daemon model-key session lifecycle', () => {
 
     // Live SDK work: the switch is recorded, but the running host keeps its binding.
     h.daemon.store.getSession = () => ({ agentId: 'agent-a', acpSessionId: 'acp-1' })
-    h.daemon.sdkLease.set(JSON.stringify(['agent-a', 'acp-1']), {
+    h.daemon.sdkLease.set(sdkLeaseKey(sessionHostKey('agent-a', 'session-a'), 'acp-1'), {
       agentId: 'agent-a',
       tasks: new Map([['task-1', {}]]),
       settled: [],

--- a/packages/daemon/test/runtime-commands.test.ts
+++ b/packages/daemon/test/runtime-commands.test.ts
@@ -1,3 +1,4 @@
+import { agentHostKey } from '../src/acp/host-key.js'
 import { describe, expect, it } from 'vitest'
 import { Daemon } from '../src/daemon.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
@@ -260,7 +261,7 @@ describe('the daemon records only its own host’s advertisement', () => {
       runtimeCommands: RuntimeCommandsCache
     }
     inner.hosts.set('agent-1', { hasSession: () => true, isLoadingSession: () => false })
-    const passKey = pendingTurnKey('agent-1', 'commit-session')
+    const passKey = pendingTurnKey(agentHostKey('agent-1'), 'commit-session')
     inner.internalPassSessions.add(internalPassSlot.commit('agent-1', 'commit-session'), passKey)
 
     await inner.onAcpUpdate('agent-1', 'commit-session', advertisement)

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -78,7 +78,7 @@ describe('sandboxWrap', () => {
       mkdirSync(workspace, { recursive: true })
       mkdirSync(home)
       mkdirSync(memory)
-      const settingsPath = writeSandboxSettings(agentDir, {
+      const settingsPath = writeSandboxSettings(agentDir, 'agent', {
         writable: [workspace, home, memory],
         denyRead: [agentDir],
         allowRead: [workspace, home, memory],
@@ -213,7 +213,7 @@ describe('bwrap PID isolation', () => {
     const home = join(agentDir, 'home')
     mkdirSync(workspace, { recursive: true })
     mkdirSync(home)
-    const settingsPath = writeSandboxSettings(agentDir, {
+    const settingsPath = writeSandboxSettings(agentDir, 'agent', {
       writable: [workspace, home],
       denyRead: [],
       allowRead: [],
@@ -249,6 +249,7 @@ describe('bwrap config-file rematerialization', () => {
     const configRootInode = statSync(configFilesDir(agentDir)).ino
     const settingsPath = writeSandboxSettings(
       agentDir,
+      'agent',
       sandboxBoundary({ agentDir, cwd: workspace, runtimeHome: home })
     )
     const { cmd, args } = sandboxWrap(

--- a/packages/daemon/test/session-metadata-outbox-owner.test.ts
+++ b/packages/daemon/test/session-metadata-outbox-owner.test.ts
@@ -1,0 +1,105 @@
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, it, vi } from 'vitest'
+import type { EventSession } from '@agentconnect.md/protocol'
+import { SessionMetadataOutbox, type SessionMetadataHost } from '../src/store/session-metadata-outbox.js'
+import { LocalStore, sessionKey } from '../src/store/local-store.js'
+import { SqliteAsyncDatabase } from '../src/store/sqlite-async-database.js'
+
+const AGENT = 'a0a0a0a0-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const DAEMON = 'd1'
+
+/** git-workspace-model §11: one host per session, so two sessions of one agent can share a runtime-local ACP id. */
+async function world() {
+  const store = await LocalStore.open({ database: SqliteAsyncDatabase.adopt(new DatabaseSync(':memory:')) })
+  const now = 1_000_000
+  const sync = vi.fn<(event: EventSession) => Promise<'acknowledged' | 'unsupported'>>(async () => 'acknowledged')
+  const cp = { state: 'READY', supportsServerFeature: () => true, syncEventSession: sync }
+  const host: SessionMetadataHost = {
+    store: () => store,
+    warn: vi.fn(),
+    debug: vi.fn(),
+    clock: () => ({ now: () => now, setTimeout, clearTimeout }) as never,
+    daemonId: () => DAEMON,
+    controlPlaneConfigured: () => true,
+    draining: () => false,
+    cpClient: () => cp as never,
+    agents: () => new Map([[AGENT, { id: AGENT } as never]]),
+    servesAgent: () => true,
+    sessionLink: (id) => `https://console.example.test/sessions/${id}`,
+    sessionThreadUrl: () => undefined
+  }
+  const outbox = new SessionMetadataOutbox(host)
+  const row = async (channel: string, thread: string) => {
+    const key = sessionKey('slack', channel, thread, AGENT)
+    await store.upsertSession({
+      key,
+      agentId: AGENT,
+      platform: 'slack',
+      channel,
+      thread,
+      acpSessionId: 'acp-1',
+      state: 'idle',
+      lastDeliveredTs: null,
+      updatedAt: now,
+      triggeredBy: 'U1'
+    })
+    return { key, channel, outward: await store.ensureOutwardSessionId(key, AGENT, now) }
+  }
+  // A private DM and a public channel session, both minted `acp-1` by their own hosts.
+  const dm = await row('D1', 'T1')
+  const channel = await row('C1', 'T2')
+  const classify = async () => {
+    await store.setSessionClassification(dm.key, { conversationKind: 'dm', directDestination: true })
+    await store.setSessionClassification(channel.key, { conversationKind: 'channel' })
+  }
+  const start = async () => {
+    for (const s of [dm, channel]) {
+      await outbox.emitSessionMetadataSnapshot({
+        sessionId: 'acp-1',
+        sessionKey: s.key,
+        agentId: AGENT,
+        phase: 'start',
+        platform: 'slack',
+        channel: s.channel
+      })
+    }
+  }
+  const events = async (): Promise<Map<string, EventSession>> => {
+    await outbox.drainSessionMetadataSnapshots()
+    return new Map(sync.mock.calls.map(([event]) => [event.sessionId, event]))
+  }
+  return { store, outbox, sync, cp, dm, channel, classify, start, events }
+}
+
+describe('session metadata names its classification by the logical session', () => {
+  it("a snapshot carrying the session key publishes that session's own facts, not a sibling's sharing the ACP id", async () => {
+    const w = await world()
+    await w.classify()
+    await w.start()
+    const seen = await w.events()
+    expect([...seen.keys()].sort()).toEqual([w.dm.outward, w.channel.outward].sort())
+    expect(seen.get(w.dm.outward)).toMatchObject({ conversationKind: 'dm', directDestination: true })
+    expect(seen.get(w.channel.outward)?.conversationKind).toBe('channel')
+    expect(seen.get(w.channel.outward)?.directDestination).toBeUndefined()
+    w.outbox.dispose()
+    await w.store.close()
+  })
+
+  it("the display-name re-emit carries each row's key, so both siblings are re-emitted as themselves", async () => {
+    const w = await world()
+    // A `plan` re-emit updates a pending obligation, so the CP is held away until the re-emit has landed;
+    // the facts are classified only after the start milestones, so what each event carries came through it.
+    w.cp.state = 'CONNECTING'
+    await w.start()
+    await w.classify()
+    await w.outbox.emitSessionMetadataSnapshotsForDisplayName('U1')
+    w.cp.state = 'READY'
+    const seen = await w.events()
+    expect(seen.size).toBe(2)
+    expect([...seen.keys()].sort()).toEqual([w.dm.outward, w.channel.outward].sort())
+    expect(seen.get(w.dm.outward)).toMatchObject({ conversationKind: 'dm', directDestination: true })
+    expect(seen.get(w.channel.outward)?.conversationKind).toBe('channel')
+    w.outbox.dispose()
+    await w.store.close()
+  })
+})


### PR DESCRIPTION
PR 2 of the `docs/designs/git-workspace-model.md` §11 rollout. A self-hosted daemon whose sandbox is effective now runs **one ACP host per (agent, session)**; everything else keeps today's one host per agent. The per-session clone (PR 3) and per-session `HOME` (PR 4) build on the host key introduced here.

## The predicate

```ts
perSessionHost(agent) = !this.k8s && this.agentRunsInSandbox(agent)
```

`agentRunsInSandbox` is `effectiveRunInSandbox(requireSandbox, agent.runInSandbox, sandboxMechanism, runtime)`. The `!k8s` half is load-bearing: a pool launch dials the agent's one sandbox pod, which runs one adapter, so the pool keeps exactly the per-agent host until it moves to one pod per session. Unconfined self-hosted launches keep the per-agent host too.

## The host key (what PR 3 / PR 4 will use)

`packages/daemon/src/acp/host-key.ts`:

- `HostKey` — a branded string. `agentHostKey(agentId)` is the agent id itself (so every existing `hosts.get(agentId)`-shaped caller and test keeps working for the shared host); `sessionHostKey(agentId, sessionKey)` joins the agent id and the **logical session key** (`sessionKey(...)` from `store/local-store.ts`) with a NUL, which can never appear in an agent id.
- `hostKeyAgentId` / `hostKeySessionKey` split it; `hostKeyDirName` gives the filesystem leaf for daemon-owned per-host state (`agent`, or `session-<24 hex of sha256(sessionKey)>` — the same hash the session worktree already uses); `hostKeyLabel` is the log form.
- `AssembleRuntimeLaunchOptions.hostKey` (required) flows through `composeRuntimeLaunch` to `prepareRuntimeLaunch` (optional there; a probe takes the shared leaf). That is the hook for per-session HOME and exact per-session grants.

## What changed

- **Host state** — `hosts`, `hostStartedAt`, `hostRuntimeHome`, `hostStarts`, `hostStartGeneration`, `readyHosts`, `hostStartAborts`, `hostStopping` are keyed by `HostKey`; new `hostLaunch` records each host's agent dir and launch cwd. `hostConfigFiles` stays **per agent**: the materialized secrets live in the agent dir and are shared by every host of the agent, so they are removed with the agent's *last* host (previously the first stop would have deleted files a sibling host still reads). Flagging this as the one place I did not key by host, deliberately.
- **Lifecycle** — `stopHost(agentId)` now stops every host of the agent; `stopHostByKey` is the per-host teardown, which scopes lease / delivery-binding / quarantine cleanup to the sessions the host served and removes the host's sandbox policy directory. Every existing agent-wide caller (reconcile `hostSpawnSig`/workspace eviction, removal, drains, quiesce, memory-connection fences, CP handlers, duty coordinator) keeps its meaning. A session-bound host is also stopped when its worktree is removed (`cleanupSessionWorktree`), when retention deletes the row, and when the TTL closes the session. `SelectedTurnHost.stop` force-stops exactly the turn's host.
- **Ordering** — for a session-bound key `startHostWithRetry` runs `prepareAgentWorkspace(agent, undefined, request)` inside the existing cold-host gate, so the session directory exists before the spawn, and `ensureHost` launches there. `SessionManager` gained `hostFor(agentId, request, cwd?)`, `isHostRunning(agentId, request)` and `boundHostCwd(agentId, request)`; `openRuntimeSession` takes `hostBoundCwd` ahead of every other cwd source. A daemon-verified cwd prepared before `handle()` (the GitHub exact-ref / revision-only review path) is passed to `hostFor` so the host launches in it instead of a re-preparation that would not reproduce it; a mismatch throws rather than opening the session elsewhere.
- **Per-host sandbox settings** — `writeSandboxSettings(agentDir, hostDir, policy)` writes `<agentDir>/.agentconnect/sandbox/<hostDir>/settings.json`, still under the agent dir's `denyRead` with no carve-back and outside every writable root; `removeSandboxSettings` cleans it with the host. Symlink validation walks the extra component. Dream hosts and key-server model-session hosts get their own leaf (previously they shared the warm host's file, the same overwrite hazard).
- **session/load after restart** — the resumed session re-spawns its own host under the per-session key and loads there.
- **Sockets** — one correction to the brief: the MCP bridge socket (`run/mcp.sock`) and the git-credential socket (`run/gitcred.sock`) are per **daemon**, not per host. What is per host is the bridge subprocess and its token; credential identity is per agent. Nothing assumed one host per agent, so nothing changed.
- **Capacity decision** — gates keep counting agents (`agent/activate`'s `agents + activating`, duty headroom); per-session hosts are bounded by session admission. One-line comments at the `agent/activate` gate and at `hostCount`. The only gate that would have drifted was the heartbeat's `load.agents: hostCount()`, which would have over-reported a confined agent as N agents; it now counts agents with a live host.
- **Idle reaper** — a session-bound host is judged by its own session's activity (`sessionLastActivityTs`), its own in-flight turn and its own background work; the shared host keeps the agent-wide predicates.

## Verified (unit level, on this machine)

- `pnpm --filter @agentconnect.md/daemon exec tsc -p tsconfig.typecheck.json --noEmit` — clean.
- New `test/daemon-session-hosts.test.ts` (7 tests) and a k8s row in `test/daemon-k8s-mode.test.ts`: per-session key with the session request reaching preparation *before* the host is constructed and `newSession` opening at the host's launch cwd; per-agent key when `runInSandbox: false` and when the sandbox is requested but no mechanism exists; two concurrent sessions → two hosts, and at the launch layer two `prepareRuntimeLaunch` calls from one agent dir → two distinct policy files that both survive, each with its session cwd as a write root, `sandbox.cwd`, and Git safe directory; `stopHost` and a `description` change through `daemon.reconcile()` stop every host; the policy directory is removed with its host and siblings are untouched; resume after a daemon restart lands on a fresh per-session host via `loadSession` at the bound cwd; a `--k8s` daemon with the mechanism forced on still keys by agent.
- **Mutation check**: dropping `!this.k8s` turns the k8s test red (`expected true to be false`); dropping the sandbox half turns both per-agent tests red (factory called twice). Both restored.
- Affected existing suites green: `daemon-lifecycle`, `daemon-k8s-mode`, `sandbox`, `runtime-launch`, `runtime-credentials`, `daemon-session-sweeps-pool`, `skills-offline-sandbox`, `daemon-smoke`, `daemon-commands`, `daemon-webchat`, `daemon-commit-message-pass`, `runtime-install-repair-collapse`, `sandbox-bootstrap-notice`, `daemon-retired-roots-sweep`, `daemon-transcript` (344 tests). Prettier and ESLint clean on every touched file.

## Not verified

- No live Linux daemon with bwrap: the provider actually reading the per-host policy file, a real session directory as launch cwd under confinement, and the reorder against a real `git worktree` were exercised only through the launch-layer test and the fake host factory.
- The full daemon suite was not run (known to OOM locally); the batches above are the host-touching subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
