### PR TITLE
feat(daemon): agentconnect auth logs a runtime in, and the console hands over the command

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -4,6 +4,7 @@ import {
   ndJsonStream,
   type ClientConnection,
   type ContentBlock,
+  type AuthMethod,
   type CreateElicitationRequest,
   type CreateElicitationResponse,
   type McpServer,
@@ -531,6 +532,7 @@ export class AcpHost {
   // baseline and always accepted). null until the handshake completes; the
   // unstable `acp` transport flag is deliberately ignored. Read via mcpCapabilities().
   private mcpCaps: McpTransportCapabilities | null = null
+  private agentAuthMethods: AuthMethod[] = []
   // The ACP agent's self-reported identity from the `initialize` response
   // (`agentInfo`: name/title/version) — the ACTUAL running adapter version (e.g.
   // claude-agent-acp 0.59.0), as opposed to the registry's declared version.
@@ -580,6 +582,18 @@ export class AcpHost {
        * breaking. Never fires for non-Claude runtimes or adapters that don't forward it.
        */
       onSdkLifecycle?: (sessionId: string, message: unknown) => void
+      /**
+       * Services the REQUEST-scoped elicitations of the auth/config phase (no sessionId), which
+       * {@link onElicit} deliberately declines because they map to no live turn. Set only by an
+       * interactive caller — a daemon session has no reader for a question its turn cannot carry.
+       */
+      onAuthElicit?: (params: CreateElicitationRequest) => Promise<CreateElicitationResponse | undefined>
+      /**
+       * Advertises `auth.terminal`, letting the agent offer auth methods the CLIENT completes by
+       * re-launching the agent program interactively. Per the spec a client may claim this only
+       * when it can reproduce that invocation on a real terminal, so a daemon session never does.
+       */
+      authTerminalCapable?: boolean
       env?: Record<string, string>
       /** Files `env` points at, written by the driver in the runtime's own filesystem before start. */
       files?: SpawnFile[]
@@ -740,6 +754,14 @@ export class AcpHost {
         // Only session-scoped elicitations map to a live turn; request-scoped ones
         // (auth/config phase, no session) have no sessionId — decline those.
         const sessionId = (ctx.params as { sessionId?: string }).sessionId
+        if (!sessionId && self.opts.onAuthElicit) {
+          try {
+            const res = await self.opts.onAuthElicit(ctx.params)
+            if (res) return res
+          } catch (err) {
+            self.opts.log?.debug(`acp: onAuthElicit failed, declining: ${(err as Error).message}`)
+          }
+        }
         if (self.opts.onElicit && sessionId) {
           try {
             const res = await self.opts.onElicit(sessionId, ctx.params)
@@ -785,10 +807,12 @@ export class AcpHost {
         // spec reserves for them instead of a form that would carry the secret through chat.
         // Unrenderable forms and surfaces without a consent card are declined gracefully by
         // the onElicit fallback above.
-        elicitation: { form: {}, url: {} }
+        elicitation: { form: {}, url: {} },
+        ...(this.opts.authTerminalCapable ? { auth: { terminal: true } } : {})
       }
     })
     this.negotiatedProtocolVersion = init.protocolVersion
+    this.agentAuthMethods = init.authMethods ?? []
     this.canLoad = init.agentCapabilities?.loadSession ?? false
     this.canUseAdditionalDirectories = init.agentCapabilities?.sessionCapabilities?.additionalDirectories != null
     this.canDelete = init.agentCapabilities?.sessionCapabilities?.delete != null
@@ -1027,6 +1051,21 @@ export class AcpHost {
 
   /** The ACP protocol version negotiated at initialize, or undefined before the
    *  handshake completed. Used by the runtime probe to report ACP coverage. */
+  /** Login methods the agent advertised at `initialize`, in its own order. */
+  authMethods(): AuthMethod[] {
+    return this.agentAuthMethods
+  }
+
+  /** Run the agent's own login for one advertised method. `terminal` methods are the CLIENT's to
+   *  run as an interactive process, and the spec forbids passing them here. */
+  async authenticate(methodId: string): Promise<void> {
+    const method = this.agentAuthMethods.find((entry) => entry.id === methodId)
+    if (method && 'type' in method && method.type === 'terminal') {
+      throw new Error(`auth method "${methodId}" is completed by the client, not by \`authenticate\``)
+    }
+    await this.conn!.agent.request(methods.agent.authenticate, { methodId })
+  }
+
   acpProtocolVersion(): number | undefined {
     return this.negotiatedProtocolVersion
   }
@@ -1163,10 +1202,10 @@ export class AcpHost {
    *  spawned detached) so they reach the real adapter behind an npx wrapper too.
    *  Idempotent — the child handle is cleared up front so a concurrent stop (drain
    *  + reconcile racing) is a no-op rather than a double-kill. */
-  async stop(deadlineMs = 5000): Promise<void> {
+  async stop(deadlineMs = 5000, eofGraceMs = 0): Promise<void> {
     const spawned = this.spawned
     if (!spawned) return
     this.spawned = undefined
-    await spawned.stop(deadlineMs)
+    await spawned.stop(deadlineMs, eofGraceMs)
   }
 }

--- a/packages/daemon/src/acp/spawn-driver.ts
+++ b/packages/daemon/src/acp/spawn-driver.ts
@@ -74,8 +74,10 @@ export interface SpawnedRuntime {
   fromAgent: ReadableStream<Uint8Array>
   /** Fires once when the runtime reaches terminal exit on its own. */
   onExit(listener: () => void): void
-  /** Graceful stop escalating past the deadline. Safe to call on a dead target. */
-  stop(deadlineMs: number): Promise<void>
+  /** Graceful stop escalating past the deadline. Safe to call on a dead target.
+   *  `eofGraceMs` waits that long for the runtime to exit on stdin EOF before any signal —
+   *  0 (the default) signals immediately, which is what a daemon teardown wants. */
+  stop(deadlineMs: number, eofGraceMs?: number): Promise<void>
 }
 
 /**
@@ -266,7 +268,7 @@ class LocalSpawnedRuntime implements SpawnedRuntime {
     this.child.once('close', once)
   }
 
-  async stop(deadlineMs: number): Promise<void> {
+  async stop(deadlineMs: number, eofGraceMs = 0): Promise<void> {
     if (this.stopped) return
     this.stopped = true
     const child = this.child
@@ -300,6 +302,19 @@ class LocalSpawnedRuntime implements SpawnedRuntime {
       child.stdin?.end()
     } catch {
       /* stream locked/destroyed — signals still land */
+    }
+    // An interactive caller may pay for a graceful exit: a runtime that handles EOF exits with
+    // status 0 and prints nothing, while the SIGTERM below makes some of them dump a signal
+    // handler's stack trace over the operator's terminal. Daemon teardown passes 0 and skips this.
+    if (eofGraceMs > 0) {
+      const exited = await new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => resolve(false), eofGraceMs)
+        this.onExit(() => {
+          clearTimeout(timer)
+          resolve(true)
+        })
+      })
+      if (exited) return
     }
     kill('SIGTERM')
     await new Promise<void>((resolve) => {

--- a/packages/daemon/src/cli/auth-picker.ts
+++ b/packages/daemon/src/cli/auth-picker.ts
@@ -1,0 +1,132 @@
+/**
+ * Arrow-key list for `agentconnect auth`.
+ *
+ * One flat list in a FIXED order: the login sweep launches every runtime and answers slowly, so a
+ * verdict arrives as a per-row status rather than as a re-sort. A list that reorders itself under
+ * the cursor is unusable. The same list drives both the runtime choice and the method choice.
+ *
+ * Deliberately dependency-free and stream-injected: the daemon ships no TUI library, and the key
+ * decoding is what tests drive. Rendering redraws in place on a TTY and degrades to a plain list
+ * when stdin is not a terminal, so a piped or CI invocation still shows what it would have offered.
+ */
+
+export interface PickerRow {
+  id: string
+  /** Display name, when there is one worth showing beside the id. */
+  name?: string
+  /** Trailing detail: the live login status, or what a method does. */
+  hint?: string
+}
+
+export interface PickerIo {
+  input: NodeJS.ReadableStream & { isTTY?: boolean; setRawMode?: (raw: boolean) => void }
+  output: NodeJS.WritableStream & { isTTY?: boolean }
+}
+
+/**
+ * The rows to show, which may still be changing. Row ORDER is fixed for the life of the picker;
+ * only each row's `hint` is expected to change, so the operator can select at any point —
+ * including before the first verdict lands.
+ */
+export interface PickerModel {
+  rows(): PickerRow[]
+  /** Called on every change; returns its own unsubscribe. Absent means the list is final. */
+  subscribe?: (listener: () => void) => () => void
+}
+
+/** A model for a list that will not change. */
+export function fixedRows(rows: PickerRow[]): PickerModel {
+  return { rows: () => rows }
+}
+
+const ESC = '\u001b'
+const CTRL_C = '\u0003'
+
+function label(row: PickerRow): string {
+  const name = row.name && row.name !== row.id ? ` (${row.name})` : ''
+  return `${row.id}${name}${row.hint ? ` — ${row.hint}` : ''}`
+}
+
+/** The list as lines, with `cursor` marked. Exported for tests and the non-TTY fallback. */
+export function renderPicker(rows: PickerRow[], cursor: number): string[] {
+  return rows.map((row, index) => `${index === cursor ? '❯' : ' '} ${label(row)}`)
+}
+
+/**
+ * Show the list and resolve the chosen id, or undefined when the operator cancelled (q / Esc /
+ * Ctrl-C). Non-TTY input prints the rows and resolves undefined — there is nothing to steer with,
+ * and guessing a selection for someone is worse than saying so.
+ */
+export async function pickRow(model: PickerModel, io: PickerIo, prompt: string): Promise<string | undefined> {
+  const write = (text: string): void => void io.output.write(text)
+  if (model.rows().length === 0) return undefined
+
+  if (!io.input.isTTY || !io.input.setRawMode) {
+    for (const line of renderPicker(model.rows(), -1)) write(`${line}\n`)
+    return undefined
+  }
+
+  // The cursor follows the ROW ID, not the row number: the order is fixed, but a model is free to
+  // grow, and an index would then point somewhere the operator never put it.
+  let selected = model.rows()[0]!.id
+  let painted = 0
+  const paint = (): void => {
+    const rows = model.rows()
+    const cursor = Math.max(
+      0,
+      rows.findIndex((row) => row.id === selected)
+    )
+    selected = rows[cursor]?.id ?? selected
+    if (painted > 0) write(`${ESC}[${painted}A${ESC}[0J`)
+    const lines = renderPicker(rows, cursor)
+    write(`${lines.join('\n')}\n`)
+    painted = lines.length
+  }
+
+  io.input.setRawMode(true)
+  io.input.resume()
+  if ('setEncoding' in io.input) (io.input as NodeJS.ReadStream).setEncoding('utf8')
+  write(`${prompt} — ↑/↓ to move, Enter to select, q to cancel.\n\n`)
+  paint()
+
+  const unsubscribe = model.subscribe?.(paint)
+
+  return await new Promise<string | undefined>((resolve) => {
+    const finish = (value: string | undefined): void => {
+      unsubscribe?.()
+      io.input.removeListener('data', onData)
+      io.input.setRawMode?.(false)
+      io.input.pause()
+      write('\n')
+      resolve(value)
+    }
+    const move = (delta: number): void => {
+      const rows = model.rows()
+      const at = Math.max(
+        0,
+        rows.findIndex((row) => row.id === selected)
+      )
+      selected = rows[(at + delta + rows.length) % rows.length]!.id
+      paint()
+    }
+    const onData = (chunk: string | Buffer): void => {
+      const keys = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+      // A single read can carry a whole escape sequence, or several keys at once when held down.
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i]!
+        if (key === ESC && keys[i + 1] === '[') {
+          const code = keys[i + 2]
+          i += 2
+          if (code === 'A') move(-1)
+          else if (code === 'B') move(1)
+          continue
+        }
+        if (key === ESC || key === CTRL_C || key === 'q') return finish(undefined)
+        if (key === '\r' || key === '\n') return finish(selected)
+        if (key === 'k') move(-1)
+        else if (key === 'j') move(1)
+      }
+    }
+    io.input.on('data', onData)
+  })
+}

--- a/packages/daemon/src/cli/auth.ts
+++ b/packages/daemon/src/cli/auth.ts
@@ -14,6 +14,16 @@ import { installedRuntimeCatalog } from '../runtimes/probe.js'
 import { probeAllRuntimes, type RuntimeProbeResult } from '../runtimes/runtime-prober.js'
 import { defaultProbeHostFactory } from '../acp/probe-host-factory.js'
 import { fixedRows, pickRow, type PickerIo, type PickerModel, type PickerRow } from './auth-picker.js'
+import {
+  CLI_ELICIT_SURFACE,
+  elicitFieldLabel,
+  elicitForm,
+  elicitFormAccepts,
+  elicitFormContent,
+  elicitRequiredProps,
+  fieldAccepts,
+  type ElicitTarget
+} from '../slack/render.js'
 import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from '../runtimes/registry.js'
 import type { RuntimeDef } from '../config/config-schema.js'
 
@@ -46,8 +56,9 @@ export interface RunAuthOpts {
   hostFactory?: (runtime: RuntimeDef, options: ConstructorParameters<typeof AcpHost>[1]) => AcpHost
   /** Test seam for the client-run `terminal` method; production spawns it on the real TTY. */
   runTerminalAuth?: (runtime: RuntimeDef, method: AuthMethod) => Promise<number>
-  /** Test seams for the loopback-paste fallback: reading a line, and replaying the pasted URL. */
-  readLine?: (question: string) => Promise<string>
+  /** Test seams for the loopback-paste fallback: reading a line, and replaying the pasted URL.
+   *  An aborted `signal` must release a question already waiting on stdin, answering empty. */
+  readLine?: (question: string, signal?: AbortSignal) => Promise<string>
   deliverLoopback?: (url: string) => Promise<void>
   /** How long to let an agent-run login settle before offering the paste fallback. */
   pasteAfterMs?: number
@@ -69,11 +80,20 @@ function hintFor(method: AuthMethod): string {
   return `${method.description?.trim() || method.name} (${kind})`
 }
 
-async function readLine(question: string): Promise<string> {
+/** Ask one line. An abort resolves it empty and closes the interface: a login that settles while
+ *  the operator is being prompted must not stay parked on stdin waiting for a keypress. */
+async function readLine(question: string, signal?: AbortSignal): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stdout })
+  let onAbort: (() => void) | undefined
   try {
-    return await new Promise<string>((resolve) => rl.question(question, resolve))
+    return await new Promise<string>((resolve) => {
+      if (signal?.aborted) return resolve('')
+      onAbort = () => resolve('')
+      signal?.addEventListener('abort', onAbort, { once: true })
+      rl.question(question, resolve)
+    })
   } finally {
+    if (onAbort) signal?.removeEventListener('abort', onAbort)
     rl.close()
   }
 }
