### PR TITLE
feat(console): webchat answers multi-field elicitation forms

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -14,7 +14,8 @@ import type {
   AgentApprovalRoute,
   AgentApprovalRouted,
   AgentPermissionDecision,
-  ApprovalRouteTarget
+  ApprovalRouteTarget,
+  ElicitField
 } from '@agentconnect.md/protocol'
 import type { Clock } from '@agentconnect.md/connection'
 import type { Logger } from '../log.js'
@@ -31,6 +32,11 @@ import {
   buildPermissionCard,
   buildPermissionResolvedCard,
   clampTo,
+  elicitFieldLabel,
+  elicitForm,
+  elicitFormAccepts,
+  elicitFormContent,
+  elicitRequiredProps,
   elicitTarget,
   multiSelectAccepts,
   numberAccepts,
@@ -121,6 +127,78 @@ function answerFitsKind(kind: ElicitKind, value: string | string[] | number): bo
   return typeof value === 'string'
 }
 
+/** A multi-field form card's answer: one value per answered field, keyed by property name. */
+type ElicitFormAnswer = Record<string, string | number | string[]>
+
+/** The answer shapes a card settles with — a record only ever answers a FORM card. */
+type ElicitAnswer = string | string[] | number | ElicitFormAnswer | null
+
+function isFormAnswer(value: ElicitAnswer): value is ElicitFormAnswer {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+/** How a settled FORM card names its answer: every answered field as `label: answer`, in the
+ *  card's own words, clamped as ONE line. Naming the fields is what keeps the thread of what
+ *  was agreed; the clamp is what stops a long form pasting a wall of values into a transcript. */
+function formAnswerLabel(
+  params: CreateElicitationRequest,
+  form: readonly ElicitTarget[],
+  answer: ElicitFormAnswer
+): string {
+  const parts: string[] = []
+  for (const t of form) {
+    const value = answer[t.propName]
+    if (value !== undefined) parts.push(`${elicitFieldLabel(params, t.propName)}: ${chosenLabel(t, value)}`)
+  }
+  return clampTo(parts.join(' · '), 200)
+}
+
+/** The card-side descriptors of ONE field — the wire's own shape, minus what only a form
+ *  entry names (property, label, kind, requiredness). */
+type ElicitCardDescriptors = Pick<ElicitField, 'options' | 'multi' | 'text' | 'number' | 'defaultValue'>
+
+/** The per-kind descriptors a webchat elicitation card carries for one field: its options plus
+ *  whichever constraint block its kind brings. Shared by the single-field card and each entry
+ *  of a form, so a one-field form's payload stays exactly the single-field card's. */
+function elicitCardDescriptors(t: ElicitTarget): ElicitCardDescriptors {
+  return {
+    options: t.options,
+    // Present only for a multi-select: it is what tells the card to offer toggles and a
+    // confirm rather than one-tap buttons, and the bounds the confirm enforces.
+    ...(t.kind === 'multi-enum'
+      ? {
+          multi: {
+            ...(t.minItems !== undefined ? { minItems: t.minItems } : {}),
+            ...(t.maxItems !== undefined ? { maxItems: t.maxItems } : {})
+          }
+        }
+      : {}),
+    // Present only for a typed field, and likewise what makes the card an input rather than a
+    // row of options. The constraints ride along so the control can refuse an answer the
+    // daemon would reject anyway.
+    ...(t.kind === 'text'
+      ? {
+          text: {
+            ...(t.minLength !== undefined ? { minLength: t.minLength } : {}),
+            ...(t.maxLength !== undefined ? { maxLength: t.maxLength } : {}),
+            ...(t.pattern !== undefined ? { pattern: t.pattern } : {}),
+            ...(t.format !== undefined ? { format: t.format } : {})
+          }
+        }
+      : {}),
+    ...(t.kind === 'number'
+      ? {
+          number: {
+            ...(t.integer ? { integer: true } : {}),
+            ...(t.minimum !== undefined ? { minimum: t.minimum } : {}),
+            ...(t.maximum !== undefined ? { maximum: t.maximum } : {})
+          }
+        }
+      : {}),
+    ...(t.defaultValue !== undefined ? { defaultValue: t.defaultValue } : {})
+  }
+}
+
 /** One outstanding `elicitation/create` awaiting a human answer. */
 type PendingElicit = PendingElicitSurface & {
   owner: HostKey
@@ -129,6 +207,9 @@ type PendingElicit = PendingElicitSurface & {
   params: CreateElicitationRequest
   propName: string
   kind: ElicitKind
+  /** Set only for a MULTI-field webchat form card — the fields it rendered, in schema order.
+   *  Absent ⇒ the single-field card, answered by a scalar or a list as it always was. */
+  form?: ElicitTarget[]
   approval: boolean
   resolve: (res: CreateElicitationResponse) => void
 }
@@ -1347,8 +1428,11 @@ export class PermissionCoordinator {
   }
 
   /** Webchat's peer of the Slack elicitation card: stream the card as an in-band event and
-   *  park the same resolver. Returns `undefined` (⇒ decline) when the form has no field this
-   *  surface can render — the identical verdict Slack reaches, via the same `elicitTarget`. */
+   *  park the same resolver. Takes the WHOLE form (`elicitForm`) rather than Slack's one field,
+   *  so a multi-field ask renders one control per field and answers with a record; a one-field
+   *  form takes the single-field path and its payload is unchanged. Returns `undefined`
+   *  (⇒ decline) when the surface cannot render the form — including a `required` property it
+   *  has no control for, which is the same verdict Slack reaches by the same rule. */
   private async awaitWebchatElicitation(
     agentId: string,
     sessionId: string,
@@ -1356,8 +1440,10 @@ export class PermissionCoordinator {
     p: Pending,
     wc: NonNullable<Pending['webchat']>
   ): Promise<CreateElicitationResponse | undefined> {
-    const target = elicitTarget(params, WEBCHAT_ELICIT_KINDS)
-    if (!target) return undefined
+    const form = elicitForm(params, WEBCHAT_ELICIT_KINDS)
+    if (!form) return undefined
+    const target = form[0]!
+    const required = new Set(elicitRequiredProps(params))
     const requestId = `elicit-${++this.elicitSeq}`
     const message = (params as { message?: string }).message?.trim() || 'The agent needs your input'
     let resolveResult!: (res: CreateElicitationResponse) => void
@@ -1369,6 +1455,7 @@ export class PermissionCoordinator {
       params,
       propName: target.propName,
       kind: target.kind,
+      ...(form.length > 1 ? { form } : {}),
       approval: false,
       surface: 'webchat',
       wc,
@@ -1384,40 +1471,21 @@ export class PermissionCoordinator {
           kind: 'elicitation',
           requestId,
           message,
-          options: target.options,
-          // Present only for a multi-select: it is what tells the card to offer toggles and a
-          // confirm rather than one-tap buttons, and the bounds the confirm enforces.
-          ...(target.kind === 'multi-enum'
+          // A multi-field form carries its fields as a LIST and NONE of the single-field
+          // descriptors: an old reader then gets an optionless card it can only dismiss,
+          // rather than one it could half-fill with an answer the daemon would refuse.
+          ...(form.length > 1
             ? {
-                multi: {
-                  ...(target.minItems !== undefined ? { minItems: target.minItems } : {}),
-                  ...(target.maxItems !== undefined ? { maxItems: target.maxItems } : {})
-                }
+                options: [],
+                fields: form.map((t) => ({
+                  propName: t.propName,
+                  label: elicitFieldLabel(params, t.propName),
+                  kind: t.kind,
+                  ...(required.has(t.propName) ? { required: true } : {}),
+                  ...elicitCardDescriptors(t)
+                }))
               }
-            : {}),
-          // Present only for a typed field, and likewise what makes the card an input rather
-          // than a row of options. The constraints ride along so the control can refuse an
-          // answer the daemon would reject anyway.
-          ...(target.kind === 'text'
-            ? {
-                text: {
-                  ...(target.minLength !== undefined ? { minLength: target.minLength } : {}),
-                  ...(target.maxLength !== undefined ? { maxLength: target.maxLength } : {}),
-                  ...(target.pattern !== undefined ? { pattern: target.pattern } : {}),
-                  ...(target.format !== undefined ? { format: target.format } : {})
-                }
-              }
-            : {}),
-          ...(target.kind === 'number'
-            ? {
-                number: {
-                  ...(target.integer ? { integer: true } : {}),
-                  ...(target.minimum !== undefined ? { minimum: target.minimum } : {}),
-                  ...(target.maximum !== undefined ? { maximum: target.maximum } : {})
-                }
-              }
-            : {}),
-          ...(target.defaultValue !== undefined ? { defaultValue: target.defaultValue } : {})
+            : elicitCardDescriptors(target))
         }
       })
     } catch (err) {
@@ -1453,11 +1521,12 @@ export class PermissionCoordinator {
 
   /** A tapped elicitation-card button (SlackDeps.onElicitChoice): resolve the pending ACP
    *  request — `accept` with the chosen value (a LIST of them for a multi-select, a real number
-   *  for a numeric field, under the field name), or `decline` for the Dismiss button
-   *  (value === null) — and edit the card in place. No-op if already gone. */
+   *  for a numeric field, a RECORD of value-per-field for a form, under the field name(s)), or
+   *  `decline` for the Dismiss button (value === null) — and edit the card in place. No-op if
+   *  already gone. */
   async handleElicitChoice(a: {
     requestId: string
-    value: string | string[] | number | null
+    value: ElicitAnswer
     actor?: InteractionActor
     /** Set only by the webchat ingress: the answering browser's conversation. It confines
      *  the answer to a card THIS conversation was shown — a webchat client can neither
@@ -1468,15 +1537,27 @@ export class PermissionCoordinator {
     // A DM elicitation card's request lives on the editor path (§2/§6.4).
     const editor = this.pendingEditorPermissions.get(a.requestId)
     if (editor?.kind === 'elicitation' && editor.notify) {
-      // A DM card is a Slack button row: never answered by a list, a number, or a browser.
-      if (a.webchatConversationId !== undefined || Array.isArray(a.value) || typeof a.value === 'number') return
+      // A DM card is a Slack button row: never answered by a list, a number, a form record,
+      // or a browser.
+      if (
+        a.webchatConversationId !== undefined ||
+        Array.isArray(a.value) ||
+        typeof a.value === 'number' ||
+        isFormAnswer(a.value)
+      )
+        return
       return await this.handleDmElicitChoice(a.requestId, editor, a.value, a.actor)
     }
     const rec = this.pendingElicits.get(a.requestId)
     if (!rec) return
+    // A FORM card is answered by a record and nothing else, and every other card by a scalar
+    // or a list — re-derived from the card's own params, exactly as `target` is below.
+    const form = rec.form ? elicitForm(rec.params, surfaceKinds(rec)) : null
+    if (rec.form && !form) return
+    if (a.value !== null && isFormAnswer(a.value) !== !!form) return
     // Each kind takes one shape of answer and no other: a list for a multi-select, a number
     // for a numeric field, a string for the rest. Dismiss (null) settles any of them.
-    if (a.value !== null && !answerFitsKind(rec.kind, a.value)) return
+    if (a.value !== null && !isFormAnswer(a.value) && !answerFitsKind(rec.kind, a.value)) return
     const target = elicitTarget(rec.params, surfaceKinds(rec))
     if (a.webchatConversationId !== undefined) {
       if (rec.surface !== 'webchat' || rec.wc.conversationId !== a.webchatConversationId) return
@@ -1484,16 +1565,20 @@ export class PermissionCoordinator {
       // into the agent's content, so it is dropped and the card stays live. A multi-select adds
       // no repeats and a count its bounds allow; a typed field, the schema constraints the
       // control was shown — a browser frame is never what makes an answer valid.
+      // A form's record answers exactly the fields the card rendered, each value valid for its
+      // own field: one bad or unexpected field refuses the whole answer, card still live.
       const offered =
         a.value === null ||
-        (!!target &&
-          (Array.isArray(a.value)
-            ? multiSelectAccepts(target, a.value)
-            : typeof a.value === 'number'
-              ? numberAccepts(target, a.value)
-              : target.kind === 'text'
-                ? textAccepts(target, a.value)
-                : target.options.some((o) => o.value === a.value)))
+        (isFormAnswer(a.value)
+          ? !!form && elicitFormAccepts(form, elicitRequiredProps(rec.params), a.value)
+          : !!target &&
+            (Array.isArray(a.value)
+              ? multiSelectAccepts(target, a.value)
+              : typeof a.value === 'number'
+                ? numberAccepts(target, a.value)
+                : target.kind === 'text'
+                  ? textAccepts(target, a.value)
+                  : target.options.some((o) => o.value === a.value)))
       if (!offered) return
       // A card settles only from its own surface: both share one `elicit-<n>` counter, so
       // without this a Slack tap could answer a live webchat card.
@@ -1514,18 +1599,28 @@ export class PermissionCoordinator {
     }
     let res: CreateElicitationResponse
     let decision: string
+    // What the settled card says the answer WAS — the webchat label, and the Slack decision's tail.
+    let answered: string | undefined
     if (a.value === null) {
       res = { action: 'decline' }
       decision = ':no_entry_sign: Dismissed'
+    } else if (isFormAnswer(a.value)) {
+      if (!form) return
+      // A form's accepted content is the whole record: every answered field under its own name.
+      res = { action: 'accept', content: elicitFormContent(form, a.value) }
+      answered = formAnswerLabel(rec.params, form, a.value)
+      decision = `:white_check_mark: ${answered}`
     } else if (Array.isArray(a.value)) {
       // The array property's accepted content is the chosen list itself.
       res = { action: 'accept', content: { [rec.propName]: a.value } }
-      decision = `:white_check_mark: ${chosenLabel(target, a.value)}`
+      answered = chosenLabel(target, a.value)
+      decision = `:white_check_mark: ${answered}`
     } else {
       // The accepted content carries the schema's own type: a boolean for a boolean field and a
       // real number for a numeric one, never the string the wire happened to spell it with.
       const value = rec.kind === 'boolean' ? a.value === 'true' : a.value
       res = { action: 'accept', content: { [rec.propName]: value } }
+      answered = chosenLabel(target, a.value)
       decision = `:white_check_mark: ${rec.kind === 'boolean' ? (value ? 'Yes' : 'No') : String(a.value)}`
     }
     if (rec.approval) {
@@ -1547,8 +1642,7 @@ export class PermissionCoordinator {
     this.pendingElicits.delete(a.requestId)
     this.syncApprovalActivity(rec.owner, rec.sessionId, { id: a.requestId, allowed: a.value !== null })
     if (rec.surface === 'webchat') {
-      const label = a.value === null ? undefined : chosenLabel(target, a.value)
-      this.emitWebchatElicitResolved(rec, a.requestId, a.value === null ? 'dismissed' : 'accepted', label)
+      this.emitWebchatElicitResolved(rec, a.requestId, a.value === null ? 'dismissed' : 'accepted', answered)
     } else if (rec.ts)
       void rec.conn
         .updateBlocks(rec.channel, rec.ts, buildElicitationResolvedCard(rec.params, decision), 'Input received', true)

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -150,7 +150,9 @@ function formAnswerLabel(
     const value = answer[t.propName]
     if (value !== undefined) parts.push(`${elicitFieldLabel(params, t.propName)}: ${chosenLabel(t, value)}`)
   }
-  return clampTo(parts.join(' · '), 200)
+  // An all-optional form left alone is still an answer — settling it as nothing would read
+  // as a card that never resolved, the same reason a `minItems: 0` selection says so too.
+  return parts.length ? clampTo(parts.join(' · '), 200) : 'Nothing filled in'
 }
 
 /** The card-side descriptors of ONE field — the wire's own shape, minus what only a form

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -2,6 +2,7 @@ import type { CreateElicitationRequest, RequestPermissionRequest, SessionUpdate 
 import {
   ELICIT_ACTION_PREFIX,
   ELICIT_DISMISS_ACTION,
+  ELICIT_FORM_FIELD_CAP,
   PERMISSION_ACTION_PREFIX,
   SLACK_STATUS_ACTION,
   encodePermValue,
@@ -832,29 +833,41 @@ function withDefault(target: ElicitTarget, raw: unknown): ElicitTarget {
   return ok ? { ...target, defaultValue: raw as ElicitTarget['defaultValue'] } : target
 }
 
+/** The form's `required` property names, as the schema spells them — anything that is not a
+ *  string is dropped, since it cannot name a property this scan produced. */
+export function elicitRequiredProps(params: CreateElicitationRequest): string[] {
+  const req = (params as { requestedSchema?: { required?: unknown } }).requestedSchema?.required
+  return Array.isArray(req) ? req.filter((r): r is string => typeof r === 'string') : []
+}
+
+/** How a form card names one field: the schema's own `title` when it has one, else the property
+ *  name. A control stacked with others and labelled by neither is not answerable. */
+export function elicitFieldLabel(params: CreateElicitationRequest, propName: string): string {
+  const props = (params as { requestedSchema?: { properties?: Record<string, Record<string, unknown>> } })
+    .requestedSchema?.properties
+  const title = props?.[propName]?.title
+  return clampTo((typeof title === 'string' && title.trim()) || propName, 75)
+}
+
 /**
- * Resolve the single form field an elicitation card renders: the FIRST string-enum (`oneOf`
+ * Every property of the form this surface can render, in schema order: string-enum (`oneOf`
  * titled options or bare `enum`), boolean, string-array multi-select (`items.enum` or
- * `items.anyOf`), free-text string or number/integer property the CALLING SURFACE declares it
- * can render. Returns null for URL-mode, an empty/absent schema, a form whose fields this
- * surface can't render, or one that requires a property other than the rendered target — the
- * daemon then declines rather than accepting a partial answer. Pure, and shared by every
- * surface so the option values and their interpretation can't drift.
+ * `items.anyOf`), free-text string, and number/integer — each only where the CALLING SURFACE
+ * declares that kind. At most one target per property, since a property's `type` picks its
+ * kind. The shared scan behind {@link elicitTarget} and {@link elicitForm}, so the two can
+ * never disagree about what is renderable. Empty for URL-mode and an empty/absent schema.
  */
-export function elicitTarget(params: CreateElicitationRequest, renderable: ElicitSurfaceKinds): ElicitTarget | null {
+function elicitCandidates(params: CreateElicitationRequest, renderable: ElicitSurfaceKinds): ElicitTarget[] {
   const p = params as {
     mode?: string
-    requestedSchema?: { properties?: Record<string, Record<string, unknown>>; required?: unknown }
+    requestedSchema?: { properties?: Record<string, Record<string, unknown>> }
   }
-  if (p.mode !== 'form') return null
-  const props = p.requestedSchema?.properties ?? {}
-  const required = Array.isArray(p.requestedSchema?.required) ? (p.requestedSchema.required as unknown[]) : []
-  // A required field we can't render is unanswerable: accepting without it would assert a lie.
-  // A candidate that fails this does NOT end the scan — a later property may be the sole
-  // required one, and returning here would decline a form this surface can in fact answer.
-  const answerable = (t: ElicitTarget | null) => (t && required.every((r) => r === t.propName) ? t : null)
-  for (const [name, prop] of Object.entries(props)) {
-    const seeded = (t: ElicitTarget | null) => (t ? withDefault(t, prop.default) : null)
+  if (p.mode !== 'form') return []
+  const found: ElicitTarget[] = []
+  for (const [name, prop] of Object.entries(p.requestedSchema?.properties ?? {})) {
+    const keep = (t: ElicitTarget | null) => {
+      if (t) found.push(withDefault(t, prop.default))
+    }
     if (prop?.type === 'string') {
       const oneOf = prop.oneOf as { const?: unknown; title?: unknown }[] | undefined
       const en = prop.enum as unknown[] | undefined
@@ -863,55 +876,112 @@ export function elicitTarget(params: CreateElicitationRequest, renderable: Elici
         : Array.isArray(en)
           ? en.map((v) => ({ value: String(v), label: clampTo(String(v), 75) }))
           : []
-      if (options.length && renderable.has('enum')) {
-        const t = answerable(seeded({ propName: name, kind: 'enum', options }))
-        if (t) return t
-      }
+      if (options.length && renderable.has('enum')) keep({ propName: name, kind: 'enum', options })
       // Free text is the string with nothing to choose from — an enumerated one is a pick,
       // and typing into it would let an unoffered value through.
-      if (!options.length && renderable.has('text')) {
-        const t = answerable(seeded(textTarget(name, prop)))
-        if (t) return t
-      }
+      if (!options.length && renderable.has('text')) keep(textTarget(name, prop))
     }
-    if ((prop?.type === 'number' || prop?.type === 'integer') && renderable.has('number')) {
-      const t = answerable(seeded(numberTarget(name, prop)))
-      if (t) return t
-    }
+    if ((prop?.type === 'number' || prop?.type === 'integer') && renderable.has('number'))
+      keep(numberTarget(name, prop))
     if (prop?.type === 'array' && renderable.has('multi-enum')) {
       const options = arrayOptions(prop)
       const min = itemBound(prop.minItems)
       const max = itemBound(prop.maxItems)
       // Bounds that admit only the empty selection, or none at all, are not a question.
       const askable = max === undefined || (max > 0 && max >= (min ?? 0))
-      if (options.length && askable) {
-        const t = answerable(
-          seeded({
-            propName: name,
-            kind: 'multi-enum',
-            options,
-            ...(min !== undefined ? { minItems: min } : {}),
-            ...(max !== undefined ? { maxItems: max } : {})
-          })
-        )
-        if (t) return t
-      }
-    }
-    if (prop?.type === 'boolean' && renderable.has('boolean')) {
-      const t = answerable(
-        seeded({
+      if (options.length && askable)
+        keep({
           propName: name,
-          kind: 'boolean',
-          options: [
-            { value: 'true', label: 'Yes' },
-            { value: 'false', label: 'No' }
-          ]
+          kind: 'multi-enum',
+          options,
+          ...(min !== undefined ? { minItems: min } : {}),
+          ...(max !== undefined ? { maxItems: max } : {})
         })
-      )
-      if (t) return t
     }
+    if (prop?.type === 'boolean' && renderable.has('boolean'))
+      keep({
+        propName: name,
+        kind: 'boolean',
+        options: [
+          { value: 'true', label: 'Yes' },
+          { value: 'false', label: 'No' }
+        ]
+      })
   }
-  return null
+  return found
+}
+
+/**
+ * Resolve the single form field an elicitation card renders: the FIRST renderable property
+ * that ALONE satisfies the schema's `required`. Returns null for URL-mode, an empty/absent
+ * schema, a form whose fields this surface can't render, or one that requires a property other
+ * than the rendered target — the daemon then declines rather than accepting a partial answer.
+ * A candidate that fails that check does NOT end the scan: a later property may be the sole
+ * required one, and stopping here would decline a form this surface can in fact answer. Pure,
+ * and shared by every surface so the option values and their interpretation can't drift.
+ */
+export function elicitTarget(params: CreateElicitationRequest, renderable: ElicitSurfaceKinds): ElicitTarget | null {
+  const required = elicitRequiredProps(params)
+  // A required field we can't render is unanswerable: accepting without it would assert a lie.
+  return elicitCandidates(params, renderable).find((t) => required.every((r) => r === t.propName)) ?? null
+}
+
+/**
+ * Resolve the WHOLE form a card renders one control per: every renderable property, in schema
+ * order. Returns null when the surface can render nothing, when a `required` property is not
+ * among the rendered set — {@link elicitTarget}'s rule (#1795) generalised from the one
+ * rendered field to the rendered set, and still the difference between an honest `accept` and
+ * a lie — or when the form is longer than {@link ELICIT_FORM_FIELD_CAP}. A one-field result is
+ * exactly what {@link elicitTarget} would return, which is what keeps a single-field card's
+ * wire payload unchanged.
+ */
+export function elicitForm(params: CreateElicitationRequest, renderable: ElicitSurfaceKinds): ElicitTarget[] | null {
+  const targets = elicitCandidates(params, renderable)
+  if (!targets.length || targets.length > ELICIT_FORM_FIELD_CAP) return null
+  const rendered = new Set(targets.map((t) => t.propName))
+  return elicitRequiredProps(params).every((r) => rendered.has(r)) ? targets : null
+}
+
+/** Whether one value answers one field: the arity its kind is answered with, then that kind's
+ *  own accept check. The single-field card's gate, per field, so a form re-checks every one. */
+export function fieldAccepts(target: ElicitTarget, value: string | number | string[]): boolean {
+  if (Array.isArray(value)) return multiSelectAccepts(target, value)
+  if (typeof value === 'number') return numberAccepts(target, value)
+  if (target.kind === 'text') return textAccepts(target, value)
+  // An enum or boolean answers with one of the values the card itself offered.
+  return (target.kind === 'enum' || target.kind === 'boolean') && target.options.some((o) => o.value === value)
+}
+
+/** Whether a form answer is one the card it was posted for can accept: EXACTLY the fields that
+ *  card rendered (an extra or misspelled key would inject a property the agent never asked
+ *  for), every `required` one present, and each value valid for its own field. An optional
+ *  field may simply be absent — legal per the schema, and the reason #1795's rule was narrow.
+ *  One bad field refuses the whole answer; the card stays live to be answered again. */
+export function elicitFormAccepts(
+  targets: readonly ElicitTarget[],
+  required: readonly string[],
+  answer: Record<string, string | number | string[]>
+): boolean {
+  const byName = new Map(targets.map((t) => [t.propName, t]))
+  for (const name of required) if (!Object.hasOwn(answer, name)) return false
+  for (const [name, value] of Object.entries(answer)) {
+    const target = byName.get(name)
+    if (!target || !fieldAccepts(target, value)) return false
+  }
+  return true
+}
+
+/** The accept content for a form answer: every answered field under its own property name,
+ *  each carrying the schema's own type — a boolean field's wire value is its option string,
+ *  which becomes a real boolean here for the same reason the single-field card converts it. */
+export function elicitFormContent(
+  targets: readonly ElicitTarget[],
+  answer: Record<string, string | number | string[]>
+): Record<string, string | number | boolean | string[]> {
+  const boolean = new Set(targets.filter((t) => t.kind === 'boolean').map((t) => t.propName))
+  return Object.fromEntries(
+    Object.entries(answer).map(([name, value]) => [name, boolean.has(name) ? value === 'true' : value])
+  )
 }
 
 /** Whether a submitted list is an answer this multi-select target actually offered: every value

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -1054,6 +1054,23 @@ describe('webchat answers a multi-field elicitation form with a record', () => {
     })
   })
 
+  // A form of nothing but optional fields, submitted untouched, is a real answer: schema-valid
+  // empty content. The wire used to refuse the frame, so an enabled Submit did nothing.
+  it('accepts an all-optional form submitted with nothing filled in', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', twoFieldElicitation([]))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: {}, webchatConversationId: 'conv-1' })
+    await expect(result).resolves.toEqual({ action: 'accept', content: {} })
+    // Settled as an answer, not left looking like a card that never resolved.
+    expect(cardEvents(sink)[1]).toMatchObject({ outcome: 'accepted', label: 'Nothing filled in' })
+  })
+
   it('refuses the WHOLE record for one bad, extra, or misspelled field', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending: any = installPending(daemon)

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -10,7 +10,7 @@ import { join } from 'node:path'
 import { LocalStore } from '../src/store/local-store.js'
 import { listAgentPermissionRequests } from '../src/cp/config-apply-handlers.js'
 import { SlackConnection } from '../src/slack/connection.js'
-import { elicitTarget, WEBCHAT_ELICIT_KINDS } from '../src/slack/render.js'
+import { elicitForm, elicitTarget, SLACK_ELICIT_KINDS, WEBCHAT_ELICIT_KINDS } from '../src/slack/render.js'
 
 /**
  * Auto-approve policy for the daemon's OWN built-in MCP tools (UX fix): a human should
@@ -564,7 +564,8 @@ describe('webchat renders and answers ACP elicitation cards', () => {
     const pending: any = installPending(daemon)
     const sink = installWebchat(pending)
 
-    // A required field the card cannot answer (#1795) stays unanswerable on webchat too.
+    // A required field NO control can answer (#1795) stays unanswerable on webchat too — a
+    // second RENDERABLE field is now a form, so the unanswerable one has to be the nested object.
     await expect(
       (daemon as any).permissions.onAcpElicit(
         'agent-1',
@@ -572,8 +573,8 @@ describe('webchat renders and answers ACP elicitation cards', () => {
         formElicitation({
           requestedSchema: {
             type: 'object',
-            properties: { branch: { type: 'string', enum: ['main'] }, note: { type: 'string' } },
-            required: ['branch', 'note']
+            properties: { branch: { type: 'string', enum: ['main'] }, extra: { type: 'object' } },
+            required: ['branch', 'extra']
           }
         })
       )
@@ -920,5 +921,221 @@ describe('webchat answers a typed elicitation with the schema’s own type', () 
       (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation({ pattern: '^(a+)+$' }))
     ).resolves.toBeUndefined()
     expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+  })
+})
+
+// ── multi-field forms, webchat only (issue #1794 gap 1) ──────────────────────
+// A Slack card answers ONE field, so `elicitTarget` still requires one property to satisfy
+// `required` alone and a multi-field ask declines there. Webchat reads the whole form
+// (`elicitForm`) and answers it with a value per field — the first thing that can honestly
+// accept a form whose `required` names more than one property.
+
+/** A two-field form: a required pick plus an optional typed note. */
+function twoFieldElicitation(required = ['branch']): CreateElicitationRequest {
+  return formElicitation({
+    message: 'Cut a branch',
+    requestedSchema: {
+      type: 'object',
+      properties: {
+        branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' },
+        note: { type: 'string', maxLength: 20 }
+      },
+      required
+    }
+  })
+}
+
+describe('webchat answers a multi-field elicitation form with a record', () => {
+  it('cards one field per property and accepts the whole record, in the schema’s own types', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      formElicitation({
+        message: 'Cut a branch',
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' },
+            force: { type: 'boolean' },
+            retries: { type: 'integer', minimum: 1, maximum: 5, default: 2 }
+          },
+          required: ['branch', 'force']
+        }
+      })
+    )
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    expect(cardEvents(sink)[0]).toEqual({
+      kind: 'elicitation',
+      requestId: expect.any(String),
+      message: 'Cut a branch',
+      // The single-field descriptors are ALL absent: an old reader gets a card with nothing
+      // to pick and only Dismiss, never one it could half-fill.
+      options: [],
+      fields: [
+        {
+          propName: 'branch',
+          label: 'Base branch',
+          kind: 'enum',
+          required: true,
+          options: [
+            { value: 'main', label: 'main' },
+            { value: 'develop', label: 'develop' }
+          ]
+        },
+        {
+          propName: 'force',
+          label: 'force',
+          kind: 'boolean',
+          required: true,
+          options: [
+            { value: 'true', label: 'Yes' },
+            { value: 'false', label: 'No' }
+          ]
+        },
+        {
+          propName: 'retries',
+          label: 'retries',
+          kind: 'number',
+          options: [],
+          number: { integer: true, minimum: 1, maximum: 5 },
+          defaultValue: 2
+        }
+      ]
+    })
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: { branch: 'develop', force: 'false', retries: 4 },
+      webchatConversationId: 'conv-1'
+    })
+    // Each value carries its own schema type — the boolean is a boolean, not its spelling.
+    await expect(result).resolves.toEqual({
+      action: 'accept',
+      content: { branch: 'develop', force: false, retries: 4 }
+    })
+    // The settled card names each field and what it was answered with, in the card's own words.
+    expect(cardEvents(sink)[1]).toEqual({
+      kind: 'elicitation_resolved',
+      requestId,
+      outcome: 'accepted',
+      label: 'Base branch: develop · force: No · retries: 4'
+    })
+  })
+
+  it('lets an OPTIONAL field be left out, and still refuses a missing required one', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', twoFieldElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    const answer = (value: unknown) =>
+      (daemon as any).permissions.handleElicitChoice({ requestId, value, webchatConversationId: 'conv-1' })
+
+    await answer({ note: 'no branch' }) // the required field is missing
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(cardEvents(sink)).toHaveLength(1) // still live
+
+    // The optional `note` is simply absent — legal per the schema, and the accept says only
+    // what the reader actually answered.
+    await answer({ branch: 'main' })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+    expect(cardEvents(sink)[1]).toEqual({
+      kind: 'elicitation_resolved',
+      requestId,
+      outcome: 'accepted',
+      label: 'Base branch: main'
+    })
+  })
+
+  it('refuses the WHOLE record for one bad, extra, or misspelled field', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', twoFieldElicitation(['branch', 'note']))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    const answer = (value: unknown, conversationId = 'conv-1') =>
+      (daemon as any).permissions.handleElicitChoice({ requestId, value, webchatConversationId: conversationId })
+
+    await answer({ branch: 'trunk', note: 'ok' }) // an option the card never offered
+    await answer({ branch: 'main', note: 'far too long to be accepted' }) // past maxLength
+    await answer({ branch: 'main', note: 'ok', nope: 'x' }) // a field the agent never asked for
+    await answer({ branch: 'main', Note: 'ok' }) // misspelled: the required one is missing too
+    await answer({ branch: ['main'], note: 'ok' }) // the wrong shape for that field
+    await answer('main') // a scalar cannot answer a form card
+    await answer(['main']) // nor can a list
+    await answer({ branch: 'main', note: 'ok' }, 'conv-other') // another conversation, never shown this card
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(cardEvents(sink)).toHaveLength(1) // still live — nothing settled it
+
+    await answer({ branch: 'main', note: 'ok' })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main', note: 'ok' } })
+  })
+
+  it('settles a form card on Dismiss, which is still an explicit refusal to answer', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', twoFieldElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: null, webchatConversationId: 'conv-1' })
+    await expect(result).resolves.toEqual({ action: 'decline' })
+    expect(cardEvents(sink)[1]).toEqual({ kind: 'elicitation_resolved', requestId, outcome: 'dismissed' })
+  })
+
+  it('still declines a multi-field form on a Slack turn, whose card answers one field', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    pending.plan.platform = 'slack'
+    pending.conn = Object.create(SlackConnection.prototype)
+
+    await expect(
+      (daemon as any).permissions.onAcpElicit('agent-1', 's1', twoFieldElicitation(['branch', 'note']))
+    ).resolves.toBeUndefined()
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+    // Unchanged where it matters: one card, one field that satisfies `required` alone.
+    expect(elicitTarget(twoFieldElicitation(['branch', 'note']), SLACK_ELICIT_KINDS)).toBeNull()
+    // The same form IS renderable — just not here: webchat asks every field.
+    expect(elicitForm(twoFieldElicitation(['branch', 'note']), WEBCHAT_ELICIT_KINDS)).toHaveLength(2)
+  })
+
+  it('keeps a one-field form on the single-field card, byte for byte', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', formElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    // Exactly the payload the single-field card always carried: no `fields`, options intact.
+    expect(cardEvents(sink)[0]).toEqual({
+      kind: 'elicitation',
+      requestId: expect.any(String),
+      message: 'Which branch should I cut from?',
+      options: [
+        { value: 'main', label: 'main' },
+        { value: 'develop', label: 'develop' },
+        { value: 'release', label: 'release' }
+      ]
+    })
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    // And it still answers with the scalar, not a record — a form record is refused here.
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: { branch: 'main' },
+      webchatConversationId: 'conv-1'
+    })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'main', webchatConversationId: 'conv-1' })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
   })
 })

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import type { CreateElicitationRequest, RequestPermissionRequest } from '@agentclientprotocol/sdk'
-import { SHARED_CONFIG_ACTION_ID, SLACK_STATUS_ACTION, decodeSlackStatusOverflowValue } from '@agentconnect.md/protocol'
+import {
+  ELICIT_FORM_FIELD_CAP,
+  SHARED_CONFIG_ACTION_ID,
+  SLACK_STATUS_ACTION,
+  decodeSlackStatusOverflowValue
+} from '@agentconnect.md/protocol'
 import {
   OutputConverger,
   renderStatusBar,
@@ -12,6 +17,11 @@ import {
   buildElicitationCard,
   buildElicitationResolvedCard,
   buildAttributionBlocks,
+  elicitFieldLabel,
+  elicitForm,
+  elicitFormAccepts,
+  elicitFormContent,
+  elicitRequiredProps,
   elicitTarget,
   SLACK_ELICIT_KINDS,
   WEBCHAT_ELICIT_KINDS,
@@ -1837,6 +1847,133 @@ describe('elicitation card', () => {
     expect(seed({ type: 'string', minLength: 3, default: 'ab' })).toBeUndefined()
     expect(seed({ type: 'boolean', default: 'yes' })).toBeUndefined()
     expect(seed({ type: 'array', items: { type: 'string', enum: ['a'] }, default: ['z'] })).toBeUndefined()
+  })
+
+  // ── multi-field forms, webchat only (issue #1794 gap 1) ────────────────────
+  // `elicitTarget` stays the per-FIELD reduction every surface reads; `elicitForm` is the
+  // second entry point beside it, and the only thing that can honestly answer a form whose
+  // `required` names more than one property.
+
+  const req = (properties: Record<string, unknown>, required: string[]) =>
+    ({
+      mode: 'form',
+      sessionId: 's1',
+      message: 'Cut a branch',
+      requestedSchema: { type: 'object', properties, required }
+    }) as CreateElicitationRequest
+
+  const TWO = { branch: { type: 'string', enum: ['main', 'dev'] }, note: { type: 'string', maxLength: 40 } }
+
+  it('renders a two-field form on webchat and still declines it on Slack', () => {
+    const two = req(TWO, ['branch', 'note'])
+    expect(elicitForm(two, WEBCHAT_ELICIT_KINDS)?.map((t) => [t.propName, t.kind])).toEqual([
+      ['branch', 'enum'],
+      ['note', 'text']
+    ])
+    // One card answers one field there, and Slack has nothing to type into either — both
+    // reasons still hold, so the form declines rather than half-answering.
+    expect(elicitTarget(two, WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(two, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(elicitForm(two, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(buildElicitationCard('elicit-1', two)).toBeNull()
+  })
+
+  it('answers a form whose required set is fully rendered, and declines one that is not', () => {
+    // Every required property is among the rendered fields — the #1795 rule, generalised.
+    expect(elicitForm(req(TWO, ['branch']), WEBCHAT_ELICIT_KINDS)).toHaveLength(2)
+    expect(elicitForm(req(TWO, []), WEBCHAT_ELICIT_KINDS)).toHaveLength(2)
+    // A required property NO surface can render leaves the form unanswerable, exactly as one
+    // required field the single-field card could not show always did.
+    const nested = { branch: { type: 'string', enum: ['main'] }, extra: { type: 'object' } }
+    expect(elicitForm(req(nested, ['branch', 'extra']), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    // Unrenderable because of its own constraints, not its type: same verdict.
+    const bad = { branch: { type: 'string', enum: ['main'] }, name: { type: 'string', pattern: '^(a+)+$' } }
+    expect(elicitForm(req(bad, ['branch', 'name']), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    // Nothing renderable at all is not a form.
+    expect(elicitForm(req({ extra: { type: 'object' } }, []), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitForm({ mode: 'url', sessionId: 's1', url: 'https://x' } as any, WEBCHAT_ELICIT_KINDS)).toBeNull()
+  })
+
+  it('declines a form longer than one card can ask', () => {
+    const props = (n: number) => Object.fromEntries(Array.from({ length: n }, (_, i) => [`f${i}`, { type: 'boolean' }]))
+    expect(elicitForm(req(props(ELICIT_FORM_FIELD_CAP), []), WEBCHAT_ELICIT_KINDS)).toHaveLength(ELICIT_FORM_FIELD_CAP)
+    expect(elicitForm(req(props(ELICIT_FORM_FIELD_CAP + 1), []), WEBCHAT_ELICIT_KINDS)).toBeNull()
+  })
+
+  it('reduces a one-field form to exactly what the single-field card renders', () => {
+    for (const prop of [
+      { type: 'string', enum: ['main', 'dev'], default: 'dev' },
+      { type: 'boolean' },
+      { type: 'string', minLength: 3, pattern: '^[a-z]+$' },
+      { type: 'number', minimum: 1, maximum: 5 },
+      { type: 'array', items: { type: 'string', enum: ['a', 'b'] }, minItems: 1 }
+    ]) {
+      const one = req({ v: prop }, ['v'])
+      expect(elicitForm(one, WEBCHAT_ELICIT_KINDS)).toEqual([elicitTarget(one, WEBCHAT_ELICIT_KINDS)])
+    }
+  })
+
+  it('labels a field by its schema title, falling back to the property name', () => {
+    const titled = req({ branch: { type: 'string', enum: ['main'], title: 'Base branch' }, note: TWO.note }, [])
+    expect(elicitFieldLabel(titled, 'branch')).toBe('Base branch')
+    expect(elicitFieldLabel(titled, 'note')).toBe('note')
+    expect(elicitFieldLabel(req({ v: { type: 'boolean', title: '   ' } }, []), 'v')).toBe('v')
+  })
+
+  it('accepts a form answer only when EVERY field is one its own card would take', () => {
+    const props = {
+      branch: { type: 'string', enum: ['main', 'dev'] },
+      note: { type: 'string', maxLength: 5 },
+      retries: { type: 'integer', minimum: 1, maximum: 3 },
+      checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] } },
+      force: { type: 'boolean' }
+    }
+    const params = req(props, ['branch'])
+    const form = elicitForm(params, WEBCHAT_ELICIT_KINDS)!
+    const accepts = (answer: Record<string, string | number | string[]>) =>
+      elicitFormAccepts(form, elicitRequiredProps(params), answer)
+
+    expect(accepts({ branch: 'main', note: 'ok', retries: 2, checks: ['lint'], force: 'true' })).toBe(true)
+    // An OPTIONAL field may simply be absent — that is legal per the schema, and the whole
+    // reason the single-field rule had to stay narrow.
+    expect(accepts({ branch: 'main' })).toBe(true)
+    // A required one may not.
+    expect(accepts({ note: 'ok' })).toBe(false)
+    // An extra or misspelled property would inject something the agent never asked for.
+    expect(accepts({ branch: 'main', nope: 'x' })).toBe(false)
+    expect(accepts({ branch: 'main', Note: 'ok' })).toBe(false)
+    // One bad field refuses the WHOLE answer, whichever field it is.
+    expect(accepts({ branch: 'trunk' })).toBe(false)
+    expect(accepts({ branch: 'main', note: 'far too long' })).toBe(false)
+    expect(accepts({ branch: 'main', retries: 9 })).toBe(false)
+    expect(accepts({ branch: 'main', retries: 1.5 })).toBe(false)
+    expect(accepts({ branch: 'main', checks: ['lint', 'lint'] })).toBe(false)
+    expect(accepts({ branch: 'main', checks: ['deploy'] })).toBe(false)
+    expect(accepts({ branch: 'main', force: 'maybe' })).toBe(false)
+    // And a field answered in the wrong shape is no more acceptable than an unoffered value.
+    expect(accepts({ branch: ['main'] })).toBe(false)
+    expect(accepts({ branch: 'main', retries: 'two' })).toBe(false)
+  })
+
+  it('builds the accepted content in the schema’s own types', () => {
+    const params = req(
+      {
+        branch: { type: 'string', enum: ['main'] },
+        retries: { type: 'integer' },
+        checks: { type: 'array', items: { type: 'string', enum: ['lint'] } },
+        force: { type: 'boolean' }
+      },
+      ['branch']
+    )
+    const form = elicitForm(params, WEBCHAT_ELICIT_KINDS)!
+    // A boolean's wire value is its option string; the content carries a real boolean.
+    expect(elicitFormContent(form, { branch: 'main', retries: 2, checks: ['lint'], force: 'false' })).toEqual({
+      branch: 'main',
+      retries: 2,
+      checks: ['lint'],
+      force: false
+    })
+    expect(elicitFormContent(form, { branch: 'main', force: 'true' })).toEqual({ branch: 'main', force: true })
   })
 
   it('resolved card is a single section with the decision', () => {

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  ELICIT_FORM_FIELD_CAP,
   WireFeishuCardActionEvent,
   RdMsg,
   RdMsgWebchat,
@@ -203,6 +204,8 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       // A typed field answers with the schema's own type — a real number, never its spelling.
       { op: 'elicitation_choice', requestId: 'elicit-1', value: 42 },
       { op: 'elicitation_choice', requestId: 'elicit-1', value: -1.5 },
+      // A multi-field form answers with one value per field, each in the schema's own type.
+      { op: 'elicitation_choice', requestId: 'elicit-1', value: { branch: 'main', retries: 3, checks: ['lint'] } },
       { op: 'close' }
     ]
     for (const payload of ops) {
@@ -231,6 +234,17 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'elicit-1', value: ['ok', 3] }).success
     ).toBe(false)
     expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: '', value: 'y' }).success).toBe(false)
+    // An empty record is not an answer, and no form is longer than the card cap.
+    expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'e-1', value: {} }).success).toBe(false)
+    const wide = Object.fromEntries(Array.from({ length: ELICIT_FORM_FIELD_CAP + 1 }, (_, i) => [`f${i}`, 'x']))
+    expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'e-1', value: wide }).success).toBe(false)
+    // A field's value is a scalar or a list of them — never a nested object or a non-number.
+    expect(
+      RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'e-1', value: { a: { b: 1 } } }).success
+    ).toBe(false)
+    expect(
+      RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'e-1', value: { a: Number.NaN } }).success
+    ).toBe(false)
     expect(
       RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'elicit-1', value: 'y', agentId: 'nope' }).success
     ).toBe(false)

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -179,6 +179,13 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     expect(RdAck.safeParse({ msgId: 'm-1' }).success).toBe(false) // verdict is required
   })
 
