### PR TITLE
fix(daemon): tell the channel when an agent's question cannot be rendered there

### DIFF
--- a/packages/daemon/src/daemon/turn-types.ts
+++ b/packages/daemon/src/daemon/turn-types.ts
@@ -613,6 +613,9 @@ export interface Pending {
    * transcript once (webchat has no Slack post boundary where text is otherwise saved).
    */
   webchat?: WebchatTurnContext & { index: number; replyText: string; heldText: string; messageEmitted: boolean }
+  /** Agent questions this turn has already told the channel it could not render (#1794), so a
+   *  runtime re-raising the same unrenderable ask posts one notice rather than one per attempt. */
+  declinedElicitNotices?: Set<string>
 }
 
 /** Visible Slack thread messages that establish a new chronological boundary. Any live

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -50,6 +50,7 @@ import type { ElicitKind, ElicitSurface, ElicitTarget } from '../slack/render.js
 import { slackThreadUrl } from '../platforms/slack/permalink.js'
 import { slackAgentIdentityOptions } from '../platforms/slack/turn-output.js'
 import { turnChromeFor } from '../platforms/turn-chrome.js'
+import { buildElicitDeclinedNotice } from './elicit-notice.js'
 import { formatErr } from '../daemon/text.js'
 import {
   approvalRequestSummary,
@@ -1386,14 +1387,15 @@ export class PermissionCoordinator {
         ? await this.awaitWebchatUrlElicitation(agentId, sessionId, params, p, p.webchat, url)
         : await this.awaitWebchatElicitation(agentId, sessionId, params, p, p.webchat)
     }
-    if (params.mode === 'url') return undefined
+    if (params.mode === 'url') return this.noticeUnrenderableElicit(p, params, isApproval)
     const conn = p.conn
-    if (!turnChromeFor(p.plan.platform).chatInputCards || !(conn instanceof SlackConnection)) return undefined
+    if (!turnChromeFor(p.plan.platform).chatInputCards || !(conn instanceof SlackConnection))
+      return this.noticeUnrenderableElicit(p, params, isApproval)
     const target = elicitTarget(params, SLACK_ELICIT_SURFACE)
-    if (!target) return undefined
+    if (!target) return this.noticeUnrenderableElicit(p, params, isApproval)
     const requestId = isApproval ? randomUUID() : `elicit-${++this.elicitSeq}`
     const blocks = buildElicitationCard(requestId, params, this.host.httpSlackSessionTarget(p))
-    if (!blocks) return undefined
+    if (!blocks) return this.noticeUnrenderableElicit(p, params, isApproval)
     const fallback = (params as { message?: string }).message ?? 'The agent needs your input'
     let resolveResult!: (res: CreateElicitationResponse) => void
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
@@ -1461,6 +1463,36 @@ export class PermissionCoordinator {
     }
     if (live.surface === 'slack') live.ts = ts
     return isApproval ? await this.trackHumanApprovalWait(p, result) : await result
+  }
+
+  /** Say in the channel that an elicitation was declined for want of a surface that can render it.
+   *  Every caller is past the webchat branches, so this only ever speaks on a chat platform whose
+   *  card the reader would otherwise have never seen. An MCP approval is excluded: it took the
+   *  editor queue with its own notice. Returns `undefined` so a decline site stays one line.
+   *  ONE notice per distinct question — a runtime re-raising the same unrenderable ask floods
+   *  nothing, and a genuinely different question is a second thing the reader has not been told.
+   *  Best effort: the decline never depends on the notice landing. */
+  private noticeUnrenderableElicit(p: Pending, params: CreateElicitationRequest, isApproval: boolean): undefined {
+    if (isApproval || !p.conn) return undefined
+    const key = (params as { message?: string }).message?.trim() ?? ''
+    const seen = (p.declinedElicitNotices ??= new Set<string>())
+    if (seen.has(key)) return undefined
+    seen.add(key)
+    let sessionUrl: string | undefined
+    // A console link this daemon cannot compute must not cost the reader the question itself.
+    try {
+      sessionUrl = this.host.sessionLink(p.outwardSessionId)
+    } catch {
+      sessionUrl = undefined
+    }
+    try {
+      // Built from the MASKED params `onAcpElicit` reassigned at its top, never an earlier capture.
+      const text = buildElicitDeclinedNotice(params, turnChromeFor(p.plan.platform).noticeMarkup, sessionUrl)
+      this.host.enqueueApply(p, { kind: 'notice', text })
+    } catch (err) {
+      this.host.log().warn(`elicitation decline notice failed for "${p.plan.sessionKey}": ${formatErr(err)}`)
+    }
+    return undefined
   }
 
   /** Webchat's peer of the Slack elicitation card: stream the card as an in-band event and

--- a/packages/daemon/src/permissions/elicit-notice.ts
+++ b/packages/daemon/src/permissions/elicit-notice.ts
@@ -14,16 +14,11 @@ const NOTICE_QUESTION_CAP = 900
 
 /** Defuse agent-authored text bound for a plain notice. A question may not send the reader
  *  anywhere — the spec keeps URLs on URL-mode elicitations, whose consent card is the only place
- *  one is ever followable — so each surface's own link syntax is neutralised the way that surface
- *  reads it: Slack's `<url|label>` and autolink, Discord's `[label](url)` and autolink. A surface
- *  declaring no markup shows the text verbatim and has no label syntax to spoof with. Pure. */
+ *  one is ever followable — so the surface's link syntax is neutralised the way it reads it.
+ *  Escaping the brackets is what kills `[label](url)`, and it is the LABEL that matters: a bare
+ *  URL left autolinking still shows the reader the destination they are going to, whereas a
+ *  label can say anything. A surface declaring no markup shows the text verbatim. Pure. */
 export function defuseNoticeText(raw: string, markup?: NoticeMarkup): string {
-  if (markup === 'slack-mrkdwn')
-    return raw
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(BARE_URL_RE, (m) => `\`${m}\``)
   if (markup === 'markdown') return raw.replace(/[[\]]/g, (c) => `\\${c}`).replace(BARE_URL_RE, (m) => `\`${m}\``)
   return raw
 }

