### PR TITLE
fix(daemon): a bundle the checkout no longer holds is a first install, not a failed restore

### DIFF
--- a/packages/daemon/src/skills/skill-install-ledger.ts
+++ b/packages/daemon/src/skills/skill-install-ledger.ts
@@ -278,6 +278,7 @@ export async function recoverSkillLedger(
     }
 
     const priorByPath = new Map(ledger.prior.map((entry) => [entry.relativeRoot, entry]))
+    const vanished = new Set<string>()
     for (const operation of [...ledger.operations].reverse()) {
       const prior = priorByPath.get(operation.relativeRoot)
       await mutate(
@@ -302,6 +303,11 @@ export async function recoverSkillLedger(
         []
       )
       if (prior) {
+        // The discard above has settled this path, so neither address holding anything proves the prior is simply gone, not un-restorable.
+        if (await priorHasNoAddress(cwd, operation)) {
+          vanished.add(prior.relativeRoot)
+          continue
+        }
         await mutate(
           {
             action: 'restore',
@@ -325,8 +331,9 @@ export async function recoverSkillLedger(
       runtime: ledger.runtime,
       cliVersion: ledger.cliVersion,
       ...(ledger.publicationOperationId ? { publicationOperationId: ledger.publicationOperationId } : {}),
-      ...(ledger.priorFingerprint ? { fingerprint: ledger.priorFingerprint } : {}),
-      owned: ledger.prior,
+      // A set that lost a member no longer answers to the fingerprint that described it, or the next plan would skip reinstalling what vanished.
+      ...(ledger.priorFingerprint && vanished.size === 0 ? { fingerprint: ledger.priorFingerprint } : {}),
+      owned: ledger.prior.filter((entry) => !vanished.has(entry.relativeRoot)),
       gitResolutions: ledger.priorGitResolutions
     }
     if (!(await installedBundlesIntact(cwd, ready.owned, location.workspaceIdentity))) {
@@ -380,6 +387,13 @@ async function destinationOccupied(cwd: string, relativeRoot: string): Promise<b
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
     throw error
   }
+}
+
+/** Whether an operation's prior bundle is at neither of the two addresses recovery can find it at: its own path, or the quarantine a mutation moves it to. */
+async function priorHasNoAddress(cwd: string, operation: JournalOperation): Promise<boolean> {
+  const parent = operation.relativeRoot.split('/').slice(0, -1).join('/')
+  if (await destinationOccupied(cwd, operation.relativeRoot)) return false
+  return !(await destinationOccupied(cwd, `${parent}/${operation.quarantineName}`))
 }
 
 export async function reconcileSkillBundles(
@@ -442,7 +456,13 @@ async function reconcileSkillBundlesLocked(
     }
 
     // Canonicalize the recorded set too: a ledger written under another harness names the same directory by its other root.
-    const prior = await canonicalizeOwned(options.cwd, ledger?.owned ?? [])
+    const recorded = await canonicalizeOwned(options.cwd, ledger?.owned ?? [])
+    // An absent recorded bundle is not stale executable content — nothing to quarantine, nothing foreign to protect — so plan its path as a first install.
+    const prior: OwnedSkillBundle[] = []
+    for (const entry of recorded) {
+      if (await destinationOccupied(options.cwd, entry.relativeRoot)) prior.push(entry)
+      else options.warn?.(`skills: recorded bundle ${entry.relativeRoot} is gone from the workspace; reinstalling`)
+    }
     const priorByPath = new Map(prior.map((entry) => [entry.relativeRoot, entry]))
     const legacyHints = new Set<string>()
     for (const hint of options.legacyOwned ?? []) {
@@ -606,7 +626,8 @@ async function reconcileSkillBundlesLocked(
     }
     return {
       installed: candidates.map((entry) => entry.relativeRoot),
-      removed: prior.map((entry) => entry.relativeRoot),
+      // The whole previously-owned set, the paths that had already vanished included: none of it is owned once this returns.
+      removed: recorded.map((entry) => entry.relativeRoot),
       skipped: null,
       conflicts,
       owned
@@ -616,7 +637,11 @@ async function reconcileSkillBundlesLocked(
       try {
         await recoverSkillLedger(options.cwd, location, recoveryLedger, options.publicationKey)
       } catch (recoveryError) {
-        throw safety('skill installation failed and the prior executable set could not be restored', recoveryError)
+        // Name the failure that started this too: recovery's own error alone has sent readers hunting the wrong defect.
+        throw safety(
+          `skill installation failed and the prior executable set could not be restored (installation failure: ${messageChain(error)})`,
+          recoveryError
+        )
       }
     }
     if (error instanceof SkillLedgerSafetyError) throw error
@@ -1341,4 +1366,17 @@ async function assertWorkspaceIdentity(
 
 function safety(message: string, cause?: unknown): SkillLedgerSafetyError {
   return new SkillLedgerSafetyError(message, cause === undefined ? undefined : { cause })
+}
+
+/** Every message down a cause chain, so quoting one error never hides the one a reader needs. */
+function messageChain(error: unknown): string {
+  const parts: string[] = []
+  const seen = new Set<unknown>()
+  let current: unknown = error
+  while (current instanceof Error && !seen.has(current) && parts.length < 6) {
+    seen.add(current)
+    parts.push(current.message)
+    current = (current as { cause?: unknown }).cause
+  }
+  return parts.join(': ') || String(error)
 }

--- a/packages/daemon/src/skills/skill-install-ledger.ts
+++ b/packages/daemon/src/skills/skill-install-ledger.ts
@@ -513,7 +513,8 @@ async function reconcileSkillBundlesLocked(
       runtime: options.runtime,
       cliVersion: options.cliVersion,
       ...(options.publicationOperationId ? { publicationOperationId: options.publicationOperationId } : {}),
-      ...(ledger?.fingerprint ? { priorFingerprint: ledger.fingerprint } : {}),
+      // A pruned set is no longer what that fingerprint described, and recovery cannot see the prune: leaving it would let the next plan skip the reinstall.
+      ...(ledger?.fingerprint && prior.length === recorded.length ? { priorFingerprint: ledger.fingerprint } : {}),
       priorGitResolutions: ledger?.gitResolutions ?? [],
       prior,
       pending: candidates.map(stripCandidate),

--- a/packages/daemon/src/skills/skill-workspace-mutation-cli.ts
+++ b/packages/daemon/src/skills/skill-workspace-mutation-cli.ts
@@ -774,6 +774,8 @@ async function restore(spec: RestoreSpec): Promise<PathIdentity> {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
   }
+  // A mutation that failed before quarantining leaves nothing here; say so rather than surfacing a bare ENOENT on a name only this journal knows.
+  if (!(await pathExists(quarantine))) fail('no quarantined prior skill to restore')
   const found = await inspectBundle(quarantine, spec.prior)
   if (!sameIdentity(found, spec.prior.identity)) fail('restore source was replaced')
   try {

--- a/packages/daemon/test/skill-install-ledger.test.ts
+++ b/packages/daemon/test/skill-install-ledger.test.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { lstat, mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, readdir, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -11,9 +11,11 @@ import {
   reconcileSkillBundles,
   recoverSkillLedger,
   skillLedgerLocation,
+  SkillLedgerSafetyError,
   treeDigest,
   withSkillWorkspaceLock,
   type CandidateSkillBundle,
+  type OwnedSkillBundle,
   type PathIdentity,
   type SkillFileReceipt
 } from '../src/skills/skill-install-ledger.js'
@@ -286,6 +288,187 @@ describe.skipIf(!hasBwrap)('skill install ledger crash recovery', () => {
     if (!parsed || parsed.phase !== 'applying') throw new Error('expected applying ledger')
     expect(parsed.prior).toHaveLength(64)
     expect(parsed.pending).toHaveLength(64)
+  })
+})
+
+// A confined session's clone is re-checked out under a ledger that outlives it (git-workspace-model.md
+// §11), so the recorded set can be absent while the ledger naming it is intact.
+describe.skipIf(process.platform === 'win32')('skill install ledger over a re-checked-out workspace', () => {
+  const BUNDLE = '.claude/skills/fixture'
+  const BODY = '---\nname: fixture\ndescription: fixture\n---\n'
+  let root: string
+  let cwd: string
+  let stateDir: string
+  let sourceDir: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'ac-skill-recheckout-'))
+    cwd = join(root, 'workspace')
+    stateDir = join(root, 'state')
+    sourceDir = join(root, 'source')
+    await mkdir(cwd)
+    await mkdir(sourceDir)
+    await writeFile(join(sourceDir, 'SKILL.md'), BODY)
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  const reconcile = (fingerprint: string) =>
+    reconcileSkillBundles({
+      cwd,
+      stateDir,
+      agentId: 'a1',
+      runtime: 'claude',
+      cliVersion: '1.5.21',
+      fingerprint,
+      candidates: [{ ...oneFileReceipt(BUNDLE, 'fixture'), sourceDir }]
+    })
+
+  async function writeApplyingOver(
+    prior: OwnedSkillBundle[],
+    operations: ReturnType<typeof operation>[]
+  ): Promise<Awaited<ReturnType<typeof skillLedgerLocation>>> {
+    const location = await skillLedgerLocation(cwd, stateDir)
+    await writeFile(
+      location.file,
+      `${JSON.stringify({
+        version: 3,
+        phase: 'applying',
+        workspaceRealpath: location.workspaceRealpath,
+        workspaceIdentity: location.workspaceIdentity,
+        agentId: 'a1',
+        runtime: 'claude',
+        cliVersion: '1.5.21',
+        priorFingerprint: 'v1',
+        priorGitResolutions: [],
+        prior,
+        pending: [],
+        operations
+      })}\n`,
+      { mode: 0o600 }
+    )
+    return location
+  }
+
+  const recover = (
+    location: Awaited<ReturnType<typeof skillLedgerLocation>>,
+    ledger: NonNullable<Awaited<ReturnType<typeof readSkillLedger>>>
+  ) => withSkillWorkspaceLock(cwd, () => recoverSkillLedger(cwd, location, ledger), stateDir)
+
+  it('reinstalls a recorded bundle the checkout no longer holds', async () => {
+    const first = await reconcile('v1')
+    expect(first.installed).toEqual([BUNDLE])
+
+    // What `git clean -ffdx` does to a resumed session clone: the bundles go, the ledger naming them stays.
+    await rm(join(cwd, '.claude'), { recursive: true, force: true })
+    const second = await reconcile('v1')
+
+    expect(second.installed).toEqual([BUNDLE])
+    expect(second.conflicts).toEqual([])
+    expect(second.owned.map((entry) => entry.relativeRoot)).toEqual([BUNDLE])
+    expect(existsSync(join(cwd, ...BUNDLE.split('/'), 'SKILL.md'))).toBe(true)
+    const ledger = await readSkillLedger(await skillLedgerLocation(cwd, stateDir))
+    expect(ledger?.phase).toBe('ready')
+  })
+
+  it('leaves no journal artifact behind after reinstalling over a vanished record', async () => {
+    await reconcile('v1')
+    await rm(join(cwd, '.claude'), { recursive: true, force: true })
+    await reconcile('v1')
+
+    const entries = await readdir(join(cwd, '.claude/skills'))
+    expect(entries).toEqual(['fixture'])
+  })
+
+  it('still refuses a recorded path that now holds content it does not own', async () => {
+    await reconcile('v1')
+    const target = join(cwd, ...BUNDLE.split('/'))
+    await rm(target, { recursive: true, force: true })
+    await mkdir(target, { recursive: true })
+    await writeFile(join(target, 'manual'), 'do not delete')
+
+    await expect(reconcile('v1')).rejects.toThrow(SkillLedgerSafetyError)
+    expect(await readFile(join(target, 'manual'), 'utf8')).toBe('do not delete')
+  })
+
+  it('names the installation failure alongside the recovery failure', async () => {
+    await reconcile('v1')
+    const target = join(cwd, ...BUNDLE.split('/'))
+    await rm(target, { recursive: true, force: true })
+    await mkdir(target, { recursive: true })
+    await writeFile(join(target, 'manual'), 'do not delete')
+
+    await expect(reconcile('v1')).rejects.toThrow(/installation failure: .*refusing to replace unowned skill/)
+  })
+
+  it('recovers an interrupted journal by restoring the prior it quarantined', async () => {
+    await reconcile('v1')
+    const location = await skillLedgerLocation(cwd, stateDir)
+    const ready = await readSkillLedger(location)
+    if (!ready || ready.phase !== 'ready') throw new Error('expected ready ledger')
+    const old = ready.owned[0]!
+    const target = join(cwd, ...old.relativeRoot.split('/'))
+    const interrupted = operation(old.relativeRoot)
+    await rename(target, join(dirname(target), interrupted.quarantineName))
+    await writeApplyingOver([old], [interrupted])
+
+    const applying = await readSkillLedger(location)
+    const recovered = await recover(location, applying!)
+
+    expect(recovered.owned.map((entry) => entry.relativeRoot)).toEqual([old.relativeRoot])
+    expect(recovered.fingerprint).toBe('v1')
+    expect(existsSync(join(target, 'SKILL.md'))).toBe(true)
+  })
+
+  it('fails closed when a quarantined prior cannot be put back', async () => {
+    await reconcile('v1')
+    const location = await skillLedgerLocation(cwd, stateDir)
+    const ready = await readSkillLedger(location)
+    if (!ready || ready.phase !== 'ready') throw new Error('expected ready ledger')
+    const old = ready.owned[0]!
+    const target = join(cwd, ...old.relativeRoot.split('/'))
+    const interrupted = operation(old.relativeRoot)
+    const quarantine = join(dirname(target), interrupted.quarantineName)
+    await rename(target, quarantine)
+    // The quarantined bundle is still there, and is no longer the set the receipt describes.
+    await writeFile(join(quarantine, 'extra'), 'tampered')
+    await writeApplyingOver([old], [interrupted])
+
+    const applying = await readSkillLedger(location)
+    await expect(recover(location, applying!)).rejects.toThrow(SkillLedgerSafetyError)
+    expect(existsSync(join(quarantine, 'extra'))).toBe(true)
+  })
+
+  it('drops a prior that is at neither address from the recovered set', async () => {
+    const interrupted = operation(BUNDLE)
+    const location = await writeApplyingOver(
+      [{ ...oneFileReceipt(BUNDLE, 'fixture'), identity: { dev: '1', ino: '2' } }],
+      [interrupted]
+    )
+
+    const applying = await readSkillLedger(location)
+    const recovered = await recover(location, applying!)
+
+    expect(recovered.phase).toBe('ready')
+    expect(recovered.owned).toEqual([])
+    // The fingerprint described a set that lost a member, so it must not let the next plan skip the reinstall.
+    expect(recovered.fingerprint).toBeUndefined()
+  })
+
+  it('reinstalls after recovering a journal whose prior was at neither address', async () => {
+    const location = await writeApplyingOver(
+      [{ ...oneFileReceipt(BUNDLE, 'fixture'), identity: { dev: '1', ino: '2' } }],
+      [operation(BUNDLE)]
+    )
+    const applying = await readSkillLedger(location)
+    await recover(location, applying!)
+
+    const installed = await reconcile('v1')
+
+    expect(installed.installed).toEqual([BUNDLE])
+    expect(existsSync(join(cwd, ...BUNDLE.split('/'), 'SKILL.md'))).toBe(true)
   })
 })
 

--- a/packages/daemon/test/skill-install-ledger.test.ts
+++ b/packages/daemon/test/skill-install-ledger.test.ts
@@ -382,6 +382,37 @@ describe.skipIf(process.platform === 'win32')('skill install ledger over a re-ch
     expect(entries).toEqual(['fixture'])
   })
 
+  // Recovery reads the pruned journal and cannot tell a bundle was dropped, so the fingerprint must
+  // not survive the prune: an interrupted reinstall would otherwise commit "unchanged" over a short set.
+  it('reinstalls after a reinstall over a vanished record is interrupted', async () => {
+    await reconcile('v1')
+    await rm(join(cwd, '.claude'), { recursive: true, force: true })
+
+    await expect(
+      reconcileSkillBundles({
+        cwd,
+        stateDir,
+        agentId: 'a1',
+        runtime: 'claude',
+        cliVersion: '1.5.21',
+        fingerprint: 'v1',
+        candidates: [{ ...oneFileReceipt(BUNDLE, 'fixture'), sourceDir }],
+        assertMutationAuthority: () => {
+          throw new Error('mutation authority lost')
+        }
+      })
+    ).rejects.toThrow()
+
+    const interrupted = await readSkillLedger(await skillLedgerLocation(cwd, stateDir))
+    expect(interrupted?.phase).toBe('ready')
+
+    const retry = await reconcile('v1')
+
+    expect(retry.skipped).toBeNull()
+    expect(retry.installed).toEqual([BUNDLE])
+    expect(existsSync(join(cwd, ...BUNDLE.split('/'), 'SKILL.md'))).toBe(true)
+  })
+
   it('still refuses a recorded path that now holds content it does not own', async () => {
     await reconcile('v1')
     const target = join(cwd, ...BUNDLE.split('/'))

--- a/packages/daemon/test/skill-workspace-mutator.test.ts
+++ b/packages/daemon/test/skill-workspace-mutator.test.ts
@@ -1,10 +1,11 @@
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { lstat, mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { canonicalSkillMutationRoot, runSkillWorkspaceMutation } from '../src/skills/skill-workspace-mutator.js'
 import { withSkillMutationHelperLease } from '../src/skills/skill-workspace-lock-lease.js'
+import { treeDigest } from '../src/skills/skill-install-ledger.js'
 
 // The start gate only exists inside the sandbox wrapper; pin the ungated launch so every host runs the race.
 vi.mock('../src/skills/offline-sandbox.js', async (importOriginal) => ({
@@ -92,4 +93,37 @@ describe('runSkillWorkspaceMutation', () => {
       await expect(lstat(join(canonical, '.claude/skills/audit'))).resolves.toBeTruthy()
     }
   )
+
+  // A mutation that failed before quarantining leaves the journal's `.agentconnect-skill-old-<uuid>`
+  // unwritten, and a bare ENOENT on a name only the journal knows reads as a stuck file, not as a state.
+  it.skipIf(process.platform === 'win32')('names a restore that has nothing quarantined to put back', async () => {
+    const { cwd } = await workspace()
+    await mkdir(join(cwd, '.claude/skills'), { recursive: true })
+    const canonical = await realpath(cwd)
+    const stat = await lstat(canonical, { bigint: true })
+    const body = '---\nname: fixture\ndescription: fixture\n---\n'
+    const files = [
+      {
+        path: 'SKILL.md',
+        mode: 0o600,
+        size: Buffer.byteLength(body),
+        sha256: createHash('sha256').update(body).digest('hex')
+      }
+    ]
+    const operationId = randomUUID()
+
+    const restore = withSkillMutationHelperLease({ registerHelper: async () => {}, clearHelper: async () => {} }, () =>
+      runSkillWorkspaceMutation({
+        action: 'restore',
+        cwd: canonical,
+        workspaceIdentity: { dev: stat.dev.toString(), ino: stat.ino.toString() },
+        relativeRoot: '.claude/skills/fixture',
+        operationId,
+        quarantineName: `.agentconnect-skill-old-${operationId}`,
+        prior: { files, treeDigest: treeDigest(files), identity: { dev: stat.dev.toString(), ino: '999999999' } }
+      })
+    )
+
+    await expect(restore).rejects.toThrow(/no quarantined prior skill to restore/)
+  })
 })


### PR DESCRIPTION
Observed on a self-hosted daemon using per-session workspaces: **every code review after the first in a given session silently lost its exact checkout** and fell back to a trusted revision. It was a WARN in the daemon journal and nothing at all in the review output.

```
github review: exact checkout unavailable; continuing with trusted revision only
  (SkillLedgerSafetyError: skill installation failed and the prior executable set could not be restored
   Caused by: ENOENT: no such file or directory, lstat '.../.claude/skills/.agentconnect-skill-old-<uuid>')
```

## Diagnosis

The uuid changed on every attempt, so this was never a stuck file — the restore path failed every time. Reproduced end to end, and the chain is:

1. The skill ledger lives in the daemon state directory, keyed by workspace realpath plus inode (`skillLedgerLocation`). It therefore **outlives the contents of the workspace it describes**.
2. A session clone that is already attached is refreshed in place for a review — `reset --hard` then `clean -ffdx`. The directory keeps its inode, so the ledger key still resolves, but the installed bundles under `.claude/skills/` are gone. The next `withSkills` on the same prepare call reconciles against a ledger whose recorded set is no longer on disk.
3. `reconcileSkillBundlesLocked` built `prior` straight from `ledger.owned` without asking whether those paths still exist, so it planned a *replacement* of a bundle that is absent.
4. `reserve` refused that, correctly: `owned skill disappeared during reservation`. It bailed **before** renaming anything into the quarantine.
5. The catch handler ran `recoverSkillLedger`, which calls `restore` for every operation that has a `prior`. `restore` did `inspectBundle(quarantine, …)` unguarded — and the quarantine had never been created. Hence the bare `ENOENT` on a name only the journal knows.
6. That surfaced as `the prior executable set could not be restored`, which named neither the real failure nor the path. The original error was **discarded** by the handler, which is why the actionable message never reached the journal.

The second reported variant, a bare `SkillLedgerSafetyError: confined skill workspace mutation was refused`, is the same defect reached from the entry-recovery call on a leftover `applying` journal rather than from the install's own catch.

So the framing in the report was right in substance — "nothing to restore" was being treated as "the restore failed" — with one correction worth recording: the ledger did carry a non-empty `prior`. It is not that the workspace never had a skill set; it is that the ledger describing it survived a re-checkout that removed it.

## Fix

All of it inside `packages/daemon/src/skills/`.

- **`reconcileSkillBundlesLocked`** partitions the recorded set: an entry whose path does not exist is dropped from `prior` (with a warn naming it) and its path is planned as a first install. An entry whose path exists is kept exactly as before.
- **`recoverSkillLedger`** drops a prior that is at neither address it could be found at — its own path or its quarantine — instead of demanding a restore that cannot happen, and drops `priorFingerprint` with it so the next plan cannot skip reinstalling what vanished.
- **`restore`** in the confined helper reports `no quarantined prior skill to restore` instead of an `ENOENT` when a mutation failed before quarantining. This changes one error into another error, never a failure into a success.
- The install catch now names the failure that started the recovery alongside the recovery's own, via a small cause-chain flattener.

## What stays fail-closed, and why widening is not possible here

Dropping an absent prior cannot weaken the invariant, because the ledger is not what makes the replace decision — the confined helper is. `reserve` ends at an atomic no-clobber `mkdir`, so a bundle that reappears between the plan and the mutation is still refused with `refusing to replace unowned skill`. The ledger's prune only removes a *quarantine* step that has nothing to quarantine. Specifically unchanged:

- a recorded path that now holds content the ledger does not own is still refused, and that content is left untouched;
- a genuinely quarantined prior that cannot be put back still fails closed;
- the deliberate refusal on an untrusted legacy marker is untouched;
- the `trustedPrior` path used by the cluster coordinator proves every receipt with `bundleIdentity` before this prune can see it, so its behaviour is identical.

## Verified

Unit level only — **no live host was exercised by me**.

- New: 8 cases in `test/skill-install-ledger.test.ts` (first install over a wiped record, no journal artifacts left behind, unowned content still refused, the installation failure named, a real quarantined prior still restored, a tamper-proofed quarantine still failing closed, a vanished prior dropped from recovery with its fingerprint, and reinstall after such a recovery) and 1 in `test/skill-workspace-mutator.test.ts` for the helper's restore message.
- These are gated `skipIf(win32)` rather than on bwrap, so unlike the existing crash-recovery block they also run on macOS. `unified-skills.test.ts` (28 cases) stays sandbox-gated and runs only in the Linux CI lane.
- Mutation-checked, five mutations, all caught: plan-time prune disabled → 2 red; recovery prune forced off → 2 red; stale fingerprint retained → 2 red; helper's quarantine guard removed → 1 red; recovery prune forced *on* (the widening direction) → 2 red, which is the fail-closed guard biting.
- Gates: daemon `tsc -p tsconfig.typecheck.json --noEmit` clean, prettier and eslint clean on the four touched files, and `skill-install-ledger`, `skill-workspace-mutator`, `skill-workspace-lock`, `unified-skills`, `cluster-skill-ledger`, `cluster-skill-coordinator`, `shim-skill-handler`, `skills` all green. The full daemon suite was deliberately not run.

## Deliberately deferred: surfacing the degradation in the review output

The report asked for the degradation to be visible in the review's own output rather than only in the daemon journal, and to leave the degrade/fail decision alone. I have **not** done that half, and recommend it as its own change. It reaches four files in `src/github/` plus three test files and a design doc, two of which are being edited concurrently on other branches, and it changes text posted to every review — too much to bolt onto a skills-layer fix.

The precise shape it should take:

1. `src/github/hook-coords.ts` — add an optional field to `HookDispatchContext` (say `reviewCheckout?: 'exact' | 'revision_only'`). That interface is daemon-local and persisted with plain `JSON.stringify`, so no wire or store-schema change is needed and it survives restart replay.
2. `src/github/review-orchestrator.ts` — set it in `useRevisionOnlyWorkspace`, on **both** returns (the isolated revision-only workspace and the degraded shared-cwd fallback); read it where the review is submitted.
3. `src/github/poster.ts` — `GithubCommentAttribution` has no `notice` field today, but `renderAttributionMessage` in `src/messages/attribution.ts` already accepts one and Slack and Feishu already use it. Adding `notice` to the GitHub attribution and forwarding it needs no change to the shared renderer.
4. Note the trap: attribution is only built when `agent.output.showFooter` is set. If the note must appear regardless — and for a provenance disclaimer it probably must — it has to be composed in `src/github/review.ts` independently of the footer, which also changes the `GithubReviewClient.submit` signature.

One finding worth flagging to whoever picks that up: the check-run summary **already** prints a `Revision: <sha>` line, composed control-plane side in `src/github/run-reporter.ts`, and it has no notion of whether the daemon actually had that checkout. So today a degraded review does not merely omit its provenance — it displays a revision line that implies an exactness it did not have. That is the strongest argument for the note, and it may deserve to reach the check summary too, which would need a daemon → control-plane field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
