### PR TITLE
fix(daemon): install a vendor archive for the probe sweep, not only for an agent's first start

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -17822,6 +17822,7 @@ export class Daemon {
       updateCapabilities: () => this.cpClient?.updateCapabilities?.(),
       mcpServerFacts: () => this.mcpServerFactsFromDefs(),
       noteCatalogProbe: (input) => void this.modelCatalogSvc?.noteProbe(input),
+      localizeRuntime: (runtimeId) => this.ensureRuntimeInstalled(runtimeId),
       launch: () => ({
         k8s: this.k8s,
         fakeHosts: this.opts.hostFactory !== undefined,

--- a/packages/daemon/src/runtimes/facts-registry.ts
+++ b/packages/daemon/src/runtimes/facts-registry.ts
@@ -19,6 +19,7 @@ import { runtimeSandboxReadRoots } from '../launch/compose.js'
 import { capsFromConfigOptions, augmentEffortOptions } from './config-caps.js'
 import { isClaudeRuntimeDef } from '../runtime-defs/claude-runtime.js'
 import { catalogFingerprint } from './model-catalog.js'
+import { parseArchiveLaunch } from './archive-store.js'
 import { mcpSocketPath } from '../paths.js'
 import { formatErr } from '../daemon/text.js'
 
@@ -68,6 +69,8 @@ export interface RuntimeFactsHost {
   updateCapabilities(): void
   mcpServerFacts(): FactsMcpServer[]
   noteCatalogProbe(input: { runtimeId: string; rt: RuntimeDef; probedVersion?: string; models: string[] }): void
+  /** Install a runtime's daemon-owned adapter, so the sweep probes what a session would launch. */
+  localizeRuntime(runtimeId: string): Promise<void>
   launch(): RuntimeProbeLaunchContext
 }
 
@@ -358,11 +361,27 @@ export class RuntimeFactsRegistry {
       return
     }
 
+    // A vendor-archive runtime is not launchable until the store extracts it, and this sweep is
+    // exactly what needs its model list — so install it here rather than at start-up, and probe the
+    // localized command a session would launch. `parseArchiveLaunch` answers only for an entry the
+    // store has not rewritten yet, and the store memoizes, so a concurrent sweep installs once.
+    // A failed install drops the id from the catalog, reported where the install happened.
+    let entries = catalog.entries
+    if (includeOrdinary && !fresh) {
+      const pending = Object.entries(entries)
+        .filter(([id, entry]) => entry.source !== 'curated' && parseArchiveLaunch(id, entry))
+        .map(([id]) => id)
+      if (pending.length > 0) {
+        log.info(`probe: installing vendor archive(s) before probing: ${pending.join(', ')}`)
+        for (const id of pending) await this.host.localizeRuntime(id)
+        entries = this.host.catalog().entries
+      }
+    }
     const ordinaryRuntimes =
       !includeOrdinary || fresh
         ? {}
         : Object.fromEntries(
-            Object.entries(catalog.entries)
+            Object.entries(entries)
               .filter(([, entry]) => entry.source !== 'curated')
               .map(([id, entry]) => [id, entry.runtime])
           )

--- a/packages/daemon/src/runtimes/facts-registry.ts
+++ b/packages/daemon/src/runtimes/facts-registry.ts
@@ -361,27 +361,11 @@ export class RuntimeFactsRegistry {
       return
     }
 
-    // A vendor-archive runtime is not launchable until the store extracts it, and this sweep is
-    // exactly what needs its model list — so install it here rather than at start-up, and probe the
-    // localized command a session would launch. `parseArchiveLaunch` answers only for an entry the
-    // store has not rewritten yet, and the store memoizes, so a concurrent sweep installs once.
-    // A failed install drops the id from the catalog, reported where the install happened.
-    let entries = catalog.entries
-    if (includeOrdinary && !fresh) {
-      const pending = Object.entries(entries)
-        .filter(([id, entry]) => entry.source !== 'curated' && parseArchiveLaunch(id, entry))
-        .map(([id]) => id)
-      if (pending.length > 0) {
-        log.info(`probe: installing vendor archive(s) before probing: ${pending.join(', ')}`)
-        for (const id of pending) await this.host.localizeRuntime(id)
-        entries = this.host.catalog().entries
-      }
-    }
     const ordinaryRuntimes =
       !includeOrdinary || fresh
         ? {}
         : Object.fromEntries(
-            Object.entries(entries)
+            Object.entries(catalog.entries)
               .filter(([, entry]) => entry.source !== 'curated')
               .map(([id, entry]) => [id, entry.runtime])
           )
@@ -416,6 +400,18 @@ export class RuntimeFactsRegistry {
             log,
             hostFactory: probeHostFactory,
             onResult,
+            // A vendor-archive runtime is not launchable until the store extracts it, and this sweep
+            // is exactly what needs its model list — so install it inside its own probe slot rather
+            // than at start-up or ahead of the batch. `parseArchiveLaunch` answers only for an entry
+            // the store has not rewritten yet; a failed install drops the id from the catalog and is
+            // reported where the install happened, so that runtime simply gets no probe.
+            resolveRuntime: async (id, rt) => {
+              const entry = catalog.entries[id]
+              if (!entry || !parseArchiveLaunch(id, entry)) return rt
+              log.info(`probe: installing the vendor archive for "${id}" before probing it`)
+              await this.host.localizeRuntime(id)
+              return this.host.catalog().entries[id]?.runtime
+            },
             launchFor: (id, runtime, scopeDir, cwd) => {
               const runInSandbox = effectiveRunInSandbox(
                 launch.requireSandbox ?? false,

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -181,6 +181,9 @@ export interface ProbeOptions {
   agentsRoot?: string
   sandboxMechanism?: SandboxMechanism
   mcpSocketPath?: string
+  /** Resolve the def to probe, just before spawning — an archive-distributed runtime installs here.
+   *  Undefined means the runtime is no longer launchable and gets no probe at all. */
+  resolveRuntime?: (id: string, rt: RuntimeDef) => Promise<RuntimeDef | undefined>
   /** Prepare the same sandbox/private-HOME or inherited-host launch used by a real agent. */
   launchFor?: (
     id: string,
@@ -631,10 +634,14 @@ export async function probeAllRuntimes(
   const worker = async (): Promise<void> => {
     for (let i = next++; i < ids.length; i = next++) {
       const id = ids[i]!
+      // Resolved inside this worker: a vendor archive installing on demand occupies one probe slot
+      // instead of the whole sweep, and sits outside the per-runtime deadline probeRuntime applies.
+      const rt = opts.resolveRuntime ? await opts.resolveRuntime(id, runtimes[id]!) : runtimes[id]!
+      if (!rt) continue
       const runtimeDir = join(cwd, Buffer.from(id).toString('base64url'))
       const runtimeCwd = join(runtimeDir, 'workspace')
       mkdirSync(runtimeCwd, { recursive: true })
-      const result = await probeRuntime(id, runtimes[id]!, runtimeCwd, opts)
+      const result = await probeRuntime(id, rt, runtimeCwd, opts)
       results.push(result)
       try {
         opts.onResult?.(result)

--- a/packages/daemon/test/archive-store-daemon.test.ts
+++ b/packages/daemon/test/archive-store-daemon.test.ts
@@ -117,11 +117,16 @@ describe('daemon-owned vendor archive store', () => {
           return stored
         }
       },
-      probeRuntimes: async (runtimes) =>
-        Object.entries(runtimes).map(([id, rt]) => {
-          probed[id] = rt.command
-          return { runtime: id, ok: true, models: ['gemini-3-pro'] }
-        })
+      // Mirrors probeAllRuntimes: each runtime is resolved in its own slot just before spawning.
+      probeRuntimes: async (runtimes, opts) => {
+        const results = []
+        for (const [id, rt] of Object.entries(runtimes)) {
+          const resolved = (await opts.resolveRuntime?.(id, rt)) ?? rt
+          probed[id] = resolved.command
+          results.push({ runtime: id, ok: true, models: ['gemini-3-pro'] })
+        }
+        return results
+      }
     })
     await daemon.start()
     expect(calls).toBe(0) // nothing at start — no agent uses it

--- a/packages/daemon/test/archive-store-daemon.test.ts
+++ b/packages/daemon/test/archive-store-daemon.test.ts
@@ -99,6 +99,46 @@ describe('daemon-owned vendor archive store', () => {
     await daemon.stop()
   })
 
+  it('installs the archive for the probe sweep, so its model list is read from the extracted binary', async () => {
+    // The sweep is what fills the model catalog the console offers, and it launches every admitted
+    // runtime — including one no agent uses yet. Without the install it would spawn the registry's
+    // relative `./cmd` and report a bogus "executable is not available" against a live runtime.
+    const root = scaffold()
+    const stored = installed(root)
+    let calls = 0
+    const probed: Record<string, string> = {}
+    const daemon = new Daemon({
+      root,
+      resolveCatalog: async () => catalog(),
+      installed: (runtimes) => runtimes,
+      archiveStore: {
+        ensure: async () => {
+          calls += 1
+          return stored
+        }
+      },
+      probeRuntimes: async (runtimes) =>
+        Object.entries(runtimes).map(([id, rt]) => {
+          probed[id] = rt.command
+          return { runtime: id, ok: true, models: ['gemini-3-pro'] }
+        })
+    })
+    await daemon.start()
+    expect(calls).toBe(0) // nothing at start — no agent uses it
+    await (
+      daemon as unknown as { runtimeFacts: { probeAndEmit(o: boolean): Promise<void> } }
+    ).runtimeFacts.probeAndEmit(true)
+
+    expect(calls).toBe(1)
+    expect(probed[ID]).toBe(stored.bin)
+    expect(
+      (
+        daemon as unknown as { runtimeFacts: { offeredModels(id: string): string[] | undefined } }
+      ).runtimeFacts.offeredModels(ID)
+    ).toEqual(['gemini-3-pro'])
+    await daemon.stop()
+  })
+
   it('refuses to launch when the archive install failed, in one path-free line', async () => {
     const root = scaffold(ID)
     const daemon = daemonWith(root, async () => {

--- a/packages/daemon/test/runtime-prober.test.ts
+++ b/packages/daemon/test/runtime-prober.test.ts
@@ -378,6 +378,63 @@ describe('probeAllRuntimes', () => {
     expect(results.every((r) => r.ok)).toBe(true)
   })
 
+  // A vendor archive installs on demand inside the sweep. It must occupy one probe slot, not the
+  // whole batch: the runtimes that need no install answer while the download is still running.
+  it('resolves each runtime inside its own slot, so an on-demand install delays only itself', async () => {
+    let releaseInstall = (): void => {}
+    const install = new Promise<void>((resolve) => {
+      releaseInstall = resolve
+    })
+    const reported: string[] = []
+    const sweep = probeAllRuntimes(
+      { fast: rt, installing: rt },
+      {
+        concurrency: 2,
+        hostFactory: () => fakeHost({}),
+        onResult: (result) => reported.push(result.runtime),
+        resolveRuntime: async (id, runtime) => {
+          if (id !== 'installing') return runtime
+          await install
+          return { ...runtime, command: '/store/installing/bin' }
+        }
+      }
+    )
+    await vi.waitFor(() => expect(reported).toEqual(['fast']))
+    releaseInstall()
+    const results = await sweep
+    expect(reported).toEqual(['fast', 'installing'])
+    expect(results.every((r) => r.ok)).toBe(true)
+  })
+
+  it('gives no probe at all to a runtime whose on-demand install left it unlaunchable', async () => {
+    const results = await probeAllRuntimes(
+      { a: rt, gone: rt },
+      {
+        concurrency: 1,
+        hostFactory: () => fakeHost({}),
+        resolveRuntime: async (id, runtime) => (id === 'gone' ? undefined : runtime)
+      }
+    )
+    // Not a failed result: the install path already reported why, and a dropped catalog entry
+    // must not come back as a probe error against a runtime the daemon no longer offers.
+    expect(results.map((r) => r.runtime)).toEqual(['a'])
+  })
+
+  it('probes the def the resolver returns, not the one the sweep was handed', async () => {
+    const seen: string[] = []
+    await probeAllRuntimes(
+      { a: rt },
+      {
+        hostFactory: (runtime) => {
+          seen.push(runtime.command)
+          return fakeHost({})
+        },
+        resolveRuntime: async (_id, runtime) => ({ ...runtime, command: '/store/a@1.0.0/agent' })
+      }
+    )
+    expect(seen).toEqual(['/store/a@1.0.0/agent'])
+  })
+
   it('keeps probing when a result callback throws', async () => {
     const warn = vi.fn()
     const results = await probeAllRuntimes(


### PR DESCRIPTION
## What

Follow-up to #1788, from a failure observed on a live daemon (`1.53.0-rc.20`) minutes after it
landed. The daemon advertised the runtime correctly — `runtimes ready: antigravity-acp, …`, and the
control plane stored `"Google Antigravity"` in its capabilities — and then the probe sweep said:

```
probe: sweeping 10 runtime(s): antigravity-acp, claude-acp, …
WARN  probe: antigravity-acp failed — trusted runtime executable is not available: .<path>
```

The archive store installs only what an agent already uses. But the sweep launches **every** admitted
runtime, including ones no agent uses yet, because the sweep is what fills the model catalog the
console offers. So it spawned the registry's relative `./agy_acp_server.par` and reported a failure
against a runtime that is genuinely installed — leaving it in the console with no models and a
spurious error.

`npx`-distributed runtimes never showed this: their launcher is on `$PATH` and fetches on demand, so
an un-installed one probes fine. An archive runtime has nothing to spawn until the store extracts it.

## Change

The sweep localizes an archive runtime before probing it, via the same `ensureRuntimeInstalled` an
agent's first start already uses (`RuntimeFactsHost.localizeRuntime`).

This belongs in the sweep rather than at start-up: the sweep already runs in the background and
applies each result as it lands — its own comment notes that a package-launcher runtime can take
minutes to build its install tree, which is why per-result frames converge instead of the sweep
being awaited — so `runtimes ready` is never held behind a vendor download.

`parseArchiveLaunch` answers only for an entry the store has **not** rewritten yet (a localized entry
has an absolute command, which fails its flat-name rule), so it doubles as the "still needs
installing" predicate; a localized runtime is probed directly, and the store's per-daemon memoization
means a concurrent sweep installs once. A failed install drops the id from the catalog and is
reported where the install happened, unchanged.

## Verification

- `typecheck` clean; the 6 runtime/probe/catalog suites this touches pass (84 passed, 1 skipped).
- New case in `archive-store-daemon.test.ts`: nothing is fetched at start for an unused runtime, the
  sweep then installs it exactly once, the probe receives the **extracted absolute** command, and the
  models it reports land in `offeredModels`.
- `test/daemon-smoke.test.ts` has 2 failures (`GIT_CONFIG_KEY_0` / gitcred env) that reproduce on
  `main` with this diff reverted — pre-existing, unrelated to this change.
