### PR TITLE
fix(daemon): a confined session can write its own HOME, but never the credential in it

### DIFF
--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -336,7 +336,13 @@ the parent of anything.
 - **Console push and Git reads** resolve the session root as today.
 - **Sandbox grants** are per session and exact: the clone's `.git` writable,
   its `hooks` and `config` read-only, for both the outer sandbox and a runtime's
-  inner one.
+  inner one. The session's `home/` is writable in both layers as well — a
+  runtime's inner policy pins writes to the cwd, and HOME is its _sibling_, so
+  the grant is named there too or no package manager can write the caches below
+  it. `home/.codex` is carved back out of that grant and stays denied: its
+  `auth.json` is a link to the shared host credential the outer layer keeps
+  writable for the ACP parent, and the rest is that parent's own state, written
+  from outside the inner sandbox.
 - **HOME is per session.** `home/` is the runtime's private HOME — `HOME`,
   `XDG_*`, `CODEX_HOME` and the other runtime-state env point there — seeded
   from the host and protected exactly as the agent's `home/` is, and removed

--- a/packages/daemon/src/acp/codex-permission-profiles.ts
+++ b/packages/daemon/src/acp/codex-permission-profiles.ts
@@ -19,6 +19,8 @@ export interface CodexPermissionProfileOptions {
   writableGitMetadataRoots?: readonly string[]
   /** A session's own clones' `.git` (git-workspace-model §11): exact entries, nothing hangs off them. */
   sessionGitMetadataRoots?: readonly string[]
+  /** A confined session's private HOME (§11) — a SIBLING of the cwd, so `:workspace` never reaches it. */
+  sessionHomeRoot?: string
   allowModelToolUnixSockets?: boolean
   disableUnifiedExec?: boolean
 }
@@ -59,7 +61,13 @@ export function codexPermissionProfileConfig(
   const protectedRoots = [...new Set(opts.protectedRoots.map((root) => normalize(root)))]
   const writableGitMetadataRoots = [...new Set((opts.writableGitMetadataRoots ?? []).map((root) => normalize(root)))]
   const sessionGitMetadataRoots = [...new Set((opts.sessionGitMetadataRoots ?? []).map((root) => normalize(root)))]
-  const policyRoots = [...protectedRoots, ...writableGitMetadataRoots, ...sessionGitMetadataRoots]
+  const sessionHomeRoot = opts.sessionHomeRoot === undefined ? undefined : normalize(opts.sessionHomeRoot)
+  const policyRoots = [
+    ...protectedRoots,
+    ...writableGitMetadataRoots,
+    ...sessionGitMetadataRoots,
+    ...(sessionHomeRoot === undefined ? [] : [sessionHomeRoot])
+  ]
   if (policyRoots.length === 0 && !opts.allowModelToolUnixSockets && !opts.disableUnifiedExec) return undefined
   if (policyRoots.some((root) => !isAbsolute(root))) {
     throw new Error('Codex permission roots must be absolute paths')
@@ -86,6 +94,13 @@ export function codexPermissionProfileConfig(
       [join(root, 'hooks'), 'read'],
       [join(root, 'config'), 'read']
     ]),
+    // §11's per-session HOME holds the package caches and runtime state; `.codex` is carved back whole because its `auth.json` LINKS to the shared host credential and the rest is the ACP parent's state, written outside this sandbox.
+    ...(sessionHomeRoot === undefined
+      ? []
+      : ([
+          [sessionHomeRoot, 'write'],
+          [join(sessionHomeRoot, '.codex'), 'deny']
+        ] as Array<[string, string]>)),
     ...protectedRoots.map((root): [string, string] => [root, 'deny'])
   ]
   const agentFilesystem =

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -401,9 +401,10 @@ export function prepareRuntimeLaunch(opts: {
       const privateCodex = join(runtimeHome, '.codex')
       applyCodexPermissionProfile(env, {
         protectedRoots: existsSync(privateCodex) ? [realpathSync(privateCodex)] : [],
+        // A session's clones take the exact per-clone entries and its own HOME (§11); an owner checkout's `.git` takes the worktree ones.
         ...(sessionDir === undefined
           ? { writableGitMetadataRoots: gitMetadataWriteRoots }
-          : { sessionGitMetadataRoots: gitMetadataWriteRoots }),
+          : { sessionGitMetadataRoots: gitMetadataWriteRoots, sessionHomeRoot: existingRealpath(runtimeHome) }),
         allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true
       })
     }
