### PR TITLE
fix(daemon): fold a Codex form's own "Other" box into its question

### DIFF
--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -902,9 +902,11 @@ export function elicitFieldLabel(params: CreateElicitationRequest, propName: str
   return clampTo((typeof title === 'string' && title.trim()) || propName, 75)
 }
 
-/** ACP's cross-agent marker for a select question's own free-text box — written by the
- *  AskUserQuestion bridges (Claude, Codex) under a namespace-free `_meta` key on purpose. */
+// ACP's cross-agent marker for a select question's own free-text box, under a namespace-free `_meta` key on purpose.
 const CUSTOM_ANSWER_META_KEY = '_askUserQuestionCustomAnswer'
+
+// Codex spells the same box its own way: `request_user_input` writes `_meta.codex.isOtherAnswer`, so both are read.
+const CODEX_CUSTOM_ANSWER_META_KEY = 'codex'
 
 /** The longest question text a card carries under a field's label. */
 const ELICIT_DESCRIPTION_MAX = 300
@@ -912,10 +914,16 @@ const ELICIT_DESCRIPTION_MAX = 300
 /** The question a property's `_meta` claims this free-text box answers, or undefined when it
  *  claims none — an unmarked property is a question in its own right. */
 function customAnswerOwner(prop: Record<string, unknown>): string | undefined {
-  const meta = (prop._meta as Record<string, unknown> | undefined)?.[CUSTOM_ANSWER_META_KEY] as
-    { questionId?: unknown; isCustomAnswer?: unknown } | undefined
-  const owner = meta?.questionId
-  return meta?.isCustomAnswer === true && typeof owner === 'string' && owner ? owner : undefined
+  const meta = prop._meta as Record<string, unknown> | undefined
+  for (const [key, flag] of [
+    [CUSTOM_ANSWER_META_KEY, 'isCustomAnswer'],
+    [CODEX_CUSTOM_ANSWER_META_KEY, 'isOtherAnswer']
+  ] as const) {
+    const marker = meta?.[key] as Record<string, unknown> | undefined
+    const owner = marker?.questionId
+    if (marker?.[flag] === true && typeof owner === 'string' && owner) return owner
+  }
+  return undefined
 }
 
 /**

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -2052,6 +2052,7 @@ describe('elicitation card', () => {
   // An AskUserQuestion bridge (claude-agent-acp, codex) pairs every select question with its
   // own free-text box, marked `_askUserQuestionCustomAnswer`. The box belongs INSIDE its
   // question — rendered as a peer it read as a second question titled "Other" (#1817).
+  // Codex's native `request_user_input` marks the same box `_meta.codex.isOtherAnswer` instead.
   const custom = (questionId: string) => ({
     type: 'string',
     title: 'Other',
@@ -2082,6 +2083,48 @@ describe('elicitation card', () => {
     // answer without it is refused here — which is why the card keeps asking for the pick too.
     expect(elicitFormAccepts(form!, ['question_0'], { question_0_custom: 'release/1.2' })).toBe(false)
     expect(elicitFormAccepts(form!, ['question_0'], { question_0: 'main', question_0_custom: 'x' })).toBe(true)
+  })
+
+  it("binds Codex's own `_meta.codex` other-answer box the same way", () => {
+    const codexOther = (questionId: string) => ({
+      type: 'string',
+      title: 'Other',
+      description: 'Type your own answer instead of choosing an option above.',
+      _meta: { codex: { questionId, isOtherAnswer: true, isSecret: false } }
+    })
+    const asked = req(
+      {
+        need_type: {
+          type: 'string',
+          title: '需求类型',
+          description: '你希望我协助处理哪一类事情?',
+          oneOf: [{ const: '内容创作' }]
+        },
+        need_type__other: codexOther('need_type'),
+        result_form: { type: 'string', title: '结果形式', oneOf: [{ const: '简洁回答' }] },
+        result_form__other: codexOther('result_form')
+      },
+      []
+    )
+    expect(elicitForm(asked, WEBCHAT_ELICIT_SURFACE)?.map((t) => [t.propName, t.customAnswerFor])).toEqual([
+      ['need_type', undefined],
+      ['need_type__other', 'need_type'],
+      ['result_form', undefined],
+      ['result_form__other', 'result_form']
+    ])
+  })
+
+  it('ignores a codex marker that claims no question', () => {
+    // `isOtherAnswer` absent (or false) makes the box a question of its own, exactly as an
+    // unmarked property is — the flag, not the namespace, is what binds it.
+    const unflagged = req(
+      {
+        a: { type: 'string', enum: ['x'] },
+        a__other: { type: 'string', title: 'Other', _meta: { codex: { questionId: 'a', isSecret: false } } }
+      },
+      []
+    )
+    expect(elicitForm(unflagged, WEBCHAT_ELICIT_SURFACE)?.every((t) => t.customAnswerFor === undefined)).toBe(true)
   })
 
   it('leaves a custom-answer box standing alone when its question is not on the card', () => {

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -157,9 +157,11 @@ export const ElicitField = z.object({
   required: z.boolean().optional(),
   /** The schema's own `description` — the question text, where the title is only its header. */
   description: z.string().max(300).optional(),
