### PR TITLE
fix(console): the model menu opens inward, not past the dialog

### DIFF
--- a/packages/web/src/components/console/ModelSelect.test.tsx
+++ b/packages/web/src/components/console/ModelSelect.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ModelSelect } from './ModelSelect'
+
+let root: Root | undefined
+let container: HTMLDivElement | undefined
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+async function render(element: ReactNode) {
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => root?.render(element))
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  container?.remove()
+  root = undefined
+  container = undefined
+})
+
+const OPTIONS = [
+  { value: 'default', name: 'Default (recommended)', description: 'Opus (1M context)' },
+  { value: 'opus[1m]', name: 'Opus (1M context)', description: 'Opus 5 with 1M context' },
+  { value: 'haiku' }
+]
+
+const openMenu = async () => {
+  const trigger = container!.querySelector('button')!
+  await act(async () => trigger.click())
+  return container!.querySelector<HTMLElement>('.fmenu')!
+}
+
+describe('ModelSelect', () => {
+  it('offers every advertised id verbatim, with the runtime name beside it', async () => {
+    await render(<ModelSelect value="default" options={OPTIONS} onChange={vi.fn()} />)
+    const rows = [...(await openMenu()).querySelectorAll('[role="option"]')]
+
+    expect(rows.map((row) => row.textContent)).toEqual([
+      'defaultDefault (recommended)',
+      'opus[1m]Opus (1M context)',
+      'haiku'
+    ])
+    // The blurb is the row's hover text — the id stays the label.
+    expect(rows[1]!.getAttribute('title')).toBe('Opus 5 with 1M context')
+    expect(rows[0]!.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('reports the picked id and closes', async () => {
+    const onChange = vi.fn()
+    await render(<ModelSelect value="default" options={OPTIONS} onChange={onChange} />)
+    const menu = await openMenu()
+    await act(async () => menu.querySelectorAll<HTMLElement>('[role="option"]')[2]!.click())
+
+    expect(onChange).toHaveBeenCalledWith('haiku')
+    expect(container?.querySelector('.fmenu')).toBeNull()
+  })
+
+  it('opens INWARD from the field, and lets a row narrow to the cap', async () => {
+    // Model is the last field of its row: a left-anchored menu wider than the trigger pushed
+    // past the dialog, which widened the form's scroll area and added a horizontal scrollbar.
+    await render(<ModelSelect value="default" options={OPTIONS} onChange={vi.fn()} />)
+    const menu = await openMenu()
+
+    expect(menu.className).toContain('right-0')
+    // `.fmenu` itself sets `left: 0`, so the override has to be explicit.
+    expect(menu.className).toContain('left-auto')
+    expect(menu.className).not.toMatch(/(^|\s)left-0(\s|$)/)
+    // The name is the shrinkable half; a row that cannot shrink forces its own min-content
+    // width on the dialog however the menu is capped.
+    const name = menu.querySelectorAll('[role="option"]')[1]!.children[1]!
+    expect(name.className).toContain('min-w-0')
+    expect(name.className).not.toContain('flex-none')
+  })
+
+  it('is inert with its reason when the runtime advertises no models', async () => {
+    await render(
+      <ModelSelect value="" options={[]} onChange={vi.fn()} disabledHint="This runtime reports no selectable models" />
+    )
+    const trigger = container!.querySelector('button')!
+
+    expect(trigger.disabled).toBe(true)
+    expect(trigger.getAttribute('title')).toBe('This runtime reports no selectable models')
+    expect(trigger.textContent).toContain('—')
+    await act(async () => trigger.click())
+    expect(container?.querySelector('.fmenu')).toBeNull()
+  })
+})

--- a/packages/web/src/components/console/ModelSelect.tsx
+++ b/packages/web/src/components/console/ModelSelect.tsx
@@ -7,7 +7,9 @@ export interface ModelSelectOption {
    *  the row's label verbatim (runtime-model-catalog.md §7). */
   value: string
   /** The runtime's own display name, when it differs from the id. Right-aligned meta, never
-   *  the label: "Opus (1M context)" tells you what `opus[1m]` is without replacing it. */
+   *  the label: "Opus (1M context)" tells you what `opus[1m]` is without replacing it. It is
+   *  the part that gives way when the row is tight — a shrinkable name is what lets the menu
+   *  narrow to its cap instead of forcing its own min-content width on the dialog. */
   name?: string
   /** The runtime's model blurb — the row's hover text. */
   description?: string
@@ -143,9 +145,12 @@ export function ModelSelect({
             tabIndex={-1}
             aria-label={ariaLabel}
             aria-activedescendant={activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined}
-            // Sized to the widest row, trigger width as the floor: a model id and its display
-            // name are longer than this 1/3 column, and neither reads well truncated.
-            className="fmenu left-0 z-40 max-w-[420px] min-w-full rounded-lg p-2 shadow-(--shadow-xl) outline-none"
+            // Anchored to the field's RIGHT edge (`.fmenu` itself sets `left: 0`, hence the
+            // explicit `left-auto`). Model is the last field of its row, so a menu wider than
+            // the trigger has to grow INWARD: left-anchored it pushed past the dialog, widening
+            // the form's scroll area and putting a horizontal scrollbar under it. Width is the
+            // widest row, floored at the trigger and capped so it cannot outgrow the viewport.
+            className="fmenu right-0 left-auto z-40 w-max max-w-[min(420px,calc(100vw-32px))] min-w-full rounded-lg p-2 shadow-(--shadow-xl) outline-none"
             onKeyDown={onListKeyDown}
           >
             {options.map((option, index) => {
@@ -170,7 +175,7 @@ export function ModelSelect({
                   onMouseEnter={() => setActiveIndex(index)}
                   onClick={() => pick(option)}
                 >
-                  <span className="flex-1 truncate">{modelLabel(option.value)}</span>
+                  <span className="min-w-0 flex-1 truncate">{modelLabel(option.value)}</span>
                   {option.unavailable ? (
                     <span className="flex-none font-sans text-[11px] font-medium leading-normal text-(--status-paused)">
                       unavailable
@@ -178,7 +183,7 @@ export function ModelSelect({
                   ) : (
                     option.name && (
                       <span
-                        className={`flex-none truncate font-sans text-[11.5px] font-normal leading-normal ${
+                        className={`min-w-0 truncate font-sans text-[11.5px] font-normal leading-normal ${
                           isSelected ? 'text-(--brand-soft-text) opacity-80' : 'text-(--text-tertiary)'
                         }`}
                       >


### PR DESCRIPTION
## Why

Reported from the Edit-agent dialog: opening the Model picker **widens the dialog and adds a horizontal scrollbar**, and the menu is clipped at the dialog's edge.

`Model` is the last field of its row, and the menu was anchored to the field's **left** edge while sized to its widest row — so anything wider than that 1/3 column overflowed to the right, past the dialog. An absolutely-positioned element still counts toward its scroll container's width, hence the scrollbar under the form.

Two things were wrong:

1. **Anchor.** Left-anchored in the rightmost column, the only direction it can grow is out of the dialog.
2. **The row could not shrink to any cap.** The name span was `flex-none`, so the row's min-content width was `id + full name + check` and it forced that on whatever contained it, whatever `max-w` the menu carried.

## What

- Anchored to the field's right edge — `right-0 left-auto`, since `.fmenu` itself sets `left: 0` — so the width it wants grows *inward* over the two fields beside it. Capped against the viewport (`max-w-[min(420px,calc(100vw-32px))]`), the same idiom `WorkspaceScopePicker`'s menu already uses.
- The name is shrinkable (`min-w-0`, no `flex-none`): it is the half that gives way when the row is tight, and the id — the identity — stays whole.

## Test

New `ModelSelect.test.tsx`: the rows carry each id verbatim with its name beside it and its blurb as hover text, picking reports the id and closes, the empty state is inert with its reason, and the anchor + shrinkable name are pinned so this cannot regress silently.

`typecheck`, eslint, web suite (2340) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)