### PR TITLE
feat(daemon): security.sandboxWriteRoots reopens operator-declared host dirs writable in every sandbox

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -136,6 +136,7 @@ The daemon does not implement these, but interacts with them through the section
 | `--max-agents <n>`               | `limits.maxAgents`             | Capacity reported to CP + local hard limit.                                                                                                        |
 | `--require-sandbox`              | `security.requireSandbox=true` | Require every agent to run in the Linux SRT sandbox; refuse daemon startup on unsupported or failed hosts.                                         |
 | n/a (config only)                | `security.sandboxReadRoots`    | Host toolchain dirs carved read-only into every sandbox; see the config example below.                                                             |
+| n/a (config only)                | `security.sandboxWriteRoots`   | Host package-manager stores carved writable into every sandbox, shared by every session; see the config example below.                             |
 | `--k8s`                          | n/a (mode switch)              | Run runtimes in cluster sandbox pods instead of on this host; see section 2.6 for what that changes.                                               |
 | `--key-server <url>`             | `KEY_SERVER`                   | Cloud-only service for session-scoped model credentials, http or https as the deployment chooses; see [key-server.md](key-server.md).              |
 | `--key-server-token-path <path>` | `KEY_SERVER_TOKEN_PATH`        | File re-read as the key-server bearer token on every request.                                                                                      |
@@ -329,6 +330,15 @@ The layout keeps machine configuration, per-agent desired state, durable runtime
     // that also holds credentials (~/.cargo/credentials.toml, ~/.npmrc).
     "sandboxReadRoots": [],
 
+    // Host directories carved WRITABLE into EVERY sandbox, so sessions share one
+    // package-manager store instead of each downloading its own (pnpm's store,
+    // corepack's cache; point the runtime at them with the agent's env, e.g.
+    // npm_config_store_dir / COREPACK_HOME). Same expansion and existence rule as
+    // sandboxReadRoots. This is a deliberate hole in per-session isolation: what one
+    // session's install writes, the next session runs. Name the store itself, never
+    // HOME or a parent holding credentials.
+    "sandboxWriteRoots": [],
+
     // Origins that daemon-managed workspace clone/pull may target. Default ["*"]
     // admits any valid https/ssh origin; exact entries (scheme and non-default
     // port are part of the match, no partial wildcards or paths) tighten it, and
@@ -389,8 +399,9 @@ re-allows reads only for the workspace, private HOME, managed memory,
 roots, any operator-declared `security.sandboxReadRoots` (host toolchains such as
 nvm's node or a rustup toolchain, carved read-only into every sandbox regardless
 of runtime), and the runtime's selected host credential path. Writes are limited to
-the workspace, private HOME, managed memory, SRT temporary storage, and that
-credential path. Outbound
+the workspace, private HOME, managed memory, SRT temporary storage, that
+credential path, and any operator-declared `security.sandboxWriteRoots` (a shared
+package-manager store, reopened by the same exception rule as a read root). Outbound
 domains are approved by a provider callback and Unix sockets remain
 compatibility-open during this rollout. Proxy-aware HTTP(S) clients retain web
 egress, and the provider sets `NODE_USE_ENV_PROXY=1` so Node's built-in `fetch`

