### PR TITLE
fix(daemon): a confined host's temp dir is short enough for its SRT socket

### DIFF
--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -306,7 +306,7 @@ Layout, one directory per session, removed whole at retirement:
 <agentDir>/sessions/<sid>/
 ├── workspace/            # primary clone — the session cwd
 ├── repos/<owner>/<repo>/ # one clone per secondary root (multi-repository-workspaces.md decision 4)
-└── home/                 # private HOME, TMPDIR, XDG_RUNTIME_DIR, runtime state
+└── home/                 # private HOME, XDG_RUNTIME_DIR, runtime state
 ```
 
 The primary checkout keeps its roles for `shared` isolation, the console's
@@ -331,9 +331,15 @@ the parent of anything.
   its `hooks` and `config` read-only, for both the outer sandbox and a runtime's
   inner one.
 - **HOME is per session.** `home/` is the runtime's private HOME — `HOME`,
-  `TMPDIR`, `XDG_*`, `CODEX_HOME` and the other runtime-state env point there —
-  seeded from the host and protected exactly as the agent's `home/` is, and
-  removed with the leaf. Runtime-native cross-session state (Codex memories,
+  `XDG_*`, `CODEX_HOME` and the other runtime-state env point there — seeded
+  from the host and protected exactly as the agent's `home/` is, and removed
+  with the leaf. `TMPDIR` is the exception: a confined host's temp directory is
+  `<agentDir>/t/<8 hex of the host key>`, granted read+write by the sandbox
+  policy and removed with the host, because SRT opens its multiplexer socket
+  directly under `TMPDIR` and AF_UNIX caps that path at 107 bytes, which a HOME
+  below the daemon root, the agent name and this leaf overflows. That shape is
+  short rather than bounded — a launch whose socket would still not fit is
+  refused by name at preparation. Runtime-native cross-session state (Codex memories,
   goals and logs; Claude project state) is therefore per session; managed memory
   lives outside HOME and is unaffected. Package caches (`.npm`, `.cache`,
   `.local`) live there too, writable per session by construction and gone with

--- a/packages/daemon/src/acp/sandbox-runtime-provider.ts
+++ b/packages/daemon/src/acp/sandbox-runtime-provider.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process'
 import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
 import { isAbsolute, join, resolve } from 'node:path'
 import { SandboxManager, SandboxRuntimeConfigSchema } from '@anthropic-ai/sandbox-runtime'
+import { SANDBOX_TEMP_DIR_ENV } from './sandbox-temp.js'
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`
@@ -30,6 +31,31 @@ function isAncestorProcess(ownerPid: number): boolean {
   }
 
   return false
