### PR TITLE
fix(daemon): let a Codex turn ask a structured question

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -30,7 +30,8 @@ import {
   type ClaudeProtectedSettings,
   ULTRACODE_EFFORT
 } from '../runtime-defs/claude-runtime.js'
-import { runtimeExecutableHints } from '../runtime-defs/executable-hints.js'
+import { isCodexRuntimeDef, runtimeExecutableHints } from '../runtime-defs/executable-hints.js'
+import { codexConfigWithUserInputTool } from '../runtimes/codex-config.js'
 import {
   LocalDriver,
   type AcpSandboxLaunch,
@@ -660,6 +661,14 @@ export class AcpHost {
         `acp: account-app isolation disabled by daemon config for ${appIsolation.runtime}; ` +
           `signed-in account apps/connectors may be inherited${detail}`
       )
+    }
+    // Codex offers `request_user_input` only when configured on; enable it exactly when this host services session elicitations.
+    if (this.opts.onElicit && (this.opts.runtimeId === 'codex-acp' || isCodexRuntimeDef(this.runtime))) {
+      try {
+        env.CODEX_CONFIG = codexConfigWithUserInputTool(env.CODEX_CONFIG)
+      } catch (err) {
+        this.opts.log?.warn(`acp: leaving Codex's request_user_input tool off — ${(err as Error).message}`)
+      }
     }
     // NOTE: the memory-backend env (disable the runtime's own memory for `managed`,
     // or redirect it under the private runtime HOME for `native`) is assembled by the daemon

--- a/packages/daemon/src/runtime-defs/executable-hints.ts
+++ b/packages/daemon/src/runtime-defs/executable-hints.ts
@@ -8,7 +8,7 @@ export interface RuntimeExecutableHint {
 }
 
 /** A codex-acp runtime (its command/args reference `codex-acp`), including the managed npx fork. */