+  // A form of nothing but optional fields, all left alone, answers with an EMPTY record — a
+  // real answer, not a malformed frame, and the daemon's accept check already takes it.
+  it('carries an empty elicitation answer record', () => {
+    const ok = RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'elicit-1', value: {} })
+    expect(ok.success).toBe(true)
+  })
+
   it('carries every webchat control op and rejects unknown ops', () => {
     const ops = [
       {
@@ -234,8 +241,7 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'elicit-1', value: ['ok', 3] }).success
     ).toBe(false)
     expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: '', value: 'y' }).success).toBe(false)
-    // An empty record is not an answer, and no form is longer than the card cap.
-    expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'e-1', value: {} }).success).toBe(false)
+    // No form is longer than the card cap (an EMPTY record IS an answer — see the case below).
     const wide = Object.fromEntries(Array.from({ length: ELICIT_FORM_FIELD_CAP + 1 }, (_, i) => [`f${i}`, 'x']))
     expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'e-1', value: wide }).success).toBe(false)
     // A field's value is a scalar or a list of them — never a nested object or a non-number.

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -8,7 +8,7 @@ import {
 } from '../normalized-message.js'
 import { frameSchema } from '../envelope.js'
 import { ErrorFrame } from './error.js'
-import { WebchatDone, WebchatImageAttachment, WebchatOutput, WebchatPost } from './webchat.js'
+import { ELICIT_FORM_FIELD_CAP, WebchatDone, WebchatImageAttachment, WebchatOutput, WebchatPost } from './webchat.js'
 import { GitlabHookMetadata, GithubHookMetadata, HookContext, OptionalHookConfigSnapshot } from './hook.js'
 import { CronTarget } from './cron.js'
 import { Platform } from './route.js'