+}
+
+/** The child's temp root: the daemon composes an ACP host's own `<agentDir>/t/<8 hex>` and passes it here, since SRT's multiplexer socket sits directly under TMPDIR and AF_UNIX truncates a path built from a per-session runtime HOME. It stays subject to the same guard the private HOME has — an explicit SRT write root. Without one (the audited offline helpers, and a launch in a sandbox pod) the private HOME keeps its own. */
+function childTempDir(writeRoots: string[], privateHome: string): string {
+  const requested = process.env[SANDBOX_TEMP_DIR_ENV]
+  // Never travels on to the sandboxed child: it is the daemon's instruction to this process.
+  delete process.env[SANDBOX_TEMP_DIR_ENV]
+  if (requested === undefined) {
+    const homeTmp = join(resolve(privateHome), '.tmp')
+    if (existsSync(homeTmp)) {
+      const stat = lstatSync(homeTmp)
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        throw new Error('private SRT temp path must be a real directory')
+      }
+    }
+    mkdirSync(homeTmp, { recursive: true, mode: 0o700 })
+    chmodSync(homeTmp, 0o700)
+    return homeTmp
+  }
+  if (!isAbsolute(requested)) throw new Error('the SRT temp root must be an absolute path')
+  const tempDir = realpathSync(requested)
+  if (!writeRoots.includes(resolve(tempDir))) {
+    throw new Error('the SRT temp root must be an explicit SRT write root')
+  }
+  return tempDir
 }
 
 /**
@@ -84,17 +110,8 @@ export async function runSandboxRuntimeProvider(argv: string[], opts: { offline?
     if (!privateHome || !writeRoots.includes(resolve(privateHome))) {
       throw new Error('private HOME must be an explicit SRT write root')
     }
-    const privateTmp = join(resolve(privateHome), '.tmp')
-    if (existsSync(privateTmp)) {
-      const stat = lstatSync(privateTmp)
-      if (stat.isSymbolicLink() || !stat.isDirectory()) {
-        throw new Error('private SRT temp path must be a real directory')
-      }
-    }
-    mkdirSync(privateTmp, { recursive: true, mode: 0o700 })
-    chmodSync(privateTmp, 0o700)
-    // SRT otherwise defaults TMPDIR to the shared host /tmp/claude path. Keep
-    // temporary state inside this agent's private HOME instead.
+    const privateTmp = childTempDir(writeRoots, privateHome)
+    // SRT otherwise defaults TMPDIR to the shared host /tmp/claude path.
     process.env.HOME = privateHome
     process.env.TMPDIR = privateTmp
     process.env.CLAUDE_CODE_TMPDIR = privateTmp

--- a/packages/daemon/src/acp/sandbox-temp.ts
+++ b/packages/daemon/src/acp/sandbox-temp.ts
@@ -1,0 +1,108 @@
+import { createHash } from 'node:crypto'
+import { lstatSync, mkdirSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import type { HostKey } from './host-key.js'
+
+// SRT opens its multiplexer at `<TMPDIR>/srt-mux-<pid>-<seq>.sock`, directly under TMPDIR, and AF_UNIX truncates the whole path at 107 usable bytes on Linux (103 on macOS). A confined host's temp dir is therefore a SHORT leaf of the agent dir; #1763 put it under the per-session runtime HOME, whose 52-byte tail overflowed that budget on every realistic install.
+
+/** Env var carrying the daemon-composed temp root to the SRT provider; absent ⇒ the provider keeps its private-HOME default. */
+export const SANDBOX_TEMP_DIR_ENV = 'AGENTCONNECT_SANDBOX_TMPDIR'
+
+/** `<agentDir>/t` — the parent every host temp directory of one agent hangs off; the name is one byte because every byte here is socket budget. */
+export function sandboxTempParent(agentDir: string): string {
+  return join(resolve(agentDir), 't')
+}
+
+/** Written when this daemon creates the temp parent. `t` is a short name, not a reserved one: an agent's `workspace.path` resolves under the agent dir too, so ownership is PROVEN by this marker and never inferred from the name. */
+const OWNER_MARKER = '.agentconnect-runtime-temp'
+
+/** The only entry name this daemon creates under the temp parent, and so the only one it ever removes. */
+const TEMP_LEAF = /^[0-9a-f]{8}$/
+
+/** `<agentDir>/t/<8 hex>` — one ACP host's own temp directory, distinct per host key. */
+export function sandboxTempDirFor(agentDir: string, hostKey: HostKey | undefined): string {
+  return join(sandboxTempParent(agentDir), tempLeaf(hostKey))
+}
+
+function tempLeaf(hostKey: HostKey | undefined): string {
+  return createHash('sha256')
+    .update(hostKey ?? '')
+    .digest('hex')
+    .slice(0, 8)
+}
+
+/** Usable `sun_path` bytes on Linux: the struct holds 108, less the terminating NUL. */
+export const AF_UNIX_PATH_MAX = 107
+
+/** The widest socket SRT composes under TMPDIR — a Linux pid at its 22-bit ceiling. */
+const WIDEST_SRT_SOCKET = 'srt-mux-4194304-0.sock'
+
+/** Create one host's temp directory and return its canonical path. Short is not the same as bounded: a deep enough daemon root plus a long agent name still overflows `sun_path`, and it fails HERE naming the path and the limit, rather than as an opaque `listen EINVAL` three ACP start attempts deep. */
+export function prepareSandboxTempDir(
+  agentDir: string,
+  hostKey: HostKey | undefined,
+  /** Test seam: SRT confines a host on Linux alone, so only a Linux launch opens this socket and only it is held to the budget. */
+  platform: NodeJS.Platform = process.platform
+): string {
+  const created = mkdirSync(sandboxTempParent(agentDir), { recursive: true, mode: 0o700 }) !== undefined
+  const parent = join(realpathSync(resolve(agentDir)), 't')
+  // Trust the resolved directory, not the composed name: a link standing in for it would move the whole temp tree out of the agent dir.
+  if (realpathSync(parent) !== parent) {
+    throw new Error(`runtime temp parent is not a real directory inside the agent dir: ${parent}`)
+  }
+  if (created) writeFileSync(join(parent, OWNER_MARKER), '', { mode: 0o600 })
+  // Fail closed rather than write into, or later sweep, a directory this daemon did not make.
+  if (!daemonOwnsTempParent(parent)) {
+    throw new Error(
+      `runtime temp root "${parent}" exists but this daemon did not create it — an agent workspace or operator data at that path must move before a confined host can start`
+    )
+  }
+  const path = join(parent, tempLeaf(hostKey))
+  const socket = join(path, WIDEST_SRT_SOCKET)
+  const bytes = Buffer.byteLength(socket)
+  if (platform === 'linux' && bytes > AF_UNIX_PATH_MAX) {
+    throw new Error(
+      `runtime temp dir is too deep for its SRT socket: "${socket}" is ${bytes} bytes and the limit is ${AF_UNIX_PATH_MAX} — shorten the daemon root or the agent name`
+    )
+  }
+  mkdirSync(path, { recursive: true, mode: 0o700 })
+  return path
+}
+
+/** Drop one host's temp directory once its child is gone; a missing one is not an error. */
+export function removeSandboxTempDir(path: string): void {
+  rmSync(path, { recursive: true, force: true })
+}
+
+/** The marker is the whole proof: a real file, written only by the call that created the parent. */
+function daemonOwnsTempParent(parent: string): boolean {
+  try {
+    return lstatSync(join(parent, OWNER_MARKER)).isFile()
+  } catch {
+    return false
+  }
+}
+
+/** Reclaim, at boot only, the host temp directories a hard-killed daemon left behind — every host of the agent is stopped then, so all of them are stale. Removes only `<8 hex>` leaves of a temp parent this daemon proved it owns: never the parent, never the marker, and nothing under a `t` that belongs to someone else. Best effort: returns what it removed and never throws. */
+export function reclaimStaleHostTempDirs(agentDir: string): string[] {
+  const parent = sandboxTempParent(agentDir)
+  if (!daemonOwnsTempParent(parent)) return []
+  let entries: string[]
+  try {
+    entries = readdirSync(parent)
+  } catch {
+    return []
+  }
+  const removed: string[] = []
+  for (const name of entries) {
+    if (!TEMP_LEAF.test(name)) continue
+    try {
+      // `rm -r` unlinks a leaf symlink rather than following it, and no component above one is agent-writable.
+      rmSync(join(parent, name), { recursive: true, force: true })
+      removed.push(name)
+    } catch {
+      // A stale temp tree must never stop the daemon from serving the agent; the next boot retries.
+    }
+  }
+  return removed
+}

