### PR TITLE
chore(sandbox): refresh the image's runtime pins

### DIFF
--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -110,7 +110,7 @@ RUN set -eu; \
 FROM node:24-bookworm-slim AS runtime-sandbox
 
 # Exact pins keep the published runtime table truthful.
-ARG CLAUDE_ACP_VERSION=0.70.0
+ARG CLAUDE_ACP_VERSION=0.73.0
 ARG CODEX_ACP_VERSION=1.8.0-agentconnect.1
 ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.27
 ARG AGENT_BROWSER_VERSION=0.36.0

--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -112,7 +112,7 @@ FROM node:24-bookworm-slim AS runtime-sandbox
 # Exact pins keep the published runtime table truthful.
 ARG CLAUDE_ACP_VERSION=0.70.0
 ARG CODEX_ACP_VERSION=1.8.0-agentconnect.1
-ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.16
+ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.27
 ARG AGENT_BROWSER_VERSION=0.36.0
 
 # git and ca-certificates are load-bearing — the workspace surface runs git IN here over the

--- a/docker/runtime-sandbox.Dockerfile
+++ b/docker/runtime-sandbox.Dockerfile
@@ -111,7 +111,7 @@ FROM node:24-bookworm-slim AS runtime-sandbox
 
 # Exact pins keep the published runtime table truthful.
 ARG CLAUDE_ACP_VERSION=0.70.0
-ARG CODEX_ACP_VERSION=1.7.0-agentconnect.2
+ARG CODEX_ACP_VERSION=1.8.0-agentconnect.1
 ARG DEEPSEEK_HARNESS_ACP_VERSION=0.4.16
 ARG AGENT_BROWSER_VERSION=0.36.0
 

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -324,7 +324,7 @@ describe('permissionModeChoicesFor', () => {
       )
     ).toEqual([
       { v: 'plan', l: 'Plan first', description: 'Inspect the workspace without making changes.' },
-      { v: 'acceptEdits', l: 'Accept Edits' },
+      { v: 'acceptEdits', l: 'Accept edits' },
       { v: 'yolo', l: 'Yolo' }
     ])
   })

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -731,15 +731,14 @@ export function permissionModeOptions(runtime: string): { v: string; l: string }
     ]
   }
   // Labels mirror claude-agent-acp's own mode names so the console can't misrepresent
-  // them. In particular `dontAsk` is "don't prompt, DENY anything not pre-approved" — the
-  // opposite of auto-approve — and `acceptEdits` auto-accepts edits rather than asking.
+  // them: `acceptEdits` auto-accepts edits rather than asking, and `auto` approves with a
+  // model classifier. A daemon-reported catalog supersedes this list wherever one exists.
   return [
-    { v: 'default', l: 'Default' },
-    { v: 'acceptEdits', l: 'Accept Edits' },
-    { v: 'auto', l: 'Auto' },
-    { v: 'dontAsk', l: "Don't Ask" },
+    { v: 'default', l: 'Manual' },
+    { v: 'acceptEdits', l: 'Accept edits' },
     { v: 'plan', l: 'Plan' },
-    { v: 'bypassPermissions', l: 'Bypass' }
+    { v: 'auto', l: 'Auto' },
+    { v: 'bypassPermissions', l: 'Bypass permissions' }
   ]
 }
 


### PR DESCRIPTION
Refreshes every runtime pin the sandbox image installs. Each version was compared against the one it replaces before it went in.

## Codex: 1.7.0-agentconnect.2 → 1.8.0-agentconnect.1

A sandbox-launched Codex session never got a runtime session title while a self-hosted one already did. 1.8.0 carries upstream's session-title generation ([agentclientprotocol/codex-acp#392](https://github.com/agentclientprotocol/codex-acp/pull/392)): it names the thread after the first turn and pushes the result through the standard ACP `session_info_update` path, so the daemon needs no change.

Verified against both published tarballs: the bin name stays `codex-acp`, so the image's runtime-table generator still finds it; the ACP usage mapping, the terminal-output delta meta the daemon folds back into a tool call, and the three permission-mode ids and labels are unchanged. Driving the published build over ACP, the turn still ends with the old prompt-echo fallback title, which the daemon's existing echo filter drops, and the generated title arrives about six seconds later.

## Claude: 0.70.0 → 0.73.0

The public registry already serves 0.73.0, so a self-hosted daemon installs it the next time its runtime store resolves the entry. Leaving the image behind only guarantees that a pool sandbox runs an older adapter than the same agent gets anywhere else.

Probed both builds over ACP. **0.73.0 stops advertising two ids that stored agent configuration can still name** — the `dontAsk` permission mode and the `claude-fable-5[1m]` model — and renames three modes. Neither retired value breaks a session: a stored value that is no longer offered is skipped with a debug line by the config planner (`planConfigSelection`), so the session runs with the runtime's own default. For `dontAsk` that means the mode which ASKS rather than the one which denies — visible, but not a loosening. 0.73.0 also adds a `subagents` session capability.

The console's static permission-mode list is the last-resort fallback for a daemon that reports no catalog, and it still named `dontAsk` and the old labels, so it now copies what the runtime says.

## DeepSeek harness: 0.4.16 → 0.4.27

Eleven patches behind, and the surfaces the daemon and console read are unchanged between the two tarballs: the bin name stays `dsh-acp`, the three permission-mode ids and both model ids are the same. Its entry file moved from `dist/index.js` to `dist/bin.js`, which the global install's bin link resolves and the build-time runtime-table probe re-derives anyway.

## Unchanged

`agent-browser` is already at 0.36.0, the newest release.

Relates to #1613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
