### PR TITLE
fix(web): an issue with no description prints none, not its XML envelope

### DIFF
--- a/packages/web/src/components/console/platforms/linear/turn-facts.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/turn-facts.test.tsx
@@ -69,6 +69,26 @@ describe('LinearTurnFacts', () => {
     expect(el.querySelector('pre')).not.toBeNull()
   })
 
+  it('prints no Description for an issue whose envelope carries none', async () => {
+    const el = await render(
+      <LinearTurnFacts
+        body={{
+          linear: {
+            issue: { identifier: 'AC-1', title: 'who are you' },
+            team: { name: 'AAA' },
+            delegatedBy: 'Dana',
+            description: '<issue identifier="AC-1">\n<title>who are you</title>\n<team name="AAA"/>\n</issue>'
+          }
+        }}
+      />
+    )
+    const text = el.textContent ?? ''
+    expect(text).toContain('AC-1 · who are you')
+    expect(text).not.toContain('Description')
+    expect(text).not.toContain('<issue')
+    expect(el.querySelector('pre')).toBeNull()
+  })
+
   it('renders nothing for a body without Linear facts', async () => {
     const el = await render(<LinearTurnFacts body={{}} />)
     expect(el.textContent).toBe('')

--- a/packages/web/src/components/console/platforms/linear/turn-facts.test.tsx
+++ b/packages/web/src/components/console/platforms/linear/turn-facts.test.tsx
@@ -89,6 +89,24 @@ describe('LinearTurnFacts', () => {
     expect(el.querySelector('pre')).toBeNull()
   })
 
+  it('still prints a description the relay cut before its closing tag', async () => {
+    const el = await render(
+      <LinearTurnFacts
+        body={{
+          linear: {
+            issue: { identifier: 'ENG-3' },
+            description: '<issue identifier="ENG-3">\n<description>The first half of a long',
+            truncated: true
+          }
+        }}
+      />
+    )
+    const text = el.textContent ?? ''
+    expect(text).toContain('The first half of a long')
+    expect(text).toContain('Context truncated')
+    expect(text).not.toContain('<issue')
+  })
+
   it('renders nothing for a body without Linear facts', async () => {
     const el = await render(<LinearTurnFacts body={{}} />)
     expect(el.textContent).toBe('')

--- a/packages/web/src/components/console/platforms/linear/turn-facts.tsx
+++ b/packages/web/src/components/console/platforms/linear/turn-facts.tsx
@@ -16,7 +16,10 @@ export function LinearTurnFacts({ body }: { body: UserTurnBody }) {
   const { issue, team } = facts
   const issueLabel = [issue.identifier, issue.title].filter(Boolean).join(' · ')
   const teamLabel = team?.name ? `${team.name}${team.key ? ` (${team.key})` : ''}` : (team?.key ?? '')
-  const description = facts.description ? linearDescriptionMarkdown(facts.description) : undefined
+  const parsedDescription = facts.description ? linearDescriptionMarkdown(facts.description) : undefined
+  // An issue that has no description shows none: the envelope's other facts already have rows.
+  const description =
+    parsedDescription && (parsedDescription.markdown || !parsedDescription.parsed) ? parsedDescription : undefined
   return (
     <>
       <FactRows>
@@ -36,7 +39,7 @@ export function LinearTurnFacts({ body }: { body: UserTurnBody }) {
         <div className="mt-2">
           <p className="mb-[2px] font-sans text-[12px] leading-[1.6] text-(--text-tertiary)">Description</p>
           {description.parsed ? (
-            <MarkdownText text={description.markdown || '_(empty)_'} />
+            <MarkdownText text={description.markdown} />
           ) : (
             <pre className="whitespace-pre-wrap break-words font-mono text-[11.5px] leading-[1.5] text-(--text-primary)">
               {description.markdown}

--- a/packages/web/src/lib/user-turn-body.test.ts
+++ b/packages/web/src/lib/user-turn-body.test.ts
@@ -52,7 +52,22 @@ describe('linearDescriptionMarkdown', () => {
     })
   })
 
-  it('shows a context without a description element whole rather than guessing', () => {
+  it('reads an envelope with no description element as an issue that has none', () => {
+    // Everything this envelope carries — the identifier, the title, the team — is already a row
+    // of its own, so printing it raw under "Description" was the whole of the bug.
+    const context = '<issue identifier="AC-1">\n<title>who are you</title>\n<team name="AAA"/>\n</issue>'
+    expect(linearDescriptionMarkdown(context)).toEqual({ markdown: '', parsed: true })
+    expect(linearDescriptionMarkdown('<issue><description/></issue>')).toEqual({ markdown: '', parsed: true })
+  })
+
+  it('takes a description element that carries attributes', () => {
+    expect(linearDescriptionMarkdown('<issue><description format="markdown">ship it</description></issue>')).toEqual({
+      markdown: 'ship it',
+      parsed: true
+    })
+  })
+
+  it('shows a context that is not the envelope at all whole rather than guessing', () => {
     expect(linearDescriptionMarkdown('plain words')).toEqual({ markdown: 'plain words', parsed: false })
   })
 })

--- a/packages/web/src/lib/user-turn-body.test.ts
+++ b/packages/web/src/lib/user-turn-body.test.ts
@@ -60,6 +60,13 @@ describe('linearDescriptionMarkdown', () => {
     expect(linearDescriptionMarkdown('<issue><description/></issue>')).toEqual({ markdown: '', parsed: true })
   })
 
+  it('keeps a description the relay cut before its closing tag', () => {
+    // `promptContext` is byte-truncated at the relay's budget, so a long description can arrive
+    // as an open element with no close. Every word that DID arrive still reads.
+    const cut = '<issue identifier="ENG-3">\n<title>investigate</title>\n<description>The first half of a long'
+    expect(linearDescriptionMarkdown(cut)).toEqual({ markdown: 'The first half of a long', parsed: true })
+  })
+
   it('takes a description element that carries attributes', () => {
     expect(linearDescriptionMarkdown('<issue><description format="markdown">ship it</description></issue>')).toEqual({
       markdown: 'ship it',

--- a/packages/web/src/lib/user-turn-body.ts
+++ b/packages/web/src/lib/user-turn-body.ts
@@ -32,21 +32,26 @@ export function shortSha(sha: string): string {
 
 const XML_ENTITIES: Record<string, string> = { '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'", '&amp;': '&' }
 
+/** `&lt;` and friends, as Linear's XML-shaped context escapes them. */
+const decodeEntities = (value: string): string =>
+  value.replace(/&(lt|gt|quot|#39|amp);/g, (entity) => XML_ENTITIES[entity] ?? entity).trim()
+
 /**
  * Linear hands the agent the issue as XML-shaped text (`promptContext`): `<issue …><title>…</title>
  * <description>…</description> …</issue>`. The console shows the description as the markdown it is.
- * An `<issue>` envelope without that element is an issue with no description — the title and team
- * it does carry are facts of their own — so it yields an empty, parsed description rather than the
- * envelope; only a context that is not the envelope at all is shown whole, since guessing at its
- * shape would hide it.
+ *
+ * Three shapes, because the relay cuts the context at a byte budget and carries `truncated`:
+ * a closed `<description>` is that element; an OPEN one whose close was cut away is everything
+ * after it, so a long description stays readable; and an `<issue>` envelope with no such element
+ * at all is an issue that has none — its identifier, title and team are rows of their own, so the
+ * envelope is not worth printing back. Only a context that is not the envelope at all is shown
+ * whole, since guessing at its shape would hide it.
  */
 export function linearDescriptionMarkdown(description: string): { markdown: string; parsed: boolean } {
-  const match = /<description(?:\s[^>]*)?>([\s\S]*?)<\/description>/i.exec(description)
-  if (match) {
-    const markdown = match[1]!.replace(/&(lt|gt|quot|#39|amp);/g, (entity) => XML_ENTITIES[entity] ?? entity).trim()
-    return { markdown, parsed: true }
-  }
-  // The envelope with no description element: the issue simply has none.
+  const closed = /<description(?:\s[^>]*)?>([\s\S]*?)<\/description>/i.exec(description)
+  if (closed) return { markdown: decodeEntities(closed[1]!), parsed: true }
+  const open = /<description(?:\s[^>]*)?>([\s\S]*)$/i.exec(description)
+  if (open) return { markdown: decodeEntities(open[1]!), parsed: true }
   if (/^\s*<issue[\s>]/i.test(description)) return { markdown: '', parsed: true }
   return { markdown: description, parsed: false }
 }

--- a/packages/web/src/lib/user-turn-body.ts
+++ b/packages/web/src/lib/user-turn-body.ts
@@ -34,12 +34,19 @@ const XML_ENTITIES: Record<string, string> = { '&lt;': '<', '&gt;': '>', '&quot;
 
 /**
  * Linear hands the agent the issue as XML-shaped text (`promptContext`): `<issue …><title>…</title>
- * <description>…</description> …</issue>`. The console shows the description as the markdown it is;
- * a context without that element is shown whole, since guessing at its shape would hide it.
+ * <description>…</description> …</issue>`. The console shows the description as the markdown it is.
+ * An `<issue>` envelope without that element is an issue with no description — the title and team
+ * it does carry are facts of their own — so it yields an empty, parsed description rather than the
+ * envelope; only a context that is not the envelope at all is shown whole, since guessing at its
+ * shape would hide it.
  */
 export function linearDescriptionMarkdown(description: string): { markdown: string; parsed: boolean } {
-  const match = /<description>([\s\S]*?)<\/description>/i.exec(description)
-  if (!match) return { markdown: description, parsed: false }
-  const markdown = match[1]!.replace(/&(lt|gt|quot|#39|amp);/g, (entity) => XML_ENTITIES[entity] ?? entity).trim()
-  return { markdown, parsed: true }
+  const match = /<description(?:\s[^>]*)?>([\s\S]*?)<\/description>/i.exec(description)
+  if (match) {
+    const markdown = match[1]!.replace(/&(lt|gt|quot|#39|amp);/g, (entity) => XML_ENTITIES[entity] ?? entity).trim()
+    return { markdown, parsed: true }
+  }
+  // The envelope with no description element: the issue simply has none.
+  if (/^\s*<issue[\s>]/i.test(description)) return { markdown: '', parsed: true }
+  return { markdown: description, parsed: false }
 }


### PR DESCRIPTION
## Why

A Linear turn for an issue with no description printed its whole XML envelope under **Description**:

```
<issue identifier="AC-1">
<title>who are you</title>
<team name="AAA"/>
</issue>
```

The console lifts the `<description>` element out of the context Linear hands the agent; with no such element the fallback for "a context whose shape we do not know" showed the raw text. Here the shape *is* known — the issue simply has no description — and everything the envelope carries (identifier, title, team) already has a fact row above it.

## What

- `linearDescriptionMarkdown` now reads three shapes: a **closed** `<description>` is that element; an **open** one whose close the relay's byte budget cut away is everything after it, so a long description stays readable (review finding); an `<issue>` envelope with **no** such element is an issue that has none. Only a context that is not the envelope at all is still shown whole. The element pattern also accepts attributes (`<description format="markdown">`), which the old one missed.
- `turn-facts.tsx`: an empty parsed description renders no **Description** block at all, rather than an `_(empty)_` placeholder.

## Tests

`user-turn-body.test.ts` covers the envelope with no description, a self-closing one, an element cut before its closing tag, an attributed element, and the unshaped context. `turn-facts.test.tsx` asserts the reported turn prints its issue row and no Description block, and that a cut description still renders beside the "Context truncated" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