--- a/packages/daemon/src/permissions/elicit-notice.ts
+++ b/packages/daemon/src/permissions/elicit-notice.ts
@@ -17,9 +17,11 @@ const NOTICE_QUESTION_CAP = 900
  *  one is ever followable — so the surface's link syntax is neutralised the way it reads it.
  *  Escaping the brackets is what kills `[label](url)`, and it is the LABEL that matters: a bare
  *  URL left autolinking still shows the reader the destination they are going to, whereas a
- *  label can say anything. A surface declaring no markup shows the text verbatim. Pure. */
+ *  label can say anything. Backslashes are escaped in the SAME pass, or an already-escaped
+ *  `\\[label\\]` would come back to life: the parser eats our added pair as one literal
+ *  backslash and hands the bracket back. A surface declaring no markup shows it verbatim. Pure. */
 export function defuseNoticeText(raw: string, markup?: NoticeMarkup): string {
-  if (markup === 'markdown') return raw.replace(/[[\]]/g, (c) => `\\${c}`).replace(BARE_URL_RE, (m) => `\`${m}\``)
+  if (markup === 'markdown') return raw.replace(/[\\[\]]/g, (c) => `\\${c}`).replace(BARE_URL_RE, (m) => `\`${m}\``)
   return raw
 }
 

