### PR TITLE
feat(console): webchat answers multi-select elicitations

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -30,8 +30,12 @@ import {
   buildElicitationResolvedCard,
   buildPermissionCard,
   buildPermissionResolvedCard,
-  elicitTarget
+  elicitTarget,
+  multiSelectAccepts,
+  SLACK_ELICIT_KINDS,
+  WEBCHAT_ELICIT_KINDS
 } from '../slack/render.js'
+import type { ElicitKind, ElicitSurfaceKinds, ElicitTarget } from '../slack/render.js'
 import { slackThreadUrl } from '../platforms/slack/permalink.js'
 import { slackAgentIdentityOptions } from '../platforms/slack/turn-output.js'
 import { turnChromeFor } from '../platforms/turn-chrome.js'
@@ -87,6 +91,21 @@ type PendingElicitSurface =
   | { surface: 'slack'; conn: SlackConnection; channel: string; ts?: string }
   | { surface: 'webchat'; wc: NonNullable<Pending['webchat']> }
 
+/** The kinds the surface a card was posted to renders — re-deriving its target has to ask the
+ *  same question the post did, or a card could be read back as a field its surface never showed. */
+function surfaceKinds(rec: PendingElicitSurface): ElicitSurfaceKinds {
+  return rec.surface === 'webchat' ? WEBCHAT_ELICIT_KINDS : SLACK_ELICIT_KINDS
+}
+
+/** How a settled card names the answer: the chosen option's LABEL, or every chosen label for a
+ *  multi-select — what the reader picked, in the words the card used, never the wire values.
+ *  An accepted empty list (a `minItems: 0` form) still says something rather than nothing. */
+function chosenLabel(target: ElicitTarget | null, value: string | string[]): string {
+  const label = (v: string) => target?.options.find((o) => o.value === v)?.label ?? v
+  if (!Array.isArray(value)) return label(value)
+  return value.length ? value.map(label).join(', ') : 'Nothing selected'
+}
+
 /** One outstanding `elicitation/create` awaiting a human answer. */
 type PendingElicit = PendingElicitSurface & {
   owner: HostKey
@@ -94,7 +113,7 @@ type PendingElicit = PendingElicitSurface & {
   sessionId: string
   params: CreateElicitationRequest
   propName: string
-  kind: 'enum' | 'boolean'
+  kind: ElicitKind
   approval: boolean
   resolve: (res: CreateElicitationResponse) => void
 }
@@ -141,7 +160,7 @@ interface DmNotice {
    *  rewrite prepends it — a resolved card must not lose the links (issue feedback). */
   intro: unknown[]
   propName?: string
-  valueKind?: 'enum' | 'boolean'
+  valueKind?: ElicitKind
 }
 
 interface EditorPermissionEntry {
@@ -589,7 +608,7 @@ export class PermissionCoordinator {
           .catch(() => {})
       return
     }
-    const elicit = rec.kind === 'elicitation' ? elicitTarget(rec.params) : null
+    const elicit = rec.kind === 'elicitation' ? elicitTarget(rec.params, SLACK_ELICIT_KINDS) : null
     live.notify = {
       target,
       conn,
@@ -1238,7 +1257,7 @@ export class PermissionCoordinator {
     }
     const conn = p.conn
     if (!turnChromeFor(p.plan.platform).chatInputCards || !(conn instanceof SlackConnection)) return undefined
-    const target = elicitTarget(params)
+    const target = elicitTarget(params, SLACK_ELICIT_KINDS)
     if (!target) return undefined
     const requestId = isApproval ? randomUUID() : `elicit-${++this.elicitSeq}`
     const blocks = buildElicitationCard(requestId, params, this.host.httpSlackSessionTarget(p))
@@ -1322,7 +1341,7 @@ export class PermissionCoordinator {
     p: Pending,
     wc: NonNullable<Pending['webchat']>
   ): Promise<CreateElicitationResponse | undefined> {
-    const target = elicitTarget(params)
+    const target = elicitTarget(params, WEBCHAT_ELICIT_KINDS)
     if (!target) return undefined
     const requestId = `elicit-${++this.elicitSeq}`
     const message = (params as { message?: string }).message?.trim() || 'The agent needs your input'
@@ -1346,7 +1365,22 @@ export class PermissionCoordinator {
         conversationId: wc.conversationId,
         turnId: wc.turnId,
         index: wc.index++,
-        event: { kind: 'elicitation', requestId, message, options: target.options }
+        event: {
+          kind: 'elicitation',
+          requestId,
+          message,
+          options: target.options,
+          // Present only for a multi-select: it is what tells the card to offer toggles and a
+          // confirm rather than one-tap buttons, and the bounds the confirm enforces.
+          ...(target.kind === 'multi-enum'
+            ? {
+                multi: {
+                  ...(target.minItems !== undefined ? { minItems: target.minItems } : {}),
+                  ...(target.maxItems !== undefined ? { maxItems: target.maxItems } : {})
+                }
+              }
+            : {})
+        }
       })
     } catch (err) {
       // An undelivered card can never be answered — drop the resolver and decline now
@@ -1380,11 +1414,12 @@ export class PermissionCoordinator {
   }
 
   /** A tapped elicitation-card button (SlackDeps.onElicitChoice): resolve the pending ACP
-   *  request — `accept` with the chosen value (under the field name), or `decline` for the
-   *  Dismiss button (value === null) — and edit the card in place. No-op if already gone. */
+   *  request — `accept` with the chosen value (a LIST of them for a multi-select, under the
+   *  field name), or `decline` for the Dismiss button (value === null) — and edit the card in
+   *  place. No-op if already gone. */
   async handleElicitChoice(a: {
     requestId: string
-    value: string | null
+    value: string | string[] | null
     actor?: InteractionActor
     /** Set only by the webchat ingress: the answering browser's conversation. It confines
      *  the answer to a card THIS conversation was shown — a webchat client can neither
@@ -1395,16 +1430,25 @@ export class PermissionCoordinator {
     // A DM elicitation card's request lives on the editor path (§2/§6.4).
     const editor = this.pendingEditorPermissions.get(a.requestId)
     if (editor?.kind === 'elicitation' && editor.notify) {
-      if (a.webchatConversationId !== undefined) return
+      // A DM card is a Slack button row, so it is never answered by a list or a browser.
+      if (a.webchatConversationId !== undefined || Array.isArray(a.value)) return
       return await this.handleDmElicitChoice(a.requestId, editor, a.value, a.actor)
     }
     const rec = this.pendingElicits.get(a.requestId)
     if (!rec) return
+    // A list answers a multi-select card and only that; a scalar answers the single-choice
+    // kinds. Dismiss (null) settles either.
+    if (a.value !== null && Array.isArray(a.value) !== (rec.kind === 'multi-enum')) return
+    const target = elicitTarget(rec.params, surfaceKinds(rec))
     if (a.webchatConversationId !== undefined) {
       if (rec.surface !== 'webchat' || rec.wc.conversationId !== a.webchatConversationId) return
       // The card names every answer it accepts; anything else would inject an unoffered
-      // value into the agent's content, so it is dropped and the card stays live.
-      if (a.value !== null && !elicitTarget(rec.params)?.options.some((o) => o.value === a.value)) return
+      // value into the agent's content, so it is dropped and the card stays live. A
+      // multi-select adds its own terms: no repeats, and a count its bounds allow.
+      const offered = Array.isArray(a.value)
+        ? !!target && multiSelectAccepts(target, a.value)
+        : !!target?.options.some((o) => o.value === a.value)
+      if (a.value !== null && !offered) return
       // A card settles only from its own surface: both share one `elicit-<n>` counter, so
       // without this a Slack tap could answer a live webchat card.
     } else if (rec.surface === 'webchat') return
@@ -1427,6 +1471,10 @@ export class PermissionCoordinator {
     if (a.value === null) {
       res = { action: 'decline' }
       decision = ':no_entry_sign: Dismissed'
+    } else if (Array.isArray(a.value)) {
+      // The array property's accepted content is the chosen list itself.
+      res = { action: 'accept', content: { [rec.propName]: a.value } }
+      decision = `:white_check_mark: ${chosenLabel(target, a.value)}`
     } else {
       const value = rec.kind === 'boolean' ? a.value === 'true' : a.value
       res = { action: 'accept', content: { [rec.propName]: value } }
@@ -1451,10 +1499,7 @@ export class PermissionCoordinator {
     this.pendingElicits.delete(a.requestId)
     this.syncApprovalActivity(rec.owner, rec.sessionId, { id: a.requestId, allowed: a.value !== null })
     if (rec.surface === 'webchat') {
-      const label =
-        a.value === null
-          ? undefined
-          : (elicitTarget(rec.params)?.options.find((o) => o.value === a.value)?.label ?? a.value)
+      const label = a.value === null ? undefined : chosenLabel(target, a.value)
       this.emitWebchatElicitResolved(rec, a.requestId, a.value === null ? 'dismissed' : 'accepted', label)
     } else if (rec.ts)
       void rec.conn

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -666,6 +666,8 @@ export function elicitTarget(params: CreateElicitationRequest, renderable: Elici
   const props = p.requestedSchema?.properties ?? {}
   const required = Array.isArray(p.requestedSchema?.required) ? (p.requestedSchema.required as unknown[]) : []
   // A required field we can't render is unanswerable: accepting without it would assert a lie.
+  // A candidate that fails this does NOT end the scan — a later property may be the sole
+  // required one, and returning here would decline a form this surface can in fact answer.
   const answerable = (t: ElicitTarget) => (required.every((r) => r === t.propName) ? t : null)
   for (const [name, prop] of Object.entries(props)) {
     if (prop?.type === 'string' && renderable.has('enum')) {
@@ -676,23 +678,30 @@ export function elicitTarget(params: CreateElicitationRequest, renderable: Elici
         : Array.isArray(en)
           ? en.map((v) => ({ value: String(v), label: clampTo(String(v), 75) }))
           : []
-      if (options.length) return answerable({ propName: name, kind: 'enum', options })
+      if (options.length) {
+        const t = answerable({ propName: name, kind: 'enum', options })
+        if (t) return t
+      }
     }
     if (prop?.type === 'array' && renderable.has('multi-enum')) {
       const options = arrayOptions(prop)
       const min = itemBound(prop.minItems)
       const max = itemBound(prop.maxItems)
-      if (options.length)
-        return answerable({
+      // Bounds that admit only the empty selection, or none at all, are not a question.
+      const askable = max === undefined || (max > 0 && max >= (min ?? 0))
+      if (options.length && askable) {
+        const t = answerable({
           propName: name,
           kind: 'multi-enum',
           options,
           ...(min !== undefined ? { minItems: min } : {}),
           ...(max !== undefined ? { maxItems: max } : {})
         })
+        if (t) return t
+      }
     }
     if (prop?.type === 'boolean' && renderable.has('boolean')) {
-      return answerable({
+      const t = answerable({
         propName: name,
         kind: 'boolean',
         options: [
@@ -700,6 +709,7 @@ export function elicitTarget(params: CreateElicitationRequest, renderable: Elici
           { value: 'false', label: 'No' }
         ]
       })
+      if (t) return t
     }
   }
   return null

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -599,26 +599,65 @@ export function buildPermissionUpdateCard(updateUrl: string): unknown[] {
 
 // ── Elicitation (ACP elicitation/create — structured questions) ──────────────
 
+/** The field shapes an elicitation card can reduce a form to. `multi-enum` answers with a
+ *  LIST of the chosen values, the other two with one scalar. */
+export type ElicitKind = 'enum' | 'boolean' | 'multi-enum'
+
+/** What a surface declares it is able to render. {@link elicitTarget} skips every property
+ *  whose kind is absent here, so a kind reaches a surface only once that surface claims it —
+ *  a new kind is invisible to every other surface without anyone remembering to exclude it. */
+export type ElicitSurfaceKinds = ReadonlySet<ElicitKind>
+
+/** Slack's card is a row of buttons: it can express "pick one", not "pick several, then
+ *  confirm", so multi-select is not renderable there and the form is declined instead. */
+export const SLACK_ELICIT_KINDS: ElicitSurfaceKinds = new Set<ElicitKind>(['enum', 'boolean'])
+
+/** Webchat's card renders options as toggles with a confirm control, so it takes all three. */
+export const WEBCHAT_ELICIT_KINDS: ElicitSurfaceKinds = new Set<ElicitKind>(['enum', 'boolean', 'multi-enum'])
+
 /** The one form field an elicitation card renders as buttons. */
 export interface ElicitTarget {
   /** Property name in the form schema — the key the accepted value is returned under. */
   propName: string
-  kind: 'enum' | 'boolean'
+  kind: ElicitKind
   /** Selectable options: `value` is the wire value returned in the accept content,
    *  `label` is the human button text. */
   options: { value: string; label: string }[]
+  /** Selection bounds from the array schema — `multi-enum` only, absent when unbounded. */
+  minItems?: number
+  maxItems?: number
+}
+
+/** The options an array property's `items` offers, plus the `anyOf`/`oneOf` titled form. */
+function arrayOptions(prop: Record<string, unknown>): { value: string; label: string }[] {
+  const items = prop.items as Record<string, unknown> | undefined
+  const choices = (items?.anyOf ?? items?.oneOf) as { const?: unknown; title?: unknown }[] | undefined
+  if (Array.isArray(choices))
+    // A non-string const would make the accepted list lie about the schema's item type.
+    return choices.every((o) => typeof o?.const === 'string')
+      ? choices.map((o) => ({ value: String(o.const), label: clampTo(String(o.title ?? o.const), 75) }))
+      : []
+  const en = items?.enum
+  return items?.type === 'string' && Array.isArray(en)
+    ? en.map((v) => ({ value: String(v), label: clampTo(String(v), 75) }))
+    : []
+}
+
+/** A schema bound, kept only when it is a sane non-negative integer. */
+function itemBound(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined
 }
 
 /**
- * Resolve the single form field an elicitation card renders (v1): the FIRST string-enum
- * (`oneOf` titled options or bare `enum`) or boolean property in the requested schema.
- * Returns null for URL-mode, an empty/absent schema, a form whose fields we can't render
- * inline (free text, numbers), or one that requires a property other than the rendered
- * target — the daemon then declines rather than accepting a partial answer. Pure, and
- * shared by {@link buildElicitationCard} and the daemon's click handler so the button
- * values and their interpretation can't drift.
+ * Resolve the single form field an elicitation card renders: the FIRST string-enum (`oneOf`
+ * titled options or bare `enum`), boolean, or string-array multi-select (`items.enum` or
+ * `items.anyOf`) property the CALLING SURFACE declares it can render. Returns null for
+ * URL-mode, an empty/absent schema, a form whose fields we can't render inline (free text,
+ * numbers), or one that requires a property other than the rendered target — the daemon then
+ * declines rather than accepting a partial answer. Pure, and shared by every surface so the
+ * option values and their interpretation can't drift.
  */
-export function elicitTarget(params: CreateElicitationRequest): ElicitTarget | null {
+export function elicitTarget(params: CreateElicitationRequest, renderable: ElicitSurfaceKinds): ElicitTarget | null {
   const p = params as {
     mode?: string
     requestedSchema?: { properties?: Record<string, Record<string, unknown>>; required?: unknown }
@@ -629,7 +668,7 @@ export function elicitTarget(params: CreateElicitationRequest): ElicitTarget | n
   // A required field we can't render is unanswerable: accepting without it would assert a lie.
   const answerable = (t: ElicitTarget) => (required.every((r) => r === t.propName) ? t : null)
   for (const [name, prop] of Object.entries(props)) {
-    if (prop?.type === 'string') {
+    if (prop?.type === 'string' && renderable.has('enum')) {
       const oneOf = prop.oneOf as { const?: unknown; title?: unknown }[] | undefined
       const en = prop.enum as unknown[] | undefined
       const options = Array.isArray(oneOf)
@@ -639,7 +678,20 @@ export function elicitTarget(params: CreateElicitationRequest): ElicitTarget | n
           : []
       if (options.length) return answerable({ propName: name, kind: 'enum', options })
     }
-    if (prop?.type === 'boolean') {
+    if (prop?.type === 'array' && renderable.has('multi-enum')) {
+      const options = arrayOptions(prop)
+      const min = itemBound(prop.minItems)
+      const max = itemBound(prop.maxItems)
+      if (options.length)
+        return answerable({
+          propName: name,
+          kind: 'multi-enum',
+          options,
+          ...(min !== undefined ? { minItems: min } : {}),
+          ...(max !== undefined ? { maxItems: max } : {})
+        })
+    }
+    if (prop?.type === 'boolean' && renderable.has('boolean')) {
       return answerable({
         propName: name,
         kind: 'boolean',
@@ -653,18 +705,29 @@ export function elicitTarget(params: CreateElicitationRequest): ElicitTarget | n
   return null
 }
 
+/** Whether a submitted list is an answer this multi-select target actually offered: every value
+ *  is one of its options, no repeats, and the count inside `minItems`/`maxItems`. */
+export function multiSelectAccepts(target: ElicitTarget, values: string[]): boolean {
+  if (target.kind !== 'multi-enum') return false
+  if (new Set(values).size !== values.length) return false
+  if (values.length < (target.minItems ?? 0)) return false
+  if (target.maxItems !== undefined && values.length > target.maxItems) return false
+  return values.every((v) => target.options.some((o) => o.value === v))
+}
+
 /**
  * Build the interactive elicitation card: the agent's `message`, an optional field title,
  * and an actions row of option buttons (one per {@link elicitTarget} option, capped at 5)
  * plus a Dismiss button. The choice rides each button `value` (`<requestId>|<optionValue>`).
- * Returns null when the form can't be rendered inline (caller declines). Pure.
+ * Returns null when the form can't be rendered inline (caller declines) — including a
+ * multi-select, which {@link SLACK_ELICIT_KINDS} withholds from this surface. Pure.
  */
 export function buildElicitationCard(
   requestId: string,
   params: CreateElicitationRequest,
   sessionTarget?: string
 ): unknown[] | null {
-  const target = elicitTarget(params)
+  const target = elicitTarget(params, SLACK_ELICIT_KINDS)
   if (!target) return null
   const message = (params as { message?: string }).message?.trim() || 'The agent needs your input'
   const buttons = target.options.slice(0, 5).map((o, i) => ({

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -9,6 +9,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { LocalStore } from '../src/store/local-store.js'
 import { listAgentPermissionRequests } from '../src/cp/config-apply-handlers.js'
+import { SlackConnection } from '../src/slack/connection.js'
+import { elicitTarget, WEBCHAT_ELICIT_KINDS } from '../src/slack/render.js'
 
 /**
  * Auto-approve policy for the daemon's OWN built-in MCP tools (UX fix): a human should
@@ -599,5 +601,141 @@ describe('webchat renders and answers ACP elicitation cards', () => {
     pending.webchat.continuation = true
     await expect((daemon as any).permissions.onAcpElicit('agent-1', 's1', formElicitation())).resolves.toBeUndefined()
     expect(sink.output).not.toHaveBeenCalled()
+  })
+})
+
+// ── multi-select on webchat only (issue #1794 gap 2) ─────────────────────────
+// A Slack card is a row of buttons and cannot express "pick several, then confirm", so the
+// kind is one webchat renders and Slack still declines — the surfaces declare what they can
+// render (`SLACK_ELICIT_KINDS` / `WEBCHAT_ELICIT_KINDS`) rather than each kind excluding Slack.
+
+/** A multi-select form: an array of enum items, bounded unless `schema` says otherwise. */
+function multiElicitation(items: Record<string, unknown> = {}): CreateElicitationRequest {
+  return formElicitation({
+    message: 'Which checks should I run?',
+    requestedSchema: {
+      type: 'object',
+      properties: {
+        checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test', 'build'] }, ...items }
+      },
+      required: ['checks']
+    }
+  })
+}
+
+describe('webchat answers a multi-select elicitation with a list', () => {
+  it('cards the options with their bounds, and accepts the confirmed list', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      multiElicitation({ minItems: 1, maxItems: 2 })
+    )
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    expect(cardEvents(sink)[0]).toEqual({
+      kind: 'elicitation',
+      requestId: expect.any(String),
+      message: 'Which checks should I run?',
+      options: [
+        { value: 'lint', label: 'lint' },
+        { value: 'test', label: 'test' },
+        { value: 'build', label: 'build' }
+      ],
+      // `multi` is what makes this card toggles + a confirm rather than one-tap buttons.
+      multi: { minItems: 1, maxItems: 2 }
+    })
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: ['lint', 'build'],
+      webchatConversationId: 'conv-1'
+    })
+    // The accepted content is the LIST, under the array property's name.
+    await expect(result).resolves.toEqual({ action: 'accept', content: { checks: ['lint', 'build'] } })
+    expect(cardEvents(sink)[1]).toEqual({
+      kind: 'elicitation_resolved',
+      requestId,
+      outcome: 'accepted',
+      // Every chosen label, in the words the card used — the single-select reading, extended.
+      label: 'lint, build'
+    })
+  })
+
+  it('re-checks the browser’s list: bounds, repeats, unoffered values, and the wrong shape', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      multiElicitation({ minItems: 2, maxItems: 2 })
+    )
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    const answer = (value: unknown, conversationId = 'conv-1') =>
+      (daemon as any).permissions.handleElicitChoice({ requestId, value, webchatConversationId: conversationId })
+
+    await answer(['lint']) // below minItems
+    await answer(['lint', 'test', 'build']) // above maxItems
+    await answer(['lint', 'lint']) // a repeat is not two picks
+    await answer(['lint', 'rm -rf /']) // one unoffered value rejects the WHOLE answer
+    await answer('lint') // a scalar cannot answer a multi-select card
+    await answer(['lint', 'test'], 'conv-other') // another conversation was never shown this card
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(cardEvents(sink)).toHaveLength(1) // still live — nothing settled it
+
+    await answer(['lint', 'test'])
+    await expect(result).resolves.toEqual({ action: 'accept', content: { checks: ['lint', 'test'] } })
+  })
+
+  it('takes an unbounded empty confirm and a Dismiss apart', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    expect(cardEvents(sink)[0].multi).toEqual({})
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    // "None of them" is an ANSWER when the schema sets no minimum — not a refusal to answer.
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: [], webchatConversationId: 'conv-1' })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { checks: [] } })
+    expect(cardEvents(sink)[1]).toEqual({
+      kind: 'elicitation_resolved',
+      requestId,
+      outcome: 'accepted',
+      label: 'Nothing selected'
+    })
+
+    const dismissed = (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [secondId] = (daemon as any).permissions.pendingElicits.keys()
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId: secondId,
+      value: null,
+      webchatConversationId: 'conv-1'
+    })
+    await expect(dismissed).resolves.toEqual({ action: 'decline' })
+  })
+
+  it('still declines a multi-select on a Slack turn, whose card cannot express it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    // A Slack turn: chat input cards, and a connection the elicitation path recognizes.
+    pending.plan.platform = 'slack'
+    pending.conn = Object.create(SlackConnection.prototype)
+
+    await expect(
+      (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation({ minItems: 1 }))
+    ).resolves.toBeUndefined()
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+    // The same form IS renderable — just not here: webchat cards it.
+    expect(elicitTarget(multiElicitation({ minItems: 1 }), WEBCHAT_ELICIT_KINDS)?.kind).toBe('multi-enum')
   })
 })

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -1381,6 +1381,69 @@ describe('elicitation card', () => {
   const form = (properties: Record<string, unknown>, message = 'Pick a language'): CreateElicitationRequest =>
     ({ mode: 'form', sessionId: 's1', message, requestedSchema: { type: 'object', properties } }) as any
 
+  // A candidate that cannot satisfy `required` must not end the scan: before multi-select
+  // existed the array was skipped and the boolean rendered, so returning here would have
+  // regressed a form this surface can answer.
+  it('keeps scanning past a candidate that cannot satisfy required', () => {
+    const req = {
+      mode: 'form',
+      sessionId: 's1',
+      message: 'Ship it?',
+      requestedSchema: {
+        type: 'object',
+        properties: {
+          colors: { type: 'array', items: { type: 'string', enum: ['red', 'green'] } },
+          ok: { type: 'boolean' }
+        },
+        required: ['ok']
+      }
+    } as any
+    expect(elicitTarget(req, WEBCHAT_ELICIT_KINDS)).toMatchObject({ propName: 'ok', kind: 'boolean' })
+    expect(elicitTarget(req, SLACK_ELICIT_KINDS)).toMatchObject({ propName: 'ok', kind: 'boolean' })
+  })
+
+  it('reaches a later enum when an earlier optional one is not the required field', () => {
+    const req = {
+      mode: 'form',
+      sessionId: 's1',
+      message: 'Pick',
+      requestedSchema: {
+        type: 'object',
+        properties: {
+          hint: { type: 'string', enum: ['a', 'b'] },
+          branch: { type: 'string', enum: ['main', 'dev'] }
+        },
+        required: ['branch']
+      }
+    } as any
+    expect(elicitTarget(req, SLACK_ELICIT_KINDS)).toMatchObject({ propName: 'branch' })
+  })
+
+  it('declines when two properties are required, since one card answers one field', () => {
+    const req = {
+      mode: 'form',
+      sessionId: 's1',
+      message: 'Pick',
+      requestedSchema: {
+        type: 'object',
+        properties: { a: { type: 'string', enum: ['x'] }, b: { type: 'boolean' } },
+        required: ['a', 'b']
+      }
+    } as any
+    expect(elicitTarget(req, WEBCHAT_ELICIT_KINDS)).toBeNull()
+  })
+
+  // maxItems 0 admits only the empty selection, so it is not a question — and emitting it
+  // would fail the wire schema, dropping the card while the ACP request stayed live.
+  it('skips a multi-select whose bounds admit nothing to choose', () => {
+    const zero = form({ tags: { type: 'array', maxItems: 0, items: { type: 'string', enum: ['a', 'b'] } } })
+    expect(elicitTarget(zero, WEBCHAT_ELICIT_KINDS)).toBeNull()
+    const inverted = form({
+      tags: { type: 'array', minItems: 2, maxItems: 1, items: { type: 'string', enum: ['a', 'b'] } }
+    })
+    expect(elicitTarget(inverted, WEBCHAT_ELICIT_KINDS)).toBeNull()
+  })
+
   it('renders titled enum (oneOf) as buttons carrying requestId|const, plus Dismiss', () => {
     const req = form({
       lang: {

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -13,6 +13,9 @@ import {
   buildElicitationResolvedCard,
   buildAttributionBlocks,
   elicitTarget,
+  SLACK_ELICIT_KINDS,
+  WEBCHAT_ELICIT_KINDS,
+  multiSelectAccepts,
   encodePermValue,
   decodePermValue,
   PERMISSION_ACTION_PREFIX,
@@ -1400,7 +1403,7 @@ describe('elicitation card', () => {
   })
 
   it('renders bare string enum with value == label', () => {
-    const t = elicitTarget(form({ color: { type: 'string', enum: ['red', 'green'] } }))
+    const t = elicitTarget(form({ color: { type: 'string', enum: ['red', 'green'] } }), SLACK_ELICIT_KINDS)
     expect(t).toEqual({
       propName: 'color',
       kind: 'enum',
@@ -1412,7 +1415,7 @@ describe('elicitation card', () => {
   })
 
   it('renders boolean as Yes/No', () => {
-    const t = elicitTarget(form({ ok: { type: 'boolean' } }))
+    const t = elicitTarget(form({ ok: { type: 'boolean' } }), SLACK_ELICIT_KINDS)
     expect(t).toEqual({
       propName: 'ok',
       kind: 'boolean',
@@ -1430,7 +1433,7 @@ describe('elicitation card', () => {
       message: 'Pick a language',
       requestedSchema: { type: 'object', properties: { color: { type: 'string', enum: ['red'] } }, required: ['color'] }
     } as any
-    expect(elicitTarget(req)?.propName).toBe('color')
+    expect(elicitTarget(req, SLACK_ELICIT_KINDS)?.propName).toBe('color')
   })
 
   it('renders when extra non-required properties ride along', () => {
@@ -1448,7 +1451,7 @@ describe('elicitation card', () => {
         required: ['color']
       }
     } as any
-    expect(elicitTarget(req)?.propName).toBe('color')
+    expect(elicitTarget(req, SLACK_ELICIT_KINDS)?.propName).toBe('color')
   })
 
   it('returns null when the schema requires a property the card cannot answer', () => {
@@ -1462,7 +1465,7 @@ describe('elicitation card', () => {
         required: ['color', 'note']
       }
     } as any
-    expect(elicitTarget(req)).toBeNull()
+    expect(elicitTarget(req, SLACK_ELICIT_KINDS)).toBeNull()
     expect(buildElicitationCard('e', req)).toBeNull()
   })
 
@@ -1477,17 +1480,110 @@ describe('elicitation card', () => {
         required: ['ok', 'reason']
       }
     } as any
-    expect(elicitTarget(req)).toBeNull()
+    expect(elicitTarget(req, SLACK_ELICIT_KINDS)).toBeNull()
   })
 
   it('renders when required is absent', () => {
-    expect(elicitTarget(form({ ok: { type: 'boolean' } }))?.propName).toBe('ok')
+    expect(elicitTarget(form({ ok: { type: 'boolean' } }), SLACK_ELICIT_KINDS)?.propName).toBe('ok')
   })
 
   it('returns null (→ caller declines) for free-text-only forms and url mode', () => {
-    expect(elicitTarget(form({ name: { type: 'string' } }))).toBeNull()
+    expect(elicitTarget(form({ name: { type: 'string' } }), SLACK_ELICIT_KINDS)).toBeNull()
     expect(buildElicitationCard('e', form({ name: { type: 'string' } }))).toBeNull()
-    expect(elicitTarget({ mode: 'url', sessionId: 's1', message: 'go', url: 'https://x' } as any)).toBeNull()
+    expect(
+      elicitTarget({ mode: 'url', sessionId: 's1', message: 'go', url: 'https://x' } as any, SLACK_ELICIT_KINDS)
+    ).toBeNull()
+  })
+
+  // ── multi-select (issue #1794 gap 2): webchat renders it, a Slack button row cannot ──
+
+  it('reads both array shapes as one multi-enum target, with the schema bounds', () => {
+    const bare = elicitTarget(
+      form({ colors: { type: 'array', items: { type: 'string', enum: ['Red', 'Green'] }, minItems: 1, maxItems: 2 } }),
+      WEBCHAT_ELICIT_KINDS
+    )
+    expect(bare).toEqual({
+      propName: 'colors',
+      kind: 'multi-enum',
+      options: [
+        { value: 'Red', label: 'Red' },
+        { value: 'Green', label: 'Green' }
+      ],
+      minItems: 1,
+      maxItems: 2
+    })
+    const titled = elicitTarget(
+      form({
+        colors: {
+          type: 'array',
+          items: {
+            anyOf: [
+              { const: '#FF0000', title: 'Red' },
+              { const: '#00FF00', title: 'Green' }
+            ]
+          }
+        }
+      }),
+      WEBCHAT_ELICIT_KINDS
+    )
+    // Unbounded: no minItems/maxItems invented where the schema states none.
+    expect(titled).toEqual({
+      propName: 'colors',
+      kind: 'multi-enum',
+      options: [
+        { value: '#FF0000', label: 'Red' },
+        { value: '#00FF00', label: 'Green' }
+      ]
+    })
+  })
+
+  it('leaves multi-select unrenderable on Slack, whose card would have to decline it', () => {
+    const req = form({ colors: { type: 'array', items: { type: 'string', enum: ['Red', 'Green'] } } })
+    expect(elicitTarget(req, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(buildElicitationCard('elicit-1', req)).toBeNull()
+  })
+
+  it('skips a field the surface cannot render and takes the next one it can', () => {
+    // Slack passes over the array and cards the boolean, exactly as it did before the kind existed.
+    const req = form({ colors: { type: 'array', items: { type: 'string', enum: ['Red'] } }, ok: { type: 'boolean' } })
+    expect(elicitTarget(req, SLACK_ELICIT_KINDS)?.propName).toBe('ok')
+    expect(elicitTarget(req, WEBCHAT_ELICIT_KINDS)?.propName).toBe('colors')
+  })
+
+  it('declines an array the card cannot honestly answer', () => {
+    // Non-string item consts would make the accepted list lie about the schema's item type,
+    // an untyped/free-form array has nothing to offer, and a required peer is still fatal.
+    const anyOfNumbers = form({ n: { type: 'array', items: { anyOf: [{ const: 1, title: 'One' }] } } })
+    expect(elicitTarget(anyOfNumbers, WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(form({ tags: { type: 'array', items: { type: 'string' } } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    const required = {
+      mode: 'form',
+      sessionId: 's1',
+      message: 'Pick colors',
+      requestedSchema: {
+        type: 'object',
+        properties: { colors: { type: 'array', items: { type: 'string', enum: ['Red'] } }, note: { type: 'string' } },
+        required: ['colors', 'note']
+      }
+    } as any
+    expect(elicitTarget(required, WEBCHAT_ELICIT_KINDS)).toBeNull()
+  })
+
+  it('accepts only a submitted list the card offered, without repeats and inside its bounds', () => {
+    const target = elicitTarget(
+      form({
+        colors: { type: 'array', items: { type: 'string', enum: ['Red', 'Green', 'Blue'] }, minItems: 1, maxItems: 2 }
+      }),
+      WEBCHAT_ELICIT_KINDS
+    )!
+    expect(multiSelectAccepts(target, ['Red'])).toBe(true)
+    expect(multiSelectAccepts(target, ['Red', 'Blue'])).toBe(true)
+    expect(multiSelectAccepts(target, [])).toBe(false) // below minItems
+    expect(multiSelectAccepts(target, ['Red', 'Green', 'Blue'])).toBe(false) // above maxItems
+    expect(multiSelectAccepts(target, ['Red', 'Red'])).toBe(false) // a repeat is not two picks
+    expect(multiSelectAccepts(target, ['rm -rf /'])).toBe(false) // never offered
+    const single = elicitTarget(form({ color: { type: 'string', enum: ['Red'] } }), WEBCHAT_ELICIT_KINDS)!
+    expect(multiSelectAccepts(single, ['Red'])).toBe(false) // not a multi-select card at all
   })
 
   it('resolved card is a single section with the decision', () => {

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -197,6 +197,9 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       { op: 'cancel' },
       { op: 'elicitation_choice', requestId: 'elicit-1', value: 'yes' },
       { op: 'elicitation_choice', requestId: 'elicit-1', value: null, agentId: AGENT_ID },
+      // A multi-select answers with the chosen LIST — same op, widened value.
+      { op: 'elicitation_choice', requestId: 'elicit-1', value: ['lint', 'build'] },
+      { op: 'elicitation_choice', requestId: 'elicit-1', value: [] },
       { op: 'close' }
     ]
     for (const payload of ops) {
@@ -221,6 +224,9 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     // The elicitation answer is a value or an explicit Dismiss — never an absent field,
     // which would let a malformed frame read as a decline the user never made.
     expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'elicit-1' }).success).toBe(false)
+    expect(
+      RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'elicit-1', value: ['ok', 3] }).success
+    ).toBe(false)
     expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: '', value: 'y' }).success).toBe(false)
     expect(
       RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'elicit-1', value: 'y', agentId: 'nope' }).success

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -210,11 +210,14 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
   // The answer to an in-band elicitation card (the `elicitation` WebchatEvent). `value`
   // is the chosen option's wire value and `null` is Dismiss — the same shape as the Slack
   // `elicitation-choice` action below, so the two wires stay recognizably one design.
+  // A multi-select card answers with the LIST of chosen values: widening this field rather
+  // than adding a second one keeps the failure closed, since a daemon predating multi-select
+  // rejects the whole op (the card stays live) instead of reading a stripped list as Dismiss.
   // `agentId` names the participant whose card this is; absent ⇒ the sole agent.
   z.object({
     op: z.literal('elicitation_choice'),
     requestId: z.string().min(1).max(200),
-    value: z.string().nullable(),
+    value: z.union([z.string(), z.array(z.string()).max(100), z.null()]),
     agentId: z.string().uuid().optional()
   }),
   z.object({ op: z.literal('close') })

--- a/packages/protocol/src/frames/webchat.test.ts
+++ b/packages/protocol/src/frames/webchat.test.ts
@@ -86,6 +86,31 @@ describe('WebchatOutput — event / status framing', () => {
     }
   })
 
+  it('marks a multi-select card with its bounds, and leaves the single-choice card untouched', () => {
+    const card = (event: Record<string, unknown>) =>
+      WebchatOutput.safeParse({ conversationId: CONV, turnId: TURN, index: 4, event })
+    const base = {
+      kind: 'elicitation',
+      requestId: 'elicit-1',
+      message: 'Which checks should I run?',
+      options: [
+        { value: 'lint', label: 'lint' },
+        { value: 'test', label: 'test' }
+      ]
+    }
+    const multi = card({ ...base, multi: { minItems: 1, maxItems: 2 } })
+    expect(multi.success).toBe(true)
+    if (multi.success && multi.data.event?.kind === 'elicitation') expect(multi.data.event.multi?.maxItems).toBe(2)
+    // Unbounded, and the original single-choice card — `multi` absent means "pick exactly one",
+    // so every payload written before this field keeps decoding to what it always meant.
+    expect(card({ ...base, multi: {} }).success).toBe(true)
+    const single = card(base)
+    expect(single.success).toBe(true)
+    if (single.success && single.data.event?.kind === 'elicitation') expect(single.data.event.multi).toBeUndefined()
+    expect(card({ ...base, multi: { minItems: -1 } }).success).toBe(false)
+    expect(card({ ...base, multi: { maxItems: 1.5 } }).success).toBe(false)
+  })
+
   it('rejects an unrenderable elicitation frame rather than streaming a dead card', () => {
     const bad = (event: unknown) =>
       WebchatOutput.safeParse({ conversationId: CONV, turnId: TURN, index: 6, event }).success

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -174,7 +174,7 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
     // (zod strips what it does not know) instead of dropping the frame the way an unknown
     // kind would, and a daemon predating it simply never sets it.
     multi: z
-      .object({ minItems: z.number().int().min(0).optional(), maxItems: z.number().int().min(1).optional() })
+      .object({ minItems: z.number().int().min(0).optional(), maxItems: z.number().int().min(0).optional() })
       .optional()
   }),
   // The same card, settled. Slack rewrites its message in place; this stream is

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -167,11 +167,20 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
     kind: z.literal('elicitation'),
     requestId: z.string().min(1).max(200),
     message: z.string(),
-    options: z.array(z.object({ value: z.string(), label: z.string() })).min(1)
+    options: z.array(z.object({ value: z.string(), label: z.string() })).min(1),
+    // Absent ⇒ pick exactly ONE option, the original card. Present ⇒ pick several of the same
+    // options and confirm, and the answer is a list. An added OPTIONAL field rather than a new
+    // event kind on purpose: a relay or browser predating it decodes the event unchanged
+    // (zod strips what it does not know) instead of dropping the frame the way an unknown
+    // kind would, and a daemon predating it simply never sets it.
+    multi: z
+      .object({ minItems: z.number().int().min(0).optional(), maxItems: z.number().int().min(1).optional() })
+      .optional()
   }),
   // The same card, settled. Slack rewrites its message in place; this stream is
   // append-only, so the collapse is a second event keyed by the same `requestId`.
-  // `label` is the chosen option's label and is present only on 'accepted'.
+  // `label` is the chosen option's label — the chosen labels joined, for a multi-select —
+  // and is present only on 'accepted'.
   z.object({
     kind: z.literal('elicitation_resolved'),
     requestId: z.string().min(1).max(200),

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -175,6 +175,14 @@ describe('parseBrowserFrame', () => {
     expect(
       parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: null, agentId: AGENT }, USER)
     ).toEqual({ op: { op: 'elicitation_choice', requestId: 'elicit-1', value: null, agentId: AGENT } })
+    // A multi-select answers with the chosen list; anything else in it is not an answer.
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: ['a', 'b'] }, USER)).toEqual({
+      op: { op: 'elicitation_choice', requestId: 'elicit-1', value: ['a', 'b'] }
+    })
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: [] }, USER)).toEqual({
+      op: { op: 'elicitation_choice', requestId: 'elicit-1', value: [] }
+    })
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: ['a', 7] }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1' }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', value: 'yes' }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: '', value: 'yes' }, USER)).toBeNull()

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -193,9 +193,11 @@ export function parseBrowserFrame(
         ? { op: { op: 'cancel', ...(typeof m.agentId === 'string' ? { agentId: m.agentId.toLowerCase() } : {}) } }
         : null
     case 'elicitation_choice': {
-      // The answer to an in-band elicitation card. `value: null` is Dismiss; the daemon
-      // matches the requestId against its own pending card and rejects anything else.
-      if (typeof m.requestId !== 'string' || (typeof m.value !== 'string' && m.value !== null)) return null
+      // The answer to an in-band elicitation card. `value: null` is Dismiss and an array is a
+      // multi-select's chosen list; the daemon matches the requestId against its own pending
+      // card, and re-checks every value against the options that card offered.
+      const listed = Array.isArray(m.value) && m.value.every((v) => typeof v === 'string')
+      if (typeof m.requestId !== 'string' || (typeof m.value !== 'string' && m.value !== null && !listed)) return null
       if (m.agentId !== undefined && !(typeof m.agentId === 'string' && UUID_RE.test(m.agentId))) return null
       const parsed = RelayWebchatOp.safeParse({
         op: 'elicitation_choice',

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -127,12 +127,12 @@ interface PlaygroundData {
   pgSetFast: (id: string, agentId: string, fastMode: boolean, conversationId?: string) => void
   /** Interrupt the running turn without ending the session. */
   pgCancel: (id: string, agentId: string, conversationId?: string) => void
-  /** Answer the agent's in-band elicitation card; `value: null` is Dismiss. */
+  /** Answer the agent's in-band elicitation card; a list answers a multi-select, `null` is Dismiss. */
   pgAnswerElicitation: (
     id: string,
     agentId: string,
     requestId: string,
-    value: string | null,
+    value: string | string[] | null,
     conversationId?: string
   ) => void
   getPgSession: (id: string) => Session | undefined
@@ -245,7 +245,13 @@ type WebchatEvent =
   | { kind: 'superseded'; generation: number }
   | { kind: 'notice'; text: string }
   | { kind: 'plan'; entries: { content: string; status: string; priority?: string }[] }
-  | { kind: 'elicitation'; requestId: string; message: string; options: { value: string; label: string }[] }
+  | {
+      kind: 'elicitation'
+      requestId: string
+      message: string
+      options: { value: string; label: string }[]
+      multi?: { minItems?: number; maxItems?: number }
+    }
   | {
       kind: 'elicitation_resolved'
       requestId: string
@@ -612,7 +618,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             lane({
               kind: 'elicit',
               text: ev.message,
-              elicit: { requestId: ev.requestId, options: ev.options },
+              elicit: { requestId: ev.requestId, options: ev.options, ...(ev.multi ? { multi: ev.multi } : {}) },
               boundary: true
             })
           ]
@@ -1709,7 +1715,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
    *  Deliberately NOT optimistic: the daemon owns the card's outcome and settles it with
    *  the `elicitation_resolved` event, so a refused answer leaves the card answerable. */
   const pgAnswerElicitation = useCallback(
-    (id: string, agentForId: string, requestId: string, value: string | null, conversationId?: string) => {
+    (id: string, agentForId: string, requestId: string, value: string | string[] | null, conversationId?: string) => {
       connect(id, agentForId, conversationId)
         .ready.then((ws) =>
           ws.send(JSON.stringify({ type: 'elicitation_choice', requestId, value, agentId: agentForId }))

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -230,6 +230,64 @@ describe('the agent’s elicitation card on the session page', () => {
     expect(live.answered[1]).toEqual(['session-1', 'agent-1', 'elicit-1', null, 'conv-1'])
   })
 
+  it('toggles a multi-select and answers with the list only on Confirm', async () => {
+    live.steps = [
+      { ...CARD, text: 'Which checks should I run?', elicit: { ...CARD.elicit, multi: { minItems: 1, maxItems: 2 } } }
+    ]
+    await render()
+
+    // Nothing picked yet, so there is nothing valid to confirm.
+    expect(text()).toContain('Select 1–2')
+    expect(buttonNamed('Confirm')?.disabled).toBe(true)
+
+    await act(async () => {
+      buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // A toggle is not an answer: the option is held, not sent.
+    expect(live.answered).toEqual([])
+    expect(buttonNamed('main')?.getAttribute('aria-pressed')).toBe('true')
+    expect(buttonNamed('Confirm')?.disabled).toBe(false)
+
+    await act(async () => {
+      buttonNamed('develop')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {
+      buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(buttonNamed('main')?.getAttribute('aria-pressed')).toBe('false')
+
+    await act(async () => {
+      buttonNamed('Confirm')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', ['develop'], 'conv-1']])
+  })
+
+  it('stops offering picks the card would have to refuse, and confirms an empty unbounded set', async () => {
+    live.steps = [{ ...CARD, elicit: { ...CARD.elicit, multi: { maxItems: 1 } } }]
+    await render()
+
+    // No minimum: "none of them" is an answer this card accepts from the start.
+    expect(text()).toContain('Select up to 1')
+    expect(buttonNamed('Confirm')?.disabled).toBe(false)
+
+    await act(async () => {
+      buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // At the cap the unpicked option goes inert; the picked one still un-picks.
+    expect(buttonNamed('develop')?.disabled).toBe(true)
+    expect(buttonNamed('main')?.disabled).toBe(false)
+
+    await act(async () => {
+      buttonNamed('Confirm')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', ['main'], 'conv-1']])
+  })
+
+  it('keeps a single-choice card answering on the tap, with no confirm to press', async () => {
+    await render()
+    expect(buttonNamed('Confirm')).toBeUndefined()
+  })
+
   it('collapses to its outcome once settled, leaving nothing left to answer', async () => {
     live.steps = [{ ...CARD, elicit: { ...CARD.elicit, outcome: 'accepted', answerLabel: 'develop' } }]
     await render()

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -646,11 +646,26 @@ const ELICIT_OUTCOME: Record<string, { icon: string; color: string; label: (answ
   cancelled: { icon: 'clock', color: 'var(--text-tertiary)', label: () => 'Cancelled' }
 }
 
+/** What a multi-select card asks of the reader, from the schema's bounds. */
+function selectionHint(min: number, max?: number): string {
+  if (min > 0 && max !== undefined) return min === max ? `Select exactly ${min}` : `Select ${min}–${max}`
+  if (min > 0) return `Select at least ${min}`
+  return max !== undefined ? `Select up to ${max}` : 'Select any that apply'
+}
+
 /** The agent's in-band question: its options while it is live, its outcome once settled.
+ *  A multi-select (`elicit.multi`) toggles its options and answers with the list on Confirm —
+ *  one tap can't express a set — while a single-choice card still answers on the tap itself.
  *  Without `onAnswer` — a reader with no live socket to answer over — the same card renders
  *  as a plain record of the ask, controls inert rather than missing. */
-function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value: string | null) => void }) {
+function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value: string | string[] | null) => void }) {
+  const [picked, setPicked] = useState<string[]>([])
   const elicit = step.elicit
+  const multi = elicit?.multi
+  const min = multi?.minItems ?? 0
+  const max = multi?.maxItems
+  // The same bounds the daemon re-checks: a browser frame is not what makes an answer valid.
+  const complete = picked.length >= min && (max === undefined || picked.length <= max)
   if (!elicit) return null
   const settled = elicit.outcome ? ELICIT_OUTCOME[elicit.outcome] : undefined
   return (
@@ -671,17 +686,47 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
           </span>
         ) : (
           <>
-            {elicit.options.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                className="chip max-w-full truncate disabled:cursor-default disabled:opacity-55"
-                disabled={!onAnswer}
-                onClick={() => onAnswer?.(option.value)}
-              >
-                {option.label}
-              </button>
-            ))}
+            {elicit.options.map((option) => {
+              const on = picked.includes(option.value)
+              // At the cap, the options still unpicked stop taking a tap — an answer the card
+              // would have to refuse should not look available in the first place.
+              const capped = !!multi && !on && max !== undefined && picked.length >= max
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  {...(multi ? { 'aria-pressed': on } : {})}
+                  className={
+                    on
+                      ? 'chip max-w-full truncate border-(--brand) bg-(--brand-soft) text-(--brand-soft-text) disabled:cursor-default disabled:opacity-55'
+                      : 'chip max-w-full truncate disabled:cursor-default disabled:opacity-55'
+                  }
+                  disabled={!onAnswer || capped}
+                  onClick={() =>
+                    multi
+                      ? setPicked((prev) => (on ? prev.filter((v) => v !== option.value) : [...prev, option.value]))
+                      : onAnswer?.(option.value)
+                  }
+                >
+                  {option.label}
+                </button>
+              )
+            })}
+            {multi && (
+              <>
+                <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+                  {selectionHint(min, max)}
+                </span>
+                <button
+                  type="button"
+                  className="dsbtn dsbtn-primary xs"
+                  disabled={!onAnswer || !complete}
+                  onClick={() => onAnswer?.(picked)}
+                >
+                  Confirm
+                </button>
+              </>
+            )}
             <button
               type="button"
               className="chip disabled:cursor-default disabled:opacity-55"
@@ -2910,7 +2955,7 @@ export default function SessionDetailView() {
   // the card renders inert rather than offering buttons that would go nowhere.
   const answerElicitation =
     isLive && (isPg || isWebchat)
-      ? (agentId: string | undefined, requestId: string | undefined, value: string | null): void => {
+      ? (agentId: string | undefined, requestId: string | undefined, value: string | string[] | null): void => {
           if (!requestId) return
           pgAnswerElicitation(session.id, agentId ?? session.agentId ?? '', requestId, value, webchatConversationId)
         }
@@ -4312,7 +4357,7 @@ export default function SessionDetailView() {
                                           step={st}
                                           {...(answerElicitation
                                             ? {
-                                                onAnswer: (value: string | null) =>
+                                                onAnswer: (value: string | string[] | null) =>
                                                   answerElicitation(turn.agentId, st.elicit?.requestId, value)
                                               }
                                             : {})}

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1130,6 +1130,9 @@ export interface SessionStep {
   elicit?: {
     requestId: string
     options: { value: string; label: string }[]
+    /** Present ⇒ the card picks SEVERAL options and confirms, and answers with the list.
+     *  Absent ⇒ one option, answered on the tap. */
+    multi?: { minItems?: number; maxItems?: number }
     outcome?: 'accepted' | 'dismissed' | 'cancelled'
     answerLabel?: string
   }


### PR DESCRIPTION
Implements #1794 gap 2, for webchat. Multi-select is first-class in MCP `2025-11-25` and mirrored by ACP, and we declined both of its array shapes:

```jsonc
{ "type": "array", "items": { "type": "string", "enum": ["Red","Green","Blue"] } }          // bare
{ "type": "array", "items": { "anyOf": [ {"const":"#FF0000","title":"Red"}, … ] } }          // titled
```

The accepted value for such a property is a **list** of wire values, not a scalar.

## Surfaces declare what they render; kinds do not exclude surfaces

`elicitTarget()` is shared by every surface precisely so the two can never disagree about what is renderable or what an option value means, so adding a kind to it would have leaked multi-select onto Slack — where the card is a row of buttons and cannot express "pick several, then confirm".

Rather than teach the new kind to avoid Slack, the surface now states its own vocabulary:

```ts
elicitTarget(params, renderable: ElicitSurfaceKinds)
SLACK_ELICIT_KINDS   = { enum, boolean }
WEBCHAT_ELICIT_KINDS = { enum, boolean, multi-enum }
```

A property whose kind the caller did not claim is **skipped** and the scan continues — byte-identical to today's Slack behavior, where an `array` property simply matched no arm. So a new kind is invisible to every surface that has not claimed it, without anyone remembering to exclude anything, and a new surface cannot compile without saying what it renders.

`buildElicitationCard` passes `SLACK_ELICIT_KINDS`, so a multi-only form still returns null and the Slack path declines exactly as before. There are tests for that, including a coordinator test where the same form declines on a Slack turn and renders on webchat.

Re-deriving a card's target on answer asks the same question the post did (`surfaceKinds(rec)`), so a card can never be read back as a field its surface never showed.

## Wire: widened, not branched

- `WebchatEvent.elicitation` gains optional `multi: { minItems?, maxItems? }`. Absent means "pick exactly one", so every payload written before this decodes to what it always meant. A consumer predating the field strips it (the schemas are non-strict) instead of rejecting the frame, which a new event *kind* would have done — the file's own `plan` comment documents that failure mode.
- `RelayWebchatOp.elicitation_choice.value` widens from `string | null` to `string | string[] | null` (list capped at 100). Widening the existing field rather than adding a sibling `values?: string[]` **fails closed**: an old daemon rejects the whole op and the card stays live, whereas a stripped `values` next to `value: null` would have read as a Dismiss the user never sent.

## The answer is re-validated, never trusted

A browser is not a Slack button. On top of the existing conversation- and surface-binding guards:

- **Shape**: a list answers a `multi-enum` card and only that; a scalar answers the single-choice kinds; `null` (Dismiss) settles either.
- **Whitelist and bounds** (`multiSelectAccepts`): every value must be one the card offered, with no repeats and a count inside `minItems`/`maxItems`. One bad value rejects the whole answer and leaves the card live. The UI enforces the same bounds by disabling Confirm, but the daemon does not rely on that.

Duplicates are rejected rather than de-duplicated — a repeat is not two picks.

## Presentation

The settled card names the answer with the chosen **labels**, joined (`lint, build`) — what the reader actually picked, in the words the card used, since values may be opaque (`#FF0000`). An accepted empty list, legal only when `minItems` allows it, says `Nothing selected` rather than rendering as nothing.

## Known limits

- A `minItems: 0` form gives the user a Confirm and a Dismiss that look identical but map to `accept []` and `decline`. That ambiguity is inherited from ACP's action model, not introduced here.
- A new daemon streaming a `multi` card to an older browser renders one-tap buttons whose scalar answer the daemon then rejects, so the card looks inert. There is no client capability echo to gate on; the failure is silent but safe. Tracked on #1794.
- Multi-select on Slack, Telegram, Discord and Feishu remain their own queue items; on Slack it should become a modal multi-select rather than a cap.

## Verification

- protocol 484 passed, relay 644 passed, web 2380 passed.
- `packages/daemon`: `render` / `daemon-permission-autoallow` / `daemon-webchat` / `approval-dm` — 269 passed.
- `pnpm typecheck` clean (independently re-run; it covers tests).
- eslint + prettier clean on all 14 changed files.

New coverage: both array shapes with and without bounds; non-string `anyOf` consts, an untyped array and an extra required peer all decline; the `multiSelectAccepts` bounds/repeat/whitelist matrix; Slack declining multi-select at both `elicitTarget` and `buildElicitationCard`; skip-to-next-field equivalence; daemon accept of the list plus bounds/repeat/unoffered/wrong-shape/foreign-conversation rejections; empty-confirm vs Dismiss; protocol and relay codec cases; console toggle-then-Confirm, cap behavior, empty unbounded confirm, and no Confirm on a single-choice card.