--- a/packages/daemon/src/acp/sandbox-temp.ts
+++ b/packages/daemon/src/acp/sandbox-temp.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { lstatSync, mkdirSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import type { HostKey } from './host-key.js'
 
 // SRT opens its multiplexer at `<TMPDIR>/srt-mux-<pid>-<seq>.sock`, directly under TMPDIR, and AF_UNIX truncates the whole path at 107 usable bytes on Linux (103 on macOS). A confined host's temp dir is therefore a SHORT leaf of the agent dir; #1763 put it under the per-session runtime HOME, whose 52-byte tail overflowed that budget on every realistic install.
@@ -69,8 +69,9 @@ export function prepareSandboxTempDir(
   return path
 }
 
-/** Drop one host's temp directory once its child is gone; a missing one is not an error. */
+/** Drop one host's temp directory once its child is gone; a missing one is not an error. Teardown runs on paths this daemon only COMPOSED — a launch that refused an unowned parent still reaches it — so the marker gates the removal exactly as it gates the boot sweep. */
 export function removeSandboxTempDir(path: string): void {
+  if (!daemonOwnsTempParent(dirname(path))) return
   rmSync(path, { recursive: true, force: true })
 }
 

--- a/packages/daemon/src/acp/sandbox.ts
+++ b/packages/daemon/src/acp/sandbox.ts
@@ -18,6 +18,8 @@ import { spawnSync } from 'node:child_process'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { SandboxRuntimeConfig } from '@anthropic-ai/sandbox-runtime'
+import { hostKeyDirName, type HostKey } from './host-key.js'
+import { removeSandboxTempDir, sandboxTempDirFor } from './sandbox-temp.js'
 
 /**
  * OS-level process sandbox for agent runtimes (issue #312).
@@ -263,6 +265,12 @@ export function removeSandboxSettings(agentDir: string, hostDir: string): void {
   rmSync(sandboxSettingsDir(agentDir, hostDir), { recursive: true, force: true })
 }
 
+/** Drop everything daemon-owned a stopped host had: its policy directory and its temp directory. */
+export function removeHostSandboxState(agentDir: string, hostKey: HostKey | undefined): void {
+  removeSandboxSettings(agentDir, hostKeyDirName(hostKey))
+  removeSandboxTempDir(sandboxTempDirFor(agentDir, hostKey))
+}
+
 // Atomically publish the trusted SRT policy outside every agent-writable path, one directory per host.
 export function writeSandboxSettings(agentDir: string, hostDir: string, policy: SrtSandboxPolicy): string {
   const root = canonicalTarget(agentDir)
@@ -309,9 +317,7 @@ export function writeSandboxSettings(agentDir: string, hostDir: string, policy: 
       allowAllUnixSockets: policy.offline !== true
     },
     filesystem: {
-      // SRT's shared default temp path is not part of AgentConnect's per-agent
-      // storage. The provider redirects TMPDIR into the private HOME; hide the
-      // shared fallback so agents cannot exchange data through it.
+      // SRT's shared default temp path is not per-agent storage: TMPDIR points at this host's own directory, so hide the shared fallback and let no agent exchange data through it.
       denyRead,
       allowRead: canonical(policy.allowRead),
       allowWrite: canonical(policy.writable),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -29,11 +29,12 @@ import {
 import { AcpHost, turnFailureCode, turnFailureReason } from './acp/acp-host.js'
 import {
   probeSandboxHost,
-  removeSandboxSettings,
+  removeHostSandboxState,
   SandboxError,
   type SandboxMechanism,
   type SandboxProbe
 } from './acp/sandbox.js'
+import { reclaimStaleHostTempDirs } from './acp/sandbox-temp.js'
 import {
   agentHostKey,
   hostKeyAgentId,
@@ -2141,6 +2142,12 @@ export class Daemon {
           // workspace. A later restart can retry the best-effort cleanup.
           this.log.warn(`workspace: stale conversion clone cleanup failed for agent "${agent.id}" (${formatErr(err)})`)
         }
+      }
+      // Same reasoning for a confined host's temp tree: stopHost drops it, so a leaf
+      // still under the agent's own temp root at boot is a crash's leftovers.
+      const reclaimedTempDirs = reclaimStaleHostTempDirs(agent.dir)
+      if (reclaimedTempDirs.length > 0) {
+        this.log.info(`sandbox: reclaimed ${reclaimedTempDirs.length} stale temp director(ies) for agent "${agent.id}"`)
       }
       // No host is running at boot, so no materialized config-file secret should
       // exist. A clean shutdown removed them in stopHost; sweep what a
@@ -4581,7 +4588,7 @@ export class Daemon {
   private releaseHostLaunch(key: HostKey): void {
     const launch = this.hostLaunch.get(key)
     this.hostLaunch.delete(key)
-    if (launch) removeSandboxSettings(launch.agentDir, hostKeyDirName(key))
+    if (launch) removeHostSandboxState(launch.agentDir, key)
   }
 
   /** Drop an agent's config-file secrets once the pool's last host for it is gone. */
@@ -5124,7 +5131,7 @@ export class Daemon {
     try {
       host = await this.buildDreamHost(agent, context.inputDir, dreamHostKey, issued)
     } catch (error) {
-      removeSandboxSettings(agent.dir, hostKeyDirName(dreamHostKey))
+      removeHostSandboxState(agent.dir, dreamHostKey)
       if (issued) await this.modelSessions.revokeKeyQuietly(issued.grant.keyId)
       throw error
     }
@@ -5136,7 +5143,7 @@ export class Daemon {
       // attacker-influenced context never lingers (dreams are rare). Stopping the
       // child also kills a runtime that ignored `session/cancel`.
       await host.stop().catch(() => {})
-      removeSandboxSettings(agent.dir, hostKeyDirName(dreamHostKey))
+      removeHostSandboxState(agent.dir, dreamHostKey)
       if (issued) {
         await this.modelSessions.revokeKey(issued.grant.keyId)
       }
@@ -13984,7 +13991,7 @@ export class Daemon {
         await host.stop().catch(() => {})
         const failedLaunch = this.hostLaunch.get(key)
         this.hostLaunch.delete(key)
-        if (failedLaunch) removeSandboxSettings(failedLaunch.agentDir, hostKeyDirName(key))
+        if (failedLaunch) removeHostSandboxState(failedLaunch.agentDir, key)
         if (this.hostStartGeneration.get(key) !== generation) throw err
         // Remove the failed attempt's materialized config-file secrets unless another host of the agent still reads them.
         if (!this.agentHasOtherHosts(agentId, key)) {
@@ -14971,8 +14978,8 @@ export class Daemon {
       clearDeliveryBindings()
       clearMemoryExtractionQuarantines()
       removeConfigFiles()
-      // The policy the provider read for this child is daemon-owned per host; it goes with the child.
-      if (launch) removeSandboxSettings(launch.agentDir, hostKeyDirName(key))
+      // The policy the provider read for this child and the temp directory it opened are daemon-owned per host; both go with the child.
+      if (launch) removeHostSandboxState(launch.agentDir, key)
     }
   }
 

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -2,6 +2,7 @@ import { chmodSync, existsSync, lstatSync, mkdirSync, readdirSync, realpathSync 
 import { homedir } from 'node:os'
 import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { sandboxBoundary, writeSandboxSettings, type SandboxMechanism } from '../acp/sandbox.js'
+import { prepareSandboxTempDir, SANDBOX_TEMP_DIR_ENV } from '../acp/sandbox-temp.js'
 import { hostKeyDirName, hostKeySessionKey, type HostKey } from '../acp/host-key.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { compactReadRoots } from '../runtimes/read-roots.js'
@@ -158,6 +159,17 @@ function isolateHostSocketEnvironment(env: Record<string, string>, runtimeHome: 
     if (env[name] && isLocalSocketEndpoint(env[name])) delete env[name]
   }
   env.XDG_RUNTIME_DIR = realpathSync(runtimeDir)
+}
+
+/** Point the confined child's temp state at this host's own `<agentDir>/t/<8 hex>` and return it. The private HOME is the wrong home for it: SRT's multiplexer socket lives directly under TMPDIR, and a per-session HOME made that socket path overflow `sun_path` (#1763). */
+function isolateSandboxTempEnvironment(env: Record<string, string>, scopeDir: string, hostKey: HostKey | undefined) {
+  const tempDir = prepareSandboxTempDir(scopeDir, hostKey)
+  env.TMPDIR = tempDir
+  env.CLAUDE_CODE_TMPDIR = tempDir
+  env.CLAUDE_TMPDIR = tempDir
+  // The provider reads this one and drops it before wrapping, so the daemon decides the path instead of recomputing it from HOME.
+  env[SANDBOX_TEMP_DIR_ENV] = tempDir
+  return tempDir
 }
 
 export interface PreparedRuntimeLaunch {
@@ -368,7 +380,12 @@ export function prepareRuntimeLaunch(opts: {
     ...credentials?.env
   }
 
-  if (opts.runInSandbox) isolateHostSocketEnvironment(env, runtimeHome)
+  let sandboxTempDir: string | undefined
+  if (opts.runInSandbox) {
+    isolateHostSocketEnvironment(env, runtimeHome)
+    // NOT in k8s: a sandbox pod supplies its own temp dir, and this daemon must not name a path on a machine it is not on.
+    if (opts.k8s !== true) sandboxTempDir = isolateSandboxTempEnvironment(env, opts.scopeDir, opts.hostKey)
+  }
 
   if (!opts.runInSandbox) {
     const gitMetadataWriteRoots =
@@ -494,7 +511,9 @@ export function prepareRuntimeLaunch(opts: {
       ...credentialWritableRoots,
       ...trustedWorkspaceWriteRoots,
       ...packageCacheWriteRoots,
-      ...gitMetadataWriteRoots
+      ...gitMetadataWriteRoots,
+      // Inside the agent dir like every other writable root, so the agent-dir rule needs no exemption for it.
+      ...(sandboxTempDir === undefined ? [] : [sandboxTempDir])
     ]
   })
   // SRT write roots must exist before spawn.

--- a/packages/daemon/test/daemon-lifecycle.test.ts
+++ b/packages/daemon/test/daemon-lifecycle.test.ts
@@ -192,6 +192,40 @@ describe('Daemon session lifecycle (#118)', () => {
     await daemon.stop()
   })
 
+  // Boot is the one moment every host of the agent is provably stopped, so it is where a crash's
+  // leftover host temp directories are reclaimed. Only leaves of a temp root the daemon proved it
+  // owns go: an operator's data at the same short name, marker-less, is left untouched.
+  it("reclaims an agent's stale host temp directories at boot", async () => {
+    const root = scaffold()
+    const tempRoot = join(root, 'agents', 'bot-a', 't')
+    const orphaned = join(tempRoot, 'deadbeef')
+    const stranger = join(tempRoot, 'operator-notes')
+    mkdirSync(orphaned, { recursive: true })
+    mkdirSync(stranger, { recursive: true })
+    writeFileSync(join(tempRoot, '.agentconnect-runtime-temp'), '')
+
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => quietHost() as any })
+    await daemon.start()
+
+    expect(existsSync(orphaned)).toBe(false)
+    expect(existsSync(stranger)).toBe(true)
+    await daemon.stop()
+  })
+
+  // An agent whose `workspace.path` resolves to that same name keeps every byte of it.
+  it('never reclaims a temp-root name the daemon did not create', async () => {
+    const root = scaffold()
+    const workspace = join(root, 'agents', 'bot-a', 't')
+    const precious = join(workspace, 'deadbeef')
+    mkdirSync(precious, { recursive: true })
+
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: () => quietHost() as any })
+    await daemon.start()
+
+    expect(existsSync(precious)).toBe(true)
+    await daemon.stop()
+  })
+
   it('does not construct or start a cold host when workspace preparation fails', async () => {
     const root = scaffold()
     const workspace = join(root, 'agents', 'bot-a', 'workspace')

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -19,6 +19,7 @@ import { parse as parseYaml } from 'yaml'
 import { effectiveRunInSandbox, prepareRuntimeLaunch, privateRuntimeHomeFor } from '../src/launch/prepare.js'
 import { composeRuntimeLaunch, runtimeSandboxReadRoots } from '../src/launch/compose.js'
 import { agentHostKey, hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
+import { sandboxTempDirFor, SANDBOX_TEMP_DIR_ENV } from '../src/acp/sandbox-temp.js'
 import { CODEX_ACP_PERMISSION_PROFILE_CONFIG_ENV } from '../src/acp/codex-permission-profiles.js'
 import { runtimeMemoryCapabilities } from '../src/memory/runtime/capabilities.js'
 import { MemoryProviderUnavailableError } from '../src/memory/provider.js'
@@ -40,6 +41,16 @@ function agentFilesystem(env: Record<string, string>): string {
   return profile.configOverrides.find((value) =>
     value.startsWith('permissions.agentconnect-protected-workspace.filesystem=')
   )!
+}
+
+/** One launch's env or write roots without the per-host temp directory, so two hosts stay comparable. */
+function withoutTempDir(env: Record<string, string>): Record<string, string>
+function withoutTempDir(roots: string[]): string[]
+function withoutTempDir(value: Record<string, string> | string[]): Record<string, string> | string[] {
+  if (Array.isArray(value)) return value.filter((path) => !/[\\/]t[\\/][0-9a-f]{8}$/.test(path))
+  const rest = { ...value }
+  for (const name of ['TMPDIR', 'CLAUDE_TMPDIR', 'CLAUDE_CODE_TMPDIR', SANDBOX_TEMP_DIR_ENV]) delete rest[name]
+  return rest
 }
 
 function coveredBy(paths: string[], target: string): boolean {
@@ -600,9 +611,13 @@ describe('prepareRuntimeLaunch', () => {
 
     expect(shared.env.HOME).toBe(join(scopeDir, 'home'))
     expect(dream.env.HOME).toBe(join(scopeDir, 'home'))
-    expect(JSON.stringify(dream.env)).toBe(JSON.stringify(shared.env))
-    expect(dream.sandbox!.writable).toEqual(shared.sandbox!.writable)
-    expect(readFileSync(dream.sandbox!.settingsPath, 'utf8')).toBe(readFileSync(shared.sandbox!.settingsPath, 'utf8'))
+    // Its own temp directory is the ONE thing a session-keyed host does not share, by construction (#1763).
+    expect(dream.env.TMPDIR).not.toBe(shared.env.TMPDIR)
+    expect(withoutTempDir(dream.env)).toEqual(withoutTempDir(shared.env))
+    expect(withoutTempDir(dream.sandbox!.writable)).toEqual(withoutTempDir(shared.sandbox!.writable))
+    expect(readFileSync(dream.sandbox!.settingsPath, 'utf8').replaceAll(dream.env.TMPDIR!, '<temp>')).toBe(
+      readFileSync(shared.sandbox!.settingsPath, 'utf8').replaceAll(shared.env.TMPDIR!, '<temp>')
+    )
   })
 
   // The daemon redirects native memory under this HOME before the launch exists, so the two derivations must agree.
@@ -847,6 +862,81 @@ describe('prepareRuntimeLaunch', () => {
         hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
       })
     ).toThrow(/unsafe AgentConnect daemon root/)
+  })
+
+  // #1763: SRT opens its multiplexer directly under TMPDIR, so a temp dir below a per-session private
+  // HOME made that socket path a function of the session leaf too and blew past the AF_UNIX cap. It is
+  // a short leaf of the agent dir now — inside the agent dir, so the policy carves it back like any other.
+  it("puts the confined child's temp dir in the agent dir and carves exactly it back", () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const hostKey = sessionHostKey('agent-1', 'slack:C0123456789:1730000000.123456')
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'claude-acp',
+      runtime: { command: 'npx', args: ['claude-agent-acp'], env: [] },
+      scopeDir,
+      cwd,
+      hostKey,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin', TMPDIR: '/tmp' }
+    })
+    const tempDir = realpathSync(sandboxTempDirFor(scopeDir, hostKey))
+    expect(launch.env.TMPDIR).toBe(tempDir)
+    expect(launch.env.CLAUDE_TMPDIR).toBe(tempDir)
+    expect(launch.env.CLAUDE_CODE_TMPDIR).toBe(tempDir)
+    // The provider reads this one rather than recomputing the path from HOME.
+    expect(launch.env[SANDBOX_TEMP_DIR_ENV]).toBe(tempDir)
+    // Strictly inside the agent dir, which is what lets the boundary keep its rule unbroken.
+    expect(coveredBy([realpathSync(scopeDir)], tempDir)).toBe(true)
+    expect(tempDir).not.toBe(realpathSync(scopeDir))
+    if (process.platform !== 'win32') expect(statSync(tempDir).mode & 0o7777).toBe(0o700)
+    // An explicit SRT write root, which is what the provider requires of it.
+    expect(launch.sandbox!.writable).toContain(tempDir)
+    const settings = JSON.parse(readFileSync(launch.sandbox!.settingsPath, 'utf8'))
+    expect(settings.filesystem.allowWrite).toContain(tempDir)
+    expect(settings.filesystem.allowRead).toContain(tempDir)
+    // The shared temp roots stay denied — nothing about this change reopens them.
+    expect(coveredBy(settings.filesystem.denyRead, realpathSync('/tmp'))).toBe(true)
+    expect(settings.filesystem.allowRead).not.toContain(realpathSync('/tmp'))
+    // Every host of the agent gets its own, so one session's temp state is not another's.
+    expect(sandboxTempDirFor(scopeDir, agentHostKey('agent-1'))).not.toBe(sandboxTempDirFor(scopeDir, hostKey))
+  })
+
+  // A probe and a model enumerator launch against a disposable scope dir, so their temp directory is
+  // a child of the tree they already delete — nothing extra to release when the host stops.
+  it("keeps a disposable host's temp dir inside the scope its caller throws away", () => {
+    const scopeDir = mkdtempSync(join(tmpdir(), 'ac-probe-scope-'))
+    const cwd = join(scopeDir, 'workspace')
+    mkdirSync(cwd, { recursive: true })
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'claude-acp',
+      runtime: { command: 'npx', args: ['claude-agent-acp'], env: [] },
+      scopeDir,
+      cwd,
+      runInSandbox: true,
+      isolateHome: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      hostEnv: { HOME: scopeDir, PATH: '/usr/bin' }
+    })
+    expect(coveredBy([realpathSync(scopeDir)], launch.env.TMPDIR!)).toBe(true)
+    rmSync(scopeDir, { recursive: true, force: true })
+    expect(existsSync(launch.env.TMPDIR!)).toBe(false)
+  })
+
+  it('leaves an unconfined launch on the host temp dir', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'maki',
+      scopeDir,
+      cwd,
+      runInSandbox: false,
+      isolateHome: true,
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin', TMPDIR: '/tmp' }
+    })
+    expect(launch.env.TMPDIR).toBe('/tmp')
+    expect(launch.env[SANDBOX_TEMP_DIR_ENV]).toBeUndefined()
   })
 
   it('fails before creating a private HOME when sandboxing is required but unavailable', () => {

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { tmpdir } from 'node:os'
-import { basename, join } from 'node:path'
+import { basename, join, relative, resolve, sep } from 'node:path'
 import { execFileSync, spawn } from 'node:child_process'
 import { createServer } from 'node:net'
 import { createRequire } from 'node:module'
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url'
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
@@ -23,8 +24,16 @@ import {
   SandboxError,
   detectSandbox,
   probeSandboxHost,
+  removeHostSandboxState,
   writeSandboxSettings
 } from '../src/acp/sandbox.js'
+import {
+  AF_UNIX_PATH_MAX,
+  prepareSandboxTempDir,
+  reclaimStaleHostTempDirs,
+  sandboxTempDirFor
+} from '../src/acp/sandbox-temp.js'
+import { agentHostKey, hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 import { claudeInnerSandboxSettings } from '../src/runtime-defs/claude-runtime.js'
 import { clearConfigFiles, configFilesDir, materializeConfigFiles } from '../src/shim/config-file-env.js'
 
@@ -486,6 +495,153 @@ describe('Claude credential environment isolation', () => {
         else process.env[name] = value
       }
       rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+// #1763 made a confined session's runtime HOME a per-session directory, which pushed SRT's
+// multiplexer socket past the AF_UNIX cap and left every confined session-isolated agent unable
+// to start ("listen EINVAL"). A host's temp dir is a short leaf of the agent dir now, and a launch
+// whose socket would still not fit is refused where the path is visible.
+describe('sandbox temp directories', () => {
+  // SRT confines a host on Linux alone, so its 107 usable sun_path bytes are the budget. The socket
+  // name SRT composes is `srt-mux-<pid>-<n>.sock`, so a pid at the 22-bit ceiling is the widest one.
+  const SOCKET_NAME = 'srt-mux-4194304-0.sock'
+
+  const typicalAgentDir = '/home/ubuntu/.agentconnect/agents/review-bot'
+  const hostKey = sessionHostKey('review-bot', 'slack:C0123456789:1730000000.123456')
+
+  it("keeps a typical install's SRT socket inside the AF_UNIX limit, where the shape it replaced overflowed", () => {
+    const socket = join(sandboxTempDirFor(typicalAgentDir, hostKey), SOCKET_NAME)
+    expect(Buffer.byteLength(socket)).toBeLessThanOrEqual(AF_UNIX_PATH_MAX)
+    // The shape this replaced, on the SAME input: a temp dir under the session's own HOME overflows.
+    const underSessionHome = join(typicalAgentDir, 'sessions', hostKeyDirName(hostKey), 'home', '.tmp', SOCKET_NAME)
+    expect(Buffer.byteLength(underSessionHome)).toBeGreaterThan(AF_UNIX_PATH_MAX)
+  })
+
+  it('gives the agent host and each session host of one agent their own directory', () => {
+    const shared = sandboxTempDirFor(typicalAgentDir, agentHostKey('review-bot'))
+    const first = sandboxTempDirFor(typicalAgentDir, sessionHostKey('review-bot', 'session-a'))
+    const second = sandboxTempDirFor(typicalAgentDir, sessionHostKey('review-bot', 'session-b'))
+    expect(new Set([shared, first, second]).size).toBe(3)
+    // Each is a two-segment leaf of the agent's own dir, so the agent-dir rule covers it with no exemption.
+    for (const dir of [shared, first, second]) {
+      expect(relative(resolve(typicalAgentDir), dir).split(sep)).toEqual(['t', expect.stringMatching(/^[0-9a-f]{8}$/)])
+    }
+  })
+
+  it('creates the directory 0700 under the agent dir and reuses it', () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'ac-temp-ok-'))
+    try {
+      const created = prepareSandboxTempDir(agentDir, hostKey)
+      expect(created).toBe(realpathSync(sandboxTempDirFor(agentDir, hostKey)))
+      expect(existsSync(created)).toBe(true)
+      expect(prepareSandboxTempDir(agentDir, hostKey)).toBe(created)
+      if (process.platform !== 'win32') {
+        expect(statSync(created).mode & 0o7777).toBe(0o700)
+        expect(statSync(join(realpathSync(agentDir), 't')).mode & 0o7777).toBe(0o700)
+      }
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  // The honest cost of living in the agent dir: this is short, not bounded. A deep enough daemon
+  // root plus a long agent name still overflows, and the launch has to say so — the alternative is
+  // the opaque `listen EINVAL` three ACP start attempts deep that #1763 shipped.
+  it('refuses a launch whose SRT socket would not fit, naming the limit and the path', () => {
+    // The system temp dir is deep on macOS; this case needs room for a FITTING path beside the overflowing one.
+    const root = realpathSync(mkdtempSync(join(process.platform === 'win32' ? tmpdir() : '/tmp', 'ac-t-')))
+    const budget = AF_UNIX_PATH_MAX - Buffer.byteLength(join(sandboxTempDirFor(root, hostKey), SOCKET_NAME))
+    try {
+      const tooDeep = join(root, 'a'.repeat(budget))
+      mkdirSync(tooDeep, { recursive: true })
+      expect(() => prepareSandboxTempDir(tooDeep, hostKey, 'linux')).toThrow(
+        new RegExp(`${SOCKET_NAME}" is \\d+ bytes and the limit is ${AF_UNIX_PATH_MAX}`)
+      )
+      // Refused before the leaf exists, so a retry on a shorter root is not left a stale directory.
+      expect(existsSync(sandboxTempDirFor(tooDeep, hostKey))).toBe(false)
+      // One byte shorter fits, so what the refusal measures is the budget and not the fixture.
+      const fits = join(root, 'a'.repeat(budget - 1))
+      mkdirSync(fits, { recursive: true })
+      expect(existsSync(prepareSandboxTempDir(fits, hostKey, 'linux'))).toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it.skipIf(process.platform === 'win32')('refuses a symlink standing in for the temp parent', () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'ac-temp-link-'))
+    try {
+      const elsewhere = join(agentDir, 'elsewhere')
+      mkdirSync(elsewhere)
+      symlinkSync(elsewhere, join(agentDir, 't'))
+      expect(() => prepareSandboxTempDir(agentDir, hostKey)).toThrow(/not a real directory inside the agent dir/)
+      // And nothing was written through the link.
+      expect(existsSync(join(elsewhere, basename(sandboxTempDirFor(agentDir, hostKey))))).toBe(false)
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  // `t` is a short name, not a reserved one: an agent's `workspace.path` resolves under the agent dir
+  // too, so an operator may already have data — a whole workspace — at exactly that path. Ownership is
+  // proven by the marker this daemon writes when it creates the parent, never assumed from the name.
+  it('refuses a temp root this daemon did not create, and never reclaims anything under it', () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'ac-temp-own-'))
+    try {
+      // A workspace that happens to live at `<agentDir>/t`, holding a name that looks like a leaf.
+      const workspace = join(agentDir, 't')
+      const precious = join(workspace, 'deadbeef')
+      mkdirSync(precious, { recursive: true })
+      writeFileSync(join(workspace, 'README.md'), 'operator data')
+
+      expect(() => prepareSandboxTempDir(agentDir, hostKey)).toThrow(/this daemon did not create it/)
+      expect(reclaimStaleHostTempDirs(agentDir)).toEqual([])
+      expect(existsSync(precious)).toBe(true)
+      expect(existsSync(join(workspace, 'README.md'))).toBe(true)
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  it('reclaims only the leaves of a temp root it owns', () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'ac-temp-sweep-'))
+    try {
+      const live = prepareSandboxTempDir(agentDir, hostKey)
+      const parent = join(realpathSync(agentDir), 't')
+      const stranger = join(parent, 'not-a-leaf')
+      mkdirSync(stranger)
+
+      expect(reclaimStaleHostTempDirs(agentDir)).toEqual([basename(live)])
+
+      expect(existsSync(live)).toBe(false)
+      // The parent, its ownership marker and anything that is not a leaf survive.
+      expect(existsSync(parent)).toBe(true)
+      expect(existsSync(stranger)).toBe(true)
+      expect(readdirSync(parent).sort()).toEqual(['.agentconnect-runtime-temp', 'not-a-leaf'])
+      // Idempotent: a second boot finds nothing left to reclaim.
+      expect(reclaimStaleHostTempDirs(agentDir)).toEqual([])
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
+    }
+  })
+
+  it("retires a stopped host's policy directory and its temp directory together", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), 'ac-agent-teardown-'))
+    const stoppedHost = sessionHostKey('agent-1', 'session-a')
+    try {
+      const settingsPath = writeSandboxSettings(agentDir, hostKeyDirName(stoppedHost), {
+        writable: [join(agentDir, 'workspace')],
+        denyRead: [agentDir],
+        allowRead: [join(agentDir, 'workspace')]
+      })
+      const tempDir = prepareSandboxTempDir(agentDir, stoppedHost)
+      removeHostSandboxState(agentDir, stoppedHost)
+      expect(existsSync(settingsPath)).toBe(false)
+      expect(existsSync(tempDir)).toBe(false)
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true })
     }
   })
 })