@@ -557,16 +558,18 @@ export function prepareRuntimeLaunch(opts: {
     ...privateCodexStateRoots
   ])
   if (credentialProfile === 'codex') {
-    // Codex's :workspace protects `.git`: re-open what the outer sandbox made writable, hooks/config excepted.
-    const writableGitMetadataRoots = gitMetadataWriteRoots.filter((gitDir) =>
-      boundary.writable.some((root) => inside(root, gitDir))
-    )
+    // Codex's :workspace protects `.git` and pins writes to the cwd: re-open only what the outer sandbox already made writable.
+    const outerWritable = (path: string): boolean => boundary.writable.some((root) => inside(root, path))
+    const writableGitMetadataRoots = gitMetadataWriteRoots.filter(outerWritable)
+    // A confined session's HOME is a SIBLING of the cwd (§11), so `:workspace` leaves it unwritable and no package manager can reach its own cache.
+    const sessionHomeRoot = sessionDir === undefined ? undefined : existingRealpath(runtimeHome)
     applyCodexPermissionProfile(env, {
       protectedRoots: protectedCredentialRoots,
       // A session's clones take the exact per-clone entries; an owner checkout's `.git` takes the worktree ones.
       ...(sessionDir === undefined
         ? { writableGitMetadataRoots }
         : { sessionGitMetadataRoots: writableGitMetadataRoots }),
+      ...(sessionHomeRoot !== undefined && outerWritable(sessionHomeRoot) ? { sessionHomeRoot } : {}),
       allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true,
       disableUnifiedExec: true
     })

--- a/packages/daemon/test/codex-permission-profiles.test.ts
+++ b/packages/daemon/test/codex-permission-profiles.test.ts
@@ -120,6 +120,81 @@ describe.skipIf(process.platform === 'win32')('Codex permission profile launch c
     ).not.toContain('/agent/sessions')
   })
 