@@ -215,11 +215,22 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
   // rejects the whole op (the card stays live) instead of reading a stripped list as Dismiss.
   // A number card answers with a real number for the same reason it is one on the wire: the
   // accepted content must be the schema's type, and a numeric string would be a different one.
+  // A multi-field FORM card answers with a value per field, keyed by property name — widening
+  // this same field again for the same reason: a daemon predating forms rejects the record
+  // outright (its card stays live) instead of reading a stripped sibling field as Dismiss.
   // `agentId` names the participant whose card this is; absent ⇒ the sole agent.
   z.object({
     op: z.literal('elicitation_choice'),
     requestId: z.string().min(1).max(200),
-    value: z.union([z.string(), z.number(), z.array(z.string()).max(100), z.null()]),
+    value: z.union([
+      z.string(),
+      z.number(),
+      z.array(z.string()).max(100),
+      z
+        .record(z.string().min(1).max(200), z.union([z.string(), z.number(), z.array(z.string()).max(100)]))
+        .refine((v) => Object.keys(v).length >= 1 && Object.keys(v).length <= ELICIT_FORM_FIELD_CAP),
+      z.null()
+    ]),
     agentId: z.string().uuid().optional()
   }),
   z.object({ op: z.literal('close') })

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -228,7 +228,9 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
       z.array(z.string()).max(100),
       z
         .record(z.string().min(1).max(200), z.union([z.string(), z.number(), z.array(z.string()).max(100)]))