### PR DESCRIPTION
## The bug

Since #1763 gave a confined session its own runtime HOME, **no sandboxed session-isolated agent could start its ACP host at all**. Every launch failed three attempts with `ACP connection closed`; the real error one line earlier was `listen EINVAL: invalid argument` on `<daemon root>/agents/<agent>/sessions/session-<24 hex>/home/.tmp/srt-mux-<pid>-0.sock`.

The provider set `TMPDIR` to `<private HOME>/.tmp`, and SRT opens its multiplexer at `<TMPDIR>/srt-mux-<pid>-<n>.sock` — a name its own source comments as "keep it short", because it assumes `TMPDIR` is short.

The arithmetic:

| piece | bytes |
| --- | --- |
| `/srt-mux-<pid>-<n>.sock` | 23 |
| `/sessions/session-<24 hex>/home/.tmp` | 52 |
| Linux `sun_path` budget | 107 usable |
| left for `<daemon root>/agents/<agent>` | **32** |

No realistic install fits a daemon root plus an agent name in 32 bytes, so `bind()` returned EINVAL for every confined session host. This is not a marginal case.

The managed pool is unaffected: its mount is `/workspace`, so the whole socket path is ~85 bytes and fits. The fragility also pre-dates #1763 in a milder form — the agent host's `<agentDir>/home/.tmp` already breaks once the agent name is ~35 characters.

