### PR TITLE
feat(daemon): the orphan reconciler collects a session pod whose session row is gone (§11)

### DIFF
--- a/charts/agentconnect/templates/_helpers.tpl
+++ b/charts/agentconnect/templates/_helpers.tpl
@@ -150,6 +150,15 @@ app.kubernetes.io/component: {{ .component }}
   value: {{ .Values.daemonPool.sandboxNamespace | default .Release.Namespace | quote }}
 - name: AGENTCONNECT_SUPERVISOR
   value: k8s
+{{- with .Values.daemonPool.reconciler.graceMs }}
+{{- /* ONE safety window for both surfaces. The sweep calls a claim orphaned once nothing has touched
+       it for this long, and a member re-stamps the claims it holds on a cadence derived from the same
+       number — so a member reading a different grace than the job sweeping after it would let a claim
+       in use age past the window between two of its own ticks. Unset ⇒ the daemon's 10-minute default
+       on both sides. */}}
+- name: AC_K8S_ORPHAN_GRACE_MS
+  value: {{ . | quote }}
+{{- end }}
 {{- end -}}
 
 {{/* One env pair per `modelEgress` client, rendered onto whichever surface asks. Two surfaces

--- a/charts/agentconnect/templates/daemon-pool-reconciler.yaml
+++ b/charts/agentconnect/templates/daemon-pool-reconciler.yaml
@@ -89,13 +89,6 @@ spec:
                 - name: AC_K8S_ORPHAN_DELETE
                   value: 'true'
                 {{- end }}
-                {{- with $reconciler.graceMs }}
-                # How old an object must be before it can be called orphaned — the guard against
-                # collecting a creation still racing the control plane's write. Unset ⇒ the
-                # daemon's own 10-minute default.
-                - name: AC_K8S_ORPHAN_GRACE_MS
-                  value: {{ . | quote }}
-                {{- end }}
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:

--- a/charts/agentconnect/templates/daemon-pool.yaml
+++ b/charts/agentconnect/templates/daemon-pool.yaml
@@ -26,7 +26,8 @@ metadata:
 rules:
   - apiGroups: ['extensions.agents.x-k8s.io']
     resources: ['sandboxclaims']
-    verbs: ['get', 'list', 'watch', 'create', 'delete']
+    # patch: admitting a claim that already exists stamps it, which is how a reused claim is told from a leaked one.
+    verbs: ['get', 'list', 'watch', 'create', 'patch', 'delete']
   - apiGroups: ['extensions.agents.x-k8s.io']
     resources: ['sandboxwarmpools', 'sandboxtemplates']
     verbs: ['get']

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -354,7 +354,12 @@ exist (`agent/exists` → `agent/exists/ok`, install-wide, advertised as the
   the grace period old (default 10 minutes);
 - a probe claim past the window the probe stamped on it;
 - a Sandbox no claim binds, whose agent the control plane no longer knows,
-  under the same grace.
+  under the same grace;
+- a session pod (`agentconnect.md/session` beside the agent label,
+  [git-workspace-model.md](git-workspace-model.md) §11) whose agent lives but
+  whose session row is gone from the shared store, under the same grace — the
+  job asks the store once per run, and a session nobody can answer for (no
+  store mounted, a read that failed) reads as live.
 
 **Safety rules.** An object of a live agent is never touched, a claimless
 Sandbox included — deleting a claim deletes the workspace volume and is

--- a/docs/designs/k8s-daemon-pool.md
+++ b/docs/designs/k8s-daemon-pool.md
@@ -374,6 +374,21 @@ replacement created after the list is never the object deleted. Each run logs
 one summary line (candidates, orphaned, deleted, skipped-live, skipped-grace,
 failed).
 
+**The admission fence.** A session row's absence is a snapshot, and a session
+can come back between that read and the delete — its admission REUSES the
+leaked claim rather than creating one, so neither the object's age nor a
+same-name replacement check would notice. So admission and collection share the
+claim's own version. `ensureSandbox` stamps every claim it takes with
+`agentconnect.md/last-admitted-at` (on the claim's metadata, never in its spec
+or its pod's, so warm-pool adoption is untouched), and `ensureClaim` WRITES that
+stamp even on the path that only reuses an existing claim. Two things follow: the
+grace runs from the later of creation and last admission, so a re-admitted claim
+is young again and no candidate at all; and the stamp's write moves the claim's
+resourceVersion, so an admission that landed after the sweep listed the object
+makes its preconditioned delete fail — reported as "replaced since it was
+listed", with the pod and its volume left alone and the next run re-deciding.
+A second uncoordinated row read would only have narrowed that window.
+
 **Dry run by default.** The reconciler ships reporting only; deletion is
 enabled per deployment with `AC_K8S_ORPHAN_DELETE=true` after an observation
 window in which the summary lines show it collecting exactly what an operator

--- a/packages/daemon/src/cli/reconcile.ts
+++ b/packages/daemon/src/cli/reconcile.ts
@@ -10,7 +10,9 @@
  * Both halves run in the one job because they ask the control plane the SAME question: the batched
  * `agent/exists` read answers "is this leaked?" for a `SandboxClaim` and for an outbox row alike.
  * The store half is skipped where no shared data plane is mounted — a local single-daemon store has
- * one owner forever and its rows are its own to drain.
+ * one owner forever and its rows are its own to drain. The store is also what answers for a SESSION
+ * pod (git-workspace-model.md §11): its claim lives as long as its session row, so a pod whose row is
+ * gone is an orphan — and without a store every session pod reads as live.
  *
  * The connection registers as an OBSERVER. It presents the same projected pool identity a member
  * does, so the control plane admits it on the same TokenReview path, but it is enrolled in no
@@ -36,6 +38,9 @@ import { DATA_PLANE_CONFIG_PATH } from '../store/postgres-config.js'
 import { openMountedPostgresDataPlane } from '../store/postgres-data-plane.js'
 import { StoreRetentionSweeper, resolveStoreRetentionSettings } from '../store/retention.js'
 import type { RetentionCapableStore } from '../store/retention.js'
+import type { LocalStore } from '../store/local-store.js'
+import { hostKeyDirName, sessionHostKey } from '../acp/host-key.js'
+import { sessionSandboxSubject } from '../k8s/sandbox-identity.js'
 import { DAEMON_VERSION } from '../version.js'
 
 const REQUEST_TIMEOUT_MS = 15_000
@@ -46,9 +51,9 @@ export interface ExistenceReader {
   close: () => void
 }
 
-/** The shared data-plane store, plus how to give it back. */
+/** The shared data-plane store, plus how to give it back; one that lists session keys also answers for session pods. */
 export interface ReapableStore {
-  store: RetentionCapableStore
+  store: RetentionCapableStore & Partial<Pick<LocalStore, 'sessionKeysForAgent'>>
   close: () => Promise<void>
 }
 
@@ -90,9 +95,18 @@ export async function runReconcileOnce(opts: ReconcileOnceOpts = {}): Promise<nu
     if (!url) throw new Error(`reconcile requires the control plane's address in ${CP_URL_ENV}`)
     cp = await (opts.connectCp ?? connectObserver)(url)
     const liveAgents = cp.liveAgents
-    const reconciler = new OrphanReconciler({ api, liveAgents, settings, log })
-    const summary = await reconciler.sweep()
+    // The store first: it is what answers for a session pod's row (git-workspace-model.md §11).
     mounted = await (opts.openStore ?? openSharedStore)()
+    const sessionKeys = mounted?.store.sessionKeysForAgent?.bind(mounted.store)
+    const liveSessionLeaves = sessionKeys ? liveSessionLeavesFrom(sessionKeys) : undefined
+    const reconciler = new OrphanReconciler({
+      api,
+      liveAgents,
+      ...(liveSessionLeaves ? { liveSessionLeaves } : {}),
+      settings,
+      log
+    })
+    const summary = await reconciler.sweep()
     // No data plane is not a failure: this deployment keeps no shared store to sweep.
     // No `ownerId`: a one-shot job owns no rows, so every rule keeps its conservative window.
     const storeSummary = mounted
@@ -107,6 +121,21 @@ export async function runReconcileOnce(opts: ReconcileOnceOpts = {}): Promise<nu
   } finally {
     cp?.close()
     await mounted?.close().catch(() => undefined)
+  }
+}
+
+/** Which session pods still have a row: one store read per agent, the leaves derived as the host keys derive them. */
+function liveSessionLeavesFrom(
+  sessionKeysForAgent: LocalStore['sessionKeysForAgent']
+): NonNullable<ConstructorParameters<typeof OrphanReconciler>[0]['liveSessionLeaves']> {
+  return async (sessions) => {
+    const live = new Set<string>()
+    for (const agentId of new Set(sessions.map((session) => session.agentId))) {
+      for (const key of await sessionKeysForAgent(agentId)) {
+        live.add(sessionSandboxSubject(agentId, hostKeyDirName(sessionHostKey(agentId, key))))
+      }
+    }
+    return live
   }
 }
 

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -1,5 +1,6 @@
 import { LaunchTimer, noopClusterMetrics, type ClusterMetrics } from '../metrics/cluster-metrics.js'
 import { systemClock, type Clock } from '@agentconnect.md/connection'
+import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { SpawnDriver, SpawnRequest, SpawnedRuntime } from '../acp/spawn-driver.js'
 import type { ShimCapability } from '../shim/protocol.js'
 import type { ShimConnection } from '../shim/connection.js'
@@ -170,8 +171,36 @@ export class K8sDriver implements SpawnDriver {
     return this.registry.recordLaunch(subject, sandboxName, sandboxUid, claimUid)
   }
 
+  /**
+   * Re-stamp every claim this member holds a launch for, so a claim in USE never looks like a leak.
+   *
+   * The stamp cannot be an admission marker alone. `ensureSandbox` returns from the launch registry
+   * without touching the API, and `adoptSessions` caches a Running claim this member never admitted,
+   * so a member can serve a session indefinitely without writing to its claim. A sweep that snapshotted
+   * the session's row as absent would then still match on `resourceVersion` when the row came back, and
+   * take a live pod's volume. Refreshed well inside the sweep's grace, the stamp means "last seen in
+   * use by a member", which is the fact the sweep actually needs.
+   *
+   * Best effort by construction: one claim's failure never stops the rest, and nothing here is on a
+   * turn's path — a refresh that does not land costs freshness, and the next tick tries again.
+   */
+  async refreshAdmissionStamps(): Promise<void> {
+    const at = new Date(this.clock.now()).toISOString()
+    for (const { subject } of this.registry.launched()) {
+      const name = this.claimName(subject)
+      // A claim retired under this member is not an error to report: its launch is simply on its way out.
+      const stamped = await this.deps.api.stampClaim(name, { [AC_ANNOTATION_ADMITTED]: at }).catch((err: unknown) => {
+        if (!(err instanceof K8sApiError) || !err.isNotFound) {
+          this.deps.log.debug?.(`cluster: could not refresh the stamp on claim ${name} — ${(err as Error).message}`)
+        }
+        return undefined
+      })
+      if (stamped?.stampRefused) this.reportStampRefused(name)
+    }
+  }
+
   // Said once per process: the launch is unaffected, but the orphan sweep loses the stamp that tells a