-        .refine((v) => Object.keys(v).length >= 1 && Object.keys(v).length <= ELICIT_FORM_FIELD_CAP),
+        // EMPTY is a real answer: a form of nothing but optional fields, all left alone, is
+        // schema-valid content and the daemon's own accept check already takes it.
+        .refine((v) => Object.keys(v).length <= ELICIT_FORM_FIELD_CAP),
       z.null()
     ]),
     agentId: z.string().uuid().optional()

--- a/packages/protocol/src/frames/webchat.test.ts
+++ b/packages/protocol/src/frames/webchat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { WebchatOutput, WebchatStatus } from '../index.js'
+import { ELICIT_FORM_FIELD_CAP, WebchatOutput, WebchatStatus } from '../index.js'
 
 const CONV = '11111111-1111-4111-8111-111111111111'
 const TURN = '22222222-2222-4222-8222-222222222222'
@@ -144,6 +144,58 @@ describe('WebchatOutput — event / status framing', () => {
       expect(single.data.event.number).toBeUndefined()
       expect(single.data.event.defaultValue).toBeUndefined()
     }
+  })
+
+  it('carries a multi-field form card, its fields bounded and the single-field descriptors left off', () => {
+    const card = (event: Record<string, unknown>) =>
+      WebchatOutput.safeParse({ conversationId: CONV, turnId: TURN, index: 4, event })
+    const field = (propName: string, over: Record<string, unknown> = {}) => ({
+      propName,
+      label: propName,
+      kind: 'text',
+      options: [],
+      ...over
+    })
+    const form = card({
+      kind: 'elicitation',
+      requestId: 'elicit-1',
+      message: 'Cut the branch',
+      // Empty, and NO multi/text/number/defaultValue: a reader that does not know `fields`
+      // gets a card with nothing to pick rather than one it could half-answer.
+      options: [],
+      fields: [
+        field('branch', { kind: 'enum', required: true, options: [{ value: 'main', label: 'main' }] }),
+        field('note', { text: { maxLength: 40 } }),
+        field('retries', { kind: 'number', number: { integer: true }, defaultValue: 3 })
+      ]
+    })
+    expect(form.success).toBe(true)
+    if (form.success && form.data.event?.kind === 'elicitation') {
+      expect(form.data.event.fields?.map((f) => f.propName)).toEqual(['branch', 'note', 'retries'])
+      expect(form.data.event.fields?.[0]?.required).toBe(true)
+      expect(form.data.event.fields?.[1]?.required).toBeUndefined()
+      expect(form.data.event.multi).toBeUndefined()
+      expect(form.data.event.text).toBeUndefined()
+    }
+    // One field is the single-field card, not a form; and no card is longer than the cap.
+    expect(card({ kind: 'elicitation', requestId: 'e', message: 'm', options: [], fields: [field('a')] }).success).toBe(
+      false
+    )
+    const wide = Array.from({ length: ELICIT_FORM_FIELD_CAP + 1 }, (_, i) => field(`f${i}`))
+    expect(card({ kind: 'elicitation', requestId: 'e', message: 'm', options: [], fields: wide }).success).toBe(false)
+    // A field with no property to answer under, or a kind no surface renders, is not a field.
+    expect(
+      card({ kind: 'elicitation', requestId: 'e', message: 'm', options: [], fields: [field(''), field('b')] }).success
+    ).toBe(false)
+    expect(
+      card({
+        kind: 'elicitation',
+        requestId: 'e',
+        message: 'm',
+        options: [],
+        fields: [field('a', { kind: 'slider' }), field('b')]
+      }).success
+    ).toBe(false)
   })
 
   it('rejects an unrenderable elicitation frame rather than streaming a dead card', () => {

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -115,6 +115,49 @@ export const PlanEntry = z.object({
 })
 export type PlanEntry = z.infer<typeof PlanEntry>
 
+/** The most fields one elicitation card renders. A card is a question standing in a
+ *  transcript, not a settings page: past ten controls the reader cannot take the ask in, and
+ *  the daemon must hold and re-validate every field of the record that answers it. A longer
+ *  form is declined, which is honest — the agent can ask again in smaller pieces. */
+export const ELICIT_FORM_FIELD_CAP = 10
+
+/** The per-kind field descriptors of an elicitation card. Shared by the single-field card and
+ *  by each entry of a multi-field form, so the two can never describe one field differently. */
+const ElicitOptions = z.array(z.object({ value: z.string(), label: z.string() }))
+const ElicitMulti = z.object({
+  minItems: z.number().int().min(0).optional(),
+  maxItems: z.number().int().min(0).optional()
+})
+const ElicitText = z.object({
+  minLength: z.number().int().min(0).optional(),
+  maxLength: z.number().int().min(0).optional(),
+  pattern: z.string().max(200).optional(),
+  format: z.enum(['email', 'uri', 'date', 'date-time']).optional()
+})
+const ElicitNumber = z.object({
+  integer: z.boolean().optional(),
+  minimum: z.number().optional(),
+  maximum: z.number().optional()
+})
+const ElicitDefault = z.union([z.string(), z.number(), z.boolean(), z.array(z.string())])
+
+/** One field of a multi-field form card: the descriptors above plus what only a form needs —
+ *  the schema key the answer is returned under, a label to render it beside, its kind (a
+ *  boolean's two options are indistinguishable from an enum's otherwise), and whether the
+ *  schema requires it, since an optional field may be left out of the answer entirely. */
+export const ElicitField = z.object({
+  propName: z.string().min(1).max(200),
+  label: z.string(),
+  kind: z.enum(['enum', 'boolean', 'multi-enum', 'text', 'number']),
+  required: z.boolean().optional(),
+  options: ElicitOptions,
+  multi: ElicitMulti.optional(),
+  text: ElicitText.optional(),
+  number: ElicitNumber.optional(),
+  defaultValue: ElicitDefault.optional()
+})
+export type ElicitField = z.infer<typeof ElicitField>
+
 export const WebchatEvent = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('message'), text: z.string() }), // from agent_message_chunk
   z.object({ kind: z.literal('thinking'), text: z.string() }), // from agent_thought_chunk
