### PR TITLE
feat(daemon): a URL elicitation posts a consent card on Slack

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -31,6 +31,8 @@ import {
   buildElicitationResolvedCard,
   buildPermissionCard,
   buildPermissionResolvedCard,
+  buildUrlConsentCard,
+  buildUrlConsentResolvedCard,
   clampTo,
   elicitFieldLabel,
   elicitForm,
@@ -213,6 +215,15 @@ function elicitCardDescriptors(t: ElicitTarget): ElicitCardDescriptors {
 /** How many consented URL elicitations wait for an `elicitation/complete` that may never come. */
 const CONSENTED_URL_ELICIT_CAP = 64
 
+/** How a settled Slack consent card labels each outcome. "Opened" is deliberately not "Done":
+ *  consent is all the tap proves, and only the agent's own `elicitation/complete` says more. */
+const URL_CONSENT_DECISION = {
+  accepted: ':white_check_mark: Opened',
+  dismissed: ':no_entry_sign: Dismissed',
+  cancelled: ':hourglass: Cancelled',
+  completed: ':white_check_mark: Completed'
+} as const
+
 /** `elicitation/complete` carries no session, so a consented card is keyed by its ACP id within
  *  the agent host that raised it — two agents may hold the same id concurrently. */
 function consentedUrlKey(owner: HostKey, elicitationId: string): string {
@@ -335,12 +346,9 @@ export class PermissionCoordinator {
   private pendingElicits = new Map<string, PendingElicit>()
   /** URL-mode cards already consented to, keyed by `<owner>\x00<elicitationId>` and awaiting
    *  an `elicitation/complete` that may never come — their ACP request resolved at consent, so
-   *  these hold only the webchat coordinates the "Completed" re-label is emitted on. Bounded:
+   *  these hold only the surface coordinates the "Completed" re-label is said on. Bounded:
    *  an agent that never completes its flows must not grow this without limit. */
-  private readonly consentedUrlElicits = new Map<
-    string,
-    { requestId: string; rec: Extract<PendingElicit, { surface: 'webchat' }> }
-  >()
+  private readonly consentedUrlElicits = new Map<string, { requestId: string; rec: PendingElicit }>()
 
   /** Sessions the CP currently believes are waiting, keyed by `pendingTurnKey` — emit only on a change. */
   private readonly awaitingApproval = new Map<string, { owner: HostKey; agentId: string; sessionId: string }>()
@@ -1393,10 +1401,12 @@ export class PermissionCoordinator {
         ? await this.awaitWebchatUrlElicitation(agentId, sessionId, params, p, p.webchat, url)
         : await this.awaitWebchatElicitation(agentId, sessionId, params, p, p.webchat)
     }
-    if (params.mode === 'url') return this.noticeUnrenderableElicit(p, params, isApproval)
     const conn = p.conn
     if (!turnChromeFor(p.plan.platform).chatInputCards || !(conn instanceof SlackConnection))
       return this.noticeUnrenderableElicit(p, params, isApproval)
+    // A second SURFACE for #1810's URL mode: the notice is only for an ask Slack still cannot render.
+    if (url) return await this.awaitSlackUrlElicitation(agentId, sessionId, params, p, conn, url)
+    if (params.mode === 'url') return this.noticeUnrenderableElicit(p, params, isApproval)
     const target = elicitTarget(params, SLACK_ELICIT_SURFACE)
     if (!target) return this.noticeUnrenderableElicit(p, params, isApproval)
     const requestId = isApproval ? randomUUID() : `elicit-${++this.elicitSeq}`
@@ -1624,6 +1634,80 @@ export class PermissionCoordinator {
     return await result
   }
 
+  /** Slack's peer of {@link awaitWebchatUrlElicitation}: post the CONSENT card and park the
+   *  resolver until the reader taps Open link or Dismiss. Nothing here fetches the URL — the tap
+   *  hands it to the reader's browser, which is what keeps the page out of the model's context —
+   *  so the only thing this seam decides is whether they agreed to go there. A card this surface
+   *  cannot build falls back to the same decline notice every other unrenderable ask gets. */
+  private async awaitSlackUrlElicitation(
+    agentId: string,
+    sessionId: string,
+    params: CreateElicitationRequest,
+    p: Pending,
+    conn: SlackConnection,
+    url: { elicitationId: string; url: string }
+  ): Promise<CreateElicitationResponse | undefined> {
+    const requestId = `elicit-${++this.elicitSeq}`
+    const blocks = buildUrlConsentCard(requestId, params, this.host.httpSlackSessionTarget(p))
+    if (!blocks) return this.noticeUnrenderableElicit(p, params, false)
+    const fallback = (params as { message?: string }).message ?? 'The agent needs you to open a link'
+    let resolveResult!: (res: CreateElicitationResponse) => void
+    const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
+    this.pendingElicits.set(requestId, {
+      owner: p.hostKey,
+      agentId,
+      sessionId,
+      params,
+      // A URL card has no field; these are the record's unused shape, never read on this path.
+      propName: '',
+      kind: 'text',
+      url,
+      approval: false,
+      surface: 'slack',
+      conn,
+      channel: p.plan.channel,
+      resolve: resolveResult
+    })
+    this.syncApprovalActivity(p.hostKey, sessionId)
+    const ts = await this.host.postCardSerialized(p, (sc) =>
+      sc.postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
+        ...(slackAgentIdentityOptions(p.plan) ?? {}),
+        chrome: true
+      })
+    )
+    const live = this.pendingElicits.get(requestId)
+    // Settled mid-post (an ended turn, say) — the card must stop offering a consent nobody awaits.
+    if (!live) {
+      if (ts) this.rewriteSlackCard(conn, p.plan.channel, ts, params, ':hourglass: Cancelled', 'Cancelled', true)
+      return await result
+    }
+    if (!ts) {
+      this.pendingElicits.delete(requestId)
+      this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
+      live.resolve({ action: 'cancel' })
+      return await result
+    }
+    if (live.surface === 'slack') live.ts = ts
+    return await result
+  }
+
+  /** Rewrite a settled Slack card in place, best effort — the ACP resolution never depends on it.
+   *  A consent card keeps its own shape so the settled message still records the URL. */
+  private rewriteSlackCard(
+    conn: SlackConnection,
+    channel: string,
+    ts: string,
+    params: CreateElicitationRequest,
+    decision: string,
+    fallback: string,
+    consent: boolean
+  ): void {
+    const blocks = consent
+      ? buildUrlConsentResolvedCard(params, decision)
+      : buildElicitationResolvedCard(params, decision)
+    void conn.updateBlocks(channel, ts, blocks, fallback, true).catch(() => {})
+  }
+
   /** Settle a URL-mode consent card. `accept` means only that the user agreed to OPEN the URL —
    *  not that whatever happens on that page finished — so the ACP request resolves right here
    *  and any later `elicitation/complete` is a re-label, not a second resolution. Dismiss is the
@@ -1633,30 +1717,42 @@ export class PermissionCoordinator {
     rec: PendingElicit & { url: NonNullable<PendingElicit['url']> },
     a: { value: ElicitAnswer; webchatConversationId?: string }
   ): Promise<void> {
-    // A consent card lives only on webchat, and only the conversation it was shown in answers it.
-    if (rec.surface !== 'webchat') return
-    if (a.webchatConversationId === undefined || rec.wc.conversationId !== a.webchatConversationId) return
+    // A card settles only from its own surface: its webchat conversation, or a Slack tap (no conversation).
+    if (rec.surface === 'webchat') {
+      if (a.webchatConversationId === undefined || rec.wc.conversationId !== a.webchatConversationId) return
+    } else if (a.webchatConversationId !== undefined) return
     // Consent echoes the card's own URL back: the only value this card offers, checked the way
     // every other card checks that an answer was one it actually rendered.
     const consented = a.value === rec.url.url
     if (!consented && a.value !== null) return
     this.pendingElicits.delete(requestId)
     this.syncApprovalActivity(rec.owner, rec.sessionId, { id: requestId, allowed: consented })
-    this.emitWebchatElicitResolved(
-      rec,
-      requestId,
-      consented ? 'accepted' : 'dismissed',
-      consented ? 'Opened' : undefined
-    )
+    this.settleUrlElicit(rec, requestId, consented ? 'accepted' : 'dismissed')
     if (consented) this.rememberConsentedUrlElicit(requestId, rec)
     rec.resolve({ action: consented ? 'accept' : 'decline' })
+  }
+
+  /** Say on the card's own surface how a consent card ended: webchat appends a stream event,
+   *  Slack rewrites the message. Best effort on both — the ACP resolution never depends on it. */
+  private settleUrlElicit(
+    rec: PendingElicit,
+    requestId: string,
+    outcome: 'accepted' | 'dismissed' | 'cancelled' | 'completed'
+  ): void {
+    if (rec.surface === 'webchat') {
+      this.emitWebchatElicitResolved(rec, requestId, outcome, outcome === 'accepted' ? 'Opened' : undefined)
+      return
+    }
+    if (!rec.ts) return
+    const decision = URL_CONSENT_DECISION[outcome]
+    this.rewriteSlackCard(rec.conn, rec.channel, rec.ts, rec.params, decision, decision, true)
   }
 
   /** Park a consented card's coordinates so a later `elicitation/complete` can find it. Oldest
    *  out at the cap — a flow that never completes must not pin this map open forever. */
   private rememberConsentedUrlElicit(
     requestId: string,
-    rec: Extract<PendingElicit, { surface: 'webchat' }> & { url: NonNullable<PendingElicit['url']> }
+    rec: PendingElicit & { url: NonNullable<PendingElicit['url']> }
   ): void {
     while (this.consentedUrlElicits.size >= CONSENTED_URL_ELICIT_CAP) {
       const oldest = this.consentedUrlElicits.keys().next().value
@@ -1676,7 +1772,7 @@ export class PermissionCoordinator {
     const hit = this.consentedUrlElicits.get(key)
     if (!hit) return
     this.consentedUrlElicits.delete(key)
-    this.emitWebchatElicitResolved(hit.rec, hit.requestId, 'completed')
+    this.settleUrlElicit(hit.rec, hit.requestId, 'completed')
   }
 
   /** Append the settled card to a webchat stream — the append-only equivalent of Slack
@@ -1840,17 +1936,11 @@ export class PermissionCoordinator {
       this.pendingElicits.delete(id)
       this.syncApprovalActivity(owner, sessionId, { id })
       if (rec.approval) await this.resolveStoredPermissionRequest(agentId, id, 'expired')
-      if (rec.surface === 'webchat') this.emitWebchatElicitResolved(rec, id, 'cancelled')
+      // A consent card settles through its own shape, so the cancelled message still shows the URL.
+      if (rec.url) this.settleUrlElicit(rec, id, 'cancelled')
+      else if (rec.surface === 'webchat') this.emitWebchatElicitResolved(rec, id, 'cancelled')
       else if (rec.ts)
-        void rec.conn
-          .updateBlocks(
-            rec.channel,
-            rec.ts,
-            buildElicitationResolvedCard(rec.params, ':hourglass: Cancelled'),
-            'Cancelled',
-            true
-          )
-          .catch(() => {})
+        this.rewriteSlackCard(rec.conn, rec.channel, rec.ts, rec.params, ':hourglass: Cancelled', 'Cancelled', false)
       rec.resolve({ action: 'cancel' })
     }
   }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -1119,11 +1119,13 @@ const BARE_URL_RE = /(?:https?:\/\/|www\.)\S+/gi
  *  wrapped in a code span, which Slack mrkdwn does not autolink. Pure. */
 function elicitCardMessage(params: CreateElicitationRequest): string {
   const raw = (params as { message?: string }).message?.trim() || 'The agent needs your input'
-  return raw
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(BARE_URL_RE, (m) => `\`${m}\``)
+  return escapeSlackMrkdwn(raw).replace(BARE_URL_RE, (m) => `\`${m}\``)
+}
+
+/** The three characters Slack mrkdwn reads as markup rather than as themselves. Escaping them is
+ *  how a literal `&`, `<` or `>` reaches the reader — Slack unescapes the entities on display. */
+function escapeSlackMrkdwn(raw: string): string {
+  return raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
 /** Slack's own limit on one section's mrkdwn text. */
@@ -1174,6 +1176,104 @@ export function buildElicitationResolvedCard(params: CreateElicitationRequest, d
   const message = elicitCardMessage(params)
   const text = clampTo(`:speech_balloon: ${clampTo(message, ELICIT_MESSAGE_CAP)}\n${decision}`, SLACK_SECTION_TEXT_CAP)
   return [{ type: 'section', text: { type: 'mrkdwn', text } }]
+}
+
+/** Slack's own limit on an interactive element's `value`. A URL longer than this cannot ride a
+ *  button, so its card is not built at all rather than posted with a truncated consent. */
+const SLACK_ACTION_VALUE_CAP = 2000
+
+/** What a consent card shows about its URL: the REAL host, so a lookalike or a userinfo prefix
+ *  cannot pass itself off as one, and what to warn about. Both checks are on the host alone — a
+ *  lookalike hides there, not in the path — and both are advisory: the card still shows the whole
+ *  URL and still opens only on an explicit tap. Null ⇒ nothing a consent card may offer: a scheme
+ *  no browser tab should take (the caller's {@link elicitUrl} already refused those, and this
+ *  refuses them again rather than trust its caller), or a backtick, which cannot sit inside the
+ *  code span that keeps the URL unfollowable without either escaping the span or lying about the
+ *  bytes. Pure — it parses the URL and never touches the network. */
+function consentUrlParts(url: string): { host: string; warnings: string[] } | null {
+  if (url.includes('`')) return null
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null
+  // Sliced by POSITION, never by searching `parsed.host`: the parser's spelling is not in the original.
+  const afterScheme = url.indexOf('//') + 2
+  const authorityEnd = url.slice(afterScheme).search(/[/?#]/)
+  const shownHost = url.slice(afterScheme, authorityEnd < 0 ? url.length : afterScheme + authorityEnd)
+  const warnings: string[] = []
+  if (parsed.protocol !== 'https:')
+    warnings.push('Not encrypted (http) — anything you type on that page can be read in transit.')
+  // Both spellings of one risk: the parser punycodes Unicode, but a homograph is a lookalike ON SCREEN.
+  if (/(^|\.)xn--/i.test(parsed.hostname) || /[^\x00-\x7F]/.test(shownHost))
+    warnings.push('This host is not plain ASCII, which can disguise a lookalike domain.')
+  return { host: parsed.hostname, warnings }
+}
+
+/** Build the URL-mode CONSENT card: the agent's defused `message`, the real host, the whole URL in
+ *  a code span, any advisory warnings, an Open link button and a Dismiss button. The URL is shown
+ *  but deliberately NOT followable as text — Slack autolinks a bare URL, and a reader who left
+ *  through that autolink would deliver no interaction, so the card would hang unanswered. The
+ *  button's `url` field both opens the page and still sends Slack's interaction, which is what
+ *  makes consent observable; its `value` carries the URL back so the answer is re-derived against
+ *  the card that offered it. Returns null — the caller then declines with a notice — when this is
+ *  not a URL-mode ask, when the URL is not one a card may offer, or when it will not fit a Slack
+ *  button `value`. Pure; the daemon never fetches the URL. */
+export function buildUrlConsentCard(
+  requestId: string,
+  params: CreateElicitationRequest,
+  sessionTarget?: string
+): unknown[] | null {
+  const url = elicitUrl(params)
+  const parts = url && consentUrlParts(url.url)
+  if (!url || !parts) return null
+  const value = encodePermValue(requestId, url.url)
+  if (value.length > SLACK_ACTION_VALUE_CAP) return null
+  const detail = [
+    'Opens in your browser. This agent never sees that page or anything you type on it.',
+    `Host: \`${escapeSlackMrkdwn(parts.host)}\``,
+    `\`${escapeSlackMrkdwn(url.url)}\``,
+    ...parts.warnings.map((w) => `:warning: ${escapeSlackMrkdwn(w)}`)
+  ].join('\n')
+  return [
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: `:link: ${clampTo(elicitCardMessage(params), ELICIT_MESSAGE_CAP)}` }
+    },
+    { type: 'section', text: { type: 'mrkdwn', text: clampTo(detail, SLACK_SECTION_TEXT_CAP) } },
+    {
+      type: 'actions',
+      ...(sessionTarget ? { block_id: sessionTarget } : {}),
+      elements: [
+        {
+          type: 'button',
+          action_id: `${ELICIT_ACTION_PREFIX}:0`,
+          text: { type: 'plain_text', text: 'Open link', emoji: true },
+          style: 'primary',
+          url: url.url,
+          value
+        },
+        {
+          type: 'button',
+          action_id: ELICIT_DISMISS_ACTION as string,
+          text: { type: 'plain_text', text: 'Dismiss', emoji: true },
+          value: requestId
+        }
+      ]
+    }
+  ]
+}
+
+/** Build the RESOLVED consent card (buttons removed) that replaces {@link buildUrlConsentCard}
+ *  once opened, dismissed, cancelled, or reported complete. It keeps the URL on screen so the
+ *  settled card still records what was consented to. Pure. */
+export function buildUrlConsentResolvedCard(params: CreateElicitationRequest, decision: string): unknown[] {
+  const url = elicitUrl(params)
+  const shown = url && !url.url.includes('`') ? `\n\`${escapeSlackMrkdwn(url.url)}\`` : ''
+  const text = `:link: ${clampTo(elicitCardMessage(params), ELICIT_MESSAGE_CAP)}${shown}\n${decision}`
+  return [{ type: 'section', text: { type: 'mrkdwn', text: clampTo(text, SLACK_SECTION_TEXT_CAP) } }]
 }
 
 export interface SharedStatusActions {

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -1394,9 +1394,9 @@ describe('webchat renders and settles a URL-mode consent card', () => {
     ).resolves.toBeUndefined()
     expect((daemon as any).permissions.pendingElicits.size).toBe(0)
 
-    // And a surface with no consent card keeps declining — Slack gains none here.
-    const slack: any = installPending(daemon)
-    slack.plan.platform = 'slack'
+    // And a platform whose chrome declares no input cards keeps declining.
+    const telegram: any = installPending(daemon)
+    telegram.plan.platform = 'telegram'
     await expect((daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())).resolves.toBeUndefined()
   })
 
@@ -1415,5 +1415,186 @@ describe('webchat renders and settles a URL-mode consent card', () => {
     )
     await vi.waitFor(() => expect(cardEvents(sink)).toHaveLength(1))
     expect(cardEvents(sink)[0].url).not.toContain('sk-live-DEADBEEF')
+  })
+})
+
+// ── Slack's URL-mode consent card (#1794, Slack column) ──────────────────────
+// URL mode used to decline on Slack — latterly with a notice (#1819), which the reader still
+// could not act on without leaving the channel. The card is a second SURFACE for the machinery
+// #1810 built, not a second implementation of it.
+
+/** Every mrkdwn string a posted card carries, in block order. */
+const cardText = (blocks: any[]): string[] =>
+  blocks.filter((b) => b.type === 'section').map((b) => b.text.text as string)
+
+/** The card's action row elements. */
+const cardButtons = (blocks: any[]): any[] => blocks.find((b) => b.type === 'actions')?.elements ?? []
+
+/** The one live card's request id, once it is actually ON the channel — a reader cannot tap a
+ *  card whose `chat.postMessage` has not returned, and only then can the record be rewritten. */
+async function liveSlackCard(daemon: any): Promise<string> {
+  return await vi.waitFor(() => {
+    const [id, rec] = [...daemon.permissions.pendingElicits.entries()][0] ?? []
+    expect(rec?.ts).toBeTruthy()
+    return id as string
+  })
+}
+
+describe('Slack renders and settles a URL-mode consent card', () => {
+  it('shows the whole URL unfollowable, opens it from the button, and resolves accept on consent', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted, updated } = slackPending(daemon)
+
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())
+    await vi.waitFor(() => expect(posted).toHaveLength(1))
+    const url = 'https://billing.example.com/oauth/authorize?state=xyz'
+    const text = cardText(posted[0]!).join('\n')
+    // The full URL is examinable, and it sits in a code span — which Slack mrkdwn does not
+    // autolink, so following it as TEXT (and thus consenting unobservably) is not on offer.
+    expect(text).toContain(`\`${url}\``)
+    expect(text).not.toContain(`<${url}`)
+    // The real host stands on its own line, so a userinfo prefix or a lookalike path cannot
+    // pass itself off as the destination.
+    expect(text).toContain('Host: `billing.example.com`')
+    expect(text).toContain('Sign in to the billing provider to continue')
+
+    const [open, dismiss] = cardButtons(posted[0]!)
+    // Slack's `url` field is what both opens the page and still delivers an interaction.
+    expect(open).toMatchObject({ text: { text: 'Open link' }, url, value: expect.stringContaining(url) })
+    expect(dismiss).toMatchObject({ text: { text: 'Dismiss' } })
+
+    const requestId = await liveSlackCard(daemon)
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: url })
+    // Consent resolves the ACP request — with no `content`, since nothing was answered here.
+    await expect(result).resolves.toEqual({ action: 'accept' })
+    // "Opened" and not "Done": the tap proves consent, never that the flow behind it finished.
+    await vi.waitFor(() => expect(cardText(updated[0] ?? [])[0]).toContain(':white_check_mark: Opened'))
+    expect(cardText(updated[0]!)[0]).toContain(`\`${url}\``)
+    expect(cardButtons(updated[0]!)).toEqual([])
+  })
+
+  it('declines on Dismiss and cancels when the turn ends under a live card', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { updated } = slackPending(daemon)
+    const dismissed = (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())
+    const first = await liveSlackCard(daemon)
+    await (daemon as any).permissions.handleElicitChoice({ requestId: first, value: null })
+    await expect(dismissed).resolves.toEqual({ action: 'decline' })
+    await vi.waitFor(() => expect(cardText(updated[0] ?? [])[0]).toContain(':no_entry_sign: Dismissed'))
+
+    const abandoned = (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())
+    await liveSlackCard(daemon)
+    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
+    await expect(abandoned).resolves.toEqual({ action: 'cancel' })
+    await vi.waitFor(() => expect(cardText(updated[1] ?? [])[0]).toContain(':hourglass: Cancelled'))
+  })
+
+  it('flags a Punycode host and calls out an unencrypted one', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+
+    void (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      urlElicitation({ url: 'http://xn--80ak6aa92e.example-login.com/authorize' })
+    )
+    await vi.waitFor(() => expect(posted).toHaveLength(1))
+    const text = cardText(posted[0]!).join('\n')
+    expect(text).toContain('Not encrypted (http)')
+    expect(text).toContain('not plain ASCII')
+    // Whatever it warns about, the bytes the agent asked for are still shown verbatim.
+    expect(text).toContain('`http://xn--80ak6aa92e.example-login.com/authorize`')
+    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
+  })
+
+  it('declines a scheme no browser tab may be handed, with no card at all', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+    for (const url of ['javascript:alert(1)', 'data:text/html,<script>1</script>', 'file:///etc/passwd'])
+      await expect(
+        (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation({ url }))
+      ).resolves.toBeUndefined()
+    expect(posted).toEqual([])
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+  })
+
+  it('cannot let the agent’s own message contribute a second followable link', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+
+    void (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      urlElicitation({ message: 'Or sign in at <https://evil.example/x|your account> or https://evil.example/y' })
+    )
+    await vi.waitFor(() => expect(posted).toHaveLength(1))
+    const text = cardText(posted[0]!).join('\n')
+    // A Slack CARD is an mrkdwn section, so the syntax to kill is `<url|label>` — and a bare URL
+    // autolinks, so it lands in a code span instead.
+    expect(text).not.toContain('<https://evil.example/x')
+    expect(text).toContain('&lt;`https://evil.example/x|your` account&gt;')
+    expect(text).toContain('`https://evil.example/y`')
+    // The consent URL stays the ONE followable thing on the card: no other button carries a url.
+    expect(cardButtons(posted[0]!).filter((b: any) => b.url)).toHaveLength(1)
+    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
+  })
+
+  it('refuses a consent naming a URL other than the card’s own, and a browser answering a Slack card', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    slackPending(daemon)
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())
+    const requestId = await liveSlackCard(daemon)
+
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'https://billing.example.com.evil.test/oauth/authorize?state=xyz'
+    })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    // A webchat frame cannot settle a card posted to Slack, guessable `elicit-<n>` id or not.
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'https://billing.example.com/oauth/authorize?state=xyz',
+      webchatConversationId: 'conv-1'
+    })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
+    await expect(result).resolves.toEqual({ action: 'cancel' })
+  })
+
+  it('re-labels the settled card on elicitation/complete, and ignores an id it does not hold', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { updated } = slackPending(daemon)
+    void (daemon as any).permissions.onAcpElicit('agent-1', 's1', urlElicitation())
+    const requestId = await liveSlackCard(daemon)
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: 'https://billing.example.com/oauth/authorize?state=xyz'
+    })
+    await vi.waitFor(() => expect(updated).toHaveLength(1))
+    ;(daemon as any).permissions.onAcpElicitComplete('agent-1', 'el-nope')
+    ;(daemon as any).permissions.onAcpElicitComplete('agent-2', 'el-1')
+    expect(updated).toHaveLength(1)
+    ;(daemon as any).permissions.onAcpElicitComplete('agent-1', 'el-1')
+    await vi.waitFor(() => expect(cardText(updated[1] ?? [])[0]).toContain(':white_check_mark: Completed'))
+    // Advisory and at most once: a repeat re-labels nothing, and never arriving is also fine.
+    ;(daemon as any).permissions.onAcpElicitComplete('agent-1', 'el-1')
+    expect(updated).toHaveLength(2)
+  })
+
+  it('masks an agent secret embedded in the URL before the card carries it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+    ;(daemon as any).agents = new Map([
+      ['agent-1', { id: 'agent-1', runtimeOverrides: { secrets: [{ name: 'TOKEN', value: 'sk-live-DEADBEEF' }] } }]
+    ])
+
+    void (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      urlElicitation({ url: 'https://billing.example.com/pay?token=sk-live-DEADBEEF' })
+    )
+    await vi.waitFor(() => expect(posted).toHaveLength(1))
+    expect(JSON.stringify(posted[0])).not.toContain('sk-live-DEADBEEF')
+    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
   })
 })

