### PR TITLE
fix(daemon): say that an unmarked temp parent may also be a sibling mid-claim

### DIFF
--- a/packages/daemon/src/acp/sandbox-temp.ts
+++ b/packages/daemon/src/acp/sandbox-temp.ts
@@ -1,5 +1,5 @@
-import { createHash } from 'node:crypto'
-import { lstatSync, mkdirSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { createHash, randomUUID } from 'node:crypto'
+import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import type { HostKey } from './host-key.js'
 
@@ -37,6 +37,21 @@ export const AF_UNIX_PATH_MAX = 107
 /** The widest socket SRT composes under TMPDIR — a Linux pid at its 22-bit ceiling. */
 const WIDEST_SRT_SOCKET = 'srt-mux-4194304-0.sock'
 
+// The marker is published WITH the directory, never after it: two hosts of one agent starting for the first time would otherwise interleave between the mkdir and the write, and the loser would read an unmarked parent and refuse a path that is in fact ours. Build it aside, mark it, then move it into place — the rename is atomic, so `t` never exists unmarked.
+function createOwnedTempParent(agentDir: string): void {
+  const parent = sandboxTempParent(agentDir)
+  if (existsSync(parent)) return
+  const staging = `${parent}.${randomUUID()}`
+  mkdirSync(staging, { recursive: true, mode: 0o700 })
+  writeFileSync(join(staging, OWNER_MARKER), '', { mode: 0o600 })
+  try {
+    renameSync(staging, parent)
+  } catch {
+    // Another host won the race, or something else holds the name; its own proof decides below.
+    rmSync(staging, { recursive: true, force: true })
+  }
+}
+
 /** Create one host's temp directory and return its canonical path. Short is not the same as bounded: a deep enough daemon root plus a long agent name still overflows `sun_path`, and it fails HERE naming the path and the limit, rather than as an opaque `listen EINVAL` three ACP start attempts deep. */
 export function prepareSandboxTempDir(
   agentDir: string,
@@ -44,13 +59,12 @@ export function prepareSandboxTempDir(
   /** Test seam: SRT confines a host on Linux alone, so only a Linux launch opens this socket and only it is held to the budget. */
   platform: NodeJS.Platform = process.platform
 ): string {
-  const created = mkdirSync(sandboxTempParent(agentDir), { recursive: true, mode: 0o700 }) !== undefined
+  createOwnedTempParent(agentDir)
   const parent = join(realpathSync(resolve(agentDir)), 't')
   // Trust the resolved directory, not the composed name: a link standing in for it would move the whole temp tree out of the agent dir.
   if (realpathSync(parent) !== parent) {
     throw new Error(`runtime temp parent is not a real directory inside the agent dir: ${parent}`)
   }
-  if (created) writeFileSync(join(parent, OWNER_MARKER), '', { mode: 0o600 })
   // Fail closed rather than write into, or later sweep, a directory this daemon did not make.
   if (!daemonOwnsTempParent(parent)) {
     throw new Error(

--- a/packages/daemon/src/acp/sandbox-temp.ts
+++ b/packages/daemon/src/acp/sandbox-temp.ts
@@ -1,5 +1,5 @@
-import { createHash, randomUUID } from 'node:crypto'
-import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { lstatSync, mkdirSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import type { HostKey } from './host-key.js'
 
@@ -37,18 +37,31 @@ export const AF_UNIX_PATH_MAX = 107
 /** The widest socket SRT composes under TMPDIR — a Linux pid at its 22-bit ceiling. */
 const WIDEST_SRT_SOCKET = 'srt-mux-4194304-0.sock'
 
-// The marker is published WITH the directory, never after it: two hosts of one agent starting for the first time would otherwise interleave between the mkdir and the write, and the loser would read an unmarked parent and refuse a path that is in fact ours. Build it aside, mark it, then move it into place — the rename is atomic, so `t` never exists unmarked.
+// `mkdir` is the only no-clobber claim on a directory name — `rename` REPLACES an empty destination, which would let this adopt a foreign `t`. So the winner creates the name and marks it; a loser waits briefly for that mark rather than assuming the directory is unowned, because the two are not published together and a first-launch race would otherwise refuse a path that is ours.
+const MARKER_WAIT_MS = 2_000
+const MARKER_POLL_MS = 20
+
 function createOwnedTempParent(agentDir: string): void {
   const parent = sandboxTempParent(agentDir)
-  if (existsSync(parent)) return
-  const staging = `${parent}.${randomUUID()}`
-  mkdirSync(staging, { recursive: true, mode: 0o700 })
-  writeFileSync(join(staging, OWNER_MARKER), '', { mode: 0o600 })
   try {
-    renameSync(staging, parent)
-  } catch {
-    // Another host won the race, or something else holds the name; its own proof decides below.
-    rmSync(staging, { recursive: true, force: true })
+    mkdirSync(parent, { mode: 0o700 })
+  } catch (err) {
+    // Anything but "the name is taken" is the caller's to report; a taken name may be ours, mid-creation, or foreign.
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
+    waitForOwnerMarker(parent)
+    return
+  }
+  writeFileSync(join(parent, OWNER_MARKER), '', { mode: 0o600 })
+}
+
+/** Bounded: a contender that created the name writes its marker microseconds later, so an absent one past this wait means the directory is not ours and the ownership check below refuses it. */
+function waitForOwnerMarker(parent: string): void {
+  const deadline = Date.now() + MARKER_WAIT_MS
+  while (!daemonOwnsTempParent(parent) && Date.now() < deadline) {
+    const until = Date.now() + MARKER_POLL_MS
+    while (Date.now() < until) {
+      /* a spin is enough for a window this short, and keeps preparation synchronous */
+    }
   }
 }
 

--- a/packages/daemon/src/acp/sandbox-temp.ts
+++ b/packages/daemon/src/acp/sandbox-temp.ts
@@ -37,36 +37,6 @@ export const AF_UNIX_PATH_MAX = 107
 /** The widest socket SRT composes under TMPDIR — a Linux pid at its 22-bit ceiling. */
 const WIDEST_SRT_SOCKET = 'srt-mux-4194304-0.sock'
 
-// `mkdir` is the only no-clobber claim on a directory name — `rename` REPLACES an empty destination, which would let this adopt a foreign `t`. A loser of that race finds the name taken before the winner's marker exists, so emptiness decides instead of a wait: an operator's workspace has files, a sibling's half-made claim has none, and marking an empty directory can destroy nothing.
-function createOwnedTempParent(agentDir: string): void {
-  const parent = sandboxTempParent(agentDir)
-  try {
-    mkdirSync(parent, { mode: 0o700 })
-  } catch (err) {
-    // Anything but "the name is taken" is the caller's to report; a taken name may be ours, mid-claim, or foreign.
-    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
-    if (daemonOwnsTempParent(parent) || !isEmptyDir(parent)) return
-  }
-  markTempParent(parent)
-}
-
-/** `wx` so the winner of a first-launch race writes it and the loser is content that it exists. */
-function markTempParent(parent: string): void {
-  try {
-    writeFileSync(join(parent, OWNER_MARKER), '', { mode: 0o600, flag: 'wx' })
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
-  }
-}
-
-function isEmptyDir(path: string): boolean {
-  try {
-    return readdirSync(path).length === 0
-  } catch {
-    return false
-  }
-}
-
 /** Create one host's temp directory and return its canonical path. Short is not the same as bounded: a deep enough daemon root plus a long agent name still overflows `sun_path`, and it fails HERE naming the path and the limit, rather than as an opaque `listen EINVAL` three ACP start attempts deep. */
 export function prepareSandboxTempDir(
   agentDir: string,
@@ -74,16 +44,17 @@ export function prepareSandboxTempDir(
   /** Test seam: SRT confines a host on Linux alone, so only a Linux launch opens this socket and only it is held to the budget. */
   platform: NodeJS.Platform = process.platform
 ): string {
-  createOwnedTempParent(agentDir)
+  const created = mkdirSync(sandboxTempParent(agentDir), { recursive: true, mode: 0o700 }) !== undefined
   const parent = join(realpathSync(resolve(agentDir)), 't')
   // Trust the resolved directory, not the composed name: a link standing in for it would move the whole temp tree out of the agent dir.
   if (realpathSync(parent) !== parent) {
     throw new Error(`runtime temp parent is not a real directory inside the agent dir: ${parent}`)
   }
-  // Fail closed rather than write into, or later sweep, a directory this daemon did not make.
+  if (created) writeFileSync(join(parent, OWNER_MARKER), '', { mode: 0o600 })
+  // Fail closed rather than write into, or later sweep, a directory this daemon did not make — a first-launch race puts a sibling's half-made claim here too, which the next attempt resolves.
   if (!daemonOwnsTempParent(parent)) {
     throw new Error(
-      `runtime temp root "${parent}" exists but this daemon did not create it — an agent workspace or operator data at that path must move before a confined host can start`
+      `runtime temp root "${parent}" carries no ownership marker, so this daemon did not create it — either an agent workspace or operator data sits at that path and must move, or another host of this agent is creating it right now and the next launch attempt will find it marked`
     )
   }
   const path = join(parent, tempLeaf(hostKey))

--- a/packages/daemon/src/acp/sandbox-temp.ts
+++ b/packages/daemon/src/acp/sandbox-temp.ts
@@ -37,31 +37,33 @@ export const AF_UNIX_PATH_MAX = 107
 /** The widest socket SRT composes under TMPDIR — a Linux pid at its 22-bit ceiling. */
 const WIDEST_SRT_SOCKET = 'srt-mux-4194304-0.sock'
 
-// `mkdir` is the only no-clobber claim on a directory name — `rename` REPLACES an empty destination, which would let this adopt a foreign `t`. So the winner creates the name and marks it; a loser waits briefly for that mark rather than assuming the directory is unowned, because the two are not published together and a first-launch race would otherwise refuse a path that is ours.
-const MARKER_WAIT_MS = 2_000
-const MARKER_POLL_MS = 20
-
+// `mkdir` is the only no-clobber claim on a directory name — `rename` REPLACES an empty destination, which would let this adopt a foreign `t`. A loser of that race finds the name taken before the winner's marker exists, so emptiness decides instead of a wait: an operator's workspace has files, a sibling's half-made claim has none, and marking an empty directory can destroy nothing.
 function createOwnedTempParent(agentDir: string): void {
   const parent = sandboxTempParent(agentDir)
   try {
     mkdirSync(parent, { mode: 0o700 })
   } catch (err) {
-    // Anything but "the name is taken" is the caller's to report; a taken name may be ours, mid-creation, or foreign.
+    // Anything but "the name is taken" is the caller's to report; a taken name may be ours, mid-claim, or foreign.
     if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
-    waitForOwnerMarker(parent)
-    return
+    if (daemonOwnsTempParent(parent) || !isEmptyDir(parent)) return
   }
-  writeFileSync(join(parent, OWNER_MARKER), '', { mode: 0o600 })
+  markTempParent(parent)
 }
 
-/** Bounded: a contender that created the name writes its marker microseconds later, so an absent one past this wait means the directory is not ours and the ownership check below refuses it. */
-function waitForOwnerMarker(parent: string): void {
-  const deadline = Date.now() + MARKER_WAIT_MS
-  while (!daemonOwnsTempParent(parent) && Date.now() < deadline) {
-    const until = Date.now() + MARKER_POLL_MS
-    while (Date.now() < until) {
-      /* a spin is enough for a window this short, and keeps preparation synchronous */
-    }
+/** `wx` so the winner of a first-launch race writes it and the loser is content that it exists. */
+function markTempParent(parent: string): void {
+  try {
+    writeFileSync(join(parent, OWNER_MARKER), '', { mode: 0o600, flag: 'wx' })
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err
+  }
+}
+
+function isEmptyDir(path: string): boolean {
+  try {
+    return readdirSync(path).length === 0
+  } catch {
+    return false
   }
 }
 

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -570,26 +570,6 @@ describe('sandbox temp directories', () => {
     }
   })
 
-  it('claims an empty unmarked temp parent, and refuses one holding anything', () => {
-    // A first-launch race leaves the loser looking at a directory whose marker the winner has not
-    // written yet. Emptiness tells the two cases apart without waiting: an operator's workspace has
-    // files, a sibling's half-made claim has none, and marking an empty directory destroys nothing.
-    const claimed = mkdtempSync(join(tmpdir(), 'ac-temp-empty-'))
-    const foreign = mkdtempSync(join(tmpdir(), 'ac-temp-foreign-'))
-    try {
-      mkdirSync(join(claimed, 't'))
-      expect(existsSync(prepareSandboxTempDir(claimed, hostKey))).toBe(true)
-
-      mkdirSync(join(foreign, 't'))
-      writeFileSync(join(foreign, 't', 'README.md'), 'an operator workspace')
-      expect(() => prepareSandboxTempDir(foreign, hostKey)).toThrow(/this daemon did not create it/)
-      // Refusing means untouched: no marker written into it, and no host leaf made under it.
-      expect(readdirSync(join(foreign, 't'))).toEqual(['README.md'])
-    } finally {
-      for (const dir of [claimed, foreign]) rmSync(dir, { recursive: true, force: true })
-    }
-  })
-
   it.skipIf(process.platform === 'win32')('refuses a symlink standing in for the temp parent', () => {
     const agentDir = mkdtempSync(join(tmpdir(), 'ac-temp-link-'))
     try {

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -570,6 +570,26 @@ describe('sandbox temp directories', () => {
     }
   })
 
+  it('claims an empty unmarked temp parent, and refuses one holding anything', () => {
+    // A first-launch race leaves the loser looking at a directory whose marker the winner has not
+    // written yet. Emptiness tells the two cases apart without waiting: an operator's workspace has
+    // files, a sibling's half-made claim has none, and marking an empty directory destroys nothing.
+    const claimed = mkdtempSync(join(tmpdir(), 'ac-temp-empty-'))
+    const foreign = mkdtempSync(join(tmpdir(), 'ac-temp-foreign-'))
+    try {
+      mkdirSync(join(claimed, 't'))
+      expect(existsSync(prepareSandboxTempDir(claimed, hostKey))).toBe(true)
+
+      mkdirSync(join(foreign, 't'))
+      writeFileSync(join(foreign, 't', 'README.md'), 'an operator workspace')
+      expect(() => prepareSandboxTempDir(foreign, hostKey)).toThrow(/this daemon did not create it/)
+      // Refusing means untouched: no marker written into it, and no host leaf made under it.
+      expect(readdirSync(join(foreign, 't'))).toEqual(['README.md'])
+    } finally {
+      for (const dir of [claimed, foreign]) rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it.skipIf(process.platform === 'win32')('refuses a symlink standing in for the temp parent', () => {
     const agentDir = mkdtempSync(join(tmpdir(), 'ac-temp-link-'))
     try {


### PR DESCRIPTION
## Summary

Narrowed to a **message correction**, two lines. The behaviour on `main` is unchanged.

`prepareSandboxTempDir` refuses a `<agentDir>/t` that carries no ownership marker, and says an agent workspace or operator data must move. That is one of two things it can mean. The other is a first-launch race: two hosts of one agent interleave between the `mkdir` that creates the parent and the write of its marker, and the loser sees an unmarked directory that is in fact ours, moments from being marked. It fails in the safe direction and the next attempt finds the marker — so the message was wrong, not the behaviour.

The refusal now names both readings, and the comment above it says the same.

## Why the race itself is not closed here

Three attempts were each worse than the race:

- **`rename` a marked staging directory into place** — atomic, but on POSIX it *replaces* an empty destination, so a foreign `t` appearing in the window would be adopted and then read back as ours.
- **Bounded wait for the marker** — the case it can never satisfy, a real workspace at that path, spins for its full budget on the daemon's main thread at every launch, so one misconfigured agent stalls every other agent.
- **Treat an empty unmarked directory as ours** — an operator directory can be empty, and another process can fill it between the check and the marker write; once stamped, boot reclamation trusts it.

Each reintroduced, in a narrower window, the adoption the ownership marker exists to prevent. Closing it correctly needs an asynchronous retry for the in-flight winner, and `prepareRuntimeLaunch` is a synchronous exported function whose callers would all have to change — too much for a window of microseconds that already fails safe and recovers on the next attempt.

Recorded here rather than dropped silently, so the next person reaching for one of those three knows they were tried.

## Verification

`tsc -p tsconfig.typecheck.json --noEmit` clean; `sandbox.test.ts` passes (19 passed, 4 skipped). No behavioural change to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)