### PR TITLE
feat(console): webchat renders and answers the agent's elicitation cards

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -8231,6 +8231,14 @@ export class Daemon {
       case 'cancel':
         await this.webchatTransport.handleWebchatCancel(msg.chatId, op.agentId ?? msg.agentId)
         return { msgId: msg.msgId, accepted: true }
+      case 'elicitation_choice':
+        // The conversation confines the answer to a card this browser was actually shown.
+        await this.permissions.handleElicitChoice({
+          requestId: op.requestId,
+          value: op.value,
+          webchatConversationId: msg.chatId
+        })
+        return { msgId: msg.msgId, accepted: true }
       case 'close':
         this.webchatTransport.handleWebchatClose(msg.chatId)
         return { msgId: msg.msgId, accepted: true }

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -1405,7 +1405,9 @@ export class PermissionCoordinator {
       // The card names every answer it accepts; anything else would inject an unoffered
       // value into the agent's content, so it is dropped and the card stays live.
       if (a.value !== null && !elicitTarget(rec.params)?.options.some((o) => o.value === a.value)) return
-    }
+      // A card settles only from its own surface: both share one `elicit-<n>` counter, so
+      // without this a Slack tap could answer a live webchat card.
+    } else if (rec.surface === 'webchat') return
     if (rec.approval && this.host.agents().get(rec.agentId)?.allowRuntimeChangesInChat !== true) {
       if (rec.surface === 'slack' && rec.ts) {
         void rec.conn

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -81,6 +81,24 @@ interface ClosedGate {
   allowed?: boolean
 }
 
+/** Which surface an interactive elicitation card was posted to, and what it takes to settle it
+ *  there: Slack rewrites its message in place; webchat appends a second stream event. */
+type PendingElicitSurface =
+  | { surface: 'slack'; conn: SlackConnection; channel: string; ts?: string }
+  | { surface: 'webchat'; wc: NonNullable<Pending['webchat']> }
+
+/** One outstanding `elicitation/create` awaiting a human answer. */
+type PendingElicit = PendingElicitSurface & {
+  owner: HostKey
+  agentId: string
+  sessionId: string
+  params: CreateElicitationRequest
+  propName: string
+  kind: 'enum' | 'boolean'
+  approval: boolean
+  resolve: (res: CreateElicitationResponse) => void
+}
+
 /** The turn's platform surfaces a permission or elicitation card renders through. */
 export interface PermissionSurfaceHost {
   enqueueApply(p: Pending, action: DaemonRenderAction): void
@@ -175,22 +193,7 @@ export class PermissionCoordinator {
 
   // ── Interactive elicitations (ACP elicitation/create, form mode) ─────────────
   private elicitSeq = 0
-  private pendingElicits = new Map<
-    string,
-    {
-      owner: HostKey
-      agentId: string
-      sessionId: string
-      params: CreateElicitationRequest
-      propName: string
-      kind: 'enum' | 'boolean'
-      approval: boolean
-      conn: SlackConnection
-      channel: string
-      ts?: string
-      resolve: (res: CreateElicitationResponse) => void
-    }
-  >()
+  private pendingElicits = new Map<string, PendingElicit>()
 
   /** Sessions the CP currently believes are waiting, keyed by `pendingTurnKey` — emit only on a change. */
   private readonly awaitingApproval = new Map<string, { owner: HostKey; agentId: string; sessionId: string }>()
@@ -796,7 +799,9 @@ export class PermissionCoordinator {
           id: req.requestId,
           allowed: decidedAllow
         })
-        if (elicitation.ts) {
+        // Only a Slack card is rewritten here: an editor decision settles approvals, and
+        // an approval elicitation never lands on the webchat surface.
+        if (elicitation.surface === 'slack' && elicitation.ts) {
           const decision =
             req.decision === 'allow'
               ? ':white_check_mark: Allowed by Agent editor'
@@ -992,7 +997,7 @@ export class PermissionCoordinator {
         .catch(() => {})
     }
     for (const pending of this.pendingElicits.values()) {
-      if (pending.agentId !== agentId || !pending.approval || !pending.ts) continue
+      if (pending.agentId !== agentId || !pending.approval || pending.surface !== 'slack' || !pending.ts) continue
       void pending.conn
         .updateBlocks(
           pending.channel,
@@ -1223,6 +1228,14 @@ export class PermissionCoordinator {
     }
     // A `none` Slack turn has no generic human-input card to answer this request.
     if (p.plan.approvalSurfaceSuppressed) return { action: 'cancel' }
+    // Webchat is a core-owned surface, not a chat-platform module, so it is answered here
+    // rather than through turn-chrome's per-platform table. An MCP approval never reaches
+    // this line — it took the editor queue above, since chat approval needs Slack — and the
+    // `!isApproval` guard keeps that true if the branches above ever move. A continuation
+    // mirrors an origin platform, so it keeps falling through to the Slack path.
+    if (p.webchat && !p.webchat.continuation && !isApproval) {
+      return await this.awaitWebchatElicitation(agentId, sessionId, params, p, p.webchat)
+    }
     const conn = p.conn
     if (!turnChromeFor(p.plan.platform).chatInputCards || !(conn instanceof SlackConnection)) return undefined
     const target = elicitTarget(params)
@@ -1241,6 +1254,7 @@ export class PermissionCoordinator {
       propName: target.propName,
       kind: target.kind,
       approval: isApproval,
+      surface: 'slack',
       conn,
       channel: p.plan.channel,
       resolve: resolveResult
@@ -1294,23 +1308,106 @@ export class PermissionCoordinator {
       live.resolve({ action: 'cancel' })
       return await result
     }
-    live.ts = ts
+    if (live.surface === 'slack') live.ts = ts
     return isApproval ? await this.trackHumanApprovalWait(p, result) : await result
+  }
+
+  /** Webchat's peer of the Slack elicitation card: stream the card as an in-band event and
+   *  park the same resolver. Returns `undefined` (⇒ decline) when the form has no field this
+   *  surface can render — the identical verdict Slack reaches, via the same `elicitTarget`. */
+  private async awaitWebchatElicitation(
+    agentId: string,
+    sessionId: string,
+    params: CreateElicitationRequest,
+    p: Pending,
+    wc: NonNullable<Pending['webchat']>
+  ): Promise<CreateElicitationResponse | undefined> {
+    const target = elicitTarget(params)
+    if (!target) return undefined
+    const requestId = `elicit-${++this.elicitSeq}`
+    const message = (params as { message?: string }).message?.trim() || 'The agent needs your input'
+    let resolveResult!: (res: CreateElicitationResponse) => void
+    const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
+    this.pendingElicits.set(requestId, {
+      owner: p.hostKey,
+      agentId,
+      sessionId,
+      params,
+      propName: target.propName,
+      kind: target.kind,
+      approval: false,
+      surface: 'webchat',
+      wc,
+      resolve: resolveResult
+    })
+    this.syncApprovalActivity(p.hostKey, sessionId)
+    try {
+      wc.sink.output({
+        conversationId: wc.conversationId,
+        turnId: wc.turnId,
+        index: wc.index++,
+        event: { kind: 'elicitation', requestId, message, options: target.options }
+      })
+    } catch (err) {
+      // An undelivered card can never be answered — drop the resolver and decline now
+      // rather than stall the runtime until the turn ends.
+      this.pendingElicits.delete(requestId)
+      this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
+      this.host.log().warn(`webchat elicitation card not delivered for "${p.plan.sessionKey}": ${formatErr(err)}`)
+      return undefined
+    }
+    return await result
+  }
+
+  /** Append the settled card to a webchat stream — the append-only equivalent of Slack
+   *  rewriting its message. Best effort: the ACP resolution never depends on it. */
+  private emitWebchatElicitResolved(
+    rec: Extract<PendingElicit, { surface: 'webchat' }>,
+    requestId: string,
+    outcome: 'accepted' | 'dismissed' | 'cancelled',
+    label?: string
+  ): void {
+    try {
+      rec.wc.sink.output({
+        conversationId: rec.wc.conversationId,
+        turnId: rec.wc.turnId,
+        index: rec.wc.index++,
+        event: { kind: 'elicitation_resolved', requestId, outcome, ...(label !== undefined ? { label } : {}) }
+      })
+    } catch (err) {
+      this.host.log().warn(`webchat elicitation card not settled for ${requestId}: ${formatErr(err)}`)
+    }
   }
 
   /** A tapped elicitation-card button (SlackDeps.onElicitChoice): resolve the pending ACP
    *  request — `accept` with the chosen value (under the field name), or `decline` for the
    *  Dismiss button (value === null) — and edit the card in place. No-op if already gone. */
-  async handleElicitChoice(a: { requestId: string; value: string | null; actor?: InteractionActor }): Promise<void> {
+  async handleElicitChoice(a: {
+    requestId: string
+    value: string | null
+    actor?: InteractionActor
+    /** Set only by the webchat ingress: the answering browser's conversation. It confines
+     *  the answer to a card THIS conversation was shown — a webchat client can neither
+     *  answer a Slack card nor another conversation's, both of which the guessable
+     *  `elicit-<n>` id would otherwise allow. */
+    webchatConversationId?: string
+  }): Promise<void> {
     // A DM elicitation card's request lives on the editor path (§2/§6.4).
     const editor = this.pendingEditorPermissions.get(a.requestId)
     if (editor?.kind === 'elicitation' && editor.notify) {
+      if (a.webchatConversationId !== undefined) return
       return await this.handleDmElicitChoice(a.requestId, editor, a.value, a.actor)
     }
     const rec = this.pendingElicits.get(a.requestId)
     if (!rec) return
+    if (a.webchatConversationId !== undefined) {
+      if (rec.surface !== 'webchat' || rec.wc.conversationId !== a.webchatConversationId) return
+      // The card names every answer it accepts; anything else would inject an unoffered
+      // value into the agent's content, so it is dropped and the card stays live.
+      if (a.value !== null && !elicitTarget(rec.params)?.options.some((o) => o.value === a.value)) return
+    }
     if (rec.approval && this.host.agents().get(rec.agentId)?.allowRuntimeChangesInChat !== true) {
-      if (rec.ts) {
+      if (rec.surface === 'slack' && rec.ts) {
         void rec.conn
           .updateBlocks(
             rec.channel,
@@ -1334,7 +1431,8 @@ export class PermissionCoordinator {
       decision = `:white_check_mark: ${rec.kind === 'boolean' ? (value ? 'Yes' : 'No') : a.value}`
     }
     if (rec.approval) {
-      const team = rec.conn.workspaceId()
+      // Approval elicitations only ever take the Slack card path (chat approval requires it).
+      const team = rec.surface === 'slack' ? rec.conn.workspaceId() : undefined
       const by = a.actor
         ? { resolvedBy: team ? `slack:${team}:${a.actor.userId}` : null, resolvedByName: a.actor.name ?? null }
         : undefined
@@ -1350,7 +1448,13 @@ export class PermissionCoordinator {
     }
     this.pendingElicits.delete(a.requestId)
     this.syncApprovalActivity(rec.owner, rec.sessionId, { id: a.requestId, allowed: a.value !== null })
-    if (rec.ts)
+    if (rec.surface === 'webchat') {
+      const label =
+        a.value === null
+          ? undefined
+          : (elicitTarget(rec.params)?.options.find((o) => o.value === a.value)?.label ?? a.value)
+      this.emitWebchatElicitResolved(rec, a.requestId, a.value === null ? 'dismissed' : 'accepted', label)
+    } else if (rec.ts)
       void rec.conn
         .updateBlocks(rec.channel, rec.ts, buildElicitationResolvedCard(rec.params, decision), 'Input received', true)
         .catch(() => {})
@@ -1366,7 +1470,8 @@ export class PermissionCoordinator {
       this.pendingElicits.delete(id)
       this.syncApprovalActivity(owner, sessionId, { id })
       if (rec.approval) await this.resolveStoredPermissionRequest(agentId, id, 'expired')
-      if (rec.ts)
+      if (rec.surface === 'webchat') this.emitWebchatElicitResolved(rec, id, 'cancelled')
+      else if (rec.ts)
         void rec.conn
           .updateBlocks(
             rec.channel,

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -404,3 +404,182 @@ describe('the approval list names its session the way the console asked for it',
     await store.close()
   })
 })
+
+// ── webchat's in-band elicitation card (issue #1794 gap 5) ────────────────────
+// Webchat is a core-owned surface, so its card is a stream event and its answer a
+// webchat inbound op — the same `elicitTarget` reduction Slack renders, never a
+// second opinion about what is answerable.
+
+/** A plain (non-approval) form elicitation — no `codex_approval_kind`, so it cards. */
+function formElicitation(overrides: Record<string, unknown> = {}): CreateElicitationRequest {
+  return {
+    sessionId: 's1',
+    mode: 'form',
+    message: 'Which branch should I cut from?',
+    requestedSchema: {
+      type: 'object',
+      properties: { branch: { type: 'string', enum: ['main', 'develop', 'release'] } },
+      required: ['branch']
+    },
+    ...overrides
+  } as CreateElicitationRequest
+}
+
+/** Attach a webchat turn context to the installed pending turn and hand back its sink spy. */
+function installWebchat(pending: any, conversationId = 'conv-1'): { output: ReturnType<typeof vi.fn> } {
+  const sink = { output: vi.fn(), done: vi.fn() }
+  pending.plan.platform = 'webchat'
+  pending.webchat = {
+    conversationId,
+    turnId: 'turn-1',
+    sink,
+    index: 0,
+    replyText: '',
+    heldText: '',
+    messageEmitted: false
+  }
+  return sink
+}
+
+const cardEvents = (sink: { output: ReturnType<typeof vi.fn> }): any[] =>
+  sink.output.mock.calls.map(([o]: [any]) => o.event)
+
+describe('webchat renders and answers ACP elicitation cards', () => {
+  it('streams the card, then accepts the tapped option and settles it in place', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', formElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    expect(sink.output).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: 'conv-1', turnId: 'turn-1', index: 0 })
+    )
+    expect(cardEvents(sink)[0]).toEqual({
+      kind: 'elicitation',
+      requestId: expect.any(String),
+      message: 'Which branch should I cut from?',
+      // Uncapped and unabridged — every option the form offers reaches this surface.
+      options: [
+        { value: 'main', label: 'main' },
+        { value: 'develop', label: 'develop' },
+        { value: 'release', label: 'release' }
+      ]
+    })
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'develop',
+      webchatConversationId: 'conv-1'
+    })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'develop' } })
+    expect(cardEvents(sink)[1]).toEqual({
+      kind: 'elicitation_resolved',
+      requestId,
+      outcome: 'accepted',
+      label: 'develop'
+    })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+  })
+
+  it('declines on Dismiss and cancels on turn release, settling the card either way', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const dismissed = (daemon as any).permissions.onAcpElicit('agent-1', 's1', formElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [firstId] = (daemon as any).permissions.pendingElicits.keys()
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId: firstId,
+      value: null,
+      webchatConversationId: 'conv-1'
+    })
+    await expect(dismissed).resolves.toEqual({ action: 'decline' })
+    expect(cardEvents(sink)[1]).toEqual({ kind: 'elicitation_resolved', requestId: firstId, outcome: 'dismissed' })
+
+    const abandoned = (daemon as any).permissions.onAcpElicit('agent-1', 's1', formElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [secondId] = (daemon as any).permissions.pendingElicits.keys()
+    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
+    await expect(abandoned).resolves.toEqual({ action: 'cancel' })
+    expect(cardEvents(sink).at(-1)).toEqual({
+      kind: 'elicitation_resolved',
+      requestId: secondId,
+      outcome: 'cancelled'
+    })
+  })
+
+  it('answers only cards this conversation was shown, with values the card offered', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', formElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    // A value the card never offered would inject an unoffered answer into the agent's content.
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'rm -rf /',
+      webchatConversationId: 'conv-1'
+    })
+    // Another conversation must not reach this card, even knowing its `elicit-<n>` id.
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'main',
+      webchatConversationId: 'conv-other'
+    })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(cardEvents(sink)).toHaveLength(1) // still live — nothing settled it
+
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'main', webchatConversationId: 'conv-1' })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+  })
+
+  it('declines a form no surface can render, exactly as Slack does', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    // A required field the card cannot answer (#1795) stays unanswerable on webchat too.
+    await expect(
+      (daemon as any).permissions.onAcpElicit(
+        'agent-1',
+        's1',
+        formElicitation({
+          requestedSchema: {
+            type: 'object',
+            properties: { branch: { type: 'string', enum: ['main'] }, note: { type: 'string' } },
+            required: ['branch', 'note']
+          }
+        })
+      )
+    ).resolves.toBeUndefined()
+    expect(sink.output).not.toHaveBeenCalled()
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+  })
+
+  it('keeps MCP approvals on the editor queue and continuations on the platform path', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    // An approval never becomes a webchat card — it is a durable editor decision, and the
+    // only thing that reaches the stream is today's neutral "ask an editor" notice.
+    void (daemon as any).permissions.onAcpElicit('agent-1', 's1', elicitation('tc-approval'))
+    await vi.waitFor(() => expect(sink.output).toHaveBeenCalled())
+    expect((daemon as any).permissions.pendingEditorPermissions.size).toBe(1)
+    expect(cardEvents(sink).map((e) => e.kind)).toEqual(['message'])
+    await (daemon as any).permissions.releaseEditorPermissions('agent-1', 's1')
+    sink.output.mockClear()
+
+    // A continuation mirrors an origin platform, so it keeps falling through to the Slack
+    // path — which, with no Slack connection on this turn, declines as it does today.
+    pending.webchat.continuation = true
+    await expect((daemon as any).permissions.onAcpElicit('agent-1', 's1', formElicitation())).resolves.toBeUndefined()
+    expect(sink.output).not.toHaveBeenCalled()
+  })
+})

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -442,7 +442,7 @@ function installWebchat(pending: any, conversationId = 'conv-1'): { output: Retu
 }
 
 const cardEvents = (sink: { output: ReturnType<typeof vi.fn> }): any[] =>
