### PR TITLE
feat(daemon): a Slack elicitation offers a multi-select and a Confirm

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1599,6 +1599,8 @@ export class Daemon {
       statusInfoForKey: (key) => this.statusInfoForKey(key),
       handlePermissionChoice: (a) => this.permissions.handlePermissionChoice(a),
       handleElicitChoice: (a) => this.permissions.handleElicitChoice(a),
+      handleElicitSelect: (a) => this.permissions.noteElicitSelection(a),
+      handleElicitConfirm: (a) => void this.permissions.confirmElicitSelection(a),
       handleDiscordSelect: (a) => this.commands.handleDiscordSelect(a),
       handleTelegramCallback: (cb, conn) => this.commands.handleTelegramCallback(cb, conn),
       slackShortcutSession: (shortcut, srcIntegrationIds) =>
@@ -7644,6 +7646,10 @@ export class Daemon {
       await this.permissions.handlePermissionChoice({ ...payload, actor })
     } else if (payload.kind === 'elicitation-choice') {
       await this.permissions.handleElicitChoice({ requestId: payload.requestId, value: payload.value, actor })
+    } else if (payload.kind === 'elicitation-select') {
+      this.permissions.noteElicitSelection({ requestId: payload.requestId, values: payload.values, actor })
+    } else if (payload.kind === 'elicitation-confirm') {
+      await this.permissions.confirmElicitSelection({ requestId: payload.requestId, actor })
     } else {
       await this.commands.handleStatusAction({ kind: 'cancel', sessionKey: msg.sessionKey, actor })
     }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1599,7 +1599,6 @@ export class Daemon {
       statusInfoForKey: (key) => this.statusInfoForKey(key),
       handlePermissionChoice: (a) => this.permissions.handlePermissionChoice(a),
       handleElicitChoice: (a) => this.permissions.handleElicitChoice(a),
-      handleElicitSelect: (a) => this.permissions.noteElicitSelection(a),
       handleElicitConfirm: (a) => void this.permissions.confirmElicitSelection(a),
       handleDiscordSelect: (a) => this.commands.handleDiscordSelect(a),
       handleTelegramCallback: (cb, conn) => this.commands.handleTelegramCallback(cb, conn),
@@ -7646,10 +7645,12 @@ export class Daemon {
       await this.permissions.handlePermissionChoice({ ...payload, actor })
     } else if (payload.kind === 'elicitation-choice') {
       await this.permissions.handleElicitChoice({ requestId: payload.requestId, value: payload.value, actor })
-    } else if (payload.kind === 'elicitation-select') {
-      this.permissions.noteElicitSelection({ requestId: payload.requestId, values: payload.values, actor })
     } else if (payload.kind === 'elicitation-confirm') {
-      await this.permissions.confirmElicitSelection({ requestId: payload.requestId, actor })
+      await this.permissions.confirmElicitSelection({
+        requestId: payload.requestId,
+        values: payload.values,
+        actor
+      })
     } else {
       await this.commands.handleStatusAction({ kind: 'cancel', sessionKey: msg.sessionKey, actor })
     }

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -44,6 +44,7 @@ import {
   fieldAccepts,
   multiSelectAccepts,
   numberAccepts,
+  SLACK_DM_ELICIT_SURFACE,
   SLACK_ELICIT_SURFACE,
   textAccepts,
   WEBCHAT_ELICIT_SURFACE
@@ -245,6 +246,13 @@ type PendingElicit = PendingElicitSurface & {
    *  Present ⇒ `propName`/`kind`/`form` mean nothing — the card has no field, and its only
    *  answers are consent (this same URL back) or Dismiss. */
   url?: { elicitationId: string; url: string }
+  /** A MULTI-SELECT Slack card's in-progress selection — the last whole selection Slack sent for
+   *  it. It lives here, on the card's own record, because nothing else can hold it: the relay
+   *  persists no message content, and Confirm's `value` is fixed when the card is rendered. Freed
+   *  with the card, since every settle path drops the record. Seeded from the schema's `default`,
+   *  so an untouched Confirm submits exactly what the card was posted showing. Relayed, never
+   *  trusted: `multiSelectAccepts` re-derives it against the card at Confirm. */
+  selected?: string[]
   approval: boolean
   resolve: (res: CreateElicitationResponse) => void
 }
@@ -691,7 +699,7 @@ export class PermissionCoordinator {
     const card =
       rec.kind === 'permission'
         ? buildPermissionCard(requestId, rec.params, sessionTarget)
-        : (buildElicitationCard(requestId, rec.params, sessionTarget) ?? [])
+        : (buildElicitationCard(requestId, rec.params, sessionTarget, SLACK_DM_ELICIT_SURFACE) ?? [])
     const fromSlack = p.plan.platform === 'slack'
     const sourceUrl =
       fromSlack && p.conn instanceof SlackConnection
@@ -744,7 +752,7 @@ export class PermissionCoordinator {
           .catch(() => {})
       return
     }
-    const elicit = rec.kind === 'elicitation' ? elicitTarget(rec.params, SLACK_ELICIT_SURFACE) : null
+    const elicit = rec.kind === 'elicitation' ? elicitTarget(rec.params, SLACK_DM_ELICIT_SURFACE) : null
     live.notify = {
       target,
       conn,
@@ -899,7 +907,7 @@ export class PermissionCoordinator {
     } else if (notify.propName && notify.valueKind) {
       // Same card builder, same re-derivation: the actor checks above say who tapped, not what
       // this card offered, so an unoffered value is dropped and the DM card stays live.
-      const target = elicitTarget(rec.params, SLACK_ELICIT_SURFACE)
+      const target = elicitTarget(rec.params, SLACK_DM_ELICIT_SURFACE)
       if (!target || !fieldAccepts(target, value)) return
       const chosen = notify.valueKind === 'boolean' ? value === 'true' : value
       res = { action: 'accept', content: { [notify.propName]: chosen } }
@@ -1422,6 +1430,9 @@ export class PermissionCoordinator {
       params,
       propName: target.propName,
       kind: target.kind,
+      ...(target.kind === 'multi-enum'
+        ? { selected: Array.isArray(target.defaultValue) ? target.defaultValue : [] }
+        : {}),
       approval: isApproval,
       surface: 'slack',
       conn,
@@ -1925,6 +1936,30 @@ export class PermissionCoordinator {
         .updateBlocks(rec.channel, rec.ts, buildElicitationResolvedCard(rec.params, decision), 'Input received', true)
         .catch(() => {})
     rec.resolve(res)
+  }
+
+  /** A change on a multi-select card's `multi_static_select` (SlackDeps.onElicitSelect): remember
+   *  the WHOLE selection Slack re-sent, so Confirm has something to submit. Not an answer and not
+   *  a resolution — the card stays live, nothing is validated here, and Confirm's own
+   *  re-derivation is what makes a selection an answer. No-op for any other card. */
+  noteElicitSelection(a: { requestId: string; values: string[]; actor?: InteractionActor }): void {
+    const rec = this.pendingElicits.get(a.requestId)
+    if (!rec || rec.surface !== 'slack' || rec.kind !== 'multi-enum' || rec.url) return
+    rec.selected = a.values
+  }
+
+  /** A tapped Confirm on a multi-select card (SlackDeps.onElicitConfirm): submit the selection
+   *  last seen for this request through the same answer path a button click takes, so the accepted
+   *  content, the re-derivation and the settled card are one implementation. A selection outside
+   *  `minItems`/`maxItems` is refused there and the card stays live. */
+  async confirmElicitSelection(a: { requestId: string; actor?: InteractionActor }): Promise<void> {
+    const rec = this.pendingElicits.get(a.requestId)
+    if (!rec || rec.surface !== 'slack' || rec.kind !== 'multi-enum' || rec.url) return
+    await this.handleElicitChoice({
+      requestId: a.requestId,
+      value: rec.selected ?? [],
+      ...(a.actor ? { actor: a.actor } : {})
+    })
   }
 
   /** Resolve every outstanding elicitation for a session as `cancel` — ACP's cancellation

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -246,13 +246,6 @@ type PendingElicit = PendingElicitSurface & {
    *  Present ⇒ `propName`/`kind`/`form` mean nothing — the card has no field, and its only
    *  answers are consent (this same URL back) or Dismiss. */
   url?: { elicitationId: string; url: string }
-  /** A MULTI-SELECT Slack card's in-progress selection — the last whole selection Slack sent for
-   *  it. It lives here, on the card's own record, because nothing else can hold it: the relay
-   *  persists no message content, and Confirm's `value` is fixed when the card is rendered. Freed
-   *  with the card, since every settle path drops the record. Seeded from the schema's `default`,
-   *  so an untouched Confirm submits exactly what the card was posted showing. Relayed, never
-   *  trusted: `multiSelectAccepts` re-derives it against the card at Confirm. */
-  selected?: string[]
   approval: boolean
   resolve: (res: CreateElicitationResponse) => void
 }
@@ -1430,9 +1423,6 @@ export class PermissionCoordinator {
       params,
       propName: target.propName,
       kind: target.kind,
-      ...(target.kind === 'multi-enum'
-        ? { selected: Array.isArray(target.defaultValue) ? target.defaultValue : [] }
-        : {}),
       approval: isApproval,
       surface: 'slack',
       conn,
@@ -1938,26 +1928,19 @@ export class PermissionCoordinator {
     rec.resolve(res)
   }
 
-  /** A change on a multi-select card's `multi_static_select` (SlackDeps.onElicitSelect): remember
-   *  the WHOLE selection Slack re-sent, so Confirm has something to submit. Not an answer and not
-   *  a resolution — the card stays live, nothing is validated here, and Confirm's own
-   *  re-derivation is what makes a selection an answer. No-op for any other card. */
-  noteElicitSelection(a: { requestId: string; values: string[]; actor?: InteractionActor }): void {
-    const rec = this.pendingElicits.get(a.requestId)
-    if (!rec || rec.surface !== 'slack' || rec.kind !== 'multi-enum' || rec.url) return
-    rec.selected = a.values
-  }
-
-  /** A tapped Confirm on a multi-select card (SlackDeps.onElicitConfirm): submit the selection
-   *  last seen for this request through the same answer path a button click takes, so the accepted
-   *  content, the re-derivation and the settled card are one implementation. A selection outside
-   *  `minItems`/`maxItems` is refused there and the card stays live. */
-  async confirmElicitSelection(a: { requestId: string; actor?: InteractionActor }): Promise<void> {
+  /** A tapped Confirm on a multi-select card (SlackDeps.onElicitConfirm). `values` is the
+   *  selection carried by that tap's own Slack payload, so it is the state THIS reader confirmed:
+   *  no selection is held between interactions, which is what keeps one reader's pick from being
+   *  submitted as another's answer and makes the order two interactions arrive in irrelevant. It
+   *  is a relayed value like any other, so it goes through the same answer path a button tap
+   *  takes — `multiSelectAccepts` re-derives it against the card, and a selection outside
+   *  `minItems`/`maxItems` is refused there with the card left live. */
+  async confirmElicitSelection(a: { requestId: string; values: string[]; actor?: InteractionActor }): Promise<void> {
     const rec = this.pendingElicits.get(a.requestId)
     if (!rec || rec.surface !== 'slack' || rec.kind !== 'multi-enum' || rec.url) return
     await this.handleElicitChoice({
       requestId: a.requestId,
-      value: rec.selected ?? [],
+      value: a.values,
       ...(a.actor ? { actor: a.actor } : {})
     })
   }

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -74,6 +74,8 @@ export interface PlatformActionSink {
   statusInfoForKey: NonNullable<SlackDeps['onStatusInfo']>
   handlePermissionChoice: NonNullable<SlackDeps['onPermissionChoice']>
   handleElicitChoice: NonNullable<SlackDeps['onElicitChoice']>
+  handleElicitSelect: NonNullable<SlackDeps['onElicitSelect']>
+  handleElicitConfirm: NonNullable<SlackDeps['onElicitConfirm']>
   handleDiscordSelect: NonNullable<DiscordDeps['onSelectAction']>
   handleTelegramCallback(cb: TelegramCallback, conn: TelegramConnection): Promise<void>
   slackShortcutSession(
@@ -214,6 +216,8 @@ export class ConnectionReconciler {
       onStatusInfo: (key) => this.host.statusInfoForKey(key),
       onPermissionChoice: (a) => this.host.handlePermissionChoice(a),
       onElicitChoice: (a) => this.host.handleElicitChoice(a),
+      onElicitSelect: (a) => this.host.handleElicitSelect(a),
+      onElicitConfirm: (a) => this.host.handleElicitConfirm(a),
       log: this.log,
       boltDebug: this.host.boltDebug()
     }
@@ -503,6 +507,8 @@ export class ConnectionReconciler {
             onStatusInfo: (key) => this.host.statusInfoForKey(key),
             onPermissionChoice: (a) => this.host.handlePermissionChoice(a),
             onElicitChoice: (a) => this.host.handleElicitChoice(a),
+            onElicitSelect: (a) => this.host.handleElicitSelect(a),
+            onElicitConfirm: (a) => this.host.handleElicitConfirm(a),
             log: this.log
           },
           this.host.slackAppFactory()

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -74,7 +74,6 @@ export interface PlatformActionSink {
   statusInfoForKey: NonNullable<SlackDeps['onStatusInfo']>
   handlePermissionChoice: NonNullable<SlackDeps['onPermissionChoice']>
   handleElicitChoice: NonNullable<SlackDeps['onElicitChoice']>
-  handleElicitSelect: NonNullable<SlackDeps['onElicitSelect']>
   handleElicitConfirm: NonNullable<SlackDeps['onElicitConfirm']>
   handleDiscordSelect: NonNullable<DiscordDeps['onSelectAction']>
   handleTelegramCallback(cb: TelegramCallback, conn: TelegramConnection): Promise<void>
@@ -216,7 +215,6 @@ export class ConnectionReconciler {
       onStatusInfo: (key) => this.host.statusInfoForKey(key),
       onPermissionChoice: (a) => this.host.handlePermissionChoice(a),
       onElicitChoice: (a) => this.host.handleElicitChoice(a),
-      onElicitSelect: (a) => this.host.handleElicitSelect(a),
       onElicitConfirm: (a) => this.host.handleElicitConfirm(a),
       log: this.log,
       boltDebug: this.host.boltDebug()
@@ -507,7 +505,6 @@ export class ConnectionReconciler {
             onStatusInfo: (key) => this.host.statusInfoForKey(key),
             onPermissionChoice: (a) => this.host.handlePermissionChoice(a),
             onElicitChoice: (a) => this.host.handleElicitChoice(a),
-            onElicitSelect: (a) => this.host.handleElicitSelect(a),
             onElicitConfirm: (a) => this.host.handleElicitConfirm(a),
             log: this.log
           },

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -26,6 +26,8 @@ import {
   buildStatusModal,
   buildStatusUnavailableModal,
   decodePermValue,
+  selectedOptionsFromState,
+  type SlackBlockActionsState,
   type SlackStreamChunk,
   type StatusBarInfo,
   type StatusModalIdentity
@@ -441,12 +443,10 @@ export interface SlackDeps {
    *  (render.buildElicitationCard). `value` is the chosen option's wire value, or null
    *  for the Dismiss button (decline). `actor` gates DM-card clicks (slack-approval-dm.md §6.4). */
   onElicitChoice?: (a: { requestId: string; value: string | null; actor?: InteractionActor }) => void
-  /** Fired on every change of a multi-select elicitation card's `multi_static_select`, with the
-   *  WHOLE current selection Slack re-sends each time — not a delta, and not yet an answer. */
-  onElicitSelect?: (a: { requestId: string; values: string[]; actor?: InteractionActor }) => void
-  /** Fired when a user taps that card's Confirm button: submit the selection last seen for this
-   *  request. The button carries no selection, since only the daemon holds one. */
-  onElicitConfirm?: (a: { requestId: string; actor?: InteractionActor }) => void
+  /** Fired when a user taps a multi-select elicitation card's Confirm button. `values` is the
+   *  selection read out of THAT tap's own message state, so it is the state this reader
+   *  confirmed — nothing is tracked between a selection change and the Confirm. */
+  onElicitConfirm?: (a: { requestId: string; values: string[]; actor?: InteractionActor }) => void
   newTraceId: () => string
   log?: Logger
   /** When true, hand Bolt LogLevel.DEBUG so socket-mode internals are visible. */
@@ -484,6 +484,9 @@ type BlockActionArgs = {
     view?: { id?: string; private_metadata?: string }
     actions?: { block_id?: string }[]
     user?: { id?: string; username?: string; name?: string }
+    /** The message's full state, which a Block Kit tap carries — how a Confirm reads the
+     *  selection its own card was showing (`selectedOptionsFromState`). */
+    state?: SlackBlockActionsState
   }
 }
 
@@ -1208,23 +1211,19 @@ export class SlackConnection implements PlatformConnection {
       await ack()
       if (action.value) this.deps.onElicitChoice?.({ requestId: action.value, value: null, actor: actorOf(body) })
     })
-    // Multi-select card (buildElicitationCard, `multi-enum`): the select delivers an interaction
-    // per change whose `selected_options` is the whole current selection, and its `action_id`
-    // names the request, so deselecting everything reports too; Confirm submits what was seen.
-    this.app.action(new RegExp(`^${ELICIT_SELECT_ACTION}:`), async ({ ack, action, body }) => {
+    // Multi-select card (buildElicitationCard, `multi-enum`): a selection change is acked and
+    // otherwise ignored — nothing is tracked between interactions, so there is nothing to record.
+    this.app.action(new RegExp(`^${ELICIT_SELECT_ACTION}:`), async ({ ack }) => {
       await ack()
-      const requestId = action.action_id?.slice(ELICIT_SELECT_ACTION.length + 1)
-      const selected = (action as { selected_options?: { value?: string }[] }).selected_options ?? []
-      if (!requestId || selected.some((o) => typeof o.value !== 'string')) return
-      this.deps.onElicitSelect?.({
-        requestId,
-        values: selected.map((o) => o.value as string),
-        actor: actorOf(body)
-      })
     })
+    // Confirm reads the selection out of its OWN payload's message state, keyed by the select's
+    // action id: that is the state this reader tapped Confirm on, whoever else touched the card.
     this.app.action(ELICIT_CONFIRM_ACTION, async ({ ack, action, body }) => {
       await ack()
-      if (action.value) this.deps.onElicitConfirm?.({ requestId: action.value, actor: actorOf(body) })
+      if (!action.value) return
+      const values = selectedOptionsFromState(body?.state, `${ELICIT_SELECT_ACTION}:${action.value}`)
+      // No state for the select ⇒ nothing this tap can be said to confirm; the card stays live.
+      if (values) this.deps.onElicitConfirm?.({ requestId: action.value, values, actor: actorOf(body) })
     })
     log?.debug('slack: app.start → opening Socket Mode WebSocket (wss://…slack.com)…')
     await this.app.start()

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -17,7 +17,9 @@ import type { UploadAnchor, UploadFailReason, UploadOutcome } from '../mcp/ops/c
 import {
   STATUS_ACTION,
   ELICIT_ACTION_PREFIX,
+  ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
+  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   PERMISSION_UPDATE_ACTION,
   buildPermissionUpdateCard,
@@ -439,6 +441,12 @@ export interface SlackDeps {
    *  (render.buildElicitationCard). `value` is the chosen option's wire value, or null
    *  for the Dismiss button (decline). `actor` gates DM-card clicks (slack-approval-dm.md §6.4). */
   onElicitChoice?: (a: { requestId: string; value: string | null; actor?: InteractionActor }) => void
+  /** Fired on every change of a multi-select elicitation card's `multi_static_select`, with the
+   *  WHOLE current selection Slack re-sends each time — not a delta, and not yet an answer. */
+  onElicitSelect?: (a: { requestId: string; values: string[]; actor?: InteractionActor }) => void
+  /** Fired when a user taps that card's Confirm button: submit the selection last seen for this
+   *  request. The button carries no selection, since only the daemon holds one. */
+  onElicitConfirm?: (a: { requestId: string; actor?: InteractionActor }) => void
   newTraceId: () => string
   log?: Logger
   /** When true, hand Bolt LogLevel.DEBUG so socket-mode internals are visible. */
@@ -1199,6 +1207,24 @@ export class SlackConnection implements PlatformConnection {
     this.app.action(ELICIT_DISMISS_ACTION, async ({ ack, action, body }) => {
       await ack()
       if (action.value) this.deps.onElicitChoice?.({ requestId: action.value, value: null, actor: actorOf(body) })
+    })
+    // Multi-select card (buildElicitationCard, `multi-enum`): the select delivers an interaction
+    // per change whose `selected_options` is the whole current selection, and its `action_id`
+    // names the request, so deselecting everything reports too; Confirm submits what was seen.
+    this.app.action(new RegExp(`^${ELICIT_SELECT_ACTION}:`), async ({ ack, action, body }) => {
+      await ack()
+      const requestId = action.action_id?.slice(ELICIT_SELECT_ACTION.length + 1)
+      const selected = (action as { selected_options?: { value?: string }[] }).selected_options ?? []
+      if (!requestId || selected.some((o) => typeof o.value !== 'string')) return
+      this.deps.onElicitSelect?.({
+        requestId,
+        values: selected.map((o) => o.value as string),
+        actor: actorOf(body)
+      })
+    })
+    this.app.action(ELICIT_CONFIRM_ACTION, async ({ ack, action, body }) => {
+      await ack()
+      if (action.value) this.deps.onElicitConfirm?.({ requestId: action.value, actor: actorOf(body) })
     })
     log?.debug('slack: app.start → opening Socket Mode WebSocket (wss://…slack.com)…')
     await this.app.start()

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -1,8 +1,10 @@
 import type { CreateElicitationRequest, RequestPermissionRequest, SessionUpdate } from '@agentclientprotocol/sdk'
 import {
   ELICIT_ACTION_PREFIX,
+  ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
   ELICIT_FORM_FIELD_CAP,
+  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   SLACK_STATUS_ACTION,
   encodePermValue,
@@ -10,7 +12,9 @@ import {
 } from '@agentconnect.md/protocol'
 export {
   ELICIT_ACTION_PREFIX,
+  ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
+  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   decodePermValue,
   encodePermValue
@@ -612,20 +616,42 @@ export type ElicitKind = 'enum' | 'boolean' | 'multi-enum' | 'text' | 'number'
  *  cannot see, which is exactly how an over-long option list used to be quietly cut to fit. */
 export interface ElicitSurface {
   kinds: ReadonlySet<ElicitKind>
-  /** The most options one field may offer here. `undefined` is no limit — webchat renders them all. */
-  maxOptions?: number
+  /** Per-kind option limits, because one surface's controls do not all hold the same list: on
+   *  Slack a row of buttons and a select menu differ in BOTH how many options they take and how
+   *  long an option's wire value may be. A kind absent from the map is unlimited on both counts —
+   *  webchat renders them all. Widening one kind's limit never widens another's. */
+  optionLimits?: Partial<Record<ElicitKind, { maxOptions?: number; maxOptionValue?: number }>>
 }
 
 /** Slack allows 25 elements in one `actions` block and wraps them across lines, so the card can
  *  offer every option of a list this long and still keep its Dismiss button. A longer list is
  *  declined: no card is built from a slice of it, which is what made a pick a misreported answer. */
-const SLACK_ELICIT_MAX_OPTIONS = 24
+const SLACK_ELICIT_MAX_BUTTONS = 24
 
-/** Slack's card is a row of buttons: it can express "pick one", not "pick several, then
- *  confirm", and it has no field to type into, so those forms are declined there instead. */
+/** Slack's own cap on a select menu's `options`, and on one option's `value` — the second is why
+ *  #1813 refused a `static_select` for single-select, where a button's 2000 fits any enum value.
+ *  A multi-select has no button to fall back to, so an option value this long declines instead. */
+const SLACK_SELECT_MAX_OPTIONS = 100
+const SLACK_SELECT_VALUE_CAP = 75
+
+/** Slack renders single-select and boolean as a row of buttons, and multi-select as a
+ *  `multi_static_select` plus a Confirm button — the select cannot submit on its own. It still has
+ *  no field to type into, so `text`/`number` forms are declined there. The two controls carry
+ *  different lists, which is why the limits are per kind rather than one number for the surface. */
 export const SLACK_ELICIT_SURFACE: ElicitSurface = {
+  kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum']),
+  optionLimits: {
+    enum: { maxOptions: SLACK_ELICIT_MAX_BUTTONS },
+    'multi-enum': { maxOptions: SLACK_SELECT_MAX_OPTIONS, maxOptionValue: SLACK_SELECT_VALUE_CAP }
+  }
+}
+
+/** The approval DM's card is a button row whose taps settle through the editor path, which holds
+ *  no per-card selection — so a multi-select could be shown there but never confirmed, and it is
+ *  withheld rather than posted dead. Otherwise exactly the in-channel Slack surface. */
+export const SLACK_DM_ELICIT_SURFACE: ElicitSurface = {
   kinds: new Set<ElicitKind>(['enum', 'boolean']),
-  maxOptions: SLACK_ELICIT_MAX_OPTIONS
+  optionLimits: { enum: { maxOptions: SLACK_ELICIT_MAX_BUTTONS } }
 }
 
 /** Webchat's card has toggles, a confirm control and a typed input, so it takes every kind,
@@ -905,9 +931,13 @@ function elicitCandidates(params: CreateElicitationRequest, surface: ElicitSurfa
   }
   if (p.mode !== 'form') return []
   const renderable = surface.kinds
-  // More options than the surface can show is not a renderable field: a card built from part of
-  // the list would report the reader's pick as their answer to the whole question.
-  const fits = (options: readonly unknown[]) => surface.maxOptions === undefined || options.length <= surface.maxOptions
+  // A list this surface's control for that kind cannot hold whole is not a renderable field: a
+  // card built from part of it would report the reader's pick as their answer to the question.
+  const fits = (kind: ElicitKind, options: readonly { value: string }[]) => {
+    const limits = surface.optionLimits?.[kind]
+    if (limits?.maxOptions !== undefined && options.length > limits.maxOptions) return false
+    return limits?.maxOptionValue === undefined || options.every((o) => o.value.length <= limits.maxOptionValue!)
+  }
   const found: ElicitTarget[] = []
   for (const [name, prop] of Object.entries(p.requestedSchema?.properties ?? {})) {
     const owner = customAnswerOwner(prop)
@@ -936,7 +966,8 @@ function elicitCandidates(params: CreateElicitationRequest, surface: ElicitSurfa
         : Array.isArray(en)
           ? en.map((v) => ({ value: String(v), label: clampTo(String(v), 75) }))
           : []
-      if (options.length && fits(options) && renderable.has('enum')) keep({ propName: name, kind: 'enum', options })
+      if (options.length && fits('enum', options) && renderable.has('enum'))
+        keep({ propName: name, kind: 'enum', options })
       // Free text is the string with nothing to choose from — an enumerated one is a pick,
       // and typing into it would let an unoffered value through.
       if (!options.length && renderable.has('text')) keep(textTarget(name, prop))
@@ -949,7 +980,7 @@ function elicitCandidates(params: CreateElicitationRequest, surface: ElicitSurfa
       const max = itemBound(prop.maxItems)
       // Bounds that admit only the empty selection, or none at all, are not a question.
       const askable = max === undefined || (max > 0 && max >= (min ?? 0))
-      if (options.length && fits(options) && askable)
+      if (options.length && fits('multi-enum', options) && askable)
         keep({
           propName: name,
           kind: 'multi-enum',
@@ -1136,22 +1167,85 @@ const SLACK_SECTION_TEXT_CAP = 3000
  *  trailing `…` is the only mark a cut ever gets, so a shorter cap is a quieter one. */
 const ELICIT_MESSAGE_CAP = SLACK_SECTION_TEXT_CAP - 200
 
+/** What a multi-select card says its bounds are, so a refused Confirm is not the reader's first
+ *  news of them. Slack enforces the maximum itself (`max_selected_items`); the minimum is the
+ *  one a reader can break, and the daemon re-validates both either way. Empty when unbounded. */
+function selectionHint(target: ElicitTarget): string {
+  const { minItems: min, maxItems: max } = target
+  if (min !== undefined && max !== undefined) return min === max ? `Select exactly ${min}.` : `Select ${min} to ${max}.`
+  if (min !== undefined) return `Select at least ${min}.`
+  return max !== undefined ? `Select up to ${max}.` : ''
+}
+
+/** The multi-select half of {@link buildElicitationCard}: a `multi_static_select` carrying every
+ *  option, a Confirm button and Dismiss, in ONE actions block so all three share the block_id the
+ *  relay routes on. The select re-delivers the whole selection on each change and never submits,
+ *  so Confirm carries only the request id and the daemon confirms the selection it last saw. The
+ *  request id rides the select's own `action_id`, not its option values: DESELECTING EVERYTHING is
+ *  a change too, and a card named only by its options could not report one. Slack caps an option
+ *  value at 75 chars — a card that would overflow it is not built at all rather than posted with
+ *  an option Slack would reject. Pure. */
+function buildMultiSelectElements(requestId: string, target: ElicitTarget): unknown[] | null {
+  const options = target.options.map((o) => ({
+    text: { type: 'plain_text', text: o.label, emoji: true },
+    value: o.value
+  }))
+  if (options.some((o) => o.value.length > SLACK_SELECT_VALUE_CAP)) return null
+  const seeded = Array.isArray(target.defaultValue) ? new Set(target.defaultValue) : null
+  const initial = seeded ? target.options.map((o, i) => (seeded.has(o.value) ? options[i] : null)).filter(Boolean) : []
+  return [
+    {
+      type: 'multi_static_select',
+      action_id: `${ELICIT_SELECT_ACTION}:${requestId}`,
+      placeholder: { type: 'plain_text', text: 'Select options', emoji: true },
+      options,
+      ...(initial.length ? { initial_options: initial } : {}),
+      ...(target.maxItems !== undefined ? { max_selected_items: target.maxItems } : {})
+    },
+    {
+      type: 'button',
+      action_id: ELICIT_CONFIRM_ACTION as string,
+      text: { type: 'plain_text', text: 'Confirm', emoji: true },
+      style: 'primary',
+      value: requestId
+    },
+    {
+      type: 'button',
+      action_id: ELICIT_DISMISS_ACTION as string,
+      text: { type: 'plain_text', text: 'Dismiss', emoji: true },
+      value: requestId
+    }
+  ]
+}
+
 /**
- * Build the interactive elicitation card: the agent's `message`, an optional field title, and an
- * actions row carrying EVERY {@link elicitTarget} option as a button, plus a Dismiss button. The
- * choice rides each button `value` (`<requestId>|<optionValue>`). Returns null when the form
- * can't be rendered inline (caller declines) — a multi-select, which {@link SLACK_ELICIT_SURFACE}
- * withholds from this surface, or a list longer than that surface declares it can show, which the
- * reduction has already refused. Nothing here trims a list to fit. Pure.
+ * Build the interactive elicitation card: the agent's `message` and one actions row — EVERY
+ * {@link elicitTarget} option as a button for a single-select or boolean, or a
+ * `multi_static_select` plus Confirm for a multi-select — always with a Dismiss button. The choice
+ * rides each option's `value` (`<requestId>|<optionValue>`). Returns null when the form can't be
+ * rendered on `surface` (caller declines): a kind or an option list it does not claim, which the
+ * reduction has already refused, or a multi-select whose encoded option values Slack's select
+ * would reject. Nothing here trims a list to fit. Pure.
  */
 export function buildElicitationCard(
   requestId: string,
   params: CreateElicitationRequest,
-  sessionTarget?: string
+  sessionTarget?: string,
+  surface: ElicitSurface = SLACK_ELICIT_SURFACE
 ): unknown[] | null {
-  const target = elicitTarget(params, SLACK_ELICIT_SURFACE)
+  const target = elicitTarget(params, surface)
   if (!target) return null
   const message = elicitCardMessage(params)
+  if (target.kind === 'multi-enum') {
+    const elements = buildMultiSelectElements(requestId, target)
+    if (!elements) return null
+    const hint = selectionHint(target)
+    return [
+      { type: 'section', text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(message, ELICIT_MESSAGE_CAP)}` } },
+      ...(hint ? [{ type: 'context', elements: [{ type: 'mrkdwn', text: hint }] }] : []),
+      { type: 'actions', ...(sessionTarget ? { block_id: sessionTarget } : {}), elements }
+    ]
+  }
   const buttons = target.options.map((o, i) => ({
     type: 'button',
     action_id: `${ELICIT_ACTION_PREFIX}:${i}`,

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -17,7 +17,9 @@ export {
   ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   decodePermValue,
-  encodePermValue
+  encodePermValue,
+  selectedOptionsFromState,
+  type SlackBlockActionsState
 } from '@agentconnect.md/protocol'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { flattenUnsafeLinks } from '../messages/agent-links.js'

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1989,8 +1989,8 @@ describe('Slack interactive status bar', () => {
       content: { language: 'TypeScript' }
     })
 
-    // A multi-select card's two relayed verbs: the select records the whole selection Slack
-    // re-sent, and Confirm submits it through the same re-derivation a button click takes.
+    // A multi-select card's one relayed verb: Confirm, carrying the selection the tapping
+    // reader's own payload held, submitted through the re-derivation a button click takes.
     const multiResolved = vi.fn()
     ;(daemon as any).permissions.pendingElicits.set('elicit-2', {
       agentId: 'bot-a',
@@ -2005,7 +2005,6 @@ describe('Slack interactive status bar', () => {
       },
       propName: 'checks',
       kind: 'multi-enum',
-      selected: [],
       approval: false,
       surface: 'slack',
       conn: { updateBlocks, workspaceId: () => 'T1' },
@@ -2016,16 +2015,9 @@ describe('Slack interactive status bar', () => {
     expect(
       await (daemon as any).handleRelayMsg(
         action({
-          msgId: 'action-elicit-select',
-          payload: { kind: 'elicitation-select', requestId: 'elicit-2', values: ['lint', 'test'] }
+          msgId: 'action-elicit-confirm',
+          payload: { kind: 'elicitation-confirm', requestId: 'elicit-2', values: ['lint', 'test'] }
         }),
-        () => {}
-      )
-    ).toEqual({ msgId: 'action-elicit-select', accepted: true })
-    expect(multiResolved).not.toHaveBeenCalled() // a change is not an answer
-    expect(
-      await (daemon as any).handleRelayMsg(
-        action({ msgId: 'action-elicit-confirm', payload: { kind: 'elicitation-confirm', requestId: 'elicit-2' } }),
         () => {}
       )
     ).toEqual({ msgId: 'action-elicit-confirm', accepted: true })

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -1989,6 +1989,48 @@ describe('Slack interactive status bar', () => {
       content: { language: 'TypeScript' }
     })
 
+    // A multi-select card's two relayed verbs: the select records the whole selection Slack
+    // re-sent, and Confirm submits it through the same re-derivation a button click takes.
+    const multiResolved = vi.fn()
+    ;(daemon as any).permissions.pendingElicits.set('elicit-2', {
+      agentId: 'bot-a',
+      sessionId: 'acp-1',
+      params: {
+        mode: 'form',
+        message: 'Which checks?',
+        requestedSchema: {
+          type: 'object',
+          properties: { checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] }, minItems: 1 } }
+        }
+      },
+      propName: 'checks',
+      kind: 'multi-enum',
+      selected: [],
+      approval: false,
+      surface: 'slack',
+      conn: { updateBlocks, workspaceId: () => 'T1' },
+      channel: 'C1',
+      ts: 'card-3',
+      resolve: multiResolved
+    })
+    expect(
+      await (daemon as any).handleRelayMsg(
+        action({
+          msgId: 'action-elicit-select',
+          payload: { kind: 'elicitation-select', requestId: 'elicit-2', values: ['lint', 'test'] }
+        }),
+        () => {}
+      )
+    ).toEqual({ msgId: 'action-elicit-select', accepted: true })
+    expect(multiResolved).not.toHaveBeenCalled() // a change is not an answer
+    expect(
+      await (daemon as any).handleRelayMsg(
+        action({ msgId: 'action-elicit-confirm', payload: { kind: 'elicitation-confirm', requestId: 'elicit-2' } }),
+        () => {}
+      )
+    ).toEqual({ msgId: 'action-elicit-confirm', accepted: true })
+    expect(multiResolved).toHaveBeenCalledWith({ action: 'accept', content: { checks: ['lint', 'test'] } })
+
     // A DM approval card's click (slack-approval-dm.md §5.3) bypasses the in-conversation
     // session gate — its origin session may be webchat — and authorizes in the coordinator.
     // With no CP verify available in this harness it fails closed: admitted, not decided.

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -739,9 +739,8 @@ describe('webchat answers a multi-select elicitation with a list', () => {
     const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation({ minItems: 1 }))
     await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
     const [requestId] = (daemon as any).permissions.pendingElicits.keys()
-    // A browser card holds its own selection, so the Slack select/confirm verbs are not its wire.
-    ;(daemon as any).permissions.noteElicitSelection({ requestId, values: ['lint'] })
-    await (daemon as any).permissions.confirmElicitSelection({ requestId })
+    // A browser card carries its own answer, so Slack's Confirm verb is not its wire.
+    await (daemon as any).permissions.confirmElicitSelection({ requestId, values: ['lint'] })
     expect((daemon as any).permissions.pendingElicits.size).toBe(1)
     await (daemon as any).permissions.handleElicitChoice({
       requestId,
@@ -817,9 +816,9 @@ describe('a Slack card offers every option or none', () => {
 
 // ── multi-select on Slack (issue #1794, Slack column) ───────────────────────
 // A `multi_static_select` expresses "pick several" but never submits on its own: Slack delivers
-// an interaction per selection change, each carrying the WHOLE current selection, and the card
-// needs its own Confirm. The in-progress selection lives on the card's pending record, since the
-// relay persists no message content and Confirm's `value` is fixed when the card is rendered.
+// an interaction per selection change, and the card needs its own Confirm. NOTHING is tracked
+// between the two — a Confirm carries the selection out of its own payload's message state — so
+// two readers of one card, and two interactions in any order, cannot answer for each other.
 
 describe('a Slack multi-select card confirms the selection it was sent', () => {
   const selectOf = (posted: any[][]) => posted[0]!.at(-1)!.elements[0]
@@ -831,6 +830,8 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     await vi.waitFor(() => expect(daemon.permissions.pendingElicits.get(requestId).ts).toBe('ts-1'))
     return requestId
   }
+  const confirm = (daemon: any, requestId: string, values: string[], actor?: { userId: string }) =>
+    daemon.permissions.confirmElicitSelection({ requestId, values, ...(actor ? { actor } : {}) })
 
   it('cards a select plus Confirm, and accepts the confirmed list', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
@@ -845,15 +846,34 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     expect(elements.map((e) => e.type)).toEqual(['multi_static_select', 'button', 'button'])
     expect(elements.slice(1).map((e) => e.text.text)).toEqual(['Confirm', 'Dismiss'])
     expect(selectOf(posted).action_id).toBe(`${ELICIT_SELECT_ACTION}:${requestId}`)
+    expect(updated).toHaveLength(0) // nothing has answered it yet
 
-    // Slack re-sends the whole selection on each change; the daemon holds the last one it saw.
-    ;(daemon as any).permissions.noteElicitSelection({ requestId, values: ['lint'] })
-    ;(daemon as any).permissions.noteElicitSelection({ requestId, values: ['lint', 'build'] })
-    expect(updated).toHaveLength(0) // a change is not an answer: the card is still live
-    await (daemon as any).permissions.confirmElicitSelection({ requestId })
+    await confirm(daemon, requestId, ['lint', 'build'])
     await expect(answered).resolves.toEqual({ action: 'accept', content: { checks: ['lint', 'build'] } })
     // The settled card names the chosen option LABELS, as #1801 settled a browser card.
     expect(updated[0]![0].text.text).toContain(':white_check_mark: lint, build')
+  })
+
+  // The bug this shape exists to prevent: a per-card record of "the last selection seen" is
+  // shared by every reader and ordered by processing, so A's Confirm could submit B's picks —
+  // an `accept` asserting one reader answered what another chose, and every value in it is a
+  // valid option, so no whitelist can catch it. A Confirm carrying its own snapshot cannot.
+  it('answers each reader with the selection THEIR Confirm carried', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    slackPending(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation({ minItems: 1 }))
+    const requestId = await liveCard(daemon)
+
+    // A selects lint, B selects test — neither reaches the daemon; only a Confirm does. A then
+    // confirms the card A was looking at, and that is what the runtime is told.
+    await confirm(daemon, requestId, ['lint'], { userId: 'U-A' })
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { checks: ['lint'] } })
+
+    // And the same card confirmed by B alone answers with B's own selection, not A's.
+    const second = (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation({ minItems: 1 }))
+    const secondId = await liveCard(daemon)
+    await confirm(daemon, secondId, ['test'], { userId: 'U-B' })
+    await expect(second).resolves.toEqual({ action: 'accept', content: { checks: ['test'] } })
   })
 
   it('refuses a selection outside minItems/maxItems and leaves the card live', async () => {
@@ -865,23 +885,22 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
       multiElicitation({ minItems: 2, maxItems: 2 })
     )
     const requestId = await liveCard(daemon)
-    const confirm = async (values: string[]) => {
-      ;(daemon as any).permissions.noteElicitSelection({ requestId, values })
-      await (daemon as any).permissions.confirmElicitSelection({ requestId })
-    }
-    await (daemon as any).permissions.confirmElicitSelection({ requestId }) // untouched: nothing selected
-    await confirm(['lint']) // below minItems
-    await confirm(['lint', 'test', 'build']) // above maxItems — Slack's own cap is not the gate
-    await confirm(['lint', 'lint']) // a repeat is not two picks
-    await confirm(['lint', 'rm -rf /']) // a relayed value the card never offered
+    await confirm(daemon, requestId, []) // an emptied select is an answer, and not a legal one here
+    await confirm(daemon, requestId, ['lint']) // below minItems
+    await confirm(daemon, requestId, ['lint', 'test', 'build']) // above maxItems — Slack's own cap is not the gate
+    await confirm(daemon, requestId, ['lint', 'lint']) // a repeat is not two picks
+    await confirm(daemon, requestId, ['lint', 'rm -rf /']) // a relayed value the card never offered
     expect((daemon as any).permissions.pendingElicits.size).toBe(1)
     expect(updated).toHaveLength(0)
 
-    await confirm(['lint', 'test'])
+    await confirm(daemon, requestId, ['lint', 'test'])
     await expect(answered).resolves.toEqual({ action: 'accept', content: { checks: ['lint', 'test'] } })
   })
 
-  it('confirms the schema default when the reader never touched the select', async () => {
+  // The card still SHOWS the schema default (`initial_options`), which is what Slack then reports
+  // as that select's state for a reader who never touched it — so the seeding lives on the card
+  // alone, and the daemon holds no copy of it to go stale.
+  it('shows the schema default as the select’s own initial state', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const { posted } = slackPending(daemon)
     const answered = (daemon as any).permissions.onAcpElicit(
@@ -891,7 +910,7 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     )
     const requestId = await liveCard(daemon)
     expect(selectOf(posted).initial_options.map((o: any) => o.value)).toEqual(['test'])
-    await (daemon as any).permissions.confirmElicitSelection({ requestId })
+    await confirm(daemon, requestId, ['test'])
     await expect(answered).resolves.toEqual({ action: 'accept', content: { checks: ['test'] } })
   })
 
@@ -900,7 +919,6 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     const { updated } = slackPending(daemon)
     const dismissed = (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation({ minItems: 1 }))
     const first = await liveCard(daemon)
-    ;(daemon as any).permissions.noteElicitSelection({ requestId: first, values: ['lint'] })
     await (daemon as any).permissions.handleElicitChoice({ requestId: first, value: null })
     await expect(dismissed).resolves.toEqual({ action: 'decline' })
     expect(updated[0]![0].text.text).toContain(':no_entry_sign: Dismissed')
@@ -909,7 +927,6 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     await liveCard(daemon)
     await (daemon as any).permissions.releaseElicits('agent-1', 's1')
     await expect(cancelled).resolves.toEqual({ action: 'cancel' })
-    // The selection is freed with the card: the record it lived on is gone.
     expect((daemon as any).permissions.pendingElicits.size).toBe(0)
   })
 
@@ -924,13 +941,12 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     expect(elicitTarget(over, WEBCHAT_ELICIT_SURFACE)?.options).toHaveLength(101)
   })
 
-  it('ignores a selection aimed at a card that is not a multi-select', async () => {
+  it('ignores a Confirm aimed at a card that is not a multi-select', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const { updated } = slackPending(daemon)
     const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', enumElicitation(['a', 'b']))
     const requestId = await liveCard(daemon)
-    ;(daemon as any).permissions.noteElicitSelection({ requestId, values: ['a'] })
-    await (daemon as any).permissions.confirmElicitSelection({ requestId })
+    await confirm(daemon, requestId, ['a'])
     expect((daemon as any).permissions.pendingElicits.size).toBe(1)
     expect(updated).toHaveLength(0)
     await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'a' })

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -10,7 +10,13 @@ import { join } from 'node:path'
 import { LocalStore } from '../src/store/local-store.js'
 import { listAgentPermissionRequests } from '../src/cp/config-apply-handlers.js'
 import { SlackConnection } from '../src/slack/connection.js'
-import { elicitForm, elicitTarget, SLACK_ELICIT_SURFACE, WEBCHAT_ELICIT_SURFACE } from '../src/slack/render.js'
+import {
+  ELICIT_SELECT_ACTION,
+  elicitForm,
+  elicitTarget,
+  SLACK_ELICIT_SURFACE,
+  WEBCHAT_ELICIT_SURFACE
+} from '../src/slack/render.js'
 
 /**
  * Auto-approve policy for the daemon's OWN built-in MCP tools (UX fix): a human should
@@ -725,18 +731,24 @@ describe('webchat answers a multi-select elicitation with a list', () => {
     await expect(dismissed).resolves.toEqual({ action: 'decline' })
   })
 
-  it('still declines a multi-select on a Slack turn, whose card cannot express it', async () => {
+  it('is unchanged by Slack learning the kind: the same list still answers a browser card', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending: any = installPending(daemon)
-    // A Slack turn: chat input cards, and a connection the elicitation path recognizes.
-    pending.plan.platform = 'slack'
-    pending.conn = Object.create(SlackConnection.prototype)
+    installWebchat(pending)
 
-    await expect(
-      (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation({ minItems: 1 }))
-    ).resolves.toBeUndefined()
-    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
-    // The same form IS renderable — just not here: webchat cards it.
+    const result = (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation({ minItems: 1 }))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    const [requestId] = (daemon as any).permissions.pendingElicits.keys()
+    // A browser card holds its own selection, so the Slack select/confirm verbs are not its wire.
+    ;(daemon as any).permissions.noteElicitSelection({ requestId, values: ['lint'] })
+    await (daemon as any).permissions.confirmElicitSelection({ requestId })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    await (daemon as any).permissions.handleElicitChoice({
+      requestId,
+      value: ['lint'],
+      webchatConversationId: 'conv-1'
+    })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { checks: ['lint'] } })
     expect(elicitTarget(multiElicitation({ minItems: 1 }), WEBCHAT_ELICIT_SURFACE)?.kind).toBe('multi-enum')
   })
 })
@@ -800,6 +812,129 @@ describe('a Slack card offers every option or none', () => {
     expect(posted).toHaveLength(0)
     // The same form is renderable where nothing declares a limit — webchat still shows them all.
     expect(elicitTarget(enumElicitation(many), WEBCHAT_ELICIT_SURFACE)?.options).toHaveLength(25)
+  })
+})
+
+// ── multi-select on Slack (issue #1794, Slack column) ───────────────────────
+// A `multi_static_select` expresses "pick several" but never submits on its own: Slack delivers
+// an interaction per selection change, each carrying the WHOLE current selection, and the card
+// needs its own Confirm. The in-progress selection lives on the card's pending record, since the
+// relay persists no message content and Confirm's `value` is fixed when the card is rendered.
+
+describe('a Slack multi-select card confirms the selection it was sent', () => {
+  const selectOf = (posted: any[][]) => posted[0]!.at(-1)!.elements[0]
+  /** The one live card's request id, once its posted `ts` is on the record — a settle before that
+   *  has no message to rewrite, which is the card path's own pre-existing race (#1821), not ours. */
+  const liveCard = async (daemon: any): Promise<string> => {
+    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
+    const [requestId] = daemon.permissions.pendingElicits.keys()
+    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.get(requestId).ts).toBe('ts-1'))
+    return requestId
+  }
+
+  it('cards a select plus Confirm, and accepts the confirmed list', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted, updated } = slackPending(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      multiElicitation({ minItems: 1, maxItems: 2 })
+    )
+    const requestId = await liveCard(daemon)
+    const elements = posted[0]!.at(-1)!.elements as any[]
+    expect(elements.map((e) => e.type)).toEqual(['multi_static_select', 'button', 'button'])
+    expect(elements.slice(1).map((e) => e.text.text)).toEqual(['Confirm', 'Dismiss'])
+    expect(selectOf(posted).action_id).toBe(`${ELICIT_SELECT_ACTION}:${requestId}`)
+
+    // Slack re-sends the whole selection on each change; the daemon holds the last one it saw.
+    ;(daemon as any).permissions.noteElicitSelection({ requestId, values: ['lint'] })
+    ;(daemon as any).permissions.noteElicitSelection({ requestId, values: ['lint', 'build'] })
+    expect(updated).toHaveLength(0) // a change is not an answer: the card is still live
+    await (daemon as any).permissions.confirmElicitSelection({ requestId })
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { checks: ['lint', 'build'] } })
+    // The settled card names the chosen option LABELS, as #1801 settled a browser card.
+    expect(updated[0]![0].text.text).toContain(':white_check_mark: lint, build')
+  })
+
+  it('refuses a selection outside minItems/maxItems and leaves the card live', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { updated } = slackPending(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      multiElicitation({ minItems: 2, maxItems: 2 })
+    )
+    const requestId = await liveCard(daemon)
+    const confirm = async (values: string[]) => {
+      ;(daemon as any).permissions.noteElicitSelection({ requestId, values })
+      await (daemon as any).permissions.confirmElicitSelection({ requestId })
+    }
+    await (daemon as any).permissions.confirmElicitSelection({ requestId }) // untouched: nothing selected
+    await confirm(['lint']) // below minItems
+    await confirm(['lint', 'test', 'build']) // above maxItems — Slack's own cap is not the gate
+    await confirm(['lint', 'lint']) // a repeat is not two picks
+    await confirm(['lint', 'rm -rf /']) // a relayed value the card never offered
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(updated).toHaveLength(0)
+
+    await confirm(['lint', 'test'])
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { checks: ['lint', 'test'] } })
+  })
+
+  it('confirms the schema default when the reader never touched the select', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      multiElicitation({ minItems: 1, default: ['test'] })
+    )
+    const requestId = await liveCard(daemon)
+    expect(selectOf(posted).initial_options.map((o: any) => o.value)).toEqual(['test'])
+    await (daemon as any).permissions.confirmElicitSelection({ requestId })
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { checks: ['test'] } })
+  })
+
+  it('takes Dismiss as decline and the turn ending as cancel', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { updated } = slackPending(daemon)
+    const dismissed = (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation({ minItems: 1 }))
+    const first = await liveCard(daemon)
+    ;(daemon as any).permissions.noteElicitSelection({ requestId: first, values: ['lint'] })
+    await (daemon as any).permissions.handleElicitChoice({ requestId: first, value: null })
+    await expect(dismissed).resolves.toEqual({ action: 'decline' })
+    expect(updated[0]![0].text.text).toContain(':no_entry_sign: Dismissed')
+
+    const cancelled = (daemon as any).permissions.onAcpElicit('agent-1', 's1', multiElicitation({ minItems: 1 }))
+    await liveCard(daemon)
+    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
+    await expect(cancelled).resolves.toEqual({ action: 'cancel' })
+    // The selection is freed with the card: the record it lived on is gone.
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+  })
+
+  it('declines a list past what a Slack select holds, rather than carding part of it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted } = slackPending(daemon)
+    const many = Array.from({ length: 101 }, (_, i) => `o${i}`)
+    const over = multiElicitation({ items: { type: 'string', enum: many } })
+    await expect((daemon as any).permissions.onAcpElicit('agent-1', 's1', over)).resolves.toBeUndefined()
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+    expect(posted).toHaveLength(0)
+    expect(elicitTarget(over, WEBCHAT_ELICIT_SURFACE)?.options).toHaveLength(101)
+  })
+
+  it('ignores a selection aimed at a card that is not a multi-select', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { updated } = slackPending(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', enumElicitation(['a', 'b']))
+    const requestId = await liveCard(daemon)
+    ;(daemon as any).permissions.noteElicitSelection({ requestId, values: ['a'] })
+    await (daemon as any).permissions.confirmElicitSelection({ requestId })
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(updated).toHaveLength(0)
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'a' })
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { pick: 'a' } })
   })
 })
 

--- a/packages/daemon/test/elicit-decline-notice.test.ts
+++ b/packages/daemon/test/elicit-decline-notice.test.ts
@@ -28,16 +28,28 @@ function formElicitation(overrides: Record<string, unknown> = {}): CreateElicita
   } as CreateElicitationRequest
 }
 
-/** A multi-select: renderable on webchat, never on a Slack button row. */
-function multiElicitation(overrides: Record<string, unknown> = {}): CreateElicitationRequest {
+/** A free-text field: renderable on webchat, never on Slack, which has no box to type into. */
+function unrenderableElicitation(overrides: Record<string, unknown> = {}): CreateElicitationRequest {
+  return formElicitation({
+    message: 'Which checks should I run?',
+    requestedSchema: {
+      type: 'object',
+      properties: { checks: { type: 'string' } },
+      required: ['checks']
+    },
+    ...overrides
+  })
+}
+
+/** A multi-select — which Slack renders as a select plus Confirm, so it keeps no notice. */
+function multiElicitation(): CreateElicitationRequest {
   return formElicitation({
     message: 'Which checks should I run?',
     requestedSchema: {
       type: 'object',
       properties: { checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] } } },
       required: ['checks']
-    },
-    ...overrides
+    }
   })
 }
 
@@ -95,7 +107,7 @@ function slackTurn(): { daemon: any; pending: any; notices: () => string[] } {
 describe('an elicitation declined for want of a surface says so in the channel', () => {
   it('posts the notice and still declines when a Slack card cannot express the form', async () => {
     const { daemon, notices } = slackTurn()
-    await expect(daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())).resolves.toBeUndefined()
+    await expect(daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())).resolves.toBeUndefined()
     expect(daemon.permissions.pendingElicits.size).toBe(0)
     expect(notices()).toHaveLength(1)
     expect(notices()[0]).toContain("this chat can't collect an answer for")
@@ -110,7 +122,9 @@ describe('an elicitation declined for want of a surface says so in the channel',
     await daemon.permissions.onAcpElicit(
       'agent-1',
       's1',
-      multiElicitation({ message: 'Sign in at [your account](https://evil.example/x) or https://evil.example/y' })
+      unrenderableElicitation({
+        message: 'Sign in at [your account](https://evil.example/x) or https://evil.example/y'
+      })
     )
     const text = notices()[0]!
     // The label form cannot survive as markup, and the bare URL cannot autolink.
@@ -125,17 +139,21 @@ describe('an elicitation declined for want of a surface says so in the channel',
       ...params,
       message: params.message.replace('hunter2', '••••')
     })
-    await daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation({ message: 'Is hunter2 still the token?' }))
+    await daemon.permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      unrenderableElicitation({ message: 'Is hunter2 still the token?' })
+    )
     expect(notices()[0]).toContain('Is •••• still the token?')
     expect(notices()[0]).not.toContain('hunter2')
   })
 
   it('collapses a repeated question to one notice, and lets a different question through', async () => {
     const { daemon, notices } = slackTurn()
-    await daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())
-    await daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())
+    await daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())
+    await daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())
     expect(notices()).toHaveLength(1)
-    await daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation({ message: 'And which runner?' }))
+    await daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation({ message: 'And which runner?' }))
     expect(notices()).toHaveLength(2)
     expect(notices()[1]).toContain('And which runner?')
   })
@@ -160,6 +178,14 @@ describe('an elicitation declined for want of a surface says so in the channel',
       heldText: '',
       messageEmitted: false
     }
+    void daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())
+    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
+    expect(notices()).toEqual([])
+    await daemon.permissions.releaseElicits('agent-1', 's1')
+  })
+
+  it('says nothing for a multi-select Slack now renders as a select plus Confirm', async () => {
+    const { daemon, notices } = slackTurn()
     void daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())
     await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
     expect(notices()).toEqual([])
@@ -200,7 +226,7 @@ describe('an elicitation declined for want of a surface says so in the channel',
       daemon.permissions.onAcpElicit(
         'agent-1',
         's1',
-        multiElicitation({ _meta: { codex_approval_kind: 'mcp_tool_call' } })
+        unrenderableElicitation({ _meta: { codex_approval_kind: 'mcp_tool_call' } })
       )
     ).resolves.toBeUndefined()
     expect(notices()).toEqual([])
@@ -209,14 +235,16 @@ describe('an elicitation declined for want of a surface says so in the channel',
   it('says nothing on a turn whose surface was deliberately suppressed', async () => {
     const suppressed = slackTurn()
     suppressed.pending.plan.approvalSurfaceSuppressed = true
-    await expect(suppressed.daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())).resolves.toEqual({
+    await expect(
+      suppressed.daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())
+    ).resolves.toEqual({
       action: 'cancel'
     })
     expect(suppressed.notices()).toEqual([])
 
     const quiet = slackTurn()
     quiet.pending.outputSuppressed = 'paused'
-    await expect(quiet.daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())).resolves.toEqual({
+    await expect(quiet.daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())).resolves.toEqual({
       action: 'cancel'
     })
     expect(quiet.notices()).toEqual([])

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -25,6 +25,7 @@ import {
   elicitTarget,
   elicitUrl,
   buildUrlConsentCard,
+  SLACK_DM_ELICIT_SURFACE,
   SLACK_ELICIT_SURFACE,
   WEBCHAT_ELICIT_SURFACE,
   multiSelectAccepts,
@@ -35,7 +36,9 @@ import {
   decodePermValue,
   PERMISSION_ACTION_PREFIX,
   ELICIT_ACTION_PREFIX,
+  ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
+  ELICIT_SELECT_ACTION,
   type SlackAction,
   type SlackAttributionInfo
 } from '../src/slack/render.js'
@@ -1672,17 +1675,94 @@ describe('elicitation card', () => {
     })
   })
 
-  it('leaves multi-select unrenderable on Slack, whose card would have to decline it', () => {
+  // #1794 Slack column: a `multi_static_select` CAN express "pick several", but it never submits
+  // on its own — so the card is a select plus its own Confirm, and Dismiss as always.
+  it('cards a multi-select as a select plus Confirm', () => {
+    const req = form({
+      colors: {
+        type: 'array',
+        items: {
+          anyOf: [
+            { const: '#FF0000', title: 'Red' },
+            { const: '#00FF00', title: 'Green' }
+          ]
+        },
+        minItems: 1,
+        maxItems: 2,
+        default: ['#00FF00']
+      }
+    })
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)?.kind).toBe('multi-enum')
+    const blocks = buildElicitationCard('elicit-1', req, 'shared-session-target') as any[]
+    // The bounds are on the card, so a refused Confirm is not the reader's first news of them.
+    expect(blocks[1]).toEqual({ type: 'context', elements: [{ type: 'mrkdwn', text: 'Select 1 to 2.' }] })
+    expect(blocks[2].block_id).toBe('shared-session-target')
+    const [select, confirm, dismiss] = blocks[2].elements
+    expect(select.type).toBe('multi_static_select')
+    // The request rides the select's OWN action_id: deselecting everything is a change too,
+    // and a card named only by its selected options could not report one.
+    expect(select.action_id).toBe(`${ELICIT_SELECT_ACTION}:elicit-1`)
+    expect(select.options.map((o: any) => [o.text.text, o.value])).toEqual([
+      ['Red', '#FF0000'],
+      ['Green', '#00FF00']
+    ])
+    expect(select.max_selected_items).toBe(2)
+    // Seeded from the schema's `default`, so an untouched Confirm submits what the card shows.
+    expect(select.initial_options).toEqual([
+      { text: { type: 'plain_text', text: 'Green', emoji: true }, value: '#00FF00' }
+    ])
+    expect([confirm.action_id, confirm.value]).toEqual([ELICIT_CONFIRM_ACTION, 'elicit-1'])
+    expect([dismiss.action_id, dismiss.value]).toEqual([ELICIT_DISMISS_ACTION, 'elicit-1'])
+  })
+
+  it('names an unbounded multi-select no bounds and seeds it nothing', () => {
     const req = form({ colors: { type: 'array', items: { type: 'string', enum: ['Red', 'Green'] } } })
-    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)).toBeNull()
-    expect(buildElicitationCard('elicit-1', req)).toBeNull()
+    const blocks = buildElicitationCard('elicit-1', req) as any[]
+    expect(blocks).toHaveLength(2) // no hint block: there is nothing to say
+    const select = blocks[1].elements[0]
+    expect(select.max_selected_items).toBeUndefined()
+    expect(select.initial_options).toBeUndefined()
+  })
+
+  // A select holds 100 options where an actions row of buttons holds 24, and caps one option's
+  // `value` at 75 chars where a button's is 2000 — so the limits are per kind, not per surface.
+  it('declines a multi-select past Slack’s own select limits', () => {
+    const items = (n: number) => ({ type: 'string', enum: Array.from({ length: n }, (_, i) => `o${i}`) })
+    const at = form({ colors: { type: 'array', items: items(100) } })
+    expect(elicitTarget(at, SLACK_ELICIT_SURFACE)?.options).toHaveLength(100)
+    expect((buildElicitationCard('elicit-100', at) as any[])[1].elements[0].options).toHaveLength(100)
+    const over = form({ colors: { type: 'array', items: items(101) } })
+    expect(elicitTarget(over, SLACK_ELICIT_SURFACE)).toBeNull()
+    expect(buildElicitationCard('elicit-101', over)).toBeNull()
+    // 25 buttons is past the actions row, but well inside the select — one kind's cap is its own.
+    expect(elicitTarget(form({ pick: { type: 'string', enum: items(25).enum } }), SLACK_ELICIT_SURFACE)).toBeNull()
+    expect(elicitTarget(form({ colors: { type: 'array', items: items(25) } }), SLACK_ELICIT_SURFACE)).not.toBeNull()
+    // A value Slack's select cannot carry: declined whole, never posted with the option cut.
+    const long = form({ colors: { type: 'array', items: { type: 'string', enum: ['ok', 'x'.repeat(76)] } } })
+    expect(elicitTarget(long, SLACK_ELICIT_SURFACE)).toBeNull()
+    expect(buildElicitationCard('elicit-long', long)).toBeNull()
+    // Webchat's own list is unlimited on both counts, exactly as before.
+    expect(elicitTarget(over, WEBCHAT_ELICIT_SURFACE)?.options).toHaveLength(101)
+    expect(elicitTarget(long, WEBCHAT_ELICIT_SURFACE)?.options).toHaveLength(2)
+  })
+
+  // The approval DM's taps settle through the editor path, which holds no per-card selection,
+  // so a multi-select there could be shown but never confirmed.
+  it('withholds a multi-select from the approval-DM surface', () => {
+    const req = form({ colors: { type: 'array', items: { type: 'string', enum: ['Red', 'Green'] } } })
+    expect(elicitTarget(req, SLACK_DM_ELICIT_SURFACE)).toBeNull()
+    expect(buildElicitationCard('elicit-1', req, undefined, SLACK_DM_ELICIT_SURFACE)).toBeNull()
+    // The button kinds it does render are unchanged there.
+    expect(
+      buildElicitationCard('elicit-1', form({ ok: { type: 'boolean' } }), undefined, SLACK_DM_ELICIT_SURFACE)
+    ).not.toBeNull()
   })
 
   it('skips a field the surface cannot render and takes the next one it can', () => {
-    // Slack passes over the array and cards the boolean, exactly as it did before the kind existed.
-    const req = form({ colors: { type: 'array', items: { type: 'string', enum: ['Red'] } }, ok: { type: 'boolean' } })
+    // Slack passes over the free-text field and cards the boolean; webchat renders both kinds.
+    const req = form({ name: { type: 'string' }, ok: { type: 'boolean' } })
     expect(elicitTarget(req, SLACK_ELICIT_SURFACE)?.propName).toBe('ok')
-    expect(elicitTarget(req, WEBCHAT_ELICIT_SURFACE)?.propName).toBe('colors')
+    expect(elicitTarget(req, WEBCHAT_ELICIT_SURFACE)?.propName).toBe('name')
   })
 
   it('declines an array the card cannot honestly answer', () => {

--- a/packages/daemon/test/slack-status-actor.test.ts
+++ b/packages/daemon/test/slack-status-actor.test.ts
@@ -7,11 +7,23 @@
  */
 import { describe, it, expect } from 'vitest'
 import { SlackConnection } from '../src/slack/connection.js'
-import { STATUS_ACTION, PERMISSION_ACTION_PREFIX, encodePermValue } from '../src/slack/render.js'
+import {
+  STATUS_ACTION,
+  ELICIT_CONFIRM_ACTION,
+  ELICIT_SELECT_ACTION,
+  PERMISSION_ACTION_PREFIX,
+  encodePermValue
+} from '../src/slack/render.js'
 
 type ActionArgs = {
   ack: () => Promise<void>
-  action: { action_id?: string; block_id?: string; value?: string; selected_option?: { value?: string } }
+  action: {
+    action_id?: string
+    block_id?: string
+    value?: string
+    selected_option?: { value?: string }
+    selected_options?: { value?: string }[]
+  }
   body?: { view?: { private_metadata?: string }; user?: { id?: string } }
 }
 type Handler = (args: ActionArgs) => Promise<void> | void
@@ -74,6 +86,38 @@ describe('slack status actions carry the acting user', () => {
     })
 
     expect(seen).toEqual([{ requestId: 'req-1', optionId: 'allow_always', actor: { userId: 'U-BOB' } }])
+  })
+
+  // A multi-select card is two interactions: the select re-sends the whole current selection on
+  // every change, its own action_id naming the request, and Confirm submits what was seen.
+  it('reports a multi-select card’s whole selection, then its Confirm', async () => {
+    const selected: unknown[] = []
+    const confirmed: unknown[] = []
+    const actions = await connect({
+      onElicitSelect: (a: unknown) => selected.push(a),
+      onElicitConfirm: (a: unknown) => confirmed.push(a)
+    })
+    const select = [...actions.entries()].find(([id]) => id.includes(`${ELICIT_SELECT_ACTION}:`))![1]
+
+    await select({
+      ack,
+      action: {
+        action_id: `${ELICIT_SELECT_ACTION}:elicit-9`,
+        selected_options: [{ value: 'lint' }, { value: 'test' }]
+      },
+      body: { user: { id: 'U-CAROL' } }
+    })
+    // Deselecting everything is a change too, and the action_id still names the card.
+    await select({ ack, action: { action_id: `${ELICIT_SELECT_ACTION}:elicit-9`, selected_options: [] }, body: {} })
+    // An option Slack sent without a value would make the list lie about what is selected.
+    await select({ ack, action: { action_id: `${ELICIT_SELECT_ACTION}:elicit-9`, selected_options: [{}] }, body: {} })
+    expect(selected).toEqual([
+      { requestId: 'elicit-9', values: ['lint', 'test'], actor: { userId: 'U-CAROL' } },
+      { requestId: 'elicit-9', values: [], actor: undefined }
+    ])
+
+    await actions.get(ELICIT_CONFIRM_ACTION)!({ ack, action: { value: 'elicit-9' }, body: { user: { id: 'U-DAN' } } })
+    expect(confirmed).toEqual([{ requestId: 'elicit-9', actor: { userId: 'U-DAN' } }])
   })
 
   it('leaves the actor absent when the payload names no user', async () => {

--- a/packages/daemon/test/slack-status-actor.test.ts
+++ b/packages/daemon/test/slack-status-actor.test.ts
@@ -24,7 +24,11 @@ type ActionArgs = {
     selected_option?: { value?: string }
     selected_options?: { value?: string }[]
   }
-  body?: { view?: { private_metadata?: string }; user?: { id?: string } }
+  body?: {
+    view?: { private_metadata?: string }
+    user?: { id?: string }
+    state?: { values?: Record<string, Record<string, { selected_options?: { value?: unknown }[] }>> }
+  }
 }
 type Handler = (args: ActionArgs) => Promise<void> | void
 
@@ -88,36 +92,51 @@ describe('slack status actions carry the acting user', () => {
     expect(seen).toEqual([{ requestId: 'req-1', optionId: 'allow_always', actor: { userId: 'U-BOB' } }])
   })
 
-  // A multi-select card is two interactions: the select re-sends the whole current selection on
-  // every change, its own action_id naming the request, and Confirm submits what was seen.
-  it('reports a multi-select card’s whole selection, then its Confirm', async () => {
-    const selected: unknown[] = []
+  // A multi-select card's Confirm reads its selection out of its OWN payload's message state
+  // (Slack has carried full state on `block_actions` since 2020-09-01), so what reaches the
+  // daemon is the state THIS reader tapped Confirm on — nothing is kept between interactions.
+  it('reports the selection a multi-select Confirm’s own payload carried', async () => {
     const confirmed: unknown[] = []
-    const actions = await connect({
-      onElicitSelect: (a: unknown) => selected.push(a),
-      onElicitConfirm: (a: unknown) => confirmed.push(a)
+    const actions = await connect({ onElicitConfirm: (a: unknown) => confirmed.push(a) })
+    const stateWith = (values: string[], block = 'blk-1') => ({
+      values: {
+        [block]: { [`${ELICIT_SELECT_ACTION}:elicit-9`]: { selected_options: values.map((value) => ({ value })) } }
+      }
     })
-    const select = [...actions.entries()].find(([id]) => id.includes(`${ELICIT_SELECT_ACTION}:`))![1]
+    const confirm = (state?: ReturnType<typeof stateWith>, user?: string) =>
+      actions.get(ELICIT_CONFIRM_ACTION)!({
+        ack,
+        action: { value: 'elicit-9' },
+        body: { ...(state !== undefined ? { state } : {}), ...(user ? { user: { id: user } } : {}) }
+      })
 
-    await select({
-      ack,
-      action: {
-        action_id: `${ELICIT_SELECT_ACTION}:elicit-9`,
-        selected_options: [{ value: 'lint' }, { value: 'test' }]
-      },
-      body: { user: { id: 'U-CAROL' } }
-    })
-    // Deselecting everything is a change too, and the action_id still names the card.
-    await select({ ack, action: { action_id: `${ELICIT_SELECT_ACTION}:elicit-9`, selected_options: [] }, body: {} })
-    // An option Slack sent without a value would make the list lie about what is selected.
-    await select({ ack, action: { action_id: `${ELICIT_SELECT_ACTION}:elicit-9`, selected_options: [{}] }, body: {} })
-    expect(selected).toEqual([
-      { requestId: 'elicit-9', values: ['lint', 'test'], actor: { userId: 'U-CAROL' } },
+    await confirm(stateWith(['lint', 'test']), 'U-DAN')
+    // Found by ACTION id, whichever block Slack grouped the select into.
+    await confirm(stateWith(['test'], 'another-block'), 'U-ERIN')
+    // An emptied select is a real answer; no state for it is not one, and reaches nothing.
+    await confirm(stateWith([]))
+    await confirm({ values: {} })
+    await confirm()
+    expect(confirmed).toEqual([
+      { requestId: 'elicit-9', values: ['lint', 'test'], actor: { userId: 'U-DAN' } },
+      { requestId: 'elicit-9', values: ['test'], actor: { userId: 'U-ERIN' } },
       { requestId: 'elicit-9', values: [], actor: undefined }
     ])
+  })
 
-    await actions.get(ELICIT_CONFIRM_ACTION)!({ ack, action: { value: 'elicit-9' }, body: { user: { id: 'U-DAN' } } })
-    expect(confirmed).toEqual([{ requestId: 'elicit-9', actor: { userId: 'U-DAN' } }])
+  // A selection change is acked and otherwise ignored: there is no state to record.
+  it('acks a selection change without reporting anything', async () => {
+    const seen: unknown[] = []
+    const actions = await connect({ onElicitConfirm: (a: unknown) => seen.push(a) })
+    const select = [...actions.entries()].find(([id]) => id.includes(`${ELICIT_SELECT_ACTION}:`))![1]
+    let acked = false
+    await select({
+      ack: async () => void (acked = true),
+      action: { action_id: `${ELICIT_SELECT_ACTION}:elicit-9`, selected_options: [{ value: 'lint' }] },
+      body: {}
+    })
+    expect(acked).toBe(true)
+    expect(seen).toEqual([])
   })
 
   it('leaves the actor absent when the payload names no user', async () => {

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -601,13 +601,37 @@ export const SLACK_STATUS_ACTION = {
 export const PERMISSION_ACTION_PREFIX = 'ac_perm'
 export const ELICIT_ACTION_PREFIX = 'ac_elicit'
 export const ELICIT_DISMISS_ACTION = 'ac_elicit_dismiss'
-/** A multi-select elicitation card's own two ids: the `multi_static_select`, which Slack
- *  re-delivers with the WHOLE current selection on every change, and the Confirm button that
- *  submits it — a select never submits on its own, so the two are separate interactions. Each
- *  selected option carries `encodePermValue`, so the change names its own card; Confirm carries
- *  the bare request id, since only the daemon holds what is selected. */
+/** A multi-select elicitation card's own two ids: the `multi_static_select`, which never submits
+ *  on its own, and the Confirm button that does. The selection is not tracked between the two —
+ *  Confirm reads it out of its OWN payload's message state, so what it submits is the state that
+ *  card was in when this reader tapped it. The select's action_id carries the request id, which
+ *  is the key {@link selectedOptionsFromState} finds that state under. */
 export const ELICIT_SELECT_ACTION = 'ac_elicit_select'
 export const ELICIT_CONFIRM_ACTION = 'ac_elicit_confirm'
+
+/** One `block_actions` payload's message state — every stateful element of the message the tap
+ *  came from, keyed by block then action id. Slack has carried the full state on `block_actions`
+ *  (not just view submissions) since 2020-09-01. */
+export interface SlackBlockActionsState {
+  values?: Record<string, Record<string, { selected_options?: { value?: unknown }[] } | undefined> | undefined>
+}
+
+/** The selection a `multi_static_select` held when this interaction was raised, read from the
+ *  payload's own message state — the snapshot a Confirm tap submits, and the reason no selection
+ *  has to be tracked between interactions. Searched by ACTION id across every block, so it does
+ *  not depend on which block Slack grouped the select into, nor on the card naming that block.
+ *  Null ⇒ this payload carries no state for that select, which is NOT an empty selection: the
+ *  caller drops the interaction rather than confirm a selection it cannot see. An empty array is
+ *  a real answer (the reader cleared the select), which is why the two are distinct. */
+export function selectedOptionsFromState(state: SlackBlockActionsState | undefined, actionId: string): string[] | null {
+  for (const block of Object.values(state?.values ?? {})) {
+    const element = block?.[actionId]
+    if (!element?.selected_options) continue
+    const values = element.selected_options.map((o) => o.value)
+    return values.every((v) => typeof v === 'string') ? (values as string[]) : null
+  }
+  return null
+}
 
 /** Encode/decode the choice carried by permission and elicitation buttons. The
  * daemon-generated request id is `|`-free; runtime-owned option values may contain it. */

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -601,6 +601,13 @@ export const SLACK_STATUS_ACTION = {
 export const PERMISSION_ACTION_PREFIX = 'ac_perm'
 export const ELICIT_ACTION_PREFIX = 'ac_elicit'
 export const ELICIT_DISMISS_ACTION = 'ac_elicit_dismiss'
+/** A multi-select elicitation card's own two ids: the `multi_static_select`, which Slack
+ *  re-delivers with the WHOLE current selection on every change, and the Confirm button that
+ *  submits it — a select never submits on its own, so the two are separate interactions. Each
+ *  selected option carries `encodePermValue`, so the change names its own card; Confirm carries
+ *  the bare request id, since only the daemon holds what is selected. */
+export const ELICIT_SELECT_ACTION = 'ac_elicit_select'
+export const ELICIT_CONFIRM_ACTION = 'ac_elicit_confirm'
 
 /** Encode/decode the choice carried by permission and elicitation buttons. The
  * daemon-generated request id is `|`-free; runtime-owned option values may contain it. */

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -359,7 +359,20 @@ export const RdSlackAction = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('set-output'), outputMode: z.enum(['none', 'minimal', 'low', 'medium', 'high']) }),
   z.object({ kind: z.literal('cancel') }),
   z.object({ kind: z.literal('permission-choice'), requestId: z.string().min(1), optionId: z.string() }),
-  z.object({ kind: z.literal('elicitation-choice'), requestId: z.string().min(1), value: z.string().nullable() })
+  z.object({ kind: z.literal('elicitation-choice'), requestId: z.string().min(1), value: z.string().nullable() }),
+  // A Slack multi-select card settles in TWO interactions: the `multi_static_select` re-sends the
+  // whole current selection on every change, and Confirm submits it — a select never submits on
+  // its own. The selection is its own verb rather than a widened `elicitation-choice` because only
+  // the daemon may hold it: the relay persists no message content, and a Confirm button's `value`
+  // is fixed when the card is rendered. Skew fails closed forward — a daemon predating these two
+  // rejects the whole action, so the card stays live — and backward a relay predating them simply
+  // never sends one, so Confirm submits whatever selection the card was posted showing.
+  z.object({
+    kind: z.literal('elicitation-select'),
+    requestId: z.string().min(1),
+    values: z.array(z.string()).max(100)
+  }),
+  z.object({ kind: z.literal('elicitation-confirm'), requestId: z.string().min(1) })
 ])
 export type RdSlackAction = z.infer<typeof RdSlackAction>
 

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -360,19 +360,18 @@ export const RdSlackAction = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('cancel') }),
   z.object({ kind: z.literal('permission-choice'), requestId: z.string().min(1), optionId: z.string() }),
   z.object({ kind: z.literal('elicitation-choice'), requestId: z.string().min(1), value: z.string().nullable() }),
-  // A Slack multi-select card settles in TWO interactions: the `multi_static_select` re-sends the
-  // whole current selection on every change, and Confirm submits it — a select never submits on
-  // its own. The selection is its own verb rather than a widened `elicitation-choice` because only
-  // the daemon may hold it: the relay persists no message content, and a Confirm button's `value`
-  // is fixed when the card is rendered. Skew fails closed forward — a daemon predating these two
-  // rejects the whole action, so the card stays live — and backward a relay predating them simply
-  // never sends one, so Confirm submits whatever selection the card was posted showing.
+  // A Slack multi-select card's Confirm: a `multi_static_select` never submits on its own, so the
+  // reader taps a button, and `values` is the selection read out of THAT tap's own message state
+  // (`selectedOptionsFromState`). Carrying the snapshot is what makes the verb self-contained —
+  // no selection is tracked between interactions, so one reader's pick can never be submitted as
+  // another's answer, and the ordering of two interactions cannot change what is confirmed. The
+  // relay forwards no selection CHANGE at all: it acks Slack and keeps nothing. A daemon
+  // predating the verb rejects the whole action, so the card stays live.
   z.object({
-    kind: z.literal('elicitation-select'),
+    kind: z.literal('elicitation-confirm'),
     requestId: z.string().min(1),
     values: z.array(z.string()).max(100)
-  }),
-  z.object({ kind: z.literal('elicitation-confirm'), requestId: z.string().min(1) })
+  })
 ])
 export type RdSlackAction = z.infer<typeof RdSlackAction>
 

--- a/packages/relay/src/platforms/slack/http-ingest.test.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.test.ts
@@ -206,32 +206,11 @@ describe('parseHttpSlackSessionAction', () => {
     ).toBeNull()
   })
 
-  // A multi-select card settles in two interactions: the select re-sends the WHOLE current
-  // selection on every change, and Confirm submits it. The relay forwards both and holds neither.
-  it('routes a multi-select card’s selection changes and its Confirm', () => {
-    const parseSelect = (action_id: string, selected_options?: { value?: string }[]) =>
-      parseHttpSlackSessionAction(
-        body(action_id, {
-          actions: [{ action_id, action_ts: '1720000000.000600', block_id: ENCODED_TARGET, selected_options }],
-          view: undefined
-        })
-      )
-
-    expect(parseSelect(`${ELICIT_SELECT_ACTION}:elicit-3`, [{ value: 'lint' }, { value: 'test' }])).toMatchObject({
-      target: TARGET,
-      kind: 'elicitation-select',
-      requestId: 'elicit-3',
-      values: ['lint', 'test']
-    })
-    // Deselecting everything is a change too, which is why the request rides the action_id.
-    expect(parseSelect(`${ELICIT_SELECT_ACTION}:elicit-3`, [])).toMatchObject({
-      kind: 'elicitation-select',
-      requestId: 'elicit-3',
-      values: []
-    })
-    expect(parseSelect(`${ELICIT_SELECT_ACTION}:elicit-3`, [{}])).toBeNull()
-    expect(parseSelect(`${ELICIT_SELECT_ACTION}:`)).toBeNull()
-    expect(
+  // A multi-select card's Confirm carries the selection out of its OWN payload's message state,
+  // so what the relay forwards is the state the tapping reader confirmed. A selection CHANGE is
+  // acked and dropped: nothing is tracked between the two interactions.
+  it('routes a multi-select card’s Confirm with the selection its own payload carried', () => {
+    const parseConfirm = (state?: unknown, value = 'elicit-3') =>
       parseHttpSlackSessionAction(
         body(ELICIT_CONFIRM_ACTION, {
           actions: [
@@ -239,36 +218,120 @@ describe('parseHttpSlackSessionAction', () => {
               action_id: ELICIT_CONFIRM_ACTION,
               action_ts: '1720000000.000700',
               block_id: ENCODED_TARGET,
-              value: 'elicit-3'
+              value
+            }
+          ],
+          view: undefined,
+          ...(state !== undefined ? { state } : {})
+        } as Partial<SlackInteractiveBody>)
+      )
+    const stateWith = (selected_options: { value?: unknown }[], block = ENCODED_TARGET) => ({
+      values: { [block]: { [`${ELICIT_SELECT_ACTION}:elicit-3`]: { selected_options } } }
+    })
+
+    expect(parseConfirm(stateWith([{ value: 'lint' }, { value: 'test' }]))).toMatchObject({
+      target: TARGET,
+      kind: 'elicitation-confirm',
+      requestId: 'elicit-3',
+      values: ['lint', 'test']
+    })
+    // Found by ACTION id, so it does not matter which block Slack grouped the select into.
+    expect(parseConfirm(stateWith([{ value: 'lint' }], 'some-other-block'))).toMatchObject({
+      kind: 'elicitation-confirm',
+      values: ['lint']
+    })
+    // An emptied select is a real answer; NO state for it is not one, and forwards nothing.
+    expect(parseConfirm(stateWith([]))).toMatchObject({ kind: 'elicitation-confirm', values: [] })
+    expect(parseConfirm({ values: {} })).toBeNull()
+    expect(parseConfirm()).toBeNull()
+    expect(parseConfirm(stateWith([{}]))).toBeNull()
+    // Another card's state cannot answer this Confirm: the key is this request's select.
+    expect(parseConfirm(stateWith([{ value: 'lint' }]), 'elicit-9')).toBeNull()
+
+    // A selection change is not a session action at all — the relay acks it and keeps nothing.
+    expect(
+      parseHttpSlackSessionAction(
+        body(`${ELICIT_SELECT_ACTION}:elicit-3`, {
+          actions: [
+            {
+              action_id: `${ELICIT_SELECT_ACTION}:elicit-3`,
+              action_ts: '1720000000.000600',
+              block_id: ENCODED_TARGET
             }
           ],
           view: undefined
         })
       )
-    ).toMatchObject({ target: TARGET, kind: 'elicitation-confirm', requestId: 'elicit-3' })
+    ).toBeNull()
   })
 
-  // Two changes on one card are two interactions: a redelivery of either must dedup against
-  // itself, never against the other, or the second selection would be dropped as a duplicate.
-  it('gives each selection change and its Confirm distinct msgIds', () => {
-    const select = (values: string[]) => ({
+  // The reviewer's scenario, in order: A selects lint, B selects test, then A taps Confirm. With
+  // a per-card record of the last selection seen, A's Confirm submitted B's pick — every value in
+  // it a valid option, so no whitelist could catch it. Neither change is forwarded at all now,
+  // and A's Confirm carries the state A tapped it on, so processing order decides nothing.
+  it('answers A’s Confirm with A’s own selection after B changed the card', () => {
+    const selectBody = (user: string) =>
+      body(`${ELICIT_SELECT_ACTION}:elicit-3`, {
+        user: { id: user },
+        actions: [
+          { action_id: `${ELICIT_SELECT_ACTION}:elicit-3`, action_ts: '1720000000.000600', block_id: ENCODED_TARGET }
+        ],
+        view: undefined
+      })
+    const confirmBody = (user: string, values: string[]) =>
+      ({
+        ...body(ELICIT_CONFIRM_ACTION, {
+          user: { id: user },
+          actions: [
+            {
+              action_id: ELICIT_CONFIRM_ACTION,
+              action_ts: '1720000000.000800',
+              block_id: ENCODED_TARGET,
+              value: 'elicit-3'
+            }
+          ],
+          view: undefined
+        }),
+        state: {
+          values: {
+            [ENCODED_TARGET]: {
+              [`${ELICIT_SELECT_ACTION}:elicit-3`]: { selected_options: values.map((value) => ({ value })) }
+            }
+          }
+        }
+      }) as SlackInteractiveBody
+
+    // A selects, then B selects: two interactions, neither of them an answer to forward.
+    expect(parseHttpSlackSessionAction(selectBody('U-A'))).toBeNull()
+    expect(parseHttpSlackSessionAction(selectBody('U-B'))).toBeNull()
+    // A confirms. What is forwarded is the selection A's own payload carried, not B's.
+    expect(parseHttpSlackSessionAction(confirmBody('U-A', ['lint']))).toMatchObject({
+      kind: 'elicitation-confirm',
+      requestId: 'elicit-3',
+      values: ['lint'],
+      userId: 'U-A'
+    })
+    expect(parseHttpSlackSessionAction(confirmBody('U-B', ['test']))).toMatchObject({
+      kind: 'elicitation-confirm',
+      values: ['test'],
+      userId: 'U-B'
+    })
+  })
+
+  // Two Confirms on one card are two answers: a redelivery of either must dedup against itself,
+  // never against the other, or the second answer would be dropped as a duplicate.
+  it('gives each confirmed selection its own msgId', () => {
+    const confirm = (values: string[]) => ({
       target: TARGET,
-      interactionId: JSON.stringify([`${ELICIT_SELECT_ACTION}:elicit-3`, '1']),
-      kind: 'elicitation-select' as const,
+      interactionId: JSON.stringify([ELICIT_CONFIRM_ACTION, '1']),
+      kind: 'elicitation-confirm' as const,
       requestId: 'elicit-3',
       values
     })
-    const one = httpSlackActionMsgId('B1', select(['lint']))
-    expect(httpSlackActionMsgId('B1', select(['lint']))).toBe(one)
-    expect(httpSlackActionMsgId('B1', select(['lint', 'test']))).not.toBe(one)
-    expect(
-      httpSlackActionMsgId('B1', {
-        target: TARGET,
-        interactionId: JSON.stringify([ELICIT_CONFIRM_ACTION, '1']),
-        kind: 'elicitation-confirm',
-        requestId: 'elicit-3'
-      })
-    ).not.toBe(one)
+    const one = httpSlackActionMsgId('B1', confirm(['lint']))
+    expect(httpSlackActionMsgId('B1', confirm(['lint']))).toBe(one)
+    expect(httpSlackActionMsgId('B1', confirm(['lint', 'test']))).not.toBe(one)
+    expect(httpSlackActionMsgId('B1', confirm([]))).not.toBe(one)
   })
 
   it('parses an inline Cancel target from action.value', () => {

--- a/packages/relay/src/platforms/slack/http-ingest.test.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from 'vitest'
 import { createHmac } from 'node:crypto'
 import {
   ELICIT_ACTION_PREFIX,
+  ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
+  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   SHARED_AGENT_SELECT_ACTION_ID,
   SHARED_CONFIG_ACTION_ID,
@@ -21,6 +23,7 @@ import {
   type SlackHttpIngestDeps,
   type SlackInteractiveBody
 } from './http-ingest.js'
+import { httpSlackActionMsgId } from './ingress-plugin.js'
 import { verifySlackSignature } from '../../hooks/signature.js'
 
 const AGENT_ID = '11111111-1111-4111-8111-111111111111'
@@ -201,6 +204,71 @@ describe('parseHttpSlackSessionAction', () => {
         })
       )
     ).toBeNull()
+  })
+
+  // A multi-select card settles in two interactions: the select re-sends the WHOLE current
+  // selection on every change, and Confirm submits it. The relay forwards both and holds neither.
+  it('routes a multi-select card’s selection changes and its Confirm', () => {
+    const parseSelect = (action_id: string, selected_options?: { value?: string }[]) =>
+      parseHttpSlackSessionAction(
+        body(action_id, {
+          actions: [{ action_id, action_ts: '1720000000.000600', block_id: ENCODED_TARGET, selected_options }],
+          view: undefined
+        })
+      )
+
+    expect(parseSelect(`${ELICIT_SELECT_ACTION}:elicit-3`, [{ value: 'lint' }, { value: 'test' }])).toMatchObject({
+      target: TARGET,
+      kind: 'elicitation-select',
+      requestId: 'elicit-3',
+      values: ['lint', 'test']
+    })
+    // Deselecting everything is a change too, which is why the request rides the action_id.
+    expect(parseSelect(`${ELICIT_SELECT_ACTION}:elicit-3`, [])).toMatchObject({
+      kind: 'elicitation-select',
+      requestId: 'elicit-3',
+      values: []
+    })
+    expect(parseSelect(`${ELICIT_SELECT_ACTION}:elicit-3`, [{}])).toBeNull()
+    expect(parseSelect(`${ELICIT_SELECT_ACTION}:`)).toBeNull()
+    expect(
+      parseHttpSlackSessionAction(
+        body(ELICIT_CONFIRM_ACTION, {
+          actions: [
+            {
+              action_id: ELICIT_CONFIRM_ACTION,
+              action_ts: '1720000000.000700',
+              block_id: ENCODED_TARGET,
+              value: 'elicit-3'
+            }
+          ],
+          view: undefined
+        })
+      )
+    ).toMatchObject({ target: TARGET, kind: 'elicitation-confirm', requestId: 'elicit-3' })
+  })
+
+  // Two changes on one card are two interactions: a redelivery of either must dedup against
+  // itself, never against the other, or the second selection would be dropped as a duplicate.
+  it('gives each selection change and its Confirm distinct msgIds', () => {
+    const select = (values: string[]) => ({
+      target: TARGET,
+      interactionId: JSON.stringify([`${ELICIT_SELECT_ACTION}:elicit-3`, '1']),
+      kind: 'elicitation-select' as const,
+      requestId: 'elicit-3',
+      values
+    })
+    const one = httpSlackActionMsgId('B1', select(['lint']))
+    expect(httpSlackActionMsgId('B1', select(['lint']))).toBe(one)
+    expect(httpSlackActionMsgId('B1', select(['lint', 'test']))).not.toBe(one)
+    expect(
+      httpSlackActionMsgId('B1', {
+        target: TARGET,
+        interactionId: JSON.stringify([ELICIT_CONFIRM_ACTION, '1']),
+        kind: 'elicitation-confirm',
+        requestId: 'elicit-3'
+      })
+    ).not.toBe(one)
   })
 
   it('parses an inline Cancel target from action.value', () => {

--- a/packages/relay/src/platforms/slack/http-ingest.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.ts
@@ -25,7 +25,9 @@ import {
 } from '@agentconnect.md/message'
 import {
   ELICIT_ACTION_PREFIX,
+  ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
+  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   SHARED_AGENT_SELECT_ACTION_ID,
   SHARED_CONFIG_ACTION_ID,
@@ -68,6 +70,7 @@ export interface SlackInteractiveBody {
     block_id?: string
     value?: string
     selected_option?: { value?: string }
+    selected_options?: { value?: string }[]
   }[]
   view?: {
     callback_id?: string
@@ -217,6 +220,29 @@ function decodeHttpSlackSessionAction(body: SlackInteractiveBody): HttpSlackSess
           value: choice.optionId
         }
       : null
+  }
+  // A multi-select card is two interactions: the select re-sends the WHOLE current selection on
+  // every change (its `action_id` names the request, so deselecting everything reports too), and
+  // Confirm submits it. The relay holds neither — it forwards both verbs and the daemon decides.
+  if (target && action.action_id.startsWith(`${ELICIT_SELECT_ACTION}:`)) {
+    const requestId = action.action_id.slice(ELICIT_SELECT_ACTION.length + 1)
+    const selected = action.selected_options ?? []
+    if (!requestId || selected.some((o) => typeof o.value !== 'string')) return null
+    return {
+      target,
+      interactionId: JSON.stringify([action.action_id, receipt]),
+      kind: 'elicitation-select',
+      requestId,
+      values: selected.map((o) => o.value as string)
+    }
+  }
+  if (target && action.action_id === ELICIT_CONFIRM_ACTION && action.value) {
+    return {
+      target,
+      interactionId: JSON.stringify([action.action_id, receipt]),
+      kind: 'elicitation-confirm',
+      requestId: action.value
+    }
   }
   if (target && action.action_id === ELICIT_DISMISS_ACTION && action.value) {
     return {

--- a/packages/relay/src/platforms/slack/http-ingest.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.ts
@@ -36,7 +36,9 @@ import {
   decodePermValue,
   decodeSlackStatusOverflowValue,
   decodeSharedSlackStatusTarget,
+  selectedOptionsFromState,
   type RdSlackAction,
+  type SlackBlockActionsState,
   type SharedSlackStatusTarget,
   type WireNormalizedMessage
 } from '@agentconnect.md/protocol'
@@ -70,8 +72,10 @@ export interface SlackInteractiveBody {
     block_id?: string
     value?: string
     selected_option?: { value?: string }
-    selected_options?: { value?: string }[]
   }[]
+  /** A `block_actions` payload's full message state (Slack, 2020-09-01) — how a Confirm tap
+   *  carries the selection its own card was showing. */
+  state?: SlackBlockActionsState
   view?: {
     callback_id?: string
     private_metadata?: string
@@ -221,28 +225,22 @@ function decodeHttpSlackSessionAction(body: SlackInteractiveBody): HttpSlackSess
         }
       : null
   }
-  // A multi-select card is two interactions: the select re-sends the WHOLE current selection on
-  // every change (its `action_id` names the request, so deselecting everything reports too), and
-  // Confirm submits it. The relay holds neither — it forwards both verbs and the daemon decides.
-  if (target && action.action_id.startsWith(`${ELICIT_SELECT_ACTION}:`)) {
-    const requestId = action.action_id.slice(ELICIT_SELECT_ACTION.length + 1)
-    const selected = action.selected_options ?? []
-    if (!requestId || selected.some((o) => typeof o.value !== 'string')) return null
-    return {
-      target,
-      interactionId: JSON.stringify([action.action_id, receipt]),
-      kind: 'elicitation-select',
-      requestId,
-      values: selected.map((o) => o.value as string)
-    }
-  }
+  // A multi-select card's Confirm. A selection CHANGE is not forwarded at all — the relay acks
+  // Slack and keeps nothing — because the selection rides this tap's own message state, which
+  // Slack has carried on `block_actions` since 2020-09-01. Reading it here is what makes the
+  // forwarded answer the state THIS reader confirmed, rather than whatever was recorded last.
   if (target && action.action_id === ELICIT_CONFIRM_ACTION && action.value) {
-    return {
-      target,
-      interactionId: JSON.stringify([action.action_id, receipt]),
-      kind: 'elicitation-confirm',
-      requestId: action.value
-    }
+    const values = selectedOptionsFromState(body.state, `${ELICIT_SELECT_ACTION}:${action.value}`)
+    // No state for the select ⇒ nothing this tap can be said to confirm, so nothing is forwarded.
+    return values
+      ? {
+          target,
+          interactionId: JSON.stringify([action.action_id, receipt]),
+          kind: 'elicitation-confirm',
+          requestId: action.value,
+          values
+        }
+      : null
   }
   if (target && action.action_id === ELICIT_DISMISS_ACTION && action.value) {
     return {

--- a/packages/relay/src/platforms/slack/ingress-plugin.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.ts
@@ -62,13 +62,10 @@ export function httpSlackActionMsgId(botId: string, action: HttpSlackSessionActi
     case 'elicitation-choice':
       value = `${action.requestId}:${action.value ?? ''}`
       break
-    // The selection is part of the identity: two changes on one card are two interactions, and a
-    // redelivery of either must dedup against itself and not against the other.
-    case 'elicitation-select':
-      value = `${action.requestId}:${JSON.stringify(action.values)}`
-      break
+    // The confirmed selection is part of the identity: two Confirms on one card are two answers,
+    // and a redelivery of either must dedup against itself rather than against the other.
     case 'elicitation-confirm':
-      value = action.requestId
+      value = `${action.requestId}:${JSON.stringify(action.values)}`
       break
     case 'open-config':
     case 'cancel':

--- a/packages/relay/src/platforms/slack/ingress-plugin.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.ts
@@ -62,6 +62,14 @@ export function httpSlackActionMsgId(botId: string, action: HttpSlackSessionActi
     case 'elicitation-choice':
       value = `${action.requestId}:${action.value ?? ''}`
       break
+    // The selection is part of the identity: two changes on one card are two interactions, and a
+    // redelivery of either must dedup against itself and not against the other.
+    case 'elicitation-select':
+      value = `${action.requestId}:${JSON.stringify(action.values)}`
+      break
+    case 'elicitation-confirm':
+      value = action.requestId
+      break
     case 'open-config':
     case 'cancel':
       break


### PR DESCRIPTION
Implements the Slack-column item on #1794: **multi-select on Slack**, with no modal.

Multi-select landed for webchat in #1801 and declined on Slack, because a row of buttons cannot express "pick several, then confirm". `multi_static_select` can, inside a message — which is why this is separate from the form work that does need a modal.

## The interaction, and where the in-progress selection lives

A `multi_static_select` does not submit itself: Slack delivers an interaction on every selection change, and the reader needs a separate **Confirm**. So the card is select + Confirm + Dismiss.

Checked rather than assumed: **Slack re-sends the whole selection** on each change (`actions[0].selected_options`), so nothing accumulates — only the *last* one has to be remembered. It lives on the card's own pending record and is freed by every settle path, so there is no new cleanup hook. Nothing else could hold it: the relay persists no message content, and Confirm's button `value` is frozen at render time.

It is seeded from the schema's `default`, matching the select's `initial_options`, so an untouched Confirm submits exactly what the card was posted showing. It is relayed, never trusted — Confirm delegates to the same path as every other answer, so #1815's re-derivation against the card is still the only thing that makes it valid.

Message-level `state.values` was deliberately not used: it is documented for views, and I could not confirm Slack populates it for elements in a message's `actions` block. The `selected_options` route needs no such guarantee.

## Per-kind option limits, because Slack's two caps differ

#1813 made the option limit a property of the surface. It has to become a property of the surface **and the kind**, because Slack's caps are not the same thing:

- `enum` → 24 options (the 25-element actions block minus Dismiss) — unchanged
- `multi-enum` → 100 options (the select's own cap) **and 75 characters per option `value`**

That 75-char value cap is exactly why #1813 rejected `static_select` for single-select. A multi-select has no button fallback, so an over-long option value declines instead. Keeping the limits per kind is what stops the select's 100 quietly widening the button row's 24 — pinned by a test where 25 buttons still decline while 25 select options do not.

One design consequence worth naming: the request id rides the select's own `action_id`, not its option values, because a card identified only by its selected options cannot report an **empty** selection. Option values therefore stay bare, so the 75-char cap applies exactly.

## Both interaction edges needed changing, and that was not avoidable

The existing `ac_elicit:*` / `elicitation-choice` path could not be reused: a select payload has **no `value` field at all**, and Confirm is a third verb with no room in one nullable string. Both edges — the relay's HTTP ingest and the daemon's Bolt handlers — decode two new verbs, carried as two new `RdSlackAction` members rather than by widening `value`.

Skew: forward (new relay → old daemon) **fails closed** — zod rejects the action, the forward is refused, the card stays live. Backward (old relay → new daemon) simply never sends them, so Confirm submits what the card was posted showing, which is why seeding from `default` rather than leaving it empty matters.

The relay also folds the selection into its dedup id, so two changes on one card are two interactions rather than one swallowed.

## The approval DM would have been widened silently

`sendApprovalDm` reuses `buildElicitationCard`, so adding `multi-enum` to the Slack surface widened the DM card too — and a DM tap settles through the editor path, which holds no per-card selection. That would have been a Confirm that could never work.

`SLACK_DM_ELICIT_SURFACE` (enum + boolean) now bounds it, and the DM's own re-derivation sites use it. This is the same shape as the `?? []` empty-DM-card hole already tracked on #1794.

## Known gaps, recorded on #1794 rather than left in this body

- **A refused Confirm is silent.** The re-derivation convention is "drop it, leave the card live", so a below-`minItems` Confirm tells the reader nothing. Mitigated by putting the bounds on the card as a context line; the proper fix is an ephemeral `response_url` reply.
- **The 75-char option-value cap bites in practice.** Enum values that are paths, URLs or ids are common, and such a multi-select declines on Slack while rendering on webchat. Same fix as #1821's long-URL gap: a per-request nonce with a server-side lookup.
- `minItems: 0` with a seeded default makes an untouched Confirm accept `[]`, indistinguishable from a deliberate empty choice. Webchat reads it the same way (#1801), so consistency was kept rather than inventing a second rule.

## Verification

- protocol 488, relay 646, web 2404 — green.
- `pnpm typecheck`: `error TS` count 0. eslint + prettier clean on the 15 changed files.
- Affected daemon suites (`render`, `daemon-permission-autoallow`, `elicit-decline-notice`, `approval-dm`, `daemon-commands`, `slack-status-actor`, `turn-chrome`): **388 passing**, independently re-run.
- Full daemon suite: 11 files failing, all confirmed as the known-unrelated set — `acp-matrix` dialling live runtimes, the five skills-CLI files (`skills CLI exited with status 1`), bwrap `sandbox`, the memoed `evaluation-runner` baseline, and `daemon-smoke`'s gitcred/workspace pair, which reproduced **exactly** at HEAD with the source reverted. Two more (`daemon-duty-drain`, `daemon-hook`) pass alone and were a different pair in an earlier run — full-suite load flakes.

One real failure this caused, fixed here: `elicit-decline-notice.test.ts` used a multi-select as its "Slack cannot render this" exemplar. It now uses a free-text field, plus a case asserting a multi-select gets a card and **no** notice.

Every new test was confirmed red with only the source reverted — 12 daemon cases across four files and 2 relay cases, with failures like `Target cannot be null or undefined` (no card) and `Cannot read properties of undefined (reading 'kinds')` (no DM surface).