--- a/packages/daemon/test/elicit-decline-notice.test.ts
+++ b/packages/daemon/test/elicit-decline-notice.test.ts
@@ -166,6 +166,32 @@ describe('an elicitation declined for want of a surface says so in the channel',
     await daemon.permissions.releaseElicits('agent-1', 's1')
   })
 
+  it('says nothing for a URL-mode ask Slack now renders as a consent card', async () => {
+    const { daemon, notices } = slackTurn()
+    void daemon.permissions.onAcpElicit('agent-1', 's1', {
+      sessionId: 's1',
+      mode: 'url',
+      elicitationId: 'el-1',
+      url: 'https://billing.example.com/oauth/authorize',
+      message: 'Sign in to continue'
+    } as CreateElicitationRequest)
+    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
+    expect(notices()).toEqual([])
+    await daemon.permissions.releaseElicits('agent-1', 's1')
+
+    // A URL no card may offer is still an ask Slack cannot render, so that one keeps its notice.
+    await expect(
+      daemon.permissions.onAcpElicit('agent-1', 's1', {
+        sessionId: 's1',
+        mode: 'url',
+        elicitationId: 'el-2',
+        url: 'javascript:alert(1)',
+        message: 'Run this'
+      } as CreateElicitationRequest)
+    ).resolves.toBeUndefined()
+    expect(notices()).toHaveLength(1)
+  })
+
   it('says nothing for an MCP approval, which has its own notice on the editor path', async () => {
     const { daemon, notices } = slackTurn()
     // Chat approval enabled, so the request reaches the card path rather than the editor queue.

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -24,6 +24,7 @@ import {
   elicitRequiredProps,
   elicitTarget,
   elicitUrl,
+  buildUrlConsentCard,
   SLACK_ELICIT_SURFACE,
   WEBCHAT_ELICIT_SURFACE,
   multiSelectAccepts,
@@ -2145,6 +2146,48 @@ describe('elicitUrl', () => {
 
   it('takes http as well as https — the card calls the missing encryption out instead', () => {
     expect(elicitUrl(urlReq({ url: 'http://x.test/a' }))?.url).toBe('http://x.test/a')
+  })
+})
+
+describe('buildUrlConsentCard', () => {
+  const urlReq = (overrides: Record<string, unknown> = {}) =>
+    ({
+      mode: 'url',
+      sessionId: 's1',
+      message: 'Sign in',
+      elicitationId: 'el-1',
+      url: 'https://login.example.test/a?b=1',
+      ...overrides
+    }) as any
+  const text = (blocks: unknown[]) =>
+    blocks
+      .filter((b: any) => b.type === 'section')
+      .map((b: any) => b.text.text as string)
+      .join('\n')
+
+  it('refuses a non-URL ask, a scheme no tab may take, and a URL too long for a Slack value', () => {
+    expect(buildUrlConsentCard('r1', { mode: 'form', message: 'x' } as any)).toBeNull()
+    expect(buildUrlConsentCard('r1', urlReq({ url: 'javascript:alert(1)' }))).toBeNull()
+    // Slack caps a button `value` at 2000; a URL that cannot ride one has no observable consent.
+    expect(buildUrlConsentCard('r1', urlReq({ url: `https://x.test/${'a'.repeat(1990)}` }))).toBeNull()
+    // A backtick cannot sit inside the code span that keeps the URL unfollowable.
+    expect(buildUrlConsentCard('r1', urlReq({ url: 'https://x.test/a`b' }))).toBeNull()
+  })
+
+  it('escapes the mrkdwn metacharacters a URL carries, so the reader sees its real bytes', () => {
+    const blocks = buildUrlConsentCard('r1', urlReq({ url: 'https://x.test/a?b=1&c=<2>' }))!
+    expect(text(blocks)).toContain('`https://x.test/a?b=1&amp;c=&lt;2&gt;`')
+  })
+
+  it('names the REAL host, so a userinfo prefix cannot pass itself off as the destination', () => {
+    const blocks = buildUrlConsentCard('r1', urlReq({ url: 'https://login.example.test@evil.test/authorize' }))!
+    expect(text(blocks)).toContain('Host: `evil.test`')
+    expect(text(blocks)).toContain('`https://login.example.test@evil.test/authorize`')
+  })
+
+  it('flags a Unicode host the parser punycodes, which never appears in the shown bytes', () => {
+    const blocks = buildUrlConsentCard('r1', urlReq({ url: 'https://\u0440\u0430\u0443.example.test/a' }))!
+    expect(text(blocks)).toContain('not plain ASCII')
   })
 })
 

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -756,6 +756,18 @@ describe('the agent’s URL-mode consent card', () => {
     expect(linkNamed('Open link')).toBeDefined()
   })
 
+  // The emphasized authority is attacker-chosen when it carries userinfo, so the card must name
+  // where the link actually goes rather than letting the prefix speak for it.
+  it('names the real destination when a userinfo prefix impersonates the host', async () => {
+    live.steps = urlCard('https://login.example.com@evil.test/authorize')
+    await render()
+
+    expect(text()).toContain('This link goes to evil.test')
+    // The full URL is still shown verbatim, and the card stays answerable — the warning is advisory.
+    expect(text()).toContain('login.example.com@evil.test')
+    expect(linkNamed('Open link')).toBeDefined()
+  })
+
   it('calls out a link that is not encrypted', async () => {
     live.steps = urlCard('http://billing.example.com/pay')
     await render()

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -692,6 +692,10 @@ function readConsentUrl(url: string): { scheme: string; host: string; rest: stri
   // Both spellings of the same risk: the parser punycodes a Unicode host, so check the ORIGINAL
   // too — the reader is looking at that, and a homograph is only a lookalike on screen.
   const shownHost = url.slice(afterScheme, hostEnd)
+  // Userinfo makes the emphasized authority attacker-chosen text: `login.example.com@evil.test`
+  // reads as the host it is not. Name the real destination rather than trusting what shows.
+  if (shownHost.includes('@'))
+    warnings.push(`This link goes to ${parsed.hostname} — the text before the @ is not the destination.`)
   if (/(^|\.)xn--/i.test(parsed.hostname) || /[^\x00-\x7F]/.test(shownHost))
     warnings.push(
       `This host is not plain ASCII (it resolves to ${parsed.hostname}), which can disguise a lookalike domain.`


### PR DESCRIPTION
Implements the Slack-column item on #1794: **URL-mode consent on Slack**. Also fixes a phishing display gap in the already-shipped webchat consent card — see the last section.

URL mode is how the spec says credentials, API keys, OAuth and payment flows MUST be handled. Webchat got a consent card in #1810; on Slack a URL elicitation declined, and after #1819 it at least said so — but the reader still could not act on it without leaving Slack.

## The card

Three blocks, through the existing card path, reusing #1810's `elicitUrl` reduction rather than reimplementing it:

1. the agent's message, defused with `elicitCardMessage`
2. `Opens in your browser. This agent never sees that page or anything you type on it.` · `Host: <parsed.hostname>` · the whole URL, **verbatim bytes, in a code span** · any warnings
3. **Open link** (carries Slack's `url`) and **Dismiss**

**The URL is shown but deliberately not followable as text.** Slack autolinks a bare URL in `mrkdwn`, and if the reader followed that autolink they would leave for the page while we receive no interaction at all — the ACP request would never resolve and the card would hang until the turn ended. Consent has to be observable, so the URL sits in a code span and the button is the only way to go.

`accept` means the reader **consented to open it**, not that the flow finished; the request resolves at consent. Dismiss declines, turn end cancels. `elicitation/complete` re-labels the settled card, and the card settles correctly whether or not it ever arrives — hence "Opened", not "Done".

Reusing the existing `ac_elicit:0` / `ac_elicit_dismiss` action ids means **no relay or connection changes**: both interaction edges already decode them and already forward `value` unbounded. Consent is re-derived against the card's own URL, as #1815 requires of every surface.

The card refuses to build — falling back to #1819's notice — for a non-`http(s)` scheme (re-checked here, not trusted from the caller), a URL past Slack's `value` cap, or one carrying a backtick that would break out of the code span.

## What we can and cannot honestly claim about where it opens

The spec requires the URL open so neither the client nor the model can observe the page or the reader's input. **We cannot guarantee it opens in the reader's own browser.** Slack mobile's "Open web pages in app" is on by default, Org Owners can force a specific browser, and a `url` button has no way to request an external one.

What is true: the page is opened by the Slack client, never by the daemon and never by the agent; nothing pre-fetches it; no response body enters the ACP stream; and the request resolves with no `content`. So the part that concerns AgentConnect and the model is met.

What is not, stated plainly: it may be a Slack-owned webview rather than the reader's browser, so Slack is in the loop for a credentials page — and that webview does not share the reader's cookie jar, password manager or SSO session, which makes a credential flow *more* likely to be typed by hand into a Slack-hosted view. If the spec means the reader's own browser, Slack mobile does not satisfy it and no Block Kit field can make it. Slack's docs specify the `url` and `value` length caps but say nothing about scheme validation, so we do not depend on it.

## Known gaps, deliberately

- **A URL between ~1989 and 2048 characters loses its card** and falls back to the notice: Slack caps a button `value` at 2000 while `elicitUrl` admits 2048. The alternative — an opaque token as the `value` — would break "the answer is checked against the card's own URL". An OAuth `state` can be long enough to hit this; the real fix is a per-request nonce with a server-side lookup, which is a design change.
- **`accept`-at-consent is unfalsifiable by us.** The reader can open the page and close it immediately, and the agent still gets `accept`. That is what the spec asks for, but agents cannot distinguish consent from completion without `elicitation/complete`, which may never come.
- **A consent arriving before `chat.postMessage` returns** leaves the card labelled cancelled although the request resolved `accept`. Inherited verbatim from the existing card path — parity was kept rather than diverging — but on a consent card the mislabel is worse, since the channel record then says cancelled for a credential page the reader actually opened. Worth its own fix on both paths.

## The DM path is not in scope, and cannot be reached

`sendApprovalDm` posts from `pendingEditorPermissions`, which for an elicitation is only ever filled by `awaitEditorElicitation` — one caller, gated on `isApproval`. A URL-mode ask is never an MCP tool approval, so it cannot reach the DM path today; adding a card there would mean creating a route that does not exist, and would decouple the tap from the channel the turn is in.

## The webchat card had a userinfo phishing gap, fixed here

Building the Slack card surfaced it. Webchat's `readConsentUrl` splits the original URL and weights the **authority slice** as the host, so `https://login.example.com@evil.test/authorize` renders with `login.example.com@evil.test` emphasised as the destination. Every byte is shown, but the part the card presents *as the host* is attacker-chosen text and the link goes to `evil.test`.

Slack's new card shows `parsed.hostname` and never had the gap. Rather than file it and leave one honest card and one dishonest one, webchat now names where the link actually resolves whenever the authority carries userinfo, and still shows the URL verbatim — a userinfo prefix, like a homograph, is only a lookalike on screen, so the warning has to be about what is on screen.

## Verification

- protocol 488, relay 644, web 2404 — green.
- `pnpm typecheck`: `error TS` count 0. eslint + prettier clean on changed files.
- Touched daemon suites (`render`, `elicit-decline-notice`, `daemon-permission-autoallow`, `turn-chrome`, `approval-dm`): 311 passing.
- **Full daemon suite**, finally runnable (the host had freed disk): 12 files / 53 tests failing — `acp-matrix` dialling live runtimes, plus the known skills-CLI, bwrap-sandbox and workspace-clone set. None of the failing files reference `elicit`, `permissions/coordinator` or `slack/render`, and reverting both source files reproduces the same failure count, so they are pre-existing rather than caused here.

Every new test was confirmed red with only the source reverted — including the webchat userinfo case, and the Slack card's whole lifecycle (consent, dismiss, cancel, `complete` re-label, a consent naming a different URL, and the agent's message being unable to contribute a second followable link). One new case passes either way by design: `javascript:` already declined, and the test pins that the new path did not weaken it.
