### PR TITLE
fix(console): offer "Adopt anyway" when a dream hits the snapshot fence

### DIFF
--- a/docs/designs/memory-dreaming.md
+++ b/docs/designs/memory-dreaming.md
@@ -525,8 +525,13 @@ architecture invariant:
   the daemon is offline.
 - **Console** — the Background memory section (§3) plus, per dream: a review
   screen showing a current-to-staged line diff for each store file (reusing the
-  managed-memory history diff and file browser components) with Adopt / Discard,
-  and a "Recommended skills" list rendering
+  managed-memory history diff and file browser components) with Adopt / Discard.
+  When Adopt hits the §6 snapshot fence (the live store moved under the dream),
+  the console does not dead-end on the error: it offers "Adopt anyway" (the
+  `force` flag), warning that adoption is a whole-directory swap and naming the
+  live-only files it would drop, with re-running the dream as the alternative
+  that keeps the newer changes. The review screen also has a
+  "Recommended skills" list rendering
   each candidate's `SKILL.md` and scripts with Accept / Dismiss. Accepted
   skills also surface on the Tools & Skills page alongside imported sources.
   Both branches of the mobile/desktop split follow the existing

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -377,16 +377,20 @@ describe('DreamPanel', () => {
     expect(api.adoptDream).toHaveBeenLastCalledWith(AGENT, 'drm-1', true, 'sha256:store')
   })
 
