### PR TITLE
fix(web): onboarding describes the daemon path as bring-your-own credentials

### DIFF
--- a/packages/web/src/components/console/views/OnboardingView.tsx
+++ b/packages/web/src/components/console/views/OnboardingView.tsx
@@ -470,7 +470,7 @@ function WhereStep({
         />
         <WhereCard
           name="Daemon"
-          desc="Bring your own subscription or API key, and your own machine."
+          desc="Bring your own provider credentials, and your own machine."
           icon="server"
           selected={choice === 'daemon'}
           onSelect={() => onChoice('daemon')}
@@ -677,7 +677,7 @@ function DaemonStep({
     <StepFrame
       stepLabel={stepLabel}
       title="Run the daemon"
-      sub="Bring your own subscription or API key, and your own machine. Run this on the machine your agents should work on."
+      sub="Bring your own provider credentials, and your own machine. Run this on the machine your agents should work on."
       footer={
         <>
           {onBack && (


### PR DESCRIPTION
The two daemon cards in owner onboarding (the placement chooser and the "Run the daemon" step) read "Bring your own subscription or API key, and your own machine." They now read "Bring your own provider credentials, and your own machine.", matching the public documentation change made alongside this. Copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)