### PR TITLE
fix(web): one Cancel and shorter copy in the Linear connect wizard

### DIFF
--- a/packages/web/src/components/console/platforms/linear/Body.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/Body.test.tsx
@@ -272,7 +272,7 @@ describe('the connect hand-off', () => {
     mocks.probeConfig = answered
     await render()
 
-    expect(text()).toContain('There is nothing to fill in here')
+    expect(text()).toContain('You approve the workspace in a Linear popup')
     expect(text()).toContain('becomes the workspace’s default agent')
     expect(mocks.startLinearConnect).not.toHaveBeenCalled()
     expect(window.open).not.toHaveBeenCalled()
@@ -312,7 +312,7 @@ describe('the connect hand-off', () => {
 
     await act(async () => buttonWith('Connect another workspace')!.click())
     await settle()
-    expect(text()).toContain('There is nothing to fill in here')
+    expect(text()).toContain('You approve the workspace in a Linear popup')
     expect(mocks.startLinearConnect).not.toHaveBeenCalled()
 
     await act(async () => buttonWith('Connect Linear')!.click())
@@ -341,14 +341,50 @@ describe('the connect hand-off', () => {
     expect(buttonWith('Cancel')).toBeUndefined()
   })
 
-  it('cancels a round trip in flight, closing the wizard it was the whole pane of', async () => {
+  it('renders no second Cancel beside the host’s while the forced pane’s round trip is in flight', async () => {
     mocks.probeConfig = answered
-    const state = await render()
+    await render()
     await act(async () => buttonWith('Connect Linear')!.click())
     await settle()
-    await act(async () => buttonWith('Cancel')!.click())
 
-    expect(state.close).toHaveBeenCalled()
+    expect(text()).toContain('Waiting for Linear')
+    expect(buttonWith('Cancel')).toBeUndefined()
+    expect(buttonWith('Back')).toBeUndefined()
+  })
+
+  it('closes the authorize popup when the host closes the wizard mid-round-trip', async () => {
+    // The host footer's Cancel unmounts the pane; the popup must not outlive the poll.
+    const popup = { close: vi.fn(), closed: false }
+    vi.stubGlobal(
+      'open',
+      vi.fn(() => popup)
+    )
+    mocks.probeConfig = answered
+    await render()
+    await act(async () => buttonWith('Connect Linear')!.click())
+    await settle()
+    await act(async () => root.unmount())
+
+    expect(popup.close).toHaveBeenCalled()
+  })
+
+  it('goes back to the picker from a round trip in flight, closing the popup it opened', async () => {
+    const popup = { close: vi.fn(), closed: false }
+    vi.stubGlobal(
+      'open',
+      vi.fn(() => popup)
+    )
+    mocks.probeConfig = answered
+    mocks.bots = [workspace()]
+    const state = await render()
+    await act(async () => buttonWith('Connect another workspace')!.click())
+    await act(async () => buttonWith('Connect Linear')!.click())
+    await settle()
+    await act(async () => buttonWith('Back')!.click())
+
+    expect(popup.close).toHaveBeenCalled()
+    expect(text()).toContain('Example Workspace')
+    expect(state.close).not.toHaveBeenCalled()
   })
 
   it('names the settled success and the default agent it just made', async () => {
@@ -362,7 +398,8 @@ describe('the connect hand-off', () => {
 
     expect(state.invalidate).toHaveBeenCalled()
     expect(text()).toContain('Workspace connected')
-    expect(text()).toContain('is now its default agent')
+    expect(text()).toContain('is its default agent')
+    expect(text()).not.toContain('bare delegation')
     await act(async () => buttonWith('Done')!.click())
     expect(state.close).toHaveBeenCalled()
   })

--- a/packages/web/src/components/console/platforms/linear/Body.tsx
+++ b/packages/web/src/components/console/platforms/linear/Body.tsx
@@ -94,8 +94,8 @@ export function LinearWizardBody({ agent, host }: { agent: Agent; host: WizardHo
     })()
   }
 
-  // Back from a pane the operator chose; from the forced one there is nowhere to go but
-  // out, and the host footer's own Cancel is what the gate leaves that job to.
+  // Back from a pane the operator chose. The forced pane renders no button of its own in any
+  // state: the host footer's Cancel is the one way out, and unmounting closes the popup.
   const leaveConnect = () => {
     cancel()
     if (forcedConnect) close()
@@ -143,8 +143,7 @@ export function LinearWizardBody({ agent, host }: { agent: Agent; host: WizardHo
             <div className="flex items-start gap-[10px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
               <Icon name="check" size={15} color="var(--status-online)" className="mt-[1px] flex-none" />
               <span>
-                Workspace connected —&#32;<span className="mono">{agent.name}</span>&#32;is now its default agent, the
-                one a bare delegation starts a session with.
+                Workspace connected —&#32;<span className="mono">{agent.name}</span>&#32;is its default agent.
               </span>
             </div>
             <button type="button" onClick={close} className={`${PRIMARY} mt-[12px] cursor-pointer`}>
@@ -161,9 +160,11 @@ export function LinearWizardBody({ agent, host }: { agent: Agent; host: WizardHo
               <button type="button" onClick={start} className={`${PRIMARY} cursor-pointer`}>
                 Try again
               </button>
-              <button type="button" onClick={leaveConnect} className={SECONDARY}>
-                {forcedConnect ? 'Cancel' : 'Back'}
-              </button>
+              {!forcedConnect && (
+                <button type="button" onClick={leaveConnect} className={SECONDARY}>
+                  Back
+                </button>
+              )}
             </div>
           </>
         ) : flow.phase === 'authorizing' ? (
@@ -176,17 +177,18 @@ export function LinearWizardBody({ agent, host }: { agent: Agent; host: WizardHo
               <span className="font-sans text-[12px] font-normal leading-[1.4] text-(--text-tertiary)">
                 Approve the workspace in the Linear tab.
               </span>
-              <button type="button" onClick={leaveConnect} className={SECONDARY}>
-                Cancel
-              </button>
+              {!forcedConnect && (
+                <button type="button" onClick={leaveConnect} className={SECONDARY}>
+                  Back
+                </button>
+              )}
             </div>
           </>
         ) : (
           <>
             <div className="mb-[12px] font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
-              <span className="mono">{agent.name}</span>&#32;becomes the workspace&rsquo;s default agent — the one a
-              bare delegation starts a session with. There is nothing to fill in here: you approve the workspace in a
-              Linear popup.
+              <span className="mono">{agent.name}</span>&#32;becomes the workspace&rsquo;s default agent. You approve
+              the workspace in a Linear popup.
             </div>
             {/* The popup opens from THIS click. Fired from an effect it is blocked. */}
             <button type="button" onClick={start} className={`${PRIMARY} cursor-pointer`}>

--- a/packages/web/src/components/console/platforms/linear/connect.ts
+++ b/packages/web/src/components/console/platforms/linear/connect.ts
@@ -118,6 +118,18 @@ export function useLinearConnect(
     setErr(null)
   }, [reset])
 
+  // The host's own Cancel unmounts this hook mid-round-trip: close the tab then too, so no
+  // orphan authorize page outlives the poll that would have acted on it.
+  useEffect(() => {
+    return () => {
+      try {
+        popup.current?.close()
+      } catch {
+        // a cross-origin popup may refuse; nothing is polling it any more either way
+      }
+    }
+  }, [])
+
   const start = useCallback(() => {
     if (busy.current) return
     busy.current = true


### PR DESCRIPTION
## Why

Two things seen while connecting the first workspaces on the new environments:

- The success message ran long: "Workspace connected — agent is now its default agent, the one a bare delegation starts a session with."
- The wizard showed more than one Cancel: the forced connect pane rendered its own beside the host footer's while the round trip was in flight, and again on an error.

## What

- `Body.tsx`: success copy is "Workspace connected — `<agent>` is its default agent."; the pre-connect copy is "`<agent>` becomes the workspace's default agent. You approve the workspace in a Linear popup." The forced pane renders no Cancel of its own in any state; a pane the operator chose keeps **Back** (aborts the round trip, returns to the picker).
- `connect.ts`: the hook closes the authorize popup on unmount, so the host's Cancel leaves no orphan authorize page behind — the reason the in-pane Cancel existed.
- `Body.test.tsx`: no second Cancel in flight; unmount closes the popup; Back from a chosen pane closes it and returns to the picker; the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
