### PR TITLE
feat(daemon): install a registry binary's vendor archive, so Antigravity probes

### DIFF
--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -17,6 +17,7 @@ import { resolveRoot } from '../paths.js'
 import { runtimeHomePath } from '../runtimes/runtime-home.js'
 import { sandboxReadRoots } from '../runtimes/read-roots.js'
 import { installedRuntimeCatalog } from '../runtimes/probe.js'
+import { ArchiveStore, parseArchiveLaunch, storedArchiveRuntimeDef } from '../runtimes/archive-store.js'
 import { probeAllRuntimes, type ProbeOptions, type RuntimeProbeResult } from '../runtimes/runtime-prober.js'
 import { defaultProbeHostFactory } from '../acp/probe-host-factory.js'
 import { CuratedRuntimeAdmission } from '../runtimes/curated-admission.js'
@@ -71,14 +72,28 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     : await resolveRuntimeCatalog(cfg, root, { neededRuntimes: [agent.runtime], mode: 'cache-first' })
   const runtimes = opts.installed ? opts.installed(catalog.runtimes) : installedRuntimeCatalog(catalog).runtimes
   const entry = catalog.entries[agent.runtime]
-  const runtime = runtimes[agent.runtime]
-  if (!runtime) {
+  const selected = runtimes[agent.runtime]
+  if (!selected) {
     if (entry?.source === 'curated') {
       throw new Error(`curated runtime "${agent.runtime}" is not installed or initialized on this host`)
     }
     const available = Object.keys(runtimes).sort().join(', ') || '(none)'
     throw new Error(`runtime "${agent.runtime}" not found. Available: ${available}`)
   }
+
+  // An archive-distributed runtime was admitted on the product's own state, and its binary lives in
+  // the daemon-owned store rather than on `$PATH` — so this launch path installs it too, or the
+  // spawn below would run the registry's relative `./cmd`. The store reuses what a previous run left.
+  const archiveLaunch = entry ? parseArchiveLaunch(agent.runtime, entry) : undefined
+  const runtime = archiveLaunch
+    ? storedArchiveRuntimeDef(
+        selected,
+        await new ArchiveStore({
+          root,
+          log: { info: (message) => out.write(`${message}\n`), warn: (message) => out.write(`${message}\n`) }
+        }).ensure(archiveLaunch)
+      )
+    : selected
 
   const sandboxMechanism = detectSandbox()
   // Sandbox-optional principle (#36): the single-shot host follows the agent's OWN

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -289,6 +289,7 @@ import { clusterProbeHostFactory, defaultProbeHostFactory } from './acp/probe-ho
 import { runtimeHomePath } from './runtimes/runtime-home.js'
 import { planRuntimeInstallRepair, repairRuntimeInstall } from './runtimes/runtime-install-repair.js'
 import { RuntimeStore, parseNpxLaunch, storedRuntimeDef } from './runtimes/runtime-store.js'
+import { ArchiveStore, parseArchiveLaunch, storedArchiveRuntimeDef } from './runtimes/archive-store.js'
 import {
   applyCodexSessionFloor,
   applyClaudeModelAliases,
@@ -819,6 +820,7 @@ export class Daemon {
   // Why a daemon-supplied adapter has no install in the runtime store, so a refusal can name its tree.
   private runtimeStoreFailures = new Map<string, string>()
   private runtimeStore?: Pick<RuntimeStore, 'ensure'>
+  private archiveStore?: Pick<ArchiveStore, 'ensure'>
   // Terminal ACP start failure per agent, so a later refusal can say the runtime did not start
   // instead of reporting the agent as absent. Cleared once the agent starts or leaves the roster.
   private lastStartFailure = new Map<string, string>()
@@ -1347,6 +1349,8 @@ export class Daemon {
       installed?: typeof installedRuntimes
       /** Test seam for the daemon-owned adapter store; production builds one over the daemon root. */
       runtimeStore?: Pick<RuntimeStore, 'ensure'>
+      /** Test seam for the daemon-owned vendor-archive store; production builds one over the daemon root. */
+      archiveStore?: Pick<ArchiveStore, 'ensure'>
       /** Test seam: null simulates a host without Linux SRT/bwrap. */
       sandboxMechanism?: SandboxMechanism | null
       /** `--k8s`: runtimes live in sandbox pods, not on this host. Disables runtime
@@ -2256,25 +2260,47 @@ export class Daemon {
     return this.runtimeStore
   }
 
-  /** Install each id's daemon-supplied `npx` adapter into the daemon-owned store and launch it from
-   *  there, so no agent launch resolves a package and none loads adapter code out of a writable HOME.
+  /** The store this daemon extracts vendor agent archives into; a pool launch and an injected host
+   *  factory get none for the same reasons {@link adapterStore} does. */
+  private vendorArchiveStore(root: string): Pick<ArchiveStore, 'ensure'> | undefined {
+    if (this.k8s || this.opts.hostFactory) return undefined
+    this.archiveStore ??= this.opts.archiveStore ?? new ArchiveStore({ root, log: this.log })
+    return this.archiveStore
+  }
+
+  /** Install each id's daemon-supplied adapter — an `npx` package, or a vendor archive the registry
+   *  distributes a binary in — into the daemon-owned store and launch it from there, so no agent
+   *  launch resolves or downloads anything and none loads adapter code out of a writable HOME.
    *  An adapter with no install leaves the catalog: {@link runtimeUnavailableMessage} names its tree. */
   private async installManagedRuntimePackages(
     catalog: ResolvedRuntimeCatalog,
     ids: Iterable<string>
   ): Promise<ResolvedRuntimeCatalog> {
     const store = this.adapterStore(this.root)
+    const archives = this.vendorArchiveStore(this.root)
     if (!store) return catalog
     const entries = { ...catalog.entries }
     for (const id of new Set(ids)) {
       const entry = entries[id]
-      const launch = entry && Daemon.STORE_MANAGED_SOURCES.has(entry.source) ? parseNpxLaunch(entry.runtime) : undefined
-      if (!entry || !launch) continue
+      if (!entry || !Daemon.STORE_MANAGED_SOURCES.has(entry.source)) continue
+      const npx = parseNpxLaunch(entry.runtime)
+      const archive = npx ? undefined : parseArchiveLaunch(id, entry)
+      if (!npx && !archive) continue
       try {
-        const installed = await store.ensure(launch)
-        entries[id] = { ...entry, runtime: storedRuntimeDef(entry.runtime, launch, installed) }
+        let rewritten: RuntimeDef
+        let label: string
+        if (npx) {
+          const installed = await store.ensure(npx)
+          rewritten = storedRuntimeDef(entry.runtime, npx, installed)
+          label = `${npx.name}@${installed.version} from ${installed.tree}`
+        } else if (archive && archives) {
+          const installed = await archives.ensure(archive)
+          rewritten = storedArchiveRuntimeDef(entry.runtime, installed)
+          label = `${archive.bin}@${installed.version} from ${installed.tree}`
+        } else continue
+        entries[id] = { ...entry, runtime: rewritten }
         this.runtimeStoreFailures.delete(id)
-        this.log.info(`runtimes: "${id}" launches ${launch.name}@${installed.version} from ${installed.tree}`)
+        this.log.info(`runtimes: "${id}" launches ${label}`)
       } catch (err) {
         delete entries[id]
         // This detail reaches a console reader through the refusal, so it is the bounded, path-free
@@ -2293,7 +2319,8 @@ export class Daemon {
    *  after boot. The store memoizes, so this resolves once for the runtime and never once per spawn. */
   private async ensureRuntimeInstalled(runtimeId: string): Promise<void> {
     const entry = this.runtimeCatalog.entries[runtimeId]
-    if (!entry || !Daemon.STORE_MANAGED_SOURCES.has(entry.source) || !parseNpxLaunch(entry.runtime)) return
+    if (!entry || !Daemon.STORE_MANAGED_SOURCES.has(entry.source)) return
+    if (!parseNpxLaunch(entry.runtime) && !parseArchiveLaunch(runtimeId, entry)) return
     this.runtimeCatalog = await this.installManagedRuntimePackages(this.runtimeCatalog, [runtimeId])
     this.refreshAdmittedRuntimes()
   }

--- a/packages/daemon/src/runtimes/archive-store.ts
+++ b/packages/daemon/src/runtimes/archive-store.ts
@@ -70,6 +70,10 @@ export function parseArchiveLaunch(
   }
   // No plaintext and no `file:`: the store's install is the runtime's parent process.
   if (url.protocol !== 'https:') return undefined
+  // ZIP is the only format this store inflates, and the registry publishes plenty of `.tar.gz`,
+  // `.tar.bz2`, and bare binaries. Leaving those unclassified is what keeps them on the command
+  // probe they already pass — claiming them here would drop an install that launches from `$PATH`.
+  if (!url.pathname.toLowerCase().endsWith('.zip')) return undefined
   // The registry writes the member as `./name` or `name`; anything with real path structure is not
   // a member of this archive, and taking its basename would launch something else under that name.
   const bin = entry.runtime.command.replace(/^\.[/\\]/, '')

--- a/packages/daemon/src/runtimes/archive-store.ts
+++ b/packages/daemon/src/runtimes/archive-store.ts
@@ -1,0 +1,258 @@
+import { createHash, randomUUID } from 'node:crypto'
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  writeSync
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { Unzip, UnzipInflate } from 'fflate'
+import type { RuntimeDef } from '../config/config-schema.js'
+import { runtimeStoreDir } from '../paths.js'
+import type { ResolvedRuntimeEntry } from './registry.js'
+
+// Some ACP agents ship as a signed vendor binary in a ZIP rather than an npm package, and the
+// registry's `cmd` for those (`./agy_acp_server.par`) only means anything to a client that fetched
+// the archive itself. This store is that client: one install per (id, version) under the daemon
+// root, launched by absolute path, so no agent spawn downloads anything and no adapter loads its
+// code out of a writable HOME. Presence on the host is a separate question — the probe answers it
+// from the product's own state dir, exactly as it does for an `npx`-distributed adapter.
+
+/** One archive-distributed launch: what to fetch, where its binary lands, and the args it gets. */
+export interface ArchiveLaunch {
+  id: string
+  url: string
+  version: string
+  /** The archive member to launch, a flat file name. */
+  bin: string
+  args: string[]
+}
+
+/** One installed archive: the tree, the version it holds, and the absolute binary to launch. */
+export interface StoredRuntimeArchive {
+  tree: string
+  version: string
+  bin: string
+}
+
+// A registry answer becomes a directory name, so refuse anything that is not plainly a version.
+const VERSION_RE = /^[0-9][0-9A-Za-z.+-]*$/
+// Archive members and store ids stay flat, printable, and free of any path or shell meaning.
+const FLAT_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+const MARKER_FILE = '.archive.json'
+// A vendor agent binary is hundreds of megabytes; these bound a hostile archive, not a large one.
+const MAX_FILES = 64
+const MAX_EXPANDED_BYTES = 6 * 1024 * 1024 * 1024
+// Bounded because a start-time install waits on it: a cold multi-hundred-megabyte fetch fits, a
+// stalled CDN fails the install instead of parking the daemon forever.
+const FETCH_TIMEOUT_MS = 30 * 60_000
+
+export type ArchiveFetch = (url: string, init: { signal: AbortSignal }) => Promise<Response>
+
+/** Decompose a resolved entry into the archive the store can install, or undefined when it is not one. */
+export function parseArchiveLaunch(
+  id: string,
+  entry: Pick<ResolvedRuntimeEntry, 'runtime' | 'archive' | 'version'>
+): ArchiveLaunch | undefined {
+  if (!entry.archive || !FLAT_NAME_RE.test(id)) return undefined
+  let url: URL
+  try {
+    url = new URL(entry.archive)
+  } catch {
+    return undefined
+  }
+  // No plaintext and no `file:`: the store's install is the runtime's parent process.
+  if (url.protocol !== 'https:') return undefined
+  // The registry writes the member as `./name` or `name`; anything with real path structure is not
+  // a member of this archive, and taking its basename would launch something else under that name.
+  const bin = entry.runtime.command.replace(/^\.[/\\]/, '')
+  if (!FLAT_NAME_RE.test(bin)) return undefined
+  // The registry version names the product, not the build; digest the URL when it cannot name a tree.
+  const version = VERSION_RE.test(entry.version)
+    ? entry.version
+    : createHash('sha256').update(entry.archive).digest('hex').slice(0, 12)
+  return { id, url: entry.archive, version, bin, args: entry.runtime.args }
+}
+
+/** `<root>/runtimes/<id>@<version>` — the tree one archive install owns outright. */
+export function runtimeArchiveTree(root: string, id: string, version: string): string {
+  return join(runtimeStoreDir(root), `${id}@${version}`)
+}
+
+/** Versions of `id` already installed in the store. */
+export function installedArchiveVersions(root: string, id: string): string[] {
+  try {
+    return readdirSync(runtimeStoreDir(root), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith(`${id}@`))
+      .map((entry) => entry.name.slice(id.length + 1))
+      .filter((version) => VERSION_RE.test(version) || /^[0-9a-f]{12}$/.test(version))
+  } catch {
+    return []
+  }
+}
+
+/** The launchable binary inside an installed tree, or undefined when it is absent or holds another URL. */
+export function installedArchiveBin(tree: string, launch: ArchiveLaunch): string | undefined {
+  let marker: { url?: unknown }
+  try {
+    marker = JSON.parse(readFileSync(join(tree, MARKER_FILE), 'utf8')) as { url?: unknown }
+  } catch {
+    return undefined
+  }
+  // A vendor can move a build behind the same version; the URL is what the tree actually holds.
+  if (marker.url !== launch.url) return undefined
+  const bin = join(tree, launch.bin)
+  return existsSync(bin) ? bin : undefined
+}
+
+/** Launch the store's own install by absolute path; the outer sandbox denies the daemon root, so carve the tree back. */
+export function storedArchiveRuntimeDef(runtime: RuntimeDef, installed: StoredRuntimeArchive): RuntimeDef {
+  return {
+    ...runtime,
+    command: installed.bin,
+    readRoots: [...(runtime.readRoots ?? []), installed.tree]
+  }
+}
+
+export interface ArchiveStoreOptions {
+  root: string
+  fetchImpl?: ArchiveFetch
+  log?: { info(message: string): void; warn(message: string): void }
+}
+
+/** Installs archive-distributed ACP agents under the daemon root and reports where to launch them. */
+export class ArchiveStore {
+  private readonly inFlight = new Map<string, Promise<StoredRuntimeArchive>>()
+  private readonly fetchImpl: ArchiveFetch
+
+  constructor(private readonly opts: ArchiveStoreOptions) {
+    this.fetchImpl = opts.fetchImpl ?? ((url, init) => fetch(url, init))
+  }
+
+  /** One install per archive for this daemon's lifetime: two hosts starting at once share this promise. */
+  ensure(launch: ArchiveLaunch): Promise<StoredRuntimeArchive> {
+    const key = `${launch.id}@${launch.version}:${launch.bin}`
+    const existing = this.inFlight.get(key)
+    if (existing) return existing
+    const run = this.install(launch)
+    this.inFlight.set(key, run)
+    void run.catch(() => {})
+    return run
+  }
+
+  private async install(launch: ArchiveLaunch): Promise<StoredRuntimeArchive> {
+    const tree = runtimeArchiveTree(this.opts.root, launch.id, launch.version)
+    const present = installedArchiveBin(tree, launch)
+    if (present) return { tree, version: launch.version, bin: present }
+    // Extract into staging and rename, so a partial tree is never visible as an install.
+    const staging = join(runtimeStoreDir(this.opts.root), `.staging-${randomUUID().slice(0, 8)}`)
+    mkdirSync(staging, { recursive: true })
+    try {
+      this.opts.log?.info(`runtimes: fetching "${launch.id}" archive ${launch.url}`)
+      const files = await this.extract(launch.url, staging)
+      if (!files.includes(launch.bin)) {
+        throw new Error(`archive for ${launch.id}@${launch.version} contains no "${launch.bin}"`)
+      }
+      writeFileSync(join(staging, MARKER_FILE), `${JSON.stringify({ url: launch.url, version: launch.version })}\n`)
+      mkdirSync(dirname(tree), { recursive: true })
+      rmSync(tree, { recursive: true, force: true })
+      renameSync(staging, tree)
+    } catch (err) {
+      rmSync(staging, { recursive: true, force: true })
+      throw err
+    }
+    this.prune(launch.id, launch.version)
+    return { tree, version: launch.version, bin: join(tree, launch.bin) }
+  }
+
+  /** Stream the ZIP straight into `dir` — the whole archive never lands on disk compressed as well. */
+  private async extract(url: string, dir: string): Promise<string[]> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    try {
+      const res = await this.fetchImpl(url, { signal: controller.signal })
+      if (!res.ok) throw new Error(`archive fetch failed: HTTP ${res.status}`)
+      if (!res.body) throw new Error('archive fetch returned no body')
+      return await this.inflate(res.body, dir)
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  private async inflate(body: ReadableStream<Uint8Array>, dir: string): Promise<string[]> {
+    const written: string[] = []
+    const open = new Map<string, number>()
+    let expanded = 0
+    let failure: Error | undefined
+    const unzip = new Unzip()
+    unzip.register(UnzipInflate)
+    unzip.onfile = (file) => {
+      // Directory entries carry no data, and a member the store cannot name flatly is refused outright.
+      if (file.name.endsWith('/')) return
+      if (!FLAT_NAME_RE.test(file.name)) {
+        failure ??= new Error(`archive member is not a flat file name: ${file.name.slice(0, 64)}`)
+        return
+      }
+      if (written.length >= MAX_FILES) {
+        failure ??= new Error(`archive holds more than ${MAX_FILES} files`)
+        return
+      }
+      written.push(file.name)
+      const path = join(dir, file.name)
+      file.ondata = (err, chunk, final) => {
+        if (err) failure ??= err
+        if (failure) return
+        expanded += chunk.length
+        if (expanded > MAX_EXPANDED_BYTES) {
+          failure ??= new Error('archive expands beyond the daemon ceiling')
+          return
+        }
+        let fd = open.get(path)
+        if (fd === undefined) {
+          // Every member is a vendor executable or its data; the launch needs the execute bit.
+          fd = openSync(path, 'w', 0o755)
+          open.set(path, fd)
+        }
+        if (chunk.length > 0) writeSync(fd, chunk)
+        if (final) {
+          closeSync(fd)
+          open.delete(path)
+          if (process.platform !== 'win32') chmodSync(path, 0o755)
+        }
+      }
+      file.start()
+    }
+    try {
+      for await (const chunk of body) {
+        if (failure) break
+        unzip.push(chunk)
+      }
+      if (!failure) unzip.push(new Uint8Array(0), true)
+    } catch (err) {
+      failure ??= err as Error
+    } finally {
+      for (const fd of open.values()) closeSync(fd)
+    }
+    if (failure) throw failure
+    return written
+  }
+
+  /** Drop versions this daemon no longer launches; the store resolves before any host is running. */
+  private prune(id: string, keep: string): void {
+    for (const version of installedArchiveVersions(this.opts.root, id)) {
+      if (version === keep) continue
+      try {
+        rmSync(runtimeArchiveTree(this.opts.root, id, version), { recursive: true, force: true })
+      } catch (err) {
+        this.opts.log?.warn(`runtimes: could not remove ${id}@${version} — ${(err as Error).message}`)
+      }
+    }
+  }
+}

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -199,8 +199,16 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
   // OpenAI Codex CLI — ~/.codex (honors $CODEX_HOME).
   'codex-acp': (env) => [...state(env.CODEX_HOME, '.codex'), ...state(join(home(env), '.codex'), '.codex')],
 
-  // Google Gemini CLI — ~/.gemini.
-  gemini: (env) => state(join(home(env), '.gemini'), '.gemini'),
+  // Google Gemini CLI — ~/.gemini, which the Antigravity CLI also writes into (its own
+  // `antigravity-cli/`, `antigravity-acp/`, and `config/` subdirs), so the shared root is not a
+  // signal for either: probe this CLI's own top-level files, plus `tmp/` as a ran-here marker that
+  // seeds nothing.
+  gemini: (env) => [
+    ...state(join(home(env), '.gemini', 'settings.json'), join('.gemini', 'settings.json')),
+    ...state(join(home(env), '.gemini', 'oauth_creds.json'), join('.gemini', 'oauth_creds.json')),
+    ...state(join(home(env), '.gemini', 'google_accounts.json'), join('.gemini', 'google_accounts.json')),
+    ...state(join(home(env), '.gemini', 'tmp'), join('.gemini', 'tmp'), [])
+  ],
 
   // Qwen Code (Gemini-CLI fork) — ~/.qwen.
   'qwen-code': (env) => state(join(home(env), '.qwen'), '.qwen'),

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -176,6 +176,8 @@ const QODER_SEED = (brand: string): readonly string[] => [
 const CLAUDE_MODEL_CACHE_KEYS = ['additionalModelOptionsCache'] as const
 /** DeepSeek Harness auth: the managed 0600 credential store plus its .env fallback. */
 const DSH_SEED = ['.credentials.yaml', '.env'] as const
+/** Antigravity login inputs: the ACP server's auth.type selection, the CLI's OAuth token, and the install identity. */
+const ANTIGRAVITY_SEED = ['settings.json', 'antigravity-oauth-token', 'installation_id'] as const
 /** OpenClaw acp bridge inputs: gateway address + token config and its .env fallback. */
 const OPENCLAW_SEED = ['openclaw.json', '.env'] as const
 
@@ -361,6 +363,14 @@ export const RUNTIME_STATE_LOCATIONS: Record<string, RuntimeStateLocator> = {
     ...state(join(home(env), '.openclaw'), '.openclaw', OPENCLAW_SEED)
   ],
 
+  // Google Antigravity — the ACP server is a separate vendor archive the runtime store installs, so
+  // presence is the product's own state under ~/.gemini: the agy CLI's dir, and the ACP server's own
+  // dir beside it (where it reads auth.type). Conversations, caches, and logs stay agent-private.
+  'antigravity-acp': (env) => [
+    ...state(join(home(env), '.gemini', 'antigravity-acp'), join('.gemini', 'antigravity-acp'), ANTIGRAVITY_SEED),
+    ...state(join(home(env), '.gemini', 'antigravity-cli'), join('.gemini', 'antigravity-cli'), ANTIGRAVITY_SEED)
+  ],
+
   // Cognition Devin (for Terminal) — XDG config + data dirs.
   devin: (env) => [
     ...state(join(xdgConfigHome(env), 'devin'), join('.config', 'devin')),
@@ -429,8 +439,11 @@ export function installedRuntimeCatalog(
   const runtimes: Record<string, RuntimeDef> = {}
   const entries: ResolvedRuntimeCatalog['entries'] = {}
   for (const [id, entry] of Object.entries(catalog.entries)) {
-    const available =
-      entry.source === 'curated' || !CURATED_RUNTIME_IDS.has(id)
+    const available = entry.archive
+      ? // The runtime store fetches this binary, so the command cannot be on `$PATH` yet — the
+        // host signal is the product's own state, exactly as it is for an `npx` adapter.
+        (CUSTOM_PROBES[id]?.(env) ?? false)
+      : entry.source === 'curated' || !CURATED_RUNTIME_IDS.has(id)
         ? isRuntimeAvailable(id, entry.runtime, env)
         : isCommandAvailable(entry.runtime.command, env) && !PACKAGE_LAUNCHERS.has(entry.runtime.command)
     if (!available) continue

--- a/packages/daemon/src/runtimes/probe.ts
+++ b/packages/daemon/src/runtimes/probe.ts
@@ -3,6 +3,7 @@ import { basename, delimiter, join } from 'node:path'
 import { homedir } from 'node:os'
 import type { RuntimeDef } from '../config/config-schema.js'
 import { CURATED_RUNTIME_CATALOG } from './curated.js'
+import { parseArchiveLaunch } from './archive-store.js'
 import type { ResolvedRuntimeCatalog } from './registry.js'
 
 /**
@@ -447,9 +448,11 @@ export function installedRuntimeCatalog(
   const runtimes: Record<string, RuntimeDef> = {}
   const entries: ResolvedRuntimeCatalog['entries'] = {}
   for (const [id, entry] of Object.entries(catalog.entries)) {
-    const available = entry.archive
-      ? // The runtime store fetches this binary, so the command cannot be on `$PATH` yet — the
-        // host signal is the product's own state, exactly as it is for an `npx` adapter.
+    // Ask the store itself whether it can install this entry: an archive format it does not
+    // inflate stays on the command probe below, which is what the host already passes.
+    const available = parseArchiveLaunch(id, entry)
+      ? // The store fetches this binary, so the command cannot be on `$PATH` yet — the host signal
+        // is the product's own state, exactly as it is for an `npx` adapter.
         (CUSTOM_PROBES[id]?.(env) ?? false)
       : entry.source === 'curated' || !CURATED_RUNTIME_IDS.has(id)
         ? isRuntimeAvailable(id, entry.runtime, env)

--- a/packages/daemon/src/runtimes/registry.ts
+++ b/packages/daemon/src/runtimes/registry.ts
@@ -47,6 +47,8 @@ export interface ResolvedRuntimeEntry {
   /** Audited skills CLI identity; absent means this harness has not passed the
    * skill-discovery compatibility admission. */
   skillsAgentId: string | null
+  /** Vendor ZIP this platform's binary comes from; the store installs it and rewrites the command. */
+  archive?: string
 }
 
 export interface ResolvedRuntimeCatalog {
@@ -66,6 +68,12 @@ export function platformKey(): string | null {
   const arch = process.arch === 'arm64' ? 'aarch64' : process.arch === 'x64' ? 'x86_64' : null
   if (!os || !arch) return null
   return `${os}-${arch}`
+}
+
+/** The archive this platform's binary is distributed in, when the entry names one. */
+export function archiveUrl(entry: RegistryEntry): string | undefined {
+  const key = platformKey()
+  return (key ? entry.distribution.binary?.[key]?.archive : undefined) || undefined
 }
 
 export function toRuntimeDef(entry: RegistryEntry): RuntimeDef | null {
@@ -241,7 +249,7 @@ export async function resolveRuntimeCatalog(
   for (const [id, entry] of Object.entries(registry.agents)) {
     const runtime = toRuntimeDef(entry)
     if (!runtime) continue
-    entries[id] = resolvedRuntimeEntry(id, runtime, 'registry', entry.name || id, entry.version)
+    entries[id] = resolvedRuntimeEntry(id, runtime, 'registry', entry.name || id, entry.version, archiveUrl(entry))
   }
   for (const [id, entry] of Object.entries(MANAGED_RUNTIME_CATALOG)) {
     entries[id] = resolvedRuntimeEntry(id, entry.runtime, 'managed', entry.name, entry.version)
@@ -262,7 +270,8 @@ function resolvedRuntimeEntry(
   runtime: RuntimeDef,
   source: RuntimeSource,
   name: string,
-  version: string
+  version: string,
+  archive?: string
 ): ResolvedRuntimeEntry {
   // A user runtime overrides the command/args as well as the id's semantics.
   // Never inherit an audited built-in capability from the reused id: operators
@@ -271,7 +280,7 @@ function resolvedRuntimeEntry(
     source === 'user' && !Object.prototype.hasOwnProperty.call(runtime, 'skillsAgentId')
       ? undefined
       : skillsAgentIdForRuntime(id, runtime)
-  return { runtime, source, name, version, skillsAgentId: skillsAgentId ?? null }
+  return { runtime, source, name, version, skillsAgentId: skillsAgentId ?? null, ...(archive ? { archive } : {}) }
 }
 
 export async function resolveRuntimes(

--- a/packages/daemon/test/archive-store-daemon.test.ts
+++ b/packages/daemon/test/archive-store-daemon.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Daemon } from '../src/daemon.js'
+import { runtimeArchiveTree, type ArchiveLaunch, type StoredRuntimeArchive } from '../src/runtimes/archive-store.js'
+import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
+
+const ID = 'antigravity-acp'
+const URL = 'https://dl.example.test/agy-acp-server-RC01-linux-x86_64.zip'
+const RUNTIME = { command: './agy_acp_server.par', args: ['--uid='], env: [] }
+
+type Probe = { runtimes: Record<string, { command: string; args: string[]; readRoots?: string[] }> }
+
+function scaffold(agentRuntime?: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'ac-archive-daemon-'))
+  writeFileSync(join(root, 'config.json'), JSON.stringify({ version: 1, controlPlane: { enabled: false } }))
+  if (!agentRuntime) return root
+  const dir = join(root, 'agents', 'bot-a')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'agent.json'),
+    JSON.stringify({
+      id: 'bot-a',
+      name: 'bot-a',
+      status: 'active',
+      runtime: agentRuntime,
+      workspace: { mode: 'from-scratch', path: join(dir, 'workspace') },
+      integrations: []
+    })
+  )
+  return root
+}
+
+function catalog(): ResolvedRuntimeCatalog {
+  const entry = {
+    runtime: RUNTIME,
+    source: 'registry' as const,
+    name: 'Google Antigravity',
+    version: '1.0.0',
+    skillsAgentId: null,
+    archive: URL
+  }
+  return { entries: { [ID]: entry }, runtimes: { [ID]: RUNTIME } }
+}
+
+function daemonWith(root: string, ensure: (launch: ArchiveLaunch) => Promise<StoredRuntimeArchive>): Daemon {
+  return new Daemon({
+    root,
+    resolveCatalog: async () => catalog(),
+    installed: (runtimes) => runtimes,
+    archiveStore: { ensure }
+  })
+}
+
+function installed(root: string): StoredRuntimeArchive {
+  const tree = runtimeArchiveTree(root, ID, '1.0.0')
+  return { tree, version: '1.0.0', bin: join(tree, 'agy_acp_server.par') }
+}
+
+describe('daemon-owned vendor archive store', () => {
+  it('installs at start and launches the extracted binary, not the registry `./cmd`', async () => {
+    const root = scaffold(ID)
+    const stored = installed(root)
+    const seen: ArchiveLaunch[] = []
+    const daemon = daemonWith(root, async (launch) => {
+      seen.push(launch)
+      return stored
+    })
+    await daemon.start()
+
+    // One install for the whole daemon lifetime — a host spawn re-reads this def, never re-fetches.
+    expect(seen).toEqual([{ id: ID, url: URL, version: '1.0.0', bin: 'agy_acp_server.par', args: ['--uid='] }])
+    const runtime = (daemon as unknown as Probe).runtimes[ID]!
+    expect(runtime.command).toBe(stored.bin)
+    expect(runtime.args).toEqual(['--uid='])
+    // The outer sandbox denies the daemon root, so the store tree comes back as a read root.
+    expect(runtime.readRoots).toEqual([stored.tree])
+    await daemon.stop()
+  })
+
+  it('fetches nothing at start for a runtime no agent uses, and installs it once on first start', async () => {
+    const root = scaffold()
+    const stored = installed(root)
+    let calls = 0
+    const daemon = daemonWith(root, async () => {
+      calls += 1
+      return stored
+    })
+    await daemon.start()
+    expect(calls).toBe(0)
+    expect((daemon as unknown as Probe).runtimes[ID]!.command).toBe('./agy_acp_server.par')
+
+    const localize = (daemon as unknown as { ensureRuntimeInstalled(id: string): Promise<void> }).ensureRuntimeInstalled
+    await localize.call(daemon, ID)
+    await localize.call(daemon, ID)
+    expect(calls).toBe(1)
+    expect((daemon as unknown as Probe).runtimes[ID]!.command).toBe(stored.bin)
+    await daemon.stop()
+  })
+
+  it('refuses to launch when the archive install failed, in one path-free line', async () => {
+    const root = scaffold(ID)
+    const daemon = daemonWith(root, async () => {
+      throw new Error(`archive for ${ID}@1.0.0 contains no "agy_acp_server.par"`)
+    })
+    await daemon.start()
+
+    expect((daemon as unknown as Probe).runtimes[ID]).toBeUndefined()
+    const message = (daemon as unknown as { runtimeUnavailableMessage(id: string): string }).runtimeUnavailableMessage(
+      ID
+    )
+    expect(message).toContain(`${ID}@1.0.0`)
+    expect(message).not.toContain('\n')
+    expect(message).not.toContain(root)
+    await daemon.stop()
+  })
+})

--- a/packages/daemon/test/archive-store.test.ts
+++ b/packages/daemon/test/archive-store.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { zipSync } from 'fflate'
+import {
+  ArchiveStore,
+  installedArchiveBin,
+  installedArchiveVersions,
+  parseArchiveLaunch,
+  runtimeArchiveTree,
+  storedArchiveRuntimeDef,
+  type ArchiveFetch,
+  type ArchiveLaunch
+} from '../src/runtimes/archive-store.js'
+import { runtimeStoreDir } from '../src/paths.js'
+import type { ResolvedRuntimeEntry } from '../src/runtimes/registry.js'
+
+const URL_A = 'https://dl.example.test/agy-acp-server-RC01-linux-x86_64.zip'
+const URL_B = 'https://dl.example.test/agy-acp-server-RC02-linux-x86_64.zip'
+
+function root(): string {
+  return mkdtempSync(join(tmpdir(), 'ac-archive-'))
+}
+
+/** The resolved entry the ACP registry produces for a binary distribution with an archive. */
+function entry(overrides: Partial<ResolvedRuntimeEntry> = {}): ResolvedRuntimeEntry {
+  return {
+    runtime: { command: './agy_acp_server.par', args: ['--uid='], env: [] },
+    source: 'registry',
+    name: 'Google Antigravity',
+    version: '1.0.0',
+    skillsAgentId: null,
+    archive: URL_A,
+    ...overrides
+  }
+}
+
+/** A fetch that answers with a real ZIP of `files`, and records every URL it was asked for. */
+function fakeFetch(files: Record<string, string>, calls: string[] = []): { fetchImpl: ArchiveFetch; calls: string[] } {
+  const zipped = zipSync(Object.fromEntries(Object.entries(files).map(([n, c]) => [n, Buffer.from(c)])))
+  const fetchImpl: ArchiveFetch = async (url) => {
+    calls.push(url)
+    return new Response(new Uint8Array(zipped), { status: 200 })
+  }
+  return { fetchImpl, calls }
+}
+
+const PAR = { 'agy_acp_server.par': '#!par\n', localharness_external: 'data' }
+
+const launch = (): ArchiveLaunch => parseArchiveLaunch('antigravity-acp', entry())!
+
+describe('parseArchiveLaunch', () => {
+  it('decomposes the antigravity registry entry', () => {
+    expect(parseArchiveLaunch('antigravity-acp', entry())).toEqual({
+      id: 'antigravity-acp',
+      url: URL_A,
+      version: '1.0.0',
+      bin: 'agy_acp_server.par',
+      args: ['--uid=']
+    })
+  })
+
+  it('digests the URL when the entry version cannot name a tree', () => {
+    const launch = parseArchiveLaunch('antigravity-acp', entry({ version: '' }))
+    expect(launch?.version).toMatch(/^[0-9a-f]{12}$/)
+    // A moved build must not land in the tree the previous one owns.
+    const moved = parseArchiveLaunch('antigravity-acp', entry({ version: '', archive: URL_B }))
+    expect(moved?.version).not.toEqual(launch?.version)
+  })
+
+  it('refuses an entry that is not an https archive of one flat binary', () => {
+    expect(parseArchiveLaunch('antigravity-acp', entry({ archive: undefined }))).toBeUndefined()
+    expect(parseArchiveLaunch('antigravity-acp', entry({ archive: 'http://dl.example.test/a.zip' }))).toBeUndefined()
+    expect(parseArchiveLaunch('antigravity-acp', entry({ archive: 'file:///tmp/a.zip' }))).toBeUndefined()
+    expect(parseArchiveLaunch('../escape', entry())).toBeUndefined()
+    const nested = { command: './nested/../../etc/passwd', args: [], env: [] }
+    expect(parseArchiveLaunch('antigravity-acp', entry({ runtime: nested }))).toBeUndefined()
+  })
+})
+
+describe('ArchiveStore', () => {
+  it('extracts the archive into the store and launches the binary by absolute path', async () => {
+    const dir = root()
+    const { fetchImpl, calls } = fakeFetch(PAR)
+    const installed = await new ArchiveStore({ root: dir, fetchImpl }).ensure(launch())
+
+    const tree = runtimeArchiveTree(dir, 'antigravity-acp', '1.0.0')
+    expect(installed).toEqual({ tree, version: '1.0.0', bin: join(tree, 'agy_acp_server.par') })
+    expect(readFileSync(installed.bin, 'utf8')).toBe('#!par\n')
+    expect(existsSync(join(tree, 'localharness_external'))).toBe(true)
+    expect(calls).toEqual([URL_A])
+    // No staging directory survives a successful install.
+    expect(existsSync(join(runtimeStoreDir(dir), '.staging'))).toBe(false)
+  })
+
+  it.skipIf(process.platform === 'win32')('gives every extracted member the execute bit', async () => {
+    const dir = root()
+    const { fetchImpl } = fakeFetch(PAR)
+    const installed = await new ArchiveStore({ root: dir, fetchImpl }).ensure(launch())
+    expect(statSync(installed.bin).mode & 0o111).toBe(0o111)
+  })
+
+  it('fetches once per archive and reuses the install across stores', async () => {
+    const dir = root()
+    const { fetchImpl, calls } = fakeFetch(PAR)
+    const store = new ArchiveStore({ root: dir, fetchImpl })
+    const [a, b] = await Promise.all([store.ensure(launch()), store.ensure(launch())])
+    expect(a).toEqual(b)
+    // A restarted daemon finds the tree the last one left and never fetches again.
+    await new ArchiveStore({ root: dir, fetchImpl }).ensure(launch())
+    expect(calls).toEqual([URL_A])
+  })
+
+  it('reinstalls when the vendor moves the build behind the same version', async () => {
+    const dir = root()
+    const first = fakeFetch(PAR)
+    await new ArchiveStore({ root: dir, fetchImpl: first.fetchImpl }).ensure(launch())
+    const moved = parseArchiveLaunch('antigravity-acp', entry({ archive: URL_B }))!
+    const second = fakeFetch({ 'agy_acp_server.par': '#!rc02\n' })
+    const installed = await new ArchiveStore({ root: dir, fetchImpl: second.fetchImpl }).ensure(moved)
+    expect(readFileSync(installed.bin, 'utf8')).toBe('#!rc02\n')
+    expect(second.calls).toEqual([URL_B])
+  })
+
+  it('drops the versions this daemon no longer launches', async () => {
+    const dir = root()
+    const stale = runtimeArchiveTree(dir, 'antigravity-acp', '0.9.0')
+    mkdirSync(stale, { recursive: true })
+    writeFileSync(join(stale, 'agy_acp_server.par'), 'old')
+    const { fetchImpl } = fakeFetch(PAR)
+    await new ArchiveStore({ root: dir, fetchImpl }).ensure(launch())
+    expect(installedArchiveVersions(dir, 'antigravity-acp')).toEqual(['1.0.0'])
+    expect(existsSync(stale)).toBe(false)
+  })
+
+  it('leaves no install when the archive lacks the binary the registry named', async () => {
+    const dir = root()
+    const { fetchImpl } = fakeFetch({ readme: 'nothing to launch' })
+    await expect(new ArchiveStore({ root: dir, fetchImpl }).ensure(launch())).rejects.toThrow(
+      /contains no "agy_acp_server\.par"/
+    )
+    expect(installedArchiveVersions(dir, 'antigravity-acp')).toEqual([])
+  })
+
+  it('refuses an archive member that is not a flat file name', async () => {
+    const dir = root()
+    const { fetchImpl } = fakeFetch({ '../escape.par': 'x' })
+    await expect(new ArchiveStore({ root: dir, fetchImpl }).ensure(launch())).rejects.toThrow(/flat file name/)
+    expect(existsSync(runtimeArchiveTree(dir, 'antigravity-acp', '1.0.0'))).toBe(false)
+  })
+
+  it('leaves no install when the fetch fails', async () => {
+    const dir = root()
+    const fetchImpl: ArchiveFetch = async () => new Response(null, { status: 404 })
+    await expect(new ArchiveStore({ root: dir, fetchImpl }).ensure(launch())).rejects.toThrow(/HTTP 404/)
+    expect(installedArchiveVersions(dir, 'antigravity-acp')).toEqual([])
+  })
+})
+
+describe('installedArchiveBin', () => {
+  it('reports nothing for a tree with no marker, a foreign URL, or a missing binary', async () => {
+    const dir = root()
+    const { fetchImpl } = fakeFetch(PAR)
+    await new ArchiveStore({ root: dir, fetchImpl }).ensure(launch())
+    const tree = runtimeArchiveTree(dir, 'antigravity-acp', '1.0.0')
+    expect(installedArchiveBin(tree, launch())).toBe(join(tree, 'agy_acp_server.par'))
+    expect(installedArchiveBin(tree, parseArchiveLaunch('antigravity-acp', entry({ archive: URL_B }))!)).toBeUndefined()
+    expect(installedArchiveBin(join(dir, 'absent'), launch())).toBeUndefined()
+  })
+})
+
+describe('storedArchiveRuntimeDef', () => {
+  it('launches the stored binary and carves its tree back into the sandbox', () => {
+    const runtime = { command: './agy_acp_server.par', args: ['--uid='], env: [] }
+    const installed = {
+      tree: '/root/runtimes/antigravity-acp@1.0.0',
+      version: '1.0.0',
+      bin: '/root/runtimes/antigravity-acp@1.0.0/agy_acp_server.par'
+    }
+    expect(storedArchiveRuntimeDef(runtime, installed)).toEqual({
+      command: installed.bin,
+      args: ['--uid='],
+      env: [],
+      readRoots: [installed.tree]
+    })
+  })
+})

--- a/packages/daemon/test/archive-store.test.ts
+++ b/packages/daemon/test/archive-store.test.ts
@@ -69,6 +69,19 @@ describe('parseArchiveLaunch', () => {
     expect(moved?.version).not.toEqual(launch?.version)
   })
 
+  it('leaves a non-ZIP archive unclassified, so its command probe still applies', () => {
+    // The registry publishes plenty of these; the store inflates ZIP only, and claiming a `.tar.gz`
+    // entry here would drop an install that launches from `$PATH` (amp-acp, opencode, kimi, goose…).
+    const amp = { command: './amp-acp', args: [], env: [] }
+    const tar = 'https://packages.example.test/amp-acp-linux-x86_64.tar.gz'
+    expect(parseArchiveLaunch('amp-acp', entry({ runtime: amp, archive: tar }))).toBeUndefined()
+    expect(parseArchiveLaunch('goose', entry({ archive: 'https://x.example.test/goose.tar.bz2' }))).toBeUndefined()
+    // A bare binary with no archive extension at all (sigit publishes these).
+    expect(parseArchiveLaunch('sigit', entry({ archive: 'https://x.example.test/sigit-linux-amd64' }))).toBeUndefined()
+    // A query string must not defeat the check either way round.
+    expect(parseArchiveLaunch('antigravity-acp', entry({ archive: `${URL_A}?v=2` }))?.bin).toBe('agy_acp_server.par')
+  })
+
   it('refuses an entry that is not an https archive of one flat binary', () => {
     expect(parseArchiveLaunch('antigravity-acp', entry({ archive: undefined }))).toBeUndefined()
     expect(parseArchiveLaunch('antigravity-acp', entry({ archive: 'http://dl.example.test/a.zip' }))).toBeUndefined()

--- a/packages/daemon/test/chat.test.ts
+++ b/packages/daemon/test/chat.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Writable } from 'node:stream'
+import { zipSync } from 'fflate'
 import { runChat } from '../src/cli/chat.js'
 import type { AcpHost } from '../src/acp/acp-host.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
@@ -153,6 +154,48 @@ describe('runChat', () => {
     await expect(runChat({ agentsDir, message: 'hi', configPath, root, out: capture().stream })).rejects.toThrow(
       /runtime "missing".*Available: .*fake/s
     )
+  })
+
+  it('installs an archive-distributed runtime into the store rather than launching the registry ./cmd', async () => {
+    const files = scaffold()
+    const runtime = { command: './agy_acp_server.par', args: ['--uid='], env: [] }
+    const zipped = zipSync({ 'agy_acp_server.par': Buffer.from('#!par\n') })
+    const fetchStub = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(new Uint8Array(zipped), { status: 200 }))
+    let launched: { command: string; args: string[]; readRoots?: string[] } | undefined
+    try {
+      await runChat({
+        ...files,
+        message: 'hi',
+        out: capture().stream,
+        resolveCatalog: async () => ({
+          entries: {
+            fake: {
+              runtime,
+              source: 'registry',
+              name: 'Google Antigravity',
+              version: '1.0.0',
+              skillsAgentId: null,
+              archive: 'https://dl.example.test/agy-acp-server-linux-x86_64.zip'
+            }
+          },
+          runtimes: { fake: runtime }
+        }),
+        installed: (runtimes) => runtimes,
+        hostFactory: (rt) => {
+          launched = rt
+          return quietHost()
+        }
+      })
+    } finally {
+      fetchStub.mockRestore()
+    }
+    // `installedRuntimeCatalog` admits this on the product's state, so the launch path has to
+    // localize it too — otherwise the spawn runs a relative path that resolves to nothing.
+    expect(launched?.command).toMatch(/runtimes[/\\]fake@1\.0\.0[/\\]agy_acp_server\.par$/)
+    expect(launched?.args).toEqual(['--uid='])
+    expect(existsSync(launched!.command)).toBe(true)
   })
 
   it('errors and asks for --agent when several agents are discovered', async () => {

--- a/packages/daemon/test/probe.test.ts
+++ b/packages/daemon/test/probe.test.ts
@@ -310,6 +310,29 @@ describe('installedRuntimes', () => {
     expect(Object.keys(installedRuntimes(all, env())).sort()).toEqual(['binary-agent', 'claude-acp'])
   })
 
+  it('gates an archive-distributed runtime on its own state, not on the command the store fetches', () => {
+    // `./agy_acp_server.par` cannot be on PATH before the runtime store extracts it, so the host
+    // signal is ~/.gemini/antigravity-* — the product itself being installed and initialized here.
+    const runtime: RuntimeDef = { command: './agy_acp_server.par', args: ['--uid='], env: [] }
+    const catalog = (): ResolvedRuntimeCatalog => ({
+      entries: {
+        'antigravity-acp': {
+          runtime,
+          source: 'registry',
+          name: 'Google Antigravity',
+          version: '1.0.0',
+          skillsAgentId: null,
+          archive: 'https://dl.example.test/agy-acp-server.zip'
+        }
+      },
+      runtimes: { 'antigravity-acp': runtime }
+    })
+
+    expect(Object.keys(installedRuntimeCatalog(catalog(), env()).runtimes)).toEqual([])
+    mkdirSync(join(home, '.gemini', 'antigravity-cli'), { recursive: true })
+    expect(Object.keys(installedRuntimeCatalog(catalog(), env()).runtimes)).toEqual(['antigravity-acp'])
+  })
+
   it('applies curated state gates only when the curated source wins', () => {
     makeExecutable(binDir, 'hermes')
     makeExecutable(binDir, 'custom-hermes')

--- a/packages/daemon/test/probe.test.ts
+++ b/packages/daemon/test/probe.test.ts
@@ -310,6 +310,18 @@ describe('installedRuntimes', () => {
     expect(Object.keys(installedRuntimes(all, env())).sort()).toEqual(['binary-agent', 'claude-acp'])
   })
 
+  it('does not read an Antigravity install as a Gemini CLI one, though they share ~/.gemini', () => {
+    makeExecutable(binDir, 'npx')
+    const gemini: RuntimeDef = { command: 'npx', args: ['-y', '@google/gemini-cli', '--acp'], env: [] }
+    // What `agy` itself writes: the shared root exists, but no Gemini CLI file in it does.
+    mkdirSync(join(home, '.gemini', 'antigravity-cli'), { recursive: true })
+    mkdirSync(join(home, '.gemini', 'config'), { recursive: true })
+    expect(isRuntimeAvailable('gemini', gemini, env())).toBe(false)
+
+    writeFileSync(join(home, '.gemini', 'settings.json'), '{}')
+    expect(isRuntimeAvailable('gemini', gemini, env())).toBe(true)
+  })
+
   it('gates an archive-distributed runtime on its own state, not on the command the store fetches', () => {
     // `./agy_acp_server.par` cannot be on PATH before the runtime store extracts it, so the host
     // signal is ~/.gemini/antigravity-* — the product itself being installed and initialized here.

--- a/packages/daemon/test/probe.test.ts
+++ b/packages/daemon/test/probe.test.ts
@@ -322,6 +322,30 @@ describe('installedRuntimes', () => {
     expect(isRuntimeAvailable('gemini', gemini, env())).toBe(true)
   })
 
+  it('keeps the command probe for an archive format the store cannot install', () => {
+    // opencode/amp/kimi ship `.tar.gz` on Linux with a flat `./cmd`. The store inflates ZIP only,
+    // so these must stay on the probe they already pass rather than be admitted and then dropped.
+    makeExecutable(binDir, 'amp-acp')
+    const runtime: RuntimeDef = { command: './amp-acp', args: [], env: [] }
+    const catalog = (): ResolvedRuntimeCatalog => ({
+      entries: {
+        'amp-acp': {
+          runtime,
+          source: 'registry',
+          name: 'Amp',
+          version: '0.1.0',
+          skillsAgentId: null,
+          archive: 'https://packages.example.test/amp-acp-linux-x86_64.tar.gz'
+        }
+      },
+      runtimes: { 'amp-acp': runtime }
+    })
+
+    // On PATH and initialized → kept, exactly as before archives were classified at all.
+    mkdirSync(join(home, '.config', 'amp'), { recursive: true })
+    expect(Object.keys(installedRuntimeCatalog(catalog(), env()).runtimes)).toEqual(['amp-acp'])
+  })
+
   it('gates an archive-distributed runtime on its own state, not on the command the store fetches', () => {
     // `./agy_acp_server.par` cannot be on PATH before the runtime store extracts it, so the host
     // signal is ~/.gemini/antigravity-* — the product itself being installed and initialized here.


### PR DESCRIPTION
## What

The ACP registry distributes some agents as a signed vendor binary in a ZIP rather than an
npm package. The daemon parsed that `archive` field and dropped it, so such an entry
resolved to a command no host has on `$PATH` — `antigravity-acp` resolved to
`./agy_acp_server.par` and was never probed and never launchable, however installed Google
Antigravity was on the machine.

Two commits:

**`feat(daemon)`: install a registry binary's vendor archive, so Antigravity probes**

- `runtimes/archive-store.ts` — the missing half of the runtime store, one layer below the
  `npx` store it mirrors: one install per (id, version) under the daemon root, streamed
  into staging and renamed so a partial tree is never visible as an install, launched by
  absolute path with the tree carved back as a read root. A `.archive.json` marker records
  the URL, so a build moved behind an unchanged version reinstalls instead of being reused.
  https only, flat archive members only, only the member the registry named, with file
  count and expanded bytes bounded.
- `runtimes/registry.ts` — `archiveUrl(entry)`, carried on `ResolvedRuntimeEntry.archive`.
- `runtimes/probe.ts` — `antigravity-acp` probes the product's own state under `~/.gemini`
  (seeding narrowed to settings / OAuth token / installation id), and an archive entry
  skips the command check that cannot pass before the store has run. Presence stays a
  separate question from installability, exactly as it is for an `npx` adapter.
- `daemon.ts` — the start-time sweep and `ensureRuntimeInstalled` now recognize both launch
  shapes; `vendorArchiveStore()` is skipped under `--k8s` and an injected host factory for
  the same reasons `adapterStore()` is. Nothing is fetched for a runtime no agent uses; a
  later assignment installs it before its first host start. A failed install leaves the
  catalog and `runtimeUnavailableMessage` reports it in one path-free line, unchanged.

**`fix(daemon)`: stop reading an Antigravity install as a Gemini CLI one**

`~/.gemini` is not the Gemini CLI's alone — the Antigravity CLI keeps its whole state under
it (`antigravity-cli/`, `config/`, and the ACP server's `antigravity-acp/`). The `gemini`
probe tested that shared root, so installing `agy` made the daemon advertise `gemini` to the
control plane on a host with no Gemini CLI at all. Since that runtime is `npx`-distributed
the state probe is its only gate, so an agent assigned it would fetch the package and fail
on a login that was never there. Probe the CLI's own top-level files instead, plus `tmp/` as
a ran-here marker with an empty seed allowlist.

## Verification

- `typecheck` clean; 11 runtime-adjacent suites, 220 passed.
- New: `test/archive-store.test.ts` (13 cases — parsing, URL-digest version fallback,
  refusing http/file/non-flat members, real ZIP extraction, execute bit, one fetch per
  archive, reuse across a restart, reinstall on a moved build, prune, and no residual tree
  after a missing bin / bad member / HTTP 404), `test/archive-store-daemon.test.ts`
  (3 cases — install at start rewrites the launch def and read roots, nothing fetched for an
  unused runtime, path-free refusal after a failed install), plus two `probe.test.ts` cases
  for the archive gate and the Gemini/Antigravity split.
- Verified end to end on a real host against `dl.google.com`: probed from an `agy` install,
  543 MB fetched once, reused in 0 s afterwards, and the rewritten launch def handshakes
  `initialize` as `agy_acp_server_20260818_01_RC01`.

## Not in scope

Running a full session through Antigravity is unverified: its ACP server needs an `auth.type`
selection in `~/.gemini/antigravity-acp/settings.json` and then waits on an OAuth flow. That
is the operator's login step, not a daemon concern. Its `mcpCapabilities: {http, sse}` is
additive over ACP's mandatory stdio baseline, so the daemon's stdio bridge needs no change.
