### PR TITLE
fix(daemon): keep the confined session tier inside the sandbox git inventory

### DIFF
--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -381,6 +381,23 @@ the volume, which is the same fail-closed gate that empties the primary checkout
 and the first point after the edit at which anything is authoritative. HOME is
 per pod by construction.
 
+**Every Git of this tier runs inside the pod's closed inventory.** On a pool
+member the daemon does not spawn Git at all: each invocation crosses the shim's
+`exec` channel and is judged there against a deliberately small subcommand list
+(`packages/daemon/src/shim/exec-handler.ts`), because the process that spawns
+Git is the only one whose check is a control. So an operation this tier needs is
+either expressed out of subcommands already admitted or it is a session that
+fails on the pool and works self-hosted — the failure mode is silent everywhere
+except the pool, since self-hosted Git never meets the list. Two operations are
+phrased for that reason rather than for Git's convenience: the session branch is
+made with `branch --no-track` + `symbolic-ref HEAD` + `reset --hard` instead of
+`checkout -b` (same three steps, and the `reset` is the one that materializes,
+so it keeps the lazy fetch a blobless clone needs), and retirement's
+review-snapshot probe reads the head ref with `show-ref --verify` instead of
+listing the ref root with `for-each-ref`. Widening the inventory is the other
+way to close such a gap, and it is the one that costs something permanent:
+`checkout` was left out.
+
 ### The tier a session is born in (decided 2026-09-03)
 
 A tier is a property of **one session**, decided when it is created and kept for its whole

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -201,6 +201,8 @@ const CONVERSION_FILE = 'workspace-conversion.json'
 /** Word-pair branch names to try before falling back to a random suffix. */
 const SESSION_BRANCH_DRAWS = 5
 const GIT_OBJECT_ID = /^[0-9a-f]{40,64}$/i
+/** The ref every review fetch writes and verifies, so probing this ONE answers "is this a daemon-owned review snapshot" without listing the ref root. */
+const reviewHeadRefFor = (id: string): string => `refs/agentconnect/reviews/${id}/head`
 
 // The per-daemon execution plane every workspace operation resolves through: where an agent's git
 // runs, how a path this process cannot see gets emptied, whether workspaces live in sandboxes at
