### PR TITLE
fix(daemon): answer every Slack elicitation in the message, and drop the modal

### DIFF
--- a/evals/test/connection-surface.test.ts
+++ b/evals/test/connection-surface.test.ts
@@ -60,8 +60,7 @@ const EXEMPT: Record<string, string> = {
   // Interactive Slack surfaces (Block Kit actions / modals) are driven by
   // Bolt callbacks the virtual transport never receives; the daemon only
   // invokes them from those callbacks.
-  openStatusModal: 'interactivity-only (status modal from a Bolt action)',
-  openView: 'interactivity-only (elicitation form modal from a Bolt action or a forwarded trigger_id)'
+  openStatusModal: 'interactivity-only (status modal from a Bolt action)'
 }
 
 function recordingConnection() {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1599,9 +1599,7 @@ export class Daemon {
       statusInfoForKey: (key) => this.statusInfoForKey(key),
       handlePermissionChoice: (a) => this.permissions.handlePermissionChoice(a),
       handleElicitChoice: (a) => this.permissions.handleElicitChoice(a),
-      handleElicitConfirm: (a) => void this.permissions.confirmElicitSelection(a),
-      handleElicitFormOpen: (a) => void this.permissions.openElicitFormModal(a),
-      handleElicitFormSubmit: (a) => this.permissions.submitElicitForm(a),
+      handleElicitFormSubmit: (a) => void this.permissions.submitElicitForm(a),
       handleDiscordSelect: (a) => this.commands.handleDiscordSelect(a),
       handleTelegramCallback: (cb, conn) => this.commands.handleTelegramCallback(cb, conn),
       slackShortcutSession: (shortcut, srcIntegrationIds) =>
@@ -6423,11 +6421,6 @@ export class Daemon {
       return { kind: 'rejected', reason: 'suppressed' }
     }
 
-    // A live `text`/`number` elicitation card is answered by a reply in its own thread, and while
-    // it waits the ACP prompt is still blocked — so the reply is intercepted as the answer here,
-    // before routing could dispatch or queue it as a turn of its own (#1794's Slack column).
-    if (await this.permissions.answerElicitReply(msg)) return { kind: 'rejected', reason: 'suppressed' }
-
     const threadOwner = await this.prefetchedThreadOwner(msg)
     const result = routeRules(msg, routingRules, () => threadOwner)
     // Participant delivery is independent of whether the single-target ladder found an
@@ -7058,9 +7051,6 @@ export class Daemon {
       await this.commands.handleCommand(command, normalized, target)
       return { msgId: msg.msgId, accepted: true }
     }
-    // The same elicitation-reply interception the direct path applies, at the same point in the
-    // ladder: both Slack ingresses behave identically for every other elicitation verb too.
-    if (await this.permissions.answerElicitReply(normalized)) return { msgId: msg.msgId, accepted: true }
     // HTTP-bot ingress bypasses onInbound(), so repeat its `!stop` thread-mute gate:
     // while muted, implicit routing (thread affinity / keyword / auto / dm) never
     // dispatches — only an explicit @mention does, and it clears the mute. Muted traffic
@@ -7656,28 +7646,11 @@ export class Daemon {
     } else if (payload.kind === 'elicitation-choice') {
       await this.permissions.handleElicitChoice({ requestId: payload.requestId, value: payload.value, actor })
     } else if (payload.kind === 'elicitation-confirm') {
-      await this.permissions.confirmElicitSelection({
-        requestId: payload.requestId,
-        values: payload.values,
-        actor
-      })
-    } else if (payload.kind === 'elicitation-open') {
-      // The trigger id is one-shot and short-lived: open on this daemon's own bot token now,
-      // exactly as open-config above does, and let rd/ack be the relay receipt it always was.
-      void this.permissions.openElicitFormModal({
-        requestId: payload.requestId,
-        triggerId: payload.triggerId,
-        conn
-      })
-    } else if (payload.kind === 'elicitation-submit') {
-      // The ONE Slack action whose verdict Slack itself is waiting for: the per-field errors ride
-      // back on the ack's opaque `response`, which the relay surfaces verbatim on its 200.
-      const response = await this.permissions.submitElicitForm({
+      await this.permissions.submitElicitForm({
         requestId: payload.requestId,
         fields: payload.fields,
         ...(actor ? { actor } : {})
       })
-      return { msgId: msg.msgId, accepted: true, ...(response ? { response } : {}) }
     } else {
       await this.commands.handleStatusAction({ kind: 'cancel', sessionKey: msg.sessionKey, actor })
     }

--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -27,28 +27,22 @@ import { SlackConnection } from '../slack/connection.js'
 import type { InteractionActor } from '../platforms/contract.js'
 import {
   buildApprovalDmIntro,
-  buildElicitFormClosedModal,
   buildElicitationCard,
   buildElicitationFormCard,
-  buildElicitationFormModal,
   buildElicitationResolvedCard,
   buildPermissionCard,
   buildPermissionResolvedCard,
   buildUrlConsentCard,
   buildUrlConsentResolvedCard,
   clampTo,
-  decodeSlackReplyValue,
-  ELICIT_REPLY_KINDS,
+  elicitCardShape,
   elicitFieldLabel,
   elicitForm,
   elicitFormFieldLabel,
   elicitFormAccepts,
-  elicitFormClosedResponse,
   elicitFormContent,
-  elicitFormErrorResponse,
+  elicitFormRefusalNotice,
   elicitFormSubmission,
-  elicitReplyAnswer,
-  elicitReplyExpectation,
   elicitRequiredProps,
   elicitTarget,
   elicitUrl,
@@ -57,7 +51,6 @@ import {
   numberAccepts,
   SLACK_DM_ELICIT_SURFACE,
   SLACK_ELICIT_SURFACE,
-  stripLeadingSelfMention,
   textAccepts,
   WEBCHAT_ELICIT_SURFACE
 } from '../slack/render.js'
@@ -77,10 +70,6 @@ import {
   type ApprovalRequestParts
 } from '../daemon/tool-classification.js'
 import { pendingTurnKey, type DaemonRenderAction, type Pending } from '../daemon/turn-types.js'
-import { slackTsFromMsgId } from '../daemon/helpers.js'
-import { isTrustedHumanTurn } from '../daemon/loop-guard-scope.js'
-import { transcriptChannelKey } from '../store/local-store.js'
-import type { NormalizedMessage } from '../messages/normalized.js'
 
 /** The union of a turn's explicit human-approval waits, measured here and nowhere else.
  *  Regeneration budgets subtract it while retaining runtime/tool work time; `depth` counts
@@ -243,51 +232,6 @@ function consentedUrlKey(owner: HostKey, elicitationId: string): string {
   return `${owner}\x00${elicitationId}`
 }
 
-/** Where a reply-answered Slack card takes its answer from — the whole interception, held on the
- *  card's own record so it can never outlive it. `conversation` is the platform plus the turn's
- *  transcript channel, so another Slack app watching the same channel is a different
- *  conversation; `thread` is the turn's own thread, so another thread of that channel is not the
- *  answer either. A DM session ALSO takes a top-level message there, since a DM reader answers
- *  where they are talking rather than in a thread. `requesterId` is the turn's requester when it
- *  is known — the only person the card then waits for. */
-interface ElicitReplyTarget {
-  conversation: string
-  thread: string
-  dm: boolean
-  requesterId?: string
-}
-
-/** The conversation half of {@link ElicitReplyTarget}, from either side: a live turn's plan or an
- *  inbound message. Both spell the channel the way the transcript does, scope included. */
-function elicitReplyConversation(platform: string, transcriptChannel: string): string {
-  return `${platform}\x00${transcriptChannel}`
-}
-
-/** Is this message a reply INTO someone else's thread, rather than a root of its own?
- *
- *  Slack normalization sets `thread` to `thread_ts ?? ts`, so it is never absent and a top-level
- *  message carries its OWN id there — which is exactly how a root is told apart from a reply,
- *  once you compare the two rather than test for absence. Derived here rather than preserved as a
- *  new normalized field: nothing was lost in normalization, `thread` has some forty readers whose
- *  meaning must not shift under them, and a new wire field would need a skew window on both
- *  ingress paths for a fact already in hand. */
-function isThreadReply(msg: NormalizedMessage): boolean {
-  return msg.thread !== undefined && msg.thread !== slackTsFromMsgId(msg.msgId)
-}
-
-/** The reply target a live turn's card takes: its own conversation and thread, and its requester
- *  where the turn names one. `unknown` is not a person — a turn whose author could not be
- *  identified waits for anyone in the thread instead, which is what the card then says. */
-function elicitReplyTargetFor(p: Pending): ElicitReplyTarget {
-  const requester = p.plan.requesterId
-  return {
-    conversation: elicitReplyConversation(p.plan.platform, p.plan.transcriptChannel),
-    thread: p.plan.statusThread,
-    dm: p.plan.isDm === true,
-    ...(requester && requester !== 'unknown' ? { requesterId: requester } : {})
-  }
-}
-
 /** One outstanding `elicitation/create` awaiting a human answer. */
 type PendingElicit = PendingElicitSurface & {
   owner: HostKey
@@ -296,21 +240,17 @@ type PendingElicit = PendingElicitSurface & {
   params: CreateElicitationRequest
   propName: string
   kind: ElicitKind
-  /** Set only for a MULTI-field form card — webchat's, or Slack's Answer-button-plus-modal —
-   *  the fields it rendered, in schema order. Absent ⇒ the single-field card, answered by a
-   *  scalar or a list as it always was. */
+  /** Set on every card whose fields are `input` blocks — webchat's multi-field card and Slack's
+   *  Confirm-bearing one — the fields it rendered, in schema order. Absent ⇒ a one-tap button
+   *  row, answered by a scalar as it always was. */
   form?: ElicitTarget[]
-  /** Set beside `form` on a SLACK form card: the opaque session target its modal carries in
-   *  `private_metadata`, so a relay-forwarded submission routes back to this daemon. It is the
-   *  same value the card's own `block_id` carries, and it names nothing about the reader. */
+  /** Set beside `form` on a SLACK form card: the opaque session target its actions block carries,
+   *  so a relay-forwarded Confirm routes back to this daemon. It names nothing about the reader. */
   sessionTarget?: string
   /** Set only for a URL-mode consent card: the ACP `elicitationId` and the exact URL shown.
    *  Present ⇒ `propName`/`kind`/`form` mean nothing — the card has no field, and its only
    *  answers are consent (this same URL back) or Dismiss. */
   url?: { elicitationId: string; url: string }
-  /** Set only for a card answered by a THREAD REPLY ({@link ELICIT_REPLY_KINDS}) — the reply this
-   *  card takes as its answer. Absent on every card whose answer is a tap. */
-  reply?: ElicitReplyTarget
   approval: boolean
   resolve: (res: CreateElicitationResponse) => void
 }
@@ -1473,27 +1413,21 @@ export class PermissionCoordinator {
     // A second SURFACE for #1810's URL mode: the notice is only for an ask Slack still cannot render.
     if (url) return await this.awaitSlackUrlElicitation(agentId, sessionId, params, p, conn, url)
     if (params.mode === 'url') return this.noticeUnrenderableElicit(p, params, isApproval)
-    // A form asking more than one QUESTION cannot be a row of buttons: an `actions` block holds
-    // no inputs at all, so it becomes an Answer button plus a modal — the one shape on this
-    // surface that needs one (#1794's Slack column). An approval never takes it: allow/deny is a
-    // single enum, and chat approval's own bookkeeping lives on the single-field path below.
-    const form = isApproval ? null : elicitForm(params, SLACK_ELICIT_SURFACE)
-    if (form && form.filter((t) => !t.customAnswerFor).length > 1)
+    // ONE reduction decides the card's shape (#1794's Slack column). Anything the reader has to
+    // fill in before submitting — several questions, a question with its own free-text box, a
+    // multi-select, a typed box — is a card of `input` blocks with one Confirm; only a lone
+    // single-select or boolean, which one tap answers, keeps its row of buttons below. An approval
+    // is allow/deny by construction, so it is always the button row: chat approval has no shape
+    // for a filled-in field, and its own bookkeeping lives on the button path.
+    const form = elicitForm(params, SLACK_ELICIT_SURFACE)
+    if (!form) return this.noticeUnrenderableElicit(p, params, isApproval)
+    if (elicitCardShape(form) === 'inputs') {
+      if (isApproval) return this.noticeUnrenderableElicit(p, params, isApproval)
       return await this.awaitSlackFormElicitation(agentId, sessionId, params, p, conn, form)
-    const target = elicitTarget(params, SLACK_ELICIT_SURFACE)
-    if (!target) return this.noticeUnrenderableElicit(p, params, isApproval)
-    // A `text`/`number` card has nothing to tap: the reader answers by replying in the thread,
-    // and the card says whose reply it waits for. An approval never takes this shape — allow/deny
-    // is an enum — so the interception only ever belongs to a plain question.
-    const reply = ELICIT_REPLY_KINDS.has(target.kind) ? elicitReplyTargetFor(p) : undefined
+    }
+    const target = form[0]!
     const requestId = isApproval ? randomUUID() : `elicit-${++this.elicitSeq}`
-    const blocks = buildElicitationCard(
-      requestId,
-      params,
-      this.host.httpSlackSessionTarget(p),
-      SLACK_ELICIT_SURFACE,
-      reply?.requesterId ? `<@${reply.requesterId}>` : undefined
-    )
+    const blocks = buildElicitationCard(requestId, params, this.host.httpSlackSessionTarget(p), SLACK_ELICIT_SURFACE)
     if (!blocks) return this.noticeUnrenderableElicit(p, params, isApproval)
     const fallback = (params as { message?: string }).message ?? 'The agent needs your input'
     let resolveResult!: (res: CreateElicitationResponse) => void
@@ -1505,7 +1439,6 @@ export class PermissionCoordinator {
       params,
       propName: target.propName,
       kind: target.kind,
-      ...(reply ? { reply } : {}),
       approval: isApproval,
       surface: 'slack',
       conn,
@@ -1776,15 +1709,13 @@ export class PermissionCoordinator {
   }
 
   /**
-   * Slack's peer of {@link awaitWebchatElicitation}: post the multi-field card — the question, a
-   * line naming what will be asked, an Answer button and Dismiss — and park the resolver until
-   * the modal behind Answer is submitted, Dismiss is tapped, or the turn ends. The fields live in
-   * the modal because Slack's `actions` block holds none, and the modal itself is built on demand
-   * from these same `params`, so nothing pre-rendered is stored anywhere.
+   * Slack's peer of {@link awaitWebchatElicitation}: post the card whose fields are `input` blocks
+   * in the message itself — the question, one input per field, Confirm and Dismiss — and park the
+   * resolver until Confirm is tapped, Dismiss is tapped, or the turn ends.
    *
-   * A form no modal can hold (an enum option value past Slack's select cap, a minimum length past
-   * an input's) is declined with the same notice every other unrenderable ask gets — checked HERE,
-   * before the card is posted, so the reader is never offered an Answer button with no modal.
+   * A form no card can hold (an enum option value past Slack's select cap, a minimum length past
+   * an input's) is declined with the same notice every other unrenderable ask gets: the builder
+   * returns null and nothing is posted.
    */
   private async awaitSlackFormElicitation(
     agentId: string,
@@ -1796,9 +1727,8 @@ export class PermissionCoordinator {
   ): Promise<CreateElicitationResponse | undefined> {
     const requestId = `elicit-${++this.elicitSeq}`
     const sessionTarget = this.host.httpSlackSessionTarget(p)
-    if (!buildElicitationFormModal(requestId, params, form, sessionTarget))
-      return this.noticeUnrenderableElicit(p, params, false)
     const blocks = buildElicitationFormCard(requestId, params, form, sessionTarget)
+    if (!blocks) return this.noticeUnrenderableElicit(p, params, false)
     const fallback = (params as { message?: string }).message ?? 'The agent needs your input'
     let resolveResult!: (res: CreateElicitationResponse) => void
     const result = new Promise<CreateElicitationResponse>((resolve) => (resolveResult = resolve))
@@ -1843,55 +1773,47 @@ export class PermissionCoordinator {
   }
 
   /**
-   * Open a live form card's modal (SlackDeps.onElicitFormOpen, and the relay's
-   * `elicitation-open`). The view is BUILT HERE, from the card's own params, on both ingress
-   * paths — so the two produce the same modal by construction, and the relay never holds,
-   * renders or caches any part of it. Opened on the card's OWN connection, which is the bot
-   * token that posted it.
-   *
-   * A request id with no live form card — already answered, dismissed, cancelled, or simply
-   * never ours — opens the closed modal instead of nothing at all: a stale client still shows
-   * the Answer button, and this is the difference between an explanation and a dead button.
+   * The field list a live card's `input` blocks were built from, re-derived from its OWN params
+   * rather than read back off the record (#1815) — the same reduction, on the same surface, so it
+   * is the very list the card rendered. Null when this card has no inputs to submit.
    */
-  async openElicitFormModal(a: { requestId: string; triggerId: string; conn: SlackConnection }): Promise<void> {
-    const rec = this.pendingElicits.get(a.requestId)
-    const form = rec?.form && rec.surface === 'slack' ? elicitForm(rec.params, surfaceOf(rec)) : null
-    const view = rec && form ? buildElicitationFormModal(a.requestId, rec.params, form, rec.sessionTarget) : null
-    // A closed card is told on the connection the tap arrived through: the record that would
-    // have named one is exactly what is missing.
-    await a.conn.openView(a.triggerId, view ?? buildElicitFormClosedModal())
+  private cardForm(rec: PendingElicit): ElicitTarget[] | null {
+    return rec.form ? elicitForm(rec.params, surfaceOf(rec)) : null
   }
 
   /**
-   * Answer a form card from its modal's `view_submission` (SlackDeps.onElicitFormSubmit, and the
-   * relay's `elicitation-submit`). The whole record is re-derived against the form THAT CARD
-   * rendered, exactly as webchat's is (#1807) and as every tapped option is (#1815): the rendered
-   * property set, every `required` name present, an omitted optional field allowed, each value
-   * valid for its own field. One bad field refuses the submission with that field's own error and
-   * leaves the card live — Dismiss stays the only explicit refusal.
+   * Answer a form card from its Confirm tap (SlackDeps.onElicitFormSubmit, and the relay's
+   * `elicitation-confirm`). `fields` is the message state that tap carried, so it is what THIS
+   * reader had filled in; nothing is held between a field change and the Confirm. The whole
+   * record is re-derived against the form THAT CARD rendered, exactly as webchat's is (#1807) and
+   * as every tapped option is (#1815): the rendered property set, every `required` name present,
+   * an omitted optional field allowed, each value valid for its own field.
    *
-   * Resolves to the response Slack is given: undefined closes the modal, `errors` keeps it open,
-   * and an already-settled card is replaced by the closed view — which is what a SECOND reader
-   * sees when someone else's submission got there first.
+   * One bad field refuses the whole answer, says which in the thread — a message card has no
+   * modal to hand the errors back to — and leaves the card LIVE, which is the same verdict every
+   * other surface's re-derivation reaches. Dismiss stays the only explicit refusal.
    */
   async submitElicitForm(a: {
     requestId: string
     fields: Record<string, string | string[]>
     actor?: InteractionActor
-  }): Promise<Record<string, unknown> | undefined> {
+  }): Promise<void> {
     const rec = this.pendingElicits.get(a.requestId)
-    const form = rec?.form && rec.surface === 'slack' ? elicitForm(rec.params, surfaceOf(rec)) : null
-    if (!rec || !form) return elicitFormClosedResponse()
+    if (!rec || rec.surface !== 'slack' || !rec.form) return
+    const form = this.cardForm(rec)
+    if (!form) return
     const submission = elicitFormSubmission(rec.params, form, a.fields)
-    if (submission.errors) return elicitFormErrorResponse(submission.errors)
-    // No await between the check above and the settlement below, so two concurrent submissions
-    // cannot both pass: the loser finds no record and is answered with the closed view.
+    if (submission.errors) {
+      this.noticeInTurn(rec, elicitFormRefusalNotice(rec.params, form, submission.errors))
+      return
+    }
+    // No await between the check above and the settlement below, so two concurrent Confirms
+    // cannot both pass: the loser finds no record at all.
     await this.handleElicitChoice({
       requestId: a.requestId,
       value: submission.answer ?? {},
       ...(a.actor ? { actor: a.actor } : {})
     })
-    return undefined
   }
 
   /** Rewrite a settled Slack card in place, best effort — the ACP resolution never depends on it.
@@ -2033,7 +1955,7 @@ export class PermissionCoordinator {
     if (rec.url) return await this.handleUrlElicitConsent(a.requestId, { ...rec, url: rec.url }, a)
     // A FORM card is answered by a record and nothing else, and every other card by a scalar
     // or a list — re-derived from the card's own params, exactly as `target` is below.
-    const form = rec.form ? elicitForm(rec.params, surfaceOf(rec)) : null
+    const form = this.cardForm(rec)
     if (rec.form && !form) return
     if (a.value !== null && isFormAnswer(a.value) !== !!form) return
     // Each kind takes one shape of answer and no other: a list for a multi-select, a number
@@ -2130,106 +2052,6 @@ export class PermissionCoordinator {
     rec.resolve(res)
   }
 
-  /** A tapped Confirm on a multi-select card (SlackDeps.onElicitConfirm). `values` is the
-   *  selection carried by that tap's own Slack payload, so it is the state THIS reader confirmed:
-   *  no selection is held between interactions, which is what keeps one reader's pick from being
-   *  submitted as another's answer and makes the order two interactions arrive in irrelevant. It
-   *  is a relayed value like any other, so it goes through the same answer path a button tap
-   *  takes — `multiSelectAccepts` re-derives it against the card, and a selection outside
-   *  `minItems`/`maxItems` is refused there with the card left live. */
-  async confirmElicitSelection(a: { requestId: string; values: string[]; actor?: InteractionActor }): Promise<void> {
-    const rec = this.pendingElicits.get(a.requestId)
-    if (!rec || rec.surface !== 'slack' || rec.kind !== 'multi-enum' || rec.url || rec.form) return
-    await this.handleElicitChoice({
-      requestId: a.requestId,
-      value: a.values,
-      ...(a.actor ? { actor: a.actor } : {})
-    })
-  }
-
-  /**
-   * A thread reply, while a `text`/`number` card is live, IS that card's answer rather than a new
-   * turn (issue #1794's Slack column): sending a message is what typing something already is on
-   * Slack. Called from BOTH Slack ingress paths — relay-forwarded and direct socket — before
-   * either dispatches or queues, since the ACP prompt is still blocked while the card waits.
-   *
-   * Returns true when the reply was consumed: accepted, or refused with the reason said in the
-   * thread and the card LEFT LIVE, which is the same "drop it and leave the card live" verdict
-   * every other surface's re-derivation reaches — Dismiss is the only explicit refusal. Returns
-   * false for a message that is not this card's answer, which then stays an ordinary one.
-   *
-   * Nothing is remembered here: the interception is the pending card's own `reply` target, so it
-   * is released the instant the card settles, is dismissed, or the turn ends (`releaseElicits`).
-   */
-  async answerElicitReply(msg: NormalizedMessage): Promise<boolean> {
-    // Only a human's own words answer a question — a bot echo, an automation, and this daemon's
-    // own posts all reach the same ingress. An EDIT of an earlier message never gets here at all:
-    // Slack ingress drops edit wrappers, so re-typing a past message is not an answer either.
-    if (!isTrustedHumanTurn(msg)) return false
-    // A reply that shares a file is not a typed answer, and consuming it would drop the file:
-    // it stays an ordinary message, and the card stays live for a reply that IS one.
-    if (msg.attachments?.length) return false
-    const conversation = elicitReplyConversation(msg.platform, transcriptChannelKey(msg.channel, msg.transportScope))
-    const matched: { requestId: string; rec: PendingElicit; target: ElicitTarget }[] = []
-    for (const [requestId, rec] of this.pendingElicits) {
-      const reply = rec.reply
-      if (!reply || reply.conversation !== conversation) continue
-      // The turn's OWN thread — another thread of the same channel is another conversation, word
-      // for word. A DM session ALSO takes a root message, since that is where its reader talks.
-      if (isThreadReply(msg) ? msg.thread !== reply.thread : !reply.dm) continue
-      // The requester answers their own turn; a card that could name none takes anyone in the
-      // thread. Anyone else is not answering it — their message stays an ordinary one.
-      if (reply.requesterId !== undefined && reply.requesterId !== msg.sender.id) continue
-      const target = elicitTarget(rec.params, surfaceOf(rec))
-      if (target && ELICIT_REPLY_KINDS.has(target.kind)) matched.push({ requestId, rec, target })
-    }
-    if (!matched.length) return false
-    // Two open questions in one thread cannot both be answered by one reply, and picking either
-    // would tell one runtime the reader answered a question they did not. Name the ambiguity and
-    // take nothing: the reader can dismiss one, or wait for one to settle.
-    if (matched.length > 1) {
-      this.sayElicitReplyAmbiguous(matched.map((m) => m.rec))
-      return false
-    }
-    const { requestId, rec, target } = matched[0]!
-    // What the reader actually typed, in two pure steps before any schema check: the one piece of
-    // addressing that is chrome rather than value comes off (`@bot 42` is 42), then Slack's own
-    // representation of a link is decoded (`<mailto:a@b|a@b>` is a@b), since neither is the
-    // reader's answer and both would fail validation forever. The bot id comes from the card's
-    // OWN connection, so both ingresses read the same identity, and an unresolved one (a
-    // send-only connection before `auth.test`) strips nothing.
-    const addressed = stripLeadingSelfMention(msg.text, rec.surface === 'slack' ? rec.conn.botUserId : undefined)
-    // Re-derived against the card that asked, exactly as a tapped option is (#1815).
-    const answer = elicitReplyAnswer(target, decodeSlackReplyValue(addressed))
-    if (answer === null) {
-      this.sayElicitReplyRefused(rec, target)
-      return true
-    }
-    await this.handleElicitChoice({
-      requestId,
-      value: answer,
-      actor: { userId: msg.sender.id, ...(msg.sender.name ? { name: msg.sender.name } : {}) }
-    })
-    return true
-  }
-
-  /** Say that a reply cannot answer any of the several questions open in this thread, leaving
-   *  every one of them live. ONE line per reply rather than one per card — they share the thread,
-   *  and it is the thread that is ambiguous — spoken through the first card whose turn is still
-   *  live. */
-  private sayElicitReplyAmbiguous(recs: readonly PendingElicit[]): void {
-    const text =
-      `${recs.length} questions are open in this thread, so a reply cannot answer any of them — ` +
-      'dismiss all but one, or let one settle, and the next reply answers that one.'
-    for (const rec of recs) if (this.noticeInTurn(rec, text)) return
-  }
-
-  /** Say why a reply could not be the answer, leaving the card live: an invalid reply is not a
-   *  refusal, so it does not consume the question. Dismiss remains the only one. */
-  private sayElicitReplyRefused(rec: PendingElicit, target: ElicitTarget): void {
-    this.noticeInTurn(rec, `That reply isn't ${elicitReplyExpectation(target)} — the question is still open.`)
-  }
-
   /** Post one daemon-authored line into a pending card's own turn — a notice, so it lands where
    *  every other one does. False when that turn is already gone, or when the surface refused it.
    *  Best effort by construction: no elicitation outcome depends on it. */
@@ -2239,7 +2061,7 @@ export class PermissionCoordinator {
     try {
       this.host.enqueueApply(p, { kind: 'notice', text })
     } catch (err) {
-      this.host.log().warn(`elicitation reply notice not delivered for ${rec.sessionId}: ${formatErr(err)}`)
+      this.host.log().warn(`elicitation notice not delivered for ${rec.sessionId}: ${formatErr(err)}`)
       return false
     }
     return true

--- a/packages/daemon/src/platforms/connection-reconciler.ts
+++ b/packages/daemon/src/platforms/connection-reconciler.ts
@@ -74,8 +74,6 @@ export interface PlatformActionSink {
   statusInfoForKey: NonNullable<SlackDeps['onStatusInfo']>
   handlePermissionChoice: NonNullable<SlackDeps['onPermissionChoice']>
   handleElicitChoice: NonNullable<SlackDeps['onElicitChoice']>
-  handleElicitConfirm: NonNullable<SlackDeps['onElicitConfirm']>
-  handleElicitFormOpen: NonNullable<SlackDeps['onElicitFormOpen']>
   handleElicitFormSubmit: NonNullable<SlackDeps['onElicitFormSubmit']>
   handleDiscordSelect: NonNullable<DiscordDeps['onSelectAction']>
   handleTelegramCallback(cb: TelegramCallback, conn: TelegramConnection): Promise<void>
@@ -217,8 +215,6 @@ export class ConnectionReconciler {
       onStatusInfo: (key) => this.host.statusInfoForKey(key),
       onPermissionChoice: (a) => this.host.handlePermissionChoice(a),
       onElicitChoice: (a) => this.host.handleElicitChoice(a),
-      onElicitConfirm: (a) => this.host.handleElicitConfirm(a),
-      onElicitFormOpen: (a) => this.host.handleElicitFormOpen(a),
       onElicitFormSubmit: (a) => this.host.handleElicitFormSubmit(a),
       log: this.log,
       boltDebug: this.host.boltDebug()
@@ -509,8 +505,6 @@ export class ConnectionReconciler {
             onStatusInfo: (key) => this.host.statusInfoForKey(key),
             onPermissionChoice: (a) => this.host.handlePermissionChoice(a),
             onElicitChoice: (a) => this.host.handleElicitChoice(a),
-            onElicitConfirm: (a) => this.host.handleElicitConfirm(a),
-            onElicitFormOpen: (a) => this.host.handleElicitFormOpen(a),
             onElicitFormSubmit: (a) => this.host.handleElicitFormSubmit(a),
             log: this.log
           },

--- a/packages/daemon/src/slack/connection.ts
+++ b/packages/daemon/src/slack/connection.ts
@@ -19,19 +19,13 @@ import {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
-  ELICIT_FORM_CALLBACK_ID,
-  ELICIT_OPEN_ACTION,
-  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   PERMISSION_UPDATE_ACTION,
   buildPermissionUpdateCard,
   buildStatusModal,
   buildStatusUnavailableModal,
-  decodeElicitFormMetadata,
   decodePermValue,
   elicitFormViewValues,
-  selectedOptionsFromState,
-  type SlackBlockActionsState,
   type SlackViewState,
   type SlackStreamChunk,
   type StatusBarInfo,
@@ -448,27 +442,14 @@ export interface SlackDeps {
    *  (render.buildElicitationCard). `value` is the chosen option's wire value, or null
    *  for the Dismiss button (decline). `actor` gates DM-card clicks (slack-approval-dm.md §6.4). */
   onElicitChoice?: (a: { requestId: string; value: string | null; actor?: InteractionActor }) => void
-  /** Fired when a user taps a multi-select elicitation card's Confirm button. `values` is the
-   *  selection read out of THAT tap's own message state, so it is the state this reader
-   *  confirmed — nothing is tracked between a selection change and the Confirm. */
-  onElicitConfirm?: (a: { requestId: string; values: string[]; actor?: InteractionActor }) => void
-  /** Fired when a reader taps a MULTI-FIELD elicitation card's Answer button. The fields cannot
-   *  sit on the card, so the answer is a modal: the daemon builds it from the card's own schema
-   *  and opens it on `conn` — the very connection, and the very bot token, that posted the card. */
-  onElicitFormOpen?: (a: {
-    requestId: string
-    triggerId: string
-    conn: SlackConnection
-    actor?: InteractionActor
-  }) => void
-  /** Fired when that modal is submitted. Resolves to the `view_submission` response Slack is
-   *  given: undefined closes the modal, a `response_action` payload keeps it open carrying the
-   *  per-field errors the daemon's re-validation produced. */
+  /** Fired when a reader taps an input-block elicitation card's Confirm button. `fields` is
+   *  every input of THAT tap's own message state, keyed by block id, so it is the state this
+   *  reader confirmed — nothing is tracked between a field change and the Confirm. */
   onElicitFormSubmit?: (a: {
     requestId: string
     fields: Record<string, string | string[]>
     actor?: InteractionActor
-  }) => Promise<Record<string, unknown> | undefined>
+  }) => void
   newTraceId: () => string
   log?: Logger
   /** When true, hand Bolt LogLevel.DEBUG so socket-mode internals are visible. */
@@ -506,18 +487,10 @@ type BlockActionArgs = {
     view?: { id?: string; private_metadata?: string }
     actions?: { block_id?: string }[]
     user?: { id?: string; username?: string; name?: string }
-    /** The message's full state, which a Block Kit tap carries — how a Confirm reads the
-     *  selection its own card was showing (`selectedOptionsFromState`). */
-    state?: SlackBlockActionsState
+    /** The message's full state, which a Block Kit tap carries — how a Confirm reads every
+     *  input its own card was showing (`elicitFormViewValues`). */
+    state?: SlackViewState
   }
-}
-
-/** The subset of a `view_submission` payload we read: who submitted it, the modal's opaque
- *  `private_metadata`, and every input's state. `ack` takes the response Slack applies. */
-type ViewSubmissionArgs = {
-  ack: (response?: unknown) => Promise<void>
-  body?: { user?: { id?: string; username?: string; name?: string } }
-  view?: { private_metadata?: string; state?: SlackViewState }
 }
 
 type MessageShortcutArgs = {
@@ -545,7 +518,6 @@ export type AppLike = {
   event: (type: string, handler: (args: { event: unknown }) => Promise<void> | void) => void
   action: (actionId: string | RegExp, handler: (args: BlockActionArgs) => Promise<void> | void) => void
   shortcut: (callbackId: string, handler: (args: MessageShortcutArgs) => Promise<void> | void) => void
-  view: (callbackId: string, handler: (args: ViewSubmissionArgs) => Promise<void> | void) => void
   client: {
     views: {
       open: (a: unknown) => Promise<unknown>
@@ -929,7 +901,6 @@ function sendOnlyApp(botToken: string): AppLike {
     event: () => {},
     action: () => {},
     shortcut: () => {},
-    view: () => {},
     client: client as unknown as AppLike['client'],
     start: async () => {},
     stop: async () => {}
@@ -1243,42 +1214,18 @@ export class SlackConnection implements PlatformConnection {
       await ack()
       if (action.value) this.deps.onElicitChoice?.({ requestId: action.value, value: null, actor: actorOf(body) })
     })
-    // Multi-select card (buildElicitationCard, `multi-enum`): a selection change is acked and
-    // otherwise ignored — nothing is tracked between interactions, so there is nothing to record.
-    this.app.action(new RegExp(`^${ELICIT_SELECT_ACTION}:`), async ({ ack }) => {
-      await ack()
-    })
-    // Confirm reads the selection out of its OWN payload's message state, keyed by the select's
-    // action id: that is the state this reader tapped Confirm on, whoever else touched the card.
+    // Input-block card (buildElicitationFormCard): every field is an `input`, which raises no
+    // interaction of its own, so Confirm is the only tap and it reads the WHOLE state out of its
+    // own payload — the state this reader confirmed, whoever else touched the card meanwhile.
     this.app.action(ELICIT_CONFIRM_ACTION, async ({ ack, action, body }) => {
       await ack()
       if (!action.value) return
-      const values = selectedOptionsFromState(body?.state, `${ELICIT_SELECT_ACTION}:${action.value}`)
-      // No state for the select ⇒ nothing this tap can be said to confirm; the card stays live.
-      if (values) this.deps.onElicitConfirm?.({ requestId: action.value, values, actor: actorOf(body) })
-    })
-    // Multi-field card (buildElicitationFormCard): Answer opens the modal the daemon builds from
-    // the card's own schema. The trigger id is valid ~3s, so the ack goes first and the open is
-    // not awaited — a missed window leaves the card live, and the reader taps Answer again.
-    this.app.action(ELICIT_OPEN_ACTION, async ({ ack, action, body }) => {
-      await ack()
-      const triggerId = body?.trigger_id
-      if (!action.value || !triggerId) return
       const actor = actorOf(body)
-      this.deps.onElicitFormOpen?.({ requestId: action.value, triggerId, conn: this, ...(actor ? { actor } : {}) })
-    })
-    // That modal's submission (buildElicitationFormModal). The response rides THIS ack, so a
-    // refused field returns to the modal with no relay and no second interaction involved.
-    this.app.view(ELICIT_FORM_CALLBACK_ID, async ({ ack, body, view }) => {
-      const meta = view?.private_metadata ? decodeElicitFormMetadata(view.private_metadata) : null
-      if (!meta) return await ack()
-      const actor = actorOf(body)
-      const response = await this.deps.onElicitFormSubmit?.({
-        requestId: meta.requestId,
-        fields: elicitFormViewValues(view?.state),
+      this.deps.onElicitFormSubmit?.({
+        requestId: action.value,
+        fields: elicitFormViewValues(body?.state),
         ...(actor ? { actor } : {})
       })
-      await ack(response)
     })
     log?.debug('slack: app.start → opening Socket Mode WebSocket (wss://…slack.com)…')
     await this.app.start()
@@ -1299,18 +1246,6 @@ export class SlackConnection implements PlatformConnection {
             ? buildStatusModal(data.info, sessionKey, data.link, privateMetadata, data.identity)
             : buildStatusUnavailableModal()
       })
-    } catch (err) {
-      this.deps.log?.debug(`slack: views.open failed: ${(err as Error).message}`)
-    }
-  }
-
-  /** Open one daemon-built modal on this connection's own bot token — the elicitation form's
-   *  view, on either ingress. Web API failures are logged and swallowed for the same reason
-   *  {@link openStatusModal}'s are: a one-shot trigger id cannot be retried, and the card the
-   *  view answers is still there to be tapped again. */
-  async openView(triggerId: string, view: unknown): Promise<void> {
-    try {
-      await this.app.client.views.open({ trigger_id: triggerId, view })
     } catch (err) {
       this.deps.log?.debug(`slack: views.open failed: ${(err as Error).message}`)
     }

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -3,15 +3,12 @@ import {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
-  ELICIT_FORM_CALLBACK_ID,
   ELICIT_FORM_FIELD_CAP,
   ELICIT_FORM_INPUT_ACTION,
-  ELICIT_OPEN_ACTION,
-  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   SLACK_STATUS_ACTION,
   elicitFormBlockId,
-  encodeElicitFormMetadata,
+  elicitFormBlockIndex,
   encodePermValue,
   encodeSlackStatusOverflowValue
 } from '@agentconnect.md/protocol'
@@ -19,17 +16,11 @@ export {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
-  ELICIT_FORM_CALLBACK_ID,
-  ELICIT_OPEN_ACTION,
-  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
-  decodeElicitFormMetadata,
   decodePermValue,
   elicitFormBlockId,
   elicitFormViewValues,
   encodePermValue,
-  selectedOptionsFromState,
-  type SlackBlockActionsState,
   type SlackViewState
 } from '@agentconnect.md/protocol'
 import { renderAttributionMessage, type ReplyAttributionInfo } from '../messages/attribution.js'
@@ -647,11 +638,11 @@ const SLACK_ELICIT_MAX_BUTTONS = 24
 const SLACK_SELECT_MAX_OPTIONS = 100
 const SLACK_SELECT_VALUE_CAP = 75
 
-/** Slack renders single-select and boolean as a row of buttons, multi-select as a
- *  `multi_static_select` plus a Confirm button — the select cannot submit on its own — and a
- *  `text`/`number` field as a question answered by REPLYING in the thread, since sending a
- *  message is what typing something already is on Slack. The option-taking controls carry
- *  different lists, which is why the limits are per kind rather than one number for the surface. */
+/** Slack renders a lone single-select or boolean as a row of buttons — one tap answers it — and
+ *  every other shape as `input` blocks in the message with one Confirm, since a select, a
+ *  checkbox list and a typed box all need something filled in before they can submit. The
+ *  option-taking controls carry different lists, which is why the limits are per kind rather than
+ *  one number for the surface. */
 export const SLACK_ELICIT_SURFACE: ElicitSurface = {
   kinds: new Set<ElicitKind>(['enum', 'boolean', 'multi-enum', 'text', 'number']),
   optionLimits: {
@@ -661,10 +652,9 @@ export const SLACK_ELICIT_SURFACE: ElicitSurface = {
 }
 
 /** The approval DM's card is a button row whose taps settle through the editor path, which holds
- *  no per-card selection — so a multi-select could be shown there but never confirmed, and it is
- *  withheld rather than posted dead. A `text`/`number` field is withheld for the same reason from
- *  the other end: a DM has no session thread whose replies are intercepted as the answer, so the
- *  card would ask for a reply nothing reads. Otherwise exactly the in-channel Slack surface. */
+ *  no per-card state — so every kind that needs a Confirm to submit could be shown there but never
+ *  confirmed, and all of them are withheld rather than posted dead. What is left is exactly the
+ *  one-tap half of the in-channel Slack surface. */
 export const SLACK_DM_ELICIT_SURFACE: ElicitSurface = {
   kinds: new Set<ElicitKind>(['enum', 'boolean']),
   optionLimits: { enum: { maxOptions: SLACK_ELICIT_MAX_BUTTONS } }
@@ -1174,14 +1164,8 @@ export function numberAccepts(target: ElicitTarget, value: number): boolean {
   return target.maximum === undefined || value <= target.maximum
 }
 
-/** The kinds a Slack card holds no control for and answers with a THREAD REPLY instead
- *  (issue #1794's Slack column): sending a message is what typing something already is there,
- *  where an `input` block with `dispatch_action` costs an interaction per change and buys
- *  nothing. Read by the card builder and by the ingress interception, so the two agree. */
-export const ELICIT_REPLY_KINDS: ReadonlySet<ElicitKind> = new Set<ElicitKind>(['text', 'number'])
-
-/** How a reply-answered card names the shape a `format` asks for — plain words, with an example
- *  where the shape is not one, because the reader has to type it from the card alone. */
+/** How a card names the shape a `format` asks for — plain words, with an example where the shape
+ *  is not one, because the reader has to type it from the card alone. */
 const FORMAT_EXPECTATION: Record<ElicitFormat, string> = {
   email: 'an email address',
   uri: 'a link',
@@ -1189,10 +1173,9 @@ const FORMAT_EXPECTATION: Record<ElicitFormat, string> = {
   'date-time': 'a date and time, like 2026-09-07T09:30:00Z'
 }
 
-/** What a reply-answered card asks for, in plain words and never in schema vocabulary — shown on
- *  the card and repeated when a reply does not fit, so the reader is told the same thing twice
- *  rather than two different things. Pure. */
-export function elicitReplyExpectation(target: ElicitTarget): string {
+/** What a typed field asks for, in plain words and never in schema vocabulary — said when an
+ *  entry does not fit, so the reader is told the shape rather than the schema keyword. Pure. */
+export function elicitFieldExpectation(target: ElicitTarget): string {
   if (target.kind === 'number') {
     const noun = target.integer ? 'a whole number' : 'a number'
     const { minimum: min, maximum: max } = target
@@ -1219,68 +1202,9 @@ export function elicitReplyExpectation(target: ElicitTarget): string {
   return parts.join(', ')
 }
 
-/** Slack's mention token for one user, at the very START of a message: the modern `<@U…>` and
- *  the legacy `<@U…|name>`, plus the punctuation a reader puts after an address. */
-const LEADING_MENTION_RE = /^\s*<@([A-Z0-9]+)(?:\|[^>]*)?>[ \t]*[:,]?[ \t]*/
-
-/** A reply's text with a LEADING mention of the ASKING bot removed: "@bot 42" is 42, because
- *  addressing the bot is chrome rather than value. Only that token, only this bot's own id —
- *  a mention of anyone else, a second mention, or one anywhere but the front is content, and
- *  guessing which PART of a message is the answer is how a typed answer comes back wrong. An
- *  unknown bot id (identity not resolved yet) strips nothing. Pure. */
-export function stripLeadingSelfMention(text: string, botUserId?: string): string {
-  if (!botUserId) return text
-  const found = LEADING_MENTION_RE.exec(text)
-  return found && found[1] === botUserId ? text.slice(found[0].length) : text
-}
-
-/** Slack's retrieved-message form for ONE link and nothing else: `<dest>` or `<dest|label>`,
- *  where the destination is the part BEFORE the pipe and the label is display text. Anchored on
- *  purpose — a link sitting inside prose is not this. */
-const SLACK_LINK_ONLY_RE = /^<([^|>\s]+)(?:\|[^>]*)?>$/
-
-/** The three characters Slack HTML-escapes in the text it hands back, and nothing else — so
- *  un-escaping exactly these is the lossless inverse of what the reader typed. */
-const SLACK_ENTITIES: [RegExp, string][] = [
-  [/&lt;/g, '<'],
-  [/&gt;/g, '>'],
-  [/&amp;/g, '&']
-]
-
-/** What the reader actually typed, recovered from Slack's own representation of it — the step
- *  before any schema check, because `<https://x/>` and `<mailto:a@b|a@b>` are Slack's spelling
- *  of a link, not the reader's answer, and would fail `uri`/`email` forever.
- *
- *  DECODING, never extracting: only a reply that is one link and nothing else is unwrapped, and
- *  `mailto:` comes off so an `email` field gets `a@b` rather than `mailto:a@b`. Prose with a link
- *  inside is returned whole — deciding which PART of a message is the value is the guess this
- *  route refuses to make. Entity un-escaping applies either way, since Slack escapes those three
- *  everywhere in message text. Inbound only: it has nothing to do with the outbound defusing
- *  (#1810/#1819) that keeps AGENT-authored text from becoming markup on a card. Pure. */
-export function decodeSlackReplyValue(text: string): string {
-  const trimmed = text.trim()
-  const link = SLACK_LINK_ONLY_RE.exec(trimmed)
-  const value = link ? link[1]!.replace(/^mailto:/, '') : trimmed
-  return SLACK_ENTITIES.reduce((out, [pattern, char]) => out.replace(pattern, char), value)
-}
-
-/** The digit shapes a numeric reply may take. Deliberately narrower than `Number()`, which reads
+/** The digit shapes a typed number may take. Deliberately narrower than `Number()`, which reads
  *  `0x1f`, `Infinity` and whitespace as numbers a reader plainly did not type. */
 const NUMERIC_REPLY_RE = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/
-
-/** The answer a thread reply carries for a reply-answered card, re-derived against the card
- *  itself exactly as a tapped option is: the typed value when this target would accept it, null
- *  when it would not — the caller then says why and leaves the card live. A numeric field comes
- *  back as a real JS number, so the accept content carries the schema's own type. Pure. */
-export function elicitReplyAnswer(target: ElicitTarget, reply: string): string | number | null {
-  const value = reply.trim()
-  if (target.kind === 'number') {
-    if (!NUMERIC_REPLY_RE.test(value)) return null
-    const parsed = Number(value)
-    return numberAccepts(target, parsed) ? parsed : null
-  }
-  return target.kind === 'text' && textAccepts(target, value) ? value : null
-}
 
 const BARE_URL_RE = /(?:https?:\/\/|www\.)\S+/gi
 
@@ -1328,92 +1252,140 @@ function elicitDismissButton(requestId: string): Record<string, unknown> {
   }
 }
 
-/** What a reply-answered card tells the reader to do: reply in this thread, with what, and whom
- *  the question waits for — there is nothing on the card itself to type into. `awaits` is the
- *  turn's requester as the platform spells them, absent when the card could not name one. */
-function replyInstruction(target: ElicitTarget, awaits?: string): string {
-  const ask = `Reply in this thread with ${elicitReplyExpectation(target)}.`
-  return awaits ? `${ask} Waiting for ${awaits}.` : `${ask} Anyone in this thread can answer.`
+/** Element types Slack REFUSES inside a block, by block type. Slack rejects the WHOLE message
+ *  rather than the offending block, so a card that gets this wrong never posts and its request is
+ *  cancelled with no trace in the channel — which is exactly how a `multi_static_select` in an
+ *  `actions` block took down a live session. Verified against the live API, not read off the docs:
+ *  an `actions` block answers `unsupported element: multiselect` for a multi-select and
+ *  `unsupported type` for a typed input, and an `input` block holds no button. */
+const SLACK_FORBIDDEN_ELEMENTS: Readonly<Record<string, ReadonlySet<string>>> = {
+  actions: new Set([
+    'multi_static_select',
+    'multi_external_select',
+    'multi_users_select',
+    'multi_conversations_select',
+    'multi_channels_select',
+    'plain_text_input',
+    'number_input',
+    'email_text_input',
+    'url_text_input'
+  ]),
+  input: new Set(['button', 'overflow'])
 }
 
-/** The multi-select half of {@link buildElicitationCard}: a `multi_static_select` carrying every
- *  option, a Confirm button and Dismiss, in ONE actions block so all three share the block_id the
- *  relay routes on. The select re-delivers the whole selection on each change and never submits,
- *  so Confirm carries only the request id and the daemon confirms the selection it last saw. The
- *  request id rides the select's own `action_id`, not its option values: DESELECTING EVERYTHING is
- *  a change too, and a card named only by its options could not report one. Slack caps an option
- *  value at 75 chars — a card that would overflow it is not built at all rather than posted with
- *  an option Slack would reject. Pure. */
-function buildMultiSelectElements(requestId: string, target: ElicitTarget): unknown[] | null {
-  const options = target.options.map((o) => ({
-    text: { type: 'plain_text', text: o.label, emoji: true },
-    value: o.value
-  }))
-  if (options.some((o) => o.value.length > SLACK_SELECT_VALUE_CAP)) return null
-  const seeded = Array.isArray(target.defaultValue) ? new Set(target.defaultValue) : null
-  const initial = seeded ? target.options.map((o, i) => (seeded.has(o.value) ? options[i] : null)).filter(Boolean) : []
-  return [
-    {
-      type: 'multi_static_select',
-      action_id: `${ELICIT_SELECT_ACTION}:${requestId}`,
-      placeholder: { type: 'plain_text', text: 'Select options', emoji: true },
-      options,
-      ...(initial.length ? { initial_options: initial } : {}),
-      ...(target.maxItems !== undefined ? { max_selected_items: target.maxItems } : {})
-    },
-    {
-      type: 'button',
-      action_id: ELICIT_CONFIRM_ACTION as string,
-      text: { type: 'plain_text', text: 'Confirm', emoji: true },
-      style: 'primary',
-      value: requestId
-    },
-    elicitDismissButton(requestId)
+/** How many `options` each element type holds. `checkboxes` and `radio_buttons` answer
+ *  `no more than 10 items allowed` past ten, where the select menus take a hundred — which is why
+ *  the card picks between them by list length rather than by taste. Verified against the API. */
+const SLACK_ELEMENT_MAX_OPTIONS: Readonly<Record<string, number>> = {
+  checkboxes: 10,
+  radio_buttons: 10,
+  static_select: 100,
+  multi_static_select: 100,
+  overflow: 5
+}
+
+/** The elements that HAVE a `max_selected_items`. `checkboxes` does not: Slack answers
+ *  `invalid additional property` for it, so a checkbox list's upper bound is said in the block's
+ *  hint and enforced when the answer comes back, never by the control. */
+const SLACK_MAX_SELECTED_ELEMENTS: ReadonlySet<string> = new Set([
+  'multi_static_select',
+  'multi_external_select',
+  'multi_users_select',
+  'multi_conversations_select',
+  'multi_channels_select'
+])
+
+/** Slack's own caps on one `actions` block's elements and on an option object's `value`. */
+const SLACK_ACTIONS_MAX_ELEMENTS = 25
+const SLACK_OPTION_VALUE_CAP = 75
+
+/** Every Slack rule this file has paid for, checked over one card's blocks: the element types a
+ *  block type refuses, the per-element option caps, `max_selected_items` only where it exists,
+ *  an `input` block's mandatory element, an option value past Slack's cap, and block ids unique
+ *  within the message. Returns the reasons Slack would reject the card, empty when it would take
+ *  it. Exported and asserted over every card we build, because our own JSON looks valid to us
+ *  right up until Slack sees it — which is the only reason #1825 shipped. Pure. */
+export function slackCardViolations(blocks: readonly unknown[]): string[] {
+  const bad: string[] = []
+  const seen = new Set<string>()
+  for (const [i, raw] of blocks.entries()) {
+    const b = raw as SlackBlockShape
+    if (typeof b.block_id === 'string') {
+      if (seen.has(b.block_id)) bad.push(`blocks/${i}: duplicate block_id "${b.block_id}"`)
+      seen.add(b.block_id)
+    }
+    const forbidden = SLACK_FORBIDDEN_ELEMENTS[b.type ?? ''] ?? new Set<string>()
+    if (b.type === 'input' && !b.element?.type) bad.push(`blocks/${i}: input block has no element`)
+    if (b.type === 'actions' && (b.elements?.length ?? 0) > SLACK_ACTIONS_MAX_ELEMENTS)
+      bad.push(`blocks/${i}: ${b.elements?.length} elements in an actions block, past ${SLACK_ACTIONS_MAX_ELEMENTS}`)
+    for (const el of [...(b.elements ?? []), ...(b.element ? [b.element] : [])]) {
+      if (!el?.type) continue
+      if (forbidden.has(el.type)) bad.push(`blocks/${i}: ${el.type} is not allowed in a ${b.type} block`)
+      bad.push(...slackElementViolations(el, `blocks/${i}/${el.type}`))
+    }
+  }
+  return bad
+}
+
+/** The shape {@link slackCardViolations} reads a block and its elements through — deliberately
+ *  everything-optional, since the point is to inspect JSON that may be wrong. */
+interface SlackElementShape {
+  type?: string
+  options?: { value?: unknown }[]
+  initial_options?: { value?: unknown }[]
+  initial_option?: { value?: unknown }
+  max_selected_items?: unknown
+}
+interface SlackBlockShape {
+  type?: string
+  block_id?: string
+  elements?: SlackElementShape[]
+  element?: SlackElementShape
+}
+
+/** One element's own rules: its option cap, its option values, and whether it may be told a
+ *  maximum selection at all. Pure. */
+function slackElementViolations(el: SlackElementShape, at: string): string[] {
+  const bad: string[] = []
+  const cap = SLACK_ELEMENT_MAX_OPTIONS[el.type ?? '']
+  if (cap !== undefined && (el.options?.length ?? 0) > cap)
+    bad.push(`${at}: ${el.options?.length} options, past the ${cap} this element holds`)
+  if (el.max_selected_items !== undefined && !SLACK_MAX_SELECTED_ELEMENTS.has(el.type ?? ''))
+    bad.push(`${at}: max_selected_items is not a property of this element`)
+  const values = [
+    ...(el.options ?? []),
+    ...(el.initial_options ?? []),
+    ...(el.initial_option ? [el.initial_option] : [])
   ]
+  for (const o of values)
+    if (typeof o?.value === 'string' && o.value.length > SLACK_OPTION_VALUE_CAP)
+      bad.push(`${at}: an option value is ${o.value.length} characters, past ${SLACK_OPTION_VALUE_CAP}`)
+  return bad
 }
 
 /**
- * Build the interactive elicitation card: the agent's `message` and one actions row — EVERY
- * {@link elicitTarget} option as a button for a single-select or boolean, or a
- * `multi_static_select` plus Confirm for a multi-select — always with a Dismiss button. The choice
- * rides each option's `value` (`<requestId>|<optionValue>`). A {@link ELICIT_REPLY_KINDS} field
- * has no control at all: the card carries the question, what is expected, whom it awaits
- * (`awaits`) and Dismiss, and the answer arrives as a reply in the thread. Returns null when the
- * form can't be rendered on `surface` (caller declines): a kind or an option list it does not
- * claim, which the reduction has already refused, or a multi-select whose encoded option values
- * Slack's select would reject. Nothing here trims a list to fit. Pure.
+ * Build the ONE-TAP elicitation card: the agent's `message` and one actions row carrying EVERY
+ * {@link elicitTarget} option as a button, plus Dismiss. The choice rides each option's `value`
+ * (`<requestId>|<optionValue>`). Only a single-select or a boolean is answered this way — one tap
+ * IS the answer there, where every other kind needs something filled in first and takes the
+ * `input` blocks of {@link buildElicitationFormCard} ({@link elicitCardShape} decides). Returns
+ * null when the form can't be rendered on `surface` (caller declines): a kind or an option list
+ * it does not claim, which the reduction has already refused. Nothing here trims a list to fit.
+ * Pure.
  */
 export function buildElicitationCard(
   requestId: string,
   params: CreateElicitationRequest,
   sessionTarget?: string,
-  surface: ElicitSurface = SLACK_ELICIT_SURFACE,
-  awaits?: string
+  surface: ElicitSurface = SLACK_ELICIT_SURFACE
 ): unknown[] | null {
   const target = elicitTarget(params, surface)
   if (!target) return null
   const message = elicitCardMessage(params)
-  if (ELICIT_REPLY_KINDS.has(target.kind)) {
-    return [
-      { type: 'section', text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(message, ELICIT_MESSAGE_CAP)}` } },
-      { type: 'context', elements: [{ type: 'mrkdwn', text: replyInstruction(target, awaits) }] },
-      {
-        type: 'actions',
-        ...(sessionTarget ? { block_id: sessionTarget } : {}),
-        elements: [elicitDismissButton(requestId)]
-      }
-    ]
-  }
-  if (target.kind === 'multi-enum') {
-    const elements = buildMultiSelectElements(requestId, target)
-    if (!elements) return null
-    const hint = selectionHint(target)
-    return [
-      { type: 'section', text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(message, ELICIT_MESSAGE_CAP)}` } },
-      ...(hint ? [{ type: 'context', elements: [{ type: 'mrkdwn', text: hint }] }] : []),
-      { type: 'actions', ...(sessionTarget ? { block_id: sessionTarget } : {}), elements }
-    ]
-  }
+  // A lone question that has to be filled in is its own ONE-FIELD form: nothing tapped in an
+  // `actions` block can carry what was typed or selected, so the control is an input block.
+  if (elicitCardShape([target]) !== 'buttons')
+    return buildElicitationFormCard(requestId, params, [target], sessionTarget)
   const buttons = target.options.map((o, i) => ({
     type: 'button',
     action_id: `${ELICIT_ACTION_PREFIX}:${i}`,
@@ -1435,26 +1407,27 @@ export function buildElicitationResolvedCard(params: CreateElicitationRequest, d
   return [{ type: 'section', text: { type: 'mrkdwn', text } }]
 }
 
-// ── Multi-field elicitation forms (Slack modal, issue #1794's last Slack item) ────────────────
+// ── Elicitation form cards (`input` blocks in the message, issue #1794's last Slack item) ────
 
-/** Slack's own cap on a modal title. 24 characters hold no question, so the title is a FIXED
- *  deployment-authored line and the agent's own words go in the modal's first section, defused
- *  by {@link elicitCardMessage} like every other card's — an agent-authored string clamped into
- *  24 characters would be both unreadable and the one place on the modal a reader would trust
- *  most. This is the same phrase the seam already uses as a card's notification fallback. */
-const SLACK_MODAL_TITLE = 'Agent needs your input'
-
-/** Slack's own cap on a `plain_text_input`'s `min_length`/`max_length`, and on a select option's
- *  `value` — a modal has no button to fall back to, so an enum whose values outrun the second
- *  cap declines rather than posting a modal Slack would reject (#1813's finding, one surface on). */
+/** Slack's own cap on a `plain_text_input`'s `min_length`/`max_length`. */
 const SLACK_INPUT_LENGTH_CAP = 3000
 
-/** The `input` element one form field is answered by: a select for the pickable kinds, a
- *  `plain_text_input` for text and a `number_input` for numbers, each carrying the schema's own
- *  bounds so Slack refuses in the modal what the daemon would refuse anyway. Null ⇒ this field
- *  cannot BE an input block — an enum option value past Slack's 75-char select cap, or a minimum
- *  length past what an input holds — and the whole modal is then withheld rather than posted
- *  with a field the reader cannot answer honestly. Pure. */
+/** The longest list `checkboxes` and `radio_buttons` hold — past ten Slack answers `no more than
+ *  10 items allowed`, so a longer list falls back to the select menu, which holds a hundred. */
+const SLACK_CHOICE_MAX_OPTIONS = 10
+
+/** Slack's own cap on an `input` block's hint. */
+const SLACK_HINT_TEXT_CAP = 2000
+
+/** The `input` element one form field is answered by: for a pick, the control that fits the list —
+ *  `radio_buttons`/`checkboxes` for a short one, which show every option without a second tap, and
+ *  a select menu past what those hold — plus a `plain_text_input` for text and a `number_input` for
+ *  numbers, each carrying the schema's own bounds so Slack refuses on the card what the daemon
+ *  would refuse anyway. A checkbox list gets no `max_selected_items` (Slack has no such property
+ *  there): its bounds are said in the block's hint and enforced when the answer comes back, which
+ *  is where they were always binding. Null ⇒ this field cannot BE an input block — an option value
+ *  past Slack's 75-char cap, or a minimum length past what an input holds — and the whole card is
+ *  then withheld rather than posted with a field the reader cannot answer honestly. Pure. */
 function elicitFormInputElement(target: ElicitTarget): Record<string, unknown> | null {
   const action_id = ELICIT_FORM_INPUT_ACTION as string
   if (target.kind === 'text') {
@@ -1484,9 +1457,12 @@ function elicitFormInputElement(target: ElicitTarget): Record<string, unknown> |
     value: o.value
   }))
   if (!options.length || options.some((o) => o.value.length > SLACK_SELECT_VALUE_CAP)) return null
+  const short = options.length <= SLACK_CHOICE_MAX_OPTIONS
   if (target.kind === 'multi-enum') {
     const seeded = Array.isArray(target.defaultValue) ? new Set(target.defaultValue) : null
     const initial = seeded ? options.filter((o) => seeded.has(o.value)) : []
+    if (short)
+      return { type: 'checkboxes', action_id, options, ...(initial.length ? { initial_options: initial } : {}) }
     return {
       type: 'multi_static_select',
       action_id,
@@ -1499,6 +1475,7 @@ function elicitFormInputElement(target: ElicitTarget): Record<string, unknown> |
   // A boolean's `default` is a real boolean, so its option value is the string the card spells it with.
   const seed = target.kind === 'boolean' ? String(target.defaultValue) : target.defaultValue
   const initial = options.find((o) => o.value === seed)
+  if (short) return { type: 'radio_buttons', action_id, options, ...(initial ? { initial_option: initial } : {}) }
   return {
     type: 'static_select',
     action_id,
@@ -1508,68 +1485,39 @@ function elicitFormInputElement(target: ElicitTarget): Record<string, unknown> |
   }
 }
 
+/** What one field's block says under its label: the question's own words, plus a multi-select's
+ *  bounds, since a checkbox list cannot enforce them itself. Empty when there is nothing to add. */
+function elicitFormFieldHint(target: ElicitTarget): string {
+  const parts = [target.description ?? '', target.kind === 'multi-enum' ? selectionHint(target) : '']
+  return clampTo(parts.filter(Boolean).join(' '), SLACK_HINT_TEXT_CAP)
+}
+
 /**
- * Build the MULTI-FIELD elicitation card that goes in the channel. An `actions` block holds no
- * inputs, so the fields cannot be here at all: the card carries the agent's defused question, one
- * line naming what will be asked, an Answer button that opens the modal, and Dismiss — both in
- * one actions block so they share the `block_id` the relay routes on. Pure.
+ * Build the elicitation card whose fields are ANSWERED IN THE MESSAGE: the agent's defused
+ * question, then one `input` block per field in schema order — each keyed by {@link
+ * elicitFormBlockId}, which is the key its submitted value comes back under — and one actions
+ * block carrying Confirm and Dismiss, which share the `block_id` the relay routes on.
+ *
+ * ONE Confirm for the whole card, never one per question: a message's input values all arrive in
+ * `state.values` on any button tap in that message, so a single button submits the lot. That is
+ * also why a lone select that needs no typing keeps its row of buttons instead — one tap answers
+ * it, and there is nothing to fill in first ({@link elicitCardShape}).
+ *
+ * Null ⇒ some field cannot be an input block (see {@link elicitFormInputElement}) and the caller
+ * declines with a notice rather than posting a card with a field nobody can answer. Pure.
  */
 export function buildElicitationFormCard(
   requestId: string,
   params: CreateElicitationRequest,
   form: readonly ElicitTarget[],
   sessionTarget?: string
-): unknown[] {
-  const asked = form.map((t) => elicitFormFieldLabel(params, t)).join(', ')
-  return [
-    {
-      type: 'section',
-      text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(elicitCardMessage(params), ELICIT_MESSAGE_CAP)}` }
-    },
-    {
-      type: 'context',
-      elements: [{ type: 'mrkdwn', text: clampTo(`Asks for ${escapeSlackMrkdwn(asked)}.`, SLACK_SECTION_TEXT_CAP) }]
-    },
-    {
-      type: 'actions',
-      ...(sessionTarget ? { block_id: sessionTarget } : {}),
-      elements: [
-        {
-          type: 'button',
-          action_id: ELICIT_OPEN_ACTION as string,
-          text: { type: 'plain_text', text: 'Answer', emoji: true },
-          style: 'primary',
-          value: requestId
-        },
-        elicitDismissButton(requestId)
-      ]
-    }
-  ]
-}
-
-/**
- * Build the modal that ANSWERS a multi-field card: the agent's defused question, then one
- * `input` block per field in schema order, each keyed by {@link elicitFormBlockId} so the
- * submitted state and a per-field error share one key. `private_metadata` names the card and
- * carries the opaque session target the relay routes the submission on — the same value the
- * card's own `block_id` carries, and nothing about the reader.
- *
- * Both ingress paths call THIS function with the card's own params, so the direct Socket Mode
- * modal and the relay-forwarded one are the same view. Null ⇒ some field cannot be an input
- * block (see {@link elicitFormInputElement}) and the caller declines with a notice. Pure.
- */
-export function buildElicitationFormModal(
-  requestId: string,
-  params: CreateElicitationRequest,
-  form: readonly ElicitTarget[],
-  sessionTarget?: string
-): Record<string, unknown> | null {
+): unknown[] | null {
   const required = new Set(elicitRequiredProps(params))
   const inputs: Record<string, unknown>[] = []
   for (const [index, target] of form.entries()) {
     const element = elicitFormInputElement(target)
     if (!element) return null
-    const hint = target.description ?? (target.kind === 'multi-enum' ? selectionHint(target) : '')
+    const hint = elicitFormFieldHint(target)
     inputs.push({
       type: 'input',
       block_id: elicitFormBlockId(index),
@@ -1581,61 +1529,72 @@ export function buildElicitationFormModal(
       element
     })
   }
-  return {
-    type: 'modal',
-    callback_id: ELICIT_FORM_CALLBACK_ID as string,
-    private_metadata: encodeElicitFormMetadata({ requestId, ...(sessionTarget ? { target: sessionTarget } : {}) }),
-    title: { type: 'plain_text', text: SLACK_MODAL_TITLE },
-    submit: { type: 'plain_text', text: 'Submit' },
-    close: { type: 'plain_text', text: 'Cancel' },
-    blocks: [
-      {
-        type: 'section',
-        text: { type: 'mrkdwn', text: clampTo(elicitCardMessage(params), ELICIT_MESSAGE_CAP) }
-      },
-      ...inputs
-    ]
-  }
+  return [
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: `:speech_balloon: ${clampTo(elicitCardMessage(params), ELICIT_MESSAGE_CAP)}` }
+    },
+    ...inputs,
+    {
+      type: 'actions',
+      ...(sessionTarget ? { block_id: sessionTarget } : {}),
+      elements: [
+        {
+          type: 'button',
+          action_id: ELICIT_CONFIRM_ACTION as string,
+          text: { type: 'plain_text', text: 'Confirm', emoji: true },
+          style: 'primary',
+          value: requestId
+        },
+        elicitDismissButton(requestId)
+      ]
+    }
+  ]
 }
 
-/** The modal a tap on an ALREADY-SETTLED card opens: a stale client still shows the Answer
- *  button, and telling the reader the question closed is the difference between an explanation
- *  and a button that does nothing. Also the view a second reader's submission is replaced with
- *  once the first one settled the request. Pure. */
-export function buildElicitFormClosedModal(): Record<string, unknown> {
-  return {
-    type: 'modal',
-    title: { type: 'plain_text', text: SLACK_MODAL_TITLE },
-    close: { type: 'plain_text', text: 'Close' },
-    blocks: [
-      { type: 'section', text: { type: 'mrkdwn', text: 'This question has already been answered or dismissed.' } }
-    ]
-  }
+/** The two shapes a Slack elicitation card takes, decided by the reduction alone.
+ *
+ * A card is a row of BUTTONS exactly when ONE TAP CAN ANSWER IT: a single question that is a pure
+ * single-select or a boolean. Everything else is INPUT blocks with one Confirm and one Dismiss —
+ * a multi-select, a typed box, several questions, and a single question that brought a free-text
+ * companion box. A button submits the instant it is tapped, which leaves no moment to fill
+ * anything in; that is why a question gains a Confirm exactly when it has something to fill in.
+ *
+ * The companion case is not a guess about the schema: {@link elicitForm} already marks a companion
+ * with {@link ElicitTarget.customAnswerFor} (the `_meta` flag an AskUserQuestion bridge or a Codex
+ * `request_user_input` writes), so a question with a box is a reduction of two TARGETS and one
+ * QUESTION, where two questions are two of each. Reading the TARGET count is therefore all this
+ * needs: either way the card needs its inputs. Pure. */
+export type ElicitCardShape = 'buttons' | 'inputs'
+
+export function elicitCardShape(form: readonly ElicitTarget[]): ElicitCardShape {
+  const only = form.length === 1 ? form[0]! : null
+  return only && (only.kind === 'enum' || only.kind === 'boolean') ? 'buttons' : 'inputs'
 }
 
 /** What a refused field's error says, in the same plain words the card would have used — a
  *  reader who has to retype something is told the shape, never the schema keyword. */
 function elicitFormFieldError(target: ElicitTarget): string {
-  if (target.kind === 'text' || target.kind === 'number') return `Enter ${elicitReplyExpectation(target)}.`
+  if (target.kind === 'text' || target.kind === 'number') return `Enter ${elicitFieldExpectation(target)}.`
   if (target.kind === 'multi-enum') return selectionHint(target) || 'Select from the options offered.'
   return 'Choose one of the options offered.'
 }
 
-/** A form modal's answer, or the per-field errors that refuse it. Keyed by BLOCK id, which is
- *  what Slack's `response_action: errors` addresses. */
+/** A form card's answer, or the per-field errors that refuse it. Keyed by BLOCK id, which is what
+ *  the submitted state itself is keyed by. */
 export interface ElicitFormSubmission {
   answer?: Record<string, string | number | string[]>
   errors?: Record<string, string>
 }
 
 /**
- * Decode one `view_submission`'s raw field state into the typed record a form card answers with,
- * re-derived against the FORM THAT WAS RENDERED rather than trusted from the wire (#1815): each
- * value is read under its field's own block id, given the schema's own type — a real number for
- * `number`/`integer`, a list for a multi-select — and checked by {@link fieldAccepts}. A blank
- * optional input is simply absent; a missing REQUIRED field, a value of the wrong shape, and a
- * value the field does not admit each come back as that field's error, so one bad field refuses
- * the submission instead of being silently dropped. Pure.
+ * Decode one Confirm's raw field state into the typed record a form card answers with, re-derived
+ * against the FORM THAT WAS RENDERED rather than trusted from the wire (#1815): each value is read
+ * under its field's own block id, given the schema's own type — a real number for `number`/
+ * `integer`, a list for a multi-select — and checked by {@link fieldAccepts}. A blank optional
+ * input is simply absent; a missing REQUIRED field, a value of the wrong shape, and a value the
+ * field does not admit each come back as that field's error, so one bad field refuses the whole
+ * answer instead of being silently dropped. Pure.
  */
 export function elicitFormSubmission(
   params: CreateElicitationRequest,
@@ -1675,15 +1634,21 @@ export function elicitFormSubmission(
   return Object.keys(errors).length ? { errors } : { answer }
 }
 
-/** The `view_submission` response that puts those errors back on the modal, and the one that
- *  replaces it when the card it answers is already settled. Slack decodes both; the relay only
- *  carries them, on the opaque `response` slot of its own ack. Pure. */
-export function elicitFormErrorResponse(errors: Record<string, string>): Record<string, unknown> {
-  return { response_action: 'errors', errors }
-}
-
-export function elicitFormClosedResponse(): Record<string, unknown> {
-  return { response_action: 'update', view: buildElicitFormClosedModal() }
+/** What a refused Confirm is told IN THE THREAD, since a message card has no modal to return the
+ *  errors to: each refused field named as the card names it, with the same plain words a reply-
+ *  answered card would use, and the card left live to be answered again. Pure. */
+export function elicitFormRefusalNotice(
+  params: CreateElicitationRequest,
+  form: readonly ElicitTarget[],
+  errors: Readonly<Record<string, string>>
+): string {
+  const parts: string[] = []
+  for (const [blockId, message] of Object.entries(errors)) {
+    const index = elicitFormBlockIndex(blockId)
+    const target = index === null ? undefined : form[index]
+    parts.push(target ? `${elicitFormFieldLabel(params, target)}: ${message}` : message)
+  }
+  return clampTo(`That answer wasn't accepted — the question is still open. ${parts.join(' ')}`, ELICIT_MESSAGE_CAP)
 }
 
 /** Slack's own limit on an interactive element's `value`. A URL longer than this cannot ride a

--- a/packages/daemon/test/daemon-commands.test.ts
+++ b/packages/daemon/test/daemon-commands.test.ts
@@ -267,52 +267,6 @@ describe('Daemon in-conversation commands', () => {
     expect(dispatch).toHaveBeenCalledWith('bot-a', payload, 'int-a')
   })
 
-  // #1794's Slack column: a `text`/`number` elicitation card is answered by a reply in the
-  // turn's thread, so while one is live the reply must be intercepted as the answer rather than
-  // dispatched or queued as a turn of its own. Both Slack ingresses do it at the same point in
-  // the ladder — after control commands, before routing — so they behave identically here too.
-  it('hands a thread reply to a live elicitation card instead of dispatching it, on both ingresses', async () => {
-    const blocked = blockingHost()
-    const daemon = new Daemon({
-      slackAppFactory: fakeSlackAppFactory(),
-      root: scaffold(),
-      hostFactory: () => blocked.host as any
-    })
-    await daemon.start()
-    makeRoutable(daemon)
-    const seen: string[] = []
-    ;(daemon as any).permissions.answerElicitReply = async (msg: any) => {
-      seen.push(msg.msgId)
-      return true
-    }
-
-    const payload = dm('relay-answer', '42')
-    expect(
-      await (daemon as any).handleRelayMsg(
-        {
-          source: 'im',
-          agentId: 'bot-a',
-          sessionKey: 'slack:C1:dm',
-          msgId: 'relay-answer',
-          botId: '11111111-1111-4111-8111-111111111111',
-          integrationId: 'int-a',
-          chatId: 'C1',
-          payload
-        } as RdMsgIm,
-        () => {}
-      )
-    ).toEqual({ msgId: 'relay-answer', accepted: true })
-
-    expect(await (daemon as any).onInboundOutcome(dm('300', '42'))).toEqual({
-      kind: 'rejected',
-      reason: 'suppressed'
-    })
-    expect(seen).toEqual(['slack:C1:relay-answer', 'slack:C1:300'])
-    // Both deliveries would otherwise have been a turn each — this agent routes DMs.
-    expect(blocked.prompts).toHaveLength(0)
-    await daemon.stop()
-  })
-
   it('stamps trigger=mention on relay im when the message mentions the integration bot', async () => {
     // Relay arbitration never populates the wire `trigger`; the daemon recomputes it
     // from the mention list + this integration's own bot identity (see handleRelayIm).
@@ -2035,8 +1989,8 @@ describe('Slack interactive status bar', () => {
       content: { language: 'TypeScript' }
     })
 
-    // A multi-select card's one relayed verb: Confirm, carrying the selection the tapping
-    // reader's own payload held, submitted through the re-derivation a button click takes.
+    // An input-block card's one relayed verb: Confirm, carrying the fields the tapping reader's
+    // own payload held, submitted through the re-derivation a button click takes.
     const multiResolved = vi.fn()
     ;(daemon as any).permissions.pendingElicits.set('elicit-2', {
       agentId: 'bot-a',
@@ -2051,6 +2005,17 @@ describe('Slack interactive status bar', () => {
       },
       propName: 'checks',
       kind: 'multi-enum',
+      form: [
+        {
+          propName: 'checks',
+          kind: 'multi-enum',
+          options: [
+            { value: 'lint', label: 'lint' },
+            { value: 'test', label: 'test' }
+          ],
+          minItems: 1
+        }
+      ],
       approval: false,
       surface: 'slack',
       conn: { updateBlocks, workspaceId: () => 'T1' },
@@ -2062,7 +2027,7 @@ describe('Slack interactive status bar', () => {
       await (daemon as any).handleRelayMsg(
         action({
           msgId: 'action-elicit-confirm',
-          payload: { kind: 'elicitation-confirm', requestId: 'elicit-2', values: ['lint', 'test'] }
+          payload: { kind: 'elicitation-confirm', requestId: 'elicit-2', fields: { ac_elicit_f0: ['lint', 'test'] } }
         }),
         () => {}
       )

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -11,11 +11,12 @@ import { LocalStore } from '../src/store/local-store.js'
 import { listAgentPermissionRequests } from '../src/cp/config-apply-handlers.js'
 import { SlackConnection } from '../src/slack/connection.js'
 import {
-  ELICIT_OPEN_ACTION,
-  ELICIT_SELECT_ACTION,
+  ELICIT_CONFIRM_ACTION,
   elicitForm,
+  elicitFormBlockId,
   elicitTarget,
   SLACK_ELICIT_SURFACE,
+  slackCardViolations,
   WEBCHAT_ELICIT_SURFACE
 } from '../src/slack/render.js'
 
@@ -743,7 +744,7 @@ describe('webchat answers a multi-select elicitation with a list', () => {
     await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
     const [requestId] = (daemon as any).permissions.pendingElicits.keys()
     // A browser card carries its own answer, so Slack's Confirm verb is not its wire.
-    await (daemon as any).permissions.confirmElicitSelection({ requestId, values: ['lint'] })
+    await (daemon as any).permissions.submitElicitForm({ requestId, fields: { [elicitFormBlockId(0)]: ['lint'] } })
     expect((daemon as any).permissions.pendingElicits.size).toBe(1)
     await (daemon as any).permissions.handleElicitChoice({
       requestId,
@@ -824,7 +825,7 @@ describe('a Slack card offers every option or none', () => {
 // two readers of one card, and two interactions in any order, cannot answer for each other.
 
 describe('a Slack multi-select card confirms the selection it was sent', () => {
-  const selectOf = (posted: any[][]) => posted[0]!.at(-1)!.elements[0]
+  const selectOf = (posted: any[][]) => posted[0]!.find((b: any) => b.type === 'input')!.element
   /** The one live card's request id, once its posted `ts` is on the record — a settle before that
    *  has no message to rewrite, which is the card path's own pre-existing race (#1821), not ours. */
   const liveCard = async (daemon: any): Promise<string> => {
@@ -834,7 +835,11 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     return requestId
   }
   const confirm = (daemon: any, requestId: string, values: string[], actor?: { userId: string }) =>
-    daemon.permissions.confirmElicitSelection({ requestId, values, ...(actor ? { actor } : {}) })
+    daemon.permissions.submitElicitForm({
+      requestId,
+      fields: { [elicitFormBlockId(0)]: values },
+      ...(actor ? { actor } : {})
+    })
 
   it('cards a select plus Confirm, and accepts the confirmed list', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
@@ -845,16 +850,23 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
       multiElicitation({ minItems: 1, maxItems: 2 })
     )
     const requestId = await liveCard(daemon)
+    // The select is an INPUT block of its own — Slack refuses a multi-select inside `actions`
+    // and drops the WHOLE message — and Confirm plus Dismiss keep the routing actions block.
+    expect(slackCardViolations(posted[0]!)).toEqual([])
+    expect(selectOf(posted).type).toBe('checkboxes')
+    expect(selectOf(posted).action_id).toBe('ac_elicit_input')
     const elements = posted[0]!.at(-1)!.elements as any[]
-    expect(elements.map((e) => e.type)).toEqual(['multi_static_select', 'button', 'button'])
-    expect(elements.slice(1).map((e) => e.text.text)).toEqual(['Confirm', 'Dismiss'])
-    expect(selectOf(posted).action_id).toBe(`${ELICIT_SELECT_ACTION}:${requestId}`)
+    expect(elements.map((e) => [e.type, e.text.text])).toEqual([
+      ['button', 'Confirm'],
+      ['button', 'Dismiss']
+    ])
+    expect(elements[0].action_id).toBe(ELICIT_CONFIRM_ACTION)
     expect(updated).toHaveLength(0) // nothing has answered it yet
 
     await confirm(daemon, requestId, ['lint', 'build'])
     await expect(answered).resolves.toEqual({ action: 'accept', content: { checks: ['lint', 'build'] } })
     // The settled card names the chosen option LABELS, as #1801 settled a browser card.
-    expect(updated[0]![0].text.text).toContain(':white_check_mark: lint, build')
+    expect(updated[0]![0].text.text).toContain(':white_check_mark: checks: lint, build')
   })
 
   // The bug this shape exists to prevent: a per-card record of "the last selection seen" is
@@ -944,7 +956,7 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
     expect(elicitTarget(over, WEBCHAT_ELICIT_SURFACE)?.options).toHaveLength(101)
   })
 
-  it('ignores a Confirm aimed at a card that is not a multi-select', async () => {
+  it('ignores a Confirm aimed at a card that has no fields to submit', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const { updated } = slackPending(daemon)
     const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', enumElicitation(['a', 'b']))
@@ -1358,7 +1370,7 @@ describe('webchat answers a multi-field elicitation form with a record', () => {
     expect(cardEvents(sink)[1]).toEqual({ kind: 'elicitation_resolved', requestId, outcome: 'dismissed' })
   })
 
-  it('takes the MODAL path on a Slack turn rather than a single-field card', async () => {
+  it('takes the INPUT-BLOCK path on a Slack turn rather than a single-field card', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const pending: any = installPending(daemon)
     pending.plan.platform = 'slack'
@@ -1375,8 +1387,11 @@ describe('webchat answers a multi-field elicitation form with a record', () => {
 
     void (daemon as any).permissions.onAcpElicit('agent-1', 's1', twoFieldElicitation(['branch', 'note']))
     await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
-    // The card carries an Answer button, never the fields — the modal behind it asks both.
-    await vi.waitFor(() => expect(JSON.stringify(posted[0])).toContain(ELICIT_OPEN_ACTION))
+    // The card carries both fields as `input` blocks and ONE Confirm — never one per question.
+    await vi.waitFor(() => expect(JSON.stringify(posted[0])).toContain(ELICIT_CONFIRM_ACTION))
+    expect((posted[0] as any[]).filter((b: any) => b.type === 'input')).toHaveLength(2)
+    expect((posted[0] as any[]).filter((b: any) => b.type === 'actions')).toHaveLength(1)
+    expect(slackCardViolations(posted[0] as any[])).toEqual([])
     // Unchanged where it matters: the per-field reduction still needs one field that satisfies
     // `required` alone, and there is none here.
     expect(elicitTarget(twoFieldElicitation(['branch', 'note']), SLACK_ELICIT_SURFACE)).toBeNull()
@@ -1749,310 +1764,5 @@ describe('Slack renders and settles a URL-mode consent card', () => {
     await vi.waitFor(() => expect(posted).toHaveLength(1))
     expect(JSON.stringify(posted[0])).not.toContain('sk-live-DEADBEEF')
     await (daemon as any).permissions.releaseElicits('agent-1', 's1')
-  })
-})
-
-// ── a single text / number field, answered by a thread reply (issue #1794, Slack column) ────
-// Slack's own way to type something is to send a message, so the card has nothing to type into
-// and the next reply in the turn's thread IS the answer. The hard part is that such a reply
-// would otherwise start a new turn: while the card is live the ACP prompt is still blocked, so
-// ingress intercepts it before dispatch — and the interception is the pending card itself, so it
-// is gone the moment the card settles or the turn ends.
-
-describe('a Slack text/number card is answered by a reply in its thread', () => {
-  /** A Slack turn plus the notices its refusals post, and the card's live request id. */
-  const slackReplyTurn = (daemon: any) => {
-    const surface = slackPending(daemon)
-    // A real connection resolves this at `auth.test`, on the send-only (relay-managed) path too.
-    surface.pending.conn.botUserId = 'UBOT'
-    const notices: string[] = []
-    daemon.enqueueApply = (_p: unknown, action: any) => {
-      if (action.kind === 'notice') notices.push(action.text as string)
-    }
-    return { ...surface, notices }
-  }
-  const liveCard = async (daemon: any): Promise<string> => {
-    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
-    const [requestId] = daemon.permissions.pendingElicits.keys()
-    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.get(requestId).ts).toBe('ts-1'))
-    return requestId
-  }
-  /** A human reply in the turn's own thread, as ingress normalizes it. */
-  const reply = (text: string, over: Record<string, unknown> = {}) =>
-    ({
-      msgId: 'slack:test:200',
-      traceId: '200',
-      source: 'user',
-      platform: 'slack',
-      channel: 'test',
-      thread: 'test',
-      sender: { id: 'turn-user', isBot: false, name: 'Turn User' },
-      text,
-      mentionedBots: [],
-      isDm: false,
-      ...over
-    }) as any
-  const answer = (daemon: any, text: string, over: Record<string, unknown> = {}): Promise<boolean> =>
-    daemon.permissions.answerElicitReply(reply(text, over))
-
-  // One reply cannot answer two open questions, and picking either would tell one runtime the
-  // reader answered something they did not — the same lie a shared selection told on #1825.
-  it('answers neither of two questions open in one thread, and says why', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const { notices } = slackReplyTurn(daemon)
-    void (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation({ minLength: 1 }))
-    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
-    void (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation({ minLength: 1 }))
-    await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(2))
-
-    // Taken as neither answer, and left an ordinary message.
-    expect(await answer(daemon, 'add-retries')).toBe(false)
-    expect((daemon as any).permissions.pendingElicits.size).toBe(2)
-    expect(notices).toEqual([
-      '2 questions are open in this thread, so a reply cannot answer any of them — dismiss all ' +
-        'but one, or let one settle, and the next reply answers that one.'
-    ])
-
-    // One dismissed leaves exactly one question in the thread, and the next reply answers it.
-    const [firstId] = (daemon as any).permissions.pendingElicits.keys()
-    await (daemon as any).permissions.handleElicitChoice({ requestId: firstId, value: null })
-    expect(await answer(daemon, 'add-retries')).toBe(true)
-    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
-  })
-
-  it('drops a leading mention of the asker, which addresses it rather than answering it', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const { notices } = slackReplyTurn(daemon)
-    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', numberElicitation({ minimum: 0 }))
-    await liveCard(daemon)
-
-    // Everything that is NOT this one shape stays part of the answer, so none of these is a
-    // number: guessing which other PART of a message is the value is how an answer comes back
-    // wrong. Each is refused with the reason and the card stays live.
-    expect(await answer(daemon, '<@U-someone-else> 42')).toBe(true)
-    expect(await answer(daemon, '42 <@UBOT>')).toBe(true)
-    expect(await answer(daemon, 'ping <@UBOT> 42')).toBe(true)
-    expect(await answer(daemon, '<@UBOT> <@UBOT> 42')).toBe(true)
-    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
-    expect(notices).toHaveLength(4)
-
-    expect(await answer(daemon, '<@UBOT> 42')).toBe(true)
-    await expect(answered).resolves.toEqual({ action: 'accept', content: { retries: 42 } })
-  })
-
-  it('keeps a text answer’s own words, minus only that one leading address', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    slackReplyTurn(daemon)
-    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation({ minLength: 3 }))
-    await liveCard(daemon)
-    expect(await answer(daemon, '<@UBOT>: add-retries')).toBe(true)
-    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
-  })
-
-  it('cards the question, what is expected and whom it awaits, then takes the reply', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const { posted, updated } = slackReplyTurn(daemon)
-    const answered = (daemon as any).permissions.onAcpElicit(
-      'agent-1',
-      's1',
-      textElicitation({ minLength: 3, maxLength: 40 })
-    )
-    await liveCard(daemon)
-    const blocks = posted[0]!
-    expect(blocks[0].text.text).toBe(':speech_balloon: What should I name the branch?')
-    expect(blocks[1].elements[0].text).toBe(
-      'Reply in this thread with some text, 3 to 40 characters long. Waiting for <@turn-user>.'
-    )
-    // Nothing to type into on the card — Dismiss is the only control it carries.
-    expect(blocks[2].elements.map((e: any) => e.text.text)).toEqual(['Dismiss'])
-    expect(updated).toHaveLength(0)
-
-    expect(await answer(daemon, 'add-retries')).toBe(true)
-    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
-    // The settled card records the answer the way every other surface does: the reader's own
-    // words back (#1803's `chosenLabel`), which is also what the thread already shows.
-    expect(updated[0]![0].text.text).toContain(':white_check_mark: add-retries')
-    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
-  })
-
-  it('answers a numeric field with a real number, not the string that spelled it', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    slackReplyTurn(daemon)
-    const answered = (daemon as any).permissions.onAcpElicit(
-      'agent-1',
-      's1',
-      numberElicitation({ minimum: 1, maximum: 5 })
-    )
-    await liveCard(daemon)
-    expect(await answer(daemon, ' 3 ')).toBe(true)
-    const res = await answered
-    expect(res).toEqual({ action: 'accept', content: { retries: 3 } })
-    expect(typeof (res as any).content.retries).toBe('number')
-  })
-
-  it('says why an invalid reply is not the answer, and leaves the card live', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const { updated, notices } = slackReplyTurn(daemon)
-    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', numberElicitation({ minimum: 1 }))
-    await liveCard(daemon)
-
-    // Consumed (it was meant as the answer) but not spent: an invalid reply is not a refusal,
-    // so the question stays open and Dismiss remains the only way to say no.
-    expect(await answer(daemon, 'lots')).toBe(true)
-    expect(await answer(daemon, '0')).toBe(true)
-    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
-    expect(updated).toHaveLength(0)
-    expect(notices).toEqual([
-      "That reply isn't a number, 1 or more — the question is still open.",
-      "That reply isn't a number, 1 or more — the question is still open."
-    ])
-
-    expect(await answer(daemon, '7')).toBe(true)
-    await expect(answered).resolves.toEqual({ action: 'accept', content: { retries: 7 } })
-  })
-
-  it('takes the requester’s reply and leaves every other message an ordinary one', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const { notices } = slackReplyTurn(daemon)
-    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
-    await liveCard(daemon)
-
-    // Someone other than the turn's requester is not answering it — the card names who it waits
-    // for, and their message stays a message.
-    expect(await answer(daemon, 'add-retries', { sender: { id: 'U-other', isBot: false } })).toBe(false)
-    // Another thread of the same channel is another conversation, even one word for word.
-    expect(await answer(daemon, 'add-retries', { thread: 'other-thread' })).toBe(false)
-    // A root channel post is not a reply in the thread either — and its `thread` is its own ts,
-    // which is the shape normalization really produces.
-    expect(await answer(daemon, 'add-retries', { msgId: 'slack:test:200', thread: '200' })).toBe(false)
-    // Another Slack app watching the same channel is a different conversation.
-    expect(await answer(daemon, 'add-retries', { transportScope: 'slack:other-app' })).toBe(false)
-    // A bot's message never answers a question — including this daemon's own posts.
-    expect(await answer(daemon, 'add-retries', { sender: { id: 'B1', isBot: true } })).toBe(false)
-    // A reply that shares a file is not a typed answer, and consuming it would drop the file.
-    expect(
-      await answer(daemon, 'add-retries', {
-        attachments: [{ id: 'F1', name: 'log.txt', mimeType: 'text/plain', sourceUrl: 'https://x' }]
-      })
-    ).toBe(false)
-    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
-    expect(notices).toEqual([]) // none of them was an attempt to answer, so none is refused
-
-    expect(await answer(daemon, 'add-retries')).toBe(true)
-    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
-  })
-
-  it('waits for anyone in the thread when the turn identifies no requester', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const { pending, posted } = slackReplyTurn(daemon)
-    pending.plan.requesterId = 'unknown'
-    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
-    await liveCard(daemon)
-    expect(posted[0]![1].elements[0].text).toContain('Anyone in this thread can answer.')
-    expect(await answer(daemon, 'add-retries', { sender: { id: 'U-other', isBot: false } })).toBe(true)
-    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
-  })
-
-  // The shape Slack normalization ACTUALLY produces: `thread` is `thread_ts ?? ts`, so it is
-  // never absent and a root message carries its OWN ts there. Testing for absence made the DM
-  // exception dead code — the card was as unanswerable as if it had never been written.
-  it('takes a DM session’s ROOT message, whose thread is its own timestamp', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const { pending } = slackReplyTurn(daemon)
-    pending.plan.isDm = true
-    pending.plan.statusThread = '100.001'
-    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
-    await liveCard(daemon)
-
-    // Still not ANY thread of that conversation: a reply under another root is another question.
-    expect(await answer(daemon, 'add-retries', { msgId: 'slack:test:300.001', thread: '250.001', isDm: true })).toBe(
-      false
-    )
-    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
-
-    // The reviewer's reproduction: card at 100.001, a later top-level answer at 200.001.
-    expect(await answer(daemon, 'add-retries', { msgId: 'slack:test:200.001', thread: '200.001', isDm: true })).toBe(
-      true
-    )
-    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'add-retries' } })
-  })
-
-  // A `format`ted field asks for exactly the two things Slack rewrites on the way back out, so
-  // without decoding, a reader following the card's own instruction is refused forever.
-  it('reads a link answer out of Slack’s own markup for it', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    slackReplyTurn(daemon)
-    const uri = (daemon as any).permissions.onAcpElicit(
-      'agent-1',
-      's1',
-      textElicitation({ format: 'uri' }, 'Which page should I open?')
-    )
-    await liveCard(daemon)
-    expect(await answer(daemon, '<https://example.com/>')).toBe(true)
-    await expect(uri).resolves.toEqual({ action: 'accept', content: { name: 'https://example.com/' } })
-
-    // `<dest|label>`: the destination is the part BEFORE the pipe, and a `mailto:` scheme is
-    // Slack's spelling of an address rather than part of it.
-    const email = (daemon as any).permissions.onAcpElicit(
-      'agent-1',
-      's1',
-      textElicitation({ format: 'email' }, 'Who should I notify?')
-    )
-    await liveCard(daemon)
-    expect(await answer(daemon, '<mailto:reader@example.com|reader@example.com>')).toBe(true)
-    await expect(email).resolves.toEqual({ action: 'accept', content: { name: 'reader@example.com' } })
-  })
-
-  // Decoding is not extracting: unwrapping ONE link is recovering what the reader typed, while
-  // picking a link out of a sentence is a judgement about which PART of it is the value.
-  it('leaves a link inside prose alone, and never takes a label for the value', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const { notices } = slackReplyTurn(daemon)
-    const answered = (daemon as any).permissions.onAcpElicit(
-      'agent-1',
-      's1',
-      textElicitation({ format: 'uri' }, 'Which page should I open?')
-    )
-    await liveCard(daemon)
-
-    // Prose carrying a link is not one link: refused with the reason, and the card stays live.
-    expect(await answer(daemon, 'try <https://example.com/> first')).toBe(true)
-    expect((daemon as any).permissions.pendingElicits.size).toBe(1)
-    expect(notices).toHaveLength(1)
-
-    // A labelled link IS one link, and its value is the destination — the label is display text
-    // Slack added, and answering with it would report something the reader never gave.
-    expect(await answer(daemon, '<https://example.com/|the docs page>')).toBe(true)
-    await expect(answered).resolves.toEqual({ action: 'accept', content: { name: 'https://example.com/' } })
-    expect(notices).toHaveLength(1)
-  })
-
-  it('releases the interception on Dismiss and on turn end — a later reply is conversation', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    const { updated } = slackReplyTurn(daemon)
-    const dismissed = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
-    const firstId = await liveCard(daemon)
-    await (daemon as any).permissions.handleElicitChoice({ requestId: firstId, value: null })
-    await expect(dismissed).resolves.toEqual({ action: 'decline' })
-    expect(updated[0]![0].text.text).toContain(':no_entry_sign: Dismissed')
-    expect(await answer(daemon, 'add-retries')).toBe(false)
-
-    const abandoned = (daemon as any).permissions.onAcpElicit('agent-1', 's1', textElicitation())
-    await liveCard(daemon)
-    await (daemon as any).permissions.releaseElicits('agent-1', 's1')
-    await expect(abandoned).resolves.toEqual({ action: 'cancel' })
-    expect(await answer(daemon, 'add-retries')).toBe(false)
-    expect((daemon as any).permissions.pendingElicits.size).toBe(0)
-  })
-
-  it('leaves a card whose answer is a TAP untouched by a thread reply', async () => {
-    const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
-    slackReplyTurn(daemon)
-    const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', formElicitation())
-    const requestId = await liveCard(daemon)
-    // An enum card holds no reply target, so a reply naming one of its options is not its answer.
-    expect(await answer(daemon, 'main')).toBe(false)
-    await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'main' })
-    await expect(answered).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
   })
 })

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -21,15 +21,17 @@ import {
   elicitForm,
   elicitFormAccepts,
   elicitFormContent,
-  decodeSlackReplyValue,
-  elicitReplyAnswer,
-  elicitReplyExpectation,
-  stripLeadingSelfMention,
+  buildElicitationFormCard,
+  elicitCardShape,
+  elicitFieldExpectation,
+  elicitFormBlockId,
   elicitRequiredProps,
   elicitTarget,
   elicitUrl,
   buildUrlConsentCard,
+  buildUrlConsentResolvedCard,
   SLACK_DM_ELICIT_SURFACE,
+  slackCardViolations,
   SLACK_ELICIT_SURFACE,
   WEBCHAT_ELICIT_SURFACE,
   multiSelectAccepts,
@@ -42,7 +44,6 @@ import {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
-  ELICIT_SELECT_ACTION,
   type SlackAction,
   type SlackAttributionInfo
 } from '../src/slack/render.js'
@@ -1399,6 +1400,126 @@ describe('permission card', () => {
   })
 })
 
+// Slack refuses a multi-select inside an `actions` block and drops the WHOLE message, so a card
+// that gets this wrong never posts and its request is cancelled with nothing shown in the channel.
+// Our own tests all passed while we shipped exactly that, because they assert the JSON we build
+// and never the rules Slack applies to it. These are those rules, verified against the live API,
+// asserted over EVERY card this file can build — across kinds, sizes and both card shapes.
+describe('every card we build is one Slack would accept', () => {
+  const req = (props: Record<string, unknown>, required?: string[]) =>
+    ({
+      mode: 'form',
+      sessionId: 's1',
+      message: 'Pick',
+      requestedSchema: { type: 'object', properties: props, ...(required ? { required } : {}) }
+    }) as any
+  const enumOf = (n: number) => Array.from({ length: n }, (_, i) => `o${i}`)
+  const pick = (n: number) => ({ type: 'string', enum: enumOf(n) })
+  const many = (n: number) => ({ type: 'array', items: { type: 'string', enum: enumOf(n) } })
+
+  // Every SHAPE and every SIZE that changes the control a field renders as: the checkbox/radio
+  // cap at 10, the select cap at 100, the button row's 24, a companion box, a whole form.
+  const cards: [string, any][] = [
+    ['a lone single-select (buttons)', req({ p: pick(2) })],
+    ['a full button row', req({ p: pick(24) })],
+    ['a lone boolean', req({ b: { type: 'boolean' } })],
+    ['a lone text field', req({ t: { type: 'string', minLength: 2, maxLength: 40 } })],
+    ['a lone patterned text field', req({ t: { type: 'string', pattern: '^[a-z]+$' } })],
+    ['a lone number field', req({ n: { type: 'integer', minimum: 1, maximum: 9 } })],
+    ['a multi-select at the checkbox cap', req({ m: { ...many(10), minItems: 1, maxItems: 3 } })],
+    ['a multi-select past it', req({ m: { ...many(11), maxItems: 3 } })],
+    ['a multi-select at the select cap', req({ m: many(100) })],
+    ['a seeded multi-select', req({ m: { ...many(4), default: ['o1', 'o2'] } })],
+    ['a two-question form', req({ p: pick(2), t: { type: 'string' } }, ['p'])],
+    [
+      'a form of every kind',
+      req({ p: pick(2), m: many(3), t: { type: 'string' }, n: { type: 'number' }, b: { type: 'boolean' } })
+    ],
+    ['a form whose select outgrows radio buttons', req({ p: pick(11), q: pick(2) })],
+    [
+      'a select with its own free-text companion',
+      req({
+        p: pick(3),
+        other: { type: 'string', _meta: { _askUserQuestionCustomAnswer: { isCustomAnswer: true, questionId: 'p' } } }
+      })
+    ],
+    [
+      'a URL consent card',
+      { mode: 'url', sessionId: 's1', message: 'Sign in', elicitationId: 'e1', url: 'https://x.test/' } as any
+    ]
+  ]
+
+  it.each(cards)('accepts %s', (_name, params) => {
+    const built =
+      params.mode === 'url'
+        ? buildUrlConsentCard('elicit-1', params, 'sess-target')
+        : (buildElicitationCard('elicit-1', params, 'sess-target') ??
+          buildElicitationFormCard('elicit-1', params, elicitForm(params, SLACK_ELICIT_SURFACE) ?? [], 'sess-target'))
+    expect(built).not.toBeNull()
+    expect(slackCardViolations(built!)).toEqual([])
+    // The routing block_id is on the actions block, and every other block_id is distinct from it.
+    const actions = (built as any[]).find((b: any) => b.type === 'actions')
+    expect(actions.block_id).toBe('sess-target')
+  })
+
+  it('holds for the settled cards, the permission card and the DM card too', () => {
+    const settled = [
+      buildElicitationResolvedCard(req({ p: pick(2) }), ':white_check_mark: o0'),
+      buildUrlConsentResolvedCard(
+        { mode: 'url', sessionId: 's1', message: 'Sign in', elicitationId: 'e1', url: 'https://x.test/' } as any,
+        'Opened'
+      ),
+      buildPermissionCard(
+        'perm-1',
+        {
+          sessionId: 's1',
+          toolCall: { toolCallId: 'tc1', title: 'Write perm-test.txt' },
+          options: [{ optionId: 'a', name: 'Allow Once', kind: 'allow_once' }]
+        } as any,
+        'sess-target'
+      ),
+      buildElicitationCard('elicit-1', req({ b: { type: 'boolean' } }), 'sess-target', SLACK_DM_ELICIT_SURFACE)!
+    ]
+    for (const card of settled) expect(slackCardViolations(card)).toEqual([])
+  })
+
+  // The guard has to FAIL on the thing that shipped, or it is decoration.
+  it('names the rules a hand-written card would break', () => {
+    expect(
+      slackCardViolations([
+        { type: 'actions', block_id: 'a', elements: [{ type: 'multi_static_select', options: [] }] },
+        { type: 'actions', block_id: 'a', elements: [{ type: 'plain_text_input' }, { type: 'number_input' }] },
+        { type: 'input', block_id: 'b' },
+        { type: 'input', block_id: 'c', element: { type: 'button' } },
+        {
+          type: 'input',
+          block_id: 'd',
+          element: { type: 'checkboxes', options: enumOf(11).map((value) => ({ value })), max_selected_items: 2 }
+        },
+        {
+          type: 'input',
+          block_id: 'e',
+          element: { type: 'radio_buttons', options: enumOf(11).map((value) => ({ value })) }
+        },
+        { type: 'input', block_id: 'f', element: { type: 'static_select', options: [{ value: 'x'.repeat(76) }] } },
+        { type: 'actions', block_id: 'g', elements: enumOf(26).map((value) => ({ type: 'button', value })) }
+      ])
+    ).toEqual([
+      'blocks/0: multi_static_select is not allowed in a actions block',
+      'blocks/1: duplicate block_id "a"',
+      'blocks/1: plain_text_input is not allowed in a actions block',
+      'blocks/1: number_input is not allowed in a actions block',
+      'blocks/2: input block has no element',
+      'blocks/3: button is not allowed in a input block',
+      'blocks/4/checkboxes: 11 options, past the 10 this element holds',
+      'blocks/4/checkboxes: max_selected_items is not a property of this element',
+      'blocks/5/radio_buttons: 11 options, past the 10 this element holds',
+      'blocks/6/static_select: an option value is 76 characters, past 75',
+      'blocks/7: 26 elements in an actions block, past 25'
+    ])
+  })
+})
+
 describe('elicitation card', () => {
   const form = (properties: Record<string, unknown>, message = 'Pick a language'): CreateElicitationRequest =>
     ({ mode: 'form', sessionId: 's1', message, requestedSchema: { type: 'object', properties } }) as any
@@ -1677,9 +1798,9 @@ describe('elicitation card', () => {
     })
   })
 
-  // #1794 Slack column: a `multi_static_select` CAN express "pick several", but it never submits
-  // on its own — so the card is a select plus its own Confirm, and Dismiss as always.
-  it('cards a multi-select as a select plus Confirm', () => {
+  // #1794 Slack column: a multi-select CAN express "pick several", but it never submits on its
+  // own — so the card is an input block plus its own Confirm, and Dismiss as always.
+  it('cards a multi-select as an input block plus Confirm', () => {
     const req = form({
       colors: {
         type: 'array',
@@ -1696,19 +1817,24 @@ describe('elicitation card', () => {
     })
     expect(elicitTarget(req, SLACK_ELICIT_SURFACE)?.kind).toBe('multi-enum')
     const blocks = buildElicitationCard('elicit-1', req, 'shared-session-target') as any[]
-    // The bounds are on the card, so a refused Confirm is not the reader's first news of them.
-    expect(blocks[1]).toEqual({ type: 'context', elements: [{ type: 'mrkdwn', text: 'Select 1 to 2.' }] })
+    expect(slackCardViolations(blocks)).toEqual([])
+    // The control is an INPUT block of its own — Slack refuses a multi-select inside `actions`
+    // and drops the WHOLE message — and the buttons keep the actions block the relay routes on.
+    expect(blocks.map((b: any) => b.type)).toEqual(['section', 'input', 'actions'])
     expect(blocks[2].block_id).toBe('shared-session-target')
-    const [select, confirm, dismiss] = blocks[2].elements
-    expect(select.type).toBe('multi_static_select')
-    // The request rides the select's OWN action_id: deselecting everything is a change too,
-    // and a card named only by its selected options could not report one.
-    expect(select.action_id).toBe(`${ELICIT_SELECT_ACTION}:elicit-1`)
+    expect(blocks[1].block_id).toBe(elicitFormBlockId(0))
+    // Two options fit a checkbox list, which shows every one of them without a second tap. It has
+    // NO `max_selected_items` (Slack answers `invalid additional property`), so the bounds are on
+    // the block's hint and enforced when the answer comes back — never the reader's first news.
+    const select = blocks[1].element
+    const [confirm, dismiss] = blocks[2].elements
+    expect(select.type).toBe('checkboxes')
+    expect(select.max_selected_items).toBeUndefined()
+    expect(blocks[1].hint.text).toBe('Select 1 to 2.')
     expect(select.options.map((o: any) => [o.text.text, o.value])).toEqual([
       ['Red', '#FF0000'],
       ['Green', '#00FF00']
     ])
-    expect(select.max_selected_items).toBe(2)
     // Seeded from the schema's `default`, so an untouched Confirm submits what the card shows.
     expect(select.initial_options).toEqual([
       { text: { type: 'plain_text', text: 'Green', emoji: true }, value: '#00FF00' }
@@ -1720,9 +1846,9 @@ describe('elicitation card', () => {
   it('names an unbounded multi-select no bounds and seeds it nothing', () => {
     const req = form({ colors: { type: 'array', items: { type: 'string', enum: ['Red', 'Green'] } } })
     const blocks = buildElicitationCard('elicit-1', req) as any[]
-    expect(blocks).toHaveLength(2) // no hint block: there is nothing to say
-    const select = blocks[1].elements[0]
-    expect(select.max_selected_items).toBeUndefined()
+    expect(blocks).toHaveLength(3) // section + the control's input block + the buttons
+    expect(blocks[1].hint).toBeUndefined() // no bounds to say
+    const select = blocks[1].element
     expect(select.initial_options).toBeUndefined()
   })
 
@@ -1732,7 +1858,7 @@ describe('elicitation card', () => {
     const items = (n: number) => ({ type: 'string', enum: Array.from({ length: n }, (_, i) => `o${i}`) })
     const at = form({ colors: { type: 'array', items: items(100) } })
     expect(elicitTarget(at, SLACK_ELICIT_SURFACE)?.options).toHaveLength(100)
-    expect((buildElicitationCard('elicit-100', at) as any[])[1].elements[0].options).toHaveLength(100)
+    expect((buildElicitationCard('elicit-100', at) as any[])[1].element.options).toHaveLength(100)
     const over = form({ colors: { type: 'array', items: items(101) } })
     expect(elicitTarget(over, SLACK_ELICIT_SURFACE)).toBeNull()
     expect(buildElicitationCard('elicit-101', over)).toBeNull()
@@ -1769,32 +1895,20 @@ describe('elicitation card', () => {
     expect(elicitTarget(req, SLACK_DM_ELICIT_SURFACE)?.propName).toBe('ok')
   })
 
-  // ── a single text / number field, answered by a thread reply (issue #1794, Slack column) ──
-  // Slack's own way to type something is to send a message, so the card carries the question,
-  // what is expected, whom it waits for, and Dismiss — and nothing to type into.
+  // ── a single text / number field: a control of its own, and one Confirm ────────────────────
+  // A button submits the instant it is tapped, so it cannot answer a question that has to be
+  // typed into first — a typed field gets an `input` block and the card's one Confirm.
 
-  it('cards a text field as a question with no control but Dismiss', () => {
+  it('cards a text field as an input block with its bounds, plus Confirm and Dismiss', () => {
     const req = form({ note: { type: 'string', minLength: 3, maxLength: 40 } }, 'What should the release note say?')
-    const blocks = buildElicitationCard(
-      'elicit-1',
-      req,
-      'shared-session-target',
-      SLACK_ELICIT_SURFACE,
-      '<@U1>'
-    ) as any[]
+    const blocks = buildElicitationCard('elicit-1', req, 'shared-session-target') as any[]
+    expect(slackCardViolations(blocks)).toEqual([])
     expect(blocks[0].text.text).toBe(':speech_balloon: What should the release note say?')
-    expect(blocks[1]).toEqual({
-      type: 'context',
-      elements: [
-        {
-          type: 'mrkdwn',
-          text: 'Reply in this thread with some text, 3 to 40 characters long. Waiting for <@U1>.'
-        }
-      ]
-    })
+    expect(blocks.map((b: any) => b.type)).toEqual(['section', 'input', 'actions'])
+    expect(blocks[1].element).toMatchObject({ type: 'plain_text_input', min_length: 3, max_length: 40 })
     expect(blocks[2].block_id).toBe('shared-session-target')
-    const [dismiss, ...rest] = blocks[2].elements
-    expect(rest).toEqual([]) // nothing to tap but the refusal
+    const [confirm, dismiss] = blocks[2].elements
+    expect([confirm.action_id, confirm.text.text]).toEqual([ELICIT_CONFIRM_ACTION, 'Confirm'])
     expect([dismiss.action_id, dismiss.value, dismiss.text.text]).toEqual([
       ELICIT_DISMISS_ACTION,
       'elicit-1',
@@ -1802,16 +1916,30 @@ describe('elicitation card', () => {
     ])
   })
 
-  it('says who may answer when the turn named no requester', () => {
+  it('cards a number field as a number input carrying the schema’s own bounds', () => {
     const blocks = buildElicitationCard('elicit-1', form({ n: { type: 'integer', minimum: 1, maximum: 5 } })) as any[]
-    expect(blocks[1].elements[0].text).toBe(
-      'Reply in this thread with a whole number from 1 to 5. Anyone in this thread can answer.'
-    )
+    expect(blocks[1].element).toMatchObject({
+      type: 'number_input',
+      is_decimal_allowed: false,
+      min_value: '1',
+      max_value: '5'
+    })
   })
 
-  it('says what is expected in plain words, never in schema vocabulary', () => {
+  // A card is a button row exactly when ONE TAP can answer it: a lone single-select or boolean.
+  it('gives buttons only to what a single tap answers', () => {
+    const shape = (props: Record<string, unknown>) => elicitCardShape(elicitForm(form(props), SLACK_ELICIT_SURFACE)!)
+    expect(shape({ p: { type: 'string', enum: ['a', 'b'] } })).toBe('buttons')
+    expect(shape({ b: { type: 'boolean' } })).toBe('buttons')
+    expect(shape({ t: { type: 'string' } })).toBe('inputs')
+    expect(shape({ n: { type: 'number' } })).toBe('inputs')
+    expect(shape({ m: { type: 'array', items: { type: 'string', enum: ['a'] } } })).toBe('inputs')
+    expect(shape({ p: { type: 'string', enum: ['a'] }, t: { type: 'string' } })).toBe('inputs')
+  })
+
+  it('says what a field expects in plain words, never in schema vocabulary', () => {
     const expectation = (prop: Record<string, unknown>) =>
-      elicitReplyExpectation(elicitTarget(form({ f: prop }), SLACK_ELICIT_SURFACE)!)
+      elicitFieldExpectation(elicitTarget(form({ f: prop }), SLACK_ELICIT_SURFACE)!)
     expect(expectation({ type: 'number' })).toBe('a number')
     expect(expectation({ type: 'integer' })).toBe('a whole number')
     expect(expectation({ type: 'number', minimum: 0.5 })).toBe('a number, 0.5 or more')
@@ -1824,67 +1952,6 @@ describe('elicitation card', () => {
     expect(expectation({ type: 'string', pattern: '^[a-z]+$' })).toBe(
       'some text, in the exact format the question asks for'
     )
-  })
-
-  it('strips one leading mention of the asking bot, and nothing else', () => {
-    // `@bot 42` is 42: addressing the asker is chrome, not value. Both mention spellings, and
-    // the punctuation a reader puts after an address.
-    expect(stripLeadingSelfMention('<@UBOT> 42', 'UBOT')).toBe('42')
-    expect(stripLeadingSelfMention('<@UBOT|acme-bot> 42', 'UBOT')).toBe('42')
-    expect(stripLeadingSelfMention('  <@UBOT>:  42', 'UBOT')).toBe('42')
-    expect(stripLeadingSelfMention('<@UBOT>, add-retries', 'UBOT')).toBe('add-retries')
-    // Anyone else's mention, a second one, and any position but the front are all content.
-    expect(stripLeadingSelfMention('<@UOTHER> 42', 'UBOT')).toBe('<@UOTHER> 42')
-    expect(stripLeadingSelfMention('<@UBOT> <@UBOT> 42', 'UBOT')).toBe('<@UBOT> 42')
-    expect(stripLeadingSelfMention('42 <@UBOT>', 'UBOT')).toBe('42 <@UBOT>')
-    expect(stripLeadingSelfMention('ping <@UBOT> 42', 'UBOT')).toBe('ping <@UBOT> 42')
-    // An identity not resolved yet strips nothing rather than guessing at the token.
-    expect(stripLeadingSelfMention('<@UBOT> 42', '')).toBe('<@UBOT> 42')
-    expect(stripLeadingSelfMention('<@UBOT> 42', undefined)).toBe('<@UBOT> 42')
-  })
-
-  it('decodes a reply Slack handed back as link markup, and only when it is one link', () => {
-    // Slack rewrites what the reader typed on the way back out, so `uri`/`email` would refuse a
-    // reader following the card's own instruction.
-    expect(decodeSlackReplyValue('<https://example.com/>')).toBe('https://example.com/')
-    // The destination is the part BEFORE the pipe; the label is display text Slack added.
-    expect(decodeSlackReplyValue('<https://example.com/|the docs page>')).toBe('https://example.com/')
-    expect(decodeSlackReplyValue('<mailto:a@b.co|a@b.co>')).toBe('a@b.co')
-    expect(decodeSlackReplyValue('<mailto:a@b.co>')).toBe('a@b.co')
-    // One link and nothing else. Prose with a link inside is returned whole: choosing which PART
-    // of a sentence is the value is a guess, not a decode.
-    expect(decodeSlackReplyValue('try <https://example.com/> first')).toBe('try <https://example.com/> first')
-    expect(decodeSlackReplyValue('<https://a/> <https://b/>')).toBe('<https://a/> <https://b/>')
-    // Slack escapes exactly these three everywhere in message text, so undoing them is lossless
-    // — and a query string is where a silently wrong value would otherwise have got through.
-    expect(decodeSlackReplyValue('<https://example.com/?a=1&amp;b=2>')).toBe('https://example.com/?a=1&b=2')
-    expect(decodeSlackReplyValue('2 &lt; 3 &amp;&amp; 3 &gt; 2')).toBe('2 < 3 && 3 > 2')
-    // An ordinary answer is itself, trimmed.
-    expect(decodeSlackReplyValue('  add-retries \n')).toBe('add-retries')
-  })
-
-  it('re-derives a reply against the card, and answers a numeric field with a real number', () => {
-    const number = elicitTarget(form({ n: { type: 'integer', minimum: 1, maximum: 5 } }), SLACK_ELICIT_SURFACE)!
-    expect(elicitReplyAnswer(number, ' 4 ')).toBe(4)
-    expect(elicitReplyAnswer(number, '4')).not.toBe('4') // a real number, never the wire string
-    expect(elicitReplyAnswer(number, '9')).toBeNull() // outside the bounds the card showed
-    expect(elicitReplyAnswer(number, '2.5')).toBeNull() // not whole
-    expect(elicitReplyAnswer(number, 'four')).toBeNull()
-    // Shapes `Number()` reads as numbers that no reader typed as one.
-    expect(elicitReplyAnswer(number, '0x3')).toBeNull()
-    expect(elicitReplyAnswer(number, '')).toBeNull()
-    expect(elicitReplyAnswer(number, 'Infinity')).toBeNull()
-    const text = elicitTarget(
-      form({ t: { type: 'string', minLength: 3, maxLength: 6, pattern: '^[a-z]+$' } }),
-      SLACK_ELICIT_SURFACE
-    )!
-    expect(elicitReplyAnswer(text, ' abcd \n')).toBe('abcd')
-    expect(elicitReplyAnswer(text, 'ab')).toBeNull()
-    expect(elicitReplyAnswer(text, 'abcdefg')).toBeNull()
-    expect(elicitReplyAnswer(text, 'ABCD')).toBeNull()
-    // A pick is never answered by typing at it: that would let an unoffered value through.
-    const pick = elicitTarget(form({ p: { type: 'string', enum: ['main'] } }), SLACK_ELICIT_SURFACE)!
-    expect(elicitReplyAnswer(pick, 'main')).toBeNull()
   })
 
   it('declines an array the card cannot honestly answer', () => {

--- a/packages/daemon/test/slack-elicit-form.test.ts
+++ b/packages/daemon/test/slack-elicit-form.test.ts
@@ -1,11 +1,11 @@
 /**
- * A MULTI-FIELD elicitation form on Slack (issue #1794's last Slack-column item). Every other
- * shape now answers without a modal — buttons, a `multi_static_select` plus Confirm, a thread
- * reply, a consent button — and this is the one that genuinely needs one: an `actions` block
- * holds no inputs, so the fields cannot be in the channel at all.
+ * A Slack elicitation whose answer has to be FILLED IN (issue #1794's last Slack-column item).
+ * Only a lone single-select or boolean is a row of buttons — one tap answers it — and everything
+ * else is `input` blocks in the message itself with one Confirm and one Dismiss: several
+ * questions, a question with its own free-text box, a multi-select, a typed box.
  *
- * The card is therefore the question, a line naming what will be asked, Answer and Dismiss; the
- * modal behind Answer carries one `input` block per field, and its submission is re-validated
+ * There is no modal. Slack carries a message's whole input state on any `block_actions` payload,
+ * so Confirm submits every field the tapping reader had filled in, and the record is re-validated
  * whole against the card that offered it before the ACP request is resolved.
  */
 import { describe, it, expect, vi } from 'vitest'
@@ -15,19 +15,20 @@ import { TerminalOutputFolder } from '../src/session/terminal-output-folder.js'
 import { fakeSlackAppFactory } from './fakes/slack-app.js'
 import { SlackConnection } from '../src/slack/connection.js'
 import {
+  ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
-  ELICIT_OPEN_ACTION,
   SLACK_DM_ELICIT_SURFACE,
   SLACK_ELICIT_SURFACE,
   buildElicitationCard,
   buildElicitationFormCard,
-  buildElicitationFormModal,
+  elicitCardShape,
   elicitForm,
   elicitFormBlockId,
   elicitFormSubmission,
-  elicitTarget
+  elicitTarget,
+  slackCardViolations
 } from '../src/slack/render.js'
-import { decodeElicitFormMetadata, encodeSharedSlackStatusTarget } from '@agentconnect.md/protocol'
+import { encodeSharedSlackStatusTarget } from '@agentconnect.md/protocol'
 
 const TARGET = encodeSharedSlackStatusTarget({ agentId: 'agent-1', integrationId: 'int-a', sessionKey: 'k1' })
 
@@ -40,7 +41,7 @@ function form(properties: Record<string, unknown>, required: string[] = []): Cre
   } as CreateElicitationRequest
 }
 
-/** One field of every kind Slack claims, so the modal's whole element table is exercised. */
+/** One field of every kind Slack claims, so the card's whole element table is exercised. */
 const EVERY_KIND = {
   branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' },
   checks: { type: 'array', items: { type: 'string', enum: ['lint', 'test'] }, minItems: 1, title: 'Checks' },
@@ -55,87 +56,139 @@ const TWO = {
   note: { type: 'string', maxLength: 20 }
 }
 
-const blocksOf = (view: Record<string, unknown> | null) => (view?.blocks ?? []) as Record<string, any>[]
-const inputsOf = (view: Record<string, unknown> | null) => blocksOf(view).filter((b) => b.type === 'input')
+const cardFor = (req: CreateElicitationRequest, target?: string) =>
+  buildElicitationFormCard('elicit-1', req, elicitForm(req, SLACK_ELICIT_SURFACE)!, target) as any[] | null
+const inputsOf = (blocks: any[] | null) => (blocks ?? []).filter((b) => b.type === 'input')
 
-describe('the in-channel card of a multi-field form', () => {
-  it('carries the question, what will be asked, and Answer beside Dismiss — never the fields', () => {
-    const req = form(TWO, ['branch'])
-    const card = buildElicitationFormCard('elicit-1', req, elicitForm(req, SLACK_ELICIT_SURFACE)!, TARGET) as any[]
+describe('the in-message card a filled-in answer is given on', () => {
+  it('renders one input block per field, each with its own kind and bounds, then ONE Confirm', () => {
+    const card = cardFor(form(EVERY_KIND, ['branch', 'checks']), TARGET)!
+    expect(slackCardViolations(card)).toEqual([])
+    const inputs = inputsOf(card)
+    expect(inputs.map((b) => [b.block_id, b.element.type, b.optional, b.label.text])).toEqual([
+      [elicitFormBlockId(0), 'radio_buttons', false, 'Base branch'],
+      [elicitFormBlockId(1), 'checkboxes', false, 'Checks'],
+      [elicitFormBlockId(2), 'plain_text_input', true, 'note'],
+      [elicitFormBlockId(3), 'number_input', true, 'count'],
+      [elicitFormBlockId(4), 'radio_buttons', true, 'draft']
+    ])
+    expect(inputs[0]!.element.options.map((o: any) => o.value)).toEqual(['main', 'develop'])
+    // `minItems` has no Slack attribute — and `checkboxes` has no `max_selected_items` at all —
+    // so the bounds are said as a hint and enforced when the answer comes back.
+    expect(inputs[1]!.hint.text).toBe('Select at least 1.')
+    expect(inputs[1]!.element.max_selected_items).toBeUndefined()
+    expect(inputs[2]!.element.max_length).toBe(20)
+    expect(inputs[2]!.hint.text).toBe('Anything the reviewer should know')
+    expect(inputs[3]!.element).toMatchObject({ is_decimal_allowed: false, min_value: '1', max_value: '9' })
+    // A boolean's `default` seeds the control with the option that spells it.
+    expect(inputs[4]!.element.initial_option.value).toBe('true')
+    // The question is a section, and the FIRST thing on the card.
+    expect(card[0]).toMatchObject({ type: 'section' })
     expect(card[0].text.text).toContain('How should I cut the release?')
-    expect(card[1].elements[0].text).toBe('Asks for Base branch, note.')
-    const actions = card[2]
+    // ONE Confirm for the whole card, never one per question, beside Dismiss — and they keep the
+    // actions block whose block_id the relay routes on.
+    const actions = card[card.length - 1]
     expect(actions.type).toBe('actions')
     expect(actions.block_id).toBe(TARGET)
     expect(actions.elements.map((e: any) => [e.action_id, e.value, e.text.text])).toEqual([
-      [ELICIT_OPEN_ACTION, 'elicit-1', 'Answer'],
+      [ELICIT_CONFIRM_ACTION, 'elicit-1', 'Confirm'],
       [ELICIT_DISMISS_ACTION, 'elicit-1', 'Dismiss']
     ])
-    // No input element anywhere: an actions block cannot hold one, which is the whole reason
-    // this shape has a modal at all.
-    expect(JSON.stringify(card)).not.toContain('plain_text_input')
+  })
+
+  // Slack caps `checkboxes` and `radio_buttons` at ten options and answers `no more than 10 items
+  // allowed` past that; the select menus hold a hundred. The card picks by list length, not taste.
+  it('falls back to the select menus past the ten options a checkbox or radio list holds', () => {
+    const many = (n: number) => Array.from({ length: n }, (_, i) => `o${i}`)
+    const short = cardFor(
+      form({
+        pick: { type: 'string', enum: many(10) },
+        many: { type: 'array', items: { type: 'string', enum: many(10) } }
+      })
+    )!
+    expect(inputsOf(short).map((b) => b.element.type)).toEqual(['radio_buttons', 'checkboxes'])
+    const long = cardFor(
+      form({
+        pick: { type: 'string', enum: many(11) },
+        many: { type: 'array', items: { type: 'string', enum: many(11) } }
+      })
+    )!
+    expect(inputsOf(long).map((b) => b.element.type)).toEqual(['static_select', 'multi_static_select'])
+    expect(slackCardViolations(short)).toEqual([])
+    expect(slackCardViolations(long)).toEqual([])
   })
 
   it('defuses the agent’s own message exactly as every other card does', () => {
     const req = form(TWO, ['branch'])
     ;(req as any).message = 'Sign in at https://evil.example/x <https://evil.example/y|here>'
-    const card = buildElicitationFormCard('elicit-1', req, elicitForm(req, SLACK_ELICIT_SURFACE)!) as any[]
+    const card = cardFor(req)!
     expect(card[0].text.text).toContain('`https://evil.example/x`')
     expect(card[0].text.text).toContain('&lt;')
     expect(card[0].text.text).not.toContain('<https://evil.example/y|here>')
   })
-})
 
-describe('the modal a multi-field form is answered in', () => {
-  it('renders one input block per field, each with its own kind and bounds', () => {
-    const req = form(EVERY_KIND, ['branch', 'checks'])
-    const view = buildElicitationFormModal('elicit-1', req, elicitForm(req, SLACK_ELICIT_SURFACE)!, TARGET)
-    const inputs = inputsOf(view)
-    expect(inputs.map((b) => [b.block_id, b.element.type, b.optional, b.label.text])).toEqual([
-      [elicitFormBlockId(0), 'static_select', false, 'Base branch'],
-      [elicitFormBlockId(1), 'multi_static_select', false, 'Checks'],
-      [elicitFormBlockId(2), 'plain_text_input', true, 'note'],
-      [elicitFormBlockId(3), 'number_input', true, 'count'],
-      [elicitFormBlockId(4), 'static_select', true, 'draft']
-    ])
-    expect(inputs[0]!.element.options.map((o: any) => o.value)).toEqual(['main', 'develop'])
-    // `minItems` has no Slack attribute, so it is said as a hint and enforced on submit.
-    expect(inputs[1]!.hint.text).toBe('Select at least 1.')
-    expect(inputs[2]!.element.max_length).toBe(20)
-    expect(inputs[2]!.hint.text).toBe('Anything the reviewer should know')
-    expect(inputs[3]!.element).toMatchObject({ is_decimal_allowed: false, min_value: '1', max_value: '9' })
-    // A boolean's `default` seeds the select with the option that spells it.
-    expect(inputs[4]!.element.initial_option.value).toBe('true')
-    // The question itself is a section, and the FIRST thing in the modal.
-    expect(blocksOf(view)[0]).toMatchObject({ type: 'section' })
-    expect((blocksOf(view)[0]! as any).text.text).toContain('How should I cut the release?')
-  })
-
-  it('titles itself in fixed words inside Slack’s 24-character cap, and names the card in its metadata', () => {
-    const req = form(TWO, ['branch'])
-    const view = buildElicitationFormModal('elicit-9', req, elicitForm(req, SLACK_ELICIT_SURFACE)!, TARGET)!
-    const title = (view.title as { text: string }).text
-    expect(title).toBe('Agent needs your input')
-    expect(title.length).toBeLessThanOrEqual(24)
-    // Not the agent's words: 24 characters hold no question, and the title is the line a reader
-    // trusts most. Its own message is in the body instead, defused like the card's.
-    expect(title).not.toContain('release')
-    expect(decodeElicitFormMetadata(view.private_metadata as string)).toEqual({
-      requestId: 'elicit-9',
-      target: TARGET
-    })
-  })
-
-  it('is withheld when a field cannot BE an input block, so no Answer button is ever posted dead', () => {
-    // Slack caps a select option's `value` at 75 characters and a modal has no button to fall
-    // back to (#1813's finding, one surface on).
+  it('is withheld when a field cannot BE an input block, so no card is ever posted dead', () => {
+    // Slack caps a select option's `value` at 75 characters and an input block has no button to
+    // fall back to (#1813's finding, one surface on).
     const long = 'x'.repeat(80)
     const req = form({ branch: { type: 'string', enum: [long, 'dev'] }, note: { type: 'string' } }, ['branch'])
     expect(elicitForm(req, SLACK_ELICIT_SURFACE)).toHaveLength(2)
-    expect(buildElicitationFormModal('elicit-1', req, elicitForm(req, SLACK_ELICIT_SURFACE)!)).toBeNull()
+    expect(cardFor(req)).toBeNull()
     // And a minimum length no input can hold.
-    const wide = form({ a: { type: 'string', minLength: 3500 }, b: { type: 'boolean' } })
-    expect(buildElicitationFormModal('elicit-1', wide, elicitForm(wide, SLACK_ELICIT_SURFACE)!)).toBeNull()
+    expect(cardFor(form({ a: { type: 'string', minLength: 3500 }, b: { type: 'boolean' } }))).toBeNull()
+  })
+})
+
+// The crux of the shape matrix: a button submits the instant it is tapped, so it can only answer
+// a question that needs nothing filled in first.
+describe('a card is a button row exactly when ONE TAP can answer it', () => {
+  const shape = (props: Record<string, unknown>, required: string[] = []) =>
+    elicitCardShape(elicitForm(form(props, required), SLACK_ELICIT_SURFACE)!)
+
+  it('gives buttons to a lone single-select or boolean, and inputs to everything else', () => {
+    expect(shape({ branch: { type: 'string', enum: ['main', 'dev'] } })).toBe('buttons')
+    expect(shape({ draft: { type: 'boolean' } })).toBe('buttons')
+    // A multi-select cannot be carried by a tap; a typed box has to be typed into first.
+    expect(shape({ checks: { type: 'array', items: { type: 'string', enum: ['lint'] } } })).toBe('inputs')
+    expect(shape({ note: { type: 'string' } })).toBe('inputs')
+    expect(shape({ count: { type: 'integer' } })).toBe('inputs')
+    // Several questions, however each is answered.
+    expect(shape(TWO, ['branch'])).toBe('inputs')
+  })
+
+  // The distinction that decides this: `elicitForm` marks a select question's own free-text box
+  // with `customAnswerFor`, so a question WITH a box is two targets and one question, where two
+  // questions are two of each. Either way the card needs its inputs — and a companion box is
+  // precisely a thing to fill in before submitting, so its question loses the button row.
+  it('gives a single-select with its own “Other” box radio buttons and that box, plus one Confirm', () => {
+    const req = form({
+      branch: { type: 'string', enum: ['main', 'develop'], title: 'Base branch' },
+      other: {
+        type: 'string',
+        title: 'Other',
+        _meta: { _askUserQuestionCustomAnswer: { isCustomAnswer: true, questionId: 'branch' } }
+      }
+    })
+    const reduced = elicitForm(req, SLACK_ELICIT_SURFACE)!
+    expect(reduced).toHaveLength(2)
+    expect(reduced.filter((t) => !t.customAnswerFor)).toHaveLength(1)
+    expect(elicitCardShape(reduced)).toBe('inputs')
+    const card = cardFor(req)!
+    expect(slackCardViolations(card)).toEqual([])
+    expect(inputsOf(card).map((b) => [b.element.type, b.label.text])).toEqual([
+      ['radio_buttons', 'Base branch'],
+      // The box is named for the question it belongs to, never "Other" on its own.
+      ['plain_text_input', 'Base branch (Other)']
+    ])
+    expect(card[card.length - 1].elements[0].action_id).toBe(ELICIT_CONFIRM_ACTION)
+  })
+
+  it('keeps the one-tap row for a lone select — the same field, alone, does not lose its tap', () => {
+    const req = form({ branch: { type: 'string', enum: ['main', 'develop'] } }, ['branch'])
+    const card = buildElicitationCard('elicit-1', req, TARGET) as any[]
+    expect(slackCardViolations(card)).toEqual([])
+    expect(card[1].elements.map((e: any) => e.text.text)).toEqual(['main', 'develop', 'Dismiss'])
+    expect(JSON.stringify(card)).not.toContain(ELICIT_CONFIRM_ACTION)
   })
 })
 
@@ -216,8 +269,7 @@ describe('a form submission is re-derived against the card that offered it', () 
   it('validates a pattern Slack has no attribute for, and returns it as that field’s error', () => {
     const patterned = form({ tag: { type: 'string', pattern: '^v[0-9]+$' }, note: { type: 'string' } }, ['tag'])
     const shape = elicitForm(patterned, SLACK_ELICIT_SURFACE)!
-    const view = buildElicitationFormModal('elicit-1', patterned, shape)!
-    expect(JSON.stringify(view)).not.toContain('pattern')
+    expect(JSON.stringify(cardFor(patterned))).not.toContain('pattern')
     expect(elicitFormSubmission(patterned, shape, { [elicitFormBlockId(0)]: 'v12' })).toEqual({
       answer: { tag: 'v12' }
     })
@@ -227,10 +279,10 @@ describe('a form submission is re-derived against the card that offered it', () 
   })
 })
 
-describe('the approval-DM surface does not gain multi-field', () => {
-  it('builds no card for a form asking two questions, so a DM never posts an Answer button', () => {
-    // Both kinds ARE in the DM surface, so this is not a kind refusal: the DM path reads the
-    // single-field reduction and nothing else, and a DM has no turn whose card we could rewrite.
+describe('the approval-DM surface stays one tap', () => {
+  it('builds no card for a form asking two questions, so a DM never posts a dead Confirm', () => {
+    // Both kinds ARE in the DM surface, so this is not a kind refusal: a DM card settles through
+    // the editor path, which holds no per-card state, so nothing needing a Confirm can live there.
     const req = form({ branch: { type: 'string', enum: ['main', 'dev'] }, draft: { type: 'boolean' } }, [
       'branch',
       'draft'
@@ -241,28 +293,7 @@ describe('the approval-DM surface does not gain multi-field', () => {
   })
 })
 
-describe('the single-field card paths are unchanged', () => {
-  it('a one-question form still posts its button row, with no Answer button', () => {
-    const req = form({ branch: { type: 'string', enum: ['main', 'develop'] } }, ['branch'])
-    const card = buildElicitationCard('elicit-1', req, TARGET) as any[]
-    expect(card[1].elements.map((e: any) => e.text.text)).toEqual(['main', 'develop', 'Dismiss'])
-    expect(JSON.stringify(card)).not.toContain(ELICIT_OPEN_ACTION)
-  })
-
-  it('a select question plus its own “Other” box stays one question, and stays on the button row', () => {
-    const req = form({
-      branch: { type: 'string', enum: ['main', 'develop'] },
-      other: {
-        type: 'string',
-        _meta: { _askUserQuestionCustomAnswer: { isCustomAnswer: true, questionId: 'branch' } }
-      }
-    })
-    expect(elicitForm(req, SLACK_ELICIT_SURFACE)!.filter((t) => !t.customAnswerFor)).toHaveLength(1)
-    expect(elicitTarget(req, SLACK_ELICIT_SURFACE)?.propName).toBe('branch')
-  })
-})
-
-// ── the coordinator: posting the card, opening the modal, settling on submit ──────────────────
+// ── the coordinator: posting the card, settling on Confirm ────────────────────────────────────
 
 function installPending(daemon: any): any {
   daemon.store = {
@@ -304,7 +335,6 @@ interface Harness {
   conn: any
   posted: unknown[][]
   updated: unknown[][]
-  views: unknown[]
   notices: () => string[]
 }
 
@@ -314,7 +344,6 @@ function slackTurn(): Harness {
   installPending(daemon)
   const posted: unknown[][] = []
   const updated: unknown[][] = []
-  const views: unknown[] = []
   const conn = Object.create(SlackConnection.prototype)
   conn.postBlocks = async (_c: string, blocks: unknown[]) => {
     posted.push(blocks)
@@ -324,7 +353,6 @@ function slackTurn(): Harness {
     updated.push(blocks)
     return true
   }
-  conn.openView = async (_t: string, view: unknown) => void views.push(view)
   conn.workspaceId = () => 'T1'
   daemon.pending.get(JSON.stringify(['agent-1', 's1'])).conn = conn
   daemon.httpSlackSessionTarget = () => TARGET
@@ -336,7 +364,6 @@ function slackTurn(): Harness {
     conn,
     posted,
     updated,
-    views,
     notices: () => applied.filter((a) => a.kind === 'notice').map((a) => a.text as string)
   }
 }
@@ -355,23 +382,19 @@ const submitFields = (branch: string, note?: string) => ({
   ...(note !== undefined ? { [elicitFormBlockId(1)]: note } : {})
 })
 
-describe('a Slack turn answers a multi-field form through its modal', () => {
-  it('posts the Answer card, opens one input per field, and accepts the typed record', async () => {
+describe('a Slack turn answers a form card from its own Confirm', () => {
+  it('posts the inputs in the channel, and accepts the typed record on Confirm', async () => {
     const h = slackTurn()
     const { requestId, result } = await raise(h, form(TWO, ['branch']))
     expect(h.notices()).toEqual([])
-    expect(JSON.stringify(h.posted[0])).toContain(ELICIT_OPEN_ACTION)
+    expect(inputsOf(h.posted[0] as any[])).toHaveLength(2)
+    expect(slackCardViolations(h.posted[0] as any[])).toEqual([])
 
-    await h.daemon.permissions.openElicitFormModal({ requestId, triggerId: 'trig-1', conn: h.conn })
-    expect(inputsOf(h.views[0] as any)).toHaveLength(2)
-
-    await expect(
-      h.daemon.permissions.submitElicitForm({
-        requestId,
-        fields: submitFields('develop', 'ship it'),
-        actor: { userId: 'U-ALICE', name: 'alice' }
-      })
-    ).resolves.toBeUndefined()
+    await h.daemon.permissions.submitElicitForm({
+      requestId,
+      fields: submitFields('develop', 'ship it'),
+      actor: { userId: 'U-ALICE', name: 'alice' }
+    })
     await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'develop', note: 'ship it' } })
     // The card is rewritten to the settled state, naming the fields in the card's own words.
     expect(JSON.stringify(h.updated[0])).toContain('Base branch: develop')
@@ -382,12 +405,11 @@ describe('a Slack turn answers a multi-field form through its modal', () => {
   it('takes an omitted optional field and refuses a missing required one, leaving the card live', async () => {
     const h = slackTurn()
     const { requestId, result } = await raise(h, form(TWO, ['branch']))
-    await expect(
-      h.daemon.permissions.submitElicitForm({ requestId, fields: { [elicitFormBlockId(1)]: 'note only' } })
-    ).resolves.toEqual({
-      response_action: 'errors',
-      errors: { [elicitFormBlockId(0)]: 'This field is required.' }
-    })
+    await h.daemon.permissions.submitElicitForm({ requestId, fields: { [elicitFormBlockId(1)]: 'note only' } })
+    // No modal to hand the errors back to, so the thread is told which field refused it.
+    expect(h.notices()).toEqual([
+      "That answer wasn't accepted — the question is still open. Base branch: This field is required."
+    ])
     expect(h.daemon.permissions.pendingElicits.size).toBe(1)
     expect(h.updated).toEqual([])
 
@@ -395,65 +417,41 @@ describe('a Slack turn answers a multi-field form through its modal', () => {
     await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
   })
 
-  it('refuses one bad field with a per-field error and does NOT resolve the request', async () => {
+  it('refuses one bad field, names it in the thread, and does NOT resolve the request', async () => {
     const h = slackTurn()
     const { requestId, result } = await raise(h, form(TWO, ['branch']))
     let settled = false
     void result.then(() => (settled = true))
-    await expect(
-      h.daemon.permissions.submitElicitForm({ requestId, fields: submitFields('main', 'x'.repeat(50)) })
-    ).resolves.toEqual({
-      response_action: 'errors',
-      errors: { [elicitFormBlockId(1)]: 'Enter some text, at most 20 characters long.' }
-    })
+    await h.daemon.permissions.submitElicitForm({ requestId, fields: submitFields('main', 'x'.repeat(50)) })
+    expect(h.notices()[0]).toContain('note: Enter some text, at most 20 characters long.')
     expect(settled).toBe(false)
     expect(h.daemon.permissions.pendingElicits.size).toBe(1)
     await h.daemon.permissions.releaseElicits('agent-1', 's1')
     await expect(result).resolves.toEqual({ action: 'cancel' })
   })
 
-  it('Dismiss on the card declines it without ever opening the modal', async () => {
+  it('Dismiss on the card declines it without any field being read', async () => {
     const h = slackTurn()
     const { requestId, result } = await raise(h, form(TWO, ['branch']))
     await h.daemon.permissions.handleElicitChoice({ requestId, value: null, actor: { userId: 'U-BOB' } })
     await expect(result).resolves.toEqual({ action: 'decline' })
-    expect(h.views).toEqual([])
   })
 
-  it('tells the SECOND submitter the question is closed, rather than settling it twice', async () => {
+  it('settles once when two readers Confirm, and the second finds nothing to answer', async () => {
     const h = slackTurn()
     const { requestId, result } = await raise(h, form(TWO, ['branch']))
-    // Two readers may each open the modal — Slack keeps their input in their own view — and the
-    // first submission settles the ACP request. The second gets the closed view, not silence.
-    await h.daemon.permissions.openElicitFormModal({ requestId, triggerId: 'trig-a', conn: h.conn })
-    await h.daemon.permissions.openElicitFormModal({ requestId, triggerId: 'trig-b', conn: h.conn })
-    expect(h.views).toHaveLength(2)
-    expect(h.views[0]).toEqual(h.views[1])
-
     await h.daemon.permissions.submitElicitForm({ requestId, fields: submitFields('main'), actor: { userId: 'U-A' } })
     await expect(result).resolves.toEqual({ action: 'accept', content: { branch: 'main' } })
-    const second = await h.daemon.permissions.submitElicitForm({
+    await h.daemon.permissions.submitElicitForm({
       requestId,
       fields: submitFields('develop'),
       actor: { userId: 'U-B' }
     })
-    expect(second).toMatchObject({ response_action: 'update' })
-    expect(JSON.stringify(second)).toContain('already been answered')
     // One resolution only: the accepted content is still the first reader's.
     expect(h.updated).toHaveLength(1)
   })
 
-  it('opens the closed modal when the card is already settled, so Answer is never a dead button', async () => {
-    const h = slackTurn()
-    const { requestId, result } = await raise(h, form(TWO, ['branch']))
-    await h.daemon.permissions.handleElicitChoice({ requestId, value: null })
-    await expect(result).resolves.toEqual({ action: 'decline' })
-    await h.daemon.permissions.openElicitFormModal({ requestId, triggerId: 'trig-late', conn: h.conn })
-    expect(JSON.stringify(h.views[0])).toContain('already been answered')
-    expect(inputsOf(h.views[0] as any)).toEqual([])
-  })
-
-  it('declines with a notice, and posts no card, when no modal can hold the form', async () => {
+  it('declines with a notice, and posts no card, when no card can hold the form', async () => {
     const h = slackTurn()
     const long = 'x'.repeat(80)
     const req = form({ branch: { type: 'string', enum: [long, 'dev'] }, note: { type: 'string' } }, ['branch'])
@@ -464,15 +462,10 @@ describe('a Slack turn answers a multi-field form through its modal', () => {
   })
 })
 
-describe('both Slack ingress paths open the same modal and settle the same way', () => {
-  it('a relay-forwarded Answer opens the identical view, and its submit rides the ack', async () => {
+describe('both Slack ingress paths settle a form card the same way', () => {
+  it('a relay-forwarded Confirm carries the fields and settles the identical request', async () => {
     const h = slackTurn()
     const { requestId, result } = await raise(h, form(TWO, ['branch']))
-    // The direct Socket Mode arm: the connection's own handler calls exactly this.
-    await h.daemon.permissions.openElicitFormModal({ requestId, triggerId: 'trig-socket', conn: h.conn })
-
-    // The relay arm: the click is forwarded as `elicitation-open` and the DAEMON opens the view
-    // on its own bot token, so nothing pre-rendered ever crosses to the relay.
     const agent = { id: 'agent-1', integrations: [{ id: 'int-a', platform: 'slack', core: { mode: 'shared' } }] }
     h.daemon.agents = new Map([['agent-1', agent]])
     h.daemon.connByIntegration = new Map([['int-a', h.conn]])
@@ -488,28 +481,15 @@ describe('both Slack ingress paths open the same modal and settle the same way',
         payload
       })
 
-    expect(await relay({ kind: 'elicitation-open', requestId, triggerId: 'trig-relay' }, 'a-open')).toEqual({
-      msgId: 'a-open',
-      accepted: true
-    })
-    await vi.waitFor(() => expect(h.views).toHaveLength(2))
-    expect(h.views[1]).toEqual(h.views[0])
-
-    // A refused field's verdict rides back on the ack's opaque `response`, which the relay
-    // surfaces verbatim on Slack's own 200 — the one action on this seam Slack waits for.
+    // A refused field leaves the card live and says so in the thread; the ack carries no verdict,
+    // because there is no modal on the far side waiting for one.
     expect(
-      await relay({ kind: 'elicitation-submit', requestId, fields: submitFields('main', 'x'.repeat(50)) }, 'a-bad')
-    ).toEqual({
-      msgId: 'a-bad',
-      accepted: true,
-      response: {
-        response_action: 'errors',
-        errors: { [elicitFormBlockId(1)]: 'Enter some text, at most 20 characters long.' }
-      }
-    })
+      await relay({ kind: 'elicitation-confirm', requestId, fields: submitFields('main', 'x'.repeat(50)) }, 'a-bad')
+    ).toEqual({ msgId: 'a-bad', accepted: true })
+    expect(h.notices()[0]).toContain('note: Enter some text, at most 20 characters long.')
     expect(h.daemon.permissions.pendingElicits.size).toBe(1)
 
-    expect(await relay({ kind: 'elicitation-submit', requestId, fields: submitFields('main') }, 'a-ok')).toEqual({
+    expect(await relay({ kind: 'elicitation-confirm', requestId, fields: submitFields('main') }, 'a-ok')).toEqual({
       msgId: 'a-ok',
       accepted: true
     })

--- a/packages/daemon/test/slack-status-actor.test.ts
+++ b/packages/daemon/test/slack-status-actor.test.ts
@@ -10,14 +10,10 @@ import { SlackConnection } from '../src/slack/connection.js'
 import {
   STATUS_ACTION,
   ELICIT_CONFIRM_ACTION,
-  ELICIT_FORM_CALLBACK_ID,
-  ELICIT_OPEN_ACTION,
-  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   elicitFormBlockId,
   encodePermValue
 } from '../src/slack/render.js'
-import { encodeElicitFormMetadata } from '@agentconnect.md/protocol'
 
 type ActionArgs = {
   ack: () => Promise<void>
@@ -32,34 +28,26 @@ type ActionArgs = {
     trigger_id?: string
     view?: { private_metadata?: string }
     user?: { id?: string }
-    state?: { values?: Record<string, Record<string, { selected_options?: { value?: unknown }[] }>> }
+    state?: { values?: Record<string, Record<string, unknown>> }
   }
 }
 type Handler = (args: ActionArgs) => Promise<void> | void
 
-type ViewArgs = {
-  ack: (response?: unknown) => Promise<void>
-  body?: { user?: { id?: string } }
-  view?: { private_metadata?: string; state?: { values?: Record<string, Record<string, unknown>> } }
-}
-type ViewHandler = (args: ViewArgs) => Promise<void> | void
-
 /** A Bolt stand-in: enough surface for `start()` to reach handler registration. */
-function fakeApp(actions: Map<string, Handler>, views?: Map<string, ViewHandler>) {
+function fakeApp(actions: Map<string, Handler>) {
   return {
     init: async () => {},
     message: () => {},
     event: () => {},
     action: (id: string | RegExp, handler: Handler) => actions.set(String(id), handler),
     shortcut: () => {},
-    view: (id: string, handler: ViewHandler) => void views?.set(id, handler),
     start: async () => {},
     stop: async () => {},
     client: { auth: { test: async () => ({ user_id: 'UBOT', bot_id: 'BBOT', url: 'https://x.slack.test/' }) } }
   } as never
 }
 
-async function connect(deps: Record<string, unknown>, views?: Map<string, ViewHandler>): Promise<Map<string, Handler>> {
+async function connect(deps: Record<string, unknown>): Promise<Map<string, Handler>> {
   const actions = new Map<string, Handler>()
   const conn = new SlackConnection(
     {
@@ -69,7 +57,7 @@ async function connect(deps: Record<string, unknown>, views?: Map<string, ViewHa
       sendIntervalMs: 0,
       ...deps
     } as never,
-    () => fakeApp(actions, views)
+    () => fakeApp(actions)
   )
   await conn.start()
   return actions
@@ -105,17 +93,14 @@ describe('slack status actions carry the acting user', () => {
     expect(seen).toEqual([{ requestId: 'req-1', optionId: 'allow_always', actor: { userId: 'U-BOB' } }])
   })
 
-  // A multi-select card's Confirm reads its selection out of its OWN payload's message state
-  // (Slack has carried full state on `block_actions` since 2020-09-01), so what reaches the
-  // daemon is the state THIS reader tapped Confirm on — nothing is kept between interactions.
-  it('reports the selection a multi-select Confirm’s own payload carried', async () => {
-    const confirmed: unknown[] = []
-    const actions = await connect({ onElicitConfirm: (a: unknown) => confirmed.push(a) })
-    const stateWith = (values: string[], block = 'blk-1') => ({
-      values: {
-        [block]: { [`${ELICIT_SELECT_ACTION}:elicit-9`]: { selected_options: values.map((value) => ({ value })) } }
-      }
-    })
+  // A form card's Confirm reads every field out of its OWN payload's message state (Slack has
+  // carried full state on `block_actions` since 2020-09-01), so what reaches the daemon is the
+  // state THIS reader tapped Confirm on — nothing is kept between interactions. An `input` block
+  // raises no interaction of its own, so Confirm is the only handler this card needs.
+  it('reports the fields a Confirm’s own payload carried, keyed by block id', async () => {
+    const submitted: unknown[] = []
+    const actions = await connect({ onElicitFormSubmit: (a: unknown) => submitted.push(a) })
+    const stateWith = (values: Record<string, Record<string, unknown>>) => ({ values })
     const confirm = (state?: ReturnType<typeof stateWith>, user?: string) =>
       actions.get(ELICIT_CONFIRM_ACTION)!({
         ack,
@@ -123,109 +108,34 @@ describe('slack status actions carry the acting user', () => {
         body: { ...(state !== undefined ? { state } : {}), ...(user ? { user: { id: user } } : {}) }
       })
 
-    await confirm(stateWith(['lint', 'test']), 'U-DAN')
-    // Found by ACTION id, whichever block Slack grouped the select into.
-    await confirm(stateWith(['test'], 'another-block'), 'U-ERIN')
-    // An emptied select is a real answer; no state for it is not one, and reaches nothing.
-    await confirm(stateWith([]))
-    await confirm({ values: {} })
-    await confirm()
-    expect(confirmed).toEqual([
-      { requestId: 'elicit-9', values: ['lint', 'test'], actor: { userId: 'U-DAN' } },
-      { requestId: 'elicit-9', values: ['test'], actor: { userId: 'U-ERIN' } },
-      { requestId: 'elicit-9', values: [], actor: undefined }
-    ])
-  })
-
-  // A selection change is acked and otherwise ignored: there is no state to record.
-  it('acks a selection change without reporting anything', async () => {
-    const seen: unknown[] = []
-    const actions = await connect({ onElicitConfirm: (a: unknown) => seen.push(a) })
-    const select = [...actions.entries()].find(([id]) => id.includes(`${ELICIT_SELECT_ACTION}:`))![1]
-    let acked = false
-    await select({
-      ack: async () => void (acked = true),
-      action: { action_id: `${ELICIT_SELECT_ACTION}:elicit-9`, selected_options: [{ value: 'lint' }] },
-      body: {}
-    })
-    expect(acked).toBe(true)
-    expect(seen).toEqual([])
-  })
-
-  // A multi-field card's two interactions (#1794's Slack column): Answer, which opens the modal
-  // the daemon builds, and the modal's own submission, whose verdict rides that ack. Both carry
-  // the tapping user, and Answer carries the connection so the view opens on this bot's token.
-  it('reports the reader who tapped Answer, and hands the connection the view opens on', async () => {
-    const opened: any[] = []
-    const actions = await connect({ onElicitFormOpen: (a: unknown) => opened.push(a) })
-
-    await actions.get(ELICIT_OPEN_ACTION)!({
-      ack,
-      action: { value: 'elicit-7' },
-      body: { trigger_id: 'trig-1', user: { id: 'U-CARA' } }
-    })
-    // No trigger id is nothing to open — the card stays live and Answer can be tapped again.
-    await actions.get(ELICIT_OPEN_ACTION)!({ ack, action: { value: 'elicit-7' }, body: { user: { id: 'U-CARA' } } })
-
-    expect(opened).toHaveLength(1)
-    expect(opened[0]).toMatchObject({ requestId: 'elicit-7', triggerId: 'trig-1', actor: { userId: 'U-CARA' } })
-    expect(opened[0].conn).toBeInstanceOf(SlackConnection)
-  })
-
-  it('submits the modal’s own state and returns the daemon’s verdict on that ack', async () => {
-    const submitted: any[] = []
-    const views = new Map<string, ViewHandler>()
-    await connect(
-      {
-        onElicitFormSubmit: async (a: unknown) => {
-          submitted.push(a)
-          return { response_action: 'errors', errors: { [elicitFormBlockId(0)]: 'nope' } }
-        }
-      },
-      views
+    await confirm(
+      stateWith({
+        [elicitFormBlockId(0)]: { ac_elicit_input: { selected_option: { value: 'main' } } },
+        [elicitFormBlockId(1)]: { ac_elicit_input: { value: 'ship it' } },
+        [elicitFormBlockId(2)]: { ac_elicit_input: { selected_options: [{ value: 'lint' }] } },
+        // A blank input is OMITTED, which is what an untouched optional field means.
+        [elicitFormBlockId(3)]: { ac_elicit_input: { value: null } },
+        // Neither another block nor another action inside one of ours is this card's field.
+        not_ours: { ac_elicit_input: { value: 'injected' } }
+      }),
+      'U-DAN'
     )
-    const acked: unknown[] = []
-    const submit = (view?: ViewArgs['view']) =>
-      views.get(ELICIT_FORM_CALLBACK_ID)!({
-        ack: async (response?: unknown) => void acked.push(response),
-        body: { user: { id: 'U-DEE' } },
-        ...(view ? { view } : {})
-      })
-
-    await submit({
-      private_metadata: encodeElicitFormMetadata({ requestId: 'elicit-7', target: 'tgt' }),
-      state: {
-        values: {
-          [elicitFormBlockId(0)]: { ac_elicit_input: { selected_option: { value: 'main' } } },
-          [elicitFormBlockId(1)]: { ac_elicit_input: { value: 'ship it' } },
-          [elicitFormBlockId(2)]: { ac_elicit_input: { selected_options: [{ value: 'lint' }] } },
-          // A blank input is OMITTED, which is what an untouched optional field means.
-          [elicitFormBlockId(3)]: { ac_elicit_input: { value: null } },
-          not_ours: { ac_elicit_input: { value: 'injected' } }
-        }
-      }
-    })
+    // An emptied select is a real answer; a Confirm with no state at all submits nothing, and
+    // the daemon refuses it against the card's own `required` set.
+    await confirm(stateWith({ [elicitFormBlockId(0)]: { ac_elicit_input: { selected_options: [] } } }), 'U-ERIN')
+    await confirm()
     expect(submitted).toEqual([
       {
-        requestId: 'elicit-7',
+        requestId: 'elicit-9',
         fields: {
           [elicitFormBlockId(0)]: 'main',
           [elicitFormBlockId(1)]: 'ship it',
           [elicitFormBlockId(2)]: ['lint']
         },
-        actor: { userId: 'U-DEE' }
-      }
-    ])
-    expect(acked).toEqual([{ response_action: 'errors', errors: { [elicitFormBlockId(0)]: 'nope' } }])
-
-    // A submission whose metadata is not ours reaches nothing and is just acked closed.
-    await submit({ private_metadata: 'garbage' })
-    await submit()
-    expect(submitted).toHaveLength(1)
-    expect(acked).toEqual([
-      { response_action: 'errors', errors: { [elicitFormBlockId(0)]: 'nope' } },
-      undefined,
-      undefined
+        actor: { userId: 'U-DAN' }
+      },
+      { requestId: 'elicit-9', fields: { [elicitFormBlockId(0)]: [] }, actor: { userId: 'U-ERIN' } },
+      { requestId: 'elicit-9', fields: {} }
     ])
   })
 

--- a/packages/protocol/src/frames/relay-cp.test.ts
+++ b/packages/protocol/src/frames/relay-cp.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import {
   ELICIT_FORM_INPUT_ACTION,
-  decodeElicitFormMetadata,
   elicitFormBlockId,
   elicitFormBlockIndex,
   elicitFormViewValues,
-  encodeElicitFormMetadata,
   HOOK_DELIVERY_REASON_DISPATCH_TIMEOUT,
   HOOK_DELIVERY_REASON_DAEMON_DRAINING,
   HOOK_DELIVERY_REASON_DAEMON_NOT_HOLDER,
@@ -1070,11 +1068,11 @@ describe('relay↔CP wire — skeleton frame codec (shared-bot-relay.md §7.1)',
   })
 })
 
-describe('the elicitation form modal’s own Slack codecs', () => {
-  it('round-trips the block id, and reads exactly our own field state out of a view', () => {
+describe('the elicitation form card’s own Slack codecs', () => {
+  it('round-trips the block id, and reads exactly our own field state out of a payload', () => {
     expect(elicitFormBlockId(0)).toBe('ac_elicit_f0')
     expect(elicitFormBlockIndex(elicitFormBlockId(12))).toBe(12)
-    // Not ours, or not an index: nothing this modal rendered.
+    // Not ours, or not an index: nothing this card rendered.
     expect(elicitFormBlockIndex('agent_block')).toBeNull()
     expect(elicitFormBlockIndex('ac_elicit_fx')).toBeNull()
     expect(
@@ -1101,20 +1099,6 @@ describe('the elicitation form modal’s own Slack codecs', () => {
       [elicitFormBlockId(6)]: []
     })
     expect(elicitFormViewValues(undefined)).toEqual({})
-  })
-
-  it('round-trips the view metadata and refuses anything that is not one', () => {
-    expect(decodeElicitFormMetadata(encodeElicitFormMetadata({ requestId: 'elicit-1', target: 'tgt' }))).toEqual({
-      requestId: 'elicit-1',
-      target: 'tgt'
-    })
-    // The direct Socket Mode path needs no routing hint: the connection that received the
-    // submission is the one that posted the card.
-    expect(decodeElicitFormMetadata(encodeElicitFormMetadata({ requestId: 'elicit-1' }))).toEqual({
-      requestId: 'elicit-1'
-    })
-    for (const bad of ['', 'not json', '{}', '{"v":2,"r":"x"}', '{"v":1,"r":""}', '{"v":1,"r":"x","t":3}'])
-      expect(decodeElicitFormMetadata(bad)).toBeNull()
   })
 })
 

--- a/packages/protocol/src/frames/relay-cp.ts
+++ b/packages/protocol/src/frames/relay-cp.ts
@@ -601,25 +601,19 @@ export const SLACK_STATUS_ACTION = {
 export const PERMISSION_ACTION_PREFIX = 'ac_perm'
 export const ELICIT_ACTION_PREFIX = 'ac_elicit'
 export const ELICIT_DISMISS_ACTION = 'ac_elicit_dismiss'
-/** A multi-select elicitation card's own two ids: the `multi_static_select`, which never submits
- *  on its own, and the Confirm button that does. The selection is not tracked between the two —
- *  Confirm reads it out of its OWN payload's message state, so what it submits is the state that
- *  card was in when this reader tapped it. The select's action_id carries the request id, which
- *  is the key {@link selectedOptionsFromState} finds that state under. */
-export const ELICIT_SELECT_ACTION = 'ac_elicit_select'
+/** The Confirm button on an elicitation card whose fields are `input` blocks — a select, a
+ *  checkbox list or a typed box never submits on its own. Nothing is tracked between the two:
+ *  Confirm reads every field out of its OWN payload's message state, so what it submits is the
+ *  state that card was in when this reader tapped it. Its `value` is the bare request id. */
 export const ELICIT_CONFIRM_ACTION = 'ac_elicit_confirm'
 
-/** A MULTI-FIELD elicitation card's own three ids. An `actions` block holds no inputs, so the
- *  in-channel card cannot carry the fields at all: it carries an Answer button whose tap opens a
- *  modal ({@link ELICIT_FORM_CALLBACK_ID}) whose `input` blocks are the fields. One input per
- *  block, because Slack keys both the submitted state AND `response_action: errors` by BLOCK id. */
-export const ELICIT_OPEN_ACTION = 'ac_elicit_open'
-export const ELICIT_FORM_CALLBACK_ID = 'ac_elicit_form'
+/** The `action_id` every one of those `input` elements carries. One input per block, because
+ *  Slack keys the submitted state by BLOCK id — {@link elicitFormBlockId} is that key. */
 export const ELICIT_FORM_INPUT_ACTION = 'ac_elicit_input'
 
 const ELICIT_FORM_BLOCK_PREFIX = 'ac_elicit_f'
 
-/** The block id of the modal's Nth field. The INDEX rather than the property name: a property
+/** The block id of the card's Nth field. The INDEX rather than the property name: a property
  *  name can outrun Slack's own id length, and the daemon re-derives the field list from the
  *  card's params anyway (#1815), so an index is all the wire has to carry. */
 export function elicitFormBlockId(index: number): string {
@@ -633,9 +627,10 @@ export function elicitFormBlockIndex(blockId: string): number | null {
   return /^\d+$/.test(digits) ? Number(digits) : null
 }
 
-/** One `view_submission` payload's state — every input of the modal, keyed by block then action
- *  id. Widened past {@link SlackBlockActionsState} because a form's inputs answer with a typed
- *  `value` or a single `selected_option` as well as a list. */
+/** One interactive payload's state — every `input` block of the message, keyed by block then
+ *  action id. Slack has carried the full message state on `block_actions` since 2020-09-01, so a
+ *  Confirm tap arrives with the same shape a view submission does: a typed `value`, one
+ *  `selected_option`, or a list. */
 export interface SlackViewState {
   values?:
     | Record<
@@ -654,11 +649,11 @@ export interface SlackViewState {
     | undefined
 }
 
-/** What the reader typed and picked in a form modal, keyed by the field's BLOCK id so a
- *  per-field error can be returned under the very same key. A blank input and a cleared select
- *  are OMITTED rather than reported as empty: an untouched optional field is absent from the
- *  answer, which is what the schema means by optional, and the daemon's own accept check is
- *  what decides whether a required one may be missing. Pure. */
+/** What the reader typed and picked on a form card, keyed by the field's BLOCK id so a per-field
+ *  verdict can name the very same key. A blank input and a cleared select are OMITTED rather than
+ *  reported as empty: an untouched optional field is absent from the answer, which is what the
+ *  schema means by optional, and the daemon's own accept check is what decides whether a required
+ *  one may be missing. Pure. */
 export function elicitFormViewValues(state: SlackViewState | undefined): Record<string, string | string[]> {
   const out: Record<string, string | string[]> = {}
   for (const [blockId, block] of Object.entries(state?.values ?? {})) {
@@ -675,53 +670,6 @@ export function elicitFormViewValues(state: SlackViewState | undefined): Record<
     else if (typeof input.value === 'string' && input.value.length) out[blockId] = input.value
   }
   return out
-}
-
-/** A form modal's `private_metadata`: which card it answers, plus the opaque session target the
- *  relay routes its submission on (absent on the direct Socket Mode path, which needs no
- *  routing hint — the connection that received the submission is the one that posted the card). */
-export interface SlackElicitFormMetadata {
-  requestId: string
-  target?: string
-}
-
-export function encodeElicitFormMetadata(meta: SlackElicitFormMetadata): string {
-  return JSON.stringify({ v: 1, r: meta.requestId, ...(meta.target ? { t: meta.target } : {}) })
-}
-
-export function decodeElicitFormMetadata(raw: string): SlackElicitFormMetadata | null {
-  try {
-    const parsed = JSON.parse(raw) as { v?: unknown; r?: unknown; t?: unknown }
-    if (parsed.v !== 1 || typeof parsed.r !== 'string' || !parsed.r) return null
-    if (parsed.t !== undefined && typeof parsed.t !== 'string') return null
-    return { requestId: parsed.r, ...(typeof parsed.t === 'string' && parsed.t ? { target: parsed.t } : {}) }
-  } catch {
-    return null
-  }
-}
-
-/** One `block_actions` payload's message state — every stateful element of the message the tap
- *  came from, keyed by block then action id. Slack has carried the full state on `block_actions`
- *  (not just view submissions) since 2020-09-01. */
-export interface SlackBlockActionsState {
-  values?: Record<string, Record<string, { selected_options?: { value?: unknown }[] } | undefined> | undefined>
-}
-
-/** The selection a `multi_static_select` held when this interaction was raised, read from the
- *  payload's own message state — the snapshot a Confirm tap submits, and the reason no selection
- *  has to be tracked between interactions. Searched by ACTION id across every block, so it does
- *  not depend on which block Slack grouped the select into, nor on the card naming that block.
- *  Null ⇒ this payload carries no state for that select, which is NOT an empty selection: the
- *  caller drops the interaction rather than confirm a selection it cannot see. An empty array is
- *  a real answer (the reader cleared the select), which is why the two are distinct. */
-export function selectedOptionsFromState(state: SlackBlockActionsState | undefined, actionId: string): string[] | null {
-  for (const block of Object.values(state?.values ?? {})) {
-    const element = block?.[actionId]
-    if (!element?.selected_options) continue
-    const values = element.selected_options.map((o) => o.value)
-    return values.every((v) => typeof v === 'string') ? (values as string[]) : null
-  }
-  return null
 }
 
 /** Encode/decode the choice carried by permission and elicitation buttons. The

--- a/packages/protocol/src/frames/relay-daemon.test.ts
+++ b/packages/protocol/src/frames/relay-daemon.test.ts
@@ -500,12 +500,10 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       { kind: 'permission-choice', requestId: 'perm-1', optionId: 'allow_once' },
       { kind: 'elicitation-choice', requestId: 'elicit-1', value: 'TypeScript' },
       { kind: 'elicitation-choice', requestId: 'elicit-2', value: null },
-      { kind: 'elicitation-confirm', requestId: 'elicit-3', values: ['lint'] },
-      { kind: 'elicitation-open', requestId: 'elicit-4', triggerId: 'trigger-3' },
-      { kind: 'elicitation-submit', requestId: 'elicit-5', fields: { ac_elicit_f0: 'main', ac_elicit_f1: ['lint'] } },
+      { kind: 'elicitation-confirm', requestId: 'elicit-5', fields: { ac_elicit_f0: 'main', ac_elicit_f1: ['lint'] } },
       // An EMPTY record is a real submission: a form of nothing but optional fields, all left
       // alone, and the daemon's own accept check is what decides whether that is an answer.
-      { kind: 'elicitation-submit', requestId: 'elicit-6', fields: {} }
+      { kind: 'elicitation-confirm', requestId: 'elicit-6', fields: {} }
     ]
     for (const payload of actions) {
       expect(RdSlackAction.safeParse(payload).success).toBe(true)
@@ -524,17 +522,16 @@ describe('relay↔daemon wire — skeleton frame codec (shared-bot-relay.md §7.
       }).success
     ).toBe(false)
     expect(RdSlackAction.safeParse({ kind: 'agent-session-stopped', channelId: 'C123' }).success).toBe(false)
-    // A modal cannot be opened without a trigger, and no form is wider than the card cap.
-    expect(RdSlackAction.safeParse({ kind: 'elicitation-open', requestId: 'e-1', triggerId: '' }).success).toBe(false)
+    // No form is wider than the card cap.
     const wideForm = Object.fromEntries(
       Array.from({ length: ELICIT_FORM_WIRE_FIELD_CAP + 1 }, (_, i) => [`ac_elicit_f${i}`, 'x'])
     )
-    expect(RdSlackAction.safeParse({ kind: 'elicitation-submit', requestId: 'e-1', fields: wideForm }).success).toBe(
+    expect(RdSlackAction.safeParse({ kind: 'elicitation-confirm', requestId: 'e-1', fields: wideForm }).success).toBe(
       false
     )
     // A field answers with a string or a list of them — never a number or a nested object, both
     // of which Slack's own view state cannot produce.
-    expect(RdSlackAction.safeParse({ kind: 'elicitation-submit', requestId: 'e-1', fields: { a: 3 } }).success).toBe(
+    expect(RdSlackAction.safeParse({ kind: 'elicitation-confirm', requestId: 'e-1', fields: { a: 3 } }).success).toBe(
       false
     )
     // Envelope-level identity stays schema-enforced.

--- a/packages/protocol/src/frames/relay-daemon.ts
+++ b/packages/protocol/src/frames/relay-daemon.ts
@@ -360,28 +360,16 @@ export const RdSlackAction = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('cancel') }),
   z.object({ kind: z.literal('permission-choice'), requestId: z.string().min(1), optionId: z.string() }),
   z.object({ kind: z.literal('elicitation-choice'), requestId: z.string().min(1), value: z.string().nullable() }),
-  // A Slack multi-select card's Confirm: a `multi_static_select` never submits on its own, so the
-  // reader taps a button, and `values` is the selection read out of THAT tap's own message state
-  // (`selectedOptionsFromState`). Carrying the snapshot is what makes the verb self-contained —
-  // no selection is tracked between interactions, so one reader's pick can never be submitted as
-  // another's answer, and the ordering of two interactions cannot change what is confirmed. The
-  // relay forwards no selection CHANGE at all: it acks Slack and keeps nothing. A daemon
-  // predating the verb rejects the whole action, so the card stays live.
+  // An input-block card's Confirm: a select, a checkbox list and a typed box each never submit on
+  // their own, so the reader taps a button and `fields` is every field read out of THAT tap's own
+  // message state (`elicitFormViewValues`), keyed by the field's own block id. Carrying the
+  // snapshot is what makes the verb self-contained — nothing is tracked between interactions, so
+  // one reader's entries can never be submitted as another's answer, and the ordering of two
+  // interactions cannot change what is confirmed. The relay forwards no field CHANGE at all: it
+  // acks Slack and keeps nothing. A blank optional input is simply absent, and the record is
+  // re-validated whole against the card, so nothing here is trusted.
   z.object({
     kind: z.literal('elicitation-confirm'),
-    requestId: z.string().min(1),
-    values: z.array(z.string()).max(100)
-  }),
-  // A MULTI-FIELD card's Answer button. Only the trigger id crosses: the relay never renders or
-  // holds the view — the daemon owns the card's schema and opens the modal on the same bot token
-  // it posted the card with, exactly as `open-config` above has always opened the status modal.
-  z.object({ kind: z.literal('elicitation-open'), requestId: z.string().min(1), triggerId: z.string().min(1) }),
-  // That modal's `view_submission`, keyed by the field's own block id so the daemon's per-field
-  // verdict can ride back under the same keys (`RdAck.response`, a `response_action: errors`
-  // payload the relay surfaces verbatim on Slack's 200). A blank optional input is simply
-  // absent — the record is re-validated whole against the card, so nothing here is trusted.
-  z.object({
-    kind: z.literal('elicitation-submit'),
     requestId: z.string().min(1),
     fields: z
       .record(z.string().min(1).max(200), z.union([z.string(), z.array(z.string()).max(100)]))

--- a/packages/relay/src/platforms/slack/http-ingest.test.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.test.ts
@@ -4,17 +4,13 @@ import {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
-  ELICIT_FORM_CALLBACK_ID,
   ELICIT_FORM_INPUT_ACTION,
-  ELICIT_OPEN_ACTION,
-  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   SHARED_AGENT_SELECT_ACTION_ID,
   SHARED_CONFIG_ACTION_ID,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
   SLACK_STATUS_ACTION,
   elicitFormBlockId,
-  encodeElicitFormMetadata,
   encodeSlackStatusOverflowValue,
   encodeSharedSlackStatusTarget
 } from '@agentconnect.md/protocol'
@@ -22,7 +18,6 @@ import {
   normalizeSlackMessage,
   parseHttpSlackAgentSelection,
   parseHttpSlackAgentSwitch,
-  parseHttpSlackElicitFormSubmit,
   parseHttpSlackSessionAction,
   httpSlackAgentOptions,
   SlackHttpIngest,
@@ -212,10 +207,10 @@ describe('parseHttpSlackSessionAction', () => {
     ).toBeNull()
   })
 
-  // A multi-select card's Confirm carries the selection out of its OWN payload's message state,
-  // so what the relay forwards is the state the tapping reader confirmed. A selection CHANGE is
-  // acked and dropped: nothing is tracked between the two interactions.
-  it('routes a multi-select card’s Confirm with the selection its own payload carried', () => {
+  // A form card's Confirm carries every field out of its OWN payload's message state, so what the
+  // relay forwards is what the tapping reader had filled in. An `input` block raises no
+  // interaction of its own, so there is no field CHANGE to forward and nothing is tracked.
+  it('routes a form card’s Confirm with the fields its own payload carried', () => {
     const parseConfirm = (state?: unknown, value = 'elicit-3') =>
       parseHttpSlackSessionAction(
         body(ELICIT_CONFIRM_ACTION, {
@@ -231,59 +226,37 @@ describe('parseHttpSlackSessionAction', () => {
           ...(state !== undefined ? { state } : {})
         } as Partial<SlackInteractiveBody>)
       )
-    const stateWith = (selected_options: { value?: unknown }[], block = ENCODED_TARGET) => ({
-      values: { [block]: { [`${ELICIT_SELECT_ACTION}:elicit-3`]: { selected_options } } }
+    const stateWith = (selected_options: { value?: unknown }[], block = elicitFormBlockId(0)) => ({
+      values: { [block]: { [ELICIT_FORM_INPUT_ACTION]: { selected_options } } }
     })
 
     expect(parseConfirm(stateWith([{ value: 'lint' }, { value: 'test' }]))).toMatchObject({
       target: TARGET,
       kind: 'elicitation-confirm',
       requestId: 'elicit-3',
-      values: ['lint', 'test']
+      fields: { [elicitFormBlockId(0)]: ['lint', 'test'] }
     })
-    // Found by ACTION id, so it does not matter which block Slack grouped the select into.
+    // Only OUR blocks are read: a block the card did not render is not one of its fields.
     expect(parseConfirm(stateWith([{ value: 'lint' }], 'some-other-block'))).toMatchObject({
       kind: 'elicitation-confirm',
-      values: ['lint']
+      fields: {}
     })
-    // An emptied select is a real answer; NO state for it is not one, and forwards nothing.
-    expect(parseConfirm(stateWith([]))).toMatchObject({ kind: 'elicitation-confirm', values: [] })
-    expect(parseConfirm({ values: {} })).toBeNull()
-    expect(parseConfirm()).toBeNull()
-    expect(parseConfirm(stateWith([{}]))).toBeNull()
-    // Another card's state cannot answer this Confirm: the key is this request's select.
-    expect(parseConfirm(stateWith([{ value: 'lint' }]), 'elicit-9')).toBeNull()
-
-    // A selection change is not a session action at all — the relay acks it and keeps nothing.
-    expect(
-      parseHttpSlackSessionAction(
-        body(`${ELICIT_SELECT_ACTION}:elicit-3`, {
-          actions: [
-            {
-              action_id: `${ELICIT_SELECT_ACTION}:elicit-3`,
-              action_ts: '1720000000.000600',
-              block_id: ENCODED_TARGET
-            }
-          ],
-          view: undefined
-        })
-      )
-    ).toBeNull()
+    // An emptied select is a real answer; a Confirm with no state at all forwards an empty
+    // record, which the daemon refuses against the card's own `required` set.
+    expect(parseConfirm(stateWith([]))).toMatchObject({
+      kind: 'elicitation-confirm',
+      fields: { [elicitFormBlockId(0)]: [] }
+    })
+    expect(parseConfirm({ values: {} })).toMatchObject({ kind: 'elicitation-confirm', fields: {} })
+    expect(parseConfirm()).toMatchObject({ kind: 'elicitation-confirm', fields: {} })
+    expect(parseConfirm(stateWith([{}]))).toMatchObject({ kind: 'elicitation-confirm', fields: {} })
   })
 
-  // The reviewer's scenario, in order: A selects lint, B selects test, then A taps Confirm. With
-  // a per-card record of the last selection seen, A's Confirm submitted B's pick — every value in
-  // it a valid option, so no whitelist could catch it. Neither change is forwarded at all now,
-  // and A's Confirm carries the state A tapped it on, so processing order decides nothing.
-  it('answers A’s Confirm with A’s own selection after B changed the card', () => {
-    const selectBody = (user: string) =>
-      body(`${ELICIT_SELECT_ACTION}:elicit-3`, {
-        user: { id: user },
-        actions: [
-          { action_id: `${ELICIT_SELECT_ACTION}:elicit-3`, action_ts: '1720000000.000600', block_id: ENCODED_TARGET }
-        ],
-        view: undefined
-      })
+  // The reviewer's scenario, in order: A fills the card in, B changes it, then A taps Confirm.
+  // With a per-card record of the last state seen, A's Confirm submitted B's entries — every value
+  // in it a valid option, so no whitelist could catch it. Nothing is tracked between interactions
+  // now, and A's Confirm carries the state A tapped it on, so processing order decides nothing.
+  it('answers A’s Confirm with A’s own entries after B changed the card', () => {
     const confirmBody = (user: string, values: string[]) =>
       ({
         ...body(ELICIT_CONFIRM_ACTION, {
@@ -300,39 +273,35 @@ describe('parseHttpSlackSessionAction', () => {
         }),
         state: {
           values: {
-            [ENCODED_TARGET]: {
-              [`${ELICIT_SELECT_ACTION}:elicit-3`]: { selected_options: values.map((value) => ({ value })) }
+            [elicitFormBlockId(0)]: {
+              [ELICIT_FORM_INPUT_ACTION]: { selected_options: values.map((value) => ({ value })) }
             }
           }
         }
       }) as SlackInteractiveBody
 
-    // A selects, then B selects: two interactions, neither of them an answer to forward.
-    expect(parseHttpSlackSessionAction(selectBody('U-A'))).toBeNull()
-    expect(parseHttpSlackSessionAction(selectBody('U-B'))).toBeNull()
-    // A confirms. What is forwarded is the selection A's own payload carried, not B's.
     expect(parseHttpSlackSessionAction(confirmBody('U-A', ['lint']))).toMatchObject({
       kind: 'elicitation-confirm',
       requestId: 'elicit-3',
-      values: ['lint'],
+      fields: { [elicitFormBlockId(0)]: ['lint'] },
       userId: 'U-A'
     })
     expect(parseHttpSlackSessionAction(confirmBody('U-B', ['test']))).toMatchObject({
       kind: 'elicitation-confirm',
-      values: ['test'],
+      fields: { [elicitFormBlockId(0)]: ['test'] },
       userId: 'U-B'
     })
   })
 
   // Two Confirms on one card are two answers: a redelivery of either must dedup against itself,
   // never against the other, or the second answer would be dropped as a duplicate.
-  it('gives each confirmed selection its own msgId', () => {
+  it('gives each confirmed answer its own msgId', () => {
     const confirm = (values: string[]) => ({
       target: TARGET,
       interactionId: JSON.stringify([ELICIT_CONFIRM_ACTION, '1']),
       kind: 'elicitation-confirm' as const,
       requestId: 'elicit-3',
-      values
+      fields: { [elicitFormBlockId(0)]: values }
     })
     const one = httpSlackActionMsgId('B1', confirm(['lint']))
     expect(httpSlackActionMsgId('B1', confirm(['lint']))).toBe(one)
@@ -389,107 +358,6 @@ describe('parseHttpSlackSessionAction', () => {
         view: { private_metadata: ENCODED_TARGET }
       })
     ).toBeNull()
-  })
-})
-
-// A multi-field card's two interactions (#1794's Slack column). Answer carries only the trigger
-// id: the DAEMON builds and opens the view on its own bot token, so the relay renders no part of
-// that modal and holds nothing of it. The submission carries the fields keyed by block id, which
-// is also how the daemon's per-field errors come back.
-describe('the multi-field elicitation form’s Slack interactions', () => {
-  it('forwards the Answer tap as elicitation-open, with the trigger id and nothing else', () => {
-    const parsed = parseHttpSlackSessionAction(
-      body(ELICIT_OPEN_ACTION, {
-        actions: [
-          {
-            action_id: ELICIT_OPEN_ACTION,
-            action_ts: '1720000000.000800',
-            block_id: ENCODED_TARGET,
-            value: 'elicit-4'
-          }
-        ],
-        view: undefined,
-        user: { id: 'U-ALICE' }
-      })
-    )
-    expect(parsed).toMatchObject({
-      target: TARGET,
-      kind: 'elicitation-open',
-      requestId: 'elicit-4',
-      triggerId: 'trigger-1',
-      userId: 'U-ALICE'
-    })
-    // The one-shot trigger id stays OUT of the dedup identity (as open-config's does), so trigger
-    // material never reaches a log or a key — and a redelivery still dedups against itself.
-    expect(httpSlackActionMsgId('bot', parsed!)).toBe(
-      httpSlackActionMsgId('bot', { ...parsed!, triggerId: 'another-trigger' } as never)
-    )
-    // No trigger is nothing to open.
-    expect(
-      parseHttpSlackSessionAction(
-        body(ELICIT_OPEN_ACTION, {
-          trigger_id: undefined,
-          actions: [{ action_id: ELICIT_OPEN_ACTION, action_ts: '1', block_id: ENCODED_TARGET, value: 'elicit-4' }],
-          view: undefined
-        })
-      )
-    ).toBeNull()
-  })
-
-  it('reads the submitted view state into elicitation-submit, keyed by block id', () => {
-    const submit = parseHttpSlackElicitFormSubmit({
-      type: 'view_submission',
-      trigger_id: 'trigger-submit',
-      user: { id: 'U-BOB' },
-      view: {
-        callback_id: ELICIT_FORM_CALLBACK_ID,
-        private_metadata: encodeElicitFormMetadata({ requestId: 'elicit-5', target: ENCODED_TARGET }),
-        state: {
-          values: {
-            [elicitFormBlockId(0)]: { [ELICIT_FORM_INPUT_ACTION]: { selected_option: { value: 'main' } } },
-            [elicitFormBlockId(1)]: { [ELICIT_FORM_INPUT_ACTION]: { value: 'ship it' } }
-          }
-        }
-      }
-    })
-    expect(submit).toMatchObject({
-      target: TARGET,
-      kind: 'elicitation-submit',
-      requestId: 'elicit-5',
-      fields: { [elicitFormBlockId(0)]: 'main', [elicitFormBlockId(1)]: 'ship it' },
-      userId: 'U-BOB'
-    })
-    // The submitted fields ARE part of the identity: a corrected resubmission is a second answer.
-    expect(httpSlackActionMsgId('bot', submit!)).not.toBe(
-      httpSlackActionMsgId('bot', { ...submit!, fields: { [elicitFormBlockId(0)]: 'develop' } })
-    )
-  })
-
-  it('is not one of ours without our callback id, a decodable metadata, or a receipt', () => {
-    const meta = encodeElicitFormMetadata({ requestId: 'elicit-5', target: ENCODED_TARGET })
-    const view = { callback_id: ELICIT_FORM_CALLBACK_ID, private_metadata: meta }
-    expect(parseHttpSlackElicitFormSubmit({ type: 'view_submission', trigger_id: 't', view })).toMatchObject({
-      kind: 'elicitation-submit'
-    })
-    expect(parseHttpSlackElicitFormSubmit({ type: 'block_actions', trigger_id: 't', view })).toBeNull()
-    expect(
-      parseHttpSlackElicitFormSubmit({
-        type: 'view_submission',
-        trigger_id: 't',
-        view: { callback_id: SHARED_CONFIG_ACTION_ID, private_metadata: meta }
-      })
-    ).toBeNull()
-    expect(parseHttpSlackElicitFormSubmit({ type: 'view_submission', trigger_id: 't', view: {} })).toBeNull()
-    // The direct Socket Mode modal carries no session target, so its submission is not routable
-    // here at all — and it never arrives here, since that path has no relay.
-    expect(
-      parseHttpSlackElicitFormSubmit({
-        type: 'view_submission',
-        trigger_id: 't',
-        view: { callback_id: ELICIT_FORM_CALLBACK_ID, private_metadata: encodeElicitFormMetadata({ requestId: 'e' }) }
-      })
-    ).toBeNull()
-    expect(parseHttpSlackElicitFormSubmit({ type: 'view_submission', view })).toBeNull()
   })
 })
 
@@ -570,7 +438,6 @@ describe('SlackHttpIngest.handleInteraction', () => {
     onSetChannelAgent: vi.fn(),
     onSelectThreadAgent: vi.fn(),
     onSessionAction: vi.fn(),
-    onElicitFormSubmit: vi.fn(async () => ''),
     onSessionShortcut: vi.fn(() => false),
     onSessionStopped: vi.fn(),
     log: silentLog,
@@ -602,33 +469,6 @@ describe('SlackHttpIngest.handleInteraction', () => {
     })
     expect(result).toBe('')
     expect(onSelectThreadAgent).toHaveBeenCalledWith('C123', '1720000000.000100', AGENT_ID)
-  })
-
-  it('puts the daemon’s form verdict on the 200 body — the one interaction Slack waits for', async () => {
-    const onElicitFormSubmit = vi.fn<SlackHttpIngestDeps['onElicitFormSubmit']>(async () => ({
-      response_action: 'errors',
-      errors: { ac_elicit_f0: 'nope' }
-    }))
-    const ingest = new SlackHttpIngest(
-      'bot',
-      { botToken: 'xoxb', signingSecret: 's' },
-      ingestDeps({ onElicitFormSubmit })
-    )
-    const result = await ingest.handleInteraction({
-      type: 'view_submission',
-      trigger_id: 'trigger-submit',
-      view: {
-        callback_id: ELICIT_FORM_CALLBACK_ID,
-        private_metadata: encodeElicitFormMetadata({ requestId: 'elicit-5', target: ENCODED_TARGET }),
-        state: { values: { [elicitFormBlockId(0)]: { [ELICIT_FORM_INPUT_ACTION]: { value: 'main' } } } }
-      }
-    })
-    expect(result).toEqual({ response_action: 'errors', errors: { ac_elicit_f0: 'nope' } })
-    expect(onElicitFormSubmit).toHaveBeenCalledTimes(1)
-    expect(onElicitFormSubmit.mock.calls[0]![0]).toMatchObject({
-      requestId: 'elicit-5',
-      fields: { [elicitFormBlockId(0)]: 'main' }
-    })
   })
 
   it('forwards a message shortcut with the selected conversation coordinates', async () => {
@@ -669,7 +509,6 @@ describe('SlackHttpIngest channel membership events', () => {
     onSetChannelAgent: vi.fn(),
     onSelectThreadAgent: vi.fn(),
     onSessionAction: vi.fn(),
-    onElicitFormSubmit: vi.fn(async () => ''),
     onSessionShortcut: vi.fn(() => false),
     onSessionStopped: vi.fn(),
     webClientFactory: () => web as never,
@@ -920,7 +759,6 @@ describe('SlackHttpIngest message events', () => {
         onSetChannelAgent: vi.fn(),
         onSelectThreadAgent: vi.fn(),
         onSessionAction: vi.fn(),
-        onElicitFormSubmit: vi.fn(async () => ''),
         onSessionShortcut: vi.fn(() => false),
         onSessionStopped: vi.fn(),
         webClientFactory: () => web as never,

--- a/packages/relay/src/platforms/slack/http-ingest.ts
+++ b/packages/relay/src/platforms/slack/http-ingest.ts
@@ -27,22 +27,16 @@ import {
   ELICIT_ACTION_PREFIX,
   ELICIT_CONFIRM_ACTION,
   ELICIT_DISMISS_ACTION,
-  ELICIT_FORM_CALLBACK_ID,
-  ELICIT_OPEN_ACTION,
-  ELICIT_SELECT_ACTION,
   PERMISSION_ACTION_PREFIX,
   SHARED_AGENT_SELECT_ACTION_ID,
   SHARED_CONFIG_ACTION_ID,
   SLACK_MANAGE_SESSION_SHORTCUT_CALLBACK_ID,
   SLACK_STATUS_ACTION,
-  decodeElicitFormMetadata,
   decodePermValue,
   decodeSlackStatusOverflowValue,
   decodeSharedSlackStatusTarget,
   elicitFormViewValues,
-  selectedOptionsFromState,
   type RdSlackAction,
-  type SlackBlockActionsState,
   type SlackViewState,
   type SharedSlackStatusTarget,
   type WireNormalizedMessage
@@ -79,14 +73,12 @@ export interface SlackInteractiveBody {
     selected_option?: { value?: string }
   }[]
   /** A `block_actions` payload's full message state (Slack, 2020-09-01) — how a Confirm tap
-   *  carries the selection its own card was showing. */
-  state?: SlackBlockActionsState
+   *  carries every input its own card was showing. */
+  state?: SlackViewState
   view?: {
     callback_id?: string
     private_metadata?: string
-    /** Widened past the config modal's one select: an elicitation form's inputs answer with a
-     *  typed value and with lists too, and {@link elicitFormViewValues} reads all three. */
-    state?: SlackViewState & { values?: Record<string, Record<string, { selected_option?: { value?: string } }>> }
+    state?: { values?: Record<string, Record<string, { selected_option?: { value?: string } }>> }
   }
 }
 
@@ -232,33 +224,17 @@ function decodeHttpSlackSessionAction(body: SlackInteractiveBody): HttpSlackSess
         }
       : null
   }
-  // A multi-select card's Confirm. A selection CHANGE is not forwarded at all — the relay acks
-  // Slack and keeps nothing — because the selection rides this tap's own message state, which
-  // Slack has carried on `block_actions` since 2020-09-01. Reading it here is what makes the
-  // forwarded answer the state THIS reader confirmed, rather than whatever was recorded last.
+  // An input-block card's Confirm. A field CHANGE is not forwarded at all — an `input` block
+  // raises no interaction, and the values ride this tap's own message state, which Slack has
+  // carried on `block_actions` since 2020-09-01. Reading them here is what makes the forwarded
+  // answer the state THIS reader confirmed, rather than whatever was recorded last.
   if (target && action.action_id === ELICIT_CONFIRM_ACTION && action.value) {
-    const values = selectedOptionsFromState(body.state, `${ELICIT_SELECT_ACTION}:${action.value}`)
-    // No state for the select ⇒ nothing this tap can be said to confirm, so nothing is forwarded.
-    return values
-      ? {
-          target,
-          interactionId: JSON.stringify([action.action_id, receipt]),
-          kind: 'elicitation-confirm',
-          requestId: action.value,
-          values
-        }
-      : null
-  }
-  // A multi-field card's Answer. Only the trigger id crosses to the daemon, which builds and
-  // opens the view itself on the same bot token it posted the card with — the relay renders no
-  // part of that modal and keeps nothing of it, exactly as it keeps nothing of a status modal.
-  if (target && action.action_id === ELICIT_OPEN_ACTION && action.value && body.trigger_id) {
     return {
       target,
       interactionId: JSON.stringify([action.action_id, receipt]),
-      kind: 'elicitation-open',
+      kind: 'elicitation-confirm',
       requestId: action.value,
-      triggerId: body.trigger_id
+      fields: elicitFormViewValues(body.state)
     }
   }
   if (target && action.action_id === ELICIT_DISMISS_ACTION && action.value) {
@@ -322,32 +298,6 @@ function decodeHttpSlackSessionAction(body: SlackInteractiveBody): HttpSlackSess
       return { target: statusTarget, interactionId, kind: 'cancel' }
     default:
       return null
-  }
-}
-
-/** One submitted elicitation-form modal, ready to forward: the daemon-minted session target the
- *  view carried in `private_metadata`, plus the raw field state keyed by block id. Null when the
- *  payload is not one of our form submissions, or names no routable target. */
-export type HttpSlackElicitFormSubmit = HttpSlackInteractionReceipt & {
-  target: SharedSlackStatusTarget
-  userId?: string
-} & Extract<RdSlackAction, { kind: 'elicitation-submit' }>
-
-export function parseHttpSlackElicitFormSubmit(body: SlackInteractiveBody): HttpSlackElicitFormSubmit | null {
-  if (body.type !== 'view_submission' || body.view?.callback_id !== ELICIT_FORM_CALLBACK_ID) return null
-  const meta = body.view.private_metadata ? decodeElicitFormMetadata(body.view.private_metadata) : null
-  const target = meta?.target ? decodeSharedSlackStatusTarget(meta.target) : null
-  // A view_submission's trigger id is fresh per submission, so a corrected resubmission is its
-  // own interaction while Slack's own redelivery of one dedups against itself.
-  const receipt = body.trigger_id
-  if (!meta || !target || !receipt) return null
-  return {
-    target,
-    interactionId: JSON.stringify([ELICIT_FORM_CALLBACK_ID, receipt]),
-    kind: 'elicitation-submit',
-    requestId: meta.requestId,
-    fields: elicitFormViewValues(body.view.state),
-    ...(body.user?.id ? { userId: body.user.id } : {})
   }
 }
 
@@ -431,11 +381,6 @@ export interface SlackHttpIngestDeps {
   onSelectThreadAgent: (channelId: string, threadTs: string, agentId: string) => void
   /** Forward the current agent/session controls to its owning daemon. */
   onSessionAction: (action: HttpSlackSessionAction) => void
-  /** Forward a submitted elicitation-form modal and RESOLVE to the daemon's verdict: the one
-   *  Slack interaction on this seam whose answer Slack itself is waiting for, since per-field
-   *  errors only exist as a `view_submission` response. Resolves to '' when there is nothing
-   *  to say, which closes the modal. */
-  onElicitFormSubmit: (submit: HttpSlackElicitFormSubmit) => Promise<unknown>
   /** Resolve and forward the app-level message shortcut. False opens a local
    *  unavailable modal while the one-shot trigger id is still valid. */
   onSessionShortcut: (shortcut: HttpSlackSessionShortcut) => boolean
@@ -735,9 +680,6 @@ export class SlackHttpIngest {
         else if (context && picked) this.deps.onSetChannelAgent(context.channelId, picked)
         return '' // empty 200 closes the modal (same as the old empty ack)
       }
-      const formSubmit = parseHttpSlackElicitFormSubmit(body)
-      // Awaited, unlike every other forward here: the daemon's re-validation IS this 200's body.
-      if (formSubmit) return await this.deps.onElicitFormSubmit(formSubmit)
       const sessionAction = parseHttpSlackSessionAction(body)
       if (sessionAction) {
         this.deps.onSessionAction(sessionAction)

--- a/packages/relay/src/platforms/slack/ingress-plugin.ts
+++ b/packages/relay/src/platforms/slack/ingress-plugin.ts
@@ -22,7 +22,6 @@ import { createHash } from 'node:crypto'
 import type { RdMsgPlatformAction } from '@agentconnect.md/protocol'
 import {
   SlackHttpIngest,
-  type HttpSlackElicitFormSubmit,
   type HttpSlackSessionAction,
   type HttpSlackSessionShortcut,
   type HttpSlackSessionStop,
@@ -63,19 +62,9 @@ export function httpSlackActionMsgId(botId: string, action: HttpSlackSessionActi
     case 'elicitation-choice':
       value = `${action.requestId}:${action.value ?? ''}`
       break
-    // The confirmed selection is part of the identity: two Confirms on one card are two answers,
+    // The confirmed fields are part of the identity: two Confirms on one card are two answers,
     // and a redelivery of either must dedup against itself rather than against the other.
     case 'elicitation-confirm':
-      value = `${action.requestId}:${JSON.stringify(action.values)}`
-      break
-    // The one-shot triggerId is deliberately omitted, as open-config's is: the interactionId
-    // already identifies the click, and trigger material must not reach a log or a dedup key.
-    case 'elicitation-open':
-      value = action.requestId
-      break
-    // The submitted fields are part of the identity: a corrected resubmission is a second
-    // answer, and a redelivery of either must dedup against itself rather than the other.
-    case 'elicitation-submit':
       value = `${action.requestId}:${JSON.stringify(action.fields)}`
       break
     case 'open-config':
@@ -159,46 +148,6 @@ export function forwardSessionAction(host: RelayIngressHost, botId: string, acti
         host.log.warn(`relay-ingress(${botId}): daemon rejected session action (${ack.reason ?? 'unknown'})`)
     })
     .catch((err) => host.log.warn(`relay-ingress(${botId}): session action forward failed: ${(err as Error).message}`))
-}
-
-/** Forward a submitted elicitation-form modal and RETURN the daemon's verdict, so the relay can
- *  put it on Slack's own 200. This is the one interaction forward that is awaited: the per-field
- *  errors exist only as a `view_submission` response, and the daemon owns the schema they come
- *  from. An unroutable or unreachable daemon answers '' — the modal closes and the card stays
- *  live, which is the same bounded loss every other forward on this seam declares. */
-export async function forwardElicitFormSubmit(
-  host: RelayIngressHost,
-  botId: string,
-  submit: HttpSlackElicitFormSubmit
-): Promise<unknown> {
-  const { target, interactionId: _interactionId, userId, ...payload } = submit
-  const route = host.directory.targetForAgent(botId, target.agentId, target.integrationId)
-  if (!route) {
-    host.log.warn(`relay-ingress(${botId}): ignored stale elicitation submission for agent ${target.agentId}`)
-    return ''
-  }
-  const rd: RdMsgPlatformAction = {
-    source: 'platform_action',
-    platformId: 'slack',
-    agentId: route.agentId,
-    integrationId: route.integrationId,
-    sessionKey: target.sessionKey,
-    msgId: httpSlackActionMsgId(botId, submit),
-    botId,
-    ...(userId ? { userId } : {}),
-    payload
-  }
-  try {
-    const ack = await host.forwardAction(rd, route)
-    if (!ack.accepted) {
-      host.log.warn(`relay-ingress(${botId}): daemon rejected the elicitation submission (${ack.reason ?? 'unknown'})`)
-      return ''
-    }
-    return ack.response ?? ''
-  } catch (err) {
-    host.log.warn(`relay-ingress(${botId}): elicitation submission forward failed: ${(err as Error).message}`)
-    return ''
-  }
 }
 
 /** Resolve a message shortcut from live conversation ownership (the core-owned
@@ -320,7 +269,6 @@ export const slackIngressPlugin: RelayPlatformIngressPlugin<SlackHttpIngest, Sla
         onSelectThreadAgent: (channelId, threadTs, agentId) =>
           host.selectThreadAgent(botId, channelId, threadTs, agentId),
         onSessionAction: (action) => forwardSessionAction(host, botId, action),
-        onElicitFormSubmit: (submit) => forwardElicitFormSubmit(host, botId, submit),
         onSessionShortcut: (shortcut) => forwardSessionShortcut(host, botId, shortcut),
         onSessionStopped: (stop) => forwardSessionStop(host, botId, stop),
         onBotRevoked: (reason, eventAtMs) => {

--- a/packages/relay/src/relay-ingress-manager.test.ts
+++ b/packages/relay/src/relay-ingress-manager.test.ts
@@ -23,7 +23,6 @@ import { RelayIngressManager, type RelayIngressManagerDeps } from './relay-ingre
 // the identity, core owns the table). This suite was the last importer of the
 // core re-export shim that outlived the #571 route migration (audit F7).
 import {
-  forwardElicitFormSubmit,
   forwardSessionAction,
   forwardSessionShortcut,
   forwardSessionStop,
@@ -238,50 +237,6 @@ describe('RelayIngressManager HTTP Slack session actions', () => {
     })
     expect(second.msgId).toBe(first.msgId)
     expect(first.msgId).toMatch(/^slack-action:[a-f0-9]{64}$/)
-  })
-
-  // The one interaction forward that is AWAITED: per-field errors exist only as a
-  // `view_submission` response, and the daemon owns the schema they come from. The relay carries
-  // that verdict — it never renders, validates or holds any part of the modal.
-  it('returns the daemon’s form verdict, and an empty body when it cannot be asked', async () => {
-    const response = { response_action: 'errors', errors: { ac_elicit_f0: 'nope' } }
-    const sendMsg = vi.fn(async (msg: RdMsgPlatformAction): Promise<RdAck> => ({
-      msgId: msg.msgId,
-      accepted: true,
-      response
-    }))
-    const daemon = { sendMsg } as unknown as RelayDaemonConnection
-    const manager = new RelayIngressManager(
-      deps({ getDaemon: (daemonId) => (daemonId === DAEMON_ID ? daemon : undefined) })
-    )
-    const internals = internalsOf(manager)
-    internals.router.upsert(assignment())
-
-    const submit = action({
-      interactionId: JSON.stringify(['ac_elicit_form', 'trigger-submit']),
-      kind: 'elicitation-submit',
-      requestId: 'elicit-5',
-      fields: { ac_elicit_f0: 'main' }
-    } as never)
-    expect(await forwardElicitFormSubmit(internals.ingressHost, BOT_ID, submit as never)).toEqual(response)
-    expect(sendMsg.mock.calls[0]![0]).toMatchObject({
-      source: 'platform_action',
-      platformId: 'slack',
-      agentId: AGENT_ID,
-      integrationId: INTEGRATION_ID,
-      payload: { kind: 'elicitation-submit', requestId: 'elicit-5', fields: { ac_elicit_f0: 'main' } }
-    })
-
-    // A refusal, an ack with nothing to say, and a throw all close the modal and leave the card
-    // live — the same bounded loss every other forward on this seam declares.
-    sendMsg.mockImplementation(async (msg) => ({ msgId: msg.msgId, accepted: false, reason: 'not_found' }))
-    expect(await forwardElicitFormSubmit(internals.ingressHost, BOT_ID, submit as never)).toBe('')
-    sendMsg.mockImplementation(async (msg) => ({ msgId: msg.msgId, accepted: true }))
-    expect(await forwardElicitFormSubmit(internals.ingressHost, BOT_ID, submit as never)).toBe('')
-    sendMsg.mockImplementation(async () => {
-      throw new Error('socket gone')
-    })
-    expect(await forwardElicitFormSubmit(internals.ingressHost, BOT_ID, submit as never)).toBe('')
   })
 
   it('forwards a message shortcut through the current thread affinity', () => {


### PR DESCRIPTION
Fixes a production failure, and reshapes the Slack surface around what that failure taught us. Closes the Slack column on #1794.

## What broke

A live Slack session answered `Tool permission request failed: Error: Tool use aborted`, twice. The cause was ours: #1825 put a `multi_static_select` inside an `actions` block. **Slack rejects the entire message** — `invalid_blocks: unsupported element: multiselect` — so the card never posted, the elicitation was cancelled, and the channel showed nothing at all. From the reader's side the agent simply stopped answering.

Every test passed while we shipped it, and so did review. Our tests assert the JSON we build; none of them assert the rules Slack applies to it. That gap is the reason this PR is as large as it is.

## What we learned, by asking Slack instead of the docs

Candidate Block Kit was posted to a real channel and the API's answers recorded:

- `actions` blocks **refuse** `multi_static_select`, `plain_text_input` and `number_input` (`unsupported type` / `unsupported element: multiselect`); they accept `button`, `static_select`, `checkboxes`, `radio_buttons`.
- `checkboxes` and `radio_buttons` cap at **10 options**; `static_select` / `multi_static_select` hold 100.
- `checkboxes` has no `max_selected_items` (`invalid additional property`), but takes per-option `description` and `initial_options`.
- A message may carry **several `input` blocks, and their values arrive in `state.values` when a button in the same message is clicked** — confirmed end to end through a real Slack turn, where the agent received exactly the two options the reader ticked.

That last fact is what makes everything below possible, and it is the one the modal existed to work around.

## The shape, after

A question renders buttons **exactly when one tap can answer it**. Everything else is `input` blocks plus one Confirm and one Dismiss.

| Case | Render | Confirm |
| --- | --- | --- |
| single question, pure single-select or boolean | a row of buttons | none |
| single question with a companion "Other" box | `radio_buttons` + `plain_text_input` | one |
| single question, multi-select | `checkboxes` (≤10) else `multi_static_select` | one |
| single question, lone text or number | `plain_text_input` / `number_input` | one |
| a form of several questions | one `input` block each | **one for the whole form** |

The same single-select field is buttons alone and `radio_buttons` inside a form. That is deliberate: a lone question should not lose its one-tap answer for the sake of uniformity.

`elicitForm` already marks a select's companion box via the AskUserQuestion bridge metadata, so a question-with-a-box is two targets of one question — which is why the shape rule needs only the target count, and why the marker is still load-bearing upstream (without it the box counts as a second question and halves the usable form width).

## Two seams removed

**The modal (#1830) is gone** — `views.open` / `view_submission`, `openView`, the relay forward, the `elicitation-open` / `elicitation-submit` frames, the view builders and metadata codecs, and the `openView` EXEMPT entry in the evaluation arena's connection-surface gate. It existed to reach a `trigger_id` inside ~3 s; once message-level input state was proven, it bought only per-field errors, at the price of an interaction surface nothing else on the seam has. The loss is real and stated: an invalid field is now reported as a message rather than inline.

**The thread-reply route (#1828) is gone** — the interception before dispatch on both ingress ladders, the reply target, the ambiguity notice, the leading-mention strip and the Slack link-markup decode. All of that complexity existed because a reply is ambiguous by nature: which reply, whose, in which thread, with what markup around it. An `input` block has none of that ambiguity — it belongs to one field of one card. This restores the invariant the shared-selection bug (#1825) and the multi-card ambiguity (#1828) both broke: **one answer channel per card.**

The cost, named plainly: a mobile reader can no longer answer a long free-text question by typing in the composer. A `plain_text_input` in a channel message is a smaller box.

## The guard is the other half

`slackCardViolations()` encodes every rule above — forbidden elements per block type, per-element option caps, `max_selected_items` only where it exists, `input` blocks needing an element, option `value` length, `actions` element count, unique `block_id` — and is asserted table-driven over every shape this file can build, plus the settled, permission and DM cards. The bug that started this passed a full suite and a review; only a check of what Slack accepts would have caught it.

## Verified against live Slack, not only against ourselves

The seven card shapes were emitted from the **real builder through the real dispatch** and posted to a live channel. All seven accepted, including the one nobody had verified: a message carrying three `input` blocks and an `actions` block.

## Behaviour narrowings, deliberate

- A schema past `ELICIT_FORM_FIELD_CAP` now declines with the #1819 notice instead of falling back to carding one of eleven questions — that fallback was the lie the cap exists to prevent.
- An MCP chat approval that is not a lone enum/boolean declines rather than rendering; chat approval is allow/deny by construction.
- A multi-select's upper bound is enforced on submit rather than by Slack, since `checkboxes` has no `max_selected_items`; the bound is stated in the block hint.

## Verification

- protocol 489, relay 647, web 2406 — green.
- daemon, affected suites (`render`, `daemon-permission-autoallow`, `elicit-decline-notice`, `approval-dm`, `daemon-commands`, `slack-status-actor`, `connection`, `slack-streaming`): **541 passing**, independently re-run.
- Full daemon suite: 9 failing files, all the known-unrelated set — confirmed against a `HEAD~1` worktree producing an identical baseline.
- `pnpm eval:gates` — a CI gate independent of the daemon suite, and the one that caught `openView`: only `evaluation-runner` fails, identically at baseline. `connection-surface` passes.
- `pnpm typecheck`: `error TS` count 0. eslint + prettier clean on the 19 changed files.

Three mutation runs confirm the guard bites: putting the elements back in an `actions` block, removing the 10-option fallback, and counting questions instead of targets each turn the relevant tests red with the exact violation strings.
