### PR TITLE
chore(docker): correct the shim direction in the daemon stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -188,10 +188,9 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 FROM node:24-bookworm-slim AS daemon
 WORKDIR /app/packages/daemon
 ENV NODE_ENV=production \
-  AC_K8S_SHIM_HOST=0.0.0.0 \
+  # The port the daemon DIALS on a ready sandbox pod's IP — the shim listens there, not here.
   AC_K8S_SHIM_PORT=8085 \
-  # The kubelet is the supervisor: it restarts the container, and an in-pod
-  # self-upgrade would exit for a version the cluster never asked for.
+  # The kubelet is the supervisor: it restarts the container, so an in-pod self-upgrade would exit for a version the cluster never asked for.
   AGENTCONNECT_SUPERVISOR=k8s
 
 # git is load-bearing even here: a self-hosted agent on this daemon still clones
@@ -223,9 +222,6 @@ RUN groupadd --gid 10002 daemon-user \
 ENV HOME=/var/lib/agentconnect
 USER 10002:10002
 
-# The shim callback endpoint. Sandboxes dial IN to this; the daemon never dials
-# into a sandbox, which is what lets a sandbox keep zero inbound rules.
-EXPOSE 8085
 # tini so a SIGTERM reaches the daemon and its drain actually runs — without it
 # PID 1 ignores the signal and every rollout ends in SIGKILL mid-drain.
 ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION
The daemon stage of `docker/Dockerfile` still described the shim as a daemon-side
callback endpoint that sandboxes dial in to, with the daemon never dialling into a
sandbox. The direction reversed since then, and both the design and the code now say
the opposite:

- `docs/designs/cluster-spawn-and-shim.md` §2 — "The shim listens; the daemon dials the
  ready pod's IP", and "The daemon no longer exposes a shim listener."
- `packages/daemon/src/shim/server.ts` is the sandbox-side WebSocket listener,
  `packages/daemon/src/shim/dialer.ts` is the daemon-side dialer, and
  `packages/daemon/src/k8s/runtime-plane.ts` resolves `AC_K8S_SHIM_PORT` and combines it
  with the ready pod's IP.

So the comment is replaced with a one-line one on `AC_K8S_SHIM_PORT` itself, saying that
the value is the port the daemon dials on the pod, not a port it binds.

Two listener-era leftovers went with it:

- `EXPOSE 8085` — nothing in this image listens there. The port the shim actually binds is
  declared by the runtime sandbox image (`docker/runtime-sandbox.Dockerfile`), which sets
  `AC_SHIM_PORT` and its own `EXPOSE`.
- `AC_K8S_SHIM_HOST=0.0.0.0` — a bind address, and `grep` finds no reader for it anywhere
  in the tree. It was the listener's host and has no meaning for a dialer.

`AC_K8S_SHIM_PORT=8085` stays: `resolveK8sPlaneSettings` reads it as the dialer's target
port, so it is live configuration, not a listener declaration.

Scope is that one file. The `AGENTCONNECT_SUPERVISOR` comment in the same `ENV` block was
condensed to one line per the repo's comment style, since the block was being edited.

`docker build --check --target daemon` reports no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