-  /** Set on a select question's free-text companion (ACP `_askUserQuestionCustomAnswer`): the
-   *  property whose question this box types an answer for. The card renders it INSIDE that
-   *  question rather than as a question of its own, and never numbers or counts it. */
+  /** Set on a select question's free-text companion: the property whose question this box types
+   *  an answer for. The card renders it INSIDE that question rather than as a question of its
+   *  own, and never numbers or counts it. Which `_meta` marker said so (ACP
+   *  `_askUserQuestionCustomAnswer`, or Codex's `_meta.codex.isOtherAnswer`) is the daemon's to
+   *  read: the raw schema never crosses this wire, so a reader has only this field. */
   customAnswerFor: z.string().min(1).max(200).optional(),
   options: ElicitOptions,
   multi: ElicitMulti.optional(),


### PR DESCRIPTION
## What

A Codex turn's form asked every question twice: once as itself, once as a peer question
titled "Other". A three-question form arrived as `0/6`.

Codex's native `request_user_input` marks a select question's free-text companion its own
way:

```jsonc
"retry_count__other": {
  "type": "string", "title": "Other",
  "_meta": { "codex": { "questionId": "retry_count", "isOtherAnswer": true, "isSecret": false } }
}
```

`customAnswerOwner` (`daemon/src/slack/render.ts`) read only the ACP spelling
`_meta._askUserQuestionCustomAnswer.isCustomAnswer` that #1817 was built against. The Codex
marker went unrecognized, so the box lost its `customAnswerFor` and `elicitCandidates`
promoted it to a question.

This surfaced only now because #1824 is what first let a Codex turn reach the form
elicitation at all — the shape was never on this path before.

## Why the daemon and not the reader

The reader surfaces were never wrong. `ElicitField` on the wire
(`protocol/src/frames/webchat.ts`) carries the *projected* card — `propName`, `label`,
`kind`, `options`, `customAnswerFor` — and no `requestedSchema`, no `_meta`. A card has only
`customAnswerFor` to go on (`rows = fields.filter((f) => !f.customAnswerFor)`,
`companionOf`), so from the console's side the agent really did ask six questions, two of
them named "Other". Three further reasons the semantics belong here:

- One projector feeds every surface — `elicitCandidates` is parameterized by `ElicitSurface`,
  so Slack gets the same fix rather than a second copy of the rule.
- The form cap counts **questions**, not properties
  (`targets.filter((t) => !t.customAnswerFor).length > ELICIT_FORM_FIELD_CAP`), so the daemon
  must know which box is an "Other" *before* it decides whether to send the card at all. On
  this six-property form that is 3 vs 6 against the cap.
- `elicitFormAccepts` and `elicitTarget` share the same scan on purpose, and #1815 re-derives
  every answer against the card that offered it — render side and accept side cannot disagree
  about which property is a companion.

## How

`customAnswerOwner` reads both spellings, binding on the **flag** rather than the namespace,
so a `_meta.codex` box that does not claim `isOtherAnswer` stays a question of its own. Nothing
downstream changes: `propName` is untouched (codex-acp reads answers back under `<id>__other`),
and orphan degradation, cap counting, and `elicitFormAccepts` keep #1817's behavior.

`ElicitField.customAnswerFor`'s doc comment named only the ACP marker; it now records both
spellings and that the raw schema never crosses the wire, so the next reader does not go
looking on the web side.

## Verification

- Replayed a **real** `elicitation/create` payload captured from a live `codex-acp` turn
  through `elicitForm(params, WEBCHAT_ELICIT_SURFACE)`:
  `[[branch,enum,-],[branch__other,text,branch],[note,enum,-],[note__other,text,note],[retry_count,enum,-],[retry_count__other,text,retry_count]]`
  — 3 questions / 6 fields. Before the fix all six were questions, which is the `0/6` in the
  report.
- Two new cases in `render.test.ts`: the fold under real Codex field names and titles, and a
  `_meta.codex` box without `isOtherAnswer` staying independent.
- `render`, `elicit-decline-notice`, `daemon-permission-autoallow`, `daemon-commands`:
  375 passed on this base (rebased onto #1825, which also touched `render.ts` — applied
  cleanly). Daemon + protocol `typecheck`, ESLint, Prettier clean.
