### PR TITLE
feat(daemon): sync the workspace to its configured branch instead of pulling

### DIFF
--- a/docs/designs/daemon-detailed-design.md
+++ b/docs/designs/daemon-detailed-design.md
@@ -540,7 +540,7 @@ This aligns upstream section 6.6 `Agent` / `Integration` / `Workspace` / `CronJo
     "path": "./workspace",
     "gitRepo": "git@github.com:acme/ops.git",
     "gitBranch": "main",
-    "pullOnNewSession": true, // git pull --ff-only before each new session; see packages/daemon/src/workspace/workspace-manager.ts
+    "pullOnNewSession": true, // sync the checkout to the configured remote branch before each new session; see packages/daemon/src/workspace/workspace-manager.ts
     "skills": ["deploy", "rpc-health"]
   },
 
@@ -594,7 +594,7 @@ This aligns upstream section 6.6 `Agent` / `Integration` / `Workspace` / `CronJo
 
 Before a new or reloaded session, Session Manager calls `prepareWorkspace(agent)`:
 
-1. `git-repo`: validate `agentDir`; clone the configured repository and branch if no checkout exists, or run a best-effort `git pull --ff-only` with an approximately 4.5-second timeout when `pullOnNewSession` is enabled. A clone failure is fatal because no checkout exists; a pull failure is nonfatal so offline execution can continue from disk.
+1. `git-repo`: validate `agentDir`; clone the configured repository and branch if no checkout exists, or, when `pullOnNewSession` is enabled, run a best-effort sync with an approximately 4.5-second timeout: fetch the configured branch, point the local branch at the remote tip and check it out, carrying uncommitted edits and never merging (a local commit the remote lacks, or an edit the sync would rewrite, refuses it). A clone failure is fatal because no checkout exists; a refused or offline sync is nonfatal so execution can continue from disk.
 2. `from-scratch`: ensure the workspace directory exists; agent memory is initialized separately under the agent root by `packages/daemon/src/memory/store.ts`.
 3. Return the absolute repository root, validated `agentDir`, or from-scratch directory as the `cwd` for section 7 `session/new` or `session/load`.
 

--- a/docs/designs/git-workspace-model.md
+++ b/docs/designs/git-workspace-model.md
@@ -395,8 +395,12 @@ made with `branch --no-track` + `symbolic-ref HEAD` + `reset --hard` instead of
 so it keeps the lazy fetch a blobless clone needs), and retirement's
 review-snapshot probe reads the head ref with `show-ref --verify` instead of
 listing the ref root with `for-each-ref`. Widening the inventory is the other
-way to close such a gap, and it is the one that costs something permanent:
-`checkout` was left out.
+way to close such a gap, and it is the one that costs something permanent, so it
+is done narrowly: `checkout` is admitted only for the workspace sync's branch
+switch (`checkout --no-track -B <branch> <ref>`, the two-tree merge that carries
+uncommitted edits and lets Git refuse an overlap, which no admitted subcommand
+reproduces), with every form that would discard or restore working-tree files
+(`-f`, pathspecs, merge and patch modes) refused by the executor itself.
 
 ### The tier a session is born in (decided 2026-09-03)
 