-  // re-admitted claim from a leaked one and falls back to the object's own age for it.
+  // claim in use from a leaked one and falls back to the object's own age for it.
   private reportStampRefused(name: string): void {
     if (this.stampRefusalReported) return
     this.stampRefusalReported = true

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -75,6 +75,8 @@ export class K8sDriver implements SpawnDriver {
   private readonly lease: SandboxLease
   private readonly binder: ChannelBinder
   private readonly clock: Clock
+  /** So a Role without `patch` on claims says so once, not on every admission it degrades. */
+  private stampRefusalReported = false
 
   constructor(private readonly deps: K8sDriverDeps) {
     this.clock = deps.clock ?? systemClock
@@ -151,6 +153,7 @@ export class K8sDriver implements SpawnDriver {
         additionalPodMetadata: { labels }
       }
     })
+    if (ensured.stampRefused) this.reportStampRefused(name)
     // Bound, NOT ready: waiting for Ready here would block the only call that revives a suspended
     // claim, whose Sandbox it still names. Resume is "patch Running, then wait", in that order.
     const sandboxName = await awaitBoundSandbox(name, this.waits)
@@ -165,6 +168,17 @@ export class K8sDriver implements SpawnDriver {
     const claimUid = ensured.claim.metadata?.uid ?? sandboxUid
     this.registry.assertStillServed(subject, releasedAt)
     return this.registry.recordLaunch(subject, sandboxName, sandboxUid, claimUid)
+  }
+
+  // Said once per process: the launch is unaffected, but the orphan sweep loses the stamp that tells a
+  // re-admitted claim from a leaked one and falls back to the object's own age for it.
+  private reportStampRefused(name: string): void {
+    if (this.stampRefusalReported) return
+    this.stampRefusalReported = true
+    this.deps.log.warn(
+      `cluster: the API server refused the admission stamp on claim ${name} — sandboxes still launch, but the orphan sweep ` +
+        `judges this claim by age alone until the pool member's Role is granted patch on sandboxclaims`
+    )
   }
 
   /** Takeover: re-derive the launch from the cluster (claim → bound Sandbox → mode), creating nothing. */

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -185,18 +185,21 @@ export class K8sDriver implements SpawnDriver {
    * turn's path — a refresh that does not land costs freshness, and the next tick tries again.
    */
   async refreshAdmissionStamps(): Promise<void> {
+    for (const { subject } of this.registry.launched()) await this.stampHeldClaim(subject)
+  }
+
+  // Mark one claim as in use NOW. Best effort: a claim retired under this member is not an error to
+  // report — its launch is simply on its way out — and a Role without `patch` degrades as admission does.
+  private async stampHeldClaim(subject: SandboxSubject): Promise<void> {
+    const name = this.claimName(subject)
     const at = new Date(this.clock.now()).toISOString()
-    for (const { subject } of this.registry.launched()) {
-      const name = this.claimName(subject)
-      // A claim retired under this member is not an error to report: its launch is simply on its way out.
-      const stamped = await this.deps.api.stampClaim(name, { [AC_ANNOTATION_ADMITTED]: at }).catch((err: unknown) => {
-        if (!(err instanceof K8sApiError) || !err.isNotFound) {
-          this.deps.log.debug?.(`cluster: could not refresh the stamp on claim ${name} — ${(err as Error).message}`)
-        }
-        return undefined
-      })
-      if (stamped?.stampRefused) this.reportStampRefused(name)
-    }
+    const stamped = await this.deps.api.stampClaim(name, { [AC_ANNOTATION_ADMITTED]: at }).catch((err: unknown) => {
+      if (!(err instanceof K8sApiError) || !err.isNotFound) {
+        this.deps.log.debug?.(`cluster: could not refresh the stamp on claim ${name} — ${(err as Error).message}`)
+      }
+      return undefined
+    })
+    if (stamped?.stampRefused) this.reportStampRefused(name)
   }
 
   // Said once per process: the launch is unaffected, but the orphan sweep loses the stamp that tells a
@@ -226,6 +229,11 @@ export class K8sDriver implements SpawnDriver {
       const current = this.registry.currentLaunch(subject)
       if (current) return current
       if (!this.registry.stillServed(subject, releasedAt)) return undefined
+      // Stamped BEFORE the launch is published, not at the next tick: a takeover writes nothing to the
+      // claim otherwise, and the launch it publishes is then served from the registry — so a sweep that
+      // listed this claim while the session's row was absent would still match its version when the row
+      // came back, and delete a pod this member is serving.
+      await this.stampHeldClaim(subject)
       this.deps.log.info(`cluster: sandbox ${subject} taken over with sandbox ${sandboxName} running`)
       return this.registry.recordLaunch(subject, sandboxName, sandboxUid, claimUid)
     })
@@ -291,6 +299,8 @@ export class K8sDriver implements SpawnDriver {
     const sandboxUid = sandbox?.metadata?.uid
     if (!sandboxUid) throw new Error(`sandbox ${sandboxName} is gone — nothing to resume`)
     this.registry.assertStillServed(subject, releasedAt)
+    // A resume publishes a launch without admitting one, exactly as a takeover does, so it stamps too.
+    await this.stampHeldClaim(subject)
     return await this.registry.recordLaunch(subject, sandboxName, sandboxUid, claimUid)
   }
 

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -1,6 +1,5 @@
 import { LaunchTimer, noopClusterMetrics, type ClusterMetrics } from '../metrics/cluster-metrics.js'
 import { systemClock, type Clock } from '@agentconnect.md/connection'
-import { K8sApiError } from '@agentconnect.md/k8s-client'
 import type { SpawnDriver, SpawnRequest, SpawnedRuntime } from '../acp/spawn-driver.js'
 import type { ShimCapability } from '../shim/protocol.js'
 import type { ShimConnection } from '../shim/connection.js'
@@ -185,21 +184,47 @@ export class K8sDriver implements SpawnDriver {
    * turn's path — a refresh that does not land costs freshness, and the next tick tries again.
    */
   async refreshAdmissionStamps(): Promise<void> {
-    for (const { subject } of this.registry.launched()) await this.stampHeldClaim(subject)
+    // Best effort, unlike a publication fence: a claim retired under this member is on its way out, and
+    // a write that does not land costs freshness the next tick restores, never a launch.
+    for (const { subject } of this.registry.launched()) {
+      const outcome = await this.writeStamp(subject)
+      if (outcome === 'failed') {
+        this.deps.log.debug?.(`cluster: could not refresh the stamp on claim ${this.claimName(subject)}`)
+      }
+    }
   }
 
-  // Mark one claim as in use NOW. Best effort: a claim retired under this member is not an error to
-  // report — its launch is simply on its way out — and a Role without `patch` degrades as admission does.
-  private async stampHeldClaim(subject: SandboxSubject): Promise<void> {
+  /**
+   * Mark a claim as in use, as the fence a launch about to be PUBLISHED depends on.
+   *
+   * Only two outcomes may publish: the write landed, or the API server refused the permission — the
+   * mixed-Role degradation this daemon already reports once and accepts, because failing every takeover
+   * over a missing verb would be worse than the race. A transient rejection is neither, and swallowing
+   * it would publish a launch the sweep cannot see: it would still hold the resourceVersion it listed
+   * while the session's row was absent, and its delete would take a live pod's volume.
+   */
+  private async fenceLaunch(subject: SandboxSubject): Promise<boolean> {
+    const outcome = await this.writeStamp(subject)
+    if (outcome === 'failed') {
+      this.deps.log.warn(
+        `cluster: not publishing the launch of sandbox ${subject} — its claim ${this.claimName(subject)} could not be ` +
+          `marked in use, and an unmarked claim can be collected while this member serves it`
+      )
+    }
+    return outcome !== 'failed'
+  }
+
+  // The stamp write itself: `refused` is the permission gap, reported once; `failed` is everything else.
+  private async writeStamp(subject: SandboxSubject): Promise<'stamped' | 'refused' | 'failed'> {
     const name = this.claimName(subject)
     const at = new Date(this.clock.now()).toISOString()
-    const stamped = await this.deps.api.stampClaim(name, { [AC_ANNOTATION_ADMITTED]: at }).catch((err: unknown) => {
-      if (!(err instanceof K8sApiError) || !err.isNotFound) {
-        this.deps.log.debug?.(`cluster: could not refresh the stamp on claim ${name} — ${(err as Error).message}`)
-      }
-      return undefined
-    })
-    if (stamped?.stampRefused) this.reportStampRefused(name)
+    const stamped = await this.deps.api.stampClaim(name, { [AC_ANNOTATION_ADMITTED]: at }).catch(() => undefined)
+    if (!stamped) return 'failed'
+    if (stamped.stampRefused) {
+      this.reportStampRefused(name)
+      return 'refused'
+    }
+    return 'stamped'
   }
 
   // Said once per process: the launch is unaffected, but the orphan sweep loses the stamp that tells a
@@ -232,8 +257,9 @@ export class K8sDriver implements SpawnDriver {
       // Stamped BEFORE the launch is published, not at the next tick: a takeover writes nothing to the
       // claim otherwise, and the launch it publishes is then served from the registry — so a sweep that
       // listed this claim while the session's row was absent would still match its version when the row
-      // came back, and delete a pod this member is serving.
-      await this.stampHeldClaim(subject)
+      // came back, and delete a pod this member is serving. A fence that does not land adopts nothing;
+      // the next duty tick or the next turn tries again.
+      if (!(await this.fenceLaunch(subject))) return undefined
       this.deps.log.info(`cluster: sandbox ${subject} taken over with sandbox ${sandboxName} running`)
       return this.registry.recordLaunch(subject, sandboxName, sandboxUid, claimUid)
     })
@@ -299,8 +325,11 @@ export class K8sDriver implements SpawnDriver {
     const sandboxUid = sandbox?.metadata?.uid
     if (!sandboxUid) throw new Error(`sandbox ${sandboxName} is gone — nothing to resume`)
     this.registry.assertStillServed(subject, releasedAt)
-    // A resume publishes a launch without admitting one, exactly as a takeover does, so it stamps too.
-    await this.stampHeldClaim(subject)
+    // A resume publishes a launch without admitting one, exactly as a takeover does, so it stamps too —
+    // and refuses the read rather than serving a pod the sweep could collect underneath it.
+    if (!(await this.fenceLaunch(subject))) {
+      throw new Error(`sandbox ${subject} claim ${name} could not be marked in use — not resuming onto it`)
+    }
     return await this.registry.recordLaunch(subject, sandboxName, sandboxUid, claimUid)
   }
 

--- a/packages/daemon/src/k8s/driver.ts
+++ b/packages/daemon/src/k8s/driver.ts
@@ -13,6 +13,7 @@ import { LaunchRegistry, type Launch, type LaunchGenerations } from './launch-re
 import { ChannelBinder } from './channel-binder.js'
 import { awaitBoundSandbox, awaitReady, readIfPresent, type SandboxWaitDeps } from './sandbox-waits.js'
 import {
+  AC_ANNOTATION_ADMITTED,
   AC_LABEL_AGENT,
   AC_LABEL_SESSION,
   LaunchTimeoutError,
@@ -133,10 +134,16 @@ export class K8sDriver implements SpawnDriver {
     if (!orgId) throw new Error(`cannot resolve sandbox organization for agent ${agentId}`)
     const claimMetadata = this.deps.claimMetadataForAgent?.(agentId)
     const labels = sandboxPodLabels(orgId, subject)
+    // Every admission STAMPS the claim, including one that only reuses an existing object: the write
+    // gives a re-admitted claim a new resourceVersion, so the orphan sweep's preconditioned delete —
+    // fenced on the version it listed — loses to a session that came back after that snapshot (§4).
     const ensured = await this.deps.api.ensureClaim({
       metadata: {
         name,
-        ...(claimMetadata?.annotations ? { annotations: claimMetadata.annotations } : {}),
+        annotations: {
+          ...claimMetadata?.annotations,
+          [AC_ANNOTATION_ADMITTED]: new Date(this.clock.now()).toISOString()
+        },
         labels: { ...labels, ...claimMetadata?.labels }
       },
       spec: {

--- a/packages/daemon/src/k8s/orphan-reconciler.ts
+++ b/packages/daemon/src/k8s/orphan-reconciler.ts
@@ -1,6 +1,6 @@
 import { systemClock, type Clock } from '@agentconnect.md/connection'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
-import { AC_LABEL_AGENT } from './sandbox-identity.js'
+import { AC_LABEL_AGENT, AC_LABEL_SESSION, sessionSandboxSubject } from './sandbox-identity.js'
 import { probeClaimExpiry } from './probe-claim.js'
 import type { Sandbox, SandboxApi, SandboxClaim } from './sandbox-api.js'
 
@@ -16,9 +16,10 @@ import type { Sandbox, SandboxApi, SandboxClaim } from './sandbox-api.js'
  * Safety over completeness. Deleting a claim deletes the workspace volume, so a candidate is
  * collected only when it is PROVABLY orphaned: the control plane no longer knows its agent and the
  * object is older than the grace period; a probe claim is past its own window; a Sandbox has no
- * claim and no live agent. An object of a live agent is never touched — not even a claimless
- * Sandbox — and an unreadable answer fails the sweep. Ships dry-run: it logs and counts until the
- * deployment enables deletion.
+ * claim and no live agent; a session pod's session row is provably gone from the shared store
+ * (git-workspace-model.md §11) while its agent lives. An object of a live agent is never touched —
+ * not even a claimless Sandbox — an unreadable answer fails the sweep, and a session nobody can
+ * answer for reads as live. Ships dry-run: it logs and counts until the deployment enables deletion.
  */
 
 /** Deployment-owned settings, env like the rest of the plane's; absent ⇒ the default below. */
@@ -59,6 +60,8 @@ export interface OrphanReconcilerDeps {
   api: Pick<SandboxApi, 'listClaims' | 'deleteClaimIfCurrent' | 'listSandboxes' | 'deleteSandboxIfCurrent'>
   /** Which of these agents the control plane still knows; a throw fails the sweep. */
   liveAgents: (agentIds: string[]) => Promise<Set<string>>
+  /** Which of these session pods still have a session row, as `<agentId>/<leaf>` subjects; absent or throwing ⇒ every session pod reads as live. */
+  liveSessionLeaves?: (sessions: Array<{ agentId: string; leaf: string }>) => Promise<Set<string>>
   settings: OrphanReconcilerSettings
   clock?: Clock
   log: { info: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void }
@@ -71,6 +74,8 @@ interface Candidate {
   uid: string
   resourceVersion?: string
   agentId: string
+  /** The session leaf a per-session pod carries (`agentconnect.md/session`); absent for the agent's own pod. */
+  sessionLeaf?: string
   /** Epoch ms, NaN when the object did not say — an age nobody knows never passes the grace. */
   createdAt: number
   /** A probe claim's own window, stamped by the probe that made it. */
@@ -125,6 +130,10 @@ export class OrphanReconciler {
       ...new Set(candidates.filter((c) => c.kind !== 'probe-claim' && UUID.test(c.agentId)).map((c) => c.agentId))
     ]
     const live = askable.length > 0 ? await this.deps.liveAgents(askable) : new Set<string>()
+    // Session pods of LIVE agents are asked about once per run; an agent's death already collects its sessions' pods.
+    const liveSessions = await this.liveSessions(
+      candidates.filter((c) => c.kind !== 'probe-claim' && c.sessionLeaf !== undefined && live.has(c.agentId))
+    )
     const orphans: Candidate[] = []
     for (const candidate of candidates) {
       if (candidate.kind === 'probe-claim') {
@@ -135,9 +144,21 @@ export class OrphanReconciler {
         continue
       }
       // An id the control plane could not even be asked about is treated as live: never guess.
-      if (!UUID.test(candidate.agentId) || live.has(candidate.agentId)) {
+      if (!UUID.test(candidate.agentId)) {
         summary.skippedLive += 1
         continue
+      }
+      if (live.has(candidate.agentId)) {
+        // A live agent's own pod is never touched; its session pod only when its row is PROVABLY gone (§11).
+        const leaf = candidate.sessionLeaf
+        if (
+          leaf === undefined ||
+          liveSessions === undefined ||
+          liveSessions.has(sessionSandboxSubject(candidate.agentId, leaf))
+        ) {
+          summary.skippedLive += 1
+          continue
+        }
       }
       // The object's own age IS the grace: a one-shot run has no memory of an earlier sweep, and this
       // is the clock that matters anyway — no in-flight creation can still be racing the CP's write.
@@ -150,14 +171,14 @@ export class OrphanReconciler {
     summary.orphaned = orphans.length
     for (const orphan of orphans) {
       if (!settings.deleteEnabled) {
-        log.info(`k8s orphans: would delete ${orphan.kind} ${orphan.name} (agent ${orphan.agentId}) — dry run`)
+        log.info(`k8s orphans: would delete ${orphan.kind} ${orphan.name} (${ownerOf(orphan)}) — dry run`)
         continue
       }
       try {
         const current = await this.deleteCurrent(orphan)
         if (current) {
           summary.deleted += 1
-          log.info(`k8s orphans: deleted ${orphan.kind} ${orphan.name} (agent ${orphan.agentId})`)
+          log.info(`k8s orphans: deleted ${orphan.kind} ${orphan.name} (${ownerOf(orphan)})`)
         } else {
           log.info(`k8s orphans: ${orphan.kind} ${orphan.name} was replaced since it was listed — left alone`)
         }
@@ -172,6 +193,21 @@ export class OrphanReconciler {
         (settings.deleteEnabled ? '' : ' (dry run)')
     )
     return summary
+  }
+
+  // Fail-closed: no store to ask, or a store that will not answer, keeps every session pod of a live agent.
+  private async liveSessions(sessions: Candidate[]): Promise<Set<string> | undefined> {
+    if (sessions.length === 0) return new Set()
+    const ask = this.deps.liveSessionLeaves
+    if (!ask) return undefined
+    try {
+      return await ask(sessions.map((c) => ({ agentId: c.agentId, leaf: c.sessionLeaf! })))
+    } catch (err) {
+      this.deps.log.warn(
+        `k8s orphans: could not ask which sessions still exist — keeping every session pod (${(err as Error).message})`
+      )
+      return undefined
+    }
   }
 
   // Listing Sandboxes needs a verb the claim path never did; a Role without it just narrows the sweep to claims.
@@ -198,6 +234,13 @@ export class OrphanReconciler {
   }
 }
 
+/** Who an orphan belonged to, for the log line: its agent, and its session leaf for a session pod. */
+function ownerOf(orphan: Candidate): string {
+  return orphan.sessionLeaf === undefined
+    ? `agent ${orphan.agentId}`
+    : `agent ${orphan.agentId}, session ${orphan.sessionLeaf}`
+}
+
 /** The install's objects carry the agent label on their pod metadata; anything else is not ours. */
 function candidateOf(object: SandboxClaim | Sandbox, kind: 'claim' | 'sandbox'): Candidate | undefined {
   const name = object.metadata?.name
@@ -209,6 +252,7 @@ function candidateOf(object: SandboxClaim | Sandbox, kind: 'claim' | 'sandbox'):
       : (object as Sandbox).spec?.podTemplate?.metadata?.labels
   const agentId = labels?.[AC_LABEL_AGENT]
   if (!agentId) return undefined
+  const sessionLeaf = labels?.[AC_LABEL_SESSION]
   const resourceVersion = object.metadata?.resourceVersion
   const probeExpiresAt = kind === 'claim' ? probeClaimExpiry(object as SandboxClaim) : undefined
   return {
@@ -217,6 +261,7 @@ function candidateOf(object: SandboxClaim | Sandbox, kind: 'claim' | 'sandbox'):
     uid,
     ...(resourceVersion ? { resourceVersion } : {}),
     agentId,
+    ...(sessionLeaf ? { sessionLeaf } : {}),
     createdAt: Date.parse(object.metadata?.creationTimestamp ?? ''),
     ...(probeExpiresAt === undefined ? {} : { probeExpiresAt })
   }

--- a/packages/daemon/src/k8s/orphan-reconciler.ts
+++ b/packages/daemon/src/k8s/orphan-reconciler.ts
@@ -22,10 +22,13 @@ import type { Sandbox, SandboxApi, SandboxClaim } from './sandbox-api.js'
  * answer for reads as live. Ships dry-run: it logs and counts until the deployment enables deletion.
  *
  * The absence proof is a SNAPSHOT, so it is fenced by the claim's own version rather than trusted on
- * its own. Admission stamps every claim it takes (`agentconnect.md/last-admitted-at`, written even
- * when it only reuses an existing object), which does two things here: the grace runs from that stamp
- * as much as from creation, so a leaked claim a new session re-admitted is young again and no
- * candidate at all; and the stamp's write moves the claim's resourceVersion, so an admission that
+ * its own. A member stamps every claim it admits AND every claim it currently holds a launch for
+ * (`agentconnect.md/last-admitted-at`, refreshed on a tick well inside the grace), so the stamp reads
+ * "last seen in use by a member" rather than "last admitted" — a launch served from a member's registry
+ * touches no API, so an admission-only marker would have left a claim in use looking untouched. That
+ * does two things here: the grace runs from that stamp as much as from creation, so a claim a member is
+ * using, or one a new session re-admitted, is young again and no candidate at all; and the stamp's write
+ * moves the claim's resourceVersion, so a use that
  * landed after this sweep listed the object makes the preconditioned delete below fail rather than
  * take a live session's pod and volume. Admission and collection share one object version.
  */
@@ -172,8 +175,8 @@ export class OrphanReconciler {
       }
       // The object's own age IS the grace: a one-shot run has no memory of an earlier sweep, and this
       // is the clock that matters anyway — no in-flight creation can still be racing the CP's write.
-      // Age runs from the LATER of creation and last admission, because a leaked claim that a new
-      // session re-admitted is young again — its object is old, and only the stamp says so.
+      // Age runs from the LATER of creation and the last time a member admitted or refreshed this claim,
+      // because one in use — or one a returning session re-admitted — is young again, and only the stamp says so.
       const since =
         candidate.admittedAt === undefined ? candidate.createdAt : Math.max(candidate.createdAt, candidate.admittedAt)
       if (!(Number.isFinite(since) && now - since >= settings.graceMs)) {

--- a/packages/daemon/src/k8s/orphan-reconciler.ts
+++ b/packages/daemon/src/k8s/orphan-reconciler.ts
@@ -1,6 +1,6 @@
 import { systemClock, type Clock } from '@agentconnect.md/connection'
 import { K8sApiError } from '@agentconnect.md/k8s-client'
-import { AC_LABEL_AGENT, AC_LABEL_SESSION, sessionSandboxSubject } from './sandbox-identity.js'
+import { AC_LABEL_AGENT, AC_LABEL_SESSION, claimAdmittedAt, sessionSandboxSubject } from './sandbox-identity.js'
 import { probeClaimExpiry } from './probe-claim.js'
 import type { Sandbox, SandboxApi, SandboxClaim } from './sandbox-api.js'
 
@@ -20,6 +20,14 @@ import type { Sandbox, SandboxApi, SandboxClaim } from './sandbox-api.js'
  * (git-workspace-model.md §11) while its agent lives. An object of a live agent is never touched —
  * not even a claimless Sandbox — an unreadable answer fails the sweep, and a session nobody can
  * answer for reads as live. Ships dry-run: it logs and counts until the deployment enables deletion.
+ *
+ * The absence proof is a SNAPSHOT, so it is fenced by the claim's own version rather than trusted on
+ * its own. Admission stamps every claim it takes (`agentconnect.md/last-admitted-at`, written even
+ * when it only reuses an existing object), which does two things here: the grace runs from that stamp
+ * as much as from creation, so a leaked claim a new session re-admitted is young again and no
+ * candidate at all; and the stamp's write moves the claim's resourceVersion, so an admission that
+ * landed after this sweep listed the object makes the preconditioned delete below fail rather than
+ * take a live session's pod and volume. Admission and collection share one object version.
  */
 
 /** Deployment-owned settings, env like the rest of the plane's; absent ⇒ the default below. */
@@ -78,6 +86,8 @@ interface Candidate {
   sessionLeaf?: string
   /** Epoch ms, NaN when the object did not say — an age nobody knows never passes the grace. */
   createdAt: number
+  /** Epoch ms of the claim's last admission stamp, absent when it carries none — a Sandbox never does. */
+  admittedAt?: number
   /** A probe claim's own window, stamped by the probe that made it. */
   probeExpiresAt?: number
 }
@@ -162,7 +172,11 @@ export class OrphanReconciler {
       }
       // The object's own age IS the grace: a one-shot run has no memory of an earlier sweep, and this
       // is the clock that matters anyway — no in-flight creation can still be racing the CP's write.
-      if (!(Number.isFinite(candidate.createdAt) && now - candidate.createdAt >= settings.graceMs)) {
+      // Age runs from the LATER of creation and last admission, because a leaked claim that a new
+      // session re-admitted is young again — its object is old, and only the stamp says so.
+      const since =
+        candidate.admittedAt === undefined ? candidate.createdAt : Math.max(candidate.createdAt, candidate.admittedAt)
+      if (!(Number.isFinite(since) && now - since >= settings.graceMs)) {
         summary.skippedGrace += 1
         continue
       }
@@ -255,6 +269,8 @@ function candidateOf(object: SandboxClaim | Sandbox, kind: 'claim' | 'sandbox'):
   const sessionLeaf = labels?.[AC_LABEL_SESSION]
   const resourceVersion = object.metadata?.resourceVersion
   const probeExpiresAt = kind === 'claim' ? probeClaimExpiry(object as SandboxClaim) : undefined
+  // Only a claim is admitted; a Sandbox is the controller's object and nothing stamps it.
+  const admittedAt = kind === 'claim' ? claimAdmittedAt(object.metadata?.annotations) : Number.NaN
   return {
     kind: probeExpiresAt === undefined ? kind : 'probe-claim',
     name,
@@ -262,6 +278,7 @@ function candidateOf(object: SandboxClaim | Sandbox, kind: 'claim' | 'sandbox'):
     ...(resourceVersion ? { resourceVersion } : {}),
     agentId,
     ...(sessionLeaf ? { sessionLeaf } : {}),
+    ...(Number.isFinite(admittedAt) ? { admittedAt } : {}),
     createdAt: Date.parse(object.metadata?.creationTimestamp ?? ''),
     ...(probeExpiresAt === undefined ? {} : { probeExpiresAt })
   }

--- a/packages/daemon/src/k8s/orphan-reconciler.ts
+++ b/packages/daemon/src/k8s/orphan-reconciler.ts
@@ -38,6 +38,19 @@ export const ORPHAN_GRACE_ENV = 'AC_K8S_ORPHAN_GRACE_MS'
 /** Deletion is opt-in: `1`/`true` collects, anything else only reports. */
 export const ORPHAN_DELETE_ENV = 'AC_K8S_ORPHAN_DELETE'
 export const DEFAULT_ORPHAN_GRACE_MS = 10 * 60_000
+
+/**
+ * How often a member must re-stamp the claims it holds, for a sweep that waits `graceMs`.
+ *
+ * ONE safety window, read from one place: the sweep decides a claim is collectable once nothing has
+ * touched it for `graceMs`, so a member using a claim has to touch it strictly more often than that.
+ * A third of the window leaves two missed ticks of margin. Derived rather than fixed because the grace
+ * is deployment-owned — a hardcoded cadence is silently wrong for every install that shortens it, and
+ * a floor would be the same bug at a different number.
+ */
+export function stampRefreshMsFor(graceMs: number): number {
+  return Math.max(1, Math.floor(graceMs / 3))
+}
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export interface OrphanReconcilerSettings {

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -55,6 +55,9 @@ const PROBE_TIMEOUT_MS = 180_000
  * (git-workspace-model §11). Agent-keyed seams below route each path to the pod that owns it — a
  * session pod owns `<mount>/sessions/<leaf>`, the agent pod everything else.
  */
+/** Stamp refresh cadence: a third of the orphan sweep's default grace, so two misses still leave a claim young. */
+export const STAMP_REFRESH_MS = 3 * 60_000
+
 export interface K8sRuntimePlaneOptions {
   /** Durable, install-shared allocator for launch generations — in production the daemon store,
    *  which every pool member shares, so an agent that moves between members keeps counting up. */
@@ -72,6 +75,8 @@ export interface K8sRuntimePlaneOptions {
   /** Environment the deployment settings come from; `process.env` unless a test names another. */
   env?: NodeJS.ProcessEnv
   readyTimeoutMs?: number
+  /** How often held claims are re-stamped as in use; omit for {@link STAMP_REFRESH_MS}, 0 to run no timer. */
+  stampRefreshMs?: number
   /** Kubernetes surface. Built from the pod's own in-cluster config when omitted; supplied by
    *  tests so the assembly can be exercised without a cluster. */
   api?: SandboxApi
@@ -387,6 +392,20 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     releaseSubject(agentSandboxSubject(agentId), reason)
   }
 
+  // A claim this member is USING must not look like a leak to the orphan sweep, and a launch served
+  // from the registry never touches the API — so the stamp is refreshed on a tick well inside that
+  // sweep's grace. Unref'd: it is bookkeeping, never a reason for the process to stay up.
+  const stampRefreshMs = options.stampRefreshMs ?? STAMP_REFRESH_MS
+  const stampRefresh =
+    stampRefreshMs > 0
+      ? setInterval(() => {
+          void driver.refreshAdmissionStamps().catch((err: unknown) => {
+            options.log?.warn(`k8s: refreshing the sandbox admission stamps failed: ${(err as Error).message}`)
+          })
+        }, stampRefreshMs)
+      : undefined
+  stampRefresh?.unref?.()
+
   return {
     driver,
     dialer,
@@ -481,6 +500,7 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     },
     hasSandbox: (subject) => driver.hasClaim(subject as SandboxSubject),
     stop: async () => {
+      if (stampRefresh) clearInterval(stampRefresh)
       lossWatcher.cancelAll()
       tunnels.releaseAll('daemon is shutting down')
       dialer.stop()

--- a/packages/daemon/src/k8s/runtime-plane.ts
+++ b/packages/daemon/src/k8s/runtime-plane.ts
@@ -32,6 +32,7 @@ import type { WorkspaceFs, WorkspacePlacement } from '../workspace/workspace-fs.
 import { sessionDirIn } from '../workspace/session-layout.js'
 import type { MemoryFs } from '../memory/fs.js'
 import { DEFAULT_SHIM_LISTEN_PORT, DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
+import { resolveOrphanReconcilerSettings, stampRefreshMsFor } from './orphan-reconciler.js'
 import type { TunnelName } from '../shim/tunnel.js'
 import { K8sRuntimeTableSchema, type K8sRuntimeTable } from '../runtimes/k8s-runtimes.js'
 import type { GitRunner } from '../workspace/git-runner.js'
@@ -55,9 +56,6 @@ const PROBE_TIMEOUT_MS = 180_000
  * (git-workspace-model §11). Agent-keyed seams below route each path to the pod that owns it — a
  * session pod owns `<mount>/sessions/<leaf>`, the agent pod everything else.
  */
-/** Stamp refresh cadence: a third of the orphan sweep's default grace, so two misses still leave a claim young. */
-export const STAMP_REFRESH_MS = 3 * 60_000
-
 export interface K8sRuntimePlaneOptions {
   /** Durable, install-shared allocator for launch generations — in production the daemon store,
    *  which every pool member shares, so an agent that moves between members keeps counting up. */
@@ -75,7 +73,7 @@ export interface K8sRuntimePlaneOptions {
   /** Environment the deployment settings come from; `process.env` unless a test names another. */
   env?: NodeJS.ProcessEnv
   readyTimeoutMs?: number
-  /** How often held claims are re-stamped as in use; omit for {@link STAMP_REFRESH_MS}, 0 to run no timer. */
+  /** How often held claims are re-stamped as in use; omit to derive it from the sweep's own grace, 0 to run no timer. */
   stampRefreshMs?: number
   /** Kubernetes surface. Built from the pod's own in-cluster config when omitted; supplied by
    *  tests so the assembly can be exercised without a cluster. */
@@ -392,10 +390,11 @@ export async function startK8sRuntimePlane(options: K8sRuntimePlaneOptions): Pro
     releaseSubject(agentSandboxSubject(agentId), reason)
   }
 
-  // A claim this member is USING must not look like a leak to the orphan sweep, and a launch served
-  // from the registry never touches the API — so the stamp is refreshed on a tick well inside that
-  // sweep's grace. Unref'd: it is bookkeeping, never a reason for the process to stay up.
-  const stampRefreshMs = options.stampRefreshMs ?? STAMP_REFRESH_MS
+  // A claim this member is USING must not look like a leak to the orphan sweep, and a launch served from
+  // the registry never touches the API — so the stamp is refreshed on a tick derived from the SAME grace
+  // the sweep reads, never a constant of its own: an install that shortens the grace would otherwise let a
+  // held claim age past it between two ticks. Unref'd — bookkeeping never holds a process up.
+  const stampRefreshMs = options.stampRefreshMs ?? stampRefreshMsFor(resolveOrphanReconcilerSettings().graceMs)
   const stampRefresh =
     stampRefreshMs > 0
       ? setInterval(() => {

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -54,6 +54,8 @@ export interface TokenReviewResult {
 export interface EnsuredClaim {
   claim: SandboxClaim
   created: boolean
+  /** The API server refused the admission stamp: the claim is admitted, the orphan sweep's fence on it is not. */
+  stampRefused?: boolean
 }
 
 const POD_NAME_EXTRA = 'authentication.kubernetes.io/pod-name'
@@ -140,7 +142,7 @@ export class SandboxApi {
     } catch (err) {
       if (err instanceof K8sApiError && err.isAlreadyExists) {
         return {
-          claim: await this.mergeClaimAnnotations(claim.metadata.name, claim.metadata.annotations),
+          ...(await this.mergeClaimAnnotations(claim.metadata.name, claim.metadata.annotations)),
           created: false
         }
       }
@@ -149,12 +151,24 @@ export class SandboxApi {
   }
 
   /** Merge annotations onto an existing claim and return it; with none to merge it is a plain read. */
+  // A Role without `patch` on claims DEGRADES here rather than failing: the stamp is a fence for the
+  // orphan sweep, and refusing every resume of an existing claim over it would trade a race for an outage.
   private async mergeClaimAnnotations(
     name: string,
     annotations: Record<string, string> | undefined
-  ): Promise<SandboxClaim> {
-    if (!annotations || Object.keys(annotations).length === 0) return await this.getClaim(name)
-    return await this.http.json<SandboxClaim>({
+  ): Promise<{ claim: SandboxClaim; stampRefused?: boolean }> {
+    if (!annotations || Object.keys(annotations).length === 0) return { claim: await this.getClaim(name) }
+    try {
+      return { claim: await this.patchClaimAnnotations(name, annotations) }
+    } catch (err) {
+      // Only a permission refusal degrades; every other rejection is this call failing and stays fatal.
+      if (!(err instanceof K8sApiError) || err.status !== 403) throw err
+      return { claim: await this.getClaim(name), stampRefused: true }
+    }
+  }
+
+  private patchClaimAnnotations(name: string, annotations: Record<string, string>): Promise<SandboxClaim> {
+    return this.http.json<SandboxClaim>({
       method: 'PATCH',
       path: `${this.claims()}/${name}`,
       contentType: 'application/merge-patch+json',

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -124,6 +124,11 @@ export class SandboxApi {
   // Reports whether it CREATED the claim, because that is the only trustworthy cold-start
   // signal: a first claim is the launch that pays PVC provisioning and an image pull, and the
   // AlreadyExists branch is exactly the case that does not.
+  //
+  // That branch WRITES rather than merely reading: the caller's annotations are merged onto the
+  // claim it found, so every admission of an existing claim leaves a new resourceVersion behind.
+  // A reader that fenced a delete on the version it listed then loses to an admission that
+  // followed its snapshot, which is the property the orphan sweep depends on.
   async ensureClaim(claim: SandboxClaim & { metadata: { name: string } }): Promise<EnsuredClaim> {
     try {
       const created = await this.http.json<SandboxClaim>({
@@ -134,10 +139,27 @@ export class SandboxApi {
       return { claim: created, created: true }
     } catch (err) {
       if (err instanceof K8sApiError && err.isAlreadyExists) {
-        return { claim: await this.getClaim(claim.metadata.name), created: false }
+        return {
+          claim: await this.mergeClaimAnnotations(claim.metadata.name, claim.metadata.annotations),
+          created: false
+        }
       }
       throw err
     }
+  }
+
+  /** Merge annotations onto an existing claim and return it; with none to merge it is a plain read. */
+  private async mergeClaimAnnotations(
+    name: string,
+    annotations: Record<string, string> | undefined
+  ): Promise<SandboxClaim> {
+    if (!annotations || Object.keys(annotations).length === 0) return await this.getClaim(name)
+    return await this.http.json<SandboxClaim>({
+      method: 'PATCH',
+      path: `${this.claims()}/${name}`,
+      contentType: 'application/merge-patch+json',
+      body: { metadata: { annotations } }
+    })
   }
 
   getClaim(name: string): Promise<SandboxClaim> {

--- a/packages/daemon/src/k8s/sandbox-api.ts
+++ b/packages/daemon/src/k8s/sandbox-api.ts
@@ -167,6 +167,14 @@ export class SandboxApi {
     }
   }
 
+  /** Merge annotations onto a claim that is known to exist, degrading on a refused permission like an admission does. */
+  async stampClaim(
+    name: string,
+    annotations: Record<string, string>
+  ): Promise<{ claim: SandboxClaim; stampRefused?: boolean }> {
+    return await this.mergeClaimAnnotations(name, annotations)
+  }
+
   private patchClaimAnnotations(name: string, annotations: Record<string, string>): Promise<SandboxClaim> {
     return this.http.json<SandboxClaim>({
       method: 'PATCH',

--- a/packages/daemon/src/k8s/sandbox-identity.ts
+++ b/packages/daemon/src/k8s/sandbox-identity.ts
@@ -8,6 +8,8 @@ export const AC_LABEL_ORG = 'agentconnect.md/org'
 export const AC_LABEL_AGENT = 'agentconnect.md/agent'
 /** The session leaf of a per-session pod, beside — never inside — the agent label the reconciler validates as a UUID. */
 export const AC_LABEL_SESSION = 'agentconnect.md/session'
+// When a claim was last admitted, RFC 3339, on the CLAIM's own metadata and never in its spec or its pod's — warm-pool adoption reads the spec, and this is bookkeeping between admission and the orphan sweep (k8s-daemon-pool.md §4).
+export const AC_ANNOTATION_ADMITTED = 'agentconnect.md/last-admitted-at'
 
 // What a Sandbox is claimed for: the agent's shared pod, or one confined session's own (git-workspace-model §11). A plain agent id IS the agent pod's subject, so the alias is deliberate: every agent-keyed caller is already a subject-keyed one.
 export type SandboxSubject = string
@@ -59,6 +61,11 @@ export function sandboxSubjectForPath(agentId: string, path: string | undefined,
     if (dir === SESSIONS_DIR && leaf?.startsWith('session-')) return sessionSandboxSubject(agentId, leaf)
   }
   return agentSandboxSubject(agentId)
+}
+
+/** When these annotations say the claim was last admitted, epoch ms, or NaN when they do not say. */
+export function claimAdmittedAt(annotations: Record<string, string> | undefined): number {
+  return Date.parse(annotations?.[AC_ANNOTATION_ADMITTED] ?? '')
 }
 
 /** The pod labels a subject's claim carries: the tenant, the agent, and — for a session pod — its leaf. */

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -3047,6 +3047,14 @@ export class LocalStore {
     return row?.ts ?? null
   }
 
+  /** Every session key of the agent, open or closed — a row's existence is what keeps its session pod's claim (git-workspace-model §11). */
+  async sessionKeysForAgent(agentId: string): Promise<string[]> {
+    const rows = (await this.db.prepare('SELECT key FROM sessions WHERE agentId = ?').all(agentId)) as Array<{
+      key: string
+    }>
+    return rows.map((row) => row.key)
+  }
+
   /** One session's own last activity (epoch ms), or null once closed or gone — reaps a session-bound host. */
   async sessionLastActivityTs(key: string): Promise<number | null> {
     const row = (await this.db

--- a/packages/daemon/test/cli-reconcile.test.ts
+++ b/packages/daemon/test/cli-reconcile.test.ts
@@ -6,7 +6,14 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { K8sHttp } from '@agentconnect.md/k8s-client'
 import { closeFakeApiServers, fakeApiServer } from '@agentconnect.md/k8s-client/testing'
 import { buildEnvelope, decodeEnvelope, encode, type AnyFrame } from '@agentconnect.md/protocol'
-import { AC_LABEL_AGENT, AC_LABEL_ORG } from '../src/k8s/sandbox-identity.js'
+import {
+  AC_LABEL_AGENT,
+  AC_LABEL_ORG,
+  AC_LABEL_SESSION,
+  sandboxClaimName,
+  sessionSandboxSubject
+} from '../src/k8s/sandbox-identity.js'
+import { hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 import { SandboxApi, type SandboxClaim } from '../src/k8s/sandbox-api.js'
 import { ORPHAN_DELETE_ENV } from '../src/k8s/orphan-reconciler.js'
 import { STORE_ORPHAN_DELETE_ENV } from '../src/store/retention.js'
@@ -32,8 +39,19 @@ function claim(agentId: string): SandboxClaim {
   }
 }
 
-/** A cluster holding two claims — one of a live agent, one of a forgotten one. */
-async function cluster(opts: { deleteStatus?: number } = {}) {
+/** A live agent's session pod claim (git-workspace-model §11), by the session key its row would carry. */
+function sessionClaim(agentId: string, sessionKey: string): SandboxClaim {
+  const leaf = hostKeyDirName(sessionHostKey(agentId, sessionKey))
+  const name = sandboxClaimName(sessionSandboxSubject(agentId, leaf))
+  const labels = { [AC_LABEL_ORG]: 'org-1', [AC_LABEL_AGENT]: agentId, [AC_LABEL_SESSION]: leaf }
+  return {
+    metadata: { name, uid: `uid-${name}`, resourceVersion: `rv-${name}`, creationTimestamp: OLD, labels },
+    spec: { warmPoolRef: { name: 'pool' }, additionalPodMetadata: { labels } }
+  }
+}
+
+/** A cluster holding two claims — one of a live agent, one of a forgotten one — plus any extra. */
+async function cluster(opts: { deleteStatus?: number; extraClaims?: SandboxClaim[] } = {}) {
   const deletes: string[] = []
   const { config } = await fakeApiServer(({ method, url }) => {
     if (method === 'DELETE') {
@@ -41,7 +59,9 @@ async function cluster(opts: { deleteStatus?: number } = {}) {
       if (opts.deleteStatus) return { status: opts.deleteStatus, json: { kind: 'Status', reason: 'Forbidden' } }
       return { json: {} }
     }
-    if (url.pathname.endsWith('/sandboxclaims')) return { json: { items: [claim(LIVE), claim(GONE)] } }
+    if (url.pathname.endsWith('/sandboxclaims')) {
+      return { json: { items: [claim(LIVE), claim(GONE), ...(opts.extraClaims ?? [])] } }
+    }
     if (url.pathname.endsWith('/sandboxes')) return { json: { items: [] } }
     return { status: 404, json: { kind: 'Status', reason: 'NotFound' } }
   })
@@ -117,6 +137,55 @@ describe('reconcile --once', () => {
     expect(infos.at(-1)).toContain('agent-gone=1 horizon=0')
     expect(infos.at(-1)).toContain('session-purge=1')
     expect(closed).toBe(true)
+  })
+
+  it('asks the shared store which session pods still have a row, and collects the rest (§11)', async () => {
+    const kept = 'slack:C1:T-kept:agent'
+    const gone = 'slack:C1:T-gone:agent'
+    const { api, deletes } = await cluster({ extraClaims: [sessionClaim(LIVE, kept), sessionClaim(LIVE, gone)] })
+    const asked: string[] = []
+    const code = await runReconcileOnce({
+      api,
+      connectCp: fakeCp().connectCp,
+      apiUrl: 'wss://cp.example.test/daemon/ws',
+      env: { [ORPHAN_DELETE_ENV]: 'true' },
+      openStore: async () => ({
+        store: {
+          ...storeOf({}, []),
+          sessionKeysForAgent: async (agentId: string) => {
+            asked.push(agentId)
+            return agentId === LIVE ? [kept] : []
+          }
+        },
+        close: async () => undefined
+      }),
+      log: { info: () => {}, warn: () => {} }
+    })
+    expect(code).toBe(0)
+    expect(asked).toEqual([LIVE])
+    const claims = '/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/agent-sandboxes/sandboxclaims'
+    expect(deletes.sort()).toEqual(
+      [
+        `${claims}/agent-${GONE}`,
+        `${claims}/${sandboxClaimName(sessionSandboxSubject(LIVE, hostKeyDirName(sessionHostKey(LIVE, gone))))}`
+      ].sort()
+    )
+  })
+
+  it('keeps every session pod when no shared store is mounted to answer for its row', async () => {
+    const { api, deletes } = await cluster({ extraClaims: [sessionClaim(LIVE, 'slack:C1:T-any:agent')] })
+    const code = await runReconcileOnce({
+      api,
+      connectCp: fakeCp().connectCp,
+      apiUrl: 'wss://cp.example.test/daemon/ws',
+      env: { [ORPHAN_DELETE_ENV]: 'true' },
+      openStore: async () => undefined,
+      log: { info: () => {}, warn: () => {} }
+    })
+    expect(code).toBe(0)
+    expect(deletes).toEqual([
+      `/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/agent-sandboxes/sandboxclaims/agent-${GONE}`
+    ])
   })
 
   it('exits 1 when the store sweep left an orphan behind, however clean the cluster was', async () => {

--- a/packages/daemon/test/k8s-client.test.ts
+++ b/packages/daemon/test/k8s-client.test.ts
@@ -81,6 +81,54 @@ describe('SandboxApi', () => {
     expect(Object.keys((requests[1]!.body as { metadata: object }).metadata)).toEqual(['annotations'])
   })
 
+  it('still admits an existing claim when the API server refuses the stamp, and says the fence is off', async () => {
+    // The stamp is a fence for the orphan sweep, not a precondition for running: a Role without
+    // `patch` on claims must cost the fence, never every resume of an existing claim. Anything but a
+    // permission refusal is this call failing and stays fatal.
+    const methods: string[] = []
+    const { config } = await fakeApiServer(({ method }) => {
+      methods.push(method)
+      if (method === 'POST')
+        return { status: 409, json: { kind: 'Status', reason: 'AlreadyExists', message: 'exists' } }
+      if (method === 'PATCH')
+        return { status: 403, json: { kind: 'Status', reason: 'Forbidden', message: 'cannot patch sandboxclaims' } }
+      return { json: { metadata: { name: 'agent-a', uid: 'claim-uid', resourceVersion: 'rv-1' } } }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const ensured = await api.ensureClaim({
+      metadata: { name: 'agent-a', annotations: { 'agentconnect.md/last-admitted-at': '2026-08-14T10:00:00.000Z' } },
+      spec: { warmPoolRef: { name: 'pool' } }
+    })
+
+    expect(ensured.created).toBe(false)
+    expect(ensured.stampRefused).toBe(true)
+    // The claim the caller gets is the one the cluster holds, read back after the refusal.
+    expect(ensured.claim.metadata?.uid).toBe('claim-uid')
+    expect(methods).toEqual(['POST', 'PATCH', 'GET'])
+  })
+
+  it('fails the admission when the stamp is rejected for any reason but permission', async () => {
+    // The GET deliberately SUCCEEDS here: if the fallback read failed too, a degrade-on-everything
+    // bug would still surface as a rejection and this case would pass without testing anything.
+    const methods: string[] = []
+    const { config } = await fakeApiServer(({ method }) => {
+      methods.push(method)
+      if (method === 'POST')
+        return { status: 409, json: { kind: 'Status', reason: 'AlreadyExists', message: 'exists' } }
+      if (method === 'PATCH') return { status: 422, json: { kind: 'Status', reason: 'Invalid', message: 'bad patch' } }
+      return { json: { metadata: { name: 'agent-a', uid: 'claim-uid' } } }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    await expect(
+      api.ensureClaim({
+        metadata: { name: 'agent-a', annotations: { 'agentconnect.md/last-admitted-at': '2026-08-14T10:00:00.000Z' } },
+        spec: { warmPoolRef: { name: 'pool' } }
+      })
+    ).rejects.toBeInstanceOf(K8sApiError)
+    // It never reached the fallback read: only a permission refusal takes that path.
+    expect(methods).toEqual(['POST', 'PATCH'])
+  })
+
   it('reports a first claim as CREATED, which is the cold-start signal', async () => {
     // The cold/resume split has to come from a fact, not from elapsed time — a latency metric
     // whose own bucketing is inferred from latency cannot settle a latency target.

--- a/packages/daemon/test/k8s-client.test.ts
+++ b/packages/daemon/test/k8s-client.test.ts
@@ -49,6 +49,38 @@ describe('SandboxApi', () => {
     expect(ensured.created).toBe(false)
   })
 
+  it('WRITES the annotations onto a claim that already exists, so its version moves', async () => {
+    // The reuse path is what an orphan sweep races: it lists a claim, proves the session gone, and
+    // deletes on the version it listed. A reuse that only READ would leave that version standing and
+    // let the delete take a live pod — the merge patch here is what makes the admission win instead.
+    const requests: Array<{ method: string; contentType?: string; body?: unknown }> = []
+    const { config } = await fakeApiServer(({ method, headers, body }) => {
+      const contentType = headers['content-type']
+      requests.push({
+        method,
+        ...(typeof contentType === 'string' ? { contentType } : {}),
+        ...(body ? { body: JSON.parse(body) } : {})
+      })
+      if (method === 'POST')
+        return { status: 409, json: { kind: 'Status', reason: 'AlreadyExists', message: 'exists' } }
+      return { json: { metadata: { name: 'agent-a', resourceVersion: 'rv-2' } } }
+    })
+    const api = new SandboxApi(new K8sHttp(config), 'org-test')
+    const ensured = await api.ensureClaim({
+      metadata: { name: 'agent-a', annotations: { 'agentconnect.md/last-admitted-at': '2026-08-14T10:00:00.000Z' } },
+      spec: { warmPoolRef: { name: 'pool' } }
+    })
+    expect(ensured.created).toBe(false)
+    expect(ensured.claim.metadata?.resourceVersion).toBe('rv-2')
+    expect(requests.map((request) => request.method)).toEqual(['POST', 'PATCH'])
+    // A merge patch of the annotations alone: labels, spec and status are the caller's to leave alone.
+    expect(requests[1]).toMatchObject({
+      contentType: 'application/merge-patch+json',
+      body: { metadata: { annotations: { 'agentconnect.md/last-admitted-at': '2026-08-14T10:00:00.000Z' } } }
+    })
+    expect(Object.keys((requests[1]!.body as { metadata: object }).metadata)).toEqual(['annotations'])
+  })
+
   it('reports a first claim as CREATED, which is the cold-start signal', async () => {
     // The cold/resume split has to come from a fact, not from elapsed time — a latency metric
     // whose own bucketing is inferred from latency cannot settle a latency target.

--- a/packages/daemon/test/k8s-orphan-reconciler.test.ts
+++ b/packages/daemon/test/k8s-orphan-reconciler.test.ts
@@ -10,7 +10,13 @@ import {
   resolveOrphanReconcilerSettings,
   type OrphanReconcilerDeps
 } from '../src/k8s/orphan-reconciler.js'
-import { AC_LABEL_AGENT, AC_LABEL_ORG } from '../src/k8s/sandbox-identity.js'
+import {
+  AC_LABEL_AGENT,
+  AC_LABEL_ORG,
+  AC_LABEL_SESSION,
+  sandboxClaimName,
+  sessionSandboxSubject
+} from '../src/k8s/sandbox-identity.js'
 import { PROBE_CLAIM_EXPIRES_ANNOTATION, PROBE_CLAIM_LABEL, probeAgentId } from '../src/k8s/probe-claim.js'
 import { SandboxApi, type Sandbox, type SandboxClaim } from '../src/k8s/sandbox-api.js'
 
@@ -49,6 +55,31 @@ function claim(
     spec: {
       warmPoolRef: { name: 'pool' },
       additionalPodMetadata: { labels: { [AC_LABEL_ORG]: 'org-1', [AC_LABEL_AGENT]: agentId } }
+    },
+    ...(opts.sandbox ? { status: { sandbox: { name: opts.sandbox } } } : {})
+  }
+}
+
+/** A session pod's claim (git-workspace-model §11): the agent's label beside the session's, under the session's name. */
+function sessionClaim(
+  agentId: string,
+  leaf: string,
+  opts: { createdAt?: number; sandbox?: string } = {}
+): SandboxClaim {
+  const name = sandboxClaimName(sessionSandboxSubject(agentId, leaf))
+  return {
+    metadata: {
+      name,
+      uid: `uid-${name}`,
+      resourceVersion: `rv-${name}`,
+      creationTimestamp: new Date(opts.createdAt ?? T0 - HOUR).toISOString(),
+      labels: { [AC_LABEL_ORG]: 'org-1', [AC_LABEL_AGENT]: agentId, [AC_LABEL_SESSION]: leaf }
+    },
+    spec: {
+      warmPoolRef: { name: 'pool' },
+      additionalPodMetadata: {
+        labels: { [AC_LABEL_ORG]: 'org-1', [AC_LABEL_AGENT]: agentId, [AC_LABEL_SESSION]: leaf }
+      }
     },
     ...(opts.sandbox ? { status: { sandbox: { name: opts.sandbox } } } : {})
   }
@@ -223,3 +254,105 @@ describe('orphan reconciler', () => {
     expect(r.warns.filter((m) => m.includes('not permitted'))).toHaveLength(1)
   })
 })
+
+describe('orphan reconciler and session pods (git-workspace-model §11)', () => {
+  const KEPT = 'session-aaaaaaaaaaaaaaaaaaaaaaaa'
+  const GONE_LEAF = 'session-bbbbbbbbbbbbbbbbbbbbbbbb'
+  const claimPath = (agentId: string, leaf: string) =>
+    `/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/agent-sandboxes/sandboxclaims/${sandboxClaimName(sessionSandboxSubject(agentId, leaf))}`
+
+  it("collects a live agent's session pod whose row is gone, keeps the one whose row remains and the agent's own", async () => {
+    const { api, deletes } = await cluster(
+      [
+        claim(LIVE, { sandbox: 'sb-live' }),
+        sessionClaim(LIVE, KEPT, { sandbox: 'sb-kept' }),
+        sessionClaim(LIVE, GONE_LEAF, { sandbox: 'sb-gone' })
+      ],
+      // A claimless Sandbox with a session label answers to the same rule.
+      [sandbox('sb-stray', LIVE), withSessionLabel(sandbox('sb-stray-session', LIVE), GONE_LEAF)]
+    )
+    const askedSessions: Array<{ agentId: string; leaf: string }>[] = []
+    const r = reconciler({
+      api,
+      liveSessionLeaves: async (sessions) => {
+        askedSessions.push(sessions)
+        return new Set([sessionSandboxSubject(LIVE, KEPT)])
+      }
+    })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 5, orphaned: 2, deleted: 2, skippedLive: 3, failed: 0 })
+    expect(deletes.map((entry) => entry.path)).toEqual([
+      claimPath(LIVE, GONE_LEAF),
+      '/apis/agents.x-k8s.io/v1beta1/namespaces/agent-sandboxes/sandboxes/sb-stray-session'
+    ])
+    // One question per run, about the session pods of live agents only, and never about the agent's own pod.
+    expect(askedSessions).toEqual([
+      [
+        { agentId: LIVE, leaf: KEPT },
+        { agentId: LIVE, leaf: GONE_LEAF },
+        { agentId: LIVE, leaf: GONE_LEAF }
+      ]
+    ])
+    expect(r.infos.some((line) => line.includes(`session ${GONE_LEAF}`))).toBe(true)
+  })
+
+  it('reads a session pod as live when nothing can answer for its session', async () => {
+    const { api, deletes } = await cluster([sessionClaim(LIVE, GONE_LEAF, { sandbox: 'sb-gone' })], [])
+    const r = reconciler({ api })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 1, orphaned: 0, deleted: 0, skippedLive: 1 })
+    expect(deletes).toEqual([])
+  })
+
+  it('reads every session pod as live when the store will not answer, and still sweeps the rest', async () => {
+    const { api, deletes } = await cluster(
+      [sessionClaim(LIVE, GONE_LEAF, { sandbox: 'sb-gone' }), claim(GONE, { sandbox: 'sb-agent-gone' })],
+      []
+    )
+    const r = reconciler({
+      api,
+      liveSessionLeaves: async () => {
+        throw new Error('store unreachable')
+      }
+    })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 2, orphaned: 1, deleted: 1, skippedLive: 1, failed: 0 })
+    expect(deletes.map((entry) => entry.path)).toEqual([
+      `/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/agent-sandboxes/sandboxclaims/agent-${GONE}`
+    ])
+    expect(r.warns.some((line) => line.includes('keeping every session pod'))).toBe(true)
+  })
+
+  it("collects a gone agent's session pod on the agent rule alone, asking about no sessions", async () => {
+    const { api, deletes } = await cluster([sessionClaim(GONE, KEPT, { sandbox: 'sb-gone' })], [])
+    const askedSessions: unknown[] = []
+    const r = reconciler({
+      api,
+      liveSessionLeaves: async (sessions) => {
+        askedSessions.push(sessions)
+        return new Set()
+      }
+    })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 1, orphaned: 1, deleted: 1 })
+    expect(deletes.map((entry) => entry.path)).toEqual([claimPath(GONE, KEPT)])
+    expect(askedSessions).toEqual([])
+  })
+
+  it("leaves a live agent's young session pod alone even when its row is gone", async () => {
+    const { api, deletes } = await cluster([sessionClaim(LIVE, GONE_LEAF, { createdAt: T0 - GRACE + 1 })], [])
+    const r = reconciler({ api, liveSessionLeaves: async () => new Set() })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 1, orphaned: 0, skippedGrace: 1 })
+    expect(deletes).toEqual([])
+  })
+})
+
+/** The same Sandbox, carrying a session label on its pod template the way the controller propagates it. */
+function withSessionLabel(object: Sandbox, leaf: string): Sandbox {
+  return {
+    ...object,
+    spec: {
+      ...object.spec,
+      podTemplate: {
+        ...object.spec?.podTemplate,
+        metadata: { labels: { ...object.spec?.podTemplate?.metadata?.labels, [AC_LABEL_SESSION]: leaf } }
+      }
+    }
+  }
+}

--- a/packages/daemon/test/k8s-orphan-reconciler.test.ts
+++ b/packages/daemon/test/k8s-orphan-reconciler.test.ts
@@ -8,6 +8,7 @@ import {
   ORPHAN_GRACE_ENV,
   OrphanReconciler,
   resolveOrphanReconcilerSettings,
+  stampRefreshMsFor,
   type OrphanReconcilerDeps
 } from '../src/k8s/orphan-reconciler.js'
 import {
@@ -157,6 +158,22 @@ describe('orphan reconciler settings', () => {
       deleteEnabled: true
     })
     expect(() => resolveOrphanReconcilerSettings({ [ORPHAN_GRACE_ENV]: '-1' })).toThrow(ORPHAN_GRACE_ENV)
+  })
+
+  it('derives the members’ stamp cadence from whatever grace the sweep was given', () => {
+    // One safety window: the sweep collects a claim nothing has touched for `graceMs`, so a member using
+    // one has to touch it strictly more often than that. A fixed cadence is silently wrong for every
+    // install that shortens the grace — a held claim would age past it between two ticks and become
+    // deletable while in use — so the cadence tracks the configured value rather than a constant.
+    for (const graceMs of [DEFAULT_ORPHAN_GRACE_MS, 90_000, 30_000, 5_000, 1_000]) {
+      const refreshMs = stampRefreshMsFor(graceMs)
+      expect(refreshMs).toBeGreaterThan(0)
+      // Two missed ticks still leave a held claim inside the window.
+      expect(refreshMs * 3).toBeLessThanOrEqual(graceMs)
+    }
+    expect(stampRefreshMsFor(DEFAULT_ORPHAN_GRACE_MS)).toBe(200_000)
+    // A grace shorter than the cadence it used to be hardcoded at is the case that was broken.
+    expect(stampRefreshMsFor(90_000)).toBe(30_000)
   })
 })
 

--- a/packages/daemon/test/k8s-orphan-reconciler.test.ts
+++ b/packages/daemon/test/k8s-orphan-reconciler.test.ts
@@ -11,6 +11,7 @@ import {
   type OrphanReconcilerDeps
 } from '../src/k8s/orphan-reconciler.js'
 import {
+  AC_ANNOTATION_ADMITTED,
   AC_LABEL_AGENT,
   AC_LABEL_ORG,
   AC_LABEL_SESSION,
@@ -64,7 +65,7 @@ function claim(
 function sessionClaim(
   agentId: string,
   leaf: string,
-  opts: { createdAt?: number; sandbox?: string } = {}
+  opts: { createdAt?: number; sandbox?: string; admittedAt?: number } = {}
 ): SandboxClaim {
   const name = sandboxClaimName(sessionSandboxSubject(agentId, leaf))
   return {
@@ -73,6 +74,9 @@ function sessionClaim(
       uid: `uid-${name}`,
       resourceVersion: `rv-${name}`,
       creationTimestamp: new Date(opts.createdAt ?? T0 - HOUR).toISOString(),
+      ...(opts.admittedAt === undefined
+        ? {}
+        : { annotations: { [AC_ANNOTATION_ADMITTED]: new Date(opts.admittedAt).toISOString() } }),
       labels: { [AC_LABEL_ORG]: 'org-1', [AC_LABEL_AGENT]: agentId, [AC_LABEL_SESSION]: leaf }
     },
     spec: {
@@ -101,11 +105,17 @@ function sandbox(name: string, agentId?: string, createdAt = T0 - HOUR): Sandbox
 }
 
 /** A cluster holding `claims` and `sandboxes`, recording every delete with its preconditions. */
-async function cluster(claims: SandboxClaim[], sandboxes: Sandbox[], opts: { sandboxList?: number } = {}) {
+async function cluster(
+  claims: SandboxClaim[],
+  sandboxes: Sandbox[],
+  opts: { sandboxList?: number; deleteConflict?: boolean } = {}
+) {
   const deletes: Array<{ path: string; preconditions: unknown }> = []
   const { config } = await fakeApiServer(({ method, url, body }) => {
     if (method === 'DELETE') {
       deletes.push({ path: url.pathname, preconditions: JSON.parse(body).preconditions })
+      // What the API server answers when the object's version moved since it was listed.
+      if (opts.deleteConflict) return { status: 409, json: { kind: 'Status', reason: 'Conflict' } }
       return { json: {} }
     }
     if (url.pathname.endsWith('/sandboxclaims')) return { json: { items: claims } }
@@ -333,6 +343,44 @@ describe('orphan reconciler and session pods (git-workspace-model §11)', () => 
     expect(await r.it.sweep()).toMatchObject({ candidates: 1, orphaned: 1, deleted: 1 })
     expect(deletes.map((entry) => entry.path)).toEqual([claimPath(GONE, KEPT)])
     expect(askedSessions).toEqual([])
+  })
+
+  it('runs the grace from the admission stamp, so a re-admitted leaked claim is young again', async () => {
+    // The object's own age cannot fence this: the claim IS old — it leaked — and the session that came
+    // back reuses it rather than creating one. Admission stamping it is what makes the age honest.
+    const { api, deletes } = await cluster(
+      [sessionClaim(LIVE, GONE_LEAF, { createdAt: T0 - HOUR, admittedAt: T0 - GRACE + 1 })],
+      []
+    )
+    const r = reconciler({ api, liveSessionLeaves: async () => new Set() })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 1, orphaned: 0, deleted: 0, skippedGrace: 1 })
+    expect(deletes).toEqual([])
+
+    // And once nothing has admitted it for a whole grace, it is collectable again.
+    r.clock.advance(1)
+    expect(await r.it.sweep()).toMatchObject({ orphaned: 1, deleted: 1 })
+  })
+
+  it('loses the delete to an admission that landed after the listing, rather than taking a live pod', async () => {
+    // The absence proof is a snapshot: the row can come back, and `ensureClaim` reuse it, between the
+    // list above and the delete below. The admission's own write moves the claim's resourceVersion, so
+    // the preconditioned delete is refused — the pod and its volume stay, and the next run re-decides.
+    const { api, deletes } = await cluster([sessionClaim(LIVE, GONE_LEAF, { sandbox: 'sb-gone' })], [], {
+      deleteConflict: true
+    })
+    const r = reconciler({ api, liveSessionLeaves: async () => new Set() })
+    expect(await r.it.sweep()).toMatchObject({ candidates: 1, orphaned: 1, deleted: 0, failed: 0 })
+    // Fenced on the version it listed, which is the only reason the admission can win.
+    expect(deletes).toEqual([
+      {
+        path: claimPath(LIVE, GONE_LEAF),
+        preconditions: {
+          uid: `uid-${sandboxClaimName(sessionSandboxSubject(LIVE, GONE_LEAF))}`,
+          resourceVersion: `rv-${sandboxClaimName(sessionSandboxSubject(LIVE, GONE_LEAF))}`
+        }
+      }
+    ])
+    expect(r.infos.some((line) => line.includes('was replaced since it was listed'))).toBe(true)
   })
 
   it("leaves a live agent's young session pod alone even when its row is gone", async () => {

--- a/packages/daemon/test/k8s-runtime-plane.test.ts
+++ b/packages/daemon/test/k8s-runtime-plane.test.ts
@@ -400,6 +400,7 @@ function fakeCluster() {
   const claims = new Map<string, SandboxClaim>()
   const sandboxes = new Map<string, Sandbox>()
   let minted = 0
+  let stamps = 0
   return {
     podName,
     claims,
@@ -425,6 +426,21 @@ function fakeCluster() {
         const claim = claims.get(name)
         if (!claim) throw new K8sApiError(404, 'NotFound', 'no claim')
         return claim
+      },
+      // A resume publishes a launch without admitting one, so it stamps the claim it resumes onto.
+      stampClaim: async (name: string, annotations: Record<string, string>) => {
+        const existing = claims.get(name)
+        if (!existing) throw new K8sApiError(404, 'NotFound', 'no claim')
+        const claim = {
+          ...existing,
+          metadata: {
+            ...existing.metadata,
+            annotations: { ...existing.metadata?.annotations, ...annotations },
+            resourceVersion: `rv-${++stamps}`
+          }
+        }
+        claims.set(name, claim)
+        return { claim }
       },
       deleteClaim: async (name: string): Promise<void> => void claims.delete(name),
       listClaims: async () => [...claims.values()],

--- a/packages/daemon/test/k8s-session-pods.test.ts
+++ b/packages/daemon/test/k8s-session-pods.test.ts
@@ -7,6 +7,7 @@ import {
   AC_LABEL_AGENT,
   AC_LABEL_ORG,
   AC_LABEL_SESSION,
+  AC_ANNOTATION_ADMITTED,
   sandboxClaimName,
   sandboxSubjectFor,
   sandboxSubjectForPath,
@@ -44,10 +45,23 @@ function cluster() {
   const modeWrites: Array<{ sandbox: string; desired: string }> = []
   const deleted: string[] = []
   let minted = 0
+  let versions = 0
   const api = {
     ensureClaim: vi.fn(async (claim: SandboxClaim & { metadata: { name: string } }) => {
       const existing = claims.get(claim.metadata.name)
-      if (existing) return { claim: existing, created: false }
+      if (existing) {
+        // Reuse WRITES: the real client merge-patches the caller's annotations onto the claim it found.
+        const merged: SandboxClaim = {
+          ...existing,
+          metadata: {
+            ...existing.metadata,
+            annotations: { ...existing.metadata?.annotations, ...claim.metadata.annotations },
+            resourceVersion: `rv-${++versions}`
+          }
+        }
+        claims.set(claim.metadata.name, merged)
+        return { claim: merged, created: false }
+      }
       const name = `sb-${++minted}`
       sandboxes.set(name, {
         metadata: { name, uid: `uid-${name}` },
@@ -59,7 +73,7 @@ function cluster() {
       })
       const stored: SandboxClaim = {
         ...claim,
-        metadata: { ...claim.metadata, uid: `claim-${name}` },
+        metadata: { ...claim.metadata, uid: `claim-${name}`, resourceVersion: `rv-${++versions}` },
         status: { sandbox: { name } }
       }
       claims.set(claim.metadata.name, stored)
@@ -133,19 +147,20 @@ function podSide() {
 function member(api: ReturnType<typeof cluster>['api'], connect: ReturnType<typeof podSide>['connect']) {
   const records: SpawnRecord[] = []
   const generations = fakeGenerations()
+  const clock = new FakeClock()
   const driver = new K8sDriver({
     api: api as never,
     orgForAgent: () => 'org-1',
     warmPoolName: 'pool',
     generations,
-    clock: new FakeClock(),
+    clock,
     connectChannel: async (record) => {
       records.push(record)
       return await connect(record)
     },
     log: { info: () => {}, warn: () => {}, debug: () => {} }
   })
-  return { driver, records, generations }
+  return { driver, records, generations, clock }
 }
 
 const request = (hostKey?: typeof T1) =>
@@ -250,7 +265,9 @@ describe('one sandbox pod per session host (git-workspace-model §11)', () => {
     // The successor knows only the host key — the store, not this process, remembers the session.
     const second = member(api, pod.connect)
     const launch = await second.driver.ensureSandbox(sandboxSubjectFor(T1))
-    expect(claims.get(name)).toBe(before)
+    // The same claim object, restamped rather than replaced: same uid, same bound Sandbox, no create.
+    expect(claims.get(name)?.metadata?.uid).toBe(before!.metadata!.uid)
+    expect(claims.get(name)?.status?.sandbox?.name).toBe(before!.status!.sandbox!.name)
     expect(launch.sandboxName).toBe(before!.status!.sandbox!.name)
     expect(launch.claimUid).toBe(before!.metadata!.uid)
     expect(api.ensureClaim.mock.calls.filter((call) => call[0].metadata.name === name)).toHaveLength(2)
@@ -443,6 +460,32 @@ describe('one sandbox pod per session host (git-workspace-model §11)', () => {
     const claimedSoFar = api.ensureClaim.mock.calls.length
     expect(driver.retainLaunched(session)).toBeUndefined()
     expect(api.ensureClaim.mock.calls.length).toBe(claimedSoFar)
+  })
+
+  it('stamps every admission on the claim, so a reused one is a new incarnation to a reader', async () => {
+    // The orphan sweep proves a session gone from a snapshot and then deletes on the version it
+    // listed. A session that comes back reuses this claim rather than making one, so without a write
+    // here the sweep's preconditions would still hold and it would take a live pod and its volume.
+    const { api, claims } = cluster()
+    const { driver, clock } = member(api, podSide().connect)
+    const session = sandboxSubjectFor(T1)
+    const name = sandboxClaimName(session)
+
+    await driver.ensureSandbox(session)
+    const first = claims.get(name)!
+    expect(first.metadata?.annotations?.[AC_ANNOTATION_ADMITTED]).toBe(new Date(clock.now()).toISOString())
+    // Never in the spec or on the pod: warm-pool adoption reads the spec, and this is not the pod's business.
+    expect(Object.keys(first.spec ?? {}).sort()).toEqual(['additionalPodMetadata', 'warmPoolRef'])
+    expect(first.spec?.additionalPodMetadata?.labels?.[AC_ANNOTATION_ADMITTED]).toBeUndefined()
+
+    // A second admission of the SAME claim — a resume after an idle suspension — restamps and re-versions it.
+    driver.release(session)
+    clock.advance(60_000)
+    await driver.ensureSandbox(session)
+    const second = claims.get(name)!
+    expect(second.metadata?.uid).toBe(first.metadata?.uid)
+    expect(second.metadata?.annotations?.[AC_ANNOTATION_ADMITTED]).toBe(new Date(clock.now()).toISOString())
+    expect(second.metadata?.resourceVersion).not.toBe(first.metadata?.resourceVersion)
   })
 
   it('keeps the agent pod path byte-identical: no host key means the agent claim, as before', async () => {

--- a/packages/daemon/test/k8s-session-pods.test.ts
+++ b/packages/daemon/test/k8s-session-pods.test.ts
@@ -632,6 +632,57 @@ describe('one sandbox pod per session host (git-workspace-model §11)', () => {
     expect(resumed.metadata?.uid).toBe(claimUid)
   })
 
+  it('publishes no launch when the fence write fails for any reason but permission', async () => {
+    // The fence is what a published launch RESTS on, so swallowing a timeout or a 500 here would be the
+    // same as never stamping: the sweep still holds the version it listed, and its delete still takes a
+    // live volume. A takeover that cannot fence adopts nothing; a resume refuses the read.
+    const { api, claims } = cluster()
+    const { driver, clock, warnings } = member(api, podSide().connect)
+    const session = sandboxSubjectFor(T1)
+    const name = sandboxClaimName(session)
+    await driver.ensureSandbox(session)
+    const claimUid = (await driver.claimUidFor(session))!
+    expect(await driver.suspendIfIdle(session)).toBe('suspended')
+    const fenced = claims.get(name)!.metadata!.resourceVersion
+
+    api.stampClaim = (async () => {
+      throw new Error('the API server is having a moment')
+    }) as never
+    clock.advance(600_000)
+
+    // A resume refuses rather than serving a pod the sweep could collect underneath it.
+    await expect(driver.resumeBoundChannel(session, claimUid)).rejects.toThrow(/could not be marked in use/)
+    expect(driver.currentLaunch(session)).toBeUndefined()
+    // And a takeover adopts nothing, leaving the next duty tick to try again.
+    expect(await driver.adopt(session)).toBeUndefined()
+    expect(driver.currentLaunch(session)).toBeUndefined()
+    // Nothing was written, so the claim the sweep listed is untouched — and it says why, out loud.
+    expect(claims.get(name)!.metadata?.resourceVersion).toBe(fenced)
+    expect(warnings.some((line) => line.includes('could not be marked in use'))).toBe(true)
+  })
+
+  it('still publishes when the fence is refused by permission alone, reporting it once', async () => {
+    // The legacy-Role degradation stays exactly as agreed: failing every takeover over a missing verb
+    // would be worse than the race, and it is already reported once per process.
+    const { api } = cluster()
+    const { driver, warnings } = member(api, podSide().connect)
+    const session = sandboxSubjectFor(T1)
+    await driver.ensureSandbox(session)
+    const claimUid = (await driver.claimUidFor(session))!
+    expect(await driver.suspendIfIdle(session)).toBe('suspended')
+
+    const stamp = api.stampClaim
+    api.stampClaim = (async (name: string, annotations: Record<string, string>) => {
+      const stamped = await stamp(name, annotations)
+      return { claim: stamped.claim, stampRefused: true }
+    }) as never
+
+    await driver.resumeBoundChannel(session, claimUid)
+    expect(driver.currentLaunch(session)).toBeDefined()
+    expect(warnings.filter((line) => line.includes('refused the admission stamp'))).toHaveLength(1)
+    expect(warnings.some((line) => line.includes('could not be marked in use'))).toBe(false)
+  })
+
   it('keeps the agent pod path byte-identical: no host key means the agent claim, as before', async () => {
     const { api, claims } = cluster()
     const { driver, records } = member(api, podSide().connect)

--- a/packages/daemon/test/k8s-session-pods.test.ts
+++ b/packages/daemon/test/k8s-session-pods.test.ts
@@ -146,6 +146,7 @@ function podSide() {
 
 function member(api: ReturnType<typeof cluster>['api'], connect: ReturnType<typeof podSide>['connect']) {
   const records: SpawnRecord[] = []
+  const warnings: string[] = []
   const generations = fakeGenerations()
   const clock = new FakeClock()
   const driver = new K8sDriver({
@@ -158,9 +159,9 @@ function member(api: ReturnType<typeof cluster>['api'], connect: ReturnType<type
       records.push(record)
       return await connect(record)
     },
-    log: { info: () => {}, warn: () => {}, debug: () => {} }
+    log: { info: () => {}, warn: (m) => warnings.push(m), debug: () => {} }
   })
-  return { driver, records, generations, clock }
+  return { driver, records, generations, clock, warnings }
 }
 
 const request = (hostKey?: typeof T1) =>
@@ -486,6 +487,34 @@ describe('one sandbox pod per session host (git-workspace-model §11)', () => {
     expect(second.metadata?.uid).toBe(first.metadata?.uid)
     expect(second.metadata?.annotations?.[AC_ANNOTATION_ADMITTED]).toBe(new Date(clock.now()).toISOString())
     expect(second.metadata?.resourceVersion).not.toBe(first.metadata?.resourceVersion)
+  })
+
+  it('still admits — and launches — when the API server refuses the stamp, saying so once', async () => {
+    // A Role without `patch` on claims costs the orphan sweep its fence, and nothing else. Failing the
+    // admission instead would turn a permission gap into an outage on every resume of an existing
+    // claim, which is strictly worse than the race the stamp closes.
+    const { api, claims } = cluster()
+    const admit = api.ensureClaim
+    api.ensureClaim = vi.fn(async (claim: SandboxClaim & { metadata: { name: string } }) => {
+      const ensured = await admit(claim)
+      // The refusal writes nothing, so the claim keeps the annotations and version it already had.
+      return ensured.created ? ensured : { ...ensured, stampRefused: true }
+    }) as never
+    const { driver, warnings } = member(api, podSide().connect)
+    const session = sandboxSubjectFor(T1)
+
+    await driver.ensureSandbox(session)
+    driver.release(session)
+    await expect(driver.ensureSandbox(session)).resolves.toBeDefined()
+    driver.release(session)
+    await driver.ensureSandbox(session)
+
+    // The pod is claimed and usable throughout; only the fence is gone.
+    expect(claims.has(sandboxClaimName(session))).toBe(true)
+    expect(driver.currentLaunch(session)).toBeDefined()
+    // Once per process, not once per admission: a degraded Role would otherwise fill the log.
+    expect(warnings.filter((line) => line.includes('refused the admission stamp'))).toHaveLength(1)
+    expect(warnings[0]).toMatch(/patch on sandboxclaims/)
   })
 
   it('keeps the agent pod path byte-identical: no host key means the agent claim, as before', async () => {

--- a/packages/daemon/test/k8s-session-pods.test.ts
+++ b/packages/daemon/test/k8s-session-pods.test.ts
@@ -587,6 +587,51 @@ describe('one sandbox pod per session host (git-workspace-model §11)', () => {
     expect(warnings.filter((line) => line.includes('refused the admission stamp'))).toHaveLength(1)
   })
 
+  it('stamps a takeover BEFORE it publishes the launch, not at the next tick', async () => {
+    // `setInterval` does not fire for a whole period, and a takeover writes nothing to the claim on its
+    // own — so in that first window an adopted claim looks untouched while a returning delivery is
+    // already being served from the registry. A sweep holding this claim's old version would still
+    // match, and delete a live pod.
+    const { api, claims } = cluster()
+    const first = member(api, podSide().connect)
+    const session = sandboxSubjectFor(T1)
+    const name = sandboxClaimName(session)
+    await first.driver.ensureSandbox(session)
+    const admitted = claims.get(name)!.metadata!.resourceVersion
+
+    // A second member takes it over, with no timer having run anywhere.
+    const successor = member(api, podSide().connect)
+    successor.clock.advance(600_000)
+    expect(await successor.driver.adopt(session)).toBeDefined()
+
+    const taken = claims.get(name)!
+    expect(taken.metadata?.annotations?.[AC_ANNOTATION_ADMITTED]).toBe(new Date(successor.clock.now()).toISOString())
+    // The version moved with it, so a delete preconditioned on what the sweep listed no longer matches.
+    expect(taken.metadata?.resourceVersion).not.toBe(admitted)
+  })
+
+  it('stamps a resume onto an observed claim, which publishes a launch without admitting one either', async () => {
+    // The same class as a takeover, and the reviewer named only the takeover: `resumeSandbox` records a
+    // launch straight from the claim it read, so it too would serve a session off an untouched claim.
+    const { api, claims } = cluster()
+    const { driver, clock } = member(api, podSide().connect)
+    const session = sandboxSubjectFor(T1)
+    const name = sandboxClaimName(session)
+    await driver.ensureSandbox(session)
+    const claimUid = (await driver.claimUidFor(session))!
+    expect(await driver.suspendIfIdle(session)).toBe('suspended')
+    const before = claims.get(name)!.metadata!.resourceVersion
+
+    clock.advance(600_000)
+    await driver.resumeBoundChannel(session, claimUid)
+
+    const resumed = claims.get(name)!
+    expect(resumed.metadata?.annotations?.[AC_ANNOTATION_ADMITTED]).toBe(new Date(clock.now()).toISOString())
+    expect(resumed.metadata?.resourceVersion).not.toBe(before)
+    // Still a resume, not an admission: the claim is the same object, never a replacement.
+    expect(resumed.metadata?.uid).toBe(claimUid)
+  })
+
   it('keeps the agent pod path byte-identical: no host key means the agent claim, as before', async () => {
     const { api, claims } = cluster()
     const { driver, records } = member(api, podSide().connect)

--- a/packages/daemon/test/k8s-session-pods.test.ts
+++ b/packages/daemon/test/k8s-session-pods.test.ts
@@ -79,6 +79,20 @@ function cluster() {
       claims.set(claim.metadata.name, stored)
       return { claim: stored, created: true }
     }),
+    stampClaim: async (name: string, annotations: Record<string, string>) => {
+      const existing = claims.get(name)
+      if (!existing) throw new K8sApiError(404, 'NotFound', 'no claim')
+      const claim = {
+        ...existing,
+        metadata: {
+          ...existing.metadata,
+          annotations: { ...existing.metadata?.annotations, ...annotations },
+          resourceVersion: `rv-${++versions}`
+        }
+      }
+      claims.set(name, claim)
+      return { claim }
+    },
     getClaim: async (name: string) => {
       const claim = claims.get(name)
       if (!claim) throw new K8sApiError(404, 'NotFound', 'no claim')
@@ -515,6 +529,62 @@ describe('one sandbox pod per session host (git-workspace-model §11)', () => {
     // Once per process, not once per admission: a degraded Role would otherwise fill the log.
     expect(warnings.filter((line) => line.includes('refused the admission stamp'))).toHaveLength(1)
     expect(warnings[0]).toMatch(/patch on sandboxclaims/)
+  })
+
+  it('refreshes the stamp on every claim it HOLDS, so one in use never reads as a leak', async () => {
+    // `ensureSandbox` returns from the launch registry without touching the API, and `adoptSessions`
+    // caches a Running claim this member never admitted — so a member can serve a session for hours
+    // without writing to its claim. A sweep that snapshotted the row as absent would then still match
+    // on resourceVersion when the row came back, and take a live pod's volume.
+    const { api, claims } = cluster()
+    const { driver, clock } = member(api, podSide().connect)
+    const session = sandboxSubjectFor(T1)
+    await driver.ensureSandbox(session)
+    await driver.ensureSandbox(AGENT)
+    const before = [...claims.values()].map((claim) => claim.metadata?.resourceVersion)
+
+    clock.advance(180_000)
+    await driver.refreshAdmissionStamps()
+
+    // Every held claim is young again, and its version moved — both halves of the fence, without an admission.
+    for (const claim of claims.values()) {
+      expect(claim.metadata?.annotations?.[AC_ANNOTATION_ADMITTED]).toBe(new Date(clock.now()).toISOString())
+    }
+    expect([...claims.values()].map((claim) => claim.metadata?.resourceVersion)).not.toEqual(before)
+    // A pod this member no longer holds is nobody's to keep alive: releasing it stops the refresh.
+    driver.release(session)
+    clock.advance(180_000)
+    await driver.refreshAdmissionStamps()
+    expect(claims.get(sandboxClaimName(session))!.metadata?.annotations?.[AC_ANNOTATION_ADMITTED]).not.toBe(
+      new Date(clock.now()).toISOString()
+    )
+    expect(claims.get(`agent-${AGENT}`)!.metadata?.annotations?.[AC_ANNOTATION_ADMITTED]).toBe(
+      new Date(clock.now()).toISOString()
+    )
+  })
+
+  it('keeps refreshing the rest when one claim is gone or its stamp is refused', async () => {
+    // Best effort by construction: this runs on a tick, off every turn's path, so one claim's failure
+    // must not cost the others their freshness — and a Role without `patch` says so once, as admission does.
+    const { api, claims } = cluster()
+    const { driver, clock, warnings } = member(api, podSide().connect)
+    const session = sandboxSubjectFor(T1)
+    await driver.ensureSandbox(session)
+    await driver.ensureSandbox(AGENT)
+    // The session's claim is retired underneath the member; the agent's refuses the write.
+    claims.delete(sandboxClaimName(session))
+    const stamp = api.stampClaim
+    api.stampClaim = (async (name: string, annotations: Record<string, string>) => {
+      const stamped = await stamp(name, annotations)
+      return { claim: stamped.claim, stampRefused: true }
+    }) as never
+
+    clock.advance(180_000)
+    await expect(driver.refreshAdmissionStamps()).resolves.toBeUndefined()
+    await driver.refreshAdmissionStamps()
+
+    expect(claims.get(`agent-${AGENT}`)!.metadata?.annotations?.[AC_ANNOTATION_ADMITTED]).toBeDefined()
+    expect(warnings.filter((line) => line.includes('refused the admission stamp'))).toHaveLength(1)
   })
 
   it('keeps the agent pod path byte-identical: no host key means the agent claim, as before', async () => {

--- a/scripts/test-chart-render.rb
+++ b/scripts/test-chart-render.rb
@@ -138,7 +138,7 @@ find.call('ServiceAccount', 'ac-cloud-daemon')
 runtime_role = find.call('Role', 'example-agentconnect-daemon-pool-runtime')
 abort('runtime Role must live with the sandboxes') unless runtime_role.dig('metadata', 'namespace') == 'agentconnect-example-agents'
 runtime_rules = runtime_role.fetch('rules')
-abort('daemon pool cannot manage SandboxClaims') unless runtime_rules.any? { |r| r['resources'] == ['sandboxclaims'] && r['verbs'].sort == %w[create delete get list watch] }
+abort('daemon pool cannot manage SandboxClaims') unless runtime_rules.any? { |r| r['resources'] == ['sandboxclaims'] && r['verbs'].sort == %w[create delete get list patch watch] }
 abort('daemon pool cannot read warm pools and sandbox templates') unless runtime_rules.any? do |r|
   r['apiGroups'] == ['extensions.agents.x-k8s.io'] &&
     r['resources'].sort == %w[sandboxtemplates sandboxwarmpools] &&

--- a/scripts/test-chart-render.rb
+++ b/scripts/test-chart-render.rb
@@ -501,4 +501,28 @@ relay_paths = relay_route.dig('spec', 'rules').flat_map { |rule| rule['matches']
   abort("relay route must forward #{path}") unless relay_paths.include?(path)
 end
 
+# ONE safety window. The sweep calls a claim orphaned once nothing has touched it for this long, and a
+# member re-stamps the claims it holds on a cadence derived from the same number — so the value has to
+# reach BOTH surfaces from one place. A member reading a different grace than the job sweeping after it
+# would let a claim in use age past the window between two of its own ticks, and the sweep would then
+# delete a live pod's volume.
+grace_rendered, grace_error, grace_status = Open3.capture3(*(command + ['--set', 'daemonPool.reconciler.graceMs=90000']))
+abort("helm template (orphan grace) failed:\n#{grace_error}") unless grace_status.success?
+grace_documents = YAML.load_stream(grace_rendered).compact
+grace_env = lambda do |kind, name, path|
+  doc = grace_documents.find { |item| item['kind'] == kind && item.dig('metadata', 'name') == name } ||
+        abort("missing #{kind}/#{name} in the orphan-grace render")
+  doc.dig(*path).fetch('env').to_h { |item| [item.fetch('name'), item['value']] }
+end
+member_grace = grace_env.call('Deployment', 'example-agentconnect-daemon-pool',
+                              ['spec', 'template', 'spec', 'containers', 0])
+sweep_grace = grace_env.call('CronJob', 'example-agentconnect-daemon-pool-reconciler',
+                             ['spec', 'jobTemplate', 'spec', 'template', 'spec', 'containers', 0])
+abort('pool members must read the same orphan grace the sweep does') unless member_grace['AC_K8S_ORPHAN_GRACE_MS'] == '90000'
+abort('the orphan sweep must read the configured grace') unless sweep_grace['AC_K8S_ORPHAN_GRACE_MS'] == '90000'
+# Unset is the shared default on both, never one side defaulting while the other is configured.
+default_member = find.call('Deployment', 'example-agentconnect-daemon-pool')
+                     .dig('spec', 'template', 'spec', 'containers', 0).fetch('env').map { |item| item.fetch('name') }
+abort('an unset grace must leave both sides on the daemon default') if default_member.include?('AC_K8S_ORPHAN_GRACE_MS')
+
 puts 'chart render contract: ok'


### PR DESCRIPTION
## Summary

Stacked on #1766 (one sandbox pod per session on the pool, git-workspace-model §11; the rollout's #1757/#1758/#1761/#1763 precede it). This is the **orphan half**: a session pod whose session is gone is an orphan exactly as one whose agent is gone.

## Decision 4 — orphans

- `OrphanReconciler` reads the separate `agentconnect.md/session` label off a claim (`spec.additionalPodMetadata.labels`) or a Sandbox (`spec.podTemplate.metadata.labels`) into `Candidate.sessionLeaf`. The agent label stays the UUID-validated value it was; a session pod of an id the control plane cannot be asked about is still skipped as live.
- The session check sits **after the live-agent test and before the grace test**: a live agent's own pod is never touched; its session pod is collected only when its session is **provably gone**, and then under the same object-age grace. A gone agent's session pods fall to the agent rule without a question.
- **Fail-closed.** `liveSessionLeaves` is optional: no store to ask (a deployment without the shared data plane), or a read that throws, keeps every session pod of a live agent (`skipped-live`, with a warning) and the rest of the sweep continues. One question per run, about the session pods of live agents only.
- **No protocol change.** The daemon's session rows live in the shared data-plane store, not in the control plane, so `agent/exists` is unchanged and no session-exists frame is needed. `reconcile --once` now opens the shared store **before** the cluster sweep and answers from it: `LocalStore.sessionKeysForAgent(agentId)` (`SELECT key FROM sessions WHERE agentId = ?`, open or closed rows alike — a row's existence is what keeps its claim), with the leaf derived exactly as the host key derives it. A store stub without that method (the existing tests') simply leaves the session rule off.

## The admission fence (review round 2)

`liveSessions` is a snapshot taken before the deletion loop, and the reviewer is right that nothing downstream of it could see a session that came back: the new delivery's `ensureClaim` **reuses** the leaked claim rather than creating one, so the uid and resourceVersion the sweep listed still matched, and the object-age grace does not help because the claim is genuinely old. The delete then took a live pod and its volume.

**What I chose.** The shape the review suggested, both halves of it, because they are two consequences of one write rather than two mechanisms:

- `K8sDriver.ensureSandbox` stamps every claim it admits with `agentconnect.md/last-admitted-at` (RFC 3339), and `SandboxApi.ensureClaim`'s AlreadyExists branch now **merge-patches** those annotations onto the claim it found instead of only reading it. Admission is therefore a write in every case, not just on create.
- The reconciler's grace runs from the **later** of `creationTimestamp` and that stamp. A leaked claim a new session re-admitted is young again, so it is not a candidate at all.
- And because the stamp's write moves the claim's `resourceVersion`, an admission that lands *after* the sweep listed the object makes the preconditioned `deleteClaimIfCurrent` fail — logged as "replaced since it was listed", pod and volume left alone, next run decides again.

So the absence proof and the admission are ordered by the object's own version, in both directions: an admission before the listing is visible in the stamp, one after it is visible in the version. A second uncoordinated row read would only have narrowed the window, which is why it is not what this does.

## The stamp's permission (review round 3)

The reviewer was right, and I had missed it: the stamp is a merge PATCH, and the Role shipped for pool members granted `sandboxclaims` only `get`/`list`/`watch`/`create`/`delete`. Every admission that reused an existing claim would have gone POST 409 → PATCH 403, so a suspended claim could not resume at all. That is not a race traded for a race — it is a permission gap turned into an outage on every resume.

This is **not** a prerequisite to be carried out elsewhere: the chart is published from this repository, so the grant lands here in the same change. `charts/agentconnect/templates/daemon-pool.yaml` now grants `patch` on `sandboxclaims`, and `scripts/test-chart-render.rb` asserts the new verb set.

The daemon does **not** depend on that grant having been applied, because an install can run a newer image against an older Role. A 403 on the stamp falls back to a plain read: the claim is admitted, the sandbox launches, and `K8sDriver` says once that the orphan sweep judges that claim by object age alone until the verb is granted. Only a permission refusal takes that path — every other rejection is this call failing and stays fatal, so a malformed patch is never silently swallowed. Being explicit about what the degraded state costs: with the stamp refused the reuse path writes nothing, so **both** halves of the fence lapse for a reused claim — its grace runs from `creationTimestamp` again, and its `resourceVersion` does not move for the preconditioned delete to notice. That is exactly the pre-fence behaviour this PR set out to fix, which is why the grant ships with it; deletion is opt-in (`deleteEnabled`), so a degraded install is reporting-only by default.

## The stamp is a liveness signal, not an admission marker (review round 4)

The reviewer found the remaining hole and it was real: `ensureSandbox` returns from the launch registry **before** any API call, and `adoptSessions` caches a Running claim this member never admitted. So a member can serve a session indefinitely without ever writing to its claim — an admission-only stamp leaves a claim in use looking untouched, and a sweep that snapshotted its row as absent still matches on uid and `resourceVersion` when the row returns. The preconditioned delete then takes a live pod's volume.

Stamping the cache-hit path was not the answer (an API round trip on every turn), and neither was stamping at adoption (it only buys one grace window). The stamp has to mean **"last seen in use by a member"**, so it is refreshed on a tick: `K8sDriver.refreshAdmissionStamps()` re-stamps every claim this member holds a launch for, and the runtime plane runs it every `STAMP_REFRESH_MS` — a third of the sweep's default grace, so two missed ticks still leave a held claim young. The reconciler is unchanged: it already runs its grace from the later of `creationTimestamp` and the stamp, and its contract comment now states the new meaning.

Cost: one PATCH per held pod per three minutes, per member. It is off every turn's path, one claim's failure never stops the rest, a claim retired underneath the member is not an error, and a refused `patch` degrades exactly as an admission does — reported once.

## The two gaps the periodic pass did not cover (review round 5)

Both held, and both are places the *periodic* refresh cannot reach.

**A launch is stamped when it is published, not at the next tick.** `setInterval` waits a full period before its first callback, and a takeover writes nothing to the claim it adopts — so in that window an adopted claim looks untouched while a returning delivery is already served from the launch registry, and a sweep holding the old `resourceVersion` still matches. `adopt()` now stamps before publishing the launch. The reviewer named the takeover; the same class reaches **`resumeSandbox`**, which records a launch straight from the claim it read, so it publishes an unadmitted launch exactly as a takeover does and stamps too. That leaves `ensureSandbox` (stamps via `ensureClaim`), `adopt` and `resumeSandbox` as the three `recordLaunch` call sites, all three stamped — the periodic pass is now steady-state freshness, not what a new launch depends on.

**The cadence is derived from the grace, not from a constant.** The sweep honours any positive `AC_K8S_ORPHAN_GRACE_MS`, while members refreshed on a hardcoded 180 s, so an install that shortened the grace let a held claim age past it between every pair of ticks. `stampRefreshMsFor(graceMs)` now lives beside `DEFAULT_ORPHAN_GRACE_MS` and returns a third of the window — two missed ticks of margin — and the plane reads the grace through the reconciler's own `resolveOrphanReconcilerSettings`. No floor: a floor is the same bug at a different number, and honouring a short grace costs API calls rather than a deleted volume.

For a member to derive it, it has to *have* it: `AC_K8S_ORPHAN_GRACE_MS` moves into `agentconnect.daemonPoolClusterEnv`, the partial the member Deployment and the sweep's CronJob already share so they "cannot disagree", and the duplicate on the CronJob goes. One value, one place, both surfaces. The render contract asserts both carry the configured grace and that an unset one leaves both on the daemon default.

## A fence that does not land publishes nothing (review round 6)

Held, and it was the failure path of the fix above. The stamp helper turned every PATCH failure into success — correct while it only powered the best-effort timer, wrong the moment a takeover and a resume awaited it as a fence, because a timeout or a 500 then published a launch the sweep cannot see.

The two uses are separate now. The periodic refresh stays best effort: a write that does not land costs freshness the next tick restores. The publication fence admits exactly two outcomes — the write landed, or the API server refused the **permission**, the mixed-Role degradation already reported once and accepted because failing every takeover over a missing verb is worse than the race. Anything else publishes nothing: a takeover adopts nothing and the next duty tick retries, a resume refuses the read, and both say why.

**Constraints kept.** The stamp is on the **claim's own metadata** — never in `spec`, never in `spec.additionalPodMetadata`, so nothing per-agent or per-session enters the claim spec and warm-pool adoption is unchanged (asserted). `claimVacant` is untouched: that ledger is the control plane's duty layer, a different question from whether a cluster object is garbage. The claim controller needs no new configuration — the claim's annotations were already the daemon's to set (`claimMetadataForAgent`).

**Cost.** One extra PATCH per admission that reuses an existing claim. `ensureSandbox` returns from the launch registry without touching the API on the common path, so this is paid on cold starts, resumes and takeovers only.

## Verification

Unit level only — **no live cluster was exercised.**

- `k8s-orphan-reconciler.test.ts`: a live agent's session pod whose row is gone is collected (claim and claimless Sandbox alike) while the one whose row remains and the agent's own pod are kept; the store is asked once, only about session pods of live agents; no answer ⇒ live; a throwing store ⇒ every session pod kept and the rest of the sweep still collected; a gone agent's session pod is collected on the agent rule with no session question; grace applies. **Mutation-checked:** a reconciler that never consults session rows fails 3 tests (2 here, 1 in the CLI suite).
- `cli-reconcile.test.ts`: the job answers from the shared store's `sessionKeysForAgent` and collects the session pod without a row; with no store mounted every session pod is kept while the agent rule still collects.
- Round 2 — the fence: `k8s-orphan-reconciler.test.ts` (a leaked claim whose stamp is inside the grace is no candidate, and becomes one once a whole grace passes with no admission; a delete the API server refuses on its preconditions is reported as replaced and takes nothing, with the version it listed shown in the request); `k8s-client.test.ts` (the AlreadyExists branch sends a `merge-patch+json` of the annotations alone and returns the patched claim); `k8s-session-pods.test.ts` (admission stamps on create and re-stamps on reuse, same uid and a new resourceVersion, with nothing added to the claim spec or the pod labels). **Mutation-checked:** a grace that ignores the stamp ⇒ 1 red; a reuse path that only reads ⇒ 1 red; an admission that does not stamp ⇒ 1 red; a delete without the listed resourceVersion ⇒ 3 red.
- `pnpm --filter @agentconnect.md/daemon exec tsc -p tsconfig.typecheck.json --noEmit`, eslint and prettier on the touched files.

- Round 3: `k8s-client.test.ts` (a 403 on the stamp still admits, reads the claim back and reports `stampRefused`; a 422 stays fatal and never reaches the fallback read); `k8s-session-pods.test.ts` (three degraded admissions in a row all launch, and the warning is emitted once, not once per admission); `scripts/test-chart-render.rb` (the Role's verb set). **Mutation-checked:** degrading on every rejection rather than only a permission refusal ⇒ 1 red; a refused stamp failing the admission ⇒ 1 red; a warning that repeats per admission ⇒ 1 red; the Role losing `patch` again ⇒ the render contract aborts.

- Round 4: `k8s-session-pods.test.ts` (the refresh stamps and re-versions every held claim, an agent's and a session's alike, and stops for one this member released; one claim gone or refusing the write leaves the rest refreshed and says so once). **Mutation-checked:** a refresh that stamps nothing ⇒ 2 red; one gone claim aborting the sweep ⇒ 1 red; a refused refresh saying nothing ⇒ 1 red.

- Round 5: `k8s-session-pods.test.ts` (a takeover stamps and re-versions the claim before publishing its launch, with no timer having run; a resume onto an observed claim does the same and stays the same object); `k8s-orphan-reconciler.test.ts` (the cadence tracks any configured grace, with three ticks always inside the window); `scripts/test-chart-render.rb` (a configured grace reaches the member Deployment and the CronJob alike; unset leaves both on the default). **Mutation-checked:** a takeover publishing an unstamped launch ⇒ 1 red; a resume publishing an unstamped launch ⇒ 1 red; the cadence back to a hardcoded 180 s ⇒ 1 red; the grace reaching only the sweep ⇒ the render contract aborts.

- Round 6: `k8s-session-pods.test.ts` (a fence write that throws publishes no launch — the resume refuses, the takeover adopts nothing, the claim the sweep listed is untouched and a warning says so; a fence refused by permission alone still publishes and is reported once, not as a failure). **Mutation-checked:** the fence swallowing a transient failure ⇒ 1 red; a permission refusal blocking publication ⇒ 1 red.

Design doc: the session bullet joins the orphan list in `docs/designs/k8s-daemon-pool.md` §4, with the admission fence recorded beside the safety rules.

#1766 has merged; `main` is merged in rather than rebased, so the pushed history is append-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





