### PR TITLE
feat(console): the model field is the same listbox as the two beside it

### DIFF
--- a/packages/web/src/components/console/FleetDetail.test.ts
+++ b/packages/web/src/components/console/FleetDetail.test.ts
@@ -40,6 +40,21 @@ describe('runtime aggregation carries model display metadata', () => {
     expect(flipped!.modelInfo?.['opus[1m]']?.name).toBe('Opus (1M context)')
   })
 
+  it('drops a name the members disagree on — one alias, two concrete models', () => {
+    const other = member({
+      modelCatalog: {
+        models: [
+          { id: 'opus[1m]', name: 'Opus 4.8 (1M context)', description: 'Opus 4.8 with 1M context' },
+          { id: 'haiku' }
+        ],
+        source: 'acp',
+        observedAt: '2026-09-03T00:00:00.000Z'
+      }
+    } as never)
+    expect(unionRuntimes([member(), other])[0]!.modelInfo).toEqual({})
+    expect(intersectRuntimes([member(), other])[0]!.modelInfo).toEqual({})
+  })
+
   it('carries them through the intersection too', () => {
     const [rt] = intersectRuntimes([member(), member()])
     expect(rt!.modelInfo?.['opus[1m]']?.description).toBe('Opus 5 with 1M context')

--- a/packages/web/src/components/console/FleetDetail.test.ts
+++ b/packages/web/src/components/console/FleetDetail.test.ts
@@ -55,6 +55,19 @@ describe('runtime aggregation carries model display metadata', () => {
     expect(intersectRuntimes([member(), other])[0]!.modelInfo).toEqual({})
   })
 
+  it('stays silent once disputed, however many members agree later', () => {
+    const opus48 = member({
+      modelCatalog: {
+        models: [{ id: 'opus[1m]', name: 'Opus 4.8 (1M context)', description: 'Opus 4.8 with 1M context' }],
+        source: 'acp',
+        observedAt: '2026-09-03T00:00:00.000Z'
+      }
+    } as never)
+    // Opus 5, Opus 4.8, Opus 5 — the set still disagrees, so the third must not resurrect it.
+    expect(unionRuntimes([member(), opus48, member()])[0]!.modelInfo).toEqual({})
+    expect(intersectRuntimes([member(), opus48, member()])[0]!.modelInfo).toEqual({})
+  })
+
   it('carries them through the intersection too', () => {
     const [rt] = intersectRuntimes([member(), member()])
     expect(rt!.modelInfo?.['opus[1m]']?.description).toBe('Opus 5 with 1M context')

--- a/packages/web/src/components/console/FleetDetail.test.ts
+++ b/packages/web/src/components/console/FleetDetail.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { intersectRuntimes, unionRuntimes } from './FleetDetail'
+import type { DaemonRow } from '@/lib/data'
+
+/** The set-level runtime views a detail page renders. Their model lists are ids — and for a
+ *  claude runtime those are ALIASES — so what a member's catalog says about each id has to
+ *  survive the aggregation, or the card can only ever show `opus[1m]`. */
+
+const member = (over: Partial<DaemonRow['runtimeModels'][number]> = {}): DaemonRow =>
+  ({
+    runtimeModels: [
+      {
+        runtime: 'claude',
+        version: '0.73.0',
+        models: ['opus[1m]', 'haiku'],
+        modelCatalog: {
+          models: [
+            { id: 'opus[1m]', name: 'Opus (1M context)', description: 'Opus 5 with 1M context' },
+            { id: 'haiku' }
+          ],
+          source: 'acp',
+          observedAt: '2026-09-03T00:00:00.000Z'
+        },
+        ...over
+      }
+    ]
+  }) as unknown as DaemonRow
+
+describe('runtime aggregation carries model display metadata', () => {
+  it('unions the catalog names and blurbs alongside the ids', () => {
+    const [rt] = unionRuntimes([member()])
+    expect(rt!.models).toEqual(['opus[1m]', 'haiku'])
+    expect(rt!.modelInfo).toEqual({ 'opus[1m]': { name: 'Opus (1M context)', description: 'Opus 5 with 1M context' } })
+  })
+
+  it('keeps a describing member’s answer when a peer reports no catalog', () => {
+    const [rt] = unionRuntimes([member(), member({ modelCatalog: null })])
+    expect(rt!.modelInfo?.['opus[1m]']?.name).toBe('Opus (1M context)')
+    const [flipped] = unionRuntimes([member({ modelCatalog: null }), member()])
+    expect(flipped!.modelInfo?.['opus[1m]']?.name).toBe('Opus (1M context)')
+  })
+
+  it('carries them through the intersection too', () => {
+    const [rt] = intersectRuntimes([member(), member()])
+    expect(rt!.modelInfo?.['opus[1m]']?.description).toBe('Opus 5 with 1M context')
+  })
+})

--- a/packages/web/src/components/console/FleetDetail.tsx
+++ b/packages/web/src/components/console/FleetDetail.tsx
@@ -44,7 +44,25 @@ export interface FleetRuntime {
   /** Members disagree on the version, so there is no single one to quote. */
   versionsDiffer?: boolean
   models: string[]
+  /** What the members' catalogs say about those models, by id. A claude runtime advertises
+   *  ALIASES (`opus[1m]` is whichever Opus it resolves today), so the name is what says which
+   *  concrete model that is; absent for a member that reported no catalog. */
+  modelInfo?: Record<string, { name?: string; description?: string }>
   authRequired: boolean
+}
+
+/** The display half of a member's catalog, by model id — empty when it reported none. */
+function modelInfoOf(rt: DaemonRow['runtimeModels'][number]): Record<string, { name?: string; description?: string }> {
+  const info: Record<string, { name?: string; description?: string }> = {}
+  for (const model of rt.modelCatalog?.models ?? []) {
+    if (model.name || model.description) {
+      info[model.id] = {
+        ...(model.name ? { name: model.name } : {}),
+        ...(model.description ? { description: model.description } : {})
+      }
+    }
+  }
+  return info
 }
 
 // The runtimes a set offers, unioned over the members given (pass the serving ones). Version is
@@ -60,12 +78,16 @@ export function unionRuntimes(members: readonly DaemonRow[]): FleetRuntime[] {
           runtime: rt.runtime,
           version: rt.version,
           models: [...rt.models],
+          modelInfo: modelInfoOf(rt),
           authRequired: rt.authRequired === true
         })
         continue
       }
       if (!prev.version) prev.version = rt.version
       for (const model of rt.models) if (!prev.models.includes(model)) prev.models.push(model)
+      // First member to describe a model wins: replicas agree, and a member with no catalog
+      // must not blank out what a peer already knows.
+      prev.modelInfo = { ...modelInfoOf(rt), ...prev.modelInfo }
       prev.authRequired ||= rt.authRequired === true
     }
   }
