### PR TITLE
feat(console): webchat types free-text and numeric elicitation answers

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -30,9 +30,12 @@ import {
   buildElicitationResolvedCard,
   buildPermissionCard,
   buildPermissionResolvedCard,
+  clampTo,
   elicitTarget,
   multiSelectAccepts,
+  numberAccepts,
   SLACK_ELICIT_KINDS,
+  textAccepts,
   WEBCHAT_ELICIT_KINDS
 } from '../slack/render.js'
 import type { ElicitKind, ElicitSurfaceKinds, ElicitTarget } from '../slack/render.js'
@@ -99,11 +102,23 @@ function surfaceKinds(rec: PendingElicitSurface): ElicitSurfaceKinds {
 
 /** How a settled card names the answer: the chosen option's LABEL, or every chosen label for a
  *  multi-select — what the reader picked, in the words the card used, never the wire values.
- *  An accepted empty list (a `minItems: 0` form) still says something rather than nothing. */
-function chosenLabel(target: ElicitTarget | null, value: string | string[]): string {
+ *  An accepted empty list (a `minItems: 0` form) still says something rather than nothing.
+ *  A typed answer has no label but itself, so it is echoed (clamped): the card is the reader's
+ *  own words back, and MCP forbids eliciting secrets, so there is nothing here to withhold. */
+function chosenLabel(target: ElicitTarget | null, value: string | string[] | number): string {
   const label = (v: string) => target?.options.find((o) => o.value === v)?.label ?? v
-  if (!Array.isArray(value)) return label(value)
+  if (typeof value === 'number') return String(value)
+  if (!Array.isArray(value)) return clampTo(label(value), 200)
   return value.length ? value.map(label).join(', ') : 'Nothing selected'
+}
+
+/** Whether a submitted answer has the SHAPE this kind is answered with — the arity check a card
+ *  applies before it looks at the value at all. The string kinds are indistinguishable here;
+ *  each one's own accept check is what separates them. */
+function answerFitsKind(kind: ElicitKind, value: string | string[] | number): boolean {
+  if (kind === 'multi-enum') return Array.isArray(value)
+  if (kind === 'number') return typeof value === 'number'
+  return typeof value === 'string'
 }
 
 /** One outstanding `elicitation/create` awaiting a human answer. */
@@ -1379,7 +1394,30 @@ export class PermissionCoordinator {
                   ...(target.maxItems !== undefined ? { maxItems: target.maxItems } : {})
                 }
               }
-            : {})
+            : {}),
+          // Present only for a typed field, and likewise what makes the card an input rather
+          // than a row of options. The constraints ride along so the control can refuse an
+          // answer the daemon would reject anyway.
+          ...(target.kind === 'text'
+            ? {
+                text: {
+                  ...(target.minLength !== undefined ? { minLength: target.minLength } : {}),
+                  ...(target.maxLength !== undefined ? { maxLength: target.maxLength } : {}),
+                  ...(target.pattern !== undefined ? { pattern: target.pattern } : {}),
+                  ...(target.format !== undefined ? { format: target.format } : {})
+                }
+              }
+            : {}),
+          ...(target.kind === 'number'
+            ? {
+                number: {
+                  ...(target.integer ? { integer: true } : {}),
+                  ...(target.minimum !== undefined ? { minimum: target.minimum } : {}),
+                  ...(target.maximum !== undefined ? { maximum: target.maximum } : {})
+                }
+              }
+            : {}),
+          ...(target.defaultValue !== undefined ? { defaultValue: target.defaultValue } : {})
         }
       })
     } catch (err) {
@@ -1414,12 +1452,12 @@ export class PermissionCoordinator {
   }
 
   /** A tapped elicitation-card button (SlackDeps.onElicitChoice): resolve the pending ACP
-   *  request — `accept` with the chosen value (a LIST of them for a multi-select, under the
-   *  field name), or `decline` for the Dismiss button (value === null) — and edit the card in
-   *  place. No-op if already gone. */
+   *  request — `accept` with the chosen value (a LIST of them for a multi-select, a real number
+   *  for a numeric field, under the field name), or `decline` for the Dismiss button
+   *  (value === null) — and edit the card in place. No-op if already gone. */
   async handleElicitChoice(a: {
     requestId: string
-    value: string | string[] | null
+    value: string | string[] | number | null
     actor?: InteractionActor
     /** Set only by the webchat ingress: the answering browser's conversation. It confines
      *  the answer to a card THIS conversation was shown — a webchat client can neither
@@ -1430,25 +1468,33 @@ export class PermissionCoordinator {
     // A DM elicitation card's request lives on the editor path (§2/§6.4).
     const editor = this.pendingEditorPermissions.get(a.requestId)
     if (editor?.kind === 'elicitation' && editor.notify) {
-      // A DM card is a Slack button row, so it is never answered by a list or a browser.
-      if (a.webchatConversationId !== undefined || Array.isArray(a.value)) return
+      // A DM card is a Slack button row: never answered by a list, a number, or a browser.
+      if (a.webchatConversationId !== undefined || Array.isArray(a.value) || typeof a.value === 'number') return
       return await this.handleDmElicitChoice(a.requestId, editor, a.value, a.actor)
     }
     const rec = this.pendingElicits.get(a.requestId)
     if (!rec) return
-    // A list answers a multi-select card and only that; a scalar answers the single-choice
-    // kinds. Dismiss (null) settles either.
-    if (a.value !== null && Array.isArray(a.value) !== (rec.kind === 'multi-enum')) return
+    // Each kind takes one shape of answer and no other: a list for a multi-select, a number
+    // for a numeric field, a string for the rest. Dismiss (null) settles any of them.
+    if (a.value !== null && !answerFitsKind(rec.kind, a.value)) return
     const target = elicitTarget(rec.params, surfaceKinds(rec))
     if (a.webchatConversationId !== undefined) {
       if (rec.surface !== 'webchat' || rec.wc.conversationId !== a.webchatConversationId) return
-      // The card names every answer it accepts; anything else would inject an unoffered
-      // value into the agent's content, so it is dropped and the card stays live. A
-      // multi-select adds its own terms: no repeats, and a count its bounds allow.
-      const offered = Array.isArray(a.value)
-        ? !!target && multiSelectAccepts(target, a.value)
-        : !!target?.options.some((o) => o.value === a.value)
-      if (a.value !== null && !offered) return
+      // The card names every answer it accepts; anything else would inject an unoffered value
+      // into the agent's content, so it is dropped and the card stays live. A multi-select adds
+      // no repeats and a count its bounds allow; a typed field, the schema constraints the
+      // control was shown — a browser frame is never what makes an answer valid.
+      const offered =
+        a.value === null ||
+        (!!target &&
+          (Array.isArray(a.value)
+            ? multiSelectAccepts(target, a.value)
+            : typeof a.value === 'number'
+              ? numberAccepts(target, a.value)
+              : target.kind === 'text'
+                ? textAccepts(target, a.value)
+                : target.options.some((o) => o.value === a.value)))
+      if (!offered) return
       // A card settles only from its own surface: both share one `elicit-<n>` counter, so
       // without this a Slack tap could answer a live webchat card.
     } else if (rec.surface === 'webchat') return
@@ -1476,9 +1522,11 @@ export class PermissionCoordinator {
       res = { action: 'accept', content: { [rec.propName]: a.value } }
       decision = `:white_check_mark: ${chosenLabel(target, a.value)}`
     } else {
+      // The accepted content carries the schema's own type: a boolean for a boolean field and a
+      // real number for a numeric one, never the string the wire happened to spell it with.
       const value = rec.kind === 'boolean' ? a.value === 'true' : a.value
       res = { action: 'accept', content: { [rec.propName]: value } }
-      decision = `:white_check_mark: ${rec.kind === 'boolean' ? (value ? 'Yes' : 'No') : a.value}`
+      decision = `:white_check_mark: ${rec.kind === 'boolean' ? (value ? 'Yes' : 'No') : String(a.value)}`
     }
     if (rec.approval) {
       // Approval elicitations only ever take the Slack card path (chat approval requires it).

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -715,10 +715,17 @@ function numBound(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
-/** A string-length bound kept only when it is a sane non-negative integer inside the answer cap. */
+/** A string-length bound, kept whenever it is a sane non-negative integer. A bound ABOVE the
+ *  cap is never dropped: silently losing a minimum would let an answer the schema forbids
+ *  through, so the caller compares it against the effective cap and declines instead. */
 function lengthBound(value: unknown): number | undefined {
-  const n = itemBound(value)
-  return n !== undefined && n <= ELICIT_TEXT_CAP ? n : undefined
+  return itemBound(value)
+}
+
+/** The longest answer a text target can actually take: a pattern is only cheap over a short
+ *  input, so a patterned field's ceiling is the pattern cap rather than the answer cap. */
+function effectiveTextMax(pattern: string | undefined): number {
+  return pattern === undefined ? ELICIT_TEXT_CAP : ELICIT_PATTERN_INPUT_CAP
 }
 
 /** The four `format` checks, each strict enough that a value passing it is one the agent asked for. */
@@ -732,7 +739,12 @@ const FORMAT_CHECK: Record<ElicitFormat, (value: string) => boolean> = {
       return false
     }
   },
-  date: (v) => /^\d{4}-\d{2}-\d{2}$/.test(v) && v === new Date(`${v}T00:00:00Z`).toISOString().slice(0, 10),
+  date: (v) => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(v)) return false
+    // `2025-13-01` matches the shape but is not a date: toISOString would THROW on it.
+    const d = new Date(`${v}T00:00:00Z`)
+    return !Number.isNaN(d.getTime()) && v === d.toISOString().slice(0, 10)
+  },
   'date-time': (v) =>
     /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/.test(v) && !isNaN(Date.parse(v))
 }
@@ -765,15 +777,20 @@ function textTarget(name: string, prop: Record<string, unknown>): ElicitTarget |
   const pattern = prop.pattern
   if (pattern !== undefined && (typeof pattern !== 'string' || !safeElicitPattern(pattern))) return null
   const min = lengthBound(prop.minLength)
