### PR TITLE
feat(daemon): a confined session's runtime HOME lives under its own directory

### DIFF
--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -330,6 +330,15 @@ the parent of anything.
 - **Sandbox grants** are per session and exact: the clone's `.git` writable,
   its `hooks` and `config` read-only, for both the outer sandbox and a runtime's
   inner one.
+- **HOME is per session.** `home/` is the runtime's private HOME — `HOME`,
+  `TMPDIR`, `XDG_*`, `CODEX_HOME` and the other runtime-state env point there —
+  seeded from the host and protected exactly as the agent's `home/` is, and
+  removed with the leaf. Runtime-native cross-session state (Codex memories,
+  goals and logs; Claude project state) is therefore per session; managed memory
+  lives outside HOME and is unaffected. Package caches (`.npm`, `.cache`,
+  `.local`) live there too, writable per session by construction and gone with
+  it, which is what lets `pnpm` and corepack run inside a confined session — no
+  per-agent cache is opened and no package manager is pre-provisioned.
 
 The unconfined tier is untouched, and so is everything that made the worktree
 tier commit under a boundary in the interim (#1695, #1698, #1703, #1715); those

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -43,7 +43,7 @@ import {
   sessionHostKey,
   type HostKey
 } from './acp/host-key.js'
-import { effectiveRunInSandbox, prepareRuntimeLaunch } from './launch/prepare.js'
+import { effectiveRunInSandbox, prepareRuntimeLaunch, privateRuntimeHomeFor } from './launch/prepare.js'
 import {
   SessionManager,
   transcriptCoords,
@@ -4201,8 +4201,11 @@ export class Daemon {
           : `acp: agent "${agentId}" requested Run in sandbox but this host has no supported Linux sandbox — running without it (#312)`
       )
     }
+    // Native memory is redirected under the HOME this host actually launches with — a confined session's own (§11).
     const memoryAgent =
-      memoryKindOf(agent) === 'native' && runInSandbox ? { ...agent, dir: runtimeHomePath(agent.dir) } : agent
+      memoryKindOf(agent) === 'native' && runInSandbox
+        ? { ...agent, dir: privateRuntimeHomeFor(agent.dir, opts.hostKey) }
+        : agent
     const runtimeEnv = Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value]))
     // On --k8s the runtime runs in the agent's pod, so the session gitconfig has to be COMPUTED in
     // pod coordinates and WRITTEN there: the file travels with the launch (SpawnRequest.files) and

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -14,7 +14,7 @@ import {
 } from '../runtimes/runtime-home.js'
 import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
 import { primaryCheckoutIn, secondaryCheckoutsIn } from '../workspace/secondary-layout.js'
-import { isRealDir, sessionDirIn, sessionGitDirsIn } from '../workspace/session-layout.js'
+import { isRealDir, sessionDirIn, sessionGitDirsIn, sessionHomeIn } from '../workspace/session-layout.js'
 import {
   CLAUDE_PROFILE_ENV,
   claudeProtectedSettings,
@@ -62,6 +62,12 @@ function confinedSessionDirOf(agentRoot: string, hostKey: HostKey | undefined): 
   if (hostKey === undefined || hostKeySessionKey(hostKey) === undefined) return undefined
   const sessionDir = sessionDirIn(agentRoot, hostKeyDirName(hostKey))
   return isRealDir(sessionDir) ? sessionDir : undefined
+}
+
+/** The private HOME a host launches with: a confined session's under its own directory (§11), any other host's under the agent dir. */
+export function privateRuntimeHomeFor(scopeDir: string, hostKey: HostKey | undefined): string {
+  const sessionDir = confinedSessionDirOf(existingRealpath(scopeDir), hostKey)
+  return sessionDir === undefined ? runtimeHomePath(scopeDir) : sessionHomeIn(sessionDir)
 }
 
 /** The same roots with NO outer boundary: one escaping the agent tree is left protected, not refused. */