-  sink.output.mock.calls.map(([o]: [any]) => o.event)
+  sink.output.mock.calls.map(([o]: any[]) => o.event)
 
 describe('webchat renders and answers ACP elicitation cards', () => {
   it('streams the card, then accepts the tapped option and settles it in place', async () => {
@@ -534,6 +534,24 @@ describe('webchat renders and answers ACP elicitation cards', () => {
     })
     expect((daemon as any).permissions.pendingElicits.size).toBe(1)
     expect(cardEvents(sink)).toHaveLength(1) // still live — nothing settled it
+
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'main', webchatConversationId: 'conv-1' })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+  })
+
+  it('refuses a Slack-surface answer for a webchat card, though both share one id counter', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', formElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    // No webchatConversationId ⇒ the answer came off a Slack card, which cannot settle this one.
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'main' })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(cardEvents(sink)).toHaveLength(1)
 
     await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'main', webchatConversationId: 'conv-1' })
     await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -195,6 +195,8 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       { op: 'set_permission_mode', permissionMode: 'plan' },
       { op: 'set_fast', fastMode: true },
       { op: 'cancel' },
+      { op: 'elicitation_choice', requestId: 'elicit-1', value: 'yes' },
+      { op: 'elicitation_choice', requestId: 'elicit-1', value: null, agentId: AGENT_ID },
       { op: 'close' }
     ]
     for (const payload of ops) {
@@ -216,6 +218,13 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       false
     )
     expect(RelayWebchatOp.safeParse({ op: 'attach', agentId: 'not-a-uuid' }).success).toBe(false)