--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -385,7 +385,8 @@ export function claudeSessionMeta(
   protectedCredentialRoots?: readonly string[],
   protectedSettings?: ClaudeProtectedSettings,
   allowModelToolUnixSockets = false,
-  extraDisallowedTools: readonly string[] = []
+  extraDisallowedTools: readonly string[] = [],
+  sharedWriteRoots: readonly string[] = []
 ):
   | {
       claudeCode: {
@@ -417,7 +418,9 @@ export function claudeSessionMeta(
         // adapters spread this into SDK query() options (older ones ignore it).
         disallowedTools: [...CLAUDE_DISALLOWED_BUILTIN_TOOLS, ...extraDisallowedTools],
         ...(protectedCredentialRoots
-          ? { sandbox: claudeInnerSandboxSettings(protectedCredentialRoots, allowModelToolUnixSockets) }
+          ? {
+              sandbox: claudeInnerSandboxSettings(protectedCredentialRoots, allowModelToolUnixSockets, sharedWriteRoots)
+            }
           : {}),
         ...(protectedSettings || ultracode ? { settings } : {})
       },
@@ -842,7 +845,8 @@ export class AcpHost {
       this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined,
       this.opts.sandbox?.claudeProtectedSettings,
       this.opts.sandbox?.allowModelToolUnixSockets,
-      extraDisallowedTools
+      extraDisallowedTools,
+      this.opts.sandbox?.sharedWriteRoots
     )
     const activeAdditionalDirectories = this.canUseAdditionalDirectories ? additionalDirectories : []
     const res = await this.conn!.agent.request(methods.agent.session.new, {
@@ -1077,7 +1081,9 @@ export class AcpHost {
         undefined,
         this.opts.sandbox ? (this.opts.sandbox.protectedCredentialRoots ?? []) : undefined,
         this.opts.sandbox?.claudeProtectedSettings,
-        this.opts.sandbox?.allowModelToolUnixSockets
+        this.opts.sandbox?.allowModelToolUnixSockets,
+        [],
+        this.opts.sandbox?.sharedWriteRoots
       )
       const activeAdditionalDirectories = this.canUseAdditionalDirectories ? additionalDirectories : []
       const res = await this.conn!.agent.request(methods.agent.session.load, {

--- a/packages/daemon/src/acp/codex-permission-profiles.ts
+++ b/packages/daemon/src/acp/codex-permission-profiles.ts
@@ -21,6 +21,8 @@ export interface CodexPermissionProfileOptions {
   sessionGitMetadataRoots?: readonly string[]
   /** A confined session's private HOME (§11) — a SIBLING of the cwd, so `:workspace` never reaches it. */
   sessionHomeRoot?: string
+  /** Operator-declared `security.sandboxWriteRoots` the outer boundary already opened: a shared package store, outside the cwd. */
+  sharedWriteRoots?: readonly string[]
   allowModelToolUnixSockets?: boolean
   disableUnifiedExec?: boolean
 }
@@ -62,11 +64,13 @@ export function codexPermissionProfileConfig(
   const writableGitMetadataRoots = [...new Set((opts.writableGitMetadataRoots ?? []).map((root) => normalize(root)))]
   const sessionGitMetadataRoots = [...new Set((opts.sessionGitMetadataRoots ?? []).map((root) => normalize(root)))]
   const sessionHomeRoot = opts.sessionHomeRoot === undefined ? undefined : normalize(opts.sessionHomeRoot)
+  const sharedWriteRoots = [...new Set((opts.sharedWriteRoots ?? []).map((root) => normalize(root)))]
   const policyRoots = [
     ...protectedRoots,
     ...writableGitMetadataRoots,
     ...sessionGitMetadataRoots,
-    ...(sessionHomeRoot === undefined ? [] : [sessionHomeRoot])
+    ...(sessionHomeRoot === undefined ? [] : [sessionHomeRoot]),
+    ...sharedWriteRoots
   ]
   if (policyRoots.length === 0 && !opts.allowModelToolUnixSockets && !opts.disableUnifiedExec) return undefined
   if (policyRoots.some((root) => !isAbsolute(root))) {
@@ -101,6 +105,8 @@ export function codexPermissionProfileConfig(
           [sessionHomeRoot, 'write'],
           [join(sessionHomeRoot, '.codex'), 'deny']
         ] as Array<[string, string]>)),
+    // A shared store sits outside the cwd, so `:workspace` alone would refuse the very install it exists for; the read-only mode keeps refusing it.
+    ...sharedWriteRoots.map((root): [string, string] => [root, 'write']),
     ...protectedRoots.map((root): [string, string] => [root, 'deny'])
   ]
   const agentFilesystem =
@@ -112,6 +118,7 @@ export function codexPermissionProfileConfig(
     ['/.git', 'write'],
     ['/.agents', 'write'],
     ['/.codex', 'write'],
+    ...sharedWriteRoots.map((root): [string, string] => [root, 'write']),
     ...protectedRoots.map((root): [string, string] => [root, 'deny'])
   ])
   // On Linux Codex's restricted network seccomp permits AF_UNIX socket()

--- a/packages/daemon/src/acp/spawn-driver.ts
+++ b/packages/daemon/src/acp/spawn-driver.ts
@@ -28,6 +28,8 @@ export interface AcpSandboxLaunch {
   /** SDK flag settings that pin protected parent-only profile selection after
    * Claude merges workspace-controlled settings. */
   claudeProtectedSettings?: ClaudeProtectedSettings
+  /** Operator-declared `security.sandboxWriteRoots`, reopened in the runtime-native tool sandbox as well. */
+  sharedWriteRoots?: string[]
 }
 
 /**

--- a/packages/daemon/src/cli/chat.ts
+++ b/packages/daemon/src/cli/chat.ts
@@ -15,7 +15,7 @@ import { detectSandbox } from '../acp/sandbox.js'
 import { agentHostKey } from '../acp/host-key.js'
 import { resolveRoot } from '../paths.js'
 import { runtimeHomePath } from '../runtimes/runtime-home.js'
-import { sandboxReadRoots } from '../runtimes/read-roots.js'
+import { sandboxReadRoots, sandboxWriteRoots } from '../runtimes/read-roots.js'
 import { installedRuntimeCatalog } from '../runtimes/probe.js'
 import { ArchiveStore, parseArchiveLaunch, storedArchiveRuntimeDef } from '../runtimes/archive-store.js'
 import { probeAllRuntimes, type ProbeOptions, type RuntimeProbeResult } from '../runtimes/runtime-prober.js'
@@ -64,6 +64,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
   configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
   // Same fail-fast the daemon applies at boot: a missing operator read root is a config error, not a turn error.
   const operatorReadRoots = sandboxReadRoots(cfg.security.sandboxReadRoots)
+  const operatorWriteRoots = sandboxWriteRoots(cfg.security.sandboxWriteRoots)
   const agent = selectAgent(cfg.agentsDir!, opts.agentName)
   await persistSkillSandboxRequirement(root)
 
@@ -166,6 +167,7 @@ export async function runChat(opts: RunChatOpts): Promise<void> {
     // back: mcpSocketPath / allowModelToolUnixSockets stay genuinely unused. The operator's
     // daemon-wide toolchain roots still apply, exactly as they do under the daemon.
     runtimeReadRoots: runInSandbox ? operatorReadRoots : undefined,
+    runtimeWriteRoots: runInSandbox ? operatorWriteRoots : undefined,
     sandboxMechanism
   })
   for (const notice of assembled.configFiles?.notices ?? []) out.write(`⚠️ ${notice}\n`)

--- a/packages/daemon/src/config/config-schema.ts
+++ b/packages/daemon/src/config/config-schema.ts
@@ -171,6 +171,8 @@ export const ConfigSchema = z.object({
       requireSandbox: z.boolean().default(false),
       // Operator-owned host dirs (toolchains such as nvm's node or a rustup toolchain) carved read-only into every sandbox.
       sandboxReadRoots: z.array(z.string()).default([]),
+      // Operator-owned host dirs carved WRITABLE into every sandbox: package-manager stores (pnpm's store, corepack's cache) every session shares, so a PR's install lands in one place. Nothing here is verified by the daemon — whatever a sandboxed turn writes, the next session reads.
+      sandboxWriteRoots: z.array(z.string()).default([]),
       // Operator-owned remote-origin policy for daemon-managed workspace clone/pull. Default
       // ['*'] admits any https/ssh origin; exact scheme+host+port entries tighten it, and []
       // disables remote Git workspaces entirely.
@@ -180,6 +182,7 @@ export const ConfigSchema = z.object({
       isolateAccountApps: true,
       requireSandbox: false,
       sandboxReadRoots: [],
+      sandboxWriteRoots: [],
       workspaceGitAllowedOrigins: [...DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS]
     }),
   // Relay roster the CP last published (shared-bot-relay.md §5). Persisted whole so

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -306,7 +306,12 @@ import { internalSessionKey, ModelSessionHostPool, type ModelSessionHostPoolHost
 import { CuratedRuntimeAdmission } from './runtimes/curated-admission.js'
 import { RuntimeFactsRegistry, PROBE_TTL_MS, type RuntimeFactsHost } from './runtimes/facts-registry.js'
 import { assembleRuntimeLaunch } from './launch/assemble.js'
-import { resolveTrustedExecutable, sandboxReadRoots, trustedRuntimeReadRoots } from './runtimes/read-roots.js'
+import {
+  resolveTrustedExecutable,
+  sandboxReadRoots,
+  sandboxWriteRoots,
+  trustedRuntimeReadRoots
+} from './runtimes/read-roots.js'
 import { nodeExecArgvModuleEntries } from './runtimes/node-exec-argv.js'
 import { makeLogger, type Logger } from './log.js'
 import { CpClient } from './cp/client.js'
@@ -1842,8 +1847,9 @@ export class Daemon {
       autoCreate: true
     })
     this.cfg = cfg
-    // Fail the boot, not the first sandboxed turn, on a mistyped or missing operator read root.
+    // Fail the boot, not the first sandboxed turn, on a mistyped or missing operator read or write root.
     sandboxReadRoots(cfg.security.sandboxReadRoots)
+    sandboxWriteRoots(cfg.security.sandboxWriteRoots)
     configureWorkspaceGitOrigins(cfg.security.workspaceGitAllowedOrigins)
     // §24.4: an excluded origin is named at SPEC admission. All this knows is the operator list —
     // whether a spec names an instance of its own, which stays cloneable either way, is per-agent.
@@ -4447,6 +4453,7 @@ export class Daemon {
                 gitlabCredentials
               )
           : undefined,
+        runtimeWriteRoots: runInSandbox ? sandboxWriteRoots(this.cfg.security.sandboxWriteRoots) : undefined,
         // A session host with its own clones (§11) writes its session directory alone; the launch derives its Git grants from it.
         trustedWorkspaceWriteRoots: runInSandbox
           ? this.workspaces.trustedWorkspaceWriteRoots(agent, hostKeySessionKey(opts.hostKey))

--- a/packages/daemon/src/launch/assemble.ts
+++ b/packages/daemon/src/launch/assemble.ts
@@ -41,6 +41,8 @@ export interface AssembleRuntimeLaunchOptions {
   finalizeLaunchEnv?: (launchEnv: Record<string, string>) => void
   /** Daemon-owned code/socket/config carve-backs; a function receives the final launch env. */
   runtimeReadRoots?: string[] | ((launchEnv: Record<string, string>) => string[] | undefined)
+  /** Operator-declared `security.sandboxWriteRoots`, already normalized. */
+  runtimeWriteRoots?: string[]
   trustedWorkspaceWriteRoots?: string[]
   trustedPrimaryCheckout?: string
   sandboxMechanism?: SandboxMechanism
@@ -93,6 +95,7 @@ export function assembleRuntimeLaunch(opts: AssembleRuntimeLaunchOptions): Assem
     agentsRoot: opts.agentsRoot,
     explicitEnv: launchEnv,
     runtimeReadRoots,
+    runtimeWriteRoots: opts.runtimeWriteRoots,
     trustedWorkspaceWriteRoots: opts.trustedWorkspaceWriteRoots,
     trustedPrimaryCheckout: opts.trustedPrimaryCheckout,
     sandboxMechanism: opts.sandboxMechanism,

--- a/packages/daemon/src/launch/compose.ts
+++ b/packages/daemon/src/launch/compose.ts
@@ -158,6 +158,8 @@ export function composeRuntimeLaunch(opts: {
   /** Additional daemon-owned code/socket/config paths required by trusted
    * descendants such as the AgentConnect MCP bridge. */
   runtimeReadRoots?: string[]
+  /** Operator-declared `security.sandboxWriteRoots`, already normalized. */
+  runtimeWriteRoots?: string[]
   trustedWorkspaceWriteRoots?: string[]
   trustedPrimaryCheckout?: string
   sandboxMechanism?: SandboxMechanism
@@ -202,6 +204,7 @@ export function composeRuntimeLaunch(opts: {
     agentsRoot: opts.agentsRoot,
     trustedRuntimeReadRoots: [...(sandboxAccess?.readRoots ?? []), ...(opts.runtimeReadRoots ?? [])],
     trustedWorkspaceWriteRoots: opts.trustedWorkspaceWriteRoots,
+    trustedOperatorWriteRoots: opts.runtimeWriteRoots,
     trustedPrimaryCheckout: opts.trustedPrimaryCheckout,
     sandboxMechanism: opts.sandboxMechanism,
     mcpSocketPath: opts.mcpSocketPath,

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -243,6 +243,8 @@ export function prepareRuntimeLaunch(opts: {
    * Every entry is revalidated as a strict descendant of scopeDir. */
   trustedWorkspaceWriteRoots?: string[]
   trustedPrimaryCheckout?: string
+  /** Operator-declared host dirs (`security.sandboxWriteRoots`) reopened writable: a shared package store, never the daemon's own. */
+  trustedOperatorWriteRoots?: string[]
   /** Test seam. Shared login remains Linux-only with the sandbox rollout. */
   credentialPlatform?: NodeJS.Platform
   sandboxMechanism?: SandboxMechanism
@@ -452,6 +454,10 @@ export function prepareRuntimeLaunch(opts: {
       return trusted
     })
   )
+  // An operator write root follows the exception rule: it may sit below the hidden host HOME (a pnpm store does), never equal or contain HOME, daemon state, an agent root, or shared temp.
+  const operatorWriteRoots = compactReadRoots(
+    (opts.trustedOperatorWriteRoots ?? []).map((path) => validateException(path, 'security.sandboxWriteRoots entry'))
+  )
   const agentRoot = safeRoot(opts.scopeDir, 'agent root')
   const trustedWorkspaceWriteRoots = compactReadRoots(
     (opts.trustedWorkspaceWriteRoots ?? []).map((path) => {
@@ -521,6 +527,7 @@ export function prepareRuntimeLaunch(opts: {
       ...credentialWritableRoots,
       ...trustedWorkspaceWriteRoots,
       ...packageCacheWriteRoots,
+      ...operatorWriteRoots,
       ...gitMetadataWriteRoots,
       // Inside the agent dir like every other writable root, so the agent-dir rule needs no exemption for it.
       ...(sandboxTempDir === undefined ? [] : [sandboxTempDir])

--- a/packages/daemon/src/launch/prepare.ts
+++ b/packages/daemon/src/launch/prepare.ts
@@ -195,6 +195,8 @@ export interface PreparedRuntimeLaunch {
     /** Highest-precedence Claude settings that keep project/local settings from
      * redirecting the trusted parent to an attacker-selected credential profile. */
     claudeProtectedSettings?: ClaudeProtectedSettings
+    /** Operator-declared `security.sandboxWriteRoots`, canonical: the runtime-native tool sandboxes reopen them too. */
+    sharedWriteRoots?: string[]
   }
 }
 
@@ -577,6 +579,7 @@ export function prepareRuntimeLaunch(opts: {
         ? { writableGitMetadataRoots }
         : { sessionGitMetadataRoots: writableGitMetadataRoots }),
       ...(sessionHomeRoot !== undefined && outerWritable(sessionHomeRoot) ? { sessionHomeRoot } : {}),
+      sharedWriteRoots: operatorWriteRoots.filter(outerWritable),
       allowModelToolUnixSockets: opts.allowModelToolUnixSockets === true,
       disableUnifiedExec: true
     })
@@ -595,7 +598,8 @@ export function prepareRuntimeLaunch(opts: {
       allowReadRoots: boundary.allowRead,
       protectedCredentialRoots,
       ...(opts.allowModelToolUnixSockets ? { allowModelToolUnixSockets: true } : {}),
-      ...(protectedClaudeSettings ? { claudeProtectedSettings: protectedClaudeSettings } : {})
+      ...(protectedClaudeSettings ? { claudeProtectedSettings: protectedClaudeSettings } : {}),
+      ...(operatorWriteRoots.length > 0 ? { sharedWriteRoots: operatorWriteRoots } : {})
     }
   }
 }

--- a/packages/daemon/src/runtime-defs/claude-runtime.ts
+++ b/packages/daemon/src/runtime-defs/claude-runtime.ts
@@ -114,6 +114,8 @@ export interface ClaudeInnerSandboxSettings {
     allowAllUnixSockets: boolean
   }
   filesystem: {
+    /** Operator-declared `security.sandboxWriteRoots`; absent when there are none, so the policy stays byte-identical. */
+    allowWrite?: string[]
     denyRead: string[]
     denyWrite: string[]
   }
@@ -129,9 +131,11 @@ export interface ClaudeInnerSandboxSettings {
  * while the parent Claude process retains shared-login access. */
 export function claudeInnerSandboxSettings(
   protectedCredentialRoots: readonly string[],
-  allowAllUnixSockets = false
+  allowAllUnixSockets = false,
+  sharedWriteRoots: readonly string[] = []
 ): ClaudeInnerSandboxSettings {
   const roots = [...new Set(protectedCredentialRoots)]
+  const allowWrite = [...new Set(sharedWriteRoots)]
   return {
     enabled: true,
     failIfUnavailable: true,
@@ -144,6 +148,7 @@ export function claudeInnerSandboxSettings(
       allowAllUnixSockets
     },
     filesystem: {
+      ...(allowWrite.length > 0 ? { allowWrite } : {}),
       denyRead: roots,
       denyWrite: roots
     },

--- a/packages/daemon/src/runtimes/read-roots.ts
+++ b/packages/daemon/src/runtimes/read-roots.ts
@@ -52,6 +52,11 @@ export function sandboxReadRoots(paths: readonly string[], env: NodeJS.ProcessEn
   return paths.map((path) => existingRoot(path, env, 'security.sandboxReadRoots entry'))
 }
 
+/** `security.sandboxWriteRoots`, normalized exactly like the read roots; the launch decides whether each may be reopened writable. */
+export function sandboxWriteRoots(paths: readonly string[], env: NodeJS.ProcessEnv = process.env): string[] {
+  return paths.map((path) => existingRoot(path, env, 'security.sandboxWriteRoots entry'))
+}
+
 /** Resolve the existing prefix too, so a missing socket/file below a symlink is
  * still expressed against the path the kernel will see later. */
 function canonicalPath(path: string, env: NodeJS.ProcessEnv): string {

--- a/packages/daemon/test/acp-config.test.ts
+++ b/packages/daemon/test/acp-config.test.ts
@@ -339,6 +339,11 @@ describe('claudeSessionMeta', () => {
       })
     )
     expect(claudeSessionMeta(undefined, true)).toEqual(cc({ thinking: THINKING }))
+    // An operator-declared shared store is reopened for model-authored Bash too; the credential roots stay denied.
+    expect(
+      claudeSessionMeta(undefined, true, undefined, undefined, [credentialRoot], undefined, false, [], ['/host/store'])
+        ?.claudeCode.options.sandbox?.filesystem
+    ).toEqual({ allowWrite: ['/host/store'], denyRead: [credentialRoot], denyWrite: [credentialRoot] })
   })
 
   it('returns undefined off a Claude runtime (the _meta is claude-acp-specific)', () => {

--- a/packages/daemon/test/chat.test.ts
+++ b/packages/daemon/test/chat.test.ts
@@ -286,6 +286,25 @@ describe('runChat', () => {
     expect(hostFactory).not.toHaveBeenCalled()
   })
 
+  it('rejects a missing security.sandboxWriteRoots entry before creating any host', async () => {
+    const files = scaffold()
+    writeFileSync(
+      files.configPath,
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        runtimes: { fake: { command: process.execPath, args: [fakeAgent], env: [] } },
+        security: { sandboxWriteRoots: [join(files.root, 'no-such-store')] }
+      })
+    )
+    const hostFactory = vi.fn()
+
+    await expect(runChat({ ...files, message: 'hi', out: capture().stream, hostFactory })).rejects.toThrow(
+      /security\.sandboxWriteRoots entry does not exist/
+    )
+    expect(hostFactory).not.toHaveBeenCalled()
+  })
+
   it('does not create the real host when curated ACP admission fails', async () => {
     const files = curatedScaffold('maki')
     const hostFactory = vi.fn()

--- a/packages/daemon/test/codex-permission-profiles.test.ts
+++ b/packages/daemon/test/codex-permission-profiles.test.ts
@@ -120,6 +120,29 @@ describe.skipIf(process.platform === 'win32')('Codex permission profile launch c
     ).not.toContain('/agent/sessions')
   })
 
+  it('opens an operator-declared shared store for writes in the agent and full-access profiles, never in read-only', () => {
+    const store = '/host/.local/share/pnpm/store'
+    const config = codexPermissionProfileConfig({ protectedRoots: ['/host/.codex'], sharedWriteRoots: [store] })!
+
+    const agent = config.configOverrides.find((value) =>
+      value.startsWith('permissions.agentconnect-protected-workspace.filesystem=')
+    )!
+    expect(agent).toContain(`"${store}" = "write"`)
+    expect(agent).toContain('"/host/.codex" = "deny"')
+    expect(
+      config.configOverrides.find((value) =>
+        value.startsWith('permissions.agentconnect-protected-full-access.filesystem=')
+      )
+    ).toContain(`"${store}" = "write"`)
+    expect(
+      config.configOverrides.find((value) =>
+        value.startsWith('permissions.agentconnect-protected-read-only.filesystem=')
+      )
+    ).not.toContain(store)
+    // The store alone is a policy: nothing else needs to be protected for it to be emitted.
+    expect(codexPermissionProfileConfig({ protectedRoots: [], sharedWriteRoots: [store] })).toBeDefined()
+  })
+
   // §11: the per-session HOME is a SIBLING of the cwd, so `:workspace` never reaches it and pnpm/corepack cannot write their caches.
   it('opens a confined session HOME for writes and denies its .codex whole', () => {
     const home = '/agent/sessions/session-1/home'

--- a/packages/daemon/test/daemon-smoke.test.ts
+++ b/packages/daemon/test/daemon-smoke.test.ts
@@ -108,6 +108,22 @@ describe('Daemon (no Slack, injected ACP host)', () => {
     ).rejects.toThrow(/security\.sandboxReadRoots entry does not exist/)
   })
 
+  it('refuses daemon startup when security.sandboxWriteRoots names a directory that does not exist', async () => {
+    const root = scaffold()
+    writeFileSync(
+      join(root, 'config.json'),
+      JSON.stringify({
+        version: 1,
+        controlPlane: { enabled: false },
+        security: { sandboxWriteRoots: [join(root, 'no-such-store')] }
+      })
+    )
+
+    await expect(
+      new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: null }).start()
+    ).rejects.toThrow(/security\.sandboxWriteRoots entry does not exist/)
+  })
+
   it('does not force the skill sandbox or fail closed when the host has no sandbox mechanism (#36)', async () => {
     const root = scaffold()
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), root, sandboxMechanism: null })

--- a/packages/daemon/test/read-roots.test.ts
+++ b/packages/daemon/test/read-roots.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { resolveTrustedExecutable, sandboxReadRoots, trustedRuntimeReadRoots } from '../src/runtimes/read-roots.js'
+import {
+  resolveTrustedExecutable,
+  sandboxReadRoots,
+  sandboxWriteRoots,
+  trustedRuntimeReadRoots
+} from '../src/runtimes/read-roots.js'
 
 const temporaryRoots: string[] = []
 
@@ -70,6 +75,22 @@ describe('trusted runtime read roots', () => {
     ).toThrow(/security\.sandboxReadRoots entry does not exist/)
     expect(() => sandboxReadRoots(['relative/toolchain'], { HOME: tmpdir() })).toThrow(
       /security\.sandboxReadRoots entry must be absolute/
+    )
+  })
+
+  it('normalizes security.sandboxWriteRoots like the read roots, and rejects a missing or relative one', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ac-daemon-write-roots-'))
+    temporaryRoots.push(root)
+    const home = join(root, 'host-home')
+    const store = join(home, '.local', 'share', 'pnpm', 'store')
+    mkdirSync(store, { recursive: true })
+
+    expect(sandboxWriteRoots(['~/.local/share/pnpm/store'], { HOME: home })).toEqual([realpathSync(store)])
+    expect(() => sandboxWriteRoots([join(root, 'no-such-store')], { HOME: home })).toThrow(
+      /security\.sandboxWriteRoots entry does not exist/
+    )
+    expect(() => sandboxWriteRoots(['relative/store'], { HOME: home })).toThrow(
+      /security\.sandboxWriteRoots entry must be absolute/
     )
   })
 

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -379,6 +379,9 @@ describe('prepareRuntimeLaunch', () => {
     const launch = prepareRuntimeLaunch({ ...base, trustedOperatorWriteRoots: [store] })
     expect(launch.sandbox!.writable).toContain(realpathSync(store))
     expect(launch.sandbox!.allowReadRoots).toContain(realpathSync(store))
+    // The runtime-native tool sandboxes must reopen it too, or the install this exists for still fails inside them.
+    expect(launch.sandbox!.sharedWriteRoots).toEqual([realpathSync(store)])
+    expect(prepareRuntimeLaunch(base).sandbox!.sharedWriteRoots).toBeUndefined()
     // The host HOME stays hidden around it: only the store is reopened.
     expect(coveredBy(launch.sandbox!.denyReadRoots, realpathSync(hostHome))).toBe(true)
 
@@ -489,6 +492,8 @@ describe('prepareRuntimeLaunch', () => {
 
   it('grants a confined session its own clones exactly, and never the primary checkout .git', () => {
     const { scopeDir, hostHome, key, sessionDir, cwd, primaryGit, cloneGit, secondaryGit } = sessionCloneFixture()
+    const store = join(hostHome, '.local', 'share', 'pnpm', 'store')
+    mkdirSync(store, { recursive: true })
 
     const launch = prepareRuntimeLaunch({
       runtimeId: 'codex-acp',
@@ -502,6 +507,7 @@ describe('prepareRuntimeLaunch', () => {
       credentialPlatform: 'linux',
       // What the daemon hands a session host: the session directory alone (workspace-manager.ts).
       trustedWorkspaceWriteRoots: [sessionDir],
+      trustedOperatorWriteRoots: [store],
       trustedPrimaryCheckout: join(scopeDir, 'workspace'),
       hostEnv: { HOME: hostHome, PATH: '/usr/bin' }
     })
@@ -526,6 +532,9 @@ describe('prepareRuntimeLaunch', () => {
     }
     expect(table).not.toContain('worktrees')
     expect(table).not.toContain(realpathSync(primaryGit))
+    // An operator-declared shared store is reopened at both layers: the outer boundary and the inner Codex profile.
+    expect(coveredBy(policy.filesystem.allowWrite, realpathSync(store))).toBe(true)
+    expect(table).toContain(`"${realpathSync(store)}" = "write"`)
   })
 
   // §11: the session's HOME lives under its leaf, so runtime state, temp and package caches are the session's alone and go with it.

--- a/packages/daemon/test/runtime-launch.test.ts
+++ b/packages/daemon/test/runtime-launch.test.ts
@@ -361,6 +361,38 @@ describe('prepareRuntimeLaunch', () => {
     expect(coveredBy(agent.sandbox!.writable, join(hostHome, '.npm'))).toBe(false)
   })
 
+  it('reopens an operator write root below the hidden host HOME writable, but never HOME itself', () => {
+    const { scopeDir, cwd, hostHome } = fixture()
+    const store = join(hostHome, '.local', 'share', 'pnpm', 'store')
+    mkdirSync(store, { recursive: true })
+    const base = {
+      runtimeId: 'dsh-acp',
+      runtime: { command: process.execPath, args: [], env: [] } as RuntimeDef,
+      scopeDir,
+      cwd,
+      runInSandbox: true,
+      daemonRoot: dirname(scopeDir),
+      sandboxMechanism: 'bwrap' as const,
+      hostEnv: { HOME: hostHome, PATH: dirname(process.execPath) }
+    }
+
+    const launch = prepareRuntimeLaunch({ ...base, trustedOperatorWriteRoots: [store] })
+    expect(launch.sandbox!.writable).toContain(realpathSync(store))
+    expect(launch.sandbox!.allowReadRoots).toContain(realpathSync(store))
+    // The host HOME stays hidden around it: only the store is reopened.
+    expect(coveredBy(launch.sandbox!.denyReadRoots, realpathSync(hostHome))).toBe(true)
+
+    // The same rule as every other exception: a root that IS a protected boundary reopens it wholesale.
+    expect(() => prepareRuntimeLaunch({ ...base, trustedOperatorWriteRoots: [hostHome] })).toThrow(
+      /security\.sandboxWriteRoots entry .* would reopen protected path/
+    )
+    expect(() => prepareRuntimeLaunch({ ...base, trustedOperatorWriteRoots: [dirname(scopeDir)] })).toThrow(
+      /would reopen protected path/
+    )
+    // Without the declaration nothing below the host HOME is writable.
+    expect(coveredBy(prepareRuntimeLaunch(base).sandbox!.writable, store)).toBe(false)
+  })
+
   // multi-repository-workspaces.md decision 8: the secondary roots live under the agent dir, which
   // the boundary denies wholesale — without this carve-back a sandboxed runtime cannot see them.
   it('carves back the secondary-roots parent and every existing secondary .git for Codex', () => {


### PR DESCRIPTION
## Why

A confined session installs its dependencies into its own private HOME, so every new review session downloads the whole package store again (about 3 GB of pnpm store per session on the reference host, roughly 90 s of a first review round inside the sandbox). The obvious zero-code route, exposing the host's store through `security.sandboxReadRoots`, does not work: pnpm 11 opens the store's `index.db` read-write on every install and fails on a read-only store, and corepack refuses a read-only `COREPACK_HOME`. A writable install of the same tree from a warm store takes about 10 s.

## What

`security.sandboxWriteRoots`, the writable twin of `security.sandboxReadRoots`:

- Normalized exactly like the read roots (`~/` against the host HOME, must exist, realpath'd) and validated at boot on both launch paths, the daemon and `agentconnect-daemon chat`, so a mistyped entry fails the process, not the first sandboxed turn.
- Reopened under the same exception rule as every other carve-back in `prepareRuntimeLaunch`: an entry may sit below the hidden host HOME (a pnpm store does), and is refused when it equals or contains HOME, daemon state, an agent root, or shared temp.
- The operator points the runtime at the shared store through the agent's env (`npm_config_store_dir`, `COREPACK_HOME`); the daemon adds no env of its own, so nothing package-manager-specific enters the daemon.

This is a deliberate hole in per-session isolation: whatever one session's install writes into the shared store, the next session reads. The schema comment and the design doc say so; default is empty.

## Tests

- `read-roots.test.ts`: `~` expansion, missing and relative entries rejected with the `security.sandboxWriteRoots` label.
- `runtime-launch.test.ts`: a store below the host HOME lands in the sandbox's writable and readable sets while HOME itself stays denied; HOME or the daemon root as an entry is refused; nothing below HOME is writable without the declaration.
- `daemon-smoke.test.ts` / `chat.test.ts`: boot refusal on a missing entry, before any host is created.

Daemon typecheck, ESLint and Prettier pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
