### PR TITLE
feat(daemon): security.sandboxReadRoots carves host toolchains into every sandbox

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -135,6 +135,7 @@ The daemon does not implement these, but interacts with them through the section
 | `--agent <name>`                 | Selector                       | Select by `agent.id`: single-agent `run` ignoring status, or disambiguate `chat`.                                                                  |
 | `--max-agents <n>`               | `limits.maxAgents`             | Capacity reported to CP + local hard limit.                                                                                                        |
 | `--require-sandbox`              | `security.requireSandbox=true` | Require every agent to run in the Linux SRT sandbox; refuse daemon startup on unsupported or failed hosts.                                         |
+| n/a (config only)                | `security.sandboxReadRoots`    | Host toolchain dirs carved read-only into every sandbox; see the config example below.                                                             |
 | `--k8s`                          | n/a (mode switch)              | Run runtimes in cluster sandbox pods instead of on this host; see section 2.6 for what that changes.                                               |
 | `--key-server <url>`             | `KEY_SERVER`                   | Cloud-only service for session-scoped model credentials, http or https as the deployment chooses; see [key-server.md](key-server.md).              |
 | `--key-server-token-path <path>` | `KEY_SERVER_TOKEN_PATH`        | File re-read as the key-server bearer token on every request.                                                                                      |
@@ -320,6 +321,14 @@ The layout keeps machine configuration, per-agent desired state, durable runtime
     // Linux SRT/bwrap sandbox. macOS and Windows are not supported in this rollout.
     "requireSandbox": false,
 
+    // Host directories carved read-only into EVERY sandbox, for toolchains the
+    // agent needs but the runtime-scoped read set would otherwise hide (nvm's
+    // node, a rustup toolchain, ...). `~/` expands against the daemon's HOME;
+    // each entry must exist or startup fails. Caches still land in the
+    // per-session private HOME. Name the toolchain dir itself, never a parent
+    // that also holds credentials (~/.cargo/credentials.toml, ~/.npmrc).
+    "sandboxReadRoots": [],
+
     // Origins that daemon-managed workspace clone/pull may target. Default ["*"]
     // admits any valid https/ssh origin; exact entries (scheme and non-default
     // port are part of the match, no partial wildcards or paths) tighten it, and
@@ -377,7 +386,9 @@ An enabled sandbox gives the runtime a private HOME, hides daemon-owned agent
 metadata and the host source from which that runtime state was seeded, and
 re-allows reads only for the workspace, private HOME, managed memory,
 `run/config-files`, `.agentconnect/runtime-policy`, trusted runtime installation
-roots, and the runtime's selected host credential path. Writes are limited to
+roots, any operator-declared `security.sandboxReadRoots` (host toolchains such as
+nvm's node or a rustup toolchain, carved read-only into every sandbox regardless
+of runtime), and the runtime's selected host credential path. Writes are limited to
 the workspace, private HOME, managed memory, SRT temporary storage, and that
 credential path. Outbound
 domains are approved by a provider callback and Unix sockets remain

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -15,6 +15,7 @@ import { detectSandbox } from '../acp/sandbox.js'
 import { agentHostKey } from '../acp/host-key.js'
 import { resolveRoot } from '../paths.js'
 import { runtimeHomePath } from '../runtimes/runtime-home.js'
+import { sandboxReadRoots } from '../runtimes/read-roots.js'
 import { installedRuntimeCatalog } from '../runtimes/probe.js'
 import { probeAllRuntimes, type ProbeOptions, type RuntimeProbeResult } from '../runtimes/runtime-prober.js'
 import { defaultProbeHostFactory } from '../acp/probe-host-factory.js'
@@ -60,6 +61,8 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     overrides: { agentsDir: opts.agentsDir }
   })
   configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
+  // Same fail-fast the daemon applies at boot: a missing operator read root is a config error, not a turn error.
+  const operatorReadRoots = sandboxReadRoots(cfg.security.sandboxReadRoots)
   const agent = selectAgent(cfg.agentsDir!, opts.agentName)
   await persistSkillSandboxRequirement(root)
 
@@ -145,7 +148,9 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     trustedWorkspaceWriteRoots: runInSandbox ? workspaces.trustedWorkspaceWriteRoots(agent) : undefined,
     trustedPrimaryCheckout: runInSandbox ? workspaces.localPrimaryCheckoutFor(agent) : undefined,
     // No daemon here, so there is no MCP bridge socket, gh wrapper, or git-credential shim to carve
