### PR TITLE
refactor(daemon): drop the retired model-authored session-title tool

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -69,7 +69,7 @@ import { TerminalOutputFolder } from './session/terminal-output-folder.js'
 import { attachmentMention, sniffImageMimeType } from './session/attachment-block.js'
 import { McpControlServer } from './mcp/control-server.js'
 import { RemoteWebchatGrantManager } from './mcp/remote-webchat-grant.js'
-import type { CodeHostEffectReq, SessionContext, SetSessionTitleReq } from './mcp/ops.js'
+import type { CodeHostEffectReq, SessionContext } from './mcp/ops.js'
 import { GitCredentialCache } from './cp/git-credential.js'
 import { GitlabBroker } from './gitlab/broker.js'
 import { gitlabApiBaseUrl } from './gitlab/api-base.js'
@@ -101,7 +101,6 @@ import { resolveAgentMcpServers, RESERVED_MCP_SERVER_NAME } from './mcp/resolve-
 import { toolsForIntegrations, CODE_HOST_EFFECT_TOOLS, GITHUB_REVIEW_TOOLS, KNOWLEDGE_TOOLS } from './mcp/tools.js'
 import { MEMORY_TOOL_NAMES, MEMORY_TOOLS } from './memory/tools.js'
 import { DREAM_TOPIC_RE, MAX_DREAM_FILES } from './dream/dreamer.js'