+    // The elicitation answer is a value or an explicit Dismiss — never an absent field,
+    // which would let a malformed frame read as a decline the user never made.
+    expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'elicit-1' }).success).toBe(false)
+    expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: '', value: 'y' }).success).toBe(false)
+    expect(
+      RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'elicit-1', value: 'y', agentId: 'nope' }).success
+    ).toBe(false)
   })
 
   it('rd/ack carries the attach probe verdict (turnId + resume generation)', () => {

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -207,6 +207,16 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
   // `agentId` cancels one participant's live turn; absent ⇒ every live turn in
   // the conversation (and the sole agent's, in a single-agent conversation).
   z.object({ op: z.literal('cancel'), agentId: z.string().uuid().optional() }),
+  // The answer to an in-band elicitation card (the `elicitation` WebchatEvent). `value`
+  // is the chosen option's wire value and `null` is Dismiss — the same shape as the Slack
+  // `elicitation-choice` action below, so the two wires stay recognizably one design.
+  // `agentId` names the participant whose card this is; absent ⇒ the sole agent.
+  z.object({
+    op: z.literal('elicitation_choice'),
+    requestId: z.string().min(1).max(200),
+    value: z.string().nullable(),
+    agentId: z.string().uuid().optional()
+  }),
   z.object({ op: z.literal('close') })
 ])
 export type RelayWebchatOp = z.infer<typeof RelayWebchatOp>

--- a/packages/protocol/src/frames/webchat.test.ts
+++ b/packages/protocol/src/frames/webchat.test.ts
@@ -54,6 +54,47 @@ describe('WebchatOutput — event / status framing', () => {
     expect(r.success).toBe(true)
   })
 
+  it('carries an elicitation card and its settled twin, uncapped in options', () => {
+    const card = WebchatOutput.safeParse({
+      conversationId: CONV,
+      turnId: TURN,
+      index: 4,
+      event: {
+        kind: 'elicitation',
+        requestId: 'elicit-1',
+        message: 'Which branch should I cut from?',
+        // Well past Slack's five-button cap — that limit belongs to Slack's card, not here.
+        options: Array.from({ length: 12 }, (_, i) => ({ value: `b${i}`, label: `branch ${i}` }))
+      }
+    })
+    expect(card.success).toBe(true)
+    if (card.success && card.data.event?.kind === 'elicitation') expect(card.data.event.options).toHaveLength(12)
+    for (const outcome of ['accepted', 'dismissed', 'cancelled']) {
+      expect(
+        WebchatOutput.safeParse({
+          conversationId: CONV,
+          turnId: TURN,
+          index: 5,
+          event: {
+            kind: 'elicitation_resolved',
+            requestId: 'elicit-1',
+            outcome,
+            ...(outcome === 'accepted' ? { label: 'branch 3' } : {})
+          }
+        }).success
+      ).toBe(true)
+    }
+  })
+
+  it('rejects an unrenderable elicitation frame rather than streaming a dead card', () => {
+    const bad = (event: unknown) =>
+      WebchatOutput.safeParse({ conversationId: CONV, turnId: TURN, index: 6, event }).success
+    expect(bad({ kind: 'elicitation', requestId: '', message: 'm', options: [] })).toBe(false)
+    expect(bad({ kind: 'elicitation', requestId: 'e', message: 'm' })).toBe(false) // options required
+    expect(bad({ kind: 'elicitation', requestId: 'e', message: 'm', options: [{ value: 'v' }] })).toBe(false)
+    expect(bad({ kind: 'elicitation_resolved', requestId: 'e', outcome: 'expired' })).toBe(false)
+  })
+
   it('rejects an empty frame carrying neither event nor status', () => {
     const r = WebchatOutput.safeParse({ conversationId: CONV, turnId: TURN, index: 3 })
     expect(r.success).toBe(false)

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -155,7 +155,29 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   // connection, so every other chunk still flows and the turn degrades to showing its plan
   // only after the fact. There is no relay capability echo to gate on (`rd/hello/ok` carries
   // only `relayId`), so this is the tradeoff rather than an oversight.
-  z.object({ kind: z.literal('plan'), entries: z.array(PlanEntry) })
+  z.object({ kind: z.literal('plan'), entries: z.array(PlanEntry) }),
+  // The agent asked for a choice (ACP `elicitation/create`, form mode) — webchat's own
+  // in-band card, the peer of the Slack Block Kit one. Deliberately NOT the raw
+  // `requestedSchema`: the daemon has already reduced the form to the one renderable
+  // field, and its options are the only answers the browser may send back (as the
+  // `elicitation_choice` op keyed by this `requestId`). `message` is agent-authored text,
+  // masked before it reaches here. Options are UNCAPPED — the Slack 5-button cap is a
+  // Slack surface limit and does not follow the choice onto this surface.
+  z.object({
+    kind: z.literal('elicitation'),
+    requestId: z.string().min(1).max(200),
+    message: z.string(),
+    options: z.array(z.object({ value: z.string(), label: z.string() })).min(1)
+  }),
+  // The same card, settled. Slack rewrites its message in place; this stream is
+  // append-only, so the collapse is a second event keyed by the same `requestId`.
+  // `label` is the chosen option's label and is present only on 'accepted'.
+  z.object({
+    kind: z.literal('elicitation_resolved'),
+    requestId: z.string().min(1).max(200),
+    outcome: z.enum(['accepted', 'dismissed', 'cancelled']),
+    label: z.string().optional()
+  })
 ])
 export type WebchatEvent = z.infer<typeof WebchatEvent>
 

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -167,6 +167,21 @@ describe('parseBrowserFrame', () => {
     })
     expect(parseBrowserFrame({ type: 'attach', agentId: 'not-a-uuid' }, USER)).toBeNull()
   })
