### PR TITLE
perf(control-plane): render an agent icon without scanning the system fonts

### DIFF
--- a/packages/control-plane/src/agents/agent-icon-render.ts
+++ b/packages/control-plane/src/agents/agent-icon-render.ts
@@ -106,6 +106,9 @@ export function buildAgentIconSvg(icon: AgentIcon | null, runtime: string | null
   return `${open}<rect width="64" height="64" fill="${DARK_PLATE}"/>${centered(runtimeMarkInner(runtime ?? ''), 0.62)}</svg>`
 }
 
+/** Composed icon SVGs are shapes only, never `<text>`, so skip resvg's system-font scan — it costs ~180ms of every render. */
+export const ICON_RENDER_FONT = { loadSystemFonts: false }
+
 /** Rasterize the console descriptor for consumers that require uploaded image
  * bytes rather than an SVG or public URL (the icon endpoint and bot profile setup).
  * Keep the native module lazy so a load failure degrades only the calling feature,
@@ -113,5 +116,7 @@ export function buildAgentIconSvg(icon: AgentIcon | null, runtime: string | null
 export async function renderAgentIconPng(icon: AgentIcon | null, runtime: string | null, width = 128): Promise<Buffer> {
   const { Resvg } = await import('@resvg/resvg-js')
   const svg = buildAgentIconSvg(icon, runtime)
-  return Buffer.from(new Resvg(svg, { fitTo: { mode: 'width', value: width } }).render().asPng())
+  return Buffer.from(
+    new Resvg(svg, { fitTo: { mode: 'width', value: width }, font: ICON_RENDER_FONT }).render().asPng()
+  )
 }

--- a/packages/control-plane/src/http/routes/org-icon.ts
+++ b/packages/control-plane/src/http/routes/org-icon.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyReply } from 'fastify'
 import { z } from 'zod'
 import type { ZodTypeProvider } from '../plugins/zod.js'
 import type { HttpDeps } from '../deps.js'
-import { buildAgentIconSvg } from '../../agents/agent-icon-render.js'
+import { buildAgentIconSvg, ICON_RENDER_FONT } from '../../agents/agent-icon-render.js'
 import { defaultOrgGlyphIcon } from '../../agents/agent-icon.js'
 import { orgIconKey, joinPublicUrl } from '../../icons/icon-store.js'
 
@@ -39,7 +39,7 @@ export function orgIconRoutes(deps: HttpDeps) {
         let png: Buffer
         try {
           const { Resvg } = await import('@resvg/resvg-js')
-          png = new Resvg(svg, { fitTo: { mode: 'width', value: 128 } }).render().asPng()
+          png = new Resvg(svg, { fitTo: { mode: 'width', value: 128 }, font: ICON_RENDER_FONT }).render().asPng()
         } catch (err) {
           req.log.error({ err }, 'org icon render failed')
           return reply.code(500).send()


### PR DESCRIPTION
## What

`renderAgentIconPng` and the org icon route both rasterize the SVG that `buildAgentIconSvg` composes. That SVG is shapes only — `rect`, `polygon`, `circle`, `path` — and never contains `<text>`. resvg nonetheless builds a system font database on every `new Resvg()`.

Both call sites now pass `font: { loadSystemFonts: false }`.

## Why

The font scan is ~180ms of an ~190ms render, so it is essentially the entire cost of both public icon endpoints:

```
default:                191ms / 172ms
loadSystemFonts:false:    2ms /   2ms
```

It also caused a unit-test flake. The three bot-profile icon suites pay that render inside Vitest's 5s unit budget, so an oversubscribed runner can push a ~1s test past the wall — which is what happened on the `Release` run for #1769: `discord-bot-profile.test.ts` timed out at 5094ms, while the sibling `feishu-app-icon.test.ts` scraped past at 4729ms. A re-run of the same commit was green, with the same files at 1121ms and 856ms.

## Verification

- **Output is unchanged.** Every glyph in `AGENT_ICON_GLYPHS` plus each runtime mark — 31 composed SVGs — renders byte-identical PNGs with and without the font scan (checked with a throwaway test, not committed).
- The three icon suites' first tests drop from 229/226/219ms to 21/17/19ms; the files' `tests` phase goes from 1.05s to 77ms. On a runner 5x slower than healthy that is ~100ms against the 5s budget.
- `test:unit` for the package: 190 files / 2247 tests green. `typecheck`, `eslint`, `prettier --check` clean.
- `test/integration/agent-icon-sync.route.test.ts` green against real Postgres.

## For the reviewer

One thing this does **not** fix: when a test in these files times out, its in-flight `sync()` keeps running and its `fetch` lands on the *next* test's fresh mock, so the next test reads the previous test's request body and fails on an unrelated assertion. That is how the timeout surfaced as `expected [ 244, 121, 58 ] to deeply equal [ 12, 34, 56 ]` — the received value is the first test's brand-diamond avatar. The trigger is removed here; the amplifier is still there if anything else ever times out in these files. Happy to address it separately if you want it closed off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
