### PR TITLE
fix(daemon): move the session hook policy onto the gitconfig file channel

### DIFF
--- a/docs/designs/github-app-git-credentials.md
+++ b/docs/designs/github-app-git-credentials.md
@@ -836,12 +836,21 @@ Injection uses **two channels**:
      automatically uses its own App bot. Git always reads global config;
      children inherit the path, and no indexed-count conflict exists. Reserve
      indexed `GIT_CONFIG_*` variables for **short-lived subprocesses directly
-     controlled by the daemon, such as clone**, and for non-credential ambient
-     policy. In particular, configured Git workspaces inject
-     `core.hooksPath=/dev/null` (or `NUL`) and `core.fsmonitor=false` at command
-     scope for the Agent process. If a nested tool deliberately replaces that
-     indexed channel it can opt out of the ambient hook policy, but it cannot
-     remove or replace the global-file credential reset.
+     controlled by the daemon, such as clone**.
+   - **The ambient hook policy rides the same file, not the indexed channel.**
+     The generated gitconfig sets `core.hooksPath=/dev/null` (or `NUL`) and
+     `core.fsmonitor=false` after the host `[include]`, for every configured Git
+     workspace — including one the daemon issues no managed credential to, which
+     gets the file for the policy alone. The indexed channel was tried first and
+     is unusable for anything the model's git must read: it does not merge across
+     processes, and a child that inherits `GIT_CONFIG_COUNT` without the indexed
+     pairs makes **every** git invocation fail to parse its command-line config.
+     The cost is precedence — `GIT_CONFIG_GLOBAL` is global
+     scope, which repository-local config outranks, where command scope outranked
+     everything. Daemon-run Git keeps its command-scope pins
+     (`workspaceGitConfigPairs`) and a confined runtime cannot write
+     `.git/config` or `.git/hooks`, so the exposed case is an unconfined agent's
+     own git in a checkout that sets `core.hooksPath` locally.
    - This injection must be spread **last, at the highest precedence** in the
      spawn-environment merge: after
      `{ ...agentChildEnv(agent), ...cpRuntimeEnv(agent) }` in `ensureHost` at

--- a/docs/designs/github-app-git-credentials.md
+++ b/docs/designs/github-app-git-credentials.md
@@ -851,6 +851,16 @@ Injection uses **two channels**:
      (`workspaceGitConfigPairs`) and a confined runtime cannot write
      `.git/config` or `.git/hooks`, so the exposed case is an unconfined agent's
      own git in a checkout that sets `core.hooksPath` locally.
