### PR TITLE
feat(console): webchat consents to URL-mode elicitations

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -557,13 +557,19 @@ export class AcpHost {
        *  immutable snapshots; failures/mutation attempts cannot change the policy. */
       onPermissionEvent?: (sessionId: string, params: RequestPermissionRequest, event: AcpPermissionPolicyEvent) => void
       /**
-       * Structured-input policy for ACP `elicitation/create` (form mode). When set, the
+       * Structured-input policy for ACP `elicitation/create` (form and url mode). When set, the
        * daemon renders the form to the user (e.g. a Slack select/buttons card) and
        * resolves with their choice. Omitted / throwing / returning undefined falls back
        * to declining the elicitation — the spec has agents handle `decline` — so a
        * platform with no interactive surface, or an unrenderable form, never hangs.
        */
       onElicit?: (sessionId: string, params: CreateElicitationRequest) => Promise<CreateElicitationResponse | undefined>
+      /**
+       * ACP `elicitation/complete` — the agent reporting that a URL-mode flow finished. It
+       * carries only an `elicitationId` (no sessionId), so the consumer keys off that alone,
+       * and it is advisory: it may never arrive, and one for an unknown id is ignored.
+       */
+      onElicitComplete?: (elicitationId: string) => void
       /**
        * Raw Claude SDK lifecycle messages, forwarded by claude-agent-acp ≥ 0.59.0 as
        * the `_claude/sdkMessage` ext-notification (opt-in via `emitRawSDKMessages`, see
@@ -744,6 +750,18 @@ export class AcpHost {
         }
         return { action: 'decline' }
       })
+      .onNotification(methods.client.elicitation.complete, (ctx) => {
+        // Advisory settlement for a URL-mode elicitation the user already consented to; the
+        // ACP request resolved at consent, so nothing is waiting on this.
+        const id = ctx.params?.elicitationId
+        if (typeof id === 'string' && id && self.opts.onElicitComplete) {
+          try {
+            self.opts.onElicitComplete(id)
+          } catch (err) {
+            self.opts.log?.debug(`acp: onElicitComplete failed: ${(err as Error).message}`)
+          }
+        }
+      })
       // Claude SDK lifecycle feed (claude-agent-acp ≥ 0.59.0). Params are
       // `{ sessionId, message }`; the message is passed through untyped and parsed
       // defensively by the consumer. Parser is a passthrough — validation lives in
@@ -763,9 +781,11 @@ export class AcpHost {
       clientCapabilities: {
         fs: { readTextFile: false, writeTextFile: false },
         // Advertise form-based elicitation so runtimes may ask structured questions
-        // (choice/boolean). Unrenderable forms / non-interactive platforms are declined
-        // gracefully by the onElicit fallback above.
-        elicitation: { form: {} }
+        // (choice/boolean), and URL-based so credential/OAuth/payment flows take the seam the
+        // spec reserves for them instead of a form that would carry the secret through chat.
+        // Unrenderable forms and surfaces without a consent card are declined gracefully by
+        // the onElicit fallback above.
+        elicitation: { form: {}, url: {} }
       }
     })
     this.negotiatedProtocolVersion = init.protocolVersion

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -4510,6 +4510,7 @@ export class Daemon {
           }
         : {}),
       onElicit: (sid, params) => this.permissions.onAcpElicit(opts.hostKey, sid, params),
+      onElicitComplete: (elicitationId) => this.permissions.onAcpElicitComplete(opts.hostKey, elicitationId),
       onSdkLifecycle: (sid, message) => this.onSdkLifecycle(opts.hostKey, sid, message),
       // Pairs the runtime's terminal exit with the ordinary rebuild — see reapTerminalHost.
       onTerminal: () => this.reapTerminalHost(opts.hostKey, constructed.host),

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -208,7 +208,7 @@ const CONSENTED_URL_ELICIT_CAP = 64
 /** `elicitation/complete` carries no session, so a consented card is keyed by its ACP id within
  *  the agent host that raised it — two agents may hold the same id concurrently. */
 function consentedUrlKey(owner: HostKey, elicitationId: string): string {
-  return `${owner} ${elicitationId}`
+  return `${owner}\x00${elicitationId}`
 }
 
 /** One outstanding `elicitation/create` awaiting a human answer. */
@@ -325,7 +325,7 @@ export class PermissionCoordinator {
   // ── Interactive elicitations (ACP elicitation/create, form + url mode) ──────
   private elicitSeq = 0
   private pendingElicits = new Map<string, PendingElicit>()
-  /** URL-mode cards already consented to, keyed by `<owner> <elicitationId>` and awaiting
+  /** URL-mode cards already consented to, keyed by `<owner>\x00<elicitationId>` and awaiting
    *  an `elicitation/complete` that may never come — their ACP request resolved at consent, so
    *  these hold only the webchat coordinates the "Completed" re-label is emitted on. Bounded:
    *  an agent that never completes its flows must not grow this without limit. */

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -38,6 +38,7 @@ import {
   elicitFormContent,
   elicitRequiredProps,
   elicitTarget,
+  elicitUrl,
   multiSelectAccepts,
   numberAccepts,
   SLACK_ELICIT_KINDS,
@@ -201,6 +202,15 @@ function elicitCardDescriptors(t: ElicitTarget): ElicitCardDescriptors {
   }
 }
 
+/** How many consented URL elicitations wait for an `elicitation/complete` that may never come. */
+const CONSENTED_URL_ELICIT_CAP = 64
+
+/** `elicitation/complete` carries no session, so a consented card is keyed by its ACP id within
+ *  the agent host that raised it — two agents may hold the same id concurrently. */
+function consentedUrlKey(owner: HostKey, elicitationId: string): string {
+  return `${owner} ${elicitationId}`
+}
+
 /** One outstanding `elicitation/create` awaiting a human answer. */
 type PendingElicit = PendingElicitSurface & {
   owner: HostKey
@@ -212,6 +222,10 @@ type PendingElicit = PendingElicitSurface & {
   /** Set only for a MULTI-field webchat form card — the fields it rendered, in schema order.
    *  Absent ⇒ the single-field card, answered by a scalar or a list as it always was. */
   form?: ElicitTarget[]
+  /** Set only for a URL-mode consent card: the ACP `elicitationId` and the exact URL shown.
+   *  Present ⇒ `propName`/`kind`/`form` mean nothing — the card has no field, and its only
+   *  answers are consent (this same URL back) or Dismiss. */
+  url?: { elicitationId: string; url: string }
   approval: boolean
   resolve: (res: CreateElicitationResponse) => void
 }
@@ -308,9 +322,17 @@ export class PermissionCoordinator {
    * single terminal event emitted by AcpHost's policy observer. */
   private readonly permissionEvaluationDetails = new WeakMap<RequestPermissionRequest, Record<string, unknown>>()
 
-  // ── Interactive elicitations (ACP elicitation/create, form mode) ─────────────
+  // ── Interactive elicitations (ACP elicitation/create, form + url mode) ──────
   private elicitSeq = 0
   private pendingElicits = new Map<string, PendingElicit>()
+  /** URL-mode cards already consented to, keyed by `<owner> <elicitationId>` and awaiting
+   *  an `elicitation/complete` that may never come — their ACP request resolved at consent, so
+   *  these hold only the webchat coordinates the "Completed" re-label is emitted on. Bounded:
+   *  an agent that never completes its flows must not grow this without limit. */
+  private readonly consentedUrlElicits = new Map<
+    string,
+    { requestId: string; rec: Extract<PendingElicit, { surface: 'webchat' }> }
+  >()
 
   /** Sessions the CP currently believes are waiting, keyed by `pendingTurnKey` — emit only on a change. */
   private readonly awaitingApproval = new Map<string, { owner: HostKey; agentId: string; sessionId: string }>()
@@ -1350,9 +1372,16 @@ export class PermissionCoordinator {
     // this line — it took the editor queue above, since chat approval needs Slack — and the
     // `!isApproval` guard keeps that true if the branches above ever move. A continuation
     // mirrors an origin platform, so it keeps falling through to the Slack path.
+    // URL mode is the seam the spec reserves for credentials, OAuth and payment — the page must
+    // stay out of the model's context and off every card, so only a surface that can render the
+    // consent card takes it and every other one declines (elicitTarget is null for it anyway).
+    const url = elicitUrl(params)
     if (p.webchat && !p.webchat.continuation && !isApproval) {
-      return await this.awaitWebchatElicitation(agentId, sessionId, params, p, p.webchat)
+      return url
+        ? await this.awaitWebchatUrlElicitation(agentId, sessionId, params, p, p.webchat, url)
+        : await this.awaitWebchatElicitation(agentId, sessionId, params, p, p.webchat)
     }
+    if (params.mode === 'url') return undefined
     const conn = p.conn
     if (!turnChromeFor(p.plan.platform).chatInputCards || !(conn instanceof SlackConnection)) return undefined
     const target = elicitTarget(params, SLACK_ELICIT_KINDS)
@@ -1501,12 +1530,116 @@ export class PermissionCoordinator {
     return await result
   }
 
+  /** URL mode's peer of {@link awaitWebchatElicitation}: stream a CONSENT card carrying the
+   *  exact URL and park the resolver until the reader consents or dismisses. The daemon never
+   *  fetches the URL and never sees the page — the browser opens it in a tab of its own — so
+   *  the only thing this seam decides is whether the user agreed to go there. */
+  private async awaitWebchatUrlElicitation(
+    agentId: string,
+    sessionId: string,
+    params: CreateElicitationRequest,
+    p: Pending,
+    wc: NonNullable<Pending['webchat']>,
+    url: { elicitationId: string; url: string }
+  ): Promise<CreateElicitationResponse | undefined> {
+    const requestId = `elicit-${++this.elicitSeq}`
+    const message = (params as { message?: string }).message?.trim() || 'The agent needs you to open a link'
+    let resolveResult!: (res: CreateElicitationResponse) => void
+    const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
+    this.pendingElicits.set(requestId, {
+      owner: p.hostKey,
+      agentId,
+      sessionId,
+      params,
+      // A URL card has no field; these are the record's unused shape, never read on this path.
+      propName: '',
+      kind: 'text',
+      url,
+      approval: false,
+      surface: 'webchat',
+      wc,
+      resolve: resolveResult
+    })
+    this.syncApprovalActivity(p.hostKey, sessionId)
+    try {
+      wc.sink.output({
+        conversationId: wc.conversationId,
+        turnId: wc.turnId,
+        index: wc.index++,
+        // No options and no field descriptors: a reader that does not know `url` gets a card it
+        // can only Dismiss, which is the spec's `decline` — never an accidental consent.
+        event: { kind: 'elicitation', requestId, message, options: [], url: url.url }
+      })
+    } catch (err) {
+      this.pendingElicits.delete(requestId)
+      this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
+      this.host.log().warn(`webchat consent card not delivered for "${p.plan.sessionKey}": ${formatErr(err)}`)
+      return undefined
+    }
+    return await result
+  }
+
+  /** Settle a URL-mode consent card. `accept` means only that the user agreed to OPEN the URL —
+   *  not that whatever happens on that page finished — so the ACP request resolves right here
+   *  and any later `elicitation/complete` is a re-label, not a second resolution. Dismiss is the
+   *  spec's explicit `decline`; the turn ending is `cancel`, via releaseElicits. */
+  private async handleUrlElicitConsent(
+    requestId: string,
+    rec: PendingElicit & { url: NonNullable<PendingElicit['url']> },
+    a: { value: ElicitAnswer; webchatConversationId?: string }
+  ): Promise<void> {
+    // A consent card lives only on webchat, and only the conversation it was shown in answers it.
+    if (rec.surface !== 'webchat') return
+    if (a.webchatConversationId === undefined || rec.wc.conversationId !== a.webchatConversationId) return
+    // Consent echoes the card's own URL back: the only value this card offers, checked the way
+    // every other card checks that an answer was one it actually rendered.
+    const consented = a.value === rec.url.url
+    if (!consented && a.value !== null) return
+    this.pendingElicits.delete(requestId)
+    this.syncApprovalActivity(rec.owner, rec.sessionId, { id: requestId, allowed: consented })
+    this.emitWebchatElicitResolved(
+      rec,
+      requestId,
+      consented ? 'accepted' : 'dismissed',
+      consented ? 'Opened' : undefined
+    )
+    if (consented) this.rememberConsentedUrlElicit(requestId, rec)
+    rec.resolve({ action: consented ? 'accept' : 'decline' })
+  }
+
+  /** Park a consented card's coordinates so a later `elicitation/complete` can find it. Oldest
+   *  out at the cap — a flow that never completes must not pin this map open forever. */
+  private rememberConsentedUrlElicit(
+    requestId: string,
+    rec: Extract<PendingElicit, { surface: 'webchat' }> & { url: NonNullable<PendingElicit['url']> }
+  ): void {
+    while (this.consentedUrlElicits.size >= CONSENTED_URL_ELICIT_CAP) {
+      const oldest = this.consentedUrlElicits.keys().next().value
+      if (oldest === undefined) break
+      this.consentedUrlElicits.delete(oldest)
+    }
+    this.consentedUrlElicits.set(consentedUrlKey(rec.owner, rec.url.elicitationId), { requestId, rec })
+  }
+
+  /** ACP `elicitation/complete` (wired as AcpHost.onElicitComplete): re-label the already
+   *  settled consent card as Completed. The notification carries no session, so it is keyed by
+   *  `elicitationId` within the agent host that sent it. An unknown id — never consented, from
+   *  another agent, or already completed — is ignored, which is also what makes this safe to
+   *  never receive at all. */
+  onAcpElicitComplete(owner: HostKey, elicitationId: string): void {
+    const key = consentedUrlKey(owner, elicitationId)
+    const hit = this.consentedUrlElicits.get(key)
+    if (!hit) return
+    this.consentedUrlElicits.delete(key)
+    this.emitWebchatElicitResolved(hit.rec, hit.requestId, 'completed')
+  }
+
   /** Append the settled card to a webchat stream — the append-only equivalent of Slack
    *  rewriting its message. Best effort: the ACP resolution never depends on it. */
   private emitWebchatElicitResolved(
     rec: Extract<PendingElicit, { surface: 'webchat' }>,
     requestId: string,
-    outcome: 'accepted' | 'dismissed' | 'cancelled',
+    outcome: 'accepted' | 'dismissed' | 'cancelled' | 'completed',
     label?: string
   ): void {
     try {
@@ -1552,6 +1685,8 @@ export class PermissionCoordinator {
     }
     const rec = this.pendingElicits.get(a.requestId)
     if (!rec) return
+    // A URL consent card has no field to validate — it takes its own URL back, or Dismiss.
+    if (rec.url) return await this.handleUrlElicitConsent(a.requestId, { ...rec, url: rec.url }, a)
     // A FORM card is answered by a record and nothing else, and every other card by a scalar
     // or a list — re-derived from the card's own params, exactly as `target` is below.
     const form = rec.form ? elicitForm(rec.params, surfaceKinds(rec)) : null

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -911,6 +911,26 @@ function elicitCandidates(params: CreateElicitationRequest, renderable: ElicitSu
   return found
 }
 
+/** The elicitation's URL-mode target (ACP `ElicitationUrlMode`), or null when this is not a
+ *  URL-mode ask. Only `http`/`https` survive: every other scheme — `javascript:`, `data:`,
+ *  `file:` — is something a consent card must never hand a browser as an href, and the caller
+ *  declines instead. The URL is returned VERBATIM, never re-serialized, because the reader has
+ *  to examine the same bytes the agent asked for. Pure. */
+export function elicitUrl(params: CreateElicitationRequest): { elicitationId: string; url: string } | null {
+  const p = params as { mode?: string; url?: unknown; elicitationId?: unknown }
+  if (p.mode !== 'url') return null
+  if (typeof p.url !== 'string' || typeof p.elicitationId !== 'string' || !p.elicitationId) return null
+  if (p.url.length > 2048) return null
+  let parsed: URL
+  try {
+    parsed = new URL(p.url)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null
+  return { elicitationId: p.elicitationId, url: p.url }
+}
+
 /**
  * Resolve the single form field an elicitation card renders: the FIRST renderable property
  * that ALONE satisfies the schema's `required`. Returns null for URL-mode, an empty/absent
@@ -1021,6 +1041,22 @@ export function numberAccepts(target: ElicitTarget, value: number): boolean {
   return target.maximum === undefined || value <= target.maximum
 }
 
+const BARE_URL_RE = /(?:https?:\/\/|www\.)\S+/gi
+
+/** The agent-authored elicitation `message`, with every link in it defused. A form-mode ask
+ *  may not send the reader anywhere — the spec keeps URLs on URL-mode elicitations, whose
+ *  consent card is the only place a URL is ever followable — and Slack turns both bare URLs
+ *  and `<url|label>` into taps, so the angle-bracket form is escaped and the bare form is
+ *  wrapped in a code span, which Slack mrkdwn does not autolink. Pure. */
+function elicitCardMessage(params: CreateElicitationRequest): string {
+  const raw = (params as { message?: string }).message?.trim() || 'The agent needs your input'
+  return raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(BARE_URL_RE, (m) => `\`${m}\``)
+}
+
 /**
  * Build the interactive elicitation card: the agent's `message`, an optional field title,
  * and an actions row of option buttons (one per {@link elicitTarget} option, capped at 5)
@@ -1035,7 +1071,7 @@ export function buildElicitationCard(
 ): unknown[] | null {
   const target = elicitTarget(params, SLACK_ELICIT_KINDS)
   if (!target) return null
-  const message = (params as { message?: string }).message?.trim() || 'The agent needs your input'
+  const message = elicitCardMessage(params)
   const buttons = target.options.slice(0, 5).map((o, i) => ({
     type: 'button',
     action_id: `${ELICIT_ACTION_PREFIX}:${i}`,
@@ -1057,7 +1093,7 @@ export function buildElicitationCard(
 /** Build the RESOLVED elicitation card (buttons removed) that replaces {@link
  *  buildElicitationCard} once answered, dismissed, or cancelled. Pure. */
 export function buildElicitationResolvedCard(params: CreateElicitationRequest, decision: string): unknown[] {
-  const message = (params as { message?: string }).message?.trim() || 'The agent needs your input'
+  const message = elicitCardMessage(params)
   return [{ type: 'section', text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(message, 400)}\n${decision}` } }]
 }
 

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs'
@@ -691,4 +691,75 @@ describe('AcpHost.stop', () => {
     },
     15_000
   )
+})
+
+// URL-mode elicitation (issue #1794 gap 4). The daemon is an ACP *client*: it answers
+// `elicitation/create` and receives `elicitation/complete`, and never raises either.
+describe('AcpHost elicitation capabilities', () => {
+  it('advertises both form and url elicitation, so a runtime may pick the URL seam', async () => {
+    const chunks: string[] = []
+    const host = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: [{ name: 'AC_ECHO_CLIENT_CAPS', value: '1' }] },
+      {
+        onUpdate: (_sid, update) => {
+          const c = (update as any).content
+          if ((update as any).sessionUpdate === 'agent_message_chunk' && c?.type === 'text') chunks.push(c.text)
+        }
+      }
+    )
+    await host.start()
+    const sessionId = await host.newSession('/tmp')
+    await host.prompt(sessionId, [{ type: 'text', text: 'hi' }])
+    // Without `url` here a runtime cannot use the seam the spec reserves for credentials.
+    expect(JSON.parse(chunks[0]!).elicitation).toEqual({ form: {}, url: {} })
+    await host.stop()
+  })
+
+  it('routes a URL elicitation to the policy and reports its completion by id alone', async () => {
+    const completed: string[] = []
+    const chunks: string[] = []
+    let seen: any
+    const host = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: [{ name: 'AC_ELICIT_URL', value: '1' }] },
+      {
+        onUpdate: (_sid, update) => {
+          const c = (update as any).content
+          if ((update as any).sessionUpdate === 'agent_message_chunk' && c?.type === 'text') chunks.push(c.text)
+        },
+        onElicit: async (_sid, params) => {
+          seen = params
+          return { action: 'accept' }
+        },
+        onElicitComplete: (elicitationId) => completed.push(elicitationId)
+      }
+    )
+    await host.start()
+    const sessionId = await host.newSession('/tmp')
+    await host.prompt(sessionId, [{ type: 'text', text: 'hi' }])
+    expect(seen).toMatchObject({ mode: 'url', elicitationId: 'el-fixture', url: 'https://example.test/authorize' })
+    expect(chunks).toContain('elicited:accept')
+    // The notification carries no session — only the elicitation id it settles. It rides the
+    // same stream as the prompt result and is dispatched independently of it, so wait rather
+    // than assume the turn's resolution ordered it.
+    await vi.waitFor(() => expect(completed).toEqual(['el-fixture']))
+    await host.stop()
+  })
+
+  it('declines a URL elicitation when no policy is wired, rather than hanging the turn', async () => {
+    const chunks: string[] = []
+    const host = new AcpHost(
+      { command: process.execPath, args: [fakeAgent], env: [{ name: 'AC_ELICIT_URL', value: '1' }] },
+      {
+        onUpdate: (_sid, update) => {
+          const c = (update as any).content
+          if ((update as any).sessionUpdate === 'agent_message_chunk' && c?.type === 'text') chunks.push(c.text)
+        }
+      }
+    )
+    await host.start()
+    const sessionId = await host.newSession('/tmp')
+    await host.prompt(sessionId, [{ type: 'text', text: 'hi' }])
+    await vi.waitFor(() => expect(chunks).toContain('elicited:decline'))
+    await host.stop()
+  })
 })

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -1156,3 +1156,159 @@ describe('webchat answers a multi-field elicitation form with a record', () => {
     await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
   })
 })
+
+// ── URL-mode elicitation (issue #1794 gap 4) ─────────────────────────────────
+// The seam the spec reserves for credentials, OAuth and payment: `accept` means only that the
+// user consented to OPEN the URL, never that the flow behind it finished, and the page itself
+// never reaches the daemon, the card, or the model.
+
+/** A URL-mode elicitation (ACP `ElicitationUrlMode`). */
+function urlElicitation(overrides: Record<string, unknown> = {}): CreateElicitationRequest {
+  return {
+    sessionId: 's1',
+    mode: 'url',
+    elicitationId: 'el-1',
+    url: 'https://billing.example.com/oauth/authorize?state=xyz',
+    message: 'Sign in to the billing provider to continue',
+    ...overrides
+  } as CreateElicitationRequest
+}
+
+describe('webchat renders and settles a URL-mode consent card', () => {
+  it('streams the exact URL, resolves accept on consent, and never carries a form field', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    // No options and no field descriptors: a reader that does not know `url` can only Dismiss.
+    expect(cardEvents(sink)[0]).toEqual({
+      kind: 'elicitation',
+      requestId: expect.any(String),
+      message: 'Sign in to the billing provider to continue',
+      options: [],
+      url: 'https://billing.example.com/oauth/authorize?state=xyz'
+    })
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'https://billing.example.com/oauth/authorize?state=xyz',
+      webchatConversationId: 'conv-1'
+    })
+    // Consent resolves the ACP request — with no `content`, since nothing was answered here.
+    await expect(result).resolves.toEqual({ action: 'accept' })
+    expect(cardEvents(sink)[1]).toEqual({
+      kind: 'elicitation_resolved',
+      requestId,
+      outcome: 'accepted',
+      label: 'Opened'
+    })
+  })
+
+  it('refuses a value the card never offered, and declines only on an explicit dismissal', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    // A browser frame is not what makes consent valid: only the card's own URL is consent.
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'https://billing.example.com.evil.test/oauth/authorize?state=xyz',
+      webchatConversationId: 'conv-1'
+    })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    // And another conversation cannot consent on this one's behalf.
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'https://billing.example.com/oauth/authorize?state=xyz',
+      webchatConversationId: 'conv-2'
+    })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: null, webchatConversationId: 'conv-1' })
+    await expect(result).resolves.toEqual({ action: 'decline' })
+  })
+
+  it('cancels rather than declines when the turn ends under a live consent card', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
+    await expect(result).resolves.toEqual({ action: 'cancel' })
+    expect(cardEvents(sink).at(-1)).toEqual(expect.objectContaining({ outcome: 'cancelled' }))
+  })
+
+  it('settles the consented card on elicitation/complete, and ignores an id it does not hold', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+
+    void (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'https://billing.example.com/oauth/authorize?state=xyz',
+      webchatConversationId: 'conv-1'
+    })
+
+    // An id never consented to — and one from another agent host — settles nothing.
+    ;(daemon as any).permissions.onAcpElicitComplete('agent-1', 'el-nope')
+    ;(daemon as any).permissions.onAcpElicitComplete('agent-2', 'el-1')
+    expect(cardEvents(sink)).toHaveLength(2)
+
+    ;(daemon as any).permissions.onAcpElicitComplete('agent-1', 'el-1')
+    expect(cardEvents(sink)[2]).toEqual({ kind: 'elicitation_resolved', requestId, outcome: 'completed' })
+    // The notification is advisory and arrives at most once: a repeat is ignored.
+    ;(daemon as any).permissions.onAcpElicitComplete('agent-1', 'el-1')
+    expect(cardEvents(sink)).toHaveLength(3)
+  })
+
+  it('declines a URL a browser tab must never be handed, and one on a form-only surface', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    installWebchat(pending)
+
+    for (const url of ['javascript:alert(1)', 'file:///etc/passwd', 'not a url'])
+      await expect(
+        (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation({ url }))
+      ).resolves.toBeUndefined()
+    // An elicitationId is what a completion notification is keyed by; without one there is
+    // nothing to consent to either.
+    await expect(
+      (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation({ elicitationId: '' }))
+    ).resolves.toBeUndefined()
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+
+    // And a surface with no consent card keeps declining — Slack gains none here.
+    const slack: any = installPending(daemon)
+    slack.plan.platform = 'slack'
+    await expect((daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())).resolves.toBeUndefined()
+  })
+
+  it('masks an agent secret embedded in the URL before the card carries it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const pending: any = installPending(daemon)
+    const sink = installWebchat(pending)
+    ;(daemon as any).agents = new Map([
+      ['agent-1', { id: 'agent-1', runtimeOverrides: { secrets: [{ name: 'TOKEN', value: 'sk-live-DEADBEEF' }] } }]
+    ])
+
+    void (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      urlElicitation({ url: 'https://billing.example.com/pay?token=sk-live-DEADBEEF' })
+    )
+    await vi.waitFor(() => expect(cardEvents(sink)).toHaveLength(1))
+    expect(cardEvents(sink)[0].url).not.toContain('sk-live-DEADBEEF')
+  })
+})

--- a/packages/daemon/test/fixtures/fake-acp-agent.mjs
+++ b/packages/daemon/test/fixtures/fake-acp-agent.mjs
@@ -105,11 +105,34 @@ const configOptions = (sessionId) => {
   return options.length ? options : undefined
 }
 
+let clientCapabilities
+let requestCounter = 1000
+let pendingElicit
 rl.on('line', async (line) => {
   if (!line.trim()) return
   const msg = JSON.parse(line)
   const { id, method, params } = msg
+  // The client's answer to our elicitation/create: report the flow complete, then end the turn.
+  if (method === undefined && pendingElicit && msg.result?.action !== undefined) {
+    const { promptId, sessionId } = pendingElicit
+    pendingElicit = undefined
+    send({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {
+        sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: `elicited:${msg.result.action}` }
+        }
+      }
+    })
+    send({ jsonrpc: '2.0', method: 'elicitation/complete', params: { elicitationId: 'el-fixture' } })
+    send({ jsonrpc: '2.0', id: promptId, result: { stopReason: 'end_turn' } })
+    return
+  }
   if (method === 'initialize') {
+    clientCapabilities = params?.clientCapabilities
     send({ jsonrpc: '2.0', id, result: { protocolVersion: 1, agentCapabilities: agentCapabilities() } })
   } else if (method === 'session/new') {
     if (!acceptsAdditionalDirectories(id, params)) return
@@ -154,6 +177,39 @@ rl.on('line', async (line) => {
     send({ jsonrpc: '2.0', id, result: {} })
   } else if (method === 'session/prompt') {
     const text = (params.prompt ?? []).map((b) => b.text ?? '').join('')
+    // `AC_ECHO_CLIENT_CAPS=1` replies with what the client advertised at initialize, which is
+    // the only way a test sees the capability declaration from the agent's own side.
+    if (process.env.AC_ECHO_CLIENT_CAPS === '1') {
+      send({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: JSON.stringify(clientCapabilities) }
+          }
+        }
+      })
+    }
+    // `AC_ELICIT_URL=1` runs one URL-mode elicitation and reports it complete afterwards.
+    if (process.env.AC_ELICIT_URL === '1') {
+      const elicitId = ++requestCounter
+      pendingElicit = { promptId: id, sessionId: params.sessionId }
+      send({
+        jsonrpc: '2.0',
+        id: elicitId,
+        method: 'elicitation/create',
+        params: {
+          sessionId: params.sessionId,
+          mode: 'url',
+          elicitationId: 'el-fixture',
+          url: 'https://example.test/authorize',
+          message: 'Open the login page'
+        }
+      })
+      return
+    }
     // send a session/update notification to the client
     send({
       jsonrpc: '2.0',

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -23,6 +23,7 @@ import {
   elicitFormContent,
   elicitRequiredProps,
   elicitTarget,
+  elicitUrl,
   SLACK_ELICIT_KINDS,
   WEBCHAT_ELICIT_KINDS,
   multiSelectAccepts,
@@ -1980,5 +1981,69 @@ describe('elicitation card', () => {
     const blocks = buildElicitationResolvedCard(form({ ok: { type: 'boolean' } }), ':white_check_mark: Yes')
     expect(blocks).toHaveLength(1)
     expect((blocks[0] as any).text.text).toContain(':white_check_mark: Yes')
+  })
+})
+
+// URL-mode elicitation (issue #1794 gap 4).
+describe('elicitUrl', () => {
+  const urlReq = (overrides: Record<string, unknown> = {}) =>
+    ({
+      mode: 'url',
+      sessionId: 's1',
+      message: 'Sign in',
+      elicitationId: 'el-1',
+      url: 'https://x.test/a',
+      ...overrides
+    }) as any
+
+  it('reads the id and the URL verbatim, never a re-serialized spelling of it', () => {
+    // A trailing dot and an upper-case host are exactly what a lookalike hides behind, so the
+    // reader has to be shown the bytes the agent asked for, not the parser's cleanup of them.
+    const req = urlReq({ url: 'https://Login.Example.test./a?b=1' })
+    expect(elicitUrl(req)).toEqual({ elicitationId: 'el-1', url: 'https://Login.Example.test./a?b=1' })
+  })
+
+  it('refuses anything a browser tab must never be handed, and any non-URL ask', () => {
+    for (const url of ['javascript:alert(1)', 'data:text/html,x', 'file:///etc/passwd', 'mailto:a@b.c', 'nope'])
+      expect(elicitUrl(urlReq({ url }))).toBeNull()
+    expect(elicitUrl(urlReq({ url: `https://x.test/${'a'.repeat(2100)}` }))).toBeNull()
+    // A completion notification is keyed by the id alone; without one there is nothing to settle.
+    expect(elicitUrl(urlReq({ elicitationId: '' }))).toBeNull()
+    expect(elicitUrl(urlReq({ elicitationId: undefined }))).toBeNull()
+    // And a form-mode ask is never a URL ask, whatever else it carries.
+    expect(elicitUrl({ mode: 'form', message: 'x', url: 'https://x.test/a' } as any)).toBeNull()
+  })
+
+  it('takes http as well as https — the card calls the missing encryption out instead', () => {
+    expect(elicitUrl(urlReq({ url: 'http://x.test/a' }))?.url).toBe('http://x.test/a')
+  })
+})
+
+describe('a FORM-mode elicitation card never renders a URL as clickable', () => {
+  const askWith = (message: string) =>
+    ({
+      mode: 'form',
+      sessionId: 's1',
+      message,
+      requestedSchema: { type: 'object', properties: { ok: { type: 'boolean' } } }
+    }) as any
+  const cardText = (message: string) => (buildElicitationCard('r1', askWith(message))![0] as any).text.text
+
+  it('defuses a bare URL, which Slack would otherwise autolink', () => {
+    const text = cardText('Paste the token from https://evil.test/steal')
+    // Still readable in full — it just is not something to tap.
+    expect(text).toContain('https://evil.test/steal')
+    expect(text).toContain('`https://evil.test/steal`')
+  })
+
+  it('defuses Slack’s own link syntax, label and all', () => {
+    const text = cardText('Click <https://evil.test/steal|here> to continue')
+    expect(text).not.toContain('<https://evil.test/steal|here>')
+    expect(text).toContain('&lt;')
+  })
+
+  it('defuses the same URL on the settled card, which outlives the buttons', () => {
+    const blocks = buildElicitationResolvedCard(askWith('See https://evil.test/steal'), ':white_check_mark: Yes')
+    expect((blocks[0] as any).text.text).toContain('`https://evil.test/steal`')
   })
 })

--- a/packages/protocol/src/frames/webchat.test.ts
+++ b/packages/protocol/src/frames/webchat.test.ts
@@ -86,6 +86,43 @@ describe('WebchatOutput — event / status framing', () => {
     }
   })
 
+  it('carries a URL-mode consent card, and its completion as a fourth outcome', () => {
+    const card = WebchatOutput.safeParse({
+      conversationId: CONV,
+      turnId: TURN,
+      index: 4,
+      event: {
+        kind: 'elicitation',
+        requestId: 'elicit-9',
+        message: 'Sign in to continue',
+        // No options and no field descriptors — the card is the URL.
+        options: [],
+        url: 'https://billing.example.test/oauth/authorize?state=xyz'
+      }
+    })
+    expect(card.success).toBe(true)
+    if (card.success && card.data.event?.kind === 'elicitation')
+      expect(card.data.event.url).toBe('https://billing.example.test/oauth/authorize?state=xyz')
+    // 'completed' re-labels an already-consented card; the three original outcomes are untouched.
+    expect(
+      WebchatOutput.safeParse({
+        conversationId: CONV,
+        turnId: TURN,
+        index: 5,
+        event: { kind: 'elicitation_resolved', requestId: 'elicit-9', outcome: 'completed' }
+      }).success
+    ).toBe(true)
+    // A form card written before this field still decodes to exactly what it always meant.
+    const form = WebchatOutput.safeParse({
+      conversationId: CONV,
+      turnId: TURN,
+      index: 6,
+      event: { kind: 'elicitation', requestId: 'elicit-1', message: 'Pick', options: [{ value: 'a', label: 'a' }] }
+    })
+    expect(form.success).toBe(true)
+    if (form.success && form.data.event?.kind === 'elicitation') expect(form.data.event.url).toBeUndefined()
+  })
+
   it('marks a multi-select card with its bounds, and leaves the single-choice card untouched', () => {
     const card = (event: Record<string, unknown>) =>
       WebchatOutput.safeParse({ conversationId: CONV, turnId: TURN, index: 4, event })

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -199,7 +199,7 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   // only after the fact. There is no relay capability echo to gate on (`rd/hello/ok` carries
   // only `relayId`), so this is the tradeoff rather than an oversight.
   z.object({ kind: z.literal('plan'), entries: z.array(PlanEntry) }),
-  // The agent asked for a choice (ACP `elicitation/create`, form mode) — webchat's own
+  // The agent asked for a choice (ACP `elicitation/create`, form or url mode) — webchat's own
   // in-band card, the peer of the Slack Block Kit one. Deliberately NOT the raw
   // `requestedSchema`: the daemon has already reduced the form to its renderable
   // field(s), and its options are the only answers the browser may send back (as the
@@ -234,16 +234,27 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
     // absent — deliberately, and the same closed-failure trade `text` records: an old reader
     // sees an optionless card it can only Dismiss, rather than a card it could half-fill with
     // one field's answer that the daemon would then refuse.
-    fields: z.array(ElicitField).min(2).max(ELICIT_FORM_FIELD_CAP).optional()
+    fields: z.array(ElicitField).min(2).max(ELICIT_FORM_FIELD_CAP).optional(),
+    // Present ⇒ the card is a URL-mode CONSENT card (ACP `ElicitationUrlMode`): the reader is
+    // shown this exact URL and opens it in their own browser, and nothing about the page ever
+    // returns here. `options` is then empty and every field descriptor above is absent, so the
+    // same closed skew `text` records holds — an old reader sees a card it can only Dismiss,
+    // which the daemon reads as the spec's `decline`, never as consent. Only http/https reach
+    // here; the daemon declines any other scheme rather than hand a browser an unopenable href.
+    url: z.string().min(1).max(2048).optional()
   }),
   // The same card, settled. Slack rewrites its message in place; this stream is
   // append-only, so the collapse is a second event keyed by the same `requestId`.
   // `label` is the chosen option's label — the chosen labels joined, for a multi-select —
   // and is present only on 'accepted'.
+  // 'completed' is URL mode's second settlement (ACP `elicitation/complete`): the card is
+  // already 'accepted' at consent, and this only re-labels it once the agent says the flow
+  // finished. An old reader fails THIS frame's decode and keeps showing the consented card —
+  // the losing direction is a missing "Completed" label, never a wrong verdict.
   z.object({
     kind: z.literal('elicitation_resolved'),
     requestId: z.string().min(1).max(200),
-    outcome: z.enum(['accepted', 'dismissed', 'cancelled']),
+    outcome: z.enum(['accepted', 'dismissed', 'cancelled', 'completed']),
     label: z.string().optional()
   })
 ])

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -265,11 +265,12 @@ type WebchatEvent =
       number?: { integer?: boolean; minimum?: number; maximum?: number }
       defaultValue?: string | number | boolean | string[]
       fields?: ElicitFieldSpec[]
+      url?: string
     }
   | {
       kind: 'elicitation_resolved'
       requestId: string
-      outcome: 'accepted' | 'dismissed' | 'cancelled'
+      outcome: 'accepted' | 'dismissed' | 'cancelled' | 'completed'
       label?: string
     }
 
@@ -641,7 +642,10 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
                 ...(ev.defaultValue !== undefined ? { defaultValue: ev.defaultValue } : {}),
                 // A multi-field form: the fields ARE the card, and the descriptors above are
                 // absent, so a build that does not know them shows nothing to answer with.
-                ...(ev.fields ? { fields: ev.fields } : {})
+                ...(ev.fields ? { fields: ev.fields } : {}),
+                // A URL-mode consent card. Carried through verbatim: the reader has to see the
+                // same bytes the agent asked for, so nothing here normalizes or shortens it.
+                ...(ev.url ? { url: ev.url } : {})
               },
               boundary: true
             })

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -564,3 +564,119 @@ describe('the agent’s elicitation card on the session page', () => {
     expect(buttonNamed('main')).toBeUndefined()
   })
 })