@@ -272,6 +278,9 @@ export function prepareRuntimeLaunch(opts: {
     throw new Error('OS sandbox requested without the trusted AgentConnect daemon root')
   }
 
+  // A confined session's HOME lives under its own directory and goes with it (§11); every other host keeps the agent's.
+  const sessionDir = confinedSessionDirOf(existingRealpath(opts.scopeDir), opts.hostKey)
+  const sessionHome = sessionDir === undefined ? undefined : sessionHomeIn(sessionDir)
   const stateSourceEnv = opts.stateSourceEnv ?? opts.hostEnv ?? process.env
   const safeRoot = (path: string, label: string): string => {
     if (!isAbsolute(path)) throw new Error(`unsafe ${label} for sandboxing: ${path}`)
@@ -288,7 +297,11 @@ export function prepareRuntimeLaunch(opts: {
   let protectedRuntimeStateRoots: string[] = []
   let denyReadRoots: string[] = []
   if (opts.runInSandbox) {
-    sandboxBoundary({ agentDir: opts.scopeDir, cwd: opts.cwd, runtimeHome: runtimeHomePath(opts.scopeDir) })
+    sandboxBoundary({
+      agentDir: opts.scopeDir,
+      cwd: opts.cwd,
+      runtimeHome: sessionHome ?? runtimeHomePath(opts.scopeDir)
+    })
     const daemonRoot = safeRoot(opts.daemonRoot!, 'AgentConnect daemon root')
     const agentRoot = safeRoot(opts.scopeDir, 'agent root')
     const hostHomeRoots = compactReadRoots(
@@ -344,7 +357,7 @@ export function prepareRuntimeLaunch(opts: {
     opts.runtimeId,
     opts.scopeDir,
     stateSourceEnv,
-    undefined,
+    sessionHome,
     credentials?.seedExclusions
   )
   credentials?.preparePrivateHome(runtimeHome)
@@ -423,7 +436,6 @@ export function prepareRuntimeLaunch(opts: {
     })
   )
   // A confined session's clones own their `.git` (§11), so the primary's is never reopened for it; otherwise an isolated session's worktree keeps its index, refs and objects in the OWNER checkout's `.git`, which no other carve-back covers and which the daemon names (a locally authored agent may keep a path the layout does not).
-  const sessionDir = confinedSessionDirOf(agentRoot, opts.hostKey)
   const primaryCheckout = opts.trustedPrimaryCheckout
     ? safeRoot(opts.trustedPrimaryCheckout, 'trusted primary checkout')
     : primaryCheckoutIn(agentRoot)

--- a/packages/daemon/src/workspace/session-layout.ts
+++ b/packages/daemon/src/workspace/session-layout.ts
@@ -2,7 +2,7 @@ import { existsSync, lstatSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { isRepoSegment, PRIMARY_CHECKOUT_DIR, SECONDARY_ROOTS_DIR } from './secondary-layout.js'
 
-// The on-disk shape of one confined session's directory, `<agentDir>/sessions/<leaf>/{workspace,repos/<owner>/<repo>}` (git-workspace-model.md §11) — separate from the manager, like secondary-layout.ts, so the launch path derives a session host's grants without the whole workspace module.
+// The on-disk shape of one confined session's directory, `<agentDir>/sessions/<leaf>/{workspace,repos/<owner>/<repo>,home}` (git-workspace-model.md §11) — separate from the manager, like secondary-layout.ts, so the launch path derives a session host's grants without the whole workspace module.
 
 /** Every confined session's directory hangs off one agent-owned parent. */
 export const SESSIONS_DIR = 'sessions'
@@ -21,6 +21,11 @@ export function sessionDirIn(agentRoot: string, leaf: string): string {
 export function sessionRootCloneIn(sessionDir: string, repoFullName?: string): string {
   if (repoFullName === undefined) return join(sessionDir, PRIMARY_CHECKOUT_DIR)
   return join(sessionDir, SECONDARY_ROOTS_DIR, ...repoFullName.split('/'))
+}
+
+/** `<sessionDir>/home` — the session's own runtime HOME (state, temp, XDG, package caches), gone with the leaf. */
+export function sessionHomeIn(sessionDir: string): string {
+  return join(sessionDir, 'home')
 }
 
 /** Every `repos/<owner>/<repo>` clone ON DISK in a session directory, sorted by name; symlinks are skipped. */

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -233,15 +233,16 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     expect(existsSync(sandboxSettingsDir(agentDir, hostKeyDirName(second)))).toBe(false)
   })
 
-  it('launch preparation writes two concurrent session hosts two policies, each anchored on its session cwd', () => {
+  it('launch preparation writes two concurrent session hosts two policies, each anchored on its own session cwd and HOME', () => {
     const root = mkdtempSync(join(tmpdir(), 'ac-session-hosts-launch-'))
     const scopeDir = join(root, 'agent')
     const hostHome = join(root, 'host-home')
     mkdirSync(hostHome)
     const launches = ['s1', 's2'].map((session) => {
-      const cwd = join(scopeDir, 'sessions', session, 'workspace')
-      mkdirSync(cwd, { recursive: true })
       const key = sessionHostKey('bot-a', `slack:C1:${session}:bot-a`)
+      const sessionDir = join(scopeDir, 'sessions', hostKeyDirName(key))
+      const cwd = join(sessionDir, 'workspace')
+      mkdirSync(cwd, { recursive: true })
       const launch = prepareRuntimeLaunch({
         runtimeId: 'claude',
         runtime: { command: 'npx', args: ['claude-agent-acp'], env: [] },
@@ -255,11 +256,12 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
         explicitEnv: {},
         hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
       })
-      return { key, cwd: realpathSync(cwd), launch }
+      return { key, cwd: realpathSync(cwd), home: join(realpathSync(sessionDir), 'home'), launch }
     })
     const [one, two] = launches as [(typeof launches)[number], (typeof launches)[number]]
     expect(one.launch.sandbox!.settingsPath).not.toBe(two.launch.sandbox!.settingsPath)
-    for (const { key, cwd, launch } of launches) {
+    expect(one.launch.env.HOME).not.toBe(two.launch.env.HOME)
+    for (const { key, cwd, home, launch } of launches) {
       const sandbox = launch.sandbox!
       expect(sandbox.settingsPath).toBe(
         join(realpathSync(sandboxSettingsDir(scopeDir, hostKeyDirName(key))), 'settings.json')
@@ -271,6 +273,10 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
       const policy = JSON.parse(readFileSync(sandbox.settingsPath, 'utf8'))
       expect(policy.filesystem.allowWrite).toContain(cwd)
       expect(policy.git.safeDirectories).toContain(cwd)
+      // ...and its HOME under the same leaf (§11), an exact write root as the provider requires of HOME.
+      expect(launch.env.HOME).toBe(home)
+      expect(sandbox.writable).toContain(home)
+      expect(policy.filesystem.allowWrite).toContain(home)
     }
     // Neither write clobbered the other: both files still stand once both launches are prepared.
     expect(existsSync(one.launch.sandbox!.settingsPath)).toBe(true)

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -15,7 +16,7 @@ import {
 import { tmpdir } from 'node:os'
 import { delimiter, dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { parse as parseYaml } from 'yaml'
-import { effectiveRunInSandbox, prepareRuntimeLaunch } from '../src/launch/prepare.js'
+import { effectiveRunInSandbox, prepareRuntimeLaunch, privateRuntimeHomeFor } from '../src/launch/prepare.js'
 import { composeRuntimeLaunch, runtimeSandboxReadRoots } from '../src/launch/compose.js'
 import { agentHostKey, hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 import { CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV } from '../src/acp/codex-permission-profiles.js'
@@ -484,6 +485,150 @@ describe('prepareRuntimeLaunch', () => {
     expect(table).not.toContain(realpathSync(primaryGit))
   })
 
+  // §11: the session's HOME lives under its leaf, so runtime state, temp and package caches are the session's alone and go with it.
+  it('gives a confined session its own HOME under its leaf, seeded like the agent one and pointed at by the env', () => {
+    const { scopeDir, hostHome, key, sessionDir, cwd } = sessionCloneFixture()
+    const hostCodex = join(hostHome, '.codex')
+    mkdirSync(hostCodex, { recursive: true })
+    writeFileSync(join(hostCodex, 'config.toml'), 'model = "seeded"\n')
+    writeFileSync(join(hostCodex, 'auth.json'), '{"last_refresh":"2026-01-01T00:00:00Z"}\n')
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      hostKey: key,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      trustedWorkspaceWriteRoots: [sessionDir],
+      trustedPrimaryCheckout: join(scopeDir, 'workspace'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const home = join(realpathSync(sessionDir), 'home')
+    const agentHome = join(realpathSync(scopeDir), 'home')
+    expect(launch.runtimeHome).toBe(home)
+    expect(launch.env.HOME).toBe(home)
+    expect(launch.env.XDG_CONFIG_HOME).toBe(join(home, '.config'))
+    expect(launch.env.XDG_CACHE_HOME).toBe(join(home, '.cache'))
+    expect(launch.env.XDG_DATA_HOME).toBe(join(home, '.local', 'share'))
+    expect(launch.env.XDG_STATE_HOME).toBe(join(home, '.local', 'state'))
+    expect(launch.env.XDG_RUNTIME_DIR).toBe(join(home, '.run'))
+    expect(launch.env.CODEX_HOME).toBe(join(home, '.codex'))
+    // Seeded as the agent HOME is: config copied in, the credential linked to the shared host file, never copied.
+    expect(readFileSync(join(home, '.codex', 'config.toml'), 'utf8')).toBe('model = "seeded"\n')
+    expect(lstatSync(join(home, '.codex', 'auth.json')).isSymbolicLink()).toBe(true)
+    expect(realpathSync(join(home, '.codex', 'auth.json'))).toBe(realpathSync(join(hostCodex, 'auth.json')))
+    // The agent's own HOME is not this session's: never created for it, and outside its boundary both ways.
+    expect(existsSync(agentHome)).toBe(false)
+    const policy = JSON.parse(readFileSync(launch.sandbox!.settingsPath, 'utf8'))
+    expect(coveredBy(policy.filesystem.allowWrite, agentHome)).toBe(false)
+    expect(coveredBy(policy.filesystem.allowRead, agentHome)).toBe(false)
+    // What the provider requires of HOME — an exact write root — and the shared credential's own carve-back beside it.
+    expect(launch.sandbox!.writable).toContain(home)
+    expect(policy.filesystem.allowWrite).toContain(home)
+    expect(policy.filesystem.allowWrite).toContain(realpathSync(join(hostCodex, 'auth.json')))
+    // Runtime-native protected roots follow: the session .codex is what the inner tool sandbox is denied.
+    expect(launch.sandbox!.protectedCredentialRoots).toContain(join(home, '.codex'))
+    const profile = JSON.parse(launch.env[CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV]!) as { configOverrides: string[] }
+    const tables = profile.configOverrides.filter((value) => value.includes('.filesystem='))
+    expect(tables).toHaveLength(3)
+    for (const table of tables) {
+      expect(table).toContain(`"${join(home, '.codex')}" = "deny"`)
+      expect(table).not.toContain(agentHome)
+    }
+  })
+
+  it('follows the session HOME for the Claude config dir and private state roots', () => {
+    const { scopeDir, hostHome, key, sessionDir, cwd } = sessionCloneFixture()
+    writeFileSync(
+      join(hostHome, '.claude.json'),
+      JSON.stringify({
+        additionalModelOptionsCache: [{ value: 'root-fable', label: 'Root Fable', description: 'test' }],
+        mcpToken: 'do-not-copy-global-secret'
+      })
+    )
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'claude-acp',
+      runtime: { command: 'npx', args: ['claude-agent-acp'], env: [] },
+      scopeDir,
+      cwd,
+      hostKey: key,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      trustedWorkspaceWriteRoots: [sessionDir],
+      trustedPrimaryCheckout: join(scopeDir, 'workspace'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const home = join(realpathSync(sessionDir), 'home')
+    expect(launch.env.HOME).toBe(home)
+    expect(launch.env.CLAUDE_CONFIG_DIR).toBe(join(home, '.claude'))
+    expect(JSON.parse(readFileSync(join(home, '.claude.json'), 'utf8'))).toEqual({
+      additionalModelOptionsCache: [{ value: 'root-fable', label: 'Root Fable', description: 'test' }]
+    })
+    expect(launch.sandbox!.protectedCredentialRoots).toEqual(
+      expect.arrayContaining([join(home, '.claude'), join(home, '.claude.json')])
+    )
+    expect(launch.sandbox!.protectedCredentialRoots.some((root) => root.startsWith(join(scopeDir, 'home')))).toBe(false)
+    expect(existsSync(join(scopeDir, 'home'))).toBe(false)
+  })
+
+  // A dream or a model session runs on a session-keyed host with no session directory: it keeps the agent HOME, and the rest, exactly.
+  it('keeps the agent HOME and policy for a session host that has no session directory', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const base = {
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap' as const,
+      credentialPlatform: 'linux' as const,
+      trustedPrimaryCheckout: join(scopeDir, 'workspace'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    }
+    const shared = prepareRuntimeLaunch({ ...base, hostKey: agentHostKey('bot-a') })
+    const dream = prepareRuntimeLaunch({ ...base, hostKey: sessionHostKey('bot-a', 'dream:d1') })
+
+    expect(shared.env.HOME).toBe(join(scopeDir, 'home'))
+    expect(dream.env.HOME).toBe(join(scopeDir, 'home'))
+    expect(JSON.stringify(dream.env)).toBe(JSON.stringify(shared.env))
+    expect(dream.sandbox!.writable).toEqual(shared.sandbox!.writable)
+    expect(readFileSync(dream.sandbox!.settingsPath, 'utf8')).toBe(readFileSync(shared.sandbox!.settingsPath, 'utf8'))
+  })
+
+  // The daemon redirects native memory under this HOME before the launch exists, so the two derivations must agree.
+  it('names the same HOME for the native-memory redirect as the launch gives the host', () => {
+    const { scopeDir, hostHome, key, sessionDir, cwd } = sessionCloneFixture()
+    expect(privateRuntimeHomeFor(scopeDir, key)).toBe(join(realpathSync(sessionDir), 'home'))
+    expect(privateRuntimeHomeFor(scopeDir, agentHostKey('bot-a'))).toBe(join(scopeDir, 'home'))
+    expect(privateRuntimeHomeFor(scopeDir, sessionHostKey('bot-a', 'dream:d1'))).toBe(join(scopeDir, 'home'))
+    expect(privateRuntimeHomeFor(scopeDir, undefined)).toBe(join(scopeDir, 'home'))
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      hostKey: key,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      trustedWorkspaceWriteRoots: [sessionDir],
+      trustedPrimaryCheckout: join(scopeDir, 'workspace'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+    expect(launch.env.HOME).toBe(privateRuntimeHomeFor(scopeDir, key))
+  })
+
   // The unconfined tier keeps its linked worktrees and their grants: a session directory on disk and a session-bound host key must change nothing about its policy.
   it('leaves the unconfined policy byte-identical whether or not a session directory exists', () => {
     const { scopeDir, hostHome } = fixture()
@@ -551,6 +696,7 @@ describe('prepareRuntimeLaunch', () => {
     const second = prepareRuntimeLaunch(base)
     expect(readFileSync(second.sandbox!.settingsPath, 'utf8')).toBe(policyBefore)
     expect(JSON.stringify(second.env)).toBe(envBefore)
+    expect(second.env.HOME).toBe(join(scopeDir, 'home'))
     expect(second.gitMetadataWriteRoots).toEqual([realpathSync(primaryGit)])
   })
 

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -13,6 +13,7 @@ import {
   workspaceGitLocalEnv
 } from '../src/workspace/git-injection.js'
 import { LocalGitRunner, type GitRunner, type GitLogEntry, type GitPullSummary } from '../src/workspace/git-runner.js'
+import { sessionHomeIn } from '../src/workspace/session-layout.js'
 import { WorkspaceManager, type PrepareSessionWorkspaceRequest } from '../src/workspace/workspace-manager.js'
 
 // Real git against real repositories (git-workspace-model.md §11): the claims are about the disk — where a confined session's clones land, that nothing of theirs reaches the primary, that a review is fetched and verified inside the clone, and what retirement removes or keeps.
@@ -390,14 +391,19 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
 })
 
 describe('retiring a confined session', () => {
-  it('removes the whole session directory when every clone is clean and pushed', async () => {
+  it('removes the whole session directory, its HOME included, when every clone is clean and pushed', async () => {
     const agent = agentFixture({ additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }] })
     serveAll(agent)
     await workspaces.prepareSessionWorkspace(agent, confined())
     expect(existsSync(leafOf(agent))).toBe(true)
+    // What a launch leaves beside the clones (§11): the session's private HOME with runtime state in it — never a clone, never a reason to retain.
+    const home = sessionHomeIn(leafOf(agent))
+    mkdirSync(join(home, '.codex', 'memories'), { recursive: true })
+    writeFileSync(join(home, '.codex', 'memories', 'memories.sqlite'), 'session-only\n')
 
     expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({ outcome: 'removed' })
 
+    expect(existsSync(home)).toBe(false)
     expect(existsSync(leafOf(agent))).toBe(false)
     expect(workspaces.confinedSessionDir(agent, KEY)).toBeUndefined()
     expect(existsSync(join(workspaces.agentRootFor(agent), 'repos', 'acme', 'infra', 'checkout', '.git'))).toBe(true)


### PR DESCRIPTION
PR 4 of the [git-workspace-model.md §11](docs/designs/git-workspace-model.md#11-session-isolation-under-an-os-boundary-decided-2026-09-02) rollout, on top of #1761 (PR 3: the per-session clone) and #1758 (PR 2: one ACP host per confined session). Base is PR 3's branch; it retargets when that merges.

## What changes

For a **confined session** — a launch whose session host (PR 2's `HostKey`) has its directory on disk (PR 3's leaf) — the runtime's private HOME is the leaf's own:

```
<agentDir>/sessions/<leaf>/
├── workspace/              the cwd (PR 3)
├── repos/<owner>/<repo>/   secondary clones (PR 3)
└── home/                   the runtime HOME — this PR
```

- **Derivation** (`launch/prepare.ts`): `prepareRuntimeLaunch` derives the leaf from the host key once, beside the clone grants, and `sessionHomeIn(leaf)` (`workspace/session-layout.ts`, next to `workspace/` and `repos/`) is the HOME it prepares. An agent host, or a session host with no leaf, keeps `<agentDir>/home` exactly as before. `privateRuntimeHomeFor(scopeDir, hostKey)` is the same derivation, exported for the daemon.
- **Seeding** (`prepareRuntimeHome` with the session HOME as its `targetHome`): identical to the agent HOME — runtime state locations from the host, `preparePrivateHome` linking the shared credential in (Codex `auth.json` → the host file; Claude through `CLAUDE_SECURESTORAGE_CONFIG_DIR`), which stays where it is with today's write carve-back. The legacy per-agent `.claude`/`.codex` migration stays agent-HOME-only.
- **Env** (`runtimeHomeEnvironment`, `isolateHostSocketEnvironment`): `HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_RUNTIME_DIR` (`<home>/.run`), `CODEX_HOME` / `CLAUDE_CONFIG_DIR` and the other runtime-state env point at the session HOME. The provider redirects `TMPDIR` to `<HOME>/.tmp` at spawn as it always has; that now lands in the leaf too.
- **Boundary and provider**: `sandboxBoundary` already lists `runtimeHome` as an exact write root and requires it strictly inside the agent dir; `<agentDir>/sessions/<leaf>/home` satisfies both, so the provider's "private HOME must be an explicit SRT write root" rule holds — asserted, not assumed. The agent's `<agentDir>/home` is neither created for a session host nor inside its read or write set.
- **Runtime-native protected roots follow**: the Codex profile denies `<sessionHome>/.codex` in every profile table; the Claude private state roots are `<sessionHome>/.claude` and `<sessionHome>/.claude.json`. `disabledClaudeProfileRoot` and the runtime-policy directory stay agent-scoped by design.
- **Native memory** (`daemon.ts` `buildAcpHost`): the native-memory redirect used `runtimeHomePath(agent.dir)` unconditionally. For a user-named runtime id — where `runtimeHomeEnvironment`'s own per-runtime env does not override the pin — that would have left `CLAUDE_CONFIG_DIR` / `CODEX_HOME` at an agent-HOME path a confined session can neither read nor write. It now derives the HOME through `privateRuntimeHomeFor`, so the redirect and the launch agree by construction.
- **Retirement**: PR 3's `removeSessionClones` already removes the whole leaf, `home/` included; the test now plants runtime state under `home/` and asserts it is gone. A session's HOME never outlives its session; a retained (dirty) session keeps it.

## Consequences, accepted

- **Runtime-native cross-session state becomes per session** — Codex `memories` / `goals` / `logs` sqlite, Claude project state under `.claude/projects`. AgentConnect's managed memory lives outside HOME (`<agentDir>/memory`) and is unaffected. The console's native-memory view still reads the agent HOME, so a confined session's native memory is not surfaced there; nothing here tries to preserve it across sessions.
- **Package caches live in the session HOME** (`.npm`, `.cache` including pnpm and corepack, `.local`): writable per session by construction and gone with the session. This is what makes `pnpm` / corepack usable inside a confined session — today they fail on a read-only cache. No per-agent cache is opened to the model and no package manager is pre-provisioned (§11 non-goals). Sequenced after #1757 on purpose: managed ACP adapters launch from the daemon-owned tree, so a fresh HOME per session is not a fresh adapter install.

## What does not change

Unconfined launches, `shared` isolation, probes, and the dream and model-session hosts (session-keyed hosts with no leaf) keep `<agentDir>/home`. `keeps the agent HOME and policy for a session host that has no session directory` asserts a dream-keyed host's env, writable set and policy file are byte-identical to the agent host's; the unconfined-byte-identical and shared-host-unchanged tests from PR 3 still hold (the latter now also names the HOME).

## Verification (unit level only — no live Linux daemon was exercised)

- `runtime-launch.test.ts`: session HOME under the leaf with `runtimeHome` / `HOME` / `XDG_*` / `XDG_RUNTIME_DIR` / `CODEX_HOME` pointing there; Codex `config.toml` seeded and `auth.json` linked to the host file; the agent HOME never created and outside the session's read and write sets; HOME an exact write root with the shared credential's own carve-back beside it; `<sessionHome>/.codex` denied in all three Codex profile tables and present in `protectedCredentialRoots`; Claude `CLAUDE_CONFIG_DIR` and private state roots under the session HOME with the `.claude.json` projection seeded; `privateRuntimeHomeFor` agreeing with the launch's `HOME` across the four host shapes; the no-leaf session host byte-identical.
- `daemon-session-hosts.test.ts`: the two concurrent session hosts now use their real leaves — each launches with its own HOME under its own leaf, an exact write root, and the two differ.
- `workspace-session-clone.test.ts`: retirement removes `home/` with the leaf.
- **Mutation checks**: deriving the agent HOME for a session host reddened exactly the three HOME tests (two in `runtime-launch`, one in `daemon-session-hosts`; the other 43 stayed green); making retirement remove only the clones reddened the retirement test on its `home/` assertion (PR 3's two existing leaf assertions caught it as well). Both restored; all green again.
- `pnpm --filter @agentconnect.md/daemon exec tsc -p tsconfig.typecheck.json --noEmit`, eslint and prettier on the touched files; `runtime-launch`, `runtime-home`, `codex-permission-profiles`, `sandbox`, `workspace-session-clone`, `workspace-secondary-roots`, `workspace-repo-scope`, `workspace`, `daemon-session-hosts` green, re-run after rebasing onto the current PR 3 head. The full daemon suite was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