--- a/packages/control-plane/src/http/routes/agents.test.ts
+++ b/packages/control-plane/src/http/routes/agents.test.ts
@@ -376,7 +376,7 @@ describe('toWorkspaceGitPullDto', () => {
         agentId: 'a1',
         isRepo: true,
         ok: true,
-        detail: 'Fast-forwarded — updated 2 files.',
+        detail: 'Synced main — updated 2 files.',
         changed: 2,
         insertions: 10,
         deletions: 3
@@ -384,7 +384,7 @@ describe('toWorkspaceGitPullDto', () => {
     ).toEqual({
       isRepo: true,
       ok: true,
-      detail: 'Fast-forwarded — updated 2 files.',
+      detail: 'Synced main — updated 2 files.',
       changed: 2,
       insertions: 10,
       deletions: 3

--- a/packages/control-plane/src/http/routes/agents.ts
+++ b/packages/control-plane/src/http/routes/agents.ts
@@ -4758,17 +4758,18 @@ export function agentRoutes(deps: HttpDeps) {
       }
     )
 
-    // Workspace git pull: force an on-demand ff-only pull on the owning daemon. A
-    // pull that can't fast-forward (offline, diverged, local edits) is data
-    // (`ok:false` + `detail`), not an HTTP error — only an offline daemon → 503.
+    // Workspace sync: pin the configured branch to its remote and check it out on the owning daemon. A
+    // refused sync (offline remote, a local commit the remote lacks, an edit it would rewrite) is data
+    // (`ok:false` + `detail`); the daemon's "agent is working here" refusal is a 409 like every other
+    // console git write, and only an offline daemon → 503.
     r.post(
       '/agents/:id/workspace/gitpull',
       {
         schema: {
           tags: [Tag.Workspace],
-          summary: 'Pull the workspace',
+          summary: 'Sync the workspace',
           description:
-            'Force an on-demand ff-only pull on the owning daemon; a pull that can’t fast-forward (diverged, local edits) is data (ok:false + detail), only an offline daemon yields 503. Pass repo to pull one of the agent’s authorized additional repositories instead of its primary workspace.',
+            'Sync the checkout to its configured remote branch on the owning daemon: fetch, point the local branch at the remote tip and check it out, carrying uncommitted edits and never merging. A refused sync (a local commit the remote lacks, an edit it would rewrite) is data (ok:false + detail); 409 when the agent is working in the checkout, 503 only when the daemon is offline. Pass repo to sync one of the agent’s authorized additional repositories instead of its primary workspace.',
           operationId: 'pullAgentWorkspace',
           params: IdParam,
           querystring: WorkspaceRepoScopeQueryDto,
@@ -4797,10 +4798,7 @@ export function agentRoutes(deps: HttpDeps) {
           })
           return toWorkspaceGitPullDto(rep)
         } catch (err) {
-          const unavailable = daemonEdgeFailure(err)
-          if (unavailable !== null) {
-            return reply.code(503).send({ error: 'Service Unavailable', statusCode: 503, message: unavailable })
-          }
+          if (sendWorkspaceFailure(reply, err)) return
           throw err
         }
       }

--- a/packages/control-plane/test/integration/agents.workspace-repo-scope.route.test.ts
+++ b/packages/control-plane/test/integration/agents.workspace-repo-scope.route.test.ts
@@ -16,6 +16,7 @@ import {
   WORKSPACE_REPO_SCOPE_FEATURE,
   WORKSPACE_SESSION_READ_FEATURE
 } from '@agentconnect.md/protocol'
+import { ProtocolError } from '../../src/domain/errors.js'
 import type {
   WorkspaceGitCommitReq,
   WorkspaceGitCommitResult,
@@ -225,5 +226,27 @@ describe('version skew on the repo scope', () => {
     // The unscoped reads are untouched by the missing marker — the primary still serves.
     const primary = await running.app.inject({ method: 'GET', url: `${ORG}/agents/${AGENT}/workspace/files` })
     expect(primary.statusCode).toBe(200)
+  })
+
+  it("answers the daemon's busy refusal of a sync as a 409 the console can act on, not an offline daemon", async () => {
+    await seedAuthorized()
+    const control = new ScopeSpy()
+    control.workspaceGitPull = async () => {
+      throw new ProtocolError(
+        'CONFLICT',
+        'workspace/gitpull failed: the agent is working in this workspace; retry when it is idle',
+        {
+          details: { reason: 'stale' }
+        }
+      )
+    }
+    const running = app(control)
+
+    const pull = await running.app.inject({ method: 'POST', url: `${ORG}/agents/${AGENT}/workspace/gitpull` })
+    expect(pull.statusCode).toBe(409)
+    expect(pull.json()).toMatchObject({
+      code: 'WORKSPACE_STALE',
+      message: expect.stringContaining('working in this workspace')
+    })
   })
 })

--- a/packages/daemon/src/cp/workspace-git.ts
+++ b/packages/daemon/src/cp/workspace-git.ts
@@ -7,8 +7,8 @@
  * outcome is proxied to the console (§1/§12), never the repo.
  *
  * DATA vs error: a from-scratch workspace (`isRepo:false`), a dirty tree, a path
- * with no changes, a binary change, or a pull that can't fast-forward (offline,
- * diverged, would clobber local edits) are all normal REPs — the caller renders
+ * with no changes, a binary change, or a refused sync (offline, a local commit the
+ * remote lacks, an edit it would rewrite) are all normal REPs — the caller renders
  * them. So is every way a write can decline: nothing to stage, an empty index, no
  * registered commit identity, a detached HEAD, a branch with no upstream, a
  * rejected push. Only an unknown agentId, a path escaping the workspace, or a
@@ -60,7 +60,7 @@ import {
   canonicalWorkspaceGitUrl,
   gitCommitIdentityEnv,
   GITHUB_CREDENTIAL_SCOPE,
-  pullWorkspaceRef,
+  syncWorkspaceRef,
   workspaceGitLocalEnv,
   workspaceGitRemoteTarget,
   type ManagedCredentialScope
@@ -78,8 +78,7 @@ import {
 import { LOG_FORMAT, numstatByPath, parseLogZ, parseNameStatusZ, parseNumstatZ } from './workspace-git-parse.js'
 import { REPLY_BUDGET, fitToBudget, utf8Boundary } from '../wire-slice.js'
 
-/** On-demand pull is interactive, so allow more headroom than the 4.5s
- *  best-effort pull at session start (workspace-manager.ts). */
+/** On-demand sync is interactive, so allow more headroom than the 4.5s best-effort sync at session start (workspace-manager.ts). */
 const PULL_TIMEOUT_MS = 20_000
 
 /** A local diff/log/numstat never touches the network, so it either answers
@@ -547,10 +546,10 @@ export function createWorkspaceGit(
 
     async pull(agentId, repo) {
       const root = await rootFor(agentId, undefined, repo)
-      // ff-only: an on-demand pull must never rewrite or clobber the agent's working tree — a
-      // diverged branch / local edits surface as ok:false, not a forced reset. Bounded by a timeout
-      // so an offline remote can't hang the REP, and the controller is built BEFORE the resolution
-      // so the one runner this request uses already carries the signal.
+      // A sync pins the configured branch to the remote and checks it out, carrying uncommitted edits; it
+      // never merges, and an edit it would rewrite or a local commit the remote lacks surfaces as ok:false.
+      // Bounded by a timeout so an offline remote can't hang the REP, and the controller is built BEFORE
+      // the resolution so the one runner this request uses already carries the signal.
       let timer: ReturnType<typeof setTimeout> | undefined
       const abort = new AbortController()
       // Resolved ONCE per request, and `runnerFor` refuses rather than falling back in sandbox mode:
@@ -573,7 +572,7 @@ export function createWorkspaceGit(
           authorized.managed
         )
         timer = setTimeout(() => abort.abort(), PULL_TIMEOUT_MS)
-        const res = await pullWorkspaceRef(
+        const res = await syncWorkspaceRef(
           git.withEnv({
             ...workspaceGitLocalEnv(),
             ...pullTarget.env
@@ -582,6 +581,7 @@ export function createWorkspaceGit(
           pullBranch
         )
         const changed = res.files.length
+        const updated = changed > 0 ? `updated ${changed} file${changed === 1 ? '' : 's'}` : 'already in sync'
         return {
           agentId,
           isRepo: true,
@@ -589,11 +589,14 @@ export function createWorkspaceGit(
           changed,
           insertions: res.insertions,
           deletions: res.deletions,
-          detail:
-            changed > 0 ? `Fast-forwarded — updated ${changed} file${changed === 1 ? '' : 's'}.` : 'Already up to date.'
+          detail: res.switchedFrom
+            ? `Switched from ${res.switchedFrom} to ${pullBranch} — ${updated}.`
+            : changed > 0
+              ? `Synced ${pullBranch} — ${updated}.`
+              : 'Already in sync.'
         }
       } catch (err) {
-        return { agentId, isRepo: true, ok: false, detail: scrub(root, (err as Error)?.message ?? 'pull failed') }
+        return { agentId, isRepo: true, ok: false, detail: scrub(root, (err as Error)?.message ?? 'sync failed') }
       } finally {
         if (timer) clearTimeout(timer)
       }

--- a/packages/daemon/src/shim/exec-handler.ts
+++ b/packages/daemon/src/shim/exec-handler.ts
@@ -22,6 +22,7 @@ import { applyMemoryFsPayload, isMemoryFsPayload } from './memory-fs-channel.js'
 export const ALLOWED_GIT_SUBCOMMANDS = new Set([
   'branch',
   'check-ref-format',
+  'checkout',
   'clean',
   'clone',
   'config',
@@ -73,6 +74,22 @@ const REFUSED_ARGUMENT = [
  * edits config.
  */
 const REFUSED_SUBCOMMAND_ARGUMENT: Record<string, RegExp[]> = {
+  // Admitted for the workspace sync's `checkout --no-track -B <branch> <ref>` alone: the branch switch that
+  // carries uncommitted edits and lets git refuse an overlap. Every form that would instead discard or
+  // restore working-tree files (force, pathspecs, merge/patch modes) stays out.
+  checkout: [
+    /^-f$/,
+    /^--force$/,
+    /^--$/,
+    /^-m$/,
+    /^--merge$/,
+    /^-p$/,
+    /^--patch$/,
+    /^--ours$/,
+    /^--theirs$/,
+    /^--orphan/,
+    /^--detach$/
+  ],
   clone: [/^-u/],
   config: [/^-e$/, /^--edit/]
 }

--- a/packages/daemon/src/workspace/git-injection.ts
+++ b/packages/daemon/src/workspace/git-injection.ts
@@ -326,17 +326,68 @@ export async function assertSafeWorkspaceGitConfig(git: GitRunner): Promise<void
   }
 }
 
+/** What a sync moved: the files between the old and new HEAD, and the branch it had to leave. */
+export interface WorkspaceSyncSummary extends GitPullSummary {
+  /** The branch the checkout was on before, when the sync switched it to the configured one. */
+  switchedFrom?: string
+}
+
+// `ins\tdel\tpath` rows; `-` marks a binary file, which counts as a changed file with no line counts.
+function parseNumstat(out: string): GitPullSummary {
+  const summary: GitPullSummary = { files: [], insertions: 0, deletions: 0 }
+  for (const line of out.split('\n')) {
+    const row = /^(\d+|-)\t(\d+|-)\t(.+)$/.exec(line)
+    if (!row) continue
+    summary.files.push(row[3]!)
+    if (row[1] !== '-') summary.insertions += Number(row[1])
+    if (row[2] !== '-') summary.deletions += Number(row[2])
+  }
+  return summary
+}
+
 /**
- * Pull exactly the daemon-authorized repository and branch. Supplying both
- * operands keeps checkout-controlled branch.*.remote / branch.*.merge config
- * out of daemon-managed network selection; the explicit destination also keeps
- * origin/<branch> current for status. check-ref-format prevents a configured
- * branch from being interpreted as an option or refspec.
+ * Sync the checkout to the daemon-authorized `remote`'s `<branch>`: fetch it, then point the local
+ * branch at the fetched tip and check that out. Never a merge — the local branch ends identical to
+ * the remote one, so history cannot fork; a local commit the remote lacks refuses the sync instead
+ * of being discarded. Uncommitted changes ride along as `git checkout` carries them, and git refuses
+ * when one touches a file the sync would rewrite. Both operands explicit, so checkout-controlled
+ * `branch.*` config never selects the remote; check-ref-format keeps the branch from being read as an option.
  */
-export async function pullWorkspaceRef(git: GitRunner, remote: string, branch: string): Promise<GitPullSummary> {
+export async function syncWorkspaceRef(git: GitRunner, remote: string, branch: string): Promise<WorkspaceSyncSummary> {
   await git.raw(['check-ref-format', '--branch', branch])
-  const refspec = `+refs/heads/${branch}:refs/remotes/origin/${branch}`
-  return git.pull(remote, refspec, ['--ff-only', '--no-recurse-submodules'])
+  const tracking = `refs/remotes/origin/${branch}`
+  await git.raw(['fetch', '--no-recurse-submodules', remote, `+refs/heads/${branch}:${tracking}`])
+  // `--verify` without `--quiet`: a silent exit 1 is resolved by the runner as if the ref existed.
+  const before = await git.raw(['rev-parse', '--verify', 'HEAD']).then(
+    (sha) => sha.trim(),
+    () => undefined
+  )
+  const current = await git.raw(['symbolic-ref', '--short', 'HEAD']).then(
+    (name) => name.trim(),
+    () => undefined
+  )
+  const hasLocalBranch = await git.raw(['rev-parse', '--verify', `refs/heads/${branch}`]).then(
+    () => true,
+    () => false
+  )
+  if (hasLocalBranch) {
+    const unique = (await git.raw(['rev-list', '--count', `refs/heads/${branch}`, `^${tracking}`])).trim()
+    if (unique !== '0') {
+      throw new Error(
+        `local ${branch} has ${unique} commit${unique === '1' ? '' : 's'} the remote does not; push them or move them to another branch, then sync again`
+      )
+    }
+  }
+  await git.raw(['checkout', '--no-recurse-submodules', '--no-track', '-B', branch, tracking])
+  const after = (await git.raw(['rev-parse', '--verify', 'HEAD'])).trim()
+  const moved =
+    before !== undefined && before !== after
+      ? parseNumstat(await git.raw(['diff', '--numstat', before, after]))
+      : undefined
+  return {
+    ...(moved ?? { files: [], insertions: 0, deletions: 0 }),
+    ...(current !== undefined && current !== branch ? { switchedFrom: current } : {})
+  }
 }
 
 /**

--- a/packages/daemon/src/workspace/workspace-manager.ts
+++ b/packages/daemon/src/workspace/workspace-manager.ts
@@ -33,7 +33,7 @@ import {
   cloneGitEnv,
   gitFor,
   preWarmGitCred,
-  pullWorkspaceRef,
+  syncWorkspaceRef,
   workspaceGitEnvBase,
   workspaceGitLocalEnv,
   workspaceGitRemoteTarget,
@@ -1076,7 +1076,7 @@ export class WorkspaceManager {
     writeFileSync(file, JSON.stringify({ version: 1, key }, null, 2) + '\n')
   }
 
-  /** Best-effort ff-only pull of one root's checkout; never block/throw on offline (design §4.3). */
+  /** Best-effort sync of one root's checkout to its configured remote branch; never block/throw on offline (design §4.3). */
   async pullRoot(agentId: string, root: WorkspaceRoot, cwd: string): Promise<void> {
     // github-app: warm the credential cache OUTSIDE the pull budget — a cold cache costs a CP round trip.
     if (root.githubApp) await preWarmGitCred(agentId, 'pull').catch(() => undefined)
@@ -1090,9 +1090,9 @@ export class WorkspaceManager {
         ...workspaceGitLocalEnv(),
         ...pullTarget.env
       })
-      await pullWorkspaceRef(git, pullTarget.remote, root.branch)
+      await syncWorkspaceRef(git, pullTarget.remote, root.branch)
     } catch {
-      // offline / timed out / non-fast-forward: proceed with the on-disk checkout
+      // offline / timed out / refused (a local commit the remote lacks, an edit the sync would rewrite): proceed with the on-disk checkout
     } finally {
       clearTimeout(timer)
     }
@@ -2211,11 +2211,10 @@ export class WorkspaceManager {
           ...workspaceGitLocalEnv(),
           ...pullTarget.env
         })
-        await pullWorkspaceRef(git, pullTarget.remote, agent.workspace.gitBranch)
+        await syncWorkspaceRef(git, pullTarget.remote, agent.workspace.gitBranch)
         pulled = true
       } catch {
-        // offline / timed out / non-fast-forward: proceed with the checkout on the volume, which is
-        // the same degradation the local path accepts.
+        // offline / timed out / refused: proceed with the checkout on the volume, the same degradation the local path accepts.
       } finally {
         clearTimeout(timer)
       }