@@ -98,6 +120,8 @@ export function intersectRuntimes(members: readonly DaemonRow[]): FleetRuntime[]
       version: versions.size === 1 ? [...versions][0]! : '',
       versionsDiffer: versions.size > 1,
       models: rt.models.filter((model) => all.every((peer) => peer.models.includes(model))),
+      // Same rule as the union: the first member that describes a model answers for the set.
+      modelInfo: all.reduce((info, peer) => ({ ...modelInfoOf(peer), ...info }), {}),
       // Sticky, as in the union: one member needing a login qualifies the set's promise, so the
       // row is MARKED. Not withdrawn — placement is deliberately independent of login readiness
       // (preset-agents.md §3.2), which is why this does not exclude the runtime.
@@ -411,11 +435,19 @@ export function FleetRuntimesCard({
                     <div className="pb-1 font-sans text-[10px] font-semibold leading-normal tracking-[.05em] uppercase text-(--text-tertiary)">
                       Models
                     </div>
-                    {rt.models.map((m) => (
-                      <div key={m} className="mono truncate py-[3px] text-[11.5px]">
-                        {m}
-                      </div>
-                    ))}
+                    {rt.models.map((m) => {
+                      const info = rt.modelInfo?.[m]
+                      return (
+                        <div key={m} className="flex items-baseline gap-2 py-[3px]" title={info?.description}>
+                          <span className="mono truncate text-[11.5px]">{m}</span>
+                          {info?.name && (
+                            <span className="min-w-0 truncate font-sans text-[11px] font-normal leading-normal text-(--text-tertiary)">
+                              {info.name}
+                            </span>
+                          )}
+                        </div>
+                      )
+                    })}
                   </div>
                 )}
               </div>

--- a/packages/web/src/components/console/FleetDetail.tsx
+++ b/packages/web/src/components/console/FleetDetail.tsx
@@ -52,24 +52,33 @@ export interface FleetRuntime {
   authRequired: boolean
 }
 
