### PR TITLE
fix(daemon): make the elicitation option limit a surface property, not a silent slice

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -41,11 +41,11 @@ import {
   elicitUrl,
   multiSelectAccepts,
   numberAccepts,
-  SLACK_ELICIT_KINDS,
+  SLACK_ELICIT_SURFACE,
   textAccepts,
-  WEBCHAT_ELICIT_KINDS
+  WEBCHAT_ELICIT_SURFACE
 } from '../slack/render.js'
-import type { ElicitKind, ElicitSurfaceKinds, ElicitTarget } from '../slack/render.js'
+import type { ElicitKind, ElicitSurface, ElicitTarget } from '../slack/render.js'
 import { slackThreadUrl } from '../platforms/slack/permalink.js'
 import { slackAgentIdentityOptions } from '../platforms/slack/turn-output.js'
 import { turnChromeFor } from '../platforms/turn-chrome.js'
@@ -101,10 +101,10 @@ type PendingElicitSurface =
   | { surface: 'slack'; conn: SlackConnection; channel: string; ts?: string }
   | { surface: 'webchat'; wc: NonNullable<Pending['webchat']> }
 
-/** The kinds the surface a card was posted to renders — re-deriving its target has to ask the
- *  same question the post did, or a card could be read back as a field its surface never showed. */
-function surfaceKinds(rec: PendingElicitSurface): ElicitSurfaceKinds {
-  return rec.surface === 'webchat' ? WEBCHAT_ELICIT_KINDS : SLACK_ELICIT_KINDS
+/** What the surface a card was posted to renders — re-deriving its target has to ask the same
+ *  question the post did, or a card could be read back as a field its surface never showed. */
+function surfaceOf(rec: PendingElicitSurface): ElicitSurface {
+  return rec.surface === 'webchat' ? WEBCHAT_ELICIT_SURFACE : SLACK_ELICIT_SURFACE
 }
 
 /** How a settled card names the answer: the chosen option's LABEL, or every chosen label for a
@@ -728,7 +728,7 @@ export class PermissionCoordinator {
           .catch(() => {})
       return
     }
-    const elicit = rec.kind === 'elicitation' ? elicitTarget(rec.params, SLACK_ELICIT_KINDS) : null
+    const elicit = rec.kind === 'elicitation' ? elicitTarget(rec.params, SLACK_ELICIT_SURFACE) : null
     live.notify = {
       target,
       conn,
@@ -1384,7 +1384,7 @@ export class PermissionCoordinator {
     if (params.mode === 'url') return undefined
     const conn = p.conn
     if (!turnChromeFor(p.plan.platform).chatInputCards || !(conn instanceof SlackConnection)) return undefined
-    const target = elicitTarget(params, SLACK_ELICIT_KINDS)
+    const target = elicitTarget(params, SLACK_ELICIT_SURFACE)
     if (!target) return undefined
     const requestId = isApproval ? randomUUID() : `elicit-${++this.elicitSeq}`
     const blocks = buildElicitationCard(requestId, params, this.host.httpSlackSessionTarget(p))
@@ -1471,7 +1471,7 @@ export class PermissionCoordinator {
     p: Pending,
     wc: NonNullable<Pending['webchat']>
   ): Promise<CreateElicitationResponse | undefined> {
-    const form = elicitForm(params, WEBCHAT_ELICIT_KINDS)
+    const form = elicitForm(params, WEBCHAT_ELICIT_SURFACE)
     if (!form) return undefined
     const target = form[0]!
     const required = new Set(elicitRequiredProps(params))
@@ -1689,13 +1689,13 @@ export class PermissionCoordinator {
     if (rec.url) return await this.handleUrlElicitConsent(a.requestId, { ...rec, url: rec.url }, a)
     // A FORM card is answered by a record and nothing else, and every other card by a scalar
     // or a list — re-derived from the card's own params, exactly as `target` is below.
-    const form = rec.form ? elicitForm(rec.params, surfaceKinds(rec)) : null
+    const form = rec.form ? elicitForm(rec.params, surfaceOf(rec)) : null
     if (rec.form && !form) return
     if (a.value !== null && isFormAnswer(a.value) !== !!form) return
     // Each kind takes one shape of answer and no other: a list for a multi-select, a number
     // for a numeric field, a string for the rest. Dismiss (null) settles any of them.
     if (a.value !== null && !isFormAnswer(a.value) && !answerFitsKind(rec.kind, a.value)) return
-    const target = elicitTarget(rec.params, surfaceKinds(rec))
+    const target = elicitTarget(rec.params, surfaceOf(rec))
     if (a.webchatConversationId !== undefined) {
       if (rec.surface !== 'webchat' || rec.wc.conversationId !== a.webchatConversationId) return
       // The card names every answer it accepts; anything else would inject an unoffered value

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -604,23 +604,35 @@ export function buildPermissionUpdateCard(updateUrl: string): unknown[] {
  *  LIST of the chosen values, `number` with a real JS number, the rest with one scalar. */
 export type ElicitKind = 'enum' | 'boolean' | 'multi-enum' | 'text' | 'number'
 
-/** What a surface declares it is able to render. {@link elicitTarget} skips every property
- *  whose kind is absent here, so a kind reaches a surface only once that surface claims it —
- *  a new kind is invisible to every other surface without anyone remembering to exclude it. */
-export type ElicitSurfaceKinds = ReadonlySet<ElicitKind>
+/** What a surface declares it is able to render — the field kinds it has controls for, and the
+ *  most options one of those controls may offer. {@link elicitTarget} skips every property the
+ *  surface has not claimed on either count, so a kind (or an option list) reaches a surface only
+ *  once that surface claims it, and a form it cannot show whole is declined rather than trimmed.
+ *  Every surface limit belongs here: a limit left inside a card builder is one the reduction
+ *  cannot see, which is exactly how an over-long option list used to be quietly cut to fit. */
+export interface ElicitSurface {
+  kinds: ReadonlySet<ElicitKind>
+  /** The most options one field may offer here. `undefined` is no limit — webchat renders them all. */
+  maxOptions?: number
+}
+
+/** Slack allows 25 elements in one `actions` block and wraps them across lines, so the card can
+ *  offer every option of a list this long and still keep its Dismiss button. A longer list is
+ *  declined: no card is built from a slice of it, which is what made a pick a misreported answer. */
+const SLACK_ELICIT_MAX_OPTIONS = 24
 
 /** Slack's card is a row of buttons: it can express "pick one", not "pick several, then
  *  confirm", and it has no field to type into, so those forms are declined there instead. */
-export const SLACK_ELICIT_KINDS: ElicitSurfaceKinds = new Set<ElicitKind>(['enum', 'boolean'])
+export const SLACK_ELICIT_SURFACE: ElicitSurface = {
+  kinds: new Set<ElicitKind>(['enum', 'boolean']),
+  maxOptions: SLACK_ELICIT_MAX_OPTIONS
+}
 
-/** Webchat's card has toggles, a confirm control and a typed input, so it takes every kind. */
-export const WEBCHAT_ELICIT_KINDS: ElicitSurfaceKinds = new Set<ElicitKind>([
-  'enum',
-  'boolean',
-  'multi-enum',
-  'text',
-  'number'
-])
+/** Webchat's card has toggles, a confirm control and a typed input, so it takes every kind,
+ *  and its list scrolls, so it declares no option limit. */
+export const WEBCHAT_ELICIT_SURFACE: ElicitSurface = {
+  kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number'])
+}
 
 /** The `format` values MCP `2025-11-25` defines for an elicited string — exactly these four. */
 export type ElicitFormat = 'email' | 'uri' | 'date' | 'date-time'
@@ -857,12 +869,16 @@ export function elicitFieldLabel(params: CreateElicitationRequest, propName: str
  * kind. The shared scan behind {@link elicitTarget} and {@link elicitForm}, so the two can
  * never disagree about what is renderable. Empty for URL-mode and an empty/absent schema.
  */
-function elicitCandidates(params: CreateElicitationRequest, renderable: ElicitSurfaceKinds): ElicitTarget[] {
+function elicitCandidates(params: CreateElicitationRequest, surface: ElicitSurface): ElicitTarget[] {
   const p = params as {
     mode?: string
     requestedSchema?: { properties?: Record<string, Record<string, unknown>> }
   }
   if (p.mode !== 'form') return []
+  const renderable = surface.kinds
+  // More options than the surface can show is not a renderable field: a card built from part of
+  // the list would report the reader's pick as their answer to the whole question.
+  const fits = (options: readonly unknown[]) => surface.maxOptions === undefined || options.length <= surface.maxOptions
   const found: ElicitTarget[] = []
   for (const [name, prop] of Object.entries(p.requestedSchema?.properties ?? {})) {
     const keep = (t: ElicitTarget | null) => {
@@ -876,7 +892,7 @@ function elicitCandidates(params: CreateElicitationRequest, renderable: ElicitSu
         : Array.isArray(en)
           ? en.map((v) => ({ value: String(v), label: clampTo(String(v), 75) }))
           : []
-      if (options.length && renderable.has('enum')) keep({ propName: name, kind: 'enum', options })
+      if (options.length && fits(options) && renderable.has('enum')) keep({ propName: name, kind: 'enum', options })
       // Free text is the string with nothing to choose from — an enumerated one is a pick,
       // and typing into it would let an unoffered value through.
       if (!options.length && renderable.has('text')) keep(textTarget(name, prop))
@@ -889,7 +905,7 @@ function elicitCandidates(params: CreateElicitationRequest, renderable: ElicitSu
       const max = itemBound(prop.maxItems)
       // Bounds that admit only the empty selection, or none at all, are not a question.
       const askable = max === undefined || (max > 0 && max >= (min ?? 0))
-      if (options.length && askable)
+      if (options.length && fits(options) && askable)
         keep({
           propName: name,
           kind: 'multi-enum',
@@ -940,10 +956,10 @@ export function elicitUrl(params: CreateElicitationRequest): { elicitationId: st
  * required one, and stopping here would decline a form this surface can in fact answer. Pure,
  * and shared by every surface so the option values and their interpretation can't drift.
  */
-export function elicitTarget(params: CreateElicitationRequest, renderable: ElicitSurfaceKinds): ElicitTarget | null {
+export function elicitTarget(params: CreateElicitationRequest, surface: ElicitSurface): ElicitTarget | null {
   const required = elicitRequiredProps(params)
   // A required field we can't render is unanswerable: accepting without it would assert a lie.
-  return elicitCandidates(params, renderable).find((t) => required.every((r) => r === t.propName)) ?? null
+  return elicitCandidates(params, surface).find((t) => required.every((r) => r === t.propName)) ?? null
 }
 
 /**
@@ -955,8 +971,8 @@ export function elicitTarget(params: CreateElicitationRequest, renderable: Elici
  * exactly what {@link elicitTarget} would return, which is what keeps a single-field card's
  * wire payload unchanged.
  */
-export function elicitForm(params: CreateElicitationRequest, renderable: ElicitSurfaceKinds): ElicitTarget[] | null {
-  const targets = elicitCandidates(params, renderable)
+export function elicitForm(params: CreateElicitationRequest, surface: ElicitSurface): ElicitTarget[] | null {
+  const targets = elicitCandidates(params, surface)
   if (!targets.length || targets.length > ELICIT_FORM_FIELD_CAP) return null
   const rendered = new Set(targets.map((t) => t.propName))
   return elicitRequiredProps(params).every((r) => rendered.has(r)) ? targets : null
@@ -1057,22 +1073,31 @@ function elicitCardMessage(params: CreateElicitationRequest): string {
     .replace(BARE_URL_RE, (m) => `\`${m}\``)
 }
 
+/** Slack's own limit on one section's mrkdwn text. */
+const SLACK_SECTION_TEXT_CAP = 3000
+
+/** How much of the agent's question a card carries. Cut only where Slack itself would refuse the
+ *  block — the old 400 cut ordinary questions Slack could have shown whole, and {@link clampTo}'s
+ *  trailing `…` is the only mark a cut ever gets, so a shorter cap is a quieter one. */
+const ELICIT_MESSAGE_CAP = SLACK_SECTION_TEXT_CAP - 200
+
 /**
- * Build the interactive elicitation card: the agent's `message`, an optional field title,
- * and an actions row of option buttons (one per {@link elicitTarget} option, capped at 5)
- * plus a Dismiss button. The choice rides each button `value` (`<requestId>|<optionValue>`).
- * Returns null when the form can't be rendered inline (caller declines) — including a
- * multi-select, which {@link SLACK_ELICIT_KINDS} withholds from this surface. Pure.
+ * Build the interactive elicitation card: the agent's `message`, an optional field title, and an
+ * actions row carrying EVERY {@link elicitTarget} option as a button, plus a Dismiss button. The
+ * choice rides each button `value` (`<requestId>|<optionValue>`). Returns null when the form
+ * can't be rendered inline (caller declines) — a multi-select, which {@link SLACK_ELICIT_SURFACE}
+ * withholds from this surface, or a list longer than that surface declares it can show, which the
+ * reduction has already refused. Nothing here trims a list to fit. Pure.
  */
 export function buildElicitationCard(
   requestId: string,
   params: CreateElicitationRequest,
   sessionTarget?: string
 ): unknown[] | null {
-  const target = elicitTarget(params, SLACK_ELICIT_KINDS)
+  const target = elicitTarget(params, SLACK_ELICIT_SURFACE)
   if (!target) return null
   const message = elicitCardMessage(params)
-  const buttons = target.options.slice(0, 5).map((o, i) => ({
+  const buttons = target.options.map((o, i) => ({
     type: 'button',
     action_id: `${ELICIT_ACTION_PREFIX}:${i}`,
     text: { type: 'plain_text', text: o.label, emoji: true },
@@ -1085,7 +1110,7 @@ export function buildElicitationCard(
     value: requestId
   } as (typeof buttons)[number])
   return [
-    { type: 'section', text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(message, 400)}` } },
+    { type: 'section', text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(message, ELICIT_MESSAGE_CAP)}` } },
     { type: 'actions', ...(sessionTarget ? { block_id: sessionTarget } : {}), elements: buttons }
   ]
 }
@@ -1094,7 +1119,8 @@ export function buildElicitationCard(
  *  buildElicitationCard} once answered, dismissed, or cancelled. Pure. */
 export function buildElicitationResolvedCard(params: CreateElicitationRequest, decision: string): unknown[] {
   const message = elicitCardMessage(params)
-  return [{ type: 'section', text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(message, 400)}\n${decision}` } }]
+  const text = clampTo(`:speech_balloon: ${clampTo(message, ELICIT_MESSAGE_CAP)}\n${decision}`, SLACK_SECTION_TEXT_CAP)
+  return [{ type: 'section', text: { type: 'mrkdwn', text } }]
 }
 
 export interface SharedStatusActions {

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -1,7 +1,7 @@
 import { agentHostKey } from '../src/acp/host-key.js'
 import { DatabaseSync } from 'node:sqlite'
 import { describe, expect, it, vi } from 'vitest'
-import type { RequestPermissionRequest } from '@agentclientprotocol/sdk'
+import type { CreateElicitationRequest, RequestPermissionRequest } from '@agentclientprotocol/sdk'
 import { PermissionCoordinator, type PermissionHost } from '../src/permissions/coordinator.js'
 import type { SlackConnection } from '../src/slack/connection.js'
 import { LocalStore } from '../src/store/local-store.js'
@@ -32,6 +32,18 @@ function permissionParams(): RequestPermissionRequest {
       { optionId: 'o-deny', name: 'Deny', kind: 'reject_once' }
     ]
   } as unknown as RequestPermissionRequest
+}
+
+/** An MCP-approval elicitation whose single enum field offers `options` — the DM's card path. */
+function approvalElicitation(options: string[]): CreateElicitationRequest {
+  return {
+    sessionId: ACP_SESSION,
+    toolCallId: 'call-e',
+    mode: 'form',
+    message: 'Which one?',
+    requestedSchema: { type: 'object', properties: { pick: { type: 'string', enum: options } }, required: ['pick'] },
+    _meta: { codex_approval_kind: 'mcp_tool_call' }
+  } as unknown as CreateElicitationRequest
 }
 
 async function world(over?: {
@@ -135,6 +147,32 @@ describe('approval DM (slack-approval-dm.md §5–§6)', () => {
     expect(rows).toMatchObject([{ status: 'allowed', resolvedBy: 'slack:T1:U1', resolvedByName: 'Ada' }])
     expect(w.conn.updateBlocks).toHaveBeenCalled()
     await w.store.close()
+  })
+
+  // The DM builds its card with the very same `buildElicitationCard` the in-channel card uses,
+  // so #1794 gap 7's option cap has to read the same on both — every option, or no card at all.
+  it('carries every option of a long enum onto the approval DM, and declines past the cap', async () => {
+    const seven = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+    const w = await world()
+    void w.coordinator.onAcpElicit(OWNER, ACP_SESSION, approvalElicitation(seven))
+    await vi.waitFor(() => expect(w.conn.postBlocks).toHaveBeenCalledTimes(1))
+    const blocks = (w.conn.postBlocks.mock.calls[0] as unknown[])[1] as any[]
+    const actions = blocks.find((b) => b.type === 'actions')
+    expect(actions.elements.map((e: any) => e.text.text)).toEqual([...seven, 'Dismiss'])
+    await w.store.close()
+
+    // Past the cap `buildElicitationCard` returns null, so the DM posts the intro and no buttons.
+    const over = await world()
+    void over.coordinator.onAcpElicit(
+      OWNER,
+      ACP_SESSION,
+      approvalElicitation(Array.from({ length: 25 }, (_, i) => `o${i}`))
+    )
+    await vi.waitFor(() => expect(over.conn.postBlocks).toHaveBeenCalledTimes(1))
+    const overBlocks = (over.conn.postBlocks.mock.calls[0] as unknown[])[1] as any[]
+    expect(overBlocks.some((b) => b.type === 'actions')).toBe(false)
+    await over.coordinator.releaseEditorPermissions(OWNER, ACP_SESSION)
+    await over.store.close()
   })
 
   it('refuses a wrong actor and an unanswerable verify without settling the request', async () => {

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -10,7 +10,7 @@ import { join } from 'node:path'
 import { LocalStore } from '../src/store/local-store.js'
 import { listAgentPermissionRequests } from '../src/cp/config-apply-handlers.js'
 import { SlackConnection } from '../src/slack/connection.js'
-import { elicitForm, elicitTarget, SLACK_ELICIT_KINDS, WEBCHAT_ELICIT_KINDS } from '../src/slack/render.js'
+import { elicitForm, elicitTarget, SLACK_ELICIT_SURFACE, WEBCHAT_ELICIT_SURFACE } from '../src/slack/render.js'
 
 /**
  * Auto-approve policy for the daemon's OWN built-in MCP tools (UX fix): a human should
@@ -608,7 +608,7 @@ describe('webchat renders and answers ACP elicitation cards', () => {
 // ── multi-select on webchat only (issue #1794 gap 2) ─────────────────────────
 // A Slack card is a row of buttons and cannot express "pick several, then confirm", so the
 // kind is one webchat renders and Slack still declines — the surfaces declare what they can
-// render (`SLACK_ELICIT_KINDS` / `WEBCHAT_ELICIT_KINDS`) rather than each kind excluding Slack.
+// render (`SLACK_ELICIT_SURFACE` / `WEBCHAT_ELICIT_SURFACE`) rather than each kind excluding Slack.
 
 /** A multi-select form: an array of enum items, bounded unless `schema` says otherwise. */
 function multiElicitation(items: Record<string, unknown> = {}): CreateElicitationRequest {
@@ -737,7 +737,65 @@ describe('webchat answers a multi-select elicitation with a list', () => {
     ).resolves.toBeUndefined()
     expect((daemon as any).permissions.pendingElicits.size).toBe(0)
     // The same form IS renderable — just not here: webchat cards it.
-    expect(elicitTarget(multiElicitation({ minItems: 1 }), WEBCHAT_ELICIT_KINDS)?.kind).toBe('multi-enum')
+    expect(elicitTarget(multiElicitation({ minItems: 1 }), WEBCHAT_ELICIT_SURFACE)?.kind).toBe('multi-enum')
+  })
+})
+
+// ── long option lists (issue #1794 gap 7) ────────────────────────────────────
+
+/** A single-field enum form with `n` options. */
+function enumElicitation(options: string[]): CreateElicitationRequest {
+  return formElicitation({
+    message: 'Which one?',
+    requestedSchema: { type: 'object', properties: { pick: { type: 'string', enum: options } }, required: ['pick'] }
+  })
+}
+
+describe('a Slack card offers every option or none', () => {
+  /** A Slack turn whose posted card blocks are captured. */
+  function slackPending(daemon: any): { pending: any; posted: any[][] } {
+    const pending: any = installPending(daemon)
+    const posted: any[][] = []
+    pending.plan.platform = 'slack'
+    const conn = Object.create(SlackConnection.prototype)
+    conn.postBlocks = async (_c: string, blocks: any[]) => {
+      posted.push(blocks)
+      return 'ts-1'
+    }
+    conn.updateBlocks = async () => true
+    conn.workspaceId = () => 'T1'
+    pending.conn = conn
+    return { pending, posted }
+  }
+
+  // The seven-option enum of the issue: five buttons went out, the reader never saw the last two,
+  // and whichever they picked came back as `accept` on the whole question.
+  it('cards all seven options and accepts a pick past the fifth', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+    const seven = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', enumElicitation(seven))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    const elements = posted[0]![1]!.elements as any[]
+    expect(elements.map((e) => e.text.text)).toEqual([...seven, 'Dismiss'])
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'g' })
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { pick: 'g' } })
+  })
+
+  // Past what the surface declares, there is no card and no answer: the agent is declined and
+  // can ask again, which is the same verdict a field Slack cannot render already gets.
+  it('declines rather than posting a card built from part of the list', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+    const many = Array.from({ length: 25 }, (_, i) => `o${i}`)
+    await expect(
+      (daemon as any).permissions.onAcpElicit('agent-1', 's1', enumElicitation(many))
+    ).resolves.toBeUndefined()
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+    expect(posted).toHaveLength(0)
+    // The same form is renderable where nothing declares a limit — webchat still shows them all.
+    expect(elicitTarget(enumElicitation(many), WEBCHAT_ELICIT_SURFACE)?.options).toHaveLength(25)
   })
 })
 
@@ -906,8 +964,8 @@ describe('webchat answers a typed elicitation with the schema’s own type', () 
     await expect((daemon as any).permissions.onAcpElicit('agent-1', 's1', numberElicitation())).resolves.toBeUndefined()
     expect((daemon as any).permissions.pendingElicits.size).toBe(0)
     // The same forms ARE renderable — just not here: webchat types into them.
-    expect(elicitTarget(textElicitation(), WEBCHAT_ELICIT_KINDS)?.kind).toBe('text')
-    expect(elicitTarget(numberElicitation(), WEBCHAT_ELICIT_KINDS)?.kind).toBe('number')
+    expect(elicitTarget(textElicitation(), WEBCHAT_ELICIT_SURFACE)?.kind).toBe('text')
+    expect(elicitTarget(numberElicitation(), WEBCHAT_ELICIT_SURFACE)?.kind).toBe('number')
   })
 
   it('declines a form whose pattern could hang the daemon, rather than run it', async () => {
@@ -1121,9 +1179,9 @@ describe('webchat answers a multi-field elicitation form with a record', () => {
     ).resolves.toBeUndefined()
     expect((daemon as any).permissions.pendingElicits.size).toBe(0)
     // Unchanged where it matters: one card, one field that satisfies `required` alone.
-    expect(elicitTarget(twoFieldElicitation(['branch', 'note']), SLACK_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(twoFieldElicitation(['branch', 'note']), SLACK_ELICIT_SURFACE)).toBeNull()
     // The same form IS renderable — just not here: webchat asks every field.
-    expect(elicitForm(twoFieldElicitation(['branch', 'note']), WEBCHAT_ELICIT_KINDS)).toHaveLength(2)
+    expect(elicitForm(twoFieldElicitation(['branch', 'note']), WEBCHAT_ELICIT_SURFACE)).toHaveLength(2)
   })
 
   it('keeps a one-field form on the single-field card, byte for byte', async () => {

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -24,8 +24,8 @@ import {
   elicitRequiredProps,
   elicitTarget,
   elicitUrl,
-  SLACK_ELICIT_KINDS,
-  WEBCHAT_ELICIT_KINDS,
+  SLACK_ELICIT_SURFACE,
+  WEBCHAT_ELICIT_SURFACE,
   multiSelectAccepts,
   numberAccepts,
   safeElicitPattern,
@@ -1412,8 +1412,8 @@ describe('elicitation card', () => {
         required: ['ok']
       }
     } as any
-    expect(elicitTarget(req, WEBCHAT_ELICIT_KINDS)).toMatchObject({ propName: 'ok', kind: 'boolean' })
-    expect(elicitTarget(req, SLACK_ELICIT_KINDS)).toMatchObject({ propName: 'ok', kind: 'boolean' })
+    expect(elicitTarget(req, WEBCHAT_ELICIT_SURFACE)).toMatchObject({ propName: 'ok', kind: 'boolean' })
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)).toMatchObject({ propName: 'ok', kind: 'boolean' })
   })
 
   it('reaches a later enum when an earlier optional one is not the required field', () => {
@@ -1430,7 +1430,7 @@ describe('elicitation card', () => {
         required: ['branch']
       }
     } as any
-    expect(elicitTarget(req, SLACK_ELICIT_KINDS)).toMatchObject({ propName: 'branch' })
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)).toMatchObject({ propName: 'branch' })
   })
 
   it('declines when two properties are required, since one card answers one field', () => {
@@ -1444,18 +1444,18 @@ describe('elicitation card', () => {
         required: ['a', 'b']
       }
     } as any
-    expect(elicitTarget(req, WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(req, WEBCHAT_ELICIT_SURFACE)).toBeNull()
   })
 
   // maxItems 0 admits only the empty selection, so it is not a question — and emitting it
   // would fail the wire schema, dropping the card while the ACP request stayed live.
   it('skips a multi-select whose bounds admit nothing to choose', () => {
     const zero = form({ tags: { type: 'array', maxItems: 0, items: { type: 'string', enum: ['a', 'b'] } } })
-    expect(elicitTarget(zero, WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(zero, WEBCHAT_ELICIT_SURFACE)).toBeNull()
     const inverted = form({
       tags: { type: 'array', minItems: 2, maxItems: 1, items: { type: 'string', enum: ['a', 'b'] } }
     })
-    expect(elicitTarget(inverted, WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(inverted, WEBCHAT_ELICIT_SURFACE)).toBeNull()
   })
 
   it('renders titled enum (oneOf) as buttons carrying requestId|const, plus Dismiss', () => {
@@ -1479,8 +1479,65 @@ describe('elicitation card', () => {
     expect(btns[2].value).toBe('elicit-1')
   })
 
+  // #1794 gap 7: a seven-option enum used to render five buttons and still answer `accept`,
+  // reporting a pick from a set the reader never saw as their answer to the whole question.
+  it('renders EVERY option of a long enum, not the first five', () => {
+    const seven = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+    const blocks = buildElicitationCard('elicit-7', form({ pick: { type: 'string', enum: seven } })) as any[]
+    const btns = blocks[1].elements
+    expect(btns.map((b: any) => b.text.text)).toEqual([...seven, 'Dismiss'])
+    expect(btns.slice(0, 7).map((b: any) => b.value)).toEqual(seven.map((v) => `elicit-7|${v}`))
+    expect(btns.map((b: any) => b.action_id)).toEqual([
+      ...seven.map((_, i) => `${ELICIT_ACTION_PREFIX}:${i}`),
+      ELICIT_DISMISS_ACTION
+    ])
+  })
+
+  // The surface declares the limit and the reduction enforces it, so the card is never built
+  // from part of a list: at the boundary it shows everything, past it there is no card at all.
+  it('declines an enum longer than the Slack surface declares it can show', () => {
+    const opts = (n: number) => Array.from({ length: n }, (_, i) => `o${i}`)
+    const at = form({ pick: { type: 'string', enum: opts(24) } })
+    expect(elicitTarget(at, SLACK_ELICIT_SURFACE)?.options).toHaveLength(24)
+    expect((buildElicitationCard('elicit-24', at) as any[])[1].elements).toHaveLength(25)
+    const over = form({ pick: { type: 'string', enum: opts(25) } })
+    expect(elicitTarget(over, SLACK_ELICIT_SURFACE)).toBeNull()
+    expect(elicitForm(over, SLACK_ELICIT_SURFACE)).toBeNull()
+    expect(buildElicitationCard('elicit-25', over)).toBeNull()
+  })
+
+  // Webchat's list scrolls, so it declares no option limit and keeps rendering every option.
+  it('leaves webchat uncapped', () => {
+    const opts = (n: number) => Array.from({ length: n }, (_, i) => `o${i}`)
+    expect(
+      elicitTarget(form({ pick: { type: 'string', enum: opts(200) } }), WEBCHAT_ELICIT_SURFACE)?.options
+    ).toHaveLength(200)
+    expect(
+      elicitTarget(
+        form({ tags: { type: 'array', items: { type: 'string', enum: opts(200) } } }),
+        WEBCHAT_ELICIT_SURFACE
+      )?.options
+    ).toHaveLength(200)
+  })
+
+  // The question is cut only where Slack itself would refuse the block, and clampTo's `…` is
+  // what says it was cut — a 400-char cap silently dropped questions Slack could have shown.
+  it('carries a question far longer than 400 chars, and marks one Slack cannot fit', () => {
+    const long = 'x'.repeat(1200)
+    const blocks = buildElicitationCard('elicit-l', form({ ok: { type: 'boolean' } }, long)) as any[]
+    expect(blocks[0].text.text).toContain(long)
+    const huge = 'y'.repeat(5000)
+    const cut = (buildElicitationCard('elicit-h', form({ ok: { type: 'boolean' } }, huge)) as any[])[0].text.text
+    expect(cut.length).toBeLessThanOrEqual(3000)
+    expect(cut.endsWith('…')).toBe(true)
+    const resolved = (
+      buildElicitationResolvedCard(form({ ok: { type: 'boolean' } }, huge), ':x: Dismissed') as any[]
+    )[0]
+    expect(resolved.text.text.length).toBeLessThanOrEqual(3000)
+  })
+
   it('renders bare string enum with value == label', () => {
-    const t = elicitTarget(form({ color: { type: 'string', enum: ['red', 'green'] } }), SLACK_ELICIT_KINDS)
+    const t = elicitTarget(form({ color: { type: 'string', enum: ['red', 'green'] } }), SLACK_ELICIT_SURFACE)
     expect(t).toEqual({
       propName: 'color',
       kind: 'enum',
@@ -1492,7 +1549,7 @@ describe('elicitation card', () => {
   })
 
   it('renders boolean as Yes/No', () => {
-    const t = elicitTarget(form({ ok: { type: 'boolean' } }), SLACK_ELICIT_KINDS)
+    const t = elicitTarget(form({ ok: { type: 'boolean' } }), SLACK_ELICIT_SURFACE)
     expect(t).toEqual({
       propName: 'ok',
       kind: 'boolean',
@@ -1510,7 +1567,7 @@ describe('elicitation card', () => {
       message: 'Pick a language',
       requestedSchema: { type: 'object', properties: { color: { type: 'string', enum: ['red'] } }, required: ['color'] }
     } as any
-    expect(elicitTarget(req, SLACK_ELICIT_KINDS)?.propName).toBe('color')
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)?.propName).toBe('color')
   })
 
   it('renders when extra non-required properties ride along', () => {
@@ -1528,7 +1585,7 @@ describe('elicitation card', () => {
         required: ['color']
       }
     } as any
-    expect(elicitTarget(req, SLACK_ELICIT_KINDS)?.propName).toBe('color')
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)?.propName).toBe('color')
   })
 
   it('returns null when the schema requires a property the card cannot answer', () => {
@@ -1542,7 +1599,7 @@ describe('elicitation card', () => {
         required: ['color', 'note']
       }
     } as any
-    expect(elicitTarget(req, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)).toBeNull()
     expect(buildElicitationCard('e', req)).toBeNull()
   })
 
@@ -1557,18 +1614,18 @@ describe('elicitation card', () => {
         required: ['ok', 'reason']
       }
     } as any
-    expect(elicitTarget(req, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)).toBeNull()
   })
 
   it('renders when required is absent', () => {
-    expect(elicitTarget(form({ ok: { type: 'boolean' } }), SLACK_ELICIT_KINDS)?.propName).toBe('ok')
+    expect(elicitTarget(form({ ok: { type: 'boolean' } }), SLACK_ELICIT_SURFACE)?.propName).toBe('ok')
   })
 
   it('returns null (→ caller declines) for free-text-only forms and url mode', () => {
-    expect(elicitTarget(form({ name: { type: 'string' } }), SLACK_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(form({ name: { type: 'string' } }), SLACK_ELICIT_SURFACE)).toBeNull()
     expect(buildElicitationCard('e', form({ name: { type: 'string' } }))).toBeNull()
     expect(
-      elicitTarget({ mode: 'url', sessionId: 's1', message: 'go', url: 'https://x' } as any, SLACK_ELICIT_KINDS)
+      elicitTarget({ mode: 'url', sessionId: 's1', message: 'go', url: 'https://x' } as any, SLACK_ELICIT_SURFACE)
     ).toBeNull()
   })
 
@@ -1577,7 +1634,7 @@ describe('elicitation card', () => {
   it('reads both array shapes as one multi-enum target, with the schema bounds', () => {
     const bare = elicitTarget(
       form({ colors: { type: 'array', items: { type: 'string', enum: ['Red', 'Green'] }, minItems: 1, maxItems: 2 } }),
-      WEBCHAT_ELICIT_KINDS
+      WEBCHAT_ELICIT_SURFACE
     )
     expect(bare).toEqual({
       propName: 'colors',
@@ -1601,7 +1658,7 @@ describe('elicitation card', () => {
           }
         }
       }),
-      WEBCHAT_ELICIT_KINDS
+      WEBCHAT_ELICIT_SURFACE
     )
     // Unbounded: no minItems/maxItems invented where the schema states none.
     expect(titled).toEqual({
@@ -1616,23 +1673,25 @@ describe('elicitation card', () => {
 
   it('leaves multi-select unrenderable on Slack, whose card would have to decline it', () => {
     const req = form({ colors: { type: 'array', items: { type: 'string', enum: ['Red', 'Green'] } } })
-    expect(elicitTarget(req, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)).toBeNull()
     expect(buildElicitationCard('elicit-1', req)).toBeNull()
   })
 
   it('skips a field the surface cannot render and takes the next one it can', () => {
     // Slack passes over the array and cards the boolean, exactly as it did before the kind existed.
     const req = form({ colors: { type: 'array', items: { type: 'string', enum: ['Red'] } }, ok: { type: 'boolean' } })
-    expect(elicitTarget(req, SLACK_ELICIT_KINDS)?.propName).toBe('ok')
-    expect(elicitTarget(req, WEBCHAT_ELICIT_KINDS)?.propName).toBe('colors')
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)?.propName).toBe('ok')
+    expect(elicitTarget(req, WEBCHAT_ELICIT_SURFACE)?.propName).toBe('colors')
   })
 
   it('declines an array the card cannot honestly answer', () => {
     // Non-string item consts would make the accepted list lie about the schema's item type,
     // an untyped/free-form array has nothing to offer, and a required peer is still fatal.
     const anyOfNumbers = form({ n: { type: 'array', items: { anyOf: [{ const: 1, title: 'One' }] } } })
-    expect(elicitTarget(anyOfNumbers, WEBCHAT_ELICIT_KINDS)).toBeNull()
-    expect(elicitTarget(form({ tags: { type: 'array', items: { type: 'string' } } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(anyOfNumbers, WEBCHAT_ELICIT_SURFACE)).toBeNull()
+    expect(
+      elicitTarget(form({ tags: { type: 'array', items: { type: 'string' } } }), WEBCHAT_ELICIT_SURFACE)
+    ).toBeNull()
     const required = {
       mode: 'form',
       sessionId: 's1',
@@ -1643,7 +1702,7 @@ describe('elicitation card', () => {
         required: ['colors', 'note']
       }
     } as any
-    expect(elicitTarget(required, WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(required, WEBCHAT_ELICIT_SURFACE)).toBeNull()
   })
 
   it('accepts only a submitted list the card offered, without repeats and inside its bounds', () => {
@@ -1651,7 +1710,7 @@ describe('elicitation card', () => {
       form({
         colors: { type: 'array', items: { type: 'string', enum: ['Red', 'Green', 'Blue'] }, minItems: 1, maxItems: 2 }
       }),
-      WEBCHAT_ELICIT_KINDS
+      WEBCHAT_ELICIT_SURFACE
     )!
     expect(multiSelectAccepts(target, ['Red'])).toBe(true)
     expect(multiSelectAccepts(target, ['Red', 'Blue'])).toBe(true)
@@ -1659,7 +1718,7 @@ describe('elicitation card', () => {
     expect(multiSelectAccepts(target, ['Red', 'Green', 'Blue'])).toBe(false) // above maxItems
     expect(multiSelectAccepts(target, ['Red', 'Red'])).toBe(false) // a repeat is not two picks
     expect(multiSelectAccepts(target, ['rm -rf /'])).toBe(false) // never offered
-    const single = elicitTarget(form({ color: { type: 'string', enum: ['Red'] } }), WEBCHAT_ELICIT_KINDS)!
+    const single = elicitTarget(form({ color: { type: 'string', enum: ['Red'] } }), WEBCHAT_ELICIT_SURFACE)!
     expect(multiSelectAccepts(single, ['Red'])).toBe(false) // not a multi-select card at all
   })
 
@@ -1669,7 +1728,7 @@ describe('elicitation card', () => {
     expect(
       elicitTarget(
         form({ name: { type: 'string', minLength: 3, maxLength: 50, pattern: '^[A-Za-z]+$', format: 'email' } }),
-        WEBCHAT_ELICIT_KINDS
+        WEBCHAT_ELICIT_SURFACE
       )
     ).toEqual({
       propName: 'name',
@@ -1681,18 +1740,18 @@ describe('elicitation card', () => {
       format: 'email'
     })
     // An enumerated string is still a pick: typing into it would let an unoffered value through.
-    expect(elicitTarget(form({ c: { type: 'string', enum: ['Red'] } }), WEBCHAT_ELICIT_KINDS)?.kind).toBe('enum')
+    expect(elicitTarget(form({ c: { type: 'string', enum: ['Red'] } }), WEBCHAT_ELICIT_SURFACE)?.kind).toBe('enum')
   })
 
   it('reads number and integer as one numeric target, integer-ness kept apart from the bounds', () => {
-    expect(elicitTarget(form({ pct: { type: 'number', minimum: 0, maximum: 100 } }), WEBCHAT_ELICIT_KINDS)).toEqual({
+    expect(elicitTarget(form({ pct: { type: 'number', minimum: 0, maximum: 100 } }), WEBCHAT_ELICIT_SURFACE)).toEqual({
       propName: 'pct',
       kind: 'number',
       options: [],
       minimum: 0,
       maximum: 100
     })
-    expect(elicitTarget(form({ n: { type: 'integer' } }), WEBCHAT_ELICIT_KINDS)).toEqual({
+    expect(elicitTarget(form({ n: { type: 'integer' } }), WEBCHAT_ELICIT_SURFACE)).toEqual({
       propName: 'n',
       kind: 'number',
       options: [],
@@ -1703,49 +1762,51 @@ describe('elicitation card', () => {
   it('leaves typed fields unrenderable on Slack, whose card has nothing to type into', () => {
     const text = form({ name: { type: 'string' } })
     const number = form({ pct: { type: 'number' } })
-    expect(elicitTarget(text, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(text, SLACK_ELICIT_SURFACE)).toBeNull()
     expect(buildElicitationCard('elicit-1', text)).toBeNull()
-    expect(elicitTarget(number, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(number, SLACK_ELICIT_SURFACE)).toBeNull()
     expect(buildElicitationCard('elicit-1', number)).toBeNull()
     // The same forms ARE renderable — just not here: webchat types into them.
-    expect(elicitTarget(text, WEBCHAT_ELICIT_KINDS)?.kind).toBe('text')
-    expect(elicitTarget(number, WEBCHAT_ELICIT_KINDS)?.kind).toBe('number')
+    expect(elicitTarget(text, WEBCHAT_ELICIT_SURFACE)?.kind).toBe('text')
+    expect(elicitTarget(number, WEBCHAT_ELICIT_SURFACE)?.kind).toBe('number')
   })
 
   it('declines a typed field whose constraints ask for something it cannot render', () => {
     // Only the four MCP formats exist; anything else is a promise this card cannot keep.
-    expect(elicitTarget(form({ n: { type: 'string', format: 'hostname' } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(form({ n: { type: 'string', format: 'hostname' } }), WEBCHAT_ELICIT_SURFACE)).toBeNull()
     // Bounds that admit no answer at all are not a question.
-    expect(elicitTarget(form({ n: { type: 'string', minLength: 5, maxLength: 2 } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
-    expect(elicitTarget(form({ n: { type: 'number', minimum: 5, maximum: 2 } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
-    expect(elicitTarget(form({ n: { type: 'integer', minimum: 0.2, maximum: 0.8 } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(form({ n: { type: 'string', minLength: 5, maxLength: 2 } }), WEBCHAT_ELICIT_SURFACE)).toBeNull()
+    expect(elicitTarget(form({ n: { type: 'number', minimum: 5, maximum: 2 } }), WEBCHAT_ELICIT_SURFACE)).toBeNull()
+    expect(
+      elicitTarget(form({ n: { type: 'integer', minimum: 0.2, maximum: 0.8 } }), WEBCHAT_ELICIT_SURFACE)
+    ).toBeNull()
     // A pattern we refuse to run leaves the field unanswerable, never unchecked.
-    expect(elicitTarget(form({ n: { type: 'string', pattern: '^(a+)+$' } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(form({ n: { type: 'string', pattern: '^(a+)+$' } }), WEBCHAT_ELICIT_SURFACE)).toBeNull()
   })
 
   it('re-checks a typed string against every constraint the card carried', () => {
     const target = elicitTarget(
       form({ name: { type: 'string', minLength: 3, maxLength: 6, pattern: '^[a-z]+$' } }),
-      WEBCHAT_ELICIT_KINDS
+      WEBCHAT_ELICIT_SURFACE
     )!
     expect(textAccepts(target, 'abc')).toBe(true)
     expect(textAccepts(target, 'ab')).toBe(false) // below minLength
     expect(textAccepts(target, 'abcdefg')).toBe(false) // above maxLength
     expect(textAccepts(target, 'ABC')).toBe(false) // fails the pattern
     // An answer far past the cap is refused whatever the schema says.
-    const unbounded = elicitTarget(form({ name: { type: 'string' } }), WEBCHAT_ELICIT_KINDS)!
+    const unbounded = elicitTarget(form({ name: { type: 'string' } }), WEBCHAT_ELICIT_SURFACE)!
     expect(textAccepts(unbounded, 'x'.repeat(4096))).toBe(true)
     expect(textAccepts(unbounded, 'x'.repeat(4097))).toBe(false)
     // A multi-select target is not a text card, so nothing typed answers it.
     const list = elicitTarget(
       form({ c: { type: 'array', items: { type: 'string', enum: ['a'] } } }),
-      WEBCHAT_ELICIT_KINDS
+      WEBCHAT_ELICIT_SURFACE
     )!
     expect(textAccepts(list, 'a')).toBe(false)
   })
 
   it('accepts each of the four formats and refuses a value that is not one', () => {
-    const of = (format: string) => elicitTarget(form({ v: { type: 'string', format } }), WEBCHAT_ELICIT_KINDS)!
+    const of = (format: string) => elicitTarget(form({ v: { type: 'string', format } }), WEBCHAT_ELICIT_SURFACE)!
     expect(textAccepts(of('email'), 'user@example.com')).toBe(true)
     expect(textAccepts(of('email'), 'user@example')).toBe(false)
     expect(textAccepts(of('uri'), 'https://example.com/x')).toBe(true)
@@ -1757,14 +1818,14 @@ describe('elicitation card', () => {
   })
 
   it('re-checks a typed number against its bounds and its integer-ness', () => {
-    const pct = elicitTarget(form({ pct: { type: 'number', minimum: 0, maximum: 100 } }), WEBCHAT_ELICIT_KINDS)!
+    const pct = elicitTarget(form({ pct: { type: 'number', minimum: 0, maximum: 100 } }), WEBCHAT_ELICIT_SURFACE)!
     expect(numberAccepts(pct, 0)).toBe(true)
     expect(numberAccepts(pct, 50.5)).toBe(true)
     expect(numberAccepts(pct, -1)).toBe(false)
     expect(numberAccepts(pct, 101)).toBe(false)
     expect(numberAccepts(pct, Number.NaN)).toBe(false)
     expect(numberAccepts(pct, Number.POSITIVE_INFINITY)).toBe(false)
-    const count = elicitTarget(form({ n: { type: 'integer', minimum: 1 } }), WEBCHAT_ELICIT_KINDS)!
+    const count = elicitTarget(form({ n: { type: 'integer', minimum: 1 } }), WEBCHAT_ELICIT_SURFACE)!
     expect(numberAccepts(count, 2)).toBe(true)
     expect(numberAccepts(count, 2.5)).toBe(false)
   })
@@ -1781,7 +1842,7 @@ describe('elicitation card', () => {
     expect(safeElicitPattern(`^${'a'.repeat(201)}$`)).toBeNull()
     expect(safeElicitPattern('^[a-z$')).toBeNull() // does not even compile
     // The classic ReDoS input against the classic ReDoS pattern: never run at all.
-    const target = elicitTarget(form({ n: { type: 'string', pattern: '^(a+)+$' } }), WEBCHAT_ELICIT_KINDS)
+    const target = elicitTarget(form({ n: { type: 'string', pattern: '^(a+)+$' } }), WEBCHAT_ELICIT_SURFACE)
     expect(target).toBeNull()
   })
 
@@ -1791,12 +1852,15 @@ describe('elicitation card', () => {
     expect(safeElicitPattern('^a*a*a*a*b$')).toBeNull()
     // Degree is budgeted against the input cap, so ordinary multi-quantifier patterns stand.
     expect(safeElicitPattern('^\\d{3}-\\d{2}-\\d{4}$')).toBeInstanceOf(RegExp)
-    const target = elicitTarget(form({ n: { type: 'string', pattern: '^a*a*a*a*b$' } }), WEBCHAT_ELICIT_KINDS)
+    const target = elicitTarget(form({ n: { type: 'string', pattern: '^a*a*a*a*b$' } }), WEBCHAT_ELICIT_SURFACE)
     expect(target).toBeNull()
   })
 
   it('spends a pattern only on a short answer, however long the field allows', () => {
-    const t = elicitTarget(form({ n: { type: 'string', pattern: '^[a-z]+$', maxLength: 4000 } }), WEBCHAT_ELICIT_KINDS)!
+    const t = elicitTarget(
+      form({ n: { type: 'string', pattern: '^[a-z]+$', maxLength: 4000 } }),
+      WEBCHAT_ELICIT_SURFACE
+    )!
     expect(textAccepts(t, 'abc')).toBe(true)
     expect(textAccepts(t, 'a'.repeat(256))).toBe(true)
     expect(textAccepts(t, 'a'.repeat(257))).toBe(false)
@@ -1805,27 +1869,27 @@ describe('elicitation card', () => {
   // Dropping a bound we cannot enforce would accept an answer the schema forbids — the same
   // class of lie as answering a form whose required field the card never showed.
   it('declines a text field whose minimum exceeds the length it can enforce', () => {
-    expect(elicitTarget(form({ n: { type: 'string', minLength: 5000 } }), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(form({ n: { type: 'string', minLength: 5000 } }), WEBCHAT_ELICIT_SURFACE)).toBeNull()
     expect(
-      elicitTarget(form({ n: { type: 'string', pattern: '^[a-z]+$', minLength: 300 } }), WEBCHAT_ELICIT_KINDS)
+      elicitTarget(form({ n: { type: 'string', pattern: '^[a-z]+$', minLength: 300 } }), WEBCHAT_ELICIT_SURFACE)
     ).toBeNull()
   })
 
   it('carries the effective maximum, clamping a declared one down to what it can enforce', () => {
-    const plain = elicitTarget(form({ n: { type: 'string' } }), WEBCHAT_ELICIT_KINDS)!
+    const plain = elicitTarget(form({ n: { type: 'string' } }), WEBCHAT_ELICIT_SURFACE)!
     expect(plain.maxLength).toBe(4096)
-    const declared = elicitTarget(form({ n: { type: 'string', maxLength: 50 } }), WEBCHAT_ELICIT_KINDS)!
+    const declared = elicitTarget(form({ n: { type: 'string', maxLength: 50 } }), WEBCHAT_ELICIT_SURFACE)!
     expect(declared.maxLength).toBe(50)
     // A patterned field's ceiling is the pattern cap, so the browser bounds its draft by it.
     const patterned = elicitTarget(
       form({ n: { type: 'string', pattern: '^[a-z]+$', maxLength: 4000 } }),
-      WEBCHAT_ELICIT_KINDS
+      WEBCHAT_ELICIT_SURFACE
     )!
     expect(patterned.maxLength).toBe(256)
   })
 
   it('fails an impossible calendar value instead of throwing out of the check', () => {
-    const d = elicitTarget(form({ n: { type: 'string', format: 'date' } }), WEBCHAT_ELICIT_KINDS)!
+    const d = elicitTarget(form({ n: { type: 'string', format: 'date' } }), WEBCHAT_ELICIT_SURFACE)!
     expect(() => textAccepts(d, '2025-13-01')).not.toThrow()
     expect(textAccepts(d, '2025-13-01')).toBe(false)
     expect(textAccepts(d, '2025-02-30')).toBe(false)
@@ -1833,7 +1897,8 @@ describe('elicitation card', () => {
   })
 
   it('pre-populates every kind from the schema default, and drops one it would refuse', () => {
-    const seed = (prop: Record<string, unknown>) => elicitTarget(form({ v: prop }), WEBCHAT_ELICIT_KINDS)?.defaultValue
+    const seed = (prop: Record<string, unknown>) =>
+      elicitTarget(form({ v: prop }), WEBCHAT_ELICIT_SURFACE)?.defaultValue
     expect(seed({ type: 'string', enum: ['red', 'green'], default: 'green' })).toBe('green')
     expect(seed({ type: 'boolean', default: true })).toBe(true)
     expect(seed({ type: 'string', format: 'email', default: 'user@example.com' })).toBe('user@example.com')
@@ -1867,38 +1932,40 @@ describe('elicitation card', () => {
 
   it('renders a two-field form on webchat and still declines it on Slack', () => {
     const two = req(TWO, ['branch', 'note'])
-    expect(elicitForm(two, WEBCHAT_ELICIT_KINDS)?.map((t) => [t.propName, t.kind])).toEqual([
+    expect(elicitForm(two, WEBCHAT_ELICIT_SURFACE)?.map((t) => [t.propName, t.kind])).toEqual([
       ['branch', 'enum'],
       ['note', 'text']
     ])
     // One card answers one field there, and Slack has nothing to type into either — both
     // reasons still hold, so the form declines rather than half-answering.
-    expect(elicitTarget(two, WEBCHAT_ELICIT_KINDS)).toBeNull()
-    expect(elicitTarget(two, SLACK_ELICIT_KINDS)).toBeNull()
-    expect(elicitForm(two, SLACK_ELICIT_KINDS)).toBeNull()
+    expect(elicitTarget(two, WEBCHAT_ELICIT_SURFACE)).toBeNull()
+    expect(elicitTarget(two, SLACK_ELICIT_SURFACE)).toBeNull()
+    expect(elicitForm(two, SLACK_ELICIT_SURFACE)).toBeNull()
     expect(buildElicitationCard('elicit-1', two)).toBeNull()
   })
 
   it('answers a form whose required set is fully rendered, and declines one that is not', () => {
     // Every required property is among the rendered fields — the #1795 rule, generalised.
-    expect(elicitForm(req(TWO, ['branch']), WEBCHAT_ELICIT_KINDS)).toHaveLength(2)
-    expect(elicitForm(req(TWO, []), WEBCHAT_ELICIT_KINDS)).toHaveLength(2)
+    expect(elicitForm(req(TWO, ['branch']), WEBCHAT_ELICIT_SURFACE)).toHaveLength(2)
+    expect(elicitForm(req(TWO, []), WEBCHAT_ELICIT_SURFACE)).toHaveLength(2)
     // A required property NO surface can render leaves the form unanswerable, exactly as one
     // required field the single-field card could not show always did.
     const nested = { branch: { type: 'string', enum: ['main'] }, extra: { type: 'object' } }
-    expect(elicitForm(req(nested, ['branch', 'extra']), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitForm(req(nested, ['branch', 'extra']), WEBCHAT_ELICIT_SURFACE)).toBeNull()
     // Unrenderable because of its own constraints, not its type: same verdict.
     const bad = { branch: { type: 'string', enum: ['main'] }, name: { type: 'string', pattern: '^(a+)+$' } }
-    expect(elicitForm(req(bad, ['branch', 'name']), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitForm(req(bad, ['branch', 'name']), WEBCHAT_ELICIT_SURFACE)).toBeNull()
     // Nothing renderable at all is not a form.
-    expect(elicitForm(req({ extra: { type: 'object' } }, []), WEBCHAT_ELICIT_KINDS)).toBeNull()
-    expect(elicitForm({ mode: 'url', sessionId: 's1', url: 'https://x' } as any, WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitForm(req({ extra: { type: 'object' } }, []), WEBCHAT_ELICIT_SURFACE)).toBeNull()
+    expect(elicitForm({ mode: 'url', sessionId: 's1', url: 'https://x' } as any, WEBCHAT_ELICIT_SURFACE)).toBeNull()
   })
 
   it('declines a form longer than one card can ask', () => {
     const props = (n: number) => Object.fromEntries(Array.from({ length: n }, (_, i) => [`f${i}`, { type: 'boolean' }]))
-    expect(elicitForm(req(props(ELICIT_FORM_FIELD_CAP), []), WEBCHAT_ELICIT_KINDS)).toHaveLength(ELICIT_FORM_FIELD_CAP)
-    expect(elicitForm(req(props(ELICIT_FORM_FIELD_CAP + 1), []), WEBCHAT_ELICIT_KINDS)).toBeNull()
+    expect(elicitForm(req(props(ELICIT_FORM_FIELD_CAP), []), WEBCHAT_ELICIT_SURFACE)).toHaveLength(
+      ELICIT_FORM_FIELD_CAP
+    )
+    expect(elicitForm(req(props(ELICIT_FORM_FIELD_CAP + 1), []), WEBCHAT_ELICIT_SURFACE)).toBeNull()
   })
 
   it('reduces a one-field form to exactly what the single-field card renders', () => {
@@ -1910,7 +1977,7 @@ describe('elicitation card', () => {
       { type: 'array', items: { type: 'string', enum: ['a', 'b'] }, minItems: 1 }
     ]) {
       const one = req({ v: prop }, ['v'])
-      expect(elicitForm(one, WEBCHAT_ELICIT_KINDS)).toEqual([elicitTarget(one, WEBCHAT_ELICIT_KINDS)])
+      expect(elicitForm(one, WEBCHAT_ELICIT_SURFACE)).toEqual([elicitTarget(one, WEBCHAT_ELICIT_SURFACE)])
     }
   })
 
@@ -1930,7 +1997,7 @@ describe('elicitation card', () => {
       force: { type: 'boolean' }
     }
     const params = req(props, ['branch'])
-    const form = elicitForm(params, WEBCHAT_ELICIT_KINDS)!
+    const form = elicitForm(params, WEBCHAT_ELICIT_SURFACE)!
     const accepts = (answer: Record<string, string | number | string[]>) =>
       elicitFormAccepts(form, elicitRequiredProps(params), answer)
 
@@ -1966,7 +2033,7 @@ describe('elicitation card', () => {
       },
       ['branch']
     )
-    const form = elicitForm(params, WEBCHAT_ELICIT_KINDS)!
+    const form = elicitForm(params, WEBCHAT_ELICIT_SURFACE)!
     // A boolean's wire value is its option string; the content carries a real boolean.
     expect(elicitFormContent(form, { branch: 'main', retries: 2, checks: ['lint'], force: 'false' })).toEqual({
       branch: 'main',


### PR DESCRIPTION
Implements #1794 gap 7, the last item in the webchat column.

`buildElicitationCard` did `target.options.slice(0, 5)`. A seven-option enum rendered five buttons and the card still answered `accept` — the reader never saw the two that were cut, and the agent could not tell the choice was made from a truncated set. Whatever was picked was reported as the answer to the full question, which is the same quiet misrepresentation #1795 fixed for required fields.

## The limit is now a property of the surface

#1801 established that surfaces declare what they can render, so a kind is invisible to a surface that has not claimed it. An option limit is the same kind of fact — a Slack constraint — but it was a bare constant inside a card builder, which is why webchat inherited nothing and Slack truncated in silence.

```ts
export interface ElicitSurface {
  kinds: ReadonlySet<ElicitKind>
  maxOptions?: number   // undefined = no limit
}
SLACK_ELICIT_SURFACE   = { kinds: { enum, boolean }, maxOptions: 24 }
WEBCHAT_ELICIT_SURFACE = { kinds: { …all five } }        // uncapped, unchanged
```

`elicitCandidates` applies the limit, so **the reduction decides**, not the card builder — `buildElicitationCard` no longer contains a limit at all, and the approval-DM card inherits the same verdict because it shares the builder. Adding a surface later means declaring a number rather than remembering a `slice`.

Slack's `actions` block holds 25 elements, so 24 options plus Dismiss fills it; the buttons wrap across lines, and the old 5 was aesthetic rather than structural. Past 24 the field is not renderable and the form declines — the same verdict a field Slack cannot render already gets, and one the agent can act on by asking again in smaller pieces.

## Why not a select menu

The issue suggested `static_select`, and I asked for it. It does not survive Slack's own limits:

- **Slack caps an option object's `value` at 75 characters; a button's `value` allows 2000.** We send `<requestId>|<optionValue>`, and enum values come straight from the agent's schema, so a moderately long value would make Slack reject the whole message — the card never posts and the elicitation is cancelled. That trades a silent truncation for silently never asking. Avoiding it needs an index indirection, which is ambiguous against an option literally named `#3`.
- A select moves the answer from `action.value` to `selected_option.value`, widening the relay and daemon wire seam for what is purely a rendering choice.

Buttons already cover the case the issue names.

## Clamps

- **Option labels (75)** already appended `…`, and 75 is Slack's hard `plain_text` limit for a button, so truncation there is visible and unavoidable. Unchanged.
- **Message (400)** was our own number, far under Slack's 3000-character section limit, so it cut questions Slack could have shown whole. Raised to 2800, with the resolved card clamping its composed text to 3000 since the decision line is appended after. Anything past that still shows `…`.

## Two defects found next door, filed rather than swept

- **#1811** — `buildPermissionCard` has the identical `slice(0, 5)`, on ACP `PermissionOption`s. Same user-visible consequence, different seam: the permission path has no reduction to hang a surface limit off, and "decline" may be the wrong answer for a permission request, so it needs a decision rather than a port.
- **#1812** — the `offered` check that re-derives an answer against the card's own options sits inside the webchat-only branch, so **a Slack answer is never validated against the card that offered it**. Until this PR, both halves of "never report `accept` for a choice from a set the reader did not fully see" were unenforced: the card truncated silently and nothing downstream checked. This PR fixes the card; #1812 is the other half.

Also noted and deliberately not fixed: two options whose labels are identical after the 75-character clamp render as indistinguishable buttons. Declining on that risks regressing forms with genuinely duplicate titles.

## Verification

- protocol 488, relay 644, web 2400, daemon (`render` / `daemon-permission-autoallow` / `daemon-webchat` / `approval-dm` / `acp-host`) 383 — all passing, independently re-run.
- `pnpm typecheck`: `error TS` count 0.
- eslint + prettier clean on changed files.

All six new assertions were confirmed red by reverting only the behavioural parts of `render.ts` and keeping the tests — covering the full-list render, the decline past the cap, the long message, the approval-DM card, and the end-to-end accept of a pick past the fifth.
