### PR TITLE
feat(hooks): watch GitHub deployments as a fourth subject family

### DIFF
--- a/docs/designs/webhook-triggers-and-github-events.md
+++ b/docs/designs/webhook-triggers-and-github-events.md
@@ -232,18 +232,31 @@ The relay recognizes these subscription event families:
 - `issue_comment`
 - `pull_request_review_comment`
 - `push`
+- `deployment`
+- `deployment_status`
 
 Stored patterns use `family:action`, with `family:*` as a wildcard. Label
 filters require at least one current subject label to match.
 `commentFamilies` distinguishes issue comments from pull-request conversation
 comments because GitHub sends both through `issue_comment`.
 
+`deployment` and `deployment_status` share the `deployment` subject family. A
+status delivery is matched and reported by the state it carries, not by GitHub's
+invariant `created` action: the stored pattern is `deployment_status:<state>`
+(`success`, `failure`, `in_progress`, …) or `deployment_status:*`. Receiving
+either event requires the App's `deployments: read` permission and both event
+subscriptions; an App created before they were added must gain them by hand in
+its settings, because GitHub exposes no API for event subscriptions.
+
 The matcher rejects bot-authored comments and review comments, plus unrelated bot
 events, to prevent self-reply loops and agent-to-agent mention loops. Revision-bearing
 PR events authored by the configured App are admitted as the lifecycle
 exception: same-repository PRs are treated as an internal CI lane and may start review
 without a human-author permission lookup, while fork PRs remain on the maintainer
-workflow-approval path.
+workflow-approval path. Deployments are the other exception: GitHub Actions and
+deployment Apps author nearly all of them, and nothing posts back into a
+deployment, so the bot veto does not apply. Like a push, a deployment has no
+thread actor to authorize and is trusted on the installation gate alone.
 
 Closed, deleted, and reopened issue or pull-request lifecycle events do not start
 turns. Ordinary issue/PR title and body edits are also silent. A PR edit carrying
@@ -342,7 +355,11 @@ repository/pull/head delivery key coalesces multiple workflows for one revision.
 GitHub hooks always use `perThread`. The relay forms the session key from the
 hook's immutable `githubSessionKey` prefix and the issue or pull-request number.
 New rows use a numeric-repository-based prefix, so repository renames do not
-split the conversation.
+split the conversation. A push keys on its ref and a deployment on its
+environment (`prefix#deployments/production`): every deployment to one
+environment continues one session, so the agent that watched the last release
+sees the next, and the daemon's worktrees stay bounded by environments rather
+than by deployments.
 
 The daemon maps this to its normal session identity and resumes the same ACP
 session on later matching events. No GitHub-specific session store exists.
@@ -620,8 +637,8 @@ The Prisma schema is authoritative. The main records are:
 ### One Row per Subject Family
 
 A code-host `HookDef` row covers exactly ONE subject family — `pull_request`,
-`issues` or `push` for GitHub, `merge_request`, `issues` or `push` for GitLab —
-recorded in `family` and unique per `(agentId, kind, repoId, family)`. Watching a
+`issues`, `push` or `deployment` for GitHub, `merge_request`, `issues` or `push`
+for GitLab — recorded in `family` and unique per `(agentId, kind, repoId, family)`. Watching a
 repository for both pull requests and issues is therefore two rows, each with its
 own cadence, label filter and `mentionOnly` gate: pull requests can fire on every
 update while issues fire only on an explicit mention. `family` is immutable, so
@@ -633,7 +650,8 @@ traffic per family — so each row compiles into an ordinary independent rule.
 Three constraints keep those rules from overlapping:
 
 - every stored pattern must belong to the row's family, with `issue_comment` and
-  `pull_request_review_comment` riding the thread family that owns them;
+  `pull_request_review_comment` riding the thread family that owns them and
+  `deployment_status` riding `deployment`;
 - `commentFamilies` may only name the row's own family, and a GitHub row carrying
   an `issue_comment` subscription must set it — left empty it would keep the
   legacy repository-wide meaning and double-fire against its sibling; and
@@ -689,8 +707,12 @@ reporting are rejected.
 
 The agent detail Integrations card lists hooks alongside integrations. Generic
 hook creation reveals the capability URL and optional HMAC secret once. GitHub
-creation uses the App installation and repository picker. Recent runs show
-status, delivery key, duration, and a session deep link.
+creation uses the App installation and repository picker and offers the pull
+request, issue and deployment subjects; a deployment row has two cadences —
+`created` (`deployment:created`) and `any status` (`deployment:*` plus
+`deployment_status:*`) — and no label or mention gate, since nobody writes in a
+deployment. Finer state selection (`deployment_status:failure`) is API-only.
+Recent runs show status, delivery key, duration, and a session deep link.
 
 ## Redelivery and Failure Semantics
 

