### PR TITLE
fix(console): the runtime login modal hands over an npx-prefixed command

### DIFF
--- a/packages/web/src/components/console/modals/RuntimeLoginModal.tsx
+++ b/packages/web/src/components/console/modals/RuntimeLoginModal.tsx
@@ -15,7 +15,7 @@ export interface RuntimeLoginTarget {
 /** The login command for one runtime, run on the daemon's own host. `auth` is not CLI-owned, so
  *  the unified CLI delegates it verbatim to the active daemon with the terminal attached. */
 export function runtimeLoginCommand(runtimeId: string): string {
-  return `agentconnect auth --runtime ${runtimeId}`
+  return `npx -y @agentconnect.md/cli auth --runtime ${runtimeId}`
 }
 
 /**
@@ -92,15 +92,6 @@ export default function RuntimeLoginModal({ target, onClose }: { target: Runtime
           <li>
             It lists the login methods <span className="mono text-(--text-secondary)">{target.runtimeId}</span> offers
             and walks the chosen one — a browser URL, an API key, or the runtime&apos;s own interactive CLI.
-          </li>
-          <li>
-            Drop <span className="mono text-(--text-secondary)">--runtime</span> to pick from every runtime installed
-            there, each row annotated with whether it is already logged in.
-          </li>
-          <li>
-            No <span className="mono text-(--text-secondary)">agentconnect</span> on that host&apos;s PATH? Prefix it
-            with <span className="mono text-(--text-secondary)">npx -y @agentconnect.md/cli</span>. A named service
-            instance also takes <span className="mono text-(--text-secondary)">--instance &lt;name&gt;</span>.
           </li>
           <li>
             Sessions pick the credential up on their next start — the daemon needs no restart, and this warning clears

--- a/packages/web/src/components/console/views/ClusterDetailView.test.tsx
+++ b/packages/web/src/components/console/views/ClusterDetailView.test.tsx
@@ -327,7 +327,7 @@ describe('ClusterDetailView', () => {
     act(() => root.unmount())
     host.remove()
 
-    expect(opened).toContain('agentconnect auth --runtime claude-acp')
+    expect(opened).toContain('npx -y @agentconnect.md/cli auth --runtime claude-acp')
   })
 
   it('says so when no pool member has registered at all', () => {


### PR DESCRIPTION
## What

The runtime "Login required" modal handed over `agentconnect auth --runtime <id>`, then spent
one of its four bullets explaining how to run it when `agentconnect` is not on that host's
PATH (`npx -y @agentconnect.md/cli`), plus `--runtime`/`--instance` flag trivia.

Put the npx prefix in the command itself — it is correct whether or not the CLI is on PATH —
and drop the two bullets that were working around its absence. The modal now shows the
command and two lines: what it does, and when sessions pick the credential up.

## Verified

- `pnpm --filter @agentconnect.md/web test src/components/console/views/ClusterDetailView.test.tsx` — 23 passed (the assertion on the handed-over command moved with it)
- `pnpm --filter @agentconnect.md/web typecheck` — clean