@@ -1370,10 +1372,9 @@ export class WorkspaceManager {
         const git = this.runnerFor(agent.id, clone.path).withEnv(workspaceGitLocalEnv())
         // Fetched review refs mark the clone as a daemon-owned review snapshot, reset on every delivery.
         let snapshot: boolean | undefined
+        // `show-ref` on the head ref rather than `for-each-ref` over the root: the sandbox admits the one and not the other, and a review that fetched anything fetched this ref.
         const isReviewSnapshot = async () =>
-          (snapshot ??=
-            (await git.raw(['for-each-ref', '--count=1', `refs/agentconnect/reviews/${id}`]).catch(() => '')).trim() !==
-            '')
+          (snapshot ??= (await git.raw(['show-ref', '--verify', reviewHeadRefFor(id)]).catch(() => '')).trim() !== '')
         if ((await git.raw(['status', '--porcelain'])).trim() !== '' && !(await isReviewSnapshot())) {
           return { outcome: 'retained', reason: 'dirty' }
         }
@@ -1547,11 +1548,12 @@ export class WorkspaceManager {
       // protects nothing. Probed lazily — only when a protection would otherwise keep the worktree —
       // and at most once; a probe failure conservatively reads as "not a snapshot".
       let snapshot: boolean | undefined
+      // `show-ref` on the head ref rather than `for-each-ref` over the root, for the reason {@link removeSessionClones} gives: the sandbox admits the one and not the other.
       const isReviewSnapshot = async () =>
         (snapshot ??=
           (
             await rootGit()
-              .raw(['for-each-ref', '--count=1', `refs/agentconnect/reviews/${id}`])
+              .raw(['show-ref', '--verify', reviewHeadRefFor(id)])
               .catch(() => '')
           ).trim() !== '')
       if ((await worktreeGit.raw(['status', '--porcelain'])).trim() !== '' && !(await isReviewSnapshot())) {
@@ -1628,7 +1630,7 @@ export class WorkspaceManager {
     }
     const refRoot = `refs/agentconnect/reviews/${worktreeId}`
     const baseRef = `${refRoot}/base`
-    const headRef = `${refRoot}/head`
+    const headRef = reviewHeadRefFor(worktreeId)
     const mergeRef = `${refRoot}/merge`
     await assertSafeWorkspaceGitConfig(this.runnerFor(agentId, root.path))
     if (root.githubApp) await preWarmGitCred(agentId, 'pull')
@@ -2052,7 +2054,7 @@ export class WorkspaceManager {
     return { ...base, GIT_NO_LAZY_FETCH: '0' }
   }
 
-  /** Check the clone out on its own generated branch at `target` — the draw {@link addRootSessionWorktree} makes, `--no-track` for the same reason. */
+  /** Put the clone on its own generated branch at `target` — the draw {@link addRootSessionWorktree} makes, `--no-track` for the same reason. */
   private async checkoutSessionBranch(
     agentId: string,
     root: WorkspaceRoot,
@@ -2064,10 +2066,12 @@ export class WorkspaceManager {
       this.runnerFor(agentId, cwd).withEnv(workspaceGitLocalEnv()),
       initiatedBy
     )
-    // The checkout materializes the tree, so it may lazily fetch: the clone env, not the local one.
-    await this.runnerFor(agentId, cwd)
-      .withEnv(this.sessionCloneGitEnv(agentId, root))
-      .raw(['checkout', '--no-track', '-b', branch, target])
+    // Three admitted subcommands rather than `checkout -b`, which the sandbox refuses by design: create the branch, point HEAD at it, then materialize the tree HEAD now names.
+    const git = this.runnerFor(agentId, cwd).withEnv(this.sessionCloneGitEnv(agentId, root))
+    await git.raw(['branch', '--no-track', branch, target])
+    await git.raw(['symbolic-ref', 'HEAD', `refs/heads/${branch}`])
+    // The materialization is what may lazily fetch, so it runs under the clone env like the review reset below.
+    await git.raw(['reset', '--hard'])
   }
 
   clusterWorkspaceCwd(agent: Agent, runtimeRoot: string | undefined, request?: ClusterSessionScope): string {

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -137,11 +137,12 @@ function recordingRunner(cwd: string | undefined, env: Record<string, string> = 
       return ''
     }
     if (args[0] === 'reset' && args[1] === '--hard') {
-      headRev = resolve(args[2]!)
+      // Bare `reset --hard` materializes the tree at the HEAD `symbolic-ref` has already moved.
+      if (args[2] !== undefined) headRev = resolve(args[2])
       return ''
     }
-    // A session clone's branch checkout moves HEAD onto its start point, as `worktree add` does.
-    if (args[0] === 'checkout' && args.includes('-b')) {
+    // A session clone's branch is drawn at its start point and HEAD is pointed at it, moving HEAD as `worktree add` does.
+    if (args[0] === 'branch' && args[1] === '--no-track') {
       headRev = resolve(args.at(-1)!)
       return ''
     }
@@ -829,11 +830,15 @@ describe('per-session clones on the session pod (git-workspace-model §11)', () 
     expect(clone).toMatchObject({ cwd: sessionDirOf('sess-1') })
     expect(clone!.args[2]).toMatch(new RegExp(`^${cwd}\\.clone-`))
     expect(clone!.args).toEqual(expect.arrayContaining(['--filter=blob:none', '--branch', 'main', '--single-branch']))
-    // Checked out on its own branch at the remote's tip, in the clone; the checkout is the parent of nothing.
-    const checkout = calls.find((call) => call.args[0] === 'checkout')
-    expect(checkout).toMatchObject({ cwd })
-    expect(checkout!.args.slice(0, 3)).toEqual(['checkout', '--no-track', '-b'])
-    expect(checkout!.args.at(-1)).toBe('refs/remotes/origin/main')
+    // Put on its own branch at the remote's tip, in the clone, out of subcommands the sandbox admits; the checkout is the parent of nothing.
+    const draw = calls.find((call) => call.args[0] === 'branch')
+    expect(draw).toMatchObject({ cwd })
+    expect(draw!.args.slice(0, 2)).toEqual(['branch', '--no-track'])
+    expect(draw!.args.at(-1)).toBe('refs/remotes/origin/main')
+    expect(calls.some((call) => call.cwd === cwd && call.args[0] === 'symbolic-ref' && call.args[1] === 'HEAD')).toBe(
+      true
+    )
+    expect(calls.some((call) => call.cwd === cwd && call.args[0] === 'reset' && call.args[1] === '--hard')).toBe(true)
     expect(calls.some((call) => call.args[0] === 'worktree')).toBe(false)
     expect(await pod.stat(WORKTREES)).toBe('missing')
     // Nothing about it names the daemon's own bookkeeping directory, and nothing landed on this disk.
@@ -881,8 +886,8 @@ describe('per-session clones on the session pod (git-workspace-model §11)', () 
     const fetch = calls.find((call) => call.args[0] === 'fetch')
     expect(fetch).toMatchObject({ cwd })
     expect(fetch!.args).toContain(`+refs/pull/7/head:refs/agentconnect/reviews/${id}/head`)
-    // The exact head is the start point, and HEAD is re-verified against it after the checkout.
-    expect(calls.find((call) => call.args[0] === 'checkout')!.args.at(-1)).toBe(head)
+    // The exact head is the start point, and HEAD is re-verified against it once the branch is drawn there.
+    expect(calls.find((call) => call.args[0] === 'branch')!.args.at(-1)).toBe(head)
   })
 
   it('refuses a review clone whose head ref is not the verified revision', async () => {
@@ -1112,7 +1117,7 @@ describe('secondary roots on the pod volume', () => {
     const fetch = calls.find((call) => call.args[0] === 'fetch')
     expect(fetch).toMatchObject({ cwd })
     expect(fetch!.args).toContain(`+refs/pull/9/head:refs/agentconnect/reviews/${id}/head`)
-    expect(calls.find((call) => call.args[0] === 'checkout' && call.cwd === cwd)!.args.at(-1)).toBe(head)
+    expect(calls.find((call) => call.args[0] === 'branch' && call.cwd === cwd)!.args.at(-1)).toBe(head)
     // The primary rides along at its default branch, and the attestation holds the cwd across a
     // restart — a later hand-out that carries no review resolves the same working directory.
     expect(await workspaces.additionalWorkspaceDirectories(agent, cwd, request)).toEqual([

--- a/packages/daemon/test/shim-exec-handler.test.ts
+++ b/packages/daemon/test/shim-exec-handler.test.ts
@@ -71,7 +71,7 @@ describe('sandbox exec handler', () => {
 
   it('refuses a subcommand outside the declared inventory', async () => {
     const root = repository()
-    for (const subcommand of ['push', 'submodule', 'daemon', 'gc', 'apply']) {
+    for (const subcommand of ['push', 'submodule', 'daemon', 'gc', 'apply', 'checkout', 'for-each-ref']) {
       await expect(handler(root)('exec', { tool: 'git', args: [subcommand] })).rejects.toBeInstanceOf(ExecRefusedError)
     }
     // And the inventory is the daemon's declared list, not a superset invented here.
@@ -110,6 +110,33 @@ describe('sandbox exec handler', () => {
     for (const subcommand of ['branch', 'ls-remote', 'show-ref', 'symbolic-ref']) {
       expect(ALLOWED_GIT_SUBCOMMANDS.has(subcommand)).toBe(true)
     }
+  })
+
+  it('serves the branch-and-materialize sequence the confined session tier runs instead of a checkout', async () => {
+    // The clone tier (git-workspace-model.md §11) puts a session clone on its own generated branch.
+    // `checkout` is deliberately outside the inventory, so the daemon expresses that as three
+    // subcommands that are inside it — and here is where that has to hold: a refusal on this side is
+    // a session that fails on a pool member and works self-hosted, which is how it reached the field.
+    const root = repository()
+    for (const args of [
+      ['branch', '--no-track', 'dev/ada-lovelace/quiet-harbor', 'refs/heads/main'],
+      ['symbolic-ref', 'HEAD', 'refs/heads/dev/ada-lovelace/quiet-harbor'],
+      ['reset', '--hard']
+    ]) {
+      const result = (await handler(root)('exec', { tool: 'git', args })) as GitExecResult
+      expect(result.code).toBe(0)
+    }
+    const head = execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], { cwd: root, encoding: 'utf8' })
+    expect(head.trim()).toBe('dev/ada-lovelace/quiet-harbor')
+    // The tree is materialized, not merely pointed at, which is the half `checkout` was doing.
+    expect(readFileSync(join(root, 'file.txt'), 'utf8')).toBe('x\n')
+    expect(ALLOWED_GIT_SUBCOMMANDS.has('checkout')).toBe(false)
+    // And the snapshot probe retirement runs in that clone, which `for-each-ref` used to answer.
+    const probe = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['show-ref', '--verify', 'refs/agentconnect/reviews/session-1/head']
+    })) as GitExecResult
+    expect(probe.code).not.toBe(0)
   })
 
   it('still refuses every execution option on the newly permitted subcommands', async () => {

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -24,6 +24,9 @@ import {
   workspaceGitLocalEnv
 } from '../src/workspace/git-injection.js'
 import { LocalGitRunner, type GitRunner, type GitLogEntry, type GitPullSummary } from '../src/workspace/git-runner.js'
+import { ALLOWED_GIT_SUBCOMMANDS, createExecHandler } from '../src/shim/exec-handler.js'
+import { ShimGitRunner, type GitExecPayload } from '../src/shim/git-exec.js'
+import type { ShimRequester } from '../src/shim/channels.js'
 import { sessionHomeIn } from '../src/workspace/session-layout.js'
 import { WorkspaceManager, type PrepareSessionWorkspaceRequest } from '../src/workspace/workspace-manager.js'
 
@@ -54,8 +57,9 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
 
+/** Canonical, because the sandbox handler decides containment on canonical paths and macOS hands out a `/var` alias for `/private/var`. */
 function tempRoot(prefix: string): string {
-  const root = mkdtempSync(join(tmpdir(), prefix))
+  const root = realpathSync(mkdtempSync(join(tmpdir(), prefix)))
   roots.push(root)
   return root
 }
@@ -185,6 +189,35 @@ class SeamRunner implements GitRunner {
   }
 }
 
+/** The one substitution the wire makes: a fixture repository's authorized URL becomes its `file://` bare, and `file:` joins the protocol allowlist. */
+function wireEnv(env: Record<string, string>): Record<string, string> {
+  const next: Record<string, string> = { ...env, GIT_ALLOW_PROTOCOL: 'file:https:ssh' }
+  for (let index = 0; index < Number(next.GIT_CONFIG_COUNT ?? 0); index += 1) {
+    if (/^remote\..*\.url$/i.test(next[`GIT_CONFIG_KEY_${index}`] ?? '')) {
+      next[`GIT_CONFIG_VALUE_${index}`] = substitute(next[`GIT_CONFIG_VALUE_${index}`] ?? '')
+    }
+  }
+  return next
+}
+
+/** The pool's own runner against the pod's own handler, so the daemon's argv crosses the real exec channel and meets the real inventory — the enforcement a permissive stand-in hides, which is how `checkout` reached the field. */
+function shimRunner(workspaceRoot: string, cwd: string | undefined, abort: AbortSignal | undefined): GitRunner {
+  const handle = createExecHandler({ workspaceRoot, log: { info: () => {}, warn: () => {} } })
+  const requester: ShimRequester = {
+    request: async (capability, payload, options) => {
+      const sent = payload as GitExecPayload
+      gitRuns.push({ args: sent.args, env: sent.env ?? {} })
+      const wire: GitExecPayload = {
+        ...sent,
+        args: sent.args.map(substitute),
+        ...(sent.env ? { env: wireEnv(sent.env) } : {})
+      }
+      return await handle(capability, wire, options?.abort)
+    }
+  }
+  return new ShimGitRunner(requester, cwd, undefined, abort)
+}
+
 /** Serve the primary (when there is one) and every secondary root from fresh bare repositories. */
 function serveAll(agent: Agent, branches: Record<string, string> = {}): Record<string, ReturnType<typeof bareRepo>> {
   workspaces.setGitRunnerResolver((_agentId, cwd, abort) => new SeamRunner(cwd, abort))
@@ -197,6 +230,14 @@ function serveAll(agent: Agent, branches: Record<string, string> = {}): Record<s
     served[root.repoFullName] = bareRepo(branches[root.repoFullName] ?? 'main')
     serve(root.cloneUrl, served[root.repoFullName]!.url)
   }
+  return served
+}
+
+/** The same fixtures on the pool's shape: every daemon-run Git for this agent goes through the sandbox handler rooted at its directory. */
+function serveAllThroughShim(agent: Agent): Record<string, ReturnType<typeof bareRepo>> {
+  const served = serveAll(agent)
+  const root = workspaces.agentRootFor(agent)
+  workspaces.setGitRunnerResolver((_agentId, cwd, abort) => shimRunner(root, cwd, abort))
   return served
 }
 
@@ -669,5 +710,52 @@ describe('a confined session across workspace changes', () => {
     })
     expect(git(first, ['remote', 'get-url', 'origin'])).toBe('https://other-host.example/acme/elsewhere.git')
     expect(git(second, ['remote', 'get-url', 'origin'])).toBe(PRIMARY_URL)
+  })
+})
+
+// On a pool member every workspace Git call is routed through the shim into the session's pod, where a
+// closed inventory (shim/exec-handler.ts) decides what may run. Self-hosted runs git locally and never
+// meets it, so a subcommand the daemon issues and the sandbox refuses is a regression only the pool
+// sees — which is how `checkout -b` reached a live pool as "git checkout is not in the permitted
+// inventory" once this tier replaced the worktree one. These run the REAL handler, not a stand-in.
+describe('the confined tier issues only Git the sandbox admits (k8s-daemon-pool.md §4)', () => {
+  it('draws the session branch and materializes its tree across the exec channel', async () => {
+    const agent = agentFixture()
+    const { primary } = serveAllThroughShim(agent)
+
+    const cwd = await workspaces.prepareSessionWorkspace(agent, confined())
+
+    expect(cwd).toBe(realpathSync(join(leafOf(agent), 'workspace')))
+    expect(git(cwd, ['symbolic-ref', '--short', 'HEAD'])).toMatch(/^dev\/ada-lovelace\/[a-z]+-[a-z]+$/)
+    expect(git(cwd, ['rev-parse', 'HEAD'])).toBe(git(primary!.seed, ['rev-parse', 'origin/main']))
+    // Materialized, not merely pointed at: the tree is the half `checkout` was doing.
+    expect(readFileSync(join(cwd, 'README.md'), 'utf8')).toBe('seed\n')
+    expect(git(cwd, ['status', '--porcelain'])).toBe('')
+    // `--no-track` survives the replacement, or the console's push button becomes a remote-branch creator.
+    expect(() => git(cwd, ['rev-parse', '--abbrev-ref', '@{upstream}'])).toThrow()
+    // So does the lazy fetch the materialization needs, which a blobless clone dies without.
+    const materialized = gitRuns.filter((run) => run.args[0] === 'reset' && run.args[1] === '--hard')
+    expect(materialized.length).toBeGreaterThan(0)
+    for (const run of materialized) expect(run.env.GIT_NO_LAZY_FETCH).toBe('0')
+  })
+
+  it('issues nothing outside the inventory across a whole confined life — prepare, review, retire', async () => {
+    const agent = agentFixture({ additionalRepos: [{ repoFullName: 'acme/infra', repoId: '42' }] })
+    const { primary } = serveAllThroughShim(agent)
+    const pr = publishPullRequest(primary!.seed, 'pr\n')
+
+    await workspaces.prepareSessionWorkspace(agent, confined())
+    const cwd = await workspaces.prepareSessionWorkspace(
+      agent,
+      confined({ review: { pullNumber: 7, baseSha: pr.base, headSha: pr.head } })
+    )
+    writeFileSync(join(cwd, 'wip.md'), 'disposable\n')
+    // A dirty review snapshot, so retirement has to run the probe that used to ask `for-each-ref`.
+    expect(await workspaces.removeSessionWorktree(agent, KEY)).toEqual({ outcome: 'removed' })
+
+    const issued = [...new Set(gitRuns.map((run) => run.args[0]!))].sort()
+    // The assertion is only worth as much as the run behind it, so pin that the interesting ones ran.
+    expect(issued).toEqual(expect.arrayContaining(['branch', 'clone', 'fetch', 'reset', 'show-ref', 'symbolic-ref']))
+    expect(issued.filter((subcommand) => !ALLOWED_GIT_SUBCOMMANDS.has(subcommand))).toEqual([])
   })
 })

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -579,7 +579,7 @@ describe('workspaces.removeSessionWorktree(#485 retention GC)', () => {
     const { agent, id } = fixture()
     rawMock.mockImplementation(async (args: string[]) => {
       if (args[0] === 'status') return ' M src/app.ts\n?? notes.md\n'
-      if (args[0] === 'for-each-ref') return ''
+      if (args[0] === 'show-ref') return ''
       return '0\n'
     })
 
@@ -587,14 +587,14 @@ describe('workspaces.removeSessionWorktree(#485 retention GC)', () => {
     expect(gitCalls().some((args) => args[0] === 'worktree')).toBe(false)
     // The exemption probe DID run — dirt on an ordinary worktree is kept only after
     // proving the worktree is not a review snapshot.
-    expect(gitCalls()).toContainEqual(['for-each-ref', '--count=1', `refs/agentconnect/reviews/${id}`])
+    expect(gitCalls()).toContainEqual(['show-ref', '--verify', `refs/agentconnect/reviews/${id}/head`])
   })
 
   it('removes a DIRTY review-snapshot worktree — its refs mark it daemon-owned and reset on delivery', async () => {
     const { agent, cwd, id } = fixture()
     rawMock.mockImplementation(async (args: string[]) => {
       if (args[0] === 'status') return '?? scratch/analysis.md\n M src/app.ts\n'
-      if (args[0] === 'for-each-ref') return `${'c'.repeat(40)} commit\trefs/agentconnect/reviews/${id}/head\n`
+      if (args[0] === 'show-ref') return `${'c'.repeat(40)} refs/agentconnect/reviews/${id}/head\n`
       if (args[0] === 'rev-list') return '0\n'
       return ''
     })
@@ -613,7 +613,7 @@ describe('workspaces.removeSessionWorktree(#485 retention GC)', () => {
     const { agent, cwd, id } = fixture()
     rawMock.mockImplementation(async (args: string[]) => {
       if (args[0] === 'rev-list') return '3\n'
-      if (args[0] === 'for-each-ref') return `${'c'.repeat(40)} commit\trefs/agentconnect/reviews/${id}/head\n`
+      if (args[0] === 'show-ref') return `${'c'.repeat(40)} refs/agentconnect/reviews/${id}/head\n`
       if (args[0] === 'symbolic-ref') return 'dev/yulong/brave-otter\n'
       return ''
     })
@@ -629,7 +629,7 @@ describe('workspaces.removeSessionWorktree(#485 retention GC)', () => {
     rawMock.mockImplementation(async (args: string[]) => (args[0] === 'rev-list' ? '0\n' : ''))
 
     expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({ outcome: 'removed' })
-    expect(gitCalls().some((args) => args[0] === 'for-each-ref')).toBe(false)
+    expect(gitCalls().some((args) => args[0] === 'show-ref')).toBe(false)
     // And absent the probe, the removal is not forced.
     expect(gitCalls().some((args) => args[0] === 'worktree' && args[1] === 'remove' && args[2] === '--force')).toBe(
       false
@@ -638,7 +638,7 @@ describe('workspaces.removeSessionWorktree(#485 retention GC)', () => {
 
   it('retains a worktree whose HEAD has commits unreachable from every remote ref', async () => {
     const { agent } = fixture()
-    // '' for for-each-ref: no review refs, so the snapshot exemption must not apply.
+    // '' for show-ref: no review head ref, so the snapshot exemption must not apply.
     rawMock.mockImplementation(async (args: string[]) => (args[0] === 'rev-list' ? '2\n' : ''))
 
     expect(await workspaces.removeSessionWorktree(agent, 'session-a')).toEqual({


### PR DESCRIPTION
## The regression

A sandboxed agent with session isolation could not start a session on a managed pool. The console showed the allocation, then the refusal:

```
⏳ Allocating a sandbox pod…
⚠️ git checkout is not in the permitted inventory
```

On a pool member the daemon does not spawn Git at all. Every workspace invocation crosses the shim's `exec` channel and is judged there against `ALLOWED_GIT_SUBCOMMANDS` (`packages/daemon/src/shim/exec-handler.ts`), because the process that spawns Git is the only one whose check is a control — a declaration on the sending side is not one. `checkout` is not on that list, and `WorkspaceManager.checkoutSessionBranch` ran `checkout --no-track -b <branch> <target>`.

The trigger was #1766, which moved the pool from the worktree tier to the per-session clone tier. The worktree tier created its branch with `worktree add -b`, and `worktree` **is** admitted; the clone tier reaches for `checkout -b`, which never had to be permitted before.

**Why every verification missed it.** The git runner resolver is wired only for the in-cluster plane (`daemon.ts` → `k8sPlane.gitRunnerFor`). A self-hosted daemon — sandbox on or off — runs Git locally through `LocalGitRunner` and never meets the inventory, so the confined tier is fully exercised there and passes. The pool is the only place the list is consulted, which makes this class of bug silent everywhere it is easy to test.

## What I chose, and why

**Express the operation out of subcommands already admitted; do not widen the list.**

`checkoutSessionBranch` now runs three invocations instead of one:

```
branch --no-track <branch> <target>     # create the branch, no upstream
symbolic-ref HEAD refs/heads/<branch>   # point HEAD at it
reset --hard                            # materialize index and working tree at that HEAD
```

All three are in the inventory today. Both properties the previous call depended on are preserved: `--no-track` is passed explicitly to `branch` (a session branch that tracked `origin/<base>` would turn the console's push button into a remote-branch creator), and all three run under `sessionCloneGitEnv`, so the materializing step keeps `GIT_NO_LAZY_FETCH=0` and a blobless partial clone may still fetch from its promisor remote. `reset --hard` is also already how the sibling review-resume branch, three lines below, materializes the same clone — so this makes the two paths consistent rather than inventing a mechanism.

**Why the rejected option is worse.** Admitting `checkout` would be a permanent widening bought to avoid a three-line rewrite. That file's header is explicit that the list is small on purpose: anything reaching arbitrary Git reaches arbitrary execution through `-c`, hooks and `--upload-pack`, so each member is a deliberate admission and the reviewer of the next one inherits whatever this one lets in. `checkout` is not a narrow verb — it writes working-tree files, takes pathspecs and `--`, and has forms (`--orphan`, `-f`, `<tree-ish> -- .`) that have nothing to do with the one shape the daemon issues. Constraining it to that shape would mean a new `REFUSED_SUBCOMMAND_ARGUMENT` entry enumerating what `checkout` may *not* carry, which is the same allowlist problem one level down and goes stale the way the file already warns operand allowlists do. Meanwhile the operation is not inherently a checkout: creating a branch at a target and pointing HEAD there is exactly `branch` plus `symbolic-ref`, and materializing the tree is exactly `reset --hard`. The smaller trusted surface wins, and nothing is lost.

## The second gap, found by enumerating rather than waiting

Retirement of a confined session has the same shape of hole. `removeSessionClones` probed for a daemon-owned review snapshot with `for-each-ref --count=1 refs/agentconnect/reviews/<id>`, and `for-each-ref` is not admitted either. Worse, that probe carries its own `.catch(() => '')`, so on a pool member the refusal was swallowed and every review clone read as "not a snapshot": a dirty or unique-commit review clone was **retained forever** instead of removed, and its session pod's claim and volume went with it. Silent, unlike the `checkout` case.

It now reads the head ref with `show-ref --verify` (admitted). That is faithful: a review fetch always writes and verifies `<refRoot>/head` before anything else is stored, so its presence is what `for-each-ref` over the root was answering. `--quiet` is deliberately not used — its silent exit 1 is resolved as success by the local runner, the trap already documented on `drawSessionBranch`. The identical probe in the legacy worktree path is changed with it, since it is broken in the same way on a pool member that still holds one.

## Clone-tier Git versus the inventory

Every subcommand the confined session path issues, traced through `prepareClusterConfinedSession` → `prepareRootSessionClone` → `checkoutSessionBranch` / `fetchReviewRevisionIn`, and through `removeSessionWorktree` → `removeSessionClones`:

| Subcommand | Where | In the inventory |
| --- | --- | --- |
| `clone` | `cloneSessionRootAt` (blobless, `--single-branch`) | yes |
| `config` | `assertSafeWorkspaceGitConfig`, `writeRepoHelperConfig` | yes |
| `check-ref-format` | credential/branch validation | yes |
| `remote` | origin convergence on resume | yes |
| `ls-remote` | secondary root default branch | yes |
| `fetch` | review base/head/merge into the clone | yes |
| `update-ref` | drops a stale merge ref | yes |
| `rev-parse` | HEAD and exact-revision verification | yes |
| `rev-list` | merge parents, retirement's unique-commit rule | yes |
| `show-ref` | session-branch draw, **and now the snapshot probe** | yes |
| `symbolic-ref` | **now** points HEAD at the session branch | yes |
| `branch` | **now** creates the session branch | yes |
| `reset` | **now** materializes; review re-delivery already did | yes |
| `clean` | review re-delivery | yes |
| `status` | retirement's dirty rule | yes |
| `log`, `diff`, `pull` | console reads, primary refresh | yes |
| ~~`checkout`~~ | was `checkoutSessionBranch` | **no — replaced** |
| ~~`for-each-ref`~~ | was the snapshot probe (2 sites) | **no — replaced** |

Nothing else on that path is outside the list.

**One finding outside this change's scope, reported not fixed.** The console's own workspace Git *write* surface (`cp/workspace-git.ts`, reached through `consoleWorkspaceGitRunner`, which returns the remote runner in sandbox mode) issues `add`, `commit`, `push` and `ls-files`, none of which are in the inventory. That is not clone-tier work — it applies equally to a shared session on the agent pod and predates this tier — and `push`'s exclusion is asserted as intentional in the existing suite, so whether that surface should work on a pool member is a product decision rather than a patch. Flagged separately.

## Tests

- `workspace-session-clone.test.ts` gains a runner that wires the **real** `ShimGitRunner` to the **real** `createExecHandler`, so the daemon's argv crosses the production exec channel and meets production inventory enforcement instead of a permissive stand-in. Two cases: a confined session's branch is drawn and its tree materialized across that channel (asserting the tree contents, the absent upstream, and `GIT_NO_LAZY_FETCH=0` on the materializing run), and a whole confined life — prepare, review, dirty, retire — issues nothing outside the inventory, asserted as a set difference so the next addition is caught here rather than in the field.
- `shim-exec-handler.test.ts` runs the three-subcommand sequence against a real repository at the sandbox boundary and pins that `checkout` and `for-each-ref` stay refused.
- Self-hosted behaviour is unchanged: the same `checkoutSessionBranch` serves both tiers, and the existing local-git suite (25 cases in `workspace-session-clone.test.ts`, all against real repositories) passes untouched.

### Mutation check

| Mutation | Red |
| --- | --- |
| Restore `checkout --no-track -b` | **6** — both new shim-backed cases fail with the live message, `ExecRefusedError: git checkout is not in the permitted inventory`, plus 4 in `cluster-workspace-prepare` |
| Restore both `for-each-ref` probes | **4** — the enumeration case fails with `retained/dirty` where `removed` was expected, which is the live consequence, plus 3 in `workspace.test.ts` |
| Empty `REFUSED_ARGUMENT` | **3** — every argument-guard case (`-c` in all spellings, `--exec-path`, `--upload-pack`, `--config-env`) |
| Add `checkout` + `for-each-ref` to the inventory | **2** — the refusal loop and the new sequence case |

Gates: `tsc -p tsconfig.typecheck.json --noEmit` clean; `shim-exec-handler`, `workspace-session-clone`, `cluster-workspace-prepare`, `workspace`, `k8s-session-pods`, `k8s-runtime-plane`, `workspace-git-runner-seam`, `workspace-git-read`/`write`, `git-runner-contract`, `k8s-driver`, `runtime-launch`, `workspace-repo-scope` — 209 + 119 + 136 passed. One failure, `refuses a clone TARGET outside the workspace root`, is pre-existing and macOS-local (`/var` vs `/private/var`); verified failing on the unmodified file at this base. Prettier and ESLint clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