-  it('names the files a forced adopt would drop, from the live-only paths', async () => {
-    // stale.md exists live but not in the staged tree, so a whole-directory swap drops it.
+  it('names the live-only files a forced adopt would drop, recomputed at fence time (#1792)', async () => {
+    // The review panel loaded with no live-only topics; another session then added
+    // new.md, which is what trips the fence. The warning must name new.md — so the
+    // dropped set is recomputed when the fence fires, not reused from review load.
     api.listDreams.mockResolvedValue([dream()])
-    api.listAgentMemory.mockResolvedValue({
-      exists: true,
-      files: [
-        { name: 'MEMORY.md', size: 10, mtime: 'x' },
-        { name: 'stale.md', size: 10, mtime: 'x' }
-      ]
-    })
+    api.listAgentMemory
+      .mockResolvedValueOnce({ exists: true, files: [{ name: 'MEMORY.md', size: 10, mtime: 'x' }] })
+      .mockResolvedValue({
+        exists: true,
+        files: [
+          { name: 'MEMORY.md', size: 10, mtime: 'x' },
+          { name: 'new.md', size: 10, mtime: 'x' }
+        ]
+      })
     const fence = new FakeApiError(409)
     fence.message = 'the live store changed since this dream was snapshotted; rerun the dream or force'
     api.adoptDream.mockRejectedValueOnce(fence).mockResolvedValue(dream({ status: 'adopted' }))
@@ -396,13 +400,16 @@ describe('DreamPanel', () => {
     await act(async () => {
       await Promise.resolve()
     })
+    // The review panel, loaded before new.md existed, shows no deletions.
+    expect(host.textContent).not.toContain('Adopting removes')
     await act(async () => button(host, 'Adopt')?.click())
     const confirm = [...document.body.querySelectorAll<HTMLButtonElement>('button')].filter(
       (b) => b.textContent?.trim() === 'Adopt'
     )
     await act(async () => confirm.at(-1)?.click())
 
-    expect(document.body.textContent).toContain('drops 1 file added since: stale.md')
+    // Provenance is unknowable, so the copy says "not in the staged version", not "added since".
+    expect(document.body.textContent).toContain('drops 1 live file not in the staged version: new.md')
   })
 
   it('recommends mined skills and never installs one without an explicit click', async () => {

--- a/packages/web/src/components/console/DreamPanel.test.tsx
+++ b/packages/web/src/components/console/DreamPanel.test.tsx
@@ -351,13 +351,13 @@ describe('DreamPanel', () => {
     }
   })
 
-  it('keeps the server message for an adoption fence conflict', async () => {
-    // adopt's 409 is the snapshot fence, NOT the one-in-flight rule — telling
-    // the user to "wait for the running dream" would be actively wrong.
+  it('offers "Adopt anyway" (force) when adoption hits the snapshot fence, instead of dead-ending (#1792)', async () => {
+    // adopt's 409 is the snapshot fence, NOT the one-in-flight rule. Rather than
+    // surfacing a bare error the operator cannot act on, the fence opens the force path.
     api.listDreams.mockResolvedValue([dream()])
     const fence = new FakeApiError(409)
     fence.message = 'the live store changed since this dream was snapshotted; rerun the dream or force'
-    api.adoptDream.mockRejectedValue(fence)
+    api.adoptDream.mockRejectedValueOnce(fence).mockResolvedValue(dream({ status: 'adopted' }))
 
     const host = await render()
     await act(async () => button(host, 'Review')?.click())
@@ -367,8 +367,42 @@ describe('DreamPanel', () => {
     )
     await act(async () => confirm.at(-1)?.click())
 
-    expect(host.textContent).toContain('rerun the dream')
+    // The first (unforced) adopt tried and was fenced; the console now offers force.
+    expect(api.adoptDream).toHaveBeenLastCalledWith(AGENT, 'drm-1', false, 'sha256:store')
+    expect(document.body.textContent).toContain('Adopt anyway')
     expect(host.textContent).not.toContain('already running')
+
+    await act(async () => button(document.body, 'Adopt anyway')?.click())
+    // The same reviewed store bytes are adopted, now with force=true.
+    expect(api.adoptDream).toHaveBeenLastCalledWith(AGENT, 'drm-1', true, 'sha256:store')
+  })
+
+  it('names the files a forced adopt would drop, from the live-only paths', async () => {
+    // stale.md exists live but not in the staged tree, so a whole-directory swap drops it.
+    api.listDreams.mockResolvedValue([dream()])
+    api.listAgentMemory.mockResolvedValue({
+      exists: true,
+      files: [
+        { name: 'MEMORY.md', size: 10, mtime: 'x' },
+        { name: 'stale.md', size: 10, mtime: 'x' }
+      ]
+    })
+    const fence = new FakeApiError(409)
+    fence.message = 'the live store changed since this dream was snapshotted; rerun the dream or force'
+    api.adoptDream.mockRejectedValueOnce(fence).mockResolvedValue(dream({ status: 'adopted' }))
+
+    const host = await render()
+    await act(async () => button(host, 'Review')?.click())
+    await act(async () => {
+      await Promise.resolve()
+    })
+    await act(async () => button(host, 'Adopt')?.click())
+    const confirm = [...document.body.querySelectorAll<HTMLButtonElement>('button')].filter(
+      (b) => b.textContent?.trim() === 'Adopt'
+    )
+    await act(async () => confirm.at(-1)?.click())
+
+    expect(document.body.textContent).toContain('drops 1 file added since: stale.md')
   })
 
   it('recommends mined skills and never installs one without an explicit click', async () => {

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -128,13 +128,9 @@ export function DreamPanel({
   const [actionNotice, setActionNotice] = useState<string | null>(null)
   const [reviewing, setReviewing] = useState<string | null>(null)
   const [confirmStart, setConfirmStart] = useState(false)
-  const [confirmAdopt, setConfirmAdopt] = useState<{
-    dreamId: string
-    reviewToken?: string
-    droppedFiles: string[]
-  } | null>(null)
+  const [confirmAdopt, setConfirmAdopt] = useState<{ dreamId: string; reviewToken?: string } | null>(null)
   // The snapshot fence tripped: the live store moved under this dream. Adopting anyway is a
-  // whole-directory swap, so it drops any topic added since the snapshot (#1792).
+  // whole-directory swap, so it drops live files not in the staged proposal (#1792).
   const [forceAdopt, setForceAdopt] = useState<{
     dreamId: string
     reviewToken?: string
@@ -224,10 +220,26 @@ export function DreamPanel({
     }
   }
 
+  // The live files a forced adopt would drop: present in the live store, absent from
+  // the staged proposal. Recomputed fresh at fence time (not reused from review load),
+  // because the fence tripped precisely because live moved. Provenance is unknowable
+  // without the snapshot, so these are "not in the staged version", not "added since".
+  const droppedOnForce = async (dreamId: string): Promise<string[]> => {
+    try {
+      const [stagedPage, livePage] = await Promise.all([listDreamFiles(agentId, dreamId), listAgentMemory(agentId)])
+      const stagedNames = new Set(stagedPage.files.map((f: MemoryFileEntry) => f.name))
+      const liveNames = livePage.exists ? livePage.files.map((f: MemoryFileEntry) => f.name) : []
+      return liveNames.filter((name: string) => !stagedNames.has(name)).sort((a, b) => a.localeCompare(b))
+    } catch {
+      // The warning degrades to the generic wording rather than blocking the force path.
+      return []
+    }
+  }
+
   // Adopt is its own handler, not `run`, because the snapshot-fence 409 is not a
   // dead end: it opens the "adopt anyway" (force) path instead of surfacing a bare
   // error the operator cannot act on (#1792). Every other failure behaves like `run`.
-  const adopt = async (dreamId: string, reviewToken: string | undefined, droppedFiles: string[], force: boolean) => {
+  const adopt = async (dreamId: string, reviewToken: string | undefined, force: boolean) => {
     if (busy) return
     setBusy(true)
     setActionError(null)
@@ -243,8 +255,9 @@ export function DreamPanel({
         e.status === 409 &&
         /changed since this dream was snapshotted/.test(e.message)
       if (fence) {
-        // Offer the force path with the live view refreshed, so the drop warning
-        // names what is actually live now, not what the review panel saw earlier.
+        // Recompute the live-only set NOW, so the warning names what is actually live
+        // at the moment of the destructive swap, not what the review panel saw earlier.
+        const droppedFiles = await droppedOnForce(dreamId)
         await refresh()
         setForceAdopt({ dreamId, reviewToken, droppedFiles })
       } else {
@@ -428,7 +441,7 @@ export function DreamPanel({
             dreamId={reviewing}
             canEdit={canEdit}
             busy={busy}
-            onAdopt={(reviewToken, droppedFiles) => setConfirmAdopt({ dreamId: reviewing, reviewToken, droppedFiles })}
+            onAdopt={(reviewToken) => setConfirmAdopt({ dreamId: reviewing, reviewToken })}
             onDiscard={() => discard(reviewing)}
           />
         ) : null}
@@ -498,9 +511,9 @@ export function DreamPanel({
             confirmLabel="Adopt"
             onClose={() => setConfirmAdopt(null)}
             onConfirm={() => {
-              const { dreamId, reviewToken, droppedFiles } = confirmAdopt
+              const { dreamId, reviewToken } = confirmAdopt
               setConfirmAdopt(null)
-              void adopt(dreamId, reviewToken, droppedFiles, false)
+              void adopt(dreamId, reviewToken, false)
             }}
           >
             This replaces the agent’s live memory with the staged version. The current store is kept as a backup, and
@@ -514,17 +527,17 @@ export function DreamPanel({
             confirmLabel="Adopt anyway"
             onClose={() => setForceAdopt(null)}
             onConfirm={() => {
-              const { dreamId, reviewToken, droppedFiles } = forceAdopt
+              const { dreamId, reviewToken } = forceAdopt
               setForceAdopt(null)
-              void adopt(dreamId, reviewToken, droppedFiles, true)
+              void adopt(dreamId, reviewToken, true)
             }}
           >
             {`Memory changed underneath this dream since it was snapshotted. Adopting replaces the whole store with the staged version` +
               (forceAdopt.droppedFiles.length
-                ? ` and drops ${forceAdopt.droppedFiles.length} file${
+                ? ` and drops ${forceAdopt.droppedFiles.length} live file${
                     forceAdopt.droppedFiles.length === 1 ? '' : 's'
-                  } added since: ${forceAdopt.droppedFiles.join(', ')}.`
-                : `. Any file added since the snapshot is dropped.`) +
+                  } not in the staged version: ${forceAdopt.droppedFiles.join(', ')}.`
+                : `. Any live file not in the staged version is dropped.`) +
               ` The current store is kept as a backup. To keep the newer changes instead, re-run the dream.`}
           </ConfirmationDialog>
         ) : null}
@@ -546,7 +559,7 @@ function DreamReview({
   dreamId: string
   canEdit: boolean
   busy: boolean
-  onAdopt: (reviewToken: string | undefined, droppedFiles: string[]) => void
+  onAdopt: (reviewToken?: string) => void
   onDiscard: () => void
 }) {
   // The UNION of live and staged paths, not just the staged tree. Adoption swaps
@@ -647,15 +660,7 @@ function DreamReview({
             <Button variant="secondary" disabled={busy} onClick={onDiscard}>
               Discard
             </Button>
-            <Button
-              disabled={busy || !paths?.some((p) => p.staged)}
-              onClick={() =>
-                onAdopt(
-                  reviewToken,
-                  deleting.map((p) => p.name)
-                )
-              }
-            >
+            <Button disabled={busy || !paths?.some((p) => p.staged)} onClick={() => onAdopt(reviewToken)}>
               <Icon name="check" size={13} /> Adopt
             </Button>
           </span>

--- a/packages/web/src/components/console/DreamPanel.tsx
+++ b/packages/web/src/components/console/DreamPanel.tsx
@@ -128,7 +128,18 @@ export function DreamPanel({
   const [actionNotice, setActionNotice] = useState<string | null>(null)
   const [reviewing, setReviewing] = useState<string | null>(null)
   const [confirmStart, setConfirmStart] = useState(false)
-  const [confirmAdopt, setConfirmAdopt] = useState<{ dreamId: string; reviewToken?: string } | null>(null)
+  const [confirmAdopt, setConfirmAdopt] = useState<{
+    dreamId: string
+    reviewToken?: string
+    droppedFiles: string[]
+  } | null>(null)
+  // The snapshot fence tripped: the live store moved under this dream. Adopting anyway is a
+  // whole-directory swap, so it drops any topic added since the snapshot (#1792).
+  const [forceAdopt, setForceAdopt] = useState<{
+    dreamId: string
+    reviewToken?: string
+    droppedFiles: string[]
+  } | null>(null)
   const listRequest = useRef(0)
 
   const refresh = useCallback(async () => {
@@ -208,6 +219,44 @@ export function DreamPanel({
       // A conflict usually means our view is stale (someone else started or
       // adopted something) — resync so the row and its actions are correct.
       if (e instanceof ApiError && e.status === 409) await refresh()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // Adopt is its own handler, not `run`, because the snapshot-fence 409 is not a
+  // dead end: it opens the "adopt anyway" (force) path instead of surfacing a bare
+  // error the operator cannot act on (#1792). Every other failure behaves like `run`.
+  const adopt = async (dreamId: string, reviewToken: string | undefined, droppedFiles: string[], force: boolean) => {
+    if (busy) return
+    setBusy(true)
+    setActionError(null)
+    try {
+      await adoptDream(agentId, dreamId, force, reviewToken)
+      setReviewing(null)
+      setActionNotice('Memory adopted. Outdated proposals were moved to History.')
+      await refresh()
+    } catch (e) {
+      const fence =
+        !force &&
+        e instanceof ApiError &&
+        e.status === 409 &&
+        /changed since this dream was snapshotted/.test(e.message)
+      if (fence) {
+        // Offer the force path with the live view refreshed, so the drop warning
+        // names what is actually live now, not what the review panel saw earlier.
+        await refresh()
+        setForceAdopt({ dreamId, reviewToken, droppedFiles })
+      } else {
+        setActionError(
+          e instanceof ApiError && e.status === 503
+            ? 'This agent’s daemon is offline.'
+            : e instanceof Error
+              ? e.message
+              : 'That did not work.'
+        )
+        if (e instanceof ApiError && e.status === 409) await refresh()
+      }
     } finally {
       setBusy(false)
     }
@@ -379,7 +428,7 @@ export function DreamPanel({
             dreamId={reviewing}
             canEdit={canEdit}
             busy={busy}
-            onAdopt={(reviewToken) => setConfirmAdopt({ dreamId: reviewing, reviewToken })}
+            onAdopt={(reviewToken, droppedFiles) => setConfirmAdopt({ dreamId: reviewing, reviewToken, droppedFiles })}
             onDiscard={() => discard(reviewing)}
           />
         ) : null}
@@ -449,17 +498,34 @@ export function DreamPanel({
             confirmLabel="Adopt"
             onClose={() => setConfirmAdopt(null)}
             onConfirm={() => {
-              const { dreamId, reviewToken } = confirmAdopt
+              const { dreamId, reviewToken, droppedFiles } = confirmAdopt
               setConfirmAdopt(null)
-              void run(async () => {
-                await adoptDream(agentId, dreamId, false, reviewToken)
-                setReviewing(null)
-                setActionNotice('Memory adopted. Outdated proposals were moved to History.')
-              })
+              void adopt(dreamId, reviewToken, droppedFiles, false)
             }}
           >
             This replaces the agent’s live memory with the staged version. The current store is kept as a backup, and
             adopting is refused if memory changed underneath this dream.
+          </ConfirmationDialog>
+        ) : null}
+
+        {forceAdopt ? (
+          <ConfirmationDialog
+            title="Adopt anyway?"
+            confirmLabel="Adopt anyway"
+            onClose={() => setForceAdopt(null)}
+            onConfirm={() => {
+              const { dreamId, reviewToken, droppedFiles } = forceAdopt
+              setForceAdopt(null)
+              void adopt(dreamId, reviewToken, droppedFiles, true)
+            }}
+          >
+            {`Memory changed underneath this dream since it was snapshotted. Adopting replaces the whole store with the staged version` +
+              (forceAdopt.droppedFiles.length
+                ? ` and drops ${forceAdopt.droppedFiles.length} file${
+                    forceAdopt.droppedFiles.length === 1 ? '' : 's'
+                  } added since: ${forceAdopt.droppedFiles.join(', ')}.`
+                : `. Any file added since the snapshot is dropped.`) +
+              ` The current store is kept as a backup. To keep the newer changes instead, re-run the dream.`}
           </ConfirmationDialog>
         ) : null}
       </div>
@@ -480,7 +546,7 @@ function DreamReview({
   dreamId: string
   canEdit: boolean
   busy: boolean
-  onAdopt: (reviewToken?: string) => void
+  onAdopt: (reviewToken: string | undefined, droppedFiles: string[]) => void
   onDiscard: () => void
 }) {
   // The UNION of live and staged paths, not just the staged tree. Adoption swaps
@@ -581,7 +647,15 @@ function DreamReview({
             <Button variant="secondary" disabled={busy} onClick={onDiscard}>
               Discard
             </Button>
-            <Button disabled={busy || !paths?.some((p) => p.staged)} onClick={() => onAdopt(reviewToken)}>
+            <Button
+              disabled={busy || !paths?.some((p) => p.staged)}
+              onClick={() =>
+                onAdopt(
+                  reviewToken,
+                  deleting.map((p) => p.name)
+                )
+              }
+            >
               <Icon name="check" size={13} /> Adopt
             </Button>
           </span>


### PR DESCRIPTION
Fixes #1792. When dream adoption hit the snapshot fence, the daemon's error told the operator to `force` — but the console hardcoded `force=false` at the only call site (`DreamPanel.tsx`), so the fence was a dead end. `force` is implemented end to end in the REST route and the `adoptDream` client function; only the UI never passed it.

## Behaviour

Adopt now runs through its own handler instead of the generic `run`. On the fence 409 (`the live store changed since this dream was snapshotted`) it opens an **"Adopt anyway"** confirmation rather than surfacing a bare error.

The dialog is honest about what force does, which is the part the issue rightly flags: adoption is a whole-directory swap, so forcing **drops any topic added since the snapshot**. Those are exactly the live-only paths (`live && !staged`) the review screen already computes to show deletions — the dialog names them:

> Memory changed underneath this dream since it was snapshotted. Adopting replaces the whole store with the staged version and drops 1 file added since: `cn-rds-timezone-skew-tutor-voice.md`. The current store is kept as a backup. To keep the newer changes instead, re-run the dream.

The live view is refreshed before the warning renders, so the named files reflect what is live *now*, not what the review panel saw when it first loaded. Reject/discard paths are unchanged.

## Why not a plain "Force" button

Per the issue: forcing silently drops post-snapshot files. Naming them (and offering re-run as the non-destructive alternative) is what turns the dead end into an informed choice rather than a foot-gun. The daemon side is untouched — this is the UI gap only.

## Tests

`DreamPanel.test.tsx`: the fence now opens "Adopt anyway" (the first adopt was `force=false`, the confirmed one `force=true`, same reviewed store token both times); the force dialog names the live-only dropped file. The pre-existing test that asserted the old dead-end message is replaced. Full web suite green (2368), typecheck + lint clean. Design §10 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)