### PR TITLE
fix(daemon): one rule decides whether a session is confined

### DIFF
--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -320,7 +320,14 @@ the parent of anything.
   and the session fetches for itself when it wants newer state. Session branches
   exist only in the clone.
 - **Review sessions** fetch `refs/pull/<n>/merge` into the clone and verify the
-  checked-out HEAD exactly as today.
+  checked-out HEAD exactly as today. That fetch joins the class of daemon-run Git
+  that must MATERIALIZE objects into a partial clone — with the clone itself, the
+  branch checkout and a review reset — and so runs with lazy fetching permitted:
+  resolving a fetched pack against objects the clone filtered out is a promisor
+  fetch, and under the daemon's usual `GIT_NO_LAZY_FETCH=1` it dies in
+  `unpack-objects`, which degraded every review in a confined session to
+  revision-only. Retirement is deliberately not in that class: it judges a clone
+  with no network target at all.
 - **Retirement** applies the same dirty and unique-commit rules in the clone —
   every local ref counts, not only HEAD, because the directory is the object
   store and a side branch or a stash is work the checked-out branch cannot speak
@@ -368,58 +375,47 @@ the volume, which is the same fail-closed gate that empties the primary checkout
 and the first point after the edit at which anything is authoritative. HOME is
 per pod by construction.
 
-### Changing the tier (decided 2026-09-03)
+### The tier a session is born in (decided 2026-09-03)
 
-A tier is a property of **one session**, not of the settings that created it, and the
-session's own directory is the record of it. Every side asks one question — the ACP host
-key, the pod a host launches into, workspace preparation, the launch's HOME and sandbox
-grants, the console reads, and retirement — so the answer cannot differ between them for
-the life of a session.
+A tier is a property of **one session**, decided when it is created and kept for its whole
+life. Changing an agent's `runInSandbox` or `workspaceIsolation` therefore reaches only
+sessions created afterwards. Every side asks one question — the ACP host key, the pod a host
+launches into, workspace preparation, the launch's HOME and sandbox grants, the console
+reads, and retirement — so no half of the daemon can start serving a live session somewhere
+the others do not address.
 
-The rule, in full:
+Two recorded values answer it, in order:
 
-1. The session already has its own directory on this daemon's disk ⇒ **confined**,
-   whatever the agent now says.
-2. Otherwise ⇒ what a session created now would get: the session is isolated and a
-   boundary encloses the runtime — its own pod on a pool member, the effective OS sandbox
-   on a self-hosted daemon.
+1. **Is this session isolated at all?** Its own `workspaceIsolation`, persisted on the
+   session row. `SessionManager` decides it once at creation (`rec?.workspaceIsolation ??
+agent.workspace.isolation`, and always `shared` for a from-scratch agent, whose primary is
+   not a repository to clone) and keeps it. A shared session gets no host, pod, HOME or
+   directory of its own. This is the value the console's workspace routing, retention and
+   preparation already read, so the tier must come from it and nothing else.
+2. **Which tier, then?** The clones or the worktree the session already stands in — the
+   artifact of the original decision, not an inference about it. A session that stands
+   nowhere yet takes what one created now would get: a boundary around the runtime (its own
+   pod on a pool member, the effective OS sandbox on a self-hosted daemon) means clones, and
+   no boundary means a worktree. A pool member has no local disk to ask, so its session pod
+   holds that record.
 
-A session is isolated when **either** the agent or the session says so, and isolation only
-ever escalates. The agent's `workspaceIsolation` is the operator's standing choice, and the
-only one a from-scratch agent can express — its rows always report `shared`, because its
-primary is not a repository to clone. The session's own isolation is the per-session
-escalation: a formal review forces `session` on an agent that defaults to shared, and every
-workspace request reaching the daemon reports which. Erring towards isolation is the safe
-direction, since a shared session under a boundary is one writing the owner checkout's
-`.git`. A pool member has no local disk to ask, so rule 2 alone answers there — its session
-pod holds the directory.
+An empty `worktrees/<sid>` directory is **absent**, never a worktree: it is what a failed or
+degraded preparation leaves, it has no `.git` for anything to read, and counting it would pin
+a session to a tier nothing on disk serves. That is not hypothetical — a session whose stub
+was mistaken for its worktree ran with a cwd no checkout root contained and failed every turn
+with `prepared workspace cwd … resolves outside its checkout root`, with no way to recover on
+its own. Such a stub is reclaimed (by a single `rmdir`, which refuses anything not provably
+empty) rather than counted, and a review with no trusted checkout stages its empty stand-in on
+the session's **own** tier for the same reason.
 
