### PR TITLE
feat(daemon): a Slack text/number elicitation is answered by a thread reply

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6421,6 +6421,11 @@ export class Daemon {
       return { kind: 'rejected', reason: 'suppressed' }
     }
 
+    // A live `text`/`number` elicitation card is answered by a reply in its own thread, and while
+    // it waits the ACP prompt is still blocked — so the reply is intercepted as the answer here,
+    // before routing could dispatch or queue it as a turn of its own (#1794's Slack column).
+    if (await this.permissions.answerElicitReply(msg)) return { kind: 'rejected', reason: 'suppressed' }
+
     const threadOwner = await this.prefetchedThreadOwner(msg)
     const result = routeRules(msg, routingRules, () => threadOwner)
     // Participant delivery is independent of whether the single-target ladder found an
@@ -7051,6 +7056,9 @@ export class Daemon {
       await this.commands.handleCommand(command, normalized, target)
       return { msgId: msg.msgId, accepted: true }
     }
+    // The same elicitation-reply interception the direct path applies, at the same point in the
+    // ladder: both Slack ingresses behave identically for every other elicitation verb too.
+    if (await this.permissions.answerElicitReply(normalized)) return { msgId: msg.msgId, accepted: true }
     // HTTP-bot ingress bypasses onInbound(), so repeat its `!stop` thread-mute gate:
     // while muted, implicit routing (thread affinity / keyword / auto / dm) never
     // dispatches — only an explicit @mention does, and it clears the mute. Muted traffic

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -34,10 +34,13 @@ import {
   buildUrlConsentCard,
   buildUrlConsentResolvedCard,
   clampTo,
+  ELICIT_REPLY_KINDS,
   elicitFieldLabel,
   elicitForm,
   elicitFormAccepts,
   elicitFormContent,
+  elicitReplyAnswer,
+  elicitReplyExpectation,
   elicitRequiredProps,
   elicitTarget,
   elicitUrl,
@@ -65,6 +68,9 @@ import {
   type ApprovalRequestParts
 } from '../daemon/tool-classification.js'
 import { pendingTurnKey, type DaemonRenderAction, type Pending } from '../daemon/turn-types.js'
+import { isTrustedHumanTurn } from '../daemon/loop-guard-scope.js'
+import { transcriptChannelKey } from '../store/local-store.js'
+import type { NormalizedMessage } from '../messages/normalized.js'
 
 /** The union of a turn's explicit human-approval waits, measured here and nowhere else.
  *  Regeneration budgets subtract it while retaining runtime/tool work time; `depth` counts
@@ -231,6 +237,39 @@ function consentedUrlKey(owner: HostKey, elicitationId: string): string {
   return `${owner}\x00${elicitationId}`
 }
 
+/** Where a reply-answered Slack card takes its answer from — the whole interception, held on the
+ *  card's own record so it can never outlive it. `conversation` is the platform plus the turn's
+ *  transcript channel, so another Slack app watching the same channel is a different
+ *  conversation; `thread` is the turn's own thread, so another thread of that channel is not the
+ *  answer either. A DM session ALSO takes a top-level message there, since a DM reader answers
+ *  where they are talking rather than in a thread. `requesterId` is the turn's requester when it
+ *  is known — the only person the card then waits for. */
+interface ElicitReplyTarget {
+  conversation: string
+  thread: string
+  dm: boolean
+  requesterId?: string
+}
+
+/** The conversation half of {@link ElicitReplyTarget}, from either side: a live turn's plan or an
+ *  inbound message. Both spell the channel the way the transcript does, scope included. */
+function elicitReplyConversation(platform: string, transcriptChannel: string): string {
+  return `${platform}\x00${transcriptChannel}`
+}
+
+/** The reply target a live turn's card takes: its own conversation and thread, and its requester
+ *  where the turn names one. `unknown` is not a person — a turn whose author could not be
+ *  identified waits for anyone in the thread instead, which is what the card then says. */
+function elicitReplyTargetFor(p: Pending): ElicitReplyTarget {
+  const requester = p.plan.requesterId
+  return {
+    conversation: elicitReplyConversation(p.plan.platform, p.plan.transcriptChannel),
+    thread: p.plan.statusThread,
+    dm: p.plan.isDm === true,
+    ...(requester && requester !== 'unknown' ? { requesterId: requester } : {})
+  }
+}
+
 /** One outstanding `elicitation/create` awaiting a human answer. */
 type PendingElicit = PendingElicitSurface & {
   owner: HostKey
@@ -246,6 +285,9 @@ type PendingElicit = PendingElicitSurface & {
    *  Present ⇒ `propName`/`kind`/`form` mean nothing — the card has no field, and its only
    *  answers are consent (this same URL back) or Dismiss. */
   url?: { elicitationId: string; url: string }
+  /** Set only for a card answered by a THREAD REPLY ({@link ELICIT_REPLY_KINDS}) — the reply this
+   *  card takes as its answer. Absent on every card whose answer is a tap. */
+  reply?: ElicitReplyTarget
   approval: boolean
   resolve: (res: CreateElicitationResponse) => void
 }
@@ -1410,8 +1452,18 @@ export class PermissionCoordinator {
     if (params.mode === 'url') return this.noticeUnrenderableElicit(p, params, isApproval)
     const target = elicitTarget(params, SLACK_ELICIT_SURFACE)
     if (!target) return this.noticeUnrenderableElicit(p, params, isApproval)
+    // A `text`/`number` card has nothing to tap: the reader answers by replying in the thread,
+    // and the card says whose reply it waits for. An approval never takes this shape — allow/deny
+    // is an enum — so the interception only ever belongs to a plain question.
+    const reply = ELICIT_REPLY_KINDS.has(target.kind) ? elicitReplyTargetFor(p) : undefined
     const requestId = isApproval ? randomUUID() : `elicit-${++this.elicitSeq}`
-    const blocks = buildElicitationCard(requestId, params, this.host.httpSlackSessionTarget(p))
+    const blocks = buildElicitationCard(
+      requestId,
+      params,
+      this.host.httpSlackSessionTarget(p),
+      SLACK_ELICIT_SURFACE,
+      reply?.requesterId ? `<@${reply.requesterId}>` : undefined
+    )
     if (!blocks) return this.noticeUnrenderableElicit(p, params, isApproval)
     const fallback = (params as { message?: string }).message ?? 'The agent needs your input'
     let resolveResult!: (res: CreateElicitationResponse) => void
@@ -1423,6 +1475,7 @@ export class PermissionCoordinator {
       params,
       propName: target.propName,
       kind: target.kind,
+      ...(reply ? { reply } : {}),
       approval: isApproval,
       surface: 'slack',
       conn,
@@ -1942,6 +1995,67 @@ export class PermissionCoordinator {
       requestId: a.requestId,
       value: a.values,
       ...(a.actor ? { actor: a.actor } : {})
+    })
+  }
+
+  /**
+   * A thread reply, while a `text`/`number` card is live, IS that card's answer rather than a new
+   * turn (issue #1794's Slack column): sending a message is what typing something already is on
+   * Slack. Called from BOTH Slack ingress paths — relay-forwarded and direct socket — before
+   * either dispatches or queues, since the ACP prompt is still blocked while the card waits.
+   *
+   * Returns true when the reply was consumed: accepted, or refused with the reason said in the
+   * thread and the card LEFT LIVE, which is the same "drop it and leave the card live" verdict
+   * every other surface's re-derivation reaches — Dismiss is the only explicit refusal. Returns
+   * false for a message that is not this card's answer, which then stays an ordinary one.
+   *
+   * Nothing is remembered here: the interception is the pending card's own `reply` target, so it
+   * is released the instant the card settles, is dismissed, or the turn ends (`releaseElicits`).
+   */
+  async answerElicitReply(msg: NormalizedMessage): Promise<boolean> {
+    // Only a human's own words answer a question — a bot echo, an automation, and this daemon's
+    // own posts all reach the same ingress. An EDIT of an earlier message never gets here at all:
+    // Slack ingress drops edit wrappers, so re-typing a past message is not an answer either.
+    if (!isTrustedHumanTurn(msg)) return false
+    // A reply that shares a file is not a typed answer, and consuming it would drop the file:
+    // it stays an ordinary message, and the card stays live for a reply that IS one.
+    if (msg.attachments?.length) return false
+    const conversation = elicitReplyConversation(msg.platform, transcriptChannelKey(msg.channel, msg.transportScope))
+    for (const [requestId, rec] of this.pendingElicits) {
+      const reply = rec.reply
+      if (!reply || reply.conversation !== conversation) continue
+      // The turn's OWN thread. A DM session also takes a top-level message, where its reader talks.
+      if (msg.thread !== undefined ? msg.thread !== reply.thread : !reply.dm) continue
+      // The requester answers their own turn; a card that could name none takes anyone in the
+      // thread. Anyone else is not answering it — their message stays an ordinary one.
+      if (reply.requesterId !== undefined && reply.requesterId !== msg.sender.id) continue
+      const target = elicitTarget(rec.params, surfaceOf(rec))
+      if (!target || !ELICIT_REPLY_KINDS.has(target.kind)) return false
+      // Re-derived against the card that asked, exactly as a tapped option is (#1815).
+      const answer = elicitReplyAnswer(target, msg.text)
+      if (answer === null) {
+        this.sayElicitReplyRefused(rec, target)
+        return true
+      }
+      await this.handleElicitChoice({
+        requestId,
+        value: answer,
+        actor: { userId: msg.sender.id, ...(msg.sender.name ? { name: msg.sender.name } : {}) }
+      })
+      return true
+    }
+    return false
+  }
+
+  /** Say in the conversation why a reply could not be the answer, leaving the card live: an
+   *  invalid reply is not a refusal, so it does not consume the question. A notice, so it lands
+   *  where every other one does. Best effort — the card is answerable again either way. */
+  private sayElicitReplyRefused(rec: PendingElicit, target: ElicitTarget): void {
+    const p = this.host.pending().get(pendingTurnKey(rec.owner, rec.sessionId))
+    if (!p) return
+    this.host.enqueueApply(p, {
+      kind: 'notice',
+      text: `That reply isn't ${elicitReplyExpectation(target)} — the question is still open.`
     })
   }
 

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -34,6 +34,7 @@ import {
   buildUrlConsentCard,
   buildUrlConsentResolvedCard,
   clampTo,
+  decodeSlackReplyValue,
   ELICIT_REPLY_KINDS,
   elicitFieldLabel,
   elicitForm,
@@ -69,6 +70,7 @@ import {
   type ApprovalRequestParts
 } from '../daemon/tool-classification.js'
 import { pendingTurnKey, type DaemonRenderAction, type Pending } from '../daemon/turn-types.js'
+import { slackTsFromMsgId } from '../daemon/helpers.js'
 import { isTrustedHumanTurn } from '../daemon/loop-guard-scope.js'
 import { transcriptChannelKey } from '../store/local-store.js'
 import type { NormalizedMessage } from '../messages/normalized.js'
@@ -256,6 +258,18 @@ interface ElicitReplyTarget {
  *  inbound message. Both spell the channel the way the transcript does, scope included. */
 function elicitReplyConversation(platform: string, transcriptChannel: string): string {
   return `${platform}\x00${transcriptChannel}`
+}
+
+/** Is this message a reply INTO someone else's thread, rather than a root of its own?
+ *
+ *  Slack normalization sets `thread` to `thread_ts ?? ts`, so it is never absent and a top-level
+ *  message carries its OWN id there — which is exactly how a root is told apart from a reply,
+ *  once you compare the two rather than test for absence. Derived here rather than preserved as a
+ *  new normalized field: nothing was lost in normalization, `thread` has some forty readers whose
+ *  meaning must not shift under them, and a new wire field would need a skew window on both
+ *  ingress paths for a fact already in hand. */
+function isThreadReply(msg: NormalizedMessage): boolean {
+  return msg.thread !== undefined && msg.thread !== slackTsFromMsgId(msg.msgId)
 }
 
 /** The reply target a live turn's card takes: its own conversation and thread, and its requester
@@ -2026,8 +2040,9 @@ export class PermissionCoordinator {
     for (const [requestId, rec] of this.pendingElicits) {
       const reply = rec.reply
       if (!reply || reply.conversation !== conversation) continue
-      // The turn's OWN thread. A DM session also takes a top-level message, where its reader talks.
-      if (msg.thread !== undefined ? msg.thread !== reply.thread : !reply.dm) continue
+      // The turn's OWN thread — another thread of the same channel is another conversation, word
+      // for word. A DM session ALSO takes a root message, since that is where its reader talks.
+      if (isThreadReply(msg) ? msg.thread !== reply.thread : !reply.dm) continue
       // The requester answers their own turn; a card that could name none takes anyone in the
       // thread. Anyone else is not answering it — their message stays an ordinary one.
       if (reply.requesterId !== undefined && reply.requesterId !== msg.sender.id) continue
@@ -2043,12 +2058,15 @@ export class PermissionCoordinator {
       return false
     }
     const { requestId, rec, target } = matched[0]!
-    // Re-derived against the card that asked, exactly as a tapped option is (#1815) — after the
-    // one piece of addressing that is chrome rather than value comes off (`@bot 42` is 42). The
-    // bot id comes from the card's OWN connection, so both ingresses read the same identity, and
-    // an unresolved one (a send-only connection before `auth.test`) strips nothing.
+    // What the reader actually typed, in two pure steps before any schema check: the one piece of
+    // addressing that is chrome rather than value comes off (`@bot 42` is 42), then Slack's own
+    // representation of a link is decoded (`<mailto:a@b|a@b>` is a@b), since neither is the
+    // reader's answer and both would fail validation forever. The bot id comes from the card's
+    // OWN connection, so both ingresses read the same identity, and an unresolved one (a
+    // send-only connection before `auth.test`) strips nothing.
     const addressed = stripLeadingSelfMention(msg.text, rec.surface === 'slack' ? rec.conn.botUserId : undefined)
-    const answer = elicitReplyAnswer(target, addressed)
+    // Re-derived against the card that asked, exactly as a tapped option is (#1815).
+    const answer = elicitReplyAnswer(target, decodeSlackReplyValue(addressed))
     if (answer === null) {
       this.sayElicitReplyRefused(rec, target)
       return true

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -49,6 +49,7 @@ import {
   numberAccepts,
   SLACK_DM_ELICIT_SURFACE,
   SLACK_ELICIT_SURFACE,
+  stripLeadingSelfMention,
   textAccepts,
   WEBCHAT_ELICIT_SURFACE
 } from '../slack/render.js'
@@ -2021,6 +2022,7 @@ export class PermissionCoordinator {
     // it stays an ordinary message, and the card stays live for a reply that IS one.
     if (msg.attachments?.length) return false
     const conversation = elicitReplyConversation(msg.platform, transcriptChannelKey(msg.channel, msg.transportScope))
+    const matched: { requestId: string; rec: PendingElicit; target: ElicitTarget }[] = []
     for (const [requestId, rec] of this.pendingElicits) {
       const reply = rec.reply
       if (!reply || reply.conversation !== conversation) continue
@@ -2030,33 +2032,65 @@ export class PermissionCoordinator {
       // thread. Anyone else is not answering it — their message stays an ordinary one.
       if (reply.requesterId !== undefined && reply.requesterId !== msg.sender.id) continue
       const target = elicitTarget(rec.params, surfaceOf(rec))
-      if (!target || !ELICIT_REPLY_KINDS.has(target.kind)) return false
-      // Re-derived against the card that asked, exactly as a tapped option is (#1815).
-      const answer = elicitReplyAnswer(target, msg.text)
-      if (answer === null) {
-        this.sayElicitReplyRefused(rec, target)
-        return true
-      }
-      await this.handleElicitChoice({
-        requestId,
-        value: answer,
-        actor: { userId: msg.sender.id, ...(msg.sender.name ? { name: msg.sender.name } : {}) }
-      })
+      if (target && ELICIT_REPLY_KINDS.has(target.kind)) matched.push({ requestId, rec, target })
+    }
+    if (!matched.length) return false
+    // Two open questions in one thread cannot both be answered by one reply, and picking either
+    // would tell one runtime the reader answered a question they did not. Name the ambiguity and
+    // take nothing: the reader can dismiss one, or wait for one to settle.
+    if (matched.length > 1) {
+      this.sayElicitReplyAmbiguous(matched.map((m) => m.rec))
+      return false
+    }
+    const { requestId, rec, target } = matched[0]!
+    // Re-derived against the card that asked, exactly as a tapped option is (#1815) — after the
+    // one piece of addressing that is chrome rather than value comes off (`@bot 42` is 42). The
+    // bot id comes from the card's OWN connection, so both ingresses read the same identity, and
+    // an unresolved one (a send-only connection before `auth.test`) strips nothing.
+    const addressed = stripLeadingSelfMention(msg.text, rec.surface === 'slack' ? rec.conn.botUserId : undefined)
+    const answer = elicitReplyAnswer(target, addressed)
+    if (answer === null) {
+      this.sayElicitReplyRefused(rec, target)
       return true
     }
-    return false
+    await this.handleElicitChoice({
+      requestId,
+      value: answer,
+      actor: { userId: msg.sender.id, ...(msg.sender.name ? { name: msg.sender.name } : {}) }
+    })
+    return true
   }
 
-  /** Say in the conversation why a reply could not be the answer, leaving the card live: an
-   *  invalid reply is not a refusal, so it does not consume the question. A notice, so it lands
-   *  where every other one does. Best effort — the card is answerable again either way. */
+  /** Say that a reply cannot answer any of the several questions open in this thread, leaving
+   *  every one of them live. ONE line per reply rather than one per card — they share the thread,
+   *  and it is the thread that is ambiguous — spoken through the first card whose turn is still
+   *  live. */
+  private sayElicitReplyAmbiguous(recs: readonly PendingElicit[]): void {
+    const text =
+      `${recs.length} questions are open in this thread, so a reply cannot answer any of them — ` +
+      'dismiss all but one, or let one settle, and the next reply answers that one.'
+    for (const rec of recs) if (this.noticeInTurn(rec, text)) return
+  }
+
+  /** Say why a reply could not be the answer, leaving the card live: an invalid reply is not a
+   *  refusal, so it does not consume the question. Dismiss remains the only one. */
   private sayElicitReplyRefused(rec: PendingElicit, target: ElicitTarget): void {
+    this.noticeInTurn(rec, `That reply isn't ${elicitReplyExpectation(target)} — the question is still open.`)
+  }
+
+  /** Post one daemon-authored line into a pending card's own turn — a notice, so it lands where
+   *  every other one does. False when that turn is already gone, or when the surface refused it.
+   *  Best effort by construction: no elicitation outcome depends on it. */
+  private noticeInTurn(rec: PendingElicit, text: string): boolean {
     const p = this.host.pending().get(pendingTurnKey(rec.owner, rec.sessionId))
-    if (!p) return
-    this.host.enqueueApply(p, {
-      kind: 'notice',
-      text: `That reply isn't ${elicitReplyExpectation(target)} — the question is still open.`
-    })
+    if (!p) return false
+    try {
+      this.host.enqueueApply(p, { kind: 'notice', text })
+    } catch (err) {
+      this.host.log().warn(`elicitation reply notice not delivered for ${rec.sessionId}: ${formatErr(err)}`)
+      return false
+    }
+    return true
   }
 
   /** Resolve every outstanding elicitation for a session as `cancel` — ACP's cancellation

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -1206,6 +1206,36 @@ export function stripLeadingSelfMention(text: string, botUserId?: string): strin
   return found && found[1] === botUserId ? text.slice(found[0].length) : text
 }
 
+/** Slack's retrieved-message form for ONE link and nothing else: `<dest>` or `<dest|label>`,
+ *  where the destination is the part BEFORE the pipe and the label is display text. Anchored on
+ *  purpose — a link sitting inside prose is not this. */
+const SLACK_LINK_ONLY_RE = /^<([^|>\s]+)(?:\|[^>]*)?>$/
+
+/** The three characters Slack HTML-escapes in the text it hands back, and nothing else — so
+ *  un-escaping exactly these is the lossless inverse of what the reader typed. */
+const SLACK_ENTITIES: [RegExp, string][] = [
+  [/&lt;/g, '<'],
+  [/&gt;/g, '>'],
+  [/&amp;/g, '&']
+]
+
+/** What the reader actually typed, recovered from Slack's own representation of it — the step
+ *  before any schema check, because `<https://x/>` and `<mailto:a@b|a@b>` are Slack's spelling
+ *  of a link, not the reader's answer, and would fail `uri`/`email` forever.
+ *
+ *  DECODING, never extracting: only a reply that is one link and nothing else is unwrapped, and
+ *  `mailto:` comes off so an `email` field gets `a@b` rather than `mailto:a@b`. Prose with a link
+ *  inside is returned whole — deciding which PART of a message is the value is the guess this
+ *  route refuses to make. Entity un-escaping applies either way, since Slack escapes those three
+ *  everywhere in message text. Inbound only: it has nothing to do with the outbound defusing
+ *  (#1810/#1819) that keeps AGENT-authored text from becoming markup on a card. Pure. */
+export function decodeSlackReplyValue(text: string): string {
+  const trimmed = text.trim()
+  const link = SLACK_LINK_ONLY_RE.exec(trimmed)
+  const value = link ? link[1]!.replace(/^mailto:/, '') : trimmed
+  return SLACK_ENTITIES.reduce((out, [pattern, char]) => out.replace(pattern, char), value)
+}
+
 /** The digit shapes a numeric reply may take. Deliberately narrower than `Number()`, which reads
  *  `0x1f`, `Infinity` and whitespace as numbers a reader plainly did not type. */
 const NUMERIC_REPLY_RE = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -1191,6 +1191,21 @@ export function elicitReplyExpectation(target: ElicitTarget): string {
   return parts.join(', ')
 }
 
+/** Slack's mention token for one user, at the very START of a message: the modern `<@U…>` and
+ *  the legacy `<@U…|name>`, plus the punctuation a reader puts after an address. */
+const LEADING_MENTION_RE = /^\s*<@([A-Z0-9]+)(?:\|[^>]*)?>[ \t]*[:,]?[ \t]*/
+
+/** A reply's text with a LEADING mention of the ASKING bot removed: "@bot 42" is 42, because
+ *  addressing the bot is chrome rather than value. Only that token, only this bot's own id —
+ *  a mention of anyone else, a second mention, or one anywhere but the front is content, and
+ *  guessing which PART of a message is the answer is how a typed answer comes back wrong. An
+ *  unknown bot id (identity not resolved yet) strips nothing. Pure. */
+export function stripLeadingSelfMention(text: string, botUserId?: string): string {
+  if (!botUserId) return text
+  const found = LEADING_MENTION_RE.exec(text)
+  return found && found[1] === botUserId ? text.slice(found[0].length) : text
+}
+
 /** The digit shapes a numeric reply may take. Deliberately narrower than `Number()`, which reads
  *  `0x1f`, `Infinity` and whitespace as numbers a reader plainly did not type. */
 const NUMERIC_REPLY_RE = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -636,12 +636,13 @@ const SLACK_ELICIT_MAX_BUTTONS = 24
 const SLACK_SELECT_MAX_OPTIONS = 100
 const SLACK_SELECT_VALUE_CAP = 75
 
-/** Slack renders single-select and boolean as a row of buttons, and multi-select as a
- *  `multi_static_select` plus a Confirm button — the select cannot submit on its own. It still has
- *  no field to type into, so `text`/`number` forms are declined there. The two controls carry
+/** Slack renders single-select and boolean as a row of buttons, multi-select as a
+ *  `multi_static_select` plus a Confirm button — the select cannot submit on its own — and a
+ *  `text`/`number` field as a question answered by REPLYING in the thread, since sending a
+ *  message is what typing something already is on Slack. The option-taking controls carry
  *  different lists, which is why the limits are per kind rather than one number for the surface. */
 export const SLACK_ELICIT_SURFACE: ElicitSurface = {
-  kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum']),
+  kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number']),
   optionLimits: {
     enum: { maxOptions: SLACK_ELICIT_MAX_BUTTONS },
     'multi-enum': { maxOptions: SLACK_SELECT_MAX_OPTIONS, maxOptionValue: SLACK_SELECT_VALUE_CAP }
@@ -650,7 +651,9 @@ export const SLACK_ELICIT_SURFACE: ElicitSurface = {
 
 /** The approval DM's card is a button row whose taps settle through the editor path, which holds
  *  no per-card selection — so a multi-select could be shown there but never confirmed, and it is
- *  withheld rather than posted dead. Otherwise exactly the in-channel Slack surface. */
+ *  withheld rather than posted dead. A `text`/`number` field is withheld for the same reason from
+ *  the other end: a DM has no session thread whose replies are intercepted as the answer, so the
+ *  card would ask for a reply nothing reads. Otherwise exactly the in-channel Slack surface. */
 export const SLACK_DM_ELICIT_SURFACE: ElicitSurface = {
   kinds: new Set<ElicitKind>(['enum', 'boolean']),
   optionLimits: { enum: { maxOptions: SLACK_ELICIT_MAX_BUTTONS } }
@@ -1143,6 +1146,69 @@ export function numberAccepts(target: ElicitTarget, value: number): boolean {
   return target.maximum === undefined || value <= target.maximum
 }
 
+/** The kinds a Slack card holds no control for and answers with a THREAD REPLY instead
+ *  (issue #1794's Slack column): sending a message is what typing something already is there,
+ *  where an `input` block with `dispatch_action` costs an interaction per change and buys
+ *  nothing. Read by the card builder and by the ingress interception, so the two agree. */
+export const ELICIT_REPLY_KINDS: ReadonlySet<ElicitKind> = new Set<ElicitKind>(['text', 'number'])
+
+/** How a reply-answered card names the shape a `format` asks for — plain words, with an example
+ *  where the shape is not one, because the reader has to type it from the card alone. */
+const FORMAT_EXPECTATION: Record<ElicitFormat, string> = {
+  email: 'an email address',
+  uri: 'a link',
+  date: 'a date, like 2026-09-07',
+  'date-time': 'a date and time, like 2026-09-07T09:30:00Z'
+}
+
+/** What a reply-answered card asks for, in plain words and never in schema vocabulary — shown on
+ *  the card and repeated when a reply does not fit, so the reader is told the same thing twice
+ *  rather than two different things. Pure. */
+export function elicitReplyExpectation(target: ElicitTarget): string {
+  if (target.kind === 'number') {
+    const noun = target.integer ? 'a whole number' : 'a number'
+    const { minimum: min, maximum: max } = target
+    if (min !== undefined && max !== undefined) return `${noun} from ${min} to ${max}`
+    if (min !== undefined) return `${noun}, ${min} or more`
+    return max !== undefined ? `${noun}, ${max} or less` : noun
+  }
+  const min = target.minLength
+  // Only a bound TIGHTER than the ceilings this surface imposes is the reader's to break: our own
+  // 4096/256 answer caps are not news, and a target cannot tell a declared 256 from the pattern one.
+  const max =
+    target.maxLength !== undefined && target.maxLength < ELICIT_PATTERN_INPUT_CAP ? target.maxLength : undefined
+  const length =
+    min !== undefined && max !== undefined
+      ? `${min} to ${max} characters long`
+      : min !== undefined
+        ? `at least ${min} characters long`
+        : max !== undefined
+          ? `at most ${max} characters long`
+          : ''
+  const parts = [target.format ? FORMAT_EXPECTATION[target.format] : 'some text']
+  if (length) parts.push(length)
+  if (target.pattern !== undefined) parts.push('in the exact format the question asks for')
+  return parts.join(', ')
+}
+
+/** The digit shapes a numeric reply may take. Deliberately narrower than `Number()`, which reads
+ *  `0x1f`, `Infinity` and whitespace as numbers a reader plainly did not type. */
+const NUMERIC_REPLY_RE = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/
+
+/** The answer a thread reply carries for a reply-answered card, re-derived against the card
+ *  itself exactly as a tapped option is: the typed value when this target would accept it, null
+ *  when it would not — the caller then says why and leaves the card live. A numeric field comes
+ *  back as a real JS number, so the accept content carries the schema's own type. Pure. */
+export function elicitReplyAnswer(target: ElicitTarget, reply: string): string | number | null {
+  const value = reply.trim()
+  if (target.kind === 'number') {
+    if (!NUMERIC_REPLY_RE.test(value)) return null
+    const parsed = Number(value)
+    return numberAccepts(target, parsed) ? parsed : null
+  }
+  return target.kind === 'text' && textAccepts(target, value) ? value : null
+}
+
 const BARE_URL_RE = /(?:https?:\/\/|www\.)\S+/gi
 
 /** The agent-authored elicitation `message`, with every link in it defused. A form-mode ask
@@ -1179,6 +1245,24 @@ function selectionHint(target: ElicitTarget): string {
   return max !== undefined ? `Select up to ${max}.` : ''
 }
 
+/** The Dismiss button every elicitation card carries — the reader's one explicit `decline`. */
+function elicitDismissButton(requestId: string): Record<string, unknown> {
+  return {
+    type: 'button',
+    action_id: ELICIT_DISMISS_ACTION as string,
+    text: { type: 'plain_text', text: 'Dismiss', emoji: true },
+    value: requestId
+  }
+}
+
+/** What a reply-answered card tells the reader to do: reply in this thread, with what, and whom
+ *  the question waits for — there is nothing on the card itself to type into. `awaits` is the
+ *  turn's requester as the platform spells them, absent when the card could not name one. */
+function replyInstruction(target: ElicitTarget, awaits?: string): string {
+  const ask = `Reply in this thread with ${elicitReplyExpectation(target)}.`
+  return awaits ? `${ask} Waiting for ${awaits}.` : `${ask} Anyone in this thread can answer.`
+}
+
 /** The multi-select half of {@link buildElicitationCard}: a `multi_static_select` carrying every
  *  option, a Confirm button and Dismiss, in ONE actions block so all three share the block_id the
  *  relay routes on. The select re-delivers the whole selection on each change and never submits,
@@ -1211,12 +1295,7 @@ function buildMultiSelectElements(requestId: string, target: ElicitTarget): unkn
       style: 'primary',
       value: requestId
     },
-    {
-      type: 'button',
-      action_id: ELICIT_DISMISS_ACTION as string,
-      text: { type: 'plain_text', text: 'Dismiss', emoji: true },
-      value: requestId
-    }
+    elicitDismissButton(requestId)
   ]
 }
 
@@ -1224,20 +1303,34 @@ function buildMultiSelectElements(requestId: string, target: ElicitTarget): unkn
  * Build the interactive elicitation card: the agent's `message` and one actions row — EVERY
  * {@link elicitTarget} option as a button for a single-select or boolean, or a
  * `multi_static_select` plus Confirm for a multi-select — always with a Dismiss button. The choice
- * rides each option's `value` (`<requestId>|<optionValue>`). Returns null when the form can't be
- * rendered on `surface` (caller declines): a kind or an option list it does not claim, which the
- * reduction has already refused, or a multi-select whose encoded option values Slack's select
- * would reject. Nothing here trims a list to fit. Pure.
+ * rides each option's `value` (`<requestId>|<optionValue>`). A {@link ELICIT_REPLY_KINDS} field
+ * has no control at all: the card carries the question, what is expected, whom it awaits
+ * (`awaits`) and Dismiss, and the answer arrives as a reply in the thread. Returns null when the
+ * form can't be rendered on `surface` (caller declines): a kind or an option list it does not
+ * claim, which the reduction has already refused, or a multi-select whose encoded option values
+ * Slack's select would reject. Nothing here trims a list to fit. Pure.
  */
 export function buildElicitationCard(
   requestId: string,
   params: CreateElicitationRequest,
   sessionTarget?: string,
-  surface: ElicitSurface = SLACK_ELICIT_SURFACE
+  surface: ElicitSurface = SLACK_ELICIT_SURFACE,
+  awaits?: string
 ): unknown[] | null {
   const target = elicitTarget(params, surface)
   if (!target) return null
   const message = elicitCardMessage(params)
+  if (ELICIT_REPLY_KINDS.has(target.kind)) {
+    return [
+      { type: 'section', text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(message, ELICIT_MESSAGE_CAP)}` } },
+      { type: 'context', elements: [{ type: 'mrkdwn', text: replyInstruction(target, awaits) }] },
+      {
+        type: 'actions',
+        ...(sessionTarget ? { block_id: sessionTarget } : {}),
+        elements: [elicitDismissButton(requestId)]
+      }
+    ]
+  }
   if (target.kind === 'multi-enum') {
     const elements = buildMultiSelectElements(requestId, target)
     if (!elements) return null
@@ -1254,12 +1347,7 @@ export function buildElicitationCard(
     text: { type: 'plain_text', text: o.label, emoji: true },
     value: encodePermValue(requestId, o.value)
   }))
-  buttons.push({
-    type: 'button',
-    action_id: ELICIT_DISMISS_ACTION as string,
-    text: { type: 'plain_text', text: 'Dismiss', emoji: true },
-    value: requestId
-  } as (typeof buttons)[number])
+  buttons.push(elicitDismissButton(requestId) as (typeof buttons)[number])
   return [
     { type: 'section', text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(message, ELICIT_MESSAGE_CAP)}` } },
     { type: 'actions', ...(sessionTarget ? { block_id: sessionTarget } : {}), elements: buttons }

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -267,6 +267,52 @@ describe('Daemon in-conversation commands', () => {
     expect(dispatch).toHaveBeenCalledWith('bot-a', payload, 'int-a')
   })
 
+  // #1794's Slack column: a `text`/`number` elicitation card is answered by a reply in the
+  // turn's thread, so while one is live the reply must be intercepted as the answer rather than
+  // dispatched or queued as a turn of its own. Both Slack ingresses do it at the same point in
+  // the ladder — after control commands, before routing — so they behave identically here too.
+  it('hands a thread reply to a live elicitation card instead of dispatching it, on both ingresses', async () => {
+    const blocked = blockingHost()
+    const daemon = new Daemon({
+      slackAppFactory: fakeSlackAppFactory(),
+      root: scaffold(),
+      hostFactory: () => blocked.host as any
+    })
+    await daemon.start()
+    makeRoutable(daemon)
+    const seen: string[] = []
+    ;(daemon as any).permissions.answerElicitReply = async (msg: any) => {
+      seen.push(msg.msgId)
+      return true
+    }
+
+    const payload = dm('relay-answer', '42')
+    expect(
+      await (daemon as any).handleRelayMsg(
+        {
+          source: 'im',
+          agentId: 'bot-a',
+          sessionKey: 'slack:C1:dm',
+          msgId: 'relay-answer',
+          botId: '11111111-1111-4111-8111-111111111111',
+          integrationId: 'int-a',
+          chatId: 'C1',
+          payload
+        } as RdMsgIm,
+        () => {}
+      )
+    ).toEqual({ msgId: 'relay-answer', accepted: true })
+
+    expect(await (daemon as any).onInboundOutcome(dm('300', '42'))).toEqual({
+      kind: 'rejected',
+      reason: 'suppressed'
+    })
+    expect(seen).toEqual(['slack:C1:relay-answer', 'slack:C1:300'])
+    // Both deliveries would otherwise have been a turn each — this agent routes DMs.
+    expect(blocked.prompts).toHaveLength(0)
+    await daemon.stop()
+  })
+
   it('stamps trigger=mention on relay im when the message mentions the integration bot', async () => {
     // Relay arbitration never populates the wire `trigger`; the daemon recomputes it
     // from the mention list + this integration's own bot identity (see handleRelayIm).

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -1002,9 +1002,12 @@ describe('a Slack answer is re-derived against the card that offered it', () => 
 // ── free text and numbers (issue #1794 gap 3) ────────────────────────────────
 
 /** A free-text form, optionally constrained. */
-function textElicitation(prop: Record<string, unknown> = {}): CreateElicitationRequest {
+function textElicitation(
+  prop: Record<string, unknown> = {},
+  message = 'What should I name the branch?'
+): CreateElicitationRequest {
   return formElicitation({
-    message: 'What should I name the branch?',
+    message,
     requestedSchema: {
       type: 'object',
       properties: { name: { type: 'string', ...prop } },
@@ -1908,8 +1911,9 @@ describe('a Slack text/number card is answered by a reply in its thread', () => 
     expect(await answer(daemon, 'add-retries', { sender: { id: 'U-other', isBot: false } })).toBe(false)
     // Another thread of the same channel is another conversation, even one word for word.
     expect(await answer(daemon, 'add-retries', { thread: 'other-thread' })).toBe(false)
-    // A top-level channel post is not a reply in the thread either.
-    expect(await answer(daemon, 'add-retries', { thread: undefined })).toBe(false)
+    // A root channel post is not a reply in the thread either — and its `thread` is its own ts,
+    // which is the shape normalization really produces.
+    expect(await answer(daemon, 'add-retries', { msgId: 'slack:test:200', thread: '200' })).toBe(false)
     // Another Slack app watching the same channel is a different conversation.
     expect(await answer(daemon, 'add-retries', { transportScope: 'slack:other-app' })).toBe(false)
     // A bot's message never answers a question — including this daemon's own posts.
@@ -1938,14 +1942,78 @@ describe('a Slack text/number card is answered by a reply in its thread', () => 
     await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
   })
 
-  it('takes a DM session’s top-level message, where its reader actually talks', async () => {
+  // The shape Slack normalization ACTUALLY produces: `thread` is `thread_ts ?? ts`, so it is
+  // never absent and a root message carries its OWN ts there. Testing for absence made the DM
+  // exception dead code — the card was as unanswerable as if it had never been written.
+  it('takes a DM session’s ROOT message, whose thread is its own timestamp', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const { pending } = slackReplyTurn(daemon)
     pending.plan.isDm = true
+    pending.plan.statusThread = '100.001'
     const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
     await liveCard(daemon)
-    expect(await answer(daemon, 'add-retries', { thread: undefined, isDm: true })).toBe(true)
+
+    // Still not ANY thread of that conversation: a reply under another root is another question.
+    expect(await answer(daemon, 'add-retries', { msgId: 'slack:test:300.001', thread: '250.001', isDm: true })).toBe(
+      false
+    )
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+
+    // The reviewer's reproduction: card at 100.001, a later top-level answer at 200.001.
+    expect(await answer(daemon, 'add-retries', { msgId: 'slack:test:200.001', thread: '200.001', isDm: true })).toBe(
+      true
+    )
     await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
+  })
+
+  // A `format`ted field asks for exactly the two things Slack rewrites on the way back out, so
+  // without decoding, a reader following the card's own instruction is refused forever.
+  it('reads a link answer out of Slack’s own markup for it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    slackReplyTurn(daemon)
+    const uri = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      textElicitation({ format: 'uri' }, 'Which page should I open?')
+    )
+    await liveCard(daemon)
+    expect(await answer(daemon, '<https://example.com/>')).toBe(true)
+    await expect(uri).resolves.toEqual({ action: 'accept', content: { name: 'https://example.com/' } })
+
+    // `<dest|label>`: the destination is the part BEFORE the pipe, and a `mailto:` scheme is
+    // Slack's spelling of an address rather than part of it.
+    const email = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      textElicitation({ format: 'email' }, 'Who should I notify?')
+    )
+    await liveCard(daemon)
+    expect(await answer(daemon, '<mailto:reader@example.com|reader@example.com>')).toBe(true)
+    await expect(email).resolves.toEqual({ action: 'accept', content: { name: 'reader@example.com' } })
+  })
+
+  // Decoding is not extracting: unwrapping ONE link is recovering what the reader typed, while
+  // picking a link out of a sentence is a judgement about which PART of it is the value.
+  it('leaves a link inside prose alone, and never takes a label for the value', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { notices } = slackReplyTurn(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      textElicitation({ format: 'uri' }, 'Which page should I open?')
+    )
+    await liveCard(daemon)
+
+    // Prose carrying a link is not one link: refused with the reason, and the card stays live.
+    expect(await answer(daemon, 'try <https://example.com/> first')).toBe(true)
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(notices).toHaveLength(1)
+
+    // A labelled link IS one link, and its value is the destination — the label is display text
+    // Slack added, and answering with it would report something the reader never gave.
+    expect(await answer(daemon, '<https://example.com/|the docs page>')).toBe(true)
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'https://example.com/' } })
+    expect(notices).toHaveLength(1)
   })
 
   it('releases the interception on Dismiss and on turn end — a later reply is conversation', async () => {

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -1749,6 +1749,8 @@ describe('a Slack text/number card is answered by a reply in its thread', () => 
   /** A Slack turn plus the notices its refusals post, and the card's live request id. */
   const slackReplyTurn = (daemon: any) => {
     const surface = slackPending(daemon)
+    // A real connection resolves this at `auth.test`, on the send-only (relay-managed) path too.
+    surface.pending.conn.botUserId = 'UBOT'
     const notices: string[] = []
     daemon.enqueueApply = (_p: unknown, action: any) => {
       if (action.kind === 'notice') notices.push(action.text as string)
@@ -1778,6 +1780,60 @@ describe('a Slack text/number card is answered by a reply in its thread', () => 
     }) as any
   const answer = (daemon: any, text: string, over: Record<string, unknown> = {}): Promise<boolean> =>
     daemon.permissions.answerElicitReply(reply(text, over))
+
+  // One reply cannot answer two open questions, and picking either would tell one runtime the
+  // reader answered something they did not — the same lie a shared selection told on #1825.
+  it('answers neither of two questions open in one thread, and says why', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { notices } = slackReplyTurn(daemon)
+    void (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation({ minLength: 1 }))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    void (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation({ minLength: 1 }))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(2))
+
+    // Taken as neither answer, and left an ordinary message.
+    expect(await answer(daemon, 'add-retries')).toBe(false)
+    expect((daemon as any).permissions.pendingElicits.size).toBe(2)
+    expect(notices).toEqual([
+      '2 questions are open in this thread, so a reply cannot answer any of them — dismiss all ' +
+        'but one, or let one settle, and the next reply answers that one.'
+    ])
+
+    // One dismissed leaves exactly one question in the thread, and the next reply answers it.
+    const [firstId] = (daemon as any).permissions.pendingElicits.keys()
+    await (daemon as any).permissions.handleElicitChoice({ requestId: firstId, value: null })
+    expect(await answer(daemon, 'add-retries')).toBe(true)
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+  })
+
+  it('drops a leading mention of the asker, which addresses it rather than answering it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { notices } = slackReplyTurn(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', numberElicitation({ minimum: 0 }))
+    await liveCard(daemon)
+
+    // Everything that is NOT this one shape stays part of the answer, so none of these is a
+    // number: guessing which other PART of a message is the value is how an answer comes back
+    // wrong. Each is refused with the reason and the card stays live.
+    expect(await answer(daemon, '<@U-someone-else> 42')).toBe(true)
+    expect(await answer(daemon, '42 <@UBOT>')).toBe(true)
+    expect(await answer(daemon, 'ping <@UBOT> 42')).toBe(true)
+    expect(await answer(daemon, '<@UBOT> <@UBOT> 42')).toBe(true)
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(notices).toHaveLength(4)
+
+    expect(await answer(daemon, '<@UBOT> 42')).toBe(true)
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { retries: 42 } })
+  })
+
+  it('keeps a text answer’s own words, minus only that one leading address', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    slackReplyTurn(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation({ minLength: 3 }))
+    await liveCard(daemon)
+    expect(await answer(daemon, '<@UBOT>: add-retries')).toBe(true)
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
+  })
 
   it('cards the question, what is expected and whom it awaits, then takes the reply', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -132,7 +132,9 @@ function installPending(daemon: Daemon): {
       agentId: 'agent-1',
       requesterId: 'turn-user',
       channel: 'test',
+      transcriptChannel: 'test',
       statusThread: 'test',
+      isDm: false,
       approvalSurfaceSuppressed: false
     },
     hostKey: 'agent-1',
@@ -1152,20 +1154,6 @@ describe('webchat answers a typed elicitation with the schema’s own type', () 
     await expect(result).resolves.toEqual({ action: 'accept', content: { retries: 3 } })
   })
 
-  it('declines a typed form on a Slack turn, whose card has no field to type into', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const pending: any = installPending(daemon)
-    pending.plan.platform = 'slack'
-    pending.conn = Object.create(SlackConnection.prototype)
-
-    await expect((daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())).resolves.toBeUndefined()
-    await expect((daemon as any).permissions.onAcpElicit('agent-1', 's1', numberElicitation())).resolves.toBeUndefined()
-    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
-    // The same forms ARE renderable — just not here: webchat types into them.
-    expect(elicitTarget(textElicitation(), WEBCHAT_ELICIT_SURFACE)?.kind).toBe('text')
-    expect(elicitTarget(numberElicitation(), WEBCHAT_ELICIT_SURFACE)?.kind).toBe('number')
-  })
-
   it('declines a form whose pattern could hang the daemon, rather than run it', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending: any = installPending(daemon)
@@ -1747,5 +1735,189 @@ describe('Slack renders and settles a URL-mode consent card', () => {
     await vi.waitFor(() => expect(posted).toHaveLength(1))
     expect(JSON.stringify(posted[0])).not.toContain('sk-live-DEADBEEF')
     await (daemon as any).permissions.releaseElicits('agent-1', 's1')
+  })
+})
+
+// ── a single text / number field, answered by a thread reply (issue #1794, Slack column) ────
+// Slack's own way to type something is to send a message, so the card has nothing to type into
+// and the next reply in the turn's thread IS the answer. The hard part is that such a reply
+// would otherwise start a new turn: while the card is live the ACP prompt is still blocked, so
+// ingress intercepts it before dispatch — and the interception is the pending card itself, so it
+// is gone the moment the card settles or the turn ends.
+
+describe('a Slack text/number card is answered by a reply in its thread', () => {
+  /** A Slack turn plus the notices its refusals post, and the card's live request id. */
+  const slackReplyTurn = (daemon: any) => {
+    const surface = slackPending(daemon)
+    const notices: string[] = []
+    daemon.enqueueApply = (_p: unknown, action: any) => {
+      if (action.kind === 'notice') notices.push(action.text as string)
+    }
+    return { ...surface, notices }
+  }
+  const liveCard = async (daemon: any): Promise<string> => {
+    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
+    const [requestId] = daemon.permissions.pendingElicits.keys()
+    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.get(requestId).ts).toBe('ts-1'))
+    return requestId
+  }
+  /** A human reply in the turn's own thread, as ingress normalizes it. */
+  const reply = (text: string, over: Record<string, unknown> = {}) =>
+    ({
+      msgId: 'slack:test:200',
+      traceId: '200',
+      source: 'user',
+      platform: 'slack',
+      channel: 'test',
+      thread: 'test',
+      sender: { id: 'turn-user', isBot: false, name: 'Turn User' },
+      text,
+      mentionedBots: [],
+      isDm: false,
+      ...over
+    }) as any
+  const answer = (daemon: any, text: string, over: Record<string, unknown> = {}): Promise<boolean> =>
+    daemon.permissions.answerElicitReply(reply(text, over))
+
+  it('cards the question, what is expected and whom it awaits, then takes the reply', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { posted, updated } = slackReplyTurn(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      textElicitation({ minLength: 3, maxLength: 40 })
+    )
+    await liveCard(daemon)
+    const blocks = posted[0]!
+    expect(blocks[0].text.text).toBe(':speech_balloon: What should I name the branch?')
+    expect(blocks[1].elements[0].text).toBe(
+      'Reply in this thread with some text, 3 to 40 characters long. Waiting for <@turn-user>.'
+    )
+    // Nothing to type into on the card — Dismiss is the only control it carries.
+    expect(blocks[2].elements.map((e: any) => e.text.text)).toEqual(['Dismiss'])
+    expect(updated).toHaveLength(0)
+
+    expect(await answer(daemon, 'add-retries')).toBe(true)
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
+    // The settled card records the answer the way every other surface does: the reader's own
+    // words back (#1803's `chosenLabel`), which is also what the thread already shows.
+    expect(updated[0]![0].text.text).toContain(':white_check_mark: add-retries')
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+  })
+
+  it('answers a numeric field with a real number, not the string that spelled it', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    slackReplyTurn(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      numberElicitation({ minimum: 1, maximum: 5 })
+    )
+    await liveCard(daemon)
+    expect(await answer(daemon, ' 3 ')).toBe(true)
+    const res = await answered
+    expect(res).toEqual({ action: 'accept', content: { retries: 3 } })
+    expect(typeof (res as any).content.retries).toBe('number')
+  })
+
+  it('says why an invalid reply is not the answer, and leaves the card live', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { updated, notices } = slackReplyTurn(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', numberElicitation({ minimum: 1 }))
+    await liveCard(daemon)
+
+    // Consumed (it was meant as the answer) but not spent: an invalid reply is not a refusal,
+    // so the question stays open and Dismiss remains the only way to say no.
+    expect(await answer(daemon, 'lots')).toBe(true)
+    expect(await answer(daemon, '0')).toBe(true)
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(updated).toHaveLength(0)
+    expect(notices).toEqual([
+      "That reply isn't a number, 1 or more — the question is still open.",
+      "That reply isn't a number, 1 or more — the question is still open."
+    ])
+
+    expect(await answer(daemon, '7')).toBe(true)
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { retries: 7 } })
+  })
+
+  it('takes the requester’s reply and leaves every other message an ordinary one', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { notices } = slackReplyTurn(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
+    await liveCard(daemon)
+
+    // Someone other than the turn's requester is not answering it — the card names who it waits
+    // for, and their message stays a message.
+    expect(await answer(daemon, 'add-retries', { sender: { id: 'U-other', isBot: false } })).toBe(false)
+    // Another thread of the same channel is another conversation, even one word for word.
+    expect(await answer(daemon, 'add-retries', { thread: 'other-thread' })).toBe(false)
+    // A top-level channel post is not a reply in the thread either.
+    expect(await answer(daemon, 'add-retries', { thread: undefined })).toBe(false)
+    // Another Slack app watching the same channel is a different conversation.
+    expect(await answer(daemon, 'add-retries', { transportScope: 'slack:other-app' })).toBe(false)
+    // A bot's message never answers a question — including this daemon's own posts.
+    expect(await answer(daemon, 'add-retries', { sender: { id: 'B1', isBot: true } })).toBe(false)
+    // A reply that shares a file is not a typed answer, and consuming it would drop the file.
+    expect(
+      await answer(daemon, 'add-retries', {
+        attachments: [{ id: 'F1', name: 'log.txt', mimeType: 'text/plain', sourceUrl: 'https://x' }]
+      })
+    ).toBe(false)
+    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
+    expect(notices).toEqual([]) // none of them was an attempt to answer, so none is refused
+
+    expect(await answer(daemon, 'add-retries')).toBe(true)
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
+  })
+
+  it('waits for anyone in the thread when the turn identifies no requester', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { pending, posted } = slackReplyTurn(daemon)
+    pending.plan.requesterId = 'unknown'
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
+    await liveCard(daemon)
+    expect(posted[0]![1].elements[0].text).toContain('Anyone in this thread can answer.')
+    expect(await answer(daemon, 'add-retries', { sender: { id: 'U-other', isBot: false } })).toBe(true)
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
+  })
+
+  it('takes a DM session’s top-level message, where its reader actually talks', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { pending } = slackReplyTurn(daemon)
+    pending.plan.isDm = true
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
+    await liveCard(daemon)
+    expect(await answer(daemon, 'add-retries', { thread: undefined, isDm: true })).toBe(true)
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
+  })
+
+  it('releases the interception on Dismiss and on turn end — a later reply is conversation', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    const { updated } = slackReplyTurn(daemon)
+    const dismissed = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
+    const firstId = await liveCard(daemon)
+    await (daemon as any).permissions.handleElicitChoice({ requestId: firstId, value: null })
+    await expect(dismissed).resolves.toEqual({ action: 'decline' })
+    expect(updated[0]![0].text.text).toContain(':no_entry_sign: Dismissed')
+    expect(await answer(daemon, 'add-retries')).toBe(false)
+
+    const abandoned = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
+    await liveCard(daemon)
+    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
+    await expect(abandoned).resolves.toEqual({ action: 'cancel' })
+    expect(await answer(daemon, 'add-retries')).toBe(false)
+    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
+  })
+
+  it('leaves a card whose answer is a TAP untouched by a thread reply', async () => {
+    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+    slackReplyTurn(daemon)
+    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', formElicitation())
+    const requestId = await liveCard(daemon)
+    // An enum card holds no reply target, so a reply naming one of its options is not its answer.
+    expect(await answer(daemon, 'main')).toBe(false)
+    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'main' })
+    await expect(answered).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
   })
 })

