### PR TITLE
fix(daemon): decline elicitations whose schema requires a field the card cannot answer

### DIFF
--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -612,18 +612,22 @@ export interface ElicitTarget {
 /**
  * Resolve the single form field an elicitation card renders (v1): the FIRST string-enum
  * (`oneOf` titled options or bare `enum`) or boolean property in the requested schema.
- * Returns null for URL-mode, an empty/absent schema, or a form whose fields we can't
- * render inline (free text, numbers, multi-field) — the daemon then declines. Pure, and
+ * Returns null for URL-mode, an empty/absent schema, a form whose fields we can't render
+ * inline (free text, numbers), or one that requires a property other than the rendered
+ * target — the daemon then declines rather than accepting a partial answer. Pure, and
  * shared by {@link buildElicitationCard} and the daemon's click handler so the button
  * values and their interpretation can't drift.
  */
 export function elicitTarget(params: CreateElicitationRequest): ElicitTarget | null {
   const p = params as {
     mode?: string
-    requestedSchema?: { properties?: Record<string, Record<string, unknown>> }
+    requestedSchema?: { properties?: Record<string, Record<string, unknown>>; required?: unknown }
   }
   if (p.mode !== 'form') return null
   const props = p.requestedSchema?.properties ?? {}
+  const required = Array.isArray(p.requestedSchema?.required) ? (p.requestedSchema.required as unknown[]) : []
+  // A required field we can't render is unanswerable: accepting without it would assert a lie.
+  const answerable = (t: ElicitTarget) => (required.every((r) => r === t.propName) ? t : null)
   for (const [name, prop] of Object.entries(props)) {
     if (prop?.type === 'string') {
       const oneOf = prop.oneOf as { const?: unknown; title?: unknown }[] | undefined
@@ -633,17 +637,17 @@ export function elicitTarget(params: CreateElicitationRequest): ElicitTarget | n
         : Array.isArray(en)
           ? en.map((v) => ({ value: String(v), label: clampTo(String(v), 75) }))
           : []
-      if (options.length) return { propName: name, kind: 'enum', options }
+      if (options.length) return answerable({ propName: name, kind: 'enum', options })
     }
     if (prop?.type === 'boolean') {
-      return {
+      return answerable({
         propName: name,
         kind: 'boolean',
         options: [
           { value: 'true', label: 'Yes' },
           { value: 'false', label: 'No' }
         ]
-      }
+      })
     }
   }
   return null

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -1423,6 +1423,67 @@ describe('elicitation card', () => {
     })
   })
 
