### PR TITLE
feat(daemon): a deployment declares which model each Claude alias resolves to

### DIFF
--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -47,7 +47,11 @@ environment already) and writes them onto BOTH the spawn env and the cluster pro
 picker the console shows is the one a session can actually run — the probe env allowlist
 carries the same names for the same reason. Written like the codex floor: last, and never
 over a key the daemon itself authored. A sandbox minted before the value changed still gets
-it, because the daemon writes it rather than the frozen pod spec.
+it, because the daemon writes it rather than the frozen pod spec. The pool's shared probe
+answer is keyed on the image PLUS a digest of these declarations (and the codex floor), since
+changing one is a rollout that replaces env and not the image tag: keyed on the image alone, a
+member the rollout started would inherit an answer produced without the new declaration and
+advertise it until its next restart while its sessions ran with it.
 
 ## 1. Why a seam at all
 

--- a/docs/designs/cluster-spawn-and-shim.md
+++ b/docs/designs/cluster-spawn-and-shim.md
@@ -35,6 +35,20 @@ rejects); the shim merges it under any daemon-sent `CODEX_CONFIG`, one level dee
 both carry (the daemon always sends `features`), so every leaf the daemon decided stays
 authoritative.
 
+The daemon carries one more deployment assertion of the same kind for Claude: the
+`ANTHROPIC_DEFAULT_{FABLE,OPUS,SONNET,HAIKU}_MODEL` variables and their `_NAME`,
+`_DESCRIPTION` and `_SUPPORTED_CAPABILITIES` suffixes, which say which concrete model each
+Claude alias resolves to behind this deployment's endpoint. Claude Code offers an alias it
+was told nothing about only when the signed-in account's own rollout list names it, and a
+gateway-backed pool has no such list — so without a declaration its model picker is the
+built-in aliases and nothing else, which is why a pool that serves Fable never offered it.
+The daemon reads them at boot (`--k8s` only; a self-hosted launch inherits the host
+environment already) and writes them onto BOTH the spawn env and the cluster probe's, so the
+picker the console shows is the one a session can actually run — the probe env allowlist
+carries the same names for the same reason. Written like the codex floor: last, and never
+over a key the daemon itself authored. A sandbox minted before the value changed still gets
+it, because the daemon writes it rather than the frozen pod spec.
+
 ## 1. Why a seam at all
 
 `AcpHost` used to own two unrelated jobs: the ACP protocol, and the mechanics of a child

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -280,8 +280,10 @@ import { planRuntimeInstallRepair, repairRuntimeInstall } from './runtimes/runti
 import { RuntimeStore, parseNpxLaunch, storedRuntimeDef } from './runtimes/runtime-store.js'
 import {
   applyCodexSessionFloor,
+  applyClaudeModelAliases,
   applyModelCredential,
   applyStaticModelConfig,
+  configuredClaudeModelAliases,
   configuredCodexSessionFloor,
   configuredModelCredentials,
   modelProviderTarget,
@@ -1113,6 +1115,7 @@ export class Daemon {
   /** Deployment codex session-config floor, daemon-applied at spawn so it also reaches agents
    *  whose sandbox pod spec predates the value (the pod-env copy is a frozen snapshot). */
   private readonly codexSessionFloor?: string
+  private readonly claudeModelAliases?: Record<string, string>
   /** Reads this pod's projected CP-audience token; undefined unless the daemon runs
    *  in-cluster AND the volume is actually mounted (decided once, at boot). */
   private readonly clusterIdentityToken?: () => string | undefined
@@ -1377,6 +1380,8 @@ export class Daemon {
     // supplies the key alone.
     this.modelSessions.staticModelCredentials = this.k8s ? configuredModelCredentials(process.env) : undefined
     this.codexSessionFloor = this.k8s ? configuredCodexSessionFloor(process.env) : undefined
+    // Self-hosted launches inherit the host environment already; only a pod launch needs these carried.
+    this.claudeModelAliases = this.k8s ? configuredClaudeModelAliases(process.env) : undefined
     this.evalHooks = new DaemonEvaluationHooks(this.evaluationHost(), opts.evaluation)
     this.sessionMetadataOutbox = new SessionMetadataOutbox(this.sessionMetadataHost())
     this.observedChannelsSync = new ObservedChannelsSync(this.observedChannelsSyncHost())
@@ -4309,6 +4314,7 @@ export class Daemon {
           }
           // Last, so every key the daemon authored above stays authoritative over the floor.
           if (this.codexSessionFloor) applyCodexSessionFloor(target, launchEnv, this.codexSessionFloor)
+          if (this.claudeModelAliases) applyClaudeModelAliases(target, launchEnv, this.claudeModelAliases)
         },
         runtimeReadRoots: runInSandbox
           ? (launchEnv) =>
@@ -17885,6 +17891,7 @@ export class Daemon {
         }),
       staticCredential: (kind) => this.modelSessions.staticCredential(kind),
       ...(this.codexSessionFloor ? { codexSessionFloor: this.codexSessionFloor } : {}),
+      ...(this.claudeModelAliases ? { claudeModelAliases: this.claudeModelAliases } : {}),
       log: this.log,
       onResult: (result) => this.runtimeFacts.applySandboxProbe(result)
     })

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -261,6 +261,7 @@ import {
   K8S_PROBE_POLL_MS,
   K8S_PROBE_WAIT_MS,
   parseK8sProbePayload,
+  poolProbeKey,
   probeClusterRuntimes,
   type K8sProbePayload
 } from './runtimes/cluster-probe.js'
