### PR TITLE
feat(daemon): a confined session's directory is its own clone, not a worktree of the primary

### DIFF
--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -321,9 +321,11 @@ the parent of anything.
   exist only in the clone.
 - **Review sessions** fetch `refs/pull/<n>/merge` into the clone and verify the
   checked-out HEAD exactly as today.
-- **Retirement** applies the same dirty and unique-commit rules in the clone and
-  then removes the directory; there is no worktree registry to prune and no
-  branch to delete in the primary.
+- **Retirement** applies the same dirty and unique-commit rules in the clone —
+  every local ref counts, not only HEAD, because the directory is the object
+  store and a side branch or a stash is work the checked-out branch cannot speak
+  for — and then removes the directory; there is no worktree registry to prune
+  and no branch to delete in the primary.
 - **Console push and Git reads** resolve the session root as today.
 - **Sandbox grants** are per session and exact: the clone's `.git` writable,
   its `hooks` and `config` read-only, for both the outer sandbox and a runtime's

--- a/packages/daemon/src/acp/codex-permission-profiles.ts
+++ b/packages/daemon/src/acp/codex-permission-profiles.ts
@@ -15,7 +15,10 @@ export interface CodexPermissionProfileConfig {
 
 export interface CodexPermissionProfileOptions {
   protectedRoots: readonly string[]
+  /** Owner checkouts' `.git`, whose `worktrees/**` hold the session worktrees' admin dirs. */
   writableGitMetadataRoots?: readonly string[]
+  /** A session's own clones' `.git` (git-workspace-model §11): exact entries, nothing hangs off them. */
+  sessionGitMetadataRoots?: readonly string[]
   allowModelToolUnixSockets?: boolean
   disableUnifiedExec?: boolean
 }
@@ -55,7 +58,8 @@ export function codexPermissionProfileConfig(
 ): CodexPermissionProfileConfig | undefined {
   const protectedRoots = [...new Set(opts.protectedRoots.map((root) => normalize(root)))]
   const writableGitMetadataRoots = [...new Set((opts.writableGitMetadataRoots ?? []).map((root) => normalize(root)))]
-  const policyRoots = [...protectedRoots, ...writableGitMetadataRoots]
+  const sessionGitMetadataRoots = [...new Set((opts.sessionGitMetadataRoots ?? []).map((root) => normalize(root)))]
+  const policyRoots = [...protectedRoots, ...writableGitMetadataRoots, ...sessionGitMetadataRoots]
   if (policyRoots.length === 0 && !opts.allowModelToolUnixSockets && !opts.disableUnifiedExec) return undefined
   if (policyRoots.some((root) => !isAbsolute(root))) {
     throw new Error('Codex permission roots must be absolute paths')
@@ -69,13 +73,16 @@ export function codexPermissionProfileConfig(
           )}`
         ]
       : []
-  // Most-specific match wins. `read` on hooks/config: `deny` also hides them, and Git cannot run at
-  // all without reading its config. `worktrees/**`: Codex's :workspace pins a session worktree's own
-  // admin dir read-only at a depth the parent grant cannot reach, so the subtree is named explicitly.
+  // Most-specific match wins; hooks/config get `read` (`deny` hides them, and Git needs its config); an owner `.git` names its `worktrees/**` because :workspace pins a worktree's admin dir read-only below the parent grant, while a session clone's `.git` (§11) is the exact pinned path and its entry alone reopens it.
   const agentFilesystemEntries: Array<[string, string]> = [
     ...writableGitMetadataRoots.map((root): [string, string] => [root, 'write']),
     ...writableGitMetadataRoots.flatMap((root): Array<[string, string]> => [
       [join(root, 'worktrees', '**'), 'write'],
+      [join(root, 'hooks'), 'read'],
+      [join(root, 'config'), 'read']
+    ]),
+    ...sessionGitMetadataRoots.flatMap((root): Array<[string, string]> => [
+      [root, 'write'],
       [join(root, 'hooks'), 'read'],
       [join(root, 'config'), 'read']
     ]),

--- a/packages/daemon/src/cp/workspace-scope.ts
+++ b/packages/daemon/src/cp/workspace-scope.ts
@@ -12,7 +12,6 @@
  * and the one it commits must be the same directory, and describing them two different ways is what
  * broke both panels. Extracted from the CP client's wiring so the routing is testable on its own.
  */
-import { join } from 'node:path'
 import type { Agent } from '../agents/agent-schema.js'
 import type { WorkspaceLocation } from '../workspace/workspace-files.js'
 import type { WorkspaceManager } from '../workspace/workspace-manager.js'
@@ -79,8 +78,9 @@ export function createWorkspaceScope(deps: WorkspaceScopeDeps): WorkspaceScope {
     if (!sessionId) return { root: root.path, scratch: false }
     const session = await deps.sessionOf(agent.id, sessionId)
     if (session?.workspaceIsolation !== 'session') return undefined
+    // The root's worktree at the session's id, or its clone in the session's own directory (§11).
     return {
-      root: join(root.worktreesPath, deps.workspaces.sessionWorktreeId(session.key)),
+      root: deps.workspaces.sessionRootDirectory(agent, root, session.key),
       scratch: false,
       sessionKey: session.key
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3748,8 +3748,13 @@ export class Daemon {
       skillsStateDir: join(this.root, 'skill-installs'),
       skillsAgentId: this.runtimeCatalog.entries[agent.runtime]?.skillsAgentId ?? null
     }
+    // §11: the session a per-session host serves gets its own clones, never a worktree of the primary.
     return request
-      ? this.workspaces.prepareSessionWorkspace(agent, request, opts)
+      ? this.workspaces.prepareSessionWorkspace(
+          agent,
+          this.perSessionHost(agent) ? { ...request, confined: true } : request,
+          opts
+        )
       : this.workspaces.prepareWorkspace(agent, opts)
   }
 
@@ -4293,7 +4298,10 @@ export class Daemon {
           ? (launchEnv) =>
               this.sandboxRuntimeReadRoots(agent, runtime, launchEnv, githubAppCredentials, gitlabCredentials)
           : undefined,
-        trustedWorkspaceWriteRoots: runInSandbox ? this.workspaces.trustedWorkspaceWriteRoots(agent) : undefined,
+        // A session host with its own clones (§11) writes its session directory alone; the launch derives its Git grants from it.
+        trustedWorkspaceWriteRoots: runInSandbox
+          ? this.workspaces.trustedWorkspaceWriteRoots(agent, hostKeySessionKey(opts.hostKey))
+          : undefined,
         // Not sandbox-gated: an unconfined Codex launch needs it too, its own profile protects `.git`.
         trustedPrimaryCheckout: this.workspaces.localPrimaryCheckoutFor(agent),
         sandboxMechanism: this.sandboxMechanism,
@@ -15701,8 +15709,10 @@ export class Daemon {
       // volume carries secondary worktrees, and the session row would be deleted without them ever
       // being judged. A pod that will not come up is THIS session's failure, never the whole
       // sweep's — it retries next pass.
+      // A session directory of its own (§11) is judged even when no shared root remains to hang a worktree off.
       const result = await this.withAgentVolume(rec.agentId, async () =>
-        (await this.workspaces.hasSessionWorktreeRoots(currentAgent))
+        (await this.workspaces.hasSessionWorktreeRoots(currentAgent)) ||
+        this.workspaces.confinedSessionDir(currentAgent, rec.key) !== undefined
           ? await this.workspaces.removeSessionWorktree(currentAgent, rec.key)
           : undefined
       ).catch((err: unknown): SessionWorktreeRemoval => ({ outcome: 'failed', error: (err as Error).message }))

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3390,17 +3390,8 @@ export class Daemon {
       // after origin convergence succeeds. Otherwise fall back to the ordinary
       // cold workspace path so a live host cannot keep serving an untrusted or
       // stale checkout.
-      if (change.workspaceRepoRename) {
-        try {
-          await this.enqueueAgentWorkspacePreparation(a as LoadedAgent, () =>
-            this.workspaces.convergeGithubAppWorkspaceRename(a as LoadedAgent)
-          )
-        } catch (err) {
-          workspaceNeedsColdRecovery = true
-          this.log.warn(
-            `workspace: canonical rename convergence for "${a.id}" failed; evicting its host: ${formatErr(err)}`
-          )
-        }
+      if (change.workspaceRepoRename && !(await this.convergeWorkspaceRename(a as LoadedAgent))) {
+        workspaceNeedsColdRecovery = true
       }
       // Pause is an operator stop, not merely a gate for the next message. Publish the
       // gate first so no new turn can enter, then interrupt every active logical session
@@ -4040,6 +4031,34 @@ export class Daemon {
       const fence = this.workspaceDispatchFences.get(agentId)
       if (!fence) return
       await fence
+    }
+  }
+
+  // A canonical rename converges the primary and every session clone in place, keeping warm hosts; a session clone that would not follow gets its host evicted (its next turn re-prepares and refuses an untrusted origin), and a primary that would not follow means the ordinary cold workspace path. Answers whether the warm hosts may stay.
+  private async convergeWorkspaceRename(agent: LoadedAgent): Promise<boolean> {
+    try {
+      const { unconvergedSessions } = await this.enqueueAgentWorkspacePreparation(agent, () =>
+        this.workspaces.convergeGithubAppWorkspaceRename(agent)
+      )
+      await this.evictSessionHosts(agent.id, unconvergedSessions)
+      return true
+    } catch (err) {
+      this.log.warn(
+        `workspace: canonical rename convergence for "${agent.id}" failed; evicting its host: ${formatErr(err)}`
+      )
+      return false
+    }
+  }
+
+  /** Stop the session-bound hosts of the agent whose session leaf (hostKeyDirName) is named — the directory they launched in no longer serves them. */
+  private async evictSessionHosts(agentId: string, leaves: readonly string[]): Promise<void> {
+    if (leaves.length === 0) return
+    for (const key of this.hostKeysForAgent(agentId)) {
+      if (hostKeySessionKey(key) === undefined || !leaves.includes(hostKeyDirName(key))) continue
+      this.log.warn(
+        `workspace: session clone ${hostKeyDirName(key)} of "${agentId}" kept its old origin — evicting its host`
+      )
+      await this.stopHostByKey(key)
     }
   }
 

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -2,7 +2,7 @@ import { chmodSync, existsSync, lstatSync, mkdirSync, readdirSync, realpathSync 
 import { homedir } from 'node:os'
 import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { sandboxBoundary, writeSandboxSettings, type SandboxMechanism } from '../acp/sandbox.js'
-import { hostKeyDirName, type HostKey } from '../acp/host-key.js'
+import { hostKeyDirName, hostKeySessionKey, type HostKey } from '../acp/host-key.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { compactReadRoots } from '../runtimes/read-roots.js'
 import { prepareSharedRuntimeCredentials, sharedCredentialProfile } from '../runtimes/runtime-credentials.js'
@@ -14,6 +14,7 @@ import {
 } from '../runtimes/runtime-home.js'
 import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
 import { primaryCheckoutIn, secondaryCheckoutsIn } from '../workspace/secondary-layout.js'
+import { isRealDir, sessionDirIn, sessionGitDirsIn } from '../workspace/session-layout.js'
 import {
   CLAUDE_PROFILE_ENV,
   claudeProtectedSettings,
@@ -54,6 +55,13 @@ function gitMetadataDirsIn(agentRoot: string, primaryCheckout: string): string[]
   return [primaryCheckout, ...secondaryCheckoutsIn(agentRoot)]
     .map((checkout) => join(checkout, '.git'))
     .filter((gitDir) => existsSync(gitDir) && lstatSync(gitDir).isDirectory())
+}
+
+/** The session directory a confined session host launches for (git-workspace-model §11); undefined for the shared host, and for a session host with no clones (a dream, a model session). */
+function confinedSessionDirOf(agentRoot: string, hostKey: HostKey | undefined): string | undefined {
+  if (hostKey === undefined || hostKeySessionKey(hostKey) === undefined) return undefined
+  const sessionDir = sessionDirIn(agentRoot, hostKeyDirName(hostKey))
+  return isRealDir(sessionDir) ? sessionDir : undefined
 }
 
 /** The same roots with NO outer boundary: one escaping the agent tree is left protected, not refused. */
@@ -414,11 +422,8 @@ export function prepareRuntimeLaunch(opts: {
       return trusted
     })
   )
-  // An isolated session's cwd is its own worktree, but that worktree's index — and every ref and
-  // object its commits write — live in the OWNER checkout's `.git`, which no other carve-back
-  // covers. Without these the confined runtime cannot even run `git status` in its own worktree.
-  // The primary checkout is the daemon's own record of it: a locally authored agent may keep a
-  // path the default layout does not name, and its worktrees still hang off THAT checkout.
+  // A confined session's clones own their `.git` (§11), so the primary's is never reopened for it; otherwise an isolated session's worktree keeps its index, refs and objects in the OWNER checkout's `.git`, which no other carve-back covers and which the daemon names (a locally authored agent may keep a path the layout does not).
+  const sessionDir = confinedSessionDirOf(agentRoot, opts.hostKey)
   const primaryCheckout = opts.trustedPrimaryCheckout
     ? safeRoot(opts.trustedPrimaryCheckout, 'trusted primary checkout')
     : primaryCheckoutIn(agentRoot)
@@ -426,13 +431,15 @@ export function prepareRuntimeLaunch(opts: {
     throw new Error(`trusted primary checkout "${primaryCheckout}" is outside the agent root`)
   }
   const gitMetadataWriteRoots = compactReadRoots(
-    gitMetadataDirsIn(agentRoot, primaryCheckout).map((gitDir) => {
-      const trusted = safeRoot(gitDir, 'git metadata root')
-      if (trusted === agentRoot || !inside(agentRoot, trusted)) {
-        throw new Error(`git metadata root "${trusted}" is outside the agent root`)
+    (sessionDir === undefined ? gitMetadataDirsIn(agentRoot, primaryCheckout) : sessionGitDirsIn(sessionDir)).map(
+      (gitDir) => {
+        const trusted = safeRoot(gitDir, 'git metadata root')
+        if (trusted === agentRoot || !inside(agentRoot, trusted)) {
+          throw new Error(`git metadata root "${trusted}" is outside the agent root`)
+        }
+        return trusted
       }
-      return trusted
-    })
+    )
   )
   const claudeRuntime = Boolean(opts.runtime && isClaudeRuntimeDef(opts.runtime))
   if (claudeRuntime) {
@@ -516,7 +523,10 @@ export function prepareRuntimeLaunch(opts: {
     )
     applyCodexPermissionProfile(env, {
       protectedRoots: protectedCredentialRoots,
-      writableGitMetadataRoots,
+      // A session's clones take the exact per-clone entries; an owner checkout's `.git` takes the worktree ones.
+      ...(sessionDir === undefined
+        ? { writableGitMetadataRoots }
+        : { sessionGitMetadataRoots: writableGitMetadataRoots }),
       allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true,
       disableUnifiedExec: true
     })

--- a/packages/daemon/src/workspace/session-layout.ts
+++ b/packages/daemon/src/workspace/session-layout.ts
@@ -74,3 +74,17 @@ function realDirEntries(dir: string): string[] {
 export function hasSessionsDirIn(agentRoot: string): boolean {
   return existsSync(sessionsDirIn(agentRoot))
 }
+
+/** Every session directory ON DISK under `<agentRoot>/sessions`, by leaf name, sorted; symlinks are skipped. */
+export function sessionDirsIn(agentRoot: string): { leaf: string; path: string }[] {
+  const parent = sessionsDirIn(agentRoot)
+  if (!isRealDir(parent)) return []
+  try {
+    return readdirSync(parent, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => ({ leaf: entry.name, path: join(parent, entry.name) }))
+      .sort((a, b) => (a.leaf < b.leaf ? -1 : a.leaf > b.leaf ? 1 : 0))
+  } catch {
+    return []
+  }
+}

--- a/packages/daemon/src/workspace/session-layout.ts
+++ b/packages/daemon/src/workspace/session-layout.ts
@@ -1,0 +1,76 @@
+import { existsSync, lstatSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { isRepoSegment, PRIMARY_CHECKOUT_DIR, SECONDARY_ROOTS_DIR } from './secondary-layout.js'
+
+// The on-disk shape of one confined session's directory, `<agentDir>/sessions/<leaf>/{workspace,repos/<owner>/<repo>}` (git-workspace-model.md §11) — separate from the manager, like secondary-layout.ts, so the launch path derives a session host's grants without the whole workspace module.
+
+/** Every confined session's directory hangs off one agent-owned parent. */
+export const SESSIONS_DIR = 'sessions'
+
+/** `<agentRoot>/sessions` — the parent of every session directory. */
+export function sessionsDirIn(agentRoot: string): string {
+  return join(agentRoot, SESSIONS_DIR)
+}
+
+/** `<agentRoot>/sessions/<leaf>` — one session's own directory. */
+export function sessionDirIn(agentRoot: string, leaf: string): string {
+  return join(sessionsDirIn(agentRoot), leaf)
+}
+
+/** One root's clone inside a session directory: the primary's `workspace`, a secondary's `repos/<owner>/<repo>`. */
+export function sessionRootCloneIn(sessionDir: string, repoFullName?: string): string {
+  if (repoFullName === undefined) return join(sessionDir, PRIMARY_CHECKOUT_DIR)
+  return join(sessionDir, SECONDARY_ROOTS_DIR, ...repoFullName.split('/'))
+}
+
+/** Every `repos/<owner>/<repo>` clone ON DISK in a session directory, sorted by name; symlinks are skipped. */
+export function sessionSecondaryClonesIn(sessionDir: string): { repoFullName: string; path: string }[] {
+  const parent = join(sessionDir, SECONDARY_ROOTS_DIR)
+  const out: { repoFullName: string; path: string }[] = []
+  for (const owner of realDirEntries(parent)) {
+    for (const repo of realDirEntries(join(parent, owner))) {
+      out.push({ repoFullName: `${owner}/${repo}`, path: join(parent, owner, repo) })
+    }
+  }
+  return out
+}
+
+/** Every clone a session directory holds — the primary's when it has one, then the secondaries'. */
+export function sessionClonesIn(sessionDir: string): { repoFullName?: string; path: string }[] {
+  const primary = sessionRootCloneIn(sessionDir)
+  return [...(isRealDir(primary) ? [{ path: primary }] : []), ...sessionSecondaryClonesIn(sessionDir)]
+}
+
+/** The `.git` DIRECTORY of every clone in a session directory — a clone's own, never a worktree's link file. */
+export function sessionGitDirsIn(sessionDir: string): string[] {
+  return sessionClonesIn(sessionDir)
+    .map((clone) => join(clone.path, '.git'))
+    .filter(isRealDir)
+}
+
+/** Whether `path` is a directory in its own right — never a symlink to one. */
+export function isRealDir(path: string): boolean {
+  try {
+    return lstatSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/** Real (never symlinked) child directories whose names are legal repository segments, sorted. */
+function realDirEntries(dir: string): string[] {
+  if (!isRealDir(dir)) return []
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && isRepoSegment(entry.name))
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+/** Whether the agent has any session directory at all — the cheap prefilter the retention GC wants. */
+export function hasSessionsDirIn(agentRoot: string): boolean {
+  return existsSync(sessionsDirIn(agentRoot))
+}

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -58,7 +58,15 @@ import {
 } from './secondary-layout.js'
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
 import { isSessionBranch, sessionBranchName } from './session-branch.js'
-import { hasSessionsDirIn, isRealDir, sessionClonesIn, sessionDirIn, sessionRootCloneIn } from './session-layout.js'
+import {
+  hasSessionsDirIn,
+  isRealDir,
+  sessionClonesIn,
+  sessionDirIn,
+  sessionRootCloneIn,
+  sessionsDirIn,
+  sessionDirsIn
+} from './session-layout.js'
 import { hostKeyDirName, sessionHostKey } from '../acp/host-key.js'
 import { DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
 import { SANDBOX_CHECKOUT_DIR } from '../shim/sandbox-paths.js'
@@ -1004,10 +1012,30 @@ export class WorkspaceManager {
     }
   }
 
-  async convergeGithubAppWorkspaceRename(agent: Agent): Promise<void> {
-    if (!this.usesGithubApp(agent)) return
+  /** Follow a canonical rename onto the primary AND every session clone of it (§11); the session leaves whose clone could not be repointed are returned for the caller to evict, since a live host there would keep pushing to the old origin. */
+  async convergeGithubAppWorkspaceRename(agent: Agent): Promise<{ unconvergedSessions: string[] }> {
+    if (!this.usesGithubApp(agent)) return { unconvergedSessions: [] }
     this.recordWorkspaceMaterialization(agent)
     await this.convergeWorkspaceOrigin(agent)
+    return { unconvergedSessions: await this.convergeSessionCloneOrigins(agent) }
+  }
+
+  /** Repoint each session's primary clone at the canonical origin, the way the primary just was; a clone that refuses (an origin off the managed host, a locked config) is reported by its leaf, not thrown, so one session cannot hold the rename of the rest. */
+  private async convergeSessionCloneOrigins(agent: Agent): Promise<string[]> {
+    if (this.sandboxMode) return []
+    const root = this.primaryRoot(agent)
+    const unconverged: string[] = []
+    for (const { leaf, path } of sessionDirsIn(this.agentRootFor(agent))) {
+      const clone = sessionRootCloneIn(path)
+      if (!isRealDir(join(clone, '.git'))) continue
+      try {
+        await this.convergeOriginInPlaceFor(agent.id, root, clone)
+      } catch (err) {
+        workspaceLog.warn(`workspace: session clone ${leaf} of agent "${agent.id}" kept its origin (${formatErr(err)})`)
+        unconverged.push(leaf)
+      }
+    }
+    return unconverged
   }
 
   ensureWorkspaceMaterialization(agent: Agent): void {
@@ -1176,9 +1204,10 @@ export class WorkspaceManager {
     return await this.validateWorktreesRoot(agent, worktreesPath)
   }
 
-  /** An `rmSync`, so its subject can only ever be this daemon's own disk. */
+  /** Discard every per-session directory of the agent — the worktrees parent and every session's own clones (§11) alike, since a replaced workspace makes both describe a repository the agent no longer has. An `rmSync`, so its subject can only ever be this daemon's own disk. */
   clearSessionWorktrees(agent: Agent): void {
     rmSync(this.localWorktreesPathFor(agent), { recursive: true, force: true })
+    rmSync(sessionsDirIn(this.agentRootFor(agent)), { recursive: true, force: true })
   }
 
   sessionWorktreeId(sessionKey: string): string {

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -58,6 +58,8 @@ import {
 } from './secondary-layout.js'
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
 import { isSessionBranch, sessionBranchName } from './session-branch.js'
+import { hasSessionsDirIn, isRealDir, sessionClonesIn, sessionDirIn, sessionRootCloneIn } from './session-layout.js'
+import { hostKeyDirName, sessionHostKey } from '../acp/host-key.js'
 import { DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
 import { SANDBOX_CHECKOUT_DIR } from '../shim/sandbox-paths.js'
 
@@ -99,11 +101,16 @@ export interface WorkspaceRoot {
   path: string
   /** Where this root's per-session worktrees live. */
   worktreesPath: string
+  /** The `owner/repo` a secondary root's subtrees are keyed by (`repos/<owner>/<repo>`); absent for the primary. */
+  repoFullName?: string
   /** Credentials ride the github-app helper (vs anonymous). */
   githubApp: boolean
   /** The managed host this root's credential channel pins, resolved from the spec (§24.4). */
   managed?: ManagedCredentialScope
 }
+
+/** What places one root's per-session directory: its worktrees parent on the worktree tier, its `owner/repo` on the clone tier (§11) — absent ⇒ the primary's `workspace`. */
+export type SessionRootLocator = Pick<WorkspaceRoot, 'path' | 'worktreesPath' | 'repoFullName'>
 
 /** One authorized additional repository as a root beside the primary (design decision 1). */
 export interface SecondaryWorkspaceRoot extends WorkspaceRoot {
@@ -168,6 +175,8 @@ export interface PrepareSessionWorkspaceRequest {
   /** Use an empty daemon-owned cwd when an exact local review checkout is
    * unavailable. The model must inspect the trusted revision through GitHub. */
   githubReviewRevisionOnly?: true
+  /** An OS boundary encloses this session's runtime (§11): its directory is a clone of every root under `sessions/<leaf>/`, never a worktree of the primary. */
+  confined?: boolean
 }
 
 const PULL_TIMEOUT_MS = 4500
@@ -525,9 +534,8 @@ export class WorkspaceManager {
         roots.push({ path: root.path, repoFullName: root.repoFullName, branch: root.branch })
         continue
       }
-      const cwd = join(root.worktreesPath, id)
-      // The `.git` marker is what `worktree add` writes, so its presence is the proof that this
-      // root's per-session checkout exists rather than a directory a failed attempt left behind.
+      const cwd = this.sessionRootDirectory(agent, root, request!.sessionKey!)
+      // The `.git` marker is what `worktree add` (or a clone) writes: proof of a checkout, not of a failed attempt's leftover.
       if ((await fs.stat(join(cwd, '.git'))) === 'missing') continue
       roots.push({
         path: this.canonicalWorkspacePath(agent.id, cwd),
@@ -559,13 +567,7 @@ export class WorkspaceManager {
   ): Promise<ReadyWorkspaceRoot | undefined> {
     if (agent.workspace.mode !== 'git-repo' || !agent.workspace.gitRepo) return undefined
     if ((await this.sessionCwdRepoFullName(agent, request)) === undefined) return undefined
-    const mount = this.sandboxMountFor(agent.id)
-    const path = await this.sessionRootPath(
-      agent,
-      this.primaryCheckoutAt(agent, mount),
-      this.worktreesPathAt(agent, mount),
-      request
-    )
+    const path = await this.sessionRootPath(agent, this.primaryLocator(agent), request)
     // Same proof the secondaries answer to: a checkout the session did not get is not named here.
     if ((await this.fsFor(agent.id).stat(join(path, '.git'))) === 'missing') return undefined
     return {
@@ -575,16 +577,16 @@ export class WorkspaceManager {
     }
   }
 
-  /** One root's directory for a session: its per-session worktree, or the checkout itself when the
-   *  session shares every root (decision 4). */
-  private async sessionRootPath(
-    agent: Agent,
-    checkout: string,
-    worktreesPath: string,
-    request?: SessionRootScope
-  ): Promise<string> {
+  /** One root's directory for a session: its per-session worktree or clone, or the checkout itself when the session shares every root (decision 4). */
+  private async sessionRootPath(agent: Agent, root: SessionRootLocator, request?: SessionRootScope): Promise<string> {
     const id = await this.sessionWorktreeIdFor(agent, request)
-    return id === undefined ? checkout : join(worktreesPath, id)
+    return id === undefined ? root.path : this.sessionRootDirectory(agent, root, request!.sessionKey!)
+  }
+
+  /** The primary checkout as a locator, in the coordinates of whichever filesystem holds it. */
+  private primaryLocator(agent: Agent): SessionRootLocator {
+    const mount = this.sandboxMountFor(agent.id)
+    return { path: this.primaryCheckoutAt(agent, mount), worktreesPath: this.worktreesPathAt(agent, mount) }
   }
 
   /** The id naming this session's worktrees, or undefined when it shares the roots' checkouts. A
@@ -630,7 +632,7 @@ export class WorkspaceManager {
     const id = this.sessionWorktreeId(sessionKey)
     for (const entry of await this.secondarySubtreesFor(agent)) {
       if ((await fs.stat(sessionCwdMarkerIn(entry.subtree, id))) === 'missing') continue
-      if ((await fs.stat(join(entry.worktreesPath, id, '.git'))) === 'missing') continue
+      if ((await fs.stat(join(this.sessionRootDirectory(agent, entry, sessionKey), '.git'))) === 'missing') continue
       return entry
     }
     return undefined
@@ -1125,16 +1127,11 @@ export class WorkspaceManager {
     return this.worktreesPathFor(agent)
   }
 
-  /**
-   * The daemon-owned parents a sandboxed runtime must be able to write, given that
-   * `sandboxBoundary` denies read on the agent directory and carves back only what it is told.
-   *
-   * The secondary parent is granted to EVERY sandboxed agent, scratch included: a host is
-   * long-lived per agent, so a root materialized under a running one has to already be inside the
-   * boundary or it stays invisible until the next spawn.
-   */
-  trustedWorkspaceWriteRoots(agent: Agent): string[] {
+  // The daemon-owned parents a sandboxed runtime may write (`sandboxBoundary` hides the agent dir and carves back only what it is told): a session with its own directory (§11) gets that alone — the primary's worktrees and the shared secondary checkouts are what its clones keep it out of — while otherwise every sandboxed agent, scratch included, gets the secondary parent up front, since a root materialized under a long-lived host would otherwise stay invisible until the next spawn.
+  trustedWorkspaceWriteRoots(agent: Agent, sessionKey?: string): string[] {
     // This host's own sandbox boundary, so a pod path here would carve out nothing.
+    const sessionDir = sessionKey === undefined ? undefined : this.confinedSessionDir(agent, sessionKey)
+    if (sessionDir !== undefined) return [sessionDir]
     return [
       ...(agent.workspace.mode === 'git-repo' ? [this.localWorktreesPathFor(agent)] : []),
       this.secondaryRootsDir(agent)
@@ -1188,24 +1185,41 @@ export class WorkspaceManager {
     return createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)
   }
 
+  /** The primary's per-session directory: its clone when the session has its own directory (§11), else its worktree. */
   sessionWorktreePath(agent: Agent, sessionKey: string): string {
-    return join(this.sessionWorktreeRoot(agent), this.sessionWorktreeId(sessionKey))
+    return this.sessionRootDirectory(agent, this.primaryLocator(agent), sessionKey)
+  }
+
+  /** `<agentDir>/sessions/<leaf>` — the directory a confined session owns, whether or not it exists yet (§11); the leaf is the session host's, so policy directory and clones name one session. */
+  sessionDir(agent: Agent, sessionKey: string): string {
+    return sessionDirIn(this.agentRootFor(agent), hostKeyDirName(sessionHostKey(agent.id, sessionKey)))
+  }
+
+  /** The session's own directory when it HAS one on this disk, else undefined — the disk, not the request, decides a session's tier, so reads and preparation cannot disagree. */
+  confinedSessionDir(agent: Agent, sessionKey: string): string | undefined {
+    // A pod agent's sessions live on its volume as worktrees; nothing here is its.
+    if (this.sandboxMode) return undefined
+    const dir = this.sessionDir(agent, sessionKey)
+    return isRealDir(dir) ? dir : undefined
+  }
+
+  /** One root's per-session directory: its clone in the session's own directory when the session has one, else its worktree at the session's id — derived, never stored. */
+  sessionRootDirectory(agent: Agent, root: SessionRootLocator, sessionKey: string): string {
+    const sessionDir = this.confinedSessionDir(agent, sessionKey)
+    if (sessionDir !== undefined) return sessionRootCloneIn(sessionDir, root.repoFullName)
+    return join(root.worktreesPath, this.sessionWorktreeId(sessionKey))
   }
 
   /** Every root that can hold a per-session worktree: the primary when there is one, plus every
    *  MATERIALIZED secondary subtree on disk — a retired root's worktrees are this session's too
    *  (decision 12), while a subtree a failed clone left behind owns none and has no checkout for
    *  Git to run in, which would fail the whole session's cleanup forever. */
-  async sessionWorktreeRoots(agent: Agent): Promise<Pick<WorkspaceRoot, 'path' | 'worktreesPath'>[]> {
+  async sessionWorktreeRoots(agent: Agent): Promise<SessionRootLocator[]> {
     const fs = this.fsFor(agent.id)
-    const mount = this.sandboxMountFor(agent.id)
-    const roots: Pick<WorkspaceRoot, 'path' | 'worktreesPath'>[] =
-      agent.workspace.mode === 'git-repo'
-        ? [{ path: this.primaryCheckoutAt(agent, mount), worktreesPath: this.worktreesPathAt(agent, mount) }]
-        : []
-    for (const { path, worktreesPath } of await this.secondarySubtreesFor(agent)) {
+    const roots: SessionRootLocator[] = agent.workspace.mode === 'git-repo' ? [this.primaryLocator(agent)] : []
+    for (const { path, worktreesPath, repoFullName } of await this.secondarySubtreesFor(agent)) {
       if ((await fs.stat(join(path, '.git'))) === 'missing') continue
-      roots.push({ path, worktreesPath })
+      roots.push({ path, worktreesPath, repoFullName })
     }
     return roots
   }
@@ -1234,7 +1248,12 @@ export class WorkspaceManager {
   mayOwnSessionWorktrees(agent: Agent): boolean {
     if (agent.workspace.mode === 'git-repo') return true
     if ((agent.workspace.additionalRepos ?? []).length > 0) return true
-    return this.sandboxMode || secondarySubtreesIn(this.agentRootFor(agent)).length > 0
+    // A session directory (§11) may hold clones of roots whose rows are gone; it is judged the same way.
+    return (
+      this.sandboxMode ||
+      secondarySubtreesIn(this.agentRootFor(agent)).length > 0 ||
+      hasSessionsDirIn(this.agentRootFor(agent))
+    )
   }
 
   /**
@@ -1249,20 +1268,75 @@ export class WorkspaceManager {
    */
   async removeSessionWorktree(agent: Agent, sessionKey: string): Promise<SessionWorktreeRemoval> {
     const roots = await this.sessionWorktreeRoots(agent)
-    if (roots.length === 0) return { outcome: 'failed', error: 'agent workspace is not a Git repository' }
+    const sessionDir = this.confinedSessionDir(agent, sessionKey)
+    if (roots.length === 0 && sessionDir === undefined) {
+      return { outcome: 'failed', error: 'agent workspace is not a Git repository' }
+    }
     const id = this.sessionWorktreeId(sessionKey)
     let retained: SessionWorktreeRemoval | undefined
     let failed: SessionWorktreeRemoval | undefined
     let removed = false
-    for (const root of roots) {
-      const result = await this.removeRootSessionWorktree(agent, root, id)
+    const note = (result: SessionWorktreeRemoval): void => {
       if (result.outcome === 'retained') retained ??= result
       else if (result.outcome === 'failed') failed ??= result
       else if (result.outcome === 'removed') removed = true
     }
+    // The session's own directory first (§11), then any worktree left from before the agent was confined — the legacy loop also drops the shared roots' review refs, registrations and cwd attestation.
+    if (sessionDir !== undefined) note(await this.removeSessionClones(agent, sessionDir, id))
+    for (const root of roots) note(await this.removeRootSessionWorktree(agent, root, id))
     const kept = retained ?? failed
     if (kept) return removed ? { ...kept, partial: true } : kept
     return removed ? { outcome: 'removed' } : { outcome: 'absent' }
+  }
+
+  // Remove one confined session's directory with every clone in it (§11) under a session worktree's rules — clean tree, no commit unreachable from a remote, review snapshots exempt — over EVERY local ref, not just HEAD: this removes the object store, so a side branch or a stash is work the checked-out branch cannot speak for.
+  private async removeSessionClones(agent: Agent, sessionDir: string, id: string): Promise<SessionWorktreeRemoval> {
+    const fs = this.fsFor(agent.id)
+    try {
+      const canonical = await this.validateSessionDir(agent, sessionDir)
+      for (const clone of sessionClonesIn(canonical)) {
+        if ((await fs.stat(join(clone.path, '.git'))) === 'missing') {
+          // No `.git` to interrogate: reclaim only a provably empty leftover, in one operation.
+          if (!(await fs.rmdir(clone.path))) return { outcome: 'retained', reason: 'dirty' }
+          continue
+        }
+        const git = this.runnerFor(agent.id, clone.path).withEnv(workspaceGitLocalEnv())
+        // Fetched review refs mark the clone as a daemon-owned review snapshot, reset on every delivery.
+        let snapshot: boolean | undefined
+        const isReviewSnapshot = async () =>
+          (snapshot ??=
+            (await git.raw(['for-each-ref', '--count=1', `refs/agentconnect/reviews/${id}`]).catch(() => '')).trim() !==
+            '')
+        if ((await git.raw(['status', '--porcelain'])).trim() !== '' && !(await isReviewSnapshot())) {
+          return { outcome: 'retained', reason: 'dirty' }
+        }
+        const unique = (
+          await git.raw([
+            'rev-list',
+            '--count',
+            '--all',
+            '--not',
+            '--remotes',
+            `--glob=refs/agentconnect/reviews/${id}`
+          ])
+        ).trim()
+        if (unique !== '0' && !(await isReviewSnapshot())) return { outcome: 'retained', reason: 'unique-commits' }
+      }
+      await fs.rmTree(canonical)
+      return { outcome: 'removed' }
+    } catch (err) {
+      return { outcome: 'failed', error: (err as Error).message }
+    }
+  }
+
+  /** Canonicalize a session directory and prove it still resolves inside the agent directory, as every destructive worktree path does through {@link validateWorktreesRoot}. */
+  private async validateSessionDir(agent: Agent, sessionDir: string): Promise<string> {
+    if ((await this.fsFor(agent.id).stat(sessionDir)) === 'other')
+      throw new Error('session directory must not be a symlink')
+    const agentRoot = realpathSync(this.agentRootFor(agent))
+    const canonical = realpathSync(sessionDir)
+    if (escapesRoot(agentRoot, canonical)) throw new Error('session directory resolves outside the agent directory')
+    return canonical
   }
 
   /** The agent's secondary subtrees whose `.materialization.json` no longer matches a current row —
@@ -1575,21 +1649,25 @@ export class WorkspaceManager {
     initiatedBy?: string
   ): Promise<void> {
     const git = () => this.runnerFor(agentId, root.path).withEnv(workspaceGitLocalEnv())
-    let branch = ''
-    for (let attempt = 0; ; attempt++) {
-      branch = sessionBranchName(initiatedBy, attempt >= SESSION_BRANCH_DRAWS)
-      if (attempt >= SESSION_BRANCH_DRAWS) break
-      const taken = await git()
-        .raw(['show-ref', '--verify', '--quiet', `refs/heads/${branch}`])
-        .then(() => true)
-        .catch(() => false)
-      if (!taken) break
-    }
+    const branch = await this.drawSessionBranch(git(), initiatedBy)
     // --no-track: the start point is a remote-tracking ref, so git's own `branch.autoSetupMerge`
     // would otherwise make `origin/<base>` this branch's upstream. That upstream is what the console's
     // push authorizes against — it would turn the push button into a remote-branch creator — and it
     // leaves a plain `git push` failing under push.default=simple on the name mismatch.
     await git().raw(['worktree', 'add', '-b', branch, '--no-track', cwd, target])
+  }
+
+  /** A session branch name the repository `git` runs in does not hold yet — word pairs first, random bytes once the draws are spent; not `--quiet`, whose silent exit 1 the runner resolves as if the ref existed, which made every draw read as taken. */
+  private async drawSessionBranch(git: GitRunner, initiatedBy?: string): Promise<string> {
+    for (let attempt = 0; ; attempt++) {
+      const branch = sessionBranchName(initiatedBy, attempt >= SESSION_BRANCH_DRAWS)
+      if (attempt >= SESSION_BRANCH_DRAWS) return branch
+      const taken = await git
+        .raw(['show-ref', '--verify', `refs/heads/${branch}`])
+        .then(() => true)
+        .catch(() => false)
+      if (!taken) return branch
+    }
   }
 
   async prepareSessionWorkspace(
@@ -1623,7 +1701,7 @@ export class WorkspaceManager {
     // branch it off — but its secondaries still get per-session worktrees (decisions 4 and 5).
     const cwd =
       agent.workspace.mode === 'git-repo'
-        ? await this.prepareRootSessionWorktree(agent, this.primaryRoot(agent), request)
+        ? await this.prepareRootSessionDirectory(agent, this.primaryRoot(agent), request)
         : undefined
     await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent), request)
     if (cwd === undefined) return primary
@@ -1669,7 +1747,7 @@ export class WorkspaceManager {
     if (!prepared) {
       throw new Error(`github review checkout of ${root.repoFullName} is unavailable to agent "${agent.id}"`)
     }
-    const cwd = await this.prepareRootSessionWorktree(agent, prepared, request)
+    const cwd = await this.prepareRootSessionDirectory(agent, prepared, request)
     await this.prepareReferenceSessionWorktrees(agent, this.referenceRootsOf(agent, prepared.repoFullName), request)
     // The same post-steps the primary cwd gets, deliberately: skills install into the working
     // directory, and the reviewed root is the one the model stands in. `agentDir` is the primary's.
@@ -1736,11 +1814,12 @@ export class WorkspaceManager {
     const rootRequest: PrepareSessionWorkspaceRequest = {
       sessionKey: request.sessionKey,
       isolation: 'session',
-      ...(request.initiatedBy !== undefined ? { initiatedBy: request.initiatedBy } : {})
+      ...(request.initiatedBy !== undefined ? { initiatedBy: request.initiatedBy } : {}),
+      ...(request.confined ? { confined: true } : {})
     }
     for (const { root, label } of roots) {
       try {
-        await this.prepareRootSessionWorktree(agent, root, rootRequest)
+        await this.prepareRootSessionDirectory(agent, root, rootRequest)
       } catch (err) {
         workspaceLog.warn(`workspace: ${label} has no session worktree for agent "${agent.id}" (${formatErr(err)})`)
       }
@@ -1791,6 +1870,113 @@ export class WorkspaceManager {
       throw new Error('github review worktree HEAD does not match the verified revision')
     }
     return cwd
+  }
+
+  /** One root's per-session directory on whichever tier the session is: a session with its own directory keeps it, a confined request gets one (§11), anything else is a worktree. */
+  private async prepareRootSessionDirectory(
+    agent: Agent,
+    root: WorkspaceRoot,
+    request: PrepareSessionWorkspaceRequest
+  ): Promise<string> {
+    if (request.confined || this.confinedSessionDir(agent, request.sessionKey) !== undefined) {
+      return await this.prepareRootSessionClone(agent, root, request)
+    }
+    return await this.prepareRootSessionWorktree(agent, root, request)
+  }
+
+  // The stable per-session CLONE of one root (§11) on its own generated branch at the root's tip — or at the reviewed revision, fetched into the clone itself and verified exactly as a worktree's is; its `.git` is the session's own, so nothing it writes touches the primary.
+  private async prepareRootSessionClone(
+    agent: Agent,
+    root: WorkspaceRoot,
+    request: PrepareSessionWorkspaceRequest
+  ): Promise<string> {
+    const fs = this.fsFor(agent.id)
+    const id = this.sessionWorktreeId(request.sessionKey)
+    const sessionDir = this.sessionDir(agent, request.sessionKey)
+    if ((await fs.stat(sessionDir)) === 'other') throw new Error('session directory must not be a symlink')
+    await fs.mkdir(sessionDir, 0o700)
+    const canonicalSessionDir = await this.validateSessionDir(agent, sessionDir)
+    const cwd = sessionRootCloneIn(canonicalSessionDir, root.repoFullName)
+    if ((await fs.stat(cwd)) === 'other') throw new Error('session clone path must not be a symlink')
+    // A clone's `.git` is a directory; a link file there is a worktree, which is never this tier's.
+    let attached = (await fs.stat(join(cwd, '.git'))) === 'dir'
+    if (attached) {
+      try {
+        await this.revParse(agent.id, cwd, 'HEAD')
+      } catch {
+        attached = false
+      }
+    }
+    if (!attached) {
+      await fs.rmTree(cwd)
+      await fs.mkdir(dirname(cwd), 0o700)
+      const staged = `${cwd}.clone-${randomUUID()}`
+      try {
+        await this.cloneSessionRootAt(agent.id, root, staged)
+        await fs.rename(staged, cwd)
+      } catch (err) {
+        await fs.rmTree(staged)
+        // A session directory that ended up holding nothing says nothing about the session: reclaim it.
+        await fs.rmdir(canonicalSessionDir).catch(() => false)
+        throw new Error(`session clone of ${root.cloneUrl} failed: ${formatErr(err)}`, { cause: err })
+      }
+    } else if (root.githubApp) {
+      // A resumed clone gets what a resumed primary gets: the canonical origin and a live helper pin.
+      await this.convergeOriginInPlaceFor(agent.id, root, cwd)
+      await writeRepoHelperConfig(this.runnerFor(agent.id, cwd), agent.id, root.managed).catch(() => undefined)
+    }
+    // Into the clone, never the primary: the refs, and the exact-HEAD proof, are this session's alone.
+    const review = request.review
+      ? await this.fetchReviewRevisionIn(agent.id, { ...root, path: cwd, worktreesPath: '' }, id, request.review)
+      : undefined
+    const target = review?.checkout ?? `refs/remotes/origin/${root.branch}`
+    // Unsafe executable config gates the checkout itself, as it gates a worktree's creation.
+    await assertSafeWorkspaceGitConfig(this.runnerFor(agent.id, cwd))
+    if (!attached) {
+      await this.checkoutSessionBranch(agent.id, root, cwd, target, request.initiatedBy)
+    } else if (review) {
+      const git = this.runnerFor(agent.id, cwd).withEnv(this.sessionCloneGitEnv(agent.id, root))
+      await git.raw(['reset', '--hard', target])
+      await git.raw(['clean', '-ffdx'])
+    }
+    if (review && (await this.revParse(agent.id, cwd, 'HEAD')).toLowerCase() !== review.checkout) {
+      throw new Error('github review clone HEAD does not match the verified revision')
+    }
+    return cwd
+  }
+
+  // A blobless partial clone of one root for a session (§11) — whole history, file contents on demand — straight from the remote through the daemon's credential path like a primary's first clone: never a hardlink of the primary (a session with write on its own `.git` could reach the shared inodes), never `--shared`; a remote that refuses the filter answers with a full clone, and a clone that fails fails the session.
+  private async cloneSessionRootAt(agentId: string, root: WorkspaceRoot, cwd: string): Promise<void> {
+    if (root.githubApp) await preWarmGitCred(agentId, 'clone')
+    const git = this.runnerFor(agentId).withEnv(this.sessionCloneGitEnv(agentId, root))
+    await git.clone(root.cloneUrl, cwd, ['--filter=blob:none', '--branch', root.branch, '--single-branch'])
+    if (root.githubApp) await writeRepoHelperConfig(this.runnerFor(agentId, cwd), agentId, root.managed)
+  }
+
+  /** The env for daemon-run Git that materializes a session clone's tree (the clone, the branch checkout, a review reset): a blobless clone fetches file contents on demand from the promisor remote, which the usual `GIT_NO_LAZY_FETCH=1` refuses, so these permit it and carry the credential channel; everything local keeps `workspaceGitLocalEnv`. */
+  private sessionCloneGitEnv(agentId: string, root: WorkspaceRoot): Record<string, string> {
+    const base = root.githubApp
+      ? { ...workspaceGitEnvBase(root.cloneUrl), ...cloneGitEnv(agentId, root.cloneUrl, root.managed) }
+      : { ...workspaceGitEnvBase(root.cloneUrl), GIT_TERMINAL_PROMPT: '0' }
+    return { ...base, GIT_NO_LAZY_FETCH: '0' }
+  }
+
+  /** Check the clone out on its own generated branch at `target` — the draw {@link addRootSessionWorktree} makes, `--no-track` for the same reason. */
+  private async checkoutSessionBranch(
+    agentId: string,
+    root: WorkspaceRoot,
+    cwd: string,
+    target: string,
+    initiatedBy?: string
+  ): Promise<void> {
+    const branch = await this.drawSessionBranch(
+      this.runnerFor(agentId, cwd).withEnv(workspaceGitLocalEnv()),
+      initiatedBy
+    )
+    // The checkout materializes the tree, so it may lazily fetch: the clone env, not the local one.
+    await this.runnerFor(agentId, cwd)
+      .withEnv(this.sessionCloneGitEnv(agentId, root))
+      .raw(['checkout', '--no-track', '-b', branch, target])
   }
 
   clusterWorkspaceCwd(agent: Agent, runtimeRoot: string | undefined, request?: ClusterSessionScope): string {
@@ -2105,15 +2291,10 @@ export class WorkspaceManager {
       const root = (await this.secondarySubtreesFor(agent)).find((entry) => repoKey(entry.repoFullName) === key)
       // A subtree that is no longer on disk cannot vouch for the cwd; fall through to the primary,
       // which the cwd is not under either, so the containment check refuses it.
-      if (root) return await this.sessionRootPath(agent, root.path, root.worktreesPath, request)
+      if (root) return await this.sessionRootPath(agent, root, request)
     }
     if (agent.workspace.mode !== 'git-repo') return undefined
-    return await this.sessionRootPath(
-      agent,
-      this.primaryCheckoutAt(agent, mount),
-      this.worktreesPathAt(agent, mount),
-      request
-    )
+    return await this.sessionRootPath(agent, this.primaryLocator(agent), request)
   }
 
   resolveAcpCwd(workspaceRoot: string, agentDir: string | undefined): string {

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -1055,7 +1055,7 @@ describe('secondary roots on the pod volume', () => {
 
     expect(await workspaces.hasSessionWorktreeRoots(agent)).toBe(true)
     expect(await workspaces.sessionWorktreeRoots(agent)).toEqual([
-      { path: `${INFRA}/checkout`, worktreesPath: `${INFRA}/worktrees` }
+      { path: `${INFRA}/checkout`, worktreesPath: `${INFRA}/worktrees`, repoFullName: 'acme/infra' }
     ])
     worktreeStatus = ' M a.txt\n'
     expect(await workspaces.removeSessionWorktree(agent, 'sess-1')).toEqual({

--- a/packages/daemon/test/codex-permission-profiles.test.ts
+++ b/packages/daemon/test/codex-permission-profiles.test.ts
@@ -93,6 +93,33 @@ describe.skipIf(process.platform === 'win32')('Codex permission profile launch c
     }
   })
 
+  // A session clone's `.git` is the exact path :workspace pins (§11): its entry alone reopens it, hooks and config stay `read`, and no worktrees subtree hangs off it.
+  it('opens a session clone .git exactly: write, hooks and config read, no worktrees subtree', () => {
+    const primary = '/agent/sessions/session-1/workspace/.git'
+    const secondary = '/agent/sessions/session-1/repos/acme/infra/.git'
+    const config = codexPermissionProfileConfig({
+      protectedRoots: ['/agent/home/.codex'],
+      sessionGitMetadataRoots: [primary, secondary]
+    })!
+
+    expect(config.configOverrides).toContain(
+      'permissions.agentconnect-protected-workspace.filesystem={ ' +
+        `"${primary}" = "write", "${primary}/hooks" = "read", "${primary}/config" = "read", ` +
+        `"${secondary}" = "write", "${secondary}/hooks" = "read", "${secondary}/config" = "read", ` +
+        '"/agent/home/.codex" = "deny" }'
+    )
+    const agent = config.configOverrides.find((value) =>
+      value.startsWith('permissions.agentconnect-protected-workspace.filesystem=')
+    )!
+    expect(agent).not.toContain('worktrees')
+    expect(agent).not.toContain('= "deny" }"') // no clone path is denied
+    expect(
+      config.configOverrides.find((value) =>
+        value.startsWith('permissions.agentconnect-protected-read-only.filesystem=')
+      )
+    ).not.toContain('/agent/sessions')
+  })
+
   // agent-full-access is deliberately unconfined; the paired deny belongs only where the write was granted.
   it('leaves the full-access profile untouched by the Git metadata grant', () => {
     const config = codexPermissionProfileConfig({

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -277,6 +277,25 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     expect(existsSync(two.launch.sandbox!.settingsPath)).toBe(true)
   })
 
+  // git-workspace-model §11: the same predicate that gives the session its own host gives it its own clones.
+  it('asks the session workspace for its own clone directory only under a confined launch', async () => {
+    const confined = await startDaemon(scaffold())
+    const confinedPrepare = vi.spyOn((confined.daemon as any).workspaces, 'prepareSessionWorkspace')
+    await (confined.daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    expect(confinedPrepare).toHaveBeenCalled()
+    expect(confinedPrepare.mock.calls.at(-1)![1]).toMatchObject({ sessionKey: KEY('T1'), confined: true })
+    await confined.daemon.stop()
+
+    // A shared host's cold gate prepares no session workspace for a scratch agent, so ask the funnel directly.
+    const open = await startDaemon(scaffold({ runInSandbox: false }))
+    const openPrepare = vi.spyOn((open.daemon as any).workspaces, 'prepareSessionWorkspace')
+    const request = { sessionKey: KEY('T1'), isolation: 'session' as const }
+    await (open.daemon as any).runAgentWorkspacePreparation((open.daemon as any).agents.get('bot-a'), request)
+    expect(openPrepare).toHaveBeenCalledTimes(1)
+    expect(openPrepare.mock.calls[0]![1]).toEqual(request)
+    await open.daemon.stop()
+  })
+
   it('gives a resumed session its own host again after a daemon restart', async () => {
     const root = scaffold()
     const first = await startDaemon(root)

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -296,6 +296,31 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     await open.daemon.stop()
   })
 
+  // A canonical rename keeps warm hosts only where the clone followed: the session whose clone kept its old origin loses its host, the others keep theirs.
+  it('evicts only the session hosts whose clone would not follow a canonical rename', async () => {
+    const { daemon, hosts } = await startDaemon(scaffold())
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    await (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+    const first = sessionHostKey('bot-a', KEY('T1'))
+    const second = sessionHostKey('bot-a', KEY('T2'))
+    const agent = (daemon as any).agents.get('bot-a')
+    const converge = vi
+      .spyOn((daemon as any).workspaces, 'convergeGithubAppWorkspaceRename')
+      .mockResolvedValue({ unconvergedSessions: [hostKeyDirName(first)] })
+
+    expect(await (daemon as any).convergeWorkspaceRename(agent)).toBe(true)
+
+    expect(converge).toHaveBeenCalledTimes(1)
+    expect(hosts[0]!.stop).toHaveBeenCalledTimes(1)
+    expect(hosts[1]!.stop).not.toHaveBeenCalled()
+    expect([...(daemon as any).hosts.keys()]).toEqual([second])
+    // A primary that will not follow means the ordinary cold workspace path for the whole agent.
+    converge.mockRejectedValue(new Error('config locked'))
+    expect(await (daemon as any).convergeWorkspaceRename(agent)).toBe(false)
+    expect(hosts[1]!.stop).not.toHaveBeenCalled()
+    await daemon.stop()
+  })
+
   it('gives a resumed session its own host again after a daemon restart', async () => {
     const root = scaffold()
     const first = await startDaemon(root)

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Daemon } from '../src/daemon.js'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV } from '../src/cp/gitcred-server.js'
+import { agentHostKey } from '../src/acp/host-key.js'
 import { FakeClock } from './cp/fake-clock.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import { WAIT } from './wait-support.js'
@@ -178,12 +179,20 @@ describe('Daemon (no Slack, injected ACP host)', () => {
         pullOnNewSession: true,
         skills: []
       }
-      const scratch = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, { runInSandbox: true, cwd }).host
+      const scratch = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, {
+        hostKey: agentHostKey(agent.id),
+        runInSandbox: true,
+        cwd
+      }).host
       expect((scratch as any).opts.env[GITCRED_CAPABILITY_ENV]).toEqual(expect.any(String))
       expect((scratch as any).opts.env[GITCRED_AGENT_ENV]).toBe('bot-a')
       // Without App credentials a scratch workspace still carries no git identity of any kind.
       agent.workspace = { mode: 'from-scratch', path: cwd, gitBranch: 'main', pullOnNewSession: true, skills: [] }
-      const plain = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, { runInSandbox: true, cwd }).host
+      const plain = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, {
+        hostKey: agentHostKey(agent.id),
+        runInSandbox: true,
+        cwd
+      }).host
       expect((plain as any).opts.env[GITCRED_CAPABILITY_ENV]).toBeUndefined()
       expect((plain as any).opts.env.GIT_CONFIG_KEY_0).toBeUndefined()
     } finally {
@@ -215,11 +224,16 @@ describe('Daemon (no Slack, injected ACP host)', () => {
         skills: []
       }
       // A normal (non-dream) host still carries the agent's configured secret…
-      const normal = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, { runInSandbox: true, cwd }).host
+      const normal = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, {
+        hostKey: agentHostKey(agent.id),
+        runInSandbox: true,
+        cwd
+      }).host
       expect((normal as any).opts.env.API_KEY).toBe('super-secret')
       // …but a dream host must not — even sandboxed, the mined transcript's own
       // tools could otherwise read the secret straight from the environment.
       const dreamHost = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, {
+        hostKey: agentHostKey(agent.id),
         runInSandbox: true,
         cwd,
         excludeAgentToolCredentials: true

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -17,6 +17,7 @@ import { delimiter, dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 import { effectiveRunInSandbox, prepareRuntimeLaunch } from '../src/launch/prepare.js'
 import { composeRuntimeLaunch, runtimeSandboxReadRoots } from '../src/launch/compose.js'
+import { agentHostKey, hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 import { CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV } from '../src/acp/codex-permission-profiles.js'
 import { runtimeMemoryCapabilities } from '../src/memory/runtime/capabilities.js'
 import { MemoryProviderUnavailableError } from '../src/memory/provider.js'
@@ -417,6 +418,140 @@ describe('prepareRuntimeLaunch', () => {
     const profile = JSON.parse(launch.env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]!) as { configOverrides: string[] }
     const writes = profile.configOverrides.filter((value) => value.includes('filesystem='))
     expect(writes.some((value) => value.includes(`"${realpathSync(primaryGit)}" = "write"`))).toBe(true)
+  })
+
+  /** A confined session's directory (§11) with a primary and a secondary clone, beside a primary checkout that also holds a `.git` — the grant must reach the former and never the latter. */
+  function sessionCloneFixture(sessionKey = 'slack:C1:s1') {
+    const { scopeDir, hostHome } = fixture()
+    const primaryGit = join(scopeDir, 'workspace', '.git')
+    mkdirSync(primaryGit, { recursive: true })
+    const key = sessionHostKey('bot-a', sessionKey)
+    const sessionDir = join(scopeDir, 'sessions', hostKeyDirName(key))
+    const cloneGit = join(sessionDir, 'workspace', '.git')
+    const secondaryGit = join(sessionDir, 'repos', 'acme', 'infra', '.git')
+    mkdirSync(cloneGit, { recursive: true })
+    mkdirSync(secondaryGit, { recursive: true })
+    return {
+      scopeDir,
+      hostHome,
+      key,
+      sessionDir,
+      cwd: join(sessionDir, 'workspace'),
+      primaryGit,
+      cloneGit,
+      secondaryGit
+    }
+  }
+
+  it('grants a confined session its own clones exactly, and never the primary checkout .git', () => {
+    const { scopeDir, hostHome, key, sessionDir, cwd, primaryGit, cloneGit, secondaryGit } = sessionCloneFixture()
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      hostKey: key,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      // What the daemon hands a session host: the session directory alone (workspace-manager.ts).
+      trustedWorkspaceWriteRoots: [sessionDir],
+      trustedPrimaryCheckout: join(scopeDir, 'workspace'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const clones = [realpathSync(cloneGit), realpathSync(secondaryGit)]
+    expect([...launch.gitMetadataWriteRoots].sort()).toEqual([...clones].sort())
+    const policy = JSON.parse(readFileSync(launch.sandbox!.settingsPath, 'utf8'))
+    // Outer sandbox: the session directory is writable, the primary checkout is not.
+    expect(coveredBy(policy.filesystem.allowWrite, realpathSync(sessionDir))).toBe(true)
+    expect(coveredBy(policy.filesystem.allowWrite, realpathSync(primaryGit))).toBe(false)
+    expect(coveredBy(policy.filesystem.allowWrite, realpathSync(join(scopeDir, 'workspace')))).toBe(false)
+    for (const gitDir of clones) {
+      expect(policy.filesystem.denyWrite).toContain(join(gitDir, 'hooks'))
+      expect(policy.filesystem.denyWrite).toContain(join(gitDir, 'config'))
+    }
+    // Inner Codex profile: the exact per-clone entries, `read` on hooks/config, no worktrees subtree.
+    const table = agentFilesystem(launch.env)
+    for (const gitDir of clones) {
+      expect(table).toContain(`"${gitDir}" = "write"`)
+      expect(table).toContain(`"${join(gitDir, 'hooks')}" = "read"`)
+      expect(table).toContain(`"${join(gitDir, 'config')}" = "read"`)
+    }
+    expect(table).not.toContain('worktrees')
+    expect(table).not.toContain(realpathSync(primaryGit))
+  })
+
+  // The unconfined tier keeps its linked worktrees and their grants: a session directory on disk and a session-bound host key must change nothing about its policy.
+  it('leaves the unconfined policy byte-identical whether or not a session directory exists', () => {
+    const { scopeDir, hostHome } = fixture()
+    const primaryGit = join(scopeDir, 'workspace', '.git')
+    const cwd = join(scopeDir, 'worktrees', 'session-1')
+    mkdirSync(join(primaryGit, 'worktrees', 'session-1'), { recursive: true })
+    mkdirSync(cwd, { recursive: true })
+    writeFileSync(join(cwd, '.git'), `gitdir: ${join(primaryGit, 'worktrees', 'session-1')}\n`)
+    const base = {
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: false,
+      trustedPrimaryCheckout: join(scopeDir, 'workspace'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    }
+    const key = sessionHostKey('bot-a', 'slack:C1:s1')
+    const before = prepareRuntimeLaunch({ ...base, hostKey: key })
+
+    mkdirSync(join(scopeDir, 'sessions', hostKeyDirName(key), 'workspace', '.git'), { recursive: true })
+
+    expect(JSON.stringify(prepareRuntimeLaunch({ ...base, hostKey: key }))).toBe(JSON.stringify(before))
+    expect(JSON.stringify(prepareRuntimeLaunch({ ...base, hostKey: agentHostKey('bot-a') }))).toBe(
+      JSON.stringify(before)
+    )
+    expect(JSON.stringify(prepareRuntimeLaunch(base))).toBe(JSON.stringify(before))
+    // ...and that unchanged policy is still the owner checkout's grant, worktrees subtree included.
+    const owner = realpathSync(primaryGit)
+    expect(agentFilesystem(before.env)).toContain(`"${owner}" = "write"`)
+    expect(agentFilesystem(before.env)).toContain(`"${join(owner, 'worktrees', '**')}" = "write"`)
+    expect(before.gitMetadataWriteRoots).toEqual([owner])
+  })
+
+  // The agent's shared host is not a session's: a session directory another session owns must not reach into its worktree-tier policy.
+  it('keeps the shared host sandbox policy identical when another session has its own directory', () => {
+    const { scopeDir, hostHome } = fixture()
+    const primaryGit = join(scopeDir, 'workspace', '.git')
+    const worktrees = join(scopeDir, 'worktrees')
+    const cwd = join(worktrees, 'session-1')
+    mkdirSync(join(primaryGit, 'worktrees', 'session-1'), { recursive: true })
+    mkdirSync(cwd, { recursive: true })
+    writeFileSync(join(cwd, '.git'), `gitdir: ${join(primaryGit, 'worktrees', 'session-1')}\n`)
+    const base = {
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      hostKey: agentHostKey('bot-a'),
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap' as const,
+      credentialPlatform: 'linux' as const,
+      trustedWorkspaceWriteRoots: [worktrees, join(scopeDir, 'repos')],
+      trustedPrimaryCheckout: join(scopeDir, 'workspace'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    }
+    const first = prepareRuntimeLaunch(base)
+    const policyBefore = readFileSync(first.sandbox!.settingsPath, 'utf8')
+    const envBefore = JSON.stringify(first.env)
+
+    const other = sessionHostKey('bot-a', 'slack:C1:s2')
+    mkdirSync(join(scopeDir, 'sessions', hostKeyDirName(other), 'workspace', '.git'), { recursive: true })
+
+    const second = prepareRuntimeLaunch(base)
+    expect(readFileSync(second.sandbox!.settingsPath, 'utf8')).toBe(policyBefore)
+    expect(JSON.stringify(second.env)).toBe(envBefore)
+    expect(second.gitMetadataWriteRoots).toEqual([realpathSync(primaryGit)])
   })
 
   // A locally authored agent may keep a checkout path the default layout does not name, and its

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -459,3 +459,59 @@ describe('retiring a confined session', () => {
     expect(git(agent.workspace.path, ['branch', '--list', 'dev/*'])).toBe('')
   })
 })
+
+describe('a confined session across workspace changes', () => {
+  // A replaced workspace makes every session directory describe a repository the agent no longer has: they go with the worktrees, and the next turn re-clones from the new definition.
+  it('discards every session directory when the workspace is replaced, and re-clones on the next turn', async () => {
+    const agent = agentFixture()
+    const { primary } = serveAll(agent)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+    const oldTip = git(cwd, ['rev-parse', 'HEAD'])
+    git(primary!.seed, ['checkout', '-q', '-b', 'trunk'])
+    writeFileSync(join(primary!.seed, 'TRUNK.md'), 'trunk\n')
+    git(primary!.seed, ['add', '-A'])
+    git(primary!.seed, ['commit', '-q', '-m', 'trunk only'])
+    git(primary!.seed, ['push', '-q', 'origin', 'trunk'])
+    const trunkTip = git(primary!.seed, ['rev-parse', 'HEAD'])
+    const onTrunk = { ...agent, workspace: { ...agent.workspace, gitBranch: 'trunk' } } as Agent
+
+    const rollback = await workspaces.prepareWorkspaceForActivation(onTrunk, { reconcileMaterialization: true })
+
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'sessions'))).toBe(false)
+    expect(workspaces.confinedSessionDir(onTrunk, KEY)).toBeUndefined()
+    expect(git(onTrunk.workspace.path, ['symbolic-ref', '--short', 'HEAD'])).toBe('trunk')
+    const again = await workspaces.prepareSessionWorkspace(onTrunk, confined())
+    expect(again).toBe(cwd)
+    expect(git(again, ['rev-parse', 'HEAD'])).toBe(trunkTip)
+    expect(git(again, ['rev-parse', 'HEAD'])).not.toBe(oldTip)
+    expect(existsSync(join(again, 'TRUNK.md'))).toBe(true)
+    expect(rollback).toBeTypeOf('function')
+  })
+
+  it('follows a canonical rename onto every session clone with the primary, reporting the ones that will not', async () => {
+    const agent = agentFixture({ githubApp: true })
+    serveAll(agent)
+    const other = 'slack:C1:1700000000.000200'
+    const first = await workspaces.prepareSessionWorkspace(agent, confined())
+    // The fixture's `file://` origin is what a real clone would have recorded as the authorized URL.
+    git(agent.workspace.path, ['remote', 'set-url', 'origin', PRIMARY_URL])
+    const second = await workspaces.prepareSessionWorkspace(agent, confined({ sessionKey: other }))
+    for (const checkout of [agent.workspace.path, first, second]) {
+      git(checkout, ['remote', 'set-url', 'origin', 'https://github.com/acme/old-name.git'])
+    }
+
+    expect(await workspaces.convergeGithubAppWorkspaceRename(agent)).toEqual({ unconvergedSessions: [] })
+
+    for (const checkout of [agent.workspace.path, first, second]) {
+      expect(git(checkout, ['remote', 'get-url', 'origin'])).toBe(PRIMARY_URL)
+    }
+    // A clone whose origin left the managed host is reported by its leaf and left alone; the rest still follow.
+    git(first, ['remote', 'set-url', 'origin', 'https://other-host.example/acme/elsewhere.git'])
+    git(second, ['remote', 'set-url', 'origin', 'https://github.com/acme/old-name.git'])
+    expect(await workspaces.convergeGithubAppWorkspaceRename(agent)).toEqual({
+      unconvergedSessions: [hostKeyDirName(sessionHostKey(agent.id, KEY))]
+    })
+    expect(git(first, ['remote', 'get-url', 'origin'])).toBe('https://other-host.example/acme/elsewhere.git')
+    expect(git(second, ['remote', 'get-url', 'origin'])).toBe(PRIMARY_URL)
+  })
+})

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -1,0 +1,461 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, afterEach, describe, expect, it } from 'vitest'
+import type { Agent } from '../src/agents/agent-schema.js'
+import { hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
+import { createWorkspaceScope } from '../src/cp/workspace-scope.js'
+import {
+  daemonGitCredentialTarget,
+  gitFor,
+  initGitInjection,
+  workspaceGitLocalEnv
+} from '../src/workspace/git-injection.js'
+import { LocalGitRunner, type GitRunner, type GitLogEntry, type GitPullSummary } from '../src/workspace/git-runner.js'
+import { WorkspaceManager, type PrepareSessionWorkspaceRequest } from '../src/workspace/workspace-manager.js'
+
+// Real git against real repositories (git-workspace-model.md §11): the claims are about the disk — where a confined session's clones land, that nothing of theirs reaches the primary, that a review is fetched and verified inside the clone, and what retirement removes or keeps.
+
+const workspaces = new WorkspaceManager()
+
+const SHIM = join(mkdtempSync(join(tmpdir(), 'ac-session-clone-shim-')), 'git-credential-helper.sh')
+initGitInjection({
+  targetFor: () => daemonGitCredentialTarget({ shimPath: SHIM, runDir: join(SHIM, '..') }),
+  preWarm: async () => undefined,
+  capabilityFor: (agentId) => `cap-${agentId}`
+})
+
+const KEY = 'slack:C1:1700000000.000100'
+const PRIMARY_URL = 'https://github.com/acme/primary-service.git'
+const roots: string[] = []
+/** Authorized clone URL (minus any `.git`) → the `file://` bare repository standing in for it. */
+const remotes = new Map<string, string>()
+
+afterAll(() => rmSync(join(SHIM, '..'), { recursive: true, force: true }))
+afterEach(() => {
+  workspaces.setGitRunnerResolver(undefined)
+  remotes.clear()
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function tempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix))
+  roots.push(root)
+  return root
+}
+
+/** Setup-only env: the daemon's own local policy widened to `file:`, plus a fixture identity. */
+function fixtureEnv(): Record<string, string> {
+  return {
+    ...workspaceGitLocalEnv(),
+    GIT_ALLOW_PROTOCOL: 'file:https:ssh',
+    GIT_AUTHOR_NAME: 'Fixture',
+    GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
+    GIT_COMMITTER_NAME: 'Fixture',
+    GIT_COMMITTER_EMAIL: 'fixture@example.invalid'
+  }
+}
+
+function git(cwd: string, args: string[]): string {
+  const quiesced = ['-c', 'maintenance.auto=false', '-c', 'gc.auto=0', ...args]
+  return execFileSync('git', quiesced, { cwd, env: fixtureEnv(), encoding: 'utf8' }).trim()
+}
+
+/** A bare repository serving `branch` with one commit (partial clones allowed, as a code host allows them) plus the seed checkout that pushes more to it; served over `file://`, so `--filter` is honoured. */
+function bareRepo(branch = 'main'): { bare: string; seed: string; url: string } {
+  const root = tempRoot('ac-session-clone-remote-')
+  const bare = join(root, 'origin.git')
+  const seed = join(root, 'seed')
+  git(root, ['init', '-q', '--bare', `--initial-branch=${branch}`, bare])
+  git(bare, ['config', 'receive.autogc', 'false'])
+  git(bare, ['config', 'uploadpack.allowFilter', 'true'])
+  mkdirSync(seed)
+  git(seed, ['init', '-q', `--initial-branch=${branch}`, '.'])
+  writeFileSync(join(seed, 'README.md'), 'seed\n')
+  git(seed, ['add', '-A'])
+  git(seed, ['commit', '-q', '-m', 'initial'])
+  git(seed, ['remote', 'add', 'origin', bare])
+  git(seed, ['push', '-q', 'origin', branch])
+  return { bare, seed, url: `file://${bare}` }
+}
+
+function agentFixture(
+  opts: {
+    mode?: 'git-repo' | 'from-scratch'
+    githubApp?: boolean
+    additionalRepos?: Array<{ repoFullName: string; repoId: string }>
+  } = {}
+): Agent {
+  const home = tempRoot('ac-session-clone-agent-')
+  return {
+    id: 'bot-clone',
+    dir: home,
+    name: 'bot-clone',
+    status: 'active',
+    runtime: 'claude',
+    workspace: {
+      mode: opts.mode ?? 'git-repo',
+      isolation: 'session',
+      path: join(home, 'workspace'),
+      gitRepo: PRIMARY_URL,
+      gitBranch: 'main',
+      ...(opts.githubApp ? { gitCredential: 'github-app' } : {}),
+      additionalRepos: opts.additionalRepos ?? [],
+      pullOnNewSession: false,
+      skills: []
+    },
+    integrations: [],
+    output: { mode: 'medium' },
+    permissions: { policy: 'ask', autoApprove: [] },
+    crons: []
+  } as unknown as Agent
+}
+
+function serve(cloneUrl: string, url: string): void {
+  remotes.set(cloneUrl.replace(/\.git$/i, ''), url)
+}
+
+function substitute(value: string): string {
+  return remotes.get(value.replace(/\.git$/i, '')) ?? value
+}
+
+/** Real git through the workspace runner seam, with exactly one substitution: a fixture repository's authorized URL becomes its `file://` bare, and `file:` joins the protocol allowlist. */
+class SeamRunner implements GitRunner {
+  constructor(
+    private readonly cwd: string | undefined,
+    private readonly abort: AbortSignal | undefined,
+    private readonly env: Record<string, string> = {}
+  ) {}
+
+  withEnv(env: Record<string, string>): GitRunner {
+    return new SeamRunner(this.cwd, this.abort, env)
+  }
+
+  private delegate(): GitRunner {
+    const env: Record<string, string> = { ...this.env, GIT_ALLOW_PROTOCOL: 'file:https:ssh' }
+    for (let index = 0; index < Number(env.GIT_CONFIG_COUNT ?? 0); index += 1) {
+      if (/^remote\..*\.url$/i.test(env[`GIT_CONFIG_KEY_${index}`] ?? '')) {
+        env[`GIT_CONFIG_VALUE_${index}`] = substitute(env[`GIT_CONFIG_VALUE_${index}`] ?? '')
+      }
+    }
+    const make = (value: Record<string, string>) => gitFor(this.cwd, this.abort).env(value)
+    return new LocalGitRunner(gitFor(this.cwd, this.abort), this.cwd, make).withEnv(env)
+  }
+
+  raw(args: string[]): Promise<string> {
+    return this.delegate().raw(args[0] === 'ls-remote' ? args.map(substitute) : args)
+  }
+
+  clone(repo: string, target: string, options?: string[]): Promise<void> {
+    return this.delegate().clone(substitute(repo), target, options)
+  }
+
+  pull(remote: string, branch: string, options?: string[]): Promise<GitPullSummary> {
+    return this.delegate().pull(remote, branch, options)
+  }
+
+  status() {
+    return this.delegate().status()
+  }
+
+  log(options: { maxCount: number }): Promise<GitLogEntry[]> {
+    return this.delegate().log(options)
+  }
+
+  readBounded(args: string[], maxBytes: number) {
+    return this.delegate().readBounded(args, maxBytes)
+  }
+}
+
+/** Serve the primary (when there is one) and every secondary root from fresh bare repositories. */
+function serveAll(agent: Agent, branches: Record<string, string> = {}): Record<string, ReturnType<typeof bareRepo>> {
+  workspaces.setGitRunnerResolver((_agentId, cwd, abort) => new SeamRunner(cwd, abort))
+  const served: Record<string, ReturnType<typeof bareRepo>> = {}
+  if (agent.workspace.mode === 'git-repo') {
+    served.primary = bareRepo('main')
+    serve(workspaces.primaryRoot(agent).cloneUrl, served.primary.url)
+  }
+  for (const root of workspaces.secondaryRoots(agent)) {
+    served[root.repoFullName] = bareRepo(branches[root.repoFullName] ?? 'main')
+    serve(root.cloneUrl, served[root.repoFullName]!.url)
+  }
+  return served
+}
+
+const confined = (extra: Partial<PrepareSessionWorkspaceRequest> = {}): PrepareSessionWorkspaceRequest => ({
+  sessionKey: KEY,
+  isolation: 'session',
+  initiatedBy: 'Ada Lovelace',
+  confined: true,
+  ...extra
+})
+
+const leafOf = (agent: Agent) => workspaces.sessionDir(agent, KEY)
+const idOf = () => workspaces.sessionWorktreeId(KEY)
+
+/** One pull request on the served primary: a commit on top of `main`, published as `refs/pull/7/head`. */
+function publishPullRequest(seed: string, content: string): { base: string; head: string } {
+  writeFileSync(join(seed, 'feature.md'), content)
+  git(seed, ['add', '-A'])
+  git(seed, ['commit', '-q', '-m', `feature: ${content.trim()}`])
+  git(seed, ['push', '-q', 'origin', 'HEAD:refs/pull/7/head'])
+  return { base: git(seed, ['rev-parse', 'origin/main']), head: git(seed, ['rev-parse', 'HEAD']) }
+}
+
+describe('a confined session gets its own clone of every root (git-workspace-model §11)', () => {
+  it('lays the session out under sessions/<leaf>: a blobless clone as the cwd on its own branch, the primary untouched', async () => {
+    const agent = agentFixture()
+    const { primary } = serveAll(agent)
+    const home = workspaces.agentRootFor(agent)
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+
+    const leaf = leafOf(agent)
+    expect(leaf).toBe(join(home, 'sessions', hostKeyDirName(sessionHostKey(agent.id, KEY))))
+    expect(cwd).toBe(realpathSync(join(leaf, 'workspace')))
+    expect(statSync(join(cwd, '.git')).isDirectory()).toBe(true)
+    expect(git(cwd, ['symbolic-ref', '--short', 'HEAD'])).toMatch(/^dev\/ada-lovelace\/[a-z]+-[a-z]+$/)
+    expect(git(cwd, ['rev-parse', 'HEAD'])).toBe(git(primary!.seed, ['rev-parse', 'origin/main']))
+    // A blobless partial clone straight from the remote: no alternates, no upstream on the session branch.
+    expect(git(cwd, ['config', '--get', 'remote.origin.partialclonefilter'])).toBe('blob:none')
+    expect(existsSync(join(cwd, '.git', 'objects', 'info', 'alternates'))).toBe(false)
+    expect(() => git(cwd, ['rev-parse', '--abbrev-ref', '@{upstream}'])).toThrow()
+    // The primary is not the parent of anything: no worktrees parent, no session branch, one checkout.
+    const checkout = agent.workspace.path
+    expect(existsSync(join(checkout, '.git'))).toBe(true)
+    expect(existsSync(join(home, 'worktrees'))).toBe(false)
+    expect(git(checkout, ['branch', '--list', 'dev/*'])).toBe('')
+    expect(git(checkout, ['worktree', 'list']).split('\n')).toHaveLength(1)
+  })
+
+  it('keeps the clone, its branch and its files across turns', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+    const branch = git(cwd, ['symbolic-ref', '--short', 'HEAD'])
+    writeFileSync(join(cwd, 'notes.md'), 'kept\n')
+
+    const again = await workspaces.prepareSessionWorkspace(agent, confined())
+
+    expect(again).toBe(cwd)
+    expect(git(cwd, ['symbolic-ref', '--short', 'HEAD'])).toBe(branch)
+    expect(existsSync(join(cwd, 'notes.md'))).toBe(true)
+    expect(workspaces.sessionWorktreePath(agent, KEY)).toBe(join(leafOf(agent), 'workspace'))
+  })
+
+  it('pins the credential helper in a github-app clone and converges its origin on resume', async () => {
+    const agent = agentFixture({ githubApp: true })
+    serveAll(agent)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+
+    expect(git(cwd, ['config', '--get-all', 'credential.https://github.com.helper'])).toContain(SHIM)
+    // The fixture's `file://` origin is what a real clone would have recorded as the authorized URL.
+    git(agent.workspace.path, ['remote', 'set-url', 'origin', PRIMARY_URL])
+    // A resumed clone is converged like a resumed primary: an origin off the managed host is refused...
+    await expect(workspaces.prepareSessionWorkspace(agent, confined())).rejects.toThrow(/trusted GitHub remote/)
+    // ...and one on it is repointed at the authorized repository.
+    git(cwd, ['remote', 'set-url', 'origin', 'https://github.com/acme/renamed.git'])
+    expect(await workspaces.prepareSessionWorkspace(agent, confined())).toBe(cwd)
+    expect(git(cwd, ['remote', 'get-url', 'origin'])).toBe(PRIMARY_URL)
+  })
+
+  it('clones every secondary root under repos/<owner>/<repo> of the same leaf and hands them out', async () => {
+    const agent = agentFixture({ additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }] })
+    const served = serveAll(agent, { 'acme/infra': 'trunk' })
+    const home = workspaces.agentRootFor(agent)
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+
+    const infra = join(leafOf(agent), 'repos', 'acme', 'infra')
+    expect(statSync(join(infra, '.git')).isDirectory()).toBe(true)
+    expect(git(infra, ['symbolic-ref', '--short', 'HEAD'])).toMatch(/^dev\/ada-lovelace\//)
+    expect(git(infra, ['rev-parse', 'HEAD'])).toBe(git(served['acme/infra']!.seed, ['rev-parse', 'origin/trunk']))
+    expect(git(infra, ['config', '--get', 'remote.origin.partialclonefilter'])).toBe('blob:none')
+    expect(existsSync(join(infra, '.git', 'objects', 'info', 'alternates'))).toBe(false)
+    const scope = { sessionKey: KEY, isolation: 'session' as const }
+    expect(await workspaces.sessionAdditionalRoots(agent, scope)).toEqual([
+      { path: realpathSync(infra), repoFullName: 'acme/infra', branch: 'trunk' }
+    ])
+    expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, scope)).toEqual([realpathSync(infra)])
+    // The shared secondary checkout stays what it was: materialized for the console, no worktrees.
+    expect(existsSync(join(home, 'repos', 'acme', 'infra', 'checkout', '.git'))).toBe(true)
+    expect(existsSync(join(home, 'repos', 'acme', 'infra', 'worktrees'))).toBe(false)
+  })
+
+  it('keeps a scratch primary as the cwd while its secondaries get session clones', async () => {
+    const agent = agentFixture({
+      mode: 'from-scratch',
+      additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }]
+    })
+    serveAll(agent)
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+
+    expect(cwd).toBe(agent.workspace.path)
+    const infra = join(leafOf(agent), 'repos', 'acme', 'infra')
+    expect(statSync(join(infra, '.git')).isDirectory()).toBe(true)
+    expect(existsSync(join(leafOf(agent), 'workspace'))).toBe(false)
+    expect(
+      await workspaces.additionalWorkspaceDirectories(agent, cwd, { sessionKey: KEY, isolation: 'session' })
+    ).toEqual([realpathSync(infra)])
+  })
+
+  it('fetches a review into the clone, verifies HEAD exactly, and leaves no ref in the primary', async () => {
+    const agent = agentFixture()
+    const { primary } = serveAll(agent)
+    const first = publishPullRequest(primary!.seed, 'pr\n')
+
+    const cwd = await workspaces.prepareSessionWorkspace(
+      agent,
+      confined({ review: { pullNumber: 7, baseSha: first.base, headSha: first.head } })
+    )
+
+    const headRef = `refs/agentconnect/reviews/${idOf()}/head`
+    expect(git(cwd, ['rev-parse', 'HEAD'])).toBe(first.head)
+    expect(git(cwd, ['rev-parse', headRef])).toBe(first.head)
+    expect(git(cwd, ['rev-parse', `refs/agentconnect/reviews/${idOf()}/base`])).toBe(first.base)
+    expect(existsSync(join(cwd, 'feature.md'))).toBe(true)
+    expect(() => git(agent.workspace.path, ['rev-parse', '--verify', '--quiet', headRef])).toThrow()
+
+    // A later delivery re-fetches the exact revision and resets the clone, dirt and all.
+    const second = publishPullRequest(primary!.seed, 'pr v2\n')
+    writeFileSync(join(cwd, 'scratch.txt'), 'dropped\n')
+    const again = await workspaces.prepareSessionWorkspace(
+      agent,
+      confined({ review: { pullNumber: 7, baseSha: second.base, headSha: second.head } })
+    )
+    expect(again).toBe(cwd)
+    expect(git(cwd, ['rev-parse', 'HEAD'])).toBe(second.head)
+    expect(existsSync(join(cwd, 'scratch.txt'))).toBe(false)
+    expect(git(cwd, ['status', '--porcelain'])).toBe('')
+  })
+
+  it('fails the session when the clone fails, leaving no worktree behind', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    await workspaces.prepareWorkspace(agent)
+    serve(PRIMARY_URL, `file://${join(tempRoot('ac-session-clone-missing-'), 'nowhere.git')}`)
+
+    await expect(workspaces.prepareSessionWorkspace(agent, confined())).rejects.toThrow(/session clone of .* failed/)
+
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'worktrees'))).toBe(false)
+    expect(existsSync(join(leafOf(agent), 'workspace'))).toBe(false)
+    expect(workspaces.confinedSessionDir(agent, KEY)).toBeUndefined()
+  })
+
+  it('resolves the console session root, and a repo-scoped one, to the clone', async () => {
+    const agent = agentFixture({ additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }] })
+    serveAll(agent)
+    await workspaces.prepareSessionWorkspace(agent, confined())
+    const scope = createWorkspaceScope({
+      workspaces,
+      agentOf: () => agent,
+      sessionOf: async () => ({ key: KEY, workspaceIsolation: 'session' }),
+      runtimeRootOf: () => undefined
+    })
+
+    expect(await scope.gitRoot(agent.id, 'sid-1')).toBe(join(leafOf(agent), 'workspace'))
+    expect(await scope.gitRoot(agent.id, 'sid-1', 'acme/infra')).toBe(join(leafOf(agent), 'repos', 'acme', 'infra'))
+    expect(await scope.gitRoot(agent.id)).toBe(agent.workspace.path)
+  })
+
+  it('grants a confined session its own directory alone as a workspace write root', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    const home = workspaces.agentRootFor(agent)
+    expect(workspaces.trustedWorkspaceWriteRoots(agent, KEY)).toEqual([join(home, 'worktrees'), join(home, 'repos')])
+
+    await workspaces.prepareSessionWorkspace(agent, confined())
+
+    expect(workspaces.trustedWorkspaceWriteRoots(agent, KEY)).toEqual([leafOf(agent)])
+    // The agent's shared host, and a session without a directory of its own, keep the worktree tier's parents.
+    expect(workspaces.trustedWorkspaceWriteRoots(agent)).toEqual([join(home, 'worktrees'), join(home, 'repos')])
+    expect(workspaces.trustedWorkspaceWriteRoots(agent, 'slack:C1:other')).toEqual([
+      join(home, 'worktrees'),
+      join(home, 'repos')
+    ])
+  })
+
+  it('keeps the worktree tier for an unconfined request', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, { sessionKey: KEY, isolation: 'session' })
+
+    expect(cwd).toBe(realpathSync(join(workspaces.agentRootFor(agent), 'worktrees', idOf())))
+    expect(statSync(join(cwd, '.git')).isFile()).toBe(true)
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'sessions'))).toBe(false)
+  })
+})
+
+describe('retiring a confined session', () => {
+  it('removes the whole session directory when every clone is clean and pushed', async () => {
+    const agent = agentFixture({ additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }] })
+    serveAll(agent)
+    await workspaces.prepareSessionWorkspace(agent, confined())
+    expect(existsSync(leafOf(agent))).toBe(true)
+
+    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({ outcome: 'removed' })
+
+    expect(existsSync(leafOf(agent))).toBe(false)
+    expect(workspaces.confinedSessionDir(agent, KEY)).toBeUndefined()
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout', '.git'))).toBe(true)
+  })
+
+  it('retains a dirty clone', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+    writeFileSync(join(cwd, 'wip.md'), 'unsaved\n')
+
+    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({ outcome: 'retained', reason: 'dirty' })
+    expect(existsSync(join(cwd, 'wip.md'))).toBe(true)
+  })
+
+  it('retains a clone with commits no remote holds, on any of its branches', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+    git(cwd, ['checkout', '-q', '-b', 'side'])
+    git(cwd, ['commit', '-q', '--allow-empty', '-m', 'only here'])
+    git(cwd, ['checkout', '-q', '-'])
+
+    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({
+      outcome: 'retained',
+      reason: 'unique-commits'
+    })
+    expect(existsSync(cwd)).toBe(true)
+  })
+
+  it('removes a dirty review snapshot — its refs mark it daemon-owned and reset on delivery', async () => {
+    const agent = agentFixture()
+    const { primary } = serveAll(agent)
+    const pr = publishPullRequest(primary!.seed, 'pr\n')
+    const cwd = await workspaces.prepareSessionWorkspace(
+      agent,
+      confined({ review: { pullNumber: 7, baseSha: pr.base, headSha: pr.head } })
+    )
+    writeFileSync(join(cwd, 'wip.md'), 'disposable\n')
+    git(cwd, ['commit', '-q', '--allow-empty', '-m', 'disposable too'])
+
+    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({ outcome: 'removed' })
+    expect(existsSync(leafOf(agent))).toBe(false)
+  })
+
+  it('sweeps a legacy worktree of the same session along with its directory', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    const worktree = await workspaces.prepareSessionWorkspace(agent, { sessionKey: KEY, isolation: 'session' })
+    expect(statSync(join(worktree, '.git')).isFile()).toBe(true)
+    const clone = await workspaces.prepareSessionWorkspace(agent, confined())
+    expect(clone).toBe(realpathSync(join(leafOf(agent), 'workspace')))
+
+    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({ outcome: 'removed' })
+
+    expect(existsSync(worktree)).toBe(false)
+    expect(existsSync(leafOf(agent))).toBe(false)
+    expect(git(agent.workspace.path, ['worktree', 'list']).split('\n')).toHaveLength(1)
+    expect(git(agent.workspace.path, ['branch', '--list', 'dev/*'])).toBe('')
+  })
+})


### PR DESCRIPTION
PR 3 of the [git-workspace-model.md §11](docs/designs/git-workspace-model.md#11-session-isolation-under-an-os-boundary-decided-2026-09-02) rollout, on top of #1758 (PR 2: one ACP host per confined session). Base is PR 2's branch; it retargets to `main` when that merges.

## What changes

For a **confined self-hosted session** — PR 2's predicate, `!k8s && effectiveRunInSandbox(...)` — the per-session directory is no longer a linked worktree of the primary checkout but its own clone:

```
<agentDir>/sessions/<leaf>/            leaf = hostKeyDirName(sessionHostKey(agentId, sessionKey))
├── workspace/                          primary clone — the session cwd
└── repos/<owner>/<repo>/               one clone per secondary root (decision 4)
```

(`home/` under the leaf is PR 4's; nothing here creates it.)

- **The clone** (`workspace-manager.ts` `prepareRootSessionClone` / `cloneSessionRootAt`): `git clone --filter=blob:none --branch <b> --single-branch` straight from the remote through the daemon's credential path, with the same post-clone helper pin the primary gets and origin convergence on resume. Never a hardlink or `--shared`/alternates of the primary; a remote that refuses the filter answers with a full clone on its own (verified: `warning: filtering not recognized by server, ignoring`, exit 0); a clone that fails fails the session with `session clone of <url> failed: …` and no worktree fallback. The session branch is drawn with the same `sessionBranchName` draw as the worktree tier and checked out `--no-track`.
- **Lazy fetch**: a blobless clone under the daemon's usual `GIT_NO_LAZY_FETCH=1` fails at checkout (`could not fetch … from promisor remote` — measured), so the three daemon-run operations that materialize the clone's tree (the clone, the branch checkout, a review reset) run with lazy fetching permitted and the credential channel attached (`sessionCloneGitEnv`); everything local keeps `workspaceGitLocalEnv`.
- **Secondary roots** get the same treatment under `repos/<owner>/<repo>/` of the same leaf; `readySecondaryRoots` / `sessionAdditionalRoots` / `additionalWorkspaceDirectories` hand out the session's clones. A scratch primary keeps its scratch dir as cwd while its secondaries get clones, as before with worktrees.
- **Review sessions**: `fetchReviewRevisionIn` runs against the clone — `refs/agentconnect/reviews/<id>/{base,head,merge}` land in the clone, never the primary — and HEAD is verified exactly as today; a later delivery resets the clone to the freshly fetched revision. Prompt text unchanged.
- **The disk decides the tier** (`confinedSessionDir`): a session whose leaf exists is a clone session for every reader — console `rootFor` (via `workspace-scope.ts` → `sessionRootDirectory`), additional directories, retention — so reads and preparation cannot disagree; a confined request with no leaf creates one.
- **Retirement** (`removeSessionClones`): the dirty / unique-commit rules with the review-snapshot exception, applied in every clone of the leaf, then the whole leaf is removed. Deliberately `rev-list --all --not --remotes --glob=refs/agentconnect/reviews/<id>` rather than `HEAD …`: the leaf is the object store, so a side branch or a stash is work HEAD cannot speak for (the retired-root removal already reasons this way). No `worktree remove` / `prune` / `branch -D` in the primary for the clone; the legacy worktree loop still runs for the same session, so a worktree left from before the agent was confined is swept in the same pass. §11's retirement bullet records the every-ref rule.
- **Sandbox grants** (`launch/prepare.ts`, `codex-permission-profiles.ts`): for a session host whose leaf exists, the outer boundary's workspace write root is the leaf alone (`trustedWorkspaceWriteRoots(agent, sessionKey)` — no primary `worktrees` parent, no shared `repos`), the Git metadata write roots are the clones' own `.git` directories with `hooks`/`config` deny-written, and the inner Codex profile gets the new `sessionGitMetadataRoots` entries — `<clone>/.git = write`, `<clone>/.git/hooks = read`, `<clone>/.git/config = read` — with **no** `worktrees/**` entry and **no** primary `.git`. `unsandboxedGitMetadataRoots` and the worktree-tier derivation are untouched for the unconfined tier.
- `hostSpawnSig` / eviction: unchanged.

Found on the way: `show-ref --verify --quiet` on a missing ref exits 1 with no stderr, which simple-git resolves rather than rejects, so every session-branch draw read as "taken" and every session branch carried the random suffix. The draw now runs without `--quiet` (`drawSessionBranch`, shared by both tiers).

## What does not change

`isolation: 'shared'`, every unconfined launch and every `--k8s` launch keep their worktrees and their grants; `leaves the unconfined policy byte-identical whether or not a session directory exists` asserts the unconfined `prepareRuntimeLaunch` output is identical (JSON) with and without a leaf and with either host key, and `keeps the shared host sandbox policy identical when another session has its own directory` asserts the same for the agent's shared sandboxed host. The primary checkout keeps its roles (`shared`, console views, `pullOnNewSession`).

## Verification (unit level only — no live Linux daemon was exercised)

- `packages/daemon/test/workspace-session-clone.test.ts` (new, real git over `file://` bare repositories with `uploadpack.allowFilter`): leaf layout with a blobless clone (`remote.origin.partialclonefilter=blob:none`, `objects/info/alternates` absent) on a `dev/<user>/<words>` branch with no upstream and a primary with no `worktrees/`, no session branch, one worktree entry; clone kept across turns; github-app helper pin and origin convergence on resume; secondary clones under the leaf handed out as additional directories with the shared checkout untouched; scratch primary + secondary clones; review fetched into the clone with exact HEAD, refs absent from the primary, and a second delivery resetting a dirtied clone; clone failure fails the session with no worktree and no leaf left; console scope resolves session and repo-scoped roots to the clones; write roots are the leaf alone for the session, the legacy pair otherwise; an unconfined request still gets a worktree; retirement removes a clean leaf, retains dirty, retains unique commits on any branch, removes a dirty review snapshot, and sweeps a legacy worktree with the leaf.
- `runtime-launch.test.ts`: exact clone-tier grants (outer leaf writable, primary `.git` not covered, hooks/config deny-written per clone; inner Codex exact entries with `read`, no `worktrees`, no primary `.git`), unconfined byte-identical, shared sandboxed host unchanged.
- `codex-permission-profiles.test.ts`: the exact `sessionGitMetadataRoots` table.
- `daemon-session-hosts.test.ts`: the daemon marks the session request `confined: true` only under a confined launch.
- **Mutation checks**: flipping the session entries' `read` to `deny` reddened the Codex profile test and the clone-tier launch test; disabling the dirty-retain rule in `removeSessionClones` reddened `retains a dirty clone`; nothing else changed (3 failed / 55 passed), and all pass again after reverting.
- `pnpm --filter @agentconnect.md/daemon exec tsc -p tsconfig.typecheck.json --noEmit`, eslint and prettier on the touched files, and the affected suites (`workspace`, `workspace-secondary-roots`, `workspace-repo-scope`, `workspace-git*`, `daemon-hook`, `cluster-workspace-prepare`) green. The full daemon suite was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