--- a/packages/daemon/src/permissions/elicit-notice.ts
+++ b/packages/daemon/src/permissions/elicit-notice.ts
@@ -1,0 +1,49 @@
+// The in-channel notice for an elicitation declined because this turn's surface cannot render it.
+// Without it the agent asks the reader a question and the reader never learns it was asked (#1794).
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import type { NoticeMarkup } from '../platforms/turn-chrome.js'
+import { clampTo } from '../slack/render.js'
+
+// Stops at whitespace and at the bracketing a link syntax uses, so a defused URL keeps its own
+// punctuation out of the code span it lands in.
+const BARE_URL_RE = /(?:https?:\/\/|www\.)[^\s<>()[\]]+/gi
+
+/** How much of the agent's question the notice quotes. Every transport here takes far more; this
+ *  only stops one runaway `message` from filling the channel. */
+const NOTICE_QUESTION_CAP = 900
+
+/** Defuse agent-authored text bound for a plain notice. A question may not send the reader
+ *  anywhere — the spec keeps URLs on URL-mode elicitations, whose consent card is the only place
+ *  one is ever followable — so each surface's own link syntax is neutralised the way that surface
+ *  reads it: Slack's `<url|label>` and autolink, Discord's `[label](url)` and autolink. A surface
+ *  declaring no markup shows the text verbatim and has no label syntax to spoof with. Pure. */
+export function defuseNoticeText(raw: string, markup?: NoticeMarkup): string {
+  if (markup === 'slack-mrkdwn')
+    return raw
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(BARE_URL_RE, (m) => `\`${m}\``)
+  if (markup === 'markdown') return raw.replace(/[[\]]/g, (c) => `\\${c}`).replace(BARE_URL_RE, (m) => `\`${m}\``)
+  return raw
+}
+
+/** The agent's question as the notice quotes it — already `maskAgentSecrets`-masked by the caller,
+ *  clamped here, then defused so the clamp cannot cut a defusing apart. Pure. */
+export function elicitNoticeQuestion(params: CreateElicitationRequest, markup?: NoticeMarkup): string {
+  const raw = (params as { message?: string }).message?.trim() || 'The agent needs your input'
+  return defuseNoticeText(clampTo(raw, NOTICE_QUESTION_CAP), markup)
+}
+
+/** The whole notice: that something was asked, what it was, that this chat cannot collect the
+ *  answer, and where it can be answered. It names nothing from the schema — the reader did not
+ *  write the schema, and "multi-enum" tells them nothing they can act on. Pure. */
+export function buildElicitDeclinedNotice(
+  params: CreateElicitationRequest,
+  markup?: NoticeMarkup,
+  sessionUrl?: string
+): string {
+  const tail = sessionUrl ? `\nYou can answer it in the session console: ${sessionUrl}` : ''
+  const head = "💬 The agent asked something this chat can't collect an answer for, so it was declined:"
+  return `${head}\n${elicitNoticeQuestion(params, markup)}${tail}`
+}

--- a/packages/daemon/src/platforms/turn-chrome.ts
+++ b/packages/daemon/src/platforms/turn-chrome.ts
@@ -47,9 +47,11 @@ export interface TurnChrome {
   readonly noticeMarkup?: NoticeMarkup
 }
 