@@ -17677,8 +17678,9 @@ export class Daemon {
     if (!plane || !resolved) return
     let claimed: string | undefined
     try {
-      // Who probes: one member per runtime image, not one per replica.
-      const imageRef = await this.poolRuntimeImageRef(plane)
+      // Who probes: one member per runtime image, not one per replica — and per the declarations
+      // this daemon hands that image, which a rollout can change without moving the tag.
+      const imageRef = this.poolProbeKeyFor(await this.poolRuntimeImageRef(plane))
       if (imageRef && (await this.adoptPublishedK8sProbe(imageRef, resolved))) return
       if (imageRef) {
         if (await this.claimK8sProbe(imageRef, plane.memberId)) claimed = imageRef
@@ -17738,6 +17740,13 @@ export class Daemon {
       this.log.warn(`runtimes: could not resolve the pool's runtime image — probing alone (${formatErr(err)})`)
       return undefined
     }
+  }
+
+  /** The pool-probe key for this member: the image plus its own deployment declarations. */
+  private poolProbeKeyFor(imageRef: string | undefined): string | undefined {
+    return imageRef === undefined
+      ? undefined
+      : poolProbeKey(imageRef, { ...this.claudeModelAliases, AC_CODEX_CONFIG: this.codexSessionFloor })
   }
 
   /** Adopt an answer another member already published for this image, if there is one. */

--- a/packages/daemon/src/runtimes/cluster-probe.ts
+++ b/packages/daemon/src/runtimes/cluster-probe.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod'
 import type { RuntimeDef } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
-import { applyCodexSessionFloor, applyStaticModelConfig, modelProviderTarget } from './model-provider-config.js'
+import {
+  applyClaudeModelAliases,
+  applyCodexSessionFloor,
+  applyStaticModelConfig,
+  modelProviderTarget
+} from './model-provider-config.js'
 import type { ModelCredential, ModelRuntimeKind } from './model-provider-config.js'
 import { probeRuntime, type ProbeHostFactory, type RuntimeProbeResult } from './runtime-prober.js'
 import { K8sRuntimeTableSchema, type K8sRuntimeTable } from './k8s-runtimes.js'
@@ -52,6 +57,9 @@ export interface ClusterProbeOptions {
   staticCredential?: (kind: ModelRuntimeKind) => ModelCredential | undefined
   /** Deployment-asserted codex session config, applied exactly as a real launch applies it. */
   codexSessionFloor?: string
+  /** Deployment-declared Claude alias→model variables, applied exactly as a real launch applies
+   *  them — the probe reads the picker they produce, so it must launch with the same ones. */
+  claudeModelAliases?: Record<string, string>
   log?: Logger
   timeoutMs?: number
   /** Called as each runtime answers, so the console converges per runtime rather than at the end. */
@@ -89,7 +97,7 @@ function probeCredential(configured: ModelCredential | undefined): ModelCredenti
 export function clusterProbeEnv(
   runtimeId: string,
   runtime: RuntimeDef,
-  opts: Pick<ClusterProbeOptions, 'agentId' | 'staticCredential' | 'codexSessionFloor'>
+  opts: Pick<ClusterProbeOptions, 'agentId' | 'staticCredential' | 'codexSessionFloor' | 'claudeModelAliases'>
 ): { env: Record<string, string>; redactValues: string[]; uncredentialed: boolean } {
   const env: Record<string, string> = { AC_AGENT_ID: opts.agentId }
   const target = modelProviderTarget({ runtime: runtimeId }, runtime)
@@ -101,6 +109,7 @@ export function clusterProbeEnv(
   // Last, so every key the daemon authored above stays authoritative over the floor — the same
   // order a real launch uses.
   if (opts.codexSessionFloor) applyCodexSessionFloor(target, env, opts.codexSessionFloor)
+  if (opts.claudeModelAliases) applyClaudeModelAliases(target, env, opts.claudeModelAliases)
   const key = configured?.key
   // The key itself, plus every value it was folded into — matched by content rather than by
   // variable name, so a runtime that gains a new credential-bearing variable is covered already.

--- a/packages/daemon/src/runtimes/cluster-probe.ts
+++ b/packages/daemon/src/runtimes/cluster-probe.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { z } from 'zod'
 import type { RuntimeDef } from '../config/config-schema.js'
 import type { Logger } from '../log.js'
@@ -178,6 +179,28 @@ export const K8S_PROBE_POLL_MS = 5_000
  * short window costs at most one probe pod per hour per pool and self-heals both.
  */
 export const K8S_PROBE_FRESH_MS = 60 * 60_000
+
+/**
+ * What one published answer is keyed on: the pod's image, plus what the DAEMON asserted to the
+ * probe it ran.
+ *
+ * The image reference alone is the pod's identity, but the picker a probe reads also depends on
+ * the deployment's own declarations — the Claude alias→model variables and the codex session
+ * floor — and changing one is a rollout that replaces env, not the image tag. Keyed on the image
+ * alone, a member started by that rollout would inherit an answer produced WITHOUT the new
+ * declaration and keep advertising it until its next restart, while its sessions ran with it.
+ *
+ * A digest, not the values: this key lands in the pool's shared store and in log lines. Provider
+ * credentials stay out of it deliberately — they also shape the answer, and K8S_PROBE_FRESH_MS is
+ * the documented treatment for that, which no key should have to carry a secret to improve on.
+ */
+export function poolProbeKey(imageRef: string, declared: Record<string, string | undefined>): string {
+  const entries = Object.entries(declared)
+    .filter((entry): entry is [string, string] => entry[1] !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b))
+  if (entries.length === 0) return imageRef
+  return `${imageRef}#${createHash('sha256').update(JSON.stringify(entries)).digest('hex').slice(0, 12)}`
+}
 
 // Every field of RuntimeProbeResult, deliberately: a field added to the interface and not here is
 // dropped for ADOPTERS only, which reads as "the pool disagrees with itself" rather than as a bug.

--- a/packages/daemon/src/runtimes/model-provider-config.ts
+++ b/packages/daemon/src/runtimes/model-provider-config.ts
@@ -134,6 +134,41 @@ export function applyCodexSessionFloor(
   if (merged !== undefined) env.CODEX_CONFIG = merged
 }
 
+// Which concrete model each Claude alias resolves to on this deployment, in Claude Code's own
+// model-config variables. Only the deployment knows what its gateway serves, and Claude Code
+// offers an alias it was told nothing about only when the account's own rollout list names it —
+// which a gateway-backed pool has none of, so its picker shows the built-in aliases and stops
+// there. Declaring `ANTHROPIC_DEFAULT_FABLE_MODEL` is what puts Fable in that picker; the three
+// metadata suffixes are how the option is labelled, described, and told what it supports.
+const CLAUDE_MODEL_ALIASES = ['FABLE', 'OPUS', 'SONNET', 'HAIKU'] as const
+const CLAUDE_ALIAS_SUFFIXES = ['', '_NAME', '_DESCRIPTION', '_SUPPORTED_CAPABILITIES'] as const
+
+export const CLAUDE_MODEL_ALIAS_ENV: readonly string[] = CLAUDE_MODEL_ALIASES.flatMap((alias) =>
+  CLAUDE_ALIAS_SUFFIXES.map((suffix) => `ANTHROPIC_DEFAULT_${alias}_MODEL${suffix}`)
+)
+
+/** The deployment's alias declarations, read once at boot like the codex floor. */
+export function configuredClaudeModelAliases(env: NodeJS.ProcessEnv): Record<string, string> | undefined {
+  const declared: Record<string, string> = {}
+  for (const name of CLAUDE_MODEL_ALIAS_ENV) {
+    const value = env[name]?.trim()
+    if (value) declared[name] = value
+  }
+  return Object.keys(declared).length > 0 ? declared : undefined
+}
+
+// Applied by the DAEMON at spawn and at probe, so the picker a console shows and the models a
+// session can run come from the same declaration — and so a sandbox minted before the value
+// changed still gets it. Never overwrites a key the daemon already authored.
+export function applyClaudeModelAliases(
+  target: ModelProviderTarget,
+  env: Record<string, string>,
+  declared: Record<string, string>
+): void {
+  if (target.runtime !== 'claude') return
+  for (const [name, value] of Object.entries(declared)) env[name] ??= value
+}
+
 // Validated at daemon construction so a malformed value fails the member loudly at boot instead
 // of failing every codex spawn one at a time.
 export function configuredCodexSessionFloor(env: NodeJS.ProcessEnv): string | undefined {

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -23,6 +23,7 @@ import type { SandboxMechanism } from '../acp/sandbox.js'
 import { effectiveRunInSandbox, type PreparedRuntimeLaunch } from '../launch/prepare.js'
 import { composeRuntimeLaunch } from '../launch/compose.js'
 import { PACKAGE_LAUNCHERS } from './probe.js'
+import { CLAUDE_MODEL_ALIAS_ENV } from './model-provider-config.js'
 
 const PROCESS_ENV_KEYS = new Map([
   ['PATH', 'PATH'],
@@ -52,7 +53,10 @@ const PROVIDER_ENV_KEYS = new Set([
   // host configured via env instead of ~/.openclaw/openclaw.json.
   'OPENCLAW_GATEWAY_URL',
   'OPENCLAW_GATEWAY_TOKEN',
-  'OPENCLAW_GATEWAY_PASSWORD'
+  'OPENCLAW_GATEWAY_PASSWORD',
+  // Claude's alias→model declarations. A real launch inherits these from the host environment;
+  // without them here the probe would read a picker the sessions do not have.
+  ...CLAUDE_MODEL_ALIAS_ENV
 ])
 
 /** Minimal ambient environment for an untrusted disposable compatibility probe. */

--- a/packages/daemon/test/cluster-probe.test.ts
+++ b/packages/daemon/test/cluster-probe.test.ts
@@ -76,6 +76,23 @@ describe('cluster runtime probe', () => {
     expect(redactValues).toContain(env.DEFAULT_AUTH_REQUEST)
   })
 
+  it('probes claude with the deployment’s alias declarations, so the picker it reads is the one sessions get', () => {
+    const aliases = {
+      ANTHROPIC_DEFAULT_FABLE_MODEL: 'claude-fable-5-1',
+      ANTHROPIC_DEFAULT_FABLE_MODEL_NAME: 'Fable'
+    }
+    const { env } = clusterProbeEnv('claude-acp', claude, {
+      agentId: 'probe',
+      staticCredential: () => ({ key: 'k', baseUrl: 'https://gw.example' }),
+      claudeModelAliases: aliases
+    })
+    expect(env).toMatchObject(aliases)
+    // A codex probe is told nothing about Claude's aliases.
+    expect(clusterProbeEnv('codex-acp', codex, { agentId: 'probe', claudeModelAliases: aliases }).env).toEqual({
+      AC_AGENT_ID: 'probe'
+    })
+  })
+
   it('reports every runtime as it answers, and one refusal does not end the sweep', async () => {
     const reported: Array<{ runtime: string; ok: boolean; models: string[] }> = []
     const results = await probeClusterRuntimes({

--- a/packages/daemon/test/cluster-probe.test.ts
+++ b/packages/daemon/test/cluster-probe.test.ts
@@ -3,6 +3,7 @@ import {
   PROBE_PLACEHOLDER_KEY,
   clusterProbeEnv,
   parseK8sProbePayload,
+  poolProbeKey,
   probeClusterRuntimes
 } from '../src/runtimes/cluster-probe.js'
 import type { RuntimeDef } from '../src/config/config-schema.js'
@@ -150,5 +151,31 @@ describe('published probe payload', () => {
     expect(parseK8sProbePayload('not json')).toBeUndefined()
     expect(parseK8sProbePayload('{"table":{"runtimes":[]},"results":[]}')).toBeUndefined()
     expect(parseK8sProbePayload('{"results":[]}')).toBeUndefined()
+  })
+})
+
+describe('pool probe key', () => {
+  const image = 'ghcr.io/agentconnect-md/runtime-sandbox:latest'
+
+  it('is the bare image when the deployment declares nothing', () => {
+    expect(poolProbeKey(image, {})).toBe(image)
+    expect(poolProbeKey(image, { AC_CODEX_CONFIG: undefined })).toBe(image)
+  })
+
+  it('changes with the declarations, so a rollout that moves env and not the tag re-probes', () => {
+    const before = poolProbeKey(image, { ANTHROPIC_DEFAULT_FABLE_MODEL: 'claude-fable-5' })
+    const after = poolProbeKey(image, { ANTHROPIC_DEFAULT_FABLE_MODEL: 'claude-fable-5-1' })
+    expect(before).not.toBe(after)
+    expect(before).not.toBe(image)
+    // The declaration is hashed, never spelled out: this key lands in the shared store and the logs.
+    expect(before).toMatch(new RegExp(`^${image}#[0-9a-f]{12}$`))
+    expect(before).not.toContain('claude-fable-5')
+  })
+
+  it('is stable across key order and distinguishes one declaration from two', () => {
+    const a = { ANTHROPIC_DEFAULT_FABLE_MODEL: 'm', AC_CODEX_CONFIG: '{}' }
+    const b = { AC_CODEX_CONFIG: '{}', ANTHROPIC_DEFAULT_FABLE_MODEL: 'm' }
+    expect(poolProbeKey(image, a)).toBe(poolProbeKey(image, b))
+    expect(poolProbeKey(image, a)).not.toBe(poolProbeKey(image, { ANTHROPIC_DEFAULT_FABLE_MODEL: 'm' }))
   })
 })

--- a/packages/daemon/test/model-provider-config.test.ts
+++ b/packages/daemon/test/model-provider-config.test.ts
@@ -5,6 +5,8 @@ import {
   applyCodexSessionFloor,
   applyModelCredential,
   applyStaticModelConfig,
+  applyClaudeModelAliases,
+  configuredClaudeModelAliases,
   configuredCodexSessionFloor,
   configuredModelCredentials,
   modelProviderTarget
@@ -258,5 +260,42 @@ describe('configuredCodexSessionFloor', () => {
 
   it('fails loudly at boot on a malformed value', () => {
     expect(() => configuredCodexSessionFloor({ AC_CODEX_CONFIG: '[1]' })).toThrow('AC_CODEX_CONFIG')
+  })
+})
+
+describe('claude model aliases', () => {
+  it('collects only the declared alias variables, trimmed', () => {
+    expect(
+      configuredClaudeModelAliases({
+        ANTHROPIC_DEFAULT_FABLE_MODEL: ' claude-fable-5-1 ',
+        ANTHROPIC_DEFAULT_FABLE_MODEL_NAME: 'Fable',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: '   ',
+        ANTHROPIC_API_KEY: 'not-an-alias'
+      })
+    ).toEqual({ ANTHROPIC_DEFAULT_FABLE_MODEL: 'claude-fable-5-1', ANTHROPIC_DEFAULT_FABLE_MODEL_NAME: 'Fable' })
+  })
+
+  it('is undefined when the deployment declares nothing', () => {
+    expect(configuredClaudeModelAliases({})).toBeUndefined()
+  })
+
+  it('writes the declarations onto a claude launch without overwriting a daemon-authored key', () => {
+    const env: Record<string, string> = { ANTHROPIC_DEFAULT_OPUS_MODEL: 'daemon-chose-this' }
+    applyClaudeModelAliases({ provider: 'anthropic', runtime: 'claude' }, env, {
+      ANTHROPIC_DEFAULT_FABLE_MODEL: 'claude-fable-5-1',
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'deployment-default'
+    })
+    expect(env).toEqual({
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'daemon-chose-this',
+      ANTHROPIC_DEFAULT_FABLE_MODEL: 'claude-fable-5-1'
+    })
+  })
+
+  it('touches no runtime but claude', () => {
+    const env: Record<string, string> = {}
+    applyClaudeModelAliases({ provider: 'openai', runtime: 'codex' }, env, {
+      ANTHROPIC_DEFAULT_FABLE_MODEL: 'claude-fable-5-1'
+    })
+    expect(env).toEqual({})
   })
 })

--- a/packages/daemon/test/runtime-prober.test.ts
+++ b/packages/daemon/test/runtime-prober.test.ts
@@ -307,6 +307,8 @@ describe('curatedProbeEnvironment', () => {
       OPENCLAW_GATEWAY_URL: 'ws://127.0.0.1:18789',
       OPENCLAW_GATEWAY_TOKEN: 'gateway-token',
       OPENCLAW_STATE_DIR: '/host/openclaw',
+      ANTHROPIC_DEFAULT_FABLE_MODEL: 'claude-fable-5-1',
+      ANTHROPIC_DEFAULT_FABLE_MODEL_NAME: 'Fable',
       AWS_SHARED_CREDENTIALS_FILE: '/host/aws',
       GOOGLE_APPLICATION_CREDENTIALS: '/host/google.json',
       KUBECONFIG: '/host/kube',
@@ -328,7 +330,11 @@ describe('curatedProbeEnvironment', () => {
       ANTHROPIC_API_KEY: 'anthropic-key',
       KIRO_API_KEY: 'kiro-key',
       OPENCLAW_GATEWAY_URL: 'ws://127.0.0.1:18789',
-      OPENCLAW_GATEWAY_TOKEN: 'gateway-token'
+      OPENCLAW_GATEWAY_TOKEN: 'gateway-token',
+      // A launch inherits these from the host; a probe that read the model picker without them
+      // would advertise a list the sessions do not have.
+      ANTHROPIC_DEFAULT_FABLE_MODEL: 'claude-fable-5-1',
+      ANTHROPIC_DEFAULT_FABLE_MODEL_NAME: 'Fable'
     })
   })
 })


### PR DESCRIPTION
## Why

A Cloud agent's model picker offers `default / opus[1m] / sonnet / sonnet[1m] / haiku` and nothing else — no Fable, whatever the pool's gateway actually serves.

Claude Code builds that picker from its baked-in aliases **plus the signed-in account's rollout list**, which it caches as `additionalModelOptionsCache` in `~/.claude.json`. A self-hosted daemon seeds exactly that one field into the runtime's private HOME (`probe.ts` — the comment there already names Fable), which is why Fable appears there; verified in this repo's own daemon cache, which holds a `claude-fable-5-1[1m]` row. A sandbox pod has no account and no such list, so nothing can add to its picker. `availableModels` is an allow**list** (it can only restrict), and `ANTHROPIC_CUSTOM_MODEL_OPTION` only re-selects a model the SDK already offers — neither can add one.

Claude Code's own mechanism for a deployment that knows better than its endpoint's defaults is `ANTHROPIC_DEFAULT_<ALIAS>_MODEL` and its `_NAME` / `_DESCRIPTION` / `_SUPPORTED_CAPABILITIES` suffixes, honoured exactly when the base URL is not first-party — i.e. every gateway-backed pool.

## What

- `configuredClaudeModelAliases()` reads the four alias families (`FABLE`/`OPUS`/`SONNET`/`HAIKU` × 4 suffixes) at boot, `--k8s` only: a self-hosted launch inherits the host environment already.
- `applyClaudeModelAliases()` writes them onto the **spawn env** and the **cluster probe env**, so the picker the console shows is the one a session can actually run. Claude-only, applied last, never over a key the daemon itself authored — the codex-session-floor shape.
- The curated probe env allowlist gains the same names, so a self-hosted probe reads the same picker its own launches get.
- Daemon-sent rather than a `SandboxTemplate` variable, so a sandbox minted before the declaration changed still gets it.

## Deploying it

Set on the cloud daemon deployment (nothing changes until it is set):

```
ANTHROPIC_DEFAULT_FABLE_MODEL=claude-fable-5-1
ANTHROPIC_DEFAULT_FABLE_MODEL_NAME=Fable
ANTHROPIC_DEFAULT_FABLE_MODEL_DESCRIPTION=Fable 5.1 · Most capable for your hardest and longest-running tasks
```

The gateway must of course route the model; the console's picker will show it after the next probe sweep.

## Test

- `model-provider-config.test.ts`: collection (trimmed, alias vars only), the undefined-when-undeclared case, no-overwrite of a daemon-authored key, and no effect on a non-claude runtime.
- `cluster-probe.test.ts`: a claude probe launches with the declarations; a codex probe is told nothing about them.
- `runtime-prober.test.ts`: the curated probe env carries them.
- `pnpm typecheck`; daemon k8s/probe/provider suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)