@@ -147,9 +167,10 @@ async function chooseRuntime(
     }
   }
 
-  // Aborted the moment a runtime is chosen: nothing new is launched, and the probes already in
-  // flight tear their own children down on their per-runtime deadline. The sweep is deliberately
-  // NOT awaited — waiting for it is the very delay this list exists to avoid.
+  // Aborted the moment a runtime is chosen: nothing new is launched and every probe in flight
+  // ends at once (runtime-prober races the signal), which is what makes the teardown below cheap
+  // to wait for. The sweep is never awaited BEFORE a choice — that delay is what this list exists
+  // to avoid.
   const sweep = new AbortController()
   const probe = opts.probeRuntimes ?? probeAllRuntimes
   const running = probe(Object.fromEntries(ids.map((id) => [id, catalog.entries[id]!.runtime])), {
@@ -173,7 +194,12 @@ async function chooseRuntime(
   try {
     return await pick(model, io, 'Select a runtime to log in')
   } finally {
+    // Cancelled AND awaited: these probes are children of THIS process, and the CLI action exits
+    // as soon as runAuth resolves, so a teardown nobody waited for leaves them running after the
+    // command is gone. The abort ends each in-flight probe at once rather than at its deadline,
+    // so waiting for it costs the operator nothing measurable.
     sweep.abort()
+    await running.catch(() => undefined)
   }
 }
 
@@ -218,18 +244,22 @@ async function offerLoopbackPaste(login: Promise<void>, opts: RunAuthOpts, out: 
       if (res.status >= 500) throw new Error(`the local listener answered HTTP ${res.status}`)
     })
 
+  // The prompt is racing the login itself, so it gets a signal rather than a flag: a resolved
+  // login has to close the readline question, which no amount of polling `settled` can do.
   let settled = false
-  void login.then(
-    () => (settled = true),
-    () => (settled = true)
-  )
+  const done = new AbortController()
+  const finish = (): void => {
+    settled = true
+    done.abort()
+  }
+  void login.then(finish, finish)
   await Promise.race([login.catch(() => undefined), new Promise((r) => setTimeout(r, opts.pasteAfterMs ?? 3000))])
   if (settled) return
 
   out.write('\nIf the browser could not reach the redirect (this host is headless, no port forward),\n')
   out.write('copy the URL of the tab that failed to load and paste it here — it carries the code.\n')
   while (!settled) {
-    const answer = (await ask('\nRedirect URL (Enter to keep waiting): ')).trim()
+    const answer = (await ask('\nRedirect URL (Enter to keep waiting): ', done.signal)).trim()
     if (settled || answer === '') return
     const url = loopbackRedirect(answer)
     if (!url) {
@@ -244,6 +274,92 @@ async function offerLoopbackPaste(login: Promise<void>, opts: RunAuthOpts, out: 
       out.write(`Could not reach the local listener: ${(err as Error).message}\n`)
     }
   }
+}
+
+/** Split a typed multi-select answer into the values the schema will be checked against. */
+function splitValues(line: string): string[] {
+  return line
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value !== '')
+}
+
+/** The most times one field is re-asked before it is left unanswered — a typo deserves another
+ *  go, an operator who cannot satisfy the schema deserves to be let out of the loop. */
+const FIELD_ATTEMPTS = 3
+
+/**
+ * Ask one reduced field on the terminal, or return undefined when it was left unanswered.
+ *
+ * The pickable kinds are chosen from the options the AGENT offered, so a typo cannot invent a
+ * value it never asked for; text, number and multi-select are typed and re-asked while the
+ * field's own schema refuses them ({@link fieldAccepts} — the same gate the answer is checked
+ * against, applied here so the refusal is explainable rather than a late blanket decline).
+ */
+async function askField(
+  target: ElicitTarget,
+  label: string,
+  opts: RunAuthOpts,
+  out: NodeJS.WritableStream
+): Promise<string | number | string[] | undefined> {
+  if (target.kind === 'enum' || target.kind === 'boolean') {
+    const io = opts.io ?? { input: process.stdin, output: process.stdout }
+    const rows = target.options.map((option) => ({ id: option.value, name: option.label }))
+    return await (opts.pick ?? pickRow)(fixedRows(rows), io, label)
+  }
+
+  const ask = opts.readLine ?? readLine
+  if (target.kind === 'multi-enum') {
+    out.write(`\n${label} — one or more of: ${target.options.map((option) => option.value).join(', ')}\n`)
+  } else {
+    out.write(`\n${label}\n`)
+  }
+  const prompt = target.kind === 'multi-enum' ? 'Values (comma-separated, empty to skip): ' : 'Value (empty to skip): '
+  for (let attempt = 0; attempt < FIELD_ATTEMPTS; attempt++) {
+    const line = (await ask(prompt)).trim()
+    if (line === '') return undefined
+    const value = target.kind === 'multi-enum' ? splitValues(line) : target.kind === 'number' ? Number(line) : line
+    if (fieldAccepts(target, value)) return value
+    out.write(`That is not a value ${target.propName} accepts.\n`)
+  }
+  return undefined
+}
+
+/**
+ * Answer a form elicitation with the properties the agent's own `requestedSchema` asked for.
+ *
+ * The reduction is the shared one — {@link elicitForm} over {@link CLI_ELICIT_SURFACE} — so this
+ * terminal answers under the schema's own property names and types, and a form carrying a
+ * required field it cannot render is declined whole rather than half-answered. An accept keyed
+ * on anything else (a fixed `{type,text}`, say) is an answer the runtime never asked for: a
+ * request for `projectId` would come back without one and the login would fail on it.
+ */
+async function answerAuthForm(
+  params: CreateElicitationRequest,
+  opts: RunAuthOpts,
+  out: NodeJS.WritableStream
+): Promise<CreateElicitationResponse | undefined> {
+  const form = elicitForm(params, CLI_ELICIT_SURFACE)
+  if (!form) {
+    out.write('\nThe runtime asked for input this terminal cannot render whole — declining.\n')
+    return undefined
+  }
+  const message = (params as { message?: unknown }).message
+  if (typeof message === 'string' && message.trim()) out.write(`\n${message.trim()}\n`)
+
+  const answer: Record<string, string | number | string[]> = {}
+  for (const target of form) {
+    const value = await askField(target, elicitFieldLabel(params, target.propName), opts, out)
+    if (value !== undefined) answer[target.propName] = value
+  }
+  // Nothing typed is a decline, not an empty accept: the spec has agents handle `decline`, and
+  // an empty accept would report "answered" for a question the operator walked away from.
+  if (Object.keys(answer).length === 0) return undefined
+  if (!elicitFormAccepts(form, elicitRequiredProps(params), answer)) {
+    out.write('\nDeclined — the runtime needs every required field answered.\n')
+    return undefined
+  }
+  return { action: 'accept', content: elicitFormContent(form, answer) } as CreateElicitationResponse
 }
 
 export async function runAuth(opts: RunAuthOpts): Promise<void> {
@@ -295,12 +411,7 @@ export async function runAuth(opts: RunAuthOpts): Promise<void> {
         out.write('Waiting for the runtime to confirm…\n')
         return { action: 'accept' } as CreateElicitationResponse
       }
-      const message = (params as { message?: unknown }).message
-      if (typeof message === 'string') out.write(`\n${message}\n`)
-      const answer = (await (opts.readLine ?? readLine)('Response (empty to decline): ')).trim()
-      return answer
-        ? ({ action: 'accept', content: { type: 'text', text: answer } } as unknown as CreateElicitationResponse)
-        : undefined
+      return await answerAuthForm(params, opts, out)
     }
   }
   const host = opts.hostFactory ? opts.hostFactory(runtime, hostOptions) : new AcpHost(runtime, hostOptions)