+  it('maps the elicitation answer, Dismiss included, and rejects a malformed one', () => {
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: 'yes' }, USER)).toEqual({
+      op: { op: 'elicitation_choice', requestId: 'elicit-1', value: 'yes' }
+    })
+    // null is Dismiss and must survive parsing as null — not be dropped into an absent field.
+    expect(
+      parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: null, agentId: AGENT }, USER)
+    ).toEqual({ op: { op: 'elicitation_choice', requestId: 'elicit-1', value: null, agentId: AGENT } })
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1' }, USER)).toBeNull()
+    expect(parseBrowserFrame({ type: 'elicitation_choice', value: 'yes' }, USER)).toBeNull()
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: '', value: 'yes' }, USER)).toBeNull()
+    expect(
+      parseBrowserFrame({ type: 'elicitation_choice', requestId: 'e', value: 'yes', agentId: 'not-a-uuid' }, USER)
+    ).toBeNull()
+  })
   it('preserves structured mentions on the turn op and surfaces targets separately', () => {
     const PEER = '22222222-2222-4222-8222-222222222222'
     expect(parseBrowserFrame({ text: 'hi', mentions: [AGENT, PEER], targets: [AGENT, PEER] }, USER)).toEqual({
@@ -267,6 +282,30 @@ describe('RelayBrowserConnection', () => {
       Array.from({ length: operations.length + 1 }, () => ENTITLEMENT)
     )
     expect(sent.at(-1)?.payload).toEqual({ op: 'close' })
+  })
+
+  it('routes an elicitation answer to the participant whose card it is', async () => {
+    const PEER = '22222222-2222-4222-8222-222222222222'
+    const { transport, sent } = build({
+      participants: [
+        { agentId: AGENT, daemonId: DAEMON, primary: true },
+        { agentId: PEER, daemonId: DAEMON }
+      ]
+    })
+    transport.feed({ type: 'elicitation_choice', requestId: 'elicit-3', value: 'yes', agentId: PEER })
+    transport.feed({ type: 'elicitation_choice', requestId: 'elicit-4', value: null })
+    await tick()
+    expect(sent).toHaveLength(2)
+    expect(sent[0]).toMatchObject({
+      agentId: PEER,
+      chatId: CHAT,
+      payload: { op: 'elicitation_choice', requestId: 'elicit-3', value: 'yes' }
+    })
+    // No agentId named ⇒ the conversation's primary, exactly like `cancel`.
+    expect(sent[1]).toMatchObject({
+      agentId: AGENT,
+      payload: { op: 'elicitation_choice', requestId: 'elicit-4', value: null }
+    })
   })
 
   it('keeps ordinary browser connections entitlement-free', async () => {

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -192,6 +192,19 @@ export function parseBrowserFrame(
       return m.agentId === undefined || (typeof m.agentId === 'string' && UUID_RE.test(m.agentId))
         ? { op: { op: 'cancel', ...(typeof m.agentId === 'string' ? { agentId: m.agentId.toLowerCase() } : {}) } }
         : null
+    case 'elicitation_choice': {
+      // The answer to an in-band elicitation card. `value: null` is Dismiss; the daemon
+      // matches the requestId against its own pending card and rejects anything else.
+      if (typeof m.requestId !== 'string' || (typeof m.value !== 'string' && m.value !== null)) return null
+      if (m.agentId !== undefined && !(typeof m.agentId === 'string' && UUID_RE.test(m.agentId))) return null
+      const parsed = RelayWebchatOp.safeParse({
+        op: 'elicitation_choice',
+        requestId: m.requestId,
+        value: m.value,
+        ...(typeof m.agentId === 'string' ? { agentId: m.agentId.toLowerCase() } : {})
+      })
+      return parsed.success ? { op: parsed.data } : null
+    }
     default:
       return null
   }
@@ -301,11 +314,11 @@ export class RelayBrowserConnection implements ChatSink {
       for (const p of this.byAgentId.values()) void this.sendToParticipant(p.agentId, { op: 'cancel' }, 'cancel')
       return
     }
-    // Single-daemon ops: resume/attach/cancel go to the named participant, everything
-    // else (set_*) to the primary — multi-agent conversations expose no runtime
-    // override (webchat-multi-agents.md §9.3), so set_* only occurs single-agent.
+    // Single-daemon ops: resume/attach/cancel/elicitation_choice go to the named
+    // participant, everything else (set_*) to the primary — multi-agent conversations
+    // expose no runtime override (webchat-multi-agents.md §9.3), so set_* is single-agent.
     const targetAgent =
-      op.op === 'resume' || op.op === 'attach' || op.op === 'cancel'
+      op.op === 'resume' || op.op === 'attach' || op.op === 'cancel' || op.op === 'elicitation_choice'
         ? (op.agentId ?? this.deps.agentId)
         : this.deps.agentId
     await this.sendToParticipant(targetAgent, op, op.op)

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -127,6 +127,14 @@ interface PlaygroundData {
   pgSetFast: (id: string, agentId: string, fastMode: boolean, conversationId?: string) => void
   /** Interrupt the running turn without ending the session. */
   pgCancel: (id: string, agentId: string, conversationId?: string) => void
+  /** Answer the agent's in-band elicitation card; `value: null` is Dismiss. */
+  pgAnswerElicitation: (
+    id: string,
+    agentId: string,
+    requestId: string,
+    value: string | null,
+    conversationId?: string
+  ) => void
   getPgSession: (id: string) => Session | undefined
   pgSessionList: Session[]
   /** Live tail (this-visit) steps for an ADOPTED webchat session, keyed by its CP session
@@ -237,6 +245,13 @@ type WebchatEvent =
   | { kind: 'superseded'; generation: number }
   | { kind: 'notice'; text: string }
   | { kind: 'plan'; entries: { content: string; status: string; priority?: string }[] }
+  | { kind: 'elicitation'; requestId: string; message: string; options: { value: string; label: string }[] }
+  | {
+      kind: 'elicitation_resolved'
+      requestId: string
+      outcome: 'accepted' | 'dismissed' | 'cancelled'
+      label?: string
+    }
 
 /** The session status snapshot carried in a relay `rd/chat` WebchatOutput payload
  *  (mirrors protocol WebchatStatus). Partial: context/cost stream live, token
@@ -569,6 +584,38 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             if (step.kind === 'planblock') return replaceAt(i, { ...step, plan: ev.entries, observedAtMs })
           }
           return [...steps, lane({ kind: 'planblock', text: '', plan: ev.entries })]
+        }
+        if (ev.kind === 'elicitation') {
+          // The agent's question, standing in the conversation until it is answered.
+          // `boundary` keeps the reply chunks that follow from accumulating into it.
+          return [
+            ...steps,
+            lane({
+              kind: 'elicit',
+              text: ev.message,
+              elicit: { requestId: ev.requestId, options: ev.options },
+              boundary: true
+            })
+          ]
+        }
+        if (ev.kind === 'elicitation_resolved') {
+          // Settle the card in place — the append-only stream's equivalent of Slack
+          // rewriting its message. Matched by requestId across the whole transcript: a
+          // card can outlive the lane fences the chunk accumulator scans within.
+          for (let i = steps.length - 1; i >= 0; i--) {
+            const step = steps[i]!
+            if (step.kind !== 'elicit' || step.elicit?.requestId !== ev.requestId) continue
+            return replaceAt(i, {
+              ...step,
+              elicit: {
+                ...step.elicit,
+                outcome: ev.outcome,
+                ...(ev.label !== undefined ? { answerLabel: ev.label } : {})
+              },
+              observedAtMs
+            })
+          }
+          return steps
         }
         if (ev.kind === 'notice') {
           // Daemon chrome for a wait with nothing else to show (a sandbox pod coming up).
@@ -1634,6 +1681,20 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [connect, stageRuntimeChange]
   )
 
+  /** Answer an in-band elicitation card (fire-and-forget) — `value: null` is Dismiss.
+   *  Deliberately NOT optimistic: the daemon owns the card's outcome and settles it with
+   *  the `elicitation_resolved` event, so a refused answer leaves the card answerable. */
+  const pgAnswerElicitation = useCallback(
+    (id: string, agentForId: string, requestId: string, value: string | null, conversationId?: string) => {
+      connect(id, agentForId, conversationId)
+        .ready.then((ws) =>
+          ws.send(JSON.stringify({ type: 'elicitation_choice', requestId, value, agentId: agentForId }))
+        )
+        .catch(() => {})
+    },
+    [connect]
+  )
+
   /** Interrupt the running turn (fire-and-forget). The daemon ends the turn with a
    *  relay `done` item, which clears pgBusy via the socket's done handler. */
   const pgCancel = useCallback(
@@ -1708,6 +1769,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       pgSetEffort,
       pgSetPermissionPreset,
       pgSetFast,
+      pgAnswerElicitation,
       pgCancel,
       getPgSession,
       pgSessionList,
@@ -1735,6 +1797,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       pgSetEffort,
       pgSetPermissionPreset,
       pgSetFast,
+      pgAnswerElicitation,
       pgCancel,
       getPgSession,
       pgSessionList,

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -464,6 +464,25 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
     [mutateSteps]
   )
 
+  /** Settle any card this lane left standing when its terminal frame lands. The daemon
+   *  resolves every pending elicitation as the turn ends, but that output can lose the race
+   *  with `done` — which retires the lane cursor, so a later event is dropped and the card
+   *  would stay answerable forever. A card cannot outlive its turn, so settle it here. */
+  const settleLiveElicits = useCallback(
+    (id: string, agentId: string | undefined, turnId: string): void =>
+      mutateSteps(id, (steps) => {
+        let changed = false
+        const next = steps.map((s) => {
+          if (s.kind !== 'elicit' || s.turnId !== turnId || (s.agentId ?? undefined) !== agentId) return s
+          if (!s.elicit || s.elicit.outcome) return s
+          changed = true
+          return { ...s, elicit: { ...s.elicit, outcome: 'cancelled' as const } }
+        })
+        return changed ? next : steps
+      }),
+    [mutateSteps]
+  )
+
   /** Retire a lane's wait notice on an event that is not folded into a step (a title, a clean end). */
   const retireWaitNotice = useCallback(
     (id: string, agentId: string | undefined, turnId: string): void =>
@@ -600,11 +619,14 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         }
         if (ev.kind === 'elicitation_resolved') {
           // Settle the card in place — the append-only stream's equivalent of Slack
-          // rewriting its message. Matched by requestId across the whole transcript: a
-          // card can outlive the lane fences the chunk accumulator scans within.
+          // rewriting its message. Scanned across the whole transcript, since a card can
+          // outlive the lane fences the chunk accumulator stops at, but matched on lane
+          // identity too: `elicit-<n>` is unique only within one daemon, so two
+          // participants on different daemons can hold the same id concurrently.
           for (let i = steps.length - 1; i >= 0; i--) {
             const step = steps[i]!
             if (step.kind !== 'elicit' || step.elicit?.requestId !== ev.requestId) continue
+            if ((step.agentId ?? undefined) !== agentId || step.turnId !== turnId) continue
             return replaceAt(i, {
               ...step,
               elicit: {
@@ -865,6 +887,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
         if (rec && rec.turnId === result.done.turnId) rec.agents.add(agentId)
         else finishedTurnLanes.current.set(id, { turnId: result.done.turnId, agents: new Set([agentId]) })
       }
+      if (result.done.turnId) settleLiveElicits(id, agentId, result.done.turnId)
       if (result.done.error) {
         // The notice STAYS on a failure: a turn that died waiting for its pod is explained by it.
         const name = participantName(id, agentId)
@@ -893,7 +916,8 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
       participantName,
       pushStep,
       retireWaitNotice,
-      setBusy
+      setBusy,
+      settleLiveElicits
     ]
   )
 

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -54,6 +54,7 @@ let getPgQueue: ReturnType<typeof usePlayground>['getPgQueue']
 let pgCancelQueued: ReturnType<typeof usePlayground>['pgCancelQueued']
 let getLiveSteps: ReturnType<typeof usePlayground>['getLiveSteps']
 let pgAttach: ReturnType<typeof usePlayground>['pgAttach']
+let pgAnswerElicitation: ReturnType<typeof usePlayground>['pgAnswerElicitation']
 
 function Probe() {
   const pg = usePlayground()
@@ -63,6 +64,7 @@ function Probe() {
   pgCancelQueued = pg.pgCancelQueued
   getLiveSteps = pg.getLiveSteps
   pgAttach = pg.pgAttach
+  pgAnswerElicitation = pg.pgAnswerElicitation
   return null
 }
 
@@ -858,5 +860,112 @@ describe('cold-attach retirement anchor', () => {
     const replayed = getLiveSteps('s-cold').filter((s) => s.turnId === 'turn-late')
     expect(replayed.length).toBeGreaterThan(0)
     expect(replayed.every((s) => s.postId === 'post-late')).toBe(true)
+  })
+})
+
+// #1794 gap 5: the agent's in-band elicitation card is a stream event, and its answer a
+// webchat op on the same socket — no CP resource, and the card lives in the transcript.
+describe('in-band elicitation cards', () => {
+  class ElicitSocket extends StubSocket {
+    // The answer rides the SAME socket the card arrived on, so this stub carries the
+    // readyState constants `connect`'s reuse check reads.
+    static OPEN = 1
+    static CLOSED = 3
+    static instances: ElicitSocket[] = []
+    onopen?: () => void
+    onmessage?: (e: { data: string }) => void
+    onerror?: (e: unknown) => void
+    onclose?: () => void
+    constructor() {
+      super()
+      ElicitSocket.instances.push(this)
+    }
+  }
+
+  async function openStream() {
+    ElicitSocket.instances = []
+    Reflect.set(globalThis, 'WebSocket', ElicitSocket)
+    const api = await import('@/lib/api')
+    vi.mocked(api.webchatWsUrl).mockResolvedValue('wss://relay.test/ws')
+    await act(async () => {
+      pgSend('s1', 'agent-1', 'hello', 'c1')
+    })
+    const socket = ElicitSocket.instances[0]!
+    await act(async () => {
+      socket.readyState = 1
+      socket.onopen?.()
+    })
+    const turn = JSON.parse(String(socket.send.mock.calls.at(-1)?.[0])) as { turnId: string }
+    return { socket, turnId: turn.turnId }
+  }
+
+  function feed(socket: ElicitSocket, turnId: string, index: number, event: unknown) {
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({ type: 'output', output: { turnId, agentId: 'agent-1', index, event } })
+      })
+    })
+  }
+
+  const card = (requestId: string) => ({
+    kind: 'elicitation',
+    requestId,
+    message: 'Which branch should I cut from?',
+    options: [
+      { value: 'main', label: 'main' },
+      { value: 'develop', label: 'develop' }
+    ]
+  })
+
+  it('lands the card as its own live transcript step', async () => {
+    const { socket, turnId } = await openStream()
+    feed(socket, turnId, 0, card('elicit-1'))
+    expect(getLiveSteps('s1').filter((s) => s.kind === 'elicit')).toMatchObject([
+      {
+        kind: 'elicit',
+        text: 'Which branch should I cut from?',
+        boundary: true,
+        elicit: { requestId: 'elicit-1', options: [{ value: 'main' }, { value: 'develop' }] }
+      }
+    ])
+  })
+
+  it('settles the card in place on the resolved event, keeping its position', async () => {
+    const { socket, turnId } = await openStream()
+    feed(socket, turnId, 0, card('elicit-1'))
+    feed(socket, turnId, 1, { kind: 'tool_call', toolCallId: 't1', title: 'Read', status: 'pending' })
+    feed(socket, turnId, 2, { kind: 'elicitation_resolved', requestId: 'elicit-1', outcome: 'accepted', label: 'main' })
+    const steps = getLiveSteps('s1').filter((s) => s.kind === 'elicit' || s.kind === 'tool')
+    expect(steps.map((s) => s.kind)).toEqual(['elicit', 'tool']) // settled where it stood
+    expect(steps[0]!.elicit).toMatchObject({ outcome: 'accepted', answerLabel: 'main' })
+
+    // A settlement for a card this stream never carried changes nothing.
+    feed(socket, turnId, 3, { kind: 'elicitation_resolved', requestId: 'elicit-9', outcome: 'cancelled' })
+    expect(getLiveSteps('s1').filter((s) => s.kind === 'elicit')).toHaveLength(1)
+  })
+
+  it('records a turn-end cancellation on the card rather than leaving it live', async () => {
+    const { socket, turnId } = await openStream()
+    feed(socket, turnId, 0, card('elicit-2'))
+    feed(socket, turnId, 1, { kind: 'elicitation_resolved', requestId: 'elicit-2', outcome: 'cancelled' })
+    expect(getLiveSteps('s1').find((s) => s.kind === 'elicit')?.elicit).toMatchObject({
+      outcome: 'cancelled'
+    })
+  })
+
+  it('answers over the same socket — a chosen value and an explicit Dismiss', async () => {
+    const { socket, turnId } = await openStream()
+    feed(socket, turnId, 0, card('elicit-1'))
+    act(() => pgAnswerElicitation('s1', 'agent-1', 'elicit-1', 'develop', 'c1'))
+    act(() => pgAnswerElicitation('s1', 'agent-1', 'elicit-1', null, 'c1'))
+    await act(async () => {})
+    const frames = socket.send.mock.calls.map((call) => JSON.parse(String(call[0])))
+    expect(frames.filter((f) => f.type === 'elicitation_choice')).toEqual([
+      { type: 'elicitation_choice', requestId: 'elicit-1', value: 'develop', agentId: 'agent-1' },
+      { type: 'elicitation_choice', requestId: 'elicit-1', value: null, agentId: 'agent-1' }
+    ])
+    // The daemon owns the outcome: nothing settles locally on the send alone.
+    expect(getLiveSteps('s1').find((s) => s.kind === 'elicit')?.elicit?.outcome).toBeUndefined()
+    expect(ElicitSocket.instances).toHaveLength(1) // one socket, card in and answer out
   })
 })

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -899,11 +899,17 @@ describe('in-band elicitation cards', () => {
     return { socket, turnId: turn.turnId }
   }
 
-  function feed(socket: ElicitSocket, turnId: string, index: number, event: unknown) {
+  function feed(socket: ElicitSocket, turnId: string, index: number, event: unknown, agentId = 'agent-1') {
     act(() => {
       socket.onmessage?.({
-        data: JSON.stringify({ type: 'output', output: { turnId, agentId: 'agent-1', index, event } })
+        data: JSON.stringify({ type: 'output', output: { turnId, agentId, index, event } })
       })
+    })
+  }
+
+  function finish(socket: ElicitSocket, turnId: string, lastIndex: number, agentId = 'agent-1') {
+    act(() => {
+      socket.onmessage?.({ data: JSON.stringify({ type: 'done', done: { turnId, agentId, lastIndex } }) })
     })
   }
 
@@ -927,6 +933,40 @@ describe('in-band elicitation cards', () => {
         boundary: true,
         elicit: { requestId: 'elicit-1', options: [{ value: 'main' }, { value: 'develop' }] }
       }
+    ])
+  })
+
+  it('settles a card another participant cannot claim: `elicit-<n>` is unique per daemon only', async () => {
+    const { socket, turnId } = await openStream()
+    feed(socket, turnId, 0, card('elicit-1'))
+    // A second participant on a DIFFERENT daemon reuses the id from its own counter.
+    // agent-2 streams on its OWN index sequence — cursors are per participant lane.
+    feed(
+      socket,
+      turnId,
+      0,
+      { kind: 'elicitation_resolved', requestId: 'elicit-1', outcome: 'accepted', label: 'x' },
+      'agent-2'
+    )
+    const held = getLiveSteps('s1').filter((s) => s.kind === 'elicit')
+    expect(held).toHaveLength(1)
+    expect(held[0]!.elicit).toMatchObject({ requestId: 'elicit-1' })
+    expect(held[0]!.elicit?.outcome).toBeUndefined() // still live — the other lane's id is not ours
+
+    feed(socket, turnId, 1, { kind: 'elicitation_resolved', requestId: 'elicit-1', outcome: 'accepted', label: 'main' })
+    expect(getLiveSteps('s1').filter((s) => s.kind === 'elicit')).toMatchObject([
+      { elicit: { requestId: 'elicit-1', outcome: 'accepted', answerLabel: 'main' } }
+    ])
+  })
+
+  it("cancels a card the lane's terminal frame overtook, so it cannot stay answerable forever", async () => {
+    const { socket, turnId } = await openStream()
+    feed(socket, turnId, 0, card('elicit-1'))
+    // An interrupt sends `done` before releaseElicits' output reaches the browser, which
+    // retires the lane cursor — the settlement that follows is dropped.
+    finish(socket, turnId, 0)
+    expect(getLiveSteps('s1').filter((s) => s.kind === 'elicit')).toMatchObject([
+      { elicit: { requestId: 'elicit-1', outcome: 'cancelled' } }
     ])
   })
 

--- a/packages/web/src/components/console/session-work.ts
+++ b/packages/web/src/components/console/session-work.ts
@@ -16,6 +16,11 @@ export const NOTICE_LANE = 'NOTICE'
  *  deliberately not `'PLAN'` — that one is a WORK lane, the playground's live re-tag. */
 export const PLAN_LANE = 'PLAN_BLOCK'
 
+/** An in-band elicitation card — the agent's question, awaiting or carrying an answer. Also
+ *  NOT a work lane: it is addressed to the reader, so it stands in the conversation instead
+ *  of collapsing behind the work toggle where nobody would see it in time to answer. */
+export const ELICIT_LANE = 'ELICIT'
+
 export type PlanEntry = PlanBody['entries'][number]
 
 /** The plan block's one-line label. Computed from the entries wherever they are present —

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -1,0 +1,251 @@
+// @vitest-environment happy-dom
+
+// The agent's in-band elicitation card on the real session page (#1794 gap 5). What matters is
+// that the question stands in the conversation with answerable buttons, that the answer goes out
+// on the webchat socket, and that a settled card collapses to its outcome for every reader.
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Agent, Session } from '@/lib/data'
+
+const wire = vi.hoisted(() => ({ messages: [] as unknown[] }))
+const live = vi.hoisted(() => ({ steps: [] as unknown[], answered: [] as unknown[] }))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'session-1' }),
+  usePathname: () => '/acme/sessions/session-1',
+  useSearchParams: () => new URLSearchParams(''),
+  useRouter: () => ({
+    replace: () => {},
+    push: () => {},
+    prefetch: () => {},
+    back: () => {},
+    forward: () => {},
+    refresh: () => {}
+  })
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>
+}))
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    fetchSessionMessages: vi.fn(() => Promise.resolve({ messages: wire.messages, nextCursor: null })),
+    fetchSessionDetail: vi.fn(() => Promise.reject(new Error('no detail'))),
+    fetchMySessionIdentity: vi.fn(() => Promise.reject(new Error('no identity'))),
+    fetchConversationByKey: vi.fn(() => Promise.reject(new Error('no conversation'))),
+    fetchAgentTasks: vi.fn(() =>
+      Promise.resolve({ sessionId: 'session-1', tracked: true, tasks: [], truncated: false })
+    ),
+    fetchSessionPullRequest: vi.fn(() => Promise.reject(new actual.ApiError('pull request not found', 404))),
+    fetchWorkspaceFiles: vi.fn((_agentId: string, opts: { path: string }) =>
+      Promise.resolve({ path: opts.path, exists: true, entries: [], nextCursor: null })
+    ),
+    fetchWorkspaceGitStatus: vi.fn(() => Promise.resolve({ isRepo: false })),
+    fetchWorkspaceGitLog: vi.fn(() => Promise.resolve({ isRepo: false, commits: [], truncated: false, tracking: null }))
+  }
+})
+
+const agent = {
+  id: 'agent-1',
+  name: 'Ops bot',
+  runtime: 'claude',
+  model: 'sonnet',
+  status: 'online',
+  statusLabel: 'online',
+  icon: 'bot',
+  daemon: 'daemon-1',
+  workdir: './services/api',
+  workspace: { mode: 'scratch' },
+  canEdit: false
+} as unknown as Agent
+
+const session = {
+  id: 'session-1',
+  title: 'Upgrade the node',
+  status: 'idle',
+  statusLabel: 'completed',
+  platform: 'webchat',
+  channel: 'Playground',
+  channelId: 'conv-1',
+  user: 'sam',
+  agentId: 'agent-1',
+  agentName: 'Ops bot',
+  // Empty, which is what puts the page on the REAL transcript (`wantTranscript`) instead of
+  // the mock step list a list-only session carries.
+  steps: []
+} as unknown as Session
+
+vi.mock('@/lib/data-context', () => ({
+  useConsoleData: () => ({
+    agents: [agent],
+    allSessions: [session],
+    getSessions: () => [session],
+    sessionsLoading: false,
+    crons: [],
+    daemons: [],
+    members: [],
+    sessionActivityVersionById: {},
+    sessionStreamGeneration: 0,
+    revalidateSessionLists: () => {}
+  })
+}))
+
+vi.mock('@/lib/org-context', () => ({
+  useOrgs: () => ({
+    activeOrg: { id: 'org-1', slug: 'acme' },
+    myRole: 'collaborator',
+    orgPath: (p: string) => `/acme${p}`
+  })
+}))
+
+vi.mock('@/lib/profile', () => ({ useProfile: () => ({ user: { name: 'Sam' }, me: null }) }))
+vi.mock('@/lib/acp-registry', () => ({ useAcpRegistry: () => ({}), acpRuntime: () => undefined }))
+vi.mock('@/lib/stick-to-bottom', () => ({ useStickToBottom: () => () => {} }))
+vi.mock('@/lib/auth', () => ({ isAuthConfigured: () => false }))
+vi.mock('@/lib/use-session-list', () => ({
+  useSessionList: () => ({ sessions: [], total: 0, isLoading: false, nextCursor: null, loadingMore: false })
+}))
+
+vi.mock('@/components/console/Shell', () => ({
+  useCrumbSlot: () => ({ register: () => {} }),
+  useMobileActionSlot: () => ({ action: null, register: () => {} })
+}))
+
+// One frozen object, not a fresh one per render: the transcript effect keys on
+// `reconcileLiveSteps` by identity, so a new closure each render refetches, re-renders, and
+// spins forever. (The viewer suite never sees this — its session carries mock steps, which
+// turns the real transcript off.)
+vi.mock('@/components/console/PlaygroundProvider', () => {
+  const playground = {
+    getPgSession: () => undefined,
+    getLiveSteps: () => live.steps,
+    getBusyLaneAgentIds: () => [],
+    reconcileLiveSteps: () => {},
+    getPgImage: () => null,
+    getPgWorktree: () => false,
+    isPgBusy: () => false,
+    setPgImage: () => {},
+    openPlayground: () => 'pg_new',
+    pgSend: () => {},
+    pgAttach: () => {},
+    getPgQueue: () => [],
+    pgCancelQueued: () => {},
+    pgAddAgent: () => {},
+    pgSetModel: () => {},
+    pgSetEffort: () => {},
+    pgSetPermissionPreset: () => {},
+    pgSetFast: () => {},
+    pgSetWorktree: () => {},
+    pgCancel: () => {},
+    pgAnswerElicitation: (...args: unknown[]) => live.answered.push(args),
+    setPgInput: () => {}
+  }
+  return { usePlayground: () => playground, usePgDraft: () => '', usePgDraftHasText: () => false }
+})
+
+import SessionDetailView from './SessionDetailView'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+let container: HTMLDivElement | undefined
+let root: ReturnType<typeof createRoot> | undefined
+
+const CARD = {
+  kind: 'elicit',
+  turnId: 'turn-1',
+  agentId: 'agent-1',
+  boundary: true,
+  text: 'Which branch should I cut from?',
+  elicit: {
+    requestId: 'elicit-1',
+    options: [
+      { value: 'main', label: 'main' },
+      { value: 'develop', label: 'develop' }
+    ]
+  }
+}
+
+async function render() {
+  await act(async () => {
+    root?.render(<SessionDetailView />)
+    await Promise.resolve()
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+const text = () => container?.textContent ?? ''
+const buttonNamed = (label: string) =>
+  [...(container?.querySelectorAll('button') ?? [])].find((b) => b.textContent === label)
+
+beforeEach(() => {
+  wire.messages = []
+  live.steps = [CARD]
+  live.answered = []
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    onchange: null,
+    dispatchEvent: () => false
+  })) as unknown as typeof window.matchMedia
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container?.remove()
+  container = undefined
+  root = undefined
+})
+
+describe('the agent’s elicitation card on the session page', () => {
+  it('asks its question with every option answerable, and sends the tapped choice', async () => {
+    await render()
+
+    expect(text()).toContain('Which branch should I cut from?')
+    for (const label of ['main', 'develop', 'Dismiss']) expect(buttonNamed(label)?.disabled).toBe(false)
+
+    await act(async () => {
+      buttonNamed('develop')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // The card's own agent answers, over this conversation's socket.
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', 'develop', 'conv-1']])
+
+    await act(async () => {
+      buttonNamed('Dismiss')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // Dismiss is an explicit null, never an absent value.
+    expect(live.answered[1]).toEqual(['session-1', 'agent-1', 'elicit-1', null, 'conv-1'])
+  })
+
+  it('collapses to its outcome once settled, leaving nothing left to answer', async () => {
+    live.steps = [{ ...CARD, elicit: { ...CARD.elicit, outcome: 'accepted', answerLabel: 'develop' } }]
+    await render()
+
+    expect(text()).toContain('Which branch should I cut from?')
+    expect(text()).toContain('develop')
+    expect(buttonNamed('main')).toBeUndefined()
+    expect(buttonNamed('Dismiss')).toBeUndefined()
+    expect(live.answered).toEqual([])
+  })
+
+  it('names a turn-end cancellation rather than showing a card nobody can answer', async () => {
+    live.steps = [{ ...CARD, elicit: { ...CARD.elicit, outcome: 'cancelled' } }]
+    await render()
+
+    expect(text()).toContain('Cancelled')
+    expect(buttonNamed('main')).toBeUndefined()
+  })
+})

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -99,6 +99,7 @@ import { useCommandAutocomplete } from '@/components/console/useCommandAutocompl
 import { useRuntimeCommands } from '@/components/console/useRuntimeCommands'
 import type { AgentIcon } from '@/lib/agent-icon'
 import {
+  ELICIT_LANE,
   NOTICE_LANE,
   PLAN_LANE,
   WORK_LANES,
@@ -483,6 +484,8 @@ interface FmtStep {
   // The turn's task list — present only on a PLAN_LANE step, and empty when the row
   // arrived without a readable body.
   plan?: PlanEntry[]
+  // The agent's in-band question — present only on an ELICIT_LANE step.
+  elicit?: NonNullable<SessionStep['elicit']>
   // A superseded answer collapsed into this lane — carried so the summary can skip it.
   demoted?: boolean
   // A peer participant's message attachment (rendered like the user bubble's).
@@ -631,6 +634,65 @@ function PlanBlock({ step }: { step: FmtStep }) {
             </div>
           )
         })}
+      </div>
+    </div>
+  )
+}
+
+// How a settled elicitation card reads once its buttons are gone.
+const ELICIT_OUTCOME: Record<string, { icon: string; color: string; label: (answer?: string) => string }> = {
+  accepted: { icon: 'check', color: 'var(--green-500)', label: (answer) => answer ?? 'Answered' },
+  dismissed: { icon: 'x', color: 'var(--text-tertiary)', label: () => 'Dismissed' },
+  cancelled: { icon: 'clock', color: 'var(--text-tertiary)', label: () => 'Cancelled' }
+}
+
+/** The agent's in-band question: its options while it is live, its outcome once settled.
+ *  Without `onAnswer` — a reader with no live socket to answer over — the same card renders
+ *  as a plain record of the ask, controls inert rather than missing. */
+function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value: string | null) => void }) {
+  const elicit = step.elicit
+  if (!elicit) return null
+  const settled = elicit.outcome ? ELICIT_OUTCOME[elicit.outcome] : undefined
+  return (
+    <div className="overflow-hidden rounded-md border border-(--border-subtle) bg-(--surface-app)">
+      <div className="flex min-w-0 items-start gap-[8px] px-[14px] py-[10px]">
+        <span className="mt-[2px] flex-none">
+          <Icon name="message-circle-question-mark" size={13} color="var(--text-tertiary)" />
+        </span>
+        <span className="min-w-0 whitespace-pre-wrap font-sans text-[13px] leading-[1.5] text-(--text-primary)">
+          {step.text}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-[6px] border-t border-(--border-subtle) px-[14px] py-[10px]">
+        {settled ? (
+          <span className="inline-flex min-w-0 items-center gap-[6px] font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+            <Icon name={settled.icon} size={13} color={settled.color} />
+            <span className="min-w-0 truncate">{settled.label(elicit.answerLabel)}</span>
+          </span>
+        ) : (
+          <>
+            {elicit.options.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className="chip max-w-full truncate disabled:cursor-default disabled:opacity-55"
+                disabled={!onAnswer}
+                onClick={() => onAnswer?.(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              className="chip disabled:cursor-default disabled:opacity-55"
+              disabled={!onAnswer}
+              onClick={() => onAnswer?.(null)}
+              title="Dismiss without answering"
+            >
+              Dismiss
+            </button>
+          </>
+        )}
       </div>
     </div>
   )
@@ -802,6 +864,7 @@ function fmtStep(stp: SessionStep, platform?: string): FmtStep {
     files: (stp.files ?? []).map((f) => ({ tag: f.tag, path: f.path, color: fileColor(f.tag) })),
     time: stp.time ?? '',
     ...(stp.kind === 'planblock' ? { plan: stp.plan ?? [] } : {}),
+    ...(stp.kind === 'elicit' && stp.elicit ? { elicit: stp.elicit } : {}),
     ...(stp.demoted ? { demoted: true } : {}),
     ...(platform ? { platform } : {}),
     // The live wire frame carries no body (kept off the hot path); attach just
@@ -1633,6 +1696,7 @@ export default function SessionDetailView() {
     pgSetPermissionPreset,
     pgSetFast,
     pgSetWorktree,
+    pgAnswerElicitation,
     pgCancel
   } = usePlayground()
   const { user: viewer, me } = useProfile()
@@ -2841,6 +2905,16 @@ export default function SessionDetailView() {
   // Continuations excluded: their channelId is a platform coordinate, not a
   // webchat conversation id, and a targeted conversation has no remote MCP.
   const webchatConversationId = isPg || isWebchat ? session.channelId : undefined
+  // An in-band elicitation card is answerable only where this reader can reach the session
+  // over the live webchat socket — the same gate the composer rides. Absent otherwise, and
+  // the card renders inert rather than offering buttons that would go nowhere.
+  const answerElicitation =
+    isLive && (isPg || isWebchat)
+      ? (agentId: string | undefined, requestId: string | undefined, value: string | null): void => {
+          if (!requestId) return
+          pgAnswerElicitation(session.id, agentId ?? session.agentId ?? '', requestId, value, webchatConversationId)
+        }
+      : undefined
   // Mid-conversation join (webchat-multi-agents.md §3.1): a live playground
   // conversation may GROW its roster; removal stays unsupported. The join is
   // still playground-only — `pgAddAgent` mutates provider-side session state that
@@ -4108,8 +4182,15 @@ export default function SessionDetailView() {
                             // collapsed work. A turn carries at most one (the row is upserted), but
                             // a merged conversation interleaves turns from several sources.
                             const planSteps = turn.steps.filter((s) => s.lane === PLAN_LANE)
+                            // The agent's in-band questions — their own block, above the answer,
+                            // because they are addressed to the reader rather than spoken at them.
+                            const elicitSteps = turn.steps.filter((s) => s.lane === ELICIT_LANE)
                             const textSteps = turn.steps.filter(
-                              (s) => !WORK_LANES.has(s.lane) && s.lane !== NOTICE_LANE && s.lane !== PLAN_LANE
+                              (s) =>
+                                !WORK_LANES.has(s.lane) &&
+                                s.lane !== NOTICE_LANE &&
+                                s.lane !== PLAN_LANE &&
+                                s.lane !== ELICIT_LANE
                             )
                             const workSteps = turn.steps.filter((s) => WORK_LANES.has(s.lane))
                             // Reasoning steps / tool commands / edited FILES (distinct paths across
@@ -4218,6 +4299,24 @@ export default function SessionDetailView() {
                                     >
                                       {planSteps.map((st, si) => (
                                         <PlanBlock key={`p:${si}`} step={st} />
+                                      ))}
+                                    </div>
+                                  )}
+                                  {elicitSteps.length > 0 && (
+                                    <div
+                                      className={`flex min-w-0 flex-col gap-2 ${textSteps.length > 0 || workSteps.length > 0 ? 'mb-2' : ''}`}
+                                    >
+                                      {elicitSteps.map((st, si) => (
+                                        <ElicitationCard
+                                          key={`e:${st.elicit?.requestId ?? si}`}
+                                          step={st}
+                                          {...(answerElicitation
+                                            ? {
+                                                onAnswer: (value: string | null) =>
+                                                  answerElicitation(turn.agentId, st.elicit?.requestId, value)
+                                              }
+                                            : {})}
+                                        />
                                       ))}
                                     </div>
                                   )}

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -276,7 +276,7 @@ export function agentIsPlaced(agent: Pick<Agent, 'daemon' | 'runtime' | 'placeme
 // `plan` is REASONING, for historical reasons — the ACP task list is `planblock`, which is
 // not a work lane at all. Renaming `plan` to `think` would be the honest fix; it is left
 // alone here so this change stays about the task list.
-export type LaneKind = 'msg' | 'plan' | 'tool' | 'edit' | 'done' | 'notice' | 'planblock'
+export type LaneKind = 'msg' | 'plan' | 'tool' | 'edit' | 'done' | 'notice' | 'planblock' | 'elicit'
 
 export interface LaneInfo {
   lane: string
@@ -342,6 +342,18 @@ const LANE_MAP: Record<LaneKind, LaneInfo> = {
     dot: 'var(--text-disabled)',
     weight: 400,
     textColor: 'var(--text-secondary)',
+    codeColor: 'var(--text-secondary)'
+  },
+  // The agent's in-band question (ACP elicitation). Like `notice` and `planblock`, NOT a work
+  // lane: it is a thing asked of the reader, so it stands in the conversation rather than
+  // collapsing into "Thought through N steps". The row colors are unused — ElicitationCard
+  // paints its own surface.
+  elicit: {
+    lane: 'ELICIT',
+    laneColor: 'var(--text-tertiary)',
+    dot: 'var(--text-disabled)',
+    weight: 400,
+    textColor: 'var(--text-primary)',
     codeColor: 'var(--text-secondary)'
   },
   // An assistant's completed reply — rendered neutrally, identical to a real transcript
@@ -1112,6 +1124,15 @@ export interface SessionStep {
    *  drops the step outright once a persisted row carries the same `postId`, from
    *  ANY conversation participant's session — not just this step's own author. */
   postId?: string
+  /** The agent's in-band question — present only on an `elicit` step. `outcome` is absent
+   *  while the card is live and set once the daemon settles it (answered, dismissed, or
+   *  cancelled with the turn), which is what collapses the card in place. */
+  elicit?: {
+    requestId: string
+    options: { value: string; label: string }[]
+    outcome?: 'accepted' | 'dismissed' | 'cancelled'
+    answerLabel?: string
+  }
 }
 
 // Per-session token accounting (protocol `SessionUsage`), metered by the daemon.


### PR DESCRIPTION
Implements #1794 gap 5. Webchat has been the one surface with no widget constraints at all and the only one with no elicitation support: every `elicitation/create` on a webchat turn was declined, because `onAcpElicit` gated on `turnChromeFor(platform).chatInputCards` **and** `conn instanceof SlackConnection`.

## Shape

**In-band, not a polled CP resource.** The card is a webchat stream event and the answer is a webchat inbound op, so it lives in the transcript exactly as Slack's card lives in the thread, and the CP stays out of the webchat content path — it persists nothing here, as it persists nothing else on that path.

Two new `WebchatEvent` kinds:

```ts
{ kind: 'elicitation', requestId, message, options: [{ value, label }] }
{ kind: 'elicitation_resolved', requestId, outcome: 'accepted'|'dismissed'|'cancelled', label? }
```

The raw `requestedSchema` never reaches the wire — the daemon has already reduced the form through `elicitTarget`, and the offered options are the only answers the browser may return. Slack settles a card by rewriting its message; a webchat stream is append-only, so the resolved twin is the equivalent.

One new inbound `RelayWebchatOp`, mirroring the Slack `elicitation-choice` action so the two wires stay recognizably the same:

```ts
{ op: 'elicitation_choice', requestId, value: string | null, agentId? }   // null = Dismiss
```

`RdChatEvent` and the relay's output path are already generic and needed no change.

## Notable decisions

- **No `webchat` entry in the `CHROME` table.** That table declares chat-*platform* chrome, and the file documents that "no entry" and "explicit entry" mean different things. Webchat is a core-owned surface, so the branch sits in `onAcpElicit` ahead of the platform gate instead.
- **`elicitTarget()` is reused verbatim.** Slack and webchat can therefore never disagree about what is renderable or what a button value means — including #1795's rule that a schema requiring an unrendered property declines.
- **No 5-option cap on webchat.** That cap is a Slack surface limit and stays in `buildElicitationCard`.
- **Approval routing is unchanged.** MCP approvals still take the editor queue on webchat; only non-approval elicitations get the new card. `pendingElicits` now carries a `{surface:'slack'|'webchat'}` discriminant instead of a hardcoded `SlackConnection`, and all five existing consumers narrow on it.
- **Continuations keep the platform path**, following the precedent in `noteEditorPermissionRequest`.

## Answers are authenticated, not just parsed

`elicit-<n>` ids are guessable and were previously reachable only from a signed Slack card. Three guards:

- **Conversation binding.** The webchat ingress passes `msg.chatId`; an answer settles a card only if that conversation is the one the card was streamed to.
- **Surface binding.** Both surfaces draw request ids from one counter, so an id does not identify a surface. An answer settles only a card on its own surface — a Slack tap cannot settle a live webchat card, and a browser cannot settle a Slack or DM card.
- **Value whitelist.** A webchat answer must be one of the options the card offered; anything else is dropped and the card stays live. A browser is not a Slack button, and without this a crafted frame injects an arbitrary string into `content[propName]`.

Also: if `sink.output` throws, the resolver is dropped and the request declines immediately rather than stalling the runtime until the turn ends.

## Known limits, deliberately not fixed here

Neither event is persisted, so a card is live-only — a viewer who loads the conversation later sees nothing, the same as today's `notice` kind. Making it survive a reload is a transcript-row change and belongs in its own issue; `ElicitationCard`'s read-only branch is written for that day but is currently unreachable through the view.

`Dismiss` maps to `{action:'decline'}`, so an agent still cannot distinguish "user dismissed" from "no surface could render this" — pre-existing, inherited from Slack.

## Verification

- `@agentconnect.md/protocol` 483 passed, `@agentconnect.md/relay` 644 passed, `@agentconnect.md/web` 2374 passed.
- `packages/daemon`: `daemon-permission-autoallow` / `render` / `daemon-webchat` / `approval-dm` / `turn-chrome` — 259 passed, plus the surface-binding case added on review.
- `pnpm typecheck` clean (it covers tests; a TS2345 in the new webchat coverage was caught and fixed here).
- eslint + prettier clean on all changed files.

New coverage at every layer: protocol schemas, relay frame parse and participant routing, the daemon's webchat branch / resolve / release / auth guards, and the console (`PlaygroundSend`, `SessionDetailView.elicitation`).