--- a/packages/control-plane/src/hooks/hook-family.test.ts
+++ b/packages/control-plane/src/hooks/hook-family.test.ts
@@ -31,7 +31,10 @@ describe('hook family — pattern classification', () => {
     expect(familyOfEventPattern('pull_request:*')).toBe('pull_request')
     expect(familyOfEventPattern('merge_request:*')).toBe('merge_request')
     expect(familyOfEventPattern('push:*')).toBe('push')
-    // A diff-line review comment is a pull-request subject…
+    expect(familyOfEventPattern('deployment:created')).toBe('deployment')
+    // A status is posted against a deployment, so it is a deployment subject…
+    expect(familyOfEventPattern('deployment_status:failure')).toBe('deployment')
+    // …as a diff-line review comment is a pull-request subject…
     expect(familyOfEventPattern('pull_request_review_comment:created')).toBe('pull_request')
     // …but GitHub's shared conversation subscription names no subject by itself.
     expect(familyOfEventPattern('issue_comment:created')).toBeNull()
@@ -48,6 +51,11 @@ describe('hook family — pattern classification', () => {
     expect(eventPatternFitsFamily('github', 'issues', 'pull_request_review_comment:created')).toBe(false)
     expect(eventPatternFitsFamily('gitlab', 'merge_request', 'merge_request:*')).toBe(true)
     expect(eventPatternFitsFamily('gitlab', 'merge_request', 'issues:*')).toBe(false)
+    // A deployment status rides the deployment row, and only GitHub has one.
+    expect(eventPatternFitsFamily('github', 'deployment', 'deployment_status:*')).toBe(true)
+    expect(eventPatternFitsFamily('github', 'deployment', 'deployment:created')).toBe(true)
+    expect(eventPatternFitsFamily('github', 'push', 'deployment_status:*')).toBe(false)
+    expect(eventPatternFitsFamily('gitlab', 'deployment', 'deployment_status:*')).toBe(false)
   })
 
   it('knows which families can carry reviews, and which patterns ride the shared subscription', () => {
@@ -55,7 +63,8 @@ describe('hook family — pattern classification', () => {
       ['pull_request', true],
       ['merge_request', true],
       ['issues', false],
-      ['push', false]
+      ['push', false],
+      ['deployment', false]
     ]
     for (const [family, expected] of carries) expect(familyCarriesReviews(family)).toBe(expected)
     expect(hasSharedCommentPattern(['pull_request:*', 'issue_comment:created'])).toBe(true)
@@ -76,6 +85,8 @@ describe('hook family — one-row shape', () => {
       shape({ family: 'issues', events: ['issues:*', 'issue_comment:created'], commentFamilies: ['issues'] })
     ).toBeNull()
     expect(shape({ family: 'push', events: ['push:*'] })).toBeNull()
+    expect(shape({ family: 'deployment', events: ['deployment:created'] })).toBeNull()
+    expect(shape({ family: 'deployment', events: ['deployment:*', 'deployment_status:failure'] })).toBeNull()
     expect(
       shape({
         kind: 'gitlab',
@@ -89,6 +100,9 @@ describe('hook family — one-row shape', () => {
   it('names the offending pattern when it belongs to another family', () => {
     expect(shape({ events: ['pull_request:*', 'issues:opened'] })).toMatch(/"issues:opened".*pull_request family/)
     expect(shape({ family: 'push', events: ['push:*', 'issue_comment:created'] })).toMatch(/issue_comment:created/)
+    // A status belongs to the deployment row, whichever sibling tries to carry it.
+    expect(shape({ family: 'issues', events: ['issues:*', 'deployment_status:*'] })).toMatch(/"deployment_status:\*"/)
+    expect(shape({ family: 'deployment', events: ['deployment:*', 'push:*'] })).toMatch(/"push:\*".*deployment family/)
   })
 
   it('keeps commentFamilies inside the row it scopes', () => {
@@ -110,6 +124,7 @@ describe('hook family — one-row shape', () => {
     expect(shape({ family: 'issues', events: ['issues:*'], reviewPolicy: 'comment' })).toBe(reviews)
     expect(shape({ family: 'issues', events: ['issues:*'], reportingMode: 'check' })).toBe(reviews)
     expect(shape({ family: 'push', events: ['push:*'], gateMode: 'required' })).toBe(reviews)
+    expect(shape({ family: 'deployment', events: ['deployment:*'], reviewPolicy: 'comment' })).toBe(reviews)
     expect(shape({ reviewPolicy: 'full', reportingMode: 'check' })).toBeNull()
     expect(
       shape({ kind: 'gitlab', family: 'merge_request', events: ['merge_request:*'], reviewPolicy: 'full' })

--- a/packages/control-plane/src/hooks/hook-family.ts
+++ b/packages/control-plane/src/hooks/hook-family.ts
@@ -9,10 +9,10 @@
  */
 
 /** Every subject family the two code hosts between them subscribe to. */
-export type HookFamily = 'issues' | 'pull_request' | 'merge_request' | 'push'
+export type HookFamily = 'issues' | 'pull_request' | 'merge_request' | 'push' | 'deployment'
 
 /** The families a row of each kind may declare. */
-export const GITHUB_FAMILIES = ['pull_request', 'issues', 'push'] as const
+export const GITHUB_FAMILIES = ['pull_request', 'issues', 'push', 'deployment'] as const
 export const GITLAB_FAMILIES = ['merge_request', 'issues', 'push'] as const
 
 /** Reviews and run reporting exist only on a change-proposal subject. */
@@ -33,9 +33,12 @@ export function familyOfEventPattern(pattern: string): HookFamily | null {
     case 'pull_request':
     case 'merge_request':
     case 'push':
+    case 'deployment':
       return prefix
     case 'pull_request_review_comment':
       return 'pull_request'
+    case 'deployment_status':
+      return 'deployment'
     default:
       return null
   }
@@ -48,6 +51,8 @@ export function eventPatternFitsFamily(kind: 'github' | 'gitlab', family: HookFa
     return kind === 'github' && (family === 'issues' || family === 'pull_request')
   }
   if (prefix === 'pull_request_review_comment') return kind === 'github' && family === 'pull_request'
+  // A status is posted against a deployment, so it rides the deployment row (GitHub only).
+  if (prefix === 'deployment_status') return kind === 'github' && family === 'deployment'
   return prefix === family
 }
 

--- a/packages/control-plane/src/http/dto/index.ts
+++ b/packages/control-plane/src/http/dto/index.ts
@@ -2480,10 +2480,11 @@ export const CronListDto = z.array(CronDto)
 
 export const HookSessionModeEnum = z.enum(['perDelivery', 'perThread', 'perSubject', 'shared'])
 
-/** `event:action` with an `event:*` family wildcard; only the three subscribed
- *  families are accepted (the relay routes nothing else to the matcher). The
- *  action part is deliberately loose — a new GitHub action must not 400. */
-export const HookEventPattern = /^(issues|pull_request|issue_comment|pull_request_review_comment|push):([a-z_]+|\*)$/
+/** `event:action` with an `event:*` family wildcard; only the subscribed events are accepted (the relay
+ *  routes nothing else to the matcher). The action part is deliberately loose — a new GitHub action must
+ *  not 400 — and a `deployment_status` action is the status STATE (`success`, `failure`, …). */
+export const HookEventPattern =
+  /^(issues|pull_request|issue_comment|pull_request_review_comment|push|deployment|deployment_status):([a-z_]+|\*)$/
 export const GithubCommentFamily = z.enum(['issues', 'pull_request'])
 const GithubCommentFamilies = z.array(GithubCommentFamily).max(2)
 export const HookReviewPolicyEnum = z.enum(['off', 'comment', 'request_changes', 'full'])
@@ -2517,7 +2518,7 @@ export const CreateWebhookHookBody = HookBodyBase.extend({
 /** The subject family one row covers. A row is `(agent, repo, family)`: each
  *  family carries its own cadence and its own mention gate, so a repository the
  *  agent watches for both PRs and issues is TWO rows. Immutable after create. */
-export const GithubHookFamily = z.enum(['pull_request', 'issues', 'push'])
+export const GithubHookFamily = z.enum(['pull_request', 'issues', 'push', 'deployment'])
 export const GitlabHookFamily = z.enum(['merge_request', 'issues', 'push'])
 
 export const CreateGithubHookBody = HookBodyBase.extend({

--- a/packages/control-plane/src/http/routes/hooks.ts
+++ b/packages/control-plane/src/http/routes/hooks.ts
@@ -505,7 +505,7 @@ export function hookRoutes(deps: HttpDeps) {
           tags: [Tag.Hooks],
           summary: 'Create a hook',
           description:
-            'Create a trigger for one agent. `kind:"webhook"` mints an ingress URL (the response carries it plus — when requested — the one-time HMAC signing secret, never retrievable again). `kind:"github"` subscribes a repository covered by one of the organization’s GitHub App installations to issue/PR events. A code-host trigger covers ONE subject `family`, so a repository watched for both pull requests and issues is two triggers, each with its own cadence and mention gate; a second trigger on the same family is a 409.',
+            'Create a trigger for one agent. `kind:"webhook"` mints an ingress URL (the response carries it plus — when requested — the one-time HMAC signing secret, never retrievable again). `kind:"github"` subscribes a repository covered by one of the organization’s GitHub App installations to issue, pull-request, push or deployment events. A code-host trigger covers ONE subject `family`, so a repository watched for both pull requests and issues is two triggers, each with its own cadence and mention gate; a second trigger on the same family is a 409. A `deployment_status:<state>` pattern selects on the status state (`success`, `failure`, …).',
           operationId: 'createHook',
           body: CreateHookBody,
           response: { 200: CreatedHookDto, 400: ErrorDto, 403: ErrorDto, 409: ErrorDto, 429: ErrorDto, 502: ErrorDto }

--- a/packages/control-plane/src/orchestrator/hookRedeliveryReconciler.test.ts
+++ b/packages/control-plane/src/orchestrator/hookRedeliveryReconciler.test.ts
@@ -213,6 +213,28 @@ describe('HookRedeliveryReconciler', () => {
     expect(h.redelivered).toEqual(['1234567890123456789'])
   })
 
+  // GitHub's delivery summary says only `created` for a status; the state the
+  // relay matches on is in the body it never lists. Any status subscription is
+  // therefore a candidate, and the relay's precise filter decides on redelivery.
+  it('offers a deployment_status GUID to any status subscription, and a deployment to its exact pattern', async () => {
+    const watched = make({
+      hooks: [ghHook({ events: ['deployment:created', 'deployment_status:failure'] })],
+      deliveries: [
+        delivery({ id: '1', guid: 'dep', event: 'deployment', action: 'created' }),
+        delivery({ id: '2', guid: 'status', event: 'deployment_status', action: 'created' })
+      ]
+    })
+    await watched.reconciler.tick()
+    expect(watched.redelivered).toEqual(['1', '2'])
+
+    const createdOnly = make({
+      hooks: [ghHook({ events: ['deployment:created'] })],
+      deliveries: [delivery({ id: '3', guid: 'status-unwatched', event: 'deployment_status', action: 'created' })]
+    })
+    await createdOnly.reconciler.tick()
+    expect(createdOnly.redelivered).toEqual([])
+  })
+
   it('conservatively redelivers possible created-cadence summons', async () => {
     const issue = make({
       hooks: [ghHook({ events: ['issues:opened'], commentFamilies: ['issues'] })],

--- a/packages/control-plane/src/orchestrator/hookRedeliveryReconciler.ts
+++ b/packages/control-plane/src/orchestrator/hookRedeliveryReconciler.ts
@@ -5,7 +5,15 @@ import type { GhHookDeliveryPage } from '../github/service.js'
 import type { HookRecord, RelayRecord } from '../persistence/ports.js'
 
 /** The families the relay matches (everything else never produces a run). */
-const SUBSCRIPTION_EVENTS = new Set(['issues', 'pull_request', 'issue_comment', 'pull_request_review_comment', 'push'])
+const SUBSCRIPTION_EVENTS = new Set([
+  'issues',
+  'pull_request',
+  'issue_comment',
+  'pull_request_review_comment',
+  'push',
+  'deployment',
+  'deployment_status'
+])
 /** Redeliveries requested per GUID before giving up (loop breaker). */
 const MAX_ATTEMPTS = 3
 /** Delay before the first sweep of a process — see {@link HookRedeliveryReconciler.start}. */
@@ -76,6 +84,9 @@ export interface ReconcilerLog {
 function hookMatchesEvent(hook: HookRecord, event: string, action: string | null): boolean {
   if ((action === 'closed' || action === 'reopened') && (event === 'issues' || event === 'pull_request')) return false
   if ((event === 'issues' || event === 'pull_request') && action === 'edited') return false
+  // The summary says only `created` for a status; the relay matches on the state it carries, so any
+  // deployment_status pattern is a conservative candidate and the relay's own filter decides.
+  if (event === 'deployment_status') return hook.events.some((pattern) => pattern.startsWith('deployment_status:'))
   const matchesPattern = (candidate: string): boolean =>
     hook.events.includes(`${candidate}:${action ?? ''}`) || hook.events.includes(`${candidate}:*`)
   if (matchesPattern(event)) return true

--- a/packages/control-plane/src/persistence/repositories/hook.repo.ts
+++ b/packages/control-plane/src/persistence/repositories/hook.repo.ts
@@ -351,7 +351,9 @@ const DURABLE_GITHUB_REDELIVERY_EVENTS = new Set([
   'pull_request',
   'issue_comment',
   'pull_request_review_comment',
-  'push'
+  'push',
+  'deployment',
+  'deployment_status'
 ])
 /** Only ordinary GitHub webhook families can be reconstructed from the App's
  * delivery list. Generic webhooks and Check rererequests use the Relay's short

--- a/packages/control-plane/test/integration/hooks.route.test.ts
+++ b/packages/control-plane/test/integration/hooks.route.test.ts
@@ -536,6 +536,34 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
       expect(other.statusCode).toBe(200)
     })
 
+    it('POST accepts a deployment subscription, state patterns included, as one more family of the repo', async () => {
+      const agentId = await githubAgent()
+      await seedRelay()
+      await seedInstallation()
+      const a = ghApp()
+
+      const body = ghBody(agentId, {
+        name: 'deploy-hook',
+        family: 'deployment',
+        events: ['deployment:*', 'deployment_status:failure'],
+        commentFamilies: [],
+        labelFilter: []
+      })
+      const created = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: body })
+      expect(created.statusCode).toBe(200)
+      expect(created.json()).toMatchObject({
+        family: 'deployment',
+        events: ['deployment:*', 'deployment_status:failure'],
+        commentFamilies: []
+      })
+      // Beside the issues row of the same repo — the family is the row's identity.
+      const issues = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: ghBody(agentId) })
+      expect(issues.statusCode).toBe(200)
+      const dup = await a.app.inject({ method: 'POST', url: `${ORG}/hooks`, payload: body })
+      expect(dup.statusCode).toBe(409)
+      expect((dup.json() as { message: string }).message).toMatch(/already watches acme\/infra \(deployment\)/)
+    })
+
     it('the agents list carries hookKinds marks for enabled triggers', async () => {
       const agentId = await githubAgent()
       await seedRelay()
@@ -865,6 +893,8 @@ describe('hooks REST — CRUD, ingress gating, secret echo, runs, audit', () => 
         // A pattern belonging to another family — that family has its own row.
         [{ family: 'pull_request', events: ['pull_request:*', 'issues:opened'] }, /"issues:opened"/],
         [{ family: 'push', events: ['push:*', 'issue_comment:created'] }, /"issue_comment:created"/],
+        // A status rides the deployment row alone.
+        [{ family: 'issues', events: ['issues:*', 'deployment_status:*'] }, /"deployment_status:\*"/],
         // An unscoped issue_comment is the legacy repo-wide meaning: it would
         // double-fire against the sibling row that owns the other thread family.
         [

--- a/packages/daemon/src/messages/hook-message.ts
+++ b/packages/daemon/src/messages/hook-message.ts
@@ -108,6 +108,11 @@ function clampSessionTitle(title: string): string {
 function githubSessionTitle(msg: RdMsgHook): string | undefined {
   const context = msg.context
   if (context?.source !== 'github') return undefined
+  // A deployment session is the environment's: every deployment there continues it.
+  if (isGithubDeploymentDelivery(context) && context.environment) {
+    const repo = msg.github?.repoFullName ?? context.repo
+    return clampSessionTitle(`Deployment ${repo ? `${repo} → ` : ''}${context.environment}`)
+  }
 
   const subjectKind =
     msg.github?.subjectKind ??
@@ -159,10 +164,20 @@ function deliveryMessage(body: string): { message: string; rest?: string } {
   return { message: '', rest: body }
 }
 
-/** `issues:opened — acme/infra#42` — the event's one-line identity. */
+/** `deployment` / `deployment_status` — the environment, not a thread, is the subject. */
+function isGithubDeploymentDelivery(c: HookContext): boolean {
+  return c.event === 'deployment' || c.event === 'deployment_status'
+}
+
+/** `issues:opened — acme/infra#42` (or `… — acme/infra → production`) — the event's one-line identity. */
 function githubSubjectLine(c: HookContext): string {
   const event = c.action ? `${c.event}:${c.action}` : (c.event ?? 'event')
-  const where = c.number !== undefined ? `${c.repo ?? ''}#${c.number}` : (c.repo ?? '')
+  const where =
+    c.number !== undefined
+      ? `${c.repo ?? ''}#${c.number}`
+      : c.environment
+        ? `${c.repo ? `${c.repo} ` : ''}→ ${c.environment}`
+        : (c.repo ?? '')
   return `${event}${where ? ` — ${where}` : ''}`
 }
 
@@ -321,6 +336,9 @@ function buildGithubHookText(
     ...(github?.baseSha ? [`Base SHA: ${github.baseSha}`] : []),
     ...(github?.headSha ? [`Head SHA: ${github.headSha}`] : []),
     ...(github?.isDraft !== undefined ? [`Draft: ${github.isDraft}`] : []),
+    ...(c.environment ? [`Environment: ${c.environment}`] : []),
+    ...(c.ref ? [`Ref: ${c.ref}`] : []),
+    ...(c.sha ? [`Commit: ${c.sha}`] : []),
     ...(c.htmlUrl ? [c.htmlUrl] : [])
   ].join('\n')
   // Ordinary replies use the display context's number. Inline replies instead
@@ -512,12 +530,14 @@ export function buildHookTurnFacts(msg: RdMsgHook): CodehostTurnFacts | undefine
         ? 'conversation'
         : undefined
   const base = github?.baseSha
-  const head = github?.headSha
+  // A deployment carries no trusted PR metadata; its commit is the deployed one.
+  const head = github?.headSha ?? c.sha
+  const deployment = isGithubDeploymentDelivery(c)
   return {
     provider: 'github',
     ...common,
     subject: {
-      ...(github?.subjectKind ? { kind: github.subjectKind } : {}),
+      ...(github?.subjectKind ? { kind: github.subjectKind } : deployment ? { kind: 'deployment' } : {}),
       ...(github?.repoFullName || c.repo ? { repo: github?.repoFullName ?? c.repo } : {}),
       ...((github?.pullNumber ?? c.number) !== undefined ? { number: github?.pullNumber ?? c.number } : {}),
       ...(c.title ? { title: c.title } : {}),
@@ -525,6 +545,8 @@ export function buildHookTurnFacts(msg: RdMsgHook): CodehostTurnFacts | undefine
     },
     ...(base || head ? { revision: { ...(base ? { base } : {}), ...(head ? { head } : {}) } } : {}),
     ...(github?.isDraft !== undefined ? { draft: github.isDraft } : {}),
+    ...(c.ref ? { ref: c.ref } : {}),
+    ...(c.environment ? { environment: c.environment } : {}),
     ...(review ? { review } : {})
   }
 }
@@ -550,6 +572,19 @@ const ACTION_VERBS: Record<string, string> = {
   rerequested: 'Re-requested checks on',
   requested_action: 'Requested an action on',
   submitted: 'Reviewed'
+}
+
+/** `success` → `succeeded`: a deployment state as a person reads it (the `deployment` event itself is `created`). */
+const DEPLOYMENT_STATE_VERBS: Record<string, string> = {
+  created: 'requested',
+  pending: 'pending',
+  queued: 'queued',
+  waiting: 'waiting for approval',
+  in_progress: 'in progress',
+  success: 'succeeded',
+  failure: 'failed',
+  error: 'errored',
+  inactive: 'marked inactive'
 }
 
 /** `PR #42` / `issue #42` / `MR !77` — the subject as a person would say it. */
@@ -583,6 +618,12 @@ export function hookDisplayText(msg: RdMsgHook): string | undefined {
     // thread segment IS the ref — except under `shared` / `perDelivery` keys, which name no branch.
     const { thread } = splitSessionKey(msg)
     return thread?.startsWith('refs/') ? `Pushed ${thread}` : `Pushed to ${subject}`
+  }
+  if (isGithubDeploymentDelivery(c)) {
+    // "Deployment to production failed" — the state is the news; the environment is where.
+    const where = c.environment ? `to ${c.environment}` : `of ${subject}`
+    const state = c.action ? (DEPLOYMENT_STATE_VERBS[c.action] ?? c.action.replace(/_/g, ' ')) : 'updated'
+    return `Deployment ${where} ${state}`
   }
   const verb = c.action ? ACTION_VERBS[c.action] : undefined
   if (verb) return `${verb} ${subject}${title}`

--- a/packages/daemon/test/daemon-hook.test.ts
+++ b/packages/daemon/test/daemon-hook.test.ts
@@ -4136,6 +4136,66 @@ describe('buildHookMessage', () => {
       expect(push.text).toBe('Pushed to acme/infra')
     })
 
+    it('a deployment is the environment’s session: titled by it, keyed by it, read by its state', async () => {
+      const deploy = (event: 'deployment' | 'deployment_status', action: string, bodyExcerpt?: string) =>
+        ghFire(
+          {
+            event,
+            action,
+            number: undefined,
+            title: undefined,
+            labels: undefined,
+            authorAssociation: undefined,
+            senderLogin: 'github-actions[bot]',
+            htmlUrl: 'https://github.com/acme/infra/actions/runs/1',
+            bodyExcerpt,
+            environment: 'production',
+            ref: 'main',
+            sha: 'c'.repeat(40)
+          },
+          { sessionKey: 'acme/infra#deployments/production', event: `${event}:${action}` }
+        )
+      const created = buildHookMessage(deploy('deployment', 'created', 'Deploy v1.2.3'), 'trace')
+      expect(created).toMatchObject({
+        channel: 'acme/infra',
+        thread: 'deployments/production',
+        threadUrl: 'https://github.com/acme/infra/actions/runs/1',
+        initialSessionTitle: 'Deployment acme/infra → production',
+        text: 'Deployment to production requested'
+      })
+      // Nothing to answer: no reply line, no standing rules, no review — just the facts.
+      expect(created.standingContext).toBeUndefined()
+      expect(created.turnBody?.codehost).toMatchObject({
+        provider: 'github',
+        event: 'deployment:created',
+        subject: { kind: 'deployment', repo: 'acme/infra', url: 'https://github.com/acme/infra/actions/runs/1' },
+        revision: { head: 'c'.repeat(40) },
+        ref: 'main',
+        environment: 'production',
+        body: 'Deploy v1.2.3'
+      })
+      expect(created.turnBody?.codehost?.review).toBeUndefined()
+      expect(created.turnBody?.codehost?.subject.number).toBeUndefined()
+
+      const failed = deploy('deployment_status', 'failure', 'Deploy failed: healthcheck timed out')
+      expect(buildHookMessage(failed, 'trace').text).toBe('Deployment to production failed')
+      expect(buildHookMessage(deploy('deployment_status', 'in_progress'), 'trace').text).toBe(
+        'Deployment to production in progress'
+      )
+      const text = buildHookText(failed)
+      expect(text).toContain('GitHub deployment_status:failure — acme/infra → production')
+      expect(text).toContain('From: github-actions[bot]')
+      expect(text).toContain('Environment: production')
+      expect(text).toContain('Ref: main')
+      expect(text).toContain(`Commit: ${'c'.repeat(40)}`)
+      expect(text).toContain('https://github.com/acme/infra/actions/runs/1')
+      // The description is still third-party text: fenced, never on the header.
+      const beginAt = text.indexOf(UNTRUSTED_CONTENT_BEGIN)
+      expect(beginAt).toBeGreaterThan(text.indexOf('Commit:'))
+      expect(text.slice(beginAt)).toContain('healthcheck timed out')
+      expect(text).not.toContain('The daemon owns the reply')
+    })
+
     it('requires a formal verdict for an authorized explicit PR review mention', async () => {
       const text = buildHookText(
         ghFire(

--- a/packages/protocol/src/frames/hook.ts
+++ b/packages/protocol/src/frames/hook.ts
@@ -215,8 +215,8 @@ export type PublishedHookOutput = z.infer<typeof PublishedHookOutput>
 export const HookContext = z.object({
   source: z.enum(HOOK_KINDS),
   // ── github (P2) ──
-  event: z.string().optional(), // 'issues' | 'pull_request' | 'issue_comment'
-  action: z.string().optional(), // 'opened' | 'synchronize' | 'created' | …
+  event: z.string().optional(), // 'issues' | 'pull_request' | 'issue_comment' | 'deployment' | 'deployment_status'
+  action: z.string().optional(), // 'opened' | 'synchronize' | 'created' | … (a deployment_status carries its state here)
   repo: z.string().optional(), // 'owner/repo'
   number: z.number().int().optional(), // issue/PR number
   title: z.string().optional(),
@@ -226,6 +226,10 @@ export const HookContext = z.object({
   labels: z.array(z.string()).optional(),
   htmlUrl: z.string().optional(),
   bodyExcerpt: z.string().optional(), // ≤4 KiB
+  // ── github deployment (no thread: the environment is the subject) ──
+  environment: z.string().optional(), // 'production'
+  ref: z.string().optional(), // the deployed ref, as GitHub names it
+  sha: z.string().optional(), // the deployed commit
   // ── webhook ──
   body: z.string().optional(), // raw body, truncated to ≤64 KiB
   truncated: z.boolean().optional()

--- a/packages/protocol/src/user-turn-body.ts
+++ b/packages/protocol/src/user-turn-body.ts
@@ -28,7 +28,7 @@ export const CodehostTurnFacts = z.object({
   event: z.string(),
   action: z.string().optional(),
   subject: z.object({
-    kind: z.string().optional(), // issue | pull_request | merge_request | push
+    kind: z.string().optional(), // issue | pull_request | merge_request | push | deployment
     repo: z.string().optional(),
     number: z.number().int().optional(),
     title: z.string().optional(),
@@ -39,6 +39,8 @@ export const CodehostTurnFacts = z.object({
   revision: z.object({ base: z.string().optional(), head: z.string().optional() }).optional(),
   draft: z.boolean().optional(),
   ref: z.string().optional(),
+  /** The target environment of a deployment delivery. */
+  environment: z.string().optional(),
   /** The event body as delivered (an issue/PR description or a comment), already relay-bounded. */
   body: z.string().optional(),
   truncated: z.boolean().optional(),

--- a/packages/relay/src/hooks/github-ingress.test.ts
+++ b/packages/relay/src/hooks/github-ingress.test.ts
@@ -2485,6 +2485,22 @@ describe('github ingress', () => {
       expect(h.reports.map((r) => r.event)).toEqual(['deployment_status:failure'])
     })
 
+    it('skips the empty-string URLs GitHub defaults omitted status fields to', async () => {
+      h.table.upsert(rule({}, { events: ['deployment_status:*'] }))
+      await post('deployment_status', deploymentStatusPayload({ state: 'success', log_url: '', target_url: '' }), {
+        headers: { 'x-github-delivery': 'ds-env-url' }
+      })
+      await post(
+        'deployment_status',
+        deploymentStatusPayload({ state: 'success', log_url: '', target_url: '', environment_url: '' }),
+        { headers: { 'x-github-delivery': 'ds-run-url' } }
+      )
+      await flush()
+      const urls = h.sent.map((m) => (m.source === 'hook' ? m.context?.htmlUrl : undefined))
+      // The first non-empty link wins: the environment URL, then the workflow run that created the deployment.
+      expect(urls).toEqual(['https://app.example.test', 'https://github.com/acme/infra/actions/runs/1'])
+    })
+
     it('`deployment_status:*` takes every state; thread and push subscriptions take none', async () => {
       h.table.upsert(rule({}, { events: ['deployment:*', 'deployment_status:*'] }))
       h.table.upsert(rule({ hookId: HOOK_B }, { events: ['issues:opened', 'pull_request:*', 'push:*'] }))

--- a/packages/relay/src/hooks/github-ingress.test.ts
+++ b/packages/relay/src/hooks/github-ingress.test.ts
@@ -118,6 +118,40 @@ function pullPayload(overrides: Record<string, unknown> = {}): Record<string, un
   }
 }
 
+/** A GitHub Actions deployment — the sender is the Actions bot, as it is for nearly every deployment. */
+function deploymentPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    action: 'created',
+    installation: { id: INSTALLATION },
+    repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
+    sender: { login: 'github-actions[bot]', type: 'Bot' },
+    deployment: {
+      id: 9001,
+      sha: 'c'.repeat(40),
+      ref: 'main',
+      task: 'deploy',
+      environment: 'production',
+      description: 'Deploy v1.2.3'
+    },
+    workflow_run: { html_url: 'https://github.com/acme/infra/actions/runs/1' },
+    ...overrides
+  }
+}
+
+/** A status posted against that deployment; GitHub's action is always `created`, the news is `state`. */
+function deploymentStatusPayload(status: Record<string, unknown> = {}): Record<string, unknown> {
+  return deploymentPayload({
+    deployment_status: {
+      state: 'failure',
+      description: 'Deploy failed: healthcheck timed out',
+      log_url: 'https://github.com/acme/infra/actions/runs/1/job/2',
+      target_url: null,
+      environment_url: 'https://app.example.test',
+      ...status
+    }
+  })
+}
+
 function rerequestPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     action: 'rerequested',
@@ -2388,6 +2422,80 @@ describe('github ingress', () => {
         repository: { id: REPO_ID, full_name: 'acme/infra', owner: { login: 'acme', type: 'Organization' } },
         sender: { login: 'alice', type: 'User' }
       })
+      expect(res.statusCode).toBe(202)
+      await flush()
+      expect(h.sent).toHaveLength(0)
+    })
+
+    it('a deployment fires on `deployment:created` with per-environment affinity — bot sender and all', async () => {
+      h.table.upsert(rule({}, { events: ['deployment:created'] }))
+      const res = await post('deployment', deploymentPayload())
+      expect(res.statusCode).toBe(202)
+      await flush()
+      expect(h.sent).toHaveLength(1)
+      const msg = h.sent[0]!
+      if (msg.source !== 'hook') throw new Error('expected hook member')
+      expect(msg.sessionKey).toBe('acme/infra#deployments/production')
+      expect(msg.event).toBe('deployment:created')
+      // No issue/PR subject ⇒ no trusted review metadata, and no number.
+      expect(msg.github).toBeUndefined()
+      expect(msg.context?.number).toBeUndefined()
+      expect(msg.context).toMatchObject({
+        source: 'github',
+        event: 'deployment',
+        action: 'created',
+        repo: 'acme/infra',
+        senderLogin: 'github-actions[bot]',
+        environment: 'production',
+        ref: 'main',
+        sha: 'c'.repeat(40),
+        htmlUrl: 'https://github.com/acme/infra/actions/runs/1',
+        bodyExcerpt: 'Deploy v1.2.3'
+      })
+      // No thread actor: trusted on the installation gate, no live authorization round-trip.
+      expect(h.authzRequests).toHaveLength(0)
+      expect(h.reports[0]?.event).toBe('deployment:created')
+    })
+
+    it('a deployment_status is matched by the state it carries, never by GitHub’s invariant `created`', async () => {
+      h.table.upsert(rule({}, { events: ['deployment_status:failure'] }))
+      await post('deployment_status', deploymentStatusPayload({ state: 'success', description: 'Deployed' }), {
+        headers: { 'x-github-delivery': 'ds-ok' }
+      })
+      await flush()
+      expect(h.sent).toHaveLength(0)
+
+      await post('deployment_status', deploymentStatusPayload(), { headers: { 'x-github-delivery': 'ds-failed' } })
+      await flush()
+      expect(h.sent).toHaveLength(1)
+      const msg = h.sent[0]!
+      if (msg.source !== 'hook') throw new Error('expected hook member')
+      expect(msg.event).toBe('deployment_status:failure')
+      expect(msg.msgId).toBe(`${HOOK}:ds-failed`)
+      // The same environment key as the deployment that opened it.
+      expect(msg.sessionKey).toBe('acme/infra#deployments/production')
+      expect(msg.context).toMatchObject({
+        event: 'deployment_status',
+        action: 'failure',
+        environment: 'production',
+        // The status log wins over the environment URL and the workflow run.
+        htmlUrl: 'https://github.com/acme/infra/actions/runs/1/job/2',
+        bodyExcerpt: 'Deploy failed: healthcheck timed out'
+      })
+      expect(h.reports.map((r) => r.event)).toEqual(['deployment_status:failure'])
+    })
+
+    it('`deployment_status:*` takes every state; thread and push subscriptions take none', async () => {
+      h.table.upsert(rule({}, { events: ['deployment:*', 'deployment_status:*'] }))
+      h.table.upsert(rule({ hookId: HOOK_B }, { events: ['issues:opened', 'pull_request:*', 'push:*'] }))
+      await post('deployment_status', deploymentStatusPayload({ state: 'in_progress' }))
+      await flush()
+      expect(h.sent.map((m) => m.msgId)).toEqual([`${HOOK}:gh-delivery-1`])
+    })
+
+    it('a deployment delivery without an environment has no session to continue — 202 no-op', async () => {
+      h.table.upsert(rule({}, { events: ['deployment:*'] }))
+      const res = await post('deployment', deploymentPayload({ deployment: { id: 1, sha: 'c'.repeat(40) } }))
       expect(res.statusCode).toBe(202)
       await flush()
       expect(h.sent).toHaveLength(0)

--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -476,6 +476,11 @@ function sanitizeTitle(title: string): string {
 /** A commit id as GitHub writes it; anything else is dropped rather than rendered on the trusted header. */
 const COMMIT_SHA = /^[0-9a-f]{7,64}$/i
 
+/** The first link a payload actually carries — GitHub defaults an omitted status URL to `""`, not null. */
+function firstUrl(...candidates: Array<string | null | undefined>): string | undefined {
+  return candidates.find((candidate): candidate is string => typeof candidate === 'string' && candidate !== '')
+}
+
 /** Build the trimmed envelope shared by every hook this delivery fans out to
  *  (exported for unit tests). Comment fields win over the subject's for
  *  `issue_comment` deliveries — the comment is what fired. Push deliveries have
@@ -495,14 +500,15 @@ export function buildGithubContext(event: string, payload: GithubPayload): HookC
     ''
   const excerpt = truncateUtf8(bodySource, GITHUB_BODY_EXCERPT_MAX)
   const action = githubEventAction(event, payload)
-  const htmlUrl =
-    payload.comment?.html_url ??
-    subject?.html_url ??
-    payload.compare ??
-    status?.log_url ??
-    status?.target_url ??
-    status?.environment_url ??
-    (deployment ? payload.workflow_run?.html_url : undefined)
+  const htmlUrl = firstUrl(
+    payload.comment?.html_url,
+    subject?.html_url,
+    payload.compare,
+    status?.log_url,
+    status?.target_url,
+    status?.environment_url,
+    deployment ? payload.workflow_run?.html_url : undefined
+  )
   return {
     source: 'github',
     event,

--- a/packages/relay/src/hooks/github-ingress.ts
+++ b/packages/relay/src/hooks/github-ingress.ts
@@ -14,10 +14,11 @@
  * `installation` / `installation_repositories` events are not matched — they
  * become an `rc/github-installation` doorbell poke and the CP re-pulls the
  * facts from GitHub (decision 11). Subscription events (`issues`,
- * `pull_request`, `issue_comment`) match against the CP-compiled rules by
- * NUMERIC repo id, gated per rule by the org's installation set (decision 6),
- * with a bot-sender veto except for PR revisions authored by this App (decision
- * 10). Same-repository revisions enter the internal CI lane; fork revisions
+ * `pull_request`, `issue_comment`, `push`, `deployment`) match against the
+ * CP-compiled rules by NUMERIC repo id, gated per rule by the org's installation
+ * set (decision 6), with a bot-sender veto except for PR revisions authored by
+ * this App (decision 10) and for deployments, which are machine-authored by
+ * design. Same-repository revisions enter the internal CI lane; fork revisions
  * remain behind workflow approval. Every matching hook fires its own `rd/msg`
  * (msgId is hookId-prefixed, so fan-out of one delivery to several hooks never
  * self-dedups at the daemon).
@@ -54,7 +55,15 @@ export const GITHUB_BODY_LIMIT = 1024 * 1024
 export const GITHUB_BODY_EXCERPT_MAX = 4 * 1024
 
 /** The event families that are matched against hook rules (everything else: 202 no-op). */
-const SUBSCRIPTION_EVENTS = new Set(['issues', 'pull_request', 'issue_comment', 'pull_request_review_comment', 'push'])
+const SUBSCRIPTION_EVENTS = new Set([
+  'issues',
+  'pull_request',
+  'issue_comment',
+  'pull_request_review_comment',
+  'push',
+  'deployment',
+  'deployment_status'
+])
 /** The events that ring the installation doorbell instead of matching. */
 const INSTALLATION_EVENTS = new Set(['installation', 'installation_repositories'])
 
@@ -129,9 +138,37 @@ interface GithubPayload {
   workflow_run?: {
     event?: string
     head_sha?: string
+    html_url?: string
     triggering_actor?: { login?: string }
     pull_requests?: Array<{ number?: number; head?: { sha?: string } }>
   }
+  // deployment deliveries — the environment is the subject; a status carries the state.
+  deployment?: {
+    id?: number
+    sha?: string
+    ref?: string
+    environment?: string
+    description?: string | null
+  }
+  deployment_status?: {
+    state?: string // 'pending' | 'queued' | 'in_progress' | 'waiting' | 'success' | 'failure' | 'error' | 'inactive'
+    description?: string | null
+    target_url?: string | null
+    log_url?: string | null
+    environment_url?: string | null
+  }
+}
+
+/** `deployment` and `deployment_status` — one subject family, no thread, machine-authored by design. */
+export function isGithubDeploymentEvent(event: string): boolean {
+  return event === 'deployment' || event === 'deployment_status'
+}
+
+/** The action a delivery is matched and reported by: GitHub's own, except a status, whose `created`
+ *  never varies — its STATE is the axis a `deployment_status:<state>` subscription selects on. */
+export function githubEventAction(event: string, payload: GithubPayload): string | undefined {
+  if (event === 'deployment_status') return payload.deployment_status?.state ?? payload.action
+  return payload.action
 }
 
 /** The delivery's own repository. `owner.type` is GitHub's signed owner kind. */
@@ -162,7 +199,8 @@ interface GithubSubject {
 export interface GithubMatchCtx {
   event: string // 'issues'
   eventAction: string // 'issues:opened'; action-less events (push) carry just 'push' —
-  // never equal to a stored `family:action` pattern, so they match via `family:*` only
+  // never equal to a stored `family:action` pattern, so they match via `family:*` only;
+  // a deployment_status carries its state ('deployment_status:failure')
   installationId: string | undefined // String(payload.installation.id); absent ⇒ never matches
   labels: string[] // the subject's CURRENT labels (not payload.label)
   senderType: string | undefined // 'User' | 'Bot' | …
@@ -341,7 +379,10 @@ export function githubRuleVerdict(rule: RcHookAssign, ctx: GithubMatchCtx): Gith
     return 'no-match'
   // Decision 10: bot-authored comments/review-comments and unrelated bot PRs
   // remain vetoed; only this App's same-repository PR revisions enter review.
-  if (ctx.senderType === 'Bot' && !isConfiguredAppPullRequest(rule, ctx)) return 'no-match'
+  // Deployments are exempt: Actions and deploy Apps author nearly all of them,
+  // and nothing here posts back into a deployment, so no loop can form.
+  if (ctx.senderType === 'Bot' && !isConfiguredAppPullRequest(rule, ctx) && !isGithubDeploymentEvent(ctx.event))
+    return 'no-match'
   // Decision 6(a): the org-attribution gate. An event that cannot prove its
   // installation does not fire.
   if (!ctx.installationId || !rule.github.installationIds.includes(ctx.installationId)) return 'no-match'
@@ -406,8 +447,11 @@ export function githubRuleVerdict(rule: RcHookAssign, ctx: GithubMatchCtx): Gith
     return 'no-match'
 
   // GitHub's relationship labels are descriptive, not an authorization proof: MEMBER and
-  // COLLABORATOR may still hold read only. Every numbered-thread event resolves the live role.
-  return ctx.event === 'push' || isInternalAppPullRequest(rule, ctx) ? 'trusted' : 'needs-authz'
+  // COLLABORATOR may still hold read only. Every numbered-thread event resolves the live role;
+  // a push or a deployment has no thread actor, so the installation gate is its whole proof.
+  return ctx.event === 'push' || isGithubDeploymentEvent(ctx.event) || isInternalAppPullRequest(rule, ctx)
+    ? 'trusted'
+    : 'needs-authz'
 }
 
 /** Truncate on a UTF-8 BYTE budget, cutting at a code-point boundary — the
@@ -429,18 +473,40 @@ function sanitizeTitle(title: string): string {
   return flat.length > 200 ? `${flat.slice(0, 199)}…` : flat
 }
 
+/** A commit id as GitHub writes it; anything else is dropped rather than rendered on the trusted header. */
+const COMMIT_SHA = /^[0-9a-f]{7,64}$/i
+
 /** Build the trimmed envelope shared by every hook this delivery fans out to
  *  (exported for unit tests). Comment fields win over the subject's for
  *  `issue_comment` deliveries — the comment is what fired. Push deliveries have
- *  no subject: the head commit message is the excerpt, the compare URL the link. */
+ *  no subject: the head commit message is the excerpt, the compare URL the link.
+ *  A deployment's excerpt is its (status) description; its link is the status
+ *  log, target or environment URL, else the workflow run that created it. */
 export function buildGithubContext(event: string, payload: GithubPayload): HookContext {
   const subject = payload.issue ?? payload.pull_request
-  const bodySource = payload.comment?.body ?? subject?.body ?? payload.head_commit?.message ?? ''
+  const deployment = isGithubDeploymentEvent(event) ? payload.deployment : undefined
+  const status = event === 'deployment_status' ? payload.deployment_status : undefined
+  const bodySource =
+    payload.comment?.body ??
+    subject?.body ??
+    status?.description ??
+    deployment?.description ??
+    payload.head_commit?.message ??
+    ''
   const excerpt = truncateUtf8(bodySource, GITHUB_BODY_EXCERPT_MAX)
+  const action = githubEventAction(event, payload)
+  const htmlUrl =
+    payload.comment?.html_url ??
+    subject?.html_url ??
+    payload.compare ??
+    status?.log_url ??
+    status?.target_url ??
+    status?.environment_url ??
+    (deployment ? payload.workflow_run?.html_url : undefined)
   return {
     source: 'github',
     event,
-    ...(payload.action ? { action: payload.action } : {}),
+    ...(action ? { action } : {}),
     ...(payload.repository?.full_name ? { repo: payload.repository.full_name } : {}),
     ...(subject?.number !== undefined ? { number: subject.number } : {}),
     ...(subject?.title ? { title: sanitizeTitle(subject.title) } : {}),
@@ -450,27 +516,29 @@ export function buildGithubContext(event: string, payload: GithubPayload): HookC
       ? { authorAssociation: payload.comment?.author_association ?? subject?.author_association }
       : {}),
     ...(subject?.labels ? { labels: subject.labels.map((l) => l.name ?? '').filter(Boolean) } : {}),
-    ...((payload.comment?.html_url ?? subject?.html_url ?? payload.compare)
-      ? { htmlUrl: payload.comment?.html_url ?? subject?.html_url ?? payload.compare }
-      : {}),
+    ...(htmlUrl ? { htmlUrl } : {}),
     ...(excerpt.text ? { bodyExcerpt: excerpt.text } : {}),
+    // The environment and ref ride the daemon's trusted header line, so they get the title's defanging.
+    ...(deployment?.environment ? { environment: sanitizeTitle(deployment.environment) } : {}),
+    ...(deployment?.ref ? { ref: sanitizeTitle(deployment.ref) } : {}),
+    ...(deployment?.sha && COMMIT_SHA.test(deployment.sha) ? { sha: deployment.sha } : {}),
     truncated: excerpt.truncated
   }
 }
 
 /**
  * Cut the body-free, trusted subject/revision envelope for one matched rule.
- * Push has no issue/PR subject and therefore returns undefined: review/check
- * settings are PR-only. A PR issue_comment has no revision in GitHub's payload;
- * it still carries repo/pull identity and the daemon resolves the SHA before
- * the hook/start barrier.
+ * Push and deployment have no issue/PR subject and therefore return undefined:
+ * review/check settings are PR-only. A PR issue_comment has no revision in
+ * GitHub's payload; it still carries repo/pull identity and the daemon resolves
+ * the SHA before the hook/start barrier.
  */
 export function buildTrustedGithubMetadata(
   event: string,
   payload: GithubPayload,
   rule: RcHookAssign
 ): GithubHookMetadata | undefined {
-  if (!rule.github || event === 'push') return undefined
+  if (!rule.github || event === 'push' || isGithubDeploymentEvent(event)) return undefined
   const installationId = payload.installation?.id
   const repoId = payload.repository?.id
   if (installationId === undefined || repoId === undefined || String(repoId) !== rule.github.repoId) return undefined
@@ -987,15 +1055,25 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
       const repoId = payload.repository?.id
       const subject = payload.issue ?? payload.pull_request
       const rules = repoId === undefined ? [] : deps.table.getByRepoId(String(repoId))
-      // Thread events need a subject number; push ("commits") events need a ref.
-      const thread = subject?.number !== undefined ? String(subject.number) : event === 'push' ? payload.ref : undefined
+      // Thread events need a subject number; push ("commits") events need a ref; a
+      // deployment needs its environment — every deployment there continues one session.
+      const environment = isGithubDeploymentEvent(event) ? payload.deployment?.environment : undefined
+      const thread =
+        subject?.number !== undefined
+          ? String(subject.number)
+          : event === 'push'
+            ? payload.ref
+            : environment
+              ? `deployments/${environment}`
+              : undefined
       if (rules.length === 0 || thread === undefined) return reply.code(202).send({ deliveryKey })
 
       const cleanupEvent = githubThreadWorktreeCleanupEvent(event, payload)
+      const action = githubEventAction(event, payload)
       const ctx: GithubMatchCtx = {
         event,
         // Action-less events (push) stay bare — they only ever match `family:*`.
-        eventAction: cleanupEvent ?? (payload.action ? `${event}:${payload.action}` : event),
+        eventAction: cleanupEvent ?? (action ? `${event}:${action}` : event),
         installationId: payload.installation?.id !== undefined ? String(payload.installation.id) : undefined,
         labels: (subject?.labels ?? []).map((l) => l.name ?? '').filter(Boolean),
         senderType: payload.sender?.type,
@@ -1017,6 +1095,7 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
               : undefined,
         // push: a summon may sit in ANY pushed commit's message, not just the
         // head (GitHub ships ≤20 in the payload — enough for the mention gate).
+        // A deployment's only authored text is its (status) description.
         mentionText:
           payload.comment?.body ??
           subject?.body ??
@@ -1024,11 +1103,14 @@ export function registerGithubIngress(app: FastifyInstance, deps: GithubIngressD
             ? [payload.head_commit?.message, ...(payload.commits ?? []).map((c) => c.message)]
                 .filter(Boolean)
                 .join('\n') || undefined
-            : undefined)
+            : isGithubDeploymentEvent(event)
+              ? (payload.deployment_status?.description ?? payload.deployment?.description ?? undefined)
+              : undefined)
       }
       const context = buildGithubContext(event, payload)
-      // Session affinity: issue/PR thread (`prefix#42`) or the pushed branch
-      // (`prefix#refs/heads/main`) — the daemon splits on the LAST '#'.
+      // Session affinity: issue/PR thread (`prefix#42`), the pushed branch
+      // (`prefix#refs/heads/main`) or the deployment environment
+      // (`prefix#deployments/production`) — the daemon splits on the LAST '#'.
       // The compiled prefix is immutable across GitHub repository renames.
       const fallbackSessionKeyPrefix = payload.repository?.full_name ?? String(repoId)
       const firedAt = new Date(deps.clock.now()).toISOString()

--- a/packages/setup/src/github-app.ts
+++ b/packages/setup/src/github-app.ts
@@ -42,6 +42,7 @@ export const GITHUB_APP_PERMISSIONS = {
   actions: 'write',
   checks: 'write',
   workflows: 'write',
+  deployments: 'read',
   emails: 'read'
 } as const
 
@@ -55,6 +56,8 @@ export const GITHUB_APP_EVENTS = [
   'check_run',
   'check_suite',
   'workflow_run',
+  'deployment',
+  'deployment_status',
   'release',
   'repository'
 ] as const

--- a/packages/web/src/components/console/UserTurnDetails.tsx
+++ b/packages/web/src/components/console/UserTurnDetails.tsx
@@ -51,6 +51,7 @@ export function CodehostTurnFacts({ facts }: { facts: CodehostFacts }) {
           {revisionText ? <span className="font-mono text-[11.5px]">{revisionText}</span> : ''}
         </FactRow>
         <FactRow label="Ref">{facts.ref ?? ''}</FactRow>
+        <FactRow label="Environment">{facts.environment ?? ''}</FactRow>
         <FactRow label="Draft">{facts.draft === true ? 'yes' : ''}</FactRow>
         <FactRow label="Labels">{facts.labels?.length ? facts.labels.join(', ') : ''}</FactRow>
         <FactRow label="Review">{facts.review ? REVIEW_LABEL[facts.review] : ''}</FactRow>

--- a/packages/web/src/components/console/modals/AddIntegrationModal.tsx
+++ b/packages/web/src/components/console/modals/AddIntegrationModal.tsx
@@ -171,6 +171,11 @@ const GH_TRIGGER_TILES: Partial<Record<GhFamily, TriggerTile<GhTriggerMode>[]>> 
     { mode: 'first', label: GH_TRIGGER_LABEL.first, desc: 'A new issue is filed' },
     { mode: 'labeled', label: GH_TRIGGER_LABEL.labeled, desc: 'A label is applied' },
     { mode: 'mention', label: GH_TRIGGER_LABEL.mention, desc: 'Only when the agent is @-mentioned' }
+  ],
+  // A deployment has no thread: nobody opens or @-mentions in it, so two cadences, worded for it.
+  deployment: [
+    { mode: 'first', label: 'created', desc: 'A deployment is created' },
+    { mode: 'every', label: 'any status', desc: 'Every status it reports — in progress, success, failure' }
   ]
 }
 
@@ -224,7 +229,7 @@ function FamilyCards<F extends string, M extends string>({
   familyAttr: 'data-github-family' | 'data-gitlab-family'
   triggerAttr: 'data-github-trigger' | 'data-gitlab-trigger'
   /** Hover copy that goes BEYOND the tile's own subtitle, which the user can already read. */
-  titleOf: (mode: M) => string
+  titleOf: (mode: M, fam: F) => string
   bodyExtra?: (fam: F) => ReactNode
 }) {
   return (
@@ -281,7 +286,10 @@ function FamilyCards<F extends string, M extends string>({
                   <div>
                     <div className="fldlbl mb-2">Trigger when</div>
                     <div
-                      className="grid grid-cols-1 gap-2 desktop:grid-cols-3"
+                      // One column per tile: a two-cadence subject must not leave a hole in a 3-up grid.
+                      className={`grid grid-cols-1 gap-2 ${
+                        tilesOf(row.fam).length === 2 ? 'desktop:grid-cols-2' : 'desktop:grid-cols-3'
+                      }`}
                       role="group"
                       aria-label={`Trigger for ${row.pill}`}
                     >
@@ -293,7 +301,7 @@ function FamilyCards<F extends string, M extends string>({
                             type="button"
                             {...{ [triggerAttr]: `${row.fam}:${tile.mode}` }}
                             aria-pressed={picked}
-                            title={titleOf(tile.mode)}
+                            title={titleOf(tile.mode, row.fam)}
                             className={`flex min-w-0 cursor-pointer items-start gap-[9px] rounded-[9px] border px-3 py-[10px] text-left ${
                               picked
                                 ? 'border-(--brand) bg-(--brand-soft)'
@@ -1818,10 +1826,10 @@ export default function AddIntegrationModal({
                   onPick={(fam, mode) => setGhModes((prev) => ({ ...prev, [fam]: mode }))}
                   familyAttr="data-github-family"
                   triggerAttr="data-github-trigger"
-                  titleOf={(mode) =>
+                  titleOf={(mode, fam) =>
                     mode === 'mention'
                       ? githubMentionUsage(agent.name, ghTeamOwner)
-                      : githubTriggerTooltip(mode, agent.name)
+                      : githubTriggerTooltip(mode, agent.name, fam)
                   }
                   // Reviews and Checks ride the change-proposal subject, so the
                   // format section lives in that card's body and nowhere else.

--- a/packages/web/src/components/console/views/AgentDetailView.tsx
+++ b/packages/web/src/components/console/views/AgentDetailView.tsx
@@ -1803,11 +1803,11 @@ export default function AgentDetailView() {
                               {/* Trigger — the same ⚡ dropdown the IM channel rows carry, mention last. */}
                               <TriggerSelect
                                 className="w-[126px] flex-none"
-                                // Per family: the label cadence exists on issues alone.
+                                // Per family: the label cadence exists on issues alone, and a deployment reads its own copy.
                                 options={ghRowTriggerModes(h).map((mode) => ({
                                   value: mode,
                                   label: GH_TRIGGER_PILL[mode],
-                                  hint: githubTriggerTooltip(mode, da.name)
+                                  hint: githubTriggerTooltip(mode, da.name, githubHookFamily(h) ?? undefined)
                                 }))}
                                 value={triggerModeOf(h)}
                                 onChange={(mode) => void setHookCadence(h, mode)}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -4065,7 +4065,7 @@ export type GithubCommentFamily = 'issues' | 'pull_request'
 export type GitlabCommentFamily = 'issues' | 'merge_request'
 /** The subject family ONE code-host row covers: a row is `(agent, repo, family)`,
  *  each with its own cadence and mention gate, and the family is immutable. */
-export type GithubHookFamily = 'pull_request' | 'issues' | 'push'
+export type GithubHookFamily = 'pull_request' | 'issues' | 'push' | 'deployment'
 export type GitlabHookFamily = 'merge_request' | 'issues' | 'push'
 /** The stored union across code hosts; each row carries only its own host's subset. */
 export type HookCommentFamily = GithubCommentFamily | GitlabCommentFamily

--- a/packages/web/src/lib/code-host-hook-groups.ts
+++ b/packages/web/src/lib/code-host-hook-groups.ts
@@ -11,8 +11,8 @@ import type { HookDto } from './api'
 import { GH_FAMILIES, githubHookFamily, type GhFamily } from './github-events'
 import { GL_FAMILIES, gitlabHookFamily, type GlFamily } from './gitlab-events'
 
-// Sibling order for one repo: the change-proposal subject (it carries reviews), then issues, then the held-back push.
-const GH_ROW_ORDER: readonly GhFamily[] = ['pull_request', 'issues', 'push']
+// Sibling order for one repo: the change-proposal subject (it carries reviews), issues, deployments, then the held-back push.
+const GH_ROW_ORDER: readonly GhFamily[] = ['pull_request', 'issues', 'deployment', 'push']
 const GL_ROW_ORDER: readonly GlFamily[] = ['merge_request', 'issues', 'push']
 
 /** One listed subscription: its row, the family it covers (null on a legacy-inert row), and its place in the block. */

--- a/packages/web/src/lib/github-events.test.ts
+++ b/packages/web/src/lib/github-events.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   commentFamiliesForFamilies,
+  DEPLOYMENT_CREATED_EVENT,
+  DEPLOYMENT_STATUS_EVENT,
   eventsForFamilies,
   GH_FAMILIES,
   GH_TRIGGER_LABEL,
@@ -26,6 +28,8 @@ describe('GH_TRIGGER_LABEL', () => {
     expect(githubDefaultTriggerMode('issues')).toBe('first')
     expect(githubDefaultTriggerMode('push')).toBe('first')
     expect(GH_TRIGGER_LABEL[githubDefaultTriggerMode('issues')]).toBe('opened')
+    // A deployment watch is about how it ends, so it opens on every status.
+    expect(githubDefaultTriggerMode('deployment')).toBe('every')
   })
 
   it('spells the cadences out for the create surfaces', () => {
@@ -40,6 +44,14 @@ describe('githubTriggerModes', () => {
     expect(githubTriggerModes('issues')).toEqual(['first', 'every', 'labeled', 'mention'])
     expect(githubTriggerModes('pull_request')).toEqual(['first', 'every', 'mention'])
     expect(githubTriggerModes('push')).toEqual(['first', 'every', 'mention'])
+  })
+
+  it('offers a deployment only the two plain cadences — nobody labels or @-mentions in one', () => {
+    expect(githubTriggerModes('deployment')).toEqual(['first', 'every'])
+    expect(githubTriggerTooltip('first', 'reviewer', 'deployment')).toBe('Runs when a deployment is created.')
+    expect(githubTriggerTooltip('every', 'reviewer', 'deployment')).toContain('every status it reports')
+    // The family-less form keeps reading as the thread copy.
+    expect(githubTriggerTooltip('first', 'reviewer', 'issues')).toBe(githubTriggerTooltip('first', 'reviewer'))
   })
 })
 
@@ -82,11 +94,11 @@ describe('GH_TRIGGER_PILL', () => {
 
 describe('GH_FAMILIES', () => {
   it('names each subject without promising signals its cadences do not carry', () => {
-    expect(GH_FAMILIES.map(({ label }) => label)).toEqual(['Pull requests', 'Issues'])
+    expect(GH_FAMILIES.map(({ label }) => label)).toEqual(['Pull requests', 'Issues', 'Deployments'])
   })
 
   it('omits the commit (push) family — the subscription flow is held back for now', () => {
-    expect(GH_FAMILIES.map(({ fam }) => fam)).toEqual(['pull_request', 'issues'])
+    expect(GH_FAMILIES.map(({ fam }) => fam)).toEqual(['pull_request', 'issues', 'deployment'])
   })
 
   it('still labels a stored push row the console never offers', () => {
@@ -157,11 +169,34 @@ describe('githubFamilySubscription', () => {
     )
   })
 
+  it('compiles a deployment row to its creation or to creation plus every status, with no reply scope', () => {
+    expect(githubFamilySubscription('deployment', 'first')).toEqual({
+      events: [DEPLOYMENT_CREATED_EVENT],
+      commentFamilies: [],
+      mentionOnly: false
+    })
+    expect(githubFamilySubscription('deployment', 'every')).toEqual({
+      events: ['deployment:*', DEPLOYMENT_STATUS_EVENT],
+      commentFamilies: [],
+      mentionOnly: false
+    })
+    // Cadences a deployment cannot carry narrow to the opening and never set the mention gate.
+    expect(githubFamilySubscription('deployment', 'mention')).toEqual(githubFamilySubscription('deployment', 'first'))
+    expect(githubFamilySubscription('deployment', 'labeled')).toEqual(githubFamilySubscription('deployment', 'first'))
+  })
+
   it('never emits a pattern from another family', () => {
-    for (const fam of ['pull_request', 'issues', 'push'] as const) {
+    for (const fam of ['pull_request', 'issues', 'push', 'deployment'] as const) {
       for (const mode of GH_TRIGGER_MODES) {
         const { events } = githubFamilySubscription(fam, mode)
-        expect(events.every((event) => event.startsWith(`${fam}:`) || event === THREAD_COMMENT_EVENT)).toBe(true)
+        expect(
+          events.every(
+            (event) =>
+              event.startsWith(`${fam}:`) ||
+              event === THREAD_COMMENT_EVENT ||
+              (fam === 'deployment' && event === DEPLOYMENT_STATUS_EVENT)
+          )
+        ).toBe(true)
       }
     }
   })
@@ -176,12 +211,16 @@ describe('githubFamilyCarriesReviews', () => {
 })
 
 describe('commentFamiliesForFamilies', () => {
-  it('keeps the selected issue and PR families while excluding push', () => {
-    expect(commentFamiliesForFamilies(['issues', 'push', 'pull_request'])).toEqual(['issues', 'pull_request'])
+  it('keeps the selected issue and PR families while excluding push and deployment', () => {
+    expect(commentFamiliesForFamilies(['issues', 'push', 'deployment', 'pull_request'])).toEqual([
+      'issues',
+      'pull_request'
+    ])
   })
 
   it('returns an empty scope when no thread family is selected', () => {
     expect(commentFamiliesForFamilies(['push'])).toEqual([])
+    expect(commentFamiliesForFamilies(['deployment'])).toEqual([])
   })
 })
 
@@ -250,6 +289,27 @@ describe('githubHookNeedsNormalization', () => {
     ).toBe(false)
   })
 
+  it('accepts both canonical deployment encodings and flags a hand-written state pattern', () => {
+    expect(
+      githubHookNeedsNormalization({ events: [DEPLOYMENT_CREATED_EVENT], commentFamilies: [], mentionOnly: false })
+    ).toBe(false)
+    expect(
+      githubHookNeedsNormalization({
+        events: ['deployment:*', DEPLOYMENT_STATUS_EVENT],
+        commentFamilies: [],
+        mentionOnly: false
+      })
+    ).toBe(false)
+    // An API-only `deployment_status:failure` row is not what the console writes for "any status".
+    expect(
+      githubHookNeedsNormalization({
+        events: ['deployment:*', 'deployment_status:failure'],
+        commentFamilies: [],
+        mentionOnly: false
+      })
+    ).toBe(true)
+  })
+
   it('accepts a canonical labeled row', () => {
     expect(githubHookNeedsNormalization({ events: ['issues:labeled'], commentFamilies: [], mentionOnly: false })).toBe(
       false
@@ -274,5 +334,13 @@ describe('triggerModeOf', () => {
   it('keeps reading the opened and updated encodings', () => {
     expect(triggerModeOf({ events: ['issues:opened'], mentionOnly: false })).toBe('first')
     expect(triggerModeOf({ events: ['issues:*', THREAD_COMMENT_EVENT], mentionOnly: false })).toBe('every')
+  })
+
+  it('reads a bare deployment opening as created and anything wider as any status', () => {
+    expect(triggerModeOf({ events: [DEPLOYMENT_CREATED_EVENT], mentionOnly: false })).toBe('first')
+    expect(triggerModeOf({ events: ['deployment:*', DEPLOYMENT_STATUS_EVENT], mentionOnly: false })).toBe('every')
+    expect(triggerModeOf({ events: [DEPLOYMENT_CREATED_EVENT, DEPLOYMENT_STATUS_EVENT], mentionOnly: false })).toBe(
+      'every'
+    )
   })
 })

--- a/packages/web/src/lib/github-events.ts
+++ b/packages/web/src/lib/github-events.ts
@@ -3,18 +3,19 @@ import type { GithubCommentFamily, GithubHookFamily, HookCommentFamily } from '.
 /**
  * GitHub subscription event model shared by the Add-integration form and the
  * agent-detail pills. A stored row covers exactly ONE family (pull requests /
- * issues / commits) and carries its own TRIGGER MODE ("when"), so a repository
- * watched for both PRs and issues is two rows; the family is immutable, and the
- * row's stored `events` patterns plus its `mentionOnly` flag encode the mode:
+ * issues / deployments / commits) and carries its own TRIGGER MODE ("when"), so a
+ * repository watched for both PRs and issues is two rows; the family is immutable,
+ * and the row's stored `events` patterns plus its `mentionOnly` flag encode the mode:
  *
  *   opened   → `family:opened` for the regular cadence; the relay additionally accepts a later explicit
  *              @mention in the row's thread family (commits have no "first"
  *              — a push subscription is inherently per-push, so `push:*` rides
- *              along unchanged)
+ *              along unchanged; a deployment's "first" is `deployment:created`)
  *   any update → `family:*` + `issue_comment:created` on a thread family, scoped
  *              to that family by `commentFamilies`. The relay ignores
  *              close/reopen and content edits; PR target-branch changes, other
- *              supported updates, and replies run.
+ *              supported updates, and replies run. A deployment row adds
+ *              `deployment_status:*` — every status GitHub posts against it.
  *   labeled  → `issues:labeled` alone. Issues-only, and the one cadence that
  *              subscribes to no replies at all: a label is applied to a thread,
  *              not said in it. A `labelFilter` intersects the issue's CURRENT
@@ -46,6 +47,7 @@ export interface GhFamilyTile {
 const GH_ALL_FAMILIES: GhFamilyTile[] = [
   { fam: 'pull_request', pill: 'PRs', icon: 'git-pull-request', label: 'Pull requests' },
   { fam: 'issues', pill: 'Issues', icon: 'circle-dot', label: 'Issues' },
+  { fam: 'deployment', pill: 'Deploys', icon: 'rocket', label: 'Deployments' },
   { fam: 'push', pill: 'Commits', icon: 'git-commit-horizontal', label: 'Commits' }
 ]
 
@@ -82,8 +84,10 @@ export const GH_TRIGGER_PILL: Record<GhTriggerMode, string> = {
   mention: '@-mention'
 }
 
-/** Label events ride the issues subject alone — a PR row never offers or compiles one. */
+/** Label events ride the issues subject alone — a PR row never offers or compiles one. A deployment
+ *  carries no labels and no thread anyone writes in, so it offers only the two plain cadences. */
 export function githubFamilySupportsMode(fam: GhFamily, mode: GhTriggerMode): boolean {
+  if (fam === 'deployment') return mode === 'first' || mode === 'every'
   return mode !== 'labeled' || fam === 'issues'
 }
 
@@ -92,8 +96,13 @@ export function githubTriggerModes(fam: GhFamily): readonly GhTriggerMode[] {
   return GH_TRIGGER_MODES.filter((mode) => githubFamilySupportsMode(fam, mode))
 }
 
-/** Per-segment hover copy for the trigger bar. */
-export function githubTriggerTooltip(mode: GhTriggerMode, agentName: string): string {
+/** Per-segment hover copy for the trigger bar. A deployment has no thread, so its two cadences read differently. */
+export function githubTriggerTooltip(mode: GhTriggerMode, agentName: string, fam?: GhFamily): string {
+  if (fam === 'deployment') {
+    return mode === 'first'
+      ? 'Runs when a deployment is created.'
+      : 'Runs when a deployment is created and on every status it reports (in progress, success, failure, …).'
+  }
   switch (mode) {
     case 'first':
       return `Runs when an issue or PR opens, plus later @${agentName} mentions.`
@@ -121,13 +130,18 @@ export function githubMentionUsage(agentName: string, teamOwner?: string | null)
 /** The default create-form selection: pull requests only. */
 export const GH_DEFAULT_FAMILIES: readonly GhFamily[] = ['pull_request']
 
-/** The cadence a create surface opens a new subject on — a change proposal on every update, the rest on the opening. */
+/** The cadence a create surface opens a new subject on — a change proposal and a deployment on every
+ *  update (a deployment watch is about how it ends), the rest on the opening. */
 export function githubDefaultTriggerMode(fam: GhFamily): GhTriggerMode {
-  return fam === 'pull_request' ? 'every' : 'first'
+  return fam === 'pull_request' || fam === 'deployment' ? 'every' : 'first'
 }
 
 /** The comment subscription that rides updated/mention-only modes for thread families. */
 export const THREAD_COMMENT_EVENT = 'issue_comment:created'
+/** A deployment's opening: GitHub's `deployment` event, always `created`. */
+export const DEPLOYMENT_CREATED_EVENT = 'deployment:created'
+/** The status subscription that rides a deployment row's update mode — one delivery per state GitHub posts. */
+export const DEPLOYMENT_STATUS_EVENT = 'deployment_status:*'
 
 /** Narrow a stored cross-host comment scope to the GitHub families a github hook may carry. */
 export function githubCommentFamilies(families: readonly HookCommentFamily[]): GithubCommentFamily[] {
@@ -152,6 +166,9 @@ export function eventsForFamilies(fams: Iterable<GhFamily>, mode: GhTriggerMode)
   const familyEvents = families.flatMap((fam) => {
     const own = effectiveMode(fam, mode)
     if (own === 'labeled') return [`${fam}:labeled`]
+    if (fam === 'deployment') {
+      return own === 'first' ? [DEPLOYMENT_CREATED_EVENT] : [`${fam}:*`, DEPLOYMENT_STATUS_EVENT]
+    }
     if (own !== 'first' || fam === 'push') return [`${fam}:*`]
     return [`${fam}:opened`]
   })
@@ -198,10 +215,11 @@ export function githubFamilySubscription(fam: GhFamily, mode: GhTriggerMode): Gi
 const LABELED_EVENT = 'issues:labeled'
 
 /** Recover the trigger mode: the mentionOnly flag wins, the bare label
- *  subscription is labeled, and `:opened` ⇒ opened. */
+ *  subscription is labeled, and `:opened` (or a bare deployment opening) ⇒ opened. */
 export function triggerModeOf(h: { events: string[]; mentionOnly: boolean }): GhTriggerMode {
   if (h.mentionOnly) return 'mention'
   if (h.events.length === 1 && h.events[0] === LABELED_EVENT) return 'labeled'
+  if (h.events.length === 1 && h.events[0] === DEPLOYMENT_CREATED_EVENT) return 'first'
   return h.events.some((e) => e.endsWith(':opened')) ? 'first' : 'every'
 }
 


### PR DESCRIPTION
## What

A GitHub trigger can now watch a repository's **deployments**. `deployment` joins `pull_request`, `issues` and `push` as a subject family, and GitHub's `deployment_status` event rides that row.

- **Matching.** A status delivery is matched and reported by the state it carries, not by GitHub's invariant `created` action: `deployment_status:failure`, `deployment_status:success`, … or `deployment_status:*`. The `deployment` event itself stays `deployment:created`.
- **No bot veto, no thread authorization.** Nearly every deployment is authored by GitHub Actions or a deploy App, and nothing posts back into one, so the sender veto does not apply. Like a push, the delivery is trusted on the installation gate alone.
- **Session affinity.** The environment is the thread: `prefix#deployments/production`. Every deployment to one environment continues one session, so the agent that watched the last release sees the next, and worktrees stay bounded by environments rather than deployments.
- **Prompt and transcript.** The trusted header carries `Environment`, `Ref` and `Commit`; the (status) description stays inside the untrusted fence like any third-party text. The console reads the turn as "Deployment to production failed" and titles the session by repository and environment; the turn's facts fold shows the environment.
- **Console.** The wizard and the agent page offer a **Deployments** subject with two cadences: `created` (`deployment:created`) and `any status` (`deployment:*` + `deployment_status:*`). No label or mention gate — nobody writes in a deployment. Finer state selection is API-only.
- **Setup Server.** The App manifest requests `deployments: read` and subscribes to `deployment` and `deployment_status`; the audit flags an existing App that lacks them.
- **Redelivery.** GitHub's delivery summary hides the status state, so the reconciler offers a `deployment_status` GUID to any status subscription and the relay's own filter decides.

## Operator note

An App created before this change must add the `deployments: read` permission and the `deployment` / `deployment_status` event subscriptions by hand in its settings — GitHub exposes no API for event subscriptions — and installations then approve the new permission. The Setup Server audit shows the drift.

## Tests

Relay ingress (four new cases: created, state matching, wildcard fan-out, missing environment), CP family shape and reconciler unit tests, the hooks route integration suite, daemon rendering, and the web catalog. `pnpm typecheck`, eslint and prettier are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