## The fix

The temp directory becomes one short leaf of the agent directory, one per host:

```
<agentDir>/t/<8 hex>/srt-mux-<pid>-0.sock
```

The win is dropping `sessions/session-<24 hex>/home/.tmp` (52 bytes) for `t/<8 hex>` (11). A typical install — `/home/ubuntu/.agentconnect/agents/review-bot` — lands at about 82 bytes against the broken shape's 124. The 8 hex digest is over the host key, so the agent host and each session host get their own directory.

**The daemon decides the path.** `prepareRuntimeLaunch` composes and creates it, adds it to the sandbox's writable roots, and passes it in the launch env. The provider uses that path and keeps its existing guard — the temp root must be an explicit SRT write root — instead of recomputing it from `HOME`.

**No boundary exemption.** The directory is inside the agent dir like every other writable root, so `sandboxBoundary`'s "every writable root is strictly inside the agent dir" rule is untouched. The temp parent is resolved and required to be a real directory before anything is created under it, so a link standing in for `<agentDir>/t` cannot move the tree out of the agent dir.

**Policy.** `/tmp` and `/var/tmp` stay in `denyRead`; the host's own directory is carved back into `allowRead` + `allowWrite` exactly as the private HOME is.

**Lifetime.** The directory is dropped alongside the host's SRT policy directory at every place a host's process is already known to be gone (`releaseHostLaunch`, the failed-start path, `stopHost`, and both dream-host paths), via one `removeHostSandboxState`. A probe or model enumerator launches against a disposable scope directory, so its temp dir is a child of the tree the caller already deletes — on the success path and on every failure path — and needs no separate release.