-/** The markup dialects a notice's text is read as. `slack-mrkdwn` autolinks bare URLs and honours
- *  `<url|label>`; `markdown` autolinks and honours `[label](url)`. */
-export type NoticeMarkup = 'slack-mrkdwn' | 'markdown'
+/** The markup dialects a NOTICE's text is read as — `markdown` autolinks and honours
+ *  `[label](url)`. Slack's notice is one of these: `postMessage` sends a `type: 'markdown'`
+ *  block, NOT the `mrkdwn` section its elicitation CARD uses, which is defused separately in
+ *  `elicitCardMessage`. Getting those two confused leaves the label syntax live. */
+export type NoticeMarkup = 'markdown'
 
 const CHROME = new Map<string, TurnChrome>([
   [
@@ -60,7 +62,7 @@ const CHROME = new Map<string, TurnChrome>([
       sessionTitle: true,
       chatInputCards: true,
       chromeMarkedNotices: true,
-      noticeMarkup: 'slack-mrkdwn'
+      noticeMarkup: 'markdown'
     }
   ],
   // The three on-demand platforms declare so EXPLICITLY: their status emit path

--- a/packages/daemon/src/platforms/turn-chrome.ts
+++ b/packages/daemon/src/platforms/turn-chrome.ts
@@ -41,7 +41,15 @@ export interface TurnChrome {
   /** Failure notices are posted with a chrome marker (and agent identity) so a
    *  peer daemon's thread backfill skips them. */
   readonly chromeMarkedNotices?: boolean
+  /** How the surface PARSES a plain notice's text, so agent-authored text quoted in one can be
+   *  defused before the surface turns it into a tappable link. Absent ⇒ no markup at all: the
+   *  text is shown verbatim and there is no label syntax to spoof a destination with. */
+  readonly noticeMarkup?: NoticeMarkup
 }
+
+/** The markup dialects a notice's text is read as. `slack-mrkdwn` autolinks bare URLs and honours
+ *  `<url|label>`; `markdown` autolinks and honours `[label](url)`. */
+export type NoticeMarkup = 'slack-mrkdwn' | 'markdown'
 
 const CHROME = new Map<string, TurnChrome>([
   [
@@ -51,14 +59,15 @@ const CHROME = new Map<string, TurnChrome>([
       attributionFooter: true,
       sessionTitle: true,
       chatInputCards: true,
-      chromeMarkedNotices: true
+      chromeMarkedNotices: true,
+      noticeMarkup: 'slack-mrkdwn'
     }
   ],
   // The three on-demand platforms declare so EXPLICITLY: their status emit path
   // records the dedup key and posts nothing, which is different from having no
   // declaration at all (the legacy default arm).
   ['telegram', { statusSurface: 'on-demand' }],
-  ['discord', { statusSurface: 'on-demand' }],
+  ['discord', { statusSurface: 'on-demand', noticeMarkup: 'markdown' }],
   ['feishu', { statusSurface: 'on-demand' }]
 ])
 

--- a/packages/daemon/test/elicit-decline-notice.test.ts
+++ b/packages/daemon/test/elicit-decline-notice.test.ts
@@ -103,18 +103,19 @@ describe('an elicitation declined for want of a surface says so in the channel',
     expect(notices()[0]).toContain('/sessions/sess-1')
   })
 
-  it('carries the agent’s question DEFUSED — a Slack notice is mrkdwn, and links in it are taps', async () => {
+  // A Slack NOTICE is a `type: 'markdown'` block (postMessage → markdownBlock), NOT the `mrkdwn`
+  // section an elicitation CARD uses — so the syntax to kill here is `[label](url)`, not `<url|label>`.
+  it('carries the agent’s question DEFUSED — a Slack notice is markdown, and links in it are taps', async () => {
     const { daemon, notices } = slackTurn()
     await daemon.permissions.onAcpElicit(
       'agent-1',
       's1',
-      multiElicitation({ message: 'Sign in at <https://evil.example/x|your account> or https://evil.example/y' })
+      multiElicitation({ message: 'Sign in at [your account](https://evil.example/x) or https://evil.example/y' })
     )
     const text = notices()[0]!
-    // The angle-bracket label form cannot survive as markup, and the bare URL cannot autolink.
-    expect(text).not.toContain('<https://')
-    expect(text).toContain('&lt;')
-    expect(text).toContain('&gt;')
+    // The label form cannot survive as markup, and the bare URL cannot autolink.
+    expect(text).not.toContain('[your account](')
+    expect(text).toContain('\\[your account\\]')
     expect(text).toContain('`https://evil.example/y`')
   })
 
@@ -198,6 +199,12 @@ describe('an elicitation declined for want of a surface says so in the channel',
 
 describe('a notice defuses agent text the way its own surface reads it', () => {
   it('neutralises Discord’s masked-link syntax and its autolink', () => {
+    // A backslash-escaped scheme slips past a bare-URL scan while the parser still reads the
+    // destination, so the LABEL is what has to die — escaping the brackets is what does it.
+    const escaped = defuseNoticeText('Sign in at [your account](https\\://evil.example/login)', 'markdown')
+    expect(escaped).not.toContain('[your account](')
+    expect(escaped).toContain('\\[your account\\]')
+
     const out = defuseNoticeText('See [your account](https://evil.example/x) or https://evil.example/y', 'markdown')
     expect(out).toBe('See \\[your account\\](`https://evil.example/x`) or `https://evil.example/y`')
   })

--- a/packages/daemon/test/elicit-decline-notice.test.ts
+++ b/packages/daemon/test/elicit-decline-notice.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import { Daemon } from '../src/daemon.js'
+import { TerminalOutputFolder } from '../src/session/terminal-output-folder.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { SlackConnection } from '../src/slack/connection.js'
+import { defuseNoticeText } from '../src/permissions/elicit-notice.js'
+
+/**
+ * An elicitation this turn's surface cannot render used to be declined in SILENCE (#1794): the
+ * agent asked the reader a question and, from the channel, it was indistinguishable from the
+ * agent ignoring them. The decline stands — nothing here answers on the reader's behalf — but
+ * the channel now hears what was asked and where it can be answered.
+ */
+
+/** A plain single-enum form — renderable everywhere. */
+function formElicitation(overrides: Record<string, unknown> = {}): CreateElicitationRequest {
+  return {
+    sessionId: 's1',
+    mode: 'form',
+    message: 'Which branch should I cut from?',
+    requestedSchema: {
+      type: 'object',
+      properties: { branch: { type: 'string', enum: ['main', 'develop', 'release'] } },
+      required: ['branch']
+    },
+    ...overrides
+  } as CreateElicitationRequest
+}
+
+/** A multi-select: renderable on webchat, never on a Slack button row. */
+function multiElicitation(overrides: Record<string, unknown> = {}): CreateElicitationRequest {
+  return formElicitation({
+    message: 'Which checks should I run?',
+    requestedSchema: {
+      type: 'object',
+      properties: { checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] } } },
+      required: ['checks']
+    },
+    ...overrides
+  })
+}
+
+function installPending(daemon: Daemon): any {
+  ;(daemon as any).store = {
+    getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
+    getDisplayNames: () => new Map(),
+    createPermissionRequest: vi.fn(),
+    resolvePermissionRequest: vi.fn(() => true)
+  }
+  const pending = {
+    plan: {
+      platform: 'hook',
+      agentId: 'agent-1',
+      sessionKey: 'k1',
+      channel: 'test',
+      statusThread: 'test',
+      approvalSurfaceSuppressed: false
+    },
+    hostKey: 'agent-1',
+    outwardSessionId: 'sess-1',
+    chrome: {},
+    reply: { text: '', attemptText: '', attemptAnswerUpdates: [] },
+    signals: { applyChain: Promise.resolve() },
+    approval: { waitMs: 0, depth: 0 },
+    builtinSystemToolCallIds: new Set<string>(),
+    conv: { onUpdate: () => [], hasBuffered: () => false },
+    rec: { onUpdate: () => [] },
+    termOut: new TerminalOutputFolder()
+  }
+  ;(daemon as any).pending.set(JSON.stringify(['agent-1', 's1']), pending)
+  return pending
+}
+
+/** A daemon whose turn is a Slack turn, with every enqueued render action captured. */
+function slackTurn(): { daemon: any; pending: any; notices: () => string[] } {
+  const daemon: any = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+  const pending = installPending(daemon)
+  pending.plan.platform = 'slack'
+  const conn = Object.create(SlackConnection.prototype)
+  conn.postBlocks = async () => 'ts-1'
+  conn.updateBlocks = async () => true
+  conn.workspaceId = () => 'T1'
+  pending.conn = conn
+  daemon.cfg = { ...(daemon.cfg ?? {}), webAppUrl: 'https://console.example' }
+  const applied: any[] = []
+  daemon.enqueueApply = (_p: any, action: any) => void applied.push(action)
+  return {
+    daemon,
+    pending,
+    notices: () => applied.filter((a) => a.kind === 'notice').map((a) => a.text as string)
+  }
+}
+
+describe('an elicitation declined for want of a surface says so in the channel', () => {
+  it('posts the notice and still declines when a Slack card cannot express the form', async () => {
+    const { daemon, notices } = slackTurn()
+    await expect(daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())).resolves.toBeUndefined()
+    expect(daemon.permissions.pendingElicits.size).toBe(0)
+    expect(notices()).toHaveLength(1)
+    expect(notices()[0]).toContain("this chat can't collect an answer for")
+    expect(notices()[0]).toContain('Which checks should I run?')
+    expect(notices()[0]).toContain('/sessions/sess-1')
+  })
+
+  it('carries the agent’s question DEFUSED — a Slack notice is mrkdwn, and links in it are taps', async () => {
+    const { daemon, notices } = slackTurn()
+    await daemon.permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      multiElicitation({ message: 'Sign in at <https://evil.example/x|your account> or https://evil.example/y' })
+    )
+    const text = notices()[0]!
+    // The angle-bracket label form cannot survive as markup, and the bare URL cannot autolink.
+    expect(text).not.toContain('<https://')
+    expect(text).toContain('&lt;')
+    expect(text).toContain('&gt;')
+    expect(text).toContain('`https://evil.example/y`')
+  })
+
+  it('quotes the MASKED question, not the raw one the runtime sent', async () => {
+    const { daemon, notices } = slackTurn()
+    daemon.maskAgentSecrets = (_id: string, params: any) => ({
+      ...params,
+      message: params.message.replace('hunter2', '••••')
+    })
+    await daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation({ message: 'Is hunter2 still the token?' }))
+    expect(notices()[0]).toContain('Is •••• still the token?')
+    expect(notices()[0]).not.toContain('hunter2')
+  })
+
+  it('collapses a repeated question to one notice, and lets a different question through', async () => {
+    const { daemon, notices } = slackTurn()
+    await daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())
+    await daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())
+    expect(notices()).toHaveLength(1)
+    await daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation({ message: 'And which runner?' }))
+    expect(notices()).toHaveLength(2)
+    expect(notices()[1]).toContain('And which runner?')
+  })
+
+  it('says nothing when the card WAS rendered', async () => {
+    const { daemon, notices } = slackTurn()
+    void daemon.permissions.onAcpElicit('agent-1', 's1', formElicitation())
+    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
+    expect(notices()).toEqual([])
+    await daemon.permissions.releaseElicits('agent-1', 's1')
+  })
+
+  it('says nothing on a webchat turn, which renders every shape itself', async () => {
+    const { daemon, pending, notices } = slackTurn()
+    pending.plan.platform = 'webchat'
+    pending.webchat = {
+      conversationId: 'conv-1',
+      turnId: 'turn-1',
+      sink: { output: vi.fn(), done: vi.fn() },
+      index: 0,
+      replyText: '',
+      heldText: '',
+      messageEmitted: false
+    }
+    void daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())
+    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
+    expect(notices()).toEqual([])
+    await daemon.permissions.releaseElicits('agent-1', 's1')
+  })
+
+  it('says nothing for an MCP approval, which has its own notice on the editor path', async () => {
+    const { daemon, notices } = slackTurn()
+    // Chat approval enabled, so the request reaches the card path rather than the editor queue.
+    daemon.agents.set('agent-1', { allowRuntimeChangesInChat: true })
+    await expect(
+      daemon.permissions.onAcpElicit(
+        'agent-1',
+        's1',
+        multiElicitation({ _meta: { codex_approval_kind: 'mcp_tool_call' } })
+      )
+    ).resolves.toBeUndefined()
+    expect(notices()).toEqual([])
+  })
+
+  it('says nothing on a turn whose surface was deliberately suppressed', async () => {
+    const suppressed = slackTurn()
+    suppressed.pending.plan.approvalSurfaceSuppressed = true
+    await expect(suppressed.daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())).resolves.toEqual({
+      action: 'cancel'
+    })
+    expect(suppressed.notices()).toEqual([])
+
+    const quiet = slackTurn()
+    quiet.pending.outputSuppressed = 'paused'
+    await expect(quiet.daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())).resolves.toEqual({
+      action: 'cancel'
+    })
+    expect(quiet.notices()).toEqual([])
+  })
+})
+
+describe('a notice defuses agent text the way its own surface reads it', () => {
+  it('neutralises Discord’s masked-link syntax and its autolink', () => {
+    const out = defuseNoticeText('See [your account](https://evil.example/x) or https://evil.example/y', 'markdown')
+    expect(out).toBe('See \\[your account\\](`https://evil.example/x`) or `https://evil.example/y`')
+  })
+
+  it('leaves a markup-less surface’s text verbatim — it has no label syntax to spoof with', () => {
+    const raw = 'See <https://evil.example/x|your account> & [label](https://evil.example/y)'
+    expect(defuseNoticeText(raw, undefined)).toBe(raw)
+  })
+})