--- a/packages/daemon/src/cli/auth.ts
+++ b/packages/daemon/src/cli/auth.ts
@@ -1,0 +1,365 @@
+import { spawn } from 'node:child_process'
+import { createInterface } from 'node:readline'
+import type {
+  AuthMethod,
+  AuthMethodTerminal,
+  CreateElicitationRequest,
+  CreateElicitationResponse
+} from '@agentclientprotocol/sdk'
+import { AcpHost } from '../acp/acp-host.js'
+import { loadConfig } from '../config/load-config.js'
+import { resolveRoot } from '../paths.js'
+import { ArchiveStore, parseArchiveLaunch, storedArchiveRuntimeDef } from '../runtimes/archive-store.js'
+import { installedRuntimeCatalog } from '../runtimes/probe.js'
+import { probeAllRuntimes, type RuntimeProbeResult } from '../runtimes/runtime-prober.js'
+import { defaultProbeHostFactory } from '../acp/probe-host-factory.js'
+import { fixedRows, pickRow, type PickerIo, type PickerModel, type PickerRow } from './auth-picker.js'
+import { resolveRuntimeCatalog, type ResolvedRuntimeCatalog } from '../runtimes/registry.js'
+import type { RuntimeDef } from '../config/config-schema.js'
+
+/**
+ * Interactive login for one runtime, run by the operator ON the daemon host.
+ *
+ * ACP gives an agent two ways to be logged in, and both need a human at a terminal, which is why
+ * this is a CLI command and not something the daemon can do for itself:
+ *
+ *  - `terminal` methods: the CLIENT re-launches the agent program as an interactive process (with
+ *    the method's extra args/env) and a zero exit means success. Agents may only offer these when
+ *    the client advertises `auth.terminal`, so a daemon session never sees them — this command does.
+ *  - `agent` methods (the default when a method carries no `type`): the agent runs its own flow
+ *    behind `authenticate`, asking through URL/form elicitation, or simply printing to its stderr.
+ *
+ * The runtime deliberately runs UNSANDBOXED against the operator's own HOME, exactly as if they had
+ * run its CLI by hand: the credential must land in the host state dir that RUNTIME_STATE_LOCATIONS
+ * seeds sessions FROM. A private-HOME launch would write the login into a directory that is thrown
+ * away with the process.
+ */
+export interface RunAuthOpts {
+  runtimeId?: string
+  methodId?: string
+  configPath?: string
+  root?: string
+  out?: NodeJS.WritableStream
+  /** Test seams; production resolves the real catalog and spawns a real AcpHost. */
+  resolveCatalog?: () => Promise<ResolvedRuntimeCatalog>
+  installed?: (catalog: ResolvedRuntimeCatalog) => ResolvedRuntimeCatalog
+  hostFactory?: (runtime: RuntimeDef, options: ConstructorParameters<typeof AcpHost>[1]) => AcpHost
+  /** Test seam for the client-run `terminal` method; production spawns it on the real TTY. */
+  runTerminalAuth?: (runtime: RuntimeDef, method: AuthMethod) => Promise<number>
+  /** Test seams for the loopback-paste fallback: reading a line, and replaying the pasted URL. */
+  readLine?: (question: string) => Promise<string>
+  deliverLoopback?: (url: string) => Promise<void>
+  /** How long to let an agent-run login settle before offering the paste fallback. */
+  pasteAfterMs?: number
+  /** Skip the login-state sweep and list every installed runtime in one group. */
+  skipProbe?: boolean
+  /** Test seams for the grouped picker. */
+  probeRuntimes?: typeof probeAllRuntimes
+  pick?: (model: PickerModel, io: PickerIo, prompt: string) => Promise<string | undefined>
+  io?: PickerIo
+}
+
+function isTerminalMethod(method: AuthMethod): method is AuthMethodTerminal & { type: 'terminal' } {
+  return 'type' in method && method.type === 'terminal'
+}
+
+/** Row detail for one login method: what it is, and who runs it. */
+function hintFor(method: AuthMethod): string {
+  const kind = isTerminalMethod(method) ? 'in a terminal' : 'handled by the runtime'
+  return `${method.description?.trim() || method.name} (${kind})`
+}
+
+async function readLine(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    return await new Promise<string>((resolve) => rl.question(question, resolve))
+  } finally {
+    rl.close()
+  }
+}
+
+/** Re-launch the agent program interactively on the operator's own terminal. */
+function spawnTerminalAuth(runtime: RuntimeDef, method: AuthMethod): Promise<number> {
+  const extra = isTerminalMethod(method) ? { args: method.args, env: method.env } : {}
+  const args = [...runtime.args, ...(extra.args ?? [])]
+  const env = {
+    ...process.env,
+    ...Object.fromEntries(runtime.env.map((entry) => [entry.name, entry.value])),
+    ...(extra.env ?? {})
+  }
+  return new Promise((resolve, reject) => {
+    const child = spawn(runtime.command, args, { stdio: 'inherit', env })
+    child.on('error', reject)
+    child.on('exit', (code) => resolve(code ?? 1))
+  })
+}
+
+/**
+ * List the installed runtimes at once, then annotate each with whether it is logged in FOR THIS
+ * OPERATOR as the verdicts arrive.
+ *
+ * The order is fixed the moment the list appears and never changes: the sweep launches every
+ * runtime and answers over tens of seconds, so a verdict lands as a status on its own row rather
+ * than moving it. A selection made before any verdict is honoured immediately.
+ *
+ * The status is a real probe, not a guess: nothing persists it (the daemon's `authRequired` lives
+ * in its process, and its local store caches only model catalogs), and every on-disk heuristic
+ * misreads a runtime that authenticates from an env var. The sweep runs the way this command logs
+ * in — host HOME, unsandboxed — so "logged in" answers the question actually being asked.
+ */
+async function chooseRuntime(
+  catalog: ResolvedRuntimeCatalog,
+  root: string,
+  opts: RunAuthOpts,
+  out: NodeJS.WritableStream
+): Promise<string | undefined> {
+  const ids = Object.keys(catalog.entries).sort()
+  if (ids.length === 0) throw new Error('no runtimes are installed on this host')
+  const io = opts.io ?? { input: process.stdin, output: process.stdout }
+  const pick = opts.pick ?? pickRow
+  const rowFor = (id: string, hint?: string): PickerRow => ({
+    id,
+    ...(catalog.entries[id]?.name ? { name: catalog.entries[id]!.name } : {}),
+    ...(hint ? { hint } : {})
+  })
+
+  if (opts.skipProbe) {
+    return pick(fixedRows(ids.map((id) => rowFor(id))), io, 'Select a runtime to log in')
+  }
+
+  const results = new Map<string, RuntimeProbeResult>()
+  const listeners = new Set<() => void>()
+  const statusFor = (id: string): string => {
+    const result = results.get(id)
+    if (!result) return 'checking…'
+    if (result.ok) {
+      const models = result.models.length > 0 ? `${result.models.length} model(s)` : 'no models offered'
+      return `logged in — ${result.probedVersion ? `${models}, ${result.probedVersion}` : models}`
+    }
+    if (result.authRequired) return 'not logged in'
+    return `not logged in — ${result.error ? result.error.slice(0, 60) : 'probe failed'}`
+  }
+  const model: PickerModel = {
+    rows: () => ids.map((id) => rowFor(id, statusFor(id))),
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }
+  }
+
+  // Aborted the moment a runtime is chosen: nothing new is launched, and the probes already in
+  // flight tear their own children down on their per-runtime deadline. The sweep is deliberately
+  // NOT awaited — waiting for it is the very delay this list exists to avoid.
+  const sweep = new AbortController()
+  const probe = opts.probeRuntimes ?? probeAllRuntimes
+  const running = probe(Object.fromEntries(ids.map((id) => [id, catalog.entries[id]!.runtime])), {
+    hostFactory: defaultProbeHostFactory({}),
+    hostEnv: process.env,
+    signal: sweep.signal,
+    // The store owns an archive runtime's binary; probe what a login would actually launch.
+    resolveRuntime: async (id, runtime) => {
+      const entry = catalog.entries[id]
+      const archive = entry ? parseArchiveLaunch(id, entry) : undefined
+      if (!archive) return runtime
+      return storedArchiveRuntimeDef(runtime, await new ArchiveStore({ root }).ensure(archive))
+    },
+    onResult: (result) => {
+      results.set(result.runtime, result)
+      for (const listener of listeners) listener()
+    }
+  })
+  running.catch((err) => out.write(`login check failed: ${(err as Error).message}\n`))
+
+  try {
+    return await pick(model, io, 'Select a runtime to log in')
+  } finally {
+    sweep.abort()
+  }
+}
+
+// Long enough for a runtime to notice stdin EOF and exit on its own (Antigravity's ACP server
+// takes ~620ms), short enough that a wedged one still gets signalled promptly.
+const EOF_GRACE_MS = 2500
+
+/** A loopback redirect the operator may replay locally: http(s) to 127.0.0.1/localhost, with a port. */
+function loopbackRedirect(value: string): URL | undefined {
+  let url: URL
+  try {
+    url = new URL(value.trim())
+  } catch {
+    return undefined
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined
+  if (url.hostname !== '127.0.0.1' && url.hostname !== 'localhost' && url.hostname !== '[::1]') return undefined
+  if (url.username || url.password) return undefined
+  return url
+}
+
+/**
+ * Offer to finish a loopback OAuth login without a port forward.
+ *
+ * Google retired the copy/paste (OOB) flow in January 2023 and pointed desktop clients at the
+ * loopback IP flow instead, so a runtime like Antigravity binds an HTTP server to 127.0.0.1 on the
+ * DAEMON host and waits for the browser to be redirected there. On a headless host the browser
+ * cannot reach it — but the redirect still happens, and the full `?code=…&state=…` URL is sitting
+ * in the address bar of the tab that failed to load. Replaying that URL from this process, which
+ * does run on the daemon host, hands the code to the waiting listener.
+ *
+ * Resolves as soon as the login settles; the prompt is only offered while it is still pending, so a
+ * login completed through a port forward (or one that needed no browser at all) never sees it.
+ */
+async function offerLoopbackPaste(login: Promise<void>, opts: RunAuthOpts, out: NodeJS.WritableStream): Promise<void> {
+  const ask = opts.readLine ?? readLine
+  const deliver =
+    opts.deliverLoopback ??
+    (async (url: string) => {
+      const res = await fetch(url, { redirect: 'manual', signal: AbortSignal.timeout(15_000) })
+      // Any answer means the listener took the request; its body is a browser page, not our business.
+      if (res.status >= 500) throw new Error(`the local listener answered HTTP ${res.status}`)
+    })
+
+  let settled = false
+  void login.then(
+    () => (settled = true),
+    () => (settled = true)
+  )
+  await Promise.race([login.catch(() => undefined), new Promise((r) => setTimeout(r, opts.pasteAfterMs ?? 3000))])
+  if (settled) return
+
+  out.write('\nIf the browser could not reach the redirect (this host is headless, no port forward),\n')
+  out.write('copy the URL of the tab that failed to load and paste it here — it carries the code.\n')
+  while (!settled) {
+    const answer = (await ask('\nRedirect URL (Enter to keep waiting): ')).trim()
+    if (settled || answer === '') return
+    const url = loopbackRedirect(answer)
+    if (!url) {
+      out.write('That is not a loopback redirect URL (expected http://127.0.0.1:<port>/…). Ignored.\n')
+      continue
+    }
+    try {
+      await deliver(url.toString())
+      out.write('Delivered to the local listener; waiting for the runtime to finish…\n')
+      return
+    } catch (err) {
+      out.write(`Could not reach the local listener: ${(err as Error).message}\n`)
+    }
+  }
+}
+
+export async function runAuth(opts: RunAuthOpts): Promise<void> {
+  const out = opts.out ?? process.stdout
+  const root = resolveRoot(opts.root)
+  const cfg = loadConfig({ root: opts.root, configPath: opts.configPath, optional: true })
+
+  const resolved = opts.resolveCatalog
+    ? await opts.resolveCatalog()
+    : await resolveRuntimeCatalog(cfg, root, {
+        ...(opts.runtimeId ? { neededRuntimes: [opts.runtimeId] } : {}),
+        mode: 'cache-first'
+      })
+  const catalog = opts.installed ? opts.installed(resolved) : installedRuntimeCatalog(resolved)
+
+  const runtimeId = opts.runtimeId ?? (await chooseRuntime(catalog, root, opts, out))
+  if (!runtimeId) return
+
+  const entry = catalog.entries[runtimeId]
+  if (!entry) {
+    const ids = Object.keys(catalog.entries).sort().join(', ') || '(none)'
+    throw new Error(`runtime "${runtimeId}" is not installed on this host. Available: ${ids}`)
+  }
+
+  // Same store the daemon launches from: a vendor-archive runtime is not launchable until it is
+  // extracted, and a login against a different binary than the sessions run would be a lie.
+  const archive = parseArchiveLaunch(runtimeId, entry)
+  const runtime = archive
+    ? storedArchiveRuntimeDef(
+        entry.runtime,
+        await new ArchiveStore({
+          root,
+          log: { info: (message) => out.write(`${message}\n`), warn: (message) => out.write(`${message}\n`) }
+        }).ensure(archive)
+      )
+    : entry.runtime
+
+  const hostOptions: ConstructorParameters<typeof AcpHost>[1] = {
+    onUpdate: () => {},
+    runtimeId: runtimeId,
+    isolateAccountApps: cfg.security.isolateAccountApps,
+    authTerminalCapable: true,
+    // The agent's own flow speaks through these two channels, and its stderr — which stays
+    // unsuppressed here, because a runtime that prints a consent link has nowhere else to put it.
+    onAuthElicit: async (params: CreateElicitationRequest): Promise<CreateElicitationResponse | undefined> => {
+      const url = (params as { url?: unknown }).url
+      if (typeof url === 'string') {
+        out.write(`\nOpen this URL to continue signing in:\n\n  ${url}\n\n`)
+        out.write('Waiting for the runtime to confirm…\n')
+        return { action: 'accept' } as CreateElicitationResponse
+      }
+      const message = (params as { message?: unknown }).message
+      if (typeof message === 'string') out.write(`\n${message}\n`)
+      const answer = (await (opts.readLine ?? readLine)('Response (empty to decline): ')).trim()
+      return answer
+        ? ({ action: 'accept', content: { type: 'text', text: answer } } as unknown as CreateElicitationResponse)
+        : undefined
+    }
+  }
+  const host = opts.hostFactory ? opts.hostFactory(runtime, hostOptions) : new AcpHost(runtime, hostOptions)
+
+  const onSigint = (): void => {
+    void host.stop(5000, EOF_GRACE_MS).finally(() => process.exit(130))
+  }
+  process.once('SIGINT', onSigint)
+  try {
+    out.write(`Starting ${runtimeId}…\n`)
+    await host.start()
+    const methods = host.authMethods()
+    if (methods.length === 0) {
+      out.write(`${runtimeId} advertises no login methods — it either needs none or reads a credential from env.\n`)
+      return
+    }
+
+    let method = opts.methodId ? methods.find((m) => m.id === opts.methodId) : undefined
+    if (opts.methodId && !method) {
+      throw new Error(
+        `"${opts.methodId}" is not offered by ${runtimeId}. Offered: ${methods.map((m) => m.id).join(', ')}`
+      )
+    }
+    if (!method) {
+      if (methods.length === 1) method = methods[0]!
+      else {
+        // The same arrow-key list the runtime was chosen from: a login is no place to make someone
+        // retype an identifier they can already see.
+        const rows = methods.map((entry) => ({ id: entry.id, name: entry.name, hint: hintFor(entry) }))
+        const answer = await (opts.pick ?? pickRow)(
+          fixedRows(rows),
+          opts.io ?? { input: process.stdin, output: process.stdout },
+          `How do you want to log in to ${runtimeId}?`
+        )
+        if (!answer) return
+        method = methods.find((m) => m.id === answer)
+        if (!method) throw new Error(`"${answer}" is not one of the offered methods`)
+      }
+    }
+    out.write(`Using ${method.id} — ${method.name}\n`)
+
+    if (isTerminalMethod(method)) {
+      // The client owns this one: hand the operator's terminal to the agent program itself.
+      await host.stop(5000, EOF_GRACE_MS)
+      const code = await (opts.runTerminalAuth ?? spawnTerminalAuth)(runtime, method)
+      if (code !== 0) throw new Error(`interactive login exited with code ${code}`)
+    } else {
+      const login = host.authenticate(method.id)
+      await offerLoopbackPaste(login, opts, out)
+      await login
+    }
+
+    out.write(`\n✓ ${runtimeId} is logged in on this host.\n`)
+    out.write('Sessions pick the credential up on their next start — the daemon needs no restart.\n')
+  } finally {
+    process.removeListener('SIGINT', onSigint)
+    // Graceful: a runtime that exits on stdin EOF then prints nothing. Some (Antigravity's ACP
+    // server) install a signal handler that dumps a full stack trace over the operator's terminal
+    // on SIGTERM, which reads like a crash right after a login that in fact succeeded.
+    await host.stop(5000, EOF_GRACE_MS).catch(() => undefined)
+  }
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -263,5 +263,29 @@ program
     }
   })
 