**Ownership is proven, never inferred from the name.** `t` is short, not reserved: `workspace.path` is an arbitrary string that `load-agents.ts` resolves directly under the agent directory, so a valid existing agent may already have a whole workspace at `<agentDir>/t`. The daemon therefore writes a marker file when it *creates* the temp root; a launch against a root it did not create is refused with an error naming the path, and the boot sweep removes only the `<8 hex>` leaves of a root carrying that marker — never the parent, never the marker, and nothing whatsoever under a directory that is someone else's. Two tests cover it, at unit level and through a real daemon start.

`CLAUDE_CODE_TMPDIR` and `CLAUDE_TMPDIR` follow `TMPDIR`. A launch in a sandbox pod does not get any of this: the pod supplies its own temp dir and the daemon must not name a path on a machine it is not on.

## The ceiling, stated plainly

**This shape is short, not bounded by construction.** A daemon root plus an agent name over roughly 75 bytes combined still overflows `sun_path`. That is the accepted cost of keeping the directory inside the agent dir; the alternative — a per-host directory in the system temp dir — is immune by construction but needs ownership/mode/symlink hardening, a pid-tagged leaf, a liveness probe and a sweep that can tell an abandoned directory from a concurrent daemon's live one, all of it existing only because `/tmp` is shared and world-writable. That was judged too much machinery for what it buys.