+
+// URL mode (#1794 gap 4). Credentials, OAuth and payment take this seam precisely so the page
+// never reaches the model, the card, or the Control Plane — so what is asserted here is as much
+// about what the console does NOT do as about what it renders.
+describe('the agent’s URL-mode consent card', () => {
+  const URL_CARD = {
+    ...CARD,
+    text: 'Sign in to the billing provider to continue',
+    elicit: { requestId: 'elicit-9', options: [] as { value: string; label: string }[], url: '' }
+  }
+  const urlCard = (url: string) => [{ ...URL_CARD, elicit: { ...URL_CARD.elicit, url } }]
+  const linkNamed = (label: string) =>
+    [...(container?.querySelectorAll('a') ?? [])].find((a) => a.textContent === label)
+
+  it('shows the full URL and opens it in a new tab only on an explicit click', async () => {
+    const url = 'https://billing.example.com/oauth/authorize?client_id=abc123&scope=read+write'
+    live.steps = urlCard(url)
+    await render()
+
+    // The whole URL, unshortened and unelided — there is nothing to examine otherwise.
+    expect(text()).toContain(url)
+    const open = linkNamed('Open link')
+    expect(open?.getAttribute('href')).toBe(url)
+    // A real browser tab: never an iframe or an in-app webview, and no referrer carried over.
+    expect(open?.getAttribute('target')).toBe('_blank')
+    expect(open?.getAttribute('rel')).toBe('noopener noreferrer')
+    expect(container?.querySelector('iframe')).toBeNull()
+    // Nothing has been consented to until the reader acts.
+    expect(live.answered).toEqual([])
+
+    // Cancel the default so the test runner does not actually open the tab; React's own
+    // handler still runs, which is the consent this asserts.
+    const stop = (e: Event) => e.preventDefault()
+    document.addEventListener('click', stop)
+    await act(async () => {
+      open?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+    document.removeEventListener('click', stop)
+    // Consent is the card's own URL back — the one value this card offers.
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-9', url, 'conv-1']])
+  })
+
+  it('never fetches the URL or any metadata about it', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    live.steps = urlCard('https://billing.example.com/oauth/authorize')
+    await render()
+
+    // No page fetch, no favicon, no title lookup, no preview.
+    for (const call of fetchSpy.mock.calls) expect(String(call[0])).not.toContain('billing.example.com')
+    // And no markup that would make the browser reach for it on our behalf.
+    expect(container?.querySelector('link[rel~="prefetch"], link[rel~="preload"], link[rel~="preconnect"]')).toBeNull()
+    for (const el of container?.querySelectorAll('img, script, iframe') ?? [])
+      expect(el.getAttribute('src') ?? '').not.toContain('billing.example.com')
+    fetchSpy.mockRestore()
+  })
+
+  it('flags a Punycode host, which is how a lookalike domain spells itself', async () => {
+    live.steps = urlCard('https://xn--80ak6aa92e.example-login.com/authorize')
+    await render()
+
+    expect(text()).toContain('Punycode')
+    // The full URL is still shown, and the card is still answerable — the warning is advisory.
+    expect(text()).toContain('xn--80ak6aa92e.example-login.com')
+    expect(linkNamed('Open link')).toBeDefined()
+  })
+
+  it('calls out a link that is not encrypted', async () => {
+    live.steps = urlCard('http://billing.example.com/pay')
+    await render()
+
+    expect(text()).toContain('Not encrypted (http)')
+  })
+
+  it('leaves an https host unflagged', async () => {
+    live.steps = urlCard('https://billing.example.com/pay')
+    await render()
+
+    expect(text()).not.toContain('Punycode')
+    expect(text()).not.toContain('Not encrypted')
+  })
+
+  it('offers nothing to open for a scheme a browser tab must never be handed', async () => {
+    live.steps = urlCard('javascript:alert(1)')
+    await render()
+
+    // The daemon already refuses these; the card refuses again rather than trust the wire.
+    expect(linkNamed('Open link')).toBeUndefined()
+    expect(container?.querySelector('a[href^="javascript:"]')).toBeNull()
+  })
+
+  it('reads Declined at refusal and Completed once the agent reports the flow finished', async () => {
+    live.steps = urlCard('https://billing.example.com/pay')
+    await render()
+
+    await act(async () => {
+      buttonNamed('Decline')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // An explicit refusal is a null answer, the same shape every other card dismisses with.
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-9', null, 'conv-1']])
+
+    live.steps = [{ ...URL_CARD, elicit: { ...URL_CARD.elicit, url: 'https://x.test/a', outcome: 'completed' } }]
+    await render()
+    expect(text()).toContain('Completed')
+    expect(linkNamed('Open link')).toBeUndefined()
+  })
+
+  it('renders no clickable URL for a FORM-mode elicitation that mentions one', async () => {
+    live.steps = [{ ...CARD, text: 'Paste the token from https://billing.example.com/tokens' }]
+    await render()
+
+    // Only URL mode may send the reader anywhere — a form's message is text, and stays text.
+    expect(text()).toContain('https://billing.example.com/tokens')
+    for (const a of container?.querySelectorAll('a') ?? [])
+      expect(a.getAttribute('href') ?? '').not.toContain('billing.example.com')
+  })
+})

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -624,9 +624,26 @@ describe('the agent’s URL-mode consent card', () => {
     live.steps = urlCard('https://xn--80ak6aa92e.example-login.com/authorize')
     await render()
 
-    expect(text()).toContain('Punycode')
+    expect(text()).toContain('not plain ASCII')
     // The full URL is still shown, and the card is still answerable — the warning is advisory.
     expect(text()).toContain('xn--80ak6aa92e.example-login.com')
+    expect(linkNamed('Open link')).toBeDefined()
+  })
+
+  // The parser lowercases an uppercase host and punycodes a Unicode one, so neither spelling
+  // occurs in the original string. Searching it for the normalized host found nothing and left
+  // a card with no URL and no way to consent, for requests the daemon had already accepted.
+  it('shows the URL and offers Open for hosts the parser would rewrite', async () => {
+    live.steps = urlCard('https://Billing.EXAMPLE.com/Pay?t=1')
+    await render()
+    expect(text()).toContain('Billing.EXAMPLE.com')
+    expect(linkNamed('Open link')?.getAttribute('href')).toBe('https://Billing.EXAMPLE.com/Pay?t=1')
+
+    live.steps = urlCard('https://例え.jp/authorize')
+    await render()
+    // Shown as the reader sees it, warned about as what it resolves to.
+    expect(text()).toContain('例え.jp')
+    expect(text()).toContain('not plain ASCII')
     expect(linkNamed('Open link')).toBeDefined()
   })
 
@@ -641,7 +658,7 @@ describe('the agent’s URL-mode consent card', () => {
     live.steps = urlCard('https://billing.example.com/pay')
     await render()
 
-    expect(text()).not.toContain('Punycode')
+    expect(text()).not.toContain('not plain ASCII')
     expect(text()).not.toContain('Not encrypted')
   })
 

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -667,17 +667,26 @@ function readConsentUrl(url: string): { scheme: string; host: string; rest: stri
   if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null
   // Split the ORIGINAL string, never the re-serialized one: the reader has to examine the same
   // bytes the agent asked for, down to a trailing dot or a stray case the URL parser would fix.
-  const at = url.indexOf(parsed.host, url.indexOf('//'))
-  if (at < 0) return null
+  // Split by POSITION, not by searching for `parsed.host` — the parser lowercases an uppercase
+  // host and punycodes a Unicode one, so neither occurs in the original and the search would
+  // find nothing, leaving a card with no URL and no way to consent.
+  const afterScheme = url.indexOf('//') + 2
+  const authorityEnd = url.slice(afterScheme).search(/[/?#]/)
+  const hostEnd = authorityEnd < 0 ? url.length : afterScheme + authorityEnd
   const warnings: string[] = []
   if (parsed.protocol !== 'https:')
     warnings.push('Not encrypted (http) — anything you type on that page can be read in transit.')
-  if (/(^|\.)xn--/i.test(parsed.hostname))
-    warnings.push('This host is written in Punycode (xn--), which can disguise a lookalike domain.')
+  // Both spellings of the same risk: the parser punycodes a Unicode host, so check the ORIGINAL
+  // too — the reader is looking at that, and a homograph is only a lookalike on screen.
+  const shownHost = url.slice(afterScheme, hostEnd)
+  if (/(^|\.)xn--/i.test(parsed.hostname) || /[^\x00-\x7F]/.test(shownHost))
+    warnings.push(
+      `This host is not plain ASCII (it resolves to ${parsed.hostname}), which can disguise a lookalike domain.`
+    )
   return {
-    scheme: url.slice(0, at),
-    host: url.slice(at, at + parsed.host.length),
-    rest: url.slice(at + parsed.host.length),
+    scheme: url.slice(0, afterScheme),
+    host: url.slice(afterScheme, hostEnd),
+    rest: url.slice(hostEnd),
     warnings
   }
 }

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -645,7 +645,41 @@ function PlanBlock({ step }: { step: FmtStep }) {
 const ELICIT_OUTCOME: Record<string, { icon: string; color: string; label: (answer?: string) => string }> = {
   accepted: { icon: 'check', color: 'var(--green-500)', label: (answer) => answer ?? 'Answered' },
   dismissed: { icon: 'x', color: 'var(--text-tertiary)', label: () => 'Dismissed' },
-  cancelled: { icon: 'clock', color: 'var(--text-tertiary)', label: () => 'Cancelled' }
+  cancelled: { icon: 'clock', color: 'var(--text-tertiary)', label: () => 'Cancelled' },
+  // URL mode's second settlement: the agent reported the flow behind an opened link finished.
+  completed: { icon: 'check', color: 'var(--green-500)', label: () => 'Completed' }
+}
+
+/** How a consent card reads its URL: the three display parts, so the HOST can be emphasized
+ *  against the rest, plus what to warn about. Both checks are on the host alone — a lookalike
+ *  hides there, not in the path — and both are advisory: the card still shows the full URL and
+ *  still opens only on an explicit click. Punycode (`xn--`) is the minimum ask, since it is how
+ *  a homograph host spells itself on the wire. Null ⇒ not something to hand a browser tab at
+ *  all; the daemon already refuses those, and the card refuses them again rather than trust the
+ *  wire. Pure — it parses the URL and never touches the network. */
+function readConsentUrl(url: string): { scheme: string; host: string; rest: string; warnings: string[] } | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null
+  // Split the ORIGINAL string, never the re-serialized one: the reader has to examine the same
+  // bytes the agent asked for, down to a trailing dot or a stray case the URL parser would fix.
+  const at = url.indexOf(parsed.host, url.indexOf('//'))
+  if (at < 0) return null
+  const warnings: string[] = []
+  if (parsed.protocol !== 'https:')
+    warnings.push('Not encrypted (http) — anything you type on that page can be read in transit.')
+  if (/(^|\.)xn--/i.test(parsed.hostname))
+    warnings.push('This host is written in Punycode (xn--), which can disguise a lookalike domain.')
+  return {
+    scheme: url.slice(0, at),
+    host: url.slice(at, at + parsed.host.length),
+    rest: url.slice(at + parsed.host.length),
+    warnings
+  }
 }
 
 /** What a multi-select card asks of the reader, from the schema's bounds. */
@@ -808,6 +842,8 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
   const [picks, setPicks] = useState<Record<string, string[]>>(() => formPicks(step.elicit?.fields))
   const elicit = step.elicit
   const multi = elicit?.multi
+  const consentUrl = elicit?.url
+  const consent = consentUrl ? readConsentUrl(consentUrl) : null
   const fields = elicit?.fields?.length ? elicit.fields : undefined
   const typed = !fields && elicit && (elicit.text || elicit.number) ? elicit : undefined
   const min = multi?.minItems ?? 0
@@ -833,6 +869,54 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
             <Icon name={settled.icon} size={13} color={settled.color} />
             <span className="min-w-0 truncate">{settled.label(elicit.answerLabel)}</span>
           </span>
+        ) : consent && consentUrl ? (
+          // URL mode. The full URL is shown for examination and NOTHING here touches it: no
+          // favicon, no preview, no title lookup, no prefetch hint. Opening is the reader's own
+          // click on a plain anchor into a new tab — never an iframe or an in-app webview — so
+          // neither the console nor the model can observe the page or what is typed there.
+          // That click is also the consent the ACP request resolves on.
+          <div className="flex w-full min-w-0 flex-col gap-[10px]">
+            <div className="min-w-0 rounded-sm border border-(--border-subtle) bg-(--surface-card) px-[10px] py-[8px] font-mono text-[12.5px] leading-[1.5] break-all">
+              <span className="text-(--text-tertiary)">{consent.scheme}</span>
+              <span className="font-medium text-(--text-primary)">{consent.host}</span>
+              <span className="text-(--text-tertiary)">{consent.rest}</span>
+            </div>
+            {consent.warnings.map((w) => (
+              <span
+                key={w}
+                className="inline-flex min-w-0 items-start gap-[6px] font-sans text-[12.5px] font-normal leading-normal text-(--amber-500)"
+              >
+                <span className="mt-[2px] flex-none">
+                  <Icon name="triangle-alert" size={13} color="var(--amber-500)" />
+                </span>
+                <span className="min-w-0">{w}</span>
+              </span>
+            ))}
+            <div className="flex flex-wrap items-center gap-[6px]">
+              {onAnswer ? (
+                <a
+                  className="dsbtn dsbtn-primary xs no-underline"
+                  href={consentUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => onAnswer(consentUrl)}
+                >
+                  Open link
+                </a>
+              ) : (
+                <span className="dsbtn dsbtn-primary xs cursor-default opacity-55">Open link</span>
+              )}
+              <button
+                type="button"
+                className="chip disabled:cursor-default disabled:opacity-55"
+                disabled={!onAnswer}
+                onClick={() => onAnswer?.(null)}
+                title="Refuse without opening"
+              >
+                Decline
+              </button>
+            </div>
+          </div>
         ) : fields ? (
           <div className="flex w-full min-w-0 flex-col gap-[10px]">
             {fields.map((f) => {

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1164,7 +1164,10 @@ export interface SessionStep {
      *  descriptor above is then absent, so a reader that does not know `fields` has nothing
      *  to answer with rather than half an answer. */
     fields?: ElicitFieldSpec[]
-    outcome?: 'accepted' | 'dismissed' | 'cancelled'
+    /** Present ⇒ a URL-mode CONSENT card: the reader examines this exact URL and opens it in
+     *  their own browser tab. Nothing here ever fetches it, and `options` is then empty. */
+    url?: string
+    outcome?: 'accepted' | 'dismissed' | 'cancelled' | 'completed'
     answerLabel?: string
   }
 }


### PR DESCRIPTION
Implements #1794 gap 4. **Also fixes a live security bug in already-shipped code — see the last section; the wider audit is #1809.**

URL mode is how the spec says credentials, API keys, OAuth and payment flows MUST be handled: out of band, never through the client, never through the LLM context. We did not advertise the capability at all, so a runtime could not use it and had only form mode — which the spec forbids for exactly those things.

## What ACP actually defines, checked against the SDK

`@agentclientprotocol/sdk@1.4.0`:

- **URL mode** — `ElicitationUrlMode` (`schema/schema.json:2156`): `{ elicitationId, url }` alongside the shared `message`. The id is camelCase and exists **only** on URL mode; form mode has no id.
- **Completion notification — ACP has one.** `CompleteElicitationNotification` (`schema.json:5929`), `x-method: "elicitation/complete"`, params `{ elicitationId }`, client side. It carries **no `sessionId`**, which is why parked cards are keyed by `elicitationId` within the raising host rather than by session.
- **`-32042` / `URLElicitationRequiredError` — does NOT exist in ACP.** Nothing in the SDK matches `32042`, `URLElicitationRequired` or `urlElicitation`. It is MCP-only and structurally inapplicable on this seam: the daemon is an ACP *client* and never calls tools on the agent, so there is no request for the agent to fail with a retry-after-auth error. Nothing was implemented for it, and the issue's sub-item is closed as not-applicable rather than invented.
- **Capability** — `ElicitationCapabilities` documents `{}` as "supports URL-based elicitation", so `{ form: {}, url: {} }` is literally the right shape.
- **Response** — only `accept` carries content. A URL accept resolves as bare `{ action: 'accept' }`, because nothing was answered.

## Response semantics are not form mode's

`accept` means **the user consented to open the URL**, not that the flow finished. The ACP request resolves at consent; the interaction then happens out of band and may complete much later, or never. `decline` is an explicit refusal, `cancel` a dismissal or the turn ending. Getting this wrong would leave the agent blocked on a request that can never resolve.

## The client MUSTs, and where each is satisfied

| Rule | How |
| --- | --- |
| MUST NOT pre-fetch the URL or its metadata | The card is inert markup; nothing fetches. Asserted: no request to the host, no `link[rel~=prefetch/preload/preconnect]`, no `img`/`script`/`iframe` src. |
| MUST NOT open without explicit action | A plain `<a href>`; nothing auto-navigates. |
| MUST show the FULL URL | Rendered unelided in three spans, split from the **original string** rather than a re-serialized `URL`, so a trailing dot or odd casing survives for inspection. |
| MUST open unobservably | `target="_blank" rel="noopener noreferrer"`; never an iframe or in-app webview. |
| SHOULD highlight the host | The host is weighted against a tertiary scheme and path, so a lookalike reads differently. |
| SHOULD warn on a suspicious host | `xn--` anywhere in the hostname is flagged. |
| Non-HTTPS | Called out as not encrypted. |

Beyond the brief: **only `http`/`https` produce a card at all.** `javascript:`, `data:`, `file:`, `mailto:` and unparseable URLs decline in `elicitUrl`, and the console re-checks rather than trusting the wire — handing a browser a `javascript:` href built from agent-authored text is an XSS primitive, not a UX wart.

`maskAgentSecrets` already covers the whole params object, so a secret in a query string never reaches the card. Asserted.

## Wire

`elicitation` gains optional `url`; `elicitation_resolved.outcome` gains `completed`. Skew directions:

- **new daemon → old reader**: `url` is stripped, leaving an optionless card that can only be dismissed → `decline`. Fails closed; never an accidental consent.
- **new daemon → old reader, for the settled event**: that one frame fails to decode and the card keeps showing the consented state. The loss is a missing "Completed" label, never a wrong verdict.
- **answer op unchanged**: consent echoes the card's own URL back through the existing string arm, and the daemon re-checks `value === rec.url` — the same "the card names every answer it accepts" rule the other cards use. An old daemon never posts a URL card, so no URL answer can reach one.

The map of consented-but-not-yet-completed cards is bounded (64, oldest evicted). Eviction can only cost a cosmetic "Completed" re-label — the ACP request already resolved at consent — so it cannot strand a pending request.

## Security fix riding along: Slack cards rendered agent-authored links

Requirement 5 was written as a check ("confirm the form card does not render URLs as clickable"). Webchat was fine. **Slack was not.**

`buildElicitationCard` put the agent-authored `message` straight into a `mrkdwn` block, and Slack both autolinks bare URLs and honours `<url|label>`. So a form-mode elicitation could render a tappable link with attacker-chosen wording — `<https://evil.example/harvest|Approve in Slack>` — inside chrome the reader trusts because the bot posted it. A phishing primitive on exactly the surface people are trained to act on, and contrary to the spec's rule that a client SHOULD NOT render URLs as clickable outside a URL-mode consent card.

`elicitCardMessage` now escapes `&`, `<`, `>` and wraps bare URLs in a code span, which Slack does not autolink. The reader still sees what the agent wrote; they just cannot be sent anywhere by it.

**The same `mrkdwn`-with-agent-text pattern likely exists on other builders in `render.ts` and on the other card surfaces.** That sweep is deliberately not in this PR — it is filed as **#1809**.

## Verification

- protocol 488, relay 644, web 2399, daemon (`render` / `daemon-permission-autoallow` / `daemon-webchat` / `approval-dm` / `acp-host`) 376 — all passing, independently re-run.
- `pnpm typecheck`: `error TS` count 0.
- eslint + prettier clean on changed files.

Every new guard test was confirmed red without its fix by reverting only the source file and keeping the test — across `coordinator.ts` (5), `render.ts` (3), `acp-host.ts` (2) and the console view (4). The tests that stay green either way are the negative "still declines" invariants, which is the honest result for them.

One housekeeping commit: the consented-card map key embedded a **literal NUL byte** in its template literal. The runtime choice is right — NUL cannot occur in either component, so the separator is unambiguous — but written raw it made the whole file read as binary (`file` said `data`, grep refused to search it). It is now the `\x00` escape, producing the identical string.
