### PR TITLE
feat(daemon): tell a sandboxed runtime its Git metadata is read-only

### DIFF
--- a/packages/daemon/src/acp/acp-host.ts
+++ b/packages/daemon/src/acp/acp-host.ts
@@ -858,6 +858,11 @@ export class AcpHost {
     return this.isClaudeRuntime()
   }
 
+  /** Whether this runtime was launched under the OS sandbox — the launch carried a sandbox plan. */
+  runsInSandbox(): boolean {
+    return this.opts.sandbox !== undefined
+  }
+
   /** Create a fresh ACP session. `effortOverride` (the sticky per-session effort choice,
    *  when set) takes the place of the agent default in the Claude `_meta` — the only
    *  channel `ultracode` can ride (the `thought_level` select rejects it); select-based

--- a/packages/daemon/src/session/session-manager.ts
+++ b/packages/daemon/src/session/session-manager.ts
@@ -589,6 +589,8 @@ export class SessionManager {
           needsReplyToParent,
           memoryIndex,
           usesMeta,
+          // The launch's own answer, so a downgraded (unconfinable) host never claims the sandbox rules.
+          sandboxed: host.runsInSandbox?.() ?? false,
           // The platform's session-stable block (Linear's issue coordinates and working convention):
           // standing, so it never lands as a leading user block or a transcript row.
           ...(platformStanding ? { platformStanding } : {})

--- a/packages/daemon/src/session/turn/standing-context.ts
+++ b/packages/daemon/src/session/turn/standing-context.ts
@@ -73,6 +73,8 @@ export type StandingContextInput = {
   usesMeta: boolean
   /** The platform module's own standing block (`NormalizedMessage.standingContext`), if any. */
   platformStanding?: string
+  /** Whether the host runs under the OS sandbox, whose Git-metadata rules the model must know. */
+  sandboxed?: boolean
 }
 
 /** The assembled standing-context strings for one turn. */
@@ -83,6 +85,8 @@ export type StandingContext = {
   workspaceRootsAppend: string
   /** The platform module's standing block; '' when the delivery carried none. */
   platformAppend: string
+  /** The sandbox's standing rules; '' for an unconfined host. */
+  sandboxAppend: string
   collabAppend: string
   parentReplyAppend: string
   /** Durable standing rules re-asserted on session/load — no memory index. */
@@ -212,6 +216,21 @@ export function buildWorkspaceRootsAppend(
   ].join('\n')
 }
 
+// Daemon-side Git runs in the same checkout outside the sandbox, so `.git/config`/`hooks` stay read-only to the model; said up front, or `push -u`'s EBUSY reads as a broken checkout.
+export function buildSandboxAppend(sandboxed: boolean | undefined): string {
+  if (!sandboxed) return ''
+  return (
+    `# Sandbox\n` +
+    `You run inside an OS sandbox. In every Git checkout, \`.git/config\` and \`.git/hooks\` are read-only: ` +
+    `commands that write them fail, usually as \`Device or resource busy\`, and that failure is expected, not a ` +
+    `broken checkout. So do not run \`git config\`, \`git remote add/set-url\`, or set an upstream — push with the ` +
+    `explicit form \`git push origin <branch>\` (never \`-u\`/\`--set-upstream\`) and pull with ` +
+    `\`git pull --ff-only origin <branch>\`. Author identity and other Git settings are already provided ` +
+    `through the environment. Zero-byte placeholder files the sandbox mounts inside the checkout may appear ` +
+    `untracked in \`git status\`; leave them alone and never commit them.`
+  )
+}
+
 // Standing guidance for agent↔agent collaboration. `sendMessage` can wake a peer, reach
 // humans, post at a channel root, or reply into a parent session. It has no visible
 // in-thread form: speaking in the current conversation is an ordinary reply. `toAgent`
@@ -290,6 +309,7 @@ export function buildStandingContext(input: StandingContextInput): StandingConte
   const memoryAppend = buildMemoryAppend(input.memoryIndex)
   const agentMeta = buildAgentMeta(input)
   const workspaceRootsAppend = buildWorkspaceRootsAppend(input.workspaceRoots)
+  const sandboxAppend = buildSandboxAppend(input.sandboxed)
   // Session-stable like the roots, so it is re-asserted on resume in the same seat.
   const platformAppend = input.platformStanding?.trim() ?? ''
   const collabAppend = COLLAB_APPEND
@@ -297,6 +317,7 @@ export function buildStandingContext(input: StandingContextInput): StandingConte
   const resumeSystemContext = [
     agentMeta,
     workspaceRootsAppend,
+    sandboxAppend,
     platformAppend,
     collabAppend,
     parentReplyAppend,
@@ -309,6 +330,7 @@ export function buildStandingContext(input: StandingContextInput): StandingConte
     memoryAppend,
     agentMeta,
     workspaceRootsAppend,
+    sandboxAppend,
     platformAppend,
     collabAppend,
     parentReplyAppend,

--- a/packages/daemon/test/standing-context.test.ts
+++ b/packages/daemon/test/standing-context.test.ts
@@ -77,3 +77,24 @@ describe('buildStandingContext with a platform standing block', () => {
     expect(buildStandingContext({ ...BASE, platformStanding: '  \n' })).toEqual(buildStandingContext(BASE))
   })
 })
+
+describe('buildStandingContext under the sandbox', () => {
+  it('states the read-only Git metadata rule after the roots and re-asserts it on resume', () => {
+    const context = buildStandingContext({ ...BASE, workspaceRoots: ROOTS, sandboxed: true })
+
+    expect(context.sandboxAppend).toContain('`.git/config` and `.git/hooks` are read-only')
+    expect(context.sandboxAppend).toContain('git push origin <branch>')
+    expect(context.resumeSystemContext).toContain(context.sandboxAppend)
+    expect(context.resumeSystemContext.indexOf('# Sandbox')).toBeGreaterThan(
+      context.resumeSystemContext.indexOf('# Additional repositories')
+    )
+    expect(context.resumeSystemContext.indexOf('# Sandbox')).toBeLessThan(
+      context.resumeSystemContext.indexOf('# Collaborating with other agents')
+    )
+  })
+
+  it('leaves an unconfined host byte-identical', () => {
+    expect(buildStandingContext({ ...BASE, sandboxed: false })).toEqual(buildStandingContext(BASE))
+    expect(buildStandingContext(BASE).sandboxAppend).toBe('')
+  })
+})


### PR DESCRIPTION
## Why

The sandbox denies writes to `.git/config` and `.git/hooks` in every checkout (SRT `allowGitConfig: false`): daemon-side Git runs in the same checkout outside the sandbox, and those two files are where a checkout can turn a later `git` into code execution. A sandboxed model meets that denial as an opaque `Device or resource busy` on `git push -u` / `git branch --set-upstream-to` and stops, treating a healthy checkout as broken. Observed on a self-hosted agent this week.

## What

- `AcpHost.runsInSandbox()` — answers from the launch itself (a sandbox plan was attached), so a host downgraded to unconfined never claims the rule.
- Standing context gains a `# Sandbox` block for a sandboxed host, seated after the additional-repositories block and re-asserted on resume: `.git/config` / `.git/hooks` are read-only, the failure shape is expected, use `git push origin <branch>` and `git pull --ff-only origin <branch>`, never `-u` / `git config` / `git remote`, and leave the sandbox's zero-byte placeholder files alone.
- Unconfined hosts produce byte-identical context (tested).

## Not in scope

Loosening the deny itself. The daemon's per-command `-c` pins and the local-config blacklist audit remain the outer defense; the sandbox deny stays as the layer that does not bet on that blacklist being complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