@@ -2223,15 +2222,15 @@ export class WorkspaceManager {
     // The marker records what the VOLUME holds, and this is the only place that knows — but ONLY when
     // that can be proven, because a marker that overstates is worse than one that lags.
     //
-    // The case that made this precise: a volume on branch A, a configuration that now says a divergent
-    // branch B. `pullWorkspaceRef` pulls INTO the current branch rather than switching, so its ff-only
-    // pull fails, the failure is swallowed as ordinary offline degradation, and the volume stays on A.
-    // Recording B there tells every later activation that nothing changed, and the agent runs the
-    // wrong branch indefinitely — silently, which is the property that makes it expensive.
+    // The case that made this precise: a volume on branch A, a configuration that now says branch B.
+    // `syncWorkspaceRef` switches to B, but a refused sync (an edit it would rewrite, a local commit the
+    // remote lacks) is swallowed as ordinary offline degradation and the volume stays on A. Recording B
+    // there tells every later activation that nothing changed, and the agent runs the wrong branch
+    // indefinitely — silently, which is the property that makes it expensive.
     //
     // Provable means: a fresh clone (its `--branch` decided HEAD), or an existing checkout whose HEAD
     // IS the configured branch AND whose tree is attributable to the configured repository — either
-    // because a stored marker already attests it, or because a pull from it just succeeded. A rewritten
+    // because a stored marker already attests it, or because a sync from it just succeeded. A rewritten
     // origin says nothing about the tree that was already there, and a branch name can match in both
     // repositories, so without one of those two the volume is simply unproven.
     //
@@ -2854,9 +2853,9 @@ export type WorkspacePathClearer = (agentId: string, root: string) => Promise<st
 /**
  * Which branch the pod's checkout is actually on.
  *
- * `pullWorkspaceRef` pulls INTO the current branch rather than switching to the configured one, so
- * this is the only thing that can tell a volume holding the requested branch from one that merely
- * fetched it. Empty when it cannot be established, which counts as "cannot prove it".
+ * A refused `syncWorkspaceRef` leaves the volume on whatever branch it held, so this is the only
+ * thing that can tell a volume holding the requested branch from one that merely fetched it. Empty
+ * when it cannot be established, which counts as "cannot prove it".
  */
 
 /**

--- a/packages/daemon/test/cluster-workspace-prepare.test.ts
+++ b/packages/daemon/test/cluster-workspace-prepare.test.ts
@@ -152,6 +152,10 @@ function recordingRunner(cwd: string | undefined, env: Record<string, string> = 
     if (args[0] === 'status') return worktreeStatus
     if (args[0] === 'rev-list' && args.includes('--count')) return uniqueCommits
     if (args[0] === 'symbolic-ref') return 'dev/alice/quiet-harbor'
+    // What git does when an uncommitted edit touches a file the sync would rewrite: refuses, leaving the checkout as it was.
+    if (args[0] === 'checkout' && args.includes('-B') && pullFails) {
+      throw new Error('Your local changes to the following files would be overwritten by checkout')
+    }
     return ''
   }
   const runner: GitRunner = {
@@ -369,15 +373,20 @@ describe('preparing a cluster git-repo workspace', () => {
     expect(helper[0]!.args.at(-1)).toContain('/opt/agentconnect/bin/git-credential')
   })
 
-  it('pulls an existing checkout instead of cloning over it', async () => {
+  it('syncs an existing checkout instead of cloning over it', async () => {
     checkoutExists = true
     await workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT)
 
     expect(calls.some((call) => call.args[0] === 'clone')).toBe(false)
-    const pull = calls.find((call) => call.args[0] === 'pull')
-    expect(pull).toMatchObject({ cwd: CHECKOUT })
-    // The pull carries the credential pair, or a private repo's fetch has nothing to authenticate with.
-    expect(pull!.env).toMatchObject({ AC_GITCRED_AGENT: 'agent-cluster' })
+    const fetch = calls.find((call) => call.args[0] === 'fetch')
+    expect(fetch).toMatchObject({ cwd: CHECKOUT })
+    // The fetch carries the credential pair, or a private repo has nothing to authenticate with.
+    expect(fetch!.env).toMatchObject({ AC_GITCRED_AGENT: 'agent-cluster' })
+    // The sync pins the configured branch to the fetched tip and checks it out — never a merge.
+    expect(calls.find((call) => call.args[0] === 'checkout')).toMatchObject({
+      cwd: CHECKOUT,
+      args: ['checkout', '--no-recurse-submodules', '--no-track', '-B', 'main', 'refs/remotes/origin/main']
+    })
     // And the audit ran against the POD's config, not a directory on this disk.
     expect(calls.some((call) => call.cwd === CHECKOUT && call.args.includes('--includes'))).toBe(true)
   })
@@ -404,7 +413,7 @@ describe('preparing a cluster git-repo workspace', () => {
     await expect(workspaces.prepareClusterWorkspace(clusterAgent(), POD_ROOT)).rejects.toThrow(
       /not a trusted GitHub remote/
     )
-    expect(calls.some((call) => call.args[0] === 'pull')).toBe(false)
+    expect(calls.some((call) => call.args[0] === 'fetch')).toBe(false)
   })
 
   it('empties a partial checkout in the pod when a clone fails, then reports the failure', async () => {
@@ -508,11 +517,11 @@ describe('replacing a cluster workspace in place', () => {
     ).resolves.toBeTypeOf('function')
   })
 
-  it('leaves the marker alone when a divergent branch keeps the volume on the old one', async () => {
-    // `pullWorkspaceRef` pulls INTO the current branch rather than switching, so a configured branch
-    // that has diverged fails ff-only and the volume stays where it was. Recording the new branch
-    // there would tell every later activation that nothing changed, and the agent would run the
-    // wrong branch indefinitely — silently, which is what makes it expensive.
+  it('leaves the marker alone when a refused sync keeps the volume on the old branch', async () => {
+    // `syncWorkspaceRef` switches to the configured branch, but an uncommitted edit it would rewrite
+    // makes git refuse and the volume stays where it was. Recording the new branch there would tell
+    // every later activation that nothing changed, and the agent would run the wrong branch
+    // indefinitely — silently, which is what makes it expensive.
     const agent = await withProvenMarker()
     const moved = { ...agent, workspace: { ...agent.workspace, gitBranch: 'release' } } as Agent
     checkoutExists = true

--- a/packages/daemon/test/git-injection.test.ts
+++ b/packages/daemon/test/git-injection.test.ts
@@ -15,7 +15,7 @@ import {
   daemonGitCredentialTarget,
   initGitInjection,
   parseGitVersion,
-  pullWorkspaceRef,
+  syncWorkspaceRef,
   sandboxGitCredentialTarget,
   sessionGitConfig,
   sessionGitEnv,
@@ -508,7 +508,7 @@ describe('gitEnvBase', () => {
     }
   })
 
-  it('updates the origin tracking ref when an explicit URL pull advances HEAD', async () => {
+  it('updates the origin tracking ref when a sync advances HEAD', async () => {
     const root = mkdtempSync(join(tmpdir(), 'git-pull-refspec-test-'))
     const remote = join(root, 'remote.git')
     const seed = join(root, 'seed')
@@ -530,7 +530,8 @@ describe('gitEnvBase', () => {
 
       const git = gitFor(workspace).env(env)
       const runner = new LocalGitRunner(git, workspace, (overrides) => gitFor(workspace).env(overrides), env)
-      await pullWorkspaceRef(runner, 'origin', 'main')
+      const moved = await syncWorkspaceRef(runner, 'origin', 'main')
+      expect(moved.switchedFrom).toBeUndefined()
 
       const [head, tracking, status] = await Promise.all([
         git.raw(['rev-parse', 'HEAD']),
@@ -540,6 +541,97 @@ describe('gitEnvBase', () => {
       expect(head.trim()).toBe(tracking.trim())
       expect(status.ahead).toBe(0)
       expect(status.behind).toBe(0)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  // One remote, one clone of it, both on `main`; the caller then moves the clone into the shape under test.
+  function seedSyncFixture(prefix: string) {
+    const root = mkdtempSync(join(tmpdir(), prefix))
+    const remote = join(root, 'remote.git')
+    const seed = join(root, 'seed')
+    const workspace = join(root, 'workspace')
+    const env = { ...workspaceGitLocalEnv(), GIT_ALLOW_PROTOCOL: 'file:https:ssh' }
+    const run = (args: string[]) => execFileSync('git', args, { env, stdio: 'ignore' })
+    run(['init', '--bare', remote])
+    run(['init', '-b', 'main', seed])
+    run(['-C', seed, 'config', 'user.name', 'Test'])
+    run(['-C', seed, 'config', 'user.email', 'test@example.invalid'])
+    writeFileSync(join(seed, 'README.md'), 'one\n')
+    run(['-C', seed, 'add', 'README.md'])
+    run(['-C', seed, 'commit', '-m', 'initial'])
+    run(['-C', seed, 'remote', 'add', 'origin', remote])
+    run(['-C', seed, 'push', 'origin', 'main'])
+    run(['clone', '--branch', 'main', remote, workspace])
+    run(['-C', workspace, 'config', 'user.name', 'Test'])
+    run(['-C', workspace, 'config', 'user.email', 'test@example.invalid'])
+    const git = gitFor(workspace).env(env)
+    const runner = new LocalGitRunner(git, workspace, (overrides) => gitFor(workspace).env(overrides), env)
+    return { root, seed, workspace, env, run, git, runner }
+  }
+
+  it('switches a checkout left on another branch back to the configured one, carrying uncommitted edits', async () => {
+    const { root, seed, workspace, run, git, runner } = seedSyncFixture('git-sync-switch-test-')
+    try {
+      // The agent branched off, committed there, and left an unrelated edit uncommitted; the remote moved on.
+      run(['-C', workspace, 'checkout', '-b', 'dev/agent/canary'])
+      writeFileSync(join(workspace, 'canary.txt'), 'canary\n')
+      run(['-C', workspace, 'add', 'canary.txt'])
+      run(['-C', workspace, 'commit', '-m', 'canary'])
+      writeFileSync(join(workspace, 'notes.md'), 'work in progress\n')
+      writeFileSync(join(seed, 'README.md'), 'one\ntwo\n')
+      run(['-C', seed, 'commit', '-am', 'advance'])
+      run(['-C', seed, 'push', 'origin', 'main'])
+
+      const moved = await syncWorkspaceRef(runner, 'origin', 'main')
+
+      expect(moved.switchedFrom).toBe('dev/agent/canary')
+      // Everything between the two HEADs: the remote's edit and the canary file that only the agent's branch has.
+      expect(moved.files.sort()).toEqual(['README.md', 'canary.txt'])
+      expect((await git.raw(['symbolic-ref', '--short', 'HEAD'])).trim()).toBe('main')
+      expect((await git.raw(['rev-parse', 'HEAD'])).trim()).toBe(
+        (await git.raw(['rev-parse', 'refs/remotes/origin/main'])).trim()
+      )
+      // The edit rode along; the agent's own branch and its commit are untouched.
+      expect(readFileSync(join(workspace, 'notes.md'), 'utf8')).toBe('work in progress\n')
+      expect((await git.raw(['rev-list', '--count', 'dev/agent/canary', '^main'])).trim()).toBe('1')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses rather than discarding a local commit the remote lacks', async () => {
+    const { root, seed, workspace, run, git, runner } = seedSyncFixture('git-sync-refuse-test-')
+    try {
+      writeFileSync(join(workspace, 'local.txt'), 'local\n')
+      run(['-C', workspace, 'add', 'local.txt'])
+      run(['-C', workspace, 'commit', '-m', 'unpushed'])
+      const before = (await git.raw(['rev-parse', 'HEAD'])).trim()
+      run(['-C', seed, 'commit', '--allow-empty', '-m', 'advance'])
+      run(['-C', seed, 'push', 'origin', 'main'])
+
+      await expect(syncWorkspaceRef(runner, 'origin', 'main')).rejects.toThrow(
+        /local main has 1 commit the remote does not/
+      )
+      expect((await git.raw(['rev-parse', 'HEAD'])).trim()).toBe(before)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses when an uncommitted edit touches a file the sync would rewrite', async () => {
+    const { root, seed, workspace, run, git, runner } = seedSyncFixture('git-sync-overlap-test-')
+    try {
+      writeFileSync(join(workspace, 'README.md'), 'one\nlocal edit\n')
+      writeFileSync(join(seed, 'README.md'), 'one\ntwo\n')
+      run(['-C', seed, 'commit', '-am', 'advance'])
+      run(['-C', seed, 'push', 'origin', 'main'])
+      const before = (await git.raw(['rev-parse', 'HEAD'])).trim()
+
+      await expect(syncWorkspaceRef(runner, 'origin', 'main')).rejects.toThrow(/README\.md/)
+      expect((await git.raw(['rev-parse', 'HEAD'])).trim()).toBe(before)
+      expect(readFileSync(join(workspace, 'README.md'), 'utf8')).toBe('one\nlocal edit\n')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/packages/daemon/test/shim-exec-handler.test.ts
+++ b/packages/daemon/test/shim-exec-handler.test.ts
@@ -71,7 +71,7 @@ describe('sandbox exec handler', () => {
 
   it('refuses a subcommand outside the declared inventory', async () => {
     const root = repository()
-    for (const subcommand of ['push', 'submodule', 'daemon', 'gc', 'apply', 'checkout', 'for-each-ref']) {
+    for (const subcommand of ['push', 'submodule', 'daemon', 'gc', 'apply', 'read-tree', 'for-each-ref']) {
       await expect(handler(root)('exec', { tool: 'git', args: [subcommand] })).rejects.toBeInstanceOf(ExecRefusedError)
     }
     // And the inventory is the daemon's declared list, not a superset invented here.
@@ -113,10 +113,10 @@ describe('sandbox exec handler', () => {
   })
 
   it('serves the branch-and-materialize sequence the confined session tier runs instead of a checkout', async () => {
-    // The clone tier (git-workspace-model.md §11) puts a session clone on its own generated branch.
-    // `checkout` is deliberately outside the inventory, so the daemon expresses that as three
-    // subcommands that are inside it — and here is where that has to hold: a refusal on this side is
-    // a session that fails on a pool member and works self-hosted, which is how it reached the field.
+    // The clone tier (git-workspace-model.md §11) puts a session clone on its own generated branch as
+    // three subcommands rather than a `checkout` — and here is where that has to hold: a refusal on
+    // this side is a session that fails on a pool member and works self-hosted, which is how it
+    // reached the field.
     const root = repository()
     for (const args of [
       ['branch', '--no-track', 'dev/ada-lovelace/quiet-harbor', 'refs/heads/main'],
@@ -130,13 +130,45 @@ describe('sandbox exec handler', () => {
     expect(head.trim()).toBe('dev/ada-lovelace/quiet-harbor')
     // The tree is materialized, not merely pointed at, which is the half `checkout` was doing.
     expect(readFileSync(join(root, 'file.txt'), 'utf8')).toBe('x\n')
-    expect(ALLOWED_GIT_SUBCOMMANDS.has('checkout')).toBe(false)
     // And the snapshot probe retirement runs in that clone, which `for-each-ref` used to answer.
     const probe = (await handler(root)('exec', {
       tool: 'git',
       args: ['show-ref', '--verify', 'refs/agentconnect/reviews/session-1/head']
     })) as GitExecResult
     expect(probe.code).not.toBe(0)
+  })
+
+  it("serves the workspace sync's branch switch and refuses every checkout form that would touch files", async () => {
+    // The sync (git-injection.ts `syncWorkspaceRef`) pins the configured branch to the fetched tip and
+    // checks it out, carrying uncommitted edits — the one `checkout` the inventory admits. On a pool
+    // member a refusal here is a shared checkout that never comes back to its branch.
+    const root = repository()
+    execFileSync('git', ['update-ref', 'refs/remotes/origin/main', 'HEAD'], { cwd: root })
+    execFileSync('git', ['checkout', '-q', '-b', 'dev/agent/parked'], { cwd: root })
+    writeFileSync(join(root, 'notes.md'), 'kept\n')
+    const result = (await handler(root)('exec', {
+      tool: 'git',
+      args: ['checkout', '--no-recurse-submodules', '--no-track', '-B', 'main', 'refs/remotes/origin/main']
+    })) as GitExecResult
+    expect(result.code).toBe(0)
+    expect(execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim()).toBe(
+      'main'
+    )
+    expect(readFileSync(join(root, 'notes.md'), 'utf8')).toBe('kept\n')
+    // Discarding or restoring working-tree files is not what was admitted.
+    for (const args of [
+      ['checkout', '-f', 'main'],
+      ['checkout', '--force', 'main'],
+      ['checkout', '--', 'file.txt'],
+      ['checkout', 'main', '--', 'file.txt'],
+      ['checkout', '-p', 'main'],
+      ['checkout', '--merge', 'main'],
+      ['checkout', '--ours', 'file.txt'],
+      ['checkout', '--orphan', 'fresh'],
+      ['checkout', '--detach', 'main']
+    ]) {
+      await expect(handler(root)('exec', { tool: 'git', args })).rejects.toBeInstanceOf(ExecRefusedError)
+    }
   })
 
   it('still refuses every execution option on the newly permitted subcommands', async () => {

--- a/packages/daemon/test/workspace-git.test.ts
+++ b/packages/daemon/test/workspace-git.test.ts
@@ -63,6 +63,44 @@ const githubTarget = async () => ({
   githubApp: false
 })
 
+const BEFORE = 'a'.repeat(40)
+const AFTER = 'b'.repeat(40)
+
+/** `raw` as the sync path sees it: the origin for `remote get-url`, and every probe answered like a checkout on `current` whose HEAD `checkout -B` moves from `before` to `after`. */
+function syncRaw(
+  opts: { origin?: string; before?: string; after?: string; current?: string; numstat?: string; unique?: string } = {}
+) {
+  const before = opts.before ?? BEFORE
+  const after = opts.after ?? before
+  let head = before
+  return vi.fn().mockImplementation(async (args: string[]) => {
+    switch (args[0]) {
+      case 'remote':
+        return `${opts.origin ?? 'https://github.com/acme/repo.git'}\n`
+      case 'rev-parse':
+        return `${args[2] === 'HEAD' ? head : before}\n`
+      case 'symbolic-ref':
+        return `${opts.current ?? 'main'}\n`
+      case 'rev-list':
+        return `${opts.unique ?? '0'}\n`
+      case 'checkout':
+        head = after
+        return ''
+      case 'diff':
+        return opts.numstat ?? ''
+      default:
+        return ''
+    }
+  })
+}
+
+/** The `raw` calls that reach the network or move the checkout — what a refused sync must never make. */
+function syncWrites(raw: ReturnType<typeof vi.fn>): string[][] {
+  return raw.mock.calls
+    .map((call) => call[0] as string[])
+    .filter((args) => args[0] === 'fetch' || args[0] === 'checkout')
+}
+
 beforeEach(() => {
   simpleGitArgs = []
   statusImpl = vi.fn()
@@ -202,7 +240,7 @@ describe('createWorkspaceGit.status', () => {
 })
 
 describe('createWorkspaceGit.pull', () => {
-  it('reports isRepo:false / ok:false for a from-scratch workspace (nothing to pull)', async () => {
+  it('reports isRepo:false / ok:false for a from-scratch workspace (nothing to sync)', async () => {
     const dir = ws(false)
     const git = createWorkspaceGit(workspaces, async () => dir)
     expect(await git.pull('a')).toEqual({
@@ -211,12 +249,12 @@ describe('createWorkspaceGit.pull', () => {
       ok: false,
       detail: 'workspace is not a git checkout'
     })
-    expect(pullImpl).not.toHaveBeenCalled()
+    expect(syncWrites(rawImpl as ReturnType<typeof vi.fn>)).toEqual([])
   })
 
-  it('ff-only pulls and summarizes the update on success', async () => {
+  it('syncs the configured branch to the remote and summarizes the update on success', async () => {
     const dir = ws(true)
-    pullImpl = vi.fn().mockResolvedValue({ files: ['a.ts', 'b.ts'], summary: { insertions: 10, deletions: 3 } })
+    rawImpl = syncRaw({ after: AFTER, numstat: '10\t3\ta.ts\n0\t0\tb.ts\n' })
     const git = createWorkspaceGit(
       workspaces,
       async () => dir,
@@ -227,30 +265,64 @@ describe('createWorkspaceGit.pull', () => {
     expect(
       simpleGitArgs.some((options) => (options as { abort?: unknown } | undefined)?.abort instanceof AbortSignal)
     ).toBe(true)
-    expect(pullImpl).toHaveBeenCalledWith(
-      expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
-      '+refs/heads/main:refs/remotes/origin/main',
-      ['--ff-only', '--no-recurse-submodules']
-    )
+    // Fetch the configured branch through the credential alias, then pin and check out — never a merge.
+    expect(syncWrites(rawImpl as ReturnType<typeof vi.fn>)).toEqual([
+      [
+        'fetch',
+        '--no-recurse-submodules',
+        expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
+        '+refs/heads/main:refs/remotes/origin/main'
+      ],
+      ['checkout', '--no-recurse-submodules', '--no-track', '-B', 'main', 'refs/remotes/origin/main']
+    ])
     expect(envImpl).toHaveBeenCalledWith(
       expect.objectContaining({ AC_GITCRED_CAPABILITY: 'cap-a', GIT_ALLOW_PROTOCOL: 'https:ssh' })
     )
     expect(r).toMatchObject({ isRepo: true, ok: true, changed: 2, insertions: 10, deletions: 3 })
-    expect(r.detail).toMatch(/updated 2 files/i)
+    expect(r.detail).toBe('Synced main — updated 2 files.')
+  })
+
+  it('names the branch it had to leave when the checkout was parked elsewhere', async () => {
+    const dir = ws(true)
+    rawImpl = syncRaw({ current: 'dev/agent/canary', after: AFTER, numstat: '1\t1\tREADME.md\n' })
+    const git = createWorkspaceGit(
+      workspaces,
+      async () => dir,
+      () => undefined,
+      githubTarget
+    )
+    const r = await git.pull('a')
+    expect(r).toMatchObject({ ok: true, changed: 1 })
+    expect(r.detail).toBe('Switched from dev/agent/canary to main — updated 1 file.')
+  })
+
+  it('refuses, as data, a local commit the remote lacks instead of discarding it', async () => {
+    const dir = ws(true)
+    rawImpl = syncRaw({ unique: '2' })
+    const git = createWorkspaceGit(
+      workspaces,
+      async () => dir,
+      () => undefined,
+      githubTarget
+    )
+    const r = await git.pull('a')
+    expect(r).toMatchObject({ isRepo: true, ok: false })
+    expect(r.detail).toMatch(/local main has 2 commits the remote does not/)
+    expect(syncWrites(rawImpl as ReturnType<typeof vi.fn>).map((args) => args[0])).toEqual(['fetch'])
   })
 
   it('sanitizes host git context before inspecting the origin', async () => {
     const dir = ws(true)
     const previousGitDir = process.env.GIT_DIR
     process.env.GIT_DIR = '/tmp/attacker-controlled-git-dir'
-    rawImpl = vi.fn().mockImplementation(async () => {
+    const probes = syncRaw()
+    rawImpl = vi.fn().mockImplementation(async (args: string[]) => {
       expect(envImpl).toHaveBeenCalled()
       const firstEnv = (envImpl as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, string>
       expect(firstEnv).not.toHaveProperty('GIT_DIR')
       expect(firstEnv.GIT_ALLOW_PROTOCOL).toBe('')
-      return 'https://github.com/acme/repo.git\n'
+      return probes(args)
     })
-    pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
 
     try {
       await expect(
@@ -271,8 +343,7 @@ describe('createWorkspaceGit.pull', () => {
 
   it('pulls the SCOPED root: its own target, its credentials, and no fallback to the primary', async () => {
     const dir = ws(true)
-    rawImpl = vi.fn().mockResolvedValue('https://github.com/acme/infra.git\n')
-    pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
+    rawImpl = syncRaw({ origin: 'https://github.com/acme/infra.git' })
     const roots: (string | undefined)[] = []
     const credentialScopes: (string | undefined)[] = []
     const git = createWorkspaceGit(
@@ -297,16 +368,17 @@ describe('createWorkspaceGit.pull', () => {
     expect(roots).toEqual(['acme/infra'])
     expect(credentialScopes).toEqual(['acme/infra'])
     // The refspec git was asked for names the secondary root's branch, never the primary's.
-    expect(pullImpl).toHaveBeenCalledWith(
+    expect(rawImpl).toHaveBeenCalledWith([
+      'fetch',
+      '--no-recurse-submodules',
       expect.any(String),
-      '+refs/heads/trunk:refs/remotes/origin/trunk',
-      expect.anything()
-    )
+      '+refs/heads/trunk:refs/remotes/origin/trunk'
+    ])
   })
 
-  it('reports "Already up to date." when nothing changed', async () => {
+  it('reports "Already in sync." when nothing changed', async () => {
     const dir = ws(true)
-    pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
+    rawImpl = syncRaw()
     const git = createWorkspaceGit(
       workspaces,
       async () => dir,
@@ -315,10 +387,10 @@ describe('createWorkspaceGit.pull', () => {
     )
     const r = await git.pull('a')
     expect(r.ok).toBe(true)
-    expect(r.detail).toBe('Already up to date.')
+    expect(r.detail).toBe('Already in sync.')
   })
 
-  it('refuses an unsafe origin without running pull or echoing its secrets', async () => {
+  it('refuses an unsafe origin without syncing or echoing its secrets', async () => {
     const dir = ws(true)
     rawImpl = vi.fn().mockResolvedValue('https://legacy-user:super-secret@invalid.invalid/repo?token=query-secret\n')
     const git = createWorkspaceGit(
@@ -338,7 +410,7 @@ describe('createWorkspaceGit.pull', () => {
     })
     expect(JSON.stringify(result)).not.toContain('super-secret')
     expect(JSON.stringify(result)).not.toContain('query-secret')
-    expect(pullImpl).not.toHaveBeenCalled()
+    expect(syncWrites(rawImpl as ReturnType<typeof vi.fn>)).toEqual([])
   })
 
   it('refuses a safe but mismatched origin for an App-backed workspace', async () => {
@@ -356,10 +428,10 @@ describe('createWorkspaceGit.pull', () => {
       ok: false,
       detail: 'workspace origin is not a safe remote'
     })
-    expect(pullImpl).not.toHaveBeenCalled()
+    expect(syncWrites(rawImpl as ReturnType<typeof vi.fn>)).toEqual([])
   })
 
-  it('refuses to pull without the configured workspace target', async () => {
+  it('refuses to sync without the configured workspace target', async () => {
     const dir = ws(true)
     const git = createWorkspaceGit(workspaces, async () => dir)
 
@@ -368,7 +440,7 @@ describe('createWorkspaceGit.pull', () => {
       ok: false,
       detail: 'workspace origin is not a safe remote'
     })
-    expect(pullImpl).not.toHaveBeenCalled()
+    expect(syncWrites(rawImpl as ReturnType<typeof vi.fn>)).toEqual([])
   })
 
   it('refuses checkout-owned URL rewrites before pull', async () => {
@@ -392,17 +464,17 @@ describe('createWorkspaceGit.pull', () => {
       ok: false,
       detail: 'workspace Git configuration contains a disallowed network override or executable setting'
     })
-    expect(pullImpl).not.toHaveBeenCalled()
+    expect(syncWrites(rawImpl as ReturnType<typeof vi.fn>)).toEqual([])
   })
 
   it('pulls normally when local includes only configure repository hooks', async () => {
     const dir = ws(true)
+    const probes = syncRaw()
     rawImpl = vi
       .fn()
       .mockImplementation(async (args: string[]) =>
-        args[0] === 'remote' ? 'https://github.com/acme/repo.git\n' : 'include.path\0core.hookspath\0'
+        args[0] === 'config' ? 'include.path\0core.hookspath\0' : probes(args)
       )
-    pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
     const git = createWorkspaceGit(
       workspaces,
       async () => dir,
@@ -411,15 +483,12 @@ describe('createWorkspaceGit.pull', () => {
     )
 
     await expect(git.pull('a')).resolves.toMatchObject({ isRepo: true, ok: true })
-    expect(pullImpl).toHaveBeenCalledOnce()
+    expect(syncWrites(rawImpl as ReturnType<typeof vi.fn>).map((args) => args[0])).toEqual(['fetch', 'checkout'])
   })
 
-  it('ignores a checkout-controlled upstream and pulls the configured target explicitly', async () => {
+  it('ignores a checkout-controlled upstream and syncs the configured target explicitly', async () => {
     const dir = ws(true)
-    rawImpl = vi
-      .fn()
-      .mockImplementation(async (args: string[]) => (args[0] === 'remote' ? 'https://github.com/acme/repo.git\n' : ''))
-    pullImpl = vi.fn().mockResolvedValue({ files: [], summary: { insertions: 0, deletions: 0 } })
+    rawImpl = syncRaw()
     const git = createWorkspaceGit(
       workspaces,
       async () => dir,
@@ -429,11 +498,12 @@ describe('createWorkspaceGit.pull', () => {
 
     await expect(git.pull('a')).resolves.toMatchObject({ ok: true })
 
-    expect(pullImpl).toHaveBeenCalledWith(
+    expect(rawImpl).toHaveBeenCalledWith([
+      'fetch',
+      '--no-recurse-submodules',
       expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
-      '+refs/heads/release/v2:refs/remotes/origin/release/v2',
-      ['--ff-only', '--no-recurse-submodules']
-    )
+      '+refs/heads/release/v2:refs/remotes/origin/release/v2'
+    ])
     expect(
       (envImpl as ReturnType<typeof vi.fn>).mock.calls.some((call) =>
         Object.values(call[0] as Record<string, string>).includes('https://github.com/acme/repo.git')
@@ -441,9 +511,13 @@ describe('createWorkspaceGit.pull', () => {
     ).toBe(true)
   })
 
-  it('surfaces a failed pull as ok:false and scrubs the host path out of the detail', async () => {
+  it('surfaces a refused sync as ok:false and scrubs the host path out of the detail', async () => {
     const dir = ws(true)
-    pullImpl = vi.fn().mockRejectedValue(new Error(`cannot fast-forward in ${dir}/x`))
+    const probes = syncRaw()
+    rawImpl = vi.fn().mockImplementation(async (args: string[]) => {
+      if (args[0] === 'checkout') throw new Error(`Your local changes would be overwritten by checkout: ${dir}/x`)
+      return probes(args)
+    })
     const git = createWorkspaceGit(
       workspaces,
       async () => dir,

--- a/packages/daemon/test/workspace.test.ts
+++ b/packages/daemon/test/workspace.test.ts
@@ -25,13 +25,25 @@ vi.mock('node:fs/promises', () => ({ rename: renameMock }))
 // reassignable per test (success / failure / slow) via `cloneImpl`.
 let cloneImpl: (...args: any[]) => Promise<unknown>
 let lastGitEnv: Record<string, string> | undefined
-// The env in effect when the PULL ran. `lastGitEnv` alone would name whichever git preparation
+// The env in effect when the sync's FETCH ran. `lastGitEnv` alone would name whichever git preparation
 // happens to run last, which is not what the credential-injection assertions are about.
 let pullGitEnv: Record<string, string> | undefined
-const pullMock = vi.fn().mockImplementation(async () => {
-  pullGitEnv = lastGitEnv
-})
+const pullMock = vi.fn()
 const rawMock = vi.fn().mockResolvedValue('')
+/** `raw` answers for the sync path: `origin` for `remote get-url`, no local commits the remote lacks, '' otherwise. */
+function syncProbes(origin = 'https://github.com/acme/repo.git'): (args: string[]) => Promise<string> {
+  return async (args: string[]) => {
+    if (args[0] === 'remote' && args[1] === 'get-url') return `${origin}\n`
+    if (args[0] === 'rev-list' && args.includes('--count')) return '0\n'
+    return ''
+  }
+}
+/** The sync's writes — network and checkout — as issued; a session that must not sync issues none. */
+function syncWrites(): string[][] {
+  return rawMock.mock.calls
+    .map((call) => call[0] as string[])
+    .filter((args) => args[0] === 'fetch' || args[0] === 'checkout')
+}
 vi.mock('simple-git', () => ({
   simpleGit: (options?: string | { baseDir?: string }) => {
     const cwd = typeof options === 'string' ? options : options?.baseDir
@@ -44,7 +56,10 @@ vi.mock('simple-git', () => ({
       },
       clone: (...args: any[]) => cloneImpl(...args),
       pull: pullMock,
-      raw: (args: string[]) => rawMock(args, cwd)
+      raw: (args: string[]) => {
+        if (args[0] === 'fetch') pullGitEnv = lastGitEnv
+        return rawMock(args, cwd)
+      }
     }
     return chain
   }
@@ -120,7 +135,7 @@ beforeEach(() => {
   lastGitEnv = undefined
   pullGitEnv = undefined
   pullMock.mockClear()
-  rawMock.mockReset().mockResolvedValue('')
+  rawMock.mockReset().mockImplementation(syncProbes())
 })
 
 describe('prepareWorkspace', () => {
@@ -145,7 +160,7 @@ describe('prepareWorkspace', () => {
       '--single-branch'
     ])
     // clone, not pull, on a fresh checkout
-    expect(pullMock).not.toHaveBeenCalled()
+    expect(syncWrites()).toEqual([])
   })
 
   it('keeps ssh clone targets working', async () => {
@@ -177,7 +192,7 @@ describe('prepareWorkspace', () => {
     }
 
     expect(cloneImpl).not.toHaveBeenCalled()
-    expect(pullMock).not.toHaveBeenCalled()
+    expect(syncWrites()).toEqual([])
     configureWorkspaceGitOrigins(DEFAULT_WORKSPACE_GIT_ALLOWED_ORIGINS)
   })
 
@@ -204,34 +219,40 @@ describe('prepareWorkspace', () => {
     await expect(workspaces.prepareWorkspace(gitRepoAgent(path))).rejects.toThrow('boom')
   })
 
-  it('pulls (not clones) when an existing .git checkout is present', async () => {
+  it('syncs (not clones) when an existing .git checkout is present', async () => {
     const dir = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
     mkdirSync(join(dir, '.git'), { recursive: true })
     await workspaces.prepareWorkspace(gitRepoAgent(dir))
     expect(cloneImpl).not.toHaveBeenCalled()
-    expect(pullMock).toHaveBeenCalledWith(
-      expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
-      '+refs/heads/main:refs/remotes/origin/main',
-      ['--ff-only', '--no-recurse-submodules']
-    )
+    expect(syncWrites()).toEqual([
+      [
+        'fetch',
+        '--no-recurse-submodules',
+        expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
+        '+refs/heads/main:refs/remotes/origin/main'
+      ],
+      ['checkout', '--no-recurse-submodules', '--no-track', '-B', 'main', 'refs/remotes/origin/main']
+    ])
     expect(Object.values(pullGitEnv ?? {})).toContain('https://github.com/acme/repo.git')
   })
 
-  it('ignores a checkout-controlled upstream when pulling an existing workspace', async () => {
+  it('ignores a checkout-controlled upstream when syncing an existing workspace', async () => {
     const dir = join(mkdtempSync(join(tmpdir(), 'ac-ws-')), 'co')
     mkdirSync(join(dir, '.git'), { recursive: true })
     const agent = gitRepoAgent(dir)
     agent.workspace.gitBranch = 'release/v2'
-    rawMock.mockImplementation(async (args: string[]) =>
-      args[0] === 'remote' && args[1] === 'get-url' ? 'https://attacker.example/other.git\n' : ''
-    )
+    rawMock.mockImplementation(syncProbes('https://attacker.example/other.git'))
 
     await workspaces.prepareWorkspace(agent)
 
-    expect(pullMock).toHaveBeenCalledWith(
-      expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
-      '+refs/heads/release/v2:refs/remotes/origin/release/v2',
-      ['--ff-only', '--no-recurse-submodules']
+    expect(rawMock).toHaveBeenCalledWith(
+      [
+        'fetch',
+        '--no-recurse-submodules',
+        expect.stringMatching(/^agentconnect-[0-9a-f-]+$/),
+        '+refs/heads/release/v2:refs/remotes/origin/release/v2'
+      ],
+      expect.anything()
     )
     expect(Object.values(pullGitEnv ?? {})).toContain('https://github.com/acme/repo.git')
   })
@@ -753,7 +774,7 @@ describe('workspaces.prefetchWorkspace(reconcile-time eager clone)', () => {
     mkdirSync(join(dir, '.git'), { recursive: true })
     await workspaces.prefetchWorkspace(gitRepoAgent(dir))
     expect(cloneImpl).not.toHaveBeenCalled()
-    expect(pullMock).not.toHaveBeenCalled()
+    expect(syncWrites()).toEqual([])
   })
 })
 
@@ -869,9 +890,7 @@ describe('prepareWorkspaceForActivation', () => {
         })
       })
     )
-    rawMock.mockImplementation(async (args: string[]) =>
-      args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/repo.git\n' : ''
-    )
+    rawMock.mockImplementation(syncProbes())
 
     const rollback = await workspaces.prepareWorkspaceForActivation(
       { ...current, workspace: { ...current.workspace, gitRepo: 'https://github.com/acme/repo' } } as Agent,
@@ -989,9 +1008,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       preWarm: async () => undefined,
       capabilityFor: (agentId) => `cap-${agentId}`
     })
-    rawMock.mockImplementation(async (args: string[]) =>
-      args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/repo.git\n' : ''
-    )
+    rawMock.mockImplementation(syncProbes())
   })
 
   it('re-pins an existing checkout to the CURRENT agent id (a recreated agent adopts a stale pin)', async () => {
@@ -1005,7 +1022,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
     const add = configCalls.find((c) => c[1] === '--add')
     expect(add?.[3]).toBe("!'/run/helper.sh' bot-git-app")
     expect(configCalls).toContainEqual(['config', 'credential.https://github.com.useHttpPath', 'true'])
-    expect(pullMock).toHaveBeenCalled() // re-pin happens in addition to the pull, not instead of it
+    expect(syncWrites().map((args) => args[0])).toEqual(['fetch', 'checkout']) // re-pin happens in addition to the sync, not instead of it
     expect(cloneImpl).not.toHaveBeenCalled()
   })
 
@@ -1068,7 +1085,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
     await expect(workspaces.prepareWorkspace(githubAppAgent(dir))).rejects.toThrow(
       'origin is not a trusted GitHub remote'
     )
-    expect(pullMock).not.toHaveBeenCalled()
+    expect(syncWrites()).toEqual([])
   })
 
   it('fails closed when an App-backed origin cannot be rewritten', async () => {
@@ -1083,15 +1100,13 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
     })
 
     await expect(workspaces.prepareWorkspace(agent)).rejects.toThrow('config locked')
-    expect(pullMock).not.toHaveBeenCalled()
+    expect(syncWrites()).toEqual([])
   })
 
   it('leaves a credential-free non-github-app origin untouched', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-ws-repin-'))
     mkdirSync(join(dir, '.git'))
-    rawMock.mockImplementation(async (args: string[]) =>
-      args[0] === 'remote' && args[1] === 'get-url' ? 'https://github.com/acme/repo.git\n' : ''
-    )
+    rawMock.mockImplementation(syncProbes())
 
     await workspaces.prepareWorkspace(gitRepoAgent(dir))
 
@@ -1107,10 +1122,8 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
   it('removes credentials from a historical anonymous origin before pull', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'ac-ws-repin-'))
     mkdirSync(join(dir, '.git'))
-    rawMock.mockImplementation(async (args: string[]) =>
-      args[0] === 'remote' && args[1] === 'get-url'
-        ? 'https://legacy-user:legacy-token@github.com/acme/repo.git?token=query-secret\n'
-        : ''
+    rawMock.mockImplementation(
+      syncProbes('https://legacy-user:legacy-token@github.com/acme/repo.git?token=query-secret')
     )
 
     await workspaces.prepareWorkspace(gitRepoAgent(dir))
@@ -1121,7 +1134,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       'origin',
       'https://github.com/acme/repo.git'
     ])
-    expect(pullMock).toHaveBeenCalled()
+    expect(syncWrites().map((args) => args[0])).toEqual(['fetch', 'checkout'])
   })
 
   it('repoints a historical shorthand origin before pull', async () => {
@@ -1129,9 +1142,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
     mkdirSync(join(dir, '.git'))
     const agent = gitRepoAgent(dir)
     agent.workspace.gitRepo = 'https://github.com/acme/repo'
-    rawMock.mockImplementation(async (args: string[]) =>
-      args[0] === 'remote' && args[1] === 'get-url' ? 'acme/repo\n' : ''
-    )
+    rawMock.mockImplementation(syncProbes('acme/repo'))
 
     await workspaces.prepareWorkspace(agent)
 
@@ -1141,7 +1152,7 @@ describe('prepareWorkspace repo-local helper re-pin (github-app)', () => {
       'origin',
       'https://github.com/acme/repo'
     ])
-    expect(pullMock).toHaveBeenCalled()
+    expect(syncWrites().map((args) => args[0])).toEqual(['fetch', 'checkout'])
   })
 })
 

--- a/packages/web/src/components/console/WorkspaceCard.tsx
+++ b/packages/web/src/components/console/WorkspaceCard.tsx
@@ -189,7 +189,7 @@ export function WorkspaceCard({
         {isGit && header?.onPull && (
           <button
             className={`iconbtn h-6 w-6 flex-none ${header.pulling ? 'pointer-events-none opacity-50' : ''}`}
-            title="Fast-forward pull from the remote"
+            title="Sync the checkout with its remote branch"
             onClick={header.onPull}
           >
             <Icon name="refresh-cw" size={13} />

--- a/packages/web/src/components/console/WorkspaceFiles.tsx
+++ b/packages/web/src/components/console/WorkspaceFiles.tsx
@@ -23,6 +23,7 @@ import { escapeHtml, highlight, linkifyHtml, loadHljs } from '@/lib/highlight'
 import { resolveWorkspaceMarkdownLink } from '@/components/console/workspace-links'
 import type { WorkspaceHeaderInfo } from '@/components/console/WorkspaceCard'
 import { isGitWorkspace, type Agent } from '@/lib/data'
+import { gitWriteRequestFailureText } from '@/components/console/dock/git-write'
 import type { MarkdownLinkResolution } from '@/components/console/MarkdownView'
 import {
   FileBrowserBreadcrumb,
@@ -292,7 +293,9 @@ export function WorkspaceFiles({
     if (guide) selectFile(guide.name, guide.name)
   }, [dirs, isMobile])
 
-  // Force a fast-forward pull on the owning daemon, then refresh status + tree.
+  // Sync the checkout to its remote branch on the owning daemon, then refresh status + tree. A
+  // refused sync answers 200 with the reason as data; a status (the agent working in the checkout,
+  // an offline daemon) is explained the way every other console git write explains it.
   const onGitPull = () => {
     if (gitPulling) return
     setGitPulling(true)
@@ -300,12 +303,16 @@ export function WorkspaceFiles({
     workspaceGitPull(agentId, repo ? { repo } : {}).then(
       (r) => {
         setGitPulling(false)
-        setGitMsg(r.detail ?? (r.ok ? 'Pulled.' : 'Pull failed.'))
+        setGitMsg(r.detail ?? (r.ok ? 'Synced.' : 'Sync failed.'))
         if (r.ok) setRefreshTick((n) => n + 1)
       },
-      () => {
+      (e: unknown) => {
         setGitPulling(false)
-        setGitMsg('Pull failed — the daemon may be offline.')
+        setGitMsg(
+          e instanceof ApiError
+            ? gitWriteRequestFailureText(e.status, e.code ?? null)
+            : gitWriteRequestFailureText(null, null)
+        )
       }
     )
   }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -3145,8 +3145,8 @@ export interface WorkspaceGitStatusDto {
   lastFetchAt: string | null // RFC3339; when the checkout last fetched/pulled
 }
 
-// Outcome of a forced ff-only pull (POST /agents/:id/workspace/gitpull). A pull
-// that can't fast-forward is `ok:false` + `detail` (data), not an HTTP error.
+// Outcome of a workspace sync (POST /agents/:id/workspace/gitpull). A refused
+// sync is `ok:false` + `detail` (data), not an HTTP error.
 export interface WorkspaceGitPullDto {
   isRepo: boolean
   ok: boolean
@@ -3239,8 +3239,8 @@ export async function fetchWorkspaceGitLog(
   return apiGet<WorkspaceGitLogDto>(`${orgBase()}/agents/${encodeURIComponent(agentId)}/workspace/gitlog${query}`)
 }
 
-// Force the owning daemon to `git pull` (fast-forward only) the agent's workspace
-// now. A pull that can't fast-forward returns `ok:false`; 503 when daemon offline.
+// Sync the agent's checkout to its remote branch on the owning daemon now. A refused sync
+// returns `ok:false` + detail; 409 while the agent works in the checkout, 503 when daemon offline.
 export async function workspaceGitPull(agentId: string, opts: { repo?: string } = {}): Promise<WorkspaceGitPullDto> {
   const query = opts.repo ? `?repo=${encodeURIComponent(opts.repo)}` : ''
   return apiPost<WorkspaceGitPullDto>(


### PR DESCRIPTION
## Why

Both the session-start pull and the console's pull button ran `git pull --ff-only` **into whatever branch the checkout was on**. A shared checkout that an agent had parked on its own branch never came back: every fast-forward failed, the failure was swallowed as offline degradation, the agent kept working on a month-old base, and the console showed that branch's HEAD as "the latest commit" while the button reported "Pull failed — the daemon may be offline" (the daemon was fine; it was refusing because the agent was mid-turn, and the CP mapped that CONFLICT to 503).

## What

**Daemon** — `syncWorkspaceRef` replaces `pullWorkspaceRef` for the session-start sync (`pullOnNewSession`), the cluster volume path and the console request:

1. `git fetch <remote> +refs/heads/<branch>:refs/remotes/origin/<branch>`
2. refuse if the local `<branch>` has commits the remote lacks — the branch is left alone and the detail says to push or move them (never discarded)
3. `git checkout --no-track -B <branch> refs/remotes/origin/<branch>` — pins the local branch to the remote tip and checks it out; uncommitted edits ride along the way `git checkout` carries them, and git refuses (naming the file) when one touches a file the sync would rewrite
4. report files/insertions/deletions between the two HEADs, plus `switchedFrom` when the checkout was on another branch

Never a merge, so local history cannot fork from the remote. The agent's own branches and their commits are untouched.

**Control plane** — the `gitpull` route maps a daemon refusal through `sendWorkspaceFailure` like every other console git write: "the agent is working in this workspace" is 409 `WORKSPACE_STALE`; only an offline daemon is 503. Summary/description updated; path and `operationId` unchanged, wire contract unchanged.

**Web** — the button is "Sync the checkout with its remote branch"; result copy is `Synced main — updated N files.` / `Switched from X to main — …` / `Already in sync.`; a status failure is explained with the shared git-write text ("The agent is working in this workspace right now. Try again when it is idle.").

## Tests

- real-git: switching back from a parked branch carrying an uncommitted edit; refusing a local commit the remote lacks; refusing an overlapping edit (HEAD and the edit untouched)
- workspace-git unit tests re-pinned to the sync's `raw` probes (fetch + checkout, never a merge); cluster fake runner refuses on `checkout -B` for the divergent-volume case
- CP integration: the busy CONFLICT → 409 `WORKSPACE_STALE`

## Not in scope

- Surfacing a *refused* session-start sync to the model/console (today it is still swallowed as degradation; the Sync button reports it on demand). Follow-up.
- `GitRunner.pull` is no longer called by production code; the interface member is left for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
