### PR TITLE
feat(web): add keyword search to the composer's agent pickers

### DIFF
--- a/packages/web/src/components/console/ComposerMenu.test.tsx
+++ b/packages/web/src/components/console/ComposerMenu.test.tsx
@@ -28,6 +28,37 @@ function Harness() {
   )
 }
 
+function SearchHarness() {
+  const [open, setOpen] = useState(false)
+  const [value, setValue] = useState('a1')
+  return (
+    <ComposerMenu
+      title="Agent"
+      value={value}
+      options={[
+        { value: 'a1', label: 'sentio-reviewer' },
+        { value: 'a2', label: 'Processor Doctor' },
+        { value: 'a3', label: 'Move Builder' }
+      ]}
+      searchable
+      searchPlaceholder="Search agents…"
+      open={open}
+      onOpenChange={setOpen}
+      onChange={setValue}
+    />
+  )
+}
+
+const labels = (scope: ParentNode) =>
+  Array.from(scope.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]')).map((o) => o.textContent)
+
+function setInput(input: HTMLInputElement, text: string) {
+  // React's controlled input needs the native value setter bypassed, then an `input` event.
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+  setter.call(input, text)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
 afterEach(async () => {
   if (root) await act(async () => root?.unmount())
   container?.remove()
@@ -59,5 +90,38 @@ describe('ComposerMenu', () => {
     expect(trigger.textContent).toContain('High')
     expect(trigger.title).toBe('Effort: High')
     expect(container.querySelector('[role="menu"]')).toBeNull()
+  })
+
+  it('filters options by keyword when searchable, and Enter picks the first match', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => root?.render(<SearchHarness />))
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]')!
+    await act(async () => trigger.click())
+
+    const menu = container.querySelector<HTMLElement>('[role="menu"]')!
+    const search = menu.querySelector<HTMLInputElement>('[role="searchbox"]')!
+    expect(search.placeholder).toBe('Search agents…')
+    expect(labels(menu)).toEqual(['sentio-reviewer', 'Processor Doctor', 'Move Builder'])
+
+    await act(async () => setInput(search, 'DOC'))
+    expect(labels(menu)).toEqual(['Processor Doctor'])
+
+    await act(async () => setInput(search, 'zzz'))
+    expect(labels(menu)).toEqual([])
+    expect(menu.textContent).toContain('No matches')
+
+    await act(async () => setInput(search, 'move'))
+    await act(async () => {
+      search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    expect(trigger.textContent).toContain('Move Builder')
+    expect(container.querySelector('[role="menu"]')).toBeNull()
+
+    // Reopening starts unfiltered — the old query must not hide the list.
+    await act(async () => trigger.click())
+    expect(labels(container.querySelector('[role="menu"]')!)).toHaveLength(3)
   })
 })

--- a/packages/web/src/components/console/ComposerMenu.test.tsx
+++ b/packages/web/src/components/console/ComposerMenu.test.tsx
@@ -104,6 +104,11 @@ describe('ComposerMenu', () => {
     const menu = container.querySelector<HTMLElement>('[role="menu"]')!
     const search = menu.querySelector<HTMLInputElement>('[role="searchbox"]')!
     expect(search.placeholder).toBe('Search agents…')
+    // The placeholder names the list, so the heading row is dropped — but the menu
+    // keeps its accessible name.
+    expect(menu.textContent).not.toContain('Agent')
+    expect(menu.getAttribute('aria-label')).toBe('Agent')
+    expect(menu.getAttribute('aria-labelledby')).toBeNull()
     expect(labels(menu)).toEqual(['sentio-reviewer', 'Processor Doctor', 'Move Builder'])
 
     await act(async () => setInput(search, 'DOC'))

--- a/packages/web/src/components/console/ComposerMenu.test.tsx
+++ b/packages/web/src/components/console/ComposerMenu.test.tsx
@@ -129,4 +129,36 @@ describe('ComposerMenu', () => {
     await act(async () => trigger.click())
     expect(labels(container.querySelector('[role="menu"]')!)).toHaveLength(3)
   })
+
+  it('leaves Enter and Escape to the IME while a CJK term is still composing', async () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    await act(async () => root?.render(<SearchHarness />))
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]')!
+    await act(async () => trigger.click())
+    const search = container.querySelector<HTMLInputElement>('[role="searchbox"]')!
+
+    // A candidate-confirming Enter must not pick an option...
+    await act(async () => setInput(search, 'move'))
+    await act(async () => {
+      search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, isComposing: true }))
+    })
+    expect(container.querySelector('[role="menu"]')).not.toBeNull()
+    expect(trigger.textContent).toContain('sentio-reviewer')
+
+    // ...nor may a candidate-cancelling Escape close the menu.
+    await act(async () => {
+      search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, isComposing: true }))
+    })
+    expect(container.querySelector('[role="menu"]')).not.toBeNull()
+
+    // Once composition ends the same keys work as before.
+    await act(async () => {
+      search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    expect(trigger.textContent).toContain('Move Builder')
+    expect(container.querySelector('[role="menu"]')).toBeNull()
+  })
 })

