### PR TITLE
fix(console): fold a question's own "Other" box into that question

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -147,10 +147,16 @@ function formAnswerLabel(
   form: readonly ElicitTarget[],
   answer: ElicitFormAnswer
 ): string {
+  // A companion box is named for the question it sits in ("Branch (Other)"), never on its own:
+  // "Other: dev" in a transcript says which words were typed but not what they answer.
+  const name = (t: ElicitTarget) =>
+    t.customAnswerFor
+      ? `${elicitFieldLabel(params, t.customAnswerFor)} (${elicitFieldLabel(params, t.propName)})`
+      : elicitFieldLabel(params, t.propName)
   const parts: string[] = []
   for (const t of form) {
     const value = answer[t.propName]
-    if (value !== undefined) parts.push(`${elicitFieldLabel(params, t.propName)}: ${chosenLabel(t, value)}`)
+    if (value !== undefined) parts.push(`${name(t)}: ${chosenLabel(t, value)}`)
   }
   // An all-optional form left alone is still an answer — settling it as nothing would read
   // as a card that never resolved, the same reason a `minItems: 0` selection says so too.
@@ -1518,6 +1524,8 @@ export class PermissionCoordinator {
                   label: elicitFieldLabel(params, t.propName),
                   kind: t.kind,
                   ...(required.has(t.propName) ? { required: true } : {}),
+                  ...(t.description ? { description: t.description } : {}),
+                  ...(t.customAnswerFor ? { customAnswerFor: t.customAnswerFor } : {}),
                   ...elicitCardDescriptors(t)
                 }))
               }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -661,6 +661,13 @@ export interface ElicitTarget {
   /** The schema's `default`, kept only when it satisfies this target's own constraints —
    *  the card seeds its control with it, and the reader may still answer something else. */
   defaultValue?: string | number | boolean | string[]
+  /** The property's own `description` — the question text, where `title` is only its header
+   *  (an AskUserQuestion bridge splits them that way). Absent when the schema gave none. */
+  description?: string
+  /** Set on a select question's free-text companion: the property whose question this box
+   *  types an answer for. Only ever a `text` target, and only when that question is rendered
+   *  in the same form — the card then places the box inside it instead of asking it twice. */
+  customAnswerFor?: string
 }
 
 /** The longest answer a card accepts: an elicitation asks a question, not for a file. */
@@ -861,6 +868,22 @@ export function elicitFieldLabel(params: CreateElicitationRequest, propName: str
   return clampTo((typeof title === 'string' && title.trim()) || propName, 75)
 }
 