@@ -158,8 +201,8 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('plan'), entries: z.array(PlanEntry) }),
   // The agent asked for a choice (ACP `elicitation/create`, form mode) — webchat's own
   // in-band card, the peer of the Slack Block Kit one. Deliberately NOT the raw
-  // `requestedSchema`: the daemon has already reduced the form to the one renderable
-  // field, and its options are the only answers the browser may send back (as the
+  // `requestedSchema`: the daemon has already reduced the form to its renderable
+  // field(s), and its options are the only answers the browser may send back (as the
   // `elicitation_choice` op keyed by this `requestId`). `message` is agent-authored text,
   // masked before it reaches here. Options are UNCAPPED — the Slack 5-button cap is a
   // Slack surface limit and does not follow the choice onto this surface. They are also
@@ -168,39 +211,30 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
     kind: z.literal('elicitation'),
     requestId: z.string().min(1).max(200),
     message: z.string(),
-    options: z.array(z.object({ value: z.string(), label: z.string() })),
+    options: ElicitOptions,
     // Absent ⇒ pick exactly ONE option, the original card. Present ⇒ pick several of the same
     // options and confirm, and the answer is a list. An added OPTIONAL field rather than a new
     // event kind on purpose: a relay or browser predating it decodes the event unchanged
     // (zod strips what it does not know) instead of dropping the frame the way an unknown
     // kind would, and a daemon predating it simply never sets it.
