### PR TITLE
feat(daemon): a multi-field Slack elicitation is answered in a modal

### DIFF
--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -60,7 +60,8 @@ const EXEMPT: Record<string, string> = {
   // Interactive Slack surfaces (Block Kit actions / modals) are driven by
   // Bolt callbacks the virtual transport never receives; the daemon only
   // invokes them from those callbacks.
-  openStatusModal: 'interactivity-only (status modal from a Bolt action)'
+  openStatusModal: 'interactivity-only (status modal from a Bolt action)',
+  openView: 'interactivity-only (elicitation form modal from a Bolt action or a forwarded trigger_id)'
 }
 
 function recordingConnection() {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1600,6 +1600,8 @@ export class Daemon {
       handlePermissionChoice: (a) => this.permissions.handlePermissionChoice(a),
       handleElicitChoice: (a) => this.permissions.handleElicitChoice(a),
       handleElicitConfirm: (a) => void this.permissions.confirmElicitSelection(a),
+      handleElicitFormOpen: (a) => void this.permissions.openElicitFormModal(a),
+      handleElicitFormSubmit: (a) => this.permissions.submitElicitForm(a),
       handleDiscordSelect: (a) => this.commands.handleDiscordSelect(a),
       handleTelegramCallback: (cb, conn) => this.commands.handleTelegramCallback(cb, conn),
       slackShortcutSession: (shortcut, srcIntegrationIds) =>
@@ -7659,6 +7661,23 @@ export class Daemon {
         values: payload.values,
         actor
       })
+    } else if (payload.kind === 'elicitation-open') {
+      // The trigger id is one-shot and short-lived: open on this daemon's own bot token now,
+      // exactly as open-config above does, and let rd/ack be the relay receipt it always was.
+      void this.permissions.openElicitFormModal({
+        requestId: payload.requestId,
+        triggerId: payload.triggerId,
+        conn
+      })
+    } else if (payload.kind === 'elicitation-submit') {
+      // The ONE Slack action whose verdict Slack itself is waiting for: the per-field errors ride
+      // back on the ack's opaque `response`, which the relay surfaces verbatim on its 200.
+      const response = await this.permissions.submitElicitForm({
+        requestId: payload.requestId,
+        fields: payload.fields,
+        ...(actor ? { actor } : {})
+      })
+      return { msgId: msg.msgId, accepted: true, ...(response ? { response } : {}) }
     } else {
       await this.commands.handleStatusAction({ kind: 'cancel', sessionKey: msg.sessionKey, actor })
     }

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -27,7 +27,10 @@ import { SlackConnection } from '../slack/connection.js'
 import type { InteractionActor } from '../platforms/contract.js'
 import {
   buildApprovalDmIntro,
+  buildElicitFormClosedModal,
   buildElicitationCard,
+  buildElicitationFormCard,
+  buildElicitationFormModal,
   buildElicitationResolvedCard,
   buildPermissionCard,
   buildPermissionResolvedCard,
@@ -38,8 +41,12 @@ import {
   ELICIT_REPLY_KINDS,
   elicitFieldLabel,
   elicitForm,
+  elicitFormFieldLabel,
   elicitFormAccepts,
+  elicitFormClosedResponse,
   elicitFormContent,
+  elicitFormErrorResponse,
+  elicitFormSubmission,
   elicitReplyAnswer,
   elicitReplyExpectation,
   elicitRequiredProps,
@@ -160,16 +167,12 @@ function formAnswerLabel(
   form: readonly ElicitTarget[],
   answer: ElicitFormAnswer
 ): string {
-  // A companion box is named for the question it sits in ("Branch (Other)"), never on its own:
-  // "Other: dev" in a transcript says which words were typed but not what they answer.
-  const name = (t: ElicitTarget) =>
-    t.customAnswerFor
-      ? `${elicitFieldLabel(params, t.customAnswerFor)} (${elicitFieldLabel(params, t.propName)})`
-      : elicitFieldLabel(params, t.propName)
   const parts: string[] = []
   for (const t of form) {
     const value = answer[t.propName]
-    if (value !== undefined) parts.push(`${name(t)}: ${chosenLabel(t, value)}`)
+    // Named exactly as a form card names its fields, companion box included ("Branch (Other)"):
+    // "Other: dev" in a transcript says which words were typed but not what they answer.
+    if (value !== undefined) parts.push(`${elicitFormFieldLabel(params, t)}: ${chosenLabel(t, value)}`)
   }
   // An all-optional form left alone is still an answer — settling it as nothing would read
   // as a card that never resolved, the same reason a `minItems: 0` selection says so too.
@@ -293,9 +296,14 @@ type PendingElicit = PendingElicitSurface & {
   params: CreateElicitationRequest
   propName: string
   kind: ElicitKind
-  /** Set only for a MULTI-field webchat form card — the fields it rendered, in schema order.
-   *  Absent ⇒ the single-field card, answered by a scalar or a list as it always was. */
+  /** Set only for a MULTI-field form card — webchat's, or Slack's Answer-button-plus-modal —
+   *  the fields it rendered, in schema order. Absent ⇒ the single-field card, answered by a
+   *  scalar or a list as it always was. */
   form?: ElicitTarget[]
+  /** Set beside `form` on a SLACK form card: the opaque session target its modal carries in
+   *  `private_metadata`, so a relay-forwarded submission routes back to this daemon. It is the
+   *  same value the card's own `block_id` carries, and it names nothing about the reader. */
+  sessionTarget?: string
   /** Set only for a URL-mode consent card: the ACP `elicitationId` and the exact URL shown.
    *  Present ⇒ `propName`/`kind`/`form` mean nothing — the card has no field, and its only
    *  answers are consent (this same URL back) or Dismiss. */
@@ -1465,6 +1473,13 @@ export class PermissionCoordinator {
     // A second SURFACE for #1810's URL mode: the notice is only for an ask Slack still cannot render.
     if (url) return await this.awaitSlackUrlElicitation(agentId, sessionId, params, p, conn, url)
     if (params.mode === 'url') return this.noticeUnrenderableElicit(p, params, isApproval)
+    // A form asking more than one QUESTION cannot be a row of buttons: an `actions` block holds
+    // no inputs at all, so it becomes an Answer button plus a modal — the one shape on this
+    // surface that needs one (#1794's Slack column). An approval never takes it: allow/deny is a
+    // single enum, and chat approval's own bookkeeping lives on the single-field path below.
+    const form = isApproval ? null : elicitForm(params, SLACK_ELICIT_SURFACE)
+    if (form && form.filter((t) => !t.customAnswerFor).length > 1)
+      return await this.awaitSlackFormElicitation(agentId, sessionId, params, p, conn, form)
     const target = elicitTarget(params, SLACK_ELICIT_SURFACE)
     if (!target) return this.noticeUnrenderableElicit(p, params, isApproval)
     // A `text`/`number` card has nothing to tap: the reader answers by replying in the thread,
@@ -1760,6 +1775,125 @@ export class PermissionCoordinator {
     return await result
   }
 
+  /**
+   * Slack's peer of {@link awaitWebchatElicitation}: post the multi-field card — the question, a
+   * line naming what will be asked, an Answer button and Dismiss — and park the resolver until
+   * the modal behind Answer is submitted, Dismiss is tapped, or the turn ends. The fields live in
+   * the modal because Slack's `actions` block holds none, and the modal itself is built on demand
+   * from these same `params`, so nothing pre-rendered is stored anywhere.
+   *
+   * A form no modal can hold (an enum option value past Slack's select cap, a minimum length past
+   * an input's) is declined with the same notice every other unrenderable ask gets — checked HERE,
+   * before the card is posted, so the reader is never offered an Answer button with no modal.
+   */
+  private async awaitSlackFormElicitation(
+    agentId: string,
+    sessionId: string,
+    params: CreateElicitationRequest,
+    p: Pending,
+    conn: SlackConnection,
+    form: ElicitTarget[]
+  ): Promise<CreateElicitationResponse | undefined> {
+    const requestId = `elicit-${++this.elicitSeq}`
+    const sessionTarget = this.host.httpSlackSessionTarget(p)
+    if (!buildElicitationFormModal(requestId, params, form, sessionTarget))
+      return this.noticeUnrenderableElicit(p, params, false)
+    const blocks = buildElicitationFormCard(requestId, params, form, sessionTarget)
+    const fallback = (params as { message?: string }).message ?? 'The agent needs your input'
+    let resolveResult!: (res: CreateElicitationResponse) => void
+    const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
+    this.pendingElicits.set(requestId, {
+      owner: p.hostKey,
+      agentId,
+      sessionId,
+      params,
+      // A form answers with a RECORD keyed by property name, so these two carry nothing: they
+      // are the single-field card's shape, and the form path never reads either.
+      propName: '',
+      kind: 'text',
+      form,
+      ...(sessionTarget ? { sessionTarget } : {}),
+      approval: false,
+      surface: 'slack',
+      conn,
+      channel: p.plan.channel,
+      resolve: resolveResult
+    })
+    this.syncApprovalActivity(p.hostKey, sessionId)
+    const ts = await this.host.postCardSerialized(p, (sc) =>
+      sc.postBlocks(p.plan.channel, blocks, fallback, p.plan.statusThread, {
+        ...(slackAgentIdentityOptions(p.plan) ?? {}),
+        chrome: true
+      })
+    )
+    const live = this.pendingElicits.get(requestId)
+    // Settled mid-post (an ended turn, say) — the card must stop offering an Answer nobody awaits.
+    if (!live) {
+      if (ts) this.rewriteSlackCard(conn, p.plan.channel, ts, params, ':hourglass: Cancelled', 'Cancelled', false)
+      return await result
+    }
+    if (!ts) {
+      this.pendingElicits.delete(requestId)
+      this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
+      live.resolve({ action: 'cancel' })
+      return await result
+    }
+    if (live.surface === 'slack') live.ts = ts
+    return await result
+  }
+
+  /**
+   * Open a live form card's modal (SlackDeps.onElicitFormOpen, and the relay's
+   * `elicitation-open`). The view is BUILT HERE, from the card's own params, on both ingress
+   * paths — so the two produce the same modal by construction, and the relay never holds,
+   * renders or caches any part of it. Opened on the card's OWN connection, which is the bot
+   * token that posted it.
+   *
+   * A request id with no live form card — already answered, dismissed, cancelled, or simply
+   * never ours — opens the closed modal instead of nothing at all: a stale client still shows
+   * the Answer button, and this is the difference between an explanation and a dead button.
+   */
+  async openElicitFormModal(a: { requestId: string; triggerId: string; conn: SlackConnection }): Promise<void> {
+    const rec = this.pendingElicits.get(a.requestId)
+    const form = rec?.form && rec.surface === 'slack' ? elicitForm(rec.params, surfaceOf(rec)) : null
+    const view = rec && form ? buildElicitationFormModal(a.requestId, rec.params, form, rec.sessionTarget) : null
+    // A closed card is told on the connection the tap arrived through: the record that would
+    // have named one is exactly what is missing.
+    await a.conn.openView(a.triggerId, view ?? buildElicitFormClosedModal())
+  }
+
+  /**
+   * Answer a form card from its modal's `view_submission` (SlackDeps.onElicitFormSubmit, and the
+   * relay's `elicitation-submit`). The whole record is re-derived against the form THAT CARD
+   * rendered, exactly as webchat's is (#1807) and as every tapped option is (#1815): the rendered
+   * property set, every `required` name present, an omitted optional field allowed, each value
+   * valid for its own field. One bad field refuses the submission with that field's own error and
+   * leaves the card live — Dismiss stays the only explicit refusal.
+   *
+   * Resolves to the response Slack is given: undefined closes the modal, `errors` keeps it open,
+   * and an already-settled card is replaced by the closed view — which is what a SECOND reader
+   * sees when someone else's submission got there first.
+   */
+  async submitElicitForm(a: {
+    requestId: string
+    fields: Record<string, string | string[]>
+    actor?: InteractionActor
+  }): Promise<Record<string, unknown> | undefined> {
+    const rec = this.pendingElicits.get(a.requestId)
+    const form = rec?.form && rec.surface === 'slack' ? elicitForm(rec.params, surfaceOf(rec)) : null
+    if (!rec || !form) return elicitFormClosedResponse()
+    const submission = elicitFormSubmission(rec.params, form, a.fields)
+    if (submission.errors) return elicitFormErrorResponse(submission.errors)
+    // No await between the check above and the settlement below, so two concurrent submissions
+    // cannot both pass: the loser finds no record and is answered with the closed view.
+    await this.handleElicitChoice({
+      requestId: a.requestId,
+      value: submission.answer ?? {},
+      ...(a.actor ? { actor: a.actor } : {})
+    })
+    return undefined
+  }
+
   /** Rewrite a settled Slack card in place, best effort — the ACP resolution never depends on it.
    *  A consent card keeps its own shape so the settled message still records the URL. */
   private rewriteSlackCard(
@@ -2005,7 +2139,7 @@ export class PermissionCoordinator {
    *  `minItems`/`maxItems` is refused there with the card left live. */
   async confirmElicitSelection(a: { requestId: string; values: string[]; actor?: InteractionActor }): Promise<void> {
     const rec = this.pendingElicits.get(a.requestId)
-    if (!rec || rec.surface !== 'slack' || rec.kind !== 'multi-enum' || rec.url) return
+    if (!rec || rec.surface !== 'slack' || rec.kind !== 'multi-enum' || rec.url || rec.form) return
     await this.handleElicitChoice({
       requestId: a.requestId,
       value: a.values,

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -75,6 +75,8 @@ export interface PlatformActionSink {
   handlePermissionChoice: NonNullable<SlackDeps['onPermissionChoice']>
   handleElicitChoice: NonNullable<SlackDeps['onElicitChoice']>
   handleElicitConfirm: NonNullable<SlackDeps['onElicitConfirm']>
+  handleElicitFormOpen: NonNullable<SlackDeps['onElicitFormOpen']>
+  handleElicitFormSubmit: NonNullable<SlackDeps['onElicitFormSubmit']>
   handleDiscordSelect: NonNullable<DiscordDeps['onSelectAction']>
   handleTelegramCallback(cb: TelegramCallback, conn: TelegramConnection): Promise<void>
   slackShortcutSession(
@@ -216,6 +218,8 @@ export class ConnectionReconciler {
       onPermissionChoice: (a) => this.host.handlePermissionChoice(a),
       onElicitChoice: (a) => this.host.handleElicitChoice(a),
       onElicitConfirm: (a) => this.host.handleElicitConfirm(a),
+      onElicitFormOpen: (a) => this.host.handleElicitFormOpen(a),
+      onElicitFormSubmit: (a) => this.host.handleElicitFormSubmit(a),
       log: this.log,
       boltDebug: this.host.boltDebug()
     }
@@ -506,6 +510,8 @@ export class ConnectionReconciler {
             onPermissionChoice: (a) => this.host.handlePermissionChoice(a),
             onElicitChoice: (a) => this.host.handleElicitChoice(a),
             onElicitConfirm: (a) => this.host.handleElicitConfirm(a),
+            onElicitFormOpen: (a) => this.host.handleElicitFormOpen(a),
+            onElicitFormSubmit: (a) => this.host.handleElicitFormSubmit(a),
             log: this.log
           },
           this.host.slackAppFactory()

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -19,15 +19,20 @@ import {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
+  ELICIT_FORM_CALLBACK_ID,
+  ELICIT_OPEN_ACTION,
   ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   PERMISSION_UPDATE_ACTION,
   buildPermissionUpdateCard,
   buildStatusModal,
   buildStatusUnavailableModal,
+  decodeElicitFormMetadata,
   decodePermValue,
+  elicitFormViewValues,
   selectedOptionsFromState,
   type SlackBlockActionsState,
+  type SlackViewState,
   type SlackStreamChunk,
   type StatusBarInfo,
   type StatusModalIdentity
@@ -447,6 +452,23 @@ export interface SlackDeps {
    *  selection read out of THAT tap's own message state, so it is the state this reader
    *  confirmed — nothing is tracked between a selection change and the Confirm. */
   onElicitConfirm?: (a: { requestId: string; values: string[]; actor?: InteractionActor }) => void
+  /** Fired when a reader taps a MULTI-FIELD elicitation card's Answer button. The fields cannot
+   *  sit on the card, so the answer is a modal: the daemon builds it from the card's own schema
+   *  and opens it on `conn` — the very connection, and the very bot token, that posted the card. */
+  onElicitFormOpen?: (a: {
+    requestId: string
+    triggerId: string
+    conn: SlackConnection
+    actor?: InteractionActor
+  }) => void
+  /** Fired when that modal is submitted. Resolves to the `view_submission` response Slack is
+   *  given: undefined closes the modal, a `response_action` payload keeps it open carrying the
+   *  per-field errors the daemon's re-validation produced. */
+  onElicitFormSubmit?: (a: {
+    requestId: string
+    fields: Record<string, string | string[]>
+    actor?: InteractionActor
+  }) => Promise<Record<string, unknown> | undefined>
   newTraceId: () => string
   log?: Logger
   /** When true, hand Bolt LogLevel.DEBUG so socket-mode internals are visible. */
@@ -490,6 +512,14 @@ type BlockActionArgs = {
   }
 }
 
+/** The subset of a `view_submission` payload we read: who submitted it, the modal's opaque
+ *  `private_metadata`, and every input's state. `ack` takes the response Slack applies. */
+type ViewSubmissionArgs = {
+  ack: (response?: unknown) => Promise<void>
+  body?: { user?: { id?: string; username?: string; name?: string } }
+  view?: { private_metadata?: string; state?: SlackViewState }
+}
+
 type MessageShortcutArgs = {
   ack: () => Promise<void>
   shortcut: {
@@ -515,6 +545,7 @@ export type AppLike = {
   event: (type: string, handler: (args: { event: unknown }) => Promise<void> | void) => void
   action: (actionId: string | RegExp, handler: (args: BlockActionArgs) => Promise<void> | void) => void
   shortcut: (callbackId: string, handler: (args: MessageShortcutArgs) => Promise<void> | void) => void
+  view: (callbackId: string, handler: (args: ViewSubmissionArgs) => Promise<void> | void) => void
   client: {
     views: {
       open: (a: unknown) => Promise<unknown>
@@ -898,6 +929,7 @@ function sendOnlyApp(botToken: string): AppLike {
     event: () => {},
     action: () => {},
     shortcut: () => {},
+    view: () => {},
     client: client as unknown as AppLike['client'],
     start: async () => {},
     stop: async () => {}
@@ -1225,6 +1257,29 @@ export class SlackConnection implements PlatformConnection {
       // No state for the select ⇒ nothing this tap can be said to confirm; the card stays live.
       if (values) this.deps.onElicitConfirm?.({ requestId: action.value, values, actor: actorOf(body) })
     })
+    // Multi-field card (buildElicitationFormCard): Answer opens the modal the daemon builds from
+    // the card's own schema. The trigger id is valid ~3s, so the ack goes first and the open is
+    // not awaited — a missed window leaves the card live, and the reader taps Answer again.
+    this.app.action(ELICIT_OPEN_ACTION, async ({ ack, action, body }) => {
+      await ack()
+      const triggerId = body?.trigger_id
+      if (!action.value || !triggerId) return
+      const actor = actorOf(body)
+      this.deps.onElicitFormOpen?.({ requestId: action.value, triggerId, conn: this, ...(actor ? { actor } : {}) })
+    })
+    // That modal's submission (buildElicitationFormModal). The response rides THIS ack, so a
+    // refused field returns to the modal with no relay and no second interaction involved.
+    this.app.view(ELICIT_FORM_CALLBACK_ID, async ({ ack, body, view }) => {
+      const meta = view?.private_metadata ? decodeElicitFormMetadata(view.private_metadata) : null
+      if (!meta) return await ack()
+      const actor = actorOf(body)
+      const response = await this.deps.onElicitFormSubmit?.({
+        requestId: meta.requestId,
+        fields: elicitFormViewValues(view?.state),
+        ...(actor ? { actor } : {})
+      })
+      await ack(response)
+    })
     log?.debug('slack: app.start → opening Socket Mode WebSocket (wss://…slack.com)…')
     await this.app.start()
     log?.debug('slack: app.start resolved → socket established')
@@ -1244,6 +1299,18 @@ export class SlackConnection implements PlatformConnection {
             ? buildStatusModal(data.info, sessionKey, data.link, privateMetadata, data.identity)
             : buildStatusUnavailableModal()
       })
+    } catch (err) {
+      this.deps.log?.debug(`slack: views.open failed: ${(err as Error).message}`)
+    }
+  }
+
+  /** Open one daemon-built modal on this connection's own bot token — the elicitation form's
+   *  view, on either ingress. Web API failures are logged and swallowed for the same reason
+   *  {@link openStatusModal}'s are: a one-shot trigger id cannot be retried, and the card the
+   *  view answers is still there to be tapped again. */
+  async openView(triggerId: string, view: unknown): Promise<void> {
+    try {
+      await this.app.client.views.open({ trigger_id: triggerId, view })
     } catch (err) {
       this.deps.log?.debug(`slack: views.open failed: ${(err as Error).message}`)
     }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -1648,7 +1648,12 @@ export function elicitFormSubmission(
   for (const [index, target] of form.entries()) {
     const blockId = elicitFormBlockId(index)
     const raw = fields[blockId]
-    if (raw === undefined) {
+    // Slack sends `[]` for a multi-select nobody touched, so a blank OPTIONAL one is an omission,
+    // not an empty answer that then fails its own `minItems`. A required field keeps being checked:
+    // there, `[]` is a real selection and its bounds decide. (An emptied REQUIRED select staying an
+    // answer is #1801's reading, kept.)
+    const blank = raw === undefined || (Array.isArray(raw) && !raw.length && !required.has(target.propName))
+    if (blank) {
       if (required.has(target.propName)) errors[blockId] = 'This field is required.'
       continue
     }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -3,10 +3,15 @@ import {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
+  ELICIT_FORM_CALLBACK_ID,
   ELICIT_FORM_FIELD_CAP,
+  ELICIT_FORM_INPUT_ACTION,
+  ELICIT_OPEN_ACTION,
   ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   SLACK_STATUS_ACTION,
+  elicitFormBlockId,
+  encodeElicitFormMetadata,
   encodePermValue,
   encodeSlackStatusOverflowValue
 } from '@agentconnect.md/protocol'
@@ -14,12 +19,18 @@ export {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
+  ELICIT_FORM_CALLBACK_ID,
+  ELICIT_OPEN_ACTION,
   ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
+  decodeElicitFormMetadata,
   decodePermValue,
+  elicitFormBlockId,
+  elicitFormViewValues,
   encodePermValue,
   selectedOptionsFromState,
-  type SlackBlockActionsState
+  type SlackBlockActionsState,
+  type SlackViewState
 } from '@agentconnect.md/protocol'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
 import { flattenUnsafeLinks } from '../messages/agent-links.js'
@@ -905,6 +916,15 @@ export function elicitFieldLabel(params: CreateElicitationRequest, propName: str
   return clampTo((typeof title === 'string' && title.trim()) || propName, 75)
 }
 
+/** How a MULTI-FIELD card names one field. A select question's free-text companion is named for
+ *  the question it belongs to ("Branch (Other)") rather than on its own: "Other" beside a stack
+ *  of other labels says which words were typed but not what they answer. Pure. */
+export function elicitFormFieldLabel(params: CreateElicitationRequest, target: ElicitTarget): string {
+  const own = elicitFieldLabel(params, target.propName)
+  if (!target.customAnswerFor) return own
+  return clampTo(`${elicitFieldLabel(params, target.customAnswerFor)} (${own})`, 75)
+}
+
 // ACP's cross-agent marker for a select question's own free-text box, under a namespace-free `_meta` key on purpose.
 const CUSTOM_ANSWER_META_KEY = '_askUserQuestionCustomAnswer'
 
@@ -1413,6 +1433,252 @@ export function buildElicitationResolvedCard(params: CreateElicitationRequest, d
   const message = elicitCardMessage(params)
   const text = clampTo(`:speech_balloon: ${clampTo(message, ELICIT_MESSAGE_CAP)}\n${decision}`, SLACK_SECTION_TEXT_CAP)
   return [{ type: 'section', text: { type: 'mrkdwn', text } }]
+}
+
+// ── Multi-field elicitation forms (Slack modal, issue #1794's last Slack item) ────────────────
+
+/** Slack's own cap on a modal title. 24 characters hold no question, so the title is a FIXED
+ *  deployment-authored line and the agent's own words go in the modal's first section, defused
+ *  by {@link elicitCardMessage} like every other card's — an agent-authored string clamped into
+ *  24 characters would be both unreadable and the one place on the modal a reader would trust
+ *  most. This is the same phrase the seam already uses as a card's notification fallback. */
+const SLACK_MODAL_TITLE = 'Agent needs your input'
+
+/** Slack's own cap on a `plain_text_input`'s `min_length`/`max_length`, and on a select option's
+ *  `value` — a modal has no button to fall back to, so an enum whose values outrun the second
+ *  cap declines rather than posting a modal Slack would reject (#1813's finding, one surface on). */
+const SLACK_INPUT_LENGTH_CAP = 3000
+
+/** The `input` element one form field is answered by: a select for the pickable kinds, a
+ *  `plain_text_input` for text and a `number_input` for numbers, each carrying the schema's own
+ *  bounds so Slack refuses in the modal what the daemon would refuse anyway. Null ⇒ this field
+ *  cannot BE an input block — an enum option value past Slack's 75-char select cap, or a minimum
+ *  length past what an input holds — and the whole modal is then withheld rather than posted
+ *  with a field the reader cannot answer honestly. Pure. */
+function elicitFormInputElement(target: ElicitTarget): Record<string, unknown> | null {
+  const action_id = ELICIT_FORM_INPUT_ACTION as string
+  if (target.kind === 'text') {
+    const min = target.minLength
+    if (min !== undefined && min > SLACK_INPUT_LENGTH_CAP) return null
+    const max = Math.min(target.maxLength ?? SLACK_INPUT_LENGTH_CAP, SLACK_INPUT_LENGTH_CAP)
+    return {
+      type: 'plain_text_input',
+      action_id,
+      ...(min !== undefined ? { min_length: min } : {}),
+      max_length: max,
+      ...(typeof target.defaultValue === 'string' ? { initial_value: target.defaultValue } : {})
+    }
+  }
+  if (target.kind === 'number') {
+    return {
+      type: 'number_input',
+      action_id,
+      is_decimal_allowed: target.integer !== true,
+      ...(target.minimum !== undefined ? { min_value: String(target.minimum) } : {}),
+      ...(target.maximum !== undefined ? { max_value: String(target.maximum) } : {}),
+      ...(typeof target.defaultValue === 'number' ? { initial_value: String(target.defaultValue) } : {})
+    }
+  }
+  const options = target.options.map((o) => ({
+    text: { type: 'plain_text', text: o.label, emoji: true },
+    value: o.value
+  }))
+  if (!options.length || options.some((o) => o.value.length > SLACK_SELECT_VALUE_CAP)) return null
+  if (target.kind === 'multi-enum') {
+    const seeded = Array.isArray(target.defaultValue) ? new Set(target.defaultValue) : null
+    const initial = seeded ? options.filter((o) => seeded.has(o.value)) : []
+    return {
+      type: 'multi_static_select',
+      action_id,
+      placeholder: { type: 'plain_text', text: 'Select options', emoji: true },
+      options,
+      ...(initial.length ? { initial_options: initial } : {}),
+      ...(target.maxItems !== undefined ? { max_selected_items: target.maxItems } : {})
+    }
+  }
+  // A boolean's `default` is a real boolean, so its option value is the string the card spells it with.
+  const seed = target.kind === 'boolean' ? String(target.defaultValue) : target.defaultValue
+  const initial = options.find((o) => o.value === seed)
+  return {
+    type: 'static_select',
+    action_id,
+    placeholder: { type: 'plain_text', text: 'Choose one', emoji: true },
+    options,
+    ...(initial ? { initial_option: initial } : {})
+  }
+}
+
+/**
+ * Build the MULTI-FIELD elicitation card that goes in the channel. An `actions` block holds no
+ * inputs, so the fields cannot be here at all: the card carries the agent's defused question, one
+ * line naming what will be asked, an Answer button that opens the modal, and Dismiss — both in
+ * one actions block so they share the `block_id` the relay routes on. Pure.
+ */
+export function buildElicitationFormCard(
+  requestId: string,
+  params: CreateElicitationRequest,
+  form: readonly ElicitTarget[],
+  sessionTarget?: string
+): unknown[] {
+  const asked = form.map((t) => elicitFormFieldLabel(params, t)).join(', ')
+  return [
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(elicitCardMessage(params), ELICIT_MESSAGE_CAP)}` }
+    },
+    {
+      type: 'context',
+      elements: [{ type: 'mrkdwn', text: clampTo(`Asks for ${escapeSlackMrkdwn(asked)}.`, SLACK_SECTION_TEXT_CAP) }]
+    },
+    {
+      type: 'actions',
+      ...(sessionTarget ? { block_id: sessionTarget } : {}),
+      elements: [
+        {
+          type: 'button',
+          action_id: ELICIT_OPEN_ACTION as string,
+          text: { type: 'plain_text', text: 'Answer', emoji: true },
+          style: 'primary',
+          value: requestId
+        },
+        elicitDismissButton(requestId)
+      ]
+    }
+  ]
+}
+
+/**
+ * Build the modal that ANSWERS a multi-field card: the agent's defused question, then one
+ * `input` block per field in schema order, each keyed by {@link elicitFormBlockId} so the
+ * submitted state and a per-field error share one key. `private_metadata` names the card and
+ * carries the opaque session target the relay routes the submission on — the same value the
+ * card's own `block_id` carries, and nothing about the reader.
+ *
+ * Both ingress paths call THIS function with the card's own params, so the direct Socket Mode
+ * modal and the relay-forwarded one are the same view. Null ⇒ some field cannot be an input
+ * block (see {@link elicitFormInputElement}) and the caller declines with a notice. Pure.
+ */
+export function buildElicitationFormModal(
+  requestId: string,
+  params: CreateElicitationRequest,
+  form: readonly ElicitTarget[],
+  sessionTarget?: string
+): Record<string, unknown> | null {
+  const required = new Set(elicitRequiredProps(params))
+  const inputs: Record<string, unknown>[] = []
+  for (const [index, target] of form.entries()) {
+    const element = elicitFormInputElement(target)
+    if (!element) return null
+    const hint = target.description ?? (target.kind === 'multi-enum' ? selectionHint(target) : '')
+    inputs.push({
+      type: 'input',
+      block_id: elicitFormBlockId(index),
+      label: { type: 'plain_text', text: elicitFormFieldLabel(params, target), emoji: true },
+      // Slack enforces presence itself for a required field; a required multi-select then also
+      // needs one selection, which is stricter than `minItems: 0` but never admits less.
+      optional: !required.has(target.propName),
+      ...(hint ? { hint: { type: 'plain_text', text: hint } } : {}),
+      element
+    })
+  }
+  return {
+    type: 'modal',
+    callback_id: ELICIT_FORM_CALLBACK_ID as string,
+    private_metadata: encodeElicitFormMetadata({ requestId, ...(sessionTarget ? { target: sessionTarget } : {}) }),
+    title: { type: 'plain_text', text: SLACK_MODAL_TITLE },
+    submit: { type: 'plain_text', text: 'Submit' },
+    close: { type: 'plain_text', text: 'Cancel' },
+    blocks: [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: clampTo(elicitCardMessage(params), ELICIT_MESSAGE_CAP) }
+      },
+      ...inputs
+    ]
+  }
+}
+
+/** The modal a tap on an ALREADY-SETTLED card opens: a stale client still shows the Answer
+ *  button, and telling the reader the question closed is the difference between an explanation
+ *  and a button that does nothing. Also the view a second reader's submission is replaced with
+ *  once the first one settled the request. Pure. */
+export function buildElicitFormClosedModal(): Record<string, unknown> {
+  return {
+    type: 'modal',
+    title: { type: 'plain_text', text: SLACK_MODAL_TITLE },
+    close: { type: 'plain_text', text: 'Close' },
+    blocks: [
+      { type: 'section', text: { type: 'mrkdwn', text: 'This question has already been answered or dismissed.' } }
+    ]
+  }
+}
+
+/** What a refused field's error says, in the same plain words the card would have used — a
+ *  reader who has to retype something is told the shape, never the schema keyword. */
+function elicitFormFieldError(target: ElicitTarget): string {
+  if (target.kind === 'text' || target.kind === 'number') return `Enter ${elicitReplyExpectation(target)}.`
+  if (target.kind === 'multi-enum') return selectionHint(target) || 'Select from the options offered.'
+  return 'Choose one of the options offered.'
+}
+
+/** A form modal's answer, or the per-field errors that refuse it. Keyed by BLOCK id, which is
+ *  what Slack's `response_action: errors` addresses. */
+export interface ElicitFormSubmission {
+  answer?: Record<string, string | number | string[]>
+  errors?: Record<string, string>
+}
+
+/**
+ * Decode one `view_submission`'s raw field state into the typed record a form card answers with,
+ * re-derived against the FORM THAT WAS RENDERED rather than trusted from the wire (#1815): each
+ * value is read under its field's own block id, given the schema's own type — a real number for
+ * `number`/`integer`, a list for a multi-select — and checked by {@link fieldAccepts}. A blank
+ * optional input is simply absent; a missing REQUIRED field, a value of the wrong shape, and a
+ * value the field does not admit each come back as that field's error, so one bad field refuses
+ * the submission instead of being silently dropped. Pure.
+ */
+export function elicitFormSubmission(
+  params: CreateElicitationRequest,
+  form: readonly ElicitTarget[],
+  fields: Readonly<Record<string, string | string[]>>
+): ElicitFormSubmission {
+  const required = new Set(elicitRequiredProps(params))
+  const answer: Record<string, string | number | string[]> = {}
+  const errors: Record<string, string> = {}
+  for (const [index, target] of form.entries()) {
+    const blockId = elicitFormBlockId(index)
+    const raw = fields[blockId]
+    if (raw === undefined) {
+      if (required.has(target.propName)) errors[blockId] = 'This field is required.'
+      continue
+    }
+    const shaped =
+      target.kind === 'multi-enum'
+        ? Array.isArray(raw)
+          ? raw
+          : undefined
+        : Array.isArray(raw)
+          ? undefined
+          : target.kind === 'number'
+            ? NUMERIC_REPLY_RE.test(raw.trim())
+              ? Number(raw.trim())
+              : undefined
+            : raw
+    if (shaped === undefined || !fieldAccepts(target, shaped)) errors[blockId] = elicitFormFieldError(target)
+    else answer[target.propName] = shaped
+  }
+  return Object.keys(errors).length ? { errors } : { answer }
+}
+
+/** The `view_submission` response that puts those errors back on the modal, and the one that
+ *  replaces it when the card it answers is already settled. Slack decodes both; the relay only
+ *  carries them, on the opaque `response` slot of its own ack. Pure. */
+export function elicitFormErrorResponse(errors: Record<string, string>): Record<string, unknown> {
+  return { response_action: 'errors', errors }
+}
+
+export function elicitFormClosedResponse(): Record<string, unknown> {
+  return { response_action: 'update', view: buildElicitFormClosedModal() }
 }
 
 /** Slack's own limit on an interactive element's `value`. A URL longer than this cannot ride a

--- a/packages/daemon/test/connection.test.ts
+++ b/packages/daemon/test/connection.test.ts
@@ -43,6 +43,7 @@ function fakeAppWith(
     event() {},
     action() {},
     shortcut() {},
+    view() {},
     client: {
       auth: { test: async () => ({ user_id: 'U1', team_id: 'T123' }) },
       chat: { postMessage, getPermalink: async () => ({ permalink: 'https://example.slack.com/thread' }) },
@@ -145,6 +146,7 @@ describe('SlackConnection.openDirectMessage', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: { conversations: { open } },
           start: async () => {},
           stop: async () => {}
@@ -164,6 +166,7 @@ describe('SlackConnection.listBotChannels', () => {
       event() {},
       action() {},
       shortcut() {},
+      view() {},
       client: {
         auth: { test: async () => ({ user_id: 'U1' }) },
         users: {
@@ -219,6 +222,7 @@ describe('SlackConnection.listBotChannels', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: {
             auth: { test: async () => ({ user_id: 'U1' }) },
             users: {
@@ -257,6 +261,7 @@ describe('SlackConnection.getThreadReplies', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { replies } },
           start: async () => {},
           stop: async () => {}
@@ -282,6 +287,7 @@ describe('SlackConnection.getThreadReplies', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { replies } },
           start: async () => {},
           stop: async () => {}
@@ -306,6 +312,7 @@ describe('SlackConnection.getThreadReplies', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { replies } },
           start: async () => {},
           stop: async () => {}
@@ -349,6 +356,7 @@ describe('SlackConnection.getThreadReplies', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { replies } },
           start: async () => {},
           stop: async () => {}
@@ -392,6 +400,7 @@ describe('SlackConnection.getThreadReplies', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { replies } },
           start: async () => {},
           stop: async () => {}
@@ -425,6 +434,7 @@ describe('SlackConnection.getThreadReplies', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { replies } },
           start: async () => {},
           stop: async () => {}
@@ -456,6 +466,7 @@ describe('SlackConnection.getChannelHistory', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { history } },
           start: async () => {},
           stop: async () => {}
@@ -494,6 +505,7 @@ describe('SlackConnection.getChannelHistory', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: { auth: { test: async () => ({ user_id: 'UBOT' }) }, conversations: { history } },
           start: async () => {},
           stop: async () => {}
@@ -521,6 +533,7 @@ describe('SlackConnection membership events', () => {
     shortcut(id: string, h: (a: any) => unknown) {
       shortcuts?.set(id, h)
     },
+    view() {},
     client: {
       auth: { test: async () => ({ user_id: 'UBOT' }) },
       views: { open: async (a: any) => void opened?.push(a), update: async () => {} }
@@ -733,6 +746,7 @@ describe('SlackConnection assistant DM threads', () => {
           },
           action() {},
           shortcut() {},
+          view() {},
           client: {
             auth: { test: async () => ({ user_id: 'UBOT' }) },
             views: { open: async () => {}, update: async () => {} }
@@ -789,6 +803,7 @@ describe('SlackConnection assistant DM threads', () => {
           event() {},
           action() {},
           shortcut() {},
+          view() {},
           client: {
             auth: { test: async () => ({ user_id: 'UBOT', bot_id: 'BSELF' }) },
             views: { open: async () => {}, update: async () => {} }
@@ -1123,6 +1138,7 @@ describe('SlackConnection agent_session_stopped', () => {
     },
     action() {},
     shortcut() {},
+    view() {},
     client: {
       auth: { test: async () => ({ user_id: 'UBOT' }) },
       views: { open: async () => {}, update: async () => {} },
@@ -1313,6 +1329,7 @@ describe('SlackConnection.updateBlocks', () => {
     event() {},
     action() {},
     shortcut() {},
+    view() {},
     client: { chat: { update } },
     start: async () => {},
     stop: async () => {}
@@ -1416,6 +1433,7 @@ describe('SlackConnection chat.postMessage boundary', () => {
     event() {},
     action() {},
     shortcut() {},
+    view() {},
     client: { chat: { postMessage, getPermalink } },
     start: async () => {},
     stop: async () => {}

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -11,6 +11,7 @@ import { LocalStore } from '../src/store/local-store.js'
 import { listAgentPermissionRequests } from '../src/cp/config-apply-handlers.js'
 import { SlackConnection } from '../src/slack/connection.js'
 import {
+  ELICIT_OPEN_ACTION,
   ELICIT_SELECT_ACTION,
   elicitForm,
   elicitTarget,
@@ -1171,11 +1172,11 @@ describe('webchat answers a typed elicitation with the schema’s own type', () 
   })
 })
 
-// ── multi-field forms, webchat only (issue #1794 gap 1) ──────────────────────
-// A Slack card answers ONE field, so `elicitTarget` still requires one property to satisfy
-// `required` alone and a multi-field ask declines there. Webchat reads the whole form
-// (`elicitForm`) and answers it with a value per field — the first thing that can honestly
-// accept a form whose `required` names more than one property.
+// ── multi-field forms (issue #1794 gap 1) ────────────────────────────────────
+// A single card answers ONE field, so `elicitTarget` still requires one property to satisfy
+// `required` alone. Webchat reads the whole form (`elicitForm`) and answers it with a value per
+// field — the first thing that can honestly accept a form whose `required` names more than one
+// property. Slack asks the same whole form in a modal (slack-elicit-form.test.ts).
 
 /** A two-field form: a required pick plus an optional typed note. */
 function twoFieldElicitation(required = ['branch']): CreateElicitationRequest {
@@ -1357,20 +1358,30 @@ describe('webchat answers a multi-field elicitation form with a record', () => {
     expect(cardEvents(sink)[1]).toEqual({ kind: 'elicitation_resolved', requestId, outcome: 'dismissed' })
   })
 
-  it('still declines a multi-field form on a Slack turn, whose card answers one field', async () => {
+  it('takes the MODAL path on a Slack turn rather than a single-field card', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending: any = installPending(daemon)
     pending.plan.platform = 'slack'
-    pending.conn = Object.create(SlackConnection.prototype)
+    pending.plan.channel = 'C1'
+    pending.plan.statusThread = 'T1'
+    const conn = Object.create(SlackConnection.prototype)
+    const posted: unknown[][] = []
+    conn.postBlocks = async (_c: string, blocks: unknown[]) => {
+      posted.push(blocks)
+      return 'ts-1'
+    }
+    conn.updateBlocks = async () => true
+    pending.conn = conn
 
-    await expect(
-      (daemon as any).permissions.onAcpElicit('agent-1', 's1', twoFieldElicitation(['branch', 'note']))
-    ).resolves.toBeUndefined()
-    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
-    // Unchanged where it matters: one card, one field that satisfies `required` alone.
+    void (daemon as any).permissions.onAcpElicit('agent-1', 's1', twoFieldElicitation(['branch', 'note']))
+    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
+    // The card carries an Answer button, never the fields — the modal behind it asks both.
+    await vi.waitFor(() => expect(JSON.stringify(posted[0])).toContain(ELICIT_OPEN_ACTION))
+    // Unchanged where it matters: the per-field reduction still needs one field that satisfies
+    // `required` alone, and there is none here.
     expect(elicitTarget(twoFieldElicitation(['branch', 'note']), SLACK_ELICIT_SURFACE)).toBeNull()
-    // The same form IS renderable — just not here: webchat asks every field.
     expect(elicitForm(twoFieldElicitation(['branch', 'note']), WEBCHAT_ELICIT_SURFACE)).toHaveLength(2)
+    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
   })
 
   it('keeps a one-field form on the single-field card, byte for byte', async () => {

--- a/packages/daemon/test/fakes/slack-app.ts
+++ b/packages/daemon/test/fakes/slack-app.ts
@@ -27,6 +27,7 @@ export function fakeSlackAppFactory(identity: FakeSlackIdentity = {}): SlackAppF
       event: () => {},
       action: () => {},
       shortcut: () => {},
+      view: () => {},
       client: {
         views: { open: ok, update: ok },
         auth: {

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -2136,16 +2136,16 @@ describe('elicitation card', () => {
 
   const TWO = { branch: { type: 'string', enum: ['main', 'dev'] }, note: { type: 'string', maxLength: 40 } }
 
-  it('renders a two-field form on webchat and still declines it on Slack', () => {
+  it('renders a two-field form on both surfaces, and never as a SINGLE-field card', () => {
     const two = req(TWO, ['branch', 'note'])
     expect(elicitForm(two, WEBCHAT_ELICIT_SURFACE)?.map((t) => [t.propName, t.kind])).toEqual([
       ['branch', 'enum'],
       ['note', 'text']
     ])
-    // One card answers one field, on either surface — so the reduction declines rather than
-    // half-answering, and Slack's card builder (which reads only the reduction) declines with
-    // it. Slack now RENDERS both kinds, so the whole-form read lists them; the modal that would
-    // show them is its own item and nothing calls this with a Slack surface yet.
+    // One SINGLE-field card answers one field, on either surface — so the per-field reduction
+    // declines rather than half-answering, and the button-row builder (which reads only that
+    // reduction) declines with it. The whole-form read is what answers this form: webchat cards
+    // every field, Slack asks them in a modal (see slack-elicit-form.test.ts).
     expect(elicitTarget(two, WEBCHAT_ELICIT_SURFACE)).toBeNull()
     expect(elicitTarget(two, SLACK_ELICIT_SURFACE)).toBeNull()
     expect(elicitForm(two, SLACK_ELICIT_SURFACE)?.map((t) => t.propName)).toEqual(['branch', 'note'])

--- a/packages/daemon/test/slack-elicit-form.test.ts
+++ b/packages/daemon/test/slack-elicit-form.test.ts
@@ -1,0 +1,501 @@
+/**
+ * A MULTI-FIELD elicitation form on Slack (issue #1794's last Slack-column item). Every other
+ * shape now answers without a modal — buttons, a `multi_static_select` plus Confirm, a thread
+ * reply, a consent button — and this is the one that genuinely needs one: an `actions` block
+ * holds no inputs, so the fields cannot be in the channel at all.
+ *
+ * The card is therefore the question, a line naming what will be asked, Answer and Dismiss; the
+ * modal behind Answer carries one `input` block per field, and its submission is re-validated
+ * whole against the card that offered it before the ACP request is resolved.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { CreateElicitationRequest } from '@agentclientprotocol/sdk'
+import { Daemon } from '../src/daemon.js'
+import { TerminalOutputFolder } from '../src/session/terminal-output-folder.js'
+import { fakeSlackAppFactory } from './fakes/slack-app.js'
+import { SlackConnection } from '../src/slack/connection.js'
+import {
+  ELICIT_DISMISS_ACTION,
+  ELICIT_OPEN_ACTION,
+  SLACK_DM_ELICIT_SURFACE,
+  SLACK_ELICIT_SURFACE,
+  buildElicitationCard,
+  buildElicitationFormCard,
+  buildElicitationFormModal,
+  elicitForm,
+  elicitFormBlockId,
+  elicitFormSubmission,
+  elicitTarget
+} from '../src/slack/render.js'
+import { decodeElicitFormMetadata, encodeSharedSlackStatusTarget } from '@agentconnect.md/protocol'
+
+const TARGET = encodeSharedSlackStatusTarget({ agentId: 'agent-1', integrationId: 'int-a', sessionKey: 'k1' })
+
+function form(properties: Record<string, unknown>, required: string[] = []): CreateElicitationRequest {
+  return {
+    sessionId: 's1',
+    mode: 'form',
+    message: 'How should I cut the release?',
+    requestedSchema: { type: 'object', properties, required }
+  } as CreateElicitationRequest
+}
+
+/** One field of every kind Slack claims, so the modal's whole element table is exercised. */
+const EVERY_KIND = {
+  branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' },
+  checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] }, minItems: 1, title: 'Checks' },
+  note: { type: 'string', maxLength: 20, description: 'Anything the reviewer should know' },
+  count: { type: 'integer', minimum: 1, maximum: 9 },
+  draft: { type: 'boolean', default: true }
+}
+
+/** The two-field form most of these use: a required pick plus an optional typed note. */
+const TWO = {
+  branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' },
+  note: { type: 'string', maxLength: 20 }
+}
+
+const blocksOf = (view: Record<string, unknown> | null) => (view?.blocks ?? []) as Record<string, any>[]
+const inputsOf = (view: Record<string, unknown> | null) => blocksOf(view).filter((b) => b.type === 'input')
+
+describe('the in-channel card of a multi-field form', () => {
+  it('carries the question, what will be asked, and Answer beside Dismiss — never the fields', () => {
+    const req = form(TWO, ['branch'])
+    const card = buildElicitationFormCard('elicit-1', req, elicitForm(req, SLACK_ELICIT_SURFACE)!, TARGET) as any[]
+    expect(card[0].text.text).toContain('How should I cut the release?')
+    expect(card[1].elements[0].text).toBe('Asks for Base branch, note.')
+    const actions = card[2]
+    expect(actions.type).toBe('actions')
+    expect(actions.block_id).toBe(TARGET)
+    expect(actions.elements.map((e: any) => [e.action_id, e.value, e.text.text])).toEqual([
+      [ELICIT_OPEN_ACTION, 'elicit-1', 'Answer'],
+      [ELICIT_DISMISS_ACTION, 'elicit-1', 'Dismiss']
+    ])
+    // No input element anywhere: an actions block cannot hold one, which is the whole reason
+    // this shape has a modal at all.
+    expect(JSON.stringify(card)).not.toContain('plain_text_input')
+  })
+
+  it('defuses the agent’s own message exactly as every other card does', () => {
+    const req = form(TWO, ['branch'])
+    ;(req as any).message = 'Sign in at https://evil.example/x <https://evil.example/y|here>'
+    const card = buildElicitationFormCard('elicit-1', req, elicitForm(req, SLACK_ELICIT_SURFACE)!) as any[]
+    expect(card[0].text.text).toContain('`https://evil.example/x`')
+    expect(card[0].text.text).toContain('&lt;')
+    expect(card[0].text.text).not.toContain('<https://evil.example/y|here>')
+  })
+})
+
+describe('the modal a multi-field form is answered in', () => {
+  it('renders one input block per field, each with its own kind and bounds', () => {
+    const req = form(EVERY_KIND, ['branch', 'checks'])
+    const view = buildElicitationFormModal('elicit-1', req, elicitForm(req, SLACK_ELICIT_SURFACE)!, TARGET)
+    const inputs = inputsOf(view)
+    expect(inputs.map((b) => [b.block_id, b.element.type, b.optional, b.label.text])).toEqual([
+      [elicitFormBlockId(0), 'static_select', false, 'Base branch'],
+      [elicitFormBlockId(1), 'multi_static_select', false, 'Checks'],
+      [elicitFormBlockId(2), 'plain_text_input', true, 'note'],
+      [elicitFormBlockId(3), 'number_input', true, 'count'],
+      [elicitFormBlockId(4), 'static_select', true, 'draft']
+    ])
+    expect(inputs[0]!.element.options.map((o: any) => o.value)).toEqual(['main', 'develop'])
+    // `minItems` has no Slack attribute, so it is said as a hint and enforced on submit.
+    expect(inputs[1]!.hint.text).toBe('Select at least 1.')
+    expect(inputs[2]!.element.max_length).toBe(20)
+    expect(inputs[2]!.hint.text).toBe('Anything the reviewer should know')
+    expect(inputs[3]!.element).toMatchObject({ is_decimal_allowed: false, min_value: '1', max_value: '9' })
+    // A boolean's `default` seeds the select with the option that spells it.
+    expect(inputs[4]!.element.initial_option.value).toBe('true')
+    // The question itself is a section, and the FIRST thing in the modal.
+    expect(blocksOf(view)[0]).toMatchObject({ type: 'section' })
+    expect((blocksOf(view)[0]! as any).text.text).toContain('How should I cut the release?')
+  })
+
+  it('titles itself in fixed words inside Slack’s 24-character cap, and names the card in its metadata', () => {
+    const req = form(TWO, ['branch'])
+    const view = buildElicitationFormModal('elicit-9', req, elicitForm(req, SLACK_ELICIT_SURFACE)!, TARGET)!
+    const title = (view.title as { text: string }).text
+    expect(title).toBe('Agent needs your input')
+    expect(title.length).toBeLessThanOrEqual(24)
+    // Not the agent's words: 24 characters hold no question, and the title is the line a reader
+    // trusts most. Its own message is in the body instead, defused like the card's.
+    expect(title).not.toContain('release')
+    expect(decodeElicitFormMetadata(view.private_metadata as string)).toEqual({
+      requestId: 'elicit-9',
+      target: TARGET
+    })
+  })
+
+  it('is withheld when a field cannot BE an input block, so no Answer button is ever posted dead', () => {
+    // Slack caps a select option's `value` at 75 characters and a modal has no button to fall
+    // back to (#1813's finding, one surface on).
+    const long = 'x'.repeat(80)
+    const req = form({ branch: { type: 'string', enum: [long, 'dev'] }, note: { type: 'string' } }, ['branch'])
+    expect(elicitForm(req, SLACK_ELICIT_SURFACE)).toHaveLength(2)
+    expect(buildElicitationFormModal('elicit-1', req, elicitForm(req, SLACK_ELICIT_SURFACE)!)).toBeNull()
+    // And a minimum length no input can hold.
+    const wide = form({ a: { type: 'string', minLength: 3500 }, b: { type: 'boolean' } })
+    expect(buildElicitationFormModal('elicit-1', wide, elicitForm(wide, SLACK_ELICIT_SURFACE)!)).toBeNull()
+  })
+})
+
+describe('a form submission is re-derived against the card that offered it', () => {
+  const req = form(EVERY_KIND, ['branch', 'checks'])
+  const fields = elicitForm(req, SLACK_ELICIT_SURFACE)!
+
+  it('answers with the typed record — real numbers, arrays, the boolean’s own wire value', () => {
+    expect(
+      elicitFormSubmission(req, fields, {
+        [elicitFormBlockId(0)]: 'main',
+        [elicitFormBlockId(1)]: ['lint', 'test'],
+        [elicitFormBlockId(2)]: 'ship it',
+        [elicitFormBlockId(3)]: '4',
+        [elicitFormBlockId(4)]: 'false'
+      })
+    ).toEqual({ answer: { branch: 'main', checks: ['lint', 'test'], note: 'ship it', count: 4, draft: 'false' } })
+  })
+
+  it('accepts an omitted OPTIONAL field and refuses a missing REQUIRED one', () => {
+    expect(
+      elicitFormSubmission(req, fields, { [elicitFormBlockId(0)]: 'main', [elicitFormBlockId(1)]: ['lint'] })
+    ).toEqual({ answer: { branch: 'main', checks: ['lint'] } })
+    expect(elicitFormSubmission(req, fields, { [elicitFormBlockId(0)]: 'main' })).toEqual({
+      errors: { [elicitFormBlockId(1)]: 'This field is required.' }
+    })
+  })
+
+  it('refuses ONE bad field with that field’s own error, rather than dropping it', () => {
+    const bad = elicitFormSubmission(req, fields, {
+      [elicitFormBlockId(0)]: 'trunk', // never offered
+      [elicitFormBlockId(1)]: ['lint'],
+      [elicitFormBlockId(2)]: 'x'.repeat(50), // past maxLength
+      [elicitFormBlockId(3)]: '40' // past maximum
+    })
+    expect(bad.answer).toBeUndefined()
+    expect(bad.errors).toEqual({
+      [elicitFormBlockId(0)]: 'Choose one of the options offered.',
+      [elicitFormBlockId(2)]: 'Enter some text, at most 20 characters long.',
+      [elicitFormBlockId(3)]: 'Enter a whole number from 1 to 9.'
+    })
+  })
+
+  it('refuses a value of the wrong SHAPE, and ignores a block the form never rendered', () => {
+    expect(
+      elicitFormSubmission(req, fields, {
+        [elicitFormBlockId(0)]: ['main'], // a list cannot answer a single select
+        [elicitFormBlockId(1)]: ['lint']
+      }).errors
+    ).toEqual({ [elicitFormBlockId(0)]: 'Choose one of the options offered.' })
+    expect(
+      elicitFormSubmission(req, fields, {
+        [elicitFormBlockId(0)]: 'main',
+        [elicitFormBlockId(1)]: ['lint'],
+        [elicitFormBlockId(99)]: 'injected',
+        not_ours: 'injected'
+      })
+    ).toEqual({ answer: { branch: 'main', checks: ['lint'] } })
+  })
+
+  it('validates a pattern Slack has no attribute for, and returns it as that field’s error', () => {
+    const patterned = form({ tag: { type: 'string', pattern: '^v[0-9]+$' }, note: { type: 'string' } }, ['tag'])
+    const shape = elicitForm(patterned, SLACK_ELICIT_SURFACE)!
+    const view = buildElicitationFormModal('elicit-1', patterned, shape)!
+    expect(JSON.stringify(view)).not.toContain('pattern')
+    expect(elicitFormSubmission(patterned, shape, { [elicitFormBlockId(0)]: 'v12' })).toEqual({
+      answer: { tag: 'v12' }
+    })
+    expect(elicitFormSubmission(patterned, shape, { [elicitFormBlockId(0)]: 'release-12' }).errors).toEqual({
+      [elicitFormBlockId(0)]: 'Enter some text, in the exact format the question asks for.'
+    })
+  })
+})
+
+describe('the approval-DM surface does not gain multi-field', () => {
+  it('builds no card for a form asking two questions, so a DM never posts an Answer button', () => {
+    // Both kinds ARE in the DM surface, so this is not a kind refusal: the DM path reads the
+    // single-field reduction and nothing else, and a DM has no turn whose card we could rewrite.
+    const req = form({ branch: { type: 'string', enum: ['main', 'dev'] }, draft: { type: 'boolean' } }, [
+      'branch',
+      'draft'
+    ])
+    expect([...SLACK_DM_ELICIT_SURFACE.kinds].sort()).toEqual(['boolean', 'enum'])
+    expect(elicitTarget(req, SLACK_DM_ELICIT_SURFACE)).toBeNull()
+    expect(buildElicitationCard('elicit-1', req, undefined, SLACK_DM_ELICIT_SURFACE)).toBeNull()
+  })
+})
+
+describe('the single-field card paths are unchanged', () => {
+  it('a one-question form still posts its button row, with no Answer button', () => {
+    const req = form({ branch: { type: 'string', enum: ['main', 'develop'] } }, ['branch'])
+    const card = buildElicitationCard('elicit-1', req, TARGET) as any[]
+    expect(card[1].elements.map((e: any) => e.text.text)).toEqual(['main', 'develop', 'Dismiss'])
+    expect(JSON.stringify(card)).not.toContain(ELICIT_OPEN_ACTION)
+  })
+
+  it('a select question plus its own “Other” box stays one question, and stays on the button row', () => {
+    const req = form({
+      branch: { type: 'string', enum: ['main', 'develop'] },
+      other: {
+        type: 'string',
+        _meta: { _askUserQuestionCustomAnswer: { isCustomAnswer: true, questionId: 'branch' } }
+      }
+    })
+    expect(elicitForm(req, SLACK_ELICIT_SURFACE)!.filter((t) => !t.customAnswerFor)).toHaveLength(1)
+    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)?.propName).toBe('branch')
+  })
+})
+
+// ── the coordinator: posting the card, opening the modal, settling on submit ──────────────────
+
+function installPending(daemon: any): any {
+  daemon.store = {
+    getSessionByAcpIdForAgent: () => ({ triggeredBy: 'user-1' }),
+    getDisplayNames: () => new Map(),
+    createPermissionRequest: vi.fn(),
+    resolvePermissionRequest: vi.fn(() => true)
+  }
+  const pending = {
+    plan: {
+      platform: 'slack',
+      agentId: 'agent-1',
+      integrationId: 'int-a',
+      sessionKey: 'k1',
+      requesterId: 'turn-user',
+      channel: 'C1',
+      transcriptChannel: 'C1',
+      statusThread: 'T1',
+      isDm: false,
+      approvalSurfaceSuppressed: false
+    },
+    hostKey: 'agent-1',
+    outwardSessionId: 'sess-1',
+    chrome: {},
+    reply: { text: '', attemptText: '', attemptAnswerUpdates: [] },
+    signals: { applyChain: Promise.resolve() },
+    approval: { waitMs: 0, depth: 0 },
+    builtinSystemToolCallIds: new Set<string>(),
+    conv: { onUpdate: () => [], hasBuffered: () => false },
+    rec: { onUpdate: () => [] },
+    termOut: new TerminalOutputFolder()
+  }
+  daemon.pending.set(JSON.stringify(['agent-1', 's1']), pending)
+  return pending
+}
+
+interface Harness {
+  daemon: any
+  conn: any
+  posted: unknown[][]
+  updated: unknown[][]
+  views: unknown[]
+  notices: () => string[]
+}
+
+/** A Slack turn on an HTTP (relay-fronted) integration, with everything the card touches captured. */
+function slackTurn(): Harness {
+  const daemon: any = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
+  installPending(daemon)
+  const posted: unknown[][] = []
+  const updated: unknown[][] = []
+  const views: unknown[] = []
+  const conn = Object.create(SlackConnection.prototype)
+  conn.postBlocks = async (_c: string, blocks: unknown[]) => {
+    posted.push(blocks)
+    return 'ts-1'
+  }
+  conn.updateBlocks = async (_c: string, _ts: string, blocks: unknown[]) => {
+    updated.push(blocks)
+    return true
+  }
+  conn.openView = async (_t: string, view: unknown) => void views.push(view)
+  conn.workspaceId = () => 'T1'
+  daemon.pending.get(JSON.stringify(['agent-1', 's1'])).conn = conn
+  daemon.httpSlackSessionTarget = () => TARGET
+  daemon.cfg = { ...(daemon.cfg ?? {}), webAppUrl: 'https://console.example' }
+  const applied: any[] = []
+  daemon.enqueueApply = (_p: any, action: any) => void applied.push(action)
+  return {
+    daemon,
+    conn,
+    posted,
+    updated,
+    views,
+    notices: () => applied.filter((a) => a.kind === 'notice').map((a) => a.text as string)
+  }
+}
+
+/** Raise the form elicitation and wait until its card is posted and its ts recorded. */
+async function raise(h: Harness, req: CreateElicitationRequest): Promise<{ requestId: string; result: Promise<any> }> {
+  const result = h.daemon.permissions.onAcpElicit('agent-1', 's1', req)
+  await vi.waitFor(() => expect(h.daemon.permissions.pendingElicits.size).toBe(1))
+  const requestId = [...h.daemon.permissions.pendingElicits.keys()][0] as string
+  await vi.waitFor(() => expect(h.daemon.permissions.pendingElicits.get(requestId).ts).toBe('ts-1'))
+  return { requestId, result }
+}
+
+const submitFields = (branch: string, note?: string) => ({
+  [elicitFormBlockId(0)]: branch,
+  ...(note !== undefined ? { [elicitFormBlockId(1)]: note } : {})
+})
+
+describe('a Slack turn answers a multi-field form through its modal', () => {
+  it('posts the Answer card, opens one input per field, and accepts the typed record', async () => {
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    expect(h.notices()).toEqual([])
+    expect(JSON.stringify(h.posted[0])).toContain(ELICIT_OPEN_ACTION)
+
+    await h.daemon.permissions.openElicitFormModal({ requestId, triggerId: 'trig-1', conn: h.conn })
+    expect(inputsOf(h.views[0] as any)).toHaveLength(2)
+
+    await expect(
+      h.daemon.permissions.submitElicitForm({
+        requestId,
+        fields: submitFields('develop', 'ship it'),
+        actor: { userId: 'U-ALICE', name: 'alice' }
+      })
+    ).resolves.toBeUndefined()
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'develop', note: 'ship it' } })
+    // The card is rewritten to the settled state, naming the fields in the card's own words.
+    expect(JSON.stringify(h.updated[0])).toContain('Base branch: develop')
+    expect(JSON.stringify(h.updated[0])).toContain('note: ship it')
+    expect(h.daemon.permissions.pendingElicits.size).toBe(0)
+  })
+
+  it('takes an omitted optional field and refuses a missing required one, leaving the card live', async () => {
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    await expect(
+      h.daemon.permissions.submitElicitForm({ requestId, fields: { [elicitFormBlockId(1)]: 'note only' } })
+    ).resolves.toEqual({
+      response_action: 'errors',
+      errors: { [elicitFormBlockId(0)]: 'This field is required.' }
+    })
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    expect(h.updated).toEqual([])
+
+    await h.daemon.permissions.submitElicitForm({ requestId, fields: submitFields('main') })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+  })
+
+  it('refuses one bad field with a per-field error and does NOT resolve the request', async () => {
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    let settled = false
+    void result.then(() => (settled = true))
+    await expect(
+      h.daemon.permissions.submitElicitForm({ requestId, fields: submitFields('main', 'x'.repeat(50)) })
+    ).resolves.toEqual({
+      response_action: 'errors',
+      errors: { [elicitFormBlockId(1)]: 'Enter some text, at most 20 characters long.' }
+    })
+    expect(settled).toBe(false)
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+    await h.daemon.permissions.releaseElicits('agent-1', 's1')
+    await expect(result).resolves.toEqual({ action: 'cancel' })
+  })
+
+  it('Dismiss on the card declines it without ever opening the modal', async () => {
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: null, actor: { userId: 'U-BOB' } })
+    await expect(result).resolves.toEqual({ action: 'decline' })
+    expect(h.views).toEqual([])
+  })
+
+  it('tells the SECOND submitter the question is closed, rather than settling it twice', async () => {
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    // Two readers may each open the modal — Slack keeps their input in their own view — and the
+    // first submission settles the ACP request. The second gets the closed view, not silence.
+    await h.daemon.permissions.openElicitFormModal({ requestId, triggerId: 'trig-a', conn: h.conn })
+    await h.daemon.permissions.openElicitFormModal({ requestId, triggerId: 'trig-b', conn: h.conn })
+    expect(h.views).toHaveLength(2)
+    expect(h.views[0]).toEqual(h.views[1])
+
+    await h.daemon.permissions.submitElicitForm({ requestId, fields: submitFields('main'), actor: { userId: 'U-A' } })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+    const second = await h.daemon.permissions.submitElicitForm({
+      requestId,
+      fields: submitFields('develop'),
+      actor: { userId: 'U-B' }
+    })
+    expect(second).toMatchObject({ response_action: 'update' })
+    expect(JSON.stringify(second)).toContain('already been answered')
+    // One resolution only: the accepted content is still the first reader's.
+    expect(h.updated).toHaveLength(1)
+  })
+
+  it('opens the closed modal when the card is already settled, so Answer is never a dead button', async () => {
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    await h.daemon.permissions.handleElicitChoice({ requestId, value: null })
+    await expect(result).resolves.toEqual({ action: 'decline' })
+    await h.daemon.permissions.openElicitFormModal({ requestId, triggerId: 'trig-late', conn: h.conn })
+    expect(JSON.stringify(h.views[0])).toContain('already been answered')
+    expect(inputsOf(h.views[0] as any)).toEqual([])
+  })
+
+  it('declines with a notice, and posts no card, when no modal can hold the form', async () => {
+    const h = slackTurn()
+    const long = 'x'.repeat(80)
+    const req = form({ branch: { type: 'string', enum: [long, 'dev'] }, note: { type: 'string' } }, ['branch'])
+    await expect(h.daemon.permissions.onAcpElicit('agent-1', 's1', req)).resolves.toBeUndefined()
+    expect(h.daemon.permissions.pendingElicits.size).toBe(0)
+    expect(h.posted).toEqual([])
+    expect(h.notices()[0]).toContain("this chat can't collect an answer for")
+  })
+})
+
+describe('both Slack ingress paths open the same modal and settle the same way', () => {
+  it('a relay-forwarded Answer opens the identical view, and its submit rides the ack', async () => {
+    const h = slackTurn()
+    const { requestId, result } = await raise(h, form(TWO, ['branch']))
+    // The direct Socket Mode arm: the connection's own handler calls exactly this.
+    await h.daemon.permissions.openElicitFormModal({ requestId, triggerId: 'trig-socket', conn: h.conn })
+
+    // The relay arm: the click is forwarded as `elicitation-open` and the DAEMON opens the view
+    // on its own bot token, so nothing pre-rendered ever crosses to the relay.
+    const agent = { id: 'agent-1', integrations: [{ id: 'int-a', platform: 'slack', core: { mode: 'shared' } }] }
+    h.daemon.agents = new Map([['agent-1', agent]])
+    h.daemon.connByIntegration = new Map([['int-a', h.conn]])
+    h.daemon.store.getSession = async () => ({ key: 'k1', agentId: 'agent-1', platform: 'slack' })
+    const relay = (payload: unknown, msgId: string) =>
+      h.daemon.handleRelaySlackAction({
+        agentId: 'agent-1',
+        sessionKey: 'k1',
+        msgId,
+        botId: 'shared-bot',
+        integrationId: 'int-a',
+        userId: 'U-ALICE',
+        payload
+      })
+
+    expect(await relay({ kind: 'elicitation-open', requestId, triggerId: 'trig-relay' }, 'a-open')).toEqual({
+      msgId: 'a-open',
+      accepted: true
+    })
+    await vi.waitFor(() => expect(h.views).toHaveLength(2))
+    expect(h.views[1]).toEqual(h.views[0])
+
+    // A refused field's verdict rides back on the ack's opaque `response`, which the relay
+    // surfaces verbatim on Slack's own 200 — the one action on this seam Slack waits for.
+    expect(
+      await relay({ kind: 'elicitation-submit', requestId, fields: submitFields('main', 'x'.repeat(50)) }, 'a-bad')
+    ).toEqual({
+      msgId: 'a-bad',
+      accepted: true,
+      response: {
+        response_action: 'errors',
+        errors: { [elicitFormBlockId(1)]: 'Enter some text, at most 20 characters long.' }
+      }
+    })
+    expect(h.daemon.permissions.pendingElicits.size).toBe(1)
+
+    expect(await relay({ kind: 'elicitation-submit', requestId, fields: submitFields('main') }, 'a-ok')).toEqual({
+      msgId: 'a-ok',
+      accepted: true
+    })
+    await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
+  })
+})

--- a/packages/daemon/test/slack-elicit-form.test.ts
+++ b/packages/daemon/test/slack-elicit-form.test.ts
@@ -164,6 +164,23 @@ describe('a form submission is re-derived against the card that offered it', () 
     })
   })
 
+  // Slack sends `[]` for a multi-select nobody touched. Reading that as an empty ANSWER made an
+  // optional `minItems: 1` field unsubmittable — the reader could not get past their own blank.
+  it('takes a blank OPTIONAL multi-select as omitted, not as a selection that fails its bounds', () => {
+    const optional = form(
+      { branch: EVERY_KIND.branch, checks: { type: 'array', minItems: 1, items: EVERY_KIND.checks.items } },
+      ['branch']
+    )
+    const target = elicitForm(optional, SLACK_ELICIT_SURFACE)!
+    expect(
+      elicitFormSubmission(optional, target, { [elicitFormBlockId(0)]: 'main', [elicitFormBlockId(1)]: [] })
+    ).toEqual({ answer: { branch: 'main' } })
+    // A REQUIRED one keeps its own bounds: there an empty selection is a real answer to judge.
+    const needed = form({ checks: { type: 'array', minItems: 1, items: EVERY_KIND.checks.items } }, ['checks'])
+    const neededTarget = elicitForm(needed, SLACK_ELICIT_SURFACE)!
+    expect(elicitFormSubmission(needed, neededTarget, { [elicitFormBlockId(0)]: [] }).errors).toBeDefined()
+  })
+
   it('refuses ONE bad field with that field’s own error, rather than dropping it', () => {
     const bad = elicitFormSubmission(req, fields, {
       [elicitFormBlockId(0)]: 'trunk', // never offered

--- a/packages/daemon/test/slack-status-actor.test.ts
+++ b/packages/daemon/test/slack-status-actor.test.ts
@@ -10,10 +10,14 @@ import { SlackConnection } from '../src/slack/connection.js'
 import {
   STATUS_ACTION,
   ELICIT_CONFIRM_ACTION,
+  ELICIT_FORM_CALLBACK_ID,
+  ELICIT_OPEN_ACTION,
   ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
+  elicitFormBlockId,
   encodePermValue
 } from '../src/slack/render.js'
+import { encodeElicitFormMetadata } from '@agentconnect.md/protocol'
 
 type ActionArgs = {
   ack: () => Promise<void>
@@ -25,6 +29,7 @@ type ActionArgs = {
     selected_options?: { value?: string }[]
   }
   body?: {
+    trigger_id?: string
     view?: { private_metadata?: string }
     user?: { id?: string }
     state?: { values?: Record<string, Record<string, { selected_options?: { value?: unknown }[] }>> }
@@ -32,21 +37,29 @@ type ActionArgs = {
 }
 type Handler = (args: ActionArgs) => Promise<void> | void
 
+type ViewArgs = {
+  ack: (response?: unknown) => Promise<void>
+  body?: { user?: { id?: string } }
+  view?: { private_metadata?: string; state?: { values?: Record<string, Record<string, unknown>> } }
+}
+type ViewHandler = (args: ViewArgs) => Promise<void> | void
+
 /** A Bolt stand-in: enough surface for `start()` to reach handler registration. */
-function fakeApp(actions: Map<string, Handler>) {
+function fakeApp(actions: Map<string, Handler>, views?: Map<string, ViewHandler>) {
   return {
     init: async () => {},
     message: () => {},
     event: () => {},
     action: (id: string | RegExp, handler: Handler) => actions.set(String(id), handler),
     shortcut: () => {},
+    view: (id: string, handler: ViewHandler) => void views?.set(id, handler),
     start: async () => {},
     stop: async () => {},
     client: { auth: { test: async () => ({ user_id: 'UBOT', bot_id: 'BBOT', url: 'https://x.slack.test/' }) } }
   } as never
 }
 
-async function connect(deps: Record<string, unknown>): Promise<Map<string, Handler>> {
+async function connect(deps: Record<string, unknown>, views?: Map<string, ViewHandler>): Promise<Map<string, Handler>> {
   const actions = new Map<string, Handler>()
   const conn = new SlackConnection(
     {
@@ -56,7 +69,7 @@ async function connect(deps: Record<string, unknown>): Promise<Map<string, Handl
       sendIntervalMs: 0,
       ...deps
     } as never,
-    () => fakeApp(actions)
+    () => fakeApp(actions, views)
   )
   await conn.start()
   return actions
@@ -137,6 +150,83 @@ describe('slack status actions carry the acting user', () => {
     })
     expect(acked).toBe(true)
     expect(seen).toEqual([])
+  })
+
+  // A multi-field card's two interactions (#1794's Slack column): Answer, which opens the modal
+  // the daemon builds, and the modal's own submission, whose verdict rides that ack. Both carry
+  // the tapping user, and Answer carries the connection so the view opens on this bot's token.
+  it('reports the reader who tapped Answer, and hands the connection the view opens on', async () => {
+    const opened: any[] = []
+    const actions = await connect({ onElicitFormOpen: (a: unknown) => opened.push(a) })
+
+    await actions.get(ELICIT_OPEN_ACTION)!({
+      ack,
+      action: { value: 'elicit-7' },
+      body: { trigger_id: 'trig-1', user: { id: 'U-CARA' } }
+    })
+    // No trigger id is nothing to open — the card stays live and Answer can be tapped again.
+    await actions.get(ELICIT_OPEN_ACTION)!({ ack, action: { value: 'elicit-7' }, body: { user: { id: 'U-CARA' } } })
+
+    expect(opened).toHaveLength(1)
+    expect(opened[0]).toMatchObject({ requestId: 'elicit-7', triggerId: 'trig-1', actor: { userId: 'U-CARA' } })
+    expect(opened[0].conn).toBeInstanceOf(SlackConnection)
+  })
+
+  it('submits the modal’s own state and returns the daemon’s verdict on that ack', async () => {
+    const submitted: any[] = []
+    const views = new Map<string, ViewHandler>()
+    await connect(
+      {
+        onElicitFormSubmit: async (a: unknown) => {
+          submitted.push(a)
+          return { response_action: 'errors', errors: { [elicitFormBlockId(0)]: 'nope' } }
+        }
+      },
+      views
+    )
+    const acked: unknown[] = []
+    const submit = (view?: ViewArgs['view']) =>
+      views.get(ELICIT_FORM_CALLBACK_ID)!({
+        ack: async (response?: unknown) => void acked.push(response),
+        body: { user: { id: 'U-DEE' } },
+        ...(view ? { view } : {})
+      })
+
+    await submit({
+      private_metadata: encodeElicitFormMetadata({ requestId: 'elicit-7', target: 'tgt' }),
+      state: {
+        values: {
+          [elicitFormBlockId(0)]: { ac_elicit_input: { selected_option: { value: 'main' } } },
+          [elicitFormBlockId(1)]: { ac_elicit_input: { value: 'ship it' } },
+          [elicitFormBlockId(2)]: { ac_elicit_input: { selected_options: [{ value: 'lint' }] } },
+          // A blank input is OMITTED, which is what an untouched optional field means.
+          [elicitFormBlockId(3)]: { ac_elicit_input: { value: null } },
+          not_ours: { ac_elicit_input: { value: 'injected' } }
+        }
+      }
+    })
+    expect(submitted).toEqual([
+      {
+        requestId: 'elicit-7',
+        fields: {
+          [elicitFormBlockId(0)]: 'main',
+          [elicitFormBlockId(1)]: 'ship it',
+          [elicitFormBlockId(2)]: ['lint']
+        },
+        actor: { userId: 'U-DEE' }
+      }
+    ])
+    expect(acked).toEqual([{ response_action: 'errors', errors: { [elicitFormBlockId(0)]: 'nope' } }])
+
+    // A submission whose metadata is not ours reaches nothing and is just acked closed.
+    await submit({ private_metadata: 'garbage' })
+    await submit()
+    expect(submitted).toHaveLength(1)
+    expect(acked).toEqual([
+      { response_action: 'errors', errors: { [elicitFormBlockId(0)]: 'nope' } },
+      undefined,
+      undefined
+    ])
   })
 
   it('leaves the actor absent when the payload names no user', async () => {

--- a/packages/daemon/test/slack-streaming.test.ts
+++ b/packages/daemon/test/slack-streaming.test.ts
@@ -920,6 +920,7 @@ describe('SlackConnection chrome streaming', () => {
       event() {},
       action() {},
       shortcut() {},
+      view() {},
       client: {
         auth: { test: async () => ({ user_id: 'UBOT', bot_id: 'B1', team_id: 'T123' }) },
         views: { open: async () => ({}), update: async () => ({}) },

--- a/packages/protocol/src/frames/relay-cp.test.ts
+++ b/packages/protocol/src/frames/relay-cp.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
+  ELICIT_FORM_INPUT_ACTION,
+  decodeElicitFormMetadata,
+  elicitFormBlockId,
+  elicitFormBlockIndex,
+  elicitFormViewValues,
+  encodeElicitFormMetadata,
   HOOK_DELIVERY_REASON_DISPATCH_TIMEOUT,
   HOOK_DELIVERY_REASON_DAEMON_DRAINING,
   HOOK_DELIVERY_REASON_DAEMON_NOT_HOLDER,
@@ -1061,6 +1067,54 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
     expect(r.ok).toBe(false)
     if (r.ok) throw new Error('expected failure')
     expect(r.msg).toBe('FRAME_TOO_LARGE')
+  })
+})
+
+describe('the elicitation form modal’s own Slack codecs', () => {
+  it('round-trips the block id, and reads exactly our own field state out of a view', () => {
+    expect(elicitFormBlockId(0)).toBe('ac_elicit_f0')
+    expect(elicitFormBlockIndex(elicitFormBlockId(12))).toBe(12)
+    // Not ours, or not an index: nothing this modal rendered.
+    expect(elicitFormBlockIndex('agent_block')).toBeNull()
+    expect(elicitFormBlockIndex('ac_elicit_fx')).toBeNull()
+    expect(
+      elicitFormViewValues({
+        values: {
+          [elicitFormBlockId(0)]: { [ELICIT_FORM_INPUT_ACTION]: { selected_option: { value: 'main' } } },
+          [elicitFormBlockId(1)]: { [ELICIT_FORM_INPUT_ACTION]: { value: 'ship it' } },
+          [elicitFormBlockId(2)]: { [ELICIT_FORM_INPUT_ACTION]: { selected_options: [{ value: 'lint' }] } },
+          // A blank input and a cleared select are OMITTED, which is what an untouched
+          // optional field means; an empty LIST stays a real (empty) selection.
+          [elicitFormBlockId(3)]: { [ELICIT_FORM_INPUT_ACTION]: { value: null } },
+          [elicitFormBlockId(4)]: { [ELICIT_FORM_INPUT_ACTION]: { value: '' } },
+          [elicitFormBlockId(5)]: { [ELICIT_FORM_INPUT_ACTION]: { selected_option: null } },
+          [elicitFormBlockId(6)]: { [ELICIT_FORM_INPUT_ACTION]: { selected_options: [] } },
+          // Another block, and another action inside one of ours, are not this form's fields.
+          [elicitFormBlockId(7)]: { some_other_action: { value: 'injected' } },
+          agent_block: { [ELICIT_FORM_INPUT_ACTION]: { value: 'injected' } }
+        }
+      })
+    ).toEqual({
+      [elicitFormBlockId(0)]: 'main',
+      [elicitFormBlockId(1)]: 'ship it',
+      [elicitFormBlockId(2)]: ['lint'],
+      [elicitFormBlockId(6)]: []
+    })
+    expect(elicitFormViewValues(undefined)).toEqual({})
+  })
+
+  it('round-trips the view metadata and refuses anything that is not one', () => {
+    expect(decodeElicitFormMetadata(encodeElicitFormMetadata({ requestId: 'elicit-1', target: 'tgt' }))).toEqual({
+      requestId: 'elicit-1',
+      target: 'tgt'
+    })
+    // The direct Socket Mode path needs no routing hint: the connection that received the
+    // submission is the one that posted the card.
+    expect(decodeElicitFormMetadata(encodeElicitFormMetadata({ requestId: 'elicit-1' }))).toEqual({
+      requestId: 'elicit-1'
+    })
+    for (const bad of ['', 'not json', '{}', '{"v":2,"r":"x"}', '{"v":1,"r":""}', '{"v":1,"r":"x","t":3}'])
+      expect(decodeElicitFormMetadata(bad)).toBeNull()
   })
 })
 

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -609,6 +609,97 @@ export const ELICIT_DISMISS_ACTION = 'ac_elicit_dismiss'
 export const ELICIT_SELECT_ACTION = 'ac_elicit_select'
 export const ELICIT_CONFIRM_ACTION = 'ac_elicit_confirm'
 
+/** A MULTI-FIELD elicitation card's own three ids. An `actions` block holds no inputs, so the
+ *  in-channel card cannot carry the fields at all: it carries an Answer button whose tap opens a
+ *  modal ({@link ELICIT_FORM_CALLBACK_ID}) whose `input` blocks are the fields. One input per
+ *  block, because Slack keys both the submitted state AND `response_action: errors` by BLOCK id. */
+export const ELICIT_OPEN_ACTION = 'ac_elicit_open'
+export const ELICIT_FORM_CALLBACK_ID = 'ac_elicit_form'
+export const ELICIT_FORM_INPUT_ACTION = 'ac_elicit_input'
+
+const ELICIT_FORM_BLOCK_PREFIX = 'ac_elicit_f'
+
+/** The block id of the modal's Nth field. The INDEX rather than the property name: a property
+ *  name can outrun Slack's own id length, and the daemon re-derives the field list from the
+ *  card's params anyway (#1815), so an index is all the wire has to carry. */
+export function elicitFormBlockId(index: number): string {
+  return `${ELICIT_FORM_BLOCK_PREFIX}${index}`
+}
+
+/** The field index one of those block ids names, or null when the id is not one of ours. */
+export function elicitFormBlockIndex(blockId: string): number | null {
+  if (!blockId.startsWith(ELICIT_FORM_BLOCK_PREFIX)) return null
+  const digits = blockId.slice(ELICIT_FORM_BLOCK_PREFIX.length)
+  return /^\d+$/.test(digits) ? Number(digits) : null
+}
+
+/** One `view_submission` payload's state — every input of the modal, keyed by block then action
+ *  id. Widened past {@link SlackBlockActionsState} because a form's inputs answer with a typed
+ *  `value` or a single `selected_option` as well as a list. */
+export interface SlackViewState {
+  values?:
+    | Record<
+        string,
+        | Record<
+            string,
+            | {
+                value?: unknown
+                selected_option?: { value?: unknown } | null
+                selected_options?: { value?: unknown }[]
+              }
+            | undefined
+          >
+        | undefined
+      >
+    | undefined
+}
+
+/** What the reader typed and picked in a form modal, keyed by the field's BLOCK id so a
+ *  per-field error can be returned under the very same key. A blank input and a cleared select
+ *  are OMITTED rather than reported as empty: an untouched optional field is absent from the
+ *  answer, which is what the schema means by optional, and the daemon's own accept check is
+ *  what decides whether a required one may be missing. Pure. */
+export function elicitFormViewValues(state: SlackViewState | undefined): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {}
+  for (const [blockId, block] of Object.entries(state?.values ?? {})) {
+    if (elicitFormBlockIndex(blockId) === null) continue
+    const input = block?.[ELICIT_FORM_INPUT_ACTION]
+    if (!input) continue
+    if (Array.isArray(input.selected_options)) {
+      const values = input.selected_options.map((o) => o.value)
+      if (values.every((v) => typeof v === 'string')) out[blockId] = values as string[]
+      continue
+    }
+    const picked = input.selected_option?.value
+    if (typeof picked === 'string') out[blockId] = picked
+    else if (typeof input.value === 'string' && input.value.length) out[blockId] = input.value
+  }
+  return out
+}
+
+/** A form modal's `private_metadata`: which card it answers, plus the opaque session target the
+ *  relay routes its submission on (absent on the direct Socket Mode path, which needs no
+ *  routing hint — the connection that received the submission is the one that posted the card). */
+export interface SlackElicitFormMetadata {
+  requestId: string
+  target?: string
+}
+
+export function encodeElicitFormMetadata(meta: SlackElicitFormMetadata): string {
+  return JSON.stringify({ v: 1, r: meta.requestId, ...(meta.target ? { t: meta.target } : {}) })
+}
+
+export function decodeElicitFormMetadata(raw: string): SlackElicitFormMetadata | null {
+  try {
+    const parsed = JSON.parse(raw) as { v?: unknown; r?: unknown; t?: unknown }
+    if (parsed.v !== 1 || typeof parsed.r !== 'string' || !parsed.r) return null
+    if (parsed.t !== undefined && typeof parsed.t !== 'string') return null
+    return { requestId: parsed.r, ...(typeof parsed.t === 'string' && parsed.t ? { target: parsed.t } : {}) }
+  } catch {
+    return null
+  }
+}
+
 /** One `block_actions` payload's message state — every stateful element of the message the tap
  *  came from, keyed by block then action id. Slack has carried the full state on `block_actions`
  *  (not just view submissions) since 2020-09-01. */

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -499,7 +499,13 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       { kind: 'cancel' },
       { kind: 'permission-choice', requestId: 'perm-1', optionId: 'allow_once' },
       { kind: 'elicitation-choice', requestId: 'elicit-1', value: 'TypeScript' },
-      { kind: 'elicitation-choice', requestId: 'elicit-2', value: null }
+      { kind: 'elicitation-choice', requestId: 'elicit-2', value: null },
+      { kind: 'elicitation-confirm', requestId: 'elicit-3', values: ['lint'] },
+      { kind: 'elicitation-open', requestId: 'elicit-4', triggerId: 'trigger-3' },
+      { kind: 'elicitation-submit', requestId: 'elicit-5', fields: { ac_elicit_f0: 'main', ac_elicit_f1: ['lint'] } },
+      // An EMPTY record is a real submission: a form of nothing but optional fields, all left
+      // alone, and the daemon's own accept check is what decides whether that is an answer.
+      { kind: 'elicitation-submit', requestId: 'elicit-6', fields: {} }
     ]
     for (const payload of actions) {
       expect(RdSlackAction.safeParse(payload).success).toBe(true)
@@ -518,6 +524,19 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       }).success
     ).toBe(false)
     expect(RdSlackAction.safeParse({ kind: 'agent-session-stopped', channelId: 'C123' }).success).toBe(false)
+    // A modal cannot be opened without a trigger, and no form is wider than the card cap.
+    expect(RdSlackAction.safeParse({ kind: 'elicitation-open', requestId: 'e-1', triggerId: '' }).success).toBe(false)
+    const wideForm = Object.fromEntries(
+      Array.from({ length: ELICIT_FORM_WIRE_FIELD_CAP + 1 }, (_, i) => [`ac_elicit_f${i}`, 'x'])
+    )
+    expect(RdSlackAction.safeParse({ kind: 'elicitation-submit', requestId: 'e-1', fields: wideForm }).success).toBe(
+      false
+    )
+    // A field answers with a string or a list of them — never a number or a nested object, both
+    // of which Slack's own view state cannot produce.
+    expect(RdSlackAction.safeParse({ kind: 'elicitation-submit', requestId: 'e-1', fields: { a: 3 } }).success).toBe(
+      false
+    )
     // Envelope-level identity stays schema-enforced.
     expect(RdMsg.safeParse({ ...base, integrationId: 'not-a-uuid', payload: { kind: 'cancel' } }).success).toBe(false)
   })

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -371,6 +371,21 @@ export const RdSlackAction = z.discriminatedUnion('kind', [
     kind: z.literal('elicitation-confirm'),
     requestId: z.string().min(1),
     values: z.array(z.string()).max(100)
+  }),
+  // A MULTI-FIELD card's Answer button. Only the trigger id crosses: the relay never renders or
+  // holds the view — the daemon owns the card's schema and opens the modal on the same bot token
+  // it posted the card with, exactly as `open-config` above has always opened the status modal.
+  z.object({ kind: z.literal('elicitation-open'), requestId: z.string().min(1), triggerId: z.string().min(1) }),
+  // That modal's `view_submission`, keyed by the field's own block id so the daemon's per-field
+  // verdict can ride back under the same keys (`RdAck.response`, a `response_action: errors`
+  // payload the relay surfaces verbatim on Slack's 200). A blank optional input is simply
+  // absent — the record is re-validated whole against the card, so nothing here is trusted.
+  z.object({
+    kind: z.literal('elicitation-submit'),
+    requestId: z.string().min(1),
+    fields: z
+      .record(z.string().min(1).max(200), z.union([z.string(), z.array(z.string()).max(100)]))
+      .refine((v) => Object.keys(v).length <= ELICIT_FORM_WIRE_FIELD_CAP)
   })
 ])
 export type RdSlackAction = z.infer<typeof RdSlackAction>

--- a/packages/relay/src/platforms/slack/http-ingest.test.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.test.ts
@@ -4,12 +4,17 @@ import {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
+  ELICIT_FORM_CALLBACK_ID,
+  ELICIT_FORM_INPUT_ACTION,
+  ELICIT_OPEN_ACTION,
   ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   SHARED_AGENT_SELECT_ACTION_ID,
   SHARED_CONFIG_ACTION_ID,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
   SLACK_STATUS_ACTION,
+  elicitFormBlockId,
+  encodeElicitFormMetadata,
   encodeSlackStatusOverflowValue,
   encodeSharedSlackStatusTarget
 } from '@agentconnect.md/protocol'
@@ -17,6 +22,7 @@ import {
   normalizeSlackMessage,
   parseHttpSlackAgentSelection,
   parseHttpSlackAgentSwitch,
+  parseHttpSlackElicitFormSubmit,
   parseHttpSlackSessionAction,
   httpSlackAgentOptions,
   SlackHttpIngest,
@@ -386,6 +392,107 @@ describe('parseHttpSlackSessionAction', () => {
   })
 })
 
+// A multi-field card's two interactions (#1794's Slack column). Answer carries only the trigger
+// id: the DAEMON builds and opens the view on its own bot token, so the relay renders no part of
+// that modal and holds nothing of it. The submission carries the fields keyed by block id, which
+// is also how the daemon's per-field errors come back.
+describe('the multi-field elicitation form’s Slack interactions', () => {
+  it('forwards the Answer tap as elicitation-open, with the trigger id and nothing else', () => {
+    const parsed = parseHttpSlackSessionAction(
+      body(ELICIT_OPEN_ACTION, {
+        actions: [
+          {
+            action_id: ELICIT_OPEN_ACTION,
+            action_ts: '1720000000.000800',
+            block_id: ENCODED_TARGET,
+            value: 'elicit-4'
+          }
+        ],
+        view: undefined,
+        user: { id: 'U-ALICE' }
+      })
+    )
+    expect(parsed).toMatchObject({
+      target: TARGET,
+      kind: 'elicitation-open',
+      requestId: 'elicit-4',
+      triggerId: 'trigger-1',
+      userId: 'U-ALICE'
+    })
+    // The one-shot trigger id stays OUT of the dedup identity (as open-config's does), so trigger
+    // material never reaches a log or a key — and a redelivery still dedups against itself.
+    expect(httpSlackActionMsgId('bot', parsed!)).toBe(
+      httpSlackActionMsgId('bot', { ...parsed!, triggerId: 'another-trigger' } as never)
+    )
+    // No trigger is nothing to open.
+    expect(
+      parseHttpSlackSessionAction(
+        body(ELICIT_OPEN_ACTION, {
+          trigger_id: undefined,
+          actions: [{ action_id: ELICIT_OPEN_ACTION, action_ts: '1', block_id: ENCODED_TARGET, value: 'elicit-4' }],
+          view: undefined
+        })
+      )
+    ).toBeNull()
+  })
+
+  it('reads the submitted view state into elicitation-submit, keyed by block id', () => {
+    const submit = parseHttpSlackElicitFormSubmit({
+      type: 'view_submission',
+      trigger_id: 'trigger-submit',
+      user: { id: 'U-BOB' },
+      view: {
+        callback_id: ELICIT_FORM_CALLBACK_ID,
+        private_metadata: encodeElicitFormMetadata({ requestId: 'elicit-5', target: ENCODED_TARGET }),
+        state: {
+          values: {
+            [elicitFormBlockId(0)]: { [ELICIT_FORM_INPUT_ACTION]: { selected_option: { value: 'main' } } },
+            [elicitFormBlockId(1)]: { [ELICIT_FORM_INPUT_ACTION]: { value: 'ship it' } }
+          }
+        }
+      }
+    })
+    expect(submit).toMatchObject({
+      target: TARGET,
+      kind: 'elicitation-submit',
+      requestId: 'elicit-5',
+      fields: { [elicitFormBlockId(0)]: 'main', [elicitFormBlockId(1)]: 'ship it' },
+      userId: 'U-BOB'
+    })
+    // The submitted fields ARE part of the identity: a corrected resubmission is a second answer.
+    expect(httpSlackActionMsgId('bot', submit!)).not.toBe(
+      httpSlackActionMsgId('bot', { ...submit!, fields: { [elicitFormBlockId(0)]: 'develop' } })
+    )
+  })
+
+  it('is not one of ours without our callback id, a decodable metadata, or a receipt', () => {
+    const meta = encodeElicitFormMetadata({ requestId: 'elicit-5', target: ENCODED_TARGET })
+    const view = { callback_id: ELICIT_FORM_CALLBACK_ID, private_metadata: meta }
+    expect(parseHttpSlackElicitFormSubmit({ type: 'view_submission', trigger_id: 't', view })).toMatchObject({
+      kind: 'elicitation-submit'
+    })
+    expect(parseHttpSlackElicitFormSubmit({ type: 'block_actions', trigger_id: 't', view })).toBeNull()
+    expect(
+      parseHttpSlackElicitFormSubmit({
+        type: 'view_submission',
+        trigger_id: 't',
+        view: { callback_id: SHARED_CONFIG_ACTION_ID, private_metadata: meta }
+      })
+    ).toBeNull()
+    expect(parseHttpSlackElicitFormSubmit({ type: 'view_submission', trigger_id: 't', view: {} })).toBeNull()
+    // The direct Socket Mode modal carries no session target, so its submission is not routable
+    // here at all — and it never arrives here, since that path has no relay.
+    expect(
+      parseHttpSlackElicitFormSubmit({
+        type: 'view_submission',
+        trigger_id: 't',
+        view: { callback_id: ELICIT_FORM_CALLBACK_ID, private_metadata: encodeElicitFormMetadata({ requestId: 'e' }) }
+      })
+    ).toBeNull()
+    expect(parseHttpSlackElicitFormSubmit({ type: 'view_submission', view })).toBeNull()
+  })
+})
+
 describe('HTTP Slack agent selector', () => {
   const agents = [
     { agentId: AGENT_ID, name: 'Deploy Agent' },
@@ -463,6 +570,7 @@ describe('SlackHttpIngest.handleInteraction', () => {
     onSetChannelAgent: vi.fn(),
     onSelectThreadAgent: vi.fn(),
     onSessionAction: vi.fn(),
+    onElicitFormSubmit: vi.fn(async () => ''),
     onSessionShortcut: vi.fn(() => false),
     onSessionStopped: vi.fn(),
     log: silentLog,
@@ -494,6 +602,33 @@ describe('SlackHttpIngest.handleInteraction', () => {
     })
     expect(result).toBe('')
     expect(onSelectThreadAgent).toHaveBeenCalledWith('C123', '1720000000.000100', AGENT_ID)
+  })
+
+  it('puts the daemon’s form verdict on the 200 body — the one interaction Slack waits for', async () => {
+    const onElicitFormSubmit = vi.fn<SlackHttpIngestDeps['onElicitFormSubmit']>(async () => ({
+      response_action: 'errors',
+      errors: { ac_elicit_f0: 'nope' }
+    }))
+    const ingest = new SlackHttpIngest(
+      'bot',
+      { botToken: 'xoxb', signingSecret: 's' },
+      ingestDeps({ onElicitFormSubmit })
+    )
+    const result = await ingest.handleInteraction({
+      type: 'view_submission',
+      trigger_id: 'trigger-submit',
+      view: {
+        callback_id: ELICIT_FORM_CALLBACK_ID,
+        private_metadata: encodeElicitFormMetadata({ requestId: 'elicit-5', target: ENCODED_TARGET }),
+        state: { values: { [elicitFormBlockId(0)]: { [ELICIT_FORM_INPUT_ACTION]: { value: 'main' } } } }
+      }
+    })
+    expect(result).toEqual({ response_action: 'errors', errors: { ac_elicit_f0: 'nope' } })
+    expect(onElicitFormSubmit).toHaveBeenCalledTimes(1)
+    expect(onElicitFormSubmit.mock.calls[0]![0]).toMatchObject({
+      requestId: 'elicit-5',
+      fields: { [elicitFormBlockId(0)]: 'main' }
+    })
   })
 
   it('forwards a message shortcut with the selected conversation coordinates', async () => {
@@ -534,6 +669,7 @@ describe('SlackHttpIngest channel membership events', () => {
     onSetChannelAgent: vi.fn(),
     onSelectThreadAgent: vi.fn(),
     onSessionAction: vi.fn(),
+    onElicitFormSubmit: vi.fn(async () => ''),
     onSessionShortcut: vi.fn(() => false),
     onSessionStopped: vi.fn(),
     webClientFactory: () => web as never,
@@ -784,6 +920,7 @@ describe('SlackHttpIngest message events', () => {
         onSetChannelAgent: vi.fn(),
         onSelectThreadAgent: vi.fn(),
         onSessionAction: vi.fn(),
+        onElicitFormSubmit: vi.fn(async () => ''),
         onSessionShortcut: vi.fn(() => false),
         onSessionStopped: vi.fn(),
         webClientFactory: () => web as never,

--- a/packages/relay/src/platforms/slack/http-ingest.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.ts
@@ -27,18 +27,23 @@ import {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
+  ELICIT_FORM_CALLBACK_ID,
+  ELICIT_OPEN_ACTION,
   ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   SHARED_AGENT_SELECT_ACTION_ID,
   SHARED_CONFIG_ACTION_ID,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
   SLACK_STATUS_ACTION,
+  decodeElicitFormMetadata,
   decodePermValue,
   decodeSlackStatusOverflowValue,
   decodeSharedSlackStatusTarget,
+  elicitFormViewValues,
   selectedOptionsFromState,
   type RdSlackAction,
   type SlackBlockActionsState,
+  type SlackViewState,
   type SharedSlackStatusTarget,
   type WireNormalizedMessage
 } from '@agentconnect.md/protocol'
@@ -79,7 +84,9 @@ export interface SlackInteractiveBody {
   view?: {
     callback_id?: string
     private_metadata?: string
-    state?: { values?: Record<string, Record<string, { selected_option?: { value?: string } }>> }
+    /** Widened past the config modal's one select: an elicitation form's inputs answer with a
+     *  typed value and with lists too, and {@link elicitFormViewValues} reads all three. */
+    state?: SlackViewState & { values?: Record<string, Record<string, { selected_option?: { value?: string } }>> }
   }
 }
 
@@ -242,6 +249,18 @@ function decodeHttpSlackSessionAction(body: SlackInteractiveBody): HttpSlackSess
         }
       : null
   }
+  // A multi-field card's Answer. Only the trigger id crosses to the daemon, which builds and
+  // opens the view itself on the same bot token it posted the card with — the relay renders no
+  // part of that modal and keeps nothing of it, exactly as it keeps nothing of a status modal.
+  if (target && action.action_id === ELICIT_OPEN_ACTION && action.value && body.trigger_id) {
+    return {
+      target,
+      interactionId: JSON.stringify([action.action_id, receipt]),
+      kind: 'elicitation-open',
+      requestId: action.value,
+      triggerId: body.trigger_id
+    }
+  }
   if (target && action.action_id === ELICIT_DISMISS_ACTION && action.value) {
     return {
       target,
@@ -303,6 +322,32 @@ function decodeHttpSlackSessionAction(body: SlackInteractiveBody): HttpSlackSess
       return { target: statusTarget, interactionId, kind: 'cancel' }
     default:
       return null
+  }
+}
+
+/** One submitted elicitation-form modal, ready to forward: the daemon-minted session target the
+ *  view carried in `private_metadata`, plus the raw field state keyed by block id. Null when the
+ *  payload is not one of our form submissions, or names no routable target. */
+export type HttpSlackElicitFormSubmit = HttpSlackInteractionReceipt & {
+  target: SharedSlackStatusTarget
+  userId?: string
+} & Extract<RdSlackAction, { kind: 'elicitation-submit' }>
+
+export function parseHttpSlackElicitFormSubmit(body: SlackInteractiveBody): HttpSlackElicitFormSubmit | null {
+  if (body.type !== 'view_submission' || body.view?.callback_id !== ELICIT_FORM_CALLBACK_ID) return null
+  const meta = body.view.private_metadata ? decodeElicitFormMetadata(body.view.private_metadata) : null
+  const target = meta?.target ? decodeSharedSlackStatusTarget(meta.target) : null
+  // A view_submission's trigger id is fresh per submission, so a corrected resubmission is its
+  // own interaction while Slack's own redelivery of one dedups against itself.
+  const receipt = body.trigger_id
+  if (!meta || !target || !receipt) return null
+  return {
+    target,
+    interactionId: JSON.stringify([ELICIT_FORM_CALLBACK_ID, receipt]),
+    kind: 'elicitation-submit',
+    requestId: meta.requestId,
+    fields: elicitFormViewValues(body.view.state),
+    ...(body.user?.id ? { userId: body.user.id } : {})
   }
 }
 
@@ -386,6 +431,11 @@ export interface SlackHttpIngestDeps {
   onSelectThreadAgent: (channelId: string, threadTs: string, agentId: string) => void
   /** Forward the current agent/session controls to its owning daemon. */
   onSessionAction: (action: HttpSlackSessionAction) => void
+  /** Forward a submitted elicitation-form modal and RESOLVE to the daemon's verdict: the one
+   *  Slack interaction on this seam whose answer Slack itself is waiting for, since per-field
+   *  errors only exist as a `view_submission` response. Resolves to '' when there is nothing
+   *  to say, which closes the modal. */
+  onElicitFormSubmit: (submit: HttpSlackElicitFormSubmit) => Promise<unknown>
   /** Resolve and forward the app-level message shortcut. False opens a local
    *  unavailable modal while the one-shot trigger id is still valid. */
   onSessionShortcut: (shortcut: HttpSlackSessionShortcut) => boolean
@@ -685,6 +735,9 @@ export class SlackHttpIngest {
         else if (context && picked) this.deps.onSetChannelAgent(context.channelId, picked)
         return '' // empty 200 closes the modal (same as the old empty ack)
       }
+      const formSubmit = parseHttpSlackElicitFormSubmit(body)
+      // Awaited, unlike every other forward here: the daemon's re-validation IS this 200's body.
+      if (formSubmit) return await this.deps.onElicitFormSubmit(formSubmit)
       const sessionAction = parseHttpSlackSessionAction(body)
       if (sessionAction) {
         this.deps.onSessionAction(sessionAction)

--- a/packages/relay/src/platforms/slack/ingress-plugin.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.ts
@@ -22,6 +22,7 @@ import { createHash } from 'node:crypto'
 import type { RdMsgPlatformAction } from '@agentconnect.md/protocol'
 import {
   SlackHttpIngest,
+  type HttpSlackElicitFormSubmit,
   type HttpSlackSessionAction,
   type HttpSlackSessionShortcut,
   type HttpSlackSessionStop,
@@ -66,6 +67,16 @@ export function httpSlackActionMsgId(botId: string, action: HttpSlackSessionActi
     // and a redelivery of either must dedup against itself rather than against the other.
     case 'elicitation-confirm':
       value = `${action.requestId}:${JSON.stringify(action.values)}`
+      break
+    // The one-shot triggerId is deliberately omitted, as open-config's is: the interactionId
+    // already identifies the click, and trigger material must not reach a log or a dedup key.
+    case 'elicitation-open':
+      value = action.requestId
+      break
+    // The submitted fields are part of the identity: a corrected resubmission is a second
+    // answer, and a redelivery of either must dedup against itself rather than the other.
+    case 'elicitation-submit':
+      value = `${action.requestId}:${JSON.stringify(action.fields)}`
       break
     case 'open-config':
     case 'cancel':
@@ -148,6 +159,46 @@ export function forwardSessionAction(host: RelayIngressHost, botId: string, acti
         host.log.warn(`relay-ingress(${botId}): daemon rejected session action (${ack.reason ?? 'unknown'})`)
     })
     .catch((err) => host.log.warn(`relay-ingress(${botId}): session action forward failed: ${(err as Error).message}`))
+}
+
+/** Forward a submitted elicitation-form modal and RETURN the daemon's verdict, so the relay can
+ *  put it on Slack's own 200. This is the one interaction forward that is awaited: the per-field
+ *  errors exist only as a `view_submission` response, and the daemon owns the schema they come
+ *  from. An unroutable or unreachable daemon answers '' — the modal closes and the card stays
+ *  live, which is the same bounded loss every other forward on this seam declares. */
+export async function forwardElicitFormSubmit(
+  host: RelayIngressHost,
+  botId: string,
+  submit: HttpSlackElicitFormSubmit
+): Promise<unknown> {
+  const { target, interactionId: _interactionId, userId, ...payload } = submit
+  const route = host.directory.targetForAgent(botId, target.agentId, target.integrationId)
+  if (!route) {
+    host.log.warn(`relay-ingress(${botId}): ignored stale elicitation submission for agent ${target.agentId}`)
+    return ''
+  }
+  const rd: RdMsgPlatformAction = {
+    source: 'platform_action',
+    platformId: 'slack',
+    agentId: route.agentId,
+    integrationId: route.integrationId,
+    sessionKey: target.sessionKey,
+    msgId: httpSlackActionMsgId(botId, submit),
+    botId,
+    ...(userId ? { userId } : {}),
+    payload
+  }
+  try {
+    const ack = await host.forwardAction(rd, route)
+    if (!ack.accepted) {
+      host.log.warn(`relay-ingress(${botId}): daemon rejected the elicitation submission (${ack.reason ?? 'unknown'})`)
+      return ''
+    }
+    return ack.response ?? ''
+  } catch (err) {
+    host.log.warn(`relay-ingress(${botId}): elicitation submission forward failed: ${(err as Error).message}`)
+    return ''
+  }
 }
 
 /** Resolve a message shortcut from live conversation ownership (the core-owned
@@ -269,6 +320,7 @@ export const slackIngressPlugin: RelayPlatformIngressPlugin<SlackHttpIngest, Sla
         onSelectThreadAgent: (channelId, threadTs, agentId) =>
           host.selectThreadAgent(botId, channelId, threadTs, agentId),
         onSessionAction: (action) => forwardSessionAction(host, botId, action),
+        onElicitFormSubmit: (submit) => forwardElicitFormSubmit(host, botId, submit),
         onSessionShortcut: (shortcut) => forwardSessionShortcut(host, botId, shortcut),
         onSessionStopped: (stop) => forwardSessionStop(host, botId, stop),
         onBotRevoked: (reason, eventAtMs) => {

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -23,6 +23,7 @@ import { RelayIngressManager, type RelayIngressManagerDeps } from './relay-ingre
 // the identity, core owns the table). This suite was the last importer of the
 // core re-export shim that outlived the #571 route migration (audit F7).
 import {
+  forwardElicitFormSubmit,
   forwardSessionAction,
   forwardSessionShortcut,
   forwardSessionStop,
@@ -237,6 +238,50 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
     })
     expect(second.msgId).toBe(first.msgId)
     expect(first.msgId).toMatch(/^slack-action:[a-f0-9]{64}$/)
+  })
+
+  // The one interaction forward that is AWAITED: per-field errors exist only as a
+  // `view_submission` response, and the daemon owns the schema they come from. The relay carries
+  // that verdict — it never renders, validates or holds any part of the modal.
+  it('returns the daemon’s form verdict, and an empty body when it cannot be asked', async () => {
+    const response = { response_action: 'errors', errors: { ac_elicit_f0: 'nope' } }
+    const sendMsg = vi.fn(async (msg: RdMsgPlatformAction): Promise<RdAck> => ({
+      msgId: msg.msgId,
+      accepted: true,
+      response
+    }))
+    const daemon = { sendMsg } as unknown as RelayDaemonConnection
+    const manager = new RelayIngressManager(
+      deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
+    )
+    const internals = internalsOf(manager)
+    internals.router.upsert(assignment())
+
+    const submit = action({
+      interactionId: JSON.stringify(['ac_elicit_form', 'trigger-submit']),
+      kind: 'elicitation-submit',
+      requestId: 'elicit-5',
+      fields: { ac_elicit_f0: 'main' }
+    } as never)
+    expect(await forwardElicitFormSubmit(internals.ingressHost, BOT_ID, submit as never)).toEqual(response)
+    expect(sendMsg.mock.calls[0]![0]).toMatchObject({
+      source: 'platform_action',
+      platformId: 'slack',
+      agentId: AGENT_ID,
+      integrationId: INTEGRATION_ID,
+      payload: { kind: 'elicitation-submit', requestId: 'elicit-5', fields: { ac_elicit_f0: 'main' } }
+    })
+
+    // A refusal, an ack with nothing to say, and a throw all close the modal and leave the card
+    // live — the same bounded loss every other forward on this seam declares.
+    sendMsg.mockImplementation(async (msg) => ({ msgId: msg.msgId, accepted: false, reason: 'not_found' }))
+    expect(await forwardElicitFormSubmit(internals.ingressHost, BOT_ID, submit as never)).toBe('')
+    sendMsg.mockImplementation(async (msg) => ({ msgId: msg.msgId, accepted: true }))
+    expect(await forwardElicitFormSubmit(internals.ingressHost, BOT_ID, submit as never)).toBe('')
+    sendMsg.mockImplementation(async () => {
+      throw new Error('socket gone')
+    })
+    expect(await forwardElicitFormSubmit(internals.ingressHost, BOT_ID, submit as never)).toBe('')
   })
 
   it('forwards a message shortcut through the current thread affinity', () => {


### PR DESCRIPTION
The last Slack-column item on #1794: **a multi-field elicitation form is answered in a modal.**

This is the only shape that needs one. Everything else on Slack now works without a modal — single-select and boolean are buttons, multi-select is a `multi_static_select` plus Confirm (#1825), a lone text or number field is answered by a thread reply (#1828), and URL mode is a consent button (#1821).

The card in-channel cannot hold the fields, so it carries the question, a line naming what will be asked, **Answer** and **Dismiss**. Answer opens a modal of native `input` blocks — `plain_text_input`, `number_input`, `static_select` / `multi_static_select`, with `initial_value` / `initial_option` from the schema's `default`. On submit the modal closes and the in-channel card is rewritten to its settled state, as every other card is.

## The plan's stated reason for confining the modal was wrong, and this PR corrects it

#1794 recorded a dilemma: a `trigger_id` expires in about three seconds, so opening a modal seemed to force a choice between a daemon↔relay round trip inside that window, or **the relay holding a pre-rendered view** — which brushes against the relay persisting no message content. I asked for the second.

That premise is false in this codebase. **In relay-fronted mode the daemon already holds the bot's own `xoxb` token** — it is how the card gets posted and rewritten at all — so the daemon opens the view itself and the relay only forwards the `trigger_id`, **fire-and-forget, returning 200 without waiting**. That mechanism was already in production for the status modal:

```
// daemon.ts, open-config
// Start views.open immediately while Slack's short-lived trigger_id is valid. The
// connection catches/logs Web API failures; rd/ack is only the relay receipt.
```

`elicitation-open` sits beside `open-config` and behaves identically. The split in the plan is still the right product shape, but not for the reason first given, and #1794 has been corrected — the false premise is what pushed the plan away from a modal in the first place, so leaving it there would mislead the next reader.

Why the pre-rendered-view design would have been worse, not merely heavier:

- It does not remove the round trip, it moves it. The **submission** needs one regardless: `response_action: errors` exists only as a synchronous `view_submission` response, and only the daemon knows the schema.
- Its failure mode is worse. With a slow or reconnecting daemon, a pre-opened modal is filled in and submitted **into nothing**. As built, a slow daemon makes Answer behave like every other card button — the tap does nothing and the card stays live and answerable.
- It would put agent-authored content — question text, field and option labels — in relay memory, and need a new frame plus a lifetime protocol nothing else on that seam has.

## Nothing is pre-rendered or cached, on either side

The card's already-masked schema lives on the daemon's `PendingElicit` record, as it does for every other card kind. **The view is built on demand** at the instant Answer is tapped, by one function called from both ingress paths — so the two modals are identical by construction, and a test asserts the two captured views deep-equal.

Freed by `pendingElicits.delete` on accept, on Dismiss, and on `releaseElicits` when the turn ends or cancels — the same lifetime rule #1825's selection and #1828's reply interception already have.

What crosses to the relay is the `trigger_id` inbound, the raw field state on submit, and the daemon's opaque verdict outbound; the relay holds none of it past the HTTP request. What round-trips **through Slack** is the opaque `sessionTarget` the card's `block_id` already carried, echoed in the modal's `private_metadata` — Slack stores that, not the relay, and it names nothing about the reader.

## The whole record is re-validated on submit

Exactly as webchat's is (#1807): the rendered propName set, every `required` name present, an omitted optional field allowed, each value valid for its own field. A bad field comes back as a **per-field error** via `response_action: errors` rather than a silent drop — which is the one thing the reply route (#1828) cannot do. Slack's own `min_length` / `min_value` constraints are a convenience, never the gate; `pattern` has no Slack equivalent and is validated on submit.

Accept content is the typed record — real numbers, arrays for multi-select.

## Two readers, re-opening, and an expired trigger

- **Two readers**: both may open it, and unlike #1825's shared selection there is no shared state — Slack keeps input state per view instance per user, so each fills in their own. The first submission settles the request; the second finds no pending record and gets *"This question has already been answered or dismissed."* Not silence, and not a second resolution. There is **no `await` between the accept check and the delete**, so the loser cannot slip through.
- **Re-opening after settle**: a stale client can tap Answer before the in-place rewrite lands. It opens the same closed modal, following `buildStatusUnavailableModal`'s precedent, because the alternative is a button that does nothing. It cannot re-settle anything — the record is gone.
- **Expired `trigger_id`**: `views.open` fails, the connection logs and swallows it as it does for the status modal, and nothing else happens. The card keeps its Answer button and stays answerable, including by Dismiss. That is the honest reason the open consumes nothing: opening is not answering.

## The modal title

`Agent needs your input` — fixed and deployment-authored. Twenty-four characters hold no question, and the title is the line on a modal a reader trusts most, so it is the worst place for an agent-authored string. The agent's own message goes in the modal's first section, defused by the same `elicitCardMessage` every card uses.

## One thing I was asked for and did not do

The brief said a form "must not be settleable by someone the card was not waiting for — reuse whatever the other cards do". Those two halves conflict: **no tap-answered Slack card gates on the reader.** Option buttons, the multi-select Confirm and the URL consent button are all answerable by anyone who can see the card; only #1828's thread reply gates on the requester, and only because a reply would otherwise start a turn.

The tap convention is reused — the relay validates the card's session target, the daemon re-checks agent/integration/session binding, and the submitter is recorded as the actor — which is a gate at **card** granularity, not person. If forms should gate per person, that is one decision applied to all four tap cards at once; making the modal the odd one out would be worse than either answer. Recorded as an open item on #1794.

## Known limits, on #1794

- Slack's `plain_text_input` caps `max_length` at 3000 while ours is 4096, so such a field is narrower in the modal than on webchat (the daemon still validates the schema's real bound), and `minLength > 3000` makes the form unrenderable.
- One select question with a companion "Other" text box is still unaskable: it is one question, so it stays on the button row and the companion goes unanswered.
- On the relay path a submit's latency now includes a daemon hop inside Slack's 3 s, reusing `RdAck.response` — the mechanism that already exists for Feishu toasts and Slack `block_suggestion`. An unreachable daemon answers empty: the modal closes and the card stays live.

## Verification

- protocol 490, relay 652, web 2406 — green.
- `pnpm typecheck`: `error TS` count 0, run with sources restored.
- Affected daemon suites (`slack-elicit-form`, `daemon-permission-autoallow`, `render`, `connection`, `slack-streaming`, `slack-status-actor`, `elicit-decline-notice`): **492 passing**, independently re-run.
- Full daemon suite: nine files in the known-unrelated set (`acp-matrix`, five skills-CLI files, bwrap `sandbox`, `evaluation-runner`, `daemon-smoke`) and five load-flaky ones — 188 s to 302 s durations alongside `acp-matrix`'s 668 s, a *different* five than the previous pass. Re-run in isolation: 214/214 passing.

**One real regression caught mid-verification and fixed here:** adding `view` to `AppLike` broke 30 tests across `connection.test.ts` and `slack-streaming.test.ts`, whose local Bolt stand-ins had no `view` member. Both files green.

Two existing tests were rewritten because they asserted the behaviour this item removes — `render.test.ts`'s "still declines it on Slack" (its own comment said "the modal that would show them is its own item") and the coordinator's "still declines a multi-field form on a Slack turn". Every new test was confirmed red with only the sources reverted; the four of twenty-one that pass either way are the ones asserting the *absence* of new behaviour (the DM surface still declines multi-field, the single-field paths unchanged), which is correct for a negative guard.