-import { isSessionTitleToolCall } from './mcp/session-title-tool.js'
 import { MEMORY_DISTILLATION_SYSTEM_PROMPT, readOnlyExtractionMode } from './memory/distill.js'
 import { CLAUDE_HEADLESS_DISALLOWED_TOOLS } from './runtime-defs/claude-runtime.js'
 import {
@@ -2523,7 +2522,6 @@ export class Daemon {
       log: this.log,
       now: () => Date.now(),
       canRun: (ctx) => this.toolTurnRunnable(ctx),
-      setSessionTitle: (req) => this.setSessionTitleFromTool(req),
       gatewayFor: (integrationId) => this.connForIntegration(integrationId),
       // A platform's own session tools act through ANY platform's connection — including the one
       // the reply-surface registry above omits (Linear, §4.6).
@@ -2924,10 +2922,6 @@ export class Daemon {
       // The session integration's own bot identity (auth.test-resolved on both
       // socket and send-only connections) for the `# Agent` Slack-identity line.
       slackBotUserIdFor: (integrationId) => this.connByIntegration.get(integrationId)?.botUserId || undefined,
-      // No runtime is whitelisted for the model-authored `setSessionTitle` fallback
-      // anymore: codex-acp >= 1.1.3 emits native session_info_update titles itself
-      // (issue #659), so every runtime now relies on its native ACP title path. The
-      // ingress side (MCP handler + event hiding) stays for warm pre-upgrade sessions.
       // Same runtime-def env base the spawn path merges under the agent env, so
       // the standing-context config-file description matches what materialized.
       runtimeEnvFor: (runtimeId) =>
@@ -11081,7 +11075,6 @@ export class Daemon {
         runtimeCostReported: false
       },
       builtinSystemToolCallIds: new Set(),
-      hiddenSessionTitleToolCallIds: new Set(),
       acpSessionId: sessionId,
       outwardSessionId,
       ...(entry.selectedHost ? { selectedHost: entry.selectedHost } : {}),
@@ -13555,41 +13548,6 @@ export class Daemon {
     }
   }
 
-  /** MCP callback for the legacy model-authored title fallback. New sessions no
-   *  longer receive the tool (codex-acp >= 1.1.3 emits native titles — issue #659),
-   *  but warm ACP sessions created under the old Codex whitelist retain it for
-   *  their lifetime. The tool input contains only the title; every coordinate and
-   *  delivery route was captured in the trusted SessionContext. */
-  private async setSessionTitleFromTool(req: SetSessionTitleReq): Promise<void> {
-    const key = sessionKey(req.platform, req.channel, req.thread, req.agentId, req.transportScope)
-    const rec = await this.store.getSession(key)
-    if (!rec?.acpSessionId) throw new Error('the current session is not addressable yet')
-
-    // MCP tokens are session-static, while an integration can rotate between warm
-    // turns. Prefer the exact route installed by the current dispatch; use the token
-    // binding only as a defensive fallback for non-dispatch callers.
-    const binding: SessionDeliveryBinding = this.sessionDeliveryBindings.get(key) ?? {
-      agentId: req.agentId,
-      platform: req.platform,
-      ...(req.integrationId !== undefined ? { integrationId: req.integrationId } : {}),
-      isDm: req.isDm
-    }
-    await this.persistSessionTitle(rec, req.title)
-
-    const p = this.pending.get(pendingTurnKey(this.sessionOwnerKey(rec.agentId, rec.key), rec.acpSessionId))
-    if (p && p.plan.sessionKey === key && !p.outputSuppressed) {
-      if (p.webchat) {
-        webchatTurnOutput.emitWebchatUpdate(p.webchat, { sessionUpdate: 'session_info_update', title: req.title })
-      }
-      if (turnChromeFor(p.plan.platform).sessionTitle && p.conn) {
-        this.enqueueApply(p, { kind: 'set-title', text: req.title })
-        await p.signals.applyChain
-        return
-      }
-    }
-    await this.setSlackTitleForBinding(rec, binding, req.title)
-  }
-
   /** One ACP session's updates stay in arrival order: the async store would otherwise let
    *  a later update whose handler does less I/O emit ahead of an earlier one. */
   private enqueueAcpUpdate(owner: HostKey, sessionId: string, update: unknown): Promise<void> {
@@ -13802,12 +13760,6 @@ export class Daemon {
         p.reply.text += text
       }
     }
-    // `setSessionTitle` is daemon housekeeping, not conversational activity. Codex
-    // ACP reports it as an ordinary MCP tool_call, followed by title-less updates
-    // keyed only by toolCallId. Remember the id from the structured first event and
-    // drop the whole burst before any platform renderer, live webchat stream, GitHub
-    // collector, or persisted transcript sees it. The tool callback independently
-    // persists and streams the resulting session_info_update.
     // codex-acp streams a shell command's output as `_meta.terminal_output_delta` chunks and
     // completes the call with an empty `formatted_output` — fold the buffered text back into
     // the terminal update HERE, before any consumer, so the transcript (web console), the
@@ -13815,11 +13767,6 @@ export class Daemon {
     update = p.termOut.fold(update)
     const toolCallId = typeof update?.toolCallId === 'string' ? update.toolCallId : ''
     if (toolCallId && isBuiltinSystemToolCall(update)) p.builtinSystemToolCallIds.add(toolCallId)
-    if (isSessionTitleToolCall(update)) {
-      if (toolCallId) p.hiddenSessionTitleToolCallIds.add(toolCallId)
-      return
-    }
-    if (toolCallId && p.hiddenSessionTitleToolCallIds.has(toolCallId)) return
     // Select the complete GitHub final in memory. Do not write any GitHub comment here:
     // the prompt (and every agent-side tool call) must finish before publish() performs
     // the first and only public POST.

--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -565,10 +565,6 @@ export interface Pending {
   /** Tool-call ids structurally identified as this daemon's own MCP tools. Approval
    *  requests may carry only this opaque id, regardless of which ACP path is used. */
   builtinSystemToolCallIds: Set<string>
-  /** Tool-call ids for the internal Codex title fallback. Its MCP call updates the
-   *  session metadata, but housekeeping must not appear in platform/webchat output
-   *  or the persisted user-visible activity log. */
-  hiddenSessionTitleToolCallIds: Set<string>
   /** Bounded fingerprint of the prompt text this turn sent, for recognizing a runtime
    *  fallback title that is only that prompt read back (session/derive-title.ts). */
   promptEchoPrefix?: string

--- a/packages/daemon/src/evaluation/daemon-hooks.ts
+++ b/packages/daemon/src/evaluation/daemon-hooks.ts
@@ -162,7 +162,7 @@ export class DaemonEvaluationHooks {
     if (registryTools.length > 0) {
       // The COMPLETE stable product namespace, not just what this composition
       // happens to request: `executeTool` dispatches evaluation tools BEFORE the
-      // product handlers, so a name it never composes (e.g. `setSessionTitle`,
+      // product handlers, so a name it never composes (e.g. `viewSessionStatus`,
       // which `executeTool` handles directly) would still be shadowed. Only a
       // full-registry check makes "never shadow a product tool" exact.
       const productNames = new Set<string>(ALL_TOOL_NAMES)

--- a/packages/daemon/src/mcp/ops.ts
+++ b/packages/daemon/src/mcp/ops.ts
@@ -116,13 +116,7 @@ import {
   READ_ATTACHMENT_ARGS,
   type PlatformReadDeps
 } from './ops/platform-reads.js'
-import {
-  setSessionTitle,
-  SET_SESSION_TITLE_ARGS,
-  viewSessionStatus,
-  VIEW_SESSION_STATUS_ARGS,
-  type SessionOpsDeps
-} from './ops/session.js'
+import { viewSessionStatus, VIEW_SESSION_STATUS_ARGS, type SessionOpsDeps } from './ops/session.js'
 
 export type { McpContentResult, MessageGateway, SendIdentity, SessionContext } from './ops/context.js'
 export type { ChannelAgentsRequest } from './ops/directory.js'
@@ -141,7 +135,7 @@ export type {
   StartOrchestrationReq,
   StartOrchestrationResult
 } from './ops/orchestration.js'
-export type { SessionStatusReq, SessionStatusResult, SetSessionTitleReq } from './ops/session.js'
+export type { SessionStatusReq, SessionStatusResult } from './ops/session.js'
 
 /**
  * Everything the daemon bridge tools need, composed from the per-domain deps each
@@ -189,7 +183,6 @@ export interface OpsDeps
  * the daemon itself, or resolves its own target gateway from the trusted session snapshot.
  */
 const HANDLERS: Map<string, ToolHandler<OpsDeps>> = new Map<string, ToolHandler<OpsDeps>>([
-  ['setSessionTitle', setSessionTitle],
   ['shareFile', shareFile],
   ['viewSessionStatus', viewSessionStatus],
   ['readMemory', readMemory],
@@ -251,7 +244,6 @@ const HANDLERS: Map<string, ToolHandler<OpsDeps>> = new Map<string, ToolHandler<
  * lives in {@link SEND_MESSAGE_BRANCHES} instead.
  */
 export const TOOL_ARG_SCHEMAS: Map<string, ZodType> = new Map<string, ZodType>([
-  ['setSessionTitle', SET_SESSION_TITLE_ARGS],
   ['viewSessionStatus', VIEW_SESSION_STATUS_ARGS],
   ['readMemory', READ_MEMORY_ARGS],
   ['writeMemory', WRITE_MEMORY_ARGS],

--- a/packages/daemon/src/mcp/ops/session.ts
+++ b/packages/daemon/src/mcp/ops/session.ts
@@ -1,30 +1,9 @@
 import { z } from 'zod'
-import type { McpContentResult, SessionContext } from './context.js'
+import type { SessionContext } from './context.js'
 import { parseArgs, requiredString } from './args.js'
-
-/** `setSessionTitle` arguments: whitespace is collapsed before the 80-character cap is applied. */
-export const SET_SESSION_TITLE_ARGS = z.object({
-  title: requiredString('title')
-    .transform((title) => title.replace(/\s+/g, ' ').trim())
-    .refine((title) => title.length > 0, 'missing required string argument: title')
-    .refine((title) => [...title].length <= 80, 'session title must be at most 80 characters')
-})
 
 /** `viewSessionStatus` arguments: the child session id is the only model input. */
 export const VIEW_SESSION_STATUS_ARGS = z.object({ sessionId: requiredString('sessionId') })
-
-/** A trusted session-title update. Every coordinate comes from the registered
- *  session context; the model supplies only `title`. */
-export interface SetSessionTitleReq {
-  agentId: string
-  platform: string
-  integrationId?: string
-  transportScope?: string
-  isDm: boolean
-  channel: string
-  thread: string
-  title: string
-}
 
 /**
  * A trusted request to read the status of a session the caller STARTED. Everything except
@@ -71,10 +50,8 @@ export interface SessionStatusResult {
   updatedAt?: number
 }
 
-/** The session-lifecycle deps: name a session, and read the progress of one it started. */
+/** The session-lifecycle deps: read the progress of a session this one started. */
 export interface SessionOpsDeps {
-  /** Persist and fan out a model-authored user-facing session title. */
-  setSessionTitle: (req: SetSessionTitleReq) => Promise<void> | void
   /** Read the progress of a session the caller started (backs `viewSessionStatus`). The daemon
    *  fills the trusted caller identity from the session context and authorizes `sessionId`
    *  against the caller's own children, fail-closed. Returns null when the id is unknown or is
@@ -84,35 +61,6 @@ export interface SessionOpsDeps {
   viewSessionStatus?: (req: SessionStatusReq) => Promise<SessionStatusResult | null>
 }
 
-// Session naming is daemon-local and platform-neutral. SECURITY: the model
-// contributes only the title; all routing coordinates come from the trusted
-// token-bound SessionContext.
-export async function setSessionTitle(
-  ctx: SessionContext,
-  args: Record<string, unknown>,
-  deps: SessionOpsDeps
-): Promise<unknown> {
-  const { title } = parseArgs(SET_SESSION_TITLE_ARGS, args)
-  await deps.setSessionTitle({
-    agentId: ctx.agentId,
-    platform: ctx.platform,
-    ...(ctx.integrationId !== undefined ? { integrationId: ctx.integrationId } : {}),
-    ...(ctx.transportScope !== undefined ? { transportScope: ctx.transportScope } : {}),
-    isDm: ctx.isDm,
-    channel: ctx.channel,
-    thread: ctx.thread,
-    title
-  })
-  // Empty native content avoids rendering a redundant tool-result body. The ACP
-  // tool activity itself remains observable in the session transcript.
-  const result: McpContentResult = { mcpContent: [] }
-  return result
-}
-
-// Read the progress of a session THIS session started (session-concept §5.3, the read
-// counterpart of a SessionTarget reply). SECURITY: the caller identity + coords come from the
-// trusted session context; `sessionId` is the only tool input and the daemon authorizes it
-// against the caller's own children — an agent cannot inspect an arbitrary session.
 export async function viewSessionStatus(
   ctx: SessionContext,
   args: Record<string, unknown>,

--- a/packages/daemon/src/mcp/session-title-tool.ts
+++ b/packages/daemon/src/mcp/session-title-tool.ts
@@ -1,27 +1,8 @@
 import { RESERVED_MCP_SERVER_NAME } from '@agentconnect.md/protocol'
 
-export const SESSION_TITLE_TOOL_NAME = 'setSessionTitle'
+/** Transcript titles of the retired model-authored `setSessionTitle` tool call. No live session
+ *  can produce one anymore; the store still hides rows recorded while the tool existed. */
 export const SESSION_TITLE_TOOL_TITLES = [
-  `mcp.${RESERVED_MCP_SERVER_NAME}.${SESSION_TITLE_TOOL_NAME}`,
-  `mcp__${RESERVED_MCP_SERVER_NAME}__${SESSION_TITLE_TOOL_NAME}`
+  `mcp.${RESERVED_MCP_SERVER_NAME}.setSessionTitle`,
+  `mcp__${RESERVED_MCP_SERVER_NAME}__setSessionTitle`
 ] as const
-
-const SESSION_TITLE_TOOL_TITLE_SET = new Set<string>(SESSION_TITLE_TOOL_TITLES)
-
-/**
- * True when a Codex ACP tool event is the daemon's session-title fallback. codex-acp
- * exposes MCP identity structurally in rawInput and currently titles the event
- * `mcp.<server>.<tool>`; the exact-title fallbacks cover older adapter renderings
- * without hiding a same-named tool from another MCP server.
- */
-export function isSessionTitleToolCall(update: unknown): boolean {
-  if (!update || typeof update !== 'object') return false
-  const u = update as { sessionUpdate?: unknown; rawInput?: unknown; title?: unknown }
-  if (u.sessionUpdate !== 'tool_call' && u.sessionUpdate !== 'tool_call_update') return false
-  const rawInput =
-    u.rawInput && typeof u.rawInput === 'object' ? (u.rawInput as { server?: unknown; tool?: unknown }) : undefined
-  return (
-    (rawInput?.server === RESERVED_MCP_SERVER_NAME && rawInput.tool === SESSION_TITLE_TOOL_NAME) ||
-    (typeof u.title === 'string' && SESSION_TITLE_TOOL_TITLE_SET.has(u.title))
-  )
-}

--- a/packages/daemon/src/mcp/tools.ts
+++ b/packages/daemon/src/mcp/tools.ts
@@ -1,6 +1,5 @@
 import type { Integration } from '../agents/agent-schema.js'
 import { obj, unionOf, type JsonValue, type ToolDescriptor } from '../tool-schema/descriptor.js'
-import { SESSION_TITLE_TOOL_NAME } from './session-title-tool.js'
 import {
   allAttachmentReadTools,
   allPortPlatforms,
@@ -12,37 +11,6 @@ import {
 } from '../platforms/read-ports.js'
 import { EXTERNAL_MEMORY_TOOL_NAMES, MEMORY_TOOLS } from '../memory/tools.js'
 import { BROKER_PIPELINE_STATUSES } from '../gitlab/broker.js'
-
-/**
- * Session metadata fallback tools. Opt-in via `toolsForIntegrations`'s
- * `sessionTitle` option; no production runtime opts in anymore — Codex was the
- * last, until codex-acp >= 1.1.3 started emitting native session_info_update
- * titles itself (issue #659). The descriptor and its MCP handler stay so warm
- * ACP sessions created under the old Codex whitelist keep working until they
- * cycle out.
- */
-export const SESSION_TOOLS: ToolDescriptor[] = [
-  {
-    name: SESSION_TITLE_TOOL_NAME,
-    description:
-      'Set the user-facing title for this AgentConnect session. Before your first substantive answer, after you ' +
-      'understand the first meaningful request (ignore greetings and acknowledgements), call this once with a ' +
-      'concise, specific title of about 3-8 words or a similarly short phrase. Call it again only if the task focus ' +
-      'materially changes. If the user asks what the title is, set the exact title you give them. Do not mention this ' +
-      'housekeeping call in your response.',
-    inputSchema: obj(
-      {
-        title: {
-          type: 'string',
-          minLength: 1,
-          maxLength: 80,
-          description: 'A concise, specific session title (maximum 80 characters).'
-        }
-      },
-      ['title']
-    )
-  }
-]
 
 /**
  * The single unified send tool (session-concept §3). It merges the former
@@ -1292,7 +1260,6 @@ export const CODE_HOST_EFFECT_TOOLS: ToolDescriptor[] = [
 export const ALL_TOOL_NAMES = [
   ...new Set(
     [
-      ...SESSION_TOOLS,
       // platform-neutral tools — descriptors are built per-agent, but the names
       // are stable and belong in the permission auto-allow set.
       buildSendMessageTool([]),
@@ -1327,15 +1294,14 @@ export const ALL_TOOL_NAMES = [
 
 /**
  * The default MCP tool set for an agent. Memory and collaboration tools are
- * always present; the session-title fallback is opt-in for whitelisted runtimes,
- * and platform tools are gated by the agent's integrations. The channel/user
+ * always present; platform tools are gated by the agent's integrations. The channel/user
  * read helpers are platform-neutral (one set, routed by a `platform` argument);
  * only the per-platform file-read tools are gated per platform — and that gate
  * is a declared Layer-1 read port, not a platform name.
  */
 export function toolsForIntegrations(
   integrations: Integration[],
-  options: { sessionTitle?: boolean; organizationKnowledge?: boolean; currentPlatform?: string } = {}
+  options: { organizationKnowledge?: boolean; currentPlatform?: string } = {}
 ): ToolDescriptor[] {
   const tools: ToolDescriptor[] = []
   const seen = new Set<string>()
@@ -1346,7 +1312,6 @@ export function toolsForIntegrations(
       tools.push(t)
     }
   }
-  if (options.sessionTitle) add(SESSION_TOOLS)
   add(MEMORY_TOOLS)
   if (options.organizationKnowledge) add(KNOWLEDGE_TOOLS)
   add(COLLABORATION_TOOLS)

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -226,9 +226,6 @@ export class SessionManager {
        *  cannot tell that a multi-mention message addresses it — the
        *  response-choice rule then misfires into AC_NO_RESPONSE. */
       slackBotUserIdFor?: (integrationId: string) => string | undefined
-      /** Whether this runtime needs AgentConnect's model-authored title fallback.
-       *  Native-title runtimes (for example Claude) leave this false. */
-      usesSessionTitleTool?: (agent: Agent) => boolean
       /** The runtime-definition env (daemon config `runtimes[].env`) for an agent's
        *  runtime. The spawn path detects config-file pointer-var conflicts over
        *  `{...runtimeEnv, ...agentEnv}` — supply the same base here so the
@@ -376,7 +373,6 @@ export class SessionManager {
   }> {
     const agent = this.deps.agentById(agentId)
     if (!agent) throw new Error(`unknown agent ${agentId}`)
-    const usesSessionTitleTool = this.deps.usesSessionTitleTool?.(agent) ?? false
     const memoryEnabled = this.deps.memoryEnabled !== false
     const currentMemoryProvider = memoryEnabled ? memoryKindOf(agent) : 'none'
     // The memory scope for this turn — the per-channel folder for a channel-scoped
@@ -591,7 +587,6 @@ export class SessionManager {
           // The same list `additionalWorkspaceDirectories` hands the runtime, read from the same
           // accessor, so the prompt names exactly the directories the session got.
           workspaceRoots: await this.workspaces.sessionAdditionalRoots(agent, workspaceRequest),
-          usesSessionTitleTool,
           needsReplyToParent,
           memoryIndex,
           usesMeta,

--- a/packages/daemon/src/session/turn/standing-context.ts
+++ b/packages/daemon/src/session/turn/standing-context.ts
@@ -66,7 +66,6 @@ export type StandingContextInput = {
   fileSecrets: readonly StandingContextFileSecret[]
   /** The workspace roots this session is handed as additional directories, beside its own cwd. */
   workspaceRoots?: readonly { path: string; repoFullName: string; branch: string }[]
-  usesSessionTitleTool: boolean
   needsReplyToParent: boolean
   /** The agent memory INDEX, already read and trimmed; '' for native/absent memory. */
   memoryIndex: string
@@ -192,15 +191,6 @@ function buildAgentMeta(input: StandingContextInput): string {
                   `report only whether the file exists, never what it contains.`
               ]
             : [])
-        ]
-      : []),
-    ...(input.usesSessionTitleTool
-      ? [
-          '',
-          '# Session naming',
-          'Before sending your first substantive answer, after you understand the first meaningful user request ' +
-            '(not a greeting or acknowledgement), call `setSessionTitle` with a concise, specific title. Call it ' +
-            'again only if the task focus materially changes. Do not mention this housekeeping action.'
         ]
       : [])
   ].join('\n')

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -228,9 +228,8 @@ export interface SessionRecord {
   // NULL on legacy rows / non-platform sessions). Display-name resolution is a
   // separate `display_names` lookup keyed by this id.
   triggeredBy?: string | null
-  // Human-facing session title supplied by an ingress when the session is
-  // created, by the runtime (ACP `session_info_update`), or by AgentConnect's
-  // `setSessionTitle` tool. Later runtime/tool updates win.
+  // Human-facing session title: the ingress title (or the first-message fallback) the
+  // session is born with, then whatever the runtime pushes (ACP `session_info_update`).
   title?: string | null
   // Platform-native link to the source message/thread. First non-null wins so
   // later messages in the same logical session cannot move the title link.

--- a/packages/daemon/src/webchat/turn-output.ts
+++ b/packages/daemon/src/webchat/turn-output.ts
@@ -81,8 +81,8 @@ export function emitWebchatUpdate(wc: WebchatTurnOutput, update: any): void {
       return
     }
     case 'session_info_update': {
-      // The runtime's auto-generated title (already persisted via setSessionTitle
-      // above). Stream it so the live playground session renames in place. Slack
+      // The runtime's auto-generated title (already persisted by the update handler).
+      // Stream it so the live playground session renames in place. Slack
       // app-DM threads are updated independently through setTitle above. Only a
       // non-empty set is streamed; a null/clear leaves the client's fallback label
       // untouched.

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -45,8 +45,8 @@ describe('isBuiltinSystemTool — auto-approve the daemon’s own MCP tools', ()
   it('matches the FQN wherever the runtime puts it (title / kind / toolCallId)', () => {
     expect(isBuiltinSystemTool(req({ kind: 'mcp__agentconnect__sendMessage' }))).toBe(true)
     expect(isBuiltinSystemTool(req({ toolCallId: 'mcp__agentconnect__sendMessage-42' }))).toBe(true)
-    expect(isBuiltinSystemTool(req({ title: 'mcp.agentconnect.setSessionTitle' }))).toBe(true)
-    expect(isBuiltinSystemTool(req({ title: 'please run mcp.agentconnect.setSessionTitle' }))).toBe(false)
+    expect(isBuiltinSystemTool(req({ title: 'mcp.agentconnect.viewSessionStatus' }))).toBe(true)
+    expect(isBuiltinSystemTool(req({ title: 'please run mcp.agentconnect.viewSessionStatus' }))).toBe(false)
   })
 
   it('matches an opaque id only after a trusted tool event correlated it', () => {
@@ -111,7 +111,6 @@ function elicitation(toolCallId: string, overrides: Record<string, unknown> = {}
 function installPending(daemon: Daemon): {
   plan: { platform: string; approvalSurfaceSuppressed: boolean }
   builtinSystemToolCallIds: Set<string>
-  hiddenSessionTitleToolCallIds: Set<string>
 } {
   ;(daemon as any).store = {
     getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
@@ -134,7 +133,6 @@ function installPending(daemon: Daemon): {
     signals: { applyChain: Promise.resolve() },
     approval: { waitMs: 0, depth: 0 },
     builtinSystemToolCallIds: new Set<string>(),
-    hiddenSessionTitleToolCallIds: new Set<string>(),
     conv: { onUpdate: () => [], hasBuffered: () => false },
     rec: { onUpdate: () => [] },
     termOut: new TerminalOutputFolder()

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -821,7 +821,7 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     await daemon.stop()
   })
 
-  it('fans out a model-authored title to the UI and Slack during the turn', async () => {
+  it('fans out a runtime title to the UI and Slack during the turn', async () => {
     const root = scaffold()
     let onUpdate!: (sid: string, update: unknown) => void
     const fakeHost = {
@@ -835,17 +835,9 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       }),
       hasSession: (id: string) => id === 'acp-tool-title',
       prompt: vi.fn(async () => {
-        await (daemon as any).setSessionTitleFromTool({
-          agentId: 'bot-a',
-          platform: 'slack',
-          // Simulate a session-static MCP token created before the integration
-          // rotated from A to the current dispatch route B.
-          integrationId: 'int-a',
-          isDm: true,
-          channel: 'D1',
-          thread: '205.1',
-          title: 'Fix session titles'
-        })
+        // The rename a runtime publishes mid-turn (codex-acp's generated title): it must
+        // reach the CURRENT dispatch route, not an integration the session once used.
+        onUpdate('acp-tool-title', { sessionUpdate: 'session_info_update', title: 'Fix session titles' })
         return { stopReason: 'end_turn' }
       }),
       cancel: vi.fn(),

--- a/packages/daemon/test/daemon-webchat.test.ts
+++ b/packages/daemon/test/daemon-webchat.test.ts
@@ -132,19 +132,6 @@ const toolUpdate = (toolCallId: string, status: string) => ({
   toolCallId,
   status
 })
-const sessionTitleToolCall = (toolCallId: string, status = 'in_progress') => ({
-  sessionUpdate: 'tool_call',
-  toolCallId,
-  kind: 'execute',
-  title: 'mcp.agentconnect.setSessionTitle',
-  status,
-  rawInput: {
-    server: 'agentconnect',
-    tool: 'setSessionTitle',
-    arguments: { title: 'Fix session title visibility' }
-  },
-  _meta: { is_mcp_tool_call: true }
-})
 const sessionInfo = (title: string | null) => ({ sessionUpdate: 'session_info_update', title })
 
 /** The slice of `K8sRuntimePlane` a webchat turn touches, with the one fact under test:
@@ -494,44 +481,6 @@ describe('Daemon webchat: SessionUpdate → webchat/output mapping', () => {
       { kind: 'session_info', title: 'Inspect startup state' },
       { kind: 'message', text: 'done' }
     ])
-    await daemon.stop()
-  })
-
-  it('hides the internal session-title tool burst from live and persisted message streams', async () => {
-    const { factory } = streamingHost([
-      sessionTitleToolCall('title-tool'),
-      toolUpdate('title-tool', 'completed'),
-      toolCall('visible-tool', 'Read file.ts', 'completed'),
-      text('done')
-    ])
-    const daemon = new Daemon({ root: scaffold(undefined, { runtime: 'test-runtime' }), hostFactory: factory })
-    await daemon.start()
-    const cp = fakeCpClient()
-    ;(daemon as any).cpClient = cp
-
-    const turnId = '12121212-1212-4212-8212-121212121212'
-    const msg = {
-      msgId: `webchat:${CONV}`,
-      traceId: turnId,
-      source: 'user' as const,
-      platform: 'webchat' as const,
-      channel: CONV,
-      sender: { id: 'alice', isBot: false },
-      text: 'go',
-      mentionedBots: [] as string[],
-      isDm: true,
-      trigger: 'dm' as const
-    }
-    await (daemon as any).dispatch(AGENT_ID, msg, undefined, { conversationId: CONV, turnId, sink: cp.sink })
-
-    expect(cp.outputs.filter((o) => o.event).map((o) => o.event)).toEqual([
-      { kind: 'tool_call', toolCallId: 'visible-tool', title: 'Read file.ts', status: 'completed' },
-      { kind: 'message', text: 'done' }
-    ])
-    const toolRows = (await (daemon as any).store.threadTranscript(CONV, `webchat:${CONV}`))
-      .filter((row: { kind: string }) => row.kind === 'tool')
-      .map((row: { text: string }) => row.text)
-    expect(toolRows).toEqual(['Read file.ts'])
     await daemon.stop()
   })
 

--- a/packages/daemon/test/mcp-bridge-e2e.test.ts
+++ b/packages/daemon/test/mcp-bridge-e2e.test.ts
@@ -18,17 +18,14 @@ import type { MessageGateway } from '../src/mcp/ops.js'
 const cliEntry = fileURLToPath(new URL('../src/index.ts', import.meta.url))
 const repoRoot = realpathSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../..'))
 
-const tools = toolsForIntegrations(
-  [
-    {
-      id: 'int-1',
-      platform: 'slack',
-      core: { mode: 'direct', bindRules: [], mutedChannels: [], gated: false },
-      config: { botToken: 'x', appToken: 'y' }
-    }
-  ],
-  { sessionTitle: true }
-)
+const tools = toolsForIntegrations([
+  {
+    id: 'int-1',
+    platform: 'slack',
+    core: { mode: 'direct', bindRules: [], mutedChannels: [], gated: false },
+    config: { botToken: 'x', appToken: 'y' }
+  }
+])
 
 /** The bridge only exercises the tools these deps back; the rest are never dispatched. */
 const controlDeps = (deps: Partial<McpControlDeps>): McpControlDeps => deps as McpControlDeps
@@ -75,13 +72,9 @@ describe('mcp-bridge end-to-end (real stdio MCP handshake)', () => {
       downloadFile: vi.fn(async () => null)
     }
     const recorded: unknown[] = []
-    const titleUpdates: unknown[] = []
     server = new McpControlServer(
       controlDeps({
         socketPath: path,
-        setSessionTitle: async (req) => {
-          titleUpdates.push(req)
-        },
         gatewayFor: () => gw,
         recordOutbound: async (_c, channel, _t, text, ts) => {
           recorded.push({ channel, text, ts })
@@ -118,22 +111,6 @@ describe('mcp-bridge end-to-end (real stdio MCP handshake)', () => {
 
     const listed = await client.listTools()
     expect(listed.tools.map((t) => t.name)).toContain('sendMessage')
-    expect(listed.tools.map((t) => t.name)).toContain('setSessionTitle')
-
-    const titleOut = await client.callTool({ name: 'setSessionTitle', arguments: { title: '  Review\nPR  ' } })
-    expect(titleOut.isError).toBeFalsy()
-    expect(titleUpdates).toEqual([
-      {
-        agentId: 'bot-a',
-        platform: 'slack',
-        integrationId: 'int-1',
-        isDm: false,
-        channel: 'C9',
-        thread: '5.5',
-        title: 'Review PR'
-      }
-    ])
-
     const out = await client.callTool({
       name: 'sendMessage',
       arguments: { toUser: 'U9', channel: 'C9', message: 'e2e hi' }

--- a/packages/daemon/test/mcp-ops.test.ts
+++ b/packages/daemon/test/mcp-ops.test.ts
@@ -78,7 +78,6 @@ const noMemory = {} as unknown as MemoryProvider
  *  return a benign delivered result; the send/read/discovery deps are overridden per test. */
 function makeDeps(over: Partial<OpsDeps> = {}): OpsDeps {
   return {
-    setSessionTitle: async () => {},
     gatewayFor: () => undefined,
     channelAgents: async () => {
       throw new Error('channelAgents not stubbed in this test')
@@ -95,66 +94,17 @@ function makeDeps(over: Partial<OpsDeps> = {}): OpsDeps {
   }
 }
 
-function deps(gw: MessageGateway): { deps: OpsDeps; recorded: unknown[]; titleUpdates: unknown[] } {
+function deps(gw: MessageGateway): { deps: OpsDeps; recorded: unknown[] } {
   const recorded: unknown[] = []
-  const titleUpdates: unknown[] = []
   return {
     recorded,
-    titleUpdates,
     deps: makeDeps({
-      setSessionTitle: async (req) => {
-        titleUpdates.push(req)
-      },
       gatewayFor: () => gw,
       recordOutbound: async (_c, channel, thread, text, ts) => void recorded.push({ channel, thread, text, ts }),
       now: () => 1000
     })
   }
 }
-
-describe('executeTool: setSessionTitle', () => {
-  it('normalizes the title and forwards only trusted session coordinates', async () => {
-    const gw = fakeGateway()
-    const gatewayFor = vi.fn(() => gw)
-    const { deps: d, titleUpdates } = deps(gw)
-    d.gatewayFor = gatewayFor
-
-    const result = await executeTool(
-      { ...ctx, isDm: true },
-      'setSessionTitle',
-      {
-        title: '  Fix\n  session titles  ',
-        agentId: 'attacker',
-        channel: 'C_OTHER',
-        integrationId: 'int-other'
-      },
-      d
-    )
-
-    expect(titleUpdates).toEqual([
-      {
-        agentId: 'bot-a',
-        platform: 'slack',
-        integrationId: 'int-1',
-        isDm: true,
-        channel: 'C_CURRENT',
-        thread: '111.1',
-        title: 'Fix session titles'
-      }
-    ])
-    expect(result).toEqual({ mcpContent: [] })
-    expect(gatewayFor).not.toHaveBeenCalled()
-  })
-
-  it('rejects blank, overlong, and stopped title updates', async () => {
-    const { deps: d, titleUpdates } = deps(fakeGateway())
-    await expect(executeTool(ctx, 'setSessionTitle', { title: '  ' }, d)).rejects.toThrow(/title/)
-    await expect(executeTool(ctx, 'setSessionTitle', { title: 'x'.repeat(81) }, d)).rejects.toThrow(/80/)
-    d.canRun = () => false
-    await expect(executeTool(ctx, 'setSessionTitle', { title: 'Late title' }, d)).rejects.toThrow(/stopped/)
-    expect(titleUpdates).toEqual([])
-  })
-})
 
 // The unified `sendMessage` tool's MessageTarget post path (§3) — the former
 // `sendPlatformMessage`. A `channel`-only target posts a visible IM through the gateway

--- a/packages/daemon/test/mcp-tool-args.test.ts
+++ b/packages/daemon/test/mcp-tool-args.test.ts
@@ -35,7 +35,6 @@ const ALL_CAPABILITIES = new Set(['recall', 'create', 'get', 'update', 'delete']
 
 const advertised: ToolDescriptor[] = [
   ...toolsForIntegrations([slackInt, telegramInt], {
-    sessionTitle: true,
     organizationKnowledge: true,
     currentPlatform: 'slack'
   }),

--- a/packages/daemon/test/mcp-tools.test.ts
+++ b/packages/daemon/test/mcp-tools.test.ts
@@ -406,7 +406,7 @@ describe('toolsForIntegrations', () => {
     const retired = ['startOrchestration', 'getOrchestration', 'cancelOrchestration']
     const surfaces = [
       toolsForIntegrations([]),
-      toolsForIntegrations([slackInt, telegramInt, discordInt], { sessionTitle: true, organizationKnowledge: true }),
+      toolsForIntegrations([slackInt, telegramInt, discordInt], { organizationKnowledge: true }),
       toolsForIntegrations([slackInt])
     ]
     for (const tools of surfaces) {
@@ -426,7 +426,7 @@ describe('toolsForIntegrations', () => {
     const surfaces = [
       toolsForIntegrations([]),
       toolsForIntegrations([slackInt]),
-      toolsForIntegrations([slackInt, telegramInt, discordInt], { sessionTitle: true, organizationKnowledge: true })
+      toolsForIntegrations([slackInt, telegramInt, discordInt], { organizationKnowledge: true })
     ]
     for (const tools of surfaces) {
       const names = tools.map((tool) => tool.name)
@@ -445,13 +445,8 @@ describe('toolsForIntegrations', () => {
     }
   })
 
-  it('injects the session-title fallback only when the runtime is explicitly whitelisted', () => {
-    expect(toolsForIntegrations([]).map((t) => t.name)).not.toContain('setSessionTitle')
-    expect(toolsForIntegrations([], { sessionTitle: true }).map((t) => t.name)).toContain('setSessionTitle')
-  })
-
   it('every injected tool exposes a JSON-Schema object input + a description', () => {
-    for (const t of toolsForIntegrations([slackInt, telegramInt], { sessionTitle: true })) {
+    for (const t of toolsForIntegrations([slackInt, telegramInt])) {
       expect(t.inputSchema).toMatchObject({ type: 'object' })
       expect(typeof t.description).toBe('string')
     }
@@ -474,7 +469,6 @@ describe('toolsForIntegrations', () => {
     expect(new Set(ALL_TOOL_NAMES).size).toBe(ALL_TOOL_NAMES.length)
     expect(ALL_TOOL_NAMES).toEqual(
       expect.arrayContaining([
-        'setSessionTitle',
         'sendMessage',
         'listChannels',
         'getChannelHistory',

--- a/packages/daemon/test/session-manager.test.ts
+++ b/packages/daemon/test/session-manager.test.ts
@@ -774,8 +774,8 @@ describe('SessionManager', () => {
   })
 
   it('bounds a runtime-pushed title to one line of at most 80 characters', async () => {
-    // Every other title source is capped (ingress clamp, first-message fallback, the
-    // setSessionTitle tool). A title should never be a multi-paragraph prompt.
+    // Every other title source is capped (ingress clamp, first-message fallback), so a
+    // title should never be a multi-paragraph prompt.
     const long = `GitHub pull_request:synchronize — acme/infra#1729\n\n${'context '.repeat(40)}`
     const clamped = clampRuntimeTitle(long)!
     expect([...clamped].length).toBeLessThanOrEqual(80)
@@ -786,7 +786,7 @@ describe('SessionManager', () => {
     expect(clampRuntimeTitle('   \n  ')).toBeUndefined()
   })
 
-  it('injects session naming guidance for a whitelisted runtime and passes the exact delivery route to MCP setup', async () => {
+  it('passes the exact delivery route to MCP setup', async () => {
     const store = await newStore()
     const host = { newSession: vi.fn(async () => 'acp-title-1') } as any
     const mcpServersFor = vi.fn(() => [])
@@ -796,19 +796,11 @@ describe('SessionManager', () => {
       hostFor: async () => host,
       agentById: () => codexAgent,
       memory,
-      usesSessionTitleTool: (candidate) => candidate.runtime === 'codex-acp',
       mcpServersFor
     })
 
-    const { blocks } = await sm.handle(
-      'bot-a',
-      msg({ ts: '100.1', text: 'fix titles', isDm: true }),
-      undefined,
-      'int-b'
-    )
+    await sm.handle('bot-a', msg({ ts: '100.1', text: 'fix titles', isDm: true }), undefined, 'int-b')
 
-    expect((blocks[0] as any).text).toContain('# Session naming')
-    expect((blocks[0] as any).text).toContain('`setSessionTitle`')
     expect(mcpServersFor).toHaveBeenCalledWith(
       expect.objectContaining({
         agent: codexAgent,
@@ -819,25 +811,6 @@ describe('SessionManager', () => {
         isDm: true
       })
     )
-    await (await store).close()
-  })
-
-  it('omits session naming guidance for a native-title runtime', async () => {
-    const store = await newStore()
-    const host = { newSession: vi.fn(async () => 'acp-title-native') } as any
-    const sm = new SessionManager({
-      store,
-      hostFor: async () => host,
-      agentById: () => agent,
-      memory,
-      usesSessionTitleTool: (candidate) => candidate.runtime === 'codex-acp',
-      mcpServersFor: () => []
-    })
-
-    const { blocks } = await sm.handle('bot-a', msg({ ts: '100.1', text: 'fix titles' }))
-
-    expect((blocks[0] as any).text).not.toContain('# Session naming')
-    expect((blocks[0] as any).text).not.toContain('`setSessionTitle`')
     await (await store).close()
   })
 

--- a/packages/daemon/test/standing-context.test.ts
+++ b/packages/daemon/test/standing-context.test.ts
@@ -9,7 +9,6 @@ const BASE = {
   thread: 'T123',
   envSecretNames: [],
   fileSecrets: [],
-  usesSessionTitleTool: false,
   needsReplyToParent: false,
   memoryIndex: '',
   usesMeta: false


### PR DESCRIPTION
Nothing could reach `setSessionTitle` anymore. No runtime has opted in since the Codex whitelist was removed, and the dependency that turns it on (`usesSessionTitleTool`) was never wired in the daemon at all — only tests passed it — so the descriptor never entered a session's tool list and the "# Session naming" standing-context section never rendered. Codex has since grown its own session naming, which reaches us through the ordinary ACP `session_info_update` path like every other runtime's.

**Removed:** the descriptor and the `sessionTitle` composition option, the handler and its argument schema, the daemon callback the MCP server bound, the per-turn set of tool-call ids whose activity had to be hidden from renderers and transcripts, and the standing-context section that asked the model to call it.

**Kept, because they are load-bearing for the titles we do get:**

- the transcript titles the store filters on, so rows recorded while the tool existed stay hidden in the console;
- the prompt-echo and standing-context echo filters plus the one-line clamp. A Codex turn still ends by publishing its raw prompt as a fallback title and only seconds later the generated one, so those filters are what stands between the console and a title that is an entire prompt.

Two floors keep every session titled without the tool, both untouched here: a new session is born with its ingress title or the first-message fallback, and the session list derives one at read time for any row that is still untitled.

Test changes follow the removal: the model-authored fan-out case in the daemon smoke test now exercises the same route with a runtime-published rename, which is what actually happens today, and the two standing-context whitelist cases collapse into the delivery-route assertion they shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
