### PR TITLE
fix(daemon): make Node's built-in fetch honour the sandbox proxy

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -382,9 +382,11 @@ the workspace, private HOME, managed memory, SRT temporary storage, and that
 credential path. Outbound
 domains are approved by a provider callback and Unix sockets remain
 compatibility-open during this rollout. Proxy-aware HTTP(S) clients retain web
-egress, but SRT's isolated Linux network namespace means host access to an
-agent-started local server and clients that ignore the proxy environment are not
-yet compatibility guarantees; issue #312 tracks those boundaries. SRT's
+egress, and the provider sets `NODE_USE_ENV_PROXY=1` so Node's built-in `fetch`
+and `http` clients (corepack downloading a pinned package manager, for one) join
+them. SRT's isolated Linux network namespace still means host access to an
+agent-started local server and other clients that ignore the proxy environment
+are not yet compatibility guarantees; issue #312 tracks those boundaries. SRT's
 temporary directory is redirected below the private HOME and its shared
 `/tmp/claude` fallback is hidden.
 

--- a/packages/daemon/src/acp/sandbox-runtime-provider.ts
+++ b/packages/daemon/src/acp/sandbox-runtime-provider.ts
@@ -116,11 +116,9 @@ export async function runSandboxRuntimeProvider(argv: string[], opts: { offline?
     process.env.TMPDIR = privateTmp
     process.env.CLAUDE_CODE_TMPDIR = privateTmp
     process.env.CLAUDE_TMPDIR = privateTmp
-    // Network policy is intentionally not part of this filesystem-sandbox
-    // rollout. SRT requires an allow-only network config, so approve every
-    // domain through its callback. This preserves proxy-aware web egress; SRT's
-    // network namespace still has documented local-port/client compatibility
-    // gaps tracked in issue #312.
+    // Node's fetch/http ignore HTTP(S)_PROXY unless told to (v22.21+/v24+); otherwise corepack has no route out of SRT's netns.
+    process.env.NODE_USE_ENV_PROXY = '1'
+    // Network policy is out of scope for this rollout: approve every domain; local-port/client gaps stay in issue #312.
     await SandboxManager.initialize(config, async () => opts.offline !== true)
 
     const command = argv

--- a/packages/daemon/test/sandbox.test.ts
+++ b/packages/daemon/test/sandbox.test.ts
@@ -349,7 +349,8 @@ describe('Claude credential environment isolation', () => {
       HOME: privateHome,
       TMPDIR: privateTmp,
       CLAUDE_CODE_TMPDIR: privateTmp,
-      CLAUDE_TMPDIR: privateTmp
+      CLAUDE_TMPDIR: privateTmp,
+      NODE_USE_ENV_PROXY: '1'
     }
     mkdirSync(workspace)
     mkdirSync(privateClaudeConfig, { recursive: true })
@@ -408,6 +409,8 @@ describe('Claude credential environment isolation', () => {
       )
       for (const name of names) expect(visible).not.toContain(name)
       for (const value of Object.values(seededCredentialEnvironment)) expect(output).not.toContain(value)
+      // SRT must not strip the switch that makes Node's fetch/http honour its proxy variables.
+      expect(output).toContain('NODE_USE_ENV_PROXY=1')
 
       for (const credentialFile of [identityTokenFile, awsWebIdentityTokenFile, privateClaudeSettings]) {
         const fileRead = await SandboxManager.wrapWithSandboxArgv(


### PR DESCRIPTION
## Why

Inside SRT's Linux sandbox the runtime has no route and no resolver; the only egress is the HTTP/SOCKS proxy that proxy-aware tools adopt from `HTTP(S)_PROXY`. Node's built-in `fetch` and `http`/`https` clients ignore those variables by default, so `corepack` fetching a repository's pinned package manager failed with `EAI_AGAIN` in a confined session, while `curl` and `pnpm` worked.

## What

- `sandbox-runtime-provider.ts` sets `NODE_USE_ENV_PROXY=1` before SRT wraps the command. Node honours it since 22.21 / 24.0 and older releases ignore it, so the env var is safer than `NODE_OPTIONS=--use-env-proxy`, which an older Node would reject.
- The Linux SRT smoke test asserts the switch survives SRT's env handling and reaches the sandboxed process.
- `daemon-detailed-design.md` narrows the documented gap: Node clients now join the proxy-aware set; host-local ports and other proxy-ignoring clients remain open under #312.

## Verification

- Locally (macOS, Node 24.16): with `NODE_USE_ENV_PROXY=1` and `HTTPS_PROXY` pointed at a closed port, both `fetch()` and `corepack pnpm@9.0.0 --version` fail with `ECONNREFUSED` to the proxy address, proving they route through it; without the variable both go direct. corepack bundles no undici of its own and calls the global `fetch`, so the switch covers it.
- `pnpm --filter @agentconnect.md/daemon typecheck`, eslint and prettier on the touched files pass; `test/sandbox.test.ts` passes locally with the Linux-only cases skipped. The new assertion runs in CI's Linux sandbox suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
