### PR TITLE
fix(daemon): a declined ask and a refused answer say so on every surface

### DIFF
--- a/packages/daemon/src/permissions/coordinator.ts
+++ b/packages/daemon/src/permissions/coordinator.ts
@@ -28,6 +28,7 @@ import type { InteractionActor } from '../platforms/contract.js'
 import {
   buildApprovalDmIntro,
   buildElicitationCard,
+  buildElicitDmUnanswerableCard,
   buildElicitationFormCard,
   buildElicitationResolvedCard,
   buildPermissionCard,
@@ -42,6 +43,7 @@ import {
   elicitFormAccepts,
   elicitFormContent,
   elicitFormRefusalNotice,
+  ELICIT_ANSWER_REFUSED,
   elicitFormSubmission,
   elicitRequiredProps,
   elicitTarget,
@@ -694,10 +696,14 @@ export class PermissionCoordinator {
     if (!conn) return
     const channel = await conn.openDirectMessage(target.userId)
     const sessionTarget = this.host.slackDmSessionTarget(p, target.integrationId)
+    // A question this DM has no control for still gets its own block: the reader is handed the
+    // ask and the console, never an intro with nothing under it (#1794). The request itself is
+    // untouched — it stays open on the editor path, which is where the DM points.
     const card =
       rec.kind === 'permission'
         ? buildPermissionCard(requestId, rec.params, sessionTarget)
-        : (buildElicitationCard(requestId, rec.params, sessionTarget, SLACK_DM_ELICIT_SURFACE) ?? [])
+        : (buildElicitationCard(requestId, rec.params, sessionTarget, SLACK_DM_ELICIT_SURFACE) ??
+          buildElicitDmUnanswerableCard(rec.params))
     const fromSlack = p.plan.platform === 'slack'
     const sourceUrl =
       fromSlack && p.conn instanceof SlackConnection
@@ -1502,25 +1508,12 @@ export class PermissionCoordinator {
    *  Every caller is past the webchat branches, so this only ever speaks on a chat platform whose
    *  card the reader would otherwise have never seen. An MCP approval is excluded: it took the
    *  editor queue with its own notice. Returns `undefined` so a decline site stays one line.
-   *  ONE notice per distinct question — a runtime re-raising the same unrenderable ask floods
-   *  nothing, and a genuinely different question is a second thing the reader has not been told.
    *  Best effort: the decline never depends on the notice landing. */
   private noticeUnrenderableElicit(p: Pending, params: CreateElicitationRequest, isApproval: boolean): undefined {
     if (isApproval || !p.conn) return undefined
-    const key = (params as { message?: string }).message?.trim() ?? ''
-    const seen = (p.declinedElicitNotices ??= new Set<string>())
-    if (seen.has(key)) return undefined
-    seen.add(key)
-    let sessionUrl: string | undefined
-    // A console link this daemon cannot compute must not cost the reader the question itself.
+    const text = this.takeElicitDeclineNotice(p, params, 'chat')
+    if (text === null) return undefined
     try {
-      sessionUrl = this.host.sessionLink(p.outwardSessionId)
-    } catch {
-      sessionUrl = undefined
-    }
-    try {
-      // Built from the MASKED params `onAcpElicit` reassigned at its top, never an earlier capture.
-      const text = buildElicitDeclinedNotice(params, turnChromeFor(p.plan.platform).noticeMarkup, sessionUrl)
       this.host.enqueueApply(p, { kind: 'notice', text })
     } catch (err) {
       this.host.log().warn(`elicitation decline notice failed for "${p.plan.sessionKey}": ${formatErr(err)}`)
@@ -1528,12 +1521,82 @@ export class PermissionCoordinator {
     return undefined
   }
 
+  /** Webchat's peer of {@link noticeUnrenderableElicit}: the same words, said the way webchat says
+   *  anything — a STANDING stream event, since this surface has no channel to post a message into.
+   *  #1819 held that webchat needed none because it renders every shape; a `required` property no
+   *  control can answer (#1795) is the shape it does not, and that decline was silent. */
+  private noticeUnrenderableWebchatElicit(
+    p: Pending,
+    wc: NonNullable<Pending['webchat']>,
+    params: CreateElicitationRequest
+  ): undefined {
+    const text = this.takeElicitDeclineNotice(p, params, 'webchat')
+    if (text !== null) this.streamWebchatNotice(wc, text)
+    return undefined
+  }
+
+  /** The words one declined elicitation is described with, or null when this turn has already
+   *  said them (or the text could not be built at all). ONE notice per distinct question — a
+   *  runtime re-raising the same unrenderable ask floods nothing, and a genuinely different
+   *  question is a second thing the reader has not been told — and the set is shared with the
+   *  chat notice, so a continuation cannot say it twice on two surfaces.
+   *
+   *  `surface` decides two things. Markup: a chat notice is read as markdown and has its link
+   *  syntax defused, while webchat's card is our own DOM, which renders the text as a text node
+   *  with no label syntax to spoof, so defusing it there would only show the reader backslashes.
+   *  And the console link: a webchat reader is already IN the console, and it is that console's
+   *  own surface which just declined, so pointing them at it would be a lie. */
+  private takeElicitDeclineNotice(
+    p: Pending,
+    params: CreateElicitationRequest,
+    surface: 'chat' | 'webchat'
+  ): string | null {
+    const key = (params as { message?: string }).message?.trim() ?? ''
+    const seen = (p.declinedElicitNotices ??= new Set<string>())
+    if (seen.has(key)) return null
+    seen.add(key)
+    let sessionUrl: string | undefined
+    // A console link this daemon cannot compute must not cost the reader the question itself.
+    try {
+      sessionUrl = surface === 'chat' ? this.host.sessionLink(p.outwardSessionId) : undefined
+    } catch {
+      sessionUrl = undefined
+    }
+    try {
+      // Built from the MASKED params `onAcpElicit` reassigned at its top, never an earlier capture.
+      const markup = surface === 'chat' ? turnChromeFor(p.plan.platform).noticeMarkup : undefined
+      return buildElicitDeclinedNotice(params, markup, sessionUrl)
+    } catch (err) {
+      this.host.log().warn(`elicitation decline notice failed for "${p.plan.sessionKey}": ${formatErr(err)}`)
+      return null
+    }
+  }
+
+  /** Say one daemon-authored line on a webchat stream, as a STANDING notice: not a wait, but
+   *  something the reader has to keep, so the browser never retires it when output resumes.
+   *  Best effort by construction — no elicitation outcome depends on it. */
+  private streamWebchatNotice(wc: NonNullable<Pending['webchat']>, text: string): boolean {
+    try {
+      wc.sink.output({
+        conversationId: wc.conversationId,
+        turnId: wc.turnId,
+        index: wc.index++,
+        event: { kind: 'notice', text, standing: true }
+      })
+      return true
+    } catch (err) {
+      this.host.log().warn(`webchat notice not delivered for "${wc.conversationId}": ${formatErr(err)}`)
+      return false
+    }
+  }
+
   /** Webchat's peer of the Slack elicitation card: stream the card as an in-band event and
    *  park the same resolver. Takes the WHOLE form (`elicitForm`) rather than Slack's one field,
    *  so a multi-field ask renders one control per field and answers with a record; a one-field
    *  form takes the single-field path and its payload is unchanged. Returns `undefined`
    *  (⇒ decline) when the surface cannot render the form — including a `required` property it
-   *  has no control for, which is the same verdict Slack reaches by the same rule. */
+   *  has no control for, which is the same verdict Slack reaches by the same rule — and now says
+   *  so in the stream rather than declining into silence (#1794). */
   private async awaitWebchatElicitation(
     agentId: string,
     sessionId: string,
@@ -1542,7 +1605,7 @@ export class PermissionCoordinator {
     wc: NonNullable<Pending['webchat']>
   ): Promise<CreateElicitationResponse | undefined> {
     const form = elicitForm(params, WEBCHAT_ELICIT_SURFACE)
-    if (!form) return undefined
+    if (!form) return this.noticeUnrenderableWebchatElicit(p, wc, params)
     const target = form[0]!
     const required = new Set(elicitRequiredProps(params))
     const requestId = `elicit-${++this.elicitSeq}`
@@ -1593,7 +1656,9 @@ export class PermissionCoordinator {
       })
     } catch (err) {
       // An undelivered card can never be answered — drop the resolver and decline now
-      // rather than stall the runtime until the turn ends.
+      // rather than stall the runtime until the turn ends. No notice: this sink IS the only thing
+      // that speaks to this reader, so a line saying the ask could not be shown would go out
+      // through the very call that just threw, and a webchat turn has no second surface for it.
       this.pendingElicits.delete(requestId)
       this.syncApprovalActivity(p.hostKey, sessionId, { id: requestId })
       this.host.log().warn(`webchat elicitation card not delivered for "${p.plan.sessionKey}": ${formatErr(err)}`)
@@ -1984,7 +2049,14 @@ export class PermissionCoordinator {
               : target.kind === 'text'
                 ? textAccepts(target, a.value)
                 : target.options.some((o) => o.value === a.value)))
-    if (!offered) return
+    // A refused answer is not a silent one (#1794): the reader just acted, the card is still
+    // standing, so its own surface says the answer was not taken — the same words a refused
+    // Confirm gets, on whichever transport that card was posted to. Nothing here changes WHAT is
+    // refused, and there is no per-question dedup: one line per tap, as #1836's notice already is.
+    if (!offered) {
+      this.noticeInTurn(rec, ELICIT_ANSWER_REFUSED)
+      return
+    }
     if (rec.approval && this.host.agents().get(rec.agentId)?.allowRuntimeChangesInChat !== true) {
       if (rec.surface === 'slack' && rec.ts) {
         void rec.conn
@@ -2052,10 +2124,12 @@ export class PermissionCoordinator {
     rec.resolve(res)
   }
 
-  /** Post one daemon-authored line into a pending card's own turn — a notice, so it lands where
-   *  every other one does. False when that turn is already gone, or when the surface refused it.
-   *  Best effort by construction: no elicitation outcome depends on it. */
+  /** Post one daemon-authored line on the card's OWN surface — a notice, so it lands where every
+   *  other one does: in the channel for a Slack card, on the stream for a webchat one. False when
+   *  that turn is already gone, or when the surface refused it. Best effort by construction: no
+   *  elicitation outcome depends on it. */
   private noticeInTurn(rec: PendingElicit, text: string): boolean {
+    if (rec.surface === 'webchat') return this.streamWebchatNotice(rec.wc, text)
     const p = this.host.pending().get(pendingTurnKey(rec.owner, rec.sessionId))
     if (!p) return false
     try {

--- a/packages/daemon/src/slack/render.ts
+++ b/packages/daemon/src/slack/render.ts
@@ -1399,6 +1399,20 @@ export function buildElicitationCard(
   ]
 }
 
+/** Where a DM sends a reader whose question Slack has no control for. Mirrors the in-channel
+ *  decline notice's words, minus its verdict: this ask is still open on the editor path. */
+const ELICIT_DM_UNANSWERABLE =
+  ":hourglass: This chat can't collect an answer for it — answer it in the session console, via *Open session* above."
+
+/** The stand-in for an approval DM's elicitation card that {@link buildElicitationCard} cannot
+ *  build for the DM surface (#1794): the question, and where it CAN be answered. Without it the
+ *  DM went out carrying its intro and nothing else — a live request, no controls, and no hint
+ *  that the console holds the same ask — until the turn cancelled. The intro above it owns the
+ *  `Open session` link this points at, so the URL is never repeated. Pure. */
+export function buildElicitDmUnanswerableCard(params: CreateElicitationRequest): unknown[] {
+  return buildElicitationResolvedCard(params, ELICIT_DM_UNANSWERABLE)
+}
+
 /** Build the RESOLVED elicitation card (buttons removed) that replaces {@link
  *  buildElicitationCard} once answered, dismissed, or cancelled. Pure. */
 export function buildElicitationResolvedCard(params: CreateElicitationRequest, decision: string): unknown[] {
@@ -1634,6 +1648,12 @@ export function elicitFormSubmission(
   return Object.keys(errors).length ? { errors } : { answer }
 }
 
+/** What ANY refused answer is told on the card's own surface. A refusal drops the answer and
+ *  leaves the card live (#1815), which without a line like this one is a button that does nothing:
+ *  the reader cannot tell a rejected answer from a broken card. One wording for every transport —
+ *  a refusal explained on Slack and silent on webchat is worse than a consistent one. */
+export const ELICIT_ANSWER_REFUSED = "That answer wasn't accepted — the question is still open."
+
 /** What a refused Confirm is told IN THE THREAD, since a message card has no modal to return the
  *  errors to: each refused field named as the card names it, with the same plain words a reply-
  *  answered card would use, and the card left live to be answered again. Pure. */
@@ -1648,7 +1668,7 @@ export function elicitFormRefusalNotice(
     const target = index === null ? undefined : form[index]
     parts.push(target ? `${elicitFormFieldLabel(params, target)}: ${message}` : message)
   }
-  return clampTo(`That answer wasn't accepted — the question is still open. ${parts.join(' ')}`, ELICIT_MESSAGE_CAP)
+  return clampTo(`${ELICIT_ANSWER_REFUSED} ${parts.join(' ')}`, ELICIT_MESSAGE_CAP)
 }
 
 /** Slack's own limit on an interactive element's `value`. A URL longer than this cannot ride a

--- a/packages/daemon/test/approval-dm.test.ts
+++ b/packages/daemon/test/approval-dm.test.ts
@@ -161,7 +161,9 @@ describe('approval DM (slack-approval-dm.md §5–§6)', () => {
     expect(actions.elements.map((e: any) => e.text.text)).toEqual([...seven, 'Dismiss'])
     await w.store.close()
 
-    // Past the cap `buildElicitationCard` returns null, so the DM posts the intro and no buttons.
+    // Past the cap `buildElicitationCard` returns null. The DM used to go out carrying its intro
+    // and nothing else — a live request with no controls and no hint that the console holds the
+    // same ask (#1794) — so the missing card is now a block that says what was asked and where.
     const over = await world()
     void over.coordinator.onAcpElicit(
       OWNER,
@@ -170,7 +172,16 @@ describe('approval DM (slack-approval-dm.md §5–§6)', () => {
     )
     await vi.waitFor(() => expect(over.conn.postBlocks).toHaveBeenCalledTimes(1))
     const overBlocks = (over.conn.postBlocks.mock.calls[0] as unknown[])[1] as any[]
+    // Nothing to tap — the answer is not collectable here, and that is the point of the line.
     expect(overBlocks.some((b) => b.type === 'actions')).toBe(false)
+    const stand = overBlocks.at(-1).text.text as string
+    expect(stand).toContain('Which one?')
+    expect(stand).toContain("This chat can't collect an answer for it")
+    // It points at the link the intro already built rather than repeating the URL.
+    expect(stand).toContain('*Open session*')
+    expect(JSON.stringify(overBlocks[0])).toContain('https://console.example/sessions/outward-1|Open session')
+    // The request itself is untouched: still open on the editor path, exactly as before.
+    expect((await over.store.listPermissionRequests(AGENT))[0]!.status).toBe('pending')
     await over.coordinator.releaseEditorPermissions(OWNER, ACP_SESSION)
     await over.store.close()
   })

--- a/packages/daemon/test/daemon-permission-autoallow.test.ts
+++ b/packages/daemon/test/daemon-permission-autoallow.test.ts
@@ -453,8 +453,20 @@ function installWebchat(pending: any, conversationId = 'conv-1'): { output: Retu
   return sink
 }
 
-const cardEvents = (sink: { output: ReturnType<typeof vi.fn> }): any[] =>
+const streamEvents = (sink: { output: ReturnType<typeof vi.fn> }): any[] =>
   sink.output.mock.calls.map(([o]: any[]) => o.event)
+
+/** The card's own events. A declined ask and a refused answer now stream a STANDING notice of
+ *  their own (#1794), which is asserted where that refusal is decided — every assertion about
+ *  the CARD stays about the card. */
+const cardEvents = (sink: { output: ReturnType<typeof vi.fn> }): any[] =>
+  streamEvents(sink).filter((e) => e.kind !== 'notice')
+
+/** What this stream was TOLD, as opposed to shown: the standing notices, in order. */
+const noticeTexts = (sink: { output: ReturnType<typeof vi.fn> }): string[] =>
+  streamEvents(sink)
+    .filter((e) => e.kind === 'notice' && e.standing === true)
+    .map((e) => e.text as string)
 
 describe('webchat renders and answers ACP elicitation cards', () => {
   it('streams the card, then accepts the tapped option and settles it in place', async () => {
@@ -589,7 +601,10 @@ describe('webchat renders and answers ACP elicitation cards', () => {
         })
       )
     ).resolves.toBeUndefined()
-    expect(sink.output).not.toHaveBeenCalled()
+    // The decline stands, but it is no longer silent: webchat says what was asked and that it
+    // could not be shown, the way Slack's channel notice does (#1794).
+    expect(cardEvents(sink)).toEqual([])
+    expect(noticeTexts(sink)).toEqual([expect.stringContaining("this chat can't collect an answer for")])
     expect((daemon as any).permissions.pendingElicits.size).toBe(0)
   })
 
@@ -699,6 +714,11 @@ describe('webchat answers a multi-select elicitation with a list', () => {
     await answer(['lint', 'test'], 'conv-other') // another conversation was never shown this card
     expect((daemon as any).permissions.pendingElicits.size).toBe(1)
     expect(cardEvents(sink)).toHaveLength(1) // still live — nothing settled it
+    // Each refusal of an answer THIS reader gave says so, and the card is left to answer again
+    // (#1794): a Confirm that silently does nothing is indistinguishable from a broken card. The
+    // last two are not this reader's answers at all — a shape no card of theirs could submit, and
+    // another conversation's tap — so neither is explained to them.
+    expect(noticeTexts(sink)).toEqual(Array(4).fill("That answer wasn't accepted — the question is still open."))
 
     await answer(['lint', 'test'])
     await expect(result).resolves.toEqual({ action: 'accept', content: { checks: ['lint', 'test'] } })
@@ -975,9 +995,11 @@ describe('a Slack multi-select card confirms the selection it was sent', () => {
 // the daemon itself posted.
 
 describe('a Slack answer is re-derived against the card that offered it', () => {
-  it('drops a value the card never offered and leaves the card live', async () => {
+  it('drops a value the card never offered, says so, and leaves the card live', async () => {
     const daemon = new Daemon({ slackAppFactory: fakeSlackAppFactory(), sandboxMechanism: null })
     const { updated } = slackPending(daemon)
+    const applied: any[] = []
+    ;(daemon as any).enqueueApply = (_p: any, action: any) => void applied.push(action)
     const answered = (daemon as any).permissions.onAcpElicit('agent-1', 's1', enumElicitation(['a', 'b', 'c']))
     await vi.waitFor(() => expect((daemon as any).permissions.pendingElicits.size).toBe(1))
     const [requestId] = (daemon as any).permissions.pendingElicits.keys()
@@ -985,6 +1007,11 @@ describe('a Slack answer is re-derived against the card that offered it', () => 
     await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'rm -rf /' })
     expect((daemon as any).permissions.pendingElicits.size).toBe(1) // still live — nothing settled it
     expect(updated).toHaveLength(0)
+    // The refusal stands, and the thread hears it — the same words a refused Confirm gets, since
+    // the reader cannot tell a rejected tap from a dead button either way (#1794).
+    expect(applied.filter((a) => a.kind === 'notice').map((a) => a.text)).toEqual([
+      "That answer wasn't accepted — the question is still open."
+    ])
 
     // A Slack tap on a button the card actually carries still resolves, unchanged.
     await (daemon as any).permissions.handleElicitChoice({ requestId, value: 'b' })

--- a/packages/daemon/test/elicit-decline-notice.test.ts
+++ b/packages/daemon/test/elicit-decline-notice.test.ts
@@ -129,6 +129,34 @@ function slackTurn(): { daemon: any; pending: any; notices: () => string[] } {
   }
 }
 
+/** The same turn, on webchat — whose reader hears nothing through `enqueueApply` and everything
+ *  through the reply stream, so its notices are stream events. */
+function webchatTurn(): { daemon: any; pending: any; sink: any; events: () => any[]; notices: () => string[] } {
+  const { daemon, pending } = slackTurn()
+  pending.plan.platform = 'webchat'
+  const sink = { output: vi.fn(), done: vi.fn() }
+  pending.webchat = {
+    conversationId: 'conv-1',
+    turnId: 'turn-1',
+    sink,
+    index: 0,
+    replyText: '',
+    heldText: '',
+    messageEmitted: false
+  }
+  const events = (): any[] => sink.output.mock.calls.map(([o]: any[]) => o.event)
+  return {
+    daemon,
+    pending,
+    sink,
+    events,
+    notices: () =>
+      events()
+        .filter((e) => e.kind === 'notice')
+        .map((e) => e.text as string)
+  }
+}
+
 describe('an elicitation declined for want of a surface says so in the channel', () => {
   it('posts the notice and still declines when a Slack card cannot express the form', async () => {
     const { daemon, notices } = slackTurn()
@@ -307,5 +335,85 @@ describe('a notice defuses agent text the way its own surface reads it', () => {
   it('leaves a markup-less surface’s text verbatim — it has no label syntax to spoof with', () => {
     const raw = 'See <https://evil.example/x|your account> & [label](https://evil.example/y)'
     expect(defuseNoticeText(raw, undefined)).toBe(raw)
+  })
+})
+
+/**
+ * The plan for #1819 said webchat needed no notice because it renders every shape. It does not:
+ * a `required` property no control can answer (#1795) is declined here exactly as it is on Slack,
+ * and until now `awaitWebchatElicitation` returned `undefined` with NOTHING in the conversation.
+ * Webchat says things by streaming them, so the notice is a stream event rather than a post.
+ */
+describe('webchat says a declined elicitation out loud too', () => {
+  it('streams a standing notice, and still declines', async () => {
+    const { daemon, events } = webchatTurn()
+    await expect(daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())).resolves.toBeUndefined()
+    expect(daemon.permissions.pendingElicits.size).toBe(0)
+    expect(events()).toEqual([
+      {
+        kind: 'notice',
+        // `standing` is the whole point: a wait notice is retired the moment output resumes,
+        // which would delete the only thing the reader was ever told about this question.
+        standing: true,
+        text: expect.stringContaining("this chat can't collect an answer for")
+      }
+    ])
+    expect(events()[0].text).toContain('Which checks should I run?')
+  })
+
+  it('quotes the MASKED question, and leaves its text VERBATIM — this card is our own DOM', async () => {
+    const { daemon, notices } = webchatTurn()
+    daemon.maskAgentSecrets = (_id: string, params: any) => ({
+      ...params,
+      message: params.message.replace('hunter2', '••••')
+    })
+    await daemon.permissions.onAcpElicit(
+      'agent-1',
+      's1',
+      unrenderableElicitation({ message: 'Is hunter2 the token? See [your account](https://evil.example/x)' })
+    )
+    expect(notices()[0]).toContain('Is •••• the token?')
+    expect(notices()[0]).not.toContain('hunter2')
+    // No markup dialect reads this text — React renders it as a text node — so defusing it
+    // would only show the reader backslashes it cannot tell from the agent's own.
+    expect(notices()[0]).toContain('[your account](https://evil.example/x)')
+  })
+
+  it('does not send the reader to the console they are already reading it in', async () => {
+    const { daemon, notices } = webchatTurn()
+    await daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())
+    // The Slack notice's tail offers the session console; here that console's OWN surface is
+    // what declined, so offering it would be a lie.
+    expect(notices()[0]).not.toContain('/sessions/sess-1')
+    expect(notices()[0]).not.toContain('session console')
+  })
+
+  it('collapses a repeated question to one notice, and lets a different question through', async () => {
+    const { daemon, notices } = webchatTurn()
+    await daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())
+    await daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation())
+    expect(notices()).toHaveLength(1)
+    await daemon.permissions.onAcpElicit('agent-1', 's1', unrenderableElicitation({ message: 'And which runner?' }))
+    expect(notices()).toHaveLength(2)
+  })
+
+  it('says nothing when the STREAM is what failed — there is nothing left to say it with', async () => {
+    const { daemon, sink } = webchatTurn()
+    sink.output.mockImplementation(() => {
+      throw new Error('socket closed')
+    })
+    await expect(daemon.permissions.onAcpElicit('agent-1', 's1', formElicitation())).resolves.toBeUndefined()
+    expect(daemon.permissions.pendingElicits.size).toBe(0)
+    // One attempt, the card's own: a notice would ride the same broken call, and a webchat turn
+    // has no second surface to fall back to.
+    expect(sink.output).toHaveBeenCalledTimes(1)
+  })
+
+  it('says nothing for the shapes webchat renders', async () => {
+    const { daemon, notices } = webchatTurn()
+    void daemon.permissions.onAcpElicit('agent-1', 's1', twoFieldElicitation())
+    await vi.waitFor(() => expect(daemon.permissions.pendingElicits.size).toBe(1))
+    expect(notices()).toEqual([])
+    await daemon.permissions.releaseElicits('agent-1', 's1')
   })
 })

--- a/packages/daemon/test/render.test.ts
+++ b/packages/daemon/test/render.test.ts
@@ -32,6 +32,7 @@ import {
   buildUrlConsentResolvedCard,
   SLACK_DM_ELICIT_SURFACE,
   slackCardViolations,
+  buildElicitDmUnanswerableCard,
   SLACK_ELICIT_SURFACE,
   WEBCHAT_ELICIT_SURFACE,
   multiSelectAccepts,
@@ -1478,7 +1479,10 @@ describe('every card we build is one Slack would accept', () => {
         } as any,
         'sess-target'
       ),
-      buildElicitationCard('elicit-1', req({ b: { type: 'boolean' } }), 'sess-target', SLACK_DM_ELICIT_SURFACE)!
+      buildElicitationCard('elicit-1', req({ b: { type: 'boolean' } }), 'sess-target', SLACK_DM_ELICIT_SURFACE)!,
+      // The DM stand-in for a question that surface has no control for — a card of one section,
+      // which is exactly why it can carry no answer.
+      buildElicitDmUnanswerableCard(req({ p: pick(2) }))
     ]
     for (const card of settled) expect(slackCardViolations(card)).toEqual([])
   })

--- a/packages/protocol/src/frames/webchat.test.ts
+++ b/packages/protocol/src/frames/webchat.test.ts
@@ -123,6 +123,22 @@ describe('WebchatOutput — event / status framing', () => {
     if (form.success && form.data.event?.kind === 'elicitation') expect(form.data.event.url).toBeUndefined()
   })
 
+  it('marks a STANDING notice, and leaves the wait notice it grew out of untouched', () => {
+    const notice = (event: Record<string, unknown>) =>
+      WebchatOutput.safeParse({ conversationId: CONV, turnId: TURN, index: 2, event })
+    // A notice the reader has to keep: an ask this surface could not show, or an answer it would
+    // not take. Without the flag the browser retires it the moment output resumes, which is what
+    // made a declined webchat elicitation silent (#1794).
+    const standing = notice({ kind: 'notice', text: 'The agent asked something…', standing: true })
+    expect(standing.success).toBe(true)
+    if (standing.success && standing.data.event?.kind === 'notice') expect(standing.data.event.standing).toBe(true)
+    // The wait notice predates the field, so every payload written before it still means "a wait".
+    const wait = notice({ kind: 'notice', text: 'Allocating a sandbox pod…' })
+    expect(wait.success).toBe(true)
+    if (wait.success && wait.data.event?.kind === 'notice') expect(wait.data.event.standing).toBeUndefined()
+    expect(notice({ kind: 'notice', text: 'x', standing: 'yes' }).success).toBe(false)
+  })
+
   it('marks a multi-select card with its bounds, and leaves the single-choice card untouched', () => {
     const card = (event: Record<string, unknown>) =>
       WebchatOutput.safeParse({ conversationId: CONV, turnId: TURN, index: 4, event })

--- a/packages/protocol/src/frames/webchat.ts
+++ b/packages/protocol/src/frames/webchat.ts
@@ -200,7 +200,13 @@ export const WebchatEvent = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('superseded'), generation: z.number().int() }),
   // Live-only chrome for a wait the user cannot otherwise see (a cluster sandbox pod coming up).
   // Never persisted — a refresh rebuilds from the transcript, which does not record it.
-  z.object({ kind: z.literal('notice'), text: z.string() }),
+  // `standing` ⇒ the line is not a wait but something the reader has to keep: an ask this surface
+  // could not show, or an answer it would not take (#1794). A wait notice retires the moment
+  // output resumes, which would delete exactly those lines; a standing one stays put. An added
+  // OPTIONAL field rather than a new kind, for the reason `elicitation.multi` records: a relay or
+  // browser predating it decodes the event unchanged and merely retires the line early, where an
+  // unknown kind would drop the frame and leave the silence this field exists to end.
+  z.object({ kind: z.literal('notice'), text: z.string(), standing: z.boolean().optional() }),
   // The turn's task list (ACP `plan`). Unlike every other kind here it is a SNAPSHOT: ACP
   // resends the whole list on each revision, so the client keeps the latest and never
   // appends. Streamed because the same block already lands in the persisted transcript

--- a/packages/web/src/components/console/PlaygroundProvider.tsx
+++ b/packages/web/src/components/console/PlaygroundProvider.tsx
@@ -227,10 +227,12 @@ function stampStep(step: UnstampedStep, observedAtMs = Date.now()): SessionStep 
   }
 }
 
-/** Drop this lane's live-only wait notice — streamed output IS the wait ending, so the line must go. */
+/** Drop this lane's live-only wait notice — streamed output IS the wait ending, so the line must go.
+ *  A STANDING notice is not a wait (a declined ask, a refused answer) and survives: retiring it
+ *  would delete the only thing the reader was ever told about that question. */
 function dropWaitNotices(steps: SessionStep[], agentId: string | undefined, turnId: string): SessionStep[] {
   const waiting = (s: SessionStep): boolean =>
-    s.kind === 'notice' && (s.agentId ?? undefined) === agentId && s.turnId === turnId
+    s.kind === 'notice' && !s.standing && (s.agentId ?? undefined) === agentId && s.turnId === turnId
   return steps.some(waiting) ? steps.filter((s) => !waiting(s)) : steps
 }
 
@@ -253,7 +255,7 @@ type WebchatEvent =
   | { kind: 'tool_update'; toolCallId: string; status: string; title?: string }
   | { kind: 'session_info'; title: string }
   | { kind: 'superseded'; generation: number }
-  | { kind: 'notice'; text: string }
+  | { kind: 'notice'; text: string; standing?: boolean }
   | { kind: 'plan'; entries: { content: string; status: string; priority?: string }[] }
   | {
       kind: 'elicitation'
@@ -677,8 +679,13 @@ export function PlaygroundProvider({ children }: { children: ReactNode }) {
           // Daemon chrome for a wait with nothing else to show (a sandbox pod coming up).
           // Its own lane, not the work lane: it is not something the agent thought or did,
           // so it must not be counted or hidden as a reasoning step. `boundary` keeps the
-          // reply chunks that follow from accumulating into it.
-          return [...steps, lane({ kind: 'notice', text: ev.text, boundary: true })]
+          // reply chunks that follow from accumulating into it. A `standing` one is not a wait —
+          // it is what the reader was told about an ask this surface could not show, or an answer
+          // it would not take — so it is marked and never retired when output resumes.
+          return [
+            ...steps,
+            lane({ kind: 'notice', text: ev.text, ...(ev.standing ? { standing: true } : {}), boundary: true })
+          ]
         }
         if (ev.kind === 'message') {
           if (last && last.kind === 'done' && last.who === who) {

--- a/packages/web/src/components/console/PlaygroundSend.test.tsx
+++ b/packages/web/src/components/console/PlaygroundSend.test.tsx
@@ -383,6 +383,40 @@ describe('stream text delta batching', () => {
     ])
   })
 
+  it('keeps a STANDING notice when the turn streams on — it is not a wait that ended', async () => {
+    const runFrame = captureAnimationFrames()
+    const { socket, turnId } = await openStream()
+
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: {
+            turnId,
+            agentId: 'agent-1',
+            index: 0,
+            event: { kind: 'notice', text: 'The agent asked something this chat can’t collect…', standing: true }
+          }
+        })
+      })
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: 'output',
+          output: { turnId, agentId: 'agent-1', index: 1, event: { kind: 'message', text: 'Moving on then.' } }
+        })
+      })
+    })
+    act(runFrame)
+
+    // Retiring this one would delete the ONLY thing the reader was told about a question the
+    // agent asked and this surface could not show (#1794) — the answer that follows is not
+    // the wait ending, it is the agent carrying on without them.
+    expect(getLiveSteps('s1').filter((step) => step.agentId === 'agent-1')).toMatchObject([
+      { kind: 'notice', text: 'The agent asked something this chat can’t collect…', standing: true, boundary: true },
+      { kind: 'done', text: 'Moving on then.' }
+    ])
+  })
+
   // ACP resends the WHOLE list on every revision, so a live plan must be one block that is
   // rewritten — appending would stack a fresh checklist per keystroke of progress.
   it("replaces the lane's plan block on each revision instead of appending another", async () => {

--- a/packages/web/src/lib/data.ts
+++ b/packages/web/src/lib/data.ts
@@ -1119,6 +1119,9 @@ export interface SessionStep {
   /** A superseded answer's streamed `done` blocks, re-tagged 'plan' to collapse into the work
    *  lane. Still MESSAGE text — renderers must not apply reasoning-only treatment to it. */
   demoted?: boolean
+  /** A `notice` step the reader has to keep (an ask this surface could not show, or an answer it
+   *  would not take) rather than the wait notice that retires when output resumes. */
+  standing?: boolean
   /** Display timestamp for live/mock-only steps. Persisted transcripts use their raw ts. */
   time?: string
   text: string


### PR DESCRIPTION
Three items from #1794 that are one defect in three costumes: **the reader is left with no idea that anything was asked, or why their answer was not taken.** #1819 fixed that for the chat-platform decline path; these are what it did not reach.

## 1. Webchat declined in silence too

The plan for #1819 assumed webchat needed nothing because it renders every shape. It does not: `awaitWebchatElicitation` returns `undefined` — so the request declines with nothing shown — when `elicitForm` yields null (a `required` property no control can answer, #1795's rule) and when the sink throws.

It now streams the **same text** Slack's notice carries. The wording and the one-notice-per-distinct-question dedup were lifted into a single `takeElicitDeclineNotice(p, params, 'chat' | 'webchat')`, sharing the turn's `declinedElicitNotices` set — so a continuation, which has both surfaces, cannot say it twice.

**A plain notice would have reintroduced the bug.** The console retires a notice via `dropWaitNotices` the moment any other event lands in that lane, so the agent's very next chunk would have deleted the line. `notice` therefore gained an optional `standing?: boolean`: a standing line is not a wait that ended and survives the stream resuming. An optional field rather than a new event kind, for the reason the file's own `elicitation.multi` comment already records — an older reader decodes the event unchanged and merely retires the line early, whereas an unknown kind drops the whole frame and restores the silence.

Two deliberate omissions: **no defusing** (webchat's card is our own DOM rendered as a React text node, so `defuseNoticeText`'s escaping would only show the reader backslashes — this is exactly the "surface declaring no markup" case it documents), and **no console link** (the reader is already in the console, and it is that console's surface which just declined).

**A sink failure still posts nothing**, and that is the honest outcome rather than an oversight: `sink.output` is the only thing that speaks to this reader, so the notice would ride the very call that just threw, and a non-continuation webchat turn has no second surface.

## 2. An approval DM arrived with nothing to answer

`sendApprovalDm` did `buildElicitationCard(...) ?? []`, so when no card could be built the DM went out with its intro alone and waited until the turn cancelled.

Suppressing the DM would lose real information — the request genuinely is open on the editor path, and telling a routed editor so is the DM's whole purpose. So it now carries the question plus a line saying this chat cannot collect the answer and pointing at the *Open session* link the intro already builds. No `actions` block, because there is nothing to tap; `notify` is still recorded, so the DM is rewritten when the request settles.

## 3. A refused answer said nothing

The re-derivation convention (#1815) is "drop it and leave the card live", which left the reader with a control that simply did nothing.

Post-#1836 the Slack Confirm path already explains itself. What was still silent is the refusal decided in `handleElicitChoice` at `if (!offered) return`: **every** webchat refusal (multi-select bounds, repeats, unoffered values, a bad form field) and a Slack **button** value the card never offered. `noticeInTurn` is now surface-aware — channel for a Slack card, stream for a webchat one — and both wordings are one constant.

The guards *above* `offered` stay silent on purpose: a wrong-shape payload, or another conversation's tap, is not this reader's answer to explain.

**Validation is untouched.** Nothing about what is accepted or refused changed; this is entirely about saying so.

## Why not `response_url`

Slack's documented mechanism for "explain a refused interaction" is an ephemeral reply to the interaction's `response_url`. It is **not reachable without inventing a seam**: `grep` finds zero hits for it across relay, daemon and protocol; the relay never declares or forwards the field, `RdAck.response` is a synchronous HTTP-body channel (Feishu toast, `block_suggestion` options) that Slack does not render for a `block_actions` post, and the direct path's `AppLike` abstraction exposes neither Bolt's `respond` nor `body.response_url`. Reaching it would mean a new forwarded field plus relay capture on one path and a new egress plus a widened `AppLike` on the other.

The turn's own notice already behaves identically on both ingress paths, because it leaves through the daemon's Slack egress rather than the interaction reply — so a relay-forwarded tap and a Socket Mode tap are explained the same way. A refusal explained on one transport and silent on the other would be worse than a consistent one.

## Verification

- `pnpm typecheck`: `error TS` count **0**. protocol 490, relay 652 — green. Touched daemon suites (`elicit-decline-notice`, `approval-dm`, `render`, `daemon-permission-autoallow`): **347 passing**, independently re-run.
- `pnpm eval:gates`: 27 of 28 files green; the one failure is the documented pre-existing `evaluation-runner` `infra_error` baseline.
- Full daemon suite: the known-unrelated set (`acp-matrix` live runtimes, the five skills-CLI files, bwrap `sandbox`, `evaluation-runner`, `daemon-smoke`) plus one load-flaky file that passes 44/44 alone.
- Web suite has 8 failures in `code-host-hook-groups` and `AgentDetailView.codehost` — **pre-existing**: this commit touches neither file, and they fail identically on their own.

Every new test was confirmed red with only the sources reverted — including the webchat notice not streaming at all, the DM losing the question, the refusal notices being absent on both surfaces, and the `standing` flag being undefined.