--- a/packages/daemon/test/elicit-decline-notice.test.ts
+++ b/packages/daemon/test/elicit-decline-notice.test.ts
@@ -28,16 +28,41 @@ function formElicitation(overrides: Record<string, unknown> = {}): CreateElicita
   } as CreateElicitationRequest
 }
 
-/** A free-text field: renderable on webchat, never on Slack, which has no box to type into. */
+/** A required nested object: a field NO surface has a control for, so every one of them
+ *  declines it — which is what leaves the in-channel notice as the only thing to say. */
 function unrenderableElicitation(overrides: Record<string, unknown> = {}): CreateElicitationRequest {
+  return formElicitation({
+    message: 'Which checks should I run?',
+    requestedSchema: {
+      type: 'object',
+      properties: { checks: { type: 'object' } },
+      required: ['checks']
+    },
+    ...overrides
+  })
+}
+
+/** Two required fields: one webchat card asks both, while Slack's single-field card cannot. */
+function twoFieldElicitation(): CreateElicitationRequest {
+  return formElicitation({
+    message: 'Which checks should I run?',
+    requestedSchema: {
+      type: 'object',
+      properties: { checks: { type: 'string', enum: ['lint', 'test'] }, note: { type: 'string' } },
+      required: ['checks', 'note']
+    }
+  })
+}
+
+/** A free-text field — which Slack now asks as a question answered by a thread reply. */
+function textElicitation(): CreateElicitationRequest {
   return formElicitation({
     message: 'Which checks should I run?',
     requestedSchema: {
       type: 'object',
       properties: { checks: { type: 'string' } },
       required: ['checks']
-    },
-    ...overrides
+    }
   })
 }
 
