### PR TITLE
feat(console): bring the elicitation card back to its design

### DIFF
--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -580,6 +580,56 @@ describe('the agent’s elicitation card on the session page', () => {
     expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', { question_0: 'main' }, 'conv-1']])
   })
 
+  it('lays a question out as rows, not chips, once one of its options is a sentence', async () => {
+    const LONG = 'Roll back to the previous release and page the on-call engineer'
+    live.steps = [
+      {
+        ...CARD,
+        elicit: {
+          requestId: 'elicit-1',
+          options: [],
+          fields: [
+            { propName: 'branch', label: 'Branch', kind: 'enum', options: [{ value: 'main', label: 'main' }] },
+            {
+              propName: 'strategy',
+              label: 'If the deploy fails',
+              kind: 'enum',
+              options: [
+                { value: 'rollback', label: LONG },
+                { value: 'hold', label: 'Hold the failed build and wait for a human' }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+    await render()
+
+    // A short-value question stays a row of chips…
+    expect(buttonNamed('main')?.className).toContain('chip')
+    // …while one option long enough to be a sentence turns its whole question into full-width
+    // rows, so no answer is truncated away and they all read alike.
+    const row = buttonNamed(LONG)
+    expect(row?.className).not.toContain('chip')
+    expect(row?.className).toContain('items-start')
+    expect(buttonNamed('Hold the failed build and wait for a human')?.className).toContain('items-start')
+    expect(row?.getAttribute('aria-pressed')).toBe('false')
+
+    await act(async () => {
+      row?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(buttonNamed(LONG)?.getAttribute('aria-pressed')).toBe('true')
+    await act(async () => {
+      buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {
+      buttonNamed('Submit answers')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered).toEqual([
+      ['session-1', 'agent-1', 'elicit-1', { branch: 'main', strategy: 'rollback' }, 'conv-1']
+    ])
+  })
+
   it('still asks a REQUIRED question for its own pick, box or no box', async () => {
     // `elicitFormAccepts` refuses an answer that leaves a required property out, so a box that
     // unlocked Submit here would post an answer the daemon drops — the card would sit pending

--- a/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.elicitation.test.tsx
@@ -418,6 +418,13 @@ describe('the agent’s elicitation card on the session page', () => {
     })
   }
 
+  // A question's box is behind its own "Other…" chip, so a reader opens it before typing.
+  const openOther = async () => {
+    await act(async () => {
+      buttonNamed('Other…')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+  }
+
   const FORM_FIELDS = [
     {
       propName: 'branch',
@@ -450,9 +457,9 @@ describe('the agent’s elicitation card on the session page', () => {
 
     // Every field is named, and the one the schema does not require says so.
     for (const label of ['Base branch', 'Note', 'Force push']) expect(text()).toContain(label)
-    expect(text()).toContain('(optional)')
+    expect(text()).toContain('optional')
     // Two required fields unanswered, so there is nothing valid to submit yet.
-    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(true)
     expect(text()).toContain('Choose one')
 
     await act(async () => {
@@ -461,22 +468,22 @@ describe('the agent’s elicitation card on the session page', () => {
     // A pick is held, not sent: a form answers once, on Submit.
     expect(live.answered).toEqual([])
     expect(buttonNamed('main')?.getAttribute('aria-pressed')).toBe('true')
-    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(true)
 
     await act(async () => {
       buttonNamed('No')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
-    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(false)
 
     // One bad OPTIONAL field is still enough to hold the whole answer, with its own reason.
     await typeInto(inputNamed('Note')!, 'far too long')
     expect(text()).toContain('Enter at most 6 characters')
-    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(true)
 
     await typeInto(inputNamed('Note')!, 'ok')
-    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(false)
     await act(async () => {
-      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      buttonNamed('Submit answers')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     // One value per field, each in the shape its own kind answers with.
     expect(live.answered).toEqual([
@@ -516,26 +523,61 @@ describe('the agent’s elicitation card on the session page', () => {
       .map((n) => n.textContent ?? '')
       .filter((t) => /^\d\d$/.test(t))
     expect(numbers).toEqual(['01', '02'])
-    expect(text()).toContain('0/2')
+    expect(text()).toContain('0/2 answered')
     // The schema's question text rides under the header the title only names.
     expect(text()).toContain('Which branch should I cut from?')
 
+    // The box is not standing open — the question shows its options and its own chip.
+    expect(inputNamed('Branch — Other')).toBe(null)
     // A typed box IS the question's answer: its own select stops being asked for.
+    await openOther()
     await typeInto(inputNamed('Branch — Other')!, 'release/1.2')
     expect(text()).toContain('1/2')
-    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(false)
 
     await act(async () => {
       buttonNamed('1')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     expect(text()).toContain('2/2')
     await act(async () => {
-      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      buttonNamed('Submit answers')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     // Each answer under its own property — the untouched second box is left out entirely.
     expect(live.answered).toEqual([
       ['session-1', 'agent-1', 'elicit-1', { question_0_custom: 'release/1.2', question_1: '1' }, 'conv-1']
     ])
+  })
+
+  it('closes a question’s box back up, and answers with the options rather than a hidden draft', async () => {
+    live.steps = [
+      {
+        ...CARD,
+        elicit: {
+          requestId: 'elicit-1',
+          options: [],
+          fields: [
+            { propName: 'question_0', label: 'Branch', kind: 'enum', options: [{ value: 'main', label: 'main' }] },
+            { propName: 'question_0_custom', label: 'Other', kind: 'text', options: [], customAnswerFor: 'question_0' }
+          ]
+        }
+      }
+    ]
+    await render()
+
+    await openOther()
+    await typeInto(inputNamed('Branch — Other')!, 'release/1.2')
+    // Closing the box takes the draft with it — what is not on screen is not in the answer.
+    await openOther()
+    expect(inputNamed('Branch — Other')).toBe(null)
+    expect(text()).toContain('0/1 answered')
+
+    await act(async () => {
+      buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {
+      buttonNamed('Submit answers')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', { question_0: 'main' }, 'conv-1']])
   })
 
   it('still asks a REQUIRED question for its own pick, box or no box', async () => {
@@ -570,8 +612,9 @@ describe('the agent’s elicitation card on the session page', () => {
     ]
     await render()
 
+    await openOther()
     await typeInto(inputNamed('Branch — Other')!, 'dev')
-    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(true)
     expect(text()).toContain('Choose one')
     expect(text()).toContain('0/1')
 
@@ -579,14 +622,14 @@ describe('the agent’s elicitation card on the session page', () => {
     await act(async () => {
       buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
-    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(false)
     await typeInto(inputNamed('Branch — Other')!, 'far too long')
     expect(text()).toContain('Enter at most 6 characters')
-    expect(buttonNamed('Submit')?.disabled).toBe(true)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(true)
 
     await typeInto(inputNamed('Branch — Other')!, 'dev')
     await act(async () => {
-      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      buttonNamed('Submit answers')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     expect(live.answered).toEqual([
       ['session-1', 'agent-1', 'elicit-1', { question_0: 'main', question_0_custom: 'dev' }, 'conv-1']
@@ -615,9 +658,9 @@ describe('the agent’s elicitation card on the session page', () => {
     await act(async () => {
       buttonNamed('main')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
-    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(false)
     await act(async () => {
-      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      buttonNamed('Submit answers')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', { branch: 'main' }, 'conv-1']])
 
@@ -647,9 +690,9 @@ describe('the agent’s elicitation card on the session page', () => {
     expect(inputNamed('Note')?.value).toBe('seed')
     expect(buttonNamed('develop')?.getAttribute('aria-pressed')).toBe('true')
     // Seeded AND already valid, so the reader can simply accept what the agent suggested.
-    expect(buttonNamed('Submit')?.disabled).toBe(false)
+    expect(buttonNamed('Submit answers')?.disabled).toBe(false)
     await act(async () => {
-      buttonNamed('Submit')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      buttonNamed('Submit answers')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     expect(live.answered).toEqual([['session-1', 'agent-1', 'elicit-1', { branch: 'develop', note: 'seed' }, 'conv-1']])
   })

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -795,6 +795,14 @@ function formDrafts(fields: ElicitFieldSpec[] | undefined): Record<string, strin
   return out
 }
 
+/** Which questions open with their own "Other" box already showing — only those whose box the
+ *  schema handed a default, so a blank form shows options and nothing else. */
+function formOthers(fields: ElicitFieldSpec[] | undefined): Record<string, boolean> {
+  const out: Record<string, boolean> = {}
+  for (const f of fields ?? []) if (f.customAnswerFor && typedDraft(f).trim()) out[f.customAnswerFor] = true
+  return out
+}
+
 function formPicks(fields: ElicitFieldSpec[] | undefined): Record<string, string[]> {
   const out: Record<string, string[]> = {}
   for (const f of fields ?? []) if (f.kind !== 'text' && f.kind !== 'number') out[f.propName] = pickedDefaults(f)
@@ -905,6 +913,8 @@ const ELICIT_CHIP = 'chip max-w-full truncate rounded-sm disabled:cursor-default
 const ELICIT_CHIP_ON =
   'chip max-w-full truncate rounded-sm border-(--brand) bg-(--brand) text-white disabled:cursor-default disabled:opacity-55'
 const ELICIT_INPUT = 'inp w-full min-w-0 bg-(--surface-app) disabled:cursor-default disabled:opacity-55'
+// A chip whose label IS its value reads as the literal the agent will receive, not as prose.
+const chipFont = (option: { label: string; value: string }) => (option.label === option.value ? ' font-mono' : '')
 const ELICIT_HINT = 'font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)'
 const ELICIT_ACTIONS = 'flex flex-wrap items-center gap-[8px] border-t border-(--border-subtle) pt-[11px]'
 
@@ -922,6 +932,7 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
   const [draft, setDraft] = useState<string>(() => typedDraft(step.elicit))
   const [drafts, setDrafts] = useState<Record<string, string>>(() => formDrafts(step.elicit?.fields))
   const [picks, setPicks] = useState<Record<string, string[]>>(() => formPicks(step.elicit?.fields))
+  const [others, setOthers] = useState<Record<string, boolean>>(() => formOthers(step.elicit?.fields))
   const elicit = step.elicit
   const multi = elicit?.multi
   const consentUrl = elicit?.url
@@ -931,6 +942,14 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
   // names, not one of its own, so it is never numbered, counted, or asked twice.
   const rows = fields?.filter((f) => !f.customAnswerFor)
   const typed = !fields && elicit && (elicit.text || elicit.number) ? elicit : undefined
+  // A question's box is disclosed by its own chip rather than standing open: the options are
+  // what the agent offered, so the box only takes room once the reader asks for it. Closing it
+  // drops what was typed — a hidden draft must never be part of the answer.
+  const toggleOther = (f: ElicitFieldSpec, companion: ElicitFieldSpec) => {
+    const on = !others[f.propName]
+    setOthers((prev) => ({ ...prev, [f.propName]: on }))
+    if (!on) setDrafts((prev) => ({ ...prev, [companion.propName]: '' }))
+  }
   const min = multi?.minItems ?? 0
   const max = multi?.maxItems
   // The same bounds the daemon re-checks: a browser frame is not what makes an answer valid.
@@ -943,9 +962,13 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
   const edge = settled ? settled.edge : 'border-l-(--brand)'
   const headIcon = settled ? settled.icon : consent ? 'external-link' : 'message-circle-question-mark'
   const headColor = settled ? settled.color : 'var(--brand)'
+  // The head names the ask in one line; anything the agent wrote past that first line reads as
+  // the preamble it is, above the questions rather than as a paragraph-long title.
+  const headLine = step.text.split('\n', 1)[0] ?? step.text
+  const preamble = step.text.slice(headLine.length).trim()
   const counter =
     rows && !settled
-      ? `${rows.filter((f) => rowAnswered(f, companionOf(fields!, f), drafts, picks)).length}/${rows.length}`
+      ? `${rows.filter((f) => rowAnswered(f, companionOf(fields!, f), drafts, picks)).length}/${rows.length} answered`
       : undefined
   return (
     <div
@@ -955,16 +978,26 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
         <span className="mt-[2px] flex-none">
           <Icon name={headIcon} size={14} color={headColor} />
         </span>
-        <span className="min-w-0 flex-1 whitespace-pre-wrap font-sans text-[13.5px] font-medium leading-[1.5] text-(--text-primary)">
-          {step.text}
+        <span className="min-w-0 whitespace-pre-wrap font-sans text-[13.5px] font-medium leading-[1.5] text-(--text-primary)">
+          {headLine}
         </span>
         {counter && (
           <span className="mt-[3px] flex-none font-mono text-[11.5px] font-normal leading-normal text-(--text-tertiary)">
             {counter}
           </span>
         )}
+        {step.time && (
+          <span className="mt-[3px] ml-auto flex-none font-mono text-[11.5px] font-normal leading-normal text-(--text-disabled)">
+            {step.time}
+          </span>
+        )}
       </div>
       <div className="min-w-0 border-t border-(--border-subtle) px-[14px] py-[11px]">
+        {preamble && !settled ? (
+          <span className="mb-[11px] block min-w-0 whitespace-pre-wrap font-sans text-[12.5px] font-normal leading-[1.5] text-(--text-secondary)">
+            {preamble}
+          </span>
+        ) : null}
         {settled ? (
           <span className="inline-flex min-w-0 items-center gap-[7px] font-sans text-[12.5px] font-normal leading-normal text-(--text-secondary)">
             <Icon name={settled.icon} size={13} color={settled.color} />
@@ -1039,10 +1072,15 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                     {String(fi + 1).padStart(2, '0')}
                   </span>
                   <div className="flex min-w-0 flex-col gap-[7px]">
-                    <div className="flex min-w-0 items-baseline gap-[8px]">
+                    <div className="flex min-w-0 flex-wrap items-baseline gap-x-[8px] gap-y-[2px]">
                       <span className="min-w-0 font-sans text-[13px] font-semibold leading-normal text-(--text-primary)">
                         {f.label}
                       </span>
+                      {f.description ? (
+                        <span className="min-w-0 font-sans text-[12px] font-normal leading-normal text-(--text-secondary)">
+                          {f.description}
+                        </span>
+                      ) : null}
                       <span
                         className={
                           f.required
@@ -1050,14 +1088,9 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                             : 'ml-auto flex-none font-sans text-[11.5px] font-normal leading-normal text-(--text-disabled)'
                         }
                       >
-                        {f.required ? 'required' : '(optional)'}
+                        {f.required ? 'required' : 'optional'}
                       </span>
                     </div>
-                    {f.description ? (
-                      <span className="min-w-0 font-sans text-[12px] font-normal leading-normal text-(--text-secondary)">
-                        {f.description}
-                      </span>
-                    ) : null}
                     {f.kind === 'text' || f.kind === 'number' ? (
                       <input
                         className={`${ELICIT_INPUT} desktop:max-w-[320px]`}
@@ -1085,7 +1118,8 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                               key={option.value}
                               type="button"
                               aria-pressed={on}
-                              className={on ? ELICIT_CHIP_ON : ELICIT_CHIP}
+                              className={(on ? ELICIT_CHIP_ON : ELICIT_CHIP) + chipFont(option)}
+                              title={option.label}
                               disabled={!onAnswer || capped}
                               onClick={() =>
                                 setPicks((prev) => {
@@ -1105,21 +1139,32 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                             </button>
                           )
                         })}
+                        {companion ? (
+                          <button
+                            type="button"
+                            aria-pressed={!!others[f.propName]}
+                            className={others[f.propName] ? ELICIT_CHIP_ON : ELICIT_CHIP}
+                            disabled={!onAnswer}
+                            onClick={() => toggleOther(f, companion)}
+                            title={companion.description ?? companion.label}
+                          >
+                            Other…
+                          </button>
+                        ) : null}
                       </div>
                     )}
-                    {companion ? (
-                      <div className="flex min-w-0 items-center gap-[8px]">
-                        <span className={`flex-none ${ELICIT_HINT}`}>{companion.label}</span>
-                        <input
-                          className={`${ELICIT_INPUT} desktop:max-w-[320px]`}
-                          type="text"
-                          value={drafts[companion.propName] ?? ''}
-                          disabled={!onAnswer}
-                          aria-label={`${f.label} — ${companion.label}`}
-                          {...(companion.text?.maxLength !== undefined ? { maxLength: companion.text.maxLength } : {})}
-                          onChange={(e) => setDrafts((prev) => ({ ...prev, [companion.propName]: e.target.value }))}
-                        />
-                      </div>
+                    {companion && (f.kind === 'text' || f.kind === 'number' || others[f.propName]) ? (
+                      <input
+                        className={`${ELICIT_INPUT} desktop:max-w-[320px]`}
+                        type="text"
+                        autoFocus={!!others[f.propName]}
+                        value={drafts[companion.propName] ?? ''}
+                        disabled={!onAnswer}
+                        aria-label={`${f.label} — ${companion.label}`}
+                        placeholder={companion.label}
+                        {...(companion.text?.maxLength !== undefined ? { maxLength: companion.text.maxLength } : {})}
+                        onChange={(e) => setDrafts((prev) => ({ ...prev, [companion.propName]: e.target.value }))}
+                      />
                     ) : null}
                     {reason ? (
                       <span className="inline-flex min-w-0 items-start gap-[6px] font-sans text-[11.5px] font-normal leading-normal text-(--brand-soft-text)">
@@ -1142,7 +1187,7 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                 disabled={!onAnswer || rows.some((f) => !!rowInvalidReason(f, companionOf(fields, f), drafts, picks))}
                 onClick={() => onAnswer?.(formAnswer(fields, drafts, picks))}
               >
-                Submit
+                Submit answers
               </button>
               <button
                 type="button"
@@ -1215,7 +1260,8 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                     key={option.value}
                     type="button"
                     {...(multi ? { 'aria-pressed': on } : {})}
-                    className={on ? ELICIT_CHIP_ON : ELICIT_CHIP}
+                    className={(on ? ELICIT_CHIP_ON : ELICIT_CHIP) + chipFont(option)}
+                    title={option.label}
                     disabled={!onAnswer || capped}
                     onClick={() =>
                       multi

--- a/packages/web/src/components/console/views/SessionDetailView.tsx
+++ b/packages/web/src/components/console/views/SessionDetailView.tsx
@@ -912,9 +912,83 @@ function rowInvalidReason(
 const ELICIT_CHIP = 'chip max-w-full truncate rounded-sm disabled:cursor-default disabled:opacity-55'
 const ELICIT_CHIP_ON =
   'chip max-w-full truncate rounded-sm border-(--brand) bg-(--brand) text-white disabled:cursor-default disabled:opacity-55'
+// The "Other" affordance is an option the agent did not offer, so it wears the soft accent
+// rather than the solid one a real pick gets.
+const ELICIT_CHIP_SOFT = 'chip max-w-full truncate rounded-sm text-(--text-tertiary) disabled:opacity-55'
+const ELICIT_CHIP_SOFT_ON =
+  'chip max-w-full truncate rounded-sm border-(--brand-soft-border) bg-(--brand-soft) text-(--brand-soft-text) disabled:opacity-55'
+const ELICIT_ROW_BASE =
+  'flex w-full min-w-0 cursor-pointer items-start gap-[9px] rounded-sm border px-[11px] py-[8px] text-left font-sans text-[13px] font-medium leading-[1.45] disabled:cursor-default disabled:opacity-55'
+const ELICIT_ROW = `${ELICIT_ROW_BASE} border-(--border-default) bg-(--surface-card) text-(--text-secondary) hover:border-(--border-strong) hover:bg-(--surface-hover)`
+const ELICIT_ROW_ON = `${ELICIT_ROW_BASE} border-(--brand) bg-(--brand-soft) text-(--text-primary)`
+const ELICIT_ROW_SOFT = `${ELICIT_ROW_BASE} border-(--border-default) bg-(--surface-card) text-(--text-tertiary) hover:border-(--border-strong) hover:bg-(--surface-hover)`
+const ELICIT_ROW_SOFT_ON = `${ELICIT_ROW_BASE} border-(--brand-soft-border) bg-(--brand-soft) text-(--brand-soft-text)`
 const ELICIT_INPUT = 'inp w-full min-w-0 bg-(--surface-app) disabled:cursor-default disabled:opacity-55'
-// A chip whose label IS its value reads as the literal the agent will receive, not as prose.
-const chipFont = (option: { label: string; value: string }) => (option.label === option.value ? ' font-mono' : '')
+// An option long enough to be a sentence cannot be a chip: a row of them would either
+// truncate the answer away or wrap into a ragged block. One such option turns the whole
+// question into a list — the options stay comparable only if they are all shaped alike.
+const LONG_OPTION = 22
+const asList = (options: { label: string }[]) => options.some((o) => o.label.length > LONG_OPTION)
+
+/** One offered option, as a chip or — where the question went long — as a full-width row.
+ *  `staged` marks the selection the card is holding until Submit; a card that answers on the
+ *  tap itself shows no indicator, because there is no held state for one to report. */
+function ElicitOption({
+  label,
+  on,
+  list,
+  soft,
+  mono,
+  staged,
+  multi,
+  disabled,
+  onPick
+}: {
+  label: string
+  on: boolean
+  list: boolean
+  soft?: boolean
+  mono?: boolean
+  staged?: boolean
+  multi?: boolean
+  disabled: boolean
+  onPick: () => void
+}) {
+  const cls = list
+    ? soft
+      ? on
+        ? ELICIT_ROW_SOFT_ON
+        : ELICIT_ROW_SOFT
+      : on
+        ? ELICIT_ROW_ON
+        : ELICIT_ROW
+    : soft
+      ? on
+        ? ELICIT_CHIP_SOFT_ON
+        : ELICIT_CHIP_SOFT
+      : on
+        ? ELICIT_CHIP_ON
+        : ELICIT_CHIP
+  return (
+    <button
+      type="button"
+      {...(staged || multi ? { 'aria-pressed': on } : {})}
+      className={cls + (mono ? ' font-mono' : '')}
+      disabled={disabled}
+      title={label}
+      onClick={onPick}
+    >
+      {list && staged ? (
+        <span
+          className={`mt-[2px] grid size-[14px] flex-none place-items-center border ${multi ? 'rounded-[4px]' : 'rounded-full'} ${on ? 'border-(--brand) bg-(--brand)' : 'border-(--border-strong) bg-(--surface-card)'}`}
+        >
+          {on ? <span className={`size-[6px] bg-white ${multi ? 'rounded-[1px]' : 'rounded-full'}`} /> : null}
+        </span>
+      ) : null}
+      <span className="min-w-0">{label}</span>
+    </button>
+  )
+}
 const ELICIT_HINT = 'font-sans text-[11.5px] font-normal leading-normal text-(--text-tertiary)'
 const ELICIT_ACTIONS = 'flex flex-wrap items-center gap-[8px] border-t border-(--border-subtle) pt-[11px]'
 
@@ -960,7 +1034,7 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
   // The head reads the card's phase before the reader reaches a control: accent edge, icon, and
   // — for a form long enough to scroll past its own question — how much of it is still open.
   const edge = settled ? settled.edge : 'border-l-(--brand)'
-  const headIcon = settled ? settled.icon : consent ? 'external-link' : 'message-circle-question-mark'
+  const headIcon = settled ? settled.icon : consent ? 'external-link' : 'message-square-dot'
   const headColor = settled ? settled.color : 'var(--brand)'
   // The head names the ask in one line; anything the agent wrote past that first line reads as
   // the preamble it is, above the questions rather than as a paragraph-long title.
@@ -1059,6 +1133,7 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
               const reason = rowInvalidReason(f, companion, drafts, picks)
               const hint =
                 f.kind === 'multi-enum' ? selectionHint(f.multi?.minItems ?? 0, f.multi?.maxItems) : undefined
+              const list = asList(f.options)
               return (
                 <div
                   key={f.propName}
@@ -1105,7 +1180,13 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                         onChange={(e) => setDrafts((prev) => ({ ...prev, [f.propName]: e.target.value }))}
                       />
                     ) : (
-                      <div className="flex min-w-0 flex-wrap items-center gap-[6px]">
+                      <div
+                        className={
+                          list
+                            ? 'flex min-w-0 flex-col gap-[6px] desktop:max-w-[520px]'
+                            : 'flex min-w-0 flex-wrap items-center gap-[6px]'
+                        }
+                      >
                         {f.options.map((option) => {
                           const held = picks[f.propName] ?? []
                           const on = held.includes(option.value)
@@ -1114,14 +1195,16 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                           const cap = f.kind === 'multi-enum' ? f.multi?.maxItems : undefined
                           const capped = !on && cap !== undefined && held.length >= cap
                           return (
-                            <button
+                            <ElicitOption
                               key={option.value}
-                              type="button"
-                              aria-pressed={on}
-                              className={(on ? ELICIT_CHIP_ON : ELICIT_CHIP) + chipFont(option)}
-                              title={option.label}
+                              label={option.label}
+                              on={on}
+                              list={list}
+                              mono={option.label === option.value}
+                              staged
+                              multi={f.kind === 'multi-enum'}
                               disabled={!onAnswer || capped}
-                              onClick={() =>
+                              onPick={() =>
                                 setPicks((prev) => {
                                   const was = prev[f.propName] ?? []
                                   if (was.includes(option.value))
@@ -1134,28 +1217,25 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
                                   }
                                 })
                               }
-                            >
-                              {option.label}
-                            </button>
+                            />
                           )
                         })}
                         {companion ? (
-                          <button
-                            type="button"
-                            aria-pressed={!!others[f.propName]}
-                            className={others[f.propName] ? ELICIT_CHIP_ON : ELICIT_CHIP}
+                          <ElicitOption
+                            label="Other…"
+                            on={!!others[f.propName]}
+                            list={list}
+                            soft
+                            staged={list}
                             disabled={!onAnswer}
-                            onClick={() => toggleOther(f, companion)}
-                            title={companion.description ?? companion.label}
-                          >
-                            Other…
-                          </button>
+                            onPick={() => toggleOther(f, companion)}
+                          />
                         ) : null}
                       </div>
                     )}
                     {companion && (f.kind === 'text' || f.kind === 'number' || others[f.propName]) ? (
                       <input
-                        className={`${ELICIT_INPUT} desktop:max-w-[320px]`}
+                        className={`${ELICIT_INPUT} ${list ? 'desktop:max-w-[340px]' : 'font-mono desktop:max-w-[260px]'}`}
                         type="text"
                         autoFocus={!!others[f.propName]}
                         value={drafts[companion.propName] ?? ''}
@@ -1249,28 +1329,35 @@ function ElicitationCard({ step, onAnswer }: { step: FmtStep; onAnswer?: (value:
           </div>
         ) : (
           <div className="flex w-full min-w-0 flex-col gap-[10px]">
-            <div className="flex min-w-0 flex-wrap items-center gap-[6px]">
+            <div
+              className={
+                asList(elicit.options)
+                  ? 'flex min-w-0 flex-col gap-[6px] desktop:max-w-[520px]'
+                  : 'flex min-w-0 flex-wrap items-center gap-[6px]'
+              }
+            >
               {elicit.options.map((option) => {
                 const on = picked.includes(option.value)
                 // At the cap, the options still unpicked stop taking a tap — an answer the card
                 // would have to refuse should not look available in the first place.
                 const capped = !!multi && !on && max !== undefined && picked.length >= max
                 return (
-                  <button
+                  <ElicitOption
                     key={option.value}
-                    type="button"
-                    {...(multi ? { 'aria-pressed': on } : {})}
-                    className={(on ? ELICIT_CHIP_ON : ELICIT_CHIP) + chipFont(option)}
-                    title={option.label}
+                    label={option.label}
+                    on={on}
+                    list={asList(elicit.options)}
+                    mono={option.label === option.value}
+                    // A single-choice card answers on the tap, so it holds nothing an
+                    // indicator could report; a multi-select does.
+                    {...(multi ? { staged: true, multi: true } : {})}
                     disabled={!onAnswer || capped}
-                    onClick={() =>
+                    onPick={() =>
                       multi
                         ? setPicked((prev) => (on ? prev.filter((v) => v !== option.value) : [...prev, option.value]))
                         : onAnswer?.(option.value)
                     }
-                  >
-                    {option.label}
-                  </button>
+                  />
                 )
               })}
             </div>


### PR DESCRIPTION
The webchat elicitation card (#1816, #1817) had drifted from the design it was drawn from. Four things read wrong on a real AskUserQuestion form:

- every question stood a labelled `Other` box open beneath its options, so a three-question form was mostly empty inputs
- the description sat on its own line under the label instead of riding its baseline
- the counter and the primary read as a bare `2/3` / `Submit`, with no clock
- a long ask filled the head as a paragraph-long title

## What changed

- **A question's box is behind its own `Other…` chip.** Opening it discloses the input; closing it drops the draft, so a value the reader can no longer see is never part of the answer. A box the schema handed a default opens showing it.
- Picking an option still leaves the box alone — a required question legitimately answers with both its pick and its custom text (#1815, #1817), and clearing on pick would cut that.
- An option chip whose label **is** its value renders in mono, the way the design reads literals. Every option chip also names itself on hover, so one too long for the card is readable rather than just truncated.
- The description rides the label's baseline; `optional` loses its parentheses; `required` keeps the brand color.
- The head keeps one line and anything past it renders as the preamble it is, above the questions. The counter says `2/3 answered`, and the row's own clock sits at the far edge.
- The form's primary is `Submit answers` (a single-value card still says `Submit`).

## Not adopted from the design

The design's footer reads `Blank optional answers are sent as null`, but the implementation omits an untouched optional field entirely rather than sending null — `formAnswer` builds the record that way and the daemon accepts it. The truthful `Optional answers left blank are not sent` stays; changing it would mean changing the answer semantics, not the copy.

## Tests

`SessionDetailView.elicitation.test.tsx` follows the new interaction (it opens a question's box before typing) and gains one case: closing the box drops the draft, and the card then answers with the options alone. 74 passed across the `SessionDetailView*` files; typecheck, prettier and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)