-The transition is **sticky one way**:
-
-- **Boundary removed** (`runInSandbox` off, or the session's isolation set to `shared`):
-  a session that already has clones **keeps them** until it retires. Its work lives there,
-  and unconfined the shared `.git` adds nothing, so there is nothing to gain by moving it
-  — while moving only half of the daemon is how a session ends up prepared in one
-  directory and launched in another. An unconfined launch of such a session therefore
-  still runs against its own clones: its Git grants name the clone's `.git`, not the
-  primary's.
-- **Boundary added**: a session still standing in a linked worktree **does move** to
-  clones on its next preparation. Leaving it would keep it writing the owner checkout's
-  `.git` — the cross-session channel this section exists to close — and that boundary is
-  the whole reason for the tier. Nothing is destroyed: the worktree and its work stay on
-  disk, and retirement judges them under the same dirty and unique-commit rules.
-
-Two consequences worth stating:
-
-- A shared session gets **no** host, pod, HOME or directory of its own. The confined tier
-  serves `isolation: 'session'`; a sandboxed agent set to `shared` runs every session on
-  its one host, with the agent's private HOME.
-- An empty `worktrees/<sid>` directory is **absent**, never a worktree: it is what a
-  failed or degraded preparation leaves, it has no `.git` for anything to read, and it is
-  reclaimed (by a single `rmdir`, which refuses anything not provably empty) rather than
-  counted. A review with no trusted checkout stages its empty stand-in on the session's
-  **own** tier for the same reason — in the other tier's parent it is a working directory
-  outside the checkout root the session actually stands in, which refuses every later turn.
+The one deliberate exception is `forceWorkspaceIsolation`, which a formal review and the
+webchat per-conversation choice use to re-pin a session's isolation mid-life. It is not a
+silent overwrite: the same write retires the runtime session (`acpSessionId` cleared, state
+and delivery cursor reset), so the next turn re-prepares from the new value. Which is also why
+the row's upsert lets the incoming `workspaceIsolation` win over the stored one — that
+precedence exists for this path alone, and every other writer either carries the stored value
+or omits it. A session re-pinned to `shared` simply stops standing in its clones; they are
+left on disk and judged by retirement under the usual dirty and unique-commit rules.
 
 ### Non-goals here
 

--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -368,6 +368,59 @@ the volume, which is the same fail-closed gate that empties the primary checkout
 and the first point after the edit at which anything is authoritative. HOME is
 per pod by construction.
 
+### Changing the tier (decided 2026-09-03)
+
+A tier is a property of **one session**, not of the settings that created it, and the
+session's own directory is the record of it. Every side asks one question — the ACP host
+key, the pod a host launches into, workspace preparation, the launch's HOME and sandbox
+grants, the console reads, and retirement — so the answer cannot differ between them for
+the life of a session.
+
+The rule, in full:
+
+1. The session already has its own directory on this daemon's disk ⇒ **confined**,
+   whatever the agent now says.
+2. Otherwise ⇒ what a session created now would get: the session is isolated and a
+   boundary encloses the runtime — its own pod on a pool member, the effective OS sandbox
+   on a self-hosted daemon.
+
+A session is isolated when **either** the agent or the session says so, and isolation only
+ever escalates. The agent's `workspaceIsolation` is the operator's standing choice, and the
+only one a from-scratch agent can express — its rows always report `shared`, because its
+primary is not a repository to clone. The session's own isolation is the per-session
+escalation: a formal review forces `session` on an agent that defaults to shared, and every
+workspace request reaching the daemon reports which. Erring towards isolation is the safe
+direction, since a shared session under a boundary is one writing the owner checkout's
+`.git`. A pool member has no local disk to ask, so rule 2 alone answers there — its session
+pod holds the directory.
+
+The transition is **sticky one way**:
+
+- **Boundary removed** (`runInSandbox` off, or the session's isolation set to `shared`):
+  a session that already has clones **keeps them** until it retires. Its work lives there,
+  and unconfined the shared `.git` adds nothing, so there is nothing to gain by moving it
+  — while moving only half of the daemon is how a session ends up prepared in one
+  directory and launched in another. An unconfined launch of such a session therefore
+  still runs against its own clones: its Git grants name the clone's `.git`, not the
+  primary's.
+- **Boundary added**: a session still standing in a linked worktree **does move** to
+  clones on its next preparation. Leaving it would keep it writing the owner checkout's
+  `.git` — the cross-session channel this section exists to close — and that boundary is
+  the whole reason for the tier. Nothing is destroyed: the worktree and its work stay on
+  disk, and retirement judges them under the same dirty and unique-commit rules.
+
+Two consequences worth stating:
+
+- A shared session gets **no** host, pod, HOME or directory of its own. The confined tier
+  serves `isolation: 'session'`; a sandboxed agent set to `shared` runs every session on
+  its one host, with the agent's private HOME.
+- An empty `worktrees/<sid>` directory is **absent**, never a worktree: it is what a
+  failed or degraded preparation leaves, it has no `.git` for anything to read, and it is
+  reclaimed (by a single `rmdir`, which refuses anything not provably empty) rather than
+  counted. A review with no trusted checkout stages its empty stand-in on the session's
+  **own** tier for the same reason — in the other tier's parent it is a working directory
+  outside the checkout root the session actually stands in, which refuses every later turn.
+
 ### Non-goals here
 
 - Narrowing the model-side push credential, or a daemon-owned publish tool.

--- a/packages/daemon/src/acp/host-key.ts
+++ b/packages/daemon/src/acp/host-key.ts
@@ -28,11 +28,15 @@ export function hostKeySessionKey(key: HostKey): string | undefined {
   return at < 0 ? undefined : key.slice(at + 1)
 }
 
+/** The leaf one logical session's daemon-owned state takes, named by the session key alone — the agent owns the parent, so its id adds nothing. */
+export function sessionKeyDirName(sessionKey: string): string {
+  return `session-${createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)}`
+}
+
 /** Leaf directory for daemon-owned per-host state under the agent dir; absent ⇒ the shared host. */
 export function hostKeyDirName(key: HostKey | undefined): string {
   const sessionKey = key === undefined ? undefined : hostKeySessionKey(key)
-  if (sessionKey === undefined) return 'agent'
-  return `session-${createHash('sha256').update(sessionKey).digest('hex').slice(0, 24)}`
+  return sessionKey === undefined ? 'agent' : sessionKeyDirName(sessionKey)
 }
 
 /** Printable form for logs: the agent id, plus the session leaf for a session-bound host. */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3607,33 +3607,33 @@ export class Daemon {
    * clones, its own ACP host (its own pod on a pool member), its own private HOME. The single rule
    * the host key, preparation, the launch and cleanup all ask.
    *
-   * Sticky one way, because the disk is the record: once a session has its own directory it keeps the
-   * confined tier until it retires, so turning `runInSandbox` or `workspaceIsolation` off never leaves
-   * preparation and launch serving different directories. A session that stands nowhere yet — and one
-   * still on a linked worktree, which under a boundary would go on writing the owner checkout's `.git`
-   * — takes the tier a session created now would get.
+   * A session is served in the tier it was BORN in, for its whole life: its recorded isolation says
+   * whether it has a tier of its own at all, and the clones or worktree it already stands in say
+   * which. Changing the agent's `runInSandbox` or `workspaceIsolation` therefore reaches only
+   * sessions created afterwards, and no half of the daemon can start serving a live one somewhere
+   * the others do not address.
    */
   private confinedSession(agent: Agent, sessionKey?: string): boolean {
     if (sessionKey === undefined) return false
-    return this.workspaces.confinedSessionTier(agent, sessionKey, this.confinedTierFor(agent, sessionKey))
-  }
-
-  /** The tier a session created NOW would get (§11): session isolation with a boundary around the runtime — its own pod on a pool member, the effective OS sandbox on a self-hosted daemon. A shared session gets no host, pod, HOME or directory of its own. */
-  private confinedTierFor(agent: Agent, sessionKey?: string): boolean {
-    return this.sessionIsolated(agent, sessionKey) && (this.k8s || this.agentRunsInSandbox(agent))
+    // A shared session has no tier of its own at all: no host, no pod, no HOME, no directory.
+    if (!this.sessionIsolated(agent, sessionKey)) return false
+    return this.workspaces.confinedSessionTier(agent, sessionKey, this.k8s || this.agentRunsInSandbox(agent))
   }
 
   /**
-   * Whether THIS session is isolated — either half may say so, and isolation only ever escalates.
+   * Whether THIS session is isolated — its own persisted isolation, never the agent's default where
+   * they differ: `SessionManager` keeps the isolation a session was opened with, a formal review
+   * forces `session`, and a webchat choice can force either.
    *
-   * The agent's setting is the operator's standing choice, and the only one a from-scratch agent can
-   * express: its rows always report `shared`, because its primary is not a repository to clone.
-   * The session's own isolation is the per-session escalation — a formal review forces `session` on an
-   * agent that defaults to shared — and every workspace request reaching this daemon reports it.
+   * It has to be that value and no other, because the console's workspace routing, retention and
+   * preparation all read it: a tier chosen from anything else would put the runtime in a directory
+   * they do not address. Every workspace request reaching this daemon reports it; a session none has
+   * described yet takes what `SessionManager` will compute for it.
    */
   private sessionIsolated(agent: Agent, sessionKey?: string): boolean {
-    if (agent.workspace.isolation === 'session') return true
-    return sessionKey !== undefined && this.sessionIsolation.get(sessionKey) === 'session'
+    const reported = sessionKey === undefined ? undefined : this.sessionIsolation.get(sessionKey)
+    if (reported !== undefined) return reported === 'session'
+    return agent.workspace.mode === 'git-repo' && agent.workspace.isolation === 'session'
   }
 
   /** The host that serves `sessionKey` of this agent: its own when the session is confined, else the shared one. */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -797,7 +797,7 @@ export class Daemon {
   // mirrors only the loaded local files and is rebuilt each reconcile.
   private agents = new Map<string, LoadedAgent>()
   private fileAgents = new Map<string, LoadedAgent>()
-  // Every live ACP host by HostKey (agent id, or agent id + session key under perSessionHost); every per-host map below is keyed alike.
+  // Every live ACP host by HostKey (agent id, or agent id + session key for a confined session); every per-host map below is keyed alike.
   private hosts = new Map<HostKey, AcpHost>()
   // Per-host launch facts: the agent dir (the roster entry is gone when a removed agent's host stops) and the launch cwd.
   private hostLaunch = new Map<HostKey, { agentDir: string; cwd: string }>()
@@ -3599,19 +3599,47 @@ export class Daemon {
     )
   }
 
-  // What each session's row says its isolation is, as the requests that reached this member reported it — the one fact a pool member's host keying needs without a store round trip.
+  // What each session's row says its isolation is, as the requests that reached this member reported it — the one fact host keying needs without a store round trip.
   private readonly sessionIsolation = new Map<string, 'shared' | 'session'>()
 
-  // git-workspace-model §11: a confined self-hosted launch gives every session its own host; a pool member gives an isolated session its own host AND pod, while a shared one keeps the agent's host in the agent's pod.
-  private perSessionHost(agent: Agent, sessionKey?: string): boolean {
-    if (this.k8s) return sessionKey !== undefined && this.sessionIsolation.get(sessionKey) === 'session'
-    return this.agentRunsInSandbox(agent)
+  /**
+   * git-workspace-model §11: whether one logical session is served on the CONFINED tier — its own
+   * clones, its own ACP host (its own pod on a pool member), its own private HOME. The single rule
+   * the host key, preparation, the launch and cleanup all ask.
+   *
+   * Sticky one way, because the disk is the record: once a session has its own directory it keeps the
+   * confined tier until it retires, so turning `runInSandbox` or `workspaceIsolation` off never leaves
+   * preparation and launch serving different directories. A session that stands nowhere yet — and one
+   * still on a linked worktree, which under a boundary would go on writing the owner checkout's `.git`
+   * — takes the tier a session created now would get.
+   */
+  private confinedSession(agent: Agent, sessionKey?: string): boolean {
+    if (sessionKey === undefined) return false
+    return this.workspaces.confinedSessionTier(agent, sessionKey, this.confinedTierFor(agent, sessionKey))
   }
 
-  /** The host that serves `sessionKey` of this agent: its own under perSessionHost, else the shared one. */
+  /** The tier a session created NOW would get (§11): session isolation with a boundary around the runtime — its own pod on a pool member, the effective OS sandbox on a self-hosted daemon. A shared session gets no host, pod, HOME or directory of its own. */
+  private confinedTierFor(agent: Agent, sessionKey?: string): boolean {
+    return this.sessionIsolated(agent, sessionKey) && (this.k8s || this.agentRunsInSandbox(agent))
+  }
+
+  /**
+   * Whether THIS session is isolated — either half may say so, and isolation only ever escalates.
+   *
+   * The agent's setting is the operator's standing choice, and the only one a from-scratch agent can
+   * express: its rows always report `shared`, because its primary is not a repository to clone.
+   * The session's own isolation is the per-session escalation — a formal review forces `session` on an
+   * agent that defaults to shared — and every workspace request reaching this daemon reports it.
+   */
+  private sessionIsolated(agent: Agent, sessionKey?: string): boolean {
+    if (agent.workspace.isolation === 'session') return true
+    return sessionKey !== undefined && this.sessionIsolation.get(sessionKey) === 'session'
+  }
+
+  /** The host that serves `sessionKey` of this agent: its own when the session is confined, else the shared one. */
   private hostKeyFor(agentId: string, sessionKey?: string): HostKey {
     const agent = this.agents.get(agentId)
-    return sessionKey !== undefined && agent && this.perSessionHost(agent, sessionKey)
+    return sessionKey !== undefined && agent && this.confinedSession(agent, sessionKey)
       ? sessionHostKey(agentId, sessionKey)
       : agentHostKey(agentId)
   }
@@ -3627,7 +3655,7 @@ export class Daemon {
 
   /** The pod a session-bound host launches into, or undefined for one that shares the agent's (a dream, a model-session host). */
   private podSubjectFor(agent: Agent, hostKey: HostKey): SandboxSubject | undefined {
-    return this.perSessionHost(agent, hostKeySessionKey(hostKey)) ? sandboxSubjectFor(hostKey) : undefined
+    return this.confinedSession(agent, hostKeySessionKey(hostKey)) ? sandboxSubjectFor(hostKey) : undefined
   }
 
   /** Every host key the agent has live, starting or stopping, plus its shared one (its start fence). */
@@ -3752,6 +3780,9 @@ export class Daemon {
   }
 
   private async runAgentWorkspacePreparation(agent: Agent, request?: PrepareSessionWorkspaceRequest): Promise<string> {
+    // The session's OWN isolation, learned here as at every other request seam, so the tier rule below
+    // and the host key this preparation was gated by cannot be reading two different answers.
+    if (request) this.sessionIsolation.set(request.sessionKey, request.isolation)
     // In --k8s the workspace lives on the sandbox pod's volume, in the POD's coordinates: the
     // sandbox has to exist before anything else (the channel reports where the volume mounts),
     // and none of the local preparation below may run — its mkdir/existsSync/skills work would
@@ -3762,11 +3793,10 @@ export class Daemon {
       // The pod's own preparation: clone and pull happen on its volume through the runner, and
       // none of the local work below runs — its mkdir, `existsSync(.git)` and skills installation
       // all land on this daemon's disk, describing a filesystem the runtime never reads.
-      if (request) this.sessionIsolation.set(request.sessionKey, request.isolation)
       const agentPod = agentSandboxSubject(agent.id)
       // §11: an isolated session prepares on ITS pod (its clones, its skills); the agent pod is held beside it for the secondary-root attestation and the reads that follow.
       const pod =
-        request && this.perSessionHost(agent, request.sessionKey)
+        request && this.confinedSession(agent, request.sessionKey)
           ? sandboxSubjectFor(sessionHostKey(agent.id, request.sessionKey))
           : agentPod
       const prepare = async (): Promise<string> => {
@@ -3792,7 +3822,7 @@ export class Daemon {
     return request
       ? this.workspaces.prepareSessionWorkspace(
           agent,
-          this.perSessionHost(agent) ? { ...request, confined: true } : request,
+          this.confinedSession(agent, request.sessionKey) ? { ...request, confined: true } : request,
           opts
         )
       : this.workspaces.prepareWorkspace(agent, opts)

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -527,6 +527,13 @@ export class GithubReviewOrchestrator {
     return initiatorLabel(initiator, (await this.host.displayNames([initiator])).get(initiator), msg.sender)
   }
 
+  /** The isolation this session ALREADY has, or the one it will be created with — never one a review picks for it. A formal review may ASK for isolation (an exact checkout has to be its own); a degraded one may not take it away. */
+  private async sessionIsolationFor(key: string, agent: Agent): Promise<'shared' | 'session'> {
+    const recorded = (await this.host.getSession(key))?.workspaceIsolation
+    if (recorded) return recorded
+    return agent.workspace.mode === 'git-repo' && agent.workspace.isolation === 'session' ? 'session' : 'shared'
+  }
+
   /** Prepare an exact, isolated checkout before a formal review generation. A
    * formal review may use GitHub read-only inspection when its configured local
    * repo differs, but it must never silently fall back to a stale checkout.
@@ -549,12 +556,18 @@ export class GithubReviewOrchestrator {
 
     const revisionLine = `Base SHA: ${github.baseSha}\nHead SHA: ${github.headSha}`
     const warmHost = this.host.warmHostFor(agent.id)
+    // Degrading is a statement about WHAT this review checks out, never about which tier the session
+    // lives in (git-workspace-model §11): moving the tier under a live session leaves preparation and
+    // the launch addressing different directories, and every later turn failing its cwd containment.
     const useRevisionOnlyWorkspace = async () => {
       appendTurnPrompt(
         entry.msg,
         `\n\nTrusted review revision:\n${revisionLine}\n` +
           'No trusted local pull-request checkout is available for this review. Do not trust local files or repository traces; inspect the exact base and head through GitHub read-only tools. Local execution may be skipped.'
       )
+      // A session with no per-session directory has nowhere to stage the empty stand-in; the prompt
+      // above already removes the ordinary cwd's evidentiary authority, which is the same degradation.
+      if ((await this.sessionIsolationFor(key, agent)) === 'shared') return {}
       try {
         const preparedWorkspaceCwd = await this.host.prepareAgentWorkspace(agent, warmHost, {
           sessionKey: key,
@@ -562,7 +575,7 @@ export class GithubReviewOrchestrator {
           initiatedBy: await this.sessionInitiatorLabel(entry.msg),
           githubReviewRevisionOnly: true
         })
-        return { workspaceIsolation: 'session' as const, forceWorkspaceIsolation: true as const, preparedWorkspaceCwd }
+        return { preparedWorkspaceCwd }
       } catch (fallbackErr) {
         // A filesystem-level failure can still leave the ordinary workspace as
         // the runtime cwd. The prompt above explicitly removes its evidentiary
@@ -571,7 +584,7 @@ export class GithubReviewOrchestrator {
         this.log.warn(
           `github review: revision-only workspace unavailable; using the ordinary cwd as untrusted context (${formatErrWithCauses(fallbackErr)})`
         )
-        return { workspaceIsolation: 'shared' as const, forceWorkspaceIsolation: true as const }
+        return {}
       }
     }
     // A secondary root reviews exactly like the primary, with the root swapped (decision 6); no root

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -15,7 +15,7 @@ import {
 } from '../runtimes/runtime-home.js'
 import { RUNTIME_STATE_LOCATIONS, runtimeStateLocations } from '../runtimes/probe.js'
 import { primaryCheckoutIn, secondaryCheckoutsIn } from '../workspace/secondary-layout.js'
-import { isRealDir, sessionDirIn, sessionGitDirsIn, sessionHomeIn } from '../workspace/session-layout.js'
+import { confinedSessionDirIn, sessionGitDirsIn, sessionHomeIn } from '../workspace/session-layout.js'
 import {
   CLAUDE_PROFILE_ENV,
   claudeProtectedSettings,
@@ -58,11 +58,10 @@ function gitMetadataDirsIn(agentRoot: string, primaryCheckout: string): string[]
     .filter((gitDir) => existsSync(gitDir) && lstatSync(gitDir).isDirectory())
 }
 
-/** The session directory a confined session host launches for (git-workspace-model §11); undefined for the shared host, and for a session host with no clones (a dream, a model session). */
+/** The session directory a confined session host launches for (git-workspace-model §11) — the SAME record preparation reads, so the two tiers cannot disagree; undefined for the shared host, and for a session host with no clones (a dream, a model session). */
 function confinedSessionDirOf(agentRoot: string, hostKey: HostKey | undefined): string | undefined {
-  if (hostKey === undefined || hostKeySessionKey(hostKey) === undefined) return undefined
-  const sessionDir = sessionDirIn(agentRoot, hostKeyDirName(hostKey))
-  return isRealDir(sessionDir) ? sessionDir : undefined
+  const sessionKey = hostKey === undefined ? undefined : hostKeySessionKey(hostKey)
+  return sessionKey === undefined ? undefined : confinedSessionDirIn(agentRoot, sessionKey)
 }
 
 /** The private HOME a host launches with: a confined session's under its own directory (§11), any other host's under the agent dir. */
@@ -71,14 +70,14 @@ export function privateRuntimeHomeFor(scopeDir: string, hostKey: HostKey | undef
   return sessionDir === undefined ? runtimeHomePath(scopeDir) : sessionHomeIn(sessionDir)
 }
 
-/** The same roots with NO outer boundary: one escaping the agent tree is left protected, not refused. */
-function unsandboxedGitMetadataRoots(scopeDir: string, trustedPrimaryCheckout?: string): string[] {
+/** The same roots with NO outer boundary: a confined session's clones own theirs (§11) and the agent's checkouts are not its, while one escaping the agent tree is left protected, not refused. */
+function unsandboxedGitMetadataRoots(scopeDir: string, trustedPrimaryCheckout?: string, sessionDir?: string): string[] {
   const agentRoot = existingRealpath(scopeDir)
   const primaryCheckout = existingRealpath(trustedPrimaryCheckout ?? primaryCheckoutIn(agentRoot))
+  const gitDirs =
+    sessionDir === undefined ? gitMetadataDirsIn(agentRoot, primaryCheckout) : sessionGitDirsIn(sessionDir)
   return compactReadRoots(
-    gitMetadataDirsIn(agentRoot, primaryCheckout)
-      .map((gitDir) => realpathSync(gitDir))
-      .filter((gitDir) => gitDir !== agentRoot && inside(agentRoot, gitDir))
+    gitDirs.map((gitDir) => realpathSync(gitDir)).filter((gitDir) => gitDir !== agentRoot && inside(agentRoot, gitDir))
   )
 }
 
@@ -257,17 +256,26 @@ export function prepareRuntimeLaunch(opts: {
   hostPackageCache?: boolean
 }): PreparedRuntimeLaunch {
   const credentialProfile = sharedCredentialProfile(opts.runtimeId, opts.runtime)
+  // A confined session's own directory (§11), read before anything branches: the tier is the session's and
+  // does not follow the boundary, so an unsandboxed launch of one still runs against its clones, not the agent's.
+  const sessionDir = confinedSessionDirOf(existingRealpath(opts.scopeDir), opts.hostKey)
+  const sessionHome = sessionDir === undefined ? undefined : sessionHomeIn(sessionDir)
   if (!opts.runInSandbox && !opts.isolateHome) {
     const env = { ...(opts.explicitEnv ?? {}) }
     // No outer boundary here: the Codex profile must both reopen the Git metadata and close hooks/config.
     const gitMetadataWriteRoots =
-      credentialProfile === 'codex' ? unsandboxedGitMetadataRoots(opts.scopeDir, opts.trustedPrimaryCheckout) : []
+      credentialProfile === 'codex'
+        ? unsandboxedGitMetadataRoots(opts.scopeDir, opts.trustedPrimaryCheckout, sessionDir)
+        : []
     if (credentialProfile === 'codex') {
       applyCodexPermissionProfile(
         env,
         {
           protectedRoots: [],
-          writableGitMetadataRoots: gitMetadataWriteRoots,
+          // A session's clones take the exact per-clone entries; an owner checkout's `.git` takes the worktree ones.
+          ...(sessionDir === undefined
+            ? { writableGitMetadataRoots: gitMetadataWriteRoots }
+            : { sessionGitMetadataRoots: gitMetadataWriteRoots }),
           allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true
         },
         (opts.hostEnv ?? process.env).CODEX_CONFIG
@@ -290,9 +298,6 @@ export function prepareRuntimeLaunch(opts: {
     throw new Error('OS sandbox requested without the trusted AgentConnect daemon root')
   }
 
-  // A confined session's HOME lives under its own directory and goes with it (§11); every other host keeps the agent's.
-  const sessionDir = confinedSessionDirOf(existingRealpath(opts.scopeDir), opts.hostKey)
-  const sessionHome = sessionDir === undefined ? undefined : sessionHomeIn(sessionDir)
   const stateSourceEnv = opts.stateSourceEnv ?? opts.hostEnv ?? process.env
   const safeRoot = (path: string, label: string): string => {
     if (!isAbsolute(path)) throw new Error(`unsafe ${label} for sandboxing: ${path}`)
@@ -389,12 +394,16 @@ export function prepareRuntimeLaunch(opts: {
 
   if (!opts.runInSandbox) {
     const gitMetadataWriteRoots =
-      credentialProfile === 'codex' ? unsandboxedGitMetadataRoots(opts.scopeDir, opts.trustedPrimaryCheckout) : []
+      credentialProfile === 'codex'
+        ? unsandboxedGitMetadataRoots(opts.scopeDir, opts.trustedPrimaryCheckout, sessionDir)
+        : []
     if (credentialProfile === 'codex') {
       const privateCodex = join(runtimeHome, '.codex')
       applyCodexPermissionProfile(env, {
         protectedRoots: existsSync(privateCodex) ? [realpathSync(privateCodex)] : [],
-        writableGitMetadataRoots: gitMetadataWriteRoots,
+        ...(sessionDir === undefined
+          ? { writableGitMetadataRoots: gitMetadataWriteRoots }
+          : { sessionGitMetadataRoots: gitMetadataWriteRoots }),
         allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true
       })
     }

--- a/packages/daemon/src/workspace/secondary-layout.ts
+++ b/packages/daemon/src/workspace/secondary-layout.ts
@@ -10,6 +10,8 @@ import type { WorkspaceFs } from './workspace-fs.js'
 export const PRIMARY_CHECKOUT_DIR = 'workspace'
 /** Secondary roots live under one agent-owned parent, one subtree per authorized repository. */
 export const SECONDARY_ROOTS_DIR = 'repos'
+/** Every root's per-session worktrees hang off this leaf of it — the agent root for the primary, the subtree for a secondary. */
+export const WORKTREES_DIR = 'worktrees'
 /** What a secondary root's subtree records about the checkout beside it. */
 export const SECONDARY_MATERIALIZATION_FILE = '.materialization.json'
 
@@ -64,7 +66,7 @@ export function secondarySubtreesIn(agentRoot: string): SecondarySubtree[] {
         repoFullName: `${owner}/${repo}`,
         subtree,
         path: join(subtree, 'checkout'),
-        worktreesPath: join(subtree, 'worktrees')
+        worktreesPath: join(subtree, WORKTREES_DIR)
       })
     }
   }
@@ -90,7 +92,7 @@ export async function secondarySubtreesUnder(fs: WorkspaceFs, parent: string): P
         repoFullName: `${owner}/${repo}`,
         subtree,
         path: join(subtree, 'checkout'),
-        worktreesPath: join(subtree, 'worktrees')
+        worktreesPath: join(subtree, WORKTREES_DIR)
       })
     }
   }

--- a/packages/daemon/src/workspace/session-layout.ts
+++ b/packages/daemon/src/workspace/session-layout.ts
@@ -1,7 +1,13 @@
 import { existsSync, lstatSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { sessionKeyDirName } from '../acp/host-key.js'
-import { isRepoSegment, PRIMARY_CHECKOUT_DIR, SECONDARY_ROOTS_DIR } from './secondary-layout.js'
+import {
+  isRepoSegment,
+  PRIMARY_CHECKOUT_DIR,
+  SECONDARY_ROOTS_DIR,
+  secondarySubtreesIn,
+  WORKTREES_DIR
+} from './secondary-layout.js'
 import type { WorkspaceFs } from './workspace-fs.js'
 
 // The on-disk shape of one confined session's directory, `<agentDir>/sessions/<leaf>/{workspace,repos/<owner>/<repo>,home}` (git-workspace-model.md §11) — separate from the manager, like secondary-layout.ts, so the launch path derives a session host's grants without the whole workspace module.
@@ -28,6 +34,23 @@ export function sessionDirIn(agentRoot: string, leaf: string): string {
 export function confinedSessionDirIn(agentRoot: string, sessionKey: string): string | undefined {
   const dir = sessionDirIn(agentRoot, sessionKeyDirName(sessionKey))
   return isRealDir(dir) ? dir : undefined
+}
+
+/**
+ * The other half of that record: whether the session already stands in a per-session WORKTREE of any
+ * root — the primary's or a secondary's.
+ *
+ * The `.git` marker is the proof, exactly as {@link sessionGitDirsIn} takes it for a clone. An empty
+ * `worktrees/<id>` stub is therefore absent, not a worktree: it is what a failed or degraded
+ * preparation leaves behind, and counting it would pin the session to a tier nothing on disk serves —
+ * a cwd no checkout root contains, which is how such a session stopped being able to recover at all.
+ */
+export function hasSessionWorktreeIn(agentRoot: string, sessionWorktreeId: string): boolean {
+  const parents = [
+    join(agentRoot, WORKTREES_DIR),
+    ...secondarySubtreesIn(agentRoot).map((entry) => entry.worktreesPath)
+  ]
+  return parents.some((parent) => existsSync(join(parent, sessionWorktreeId, '.git')))
 }
 
 /** One root's clone inside a session directory: the primary's `workspace`, a secondary's `repos/<owner>/<repo>`. */

--- a/packages/daemon/src/workspace/session-layout.ts
+++ b/packages/daemon/src/workspace/session-layout.ts
@@ -1,5 +1,6 @@
 import { existsSync, lstatSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
+import { sessionKeyDirName } from '../acp/host-key.js'
 import { isRepoSegment, PRIMARY_CHECKOUT_DIR, SECONDARY_ROOTS_DIR } from './secondary-layout.js'
 import type { WorkspaceFs } from './workspace-fs.js'
 
@@ -16,6 +17,17 @@ export function sessionsDirIn(agentRoot: string): string {
 /** `<agentRoot>/sessions/<leaf>` — one session's own directory. */
 export function sessionDirIn(agentRoot: string, leaf: string): string {
   return join(sessionsDirIn(agentRoot), leaf)
+}
+
+/**
+ * THE record of a session's tier (§11): its own directory when this disk holds one, else undefined.
+ *
+ * One function, so preparation, launch, the console reads and retirement cannot answer differently.
+ * The leaf is the session key's, never a host key's — a session is one tier whichever host serves it.
+ */
+export function confinedSessionDirIn(agentRoot: string, sessionKey: string): string | undefined {
+  const dir = sessionDirIn(agentRoot, sessionKeyDirName(sessionKey))
+  return isRealDir(dir) ? dir : undefined
 }
 
 /** One root's clone inside a session directory: the primary's `workspace`, a secondary's `repos/<owner>/<repo>`. */

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -60,6 +60,7 @@ import {
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
 import { isSessionBranch, sessionBranchName } from './session-branch.js'
 import {
+  confinedSessionDirIn,
   hasSessionsDirIn,
   isRealDir,
   sessionClonesUnder,
@@ -68,7 +69,7 @@ import {
   sessionsDirIn,
   sessionDirsIn
 } from './session-layout.js'
-import { hostKeyDirName, sessionHostKey } from '../acp/host-key.js'
+import { sessionKeyDirName } from '../acp/host-key.js'
 import { DEFAULT_SHIM_WORKSPACE_ROOT } from '../shim/protocol.js'
 import { SANDBOX_CHECKOUT_DIR } from '../shim/sandbox-paths.js'
 
@@ -1226,21 +1227,34 @@ export class WorkspaceManager {
     return this.sessionRootDirectory(agent, this.primaryLocator(agent), sessionKey)
   }
 
-  /** `<agentDir>/sessions/<leaf>` — the directory a confined session owns, whether or not it exists yet (§11); the leaf is the session host's, so policy directory and clones name one session. */
+  /** `<agentDir>/sessions/<leaf>` — the directory a confined session owns, whether or not it exists yet (§11); the leaf is the session key's, the same one its host's policy directory takes. */
   sessionDir(agent: Agent, sessionKey: string): string {
     // On a pool it is on the session's OWN pod, under the mount the install's pods share; the leaf routes it there.
     const root = this.sandboxMode
       ? (this.sandboxMountFor(agent.id) ?? DEFAULT_SHIM_WORKSPACE_ROOT)
       : this.agentRootFor(agent)
-    return sessionDirIn(root, hostKeyDirName(sessionHostKey(agent.id, sessionKey)))
+    return sessionDirIn(root, sessionKeyDirName(sessionKey))
   }
 
   /** The session's own directory when it HAS one on this disk, else undefined — the disk, not the request, decides a session's tier, so reads and preparation cannot disagree. */
   confinedSessionDir(agent: Agent, sessionKey: string): string | undefined {
     // A pool member is always the confined tier (§11): every isolated session has its own pod and directory, so the policy answers where no disk can be asked.
     if (this.sandboxMode) return this.sessionDir(agent, sessionKey)
-    const dir = this.sessionDir(agent, sessionKey)
-    return isRealDir(dir) ? dir : undefined
+    return confinedSessionDirIn(this.agentRootFor(agent), sessionKey)
+  }
+
+  /**
+   * THE tier rule of §11, asked by every call site: the host key, preparation, the launch and cleanup.
+   *
+   * A session that already has its own directory on this disk keeps the confined tier for the rest of
+   * its life — the disk is the record, so turning the agent's sandbox or isolation off never leaves
+   * half of the daemon serving a session out of clones the other half does not believe in. A session
+   * that stands nowhere yet takes `wanted`: what a session created now would get. On a pool member
+   * only `wanted` answers, because the session's pod holds the directory and no disk here can be asked.
+   */
+  confinedSessionTier(agent: Agent, sessionKey: string, wanted = false): boolean {
+    if (this.sandboxMode) return wanted
+    return this.confinedSessionDir(agent, sessionKey) !== undefined || wanted
   }
 
   /** One root's per-session directory: its clone in the session's own directory when the session has one, else its worktree at the session's id — derived, never stored. */
@@ -1686,6 +1700,14 @@ export class WorkspaceManager {
     return this.canonicalWorkspacePath(agent.id, cwd)
   }
 
+  /** Where that stand-in goes on THIS session's tier (§11): the primary's slot inside the session's own directory when it is confined, else its worktree beside the primary. Never the other tier's parent, whose leftover is a directory no root can vouch for and which the cwd containment check then refuses. */
+  private revisionOnlySessionTarget(agent: Agent, request: PrepareSessionWorkspaceRequest): [string, string] {
+    if (this.confinedSessionTier(agent, request.sessionKey, request.confined)) {
+      return [PRIMARY_CHECKOUT_DIR, this.sessionDir(agent, request.sessionKey)]
+    }
+    return [this.sessionWorktreeId(request.sessionKey), this.worktreesPathFor(agent)]
+  }
+
   async addRootSessionWorktree(
     agentId: string,
     root: WorkspaceRoot,
@@ -1728,7 +1750,7 @@ export class WorkspaceManager {
       // The cwd becomes the primary's own empty directory, so no root may go on attesting that this
       // session stands in it — a surviving attestation would refuse the very fallback prepared here.
       await this.forgetSessionCwdRoots(agent, id)
-      return await this.prepareGithubRevisionOnlyWorkspace(agent, id)
+      return await this.prepareGithubRevisionOnlyWorkspace(agent, ...this.revisionOnlySessionTarget(agent, request))
     }
     // Resolved before anything is materialized: a review naming a repository this agent has no root
     // for must leave no worktree behind for the caller's revision-only fallback to step around.
@@ -1917,14 +1939,14 @@ export class WorkspaceManager {
     return cwd
   }
 
-  /** One root's per-session directory on whichever tier the session is: a session with its own directory keeps it, a confined request gets one (§11), anything else is a worktree. */
+  /** One root's per-session directory on the ONE tier this session is served on (§11) — its record on disk, else the request's. */
   private async prepareRootSessionDirectory(
     agent: Agent,
     root: WorkspaceRoot,
     request: PrepareSessionWorkspaceRequest
   ): Promise<string> {
     // Locally the disk decides — a session that has a directory keeps it; on a pool the request does, and the worktree branch below serves only a session prepared before this tier.
-    if (request.confined || (!this.sandboxMode && this.confinedSessionDir(agent, request.sessionKey) !== undefined)) {
+    if (this.confinedSessionTier(agent, request.sessionKey, request.confined)) {
       return await this.prepareRootSessionClone(agent, root, request)
     }
     return await this.prepareRootSessionWorktree(agent, root, request)
@@ -1988,6 +2010,9 @@ export class WorkspaceManager {
     if (review && (await this.revParse(agent.id, cwd, 'HEAD')).toLowerCase() !== review.checkout) {
       throw new Error('github review clone HEAD does not match the verified revision')
     }
+    // A stub this session left in the worktree parent is neither a worktree nor absent: reclaim it in ONE
+    // operation, which refuses anything that is not provably empty and so can never take a session's work.
+    if (root.worktreesPath) await fs.rmdir(join(root.worktreesPath, id)).catch(() => false)
     return cwd
   }
 
@@ -2043,7 +2068,7 @@ export class WorkspaceManager {
     if (agent.workspace.mode !== 'git-repo' || request?.isolation !== 'session' || request.sessionKey === undefined) {
       return this.clusterWorkspaceCheckout(agent, mount)
     }
-    return sessionRootCloneIn(sessionDirIn(mount, hostKeyDirName(sessionHostKey(agent.id, request.sessionKey))))
+    return sessionRootCloneIn(sessionDirIn(mount, sessionKeyDirName(request.sessionKey)))
   }
 
   clusterWorkspaceCheckout(agent: Agent, runtimeRoot: string | undefined): string {
@@ -2201,7 +2226,7 @@ export class WorkspaceManager {
     agent: Agent,
     confined: PrepareSessionWorkspaceRequest | undefined
   ): Promise<void> {
-    const ownLeaf = confined ? hostKeyDirName(sessionHostKey(agent.id, confined.sessionKey)) : undefined
+    const ownLeaf = confined ? sessionKeyDirName(confined.sessionKey) : undefined
     await this.sessionsDiscarder?.(agent.id, ownLeaf)
     if (confined) await this.requireEmptiedSandboxPath(agent.id, this.sessionDir(agent, confined.sessionKey))
   }

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -55,6 +55,7 @@ import {
   secondarySubtreesUnder,
   sessionCwdMarkerIn,
   SECONDARY_MATERIALIZATION_FILE,
+  WORKTREES_DIR,
   type SecondarySubtree
 } from './secondary-layout.js'
 import { authorizeWorkspaceGitUrl } from './git-origin-policy.js'
@@ -62,6 +63,7 @@ import { isSessionBranch, sessionBranchName } from './session-branch.js'
 import {
   confinedSessionDirIn,
   hasSessionsDirIn,
+  hasSessionWorktreeIn,
   isRealDir,
   sessionClonesUnder,
   sessionDirIn,
@@ -1144,12 +1146,12 @@ export class WorkspaceManager {
   /** The same parent in one mount's coordinates: beside the pod's checkout, or under the agent
    *  directory when there is no mount. */
   worktreesPathAt(agent: Agent, mount: string | undefined): string {
-    return mount === undefined ? this.localWorktreesPathFor(agent) : join(mount, 'worktrees')
+    return mount === undefined ? this.localWorktreesPathFor(agent) : join(mount, WORKTREES_DIR)
   }
 
   /** THIS daemon's disk, always — for the callers whose subject is this host's own filesystem. */
   localWorktreesPathFor(agent: Agent): string {
-    return join(this.agentRootFor(agent), 'worktrees')
+    return join(this.agentRootFor(agent), WORKTREES_DIR)
   }
 
   /** The same disk's primary checkout — the one whose `.git` owns every session worktree's index,
@@ -1244,17 +1246,29 @@ export class WorkspaceManager {
   }
 
   /**
+   * The tier this session was BORN in, read off the disk — undefined while it stands nowhere yet.
+   *
+   * Its clones or its worktree are the artifact of that decision, not an inference about it, and an
+   * empty `worktrees/<id>` stub counts as neither (see {@link hasSessionWorktreeIn}).
+   */
+  sessionTierOnDisk(agent: Agent, sessionKey: string): 'confined' | 'worktree' | undefined {
+    if (this.sandboxMode) return undefined
+    if (this.confinedSessionDir(agent, sessionKey) !== undefined) return 'confined'
+    return hasSessionWorktreeIn(this.agentRootFor(agent), this.sessionWorktreeId(sessionKey)) ? 'worktree' : undefined
+  }
+
+  /**
    * THE tier rule of §11, asked by every call site: the host key, preparation, the launch and cleanup.
    *
-   * A session that already has its own directory on this disk keeps the confined tier for the rest of
-   * its life — the disk is the record, so turning the agent's sandbox or isolation off never leaves
-   * half of the daemon serving a session out of clones the other half does not believe in. A session
-   * that stands nowhere yet takes `wanted`: what a session created now would get. On a pool member
-   * only `wanted` answers, because the session's pod holds the directory and no disk here can be asked.
+   * A session is served in the tier it was born in for its whole life, so changing the agent's sandbox
+   * or isolation moves no live session and cannot leave half of the daemon serving one out of clones
+   * the other half does not believe in. A session that stands nowhere yet takes `wanted`: what a
+   * session created now would get. On a pool member only `wanted` answers — its session pod holds the
+   * directory and no disk here can be asked.
    */
   confinedSessionTier(agent: Agent, sessionKey: string, wanted = false): boolean {
-    if (this.sandboxMode) return wanted
-    return this.confinedSessionDir(agent, sessionKey) !== undefined || wanted
+    const born = this.sessionTierOnDisk(agent, sessionKey)
+    return born === undefined ? wanted : born === 'confined'
   }
 
   /** One root's per-session directory: its clone in the session's own directory when the session has one, else its worktree at the session's id — derived, never stored. */
@@ -1599,11 +1613,13 @@ export class WorkspaceManager {
     ).trim()
   }
 
+  /** `blobless` names the one class that needs it: Git the daemon runs to MATERIALIZE objects into a session's partial clone (§11), where resolving a fetched pack against objects the clone filtered out is a promisor fetch. The clone, the branch checkout and a review reset take it from {@link sessionCloneGitEnv}; this fetch is the fourth. Retirement never does — it reads a clone it must judge without a network target. */
   async fetchReviewRevisionIn(
     agentId: string,
     root: WorkspaceRoot,
     worktreeId: string,
-    review: GithubReviewWorkspaceRevision
+    review: GithubReviewWorkspaceRevision,
+    blobless = false
   ): Promise<{ base: string; head: string; checkout: string }> {
     const base = this.exactObjectId(review.baseSha, 'base SHA')
     const head = this.exactObjectId(review.headSha, 'head SHA')
@@ -1620,7 +1636,10 @@ export class WorkspaceManager {
     const abort = new AbortController()
     const timer = setTimeout(() => abort.abort(), REVIEW_FETCH_TIMEOUT_MS)
     try {
-      const git = this.runnerFor(agentId, root.path, abort.signal).withEnv(pullTarget.env)
+      // Without this a blobless clone's review fetch dies in `unpack-objects` ("could not fetch <oid>
+      // from promisor remote"), and every review in a confined session degrades to revision-only.
+      const fetchEnv = blobless ? { ...pullTarget.env, GIT_NO_LAZY_FETCH: '0' } : pullTarget.env
+      const git = this.runnerFor(agentId, root.path, abort.signal).withEnv(fetchEnv)
       await git.raw([
         'fetch',
         '--force',
@@ -1995,7 +2014,7 @@ export class WorkspaceManager {
     }
     // Into the clone, never the primary: the refs, and the exact-HEAD proof, are this session's alone.
     const review = request.review
-      ? await this.fetchReviewRevisionIn(agent.id, { ...root, path: cwd, worktreesPath: '' }, id, request.review)
+      ? await this.fetchReviewRevisionIn(agent.id, { ...root, path: cwd, worktreesPath: '' }, id, request.review, true)
       : undefined
     const target = review?.checkout ?? `refs/remotes/origin/${root.branch}`
     // Unsafe executable config gates the checkout itself, as it gates a worktree's creation.

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -1311,6 +1311,7 @@ describe('Daemon rd/msg hook fires', () => {
         gitRepo: 'https://github.com/acme/primary-service',
         gitBranch: 'main',
         gitCredential: 'github-app',
+        isolation: 'session',
         pullOnNewSession: true,
         additionalRepos: [{ repoFullName: 'acme/infra', repoId: '123' }]
       }
@@ -1356,11 +1357,7 @@ describe('Daemon rd/msg hook fires', () => {
         'hook:example-co/elsewhere#461',
         (daemon as any).agents.get(AGENT_ID)
       )
-    ).resolves.toEqual({
-      workspaceIsolation: 'session',
-      forceWorkspaceIsolation: true,
-      preparedWorkspaceCwd: '/agent/worktrees/revision-only'
-    })
+    ).resolves.toEqual({ preparedWorkspaceCwd: '/agent/worktrees/revision-only' })
     // No exact checkout is attempted at all: the only preparation is the empty revision-only cwd.
     expect(prepare).toHaveBeenCalledTimes(1)
     expect(prepare).toHaveBeenCalledWith(
@@ -1381,6 +1378,7 @@ describe('Daemon rd/msg hook fires', () => {
         gitRepo: 'https://github.com/acme/infra',
         gitBranch: 'main',
         gitCredential: 'github-app',
+        isolation: 'session',
         pullOnNewSession: true
       }
     })
@@ -1430,11 +1428,7 @@ describe('Daemon rd/msg hook fires', () => {
         'hook:acme/infra#461',
         (daemon as any).agents.get(AGENT_ID)
       )
-    ).resolves.toEqual({
-      workspaceIsolation: 'session',
-      forceWorkspaceIsolation: true,
-      preparedWorkspaceCwd: '/agent/worktrees/revision-only'
-    })
+    ).resolves.toEqual({ preparedWorkspaceCwd: '/agent/worktrees/revision-only' })
     expect(prepare).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ id: AGENT_ID }),
@@ -1448,6 +1442,74 @@ describe('Daemon rd/msg hook fires', () => {
     expect(entry.msg.text).toContain('Trusted review revision')
     expect(entry.msg.text).toContain('Do not trust local files')
     expect(entry.msg.text).toContain('Local execution may be skipped')
+    await daemon.stop()
+  })
+
+  // git-workspace-model §11: degrading is a statement about what the review checks out, never about
+  // which tier the session lives in — moving it left preparation and the launch on different directories.
+  it('leaves a shared session in its own tier when a formal review degrades to revision-only', async () => {
+    const root = scaffold({
+      workspace: {
+        mode: 'git-repo',
+        path: join(tmpdir(), 'agentconnect-review-shared-tier-workspace'),
+        gitRepo: 'https://github.com/acme/infra',
+        gitBranch: 'main',
+        gitCredential: 'github-app',
+        isolation: 'shared',
+        pullOnNewSession: true
+      }
+    })
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, hostFactory: streamingHost().factory })
+    await daemon.start()
+    const dispatchDaemonId = (daemon as any).cfg.daemonId as string
+    const prepare = vi
+      .spyOn(daemon as any, 'prepareAgentWorkspace')
+      .mockRejectedValue(new Error('workspace Git configuration contains a disallowed network override'))
+    const headSha = 'a'.repeat(40)
+    const baseSha = 'b'.repeat(40)
+    const entry = {
+      msg: { text: 'Review this pull request.' },
+      hookContext: {
+        hookId: HOOK_ID,
+        agentId: AGENT_ID,
+        deliveryKey: 'shared-tier-review',
+        firedAt: new Date().toISOString(),
+        event: 'pull_request:synchronize',
+        snapshot: {
+          configRevision: '1',
+          dispatchRevision: '1',
+          dispatchDaemonId,
+          reviewPolicy: 'full',
+          reportingMode: 'check',
+          gateMode: 'informational'
+        },
+        github: {
+          repoId: '123',
+          repoFullName: 'acme/infra',
+          sourceInstallationId: '456',
+          subjectKind: 'pull_request',
+          pullNumber: 461,
+          headSha,
+          baseSha,
+          reportSha: headSha
+        }
+      }
+    }
+
+    await expect(
+      (daemon as any).githubReviews.prepareGithubReviewWorkspace(
+        entry,
+        'hook:acme/infra#461',
+        (daemon as any).agents.get(AGENT_ID)
+      )
+    ).resolves.toEqual({})
+
+    // The exact checkout was attempted; the revision-only stand-in, which would need a per-session
+    // directory this session does not have, was not — and no isolation was re-pinned on the session.
+    expect(prepare).toHaveBeenCalledTimes(1)
+    expect(prepare.mock.calls[0]![2]).not.toMatchObject({ githubReviewRevisionOnly: true })
+    expect(entry.msg.text).toContain('Trusted review revision')
+    expect(entry.msg.text).toContain('Do not trust local files')
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -6,18 +6,18 @@ import { dirname, join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
 import { agentHostKey, hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 import { sandboxSettingsDir } from '../src/acp/sandbox.js'
-import { prepareRuntimeLaunch } from '../src/launch/prepare.js'
+import { prepareRuntimeLaunch, privateRuntimeHomeFor } from '../src/launch/prepare.js'
 import { sessionKey } from '../src/store/local-store.js'
 import { pendingTurnKey, sdkLeaseKey } from '../src/daemon/turn-types.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import { WAIT } from './wait-support.js'
 
-/** git-workspace-model §11: a confined self-hosted session gets its own ACP host; nothing else does. */
+/** git-workspace-model §11: a confined self-hosted session gets its own ACP host; nothing else does, and the tier a session is served on is its own for life. */
 
 const TRANSPORT_SCOPE = `slack:${createHash('sha256').update('slack\0p').digest('hex').slice(0, 24)}`
 const KEY = (thread: string) => sessionKey('slack', 'C1', thread, 'bot-a', TRANSPORT_SCOPE)
 
-function scaffold(agent: Record<string, unknown> = {}): string {
+function scaffold(agent: Record<string, unknown> = {}, isolation: 'shared' | 'session' = 'session'): string {
   const root = mkdtempSync(join(tmpdir(), 'ac-session-hosts-'))
   writeFileSync(
     join(root, 'config.json'),
@@ -37,7 +37,7 @@ function scaffold(agent: Record<string, unknown> = {}): string {
       status: 'active',
       runtime: 'claude',
       runInSandbox: true,
-      workspace: { mode: 'from-scratch', path: join(adir, 'workspace') },
+      workspace: { mode: 'from-scratch', path: join(adir, 'workspace'), isolation },
       integrations: [],
       output: { mode: 'medium' },
       ...agent
@@ -164,12 +164,12 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     await daemon.stop()
   })
 
-  it('keys every session of a confined self-hosted agent by session, whatever isolation its row reports', async () => {
-    // The pool's isolation rule (daemon-k8s-mode.test.ts) is the pool's alone: off it, the mechanism decides and
-    // a shared-isolation session still gets its own host and its own directory on this disk.
+  it('keys every session of an isolated self-hosted agent by session, whatever isolation its row reports', async () => {
+    // Isolation only escalates: the agent's own setting is the operator's standing choice, and a
+    // from-scratch agent's rows report `shared` whatever it says, because its primary is not a clone.
     const { daemon } = await startDaemon(scaffold())
     const agent = (daemon as any).agents.get('bot-a')
-    expect((daemon as any).perSessionHost(agent, KEY('T1'))).toBe(true)
+    expect((daemon as any).confinedSession(agent, KEY('T1'))).toBe(true)
     expect((daemon as any).hostKeyForRequest('bot-a', { sessionKey: KEY('T1'), isolation: 'shared' })).toBe(
       sessionHostKey('bot-a', KEY('T1'))
     )
@@ -193,6 +193,64 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     expect(factory).toHaveBeenCalledTimes(1)
     expect([...(daemon as any).hosts.keys()]).toEqual([agentHostKey('bot-a')])
     expect(hosts[0]!.newSession).toHaveBeenCalledTimes(2)
+    await daemon.stop()
+  })
+
+  // §11: the confined tier serves `isolation: 'session'`. A sandboxed agent whose sessions are shared gets one host, one private HOME and no session directory — its boundary is the agent's, not each session's.
+  it('keeps one host, one private HOME and no session directory when the agent is shared', async () => {
+    const root = scaffold({}, 'shared')
+    const { daemon, hosts, factory } = await startDaemon(root)
+    await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
+    await (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
+
+    const agentDir = join(root, 'agents', 'bot-a')
+    expect(factory).toHaveBeenCalledTimes(1)
+    expect([...(daemon as any).hosts.keys()]).toEqual([agentHostKey('bot-a')])
+    expect(hosts[0]!.newSession).toHaveBeenCalledTimes(2)
+    // The HOME the launch would give that host is the agent's, and no session owns a directory here.
+    expect(privateRuntimeHomeFor(agentDir, agentHostKey('bot-a'))).toBe(join(agentDir, 'home'))
+    expect(privateRuntimeHomeFor(agentDir, sessionHostKey('bot-a', KEY('T1')))).toBe(join(agentDir, 'home'))
+    expect(existsSync(join(agentDir, 'sessions'))).toBe(false)
+    await daemon.stop()
+  })
+
+  // The tier is the SESSION's and the disk is its record (§11): a session with clones keeps its own host after the agent stops being sandboxed, so the host key cannot disagree with what preparation prepared.
+  it('keeps a session-bound host for a session that already has its own directory, sandbox off or shared', async () => {
+    const root = scaffold()
+    const { daemon } = await startDaemon(root)
+    const agent = (daemon as any).agents.get('bot-a')
+    const key = KEY('T1')
+    expect((daemon as any).hostKeyFor('bot-a', key)).toBe(sessionHostKey('bot-a', key))
+
+    mkdirSync(join(root, 'agents', 'bot-a', 'sessions', hostKeyDirName(sessionHostKey('bot-a', key)), 'workspace'), {
+      recursive: true
+    })
+    agent.runInSandbox = false
+    agent.workspace.isolation = 'shared'
+
+    expect((daemon as any).hostKeyFor('bot-a', key)).toBe(sessionHostKey('bot-a', key))
+    // ...while a session that stands nowhere yet follows the agent's current settings onto the shared host.
+    expect((daemon as any).hostKeyFor('bot-a', KEY('T2'))).toBe(agentHostKey('bot-a'))
+    await daemon.stop()
+  })
+
+  // The tier follows THIS session's isolation, not the agent's default: a formal review forces `session`
+  // on a shared agent, and that session must still get its own host, clones and HOME.
+  it('gives a session forced to session isolation its own host on a shared agent', async () => {
+    const { daemon } = await startDaemon(scaffold({}, 'shared'))
+    const agent = (daemon as any).agents.get('bot-a')
+    const key = KEY('T1')
+    expect((daemon as any).hostKeyFor('bot-a', key)).toBe(agentHostKey('bot-a'))
+
+    const request = { sessionKey: key, isolation: 'session' as const }
+    const prepare = vi.spyOn((daemon as any).workspaces, 'prepareSessionWorkspace')
+
+    expect((daemon as any).hostKeyForRequest('bot-a', request)).toBe(sessionHostKey('bot-a', key))
+    await (daemon as any).runAgentWorkspacePreparation(agent, request)
+
+    // Preparation was told the same thing the host key was, and every later read of the key agrees.
+    expect(prepare.mock.calls[0]![1]).toMatchObject({ sessionKey: key, confined: true })
+    expect((daemon as any).hostKeyFor('bot-a', key)).toBe(sessionHostKey('bot-a', key))
     await daemon.stop()
   })
 

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { Daemon } from '../src/daemon.js'
@@ -37,7 +37,13 @@ function scaffold(agent: Record<string, unknown> = {}, isolation: 'shared' | 'se
       status: 'active',
       runtime: 'claude',
       runInSandbox: true,
-      workspace: { mode: 'from-scratch', path: join(adir, 'workspace'), isolation },
+      workspace: {
+        mode: 'git-repo',
+        path: join(adir, 'workspace'),
+        gitRepo: 'https://github.com/acme/primary-service.git',
+        gitBranch: 'main',
+        isolation
+      },
       integrations: [],
       output: { mode: 'medium' },
       ...agent
@@ -124,7 +130,28 @@ async function startDaemon(root: string, opts: { sandboxMechanism?: 'bwrap' | nu
   })
   await daemon.start()
   makeRoutable(daemon)
+  stubWorkspacePreparation(daemon)
   return { daemon, hosts, factory }
+}
+
+/** No git here: preparation materializes the directory the request's tier names and nothing else. */
+function stubWorkspacePreparation(daemon: Daemon): void {
+  const workspaces = (daemon as any).workspaces
+  vi.spyOn(workspaces, 'prepareWorkspace').mockImplementation(async (...args: unknown[]) => {
+    const agent = args[0] as { workspace: { path: string } }
+    mkdirSync(agent.workspace.path, { recursive: true })
+    return agent.workspace.path
+  })
+  vi.spyOn(workspaces, 'prepareSessionWorkspace').mockImplementation(async (...args: unknown[]) => {
+    const agent = args[0] as { workspace: { path: string } }
+    const request = args[1] as { sessionKey: string; isolation: string; confined?: boolean }
+    if (request.isolation !== 'session') return agent.workspace.path
+    const cwd = request.confined
+      ? join(workspaces.sessionDir(agent, request.sessionKey), 'workspace')
+      : join(workspaces.localWorktreesPathFor(agent), workspaces.sessionWorktreeId(request.sessionKey))
+    mkdirSync(cwd, { recursive: true })
+    return cwd
+  })
 }
 
 describe('one ACP host per session under a confined self-hosted launch', () => {
@@ -164,25 +191,25 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     await daemon.stop()
   })
 
-  it('keys every session of an isolated self-hosted agent by session, whatever isolation its row reports', async () => {
-    // Isolation only escalates: the agent's own setting is the operator's standing choice, and a
-    // from-scratch agent's rows report `shared` whatever it says, because its primary is not a clone.
+  it('keys a session by the isolation ITS row reports, not the agent default it may differ from', async () => {
+    // The console's workspace routing, retention and preparation all read that row: a tier chosen from
+    // anything else would put the runtime in a directory none of them addresses.
     const { daemon } = await startDaemon(scaffold())
     const agent = (daemon as any).agents.get('bot-a')
     expect((daemon as any).confinedSession(agent, KEY('T1'))).toBe(true)
     expect((daemon as any).hostKeyForRequest('bot-a', { sessionKey: KEY('T1'), isolation: 'shared' })).toBe(
-      sessionHostKey('bot-a', KEY('T1'))
+      agentHostKey('bot-a')
     )
     expect((daemon as any).hostKeyForRequest('bot-a', { sessionKey: KEY('T2'), isolation: 'session' })).toBe(
       sessionHostKey('bot-a', KEY('T2'))
     )
     // No pod is involved in a self-hosted launch, and the directory the policy names stays under the agent dir.
     expect((daemon as any).k8sPlane).toBeUndefined()
-    expect((daemon as any).workspaces.sessionDir(agent, KEY('T1'))).toBe(
-      join(agent.dir, 'sessions', hostKeyDirName(sessionHostKey('bot-a', KEY('T1'))))
+    expect((daemon as any).workspaces.sessionDir(agent, KEY('T2'))).toBe(
+      join(agent.dir, 'sessions', hostKeyDirName(sessionHostKey('bot-a', KEY('T2'))))
     )
     // Not on disk yet ⇒ not confined yet: the disk decides the tier locally, never a policy.
-    expect((daemon as any).workspaces.confinedSessionDir(agent, KEY('T1'))).toBeUndefined()
+    expect((daemon as any).workspaces.confinedSessionDir(agent, KEY('T2'))).toBeUndefined()
     await daemon.stop()
   })
 
@@ -214,13 +241,15 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     await daemon.stop()
   })
 
-  // The tier is the SESSION's and the disk is its record (§11): a session with clones keeps its own host after the agent stops being sandboxed, so the host key cannot disagree with what preparation prepared.
-  it('keeps a session-bound host for a session that already has its own directory, sandbox off or shared', async () => {
+  // A session is served in the tier it was BORN in (§11): its clones record that, so losing the
+  // boundary cannot leave the host key disagreeing with what preparation already prepared.
+  it('keeps a session-bound host for a session born confined, after the agent loses its sandbox', async () => {
     const root = scaffold()
     const { daemon } = await startDaemon(root)
     const agent = (daemon as any).agents.get('bot-a')
     const key = KEY('T1')
-    expect((daemon as any).hostKeyFor('bot-a', key)).toBe(sessionHostKey('bot-a', key))
+    const request = { sessionKey: key, isolation: 'session' as const }
+    expect((daemon as any).hostKeyForRequest('bot-a', request)).toBe(sessionHostKey('bot-a', key))
 
     mkdirSync(join(root, 'agents', 'bot-a', 'sessions', hostKeyDirName(sessionHostKey('bot-a', key)), 'workspace'), {
       recursive: true
@@ -228,9 +257,33 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     agent.runInSandbox = false
     agent.workspace.isolation = 'shared'
 
-    expect((daemon as any).hostKeyFor('bot-a', key)).toBe(sessionHostKey('bot-a', key))
+    expect((daemon as any).hostKeyForRequest('bot-a', request)).toBe(sessionHostKey('bot-a', key))
     // ...while a session that stands nowhere yet follows the agent's current settings onto the shared host.
     expect((daemon as any).hostKeyFor('bot-a', KEY('T2'))).toBe(agentHostKey('bot-a'))
+    await daemon.stop()
+  })
+
+  // The other half of the same rule, and the one that was failing in the field: a session born on the
+  // worktree tier stays there when its agent later gains isolation or a boundary.
+  it('keeps a session born on the worktree tier on the agent host after the agent gains a boundary', async () => {
+    const root = scaffold({ runInSandbox: false })
+    const { daemon } = await startDaemon(root)
+    const agent = (daemon as any).agents.get('bot-a')
+    const key = KEY('T1')
+    const request = { sessionKey: key, isolation: 'session' as const }
+    expect((daemon as any).hostKeyForRequest('bot-a', request)).toBe(agentHostKey('bot-a'))
+
+    // What its preparation left: a real worktree of the primary, its `.git` link file and all.
+    const worktree = join(root, 'agents', 'bot-a', 'worktrees', (daemon as any).workspaces.sessionWorktreeId(key))
+    mkdirSync(worktree, { recursive: true })
+    writeFileSync(join(worktree, '.git'), 'gitdir: /nowhere\n')
+    agent.runInSandbox = true
+
+    expect((daemon as any).hostKeyForRequest('bot-a', request)).toBe(agentHostKey('bot-a'))
+    // An EMPTY stub is not that record: it is what a degraded preparation leaves, and a session whose
+    // stub was all that stood between it and a tier is free to take the one it would get now.
+    rmSync(join(worktree, '.git'))
+    expect((daemon as any).hostKeyForRequest('bot-a', request)).toBe(sessionHostKey('bot-a', key))
     await daemon.stop()
   })
 
@@ -251,6 +304,21 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     // Preparation was told the same thing the host key was, and every later read of the key agrees.
     expect(prepare.mock.calls[0]![1]).toMatchObject({ sessionKey: key, confined: true })
     expect((daemon as any).hostKeyFor('bot-a', key)).toBe(sessionHostKey('bot-a', key))
+    await daemon.stop()
+  })
+
+  it('keeps a session forced to shared isolation on the agent host, whatever the agent defaults to', async () => {
+    const { daemon } = await startDaemon(scaffold())
+    const agent = (daemon as any).agents.get('bot-a')
+    const key = KEY('T1')
+    const request = { sessionKey: key, isolation: 'shared' as const }
+    const prepare = vi.spyOn((daemon as any).workspaces, 'prepareSessionWorkspace')
+
+    expect((daemon as any).hostKeyForRequest('bot-a', request)).toBe(agentHostKey('bot-a'))
+    await (daemon as any).runAgentWorkspacePreparation(agent, request)
+
+    expect(prepare.mock.calls[0]![1]).toEqual(request)
+    expect((daemon as any).hostKeyFor('bot-a', key)).toBe(agentHostKey('bot-a'))
     await daemon.stop()
   })
 
@@ -372,7 +440,7 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     expect(confinedPrepare.mock.calls.at(-1)![1]).toMatchObject({ sessionKey: KEY('T1'), confined: true })
     await confined.daemon.stop()
 
-    // A shared host's cold gate prepares no session workspace for a scratch agent, so ask the funnel directly.
+    // Without a boundary the same isolated session goes to the funnel unchanged: no `confined` is added.
     const open = await startDaemon(scaffold({ runInSandbox: false }))
     const openPrepare = vi.spyOn((open.daemon as any).workspaces, 'prepareSessionWorkspace')
     const request = { sessionKey: KEY('T1'), isolation: 'session' as const }
@@ -460,6 +528,7 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     })
     await daemon.start()
     makeRoutable(daemon)
+    stubWorkspacePreparation(daemon)
     const one = (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
     const two = (daemon as any).dispatch('bot-a', dm('200', 'two', 'T2'), 'int-a')
     await vi.waitFor(() => expect((daemon as any).pending.size).toBe(2), WAIT)
@@ -625,6 +694,7 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     })
     await daemon.start()
     makeRoutable(daemon)
+    stubWorkspacePreparation(daemon)
     await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')
     const key = sessionHostKey('bot-a', KEY('T1'))
     const store = (daemon as any).store

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -644,8 +644,8 @@ describe('prepareRuntimeLaunch', () => {
     expect(launch.env.HOME).toBe(privateRuntimeHomeFor(scopeDir, key))
   })
 
-  // The unconfined tier keeps its linked worktrees and their grants: a session directory on disk and a session-bound host key must change nothing about its policy.
-  it('leaves the unconfined policy byte-identical whether or not a session directory exists', () => {
+  // A session with NO directory of its own is on the worktree tier however it is addressed: the same policy for its host key, the agent's, and none at all.
+  it('leaves the unconfined policy byte-identical for a session that has no directory of its own', () => {
     const { scopeDir, hostHome } = fixture()
     const primaryGit = join(scopeDir, 'workspace', '.git')
     const cwd = join(scopeDir, 'worktrees', 'session-1')
@@ -664,7 +664,10 @@ describe('prepareRuntimeLaunch', () => {
     const key = sessionHostKey('bot-a', 'slack:C1:s1')
     const before = prepareRuntimeLaunch({ ...base, hostKey: key })
 
-    mkdirSync(join(scopeDir, 'sessions', hostKeyDirName(key), 'workspace', '.git'), { recursive: true })
+    // Another session's directory is not this one's record and must not reach into its policy.
+    mkdirSync(join(scopeDir, 'sessions', hostKeyDirName(sessionHostKey('bot-a', 'slack:C1:s2')), 'workspace', '.git'), {
+      recursive: true
+    })
 
     expect(JSON.stringify(prepareRuntimeLaunch({ ...base, hostKey: key }))).toBe(JSON.stringify(before))
     expect(JSON.stringify(prepareRuntimeLaunch({ ...base, hostKey: agentHostKey('bot-a') }))).toBe(
@@ -676,6 +679,30 @@ describe('prepareRuntimeLaunch', () => {
     expect(agentFilesystem(before.env)).toContain(`"${owner}" = "write"`)
     expect(agentFilesystem(before.env)).toContain(`"${join(owner, 'worktrees', '**')}" = "write"`)
     expect(before.gitMetadataWriteRoots).toEqual([owner])
+  })
+
+  // The tier is the SESSION's, not the boundary's (§11): a confined session whose agent lost its sandbox still runs against its own clones, so an unconfined Codex can write the `.git` it actually stands in.
+  it('opens a confined session its own clones, not the primary, when the sandbox is off', () => {
+    const { scopeDir, hostHome, key, cwd, primaryGit, cloneGit, secondaryGit } = sessionCloneFixture()
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      hostKey: key,
+      runInSandbox: false,
+      trustedPrimaryCheckout: join(scopeDir, 'workspace'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    expect(launch.gitMetadataWriteRoots).toEqual([realpathSync(cloneGit), realpathSync(secondaryGit)])
+    expect(agentFilesystem(launch.env)).toContain(`"${realpathSync(cloneGit)}" = "write"`)
+    expect(agentFilesystem(launch.env)).toContain(`"${realpathSync(secondaryGit)}" = "write"`)
+    expect(agentFilesystem(launch.env)).toContain(`"${join(realpathSync(cloneGit), 'hooks')}" = "read"`)
+    expect(agentFilesystem(launch.env)).not.toContain(realpathSync(primaryGit))
+    // Exact entries, never an owner checkout's `worktrees/**`: a clone hangs no worktree off its `.git`.
+    expect(agentFilesystem(launch.env)).not.toContain('worktrees/**')
   })
 
   // The agent's shared host is not a session's: a session directory another session owns must not reach into its worktree-tier policy.

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -41,11 +41,14 @@ initGitInjection({
 const KEY = 'slack:C1:1700000000.000100'
 const PRIMARY_URL = 'https://github.com/acme/primary-service.git'
 const roots: string[] = []
+/** Every daemon-run Git invocation, with the env it ran under — what proves which ones may fetch lazily. */
+const gitRuns: { args: string[]; env: Record<string, string> }[] = []
 /** Authorized clone URL (minus any `.git`) → the `file://` bare repository standing in for it. */
 const remotes = new Map<string, string>()
 
 afterAll(() => rmSync(join(SHIM, '..'), { recursive: true, force: true }))
 afterEach(() => {
+  gitRuns.length = 0
   workspaces.setGitRunnerResolver(undefined)
   remotes.clear()
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
@@ -156,10 +159,12 @@ class SeamRunner implements GitRunner {
   }
 
   raw(args: string[]): Promise<string> {
+    gitRuns.push({ args, env: this.env })
     return this.delegate().raw(args[0] === 'ls-remote' ? args.map(substitute) : args)
   }
 
   clone(repo: string, target: string, options?: string[]): Promise<void> {
+    gitRuns.push({ args: ['clone', repo, target, ...(options ?? [])], env: this.env })
     return this.delegate().clone(substitute(repo), target, options)
   }
 
@@ -355,6 +360,31 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
     expect(git(cwd, ['status', '--porcelain'])).toBe('')
   })
 
+  // A blobless clone has to resolve a fetched pack against objects it filtered out, which is a promisor
+  // fetch: under the daemon's usual `GIT_NO_LAZY_FETCH=1` the review fetch dies in `unpack-objects`
+  // ("could not fetch <oid> from promisor remote") and EVERY review in a confined session degrades.
+  it('lets the review fetch into a session clone fetch lazily, as its clone and checkout may', async () => {
+    const agent = agentFixture()
+    const { primary } = serveAll(agent)
+    const pr = publishPullRequest(primary!.seed, 'pr\n')
+
+    const cwd = await workspaces.prepareSessionWorkspace(
+      agent,
+      confined({ review: { pullNumber: 7, baseSha: pr.base, headSha: pr.head } })
+    )
+
+    expect(git(cwd, ['rev-parse', 'HEAD'])).toBe(pr.head)
+    const inClone = gitRuns.filter(
+      (run) => run.args[0] === 'fetch' && run.args.some((arg) => arg.includes('refs/pull/7/head'))
+    )
+    expect(inClone.length).toBeGreaterThan(0)
+    for (const run of inClone) expect(run.env.GIT_NO_LAZY_FETCH).toBe('0')
+    // Retirement is the other side of the rule: it judges the clone with no network target at all.
+    gitRuns.length = 0
+    await workspaces.removeSessionWorktree(agent, KEY)
+    for (const run of gitRuns) expect(run.env.GIT_NO_LAZY_FETCH).not.toBe('0')
+  })
+
   it('fails the session when the clone fails, leaving no worktree behind', async () => {
     const agent = agentFixture()
     serveAll(agent)
@@ -475,10 +505,13 @@ describe('retiring a confined session', () => {
   it('sweeps a legacy worktree of the same session along with its directory', async () => {
     const agent = agentFixture()
     serveAll(agent)
-    const worktree = await workspaces.prepareSessionWorkspace(agent, { sessionKey: KEY, isolation: 'session' })
-    expect(statSync(join(worktree, '.git')).isFile()).toBe(true)
     const clone = await workspaces.prepareSessionWorkspace(agent, confined())
     expect(clone).toBe(realpathSync(join(leafOf(agent), 'workspace')))
+    // A session cannot reach both tiers any more; this is what one migrated under the older rule left.
+    const root = workspaces.primaryRoot(agent)
+    const worktree = join(await workspaces.prepareSessionWorktreeRoot(agent), idOf())
+    await workspaces.addRootSessionWorktree(agent.id, root, worktree, `refs/remotes/origin/${root.branch}`)
+    expect(statSync(join(worktree, '.git')).isFile()).toBe(true)
 
     expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({ outcome: 'removed' })
 
@@ -514,42 +547,42 @@ describe('changing the agent tier never strands a session', () => {
     await expect(workspaces.additionalWorkspaceDirectories(open, again, unconfined())).resolves.toEqual([])
   })
 
-  it('moves a session that stands on a worktree onto the confined tier when the agent gains a boundary', async () => {
+  // The transition that was failing in the field: a session born on the worktree tier whose agent
+  // later gained a boundary. It stays where it was born, so no half of the daemon moves without the
+  // others — the launch keeps the agent's HOME and the owner checkout's `.git`, as its cwd needs.
+  it('keeps a session born on the worktree tier there when the agent gains a boundary', async () => {
     const agent = agentFixture()
     serveAll(agent)
-    const legacy = await workspaces.prepareSessionWorkspace(agent, unconfined())
-    expect(statSync(join(legacy, '.git')).isFile()).toBe(true)
-    writeFileSync(join(legacy, 'earlier.md'), 'kept\n')
+    const worktree = await workspaces.prepareSessionWorkspace(agent, unconfined())
+    expect(statSync(join(worktree, '.git')).isFile()).toBe(true)
+    writeFileSync(join(worktree, 'earlier.md'), 'kept\n')
 
-    const clone = await workspaces.prepareSessionWorkspace(agent, confined())
+    const again = await workspaces.prepareSessionWorkspace(agent, confined())
 
-    // Under a boundary the linked checkout would go on writing the owner's `.git`, so this one does move.
-    expect(clone).toBe(realpathSync(join(leafOf(agent), 'workspace')))
-    expect(statSync(join(clone, '.git')).isDirectory()).toBe(true)
-    expect(workspaces.confinedSessionTier(agent, KEY)).toBe(true)
-    expect(launchHomeFor(agent)).toBe(sessionHomeIn(realpathSync(leafOf(agent))))
-    await expect(workspaces.additionalWorkspaceDirectories(agent, clone, confined())).resolves.toEqual([])
-    // Nothing was destroyed: the older directory and its work are still there for retirement to judge.
-    expect(readFileSync(join(legacy, 'earlier.md'), 'utf8')).toBe('kept\n')
-    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({
-      outcome: 'retained',
-      reason: 'dirty',
-      partial: true
-    })
-    expect(readFileSync(join(legacy, 'earlier.md'), 'utf8')).toBe('kept\n')
+    expect(again).toBe(worktree)
+    expect(readFileSync(join(worktree, 'earlier.md'), 'utf8')).toBe('kept\n')
+    expect(workspaces.sessionTierOnDisk(agent, KEY)).toBe('worktree')
+    expect(workspaces.confinedSessionTier(agent, KEY, true)).toBe(false)
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'sessions'))).toBe(false)
+    expect(launchHomeFor(agent)).toBe(join(workspaces.agentRootFor(agent), 'home'))
+    await expect(workspaces.additionalWorkspaceDirectories(agent, again, confined())).resolves.toEqual([])
   })
 
-  it('treats an empty stub in the worktrees parent as absent, prepares the clone, and reclaims it', async () => {
+  // The same session with an EMPTY stub where its worktree should be: that is no record at all, so it
+  // takes the tier it would get now and can recover on its own instead of dying on every turn.
+  it('treats an empty stub as absent, so a session whose worktree is gone takes the tier it would get now', async () => {
     const agent = agentFixture()
     serveAll(agent)
     await workspaces.prepareWorkspace(agent)
     const stub = join(workspaces.agentRootFor(agent), 'worktrees', idOf())
     mkdirSync(stub, { recursive: true })
+    expect(workspaces.sessionTierOnDisk(agent, KEY)).toBeUndefined()
 
     const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
 
     expect(cwd).toBe(realpathSync(join(leafOf(agent), 'workspace')))
     expect(existsSync(stub)).toBe(false)
+    expect(launchHomeFor(agent)).toBe(sessionHomeIn(realpathSync(leafOf(agent))))
     await expect(workspaces.additionalWorkspaceDirectories(agent, cwd, confined())).resolves.toEqual([])
   })
 

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -1,11 +1,22 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, afterEach, describe, expect, it } from 'vitest'
 import type { Agent } from '../src/agents/agent-schema.js'
 import { hostKeyDirName, sessionHostKey } from '../src/acp/host-key.js'
 import { createWorkspaceScope } from '../src/cp/workspace-scope.js'
+import { privateRuntimeHomeFor } from '../src/launch/prepare.js'
 import {
   daemonGitCredentialTarget,
   gitFor,
@@ -194,6 +205,18 @@ const confined = (extra: Partial<PrepareSessionWorkspaceRequest> = {}): PrepareS
 
 const leafOf = (agent: Agent) => workspaces.sessionDir(agent, KEY)
 const idOf = () => workspaces.sessionWorktreeId(KEY)
+
+/** The same session, requested with no boundary around it — what a turn asks for once the agent's sandbox is off. */
+const unconfined = (extra: Partial<PrepareSessionWorkspaceRequest> = {}): PrepareSessionWorkspaceRequest => ({
+  sessionKey: KEY,
+  isolation: 'session',
+  initiatedBy: 'Ada Lovelace',
+  ...extra
+})
+
+/** The directory the LAUNCH resolves for this session's host — the same record preparation reads. */
+const launchHomeFor = (agent: Agent) =>
+  privateRuntimeHomeFor(workspaces.agentRootFor(agent), sessionHostKey(agent.id, KEY))
 
 /** One pull request on the served primary: a commit on top of `main`, published as `refs/pull/7/head`. */
 function publishPullRequest(seed: string, content: string): { base: string; head: string } {
@@ -463,6 +486,100 @@ describe('retiring a confined session', () => {
     expect(existsSync(leafOf(agent))).toBe(false)
     expect(git(agent.workspace.path, ['worktree', 'list']).split('\n')).toHaveLength(1)
     expect(git(agent.workspace.path, ['branch', '--list', 'dev/*'])).toBe('')
+  })
+})
+
+// git-workspace-model §11 "Changing the tier": the disk is the record, and every side reads it — so an
+// agent's `runInSandbox` or `workspaceIsolation` changing under a live session cannot leave preparation,
+// the launch and the reads serving three different directories.
+describe('changing the agent tier never strands a session', () => {
+  it('keeps a session in its clones once the agent stops being sandboxed, preparation and launch on one directory', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+    writeFileSync(join(cwd, 'wip.md'), 'in progress\n')
+
+    // The next turn arrives with the boundary gone: nothing asks for confinement any more.
+    const open = { ...agent, runInSandbox: false, workspace: { ...agent.workspace, isolation: 'shared' } } as Agent
+    const again = await workspaces.prepareSessionWorkspace(open, unconfined())
+
+    expect(again).toBe(cwd)
+    expect(readFileSync(join(cwd, 'wip.md'), 'utf8')).toBe('in progress\n')
+    expect(workspaces.confinedSessionTier(open, KEY)).toBe(true)
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'worktrees'))).toBe(false)
+    // The launch derives the SAME directory from the same record — its HOME and its write root are the session's.
+    expect(launchHomeFor(open)).toBe(sessionHomeIn(realpathSync(leafOf(agent))))
+    expect(workspaces.trustedWorkspaceWriteRoots(open, KEY)).toEqual([leafOf(agent)])
+    // ...and the cwd containment check, which is what refused every turn on the live host, agrees with both.
+    await expect(workspaces.additionalWorkspaceDirectories(open, again, unconfined())).resolves.toEqual([])
+  })
+
+  it('moves a session that stands on a worktree onto the confined tier when the agent gains a boundary', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    const legacy = await workspaces.prepareSessionWorkspace(agent, unconfined())
+    expect(statSync(join(legacy, '.git')).isFile()).toBe(true)
+    writeFileSync(join(legacy, 'earlier.md'), 'kept\n')
+
+    const clone = await workspaces.prepareSessionWorkspace(agent, confined())
+
+    // Under a boundary the linked checkout would go on writing the owner's `.git`, so this one does move.
+    expect(clone).toBe(realpathSync(join(leafOf(agent), 'workspace')))
+    expect(statSync(join(clone, '.git')).isDirectory()).toBe(true)
+    expect(workspaces.confinedSessionTier(agent, KEY)).toBe(true)
+    expect(launchHomeFor(agent)).toBe(sessionHomeIn(realpathSync(leafOf(agent))))
+    await expect(workspaces.additionalWorkspaceDirectories(agent, clone, confined())).resolves.toEqual([])
+    // Nothing was destroyed: the older directory and its work are still there for retirement to judge.
+    expect(readFileSync(join(legacy, 'earlier.md'), 'utf8')).toBe('kept\n')
+    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({
+      outcome: 'retained',
+      reason: 'dirty',
+      partial: true
+    })
+    expect(readFileSync(join(legacy, 'earlier.md'), 'utf8')).toBe('kept\n')
+  })
+
+  it('treats an empty stub in the worktrees parent as absent, prepares the clone, and reclaims it', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    await workspaces.prepareWorkspace(agent)
+    const stub = join(workspaces.agentRootFor(agent), 'worktrees', idOf())
+    mkdirSync(stub, { recursive: true })
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+
+    expect(cwd).toBe(realpathSync(join(leafOf(agent), 'workspace')))
+    expect(existsSync(stub)).toBe(false)
+    await expect(workspaces.additionalWorkspaceDirectories(agent, cwd, confined())).resolves.toEqual([])
+  })
+
+  // The stub's own source: a review with no trusted checkout stages an empty stand-in, and it belongs on
+  // THIS session's tier — in the worktrees parent it was a cwd outside the checkout root every later turn.
+  it('stages a revision-only review inside the session directory, leaving no stub beside the primary', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+    writeFileSync(join(cwd, 'stale.md'), 'from the previous turn\n')
+
+    const revisionOnly = await workspaces.prepareSessionWorkspace(agent, confined({ githubReviewRevisionOnly: true }))
+
+    expect(revisionOnly).toBe(cwd)
+    expect(readdirSync(revisionOnly)).toEqual([])
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'worktrees'))).toBe(false)
+    await expect(workspaces.additionalWorkspaceDirectories(agent, revisionOnly, confined())).resolves.toEqual([])
+  })
+
+  it('stages that same review beside the primary for a session with no directory of its own', async () => {
+    const agent = agentFixture()
+    serveAll(agent)
+    await workspaces.prepareWorkspace(agent)
+
+    const revisionOnly = await workspaces.prepareSessionWorkspace(agent, unconfined({ githubReviewRevisionOnly: true }))
+
+    expect(revisionOnly).toBe(realpathSync(join(workspaces.agentRootFor(agent), 'worktrees', idOf())))
+    expect(readdirSync(revisionOnly)).toEqual([])
+    expect(existsSync(join(workspaces.agentRootFor(agent), 'sessions'))).toBe(false)
+    await expect(workspaces.additionalWorkspaceDirectories(agent, revisionOnly, unconfined())).resolves.toEqual([])
   })
 })
 


### PR DESCRIPTION
## The three answers

"Is this session confined — its own clone and its own ACP host — or not?" was answered in three places by three different rules:

| predicate | file | decided on |
| --- | --- | --- |
| `perSessionHost` | `packages/daemon/src/daemon.ts` | on a self-hosted daemon, `agentRunsInSandbox(agent)` alone — whether the session was isolated was never consulted |
| `WorkspaceManager.confinedSessionDir` | `packages/daemon/src/workspace/workspace-manager.ts` | whether the session's directory exists on disk |
| `confinedSessionDirOf` | `packages/daemon/src/launch/prepare.ts` | whether the host key carried a session key |

**None of them read the value the session already carries.** `sessions.workspaceIsolation` has been persisted since the tier existed (`local-store.ts`, column ~:1181, upsert ~:2474), and the console's workspace routing (`cp/workspace-scope.ts`), retention (`daemon.ts` ~:15750) and workspace preparation (~:11384) all address it. The three predicates inferred a tier beside it, and diverged as soon as an agent's settings changed:

1. **Isolation `shared` did not turn the confined tier off.** A sandboxed agent got a per-session host — with a per-session private HOME and temp dir — for sessions that were not isolated at all. Observed on a self-hosted daemon as a launch whose cwd was the primary checkout while its Git metadata roots and TMPDIR pointed inside `sessions/session-<hex>/`.
2. **A tier change stranded live sessions.** With a directory on disk and the host key back at agent level, preparation took the clone branch while the launch took the worktree branch. Every turn then died on the cwd containment check (`prepared workspace cwd "…" resolves outside its checkout root`), and the skill ledger, which had followed preparation, ran inside a clone the launch did not believe in. Recovery needed the session directories moved aside by hand.

## The rule: the tier a session is born in

One rule, `WorkspaceManager.confinedSessionTier`, asked by the host key, the pod a host launches into, preparation, the review stand-in, the launch's HOME and Git grants, and cleanup. Two recorded values answer it, in order:

1. **Is this session isolated at all?** Its own `workspaceIsolation`. `SessionManager` decides it once at creation and keeps it (`rec?.workspaceIsolation ?? …`, always `shared` for a from-scratch agent). A shared session gets no host, pod, HOME or directory of its own. The daemon learns it from the workspace request at every seam that carries one — #1766's `sessionIsolation` memo, now populated on both planes — and falls back to what `SessionManager` will compute for a session no request has described yet.
2. **Which tier, then?** The clones or the worktree the session already stands in — the artifact of the original decision, not an inference about it. A session that stands nowhere yet takes what one created now would get: a boundary around the runtime means clones, no boundary means a worktree. A pool member has no local disk to ask, so its session pod holds that record and rule 2 short-circuits to the request, exactly as #1766 left it.

So changing an agent's `runInSandbox` or `workspaceIsolation` reaches only sessions created afterwards, and no half of the daemon can start serving a live one somewhere the others do not address. `perSessionHost` is gone; the launch no longer derives a second answer, it reads the same record through `confinedSessionDirIn` in `workspace/session-layout.ts`.

**An empty `worktrees/<id>` directory is absent**, never a worktree: it has no `.git` for anything to read, and counting it pinned a session to a tier nothing on disk served — a cwd no checkout root contained, failing every turn with no way to recover. It is reclaimed by a single `rmdir` (which refuses anything not provably empty) rather than counted.

## Two live bugs on the same seam

**A — a confined session's review could never get an exact checkout.** The review's fetch of `refs/pull/<n>/head` ran under the daemon's usual `GIT_NO_LAZY_FETCH=1`. A blobless clone has to resolve a fetched pack against objects it filtered out, which is a promisor fetch, so the fetch died in `unpack-objects` (`could not fetch <oid> from promisor remote`) and **every review in a confined session degraded to revision-only** — never inspecting the code it was asked to review. The class is daemon-run Git that must *materialize* objects into a partial clone: the clone, the branch checkout and a review reset already took the exemption from `sessionCloneGitEnv`; this fetch is the fourth and last. Retirement is deliberately not in it — it judges a clone with no network target at all, and a test asserts that too.

**B — the degradation then moved the session's tier.** When the exact checkout failed, the orchestrator returned `forceWorkspaceIsolation: true` with an explicit tier, on a session whose recorded value was `session`. Preparation was forced onto the worktree tier while the metadata roots still resolved into `sessions/session-<sid>/workspace/.git`, and the empty stub was re-created on every attempt, so clearing it by hand did not help. Degrading is a statement about *what a review checks out*, not about *which tier the session lives in*, and the two are now separate:

- the exact-checkout path keeps `forceWorkspaceIsolation` — a formal review genuinely requires an isolated checkout at the exact revision, and it is a request, not a degradation;
- both degraded paths report no isolation at all, so the session stays in its recorded tier;
- a session with nowhere to stage the empty stand-in keeps the ordinary cwd under the prompt that already removes its evidentiary authority — which is what the deeper fallback did anyway.

## What the recorded value's precedence turns out to be

`workspaceIsolation=COALESCE(excluded.workspaceIsolation, sessions.workspaceIsolation)` does let the incoming value win. Reversing it would break exactly one caller and break it silently: `forceWorkspaceIsolation`, which is the only path that changes a stored value. Every other writer either carries the stored value (`session-manager.ts`, `runtime-session.ts`, the daemon's interrupted-session rewrite) or omits the field entirely (the dream row), so `COALESCE` already keeps what is stored for all of them.

And that one path is not a silent overwrite: the same write clears `acpSessionId` and resets state and the delivery cursor, so the session is retired and the next turn re-prepares from the new value. With B fixed, the only thing that reaches it is a genuine request for isolation. **So nothing legitimately changes a session's tier mid-life** — an escalation to `session` re-prepares deliberately, and the born-in half never moves. A session re-pinned to `shared` simply stops standing in its clones; they stay on disk and retirement judges them under the usual dirty and unique-commit rules. The precedence is left as it is, and §11 now records why.

## What `perSessionHost` fed, and how each is affected

- `hostKeyFor` / `hostKeyForRequest` → `ensureHostAsync` / `isHostRunning` / `boundHostCwd`, the turn plan's `hostAlreadyRunning`, `createPending`, `reapplyStickyControls`. All keep one synchronous rule, so a turn cannot file state under one key and look it up under another.
- `sessionOwnerKey`, and through it the #1758 state filed by owning host: pending turns, SDK leases, update chains, permission records, `session_gates`, plus `sessionHostKey`-addressed stop fences. The key is now stable for a session's life.
- `podSubjectFor` — which pod a session-bound host launches into, and which pod preparation runs on.
- The `confined` flag on the workspace preparation request, and the review stand-in's parent.
- Indirectly, `trustedWorkspaceWriteRoots(agent, hostKeySessionKey(hostKey))` and the launch's HOME/policy, already disk-driven and being handed the wrong host key.

## Verified

Unit level only; no live host was exercised by me.

- `tsc -p tsconfig.typecheck.json --noEmit`, prettier and eslint on every touched file.
- 22 suites, 859 tests: the four core ones (`workspace-session-clone`, `daemon-session-hosts`, `runtime-launch`, `daemon-hook`), the pool set (`daemon-k8s-mode`, `k8s-session-pods`, `daemon-session-sweeps-pool`, `daemon-session-metadata-outbox-pool`, `daemon-loop-guard-pool`, `cluster-workspace-prepare`), and the host-key reach (`session-manager`, `workspace`, `daemon-workspace-git-review-feature`, `codex-permission-profiles`, `workspace-repo-scope`, `workspace-secondary-roots`, `session-reader`, `daemon-smoke`, `sandbox-keep-alive`, `daemon-webchat`, `mcp-ops`, `turn-plan`).

New cases: a sandboxed agent whose sessions are shared gets one host, one private HOME and no session directory; a session keyed by the isolation its row reports rather than the agent default; a formal review forcing `session` on a shared agent gets its own host and a confined preparation; a session born confined keeps its host after the agent loses its sandbox; a session born on the worktree tier stays there when the agent gains a boundary, with preparation, the launch HOME and the containment check on one directory; an empty stub reads as absent so such a session takes the tier it would get now and recovers; the review fetch into a session clone runs with lazy fetching permitted while retirement does not; the revision-only stand-in stages inside the session directory when confined and beside the primary when not; a degraded review leaves a shared session's tier alone and stages nothing; and an unsandboxed launch of a confined session opens its clones' `.git`, never the primary's.

Existing tests changed with the rule: `runtime-launch`'s byte-identical unconfined case (it asserted that a session directory changes nothing for a session-bound host key — the divergence itself); `daemon-session-hosts`' fixture (a git-repo agent with `isolation: 'session'`, since only such an agent *has* isolated sessions, with a preparation stub because the suite is about host keying, not git) and its "whatever isolation its row reports" case, whose rationale was failure 1; `workspace-session-clone`'s legacy-worktree sweep, whose mixed on-disk state a session can no longer reach through preparation and is now built directly; and two `daemon-hook` review expectations, which no longer carry a forced isolation.

### Mutation check

Each old predicate and each fixed behaviour reintroduced independently:

| mutation | red |
| --- | --- |
| `confinedSession` → the old rule (the mechanism alone off the pool, the memo alone on it) | **6** |
| the tier read from the disk alone, `wanted` ignored | **31** |
| an empty stub counted as the worktree it is not | **2** |
| the review stand-in always staged beside the primary | **1** |
| unsandboxed Git grants derived from the boundary, not the session's record | **1** |
| bug A: the review fetch back on `GIT_NO_LAZY_FETCH=1` | **1** |
| bug B: the degradation re-pinning the session's isolation | **2** |

## Rebase note

Rebased onto `main` after #1766 (one sandbox pod per session) and #1770 (the confined host's temp dir). #1766's `sessionIsolation` memo and `hostKeyForRequest` are the seam this needed, and the pool's semantics are preserved rather than replaced. The one Linux `Unit Test` failure on the previous head was the timer-sensitive `dream-runner` cancellation case, outside this diff and green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