@@ -166,7 +191,7 @@ describe('an elicitation declined for want of a surface says so in the channel',
     await daemon.permissions.releaseElicits('agent-1', 's1')
   })
 
-  it('says nothing on a webchat turn, which renders every shape itself', async () => {
+  it('says nothing on a webchat turn, which renders a whole form Slack cannot', async () => {
     const { daemon, pending, notices } = slackTurn()
     pending.plan.platform = 'webchat'
     pending.webchat = {
@@ -178,7 +203,7 @@ describe('an elicitation declined for want of a surface says so in the channel',
       heldText: '',
       messageEmitted: false
     }
-    void daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())
+    void daemon.permissions.onAcpElicit('agent-1', 's1', twoFieldElicitation())
     await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
     expect(notices()).toEqual([])
     await daemon.permissions.releaseElicits('agent-1', 's1')
@@ -187,6 +212,14 @@ describe('an elicitation declined for want of a surface says so in the channel',
   it('says nothing for a multi-select Slack now renders as a select plus Confirm', async () => {
     const { daemon, notices } = slackTurn()
     void daemon.permissions.onAcpElicit('agent-1', 's1', multiElicitation())
+    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
+    expect(notices()).toEqual([])
+    await daemon.permissions.releaseElicits('agent-1', 's1')
+  })
+
+  it('says nothing for a text field Slack now answers by a thread reply', async () => {
+    const { daemon, notices } = slackTurn()
+    void daemon.permissions.onAcpElicit('agent-1', 's1', textElicitation())
     await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
     expect(notices()).toEqual([])
     await daemon.permissions.releaseElicits('agent-1', 's1')

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -21,6 +21,8 @@ import {
   elicitForm,
   elicitFormAccepts,
   elicitFormContent,
+  elicitReplyAnswer,
+  elicitReplyExpectation,
   elicitRequiredProps,
   elicitTarget,
   elicitUrl,
@@ -1625,9 +1627,7 @@ describe('elicitation card', () => {
     expect(elicitTarget(form({ ok: { type: 'boolean' } }), SLACK_ELICIT_SURFACE)?.propName).toBe('ok')
   })
 
-  it('returns null (→ caller declines) for free-text-only forms and url mode', () => {
-    expect(elicitTarget(form({ name: { type: 'string' } }), SLACK_ELICIT_SURFACE)).toBeNull()
-    expect(buildElicitationCard('e', form({ name: { type: 'string' } }))).toBeNull()
+  it('returns null (→ caller declines) for url mode, which is a consent card and not a field', () => {
     expect(
       elicitTarget({ mode: 'url', sessionId: 's1', message: 'go', url: 'https://x' } as any, SLACK_ELICIT_SURFACE)
     ).toBeNull()
@@ -1759,10 +1759,93 @@ describe('elicitation card', () => {
   })
 
   it('skips a field the surface cannot render and takes the next one it can', () => {
-    // Slack passes over the free-text field and cards the boolean; webchat renders both kinds.
-    const req = form({ name: { type: 'string' }, ok: { type: 'boolean' } })
-    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)?.propName).toBe('ok')
+    // A nested object is a field NO surface has a control for, so both pass over it; the
+    // approval DM, which renders neither typed kind, passes over the text field too.
+    const req = form({ extra: { type: 'object' }, name: { type: 'string' }, ok: { type: 'boolean' } })
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)?.propName).toBe('name')
     expect(elicitTarget(req, WEBCHAT_ELICIT_SURFACE)?.propName).toBe('name')
+    expect(elicitTarget(req, SLACK_DM_ELICIT_SURFACE)?.propName).toBe('ok')
+  })
+
+  // ── a single text / number field, answered by a thread reply (issue #1794, Slack column) ──
+  // Slack's own way to type something is to send a message, so the card carries the question,
+  // what is expected, whom it waits for, and Dismiss — and nothing to type into.
+
+  it('cards a text field as a question with no control but Dismiss', () => {
+    const req = form({ note: { type: 'string', minLength: 3, maxLength: 40 } }, 'What should the release note say?')
+    const blocks = buildElicitationCard(
+      'elicit-1',
+      req,
+      'shared-session-target',
+      SLACK_ELICIT_SURFACE,
+      '<@U1>'
+    ) as any[]
+    expect(blocks[0].text.text).toBe(':speech_balloon: What should the release note say?')
+    expect(blocks[1]).toEqual({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: 'Reply in this thread with some text, 3 to 40 characters long. Waiting for <@U1>.'
+        }
+      ]
+    })
+    expect(blocks[2].block_id).toBe('shared-session-target')
+    const [dismiss, ...rest] = blocks[2].elements
+    expect(rest).toEqual([]) // nothing to tap but the refusal
+    expect([dismiss.action_id, dismiss.value, dismiss.text.text]).toEqual([
+      ELICIT_DISMISS_ACTION,
+      'elicit-1',
+      'Dismiss'
+    ])
+  })
+
+  it('says who may answer when the turn named no requester', () => {
+    const blocks = buildElicitationCard('elicit-1', form({ n: { type: 'integer', minimum: 1, maximum: 5 } })) as any[]
+    expect(blocks[1].elements[0].text).toBe(
+      'Reply in this thread with a whole number from 1 to 5. Anyone in this thread can answer.'
+    )
+  })
+
+  it('says what is expected in plain words, never in schema vocabulary', () => {
+    const expectation = (prop: Record<string, unknown>) =>
+      elicitReplyExpectation(elicitTarget(form({ f: prop }), SLACK_ELICIT_SURFACE)!)
+    expect(expectation({ type: 'number' })).toBe('a number')
+    expect(expectation({ type: 'integer' })).toBe('a whole number')
+    expect(expectation({ type: 'number', minimum: 0.5 })).toBe('a number, 0.5 or more')
+    expect(expectation({ type: 'integer', maximum: 10 })).toBe('a whole number, 10 or less')
+    expect(expectation({ type: 'string' })).toBe('some text')
+    expect(expectation({ type: 'string', minLength: 2 })).toBe('some text, at least 2 characters long')
+    expect(expectation({ type: 'string', maxLength: 8 })).toBe('some text, at most 8 characters long')
+    expect(expectation({ type: 'string', format: 'email' })).toBe('an email address')
+    expect(expectation({ type: 'string', format: 'date' })).toBe('a date, like 2026-09-07')
+    expect(expectation({ type: 'string', pattern: '^[a-z]+$' })).toBe(
+      'some text, in the exact format the question asks for'
+    )
+  })
+
+  it('re-derives a reply against the card, and answers a numeric field with a real number', () => {
+    const number = elicitTarget(form({ n: { type: 'integer', minimum: 1, maximum: 5 } }), SLACK_ELICIT_SURFACE)!
+    expect(elicitReplyAnswer(number, ' 4 ')).toBe(4)
+    expect(elicitReplyAnswer(number, '4')).not.toBe('4') // a real number, never the wire string
+    expect(elicitReplyAnswer(number, '9')).toBeNull() // outside the bounds the card showed
+    expect(elicitReplyAnswer(number, '2.5')).toBeNull() // not whole
+    expect(elicitReplyAnswer(number, 'four')).toBeNull()
+    // Shapes `Number()` reads as numbers that no reader typed as one.
+    expect(elicitReplyAnswer(number, '0x3')).toBeNull()
+    expect(elicitReplyAnswer(number, '')).toBeNull()
+    expect(elicitReplyAnswer(number, 'Infinity')).toBeNull()
+    const text = elicitTarget(
+      form({ t: { type: 'string', minLength: 3, maxLength: 6, pattern: '^[a-z]+$' } }),
+      SLACK_ELICIT_SURFACE
+    )!
+    expect(elicitReplyAnswer(text, ' abcd \n')).toBe('abcd')
+    expect(elicitReplyAnswer(text, 'ab')).toBeNull()
+    expect(elicitReplyAnswer(text, 'abcdefg')).toBeNull()
+    expect(elicitReplyAnswer(text, 'ABCD')).toBeNull()
+    // A pick is never answered by typing at it: that would let an unoffered value through.
+    const pick = elicitTarget(form({ p: { type: 'string', enum: ['main'] } }), SLACK_ELICIT_SURFACE)!
+    expect(elicitReplyAnswer(pick, 'main')).toBeNull()
   })
 
   it('declines an array the card cannot honestly answer', () => {
@@ -1840,16 +1923,19 @@ describe('elicitation card', () => {
     })
   })
 
-  it('leaves typed fields unrenderable on Slack, whose card has nothing to type into', () => {
+  it('renders typed fields on Slack as a question answered by a thread reply', () => {
     const text = form({ name: { type: 'string' } })
     const number = form({ pct: { type: 'number' } })
-    expect(elicitTarget(text, SLACK_ELICIT_SURFACE)).toBeNull()
-    expect(buildElicitationCard('elicit-1', text)).toBeNull()
-    expect(elicitTarget(number, SLACK_ELICIT_SURFACE)).toBeNull()
-    expect(buildElicitationCard('elicit-1', number)).toBeNull()
-    // The same forms ARE renderable — just not here: webchat types into them.
+    expect(elicitTarget(text, SLACK_ELICIT_SURFACE)?.kind).toBe('text')
+    expect(elicitTarget(number, SLACK_ELICIT_SURFACE)?.kind).toBe('number')
     expect(elicitTarget(text, WEBCHAT_ELICIT_SURFACE)?.kind).toBe('text')
     expect(elicitTarget(number, WEBCHAT_ELICIT_SURFACE)?.kind).toBe('number')
+    // The approval DM keeps declining both: a DM has no session thread whose replies are read
+    // as the answer, so the card would ask for a reply nothing intercepts.
+    expect(elicitTarget(text, SLACK_DM_ELICIT_SURFACE)).toBeNull()
+    expect(elicitTarget(number, SLACK_DM_ELICIT_SURFACE)).toBeNull()
+    expect(buildElicitationCard('elicit-1', text, undefined, SLACK_DM_ELICIT_SURFACE)).toBeNull()
+    expect(buildElicitationCard('elicit-1', number, undefined, SLACK_DM_ELICIT_SURFACE)).toBeNull()
   })
 
   it('declines a typed field whose constraints ask for something it cannot render', () => {
@@ -2017,11 +2103,13 @@ describe('elicitation card', () => {
       ['branch', 'enum'],
       ['note', 'text']
     ])
-    // One card answers one field there, and Slack has nothing to type into either — both
-    // reasons still hold, so the form declines rather than half-answering.
+    // One card answers one field, on either surface — so the reduction declines rather than
+    // half-answering, and Slack's card builder (which reads only the reduction) declines with
+    // it. Slack now RENDERS both kinds, so the whole-form read lists them; the modal that would
+    // show them is its own item and nothing calls this with a Slack surface yet.
     expect(elicitTarget(two, WEBCHAT_ELICIT_SURFACE)).toBeNull()
     expect(elicitTarget(two, SLACK_ELICIT_SURFACE)).toBeNull()
-    expect(elicitForm(two, SLACK_ELICIT_SURFACE)).toBeNull()
+    expect(elicitForm(two, SLACK_ELICIT_SURFACE)?.map((t) => t.propName)).toEqual(['branch', 'note'])
     expect(buildElicitationCard('elicit-1', two)).toBeNull()
   })
 

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -21,6 +21,7 @@ import {
   elicitForm,
   elicitFormAccepts,
   elicitFormContent,
+  decodeSlackReplyValue,
   elicitReplyAnswer,
   elicitReplyExpectation,
   stripLeadingSelfMention,
@@ -1840,6 +1841,26 @@ describe('elicitation card', () => {
     // An identity not resolved yet strips nothing rather than guessing at the token.
     expect(stripLeadingSelfMention('<@UBOT> 42', '')).toBe('<@UBOT> 42')
     expect(stripLeadingSelfMention('<@UBOT> 42', undefined)).toBe('<@UBOT> 42')
+  })
+
+  it('decodes a reply Slack handed back as link markup, and only when it is one link', () => {
+    // Slack rewrites what the reader typed on the way back out, so `uri`/`email` would refuse a
+    // reader following the card's own instruction.
+    expect(decodeSlackReplyValue('<https://example.com/>')).toBe('https://example.com/')
+    // The destination is the part BEFORE the pipe; the label is display text Slack added.
+    expect(decodeSlackReplyValue('<https://example.com/|the docs page>')).toBe('https://example.com/')
+    expect(decodeSlackReplyValue('<mailto:a@b.co|a@b.co>')).toBe('a@b.co')
+    expect(decodeSlackReplyValue('<mailto:a@b.co>')).toBe('a@b.co')
+    // One link and nothing else. Prose with a link inside is returned whole: choosing which PART
+    // of a sentence is the value is a guess, not a decode.
+    expect(decodeSlackReplyValue('try <https://example.com/> first')).toBe('try <https://example.com/> first')
+    expect(decodeSlackReplyValue('<https://a/> <https://b/>')).toBe('<https://a/> <https://b/>')
+    // Slack escapes exactly these three everywhere in message text, so undoing them is lossless
+    // — and a query string is where a silently wrong value would otherwise have got through.
+    expect(decodeSlackReplyValue('<https://example.com/?a=1&amp;b=2>')).toBe('https://example.com/?a=1&b=2')
+    expect(decodeSlackReplyValue('2 &lt; 3 &amp;&amp; 3 &gt; 2')).toBe('2 < 3 && 3 > 2')
+    // An ordinary answer is itself, trimmed.
+    expect(decodeSlackReplyValue('  add-retries \n')).toBe('add-retries')
   })
 
   it('re-derives a reply against the card, and answers a numeric field with a real number', () => {

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -23,6 +23,7 @@ import {
   elicitFormContent,
   elicitReplyAnswer,
   elicitReplyExpectation,
+  stripLeadingSelfMention,
   elicitRequiredProps,
   elicitTarget,
   elicitUrl,
@@ -1822,6 +1823,23 @@ describe('elicitation card', () => {
     expect(expectation({ type: 'string', pattern: '^[a-z]+$' })).toBe(
       'some text, in the exact format the question asks for'
     )
+  })
+
+  it('strips one leading mention of the asking bot, and nothing else', () => {
+    // `@bot 42` is 42: addressing the asker is chrome, not value. Both mention spellings, and
+    // the punctuation a reader puts after an address.
+    expect(stripLeadingSelfMention('<@UBOT> 42', 'UBOT')).toBe('42')
+    expect(stripLeadingSelfMention('<@UBOT|acme-bot> 42', 'UBOT')).toBe('42')
+    expect(stripLeadingSelfMention('  <@UBOT>:  42', 'UBOT')).toBe('42')
+    expect(stripLeadingSelfMention('<@UBOT>, add-retries', 'UBOT')).toBe('add-retries')
+    // Anyone else's mention, a second one, and any position but the front are all content.
+    expect(stripLeadingSelfMention('<@UOTHER> 42', 'UBOT')).toBe('<@UOTHER> 42')
+    expect(stripLeadingSelfMention('<@UBOT> <@UBOT> 42', 'UBOT')).toBe('<@UBOT> 42')
+    expect(stripLeadingSelfMention('42 <@UBOT>', 'UBOT')).toBe('42 <@UBOT>')
+    expect(stripLeadingSelfMention('ping <@UBOT> 42', 'UBOT')).toBe('ping <@UBOT> 42')
+    // An identity not resolved yet strips nothing rather than guessing at the token.
+    expect(stripLeadingSelfMention('<@UBOT> 42', '')).toBe('<@UBOT> 42')
+    expect(stripLeadingSelfMention('<@UBOT> 42', undefined)).toBe('<@UBOT> 42')
   })
 
   it('re-derives a reply against the card, and answers a numeric field with a real number', () => {


### PR DESCRIPTION
Implements the Slack-column item on #1794: **a single text or number field answered by a thread reply.**

Slack's native way to type something is to send a message. So a lone `text` or `number` field needs no modal and no `input` block with `dispatch_action` — the card asks, the reader replies in the thread, and that reply is the answer. A modal stays reserved for multi-field forms, which is the last item.

The card carries the question, what is expected in plain words, whom it is waiting for, and Dismiss. There is nothing to type into on the card itself.

## The interception, which is where this route's bugs live

A thread reply would otherwise start a new turn. While a card is live the ACP prompt is still blocked, so the reply has to be consumed as the answer rather than dispatched or queued.

`answerElicitReply` is called from **both** Slack ingress ladders at the same point — after control-command interception, so `!stop` still wins, and **before** routing or queueing. **The interception is the pending card**: a `reply` field on the record, so there is no map, no timer and no per-session state, and it disappears with the record on accept, on Dismiss, and on `releaseElicits` (turn end or cancel). Nothing can outlive its card.

Keyed on `platform + transcriptChannelKey(channel, transportScope)` **and** the turn's own `statusThread`, both taken from the plan at card time. So a reply in a different thread of the same channel cannot answer it, and a second Slack app watching the same channel is a different conversation. One exception: a **DM session** also takes a top-level message, because a DM reader answers where they are talking — a strict thread-only key would have posted an unanswerable card there.

The answer is re-derived against the card exactly as a tapped option is (#1815), and a numeric reply goes through a stricter pattern than `Number()` — `0x1f`, `Infinity` and stray whitespace are not numbers a reader typed — landing in the accept content as a real JS number.

## What is not an answer, and why

| Reaches the same ingress | Treatment |
| --- | --- |
| reply carrying an attachment | not consumed — consuming it would silently drop the file, which a text answer cannot carry anyway |
| an edit of an earlier message | never reaches the interception; Slack ingress drops edit wrappers, so re-typing a past message is not an answer |
| a bot or automation message | not consumed (`isTrustedHumanTurn`) |
| anyone other than the requester | not consumed; ordinary conversation. A card that could name no requester takes anyone in the thread, and says so |
| an invalid reply | posts the reason and **leaves the card live** — it does not consume the attempt. Dismiss is the only explicit refusal |

## Two defects found in review of the first pass

**A reply matching more than one live card answered one of them.** Two questions open in one thread — a runtime raising two concurrent elicitations is enough — and the first record won, so a reader answering the second was reported to the first runtime as having answered *that* question. Structurally the same lie #1825's shared selection told, and the whitelist cannot catch it because the value is valid for both cards.

Now all matching cards are collected; more than one settles nothing, consumes nothing, and the thread is told: *N questions are open in this thread, so a reply cannot answer any of them — dismiss all but one, or let one settle, and the next reply answers that one.* The reader keeps a path forward instead of a silent misattribution.

**`<@bot> 42` was refused as malformed.** A leading mention of the asking bot is addressing it, not answering it. `stripLeadingSelfMention` removes only the first token, only at the front, and only when the captured id is this bot's own — guessing which *other* part of a message is the value is how a typed answer becomes wrong. The id comes from **the card's own connection**, which is why both ingress paths read it identically and neither has to supply it; it is resolved from `auth.test` before the send-only early return, so a relay-managed connection has it too. When it is unavailable nothing is stripped rather than guessed at.

## Notes worth carrying

- The refusal lands where notices land, which is `plan.thread` — `undefined` for a turn rooted at a top-level channel message, so for those turns the reason appears at channel level while the card sits in the thread. Pre-existing for every notice; fixing it is a `notice`-into-`statusThread` change of its own.
- The consumed reply gets no transcript row, the same as a tapped button. Making it visible on replay would mean the agent seeing the answer twice on catch-up.
- The settled card quotes the answer, through the shared `chosenLabel` path. Mildly redundant with the thread, but making Slack the one surface that hides the accepted value would break the shared settle path for no gain.
- `elicitForm(_, SLACK_ELICIT_SURFACE)` now returns multi-field forms; only `elicitTarget` still declines them, and only `elicitTarget` feeds the Slack card. Nothing calls it that way today — the modal item will, and that read is now honest rather than accidentally null.
- The approval DM (`SLACK_DM_ELICIT_SURFACE`) deliberately does **not** gain these kinds: a DM has no session thread whose replies are intercepted. Pinned by test.

## Verification

- protocol 488, relay 647, web 2406 — green.
- `pnpm typecheck`: `error TS` count 0. eslint + prettier clean on changed files.
- Elicitation suites (`daemon-permission-autoallow`, `render`, `elicit-decline-notice`, `daemon-commands`): **390 passing**, independently re-run.
- Full daemon suite: the known-unrelated set (`acp-matrix` live runtimes, five skills-CLI files, bwrap `sandbox`, `evaluation-runner`, `daemon-smoke`) plus a load-flaky set that is a *different* set each pass — itself the tell. Confirmed rather than assumed: those eight with the sources reverted pass 230/230, and with them restored the same eight plus the four elicitation files leave one 30s timeout under twelve-file parallelism that passes 33/33 alone.

Each new behaviour was confirmed red with only the sources reverted. The signatures are the defects themselves: `expected true to be false` where the old code answered one of two cards, a timeout where it refused `<@UBOT> 42` so the request never resolved, and a content diff showing the raw mention reaching the agent as the answer.