So the overflow becomes an **actionable failure instead of a silent one**. `prepareSandboxTempDir` computes the worst-case socket path for the host being launched and, if it would exceed the platform limit, refuses the launch naming the path, its byte count and the limit:

```
runtime temp dir is too deep for its SRT socket: "<path>" is 114 bytes and the
limit is 107 — shorten the daemon root or the agent name
```

That is strictly better than today, where the same situation dies as an opaque `listen EINVAL` three ACP retries deep with nothing pointing at path length — and the check also covers the pre-existing `<agentDir>/home/.tmp` ceiling, which an agent name of about 35 characters already crossed. SRT confines a host on Linux alone, so the budget is Linux's 107 and the check is scoped to it (with the platform as a test seam, as the shared-credential platform already is).

## The old temp location is deliberately NOT reclaimed here

Nothing ever collected `<runtime HOME>/.tmp`. One observed on a long-running daemon had reached tens of GB across ~37k entries — leftover `claude-http-*.sock` and `srt-mux-*.sock` files, and thousands of shell scratch files, several of them multi-GB. This change stops that growing: no confined host writes there any more.

An earlier revision also deleted those trees at boot. It is gone, because it could not prove what it was deleting. The same `workspace.path` resolution that can put a workspace at `<agentDir>/t` can put one at `home/.tmp`, and "the name looks like the old temp dir" is not ownership — no marker was ever written there, so there is nothing to check. Deleting an operator's data would be a far worse bug than the one this PR fixes, so the historical piles stay until a change that can prove ownership of them reclaims them. Operators who want the space back today can remove `<agent dir>/home/.tmp` while the daemon is stopped.