+   - **The file is keyed by what it contains, not by the host that asked for
+     it.** A credential-stripped host (a dream) coexists with the warm host and
+     shares its pod on the pool, so it writes a separate policy-only name rather
+     than the credentialed one: landing policy-only content on the credentialed
+     path would strip the live runtime's helper and reset until it rebuilt.
+     Content is a pure function of (agent, class) — scope comes from the agent
+     spec and commit identity is daemon-global — so every writer of a path
+     writes identical bytes, and an agent never owns more than these two files.
+     Per-host names were rejected for the opposite reason: nothing reaps these
+     files, so they would accumulate one per host indefinitely.
    - This injection must be spread **last, at the highest precedence** in the
      spawn-environment merge: after
      `{ ...agentChildEnv(agent), ...cpRuntimeEnv(agent) }` in `ensureHost` at

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3538,7 +3538,9 @@ export class Daemon {
   private sandboxRuntimeReadRoots(
     agent: LoadedAgent,
     runtime: RuntimeDef,
-    launchEnv: Record<string, string>,
+    // The daemon-authored session gitconfig, passed rather than read back from the merged child
+    // env: runtimeOverrides.env could otherwise name any host file and have it carved in here.
+    sessionGitConfigPath: string | undefined,
     githubAppCredentials: boolean,
     gitlabCredentials: boolean
   ): string[] {
@@ -3549,9 +3551,9 @@ export class Daemon {
     const cliEntry = daemonEntryForShims(this.root)
     const paths = [mcpSocketPath(this.root)]
     const executableCommands = [process.execPath]
-    // Whatever the launch names, credentials or not: it carries the hook policy, and a hidden
-    // global config is read by git as no config at all — a silent loss of the pins, not an error.
-    if (launchEnv.GIT_CONFIG_GLOBAL) paths.push(launchEnv.GIT_CONFIG_GLOBAL)
+    // Carved with or without credentials: the file carries the hook policy, and a hidden global
+    // config is read by git as no config at all — a silent loss of the pins, not an error.
+    if (sessionGitConfigPath) paths.push(sessionGitConfigPath)
     if (githubAppCredentials) {
       paths.push(gitcredSocketPath(this.root), gitcredShimPath(this.root))
       if (this.ghBinDir) paths.push(this.ghBinDir)
@@ -4305,6 +4307,11 @@ export class Daemon {
       this.k8sPlane && needsSessionGit
         ? sessionGitConfig(agent.id, sessionGitIdentity, sandboxGitCredentialTarget(), sessionGitScope)
         : undefined
+    // Held as its own value: the sandbox read grant must come from the path the DAEMON authored,
+    // never read back out of the merged child env, where runtimeOverrides.env could name any file.
+    const sessionGitInjection = needsSessionGit
+      ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, sessionGitIdentity, sessionGitScope))
+      : undefined
     const env: Record<string, string> = {
       ...baseEnv,
       // Memory backend env: managed disables the runtime's own memory; native
@@ -4314,9 +4321,7 @@ export class Daemon {
       ...memoryProviderFor(memoryAgent, runtime, baseEnv, this.externalMemoryAdmission(agent.id)).runtimeEnv(),
       // App identity rides with the CREDENTIAL mode, not the workspace mode: a scratch workspace with
       // authorized repositories needs the capability for its git and gh exactly like a clone does.
-      ...(needsSessionGit
-        ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, sessionGitIdentity, sessionGitScope))
-        : {})
+      ...(sessionGitInjection ?? {})
     }
     // Config-file secrets are materialized by assembleRuntimeLaunch below; the pre-strip merged env
     // is snapshotted so the idle sweep can delete the files and rematerializeConfigFiles() can
@@ -4406,8 +4411,14 @@ export class Daemon {
           if (this.claudeModelAliases) applyClaudeModelAliases(target, launchEnv, this.claudeModelAliases)
         },
         runtimeReadRoots: runInSandbox
-          ? (launchEnv) =>
-              this.sandboxRuntimeReadRoots(agent, runtime, launchEnv, githubAppCredentials, gitlabCredentials)
+          ? () =>
+              this.sandboxRuntimeReadRoots(
+                agent,
+                runtime,
+                sessionGitInjection?.GIT_CONFIG_GLOBAL,
+                githubAppCredentials,
+                gitlabCredentials
+              )
           : undefined,
         // A session host with its own clones (§11) writes its session directory alone; the launch derives its Git grants from it.
         trustedWorkspaceWriteRoots: runInSandbox

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -100,8 +100,7 @@ import {
   probeGitVersion,
   sandboxGitCredentialTarget,
   sessionGitConfig,
-  sessionGitEnv,
-  sessionGitPolicyEnv
+  sessionGitEnv
 } from './workspace/git-injection.js'
 import { configureWorkspaceGitOrigins, permitsNoHttpsOrigin } from './workspace/git-origin-policy.js'
 import { buildMcpServers, buildSandboxMcpServers, type McpStdioServer } from './mcp/inject.js'
@@ -4274,9 +4273,9 @@ export class Daemon {
       agent.gitlabHost,
       !excludeAgentToolCredentials && this.workspaces.gitlabRepoBearing(agent)
     )
-    // The Git session policy runs for every configured repository, not only
-    // GitHub review: repository hooks/fsmonitor stay disabled without rewriting
-    // checkout config. sessionGitEnv additionally supplies GitHub App identity.
+    // The Git session policy runs for every configured repository, not only GitHub review:
+    // repository hooks/fsmonitor stay disabled through the per-agent gitconfig the whole agent
+    // process tree inherits. sessionGitEnv additionally supplies GitHub App identity.
     // Keep this channel LAST so runtimeOverrides cannot replace either policy.
     const baseEnv: Record<string, string> = { ...agentChildEnv(agent), ...cpRuntimeEnv(agent) }
     const runInSandbox = opts.runInSandbox
@@ -4297,9 +4296,13 @@ export class Daemon {
     // pod coordinates and WRITTEN there: the file travels with the launch (SpawnRequest.files) and
     // is re-materialized on every spawn, because a resumed Sandbox is a new pod with an empty tmpfs.
     // The daemon-local write (sessionGitEnv) would land the file on this daemon's disk instead.
+    // A git-repo workspace with no managed credential still gets the file, for its policy alone.
+    const sessionGitScope = managedCredentials ? managedScope : null
+    const sessionGitIdentity = managedCredentials ? this.gitCommitIdentity : undefined
+    const needsSessionGit = managedCredentials || agent.workspace.mode === 'git-repo'
     const sandboxSessionGit =
-      this.k8sPlane && managedCredentials
-        ? sessionGitConfig(agent.id, this.gitCommitIdentity, sandboxGitCredentialTarget(), managedScope)
+      this.k8sPlane && needsSessionGit
+        ? sessionGitConfig(agent.id, sessionGitIdentity, sandboxGitCredentialTarget(), sessionGitScope)
         : undefined
     const env: Record<string, string> = {
       ...baseEnv,
@@ -4310,11 +4313,9 @@ export class Daemon {
       ...memoryProviderFor(memoryAgent, runtime, baseEnv, this.externalMemoryAdmission(agent.id)).runtimeEnv(),
       // App identity rides with the CREDENTIAL mode, not the workspace mode: a scratch workspace with
       // authorized repositories needs the capability for its git and gh exactly like a clone does.
-      ...(managedCredentials
-        ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, this.gitCommitIdentity, managedScope))
-        : agent.workspace.mode === 'git-repo'
-          ? sessionGitPolicyEnv()
-          : {})
+      ...(needsSessionGit
+        ? (sandboxSessionGit?.env ?? sessionGitEnv(agent.id, sessionGitIdentity, sessionGitScope))
+        : {})
     }
     // Config-file secrets are materialized by assembleRuntimeLaunch below; the pre-strip merged env
     // is snapshotted so the idle sweep can delete the files and rematerializeConfigFiles() can

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -3549,10 +3549,12 @@ export class Daemon {
     const cliEntry = daemonEntryForShims(this.root)
     const paths = [mcpSocketPath(this.root)]
     const executableCommands = [process.execPath]
+    // Whatever the launch names, credentials or not: it carries the hook policy, and a hidden
+    // global config is read by git as no config at all — a silent loss of the pins, not an error.
+    if (launchEnv.GIT_CONFIG_GLOBAL) paths.push(launchEnv.GIT_CONFIG_GLOBAL)
     if (githubAppCredentials) {
       paths.push(gitcredSocketPath(this.root), gitcredShimPath(this.root))
       if (this.ghBinDir) paths.push(this.ghBinDir)
-      if (launchEnv.GIT_CONFIG_GLOBAL) paths.push(launchEnv.GIT_CONFIG_GLOBAL)
       const gh = resolveCommandPath('gh', process.env)
       if (gh) executableCommands.push(gh)
     }
@@ -3561,7 +3563,6 @@ export class Daemon {
       // real glab binary for the OS sandbox's read allowlist (§13.3).
       paths.push(gitcredSocketPath(this.root), gitcredShimPath(this.root))
       if (this.glabBinDir) paths.push(this.glabBinDir)
-      if (launchEnv.GIT_CONFIG_GLOBAL) paths.push(launchEnv.GIT_CONFIG_GLOBAL)
       const glab = resolveCommandPath('glab', process.env)
       if (glab) executableCommands.push(glab)
     }

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -579,7 +579,12 @@ export function sessionGitConfig(
   // ambient policy, and nothing that would hand it a credential pointer or a socket capability.
   scope: ManagedCredentialScope | null = GITHUB_CREDENTIAL_SCOPE
 ): { path: string; content: string; env: Record<string, string> } {
-  const file = join(target.configDir, `${agentId}.gitconfig`)
+  // Keyed by what the file CONTAINS, not by the host that asked for it. A dream host is stripped of
+  // tool credentials and coexists with the warm host (sharing its pod on the pool), so writing the
+  // credentialed name with policy-only content would cut the live host's helper until it rebuilds.
+  // Content is a pure function of (agent, class) — scope and identity are agent- and daemon-global —
+  // so every writer of a path writes identical bytes, and an agent can never own more than these two.
+  const file = join(target.configDir, `${agentId}${scope ? '' : '.policy'}.gitconfig`)
   const bases = scope ? sessionCredentialBases(scope) : []
   const lines = [
     '# agentconnect session git config — regenerated on agent start; NO secrets.',

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -14,9 +14,12 @@
  *     pinned separately). Inherited by the WHOLE agent process tree —
  *     submodules and nested clones hit OUR
  *     helper (and get a clean denial) instead of leaking to a machine-global
- *     osxkeychain credential. NOT GIT_CONFIG_COUNT: the indexed env vars don't
+ *     osxkeychain credential. It carries the model-facing hooks/fsmonitor
+ *     policy too. NOT GIT_CONFIG_COUNT: the indexed env vars don't
  *     merge across processes, so any child that sets its own COUNT would
- *     silently drop the reset and reopen the leak.
+ *     silently drop the reset and reopen the leak — and a child that inherits
+ *     COUNT without the indexed pairs makes every git invocation fail with
+ *     "unable to parse command-line config", measured per process in a pod.
  *
  * All config values single-quote the shim path (git runs `!`-helpers via
  * `sh -c` — a space in $HOME must not word-split), reset the helper list first
@@ -305,7 +308,8 @@ export function workspaceGitLocalEnv(): Record<string, string> {
  * before daemon-run network or checkout operations. Unconditional includes are
  * expanded and their actual keys are audited instead of rejecting include.path
  * itself: a repository may legitimately include a shared hooksPath, and daemon
- * Git pins hooksPath/fsmonitor at command scope so neither can run. Conditional
+ * Git pins hooksPath/fsmonitor at command scope so neither can run — the model's
+ * own git gets the same pins at global scope, which repo-local config outranks. Conditional
  * includes remain disallowed because their activation can change between the
  * primary checkout used for this audit and a later linked worktree. The
  * separate worktree config scope is also disallowed because `--local` cannot
@@ -320,17 +324,6 @@ export async function assertSafeWorkspaceGitConfig(git: GitRunner): Promise<void
   if (names.split('\0').some((name) => UNSAFE_LOCAL_WORKSPACE_GIT_CONFIG.test(name))) {
     throw new Error('workspace Git configuration contains a disallowed network override or executable setting')
   }
-}
-
-/** Ambient Git policy inherited by every configured repository session. The
- * command-scope config outranks repo-local and included hooksPath/fsmonitor
- * values without rewriting the checkout's own config. A tool may still opt in
- * explicitly with a later `git -c` override when running a hook is the task. */
-export function sessionGitPolicyEnv(): Record<string, string> {
-  return gitConfigEnv([
-    ['core.hooksPath', EMPTY_GIT_CONFIG],
-    ['core.fsmonitor', 'false']
-  ])
 }
 
 /**
@@ -582,14 +575,20 @@ export function sessionGitConfig(
   // Explicit for a spawn that KNOWS where the runtime will run (a --k8s launch always lands in the
   // pod), so the env cannot depend on whether the shim channel happens to be attached right now.
   target: GitCredentialTarget = targetOf(agentId),
-  scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE
+  // `null` is an agent the daemon issues NO managed credential to: it still gets the file for the
+  // ambient policy, and nothing that would hand it a credential pointer or a socket capability.
+  scope: ManagedCredentialScope | null = GITHUB_CREDENTIAL_SCOPE
 ): { path: string; content: string; env: Record<string, string> } {
   const file = join(target.configDir, `${agentId}.gitconfig`)
-  const bases = sessionCredentialBases(scope)
+  const bases = scope ? sessionCredentialBases(scope) : []
   const lines = [
     '# agentconnect session git config — regenerated on agent start; NO secrets.',
-    `# Keeps non-identity host config, then pins ${bases.join(' + ')} credentials to the daemon helper.`,
+    `# Keeps non-identity host config and disables repository hooks${bases.length ? `, then pins ${bases.join(' + ')} credentials to the daemon helper` : ''}.`,
     ...(target.hostConfig ? ['[include]', `\tpath = ${target.hostConfig}`] : []),
+    // AFTER the include, or a host ~/.gitconfig hooksPath would be the last writer and win.
+    '[core]',
+    `\thooksPath = ${EMPTY_GIT_CONFIG}`,
+    '\tfsmonitor = false',
     ...bases.flatMap((base) => [
       `[credential "${base}"]`,
       '\thelper = ', // reset the accumulated helper list for this host
@@ -602,10 +601,8 @@ export function sessionGitConfig(
     path: file,
     content: lines.join('\n'),
     env: {
-      ...gitCredentialEnv(agentId, target, scope),
-      ...sessionGitPolicyEnv(),
+      ...(scope ? { ...gitCredentialEnv(agentId, target, scope), GIT_TERMINAL_PROMPT: '0' } : {}),
       GIT_CONFIG_GLOBAL: file,
-      GIT_TERMINAL_PROMPT: '0',
       ...(commitIdentity ? gitCommitIdentityEnv(commitIdentity) : {})
     }
   }
@@ -622,7 +619,7 @@ export function sessionGitConfig(
 export function sessionGitEnv(
   agentId: string,
   commitIdentity?: GitCommitIdentity,
-  scope: ManagedCredentialScope = GITHUB_CREDENTIAL_SCOPE
+  scope: ManagedCredentialScope | null = GITHUB_CREDENTIAL_SCOPE
 ): Record<string, string> {
   if (targetOf(agentId).kind !== 'daemon') {
     throw new Error(`agent ${agentId} runs its git in a sandbox — materialize its gitconfig instead of writing it`)

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -272,6 +272,11 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       const runtimeDef = (daemon as any).runtimes[agent.runtime]
       const roots = (daemon as any).sandboxRuntimeReadRoots(agent, runtimeDef, dreamEnv, false, false)
       expect(roots).toContain(realpathSync(dreamEnv.GIT_CONFIG_GLOBAL))
+      // A dream COEXISTS with the warm host, so it must not write over the file that host is still
+      // pointing at: doing so would strip the live runtime's credential helper until it rebuilds.
+      const normalEnv = (normal as any).opts.env
+      expect(dreamEnv.GIT_CONFIG_GLOBAL).not.toBe(normalEnv.GIT_CONFIG_GLOBAL)
+      expect(readFileSync(normalEnv.GIT_CONFIG_GLOBAL, 'utf8')).toContain('[credential')
     } finally {
       await daemon.stop().catch(() => undefined)
       rmSync(root, { recursive: true, force: true })

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -258,13 +258,15 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       expect(dreamEnv.API_KEY).toBeUndefined()
       expect(dreamEnv[GITCRED_AGENT_ENV]).toBeUndefined()
       expect(dreamEnv[GITCRED_CAPABILITY_ENV]).toBeUndefined()
-      expect([
-        [dreamEnv.GIT_CONFIG_KEY_0, dreamEnv.GIT_CONFIG_VALUE_0],
-        [dreamEnv.GIT_CONFIG_KEY_1, dreamEnv.GIT_CONFIG_VALUE_1]
-      ]).toEqual([
-        ['core.hooksPath', process.platform === 'win32' ? 'NUL' : '/dev/null'],
-        ['core.fsmonitor', 'false']
-      ])
+      // The policy rides the per-agent gitconfig, which the whole process tree inherits; the
+      // indexed channel is gone, because a child that keeps COUNT without the pairs breaks git.
+      expect(dreamEnv.GIT_CONFIG_COUNT).toBeUndefined()
+      expect(Object.keys(dreamEnv).filter((key) => key.startsWith('GIT_CONFIG_KEY_'))).toEqual([])
+      const dreamConfig = readFileSync(dreamEnv.GIT_CONFIG_GLOBAL, 'utf8')
+      expect(dreamConfig).toContain(`hooksPath = ${process.platform === 'win32' ? 'NUL' : '/dev/null'}`)
+      expect(dreamConfig).toContain('fsmonitor = false')
+      // A dream gets NO tool credentials, so its file must carry no helper pointer either.
+      expect(dreamConfig).not.toContain('[credential')
     } finally {
       await daemon.stop().catch(() => undefined)
       rmSync(root, { recursive: true, force: true })

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -267,6 +267,11 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       expect(dreamConfig).toContain('fsmonitor = false')
       // A dream gets NO tool credentials, so its file must carry no helper pointer either.
       expect(dreamConfig).not.toContain('[credential')
+      // …and the confined launch must still be able to READ it. A hidden global config is read by
+      // git as no config at all, so an uncarved path loses the hook pins silently rather than loudly.
+      const runtimeDef = (daemon as any).runtimes[agent.runtime]
+      const roots = (daemon as any).sandboxRuntimeReadRoots(agent, runtimeDef, dreamEnv, false, false)
+      expect(roots).toContain(realpathSync(dreamEnv.GIT_CONFIG_GLOBAL))
     } finally {
       await daemon.stop().catch(() => undefined)
       rmSync(root, { recursive: true, force: true })

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -270,13 +270,56 @@ describe('Daemon (no Slack, injected ACP host)', () => {
       // …and the confined launch must still be able to READ it. A hidden global config is read by
       // git as no config at all, so an uncarved path loses the hook pins silently rather than loudly.
       const runtimeDef = (daemon as any).runtimes[agent.runtime]
-      const roots = (daemon as any).sandboxRuntimeReadRoots(agent, runtimeDef, dreamEnv, false, false)
-      expect(roots).toContain(realpathSync(dreamEnv.GIT_CONFIG_GLOBAL))
+      const carve = (path: string | undefined) =>
+        (daemon as any).sandboxRuntimeReadRoots(agent, runtimeDef, path, false, false)
+      expect(carve(dreamEnv.GIT_CONFIG_GLOBAL)).toContain(realpathSync(dreamEnv.GIT_CONFIG_GLOBAL))
+      // The grant takes the DAEMON-authored path as an argument, never the merged child env: a
+      // launch the daemon issues no session gitconfig for must carve nothing, whatever env says.
+      expect(carve(undefined)).not.toContain(realpathSync(dreamEnv.GIT_CONFIG_GLOBAL))
       // A dream COEXISTS with the warm host, so it must not write over the file that host is still
       // pointing at: doing so would strip the live runtime's credential helper until it rebuilds.
       const normalEnv = (normal as any).opts.env
       expect(dreamEnv.GIT_CONFIG_GLOBAL).not.toBe(normalEnv.GIT_CONFIG_GLOBAL)
       expect(readFileSync(normalEnv.GIT_CONFIG_GLOBAL, 'utf8')).toContain('[credential')
+    } finally {
+      await daemon.stop().catch(() => undefined)
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('never carves an operator-configured GIT_CONFIG_GLOBAL into the sandbox read roots', async () => {
+    const root = scaffold()
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root,
+      sandboxMechanism: 'bwrap',
+      probeRuntimes: async () => []
+    })
+    try {
+      await daemon.start()
+      const agent = (daemon as any).agents.get('bot-a')
+      // A from-scratch workspace with no managed credential: the daemon issues no session
+      // gitconfig, so the only GIT_CONFIG_GLOBAL in the merged env is the operator's own. Carving
+      // that back would name any host file the model could then read straight out of the sandbox.
+      const planted = join(root, 'planted-host-file')
+      writeFileSync(planted, 'host-only')
+      agent.runtimeOverrides = { env: [{ name: 'GIT_CONFIG_GLOBAL', value: planted }] }
+      const granted: string[][] = []
+      const real = (daemon as any).sandboxRuntimeReadRoots.bind(daemon)
+      ;(daemon as any).sandboxRuntimeReadRoots = (...args: any[]) => {
+        const roots = real(...args)
+        granted.push(roots)
+        return roots
+      }
+      const host = (daemon as any).buildAcpHost(agent, (daemon as any).cfg, {
+        hostKey: agentHostKey(agent.id),
+        runInSandbox: true,
+        cwd: agent.workspace.path
+      }).host
+      // The value does reach the child env — it is the read GRANT that must not be derived from it.
+      expect((host as any).opts.env.GIT_CONFIG_GLOBAL).toBe(planted)
+      expect(granted.length).toBeGreaterThan(0)
+      for (const roots of granted) expect(roots).not.toContain(realpathSync(planted))
     } finally {
       await daemon.stop().catch(() => undefined)
       rmSync(root, { recursive: true, force: true })

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { simpleGit } from 'simple-git'
 import { GITCRED_AGENT_ENV, GITCRED_CAPABILITY_ENV, GITCRED_SOCKET_ENV } from '../src/cp/gitcred-server.js'
@@ -737,6 +737,27 @@ describe('sessionGitEnv', () => {
     expect(content).not.toContain('[credential')
     expect(env[GITCRED_CAPABILITY_ENV]).toBeUndefined()
     expect(env[GITCRED_AGENT_ENV]).toBeUndefined()
+  })
+
+  // A credential-stripped host (a dream) coexists with the warm credentialed one and shares its pod
+  // on the pool, so the two must never name the same file: policy-only content landing on the
+  // credentialed path would cut the live runtime's helper and reset until that host is rebuilt.
+  it('keys the file by what it contains, so a credential-stripped host cannot overwrite the other', () => {
+    const podCredentialed = sessionGitConfig('agent-1', undefined, sandboxGitCredentialTarget())
+    const podPolicyOnly = sessionGitConfig('agent-1', undefined, sandboxGitCredentialTarget(), null)
+    expect(podPolicyOnly.path).not.toBe(podCredentialed.path)
+    // Both are materialized into the one pod, so they have to coexist in the same directory.
+    expect(dirname(podPolicyOnly.path)).toBe(dirname(podCredentialed.path))
+    expect(podCredentialed.content).toContain('[credential')
+    expect(podPolicyOnly.content).not.toContain('[credential')
+
+    // On this daemon's disk the same holds, and it holds AFTER the policy-only write, not just in
+    // the returned paths — the warm host is still pointing at the credentialed file.
+    const credentialed = sessionGitEnv('agent-1')
+    const policyOnly = sessionGitEnv('agent-1', undefined, null)
+    expect(policyOnly.GIT_CONFIG_GLOBAL).not.toBe(credentialed.GIT_CONFIG_GLOBAL)
+    expect(readFileSync(credentialed.GIT_CONFIG_GLOBAL!, 'utf8')).toContain('[credential')
+    expect(readFileSync(policyOnly.GIT_CONFIG_GLOBAL!, 'utf8')).not.toContain('[credential')
   })
 
   // Real git resolves these, because the whole defect was a channel that looked right and was not.

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -19,7 +19,6 @@ import {
   sandboxGitCredentialTarget,
   sessionGitConfig,
   sessionGitEnv,
-  sessionGitPolicyEnv,
   workspaceGitEnvBase,
   workspaceGitLocalEnv,
   workspaceGitRemoteTarget,
@@ -702,13 +701,88 @@ describe('workspaceGitRemoteTarget', () => {
 })
 
 describe('sessionGitEnv', () => {
-  it('disables repository hooks and fsmonitor for every configured Git workspace session', () => {
-    expect(configPairs(sessionGitPolicyEnv())).toEqual([
-      ['core.hooksPath', process.platform === 'win32' ? 'NUL' : '/dev/null'],
-      ['core.fsmonitor', 'false']
-    ])
-    expect(configPairs(sessionGitEnv('agent-1'))).toEqual(configPairs(sessionGitPolicyEnv()))
+  // The policy lives in the FILE, not in indexed env pairs. Read per process inside a runtime pod:
+  // the ACP runtime had GIT_CONFIG_COUNT plus both KEY/VALUE pairs, while its own child had COUNT
+  // alone — enough for git to refuse EVERY invocation with "unable to parse command-line config".
+  const HOOKS_PATH = process.platform === 'win32' ? 'NUL' : '/dev/null'
+
+  it('carries the hooks and fsmonitor policy in the file, for a pod launch and a daemon launch alike', () => {
+    const daemonLaunch = readFileSync(sessionGitEnv('agent-1').GIT_CONFIG_GLOBAL!, 'utf8')
+    expect(daemonLaunch).toContain(`hooksPath = ${HOOKS_PATH}`)
+    expect(daemonLaunch).toContain('fsmonitor = false')
+    // A --k8s launch never writes here, so its content is asserted where the pod would read it.
+    const podLaunch = sessionGitConfig('agent-1', undefined, sandboxGitCredentialTarget()).content
+    expect(podLaunch).toContain(`hooksPath = ${HOOKS_PATH}`)
+    expect(podLaunch).toContain('fsmonitor = false')
   })
+
+  it('leaves no indexed command-scope config in any session launch env', () => {
+    const launches = [
+      sessionGitEnv('agent-1'),
+      sessionGitEnv('agent-2', undefined, null),
+      sessionGitConfig('agent-1', undefined, sandboxGitCredentialTarget()).env,
+      sessionGitConfig('agent-2', undefined, sandboxGitCredentialTarget(), null).env
+    ]
+    for (const env of launches) {
+      expect(env).not.toHaveProperty('GIT_CONFIG_COUNT')
+      expect(Object.keys(env).filter((key) => key.startsWith('GIT_CONFIG_KEY_'))).toEqual([])
+      expect(env.GIT_CONFIG_GLOBAL).toBeDefined()
+    }
+  })
+
+  it('gives a credential-free git workspace the policy and no credential pointer at all', () => {
+    const env = sessionGitEnv('agent-2', undefined, null)
+    const content = readFileSync(env.GIT_CONFIG_GLOBAL!, 'utf8')
+    expect(content).toContain(`hooksPath = ${HOOKS_PATH}`)
+    expect(content).not.toContain('[credential')
+    expect(env[GITCRED_CAPABILITY_ENV]).toBeUndefined()
+    expect(env[GITCRED_AGENT_ENV]).toBeUndefined()
+  })
+
+  // Real git resolves these, because the whole defect was a channel that looked right and was not.
+  it.skipIf(process.platform === 'win32')('outranks a host gitconfig hooksPath by sitting AFTER the include', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gitcred-host-'))
+    try {
+      const hostConfig = join(dir, 'host.gitconfig')
+      writeFileSync(hostConfig, '[core]\n\thooksPath = /host/hooks\n')
+      const cfg = sessionGitConfig('agent-1', undefined, {
+        kind: 'daemon',
+        helper: join(tmpRun, 'helper.sh'),
+        configDir: dir,
+        hostConfig
+      })
+      writeFileSync(cfg.path, cfg.content)
+      expect(cfg.content.indexOf('[include]')).toBeLessThan(cfg.content.indexOf('hooksPath = /dev/null'))
+      const env = { ...gitEnvBase(), ...cfg.env }
+      expect(
+        execFileSync('git', ['config', '--get', 'core.hooksPath'], { cwd: dir, encoding: 'utf8', env }).trim()
+      ).toBe('/dev/null')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  // The KNOWN cost of moving off the indexed channel: GIT_CONFIG_GLOBAL is global scope, which
+  // repository-local config outranks, where command scope outranked everything. Daemon-run git is
+  // unaffected (workspaceGitConfigPairs still pins both at command scope) and a confined runtime
+  // cannot write .git/config, but an unconfined agent's own git can now opt back into its hooks.
+  it.skipIf(process.platform === 'win32')(
+    'lets a repository-local hooksPath win, which the indexed channel refused',
+    () => {
+      const repo = mkdtempSync(join(tmpdir(), 'gitcred-repo-'))
+      try {
+        const env = { ...gitEnvBase(), ...sessionGitEnv('agent-1') }
+        execFileSync('git', ['init', '-q'], { cwd: repo, env })
+        const read = () =>
+          execFileSync('git', ['config', '--get', 'core.hooksPath'], { cwd: repo, encoding: 'utf8', env }).trim()
+        expect(read()).toBe('/dev/null')
+        execFileSync('git', ['config', '--local', 'core.hooksPath', join(repo, 'hooks')], { cwd: repo, env })
+        expect(read()).toBe(join(repo, 'hooks'))
+      } finally {
+        rmSync(repo, { recursive: true, force: true })
+      }
+    }
+  )
 
   // The runner shells out to `git var GIT_AUTHOR_IDENT`, which the runner image cannot answer here.
   it.skipIf(process.platform === 'win32')('pins the CP-provided bot as both author and committer', () => {


### PR DESCRIPTION
## The bug, measured

`sessionGitPolicyEnv()` pinned the model-facing `core.hooksPath` / `core.fsmonitor` policy through
the indexed `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` channel. Read per process
inside a runtime pod:

| process | `GIT_CONFIG_COUNT` | `GIT_CONFIG_KEY_*` |
| --- | --- | --- |
| the ACP runtime itself | present | **both present** |
| a helper the runtime spawns | present | **absent** |

The indexed pairs are lost when the runtime spawns a child while `COUNT` survives. Git reads "there
are 2 command-line settings", cannot find `KEY_0`, and refuses **every** invocation with `unable to
parse command-line config` — the agent has to `unset` the variables to get any Git working. The two
settings that failed to arrive are the ones that stop a repository's hooks from running. The
mechanism in the child is not ours; the daemon's own env for that pod is complete and correct.

## The rule this restores

The module header of `git-injection.ts` had already ruled the indexed channel out for anything the
model's git reads:

> **NOT `GIT_CONFIG_COUNT`: the indexed env vars don't merge across processes, so any child that
> sets its own COUNT would silently drop the reset and reopen the leak.**

`sessionGitPolicyEnv` was that documented rule being violated. The live failure is a second, louder
consequence of the same defect the comment predicted.

## The change

Both settings move into the per-agent gitconfig that `GIT_CONFIG_GLOBAL` names — the channel the
module already established for model-facing configuration, inherited by the whole agent process
tree and immune to a child that rebuilds its env. Placement respects the file's existing
constraints:

- **after** the host `[include]`, or an operator `~/.gitconfig` `hooksPath` would be the last writer
  and win;
- **before** the credential blocks, so the empty-entry helper reset and `useHttpPath=true` keep
  their order;
- still nothing but pointers to the daemon — no secret.

`sessionGitPolicyEnv` is deleted. It had two callers and both moved to the file channel:

- `sessionGitConfig` — the managed-credential path; the pins are now part of the content it already
  emits.
- `daemon.ts` `buildAcpHost` — a `git-repo` workspace with no managed credential. `scope: null` now
  means "issue the file for its policy alone": no credential block, no helper pointer, no socket
  capability, no `GIT_TERMINAL_PROMPT`. Both the daemon-local write and the pod materialisation
  (`SpawnRequest.files`) follow the same branch, so a launch that reaches a pod gets it too.

## Two things the move exposed, fixed here

**The sandbox read allowlist.** The confined read roots named the launch's `GIT_CONFIG_GLOBAL` only
inside the github-app and gitlab branches. A credential-free `git-repo` workspace now gets the same
file, and a hidden global config is read by git as *no config at all* — the pins would have vanished
silently rather than failed.

The first attempt hoisted that carve-back out of the credential branches, which was a privilege
escalation (found in review). `sandboxRuntimeReadRoots` read `GIT_CONFIG_GLOBAL` out of the **merged
child env**; for a sandboxed `from-scratch` agent with no managed credential the daemon installs no
session Git config, so nothing overwrites that key and it can arrive straight from
`runtimeOverrides.env` — agent configuration, not daemon output. Pointing it at a file beneath the
otherwise-hidden host HOME would have carved that file into the sandbox for the model to read. It
also broke the method's own stated contract: *every input is daemon- or registry-owned; agent.json
contributes only MCP names, never a filesystem path.*

The generated path is now **passed in** rather than read back. Of the two remedies, this is the
stronger: gating the carve-back on `needsSessionGit` would still take the value from the merged env
and merely narrow when it is consulted, leaving agent configuration in the data flow. Passing the
path removes it entirely — the `launchEnv` parameter is gone, and the grant can only name a file
this daemon wrote, which restores the contract instead of working around it.

**File collision with a credential-stripped host** (found in review; introduced by this change — the
previous env-only policy had no file to collide on). A dream host reaches the same call with
`excludeAgentToolCredentials`, so its scope is `null` and it would have rewritten the *credentialed*
`${agentId}.gitconfig` with policy-only content. The warm host keeps pointing at that path, so its
nested clones and submodules would lose the helper and the reset until it rebuilt. The two coexist by
design and share a pod on the pool.

The file is now keyed by **what it contains**, not by the host that asked for it: the credential-free
variant writes its own name. Content is a pure function of (agent, class) — scope comes from the
agent spec, commit identity is daemon-global — so every writer of a path writes identical bytes, and
an agent never owns more than the two files. Per-host names were rejected for the opposite reason:
nothing reaps these files, so they would accumulate one per host indefinitely.

## The precedence trade-off, and what actually covers it

`GIT_CONFIG_GLOBAL` is **global** scope, which repository-local config outranks; the indexed vars
were **command** scope and outranked everything. This is a genuine weakening for a repository that
sets `core.hooksPath` in its own `.git/config`. Of the three things that might cover it:

- **`workspaceGitConfigPairs` — covers its half.** Daemon-run Git is untouched: it still pins both
  at command scope, plus `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_NOSYSTEM=1`. Clone, pull,
  status and the config audit can never run a hook.
- **The confined tier — covers its half.** `allowGitConfig: false` plus the runtime's mandatory deny
  paths (and the Codex profile's `read` entries for `.git/config` and `.git/hooks`) mean a confined
  agent cannot introduce the local override in the first place.
- **`assertSafeWorkspaceGitConfig` — does not cover it, and says so.** Its own comment exempts
  `core.hooksPath` explicitly, on the grounds that daemon Git pins it at command scope. That
  reasoning still holds for daemon Git and no longer holds for the model's Git.

So the honest statement: **an unconfined runtime's own git, in a checkout that already carries a
local `core.hooksPath`, is not covered by any of the three.** Weighed against the current state —
where the model's git in a pod is broken outright rather than pinned — this is the right trade, but
it is not free. A test pins it as the known consequence rather than asserting it away.

One further consequence worth naming: a credential-free `git-repo` agent now reads our generated
file as its global config instead of the host's own. The file `[include]`s `~/.gitconfig` first, so
that content still applies — but a host that keeps its global config at the XDG location
(`~/.config/git/config`) loses it, exactly as the managed-credential path already does.

## Verified

- `tsc -p tsconfig.typecheck.json --noEmit` on the daemon package: clean.
- `git-injection`, `daemon-smoke` (launch env composition), `gitlab-self-managed-host`,
  `cp/gitlab-gitcred`, `k8s-driver` (pod git config materialisation), `workspace`, `read-roots`,
  `runtime-launch`, `runtime-credentials`: **307 passed**.
- prettier and eslint on every touched file: clean.
- The full daemon suite was deliberately not run — it OOMs locally and carries pre-existing
  macOS-local failures unrelated to this change.

New tests: the file carries both settings for a pod launch and a daemon launch alike; no session
launch env carries `GIT_CONFIG_COUNT` or any `GIT_CONFIG_KEY_*`; a credential-free workspace gets
the policy and no credential pointer; the policy outranks a host gitconfig `hooksPath` because it
sits after the include; a repository-local `hooksPath` wins, resolved by real `git config`; the
confined launch can read the file it is pointed at; a credential-stripped host neither shares a
path with the credentialed one nor disturbs it, on disk and in the one pod they share; and a
sandboxed `from-scratch` agent whose `runtimeOverrides.env` sets `GIT_CONFIG_GLOBAL` to a host path
gets no carve-back for it, asserted on the read roots the launch actually computes.

### Mutation-check

| mutation | cases red |
| --- | --- |
| drop the `hooksPath` line from the generated file | **5** |
| drop the `fsmonitor` line from the generated file | **2** |
| move the `[core]` block *before* the host `[include]` | **1** (the ordering test) |
| re-add the indexed `GIT_CONFIG_COUNT` pins alongside the file | **3** (incl. the precedence test) |
| remove the daemon-authored read grant | **1** |
| read the grant back out of the merged child env instead of taking it as an argument | **2** (incl. the escalation test) |
| collapse both classes back onto one filename | **2** (unit isolation + dream/warm coexistence) |

The last one matters most: it proves the repository-local test detects command-vs-global **scope**
and not merely a string in a file — with command scope restored, the local override stops winning
and the test goes red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