+  it('renders when the only required property is the rendered one', () => {
+    const req = {
+      mode: 'form',
+      sessionId: 's1',
+      message: 'Pick a language',
+      requestedSchema: { type: 'object', properties: { color: { type: 'string', enum: ['red'] } }, required: ['color'] }
+    } as any
+    expect(elicitTarget(req)?.propName).toBe('color')
+  })
+
+  it('renders when extra non-required properties ride along', () => {
+    const req = {
+      mode: 'form',
+      sessionId: 's1',
+      message: 'Pick a language',
+      requestedSchema: {
+        type: 'object',
+        properties: {
+          color: { type: 'string', enum: ['red'] },
+          note: { type: 'string' },
+          count: { type: 'number' }
+        },
+        required: ['color']
+      }
+    } as any
+    expect(elicitTarget(req)?.propName).toBe('color')
+  })
+
+  it('returns null when the schema requires a property the card cannot answer', () => {
+    const req = {
+      mode: 'form',
+      sessionId: 's1',
+      message: 'Pick a language',
+      requestedSchema: {
+        type: 'object',
+        properties: { color: { type: 'string', enum: ['red'] }, note: { type: 'string' } },
+        required: ['color', 'note']
+      }
+    } as any
+    expect(elicitTarget(req)).toBeNull()
+    expect(buildElicitationCard('e', req)).toBeNull()
+  })
+
+  it('returns null for a boolean target with an extra required property', () => {
+    const req = {
+      mode: 'form',
+      sessionId: 's1',
+      message: 'Proceed?',
+      requestedSchema: {
+        type: 'object',
+        properties: { ok: { type: 'boolean' }, reason: { type: 'string' } },
+        required: ['ok', 'reason']
+      }
+    } as any
+    expect(elicitTarget(req)).toBeNull()
+  })
+
+  it('renders when required is absent', () => {
+    expect(elicitTarget(form({ ok: { type: 'boolean' } }))?.propName).toBe('ok')
+  })
+
   it('returns null (→ caller declines) for free-text-only forms and url mode', () => {
     expect(elicitTarget(form({ name: { type: 'string' } }))).toBeNull()
     expect(buildElicitationCard('e', form({ name: { type: 'string' } }))).toBeNull()


### PR DESCRIPTION
First sub-item of #1794 gap 1.

## The bug

`elicitTarget()` resolves the FIRST renderable form property out of an ACP `elicitation/create` schema — a string-enum (bare `enum` or titled `oneOf`) or a boolean — and `handleElicitChoice()` answers the agent with `content: { [propName]: value }`.

When the schema requires a property we did not render, that answer does not satisfy the schema the agent asked for, and we still send `action: 'accept'`. `accept` asserts the user answered the question that was asked, so a partial accept is worse than a decline: the agent proceeds on an answer it never received.

## The fix

`elicitTarget()` now reads `requestedSchema.required` and returns `null` when it names any property other than the rendered target. The daemon then declines, which agents are expected to handle.

The rule is deliberately narrower than "multi-field forms decline". `content` may legitimately omit **optional** properties, so a schema with several properties where only the rendered one is `required` stays answerable, exactly as today. Absent or empty `required` is likewise unchanged.

The check lives inside `elicitTarget` so every caller inherits it — `buildElicitationCard`, `onAcpElicit`, and the approval-DM path — rather than being a second opinion in the coordinator. No new decline plumbing was needed: a null target already makes `onAcpElicit` return `undefined`, and `AcpHost` turns that into `{ action: 'decline' }`.

## Impact on the Codex approval path — checked, no regression

Codex ACP maps MCP tool approval onto form elicitation, so those requests also flow through `elicitTarget`. codex-acp builds those schemas with `addPersistChoiceToSchema`, which appends a `persist` property and sets `required = union(upstream.required ?? [], 'persist')`. For Codex's own MCP tool-call approvals the upstream schema is empty, so in practice `required === ['persist']` and `persist` is the property we render — it still renders and accepts. The in-repo fixture (`test/daemon-permission-autoallow.test.ts`) has that exact shape and is unaffected.

The one behavior change is an MCP *server* that authors an elicitation schema with its own required fields: previously we rendered a `persist`-only card and partially accepted it, now we decline. That partial accept was the bug this PR fixes, so declining is the correct outcome.

## Follow-ups, deliberately not in this PR

- The target is still the first renderable property, so a schema whose only required property is renderable but sorts after an optional one declines where it could be answered. Improving field selection changes which question the card asks and belongs in its own change.
- `sendApprovalDm` does `buildElicitationCard(...) ?? []`, so an unrenderable approval posts a DM intro with no buttons and waits until cancel. That is pre-existing for free-text and numeric forms; this change widens the set of schemas that reach it. Tracked on #1794.

## Verification

- `pnpm --filter @agentconnect.md/daemon typecheck` — clean.
- `packages/daemon`: `test/render.test.ts` 114 passed, `test/daemon-permission-autoallow.test.ts` + `test/approval-dm.test.ts` 92 passed.
- eslint + prettier clean on the two touched files.

New cases in `test/render.test.ts`: required is exactly the rendered prop → renders; extra non-required properties → renders; extra required property → `null` (and `buildElicitationCard` → `null`); boolean target with an extra required property → `null`; `required` absent → renders.