## What else shares the hazard

Nothing. `skills/offline-sandbox.ts`, `skills-cli-cell.ts` and `skill-workspace-mutator.ts` all run the same provider, but each already roots its private HOME in a short `mkdtemp` under the system temp dir — `skills-cli-cell.ts` even carries a comment naming this exact AF_UNIX cap — so their socket paths land at 69–82 bytes. They keep the private-HOME temp they have (the provider falls back to it when the daemon passed nothing), which leaves them byte-identical to today. `skill-git-source.ts` sets `TMPDIR` for plain `git`, which opens no socket.

## Non-sandboxed launches

Unaffected: the temp env is set only on the sandbox path, and a covering test asserts an unconfined launch still inherits the host `TMPDIR`.

## Verified

Unit level only — no live host was exercised.

- The composed socket path stays inside the AF_UNIX budget for a typical install, and the shape it replaced overflows on the same input.
- The budget refusal names the socket, its byte count and the limit; one byte shorter is accepted, so what it measures is the budget and not the fixture.
- The temp dir is strictly inside the agent dir, is an explicit SRT write root, and appears in the emitted settings' `allowRead`/`allowWrite`, while `/tmp` stays denied and is not carved back.
- A disposable (probe/enumerator) host's temp dir disappears with the scope its caller deletes.
- The agent host and each session host of one agent get different directories; a symlink standing in for the temp parent is refused; a stopped host's policy directory and temp directory retire together.
- A temp root this daemon did not create is refused at launch and reclaimed from not at all — an agent whose workspace resolves to that name keeps every byte, asserted both as a unit and through a real daemon start. The sweep removes only `<8 hex>` leaves and leaves the parent, the marker and any other entry alone.
- Mutation-checked: restoring the deep pre-fix shape turned **7** cases red; letting a launch's temp dir escape its scope turned **2**; dropping the ownership proof from the sweep turned **2**; removing the parent instead of matching leaves turned **2**; adopting an existing temp root instead of failing closed turned **1**; and dropping the budget check, the temp-parent symlink guard, the teardown, or the boot call each turned exactly **1**.
- `tsc -p tsconfig.typecheck.json --noEmit`, prettier, eslint, and the `sandbox`, `runtime-launch`, `daemon-lifecycle`, `daemon-session-hosts`, `runtime-home`, `runtime-prober`, `skills-cli-cell`, `skill-workspace-mutator`, `daemon-source-hygiene`, `windows-exclusions`, `no-stray-vi-mock`, `acp-config` and `reconcile-watch` suites: 308 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
