### PR TITLE
fix(daemon): a perSubject delivery continues the subject's session

### DIFF
--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -5,8 +5,9 @@
  *
  *  - `channel`/`thread` derive from the relay-computed session-affinity key
  *    (decision 7), so `SessionManager` continuity works unchanged: perDelivery
- *    keys a fresh session per delivery, `shared` keys the whole hook to one
- *    session, github perThread (P2) keys `<stable-repo-prefix>#N`.
+ *    keys a fresh session per delivery, perSubject keys one per caller-named
+ *    subject, `shared` keys the whole hook to one session, github perThread
+ *    (P2) keys `<stable-repo-prefix>#N`.
  *  - **The payload IS the message.** The generic webhook's URL is a capability
  *    credential: whoever holds it is a trusted caller, exactly like a user
  *    DMing the bot — so their payload carries the instructions. A JSON object
@@ -21,6 +22,7 @@
  *    repo-scoped tokens, permission mode), never content filtering.
  */
 import {
+  HOOK_SUBJECT_SEGMENT,
   isGithubPullRequestRevisionEvent,
   type CodehostTurnFacts,
   type GithubHookMetadata,
@@ -61,6 +63,11 @@ function splitSessionKey(msg: RdMsgHook): { channel: string; thread?: string } {
   // stable synthetic thread so every delivery really shares one logical key.
   if (msg.sessionKey === msg.hookId) return { channel: msg.hookId, thread: msg.hookId } // shared
   if (msg.sessionKey === `${msg.hookId}:${msg.deliveryKey}`) return { channel: msg.hookId, thread: msg.deliveryKey } // perDelivery
+  // perSubject: '<hookId>:subject:<caller key>'. The mode-namespaced suffix IS the thread, so every
+  // delivery naming one subject shares a session and a '#' in the caller's key is not read as perThread.
+  if (msg.sessionKey.startsWith(`${msg.hookId}:${HOOK_SUBJECT_SEGMENT}:`)) {
+    return { channel: msg.hookId, thread: msg.sessionKey.slice(msg.hookId.length + 1) }
+  }
   // perThread (github, P2): '<stable-repo-prefix>#42'.
   const hash = msg.sessionKey.lastIndexOf('#')
   if (hash > 0) return { channel: msg.sessionKey.slice(0, hash), thread: msg.sessionKey.slice(hash + 1) }

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -16,6 +16,7 @@ import {
   CODEHOST_REVIEW_V1_FEATURE,
   HOOK_REPORT_REASON_PROVIDER_AUTH_REQUIRED,
   HOOK_REPORT_REASON_PROVIDER_QUOTA_EXHAUSTED,
+  hookSubjectSessionKey,
   type EventSession,
   type HookReport,
   type HookStart,
@@ -3651,6 +3652,32 @@ describe('buildHookMessage', () => {
     const m = buildHookMessage(fire({ sessionKey: 'acme/infra#42' }), 'trace-1')
     expect(m.channel).toBe('acme/infra')
     expect(m.thread).toBe('42')
+  })
+
+  it('perSubject keys every delivery of one subject to one session-store key', async () => {
+    const sessionKey = hookSubjectSessionKey(HOOK_ID, 'ticket-42')
+    const first = buildHookMessage(fire({ sessionKey, msgId: `${HOOK_ID}:d-1`, deliveryKey: 'd-1' }), 'trace-1')
+    const second = buildHookMessage(fire({ sessionKey, msgId: `${HOOK_ID}:d-2`, deliveryKey: 'd-2' }), 'trace-2')
+
+    expect(first).toMatchObject({ channel: HOOK_ID, thread: 'subject:ticket-42' })
+    // The store key is (platform, channel, thread): equal across deliveries, distinct per subject.
+    expect(second.channel).toBe(first.channel)
+    expect(transcriptCoords(second).thread).toBe(transcriptCoords(first).thread)
+    const other = buildHookMessage(fire({ sessionKey: hookSubjectSessionKey(HOOK_ID, 'ticket-43') }), 'trace-3')
+    expect(other.thread).not.toBe(first.thread)
+  })
+
+  it("perSubject does not read a '#' in the caller's subject key as a github thread", async () => {
+    const m = buildHookMessage(fire({ sessionKey: hookSubjectSessionKey(HOOK_ID, 'ticket#42') }), 'trace-1')
+    expect(m).toMatchObject({ channel: HOOK_ID, thread: 'subject:ticket#42' })
+  })
+
+  it('a perSubject key and the perDelivery key that spells it agree on coordinates', async () => {
+    const sessionKey = hookSubjectSessionKey(HOOK_ID, 'ticket-42')
+    const asDelivery = buildHookMessage(fire({ sessionKey, msgId: sessionKey, deliveryKey: 'subject:ticket-42' }), 't')
+    const asSubject = buildHookMessage(fire({ sessionKey }), 't')
+    expect(asDelivery.thread).toBe(asSubject.thread)
+    expect(asDelivery.channel).toBe(asSubject.channel)
   })
 
   it('the payload IS the message: a `prompt` field speaks for the caller', async () => {

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -6,7 +6,7 @@ import { LocalStore, sessionKey, transcriptChannelKey } from '../src/store/local
 import { SessionManager, isStandingContextTitleEcho } from '../src/session/session-manager.js'
 import { clampRuntimeTitle, isPromptEchoTitle, promptEchoPrefix } from '../src/session/derive-title.js'
 import { buildHookMessage } from '../src/messages/hook-message.js'
-import type { RdMsgHook } from '@agentconnect.md/protocol'
+import { hookSubjectSessionKey, type RdMsgHook } from '@agentconnect.md/protocol'
 import { WorkspaceManager } from '../src/workspace/workspace-manager.js'
 import { createManagedMemoryProvider } from '../src/memory/provider.js'
 import { writeMemoryFile, MEMORY_INDEX, MAX_INDEX_INJECT_BYTES } from '../src/memory/store.js'
@@ -742,6 +742,34 @@ describe('SessionManager', () => {
     expect(isPromptEchoTitle(upstreamFallbackTitle, promptEchoPrefix(promptTexts))).toBe(true)
     // A real runtime title on the same turn still gets through.
     expect(isPromptEchoTitle('Review the Linear transcript change', promptEchoPrefix(promptTexts))).toBe(false)
+    await (await store).close()
+  })
+
+  it('continues one session across every webhook delivery naming the same subject', async () => {
+    const store = await newStore()
+    const host = { newSession: vi.fn(async () => 'acp-subject-1') } as any
+    const sm = new SessionManager({ store, hostFor: async () => host, agentById: () => agent, memory })
+    const hookId = 'hook-1'
+    const fire = (deliveryKey: string, subject: string): RdMsgHook =>
+      ({
+        source: 'hook',
+        agentId: 'bot-a',
+        sessionKey: hookSubjectSessionKey(hookId, subject),
+        msgId: `${hookId}:${deliveryKey}`,
+        hookId,
+        deliveryKey,
+        firedAt: new Date().toISOString(),
+        context: { source: 'webhook', body: `{"ticket":"${subject}"}`, truncated: false }
+      }) as unknown as RdMsgHook
+
+    const opened = await sm.handle('bot-a', buildHookMessage(fire('d-1', 'ticket-42'), 't-1'))
+    expect(opened.created).toBe(true)
+    // A distinct delivery of the SAME subject appends a turn instead of waking context-free.
+    const followUp = await sm.handle('bot-a', buildHookMessage(fire('d-2', 'ticket-42'), 't-2'))
+    expect(followUp.created).toBe(false)
+    // Another subject on the same hook stays its own session.
+    const other = await sm.handle('bot-a', buildHookMessage(fire('d-3', 'ticket-43'), 't-3'))
+    expect(other.created).toBe(true)
     await (await store).close()
   })
 

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -411,6 +411,15 @@ export const RdMsgPlatformAction = z.object({
 })
 export type RdMsgPlatformAction = z.infer<typeof RdMsgPlatformAction>
 
+/** The `perSubject` namespace inside a webhook affinity key — minted by the relay, read back by the
+ *  daemon's normalizer, so the one grammar both sides depend on lives in one place. */
+export const HOOK_SUBJECT_SEGMENT = 'subject'
+
+/** The `perSubject` affinity key for one caller-named subject. */
+export function hookSubjectSessionKey(hookId: string, subjectKey: string): string {
+  return `${hookId}:${HOOK_SUBJECT_SEGMENT}:${subjectKey}`
+}
+
 // R→D REQ → rd/ack. One already-adjudicated trigger delivery: the relay matched
 // the hook rule and names the target agent (explicit-agent short-circuit, same
 // as webchat — no local trigger arbitration). The daemon synthesizes a
@@ -423,8 +432,8 @@ export const RdMsgHook = z.object({
   // (sessionKey, msgId) is the daemon's dedup key. msgId folds in the hookId:
   // one GitHub delivery fanning out to two hooks on the same agent+repo must
   // not swallow each other.
-  sessionKey: z.string().min(1), // relay-computed: github perThread '<stable-prefix>#42';
-  // webhook perDelivery '<hookId>:<deliveryKey>' / shared '<hookId>'
+  sessionKey: z.string().min(1), // relay-computed: github perThread '<stable-prefix>#42'; webhook
+  // perDelivery '<hookId>:<deliveryKey>' / perSubject '<hookId>:subject:<key>' / shared '<hookId>'
   msgId: z.string().min(1), // `${hookId}:${deliveryKey}`
   hookId: z.string().uuid(),
   deliveryKey: z.string().min(1),

--- a/packages/relay/src/hooks/ingress.ts
+++ b/packages/relay/src/hooks/ingress.ts
@@ -28,6 +28,7 @@ import {
   isSelfManagedGitlabHost,
   HOOK_DELIVERY_REASON_DISPATCH_TIMEOUT,
   HOOK_DELIVERY_REASON_DAEMON_OFFLINE,
+  hookSubjectSessionKey,
   RD_GITHUB_THREAD_WORKTREE_CLEANUP_V2,
   type RcHookAssign,
   type RcRunReport,
@@ -78,7 +79,7 @@ function sessionKeyFor(rule: RcHookAssign, deliveryKey: string, subjectKey?: str
   if (rule.sessionMode === 'shared') return rule.hookId
   // perSubject: the caller names the subject; the `subject:` segment keeps the space disjoint
   // from per-delivery keys, and a delivery without the header degrades to per-delivery.
-  if (rule.sessionMode === 'perSubject' && subjectKey) return `${rule.hookId}:subject:${subjectKey}`
+  if (rule.sessionMode === 'perSubject' && subjectKey) return hookSubjectSessionKey(rule.hookId, subjectKey)
   return `${rule.hookId}:${deliveryKey}`
 }
 


### PR DESCRIPTION
Follow-up to #1765 — resolves the [P2] review comment on `packages/relay/src/hooks/ingress.ts`.

## The gap

#1765 shipped the relay half of `perSubject`: a delivery carrying `X-AC-Session-Key` gets the affinity key `<hookId>:subject:<key>`. The daemon's normalizer (`splitSessionKey` in `messages/hook-message.ts`) was never taught that shape. It recognizes `<hookId>` (shared), `<hookId>:<deliveryKey>` (perDelivery), and a `#`-bearing code-host key — a subject key matched none, so it fell through to `{ channel: sessionKey }` with **no thread**. `transcriptCoords()` then substitutes this delivery's `msgId`, and since the store key is `(platform, channel, thread, agent)`, two deliveries naming the same subject landed in two different sessions. The mode's whole promise — one subject accumulates context — was inverted on the daemon side.

## What changes

- **daemon** (`messages/hook-message.ts`): a `perSubject` branch reads the namespaced suffix back as the thread — `channel = hookId`, `thread = subject:<key>` — matching how `shared` and `perDelivery` key their channel. It sits **ahead of** the `#` split, so a `#` inside a caller's subject key (`ticket#42`) is no longer misread as a code-host issue number.
- **protocol** (`frames/relay-daemon.ts`): `HOOK_SUBJECT_SEGMENT` + `hookSubjectSessionKey()` — the relay mints through them and the daemon reads through them, so the one grammar both sides depend on has a single home instead of two hand-written templates that can drift. The `sessionKey` grammar comment on `RdMsgHook` now lists `perSubject`.
- **relay** (`hooks/ingress.ts`): mints via the shared helper. Byte-identical output.

The mapping stays a total function of the key string: a `perDelivery` delivery whose delivery key literally spells `subject:<x>` produces the same string the perSubject minter would, and both readings now resolve to the same coordinates — asserted by a test.

## Scope

Behavior for `perDelivery`, `shared`, github `perThread`, and GitLab is untouched (GitLab still short-circuits on its trusted discriminator, ahead of every string branch). No wire, schema, or migration change — `perSubject` frames already on the wire simply normalize correctly from this daemon on.

One pre-existing limit left alone: a hook with an anchoring **target** pins `thread = msgId` for every mode, so `perSubject` and `shared` both open a session per delivery there. That predates #1765 and changing it would move `shared` too — out of scope for this fix.

## Verification

- The regression is reproduced and pinned: reverting only the normalizer branch fails all four new cases, including `followUp.created` flipping to `true` (a fresh session per delivery — exactly the reported symptom).
- New: 3 cases in `daemon-hook.test.ts` (stable coordinates across deliveries, `#`-in-key, perDelivery/perSubject agreement) and 1 in `session-manager.test.ts` driving `SessionManager.handle` twice to assert the second delivery continues the session while a different subject opens its own.
- daemon 5636 passed / relay 642 / protocol 481; `typecheck`, `lint`, `format:check` clean. The four failures in the daemon suite are `shim-*` sandbox tests and the live-provider runtime matrix — both fail identically on the base commit in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