+/** ACP's cross-agent marker for a select question's own free-text box — written by the
+ *  AskUserQuestion bridges (Claude, Codex) under a namespace-free `_meta` key on purpose. */
+const CUSTOM_ANSWER_META_KEY = '_askUserQuestionCustomAnswer'
+
+/** The longest question text a card carries under a field's label. */
+const ELICIT_DESCRIPTION_MAX = 300
+
+/** The question a property's `_meta` claims this free-text box answers, or undefined when it
+ *  claims none — an unmarked property is a question in its own right. */
+function customAnswerOwner(prop: Record<string, unknown>): string | undefined {
+  const meta = (prop._meta as Record<string, unknown> | undefined)?.[CUSTOM_ANSWER_META_KEY] as
+    { questionId?: unknown; isCustomAnswer?: unknown } | undefined
+  const owner = meta?.questionId
+  return meta?.isCustomAnswer === true && typeof owner === 'string' && owner ? owner : undefined
+}
+
 /**
  * Every property of the form this surface can render, in schema order: string-enum (`oneOf`
  * titled options or bare `enum`), boolean, string-array multi-select (`items.enum` or
@@ -881,8 +904,23 @@ function elicitCandidates(params: CreateElicitationRequest, surface: ElicitSurfa
   const fits = (options: readonly unknown[]) => surface.maxOptions === undefined || options.length <= surface.maxOptions
   const found: ElicitTarget[] = []
   for (const [name, prop] of Object.entries(p.requestedSchema?.properties ?? {})) {
+    const owner = customAnswerOwner(prop)
+    // A companion's own description is boilerplate the inline placement already says; the
+    // question's is the ask itself, which `title` (a header) does not carry.
+    const desc = !owner && typeof prop.description === 'string' ? prop.description.trim() : ''
     const keep = (t: ElicitTarget | null) => {
-      if (t) found.push(withDefault(t, prop.default))
+      if (!t) return
+      found.push(
+        withDefault(
+          {
+            ...t,
+            ...(desc ? { description: clampTo(desc, ELICIT_DESCRIPTION_MAX) } : {}),
+            // Only a typed box can BE a custom answer; a marker on anything else is ignored.
+            ...(owner && t.kind === 'text' ? { customAnswerFor: owner } : {})
+          },
+          prop.default
+        )
+      )
     }
     if (prop?.type === 'string') {
       const oneOf = prop.oneOf as { const?: unknown; title?: unknown }[] | undefined
@@ -924,7 +962,14 @@ function elicitCandidates(params: CreateElicitationRequest, surface: ElicitSurfa
         ]
       })
   }
-  return found
+  // A companion whose question this surface did not render has nothing to sit inside, so it
+  // stands as a field of its own rather than pointing at a control that is not on the card.
+  const questions = new Set(found.filter((t) => !t.customAnswerFor).map((t) => t.propName))
+  return found.map((t) => {
+    if (!t.customAnswerFor || questions.has(t.customAnswerFor)) return t
+    const { customAnswerFor: _orphan, ...rest } = t
+    return rest
+  })
 }
 
 /** The elicitation's URL-mode target (ACP `ElicitationUrlMode`), or null when this is not a
@@ -967,13 +1012,15 @@ export function elicitTarget(params: CreateElicitationRequest, surface: ElicitSu
  * order. Returns null when the surface can render nothing, when a `required` property is not
  * among the rendered set — {@link elicitTarget}'s rule (#1795) generalised from the one
  * rendered field to the rendered set, and still the difference between an honest `accept` and
- * a lie — or when the form is longer than {@link ELICIT_FORM_FIELD_CAP}. A one-field result is
- * exactly what {@link elicitTarget} would return, which is what keeps a single-field card's
- * wire payload unchanged.
+ * a lie — or when the form asks more than {@link ELICIT_FORM_FIELD_CAP} QUESTIONS. A select
+ * question's free-text companion is not one of them: it rides inside the question it belongs
+ * to, so pairing every question with an "Other" box does not halve the form a card can show.
+ * A one-field result is exactly what {@link elicitTarget} would return, which is what keeps a
+ * single-field card's wire payload unchanged.
  */
 export function elicitForm(params: CreateElicitationRequest, surface: ElicitSurface): ElicitTarget[] | null {
   const targets = elicitCandidates(params, surface)
-  if (!targets.length || targets.length > ELICIT_FORM_FIELD_CAP) return null
+  if (!targets.length || targets.filter((t) => !t.customAnswerFor).length > ELICIT_FORM_FIELD_CAP) return null
   const rendered = new Set(targets.map((t) => t.propName))
   return elicitRequiredProps(params).every((r) => rendered.has(r)) ? targets : null
 }

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -1997,6 +1997,10 @@ describe('elicitation card', () => {
     expect(form?.[1]?.description).toBeUndefined()
     // The box is still an ordinary optional text field on the way back in.
     expect(elicitFormAccepts(form!, [], { question_0_custom: 'release/1.2' })).toBe(true)
+    // And it does NOT stand in for a REQUIRED question: the schema names that property, so an
+    // answer without it is refused here — which is why the card keeps asking for the pick too.
+    expect(elicitFormAccepts(form!, ['question_0'], { question_0_custom: 'release/1.2' })).toBe(false)
+    expect(elicitFormAccepts(form!, ['question_0'], { question_0: 'main', question_0_custom: 'x' })).toBe(true)
   })
 
   it('leaves a custom-answer box standing alone when its question is not on the card', () => {

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -1968,6 +1968,64 @@ describe('elicitation card', () => {
     expect(elicitForm(req(props(ELICIT_FORM_FIELD_CAP + 1), []), WEBCHAT_ELICIT_SURFACE)).toBeNull()
   })
 
+  // An AskUserQuestion bridge (claude-agent-acp, codex) pairs every select question with its
+  // own free-text box, marked `_askUserQuestionCustomAnswer`. The box belongs INSIDE its
+  // question — rendered as a peer it read as a second question titled "Other" (#1817).
+  const custom = (questionId: string) => ({
+    type: 'string',
+    title: 'Other',
+    description: 'Type your own answer instead of choosing an option above (optional).',
+    _meta: { _askUserQuestionCustomAnswer: { questionId, isCustomAnswer: true } }
+  })
+
+  it('binds a free-text custom-answer box to the question that offered it', () => {
+    const asked = req(
+      {
+        question_0: { type: 'string', title: 'Branch', description: 'Which branch?', oneOf: [{ const: 'main' }] },
+        question_0_custom: custom('question_0')
+      },
+      []
+    )
+    const form = elicitForm(asked, WEBCHAT_ELICIT_SURFACE)
+    expect(form?.map((t) => [t.propName, t.customAnswerFor])).toEqual([
+      ['question_0', undefined],
+      ['question_0_custom', 'question_0']
+    ])
+    // The question's own text rides under its header; the companion's boilerplate does not,
+    // since sitting inside the question is what already says what it is for.
+    expect(form?.[0]?.description).toBe('Which branch?')
+    expect(form?.[1]?.description).toBeUndefined()
+    // The box is still an ordinary optional text field on the way back in.
+    expect(elicitFormAccepts(form!, [], { question_0_custom: 'release/1.2' })).toBe(true)
+  })
+
+  it('leaves a custom-answer box standing alone when its question is not on the card', () => {
+    // The marker names a property this surface never rendered (or none at all): a box that
+    // pointed at an absent control would simply vanish, so it stays a field of its own.
+    const orphan = req({ q: { type: 'object' }, q_custom: custom('q') }, [])
+    expect(elicitForm(orphan, WEBCHAT_ELICIT_SURFACE)?.map((t) => [t.propName, t.customAnswerFor])).toEqual([
+      ['q_custom', undefined]
+    ])
+    // A marker on something that is not a typed box claims nothing.
+    const notText = req({ a: { type: 'string', enum: ['x'] }, b: { ...custom('a'), type: 'boolean' } }, [])
+    expect(elicitForm(notText, WEBCHAT_ELICIT_SURFACE)?.every((t) => t.customAnswerFor === undefined)).toBe(true)
+  })
+
+  it('counts questions, not their custom-answer boxes, against the form cap', () => {
+    const paired = (n: number) =>
+      Object.fromEntries(
+        Array.from({ length: n }, (_, i) => [
+          [`question_${i}`, { type: 'string', oneOf: [{ const: 'y' }] }],
+          [`question_${i}_custom`, custom(`question_${i}`)]
+        ]).flat() as [string, unknown][]
+      )
+    // At the cap the card carries twice the cap in properties and still renders.
+    expect(elicitForm(req(paired(ELICIT_FORM_FIELD_CAP), []), WEBCHAT_ELICIT_SURFACE)).toHaveLength(
+      ELICIT_FORM_FIELD_CAP * 2
+    )
+    expect(elicitForm(req(paired(ELICIT_FORM_FIELD_CAP + 1), []), WEBCHAT_ELICIT_SURFACE)).toBeNull()
+  })
+
   it('reduces a one-field form to exactly what the single-field card renders', () => {
     for (const prop of [
       { type: 'string', enum: ['main', 'dev'], default: 'dev' },

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  ELICIT_FORM_FIELD_CAP,
+  ELICIT_FORM_WIRE_FIELD_CAP,
   WireFeishuCardActionEvent,
   RdMsg,
   RdMsgWebchat,
@@ -242,7 +242,7 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
     ).toBe(false)
     expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: '', value: 'y' }).success).toBe(false)
     // No form is longer than the card cap (an EMPTY record IS an answer — see the case below).
-    const wide = Object.fromEntries(Array.from({ length: ELICIT_FORM_FIELD_CAP + 1 }, (_, i) => [`f${i}`, 'x']))
+    const wide = Object.fromEntries(Array.from({ length: ELICIT_FORM_WIRE_FIELD_CAP + 1 }, (_, i) => [`f${i}`, 'x']))
     expect(RelayWebchatOp.safeParse({ op: 'elicitation_choice', requestId: 'e-1', value: wide }).success).toBe(false)
     // A field's value is a scalar or a list of them — never a nested object or a non-number.
     expect(

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -8,7 +8,13 @@ import {
 } from '../normalized-message.js'
 import { frameSchema } from '../envelope.js'
 import { ErrorFrame } from './error.js'
-import { ELICIT_FORM_FIELD_CAP, WebchatDone, WebchatImageAttachment, WebchatOutput, WebchatPost } from './webchat.js'
+import {
+  ELICIT_FORM_WIRE_FIELD_CAP,
+  WebchatDone,
+  WebchatImageAttachment,
+  WebchatOutput,
+  WebchatPost
+} from './webchat.js'
 import { GitlabHookMetadata, GithubHookMetadata, HookContext, OptionalHookConfigSnapshot } from './hook.js'
 import { CronTarget } from './cron.js'
 import { Platform } from './route.js'
@@ -230,7 +236,7 @@ export const RelayWebchatOp = z.discriminatedUnion('op', [
         .record(z.string().min(1).max(200), z.union([z.string(), z.number(), z.array(z.string()).max(100)]))
         // EMPTY is a real answer: a form of nothing but optional fields, all left alone, is
         // schema-valid content and the daemon's own accept check already takes it.
-        .refine((v) => Object.keys(v).length <= ELICIT_FORM_FIELD_CAP),
+        .refine((v) => Object.keys(v).length <= ELICIT_FORM_WIRE_FIELD_CAP),
       z.null()
     ]),
     agentId: z.string().uuid().optional()

--- a/packages/protocol/src/frames/webchat.test.ts
+++ b/packages/protocol/src/frames/webchat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { ELICIT_FORM_FIELD_CAP, WebchatOutput, WebchatStatus } from '../index.js'
+import { ELICIT_FORM_WIRE_FIELD_CAP, WebchatOutput, WebchatStatus } from '../index.js'
 
 const CONV = '11111111-1111-4111-8111-111111111111'
 const TURN = '22222222-2222-4222-8222-222222222222'
@@ -218,7 +218,7 @@ describe('WebchatOutput — event / status framing', () => {
     expect(card({ kind: 'elicitation', requestId: 'e', message: 'm', options: [], fields: [field('a')] }).success).toBe(
       false
     )
-    const wide = Array.from({ length: ELICIT_FORM_FIELD_CAP + 1 }, (_, i) => field(`f${i}`))
+    const wide = Array.from({ length: ELICIT_FORM_WIRE_FIELD_CAP + 1 }, (_, i) => field(`f${i}`))
     expect(card({ kind: 'elicitation', requestId: 'e', message: 'm', options: [], fields: wide }).success).toBe(false)
     // A field with no property to answer under, or a kind no surface renders, is not a field.
     expect(

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -121,6 +121,11 @@ export type PlanEntry = z.infer<typeof PlanEntry>
  *  form is declined, which is honest — the agent can ask again in smaller pieces. */
 export const ELICIT_FORM_FIELD_CAP = 10
 
+/** The most FIELDS one card's wire payload carries. The cap above counts QUESTIONS, and an
+ *  AskUserQuestion bridge gives every question its own free-text companion (`customAnswerFor`),
+ *  so a form at the cap arrives as twice that many properties — and answers with them too. */
+export const ELICIT_FORM_WIRE_FIELD_CAP = ELICIT_FORM_FIELD_CAP * 2
+
 /** The per-kind field descriptors of an elicitation card. Shared by the single-field card and
  *  by each entry of a multi-field form, so the two can never describe one field differently. */
 const ElicitOptions = z.array(z.object({ value: z.string(), label: z.string() }))
@@ -150,6 +155,12 @@ export const ElicitField = z.object({
   label: z.string(),
   kind: z.enum(['enum', 'boolean', 'multi-enum', 'text', 'number']),
   required: z.boolean().optional(),
+  /** The schema's own `description` — the question text, where the title is only its header. */
+  description: z.string().max(300).optional(),
+  /** Set on a select question's free-text companion (ACP `_askUserQuestionCustomAnswer`): the
+   *  property whose question this box types an answer for. The card renders it INSIDE that
+   *  question rather than as a question of its own, and never numbers or counts it. */
+  customAnswerFor: z.string().min(1).max(200).optional(),
   options: ElicitOptions,
   multi: ElicitMulti.optional(),
   text: ElicitText.optional(),
@@ -234,7 +245,7 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
     // absent — deliberately, and the same closed-failure trade `text` records: an old reader
     // sees an optionless card it can only Dismiss, rather than a card it could half-fill with
     // one field's answer that the daemon would then refuse.
-    fields: z.array(ElicitField).min(2).max(ELICIT_FORM_FIELD_CAP).optional(),
+    fields: z.array(ElicitField).min(2).max(ELICIT_FORM_WIRE_FIELD_CAP).optional(),
     // Present ⇒ the card is a URL-mode CONSENT card (ACP `ElicitationUrlMode`): the reader is
     // shown this exact URL and opens it in their own browser, and nothing about the page ever
     // returns here. `options` is then empty and every field descriptor above is absent, so the

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -484,6 +484,62 @@ describe('the agent’s elicitation card on the session page', () => {
     ])
   })
 
+  it('folds a question’s own free-text box into that question instead of asking it twice', async () => {
+    // What an AskUserQuestion bridge sends: one select per question, each followed by its own
+    // "Other" box carrying `customAnswerFor` (#1817).
+    live.steps = [
+      {
+        ...CARD,
+        text: 'Please answer the following questions.',
+        elicit: {
+          requestId: 'elicit-1',
+          options: [],
+          fields: [
+            {
+              propName: 'question_0',
+              label: 'Branch',
+              description: 'Which branch should I cut from?',
+              kind: 'enum',
+              required: true,
+              options: [{ value: 'main', label: 'main' }]
+            },
+            { propName: 'question_0_custom', label: 'Other', kind: 'text', options: [], customAnswerFor: 'question_0' },
+            { propName: 'question_1', label: 'Retries', kind: 'enum', options: [{ value: '1', label: '1' }] },
+            { propName: 'question_1_custom', label: 'Other', kind: 'text', options: [], customAnswerFor: 'question_1' }
+          ]
+        }
+      }
+    ]
+    await render()
+
+    // Two questions, numbered 01 and 02 — the boxes are part of them, not lines of their own.
+    const numbers = [...(container?.querySelectorAll('span.font-mono') ?? [])]
+      .map((n) => n.textContent ?? '')
+      .filter((t) => /^\d\d$/.test(t))
+    expect(numbers).toEqual(['01', '02'])
+    expect(text()).toContain('0/2')
+    // The schema's question text rides under the header the title only names.
+    expect(text()).toContain('Which branch should I cut from?')
+
+    // A typed box IS the question's answer: the required select stops being asked for.
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    await typeInto(inputNamed('Branch — Other')!, 'release/1.2')
+    expect(text()).toContain('1/2')
+    expect(buttonNamed('Submit')?.disabled).toBe(false)
+
+    await act(async () => {
+      buttonNamed('1')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(text()).toContain('2/2')
+    await act(async () => {
+      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // Each answer under its own property — the untouched second box is left out entirely.
+    expect(live.answered).toEqual([
+      ['session-1', 'agent-1', 'elicit-1', { question_0_custom: 'release/1.2', question_1: '1' }, 'conv-1']
+    ])
+  })
+
   it('leaves an untouched optional field out of the record entirely', async () => {
     live.steps = [
       {

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -500,7 +500,6 @@ describe('the agent’s elicitation card on the session page', () => {
               label: 'Branch',
               description: 'Which branch should I cut from?',
               kind: 'enum',
-              required: true,
               options: [{ value: 'main', label: 'main' }]
             },
             { propName: 'question_0_custom', label: 'Other', kind: 'text', options: [], customAnswerFor: 'question_0' },
@@ -521,8 +520,7 @@ describe('the agent’s elicitation card on the session page', () => {
     // The schema's question text rides under the header the title only names.
     expect(text()).toContain('Which branch should I cut from?')
 
-    // A typed box IS the question's answer: the required select stops being asked for.
-    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    // A typed box IS the question's answer: its own select stops being asked for.
     await typeInto(inputNamed('Branch — Other')!, 'release/1.2')
     expect(text()).toContain('1/2')
     expect(buttonNamed('Submit')?.disabled).toBe(false)
@@ -537,6 +535,61 @@ describe('the agent’s elicitation card on the session page', () => {
     // Each answer under its own property — the untouched second box is left out entirely.
     expect(live.answered).toEqual([
       ['session-1', 'agent-1', 'elicit-1', { question_0_custom: 'release/1.2', question_1: '1' }, 'conv-1']
+    ])
+  })
+
+  it('still asks a REQUIRED question for its own pick, box or no box', async () => {
+    // `elicitFormAccepts` refuses an answer that leaves a required property out, so a box that
+    // unlocked Submit here would post an answer the daemon drops — the card would sit pending
+    // with nothing said about why.
+    live.steps = [
+      {
+        ...CARD,
+        elicit: {
+          requestId: 'elicit-1',
+          options: [],
+          fields: [
+            {
+              propName: 'question_0',
+              label: 'Branch',
+              kind: 'enum',
+              required: true,
+              options: [{ value: 'main', label: 'main' }]
+            },
+            {
+              propName: 'question_0_custom',
+              label: 'Other',
+              kind: 'text',
+              options: [],
+              customAnswerFor: 'question_0',
+              text: { maxLength: 6 }
+            }
+          ]
+        }
+      }
+    ]
+    await render()
+
+    await typeInto(inputNamed('Branch — Other')!, 'dev')
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(text()).toContain('Choose one')
+    expect(text()).toContain('0/1')
+
+    // What was typed is checked either way — an over-long box holds an answered question too.
+    await act(async () => {
+      buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    await typeInto(inputNamed('Branch — Other')!, 'far too long')
+    expect(text()).toContain('Enter at most 6 characters')
+    expect(buttonNamed('Submit')?.disabled).toBe(true)
+
+    await typeInto(inputNamed('Branch — Other')!, 'dev')
+    await act(async () => {
+      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered).toEqual([
+      ['session-1', 'agent-1', 'elicit-1', { question_0: 'main', question_0_custom: 'dev' }, 'conv-1']
     ])
   })
 

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -854,6 +854,36 @@ function fieldAnswered(f: ElicitFieldSpec, drafts: Record<string, string>, picks
   return (picks[f.propName] ?? []).length > 0
 }
 
+/** The free-text box a question carries instead of an option, if the form gave it one. */
+function companionOf(fields: ElicitFieldSpec[], f: ElicitFieldSpec): ElicitFieldSpec | undefined {
+  return fields.find((c) => c.customAnswerFor === f.propName)
+}
+
+/** Whether a question is answered — by its own control, or by the box the reader typed into
+ *  instead, which is what the counter has to count for the two to agree. */
+function rowAnswered(
+  f: ElicitFieldSpec,
+  companion: ElicitFieldSpec | undefined,
+  drafts: Record<string, string>,
+  picks: Record<string, string[]>
+): boolean {
+  return fieldAnswered(f, drafts, picks) || (!!companion && fieldAnswered(companion, drafts, picks))
+}
+
+/** Why a question is not yet answerable. A typed companion IS the answer — the agent reads it
+ *  in place of the selection — so the question's own control stops being asked for and only
+ *  what was typed is checked. */
+function rowInvalidReason(
+  f: ElicitFieldSpec,
+  companion: ElicitFieldSpec | undefined,
+  drafts: Record<string, string>,
+  picks: Record<string, string[]>
+): string | undefined {
+  const draft = companion ? (drafts[companion.propName] ?? '') : ''
+  if (companion && draft.trim()) return typedInvalidReason(companion, draft)
+  return fieldInvalidReason(f, drafts, picks)
+}
+
 // One elicitation control, styled alike wherever a card places it.
 const ELICIT_CHIP = 'chip max-w-full truncate rounded-sm disabled:cursor-default disabled:opacity-55'
 const ELICIT_CHIP_ON =
@@ -881,6 +911,9 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
   const consentUrl = elicit?.url
   const consent = consentUrl ? readConsentUrl(consentUrl) : null
   const fields = elicit?.fields?.length ? elicit.fields : undefined
+  // The card's QUESTIONS: a select question's free-text companion is part of the question it
+  // names, not one of its own, so it is never numbered, counted, or asked twice.
+  const rows = fields?.filter((f) => !f.customAnswerFor)
   const typed = !fields && elicit && (elicit.text || elicit.number) ? elicit : undefined
   const min = multi?.minItems ?? 0
   const max = multi?.maxItems
@@ -895,7 +928,9 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
   const headIcon = settled ? settled.icon : consent ? 'external-link' : 'message-circle-question-mark'
   const headColor = settled ? settled.color : 'var(--brand)'
   const counter =
-    fields && !settled ? `${fields.filter((f) => fieldAnswered(f, drafts, picks)).length}/${fields.length}` : undefined
+    rows && !settled
+      ? `${rows.filter((f) => rowAnswered(f, companionOf(fields!, f), drafts, picks)).length}/${rows.length}`
+      : undefined
   return (
     <div
       className={`overflow-hidden rounded-md border border-l-2 border-(--border-subtle) bg-(--surface-card) shadow-(--shadow-xs) ${edge}`}
@@ -968,10 +1003,11 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
               <span className={`ml-auto ${ELICIT_HINT}`}>Opens in a new tab</span>
             </div>
           </div>
-        ) : fields ? (
+        ) : fields && rows ? (
           <div className="flex w-full min-w-0 flex-col">
-            {fields.map((f, fi) => {
-              const reason = fieldInvalidReason(f, drafts, picks)
+            {rows.map((f, fi) => {
+              const companion = companionOf(fields, f)
+              const reason = rowInvalidReason(f, companion, drafts, picks)
               const hint =
                 f.kind === 'multi-enum' ? selectionHint(f.multi?.minItems ?? 0, f.multi?.maxItems) : undefined
               return (
@@ -1001,6 +1037,11 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                         {f.required ? 'required' : '(optional)'}
                       </span>
                     </div>
+                    {f.description ? (
+                      <span className="min-w-0 font-sans text-[12px] font-normal leading-normal text-(--text-secondary)">
+                        {f.description}
+                      </span>
+                    ) : null}
                     {f.kind === 'text' || f.kind === 'number' ? (
                       <input
                         className={`${ELICIT_INPUT} desktop:max-w-[320px]`}
@@ -1050,6 +1091,20 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                         })}
                       </div>
                     )}
+                    {companion ? (
+                      <div className="flex min-w-0 items-center gap-[8px]">
+                        <span className={`flex-none ${ELICIT_HINT}`}>{companion.label}</span>
+                        <input
+                          className={`${ELICIT_INPUT} desktop:max-w-[320px]`}
+                          type="text"
+                          value={drafts[companion.propName] ?? ''}
+                          disabled={!onAnswer}
+                          aria-label={`${f.label} — ${companion.label}`}
+                          {...(companion.text?.maxLength !== undefined ? { maxLength: companion.text.maxLength } : {})}
+                          onChange={(e) => setDrafts((prev) => ({ ...prev, [companion.propName]: e.target.value }))}
+                        />
+                      </div>
+                    ) : null}
                     {reason ? (
                       <span className="inline-flex min-w-0 items-start gap-[6px] font-sans text-[11.5px] font-normal leading-normal text-(--brand-soft-text)">
                         <span className="mt-[2px] flex-none">
@@ -1068,7 +1123,7 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
               <button
                 type="button"
                 className="dsbtn dsbtn-primary xs"
-                disabled={!onAnswer || fields.some((f) => !!fieldInvalidReason(f, drafts, picks))}
+                disabled={!onAnswer || rows.some((f) => !!rowInvalidReason(f, companionOf(fields, f), drafts, picks))}
                 onClick={() => onAnswer?.(formAnswer(fields, drafts, picks))}
               >
                 Submit

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -859,20 +859,33 @@ function companionOf(fields: ElicitFieldSpec[], f: ElicitFieldSpec): ElicitField
   return fields.find((c) => c.customAnswerFor === f.propName)
 }
 
-/** Whether a question is answered — by its own control, or by the box the reader typed into
- *  instead, which is what the counter has to count for the two to agree. */
+/** Whether what the reader typed into a question's box answers that question BY ITSELF. It
+ *  does — the agent reads a typed answer in place of the selection — unless the schema requires
+ *  the question's own property, which the daemon enforces by refusing an answer that leaves it
+ *  out. Enabling Submit there would post an answer the daemon drops, leaving the card pending
+ *  with nothing said. */
+function customAnswerStandsAlone(
+  f: ElicitFieldSpec,
+  companion: ElicitFieldSpec | undefined,
+  drafts: Record<string, string>
+): boolean {
+  return !!companion && !f.required && !!(drafts[companion.propName] ?? '').trim()
+}
+
+/** Whether a question is answered — by its own control, or by a box that answers for it, which
+ *  is what the counter has to count for it and the Submit gate to agree. */
 function rowAnswered(
   f: ElicitFieldSpec,
   companion: ElicitFieldSpec | undefined,
   drafts: Record<string, string>,
   picks: Record<string, string[]>
 ): boolean {
-  return fieldAnswered(f, drafts, picks) || (!!companion && fieldAnswered(companion, drafts, picks))
+  return fieldAnswered(f, drafts, picks) || customAnswerStandsAlone(f, companion, drafts)
 }
 
-/** Why a question is not yet answerable. A typed companion IS the answer — the agent reads it
- *  in place of the selection — so the question's own control stops being asked for and only
- *  what was typed is checked. */
+/** Why a question is not yet answerable. What was typed into its box is always checked — the
+ *  daemon re-checks it either way — and it stops the question's own control being asked for
+ *  only where it answers on its own. */
 function rowInvalidReason(
   f: ElicitFieldSpec,
   companion: ElicitFieldSpec | undefined,
@@ -880,7 +893,10 @@ function rowInvalidReason(
   picks: Record<string, string[]>
 ): string | undefined {
   const draft = companion ? (drafts[companion.propName] ?? '') : ''
-  if (companion && draft.trim()) return typedInvalidReason(companion, draft)
+  if (companion && draft.trim()) {
+    const typed = typedInvalidReason(companion, draft)
+    if (typed || customAnswerStandsAlone(f, companion, drafts)) return typed
+  }
   return fieldInvalidReason(f, drafts, picks)
 }
 

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1084,6 +1084,11 @@ export interface ElicitFieldSpec {
   label: string
   kind: 'enum' | 'boolean' | 'multi-enum' | 'text' | 'number'
   required?: boolean
+  /** The schema's own question text, where `label` is only its header. */
+  description?: string
+  /** Set on a select question's free-text companion: the property whose question it answers.
+   *  The card renders it inside that question, and never numbers or counts it as one. */
+  customAnswerFor?: string
   options: { value: string; label: string }[]
   multi?: { minItems?: number; maxItems?: number }
   text?: { minLength?: number; maxLength?: number; pattern?: string; format?: string }


### PR DESCRIPTION
## What

An AskUserQuestion bridge (`claude-agent-acp`, codex) renders each question as **two** schema properties: the select (`question_<n>`) and a free-text companion titled "Other" (`question_<n>_custom`), tied to its question only by an ACP `_meta._askUserQuestionCustomAnswer` marker.

The elicitation card read one control per property and knew nothing of that marker, so every box stood as a second question named "Other":

```
01 分支      [main] [develop]
02 Other     [____]              ← not a question
03 备注      [不填] [自定义备注]
04 Other     [____]
```

…and the counter asked for `1/6` answers where the agent asked three. Two more gaps fell out of the same scan: the schema's `description` (the question text — `title` is only its header) was dropped entirely, and the 10-field form cap counted properties, so a 6-question ask was declined outright.

## How

- **protocol** — `ElicitField` gains `description` and `customAnswerFor`. `ELICIT_FORM_FIELD_CAP` now counts *questions*; the new `ELICIT_FORM_WIRE_FIELD_CAP` (2×) bounds the wire array and the answer record, since a paired form carries twice the properties.
- **daemon** — `elicitCandidates` honors the marker (only on a `text` target) and carries `description`. A companion whose question this surface did not render is demoted to a field of its own rather than pointing at a control that is not on the card. `elicitForm`'s cap skips companions. A settled card names a typed answer for the question it sits in — `分支 (Other): release/1.2`, not a bare `Other:`.
- **console** — the box renders *inside* its question: unnumbered, uncounted, and — since the agent reads a typed answer in place of the selection — enough to satisfy a required question on its own. The question's `description` renders under its header.

Slack is untouched: its surface renders no text field, so `elicitTarget` still reduces to the first select.

## Verification

- New: 3 daemon cases (binding, orphan demotion + a marker on a non-text property, cap counted by questions) and 1 console case (numbering is `01`/`02` only, question text shown, a typed "Other" satisfies a required question, submit sends `{question_0_custom, question_1}`).
- `pnpm typecheck` + `pnpm lint` clean; protocol 488, web console 1614, daemon `render` + `daemon-webchat` 205 — all green.