--- a/packages/web/src/components/console/ComposerMenu.tsx
+++ b/packages/web/src/components/console/ComposerMenu.tsx
@@ -99,6 +99,10 @@ export function ComposerMenu({
   }
 
   const moveFocus = (event: KeyboardEvent<HTMLDivElement>) => {
+    // An IME candidate window owns Enter / arrows / Escape while composing — confirm,
+    // navigate, cancel. Acting on them would pick an agent or close the menu before a
+    // CJK term is committed, so leave the whole handler to the IME.
+    if (event.nativeEvent.isComposing) return
     if (event.key === 'Escape') {
       event.preventDefault()
       event.stopPropagation()

--- a/packages/web/src/components/console/ComposerMenu.tsx
+++ b/packages/web/src/components/console/ComposerMenu.tsx
@@ -163,7 +163,10 @@ export function ComposerMenu({
           <div
             id={menuId}
             role="menu"
-            aria-labelledby={headingId}
+            // The search box's own placeholder names the list, so a searchable menu
+            // drops the heading row rather than stacking two labels; the menu keeps
+            // the same accessible name via aria-label.
+            {...(searchable ? { 'aria-label': title } : { 'aria-labelledby': headingId })}
             className={`absolute z-50 rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg) ${
               searchable ? 'min-w-[220px]' : 'min-w-[148px]'
             } ${placement === 'down' ? 'top-[calc(100%+8px)]' : 'bottom-[calc(100%+8px)]'} ${
@@ -171,23 +174,29 @@ export function ComposerMenu({
             }`}
             onKeyDown={moveFocus}
           >
-            <div
-              id={headingId}
-              className="px-2 pt-[5px] pb-1 font-sans text-[10.5px] font-semibold leading-normal text-(--text-tertiary)"
-            >
-              {title}
-            </div>
+            {!searchable && (
+              <div
+                id={headingId}
+                className="px-2 pt-[5px] pb-1 font-sans text-[10.5px] font-semibold leading-normal text-(--text-tertiary)"
+              >
+                {title}
+              </div>
+            )}
             {searchable && (
-              <input
-                type="search"
-                role="searchbox"
-                aria-label={`Filter ${title.toLowerCase()}`}
-                className="fsearch"
-                value={query}
-                placeholder={searchPlaceholder}
-                autoFocus
-                onChange={(event) => setQuery(event.target.value)}
-              />
+              // px-2 matches the options' own inset, so the field's border lines up
+              // with the option icons below instead of running wider than the list.
+              <div className="px-2 pt-[3px]">
+                <input
+                  type="search"
+                  role="searchbox"
+                  aria-label={`Filter ${title.toLowerCase()}`}
+                  className="fsearch"
+                  value={query}
+                  placeholder={searchPlaceholder}
+                  autoFocus
+                  onChange={(event) => setQuery(event.target.value)}
+                />
+              </div>
             )}
             {/* Options scroll within a capped height so a long list (e.g. dozens of
                 models) never runs off-screen; the heading above stays put. */}

--- a/packages/web/src/components/console/ComposerMenu.tsx
+++ b/packages/web/src/components/console/ComposerMenu.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useId, useRef, type KeyboardEvent, type ReactNode } from 'react'
+import { useEffect, useId, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
 import { Icon } from '@/components/ui'
 
 // Default trigger look — the minimal inline chip used by the session composer.
@@ -18,6 +18,12 @@ type ComposerMenuChoice = {
   dimmed?: boolean
 }
 
+// Case-insensitive substring match on the label (what the user sees) and the value.
+const matches = (choice: ComposerMenuChoice, query: string) => {
+  const q = query.trim().toLowerCase()
+  return q === '' || choice.label.toLowerCase().includes(q) || choice.value.toLowerCase().includes(q)
+}
+
 export function ComposerMenu({
   title,
   value,
@@ -31,6 +37,8 @@ export function ComposerMenu({
   triggerClassName,
   iconOnly = false,
   tooltips = true,
+  searchable = false,
+  searchPlaceholder = 'Search…',
   onOpenChange,
   onChange
 }: {
@@ -57,13 +65,24 @@ export function ComposerMenu({
    *  off for self-explanatory menus (model / effort / permission) where that reads as
    *  noise; a choice's own `description` is shown either way. */
   tooltips?: boolean
+  /** Render a keyword filter above the options — for unbounded lists (agents), not
+   *  the fixed three-or-four-choice menus. The filter takes focus when the menu opens;
+   *  Enter picks the first match, ArrowDown steps into the list. */
+  searchable?: boolean
+  searchPlaceholder?: string
   onOpenChange: (open: boolean) => void
   onChange: (value: string) => void
 }) {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const menuId = useId()
   const headingId = useId()
+  const [query, setQuery] = useState('')
+  // A fresh open always starts unfiltered — a stale query would hide the list.
+  useEffect(() => {
+    if (!open) setQuery('')
+  }, [open])
   const selected = options.find((choice) => choice.value === value) ?? options[0]
+  const visible = searchable ? options.filter((choice) => matches(choice, query)) : options
   // A choice's own description always shows: `tooltips` only governs the generic
   // "<title>: <label>" fallback, which is the part that reads as noise.
   const tooltipFor = (choice: ComposerMenuChoice | undefined) =>
@@ -86,17 +105,29 @@ export function ComposerMenu({
       closeAndFocus()
       return
     }
-    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return
+    const inSearch = event.target instanceof HTMLInputElement
+    if (inSearch && event.key === 'Enter') {
+      event.preventDefault()
+      if (visible[0]) pick(visible[0].value)
+      return
+    }
+    // Home/End move the caret inside the search box; only the arrows leave it.
+    if (!['ArrowDown', 'ArrowUp', ...(inSearch ? [] : ['Home', 'End'])].includes(event.key)) return
     event.preventDefault()
     const options = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'))
     if (options.length === 0) return
-    const current = Math.max(0, options.indexOf(document.activeElement as HTMLButtonElement))
+    const current = options.indexOf(document.activeElement as HTMLButtonElement)
+    // From the search box (not in the list) ArrowDown enters at the top, ArrowUp at the bottom.
     const next =
       event.key === 'Home'
         ? 0
         : event.key === 'End'
           ? options.length - 1
-          : (current + (event.key === 'ArrowDown' ? 1 : -1) + options.length) % options.length
+          : current === -1
+            ? event.key === 'ArrowDown'
+              ? 0
+              : options.length - 1
+            : (current + (event.key === 'ArrowDown' ? 1 : -1) + options.length) % options.length
     options[next]?.focus()
   }
 
@@ -133,9 +164,11 @@ export function ComposerMenu({
             id={menuId}
             role="menu"
             aria-labelledby={headingId}
-            className={`absolute z-50 min-w-[148px] rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg) ${
-              placement === 'down' ? 'top-[calc(100%+8px)]' : 'bottom-[calc(100%+8px)]'
-            } ${align === 'left' ? 'left-0' : 'right-0'}`}
+            className={`absolute z-50 rounded-[9px] border border-(--border-default) bg-(--surface-card) p-1 shadow-(--shadow-lg) ${
+              searchable ? 'min-w-[220px]' : 'min-w-[148px]'
+            } ${placement === 'down' ? 'top-[calc(100%+8px)]' : 'bottom-[calc(100%+8px)]'} ${
+              align === 'left' ? 'left-0' : 'right-0'
+            }`}
             onKeyDown={moveFocus}
           >
             <div
@@ -144,10 +177,22 @@ export function ComposerMenu({
             >
               {title}
             </div>
+            {searchable && (
+              <input
+                type="search"
+                role="searchbox"
+                aria-label={`Filter ${title.toLowerCase()}`}
+                className="fsearch"
+                value={query}
+                placeholder={searchPlaceholder}
+                autoFocus
+                onChange={(event) => setQuery(event.target.value)}
+              />
+            )}
             {/* Options scroll within a capped height so a long list (e.g. dozens of
                 models) never runs off-screen; the heading above stays put. */}
             <div className="max-h-[300px] overflow-y-auto overflow-x-hidden">
-              {options.map((choice) => {
+              {visible.map((choice) => {
                 const selectedChoice = choice.value === selected?.value
                 return (
                   <button
@@ -155,7 +200,7 @@ export function ComposerMenu({
                     type="button"
                     role="menuitemradio"
                     aria-checked={selectedChoice}
-                    autoFocus={selectedChoice}
+                    autoFocus={selectedChoice && !searchable}
                     title={tooltipFor(choice)}
                     className={`fopt min-h-8 gap-2 rounded-md px-2 py-[5px] text-[12px] ${
                       selectedChoice ? 'bg-(--brand-soft) text-(--brand-soft-text) hover:bg-(--brand-soft)' : ''
@@ -168,6 +213,7 @@ export function ComposerMenu({
                   </button>
                 )
               })}
+              {searchable && visible.length === 0 && <div className="fnohit">No matches</div>}
             </div>
             {footer && <div className="mt-1 border-t border-(--border-subtle)">{footer}</div>}
           </div>

--- a/packages/web/src/components/console/views/HomeView.tsx
+++ b/packages/web/src/components/console/views/HomeView.tsx
@@ -642,6 +642,8 @@ export default function HomeView() {
                     title="Agent"
                     value={agent.id}
                     options={agentOptions}
+                    searchable
+                    searchPlaceholder="Search agents…"
                     open={menu === 'agent'}
                     align="left"
                     placement="down"
@@ -660,6 +662,8 @@ export default function HomeView() {
                     title="Add agents"
                     value=""
                     options={addOptions}
+                    searchable
+                    searchPlaceholder="Search agents…"
                     iconOnly
                     open={menu === 'add'}
                     align="left"

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -4597,6 +4597,8 @@ export default function SessionDetailView() {
                                 title="Add agents"
                                 value=""
                                 options={addAgentOptions}
+                                searchable
+                                searchPlaceholder="Search agents…"
                                 iconOnly
                                 open={composerMenuOpen === 'addAgent'}
                                 align="left"


### PR DESCRIPTION
## What

`ComposerMenu` gains an opt-in `searchable` mode, turned on for the Home composer's **Agent** and **Add agents** menus and the session composer's **Add agents** twin.

- A filter input under the menu heading (reusing the existing `.fsearch` style) narrows options by label/value, case-insensitively; an empty result shows `No matches`.
- The input takes focus on open. **Enter** picks the first match, **ArrowDown / ArrowUp** step from the input into the list, **Escape** closes. Home/End keep moving the caret while the input has focus.
- The query resets on every open, so a stale filter never hides the list.
- Searchable menus get a wider `min-w-[220px]`; the fixed Model / Effort / Permission menus are unchanged.

## Why

The agent pickers list every agent in the org. Once a workspace has a dozen or more, the popover turns into a scroll hunt — a keyword filter is the expected affordance for an unbounded list.

## Verification

- New `ComposerMenu` test covers filtering, the no-match state, Enter-picks-first, and the reset on reopen. `ComposerMenu` + `HomeView` suites pass (21 tests); `eslint`, `prettier --check`, and `tsc --noEmit` are clean.
- Manually exercised in the console (mock mode): typed `review` in the Agent menu → only `mocked-review-bot` remained; Enter selected it and the trigger updated; reopening showed the full list with an empty filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