+  // §11: the per-session HOME is a SIBLING of the cwd, so `:workspace` never reaches it and pnpm/corepack cannot write their caches.
+  it('opens a confined session HOME for writes and denies its .codex whole', () => {
+    const home = '/agent/sessions/session-1/home'
+    const config = codexPermissionProfileConfig({
+      protectedRoots: [],
+      sessionGitMetadataRoots: ['/agent/sessions/session-1/workspace/.git'],
+      sessionHomeRoot: home
+    })!
+
+    const agent = config.configOverrides.find((value) =>
+      value.startsWith('permissions.agentconnect-protected-workspace.filesystem=')
+    )!
+    expect(agent).toContain(`"${home}" = "write"`)
+    // `auth.json` under it LINKS to the shared host credential, and the rest is the ACP parent's own state.
+    expect(agent).toContain(`"${home}/.codex" = "deny"`)
+    expect(agent).not.toContain(`"${home}/.codex" = "read"`)
+    // The read-only profile grants nothing, and the write never leaks into it.
+    expect(
+      config.configOverrides.find((value) =>
+        value.startsWith('permissions.agentconnect-protected-read-only.filesystem=')
+      )
+    ).toBeUndefined()
+  })
+
+  // The HOME grant is the session tier's alone: nothing appears for a shared-isolation or agent-tier launch.
+  it('adds no HOME entry when no confined session HOME is named', () => {
+    const config = codexPermissionProfileConfig({
+      protectedRoots: ['/agent/home/.codex'],
+      writableGitMetadataRoots: ['/agent/workspace/.git']
+    })!
+
+    const agent = config.configOverrides.find((value) =>
+      value.startsWith('permissions.agentconnect-protected-workspace.filesystem=')
+    )!
+    expect(agent).toBe(
+      'permissions.agentconnect-protected-workspace.filesystem={ "/agent/workspace/.git" = "write", ' +
+        '"/agent/workspace/.git/worktrees/**" = "write", ' +
+        '"/agent/workspace/.git/hooks" = "read", "/agent/workspace/.git/config" = "read", ' +
+        '"/agent/home/.codex" = "deny" }'
+    )
+    expect(agent).not.toContain('= "write" }')
+  })
+
+  // The caller's own `.codex` deny and this one name the same path: one entry, still `deny`.
+  it('keeps the session .codex denied once when the caller already protects it', () => {
+    const home = '/agent/sessions/session-1/home'
+    const config = codexPermissionProfileConfig({
+      protectedRoots: [`${home}/.codex`],
+      sessionHomeRoot: home
+    })!
+
+    const agent = config.configOverrides.find((value) =>
+      value.startsWith('permissions.agentconnect-protected-workspace.filesystem=')
+    )!
+    expect(agent).toBe(
+      `permissions.agentconnect-protected-workspace.filesystem={ "${home}" = "write", "${home}/.codex" = "deny" }`
+    )
+  })
+
+  // A HOME alone is a policy: it must not be silently dropped by the "nothing to say" early return.
+  it('emits the profile for a session HOME with no other policy root', () => {
+    const config = codexPermissionProfileConfig({
+      protectedRoots: [],
+      sessionHomeRoot: '/agent/sessions/session-1/home'
+    })
+
+    expect(config?.configOverrides).toContain('default_permissions="agentconnect-protected-workspace"')
+  })
+
+  it('rejects a non-absolute session HOME', () => {
+    expect(() => codexPermissionProfileConfig({ protectedRoots: [], sessionHomeRoot: 'sessions/s1/home' })).toThrow(
+      'must be absolute'
+    )
+  })
+
   // agent-full-access is deliberately unconfined; the paired deny belongs only where the write was granted.
   it('leaves the full-access profile untouched by the Git metadata grant', () => {
     const config = codexPermissionProfileConfig({

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -551,6 +551,73 @@ describe('prepareRuntimeLaunch', () => {
       expect(table).toContain(`"${join(home, '.codex')}" = "deny"`)
       expect(table).not.toContain(agentHome)
     }
+    // The inner sandbox pins writes to the cwd, and HOME is its SIBLING: without this the package caches §11 puts here are unwritable.
+    expect(agentFilesystem(launch.env)).toContain(`"${home}" = "write"`)
+    // Only the inner restriction is lifted — the outer boundary already granted exactly this.
+    expect(coveredBy(launch.sandbox!.writable, home)).toBe(true)
+  })
+
+  // The shared-login credential lives on the HOST and the session `.codex/auth.json` merely LINKS to it, so opening HOME wholesale would write through the link.
+  it('denies the session .codex while its HOME is writable, and the host credential it links to', () => {
+    const { scopeDir, hostHome, key, sessionDir, cwd } = sessionCloneFixture()
+    const hostCodex = join(hostHome, '.codex')
+    mkdirSync(hostCodex, { recursive: true })
+    writeFileSync(join(hostCodex, 'auth.json'), '{"last_refresh":"2026-01-01T00:00:00Z"}\n')
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      hostKey: key,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      trustedWorkspaceWriteRoots: [sessionDir],
+      trustedPrimaryCheckout: join(scopeDir, 'workspace'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    const home = join(realpathSync(sessionDir), 'home')
+    const table = agentFilesystem(launch.env)
+    expect(table).toContain(`"${home}" = "write"`)
+    expect(table).toContain(`"${join(home, '.codex')}" = "deny"`)
+    // The link target is the ACP parent's own write capability; the model's tools are denied it directly too.
+    expect(table).toContain(`"${realpathSync(join(hostCodex, 'auth.json'))}" = "deny"`)
+    expect(launch.sandbox!.protectedCredentialRoots).toContain(realpathSync(join(hostCodex, 'auth.json')))
+  })
+
+  // The worktree tier's HOME belongs to the AGENT, not one session: opening it would be a cross-session channel, which is what §11 removes.
+  it('adds no inner HOME grant for a session on the worktree tier', () => {
+    const { scopeDir, hostHome } = fixture()
+    const primaryGit = join(scopeDir, 'workspace', '.git')
+    const worktrees = join(scopeDir, 'worktrees')
+    const cwd = join(worktrees, 'session-1')
+    mkdirSync(join(primaryGit, 'worktrees', 'session-1'), { recursive: true })
+    mkdirSync(cwd, { recursive: true })
+    writeFileSync(join(cwd, '.git'), `gitdir: ${join(primaryGit, 'worktrees', 'session-1')}\n`)
+
+    const launch = prepareRuntimeLaunch({
+      runtimeId: 'codex-acp',
+      runtime: { command: 'npx', args: ['codex-acp'], env: [] },
+      scopeDir,
+      cwd,
+      hostKey: sessionHostKey('bot-a', 'slack:C1:s1'),
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap',
+      credentialPlatform: 'linux',
+      trustedWorkspaceWriteRoots: [worktrees],
+      trustedPrimaryCheckout: join(scopeDir, 'workspace'),
+      hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
+    })
+
+    expect(launch.env.HOME).toBe(join(scopeDir, 'home'))
+    const agentHome = realpathSync(join(scopeDir, 'home'))
+    const table = agentFilesystem(launch.env)
+    expect(table).toContain(`"${join(agentHome, '.codex')}" = "deny"`)
+    expect(table).not.toContain(`"${agentHome}" = "write"`)
   })
 
   it('follows the session HOME for the Claude config dir and private state roots', () => {


### PR DESCRIPTION
## The two layers disagreed

A session-isolated Codex runtime gets a private HOME at `<agent dir>/sessions/<leaf>/home` (git-workspace-model §11). Two sandboxes stand between the model and that directory, and they did not say the same thing:

- **Outer (SRT).** Already writable. `sandboxBoundary()` puts the runtime HOME in its writable set unconditionally, and `prepareRuntimeLaunch` passes the session HOME as that runtime HOME for a confined session. The emitted policy's `allowWrite` contains the exact path; a test in `runtime-launch.test.ts` has asserted this since the session tier landed.
- **Inner (Codex's own filesystem policy).** Not writable. The agent profile extends `:workspace`, whose writable root is the **cwd** — `sessions/<leaf>/workspace`. HOME is a **sibling** of the cwd, not below it, and `codexPermissionProfileConfig` composed its table from Git-metadata roots and protected roots only. The session HOME appeared nowhere in it.

The visible effect: a package manager could not write its own store or cache under HOME, so `pnpm` and corepack failed inside a confined session — exactly the thing §11 says the per-session HOME exists to make work ("writable per session by construction and gone with it").

## The change

Name the session HOME in the inner agent profile as `write`, and carve `.codex` back out of it as `deny`. This uses the mechanism already in the file — an inline TOML table where **most-specific match wins**, the same idiom by which an existing `.git` entry reopens the directory while pinning `hooks` and `config` to `read`.

| path | permission | change |
| --- | --- | --- |
| `<session home>` | `write` | **new** |
| `<session home>/.codex` | `deny` | **new** |
| `<clone>/.git` | `write` | unchanged |
| `<clone>/.git/hooks`, `<clone>/.git/config` | `read` | unchanged |
| cwd | write, via the `:workspace` base | unchanged |

## Why the carve-out is the whole directory

Both reasons cross a trust boundary — they are not merely cross-session leakage:

1. **`<session home>/.codex/auth.json` is a symlink to the host's shared credential**, not a copy. `prepareCodexCredentials` creates it that way deliberately so the credential is never duplicated into a per-session HOME. The outer sandbox keeps the link's *target* writable, because the ACP parent must be able to refresh it. So opening HOME wholesale would let a model-authored command write **through the link** to the credential every agent on the machine shares — and the inner policy is the only layer that would still say no.
2. **The rest of `.codex` is the ACP parent's own state** — `session_index.jsonl`, `sessions/`, `shell_snapshots/`, `plugins/`, `skills/`, and the `goals_*` / `memories_*` / `logs_*` / `queue_*` / `state_*` / `thread_history_*` databases. That parent runs **outside** the inner sandbox. A model-authored command that can write them tampers with its own supervisor's state.

**Whole directory, not a narrower set, and `deny` rather than `read`.** The decisive argument is that `deny` on `.codex` is a **no-op on behaviour**: the caller already passes `<session home>/.codex` in `protectedRoots`, which emits the same `deny` in all three profiles today. Writing it explicitly *preserves* the current boundary; choosing `read`, or narrowing to `auth.json` plus the databases, would be a **widening** relative to today and would have to be justified per entry. Nothing was found that needs the model to read anything under `.codex` — the runtime's own `cache/`, `tmp/`, `models_cache.json`, `installation_id`, `version.json` and `.sandbox_migration` are all written by that same out-of-sandbox parent, not by model-authored tools.

The explicit entry is not redundant, though. `tomlInlineTable` dedups by key with last-wins, and the caller's denies are composed *after* these entries. Emitting the write grant and its carve-out together in the same function means no caller can ever obtain the former without the latter, whatever the composition order.

## This does not widen the outer boundary

Verified by reading how the outer policy is composed, not by assumption. `boundary.writable` is `{cwd, runtimeHome, managedMemory, ...trustedWriteRoots}`; `runtimeHome` **is** the session HOME here. The new grant is additionally gated on `boundary.writable.some((root) => inside(root, sessionHomeRoot))`, mirroring the filter the Git-metadata roots already pass through, so the inner grant cannot name anything the outer layer has not already permitted. Nothing in `writeSandboxSettings`, `denyRead`, `allowRead` or `denyWrite` changed.

## Other runtimes

Codex is the only runtime whose inner filesystem policy the daemon composes. Confirmed rather than assumed:

- `sharedCredentialProfile` resolves to `claude`, `codex`, `qoder` or `qoder-cn`, and `applyCodexPermissionProfile` — the single writer of an inner filesystem table — is called only when the profile is `codex`.
- **Claude does reach the same session HOME** (`HOME` and `CLAUDE_CONFIG_DIR` both point below it), but the daemon composes no filesystem policy for it. `claudeProtectedSettings` supplies only the config-dir/profile env and model config; `additionalDirectories` carries workspace repository roots, never HOME. There is no equivalent knob to set, so nothing to change on that side.

## Verified at unit level

- A confined session's inner agent profile grants its HOME `write` and denies `<home>/.codex`, in the profile builder and end-to-end through `prepareRuntimeLaunch`, alongside an assertion that the outer policy already covered the same path.
- The host credential the link points at is itself denied in the inner table.
- A worktree-tier session and an agent-tier host get **no** HOME entry: the agent HOME appears only as its existing `.codex` deny, never as a `write`. The existing byte-identical-policy regressions for a session host with no session directory still hold.
- The Git-metadata entries and their `hooks` / `config` `read` pins emit exactly as before, including the two existing exact-string table assertions.
- A HOME named on its own still produces a profile (it is a policy root), and a relative one is rejected.

**Mutation check**, on `codex-permission-profiles` + `runtime-launch` (58 cases):

| mutation | red |
| --- | --- |
| delete `[join(sessionHomeRoot, '.codex'), 'deny']` | 1 |
| weaken that entry to `'read'` | 1 |
| delete the whole HOME block (revert the feature) | 4 |

The carve-out mutations kill one case each rather than several *because* the deny is a behavioural no-op in every production caller — the caller's `protectedRoots` re-supplies it, and last-wins dedup even makes the caller's `deny` beat a mutated `read`. Only the direct unit test can see the module's own guarantee, which is the point of asserting it there.

`tsc -p tsconfig.typecheck.json --noEmit` clean; `codex-permission-profiles`, `runtime-launch`, `sandbox`, `daemon-session-hosts`, `runtime-credentials`, `runtime-home`, `workspace-session-clone` all green (132 passed, 4 skipped); prettier and eslint clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
