### PR TITLE
fix(daemon): re-derive every elicitation answer against the card that offered it

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -39,6 +39,7 @@ import {
   elicitRequiredProps,
   elicitTarget,
   elicitUrl,
+  fieldAccepts,
   multiSelectAccepts,
   numberAccepts,
   SLACK_ELICIT_SURFACE,
@@ -881,6 +882,10 @@ export class PermissionCoordinator {
       res = { action: 'decline' }
       decision = ':no_entry_sign: Dismissed'
     } else if (notify.propName && notify.valueKind) {
+      // Same card builder, same re-derivation: the actor checks above say who tapped, not what
+      // this card offered, so an unoffered value is dropped and the DM card stays live.
+      const target = elicitTarget(rec.params, SLACK_ELICIT_SURFACE)
+      if (!target || !fieldAccepts(target, value)) return
       const chosen = notify.valueKind === 'boolean' ? value === 'true' : value
       res = { action: 'accept', content: { [notify.propName]: chosen } }
       decision = `:white_check_mark: ${notify.valueKind === 'boolean' ? (chosen ? 'Yes' : 'No') : value}`
@@ -1696,30 +1701,29 @@ export class PermissionCoordinator {
     // for a numeric field, a string for the rest. Dismiss (null) settles any of them.
     if (a.value !== null && !isFormAnswer(a.value) && !answerFitsKind(rec.kind, a.value)) return
     const target = elicitTarget(rec.params, surfaceOf(rec))
+    // A browser answers only a card ITS OWN conversation was shown: both surfaces share one
+    // `elicit-<n>` counter, so the guessable id would otherwise reach another conversation's.
     if (a.webchatConversationId !== undefined) {
       if (rec.surface !== 'webchat' || rec.wc.conversationId !== a.webchatConversationId) return
-      // The card names every answer it accepts; anything else would inject an unoffered value
-      // into the agent's content, so it is dropped and the card stays live. A multi-select adds
-      // no repeats and a count its bounds allow; a typed field, the schema constraints the
-      // control was shown — a browser frame is never what makes an answer valid.
-      // A form's record answers exactly the fields the card rendered, each value valid for its
-      // own field: one bad or unexpected field refuses the whole answer, card still live.
-      const offered =
-        a.value === null ||
-        (isFormAnswer(a.value)
-          ? !!form && elicitFormAccepts(form, elicitRequiredProps(rec.params), a.value)
-          : !!target &&
-            (Array.isArray(a.value)
-              ? multiSelectAccepts(target, a.value)
-              : typeof a.value === 'number'
-                ? numberAccepts(target, a.value)
-                : target.kind === 'text'
-                  ? textAccepts(target, a.value)
-                  : target.options.some((o) => o.value === a.value)))
-      if (!offered) return
-      // A card settles only from its own surface: both share one `elicit-<n>` counter, so
-      // without this a Slack tap could answer a live webchat card.
+      // And a card settles only from its own surface, so a Slack tap never answers a webchat one.
     } else if (rec.surface === 'webchat') return
+    // Every surface's answer is re-derived against the card that offered it: a signed interaction
+    // and a relay that checks the block target say who tapped, never what the card offered.
+    // An unoffered value would inject content the agent never asked for, so it is dropped and the
+    // card stays live — one bad field refusing a whole form answer, as on webchat all along.
+    const offered =
+      a.value === null ||
+      (isFormAnswer(a.value)
+        ? !!form && elicitFormAccepts(form, elicitRequiredProps(rec.params), a.value)
+        : !!target &&
+          (Array.isArray(a.value)
+            ? multiSelectAccepts(target, a.value)
+            : typeof a.value === 'number'
+              ? numberAccepts(target, a.value)
+              : target.kind === 'text'
+                ? textAccepts(target, a.value)
+                : target.options.some((o) => o.value === a.value)))
+    if (!offered) return
     if (rec.approval && this.host.agents().get(rec.agentId)?.allowRuntimeChangesInChat !== true) {
       if (rec.surface === 'slack' && rec.ts) {
         void rec.conn

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -175,6 +175,23 @@ describe('approval DM (slack-approval-dm.md §5–§6)', () => {
     await over.store.close()
   })
 
+  // Same card builder, so the same #1812 re-derivation: the actor and verify checks establish
+  // WHO tapped, never what this card offered.
+  it('re-derives the DM answer against its own card, dropping one it never offered', async () => {
+    const w = await world()
+    const answered = w.coordinator.onAcpElicit(OWNER, ACP_SESSION, approvalElicitation(['once', 'session']))
+    await vi.waitFor(() => expect(w.conn.postBlocks).toHaveBeenCalledTimes(1))
+    const requestId = requestIdOf(w.route)
+
+    await w.coordinator.handleElicitChoice({ requestId, value: 'always', actor: { userId: 'U1' } })
+    expect(w.conn.updateBlocks).not.toHaveBeenCalled()
+    expect((await w.store.listPermissionRequests(AGENT))[0]!.status).toBe('pending')
+
+    await w.coordinator.handleElicitChoice({ requestId, value: 'session', actor: { userId: 'U1' } })
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { pick: 'session' } })
+    await w.store.close()
+  })
+
   it('refuses a wrong actor and an unanswerable verify without settling the request', async () => {
     const w = await world()
     const decided = w.coordinator.onAcpPermission(OWNER, ACP_SESSION, permissionParams())

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1959,10 +1959,17 @@ describe('Slack interactive status bar', () => {
     ;(daemon as any).permissions.pendingElicits.set('elicit-1', {
       agentId: 'bot-a',
       sessionId: 'acp-1',
-      params: { message: 'Pick one' },
+      // The params a real entry carries: onAcpElicit only stores what built the card, and the
+      // answer is now re-derived against it, so a schema-less stand-in is not a card at all.
+      params: {
+        mode: 'form',
+        message: 'Pick one',
+        requestedSchema: { type: 'object', properties: { language: { type: 'string', enum: ['TypeScript', 'Go'] } } }
+      },
       propName: 'language',
       kind: 'enum',
       approval: false,
+      surface: 'slack',
       conn: { updateBlocks, workspaceId: () => 'T1' },
       channel: 'C1',
       ts: 'card-2',

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -751,23 +751,27 @@ function enumElicitation(options: string[]): CreateElicitationRequest {
   })
 }
 
-describe('a Slack card offers every option or none', () => {
-  /** A Slack turn whose posted card blocks are captured. */
-  function slackPending(daemon: any): { pending: any; posted: any[][] } {
-    const pending: any = installPending(daemon)
-    const posted: any[][] = []
-    pending.plan.platform = 'slack'
-    const conn = Object.create(SlackConnection.prototype)
-    conn.postBlocks = async (_c: string, blocks: any[]) => {
-      posted.push(blocks)
-      return 'ts-1'
-    }
-    conn.updateBlocks = async () => true
-    conn.workspaceId = () => 'T1'
-    pending.conn = conn
-    return { pending, posted }
+/** A Slack turn whose posted card blocks are captured, alongside every in-place rewrite. */
+function slackPending(daemon: any): { pending: any; posted: any[][]; updated: any[][] } {
+  const pending: any = installPending(daemon)
+  const posted: any[][] = []
+  const updated: any[][] = []
+  pending.plan.platform = 'slack'
+  const conn = Object.create(SlackConnection.prototype)
+  conn.postBlocks = async (_c: string, blocks: any[]) => {
+    posted.push(blocks)
+    return 'ts-1'
   }
+  conn.updateBlocks = async (_c: string, _ts: string, blocks: any[]) => {
+    updated.push(blocks)
+    return true
+  }
+  conn.workspaceId = () => 'T1'
+  pending.conn = conn
+  return { pending, posted, updated }
+}
 
+describe('a Slack card offers every option or none', () => {
   // The seven-option enum of the issue: five buttons went out, the reader never saw the last two,
   // and whichever they picked came back as `accept` on the whole question.
   it('cards all seven options and accepts a pick past the fifth', async () => {
@@ -796,6 +800,49 @@ describe('a Slack card offers every option or none', () => {
     expect(posted).toHaveLength(0)
     // The same form is renderable where nothing declares a limit — webchat still shows them all.
     expect(elicitTarget(enumElicitation(many), WEBCHAT_ELICIT_SURFACE)?.options).toHaveLength(25)
+  })
+})
+
+// ── every surface re-derives its answer (issue #1812) ────────────────────────
+// The whitelist used to sit inside the webchat-only branch, so a Slack answer became agent
+// content unchecked — correctness resting on the relay and on Slack rather than on the card
+// the daemon itself posted.
+
+describe('a Slack answer is re-derived against the card that offered it', () => {
+  it('drops a value the card never offered and leaves the card live', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { updated } = slackPending(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', enumElicitation(['a', 'b', 'c']))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'rm -rf /' })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1) // still live — nothing settled it
+    expect(updated).toHaveLength(0)
+
+    // A Slack tap on a button the card actually carries still resolves, unchanged.
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'b' })
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { pick: 'b' } })
+  })
+
+  it('resolves a Codex MCP approval through the persist option its own card offered', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted, updated } = slackPending(daemon)
+    ;(daemon as any).agents.set('agent-1', { allowRuntimeChangesInChat: true })
+    const approval = (daemon as any).permissions.onAcpElicit('agent-1', 's1', elicitation('call-1'))
+    await vi.waitFor(() => expect(posted).toHaveLength(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    // The approval's enum reaches Slack as one button per value, each carrying `<id>|<value>`.
+    const elements = posted[0]![1]!.elements as any[]
+    expect(elements.map((e) => e.value)).toEqual([`${requestId}|once`, `${requestId}|session`, requestId])
+
+    // A `persist` the schema never enumerated is not an approval this card can report.
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'always' })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(updated).toHaveLength(0)
+
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'session' })
+    await expect(approval).resolves.toEqual({ action: 'accept', content: { persist: 'session' } })
   })
 })
 


### PR DESCRIPTION
Fixes #1812. First item of the Slack column on #1794.

## The defect

The check that re-derives an elicitation answer against the card that offered it — the option whitelist, `multiSelectAccepts`, the typed-field constraints, `elicitFormAccepts` — sat **inside** `if (a.webchatConversationId !== undefined)`. That branch is only entered for a browser answer, so **a Slack answer was never validated against its own card**: the daemon took the relay-forwarded value, converted it, and reported it to the agent as the reader's answer.

The reasoning that produced this was that Slack is signed and the relay checks the block target, so the value can only be one the daemon itself put on a button. That holds for an intact chain, but it makes the daemon's correctness depend on the relay and on Slack rather than on something it re-derives from the card it posted — and it is defence the webchat path already had. A signed interaction and a validated block target establish **who tapped**, never **what the card offered**.

## The fix

The `offered` expression moves out of the webchat-only branch, verbatim, so every surface's answer is re-derived before it becomes agent content. It is a relocation, not a rewrite — the diff reads as one.

The two binding guards stay exactly where they were, because they are genuinely webchat-specific: a browser answer is still confined to its own conversation, and a card still settles only from its own surface. `surfaceOf(rec)` still feeds the re-derivation, so a Slack card is re-derived with `SLACK_ELICIT_SURFACE` and a webchat one with `WEBCHAT_ELICIT_SURFACE` — the re-derivation asks the same question the post did.

A refused answer is still a bare return: card live, nothing settled, on both surfaces.

## The issue was wrong about "the only path", and the second one was live

#1812 called this the only path where the agent's content is not checked against the reduction that produced the card. That was inaccurate, and I have corrected the issue.

`handleDmElicitChoice` — the approval-DM route — was a second such path. It checked only `notify.propName` and `notify.valueKind`, both captured at card-build time, and never the option list, so it accepted **any** string. Its card is literally `buildElicitationCard`, reached over the same relay chain: the same defect on the same builder, one function away. `verifyDmActor` establishes who tapped, not what was offered.

It was live, not theoretical. With the fix reverted, the new test shows an unoffered `always` reported to the agent and the DM card rewritten as `:white_check_mark: always — Ada`.

Fixing one and not the other would have left this issue's own stated invariant untrue, so both are fixed here.

## The Codex approval path round-trips byte-exactly — checked, not assumed

Codex MCP approvals ride `pendingElicits` with `surface: 'slack'` and a `persist` enum, so the new check now applies to them. It is safe because the value that comes back is the one the card put out:

- `buildElicitationCard` derives its buttons from `elicitTarget(params, SLACK_ELICIT_SURFACE)` and sets `value: encodePermValue(requestId, o.value)`. `onAcpElicit` stores that same (already masked) `params` object, and posts only when the target is non-null — so the resolve-time re-derivation yields the identical option set.
- `encodePermValue`/`decodePermValue` split on the **first** `|`, and a `requestId` is a UUID or `elicit-<n>`, both `|`-free — so an option value containing `|` still returns verbatim.
- Both ingress paths pass it through untouched (relay `http-ingest`, and direct Socket Mode), and the wire type is `value: string | null`, so a Slack answer is always a bare string.

`isMcpToolApprovalElicitation` only affects routing and `rec.approval`, never the reduction. The new test asserts the posted button values are `<requestId>|once` / `<requestId>|session` and then resolves through `session`.

## Follow-up, deliberately not done here

The `offered` expression is now a near-duplicate of the exported `fieldAccepts`; they differ only in a condition that is a no-op today. Collapsing them is the right cleanup, but it is behaviour-shaped code inside a security fix, so the move was kept pure.

## Verification

- protocol 488, relay 644, web 2400, daemon (`render` / `daemon-permission-autoallow` / `daemon-webchat` / `approval-dm` / `acp-host`) 386 — all passing, independently re-run.
- `pnpm typecheck`: `error TS` count 0.
- eslint + prettier clean on the three changed files.

New tests, each confirmed red with only the source file reverted: a Slack answer carrying a value the card never offered leaves the card live; a Codex MCP approval still resolves through the `persist` option its own card offered; the DM answer is re-derived against its own card. The pre-existing webchat guards — conversation binding, surface binding, and its own whitelist — are unmodified and still green.