--- a/packages/daemon/test/elicit-decline-notice.test.ts
+++ b/packages/daemon/test/elicit-decline-notice.test.ts
@@ -199,6 +199,14 @@ describe('an elicitation declined for want of a surface says so in the channel',
 
 describe('a notice defuses agent text the way its own surface reads it', () => {
   it('neutralises Discord’s masked-link syntax and its autolink', () => {
+    // Escaping only the brackets can CREATE the link it means to kill: the parser eats our
+    // added pair as one literal backslash and hands an already-escaped bracket back, live.
+    const preEscaped = defuseNoticeText(
+      String.raw`Sign in at \[your account\](https\://evil.example/login)`,
+      'markdown'
+    )
+    expect(preEscaped).toBe(String.raw`Sign in at \\\[your account\\\](https\\://evil.example/login)`)
+
     // A backslash-escaped scheme slips past a bare-URL scan while the parser still reads the
     // destination, so the LABEL is what has to die — escaping the brackets is what does it.
     const escaped = defuseNoticeText('Sign in at [your account](https\\://evil.example/login)', 'markdown')

--- a/packages/daemon/test/turn-chrome.test.ts
+++ b/packages/daemon/test/turn-chrome.test.ts
@@ -8,8 +8,17 @@ describe('turn chrome facet', () => {
       attributionFooter: true,
       sessionTitle: true,
       chatInputCards: true,
-      chromeMarkedNotices: true
+      chromeMarkedNotices: true,
+      noticeMarkup: 'slack-mrkdwn'
     })
+  })
+
+  it('declares how each surface PARSES a notice, so agent text in one can be defused', () => {
+    // A notice is plain text, and a surface that reads markup in it turns an agent's link into a
+    // tap — Slack's `<url|label>`, Discord's `[label](url)`. Telegram and Feishu read neither.
+    expect(turnChromeFor('discord').noticeMarkup).toBe('markdown')
+    expect(turnChromeFor('telegram').noticeMarkup).toBeUndefined()
+    expect(turnChromeFor('feishu').noticeMarkup).toBeUndefined()
   })
 
   it('declares the on-demand status platforms EXPLICITLY', () => {

--- a/packages/daemon/test/turn-chrome.test.ts
+++ b/packages/daemon/test/turn-chrome.test.ts
@@ -9,7 +9,7 @@ describe('turn chrome facet', () => {
       sessionTitle: true,
       chatInputCards: true,
       chromeMarkedNotices: true,
-      noticeMarkup: 'slack-mrkdwn'
+      noticeMarkup: 'markdown'
     })
   })
 


### PR DESCRIPTION
Implements the Slack-column item on #1794: *say something in-channel when a form cannot be rendered, instead of declining in silence.*

## The problem

When an elicitation could not be rendered, `onAcpElicit` returned `undefined`, `AcpHost` answered `decline`, and **nothing appeared in the conversation at all**. The agent asked the reader a question and the reader never learned it had been asked — from the channel it is indistinguishable from the agent ignoring them.

This is what made every other gap worse. A multi-field form, a pattern we refuse to run, a required field with no control, an option list past the surface's cap: all of them vanished without trace.

## Not Slack-only

A notice is text, not a card, so Telegram, Discord and Feishu were silent in exactly the same way and can all carry one. All four are covered.

The notice reads:

```
💬 The agent asked something this chat can't collect an answer for, so it was declined:
   <the agent's question>
   You can answer it in the session console: <link>
```

No schema vocabulary — the reader did not write the schema, so `requestedSchema` / `minLength` / `multi-enum` appear nowhere. If the console link cannot be computed the line is dropped and the question still goes out; a link we cannot build must not cost the reader the question.

## The quoted question is agent-authored, so it is defused per surface

#1810 fixed a live phishing shape: agent text in a Slack `mrkdwn` block could render a tappable link with attacker-chosen wording. Quoting the question in a notice would have reintroduced exactly that, so it goes through the same defusing — but the defusing is **not** one dialect:

| Surface | Reads markup? |
| --- | --- |
| Slack | yes — autolinks bare URLs, honours `<url\|label>` |
| Discord | yes — honours `[label](url)`; the repo already relies on this, `discord/render.ts:535` emits `[details](…)` inside a notice |
| Telegram | no `parse_mode` is set, so no label syntax to spoof with |
| Feishu | plain text |

`elicitCardMessage`'s escaping is Slack-specific (HTML entities), so pasting it into a Telegram notice would print literal `&amp;`, and doing nothing on Discord leaves `[label](evil)` live. CLAUDE.md forbids core reading a platform name, so the fact is declared where the other post-dispatch surface facts live:

```ts
noticeMarkup?: 'slack-mrkdwn' | 'markdown'   // absent ⇒ verbatim, no markup
```

Three implementers on arrival (Slack, Discord, and the absent arm), so the member is not an interface guessed from a single caller. Core reads the flag.

The notice is built from the `maskAgentSecrets`-masked params, and goes out through the existing notice path so the chrome marking that makes a peer daemon's backfill skip it applies here too.

## One notice per distinct question per turn

Not one per elicitation, and not one per turn. The flood risk is a runtime re-raising the *same* unrenderable ask in a retry loop, and deduping on the question text removes exactly that. But a turn that asks three genuinely different unanswerable questions has three things the reader has not been told, and staying silent about two of them is the bug being fixed. The set lives on `Pending`, so it is scoped to the turn and freed with it.

## Not covered, and the plan was wrong about why

The original plan said webchat needed nothing because it renders every shape. **That is not true.** `awaitWebchatElicitation` also returns `undefined` — declining with nothing shown — when `elicitForm` is null (a `required` property no control can answer) and when the sink throws. Webchat is silent in the same way; its fix is a stream event rather than a notice, and it is now tracked on #1794 rather than left implicit.

A webchat *continuation* does get a notice: it falls through to the platform path and its origin thread was silent, which is the case this fixes.

## Verification

- protocol 488, relay 644, web 2400 — all green.
- `pnpm typecheck`: `error TS` count 0.
- eslint + prettier clean on the six changed files.

**The full daemon suite was not observed green, and this PR does not claim it was.** This host's root filesystem is full (~120 MB free) and the suite fails wholesale with `SQLITE_FULL: database or disk is full`. Running it under a tmpfs `TMPDIR` got it to 10 failing files, of which one was **real and mine** — `turn-chrome.test.ts` asserts Slack's chrome set exhaustively and the new `noticeMarkup` broke it. That is fixed here, and it is precisely the failure a hand-picked subset would have missed. The rest were the documented pre-existing `evaluation-runner` case, `acp-matrix` dialling live runtimes (`402 Insufficient Balance`), and files whose failing test names changed run to run under disk pressure.

Run alone and green: `elicit-decline-notice` (10), `turn-chrome` (4), `daemon-permission-autoallow`, `approval-dm`, `daemon-commands` — 204 passing together on re-verification.

Every new test was confirmed red with only the source reverted: the notice not posted, the question not defused, the raw rather than masked question quoted, and the repeat not collapsed.