-    multi: z
-      .object({ minItems: z.number().int().min(0).optional(), maxItems: z.number().int().min(0).optional() })
-      .optional(),
+    multi: ElicitMulti.optional(),
     // Present ⇒ the card is a free-text input carrying the schema's own constraints, which the
     // daemon re-checks on the way back in. Same optional-field reasoning as `multi`, with one
     // added skew note: an old reader keeps `options` (now empty) and shows a card with nothing
     // but Dismiss — unanswerable, never wrongly answered. `pattern` reaches here only once the
     // daemon has cleared it as safe to run.
-    text: z
-      .object({
-        minLength: z.number().int().min(0).optional(),
-        maxLength: z.number().int().min(0).optional(),
-        pattern: z.string().max(200).optional(),
-        format: z.enum(['email', 'uri', 'date', 'date-time']).optional()
-      })
-      .optional(),
+    text: ElicitText.optional(),
     // Present ⇒ a numeric input; `integer` is the schema's `integer` type, not just a bound.
-    number: z
-      .object({
-        integer: z.boolean().optional(),
-        minimum: z.number().optional(),
-        maximum: z.number().optional()
-      })
-      .optional(),
+    number: ElicitNumber.optional(),
     // The schema's `default`, already checked against the constraints above: the card
     // pre-populates its control with it (MCP `2025-11-25`), and the reader may answer otherwise.
-    defaultValue: z.union([z.string(), z.number(), z.boolean(), z.array(z.string())]).optional()
+    defaultValue: ElicitDefault.optional(),
+    // Present ⇒ the card is a multi-field FORM: one control per field, one submit, and the
+    // answer is a record of value-per-field. The single-field descriptors above are then all
+    // absent — deliberately, and the same closed-failure trade `text` records: an old reader
+    // sees an optionless card it can only Dismiss, rather than a card it could half-fill with
+    // one field's answer that the daemon would then refuse.
+    fields: z.array(ElicitField).min(2).max(ELICIT_FORM_FIELD_CAP).optional()
   }),
   // The same card, settled. Slack rewrites its message in place; this stream is
   // append-only, so the collapse is a second event keyed by the same `requestId`.

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -195,8 +195,11 @@ describe('parseBrowserFrame', () => {
     ).toEqual({
       op: { op: 'elicitation_choice', requestId: 'elicit-1', value: { branch: 'main', checks: ['lint'], retries: 3 } }
     })
-    // An empty record answers nothing, and a nested one is not a field value.
-    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: {} }, USER)).toBeNull()
+    // An all-optional form left alone answers with an EMPTY record — a real answer, forwarded.
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: {} }, USER)).toEqual({
+      op: { op: 'elicitation_choice', requestId: 'elicit-1', value: {} }
+    })
+    // A nested object is not a field value.
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'e-1', value: { a: { b: 1 } } }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: Number.NaN }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: ['a', 7] }, USER)).toBeNull()

--- a/packages/relay/src/relay-browser-connection.test.ts
+++ b/packages/relay/src/relay-browser-connection.test.ts
@@ -186,6 +186,18 @@ describe('parseBrowserFrame', () => {
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: 42 }, USER)).toEqual({
       op: { op: 'elicitation_choice', requestId: 'elicit-1', value: 42 }
     })