-    // back: mcpSocketPath / allowModelToolUnixSockets / runtimeReadRoots stay genuinely unused.
+    // back: mcpSocketPath / allowModelToolUnixSockets stay genuinely unused. The operator's
+    // daemon-wide toolchain roots still apply, exactly as they do under the daemon.
+    runtimeReadRoots: runInSandbox ? operatorReadRoots : undefined,
     sandboxMechanism
   })
   for (const notice of assembled.configFiles?.notices ?? []) out.write(`⚠️ ${notice}\n`)

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -169,6 +169,8 @@ export const ConfigSchema = z.object({
       // Linux SRT/bwrap is available and every agent runs sandboxed; the
       // console locks the per-agent option on. false leaves it agent-selectable.
       requireSandbox: z.boolean().default(false),
+      // Operator-owned host dirs (toolchains such as nvm's node or a rustup toolchain) carved read-only into every sandbox.
+      sandboxReadRoots: z.array(z.string()).default([]),
       // Operator-owned remote-origin policy for daemon-managed workspace clone/pull. Default
       // ['*'] admits any https/ssh origin; exact scheme+host+port entries tighten it, and []
       // disables remote Git workspaces entirely.
@@ -177,6 +179,7 @@ export const ConfigSchema = z.object({
     .default({
       isolateAccountApps: true,
       requireSandbox: false,
+      sandboxReadRoots: [],
       workspaceGitAllowedOrigins: [...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS]
     }),
   // Relay roster the CP last published (shared-bot-relay.md §5). Persisted whole so

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -306,7 +306,7 @@ import { internalSessionKey, ModelSessionHostPool, type ModelSessionHostPoolHost
 import { CuratedRuntimeAdmission } from './runtimes/curated-admission.js'
 import { RuntimeFactsRegistry, PROBE_TTL_MS, type RuntimeFactsHost } from './runtimes/facts-registry.js'
 import { assembleRuntimeLaunch } from './launch/assemble.js'
-import { resolveTrustedExecutable, trustedRuntimeReadRoots } from './runtimes/read-roots.js'
+import { resolveTrustedExecutable, sandboxReadRoots, trustedRuntimeReadRoots } from './runtimes/read-roots.js'
 import { nodeExecArgvModuleEntries } from './runtimes/node-exec-argv.js'
 import { makeLogger, type Logger } from './log.js'
 import { CpClient } from './cp/client.js'
@@ -1839,6 +1839,8 @@ export class Daemon {
       autoCreate: true
     })
     this.cfg = cfg
+    // Fail the boot, not the first sandboxed turn, on a mistyped or missing operator read root.
+    sandboxReadRoots(cfg.security.sandboxReadRoots)
     configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
     // §24.4: an excluded origin is named at SPEC admission. All this knows is the operator list —
     // whether a spec names an instance of its own, which stays cloneable either way, is per-agent.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3570,7 +3570,8 @@ export class Daemon {
       mcpServers: configuredMcp,
       executableCommands,
       moduleEntries: [cliEntry, ...nodeExecArgvModuleEntries()],
-      paths
+      paths,
+      readRoots: this.cfg.security.sandboxReadRoots
     })
   }
 

--- a/packages/daemon/src/runtimes/read-roots.ts
+++ b/packages/daemon/src/runtimes/read-roots.ts
@@ -23,6 +23,8 @@ export interface TrustedRuntimeReadRootsOptions {
   moduleEntries?: readonly string[]
   /** Exact daemon-owned files, sockets, or already-reviewed directories. */
   paths?: readonly string[]
+  /** Operator-owned daemon-wide read-only host dirs (`security.sandboxReadRoots`), shared by every runtime. */
+  readRoots?: readonly string[]
 }
 
 function envWith(base: NodeJS.ProcessEnv, entries: readonly { name: string; value: string }[]): NodeJS.ProcessEnv {
@@ -238,6 +240,7 @@ export function trustedRuntimeReadRoots(opts: TrustedRuntimeReadRootsOptions): s
 
   addExecutable(opts.runtime.command, runtimeEnv, out, executables)
   for (const path of opts.runtime.readRoots ?? []) out.add(existingRoot(path, runtimeEnv))
+  for (const path of opts.readRoots ?? []) out.add(existingRoot(path, hostEnv))
 
   for (const server of opts.mcpServers ?? []) {
     if (server.transport !== 'stdio' || !server.command) continue

--- a/packages/daemon/src/runtimes/read-roots.ts
+++ b/packages/daemon/src/runtimes/read-roots.ts
@@ -41,10 +41,15 @@ function expandedAbsolute(path: string, env: NodeJS.ProcessEnv, label: string): 
   return resolve(expanded)
 }
 
-function existingRoot(path: string, env: NodeJS.ProcessEnv): string {
-  const expanded = expandedAbsolute(path, env, 'trusted runtime read root')
-  if (!existsSync(expanded)) throw new Error(`trusted runtime read root does not exist: ${expanded}`)
+function existingRoot(path: string, env: NodeJS.ProcessEnv, label = 'trusted runtime read root'): string {
+  const expanded = expandedAbsolute(path, env, label)
+  if (!existsSync(expanded)) throw new Error(`${label} does not exist: ${expanded}`)
   return realpathSync(expanded)
+}
+
+/** Normalize `security.sandboxReadRoots` (`~/` against the host HOME, must exist, realpath'd); throws so a boot fails fast. */
+export function sandboxReadRoots(paths: readonly string[], env: NodeJS.ProcessEnv = process.env): string[] {
+  return paths.map((path) => existingRoot(path, env, 'security.sandboxReadRoots entry'))
 }
 
 /** Resolve the existing prefix too, so a missing socket/file below a symlink is
@@ -240,7 +245,7 @@ export function trustedRuntimeReadRoots(opts: TrustedRuntimeReadRootsOptions): s
 
   addExecutable(opts.runtime.command, runtimeEnv, out, executables)
   for (const path of opts.runtime.readRoots ?? []) out.add(existingRoot(path, runtimeEnv))
-  for (const path of opts.readRoots ?? []) out.add(existingRoot(path, hostEnv))
+  for (const path of sandboxReadRoots(opts.readRoots ?? [], hostEnv)) out.add(path)
 
   for (const server of opts.mcpServers ?? []) {
     if (server.transport !== 'stdio' || !server.command) continue

--- a/packages/daemon/test/chat.test.ts
+++ b/packages/daemon/test/chat.test.ts
@@ -224,6 +224,25 @@ describe('runChat', () => {
     expect(hostFactory).not.toHaveBeenCalled()
   })
 
+  it('rejects a missing security.sandboxReadRoots entry before creating any host', async () => {
+    const files = scaffold()
+    writeFileSync(
+      files.configPath,
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        runtimes: { fake: { command: process.execPath, args: [fakeAgent], env: [] } },
+        security: { sandboxReadRoots: [join(files.root, 'no-such-toolchain')] }
+      })
+    )
+    const hostFactory = vi.fn()
+
+    await expect(runChat({ ...files, message: 'hi', out: capture().stream, hostFactory })).rejects.toThrow(
+      /security\.sandboxReadRoots entry does not exist/
+    )
+    expect(hostFactory).not.toHaveBeenCalled()
+  })
+
   it('does not create the real host when curated ACP admission fails', async () => {
     const files = curatedScaffold('maki')
     const hostFactory = vi.fn()

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -92,6 +92,22 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     ).rejects.toThrow(/daemon startup refused.*requireSandbox.*no supported Linux SRT\/bwrap/)
   })
 
+  it('refuses daemon startup when security.sandboxReadRoots names a directory that does not exist', async () => {
+    const root = scaffold()
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        security: { sandboxReadRoots: [join(root, 'no-such-toolchain')] }
+      })
+    )
+
+    await expect(
+      new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: null }).start()
+    ).rejects.toThrow(/security\.sandboxReadRoots entry does not exist/)
+  })
+
   it('does not force the skill sandbox or fail closed when the host has no sandbox mechanism (#36)', async () => {
     const root = scaffold()
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: null })

--- a/packages/daemon/test/read-roots.test.ts
+++ b/packages/daemon/test/read-roots.test.ts
@@ -41,6 +41,35 @@ describe('trusted runtime read roots', () => {
     expect(resolveTrustedExecutable('runtime', { PATH: bin })).toBe(realpathSync(cli))
   })
 
+  it('carves daemon-wide security.sandboxReadRoots into every runtime, expanding ~ against the host HOME', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-daemon-roots-'))
+    temporaryRoots.push(root)
+    const home = join(root, 'host-home')
+    const toolchain = join(home, '.rustup', 'toolchains', 'stable', 'bin')
+    const nodeInstall = join(root, 'opt', 'node-24')
+    mkdirSync(toolchain, { recursive: true })
+    mkdirSync(nodeInstall, { recursive: true })
+
+    const roots = trustedRuntimeReadRoots({
+      runtime: { command: process.execPath, args: [], env: [] },
+      hostEnv: { PATH: dirname(process.execPath), HOME: home },
+      readRoots: ['~/.rustup/toolchains/stable/bin', nodeInstall]
+    })
+
+    expect(roots).toContain(realpathSync(toolchain))
+    expect(roots).toContain(realpathSync(nodeInstall))
+  })
+
+  it('rejects a daemon-wide read root that does not exist', () => {
+    expect(() =>
+      trustedRuntimeReadRoots({
+        runtime: { command: process.execPath, args: [], env: [] },
+        hostEnv: { PATH: dirname(process.execPath) },
+        readRoots: [join(tmpdir(), 'ac-missing-daemon-root-does-not-exist')]
+      })
+    ).toThrow(/does not exist/)
+  })
+
   it('rejects relative operator read roots', () => {
     expect(() =>
       trustedRuntimeReadRoots({

--- a/packages/daemon/test/read-roots.test.ts
+++ b/packages/daemon/test/read-roots.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { resolveTrustedExecutable, trustedRuntimeReadRoots } from '../src/runtimes/read-roots.js'
+import { resolveTrustedExecutable, sandboxReadRoots, trustedRuntimeReadRoots } from '../src/runtimes/read-roots.js'
 
 const temporaryRoots: string[] = []
 
@@ -67,7 +67,10 @@ describe('trusted runtime read roots', () => {
         hostEnv: { PATH: dirname(process.execPath) },
         readRoots: [join(tmpdir(), 'ac-missing-daemon-root-does-not-exist')]
       })
-    ).toThrow(/does not exist/)
+    ).toThrow(/security\.sandboxReadRoots entry does not exist/)
+    expect(() => sandboxReadRoots(['relative/toolchain'], { HOME: tmpdir() })).toThrow(
+      /security\.sandboxReadRoots entry must be absolute/
+    )
   })
 
   it('rejects relative operator read roots', () => {


### PR DESCRIPTION
## Why

A confined session's read set is derived from its ACP runtime: the runtime HOME is hidden and only the runtime's own installation unit is carved back. Any host toolchain the *agent* needs but the *runtime* does not is invisible even when installed on the host. The first symptom was `corepack: command not found` (exit 127) inside a Codex session on a host where nvm's node was present; cargo, go and the like fail the same way.

The only existing knob, `runtimes[id].readRoots`, is per runtime and a user entry **replaces** the built-in definition wholesale (`command` required, `skillsAgentId` not inherited). Exposing one toolchain meant copying every runtime's built-in command into config and re-declaring its skills capability, and that copy silently drifts on the next upgrade.

## What

- **`security.sandboxReadRoots`** (default `[]`): a daemon-wide list of host directories carved read-only into every sandbox, independent of which runtime an agent uses.
- `trustedRuntimeReadRoots` gains a `readRoots` option; entries go through the same `existingRoot` validation as a runtime read root: `~/` expands against the daemon HOME, the path must exist (startup fails otherwise, so a typo cannot silently widen nothing), and it is realpath'd. Deliberately not routed through `paths`/`canonicalPath`, whose tolerate-missing semantics are for daemon-owned sockets and files.
- The single call site in `Daemon.sandboxRuntimeReadRoots` passes the configured list.
- Design doc: the flag/config table, the annotated `config.json` example, and the sentence listing what a sandbox re-allows for reading.

Read-only by construction. Caches (`~/.npm`, `~/.cargo` registry) still land in the per-session private HOME, which is the intended behavior. The example and comments tell operators to name the toolchain directory itself, never a parent that also holds credentials (`~/.cargo/credentials.toml`, `~/.npmrc`).

Not in scope: hot-reload (runtimes and this list are resolved at boot; a daemon restart applies the change, same as `security.requireSandbox`).

## Verification

- `read-roots.test.ts`: two new cases: daemon-wide roots reach the output with `~/` expanded against `hostEnv.HOME`, and a nonexistent root is rejected. 4/4 pass, plus `runtime-launch.test.ts` 45/45 and `config.test.ts` 32/32.
- Full daemon suite: 5749 pass. The 14 failures are the pre-existing environment-dependent set (acp-matrix live runtimes, shim-cancellation, shim-exec-handler, shim-workspace-files) and fail identically on a clean tree.
- `typecheck`, eslint and prettier pass on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