-  const max = lengthBound(prop.maxLength)
-  if (min !== undefined && max !== undefined && min > max) return null
+  const declared = lengthBound(prop.maxLength)
+  // The ceiling this surface can actually enforce. A declared minimum above it is
+  // unanswerable — dropping it would accept a short answer the schema forbids — and the
+  // effective maximum is carried on the target so the browser bounds its own draft by it.
+  const ceiling = effectiveTextMax(typeof pattern === 'string' ? pattern : undefined)
+  const max = declared === undefined ? ceiling : Math.min(declared, ceiling)
+  if (min !== undefined && min > max) return null
   if (max === 0) return null
   return {
     propName: name,
     kind: 'text',
     options: [],
     ...(min !== undefined ? { minLength: min } : {}),
-    ...(max !== undefined ? { maxLength: max } : {}),
+    maxLength: max,
     ...(typeof pattern === 'string' ? { pattern } : {}),
     ...(format !== undefined ? { format: format as ElicitFormat } : {})
   }
@@ -917,7 +934,8 @@ export function textAccepts(target: ElicitTarget, value: string): boolean {
   if (target.maxLength !== undefined && value.length > target.maxLength) return false
   if (target.format && !FORMAT_CHECK[target.format](value)) return false
   if (target.pattern === undefined) return true
-  // The screen bounds a pattern's degree; this bounds the input it is spent on.
+  // maxLength already carries the pattern ceiling, so the expression only ever runs over a
+  // short input; this is the belt to that braces, since the target arrives from a caller.
   if (value.length > ELICIT_PATTERN_INPUT_CAP) return false
   const re = safeElicitPattern(target.pattern)
   return !!re && re.test(value)

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -653,6 +653,16 @@ export interface ElicitTarget {
 /** The longest answer a card accepts: an elicitation asks a question, not for a file. */
 const ELICIT_TEXT_CAP = 4096
 
+/** The longest answer a PATTERN is matched against. Backtracking cost grows with the input,
+ *  so a screened pattern is only cheap over a short one — and a patterned field asks for a
+ *  name or an id, not prose. A longer answer is rejected rather than matched. */
+const ELICIT_PATTERN_INPUT_CAP = 256
+
+/** The most quantifiers a screened pattern may carry. The group rule below stops nested
+ *  blow-up, but ADJACENT quantifiers backtrack polynomially with no group at all (`a*a*a*b`),
+ *  and degree is what the input cap is budgeted against. */
+const ELICIT_PATTERN_QUANTIFIER_CAP = 3
+
 /**
  * Compile a schema `pattern` only when a linear-time match is assured, since the expression is
  * agent-authored and JS regexes backtrack: over-long sources and every quantified group whose
@@ -664,6 +674,7 @@ export function safeElicitPattern(src: string): RegExp | null {
   // Riskiness of the body being scanned, and of every enclosing group, innermost last.
   const enclosing: boolean[] = []
   let risky: boolean = false
+  let quantifiers = 0
   for (let i = 0; i < src.length; i++) {
     const c = src[i]!
     if (c === '\\') i++
@@ -686,7 +697,10 @@ export function safeElicitPattern(src: string): RegExp | null {
       const quantified = i + 1 < src.length && '*+?{'.includes(src[i + 1]!)
       if (quantified && body) return null
       risky = parent || body || quantified
-    } else if (c === '|' || '*+?{'.includes(c)) risky = true
+    } else if (c === '|' || '*+?{'.includes(c)) {
+      if (c !== '|' && ++quantifiers > ELICIT_PATTERN_QUANTIFIER_CAP) return null
+      risky = true
+    }
   }
   if (enclosing.length) return null
   try {
@@ -903,6 +917,8 @@ export function textAccepts(target: ElicitTarget, value: string): boolean {
   if (target.maxLength !== undefined && value.length > target.maxLength) return false
   if (target.format && !FORMAT_CHECK[target.format](value)) return false
   if (target.pattern === undefined) return true
+  // The screen bounds a pattern's degree; this bounds the input it is spent on.
+  if (value.length > ELICIT_PATTERN_INPUT_CAP) return false
   const re = safeElicitPattern(target.pattern)
   return !!re && re.test(value)
 }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -175,7 +175,7 @@ const STREAM_PLAN_FAILED = 'Failed'
  *  and no shortcodes, so plain text is the entire palette. */
 const FAILED_PREFIX = '(failed) '
 
-function clampTo(s: string, max: number): string {
+export function clampTo(s: string, max: number): string {
   const t = s.trim()
   return t.length > max ? `${t.slice(0, max - 1)}…` : t
 }
@@ -600,8 +600,8 @@ export function buildPermissionUpdateCard(updateUrl: string): unknown[] {
 // ── Elicitation (ACP elicitation/create — structured questions) ──────────────
 
 /** The field shapes an elicitation card can reduce a form to. `multi-enum` answers with a
- *  LIST of the chosen values, the other two with one scalar. */
-export type ElicitKind = 'enum' | 'boolean' | 'multi-enum'
+ *  LIST of the chosen values, `number` with a real JS number, the rest with one scalar. */
+export type ElicitKind = 'enum' | 'boolean' | 'multi-enum' | 'text' | 'number'
 
 /** What a surface declares it is able to render. {@link elicitTarget} skips every property
  *  whose kind is absent here, so a kind reaches a surface only once that surface claims it —
@@ -609,11 +609,21 @@ export type ElicitKind = 'enum' | 'boolean' | 'multi-enum'
 export type ElicitSurfaceKinds = ReadonlySet<ElicitKind>
 
 /** Slack's card is a row of buttons: it can express "pick one", not "pick several, then
- *  confirm", so multi-select is not renderable there and the form is declined instead. */
+ *  confirm", and it has no field to type into, so those forms are declined there instead. */
 export const SLACK_ELICIT_KINDS: ElicitSurfaceKinds = new Set<ElicitKind>(['enum', 'boolean'])
 
-/** Webchat's card renders options as toggles with a confirm control, so it takes all three. */
-export const WEBCHAT_ELICIT_KINDS: ElicitSurfaceKinds = new Set<ElicitKind>(['enum', 'boolean', 'multi-enum'])
+/** Webchat's card has toggles, a confirm control and a typed input, so it takes every kind. */
+export const WEBCHAT_ELICIT_KINDS: ElicitSurfaceKinds = new Set<ElicitKind>([
+  'enum',
+  'boolean',
+  'multi-enum',
+  'text',
+  'number'
+])
+
+/** The `format` values MCP `2025-11-25` defines for an elicited string — exactly these four. */
+export type ElicitFormat = 'email' | 'uri' | 'date' | 'date-time'
+const ELICIT_FORMATS: readonly ElicitFormat[] = ['email', 'uri', 'date', 'date-time']
 
 /** The one form field an elicitation card renders as buttons. */
 export interface ElicitTarget {
@@ -621,11 +631,96 @@ export interface ElicitTarget {
   propName: string
   kind: ElicitKind
   /** Selectable options: `value` is the wire value returned in the accept content,
-   *  `label` is the human button text. */
+   *  `label` is the human button text. Empty for `text`/`number`, which offer none. */
   options: { value: string; label: string }[]
   /** Selection bounds from the array schema — `multi-enum` only, absent when unbounded. */
   minItems?: number
   maxItems?: number
+  /** String bounds — `text` only. `pattern` is present only when {@link safeElicitPattern} cleared it. */
+  minLength?: number
+  maxLength?: number
+  pattern?: string
+  format?: ElicitFormat
+  /** Numeric bounds — `number` only; `integer` marks the schema's `integer` type. */
+  minimum?: number
+  maximum?: number
+  integer?: boolean
+  /** The schema's `default`, kept only when it satisfies this target's own constraints —
+   *  the card seeds its control with it, and the reader may still answer something else. */
+  defaultValue?: string | number | boolean | string[]
+}
+
+/** The longest answer a card accepts: an elicitation asks a question, not for a file. */
+const ELICIT_TEXT_CAP = 4096
+
+/**
+ * Compile a schema `pattern` only when a linear-time match is assured, since the expression is
+ * agent-authored and JS regexes backtrack: over-long sources and every quantified group whose
+ * body itself quantifies or alternates ((a+)+, (a|a)*) are refused. A refused pattern makes the
+ * property unrenderable, so the form declines rather than accepting an unchecked answer.
+ */
+export function safeElicitPattern(src: string): RegExp | null {
+  if (src.length > 200) return null
+  // Riskiness of the body being scanned, and of every enclosing group, innermost last.
+  const enclosing: boolean[] = []
+  let risky: boolean = false
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i]!
+    if (c === '\\') i++
+    else if (c === '[') {
+      while (i < src.length && src[i] !== ']') i += src[i] === '\\' ? 2 : 1
+    } else if (c === '(') {
+      enclosing.push(risky)
+      risky = false
+      // A group modifier ((?:, (?=, (?!, (?<=, (?<name>) is syntax, not a quantifier.
+      if (src[i + 1] === '?') {
+        i++
+        const kind = src[i + 1]
+        if (kind === ':' || kind === '=' || kind === '!') i++
+        else if (kind === '<') while (i + 1 < src.length && !'>=!'.includes(src[++i] ?? '')) {}
+      }
+    } else if (c === ')') {
+      const body: boolean = risky
+      const parent = enclosing.pop()
+      if (parent === undefined) return null
+      const quantified = i + 1 < src.length && '*+?{'.includes(src[i + 1]!)
+      if (quantified && body) return null
+      risky = parent || body || quantified
+    } else if (c === '|' || '*+?{'.includes(c)) risky = true
+  }
+  if (enclosing.length) return null
+  try {
+    return new RegExp(src)
+  } catch {
+    return null
+  }
+}
+
+/** A schema bound kept only when it is a real finite number. */
+function numBound(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+/** A string-length bound kept only when it is a sane non-negative integer inside the answer cap. */
+function lengthBound(value: unknown): number | undefined {
+  const n = itemBound(value)
+  return n !== undefined && n <= ELICIT_TEXT_CAP ? n : undefined
+}
+
+/** The four `format` checks, each strict enough that a value passing it is one the agent asked for. */
+const FORMAT_CHECK: Record<ElicitFormat, (value: string) => boolean> = {
+  // Deliberately narrow: one @, no spaces, a dotted host — not a full RFC 5322 grammar.
+  email: (v) => /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/.test(v),
+  uri: (v) => {
+    try {
+      return !!new URL(v).protocol
+    } catch {
+      return false
+    }
+  },
+  date: (v) => /^\d{4}-\d{2}-\d{2}$/.test(v) && v === new Date(`${v}T00:00:00Z`).toISOString().slice(0, 10),
+  'date-time': (v) =>
+    /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/.test(v) && !isNaN(Date.parse(v))
 }
 
 /** The options an array property's `items` offers, plus the `anyOf`/`oneOf` titled form. */
@@ -648,14 +743,72 @@ function itemBound(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined
 }
 
+/** Build the `text` target for a bare string property, or null when a constraint makes it
+ *  unrenderable: an unsupported `format`, a pattern we refuse to run, an impossible length. */
+function textTarget(name: string, prop: Record<string, unknown>): ElicitTarget | null {
+  const format = prop.format
+  if (format !== undefined && !ELICIT_FORMATS.includes(format as ElicitFormat)) return null
+  const pattern = prop.pattern
+  if (pattern !== undefined && (typeof pattern !== 'string' || !safeElicitPattern(pattern))) return null
+  const min = lengthBound(prop.minLength)
+  const max = lengthBound(prop.maxLength)
+  if (min !== undefined && max !== undefined && min > max) return null
+  if (max === 0) return null
+  return {
+    propName: name,
+    kind: 'text',
+    options: [],
+    ...(min !== undefined ? { minLength: min } : {}),
+    ...(max !== undefined ? { maxLength: max } : {}),
+    ...(typeof pattern === 'string' ? { pattern } : {}),
+    ...(format !== undefined ? { format: format as ElicitFormat } : {})
+  }
+}
+
+/** Build the `number` target for a numeric property, or null when its bounds admit nothing. */
+function numberTarget(name: string, prop: Record<string, unknown>): ElicitTarget | null {
+  const integer = prop.type === 'integer'
+  const min = numBound(prop.minimum)
+  const max = numBound(prop.maximum)
+  if (min !== undefined && max !== undefined && min > max) return null
+  // An integer range spanning no integer at all (0.2 … 0.8) is not a question either.
+  if (integer && min !== undefined && max !== undefined && Math.ceil(min) > Math.floor(max)) return null
+  return {
+    propName: name,
+    kind: 'number',
+    options: [],
+    ...(min !== undefined ? { minimum: min } : {}),
+    ...(max !== undefined ? { maximum: max } : {}),
+    ...(integer ? { integer: true } : {})
+  }
+}
+
+/** Carry the schema's `default` onto a target, but only where the target itself would accept it —
+ *  the spec asks the card to pre-populate, and pre-populating an answer we would then refuse
+ *  hands the reader a control that cannot be submitted. */
+function withDefault(target: ElicitTarget, raw: unknown): ElicitTarget {
+  if (raw === undefined) return target
+  const ok =
+    target.kind === 'boolean'
+      ? typeof raw === 'boolean'
+      : target.kind === 'multi-enum'
+        ? Array.isArray(raw) && raw.every((v) => typeof v === 'string') && multiSelectAccepts(target, raw)
+        : target.kind === 'number'
+          ? typeof raw === 'number' && numberAccepts(target, raw)
+          : target.kind === 'text'
+            ? typeof raw === 'string' && textAccepts(target, raw)
+            : typeof raw === 'string' && target.options.some((o) => o.value === raw)
+  return ok ? { ...target, defaultValue: raw as ElicitTarget['defaultValue'] } : target
+}
+
 /**
  * Resolve the single form field an elicitation card renders: the FIRST string-enum (`oneOf`
- * titled options or bare `enum`), boolean, or string-array multi-select (`items.enum` or
- * `items.anyOf`) property the CALLING SURFACE declares it can render. Returns null for
- * URL-mode, an empty/absent schema, a form whose fields we can't render inline (free text,
- * numbers), or one that requires a property other than the rendered target — the daemon then
- * declines rather than accepting a partial answer. Pure, and shared by every surface so the
- * option values and their interpretation can't drift.
+ * titled options or bare `enum`), boolean, string-array multi-select (`items.enum` or
+ * `items.anyOf`), free-text string or number/integer property the CALLING SURFACE declares it
+ * can render. Returns null for URL-mode, an empty/absent schema, a form whose fields this
+ * surface can't render, or one that requires a property other than the rendered target — the
+ * daemon then declines rather than accepting a partial answer. Pure, and shared by every
+ * surface so the option values and their interpretation can't drift.
  */
 export function elicitTarget(params: CreateElicitationRequest, renderable: ElicitSurfaceKinds): ElicitTarget | null {
   const p = params as {
@@ -668,9 +821,10 @@ export function elicitTarget(params: CreateElicitationRequest, renderable: Elici
   // A required field we can't render is unanswerable: accepting without it would assert a lie.
   // A candidate that fails this does NOT end the scan — a later property may be the sole
   // required one, and returning here would decline a form this surface can in fact answer.
-  const answerable = (t: ElicitTarget) => (required.every((r) => r === t.propName) ? t : null)
+  const answerable = (t: ElicitTarget | null) => (t && required.every((r) => r === t.propName) ? t : null)
   for (const [name, prop] of Object.entries(props)) {
-    if (prop?.type === 'string' && renderable.has('enum')) {
+    const seeded = (t: ElicitTarget | null) => (t ? withDefault(t, prop.default) : null)
+    if (prop?.type === 'string') {
       const oneOf = prop.oneOf as { const?: unknown; title?: unknown }[] | undefined
       const en = prop.enum as unknown[] | undefined
       const options = Array.isArray(oneOf)
@@ -678,10 +832,20 @@ export function elicitTarget(params: CreateElicitationRequest, renderable: Elici
         : Array.isArray(en)
           ? en.map((v) => ({ value: String(v), label: clampTo(String(v), 75) }))
           : []
-      if (options.length) {
-        const t = answerable({ propName: name, kind: 'enum', options })
+      if (options.length && renderable.has('enum')) {
+        const t = answerable(seeded({ propName: name, kind: 'enum', options }))
         if (t) return t
       }
+      // Free text is the string with nothing to choose from — an enumerated one is a pick,
+      // and typing into it would let an unoffered value through.
+      if (!options.length && renderable.has('text')) {
+        const t = answerable(seeded(textTarget(name, prop)))
+        if (t) return t
+      }
+    }
+    if ((prop?.type === 'number' || prop?.type === 'integer') && renderable.has('number')) {
+      const t = answerable(seeded(numberTarget(name, prop)))
+      if (t) return t
     }
     if (prop?.type === 'array' && renderable.has('multi-enum')) {
       const options = arrayOptions(prop)
@@ -690,25 +854,29 @@ export function elicitTarget(params: CreateElicitationRequest, renderable: Elici
       // Bounds that admit only the empty selection, or none at all, are not a question.
       const askable = max === undefined || (max > 0 && max >= (min ?? 0))
       if (options.length && askable) {
-        const t = answerable({
-          propName: name,
-          kind: 'multi-enum',
-          options,
-          ...(min !== undefined ? { minItems: min } : {}),
-          ...(max !== undefined ? { maxItems: max } : {})
-        })
+        const t = answerable(
+          seeded({
+            propName: name,
+            kind: 'multi-enum',
+            options,
+            ...(min !== undefined ? { minItems: min } : {}),
+            ...(max !== undefined ? { maxItems: max } : {})
+          })
+        )
         if (t) return t
       }
     }
     if (prop?.type === 'boolean' && renderable.has('boolean')) {
-      const t = answerable({
-        propName: name,
-        kind: 'boolean',
-        options: [
-          { value: 'true', label: 'Yes' },
-          { value: 'false', label: 'No' }
-        ]
-      })
+      const t = answerable(
+        seeded({
+          propName: name,
+          kind: 'boolean',
+          options: [
+            { value: 'true', label: 'Yes' },
+            { value: 'false', label: 'No' }
+          ]
+        })
+      )
       if (t) return t
     }
   }
@@ -723,6 +891,30 @@ export function multiSelectAccepts(target: ElicitTarget, values: string[]): bool
   if (values.length < (target.minItems ?? 0)) return false
   if (target.maxItems !== undefined && values.length > target.maxItems) return false
   return values.every((v) => target.options.some((o) => o.value === v))
+}
+
+/** Whether a typed string is an answer this text target's own schema allows: inside the answer
+ *  cap and `minLength`/`maxLength`, matching `pattern`, and of the declared `format`. The
+ *  browser enforces the same rules to keep the control honest; this is what makes them binding. */
+export function textAccepts(target: ElicitTarget, value: string): boolean {
+  if (target.kind !== 'text') return false
+  if (value.length > ELICIT_TEXT_CAP) return false
+  if (value.length < (target.minLength ?? 0)) return false
+  if (target.maxLength !== undefined && value.length > target.maxLength) return false
+  if (target.format && !FORMAT_CHECK[target.format](value)) return false
+  if (target.pattern === undefined) return true
+  const re = safeElicitPattern(target.pattern)
+  return !!re && re.test(value)
+}
+
+/** Whether a typed number is an answer this number target allows: real and finite, inside
+ *  `minimum`/`maximum`, and a whole number where the schema said `integer`. */
+export function numberAccepts(target: ElicitTarget, value: number): boolean {
+  if (target.kind !== 'number') return false
+  if (!Number.isFinite(value)) return false
+  if (target.integer && !Number.isInteger(value)) return false
+  if (target.minimum !== undefined && value < target.minimum) return false
+  return target.maximum === undefined || value <= target.maximum
 }
 
 /**

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -739,3 +739,186 @@ describe('webchat answers a multi-select elicitation with a list', () => {
     expect(elicitTarget(multiElicitation({ minItems: 1 }), WEBCHAT_ELICIT_KINDS)?.kind).toBe('multi-enum')
   })
 })
+
+// ── free text and numbers (issue #1794 gap 3) ────────────────────────────────
+
+/** A free-text form, optionally constrained. */
+function textElicitation(prop: Record<string, unknown> = {}): CreateElicitationRequest {
+  return formElicitation({
+    message: 'What should I name the branch?',
+    requestedSchema: {
+      type: 'object',
+      properties: { name: { type: 'string', ...prop } },
+      required: ['name']
+    }
+  })
+}
+
+/** A numeric form, optionally constrained. */
+function numberElicitation(prop: Record<string, unknown> = {}): CreateElicitationRequest {
+  return formElicitation({
+    message: 'How many retries?',
+    requestedSchema: {
+      type: 'object',
+      properties: { retries: { type: 'number', ...prop } },
+      required: ['retries']
+    }
+  })
+}
+
+describe('webchat answers a typed elicitation with the schema’s own type', () => {
+  it('cards a text field with its constraints and default, and accepts the typed string', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      textElicitation({ minLength: 3, maxLength: 50, pattern: '^[a-z-]+$', default: 'fix-login' })
+    )
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    expect(cardEvents(sink)[0]).toEqual({
+      kind: 'elicitation',
+      requestId: expect.any(String),
+      message: 'What should I name the branch?',
+      // A typed field offers nothing to pick; `text` is what makes the card an input.
+      options: [],
+      text: { minLength: 3, maxLength: 50, pattern: '^[a-z-]+$' },
+      defaultValue: 'fix-login'
+    })
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'add-retries',
+      webchatConversationId: 'conv-1'
+    })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
+    // A typed answer has no label but itself — the reader's own words, back in the transcript.
+    expect(cardEvents(sink)[1]).toEqual({
+      kind: 'elicitation_resolved',
+      requestId,
+      outcome: 'accepted',
+      label: 'add-retries'
+    })
+  })
+
+  it('cards a number field and accepts a real number, never the string that spelled it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      numberElicitation({ minimum: 0, maximum: 100, default: 50 })
+    )
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    expect(cardEvents(sink)[0]).toEqual({
+      kind: 'elicitation',
+      requestId: expect.any(String),
+      message: 'How many retries?',
+      options: [],
+      number: { minimum: 0, maximum: 100 },
+      defaultValue: 50
+    })
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 7, webchatConversationId: 'conv-1' })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { retries: 7 } })
+    expect(cardEvents(sink)[1]).toEqual({
+      kind: 'elicitation_resolved',
+      requestId,
+      outcome: 'accepted',
+      label: '7'
+    })
+  })
+
+  it('re-checks the browser’s typed answer: bounds, pattern, format, and the wrong shape', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      textElicitation({ minLength: 3, maxLength: 8, format: 'email' })
+    )
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    const answer = (value: unknown) =>
+      (daemon as any).permissions.handleElicitChoice({ requestId, value, webchatConversationId: 'conv-1' })
+
+    await answer('ab') // below minLength
+    await answer('a@example.com') // above maxLength
+    await answer('abcdef') // not an email at all
+    await answer(7) // a number cannot answer a text card
+    await answer(['a@b.co']) // nor can a list
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(cardEvents(sink)).toHaveLength(1) // still live — nothing settled it
+
+    await answer('a@b.co')
+    await expect(result).resolves.toEqual({ action: 'accept', content: { name: 'a@b.co' } })
+  })
+
+  it('re-checks the browser’s number: its bounds, its integer-ness, and a string spelling it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      formElicitation({
+        message: 'How many retries?',
+        requestedSchema: {
+          type: 'object',
+          properties: { retries: { type: 'integer', minimum: 1, maximum: 5 } },
+          required: ['retries']
+        }
+      })
+    )
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    const answer = (value: unknown) =>
+      (daemon as any).permissions.handleElicitChoice({ requestId, value, webchatConversationId: 'conv-1' })
+
+    await answer(0) // below minimum
+    await answer(6) // above maximum
+    await answer(2.5) // not a whole number
+    await answer('3') // the string is a different type than the schema asked for
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(cardEvents(sink)).toHaveLength(1)
+
+    await answer(3)
+    await expect(result).resolves.toEqual({ action: 'accept', content: { retries: 3 } })
+  })
+
+  it('declines a typed form on a Slack turn, whose card has no field to type into', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    pending.plan.platform = 'slack'
+    pending.conn = Object.create(SlackConnection.prototype)
+
+    await expect((daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())).resolves.toBeUndefined()
+    await expect((daemon as any).permissions.onAcpElicit('agent-1', 's1', numberElicitation())).resolves.toBeUndefined()
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+    // The same forms ARE renderable — just not here: webchat types into them.
+    expect(elicitTarget(textElicitation(), WEBCHAT_ELICIT_KINDS)?.kind).toBe('text')
+    expect(elicitTarget(numberElicitation(), WEBCHAT_ELICIT_KINDS)?.kind).toBe('number')
+  })
+
+  it('declines a form whose pattern could hang the daemon, rather than run it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    installWebchat(pending)
+
+    // (a+)+$ against a long non-matching string is the textbook catastrophic backtrack: the
+    // card never exists, so the daemon never gets the chance to run it.
+    await expect(
+      (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation({ pattern: '^(a+)+$' }))
+    ).resolves.toBeUndefined()
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+  })
+})

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -16,6 +16,9 @@ import {
   SLACK_ELICIT_KINDS,
   WEBCHAT_ELICIT_KINDS,
   multiSelectAccepts,
+  numberAccepts,
+  safeElicitPattern,
+  textAccepts,
   encodePermValue,
   decodePermValue,
   PERMISSION_ACTION_PREFIX,
@@ -1647,6 +1650,146 @@ describe('elicitation card', () => {
     expect(multiSelectAccepts(target, ['rm -rf /'])).toBe(false) // never offered
     const single = elicitTarget(form({ color: { type: 'string', enum: ['Red'] } }), WEBCHAT_ELICIT_KINDS)!
     expect(multiSelectAccepts(single, ['Red'])).toBe(false) // not a multi-select card at all
+  })
+
+  // ── free text and numbers (issue #1794 gap 3): webchat types, Slack has no field ──
+
+  it('reads a bare string as a text target carrying its own constraints', () => {
+    expect(
+      elicitTarget(
+        form({ name: { type: 'string', minLength: 3, maxLength: 50, pattern: '^[A-Za-z]+$', format: 'email' } }),
+        WEBCHAT_ELICIT_KINDS
+      )
+    ).toEqual({
+      propName: 'name',
+      kind: 'text',
+      options: [],
+      minLength: 3,
+      maxLength: 50,
+      pattern: '^[A-Za-z]+$',
+      format: 'email'
+    })
+    // An enumerated string is still a pick: typing into it would let an unoffered value through.
+    expect(elicitTarget(form({ c: { type: 'string', enum: ['Red'] } }), WEBCHAT_ELICIT_KINDS)?.kind).toBe('enum')
+  })
+
+  it('reads number and integer as one numeric target, integer-ness kept apart from the bounds', () => {
+    expect(elicitTarget(form({ pct: { type: 'number', minimum: 0, maximum: 100 } }), WEBCHAT_ELICIT_KINDS)).toEqual({
+      propName: 'pct',
+      kind: 'number',
+      options: [],
+      minimum: 0,
+      maximum: 100
+    })
+    expect(elicitTarget(form({ n: { type: 'integer' } }), WEBCHAT_ELICIT_KINDS)).toEqual({
+      propName: 'n',
+      kind: 'number',
+      options: [],
+      integer: true
+    })
+  })
+
+  it('leaves typed fields unrenderable on Slack, whose card has nothing to type into', () => {
+    const text = form({ name: { type: 'string' } })
+    const number = form({ pct: { type: 'number' } })
+    expect(elicitTarget(text, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(buildElicitationCard('elicit-1', text)).toBeNull()
+    expect(elicitTarget(number, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(buildElicitationCard('elicit-1', number)).toBeNull()
+    // The same forms ARE renderable — just not here: webchat types into them.
+    expect(elicitTarget(text, WEBCHAT_ELICIT_KINDS)?.kind).toBe('text')
+    expect(elicitTarget(number, WEBCHAT_ELICIT_KINDS)?.kind).toBe('number')
+  })
+
+  it('declines a typed field whose constraints ask for something it cannot render', () => {
+    // Only the four MCP formats exist; anything else is a promise this card cannot keep.
+    expect(elicitTarget(form({ n: { type: 'string', format: 'hostname' } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    // Bounds that admit no answer at all are not a question.
+    expect(elicitTarget(form({ n: { type: 'string', minLength: 5, maxLength: 2 } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(form({ n: { type: 'number', minimum: 5, maximum: 2 } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(form({ n: { type: 'integer', minimum: 0.2, maximum: 0.8 } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    // A pattern we refuse to run leaves the field unanswerable, never unchecked.
+    expect(elicitTarget(form({ n: { type: 'string', pattern: '^(a+)+$' } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+  })
+
+  it('re-checks a typed string against every constraint the card carried', () => {
+    const target = elicitTarget(
+      form({ name: { type: 'string', minLength: 3, maxLength: 6, pattern: '^[a-z]+$' } }),
+      WEBCHAT_ELICIT_KINDS
+    )!
+    expect(textAccepts(target, 'abc')).toBe(true)
+    expect(textAccepts(target, 'ab')).toBe(false) // below minLength
+    expect(textAccepts(target, 'abcdefg')).toBe(false) // above maxLength
+    expect(textAccepts(target, 'ABC')).toBe(false) // fails the pattern
+    // An answer far past the cap is refused whatever the schema says.
+    const unbounded = elicitTarget(form({ name: { type: 'string' } }), WEBCHAT_ELICIT_KINDS)!
+    expect(textAccepts(unbounded, 'x'.repeat(4096))).toBe(true)
+    expect(textAccepts(unbounded, 'x'.repeat(4097))).toBe(false)
+    // A multi-select target is not a text card, so nothing typed answers it.
+    const list = elicitTarget(
+      form({ c: { type: 'array', items: { type: 'string', enum: ['a'] } } }),
+      WEBCHAT_ELICIT_KINDS
+    )!
+    expect(textAccepts(list, 'a')).toBe(false)
+  })
+
+  it('accepts each of the four formats and refuses a value that is not one', () => {
+    const of = (format: string) => elicitTarget(form({ v: { type: 'string', format } }), WEBCHAT_ELICIT_KINDS)!
+    expect(textAccepts(of('email'), 'user@example.com')).toBe(true)
+    expect(textAccepts(of('email'), 'user@example')).toBe(false)
+    expect(textAccepts(of('uri'), 'https://example.com/x')).toBe(true)
+    expect(textAccepts(of('uri'), 'example.com')).toBe(false)
+    expect(textAccepts(of('date'), '2025-01-31')).toBe(true)
+    expect(textAccepts(of('date'), '2025-02-30')).toBe(false) // a real calendar, not a shape
+    expect(textAccepts(of('date-time'), '2025-01-31T09:00:00Z')).toBe(true)
+    expect(textAccepts(of('date-time'), '2025-01-31 09:00')).toBe(false)
+  })
+
+  it('re-checks a typed number against its bounds and its integer-ness', () => {
+    const pct = elicitTarget(form({ pct: { type: 'number', minimum: 0, maximum: 100 } }), WEBCHAT_ELICIT_KINDS)!
+    expect(numberAccepts(pct, 0)).toBe(true)
+    expect(numberAccepts(pct, 50.5)).toBe(true)
+    expect(numberAccepts(pct, -1)).toBe(false)
+    expect(numberAccepts(pct, 101)).toBe(false)
+    expect(numberAccepts(pct, Number.NaN)).toBe(false)
+    expect(numberAccepts(pct, Number.POSITIVE_INFINITY)).toBe(false)
+    const count = elicitTarget(form({ n: { type: 'integer', minimum: 1 } }), WEBCHAT_ELICIT_KINDS)!
+    expect(numberAccepts(count, 2)).toBe(true)
+    expect(numberAccepts(count, 2.5)).toBe(false)
+  })
+
+  // The pattern is agent-authored and JS regexes backtrack, so a quantified group that itself
+  // quantifies or alternates is refused OUTRIGHT rather than run under some hoped-for budget.
+  it('refuses to compile a pattern that could backtrack catastrophically', () => {
+    expect(safeElicitPattern('^[A-Za-z]+$')).toBeInstanceOf(RegExp)
+    expect(safeElicitPattern('^(?:foo|bar)-\\d{2}$')).toBeInstanceOf(RegExp)
+    expect(safeElicitPattern('^(a+)+$')).toBeNull()
+    expect(safeElicitPattern('^(a|a)*$')).toBeNull()
+    expect(safeElicitPattern('^(a*)*$')).toBeNull()
+    expect(safeElicitPattern('^((a+)*)+$')).toBeNull()
+    expect(safeElicitPattern(`^${'a'.repeat(201)}$`)).toBeNull()
+    expect(safeElicitPattern('^[a-z$')).toBeNull() // does not even compile
+    // The classic ReDoS input against the classic ReDoS pattern: never run at all.
+    const target = elicitTarget(form({ n: { type: 'string', pattern: '^(a+)+$' } }), WEBCHAT_ELICIT_KINDS)
+    expect(target).toBeNull()
+  })
+
+  it('pre-populates every kind from the schema default, and drops one it would refuse', () => {
+    const seed = (prop: Record<string, unknown>) => elicitTarget(form({ v: prop }), WEBCHAT_ELICIT_KINDS)?.defaultValue
+    expect(seed({ type: 'string', enum: ['red', 'green'], default: 'green' })).toBe('green')
+    expect(seed({ type: 'boolean', default: true })).toBe(true)
+    expect(seed({ type: 'string', format: 'email', default: 'user@example.com' })).toBe('user@example.com')
+    expect(seed({ type: 'number', minimum: 0, maximum: 100, default: 50 })).toBe(50)
+    expect(seed({ type: 'integer', default: 3 })).toBe(3)
+    expect(seed({ type: 'array', items: { type: 'string', enum: ['a', 'b'] }, default: ['a'] })).toEqual(['a'])
+    // A default the card would then refuse is no default at all — pre-populating it would hand
+    // the reader a control that cannot be submitted.
+    expect(seed({ type: 'string', enum: ['red'], default: 'blue' })).toBeUndefined()
+    expect(seed({ type: 'number', minimum: 10, default: 1 })).toBeUndefined()
+    expect(seed({ type: 'integer', default: 1.5 })).toBeUndefined()
+    expect(seed({ type: 'string', minLength: 3, default: 'ab' })).toBeUndefined()
+    expect(seed({ type: 'boolean', default: 'yes' })).toBeUndefined()
+    expect(seed({ type: 'array', items: { type: 'string', enum: ['a'] }, default: ['z'] })).toBeUndefined()
   })
 
   it('resolved card is a single section with the decision', () => {

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -1774,6 +1774,23 @@ describe('elicitation card', () => {
     expect(target).toBeNull()
   })
 
+  // Nested quantifiers are not the only shape that backtracks: adjacent ones are polynomial
+  // with no group at all, and degree is what the input cap is budgeted against.
+  it('refuses a pattern whose adjacent quantifiers backtrack without any group', () => {
+    expect(safeElicitPattern('^a*a*a*a*b$')).toBeNull()
+    // Degree is budgeted against the input cap, so ordinary multi-quantifier patterns stand.
+    expect(safeElicitPattern('^\\d{3}-\\d{2}-\\d{4}$')).toBeInstanceOf(RegExp)
+    const target = elicitTarget(form({ n: { type: 'string', pattern: '^a*a*a*a*b$' } }), WEBCHAT_ELICIT_KINDS)
+    expect(target).toBeNull()
+  })
+
+  it('spends a pattern only on a short answer, however long the field allows', () => {
+    const t = elicitTarget(form({ n: { type: 'string', pattern: '^[a-z]+$', maxLength: 4000 } }), WEBCHAT_ELICIT_KINDS)!
+    expect(textAccepts(t, 'abc')).toBe(true)
+    expect(textAccepts(t, 'a'.repeat(256))).toBe(true)
+    expect(textAccepts(t, 'a'.repeat(257))).toBe(false)
+  })
+
   it('pre-populates every kind from the schema default, and drops one it would refuse', () => {
     const seed = (prop: Record<string, unknown>) => elicitTarget(form({ v: prop }), WEBCHAT_ELICIT_KINDS)?.defaultValue
     expect(seed({ type: 'string', enum: ['red', 'green'], default: 'green' })).toBe('green')

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -1791,6 +1791,36 @@ describe('elicitation card', () => {
     expect(textAccepts(t, 'a'.repeat(257))).toBe(false)
   })
 
+  // Dropping a bound we cannot enforce would accept an answer the schema forbids — the same
+  // class of lie as answering a form whose required field the card never showed.
+  it('declines a text field whose minimum exceeds the length it can enforce', () => {
+    expect(elicitTarget(form({ n: { type: 'string', minLength: 5000 } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(
+      elicitTarget(form({ n: { type: 'string', pattern: '^[a-z]+$', minLength: 300 } }), WEBCHAT_ELICIT_KINDS)
+    ).toBeNull()
+  })
+
+  it('carries the effective maximum, clamping a declared one down to what it can enforce', () => {
+    const plain = elicitTarget(form({ n: { type: 'string' } }), WEBCHAT_ELICIT_KINDS)!
+    expect(plain.maxLength).toBe(4096)
+    const declared = elicitTarget(form({ n: { type: 'string', maxLength: 50 } }), WEBCHAT_ELICIT_KINDS)!
+    expect(declared.maxLength).toBe(50)
+    // A patterned field's ceiling is the pattern cap, so the browser bounds its draft by it.
+    const patterned = elicitTarget(
+      form({ n: { type: 'string', pattern: '^[a-z]+$', maxLength: 4000 } }),
+      WEBCHAT_ELICIT_KINDS
+    )!
+    expect(patterned.maxLength).toBe(256)
+  })
+
+  it('fails an impossible calendar value instead of throwing out of the check', () => {
+    const d = elicitTarget(form({ n: { type: 'string', format: 'date' } }), WEBCHAT_ELICIT_KINDS)!
+    expect(() => textAccepts(d, '2025-13-01')).not.toThrow()
+    expect(textAccepts(d, '2025-13-01')).toBe(false)
+    expect(textAccepts(d, '2025-02-30')).toBe(false)
+    expect(textAccepts(d, '2025-01-31')).toBe(true)
+  })
+
   it('pre-populates every kind from the schema default, and drops one it would refuse', () => {
     const seed = (prop: Record<string, unknown>) => elicitTarget(form({ v: prop }), WEBCHAT_ELICIT_KINDS)?.defaultValue
     expect(seed({ type: 'string', enum: ['red', 'green'], default: 'green' })).toBe('green')

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -200,6 +200,9 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       // A multi-select answers with the chosen LIST — same op, widened value.
       { op: 'elicitation_choice', requestId: 'elicit-1', value: ['lint', 'build'] },
       { op: 'elicitation_choice', requestId: 'elicit-1', value: [] },
+      // A typed field answers with the schema's own type — a real number, never its spelling.
+      { op: 'elicitation_choice', requestId: 'elicit-1', value: 42 },
+      { op: 'elicitation_choice', requestId: 'elicit-1', value: -1.5 },
       { op: 'close' }
     ]
     for (const payload of ops) {

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -213,11 +213,13 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
   // A multi-select card answers with the LIST of chosen values: widening this field rather
   // than adding a second one keeps the failure closed, since a daemon predating multi-select
   // rejects the whole op (the card stays live) instead of reading a stripped list as Dismiss.
+  // A number card answers with a real number for the same reason it is one on the wire: the
+  // accepted content must be the schema's type, and a numeric string would be a different one.
   // `agentId` names the participant whose card this is; absent ⇒ the sole agent.
   z.object({
     op: z.literal('elicitation_choice'),
     requestId: z.string().min(1).max(200),
-    value: z.union([z.string(), z.array(z.string()).max(100), z.null()]),
+    value: z.union([z.string(), z.number(), z.array(z.string()).max(100), z.null()]),
     agentId: z.string().uuid().optional()
   }),
   z.object({ op: z.literal('close') })

--- a/packages/protocol/src/frames/webchat.test.ts
+++ b/packages/protocol/src/frames/webchat.test.ts
@@ -111,6 +111,41 @@ describe('WebchatOutput — event / status framing', () => {
     expect(card({ ...base, multi: { maxItems: 1.5 } }).success).toBe(false)
   })
 
+  it('marks a typed card with its constraints and its default, leaving the option cards alone', () => {
+    const card = (event: Record<string, unknown>) =>
+      WebchatOutput.safeParse({ conversationId: CONV, turnId: TURN, index: 4, event })
+    const base = { kind: 'elicitation', requestId: 'elicit-1', message: 'Name the branch?', options: [] }
+    const text = card({
+      ...base,
+      text: { minLength: 3, maxLength: 50, pattern: '^[a-z-]+$', format: 'email' },
+      defaultValue: 'user@example.com'
+    })
+    expect(text.success).toBe(true)
+    if (text.success && text.data.event?.kind === 'elicitation') {
+      // A typed card offers nothing to pick, which is exactly why `options` may now be empty.
+      expect(text.data.event.options).toEqual([])
+      expect(text.data.event.text?.format).toBe('email')
+      expect(text.data.event.defaultValue).toBe('user@example.com')
+    }
+    expect(card({ ...base, number: { integer: true, minimum: 0, maximum: 100 }, defaultValue: 50 }).success).toBe(true)
+    // Only the four formats MCP defines, and a pattern short enough to have been screened.
+    expect(card({ ...base, text: { format: 'hostname' } }).success).toBe(false)
+    expect(card({ ...base, text: { pattern: 'a'.repeat(201) } }).success).toBe(false)
+    // The option cards keep decoding to exactly what they always meant: no typed fields at all.
+    const single = card({
+      kind: 'elicitation',
+      requestId: 'elicit-1',
+      message: 'Which branch?',
+      options: [{ value: 'main', label: 'main' }]
+    })
+    expect(single.success).toBe(true)
+    if (single.success && single.data.event?.kind === 'elicitation') {
+      expect(single.data.event.text).toBeUndefined()
+      expect(single.data.event.number).toBeUndefined()
+      expect(single.data.event.defaultValue).toBeUndefined()
+    }
+  })
+
   it('rejects an unrenderable elicitation frame rather than streaming a dead card', () => {
     const bad = (event: unknown) =>
       WebchatOutput.safeParse({ conversationId: CONV, turnId: TURN, index: 6, event }).success

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -162,12 +162,13 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   // field, and its options are the only answers the browser may send back (as the
   // `elicitation_choice` op keyed by this `requestId`). `message` is agent-authored text,
   // masked before it reaches here. Options are UNCAPPED — the Slack 5-button cap is a
-  // Slack surface limit and does not follow the choice onto this surface.
+  // Slack surface limit and does not follow the choice onto this surface. They are also
+  // EMPTY for a typed field (`text`/`number`), whose card offers nothing to pick.
   z.object({
     kind: z.literal('elicitation'),
     requestId: z.string().min(1).max(200),
     message: z.string(),
-    options: z.array(z.object({ value: z.string(), label: z.string() })).min(1),
+    options: z.array(z.object({ value: z.string(), label: z.string() })),
     // Absent ⇒ pick exactly ONE option, the original card. Present ⇒ pick several of the same
     // options and confirm, and the answer is a list. An added OPTIONAL field rather than a new
     // event kind on purpose: a relay or browser predating it decodes the event unchanged
@@ -175,7 +176,31 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
     // kind would, and a daemon predating it simply never sets it.
     multi: z
       .object({ minItems: z.number().int().min(0).optional(), maxItems: z.number().int().min(0).optional() })
-      .optional()
+      .optional(),
+    // Present ⇒ the card is a free-text input carrying the schema's own constraints, which the
+    // daemon re-checks on the way back in. Same optional-field reasoning as `multi`, with one
+    // added skew note: an old reader keeps `options` (now empty) and shows a card with nothing
+    // but Dismiss — unanswerable, never wrongly answered. `pattern` reaches here only once the
+    // daemon has cleared it as safe to run.
+    text: z
+      .object({
+        minLength: z.number().int().min(0).optional(),
+        maxLength: z.number().int().min(0).optional(),
+        pattern: z.string().max(200).optional(),
+        format: z.enum(['email', 'uri', 'date', 'date-time']).optional()
+      })
+      .optional(),
+    // Present ⇒ a numeric input; `integer` is the schema's `integer` type, not just a bound.
+    number: z
+      .object({
+        integer: z.boolean().optional(),
+        minimum: z.number().optional(),
+        maximum: z.number().optional()
+      })
+      .optional(),
+    // The schema's `default`, already checked against the constraints above: the card
+    // pre-populates its control with it (MCP `2025-11-25`), and the reader may answer otherwise.
+    defaultValue: z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]).optional()
   }),
   // The same card, settled. Slack rewrites its message in place; this stream is
   // append-only, so the collapse is a second event keyed by the same `requestId`.

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -182,6 +182,11 @@ describe('parseBrowserFrame', () => {
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: [] }, USER)).toEqual({
       op: { op: 'elicitation_choice', requestId: 'elicit-1', value: [] }
     })
+    // A typed field answers with a real number; a non-finite one is not a number a schema means.
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: 42 }, USER)).toEqual({
+      op: { op: 'elicitation_choice', requestId: 'elicit-1', value: 42 }
+    })
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: Number.NaN }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: ['a', 7] }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1' }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', value: 'yes' }, USER)).toBeNull()

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -193,11 +193,13 @@ export function parseBrowserFrame(
         ? { op: { op: 'cancel', ...(typeof m.agentId === 'string' ? { agentId: m.agentId.toLowerCase() } : {}) } }
         : null
     case 'elicitation_choice': {
-      // The answer to an in-band elicitation card. `value: null` is Dismiss and an array is a
-      // multi-select's chosen list; the daemon matches the requestId against its own pending
-      // card, and re-checks every value against the options that card offered.
+      // The answer to an in-band elicitation card. `value: null` is Dismiss, an array is a
+      // multi-select's chosen list, a number answers a numeric field, and a string is a picked
+      // option or typed text; the daemon matches the requestId against its own pending card and
+      // re-checks the value against the constraints that card carried.
       const listed = Array.isArray(m.value) && m.value.every((v) => typeof v === 'string')
-      if (typeof m.requestId !== 'string' || (typeof m.value !== 'string' && m.value !== null && !listed)) return null
+      const scalar = typeof m.value === 'string' || (typeof m.value === 'number' && Number.isFinite(m.value))
+      if (typeof m.requestId !== 'string' || (!scalar && m.value !== null && !listed)) return null
       if (m.agentId !== undefined && !(typeof m.agentId === 'string' && UUID_RE.test(m.agentId))) return null
       const parsed = RelayWebchatOp.safeParse({
         op: 'elicitation_choice',

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -127,12 +127,13 @@ interface PlaygroundData {
   pgSetFast: (id: string, agentId: string, fastMode: boolean, conversationId?: string) => void
   /** Interrupt the running turn without ending the session. */
   pgCancel: (id: string, agentId: string, conversationId?: string) => void
-  /** Answer the agent's in-band elicitation card; a list answers a multi-select, `null` is Dismiss. */
+  /** Answer the agent's in-band elicitation card; a list answers a multi-select, a number a
+   *  numeric field, `null` is Dismiss. */
   pgAnswerElicitation: (
     id: string,
     agentId: string,
     requestId: string,
-    value: string | string[] | null,
+    value: string | string[] | number | null,
     conversationId?: string
   ) => void
   getPgSession: (id: string) => Session | undefined
@@ -251,6 +252,9 @@ type WebchatEvent =
       message: string
       options: { value: string; label: string }[]
       multi?: { minItems?: number; maxItems?: number }
+      text?: { minLength?: number; maxLength?: number; pattern?: string; format?: string }
+      number?: { integer?: boolean; minimum?: number; maximum?: number }
+      defaultValue?: string | number | boolean | string[]
     }
   | {
       kind: 'elicitation_resolved'
@@ -618,7 +622,14 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
             lane({
               kind: 'elicit',
               text: ev.message,
-              elicit: { requestId: ev.requestId, options: ev.options, ...(ev.multi ? { multi: ev.multi } : {}) },
+              elicit: {
+                requestId: ev.requestId,
+                options: ev.options,
+                ...(ev.multi ? { multi: ev.multi } : {}),
+                ...(ev.text ? { text: ev.text } : {}),
+                ...(ev.number ? { number: ev.number } : {}),
+                ...(ev.defaultValue !== undefined ? { defaultValue: ev.defaultValue } : {})
+              },
               boundary: true
             })
           ]
@@ -1715,7 +1726,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
    *  Deliberately NOT optimistic: the daemon owns the card's outcome and settles it with
    *  the `elicitation_resolved` event, so a refused answer leaves the card answerable. */
   const pgAnswerElicitation = useCallback(
-    (id: string, agentForId: string, requestId: string, value: string | string[] | null, conversationId?: string) => {
+    (
+      id: string,
+      agentForId: string,
+      requestId: string,
+      value: string | string[] | number | null,
+      conversationId?: string
+    ) => {
       connect(id, agentForId, conversationId)
         .ready.then((ws) =>
           ws.send(JSON.stringify({ type: 'elicitation_choice', requestId, value, agentId: agentForId }))

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -288,6 +288,103 @@ describe('the agent’s elicitation card on the session page', () => {
     expect(buttonNamed('Confirm')).toBeUndefined()
   })
 
+  // ── free text and numbers (#1794 gap 3): a typed field has no options to offer ──
+
+  const input = () => container?.querySelector('input[aria-label="Your answer"]') as HTMLInputElement | null
+  const type = async (value: string) => {
+    const field = input()!
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(field, value)
+      field.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  it('types a free-text answer and sends it only once its constraints are met', async () => {
+    live.steps = [
+      {
+        ...CARD,
+        text: 'What should I name the branch?',
+        elicit: { requestId: 'elicit-1', options: [], text: { minLength: 3, pattern: '^[a-z-]+$' } }
+      }
+    ]
+    await render()
+
+    // Nothing typed yet, so there is nothing valid to submit — and the reason says why.
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(text()).toContain('Enter at least 3 characters')
+    // A typed field offers nothing to pick.
+    expect(buttonNamed('main')).toBeUndefined()
+
+    await type('ab')
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    await type('ADD')
+    // Long enough now, but the schema's own pattern still refuses it.
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(text()).toContain('^[a-z-]+$')
+    expect(live.answered).toEqual([])
+
+    await type('add-retries')
+    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    await act(async () => {
+      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', 'add-retries', 'conv-1']])
+  })
+
+  it('sends a numeric answer as a real number, and holds one outside the schema’s bounds', async () => {
+    live.steps = [
+      {
+        ...CARD,
+        text: 'How many retries?',
+        elicit: { requestId: 'elicit-1', options: [], number: { integer: true, minimum: 1, maximum: 5 } }
+      }
+    ]
+    await render()
+
+    await type('9')
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(text()).toContain('Enter 5 or less')
+    await type('2.5')
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(text()).toContain('Enter a whole number')
+
+    await type('3')
+    await act(async () => {
+      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // A number, not the string that spelled it — the accepted content carries the schema's type.
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', 3, 'conv-1']])
+  })
+
+  it('pre-populates every kind from the schema default', async () => {
+    live.steps = [
+      { ...CARD, elicit: { requestId: 'elicit-1', options: [], text: { format: 'email' }, defaultValue: 'a@b.co' } }
+    ]
+    await render()
+    // Pre-populated AND already valid, so the reader can simply accept the suggestion.
+    expect(input()?.value).toBe('a@b.co')
+    expect(buttonNamed('Submit')?.disabled).toBe(false)
+
+    // A distinct card each time: a card's control is seeded when it arrives, not re-seeded.
+    live.steps = [{ ...CARD, elicit: { ...CARD.elicit, requestId: 'elicit-2', defaultValue: 'develop' } }]
+    await render()
+    // A single-choice default stays marked, so the reader sees what the agent suggested.
+    expect(buttonNamed('develop')?.getAttribute('aria-pressed')).toBe(null)
+    expect(buttonNamed('develop')?.className).toContain('--brand')
+
+    live.steps = [
+      { ...CARD, elicit: { ...CARD.elicit, requestId: 'elicit-3', multi: { minItems: 1 }, defaultValue: ['main'] } }
+    ]
+    await render()
+    expect(buttonNamed('main')?.getAttribute('aria-pressed')).toBe('true')
+    expect(buttonNamed('Confirm')?.disabled).toBe(false)
+    await act(async () => {
+      buttonNamed('Confirm')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered.at(-1)).toEqual(['session-1', 'agent-1', 'elicit-3', ['main'], 'conv-1'])
+  })
+
   it('collapses to its outcome once settled, leaving nothing left to answer', async () => {
     live.steps = [{ ...CARD, elicit: { ...CARD.elicit, outcome: 'accepted', answerLabel: 'develop' } }]
     await render()

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -332,6 +332,27 @@ describe('the agent’s elicitation card on the session page', () => {
     expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', 'add-retries', 'conv-1']])
   })
 
+  // The validator runs during render, so a draft that merely LOOKS like a date used to take
+  // the whole session view down with a RangeError instead of showing the correction hint.
+  it('holds an impossible calendar draft without taking the view down with it', async () => {
+    live.steps = [
+      {
+        ...CARD,
+        text: 'When should I schedule it?',
+        elicit: { requestId: 'elicit-1', options: [], text: { format: 'date' } }
+      }
+    ]
+    await render()
+
+    await type('2025-13-01')
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(text()).toContain('Enter a date as YYYY-MM-DD')
+    expect(live.answered).toEqual([])
+
+    await type('2025-01-31')
+    expect(buttonNamed('Submit')?.disabled).toBe(false)
+  })
+
   it('sends a numeric answer as a real number, and holds one outside the schema’s bounds', async () => {
     live.steps = [
       {

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -667,11 +667,18 @@ const FORMAT_HINT: Record<string, { test: (v: string) => boolean; why: string }>
     why: 'Enter a URL, including its scheme'
   },
   date: {
-    test: (v) => /^\d{4}-\d{2}-\d{2}$/.test(v) && v === new Date(`${v}T00:00:00Z`).toISOString().slice(0, 10),
+    // `2025-13-01` matches the shape but is not a date, and toISOString THROWS on it — this
+    // runs during render, so an ordinary invalid draft would crash the view, not fail a check.
+    test: (v) => {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(v)) return false
+      const d = new Date(`${v}T00:00:00Z`)
+      return !Number.isNaN(d.getTime()) && v === d.toISOString().slice(0, 10)
+    },
     why: 'Enter a date as YYYY-MM-DD'
   },
   'date-time': {
-    test: (v) => /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/.test(v),
+    test: (v) =>
+      /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/.test(v) && !isNaN(Date.parse(v)),
     why: 'Enter a date and time, e.g. 2025-01-31T09:00:00Z'
   }
 }
@@ -694,6 +701,8 @@ function typedInvalidReason(elicit: NonNullable<FmtStep['elicit']>, draft: strin
   if (text.minLength !== undefined && draft.length < text.minLength)
     return `Enter at least ${text.minLength} character${text.minLength === 1 ? '' : 's'}`
   if (!draft.length) return 'Enter an answer'
+  // Also what keeps the pattern below cheap: the daemon sizes maxLength down to the pattern
+  // cap, so a long draft is refused here rather than matched on every keystroke.
   if (text.maxLength !== undefined && draft.length > text.maxLength) return `Enter at most ${text.maxLength} characters`
   const format = text.format ? FORMAT_HINT[text.format] : undefined
   if (format && !format.test(draft)) return format.why

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -653,19 +653,98 @@ function selectionHint(min: number, max?: number): string {
   return max !== undefined ? `Select up to ${max}` : 'Select any that apply'
 }
 
+// What each schema `format` asks of a typed answer, named the way the reader has to fix it.
+const FORMAT_HINT: Record<string, { test: (v: string) => boolean; why: string }> = {
+  email: { test: (v) => /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/.test(v), why: 'Enter an email address' },
+  uri: {
+    test: (v) => {
+      try {
+        return !!new URL(v).protocol
+      } catch {
+        return false
+      }
+    },
+    why: 'Enter a URL, including its scheme'
+  },
+  date: {
+    test: (v) => /^\d{4}-\d{2}-\d{2}$/.test(v) && v === new Date(`${v}T00:00:00Z`).toISOString().slice(0, 10),
+    why: 'Enter a date as YYYY-MM-DD'
+  },
+  'date-time': {
+    test: (v) => /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/.test(v),
+    why: 'Enter a date and time, e.g. 2025-01-31T09:00:00Z'
+  }
+}
+
+/** Why a typed draft is not yet answerable, or undefined once it is — the same constraints the
+ *  daemon re-checks, said in words the reader can act on rather than as a silent dead control. */
+function typedInvalidReason(elicit: NonNullable<FmtStep['elicit']>, draft: string): string | undefined {
+  const num = elicit.number
+  if (num) {
+    if (!draft.trim()) return 'Enter a number'
+    const value = Number(draft)
+    if (!Number.isFinite(value)) return 'Enter a number'
+    if (num.integer && !Number.isInteger(value)) return 'Enter a whole number'
+    if (num.minimum !== undefined && value < num.minimum) return `Enter ${num.minimum} or more`
+    if (num.maximum !== undefined && value > num.maximum) return `Enter ${num.maximum} or less`
+    return undefined
+  }
+  const text = elicit.text
+  if (!text) return undefined
+  if (text.minLength !== undefined && draft.length < text.minLength)
+    return `Enter at least ${text.minLength} character${text.minLength === 1 ? '' : 's'}`
+  if (!draft.length) return 'Enter an answer'
+  if (text.maxLength !== undefined && draft.length > text.maxLength) return `Enter at most ${text.maxLength} characters`
+  const format = text.format ? FORMAT_HINT[text.format] : undefined
+  if (format && !format.test(draft)) return format.why
+  if (text.pattern !== undefined) {
+    try {
+      if (!new RegExp(text.pattern).test(draft)) return `Match ${text.pattern}`
+    } catch {
+      return 'This field cannot be answered here'
+    }
+  }
+  return undefined
+}
+
+/** What a typed card's control starts out holding: the schema's `default`, or nothing. */
+function typedDraft(elicit: FmtStep['elicit']): string {
+  const value = elicit?.defaultValue
+  return typeof value === 'string' || typeof value === 'number' ? String(value) : ''
+}
+
+/** The options a card starts out holding — a multi-select's default list, or the single default
+ *  pick, which stays marked so the reader sees what the agent suggested before tapping. */
+function pickedDefaults(elicit: FmtStep['elicit']): string[] {
+  const value = elicit?.defaultValue
+  if (Array.isArray(value)) return value
+  return typeof value === 'string' || typeof value === 'boolean' ? [String(value)] : []
+}
+
 /** The agent's in-band question: its options while it is live, its outcome once settled.
  *  A multi-select (`elicit.multi`) toggles its options and answers with the list on Confirm —
  *  one tap can't express a set — while a single-choice card still answers on the tap itself.
+ *  A typed field (`elicit.text` / `elicit.number`) has no options at all: it submits what the
+ *  reader wrote, once the schema's own constraints are met.
  *  Without `onAnswer` — a reader with no live socket to answer over — the same card renders
  *  as a plain record of the ask, controls inert rather than missing. */
-function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value: string | string[] | null) => void }) {
-  const [picked, setPicked] = useState<string[]>([])
+function ElicitationCard({
+  step,
+  onAnswer
+}: {
+  step: FmtStep
+  onAnswer?: (value: string | string[] | number | null) => void
+}) {
+  const [picked, setPicked] = useState<string[]>(() => pickedDefaults(step.elicit))
+  const [draft, setDraft] = useState<string>(() => typedDraft(step.elicit))
   const elicit = step.elicit
   const multi = elicit?.multi
+  const typed = elicit && (elicit.text || elicit.number) ? elicit : undefined
   const min = multi?.minItems ?? 0
   const max = multi?.maxItems
   // The same bounds the daemon re-checks: a browser frame is not what makes an answer valid.
   const complete = picked.length >= min && (max === undefined || picked.length <= max)
+  const invalid = typed ? typedInvalidReason(typed, draft) : undefined
   if (!elicit) return null
   const settled = elicit.outcome ? ELICIT_OUTCOME[elicit.outcome] : undefined
   return (
@@ -684,6 +763,46 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
             <Icon name={settled.icon} size={13} color={settled.color} />
             <span className="min-w-0 truncate">{settled.label(elicit.answerLabel)}</span>
           </span>
+        ) : typed ? (
+          <>
+            <input
+              className="inp min-w-0 flex-1 basis-[220px] disabled:cursor-default disabled:opacity-55"
+              type={elicit.number ? 'number' : 'text'}
+              value={draft}
+              disabled={!onAnswer}
+              aria-label="Your answer"
+              {...(elicit.number?.minimum !== undefined ? { min: elicit.number.minimum } : {})}
+              {...(elicit.number?.maximum !== undefined ? { max: elicit.number.maximum } : {})}
+              {...(elicit.number?.integer ? { step: 1 } : {})}
+              {...(elicit.text?.maxLength !== undefined ? { maxLength: elicit.text.maxLength } : {})}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && onAnswer && !invalid) onAnswer(elicit.number ? Number(draft) : draft)
+              }}
+            />
+            {invalid && (
+              <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+                {invalid}
+              </span>
+            )}
+            <button
+              type="button"
+              className="dsbtn dsbtn-primary xs"
+              disabled={!onAnswer || !!invalid}
+              onClick={() => onAnswer?.(elicit.number ? Number(draft) : draft)}
+            >
+              Submit
+            </button>
+            <button
+              type="button"
+              className="chip disabled:cursor-default disabled:opacity-55"
+              disabled={!onAnswer}
+              onClick={() => onAnswer?.(null)}
+              title="Dismiss without answering"
+            >
+              Dismiss
+            </button>
+          </>
         ) : (
           <>
             {elicit.options.map((option) => {
@@ -2955,7 +3074,11 @@ export default function SessionDetailView() {
   // the card renders inert rather than offering buttons that would go nowhere.
   const answerElicitation =
     isLive && (isPg || isWebchat)
-      ? (agentId: string | undefined, requestId: string | undefined, value: string | string[] | null): void => {
+      ? (
+          agentId: string | undefined,
+          requestId: string | undefined,
+          value: string | string[] | number | null
+        ): void => {
           if (!requestId) return
           pgAnswerElicitation(session.id, agentId ?? session.agentId ?? '', requestId, value, webchatConversationId)
         }
@@ -4357,7 +4480,7 @@ export default function SessionDetailView() {
                                           step={st}
                                           {...(answerElicitation
                                             ? {
-                                                onAnswer: (value: string | string[] | null) =>
+                                                onAnswer: (value: string | string[] | number | null) =>
                                                   answerElicitation(turn.agentId, st.elicit?.requestId, value)
                                               }
                                             : {})}

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1133,6 +1133,13 @@ export interface SessionStep {
     /** Present ⇒ the card picks SEVERAL options and confirms, and answers with the list.
      *  Absent ⇒ one option, answered on the tap. */
     multi?: { minItems?: number; maxItems?: number }
+    /** Present ⇒ the card is a free-text input carrying the schema's constraints (the daemon
+     *  re-checks every one of them), and `options` is empty. */
+    text?: { minLength?: number; maxLength?: number; pattern?: string; format?: string }
+    /** Present ⇒ a numeric input; `integer` refuses a fractional answer. */
+    number?: { integer?: boolean; minimum?: number; maximum?: number }
+    /** The schema's `default` — what the control starts out holding. */
+    defaultValue?: string | number | boolean | string[]
     outcome?: 'accepted' | 'dismissed' | 'cancelled'
     answerLabel?: string
   }


### PR DESCRIPTION
Implements #1794 gap 3, for webchat. Free text and numbers were the last field shapes MCP's restricted schema allows that we could not answer at all, and their constraints were being ignored for want of an input to enforce them on.

```jsonc
{ "type": "string", "minLength": 3, "maxLength": 50, "pattern": "^[A-Za-z]+$",
  "format": "email", "default": "user@example.com" }
{ "type": "number", "minimum": 0, "maximum": 100, "default": 50 }    // and "integer"
```

Two new kinds join `WEBCHAT_ELICIT_KINDS`. `SLACK_ELICIT_KINDS` stays `{enum, boolean}`, so a text-only form still declines there — asserted by a test, and by the #1801 mechanism that makes a kind invisible to any surface which has not claimed it.

`default` is implemented for **every** kind, not just the new ones: it is one wire field and one sentence of the spec ("clients that support defaults SHOULD pre-populate"), so a default-selected enum option, boolean and multi-select come along. A default the card would then refuse is dropped rather than seeded — pre-populating an answer we would reject is worse than none.

## Wire

Outbound gains `text?`, `number?`, `defaultValue?`, and `options` loses `.min(1)` (a typed card offers nothing to pick). Inbound widens `value` to include `number`, following #1801's argument rather than adding a sibling field.

How each skew fails:

| Skew | Result |
| --- | --- |
| new daemon → old relay | `options.min(1)` rejects the frame; card never posted, request cancels at turn end. Closed. |
| new daemon → old browser | Card renders with no options and only Dismiss — unanswerable, and Dismiss is an explicit `decline`. Never a wrong value. |
| new browser → old daemon | Numeric `value` fails the zod union, whole op refused, card stays live. |

The third row is the reason for widening rather than adding: a new optional field would have been *stripped* by an old daemon, leaving `value: null` — a Dismiss the user never sent. A refusal is the safe direction.

## Answers are re-validated on the daemon

`minLength`/`maxLength`/`pattern` and the four `format` values for text; `minimum`/`maximum` and integer-ness for numbers. The console blocks submit on the same rules with a readable reason, but is never authoritative — same split as the existing option whitelist and `multiSelectAccepts`. Accept content is the typed value: a real JS number, not a numeric string.

## Containing an agent-authored `pattern`

The pattern is a regular expression written by the other side and run in the daemon, so it is contained by **refusing to compile** rather than by hoping a budget holds. `safeElicitPattern` walks the source honouring escapes, character classes and group modifiers, and refuses:

- sources over 200 characters
- a quantified group whose body itself quantifies or alternates — `(a+)+`, `(a|a)*`, `((a+)*)+`
- more than three quantifiers in total, because **adjacent** quantifiers backtrack polynomially with no group at all (`a*a*a*a*b`)
- anything `new RegExp` rejects

A refused pattern makes the property unrenderable, so the form declines; the expression is never executed, not even once under a timeout. Backtracking cost is degree against input length, so the input is bounded too: a pattern is matched only against the first 256 characters however large the field's own `maxLength` is. Ordinary patterns are untouched — `^\d{3}-\d{2}-\d{4}$` still compiles.

The rejected alternative was running the match in a worker thread with `terminate()` on a timeout, the only genuinely interruptible option in Node. It would have made `elicitTarget` and the accept checks async, and those are pure sync functions deliberately shared with the Slack card builders so both surfaces reach an identical verdict from identical code. Spawning a thread per answer to run a regex the schema author could have written safely is the wrong trade. The cost is over-rejection: `^(foo|bar)+$` declines though it is harmless.

## Two judgement calls worth naming

**`uri` accepts anything `new URL()` parses, including `javascript:`.** Left deliberately: we never render the value as a link (MCP's safe-URL rules govern rendering, and this is not rendered), and a scheme allowlist would reject `git://`, `ssh://` and `file://`, all plausible answers in this product. The value is handed to the agent as the string the user typed.

**The settled card echoes the typed answer** (clamped to 200 chars) rather than saying "Answered". The card is the reader's own words back in their own conversation, and losing them loses the thread of what was agreed. This is safe only because MCP forbids using form-mode elicitation for sensitive information; if that ever softens into a `writeOnly`-style signal, this is the line to revisit.

## Known limits

- A pattern the screen refuses declines silently, and the agent cannot tell that from the user dismissing. ACP has no field for a reason; the existing decline paths are all silent too.
- Validation is now expressed twice, in the daemon and in the console. That is intentional — the browser must never be authoritative — but the two format checks have to be kept in step by hand.
- `format` semantics are ours: `email` is deliberately narrower than RFC 5322.

## Verification

- protocol 485, relay 644, web 2383, daemon (`render` / `daemon-permission-autoallow` / `daemon-webchat` / `approval-dm`) 290 — all passing.
- `pnpm typecheck` clean, grepped for `error TS` (it covers tests).
- eslint + prettier clean on changed files.

Every new test asserting a guard was confirmed red without its fix by reverting only the source file and keeping the test: 13 daemon cases, 2 protocol, 1 relay, 3 console, plus the two ReDoS cases added on review.