+program
+  .command('auth')
+  .description("Log a runtime in on this host (ACP authenticate, or the runtime's own interactive login)")
+  .option('--runtime <id>', 'runtime to log in; omit to list what is installed here')
+  .option('--method <id>', 'login method to use; omit to be shown what the runtime offers')
+  .option('--skip-probe', 'skip the login-state check and list every installed runtime')
+  .action(async (cmd: { runtime?: string; method?: string; skipProbe?: boolean }) => {
+    const opts = program.opts()
+    try {
+      const { runAuth } = await import('./cli/auth.js')
+      await runAuth({
+        ...(cmd.runtime ? { runtimeId: cmd.runtime } : {}),
+        ...(cmd.method ? { methodId: cmd.method } : {}),
+        ...(cmd.skipProbe ? { skipProbe: true } : {}),
+        configPath: opts.config,
+        root: opts.root
+      })
+      return exit(0)
+    } catch (err) {
+      console.error(`agentconnect auth: ${(err as Error).message}`)
+      return exit(1)
+    }
+  })
+
 await program.parseAsync()
 await telemetry.shutdown()

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -184,6 +184,9 @@ export interface ProbeOptions {
   /** Resolve the def to probe, just before spawning — an archive-distributed runtime installs here.
    *  Undefined means the runtime is no longer launchable and gets no probe at all. */
   resolveRuntime?: (id: string, rt: RuntimeDef) => Promise<RuntimeDef | undefined>
+  /** Stop starting new probes. Checked between runtimes, so an aborted sweep still lets the
+   *  probes already in flight tear their own children down through their per-runtime deadline. */
+  signal?: AbortSignal
   /** Prepare the same sandbox/private-HOME or inherited-host launch used by a real agent. */
   launchFor?: (
     id: string,
@@ -633,6 +636,7 @@ export async function probeAllRuntimes(
 
   const worker = async (): Promise<void> => {
     for (let i = next++; i < ids.length; i = next++) {
+      if (opts.signal?.aborted) return
       const id = ids[i]!
       // Resolved inside this worker: a vendor archive installing on demand occupies one probe slot
       // instead of the whole sweep, and sits outside the per-runtime deadline probeRuntime applies.

--- a/packages/daemon/src/runtimes/runtime-prober.ts
+++ b/packages/daemon/src/runtimes/runtime-prober.ts
@@ -556,7 +556,21 @@ export async function probeRuntime(
     timer = setTimeout(() => reject(new Error(`probe timed out after ${timeoutMs}ms`)), timeoutMs)
   })
 
+  // An abort ends THIS probe, not just the queue behind it: the `finally` below then stops the
+  // child at once instead of leaving it to run out its deadline after the caller has moved on.
+  const signal = opts.signal
+  let onAbort: (() => void) | undefined
+  const cancelled = new Promise<never>((_, reject) => {
+    // An ALREADY-aborted sweep is the guard below, not this promise: rejecting here before the
+    // race exists is an unhandled rejection, and the guard never launches the runtime anyway.
+    if (!signal || signal.aborted) return
+    onAbort = () => reject(new Error('probe cancelled'))
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+
   try {
+    // A sweep already cancelled launches nothing: the caller has stopped waiting for verdicts.
+    if (signal?.aborted) throw new Error('probe cancelled')
     const launch = preparedProbeLaunch(id, rt, cwd, opts)
     redactValues = launch?.redactValues ?? []
     const effectiveRuntime = launch?.runtime ?? rt
@@ -578,7 +592,7 @@ export async function probeRuntime(
       probeSessionId = await activeHost.newSession(cwd, [])
       return activeHost.modelOptions()
     }
-    const opt = await Promise.race([run(), timeout])
+    const opt = await Promise.race([run(), timeout, cancelled])
     // Surface the model selector verbatim, including any literal "default" entry
     // the agent advertises (claude offers one, and it is the fresh-session
     // currentValue). We never SYNTHESIZE a "default" choice, but we mirror one the
@@ -610,6 +624,7 @@ export async function probeRuntime(
     return { runtime: id, ok: false, models: [], error, ...(isAuthRequiredError(err) ? { authRequired: true } : {}) }
   } finally {
     if (timer) clearTimeout(timer)
+    if (onAbort) signal?.removeEventListener('abort', onAbort)
     await host?.stop().catch(() => {}) // best-effort teardown — never mask the probe result
   }
 }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -634,6 +634,12 @@ export const WEBCHAT_ELICIT_SURFACE: ElicitSurface = {
   kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number'])
 }
 
+/** The auth CLI drives a real terminal: an arrow-key list for the pickable kinds and a typed
+ *  line for the rest, so it claims every kind, and its list scrolls like webchat's — no limit. */
+export const CLI_ELICIT_SURFACE: ElicitSurface = {
+  kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number'])
+}
+
 /** The `format` values MCP `2025-11-25` defines for an elicited string — exactly these four. */
 export type ElicitFormat = 'email' | 'uri' | 'date' | 'date-time'
 const ELICIT_FORMATS: readonly ElicitFormat[] = ['email', 'uri', 'date', 'date-time']

--- a/packages/daemon/test/auth-cli.test.ts
+++ b/packages/daemon/test/auth-cli.test.ts
@@ -173,12 +173,12 @@ describe('runAuth: the runtime list', () => {
       installed: (c) => c,
       probeRuntimes: async (_runtimes, opts) =>
         await new Promise((resolve) => {
-          opts.signal?.addEventListener('abort', () =>
-            setTimeout(() => {
-              torndown = true
-              resolve([])
-            }, 10)
-          )
+          // Deferred a tick past the abort, so returning before the teardown is observable.
+          const tearDown = (): void => {
+            torndown = true
+            resolve([])
+          }
+          opts.signal?.addEventListener('abort', () => void setTimeout(tearDown, 10))
         }),
       pick: async () => 'claude-acp',
       hostFactory: () => fakeHost([{ id: 'oauth', name: 'Log in' }])

--- a/packages/daemon/test/auth-cli.test.ts
+++ b/packages/daemon/test/auth-cli.test.ts
@@ -1,0 +1,492 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough, Writable } from 'node:stream'
+import { runAuth } from '../src/cli/auth.js'
+import type { AcpHost } from '../src/acp/acp-host.js'
+import type { PickerModel, PickerRow } from '../src/cli/auth-picker.js'
+import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
+import type { RuntimeDef } from '../src/config/config-schema.js'
+import type { RuntimeProbeResult } from '../src/runtimes/runtime-prober.js'
+
+function scaffold(): { root: string; configPath: string } {
+  const root = mkdtempSync(join(tmpdir(), 'ac-auth-'))
+  const configPath = join(root, 'config.json')
+  writeFileSync(configPath, JSON.stringify({ version: 1, controlPlane: { enabled: false } }))
+  return { root, configPath }
+}
+
+function capture(): { stream: Writable; text: () => string } {
+  let buf = ''
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      buf += chunk.toString()
+      cb()
+    }
+  })
+  return { stream, text: () => buf }
+}
+
+const def = (command: string): RuntimeDef => ({ command, args: ['acp'], env: [] })
+
+function catalog(): ResolvedRuntimeCatalog {
+  const entries = {
+    'antigravity-acp': { runtime: def('agy'), name: 'Google Antigravity' },
+    'claude-acp': { runtime: def('claude'), name: 'Claude Agent' },
+    'grok-build': { runtime: def('grok'), name: 'Grok Build' }
+  }
+  return {
+    entries: Object.fromEntries(
+      Object.entries(entries).map(([id, e]) => [
+        id,
+        { runtime: e.runtime, source: 'registry' as const, name: e.name, version: '', skillsAgentId: null }
+      ])
+    ),
+    runtimes: Object.fromEntries(Object.entries(entries).map(([id, e]) => [id, e.runtime]))
+  }
+}
+
+/** An AcpHost that reports the given login methods and records what was authenticated. */
+function fakeHost(methods: unknown[], calls: string[] = []): AcpHost {
+  return {
+    start: vi.fn(async () => {}),
+    authMethods: () => methods,
+    authenticate: vi.fn(async (methodId: string) => void calls.push(methodId)),
+    stop: vi.fn(async () => {})
+  } as unknown as AcpHost
+}
+
+const io = () => ({ input: new PassThrough() as never, output: capture().stream as never })
+
+describe('runAuth: the runtime list', () => {
+  it('lists every runtime as checking before a single verdict lands', async () => {
+    const { root, configPath } = scaffold()
+    let shown: PickerRow[] | undefined
+    let release = (): void => {}
+    await runAuth({
+      root,
+      configPath,
+      out: capture().stream,
+      io: io(),
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      // Never answers while the picker is open: the list must not wait for it.
+      probeRuntimes: async () => new Promise((resolve) => (release = () => resolve([]))),
+      pick: async (model) => {
+        shown = model.rows()
+        return 'antigravity-acp'
+      },
+      hostFactory: () => fakeHost([{ id: 'oauth-personal', name: 'Log in with Google' }])
+    })
+    release()
+    expect(shown).toEqual([
+      { id: 'antigravity-acp', name: 'Google Antigravity', hint: 'checking…' },
+      { id: 'claude-acp', name: 'Claude Agent', hint: 'checking…' },
+      { id: 'grok-build', name: 'Grok Build', hint: 'checking…' }
+    ])
+  })
+
+  it('keeps the order fixed and only updates each row status as verdicts land', async () => {
+    const { root, configPath } = scaffold()
+    let emit: ((result: RuntimeProbeResult) => void) | undefined
+    const repaints: PickerRow[][] = []
+    await runAuth({
+      root,
+      configPath,
+      out: capture().stream,
+      io: io(),
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      probeRuntimes: async (_runtimes, opts) => {
+        emit = (result) => opts.onResult?.(result)
+        return []
+      },
+      pick: async (model) => {
+        model.subscribe?.(() => repaints.push(model.rows()))
+        // Deliberately out of list order: the rows must not follow the answer order.
+        emit!({ runtime: 'claude-acp', ok: true, models: ['opus', 'sonnet'], probedVersion: '0.73.0' })
+        emit!({ runtime: 'grok-build', ok: false, models: [], error: 'ACP connection closed' })
+        emit!({
+          runtime: 'antigravity-acp',
+          ok: false,
+          models: [],
+          error: 'Authentication required',
+          authRequired: true
+        })
+        return undefined
+      }
+    })
+
+    expect(repaints).toHaveLength(3)
+    for (const rows of repaints) {
+      expect(rows.map((row) => row.id)).toEqual(['antigravity-acp', 'claude-acp', 'grok-build'])
+    }
+    expect(repaints.at(-1)).toEqual([
+      { id: 'antigravity-acp', name: 'Google Antigravity', hint: 'not logged in' },
+      { id: 'claude-acp', name: 'Claude Agent', hint: 'logged in — 2 model(s), 0.73.0' },
+      // A failure that is not an auth failure still reads as not logged in, with the reason.
+      { id: 'grok-build', name: 'Grok Build', hint: 'not logged in — ACP connection closed' }
+    ])
+    // The first verdict only changed its own row.
+    expect(repaints[0]!.map((row) => row.hint)).toEqual(['checking…', 'logged in — 2 model(s), 0.73.0', 'checking…'])
+  })
+
+  it('aborts the sweep as soon as a runtime is chosen', async () => {
+    const { root, configPath } = scaffold()
+    let signal: AbortSignal | undefined
+    const calls: string[] = []
+    await runAuth({
+      root,
+      configPath,
+      out: capture().stream,
+      io: io(),
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      probeRuntimes: async (_runtimes, opts) => {
+        signal = opts.signal
+        return []
+      },
+      pick: async () => {
+        expect(signal?.aborted).toBe(false)
+        return 'claude-acp'
+      },
+      hostFactory: () => fakeHost([{ id: 'oauth', name: 'Log in' }], calls)
+    })
+    // Nothing new is launched while the login this command exists for is running.
+    expect(signal?.aborted).toBe(true)
+    expect(calls).toEqual(['oauth'])
+  })
+
+  it('probes every installed runtime, keyed by id', async () => {
+    const { root, configPath } = scaffold()
+    const probed: string[][] = []
+    await runAuth({
+      root,
+      configPath,
+      out: capture().stream,
+      io: io(),
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      probeRuntimes: async (runtimes) => {
+        probed.push(Object.keys(runtimes).sort())
+        return []
+      },
+      pick: async () => undefined
+    })
+    expect(probed).toEqual([['antigravity-acp', 'claude-acp', 'grok-build']])
+  })
+
+  it('skips the sweep entirely with --skip-probe', async () => {
+    const { root, configPath } = scaffold()
+    let shown: PickerRow[] | undefined
+    let probes = 0
+    await runAuth({
+      root,
+      configPath,
+      out: capture().stream,
+      io: io(),
+      skipProbe: true,
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      probeRuntimes: async () => {
+        probes += 1
+        return []
+      },
+      pick: async (model) => {
+        shown = model.rows()
+        return undefined
+      }
+    })
+    expect(probes).toBe(0)
+    expect(shown!.map((row) => row.id)).toEqual(['antigravity-acp', 'claude-acp', 'grok-build'])
+    expect(shown!.every((row) => row.hint === undefined)).toBe(true)
+  })
+
+  it('goes straight to the runtime named by --runtime, probing nothing', async () => {
+    const { root, configPath } = scaffold()
+    const out = capture()
+    const calls: string[] = []
+    let probes = 0
+    await runAuth({
+      root,
+      configPath,
+      out: out.stream,
+      runtimeId: 'claude-acp',
+      methodId: 'oauth',
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      probeRuntimes: async () => {
+        probes += 1
+        return []
+      },
+      hostFactory: () => fakeHost([{ id: 'oauth', name: 'Log in' }], calls)
+    })
+    expect(probes).toBe(0)
+    expect(calls).toEqual(['oauth'])
+    expect(out.text()).toContain('✓ claude-acp is logged in on this host.')
+  })
+})
+
+describe('runAuth: method selection', () => {
+  it('uses the only method a runtime offers without asking', async () => {
+    const { root, configPath } = scaffold()
+    const calls: string[] = []
+    await runAuth({
+      root,
+      configPath,
+      out: capture().stream,
+      runtimeId: 'claude-acp',
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      hostFactory: () => fakeHost([{ id: 'only-one', name: 'Log in' }], calls),
+      pick: async () => {
+        throw new Error('must not ask when there is only one method')
+      }
+    })
+    expect(calls).toEqual(['only-one'])
+  })
+
+  it('offers the methods on the same arrow-key list, never as an id to retype', async () => {
+    const { root, configPath } = scaffold()
+    const calls: string[] = []
+    let shown: PickerRow[] | undefined
+    let prompt = ''
+    await runAuth({
+      root,
+      configPath,
+      out: capture().stream,
+      runtimeId: 'antigravity-acp',
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      hostFactory: () =>
+        fakeHost(
+          [
+            { id: 'oauth-personal', name: 'Log in with Google', description: 'Your Google account' },
+            { id: 'gemini-api-key', name: 'Gemini API key' },
+            { type: 'terminal', id: 'tui', name: 'Log in in a terminal' }
+          ],
+          calls
+        ),
+      pick: async (model: PickerModel, _io, text) => {
+        shown = model.rows()
+        prompt = text
+        return 'gemini-api-key'
+      }
+    })
+    expect(prompt).toBe('How do you want to log in to antigravity-acp?')
+    expect(shown).toEqual([
+      { id: 'oauth-personal', name: 'Log in with Google', hint: 'Your Google account (handled by the runtime)' },
+      { id: 'gemini-api-key', name: 'Gemini API key', hint: 'Gemini API key (handled by the runtime)' },
+      { id: 'tui', name: 'Log in in a terminal', hint: 'Log in in a terminal (in a terminal)' }
+    ])
+    expect(calls).toEqual(['gemini-api-key'])
+  })
+
+  it('cancels the login when the method list is dismissed', async () => {
+    const { root, configPath } = scaffold()
+    const out = capture()
+    const calls: string[] = []
+    await runAuth({
+      root,
+      configPath,
+      out: out.stream,
+      runtimeId: 'antigravity-acp',
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      hostFactory: () =>
+        fakeHost(
+          [
+            { id: 'a', name: 'A' },
+            { id: 'b', name: 'B' }
+          ],
+          calls
+        ),
+      pick: async () => undefined
+    })
+    expect(calls).toEqual([])
+    expect(out.text()).not.toContain('is logged in on this host')
+  })
+
+  it('refuses a method the runtime does not offer', async () => {
+    const { root, configPath } = scaffold()
+    await expect(
+      runAuth({
+        root,
+        configPath,
+        out: capture().stream,
+        runtimeId: 'claude-acp',
+        methodId: 'nope',
+        resolveCatalog: async () => catalog(),
+        installed: (c) => c,
+        hostFactory: () => fakeHost([{ id: 'oauth', name: 'Log in' }])
+      })
+    ).rejects.toThrow(/"nope" is not offered by claude-acp\. Offered: oauth/)
+  })
+
+  it('runs a terminal method as the client, and never through authenticate', async () => {
+    const { root, configPath } = scaffold()
+    const out = capture()
+    const calls: string[] = []
+    const ran: { command: string; method: string }[] = []
+    await runAuth({
+      root,
+      configPath,
+      out: out.stream,
+      runtimeId: 'claude-acp',
+      methodId: 'tui',
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      hostFactory: () => fakeHost([{ type: 'terminal', id: 'tui', name: 'Log in in a terminal' }], calls),
+      runTerminalAuth: async (runtime, method) => {
+        ran.push({ command: runtime.command, method: method.id })
+        return 0
+      }
+    })
+    // The spec forbids passing a terminal method to `authenticate`; the client owns it.
+    expect(calls).toEqual([])
+    expect(ran).toEqual([{ command: 'claude', method: 'tui' }])
+    expect(out.text()).toContain('Using tui — Log in in a terminal')
+    expect(out.text()).toContain('✓ claude-acp is logged in on this host.')
+  })
+
+  it('fails when the interactive login exits non-zero', async () => {
+    const { root, configPath } = scaffold()
+    await expect(
+      runAuth({
+        root,
+        configPath,
+        out: capture().stream,
+        runtimeId: 'claude-acp',
+        methodId: 'tui',
+        resolveCatalog: async () => catalog(),
+        installed: (c) => c,
+        hostFactory: () => fakeHost([{ type: 'terminal', id: 'tui', name: 'Log in in a terminal' }]),
+        runTerminalAuth: async () => 1
+      })
+    ).rejects.toThrow(/interactive login exited with code 1/)
+  })
+
+  it('offers the loopback paste once an agent-run login stalls, and replays it locally', async () => {
+    const { root, configPath } = scaffold()
+    const out = capture()
+    const delivered: string[] = []
+    let finishLogin = (): void => {}
+    const login = new Promise<void>((resolve) => (finishLogin = resolve))
+    const host = {
+      start: async () => {},
+      authMethods: () => [{ id: 'oauth-personal', name: 'Log in with Google' }],
+      authenticate: async () => login,
+      stop: async () => {}
+    } as unknown as AcpHost
+
+    await runAuth({
+      root,
+      configPath,
+      out: out.stream,
+      runtimeId: 'antigravity-acp',
+      methodId: 'oauth-personal',
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      hostFactory: () => host,
+      pasteAfterMs: 0,
+      readLine: async () => 'http://127.0.0.1:52481/?code=4/abc&state=xyz',
+      deliverLoopback: async (url) => {
+        delivered.push(url)
+        finishLogin()
+      }
+    })
+
+    expect(delivered).toEqual(['http://127.0.0.1:52481/?code=4/abc&state=xyz'])
+    expect(out.text()).toContain('copy the URL of the tab that failed to load')
+    expect(out.text()).toContain('✓ antigravity-acp is logged in on this host.')
+  })
+
+  it('refuses to fetch anything that is not a loopback redirect', async () => {
+    const { root, configPath } = scaffold()
+    const out = capture()
+    const delivered: string[] = []
+    let finishLogin = (): void => {}
+    const login = new Promise<void>((resolve) => (finishLogin = resolve))
+    const answers = ['https://evil.example.test/?code=stolen', 'http://127.0.0.1:52481/?code=ok']
+    await runAuth({
+      root,
+      configPath,
+      out: out.stream,
+      runtimeId: 'antigravity-acp',
+      methodId: 'oauth-personal',
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      hostFactory: () =>
+        ({
+          start: async () => {},
+          authMethods: () => [{ id: 'oauth-personal', name: 'Log in with Google' }],
+          authenticate: async () => login,
+          stop: async () => {}
+        }) as unknown as AcpHost,
+      pasteAfterMs: 0,
+      readLine: async () => answers.shift()!,
+      deliverLoopback: async (url) => {
+        delivered.push(url)
+        finishLogin()
+      }
+    })
+    // The first paste never leaves this process; the loop asks again.
+    expect(delivered).toEqual(['http://127.0.0.1:52481/?code=ok'])
+    expect(out.text()).toContain('not a loopback redirect URL')
+  })
+
+  it('never offers the paste when the login completes on its own', async () => {
+    const { root, configPath } = scaffold()
+    const out = capture()
+    let asked = 0
+    await runAuth({
+      root,
+      configPath,
+      out: out.stream,
+      runtimeId: 'claude-acp',
+      methodId: 'oauth',
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      hostFactory: () => fakeHost([{ id: 'oauth', name: 'Log in' }]),
+      pasteAfterMs: 50,
+      readLine: async () => {
+        asked += 1
+        return ''
+      }
+    })
+    expect(asked).toBe(0)
+    expect(out.text()).not.toContain('copy the URL')
+  })
+
+  it('says so when a runtime advertises no login at all', async () => {
+    const { root, configPath } = scaffold()
+    const out = capture()
+    await runAuth({
+      root,
+      configPath,
+      out: out.stream,
+      runtimeId: 'claude-acp',
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      hostFactory: () => fakeHost([])
+    })
+    expect(out.text()).toContain('advertises no login methods')
+  })
+
+  it('refuses a runtime that is not installed here', async () => {
+    const { root, configPath } = scaffold()
+    await expect(
+      runAuth({
+        root,
+        configPath,
+        out: capture().stream,
+        runtimeId: 'absent',
+        resolveCatalog: async () => catalog(),
+        installed: (c) => c
+      })
+    ).rejects.toThrow(
+      /runtime "absent" is not installed on this host\. Available: antigravity-acp, claude-acp, grok-build/
+    )
+  })
+})

--- a/packages/daemon/test/auth-cli.test.ts
+++ b/packages/daemon/test/auth-cli.test.ts
@@ -9,6 +9,7 @@ import type { PickerModel, PickerRow } from '../src/cli/auth-picker.js'
 import type { ResolvedRuntimeCatalog } from '../src/runtimes/registry.js'
 import type { RuntimeDef } from '../src/config/config-schema.js'
 import type { RuntimeProbeResult } from '../src/runtimes/runtime-prober.js'
+import type { CreateElicitationRequest, CreateElicitationResponse } from '@agentclientprotocol/sdk'
 
 function scaffold(): { root: string; configPath: string } {
   const root = mkdtempSync(join(tmpdir(), 'ac-auth-'))
@@ -63,7 +64,6 @@ describe('runAuth: the runtime list', () => {
   it('lists every runtime as checking before a single verdict lands', async () => {
     const { root, configPath } = scaffold()
     let shown: PickerRow[] | undefined
-    let release = (): void => {}
     await runAuth({
       root,
       configPath,
@@ -71,15 +71,16 @@ describe('runAuth: the runtime list', () => {
       io: io(),
       resolveCatalog: async () => catalog(),
       installed: (c) => c,
-      // Never answers while the picker is open: the list must not wait for it.
-      probeRuntimes: async () => new Promise((resolve) => (release = () => resolve([]))),
+      // Never answers while the picker is open — only once the choice cancels it, which is what
+      // a real sweep does now: the list must not wait for a verdict.
+      probeRuntimes: async (_runtimes, opts) =>
+        await new Promise((resolve) => opts.signal?.addEventListener('abort', () => resolve([]))),
       pick: async (model) => {
         shown = model.rows()
         return 'antigravity-acp'
       },
       hostFactory: () => fakeHost([{ id: 'oauth-personal', name: 'Log in with Google' }])
     })
-    release()
     expect(shown).toEqual([
       { id: 'antigravity-acp', name: 'Google Antigravity', hint: 'checking…' },
       { id: 'claude-acp', name: 'Claude Agent', hint: 'checking…' },
@@ -156,6 +157,33 @@ describe('runAuth: the runtime list', () => {
     // Nothing new is launched while the login this command exists for is running.
     expect(signal?.aborted).toBe(true)
     expect(calls).toEqual(['oauth'])
+  })
+
+  it('waits for the cancelled sweep to tear down before it returns', async () => {
+    // runAuth resolving is the CLI action calling process.exit: a teardown nobody awaited leaves
+    // probe children running after the command is gone.
+    const { root, configPath } = scaffold()
+    let torndown = false
+    await runAuth({
+      root,
+      configPath,
+      out: capture().stream,
+      io: io(),
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      probeRuntimes: async (_runtimes, opts) =>
+        await new Promise((resolve) => {
+          opts.signal?.addEventListener('abort', () =>
+            setTimeout(() => {
+              torndown = true
+              resolve([])
+            }, 10)
+          )
+        }),
+      pick: async () => 'claude-acp',
+      hostFactory: () => fakeHost([{ id: 'oauth', name: 'Log in' }])
+    })
+    expect(torndown).toBe(true)
   })
 
   it('probes every installed runtime, keyed by id', async () => {
@@ -459,6 +487,48 @@ describe('runAuth: method selection', () => {
     expect(out.text()).not.toContain('copy the URL')
   })
 
+  it('finishes on its own when the login settles while the paste prompt is waiting', async () => {
+    // A browser login routinely takes longer than the paste offer's delay. Once the question is
+    // on stdin, only releasing it can end the command — no keypress should be required.
+    const { root, configPath } = scaffold()
+    const out = capture()
+    let asked = 0
+    let released = false
+    let finishLogin = (): void => {}
+    const login = new Promise<void>((resolve) => (finishLogin = resolve))
+    await runAuth({
+      root,
+      configPath,
+      out: out.stream,
+      runtimeId: 'antigravity-acp',
+      methodId: 'oauth-personal',
+      resolveCatalog: async () => catalog(),
+      installed: (c) => c,
+      hostFactory: () =>
+        ({
+          start: async () => {},
+          authMethods: () => [{ id: 'oauth-personal', name: 'Log in with Google' }],
+          authenticate: async () => login,
+          stop: async () => {}
+        }) as unknown as AcpHost,
+      pasteAfterMs: 0,
+      readLine: async (_question, signal) => {
+        asked += 1
+        // The operator is off in a browser: this question is answered by nobody.
+        setTimeout(finishLogin, 10)
+        return await new Promise<string>((resolve) =>
+          signal?.addEventListener('abort', () => {
+            released = true
+            resolve('')
+          })
+        )
+      }
+    })
+    expect(asked).toBe(1)
+    expect(released).toBe(true)
+    expect(out.text()).toContain('✓ antigravity-acp is logged in on this host.')
+  })
+
   it('says so when a runtime advertises no login at all', async () => {
     const { root, configPath } = scaffold()
     const out = capture()
@@ -488,5 +558,155 @@ describe('runAuth: method selection', () => {
     ).rejects.toThrow(
       /runtime "absent" is not installed on this host\. Available: antigravity-acp, claude-acp, grok-build/
     )
+  })
+})
+
+/** Drive the host options the command builds — `onAuthElicit` is what the agent's auth phase
+ *  asks over, so the form answers are asserted through the very hook the agent calls. */
+async function authElicit(
+  params: CreateElicitationRequest,
+  over: Parameters<typeof runAuth>[0] = {}
+): Promise<CreateElicitationResponse | undefined> {
+  const { root, configPath } = scaffold()
+  let elicit: ((p: CreateElicitationRequest) => Promise<CreateElicitationResponse | undefined>) | undefined
+  let answer: CreateElicitationResponse | undefined
+  await runAuth({
+    root,
+    configPath,
+    out: capture().stream,
+    io: io(),
+    runtimeId: 'claude-acp',
+    methodId: 'oauth',
+    resolveCatalog: async () => catalog(),
+    installed: (c) => c,
+    hostFactory: (_runtime, options) => {
+      elicit = options?.onAuthElicit
+      return {
+        start: async () => {},
+        authMethods: () => [{ id: 'oauth', name: 'Log in' }],
+        authenticate: async () => {
+          answer = await elicit!(params)
+        },
+        stop: async () => {}
+      } as unknown as AcpHost
+    },
+    ...over
+  })
+  return answer
+}
+
+describe('runAuth: the auth phase’s form elicitations', () => {
+  it('answers under the schema’s own property names and types', async () => {
+    const answer = await authElicit(
+      {
+        mode: 'form',
+        message: 'Which project should this credential belong to?',
+        requestedSchema: {
+          type: 'object',
+          required: ['projectId'],
+          properties: {
+            projectId: { type: 'string', title: 'Project id' },
+            region: {
+              type: 'string',
+              title: 'Region',
+              oneOf: [
+                { const: 'us', title: 'United States' },
+                { const: 'eu', title: 'Europe' }
+              ]
+            },
+            sandbox: { type: 'boolean', title: 'Sandbox project' }
+          }
+        }
+      } as unknown as CreateElicitationRequest,
+      {
+        readLine: async () => 'proj-42',
+        // The enum and the boolean are PICKED from what the agent offered, never typed.
+        pick: async (model) => model.rows()[0]!.id
+      }
+    )
+
+    // A fixed {type,text} payload would answer none of these — the request asked for projectId.
+    expect(answer).toEqual({
+      action: 'accept',
+      content: { projectId: 'proj-42', region: 'us', sandbox: true }
+    })
+  })
+
+  it('declines when a required field is left unanswered', async () => {
+    const answer = await authElicit(
+      {
+        mode: 'form',
+        message: 'Which project?',
+        requestedSchema: {
+          type: 'object',
+          required: ['projectId'],
+          properties: {
+            projectId: { type: 'string', title: 'Project id' },
+            label: { type: 'string', title: 'Label' }
+          }
+        }
+      } as unknown as CreateElicitationRequest,
+      // Asked in schema order: the required field is skipped, the optional one answered — so the
+      // form is refused by the required check, not by the "nothing typed at all" shortcut.
+      {
+        readLine: (() => {
+          const typed = ['', 'staging']
+          return async () => typed.shift()!
+        })()
+      }
+    )
+    expect(answer).toBeUndefined()
+  })
+
+  it('re-asks a value the field’s own schema refuses', async () => {
+    const typed = ['not-a-number', '7']
+    const answer = await authElicit(
+      {
+        mode: 'form',
+        message: 'How many retries?',
+        requestedSchema: {
+          type: 'object',
+          required: ['retries'],
+          properties: { retries: { type: 'integer', title: 'Retries', minimum: 1, maximum: 10 } }
+        }
+      } as unknown as CreateElicitationRequest,
+      { readLine: async () => typed.shift()! }
+    )
+    expect(answer).toEqual({ action: 'accept', content: { retries: 7 } })
+  })
+
+  it('declines a form whose required field this terminal cannot render', async () => {
+    const answer = await authElicit(
+      {
+        mode: 'form',
+        message: 'Upload the key file',
+        requestedSchema: {
+          type: 'object',
+          required: ['keyFile'],
+          properties: {
+            keyFile: { type: 'object', title: 'Key file' },
+            note: { type: 'string', title: 'Note' }
+          }
+        }
+      } as unknown as CreateElicitationRequest,
+      { readLine: async () => 'anything' }
+    )
+    // Half-answering a form is a lie about what the operator supplied.
+    expect(answer).toBeUndefined()
+  })
+
+  it('accepts a URL-mode ask by showing the link, never by opening one', async () => {
+    const out = capture()
+    const answer = await authElicit(
+      {
+        mode: 'url',
+        elicitationId: 'e-1',
+        message: 'Sign in with Google',
+        url: 'https://accounts.example.test/o/oauth2/auth?client_id=x'
+      } as unknown as CreateElicitationRequest,
+      { out: out.stream }
+    )
+    expect(answer).toEqual({ action: 'accept' })
+    expect(out.text()).toContain('https://accounts.example.test/o/oauth2/auth?client_id=x')
   })
 })

--- a/packages/daemon/test/auth-picker.test.ts
+++ b/packages/daemon/test/auth-picker.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import { PassThrough, Writable } from 'node:stream'
+import { fixedRows, pickRow, renderPicker, type PickerIo, type PickerRow } from '../src/cli/auth-picker.js'
+
+const ROWS: PickerRow[] = [
+  { id: 'antigravity-acp', name: 'Google Antigravity', hint: 'not logged in' },
+  { id: 'claude-acp', name: 'Claude Agent', hint: 'logged in — 5 model(s), 0.73.0' },
+  { id: 'grok-build', name: 'Grok Build', hint: 'checking…' }
+]
+
+function capture(): { stream: Writable; text: () => string } {
+  let buf = ''
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      buf += chunk.toString()
+      cb()
+    }
+  })
+  return { stream, text: () => buf }
+}
+
+/** A stdin that claims to be a terminal, so the picker takes its interactive path. */
+function tty(): { io: PickerIo; press: (keys: string) => void; out: () => string; raw: boolean[] } {
+  const input = new PassThrough() as unknown as PickerIo['input']
+  const raw: boolean[] = []
+  ;(input as { isTTY?: boolean }).isTTY = true
+  ;(input as { setRawMode?: (v: boolean) => void }).setRawMode = (value) => raw.push(value)
+  const output = capture()
+  return {
+    io: { input, output: output.stream as PickerIo['output'] },
+    press: (keys) => (input as unknown as PassThrough).write(keys),
+    out: output.text,
+    raw
+  }
+}
+
+const DOWN = '\u001b[B'
+const UP = '\u001b[A'
+const ENTER = '\r'
+
+describe('renderPicker', () => {
+  it('renders one line per row and marks the cursor', () => {
+    expect(renderPicker(ROWS, 1)).toEqual([
+      '  antigravity-acp (Google Antigravity) — not logged in',
+      '❯ claude-acp (Claude Agent) — logged in — 5 model(s), 0.73.0',
+      '  grok-build (Grok Build) — checking…'
+    ])
+  })
+
+  it('repeats no name that is the id, and omits an absent hint', () => {
+    expect(renderPicker([{ id: 'omp', name: 'omp' }, { id: 'cline' }], 0)).toEqual(['❯ omp', '  cline'])
+  })
+})
+
+describe('pickRow', () => {
+  it('returns the row under the cursor', async () => {
+    const t = tty()
+    const chosen = pickRow(fixedRows(ROWS), t.io, 'Select a runtime to log in')
+    t.press(DOWN)
+    t.press(DOWN)
+    t.press(ENTER)
+    expect(await chosen).toBe('grok-build')
+    expect(t.raw).toEqual([true, false]) // raw mode is always restored
+    expect(t.out()).toContain('Select a runtime to log in — ↑/↓ to move, Enter to select, q to cancel.')
+  })
+
+  it('wraps at the ends and accepts j/k as well as the arrows', async () => {
+    const t = tty()
+    const chosen = pickRow(fixedRows(ROWS), t.io, 'Pick')
+    t.press('k') // up from the first row wraps to the last
+    t.press(ENTER)
+    expect(await chosen).toBe('grok-build')
+  })
+
+  it('handles several keys, and a whole escape sequence, in one read', async () => {
+    const t = tty()
+    const chosen = pickRow(fixedRows(ROWS), t.io, 'Pick')
+    t.press(`${DOWN}${DOWN}${UP}`)
+    t.press(ENTER)
+    expect(await chosen).toBe('claude-acp')
+  })
+
+  it('returns nothing when the operator cancels', async () => {
+    for (const key of ['q', '\u001b', '\u0003']) {
+      const t = tty()
+      const chosen = pickRow(fixedRows(ROWS), t.io, 'Pick')
+      t.press(key)
+      expect(await chosen).toBeUndefined()
+      expect(t.raw).toEqual([true, false])
+    }
+  })
+
+  it('prints the rows and picks nothing when stdin is not a terminal', async () => {
+    const input = new PassThrough() as unknown as PickerIo['input']
+    const output = capture()
+    const chosen = await pickRow(fixedRows(ROWS), { input, output: output.stream as PickerIo['output'] }, 'Pick')
+    expect(chosen).toBeUndefined()
+    expect(output.text()).toContain('antigravity-acp (Google Antigravity) — not logged in')
+  })
+
+  it('picks nothing when there is nothing to pick', async () => {
+    const t = tty()
+    expect(await pickRow(fixedRows([]), t.io, 'Pick')).toBeUndefined()
+  })
+
+  it('never leaves a data listener behind', async () => {
+    const t = tty()
+    const chosen = pickRow(fixedRows(ROWS), t.io, 'Pick')
+    t.press(ENTER)
+    await chosen
+    expect((t.io.input as unknown as PassThrough).listenerCount('data')).toBe(0)
+  })
+
+  it('rewinds exactly the lines it painted, so the list updates in place', async () => {
+    const t = tty()
+    const chosen = pickRow(fixedRows(ROWS), t.io, 'Pick')
+    t.press(DOWN)
+    t.press(ENTER)
+    await chosen
+    expect(t.out()).toContain('\u001b[3A\u001b[0J')
+  })
+})
+
+describe('pickRow with a list whose statuses are still arriving', () => {
+  /** Rows in a FIXED order whose hints change, the way the login sweep reports verdicts. */
+  function liveModel(): {
+    model: Parameters<typeof pickRow>[0]
+    land: (id: string, hint: string) => void
+    listeners: Set<() => void>
+  } {
+    const hints = new Map<string, string>()
+    const listeners = new Set<() => void>()
+    return {
+      model: {
+        rows: () => ROWS.map((row) => ({ ...row, hint: hints.get(row.id) ?? 'checking…' })),
+        subscribe: (listener) => {
+          listeners.add(listener)
+          return () => listeners.delete(listener)
+        }
+      },
+      land: (id, hint) => {
+        hints.set(id, hint)
+        for (const listener of listeners) listener()
+      },
+      listeners
+    }
+  }
+
+  it('repaints in place without moving the cursor off the row it was on', async () => {
+    const { model, land } = liveModel()
+    const t = tty()
+    const chosen = pickRow(model, t.io, 'Pick')
+    t.press(DOWN) // cursor on claude-acp
+    // A verdict for the row ABOVE the cursor must not disturb the selection.
+    land('antigravity-acp', 'not logged in')
+    land('claude-acp', 'logged in — 5 model(s)')
+    t.press(ENTER)
+    expect(await chosen).toBe('claude-acp')
+    expect(t.out()).toContain('claude-acp (Claude Agent) — logged in — 5 model(s)')
+  })
+
+  it('lets the operator choose before a single verdict has landed', async () => {
+    const { model } = liveModel()
+    const t = tty()
+    const chosen = pickRow(model, t.io, 'Pick')
+    t.press(DOWN)
+    t.press(DOWN)
+    t.press(ENTER)
+    expect(await chosen).toBe('grok-build')
+    expect(t.out()).toContain('checking…')
+  })
+
+  it('unsubscribes from the model on the way out', async () => {
+    const { model, listeners } = liveModel()
+    const t = tty()
+    const chosen = pickRow(model, t.io, 'Pick')
+    t.press(ENTER)
+    await chosen
+    expect(listeners.size).toBe(0)
+  })
+})

--- a/packages/daemon/test/runtime-prober.test.ts
+++ b/packages/daemon/test/runtime-prober.test.ts
@@ -281,6 +281,35 @@ describe('probeRuntime', () => {
     expect(res.ok).toBe(false)
     expect(res.error).toContain('timed out')
   })
+
+  it('ends an in-flight probe on abort instead of at its deadline, tearing the child down', async () => {
+    // The caller that aborts (the auth CLI's picker) exits right after; a probe left to run out a
+    // 60s deadline would outlive it as an orphan.
+    let stopped = false
+    const host = fakeHost({ newSession: () => new Promise<string>(() => {}), onStop: () => (stopped = true) })
+    const sweep = new AbortController()
+    setTimeout(() => sweep.abort(), 5)
+    const res = await probeRuntime('slow', rt, '/tmp/x', {
+      hostFactory: () => host,
+      timeoutMs: 60_000,
+      signal: sweep.signal
+    })
+    expect(res.ok).toBe(false)
+    expect(res.error).toContain('cancelled')
+    expect(stopped).toBe(true)
+  })
+
+  it('reports an already-aborted sweep without launching the runtime at all', async () => {
+    let started = 0
+    const host = fakeHost({ start: async () => void started++ })
+    const res = await probeRuntime('slow', rt, '/tmp/x', {
+      hostFactory: () => host,
+      signal: AbortSignal.abort()
+    })
+    expect(res.ok).toBe(false)
+    expect(res.error).toContain('cancelled')
+    expect(started).toBe(0)
+  })
 })
 
 describe('curatedProbeEnvironment', () => {

--- a/packages/daemon/test/spawn-driver.test.ts
+++ b/packages/daemon/test/spawn-driver.test.ts
@@ -193,6 +193,66 @@ describe('SpawnDriver seam', () => {
  * `error` event is rethrown as an uncaught exception, which would take down every
  * other agent this daemon runs.
  */
+/**
+ * A login command is interactive, and some runtimes install a signal handler that dumps a stack
+ * trace to the terminal on SIGTERM — after a login that in fact succeeded. A runtime that exits on
+ * stdin EOF should be allowed to, which is what the grace window buys.
+ */
+describe('LocalDriver stop with an EOF grace window', () => {
+  /** A child that exits cleanly the moment stdin closes, and shouts if it is ever signalled. */
+  const eofRunner = [
+    '-e',
+    `process.on('SIGTERM', () => { process.stdout.write('SIGNALLED'); process.exit(9) });
+     process.stdin.on('end', () => process.exit(0));
+     process.stdin.resume(); process.stdout.write('{}\\n')`
+  ]
+
+  it('lets a runtime exit on EOF, with no signal and no output', async () => {
+    const driver = new LocalDriver()
+    const runtime = await driver.launch({ command: process.execPath, args: eofRunner, env: {} })
+    const reader = (runtime.fromAgent as ReadableStream<Uint8Array>).getReader()
+    await reader.read() // it is up
+    void reader.cancel()
+    const started = Date.now()
+    await runtime.stop(5000, 2500)
+    // Under 2.5s means the wait ended on the child's own exit, not on the grace timer.
+    expect(Date.now() - started).toBeLessThan(2400)
+  })
+
+  it('still signals a runtime that ignores EOF, without waiting out the whole deadline', async () => {
+    const driver = new LocalDriver()
+    const runtime = await driver.launch({
+      command: process.execPath,
+      // Ignores EOF entirely, so only a signal ends it.
+      args: ['-e', "process.stdin.resume(); setInterval(() => {}, 1000); process.stdout.write('{}\\n')"],
+      env: {}
+    })
+    const reader = (runtime.fromAgent as ReadableStream<Uint8Array>).getReader()
+    await reader.read()
+    void reader.cancel()
+    const started = Date.now()
+    await runtime.stop(5000, 300)
+    const elapsed = Date.now() - started
+    expect(elapsed).toBeGreaterThanOrEqual(300)
+    expect(elapsed).toBeLessThan(3000)
+  })
+
+  it('signals immediately when no grace is asked for, which is what daemon teardown wants', async () => {
+    const driver = new LocalDriver()
+    const runtime = await driver.launch({
+      command: process.execPath,
+      args: ['-e', "process.stdin.resume(); setInterval(() => {}, 1000); process.stdout.write('{}\\n')"],
+      env: {}
+    })
+    const reader = (runtime.fromAgent as ReadableStream<Uint8Array>).getReader()
+    await reader.read()
+    void reader.cancel()
+    const started = Date.now()
+    await runtime.stop(5000)
+    expect(Date.now() - started).toBeLessThan(300)
+  })
+})
+
 describe('LocalDriver spawn failures', () => {
   const missing = join(tmpdir(), 'agentconnect-nonexistent-runtime')
 

--- a/packages/web/src/components/console/FleetDetail.tsx
+++ b/packages/web/src/components/console/FleetDetail.tsx
@@ -31,6 +31,7 @@ import { amountToNumber } from '@/lib/amount'
 import { consoleKeys } from '@/lib/swr-keys'
 import { SEG_FILL, bucketLabel, tickInterval } from '@/lib/spend-chart'
 import { useOrgs } from '@/lib/org-context'
+import { useModal } from '@/components/console/ModalProvider'
 
 /** Bar colour tracks the reading — one scale across Infra, cluster, group and daemon detail. */
 export function barColor(pct: number): string {
@@ -379,7 +380,8 @@ export function FleetRuntimesCard({
   runtimes,
   agents,
   empty,
-  note
+  note,
+  daemonName
 }: {
   title: string
   runtimes: readonly FleetRuntime[]
@@ -388,8 +390,12 @@ export function FleetRuntimesCard({
   empty: string
   /** What the header says the list means — a group's is narrower than a pool's. */
   note?: string
+  /** The one machine these runtimes are on, when the card is a single daemon's — a login command
+   *  belongs on a named host, and a set of them has no single one to name. */
+  daemonName?: string
 }) {
   const acpRegistry = useAcpRegistry()
+  const { openModal } = useModal()
   // Independent disclosures — more than one runtime's models can be open at once.
   const [open, setOpen] = useState<Set<string>>(new Set())
   const toggle = (rid: string) =>
@@ -451,13 +457,25 @@ export function FleetRuntimesCard({
                   />
                 </button>
                 {rt.authRequired && (
-                  <div
-                    title="The runtime rejected a probe with 'authentication required' — sign in to it on the daemon host. The warning clears on the next probe."
-                    className="flex items-center gap-[6px] bg-(--status-paused-soft) px-[13px] py-[6px] font-sans text-[11.5px] font-medium leading-normal text-(--amber-500)"
+                  <button
+                    type="button"
+                    title="The runtime rejected a probe with 'authentication required' — show the command that logs it in on the daemon host."
+                    onClick={() =>
+                      openModal('runtimeLogin', {
+                        runtimeId: rt.runtime,
+                        runtimeLabel: label,
+                        ...(daemonName ? { daemonName } : {})
+                      })
+                    }
+                    className="flex w-full cursor-pointer items-center gap-[6px] border-0 bg-(--status-paused-soft) px-[13px] py-[6px] text-left font-sans text-[11.5px] font-medium leading-normal text-(--amber-500) transition-opacity hover:opacity-80"
                   >
                     <Icon name="triangle-alert" size={12} className="flex-none" />
-                    <span className="min-w-0 truncate">Login required — sign in on the daemon host</span>
-                  </div>
+                    <span className="min-w-0 truncate">Login required</span>
+                    <span className="ml-auto flex flex-none items-center gap-[3px] underline underline-offset-2">
+                      Show command
+                      <Icon name="chevron-right" size={12} className="flex-none" />
+                    </span>
+                  </button>
                 )}
                 {shown && (
                   <div className="border-t border-(--border-subtle) bg-(--surface-sunken) px-[13px] py-[10px]">

--- a/packages/web/src/components/console/ModalProvider.tsx
+++ b/packages/web/src/components/console/ModalProvider.tsx
@@ -29,6 +29,7 @@ import EditDescriptionModal from './modals/EditDescriptionModal'
 import EditProfileModal from './modals/EditProfileModal'
 import EditOrgModal from './modals/EditOrgModal'
 import GroupModal from './modals/GroupModal'
+import RuntimeLoginModal, { type RuntimeLoginTarget } from './modals/RuntimeLoginModal'
 import DeleteGroupModal from './modals/DeleteGroupModal'
 
 export type ModalKind =
@@ -50,9 +51,11 @@ export type ModalKind =
   | 'editOrg'
   | 'group'
   | 'deleteGroup'
+  | 'runtimeLogin'
 
 // HookDto[] = the whole GitHub group (header unplug — disconnect every repo subscription).
-type ModalTarget = DaemonRow | Agent | CronDto | IntegrationRow | HookDto | HookDto[] | MemberSetRow
+type ModalTarget =
+  DaemonRow | Agent | CronDto | IntegrationRow | HookDto | HookDto[] | MemberSetRow | RuntimeLoginTarget
 
 // Per-kind extras: `platform` preselects the Add-integration pane (the GitHub group
 // card's "Add repository" lands on GitHub, not the Slack default). `focusSection`
@@ -199,6 +202,10 @@ export function ModalProvider({ children }: { children: ReactNode }) {
             )}
             {open.kind === 'editAgentDesc' && open.target && (
               <EditDescriptionModal agent={open.target as Agent} onClose={close} />
+            )}
+            {/* The "Login required" warning on a runtime row — the command belongs on that host. */}
+            {open.kind === 'runtimeLogin' && open.target && (
+              <RuntimeLoginModal target={open.target as RuntimeLoginTarget} onClose={close} />
             )}
             {open.kind === 'editProfile' && <EditProfileModal onClose={close} />}
             {open.kind === 'editOrg' && <EditOrgModal onClose={close} />}

--- a/packages/web/src/components/console/modals/RuntimeLoginModal.tsx
+++ b/packages/web/src/components/console/modals/RuntimeLoginModal.tsx
@@ -1,0 +1,119 @@
+// No 'use client' here: rendered only by ModalProvider (the client boundary).
+
+import { useState } from 'react'
+import { Button, Icon } from '@/components/ui'
+
+/** What the "Login required" warning opens on: the runtime it is about, and where it was seen. */
+export interface RuntimeLoginTarget {
+  runtimeId: string
+  /** Display name of the runtime, when the caller resolved one. */
+  runtimeLabel?: string
+  /** The daemon whose probe reported it — absent on the fleet/group card, which aggregates hosts. */
+  daemonName?: string
+}
+
+/** The login command for one runtime, run on the daemon's own host. `auth` is not CLI-owned, so
+ *  the unified CLI delegates it verbatim to the active daemon with the terminal attached. */
+export function runtimeLoginCommand(runtimeId: string): string {
+  return `agentconnect auth --runtime ${runtimeId}`
+}
+
+/**
+ * What to run to log a runtime in, and why it cannot be done from here.
+ *
+ * A runtime's credential lives in that runtime's own state directory on the daemon host — the
+ * directory sessions are seeded FROM — and every login flow it offers wants a human at a terminal
+ * (a browser consent URL, a pasted API key, its own interactive CLI). So the console's job is to
+ * hand over the exact command, not to run one.
+ */
+export default function RuntimeLoginModal({ target, onClose }: { target: RuntimeLoginTarget; onClose: () => void }) {
+  const [copied, setCopied] = useState(false)
+  const label = target.runtimeLabel || target.runtimeId
+  const command = runtimeLoginCommand(target.runtimeId)
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* clipboard unavailable (insecure context) — the text is still selectable */
+    }
+  }
+
+  return (
+    <>
+      <div className="modalhead">
+        <span className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-[7px] border border-(--border-subtle) bg-(--surface-sunken)">
+          <Icon name="terminal" size={16} color="var(--brand)" />
+        </span>
+        <span className="flex-1 font-sans text-[16px] font-semibold leading-normal">Log in to {label}</span>
+        <button className="iconbtn" onClick={onClose}>
+          <Icon name="x" size={16} />
+        </button>
+      </div>
+      <div className="modalbody">
+        <div className="mb-[14px] flex items-start gap-[9px] rounded-md border border-(--amber-500) bg-(--status-paused-soft) px-3 py-[11px]">
+          <Icon name="alert-triangle" size={15} color="var(--amber-500)" className="mt-[1px] flex-none" />
+          <span className="font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
+            <span className="mono text-(--text-primary)">{target.runtimeId}</span> rejected the probe with
+            &ldquo;authentication required&rdquo;. Its credential lives in the runtime&apos;s own state on
+            {target.daemonName ? (
+              <>
+                {' '}
+                <span className="mono text-(--text-primary)">{target.daemonName}</span>&apos;s host
+              </>
+            ) : (
+              " the daemon's host"
+            )}
+            , and every login it offers needs a human at that terminal — so run this there.
+          </span>
+        </div>
+        <div className="overflow-hidden rounded-[9px] border border-(--gray-800) bg-(--gray-1000)">
+          <div className="flex items-center gap-2 border-b border-(--gray-800) px-[13px] py-[9px]">
+            <Icon name="terminal" size={13} color="var(--text-inverse-dim)" />
+            <span className="font-mono text-[11px] font-medium leading-normal text-(--text-inverse-dim)">
+              {target.daemonName ? `${target.daemonName} · terminal` : 'daemon host · terminal'}
+            </span>
+            <button
+              type="button"
+              onClick={copy}
+              className="ml-auto inline-flex cursor-pointer items-center gap-[5px] border-0 bg-transparent font-mono text-[11px] font-medium leading-normal text-(--text-inverse-dim)"
+            >
+              <Icon name={copied ? 'check' : 'copy'} size={12} />
+              {copied ? 'copied' : 'copy'}
+            </button>
+          </div>
+          <div className="break-all px-[14px] py-[13px] font-mono text-[12px] leading-[1.7] text-[#cdd6e0]">
+            <span className="text-(--magenta-300)">$</span> {command}
+          </div>
+        </div>
+        <ul className="mt-[14px] flex list-none flex-col gap-[7px] rounded-[9px] border border-dashed border-(--border-strong) px-[14px] py-[13px] font-sans text-[12px] font-normal leading-[1.5] text-(--text-tertiary)">
+          <li>
+            It lists the login methods <span className="mono text-(--text-secondary)">{target.runtimeId}</span> offers
+            and walks the chosen one — a browser URL, an API key, or the runtime&apos;s own interactive CLI.
+          </li>
+          <li>
+            Drop <span className="mono text-(--text-secondary)">--runtime</span> to pick from every runtime installed
+            there, each row annotated with whether it is already logged in.
+          </li>
+          <li>
+            No <span className="mono text-(--text-secondary)">agentconnect</span> on that host&apos;s PATH? Prefix it
+            with <span className="mono text-(--text-secondary)">npx -y @agentconnect.md/cli</span>. A named service
+            instance also takes <span className="mono text-(--text-secondary)">--instance &lt;name&gt;</span>.
+          </li>
+          <li>
+            Sessions pick the credential up on their next start — the daemon needs no restart, and this warning clears
+            on its next probe.
+          </li>
+        </ul>
+      </div>
+      <div className="modalfoot">
+        <div className="flex-1" />
+        <Button variant="primary" onClick={onClose}>
+          Done
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -52,6 +52,9 @@ vi.mock('swr', () => ({
 }))
 
 const ClusterDetailView = (await import('./ClusterDetailView')).default
+// The runtimes card opens the runtime-login dialog, so it renders under the provider the
+// console mounts it under — the same composition, not a stub.
+const { ModalProvider } = await import('@/components/console/ModalProvider')
 
 function member(id: string, over: Partial<DaemonRow> = {}): DaemonRow {
   return {
@@ -143,7 +146,11 @@ function render(): string {
   document.body.appendChild(host)
   const root: Root = createRoot(host)
   act(() => {
-    root.render(<ClusterDetailView />)
+    root.render(
+      <ModalProvider>
+        <ClusterDetailView />
+      </ModalProvider>
+    )
   })
   const html = host.innerHTML
   act(() => root.unmount())
@@ -272,7 +279,11 @@ describe('ClusterDetailView', () => {
     document.body.appendChild(host)
     const root: Root = createRoot(host)
     act(() => {
-      root.render(<ClusterDetailView />)
+      root.render(
+        <ModalProvider>
+          <ClusterDetailView />
+        </ModalProvider>
+      )
     })
     expect(host.innerHTML).not.toContain('sonnet')
     act(() => {
@@ -284,6 +295,39 @@ describe('ClusterDetailView', () => {
 
     expect(opened).toContain('sonnet')
     expect(opened).toContain('aria-expanded="true"')
+  })
+
+  it('hands over the login command for a runtime that rejected the probe', () => {
+    // The credential lives on the daemon host, so the warning's job is to produce the exact
+    // command — the console has no way to run it.
+    mocks.daemons = [
+      member('p1', {
+        runtimeModels: [
+          { runtime: 'claude-acp', version: '0.75.1', models: ['opus'], acpProtocolVersion: 1, authRequired: true }
+        ]
+      })
+    ] as unknown[]
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root: Root = createRoot(host)
+    act(() => {
+      root.render(
+        <ModalProvider>
+          <ClusterDetailView />
+        </ModalProvider>
+      )
+    })
+    expect(host.innerHTML).toContain('Login required')
+    const warning = [...host.querySelectorAll<HTMLButtonElement>('button')].find((b) =>
+      b.textContent?.includes('Login required')
+    )
+    act(() => warning?.click())
+    const opened = host.innerHTML
+    act(() => root.unmount())
+    host.remove()
+
+    expect(opened).toContain('agentconnect auth --runtime claude-acp')
   })
 
   it('says so when no pool member has registered at all', () => {

--- a/packages/web/src/components/console/views/DaemonDetailView.tsx
+++ b/packages/web/src/components/console/views/DaemonDetailView.tsx
@@ -320,13 +320,25 @@ export default function DaemonDetailView() {
                     <div className={rowCls}>{rowInner}</div>
                   )}
                   {rt.authRequired && (
-                    <div
-                      title="The runtime rejected the daemon's probe with 'authentication required' — sign in to it on the daemon host. The warning clears on the next probe."
-                      className="flex items-center gap-[6px] bg-(--status-paused-soft) px-4 py-[7px] font-sans text-[11.5px] font-medium leading-normal text-(--amber-500)"
+                    <button
+                      type="button"
+                      title="The runtime rejected the daemon's probe with 'authentication required' — show the command that logs it in on the daemon host."
+                      onClick={() =>
+                        openModal('runtimeLogin', {
+                          runtimeId: rt.runtime,
+                          runtimeLabel: runtimeLabel(rt.runtime, meta?.name),
+                          daemonName: daemon.name
+                        })
+                      }
+                      className="flex w-full cursor-pointer items-center gap-[6px] border-0 bg-(--status-paused-soft) px-4 py-[7px] text-left font-sans text-[11.5px] font-medium leading-normal text-(--amber-500) transition-opacity hover:opacity-80"
                     >
                       <Icon name="triangle-alert" size={12} className="flex-none" />
                       <span className="min-w-0 truncate">Login required — sign in on the daemon host</span>
-                    </div>
+                      <span className="ml-auto flex flex-none items-center gap-[3px] underline underline-offset-2">
+                        Show command
+                        <Icon name="chevron-right" size={12} className="flex-none" />
+                      </span>
+                    </button>
                   )}
                   {open && (
                     <div className="flex flex-col gap-3 pt-[2px] pr-4 pb-3 pl-14">
@@ -714,6 +726,7 @@ export default function DaemonDetailView() {
         runtimes={runtimes}
         agents={hosted}
         empty="No runtimes reported — this daemon hasn't advertised its runtime profiles yet."
+        daemonName={daemon.name}
       />
 
       <FleetAgentsCard


### PR DESCRIPTION
A runtime that needs a login is currently a dead end: the daemon probes it, gets
`authentication required` back, and the console shows an amber "Login required — sign in on
the daemon host" strip that says nothing about *how*. There was no command to run either.

This adds both halves.

## `agentconnect auth` (daemon)

`agentconnect auth [--runtime <id>] [--method <id>] [--skip-probe]` — `auth` is not
CLI-owned, so the unified CLI delegates it verbatim to the active daemon with the terminal
attached (`cli-daemon-split.md` §4.2).

Why it is an operator command and not something the daemon does for itself: the credential
lands in the runtime's own state directory on the host — the one `RUNTIME_STATE_LOCATIONS`
seeds sessions FROM — and every login flow a runtime offers wants a human at a terminal (a
browser consent URL, a pasted API key, its own interactive CLI). The login therefore runs
UNSANDBOXED against the operator's own HOME, exactly as if they had run the runtime's CLI by
hand; a private-HOME launch would write the login into a directory thrown away with the
process.

- **Runtime list with real login verdicts.** Every installed runtime is listed at once in a
  fixed order, then annotated as the probe sweep answers (`logged in — 5 model(s), 0.75.1` /
  `not logged in`). Nothing persists this — `authRequired` lives in the daemon process, and
  every on-disk heuristic misreads a runtime that authenticates from an env var — so the
  status is a real probe, run the same way the login will be. A selection made before the
  first verdict is honoured immediately, and choosing aborts the sweep.
- **Both ACP method kinds.** A `terminal` method is completed by the CLIENT re-launching the
  agent program on the operator's terminal, which agents only offer when the client
  advertises `auth.terminal` — so this command does, and a daemon session never does. An
  `agent` method goes through `authenticate`, answering the request-scoped URL/form
  elicitations of the auth phase via a new `onAuthElicit` hook (previously declined, since
  they map to no live turn).
- **Loopback paste fallback.** Google retired the OOB flow in 2023, so a runtime like
  Antigravity binds its OAuth listener to 127.0.0.1 on the daemon host, which a browser on
  another machine cannot reach. The redirect still happens though, so the command offers to
  replay the pasted `?code=…` URL from the host itself. Only loopback http(s) URLs are
  accepted.
- **EOF grace on stop.** Some runtimes (Antigravity's ACP server) dump a stack trace on
  SIGTERM, which reads like a crash right after a login that in fact succeeded. `stop()` now
  gives the child a window to exit on stdin EOF before signalling.

## The console hands the command over (web)

The amber warning on a runtime row is now a button that opens a dialog with the exact
command (`agentconnect auth --runtime <id>`, with copy), why it belongs on that host, what it
will ask, the npx / `--instance` variants, and the fact that sessions pick the credential up
on their next start with no daemon restart.

Both runtime lists carry it: the daemon detail view's own rows (mobile) and the shared
`FleetRuntimesCard` (desktop daemon detail, cluster, group). The card takes an optional
`daemonName`, so one machine's dialog names its host while a cluster/group — which aggregates
hosts — stays generic. `RuntimeSelect`'s per-option warning is deliberately untouched: that
row is a `button role="option"` meaning "pick this runtime", and nesting a button inside it
is invalid markup with confused keyboard semantics.

## Verification

- `pnpm -r typecheck` clean; eslint clean (pre-push hook ran it).
- daemon: new `auth-cli` (17) and `auth-picker` (13) suites, plus `spawn-driver` (11),
  `runtime-prober`, `render`, `daemon-transcript` — 267 tests green.
- web: full suite green (214 files / 2401 tests), including a new `ClusterDetailView` case
  that clicks the warning and asserts the command lands in the dialog.
- **Ran for real on this host.** `auth --runtime antigravity-acp` handshakes and lists its
  four Google/Gemini login methods; the bare list sweeps 14 installed runtimes and annotates
  each with its live verdict, redrawing in place on a real pty.

## Follow-up (not in this PR)

The sweep's status line reports a *probe failure* (`ACP connection closed`, a timeout, a
binary that won't start) as `not logged in — <error>`, which claims more than the probe
established. That wants its own split into a `check failed` state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