-function isCodexRuntimeDef(runtime: RuntimeDef): boolean {
+export function isCodexRuntimeDef(runtime: RuntimeDef): boolean {
   return [runtime.command, ...runtime.args].some((part) => /(?:^|[\\/@])codex-acp(?:@[^\\/]*)?$/i.test(part))
 }
 

--- a/packages/daemon/src/runtimes/codex-config.ts
+++ b/packages/daemon/src/runtimes/codex-config.ts
@@ -81,3 +81,15 @@ export function codexConfigWithBaseUrlFillIn(raw: string | undefined, baseUrl: s
   if (typeof config.openai_base_url === 'string' && config.openai_base_url.trim()) return undefined
   return codexConfigWithBaseUrl(raw, baseUrl)
 }
+
+// Codex offers `request_user_input` — the only path from a Codex turn to our ACP form elicitation — in
+// Default mode only behind this feature; verified against @openai/codex-linux-x64 bundled with
+// codex-acp@1.10.0 (the `[tools] experimental_request_user_input` knob alone changes nothing there).
+export function codexConfigWithUserInputTool(raw: string | undefined): string {
+  const config = objectFromJson(raw, 'CODEX_CONFIG')
+  const features = record(config.features, 'CODEX_CONFIG.features')
+  return JSON.stringify({
+    ...config,
+    features: { ...features, default_mode_request_user_input: true }
+  })
+}

--- a/packages/daemon/test/acp-host.test.ts
+++ b/packages/daemon/test/acp-host.test.ts
@@ -365,7 +365,8 @@ async function runIsolatedFixture(
   name: string,
   value: string,
   log?: { info: (message: string) => void; warn: (message: string) => void },
-  isolateAccountApps?: boolean
+  isolateAccountApps?: boolean,
+  servicesElicitations?: boolean
 ): Promise<string[]> {
   const updates: string[] = []
   const host = new AcpHost(
@@ -381,6 +382,7 @@ async function runIsolatedFixture(
       env: { AC_ECHO_NAME: name, [name]: value },
       runtimeId,
       isolateAccountApps,
+      ...(servicesElicitations ? { onElicit: async () => undefined } : {}),
       ...(log
         ? {
             log: {
@@ -423,6 +425,24 @@ describe('AcpHost — account-bound app isolation', () => {
     const echoed = out.find((line) => line.startsWith('env:'))?.slice('env:'.length)
     expect(JSON.parse(echoed ?? '')).toEqual({ features: { apps: false } })
     expect(warns.join('\n')).toContain('ignoring unsafe inherited CODEX_CONFIG')
+  })
+
+  it("enables Codex's request_user_input tool when the host services elicitations", async () => {
+    const raw = JSON.stringify({ model: 'gpt-test', features: { apps: true } })
+    const out = await runIsolatedFixture('codex-acp', 'CODEX_CONFIG', raw, undefined, undefined, true)
+
+    const echoed = out.find((line) => line.startsWith('env:'))?.slice('env:'.length)
+    expect(JSON.parse(echoed ?? '')).toEqual({
+      model: 'gpt-test',
+      features: { apps: false, default_mode_request_user_input: true }
+    })
+  })
+
+  it('leaves it off for a headless Codex host that would decline the question', async () => {
+    const out = await runIsolatedFixture('codex-acp', 'CODEX_CONFIG', JSON.stringify({ model: 'gpt-test' }))
+
+    const echoed = out.find((line) => line.startsWith('env:'))?.slice('env:'.length)
+    expect(JSON.parse(echoed ?? '')).toEqual({ model: 'gpt-test', features: { apps: false } })
   })
 
   it('forces Claude.ai MCP servers off in the spawned process', async () => {

--- a/packages/daemon/test/codex-config.test.ts
+++ b/packages/daemon/test/codex-config.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { CODEX_DEFAULT_ENDPOINT, codexGatewayAuthRequest } from '../src/runtimes/codex-config.js'
+import {
+  CODEX_DEFAULT_ENDPOINT,
+  codexConfigWithUserInputTool,
+  codexGatewayAuthRequest
+} from '../src/runtimes/codex-config.js'
 
 describe('codexGatewayAuthRequest', () => {
   it('carries the pair as one gateway grant — base routed, key in the auth header', () => {
@@ -17,5 +21,28 @@ describe('codexGatewayAuthRequest', () => {
 
   it('names the runtime default endpoint an endpoint-less key falls through to', () => {
     expect(CODEX_DEFAULT_ENDPOINT).toBe('https://api.openai.com/v1')
+  })
+})
+
+describe('codexConfigWithUserInputTool', () => {
+  it('turns on the feature that puts request_user_input in a Default-mode tool list', () => {
+    expect(JSON.parse(codexConfigWithUserInputTool(undefined))).toEqual({
+      features: { default_mode_request_user_input: true }
+    })
+  })
+
+  it('merges into the features table instead of replacing the account-apps switch', () => {
+    const raw = JSON.stringify({ model: 'gpt-test', features: { apps: false, memories: false } })
+    expect(JSON.parse(codexConfigWithUserInputTool(raw))).toEqual({
+      model: 'gpt-test',
+      features: { apps: false, memories: false, default_mode_request_user_input: true }
+    })
+  })
+
+  it('rejects a malformed config rather than silently dropping it', () => {
+    expect(() => codexConfigWithUserInputTool('not-json')).toThrow('CODEX_CONFIG must be a valid JSON object')
+    expect(() => codexConfigWithUserInputTool(JSON.stringify({ features: 'all' }))).toThrow(
+      'CODEX_CONFIG.features must be a JSON object'
+    )
   })
 })


### PR DESCRIPTION
## What

A `codex-acp` session could never reach AgentConnect's ACP form elicitation. Everything
between the two ends was already wired — the daemon advertises
`elicitation: { form: {}, url: {} }` (`acp-host.ts`), and codex-acp implements
`item/tool/requestUserInput` → `elicitation/create` — but Codex itself offers the
`request_user_input` tool in Default mode only behind the `default_mode_request_user_input`
feature, which is off by default.

So the model had no such tool. Observed on a real session: it searched its MCP resource
templates, then `rg`'d the daemon and Codex state directories for a form schema, found
nothing, and answered in prose that interactive forms are unavailable — advising the user
to "switch to Plan mode", which codex-acp does not expose (`AgentMode.all()` is
read-only / agent / agent-full-access). That advice comes from Codex's own
`<collaboration_mode>` prompt, which names Default and Plan and says to use the tool
"only when it is listed in the available tools for this turn".

## How

- `codexConfigWithUserInputTool()` in `runtimes/codex-config.ts` merges the feature into
  `CODEX_CONFIG.features` one level deep, so it cannot clobber the `apps: false` /
  `memories: false` switches other seams set there.
- `AcpHost.start()` applies it after all caller env is merged, for a Codex runtime, gated on
  `opts.onElicit` being present — i.e. exactly when this host services session elicitations.
  That gate is host-level, so it excludes an `AcpHost` built without an answerer (the runtime
  prober, the chat CLI) but NOT the daemon's own background passes, which share an agent's
  host: a distillation / dream / commit-message pass can see the tool, and the coordinator
  declines its request because the pass has no pending turn. Malformed inherited
  `CODEX_CONFIG` warns and leaves the tool off rather than blocking startup, matching the
  account-app isolation seam above it.
- `isCodexRuntimeDef` is exported from `runtime-defs/executable-hints.ts` rather than a
  second copy of the predicate.

## Verification

- Driven end to end against a real `codex-acp` + a minimal ACP client advertising
  `elicitation.form`, two runs per arm:
  - with the feature → `elicitation/create` arrives with the full form schema (one field
    per question plus the per-question `__other` field the console already folds in #1817).
  - without it → no elicitation; the model emits a markdown pseudo-form.
  - `[tools] experimental_request_user_input = { enabled = true }` alone → no elicitation.
    That knob is inert in the Codex build bundled with `codex-acp@1.10.0` (and is a struct,
    not a bool, so a bare `true` fails Codex's config parse).
- New tests: three pure-function cases for the merge (including the features-table merge and
  malformed-input rejection) and two `AcpHost` cases through the env-echo fixture — the tool
  on for an elicitation-servicing host, off for a headless one.
- `test/codex-config.test.ts`, `test/acp-host.test.ts`, `test/account-apps.test.ts`,
  `test/elicit-decline-notice.test.ts`: 112 passed. Every test file referencing
  `CODEX_CONFIG`: 182 passed. `typecheck` / `eslint` / `prettier` clean.

Not covered: the webchat card rendering of a Codex-authored form was not exercised against a
live daemon — only the ACP payload was.