-/** Merge two members' answers: an id only one of them describes is carried, and one they
- *  DISAGREE on is dropped. A group's members are machines an operator enrolled by hand, so
- *  they can resolve the same alias to different models — `opus[1m]` is Opus 5 on one and Opus
- *  4.8 on another — and quoting the first would promise a concrete model the next turn might
- *  not run. Silence is the honest answer there; the id alone is what the card falls back to.
- *  A member that describes nothing does not vote, or one member yet to report a catalog would
- *  blank the whole set. */
-function agreedModelInfo(
-  a: Record<string, { name?: string; description?: string }>,
-  b: Record<string, { name?: string; description?: string }>
+/** The set's answer for each model id: what every member that describes it agrees on, and
+ *  nothing for one they disagree on. A group is machines an operator enrolled by hand, so two
+ *  members really can resolve the same alias to different models — `opus[1m]` is Opus 5 on one
+ *  and Opus 4.8 on another — and quoting either would promise a concrete model the next turn
+ *  might not run. Silence is the honest answer; the card falls back to the bare id.
+ *
+ *  Decided over the WHOLE list rather than folded pairwise: a fold that drops a disputed id
+ *  cannot tell "never described" from "already disputed", so a third member agreeing with the
+ *  first would put it back. A member that describes nothing does not vote — otherwise one
+ *  member yet to report a catalog would blank the set. */
+function consensusModelInfo(
+  described: ReadonlyArray<Record<string, { name?: string; description?: string }>>
 ): Record<string, { name?: string; description?: string }> {
-  const merged: Record<string, { name?: string; description?: string }> = { ...a }
-  for (const [id, info] of Object.entries(b)) {
-    const prior = merged[id]
-    if (!prior) merged[id] = info
-    else if (prior.name !== info.name || prior.description !== info.description) delete merged[id]
+  const agreed: Record<string, { name?: string; description?: string }> = {}
+  const disputed = new Set<string>()
+  for (const info of described) {
+    for (const [id, entry] of Object.entries(info)) {
+      if (disputed.has(id)) continue
+      const prior = agreed[id]
+      if (!prior) agreed[id] = entry
+      else if (prior.name !== entry.name || prior.description !== entry.description) {
+        disputed.add(id)
+        delete agreed[id]
+      }
+    }
   }
-  return merged
+  return agreed
 }
 
 /** The display half of a member's catalog, by model id — empty when it reported none. */
@@ -91,25 +100,26 @@ function modelInfoOf(rt: DaemonRow['runtimeModels'][number]): Record<string, { n
 // is sticky, because one member whose probe was rejected is a real problem on that member.
 export function unionRuntimes(members: readonly DaemonRow[]): FleetRuntime[] {
   const byId = new Map<string, FleetRuntime>()
+  const described = new Map<string, Array<Record<string, { name?: string; description?: string }>>>()
   for (const m of members) {
     for (const rt of m.runtimeModels) {
+      described.set(rt.runtime, [...(described.get(rt.runtime) ?? []), modelInfoOf(rt)])
       const prev = byId.get(rt.runtime)
       if (!prev) {
         byId.set(rt.runtime, {
           runtime: rt.runtime,
           version: rt.version,
           models: [...rt.models],
-          modelInfo: modelInfoOf(rt),
           authRequired: rt.authRequired === true
         })
         continue
       }
       if (!prev.version) prev.version = rt.version
       for (const model of rt.models) if (!prev.models.includes(model)) prev.models.push(model)
-      prev.modelInfo = agreedModelInfo(prev.modelInfo ?? {}, modelInfoOf(rt))
       prev.authRequired ||= rt.authRequired === true
     }
   }
+  for (const rt of byId.values()) rt.modelInfo = consensusModelInfo(described.get(rt.runtime) ?? [])
   return [...byId.values()]
 }
 
@@ -140,7 +150,7 @@ export function intersectRuntimes(members: readonly DaemonRow[]): FleetRuntime[]
       versionsDiffer: versions.size > 1,
       models: rt.models.filter((model) => all.every((peer) => peer.models.includes(model))),
       // Same rule as the union — and it bites here: a group's members really do differ.
-      modelInfo: all.reduce((info, peer) => agreedModelInfo(info, modelInfoOf(peer)), {}),
+      modelInfo: consensusModelInfo(all.map(modelInfoOf)),
       // Sticky, as in the union: one member needing a login qualifies the set's promise, so the
       // row is MARKED. Not withdrawn — placement is deliberately independent of login readiness
       // (preset-agents.md §3.2), which is why this does not exclude the runtime.

--- a/packages/web/src/components/console/FleetDetail.tsx
+++ b/packages/web/src/components/console/FleetDetail.tsx
@@ -46,9 +46,30 @@ export interface FleetRuntime {
   models: string[]
   /** What the members' catalogs say about those models, by id. A claude runtime advertises
    *  ALIASES (`opus[1m]` is whichever Opus it resolves today), so the name is what says which
-   *  concrete model that is; absent for a member that reported no catalog. */
+   *  concrete model that is. An id is here only when every member that describes it agrees —
+   *  a set whose members resolve one alias differently has no single answer to quote. */
   modelInfo?: Record<string, { name?: string; description?: string }>
   authRequired: boolean
+}
+
+/** Merge two members' answers: an id only one of them describes is carried, and one they
+ *  DISAGREE on is dropped. A group's members are machines an operator enrolled by hand, so
+ *  they can resolve the same alias to different models — `opus[1m]` is Opus 5 on one and Opus
+ *  4.8 on another — and quoting the first would promise a concrete model the next turn might
+ *  not run. Silence is the honest answer there; the id alone is what the card falls back to.
+ *  A member that describes nothing does not vote, or one member yet to report a catalog would
+ *  blank the whole set. */
+function agreedModelInfo(
+  a: Record<string, { name?: string; description?: string }>,
+  b: Record<string, { name?: string; description?: string }>
+): Record<string, { name?: string; description?: string }> {
+  const merged: Record<string, { name?: string; description?: string }> = { ...a }
+  for (const [id, info] of Object.entries(b)) {
+    const prior = merged[id]
+    if (!prior) merged[id] = info
+    else if (prior.name !== info.name || prior.description !== info.description) delete merged[id]
+  }
+  return merged
 }
 
 /** The display half of a member's catalog, by model id — empty when it reported none. */
@@ -85,9 +106,7 @@ export function unionRuntimes(members: readonly DaemonRow[]): FleetRuntime[] {
       }
       if (!prev.version) prev.version = rt.version
       for (const model of rt.models) if (!prev.models.includes(model)) prev.models.push(model)
-      // First member to describe a model wins: replicas agree, and a member with no catalog
-      // must not blank out what a peer already knows.
-      prev.modelInfo = { ...modelInfoOf(rt), ...prev.modelInfo }
+      prev.modelInfo = agreedModelInfo(prev.modelInfo ?? {}, modelInfoOf(rt))
       prev.authRequired ||= rt.authRequired === true
     }
   }
@@ -120,8 +139,8 @@ export function intersectRuntimes(members: readonly DaemonRow[]): FleetRuntime[]
       version: versions.size === 1 ? [...versions][0]! : '',
       versionsDiffer: versions.size > 1,
       models: rt.models.filter((model) => all.every((peer) => peer.models.includes(model))),
-      // Same rule as the union: the first member that describes a model answers for the set.
-      modelInfo: all.reduce((info, peer) => ({ ...modelInfoOf(peer), ...info }), {}),
+      // Same rule as the union — and it bites here: a group's members really do differ.
+      modelInfo: all.reduce((info, peer) => agreedModelInfo(info, modelInfoOf(peer)), {}),
       // Sticky, as in the union: one member needing a login qualifies the set's promise, so the
       // row is MARKED. Not withdrawn — placement is deliberately independent of login readiness
       // (preset-agents.md §3.2), which is why this does not exclude the runtime.

--- a/packages/web/src/components/console/ModelSelect.tsx
+++ b/packages/web/src/components/console/ModelSelect.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
+import { Icon } from '@/components/ui'
+import { modelLabel } from '@/lib/data'
+
+export interface ModelSelectOption {
+  /** The advertised model id — what the agent stores and the runtime answers to, so it is
+   *  the row's label verbatim (runtime-model-catalog.md §7). */
+  value: string
+  /** The runtime's own display name, when it differs from the id. Right-aligned meta, never
+   *  the label: "Opus (1M context)" tells you what `opus[1m]` is without replacing it. */
+  name?: string
+  /** The runtime's model blurb — the row's hover text. */
+  description?: string
+  /** Stored on the agent but no longer advertised: still selectable, marked in the row. */
+  unavailable?: boolean
+}
+
+/** The model field's picker. Same listbox as the Runtime and Runs-on fields beside it —
+ *  `.inp` trigger, scrim, `.fmenu`, `.fopt` rows, roving keyboard focus — because a native
+ *  `<select>` renders the platform's own popup: OS chrome, a system-blue selected row, and no
+ *  room for what the catalog knows about a model. No provider mark, unlike those two: every
+ *  option here belongs to the SAME runtime, so the icon would repeat down the list. */
+export function ModelSelect({
+  value,
+  options,
+  onChange,
+  ariaLabel = 'Model',
+  placeholder = '—',
+  disabledHint
+}: {
+  value: string
+  options: readonly ModelSelectOption[]
+  onChange: (value: string) => void
+  ariaLabel?: string
+  /** Shown when the runtime advertises no models at all. */
+  placeholder?: string
+  disabledHint?: string
+}) {
+  const selectedIndex = options.findIndex((option) => option.value === value)
+  const selected = selectedIndex >= 0 ? options[selectedIndex] : undefined
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(selectedIndex)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  const listboxId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    const frame = requestAnimationFrame(() => listRef.current?.focus())
+    return () => cancelAnimationFrame(frame)
+  }, [open])
+
+  const closeAndFocus = () => {
+    setOpen(false)
+    requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+
+  const pick = (option: ModelSelectOption) => {
+    onChange(option.value)
+    closeAndFocus()
+  }
+
+  const openFromKeyboard = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+    event.preventDefault()
+    setActiveIndex(event.key === 'ArrowDown' ? 0 : options.length - 1)
+    setOpen(true)
+  }
+
+  const onListKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const delta = event.key === 'ArrowDown' ? 1 : -1
+      setActiveIndex((current) => (current + delta + options.length) % options.length)
+      return
+    }
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault()
+      setActiveIndex(event.key === 'Home' ? 0 : options.length - 1)
+      return
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      const active = options[activeIndex]
+      if (active) pick(active)
+      return
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      closeAndFocus()
+      return
+    }
+    if (event.key === 'Tab') setOpen(false)
+  }
+
+  const empty = options.length === 0
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`inp relative w-full text-left outline-none transition-[background-color,border-color,box-shadow] ${
+          empty
+            ? 'cursor-not-allowed'
+            : open
+              ? 'cursor-pointer border-(--border-focus) ring-[3px] ring-(--brand-ring)'
+              : 'cursor-pointer hover:border-(--border-strong) hover:bg-(--surface-hover) focus-visible:border-(--border-focus) focus-visible:ring-[3px] focus-visible:ring-(--brand-ring)'
+        }`}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        disabled={empty}
+        title={empty ? disabledHint : selected?.description}
+        onClick={() => {
+          setActiveIndex(Math.max(selectedIndex, 0))
+          setOpen((current) => !current)
+        }}
+        onKeyDown={openFromKeyboard}
+      >
+        <span className="inline-flex min-w-0 items-center gap-2">
+          {empty ? (
+            <span className="truncate text-(--text-tertiary)">{placeholder}</span>
+          ) : (
+            <span className="truncate">{modelLabel(selected?.value ?? value)}</span>
+          )}
+        </span>
+        <Icon
+          name="chevron-down"
+          size={15}
+          color="var(--text-tertiary)"
+          className={`flex-none transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+      {open && !empty && (
+        <>
+          <div className="fscrim" onClick={() => setOpen(false)} />
+          <div
+            ref={listRef}
+            id={listboxId}
+            role="listbox"
+            tabIndex={-1}
+            aria-label={ariaLabel}
+            aria-activedescendant={activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined}
+            // Sized to the widest row, trigger width as the floor: a model id and its display
+            // name are longer than this 1/3 column, and neither reads well truncated.
+            className="fmenu left-0 z-40 max-w-[420px] min-w-full rounded-lg p-2 shadow-(--shadow-xl) outline-none"
+            onKeyDown={onListKeyDown}
+          >
+            {options.map((option, index) => {
+              const isSelected = option.value === value
+              const isActive = index === activeIndex
+              return (
+                <button
+                  key={option.value}
+                  id={`${listboxId}-option-${index}`}
+                  type="button"
+                  role="option"
+                  tabIndex={-1}
+                  aria-selected={isSelected}
+                  title={option.description}
+                  className={`fopt min-h-10 gap-3 rounded-md px-2 py-[6px] text-[13px] ${
+                    isSelected
+                      ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)'
+                      : isActive
+                        ? 'bg-(--surface-hover)'
+                        : ''
+                  }`}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => pick(option)}
+                >
+                  <span className="flex-1 truncate">{modelLabel(option.value)}</span>
+                  {option.unavailable ? (
+                    <span className="flex-none font-sans text-[11px] font-medium leading-normal text-(--status-paused)">
+                      unavailable
+                    </span>
+                  ) : (
+                    option.name && (
+                      <span
+                        className={`flex-none truncate font-sans text-[11.5px] font-normal leading-normal ${
+                          isSelected ? 'text-(--brand-soft-text) opacity-80' : 'text-(--text-tertiary)'
+                        }`}
+                      >
+                        {option.name}
+                      </span>
+                    )
+                  )}
+                  {isSelected && <Icon name="check" size={16} color="var(--brand)" className="flex-none" />}
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/console/modals/AddAgentModal.tsx
+++ b/packages/web/src/components/console/modals/AddAgentModal.tsx
@@ -20,8 +20,7 @@ import {
   effortLabel,
   fastModeAvailableFor,
   modelCapability,
-  modelLabel,
-  modelTooltip,
+  modelOptionsFor,
   displayedEffort,
   preferredModelFor,
   resolvedPermissionMode,
@@ -48,6 +47,7 @@ import {
 import { GithubMark, LoadingState } from '@/components/marks'
 import { AgentIconPicker } from '@/components/console/AgentIconPicker'
 import { DaemonSelect, type DaemonSelectOption } from '@/components/console/DaemonSelect'
+import { ModelSelect } from '@/components/console/ModelSelect'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
 import { randomGlyphIcon, type AgentIcon } from '@/lib/agent-icon'
 import { DEFAULT_AGENT_OUTPUT_MODE, type OutputMode } from '@/lib/output-mode'
@@ -921,47 +921,19 @@ export default function AddAgentModal({ onClose }: { onClose: () => void }) {
                   <span className="fldlbl">Model</span>
                   {/* No advertised models ⇒ nothing to choose: an inert em-dash field
                   rather than a fabricated "Default" entry the runtime never offered. */}
-                  <div
-                    className={models.length ? 'inp relative' : 'inp cursor-not-allowed'}
-                    title={
-                      models.length
-                        ? modelTooltip(daemon, effectiveRuntime, selectedModel)
-                        : 'This runtime reports no selectable models'
-                    }
-                  >
-                    <span className={`truncate ${models.length ? '' : 'text-(--text-tertiary)'}`}>
-                      {models.length ? modelLabel(selectedModel) : '—'}
-                    </span>
-                    {models.length > 0 && (
-                      <>
-                        <Icon name="chevron-down" size={15} color="var(--text-tertiary)" className="flex-none" />
-                        <select
-                          value={selectedModel}
-                          onChange={(e) => {
-                            const next = e.target.value
-                            setModel(next)
-                            // Picking a model resolves an effort the new model doesn't offer:
-                            // its default level, else the nearest available tier.
-                            setEffort((cur) =>
-                              resolveEffortForModel(
-                                effectiveRuntime,
-                                modelCapability(daemon, effectiveRuntime, next),
-                                cur
-                              )
-                            )
-                          }}
-                          className="absolute inset-0 cursor-pointer opacity-0"
-                          aria-label="Model"
-                        >
-                          {models.map((m) => (
-                            <option key={m} value={m} title={modelTooltip(daemon, effectiveRuntime, m)}>
-                              {modelLabel(m)}
-                            </option>
-                          ))}
-                        </select>
-                      </>
-                    )}
-                  </div>
+                  <ModelSelect
+                    value={selectedModel}
+                    options={modelOptionsFor(daemon, effectiveRuntime, models)}
+                    disabledHint="This runtime reports no selectable models"
+                    onChange={(next) => {
+                      setModel(next)
+                      // Picking a model resolves an effort the new model doesn't offer:
+                      // its default level, else the nearest available tier.
+                      setEffort((cur) =>
+                        resolveEffortForModel(effectiveRuntime, modelCapability(daemon, effectiveRuntime, next), cur)
+                      )
+                    }}
+                  />
                 </div>
               </div>
             </div>

--- a/packages/web/src/components/console/modals/EditAgentModal.tsx
+++ b/packages/web/src/components/console/modals/EditAgentModal.tsx
@@ -9,8 +9,7 @@ import {
   loginRequiredRuntimeIds,
   fastModeAvailableFor,
   modelCapability,
-  modelLabel,
-  modelTooltip,
+  modelOptionsFor,
   displayedEffort,
   preferredModelFor,
   resolveEffortForModel,
@@ -40,6 +39,7 @@ import { Spinner } from '@/components/marks'
 import { Button, Icon, Toggle } from '@/components/ui'
 import { DaemonSelect, type DaemonSelectOption } from '@/components/console/DaemonSelect'
 import { useModal } from '@/components/console/ModalProvider'
+import { ModelSelect } from '@/components/console/ModelSelect'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
 import { editAgentCapabilitySource, editAgentDaemonChoices, preselectPlacementReset } from './edit-agent-daemon-choice'
 import { VisibilityField, sameSharing, type SharingValue } from '@/components/console/VisibilityField'
@@ -811,44 +811,19 @@ export default function EditAgentModal({
                     <span className="fldlbl">Model</span>
                     {/* No advertised models ⇒ nothing to choose: an inert em-dash field
                         rather than a fabricated "Default" entry the runtime never offered. */}
-                    <div
-                      className={modelSelectable ? 'inp relative' : 'inp cursor-not-allowed'}
-                      title={
-                        modelSelectable
-                          ? modelTooltip(daemon, runtime, selectedModel)
-                          : 'This runtime reports no selectable models'
-                      }
-                    >
-                      <span className={`truncate ${modelSelectable ? '' : 'text-(--text-tertiary)'}`}>
-                        {modelSelectable ? modelLabel(selectedModel) : '—'}
-                      </span>
-                      {modelSelectable && (
-                        <>
-                          <Icon name="chevron-down" size={15} color="var(--text-tertiary)" className="flex-none" />
-                          <select
-                            value={selectedModel}
-                            onChange={(e) => {
-                              const next = e.target.value
-                              setModel(next)
-                              // Picking a model resolves an effort the new model doesn't offer:
-                              // its default level, else the nearest available tier.
-                              setEffort((cur) =>
-                                resolveEffortForModel(runtime, modelCapability(daemon, runtime, next), cur)
-                              )
-                            }}
-                            className="absolute inset-0 cursor-pointer opacity-0"
-                            aria-label="Model"
-                          >
-                            {modelOptions.map((m) => (
-                              <option key={m} value={m} title={modelTooltip(daemon, runtime, m)}>
-                                {modelLabel(m)}
-                                {!reportedModels.includes(m) ? ' (unavailable)' : ''}
-                              </option>
-                            ))}
-                          </select>
-                        </>
+                    <ModelSelect
+                      value={selectedModel}
+                      options={modelOptionsFor(daemon, runtime, modelOptions).map((option) =>
+                        reportedModels.includes(option.value) ? option : { ...option, unavailable: true }
                       )}
-                    </div>
+                      disabledHint="This runtime reports no selectable models"
+                      onChange={(next) => {
+                        setModel(next)
+                        // Picking a model resolves an effort the new model doesn't offer:
+                        // its default level, else the nearest available tier.
+                        setEffort((cur) => resolveEffortForModel(runtime, modelCapability(daemon, runtime, next), cur))
+                      }}
+                    />
                   </div>
                   {/* Wide prose — it spans the row under the three pickers. */}
                   {sourceDaemon && sourceUnavailable && (

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -15,7 +15,6 @@ import {
   effectiveAgentStatus,
   platName,
   presentedDaemonStatus,
-  modelCapability,
   runtimeLabel,
   status
 } from '@/lib/data'
@@ -340,20 +339,20 @@ export default function DaemonDetailView() {
                               names whichever Opus the runtime resolves it to today. The runtime's
                               own name is what says which one that is, so it rides alongside. */}
                           {rt.models.map((m) => {
-                            const capability = modelCapability(daemon, rt.runtime, m)
+                            const info = rt.modelInfo?.[m]
                             return (
                               <span
                                 key={m}
                                 className="inline-flex min-w-0 items-center gap-2"
-                                title={capability?.description}
+                                title={info?.description}
                               >
                                 <span className="h-[5px] w-[5px] flex-none rounded-full bg-(--border-strong)" />
                                 <span className="font-mono text-[12px] font-medium leading-normal text-(--text-primary)">
                                   {m}
                                 </span>
-                                {capability?.name && (
+                                {info?.name && (
                                   <span className="min-w-0 truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
-                                    {capability.name}
+                                    {info.name}
                                   </span>
                                 )}
                               </span>

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -15,6 +15,7 @@ import {
   effectiveAgentStatus,
   platName,
   presentedDaemonStatus,
+  modelCapability,
   runtimeLabel,
   status
 } from '@/lib/data'
@@ -335,14 +336,29 @@ export default function DaemonDetailView() {
                           <span className="font-sans text-[10px] font-semibold tracking-[.05em] uppercase leading-normal text-(--text-tertiary)">
                             Models
                           </span>
-                          {rt.models.map((m) => (
-                            <span key={m} className="inline-flex items-center gap-2">
-                              <span className="h-[5px] w-[5px] flex-none rounded-full bg-(--border-strong)" />
-                              <span className="font-mono text-[12px] font-medium leading-normal text-(--text-primary)">
-                                {m}
+                          {/* The id is the model, and for claude it is an ALIAS — `opus[1m]`
+                              names whichever Opus the runtime resolves it to today. The runtime's
+                              own name is what says which one that is, so it rides alongside. */}
+                          {rt.models.map((m) => {
+                            const capability = modelCapability(daemon, rt.runtime, m)
+                            return (
+                              <span
+                                key={m}
+                                className="inline-flex min-w-0 items-center gap-2"
+                                title={capability?.description}
+                              >
+                                <span className="h-[5px] w-[5px] flex-none rounded-full bg-(--border-strong)" />
+                                <span className="font-mono text-[12px] font-medium leading-normal text-(--text-primary)">
+                                  {m}
+                                </span>
+                                {capability?.name && (
+                                  <span className="min-w-0 truncate font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
+                                    {capability.name}
+                                  </span>
+                                )}
                               </span>
-                            </span>
-                          ))}
+                            )
+                          })}
                         </div>
                       )}
                     </div>

--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -10,13 +10,13 @@ import { isAuthConfigured } from '@/lib/auth'
 import { daemonCompletesOnboarding, firstReconnectableDaemonId, skipOnboarding } from '@/lib/onboarding'
 import { daemonCommands } from '@/lib/daemon-commands'
 import { featureFlagEnabled } from '@/lib/feature-flags'
+import { ModelSelect } from '@/components/console/ModelSelect'
 import { RuntimeSelect } from '@/components/console/RuntimeSelect'
 import {
   FALLBACK_RUNTIME_IDS,
   isPoolPlacementKind,
   localDaemons,
-  modelLabel,
-  modelTooltip,
+  modelOptionsFor,
   poolLabel,
   preferredModelFor,
   loginRequiredRuntimeIds
@@ -496,8 +496,17 @@ function useRuntimeModel(daemon?: DaemonRow, initial?: { runtime?: string; model
   const models = daemon?.runtimeModels.find((r) => r.runtime === effectiveRuntime)?.models ?? []
   const [model, setModel] = useState(initial?.model ?? '')
   const selectedModel = models.includes(model) ? model : daemon ? preferredModelFor(daemon, effectiveRuntime) : ''
-  const tooltip = (m: string) => modelTooltip(daemon, effectiveRuntime, m)
-  return { runtimeIds, runtimesNeedingLogin, effectiveRuntime, models, selectedModel, tooltip, setRuntime, setModel }
+  const modelOptions = modelOptionsFor(daemon, effectiveRuntime, models)
+  return {
+    runtimeIds,
+    runtimesNeedingLogin,
+    effectiveRuntime,
+    models,
+    selectedModel,
+    modelOptions,
+    setRuntime,
+    setModel
+  }
 }
 
 function RuntimeModelFields({ rm }: { rm: ReturnType<typeof useRuntimeModel> }) {
@@ -517,31 +526,12 @@ function RuntimeModelFields({ rm }: { rm: ReturnType<typeof useRuntimeModel> }) 
       </div>
       <div className="fld">
         <span className="fldlbl">Model</span>
-        <div
-          className={rm.models.length ? 'inp relative' : 'inp cursor-not-allowed'}
-          title={rm.models.length ? rm.tooltip(rm.selectedModel) : 'This runtime reports no selectable models'}
-        >
-          <span className={`truncate ${rm.models.length ? '' : 'text-(--text-tertiary)'}`}>
-            {rm.models.length ? modelLabel(rm.selectedModel) : '—'}
-          </span>
-          {rm.models.length > 0 && (
-            <>
-              <Icon name="chevron-down" size={15} color="var(--text-tertiary)" className="flex-none" />
-              <select
-                value={rm.selectedModel}
-                onChange={(e) => rm.setModel(e.target.value)}
-                className="absolute inset-0 cursor-pointer opacity-0"
-                aria-label="Model"
-              >
-                {rm.models.map((m) => (
-                  <option key={m} value={m} title={rm.tooltip(m)}>
-                    {modelLabel(m)}
-                  </option>
-                ))}
-              </select>
-            </>
-          )}
-        </div>
+        <ModelSelect
+          value={rm.selectedModel}
+          options={rm.modelOptions}
+          disabledHint="This runtime reports no selectable models"
+          onChange={rm.setModel}
+        />
       </div>
     </div>
   )

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -816,6 +816,24 @@ export function modelTooltip(
   return capability?.description ?? capability?.name
 }
 
+/** Picker rows for a runtime's advertised models: each advertised id plus whatever the
+ *  catalog knows about it. The id stays the row's label — this only carries the name and
+ *  blurb the runtime published beside it (runtime-model-catalog.md §7). */
+export function modelOptionsFor(
+  daemon: Pick<DaemonRow, 'runtimeModels'> | undefined,
+  runtime: string,
+  models: readonly string[]
+): Array<{ value: string; name?: string; description?: string }> {
+  return models.map((value) => {
+    const capability = modelCapability(daemon, runtime, value)
+    return {
+      value,
+      ...(capability?.name ? { name: capability.name } : {}),
+      ...(capability?.description ? { description: capability.description } : {})
+    }
+  })
+}
+
 /** The model the picker preselects when no explicit choice is stored: the
  *  catalog's resolved default when it is in the advertised list, else the FIRST
  *  advertised model. '' only when nothing is advertised at all — there is then no


### PR DESCRIPTION
## Why

`Runs on` and `Runtime` are custom listboxes (`.inp` trigger, scrim, `.fmenu`, `.fopt` rows, roving keyboard focus). `Model` was the one field still on a native `<select>`, so opening it handed the row to the platform: OS popup chrome, a system-blue selected row, raw ids — and no place for the display name and blurb the catalog now carries. The description could only ride a `title` on an `<option>`, which macOS ignores outright and other platforms render clipped and detached from its row.

And for claude those ids are **aliases**: `opus[1m]` names whichever Opus the runtime resolves it to today, which is why nothing in that list carries a version while codex's `gpt-5.6-sol` does. The catalog knows which concrete model it is — the same probe response carries "Opus (1M context)" and "Fable 5.1 · …" — it just had nowhere to appear.

## What

**1. `ModelSelect` — the same listbox as the two fields beside it**, used by the Add, Edit and onboarding forms.

- **The id stays the label, verbatim** — it is what the agent stores and the runtime answers to (runtime-model-catalog.md §7).
- The runtime's own **name is right-aligned meta** (`Opus (1M context)` beside `opus[1m]`), its **blurb is the row's hover text**.
- A model the daemon no longer advertises is **marked in the row** instead of having `" (unavailable)"` appended to its id.
- **No provider mark**, unlike those two: every option here belongs to the same runtime, so the icon would just repeat down the list.
- `modelOptionsFor()` in `data.ts` builds the rows from the catalog, so the three call sites don't each reach into it.

**2. The daemon detail card's model list says what an alias resolves to** — same pairing (`opus[1m]  Opus (1M context)`), blurb on hover. That list was ids alone, which is where "why do none of these have versions?" comes from.

## Test

`pnpm --filter web test` (2358) and `typecheck` green; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
