### PR TITLE
feat(console): a model option carries the runtime's own name and blurb

### DIFF
--- a/docs/designs/runtime-model-catalog.md
+++ b/docs/designs/runtime-model-catalog.md
@@ -459,6 +459,7 @@ const EffortOption = z.object({
 const RuntimeModelCapability = z.object({
   id: z.string(), // model selector value
   name: z.string().optional(), // Send only when display name differs from value
+  description: z.string().optional(), // The runtime's own model blurb; the picker's tooltip
   efforts: z.array(EffortOption).optional(), // Levels for this model, including daemon augmentation
   // [] = no effort selector for this model; absent = not discovered
   defaultEffort: z.string().optional(),
@@ -615,6 +616,14 @@ discovery:
    "Extra High," then capitalized value. Use `description` as a tooltip when
    present. Control titles such as "Reasoning" vs "Effort" remain static by
    runtime and do not enter the wire.
+   4a. **The model picker labels a model by its advertised id and hovers its prose.**
+   The id is what the agent stores and the runtime answers to, so it stays the
+   label; `RuntimeModelCapability.description` (else `name`) becomes the option's
+   tooltip, which is how an id like `opus[1m]` or `claude-fable-5-1[1m]` gets
+   read as "Opus 5 with 1M context ·…" without the console re-wording anything.
+   Phase 1 already knows both for EVERY advertised model — one probe response
+   carries the whole select — so the tooltip does not wait on enumeration, which
+   a `--k8s` member never runs.
 5. When present, `permissionModes` replaces the static permission table using
    the same label fallback, with runtime `description` as an option tooltip.
    When `defaultModel` is present, the model picker's "Default" option may show

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -111,6 +111,7 @@ export const PermissionModeOptionDto = z.object({
 export const RuntimeModelCapabilityDto = z.object({
   id: z.string(), // model-selector value
   name: z.string().optional(), // display name (sent only when it differs from id)
+  description: z.string().optional(), // the runtime's own model blurb — the picker's tooltip
   efforts: z.array(EffortOptionDto).optional(),
   defaultEffort: z.string().optional(),
   fastMode: z.boolean().optional()

--- a/packages/daemon/src/runtimes/config-caps.ts
+++ b/packages/daemon/src/runtimes/config-caps.ts
@@ -2,12 +2,19 @@ import type { SessionConfigOption } from '@agentclientprotocol/sdk'
 import type { EffortOption, PermissionModeOption } from '@agentconnect.md/protocol'
 import { augmentClaudeEfforts } from '../runtime-defs/claude-runtime.js'
 
+/** One model select option: the picker's value plus the runtime's own display metadata. */
+export interface ModelChoice {
+  value: string
+  name?: string
+  description?: string
+}
+
 /**
  * Distill a session's RAW ACP config options into the capability shape the
  * model-catalog cache stores (design doc runtime-model-catalog.md §4/§5).
- * Everything here describes the CURRENTLY SELECTED model — the enumerator calls
- * this once per set_config_option response to build the per-model matrix, and
- * the probe sweep calls it once to seed the default model's entry.
+ * Everything but `modelChoices` describes the CURRENTLY SELECTED model — the enumerator
+ * calls this once per set_config_option response to build the per-model matrix, and the
+ * probe sweep calls it once to seed the default model's entry plus the whole picker's names.
  *
  * Values are stored raw: daemon-side synthetic effort levels (Claude
  * max/ultracode) are appended at REPORT time, never here.
@@ -17,6 +24,8 @@ export interface ConfigCaps {
   currentModel?: string
   /** Display name of the current model, only when it differs from the value. */
   modelName?: string
+  /** Display metadata for EVERY model the selector offers, not just the current one. */
+  modelChoices?: ModelChoice[]
   /** thought_level choices offered for the current model; [] = no effort selector. */
   efforts: EffortOption[]
   /** The effort the runtime defaulted the current model to. */
@@ -68,7 +77,8 @@ export function augmentEffortOptions(efforts: EffortOption[]): EffortOption[] {
 export function capsFromConfigOptions(options: SessionConfigOption[]): ConfigCaps {
   const model = selectFor(options, 'model')
   const currentModel = model?.currentValue
-  const modelName = model ? (flatValues(model).find((v) => v.value === currentModel)?.name ?? undefined) : undefined
+  const modelChoices = model ? flatValues(model).map(configChoice) : undefined
+  const modelName = modelChoices?.find((v) => v.value === currentModel)?.name
 
   const effort = selectFor(options, 'thought_level')
   const efforts = effort ? flatValues(effort).map(configChoice) : []
@@ -86,6 +96,7 @@ export function capsFromConfigOptions(options: SessionConfigOption[]): ConfigCap
   return {
     ...(currentModel ? { currentModel } : {}),
     ...(modelName && modelName !== currentModel ? { modelName } : {}),
+    ...(modelChoices ? { modelChoices } : {}),
     efforts,
     ...(defaultEffort ? { defaultEffort } : {}),
     fastMode,

--- a/packages/daemon/src/runtimes/facts-registry.ts
+++ b/packages/daemon/src/runtimes/facts-registry.ts
@@ -8,7 +8,7 @@ import type {
 import type { Logger } from '../log.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 import type { SandboxMechanism } from '../acp/sandbox.js'
-import type { LocalStore } from '../store/local-store.js'
+import type { LocalStore, RuntimeModelCapRecord } from '../store/local-store.js'
 import type { ResolvedRuntimeCatalog } from './registry.js'
 import type { CuratedRuntimeAdmission } from './curated-admission.js'
 import type { K8sRuntimeAcpSnapshot } from './k8s-runtimes.js'
@@ -274,6 +274,7 @@ export class RuntimeFactsRegistry {
     const models = (await this.host.store().listRuntimeModelCaps(id)).map((r) => ({
       id: r.modelId,
       ...(r.caps.name ? { name: r.caps.name } : {}),
+      ...(r.caps.description ? { description: r.caps.description } : {}),
       ...(r.caps.efforts !== undefined
         ? { efforts: claude ? augmentEffortOptions(r.caps.efforts) : r.caps.efforts }
         : {}),
@@ -544,7 +545,8 @@ export class RuntimeFactsRegistry {
 
   /** Phase 1 of catalog discovery (design runtime-model-catalog.md §3.3): the probe
    *  session's config options are already in hand — seed the cache with the default
-   *  model's caps + runtime-level permission modes, then let the discovery gate decide
+   *  model's caps, every advertised model's display metadata, and the runtime-level
+   *  permission modes, then let the discovery gate decide
    *  whether a full phase-2 discovery is due. A failed probe deliberately skips this:
    *  the last-good catalog is never cleared. */
   private async seedCatalogFromProbe(r: RuntimeProbeResult): Promise<void> {
@@ -576,17 +578,43 @@ export class RuntimeFactsRegistry {
           ...(caps.currentPermissionMode ? { defaultPermissionMode: caps.currentPermissionMode } : {}),
           observedAt: this.host.clock().now()
         })
+        // Display metadata for EVERY advertised model is already in this one response, and a
+        // --k8s member never runs the enumeration that would otherwise learn it — so seed the
+        // whole picker's names/descriptions here, over a same-fingerprint row so an enumerated
+        // matrix keeps its efforts.
+        const known = new Map(
+          (await store.listRuntimeModelCaps(r.runtime))
+            .filter((row) => row.fingerprint === fp)
+            .map((row) => [row.modelId, row.caps] as const)
+        )
+        const displayOf = (choice: { name?: string; description?: string }) => ({
+          ...(choice.name ? { name: choice.name } : {}),
+          ...(choice.description ? { description: choice.description } : {})
+        })
+        const rows = new Map<string, RuntimeModelCapRecord['caps']>()
+        for (const choice of caps.modelChoices ?? []) {
+          const display = displayOf(choice)
+          if (Object.keys(display).length > 0) rows.set(choice.value, { ...known.get(choice.value), ...display })
+        }
+        // The seed model's own caps are authoritative for this fingerprint: merge only display
+        // metadata under them, never a previous round's efforts.
         if (seedModel) {
+          rows.set(seedModel, {
+            ...displayOf(known.get(seedModel) ?? {}),
+            ...displayOf(caps.modelChoices?.find((c) => c.value === seedModel) ?? {}),
+            efforts: caps.efforts,
+            ...(caps.defaultEffort ? { defaultEffort: caps.defaultEffort } : {}),
+            fastMode: caps.fastMode
+          })
+        }
+        const observedAt = this.host.clock().now()
+        for (const [modelId, modelCaps] of rows) {
           await store.upsertRuntimeModelCap({
             runtimeId: r.runtime,
-            modelId: seedModel,
+            modelId,
             fingerprint: fp,
-            caps: {
-              efforts: caps.efforts,
-              ...(caps.defaultEffort ? { defaultEffort: caps.defaultEffort } : {}),
-              fastMode: caps.fastMode
-            },
-            observedAt: this.host.clock().now()
+            caps: modelCaps,
+            observedAt
           })
         }
         await this.rebuildCatalog(r.runtime)

--- a/packages/daemon/src/runtimes/model-catalog.ts
+++ b/packages/daemon/src/runtimes/model-catalog.ts
@@ -41,6 +41,7 @@ export interface CatalogStorePort {
 /** One model's RAW advertised capabilities (cache shape — no daemon-synthesized tiers). */
 export interface ModelCaps {
   name?: string
+  description?: string
   efforts?: EffortOption[]
   defaultEffort?: string
   fastMode?: boolean
@@ -477,6 +478,7 @@ export function codexModelsFromListResult(result: unknown): DriverCatalog {
     // from models[] the same way) — it is not a catalog entry.
     if (typeof id !== 'string' || id === '' || id === 'default') continue
     const name = pickString(rec, 'displayName', 'display_name')
+    const modelDescription = typeof rec.description === 'string' && rec.description !== '' ? rec.description : undefined
     const efforts: EffortOption[] = (
       pickArray(rec, 'supportedReasoningEfforts', 'supported_reasoning_efforts') ?? []
     ).flatMap((e): EffortOption[] => {
@@ -503,6 +505,7 @@ export function codexModelsFromListResult(result: unknown): DriverCatalog {
     models.push({
       id,
       ...(name && name !== id ? { name } : {}),
+      ...(modelDescription ? { description: modelDescription } : {}),
       efforts,
       ...(defaultEffort ? { defaultEffort } : {}),
       fastMode

--- a/packages/daemon/src/runtimes/model-enumerator.ts
+++ b/packages/daemon/src/runtimes/model-enumerator.ts
@@ -99,7 +99,11 @@ export function makeModelEnumerator(deps: ModelEnumeratorDeps): EnumerateFn {
       if (!initial) return { models: [], aborted: 'runtime advertises no session config options' }
       const setSessionModel = activeHost.setSessionModel?.bind(activeHost)
       if (!setSessionModel) return { models: [], aborted: 'runtime cannot switch the session model' }
-      const initialModel = capsFromConfigOptions(initial).currentModel
+      const initialCaps = capsFromConfigOptions(initial)
+      const initialModel = initialCaps.currentModel
+      // The selector named and described every model up front; a set_config_option response
+      // only ever describes the one now selected, so carry that metadata across the loop.
+      const display = new Map((initialCaps.modelChoices ?? []).map((c) => [c.value, c] as const))
 
       const collected: Awaited<ReturnType<EnumerateFn>> & object = { models: [] }
       for (const id of modelIds) {
@@ -128,9 +132,11 @@ export function makeModelEnumerator(deps: ModelEnumeratorDeps): EnumerateFn {
         // survives the switch; verified against claude-agent-acp 0.59.0), not
         // the model's own default. Only phase 1 (fresh-session initial state)
         // and native drivers may claim a default.
+        const described = display.get(id)
         collected.models.push({
           id,
-          ...(caps.modelName ? { name: caps.modelName } : {}),
+          ...(caps.modelName ? { name: caps.modelName } : described?.name ? { name: described.name } : {}),
+          ...(described?.description ? { description: described.description } : {}),
           efforts: caps.efforts,
           fastMode: caps.fastMode
         })

--- a/packages/daemon/src/store/local-store.ts
+++ b/packages/daemon/src/store/local-store.ts
@@ -868,6 +868,7 @@ export interface RuntimeModelCapRecord {
   fingerprint: string
   caps: {
     name?: string
+    description?: string
     efforts?: Array<{ value: string; name?: string; description?: string }>
     defaultEffort?: string
     fastMode?: boolean
@@ -1588,7 +1589,7 @@ export class LocalStore {
         runtimeId TEXT NOT NULL,
         modelId TEXT NOT NULL,
         fingerprint TEXT NOT NULL,
-        capsJson TEXT NOT NULL,           -- JSON {name?, efforts?: [{value,name?,description?}], defaultEffort?, fastMode?}
+        capsJson TEXT NOT NULL,           -- JSON {name?, description?, efforts?: [{value,name?,description?}], defaultEffort?, fastMode?}
         observedAt INTEGER NOT NULL,
         PRIMARY KEY (ownerId, runtimeId, modelId)
       );

--- a/packages/daemon/test/model-catalog-daemon.test.ts
+++ b/packages/daemon/test/model-catalog-daemon.test.ts
@@ -353,7 +353,7 @@ describe('daemon sweep phase-1 catalog seeding', () => {
       type: 'select',
       currentValue: 'a',
       options: [
-        { value: 'a', name: 'Model A' },
+        { value: 'a', name: 'Model A', description: 'Model A · the everyday one' },
         { value: 'b', name: 'Model B' }
       ]
     },
@@ -434,11 +434,20 @@ describe('daemon sweep phase-1 catalog seeding', () => {
           complete: false,
           observedAt: 10_000
         })
-        // ...and ONE model row for the default model, storing RAW advertised
-        // efforts — augmentation is report-time only, never persisted.
+        // ...a full row for the default model, storing RAW advertised efforts
+        // (augmentation is report-time only, never persisted), plus a
+        // display-only row for every other advertised model — the whole
+        // picker's names/descriptions come from this one response.
         const caps = await store.listRuntimeModelCaps('probed')
-        expect(caps.map((r) => r.modelId)).toEqual(['a'])
-        expect(caps[0]!.caps).toEqual({ efforts: rawEfforts, defaultEffort: 'high', fastMode: true })
+        expect(caps.map((r) => r.modelId)).toEqual(['a', 'b'])
+        expect(caps[0]!.caps).toEqual({
+          name: 'Model A',
+          description: 'Model A · the everyday one',
+          efforts: rawEfforts,
+          defaultEffort: 'high',
+          fastMode: true
+        })
+        expect(caps[1]!.caps).toEqual({ name: 'Model B' })
 
         // Wire: the emitted catalog entry augments claude runtimes with the
         // synthetic tiers; non-claude runtimes report the raw levels as-is.
@@ -449,10 +458,15 @@ describe('daemon sweep phase-1 catalog seeding', () => {
           models: [
             {
               id: 'a',
+              name: 'Model A',
+              description: 'Model A · the everyday one',
               efforts: claude ? [...rawEfforts, { value: 'max' }, { value: 'ultracode' }] : rawEfforts,
               defaultEffort: 'high',
               fastMode: true
-            }
+            },
+            // Advertised but not yet enumerated: display metadata only, so the
+            // picker can label and hover it while `efforts` stays undiscovered.
+            { id: 'b', name: 'Model B' }
           ],
           defaultModel: 'a',
           permissionModes: [
@@ -471,6 +485,38 @@ describe('daemon sweep phase-1 catalog seeding', () => {
       }
     }
   )
+
+  it('a re-probe refreshes display metadata without wiping a same-fingerprint enumerated matrix', async () => {
+    const rt: RuntimeDef = { command: 'fake-agent', args: ['--acp'], env: [] }
+    const clock = new FakeClock()
+    clock.advance(10_000)
+    const probe = vi.fn(async (): Promise<RuntimeProbeResult[]> => [
+      { runtime: 'probed', ok: true, models: ['a', 'b'], currentModel: 'a', probedVersion: '1.0', configOptions }
+    ])
+    const daemon = daemonWith({ root: root(), catalog: catalogOf({ probed: rt }), clock, probe })
+    try {
+      await daemon.start()
+      stubCatalogSvc(daemon)
+      const store = (daemon as any).store as LocalStore
+      // What phase 2 left behind for the model the probe session never sits on.
+      await store.upsertRuntimeModelCap({
+        runtimeId: 'probed',
+        modelId: 'b',
+        fingerprint: catalogFingerprint('probed', '1.0', rt),
+        caps: { efforts: [{ value: 'low' }], fastMode: false },
+        observedAt: 5_000
+      })
+      await (daemon as any).runtimeFacts.probeAndEmit(true)
+      const caps = await store.listRuntimeModelCaps('probed')
+      expect(caps.find((r) => r.modelId === 'b')!.caps).toEqual({
+        name: 'Model B',
+        efforts: [{ value: 'low' }],
+        fastMode: false
+      })
+    } finally {
+      await daemon.stop()
+    }
+  })
 
   it('seeds caps under a runtime-advertised literal "default" model; meta.defaultModel stays unset', async () => {
     const rt: RuntimeDef = { command: 'fake-agent', args: ['--acp'], env: [] }
@@ -500,7 +546,7 @@ describe('daemon sweep phase-1 catalog seeding', () => {
       // preselection/hint) — but the caps row IS seeded under "default" so
       // selecting it surfaces the runtime's own effort/fast.
       expect(await store.getRuntimeCatalogMeta('probed')).not.toHaveProperty('defaultModel')
-      expect((await store.listRuntimeModelCaps('probed')).map((r) => r.modelId)).toEqual(['default'])
+      expect((await store.listRuntimeModelCaps('probed')).map((r) => r.modelId)).toEqual(['a', 'b', 'default'])
     } finally {
       await daemon.stop()
     }

--- a/packages/daemon/test/model-catalog.test.ts
+++ b/packages/daemon/test/model-catalog.test.ts
@@ -13,6 +13,7 @@ import {
   type EnumerateResult,
   type ModelCatalogDriver
 } from '../src/runtimes/model-catalog.js'
+import { capsFromConfigOptions } from '../src/runtimes/config-caps.js'
 
 const rt: RuntimeDef = { command: 'fake-agent', args: ['--acp'], env: [] }
 
@@ -393,6 +394,32 @@ describe('ModelCatalogService enumeration fallback', () => {
   })
 })
 
+describe('capsFromConfigOptions', () => {
+  const select = (options: unknown[]) =>
+    [{ id: 'model', name: 'Model', category: 'model', type: 'select', currentValue: 'a', options }] as never
+
+  it('carries every model option\u2019s display metadata, not just the current one', () => {
+    const caps = capsFromConfigOptions(
+      select([
+        { value: 'a', name: 'Model A', description: 'The everyday one' },
+        { group: 'More', options: [{ value: 'b', name: 'Model B' }, { value: 'c' }] }
+      ])
+    )
+    expect(caps.currentModel).toBe('a')
+    expect(caps.modelName).toBe('Model A')
+    expect(caps.modelChoices).toEqual([
+      { value: 'a', name: 'Model A', description: 'The everyday one' },
+      { value: 'b', name: 'Model B' },
+      { value: 'c' }
+    ])
+  })
+
+  it('drops a display name that only repeats the value, and reports no choices without a model select', () => {
+    expect(capsFromConfigOptions(select([{ value: 'a', name: 'a' }])).modelChoices).toEqual([{ value: 'a' }])
+    expect(capsFromConfigOptions([]).modelChoices).toBeUndefined()
+  })
+})
+
 describe('codexModelsFromListResult', () => {
   it('maps camelCase RPC entries and skips the literal "default"', () => {
     const catalog = codexModelsFromListResult({
@@ -400,6 +427,7 @@ describe('codexModelsFromListResult', () => {
         {
           id: 'gpt-5.2-codex',
           displayName: 'GPT-5.2 Codex',
+          description: 'Reliable agentic workhorse for everyday tasks.',
           supportedReasoningEfforts: [
             { reasoningEffort: 'low', description: 'Fastest' },
             { reasoningEffort: 'high', description: 'Deepest' }
@@ -416,6 +444,7 @@ describe('codexModelsFromListResult', () => {
         {
           id: 'gpt-5.2-codex',
           name: 'GPT-5.2 Codex',
+          description: 'Reliable agentic workhorse for everyday tasks.',
           efforts: [
             { value: 'low', description: 'Fastest' },
             { value: 'high', description: 'Deepest' }

--- a/packages/protocol/src/frames/telemetry.ts
+++ b/packages/protocol/src/frames/telemetry.ts
@@ -279,6 +279,7 @@ export type PermissionModeOption = z.infer<typeof PermissionModeOption>
 export const RuntimeModelCapability = z.object({
   id: z.string(), // model-selector value
   name: z.string().optional(), // display name (sent only when it differs from id)
+  description: z.string().optional(), // the runtime's own one-line model blurb — the picker's tooltip
   efforts: z.array(EffortOption).optional(),
   defaultEffort: z.string().optional(),
   fastMode: z.boolean().optional()

--- a/packages/web/src/components/console/ComposerMenu.tsx
+++ b/packages/web/src/components/console/ComposerMenu.tsx
@@ -53,8 +53,9 @@ export function ComposerMenu({
   /** Icon-only trigger (e.g. the Home composer's "+ add agents" chip): render only
    *  `leading` — no selected-value label, no chevron. */
   iconOnly?: boolean
-  /** Hover-tooltip the trigger + options (via the console Tooltip layer). Turn off
-   *  for self-explanatory menus (model / effort / permission) where the popover is noise. */
+  /** Hover-tooltip the trigger + options with the generic "<title>: <label>" text. Turn
+   *  off for self-explanatory menus (model / effort / permission) where that reads as
+   *  noise; a choice's own `description` is shown either way. */
   tooltips?: boolean
   onOpenChange: (open: boolean) => void
   onChange: (value: string) => void
@@ -63,8 +64,10 @@ export function ComposerMenu({
   const menuId = useId()
   const headingId = useId()
   const selected = options.find((choice) => choice.value === value) ?? options[0]
+  // A choice's own description always shows: `tooltips` only governs the generic
+  // "<title>: <label>" fallback, which is the part that reads as noise.
   const tooltipFor = (choice: ComposerMenuChoice | undefined) =>
-    tooltips ? (choice?.description ?? (choice ? `${title}: ${choice.label}` : title)) : undefined
+    choice?.description ?? (tooltips ? (choice ? `${title}: ${choice.label}` : title) : undefined)
 
   const closeAndFocus = () => {
     onOpenChange(false)

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -21,6 +21,7 @@ import {
   fastModeAvailableFor,
   modelCapability,
   modelLabel,
+  modelTooltip,
   displayedEffort,
   preferredModelFor,
   resolvedPermissionMode,
@@ -922,7 +923,11 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                   rather than a fabricated "Default" entry the runtime never offered. */}
                   <div
                     className={models.length ? 'inp relative' : 'inp cursor-not-allowed'}
-                    title={models.length ? undefined : 'This runtime reports no selectable models'}
+                    title={
+                      models.length
+                        ? modelTooltip(daemon, effectiveRuntime, selectedModel)
+                        : 'This runtime reports no selectable models'
+                    }
                   >
                     <span className={`truncate ${models.length ? '' : 'text-(--text-tertiary)'}`}>
                       {models.length ? modelLabel(selectedModel) : '—'}
@@ -949,7 +954,7 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                           aria-label="Model"
                         >
                           {models.map((m) => (
-                            <option key={m} value={m}>
+                            <option key={m} value={m} title={modelTooltip(daemon, effectiveRuntime, m)}>
                               {modelLabel(m)}
                             </option>
                           ))}

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -10,6 +10,7 @@ import {
   fastModeAvailableFor,
   modelCapability,
   modelLabel,
+  modelTooltip,
   displayedEffort,
   preferredModelFor,
   resolveEffortForModel,
@@ -812,7 +813,11 @@ export default function EditAgentModal({
                         rather than a fabricated "Default" entry the runtime never offered. */}
                     <div
                       className={modelSelectable ? 'inp relative' : 'inp cursor-not-allowed'}
-                      title={modelSelectable ? undefined : 'This runtime reports no selectable models'}
+                      title={
+                        modelSelectable
+                          ? modelTooltip(daemon, runtime, selectedModel)
+                          : 'This runtime reports no selectable models'
+                      }
                     >
                       <span className={`truncate ${modelSelectable ? '' : 'text-(--text-tertiary)'}`}>
                         {modelSelectable ? modelLabel(selectedModel) : '—'}
@@ -835,7 +840,7 @@ export default function EditAgentModal({
                             aria-label="Model"
                           >
                             {modelOptions.map((m) => (
-                              <option key={m} value={m}>
+                              <option key={m} value={m} title={modelTooltip(daemon, runtime, m)}>
                                 {modelLabel(m)}
                                 {!reportedModels.includes(m) ? ' (unavailable)' : ''}
                               </option>

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -36,6 +36,7 @@ import {
   agentLabel,
   agentPlacementKind,
   modelLabel,
+  modelTooltip,
   agentModelDisplay,
   runtimeLabel,
   effectiveAgentStatus,
@@ -270,7 +271,10 @@ export default function HomeView() {
       ? agent.model
       : preferredModelFor(owningDaemon, agent?.runtime ?? '') || agent?.model || ''
   const model = runtime.model ?? defaultModel
-  const modelChoices = (models.length ? models : model ? [model] : []).map((m) => ({ value: m, label: modelLabel(m) }))
+  const modelChoices = (models.length ? models : model ? [model] : []).map((m) => {
+    const description = agent ? modelTooltip(owningDaemon, agent.runtime, m) : undefined
+    return { value: m, label: modelLabel(m), ...(description ? { description } : {}) }
+  })
 
   // Effort + permission come from the SELECTED model's discovered capability / the
   // runtime catalog — the same catalog-aware helpers the session and add/edit controls

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -16,6 +16,7 @@ import {
   isPoolPlacementKind,
   localDaemons,
   modelLabel,
+  modelTooltip,
   poolLabel,
   preferredModelFor,
   loginRequiredRuntimeIds
@@ -495,7 +496,8 @@ function useRuntimeModel(daemon?: DaemonRow, initial?: { runtime?: string; model
   const models = daemon?.runtimeModels.find((r) => r.runtime === effectiveRuntime)?.models ?? []
   const [model, setModel] = useState(initial?.model ?? '')
   const selectedModel = models.includes(model) ? model : daemon ? preferredModelFor(daemon, effectiveRuntime) : ''
-  return { runtimeIds, runtimesNeedingLogin, effectiveRuntime, models, selectedModel, setRuntime, setModel }
+  const tooltip = (m: string) => modelTooltip(daemon, effectiveRuntime, m)
+  return { runtimeIds, runtimesNeedingLogin, effectiveRuntime, models, selectedModel, tooltip, setRuntime, setModel }
 }
 
 function RuntimeModelFields({ rm }: { rm: ReturnType<typeof useRuntimeModel> }) {
@@ -517,7 +519,7 @@ function RuntimeModelFields({ rm }: { rm: ReturnType<typeof useRuntimeModel> }) 
         <span className="fldlbl">Model</span>
         <div
           className={rm.models.length ? 'inp relative' : 'inp cursor-not-allowed'}
-          title={rm.models.length ? undefined : 'This runtime reports no selectable models'}
+          title={rm.models.length ? rm.tooltip(rm.selectedModel) : 'This runtime reports no selectable models'}
         >
           <span className={`truncate ${rm.models.length ? '' : 'text-(--text-tertiary)'}`}>
             {rm.models.length ? modelLabel(rm.selectedModel) : '—'}
@@ -532,7 +534,7 @@ function RuntimeModelFields({ rm }: { rm: ReturnType<typeof useRuntimeModel> }) 
                 aria-label="Model"
               >
                 {rm.models.map((m) => (
-                  <option key={m} value={m}>
+                  <option key={m} value={m} title={rm.tooltip(m)}>
                     {modelLabel(m)}
                   </option>
                 ))}

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -23,6 +23,7 @@ import {
   lane,
   modelCapability,
   modelLabel,
+  modelTooltip,
   MOCK_MODE,
   MOCK_PREFIX,
   permissionModeLabel,
@@ -4617,7 +4618,14 @@ export default function SessionDetailView() {
                                 <ComposerMenu
                                   title="Model"
                                   value={pgModel}
-                                  options={pgModelOptions.map((model) => ({ value: model, label: modelLabel(model) }))}
+                                  options={pgModelOptions.map((model) => {
+                                    const description = modelTooltip(owningDaemon, agentRuntime, model)
+                                    return {
+                                      value: model,
+                                      label: modelLabel(model),
+                                      ...(description ? { description } : {})
+                                    }
+                                  })}
                                   open={composerMenuOpen === 'model'}
                                   align="left"
                                   triggerClassName={COMPOSER_PILL}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1010,6 +1010,7 @@ export interface RuntimeModelCatalogDto {
   models: Array<{
     id: string
     name?: string
+    description?: string
     efforts?: Array<{ value: string; name?: string; description?: string }>
     defaultEffort?: string
     fastMode?: boolean

--- a/packages/web/src/lib/data.test.ts
+++ b/packages/web/src/lib/data.test.ts
@@ -15,6 +15,7 @@ import {
   rosterParticipantName,
   modelCapability,
   modelLabel,
+  modelTooltip,
   permissionModeChoicesFor,
   preferredModelFor,
   PLAYGROUND_CHANNEL_FILTER,
@@ -253,6 +254,27 @@ describe('modelCapability', () => {
     expect(modelCapability(undefined, 'claude', 'opus')).toBeUndefined()
     expect(modelCapability(daemonWith(catalog()), 'claude', 'haiku')).toBeUndefined()
     expect(modelCapability(daemonWith(catalog()), 'codex', 'opus')).toBeUndefined()
+  })
+})
+
+describe('modelTooltip', () => {
+  const described = catalog({
+    models: [
+      { id: 'opus', name: 'Opus (1M context)', description: 'Opus 5 with 1M context', efforts: [] },
+      { id: 'sonnet', name: 'Sonnet' },
+      { id: 'haiku' }
+    ]
+  })
+
+  it('prefers the runtime blurb, falls back to the display name', () => {
+    expect(modelTooltip(daemonWith(described), 'claude', 'opus')).toBe('Opus 5 with 1M context')
+    expect(modelTooltip(daemonWith(described), 'claude', 'sonnet')).toBe('Sonnet')
+  })
+
+  it('is undefined for an undescribed model, an unknown one, or a daemon with no catalog', () => {
+    expect(modelTooltip(daemonWith(described), 'claude', 'haiku')).toBeUndefined()
+    expect(modelTooltip(daemonWith(described), 'claude', 'nope')).toBeUndefined()
+    expect(modelTooltip(daemonWith(null), 'claude', 'opus')).toBeUndefined()
   })
 })
 

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -772,6 +772,7 @@ export interface EffortOption {
 export interface RuntimeModelCapability {
   id: string
   name?: string
+  description?: string
   efforts?: EffortOption[]
   defaultEffort?: string
   fastMode?: boolean
@@ -802,6 +803,18 @@ export function modelCapability(
   const id = modelId || catalog.defaultModel
   if (!id) return undefined
   return catalog.models.find((m) => m.id === id)
+}
+
+/** Hover text for one model option: the runtime's own blurb, else its display name.
+ *  The id stays the LABEL — it is what the agent stores and the runtime answers to —
+ *  so the runtime's prose lives here instead (runtime-model-catalog.md §7). */
+export function modelTooltip(
+  daemon: Pick<DaemonRow, 'runtimeModels'> | undefined,
+  runtime: string,
+  modelId: string
+): string | undefined {
+  const capability = modelCapability(daemon, runtime, modelId)
+  return capability?.description ?? capability?.name
 }
 
 /** The model the picker preselects when no explicit choice is stored: the


### PR DESCRIPTION
## Why

The console's model picker labels an option by its advertised id and nothing else, so `opus[1m]` reads as `opus[1m]`. The probe response the picker is built from already carries `"Opus (1M context)"` and `"Opus 5 with 1M context · …"` for that very option — Zed shows exactly that text as a tooltip — but the daemon kept only the CURRENT model's `name` and dropped every `description` at `capsFromConfigOptions`.

## What

- `RuntimeModelCapability` gains `description` (protocol → SQLite cache → CP DTO → web).
- **Phase 1 now seeds display metadata for every advertised model**, not just the one the probe session sits on: one `session/new` response describes the whole select, and a `--k8s` member never runs the phase-2 enumeration that would otherwise learn it. Cloud daemons therefore get names/descriptions on the first probe.
- The write merges over a same-fingerprint row, so an enumerated matrix keeps its efforts; the ACP enumerator and the codex driver (`model/list` carries a per-model `description`) carry the metadata through their own paths.
- The **id stays the label** — it is what the agent stores and the runtime answers to (§7) — so the prose becomes the option's hover text in the four catalog-driven pickers (Add/Edit agent, onboarding, Home + session composer).
- A `ComposerMenu` choice's own `description` now shows even under `tooltips={false}`; that flag exists to suppress the generic `"<title>: <label>"` filler, which is the part that reads as noise.

## Test

- `model-catalog-daemon.test.ts`: phase 1 writes a full row for the seed model plus a display-only row per advertised model; a re-probe refreshes metadata without wiping a same-fingerprint enumerated matrix.
- `model-catalog.test.ts`: `capsFromConfigOptions` carries every option's metadata (groups flattened, `name === value` dropped); codex driver maps `description`.
- `data.test.ts`: `modelTooltip` prefers the blurb, falls back to the name, is undefined otherwise.
- `pnpm typecheck`, web suite (2358), daemon probe/catalog suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)