### PR TITLE
fix(daemon): a re-review resets tracked files only, keeping what the session installed and built

### DIFF
--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -1551,8 +1551,8 @@ export class WorkspaceManager {
       }
       const worktreeGit = this.runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
       // Fetched review refs mark this root's worktree as a daemon-owned review snapshot: every
-      // delivery re-fetches the exact revision and resets the tree (`reset --hard` + `clean -ffdx`),
-      // so dirty state and local commits alike are disposable by construction and retaining on them
+      // delivery re-fetches the exact revision and resets every tracked file (`reset --hard`), so
+      // dirty state and local commits alike are disposable by construction and retaining on them
       // protects nothing. Probed lazily — only when a protection would otherwise keep the worktree —
       // and at most once; a probe failure conservatively reads as "not a snapshot".
       let snapshot: boolean | undefined
@@ -1958,9 +1958,8 @@ export class WorkspaceManager {
       // Re-audit at the checkout boundary rather than relying on the earlier
       // network fetch audit; repository config may have changed while fetching.
       await assertSafeWorkspaceGitConfig(this.runnerFor(agent.id, root.path))
-      const worktreeGit = this.runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv())
-      await worktreeGit.raw(['reset', '--hard', target])
-      await worktreeGit.raw(['clean', '-ffdx'])
+      // Tracked files alone follow the revision; untracked and ignored files (node_modules, a cargo target, build output) are the session's own intermediates and stay, so a re-review does not rebuild them.
+      await this.runnerFor(agent.id, cwd).withEnv(workspaceGitLocalEnv()).raw(['reset', '--hard', target])
     }
     if (review && (await this.revParse(agent.id, cwd, 'HEAD')).toLowerCase() !== review.checkout) {
       throw new Error('github review worktree HEAD does not match the verified revision')
@@ -2032,9 +2031,10 @@ export class WorkspaceManager {
     if (!attached) {
       await this.checkoutSessionBranch(agent.id, root, cwd, target, request.initiatedBy)
     } else if (review) {
-      const git = this.runnerFor(agent.id, cwd).withEnv(this.sessionCloneGitEnv(agent.id, root))
-      await git.raw(['reset', '--hard', target])
-      await git.raw(['clean', '-ffdx'])
+      // Tracked files alone follow the revision, as on the worktree tier: the session keeps its untracked and ignored intermediates across deliveries.
+      await this.runnerFor(agent.id, cwd)
+        .withEnv(this.sessionCloneGitEnv(agent.id, root))
+        .raw(['reset', '--hard', target])
     }
     if (review && (await this.revParse(agent.id, cwd, 'HEAD')).toLowerCase() !== review.checkout) {
       throw new Error('github review clone HEAD does not match the verified revision')

--- a/packages/daemon/test/skill-install-ledger.test.ts
+++ b/packages/daemon/test/skill-install-ledger.test.ts
@@ -361,7 +361,7 @@ describe.skipIf(process.platform === 'win32')('skill install ledger over a re-ch
     const first = await reconcile('v1')
     expect(first.installed).toEqual([BUNDLE])
 
-    // What `git clean -ffdx` does to a resumed session clone: the bundles go, the ledger naming them stays.
+    // A resumed session clone whose bundles vanished from disk while the ledger naming them stays.
     await rm(join(cwd, '.claude'), { recursive: true, force: true })
     const second = await reconcile('v1')
 

--- a/packages/daemon/test/workspace-session-clone.test.ts
+++ b/packages/daemon/test/workspace-session-clone.test.ts
@@ -388,17 +388,24 @@ describe('a confined session gets its own clone of every root (git-workspace-mod
     expect(existsSync(join(cwd, 'feature.md'))).toBe(true)
     expect(() => git(agent.workspace.path, ['rev-parse', '--verify', '--quiet', headRef])).toThrow()
 
-    // A later delivery re-fetches the exact revision and resets the clone, dirt and all.
+    // A later delivery re-fetches the exact revision and resets every tracked file, while what the
+    // session built in between — untracked or ignored — stays, so it need not install or build again.
     const second = publishPullRequest(primary!.seed, 'pr v2\n')
-    writeFileSync(join(cwd, 'scratch.txt'), 'dropped\n')
+    writeFileSync(join(cwd, 'feature.md'), 'edited locally\n')
+    writeFileSync(join(cwd, 'scratch.txt'), 'kept\n')
+    mkdirSync(join(cwd, 'node_modules', '.pnpm'), { recursive: true })
+    writeFileSync(join(cwd, 'node_modules', '.pnpm', 'lock.yaml'), 'kept\n')
+    writeFileSync(join(cwd, '.git', 'info', 'exclude'), 'node_modules/\n')
     const again = await workspaces.prepareSessionWorkspace(
       agent,
       confined({ review: { pullNumber: 7, baseSha: second.base, headSha: second.head } })
     )
     expect(again).toBe(cwd)
     expect(git(cwd, ['rev-parse', 'HEAD'])).toBe(second.head)
-    expect(existsSync(join(cwd, 'scratch.txt'))).toBe(false)
-    expect(git(cwd, ['status', '--porcelain'])).toBe('')
+    expect(readFileSync(join(cwd, 'feature.md'), 'utf8')).toBe('pr v2\n')
+    expect(existsSync(join(cwd, 'scratch.txt'))).toBe(true)
+    expect(existsSync(join(cwd, 'node_modules', '.pnpm', 'lock.yaml'))).toBe(true)
+    expect(git(cwd, ['status', '--porcelain'])).toBe('?? scratch.txt')
   })
 
   // A blobless clone has to resolve a fetched pack against objects it filtered out, which is a promisor

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -342,7 +342,11 @@ describe('prepareSessionWorkspace', () => {
           args.includes(`+refs/pull/461/head:refs/agentconnect/reviews/${basename(cwd)}/head`)
       )
     ).toBe(true)
-    expect(rawMock.mock.calls.some(([args]) => args[0] === 'clean' && args[1] === '-ffdx')).toBe(true)
+    // The second delivery resets tracked files only; nothing cleans the session's untracked intermediates.
+    expect(
+      rawMock.mock.calls.some(([args, baseDir]) => baseDir === cwd && args[0] === 'reset' && args[1] === '--hard')
+    ).toBe(true)
+    expect(rawMock.mock.calls.some(([args]) => args[0] === 'clean')).toBe(false)
   })
 
   it('replaces a stale review checkout with an empty revision-only cwd', async () => {


### PR DESCRIPTION
## Why

A formal review session reuses its checkout across pushes to the same pull request, but every delivery re-fetched the exact revision and then ran `git clean -ffdx` on it. `-x` removes ignored files too, so `node_modules`, build output and any other toolchain cache went with it, and the agent reinstalled the whole dependency tree before it could run a single test — on every push. In a live review session the second round spent its time on a fresh `pnpm install` for a checkout it had verified minutes earlier; on the test host each review session carries about 3 GB of `node_modules` it had to rebuild.

## What

Only tracked files follow the reviewed revision now, via `reset --hard` alone, on both the worktree tier and the session-clone tier. Untracked and ignored files are the session's own intermediates (Node dependencies today; a cargo `target`, a Python venv or a Go module cache tomorrow) and stay across deliveries. The exact-HEAD verification after the reset is unchanged, and the retention rule that treats a review snapshot as disposable still holds: its tracked state is reset on every delivery.

## Tests

- `workspace-session-clone.test.ts` (real git): a second delivery moves HEAD, restores a locally edited tracked file, and leaves an untracked scratch file and an ignored `node_modules` entry in place.
- `workspace.test.ts` (mocked git): the resumed worktree gets `reset --hard` and no `clean` at all.
- Mutation check: re-adding the `clean` makes the real-git test fail.

Daemon typecheck, ESLint and Prettier pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
