### PR TITLE
fix(daemon): decide a session's pod from its own isolation, and claim none for an unknown tier (§11)

### DIFF
--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -405,6 +405,20 @@ agent.workspace.isolation`, and always `shared` for a from-scratch agent, whose 
    no boundary means a worktree. A pool member has no local disk to ask, so its session pod
    holds that record.
 
+**And a tier nothing has answered yet is not isolated.** Value 1 has to be in hand before
+anything keys a host on the session, because on the pool the pod is claimed when that host
+starts — which is _before_ workspace preparation, the step that used to be where the daemon
+learned a session's isolation at all (preparation runs second because the sandbox has to exist
+for the channel to report where its volume mounts). Every turn therefore reads the session's own
+isolation from its row — else this turn's explicit choice, else the agent's default, the same
+order `SessionManager` records it in — before the host starts. Where an answer is still missing,
+the pool must not fall back to the agent's default: a wrong `shared` costs one turn in the agent
+pod and its own pod on the next, while a wrong `session` claims a pod and a volume that live as
+long as the session's row. The fallback is therefore _not isolated_, which also makes every path
+nobody wired (a dream host, a session key seen before its row) safe by construction. A
+self-hosted daemon keeps the agent's default there: a wrong answer costs a directory rather than
+a pod, and the disk still records which tier a live session was born in.
+
 An empty `worktrees/<sid>` directory is **absent**, never a worktree: it is what a failed or
 degraded preparation leaves, it has no `.git` for anything to read, and counting it would pin
 a session to a tier nothing on disk serves. That is not hypothetical — a session whose stub

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -191,6 +191,7 @@ import { ChannelNameResolver } from './messages/channel-name-resolver.js'
 import { mentionedUserIds, substituteUserMentions } from './slack/mentions.js'
 import {
   WorkspaceManager,
+  effectiveSessionIsolation,
   foldSessionRemovals,
   type PrepareSessionWorkspaceRequest,
   type RetiredRootRemoval,
@@ -3627,13 +3628,15 @@ export class Daemon {
    *
    * It has to be that value and no other, because the console's workspace routing, retention and
    * preparation all read it: a tier chosen from anything else would put the runtime in a directory
-   * they do not address. Every workspace request reaching this daemon reports it; a session none has
-   * described yet takes what `SessionManager` will compute for it.
+   * they do not address. Every workspace request reaching this daemon reports it, and the turn path
+   * reports it from the session's row before anything keys a host on it.
    */
   private sessionIsolated(agent: Agent, sessionKey?: string): boolean {
     const reported = sessionKey === undefined ? undefined : this.sessionIsolation.get(sessionKey)
     if (reported !== undefined) return reported === 'session'
-    return agent.workspace.mode === 'git-repo' && agent.workspace.isolation === 'session'
+    // An unreported tier never costs a POD: a session that runs one turn in the agent pod and gets its own on the next is cheaper than a running pod nobody asked for. Self-hosted, where it costs a directory, keeps the agent default.
+    if (this.k8s) return false
+    return effectiveSessionIsolation(agent) === 'session'
   }
 
   /** The host that serves `sessionKey` of this agent: its own when the session is confined, else the shared one. */
@@ -10893,6 +10896,9 @@ export class Daemon {
   > {
     const { entry, key, plan, agent, replyConn, evaluation } = run
     const { agentId, msg, integrationId, webchat, callMeta, hookContext } = entry
+    // The per-conversation Worktree choice this turn carries, in the isolation vocabulary the row, the host key and the pod claim all speak.
+    const webchatIsolation =
+      webchat?.worktree === undefined ? undefined : webchat.worktree ? ('session' as const) : ('shared' as const)
     // Install the exact route before session/new|load: adapters may emit metadata
     // (including a restored title) while SessionManager is still initializing.
     const previousDeliveryBinding = this.sessionDeliveryBindings.get(key)
@@ -10905,7 +10911,10 @@ export class Daemon {
       else this.sessionDeliveryBindings.delete(key)
     }
     let handled: HandledTurnSession
-    const persistedSessionId = (await this.store.getSession(key))?.acpSessionId
+    const persisted = await this.store.getSession(key)
+    const persistedSessionId = persisted?.acpSessionId
+    // §11: this session's OWN isolation, learned here because the model-session host below claims its pod before `sessions.handle` records the row — its row, else this turn's explicit choice, else the agent's default, which is the order SessionManager decides it in.
+    this.sessionIsolation.set(key, persisted?.workspaceIsolation ?? effectiveSessionIsolation(agent, webchatIsolation))
     let remoteMcpServer: import('@agentclientprotocol/sdk').McpServer | undefined
     try {
       const reviewWorkspace = await this.githubReviews.prepareGithubReviewWorkspace(entry, key, agent)
@@ -10969,9 +10978,7 @@ export class Daemon {
           // isCaptureExcluded at recordTurnForBinding).
           ...(remoteMcpServer ? { additionalMcpServers: [remoteMcpServer] } : {}),
           ...(entry.selectedHost ? { host: entry.selectedHost.host } : {}),
-          ...(webchat?.worktree !== undefined
-            ? { workspaceIsolation: webchat.worktree ? ('session' as const) : ('shared' as const) }
-            : {}),
+          ...(webchatIsolation ? { workspaceIsolation: webchatIsolation } : {}),
           ...reviewWorkspace
         }
       )

--- a/packages/daemon/src/github/review-orchestrator.ts
+++ b/packages/daemon/src/github/review-orchestrator.ts
@@ -52,7 +52,7 @@ import {
 import type { CallMeta, QueueEntry } from '../daemon/turn-types.js'
 import type { WebchatTurnContext } from '../webchat/types.js'
 import { initiatorLabel } from '../workspace/session-branch.js'
-import type { PrepareSessionWorkspaceRequest } from '../workspace/workspace-manager.js'
+import { effectiveSessionIsolation, type PrepareSessionWorkspaceRequest } from '../workspace/workspace-manager.js'
 import { GithubFinalPoster, GithubReplyCollector, type GithubCommentAttribution } from './poster.js'
 import { GitlabFinalPoster } from '../gitlab/poster.js'
 import { GITLAB_HOST_MISMATCH_REASON } from '../gitlab/host-fence.js'
@@ -531,7 +531,7 @@ export class GithubReviewOrchestrator {
   private async sessionIsolationFor(key: string, agent: Agent): Promise<'shared' | 'session'> {
     const recorded = (await this.host.getSession(key))?.workspaceIsolation
     if (recorded) return recorded
-    return agent.workspace.mode === 'git-repo' && agent.workspace.isolation === 'session' ? 'session' : 'shared'
+    return effectiveSessionIsolation(agent)
   }
 
   /** Prepare an exact, isolated checkout before a formal review generation. A

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -2,7 +2,7 @@ import type { ContentBlock, McpServer } from '@agentclientprotocol/sdk'
 import { LocalStore, sessionKey, transcriptChannelKey, type TranscriptEntry } from '../store/local-store.js'
 import { isSyntheticA2aChannel } from '../cp/cp-collab-routes.js'
 import { monotonicTs } from '../store/monotonic-ts.js'
-import { WorkspaceManager } from '../workspace/workspace-manager.js'
+import { effectiveSessionIsolation, WorkspaceManager } from '../workspace/workspace-manager.js'
 import { initiatorLabel } from '../workspace/session-branch.js'
 import { memoryKindOf, type MemoryProvider, type MemoryScope } from '../memory/provider.js'
 import { agentChildEnv } from '../agents/agent-env.js'
@@ -437,8 +437,7 @@ export class SessionManager {
         await this.deps.store.upsertSession(rec)
       }
     }
-    const requestedWorkspaceIsolation =
-      agent.workspace.mode === 'git-repo' ? (options.workspaceIsolation ?? agent.workspace.isolation) : 'shared'
+    const requestedWorkspaceIsolation = effectiveSessionIsolation(agent, options.workspaceIsolation)
     const workspaceIsolation =
       options.forceWorkspaceIsolation === true
         ? requestedWorkspaceIsolation

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -191,6 +191,14 @@ export interface PrepareSessionWorkspaceRequest {
   confined?: boolean
 }
 
+/** The isolation a session created now is recorded with (§11): its own choice where the agent's workspace can serve one, else the agent's default — and always `shared` for a from-scratch workspace, whose primary is not a repository to clone. The one rule, so the host key and the pod claim cannot answer differently from the row `SessionManager` writes. */
+export function effectiveSessionIsolation(
+  agent: Pick<Agent, 'workspace'>,
+  requested?: 'shared' | 'session'
+): 'shared' | 'session' {
+  return agent.workspace.mode === 'git-repo' ? (requested ?? agent.workspace.isolation) : 'shared'
+}
+
 const PULL_TIMEOUT_MS = 4500
 const REVIEW_FETCH_TIMEOUT_MS = 15_000
 const LS_REMOTE_TIMEOUT_MS = 10_000

--- a/packages/daemon/test/daemon-k8s-mode.test.ts
+++ b/packages/daemon/test/daemon-k8s-mode.test.ts
@@ -177,6 +177,59 @@ describe('daemon --k8s mode', () => {
     }
   })
 
+  it('claims no session pod for a tier nothing has reported, whatever the agent defaults to (§11)', async () => {
+    // The asymmetry the pool needs: guessing `session` claims a pod that lives as long as the session's
+    // row, while guessing `shared` costs at most one turn in the agent pod. Every host key whose session
+    // the pool has not been told about — a dream, a model-session host, a session key seen before its
+    // row — therefore lands in the agent's own pod.
+    const instance = daemon({ root: root(), k8s: true })
+    try {
+      await instance.start()
+      ;(instance as any).sandboxMechanism = 'bwrap'
+      const agent = poolAgent('session')
+      ;(instance as any).agents.set('bot-a', agent)
+      const unreported = 'slack:C1:T1:bot-a'
+      expect((instance as any).confinedSession(agent, unreported)).toBe(false)
+      expect((instance as any).hostKeyFor('bot-a', unreported)).toBe(agentHostKey('bot-a'))
+      expect((instance as any).podSubjectFor(agent, sessionHostKey('bot-a', unreported))).toBeUndefined()
+      expect((instance as any).podSubjectFor(agent, sessionHostKey('bot-a', 'dream:bot-a:d1'))).toBeUndefined()
+      // The feature is untouched: a session the pool HAS been told is isolated still gets its own pod.
+      const isolated = { sessionKey: 'slack:C1:T2:bot-a', isolation: 'session' as const }
+      expect((instance as any).hostKeyForRequest('bot-a', isolated)).toBe(sessionHostKey('bot-a', isolated.sessionKey))
+      expect((instance as any).podSubjectFor(agent, sessionHostKey('bot-a', isolated.sessionKey))).toBe(
+        sandboxSubjectFor(sessionHostKey('bot-a', isolated.sessionKey))
+      )
+    } finally {
+      await instance.stop()
+    }
+  })
+
+  it("claims the pod this session's own isolation names, before its row is written (§11)", async () => {
+    // The model-session host starts inside openSession, seconds before `sessions.handle` records the
+    // row — so the pod it claims has to read the session's own isolation there, or an explicit
+    // per-session opt-out is honoured only once a pod nobody asked for is already running.
+    const cases = [
+      { agentDefault: 'session' as const, recorded: 'shared' as const, ownPod: false },
+      { agentDefault: 'shared' as const, recorded: 'session' as const, ownPod: true },
+      { agentDefault: 'session' as const, worktree: false, ownPod: false },
+      { agentDefault: 'shared' as const, worktree: true, ownPod: true }
+    ]
+    for (const scenario of cases) {
+      const instance = daemon({ root: root(), k8s: true })
+      try {
+        await instance.start()
+        ;(instance as any).sandboxMechanism = 'bwrap'
+        const agent = poolAgent(scenario.agentDefault)
+        ;(instance as any).agents.set('bot-a', agent)
+        const key = 'slack:C1:T1:bot-a'
+        const claimed = await openSessionClaim(instance, agent, key, scenario)
+        expect(claimed).toBe(scenario.ownPod ? sandboxSubjectFor(sessionHostKey('bot-a', key)) : undefined)
+      } finally {
+        await instance.stop()
+      }
+    }
+  })
+
   it('does not inspect or open the PostgreSQL data plane outside k8s mode', async () => {
     const openDataPlane = vi.fn()
     const local = daemon({ root: root(), k8s: false, openDataPlane })
@@ -1004,4 +1057,62 @@ function mcpServersFor(
     thread: '1',
     isDm: false
   })
+}
+
+/** A pool agent whose workspace could serve an isolated session, so only the tier rule decides its pod. */
+function poolAgent(isolation: 'shared' | 'session') {
+  return {
+    id: 'bot-a',
+    name: 'bot-a',
+    status: 'active',
+    runtime: 'claude',
+    runInSandbox: false,
+    workspace: {
+      mode: 'git-repo',
+      path: '/agents/bot-a/workspace',
+      gitRepo: 'https://github.com/acme/private.git',
+      gitBranch: 'main',
+      isolation
+    },
+    integrations: [],
+    output: { mode: 'medium' }
+  }
+}
+
+/** Run the real openSession as far as the model-session host, and report the pod that host would claim. */
+async function openSessionClaim(
+  instance: Daemon,
+  agent: ReturnType<typeof poolAgent>,
+  key: string,
+  scenario: { recorded?: 'shared' | 'session'; worktree?: boolean }
+): Promise<string | undefined> {
+  let claimed: string | undefined
+  const inner = instance as any
+  inner.githubReviews = { prepareGithubReviewWorkspace: async () => ({}) }
+  inner.store.getSession = async () =>
+    scenario.recorded === undefined ? undefined : { key, workspaceIsolation: scenario.recorded }
+  inner.modelSessions = {
+    enabled: true,
+    keys: () => [],
+    release: async () => {},
+    ensure: async () => {
+      claimed = inner.podSubjectFor(agent, sessionHostKey('bot-a', key))
+      return { host: {}, hostKey: sessionHostKey('bot-a', key), stop: async () => {}, waitForCleanup: async () => {} }
+    }
+  }
+  inner.sessions = { handle: async () => ({ sessionId: 'acp-1', blocks: [], created: true }) }
+  const run = {
+    entry: {
+      agentId: 'bot-a',
+      initAbort: new AbortController(),
+      msg: { platform: 'webchat', channel: 'C1', msgId: 'm1', sender: { id: 'U1' }, text: 'hi' },
+      ...(scenario.worktree === undefined ? {} : { webchat: { worktree: scenario.worktree } })
+    },
+    key,
+    plan: { deliveryBinding: {} },
+    agent,
+    evaluation: {}
+  }
+  await inner.openSession(run, () => {})
+  return claimed
 }

--- a/packages/daemon/test/daemon-session-hosts.test.ts
+++ b/packages/daemon/test/daemon-session-hosts.test.ts
@@ -213,6 +213,20 @@ describe('one ACP host per session under a confined self-hosted launch', () => {
     await daemon.stop()
   })
 
+  // Self-hosted keeps the agent default for a tier nothing has reported: there an over-eager answer costs
+  // a directory, not a pod that lives as long as the session's row, and the disk still says what a session
+  // already standing somewhere was born in.
+  it('takes the agent default for a session nothing has reported yet', async () => {
+    const isolated = await startDaemon(scaffold())
+    const shared = await startDaemon(scaffold({}, 'shared'))
+    expect((isolated.daemon as any).confinedSession((isolated.daemon as any).agents.get('bot-a'), KEY('T9'))).toBe(true)
+    expect((isolated.daemon as any).hostKeyFor('bot-a', KEY('T9'))).toBe(sessionHostKey('bot-a', KEY('T9')))
+    expect((shared.daemon as any).confinedSession((shared.daemon as any).agents.get('bot-a'), KEY('T9'))).toBe(false)
+    expect((shared.daemon as any).hostKeyFor('bot-a', KEY('T9'))).toBe(agentHostKey('bot-a'))
+    await isolated.daemon.stop()
+    await shared.daemon.stop()
+  })
+
   it('keeps one host per agent when the launch is not confined', async () => {
     const { daemon, hosts, factory } = await startDaemon(scaffold({ runInSandbox: false }))
     await (daemon as any).dispatch('bot-a', dm('100', 'one', 'T1'), 'int-a')


### PR DESCRIPTION
## The bug

Observed on a pool member: a user opened a playground session against a pool agent and explicitly turned isolation **off** for that session. The session row was recorded `shared` — and it still got a sandbox pod of its own. One agent ended up holding its agent claim plus four session claims, all Running, for sessions whose recorded isolation is `shared`.

## The ordering that causes it

The pod is claimed when the session's ACP host starts. On a pool member with a key server that host is started inside `openSession` by `ModelSessionHostPool.ensure(...)`, whose host key is always `sessionHostKey(agent, session)` — so `podSubjectFor` asks the §11 tier predicate right there.

That predicate reads `Daemon.sessionIsolation`, a per-session map that was populated in exactly two places: `hostKeyForRequest` (a workspace request) and the first statement of `runAgentWorkspacePreparation`. Both run **after** the host is up — preparation deliberately so, because the sandbox has to exist before the channel can report where its volume mounts. And with a model-session host the manager is handed `options.host`, so the turn takes the warm path and `hostKeyForRequest` is never called at all.

So at claim time the map was empty, the fallback returned the **agent's** default (`session`), and a session pod was claimed. The session's own `shared` was written about ten seconds later. Every new session repeated it, so pods accumulated.

## The fix — two independent halves

**1. Carry the session's own isolation to the claim.** `openSession` already reads the session row for `acpSessionId`; it now also records that row's `workspaceIsolation` into the map, before the model-session host starts. The order is the one `SessionManager` itself decides in: the row, else this turn's explicit per-conversation Worktree choice, else the agent's default. The webchat ternary is hoisted into one `webchatIsolation` const so the value handed to `SessionManager` and the value the claim reads are literally the same expression.

The agent-default half of that rule is now one exported function, `effectiveSessionIsolation(agent, requested?)`, shared by `SessionManager`, the review orchestrator's `sessionIsolationFor`, and the claim path — three copies of the same three-way rule (including the from-scratch `shared` clamp) previously sat in three files.

**2. An unknown tier claims no pod.** When nothing has reported a session's isolation, the pool predicate now answers *not isolated* instead of guessing the agent default. The asymmetry is deliberate and carries a one-line comment: a wrong `shared` costs one turn in the agent pod and its own pod on the next, while a wrong `session` claims a pod and a volume for as long as the session's row lives. It also makes paths nobody wired safe by construction — a dream host key and any session key seen before its row now land in the agent pod.

The two halves are independent: (1) makes the common path right, (2) makes every forgotten path safe. The mutation check below shows each one failing a different test on its own.

## Self-hosted

The predicate **is** shared — the same `sessionIsolated` governs the per-session ACP host on a self-hosted daemon. It can be separated cleanly, and is: half 2 is gated on `--k8s`, so self-hosted keeps the agent default for an unreported tier. Nothing changes there. That is the right split rather than a fudge — self-hosted pays a directory, not a pod, and its `confinedSessionTier` still reads the disk for the born-in tier, which the pool has no disk to ask.

## The two review threads on #1776

Both were read before designing this.

- **[P1] "Use the session's effective isolation for the initial tier."** Its structural ask — keep directory presence as the sticky override but derive `wanted` from the request's effective isolation rather than the agent default — is what `main` already does through the reported map plus `confinedSessionTier`. What it did not cover is that on the pool nothing *reports* before the claim. Both paths it names are now covered: a formal review forcing `session` on a shared-default agent reports through its own `prepareAgentWorkspace`, which still runs before the model-session host; and the reverse mismatch (a forced-`shared` session on a session-keyed host) is now answered from the row before the host key is taken.
- **[P2] "Keep pool placement aligned with the stored session tier."** This is exactly what half 1 restores: the row is authoritative for pool placement again, so `createWorkspaceScope`, `cleanupSessionWorktree` and retention agree with where the runtime actually ran. The thread's failure mode — a clone made on a session pod while the row says `shared`, invisible to the console and deleted without the dirty/unique-commit protection — cannot arise, because a `shared` row no longer sends the turn to a session pod at all.

## Already-claimed pods

No migration. Those sessions still exist and their rows say `shared`, so:

- the orphan reconciler does **not** collect them — it only collects a session claim whose session row is provably gone;
- the idle sweep does not delete them either; it *suspends* an idle sandbox and keeps the volume. A session pod with no host on the member is judged by the **agent's** last activity (the wider window), so on a continuously busy agent it can stay Running rather than suspending — which is what the live observation showed;
- they go with their session row: retention expiry (`discardSessionSandbox` is unconditional on isolation), deleting the session, removing the agent, or replacing the workspace.

So they are reclaimed on their own, but only when the row goes. An operator who wants the volumes back sooner deletes those sessions; nothing else is required, and the fix stops new ones from being created.

## Verified

- `tsc -p tsconfig.typecheck.json --noEmit` clean; prettier and eslint clean on every touched file.
- `daemon-k8s-mode`, `daemon-session-hosts`, `k8s-session-pods`, `cluster-workspace-prepare`, `model-key-session`, `workspace-session-clone`, `workspace-repo-scope`, `daemon-hook`, `session-manager` — 409 passed. (`session-capture-gate`, `daemon-webchat-session-continuation`, `daemon-workspace-git-review-feature`, `daemon-session-sweeps-pool` also run green.)
- New cases: a `shared` session on a `session`-default pool agent claims no session pod; a session whose tier is not yet known claims none (including a dream host key); an explicitly `session` session — by row or by the turn's Worktree choice — still gets its own pod; the self-hosted predicate keeps the agent default for an unreported tier.
- The claim-path case drives the real `openSession` and reports the pod the model-session host would claim at the moment it starts, so it tests the ordering rather than a refactored helper.

### Mutation check

| Mutation | Result |
| --- | --- |
| Delete `if (this.k8s) return false` (half 2) | **1 red** — `claims no session pod for a tier nothing has reported`. Self-hosted case stays green. |
| Delete the `sessionIsolation.set(key, …)` line in `openSession` (half 1) | **1 red** — `claims the pod this session's own isolation names, before its row is written`, a *different* case. |
| Make the whole fallback `return false` (would change self-hosted too) | **2 red** in `daemon-session-hosts`, which is the guard that self-hosted behaviour is untouched. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