+    // A multi-field form answers with one value per field, keyed by property name.
+    expect(
+      parseBrowserFrame(
+        { type: 'elicitation_choice', requestId: 'elicit-1', value: { branch: 'main', checks: ['lint'], retries: 3 } },
+        USER
+      )
+    ).toEqual({
+      op: { op: 'elicitation_choice', requestId: 'elicit-1', value: { branch: 'main', checks: ['lint'], retries: 3 } }
+    })
+    // An empty record answers nothing, and a nested one is not a field value.
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: {} }, USER)).toBeNull()
+    expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'e-1', value: { a: { b: 1 } } }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: Number.NaN }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1', value: ['a', 7] }, USER)).toBeNull()
     expect(parseBrowserFrame({ type: 'elicitation_choice', requestId: 'elicit-1' }, USER)).toBeNull()

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -201,8 +201,9 @@ export function parseBrowserFrame(
       const scalar = typeof m.value === 'string' || (typeof m.value === 'number' && Number.isFinite(m.value))
       // A multi-field form card answers with one value per field, keyed by property name; the
       // daemon checks the keys against the card it posted, and each value against that field.
-      const record =
-        !!m.value && typeof m.value === 'object' && !Array.isArray(m.value) && Object.keys(m.value).length > 0
+      // An EMPTY record is a real answer — every field optional and left alone — so it is not
+      // filtered out here; the zod parse below still bounds how large one may be.
+      const record = !!m.value && typeof m.value === 'object' && !Array.isArray(m.value)
       if (typeof m.requestId !== 'string' || (!scalar && !record && m.value !== null && !listed)) return null
       if (m.agentId !== undefined && !(typeof m.agentId === 'string' && UUID_RE.test(m.agentId))) return null
       const parsed = RelayWebchatOp.safeParse({

--- a/packages/relay/src/relay-browser-connection.ts
+++ b/packages/relay/src/relay-browser-connection.ts
@@ -199,7 +199,11 @@ export function parseBrowserFrame(
       // re-checks the value against the constraints that card carried.
       const listed = Array.isArray(m.value) && m.value.every((v) => typeof v === 'string')
       const scalar = typeof m.value === 'string' || (typeof m.value === 'number' && Number.isFinite(m.value))
-      if (typeof m.requestId !== 'string' || (!scalar && m.value !== null && !listed)) return null
+      // A multi-field form card answers with one value per field, keyed by property name; the
+      // daemon checks the keys against the card it posted, and each value against that field.
+      const record =
+        !!m.value && typeof m.value === 'object' && !Array.isArray(m.value) && Object.keys(m.value).length > 0
+      if (typeof m.requestId !== 'string' || (!scalar && !record && m.value !== null && !listed)) return null
       if (m.agentId !== undefined && !(typeof m.agentId === 'string' && UUID_RE.test(m.agentId))) return null
       const parsed = RelayWebchatOp.safeParse({
         op: 'elicitation_choice',

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -19,7 +19,16 @@ import {
   useSyncExternalStore,
   type ReactNode
 } from 'react'
-import { agentLabel, isGitWorkspace, type Agent, type Session, type SessionImage, type SessionStep } from '@/lib/data'
+import {
+  agentLabel,
+  isGitWorkspace,
+  type Agent,
+  type ElicitAnswerValue,
+  type ElicitFieldSpec,
+  type Session,
+  type SessionImage,
+  type SessionStep
+} from '@/lib/data'
 import { useConsoleData } from '@/lib/data-context'
 import {
   webchatWsUrl,
@@ -128,12 +137,12 @@ interface PlaygroundData {
   /** Interrupt the running turn without ending the session. */
   pgCancel: (id: string, agentId: string, conversationId?: string) => void
   /** Answer the agent's in-band elicitation card; a list answers a multi-select, a number a
-   *  numeric field, `null` is Dismiss. */
+   *  numeric field, a record of value-per-field a multi-field form, `null` is Dismiss. */
   pgAnswerElicitation: (
     id: string,
     agentId: string,
     requestId: string,
-    value: string | string[] | number | null,
+    value: ElicitAnswerValue,
     conversationId?: string
   ) => void
   getPgSession: (id: string) => Session | undefined
@@ -255,6 +264,7 @@ type WebchatEvent =
       text?: { minLength?: number; maxLength?: number; pattern?: string; format?: string }
       number?: { integer?: boolean; minimum?: number; maximum?: number }
       defaultValue?: string | number | boolean | string[]
+      fields?: ElicitFieldSpec[]
     }
   | {
       kind: 'elicitation_resolved'
@@ -628,7 +638,10 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 ...(ev.multi ? { multi: ev.multi } : {}),
                 ...(ev.text ? { text: ev.text } : {}),
                 ...(ev.number ? { number: ev.number } : {}),
-                ...(ev.defaultValue !== undefined ? { defaultValue: ev.defaultValue } : {})
+                ...(ev.defaultValue !== undefined ? { defaultValue: ev.defaultValue } : {}),
+                // A multi-field form: the fields ARE the card, and the descriptors above are
+                // absent, so a build that does not know them shows nothing to answer with.
+                ...(ev.fields ? { fields: ev.fields } : {})
               },
               boundary: true
             })
@@ -1726,13 +1739,7 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
    *  Deliberately NOT optimistic: the daemon owns the card's outcome and settles it with
    *  the `elicitation_resolved` event, so a refused answer leaves the card answerable. */
   const pgAnswerElicitation = useCallback(
-    (
-      id: string,
-      agentForId: string,
-      requestId: string,
-      value: string | string[] | number | null,
-      conversationId?: string
-    ) => {
+    (id: string, agentForId: string, requestId: string, value: ElicitAnswerValue, conversationId?: string) => {
       connect(id, agentForId, conversationId)
         .ready.then((ws) =>
           ws.send(JSON.stringify({ type: 'elicitation_choice', requestId, value, agentId: agentForId }))

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -936,6 +936,40 @@ describe('in-band elicitation cards', () => {
     ])
   })
 
+  it('carries a multi-field form card onto the step, fields and all', async () => {
+    const { socket, turnId } = await openStream()
+    const fields = [
+      {
+        propName: 'branch',
+        label: 'Base branch',
+        kind: 'enum',
+        required: true,
+        options: [{ value: 'main', label: 'main' }]
+      },
+      { propName: 'note', label: 'Note', kind: 'text', options: [] }
+    ]
+    feed(socket, turnId, 0, { ...card('elicit-1'), options: [], fields })
+    expect(getLiveSteps('s1').filter((s) => s.kind === 'elicit')).toMatchObject([
+      { elicit: { requestId: 'elicit-1', options: [], fields } }
+    ])
+  })
+
+  it('answers a form card with the whole record over the same socket', async () => {
+    const { socket, turnId } = await openStream()
+    feed(socket, turnId, 0, card('elicit-1'))
+    act(() => pgAnswerElicitation('s1', 'agent-1', 'elicit-1', { branch: 'main', note: 'ok' }, 'c1'))
+    await act(async () => {})
+    const frames = socket.send.mock.calls.map((call) => JSON.parse(String(call[0])))
+    expect(frames.filter((f) => f.type === 'elicitation_choice')).toEqual([
+      {
+        type: 'elicitation_choice',
+        requestId: 'elicit-1',
+        value: { branch: 'main', note: 'ok' },
+        agentId: 'agent-1'
+      }
+    ])
+  })
+
   it('settles a card another participant cannot claim: `elicit-<n>` is unique per daemon only', async () => {
     const { socket, turnId } = await openStream()
     feed(socket, turnId, 0, card('elicit-1'))

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -406,6 +406,145 @@ describe('the agent’s elicitation card on the session page', () => {
     expect(live.answered.at(-1)).toEqual(['session-1', 'agent-1', 'elicit-3', ['main'], 'conv-1'])
   })
 
+  // ── multi-field forms (#1794 gap 1): one control per field, one submit ──
+
+  const inputNamed = (label: string) =>
+    container?.querySelector(`input[aria-label="${label}"]`) as HTMLInputElement | null
+  const typeInto = async (field: HTMLInputElement, value: string) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(field, value)
+      field.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  const FORM_FIELDS = [
+    {
+      propName: 'branch',
+      label: 'Base branch',
+      kind: 'enum',
+      required: true,
+      options: [
+        { value: 'main', label: 'main' },
+        { value: 'develop', label: 'develop' }
+      ]
+    },
+    { propName: 'note', label: 'Note', kind: 'text', options: [], text: { maxLength: 6 } },
+    {
+      propName: 'force',
+      label: 'Force push',
+      kind: 'boolean',
+      required: true,
+      options: [
+        { value: 'true', label: 'Yes' },
+        { value: 'false', label: 'No' }
+      ]
+    }
+  ]
+
+  it('asks every field, labelled, behind one submit that waits for all of them', async () => {
+    live.steps = [
+      { ...CARD, text: 'Cut a branch', elicit: { requestId: 'elicit-1', options: [], fields: FORM_FIELDS } }
+    ]
+    await render()
+
+    // Every field is named, and the one the schema does not require says so.
+    for (const label of ['Base branch', 'Note', 'Force push']) expect(text()).toContain(label)
+    expect(text()).toContain('(optional)')
+    // Two required fields unanswered, so there is nothing valid to submit yet.
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(text()).toContain('Choose one')
+
+    await act(async () => {
+      buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // A pick is held, not sent: a form answers once, on Submit.
+    expect(live.answered).toEqual([])
+    expect(buttonNamed('main')?.getAttribute('aria-pressed')).toBe('true')
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+
+    await act(async () => {
+      buttonNamed('No')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(buttonNamed('Submit')?.disabled).toBe(false)
+
+    // One bad OPTIONAL field is still enough to hold the whole answer, with its own reason.
+    await typeInto(inputNamed('Note')!, 'far too long')
+    expect(text()).toContain('Enter at most 6 characters')
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+
+    await typeInto(inputNamed('Note')!, 'ok')
+    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    await act(async () => {
+      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // One value per field, each in the shape its own kind answers with.
+    expect(live.answered).toEqual([
+      ['session-1', 'agent-1', 'elicit-1', { branch: 'main', note: 'ok', force: 'false' }, 'conv-1']
+    ])
+  })
+
+  it('leaves an untouched optional field out of the record entirely', async () => {
+    live.steps = [
+      {
+        ...CARD,
+        text: 'Cut a branch',
+        elicit: {
+          requestId: 'elicit-1',
+          options: [],
+          fields: [
+            FORM_FIELDS[0],
+            FORM_FIELDS[1],
+            { propName: 'checks', label: 'Checks', kind: 'multi-enum', options: [{ value: 'lint', label: 'lint' }] }
+          ]
+        }
+      }
+    ]
+    await render()
+
+    // Nothing required but the pick, so the form is answerable with the rest left alone.
+    await act(async () => {
+      buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    await act(async () => {
+      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', { branch: 'main' }, 'conv-1']])
+
+    // Dismiss stays an explicit refusal, not an empty record.
+    await act(async () => {
+      buttonNamed('Dismiss')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered[1]).toEqual(['session-1', 'agent-1', 'elicit-1', null, 'conv-1'])
+  })
+
+  it('pre-populates each field of a form from its own schema default', async () => {
+    live.steps = [
+      {
+        ...CARD,
+        elicit: {
+          requestId: 'elicit-1',
+          options: [],
+          fields: [
+            { ...FORM_FIELDS[0], defaultValue: 'develop' },
+            { ...FORM_FIELDS[1], required: true, defaultValue: 'seed' }
+          ]
+        }
+      }
+    ]
+    await render()
+
+    expect(inputNamed('Note')?.value).toBe('seed')
+    expect(buttonNamed('develop')?.getAttribute('aria-pressed')).toBe('true')
+    // Seeded AND already valid, so the reader can simply accept what the agent suggested.
+    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    await act(async () => {
+      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', { branch: 'develop', note: 'seed' }, 'conv-1']])
+  })
+
   it('collapses to its outcome once settled, leaving nothing left to answer', async () => {
     live.steps = [{ ...CARD, elicit: { ...CARD.elicit, outcome: 'accepted', answerLabel: 'develop' } }]
     await render()

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -39,6 +39,8 @@ import {
   speaker,
   status,
   type Agent,
+  type ElicitAnswerValue,
+  type ElicitFieldSpec,
   type Session,
   type SessionImage,
   type SessionStep
@@ -685,7 +687,7 @@ const FORMAT_HINT: Record<string, { test: (v: string) => boolean; why: string }>
 
 /** Why a typed draft is not yet answerable, or undefined once it is — the same constraints the
  *  daemon re-checks, said in words the reader can act on rather than as a silent dead control. */
-function typedInvalidReason(elicit: NonNullable<FmtStep['elicit']>, draft: string): string | undefined {
+function typedInvalidReason(elicit: Pick<ElicitFieldSpec, 'text' | 'number'>, draft: string): string | undefined {
   const num = elicit.number
   if (num) {
     if (!draft.trim()) return 'Enter a number'
@@ -717,38 +719,97 @@ function typedInvalidReason(elicit: NonNullable<FmtStep['elicit']>, draft: strin
 }
 
 /** What a typed card's control starts out holding: the schema's `default`, or nothing. */
-function typedDraft(elicit: FmtStep['elicit']): string {
+function typedDraft(elicit: Pick<ElicitFieldSpec, 'defaultValue'> | undefined): string {
   const value = elicit?.defaultValue
   return typeof value === 'string' || typeof value === 'number' ? String(value) : ''
 }
 
 /** The options a card starts out holding — a multi-select's default list, or the single default
  *  pick, which stays marked so the reader sees what the agent suggested before tapping. */
-function pickedDefaults(elicit: FmtStep['elicit']): string[] {
+function pickedDefaults(elicit: Pick<ElicitFieldSpec, 'defaultValue'> | undefined): string[] {
   const value = elicit?.defaultValue
   if (Array.isArray(value)) return value
   return typeof value === 'string' || typeof value === 'boolean' ? [String(value)] : []
+}
+
+/** What each field of a form card starts out holding — its own schema default, per kind. */
+function formDrafts(fields: ElicitFieldSpec[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const f of fields ?? []) if (f.kind === 'text' || f.kind === 'number') out[f.propName] = typedDraft(f)
+  return out
+}
+
+function formPicks(fields: ElicitFieldSpec[] | undefined): Record<string, string[]> {
+  const out: Record<string, string[]> = {}
+  for (const f of fields ?? []) if (f.kind !== 'text' && f.kind !== 'number') out[f.propName] = pickedDefaults(f)
+  return out
+}
+
+/** Why one form field is not yet answerable, or undefined once it is — the same per-kind rules
+ *  the daemon re-checks. A field the schema does not require may be left untouched: the answer
+ *  then leaves it out, which is legal and is why the whole form can be answered at all. */
+function fieldInvalidReason(
+  f: ElicitFieldSpec,
+  drafts: Record<string, string>,
+  picks: Record<string, string[]>
+): string | undefined {
+  if (f.kind === 'text' || f.kind === 'number') {
+    const draft = drafts[f.propName] ?? ''
+    if (!draft.trim() && !f.required) return undefined
+    return typedInvalidReason(f, draft)
+  }
+  const picked = picks[f.propName] ?? []
+  if (f.kind === 'multi-enum') {
+    const min = f.multi?.minItems ?? 0
+    const max = f.multi?.maxItems
+    if (!picked.length && !f.required) return undefined
+    return picked.length < min || (max !== undefined && picked.length > max) ? selectionHint(min, max) : undefined
+  }
+  return picked.length === 1 || (!picked.length && !f.required) ? undefined : 'Choose one'
+}
+
+/** The record a form card answers with: every answered field under its property name, in the
+ *  schema's own type. An untouched OPTIONAL field is left out entirely rather than sent empty —
+ *  the daemon accepts that, and it keeps the agent's content to what the reader actually said. */
+function formAnswer(
+  fields: ElicitFieldSpec[],
+  drafts: Record<string, string>,
+  picks: Record<string, string[]>
+): Record<string, string | number | string[]> {
+  const out: Record<string, string | number | string[]> = {}
+  for (const f of fields) {
+    if (f.kind === 'text' || f.kind === 'number') {
+      const draft = drafts[f.propName] ?? ''
+      if (draft.trim()) out[f.propName] = f.kind === 'number' ? Number(draft) : draft
+      continue
+    }
+    const picked = picks[f.propName] ?? []
+    // A required multi-select carries even the empty set: "none of them" is its answer.
+    if (f.kind === 'multi-enum') {
+      if (f.required || picked.length) out[f.propName] = picked
+    } else if (picked.length === 1) out[f.propName] = picked[0]!
+  }
+  return out
 }
 
 /** The agent's in-band question: its options while it is live, its outcome once settled.
  *  A multi-select (`elicit.multi`) toggles its options and answers with the list on Confirm —
  *  one tap can't express a set — while a single-choice card still answers on the tap itself.
  *  A typed field (`elicit.text` / `elicit.number`) has no options at all: it submits what the
- *  reader wrote, once the schema's own constraints are met.
+ *  reader wrote, once the schema's own constraints are met. A multi-field form (`elicit.fields`)
+ *  stacks one labelled control per field behind a single Submit that stays disabled until every
+ *  one of them is answerable, and sends a value per field.
  *  Without `onAnswer` — a reader with no live socket to answer over — the same card renders
  *  as a plain record of the ask, controls inert rather than missing. */
-function ElicitationCard({
-  step,
-  onAnswer
-}: {
-  step: FmtStep
-  onAnswer?: (value: string | string[] | number | null) => void
-}) {
+function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value: ElicitAnswerValue) => void }) {
   const [picked, setPicked] = useState<string[]>(() => pickedDefaults(step.elicit))
   const [draft, setDraft] = useState<string>(() => typedDraft(step.elicit))
+  const [drafts, setDrafts] = useState<Record<string, string>>(() => formDrafts(step.elicit?.fields))
+  const [picks, setPicks] = useState<Record<string, string[]>>(() => formPicks(step.elicit?.fields))
   const elicit = step.elicit
   const multi = elicit?.multi
-  const typed = elicit && (elicit.text || elicit.number) ? elicit : undefined
+  const fields = elicit?.fields?.length ? elicit.fields : undefined
+  const typed = !fields && elicit && (elicit.text || elicit.number) ? elicit : undefined
   const min = multi?.minItems ?? 0
   const max = multi?.maxItems
   // The same bounds the daemon re-checks: a browser frame is not what makes an answer valid.
@@ -772,6 +833,100 @@ function ElicitationCard({
             <Icon name={settled.icon} size={13} color={settled.color} />
             <span className="min-w-0 truncate">{settled.label(elicit.answerLabel)}</span>
           </span>
+        ) : fields ? (
+          <div className="flex w-full min-w-0 flex-col gap-[10px]">
+            {fields.map((f) => {
+              const reason = fieldInvalidReason(f, drafts, picks)
+              const note =
+                reason ??
+                (f.kind === 'multi-enum' ? selectionHint(f.multi?.minItems ?? 0, f.multi?.maxItems) : undefined)
+              return (
+                <div key={f.propName} className="flex min-w-0 flex-col gap-[6px]">
+                  <span className="font-sans text-[12.5px] font-medium leading-normal text-(--text-secondary)">
+                    {f.label}
+                    {!f.required && <span className="text-(--text-tertiary)">&#32;(optional)</span>}
+                  </span>
+                  {f.kind === 'text' || f.kind === 'number' ? (
+                    <input
+                      className="inp w-full min-w-0 desktop:max-w-[320px] disabled:cursor-default disabled:opacity-55"
+                      type={f.kind === 'number' ? 'number' : 'text'}
+                      value={drafts[f.propName] ?? ''}
+                      disabled={!onAnswer}
+                      aria-label={f.label}
+                      {...(f.number?.minimum !== undefined ? { min: f.number.minimum } : {})}
+                      {...(f.number?.maximum !== undefined ? { max: f.number.maximum } : {})}
+                      {...(f.number?.integer ? { step: 1 } : {})}
+                      {...(f.text?.maxLength !== undefined ? { maxLength: f.text.maxLength } : {})}
+                      onChange={(e) => setDrafts((prev) => ({ ...prev, [f.propName]: e.target.value }))}
+                    />
+                  ) : (
+                    <div className="flex min-w-0 flex-wrap items-center gap-[6px]">
+                      {f.options.map((option) => {
+                        const held = picks[f.propName] ?? []
+                        const on = held.includes(option.value)
+                        // At the cap, an unpicked option stops taking a tap — an answer the
+                        // card would have to refuse must not look available.
+                        const cap = f.kind === 'multi-enum' ? f.multi?.maxItems : undefined
+                        const capped = !on && cap !== undefined && held.length >= cap
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            aria-pressed={on}
+                            className={
+                              on
+                                ? 'chip max-w-full truncate border-(--brand) bg-(--brand-soft) text-(--brand-soft-text) disabled:cursor-default disabled:opacity-55'
+                                : 'chip max-w-full truncate disabled:cursor-default disabled:opacity-55'
+                            }
+                            disabled={!onAnswer || capped}
+                            onClick={() =>
+                              setPicks((prev) => {
+                                const was = prev[f.propName] ?? []
+                                if (was.includes(option.value))
+                                  return { ...prev, [f.propName]: was.filter((v) => v !== option.value) }
+                                // One choice replaces the last for a single-pick field; a
+                                // multi-select adds to the set.
+                                return {
+                                  ...prev,
+                                  [f.propName]: f.kind === 'multi-enum' ? [...was, option.value] : [option.value]
+                                }
+                              })
+                            }
+                          >
+                            {option.label}
+                          </button>
+                        )
+                      })}
+                    </div>
+                  )}
+                  {note && (
+                    <span className="font-sans text-[12.5px] font-normal leading-normal text-(--text-tertiary)">
+                      {note}
+                    </span>
+                  )}
+                </div>
+              )
+            })}
+            <div className="flex flex-wrap items-center gap-[6px]">
+              <button
+                type="button"
+                className="dsbtn dsbtn-primary xs"
+                disabled={!onAnswer || fields.some((f) => !!fieldInvalidReason(f, drafts, picks))}
+                onClick={() => onAnswer?.(formAnswer(fields, drafts, picks))}
+              >
+                Submit
+              </button>
+              <button
+                type="button"
+                className="chip disabled:cursor-default disabled:opacity-55"
+                disabled={!onAnswer}
+                onClick={() => onAnswer?.(null)}
+                title="Dismiss without answering"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
         ) : typed ? (
           <>
             <input
@@ -3083,11 +3238,7 @@ export default function SessionDetailView() {
   // the card renders inert rather than offering buttons that would go nowhere.
   const answerElicitation =
     isLive && (isPg || isWebchat)
-      ? (
-          agentId: string | undefined,
-          requestId: string | undefined,
-          value: string | string[] | number | null
-        ): void => {
+      ? (agentId: string | undefined, requestId: string | undefined, value: ElicitAnswerValue): void => {
           if (!requestId) return
           pgAnswerElicitation(session.id, agentId ?? session.agentId ?? '', requestId, value, webchatConversationId)
         }
@@ -4489,7 +4640,7 @@ export default function SessionDetailView() {
                                           step={st}
                                           {...(answerElicitation
                                             ? {
-                                                onAnswer: (value: string | string[] | number | null) =>
+                                                onAnswer: (value: ElicitAnswerValue) =>
                                                   answerElicitation(turn.agentId, st.elicit?.requestId, value)
                                               }
                                             : {})}

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1076,6 +1076,25 @@ export interface SessionImage {
   data: string
 }
 
+/** One field of a multi-field elicitation form card (protocol `ElicitField`): the control to
+ *  render, the label to render it beside, and the constraints the daemon re-checks on the way
+ *  back in. `required` absent ⇒ the schema allows the answer to leave this field out. */
+export interface ElicitFieldSpec {
+  propName: string
+  label: string
+  kind: 'enum' | 'boolean' | 'multi-enum' | 'text' | 'number'
+  required?: boolean
+  options: { value: string; label: string }[]
+  multi?: { minItems?: number; maxItems?: number }
+  text?: { minLength?: number; maxLength?: number; pattern?: string; format?: string }
+  number?: { integer?: boolean; minimum?: number; maximum?: number }
+  defaultValue?: string | number | boolean | string[]
+}
+
+/** What answers an elicitation card: one picked option, a multi-select's list, a number, a
+ *  form's value-per-field record, or `null` for Dismiss. */
+export type ElicitAnswerValue = string | string[] | number | Record<string, string | number | string[]> | null
+
 export interface SessionStep {
   kind: LaneKind
   who?: string
@@ -1140,6 +1159,11 @@ export interface SessionStep {
     number?: { integer?: boolean; minimum?: number; maximum?: number }
     /** The schema's `default` — what the control starts out holding. */
     defaultValue?: string | number | boolean | string[]
+    /** Present ⇒ the card is a multi-field FORM: one labelled control per field and one
+     *  submit, answered with a value per field keyed by property name. Every single-field
+     *  descriptor above is then absent, so a reader that does not know `fields` has nothing
+     *  to answer with rather than half an answer. */
+    fields?: ElicitFieldSpec[]
     outcome?: 'accepted' | 'dismissed' | 'cancelled'
     answerLabel?: string
   }


### PR DESCRIPTION
Implements #1794 gap 1's second sub-item, for webchat. This is the change #1795 was waiting for.

#1795 made a card decline when `requestedSchema.required` names a property the single-field card does not render, because answering `accept` with content that misses a required field asserts the user answered a question they were never shown. That was the honest verdict, but it left a whole class of ordinary forms — "which branch, and a note?" — unanswerable anywhere. Now webchat renders them.

## Factoring: a second entry point, not a plural type

`ElicitTarget` is untouched. It is the per-field reduction, and four PRs of logic sit on it being exactly one field — `textTarget`, `numberTarget`, `textAccepts`, `numberAccepts`, `multiSelectAccepts`, `withDefault`. Turning it plural would have pushed the blast radius through Slack's card builder and the approval-DM path, neither of which wants multi-field.

Instead the per-property scan was extracted verbatim into a private `elicitCandidates(params, renderable)`, with two entry points on it:

```ts
elicitTarget(params, renderable)   // unchanged contract: the FIRST field that alone satisfies `required`
elicitForm(params, renderable)     // every renderable property, or null
```

`elicitForm` returns null when the surface can render nothing, when the form exceeds the field cap, or when any `required` property is **not among the rendered set** — #1795's rule generalised from "the one rendered field" to "the rendered set", and still the line between an honest `accept` and a lie.

Slack, the approval-DM path and the answer-time re-derivation stay on `elicitTarget`, so a multi-field form still declines there. A one-field `elicitForm` result is exactly what `elicitTarget` returns, asserted over all five kinds.

## Field cap: 10

Lives in the protocol so the card schema, the daemon's reduction and the answer-record bound are one number. A card is a question standing in a transcript, not a settings page; past ten stacked controls the reader cannot take the ask in, every field costs a held descriptor and a re-validation, and a schema with hundreds of properties needs a floor. Declining is honest — the agent gets `decline` and can ask in smaller pieces.

## Wire

New optional `fields: ElicitField[]` (2–10). The per-kind descriptor sub-schemas are now shared between the single-field card and each field entry, so the two representations cannot drift. `kind` is carried explicitly (a boolean's two options are otherwise indistinguishable from an enum's) and `required` is carried so the browser knows whether an empty control blocks Submit — the daemon reads requiredness from the schema, never from the frame, so a lying browser gains nothing by it.

For a multi-field card the single-field descriptors (`options`, `text`, `number`, `multi`, `defaultValue`) are **all** absent, per #1803's precedent. Skew directions:

| Skew | Result |
| --- | --- |
| new daemon → old relay/browser | `fields` stripped or ignored; card shows nothing to pick and only Dismiss. Unanswerable, never half-answered — and `decline` is what the agent got before this change anyway. |
| old daemon → new browser | No `fields`; the console takes exactly the old branch. |
| new browser → old relay or old daemon | The record fails the `value` union, the whole op is refused, card stays live. Not read as `null`, which is the Dismiss-the-user-never-sent failure a sibling field would have invited. |
| single-field form | Byte-identical payload to today — asserted by a test that deep-equals the streamed event. |

The inbound `value` union is widened again rather than gaining a sibling, following #1801 and #1803.

## The whole record is re-validated

The form is re-derived from the card's own `params` at answer time, mirroring how the single-field target already is. A form card is answered by a record and nothing else; every other card only by a scalar or list. Then: exactly the rendered propName set (no extras, no misspellings), every `required` name present, **an omitted optional field allowed** — that is legal per the schema and is precisely why #1795's rule had to be narrow — and each value valid under its own field's existing accept function. One bad field refuses the whole record and leaves the card live. The DM path rejects a record as it already rejects lists and numbers.

Content is the typed record: option strings become real booleans, numbers real numbers.

## Settled label

`Base branch: develop · force: No · retries: 4` — each answered field as `label: answer` in the card's own words, clamped to 200 characters. Naming the fields is what keeps the thread of what was agreed; bare values would be unreadable and "Answered" loses it. Per-value labelling reuses the existing helper rather than adding a second rule.

## Known limits

- An optional multi-select with nothing picked is omitted from the record, while a *required* one with `minItems: 0` still sends `[]`. Both are legal; the distinction is a UI convention.
- A boolean answers with its option string inside the record too, keeping one spelling per kind, so the record's value union looks like it should include `boolean` and does not.

## A pre-existing test changed on purpose

`daemon-permission-autoallow.test.ts`'s "declines a form no surface can render" used `required: ['branch','note']` with a plain-string `note` — a form this PR makes legitimately answerable. It now points at a genuinely unrenderable required property (`{type:'object'}`). The old assertion was load-bearing documentation of a limit this change removes.

## Verification

- protocol 486, relay 644, web 2391, daemon (`render` / `daemon-permission-autoallow` / `daemon-webchat` / `approval-dm`) 306 — all passing, independently re-run.
- `pnpm typecheck`: `error TS` count 0 (it covers tests).
- eslint + prettier clean on the 15 changed files.

Every new guard test was confirmed red without its fix by reverting only the source file and keeping the test — across the daemon coordinator, `render.ts`, the console view, the relay parser and both protocol frames.
